### PR TITLE
feat(vtc): non-interactive `vtc setup --from <toml>` (P3.10)

### DIFF
--- a/docs/03-vtc/examples/vtc-setup.example.toml
+++ b/docs/03-vtc/examples/vtc-setup.example.toml
@@ -1,0 +1,76 @@
+# vtc-setup.example.toml — full reference for `vtc setup --from <file>`.
+#
+# Non-interactive VTC provisioning for CI, immutable images, or any
+# unattended bring-up. Mirrors the decisions the interactive `vtc setup`
+# wizard collects via prompts. See docs/03-vtc/getting-started.md.
+#
+# IMPORTANT — the ephemeral setup key is a TWO-PHASE bridge.
+# Provisioning authenticates to the VTA with an ephemeral did:key whose
+# DID must already be ACL-authorised at the VTA. A non-interactive run
+# can't pause to grant it, so do this first, out of band:
+#
+#   1. Generate + persist an ephemeral setup key (the same JSON `pnm`
+#      writes via EphemeralSetupKey::persist_to), e.g. under
+#      ~/.config/vtc/setup-key.json (0600).
+#   2. Grant its did:key an admin ACL at the VTA:
+#        pnm contexts create --id <context> --name "VTC" \
+#          --admin-did <setup-did> --admin-expires 1h
+#      (or `pnm acl create ...` if the context already exists).
+#   3. Run: vtc setup --from vtc-setup.toml
+#      with `setup_key_file` below pointing at that persisted key.
+
+# ── Required ────────────────────────────────────────────────────────────
+config_path    = "/srv/vtc/config.toml"
+base_url       = "https://vtc.example.com"   # host base, no trailing slash, no /v1
+vta_did        = "did:webvh:vta.example.com:abc"
+setup_key_file = "/srv/vtc/setup-key.json"   # persisted + ACL-granted (see above)
+
+# ── Optional top-level ──────────────────────────────────────────────────
+context = "default"   # the VTA context this community provisions under
+
+# ── DID hosting (optional) ──────────────────────────────────────────────
+# Omit the whole [webvh] table for the serverless default: the VTC
+# self-hosts its did.jsonl at base_url with a server-assigned path.
+# [webvh]
+# server_id = "host-1"                 # a registered did-hosting server id
+# domain    = "tenant.example.com"     # tenant domain on a multi-domain host
+# path      = "communities/acme"       # path in did:webvh:<scid>:<host>:<path>
+
+# ── DIDComm messaging (optional) ────────────────────────────────────────
+# Omit for no messaging — the daemon stays healthy on REST and logs a
+# one-line "messaging not configured" warning at startup. When present,
+# `mediator_did` is required; the endpoint is resolved from its DID
+# document, so `mediator_url` is informational only.
+# [messaging]
+# mediator_did = "did:web:mediator.example.com"
+# mediator_url = "https://mediator.example.com"
+
+# ── Secret-store backend (required) ─────────────────────────────────────
+# Where the VTC's key bundle is stored. Same shape as the [secrets] block
+# in config.toml. The choice is security-sensitive — there is no implicit
+# default. Pick exactly one backend; the others are shown commented.
+[secrets]
+# OS keyring (default backend). Change `keyring_service` to run multiple
+# VTC instances on one machine.
+keyring_service = "vtc"
+
+# AWS Secrets Manager (aws-secrets feature)
+# aws_secret_name = "vtc/prod/key-bundle"
+# aws_region      = "us-east-1"
+
+# GCP Secret Manager (gcp-secrets feature)
+# gcp_project     = "my-project"
+# gcp_secret_name = "vtc-prod-key-bundle"
+
+# Azure Key Vault (azure-secrets feature)
+# azure_vault_url   = "https://my-vault.vault.azure.net"
+# azure_secret_name = "vtc-prod-key-bundle"
+
+# Kubernetes Secret (k8s-secrets feature)
+# k8s_secret_name = "vtc-key-bundle"
+# k8s_namespace   = "vtc"
+# k8s_secret_key  = "secret"
+
+# Inline config-secret (dev/test): the hex key bundle is written into
+# this file's [secrets] secret by setup. Read-only at runtime.
+# secret = ""

--- a/docs/03-vtc/getting-started.md
+++ b/docs/03-vtc/getting-started.md
@@ -142,6 +142,41 @@ opens the sealed bundle, and writes:
 
 The wizard prints a one-shot **install URL**. Save it.
 
+### Non-interactive setup (`setup --from <toml>`)
+
+For CI, immutable images, or any unattended bring-up, provision from a
+TOML file instead of the prompts:
+
+```sh
+cargo run --package vtc-service -- setup --from vtc-setup.toml
+```
+
+The file mirrors the wizard's decisions — see the fully-commented
+[`docs/03-vtc/examples/vtc-setup.example.toml`](examples/vtc-setup.example.toml)
+for the schema.
+
+There's one wrinkle: provisioning authenticates to the VTA with an
+ephemeral `did:key` that must be ACL-authorised *before* setup runs, and
+a non-interactive run can't pause to grant it (the interactive wizard's
+"press Enter once authorised" step). So it's a **two-phase** flow:
+
+1. Generate + persist an ephemeral setup key (the same JSON `pnm` writes)
+   and grant its `did:key` an admin ACL at the VTA:
+
+   ```sh
+   pnm contexts create --id mycommunity --name "VTC" \
+       --admin-did "did:key:z6Mk..." --admin-expires 1h
+   # (or `pnm acl create ...` if the context already exists)
+   ```
+
+2. Point `setup_key_file` in the TOML at that persisted key and run
+   `setup --from`. Setup loads the key (it does not generate a fresh
+   one), provisions against the VTA, writes the same `did.jsonl` /
+   `config.toml` / sealed bundle as the interactive path, and prints a
+   terse `key=value` block (including the install URL + claim code).
+   The admin private key is **never** printed in non-interactive mode —
+   re-run interactively if you need it.
+
 ## Step 2 — Start the daemon
 
 ```sh

--- a/tasks/vtc-architecture-todo.md
+++ b/tasks/vtc-architecture-todo.md
@@ -164,8 +164,8 @@ the #457 posture backstop provides its regression guard.)
   - `[x]` **part 2** force host separation when a filesystem website
     (`website.root_dir`) is configured + honest docs (correct the stale
     `Path=/admin` cookie-isolation claim) — PR: #466
-- `[~]` **P3.2** (M) CSRF bearer exemption + tighten exempt list; wire CSRF into
-  the test harness — **done, PR pending.** Root-cause fix: CSRF only protects
+- `[x]` **P3.2** (M) CSRF bearer exemption + tighten exempt list; wire CSRF into
+  the test harness — Root-cause fix: CSRF only protects
   *cookie-session* requests (ambient `vtc_admin_session` replay is the entire
   threat), so `enforce` now gates `method → bearer-skip → path-exempt →
   session-cookie gate → same-origin/double-submit`. `has_bearer_auth` skips
@@ -178,7 +178,7 @@ the #457 posture backstop provides its regression guard.)
   into `routes::with_csrf` (canonical router builder) so every integration test
   exercises it — wiring it in revealed (and fixed) the previously-invisible
   401-vs-403 breakage in recognise/renewal/removal/policies/join. 15 unit + 3
-  cookie_session integration tests; full suite 968 green. — PR: #490 (in review)
+  cookie_session integration tests; full suite 968 green. — PR: #490
 - `[x]` **P3.3** (M) Website `PUT` through the full safety chain; validate before
   `create_dir_all` — `canonical_within_root_for_create` (shared
   `validate_path_components`; rejects `..`/hidden/blocklist/control/NFC + symlinked
@@ -205,13 +205,22 @@ the #457 posture backstop provides its regression guard.)
   idempotent enqueue — PR: #487
 - `[ ]` **P3.9** (XL) Backup/restore for all keyspaces (Argon2id+AES-GCM, vtc_did
   compat check) — design note first — deps: P2.5 — PR: ____
-- `[ ]` **P3.10** (L) `vtc setup --from <toml>` (WizardPlan + apply engine); fix
-  CLAUDE.md — PR: ____
-- `[~]` **P3.11** (S) Emergency bootstrap: marker-before-wipe, clear sessions,
-  `persist()` (persist already done in P2.5) — PR: #475 (in review)
-- `[~]` **P3.12** (S) Install `claim/finish` idempotent delivery against a
+- `[~]` **P3.10** (L) `vtc setup --from <toml>` (WizardPlan + apply engine); fix
+  CLAUDE.md — **done, PR pending.** Split `run_setup_wizard` into
+  `collect_interactive() → apply(WizardPlan)`; new `setup/from_toml.rs` parses a
+  `VtcWizardInputs` TOML (`deny_unknown_fields`) into the *same* `WizardPlan` and
+  feeds the *same* `apply`. The interactive ACL-grant pause is bridged in the
+  non-interactive path by a pre-persisted + pre-authorised `EphemeralSetupKey`
+  (`setup_key_file` → `load_from`), the two-phase pattern that type exists for.
+  `setup --from` prints a terse `key=value` block and never reveals the admin
+  key. Example fixture `docs/03-vtc/examples/vtc-setup.example.toml` (+ a test
+  that it parses); getting-started.md + vtc-service CLAUDE.md corrected. 8 unit
+  tests incl. headless parse→plan up to the VTA boundary. — PR: ____
+- `[x]` **P3.11** (S) Emergency bootstrap: marker-before-wipe, clear sessions,
+  `persist()` (persist already done in P2.5) — PR: #475
+- `[x]` **P3.12** (S) Install `claim/finish` idempotent delivery against a
   `Consumed` row (re-mint from persisted admin DID; `start→finish→start` still
-  rejects) — PR: #476 (in review)
+  rejects) — PR: #476
 - `[ ]` **P3.13** (M, several small PRs) Hygiene: stale webauthn doc; dead `b64:`
   path; redact `Debug` on secret types + gate wizard key print; `vtcDid`/`vtcUrl`
   field rename; public-profile field caps; path-param DID validation; reject

--- a/tasks/vtc-architecture-todo.md
+++ b/tasks/vtc-architecture-todo.md
@@ -215,7 +215,7 @@ the #457 posture backstop provides its regression guard.)
   `setup --from` prints a terse `key=value` block and never reveals the admin
   key. Example fixture `docs/03-vtc/examples/vtc-setup.example.toml` (+ a test
   that it parses); getting-started.md + vtc-service CLAUDE.md corrected. 8 unit
-  tests incl. headless parse→plan up to the VTA boundary. — PR: ____
+  tests incl. headless parse→plan up to the VTA boundary. — PR: #491 (in review)
 - `[x]` **P3.11** (S) Emergency bootstrap: marker-before-wipe, clear sessions,
   `persist()` (persist already done in P2.5) — PR: #475
 - `[x]` **P3.12** (S) Install `claim/finish` idempotent delivery against a

--- a/vtc-service/CLAUDE.md
+++ b/vtc-service/CLAUDE.md
@@ -52,7 +52,9 @@ src/
 ├── relationships/      VRC publish/revoke
 ├── routes/             Every HTTP route handler, sub-mounted by feature
 ├── routing/            Security headers, CSRF, body cap, governor middleware
-├── setup/              `vtc setup` wizard (interactive + from-TOML)
+├── setup/              `vtc setup` wizard: `wizard.rs` (interactive) +
+│                       `from_toml.rs` (`setup --from <toml>`). Both build one
+│                       `WizardPlan` and share the `apply` effect driver.
 ├── status_list/        Bitstring status list allocator + storage + serve route
 ├── store/              Re-export of vti-common's keyspace abstractions
 └── website/            Public website handler, bundle + deploy, default site

--- a/vtc-service/src/main.rs
+++ b/vtc-service/src/main.rs
@@ -26,8 +26,20 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    /// Run the interactive setup wizard
-    Setup,
+    /// Run the setup wizard.
+    ///
+    /// Without arguments, prompts interactively. With `--from <file>`,
+    /// reads a TOML setup-inputs file and provisions end-to-end without
+    /// prompts — suitable for CI, immutable images, or any unattended
+    /// bring-up. See `docs/03-vtc/examples/vtc-setup.example.toml` for
+    /// the worked schema.
+    Setup {
+        /// Path to a TOML setup-inputs file. When set, setup runs
+        /// non-interactively. The ephemeral setup key it references
+        /// (`setup_key_file`) must already be ACL-authorised at the VTA.
+        #[arg(long)]
+        from: Option<PathBuf>,
+    },
     /// Show VTC status and statistics
     Status,
     /// Create a did:key (offline, no server required)
@@ -141,16 +153,21 @@ async fn main() {
     print_banner();
 
     match cli.command {
-        Some(Commands::Setup) => {
+        Some(Commands::Setup { from }) => {
             #[cfg(feature = "setup")]
             {
-                if let Err(e) = setup::run_setup_wizard(cli.config).await {
+                let result = match from {
+                    Some(path) => setup::run_setup_from_file(path).await,
+                    None => setup::run_setup_wizard(cli.config).await,
+                };
+                if let Err(e) = result {
                     eprintln!("Setup failed: {e}");
                     std::process::exit(1);
                 }
             }
             #[cfg(not(feature = "setup"))]
             {
+                let _ = from;
                 eprintln!("Setup wizard not available (compiled without 'setup' feature)");
                 std::process::exit(1);
             }

--- a/vtc-service/src/setup/from_toml.rs
+++ b/vtc-service/src/setup/from_toml.rs
@@ -1,0 +1,426 @@
+//! Non-interactive `vtc setup --from <file>` (P3.10).
+//!
+//! The interactive [`wizard`](super::wizard) gathers operator decisions
+//! via prompts and live VTA round-trips, then hands a fully-resolved
+//! [`WizardPlan`](super::wizard::WizardPlan) to the shared
+//! [`apply`](super::wizard::apply) effect driver. This module is the
+//! second front-end: it parses a TOML file into the *same* plan and
+//! feeds it to the *same* `apply`, so a CI image, an immutable build, or
+//! any unattended provisioner can stand up a VTC with no TTY.
+//!
+//! ## The ACL-grant seam
+//!
+//! Provisioning a VTC authenticates to the VTA with an ephemeral
+//! `did:key`, and that DID must already be ACL-authorised at the VTA.
+//! The interactive wizard generates the key and *pauses* for the
+//! operator to grant the ACL. A non-interactive run can't pause, so the
+//! key has to be authorised out of band first. The flow is two-phase:
+//!
+//! 1. Generate + persist an ephemeral setup key (e.g. via the
+//!    provision-client's `EphemeralSetupKey::persist_to`, the same file
+//!    `pnm` writes), then grant its DID an admin ACL at the VTA
+//!    (`pnm contexts create --admin-did <did>` / `pnm acl create`).
+//! 2. Run `vtc setup --from <toml>`, pointing `setup_key_file` at that
+//!    persisted key. `apply` loads it (`load_from`) and provisions — the
+//!    grant is already in place, so no prompt is needed.
+//!
+//! This mirrors the VTA's deferred-setup / `pnm setup continue` pattern;
+//! the `EphemeralSetupKey` persist/reload bridge was built for exactly
+//! this race between ACL provisioning and connection verification.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use vta_sdk::provision_client::EphemeralSetupKey;
+use vti_common::error::AppError;
+
+use crate::config::{MessagingConfig, SecretsConfig};
+
+use super::wizard::{
+    SetupOutcome, WebvhTarget, WizardInputs, WizardPlan, apply, refuse_if_already_set_up,
+};
+
+/// TOML schema for `vtc setup --from <file>`.
+///
+/// `Serialize` is derived alongside `Deserialize` so the shipped example
+/// and round-trip tests can assert structural stability; production only
+/// ever deserializes. `deny_unknown_fields` makes a typo'd key a hard
+/// error rather than a silently-ignored setting.
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct VtcWizardInputs {
+    /// Output path for the generated `config.toml`. Setup refuses to
+    /// overwrite a config that already names a `vtc_did` — move it aside
+    /// to re-provision.
+    pub config_path: PathBuf,
+
+    /// The VTC daemon's public base URL (e.g. `https://vtc.example.com`),
+    /// no trailing slash and no `/v1`. All three surfaces (API, admin UX,
+    /// website) mount under it in the default path mode; it's stored as
+    /// `public_url` and passed as the `vtc-host` template's `URL` var. A
+    /// trailing slash is trimmed for you.
+    pub base_url: String,
+
+    /// DID of the VTA that mints this VTC's DID + key material (e.g.
+    /// `did:webvh:vta.example.com:abc`). Its transport endpoints are
+    /// resolved from the DID document — no separate VTA URL is needed.
+    pub vta_did: String,
+
+    /// Context name at the VTA this community provisions under. Defaults
+    /// to `default`.
+    #[serde(default = "default_context")]
+    pub context: String,
+
+    /// Where the VTC's `did:webvh` is published. All fields optional; an
+    /// empty `[webvh]` table (or omitting it) reproduces the serverless
+    /// default — the VTC self-hosts its `did.jsonl` at `base_url` with a
+    /// server-assigned path.
+    #[serde(default)]
+    pub webvh: WebvhTarget,
+
+    /// DIDComm mediator the VTC routes through. Omit for no messaging
+    /// (the daemon stays healthy on REST and logs a one-line warning).
+    /// `mediator_did` is required when present; `mediator_url` /
+    /// `mediator_host` are optional (the endpoint is resolved from the
+    /// DID document).
+    #[serde(default)]
+    pub messaging: Option<MessagingConfig>,
+
+    /// Secret-store backend for the VTC's key bundle. Required — the
+    /// choice is security-sensitive and there is no safe implicit
+    /// default. Same shape as the `[secrets]` block in `config.toml`; the
+    /// backend's own factory validates feature availability at load.
+    pub secrets: SecretsConfig,
+
+    /// Path to a JSON file holding a previously-persisted ephemeral setup
+    /// key (`EphemeralSetupKey::persist_to` format) whose `did:key` has
+    /// *already* been ACL-authorised at the VTA. This is the two-phase
+    /// bridge that replaces the interactive ACL-grant pause — see the
+    /// module docs.
+    pub setup_key_file: PathBuf,
+}
+
+fn default_context() -> String {
+    "default".to_string()
+}
+
+/// Read + parse a setup TOML into a fully-resolved [`WizardPlan`]: the
+/// same plan the interactive collector produces, ready for [`apply`].
+/// Validates the inputs and loads (does not generate) the pre-authorised
+/// ephemeral setup key.
+pub(crate) fn parse_from_toml(file_path: &Path) -> Result<WizardPlan, AppError> {
+    let raw = std::fs::read_to_string(file_path)
+        .map_err(|e| AppError::Config(format!("read setup file {}: {e}", file_path.display())))?;
+    let inputs: VtcWizardInputs = toml::from_str(&raw)
+        .map_err(|e| AppError::Config(format!("parse setup file {}: {e}", file_path.display())))?;
+
+    validate(&inputs)?;
+
+    // Guard before touching the VTA or the setup key: a config that
+    // already names a vtc_did means this VTC is provisioned.
+    refuse_if_already_set_up(&inputs.config_path)?;
+
+    let setup_key = EphemeralSetupKey::load_from(&inputs.setup_key_file).map_err(|e| {
+        AppError::Config(format!(
+            "load setup key {}: {e}. Generate + persist an ephemeral setup key and grant its \
+             did:key an admin ACL at the VTA before running `vtc setup --from` (see the \
+             non-interactive setup docs).",
+            inputs.setup_key_file.display()
+        ))
+    })?;
+
+    Ok(WizardPlan {
+        config_path: inputs.config_path,
+        inputs: WizardInputs {
+            base_url: inputs.base_url.trim_end_matches('/').to_string(),
+            vta_did: inputs.vta_did,
+            context: inputs.context,
+        },
+        webvh: inputs.webvh,
+        secrets: inputs.secrets,
+        messaging: inputs.messaging,
+        setup_key,
+    })
+}
+
+/// Cross-field validation, accumulating every problem so the operator
+/// fixes them in one pass rather than one-error-at-a-time.
+fn validate(inputs: &VtcWizardInputs) -> Result<(), AppError> {
+    let mut errors: Vec<String> = Vec::new();
+
+    let base = inputs.base_url.trim_end_matches('/');
+    if base.is_empty() {
+        errors.push("base_url must not be empty".into());
+    } else {
+        if !(base.starts_with("http://") || base.starts_with("https://")) {
+            errors.push(format!(
+                "base_url must start with http:// or https:// (got {:?})",
+                inputs.base_url
+            ));
+        }
+        if base.ends_with("/v1") {
+            errors.push(
+                "base_url must be the host base, without the /v1 API prefix (the template \
+                 appends API paths itself)"
+                    .into(),
+            );
+        }
+    }
+
+    if !inputs.vta_did.starts_with("did:") {
+        errors.push(format!(
+            "vta_did must be a DID starting with `did:` (got {:?})",
+            inputs.vta_did
+        ));
+    }
+
+    if inputs.context.trim().is_empty() {
+        errors.push("context must not be empty".into());
+    }
+
+    if let Some(messaging) = inputs.messaging.as_ref()
+        && messaging.mediator_did.trim().is_empty()
+    {
+        errors.push("messaging.mediator_did must not be empty when [messaging] is present".into());
+    }
+
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(AppError::Validation(format!(
+            "setup file has {} validation error(s):\n  - {}",
+            errors.len(),
+            errors.join("\n  - ")
+        )))
+    }
+}
+
+/// `vtc setup --from <file>`: parse → [`apply`] → terse summary. The
+/// non-interactive counterpart to [`run_setup_wizard`](super::wizard::run_setup_wizard).
+pub async fn run_setup_from_file(file_path: PathBuf) -> Result<(), AppError> {
+    eprintln!(
+        "Running non-interactive VTC setup from {} ...",
+        file_path.display()
+    );
+    let plan = parse_from_toml(&file_path)?;
+    let outcome = apply(plan).await?;
+    print_setup_summary_terse(&outcome);
+    Ok(())
+}
+
+/// Print a terse, scrape-friendly completion block. Unlike the
+/// interactive summary this never prompts and never prints the admin
+/// private key (no TTY to consciously confirm a reveal); the install URL
+/// + claim code are the actionable outputs.
+fn print_setup_summary_terse(outcome: &SetupOutcome) {
+    println!("VTC setup complete.");
+    println!("vtc_did={}", outcome.vtc_did);
+    println!("admin_did={}", outcome.admin_did);
+    println!("config_path={}", outcome.config_path.display());
+    println!("data_dir={}", outcome.data_dir.display());
+    println!("install_url={}", outcome.install_url);
+    println!("claim_code={}", outcome.claim_code);
+    if outcome.admin_key_json.is_some() {
+        println!(
+            "admin_key=<not printed in non-interactive mode; re-run interactively if you need it>"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A minimal valid TOML (keyring backend, serverless DID, no
+    /// messaging) parses and applies defaults.
+    fn minimal_toml(config_path: &str, setup_key_file: &str) -> String {
+        format!(
+            r#"
+config_path = "{config_path}"
+base_url    = "https://vtc.example.com"
+vta_did     = "did:webvh:vta.example.com:abc"
+setup_key_file = "{setup_key_file}"
+
+[secrets]
+keyring_service = "vtc-test"
+"#
+        )
+    }
+
+    /// Persist a fresh ephemeral key so `parse_from_toml` can load it,
+    /// returning (path, did).
+    fn persist_setup_key(dir: &Path) -> (PathBuf, String) {
+        let key = EphemeralSetupKey::generate().expect("generate setup key");
+        let did = key.did.clone();
+        let path = dir.join("setup-key.json");
+        key.persist_to(&path).expect("persist setup key");
+        (path, did)
+    }
+
+    #[test]
+    fn minimal_inputs_parse_and_default() {
+        let toml = minimal_toml("/srv/vtc/config.toml", "/tmp/key.json");
+        let inputs: VtcWizardInputs = toml::from_str(&toml).expect("parse");
+        assert_eq!(inputs.context, "default", "context defaults to `default`");
+        assert!(inputs.messaging.is_none());
+        assert!(inputs.webvh.server_id.is_none());
+        assert_eq!(inputs.secrets.keyring_service, "vtc-test");
+    }
+
+    #[test]
+    fn unknown_field_rejected() {
+        let toml = r#"
+config_path = "/srv/vtc/config.toml"
+base_url    = "https://vtc.example.com"
+vta_did     = "did:web:vta.example.com"
+setup_key_file = "/tmp/key.json"
+bogus_field = true
+
+[secrets]
+"#;
+        let err = toml::from_str::<VtcWizardInputs>(toml).unwrap_err();
+        assert!(
+            err.to_string().contains("bogus_field"),
+            "deny_unknown_fields should reject bogus_field, got: {err}"
+        );
+    }
+
+    #[test]
+    fn full_inputs_parse() {
+        let toml = r#"
+config_path = "/srv/vtc/config.toml"
+base_url    = "https://vtc.example.com/"
+vta_did     = "did:webvh:vta.example.com:abc"
+context     = "acme"
+setup_key_file = "/secrets/vtc-setup-key.json"
+
+[webvh]
+server_id = "host-1"
+domain    = "tenant.example.com"
+path      = "communities/acme"
+
+[messaging]
+mediator_did = "did:web:mediator.example.com"
+
+[secrets]
+keyring_service = "vtc-acme"
+"#;
+        let inputs: VtcWizardInputs = toml::from_str(toml).expect("parse");
+        assert_eq!(inputs.context, "acme");
+        assert_eq!(inputs.webvh.server_id.as_deref(), Some("host-1"));
+        assert_eq!(inputs.webvh.domain.as_deref(), Some("tenant.example.com"));
+        assert_eq!(inputs.webvh.path.as_deref(), Some("communities/acme"));
+        assert_eq!(
+            inputs.messaging.as_ref().unwrap().mediator_did,
+            "did:web:mediator.example.com"
+        );
+    }
+
+    #[test]
+    fn validate_rejects_bad_base_url_and_vta_did() {
+        let inputs: VtcWizardInputs = toml::from_str(
+            r#"
+config_path = "/srv/vtc/config.toml"
+base_url    = "vtc.example.com/v1"
+vta_did     = "not-a-did"
+setup_key_file = "/tmp/key.json"
+
+[secrets]
+"#,
+        )
+        .expect("parse");
+        let err = validate(&inputs).unwrap_err().to_string();
+        assert!(err.contains("base_url must start with http"), "{err}");
+        assert!(err.contains("/v1"), "{err}");
+        assert!(err.contains("vta_did must be a DID"), "{err}");
+    }
+
+    #[test]
+    fn validate_rejects_empty_mediator_did() {
+        let inputs: VtcWizardInputs = toml::from_str(
+            r#"
+config_path = "/srv/vtc/config.toml"
+base_url    = "https://vtc.example.com"
+vta_did     = "did:web:vta.example.com"
+setup_key_file = "/tmp/key.json"
+
+[messaging]
+mediator_did = ""
+
+[secrets]
+"#,
+        )
+        .expect("parse");
+        let err = validate(&inputs).unwrap_err().to_string();
+        assert!(err.contains("messaging.mediator_did"), "{err}");
+    }
+
+    /// End-to-end of the *headless* half: a TOML pointing at a persisted,
+    /// pre-authorised setup key parses into a `WizardPlan` with no TTY —
+    /// up to the VTA network boundary `apply` would cross. This is the
+    /// "completes with no TTY" guarantee minus the live VTA.
+    #[test]
+    fn parse_from_toml_builds_plan_with_loaded_key() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let (key_path, key_did) = persist_setup_key(dir.path());
+        // base_url carries a trailing slash to assert it's trimmed.
+        let toml = format!(
+            r#"
+config_path = "{cfg}"
+base_url    = "https://vtc.example.com/"
+vta_did     = "did:webvh:vta.example.com:abc"
+setup_key_file = "{key}"
+
+[secrets]
+keyring_service = "vtc-test"
+"#,
+            cfg = dir.path().join("config.toml").display(),
+            key = key_path.display(),
+        );
+        let toml_path = dir.path().join("setup.toml");
+        std::fs::write(&toml_path, toml).expect("write toml");
+
+        let plan = parse_from_toml(&toml_path).expect("parse_from_toml");
+        assert_eq!(
+            plan.setup_key.did, key_did,
+            "the plan must carry the pre-authorised key loaded from disk"
+        );
+        assert_eq!(
+            plan.inputs.base_url, "https://vtc.example.com",
+            "trailing slash trimmed"
+        );
+        assert_eq!(plan.inputs.context, "default");
+    }
+
+    #[test]
+    fn parse_from_toml_reports_missing_setup_key() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let toml = minimal_toml(
+            dir.path().join("config.toml").to_str().unwrap(),
+            dir.path().join("does-not-exist.json").to_str().unwrap(),
+        );
+        let toml_path = dir.path().join("setup.toml");
+        std::fs::write(&toml_path, toml).expect("write toml");
+
+        // `WizardPlan` deliberately holds the setup key and isn't `Debug`,
+        // so match rather than `unwrap_err()` (which needs `T: Debug`).
+        let err = match parse_from_toml(&toml_path) {
+            Ok(_) => panic!("expected a missing-setup-key error"),
+            Err(e) => e.to_string(),
+        };
+        assert!(err.contains("load setup key"), "{err}");
+        assert!(err.contains("admin ACL"), "actionable hint present: {err}");
+    }
+
+    /// The shipped example file must parse — keeps the docs honest.
+    #[test]
+    fn shipped_example_parses() {
+        let example = include_str!("../../../docs/03-vtc/examples/vtc-setup.example.toml");
+        let inputs: VtcWizardInputs = toml::from_str(example).expect("shipped example must parse");
+        // Sanity on a couple of fields so an accidental gut of the
+        // example is caught too.
+        assert!(inputs.base_url.starts_with("http"));
+        assert!(inputs.vta_did.starts_with("did:"));
+        validate(&inputs).expect("shipped example must validate");
+    }
+}

--- a/vtc-service/src/setup/mod.rs
+++ b/vtc-service/src/setup/mod.rs
@@ -4,14 +4,21 @@
 //!   carries the VTA-provisioned DID + key material.
 //! - [`wizard`] — interactive `vtc setup` flow (feature-gated on
 //!   `setup`).
+//! - [`from_toml`] — non-interactive `vtc setup --from <toml>`
+//!   (feature-gated on `setup`). Builds the same `WizardPlan` the
+//!   interactive wizard does and feeds it to the same `apply`.
 //!
 //! See `tasks/vtc-mvp/vta-driven-keys.md` for the design that
 //! drove this module's shape.
 
 pub mod bundle;
 #[cfg(feature = "setup")]
+pub mod from_toml;
+#[cfg(feature = "setup")]
 pub mod wizard;
 
 pub use bundle::VtcKeyBundle;
+#[cfg(feature = "setup")]
+pub use from_toml::run_setup_from_file;
 #[cfg(feature = "setup")]
 pub use wizard::run_setup_wizard;

--- a/vtc-service/src/setup/wizard.rs
+++ b/vtc-service/src/setup/wizard.rs
@@ -62,7 +62,19 @@ use crate::setup::VtcKeyBundle;
 /// Entry point bound to `Commands::Setup` in `main.rs`.
 pub async fn run_setup_wizard(config_path: Option<PathBuf>) -> Result<(), AppError> {
     intro_banner();
+    let plan = collect_interactive(config_path).await?;
+    let outcome = apply(plan).await?;
+    print_setup_summary_interactive(&outcome)?;
+    Ok(())
+}
 
+/// Gather every operator decision interactively and assemble a
+/// fully-resolved [`WizardPlan`]. This is the TTY half — prompts plus
+/// the live VTA round-trips (DID resolution, the ACL-grant pause, the
+/// did-hosting picker). The non-interactive `setup --from <toml>` path
+/// builds the same plan from a file and feeds it to the same [`apply`],
+/// so the two never drift.
+async fn collect_interactive(config_path: Option<PathBuf>) -> Result<WizardPlan, AppError> {
     let config_path = prompt_config_path(config_path)?;
     refuse_if_already_set_up(&config_path)?;
 
@@ -122,10 +134,35 @@ pub async fn run_setup_wizard(config_path: Option<PathBuf>) -> Result<(), AppErr
     //    layer.
     let secrets = prompt_secrets_config()?;
 
-    // 6. Drive the provision-integration round-trip. Capture and
-    //    discard event traffic so the wizard's UX stays terse —
-    //    long-form progress UX is for `pnm`, not the daemon setup
-    //    flow.
+    Ok(WizardPlan {
+        config_path,
+        inputs,
+        webvh,
+        secrets,
+        messaging,
+        setup_key,
+    })
+}
+
+/// Provision the VTC against the VTA and write every piece of on-disk
+/// state (did.jsonl, config.toml, the sealed key bundle, the install
+/// token). Deliberately free of prompts — both the interactive wizard
+/// and `setup --from <toml>` drive this identical effect path, so the
+/// non-interactive flow can't diverge from the interactive one. Returns
+/// the facts the caller presents; it does not print.
+pub(crate) async fn apply(plan: WizardPlan) -> Result<SetupOutcome, AppError> {
+    let WizardPlan {
+        config_path,
+        inputs,
+        webvh,
+        secrets,
+        messaging,
+        setup_key,
+    } = plan;
+
+    // Drive the provision-integration round-trip. Capture and discard
+    // event traffic so the setup UX stays terse — long-form progress UX
+    // is for `pnm`, not the daemon setup flow.
     let provision = run_provision_quietly(&inputs, &webvh, &setup_key).await?;
     let integration_did = provision
         .integration_did()
@@ -225,15 +262,30 @@ pub async fn run_setup_wizard(config_path: Option<PathBuf>) -> Result<(), AppErr
         .admin_key()
         .and_then(|k| serde_json::to_string_pretty(k).ok());
 
+    Ok(SetupOutcome {
+        vtc_did: integration_did,
+        admin_did,
+        config_path,
+        data_dir,
+        install_url,
+        claim_code,
+        admin_key_json: admin_key_summary,
+    })
+}
+
+/// Print the rich, interactive completion summary, gating the one-shot
+/// admin-key reveal behind an explicit confirm so the private key never
+/// spills into terminal scrollback unasked.
+fn print_setup_summary_interactive(outcome: &SetupOutcome) -> Result<(), AppError> {
     println!();
     println!("\x1b[1;32m✅ VTC setup complete.\x1b[0m");
     println!();
-    println!("VTC DID:       {integration_did}");
-    println!("Admin DID:     {admin_did}");
-    println!("Config:        {}", config_path.display());
-    println!("Data dir:      {}", data_dir.display());
+    println!("VTC DID:       {}", outcome.vtc_did);
+    println!("Admin DID:     {}", outcome.admin_did);
+    println!("Config:        {}", outcome.config_path.display());
+    println!("Data dir:      {}", outcome.data_dir.display());
     println!();
-    if let Some(key_json) = admin_key_summary.as_deref() {
+    if let Some(key_json) = outcome.admin_key_json.as_deref() {
         // The admin private key lands in the terminal scrollback / any
         // session recording the moment it's printed. Make the operator
         // consciously reveal it rather than spilling it by default.
@@ -257,10 +309,10 @@ pub async fn run_setup_wizard(config_path: Option<PathBuf>) -> Result<(), AppErr
         println!();
     }
     println!("\x1b[1mInstall URL (one-shot, 15 min TTL):\x1b[0m");
-    println!("  {install_url}");
+    println!("  {}", outcome.install_url);
     println!();
     println!("\x1b[1mClaim code (required at claim time):\x1b[0m");
-    println!("  {claim_code}");
+    println!("  {}", outcome.claim_code);
     println!();
     println!("Both URL and code are needed to claim the passkey. The code is shown");
     println!("only once and not persisted — copy it before continuing.");
@@ -270,7 +322,6 @@ pub async fn run_setup_wizard(config_path: Option<PathBuf>) -> Result<(), AppErr
     println!("  2. Open the install URL in your browser.");
     println!("  3. Enter the claim code when prompted, then register your passkey.");
     println!();
-
     Ok(())
 }
 
@@ -278,15 +329,55 @@ pub async fn run_setup_wizard(config_path: Option<PathBuf>) -> Result<(), AppErr
 // Input collection
 // ---------------------------------------------------------------------------
 
-struct WizardInputs {
+pub(crate) struct WizardInputs {
     /// Daemon's host base URL (e.g. `https://vtc.example.com`). The
     /// three surfaces — API, admin UX, public website — all mount
     /// under this in path mode (the default). Stored verbatim as
     /// `public_url` in the config and passed as the `vtc-host`
     /// template's `URL` var.
-    base_url: String,
-    vta_did: String,
-    context: String,
+    pub(crate) base_url: String,
+    pub(crate) vta_did: String,
+    pub(crate) context: String,
+}
+
+/// A fully-resolved setup plan: every operator decision gathered, no
+/// further prompts needed. Both front-ends produce one of these — the
+/// interactive [`collect_interactive`] (TTY prompts + the live VTA
+/// round-trips) and the non-interactive `from_toml::parse_from_toml`
+/// (`setup --from <toml>`) — and both feed it to the same [`apply`]
+/// effect driver. That shared seam is what keeps the two paths from
+/// drifting.
+pub(crate) struct WizardPlan {
+    pub(crate) config_path: PathBuf,
+    pub(crate) inputs: WizardInputs,
+    pub(crate) webvh: WebvhTarget,
+    pub(crate) secrets: SecretsConfig,
+    pub(crate) messaging: Option<MessagingConfig>,
+    /// The ephemeral `did:key` that authenticates the provision-
+    /// integration round-trip. Its DID must already be ACL-authorised
+    /// at the VTA: the interactive path generates it and pauses for the
+    /// operator to grant the ACL; the `--from` path loads a key the
+    /// operator persisted + granted out of band (the two-phase bridge
+    /// `EphemeralSetupKey::persist_to`/`load_from` exists for).
+    pub(crate) setup_key: EphemeralSetupKey,
+}
+
+/// The facts [`apply`] produces once the VTC is provisioned and all
+/// on-disk state is written. The caller decides how to present them
+/// (the interactive wizard prints a rich summary with a one-shot
+/// admin-key reveal; `setup --from` prints a terse, scrape-friendly
+/// block).
+pub(crate) struct SetupOutcome {
+    pub(crate) vtc_did: String,
+    pub(crate) admin_did: String,
+    pub(crate) config_path: PathBuf,
+    pub(crate) data_dir: PathBuf,
+    pub(crate) install_url: String,
+    pub(crate) claim_code: String,
+    /// Pretty-printed JSON of the long-term admin key, when the VTA
+    /// returned one. Sensitive — the interactive path gates its display
+    /// behind a confirm; the non-interactive path never prints it.
+    pub(crate) admin_key_json: Option<String>,
 }
 
 /// Where the VTC's `did:webvh` is published, as chosen by the operator
@@ -294,18 +385,22 @@ struct WizardInputs {
 /// VTA and enumerate its did-hosting catalogue). All three fields are
 /// optional; a fully-`None` target reproduces the serverless default
 /// (self-hosted at the VTC base URL, server-assigned path).
-#[derive(Default)]
-struct WebvhTarget {
+#[derive(Default, Debug, serde::Deserialize, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct WebvhTarget {
     /// Registered did-hosting server id (the `WEBVH_SERVER` var).
     /// `None` → serverless: the VTC publishes its own `did.jsonl` at
     /// the base URL.
-    server_id: Option<String>,
+    #[serde(default)]
+    pub(crate) server_id: Option<String>,
     /// Tenant domain on a multi-domain hosting server (the
     /// `WEBVH_DOMAIN` var). `None` → the server resolves its default.
-    domain: Option<String>,
+    #[serde(default)]
+    pub(crate) domain: Option<String>,
     /// Path component of `did:webvh:<scid>:<host>:<path>` (the
     /// `WEBVH_PATH` var). `None` → the server auto-assigns.
-    path: Option<String>,
+    #[serde(default)]
+    pub(crate) path: Option<String>,
 }
 
 fn prompt_config_path(initial: Option<PathBuf>) -> Result<PathBuf, AppError> {
@@ -321,7 +416,7 @@ fn prompt_config_path(initial: Option<PathBuf>) -> Result<PathBuf, AppError> {
     Ok(PathBuf::from(path))
 }
 
-fn refuse_if_already_set_up(config_path: &std::path::Path) -> Result<(), AppError> {
+pub(crate) fn refuse_if_already_set_up(config_path: &std::path::Path) -> Result<(), AppError> {
     if !config_path.exists() {
         return Ok(());
     }


### PR DESCRIPTION
## P3.10 — Non-interactive `vtc setup --from <toml>`

### Problem
`vtc setup` was TTY-only (`dialoguer` prompts at every step), and the crate's own CLAUDE.md advertised a "from-TOML" path that didn't exist — misdirecting operators and future agents. The VTA already has `setup --from`; this brings the VTC to parity.

### Design — one plan, two front-ends
Split the wizard into a shared seam:

- `run_setup_wizard` = `collect_interactive() → WizardPlan` then `apply(plan) → SetupOutcome`.
- New `setup/from_toml.rs` parses a `VtcWizardInputs` TOML (`deny_unknown_fields`) into the **same** `WizardPlan` and drives the **same** `apply`, so the interactive and non-interactive paths can't drift.
- `apply` is prompt-free and returns the facts; each caller presents them — the interactive path keeps its rich summary with the gated one-shot admin-key reveal; `--from` prints a terse `key=value` block and **never** reveals the admin private key (no TTY to confirm).

### The ACL-grant seam
Provisioning a VTC authenticates to the VTA with an ephemeral `did:key` that must be ACL-authorised *before* setup runs. The interactive wizard generates the key and pauses for the operator to grant it; a non-interactive run can't pause. So the TOML references a **pre-persisted, pre-authorised** key via `setup_key_file` (`EphemeralSetupKey::load_from`) — the two-phase bridge that type was built for, mirroring the VTA's deferred-setup / `pnm setup continue` pattern. (Persist + grant out of band, then run `setup --from`.)

### Changes
- **CLI:** `Setup { from: Option<PathBuf> }` → `run_setup_from_file` vs `run_setup_wizard`.
- **Validation** accumulates every error in one pass (base_url shape + no `/v1`, `vta_did` is a DID, non-empty context + `mediator_did`).
- **Docs:** worked example `docs/03-vtc/examples/vtc-setup.example.toml`; a getting-started "Non-interactive setup" section; corrected vtc-service CLAUDE.md source-layout note.

### Validation
- **Full suite: 977 passed, 0 failed** (prior 968 + 8 new `from_toml` tests; the wizard refactor leaves every existing test green).
- New tests cover: minimal/full parse, `deny_unknown_fields`, cross-field validation, a missing-setup-key actionable error, a **headless parse→`WizardPlan`** (loading a persisted key) up to the VTA network boundary — the "completes with no TTY" guarantee minus the live VTA — and a `shipped_example_parses` guard so the docs stay honest.
- `cargo fmt` + `cargo clippy` clean.

### Bookkeeping
Flips the merged **P3.2 (#490)**, **P3.11 (#475)**, **P3.12 (#476)** to done in the todo.