### PR TITLE
fix(setup): script the TEE-only resolver prompt in golden setup tests

### DIFF
--- a/vta-service/src/setup/interactive.rs
+++ b/vta-service/src/setup/interactive.rs
@@ -1115,22 +1115,29 @@ mod tests {
             text("https://trust.example.com"),   // REST URL
             text("info"),                        // log level
             Answer::Index(0),                    // log format = text
-            text("90"),                          // audit retention
-            text("/tmp/vta-golden/data"),        // data dir (doesn't exist)
-            Answer::Bool(true),                  // configure advanced server opts?
-            text("https://app.example.com"),     // cors origins
-            Answer::Bool(true),                  // trust_xff
-            Answer::Bool(true),                  // webauthn
-            Answer::Index(0),                    // secrets backend = keyring
-            text("golden-keyring"),              // keyring service
-            Answer::Index(1),                    // messaging = create mediator
-            text("mediator"),                    // mediator context
-            text("https://mediator.example.com"), // mediator DIDComm url
-            text("wss://mediator.example.com/ws"), // mediator ws url
+            // TEE builds add an extra "Remote DID resolver WebSocket URL"
+            // prompt here (vsock-bridged resolution); empty = skip. Only
+            // scripted when `tee` is active so the answer sequence stays
+            // aligned under both feature sets (CI's `--workspace` build
+            // unifies `tee` onto this binary via vta-enclave).
+            #[cfg(feature = "tee")]
+            text(""), // TEE-only: remote DID resolver URL (skip)
+            text("90"),                                // audit retention
+            text("/tmp/vta-golden/data"),              // data dir (doesn't exist)
+            Answer::Bool(true),                        // configure advanced server opts?
+            text("https://app.example.com"),           // cors origins
+            Answer::Bool(true),                        // trust_xff
+            Answer::Bool(true),                        // webauthn
+            Answer::Index(0),                          // secrets backend = keyring
+            text("golden-keyring"),                    // keyring service
+            Answer::Index(1),                          // messaging = create mediator
+            text("mediator"),                          // mediator context
+            text("https://mediator.example.com"),      // mediator DIDComm url
+            text("wss://mediator.example.com/ws"),     // mediator ws url
             text("https://dids.example.com/mediator"), // mediator DID URL (split host)
-            text(""),                            // mediator host (skip)
-            text(""),                            // routing keys (skip)
-            Answer::Index(1),                    // VTA DID = did:key
+            text(""),                                  // mediator host (skip)
+            text(""),                                  // routing keys (skip)
+            Answer::Index(1),                          // VTA DID = did:key
         ];
         let p = ScriptedPrompter::new(answers);
         let gathered = gather_inputs(&p, None)
@@ -1200,6 +1207,10 @@ mod tests {
             text("https://t.example.com"), // REST URL
             text("info"),                  // log level
             Answer::Index(0),              // log format
+            // TEE-only "Remote DID resolver WebSocket URL" prompt; empty =
+            // skip. See the note in `interactive_matches_equivalent_toml`.
+            #[cfg(feature = "tee")]
+            text(""), // TEE-only: remote DID resolver URL (skip)
             text("28"),                    // audit retention
             text("/tmp/vta-golden2/data"), // data dir
             Answer::Bool(false),           // advanced server opts? no


### PR DESCRIPTION
The `Test` job is still red on `main` after #510 — now a **runtime** failure (the prior fixes were compile errors that masked it):

```
test setup::interactive::tests::interactive_matches_equivalent_toml ... FAILED
test setup::interactive::tests::advanced_existing_keys_mode_maps_through ... FAILED

gather should succeed: "scripted answer \"/tmp/vta-golden/data\" failed
validation: invalid number: invalid digit found in string"
```

## Cause
`configure_server` shows an extra `#[cfg(feature = "tee")]` prompt — **"Remote DID resolver WebSocket URL"** (step 6, vsock-bridged resolution in the enclave). The two golden answer scripts don't include it, so under a `tee` build every later answer shifts by one: the data-dir path (`/tmp/vta-golden/data`) lands on the numeric **"Audit-log retention (days)"** prompt and fails to parse.

It only bites under `cargo test --workspace` (the CI form): `vta-enclave` depends on `vta-service` with `features = ["tee"]`, and Cargo **unifies** that onto the `vta` binary's test build. A bare `cargo test -p vta-service` (no `tee`) passes — which is why it wasn't caught locally, and the whole `Test` job was red on an earlier e2e compile error until #508/#510, so these tests had never actually run in CI.

## Fix
Script an empty answer for the resolver prompt, gated on `#[cfg(feature = "tee")]`, so the sequence stays aligned under **both** feature sets (empty = skip → `resolver_url: None`, which matches the equivalent TOML the golden test compares against).

## Verification
- `cargo test -p vta-service --bin vta --features tee,test-support,webvh setup::interactive` — 2 pass
- `cargo test -p vta-service --bin vta setup::interactive` (default, no tee) — 2 pass
- `cargo fmt --check` — clean

These two were the **only** runtime failures in the CI `Test` log (every other test binary reported `ok`), so this should take the `Test` job green. The remaining red job is `Mobile build` (upstream — affinidi/affinidi-tdk-rs#483).