### PR TITLE
docs(vtc): correct stale webauthn doc + emit typed credential bundle (P3.13)

### DIFF
--- a/vtc-service/src/did_key.rs
+++ b/vtc-service/src/did_key.rs
@@ -45,16 +45,25 @@ pub async fn run_create_did_key(args: CreateDidKeyArgs) -> Result<(), Box<dyn st
 
     eprintln!("DID: {did}");
 
-    // When --admin is set, print a credential bundle to stdout
+    // When --admin is set, print a credential bundle to stdout.
+    //
+    // This is the canonical `vta_sdk::CredentialBundle` shape — the same
+    // envelope a VTA emits — so the CLI importer parses VTC- and
+    // VTA-issued admin credentials with one type. The bundle's
+    // `vtaDid` / `vtaUrl` fields name the *issuing authority*; for a
+    // VTC-issued credential that authority is this VTC, so we pass the
+    // VTC's own DID / URL. (Not a copy-paste bug — building via the
+    // typed bundle keeps it from drifting out of the shared contract,
+    // whose `deny_unknown_fields` would reject a renamed key.)
     if args.admin {
         let vtc_did = config.vtc_did.unwrap_or_default();
-        let mut bundle = serde_json::json!({
-            "did": did,
-            "privateKeyMultibase": private_key_multibase,
-            "vtaDid": vtc_did,
-        });
+        let mut bundle = vta_sdk::credentials::CredentialBundle::new(
+            did.clone(),
+            private_key_multibase,
+            vtc_did,
+        );
         if let Some(url) = &config.public_url {
-            bundle["vtaUrl"] = serde_json::json!(url);
+            bundle = bundle.vta_url(url.clone());
         }
         let bundle_json = serde_json::to_string(&bundle)?;
         let credential = BASE64.encode(bundle_json.as_bytes());

--- a/vtc-service/src/webauthn.rs
+++ b/vtc-service/src/webauthn.rs
@@ -1,46 +1,46 @@
-//! VTC WebAuthn helpers — Ed25519-only registration enforcement.
+//! VTC WebAuthn helpers — broaden the accepted algorithm set to
+//! include EdDSA.
 //!
 //! Implements **M0.5.1** of the VTC MVP Phase 0 plan. Wraps
-//! `vti_common::auth::passkey::build_webauthn` with the VTC-specific
-//! invariant that **only Ed25519 (`COSEAlgorithm::EDDSA`,
-//! `COSEAlgorithmIdentifier = -8`) registrations are accepted**.
-//! The candidate admin DID is a `did:key` projected directly from the
-//! passkey's COSE public key — every other COSE curve breaks that
-//! projection (spec §4.2 second bullet).
+//! `vti_common::auth::passkey::build_webauthn`. There is **no**
+//! algorithm restriction: the admin `did:key` is carried in the
+//! install token, *not* projected from the passkey's COSE key, so the
+//! credential's algorithm is purely an auth-factor choice. Any
+//! algorithm the ceremony advertises — **ES256, RS256, and EdDSA** —
+//! is accepted at finish-time.
 //!
 //! ## Why a wrapper
 //!
 //! `webauthn-rs` 0.5 builds its safe `Webauthn` instance with
-//! `COSEAlgorithm::secure_algs()`, which today returns
-//! `[ES256, RS256]` — `EDDSA` is commented out in the upstream
-//! `secure_algs` constructor. The high-level builder exposes no
-//! `algorithms(…)` setter, so the only way to advertise EdDSA on the
-//! wire **and** accept it at finish-time is to post-process the
-//! ceremony state.
+//! `COSEAlgorithm::secure_algs()`, which today returns `[ES256, RS256]`
+//! — `EDDSA` is commented out in the upstream `secure_algs`
+//! constructor, and the high-level builder exposes no `algorithms(…)`
+//! setter. So to let Ed25519-capable hardware keys (YubiKey 5+, the
+//! soft test authenticator) register **alongside** the platform
+//! authenticators, this module *adds* EdDSA to the ceremony — it does
+//! not remove anything.
 //!
-//! This module provides two helpers that callers must use instead of
-//! `Webauthn::start_passkey_registration` /
-//! `Webauthn::finish_passkey_registration` directly:
+//! Two helpers, used instead of `Webauthn::{start,finish}_passkey_registration`
+//! directly:
 //!
-//! - [`start_passkey_registration`] — runs the upstream start,
-//!   then rewrites `CreationChallengeResponse.public_key.pub_key_cred_params`
-//!   and `PasskeyRegistration.rs.credential_algorithms` to contain
-//!   **only** EDDSA. The rewrite uses the `danger-allow-state-serialisation`
-//!   feature (enabled workspace-wide) to round-trip the state through
-//!   JSON — there is no other public path into the private
-//!   `credential_algorithms` field.
-//! - [`finish_passkey_registration`] — runs the upstream finish,
-//!   then rejects any returned `Passkey` whose `cred_algorithm()` is
-//!   not `EDDSA` (defence-in-depth: upstream's own check already
-//!   asserts the credential matches `credential_algorithms`, but we
-//!   double-check before the caller derives a `did:key`).
+//! - [`start_passkey_registration`] — runs the upstream start, then
+//!   **appends** EdDSA to
+//!   `CreationChallengeResponse.public_key.pub_key_cred_params` and to
+//!   `PasskeyRegistration.rs.credential_algorithms`, leaving the
+//!   default ES256 + RS256 in place. The state rewrite uses the
+//!   `danger-allow-state-serialisation` feature (enabled
+//!   workspace-wide) to round-trip through JSON — there is no other
+//!   public path into the private `credential_algorithms` field.
+//! - [`finish_passkey_registration`] — a thin pass-through to the
+//!   upstream finish. It does **not** filter by algorithm; upstream's
+//!   own check already asserts the returned credential matches the
+//!   ceremony's `credential_algorithms` (which now includes all three).
 //!
 //! ## When upstream gains an `algorithms` setter
 //!
-//! Replace the JSON-rewrite path with the setter and keep the
-//! finish-time check (it's cheap). Until then this is the only safe
-//! way to honour the spec's "Ed25519-only" invariant without forking
-//! `webauthn-rs` or dropping to `webauthn-rs-core::WebauthnCore::new_unsafe_experts_only`.
+//! Replace the JSON-rewrite in [`start_passkey_registration`] with the
+//! setter. Nothing else changes — there is no finish-time algorithm
+//! gate to keep.
 
 use webauthn_rs::prelude::{
     CreationChallengeResponse, Passkey, PasskeyRegistration, RegisterPublicKeyCredential, Webauthn,


### PR DESCRIPTION
Fourth slice of the **P3.13** batch — two doc/label hygiene fixes (no wire change).

## 1. Stale "Ed25519-only" webauthn doc

`webauthn.rs`'s module doc claimed **"Ed25519-only registration enforcement"** — *"rejects any returned `Passkey` whose `cred_algorithm()` is not `EDDSA`"*. The code does the **opposite**: it *adds* EdDSA to the upstream default `[ES256, RS256]` so Ed25519 hardware keys also work, and `finish_passkey_registration` applies **no** algorithm filter (the admin DID comes from the install token, not the passkey, so the credential's algorithm is just an auth-factor choice). Rewrote the module doc to match the real broaden-don't-restrict posture. (The function-level docs were already correct.)

## 2. `create-did-key` "vtaDid/vtaUrl" label

`vtc create-did-key --admin` hand-rolled a JSON bundle with literal `vtaDid` / `vtaUrl` keys carrying the **VTC's** own DID/URL — which reads like a copy-paste bug. **Checking the consumer first** (as the plan flagged): it *isn't* — that's the shared `vta_sdk::CredentialBundle` wire contract (`deny_unknown_fields`), reused so one CLI importer parses VTC- and VTA-issued admin credentials with one type. A rename to `vtcDid`/`vtcUrl` would break that parser. So instead of renaming, build via `CredentialBundle::new(...).vta_url(...)` (byte-identical output) + a comment explaining the field naming, so it can't drift out of the shared contract and won't get "fixed" into a broken rename.

## Tests

webauthn unit tests unchanged + green (doc-only); `CredentialBundle` round-trip is covered in vta-sdk; output is byte-identical. clippy/fmt clean.

## Remaining P3.13
Supervisor restart-on-panic for the syncer (the one behavior change in the batch) — separate PR.