### PR TITLE
fix(vtc-admin-ui): read VTA/mediator DIDs from diagnostics endpoint

### DIFF
--- a/vtc-service/admin-ui/src/lib/api.ts
+++ b/vtc-service/admin-ui/src/lib/api.ts
@@ -5,13 +5,36 @@
 // `csrf` cookie's value into the `X-CSRF-Token` header for the
 // double-submit check in `routing::csrf`.
 
+// `GET /health` is unauth and deliberately minimal: it carries only
+// `{status, version, vtc_did}`. The `vta_did` / `mediator_url` /
+// `mediator_did` infrastructure detail moved to the admin-gated
+// `/v1/health/diagnostics` (P3.7) so it isn't a free unauth recon
+// oracle — read those from `DiagnosticsResponse` instead.
 export interface HealthResponse {
   status: string;
   version: string;
   vtc_did?: string;
+}
+
+// `GET /v1/health/diagnostics` — admin-gated. Surfaces the
+// trust-registry reconciler state plus the identity/mediator detail
+// that used to live on `/health`. The dashboard only needs the
+// identity fields; the rest are typed for future diagnostics views.
+export interface DiagnosticsResponse {
+  registry_status: string;
+  queue_depth: number;
+  rtbf_batched_count: number;
+  failed_count: number;
+  oldest_pending_age_seconds?: number;
+  last_success_at?: string;
+  last_failure_at?: string;
+  last_error?: string;
   vta_did?: string;
   mediator_url?: string;
   mediator_did?: string;
+  syncer_enabled: boolean;
+  syncer_running: boolean;
+  syncer_restarts: number;
 }
 
 export interface BuildInfo {
@@ -177,6 +200,17 @@ export const fetchHealth = (): Promise<HealthResponse> =>
 
 export const fetchBuildInfo = (): Promise<BuildInfo> =>
   getJsonExempt<BuildInfo>("/admin/build-info.json");
+
+const DIAGNOSTICS_TASK =
+  "https://trusttasks.org/openvtc/vtc/health/diagnostics/1.0";
+
+// Admin-gated identity + reconciler diagnostics. The dashboard reads
+// `vta_did` / `mediator_did` from here since P3.7 stripped them off
+// the unauth `/health` payload.
+export const fetchDiagnostics = (): Promise<DiagnosticsResponse> =>
+  getJson<DiagnosticsResponse>("/v1/health/diagnostics", {
+    trustTask: DIAGNOSTICS_TASK,
+  });
 
 /** Shape returned by `GET /v1/auth/whoami`. */
 export interface WhoamiResponse {

--- a/vtc-service/admin-ui/src/plugins/dashboard.tsx
+++ b/vtc-service/admin-ui/src/plugins/dashboard.tsx
@@ -2,7 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { ExternalLink } from "lucide-react";
 
 import { CopyButton } from "@/components/CopyButton";
-import { fetchHealth, fetchBuildInfo } from "@/lib/api";
+import { fetchHealth, fetchBuildInfo, fetchDiagnostics } from "@/lib/api";
 
 export function Dashboard() {
   const health = useQuery({ queryKey: ["health"], queryFn: fetchHealth });
@@ -10,10 +10,17 @@ export function Dashboard() {
     queryKey: ["build-info"],
     queryFn: fetchBuildInfo,
   });
+  // VTA + mediator identity moved off the unauth `/health` payload to
+  // the admin-gated diagnostics endpoint (P3.7); the SPA is already
+  // authenticated as admin, so it can read them there.
+  const diagnostics = useQuery({
+    queryKey: ["diagnostics"],
+    queryFn: fetchDiagnostics,
+  });
 
   const status = health.data?.status;
-  const mediatorDid = health.data?.mediator_did;
-  const vtaDid = health.data?.vta_did;
+  const mediatorDid = diagnostics.data?.mediator_did;
+  const vtaDid = diagnostics.data?.vta_did;
 
   return (
     <section className="page">
@@ -72,20 +79,18 @@ export function Dashboard() {
           </dd>
           <dt>VTA DID</dt>
           <dd>
-            <code>{health.data?.vta_did ?? "(not configured)"}</code>
+            <code>{vtaDid ?? "(not configured)"}</code>
             <CopyButton
-              value={health.data?.vta_did}
+              value={vtaDid}
               label="Copy VTA DID"
               successMessage="VTA DID copied"
             />
           </dd>
           <dt>Mediator DID</dt>
           <dd>
-            <code>
-              {health.data?.mediator_did ?? "(none configured)"}
-            </code>
+            <code>{mediatorDid ?? "(none configured)"}</code>
             <CopyButton
-              value={health.data?.mediator_did}
+              value={mediatorDid}
               label="Copy mediator DID"
               successMessage="Mediator DID copied"
             />
@@ -100,11 +105,14 @@ export function Dashboard() {
         </dl>
       </section>
 
-      {(health.error || build.error) && (
+      {(health.error || build.error || diagnostics.error) && (
         <section className="card error">
           <h3>Errors</h3>
           {health.error && <p>health: {String(health.error)}</p>}
           {build.error && <p>build-info: {String(build.error)}</p>}
+          {diagnostics.error && (
+            <p>diagnostics: {String(diagnostics.error)}</p>
+          )}
         </section>
       )}
     </section>


### PR DESCRIPTION
## Problem

After upgrading a VTC past **PR #472 (P3.7)**, the admin dashboard shows **VTA = "Not set"** and **MEDIATOR = "Not set"** even though the VTA/mediator are still bound (config intact in `config.toml`, daemon healthy). Only the dashboard read path broke.

<img width="600" alt="dashboard showing Not set" src="https://github.com/user-attachments/assets/placeholder" />

## Root cause

PR #472 deliberately stripped `vta_did` / `mediator_url` / `mediator_did` off the **unauth** `GET /health` payload (it was a free recon oracle — `mediator_url` leaked infra topology) and moved them to the **admin-gated** `GET /v1/health/diagnostics`. The server half shipped; the admin-UI half never did.

The dashboard kept reading `health.data?.vta_did` / `?.mediator_did` (`dashboard.tsx`), which are now always `undefined` → renders "Not set". The stale `HealthResponse` TS interface still *declared* those fields, so the mismatch compiled clean instead of failing typecheck — which is why it slipped through.

`vtc_did` still displays because #472 kept it as the one identity field on `/health`.

## Fix

Complete the client half of the #472 move:

- Trim `HealthResponse` to what `/health` actually returns (`status`, `version`, `vtc_did`).
- Add `DiagnosticsResponse` + `fetchDiagnostics()` calling `/v1/health/diagnostics` with its Trust-Task header (`.../openvtc/vtc/health/diagnostics/1.0`).
- Source the dashboard's VTA/mediator DIDs (status tiles, identity rows, copy buttons) from diagnostics; surface its query error in the error panel too.

The SPA is already authenticated as admin, so it can read the gated endpoint. `/health` stays minimal — no recon-oracle regression.

## Notes

- Config was never lost; **re-running `vtc setup` is not needed** (the UI hint was misleading).
- The admin UI is baked into the binary at compile time (`build.rs` + `include_dir!`), so this needs a `cargo build -p vtc-service` + redeploy to reach a running daemon.

## Testing

- `npm run lint` (`tsc -b --noEmit`) passes clean.