### PR TITLE
feat(vta-mcp): expose the full VTA surface — generic vta_call + catalog, resolve_did, issue_vp

### DIFF
--- a/vta-mcp/Cargo.toml
+++ b/vta-mcp/Cargo.toml
@@ -10,7 +10,7 @@ repository.workspace = true
 publish = false
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.13", features = ["client", "session", "sealed-transfer"] }
+vta-sdk = { path = "../vta-sdk", version = "0.13", features = ["client", "session", "sealed-transfer", "didcomm", "vp"] }
 rmcp = { version = "1.7", features = ["server", "transport-io", "macros", "schemars"] }
 schemars = "1"
 tokio = { workspace = true }

--- a/vta-mcp/README.md
+++ b/vta-mcp/README.md
@@ -13,6 +13,18 @@ stderr.
 
 ## Tools
 
+The **full** VTA management surface is reachable via two generic tools, plus
+convenience tools for the most common operations and the client-side bits.
+
+**Generic gateway (covers everything):**
+
+| Tool | What it does |
+|---|---|
+| `vta_list_operations` | The catalog of every Trust Task operation URI (contexts, keys, acl, did-management, webvh, did-templates, device, vault, seeds, audit, backup, discovery, …) |
+| `vta_call` | Invoke any operation by URI with a JSON payload — the gateway to the whole management surface |
+
+**Convenience tools (typed, for common ops):**
+
 | Tool | What it does | Capability required |
 |---|---|---|
 | `vta_capabilities` | Discover the VTA's features, services, WebVH servers, DID modes | any auth |
@@ -22,10 +34,21 @@ stderr.
 | `vault_get` | One entry's metadata by id (no secret) | `VaultRead` |
 | `vault_release` | Release a secret sealed to this client; returns cleartext | `FillRelease` (DIDComm only) |
 | `device_heartbeat` | Check the device in; returns queued operations | any auth |
+| `resolve_did` | Resolve any DID to its DID document (via the resolver cache) | any auth |
+| `issue_vp` | Build a holder-bound OID4VP `vp_token` from supplied held credentials, signed with the agent's holder key | holder identity configured |
+
+All access is bounded by the bridge identity's VTA **role / ACL** — scope that
+role to what the agent should be allowed to do (`vta_call` can reach destructive
+operations like `contexts/delete` if the role permits them).
 
 `vault_release` opens a `didcomm-authcrypt` envelope with the client's own keys,
 so it requires the **DIDComm transport** (session mode); on a REST/token client
 it returns a clear `UnsupportedTransport` error.
+
+`issue_vp` signs locally with the agent's holder key — set `VTA_MCP_HOLDER_DID` +
+`VTA_MCP_HOLDER_KEY` (multibase; optional `VTA_MCP_HOLDER_VM_FRAGMENT`, default
+`key-0`). The key stays in the process and is never sent over MCP; without it the
+tool returns a clear "not configured" error.
 
 ## Auth
 

--- a/vta-mcp/src/main.rs
+++ b/vta-mcp/src/main.rs
@@ -63,6 +63,21 @@ struct Args {
     /// Display name for the device binding when `--enroll` is set.
     #[arg(long, env = "VTA_MCP_DEVICE_NAME", default_value = "vta-mcp")]
     device_name: String,
+
+    /// Holder DID for the `issue_vp` tool (the agent's own presentation
+    /// identity). Together with `--holder-key`, enables VP issuance.
+    #[arg(long, env = "VTA_MCP_HOLDER_DID")]
+    holder_did: Option<String>,
+
+    /// Holder Ed25519 signing key (multibase) for `issue_vp`. Stays in this
+    /// process; never sent over MCP.
+    #[arg(long, env = "VTA_MCP_HOLDER_KEY")]
+    holder_key: Option<String>,
+
+    /// Verification-method fragment of the holder DID used as the VP proof's
+    /// `verificationMethod` (`{holder_did}#{fragment}`).
+    #[arg(long, env = "VTA_MCP_HOLDER_VM_FRAGMENT", default_value = "key-0")]
+    holder_vm_fragment: String,
 }
 
 #[tokio::main]
@@ -84,9 +99,23 @@ async fn main() -> anyhow::Result<()> {
         agent.ensure_enrolled().await?;
         tracing::info!(device = %args.device_name, "vta-mcp enrolled as a managed device");
     }
+    // Optional holder identity for the `issue_vp` tool (signs presentations
+    // locally; the key never crosses MCP).
+    let holder = match (&args.holder_did, &args.holder_key) {
+        (Some(did), Some(key)) => {
+            tracing::info!(%did, "issue_vp enabled with configured holder identity");
+            Some(Arc::new(server::HolderIdentity {
+                did: did.clone(),
+                vm_fragment: args.holder_vm_fragment.clone(),
+                key_multibase: key.clone(),
+            }))
+        }
+        _ => None,
+    };
+
     tracing::info!("vta-mcp connected to VTA; serving MCP over stdio");
 
-    let service = VtaMcp::new(Arc::new(agent)).serve(stdio()).await?;
+    let service = VtaMcp::new(Arc::new(agent), holder).serve(stdio()).await?;
     service.waiting().await?;
     Ok(())
 }

--- a/vta-mcp/src/server.rs
+++ b/vta-mcp/src/server.rs
@@ -1,13 +1,17 @@
-//! The MCP server handler: a thin bridge from MCP tool calls to `VtaClient`.
+//! The MCP server handler: a bridge from MCP tool calls to the VTA.
 //!
-//! Each `#[tool]` maps one-to-one onto an SDK method so an MCP-speaking agent
-//! host (Claude Desktop, an agent framework, …) can use a VTA's capabilities —
-//! signing oracle, secrets vault, device check-in, discovery — with no custom
-//! code. Results are returned as JSON content.
+//! The whole VTA management surface is reachable through two generic tools —
+//! `vta_list_operations` (the Trust Task catalog) and `vta_call` (invoke any
+//! operation by URI) — so an MCP-speaking host (Claude Desktop, an agent
+//! framework, …) can drive contexts, keys, acl, did-management, device, vault,
+//! seeds, audit, backup, etc. with no custom code. Convenience `#[tool]`s wrap
+//! the most common operations with typed schemas, plus the client-side bits
+//! (`resolve_did`, `issue_vp`) that aren't Trust Tasks. Results are JSON content.
 //!
 //! Tools that touch secrets (`vault_release`) seal/open `didcomm-authcrypt`
 //! envelopes and therefore require the underlying client to be on the DIDComm
 //! transport; on REST they surface a clear error rather than failing opaquely.
+//! All access is bounded by the bridge identity's VTA role/ACL.
 
 use std::sync::Arc;
 
@@ -94,16 +98,61 @@ pub struct DeviceHeartbeatParams {
     pub platform: Option<String>,
 }
 
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct VtaCallParams {
+    /// The Trust Task operation URI to invoke (from `vta_list_operations`),
+    /// e.g. `https://trusttasks.org/spec/contexts/list/1.0`.
+    pub operation: String,
+    /// The operation's request payload as a JSON object. Omit (or `{}`) for
+    /// operations that take no parameters.
+    #[serde(default)]
+    pub payload: Option<Value>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ResolveDidParams {
+    /// The DID to resolve (any method the resolver supports).
+    pub did: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct IssueVpParams {
+    /// The verifier's `presentation_definition` (DCQL query) as JSON.
+    pub presentation_definition: Value,
+    /// The credentials the agent holds, as a JSON array of
+    /// `{ id, format, claims, vc, vct?, doctype?, supportsHolderBinding? }`.
+    pub held_credentials: Value,
+    /// The verifier's challenge nonce, bound into the VP proof.
+    pub nonce: String,
+    /// The verifier (audience) the VP is bound to.
+    pub audience: String,
+}
+
+/// The agent's own holder identity, used to sign Verifiable Presentations
+/// locally (the key never leaves this process). Configured out-of-band — never
+/// supplied over MCP.
+#[derive(Clone)]
+pub struct HolderIdentity {
+    /// The holder DID.
+    pub did: String,
+    /// Verification-method fragment (e.g. `key-0`).
+    pub vm_fragment: String,
+    /// The holder Ed25519 signing key, multibase-encoded.
+    pub key_multibase: String,
+}
+
 /// MCP server bridging to a single authenticated agent session.
 #[derive(Clone)]
 pub struct VtaMcp {
     agent: Arc<AgentSession>,
+    /// Optional holder identity enabling the `issue_vp` tool.
+    holder: Option<Arc<HolderIdentity>>,
 }
 
 #[tool_router]
 impl VtaMcp {
-    pub fn new(agent: Arc<AgentSession>) -> Self {
-        Self { agent }
+    pub fn new(agent: Arc<AgentSession>, holder: Option<Arc<HolderIdentity>>) -> Self {
+        Self { agent, holder }
     }
 
     /// The VTA client behind the session — every tool routes through this.
@@ -234,6 +283,72 @@ impl VtaMcp {
             .map_err(to_mcp)?;
         ok_json(result)
     }
+
+    #[tool(
+        description = "List every VTA operation reachable via `vta_call` — the catalog of Trust Task URIs (contexts, keys, acl, did-management, webvh, did-templates, device, vault, seeds, audit, backup, discovery, …)."
+    )]
+    async fn vta_list_operations(&self) -> Result<CallToolResult, McpError> {
+        let mut ops: Vec<&str> = vta_sdk::trust_tasks::ALL_URIS.to_vec();
+        ops.sort_unstable();
+        ok_json(serde_json::json!({ "operations": ops }))
+    }
+
+    #[tool(
+        description = "Invoke ANY VTA Trust Task operation by URI with a JSON payload — the generic gateway to the full management surface (contexts, keys, acl, did-management, device, vault, seeds, audit, backup, …). Use `vta_list_operations` to discover URIs. Subject to the bridge identity's role/ACL."
+    )]
+    async fn vta_call(
+        &self,
+        Parameters(p): Parameters<VtaCallParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let payload = p.payload.unwrap_or_else(|| serde_json::json!({}));
+        let result = self
+            .client()
+            .dispatch_trust_task(&p.operation, payload, 30)
+            .await
+            .map_err(to_mcp)?;
+        ok_json(result)
+    }
+
+    #[tool(
+        description = "Resolve any DID to its DID document via the shared resolver cache (independent of the VTA's own identity)."
+    )]
+    async fn resolve_did(
+        &self,
+        Parameters(p): Parameters<ResolveDidParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let doc = self.client().resolve_did(&p.did).await.map_err(to_mcp)?;
+        ok_json(doc)
+    }
+
+    #[tool(
+        description = "Issue a holder-bound Verifiable Presentation (OID4VP vp_token) for a verifier's presentation_definition from the supplied held credentials, signed with this agent's holder key. Requires the bridge to be configured with a holder identity."
+    )]
+    async fn issue_vp(
+        &self,
+        Parameters(p): Parameters<IssueVpParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let holder = self.holder.as_ref().ok_or_else(|| {
+            McpError::invalid_request(
+                "issue_vp is unavailable: no holder identity configured \
+                 (set VTA_MCP_HOLDER_DID + VTA_MCP_HOLDER_KEY)",
+                None,
+            )
+        })?;
+        let held: Vec<vta_sdk::vp::HeldCredential> = serde_json::from_value(p.held_credentials)
+            .map_err(|e| McpError::invalid_params(format!("held_credentials: {e}"), None))?;
+        let vp_token = vta_sdk::vp::issue_vp_token(
+            &holder.did,
+            &holder.vm_fragment,
+            &holder.key_multibase,
+            &p.presentation_definition,
+            &held,
+            &p.nonce,
+            &p.audience,
+        )
+        .await
+        .map_err(|e| McpError::internal_error(format!("issue_vp: {e}"), None))?;
+        ok_json(vp_token)
+    }
 }
 
 #[tool_handler]
@@ -248,10 +363,14 @@ impl ServerHandler for VtaMcp {
         ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
             .with_server_info(server_info)
             .with_instructions(
-                "Bridges a Verifiable Trust Agent (VTA) to MCP. Tools: vta_capabilities, \
-                 list_keys, sign (signing oracle), vault_list, vault_get, vault_release \
-                 (DIDComm only), device_heartbeat. Use list_keys to find a key id before \
-                 sign; secrets never leave the VTA except via vault_release to this client.",
+                "Bridges a Verifiable Trust Agent (VTA) to MCP. Convenience tools: \
+                 vta_capabilities, list_keys, sign (signing oracle), vault_list, vault_get, \
+                 vault_release (DIDComm only), device_heartbeat, resolve_did, issue_vp. \
+                 For the FULL management surface (contexts, keys, acl, did-management, webvh, \
+                 did-templates, device, vault, seeds, audit, backup, …) use vta_list_operations \
+                 to discover operation URIs and vta_call to invoke any of them. All access is \
+                 bounded by the bridge identity's VTA role/ACL; secrets never leave the VTA \
+                 except via vault_release / issue_vp to this client.",
             )
     }
 }
@@ -273,6 +392,10 @@ mod tests {
             "vault_get",
             "vault_release",
             "device_heartbeat",
+            "vta_list_operations",
+            "vta_call",
+            "resolve_did",
+            "issue_vp",
         ];
         let have: Vec<String> = router
             .list_all()

--- a/vta-sdk/src/client/mod.rs
+++ b/vta-sdk/src/client/mod.rs
@@ -564,9 +564,11 @@ impl VtaClient {
     ///   as a rejection and surfaced as an error.
     ///
     /// Used by the `device/*` and `vault/*` client methods, which have no
-    /// dedicated REST route and are reachable only through the dispatcher.
+    /// dedicated REST route and are reachable only through the dispatcher; also
+    /// the generic escape hatch for invoking *any* of the VTA's trust-task
+    /// operations by URI (see `vta_sdk::trust_tasks::ALL_URIS` for the catalog).
     #[cfg_attr(not(feature = "session"), allow(unused_variables))]
-    pub(crate) async fn dispatch_trust_task(
+    pub async fn dispatch_trust_task(
         &self,
         type_uri: &str,
         payload: serde_json::Value,
@@ -679,6 +681,23 @@ impl VtaClient {
                 "receiving inbound messages requires the DIDComm transport".into(),
             )),
         }
+    }
+
+    /// Resolve an **arbitrary** DID to its DID document JSON, via the shared
+    /// DID-resolver cache (`affinidi-did-resolver-cache-sdk`). Independent of
+    /// this client's auth/transport — pure resolution. Requires the `didcomm`
+    /// feature (which pulls the resolver).
+    #[cfg(feature = "didcomm")]
+    pub async fn resolve_did(&self, did: &str) -> Result<serde_json::Value, VtaError> {
+        use affinidi_did_resolver_cache_sdk::DIDCacheClient;
+        let resolver = DIDCacheClient::new(crate::resolver::build_did_cache_config_from_env())
+            .await
+            .map_err(|e| VtaError::Protocol(format!("resolver init: {e}")))?;
+        let resolved = resolver
+            .resolve(did)
+            .await
+            .map_err(|e| VtaError::Protocol(format!("resolve {did}: {e}")))?;
+        serde_json::to_value(resolved.doc).map_err(VtaError::from)
     }
 
     // ── Health ───────────────────────────────────────────────────────

--- a/vta-sdk/src/vp.rs
+++ b/vta-sdk/src/vp.rs
@@ -76,7 +76,8 @@ pub enum VpError {
 /// embedded verbatim into the presentation (it must already carry its issuer
 /// proof — the verifier re-checks it). Keeping the two separate lets the matcher
 /// read claims without the presentation layer having to parse a wire credential.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct HeldCredential {
     /// Caller-chosen identifier, echoed back through the match. Unique within a
     /// `select_credentials` call.
@@ -87,15 +88,22 @@ pub struct HeldCredential {
     /// The credential's claims as a JSON object — the tree a claim `path` walks.
     pub claims: Value,
     /// SD-JWT-VC type, matched against a query's `meta.vct_values` when present.
+    #[serde(default)]
     pub vct: Option<String>,
     /// mdoc doctype, matched against a query's `meta.doctype_value` when present.
+    #[serde(default)]
     pub doctype: Option<String>,
     /// Whether this credential can prove cryptographic holder binding. A DCQL
     /// query that requires holder binding (the default) will not match a
-    /// candidate that cannot.
+    /// candidate that cannot. Defaults to `true` when omitted.
+    #[serde(default = "default_true")]
     pub supports_holder_binding: bool,
     /// The full signed credential, embedded verbatim into the VP.
     pub vc: Value,
+}
+
+fn default_true() -> bool {
+    true
 }
 
 impl HeldCredential {
@@ -234,6 +242,30 @@ pub async fn build_vp_token(
     }
 
     Ok(Value::Object(vp_token))
+}
+
+/// One-shot: select the held credentials matching `presentation_definition`,
+/// then build + sign a holder-bound `vp_token` — using a holder key supplied as
+/// a multibase string. Convenience over [`select_credentials`] +
+/// [`build_vp_token`] for callers that hold the key as multibase (e.g. an MCP
+/// bridge configured with its agent identity) and don't want to construct a
+/// `Secret` themselves.
+///
+/// The proof's `verificationMethod` is `{holder_did}#{holder_vm_fragment}`.
+pub async fn issue_vp_token(
+    holder_did: &str,
+    holder_vm_fragment: &str,
+    holder_key_multibase: &str,
+    presentation_definition: &Value,
+    held: &[HeldCredential],
+    nonce: &str,
+    audience: &str,
+) -> Result<Value, VpError> {
+    let kid = format!("{holder_did}#{holder_vm_fragment}");
+    let secret = Secret::from_multibase(holder_key_multibase, Some(&kid))
+        .map_err(|e| VpError::Sign(format!("holder key: {e}")))?;
+    let candidates = select_credentials(presentation_definition, held)?;
+    build_vp_token(&candidates, &secret, nonce, audience).await
 }
 
 /// Build one holder-bound DI VP wrapping `vcs`, signed by `holder_signer`.


### PR DESCRIPTION
## What & why

Makes **every** VTA task reachable over MCP, not just the curated handful. Rather than hand-write ~50 typed tools, this leans on the fact that the whole management surface is already Trust Tasks dispatched at `/api/trust-tasks` (83 operations across contexts, keys, acl, did-management, webvh, did-templates, device, vault, seeds, audit, backup, discovery, config, management).

## Generic gateway (covers everything)
- **`vta_list_operations`** — the catalog of operation URIs (`vta_sdk::trust_tasks::ALL_URIS`).
- **`vta_call(operation, payload)`** — invoke any operation by URI with a JSON payload. Backed by the now-`pub` `VtaClient::dispatch_trust_task`.

Two tools → the full management surface, and new VTA operations are covered automatically as they're added to `ALL_URIS`.

## Client-side tools (not Trust Tasks)
- **`resolve_did(did)`** — new `VtaClient::resolve_did` (feature `didcomm`) resolves any DID to its document via the resolver cache.
- **`issue_vp(presentation_definition, held_credentials, nonce, audience)`** — builds a holder-bound OID4VP `vp_token` via the new `vta_sdk::vp::issue_vp_token`, signed with the agent's holder key.

## Holder key handling (issue_vp)
`build_vp_token` signs **locally** with a holder `Secret`, which the bridge's auth modes don't expose. So the holder identity is configured out-of-band — `VTA_MCP_HOLDER_DID` + `VTA_MCP_HOLDER_KEY` (multibase) [+ `VTA_MCP_HOLDER_VM_FRAGMENT`, default `key-0`]. The key stays in-process and **never crosses MCP**; without it the tool returns a clear "not configured" error.

## SDK changes
- `dispatch_trust_task` → `pub` (generic gateway).
- `VtaClient::resolve_did` (feature `didcomm`).
- `vp::issue_vp_token` convenience (select + sign from a multibase key); `HeldCredential` gains `Deserialize` (camelCase) so callers pass held credentials as JSON.
- vta-mcp enables vta-sdk `didcomm` + `vp`.

## Security
All access is bounded by the bridge identity's VTA **role/ACL**. `vta_call` can reach destructive ops (e.g. `contexts/delete`, `seeds/rotate`) **if the role permits** — so scope the bridge role to least privilege. Documented in the README + tool descriptions + module docs.

## Testing
- Tool-router test asserts all **11 tools**.
- **Live stdio MCP smoke test**: `tools/list` returns 11 tools; `tools/call vta_list_operations` returns the 123-URI catalog.
- `clippy -D warnings` ✅, `fmt` ✅, `cargo check --workspace` ✅; vta-sdk lib (206) + doctests pass.
- Note: the pre-existing `vta-sdk/tests/protocol_debug_redaction.rs` integration test is broken on `main` (a `SeedRecordBackup` field drift from #358) — unrelated to this PR; lib/doc tests are green.

## Follow-ups
- Optionally filter `vta_list_operations` to dispatcher-routed ops only (it currently lists all 123 `ALL_URIS`, ~40 of which are auth/passkey/attestation handled by the bridge itself, not via `vta_call`).
- Live-VTA integration test for `vta_call` + the `issue_vp` signing round-trip.