### PR TITLE
fix(vtc): supervise the MembershipSyncer + surface liveness in diagnostics (P3.13)

### DIFF
--- a/vtc-service/src/registry/health.rs
+++ b/vtc-service/src/registry/health.rs
@@ -153,6 +153,71 @@ pub struct RegistryHealthSnapshot {
     pub last_error: Option<String>,
 }
 
+/// Liveness signal for the `MembershipSyncer` task, distinct from
+/// [`RegistryHealth`] (which tracks the *registry's* reachability, not
+/// the *syncer task's*). The supervisor that owns the syncer loop
+/// updates it; `/v1/health/diagnostics` reads it so a syncer that
+/// panicked — and the queue silently stopped draining — is visible to
+/// operators instead of a queue that just stops moving. Cheap to clone;
+/// lock-free.
+#[derive(Debug, Clone, Default)]
+pub struct SyncerHealth {
+    inner: Arc<SyncerHealthInner>,
+}
+
+#[derive(Debug, Default)]
+struct SyncerHealthInner {
+    /// The syncer was spawned at all (a registry is configured).
+    enabled: std::sync::atomic::AtomicBool,
+    /// The syncer loop is currently running (false once it returns or
+    /// while it's being restarted after a panic).
+    running: std::sync::atomic::AtomicBool,
+    /// Number of panic-triggered restarts the supervisor has performed.
+    restarts: std::sync::atomic::AtomicU64,
+}
+
+impl SyncerHealth {
+    pub fn new() -> Self {
+        Self::default()
+    }
+    pub fn set_enabled(&self) {
+        self.inner
+            .enabled
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+    }
+    pub fn mark_running(&self) {
+        self.inner
+            .running
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+    }
+    pub fn mark_stopped(&self) {
+        self.inner
+            .running
+            .store(false, std::sync::atomic::Ordering::Relaxed);
+    }
+    pub fn record_restart(&self) {
+        self.inner
+            .restarts
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+    pub fn snapshot(&self) -> SyncerHealthSnapshot {
+        use std::sync::atomic::Ordering::Relaxed;
+        SyncerHealthSnapshot {
+            enabled: self.inner.enabled.load(Relaxed),
+            running: self.inner.running.load(Relaxed),
+            restarts: self.inner.restarts.load(Relaxed),
+        }
+    }
+}
+
+/// Snapshot of [`SyncerHealth`] for the diagnostics endpoint.
+#[derive(Debug, Clone, Copy)]
+pub struct SyncerHealthSnapshot {
+    pub enabled: bool,
+    pub running: bool,
+    pub restarts: u64,
+}
+
 async fn emit_changed(
     audit_writer: Option<&AuditWriter>,
     actor_did: &str,
@@ -181,6 +246,27 @@ mod tests {
     async fn default_status_is_degraded() {
         let h = RegistryHealth::new();
         assert_eq!(h.status().await, HealthStatus::Degraded);
+    }
+
+    #[test]
+    fn syncer_health_tracks_enabled_running_restarts() {
+        let h = SyncerHealth::new();
+        let s = h.snapshot();
+        assert!(!s.enabled && !s.running && s.restarts == 0);
+
+        h.set_enabled();
+        h.mark_running();
+        let s = h.snapshot();
+        assert!(s.enabled && s.running && s.restarts == 0);
+
+        // A panic-restart: stopped, counter bumped, then running again.
+        h.mark_stopped();
+        h.record_restart();
+        let s = h.snapshot();
+        assert!(s.enabled && !s.running && s.restarts == 1);
+
+        h.mark_running();
+        assert!(h.snapshot().running);
     }
 
     #[tokio::test]

--- a/vtc-service/src/registry/mod.rs
+++ b/vtc-service/src/registry/mod.rs
@@ -56,7 +56,7 @@ pub mod tail;
 pub mod upstream;
 
 pub use client::{MockRegistryClient, RegistryError, TrustRegistryClient};
-pub use health::{HealthStatus, RegistryHealth};
+pub use health::{HealthStatus, RegistryHealth, SyncerHealth, SyncerHealthSnapshot};
 pub use model::{
     DEFAULT_MAX_ATTEMPTS, MAX_BACKOFF_SECONDS, RegistryRecord, RegistryStatus, SyncJob,
     SyncJobKind, SyncJobState, exponential_backoff_seconds,

--- a/vtc-service/src/routes/health.rs
+++ b/vtc-service/src/routes/health.rs
@@ -95,6 +95,14 @@ pub struct DiagnosticsResponse {
     /// unauth `/v1/community/public-profile`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mediator_did: Option<String>,
+    /// Whether the `MembershipSyncer` task is enabled (a registry is
+    /// configured) and currently running (P3.13). `syncer_enabled &&
+    /// !syncer_running` means the syncer is spawned but dead — e.g.
+    /// mid-restart after a panic. `syncer_restarts` counts panic
+    /// restarts; a rising value is a "syncer keeps crashing" signal.
+    pub syncer_enabled: bool,
+    pub syncer_running: bool,
+    pub syncer_restarts: u64,
 }
 
 #[utoipa::path(
@@ -147,6 +155,8 @@ pub async fn diagnostics(
 
     // Identity / mediator detail — folded down from the unauth
     // `/health` payload (P3.7), now only readable by an admin.
+    let syncer = state.syncer_health.snapshot();
+
     let config = state.config.read().await;
     let vta_did = config.vta_did.clone();
     let (mediator_url, mediator_did) = config
@@ -176,5 +186,8 @@ pub async fn diagnostics(
         vta_did,
         mediator_url,
         mediator_did,
+        syncer_enabled: syncer.enabled,
+        syncer_running: syncer.running,
+        syncer_restarts: syncer.restarts,
     }))
 }

--- a/vtc-service/src/server.rs
+++ b/vtc-service/src/server.rs
@@ -119,6 +119,10 @@ pub struct AppState {
     /// profile + diagnostics handlers read this; the
     /// boot/probe paths write it.
     pub registry_health: crate::registry::RegistryHealth,
+    /// Liveness of the `MembershipSyncer` task (P3.13). The
+    /// supervisor updates it on start / restart-after-panic; the
+    /// diagnostics handler reads it so a dead syncer is visible.
+    pub syncer_health: crate::registry::SyncerHealth,
     pub config: Arc<RwLock<AppConfig>>,
     pub did_resolver: Option<DIDCacheClient>,
     pub secrets_resolver: Option<Arc<ThreadedSecretsResolver>>,
@@ -497,6 +501,7 @@ pub async fn run(
         audit_key_ks,
         registry_client: registry_client.clone(),
         registry_health: registry_health.clone(),
+        syncer_health: crate::registry::SyncerHealth::new(),
         config: Arc::new(RwLock::new(config)),
         did_resolver,
         secrets_resolver,
@@ -645,22 +650,71 @@ pub async fn run(
         (state.registry_client.clone(), syncer_actor_did_opt.clone())
     {
         let rtbf_batch_window_hours = boot_cfg.registry.rtbf_batch_window_hours;
-        let syncer = crate::registry::MembershipSyncer::new(
-            state.audit_ks.clone(),
-            state.sync_queue_ks.clone(),
-            state.sync_cursor_ks.clone(),
-            state.registry_records_ks.clone(),
-            state.policies_ks.clone(),
-            state.active_policies_ks.clone(),
-            client,
-            state.registry_health.clone(),
-            state.audit_writer.clone(),
-            actor_did,
-        )
-        .with_rtbf_batch_window_hours(rtbf_batch_window_hours);
-        let syncer_shutdown = shutdown_rx.clone();
+        // Supervisor: a bare `tokio::spawn` meant a panicking syncer
+        // loop died silently — the sync queue just stopped draining with
+        // no signal. Re-spawn the loop after a panic (with backoff) and
+        // surface liveness + restart count via `syncer_health`, which
+        // `/v1/health/diagnostics` reports (P3.13). `run(self)` consumes
+        // the syncer, so we reconstruct it from cloned handles each
+        // iteration (cheap — all inputs are `Arc`/handle clones).
+        let health = state.syncer_health.clone();
+        health.set_enabled();
+        let audit_ks = state.audit_ks.clone();
+        let sync_queue_ks = state.sync_queue_ks.clone();
+        let sync_cursor_ks = state.sync_cursor_ks.clone();
+        let registry_records_ks = state.registry_records_ks.clone();
+        let policies_ks = state.policies_ks.clone();
+        let active_policies_ks = state.active_policies_ks.clone();
+        let registry_health = state.registry_health.clone();
+        let audit_writer = state.audit_writer.clone();
+        let mut supervisor_shutdown = shutdown_rx.clone();
         tokio::spawn(async move {
-            syncer.run(syncer_shutdown).await;
+            loop {
+                if *supervisor_shutdown.borrow() {
+                    break;
+                }
+                let syncer = crate::registry::MembershipSyncer::new(
+                    audit_ks.clone(),
+                    sync_queue_ks.clone(),
+                    sync_cursor_ks.clone(),
+                    registry_records_ks.clone(),
+                    policies_ks.clone(),
+                    active_policies_ks.clone(),
+                    client.clone(),
+                    registry_health.clone(),
+                    audit_writer.clone(),
+                    actor_did.clone(),
+                )
+                .with_rtbf_batch_window_hours(rtbf_batch_window_hours);
+                let run_shutdown = supervisor_shutdown.clone();
+                health.mark_running();
+                let child = tokio::spawn(async move { syncer.run(run_shutdown).await });
+                match child.await {
+                    // Clean return — the loop observed shutdown.
+                    Ok(()) => {
+                        health.mark_stopped();
+                        break;
+                    }
+                    Err(join_err) if join_err.is_panic() => {
+                        health.mark_stopped();
+                        health.record_restart();
+                        error!(
+                            error = %join_err,
+                            "MembershipSyncer task panicked — restarting after backoff"
+                        );
+                        tokio::select! {
+                            _ = tokio::time::sleep(std::time::Duration::from_secs(5)) => {}
+                            _ = supervisor_shutdown.changed() => break,
+                        }
+                    }
+                    // Cancelled (shutdown aborted the child) — stop.
+                    Err(_) => {
+                        health.mark_stopped();
+                        break;
+                    }
+                }
+            }
+            health.mark_stopped();
         });
     }
 

--- a/vtc-service/src/test_support.rs
+++ b/vtc-service/src/test_support.rs
@@ -339,6 +339,7 @@ impl TestVtcBuilder {
             audit_key_ks,
             registry_client: None,
             registry_health: crate::registry::RegistryHealth::new(),
+            syncer_health: crate::registry::SyncerHealth::new(),
             config: Arc::new(RwLock::new(config)),
             did_resolver,
             secrets_resolver: None,

--- a/vtc-service/tests/diagnostics.rs
+++ b/vtc-service/tests/diagnostics.rs
@@ -80,6 +80,11 @@ async fn diagnostics_empty_queue_reports_zero_counts() {
             .is_none_or(|x| x.is_null()),
         "empty queue → no oldest_pending_age"
     );
+    // Syncer liveness is surfaced (P3.13). The test daemon has no
+    // registry client, so the syncer was never spawned.
+    assert_eq!(v["syncer_enabled"], false);
+    assert_eq!(v["syncer_running"], false);
+    assert_eq!(v["syncer_restarts"], 0);
 }
 
 #[tokio::test]

--- a/vtc-service/tests/emergency_bootstrap.rs
+++ b/vtc-service/tests/emergency_bootstrap.rs
@@ -312,6 +312,7 @@ async fn build_fixture(public_url: Option<&str>) -> Fixture {
         endorsements_ks: endorsements_ks.clone(),
         registry_client: None,
         registry_health: vtc_service::registry::RegistryHealth::new(),
+        syncer_health: vtc_service::registry::SyncerHealth::new(),
         credential_signer: None,
         audit_ks,
         audit_key_ks,

--- a/vtc-service/tests/passkey_state.rs
+++ b/vtc-service/tests/passkey_state.rs
@@ -87,6 +87,7 @@ fn build_state(public_url: Option<&str>) -> (AppState, tempfile::TempDir) {
         endorsements_ks: endorsements_ks.clone(),
         registry_client: None,
         registry_health: vtc_service::registry::RegistryHealth::new(),
+        syncer_health: vtc_service::registry::SyncerHealth::new(),
         credential_signer: None,
         config: Arc::new(RwLock::new(config)),
         did_resolver: None,


### PR DESCRIPTION
Final slice of the **P3.13** hygiene batch — the one behaviour change.

## Problem

The `MembershipSyncer` was spawned with a bare `tokio::spawn`, so a panic in its loop killed the task **silently** — the sync queue just stopped draining with no signal, and `/v1/health/diagnostics` couldn't tell a *stuck* syncer (registry down, queue growing) from a *dead* one (task gone).

## Change

- **Supervisor:** wrap the spawn so it runs the loop in a child task, **re-spawns it after a panic** (5s backoff, bailing promptly on shutdown), and logs each restart loudly. `run(self)` consumes the syncer, so each iteration reconstructs it from cloned handles (cheap — all `Arc`/handle clones). A clean return (shutdown observed) ends the supervisor.
- **Liveness in diagnostics:** new lock-free `SyncerHealth` (`enabled` / `running` / `restarts`) on `AppState`; the supervisor updates it, and `/v1/health/diagnostics` now carries `syncer_enabled` / `syncer_running` / `syncer_restarts`. `enabled && !running` = spawned-but-dead; a rising `restarts` = crash-looping. Distinct from `registry_status` (the *registry's* reachability, not the *task's*).

## Tests

`SyncerHealth` state transitions; diagnostics surfaces the syncer fields (`enabled=false` in the registry-less test daemon). Full `cargo test -p vtc-service --lib` (612) + diagnostics/passkey_state/emergency_bootstrap green; clippy/fmt clean.

## P3.13 complete
Closes the hygiene batch (input-hardening · secret-Debug · path-param DID validation · docs/labels · supervisor).