### PR TITLE
fix(vtc): emergency-bootstrap clears sessions + stamps marker before wipe (P3.11)

### DIFF
--- a/vtc-service/src/emergency.rs
+++ b/vtc-service/src/emergency.rs
@@ -46,6 +46,7 @@ use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
 use tracing::{info, warn};
+use vti_common::auth::session::{delete_session, list_sessions};
 use vti_common::config::StoreConfig;
 use vti_common::error::AppError;
 use vti_common::store::Store;
@@ -249,7 +250,24 @@ pub async fn run_emergency_bootstrap_with_store(
     let acl_ks = store.keyspace(keyspaces::ACL)?;
     let passkey_ks = store.keyspace(keyspaces::PASSKEY)?;
     let install_ks = store.keyspace(keyspaces::INSTALL)?;
+    let sessions_ks = store.keyspace(keyspaces::SESSIONS)?;
     let install_store = InstallTokenStore::new(install_ks);
+
+    // --- pending audit marker (BEFORE the wipe) ---------------------
+    //
+    // Stamp the marker first and flush it to disk so a crash mid-wipe
+    // still leaves a durable record that an emergency bootstrap was
+    // invoked (the marker is consumed-on-read at the next boot). If we
+    // stamped it after the deletes, a mid-loop crash would leave the
+    // wipe unaudited.
+    let operator_hostname = gethostname::gethostname().to_string_lossy().into_owned();
+    install_store
+        .mark_emergency_pending(PendingEmergencyBootstrap {
+            operator_hostname: operator_hostname.clone(),
+            invoked_at: Utc::now(),
+        })
+        .await?;
+    store.persist().await?;
 
     // --- destructive cleanup ----------------------------------------
     let mut admin_entries_cleared = 0;
@@ -283,6 +301,16 @@ pub async fn run_emergency_bootstrap_with_store(
                     .await?;
             }
         }
+    }
+
+    // Clear ALL sessions — refresh tokens for the presumed-compromised
+    // admins must not survive the wipe (without this, a stolen refresh
+    // token keeps minting access tokens after recovery). Break-glass
+    // recovery treats every live session as suspect.
+    let mut sessions_cleared = 0;
+    for session in list_sessions(&sessions_ks).await? {
+        delete_session(&sessions_ks, &session.session_id).await?;
+        sessions_cleared += 1;
     }
 
     // --- mint a fresh install token ---------------------------------
@@ -319,15 +347,6 @@ pub async fn run_emergency_bootstrap_with_store(
         )
         .await?;
 
-    // --- pending audit marker ---------------------------------------
-    let operator_hostname = gethostname::gethostname().to_string_lossy().into_owned();
-    install_store
-        .mark_emergency_pending(PendingEmergencyBootstrap {
-            operator_hostname: operator_hostname.clone(),
-            invoked_at: Utc::now(),
-        })
-        .await?;
-
     // --- install URL ------------------------------------------------
     // `/admin/install` so the embedded admin SPA picks the request
     // up and runs the install-claim ceremony in-browser. The bare
@@ -348,6 +367,7 @@ pub async fn run_emergency_bootstrap_with_store(
         operator_hostname = %operator_hostname,
         admin_entries_cleared,
         admin_records_cleared,
+        sessions_cleared,
         "emergency bootstrap completed; install URL minted"
     );
     if admin_entries_cleared == 0 {

--- a/vtc-service/tests/emergency_bootstrap.rs
+++ b/vtc-service/tests/emergency_bootstrap.rs
@@ -38,6 +38,10 @@ use vti_common::acl::{AclEntry, Role, list_acl_entries, store_acl_entry};
 use vti_common::audit::{AuditKeyStore, AuditWriter};
 use vti_common::auth::jwt::JwtKeys;
 use vti_common::auth::passkey::build_webauthn;
+use vti_common::auth::session::{
+    Session, SessionState, get_session_by_refresh, list_sessions, store_refresh_index,
+    store_session,
+};
 use vti_common::config::StoreConfig;
 use vti_common::error::AppError;
 use vti_common::seed_store::SeedStore;
@@ -345,6 +349,66 @@ fn ephemeral_key() -> EphemeralSetupKey {
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn emergency_bootstrap_clears_all_sessions_and_their_refresh_index() {
+    // P3.11: refresh tokens for the presumed-compromised admins must
+    // not survive the wipe — otherwise a stolen refresh token keeps
+    // minting access tokens after recovery.
+    let fix = build_fixture(Some(RP_ORIGIN)).await;
+    let sessions_ks = fix.store.keyspace("sessions").unwrap();
+
+    let session = Session {
+        session_id: "sess-old-admin".into(),
+        did: fix.admin_did.clone(),
+        challenge: String::new(),
+        state: SessionState::Authenticated,
+        created_at: 0,
+        refresh_token: Some("refresh-token-1".into()),
+        refresh_expires_at: Some(9_999_999_999),
+        tee_attested: false,
+        amr: vec![],
+        acr: String::new(),
+        token_id: None,
+        session_pubkey_b58btc: None,
+    };
+    store_session(&sessions_ks, &session).await.unwrap();
+    store_refresh_index(&sessions_ks, "refresh-token-1", "sess-old-admin")
+        .await
+        .unwrap();
+    assert_eq!(list_sessions(&sessions_ks).await.unwrap().len(), 1);
+    assert!(
+        get_session_by_refresh(&sessions_ks, "refresh-token-1")
+            .await
+            .unwrap()
+            .is_some()
+    );
+
+    run_emergency_bootstrap_with_store(
+        &fix.config,
+        &fix.store,
+        fix.secret_store.as_ref(),
+        &ephemeral_key(),
+        &MockProver::accept(),
+        None,
+    )
+    .await
+    .expect("emergency-bootstrap accept");
+
+    // Session row gone, and the refresh reverse-index with it (so the
+    // refresh token is dead, not just orphaned).
+    assert!(
+        list_sessions(&sessions_ks).await.unwrap().is_empty(),
+        "all sessions must be cleared"
+    );
+    assert!(
+        get_session_by_refresh(&sessions_ks, "refresh-token-1")
+            .await
+            .unwrap()
+            .is_none(),
+        "refresh-token index must be cleared"
+    );
+}
 
 #[tokio::test]
 async fn happy_path_clears_admin_via_vta_and_audits_on_restart() {


### PR DESCRIPTION
Phase 3 hardening — the destructive `vtc admin emergency-bootstrap` recovery path had two sharp edges.

## 1. Sessions survived the wipe

The cleanup cleared admin ACL entries + passkey records but left the **`sessions` keyspace intact** — so refresh tokens for the presumed-compromised admins survived. A stolen refresh token keeps minting access tokens *after* recovery. Now clear **all** sessions (break-glass: every live session is suspect) via `list_sessions` + `delete_session`, so each row's refresh reverse-index dies with it.

## 2. Audit marker stamped after the wipe

The `EmergencyBootstrap` pending marker was stamped **after** the destructive loop, so a mid-loop crash left the wipe unaudited. Now stamp it **first** and `store.persist()` it before any delete — a crash mid-wipe still leaves a durable record that recovery was invoked (the marker is consumed-on-read at next boot).

`store.persist()` before returning was already in place (P2.5).

## Accept criteria (covered by tests)

- A cleared admin's session row (and its refresh index) is gone after the run.
- Marker is written before the first delete.

## Tests

`emergency_bootstrap_clears_all_sessions_and_their_refresh_index`: a seeded authenticated session + `store_refresh_index` are both present before, both gone after. Existing suite (6) green; clippy/fmt clean.