### PR TITLE
feat(secrets): Kubernetes Secret backend for VTA + VTC (k8s-secrets feature)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4577,6 +4577,7 @@ dependencies = [
  "http 1.4.2",
  "hyper 1.10.1",
  "hyper-util",
+ "log",
  "rustls 0.23.40",
  "rustls-native-certs",
  "tokio",
@@ -4931,6 +4932,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jiff"
+version = "0.2.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4603d3033e49e2b0e31229fcab20a5d40089c607d975cd9c80551dc69eed9102"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "jni"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5204,6 +5229,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonpath-rust"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633a7320c4bb672863a3782e89b9094ad70285e097ff6832cddd0ec615beadfa"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "regex",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "jsonschema"
 version = "0.46.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5265,6 +5303,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "k8s-openapi"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51b326f5219dd55872a72c1b6ddd1b830b8334996c667449c29391d657d78d5e"
+dependencies = [
+ "base64 0.22.1",
+ "jiff",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "kasuari"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5292,6 +5342,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb1e621458ca9c51aa110bd0339d4751a056b9576bf1253aee1aa560dda0fc9d"
 dependencies = [
  "log",
+]
+
+[[package]]
+name = "kube"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acc5a6a69da2975ed9925d56b5dcfc9cc739b66f37add06785b7c9f6d1e88741"
+dependencies = [
+ "k8s-openapi",
+ "kube-client",
+ "kube-core",
+]
+
+[[package]]
+name = "kube-client"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fcaf2d1f1a91e1805d4cd82e8333c022767ae8ffd65909bbef6802733a7dd40"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "either",
+ "futures",
+ "http 1.4.2",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.10.1",
+ "hyper-rustls 0.27.9",
+ "hyper-timeout",
+ "hyper-util",
+ "jiff",
+ "jsonpath-rust",
+ "k8s-openapi",
+ "kube-core",
+ "pem",
+ "rustls 0.23.40",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tower 0.5.3",
+ "tower-http",
+ "tracing",
+]
+
+[[package]]
+name = "kube-core"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f126d2db7a8b532ec1d839ece2a71e2485dc3bbca6cc3c3f929becaa810e719e"
+dependencies = [
+ "derive_more",
+ "form_urlencoded",
+ "http 1.4.2",
+ "jiff",
+ "k8s-openapi",
+ "serde",
+ "serde-value",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6152,6 +6265,15 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "ordered-float"
 version = "3.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1e1c390732d15f1d48471625cd92d154e66db2c56645e29a9cd26f4699f72dc"
@@ -6560,6 +6682,15 @@ name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "postcard"
@@ -7685,6 +7816,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7731,6 +7871,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float 2.10.1",
+ "serde",
 ]
 
 [[package]]
@@ -9126,6 +9276,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "async-compression",
+ "base64 0.22.1",
  "bitflags 2.13.0",
  "bytes",
  "futures-core",
@@ -9133,6 +9284,7 @@ dependencies = [
  "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
+ "mime",
  "pin-project-lite",
  "tokio",
  "tokio-util",
@@ -9988,7 +10140,9 @@ dependencies = [
  "hmac 0.13.0",
  "http-body-util",
  "jsonwebtoken",
+ "k8s-openapi",
  "keyring-core",
+ "kube",
  "libc",
  "metrics",
  "metrics-exporter-prometheus",
@@ -10080,7 +10234,9 @@ dependencies = [
  "include_dir",
  "jsonschema",
  "jsonwebtoken",
+ "k8s-openapi",
  "keyring-core",
+ "kube",
  "mime_guess",
  "multibase",
  "rand 0.10.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -240,6 +240,19 @@ libc = "0.2"
 azure_security_keyvault_secrets = "0.14"
 azure_identity = "0.35"
 
+# Kubernetes secret-store backend (feature `k8s-secrets`, off by default) for
+# both services. The seed/key material is stored as a hex string inside a
+# namespaced `Secret` resource. `Client::try_default()` auto-detects the
+# in-cluster ServiceAccount or a local kubeconfig, so no auth knobs are needed.
+# `default-features = false` + `rustls-tls` keeps OpenSSL out of the tree (the
+# rest of the workspace is rustls). `k8s-openapi`'s `latest` feature floats the
+# generated API version — fine here, the core/v1 `Secret` shape is long-stable.
+kube = { version = "3.1", default-features = false, features = [
+  "client",
+  "rustls-tls",
+] }
+k8s-openapi = { version = "0.27", features = ["latest"] }
+
 # Hoist DID-resolver-cache feature drift: every crate uses 0.8 but a few
 # omit the `network` feature. The default here turns it on; dependents
 # that want the offline-only cache can opt out via `default-features = false`.

--- a/docs/02-vta/feature-flags.md
+++ b/docs/02-vta/feature-flags.md
@@ -29,6 +29,7 @@ binaries (`vta-enclave`, etc.) forward relevant flags to
 | `gcp-secrets` | GCP Secret Manager seed storage | `google-cloud-secretmanager`, `google-cloud-auth`, `bytes` |
 | `azure-secrets` | Azure Key Vault seed storage | `azure_security_keyvault_secrets`, `azure_identity` |
 | `vault-secrets` | HashiCorp Vault seed storage (KV v2; Kubernetes / token / AppRole auth) | `vaultrs` |
+| `k8s-secrets` | Kubernetes `Secret` seed storage (in-cluster SA or kubeconfig) | `kube`, `k8s-openapi` |
 | `vsock-store` | Vsock-proxied persistent storage (for enclaves) | `vti-common/vsock-store` |
 | `vsock-log` | Vsock-proxied log forwarding (for enclaves) | `vti-common/vsock-log` |
 
@@ -88,7 +89,8 @@ the dependency: `features = ["tee"]`). No need to specify it.
 | Cloud (no TEE), AWS | `rest,didcomm,aws-secrets` | N/A |
 | Cloud (no TEE), GCP | `rest,didcomm,gcp-secrets` | N/A |
 | Cloud (no TEE), Azure | `rest,didcomm,azure-secrets` | N/A |
-| Kubernetes (any cloud) | `rest,didcomm,vault-secrets` | N/A |
+| Kubernetes (Vault available) | `rest,didcomm,vault-secrets` | N/A |
+| Kubernetes (native Secret) | `rest,didcomm,k8s-secrets` | N/A |
 
 For the runtime configuration that pairs with each backend feature
 (TOML keys, env vars, IAM/Vault setup), see

--- a/docs/02-vta/non-interactive-setup.md
+++ b/docs/02-vta/non-interactive-setup.md
@@ -127,12 +127,25 @@ summary.
 | `"aws"` | `secret_name`, optional `region` |
 | `"gcp"` | `project`, `secret_name` |
 | `"azure"` | `vault_url`, `secret_name` |
+| `"vault"` | `addr`, `secret_path`, optional `kv_mount`/`secret_key`/`namespace`/`auth_method`/auth fields |
+| `"kubernetes"` | `secret_name`, optional `namespace`, optional `secret_key` (default `"seed"`) |
 | `"config_seed"` | none — hex seed embedded in `config.toml`. **Not recommended.** |
 | `"plaintext"` | none — plaintext file under `data_dir`. **Dev only.** |
 
-Cloud backends require the matching feature at compile time
-(`aws-secrets`, `gcp-secrets`, `azure-secrets`) — the wizard refuses to
-proceed with a clear error if the feature isn't compiled in.
+Cloud / external backends require the matching feature at compile time
+(`aws-secrets`, `gcp-secrets`, `azure-secrets`, `vault-secrets`,
+`k8s-secrets`) — the wizard refuses to proceed with a clear error if the
+feature isn't compiled in.
+
+A Kubernetes `Secret` backend, for example:
+
+```toml
+[secrets]
+backend     = "kubernetes"
+secret_name = "vta-master-seed"
+namespace   = "vta-prod"   # optional; omit to use the pod's ServiceAccount namespace
+secret_key  = "seed"       # optional; default "seed"
+```
 
 ### Messaging
 

--- a/docs/02-vta/secret-backends.md
+++ b/docs/02-vta/secret-backends.md
@@ -10,7 +10,8 @@ If you just want to get going, the answer for most cases is:
 |---|---|
 | Local development on a workstation | OS keyring (default) |
 | AWS Nitro Enclave | KMS-TEE (automatic via `vta-enclave`) |
-| EKS / GKE / AKS / on-prem Kubernetes | HashiCorp Vault with Kubernetes auth |
+| EKS / GKE / AKS / on-prem Kubernetes, Vault available | HashiCorp Vault with Kubernetes auth |
+| EKS / GKE / AKS / on-prem Kubernetes, no Vault | Kubernetes `Secret` (native, no extra infra) |
 | Single EC2 / GCE / Azure VM, no TEE | AWS Secrets Manager / GCP Secret Manager / Azure Key Vault |
 | CI / sealed images / unattended bootstrap | Config-seed (with the seed coming in via a sealed channel) |
 
@@ -33,9 +34,10 @@ whose feature is compiled in **and** whose config is populated:
 | 2 | GCP Secret Manager | `gcp-secrets` | `secrets.gcp_secret_name` is set |
 | 3 | Azure Key Vault | `azure-secrets` | `secrets.azure_vault_url` is set |
 | 4 | HashiCorp Vault | `vault-secrets` | `secrets.vault_addr` is set |
-| 5 | Config-seed | `config-seed` | `secrets.seed` is set |
-| 6 | OS keyring | `keyring` | always (the default) |
-| 7 | Plaintext file | always available | unconditional fallback |
+| 5 | Kubernetes `Secret` | `k8s-secrets` | `secrets.k8s_secret_name` is set |
+| 6 | Config-seed | `config-seed` | `secrets.seed` is set |
+| 7 | OS keyring | `keyring` | always (the default) |
+| 8 | Plaintext file | always available | unconditional fallback |
 
 If no secure-backend feature is compiled and no config is set, the
 service falls back to a plaintext file in the data directory and
@@ -52,7 +54,7 @@ bypassed entirely. See
 Every backend stores the master seed as a **hex-encoded string** of
 the BIP-39 entropy bytes (32 bytes for 24-word mnemonics, 16 for
 12-word). This is consistent across AWS / GCP / Azure / Vault /
-keyring / config-seed / plaintext. Mismatched encodings are the
+Kubernetes / keyring / config-seed / plaintext. Mismatched encodings are the
 single most common foot-gun when migrating between backends — they
 are otherwise wire-compatible.
 
@@ -284,6 +286,110 @@ uses the system trust store to validate.
   Vault role's `bound_service_account_*` lists. Run
   `vault read auth/kubernetes/role/vta` and double-check.
 
+### Kubernetes `Secret`
+
+Cargo feature: `k8s-secrets` · File: `vta-service/src/keys/seed_store/k8s.rs`
+
+Stores the seed as a hex string inside a namespaced Kubernetes
+`Secret`. For in-cluster deployments that want to keep secret
+material native to Kubernetes without standing up HashiCorp Vault or
+reaching out to a cloud secret manager. Credentials are resolved by
+`kube`'s `Client::try_default()`: the pod's mounted ServiceAccount
+token in-cluster, or your local kubeconfig (`~/.kube/config` /
+`$KUBECONFIG`) when running `vta` outside the cluster (e.g. during
+`vta setup`).
+
+```toml
+[secrets]
+k8s_secret_name = "vta-master-seed"
+k8s_namespace   = "vta-prod"   # optional; see below
+k8s_secret_key  = "seed"       # optional; default "seed"
+```
+
+Equivalent env vars:
+
+```bash
+VTA_SECRETS_K8S_SECRET_NAME=vta-master-seed
+VTA_SECRETS_K8S_NAMESPACE=vta-prod
+VTA_SECRETS_K8S_SECRET_KEY=seed
+```
+
+**Namespace resolution.** If `k8s_namespace` is omitted, the
+backend uses the client's default namespace — the pod's own
+namespace in-cluster (from the mounted ServiceAccount), or the
+current kubeconfig context's namespace out-of-cluster — falling back
+to `default`. The most common in-cluster pattern is to inject the
+pod's namespace via the Downward API so you don't hard-code it:
+
+```yaml
+env:
+  - name: VTA_SECRETS_K8S_SECRET_NAME
+    value: vta-master-seed
+  - name: VTA_SECRETS_K8S_NAMESPACE
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.namespace
+```
+
+**RBAC.** The pod's ServiceAccount needs `get` on the Secret, plus
+`create` (first `vta setup`, when the Secret doesn't exist yet) and
+`update` (re-keying / writes). After first-boot you can drop down to
+`get` only if the seed never rotates.
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: vta-seed-secret
+  namespace: vta-prod
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "create", "update"]
+    # Optionally scope to the single Secret by name:
+    resourceNames: ["vta-master-seed"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: vta-seed-secret
+  namespace: vta-prod
+subjects:
+  - kind: ServiceAccount
+    name: vta
+roleRef:
+  kind: Role
+  name: vta-seed-secret
+  apiGroup: rbac.authorization.k8s.io
+```
+
+#### Vault vs native Kubernetes `Secret`
+
+Both target in-cluster deployments. Reach for **Vault** when you
+already run it, want envelope encryption / dynamic secrets / a full
+audit trail, or your security posture requires secrets never to sit
+in `etcd` in (only base64-encoded) plaintext. Reach for the
+**native `Secret`** backend when you want zero extra
+infrastructure — particularly when etcd encryption-at-rest is already
+enabled on the cluster (so the Secret is encrypted at rest by the API
+server) and a `Secret` + RBAC is all you need.
+
+#### Common pitfalls
+
+- **etcd plaintext.** A bare Kubernetes `Secret` is only
+  base64-encoded in etcd, not encrypted, unless the cluster has
+  [encryption at rest](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/)
+  configured. Enable it (or use Vault / a cloud secret manager) before
+  treating this as production-grade.
+- **Wrong namespace.** A `get` returning "not found" when the Secret
+  clearly exists almost always means the resolved namespace differs
+  from where the Secret lives. Set `k8s_namespace` explicitly to rule
+  it out.
+- **Key name mismatch.** The seed lives under `data.seed` by default.
+  If your Secret stores it under a different key, set `k8s_secret_key`
+  to match — the backend fails loudly (rather than minting a new seed)
+  when the Secret exists but the configured key is absent.
+
 ### KMS-TEE (Nitro Enclave)
 
 Cargo feature: `tee` · File: `vta-service/src/keys/seed_store/kms_tee.rs`
@@ -377,7 +483,8 @@ Are you running inside an AWS Nitro Enclave?
 └── No  ↓
 
 Are you running inside a Kubernetes cluster?
-├── Yes → HashiCorp Vault, kubernetes auth
+├── Yes, and you run HashiCorp Vault → Vault, kubernetes auth
+├── Yes, no Vault                     → Kubernetes Secret (k8s-secrets)
 └── No  ↓
 
 Do you have a managed cloud secret store you already trust?
@@ -398,14 +505,15 @@ Is this a developer workstation?
 
 ### Trade-offs
 
-| | AWS SM | GCP SM | Azure KV | Vault | KMS-TEE | Keyring | Config | Plaintext |
-|---|---|---|---|---|---|---|---|---|
-| Encrypted at rest | ✅ | ✅ | ✅ | ✅ (Vault internal) | ✅ (KMS) | ✅ (OS) | ❌ | ❌ |
-| Auto rotation friendly | ✅ | ✅ | ✅ | ✅ | n/a | ❌ | ❌ | ❌ |
-| Works in TEE | via parent | via parent | via parent | via parent | ✅ native | ❌ | ❌ | ❌ |
-| Works headless / CI | ✅ | ✅ | ✅ | ✅ | n/a | ⚠️ macOS prompts | ✅ | ✅ |
-| In-process auto-renewal | implicit (IAM) | implicit (ADC) | implicit (MI) | ✅ explicit | implicit (KMS) | n/a | n/a | n/a |
-| Production-ready | ✅ | ✅ | ✅ | ✅ | ✅ | dev only | dev only | never |
+| | AWS SM | GCP SM | Azure KV | Vault | K8s Secret | KMS-TEE | Keyring | Config | Plaintext |
+|---|---|---|---|---|---|---|---|---|---|
+| Encrypted at rest | ✅ | ✅ | ✅ | ✅ (Vault internal) | ⚠️ only if etcd encryption on | ✅ (KMS) | ✅ (OS) | ❌ | ❌ |
+| Auto rotation friendly | ✅ | ✅ | ✅ | ✅ | ✅ | n/a | ❌ | ❌ | ❌ |
+| Works in TEE | via parent | via parent | via parent | via parent | via parent | ✅ native | ❌ | ❌ | ❌ |
+| Works headless / CI | ✅ | ✅ | ✅ | ✅ | ✅ | n/a | ⚠️ macOS prompts | ✅ | ✅ |
+| In-process auto-renewal | implicit (IAM) | implicit (ADC) | implicit (MI) | ✅ explicit | implicit (SA token) | implicit (KMS) | n/a | n/a | n/a |
+| Extra infra required | cloud SM | cloud SM | cloud KV | Vault | none (in-cluster) | KMS | none | none | none |
+| Production-ready | ✅ | ✅ | ✅ | ✅ | ✅ (with etcd enc.) | ✅ | dev only | dev only | never |
 
 ## Migrating between backends
 
@@ -436,6 +544,7 @@ migrating is a copy operation between two trusted CLIs.
    | GCP Secret Manager | `gcloud secrets versions access latest --secret=vta-master-seed` |
    | Azure Key Vault | `az keyvault secret show --vault-name my-vault --name vta-master-seed --query value -o tsv` |
    | HashiCorp Vault | `vault kv get -field=seed secret/vta/master-seed` |
+   | Kubernetes Secret | `kubectl -n vta-prod get secret vta-master-seed -o jsonpath='{.data.seed}' \| base64 -d` |
    | Config-seed | `awk '/^seed/ {print $3}' config.toml` (already plaintext) |
    | Plaintext file | `cat <data_dir>/seed.hex` |
 
@@ -453,6 +562,7 @@ migrating is a copy operation between two trusted CLIs.
    | GCP Secret Manager | `printf %s '<hex>' \| gcloud secrets versions add vta-master-seed --data-file=-` |
    | Azure Key Vault | `az keyvault secret set --vault-name my-vault --name vta-master-seed --value '<hex>'` |
    | HashiCorp Vault | `vault kv put secret/vta/master-seed seed='<hex>'` |
+   | Kubernetes Secret | `kubectl -n vta-prod create secret generic vta-master-seed --from-literal=seed='<hex>'` |
 
    Pass the hex via env var or stdin where possible; argv exposes
    it to `ps`. For example:

--- a/docs/03-vtc/feature-flags.md
+++ b/docs/03-vtc/feature-flags.md
@@ -16,6 +16,7 @@ side.
 | `aws-secrets` | – | AWS Secrets Manager secret backend | `aws-sdk-secretsmanager`, `aws-config` |
 | `gcp-secrets` | – | GCP Secret Manager secret backend | `google-cloud-secretmanager-v1`, `google-cloud-auth`, `bytes` |
 | `azure-secrets` | – | Azure Key Vault secret backend | `azure_security_keyvault_secrets`, `azure_identity` |
+| `k8s-secrets` | – | Kubernetes `Secret` secret backend (in-cluster SA or kubeconfig) | `kube`, `k8s-openapi` |
 
 ## Deployment profiles
 
@@ -44,6 +45,20 @@ Use a cloud secret manager instead of the OS keyring. See the
 [VTA secret backends doc](../02-vta/secret-backends.md) for the
 backend selection logic — it applies identically to the VTC.
 
+### In-cluster Kubernetes `Secret`
+
+`cargo build --release --package vtc-service --features k8s-secrets`
+
+Store the VTC key bundle in a native Kubernetes `Secret` instead of
+a cloud secret manager — no extra infrastructure beyond a `Secret` +
+RBAC. Configured via the `[secrets]` `k8s_secret_name` /
+`k8s_namespace` / `k8s_secret_key` keys (or the matching
+`VTC_SECRETS_K8S_*` env vars). The mechanics mirror the VTA's
+Kubernetes backend — see the
+[VTA secret backends doc](../02-vta/secret-backends.md#kubernetes-secret)
+(substitute `VTC_` for `VTA_` env-var prefixes and `secret` for the
+default data key).
+
 ## Dependency graph
 
 ```mermaid
@@ -62,11 +77,13 @@ graph TB
     aws --> awsconfig[aws-config]
     gcp[gcp-secrets] --> gcpsm[google-cloud-secretmanager-v1]
     azure[azure-secrets] --> azurekv[azure_security_keyvault_secrets]
+    k8s[k8s-secrets] --> kube
+    k8s --> k8sopenapi[k8s-openapi]
 
     classDef on fill:#e8f5e9,stroke:#3e8e41,color:#1b3a1f
     classDef off fill:#fff3e0,stroke:#c77a00,color:#5a3b00
     class setup,keyring,website,adminui on
-    class aws,gcp,azure,config-secret off
+    class aws,gcp,azure,k8s,config-secret off
 ```
 
 Default-on features are green; opt-in features are amber.

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -40,6 +40,10 @@ gcp-secrets = [
 ]
 azure-secrets = ["dep:azure_security_keyvault_secrets", "dep:azure_identity"]
 vault-secrets = ["dep:vaultrs"]
+# Kubernetes Secret backend — stores the master seed in a namespaced
+# `Secret` resource. Off by default; deliberately enabled for in-cluster
+# deployments that prefer native k8s Secrets over a cloud secret manager.
+k8s-secrets = ["dep:kube", "dep:k8s-openapi"]
 tee = [
   "webvh",
   "dep:libc",
@@ -181,6 +185,11 @@ azure_identity = { workspace = true, optional = true }
 # Kubernetes / token / AppRole auth methods we expose. `rustls` is
 # vaultrs's default TLS backend, matching the rest of the workspace.
 vaultrs = { version = "0.8", optional = true }
+# Kubernetes secret-store backend (k8s-secrets feature). Reads/writes the
+# master seed from a namespaced `Secret` via the in-cluster ServiceAccount or
+# a local kubeconfig (`Client::try_default`).
+kube = { workspace = true, optional = true }
+k8s-openapi = { workspace = true, optional = true }
 sha2 = { workspace = true }
 # Constant-time byte equality. Used by `backup_bundle_store` to
 # verify backup-bundle bearer tokens against their stored

--- a/vta-service/src/config.rs
+++ b/vta-service/src/config.rs
@@ -130,6 +130,18 @@ pub struct SecretsConfig {
     /// (vault-secrets feature).
     #[serde(default)]
     pub vault_skip_verify: bool,
+    /// Kubernetes `Secret` name holding the hex-encoded seed
+    /// (k8s-secrets feature). Setting this activates the Kubernetes
+    /// backend.
+    pub k8s_secret_name: Option<String>,
+    /// Kubernetes namespace the `Secret` lives in (k8s-secrets feature).
+    /// When unset, the in-cluster ServiceAccount namespace (or the
+    /// kubeconfig context namespace) is used, falling back to `default`.
+    pub k8s_namespace: Option<String>,
+    /// Key within the `Secret`'s `data` map that holds the hex-encoded
+    /// seed (k8s-secrets feature). Default `seed`.
+    #[serde(default = "default_k8s_secret_key")]
+    pub k8s_secret_key: String,
     /// Opt in to the **plaintext file** seed-store fallback. Off by
     /// default: when no secure backend (keyring / cloud / Vault /
     /// config-seed) is compiled-in *and* configured, `create_seed_store`
@@ -165,6 +177,10 @@ fn default_vault_k8s_jwt_path() -> String {
     "/var/run/secrets/kubernetes.io/serviceaccount/token".to_string()
 }
 
+fn default_k8s_secret_key() -> String {
+    "seed".to_string()
+}
+
 fn default_vault_approle_mount() -> String {
     "approle".to_string()
 }
@@ -194,6 +210,9 @@ impl Default for SecretsConfig {
             vault_approle_secret_id: None,
             vault_approle_mount: default_vault_approle_mount(),
             vault_skip_verify: false,
+            k8s_secret_name: None,
+            k8s_namespace: None,
+            k8s_secret_key: default_k8s_secret_key(),
             allow_plaintext: false,
         }
     }
@@ -592,6 +611,9 @@ impl AppConfig {
                 "VTA_SECRETS_AZURE_VAULT_URL",
                 "VTA_SECRETS_AZURE_SECRET_NAME",
                 "VTA_SECRETS_KEYRING_SERVICE",
+                "VTA_SECRETS_K8S_SECRET_NAME",
+                "VTA_SECRETS_K8S_NAMESPACE",
+                "VTA_SECRETS_K8S_SECRET_KEY",
                 "VTA_AUTH_ACCESS_EXPIRY",
                 "VTA_AUTH_REFRESH_EXPIRY",
                 "VTA_AUTH_CHALLENGE_TTL",
@@ -763,6 +785,19 @@ impl AppConfig {
         {
             config.secrets.vault_skip_verify =
                 matches!(skip.to_ascii_lowercase().as_str(), "1" | "true" | "yes");
+        }
+
+        // Kubernetes Secret backend. K8s deployments commonly inject the
+        // namespace from the pod's own metadata via the Downward API, so an
+        // env override is the natural way to set it.
+        if let Ok(name) = std::env::var("VTA_SECRETS_K8S_SECRET_NAME") {
+            config.secrets.k8s_secret_name = Some(name);
+        }
+        if let Ok(ns) = std::env::var("VTA_SECRETS_K8S_NAMESPACE") {
+            config.secrets.k8s_namespace = Some(ns);
+        }
+        if let Ok(key) = std::env::var("VTA_SECRETS_K8S_SECRET_KEY") {
+            config.secrets.k8s_secret_key = key;
         }
 
         // Auth

--- a/vta-service/src/keys/seed_store/k8s.rs
+++ b/vta-service/src/keys/seed_store/k8s.rs
@@ -1,0 +1,168 @@
+use std::collections::BTreeMap;
+use std::future::Future;
+use std::pin::Pin;
+
+use k8s_openapi::ByteString;
+use k8s_openapi::api::core::v1::Secret;
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+use kube::api::{Api, PostParams};
+use kube::{Client, ResourceExt};
+use tracing::debug;
+
+use crate::config::SecretsConfig;
+use crate::error::AppError;
+
+/// Format a `kube` error with its full source chain for troubleshooting —
+/// the top-level `Display` is usually a terse "ApiError"/"HyperError" that
+/// hides the actual cause (RBAC denial, DNS, TLS, …).
+fn format_kube_error(context: &str, err: kube::Error) -> AppError {
+    let mut msg = format!("{context}: {err}");
+    let mut source = std::error::Error::source(&err);
+    while let Some(cause) = source {
+        msg.push_str(&format!("\n  caused by: {cause}"));
+        source = cause.source();
+    }
+    AppError::SecretStore(msg)
+}
+
+/// Seed store backed by a Kubernetes `Secret`.
+///
+/// The seed is stored as a hex-encoded string under `secret_key` inside a
+/// namespaced `Secret` resource. Authentication is resolved by
+/// [`Client::try_default`]: the in-cluster ServiceAccount when running inside
+/// a pod, or the local kubeconfig (`~/.kube/config` / `$KUBECONFIG`) otherwise.
+///
+/// `namespace` is resolved at call time: the explicit config value if set,
+/// otherwise the client's default namespace (the ServiceAccount's namespace
+/// in-cluster, or the kubeconfig context's namespace), falling back to
+/// `"default"` — all handled by `Client::default_namespace`.
+pub struct K8sSeedStore {
+    secret_name: String,
+    namespace: Option<String>,
+    secret_key: String,
+}
+
+impl K8sSeedStore {
+    pub fn new(secret_name: String, namespace: Option<String>, secret_key: String) -> Self {
+        Self {
+            secret_name,
+            namespace,
+            secret_key,
+        }
+    }
+
+    /// Build a namespaced `Secret` API handle, resolving the namespace and
+    /// loading credentials from the in-cluster SA or local kubeconfig.
+    async fn api(&self) -> Result<Api<Secret>, AppError> {
+        let client = Client::try_default()
+            .await
+            .map_err(|e| format_kube_error("failed to initialise Kubernetes client", e))?;
+        let namespace = self
+            .namespace
+            .clone()
+            .unwrap_or_else(|| client.default_namespace().to_string());
+        Ok(Api::namespaced(client, &namespace))
+    }
+}
+
+/// Build the `k8s-secrets` backend from config. `k8s_secret_name` activates
+/// the backend (checked by the caller); the namespace + data key fall back to
+/// sensible defaults when unset.
+pub fn from_config(secrets: &SecretsConfig) -> Result<K8sSeedStore, AppError> {
+    let secret_name = secrets.k8s_secret_name.clone().ok_or_else(|| {
+        AppError::Config("secrets.k8s_secret_name is required for the Kubernetes backend".into())
+    })?;
+    Ok(K8sSeedStore::new(
+        secret_name,
+        secrets.k8s_namespace.clone(),
+        secrets.k8s_secret_key.clone(),
+    ))
+}
+
+impl super::SeedStore for K8sSeedStore {
+    fn get(&self) -> Pin<Box<dyn Future<Output = Result<Option<Vec<u8>>, AppError>> + Send + '_>> {
+        Box::pin(async {
+            let api = self.api().await?;
+            // `get_opt` maps a 404 to `Ok(None)` for us — a missing Secret is
+            // the legitimate first-boot case, not an error.
+            let secret = api
+                .get_opt(&self.secret_name)
+                .await
+                .map_err(|e| format_kube_error("failed to read Kubernetes Secret", e))?;
+
+            let Some(secret) = secret else {
+                debug!(secret = %self.secret_name, "Kubernetes Secret not found");
+                return Ok(None);
+            };
+
+            let data = secret.data.unwrap_or_default();
+            let Some(ByteString(raw)) = data.get(&self.secret_key) else {
+                // The Secret exists but lacks our key. Returning `None` here
+                // would make the caller think it is first-boot and mint a
+                // *new* seed, then overwrite — clobbering whatever the Secret
+                // actually holds. Fail loudly instead.
+                return Err(AppError::SecretStore(format!(
+                    "Kubernetes Secret '{}' exists but has no '{}' key",
+                    self.secret_name, self.secret_key
+                )));
+            };
+
+            let hex_seed = std::str::from_utf8(raw).map_err(|e| {
+                AppError::SecretStore(format!("Kubernetes Secret value is not valid UTF-8: {e}"))
+            })?;
+            let bytes = hex::decode(hex_seed.trim()).map_err(|e| {
+                AppError::SecretStore(format!("failed to decode hex seed from Kubernetes: {e}"))
+            })?;
+            debug!(secret = %self.secret_name, "seed loaded from Kubernetes Secret");
+            Ok(Some(bytes))
+        })
+    }
+
+    fn set(&self, seed: &[u8]) -> Pin<Box<dyn Future<Output = Result<(), AppError>> + Send + '_>> {
+        let hex_seed = hex::encode(seed);
+        Box::pin(async move {
+            let api = self.api().await?;
+
+            match api
+                .get_opt(&self.secret_name)
+                .await
+                .map_err(|e| format_kube_error("failed to read Kubernetes Secret", e))?
+            {
+                Some(mut existing) => {
+                    // Preserve any other keys on the Secret (and its
+                    // resourceVersion, for optimistic concurrency); only
+                    // touch our own data key. `string_data` is write-only and
+                    // never round-trips on GET, so clear it before replacing.
+                    let mut data = existing.data.take().unwrap_or_default();
+                    data.insert(self.secret_key.clone(), ByteString(hex_seed.into_bytes()));
+                    existing.data = Some(data);
+                    existing.string_data = None;
+                    api.replace(&self.secret_name, &PostParams::default(), &existing)
+                        .await
+                        .map_err(|e| format_kube_error("failed to update Kubernetes Secret", e))?;
+                    debug!(secret = %self.secret_name, "seed stored in existing Kubernetes Secret");
+                    Ok(())
+                }
+                None => {
+                    let mut data = BTreeMap::new();
+                    data.insert(self.secret_key.clone(), ByteString(hex_seed.into_bytes()));
+                    let secret = Secret {
+                        metadata: ObjectMeta {
+                            name: Some(self.secret_name.clone()),
+                            ..Default::default()
+                        },
+                        data: Some(data),
+                        type_: Some("Opaque".to_string()),
+                        ..Default::default()
+                    };
+                    let created = api
+                        .create(&PostParams::default(), &secret)
+                        .await
+                        .map_err(|e| format_kube_error("failed to create Kubernetes Secret", e))?;
+                    debug!(secret = %created.name_any(), "seed created in Kubernetes Secret");
+                    Ok(())
+                }
+            }
+        })
+    }
+}

--- a/vta-service/src/keys/seed_store/mod.rs
+++ b/vta-service/src/keys/seed_store/mod.rs
@@ -6,6 +6,8 @@ mod azure;
 mod config;
 #[cfg(feature = "gcp-secrets")]
 mod gcp;
+#[cfg(feature = "k8s-secrets")]
+mod k8s;
 #[cfg(feature = "keyring")]
 mod keyring;
 #[cfg(feature = "tee")]
@@ -22,6 +24,8 @@ pub use azure::AzureSeedStore;
 pub use config::ConfigSeedStore;
 #[cfg(feature = "gcp-secrets")]
 pub use gcp::GcpSeedStore;
+#[cfg(feature = "k8s-secrets")]
+pub use k8s::{K8sSeedStore, from_config as k8s_from_config};
 #[cfg(feature = "keyring")]
 pub use keyring::KeyringSeedStore;
 #[cfg(feature = "tee")]
@@ -53,9 +57,10 @@ pub(crate) type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 /// 2. GCP Secret Manager (if `gcp-secrets` compiled + `secrets.gcp_secret_name` set)
 /// 3. Azure Key Vault (if `azure-secrets` compiled + `secrets.azure_vault_url` set)
 /// 4. HashiCorp Vault (if `vault-secrets` compiled + `secrets.vault_addr` set)
-/// 5. Config file seed (if `config-seed` compiled + `secrets.seed` set)
-/// 6. OS keyring (if `keyring` compiled — the default)
-/// 7. Plaintext file (always available — NOT secure)
+/// 5. Kubernetes Secret (if `k8s-secrets` compiled + `secrets.k8s_secret_name` set)
+/// 6. Config file seed (if `config-seed` compiled + `secrets.seed` set)
+/// 7. OS keyring (if `keyring` compiled — the default)
+/// 8. Plaintext file (always available — NOT secure)
 ///
 /// `unused_variables` allowed: `config` is only read under specific
 /// feature flags; a build with none of the cloud/keyring/config-seed
@@ -99,6 +104,12 @@ pub fn create_seed_store(config: &AppConfig) -> Result<Box<dyn SeedStore>, AppEr
     #[cfg(feature = "vault-secrets")]
     if config.secrets.vault_addr.is_some() {
         let store = vault::from_config(&config.secrets)?;
+        return Ok(Box::new(store));
+    }
+
+    #[cfg(feature = "k8s-secrets")]
+    if config.secrets.k8s_secret_name.is_some() {
+        let store = k8s::from_config(&config.secrets)?;
         return Ok(Box::new(store));
     }
 

--- a/vta-service/src/setup/from_toml.rs
+++ b/vta-service/src/setup/from_toml.rs
@@ -250,6 +250,23 @@ pub enum SecretsBackendInput {
         #[serde(default)]
         skip_verify: bool,
     },
+    /// Kubernetes `Secret`. The seed is stored hex-encoded under
+    /// `secret_key` (default `seed`) in a namespaced `Secret`.
+    /// Credentials come from the in-cluster ServiceAccount or a local
+    /// kubeconfig. Compiled in only when the `k8s-secrets` feature is
+    /// enabled.
+    Kubernetes {
+        /// Name of the `Secret` resource.
+        secret_name: String,
+        /// Namespace the `Secret` lives in. When omitted, the
+        /// in-cluster ServiceAccount namespace (or kubeconfig context
+        /// namespace) is used, falling back to `default`.
+        #[serde(default)]
+        namespace: Option<String>,
+        /// Key within the `Secret`'s `data` map. Defaults to `seed`.
+        #[serde(default = "default_k8s_secret_key")]
+        secret_key: String,
+    },
     /// Plaintext file under `data_dir`. **Not recommended** — for dev only.
     Plaintext,
 }
@@ -276,6 +293,10 @@ pub(crate) fn default_vault_k8s_mount() -> String {
 
 pub(crate) fn default_vault_k8s_jwt_path() -> String {
     "/var/run/secrets/kubernetes.io/serviceaccount/token".into()
+}
+
+pub(crate) fn default_k8s_secret_key() -> String {
+    "seed".into()
 }
 
 pub(crate) fn default_vault_approle_mount() -> String {
@@ -1109,6 +1130,29 @@ fn secrets_config_from_input(
                     vault_approle_secret_id: approle_secret_id.clone(),
                     vault_approle_mount: approle_mount.clone(),
                     vault_skip_verify: *skip_verify,
+                    ..SecretsConfig::default()
+                }
+            }
+        }
+        SecretsBackendInput::Kubernetes {
+            secret_name,
+            namespace,
+            secret_key,
+        } => {
+            #[cfg(not(feature = "k8s-secrets"))]
+            {
+                let _ = (secret_name, namespace, secret_key);
+                return Err(
+                    "kubernetes backend requested but vta-service was built without the `k8s-secrets` feature"
+                        .into(),
+                );
+            }
+            #[cfg(feature = "k8s-secrets")]
+            {
+                SecretsConfig {
+                    k8s_secret_name: Some(secret_name.clone()),
+                    k8s_namespace: namespace.clone(),
+                    k8s_secret_key: secret_key.clone(),
                     ..SecretsConfig::default()
                 }
             }

--- a/vta-service/src/setup/interactive.rs
+++ b/vta-service/src/setup/interactive.rs
@@ -225,6 +225,11 @@ async fn configure_secrets(p: &dyn Prompter) -> Result<SecretsBackendInput, DynE
         labels.push("HashiCorp Vault");
         tags.push("vault");
     }
+    #[cfg(feature = "k8s-secrets")]
+    {
+        labels.push("Kubernetes Secret");
+        tags.push("k8s");
+    }
     #[cfg(feature = "config-seed")]
     {
         labels.push("Config file (hex-encoded seed in config.toml)");
@@ -261,6 +266,10 @@ async fn configure_secrets(p: &dyn Prompter) -> Result<SecretsBackendInput, DynE
     #[cfg(feature = "vault-secrets")]
     if tag == "vault" {
         return prompt_vault_secrets(p);
+    }
+    #[cfg(feature = "k8s-secrets")]
+    if tag == "k8s" {
+        return prompt_k8s_secrets(p);
     }
     #[cfg(feature = "config-seed")]
     if tag == "config" {
@@ -529,6 +538,48 @@ fn prompt_vault_secrets(p: &dyn Prompter) -> Result<SecretsBackendInput, DynErr>
         approle_secret_id,
         approle_mount: default_vault_approle_mount(),
         skip_verify: false,
+    })
+}
+
+/// Prompt for Kubernetes Secret backend settings. Synchronous — the actual
+/// cluster connection happens at first seed-store call.
+#[cfg(feature = "k8s-secrets")]
+fn prompt_k8s_secrets(p: &dyn Prompter) -> Result<SecretsBackendInput, DynErr> {
+    use super::from_toml::default_k8s_secret_key;
+
+    let secret_name = p.text(
+        "Kubernetes Secret name",
+        Some("vta-master-seed"),
+        false,
+        None,
+    )?;
+    let namespace = p.text(
+        "Namespace (leave empty to use the pod's ServiceAccount namespace)",
+        None,
+        true,
+        None,
+    )?;
+    let namespace = if namespace.is_empty() {
+        None
+    } else {
+        Some(namespace)
+    };
+    let secret_key = p.text(
+        "Key within the Secret's data map holding the hex seed",
+        Some("seed"),
+        false,
+        None,
+    )?;
+    let secret_key = if secret_key.is_empty() {
+        default_k8s_secret_key()
+    } else {
+        secret_key
+    };
+
+    Ok(SecretsBackendInput::Kubernetes {
+        secret_name,
+        namespace,
+        secret_key,
     })
 }
 

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -73,6 +73,10 @@ azure-secrets = [
   # can consume it.
   "dep:futures-util",
 ]
+# Kubernetes Secret backend — stores the VTC key bundle in a namespaced
+# `Secret` resource. Off by default; for in-cluster deployments that prefer
+# native k8s Secrets over a cloud secret manager.
+k8s-secrets = ["dep:kube", "dep:k8s-openapi"]
 
 [[bin]]
 name = "vtc"
@@ -199,6 +203,11 @@ dialoguer = { workspace = true, optional = true }
 azure_security_keyvault_secrets = { workspace = true, optional = true }
 azure_identity = { workspace = true, optional = true }
 futures-util = { version = "0.3", optional = true }
+# Kubernetes secret-store backend (k8s-secrets feature). Reads/writes the VTC
+# key bundle from a namespaced `Secret` via the in-cluster ServiceAccount or a
+# local kubeconfig (`Client::try_default`).
+kube = { workspace = true, optional = true }
+k8s-openapi = { workspace = true, optional = true }
 sha2 = { workspace = true }
 hkdf = { workspace = true }
 x25519-dalek = { workspace = true }

--- a/vtc-service/src/config.rs
+++ b/vtc-service/src/config.rs
@@ -450,10 +450,26 @@ pub struct SecretsConfig {
     /// Change this to run multiple VTC instances on the same machine.
     #[serde(default = "default_keyring_service")]
     pub keyring_service: String,
+    /// Kubernetes `Secret` name holding the hex-encoded VTC key material
+    /// (k8s-secrets feature). Setting this activates the Kubernetes
+    /// backend.
+    pub k8s_secret_name: Option<String>,
+    /// Kubernetes namespace the `Secret` lives in (k8s-secrets feature).
+    /// When unset, the in-cluster ServiceAccount namespace (or the
+    /// kubeconfig context namespace) is used, falling back to `default`.
+    pub k8s_namespace: Option<String>,
+    /// Key within the `Secret`'s `data` map that holds the hex-encoded
+    /// key material (k8s-secrets feature). Default `secret`.
+    #[serde(default = "default_k8s_secret_key")]
+    pub k8s_secret_key: String,
 }
 
 fn default_keyring_service() -> String {
     "vtc".to_string()
+}
+
+fn default_k8s_secret_key() -> String {
+    "secret".to_string()
 }
 
 // Manual Debug — `secret` is the hex-encoded VTC key material; leaking
@@ -472,6 +488,9 @@ impl std::fmt::Debug for SecretsConfig {
             .field("azure_vault_url", &self.azure_vault_url)
             .field("azure_secret_name", &self.azure_secret_name)
             .field("keyring_service", &self.keyring_service)
+            .field("k8s_secret_name", &self.k8s_secret_name)
+            .field("k8s_namespace", &self.k8s_namespace)
+            .field("k8s_secret_key", &self.k8s_secret_key)
             .finish()
     }
 }
@@ -487,6 +506,9 @@ impl Default for SecretsConfig {
             azure_vault_url: None,
             azure_secret_name: None,
             keyring_service: default_keyring_service(),
+            k8s_secret_name: None,
+            k8s_namespace: None,
+            k8s_secret_key: default_k8s_secret_key(),
         }
     }
 }
@@ -801,6 +823,18 @@ impl AppConfig {
         }
         if let Ok(service) = std::env::var("VTC_SECRETS_KEYRING_SERVICE") {
             config.secrets.keyring_service = service;
+        }
+        // Kubernetes Secret backend. The namespace is commonly injected from
+        // the pod's own metadata via the Downward API, so an env override is
+        // the natural way to set it.
+        if let Ok(name) = std::env::var("VTC_SECRETS_K8S_SECRET_NAME") {
+            config.secrets.k8s_secret_name = Some(name);
+        }
+        if let Ok(ns) = std::env::var("VTC_SECRETS_K8S_NAMESPACE") {
+            config.secrets.k8s_namespace = Some(ns);
+        }
+        if let Ok(key) = std::env::var("VTC_SECRETS_K8S_SECRET_KEY") {
+            config.secrets.k8s_secret_key = key;
         }
 
         // Auth env var overrides

--- a/vtc-service/src/keys/seed_store/k8s.rs
+++ b/vtc-service/src/keys/seed_store/k8s.rs
@@ -1,0 +1,170 @@
+use std::collections::BTreeMap;
+use std::future::Future;
+use std::pin::Pin;
+
+use k8s_openapi::ByteString;
+use k8s_openapi::api::core::v1::Secret;
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+use kube::api::{Api, PostParams};
+use kube::{Client, ResourceExt};
+use tracing::debug;
+
+use crate::config::SecretsConfig;
+use crate::error::AppError;
+
+/// Format a `kube` error with its full source chain for troubleshooting —
+/// the top-level `Display` is usually a terse "ApiError"/"HyperError" that
+/// hides the actual cause (RBAC denial, DNS, TLS, …).
+fn format_kube_error(context: &str, err: kube::Error) -> AppError {
+    let mut msg = format!("{context}: {err}");
+    let mut source = std::error::Error::source(&err);
+    while let Some(cause) = source {
+        msg.push_str(&format!("\n  caused by: {cause}"));
+        source = cause.source();
+    }
+    AppError::SecretStore(msg)
+}
+
+/// Secret store backed by a Kubernetes `Secret`.
+///
+/// The VTC key material is stored as a hex-encoded string under `secret_key`
+/// inside a namespaced `Secret` resource. Authentication is resolved by
+/// [`Client::try_default`]: the in-cluster ServiceAccount when running inside
+/// a pod, or the local kubeconfig (`~/.kube/config` / `$KUBECONFIG`) otherwise.
+///
+/// `namespace` is resolved at call time: the explicit config value if set,
+/// otherwise the client's default namespace (the ServiceAccount's namespace
+/// in-cluster, or the kubeconfig context's namespace), falling back to
+/// `"default"` — all handled by `Client::default_namespace`.
+pub struct K8sSecretStore {
+    secret_name: String,
+    namespace: Option<String>,
+    secret_key: String,
+}
+
+impl K8sSecretStore {
+    pub fn new(secret_name: String, namespace: Option<String>, secret_key: String) -> Self {
+        Self {
+            secret_name,
+            namespace,
+            secret_key,
+        }
+    }
+
+    /// Build a namespaced `Secret` API handle, resolving the namespace and
+    /// loading credentials from the in-cluster SA or local kubeconfig.
+    async fn api(&self) -> Result<Api<Secret>, AppError> {
+        let client = Client::try_default()
+            .await
+            .map_err(|e| format_kube_error("failed to initialise Kubernetes client", e))?;
+        let namespace = self
+            .namespace
+            .clone()
+            .unwrap_or_else(|| client.default_namespace().to_string());
+        Ok(Api::namespaced(client, &namespace))
+    }
+}
+
+/// Build the `k8s-secrets` backend from config. `k8s_secret_name` activates
+/// the backend (checked by the caller); the namespace + data key fall back to
+/// sensible defaults when unset.
+pub fn from_config(secrets: &SecretsConfig) -> Result<K8sSecretStore, AppError> {
+    let secret_name = secrets.k8s_secret_name.clone().ok_or_else(|| {
+        AppError::Config("secrets.k8s_secret_name is required for the Kubernetes backend".into())
+    })?;
+    Ok(K8sSecretStore::new(
+        secret_name,
+        secrets.k8s_namespace.clone(),
+        secrets.k8s_secret_key.clone(),
+    ))
+}
+
+impl super::SecretStore for K8sSecretStore {
+    fn get(&self) -> Pin<Box<dyn Future<Output = Result<Option<Vec<u8>>, AppError>> + Send + '_>> {
+        Box::pin(async {
+            let api = self.api().await?;
+            // `get_opt` maps a 404 to `Ok(None)` for us — a missing Secret is
+            // the legitimate first-boot case, not an error.
+            let secret = api
+                .get_opt(&self.secret_name)
+                .await
+                .map_err(|e| format_kube_error("failed to read Kubernetes Secret", e))?;
+
+            let Some(secret) = secret else {
+                debug!(secret = %self.secret_name, "Kubernetes Secret not found");
+                return Ok(None);
+            };
+
+            let data = secret.data.unwrap_or_default();
+            let Some(ByteString(raw)) = data.get(&self.secret_key) else {
+                // The Secret exists but lacks our key. Returning `None` here
+                // would make the caller think it is first-boot and re-bootstrap
+                // the VTC identity, clobbering whatever the Secret holds. Fail
+                // loudly instead.
+                return Err(AppError::SecretStore(format!(
+                    "Kubernetes Secret '{}' exists but has no '{}' key",
+                    self.secret_name, self.secret_key
+                )));
+            };
+
+            let hex_val = std::str::from_utf8(raw).map_err(|e| {
+                AppError::SecretStore(format!("Kubernetes Secret value is not valid UTF-8: {e}"))
+            })?;
+            let bytes = hex::decode(hex_val.trim()).map_err(|e| {
+                AppError::SecretStore(format!(
+                    "failed to decode hex key material from Kubernetes: {e}"
+                ))
+            })?;
+            debug!(secret = %self.secret_name, "VTC key material loaded from Kubernetes Secret");
+            Ok(Some(bytes))
+        })
+    }
+
+    fn set(&self, value: &[u8]) -> Pin<Box<dyn Future<Output = Result<(), AppError>> + Send + '_>> {
+        let hex_val = hex::encode(value);
+        Box::pin(async move {
+            let api = self.api().await?;
+
+            match api
+                .get_opt(&self.secret_name)
+                .await
+                .map_err(|e| format_kube_error("failed to read Kubernetes Secret", e))?
+            {
+                Some(mut existing) => {
+                    // Preserve any other keys on the Secret (and its
+                    // resourceVersion, for optimistic concurrency); only touch
+                    // our own data key. `string_data` is write-only and never
+                    // round-trips on GET, so clear it before replacing.
+                    let mut data = existing.data.take().unwrap_or_default();
+                    data.insert(self.secret_key.clone(), ByteString(hex_val.into_bytes()));
+                    existing.data = Some(data);
+                    existing.string_data = None;
+                    api.replace(&self.secret_name, &PostParams::default(), &existing)
+                        .await
+                        .map_err(|e| format_kube_error("failed to update Kubernetes Secret", e))?;
+                    debug!(secret = %self.secret_name, "VTC key material stored in existing Kubernetes Secret");
+                    Ok(())
+                }
+                None => {
+                    let mut data = BTreeMap::new();
+                    data.insert(self.secret_key.clone(), ByteString(hex_val.into_bytes()));
+                    let secret = Secret {
+                        metadata: ObjectMeta {
+                            name: Some(self.secret_name.clone()),
+                            ..Default::default()
+                        },
+                        data: Some(data),
+                        type_: Some("Opaque".to_string()),
+                        ..Default::default()
+                    };
+                    let created = api
+                        .create(&PostParams::default(), &secret)
+                        .await
+                        .map_err(|e| format_kube_error("failed to create Kubernetes Secret", e))?;
+                    debug!(secret = %created.name_any(), "VTC key material created in Kubernetes Secret");
+                    Ok(())
+                }
+            }
+        })
+    }
+}

--- a/vtc-service/src/keys/seed_store/mod.rs
+++ b/vtc-service/src/keys/seed_store/mod.rs
@@ -6,6 +6,8 @@ mod azure;
 mod config;
 #[cfg(feature = "gcp-secrets")]
 mod gcp;
+#[cfg(feature = "k8s-secrets")]
+mod k8s;
 #[cfg(feature = "keyring")]
 mod keyring;
 mod plaintext;
@@ -18,6 +20,8 @@ pub use azure::AzureSecretStore;
 pub use config::ConfigSecretStore;
 #[cfg(feature = "gcp-secrets")]
 pub use gcp::GcpSecretStore;
+#[cfg(feature = "k8s-secrets")]
+pub use k8s::{K8sSecretStore, from_config as k8s_from_config};
 #[cfg(feature = "keyring")]
 pub use keyring::KeyringSecretStore;
 pub use plaintext::PlaintextSecretStore;
@@ -35,9 +39,10 @@ pub use vti_common::seed_store::SeedStore as SecretStore;
 /// 1. AWS Secrets Manager (if `aws-secrets` compiled + `secrets.aws_secret_name` set)
 /// 2. GCP Secret Manager (if `gcp-secrets` compiled + `secrets.gcp_secret_name` set)
 /// 3. Azure Key Vault (if `azure-secrets` compiled + `secrets.azure_vault_url` set)
-/// 4. Config file secret (if `config-secret` compiled + `secrets.secret` set)
-/// 5. OS keyring (if `keyring` compiled — the default)
-/// 6. Plaintext file (always available — NOT secure)
+/// 4. Kubernetes Secret (if `k8s-secrets` compiled + `secrets.k8s_secret_name` set)
+/// 5. Config file secret (if `config-secret` compiled + `secrets.secret` set)
+/// 6. OS keyring (if `keyring` compiled — the default)
+/// 7. Plaintext file (always available — NOT secure)
 #[allow(unused_variables)]
 pub fn create_secret_store(config: &AppConfig) -> Result<Box<dyn SecretStore>, AppError> {
     // For every cloud/config backend, a set selector field on a binary that
@@ -98,6 +103,20 @@ pub fn create_secret_store(config: &AppConfig) -> Result<Box<dyn SecretStore>, A
         return Err(AppError::Config(
             "secrets.azure_vault_url is set but this binary was built without the \
              'azure-secrets' feature"
+                .into(),
+        ));
+    }
+
+    #[cfg(feature = "k8s-secrets")]
+    if config.secrets.k8s_secret_name.is_some() {
+        let store = k8s::from_config(&config.secrets)?;
+        return Ok(Box::new(store));
+    }
+    #[cfg(not(feature = "k8s-secrets"))]
+    if config.secrets.k8s_secret_name.is_some() {
+        return Err(AppError::Config(
+            "secrets.k8s_secret_name is set but this binary was built without the \
+             'k8s-secrets' feature"
                 .into(),
         ));
     }
@@ -187,6 +206,13 @@ mod tests {
         let mut config = base_config();
         config.secrets.secret = Some("ab".repeat(32));
         assert_config_err_mentions(&config, "config-secret");
+    }
+
+    #[test]
+    fn k8s_set_without_feature_is_config_error() {
+        let mut config = base_config();
+        config.secrets.k8s_secret_name = Some("vtc-master-seed".into());
+        assert_config_err_mentions(&config, "k8s-secrets");
     }
 
     #[test]

--- a/vtc-service/src/setup/wizard.rs
+++ b/vtc-service/src/setup/wizard.rs
@@ -755,6 +755,7 @@ fn prompt_secrets_config() -> Result<SecretsConfig, AppError> {
             aws: cfg!(feature = "aws-secrets"),
             gcp: cfg!(feature = "gcp-secrets"),
             azure: cfg!(feature = "azure-secrets"),
+            k8s: cfg!(feature = "k8s-secrets"),
             inline_config: cfg!(feature = "config-secret"),
             plaintext: true,
         },
@@ -1074,6 +1075,20 @@ fn secrets_choice_to_config(choice: SecretsBackendChoice) -> SecretsConfig {
         } => {
             config.azure_vault_url = Some(vault_url);
             config.azure_secret_name = Some(secret_name);
+        }
+        SecretsBackendChoice::Kubernetes {
+            secret_name,
+            namespace,
+            secret_key,
+        } => {
+            config.k8s_secret_name = Some(secret_name);
+            config.k8s_namespace = namespace;
+            // A blank key from the prompt means "use the default" — keep the
+            // `SecretsConfig::default()` value rather than overwriting it with
+            // an empty string.
+            if !secret_key.is_empty() {
+                config.k8s_secret_key = secret_key;
+            }
         }
         SecretsBackendChoice::InlineConfig => {
             // The bundle bytes go into `secret` via the

--- a/vti-common/src/setup/secrets_prompt.rs
+++ b/vti-common/src/setup/secrets_prompt.rs
@@ -50,6 +50,15 @@ pub enum SecretsBackendChoice {
         vault_url: String,
         secret_name: String,
     },
+    /// Kubernetes `Secret`. `namespace` is `None` when the operator
+    /// wants the in-cluster ServiceAccount namespace; `secret_key` is
+    /// the key within the Secret's `data` map (the caller substitutes
+    /// its own default when the operator leaves it blank).
+    Kubernetes {
+        secret_name: String,
+        namespace: Option<String>,
+        secret_key: String,
+    },
     /// Hex-encoded seed embedded directly in `config.toml`. The
     /// wizard fills the value in after key derivation; this variant
     /// just signals the choice.
@@ -68,6 +77,7 @@ pub struct AvailableBackends {
     pub aws: bool,
     pub gcp: bool,
     pub azure: bool,
+    pub k8s: bool,
     pub inline_config: bool,
     /// Plaintext is always available as a fallback; the field is
     /// here so a service that strictly disallows it (e.g. a TEE
@@ -77,7 +87,13 @@ pub struct AvailableBackends {
 
 impl AvailableBackends {
     fn any(&self) -> bool {
-        self.keyring || self.aws || self.gcp || self.azure || self.inline_config || self.plaintext
+        self.keyring
+            || self.aws
+            || self.gcp
+            || self.azure
+            || self.k8s
+            || self.inline_config
+            || self.plaintext
     }
 }
 
@@ -147,6 +163,10 @@ pub fn configure_secrets(
         labels.push("Azure Key Vault");
         tags.push("azure");
     }
+    if available.k8s {
+        labels.push("Kubernetes Secret");
+        tags.push("k8s");
+    }
     if available.inline_config {
         labels.push("Config file (hex-encoded seed in config.toml)");
         tags.push("inline-config");
@@ -193,6 +213,7 @@ pub fn configure_secrets(
             }),
             None => prompt_azure_fallback(),
         },
+        "k8s" => prompt_k8s(),
         "inline-config" => Ok(SecretsBackendChoice::InlineConfig),
         "plaintext" => {
             print_plaintext_warning();
@@ -255,6 +276,35 @@ fn prompt_azure_fallback() -> Result<SecretsBackendChoice, SecretsPromptError> {
     Ok(SecretsBackendChoice::Azure {
         vault_url,
         secret_name,
+    })
+}
+
+/// Prompt for the Kubernetes Secret backend. No cluster calls happen here —
+/// the connection is made at first secret-store access. A blank namespace
+/// means "use the in-cluster ServiceAccount namespace"; a blank data key
+/// means "use the caller's default" (`secret_key` comes back empty and the
+/// caller substitutes its own default when materialising its config).
+fn prompt_k8s() -> Result<SecretsBackendChoice, SecretsPromptError> {
+    let secret_name: String = Input::new()
+        .with_prompt("Kubernetes Secret name")
+        .interact_text()?;
+    let namespace: String = Input::new()
+        .with_prompt("Namespace (leave empty for the pod's ServiceAccount namespace)")
+        .allow_empty(true)
+        .interact_text()?;
+    let namespace = if namespace.is_empty() {
+        None
+    } else {
+        Some(namespace)
+    };
+    let secret_key: String = Input::new()
+        .with_prompt("Key within the Secret's data map (leave empty for the default)")
+        .allow_empty(true)
+        .interact_text()?;
+    Ok(SecretsBackendChoice::Kubernetes {
+        secret_name,
+        namespace,
+        secret_key,
     })
 }
 


### PR DESCRIPTION
## What

Adds a native **Kubernetes `Secret`** secrets backend alongside the existing keyring / AWS / GCP / Azure / Vault backends, behind a new **off-by-default `k8s-secrets`** feature — on **both** `vta-service` and `vtc-service`.

For in-cluster deployments that want secret material native to Kubernetes without standing up HashiCorp Vault or reaching out to a cloud secret manager.

## How it works

- Stores the master seed (VTA) / key bundle (VTC) **hex-encoded** in a namespaced `Secret`, consistent with every other backend's encoding.
- Auth via `kube`'s `Client::try_default()`: the pod's mounted ServiceAccount token in-cluster, or local kubeconfig when running `vta`/`vtc setup` outside the cluster.
- `get()` and `set()` both implemented — `set()` is create-or-update, preserving any other keys + `resourceVersion`. A Secret that exists but lacks the configured key **fails loudly** rather than re-minting a seed and clobbering it.

## Namespace — configurable three ways (per request)

1. `k8s_namespace` config field
2. `VTA_SECRETS_K8S_NAMESPACE` / `VTC_SECRETS_K8S_NAMESPACE` env var (ideal for Downward-API injection of `metadata.namespace`)
3. Omitted → client default namespace (pod SA namespace / kubeconfig context), falling back to `default`

## Setup flows — interactive **and** headless, both services

- **VTA interactive** (`vta setup`): new "Kubernetes Secret" menu entry + prompt.
- **VTA headless** (`vta setup --from <toml>`): new `backend = "kubernetes"` variant.
- **VTC interactive** (`vtc setup`): new `Kubernetes` choice in the shared `vti-common` prompt.
- **VTC headless**: TOML `[secrets]` + `VTC_SECRETS_K8S_*` env vars (VTC has no `--from`; this is its headless path).

## Safety

- Selecting the backend on a binary built **without** the feature is a clear config error (fail-closed), with a unit test mirroring the existing P0.8 pattern.
- `kube` 3.1 + `k8s-openapi` 0.27 added with **rustls** (`default-features = false`) — no OpenSSL pulled into the tree.

## Docs

Updated `docs/02-vta/secret-backends.md` (full backend section: RBAC manifest, Vault-vs-native guidance, etcd-encryption caveat, pitfalls, migration commands), both `feature-flags.md`, and `non-interactive-setup.md`.

## Verification

- `cargo fmt --check`, `clippy`, `check` clean for both services with the feature on **and** off.
- All-backends-together build (aws+gcp+azure+vault+k8s) compiles — no `k8s-openapi` single-version conflict.
- Tests pass, including the new `k8s_set_without_feature_is_config_error`.

## Not yet verified

Runtime `get`/`set` against a **live cluster** (incl. the rustls crypto-provider init path) — the code follows standard kube-rs usage, but a smoke test against kind/minikube is the remaining step before production reliance.

> ⚠️ A bare Kubernetes `Secret` is only base64-encoded in etcd unless cluster **encryption-at-rest** is enabled — documented prominently so operators don't treat it as production-grade without it. Where Vault is available, it remains the stronger in-cluster choice; this backend is for clusters that want zero extra infra.