### PR TITLE
fix(ci): unbreak Clippy and Test on main

### DIFF
--- a/tests/e2e/tests/common/state_fixtures.rs
+++ b/tests/e2e/tests/common/state_fixtures.rs
@@ -48,11 +48,19 @@ use std::sync::Arc;
 
 use tokio::sync::RwLock;
 
+use affinidi_did_resolver_cache_sdk::{DIDCacheClient, config::DIDCacheConfigBuilder};
 use vta_service::config::{AppConfig, ServicesConfig};
+use vta_service::didcomm_bridge::DIDCommBridge;
+use vta_service::keys::seed_store::PlaintextSeedStore;
+use vta_service::messaging::drain_sweeper::{DrainSweeper, teardown_channel};
+use vta_service::messaging::registry::MediatorListenerRegistry;
+use vta_service::operations::did_webvh::WebvhAuthLocks;
+use vta_service::operations::protocol::ServiceOpDeps;
 use vta_service::operations::protocol::snapshot::{
     self, DidcommSnapshot, RestSnapshot, ServiceConfigSnapshot,
 };
 use vta_service::test_support::{TestStore, open_test_store, test_app_config};
+use vti_common::telemetry::{RingBufferTelemetry, SharedTelemetrySink};
 
 /// Spec §7a.1 valid states. `S0` (off, off) is invariant-violating
 /// and intentionally absent — runtime commands can never reach it.
@@ -181,6 +189,79 @@ impl StateFixture {
     pub async fn with_didcomm_snapshot_disabled(self) -> Self {
         self.with_snapshot(ServiceConfigSnapshot::Didcomm(DidcommSnapshot::Disabled))
             .await
+    }
+}
+
+/// Owns the per-test infrastructure a runtime-service operation needs that
+/// isn't part of the persisted [`StateFixture`] — seed store, DID resolver,
+/// DIDComm bridge, telemetry sink, mediator registry, drain sweeper, and the
+/// webvh auth locks. The protocol ops were consolidated onto a single borrowed
+/// [`ServiceOpDeps`] bundle ([`mod@vta_service::operations::protocol`]), so a
+/// caller builds this once and hands out [`OpInfra::deps`] per invocation.
+///
+/// Split from `StateFixture` because these are owned values the borrowed
+/// `ServiceOpDeps` points at: keep both alive for the test body, then build
+/// the bundle on demand. The registry/sweeper are only read by the DIDComm
+/// family; REST ops ignore them but the shared bundle still carries them.
+pub struct OpInfra {
+    seed: PlaintextSeedStore,
+    resolver: DIDCacheClient,
+    bridge: Arc<DIDCommBridge>,
+    telemetry: SharedTelemetrySink,
+    registry: Arc<MediatorListenerRegistry>,
+    sweeper: Arc<DrainSweeper>,
+    locks: WebvhAuthLocks,
+}
+
+impl OpInfra {
+    /// Build the infra against a fixture's drain keyspace (the sweeper needs
+    /// it). The teardown receiver is dropped immediately — refusal-path tests
+    /// bail before any drain is swept, so nothing is ever sent on it.
+    pub async fn new(fx: &StateFixture) -> Self {
+        let resolver = DIDCacheClient::new(DIDCacheConfigBuilder::default().build())
+            .await
+            .expect("DID resolver");
+        let telemetry: SharedTelemetrySink = Arc::new(RingBufferTelemetry::new());
+        let registry = Arc::new(MediatorListenerRegistry::new(Arc::clone(&telemetry)));
+        let (tx, _rx) = teardown_channel(8);
+        let sweeper = Arc::new(DrainSweeper::new(
+            Arc::clone(&registry),
+            fx.store.drains_ks.clone(),
+            tx,
+        ));
+        Self {
+            seed: PlaintextSeedStore::new(&fx.store.data_dir),
+            resolver,
+            bridge: Arc::new(DIDCommBridge::placeholder()),
+            telemetry,
+            registry,
+            sweeper,
+            locks: WebvhAuthLocks::new(),
+        }
+    }
+
+    /// Borrow a [`ServiceOpDeps`] bundle pointing at the fixture's keyspaces +
+    /// config and this infra's owned values. Both `self` and `fx` must outlive
+    /// the returned bundle.
+    pub fn deps<'a>(&'a self, fx: &'a StateFixture) -> ServiceOpDeps<'a> {
+        ServiceOpDeps {
+            config: &fx.config,
+            keys_ks: &fx.store.keys_ks,
+            imported_ks: &fx.store.imported_ks,
+            contexts_ks: &fx.store.contexts_ks,
+            webvh_ks: &fx.store.webvh_ks,
+            audit_ks: &fx.store.audit_ks,
+            snapshot_ks: &fx.store.snapshot_ks,
+            service_state_ks: &fx.store.service_state_ks,
+            drains_ks: &fx.store.drains_ks,
+            seed_store: &self.seed,
+            did_resolver: &self.resolver,
+            didcomm_bridge: &self.bridge,
+            telemetry: &self.telemetry,
+            webvh_auth_locks: &self.locks,
+            registry: &self.registry,
+            sweeper: &self.sweeper,
+        }
     }
 }
 

--- a/tests/e2e/tests/rollback_dispatch.rs
+++ b/tests/e2e/tests/rollback_dispatch.rs
@@ -27,12 +27,7 @@
 
 mod common;
 
-use std::sync::Arc;
-
-use affinidi_did_resolver_cache_sdk::{DIDCacheClient, config::DIDCacheConfigBuilder};
 use vta_service::auth::AuthClaims;
-use vta_service::didcomm_bridge::DIDCommBridge;
-use vta_service::keys::seed_store::PlaintextSeedStore;
 use vta_service::messaging::handshake::AlwaysOkProver;
 use vta_service::operations::protocol::disable_didcomm::DisableTransport;
 use vta_service::operations::protocol::rollback_didcomm::{
@@ -42,24 +37,10 @@ use vta_service::operations::protocol::rollback_rest::{
     RollbackKind as RestRollbackKind, RollbackRestParams, rollback_rest,
 };
 
-use crate::common::state_fixtures::{ServiceState, StateFixture, setup_vta_in_state};
-
-async fn build_resolver() -> DIDCacheClient {
-    DIDCacheClient::new(DIDCacheConfigBuilder::default().build())
-        .await
-        .expect("DID resolver")
-}
+use crate::common::state_fixtures::{OpInfra, ServiceState, setup_vta_in_state};
 
 fn super_admin() -> AuthClaims {
     AuthClaims::unsafe_local_cli_super_admin("e2e-rollback")
-}
-
-fn dummy_bridge() -> Arc<DIDCommBridge> {
-    Arc::new(DIDCommBridge::placeholder())
-}
-
-fn dummy_seed_store(fx: &StateFixture) -> PlaintextSeedStore {
-    PlaintextSeedStore::new(&fx.store.data_dir)
 }
 
 /// Rolling back a `services rest enable` while DIDComm is also
@@ -84,32 +65,11 @@ async fn rollback_rest_brick_attempt_surfaces_last_service_refused() {
         .await
         .with_rest_snapshot_disabled()
         .await;
-    let resolver = build_resolver().await;
-    let seed_store = dummy_seed_store(&fx);
-    let locks = vta_service::operations::did_webvh::WebvhAuthLocks::new();
-    let bridge = dummy_bridge();
+    let infra = OpInfra::new(&fx).await;
 
-    let err = rollback_rest(
-        &fx.config,
-        &fx.store.keys_ks,
-        &fx.store.imported_ks,
-        &fx.store.contexts_ks,
-        &fx.store.webvh_ks,
-        &fx.store.audit_ks,
-        &fx.store.snapshot_ks,
-        &fx.store.service_state_ks,
-        &seed_store,
-        &resolver,
-        &bridge,
-        &(Arc::new(vti_common::telemetry::RingBufferTelemetry::new())
-            as vti_common::telemetry::SharedTelemetrySink),
-        &super_admin(),
-        RollbackRestParams,
-        &locks,
-        "test",
-    )
-    .await
-    .unwrap_err();
+    let err = rollback_rest(&infra.deps(&fx), &super_admin(), RollbackRestParams, "test")
+        .await
+        .unwrap_err();
 
     use vta_service::operations::protocol::disable_rest::DisableRestError;
     use vta_service::operations::protocol::rollback_rest::RollbackRestError;
@@ -152,46 +112,17 @@ async fn rollback_didcomm_brick_attempt_surfaces_last_service_refused() {
         .await
         .with_didcomm_snapshot_disabled()
         .await;
-    let resolver = build_resolver().await;
-    let seed_store = dummy_seed_store(&fx);
-    let locks = vta_service::operations::did_webvh::WebvhAuthLocks::new();
-    let bridge = dummy_bridge();
-    let telemetry: vti_common::telemetry::SharedTelemetrySink =
-        Arc::new(vti_common::telemetry::RingBufferTelemetry::new());
-    let registry = Arc::new(
-        vta_service::messaging::registry::MediatorListenerRegistry::new(Arc::clone(&telemetry)),
-    );
-    let (tx, _rx) = vta_service::messaging::drain_sweeper::teardown_channel(8);
-    let sweeper = Arc::new(vta_service::messaging::drain_sweeper::DrainSweeper::new(
-        Arc::clone(&registry),
-        fx.store.drains_ks.clone(),
-        tx,
-    ));
+    let infra = OpInfra::new(&fx).await;
     let prover = AlwaysOkProver;
 
     let err = rollback_didcomm(
-        &fx.config,
-        &fx.store.keys_ks,
-        &fx.store.imported_ks,
-        &fx.store.contexts_ks,
-        &fx.store.webvh_ks,
-        &fx.store.audit_ks,
-        &fx.store.drains_ks,
-        &fx.store.snapshot_ks,
-        &fx.store.service_state_ks,
-        &seed_store,
-        &resolver,
-        &bridge,
-        &registry,
-        &sweeper,
-        &telemetry,
+        &infra.deps(&fx),
         &prover,
         &super_admin(),
         RollbackDidcommParams {
             drain_ttl: std::time::Duration::from_secs(86_400),
             transport: DisableTransport::Rest,
         },
-        &locks,
         "test",
     )
     .await

--- a/tests/e2e/tests/state_op_matrix.rs
+++ b/tests/e2e/tests/state_op_matrix.rs
@@ -33,12 +33,7 @@
 
 mod common;
 
-use std::sync::Arc;
-
-use affinidi_did_resolver_cache_sdk::{DIDCacheClient, config::DIDCacheConfigBuilder};
 use vta_service::auth::AuthClaims;
-use vta_service::didcomm_bridge::DIDCommBridge;
-use vta_service::keys::seed_store::PlaintextSeedStore;
 use vta_service::messaging::handshake::AlwaysOkProver;
 use vta_service::operations::protocol::OpContext;
 use vta_service::operations::protocol::disable_didcomm::{
@@ -66,26 +61,12 @@ use vta_service::operations::protocol::update_rest::{
     UpdateRestError, UpdateRestParams, update_rest,
 };
 
-use crate::common::state_fixtures::{ServiceState, StateFixture, setup_vta_in_state};
+use crate::common::state_fixtures::{OpInfra, ServiceState, setup_vta_in_state};
 
 const FIXTURE_URL: &str = "https://vta.test";
 
-async fn build_resolver() -> DIDCacheClient {
-    DIDCacheClient::new(DIDCacheConfigBuilder::default().build())
-        .await
-        .expect("DID resolver")
-}
-
 fn super_admin() -> AuthClaims {
     AuthClaims::unsafe_local_cli_super_admin("e2e-matrix")
-}
-
-fn dummy_bridge() -> Arc<DIDCommBridge> {
-    Arc::new(DIDCommBridge::placeholder())
-}
-
-fn dummy_seed_store(fx: &StateFixture) -> PlaintextSeedStore {
-    PlaintextSeedStore::new(&fx.store.data_dir)
 }
 
 // ── enable_rest cells ────────────────────────────────────────────
@@ -93,31 +74,15 @@ fn dummy_seed_store(fx: &StateFixture) -> PlaintextSeedStore {
 #[tokio::test]
 async fn s1_rest_enable_returns_service_already_enabled() {
     let fx = setup_vta_in_state(ServiceState::S1).await;
-    let resolver = build_resolver().await;
-    let seed_store = dummy_seed_store(&fx);
-    let locks = vta_service::operations::did_webvh::WebvhAuthLocks::new();
-    let bridge = dummy_bridge();
+    let infra = OpInfra::new(&fx).await;
 
     let err = enable_rest(
-        &fx.config,
-        &fx.store.keys_ks,
-        &fx.store.imported_ks,
-        &fx.store.contexts_ks,
-        &fx.store.webvh_ks,
-        &fx.store.audit_ks,
-        &fx.store.snapshot_ks,
-        &fx.store.service_state_ks,
-        &seed_store,
-        &resolver,
-        &bridge,
-        &(Arc::new(vti_common::telemetry::RingBufferTelemetry::new())
-            as vti_common::telemetry::SharedTelemetrySink),
+        &infra.deps(&fx),
         &super_admin(),
         EnableRestParams {
             url: "https://x.example.com".into(),
         },
         OpContext::Direct,
-        &locks,
         "test",
     )
     .await
@@ -128,31 +93,15 @@ async fn s1_rest_enable_returns_service_already_enabled() {
 #[tokio::test]
 async fn s3_rest_enable_returns_service_already_enabled() {
     let fx = setup_vta_in_state(ServiceState::S3).await;
-    let resolver = build_resolver().await;
-    let seed_store = dummy_seed_store(&fx);
-    let locks = vta_service::operations::did_webvh::WebvhAuthLocks::new();
-    let bridge = dummy_bridge();
+    let infra = OpInfra::new(&fx).await;
 
     let err = enable_rest(
-        &fx.config,
-        &fx.store.keys_ks,
-        &fx.store.imported_ks,
-        &fx.store.contexts_ks,
-        &fx.store.webvh_ks,
-        &fx.store.audit_ks,
-        &fx.store.snapshot_ks,
-        &fx.store.service_state_ks,
-        &seed_store,
-        &resolver,
-        &bridge,
-        &(Arc::new(vti_common::telemetry::RingBufferTelemetry::new())
-            as vti_common::telemetry::SharedTelemetrySink),
+        &infra.deps(&fx),
         &super_admin(),
         EnableRestParams {
             url: "https://x.example.com".into(),
         },
         OpContext::Direct,
-        &locks,
         "test",
     )
     .await
@@ -165,31 +114,15 @@ async fn s3_rest_enable_returns_service_already_enabled() {
 #[tokio::test]
 async fn s2_rest_update_returns_service_not_present() {
     let fx = setup_vta_in_state(ServiceState::S2).await;
-    let resolver = build_resolver().await;
-    let seed_store = dummy_seed_store(&fx);
-    let locks = vta_service::operations::did_webvh::WebvhAuthLocks::new();
-    let bridge = dummy_bridge();
+    let infra = OpInfra::new(&fx).await;
 
     let err = update_rest(
-        &fx.config,
-        &fx.store.keys_ks,
-        &fx.store.imported_ks,
-        &fx.store.contexts_ks,
-        &fx.store.webvh_ks,
-        &fx.store.audit_ks,
-        &fx.store.snapshot_ks,
-        &fx.store.service_state_ks,
-        &seed_store,
-        &resolver,
-        &bridge,
-        &(Arc::new(vti_common::telemetry::RingBufferTelemetry::new())
-            as vti_common::telemetry::SharedTelemetrySink),
+        &infra.deps(&fx),
         &super_admin(),
         UpdateRestParams {
             url: "https://new.example.com".into(),
         },
         OpContext::Direct,
-        &locks,
         "test",
     )
     .await
@@ -202,29 +135,13 @@ async fn s2_rest_update_returns_service_not_present() {
 #[tokio::test]
 async fn s1_rest_disable_returns_last_service_refused() {
     let fx = setup_vta_in_state(ServiceState::S1).await;
-    let resolver = build_resolver().await;
-    let seed_store = dummy_seed_store(&fx);
-    let locks = vta_service::operations::did_webvh::WebvhAuthLocks::new();
-    let bridge = dummy_bridge();
+    let infra = OpInfra::new(&fx).await;
 
     let err = disable_rest(
-        &fx.config,
-        &fx.store.keys_ks,
-        &fx.store.imported_ks,
-        &fx.store.contexts_ks,
-        &fx.store.webvh_ks,
-        &fx.store.audit_ks,
-        &fx.store.snapshot_ks,
-        &fx.store.service_state_ks,
-        &seed_store,
-        &resolver,
-        &bridge,
-        &(Arc::new(vti_common::telemetry::RingBufferTelemetry::new())
-            as vti_common::telemetry::SharedTelemetrySink),
+        &infra.deps(&fx),
         &super_admin(),
         DisableRestParams,
         OpContext::Direct,
-        &locks,
         "test",
     )
     .await
@@ -235,29 +152,13 @@ async fn s1_rest_disable_returns_last_service_refused() {
 #[tokio::test]
 async fn s2_rest_disable_returns_service_not_present() {
     let fx = setup_vta_in_state(ServiceState::S2).await;
-    let resolver = build_resolver().await;
-    let seed_store = dummy_seed_store(&fx);
-    let locks = vta_service::operations::did_webvh::WebvhAuthLocks::new();
-    let bridge = dummy_bridge();
+    let infra = OpInfra::new(&fx).await;
 
     let err = disable_rest(
-        &fx.config,
-        &fx.store.keys_ks,
-        &fx.store.imported_ks,
-        &fx.store.contexts_ks,
-        &fx.store.webvh_ks,
-        &fx.store.audit_ks,
-        &fx.store.snapshot_ks,
-        &fx.store.service_state_ks,
-        &seed_store,
-        &resolver,
-        &bridge,
-        &(Arc::new(vti_common::telemetry::RingBufferTelemetry::new())
-            as vti_common::telemetry::SharedTelemetrySink),
+        &infra.deps(&fx),
         &super_admin(),
         DisableRestParams,
         OpContext::Direct,
-        &locks,
         "test",
     )
     .await
@@ -270,30 +171,11 @@ async fn s2_rest_disable_returns_service_not_present() {
 #[tokio::test]
 async fn s2_didcomm_enable_returns_already_enabled() {
     let fx = setup_vta_in_state(ServiceState::S2).await;
-    let resolver = build_resolver().await;
-    let seed_store = dummy_seed_store(&fx);
-    let locks = vta_service::operations::did_webvh::WebvhAuthLocks::new();
-    let bridge = dummy_bridge();
-    let registry = vta_service::messaging::registry::MediatorListenerRegistry::new(Arc::new(
-        vti_common::telemetry::RingBufferTelemetry::new(),
-    ));
+    let infra = OpInfra::new(&fx).await;
     let prover = AlwaysOkProver;
 
     let err = enable_didcomm(
-        &fx.config,
-        &fx.store.keys_ks,
-        &fx.store.imported_ks,
-        &fx.store.contexts_ks,
-        &fx.store.webvh_ks,
-        &fx.store.audit_ks,
-        &fx.store.snapshot_ks,
-        &fx.store.service_state_ks,
-        &seed_store,
-        &resolver,
-        &bridge,
-        &registry,
-        &(Arc::new(vti_common::telemetry::RingBufferTelemetry::new())
-            as vti_common::telemetry::SharedTelemetrySink),
+        &infra.deps(&fx),
         &prover,
         &super_admin(),
         EnableDidcommParams {
@@ -302,7 +184,6 @@ async fn s2_didcomm_enable_returns_already_enabled() {
             handshake_timeout: std::time::Duration::from_secs(1),
         },
         OpContext::Direct,
-        &locks,
         "test",
     )
     .await
@@ -313,30 +194,11 @@ async fn s2_didcomm_enable_returns_already_enabled() {
 #[tokio::test]
 async fn s3_didcomm_enable_returns_already_enabled() {
     let fx = setup_vta_in_state(ServiceState::S3).await;
-    let resolver = build_resolver().await;
-    let seed_store = dummy_seed_store(&fx);
-    let locks = vta_service::operations::did_webvh::WebvhAuthLocks::new();
-    let bridge = dummy_bridge();
-    let registry = vta_service::messaging::registry::MediatorListenerRegistry::new(Arc::new(
-        vti_common::telemetry::RingBufferTelemetry::new(),
-    ));
+    let infra = OpInfra::new(&fx).await;
     let prover = AlwaysOkProver;
 
     let err = enable_didcomm(
-        &fx.config,
-        &fx.store.keys_ks,
-        &fx.store.imported_ks,
-        &fx.store.contexts_ks,
-        &fx.store.webvh_ks,
-        &fx.store.audit_ks,
-        &fx.store.snapshot_ks,
-        &fx.store.service_state_ks,
-        &seed_store,
-        &resolver,
-        &bridge,
-        &registry,
-        &(Arc::new(vti_common::telemetry::RingBufferTelemetry::new())
-            as vti_common::telemetry::SharedTelemetrySink),
+        &infra.deps(&fx),
         &prover,
         &super_admin(),
         EnableDidcommParams {
@@ -345,7 +207,6 @@ async fn s3_didcomm_enable_returns_already_enabled() {
             handshake_timeout: std::time::Duration::from_secs(1),
         },
         OpContext::Direct,
-        &locks,
         "test",
     )
     .await
@@ -358,39 +219,11 @@ async fn s3_didcomm_enable_returns_already_enabled() {
 #[tokio::test]
 async fn s1_didcomm_update_returns_didcomm_not_enabled() {
     let fx = setup_vta_in_state(ServiceState::S1).await;
-    let resolver = build_resolver().await;
-    let seed_store = dummy_seed_store(&fx);
-    let locks = vta_service::operations::did_webvh::WebvhAuthLocks::new();
-    let bridge = dummy_bridge();
-    let telemetry: vti_common::telemetry::SharedTelemetrySink =
-        Arc::new(vti_common::telemetry::RingBufferTelemetry::new());
-    let registry = Arc::new(
-        vta_service::messaging::registry::MediatorListenerRegistry::new(Arc::clone(&telemetry)),
-    );
-    let (tx, _rx) = vta_service::messaging::drain_sweeper::teardown_channel(8);
-    let sweeper = Arc::new(vta_service::messaging::drain_sweeper::DrainSweeper::new(
-        Arc::clone(&registry),
-        fx.store.drains_ks.clone(),
-        tx,
-    ));
+    let infra = OpInfra::new(&fx).await;
     let prover = AlwaysOkProver;
 
     let err = update_didcomm(
-        &fx.config,
-        &fx.store.keys_ks,
-        &fx.store.imported_ks,
-        &fx.store.contexts_ks,
-        &fx.store.webvh_ks,
-        &fx.store.audit_ks,
-        &fx.store.drains_ks,
-        &fx.store.snapshot_ks,
-        &fx.store.service_state_ks,
-        &seed_store,
-        &resolver,
-        &bridge,
-        &registry,
-        &sweeper,
-        &telemetry,
+        &infra.deps(&fx),
         &prover,
         &super_admin(),
         UpdateDidcommParams {
@@ -402,7 +235,6 @@ async fn s1_didcomm_update_returns_didcomm_not_enabled() {
             transport: vta_service::operations::protocol::disable_didcomm::DisableTransport::Rest,
         },
         OpContext::Direct,
-        &locks,
         "test",
     )
     .await
@@ -415,45 +247,16 @@ async fn s1_didcomm_update_returns_didcomm_not_enabled() {
 #[tokio::test]
 async fn s1_didcomm_disable_returns_didcomm_not_enabled() {
     let fx = setup_vta_in_state(ServiceState::S1).await;
-    let resolver = build_resolver().await;
-    let seed_store = dummy_seed_store(&fx);
-    let locks = vta_service::operations::did_webvh::WebvhAuthLocks::new();
-    let bridge = dummy_bridge();
-    let telemetry: vti_common::telemetry::SharedTelemetrySink =
-        Arc::new(vti_common::telemetry::RingBufferTelemetry::new());
-    let registry = Arc::new(
-        vta_service::messaging::registry::MediatorListenerRegistry::new(Arc::clone(&telemetry)),
-    );
-    let (tx, _rx) = vta_service::messaging::drain_sweeper::teardown_channel(8);
-    let sweeper = vta_service::messaging::drain_sweeper::DrainSweeper::new(
-        Arc::clone(&registry),
-        fx.store.drains_ks.clone(),
-        tx,
-    );
+    let infra = OpInfra::new(&fx).await;
 
     let err = disable_didcomm(
-        &fx.config,
-        &fx.store.keys_ks,
-        &fx.store.imported_ks,
-        &fx.store.contexts_ks,
-        &fx.store.webvh_ks,
-        &fx.store.audit_ks,
-        &fx.store.drains_ks,
-        &fx.store.snapshot_ks,
-        &fx.store.service_state_ks,
-        &seed_store,
-        &resolver,
-        &bridge,
-        &registry,
-        &sweeper,
-        &telemetry,
+        &infra.deps(&fx),
         &super_admin(),
         DisableDidcommParams {
             drain_ttl: std::time::Duration::from_secs(3600),
             transport: DisableTransport::Rest,
         },
         OpContext::Direct,
-        &locks,
         "test",
     )
     .await
@@ -464,45 +267,16 @@ async fn s1_didcomm_disable_returns_didcomm_not_enabled() {
 #[tokio::test]
 async fn s2_didcomm_disable_returns_no_protocol_remaining() {
     let fx = setup_vta_in_state(ServiceState::S2).await;
-    let resolver = build_resolver().await;
-    let seed_store = dummy_seed_store(&fx);
-    let locks = vta_service::operations::did_webvh::WebvhAuthLocks::new();
-    let bridge = dummy_bridge();
-    let telemetry: vti_common::telemetry::SharedTelemetrySink =
-        Arc::new(vti_common::telemetry::RingBufferTelemetry::new());
-    let registry = Arc::new(
-        vta_service::messaging::registry::MediatorListenerRegistry::new(Arc::clone(&telemetry)),
-    );
-    let (tx, _rx) = vta_service::messaging::drain_sweeper::teardown_channel(8);
-    let sweeper = vta_service::messaging::drain_sweeper::DrainSweeper::new(
-        Arc::clone(&registry),
-        fx.store.drains_ks.clone(),
-        tx,
-    );
+    let infra = OpInfra::new(&fx).await;
 
     let err = disable_didcomm(
-        &fx.config,
-        &fx.store.keys_ks,
-        &fx.store.imported_ks,
-        &fx.store.contexts_ks,
-        &fx.store.webvh_ks,
-        &fx.store.audit_ks,
-        &fx.store.drains_ks,
-        &fx.store.snapshot_ks,
-        &fx.store.service_state_ks,
-        &seed_store,
-        &resolver,
-        &bridge,
-        &registry,
-        &sweeper,
-        &telemetry,
+        &infra.deps(&fx),
         &super_admin(),
         DisableDidcommParams {
             drain_ttl: std::time::Duration::from_secs(3600),
             transport: DisableTransport::Rest,
         },
         OpContext::Direct,
-        &locks,
         "test",
     )
     .await
@@ -519,32 +293,11 @@ async fn s2_didcomm_disable_returns_no_protocol_remaining() {
 async fn rollback_rest_with_empty_snapshot_returns_no_prior_mutation() {
     for state in [ServiceState::S1, ServiceState::S2, ServiceState::S3] {
         let fx = setup_vta_in_state(state).await;
-        let resolver = build_resolver().await;
-        let seed_store = dummy_seed_store(&fx);
-        let locks = vta_service::operations::did_webvh::WebvhAuthLocks::new();
-        let bridge = dummy_bridge();
+        let infra = OpInfra::new(&fx).await;
 
-        let err = rollback_rest(
-            &fx.config,
-            &fx.store.keys_ks,
-            &fx.store.imported_ks,
-            &fx.store.contexts_ks,
-            &fx.store.webvh_ks,
-            &fx.store.audit_ks,
-            &fx.store.snapshot_ks,
-            &fx.store.service_state_ks,
-            &seed_store,
-            &resolver,
-            &bridge,
-            &(Arc::new(vti_common::telemetry::RingBufferTelemetry::new())
-                as vti_common::telemetry::SharedTelemetrySink),
-            &super_admin(),
-            RollbackRestParams,
-            &locks,
-            "test",
-        )
-        .await
-        .unwrap_err();
+        let err = rollback_rest(&infra.deps(&fx), &super_admin(), RollbackRestParams, "test")
+            .await
+            .unwrap_err();
         assert!(
             matches!(err, RollbackRestError::NoPriorMutation),
             "rollback_rest from {state:?} with empty snapshot must return NoPriorMutation, got {err:?}",
@@ -556,46 +309,17 @@ async fn rollback_rest_with_empty_snapshot_returns_no_prior_mutation() {
 async fn rollback_didcomm_with_empty_snapshot_returns_no_prior_mutation() {
     for state in [ServiceState::S1, ServiceState::S2, ServiceState::S3] {
         let fx = setup_vta_in_state(state).await;
-        let resolver = build_resolver().await;
-        let seed_store = dummy_seed_store(&fx);
-        let locks = vta_service::operations::did_webvh::WebvhAuthLocks::new();
-        let bridge = dummy_bridge();
-        let telemetry: vti_common::telemetry::SharedTelemetrySink =
-            Arc::new(vti_common::telemetry::RingBufferTelemetry::new());
-        let registry = Arc::new(
-            vta_service::messaging::registry::MediatorListenerRegistry::new(Arc::clone(&telemetry)),
-        );
-        let (tx, _rx) = vta_service::messaging::drain_sweeper::teardown_channel(8);
-        let sweeper = Arc::new(vta_service::messaging::drain_sweeper::DrainSweeper::new(
-            Arc::clone(&registry),
-            fx.store.drains_ks.clone(),
-            tx,
-        ));
+        let infra = OpInfra::new(&fx).await;
         let prover = AlwaysOkProver;
 
         let err = rollback_didcomm(
-            &fx.config,
-            &fx.store.keys_ks,
-            &fx.store.imported_ks,
-            &fx.store.contexts_ks,
-            &fx.store.webvh_ks,
-            &fx.store.audit_ks,
-            &fx.store.drains_ks,
-            &fx.store.snapshot_ks,
-            &fx.store.service_state_ks,
-            &seed_store,
-            &resolver,
-            &bridge,
-            &registry,
-            &sweeper,
-            &telemetry,
+            &infra.deps(&fx),
             &prover,
             &super_admin(),
             RollbackDidcommParams {
                 drain_ttl: std::time::Duration::from_secs(86_400),
                 transport: DisableTransport::Rest,
             },
-            &locks,
             "test",
         )
         .await

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -96,6 +96,7 @@ use trust_tasks_rs::RejectReason;
 /// can't drift. Handlers live in `routes::auth` (passkey login, legacy
 /// challenge/authenticate/refresh) and `routes::attestation` (TEE status /
 /// report).
+#[allow(dead_code)] // consumed by the dispatcher's test-only parity harness
 const REST_ROUTED: &[&str] = vta_sdk::trust_tasks::REST_ROUTED_URIS;
 
 /// URIs that vta-sdk declares but the dispatcher may not wire in

--- a/vtc-service/src/server.rs
+++ b/vtc-service/src/server.rs
@@ -1147,14 +1147,20 @@ fn run_rest_thread(
             .layer(host_layer)
             .layer(cors_layer)
             .layer(TraceLayer::new_for_http())
-            .layer(TimeoutLayer::new(REST_REQUEST_TIMEOUT));
+            .layer(TimeoutLayer::with_status_code(
+                axum::http::StatusCode::REQUEST_TIMEOUT,
+                REST_REQUEST_TIMEOUT,
+            ));
         #[cfg(not(feature = "website"))]
         let app = routes::router_with_xff(&routing, trust_xff)
             .with_state(state)
             .layer(host_layer)
             .layer(cors_layer)
             .layer(TraceLayer::new_for_http())
-            .layer(TimeoutLayer::new(REST_REQUEST_TIMEOUT));
+            .layer(TimeoutLayer::with_status_code(
+                axum::http::StatusCode::REQUEST_TIMEOUT,
+                REST_REQUEST_TIMEOUT,
+            ));
 
         let shutdown_rx = shutdown_rx.clone();
         // `into_make_service_with_connect_info` is required for the
@@ -1614,7 +1620,10 @@ mod p0_10_timeout_tests {
         let app = axum::Router::new()
             .route("/slow", get(slow))
             .route("/fast", get(fast))
-            .layer(TimeoutLayer::new(std::time::Duration::from_millis(50)));
+            .layer(TimeoutLayer::with_status_code(
+                StatusCode::REQUEST_TIMEOUT,
+                std::time::Duration::from_millis(50),
+            ));
 
         let slow_res = app
             .clone()


### PR DESCRIPTION
`main` CI is currently red on three jobs (independent of any feature PR — `main` itself is broken). This fixes the two that originate in this repo.

## Clippy (`-D warnings`)
- **`vtc-service`** used the now-deprecated `TimeoutLayer::new`. Switched the two production layers + the test to `TimeoutLayer::with_status_code(StatusCode::REQUEST_TIMEOUT, ..)` — the same form `vta-service/src/routes/mod.rs` already uses, preserving the documented 408 behaviour.
- **`vta-service`**: `REST_ROUTED` is consumed only by the test-only parity harness, so it's dead code in a non-test build. Added `#[allow(dead_code)]`, matching its sibling `KNOWN_FEATURE_GATED_URIS`.

## Test
The `vti-e2e-tests` `state_op_matrix` and `rollback_dispatch` suites still called the runtime-service-management ops (`enable_rest`, `enable_didcomm`, …) with the old ~17 positional args. Those ops were consolidated onto a single borrowed `ServiceOpDeps` bundle. Added an `OpInfra` test helper to `common/state_fixtures.rs` — it owns the seed store / resolver / bridge / telemetry / registry / sweeper / locks and hands out a borrowed `ServiceOpDeps`, mirroring the in-crate `TestEnv` pattern — and migrated every call site to it.

## Verification
- `cargo clippy --workspace -- -D warnings` — clean
- `vti-e2e-tests` compiles; migrated suites pass (**11 + 21**)
- `cargo fmt --check` — clean

## Not addressed here — `Mobile build` (upstream)
The `Mobile build` job is also red, but from an upstream dependency: `affinidi-tdk-common` (≤ 0.6.4) calls `Verifier::new_with_extra_roots`, which `rustls-platform-verifier` 0.7.0 does not provide on Android (only `new`), and the call is not cfg-gated. Needs a fix in [`affinidi/affinidi-tdk-rs`](https://github.com/affinidi/affinidi-tdk-rs); cannot be resolved from this repo.