### PR TITLE
refactor(trust-tasks): canonical REST_ROUTED_URIS in SDK; vta_call catalog lists only dispatchable ops

### DIFF
--- a/vta-mcp/src/server.rs
+++ b/vta-mcp/src/server.rs
@@ -285,10 +285,12 @@ impl VtaMcp {
     }
 
     #[tool(
-        description = "List every VTA operation reachable via `vta_call` — the catalog of Trust Task URIs (contexts, keys, acl, did-management, webvh, did-templates, device, vault, seeds, audit, backup, discovery, …)."
+        description = "List every VTA operation reachable via `vta_call` — the catalog of dispatcher-routed Trust Task URIs (contexts, keys, acl, did-management, webvh, did-templates, device, vault, seeds, audit, backup, discovery, …). Pre-login auth and attestation are excluded (handled by the bridge itself / not vta_call-able)."
     )]
     async fn vta_list_operations(&self) -> Result<CallToolResult, McpError> {
-        let mut ops: Vec<&str> = vta_sdk::trust_tasks::ALL_URIS.to_vec();
+        // Exactly the set `vta_call` can invoke — ALL_URIS minus the REST-routed
+        // (pre-login auth + attestation) operations.
+        let mut ops = vta_sdk::trust_tasks::dispatch_routed_uris();
         ops.sort_unstable();
         ok_json(serde_json::json!({ "operations": ops }))
     }

--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -1147,9 +1147,65 @@ pub const ALL_URIS: &[&str] = &[
     TASK_ATTESTATION_REPORT_1_0,
 ];
 
+/// The subset of [`ALL_URIS`] served by **dedicated REST routes** rather than
+/// the `/api/trust-tasks` dispatcher: pre-login auth (challenge / authenticate /
+/// refresh), passkey-login, and TEE attestation.
+///
+/// These are **not** reachable through the generic dispatcher
+/// ([`crate::client::VtaClient::dispatch_trust_task`]) — pre-login auth has no
+/// session to carry, and attestation is unauthenticated/public. A generic
+/// "invoke any operation" surface (e.g. an MCP `vta_call` gateway) should
+/// exclude them; use [`dispatch_routed_uris`].
+///
+/// Canonical list: `vta-service`'s dispatcher consumes this as its `REST_ROUTED`
+/// allowlist, so the two can't drift.
+#[allow(deprecated)] // intentionally names the deprecated passkey-login 0.1 URIs
+pub const REST_ROUTED_URIS: &[&str] = &[
+    TASK_AUTH_CHALLENGE_0_1,
+    TASK_AUTH_AUTHENTICATE_0_1,
+    TASK_AUTH_REFRESH_0_1,
+    TASK_AUTH_PASSKEY_LOGIN_START_0_1,
+    TASK_AUTH_PASSKEY_LOGIN_FINISH_0_1,
+    TASK_AUTH_PASSKEY_LOGIN_START_0_2,
+    TASK_AUTH_PASSKEY_LOGIN_FINISH_0_2,
+    TASK_ATTESTATION_STATUS_1_0,
+    TASK_ATTESTATION_REPORT_1_0,
+];
+
+/// The operations reachable through the generic `/api/trust-tasks` dispatcher —
+/// [`ALL_URIS`] minus [`REST_ROUTED_URIS`]. Use this to drive a generic
+/// "invoke any operation" surface so the advertised catalog matches what the
+/// dispatcher can actually route.
+pub fn dispatch_routed_uris() -> Vec<&'static str> {
+    ALL_URIS
+        .iter()
+        .copied()
+        .filter(|u| !REST_ROUTED_URIS.contains(u))
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    #[allow(deprecated)] // references the deprecated 0.1 URIs by const on purpose
+    fn rest_routed_uris_partition_all_uris() {
+        // Every REST-routed URI must be a real catalog entry, else the filter is
+        // a silent no-op against ALL_URIS.
+        for u in REST_ROUTED_URIS {
+            assert!(ALL_URIS.contains(u), "REST_ROUTED uri not in ALL_URIS: {u}");
+        }
+        let dispatch = dispatch_routed_uris();
+        // Pre-login auth + attestation are excluded …
+        assert!(!dispatch.contains(&TASK_AUTH_CHALLENGE_0_1));
+        assert!(!dispatch.contains(&TASK_ATTESTATION_STATUS_1_0));
+        // … but dispatched auth + management ops remain reachable.
+        assert!(dispatch.contains(&TASK_AUTH_WHOAMI_0_1));
+        assert!(dispatch.contains(&TASK_AUTH_SESSIONS_LIST_0_1));
+        assert!(dispatch.contains(&TASK_CONTEXTS_LIST_1_0));
+        assert_eq!(dispatch.len(), ALL_URIS.len() - REST_ROUTED_URIS.len());
+    }
 
     #[test]
     fn every_uri_in_canonical_namespace() {

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -89,34 +89,14 @@ use trust_tasks_rs::RejectReason;
 /// URIs that the VTA exposes through dedicated unauth REST routes
 /// rather than the authenticated `/api/trust-tasks` dispatcher.
 ///
-/// Per the feature-gating convention in
-/// `docs/05-design-notes/trust-task-feature-gating.md`: the parity
-/// harness accepts these as "tracked" without requiring a dispatcher
-/// arm. The corresponding handlers live in `routes::auth` (passkey
-/// login, legacy challenge/authenticate/refresh) and
-/// `routes::attestation` (TEE status / report).
-// `#[allow(deprecated)]`: this intentionally names the deprecated passkey-login
-// 0.1 URIs — they remain REST-routed and dual-accepted during the migration.
-#[allow(dead_code, deprecated)] // consumed by the dispatcher's test-only parity harness
-const REST_ROUTED: &[&str] = &[
-    // Auth (pre-login — no session, can't pass AuthClaims)
-    vta_sdk::trust_tasks::TASK_AUTH_CHALLENGE_0_1,
-    vta_sdk::trust_tasks::TASK_AUTH_AUTHENTICATE_0_1,
-    vta_sdk::trust_tasks::TASK_AUTH_REFRESH_0_1,
-    vta_sdk::trust_tasks::TASK_AUTH_PASSKEY_LOGIN_START_0_1,
-    vta_sdk::trust_tasks::TASK_AUTH_PASSKEY_LOGIN_FINISH_0_1,
-    // Passkey-login 0.2: the only 0.1→0.2 delta in the spec is the `purpose`
-    // enum value (`step-up`→`stepUp`), and the VTA's flat-JSON request/response
-    // types (`PasskeyLoginStart/FinishRequest`, `…StartResponse`) don't carry
-    // `purpose` at all — so a 0.2 client sends structurally identical JSON to
-    // the same `/auth/passkey-login/*` handlers. Dual-accept is purely
-    // declarative here; no edge transform needed.
-    vta_sdk::trust_tasks::TASK_AUTH_PASSKEY_LOGIN_START_0_2,
-    vta_sdk::trust_tasks::TASK_AUTH_PASSKEY_LOGIN_FINISH_0_2,
-    // Attestation (unauth — TEE proofs are publicly verifiable by design)
-    vta_sdk::trust_tasks::TASK_ATTESTATION_STATUS_1_0,
-    vta_sdk::trust_tasks::TASK_ATTESTATION_REPORT_1_0,
-];
+/// The canonical list lives in the SDK
+/// ([`vta_sdk::trust_tasks::REST_ROUTED_URIS`]) so the dispatcher's parity
+/// harness and any generic client catalog (e.g. the `vta-mcp` `vta_call`
+/// gateway, which advertises [`vta_sdk::trust_tasks::dispatch_routed_uris`])
+/// can't drift. Handlers live in `routes::auth` (passkey login, legacy
+/// challenge/authenticate/refresh) and `routes::attestation` (TEE status /
+/// report).
+const REST_ROUTED: &[&str] = vta_sdk::trust_tasks::REST_ROUTED_URIS;
 
 /// URIs that vta-sdk declares but the dispatcher may not wire in
 /// every build because they depend on `vta-service` feature flags


### PR DESCRIPTION
## What & why

`vta_list_operations` (from #499) advertised all 123 `ALL_URIS`, but `vta_call` (the `/api/trust-tasks` dispatcher) can't invoke the ~9 **REST-routed** ones — pre-login auth (challenge/authenticate/refresh), passkey-login, and TEE attestation. This makes the advertised catalog match exactly what `vta_call` can actually call.

Done as a **single-source-of-truth** refactor so the catalog can't drift from the dispatcher (the safety concern behind "filter if it won't break anything"):

## Changes
- **vta-sdk**: new `trust_tasks::REST_ROUTED_URIS` (the canonical REST-routed set) + `dispatch_routed_uris()` = `ALL_URIS` − `REST_ROUTED_URIS`. A new test asserts the partition: pre-login auth + attestation are excluded; `auth/whoami`, `auth/sessions/list`, `contexts/list` are kept; counts add up.
- **vta-service**: the dispatcher's `REST_ROUTED` allowlist now **is** the SDK const (previously a duplicated literal). Its existing parity harness (`dispatcher_handles_every_vta_sdk_uri`, `no_uri_is_both_dispatched_and_rest_routed`) still validates full `ALL_URIS` coverage, so server and SDK can't drift. No behavior change.
- **vta-mcp**: `vta_list_operations` returns `dispatch_routed_uris()`.

## Why it won't break anything
The filter removes **only** the exact 9 REST-routed URIs (referenced by const, not string heuristics). Crucially, `auth/whoami` and `auth/sessions/list` are *dispatched* (not in `REST_ROUTED`) and are **kept** — a naïve `auth/` prefix filter would have wrongly hidden them.

## Verification
- Catalog: 123 → **114**; `auth/challenge` + attestation excluded, `auth/whoami` kept (live stdio smoke test).
- Server dispatcher parity tests pass **unchanged** (the server consuming the SDK const is equivalent to its old literal).
- SDK partition test passes; `clippy -D warnings` ✅, `fmt` ✅, `cargo check --workspace` ✅.