### PR TITLE
chore: bump vta-sdk/vta-cli-common/pnm-cli for the agent device/vault surface (#482)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2365,7 +2365,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.13.1",
+ "vta-sdk 0.13.2",
 ]
 
 [[package]]
@@ -3145,7 +3145,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.13.1",
+ "vta-sdk 0.13.2",
 ]
 
 [[package]]
@@ -6507,7 +6507,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "pnm-cli"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-resolver-cache-sdk",
@@ -6529,7 +6529,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.13.1",
+ "vta-sdk 0.13.2",
 ]
 
 [[package]]
@@ -9792,7 +9792,7 @@ dependencies = [
 
 [[package]]
 name = "vta-cli-common"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "aes-gcm",
  "affinidi-crypto",
@@ -9810,7 +9810,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.13.1",
+ "vta-sdk 0.13.2",
  "x25519-dalek",
 ]
 
@@ -9849,7 +9849,7 @@ dependencies = [
  "tracing-subscriber",
  "trust-tasks-rs",
  "uniffi",
- "vta-sdk 0.13.1",
+ "vta-sdk 0.13.2",
 ]
 
 [[package]]
@@ -9884,7 +9884,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10021,7 +10021,7 @@ dependencies = [
  "uuid",
  "vaultrs",
  "vta-cli-common",
- "vta-sdk 0.13.1",
+ "vta-sdk 0.13.2",
  "vta-service",
  "vti-common",
  "vti-webauthn",
@@ -10106,7 +10106,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.13.1",
+ "vta-sdk 0.13.2",
  "vtc-service",
  "vti-common",
  "webauthn-rs",
@@ -10153,7 +10153,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.13.1",
+ "vta-sdk 0.13.2",
  "webauthn-rs",
  "zeroize",
 ]
@@ -10180,7 +10180,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.13.1",
+ "vta-sdk 0.13.2",
  "vta-service",
  "vti-common",
 ]

--- a/pnm-cli/Cargo.toml
+++ b/pnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pnm-cli"
 description = "CLI Tool for managing a personal Verifiable Trust Agent"
-version = "0.9.2"
+version = "0.9.3"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-cli-common/Cargo.toml
+++ b/vta-cli-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-cli-common"
 description = "Shared CLI command handlers and rendering helpers for VTA CLIs"
 readme = "README.md"
-version = "0.9.2"
+version = "0.9.3"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.13.1"
+version = "0.13.2"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true


### PR DESCRIPTION
Version bumps for the backward-compatible public API added in #482 (which merged at the prior patch versions).

| Crate | Old | New | Why |
|---|---|---|---|
| `vta-sdk` | 0.13.1 | 0.13.2 | new `device_*`/`vault_*` client methods, seal/open helpers, `ai-agent` built-in template |
| `vta-cli-common` | 0.9.2 | 0.9.3 | new `cmd_device_*`/`cmd_vault_*` handlers |
| `pnm-cli` | 0.9.2 | 0.9.3 | new `pnm device` / `pnm vault` commands |

All changes are additive/backward-compatible, so these are **patch** bumps under the workspace's `major.minor` internal-pin scheme. Internal deps pin `major.minor` only (`"0.13"`, `"0.9"`), so no dependent pin edits or downstream version cascade are required — unchanged crates (vti-common, vta-service, vtc-service, vta-enclave, cnm-cli) resolve the new patch versions automatically.

`Cargo.lock` regenerated; `cargo check` green for all three crates.