### PR TITLE
fix(vtc): DIDComm handlers reply with typed problem-reports (P3.6, part 2)

### DIFF
--- a/tasks/vtc-architecture-todo.md
+++ b/tasks/vtc-architecture-todo.md
@@ -177,11 +177,17 @@ the #457 posture backstop provides its regression guard.)
   `plugins.json` scan; implement `If-None-Match`→304 — `cache_control_for`
   (shell no-cache, hashed assets keep TTL); `scan_plugin_dir_cached` (30s TTL);
   `etag_matches`→304 in website serve — PR: #470
-- `[ ]` **P3.6** (S) Typed errors at registry (503/502) + DIDComm (problem-reports)
-  boundaries — PR: ____
-- `[~]` **P3.7** (S) Minimal unauth `/health` (`{status,version,vtc_did}`; mediator/
+- `[~]` **P3.6** (S) Typed errors at registry (503/502) + DIDComm (problem-reports)
+  boundaries
+  - `[~]` **part 1** (REST) `From<RegistryError> for AppError` (Transient/Unreachable
+    →503, Permanent→502); `map_recognition_error` →503/502 (new `RegistryRejected`)
+    — PR: #473 (in review)
+  - `[~]` **part 2** (DIDComm) five handlers reply with threaded problem-reports;
+    `app_error_code` maps `AppError`→`e.p.msg.*` (malformed body→bad-request) — PR:
+    #474 (in review, stacked on #473)
+- `[x]` **P3.7** (S) Minimal unauth `/health` (`{status,version,vtc_did}`; mediator/
   vta detail folded into admin-gated diagnostics); `nosniff` on `did.jsonl` —
-  PR: #472 (in review)
+  PR: #472
 - `[ ]` **P3.8** (M) Syncer: seek tail walk from cursor (range API); event_id-keyed
   idempotent enqueue — PR: ____
 - `[ ]` **P3.9** (XL) Backup/restore for all keyspaces (Argon2id+AES-GCM, vtc_did

--- a/vtc-service/src/messaging.rs
+++ b/vtc-service/src/messaging.rs
@@ -13,6 +13,9 @@ use tokio::sync::watch;
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
+use serde_json::json;
+use vti_common::error::AppError;
+
 use vta_sdk::protocols::credential_exchange::PRESENT as CREDENTIAL_PRESENT_TYPE;
 use vta_sdk::protocols::credential_exchange::REQUEST as CREDENTIAL_REQUEST_TYPE;
 use vta_sdk::protocols::credential_exchange::{
@@ -27,6 +30,7 @@ use vta_sdk::protocols::join_requests::{
     MEMBER_SELF_REMOVE_RECEIPT_TYPE, MEMBER_SELF_REMOVE_TYPE, SelfRemoveBody,
     SelfRemoveReceiptBody,
 };
+use vta_sdk::protocols::{PROBLEM_REPORT_TYPE, problem_report_codes as codes};
 
 use crate::ceremony::remove_inner;
 use crate::config::AppConfig;
@@ -216,6 +220,44 @@ pub async fn run_didcomm_service(
     info!("DIDComm service stopped");
 }
 
+/// Build a DIDComm problem-report reply, threaded to the request, so a
+/// sender gets a typed code + comment instead of a silent
+/// `DIDCommServiceError::Internal` (which often yields no reply at all).
+fn problem_report(thid: String, code: &str, comment: impl Into<String>) -> DIDCommResponse {
+    DIDCommResponse::new(PROBLEM_REPORT_TYPE, problem_report_body(code, comment)).thid(thid)
+}
+
+/// The problem-report body shape — `{code, comment}`, matching
+/// [`vta_sdk::protocols::extract_problem_report`] on the receiving side.
+fn problem_report_body(code: &str, comment: impl Into<String>) -> serde_json::Value {
+    json!({ "code": code, "comment": comment.into() })
+}
+
+/// The problem-report `code` for a business-logic [`AppError`],
+/// preserving the 4xx-equivalent distinction (forbidden / unauthorized
+/// / not-found / conflict / bad-request) the same way the REST boundary
+/// does — instead of collapsing every outcome into `internal-error`,
+/// where the sender can't tell a permission failure from a real bug.
+/// Genuine infra faults keep the `internal-error` code.
+fn app_error_code(err: &AppError) -> &'static str {
+    match err {
+        AppError::Forbidden(_) | AppError::StepUpRequired(_) => codes::FORBIDDEN,
+        AppError::Unauthorized(_) | AppError::Authentication(_) => codes::UNAUTHORIZED,
+        AppError::NotFound(_) => codes::NOT_FOUND,
+        AppError::Conflict(_) | AppError::IdempotencyKeyConflict => codes::CONFLICT,
+        AppError::Validation(_)
+        | AppError::TrustTaskMalformed(_)
+        | AppError::TrustTaskMissing
+        | AppError::InvalidCursor => codes::BAD_REQUEST,
+        _ => codes::INTERNAL,
+    }
+}
+
+/// Map a business-logic [`AppError`] to a threaded problem-report reply.
+fn app_error_report(thid: String, err: &AppError) -> DIDCommResponse {
+    problem_report(thid, app_error_code(err), err.to_string())
+}
+
 /// `join-requests/submit/1.0` over DIDComm (M1.8.2).
 ///
 /// The applicant DID is the DIDComm `from` field — the
@@ -227,11 +269,20 @@ async fn join_request_submit_handler(
     meta: UnpackMetadata,
     Extension(state): Extension<AppState>,
 ) -> Result<Option<DIDCommResponse>, DIDCommServiceError> {
+    let thid = message.id.clone();
     let applicant_did = authenticated_sender_did(&message, &meta)?;
-    let body: JoinRequestSubmitBody = serde_json::from_value(message.body.clone())
-        .map_err(|e| DIDCommServiceError::Internal(format!("malformed join-request body: {e}")))?;
+    let body: JoinRequestSubmitBody = match serde_json::from_value(message.body.clone()) {
+        Ok(b) => b,
+        Err(e) => {
+            return Ok(Some(problem_report(
+                thid,
+                codes::BAD_REQUEST,
+                format!("malformed join-request body: {e}"),
+            )));
+        }
+    };
 
-    let outcome = submit_inner(
+    let outcome = match submit_inner(
         &state,
         applicant_did,
         body.vp,
@@ -241,7 +292,10 @@ async fn join_request_submit_handler(
         JoinTransport::DIDComm,
     )
     .await
-    .map_err(|e| DIDCommServiceError::Internal(format!("submit failed: {e}")))?;
+    {
+        Ok(o) => o,
+        Err(e) => return Ok(Some(app_error_report(thid, &e))),
+    };
 
     // The DIDComm receipt carries the request id + status; a sealed
     // credential bundle for an auto-admitted applicant lands in a
@@ -269,11 +323,20 @@ async fn join_request_accept_handler(
     meta: UnpackMetadata,
     Extension(state): Extension<AppState>,
 ) -> Result<Option<DIDCommResponse>, DIDCommServiceError> {
+    let thid = message.id.clone();
     let member_did = authenticated_sender_did(&message, &meta)?;
-    let body: JoinRequestAcceptBody = serde_json::from_value(message.body.clone())
-        .map_err(|e| DIDCommServiceError::Internal(format!("malformed join-accept body: {e}")))?;
+    let body: JoinRequestAcceptBody = match serde_json::from_value(message.body.clone()) {
+        Ok(b) => b,
+        Err(e) => {
+            return Ok(Some(problem_report(
+                thid,
+                codes::BAD_REQUEST,
+                format!("malformed join-accept body: {e}"),
+            )));
+        }
+    };
 
-    let outcome = accept_inner(
+    let outcome = match accept_inner(
         &state,
         body.request_id,
         member_did,
@@ -283,7 +346,10 @@ async fn join_request_accept_handler(
         JoinTransport::DIDComm,
     )
     .await
-    .map_err(|e| DIDCommServiceError::Internal(format!("accept failed: {e}")))?;
+    {
+        Ok(o) => o,
+        Err(e) => return Ok(Some(app_error_report(thid, &e))),
+    };
 
     let receipt = JoinRequestAcceptReceiptBody {
         request_id: outcome.request_id,
@@ -306,9 +372,10 @@ async fn join_request_manifest_handler(
     message: Message,
     Extension(state): Extension<AppState>,
 ) -> Result<Option<DIDCommResponse>, DIDCommServiceError> {
-    let manifest = manifest_inner(&state)
-        .await
-        .map_err(|e| DIDCommServiceError::Internal(format!("manifest failed: {e}")))?;
+    let manifest = match manifest_inner(&state).await {
+        Ok(m) => m,
+        Err(e) => return Ok(Some(app_error_report(message.id.clone(), &e))),
+    };
     let body = serde_json::to_value(&manifest)
         .map_err(|e| DIDCommServiceError::Internal(format!("manifest serialise: {e}")))?;
     Ok(Some(
@@ -326,13 +393,23 @@ async fn join_request_status_handler(
     meta: UnpackMetadata,
     Extension(state): Extension<AppState>,
 ) -> Result<Option<DIDCommResponse>, DIDCommServiceError> {
+    let thid = message.id.clone();
     let applicant_did = authenticated_sender_did(&message, &meta)?;
-    let body: JoinRequestStatusBody = serde_json::from_value(message.body.clone())
-        .map_err(|e| DIDCommServiceError::Internal(format!("malformed status body: {e}")))?;
+    let body: JoinRequestStatusBody = match serde_json::from_value(message.body.clone()) {
+        Ok(b) => b,
+        Err(e) => {
+            return Ok(Some(problem_report(
+                thid,
+                codes::BAD_REQUEST,
+                format!("malformed status body: {e}"),
+            )));
+        }
+    };
 
-    let resp = status_inner(&state, body.request_id, applicant_did, None)
-        .await
-        .map_err(|e| DIDCommServiceError::Internal(format!("status failed: {e}")))?;
+    let resp = match status_inner(&state, body.request_id, applicant_did, None).await {
+        Ok(r) => r,
+        Err(e) => return Ok(Some(app_error_report(thid, &e))),
+    };
     let body = serde_json::to_value(&resp)
         .map_err(|e| DIDCommServiceError::Internal(format!("status serialise: {e}")))?;
     Ok(Some(
@@ -353,24 +430,38 @@ async fn member_self_remove_handler(
     // The caller's DID is the *authcrypt-authenticated* sender, not the
     // plaintext `from` — otherwise a spoofed `from` would self-remove the
     // victim (`remove_inner(&caller, &caller, …)` with actor == subject).
+    let thid = message.id.clone();
     let caller_did = authenticated_sender_did(&message, &meta)?;
 
-    let body: SelfRemoveBody = serde_json::from_value(message.body.clone())
-        .map_err(|e| DIDCommServiceError::Internal(format!("malformed self-remove body: {e}")))?;
+    let body: SelfRemoveBody = match serde_json::from_value(message.body.clone()) {
+        Ok(b) => b,
+        Err(e) => {
+            return Ok(Some(problem_report(
+                thid,
+                codes::BAD_REQUEST,
+                format!("malformed self-remove body: {e}"),
+            )));
+        }
+    };
 
-    let disposition = body
+    let disposition = match body
         .disposition
         .as_deref()
         .map(parse_disposition)
         .transpose()
-        .map_err(DIDCommServiceError::Internal)?;
+    {
+        Ok(d) => d,
+        Err(e) => return Ok(Some(problem_report(thid, codes::BAD_REQUEST, e))),
+    };
 
     // DIDComm self-leave — actor == subject. The leave decision policy
     // allows self-leave unconditionally (spec §10.2); the no-last-admin
     // invariant still applies in the effect stage.
-    let outcome = remove_inner(&state, &caller_did, &caller_did, disposition, String::new())
-        .await
-        .map_err(|e| DIDCommServiceError::Internal(format!("self-remove: {e}")))?;
+    let outcome =
+        match remove_inner(&state, &caller_did, &caller_did, disposition, String::new()).await {
+            Ok(o) => o,
+            Err(e) => return Ok(Some(app_error_report(thid, &e))),
+        };
 
     let receipt = SelfRemoveReceiptBody {
         did: outcome.did,
@@ -591,6 +682,46 @@ mod tests {
 
     const ALICE: &str = "did:key:z6MkAlice";
     const ALICE_SKID: &str = "did:key:z6MkAlice#z6MkAlice";
+
+    #[test]
+    fn app_error_maps_to_typed_problem_report_codes() {
+        // 4xx-equivalent business outcomes get distinct codes instead
+        // of collapsing into internal-error (P3.6 part 2).
+        assert_eq!(
+            app_error_code(&AppError::Forbidden("nope".into())),
+            codes::FORBIDDEN
+        );
+        assert_eq!(
+            app_error_code(&AppError::Unauthorized("nope".into())),
+            codes::UNAUTHORIZED
+        );
+        assert_eq!(
+            app_error_code(&AppError::NotFound("nope".into())),
+            codes::NOT_FOUND
+        );
+        assert_eq!(
+            app_error_code(&AppError::Conflict("dup".into())),
+            codes::CONFLICT
+        );
+        assert_eq!(
+            app_error_code(&AppError::Validation("bad".into())),
+            codes::BAD_REQUEST
+        );
+        // Genuine infra faults stay internal.
+        assert_eq!(
+            app_error_code(&AppError::Internal("boom".into())),
+            codes::INTERNAL
+        );
+    }
+
+    #[test]
+    fn problem_report_body_is_code_and_comment() {
+        // The body shape must match `vta_sdk::protocols::extract_problem_report`.
+        let body = problem_report_body(codes::BAD_REQUEST, "malformed body");
+        let (code, comment) = vta_sdk::protocols::extract_problem_report(&body);
+        assert_eq!(code, codes::BAD_REQUEST);
+        assert_eq!(comment, "malformed body");
+    }
 
     #[test]
     fn accepts_authenticated_sender_whose_from_matches_the_authcrypt_key() {

--- a/vtc-service/src/recognition/verify.rs
+++ b/vtc-service/src/recognition/verify.rs
@@ -71,6 +71,14 @@ pub enum RecognitionError {
     /// route layer can map to 503 vs 403.
     #[error("trust registry unreachable: {0}")]
     RegistryUnreachable(String),
+    /// Trust-registry was reachable but rejected the recognise
+    /// query (a `RegistryError::Permanent` — bad request shape,
+    /// an upstream/workspace fault, **not** a holder-driven "not
+    /// recognised"). The route layer maps this to 502, not 403,
+    /// so an operator isn't misled into thinking they forgot to
+    /// add the peer community.
+    #[error("trust registry rejected the recognise query: {0}")]
+    RegistryRejected(String),
     /// `validFrom` is in the future or `validUntil` is in the
     /// past. Carries which credential failed for diagnostics.
     #[error("credential validity window: {0}")]
@@ -93,6 +101,7 @@ impl RecognitionError {
             Self::StatusListFailed(_) => "status-list-failed",
             Self::IssuerNotRecognised(_) => "issuer-not-recognised",
             Self::RegistryUnreachable(_) => "registry-unreachable",
+            Self::RegistryRejected(_) => "registry-rejected",
             Self::ValidityWindow(_) => "validity-window",
             Self::Malformed(_) => "malformed",
         }
@@ -233,9 +242,7 @@ pub async fn verify_foreign_vec(
         RegistryError::Unreachable(msg) | RegistryError::Transient(msg) => {
             RecognitionError::RegistryUnreachable(msg)
         }
-        RegistryError::Permanent(msg) => {
-            RecognitionError::IssuerNotRecognised(format!("registry rejected query: {msg}"))
-        }
+        RegistryError::Permanent(msg) => RecognitionError::RegistryRejected(msg),
     })?;
     if !recognised {
         return Err(RecognitionError::IssuerNotRecognised(issuer));

--- a/vtc-service/src/registry/client.rs
+++ b/vtc-service/src/registry/client.rs
@@ -61,6 +61,30 @@ impl RegistryError {
     }
 }
 
+impl From<RegistryError> for vti_common::error::AppError {
+    /// Preserve the retriable/permanent semantics at the HTTP
+    /// boundary instead of collapsing every registry failure into an
+    /// opaque 500 (house rule on typed errors). A reachable-but-flaky
+    /// or unreachable registry is **503** (try again later); a
+    /// registry that rejected the request shape is an upstream fault
+    /// surfaced as **502**.
+    fn from(e: RegistryError) -> Self {
+        use axum::http::StatusCode;
+        match e {
+            RegistryError::Transient(msg) | RegistryError::Unreachable(msg) => {
+                vti_common::error::AppError::ServiceError {
+                    status: StatusCode::SERVICE_UNAVAILABLE,
+                    message: format!("trust registry unavailable: {msg}"),
+                }
+            }
+            RegistryError::Permanent(msg) => vti_common::error::AppError::ServiceError {
+                status: StatusCode::BAD_GATEWAY,
+                message: format!("trust registry rejected request: {msg}"),
+            },
+        }
+    }
+}
+
 /// Abstraction over the upstream trust-registry transport.
 /// Production binds [`UpstreamTrustRegistryClient`] (lands in
 /// M3.2 + M3.10); tests bind [`MockRegistryClient`].
@@ -357,5 +381,30 @@ mod tests {
         assert!(RegistryError::Transient("x".into()).is_retriable());
         assert!(RegistryError::Unreachable("x".into()).is_retriable());
         assert!(!RegistryError::Permanent("x".into()).is_retriable());
+    }
+
+    #[test]
+    fn registry_error_maps_to_typed_http_status() {
+        use axum::http::StatusCode;
+        use vti_common::error::AppError;
+
+        let status = |e: RegistryError| match AppError::from(e) {
+            AppError::ServiceError { status, .. } => status,
+            other => panic!("expected ServiceError, got {other:?}"),
+        };
+        // Retriable failures → 503 (try again later), never an opaque 500.
+        assert_eq!(
+            status(RegistryError::Transient("x".into())),
+            StatusCode::SERVICE_UNAVAILABLE
+        );
+        assert_eq!(
+            status(RegistryError::Unreachable("x".into())),
+            StatusCode::SERVICE_UNAVAILABLE
+        );
+        // A registry that rejected the request shape → 502 (upstream fault).
+        assert_eq!(
+            status(RegistryError::Permanent("x".into())),
+            StatusCode::BAD_GATEWAY
+        );
     }
 }

--- a/vtc-service/src/routes/recognise.rs
+++ b/vtc-service/src/routes/recognise.rs
@@ -552,10 +552,20 @@ async fn map_foreign_role(
 }
 
 fn map_recognition_error(e: RecognitionError) -> AppError {
+    use axum::http::StatusCode;
     match e {
-        RecognitionError::RegistryUnreachable(msg) => {
-            AppError::Internal(format!("trust registry unreachable: {msg}"))
-        }
+        // The registry is a downstream dependency, not the caller —
+        // its outages must not read as a 500 (our bug) or a 403
+        // (caller's fault). Unreachable/flaky → 503 (retry later);
+        // a reachable-but-rejecting registry → 502 (upstream fault).
+        RecognitionError::RegistryUnreachable(msg) => AppError::ServiceError {
+            status: StatusCode::SERVICE_UNAVAILABLE,
+            message: format!("trust registry unavailable: {msg}"),
+        },
+        RecognitionError::RegistryRejected(msg) => AppError::ServiceError {
+            status: StatusCode::BAD_GATEWAY,
+            message: format!("trust registry rejected the recognise query: {msg}"),
+        },
         // All other variants are caller-driven rejection
         // signals → 403 Forbidden.
         other => AppError::Forbidden(other.to_string()),
@@ -590,5 +600,44 @@ async fn emit_denied_audit(
         .await
     {
         warn!(error = %e, "failed to emit CrossCommunitySessionMinted (denied) envelope");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::StatusCode;
+
+    /// The registry is a downstream dependency, not the caller: its
+    /// outages must surface as 5xx, never a 500 (our bug) or a 403
+    /// (caller's fault). Pins the P3.6 boundary mapping.
+    #[test]
+    fn registry_failures_map_to_5xx_not_500_or_403() {
+        let status = |e: RecognitionError| match map_recognition_error(e) {
+            AppError::ServiceError { status, .. } => status,
+            other => panic!("expected ServiceError, got {other:?}"),
+        };
+        assert_eq!(
+            status(RecognitionError::RegistryUnreachable("dns".into())),
+            StatusCode::SERVICE_UNAVAILABLE,
+        );
+        assert_eq!(
+            status(RecognitionError::RegistryRejected("bad query".into())),
+            StatusCode::BAD_GATEWAY,
+        );
+    }
+
+    /// Genuine caller-driven rejections stay 403 — a not-recognised
+    /// issuer is the operator's "forgot to add the peer" path.
+    #[test]
+    fn caller_rejections_stay_403() {
+        assert!(matches!(
+            map_recognition_error(RecognitionError::IssuerNotRecognised("did:x".into())),
+            AppError::Forbidden(_)
+        ));
+        assert!(matches!(
+            map_recognition_error(RecognitionError::ProofInvalid("bad sig".into())),
+            AppError::Forbidden(_)
+        ));
     }
 }


### PR DESCRIPTION
Part 2 of **P3.6** (the DIDComm half). Stacked on #473 (base = `p3.6-typed-registry-errors`) — review/merge that first.

## Problem

The DIDComm join/leave handlers (`messaging.rs`) collapsed every business outcome — malformed body, forbidden, not-found, conflict — into `DIDCommServiceError::Internal`. So a sender couldn't distinguish a malformed request from a real failure, and often got **no reply at all**.

## Change

Two helpers + a rewrite of the five handlers (submit, accept, manifest, status, self-remove) to reply with a **threaded DIDComm problem-report** instead of an opaque Internal:

- `problem_report(thid, code, comment)` builds a `{code, comment}` body matching `vta_sdk::protocols::extract_problem_report`. A malformed body or bad disposition → `e.p.msg.bad-request`.
- `app_error_code` maps the inner `AppError` to the right problem-report code (`forbidden` / `unauthorized` / `not-found` / `conflict` / `bad-request`), mirroring the REST boundary (and the same `e.p.msg.forbidden` vs `unauthorized` distinction the house rule calls for). Genuine infra faults keep `e.p.msg.internal-error`; true serialise failures stay `DIDCommServiceError::Internal`.

## Accept criterion (covered by tests)

- A malformed `join-request/submit` DIDComm body → a problem-report, not a silent Internal.

## Tests

`app_error_code` mapping matrix (forbidden/unauthorized/not-found/conflict/bad-request/internal); `problem_report_body` round-trips through `extract_problem_report`. Full `cargo test -p vtc-service --lib` (607) green; clippy/fmt clean.