### PR TITLE
feat(cnm): `cnm backup export/import` (P3.9 follow-on)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2352,12 +2352,13 @@ checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cnm-cli"
-version = "0.9.2"
+version = "0.10.0"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "clap",
  "dialoguer",
  "dirs",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "tokio",

--- a/cnm-cli/Cargo.toml
+++ b/cnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cnm-cli"
 description = "CLI Tool for Verified Trust Agents operating in Verified Trust Communities"
-version = "0.9.2"
+version = "0.10.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -29,6 +29,9 @@ dialoguer = { workspace = true }
 dirs = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+# Direct REST POST for `cnm backup` (the VTC backup routes are REST-only,
+# super-admin); forces REST regardless of the session's preferred transport.
+reqwest = { workspace = true }
 toml = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/cnm-cli/src/backup.rs
+++ b/cnm-cli/src/backup.rs
@@ -1,0 +1,250 @@
+//! `cnm backup …` — encrypted full-state backup / restore of the VTC
+//! community (the P3.9 REST surface).
+//!
+//! Mirrors `pnm backup` but targets the VTC's `/v1/backup/{export,
+//! import}` endpoints, which return a `vtc-backup-v1` envelope. The CLI
+//! treats the envelope as **opaque JSON** — it never needs the typed
+//! struct, just save/load/forward — so this stays decoupled from the
+//! vtc-service crate.
+//!
+//! Backup is REST-only + super-admin, so we make a direct authenticated
+//! POST (forcing REST regardless of the session's preferred transport)
+//! and attach the `Trust-Task` header the routes require.
+
+use std::io::Write;
+use std::path::PathBuf;
+
+use serde_json::{Value, json};
+use vta_cli_common::render::{DIM, GREEN, RED, RESET};
+use vta_sdk::client::VtaClient;
+
+use crate::auth;
+
+/// Canonical HTTP header carrying the Trust-Task URL (mirrors
+/// `vti_common::trust_task::HEADER_NAME`).
+const TRUST_TASK_HEADER: &str = "Trust-Task";
+const EXPORT_TASK: &str = "https://trusttasks.org/openvtc/vtc/backup/export/1.0";
+const IMPORT_TASK: &str = "https://trusttasks.org/openvtc/vtc/backup/import/1.0";
+
+/// Authenticated REST POST to a VTC `/v1/backup/*` route. `client.base_url()`
+/// already carries the `/v1` mount, so the path here is relative to it.
+async fn authed_post(
+    client: &VtaClient,
+    keyring_key: &str,
+    path: &str,
+    task: &str,
+    body: Value,
+) -> Result<Value, Box<dyn std::error::Error>> {
+    // Refresh / mint a REST bearer token for the VTC (aud = "VTC").
+    let token = auth::ensure_authenticated(client.base_url(), keyring_key).await?;
+    let resp = reqwest::Client::new()
+        .post(format!("{}{path}", client.base_url()))
+        .bearer_auth(&token)
+        .header(TRUST_TASK_HEADER, task)
+        .json(&body)
+        .send()
+        .await?;
+    let status = resp.status();
+    let text = resp.text().await.unwrap_or_default();
+    if !status.is_success() {
+        // Surface the server's error body verbatim — it carries the
+        // actionable message (short password, vtc_did mismatch, …).
+        return Err(format!("VTC backup request failed ({status}): {text}").into());
+    }
+    serde_json::from_str(&text)
+        .map_err(|e| format!("could not parse VTC response: {e} (body: {text})").into())
+}
+
+fn str_field<'a>(v: &'a Value, key: &str) -> &'a str {
+    v.get(key).and_then(Value::as_str).unwrap_or("(none)")
+}
+
+pub(crate) async fn cmd_export(
+    client: &VtaClient,
+    keyring_key: &str,
+    include_audit: bool,
+    output: Option<PathBuf>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let password = dialoguer::Password::new()
+        .with_prompt("Backup password (min 12 chars)")
+        .with_confirmation("Confirm password", "Passwords do not match")
+        .interact()?;
+    if password.len() < 12 {
+        return Err("password must be at least 12 characters".into());
+    }
+
+    println!("Exporting community backup...");
+    let envelope = authed_post(
+        client,
+        keyring_key,
+        "/backup/export",
+        EXPORT_TASK,
+        json!({ "password": password, "include_audit": include_audit }),
+    )
+    .await?;
+
+    let source_did = envelope.get("source_did").and_then(Value::as_str);
+    let path = output.unwrap_or_else(|| {
+        let slug = source_did
+            .and_then(|d| d.rsplit(':').next())
+            .filter(|s| !s.is_empty())
+            .unwrap_or("vtc");
+        PathBuf::from(format!(
+            "vtc-backup-{slug}-{}.vtcbak",
+            file_stamp(&envelope)
+        ))
+    });
+
+    let json_str = serde_json::to_string_pretty(&envelope)?;
+    std::fs::write(&path, &json_str)?;
+
+    println!("{GREEN}✓{RESET} Backup saved to {}", path.display());
+    println!("  Source DID:     {}", source_did.unwrap_or("(none)"));
+    println!(
+        "  Includes audit: {}",
+        envelope
+            .get("includes_audit")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+    );
+    println!("  File size:      {} bytes", json_str.len());
+    println!(
+        "{DIM}  The backup contains the community's signing key — store it like a \
+         secret.{RESET}"
+    );
+    Ok(())
+}
+
+pub(crate) async fn cmd_import(
+    client: &VtaClient,
+    keyring_key: &str,
+    file: PathBuf,
+    preview_only: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let json_str = std::fs::read_to_string(&file)?;
+    let envelope: Value = serde_json::from_str(&json_str)
+        .map_err(|e| format!("{} is not a valid backup file: {e}", file.display()))?;
+
+    println!("Backup file: {}", file.display());
+    println!("  Source DID:  {}", str_field(&envelope, "source_did"));
+    println!("  Created:     {}", str_field(&envelope, "created_at"));
+    println!("  Format:      {}", str_field(&envelope, "format"));
+    println!(
+        "  Audit:       {}",
+        envelope
+            .get("includes_audit")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+    );
+
+    let password = dialoguer::Password::new()
+        .with_prompt("Backup password")
+        .interact()?;
+
+    // Preview first (confirm=false) — no mutation, just row counts.
+    println!("Validating backup...");
+    let preview = authed_post(
+        client,
+        keyring_key,
+        "/backup/import",
+        IMPORT_TASK,
+        json!({ "backup": envelope, "password": password, "confirm": false }),
+    )
+    .await?;
+    print_counts(&preview);
+
+    if preview_only {
+        println!("\n{DIM}Preview only — no changes applied.{RESET}");
+        return Ok(());
+    }
+
+    println!();
+    println!("{RED}WARNING: This will REPLACE ALL community state in the VTC.{RESET}");
+    print!("Type 'yes' to confirm: ");
+    std::io::stdout().flush()?;
+    let mut input = String::new();
+    std::io::stdin().read_line(&mut input)?;
+    if input.trim() != "yes" {
+        println!("Import cancelled.");
+        return Ok(());
+    }
+
+    println!("Importing...");
+    let result = authed_post(
+        client,
+        keyring_key,
+        "/backup/import",
+        IMPORT_TASK,
+        json!({ "backup": envelope, "password": password, "confirm": true }),
+    )
+    .await?;
+    println!(
+        "{GREEN}✓{RESET} {}",
+        result
+            .get("message")
+            .and_then(Value::as_str)
+            .unwrap_or("Import complete")
+    );
+    if result.get("status").and_then(Value::as_str) == Some("imported") {
+        println!("  Restart the VTC daemon to serve the restored identity.");
+        println!("  Browser passkeys are not restored — re-enrol via your admin DID.");
+    }
+    Ok(())
+}
+
+/// Print the per-keyspace row counts from an import preview/result.
+fn print_counts(result: &Value) {
+    let Some(counts) = result.get("counts").and_then(Value::as_object) else {
+        return;
+    };
+    if counts.is_empty() {
+        return;
+    }
+    println!();
+    println!("  Rows by keyspace:");
+    for (ks, n) in counts {
+        println!("    {ks}: {}", n.as_u64().unwrap_or(0));
+    }
+}
+
+/// A filename-safe stamp derived from the envelope's `created_at` (the
+/// digits of its ISO-8601 timestamp), avoiding a `chrono` dependency.
+fn file_stamp(envelope: &Value) -> String {
+    let created = envelope
+        .get("created_at")
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    let digits: String = created
+        .chars()
+        .filter(char::is_ascii_digit)
+        .take(14)
+        .collect();
+    if digits.is_empty() {
+        "backup".to_string()
+    } else {
+        digits
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn file_stamp_uses_created_at_digits() {
+        let env = json!({ "created_at": "2026-06-15T14:30:05Z" });
+        assert_eq!(file_stamp(&env), "20260615143005");
+    }
+
+    #[test]
+    fn file_stamp_falls_back_without_timestamp() {
+        assert_eq!(file_stamp(&json!({})), "backup");
+    }
+
+    #[test]
+    fn print_counts_tolerates_missing_or_empty() {
+        // Must not panic on a result without counts or with an empty map.
+        print_counts(&json!({ "status": "imported" }));
+        print_counts(&json!({ "counts": {} }));
+    }
+}

--- a/cnm-cli/src/main.rs
+++ b/cnm-cli/src/main.rs
@@ -1,4 +1,5 @@
 mod auth;
+mod backup;
 mod config;
 mod setup;
 
@@ -18,8 +19,10 @@ use vta_cli_common::render::{CYAN, DIM, GREEN, RED, RESET, YELLOW, print_section
     long_about = "Community Network Manager — community-admin-scoped CLI for the VTA.\n\
                   \n\
                   CNM is deliberately a reduced surface compared to `pnm`:\n\
-                  - No `webvh` / `audit` / `backup` / `keys import` — those are VTA-\n\
-                    operator concerns, not community-admin concerns, and live on pnm.\n\
+                  - No `webvh` / `audit` / `keys import` — those are VTA-operator\n\
+                    concerns, not community-admin concerns, and live on pnm.\n\
+                  - `backup` IS here: it backs up the *community's* state (the VTC),\n\
+                    a community-admin concern, distinct from pnm's VTA backup.\n\
                   - DID-template management is mirrored here because community admins\n\
                     own context-scoped templates.\n\
                   - Contexts + ACL + auth-credential generation are present because\n\
@@ -101,6 +104,12 @@ enum Commands {
     AuthCredential {
         #[command(subcommand)]
         command: AuthCredentialCommands,
+    },
+
+    /// Encrypted full-state backup / restore of the community.
+    Backup {
+        #[command(subcommand)]
+        command: BackupCommands,
     },
 
     /// Sealed-transfer bootstrap (consumer side).
@@ -230,6 +239,27 @@ fn is_online_template_cmd(cmd: &DidTemplateCommands) -> bool {
             | DidTemplateCommands::Init { .. }
             | DidTemplateCommands::ListBuiltins
     )
+}
+
+#[derive(Subcommand)]
+enum BackupCommands {
+    /// Export the community's state to an encrypted backup file.
+    Export {
+        /// Include the audit log (can be large; off by default).
+        #[arg(long)]
+        include_audit: bool,
+        /// Output file path (default: `vtc-backup-<slug>-<ts>.vtcbak`).
+        #[arg(short, long)]
+        output: Option<std::path::PathBuf>,
+    },
+    /// Import the community's state from an encrypted backup file.
+    Import {
+        /// Path to the `.vtcbak` backup file.
+        file: std::path::PathBuf,
+        /// Preview only — show row counts without applying.
+        #[arg(long)]
+        preview: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -1094,6 +1124,15 @@ async fn main() {
                 }
                 Err(e) => Err(e),
             },
+        },
+        Commands::Backup { command } => match command {
+            BackupCommands::Export {
+                include_audit,
+                output,
+            } => backup::cmd_export(&client, &keyring_key, include_audit, output).await,
+            BackupCommands::Import { file, preview } => {
+                backup::cmd_import(&client, &keyring_key, file, preview).await
+            }
         },
         Commands::Bootstrap { command } => match command {
             BootstrapCommands::Request { out, label } => bootstrap_request(out, label),

--- a/docs/03-vtc/backup-restore.md
+++ b/docs/03-vtc/backup-restore.md
@@ -37,8 +37,18 @@ keyspace overlay (its meaningful values ride in the identity snapshot above).
 ## Export
 
 ```sh
+# Prompts for the encryption password (min 12 chars), writes
+# vtc-backup-<slug>-<timestamp>.vtcbak.
+cnm backup export [--include-audit] [--output FILE]
+```
+
+Under the hood this is `POST /v1/backup/export` (super-admin) — to script it
+directly:
+
+```sh
 curl -sS -X POST https://vtc.example.com/v1/backup/export \
   -H "Authorization: Bearer $SUPER_ADMIN_JWT" \
+  -H 'Trust-Task: https://trusttasks.org/openvtc/vtc/backup/export/1.0' \
   -H 'Content-Type: application/json' \
   -d '{"password":"correct-horse-battery-staple","include_audit":true}' \
   > vtc-backup.json
@@ -49,10 +59,19 @@ curl -sS -X POST https://vtc.example.com/v1/backup/export \
 Restore is a two-step **preview → confirm** to prevent fat-finger overwrites.
 
 ```sh
+# Shows the backup's metadata + per-keyspace row counts, then asks you to
+# type "yes" before applying. `--preview` stops after the counts.
+cnm backup import vtc-backup-<slug>-<timestamp>.vtcbak [--preview]
+```
+
+Equivalent REST (the CLI just drives these two calls):
+
+```sh
 # 1. Preview — decrypts, checks identity, returns per-keyspace row counts.
 #    Mutates nothing.
 curl -sS -X POST https://vtc.example.com/v1/backup/import \
   -H "Authorization: Bearer $SUPER_ADMIN_JWT" \
+  -H 'Trust-Task: https://trusttasks.org/openvtc/vtc/backup/import/1.0' \
   -H 'Content-Type: application/json' \
   -d "$(jq -n --slurpfile b vtc-backup.json \
         '{backup:$b[0], password:"correct-horse-battery-staple", confirm:false}')"

--- a/tasks/vtc-architecture-todo.md
+++ b/tasks/vtc-architecture-todo.md
@@ -241,10 +241,11 @@ the #457 posture backstop provides its regression guard.)
 **Checkpoint 3:** `[x]` **Phase 3 complete.** P3.1 (#465/#466), P3.2 (#490),
 P3.3 (#467), P3.4 (#469), P3.5 (#470), P3.6 (#473/#474), P3.7 (#472), P3.8
 (#487), P3.9 (#492 design + #494 impl), P3.10 (#491), P3.11 (#475), P3.12
-(#476), P3.13 (#478–#484) all merged; full suite green on each. Optional
-follow-on: a `cnm backup` CLI over the P3.9 REST surface (admin SPA + REST
-already cover the acceptance criteria). **The VTC architecture
-simplification & hardening todo is complete — all of Phase 0–3 merged.**
+(#476), P3.13 (#478–#484) all merged; full suite green on each. Follow-on
+shipped: `cnm backup export/import` over the P3.9 REST surface (raw authed
+REST + Trust-Task header, opaque-JSON envelope, preview→confirm). **The VTC
+architecture simplification & hardening todo is complete — all of Phase 0–3
+merged.**
 
 ---
 


### PR DESCRIPTION
## `cnm backup` — community backup/restore CLI

The fast-follow noted in the P3.9 closeout: brings `cnm` to parity with `pnm backup`, targeting the VTC's `/v1/backup/{export,import}` endpoints (shipped in #494).

- **`cnm backup export [--include-audit] [--output FILE]`** — prompts for the password (min 12), writes `vtc-backup-<slug>-<ts>.vtcbak`, and warns that the file contains the signing key.
- **`cnm backup import <file> [--preview]`** — shows the envelope metadata + per-keyspace row counts, then **preview → confirm** (type `yes`) before applying; `--preview` stops after the counts.

### Implementation notes
- The VTC backup routes are **REST-only + super-admin** and return a `vtc-backup-v1` envelope. So the CLI makes a **direct authenticated POST** (forcing REST regardless of the session's preferred DIDComm/REST transport) with the required `Trust-Task` header, and treats the envelope as **opaque JSON** — `cnm-cli` stays decoupled from `vtc-service`.
- Token via the existing `auth::ensure_authenticated`; base URL from the connected `VtaClient` (already carries the `/v1` mount, since cnm's context/acl commands hit `{base}/contexts` etc.).
- Updated the cnm `long_about` (backup IS a community-admin concern — the *community's* state — distinct from pnm's VTA backup) and the operator doc (`docs/03-vtc/backup-restore.md`) to lead with the CLI.

### Validation
- `cargo build`/`clippy`/`fmt` clean; 3 unit tests for the filename-stamp + counts helpers; `cnm backup --help` verified.
- `cnm-cli` 0.9.2 → 0.10.0.

With this, the P3.9 follow-on is shipped and Phase 3 is fully wrapped (todo updated).