### PR TITLE
fix(vtc): minimal unauth /health + nosniff on did.jsonl (P3.7)

### DIFF
--- a/tasks/vtc-architecture-todo.md
+++ b/tasks/vtc-architecture-todo.md
@@ -173,14 +173,15 @@ the #457 posture backstop provides its regression guard.)
 - `[x]` **P3.4** (S) Validate/clamp per-site CSP override; cache (stop per-request
   read) — `validate_csp_override` refuses weakening script-src/object-src/base-uri;
   `CspOverrideCache` (content-cache TTL) — PR: #469
-- `[~]` **P3.5** (S) `no-cache` on admin index/SPA-fallback; cache/gate
+- `[x]` **P3.5** (S) `no-cache` on admin index/SPA-fallback; cache/gate
   `plugins.json` scan; implement `If-None-Match`→304 — `cache_control_for`
   (shell no-cache, hashed assets keep TTL); `scan_plugin_dir_cached` (30s TTL);
-  `etag_matches`→304 in website serve — PR: #470 (in review)
+  `etag_matches`→304 in website serve — PR: #470
 - `[ ]` **P3.6** (S) Typed errors at registry (503/502) + DIDComm (problem-reports)
   boundaries — PR: ____
-- `[ ]` **P3.7** (S) Minimal unauth `/health`; gate DID/mediator detail; `nosniff`
-  on `did.jsonl` — PR: ____
+- `[~]` **P3.7** (S) Minimal unauth `/health` (`{status,version,vtc_did}`; mediator/
+  vta detail folded into admin-gated diagnostics); `nosniff` on `did.jsonl` —
+  PR: #472 (in review)
 - `[ ]` **P3.8** (M) Syncer: seek tail walk from cursor (range API); event_id-keyed
   idempotent enqueue — PR: ____
 - `[ ]` **P3.9** (XL) Backup/restore for all keyspaces (Argon2id+AES-GCM, vtc_did

--- a/vtc-service/src/routes/did_log.rs
+++ b/vtc-service/src/routes/did_log.rs
@@ -97,10 +97,20 @@ pub async fn did_log(State(state): State<AppState>) -> impl IntoResponse {
 
     (
         StatusCode::OK,
-        [(
-            header::CONTENT_TYPE,
-            HeaderValue::from_static("application/jsonl"),
-        )],
+        [
+            (
+                header::CONTENT_TYPE,
+                HeaderValue::from_static("application/jsonl"),
+            ),
+            // The log is served at the parent root, outside the
+            // website sub-router's security-headers middleware, so set
+            // nosniff here — a browser must not content-sniff the
+            // jsonl into something executable.
+            (
+                header::X_CONTENT_TYPE_OPTIONS,
+                HeaderValue::from_static("nosniff"),
+            ),
+        ],
         body,
     )
         .into_response()

--- a/vtc-service/src/routes/health.rs
+++ b/vtc-service/src/routes/health.rs
@@ -13,40 +13,30 @@ use crate::server::AppState;
 pub struct HealthResponse {
     status: &'static str,
     version: &'static str,
-    /// The VTC's own did:webvh, set during `vtc setup`. Exposed
-    /// publicly because external verifiers, registries, and the
-    /// default website's landing page all need to display it —
-    /// it's the community's identity, not a secret.
+    /// The VTC's own did:webvh, set during `vtc setup`. Kept on the
+    /// unauth payload because it's the community's public identity —
+    /// already served at `/.well-known/did.jsonl` and rendered by the
+    /// default landing page. The `vta_did` / `mediator_url` /
+    /// `mediator_did` fields used to live here too, but they're
+    /// infrastructure detail (which VTA backs the community + the
+    /// mediator's location) and now require auth — see
+    /// [`DiagnosticsResponse`].
     #[serde(skip_serializing_if = "Option::is_none")]
     vtc_did: Option<String>,
-    /// DID of the VTA the VTC was provisioned against. Public for
-    /// the same reason `vtc_did` is — operators + verifiers need
-    /// to know which key-management agent backs this community.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    vta_did: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    mediator_url: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    mediator_did: Option<String>,
 }
 
+/// `GET /health` — unauth, unthrottled liveness. Deliberately
+/// minimal: `{status, version, vtc_did}`. It sits at the parent root
+/// outside the governor, so it must not leak infrastructure topology
+/// (the mediator URL was a free recon oracle). The DID/mediator
+/// detail moved to the admin-gated [`diagnostics`] route.
 pub async fn health(State(state): State<AppState>) -> Json<HealthResponse> {
     debug!("health check");
-    let config = state.config.read().await;
-    let vtc_did = config.vtc_did.clone();
-    let vta_did = config.vta_did.clone();
-    let (mediator_url, mediator_did) = config
-        .messaging
-        .as_ref()
-        .map(|m| (Some(m.mediator_url.clone()), Some(m.mediator_did.clone())))
-        .unwrap_or((None, None));
+    let vtc_did = state.config.read().await.vtc_did.clone();
     Json(HealthResponse {
         status: "ok",
         version: env!("CARGO_PKG_VERSION"),
         vtc_did,
-        vta_did,
-        mediator_url,
-        mediator_did,
     })
 }
 
@@ -93,6 +83,18 @@ pub struct DiagnosticsResponse {
     pub last_failure_at: Option<DateTime<Utc>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub last_error: Option<String>,
+    /// DID of the VTA the VTC was provisioned against. Moved here
+    /// from the unauth `/health` payload (P3.7).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub vta_did: Option<String>,
+    /// The mediator's HTTPS endpoint. Infrastructure topology —
+    /// admin-gated so it's not a free unauth recon oracle.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mediator_url: Option<String>,
+    /// The mediator's DID. Also surfaced (post-bootstrap) on the
+    /// unauth `/v1/community/public-profile`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mediator_did: Option<String>,
 }
 
 #[utoipa::path(
@@ -143,6 +145,17 @@ pub async fn diagnostics(
     }
     .to_string();
 
+    // Identity / mediator detail — folded down from the unauth
+    // `/health` payload (P3.7), now only readable by an admin.
+    let config = state.config.read().await;
+    let vta_did = config.vta_did.clone();
+    let (mediator_url, mediator_did) = config
+        .messaging
+        .as_ref()
+        .map(|m| (Some(m.mediator_url.clone()), Some(m.mediator_did.clone())))
+        .unwrap_or((None, None));
+    drop(config);
+
     debug!(
         queue_depth,
         rtbf_batched_count,
@@ -160,5 +173,8 @@ pub async fn diagnostics(
         last_success_at: snapshot.last_success_at,
         last_failure_at: snapshot.last_failure_at,
         last_error: snapshot.last_error,
+        vta_did,
+        mediator_url,
+        mediator_did,
     }))
 }

--- a/vtc-service/tests/diagnostics.rs
+++ b/vtc-service/tests/diagnostics.rs
@@ -152,6 +152,51 @@ async fn diagnostics_requires_admin_role() {
 }
 
 #[tokio::test]
+async fn health_payload_is_minimal_and_unauth() {
+    // P3.7: `/health` is unauth + at the parent root, so it must not
+    // leak infrastructure topology. It carries only status, version,
+    // and the community's public DID.
+    let fix = build().await;
+
+    let req = Request::builder()
+        .method("GET")
+        .uri("/health")
+        .body(Body::empty())
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    let (status, v) = body_value(resp).await;
+    assert_eq!(status, StatusCode::OK, "{v}");
+    assert_eq!(v["status"], "ok");
+    assert!(v["version"].is_string());
+    assert!(v.get("vtc_did").is_some(), "community DID stays public");
+    // The recon-sensitive fields are gone from the unauth surface.
+    assert!(v.get("mediator_url").is_none(), "mediator_url leaked: {v}");
+    assert!(v.get("mediator_did").is_none(), "mediator_did leaked: {v}");
+    assert!(v.get("vta_did").is_none(), "vta_did leaked: {v}");
+}
+
+#[tokio::test]
+async fn diagnostics_surfaces_mediator_detail_to_admin() {
+    // The mediator detail dropped from `/health` is readable by an
+    // admin via the governed diagnostics route.
+    let vtc = TestVtc::builder()
+        .messaging_mediator("did:key:z6MkMediator")
+        .build()
+        .await;
+    let token = vtc.token("did:key:z6MkAdmin", "admin", vec![]).await;
+
+    let resp = vtc
+        .router
+        .clone()
+        .oneshot(get("/v1/health/diagnostics", DIAGNOSTICS_TASK, &token))
+        .await
+        .unwrap();
+    let (status, v) = body_value(resp).await;
+    assert_eq!(status, StatusCode::OK, "{v}");
+    assert_eq!(v["mediator_did"], "did:key:z6MkMediator");
+}
+
+#[tokio::test]
 async fn diagnostics_requires_trust_task_header() {
     let fix = build().await;
     let token = token_for(&fix, "admin").await;

--- a/vtc-service/tests/did_log.rs
+++ b/vtc-service/tests/did_log.rs
@@ -96,6 +96,35 @@ async fn serverless_dotted_host_did_resolves_as_jsonl() {
 }
 
 #[tokio::test]
+async fn did_log_response_carries_nosniff() {
+    // P3.7: the log is served at the parent root, outside the website
+    // sub-router's security-headers middleware — a browser must not
+    // content-sniff the jsonl into something executable.
+    let fix = build_fixture(VTC_DID).await;
+    seed_did_log(&fix.data_dir, VTC_LOG_LABEL, "{\"versionId\":\"1-abc\"}\n");
+
+    let res = fix
+        .router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/.well-known/did.jsonl")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .expect("oneshot");
+    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(
+        res.headers()
+            .get("x-content-type-options")
+            .and_then(|v| v.to_str().ok()),
+        Some("nosniff"),
+    );
+}
+
+#[tokio::test]
 async fn returns_404_when_only_a_foreign_label_log_exists() {
     // The VTC serves exactly its own DID's log. A stray log file under
     // some other label on disk must not be served — we read only the

--- a/vtc-service/website-default/site.js
+++ b/vtc-service/website-default/site.js
@@ -139,9 +139,9 @@ async function refresh() {
     } else {
       setText("community-did", "(not yet provisioned — run `vtc setup`)");
     }
-    if (healthJson.mediator_did) {
-      showMediatorRow(healthJson.mediator_did);
-    }
+    // The mediator DID is sourced from `/v1/community/public-profile`
+    // below; `/health` no longer carries mediator detail (it's
+    // admin-gated infrastructure topology — see P3.7).
     const state = healthJson.status === "ok" ? "ok" : "warn";
     setStatus(state, state === "ok" ? "Service online" : "Degraded");
   } catch (err) {


### PR DESCRIPTION
Phase 3 hygiene/security (independent, lands any time).

## Problem

`GET /health` — unauth, unthrottled, mounted at the parent root **outside** the governor — returned `vtc_did`, `vta_did`, `mediator_url`, `mediator_did`, and the exact build version. A free liveness/version/recon oracle; `mediator_url` in particular leaked the mediator's HTTPS endpoint (infrastructure topology) to any anonymous caller. Separately, `did.jsonl` (also parent-root) carried no `nosniff`.

## Change

- **`/health` is now minimal: `{status, version, vtc_did}`.** `vtc_did` stays — it's the community's **public** identity (already served at `/.well-known/did.jsonl` and rendered by the default landing page); gating it would be theatre.
- **`vta_did` + `mediator_url` + `mediator_did` fold into the already admin-gated, governed `/v1/health/diagnostics`** response. Operators can still read them; anonymous callers can't.
- The default landing page sourced `mediator_did` from `/health` as a fallback; it already reads it from `/v1/community/public-profile` (the primary), so the now-dead fallback is removed from `site.js`.
- **`did.jsonl` now carries `X-Content-Type-Options: nosniff`** — it's served outside the website sub-router's security-headers middleware, so the header is set on the handler directly.

## Accept criteria (covered by tests)

- Unauthenticated `/health` no longer returns `mediator_url` (nor `vta_did`/`mediator_did`); detailed identity fields require auth.

## Tests

`health_payload_is_minimal_and_unauth` (no mediator/vta detail, keeps `vtc_did`); `diagnostics_surfaces_mediator_detail_to_admin`; `did_log_response_carries_nosniff`. Full `cargo test -p vtc-service` suite green; clippy/fmt clean.