### PR TITLE
harden(vtc): reject cleartext registry URL + cap public-profile fields (P3.13)

### DIFF
--- a/vtc-service/src/community/profile.rs
+++ b/vtc-service/src/community/profile.rs
@@ -30,6 +30,29 @@ pub const PROFILE_STORAGE_KEY: &[u8] = b"community/profile";
 /// references the profile.
 pub const MAX_EXTENSIONS_BYTES: usize = 16 * 1024;
 
+/// Length caps (in Unicode scalar values) for the operator-set public
+/// profile text fields. Served on the unauth public-profile endpoint,
+/// so they're bounded to keep the response — and every audit/backup row
+/// that references the profile — from carrying unbounded content.
+const MAX_NAME_LEN: usize = 200;
+const MAX_DESCRIPTION_LEN: usize = 4_000;
+const MAX_LOGO_URL_LEN: usize = 2_048;
+const MAX_CONTACT_EMAIL_LEN: usize = 320;
+
+/// Reject a field whose char count exceeds `max`. No-op when the field
+/// is absent from the patch.
+fn cap_len(field: &str, value: Option<&str>, max: usize) -> Result<(), AppError> {
+    if let Some(v) = value
+        && v.chars().count() > max
+    {
+        return Err(AppError::Validation(format!(
+            "{field} exceeds {max} characters (got {})",
+            v.chars().count()
+        )));
+    }
+    Ok(())
+}
+
 /// The singleton record. Field names are wire contract — operators
 /// + the admin UX read this shape directly.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -110,6 +133,33 @@ impl CommunityProfileUpdate {
                     "extensions blob exceeds {MAX_EXTENSIONS_BYTES} bytes (got {})",
                     bytes.len()
                 )));
+            }
+        }
+
+        // Cap the operator-set text fields — they're served on the
+        // unauth `/v1/community/public-profile`, so an unbounded value
+        // is a stored-payload lever. Validate BEFORE mutating anything
+        // so an over-cap field doesn't half-apply the patch.
+        cap_len("name", self.name.as_deref(), MAX_NAME_LEN)?;
+        cap_len(
+            "description",
+            self.description.as_deref(),
+            MAX_DESCRIPTION_LEN,
+        )?;
+        cap_len(
+            "contactEmail",
+            self.contact_email.as_ref().and_then(|v| v.as_deref()),
+            MAX_CONTACT_EMAIL_LEN,
+        )?;
+        if let Some(Some(logo)) = self.logo_url.as_ref() {
+            cap_len("logoUrl", Some(logo), MAX_LOGO_URL_LEN)?;
+            // A logo URL ends up in an <img src> on the public page;
+            // restrict it to http(s) so it can't carry a `javascript:`
+            // / `data:` payload.
+            if !(logo.is_empty() || logo.starts_with("https://") || logo.starts_with("http://")) {
+                return Err(AppError::Validation(
+                    "logoUrl must be an http(s) URL".into(),
+                ));
             }
         }
 
@@ -261,6 +311,56 @@ mod tests {
         let changed = update.apply(&mut p).unwrap();
         assert_eq!(changed, vec!["logoUrl"]);
         assert!(p.logo_url.is_none());
+    }
+
+    #[test]
+    fn rejects_oversized_text_fields() {
+        for (label, update) in [
+            (
+                "name",
+                CommunityProfileUpdate {
+                    name: Some("x".repeat(MAX_NAME_LEN + 1)),
+                    ..Default::default()
+                },
+            ),
+            (
+                "description",
+                CommunityProfileUpdate {
+                    description: Some("x".repeat(MAX_DESCRIPTION_LEN + 1)),
+                    ..Default::default()
+                },
+            ),
+            (
+                "contactEmail",
+                CommunityProfileUpdate {
+                    contact_email: Some(Some("x".repeat(MAX_CONTACT_EMAIL_LEN + 1))),
+                    ..Default::default()
+                },
+            ),
+        ] {
+            let mut p = sample();
+            let err = update
+                .apply(&mut p)
+                .expect_err("oversized must be rejected");
+            assert!(matches!(err, AppError::Validation(_)), "{label}: {err:?}");
+        }
+    }
+
+    #[test]
+    fn rejects_non_http_logo_url_but_accepts_https() {
+        let mut p = sample();
+        let bad = CommunityProfileUpdate {
+            logo_url: Some(Some("javascript:alert(1)".into())),
+            ..Default::default()
+        };
+        assert!(bad.apply(&mut p).is_err());
+
+        let mut p = sample();
+        let ok = CommunityProfileUpdate {
+            logo_url: Some(Some("https://cdn.example.com/logo.png".into())),
+            ..Default::default()
+        };
+        assert_eq!(ok.apply(&mut p).unwrap(), vec!["logoUrl"]);
     }
 
     #[test]

--- a/vtc-service/src/registry/upstream.rs
+++ b/vtc-service/src/registry/upstream.rs
@@ -90,6 +90,12 @@ impl UpstreamRegistryClient {
     /// reqwest fails to construct (typically a misconfigured
     /// TLS backend on this platform).
     pub fn new(cfg: UpstreamConfig) -> Result<Self, RegistryError> {
+        // Recognition answers are trusted; served over cleartext they're
+        // spoofable by an on-path attacker. Require https for any real
+        // (non-loopback) registry. Loopback http stays allowed for local
+        // dev / tests, where there's no on-path attacker — the same
+        // "localhost is a secure context" carve-out browsers make.
+        validate_registry_scheme(&cfg.base_url)?;
         let http = Client::builder()
             .timeout(cfg.http_timeout)
             // No retry middleware here — the syncer's
@@ -134,6 +140,25 @@ impl UpstreamRegistryClient {
             RegistryError::Transient(format!("http: {e}"))
         }
     }
+}
+
+/// Reject a registry `base_url` that isn't `https://`, except a
+/// loopback `http://` (local dev / tests). See [`UpstreamRegistryClient::new`].
+fn validate_registry_scheme(base_url: &str) -> Result<(), RegistryError> {
+    if base_url.starts_with("https://") {
+        return Ok(());
+    }
+    if let Some(rest) = base_url.strip_prefix("http://") {
+        // Host is the authority up to the first `/`, `:`, or `?`.
+        let host = rest.split(['/', ':', '?']).next().unwrap_or("");
+        if host == "localhost" || host == "127.0.0.1" || rest.starts_with("[::1]") {
+            return Ok(());
+        }
+    }
+    Err(RegistryError::Permanent(format!(
+        "registry base_url must be https:// (got '{base_url}'); cleartext recognition is \
+         spoofable by an on-path attacker. http:// is allowed only to loopback for local dev."
+    )))
 }
 
 #[async_trait]
@@ -459,6 +484,23 @@ mod tests {
         };
         let c = UpstreamRegistryClient::new(cfg).unwrap();
         assert_eq!(c.base_url, "https://registry.example.com");
+    }
+
+    #[test]
+    fn rejects_cleartext_registry_url() {
+        // A public http:// registry is spoofable on-path — refuse at
+        // construction.
+        let err = UpstreamRegistryClient::new(config_for("http://registry.example.com"))
+            .expect_err("cleartext public registry must be rejected");
+        assert!(matches!(err, RegistryError::Permanent(_)), "got {err:?}");
+        // https is fine.
+        assert!(UpstreamRegistryClient::new(config_for("https://registry.example.com")).is_ok());
+        // Loopback http stays allowed for local dev.
+        assert!(UpstreamRegistryClient::new(config_for("http://127.0.0.1:8080")).is_ok());
+        assert!(UpstreamRegistryClient::new(config_for("http://localhost:8080")).is_ok());
+        assert!(UpstreamRegistryClient::new(config_for("http://[::1]:8080")).is_ok());
+        // A host that merely starts with "localhost" is not loopback.
+        assert!(UpstreamRegistryClient::new(config_for("http://localhost.evil.com")).is_err());
     }
 
     #[tokio::test]


### PR DESCRIPTION
First slice of the **P3.13** hygiene batch — two small untrusted-input hardening fixes.

## 1. Cleartext registry URL accepted

`UpstreamRegistryClient::new` accepted any scheme, so recognition could answer **trusted** over cleartext `http://` — spoofable by an on-path attacker. Now require `https://` for any non-loopback registry; loopback `http://` (`localhost` / `127.0.0.1` / `[::1]`) stays allowed for local dev + tests — the same "localhost is a secure context" carve-out browsers make.

## 2. Unbounded / unvalidated public-profile fields

`CommunityProfileUpdate::apply` set `name` / `description` / `logoUrl` / `contactEmail` with **no length cap** and **no scheme check** on `logoUrl` — all served on the unauth `/v1/community/public-profile`. Added per-field char caps (validated *before* any mutation, mirroring the existing `extensions` cap) and restricted `logoUrl` to an http(s) URL so it can't carry a `javascript:` / `data:` payload into the public page's `<img src>`.

## Tests

`rejects_cleartext_registry_url` (public http rejected; https + loopback pass; `localhost.evil.com` rejected); `rejects_oversized_text_fields` + `rejects_non_http_logo_url_but_accepts_https`. Full `cargo test -p vtc-service --lib` (610) green; clippy/fmt clean.

## Remaining P3.13 items (separate PRs)
Secret-`Debug` redaction + wizard key-print gate + dead `b64:` path; path-param DID validation; stale webauthn doc + `vtcDid`/`vtcUrl` rename; supervisor restart-on-panic.