### PR TITLE
perf(vtc): seek the syncer tail-walk from the cursor + event_id-keyed jobs (P3.8)

### DIFF
--- a/vtc-service/src/registry/tail.rs
+++ b/vtc-service/src/registry/tail.rs
@@ -111,7 +111,20 @@ pub async fn walk(
     rtbf_batch_window_hours: u64,
     cursor: Option<DateTime<Utc>>,
 ) -> Result<WalkOutcome, AppError> {
-    let pairs = audit_ks.prefix_iter_raw(Vec::new()).await?;
+    // Seek past everything at-or-before the cursor instead of
+    // re-scanning the whole audit log every tick (P3.8). Audit keys are
+    // `<rfc3339-ts>:<event_id>`, which sort chronologically, so a
+    // `<cursor-ts>:` lower bound skips the already-processed prefix. The
+    // in-loop `timestamp <= cursor` filter below still handles the exact
+    // boundary (several events can share a timestamp). First boot
+    // (`cursor = None`) walks from the start.
+    let pairs = match cursor {
+        Some(c) => {
+            let lower = format!("{}:", c.to_rfc3339()).into_bytes();
+            audit_ks.range_from_raw(lower).await?
+        }
+        None => audit_ks.prefix_iter_raw(Vec::new()).await?,
+    };
     let mut jobs_enqueued = 0_usize;
     let mut latest_seen = cursor;
     let mut overrides: Vec<OverrideEvent> = Vec::new();
@@ -149,6 +162,13 @@ pub async fn walk(
             latest_seen = Some(envelope.timestamp);
         }
         if let Some((mut job, override_event)) = audit_to_sync_job(&envelope, floor.as_deref()) {
+            // Derive the job id from the audit `event_id` (P3.8) — one
+            // envelope maps to at most one job, so a re-walk after a
+            // mid-walk store failure (cursor didn't advance) **overwrites**
+            // the already-stored row at the same key instead of enqueuing
+            // a fresh-UUID duplicate. Idempotent: exactly one job per
+            // source envelope.
+            job.id = envelope.event_id;
             // M3.7: park RTBF DeleteMember jobs by the batch
             // window. A non-RTBF DeleteMember (admin force-
             // purge) dispatches immediately — only RTBF gets
@@ -524,6 +544,42 @@ mod tests {
         assert_eq!(third.jobs_enqueued, 1);
         let jobs = list_sync_jobs(&t.queue).await.unwrap();
         assert_eq!(jobs.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn rewalk_without_cursor_advance_overwrites_not_duplicates() {
+        // P3.8: when a mid-walk store failure leaves the cursor unmoved,
+        // the next tick re-walks the same envelopes. Job ids are derived
+        // from the audit `event_id`, so the re-walk overwrites the same
+        // rows — exactly one job per source envelope, no fresh-UUID
+        // duplicates.
+        let t = temp_keyspaces().await;
+        write_member_added(&t.writer, "did:key:zA").await;
+        write_member_added(&t.writer, "did:key:zB").await;
+
+        let first = walk(&t.audit, &t.queue, &t.policies, &t.active_policies, 0, None)
+            .await
+            .unwrap();
+        assert_eq!(first.jobs_enqueued, 2);
+        let ids1: std::collections::BTreeSet<_> = list_sync_jobs(&t.queue)
+            .await
+            .unwrap()
+            .iter()
+            .map(|j| j.id)
+            .collect();
+        assert_eq!(ids1.len(), 2);
+
+        // Re-walk from the start (cursor never advanced).
+        walk(&t.audit, &t.queue, &t.policies, &t.active_policies, 0, None)
+            .await
+            .unwrap();
+        let jobs2 = list_sync_jobs(&t.queue).await.unwrap();
+        assert_eq!(jobs2.len(), 2, "re-walk must overwrite, not duplicate");
+        let ids2: std::collections::BTreeSet<_> = jobs2.iter().map(|j| j.id).collect();
+        assert_eq!(
+            ids1, ids2,
+            "job ids are stable across re-walks (event_id-derived)"
+        );
     }
 
     #[tokio::test]

--- a/vti-common/src/store/mod.rs
+++ b/vti-common/src/store/mod.rs
@@ -338,6 +338,25 @@ impl KeyspaceHandle {
         }
     }
 
+    /// Iterate key/value pairs whose key is `>= from` (inclusive lower
+    /// bound, unbounded above), in ascending key order. Unlike
+    /// [`Self::prefix_iter_raw`] this **seeks** to `from` rather than
+    /// scanning from the start of the keyspace — used by the registry
+    /// syncer's audit-tail walk to skip already-processed history
+    /// (audit keys are `<rfc3339-ts>:<event_id>`, which sort
+    /// chronologically), so per-tick cost is proportional to new rows
+    /// rather than the whole audit log.
+    pub async fn range_from_raw(
+        &self,
+        from: impl Into<Vec<u8>>,
+    ) -> Result<Vec<RawKvPair>, AppError> {
+        match self {
+            KeyspaceHandle::Local(h) => h.range_from_raw(from).await,
+            #[cfg(feature = "vsock-store")]
+            KeyspaceHandle::Vsock(h) => h.range_from_raw(from).await,
+        }
+    }
+
     pub async fn prefix_keys(&self, prefix: impl Into<Vec<u8>>) -> Result<Vec<Vec<u8>>, AppError> {
         match self {
             KeyspaceHandle::Local(h) => h.prefix_keys(prefix).await,
@@ -630,6 +649,36 @@ impl LocalKeyspaceHandle {
         .await
     }
 
+    /// See [`KeyspaceHandle::range_from_raw`]. fjall's `range` seeks to
+    /// the lower bound, so this reads only keys `>= from`.
+    pub async fn range_from_raw(
+        &self,
+        from: impl Into<Vec<u8>>,
+    ) -> Result<Vec<RawKvPair>, AppError> {
+        let from = from.into();
+        let ks = self.keyspace.clone();
+        #[cfg(feature = "encryption")]
+        let enc_key = self.encryption_key.clone();
+        #[cfg(feature = "encryption")]
+        let name = self.name.clone();
+        blocking_with_timeout(move || {
+            let mut results = Vec::new();
+            for guard in ks.range(from..) {
+                let (key, value) = guard.into_inner()?;
+                #[cfg(feature = "encryption")]
+                let value = {
+                    let k = enc_key.as_ref().map(|arc| &***arc);
+                    encryption::maybe_decrypt_bytes(k, &name, &key, &value)?
+                };
+                #[cfg(not(feature = "encryption"))]
+                let value = value.to_vec();
+                results.push((key.to_vec(), value));
+            }
+            Ok(results)
+        })
+        .await
+    }
+
     pub async fn prefix_keys(&self, prefix: impl Into<Vec<u8>>) -> Result<Vec<Vec<u8>>, AppError> {
         let prefix = prefix.into();
         let ks = self.keyspace.clone();
@@ -881,6 +930,38 @@ mod tests {
 
         let raw = ks.prefix_iter_raw("prefix:").await.unwrap();
         assert_eq!(raw.len(), 5);
+    }
+
+    #[tokio::test]
+    async fn test_range_from_raw_seeks_to_lower_bound() {
+        let (store, _dir) = temp_store();
+        let ks = store.keyspace("test").unwrap();
+
+        // Timestamp-like keys (the audit-tail use case): lexical order
+        // == chronological order.
+        for k in ["2026-01:a", "2026-02:b", "2026-03:c", "2026-04:d"] {
+            ks.insert_raw(k.as_bytes().to_vec(), b"v".to_vec())
+                .await
+                .unwrap();
+        }
+
+        // Seek from "2026-03:" → only the rows at-or-after it.
+        let rows = ks.range_from_raw(b"2026-03:".to_vec()).await.unwrap();
+        let keys: Vec<String> = rows
+            .iter()
+            .map(|(k, _)| String::from_utf8(k.clone()).unwrap())
+            .collect();
+        assert_eq!(keys, vec!["2026-03:c", "2026-04:d"]);
+
+        // An empty lower bound returns everything (ascending).
+        assert_eq!(ks.range_from_raw(Vec::new()).await.unwrap().len(), 4);
+        // A bound past the end returns nothing.
+        assert!(
+            ks.range_from_raw(b"2026-99:".to_vec())
+                .await
+                .unwrap()
+                .is_empty()
+        );
     }
 
     #[tokio::test]

--- a/vti-common/src/store/vsock.rs
+++ b/vti-common/src/store/vsock.rs
@@ -324,6 +324,24 @@ impl VsockKeyspaceHandle {
             .collect()
     }
 
+    /// See [`crate::store::KeyspaceHandle::range_from_raw`]. The vsock
+    /// proxy protocol has no native range op, and this backend is only
+    /// used by the enclave VTA (the registry syncer that calls
+    /// `range_from_raw` is VTC-only, never on vsock), so this falls back
+    /// to a full scan filtered to `key >= from` — correct, just not
+    /// seek-optimised.
+    pub async fn range_from_raw(
+        &self,
+        from: impl Into<Vec<u8>>,
+    ) -> Result<Vec<RawKvPair>, AppError> {
+        let from = from.into();
+        let all = self.prefix_iter_raw(Vec::<u8>::new()).await?;
+        Ok(all
+            .into_iter()
+            .filter(|(k, _)| k.as_slice() >= from.as_slice())
+            .collect())
+    }
+
     pub async fn prefix_keys(&self, prefix: impl Into<Vec<u8>>) -> Result<Vec<Vec<u8>>, AppError> {
         let prefix = prefix.into();
         let mut payload = vec![OP_PREFIX_KEYS];


### PR DESCRIPTION
Phase 3 — syncer cost + idempotency.

## Problem

- **Cost:** the registry tail-walk `prefix_iter_raw`'d the **entire** `audit` keyspace every 5s tick and then filtered by timestamp, so steady-state cost grew linearly with total audit history *forever* — the daemon's dominant background cost.
- **Idempotency:** `walk()` enqueued each job with a fresh `Uuid::new_v4()`. A mid-walk store failure leaves the cursor unadvanced, so the next tick re-walks the same envelopes and enqueues **fresh-UUID duplicates**.

## Change

- **`KeyspaceHandle::range_from_raw(from)`** — seeks to a lower bound via fjall's `range()` instead of scanning from the start. (The vsock backend — enclave VTA only; the syncer is VTC-only and never runs on vsock — gets a correct prefix-scan+filter fallback.)
- **Tail-walk seeks from `<cursor-rfc3339>:`** when a cursor exists. Audit keys are `<rfc3339-ts>:<event_id>`, which sort chronologically, so the walk now reads only rows at-or-after the cursor; the in-loop `timestamp <= cursor` filter still handles the exact boundary. First boot (`cursor = None`) still walks from the start.
- **`SyncJob.id` derived from the audit `event_id`** (one envelope → one job), so a re-walk **overwrites** the same row instead of duplicating — exactly one job per source envelope.

## Accept criteria (covered by tests)

- Walk cost is proportional to new-rows-since-cursor (seek, not full scan).
- Failing the Nth store then re-walking ends with exactly one job per source envelope.

## Tests

`range_from_raw` seek / empty-bound / past-end (vti-common); tail `rewalk_without_cursor_advance_overwrites_not_duplicates` (stable event_id-derived ids); the existing `cursor_advances_so_restart_is_idempotent` now exercises the seek path. vti-common (244) + vtc-service registry (83) green; clippy/fmt clean; `vsock-store` feature compiles.