### PR TITLE
test-support: provisionable-VTA helper for fuzzing provision_integration's render/seal/issue path (#468)

### DIFF
--- a/vta-service/src/test_support.rs
+++ b/vta-service/src/test_support.rs
@@ -382,6 +382,65 @@ pub async fn bootstrap_test_vta(ts: &TestStore) -> (String, ProvisionIntegration
     (vta_did, deps)
 }
 
+/// The context [`bootstrap_provisionable_test_vta`] registers and the one a
+/// well-formed request should target (`context_hint` + the `context` param).
+pub const PROVISIONABLE_CONTEXT: &str = "provisionable-ctx";
+
+/// Like [`bootstrap_test_vta`] but the returned VTA can actually *succeed*: it
+/// additionally registers a fresh target context ([`PROVISIONABLE_CONTEXT`]),
+/// so a well-formed request reaches the high-value render → seal → issue path
+/// instead of erroring at the context-existence precondition.
+///
+/// No template needs registering — the built-in `didcomm-mediator` /
+/// `vta-admin` templates resolve via the SDK's embedded loader, so a request
+/// naming one of those + a valid var set renders directly. Pair this with
+/// [`provisionable_mediator_vars`] for a known-`Ok` baseline that a fuzz
+/// campaign can mutate, e.g.:
+///
+/// ```ignore
+/// let ts = open_test_store().await;
+/// let (_vta_did, deps) = bootstrap_provisionable_test_vta(&ts).await;
+/// let request = signed_request_with_vars(
+///     "didcomm-mediator", PROVISIONABLE_CONTEXT, fuzzed_vars,
+/// ).await;
+/// let out = provision_integration(&deps, &super_admin_claims(), ProvisionIntegrationParams {
+///     request, context: PROVISIONABLE_CONTEXT.into(),
+///     assertion_mode: AssertionMode::PinnedOnly, vc_validity: None,
+/// }).await;
+/// ```
+///
+/// Both `AssertionMode::PinnedOnly` and `AssertionMode::DidSigned` return `Ok`
+/// for a well-formed request (the `#sealed-transfer-0` producer key is
+/// provisioned by [`bootstrap_test_vta`]); `Attested` needs Nitro material and
+/// is out of scope here.
+pub async fn bootstrap_provisionable_test_vta(
+    ts: &TestStore,
+) -> (String, ProvisionIntegrationDeps) {
+    let (vta_did, deps) = bootstrap_test_vta(ts).await;
+    crate::contexts::create_context(
+        &ts.contexts_ks,
+        PROVISIONABLE_CONTEXT,
+        "Provisionable Context",
+    )
+    .await
+    .expect("create provisionable context");
+    (vta_did, deps)
+}
+
+/// A baseline well-formed variable set for the built-in `didcomm-mediator`
+/// template — the known-`Ok` starting point a fuzz campaign mutates to drive
+/// hostile variables through the real renderer/sealer/issuer.
+pub fn provisionable_mediator_vars() -> BTreeMap<String, Value> {
+    let mut vars = BTreeMap::new();
+    vars.insert("URL".into(), Value::String("https://mediator.test".into()));
+    vars.insert(
+        "WS_URL".into(),
+        Value::String("wss://mediator.test/ws".into()),
+    );
+    vars.insert("ROUTING_KEYS".into(), Value::Array(vec![]));
+    vars
+}
+
 // ---------------------------------------------------------------------------
 // HTTP test scaffolding — shared by `tests/api_integration.rs` and any future
 // route-level test crate. The `TestApp` type returned here owns the axum

--- a/vta-service/tests/provision_integration_provisionable.rs
+++ b/vta-service/tests/provision_integration_provisionable.rs
@@ -1,0 +1,97 @@
+//! Worked example + regression for the provisionable-VTA test helper (#468).
+//!
+//! [`bootstrap_test_vta`] wires the VTA's signing identity but registers no
+//! target context, so a `provision_integration` call errors at the
+//! context-existence precondition — leaving the highest-value surface (template
+//! render → seal → VC issuance) unexercised by a fuzz campaign.
+//!
+//! [`bootstrap_provisionable_test_vta`] additionally registers
+//! [`PROVISIONABLE_CONTEXT`], so a well-formed request reaches `Ok`. This is the
+//! scaffold a fuzzer copies: stand up the provisionable VTA once, then drive
+//! arbitrary template variables (mutating [`provisionable_mediator_vars`])
+//! through the real renderer/sealer/issuer.
+
+use vta_service::operations::provision_integration::{
+    AssertionMode, ProvisionIntegrationParams, provision_integration,
+};
+use vta_service::test_support::{
+    PROVISIONABLE_CONTEXT, bootstrap_provisionable_test_vta, bootstrap_test_vta, open_test_store,
+    provisionable_mediator_vars, signed_request_with_vars, super_admin_claims,
+};
+
+/// A well-formed request against the provisionable VTA renders, seals, and
+/// issues — `Ok` with a non-empty armored bundle + digest — for both
+/// non-attested assertion modes the helper supports.
+#[tokio::test]
+async fn provisionable_vta_reaches_render_seal_issue_for_both_assertion_modes() {
+    for mode in [AssertionMode::PinnedOnly, AssertionMode::DidSigned] {
+        let ts = open_test_store().await;
+        let (_vta_did, deps) = bootstrap_provisionable_test_vta(&ts).await;
+
+        let request = signed_request_with_vars(
+            "didcomm-mediator",
+            PROVISIONABLE_CONTEXT,
+            provisionable_mediator_vars(),
+        )
+        .await;
+
+        let output = provision_integration(
+            &deps,
+            &super_admin_claims(),
+            ProvisionIntegrationParams {
+                request,
+                context: PROVISIONABLE_CONTEXT.into(),
+                assertion_mode: mode,
+                vc_validity: None,
+            },
+        )
+        .await
+        .unwrap_or_else(|e| panic!("provision should succeed in {mode:?} mode: {e:?}"));
+
+        assert!(
+            !output.armored.is_empty(),
+            "{mode:?}: armored bundle is non-empty"
+        );
+        assert!(!output.digest.is_empty(), "{mode:?}: digest is non-empty");
+    }
+}
+
+/// The gap this helper closes: without a registered context, the very same
+/// well-formed request errors at the precondition stage — never reaching the
+/// render/seal/issue path. Guards against a regression that would make the
+/// provisionable helper redundant (e.g. `bootstrap_test_vta` silently seeding a
+/// context).
+#[tokio::test]
+async fn plain_bootstrap_test_vta_errors_before_render_without_a_context() {
+    let ts = open_test_store().await;
+    let (_vta_did, deps) = bootstrap_test_vta(&ts).await;
+
+    let request = signed_request_with_vars(
+        "didcomm-mediator",
+        PROVISIONABLE_CONTEXT,
+        provisionable_mediator_vars(),
+    )
+    .await;
+
+    let result = provision_integration(
+        &deps,
+        &super_admin_claims(),
+        ProvisionIntegrationParams {
+            request,
+            context: PROVISIONABLE_CONTEXT.into(),
+            assertion_mode: AssertionMode::PinnedOnly,
+            vc_validity: None,
+        },
+    )
+    .await;
+
+    // `ProvisionIntegrationOutput` isn't `Debug`, so map the Ok arm before
+    // unwrapping the error.
+    let err = result
+        .map(|_| ())
+        .expect_err("no context registered → precondition error, not a render");
+    assert!(
+        err.to_string().contains(PROVISIONABLE_CONTEXT),
+        "error names the missing context: {err:?}"
+    );
+}


### PR DESCRIPTION
Closes #468.

## Problem

`bootstrap_test_vta` wires the VTA's signing identity (active seed, `#key-0`, `#sealed-transfer-0`, resolver, `vta_did`) but registers **no target context**. So a direct `provision_integration(&deps, &auth, params)` call errors at the context-existence precondition — every fuzzed request lands `ok=0`, and the highest-value surface (template **render → seal → VC issuance**) with hostile template variables stays unexercised.

## Change (test-support only, no prod change)

- **`bootstrap_provisionable_test_vta(&ts)`** — everything `bootstrap_test_vta` does, **plus** registers a target context (`PROVISIONABLE_CONTEXT`). That single missing piece is what unblocks the success path: built-in templates (`didcomm-mediator`, `vta-admin`) already resolve via the SDK's embedded loader, so **no template registration is needed** — a request naming one of those + a valid var set renders directly.
- **`PROVISIONABLE_CONTEXT`** — the context constant to use for both `context_hint` (on the request) and the `context` param.
- **`provisionable_mediator_vars()`** — a known-`Ok` baseline var set for `didcomm-mediator` that a campaign mutates to push hostile variables through the real renderer/sealer/issuer.

Usage the fuzzer copies:

```rust
let ts = open_test_store().await;
let (_vta_did, deps) = bootstrap_provisionable_test_vta(&ts).await;
let request = signed_request_with_vars("didcomm-mediator", PROVISIONABLE_CONTEXT, fuzzed_vars).await;
let out = provision_integration(&deps, &super_admin_claims(), ProvisionIntegrationParams {
    request, context: PROVISIONABLE_CONTEXT.into(),
    assertion_mode: AssertionMode::PinnedOnly, vc_validity: None,
}).await; // now reaches render -> seal -> issue
```

Both `AssertionMode::PinnedOnly` and `AssertionMode::DidSigned` return `Ok` for a well-formed request (the `#sealed-transfer-0` producer key is provisioned by `bootstrap_test_vta`). `Attested` needs Nitro material and is out of scope.

## Tests

New `tests/provision_integration_provisionable.rs`:
- a well-formed request reaches render/seal/issue → `Ok` with a non-empty armored bundle + digest, in **both** non-attested assertion modes;
- regression: the plain (context-less) `bootstrap_test_vta` still errors *before* render, naming the missing context — so the helper can't silently become redundant.

```
test provisionable_vta_reaches_render_seal_issue_for_both_assertion_modes ... ok
test plain_bootstrap_test_vta_errors_before_render_without_a_context ... ok
```