### PR TITLE
fix(vtc): install claim/finish idempotent against a Consumed token (P3.12)

### DIFF
--- a/tasks/vtc-architecture-todo.md
+++ b/tasks/vtc-architecture-todo.md
@@ -177,14 +177,14 @@ the #457 posture backstop provides its regression guard.)
   `plugins.json` scan; implement `If-None-Match`→304 — `cache_control_for`
   (shell no-cache, hashed assets keep TTL); `scan_plugin_dir_cached` (30s TTL);
   `etag_matches`→304 in website serve — PR: #470
-- `[~]` **P3.6** (S) Typed errors at registry (503/502) + DIDComm (problem-reports)
-  boundaries
-  - `[~]` **part 1** (REST) `From<RegistryError> for AppError` (Transient/Unreachable
+- `[x]` **P3.6** (S) Typed errors at registry (503/502) + DIDComm (problem-reports)
+  boundaries — **done** (#473, #474)
+  - `[x]` **part 1** (REST) `From<RegistryError> for AppError` (Transient/Unreachable
     →503, Permanent→502); `map_recognition_error` →503/502 (new `RegistryRejected`)
-    — PR: #473 (in review)
-  - `[~]` **part 2** (DIDComm) five handlers reply with threaded problem-reports;
+    — PR: #473
+  - `[x]` **part 2** (DIDComm) five handlers reply with threaded problem-reports;
     `app_error_code` maps `AppError`→`e.p.msg.*` (malformed body→bad-request) — PR:
-    #474 (in review, stacked on #473)
+    #474
 - `[x]` **P3.7** (S) Minimal unauth `/health` (`{status,version,vtc_did}`; mediator/
   vta detail folded into admin-gated diagnostics); `nosniff` on `did.jsonl` —
   PR: #472
@@ -194,10 +194,11 @@ the #457 posture backstop provides its regression guard.)
   compat check) — design note first — deps: P2.5 — PR: ____
 - `[ ]` **P3.10** (L) `vtc setup --from <toml>` (WizardPlan + apply engine); fix
   CLAUDE.md — PR: ____
-- `[ ]` **P3.11** (S) Emergency bootstrap: marker-before-wipe, clear sessions,
-  `persist()` — PR: ____
-- `[ ]` **P3.12** (S) Install `claim/finish` idempotent delivery against a
-  `Consumed` row — PR: ____
+- `[~]` **P3.11** (S) Emergency bootstrap: marker-before-wipe, clear sessions,
+  `persist()` (persist already done in P2.5) — PR: #475 (in review)
+- `[~]` **P3.12** (S) Install `claim/finish` idempotent delivery against a
+  `Consumed` row (re-mint from persisted admin DID; `start→finish→start` still
+  rejects) — PR: #476 (in review)
 - `[ ]` **P3.13** (M, several small PRs) Hygiene: stale webauthn doc; dead `b64:`
   path; redact `Debug` on secret types + gate wizard key print; `vtcDid`/`vtcUrl`
   field rename; public-profile field caps; path-param DID validation; reject

--- a/vtc-service/src/routes/install.rs
+++ b/vtc-service/src/routes/install.rs
@@ -52,8 +52,8 @@ use webauthn_rs::prelude::{CreationChallengeResponse, RegisterPublicKeyCredentia
 
 use crate::acl::admin::{AdminEntry, RegisteredPasskey, get_admin_entry, store_admin_entry};
 use crate::install::{
-    INSTALL_SESSION_DEFAULT_TTL_SECS, InstallTokenSigner, claim_secret, mint_install_session_token,
-    parse_install_token,
+    INSTALL_SESSION_DEFAULT_TTL_SECS, InstallTokenSigner, InstallTokenState, claim_secret,
+    mint_install_session_token, parse_install_token,
 };
 use crate::server::AppState;
 
@@ -235,6 +235,32 @@ pub async fn claim_finish(
         ));
     }
 
+    // Idempotent retry. Consume-first (below) is the security-correct
+    // direction, but it leaves an availability sharp edge: a crash —
+    // or a dropped response — between consuming the token and returning
+    // permanently spends it, stranding the operator without the
+    // `setup_session_token` `/admin/bootstrap` needs and with no way to
+    // re-run the WebAuthn ceremony (its registration state was already
+    // taken). So if the token is already `Consumed` *and* the ceremony
+    // actually persisted an admin record, re-derive + re-mint the
+    // setup-session token instead of hard-rejecting. The signed install
+    // token's own `exp` (validated by `parse_install_token` above) bounds
+    // the retry window; `start→finish→start` still rejects the second
+    // `start` (it requires `Issued`).
+    if let Some(InstallTokenState::Consumed { admin_did, .. }) = store.get_token(&jti).await? {
+        let admin_did = admin_did.unwrap_or_else(|| claims.admin_did.clone());
+        // Only re-issue if the first call got far enough to persist the
+        // admin — otherwise there's nothing to bootstrap against.
+        if get_admin_entry(&state.passkey_ks, &admin_did)
+            .await?
+            .is_some()
+        {
+            info!(jti = %jti, %admin_did, "install claim finish replayed; re-issuing setup token");
+            return issue_setup_session(&state, signer, admin_did, &jti).await;
+        }
+        return Err(AppError::Unauthorized("install token consumed".into()));
+    }
+
     let reg_state = take_registration_state(&state.passkey_ks, &jti.to_string())
         .await?
         .ok_or_else(|| {
@@ -310,6 +336,20 @@ pub async fn claim_finish(
     };
     store_admin_entry(&state.passkey_ks, &admin_entry).await?;
 
+    info!(jti = %jti, %admin_did, "install claim ceremony completed");
+
+    issue_setup_session(&state, signer, admin_did, &jti).await
+}
+
+/// Mint the `setup_session_token` for `admin_did` + build the
+/// `claim/finish` response. Shared by the first-completion path and the
+/// idempotent-replay path so a retry returns a usable token too.
+async fn issue_setup_session(
+    state: &AppState,
+    signer: &InstallTokenSigner,
+    admin_did: String,
+    jti: &Uuid,
+) -> Result<(StatusCode, Json<ClaimFinishResponse>), AppError> {
     let issuer_did = state
         .config
         .read()
@@ -325,8 +365,6 @@ pub async fn claim_finish(
         &jti.to_string(),
         INSTALL_SESSION_DEFAULT_TTL_SECS,
     )?;
-
-    info!(jti = %jti, %admin_did, "install claim ceremony completed");
 
     Ok((
         StatusCode::OK,

--- a/vtc-service/tests/install_claim.rs
+++ b/vtc-service/tests/install_claim.rs
@@ -174,12 +174,16 @@ async fn full_ceremony_completes_end_to_end() {
     )
     .await;
     assert_eq!(status, StatusCode::OK, "finish: {body}");
-    let admin_did = body["adminDid"].as_str().unwrap();
+    let admin_did = body["adminDid"].as_str().unwrap().to_string();
     assert!(admin_did.starts_with("did:key:z"));
     assert!(!body["setupSessionToken"].as_str().unwrap().is_empty());
 
-    // -- replay finish: must fail (token is now Consumed) --------------
-    let (status, _body) = post_json(
+    // -- replay finish: idempotent (P3.12) -----------------------------
+    // A dropped response / crash between consume-and-return must not
+    // strand the operator. Replaying the same finish against the now-
+    // `Consumed` token re-issues a usable setup-session token for the
+    // same admin DID rather than hard-rejecting.
+    let (status, body) = post_json(
         &fix.router,
         "/v1/install/claim/finish",
         FINISH_TASK,
@@ -190,7 +194,25 @@ async fn full_ceremony_completes_end_to_end() {
         }),
     )
     .await;
-    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    assert_eq!(status, StatusCode::OK, "idempotent replay: {body}");
+    assert_eq!(body["adminDid"].as_str().unwrap(), admin_did);
+    assert!(!body["setupSessionToken"].as_str().unwrap().is_empty());
+
+    // -- start after finish: still rejected ----------------------------
+    // Idempotent finish must not reopen the ceremony: a fresh `start`
+    // against the consumed token requires `Issued` and is refused.
+    let (status, _body) = post_json(
+        &fix.router,
+        "/v1/install/claim/start",
+        START_TASK,
+        json!({ "install_token": token }),
+    )
+    .await;
+    assert_ne!(
+        status,
+        StatusCode::OK,
+        "start after finish must be rejected"
+    );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Phase 3 availability fix for the first-admin install ceremony.

## Problem

`claim_finish` flips the install token `Issued → Consumed` (durable) **before** persisting the passkey/AdminEntry and minting the `setup_session_token`. A crash — or just a dropped HTTP response — between consume and return permanently spent the token, leaving the operator:
- without the `setup_session_token` that `/admin/bootstrap` needs, and
- unable to re-run the WebAuthn ceremony (its registration state was already taken on the first call).

They had to re-run `vtc setup`. (Consume-first is the *security*-correct direction; this is purely an availability sharp edge.)

## Change

Keep consume-first, but make the retry **idempotent**: when the token is already `Consumed` **and** an `AdminEntry` exists for the persisted admin DID (i.e. the first call got far enough to actually create the admin), re-derive + re-mint the setup-session token instead of hard-rejecting. The signed install token's own `exp` (validated up front by `parse_install_token`) bounds the retry window.

`start → finish → start` still rejects the second `start` — that path requires `Issued` and is untouched.

Extracted the token-minting tail into `issue_setup_session`, shared by the first-completion and replay paths.

## Accept criteria (covered by tests)

- Calling `claim/finish` twice for the same successful ceremony returns a usable token both times.
- A `start → finish → start` sequence still rejects the second `start`.

## Tests

The end-to-end ceremony's replay-finish now expects an idempotent **200** with the same admin DID (it previously asserted 401), plus a start-after-finish rejection. `install_claim` (13) + `install_flow` (9) + `admin_bootstrap` green; clippy/fmt clean.