### PR TITLE
fix(vtc): scope CSRF to cookie-session requests + wire it into the test harness (P3.2)

### DIFF
--- a/tasks/vtc-architecture-todo.md
+++ b/tasks/vtc-architecture-todo.md
@@ -178,7 +178,7 @@ the #457 posture backstop provides its regression guard.)
   into `routes::with_csrf` (canonical router builder) so every integration test
   exercises it — wiring it in revealed (and fixed) the previously-invisible
   401-vs-403 breakage in recognise/renewal/removal/policies/join. 15 unit + 3
-  cookie_session integration tests; full suite 968 green. — PR: ____
+  cookie_session integration tests; full suite 968 green. — PR: #490 (in review)
 - `[x]` **P3.3** (M) Website `PUT` through the full safety chain; validate before
   `create_dir_all` — `canonical_within_root_for_create` (shared
   `validate_path_components`; rejects `..`/hidden/blocklist/control/NFC + symlinked

--- a/tasks/vtc-architecture-todo.md
+++ b/tasks/vtc-architecture-todo.md
@@ -164,8 +164,21 @@ the #457 posture backstop provides its regression guard.)
   - `[x]` **part 2** force host separation when a filesystem website
     (`website.root_dir`) is configured + honest docs (correct the stale
     `Path=/admin` cookie-isolation claim) — PR: #466
-- `[ ]` **P3.2** (M) CSRF bearer exemption + tighten exempt list; wire CSRF into
-  the test harness — PR: ____
+- `[~]` **P3.2** (M) CSRF bearer exemption + tighten exempt list; wire CSRF into
+  the test harness — **done, PR pending.** Root-cause fix: CSRF only protects
+  *cookie-session* requests (ambient `vtc_admin_session` replay is the entire
+  threat), so `enforce` now gates `method → bearer-skip → path-exempt →
+  session-cookie gate → same-origin/double-submit`. `has_bearer_auth` skips
+  programmatic Bearer clients (checked first); `has_session_cookie` (pinned to
+  the extractor's `ADMIN_SESSION_COOKIE`) passes credential-less/unauth requests
+  through to the auth layer so they get a clean 401 instead of a misleading
+  `CsrfFailed`; `is_csrf_exempt` keeps the explicit bootstrap list + suffix-matches
+  the parametrised public holder endpoints (`/v1/join-requests/{id}/accept|status`)
+  while leaving admin `approve`/`reject` gated. CSRF layer moved out of `server.rs`
+  into `routes::with_csrf` (canonical router builder) so every integration test
+  exercises it — wiring it in revealed (and fixed) the previously-invisible
+  401-vs-403 breakage in recognise/renewal/removal/policies/join. 15 unit + 3
+  cookie_session integration tests; full suite 968 green. — PR: ____
 - `[x]` **P3.3** (M) Website `PUT` through the full safety chain; validate before
   `create_dir_all` — `canonical_within_root_for_create` (shared
   `validate_path_components`; rejects `..`/hidden/blocklist/control/NFC + symlinked
@@ -188,8 +201,8 @@ the #457 posture backstop provides its regression guard.)
 - `[x]` **P3.7** (S) Minimal unauth `/health` (`{status,version,vtc_did}`; mediator/
   vta detail folded into admin-gated diagnostics); `nosniff` on `did.jsonl` —
   PR: #472
-- `[ ]` **P3.8** (M) Syncer: seek tail walk from cursor (range API); event_id-keyed
-  idempotent enqueue — PR: ____
+- `[x]` **P3.8** (M) Syncer: seek tail walk from cursor (range API); event_id-keyed
+  idempotent enqueue — PR: #487
 - `[ ]` **P3.9** (XL) Backup/restore for all keyspaces (Argon2id+AES-GCM, vtc_did
   compat check) — design note first — deps: P2.5 — PR: ____
 - `[ ]` **P3.10** (L) `vtc setup --from <toml>` (WizardPlan + apply engine); fix

--- a/vtc-service/src/routes/mod.rs
+++ b/vtc-service/src/routes/mod.rs
@@ -226,7 +226,7 @@ fn router_with_inner(routing: &RoutingConfig, trust_xff: bool) -> Router<AppStat
     // assembly by [`openapi_spec`] (which `assemble` serves), so the two cannot
     // drift.
     let api_chain = build_api_chain(routing, trust_xff).split_for_parts().0;
-    assemble(routing, api_chain)
+    with_csrf(assemble(routing, api_chain))
 }
 
 #[cfg(feature = "website")]
@@ -236,7 +236,20 @@ fn router_with_inner(
     trust_xff: bool,
 ) -> Router<AppState> {
     let api_chain = build_api_chain(routing, trust_xff).split_for_parts().0;
-    assemble_with_website(routing, api_chain, website_state)
+    with_csrf(assemble_with_website(routing, api_chain, website_state))
+}
+
+/// Attach the CSRF double-submit + `Sec-Fetch-Site` middleware
+/// (Phase 5 M5.2.2). Applied here in the canonical router builder
+/// — not in `server.rs` — so every integration test exercises CSRF
+/// exactly as production does (P3.2). The matcher in `routing::csrf`
+/// compares against the post-nest URI, so the layer must sit outside
+/// the `/v1` nest, which it does (the assembled router is the full
+/// path surface). `server.rs` wraps this with host-dispatch / CORS /
+/// trace / timeout, leaving the inner→outer ordering identical to the
+/// previous in-`server.rs` placement.
+fn with_csrf(app: Router<AppState>) -> Router<AppState> {
+    app.layer(axum::middleware::from_fn(crate::routing::csrf::enforce))
 }
 
 /// Build the merged API+unauth surface. Identical shape regardless

--- a/vtc-service/src/routing/csrf.rs
+++ b/vtc-service/src/routing/csrf.rs
@@ -1,47 +1,80 @@
 //! CSRF protection for admin mutating endpoints (Phase 5 M5.2.2).
 //!
-//! Tower middleware enforces one of two checks on every
-//! `POST` / `PUT` / `PATCH` / `DELETE` request to the API surface:
+//! ## What CSRF actually defends
+//!
+//! The only attack CSRF stops is a forged cross-site request riding
+//! the victim's **ambient cookie session**: the browser auto-attaches
+//! the `vtc_admin_session` cookie to a POST initiated by an attacker
+//! page, so the request authenticates as the victim. The defense is
+//! to require proof the request was *intended* — either a same-origin
+//! stamp the attacker can't forge, or a double-submit token the
+//! attacker can't read across origins.
+//!
+//! A request that carries **no session cookie** can't be
+//! authenticated-as-victim and therefore can't be a CSRF attack —
+//! there is nothing to protect. So CSRF is enforced **only on
+//! cookie-session requests**; everything else passes through and the
+//! per-route auth layer decides (returning a clean `401` for a
+//! genuinely unauthenticated call instead of a misleading
+//! `CsrfFailed`). This is the P3.2 fix: the earlier code gated *every*
+//! mutating request, so programmatic clients and credential-less
+//! probes alike got a 403 the threat model never warranted.
+//!
+//! ## Enforcement (cookie-session requests only)
+//!
+//! For a mutating request that carries the `vtc_admin_session`
+//! cookie, one of two checks must pass:
 //!
 //! 1. **`Sec-Fetch-Site: same-origin`** — modern browsers stamp
 //!    this header on fetches initiated from the same origin as the
-//!    receiving server. Non-browser clients (cnm-cli, programmatic
-//!    SDK consumers, DIDComm bridges) don't set it, so the second
-//!    check carries them.
-//!
+//!    receiving server. An attacker page's cross-site POST is stamped
+//!    `cross-site`, not `same-origin`.
 //! 2. **CSRF double-submit cookie** — the request must carry a
-//!    `csrf` cookie value that matches the `X-CSRF-Token`
-//!    request header. The cookie is set by the admin-login flow
-//!    (M5.2.3); programmatic clients ignore this entirely.
+//!    `csrf` cookie value that matches the `X-CSRF-Token` request
+//!    header. The cookie is set by the admin-login flow (M5.2.3); an
+//!    attacker can't read it across origins to echo it in the header.
 //!
 //! Either check passing → request continues. Both failing → 403
-//! `CsrfFailed`. The two checks are belt-and-braces: a malicious
-//! cross-origin POST from a public-website XSS would have neither
-//! `Sec-Fetch-Site: same-origin` (it'd be `cross-site`) nor the
-//! `csrf` cookie's matching token (it can't read the cookie value
-//! across origins).
+//! `CsrfFailed`.
 //!
-//! ## Exemptions
+//! ## Pass-through (before enforcement)
 //!
-//! - **GET / HEAD / OPTIONS** are not state-mutating and pass through.
-//! - **`POST /v1/join-requests`** is the public form-encoded submit
-//!   endpoint (§9.3) — public-site JS posts directly without
-//!   preflight via simple-request semantics. Exempted by path
-//!   prefix match.
-//! - **`POST /v1/auth/challenge` / `/v1/auth/` / `/v1/auth/refresh`**
-//!   are the JWT-issuance unauth flows — the bearer token IS the
-//!   auth credential, no cookie session yet exists to bind a CSRF
-//!   token to. Exempted by path prefix match.
-//! - **`POST /v1/install/claim/{start,finish}`** are the install
-//!   ceremony unauth endpoints — same rationale. Exempted.
+//! - **GET / HEAD / OPTIONS** are not state-mutating.
+//! - **`Authorization: Bearer` requests** are structurally
+//!   CSRF-immune: a browser never auto-attaches an `Authorization`
+//!   header the way it replays cookies, so a forged cross-site request
+//!   can't carry the bearer credential. Programmatic CLI / wallet /
+//!   SDK clients authenticate this way. Checked explicitly (and first)
+//!   so a bearer call still passes even if a stale session cookie
+//!   tags along — the auth extractor prefers the bearer token too.
+//! - **No `vtc_admin_session` cookie** — not a cookie session, so not
+//!   forgeable (see above). This subsumes the unauthenticated
+//!   bootstrap flows (`/auth/*`, `/install/claim/*`, `/auth/recognise*`,
+//!   passkey login) and the public CLI/wallet join surface
+//!   (`/join-requests`, `…/{id}/accept`, `…/{id}/status`), none of
+//!   which carry a session cookie.
+//! - **[`CSRF_EXEMPT_PATHS`] + the join holder suffixes** — an
+//!   explicit belt-and-braces list for the known unauthenticated
+//!   bootstrap + public-form endpoints, kept so they pass even on the
+//!   off chance a request reaches them carrying a stale session
+//!   cookie (e.g. a re-login while an old cookie lingers). The
+//!   holder-facing `…/{id}/accept` / `…/{id}/status` POSTs are
+//!   suffix-matched; the admin `approve`/`reject` endpoints on the
+//!   same mount are deliberately left to the cookie-session gate.
 
 use axum::body::Body;
 use axum::extract::Request;
-use axum::http::{HeaderValue, Method, Response, StatusCode};
+use axum::http::{HeaderMap, HeaderValue, Method, Response, StatusCode};
 use axum::middleware::Next;
 use axum::response::IntoResponse;
 use serde_json::json;
 use subtle::ConstantTimeEq;
+
+// Single source of truth for the cookie name: the same constant the
+// auth extractor reads to authenticate a cookie session. If a new
+// auth cookie is ever added there, the CSRF gate must learn about it
+// too — keep them pinned to the same symbol so the coupling is loud.
+use vti_common::auth::extractor::ADMIN_SESSION_COOKIE;
 
 /// Paths exempt from CSRF: unauth bootstrapping flows + the public
 /// form-post target. Each is documented in the module-level
@@ -63,6 +96,54 @@ const CSRF_EXEMPT_PATHS: &[&str] = &[
     "/v1/admin/bootstrap",
 ];
 
+/// True when the request carries an `Authorization: Bearer …` header.
+/// Such requests are structurally CSRF-immune (a browser never
+/// auto-attaches `Authorization` the way it replays cookies), so they
+/// skip the cookie/origin checks entirely — see the module rationale.
+fn has_bearer_auth(headers: &HeaderMap) -> bool {
+    headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        // RFC 7235 auth-scheme is case-insensitive; tolerate leading
+        // whitespace. `get(..7)` keeps the slice on a char boundary so
+        // a multibyte value can't panic.
+        .and_then(|v| v.trim_start().get(..7))
+        .map(|scheme| scheme.eq_ignore_ascii_case("bearer "))
+        .unwrap_or(false)
+}
+
+/// True when `path` is exempt from CSRF enforcement: the static
+/// bootstrapping flows in [`CSRF_EXEMPT_PATHS`] plus the parametrised
+/// public holder endpoints on the join surface
+/// (`/v1/join-requests/{id}/accept`, `…/{id}/status`), which can't be
+/// exact-matched. Suffix-matching `/accept` / `/status` under the
+/// join-requests prefix deliberately leaves the admin `approve` /
+/// `reject` endpoints on the same mount gated.
+fn is_csrf_exempt(path: &str) -> bool {
+    if CSRF_EXEMPT_PATHS.contains(&path) {
+        return true;
+    }
+    if let Some(rest) = path.strip_prefix("/v1/join-requests/") {
+        return rest.ends_with("/accept") || rest.ends_with("/status");
+    }
+    false
+}
+
+/// True when the request carries the `vtc_admin_session` cookie — the
+/// only credential a CSRF attack can ride. Requests without it can't
+/// be authenticated-as-victim, so they're not a CSRF vector and skip
+/// enforcement (the auth layer 401s them if they're unauthenticated).
+fn has_session_cookie(headers: &HeaderMap) -> bool {
+    headers
+        .get_all(axum::http::header::COOKIE)
+        .iter()
+        .filter_map(|v| v.to_str().ok())
+        .flat_map(|s| s.split(';'))
+        .map(|s| s.trim())
+        .filter_map(|kv| kv.split_once('='))
+        .any(|(name, _)| name == ADMIN_SESSION_COOKIE)
+}
+
 /// Tower middleware function. Wire via
 /// `axum::middleware::from_fn(enforce)` at the parent-router level
 /// so the layer sees the full path including the API mount prefix
@@ -74,10 +155,28 @@ pub async fn enforce(request: Request, next: Next) -> Response<Body> {
         _ => return next.run(request).await,
     }
 
+    // Bearer gate — programmatic clients authenticating with an
+    // `Authorization: Bearer` token are structurally CSRF-immune.
+    // Checked first so a bearer call passes even if a stale session
+    // cookie tags along (the auth extractor prefers bearer too).
+    if has_bearer_auth(request.headers()) {
+        return next.run(request).await;
+    }
+
     let path = request.uri().path();
 
-    // Path gate — bootstrapping flows + public form post bypass.
-    if CSRF_EXEMPT_PATHS.contains(&path) {
+    // Path gate — explicit belt-and-braces exemption for the known
+    // unauth bootstrap flows + public join surface.
+    if is_csrf_exempt(path) {
+        return next.run(request).await;
+    }
+
+    // Session-cookie gate — CSRF only protects cookie-session
+    // requests (ambient-credential replay is the entire threat). A
+    // request with no `vtc_admin_session` cookie can't be forged, so
+    // it passes here and the per-route auth layer returns a clean 401
+    // if it's actually unauthenticated.
+    if !has_session_cookie(request.headers()) {
         return next.run(request).await;
     }
 
@@ -140,10 +239,19 @@ mod tests {
         "ok"
     }
 
+    /// A `Cookie` header value carrying the admin session cookie, so a
+    /// request looks like a real cookie session to the gate. The unit
+    /// `app()` has no auth layer, so the handler returns 200 once CSRF
+    /// passes — these tests assert the CSRF decision, not auth.
+    const SESSION_COOKIE: &str = "vtc_admin_session=jwt.header.sig";
+
     fn app() -> Router {
         Router::new()
             .route("/v1/members", post(ok).get(ok))
             .route("/v1/join-requests", post(ok))
+            .route("/v1/join-requests/{id}/accept", post(ok))
+            .route("/v1/join-requests/{id}/status", post(ok))
+            .route("/v1/join-requests/{id}/approve", post(ok))
             .route("/v1/auth/challenge", post(ok))
             .layer(axum::middleware::from_fn(enforce))
     }
@@ -164,12 +272,16 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn post_without_csrf_returns_403() {
+    async fn cookie_session_post_without_csrf_returns_403() {
+        // A real cookie session (carries `vtc_admin_session`) with no
+        // origin stamp and no csrf token is the genuine CSRF-exposed
+        // case → 403.
         let resp = app()
             .oneshot(
                 Request::builder()
                     .method("POST")
                     .uri("/v1/members")
+                    .header("cookie", SESSION_COOKIE)
                     .body(Body::empty())
                     .unwrap(),
             )
@@ -182,12 +294,33 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn post_with_sec_fetch_site_same_origin_passes() {
+    async fn post_without_session_cookie_passes_csrf() {
+        // No bearer, no session cookie, no origin stamp: not a cookie
+        // session, so not a CSRF vector. CSRF passes it through; the
+        // auth layer (absent in this unit harness) is what would 401 a
+        // genuinely unauthenticated call. This is the P3.2 fix — the
+        // old code 403'd here, masking the auth layer's 401.
         let resp = app()
             .oneshot(
                 Request::builder()
                     .method("POST")
                     .uri("/v1/members")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn cookie_session_post_with_sec_fetch_site_same_origin_passes() {
+        let resp = app()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/members")
+                    .header("cookie", SESSION_COOKIE)
                     .header("sec-fetch-site", "same-origin")
                     .body(Body::empty())
                     .unwrap(),
@@ -198,13 +331,16 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn post_with_matching_csrf_cookie_and_header_passes() {
+    async fn cookie_session_post_with_matching_csrf_cookie_and_header_passes() {
         let resp = app()
             .oneshot(
                 Request::builder()
                     .method("POST")
                     .uri("/v1/members")
-                    .header("cookie", "csrf=abc123; other=foo")
+                    .header(
+                        "cookie",
+                        format!("{SESSION_COOKIE}; csrf=abc123; other=foo"),
+                    )
                     .header("x-csrf-token", "abc123")
                     .body(Body::empty())
                     .unwrap(),
@@ -215,13 +351,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn post_with_non_matching_csrf_header_returns_403() {
+    async fn cookie_session_post_with_non_matching_csrf_header_returns_403() {
         let resp = app()
             .oneshot(
                 Request::builder()
                     .method("POST")
                     .uri("/v1/members")
-                    .header("cookie", "csrf=abc123")
+                    .header("cookie", format!("{SESSION_COOKIE}; csrf=abc123"))
                     .header("x-csrf-token", "different")
                     .body(Body::empty())
                     .unwrap(),
@@ -259,5 +395,126 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn bearer_post_without_cookie_or_origin_passes() {
+        // Programmatic CLI/SDK client: bearer token, no Sec-Fetch-Site,
+        // no csrf cookie. Structurally CSRF-immune → passes.
+        let resp = app()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/members")
+                    .header("authorization", "Bearer eyJabc.def.ghi")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn bearer_scheme_is_case_insensitive() {
+        let resp = app()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/members")
+                    .header("authorization", "bearer eyJabc.def.ghi")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn non_bearer_authorization_scheme_on_cookie_session_stays_gated() {
+        // A `Basic` (or any non-bearer) Authorization header is not the
+        // CSRF-immune bearer case. With a real cookie session and no
+        // origin stamp / csrf token it must still 403 — the non-bearer
+        // scheme doesn't open the bearer skip.
+        let resp = app()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/members")
+                    .header("authorization", "Basic dXNlcjpwYXNz")
+                    .header("cookie", SESSION_COOKIE)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn holder_accept_post_bypasses() {
+        let resp = app()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/join-requests/req-123/accept")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn holder_status_post_bypasses() {
+        let resp = app()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/join-requests/req-123/status")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn admin_approve_on_join_mount_stays_gated() {
+        // `approve` shares the join-requests mount but is an admin
+        // action — a cookie-session POST with no token must 403 (only
+        // the holder `accept`/`status` suffixes are exempt, and only a
+        // cookie session is gated at all).
+        let resp = app()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/join-requests/req-123/approve")
+                    .header("cookie", SESSION_COOKIE)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[test]
+    fn session_cookie_detected_among_others() {
+        // The gate must find the session cookie regardless of position
+        // / surrounding pairs, and not false-positive on a lookalike.
+        let mut present = HeaderMap::new();
+        present.insert(
+            "cookie",
+            "foo=1; vtc_admin_session=abc; csrf=t".parse().unwrap(),
+        );
+        assert!(has_session_cookie(&present));
+
+        let mut absent = HeaderMap::new();
+        absent.insert("cookie", "csrf=t; other_session=abc".parse().unwrap());
+        assert!(!has_session_cookie(&absent));
     }
 }

--- a/vtc-service/src/server.rs
+++ b/vtc-service/src/server.rs
@@ -1113,10 +1113,9 @@ fn run_rest_thread(
             axum::middleware::from_fn_with_state(host_map, crate::routing::host_dispatch::enforce);
 
         // CSRF double-submit + Sec-Fetch-Site check (Phase 5
-        // M5.2.2). Bootstrapping flows + the public form-post
-        // target are path-exempt — see `routing::csrf` for the
-        // exemption list.
-        let csrf_layer = axum::middleware::from_fn(crate::routing::csrf::enforce);
+        // M5.2.2) is attached inside `routes::router_with_xff` (via
+        // `with_csrf`) so the integration harness exercises it exactly
+        // as production does (P3.2) — it is no longer layered here.
 
         // Public-website state (Phase 5 M5.4). `None` when the
         // operator hasn't set `website.root_dir` — the website
@@ -1130,7 +1129,6 @@ fn run_rest_thread(
         #[cfg(feature = "website")]
         let app = routes::router_with_xff(&routing, website_state, trust_xff)
             .with_state(state)
-            .layer(csrf_layer)
             .layer(host_layer)
             .layer(cors_layer)
             .layer(TraceLayer::new_for_http())
@@ -1138,7 +1136,6 @@ fn run_rest_thread(
         #[cfg(not(feature = "website"))]
         let app = routes::router_with_xff(&routing, trust_xff)
             .with_state(state)
-            .layer(csrf_layer)
             .layer(host_layer)
             .layer(cors_layer)
             .layer(TraceLayer::new_for_http())

--- a/vtc-service/tests/cookie_session.rs
+++ b/vtc-service/tests/cookie_session.rs
@@ -227,3 +227,81 @@ async fn foreign_audience_cookie_rejected() {
     let (status, _body) = request(&fix.router, req).await;
     assert_eq!(status, StatusCode::UNAUTHORIZED);
 }
+
+// ─── CSRF enforcement through the real router (P3.2) ─────────
+//
+// These assert that the CSRF layer is actually wired into the
+// assembled router the harness builds (it used to be attached only in
+// `server.rs`, so CSRF was invisible to integration tests). They also
+// pin the cookie-session gate: a mutating *cookie-session* request is
+// gated, while bearer and no-cookie requests are not.
+
+#[tokio::test]
+async fn cookie_session_mutation_without_csrf_token_is_forbidden() {
+    // A cookie session POSTing with neither a same-origin stamp nor a
+    // matching csrf double-submit is the genuine CSRF-exposed case.
+    // The CSRF layer (now wired into the harness) must reject it with
+    // `CsrfFailed` *before* the handler runs.
+    let fix = build_fixture().await;
+    let jwt = mint_session(&fix, "VTC").await;
+
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/acl")
+        .header("Trust-Task", ACL_TRUST_TASK)
+        .header("Cookie", format!("{ADMIN_SESSION_COOKIE}={jwt}"))
+        .body(Body::empty())
+        .unwrap();
+    let (status, body) = request(&fix.router, req).await;
+    assert_eq!(status, StatusCode::FORBIDDEN, "cookie-session POST: {body}");
+    assert!(
+        body.contains("CsrfFailed"),
+        "expected a CSRF rejection, got: {body}"
+    );
+}
+
+#[tokio::test]
+async fn cookie_session_mutation_with_same_origin_passes_csrf() {
+    // The same cookie session with a `Sec-Fetch-Site: same-origin`
+    // stamp clears CSRF and reaches the handler — so it is never the
+    // `CsrfFailed` rejection (the handler may still 4xx the body, but
+    // that's past CSRF).
+    let fix = build_fixture().await;
+    let jwt = mint_session(&fix, "VTC").await;
+
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/acl")
+        .header("Trust-Task", ACL_TRUST_TASK)
+        .header("Cookie", format!("{ADMIN_SESSION_COOKIE}={jwt}"))
+        .header("Sec-Fetch-Site", "same-origin")
+        .body(Body::empty())
+        .unwrap();
+    let (_status, body) = request(&fix.router, req).await;
+    assert!(
+        !body.contains("CsrfFailed"),
+        "same-origin cookie POST must clear CSRF, got: {body}"
+    );
+}
+
+#[tokio::test]
+async fn bearer_mutation_bypasses_csrf() {
+    // A bearer-authenticated POST carries no ambient cookie to forge,
+    // so it bypasses CSRF entirely even with no stamp / token — the
+    // programmatic-client case the P3.2 exemption fixes.
+    let fix = build_fixture().await;
+    let jwt = mint_session(&fix, "VTC").await;
+
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/acl")
+        .header("Trust-Task", ACL_TRUST_TASK)
+        .header("Authorization", format!("Bearer {jwt}"))
+        .body(Body::empty())
+        .unwrap();
+    let (_status, body) = request(&fix.router, req).await;
+    assert!(
+        !body.contains("CsrfFailed"),
+        "bearer POST must bypass CSRF, got: {body}"
+    );
+}


### PR DESCRIPTION
## P3.2 — CSRF: bearer exemption + tighten exempt list + wire into harness

### Problem
`csrf::enforce` gated **every** mutating request, so programmatic `Authorization: Bearer` clients (CLI/wallet/SDK) got a 403 `CsrfFailed` despite being structurally CSRF-immune, and the unauthenticated holder endpoints (`accept`/`status`) were blocked. Worse, the CSRF layer was attached only in `server.rs`, **not** in the test harness `router()` — so the break was invisible to CI.

### Root-cause fix
CSRF's only threat is a forged cross-site request riding the victim's ambient `vtc_admin_session` cookie. A request with **no session cookie can't be forged-as-victim**, so gating it just produced a misleading 403 where a clean 401 belonged.

`enforce` is reordered to `method → bearer-skip → path-exempt → **session-cookie gate** → same-origin / double-submit → 403`:

- **`has_bearer_auth`** — skips programmatic Bearer clients (checked first, so a bearer call passes even if a stale cookie tags along; the auth extractor prefers bearer too).
- **`has_session_cookie`** — pinned to the auth extractor's `ADMIN_SESSION_COOKIE` (single source of truth). No session cookie ⇒ not a CSRF vector ⇒ pass through to the auth layer for a clean 401. Naturally exempts recognise/passkey/all unauth bootstrap without a drift-prone path list.
- **`is_csrf_exempt`** — keeps the explicit bootstrap allow-list and suffix-matches the parametrised public holder endpoints (`/v1/join-requests/{id}/accept|status`), leaving admin `approve`/`reject` on the same mount gated.

### Wire CSRF into the harness
Moved the CSRF layer out of `server.rs` into `routes::with_csrf` in the canonical router builder, so **every integration test exercises CSRF exactly as production does** (ordering vs host/CORS/timeout is byte-identical). Wiring it in surfaced — and the cookie-session gate fixed — the previously-hidden 401-vs-403 breakage in `recognise` (7), `renewal`, `removal`, `policies`, `join_requests`. None of those test files needed editing; correct behavior fell out of the fix.

### Acceptance (from the plan)
- ✅ bearer POST with no Sec-Fetch/cookie passes
- ✅ cookie-session POST with no token → 403
- ✅ CLI-style `accept`/`status` passes
- ✅ CSRF now exercised by the integration harness

### Validation
- **Full suite: 968 passed, 0 failed** (admin-UI built).
- 15 CSRF unit tests + 3 new `cookie_session.rs` integration tests (cookie-session POST without token → `CsrfFailed`; same-origin clears it; bearer bypasses).
- `cargo fmt` clean; `cargo clippy` clean (sole warning is a pre-existing `TimeoutLayer::new` deprecation in `server.rs`).