### PR TITLE
fix(vta-sdk): unbreak Test — add seed_enc to SeedRecordBackup in redaction test

### DIFF
--- a/vta-sdk/tests/protocol_debug_redaction.rs
+++ b/vta-sdk/tests/protocol_debug_redaction.rs
@@ -169,6 +169,7 @@ fn seed_record_backup_debug_redacts_seed_hex() {
     let s = SeedRecordBackup {
         id: 1,
         seed_hex: Some(MARKER.into()),
+        seed_enc: None,
         created_at: Utc::now(),
         retired_at: None,
     };


### PR DESCRIPTION
The `Test` CI job is still red on `main` after #508, now from a **different, previously-masked** compile error:

```
error[E0063]: missing field `seed_enc` in initializer of `SeedRecordBackup`
error: could not compile `vta-sdk` (test "protocol_debug_redaction")
```

## Cause
#507 (P0.7b encrypted retired-seed archive) added `seed_enc: Option<Vec<u8>>` to `SeedRecordBackup`, but the `protocol_debug_redaction` integration test builds that struct with a literal and wasn't updated.

It stayed hidden because the `Test` job compiles all test targets and bailed on the **earlier** `vti-e2e-tests` compile failure (fixed in #508) before reaching `vta-sdk`'s test targets. With #508 merged, this one surfaced.

## Fix
Set `seed_enc: None` in the test literal — matching every other construction site (`vta-service`'s `test_support.rs`, `from_toml.rs`, `seeds.rs`).

## Verification
- `cargo test --workspace --no-run` — clean (confirms **no further** masked compile errors behind this one)
- `cargo test -p vta-sdk --test protocol_debug_redaction` — 10/10 pass
- `cargo fmt --check` — clean

After this merges, the `Test` job goes green. The only remaining red job is `Mobile build` — the upstream `affinidi-tdk-rs` Android issue (affinidi/affinidi-tdk-rs#483).