### PR TITLE
feat(vtc): Vault backend via shared builder; drop dead vti-common SecretsConfig (#504 Phase 2)

### DIFF
--- a/docs/03-vtc/feature-flags.md
+++ b/docs/03-vtc/feature-flags.md
@@ -16,6 +16,7 @@ side.
 | `aws-secrets` | – | AWS Secrets Manager secret backend | `aws-sdk-secretsmanager`, `aws-config` |
 | `gcp-secrets` | – | GCP Secret Manager secret backend | `google-cloud-secretmanager-v1`, `google-cloud-auth`, `bytes` |
 | `azure-secrets` | – | Azure Key Vault secret backend | `azure_security_keyvault_secrets`, `azure_identity` |
+| `vault-secrets` | – | HashiCorp Vault (KV v2; kubernetes/token/approle auth). Configure via the `[secrets]` table (`vault_addr`, …) — no setup-wizard picker | *(shared via `vti-secrets`)* |
 | `k8s-secrets` | – | Kubernetes `Secret` secret backend (in-cluster SA or kubeconfig) | `kube`, `k8s-openapi` |
 
 ## Deployment profiles
@@ -97,10 +98,12 @@ Default-on features are green; opt-in features are amber.
   daemon expects a pre-populated config + secret store on first
   boot.
 - Exactly **one** secret backend should be enabled at a time. The
-  workspace picks the first one in priority order:
-  `keyring` > `aws-secrets` > `gcp-secrets` > `azure-secrets` >
-  `config-secret`. When in doubt, build with explicit `--no-default-features
-  --features <one-backend>,setup`.
+  runtime picks by which selector field is set, in priority order:
+  `aws-secrets` > `gcp-secrets` > `azure-secrets` > `vault-secrets` >
+  `k8s-secrets` > `config-secret` > `keyring` (default). A selector
+  set for a backend that wasn't compiled in is a hard error, not a
+  silent fall-through. When in doubt, build with explicit
+  `--no-default-features --features <one-backend>,setup`.
 
 ## See also
 

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -83,6 +83,11 @@ azure-secrets = [
 # `Secret` resource. Off by default; for in-cluster deployments that prefer
 # native k8s Secrets over a cloud secret manager.
 k8s-secrets = ["dep:kube", "dep:k8s-openapi", "vti-secrets/k8s-secrets"]
+# HashiCorp Vault backend (KV v2 + kubernetes/token/approle auth). Reuses
+# the shared `vti-secrets` Vault implementation. No direct dep: the VTC
+# setup wizard has no Vault picker, so operators configure it via the
+# `[secrets]` table (`vault_addr`, …) or `setup --from <toml>`.
+vault-secrets = ["vti-secrets/vault-secrets"]
 
 [[bin]]
 name = "vtc"

--- a/vtc-service/src/config.rs
+++ b/vtc-service/src/config.rs
@@ -450,6 +450,51 @@ pub struct SecretsConfig {
     /// Change this to run multiple VTC instances on the same machine.
     #[serde(default = "default_keyring_service")]
     pub keyring_service: String,
+    /// HashiCorp Vault server URL (vault-secrets feature). Setting this
+    /// activates the Vault backend. Field names mirror the VTA's
+    /// (`vti_secrets::SecretsConfig`) so the shared Vault builder is reused.
+    pub vault_addr: Option<String>,
+    /// KV v2 mount path (vault-secrets feature). Default `secret`.
+    #[serde(default = "default_vault_kv_mount")]
+    pub vault_kv_mount: String,
+    /// KV v2 secret path under the mount, e.g. `vtc/key-bundle`
+    /// (vault-secrets feature).
+    pub vault_secret_path: Option<String>,
+    /// Field name within the KV v2 secret that holds the hex-encoded key
+    /// material (vault-secrets feature). Default `seed`.
+    #[serde(default = "default_vault_secret_key")]
+    pub vault_secret_key: String,
+    /// Vault Enterprise namespace, if any (vault-secrets feature).
+    pub vault_namespace: Option<String>,
+    /// Auth method: `kubernetes` (default), `token`, or `approle`
+    /// (vault-secrets feature).
+    #[serde(default = "default_vault_auth_method")]
+    pub vault_auth_method: String,
+    /// Kubernetes auth role name (vault-secrets feature, kubernetes auth).
+    pub vault_k8s_role: Option<String>,
+    /// Kubernetes auth mount path (vault-secrets feature). Default
+    /// `kubernetes`.
+    #[serde(default = "default_vault_k8s_mount")]
+    pub vault_k8s_mount: String,
+    /// File holding the ServiceAccount JWT presented to Vault
+    /// (vault-secrets feature, kubernetes auth). Default is the
+    /// kubelet-mounted projected volume path.
+    #[serde(default = "default_vault_k8s_jwt_path")]
+    pub vault_k8s_jwt_path: String,
+    /// Static token (vault-secrets feature, token auth). Prefer the
+    /// `VAULT_TOKEN` env var over hard-coding here.
+    pub vault_token: Option<String>,
+    /// AppRole role_id (vault-secrets feature, approle auth).
+    pub vault_approle_role_id: Option<String>,
+    /// AppRole secret_id (vault-secrets feature, approle auth).
+    pub vault_approle_secret_id: Option<String>,
+    /// AppRole mount path (vault-secrets feature). Default `approle`.
+    #[serde(default = "default_vault_approle_mount")]
+    pub vault_approle_mount: String,
+    /// Skip TLS certificate verification — dev/test only
+    /// (vault-secrets feature).
+    #[serde(default)]
+    pub vault_skip_verify: bool,
     /// Kubernetes `Secret` name holding the hex-encoded VTC key material
     /// (k8s-secrets feature). Setting this activates the Kubernetes
     /// backend.
@@ -472,11 +517,34 @@ fn default_k8s_secret_key() -> String {
     "secret".to_string()
 }
 
+fn default_vault_kv_mount() -> String {
+    "secret".to_string()
+}
+
+fn default_vault_secret_key() -> String {
+    "seed".to_string()
+}
+
+fn default_vault_auth_method() -> String {
+    "kubernetes".to_string()
+}
+
+fn default_vault_k8s_mount() -> String {
+    "kubernetes".to_string()
+}
+
+fn default_vault_k8s_jwt_path() -> String {
+    "/var/run/secrets/kubernetes.io/serviceaccount/token".to_string()
+}
+
+fn default_vault_approle_mount() -> String {
+    "approle".to_string()
+}
+
 // Manual Debug — `secret` is the hex-encoded VTC key material; leaking
 // it via a stray `{:?}` (e.g. a future `debug!(?config)`) would
 // compromise every key derived from it. Redact it; the other fields are
-// backend *names*, not secrets, so they print verbatim. Mirrors
-// `vti_common::config::SecretsConfig`'s impl.
+// backend *names*, not secrets, so they print verbatim.
 impl std::fmt::Debug for SecretsConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SecretsConfig")
@@ -488,6 +556,27 @@ impl std::fmt::Debug for SecretsConfig {
             .field("azure_vault_url", &self.azure_vault_url)
             .field("azure_secret_name", &self.azure_secret_name)
             .field("keyring_service", &self.keyring_service)
+            .field("vault_addr", &self.vault_addr)
+            .field("vault_kv_mount", &self.vault_kv_mount)
+            .field("vault_secret_path", &self.vault_secret_path)
+            .field("vault_secret_key", &self.vault_secret_key)
+            .field("vault_namespace", &self.vault_namespace)
+            .field("vault_auth_method", &self.vault_auth_method)
+            .field("vault_k8s_role", &self.vault_k8s_role)
+            .field("vault_k8s_mount", &self.vault_k8s_mount)
+            .field("vault_k8s_jwt_path", &self.vault_k8s_jwt_path)
+            // Secret-bearing: redact (token / approle secret_id are bearer creds).
+            .field(
+                "vault_token",
+                &self.vault_token.as_ref().map(|_| "<redacted>"),
+            )
+            .field("vault_approle_role_id", &self.vault_approle_role_id)
+            .field(
+                "vault_approle_secret_id",
+                &self.vault_approle_secret_id.as_ref().map(|_| "<redacted>"),
+            )
+            .field("vault_approle_mount", &self.vault_approle_mount)
+            .field("vault_skip_verify", &self.vault_skip_verify)
             .field("k8s_secret_name", &self.k8s_secret_name)
             .field("k8s_namespace", &self.k8s_namespace)
             .field("k8s_secret_key", &self.k8s_secret_key)
@@ -506,6 +595,20 @@ impl Default for SecretsConfig {
             azure_vault_url: None,
             azure_secret_name: None,
             keyring_service: default_keyring_service(),
+            vault_addr: None,
+            vault_kv_mount: default_vault_kv_mount(),
+            vault_secret_path: None,
+            vault_secret_key: default_vault_secret_key(),
+            vault_namespace: None,
+            vault_auth_method: default_vault_auth_method(),
+            vault_k8s_role: None,
+            vault_k8s_mount: default_vault_k8s_mount(),
+            vault_k8s_jwt_path: default_vault_k8s_jwt_path(),
+            vault_token: None,
+            vault_approle_role_id: None,
+            vault_approle_secret_id: None,
+            vault_approle_mount: default_vault_approle_mount(),
+            vault_skip_verify: false,
             k8s_secret_name: None,
             k8s_namespace: None,
             k8s_secret_key: default_k8s_secret_key(),
@@ -895,11 +998,22 @@ mod tests {
         let cfg = SecretsConfig {
             secret: Some("deadbeefdeadbeef".into()),
             keyring_service: "vtc".into(),
+            // Vault bearer creds are also secret-bearing — must not leak.
+            vault_token: Some("hvs.SUPERSECRETTOKEN".into()),
+            vault_approle_secret_id: Some("APPROLE_SECRET_ID_XYZ".into()),
             ..Default::default()
         };
         let dbg = format!("{cfg:?}");
         assert!(dbg.contains("<redacted>"), "got {dbg}");
         assert!(!dbg.contains("deadbeef"), "secret leaked: {dbg}");
+        assert!(
+            !dbg.contains("SUPERSECRETTOKEN"),
+            "vault_token leaked: {dbg}"
+        );
+        assert!(
+            !dbg.contains("APPROLE_SECRET_ID_XYZ"),
+            "vault_approle_secret_id leaked: {dbg}"
+        );
         // Non-secret backend names still print.
         assert!(dbg.contains("vtc"));
     }

--- a/vtc-service/src/keys/seed_store/mod.rs
+++ b/vtc-service/src/keys/seed_store/mod.rs
@@ -54,10 +54,11 @@ const VTC_PLAINTEXT_FILENAME: &str = "secret.plaintext";
 /// 1. AWS Secrets Manager (if `aws-secrets` compiled + `secrets.aws_secret_name` set)
 /// 2. GCP Secret Manager (if `gcp-secrets` compiled + `secrets.gcp_secret_name` set)
 /// 3. Azure Key Vault (if `azure-secrets` compiled + `secrets.azure_vault_url` set)
-/// 4. Kubernetes Secret (if `k8s-secrets` compiled + `secrets.k8s_secret_name` set)
-/// 5. Config file secret (if `config-secret` compiled + `secrets.secret` set)
-/// 6. OS keyring (if `keyring` compiled — the default)
-/// 7. Plaintext file (always available — NOT secure)
+/// 4. HashiCorp Vault (if `vault-secrets` compiled + `secrets.vault_addr` set)
+/// 5. Kubernetes Secret (if `k8s-secrets` compiled + `secrets.k8s_secret_name` set)
+/// 6. Config file secret (if `config-secret` compiled + `secrets.secret` set)
+/// 7. OS keyring (if `keyring` compiled — the default)
+/// 8. Plaintext file (always available — NOT secure)
 #[allow(unused_variables)]
 pub fn create_secret_store(config: &AppConfig) -> Result<Box<dyn SecretStore>, AppError> {
     // For every cloud/config backend, a set selector field on a binary that
@@ -118,6 +119,40 @@ pub fn create_secret_store(config: &AppConfig) -> Result<Box<dyn SecretStore>, A
         return Err(AppError::Config(
             "secrets.azure_vault_url is set but this binary was built without the \
              'azure-secrets' feature"
+                .into(),
+        ));
+    }
+
+    // HashiCorp Vault — reuses the shared `vti-secrets` Vault builder. The
+    // VTC's `vault_*` config fields mirror the VTA's, so the auth-method
+    // parsing is not duplicated here.
+    #[cfg(feature = "vault-secrets")]
+    if config.secrets.vault_addr.is_some() {
+        let s = &config.secrets;
+        let store =
+            vti_secrets::seed_store::vault_from_params(&vti_secrets::seed_store::VaultParams {
+                addr: s.vault_addr.as_deref(),
+                namespace: s.vault_namespace.as_deref(),
+                skip_verify: s.vault_skip_verify,
+                secret_path: s.vault_secret_path.as_deref(),
+                secret_key: &s.vault_secret_key,
+                kv_mount: &s.vault_kv_mount,
+                auth_method: &s.vault_auth_method,
+                k8s_role: s.vault_k8s_role.as_deref(),
+                k8s_mount: &s.vault_k8s_mount,
+                k8s_jwt_path: &s.vault_k8s_jwt_path,
+                token: s.vault_token.as_deref(),
+                approle_role_id: s.vault_approle_role_id.as_deref(),
+                approle_secret_id: s.vault_approle_secret_id.as_deref(),
+                approle_mount: &s.vault_approle_mount,
+            })?;
+        return Ok(Box::new(store));
+    }
+    #[cfg(not(feature = "vault-secrets"))]
+    if config.secrets.vault_addr.is_some() {
+        return Err(AppError::Config(
+            "secrets.vault_addr is set but this binary was built without the \
+             'vault-secrets' feature"
                 .into(),
         ));
     }
@@ -233,6 +268,13 @@ mod tests {
         let mut config = base_config();
         config.secrets.k8s_secret_name = Some("vtc-master-seed".into());
         assert_config_err_mentions(&config, "k8s-secrets");
+    }
+
+    #[test]
+    fn vault_set_without_feature_is_config_error() {
+        let mut config = base_config();
+        config.secrets.vault_addr = Some("https://vault.internal:8200".into());
+        assert_config_err_mentions(&config, "vault-secrets");
     }
 
     #[test]

--- a/vti-common/src/config.rs
+++ b/vti-common/src/config.rs
@@ -80,50 +80,6 @@ pub struct MessagingConfig {
     pub mediator_host: Option<String>,
 }
 
-#[derive(Clone, Deserialize, Serialize)]
-pub struct SecretsConfig {
-    /// Hex-encoded key material (seed for VTA, secret for VTC).
-    /// Uses serde aliases so both `seed` and `secret` are accepted in config files.
-    #[serde(alias = "seed", alias = "secret")]
-    pub inline_secret: Option<String>,
-    /// AWS Secrets Manager secret name (aws-secrets feature)
-    pub aws_secret_name: Option<String>,
-    /// AWS region override (aws-secrets feature)
-    pub aws_region: Option<String>,
-    /// GCP project ID (gcp-secrets feature)
-    pub gcp_project: Option<String>,
-    /// GCP secret name (gcp-secrets feature)
-    pub gcp_secret_name: Option<String>,
-    /// Azure Key Vault URL (azure-secrets feature)
-    pub azure_vault_url: Option<String>,
-    /// Azure Key Vault secret name (azure-secrets feature)
-    pub azure_secret_name: Option<String>,
-    /// OS keyring service name (keyring feature).
-    /// No default — each service provides its own ("vta" or "vtc").
-    pub keyring_service: String,
-}
-
-// Manual Debug — see `AuthConfig` impl for rationale. `inline_secret`
-// is the master seed (VTA) or HMAC secret (VTC); leaking it via a
-// stray `{:?}` would compromise every key derived from it.
-impl std::fmt::Debug for SecretsConfig {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("SecretsConfig")
-            .field(
-                "inline_secret",
-                &self.inline_secret.as_ref().map(|_| "<redacted>"),
-            )
-            .field("aws_secret_name", &self.aws_secret_name)
-            .field("aws_region", &self.aws_region)
-            .field("gcp_project", &self.gcp_project)
-            .field("gcp_secret_name", &self.gcp_secret_name)
-            .field("azure_vault_url", &self.azure_vault_url)
-            .field("azure_secret_name", &self.azure_secret_name)
-            .field("keyring_service", &self.keyring_service)
-            .finish()
-    }
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AuditConfig {
     /// Number of days to retain audit logs (default 28).
@@ -237,37 +193,6 @@ mod tests {
         let dbg = format!("{cfg:?}");
         // `Option<&str>` Debug prints `None` for the absent case.
         assert!(dbg.contains("jwt_signing_key: None"), "got: {dbg}");
-    }
-
-    /// `SecretsConfig.inline_secret` is the master seed (VTA) or HMAC
-    /// secret (VTC). Same redaction discipline as `AuthConfig`.
-    #[test]
-    fn secrets_config_debug_redacts_inline_secret() {
-        let cfg = SecretsConfig {
-            inline_secret: Some("MASTER_SEED_HEX_MUST_NOT_LEAK".into()),
-            aws_secret_name: None,
-            aws_region: None,
-            gcp_project: None,
-            gcp_secret_name: None,
-            azure_vault_url: None,
-            azure_secret_name: None,
-            keyring_service: "vta".into(),
-        };
-        let dbg = format!("{cfg:?}");
-        assert!(
-            !dbg.contains("MASTER_SEED_HEX"),
-            "SecretsConfig Debug leaked inline_secret contents: {dbg}"
-        );
-        assert!(
-            dbg.contains("<redacted>"),
-            "expected redaction marker in Debug, got: {dbg}"
-        );
-        // Non-secret routing fields stay visible so the operator can
-        // tell which backend is configured.
-        assert!(
-            dbg.contains("vta"),
-            "keyring_service must be visible: {dbg}"
-        );
     }
 
     /// Serialize must remain unaffected — these structs round-trip to

--- a/vti-secrets/src/seed_store/mod.rs
+++ b/vti-secrets/src/seed_store/mod.rs
@@ -32,7 +32,9 @@ pub use keyring::KeyringSeedStore;
 pub use kms_tee::KmsTeeSeedStore;
 pub use plaintext::PlaintextSeedStore;
 #[cfg(feature = "vault-secrets")]
-pub use vault::{VaultSeedStore, from_config as vault_from_config};
+pub use vault::{
+    VaultParams, VaultSeedStore, from_config as vault_from_config, from_params as vault_from_params,
+};
 
 #[cfg(feature = "tee")]
 use std::future::Future;

--- a/vti-secrets/src/seed_store/vault.rs
+++ b/vti-secrets/src/seed_store/vault.rs
@@ -329,37 +329,68 @@ impl super::SeedStore for VaultSeedStore {
     }
 }
 
-/// Build a [`VaultSeedStore`] from the workspace [`SecretsConfig`].
+/// Config-agnostic inputs for [`from_params`]. Mirrors the `vault_*`
+/// config fields so any service can build a Vault backend from its own
+/// config shape without depending on a specific `SecretsConfig` type —
+/// the VTA builds these from [`crate::SecretsConfig`] via [`from_config`];
+/// the VTC builds them from its own config. Fields are borrowed (the
+/// builder owns only what it keeps), and the string-defaulted fields
+/// (`secret_key`, `kv_mount`, the `*_mount`s, `auth_method`) are the
+/// caller's already-resolved values.
+pub struct VaultParams<'a> {
+    pub addr: Option<&'a str>,
+    pub namespace: Option<&'a str>,
+    pub skip_verify: bool,
+    pub secret_path: Option<&'a str>,
+    pub secret_key: &'a str,
+    pub kv_mount: &'a str,
+    pub auth_method: &'a str,
+    pub k8s_role: Option<&'a str>,
+    pub k8s_mount: &'a str,
+    pub k8s_jwt_path: &'a str,
+    pub token: Option<&'a str>,
+    pub approle_role_id: Option<&'a str>,
+    pub approle_secret_id: Option<&'a str>,
+    pub approle_mount: &'a str,
+}
+
+/// Build a [`VaultSeedStore`] from config-agnostic [`VaultParams`].
 /// Validates the auth-method-specific fields and surfaces actionable
 /// errors when something required is missing.
-pub fn from_config(secrets: &crate::config::SecretsConfig) -> Result<VaultSeedStore, AppError> {
-    let addr = secrets
-        .vault_addr
-        .clone()
-        .ok_or_else(|| AppError::Config("secrets.vault_addr is required".into()))?;
-    let path = secrets.vault_secret_path.clone().ok_or_else(|| {
-        AppError::Config(
-            "secrets.vault_secret_path is required when secrets.vault_addr is set".into(),
-        )
-    })?;
+pub fn from_params(p: &VaultParams<'_>) -> Result<VaultSeedStore, AppError> {
+    let addr = p
+        .addr
+        .ok_or_else(|| AppError::Config("secrets.vault_addr is required".into()))?
+        .to_string();
+    let path = p
+        .secret_path
+        .ok_or_else(|| {
+            AppError::Config(
+                "secrets.vault_secret_path is required when secrets.vault_addr is set".into(),
+            )
+        })?
+        .to_string();
 
-    let auth = match secrets.vault_auth_method.as_str() {
+    let auth = match p.auth_method {
         "kubernetes" => {
-            let role = secrets.vault_k8s_role.clone().ok_or_else(|| {
-                AppError::Config(
-                    "secrets.vault_k8s_role is required for kubernetes auth method".into(),
-                )
-            })?;
+            let role = p
+                .k8s_role
+                .ok_or_else(|| {
+                    AppError::Config(
+                        "secrets.vault_k8s_role is required for kubernetes auth method".into(),
+                    )
+                })?
+                .to_string();
             VaultAuth::Kubernetes {
-                mount: secrets.vault_k8s_mount.clone(),
+                mount: p.k8s_mount.to_string(),
                 role,
-                jwt_path: secrets.vault_k8s_jwt_path.clone(),
+                jwt_path: p.k8s_jwt_path.to_string(),
             }
         }
         "token" => {
-            let token = secrets
-                .vault_token
-                .clone()
+            let token = p
+                .token
+                .map(str::to_string)
                 .or_else(|| std::env::var("VAULT_TOKEN").ok())
                 .ok_or_else(|| {
                     AppError::Config(
@@ -369,14 +400,22 @@ pub fn from_config(secrets: &crate::config::SecretsConfig) -> Result<VaultSeedSt
             VaultAuth::Token { token }
         }
         "approle" => {
-            let role_id = secrets.vault_approle_role_id.clone().ok_or_else(|| {
-                AppError::Config("secrets.vault_approle_role_id is required for approle".into())
-            })?;
-            let secret_id = secrets.vault_approle_secret_id.clone().ok_or_else(|| {
-                AppError::Config("secrets.vault_approle_secret_id is required for approle".into())
-            })?;
+            let role_id = p
+                .approle_role_id
+                .ok_or_else(|| {
+                    AppError::Config("secrets.vault_approle_role_id is required for approle".into())
+                })?
+                .to_string();
+            let secret_id = p
+                .approle_secret_id
+                .ok_or_else(|| {
+                    AppError::Config(
+                        "secrets.vault_approle_secret_id is required for approle".into(),
+                    )
+                })?
+                .to_string();
             VaultAuth::AppRole {
-                mount: secrets.vault_approle_mount.clone(),
+                mount: p.approle_mount.to_string(),
                 role_id,
                 secret_id,
             }
@@ -390,11 +429,32 @@ pub fn from_config(secrets: &crate::config::SecretsConfig) -> Result<VaultSeedSt
 
     Ok(VaultSeedStore::new(
         addr,
-        secrets.vault_namespace.clone(),
-        secrets.vault_skip_verify,
+        p.namespace.map(str::to_string),
+        p.skip_verify,
         path,
-        secrets.vault_secret_key.clone(),
-        secrets.vault_kv_mount.clone(),
+        p.secret_key.to_string(),
+        p.kv_mount.to_string(),
         auth,
     ))
+}
+
+/// Build a [`VaultSeedStore`] from the workspace [`SecretsConfig`]. Thin
+/// adapter over [`from_params`].
+pub fn from_config(secrets: &crate::config::SecretsConfig) -> Result<VaultSeedStore, AppError> {
+    from_params(&VaultParams {
+        addr: secrets.vault_addr.as_deref(),
+        namespace: secrets.vault_namespace.as_deref(),
+        skip_verify: secrets.vault_skip_verify,
+        secret_path: secrets.vault_secret_path.as_deref(),
+        secret_key: &secrets.vault_secret_key,
+        kv_mount: &secrets.vault_kv_mount,
+        auth_method: &secrets.vault_auth_method,
+        k8s_role: secrets.vault_k8s_role.as_deref(),
+        k8s_mount: &secrets.vault_k8s_mount,
+        k8s_jwt_path: &secrets.vault_k8s_jwt_path,
+        token: secrets.vault_token.as_deref(),
+        approle_role_id: secrets.vault_approle_role_id.as_deref(),
+        approle_secret_id: secrets.vault_approle_secret_id.as_deref(),
+        approle_mount: &secrets.vault_approle_mount,
+    })
 }


### PR DESCRIPTION
**#504 Phase 2.** Two genuinely-better, safe wins — and a deliberate decision *not* to do the full config merge.

## The "one SecretsConfig" goal: reassessed → not worth it
Implementing it surfaced that a full struct-merge would be a **net negative**, not a cleanup:
- VTC's `SecretsConfig` has **`deny_unknown_fields`** (a deliberate P0.8 guard: a typo'd selector like `aws_secretname` is rejected, not silently ignored). VTA's does **not** — it relies on a top-level `serde_ignored`/`unknown_keys` *warn* mechanism that **VTC doesn't have**.
- The two have **divergent defaults** (keyring `vta`/`vtc`, k8s key `seed`/`secret`) pinned by tests.

Merging would either **regress VTC's typo protection** or force an invasive `Option`-default refactor rippling through both setup wizards + tests — for a tidiness win that Phase 1 already neutralised by sharing the backend *implementations*. So this PR delivers the parts that *are* materially better and safe, and leaves the two thin config shapes as-is.

## What's in this PR

**1. VTC gains a HashiCorp Vault backend** (a real capability gap vs the VTA).
- Adds the `vault_*` fields to VTC's `SecretsConfig` — **additive & `deny_unknown_fields`-safe** (old configs still parse; missing fields default).
- VTC's factory **reuses the shared builder** instead of duplicating the kubernetes/token/approle auth parsing. To enable that without coupling the backend to a specific config type, `vti-secrets` gains a config-agnostic **`VaultParams` + `vault_from_params`**; `from_config` becomes a thin adapter over it.
- Follows the existing **P0.8 fail-closed** discipline (`vault_addr` set without the `vault-secrets` feature → hard `Config` error) and **redacts** the bearer creds (`vault_token`, `vault_approle_secret_id`) in `Debug`.
- No setup-wizard picker yet — operators configure via `[secrets]` / `setup --from <toml>`.

**2. Removes the dead `vti_common::config::SecretsConfig`** (the third, unreferenced shape the issue flagged) + its self-test. Confirmed no external type usage.

## Verification
- `cargo check --workspace` ✅
- VTC compiles default + every backend incl. `vault-secrets`; clippy clean
- Tests green: VTC `keys::seed_store` fail-closed factory **7/7** (incl. new `vault_set_without_feature_is_config_error`), VTC `config::` (deny_unknown_fields, keyring default, **strengthened** Debug-redaction now covering `vault_token`/`vault_approle_secret_id`); VTA `seed` **11/11** (vault `from_config` adapter + plaintext unchanged); `vti-secrets` **8/8**
- Docs: `docs/03-vtc/feature-flags.md` (vault row + corrected priority note)

## Correction to the #504 description
"TEE usable from VTC" is a **non-goal** — per `vtc-service/CLAUDE.md` the VTC never targets a TEE. Struck.

## Remaining (#504 Phase 3, separate)
Make the setup wizards drive secret enumeration + write through `vti-secrets` (a shared `discovery` API) so `vta-service`/`vtc-service` can drop their direct cloud-SDK deps. The full single-`SecretsConfig` merge is **not** planned (see above).