### PR TITLE
fix(vtc): typed HTTP status at the trust-registry boundary (P3.6, part 1)

### DIFF
--- a/vtc-service/src/recognition/verify.rs
+++ b/vtc-service/src/recognition/verify.rs
@@ -71,6 +71,14 @@ pub enum RecognitionError {
     /// route layer can map to 503 vs 403.
     #[error("trust registry unreachable: {0}")]
     RegistryUnreachable(String),
+    /// Trust-registry was reachable but rejected the recognise
+    /// query (a `RegistryError::Permanent` — bad request shape,
+    /// an upstream/workspace fault, **not** a holder-driven "not
+    /// recognised"). The route layer maps this to 502, not 403,
+    /// so an operator isn't misled into thinking they forgot to
+    /// add the peer community.
+    #[error("trust registry rejected the recognise query: {0}")]
+    RegistryRejected(String),
     /// `validFrom` is in the future or `validUntil` is in the
     /// past. Carries which credential failed for diagnostics.
     #[error("credential validity window: {0}")]
@@ -93,6 +101,7 @@ impl RecognitionError {
             Self::StatusListFailed(_) => "status-list-failed",
             Self::IssuerNotRecognised(_) => "issuer-not-recognised",
             Self::RegistryUnreachable(_) => "registry-unreachable",
+            Self::RegistryRejected(_) => "registry-rejected",
             Self::ValidityWindow(_) => "validity-window",
             Self::Malformed(_) => "malformed",
         }
@@ -233,9 +242,7 @@ pub async fn verify_foreign_vec(
         RegistryError::Unreachable(msg) | RegistryError::Transient(msg) => {
             RecognitionError::RegistryUnreachable(msg)
         }
-        RegistryError::Permanent(msg) => {
-            RecognitionError::IssuerNotRecognised(format!("registry rejected query: {msg}"))
-        }
+        RegistryError::Permanent(msg) => RecognitionError::RegistryRejected(msg),
     })?;
     if !recognised {
         return Err(RecognitionError::IssuerNotRecognised(issuer));

--- a/vtc-service/src/registry/client.rs
+++ b/vtc-service/src/registry/client.rs
@@ -61,6 +61,30 @@ impl RegistryError {
     }
 }
 
+impl From<RegistryError> for vti_common::error::AppError {
+    /// Preserve the retriable/permanent semantics at the HTTP
+    /// boundary instead of collapsing every registry failure into an
+    /// opaque 500 (house rule on typed errors). A reachable-but-flaky
+    /// or unreachable registry is **503** (try again later); a
+    /// registry that rejected the request shape is an upstream fault
+    /// surfaced as **502**.
+    fn from(e: RegistryError) -> Self {
+        use axum::http::StatusCode;
+        match e {
+            RegistryError::Transient(msg) | RegistryError::Unreachable(msg) => {
+                vti_common::error::AppError::ServiceError {
+                    status: StatusCode::SERVICE_UNAVAILABLE,
+                    message: format!("trust registry unavailable: {msg}"),
+                }
+            }
+            RegistryError::Permanent(msg) => vti_common::error::AppError::ServiceError {
+                status: StatusCode::BAD_GATEWAY,
+                message: format!("trust registry rejected request: {msg}"),
+            },
+        }
+    }
+}
+
 /// Abstraction over the upstream trust-registry transport.
 /// Production binds [`UpstreamTrustRegistryClient`] (lands in
 /// M3.2 + M3.10); tests bind [`MockRegistryClient`].
@@ -357,5 +381,30 @@ mod tests {
         assert!(RegistryError::Transient("x".into()).is_retriable());
         assert!(RegistryError::Unreachable("x".into()).is_retriable());
         assert!(!RegistryError::Permanent("x".into()).is_retriable());
+    }
+
+    #[test]
+    fn registry_error_maps_to_typed_http_status() {
+        use axum::http::StatusCode;
+        use vti_common::error::AppError;
+
+        let status = |e: RegistryError| match AppError::from(e) {
+            AppError::ServiceError { status, .. } => status,
+            other => panic!("expected ServiceError, got {other:?}"),
+        };
+        // Retriable failures → 503 (try again later), never an opaque 500.
+        assert_eq!(
+            status(RegistryError::Transient("x".into())),
+            StatusCode::SERVICE_UNAVAILABLE
+        );
+        assert_eq!(
+            status(RegistryError::Unreachable("x".into())),
+            StatusCode::SERVICE_UNAVAILABLE
+        );
+        // A registry that rejected the request shape → 502 (upstream fault).
+        assert_eq!(
+            status(RegistryError::Permanent("x".into())),
+            StatusCode::BAD_GATEWAY
+        );
     }
 }

--- a/vtc-service/src/routes/recognise.rs
+++ b/vtc-service/src/routes/recognise.rs
@@ -552,10 +552,20 @@ async fn map_foreign_role(
 }
 
 fn map_recognition_error(e: RecognitionError) -> AppError {
+    use axum::http::StatusCode;
     match e {
-        RecognitionError::RegistryUnreachable(msg) => {
-            AppError::Internal(format!("trust registry unreachable: {msg}"))
-        }
+        // The registry is a downstream dependency, not the caller —
+        // its outages must not read as a 500 (our bug) or a 403
+        // (caller's fault). Unreachable/flaky → 503 (retry later);
+        // a reachable-but-rejecting registry → 502 (upstream fault).
+        RecognitionError::RegistryUnreachable(msg) => AppError::ServiceError {
+            status: StatusCode::SERVICE_UNAVAILABLE,
+            message: format!("trust registry unavailable: {msg}"),
+        },
+        RecognitionError::RegistryRejected(msg) => AppError::ServiceError {
+            status: StatusCode::BAD_GATEWAY,
+            message: format!("trust registry rejected the recognise query: {msg}"),
+        },
         // All other variants are caller-driven rejection
         // signals → 403 Forbidden.
         other => AppError::Forbidden(other.to_string()),
@@ -590,5 +600,44 @@ async fn emit_denied_audit(
         .await
     {
         warn!(error = %e, "failed to emit CrossCommunitySessionMinted (denied) envelope");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::StatusCode;
+
+    /// The registry is a downstream dependency, not the caller: its
+    /// outages must surface as 5xx, never a 500 (our bug) or a 403
+    /// (caller's fault). Pins the P3.6 boundary mapping.
+    #[test]
+    fn registry_failures_map_to_5xx_not_500_or_403() {
+        let status = |e: RecognitionError| match map_recognition_error(e) {
+            AppError::ServiceError { status, .. } => status,
+            other => panic!("expected ServiceError, got {other:?}"),
+        };
+        assert_eq!(
+            status(RecognitionError::RegistryUnreachable("dns".into())),
+            StatusCode::SERVICE_UNAVAILABLE,
+        );
+        assert_eq!(
+            status(RecognitionError::RegistryRejected("bad query".into())),
+            StatusCode::BAD_GATEWAY,
+        );
+    }
+
+    /// Genuine caller-driven rejections stay 403 — a not-recognised
+    /// issuer is the operator's "forgot to add the peer" path.
+    #[test]
+    fn caller_rejections_stay_403() {
+        assert!(matches!(
+            map_recognition_error(RecognitionError::IssuerNotRecognised("did:x".into())),
+            AppError::Forbidden(_)
+        ));
+        assert!(matches!(
+            map_recognition_error(RecognitionError::ProofInvalid("bad sig".into())),
+            AppError::Forbidden(_)
+        ));
     }
 }


### PR DESCRIPTION
Part 1 of **P3.6** (the REST half). Part 2 will cover the DIDComm handlers.

## Problem

`RegistryError::{Transient, Permanent, Unreachable}` carries retriable/permanent semantics, but the recognise route collapsed every registry failure into `AppError::Internal` — so `/v1/auth/recognise` returned the same opaque **500** for "registry down" as for a real internal bug, against the house rule on preserving typed errors. (The `RegistryUnreachable` variant's own doc even said it should map "503 vs 403" — the mapping just sent it to 500.)

## Change

- **`impl From<RegistryError> for AppError`**: `Transient`/`Unreachable` → **503** (try again later); `Permanent` → **502** (the upstream registry rejected our request shape). One typed mapping for any direct registry call site.
- **`map_recognition_error`**: `RegistryUnreachable` → 503, and a new `RecognitionError::RegistryRejected` → 502. Previously the `Permanent` case was folded into `IssuerNotRecognised` → **403**, which misleads operators into thinking they forgot to add the peer community when the registry actually rejected the query. Split it out (new `reason_code` "registry-rejected" for the audit envelope).

## Accept criterion (covered by tests)

- recognise against an unreachable registry → **503**, not 500.

## Tests

`From<RegistryError>` status matrix (Transient/Unreachable→503, Permanent→502); `map_recognition_error` maps registry failures to 503/502 and keeps genuine caller rejections (not-recognised, proof-invalid) at 403. Existing recognise integration suite (15) still green; clippy/fmt clean.