### PR TITLE
harden(vtc): validate path-param DIDs before use as store keys (P3.13)

### DIFF
--- a/vtc-service/src/routes/directory.rs
+++ b/vtc-service/src/routes/directory.rs
@@ -96,6 +96,7 @@ pub async fn query(
     Path(subject_did): Path<String>,
     Query(q): Query<DirectoryQuery>,
 ) -> Result<Json<DirectoryResponse>, AppError> {
+    vti_common::identifier::validate_did("did", &subject_did)?;
     let facts = assemble_directory_facts(&state, &viewer, &subject_did, q.fields).await?;
     let verified = VerifiedFacts::assemble(facts)?;
 

--- a/vtc-service/src/routes/members/personhood.rs
+++ b/vtc-service/src/routes/members/personhood.rs
@@ -157,6 +157,7 @@ pub async fn challenge(
     State(state): State<AppState>,
     Path(member_did): Path<String>,
 ) -> Result<(StatusCode, Json<ChallengeResponse>), AppError> {
+    vti_common::identifier::validate_did("did", &member_did)?;
     // Member must exist — minting a challenge for a non-member
     // is operator-confusing and serves no purpose.
     let _ = get_acl_entry(&state.acl_ks, &member_did)
@@ -229,6 +230,7 @@ pub async fn assert(
     Path(member_did): Path<String>,
     Json(body): Json<AssertBody>,
 ) -> Result<(StatusCode, Json<AssertResponse>), AppError> {
+    vti_common::identifier::validate_did("did", &member_did)?;
     // Load Member row first — `404` for an unknown subject
     // is the most actionable failure mode.
     let mut member = get_member(&state.members_ks, &member_did)
@@ -427,6 +429,7 @@ pub async fn revoke(
     State(state): State<AppState>,
     Path(member_did): Path<String>,
 ) -> Result<(StatusCode, Json<RevokeResponse>), AppError> {
+    vti_common::identifier::validate_did("did", &member_did)?;
     // Auth: AdminAuth-equivalent (role == admin) OR self.
     let is_self = auth.did == member_did;
     let is_admin = auth.role == vti_common::acl::Role::Admin;

--- a/vtc-service/src/routes/members/promote.rs
+++ b/vtc-service/src/routes/members/promote.rs
@@ -74,6 +74,7 @@ pub async fn promote_start(
     State(state): State<AppState>,
     Path(target_did): Path<String>,
 ) -> Result<Json<PromoteStartResponse>, AppError> {
+    vti_common::identifier::validate_did("did", &target_did)?;
     if auth.0.did == target_did {
         return Err(AppError::Validation(
             "you cannot promote yourself; the promotion endpoint requires a separate admin caller"
@@ -166,6 +167,7 @@ pub async fn promote_finish(
     Path(target_did): Path<String>,
     Json(req): Json<PromoteFinishRequest>,
 ) -> Result<Json<PromoteFinishResponse>, AppError> {
+    vti_common::identifier::validate_did("did", &target_did)?;
     if auth.0.did == target_did {
         return Err(AppError::Validation("you cannot promote yourself".into()));
     }

--- a/vtc-service/src/routes/members/read.rs
+++ b/vtc-service/src/routes/members/read.rs
@@ -188,6 +188,7 @@ pub async fn show_member(
     State(state): State<AppState>,
     Path(did): Path<String>,
 ) -> Result<Json<MemberResponse>, AppError> {
+    vti_common::identifier::validate_did("did", &did)?;
     let member = get_member(&state.members_ks, &did)
         .await?
         .ok_or_else(|| AppError::NotFound(format!("member not found: {did}")))?;

--- a/vtc-service/src/routes/members/relationships.rs
+++ b/vtc-service/src/routes/members/relationships.rs
@@ -55,6 +55,7 @@ pub async fn list(
     Path(did): Path<String>,
     Query(query): Query<ListQuery>,
 ) -> Result<Json<Paginated<Relationship>>, AppError> {
+    vti_common::identifier::validate_did("did", &did)?;
     let limit = query.limit.unwrap_or(50).clamp(1, MAX_LIMIT);
     let audit_key = state
         .audit_writer

--- a/vtc-service/src/routes/members/remove.rs
+++ b/vtc-service/src/routes/members/remove.rs
@@ -130,6 +130,7 @@ pub async fn admin_remove(
     Path(target_did): Path<String>,
     body: Option<Json<RemoveBody>>,
 ) -> Result<(StatusCode, Json<RemoveResponse>), AppError> {
+    vti_common::identifier::validate_did("did", &target_did)?;
     if admin.0.did == target_did {
         return Err(AppError::Validation(
             "use DELETE /v1/members/me to remove yourself — \

--- a/vtc-service/src/routes/members/update.rs
+++ b/vtc-service/src/routes/members/update.rs
@@ -57,6 +57,7 @@ pub async fn update_member(
     Path(did): Path<String>,
     Json(req): Json<UpdateMemberRequest>,
 ) -> Result<Json<MemberResponse>, AppError> {
+    vti_common::identifier::validate_did("did", &did)?;
     // Role=Admin is forbidden on this surface — it routes to the
     // separate promote-to-admin endpoint (spec §10.4), where the
     // role-change policy's step-up branch is reached. Catch it early so

--- a/vtc-service/tests/members_crud.rs
+++ b/vtc-service/tests/members_crud.rs
@@ -273,6 +273,23 @@ async fn show_member_returns_joined_response() {
 }
 
 #[tokio::test]
+async fn show_member_rejects_malformed_did_path_param() {
+    // P3.13: a path-param that isn't a well-formed DID is rejected at
+    // the handler before it's ever used as a store key.
+    let fix = build_fixture().await;
+    let (status, _) = send(
+        &fix.router,
+        "GET",
+        "/v1/members/not-a-did",
+        SHOW_TASK,
+        Some(&fix.admin_token),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
 async fn show_member_returns_404_for_unknown_did() {
     let fix = build_fixture().await;
     let (status, _) = send(

--- a/vti-common/src/identifier.rs
+++ b/vti-common/src/identifier.rs
@@ -24,6 +24,45 @@ pub fn validate_identifier(label: &str, value: &str) -> Result<(), AppError> {
     vta_sdk::identifier::validate_identifier(label, value).map_err(|e| AppError::Validation(e.0))
 }
 
+/// Maximum accepted DID length, in bytes. `did:webvh` / `did:web` DIDs
+/// can be long (SCID + host + path), but a multi-KB "DID" used as a
+/// store key is an abuse / DoS lever — cap it.
+pub const MAX_DID_LEN: usize = 1024;
+
+/// Validate a caller-supplied DID before it's used as a store key (or
+/// resolved). Unlike [`validate_identifier`] (slug rules), a DID
+/// legitimately contains `:` separators, so this accepts the DID-Core
+/// method-specific-id character class (`ALPHA / DIGIT / "." / "-" /
+/// "_" / pct-encoded / ":"`) and a `did:` prefix — but still rejects
+/// control characters, whitespace, NUL, `/`, and non-ASCII, any of
+/// which would let a caller inject into logs or traverse adjacent
+/// store-keyspace prefixes when the value lands as a key.
+pub fn validate_did(label: &str, value: &str) -> Result<(), AppError> {
+    if value.is_empty() {
+        return Err(AppError::Validation(format!("{label} must not be empty")));
+    }
+    if value.len() > MAX_DID_LEN {
+        return Err(AppError::Validation(format!(
+            "{label} is {} bytes; maximum is {MAX_DID_LEN}",
+            value.len()
+        )));
+    }
+    if !value.starts_with("did:") {
+        return Err(AppError::Validation(format!(
+            "{label} is not a DID (must start with 'did:')"
+        )));
+    }
+    for (i, ch) in value.chars().enumerate() {
+        let ok = ch.is_ascii_alphanumeric() || matches!(ch, '.' | '-' | '_' | ':' | '%');
+        if !ok {
+            return Err(AppError::Validation(format!(
+                "{label} contains an invalid character {ch:?} at position {i}"
+            )));
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -91,5 +130,35 @@ mod tests {
             msg.contains("context_id"),
             "error must name the field it is validating — got {msg}"
         );
+    }
+
+    #[test]
+    fn validate_did_accepts_real_dids() {
+        for ok in [
+            "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK",
+            "did:webvh:QmSCID:example.com",
+            "did:web:example.com:user:alice",
+            "did:peer:2.Ez6LS",
+        ] {
+            validate_did("did", ok).unwrap_or_else(|e| panic!("{ok:?} rejected: {e:?}"));
+        }
+    }
+
+    #[test]
+    fn validate_did_rejects_malicious_or_malformed() {
+        for bad in [
+            "",                  // empty
+            "z6MkNotADid",       // missing did: prefix
+            "did:key:z\0null",   // NUL byte
+            "did:key:a/b",       // path separator
+            "did:key:a b",       // whitespace
+            "did:key:tab\there", // control char
+            "did:key:§§",        // non-ASCII
+        ] {
+            validate_did("did", bad).expect_err(&format!("{bad:?} must be rejected"));
+        }
+        // Over-cap.
+        let long = format!("did:key:{}", "a".repeat(MAX_DID_LEN));
+        validate_did("did", &long).expect_err("overlong must be rejected");
     }
 }


### PR DESCRIPTION
Third slice of the **P3.13** hygiene batch.

## Problem

Member + directory route handlers took a DID straight from the URL path and used it as a keyspace key / resolved it with **no validation**. The keyspace-key encoding percent-encodes `:` / `%` / `/`, but an unvalidated value could still carry control characters, a NUL, or be unbounded — log-injection / abuse levers once it lands as a key.

`validate_identifier` is slug-only (it rejects colons), so it can't validate a DID.

## Change

- Add **`vti_common::identifier::validate_did`**: requires a `did:` prefix, caps length (`MAX_DID_LEN = 1024`), and accepts the DID-Core method-specific-id char class (`alphanumeric + . - _ : %`) while rejecting control chars, whitespace, NUL, `/`, and non-ASCII.
- Wired into **all ten** path-param DID handlers: members `show` / `update` / `admin_remove` / `promote_start` / `promote_finish` / `relationships`, personhood `challenge` / `assert` / `revoke`, and directory `query`.

## Tests

`validate_did` accept/reject matrix in vti-common (real did:key/webvh/web/peer pass; missing-prefix, NUL, `/`, whitespace, control, non-ASCII, over-cap rejected); `show_member` with a non-DID path param → **400**. Existing member-route suites (members_crud / personhood / relationships / directory) unaffected; clippy/fmt clean.