### PR TITLE
refactor(vta-mcp): build on AgentSession; optional --enroll as a managed device

### DIFF
--- a/vta-mcp/README.md
+++ b/vta-mcp/README.md
@@ -6,9 +6,10 @@ host (Claude Desktop, an agent framework, an IDE) can use a VTA — signing
 oracle, secrets vault, device check-in, discovery — with **no custom
 integration code**.
 
-It's a thin bridge: each tool maps one-to-one onto a `vta_sdk::VtaClient`
-method. Transport is **stdio** (the host spawns the binary and speaks JSON-RPC
-over stdin/stdout); all logging goes to stderr.
+It's a thin bridge built on `vta_sdk::agent_session::AgentSession`: each tool
+maps one-to-one onto the session's `VtaClient`. Transport is **stdio** (the host
+spawns the binary and speaks JSON-RPC over stdin/stdout); all logging goes to
+stderr.
 
 ## Tools
 
@@ -59,6 +60,19 @@ Add to the host's MCP server config:
   }
 }
 ```
+
+## Enrolling the bridge as a managed device
+
+Pass `--enroll` (or `VTA_MCP_ENROLL=1`) to register vta-mcp as an `ai-agent`
+device at startup, so it shows up in `pnm device list` and can be revoked with
+`pnm device disable` / `pnm device wipe` (the revocation is enforced at auth).
+Set the binding name with `--device-name` (default `vta-mcp`).
+
+Only use `--enroll` when vta-mcp runs as a **dedicated agent identity** — it
+attaches a device binding to the authenticated DID's ACL entry, so don't point it
+at an operator/admin login. Enrolment runs once before serving; the bridge does
+not run a concurrent heartbeat/wake loop (that would race the tool RPCs on the
+same DIDComm session).
 
 ## Notes
 

--- a/vta-mcp/src/main.rs
+++ b/vta-mcp/src/main.rs
@@ -23,6 +23,7 @@ use std::sync::Arc;
 use clap::Parser;
 use rmcp::ServiceExt;
 use rmcp::transport::stdio;
+use vta_sdk::agent_session::{AgentConfig, AgentSession};
 use vta_sdk::client::VtaClient;
 use vta_sdk::session::SessionStore;
 
@@ -51,6 +52,17 @@ struct Args {
     /// or required in token mode).
     #[arg(long, env = "VTA_URL")]
     url: Option<String>,
+
+    /// Register this bridge as an `ai-agent` device at startup, so it appears in
+    /// `pnm device list` and can be revoked with `pnm device {disable,wipe}`.
+    /// Only use this when vta-mcp runs as a *dedicated* agent identity — it
+    /// attaches a device binding to the authenticated DID's ACL entry. Idempotent.
+    #[arg(long, env = "VTA_MCP_ENROLL")]
+    enroll: bool,
+
+    /// Display name for the device binding when `--enroll` is set.
+    #[arg(long, env = "VTA_MCP_DEVICE_NAME", default_value = "vta-mcp")]
+    device_name: String,
 }
 
 #[tokio::main]
@@ -63,9 +75,18 @@ async fn main() -> anyhow::Result<()> {
 
     let args = Args::parse();
     let client = build_client(&args).await?;
+
+    // Wrap the connected client in an AgentSession — the unified handle the MCP
+    // tools route through. Optionally enroll as a managed device first (one-shot,
+    // before serving — never concurrently with tool RPCs on a DIDComm session).
+    let agent = AgentSession::from_client(client, AgentConfig::for_attach(&args.device_name));
+    if args.enroll {
+        agent.ensure_enrolled().await?;
+        tracing::info!(device = %args.device_name, "vta-mcp enrolled as a managed device");
+    }
     tracing::info!("vta-mcp connected to VTA; serving MCP over stdio");
 
-    let service = VtaMcp::new(Arc::new(client)).serve(stdio()).await?;
+    let service = VtaMcp::new(Arc::new(agent)).serve(stdio()).await?;
     service.waiting().await?;
     Ok(())
 }

--- a/vta-mcp/src/server.rs
+++ b/vta-mcp/src/server.rs
@@ -17,7 +17,7 @@ use rmcp::{ErrorData as McpError, ServerHandler, tool, tool_handler, tool_router
 use schemars::JsonSchema;
 use serde::Deserialize;
 use serde_json::Value;
-use vta_sdk::client::VtaClient;
+use vta_sdk::agent_session::AgentSession;
 use vta_sdk::error::VtaError;
 use vta_sdk::protocols::key_management::sign::SignAlgorithm;
 
@@ -94,23 +94,28 @@ pub struct DeviceHeartbeatParams {
     pub platform: Option<String>,
 }
 
-/// MCP server bridging to a single authenticated [`VtaClient`].
+/// MCP server bridging to a single authenticated agent session.
 #[derive(Clone)]
 pub struct VtaMcp {
-    client: Arc<VtaClient>,
+    agent: Arc<AgentSession>,
 }
 
 #[tool_router]
 impl VtaMcp {
-    pub fn new(client: Arc<VtaClient>) -> Self {
-        Self { client }
+    pub fn new(agent: Arc<AgentSession>) -> Self {
+        Self { agent }
+    }
+
+    /// The VTA client behind the session — every tool routes through this.
+    fn client(&self) -> &vta_sdk::client::VtaClient {
+        self.agent.client()
     }
 
     #[tool(
         description = "Discover the connected VTA's capabilities: enabled features, advertised services, WebVH servers, and supported DID-creation modes."
     )]
     async fn vta_capabilities(&self) -> Result<CallToolResult, McpError> {
-        let caps = self.client.capabilities().await.map_err(to_mcp)?;
+        let caps = self.client().capabilities().await.map_err(to_mcp)?;
         ok_json(caps)
     }
 
@@ -120,7 +125,7 @@ impl VtaMcp {
         Parameters(p): Parameters<ListKeysParams>,
     ) -> Result<CallToolResult, McpError> {
         let keys = self
-            .client
+            .client()
             .list_keys(
                 p.offset.unwrap_or(0),
                 p.limit.unwrap_or(50),
@@ -150,7 +155,7 @@ impl VtaMcp {
             }
         };
         let resp = self
-            .client
+            .client()
             .sign(&p.key_id, p.text.as_bytes(), algorithm)
             .await
             .map_err(to_mcp)?;
@@ -168,7 +173,7 @@ impl VtaMcp {
         Parameters(p): Parameters<VaultListParams>,
     ) -> Result<CallToolResult, McpError> {
         let result = self
-            .client
+            .client()
             .vault_list(p.filters.unwrap_or_else(|| serde_json::json!({})))
             .await
             .map_err(to_mcp)?;
@@ -180,7 +185,7 @@ impl VtaMcp {
         &self,
         Parameters(p): Parameters<VaultGetParams>,
     ) -> Result<CallToolResult, McpError> {
-        let result = self.client.vault_get(&p.id).await.map_err(to_mcp)?;
+        let result = self.client().vault_get(&p.id).await.map_err(to_mcp)?;
         ok_json(result)
     }
 
@@ -195,14 +200,18 @@ impl VtaMcp {
         if let Some(t) = p.target {
             payload["target"] = t;
         }
-        let response = self.client.vault_release(payload).await.map_err(to_mcp)?;
+        let response = self.client().vault_release(payload).await.map_err(to_mcp)?;
         match response
             .get("sealedSecret")
             .and_then(|s| s.get("jwe"))
             .and_then(|j| j.as_str())
         {
             Some(jwe) => {
-                let secret = self.client.open_sealed_secret(jwe).await.map_err(to_mcp)?;
+                let secret = self
+                    .client()
+                    .open_sealed_secret(jwe)
+                    .await
+                    .map_err(to_mcp)?;
                 ok_json(secret)
             }
             // No openable envelope (e.g. an unsupported variant) — hand back the
@@ -219,7 +228,7 @@ impl VtaMcp {
         Parameters(p): Parameters<DeviceHeartbeatParams>,
     ) -> Result<CallToolResult, McpError> {
         let result = self
-            .client
+            .client()
             .device_heartbeat(p.platform.as_deref())
             .await
             .map_err(to_mcp)?;

--- a/vta-sdk/src/agent_session.rs
+++ b/vta-sdk/src/agent_session.rs
@@ -131,6 +131,15 @@ impl AgentConfig {
         self.heartbeat_secs = secs.max(1);
         self
     }
+
+    /// Config for wrapping an **already-connected** client via
+    /// [`AgentSession::from_client`]. The connection fields (DID, key, mediator)
+    /// are left empty — they're unused once a client exists; only the enrolment
+    /// fields (`display_name`, `service_kind`, `platform`, `heartbeat_secs`)
+    /// apply. Chain the setters to customise.
+    pub fn for_attach(display_name: impl Into<String>) -> Self {
+        Self::new("", "", "", "").display_name(display_name)
+    }
 }
 
 /// Whether the agent event loop should keep running after a handler call.
@@ -203,27 +212,46 @@ impl AgentSession {
         )
         .await?;
 
-        let consumer_kind = json!({ "kind": "service", "serviceKind": config.service_kind });
-        match client
+        let session = Self::from_client(client, config);
+        if let Err(e) = session.ensure_enrolled().await {
+            session.client.shutdown().await;
+            return Err(e);
+        }
+        Ok(session)
+    }
+
+    /// Wrap an **already-connected** [`VtaClient`] (built however the caller
+    /// likes — `connect_didcomm`, a stored session, a bearer token) as an agent
+    /// session, without enrolling. Use this when the connection is established
+    /// elsewhere (e.g. a bridge that reuses an operator login) and you only want
+    /// the unified `client()` accessor + optional [`Self::ensure_enrolled`] /
+    /// [`Self::run`]. Pair with [`AgentConfig::for_attach`].
+    pub fn from_client(client: VtaClient, config: AgentConfig) -> Self {
+        Self { client, config }
+    }
+
+    /// Register this identity as a device, idempotently (an already-registered
+    /// device reuses its binding). Safe to call once at startup; do **not** call
+    /// it concurrently with in-flight RPCs on a DIDComm session.
+    pub async fn ensure_enrolled(&self) -> Result<(), VtaError> {
+        let consumer_kind = json!({ "kind": "service", "serviceKind": self.config.service_kind });
+        match self
+            .client
             .device_register(
                 consumer_kind,
-                &config.display_name,
-                config.platform.as_deref(),
-                config.hpke_public_key.as_deref(),
+                &self.config.display_name,
+                self.config.platform.as_deref(),
+                self.config.hpke_public_key.as_deref(),
             )
             .await
         {
-            Ok(_) => info!(did = %config.client_did, "agent device registered"),
+            Ok(_) => info!(name = %self.config.display_name, "agent device registered"),
             Err(e) if is_already_registered(&e) => {
-                debug!(did = %config.client_did, "agent already registered; reusing binding");
+                debug!(name = %self.config.display_name, "agent already registered; reusing binding");
             }
-            Err(e) => {
-                client.shutdown().await;
-                return Err(e);
-            }
+            Err(e) => return Err(e),
         }
-
-        Ok(Self { client, config })
+        Ok(())
     }
 
     /// The underlying authenticated client — use it for vault, signing, and any
@@ -331,6 +359,21 @@ mod tests {
         assert!(msg.id.is_empty());
         assert!(msg.from.is_none());
         assert!(msg.body.is_null());
+    }
+
+    #[test]
+    fn from_client_wraps_without_enrolling() {
+        // `from_client` is pure wiring — no network — so a REST client built
+        // offline is enough to exercise it.
+        let client = VtaClient::new("http://localhost:9999");
+        let session = AgentSession::from_client(
+            client,
+            AgentConfig::for_attach("vta-mcp").service_kind("ai-agent"),
+        );
+        assert_eq!(session.config.display_name, "vta-mcp");
+        assert_eq!(session.config.service_kind, "ai-agent");
+        // The unified accessor is available for callers that only need the client.
+        let _ = session.client();
     }
 
     #[test]


### PR DESCRIPTION
## What & why

Refactors `vta-mcp` to build on `AgentSession` (from #496) instead of holding a bare `VtaClient`, unifying the agent surface — and adds an opt-in for the bridge to **manage itself as a revocable device**.

## vta-sdk — `AgentSession` factoring (no behavior change to `enroll`)
- **`AgentSession::from_client(client, config)`** — wrap an already-connected client (built however: `connect_didcomm`, a stored session, a bearer token) *without* enrolling.
- **`AgentSession::ensure_enrolled()`** — idempotent device registration, extracted from `enroll`. `enroll` is now `connect → from_client → ensure_enrolled` (identical behavior).
- **`AgentConfig::for_attach(display_name)`** — config for the `from_client` path (connection fields unused).

## vta-mcp
- `VtaMcp` holds `Arc<AgentSession>`; every tool routes through `agent.client()`.
- **`--enroll`** (`VTA_MCP_ENROLL`) registers the bridge as an `ai-agent` device at startup, so it shows up in `pnm device list` and can be revoked with `pnm device disable` / `pnm device wipe` (enforced at auth, per #493). `--device-name` sets the binding name (default `vta-mcp`).
- **Token/session auth modes unchanged; default behavior is identical to before.**

## The one real constraint (why no background loop)
The bridge does **not** run `AgentSession::run` / a concurrent heartbeat alongside serving tool calls. Both the loop's `receive_next` and a tool's `send_and_wait` read the same DIDComm live stream and would steal each other's responses. So `--enroll` does a **one-shot** registration *before* serving — safe — and that's the extent of the AgentSession lifecycle vta-mcp uses. Documented in the README + code.

## Testing
- New `from_client_wraps_without_enrolling` unit test; existing `agent_session` (5) + vta-mcp tool-router tests pass.
- **Live stdio MCP smoke test** still lists all 7 tools after the refactor (`initialize` + `tools/list`).
- `clippy -D warnings` ✅, `fmt` ✅, `cargo check --workspace` ✅.

## Follow-ups (unchanged)
- `resolve_did` / `issue_vp` MCP tools.
- Live-VTA integration test for the agent loop + sealed-vault round-trip.