### PR TITLE
fix(vta-sdk): route DID-template management over Trust Tasks on DIDComm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2352,7 +2352,7 @@ checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cnm-cli"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "clap",
@@ -2366,7 +2366,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.13.2",
+ "vta-sdk 0.14.0",
 ]
 
 [[package]]
@@ -3133,7 +3133,7 @@ dependencies = [
 
 [[package]]
 name = "didcomm-test"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-tdk",
@@ -3146,7 +3146,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.13.2",
+ "vta-sdk 0.14.0",
 ]
 
 [[package]]
@@ -6636,7 +6636,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "pnm-cli"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-resolver-cache-sdk",
@@ -6658,7 +6658,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.13.2",
+ "vta-sdk 0.14.0",
 ]
 
 [[package]]
@@ -10011,7 +10011,7 @@ dependencies = [
 
 [[package]]
 name = "vta-cli-common"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "aes-gcm",
  "affinidi-crypto",
@@ -10029,14 +10029,14 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.13.2",
+ "vta-sdk 0.14.0",
  "vti-common",
  "x25519-dalek",
 ]
 
 [[package]]
 name = "vta-enclave"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -10051,7 +10051,7 @@ dependencies = [
 
 [[package]]
 name = "vta-mcp"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -10062,12 +10062,12 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.13.2",
+ "vta-sdk 0.14.0",
 ]
 
 [[package]]
 name = "vta-mobile-core"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -10085,7 +10085,7 @@ dependencies = [
  "tracing-subscriber",
  "trust-tasks-rs",
  "uniffi",
- "vta-sdk 0.13.2",
+ "vta-sdk 0.14.0",
 ]
 
 [[package]]
@@ -10120,7 +10120,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.13.2"
+version = "0.14.0"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10175,7 +10175,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.9.6"
+version = "0.9.7"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",
@@ -10250,7 +10250,7 @@ dependencies = [
  "utoipa-axum",
  "uuid",
  "vta-cli-common",
- "vta-sdk 0.13.2",
+ "vta-sdk 0.14.0",
  "vta-service",
  "vti-common",
  "vti-secrets",
@@ -10264,7 +10264,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-service"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",
@@ -10329,7 +10329,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.13.2",
+ "vta-sdk 0.14.0",
  "vtc-service",
  "vti-common",
  "vti-secrets",
@@ -10342,7 +10342,7 @@ dependencies = [
 
 [[package]]
 name = "vti-common"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "aes-gcm",
  "affinidi-did-resolver-cache-sdk",
@@ -10377,7 +10377,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.13.2",
+ "vta-sdk 0.14.0",
  "webauthn-rs",
  "zeroize",
 ]
@@ -10404,14 +10404,14 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.13.2",
+ "vta-sdk 0.14.0",
  "vta-service",
  "vti-common",
 ]
 
 [[package]]
 name = "vti-secrets"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "aws-config",
  "aws-sdk-secretsmanager",
@@ -10433,7 +10433,7 @@ dependencies = [
  "tokio",
  "tracing",
  "vaultrs",
- "vta-sdk 0.13.2",
+ "vta-sdk 0.14.0",
  "vti-common",
 ]
 

--- a/cnm-cli/Cargo.toml
+++ b/cnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cnm-cli"
 description = "CLI Tool for Verified Trust Agents operating in Verified Trust Communities"
-version = "0.10.0"
+version = "0.10.1"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -21,7 +21,7 @@ config-session = ["vta-sdk/config-session"]
 azure-secrets = ["vta-sdk/azure-secrets"]
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.13", features = ["session"] }
+vta-sdk = { path = "../vta-sdk", version = "0.14", features = ["session"] }
 vta-cli-common = { path = "../vta-cli-common", version = "0.9" }
 affinidi-did-resolver-cache-sdk = { workspace = true }
 clap = { workspace = true, features = ["env"] }

--- a/didcomm-test/Cargo.toml
+++ b/didcomm-test/Cargo.toml
@@ -2,7 +2,7 @@
 name = "didcomm-test"
 description = "Standalone DIDComm connectivity test — mimics VTA TEE key + messaging flow"
 readme = "README.md"
-version = "0.6.3"
+version = "0.6.4"
 edition.workspace = true
 publish = false
 rust-version.workspace = true
@@ -13,7 +13,7 @@ name = "didcomm-test"
 path = "src/main.rs"
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.13", features = ["didcomm"] }
+vta-sdk = { path = "../vta-sdk", version = "0.14", features = ["didcomm"] }
 affinidi-tdk = { workspace = true }
 affinidi-did-resolver-cache-sdk = { workspace = true }
 tokio = { workspace = true }

--- a/pnm-cli/Cargo.toml
+++ b/pnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pnm-cli"
 description = "CLI Tool for managing a personal Verifiable Trust Agent"
-version = "0.9.3"
+version = "0.9.4"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -21,7 +21,7 @@ config-session = ["vta-sdk/config-session"]
 azure-secrets = ["vta-sdk/azure-secrets"]
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.13", features = ["session", "sealed-transfer", "attest-verify", "provision-integration"] }
+vta-sdk = { path = "../vta-sdk", version = "0.14", features = ["session", "sealed-transfer", "attest-verify", "provision-integration"] }
 affinidi-crypto = { workspace = true }
 base64 = { workspace = true }
 reqwest = { workspace = true }

--- a/tests/e2e/tests/client_didcomm.rs
+++ b/tests/e2e/tests/client_didcomm.rs
@@ -16,8 +16,9 @@ use vta_sdk::keys::{KeyOrigin, KeyStatus, KeyType};
 use vta_sdk::protocols::key_management::sign::SignAlgorithm;
 use vta_sdk::protocols::{
     acl_management, audit_management, backup_management, context_management, did_management,
-    did_template_management, discovery, key_management, seed_management, vta_management,
+    discovery, key_management, seed_management, vta_management,
 };
+use vta_sdk::trust_tasks;
 
 mod common;
 use common::test_vta_responder::{ResponderReply, TestVtaResponder};
@@ -621,19 +622,30 @@ fn template_record_json(name: &str) -> Value {
         "defaults": {},
         "document": {"id": "{DID}"},
         "scope": {"type": "global"},
-        "created_at": 1_700_000_000_u64,
-        "updated_at": 1_700_000_000_u64,
-        "created_by": "did:web:vta"
+        "createdAt": 1_700_000_000_u64,
+        "updatedAt": 1_700_000_000_u64,
+        "createdBy": "did:web:vta"
     })
 }
 
+/// DIDComm template management is dispatched as a Trust Task: the SDK sends the
+/// binding-envelope type carrying `{type: vta/did-templates/list/1.0, payload}`,
+/// and the VTA replies with a trust-task document whose `payload` is the result.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn list_did_templates_via_didcomm() {
-    let (mediator, responder, client) = build_didcomm(|msg_type, _body| {
-        if msg_type == did_template_management::LIST_TEMPLATES {
+    const TT_ENVELOPE: &str = "https://trusttasks.org/binding/didcomm/0.1/envelope";
+    let (mediator, responder, client) = build_didcomm(|msg_type, body| {
+        if msg_type == TT_ENVELOPE
+            && body.get("type").and_then(|v| v.as_str())
+                == Some(trust_tasks::TASK_DID_TEMPLATES_LIST_1_0)
+        {
             ResponderReply::ok(
-                did_template_management::LIST_TEMPLATES_RESULT,
-                json!({"templates": [template_record_json("custom-1")]}),
+                TT_ENVELOPE,
+                json!({
+                    "id": "urn:uuid:resp-1",
+                    "type": format!("{}#response", trust_tasks::TASK_DID_TEMPLATES_LIST_1_0),
+                    "payload": {"templates": [template_record_json("custom-1")]}
+                }),
             )
         } else {
             ResponderReply::problem_report("e.p.msg.not-found", "no handler")

--- a/vta-cli-common/Cargo.toml
+++ b/vta-cli-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-cli-common"
 description = "Shared CLI command handlers and rendering helpers for VTA CLIs"
 readme = "README.md"
-version = "0.9.3"
+version = "0.9.4"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -11,7 +11,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.13", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.14", features = [
   "client",
   "sealed-transfer",
   "provision-integration",

--- a/vta-enclave/Cargo.toml
+++ b/vta-enclave/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-enclave"
 description = "VTA binary for AWS Nitro Enclaves (TEE mode)"
 readme = "README.md"
-version = "0.7.3"
+version = "0.7.4"
 edition.workspace = true
 # `vta-enclave` is a Linux-only Nitro Enclave binary (vsock-store depends
 # on `tokio-vsock`). Publishing to crates.io would surface "fails on

--- a/vta-mcp/Cargo.toml
+++ b/vta-mcp/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-mcp"
 description = "Model Context Protocol (MCP) server exposing a VTA's agent capabilities as tools"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -10,7 +10,7 @@ repository.workspace = true
 publish = false
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.13", features = ["client", "session", "sealed-transfer", "didcomm", "vp"] }
+vta-sdk = { path = "../vta-sdk", version = "0.14", features = ["client", "session", "sealed-transfer", "didcomm", "vp"] }
 rmcp = { version = "1.7", features = ["server", "transport-io", "macros", "schemars"] }
 schemars = "1"
 tokio = { workspace = true }

--- a/vta-mobile-core/Cargo.toml
+++ b/vta-mobile-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vta-mobile-core"
-version = "0.6.3"
+version = "0.6.4"
 description = "UniFFI engine for the VTA mobile agent (Android/iOS): DIDComm, Trust Tasks, AAL step-up."
 edition.workspace = true
 # Not a crates.io library — the published artifacts are the Android AAR
@@ -61,7 +61,7 @@ affinidi-messaging-didcomm = "0.15"
 # `vta-sdk::DIDCommSession` (connect + receive_next) so the mobile approver can
 # pull VTA-pushed step-up approve-requests off the mediator — reusing the SDK
 # the VTA uses rather than reimplementing the affinidi mediator protocol.
-vta-sdk = { path = "../vta-sdk", version = "0.13", features = ["session"] }
+vta-sdk = { path = "../vta-sdk", version = "0.14", features = ["session"] }
 # iOS has no native trust store that `rustls-native-certs` can read, so the
 # mediator WebSocket (tokio-tungstenite, via affinidi-messaging-sdk) fails with
 # "no native root CA certificates found". Declaring tokio-tungstenite here with

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.13.2"
+version = "0.14.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/client/did_templates.rs
+++ b/vta-sdk/src/client/did_templates.rs
@@ -1,25 +1,34 @@
 //! DID-template management methods on [`VtaClient`] (global + context scope).
+//!
+//! **Transport model.** On the REST transport these hit the dedicated
+//! `/did-templates` (and `/contexts/{id}/did-templates`) routes. On the
+//! DIDComm transport there is no raw protocol surface — the VTA exposes
+//! template management only through its Trust-Task dispatcher, so the DIDComm
+//! leg dispatches the `trusttasks.org/spec/vta/did-templates/*` (and
+//! `.../contexts/did-templates/*`) Trust Tasks via the binding envelope. Both
+//! legs are wired through [`VtaClient::rpc_tt`] / [`VtaClient::rpc_tt_void`].
+
+use std::collections::HashMap;
+
+use serde_json::Value;
 
 use super::{VtaClient, encode_path_segment};
+use crate::did_templates::{DidTemplate, DidTemplateRecord};
 use crate::error::VtaError;
+use crate::protocols::did_template_management as proto;
+use crate::trust_tasks;
 
 impl VtaClient {
-    // ── DID templates (Phase 2: global scope, REST) ─────────────────────
+    // ── DID templates — global scope ─────────────────────────────────────
 
-    /// `GET /did-templates` — list all global templates.
-    pub async fn list_did_templates(
-        &self,
-    ) -> Result<Vec<crate::did_templates::DidTemplateRecord>, VtaError> {
-        use crate::protocols::did_template_management;
-        #[derive(serde::Deserialize)]
-        struct Wrapper {
-            templates: Vec<crate::did_templates::DidTemplateRecord>,
-        }
-        let resp: Wrapper = self
-            .rpc(
-                did_template_management::LIST_TEMPLATES,
-                serde_json::json!({}),
-                did_template_management::LIST_TEMPLATES_RESULT,
+    /// List all global templates.
+    ///
+    /// REST: `GET /did-templates`. DIDComm: `vta/did-templates/list/1.0`.
+    pub async fn list_did_templates(&self) -> Result<Vec<DidTemplateRecord>, VtaError> {
+        let resp: proto::list::ListDidTemplatesResultBody = self
+            .rpc_tt(
+                trust_tasks::TASK_DID_TEMPLATES_LIST_1_0,
+                serde_json::to_value(proto::list::ListDidTemplatesBody::default())?,
                 30,
                 |c, url| c.get(format!("{url}/did-templates")),
             )
@@ -27,49 +36,55 @@ impl VtaClient {
         Ok(resp.templates)
     }
 
-    /// `GET /did-templates/{name}` — fetch one global template.
-    pub async fn get_did_template(
-        &self,
-        name: &str,
-    ) -> Result<crate::did_templates::DidTemplateRecord, VtaError> {
-        use crate::protocols::did_template_management;
-        self.rpc(
-            did_template_management::GET_TEMPLATE,
-            serde_json::json!({ "name": name }),
-            did_template_management::GET_TEMPLATE_RESULT,
+    /// Fetch one global template by name.
+    ///
+    /// REST: `GET /did-templates/{name}`. DIDComm: `vta/did-templates/get/1.0`.
+    pub async fn get_did_template(&self, name: &str) -> Result<DidTemplateRecord, VtaError> {
+        self.rpc_tt(
+            trust_tasks::TASK_DID_TEMPLATES_GET_1_0,
+            serde_json::to_value(proto::get::GetDidTemplateBody {
+                name: name.to_string(),
+            })?,
             30,
             |c, url| c.get(format!("{url}/did-templates/{}", encode_path_segment(name))),
         )
         .await
     }
 
-    /// `POST /did-templates` — create a global template. Super admin only.
+    /// Create a global template. Super admin only.
+    ///
+    /// REST: `POST /did-templates`. DIDComm: `vta/did-templates/create/1.0`.
     pub async fn create_did_template(
         &self,
-        template: crate::did_templates::DidTemplate,
-    ) -> Result<crate::did_templates::DidTemplateRecord, VtaError> {
-        use crate::protocols::did_template_management;
-        self.rpc(
-            did_template_management::CREATE_TEMPLATE,
-            serde_json::to_value(&template)?,
-            did_template_management::CREATE_TEMPLATE_RESULT,
+        template: DidTemplate,
+    ) -> Result<DidTemplateRecord, VtaError> {
+        let payload = serde_json::to_value(proto::create::CreateDidTemplateBody {
+            template: template.clone(),
+        })?;
+        self.rpc_tt(
+            trust_tasks::TASK_DID_TEMPLATES_CREATE_1_0,
+            payload,
             30,
             |c, url| c.post(format!("{url}/did-templates")).json(&template),
         )
         .await
     }
 
-    /// `PUT /did-templates/{name}` — replace a global template. Super admin only.
+    /// Replace a global template. Super admin only.
+    ///
+    /// REST: `PUT /did-templates/{name}`. DIDComm: `vta/did-templates/update/1.0`.
     pub async fn update_did_template(
         &self,
         name: &str,
-        template: crate::did_templates::DidTemplate,
-    ) -> Result<crate::did_templates::DidTemplateRecord, VtaError> {
-        use crate::protocols::did_template_management;
-        self.rpc(
-            did_template_management::UPDATE_TEMPLATE,
-            serde_json::to_value(&template)?,
-            did_template_management::UPDATE_TEMPLATE_RESULT,
+        template: DidTemplate,
+    ) -> Result<DidTemplateRecord, VtaError> {
+        let payload = serde_json::to_value(proto::update::UpdateDidTemplateBody {
+            name: name.to_string(),
+            template: template.clone(),
+        })?;
+        self.rpc_tt(
+            trust_tasks::TASK_DID_TEMPLATES_UPDATE_1_0,
+            payload,
             30,
             |c, url| {
                 c.put(format!("{url}/did-templates/{}", encode_path_segment(name)))
@@ -79,73 +94,70 @@ impl VtaClient {
         .await
     }
 
-    /// `DELETE /did-templates/{name}` — delete a global template. Super admin only.
+    /// Delete a global template. Super admin only.
+    ///
+    /// REST: `DELETE /did-templates/{name}`. DIDComm: `vta/did-templates/delete/1.0`.
     pub async fn delete_did_template(&self, name: &str) -> Result<(), VtaError> {
-        use crate::protocols::did_template_management;
-        self.rpc_void(
-            did_template_management::DELETE_TEMPLATE,
-            serde_json::json!({ "name": name }),
-            did_template_management::DELETE_TEMPLATE_RESULT,
+        self.rpc_tt_void(
+            trust_tasks::TASK_DID_TEMPLATES_DELETE_1_0,
+            serde_json::to_value(proto::delete::DeleteDidTemplateBody {
+                name: name.to_string(),
+            })?,
             30,
             |c, url| c.delete(format!("{url}/did-templates/{}", encode_path_segment(name))),
         )
         .await
     }
 
-    /// `POST /did-templates/{name}/render` — render a stored template.
+    /// Render a stored global template with caller variables.
     ///
     /// Server injects ambient variables (`VTA_DID`, `VTA_URL`, `NOW`);
     /// `vars` provides everything else.
+    ///
+    /// REST: `POST /did-templates/{name}/render`. DIDComm:
+    /// `vta/did-templates/render/1.0`.
     pub async fn render_did_template(
         &self,
         name: &str,
-        vars: std::collections::HashMap<String, serde_json::Value>,
-    ) -> Result<serde_json::Value, VtaError> {
-        use crate::protocols::did_template_management;
-        #[derive(serde::Serialize, serde::Deserialize)]
-        struct Req {
-            vars: std::collections::HashMap<String, serde_json::Value>,
-        }
-        #[derive(serde::Deserialize)]
-        struct Resp {
-            document: serde_json::Value,
-        }
-        let body = Req { vars };
-        let resp: Resp = self
-            .rpc(
-                did_template_management::RENDER_TEMPLATE,
-                serde_json::to_value(&body)?,
-                did_template_management::RENDER_TEMPLATE_RESULT,
+        vars: HashMap<String, Value>,
+    ) -> Result<Value, VtaError> {
+        let payload = serde_json::to_value(proto::render::RenderDidTemplateBody {
+            name: name.to_string(),
+            vars: vars.clone(),
+        })?;
+        let resp: proto::render::RenderDidTemplateResultBody = self
+            .rpc_tt(
+                trust_tasks::TASK_DID_TEMPLATES_RENDER_1_0,
+                payload,
                 30,
                 |c, url| {
                     c.post(format!(
                         "{url}/did-templates/{}/render",
                         encode_path_segment(name)
                     ))
-                    .json(&body)
+                    .json(&serde_json::json!({ "vars": vars }))
                 },
             )
             .await?;
         Ok(resp.document)
     }
 
-    // ── DID templates — context scope (Phase 3) ──────────────────────
+    // ── DID templates — context scope ────────────────────────────────────
 
-    /// `GET /contexts/{id}/did-templates` — list context-scoped templates.
+    /// List context-scoped templates.
+    ///
+    /// REST: `GET /contexts/{id}/did-templates`. DIDComm:
+    /// `vta/contexts/did-templates/list/1.0`.
     pub async fn list_context_did_templates(
         &self,
         context_id: &str,
-    ) -> Result<Vec<crate::did_templates::DidTemplateRecord>, VtaError> {
-        use crate::protocols::did_template_management;
-        #[derive(serde::Deserialize)]
-        struct Wrapper {
-            templates: Vec<crate::did_templates::DidTemplateRecord>,
-        }
-        let resp: Wrapper = self
-            .rpc(
-                did_template_management::LIST_TEMPLATES,
-                serde_json::json!({ "context_id": context_id }),
-                did_template_management::LIST_TEMPLATES_RESULT,
+    ) -> Result<Vec<DidTemplateRecord>, VtaError> {
+        let resp: proto::list::ListDidTemplatesResultBody = self
+            .rpc_tt(
+                trust_tasks::TASK_CONTEXTS_DID_TEMPLATES_LIST_1_0,
+                serde_json::to_value(proto::list::ListContextDidTemplatesBody {
+                    context_id: context_id.to_string(),
+                })?,
                 30,
                 |c, url| {
                     c.get(format!(
@@ -158,17 +170,21 @@ impl VtaClient {
         Ok(resp.templates)
     }
 
-    /// `GET /contexts/{id}/did-templates/{name}` — fetch one context template.
+    /// Fetch one context-scoped template.
+    ///
+    /// REST: `GET /contexts/{id}/did-templates/{name}`. DIDComm:
+    /// `vta/contexts/did-templates/get/1.0`.
     pub async fn get_context_did_template(
         &self,
         context_id: &str,
         name: &str,
-    ) -> Result<crate::did_templates::DidTemplateRecord, VtaError> {
-        use crate::protocols::did_template_management;
-        self.rpc(
-            did_template_management::GET_TEMPLATE,
-            serde_json::json!({ "context_id": context_id, "name": name }),
-            did_template_management::GET_TEMPLATE_RESULT,
+    ) -> Result<DidTemplateRecord, VtaError> {
+        self.rpc_tt(
+            trust_tasks::TASK_CONTEXTS_DID_TEMPLATES_GET_1_0,
+            serde_json::to_value(proto::get::GetContextDidTemplateBody {
+                context_id: context_id.to_string(),
+                name: name.to_string(),
+            })?,
             30,
             |c, url| {
                 c.get(format!(
@@ -181,18 +197,22 @@ impl VtaClient {
         .await
     }
 
-    /// `POST /contexts/{id}/did-templates` — create a context-scoped template.
-    /// Context admin (Admin role + context in `allowed_contexts`) or super admin.
+    /// Create a context-scoped template. Context admin or super admin.
+    ///
+    /// REST: `POST /contexts/{id}/did-templates`. DIDComm:
+    /// `vta/contexts/did-templates/create/1.0`.
     pub async fn create_context_did_template(
         &self,
         context_id: &str,
-        template: crate::did_templates::DidTemplate,
-    ) -> Result<crate::did_templates::DidTemplateRecord, VtaError> {
-        use crate::protocols::did_template_management;
-        self.rpc(
-            did_template_management::CREATE_TEMPLATE,
-            serde_json::to_value(&template)?,
-            did_template_management::CREATE_TEMPLATE_RESULT,
+        template: DidTemplate,
+    ) -> Result<DidTemplateRecord, VtaError> {
+        let payload = serde_json::to_value(proto::create::CreateContextDidTemplateBody {
+            context_id: context_id.to_string(),
+            template: template.clone(),
+        })?;
+        self.rpc_tt(
+            trust_tasks::TASK_CONTEXTS_DID_TEMPLATES_CREATE_1_0,
+            payload,
             30,
             |c, url| {
                 c.post(format!(
@@ -205,18 +225,24 @@ impl VtaClient {
         .await
     }
 
-    /// `PUT /contexts/{id}/did-templates/{name}` — replace a context template.
+    /// Replace a context-scoped template.
+    ///
+    /// REST: `PUT /contexts/{id}/did-templates/{name}`. DIDComm:
+    /// `vta/contexts/did-templates/update/1.0`.
     pub async fn update_context_did_template(
         &self,
         context_id: &str,
         name: &str,
-        template: crate::did_templates::DidTemplate,
-    ) -> Result<crate::did_templates::DidTemplateRecord, VtaError> {
-        use crate::protocols::did_template_management;
-        self.rpc(
-            did_template_management::UPDATE_TEMPLATE,
-            serde_json::to_value(&template)?,
-            did_template_management::UPDATE_TEMPLATE_RESULT,
+        template: DidTemplate,
+    ) -> Result<DidTemplateRecord, VtaError> {
+        let payload = serde_json::to_value(proto::update::UpdateContextDidTemplateBody {
+            context_id: context_id.to_string(),
+            name: name.to_string(),
+            template: template.clone(),
+        })?;
+        self.rpc_tt(
+            trust_tasks::TASK_CONTEXTS_DID_TEMPLATES_UPDATE_1_0,
+            payload,
             30,
             |c, url| {
                 c.put(format!(
@@ -230,17 +256,21 @@ impl VtaClient {
         .await
     }
 
-    /// `DELETE /contexts/{id}/did-templates/{name}` — delete a context template.
+    /// Delete a context-scoped template.
+    ///
+    /// REST: `DELETE /contexts/{id}/did-templates/{name}`. DIDComm:
+    /// `vta/contexts/did-templates/delete/1.0`.
     pub async fn delete_context_did_template(
         &self,
         context_id: &str,
         name: &str,
     ) -> Result<(), VtaError> {
-        use crate::protocols::did_template_management;
-        self.rpc_void(
-            did_template_management::DELETE_TEMPLATE,
-            serde_json::json!({ "context_id": context_id, "name": name }),
-            did_template_management::DELETE_TEMPLATE_RESULT,
+        self.rpc_tt_void(
+            trust_tasks::TASK_CONTEXTS_DID_TEMPLATES_DELETE_1_0,
+            serde_json::to_value(proto::delete::DeleteContextDidTemplateBody {
+                context_id: context_id.to_string(),
+                name: name.to_string(),
+            })?,
             30,
             |c, url| {
                 c.delete(format!(
@@ -253,31 +283,28 @@ impl VtaClient {
         .await
     }
 
-    /// `POST /contexts/{id}/did-templates/{name}/render` — render a context template.
+    /// Render a context-scoped template.
     ///
     /// Server injects ambient variables: `VTA_DID`, `VTA_URL`, `NOW`,
     /// `CONTEXT_ID`, and (if set on the context) `CONTEXT_DID`.
+    ///
+    /// REST: `POST /contexts/{id}/did-templates/{name}/render`. DIDComm:
+    /// `vta/contexts/did-templates/render/1.0`.
     pub async fn render_context_did_template(
         &self,
         context_id: &str,
         name: &str,
-        vars: std::collections::HashMap<String, serde_json::Value>,
-    ) -> Result<serde_json::Value, VtaError> {
-        use crate::protocols::did_template_management;
-        #[derive(serde::Serialize, serde::Deserialize)]
-        struct Req {
-            vars: std::collections::HashMap<String, serde_json::Value>,
-        }
-        #[derive(serde::Deserialize)]
-        struct Resp {
-            document: serde_json::Value,
-        }
-        let body = Req { vars };
-        let resp: Resp = self
-            .rpc(
-                did_template_management::RENDER_TEMPLATE,
-                serde_json::to_value(&body)?,
-                did_template_management::RENDER_TEMPLATE_RESULT,
+        vars: HashMap<String, Value>,
+    ) -> Result<Value, VtaError> {
+        let payload = serde_json::to_value(proto::render::RenderContextDidTemplateBody {
+            context_id: context_id.to_string(),
+            name: name.to_string(),
+            vars: vars.clone(),
+        })?;
+        let resp: proto::render::RenderDidTemplateResultBody = self
+            .rpc_tt(
+                trust_tasks::TASK_CONTEXTS_DID_TEMPLATES_RENDER_1_0,
+                payload,
                 30,
                 |c, url| {
                     c.post(format!(
@@ -285,7 +312,7 @@ impl VtaClient {
                         encode_path_segment(context_id),
                         encode_path_segment(name)
                     ))
-                    .json(&body)
+                    .json(&serde_json::json!({ "vars": vars }))
                 },
             )
             .await?;

--- a/vta-sdk/src/client/mod.rs
+++ b/vta-sdk/src/client/mod.rs
@@ -549,6 +549,73 @@ impl VtaClient {
         }
     }
 
+    /// Like [`rpc`](Self::rpc), but the **DIDComm leg dispatches a Trust Task**
+    /// (binding envelope, `tt_uri`) instead of a raw protocol message, while the
+    /// **REST leg keeps using the dedicated route** built by `build_rest`.
+    ///
+    /// This is the bridge for surfaces (e.g. DID templates) that expose
+    /// dedicated REST endpoints but are only reachable over DIDComm through the
+    /// VTA's Trust-Task dispatcher (`trusttasks.org/spec/...`). The DIDComm
+    /// reply is a trust-task document whose `payload` is the result body.
+    #[cfg_attr(not(feature = "session"), allow(unused_variables))]
+    pub(crate) async fn rpc_tt<T: serde::de::DeserializeOwned>(
+        &self,
+        tt_uri: &str,
+        payload: serde_json::Value,
+        timeout: u64,
+        build_rest: impl FnOnce(&Client, &str) -> RequestBuilder,
+    ) -> Result<T, VtaError> {
+        match &self.transport {
+            Transport::Rest {
+                client,
+                base_url,
+                auth,
+            } => {
+                Self::ensure_token_valid(client, base_url, auth).await?;
+                let token = auth.lock().await.token.clone();
+                let req = build_rest(client, base_url);
+                let resp = Self::with_auth_token(req, &token).send().await?;
+                Self::handle_response(resp).await
+            }
+            #[cfg(feature = "session")]
+            Transport::DIDComm { .. } => {
+                let payload = self.dispatch_trust_task(tt_uri, payload, timeout).await?;
+                serde_json::from_value(payload)
+                    .map_err(|e| VtaError::Protocol(format!("trust-task response decode: {e}")))
+            }
+        }
+    }
+
+    /// [`rpc_tt`](Self::rpc_tt) for operations that return `()` (e.g. DELETE).
+    /// The DIDComm leg still requires a non-rejection trust-task reply.
+    #[cfg_attr(not(feature = "session"), allow(unused_variables))]
+    pub(crate) async fn rpc_tt_void(
+        &self,
+        tt_uri: &str,
+        payload: serde_json::Value,
+        timeout: u64,
+        build_rest: impl FnOnce(&Client, &str) -> RequestBuilder,
+    ) -> Result<(), VtaError> {
+        match &self.transport {
+            Transport::Rest {
+                client,
+                base_url,
+                auth,
+            } => {
+                Self::ensure_token_valid(client, base_url, auth).await?;
+                let token = auth.lock().await.token.clone();
+                let req = build_rest(client, base_url);
+                let resp = Self::with_auth_token(req, &token).send().await?;
+                Self::handle_delete_response(resp).await
+            }
+            #[cfg(feature = "session")]
+            Transport::DIDComm { .. } => {
+                let _ = self.dispatch_trust_task(tt_uri, payload, timeout).await?;
+                Ok(())
+            }
+        }
+    }
+
     // ── Trust-task dispatch (device/vault slices) ──────────────────────
 
     /// Dispatch a Trust Task over whichever transport this client uses and

--- a/vta-sdk/src/did_templates/mod.rs
+++ b/vta-sdk/src/did_templates/mod.rs
@@ -213,6 +213,7 @@ impl TemplateVars {
 /// maintains (scope, timestamps, author DID).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
 pub struct DidTemplateRecord {
     #[serde(flatten)]
     pub template: DidTemplate,

--- a/vta-sdk/src/protocols/did_template_management/create.rs
+++ b/vta-sdk/src/protocols/did_template_management/create.rs
@@ -21,6 +21,7 @@ pub struct CreateDidTemplateBody {
 /// context-scoped template. Auth: super-admin OR admin-with-context.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
 pub struct CreateContextDidTemplateBody {
     pub context_id: String,
     pub template: DidTemplate,

--- a/vta-sdk/src/protocols/did_template_management/delete.rs
+++ b/vta-sdk/src/protocols/did_template_management/delete.rs
@@ -15,6 +15,7 @@ pub struct DeleteDidTemplateBody {
 /// admin-with-context.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
 pub struct DeleteContextDidTemplateBody {
     pub context_id: String,
     pub name: String,

--- a/vta-sdk/src/protocols/did_template_management/get.rs
+++ b/vta-sdk/src/protocols/did_template_management/get.rs
@@ -18,6 +18,7 @@ pub struct GetDidTemplateBody {
 /// the context.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
 pub struct GetContextDidTemplateBody {
     pub context_id: String,
     pub name: String,

--- a/vta-sdk/src/protocols/did_template_management/list.rs
+++ b/vta-sdk/src/protocols/did_template_management/list.rs
@@ -14,6 +14,7 @@ pub struct ListDidTemplatesBody {}
 /// templates scoped to a specific context.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
 pub struct ListContextDidTemplatesBody {
     pub context_id: String,
 }

--- a/vta-sdk/src/protocols/did_template_management/mod.rs
+++ b/vta-sdk/src/protocols/did_template_management/mod.rs
@@ -6,7 +6,9 @@
 //! body types when relevant: a **global**-scope variant
 //! (`*DidTemplateBody`) and a **context**-scope variant
 //! (`*ContextDidTemplateBody`). The context-scope variant carries
-//! a required `context_id: String`; the global variant doesn't.
+//! a required `context_id` field (serialized as `contextId` on the
+//! wire, lowerCamelCase per the Trust Task framework); the global
+//! variant doesn't.
 //!
 //! The split is deliberate. Global and context templates are not
 //! the same resource filtered differently — they have different
@@ -22,9 +24,14 @@
 //! [`crate::trust_tasks`] under the `TASK_DID_TEMPLATES_*` and
 //! `TASK_CONTEXTS_DID_TEMPLATES_*` prefixes.
 //!
-//! Legacy DIDComm protocol constants are also reused over REST
-//! today; they're kept here in case a DIDComm transport for
-//! template management ships later.
+//! Template management over DIDComm ships as a **Trust Task**: the
+//! `VtaClient` dispatches the
+//! `trusttasks.org/spec/vta/(contexts/)did-templates/*` tasks through
+//! the binding envelope, and the VTA serves them via its trust-task
+//! dispatcher. The `firstperson.network/protocols/did-template-management/1.0`
+//! message-type constants below are **deprecated** — they were the
+//! never-routed raw-protocol scheme and are retained only for
+//! backward compatibility; no current code path emits them.
 
 pub mod create;
 pub mod delete;

--- a/vta-sdk/src/protocols/did_template_management/render.rs
+++ b/vta-sdk/src/protocols/did_template_management/render.rs
@@ -25,6 +25,7 @@ pub struct RenderDidTemplateBody {
 /// authed with access to the context.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
 pub struct RenderContextDidTemplateBody {
     pub context_id: String,
     pub name: String,

--- a/vta-sdk/src/protocols/did_template_management/update.rs
+++ b/vta-sdk/src/protocols/did_template_management/update.rs
@@ -27,6 +27,7 @@ pub struct UpdateDidTemplateBody {
 /// admin-with-context.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
 pub struct UpdateContextDidTemplateBody {
     pub context_id: String,
     pub name: String,

--- a/vta-sdk/tests/client_rest.rs
+++ b/vta-sdk/tests/client_rest.rs
@@ -1169,9 +1169,9 @@ fn template_record_json(name: &str) -> Value {
         "defaults": {},
         "document": {"id": "{DID}"},
         "scope": {"type": "global"},
-        "created_at": 1_700_000_000_u64,
-        "updated_at": 1_700_000_000_u64,
-        "created_by": "did:web:vta"
+        "createdAt": 1_700_000_000_u64,
+        "updatedAt": 1_700_000_000_u64,
+        "createdBy": "did:web:vta"
     })
 }
 

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.9.6"
+version = "0.9.7"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -85,7 +85,7 @@ vti-common = { path = "../vti-common", version = "0.10", features = ["encryption
 # from this crate into a shared crate so external integrations can reuse them).
 # Per-backend features are activated by this crate's matching features below.
 vti-secrets = { path = "../vti-secrets", version = "0.1" }
-vta-sdk = { path = "../vta-sdk", version = "0.13", features = ["didcomm", "sealed-transfer", "provision-integration", "openapi"] }
+vta-sdk = { path = "../vta-sdk", version = "0.14", features = ["didcomm", "sealed-transfer", "provision-integration", "openapi"] }
 # DID-VM-resolved WebAuthn assertion verifier — drives the new
 # `vta/auth/passkey-login-{start,finish}/1.0` trust-task handlers.
 # Distinct from `webauthn-rs` (which drives the passkey *enrolment*
@@ -241,7 +241,7 @@ vta-service = { path = ".", features = ["test-support"] }
 # `provision_admin_rotated_via_rest` + DI-signed REST auth) the `MockVta`
 # bootstrap→provision e2e tests drive (issues #406, DI-auth follow-up). Kept out
 # of the production `vta-sdk` dep above so the server build stays lean.
-vta-sdk = { path = "../vta-sdk", version = "0.13", features = ["provision-client"] }
+vta-sdk = { path = "../vta-sdk", version = "0.14", features = ["provision-client"] }
 # Mock HTTP server for the did-hosting-daemon REST auth flow tests. Each
 # test spins up a real local server bound to a random port, validates
 # the JWS-signed request bodies the daemon would see, and serves

--- a/vta-service/tests/api_integration.rs
+++ b/vta-service/tests/api_integration.rs
@@ -2192,7 +2192,7 @@ async fn did_templates_create_get_delete_roundtrip() {
     assert_eq!(status, StatusCode::CREATED, "body: {body}");
     assert_eq!(body["name"], "rt");
     assert_eq!(body["scope"]["type"], "global");
-    assert_eq!(body["created_by"], "did:key:z6MkSuper");
+    assert_eq!(body["createdBy"], "did:key:z6MkSuper");
 
     // Duplicate rejected
     let (status, _) = app
@@ -2242,7 +2242,7 @@ async fn did_templates_update_replaces_body_preserves_created_at() {
         ))
         .await;
     assert_eq!(status, StatusCode::CREATED);
-    let created_at_original = original["created_at"].clone();
+    let created_at_original = original["createdAt"].clone();
 
     // Update with a tweaked description.
     let mut updated = sample_template("evolving");
@@ -2252,9 +2252,9 @@ async fn did_templates_update_replaces_body_preserves_created_at() {
         .await;
     assert_eq!(status, StatusCode::OK, "body: {body}");
     assert_eq!(body["description"], "new description");
-    // created_at preserved, updated_at advances (can't assert >, but must exist).
-    assert_eq!(body["created_at"], created_at_original);
-    assert!(body["updated_at"].is_u64());
+    // createdAt preserved, updatedAt advances (can't assert >, but must exist).
+    assert_eq!(body["createdAt"], created_at_original);
+    assert!(body["updatedAt"].is_u64());
 }
 
 #[tokio::test]

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.9.4"
+version = "0.9.5"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -97,7 +97,7 @@ vti-common = { path = "../vti-common", version = "0.10", features = [
 # factory + `*SecretStore` names are a thin facade over these). Per-backend
 # features are activated by this crate's matching features above.
 vti-secrets = { path = "../vti-secrets", version = "0.1" }
-vta-sdk = { path = "../vta-sdk", version = "0.13", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.14", features = [
   "didcomm",
   "session",
   "config-session",

--- a/vti-common/Cargo.toml
+++ b/vti-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-common"
 description = "Shared server-side infrastructure for VTA and VTC services"
 readme = "README.md"
-version = "0.10.4"
+version = "0.10.5"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -48,7 +48,7 @@ openapi = ["dep:utoipa", "dep:utoipa-axum"]
 # `default-features = false` skips the optional client transports
 # (didcomm, sealed-transfer, etc.); we only consume the type
 # definitions in the default feature set.
-vta-sdk = { path = "../vta-sdk", version = "0.13", default-features = false }
+vta-sdk = { path = "../vta-sdk", version = "0.14", default-features = false }
 async-trait = "0.1"
 axum = { workspace = true }
 axum-extra = { workspace = true }

--- a/vti-secrets/Cargo.toml
+++ b/vti-secrets/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-secrets"
 description = "Pluggable secret-store backends + integration onboarding flow for Verifiable Trust Infrastructure"
 readme = "README.md"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -54,7 +54,7 @@ tracing = { workspace = true }
 tokio = { workspace = true }
 
 # Onboarding feature: the SDK session/auth state machine + local did:key mint.
-vta-sdk = { path = "../vta-sdk", version = "0.13", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.14", features = [
   "session",
 ], optional = true }
 ed25519-dalek = { workspace = true, optional = true }


### PR DESCRIPTION
## Problem

`pnm did-templates {list,create,show,update,delete}` failed over DIDComm with:

> ✗ Invalid request: unsupported message type: https://firstperson.network/protocols/did-template-management/1.0/create-template

**Not an old VTA.** At HEAD, the SDK's DIDComm path emitted the orphaned `firstperson.network/.../did-template-management/1.0/*` message types (which the VTA router never registered), while the VTA already serves DID-template management through its **Trust-Task dispatcher** under `trusttasks.org/spec/vta/(contexts/)did-templates/*` — the URIs nothing in the SDK ever sent. For context scope the SDK didn't even put the context id on the wire.

## Fix

Reconcile the two vocabularies onto the Trust-Task path (same pattern as the `vault/*` and `device/*` slices) — **no new/duplicated VTA handlers**:

- New `VtaClient::rpc_tt` / `rpc_tt_void`: REST leg keeps the dedicated `/did-templates` routes (unchanged); DIDComm leg dispatches the Trust-Task binding envelope, reaching the existing tested handlers.
- All 12 client did-template methods rewired onto it. The DIDComm wire now matches the registry specs published in trustoverip/dtgwg-trust-tasks-tf#89.
- The never-routed `firstperson.network` protocol constants are marked deprecated.

## Trust Task framework conformance (SPEC §4.10)

Added `rename_all = "camelCase"` to the context body types and `DidTemplateRecord` → `contextId`, `createdAt`, `updatedAt`, `createdBy`.

⚠️ **Breaking:** this changes the VTA's `/did-templates` REST JSON field names. No admin-UI consumes them, but any external REST consumer of that endpoint must adapt — hence the `vta-sdk` **minor** bump.

## Versioning (workspace major.minor pin policy)

- `vta-sdk` 0.13.2 → **0.14.0** (breaking wire change to public types).
- Cascaded `"0.13" → "0.14"` pin update + patch bumps to all dependents: `vti-common`, `vta-cli-common`, `vti-secrets`, `vta-service`, `vtc-service`, `pnm-cli`, `cnm-cli`, `vta-mcp`, `vta-mobile-core`, `didcomm-test`, `vta-enclave`.

## Tests

- `client_rest` 78/78 · `api_integration` did-template 15/15 · e2e `client_didcomm` updated to mock the Trust-Task envelope.
- `cargo check --workspace` green · `cargo fmt --check` clean.

Pairs with the registry specs in **trustoverip/dtgwg-trust-tasks-tf#89**.