### PR TITLE
fix(setup): make the plaintext seed-store backend actually usable

### DIFF
--- a/vta-service/src/setup/from_toml.rs
+++ b/vta-service/src/setup/from_toml.rs
@@ -1163,7 +1163,17 @@ fn secrets_config_from_input(
                 "\x1b[1;33mWARNING: plaintext seed storage selected. NOT for production.\x1b[0m"
             );
             eprintln!();
-            SecretsConfig::default()
+            // The plaintext fallback in `create_seed_store` is an explicit
+            // opt-in (P0.9) — without `allow_plaintext = true` it errors
+            // rather than silently writing the master seed in clear. Since
+            // the operator deliberately chose plaintext here, set the flag so
+            // the seed store can be created during setup *and* the booted VTA
+            // can re-open it. The flag is serialized into `[secrets]` in the
+            // generated config.toml, so plaintext deployments stay runnable.
+            SecretsConfig {
+                allow_plaintext: true,
+                ..SecretsConfig::default()
+            }
         }
     })
 }
@@ -1452,6 +1462,27 @@ mod tests {
         assert!(matches!(inputs.messaging, MessagingInput::Skip));
         assert!(matches!(inputs.vta_did, VtaDidInput::Skip));
         assert!(inputs.admin_did.is_none());
+    }
+
+    #[test]
+    fn plaintext_backend_sets_allow_plaintext() {
+        // Selecting the plaintext backend must opt in to the plaintext
+        // seed-store fallback (P0.9). Otherwise `create_seed_store` errors
+        // during setup and the booted VTA can't re-open the seed. The flag
+        // is serialized into `[secrets]` in the generated config.toml.
+        let secrets = secrets_config_from_input(&SecretsBackendInput::Plaintext)
+            .expect("plaintext backend should convert");
+        assert!(
+            secrets.allow_plaintext,
+            "plaintext backend must set allow_plaintext = true"
+        );
+
+        // And it round-trips into the written config as `allow_plaintext = true`.
+        let toml_out = toml::to_string(&secrets).expect("secrets config serializes");
+        assert!(
+            toml_out.contains("allow_plaintext = true"),
+            "generated config must carry the flag, got:\n{toml_out}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Selecting the **Plaintext** seed-store backend in `vta setup` produced a config that the VTA then refuses to boot with:

```
failed to create seed store: Config("no secure seed-store backend is available ...
and the plaintext file fallback is disabled. ... set `secrets.allow_plaintext = true` ...")
```

Root cause: the wizard's `Plaintext` branch returned `SecretsConfig::default()`, which has `allow_plaintext: false`. The P0.9 guard in `create_seed_store` then rejects that config — failing both **during setup** (the seed-store mint at `from_toml.rs:556`) and **at boot**. So plaintext was offered as a menu choice but was never usable on a build compiled without a secure backend feature (e.g. no `keyring`).

This is also why an operator who set up plaintext on an older build, then upgraded, hits the boot error: their generated config never carried the flag.

## Fix

Set `allow_plaintext: true` in the `Plaintext` branch of `secrets_config_from_input`. The same `SecretsConfig` value feeds both:
- the scratch config used by `create_seed_store` during setup (mint now succeeds), and
- the final `AppConfig.secrets` written to disk (`from_toml.rs:788`),

so the generated `config.toml` now contains `allow_plaintext = true` under `[secrets]` and the booted VTA can re-open the seed. All setup entry points (interactive and `--from <toml>`, whose `backend = "plaintext"` tag deserializes to the same `SecretsBackendInput::Plaintext`) converge on this function, so all are fixed. The existing red "NOT for production" WARNING banners are unchanged — plaintext stays loud and dangerous, just functional.

## Test

Adds `plaintext_backend_sets_allow_plaintext`, asserting the flag is set and serializes to `allow_plaintext = true`. All 31 `setup::from_toml` tests pass; `cargo fmt` clean.

## Note

This only affects **future** setup runs. An already-deployed VTA whose config was generated by the old wizard still needs the flag added manually under `[secrets]` before restart.