### PR TITLE
harden(vtc): redact secret Debug, gate wizard key print, drop dead b64 path (P3.13)

### DIFF
--- a/vtc-service/src/config.rs
+++ b/vtc-service/src/config.rs
@@ -429,7 +429,7 @@ pub struct ServerConfig {
 // (P0.8). Safe here — `SecretsConfig` carries no serde aliases; the
 // alias-bearing fields live on the parent `AppConfig`, which is intentionally
 // left lenient until the alias audit in the plan.
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecretsConfig {
     /// Hex-encoded VTC key material (config-secret feature)
@@ -454,6 +454,26 @@ pub struct SecretsConfig {
 
 fn default_keyring_service() -> String {
     "vtc".to_string()
+}
+
+// Manual Debug — `secret` is the hex-encoded VTC key material; leaking
+// it via a stray `{:?}` (e.g. a future `debug!(?config)`) would
+// compromise every key derived from it. Redact it; the other fields are
+// backend *names*, not secrets, so they print verbatim. Mirrors
+// `vti_common::config::SecretsConfig`'s impl.
+impl std::fmt::Debug for SecretsConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SecretsConfig")
+            .field("secret", &self.secret.as_ref().map(|_| "<redacted>"))
+            .field("aws_secret_name", &self.aws_secret_name)
+            .field("aws_region", &self.aws_region)
+            .field("gcp_project", &self.gcp_project)
+            .field("gcp_secret_name", &self.gcp_secret_name)
+            .field("azure_vault_url", &self.azure_vault_url)
+            .field("azure_secret_name", &self.azure_secret_name)
+            .field("keyring_service", &self.keyring_service)
+            .finish()
+    }
 }
 
 impl Default for SecretsConfig {
@@ -835,6 +855,20 @@ impl AppConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn secrets_config_debug_redacts_secret() {
+        let cfg = SecretsConfig {
+            secret: Some("deadbeefdeadbeef".into()),
+            keyring_service: "vtc".into(),
+            ..Default::default()
+        };
+        let dbg = format!("{cfg:?}");
+        assert!(dbg.contains("<redacted>"), "got {dbg}");
+        assert!(!dbg.contains("deadbeef"), "secret leaked: {dbg}");
+        // Non-secret backend names still print.
+        assert!(dbg.contains("vtc"));
+    }
 
     // ── Parse contract ──────────────────────────────────────────────
     //

--- a/vtc-service/src/setup/bundle.rs
+++ b/vtc-service/src/setup/bundle.rs
@@ -32,8 +32,6 @@
 //!   deployment fails loud at the verification step rather than
 //!   silently accepting tokens minted under the old derivation.
 
-use base64::Engine;
-use base64::engine::general_purpose::STANDARD_NO_PAD as B64;
 use multibase::Base;
 use serde::{Deserialize, Serialize};
 use vti_common::error::AppError;
@@ -46,7 +44,7 @@ use zeroize::Zeroizing;
 /// multibase-encoded strings at rest. Use the accessor methods
 /// instead of touching the raw fields if you need a `Zeroizing`
 /// buffer for the live key.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct VtcKeyBundle {
     /// The VTC's `did:webvh`. Matches [`crate::config::AppConfig::vtc_did`]
@@ -67,6 +65,23 @@ pub struct VtcKeyBundle {
     /// Multibase-encoded X25519 private key. Access via
     /// [`Self::x25519_private_zeroizing`].
     pub x25519_private_multibase: String,
+}
+
+// Manual Debug — the two `*_private_multibase` fields are live key
+// material; a derived `Debug` would print them on any `{:?}`. Redact the
+// private halves; DIDs + public keys are not secret.
+impl std::fmt::Debug for VtcKeyBundle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("VtcKeyBundle")
+            .field("integration_did", &self.integration_did)
+            .field("ed25519_key_id", &self.ed25519_key_id)
+            .field("ed25519_public_multibase", &self.ed25519_public_multibase)
+            .field("ed25519_private_multibase", &"<redacted>")
+            .field("x25519_key_id", &self.x25519_key_id)
+            .field("x25519_public_multibase", &self.x25519_public_multibase)
+            .field("x25519_private_multibase", &"<redacted>")
+            .finish()
+    }
 }
 
 impl VtcKeyBundle {
@@ -225,28 +240,6 @@ fn encode_public_multibase(bytes: &[u8; 32], codec: [u8; 2]) -> String {
     multibase::encode(Base::Base58Btc, &buf)
 }
 
-/// Encode bytes for use as the `inline_secret` config field. The
-/// secret store may treat that field as either a hex string (legacy)
-/// or — when prefixed `b64:` — base64-no-pad. JSON bytes contain
-/// characters that aren't hex-safe, so we wrap them.
-pub fn inline_secret_for_bundle(bundle: &VtcKeyBundle) -> Result<String, AppError> {
-    let bytes = bundle.to_secret_store_bytes()?;
-    Ok(format!("b64:{}", B64.encode(&bytes)))
-}
-
-/// Inverse of [`inline_secret_for_bundle`].
-pub fn bundle_from_inline_secret(secret: &str) -> Result<VtcKeyBundle, AppError> {
-    let body = secret.strip_prefix("b64:").ok_or_else(|| {
-        AppError::Internal(
-            "inline_secret is not a VtcKeyBundle wrapper (expected 'b64:' prefix)".into(),
-        )
-    })?;
-    let bytes = B64
-        .decode(body)
-        .map_err(|e| AppError::Internal(format!("inline_secret base64 decode: {e}")))?;
-    VtcKeyBundle::from_secret_store_bytes(&bytes)
-}
-
 /// Decode whatever the secret store handed back into the VTC's
 /// `(ed25519, x25519)` private-scalar pair.
 ///
@@ -316,12 +309,21 @@ mod tests {
     }
 
     #[test]
-    fn round_trip_inline_secret() {
+    fn debug_redacts_private_keys() {
         let b = fixture();
-        let s = inline_secret_for_bundle(&b).unwrap();
-        assert!(s.starts_with("b64:"));
-        let parsed = bundle_from_inline_secret(&s).unwrap();
-        assert_eq!(b, parsed);
+        let dbg = format!("{b:?}");
+        assert!(dbg.contains("<redacted>"), "got {dbg}");
+        // The actual private multibase strings must not appear.
+        assert!(
+            !dbg.contains(&b.ed25519_private_multibase),
+            "ed25519 private leaked: {dbg}"
+        );
+        assert!(
+            !dbg.contains(&b.x25519_private_multibase),
+            "x25519 private leaked: {dbg}"
+        );
+        // Public material stays visible for diagnostics.
+        assert!(dbg.contains(&b.integration_did));
     }
 
     #[test]

--- a/vtc-service/src/setup/mod.rs
+++ b/vtc-service/src/setup/mod.rs
@@ -12,6 +12,6 @@ pub mod bundle;
 #[cfg(feature = "setup")]
 pub mod wizard;
 
-pub use bundle::{VtcKeyBundle, bundle_from_inline_secret, inline_secret_for_bundle};
+pub use bundle::VtcKeyBundle;
 #[cfg(feature = "setup")]
 pub use wizard::run_setup_wizard;

--- a/vtc-service/src/setup/wizard.rs
+++ b/vtc-service/src/setup/wizard.rs
@@ -234,8 +234,26 @@ pub async fn run_setup_wizard(config_path: Option<PathBuf>) -> Result<(), AppErr
     println!("Data dir:      {}", data_dir.display());
     println!();
     if let Some(key_json) = admin_key_summary.as_deref() {
-        println!("\x1b[1;33mAdmin key (save this — needed for CLI access):\x1b[0m");
-        println!("{key_json}");
+        // The admin private key lands in the terminal scrollback / any
+        // session recording the moment it's printed. Make the operator
+        // consciously reveal it rather than spilling it by default.
+        // TODO(keyring): write this to the OS keyring instead of stdout.
+        let reveal = Confirm::new()
+            .with_prompt(
+                "Display the admin private key now? It's needed for CLI access and is shown only once",
+            )
+            .default(false)
+            .interact()
+            .map_err(prompt_err)?;
+        if reveal {
+            println!("\x1b[1;33mAdmin key (save this — needed for CLI access):\x1b[0m");
+            println!("{key_json}");
+        } else {
+            println!(
+                "\x1b[1;33mAdmin key not displayed.\x1b[0m Re-run setup if you need it; it is \
+                 not persisted."
+            );
+        }
         println!();
     }
     println!("\x1b[1mInstall URL (one-shot, 15 min TTL):\x1b[0m");


### PR DESCRIPTION
Second slice of the **P3.13** hygiene batch — secret-material hygiene.

## 1. Secret-bearing `Debug` derives

`VtcKeyBundle` (Ed25519 + X25519 private multibase) and the vtc-service `SecretsConfig` (hex VTC key material) both **derived** `Debug` — so a future `debug!(?config)` / stray `{:?}` would print live key material. Replaced both with manual `Debug` impls that redact the private fields (DIDs + public keys still print). Mirrors the existing `vti_common::config::SecretsConfig` redaction.

## 2. Wizard printed the admin private key unconditionally

`vtc setup` printed the admin private-key JSON to stdout — it lands in terminal scrollback / session recordings. Now gated behind an explicit `Confirm` (default **no**); declining prints a note that it wasn't shown. `TODO(keyring)` filed inline for the real fix (write to the OS keyring).

## 3. Dead `b64:` inline-secret path

`inline_secret_for_bundle` / `bundle_from_inline_secret` (the `b64:` wrapper) had **zero production callers**, and `ConfigSecretStore::get` only hex-decodes — so a `b64:` value was unbootable: a misleading "production path" that never worked. Deleted the pair, its re-export, its test, and the now-unused base64 imports.

## Tests

`VtcKeyBundle` + `SecretsConfig` `Debug` redact the private values while keeping non-secret fields visible. Full `cargo test -p vtc-service --lib` (611) green; clippy/fmt clean.