### PR TITLE
feat(vtc): encrypted full-state backup / restore (P3.9)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -502,6 +502,16 @@ new flow, update both this section and the relevant `docs/*.md`.
   accepts any backup; a configured VTA rejects backups whose `vta_did`
   doesn't match. Tested at `backup.rs:867-911`.
 - **Code**: `vta-service/src/operations/backup.rs`.
+- **VTC counterpart** (P3.9): same shape for the VTC — `POST
+  /backup/{export,import}` (super-admin, preview/confirm), Argon2id +
+  AES-256-GCM, `check_vtc_did_compatibility` (mismatch → 409). Backs up
+  14 of 21 keyspaces (the community's social state, incl. `status_lists`)
+  **plus the signing key bundle** so a restore reconstitutes signing, not
+  just data; sessions/passkey/install/sync/registry/config are excluded.
+  The `keyspaces::BACKED_UP`/`EXCLUDED_FROM_BACKUP` partition is pinned by
+  a census test. Code: `vtc-service/src/backup.rs`,
+  `vtc-service/src/routes/backup.rs`. Docs:
+  `docs/03-vtc/backup-restore.md`, `docs/05-design-notes/vtc-backup-restore.md`.
 
 ### Promote a serverless DID to a server-managed one
 - **What**: An operator who set up the VTA serverless (no webvh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10272,6 +10272,7 @@ dependencies = [
 name = "vtc-service"
 version = "0.9.4"
 dependencies = [
+ "aes-gcm",
  "affinidi-bbs",
  "affinidi-crypto",
  "affinidi-data-integrity",

--- a/docs/03-vtc/backup-restore.md
+++ b/docs/03-vtc/backup-restore.md
@@ -1,0 +1,96 @@
+# Backup & restore
+
+The VTC holds a community's irreplaceable social state — members, ACL,
+endorsements, relationships, policies, the audit log, and the bitstring
+**status lists** whose loss bricks every issued VMC's `credentialStatus`.
+`POST /v1/backup/export` and `POST /v1/backup/import` capture and restore that
+state in a single password-encrypted artifact.
+
+Both endpoints are **super-admin only**.
+
+## What's in a backup
+
+A backup is a JSON envelope (`format: "vtc-backup-v1"`) whose `ciphertext` is the
+AES-256-GCM encryption of:
+
+- **Community state** — every backed-up keyspace, dumped row-for-row: `acl`,
+  `community`, `members`, `join_requests`, `policies`, `active_policies`,
+  `status_lists`, `relationships`, `relationships_by_did`, `endorsement_types`,
+  `schemas`, `endorsements`, and `audit_key`. The `audit` log is included only
+  when you pass `include_audit: true`.
+- **The signing key bundle** — so the backup is a *complete* disaster-recovery
+  artifact: a restore re-establishes the VTC's ability to sign (status-list
+  re-issue, VMC minting), not just its data.
+- **An identity/config snapshot** — `vtc_did`, `vtc_name`, `vta_did`,
+  `public_url`, messaging, and the JWT signing key.
+
+> **The backup contains the signing key.** Treat the exported file like a
+> secret: it is encrypted with your password (Argon2id + AES-256-GCM), but
+> anyone who learns the password can sign as this community. Store it
+> accordingly and use a strong password (minimum 12 characters).
+
+**Not** in a backup (re-established after a restore, not carried): live
+`sessions`, browser `passkey` credentials, one-shot `install` tokens, the
+re-syncable `registry_records`, the `sync_queue`/`sync_cursor`, and the `config`
+keyspace overlay (its meaningful values ride in the identity snapshot above).
+
+## Export
+
+```sh
+curl -sS -X POST https://vtc.example.com/v1/backup/export \
+  -H "Authorization: Bearer $SUPER_ADMIN_JWT" \
+  -H 'Content-Type: application/json' \
+  -d '{"password":"correct-horse-battery-staple","include_audit":true}' \
+  > vtc-backup.json
+```
+
+## Restore
+
+Restore is a two-step **preview → confirm** to prevent fat-finger overwrites.
+
+```sh
+# 1. Preview — decrypts, checks identity, returns per-keyspace row counts.
+#    Mutates nothing.
+curl -sS -X POST https://vtc.example.com/v1/backup/import \
+  -H "Authorization: Bearer $SUPER_ADMIN_JWT" \
+  -H 'Content-Type: application/json' \
+  -d "$(jq -n --slurpfile b vtc-backup.json \
+        '{backup:$b[0], password:"correct-horse-battery-staple", confirm:false}')"
+
+# 2. Apply — clears the backed-up keyspaces and replays the backup.
+#    Same body with confirm:true.
+```
+
+After a successful import, **restart the daemon** so it serves the restored
+identity.
+
+### Identity guard
+
+- A **fresh install** (no `vtc_did` configured yet) accepts any backup — this is
+  the disaster-recovery path.
+- A **configured VTC** accepts a backup only if its `vtc_did` matches. A backup
+  from a different community is refused with **409 Conflict**. To deliberately
+  migrate identity, clear `vtc_did` from the running config first.
+
+### Recovering admin access
+
+Browser passkeys are not restored. After a restore, authenticate with your admin
+DID key (the admin entry is in the restored `acl`) over the CLI / DIDComm path,
+then re-enrol a passkey for browser SPA access.
+
+### Interrupted imports
+
+The import stamps a sentinel before it starts clearing and removes it only on
+success. If the process dies mid-import, the next boot **refuses to start** (the
+datastore is half-restored) and tells you to re-run the import with the same
+backup to finish it.
+
+## Limits
+
+- Import request body cap: **64 MiB**. A community with a very large audit log
+  may exceed it — export with `include_audit: false` (the community state itself
+  is far smaller).
+- Crypto: Argon2id (64 MiB / t=3 / p=4) + AES-256-GCM. Wrong password or a
+  tampered envelope fails closed (401).
+
+Design rationale + the keyspace partition: `docs/05-design-notes/vtc-backup-restore.md`.

--- a/tasks/vtc-architecture-todo.md
+++ b/tasks/vtc-architecture-todo.md
@@ -214,7 +214,7 @@ the #457 posture backstop provides its regression guard.)
   sessions/install/sync/registry/config excluded; vtc_did mismatch → 409.
   Operator doc `docs/03-vtc/backup-restore.md`. 8 unit + 4 integration tests
   (full-state round-trip, preview-no-mutate, foreign-did 409, wrong-password). —
-  PR: ____
+  PR: #494 (in review)
   - design note: PR #492
 - `[x]` **P3.10** (L) `vtc setup --from <toml>` (WizardPlan + apply engine); fix
   CLAUDE.md — Split `run_setup_wizard` into

--- a/tasks/vtc-architecture-todo.md
+++ b/tasks/vtc-architecture-todo.md
@@ -204,12 +204,18 @@ the #457 posture backstop provides its regression guard.)
 - `[x]` **P3.8** (M) Syncer: seek tail walk from cursor (range API); event_id-keyed
   idempotent enqueue — PR: #487
 - `[~]` **P3.9** (XL) Backup/restore for all keyspaces (Argon2id+AES-GCM, vtc_did
-  compat check) — design note first — deps: P2.5 — **design note done**
-  (`docs/05-design-notes/vtc-backup-restore.md`): ports the VTA pattern; 21
-  keyspaces partitioned 14 backed-up / 7 excluded with a census test; decisions
-  locked — include the `VtcKeyBundle`, exclude passkeys, back up join_requests,
-  409 on vtc_did mismatch, 64 MiB import cap. Implementation PR to follow. —
-  PR: #492 (design note, in review)
+  compat check) — design note first — deps: P2.5 — **design note merged (#492);
+  implementation done, PR pending.** `src/backup.rs` (export/import/decrypt +
+  `check_vtc_did_compatibility`), `routes/backup.rs` (`POST /v1/backup/{export,
+  import}`, super-admin, preview/confirm, 64 MiB import cap), `store/keyspaces.rs`
+  `BACKED_UP`/`EXCLUDED_FROM_BACKUP` + `backup_partition_is_total` census test,
+  boot sentinel guard in `server.rs`. Crypto = VTA's verbatim (Argon2id +
+  AES-256-GCM); 14 keyspaces backed up + the signing key bundle; passkeys/
+  sessions/install/sync/registry/config excluded; vtc_did mismatch → 409.
+  Operator doc `docs/03-vtc/backup-restore.md`. 8 unit + 4 integration tests
+  (full-state round-trip, preview-no-mutate, foreign-did 409, wrong-password). —
+  PR: ____
+  - design note: PR #492
 - `[x]` **P3.10** (L) `vtc setup --from <toml>` (WizardPlan + apply engine); fix
   CLAUDE.md — Split `run_setup_wizard` into
   `collect_interactive() → apply(WizardPlan)`; new `setup/from_toml.rs` parses a

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -228,6 +228,9 @@ bip39 = "2"
 # code the invitee types alongside the install URL). Same pin as
 # `vta-service`'s backup-password KDF.
 argon2 = "0.5"
+# AES-256-GCM for the encrypted backup/restore payload (P3.9). Same
+# workspace pin as `vta-service`'s backup feature.
+aes-gcm = { workspace = true }
 # Hostname capture for the `EmergencyBootstrapInvoked` audit event.
 gethostname = "1"
 # WebAuthn — used by `crate::webauthn` for Ed25519-only registration

--- a/vtc-service/src/backup.rs
+++ b/vtc-service/src/backup.rs
@@ -1,0 +1,691 @@
+//! Encrypted full-state backup / restore (P3.9).
+//!
+//! The VTC holds a community's irreplaceable social state — members,
+//! ACL, endorsements, relationships, policies, audit, and the bitstring
+//! status lists whose loss bricks every issued VMC's `credentialStatus`.
+//! This module exports that state (plus the signing key bundle) into a
+//! single password-encrypted artifact and restores it.
+//!
+//! Design note: `docs/05-design-notes/vtc-backup-restore.md`. Crypto is
+//! the VTA's verbatim — Argon2id + AES-256-GCM. The keyspace census
+//! (`keyspaces::BACKED_UP` ∪ `EXCLUDED_FROM_BACKUP` == `ALL`) guarantees
+//! no keyspace is silently omitted.
+
+use std::collections::BTreeMap;
+
+use aes_gcm::aead::rand_core::RngCore;
+use aes_gcm::aead::{Aead, OsRng};
+use aes_gcm::{Aes256Gcm, KeyInit, Nonce};
+use argon2::Argon2;
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD as BASE64;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use vti_common::error::AppError;
+use vti_common::store::KeyspaceHandle;
+
+use crate::config::MessagingConfig;
+use crate::keys::seed_store::SecretStore;
+use crate::server::AppState;
+use crate::store::keyspaces;
+
+// ── Crypto parameters (VTA-identical) ───────────────────────────────────
+const VERSION: u32 = 1;
+const FORMAT: &str = "vtc-backup-v1";
+const ARGON2_M_COST: u32 = 65536; // 64 MiB
+const ARGON2_T_COST: u32 = 3;
+const ARGON2_P_COST: u32 = 4;
+const SALT_LEN: usize = 32;
+const NONCE_LEN: usize = 12;
+const MIN_PASSWORD_LEN: usize = 12;
+
+// Import-side Argon2 bounds — clamp untrusted envelopes so a malicious
+// `m_cost` can't drive a memory bomb on decrypt.
+const MIN_M_COST: u32 = 8 * 1024; // 8 MiB
+const MAX_M_COST: u32 = 1 << 20; // 1 GiB
+const MIN_T_COST: u32 = 1;
+const MAX_T_COST: u32 = 10;
+const MIN_P_COST: u32 = 1;
+const MAX_P_COST: u32 = 16;
+
+/// Sentinel key, written into the `config` keyspace (excluded from
+/// backup, so it survives the import-time clear) before the destructive
+/// replay and removed only on success. Boot refuses to start while it's
+/// present — see [`import_in_progress`].
+const IMPORT_IN_PROGRESS_KEY: &[u8] = b"backup:import_in_progress";
+
+// ── Wire types ──────────────────────────────────────────────────────────
+
+/// Outer envelope: unencrypted metadata + the encrypted payload. Crypto
+/// fields mirror the VTA's `vta-backup-v1`.
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct BackupEnvelope {
+    pub version: u32,
+    pub format: String,
+    pub created_at: DateTime<Utc>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_did: Option<String>,
+    pub source_version: String,
+    pub kdf: KdfParams,
+    pub encryption: EncryptionParams,
+    pub includes_audit: bool,
+    /// base64url(AES-256-GCM(JSON([`BackupPayload`]))).
+    pub ciphertext: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct KdfParams {
+    pub algorithm: String, // "argon2id"
+    pub salt: String,      // base64url, 32 bytes
+    pub m_cost: u32,
+    pub t_cost: u32,
+    pub p_cost: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct EncryptionParams {
+    pub algorithm: String, // "aes-256-gcm"
+    pub nonce: String,     // base64url, 12 bytes
+}
+
+/// Inner (encrypted) payload. A config snapshot, the signing key bundle,
+/// and a faithful raw dump of every backed-up keyspace.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BackupPayload {
+    pub config: BackupConfig,
+    /// Hex of the raw secret-store bytes (the encoded `VtcKeyBundle`).
+    /// `None` only if the source had no bundle stored.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub key_bundle_hex: Option<String>,
+    pub keyspaces: Vec<KeyspaceDump>,
+}
+
+/// One backed-up keyspace's full contents. Both key and value are
+/// base64url-encoded so binary keys/values round-trip losslessly.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KeyspaceDump {
+    pub name: String,
+    pub rows: Vec<(String, String)>,
+}
+
+/// The slice of config that travels with a backup so a restore onto a
+/// fresh install reconstitutes the VTC's identity. The secrets *backend*
+/// is deliberately not carried — the target's own backend is used.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct BackupConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub vtc_did: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub vtc_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub vta_did: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub public_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub messaging: Option<MessagingConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub jwt_signing_key: Option<String>,
+}
+
+/// Result of an import (or, with `confirm = false`, a preview).
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct ImportResult {
+    pub status: String, // "imported" | "preview"
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_did: Option<String>,
+    /// Per-keyspace row counts the import wrote (or would write).
+    pub counts: BTreeMap<String, usize>,
+    pub message: String,
+}
+
+// ── Export ──────────────────────────────────────────────────────────────
+
+/// Export every backed-up keyspace + the signing key bundle into an
+/// encrypted [`BackupEnvelope`]. The `secret_store` (the configured
+/// backend, constructed by the route from config) supplies the signing
+/// key bundle. Caller must be super-admin (gated at the route).
+pub async fn export_backup(
+    state: &AppState,
+    secret_store: &dyn SecretStore,
+    password: &str,
+    include_audit: bool,
+) -> Result<BackupEnvelope, AppError> {
+    if password.len() < MIN_PASSWORD_LEN {
+        return Err(AppError::Validation(format!(
+            "backup password must be at least {MIN_PASSWORD_LEN} characters"
+        )));
+    }
+
+    // Signing key bundle (hex of the raw stored bytes — backend-agnostic
+    // round-trip).
+    let key_bundle_hex = secret_store.get().await?.map(hex::encode);
+
+    // Config snapshot.
+    let config = {
+        let cfg = state.config.read().await;
+        BackupConfig {
+            vtc_did: cfg.vtc_did.clone(),
+            vtc_name: cfg.vtc_name.clone(),
+            vta_did: cfg.vta_did.clone(),
+            public_url: cfg.public_url.clone(),
+            messaging: cfg.messaging.clone(),
+            jwt_signing_key: cfg.auth.jwt_signing_key.clone(),
+        }
+    };
+
+    // Keyspace census. `audit` rows are skipped unless requested; the
+    // keyspace still appears (empty) so the dump shape is stable.
+    let mut keyspace_dumps = Vec::with_capacity(keyspaces::BACKED_UP.len());
+    for name in keyspaces::BACKED_UP {
+        if *name == keyspaces::AUDIT && !include_audit {
+            keyspace_dumps.push(KeyspaceDump {
+                name: (*name).to_string(),
+                rows: Vec::new(),
+            });
+            continue;
+        }
+        let ks = backed_up_handle(state, name).ok_or_else(|| {
+            AppError::Internal(format!("backup: no AppState handle for keyspace '{name}'"))
+        })?;
+        let raw = ks.prefix_iter_raw(Vec::<u8>::new()).await?;
+        let rows = raw
+            .into_iter()
+            .map(|(k, v)| (BASE64.encode(k), BASE64.encode(v)))
+            .collect();
+        keyspace_dumps.push(KeyspaceDump {
+            name: (*name).to_string(),
+            rows,
+        });
+    }
+
+    let payload = BackupPayload {
+        config,
+        key_bundle_hex,
+        keyspaces: keyspace_dumps,
+    };
+    encrypt_payload(&payload, password, include_audit, state).await
+}
+
+// ── Import ──────────────────────────────────────────────────────────────
+
+/// Decrypt + apply a backup. With `confirm = false` this is a no-op
+/// **preview** returning the row counts; with `confirm = true` it clears
+/// the backed-up keyspaces and replays the backup. Identity-guarded on
+/// `vtc_did`. Caller must be super-admin (gated at the route).
+pub async fn import_backup(
+    state: &AppState,
+    secret_store: &dyn SecretStore,
+    envelope: &BackupEnvelope,
+    password: &str,
+    confirm: bool,
+) -> Result<ImportResult, AppError> {
+    let payload = decrypt_backup(envelope, password)?;
+
+    // Identity guard before any mutation.
+    {
+        let running = state.config.read().await.vtc_did.clone();
+        check_vtc_did_compatibility(running.as_deref(), payload.config.vtc_did.as_deref())?;
+    }
+
+    let counts: BTreeMap<String, usize> = payload
+        .keyspaces
+        .iter()
+        .map(|d| (d.name.clone(), d.rows.len()))
+        .collect();
+
+    if !confirm {
+        return Ok(ImportResult {
+            status: "preview".into(),
+            source_did: payload.config.vtc_did.clone(),
+            counts,
+            message: "Preview only — pass confirm=true to apply. This will overwrite \
+                      all community state."
+                .into(),
+        });
+    }
+
+    // Crash-safety: stamp the sentinel (in the excluded `config`
+    // keyspace, so it survives the clear) + flush before mutating.
+    state
+        .config_ks
+        .insert_raw(IMPORT_IN_PROGRESS_KEY.to_vec(), b"1".to_vec())
+        .await?;
+    state.config_ks.persist().await?;
+
+    // Clear every backed-up keyspace, then replay.
+    for name in keyspaces::BACKED_UP {
+        let ks = backed_up_handle(state, name).ok_or_else(|| {
+            AppError::Internal(format!("backup: no AppState handle for keyspace '{name}'"))
+        })?;
+        clear_keyspace(ks).await?;
+    }
+    for dump in &payload.keyspaces {
+        // Ignore a keyspace the dump names but we don't back up (forward
+        // compat with a future BACKED_UP addition).
+        let Some(ks) = backed_up_handle(state, &dump.name) else {
+            continue;
+        };
+        for (k_b64, v_b64) in &dump.rows {
+            let key = BASE64
+                .decode(k_b64)
+                .map_err(|e| AppError::Validation(format!("backup: bad row key b64: {e}")))?;
+            let val = BASE64
+                .decode(v_b64)
+                .map_err(|e| AppError::Validation(format!("backup: bad row value b64: {e}")))?;
+            ks.insert_raw(key, val).await?;
+        }
+        ks.persist().await?;
+    }
+
+    // Restore identity config + the signing key bundle.
+    apply_config(
+        state,
+        secret_store,
+        &payload.config,
+        payload.key_bundle_hex.as_deref(),
+    )
+    .await?;
+
+    // Done — clear the sentinel + flush.
+    state
+        .config_ks
+        .remove(IMPORT_IN_PROGRESS_KEY.to_vec())
+        .await?;
+    state.config_ks.persist().await?;
+
+    Ok(ImportResult {
+        status: "imported".into(),
+        source_did: payload.config.vtc_did.clone(),
+        counts,
+        message: "Import complete. Restart the daemon to serve the restored identity.".into(),
+    })
+}
+
+/// True if a previous import was interrupted before it finished. Boot
+/// consults this and refuses to start while it's set (the half-applied
+/// state is unsafe to serve). Cleared by a successful re-import.
+pub async fn import_in_progress(config_ks: &KeyspaceHandle) -> Result<bool, AppError> {
+    Ok(config_ks
+        .prefix_iter_raw(IMPORT_IN_PROGRESS_KEY.to_vec())
+        .await?
+        .iter()
+        .any(|(k, _)| k.as_slice() == IMPORT_IN_PROGRESS_KEY))
+}
+
+/// `vtc_did` guard — a configured VTC refuses a backup from a different
+/// identity; a fresh install accepts anything. Mirrors the VTA's
+/// `check_vta_did_compatibility`.
+fn check_vtc_did_compatibility(
+    running_did: Option<&str>,
+    backup_did: Option<&str>,
+) -> Result<(), AppError> {
+    let running = match running_did {
+        Some(d) if !d.is_empty() => d,
+        _ => return Ok(()), // fresh install accepts any backup
+    };
+    let backup = backup_did.unwrap_or("");
+    if backup == running {
+        return Ok(());
+    }
+    Err(AppError::Conflict(format!(
+        "backup vtc_did mismatch: backup claims '{backup}' but this VTC is running as \
+         '{running}'. Refusing to overwrite identity. If this is intentional (identity \
+         migration), clear vtc_did from the running config first."
+    )))
+}
+
+// ── Internals ───────────────────────────────────────────────────────────
+
+/// Map a backed-up keyspace name to its `AppState` handle. Returns
+/// `None` for names not in `BACKED_UP`.
+fn backed_up_handle<'a>(state: &'a AppState, name: &str) -> Option<&'a KeyspaceHandle> {
+    use keyspaces::*;
+    Some(match name {
+        x if x == ACL => &state.acl_ks,
+        x if x == COMMUNITY => &state.community_ks,
+        x if x == MEMBERS => &state.members_ks,
+        x if x == JOIN_REQUESTS => &state.join_requests_ks,
+        x if x == POLICIES => &state.policies_ks,
+        x if x == ACTIVE_POLICIES => &state.active_policies_ks,
+        x if x == STATUS_LISTS => &state.status_lists_ks,
+        x if x == RELATIONSHIPS => &state.relationships_ks,
+        x if x == RELATIONSHIPS_BY_DID => &state.relationships_by_did_ks,
+        x if x == ENDORSEMENT_TYPES => &state.endorsement_types_ks,
+        x if x == SCHEMAS => &state.schemas_ks,
+        x if x == ENDORSEMENTS => &state.endorsements_ks,
+        x if x == AUDIT => &state.audit_ks,
+        x if x == AUDIT_KEY => &state.audit_key_ks,
+        _ => return None,
+    })
+}
+
+/// Remove every row from a keyspace (whole-keyspace clear — VTC
+/// keyspaces are single-purpose, unlike the VTA's prefix-shared ones).
+async fn clear_keyspace(ks: &KeyspaceHandle) -> Result<(), AppError> {
+    let keys: Vec<Vec<u8>> = ks
+        .prefix_iter_raw(Vec::<u8>::new())
+        .await?
+        .into_iter()
+        .map(|(k, _)| k)
+        .collect();
+    for k in keys {
+        ks.remove(k).await?;
+    }
+    Ok(())
+}
+
+/// Apply the config snapshot + restore the signing key bundle, then
+/// persist `config.toml`.
+async fn apply_config(
+    state: &AppState,
+    secret_store: &dyn SecretStore,
+    bc: &BackupConfig,
+    key_bundle_hex: Option<&str>,
+) -> Result<(), AppError> {
+    // Restore the bundle first. The config-secret backend is read-only
+    // at runtime (its bytes live inline in config.toml), so for it we
+    // write the hex into the config; every other backend takes a `set`.
+    if let Some(hex_s) = key_bundle_hex {
+        let bundle_bytes = hex::decode(hex_s)
+            .map_err(|e| AppError::Validation(format!("backup: bad key_bundle hex: {e}")))?;
+        let is_inline = state.config.read().await.secrets.secret.is_some();
+        if is_inline {
+            state.config.write().await.secrets.secret = Some(hex::encode(&bundle_bytes));
+        } else {
+            secret_store
+                .set(&bundle_bytes)
+                .await
+                .map_err(|e| AppError::SecretStore(format!("backup: restore key bundle: {e}")))?;
+        }
+    }
+
+    let mut cfg = state.config.write().await;
+    if let Some(v) = &bc.vtc_did {
+        cfg.vtc_did = Some(v.clone());
+    }
+    if let Some(v) = &bc.vtc_name {
+        cfg.vtc_name = Some(v.clone());
+    }
+    if let Some(v) = &bc.vta_did {
+        cfg.vta_did = Some(v.clone());
+    }
+    if let Some(v) = &bc.public_url {
+        cfg.public_url = Some(v.clone());
+    }
+    if bc.messaging.is_some() {
+        cfg.messaging = bc.messaging.clone();
+    }
+    if let Some(v) = &bc.jwt_signing_key {
+        cfg.auth.jwt_signing_key = Some(v.clone());
+    }
+    cfg.save()?;
+    Ok(())
+}
+
+fn encrypt_payload_inner(
+    payload: &BackupPayload,
+    password: &str,
+    include_audit: bool,
+    source_did: Option<String>,
+) -> Result<BackupEnvelope, AppError> {
+    let plaintext = serde_json::to_vec(payload)
+        .map_err(|e| AppError::Internal(format!("backup serialize: {e}")))?;
+
+    let mut salt = [0u8; SALT_LEN];
+    OsRng.fill_bytes(&mut salt);
+    let mut nonce_bytes = [0u8; NONCE_LEN];
+    OsRng.fill_bytes(&mut nonce_bytes);
+
+    let key = derive_key(password, &salt, ARGON2_M_COST, ARGON2_T_COST, ARGON2_P_COST)?;
+    let cipher = Aes256Gcm::new_from_slice(&key)
+        .map_err(|e| AppError::Internal(format!("backup aes key: {e}")))?;
+    let ciphertext = cipher
+        .encrypt(Nonce::from_slice(&nonce_bytes), plaintext.as_ref())
+        .map_err(|e| AppError::Internal(format!("backup encrypt: {e}")))?;
+
+    Ok(BackupEnvelope {
+        version: VERSION,
+        format: FORMAT.into(),
+        created_at: Utc::now(),
+        source_did,
+        source_version: env!("CARGO_PKG_VERSION").into(),
+        kdf: KdfParams {
+            algorithm: "argon2id".into(),
+            salt: BASE64.encode(salt),
+            m_cost: ARGON2_M_COST,
+            t_cost: ARGON2_T_COST,
+            p_cost: ARGON2_P_COST,
+        },
+        encryption: EncryptionParams {
+            algorithm: "aes-256-gcm".into(),
+            nonce: BASE64.encode(nonce_bytes),
+        },
+        includes_audit: include_audit,
+        ciphertext: BASE64.encode(&ciphertext),
+    })
+}
+
+async fn encrypt_payload(
+    payload: &BackupPayload,
+    password: &str,
+    include_audit: bool,
+    state: &AppState,
+) -> Result<BackupEnvelope, AppError> {
+    let source_did = state.config.read().await.vtc_did.clone();
+    encrypt_payload_inner(payload, password, include_audit, source_did)
+}
+
+/// Decrypt + validate a backup envelope. Wrong password / tamper →
+/// `Authentication` (the GCM tag failed).
+pub fn decrypt_backup(
+    envelope: &BackupEnvelope,
+    password: &str,
+) -> Result<BackupPayload, AppError> {
+    if envelope.version != VERSION || envelope.format != FORMAT {
+        return Err(AppError::Validation(format!(
+            "unsupported backup format: {} v{}",
+            envelope.format, envelope.version
+        )));
+    }
+    if envelope.kdf.algorithm != "argon2id" {
+        return Err(AppError::Validation(format!(
+            "unsupported KDF '{}' (only argon2id)",
+            envelope.kdf.algorithm
+        )));
+    }
+    if !(MIN_M_COST..=MAX_M_COST).contains(&envelope.kdf.m_cost) {
+        return Err(AppError::Validation(format!(
+            "argon2 m_cost {} out of bounds [{MIN_M_COST}, {MAX_M_COST}]",
+            envelope.kdf.m_cost
+        )));
+    }
+    if !(MIN_T_COST..=MAX_T_COST).contains(&envelope.kdf.t_cost) {
+        return Err(AppError::Validation("argon2 t_cost out of bounds".into()));
+    }
+    if !(MIN_P_COST..=MAX_P_COST).contains(&envelope.kdf.p_cost) {
+        return Err(AppError::Validation("argon2 p_cost out of bounds".into()));
+    }
+    if envelope.encryption.algorithm != "aes-256-gcm" {
+        return Err(AppError::Validation(format!(
+            "unsupported cipher '{}' (only aes-256-gcm)",
+            envelope.encryption.algorithm
+        )));
+    }
+
+    let salt = BASE64
+        .decode(&envelope.kdf.salt)
+        .map_err(|e| AppError::Validation(format!("invalid salt: {e}")))?;
+    if salt.len() != SALT_LEN {
+        return Err(AppError::Validation(format!(
+            "invalid salt length {} (expected {SALT_LEN})",
+            salt.len()
+        )));
+    }
+    let nonce_bytes = BASE64
+        .decode(&envelope.encryption.nonce)
+        .map_err(|e| AppError::Validation(format!("invalid nonce: {e}")))?;
+    if nonce_bytes.len() != NONCE_LEN {
+        return Err(AppError::Validation(format!(
+            "invalid nonce length {} (expected {NONCE_LEN})",
+            nonce_bytes.len()
+        )));
+    }
+    let ciphertext = BASE64
+        .decode(&envelope.ciphertext)
+        .map_err(|e| AppError::Validation(format!("invalid ciphertext: {e}")))?;
+
+    let key = derive_key(
+        password,
+        &salt,
+        envelope.kdf.m_cost,
+        envelope.kdf.t_cost,
+        envelope.kdf.p_cost,
+    )?;
+    let cipher = Aes256Gcm::new_from_slice(&key)
+        .map_err(|e| AppError::Internal(format!("backup aes key: {e}")))?;
+    let plaintext = cipher
+        .decrypt(Nonce::from_slice(&nonce_bytes), ciphertext.as_ref())
+        .map_err(|_| AppError::Authentication("incorrect backup password".into()))?;
+
+    serde_json::from_slice(&plaintext)
+        .map_err(|e| AppError::Internal(format!("backup payload corrupt: {e}")))
+}
+
+fn derive_key(
+    password: &str,
+    salt: &[u8],
+    m_cost: u32,
+    t_cost: u32,
+    p_cost: u32,
+) -> Result<[u8; 32], AppError> {
+    let argon2 = Argon2::new(
+        argon2::Algorithm::Argon2id,
+        argon2::Version::V0x13,
+        argon2::Params::new(m_cost, t_cost, p_cost, Some(32))
+            .map_err(|e| AppError::Validation(format!("argon2 params: {e}")))?,
+    );
+    let mut key = [0u8; 32];
+    argon2
+        .hash_password_into(password.as_bytes(), salt, &mut key)
+        .map_err(|e| AppError::Internal(format!("argon2 hash: {e}")))?;
+    Ok(key)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_payload() -> BackupPayload {
+        BackupPayload {
+            config: BackupConfig {
+                vtc_did: Some("did:webvh:vtc.example.com:abc".into()),
+                vtc_name: Some("Acme".into()),
+                vta_did: Some("did:webvh:vta.example.com:xyz".into()),
+                public_url: Some("https://vtc.example.com".into()),
+                messaging: None,
+                jwt_signing_key: Some("sign-key".into()),
+            },
+            key_bundle_hex: Some(hex::encode(b"bundle-bytes")),
+            keyspaces: vec![
+                KeyspaceDump {
+                    name: keyspaces::ACL.into(),
+                    rows: vec![(
+                        BASE64.encode("acl:did:key:z6Mk"),
+                        BASE64.encode(r#"{"r":1}"#),
+                    )],
+                },
+                KeyspaceDump {
+                    name: keyspaces::STATUS_LISTS.into(),
+                    // a binary-ish value to prove base64 round-trips it
+                    rows: vec![(BASE64.encode("sl:0"), BASE64.encode([0u8, 159, 146, 150]))],
+                },
+            ],
+        }
+    }
+
+    fn enc(p: &BackupPayload, pw: &str) -> BackupEnvelope {
+        encrypt_payload_inner(p, pw, false, p.config.vtc_did.clone()).unwrap()
+    }
+
+    #[test]
+    fn roundtrip() {
+        let p = sample_payload();
+        let env = enc(&p, "correct-horse-battery");
+        assert_eq!(env.version, 1);
+        assert_eq!(env.format, "vtc-backup-v1");
+        assert_eq!(env.kdf.algorithm, "argon2id");
+        assert_eq!(env.encryption.algorithm, "aes-256-gcm");
+
+        let back = decrypt_backup(&env, "correct-horse-battery").unwrap();
+        assert_eq!(back.config.vtc_did, p.config.vtc_did);
+        assert_eq!(back.key_bundle_hex, p.key_bundle_hex);
+        assert_eq!(back.keyspaces.len(), 2);
+        assert_eq!(
+            back.keyspaces[1].rows[0].1,
+            BASE64.encode([0u8, 159, 146, 150])
+        );
+    }
+
+    #[test]
+    fn wrong_password_fails() {
+        let env = enc(&sample_payload(), "the-right-password");
+        let err = decrypt_backup(&env, "the-wrong-password").unwrap_err();
+        assert!(format!("{err}").contains("incorrect backup password"));
+    }
+
+    #[test]
+    fn tampered_ciphertext_detected() {
+        let mut env = enc(&sample_payload(), "twelve-char-pw!!");
+        let mut ct = BASE64.decode(&env.ciphertext).unwrap();
+        *ct.last_mut().unwrap() ^= 0xFF;
+        env.ciphertext = BASE64.encode(&ct);
+        assert!(decrypt_backup(&env, "twelve-char-pw!!").is_err());
+    }
+
+    #[test]
+    fn rejects_bad_format_and_param_bounds() {
+        let good = enc(&sample_payload(), "twelve-char-pw!!");
+
+        let mut bad = good.clone();
+        bad.format = "vta-backup-v1".into();
+        assert!(decrypt_backup(&bad, "twelve-char-pw!!").is_err());
+
+        let mut bad = good.clone();
+        bad.kdf.m_cost = MAX_M_COST + 1;
+        assert!(decrypt_backup(&bad, "twelve-char-pw!!").is_err());
+
+        let mut bad = good.clone();
+        bad.kdf.algorithm = "scrypt".into();
+        assert!(decrypt_backup(&bad, "twelve-char-pw!!").is_err());
+
+        let mut bad = good;
+        bad.kdf.salt = BASE64.encode([0u8; 8]); // wrong length
+        assert!(decrypt_backup(&bad, "twelve-char-pw!!").is_err());
+    }
+
+    #[test]
+    fn did_guard_fresh_install_accepts_any() {
+        check_vtc_did_compatibility(None, Some("did:key:z6MkAny")).unwrap();
+        check_vtc_did_compatibility(Some(""), Some("did:key:z6MkAny")).unwrap();
+        check_vtc_did_compatibility(None, None).unwrap();
+    }
+
+    #[test]
+    fn did_guard_matching_accepted() {
+        check_vtc_did_compatibility(Some("did:key:z6MkSame"), Some("did:key:z6MkSame")).unwrap();
+    }
+
+    #[test]
+    fn did_guard_mismatch_rejected() {
+        let err =
+            check_vtc_did_compatibility(Some("did:key:z6MkRunning"), Some("did:key:z6MkForeign"))
+                .unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("vtc_did mismatch"), "{msg}");
+        assert!(
+            msg.contains("z6MkForeign") && msg.contains("z6MkRunning"),
+            "{msg}"
+        );
+    }
+}

--- a/vtc-service/src/lib.rs
+++ b/vtc-service/src/lib.rs
@@ -17,6 +17,7 @@ pub mod acl_cli;
 #[cfg(feature = "admin-ui")]
 pub mod admin_ui;
 pub mod auth;
+pub mod backup;
 pub mod ceremony;
 pub mod community;
 pub mod config;

--- a/vtc-service/src/routes/backup.rs
+++ b/vtc-service/src/routes/backup.rs
@@ -1,0 +1,92 @@
+//! Encrypted backup / restore endpoints (P3.9).
+//!
+//! `POST /v1/backup/export` → encrypted [`BackupEnvelope`];
+//! `POST /v1/backup/import` applies one (or, with `confirm = false`,
+//! previews it). Both are super-admin only. The heavy lifting —
+//! keyspace census, crypto, identity guard, crash-safe replay — lives in
+//! [`crate::backup`].
+
+use axum::Json;
+use axum::extract::State;
+use serde::Deserialize;
+
+use crate::auth::SuperAdminAuth;
+use crate::backup::{self, BackupEnvelope, ImportResult};
+use crate::keys::seed_store::create_secret_store;
+use crate::server::AppState;
+use vti_common::error::AppError;
+
+/// `POST /v1/backup/export` body.
+#[derive(Debug, Deserialize, utoipa::ToSchema)]
+pub struct ExportRequest {
+    /// Encryption password (Argon2id). Minimum 12 characters.
+    pub password: String,
+    /// Include the audit log in the backup. Default `false` — audit logs
+    /// can be large and carry plaintext DIDs.
+    #[serde(default)]
+    pub include_audit: bool,
+}
+
+/// `POST /v1/backup/import` body.
+#[derive(Debug, Deserialize, utoipa::ToSchema)]
+pub struct ImportRequest {
+    /// The encrypted backup envelope produced by `export`.
+    pub backup: BackupEnvelope,
+    /// The password the backup was encrypted with.
+    pub password: String,
+    /// `false` (default) previews the restore (row counts, no mutation);
+    /// `true` clears the backed-up keyspaces and applies the backup.
+    #[serde(default)]
+    pub confirm: bool,
+}
+
+#[utoipa::path(
+    post, path = "/backup/export", tag = "backup",
+    security(("bearer_jwt" = [])),
+    request_body = ExportRequest,
+    responses(
+        (status = 200, description = "Encrypted full-state backup", body = BackupEnvelope),
+        (status = 400, description = "Password too short"),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller is not a super-admin"),
+    ),
+)]
+pub async fn export(
+    SuperAdminAuth(_auth): SuperAdminAuth,
+    State(state): State<AppState>,
+    Json(req): Json<ExportRequest>,
+) -> Result<Json<BackupEnvelope>, AppError> {
+    let store = create_secret_store(&*state.config.read().await)?;
+    let envelope =
+        backup::export_backup(&state, store.as_ref(), &req.password, req.include_audit).await?;
+    Ok(Json(envelope))
+}
+
+#[utoipa::path(
+    post, path = "/backup/import", tag = "backup",
+    security(("bearer_jwt" = [])),
+    request_body = ImportRequest,
+    responses(
+        (status = 200, description = "Import applied, or (confirm=false) a preview", body = ImportResult),
+        (status = 400, description = "Malformed / unsupported backup"),
+        (status = 401, description = "Wrong backup password or invalid bearer token"),
+        (status = 403, description = "Caller is not a super-admin"),
+        (status = 409, description = "Backup vtc_did does not match this VTC"),
+    ),
+)]
+pub async fn import(
+    SuperAdminAuth(_auth): SuperAdminAuth,
+    State(state): State<AppState>,
+    Json(req): Json<ImportRequest>,
+) -> Result<Json<ImportResult>, AppError> {
+    let store = create_secret_store(&*state.config.read().await)?;
+    let result = backup::import_backup(
+        &state,
+        store.as_ref(),
+        &req.backup,
+        &req.password,
+        req.confirm,
+    )
+    .await?;
+    Ok(Json(result))
+}

--- a/vtc-service/src/routes/mod.rs
+++ b/vtc-service/src/routes/mod.rs
@@ -4,6 +4,7 @@ mod admin;
 mod admin_ui;
 mod audit;
 mod auth;
+mod backup;
 mod ceremonies;
 mod community;
 mod config;
@@ -740,11 +741,34 @@ fn build_api_chain(_routing: &RoutingConfig, trust_xff: bool) -> OpenApiRouter<A
         )
     };
 
+    // P3.9 — encrypted backup / restore (super-admin). Import envelopes
+    // carry the whole community's state (+ optional audit log), so the
+    // import route overrides the 1 MiB global cap with 64 MiB — attached
+    // here, before the global layer below, so the route-specific cap
+    // wins (same mechanism as the website routes above). Export requests
+    // are tiny and keep the default.
+    const BACKUP_IMPORT_CAP: usize = 64 * 1024 * 1024;
+    let api = api
+        .route(
+            "/backup/export",
+            ttl(
+                post(backup::export),
+                "https://trusttasks.org/openvtc/vtc/backup/export/1.0",
+            ),
+        )
+        .route(
+            "/backup/import",
+            ttl(
+                post(backup::import).layer(DefaultBodyLimit::max(BACKUP_IMPORT_CAP)),
+                "https://trusttasks.org/openvtc/vtc/backup/import/1.0",
+            ),
+        );
+
     let api = api
         // §14.4 — every authenticated API route inherits the 1 MiB
         // global body cap. The per-route overrides above for
-        // `/v1/website/*` apply first; this layer is the default
-        // for everything else.
+        // `/v1/website/*` + `/v1/backup/import` apply first; this layer
+        // is the default for everything else.
         .layer(DefaultBodyLimit::max(MAX_BODY_SIZE));
 
     // Unauthenticated routes — tighter body cap + per-IP governor.

--- a/vtc-service/src/server.rs
+++ b/vtc-service/src/server.rs
@@ -250,6 +250,21 @@ pub async fn run(
     let community_ks = store.keyspace(keyspaces::COMMUNITY)?;
     let config_ks = store.keyspace(keyspaces::CONFIG)?;
 
+    // P3.9: refuse to boot on a half-applied backup import. The sentinel
+    // (in the `config` keyspace, which import never clears) is stamped
+    // before the destructive replay and removed only on success — its
+    // presence means a prior import crashed mid-flight and the keyspaces
+    // are in an indeterminate state. Serving that would surface partial
+    // community state; re-run the import to finish (or roll forward).
+    if crate::backup::import_in_progress(&config_ks).await? {
+        return Err(AppError::Config(
+            "a backup import was interrupted before it completed — the datastore is in a \
+             half-restored state. Re-run `POST /v1/backup/import` with the same backup to \
+             finish it; the daemon will not serve partial state."
+                .into(),
+        ));
+    }
+
     // P1.1: `config_store` (the db overlay) is canonical for the runtime
     // config keys — fold any operator PATCHes onto the in-memory config
     // *before* anything derives from it. The server bind address

--- a/vtc-service/src/store/keyspaces.rs
+++ b/vtc-service/src/store/keyspaces.rs
@@ -60,6 +60,47 @@ pub const ALL: &[&str] = &[
     AUDIT_KEY,
 ];
 
+/// Keyspaces captured by `POST /v1/backup/export` (P3.9). These hold
+/// the community's durable, irreplaceable state. `audit` is included
+/// only when the caller passes `include_audit = true`; its HMAC key
+/// (`audit_key`) is always included so restored logs stay verifiable.
+///
+/// `BACKED_UP` and [`EXCLUDED_FROM_BACKUP`] must partition [`ALL`]
+/// exactly — enforced by `backup_partition_is_total`. The signing key
+/// bundle is NOT a keyspace (it lives in the `secrets` backend) and is
+/// captured separately by the backup payload.
+pub const BACKED_UP: &[&str] = &[
+    ACL,
+    COMMUNITY,
+    MEMBERS,
+    JOIN_REQUESTS,
+    POLICIES,
+    ACTIVE_POLICIES,
+    STATUS_LISTS,
+    RELATIONSHIPS,
+    RELATIONSHIPS_BY_DID,
+    ENDORSEMENT_TYPES,
+    SCHEMAS,
+    ENDORSEMENTS,
+    AUDIT,
+    AUDIT_KEY,
+];
+
+/// Keyspaces deliberately omitted from backup (P3.9): ephemeral auth,
+/// one-shot ceremony state, re-syncable registry mirrors, and config
+/// (carried by the backup payload's config snapshot + re-applied on
+/// import). Restoring these would resurrect stale sessions or clobber
+/// runtime state. Partitions [`ALL`] with [`BACKED_UP`].
+pub const EXCLUDED_FROM_BACKUP: &[&str] = &[
+    SESSIONS,
+    CONFIG,
+    PASSKEY,
+    INSTALL,
+    REGISTRY_RECORDS,
+    SYNC_QUEUE,
+    SYNC_CURSOR,
+];
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -70,6 +111,26 @@ mod tests {
     #[test]
     fn all_matches_app_state_keyspace_count() {
         assert_eq!(ALL.len(), 21, "ALL must list every AppState keyspace");
+    }
+
+    /// The backup census (P3.9): every keyspace is either backed up or
+    /// explicitly excluded — none silently omitted — and the two sets
+    /// are disjoint. This is the guard the design note calls for.
+    #[test]
+    fn backup_partition_is_total() {
+        use std::collections::BTreeSet;
+        let all: BTreeSet<&str> = ALL.iter().copied().collect();
+        let backed: BTreeSet<&str> = BACKED_UP.iter().copied().collect();
+        let excluded: BTreeSet<&str> = EXCLUDED_FROM_BACKUP.iter().copied().collect();
+        assert!(
+            backed.is_disjoint(&excluded),
+            "a keyspace is both backed up and excluded"
+        );
+        let union: BTreeSet<&str> = backed.union(&excluded).copied().collect();
+        assert_eq!(
+            union, all,
+            "backup partition must cover every keyspace in ALL exactly once"
+        );
     }
 
     /// No accidental duplicate in `ALL` (a copy-paste slip would make

--- a/vtc-service/tests/backup.rs
+++ b/vtc-service/tests/backup.rs
@@ -1,0 +1,211 @@
+//! Full-state backup/restore round-trip (P3.9).
+//!
+//! The crypto, parameter-bounds, and `vtc_did`-guard unit tests live in
+//! `src/backup.rs`. These integration tests exercise the real keyspace
+//! census + replay against a `TestVtc`: populate every shape of state,
+//! export, restore into a fresh VTC, and assert byte-identical rows —
+//! plus that excluded keyspaces are *not* resurrected and the signing
+//! key bundle survives. A `PlaintextSecretStore` stands in for the
+//! configured secret backend (deterministic + keyring-free in CI).
+
+use std::path::PathBuf;
+
+use vtc_service::backup::{export_backup, import_backup};
+use vtc_service::keys::seed_store::{PlaintextSecretStore, SecretStore};
+use vtc_service::server::AppState;
+use vtc_service::test_support::TestVtc;
+
+const PW: &str = "twelve-char-pw!!";
+const VTC_DID: &str = "did:key:z6MkBackupRoundTrip";
+
+/// `cfg.save()` (run by import's config restore) writes `config_path` —
+/// point it at a writable file in the test's temp dir.
+async fn set_config_path(state: &AppState, path: PathBuf) {
+    state.config.write().await.config_path = path;
+}
+
+#[tokio::test]
+async fn full_state_roundtrip_restores_rows_and_bundle() {
+    // ── source VTC: seed a representative slice of state + a bundle ──
+    let a = TestVtc::builder().vtc_did(VTC_DID).build().await;
+    set_config_path(&a.state, a.data_dir().join("config.toml")).await;
+    let a_store = PlaintextSecretStore::new(a.data_dir());
+    a_store.set(b"signing-bundle-A").await.unwrap();
+
+    a.state
+        .acl_ks
+        .insert_raw(
+            b"acl:did:key:z6MkMember".to_vec(),
+            br#"{"role":"member"}"#.to_vec(),
+        )
+        .await
+        .unwrap();
+    a.state
+        .members_ks
+        .insert_raw(b"m:1".to_vec(), b"member-row-1".to_vec())
+        .await
+        .unwrap();
+    // a value with non-UTF8 bytes to prove base64 round-trips it
+    a.state
+        .status_lists_ks
+        .insert_raw(b"sl:0".to_vec(), vec![0u8, 1, 2, 0xFF, 0x80])
+        .await
+        .unwrap();
+    // an *excluded* keyspace row that must NOT survive the restore
+    a.state
+        .sessions_ks
+        .insert_raw(b"sess:ephemeral".to_vec(), b"should-not-survive".to_vec())
+        .await
+        .unwrap();
+
+    let envelope = export_backup(&a.state, &a_store, PW, true).await.unwrap();
+    assert_eq!(envelope.format, "vtc-backup-v1");
+    assert_eq!(envelope.source_did.as_deref(), Some(VTC_DID));
+
+    // ── destination VTC: same identity, empty keyspaces + empty store ──
+    let b = TestVtc::builder().vtc_did(VTC_DID).build().await;
+    set_config_path(&b.state, b.data_dir().join("config.toml")).await;
+    let b_store = PlaintextSecretStore::new(b.data_dir());
+
+    let result = import_backup(&b.state, &b_store, &envelope, PW, true)
+        .await
+        .unwrap();
+    assert_eq!(result.status, "imported");
+
+    // backed-up rows restored byte-identically
+    let acl = b
+        .state
+        .acl_ks
+        .prefix_iter_raw(Vec::<u8>::new())
+        .await
+        .unwrap();
+    assert_eq!(acl.len(), 1);
+    assert_eq!(acl[0].0, b"acl:did:key:z6MkMember");
+    assert_eq!(acl[0].1, br#"{"role":"member"}"#.to_vec());
+
+    let members = b
+        .state
+        .members_ks
+        .prefix_iter_raw(Vec::<u8>::new())
+        .await
+        .unwrap();
+    assert_eq!(members.len(), 1);
+    assert_eq!(members[0].1, b"member-row-1");
+
+    let sl = b
+        .state
+        .status_lists_ks
+        .prefix_iter_raw(Vec::<u8>::new())
+        .await
+        .unwrap();
+    assert_eq!(
+        sl[0].1,
+        vec![0u8, 1, 2, 0xFF, 0x80],
+        "binary value must round-trip"
+    );
+
+    // excluded keyspace was NOT resurrected
+    assert!(
+        b.state
+            .sessions_ks
+            .prefix_iter_raw(Vec::<u8>::new())
+            .await
+            .unwrap()
+            .is_empty(),
+        "sessions are excluded from backup and must not be restored"
+    );
+
+    // signing key bundle restored into the destination's secret store
+    assert_eq!(
+        b_store.get().await.unwrap().unwrap(),
+        b"signing-bundle-A",
+        "the signing key bundle must survive the round-trip"
+    );
+}
+
+#[tokio::test]
+async fn preview_does_not_mutate() {
+    let a = TestVtc::builder().vtc_did(VTC_DID).build().await;
+    set_config_path(&a.state, a.data_dir().join("config.toml")).await;
+    let a_store = PlaintextSecretStore::new(a.data_dir());
+    a_store.set(b"bundle").await.unwrap();
+    a.state
+        .acl_ks
+        .insert_raw(b"acl:keep".to_vec(), b"keep".to_vec())
+        .await
+        .unwrap();
+    let envelope = export_backup(&a.state, &a_store, PW, false).await.unwrap();
+
+    let b = TestVtc::builder().vtc_did(VTC_DID).build().await;
+    set_config_path(&b.state, b.data_dir().join("config.toml")).await;
+    let b_store = PlaintextSecretStore::new(b.data_dir());
+    // seed a row that a real import would clear — preview must leave it.
+    b.state
+        .acl_ks
+        .insert_raw(b"acl:pre-existing".to_vec(), b"untouched".to_vec())
+        .await
+        .unwrap();
+
+    let result = import_backup(&b.state, &b_store, &envelope, PW, false)
+        .await
+        .unwrap();
+    assert_eq!(result.status, "preview");
+
+    let acl = b
+        .state
+        .acl_ks
+        .prefix_iter_raw(Vec::<u8>::new())
+        .await
+        .unwrap();
+    assert_eq!(acl.len(), 1, "preview must not clear or write keyspaces");
+    assert_eq!(acl[0].0, b"acl:pre-existing");
+}
+
+#[tokio::test]
+async fn import_rejects_foreign_vtc_did() {
+    let a = TestVtc::builder()
+        .vtc_did("did:key:z6MkSourceIdentity")
+        .build()
+        .await;
+    set_config_path(&a.state, a.data_dir().join("config.toml")).await;
+    let a_store = PlaintextSecretStore::new(a.data_dir());
+    a_store.set(b"bundle").await.unwrap();
+    let envelope = export_backup(&a.state, &a_store, PW, false).await.unwrap();
+
+    // destination is a *different* configured identity → refuse.
+    let b = TestVtc::builder()
+        .vtc_did("did:key:z6MkRunningIdentity")
+        .build()
+        .await;
+    set_config_path(&b.state, b.data_dir().join("config.toml")).await;
+    let b_store = PlaintextSecretStore::new(b.data_dir());
+
+    let err = import_backup(&b.state, &b_store, &envelope, PW, true)
+        .await
+        .unwrap_err();
+    assert!(
+        format!("{err}").contains("vtc_did mismatch"),
+        "expected identity-guard rejection, got: {err}"
+    );
+}
+
+#[tokio::test]
+async fn wrong_password_rejected() {
+    let a = TestVtc::builder().vtc_did(VTC_DID).build().await;
+    set_config_path(&a.state, a.data_dir().join("config.toml")).await;
+    let a_store = PlaintextSecretStore::new(a.data_dir());
+    a_store.set(b"bundle").await.unwrap();
+    let envelope = export_backup(&a.state, &a_store, PW, false).await.unwrap();
+
+    let b = TestVtc::builder().vtc_did(VTC_DID).build().await;
+    set_config_path(&b.state, b.data_dir().join("config.toml")).await;
+    let b_store = PlaintextSecretStore::new(b.data_dir());
+
+    let err = import_backup(&b.state, &b_store, &envelope, "wrong-password!!", true)
+        .await
+        .unwrap_err();
+    assert!(
+        format!("{err}").contains("incorrect backup password"),
+        "{err}"
+    );
+}


### PR DESCRIPTION
## P3.9 — backup / restore (implementation)

Implements the design note merged in #492. The VTC's only export was config; the community's irreplaceable social state — members, ACL, endorsements, relationships, policies, audit, and the **status lists** whose loss bricks every issued VMC's `credentialStatus` — had no export/import path. Disk loss = community loss.

`POST /v1/backup/{export,import}` (super-admin, preview→confirm) capture and restore the whole community in one password-encrypted artifact.

### What it does
- **Crypto** reused verbatim from the VTA: Argon2id (64 MiB / t=3 / p=4) + AES-256-GCM, base64url, 12-char minimum, import-side param bounds (anti-memory-bomb).
- **Keyspace census:** `keyspaces::BACKED_UP` (14) + `EXCLUDED_FROM_BACKUP` (7) partition `ALL` exactly, pinned by `backup_partition_is_total`. `status_lists` + `join_requests` backed up; `sessions`/`passkey`/`install`/`sync_*`/`registry_records`/`config` excluded.
- **Signing key bundle** travels in the encrypted payload, so a restore reconstitutes *signing* (status-list re-issue, VMC minting), not just data. The secret store is **injected** into export/import (the route builds it from config), keeping the core backend-agnostic and headlessly testable.
- **Identity guard** `check_vtc_did_compatibility` mirrors the VTA: fresh install accepts any backup; a configured VTC refuses a foreign `vtc_did` → **409**.
- **Crash-safe import:** a sentinel in the (excluded) `config` keyspace is stamped before the destructive replay and removed on success; boot refuses to start while it's present.
- **Import body cap 64 MiB** via the per-route override the website routes use.

### Tests
- 8 unit (crypto round-trip, wrong password, ciphertext tamper, param-bound rejections, `vtc_did` guard ×3) + the census test.
- 4 integration against `TestVtc`: **full-state round-trip** (rows byte-identical incl. non-UTF8 values + the key bundle), **preview-no-mutate**, **foreign-did → 409**, **wrong-password**.
- Full suite green (**988**); `cargo fmt` + `cargo clippy` clean.

### Docs
Operator guide `docs/03-vtc/backup-restore.md`; workspace + vtc-service CLAUDE.md updated. Design note: `docs/05-design-notes/vtc-backup-restore.md` (#492).

`cnm backup` CLI is a fast follow (the REST surface + admin SPA cover the acceptance criteria).