### PR TITLE
fix(vtc): DIDComm join harness maps AppError via production taxonomy (#485)

### DIFF
--- a/vtc-service/src/messaging.rs
+++ b/vtc-service/src/messaging.rs
@@ -239,7 +239,12 @@ fn problem_report_body(code: &str, comment: impl Into<String>) -> serde_json::Va
 /// does — instead of collapsing every outcome into `internal-error`,
 /// where the sender can't tell a permission failure from a real bug.
 /// Genuine infra faults keep the `internal-error` code.
-fn app_error_code(err: &AppError) -> &'static str {
+///
+/// `pub(crate)` so the DIDComm test harness (`test_support::dispatch_join`)
+/// maps handler errors through the *same* taxonomy the production responder
+/// uses — otherwise the harness (and the fuzzer driving it) would see a
+/// different, staler mapping than real callers. See #485.
+pub(crate) fn app_error_code(err: &AppError) -> &'static str {
     match err {
         AppError::Forbidden(_) | AppError::StepUpRequired(_) => codes::FORBIDDEN,
         AppError::Unauthorized(_) | AppError::Authentication(_) => codes::UNAUTHORIZED,

--- a/vtc-service/src/test_support.rs
+++ b/vtc-service/src/test_support.rs
@@ -1066,8 +1066,16 @@ mod didcomm_harness {
         sender: &str,
         msg: &Message,
     ) -> Result<Option<(String, Value)>, (String, String)> {
-        let problem =
-            |e: vti_common::error::AppError| ("e.p.msg.internal-error".to_string(), e.to_string());
+        // Map handler errors through the *same* taxonomy the production DIDComm
+        // responder uses (`messaging::app_error_code`) — a 409-style conflict
+        // (e.g. a duplicate open join request) must surface as `e.p.msg.conflict`,
+        // not collapse into the generic `internal-error` bucket. See #485.
+        let problem = |e: vti_common::error::AppError| {
+            (
+                crate::messaging::app_error_code(&e).to_string(),
+                e.to_string(),
+            )
+        };
         let bad = |e: serde_json::Error| ("e.p.msg.bad-request".to_string(), e.to_string());
 
         match msg.typ.as_str() {

--- a/vtc-service/tests/join_didcomm.rs
+++ b/vtc-service/tests/join_didcomm.rs
@@ -331,3 +331,80 @@ async fn didcomm_try_request_classifies_reject_and_keeps_going() {
 
     mock.shutdown().await;
 }
+
+/// Regression for #485 (cross-service join-ceremony fuzzer finding): a *duplicate*
+/// submit — same applicant DID resubmits while their first request is still open —
+/// is a normal 409-Conflict business-rule rejection, so the threaded DIDComm
+/// problem-report must carry the `conflict` code, **not** the generic
+/// `internal-error` bucket. `internal-error` would mislead clients into treating
+/// an expected condition as a server fault (and the fuzzer flags any
+/// `internal-error`-coded problem-report as a soft finding). The dedup guard in
+/// `submit_inner` returns `AppError::Conflict`; this pins that it surfaces as
+/// `e.p.msg.conflict` end-to-end through the real DIDComm handler.
+#[tokio::test]
+async fn didcomm_duplicate_submit_rejects_with_conflict_not_internal_error() {
+    use vta_sdk::protocols::problem_report_codes as codes;
+
+    let mock = MockVtcDidcomm::start().await;
+    let _admin_token = seed_join_ceremony(&mock).await;
+    let vtc_did = mock.vtc_did().to_string();
+    let applicant_did = mock.client.did().to_string();
+
+    let submit = JoinRequestSubmitBody {
+        vp: json!({ "type": "VerifiablePresentation", "holder": applicant_did }),
+        registry_consent: false,
+        extensions: json!({}),
+    };
+
+    // First submit → real `submit_inner`, default policy defers to pending so the
+    // request is left *open* (the precondition for the dedup guard to fire).
+    let outcome = mock
+        .client
+        .try_request(
+            &vtc_did,
+            JOIN_REQUEST_SUBMIT_TYPE,
+            serde_json::to_value(&submit).unwrap(),
+            Duration::from_secs(15),
+        )
+        .await;
+    match outcome {
+        ReplyOutcome::Reply(body) => {
+            let receipt: JoinRequestSubmitReceiptBody =
+                serde_json::from_value(body).expect("submit receipt");
+            assert_eq!(receipt.status, "pending");
+        }
+        other => panic!("expected a pending receipt for the first submit, got {other:?}"),
+    }
+
+    // Second submit from the same applicant DID before the first is decided or
+    // withdrawn → the dedup guard rejects it. It must be a *clean, classified*
+    // conflict, not a hang and not an `internal-error`.
+    let outcome = mock
+        .client
+        .try_request(
+            &vtc_did,
+            JOIN_REQUEST_SUBMIT_TYPE,
+            serde_json::to_value(&submit).unwrap(),
+            Duration::from_secs(15),
+        )
+        .await;
+    match outcome {
+        ReplyOutcome::Problem(p) => {
+            assert_eq!(
+                p.code,
+                codes::CONFLICT,
+                "duplicate open join request is a 409-style conflict, not `{}`: {p:?}",
+                codes::INTERNAL,
+            );
+            assert!(
+                p.comment.contains("already exists"),
+                "comment names the open-request conflict: {p:?}",
+            );
+        }
+        other => {
+            panic!("expected a conflict problem-report for the duplicate submit, got {other:?}")
+        }
+    }
+
+    mock.shutdown().await;
+}


### PR DESCRIPTION
Fixes #485.

## Problem

The cross-service join-ceremony fuzzer (`vt-fuzz-ceremony`) flagged that a **duplicate join submit** — same applicant resubmits while their first request is still open — comes back over DIDComm as a problem-report coded `e.p.msg.internal-error`, not a conflict/bad-request code. That misleads clients into treating an expected 409-Conflict business-rule rejection as a server fault, and muddies genuine internal errors.

## Root cause

- `submit_inner`'s dedup guard already returns the correct `AppError::Conflict` (`join/orchestrate.rs:127`).
- The **production** DIDComm responder (`messaging::join_request_submit_handler`) already maps it through the typed `app_error_code` taxonomy → `e.p.msg.conflict` (shipped in #474, P3.6; unit-tested).
- But the fuzzer drives `MockVtcDidcomm`, whose **own** dispatch loop (`test_support::dispatch_join`) had a hardcoded mapper collapsing *every* `AppError` into `e.p.msg.internal-error`. The #474 taxonomy fix never propagated to the harness, so the fuzzer saw a staler mapping than real callers do.

Verified by writing the regression test first — it reproduced the exact report from the issue (`code: e.p.msg.internal-error`, `comment: "conflict: an open join request already exists…"`) before the fix.

## Fix

- Make `messaging::app_error_code` `pub(crate)` — single source of truth for the error → problem-report taxonomy.
- `dispatch_join` reuses it instead of its hardcoded `internal-error` mapper, so the harness mirrors production exactly. A conflict now surfaces as `e.p.msg.conflict` end-to-end, and any future production regression is caught by the harness rather than masked.
- Add `didcomm_duplicate_submit_rejects_with_conflict_not_internal_error`, reproducing the fuzz scenario: submit twice, assert the second is a problem-report coded `e.p.msg.conflict`, not `internal-error`.

## Verification

- New test passes; full `join_didcomm` (3) and `join_requests` (46) suites green; `messaging::` unit tests green.
- `cargo fmt --check` clean; `cargo clippy -p vtc-service --tests` clean (only pre-existing unrelated deprecation warnings).
- Confirmed no other hardcoded `"e.p.msg.internal-error"` mappers remain in the harnesses.