### PR TITLE
feat(vta-sdk): AgentSession — high-level personal-AI-agent runtime helper

### DIFF
--- a/docs/02-vta/personal-ai-agents.md
+++ b/docs/02-vta/personal-ai-agents.md
@@ -164,6 +164,29 @@ rejected at authentication (`check_acl`), not merely hidden from `device list`.
 `cache`, `cache-and-keys`, or `full`); a wiped device shows in `device list` only
 with `--include-wiped --include-disabled`.
 
+### Building an agent runtime in Rust (`AgentSession`)
+
+An agent runtime (open-claw / nano-claw / hermes) doesn't need to hand-wire the
+connect → enroll → heartbeat → wake-loop plumbing. The SDK's
+`vta_sdk::agent_session::AgentSession` (feature `session`) does it in a few
+calls — `enroll` connects over DIDComm and registers the device (idempotent if
+already enrolled), `run` heartbeats on a cadence and dispatches inbound
+wake/step-up messages to a handler, and `client()` exposes the full VTA surface
+(sign, vault, …):
+
+```rust
+let cfg = AgentConfig::new(client_did, private_key_mb, vta_did, mediator_did)
+    .display_name("nano-claw").platform("linux");
+let agent = AgentSession::enroll(cfg).await?;
+agent.run(|msg| async move {
+    // route on msg.typ — e.g. a push/wake or an auth/step-up request
+    AgentControl::Continue
+}).await?;
+```
+
+The CLI path above and this Rust path are equivalent surfaces over the same
+`device/*` + `vault/*` trust tasks; use whichever fits how the agent is built.
+
 ## Step 4 — Wake / push (operator + agent)
 
 So the VTA can wake a sleeping personal agent when work or an inbound message

--- a/vta-sdk/src/agent_session.rs
+++ b/vta-sdk/src/agent_session.rs
@@ -1,0 +1,346 @@
+//! High-level personal-AI-agent runtime helper.
+//!
+//! `AgentSession` collapses the enroll → heartbeat → wake-loop → vault-access
+//! boilerplate an agent runtime (open-claw / nano-claw / hermes) would otherwise
+//! hand-wire, into a few calls on top of the DIDComm [`VtaClient`]:
+//!
+//! ```no_run
+//! # async fn run() -> Result<(), vta_sdk::error::VtaError> {
+//! # let (client_did, private_key_mb, vta_did, mediator_did) = ("", "", "", "");
+//! use vta_sdk::agent_session::{AgentConfig, AgentSession, AgentControl};
+//!
+//! let cfg = AgentConfig::new(client_did, private_key_mb, vta_did, mediator_did)
+//!     .display_name("nano-claw")
+//!     .platform("linux");
+//! let agent = AgentSession::enroll(cfg).await?;
+//!
+//! // Use the VTA directly when you need to (sign, vault, …):
+//! let _keys = agent.client().list_keys(0, 50, None, None).await?;
+//!
+//! // Or run the event loop: heartbeat + handle inbound wake/step-up messages.
+//! agent.run(|msg| async move {
+//!     println!("inbound {}: {}", msg.typ, msg.body);
+//!     AgentControl::Continue
+//! }).await?;
+//! # Ok(()) }
+//! ```
+//!
+//! Requires the `session` feature (DIDComm transport — the agent receives wakes
+//! via its mediator).
+
+use std::time::Duration;
+
+use serde::Deserialize;
+use serde_json::{Value, json};
+use tracing::{debug, info, warn};
+
+use crate::client::VtaClient;
+use crate::error::VtaError;
+
+/// How long each inbound-poll window waits before the loop checks the heartbeat
+/// timer again. Bounded so a pending heartbeat can't be starved by a quiet
+/// inbound stream.
+const INBOUND_POLL_SECS: u64 = 20;
+
+/// Default heartbeat cadence (seconds) when the caller doesn't set one.
+const DEFAULT_HEARTBEAT_SECS: u64 = 300;
+
+/// Connection + enrolment parameters for an [`AgentSession`].
+///
+/// Build with [`AgentConfig::new`] (fills sensible defaults) then chain the
+/// `with`-style setters.
+#[derive(Debug, Clone)]
+pub struct AgentConfig {
+    /// The agent's own DID (its long-term key, already in the VTA's ACL).
+    pub client_did: String,
+    /// The agent's Ed25519 private key, multibase-encoded.
+    pub private_key_multibase: String,
+    /// The VTA's DID.
+    pub vta_did: String,
+    /// The mediator DID the agent receives through.
+    pub mediator_did: String,
+    /// Optional VTA REST URL (for the REST-fallback surfaces; DIDComm is primary).
+    pub rest_url: Option<String>,
+    /// Human-readable device/agent name.
+    pub display_name: String,
+    /// `consumerKind.serviceKind` for the device binding.
+    pub service_kind: String,
+    /// Platform string (e.g. `linux`, `macos`).
+    pub platform: Option<String>,
+    /// Optional HPKE public key (multibase) for sealed delivery.
+    pub hpke_public_key: Option<String>,
+    /// Heartbeat cadence in seconds.
+    pub heartbeat_secs: u64,
+}
+
+impl AgentConfig {
+    /// New config with defaults: `service_kind = "ai-agent"`,
+    /// `display_name = "agent"`, `heartbeat_secs = 300`.
+    pub fn new(
+        client_did: impl Into<String>,
+        private_key_multibase: impl Into<String>,
+        vta_did: impl Into<String>,
+        mediator_did: impl Into<String>,
+    ) -> Self {
+        Self {
+            client_did: client_did.into(),
+            private_key_multibase: private_key_multibase.into(),
+            vta_did: vta_did.into(),
+            mediator_did: mediator_did.into(),
+            rest_url: None,
+            display_name: "agent".to_string(),
+            service_kind: "ai-agent".to_string(),
+            platform: None,
+            hpke_public_key: None,
+            heartbeat_secs: DEFAULT_HEARTBEAT_SECS,
+        }
+    }
+
+    /// Set the display name.
+    pub fn display_name(mut self, v: impl Into<String>) -> Self {
+        self.display_name = v.into();
+        self
+    }
+
+    /// Override the Service kind (defaults to `ai-agent`).
+    pub fn service_kind(mut self, v: impl Into<String>) -> Self {
+        self.service_kind = v.into();
+        self
+    }
+
+    /// Set the platform string.
+    pub fn platform(mut self, v: impl Into<String>) -> Self {
+        self.platform = Some(v.into());
+        self
+    }
+
+    /// Set the REST URL.
+    pub fn rest_url(mut self, v: impl Into<String>) -> Self {
+        self.rest_url = Some(v.into());
+        self
+    }
+
+    /// Set the HPKE public key (multibase).
+    pub fn hpke_public_key(mut self, v: impl Into<String>) -> Self {
+        self.hpke_public_key = Some(v.into());
+        self
+    }
+
+    /// Set the heartbeat cadence (seconds). Clamped to ≥ 1.
+    pub fn heartbeat_secs(mut self, secs: u64) -> Self {
+        self.heartbeat_secs = secs.max(1);
+        self
+    }
+}
+
+/// Whether the agent event loop should keep running after a handler call.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AgentControl {
+    /// Keep running.
+    Continue,
+    /// Stop the loop and shut the session down cleanly.
+    Stop,
+}
+
+/// A decoded inbound DIDComm message (a VTA-pushed wake, step-up request, …).
+#[derive(Debug, Clone)]
+pub struct InboundMessage {
+    /// The message id.
+    pub id: String,
+    /// The message `type` URI (use this to route).
+    pub typ: String,
+    /// The authenticated sender DID, if present.
+    pub from: Option<String>,
+    /// The message body.
+    pub body: Value,
+}
+
+impl InboundMessage {
+    /// Parse the serialized DIDComm message JSON yielded by
+    /// [`VtaClient::receive_next`]. Lenient: missing fields default rather than
+    /// failing, so an unusual envelope still routes on whatever it carries.
+    pub fn parse(json: &str) -> Result<Self, VtaError> {
+        #[derive(Deserialize)]
+        struct Wire {
+            #[serde(default)]
+            id: String,
+            #[serde(rename = "type", default)]
+            typ: String,
+            #[serde(default)]
+            from: Option<String>,
+            #[serde(default)]
+            body: Value,
+        }
+        let w: Wire = serde_json::from_str(json)?;
+        Ok(Self {
+            id: w.id,
+            typ: w.typ,
+            from: w.from,
+            body: w.body,
+        })
+    }
+}
+
+/// A connected, enrolled personal-AI-agent session.
+pub struct AgentSession {
+    client: VtaClient,
+    config: AgentConfig,
+}
+
+impl AgentSession {
+    /// Connect over DIDComm and ensure the agent is enrolled as a device.
+    ///
+    /// Idempotent on enrolment: if the device is already registered the existing
+    /// binding is reused (re-registration would otherwise conflict). On any
+    /// other failure the half-open session is shut down before returning.
+    pub async fn enroll(config: AgentConfig) -> Result<Self, VtaError> {
+        let client = VtaClient::connect_didcomm(
+            &config.client_did,
+            &config.private_key_multibase,
+            &config.vta_did,
+            &config.mediator_did,
+            config.rest_url.clone(),
+        )
+        .await?;
+
+        let consumer_kind = json!({ "kind": "service", "serviceKind": config.service_kind });
+        match client
+            .device_register(
+                consumer_kind,
+                &config.display_name,
+                config.platform.as_deref(),
+                config.hpke_public_key.as_deref(),
+            )
+            .await
+        {
+            Ok(_) => info!(did = %config.client_did, "agent device registered"),
+            Err(e) if is_already_registered(&e) => {
+                debug!(did = %config.client_did, "agent already registered; reusing binding");
+            }
+            Err(e) => {
+                client.shutdown().await;
+                return Err(e);
+            }
+        }
+
+        Ok(Self { client, config })
+    }
+
+    /// The underlying authenticated client — use it for vault, signing, and any
+    /// other VTA operation the agent needs.
+    pub fn client(&self) -> &VtaClient {
+        &self.client
+    }
+
+    /// Run the agent event loop until `handler` returns [`AgentControl::Stop`] or
+    /// the inbound stream errors: heartbeats on the configured cadence and
+    /// dispatches each inbound DIDComm message to `handler`. Always shuts the
+    /// session down before returning.
+    ///
+    /// Heartbeat failures are logged and retried on the next tick (transient
+    /// mediator hiccups shouldn't kill the loop); an inbound-stream error is
+    /// terminal.
+    pub async fn run<H, Fut>(&self, mut handler: H) -> Result<(), VtaError>
+    where
+        H: FnMut(InboundMessage) -> Fut,
+        Fut: std::future::Future<Output = AgentControl>,
+    {
+        let mut ticker = tokio::time::interval(Duration::from_secs(self.config.heartbeat_secs));
+        // The first tick fires immediately; consume it so we don't heartbeat
+        // before the loop has even polled for inbound work.
+        ticker.tick().await;
+
+        let result = loop {
+            tokio::select! {
+                _ = ticker.tick() => {
+                    if let Err(e) = self.client.device_heartbeat(self.config.platform.as_deref()).await {
+                        warn!(error = %e, "agent heartbeat failed; retrying next tick");
+                    }
+                }
+                inbound = self.client.receive_next(INBOUND_POLL_SECS) => {
+                    match inbound {
+                        Ok(Some(json)) => match InboundMessage::parse(&json) {
+                            Ok(msg) => {
+                                if handler(msg).await == AgentControl::Stop {
+                                    break Ok(());
+                                }
+                            }
+                            Err(e) => warn!(error = %e, "dropping unparseable inbound message"),
+                        },
+                        Ok(None) => {} // poll window elapsed with nothing — loop
+                        Err(e) => break Err(e),
+                    }
+                }
+            }
+        };
+
+        self.client.shutdown().await;
+        result
+    }
+
+    /// Shut the DIDComm session down cleanly. Call this if you used the session
+    /// without [`Self::run`] (which shuts down on its own).
+    pub async fn shutdown(&self) {
+        self.client.shutdown().await;
+    }
+}
+
+/// Treat a `device/register` conflict as "already enrolled". The reject surfaces
+/// differently per transport (a `Conflict` over REST, a `Protocol` reject
+/// carrying `already_registered` over DIDComm), so match on both.
+fn is_already_registered(e: &VtaError) -> bool {
+    matches!(e, VtaError::Conflict(_)) || e.to_string().contains("already_registered")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_defaults_then_builders() {
+        let cfg = AgentConfig::new("did:key:zA", "zKey", "did:key:zVta", "did:key:zMed")
+            .display_name("nano-claw")
+            .platform("linux")
+            .heartbeat_secs(0); // clamps to 1
+        assert_eq!(cfg.service_kind, "ai-agent");
+        assert_eq!(cfg.display_name, "nano-claw");
+        assert_eq!(cfg.platform.as_deref(), Some("linux"));
+        assert_eq!(cfg.heartbeat_secs, 1, "heartbeat clamps to >= 1");
+    }
+
+    #[test]
+    fn inbound_message_parses_didcomm_envelope() {
+        let json = r#"{
+            "id": "urn:uuid:abc",
+            "type": "https://trusttasks.org/spec/push/wake/0.1",
+            "from": "did:key:zVta",
+            "body": { "reason": "work-available" }
+        }"#;
+        let msg = InboundMessage::parse(json).unwrap();
+        assert_eq!(msg.id, "urn:uuid:abc");
+        assert_eq!(msg.typ, "https://trusttasks.org/spec/push/wake/0.1");
+        assert_eq!(msg.from.as_deref(), Some("did:key:zVta"));
+        assert_eq!(msg.body["reason"], "work-available");
+    }
+
+    #[test]
+    fn inbound_message_is_lenient_about_missing_fields() {
+        // A sparse envelope still parses; absent fields default.
+        let msg = InboundMessage::parse(r#"{"type":"x/1.0"}"#).unwrap();
+        assert_eq!(msg.typ, "x/1.0");
+        assert!(msg.id.is_empty());
+        assert!(msg.from.is_none());
+        assert!(msg.body.is_null());
+    }
+
+    #[test]
+    fn already_registered_is_detected_across_transports() {
+        assert!(is_already_registered(&VtaError::Conflict("dup".into())));
+        assert!(is_already_registered(&VtaError::Protocol(
+            "trust task rejected: device/register:already_registered — ...".into()
+        )));
+        assert!(!is_already_registered(&VtaError::Protocol(
+            "something else".into()
+        )));
+    }
+}

--- a/vta-sdk/src/client/mod.rs
+++ b/vta-sdk/src/client/mod.rs
@@ -663,6 +663,24 @@ impl VtaClient {
         }
     }
 
+    /// Wait up to `timeout_secs` for the next **unsolicited** inbound DIDComm
+    /// message (e.g. a VTA-pushed wake / step-up request), returning the
+    /// serialized DIDComm `Message` JSON. `Ok(None)` on timeout with nothing
+    /// received. DIDComm-only — the inbound live stream needs the session.
+    ///
+    /// This is the receive half of an agent's event loop (see
+    /// `agent_session::AgentSession`).
+    #[cfg_attr(not(feature = "session"), allow(unused_variables))]
+    pub async fn receive_next(&self, timeout_secs: u64) -> Result<Option<String>, VtaError> {
+        match &self.transport {
+            #[cfg(feature = "session")]
+            Transport::DIDComm { session, .. } => session.receive_next(timeout_secs).await,
+            Transport::Rest { .. } => Err(VtaError::UnsupportedTransport(
+                "receiving inbound messages requires the DIDComm transport".into(),
+            )),
+        }
+    }
+
     // ── Health ───────────────────────────────────────────────────────
 
     /// GET /health (always REST, unauthenticated)

--- a/vta-sdk/src/lib.rs
+++ b/vta-sdk/src/lib.rs
@@ -70,6 +70,8 @@
 //! ## Module map
 //!
 //! * [`client`] — synchronous REST client + typed request/response shapes
+//! * `agent_session` (feature `session`) — high-level personal-AI-agent runtime:
+//!   enroll + heartbeat + inbound-wake loop on top of the DIDComm client
 //! * [`didcomm_session`] / [`didcomm_light`] — DIDComm transport
 //! * [`session`] — credential storage, login, refresh-token rotation
 //! * [`sealed_transfer`] — HPKE envelope (seal/open/armor/verify)
@@ -85,6 +87,8 @@ pub mod hex;
 pub mod context_path;
 pub mod identifier;
 
+#[cfg(feature = "session")]
+pub mod agent_session;
 #[cfg(feature = "attest-verify")]
 pub mod attestation;
 #[cfg(feature = "client")]


### PR DESCRIPTION
## What & why

The ergonomics companion to the agent surface. An agent runtime (open-claw / nano-claw / hermes) currently has to hand-wire connect → enroll → heartbeat → wake-loop → vault-access against the raw `VtaClient`. `AgentSession` collapses that into a few calls.

```rust
let cfg = AgentConfig::new(client_did, private_key_mb, vta_did, mediator_did)
    .display_name("nano-claw").platform("linux");
let agent = AgentSession::enroll(cfg).await?;

let _keys = agent.client().list_keys(0, 50, None, None).await?;   // full VTA surface

agent.run(|msg| async move {                                       // event loop
    // route on msg.typ — push/wake, auth/step-up, …
    AgentControl::Continue
}).await?;
```

## API
- **`AgentConfig::new(...)`** + `with`-style setters; `service_kind` defaults to `ai-agent`, heartbeat to 300s.
- **`AgentSession::enroll(cfg)`** — connect over DIDComm + register the device. Idempotent: an already-registered device reuses its binding (handled across transports — a `Conflict` over REST, an `already_registered` `Protocol` reject over DIDComm). Shuts the half-open session down on other failures.
- **`AgentSession::run(handler)`** — heartbeat on the configured cadence + dispatch each inbound DIDComm message (parsed into `InboundMessage { id, typ, from, body }`) to the handler until it returns `AgentControl::Stop` or the inbound stream errors. Heartbeat failures are logged + retried; always shuts down before returning.
- **`client()`** — the underlying `VtaClient` for sign/vault/etc.
- New **`VtaClient::receive_next(timeout)`** — DIDComm-only inbound receive (the receive half of the loop), mirroring the existing seal/open helper gating.

Feature-gated on `session` (DIDComm transport — the agent receives wakes via its mediator).

## Testing
- Unit tests: config defaults/builders (incl. heartbeat clamp), `InboundMessage::parse` (full + lenient/sparse), already-registered detection across transports; plus a doctest.
- `cargo test -p vta-sdk --features client,session` → 201 lib tests pass; `clippy -D warnings` ✅; `fmt` ✅; `cargo check --workspace` ✅ (pnm-cli / vta-mcp on `session` unaffected).

## Caveat (called out as a known limit)
The `run` event loop needs a live VTA + mediator to exercise end-to-end, so it isn't covered by CI — the **pure** pieces (config, message parsing, conflict detection) are unit-tested, and the loop is deliberately thin (heartbeat tick + `receive_next` + handler dispatch). A live-VTA integration test is the natural follow-up.

## Follow-ups
- `vta-mcp` could be refactored to run on top of `AgentSession` (it currently wraps `VtaClient` directly).
- Live-VTA integration test for the loop.