### PR TITLE
fix(vta-service): install rustls aws-lc-rs CryptoProvider at startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,9 +75,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-bbs"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fdebb15bb1c2d336032ba371544478c8e3a240a3292134b99960542e2d80175"
+checksum = "b7b538d0d00a984f3eff5c994553df5a0c8bb93b30305b964fd380d6d1e64554"
 dependencies = [
  "bls12_381_plus",
  "elliptic-curve",
@@ -92,9 +92,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-crypto"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a56253d8878db88e02d70a0472ec7e346412a4dcf14b84a77cca096ecbbf4f0"
+checksum = "213efdc9d9a0851b2c5d8f9e28d5bfbea3d5109d3fd8e7e7c112b335eb423abb"
 dependencies = [
  "aes 0.8.4",
  "affinidi-encoding",
@@ -121,9 +121,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-data-integrity"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3ac6d3b8f244b0531a14dfde22a90d0468e5e759b682fdc4bd41600d53a0b3a"
+checksum = "902b3bd9bad4c8b492c9282b7771c53da512422e546efed7501e3b45afa17009"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -147,9 +147,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-did-authentication"
-version = "0.3.6"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df6b7f65487eeb0332943dfb1b7140a9e0657b65c90fc6ae89c3291bd793e291"
+checksum = "619d65884a3bc237f1ba6f6b6e3e4c4c0cee24c86362772396d114d1431483fe"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-common",
@@ -170,9 +170,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-did-common"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4caccbd04e9f77b067659c9ac0312c4dfface553fe2375ceb7ed1affec550061"
+checksum = "18abdd07cabd1f40beaecabc506e2b678395d7545e05c0ebe2ab8fc82a0cd9b7"
 dependencies = [
  "affinidi-crypto",
  "affinidi-encoding",
@@ -187,25 +187,25 @@ dependencies = [
 
 [[package]]
 name = "affinidi-did-resolver-cache-sdk"
-version = "0.8.7"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bf73e3580e63f3877c10e7648f42b0082eaa4ba8f2ea6e2c16ce5921b2e415"
+checksum = "56299840e4fae025ae7764a09c96ef9a2679b053218714af9edcce773dc92e92"
 dependencies = [
  "affinidi-did-common",
  "affinidi-did-resolver-traits",
  "affinidi-did-web",
+ "affinidi-task-utils",
  "ahash 0.8.12",
  "base64 0.22.1",
  "did-ethr",
  "did-pkh",
- "did-resolver-cheqd",
  "did-scid",
  "didwebvh-rs",
  "highway",
  "moka",
  "rand 0.10.1",
  "rustls 0.23.40",
- "rustls-platform-verifier 0.6.2",
+ "rustls-platform-verifier",
  "serde",
  "serde-wasm-bindgen",
  "serde_json",
@@ -223,9 +223,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-did-resolver-traits"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe47cecce6ef851cc4a3b3d5081d00f20190bf9b3249ce0ac98d624f1b1c40e8"
+checksum = "49f8b82814335de151304dab2da48862ee1cd6529d8d34250ab2429277444a00"
 dependencies = [
  "affinidi-did-common",
  "thiserror 2.0.18",
@@ -233,9 +233,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-did-web"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6eb7955717be071a68847e752805d2c363bc03af6ee944fdf894f51f5e10154"
+checksum = "6a3508ef558bb706802587b308026c00c751c5ccec0d92e435bfde187d745ac1"
 dependencies = [
  "affinidi-did-common",
  "percent-encoding",
@@ -247,9 +247,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-encoding"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b0faa57ab55df6fad876ac64a223532a9bb159b393d88b66887c1ae42c33f52"
+checksum = "0c4100740ddcda25754956cbc48350d4ae358c1086390bbcf457b6ea7b2b07ff"
 dependencies = [
  "bs58 0.5.1",
  "serde",
@@ -260,9 +260,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-meeting-place"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e2d17c3c6f7340ef079449a40c840997fe5bcc7b64d35c0b86a028b7236cf74"
+checksum = "78feddc54b4ff0ed5d6ae20fd9e0afcb66ff0341a3b3756d1e3af5d525b496dd"
 dependencies = [
  "affinidi-did-authentication",
  "affinidi-did-common",
@@ -281,9 +281,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-didcomm"
-version = "0.15.1"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "116a97f0ee592f0fa7cda8c30b2c757175ea4a28d9bbf3b800be7e13d1740b02"
+checksum = "3c2875d8c735dacf9e2195a54f98927cc7997c54105c02afe9f78d37beecb17d"
 dependencies = [
  "affinidi-crypto",
  "base64ct",
@@ -301,9 +301,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-didcomm-service"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "049f314c1a9b8a1a54901a7f8800386a5f9e7e31f5618b817b718626e059cd37"
+checksum = "aefecceb14df23f6577a5f035fd747488066c0d40b5d4db159b5ea073f0d47cf"
 dependencies = [
  "affinidi-messaging-didcomm",
  "affinidi-messaging-sdk",
@@ -324,9 +324,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-mediator"
-version = "0.15.25"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f4fcd252b665074cc33a1d1988d2b73fad45c057f03fbbc10e7158654511718"
+checksum = "d3bfbb6e7615d05d557b4d9e7b3e18d5f5e462880decb035f6ebec7ec3b9a487"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-common",
@@ -334,8 +334,10 @@ dependencies = [
  "affinidi-encoding",
  "affinidi-messaging-didcomm",
  "affinidi-messaging-mediator-common",
+ "affinidi-messaging-mediator-config",
  "affinidi-messaging-sdk",
  "affinidi-secrets-resolver",
+ "affinidi-task-utils",
  "ahash 0.8.12",
  "async-convert",
  "async-trait",
@@ -373,20 +375,20 @@ dependencies = [
  "tokio-tungstenite",
  "tokio-util",
  "toml 1.1.2+spec-1.1.0",
- "tower 0.5.3",
+ "tower",
  "tower-http",
  "tracing",
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.11.1",
+ "vta-sdk 0.13.2",
 ]
 
 [[package]]
 name = "affinidi-messaging-mediator-common"
-version = "0.15.7"
+version = "0.15.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "629825d4fd630a25c4763c30e5f5c54e4704215ae1c077b173d4cd22fd4fecf7"
+checksum = "de97156c77842ec60f2a3156da1a8aa2a05ef214b12e796c7989eb369b9b5371"
 dependencies = [
  "aes-gcm",
  "ahash 0.8.12",
@@ -420,10 +422,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "affinidi-messaging-sdk"
-version = "0.18.7"
+name = "affinidi-messaging-mediator-config"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e03b90fdf586d88f396350f555b5569f66eee86c1d17f69ada41f6d58ee479b"
+checksum = "a2870e17d46f0498ad76bfc8f67048bf5bfedc9879e6365aff6959dcad9aa0c1"
+dependencies = [
+ "affinidi-messaging-mediator-common",
+ "serde",
+ "thiserror 2.0.18",
+ "toml 1.1.2+spec-1.1.0",
+ "tracing",
+]
+
+[[package]]
+name = "affinidi-messaging-sdk"
+version = "0.18.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2022cd5c4baa0ed5f872f3febd8c9cb7fe7fd92330f0c758d5cf05de6c46368"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-authentication",
@@ -432,10 +447,12 @@ dependencies = [
  "affinidi-messaging-didcomm",
  "affinidi-messaging-mediator-common",
  "affinidi-secrets-resolver",
+ "affinidi-task-utils",
  "affinidi-tdk-common",
  "ahash 0.8.12",
  "base64 0.22.1",
  "futures-util",
+ "rand 0.10.1",
  "regex",
  "rustls 0.23.40",
  "rustls-pemfile 2.2.0",
@@ -451,20 +468,22 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-test-mediator"
-version = "0.2.7"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1985fbe5bf2bceb80fd1904691e3f080c68d5dabbcce3c3e1a400bfefb156464"
+checksum = "737aac41d73b6651218c664ff9ce530f3849e2dead9e04cd3efdfae389c7b895"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
+ "affinidi-messaging-didcomm",
  "affinidi-messaging-mediator",
  "affinidi-messaging-mediator-common",
  "affinidi-messaging-sdk",
  "affinidi-secrets-resolver",
- "affinidi-tdk",
+ "affinidi-tdk 0.8.3",
  "async-trait",
  "jsonwebtoken",
  "ring",
  "rustls 0.23.40",
+ "serde_json",
  "sha256",
  "thiserror 2.0.18",
  "tokio",
@@ -476,9 +495,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-oid4vc-core"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64fc01f6e5abce1c03dd55aa46faa9d153d8f36b761ab6d02263403d118c6926"
+checksum = "419d638be45a2b839e503aa89fd870c2f470f1e83f1b05d5e941bd94c95c56a6"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",
@@ -507,9 +526,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-openid4vp"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552f5fa894b4a362f449afbdaaadde1ad06081244d4c2c08dffd79e1db7294bf"
+checksum = "95f23166fc2d0089d5e3dee389c15a51241ab325144b15e34d339af6bdef1ec6"
 dependencies = [
  "affinidi-oid4vc-core",
  "serde",
@@ -521,9 +540,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-rdf-encoding"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0159f4425bb7ee85d27ad530c6011db6b23e39777e28eb7391db01371984e7e5"
+checksum = "ddb75e7ca98d464c1f461ca8c8258ae8fc22dfef9fe9b72aa6a56d8659d28f8f"
 dependencies = [
  "serde",
  "serde_json",
@@ -534,9 +553,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-sd-jwt"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f71ae9d530bef6f384bc68feea57ed1b32f786ace4cc3e82951de8242f4217b6"
+checksum = "e849a20a49af4762e7520adb38dbb98800642ccc98c3ce1a64669bc56a311ac8"
 dependencies = [
  "base64 0.22.1",
  "rand 0.9.4",
@@ -563,9 +582,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-secrets-resolver"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5df3f588537611ef80a97ddfaa9fef3d8070553fab051a44e974e66781eff64"
+checksum = "95d3b1ec380684ba83d96869f5fd6c86c76c6c96704cac6578f22f1cab8abd00"
 dependencies = [
  "affinidi-crypto",
  "affinidi-encoding",
@@ -588,9 +607,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-status-list"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146663e9f7bcab5bf7b3fb1b1f83d2b306183b1e7115dcda0aada32fbea504f3"
+checksum = "d39bd34539e86ec366e77064ec583323b8701e1e0e44efce403975fb585e1f6b"
 dependencies = [
  "base64 0.22.1",
  "flate2",
@@ -598,6 +617,20 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "affinidi-task-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c43adc3f24c67ff7d71c236b7dadf225144e069d8df9d334c3d35b7d7a0c728"
+dependencies = [
+ "chrono",
+ "dashmap",
+ "serde",
+ "tokio",
+ "tokio-util",
  "tracing",
 ]
 
@@ -627,10 +660,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "affinidi-tdk-common"
-version = "0.6.3"
+name = "affinidi-tdk"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f9612ab9d79a96d32cc80707d9a4f97d9bbf07d78adc0876ccaa9ca2b9b8b92"
+checksum = "8dff9659362f202835bb155bc7b4c86fe80bc2ad0f1a20b60159338da58cec9c"
+dependencies = [
+ "affinidi-crypto",
+ "affinidi-did-authentication",
+ "affinidi-did-common",
+ "affinidi-did-resolver-cache-sdk",
+ "affinidi-messaging-didcomm",
+ "affinidi-secrets-resolver",
+ "affinidi-tdk-common",
+ "clap",
+ "rustls 0.23.40",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "affinidi-tdk-common"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "535d99e3a7af8463b71086162a41ba26b86817b3bacd47ef4f0ae48c5a8cbdbc"
 dependencies = [
  "affinidi-data-integrity",
  "affinidi-did-authentication",
@@ -646,7 +700,7 @@ dependencies = [
  "reqwest 0.13.4",
  "rustls 0.23.40",
  "rustls-pemfile 2.2.0",
- "rustls-platform-verifier 0.7.0",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -657,9 +711,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-vc"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9467f0763aa46e930957df9eeab8bf5d3b2956b0932a30dd7883c5de6829e631"
+checksum = "64d37a13101e2361c97cb3059a2b2a200c679274dabc91467ebd92a0a33a1641"
 dependencies = [
  "chrono",
  "serde",
@@ -871,7 +925,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -929,7 +983,7 @@ checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "synstructure 0.13.2",
 ]
 
@@ -941,7 +995,7 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "synstructure 0.13.2",
 ]
 
@@ -953,7 +1007,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1019,7 +1073,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1124,9 +1178,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.7.4"
+version = "1.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ed8e8c52d2dc2390ad9f15647fe663f71e9780b4262c190fbb823a32721566"
+checksum = "6c9b9de216a988dd54b754a82a7660cfe14cee4f6782ae4524470972fa0ccb39"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -1149,9 +1203,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-dynamodb"
-version = "1.115.0"
+version = "1.116.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "715fd8729709daa491b2d4aeed33e576d76031c164ad34b65062ea585d97ad5e"
+checksum = "8c937c55ae3030bec4431c0d9146e33d2b3e5f54bb47ed32597068200c56affc"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -1174,9 +1228,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-kms"
-version = "1.110.0"
+version = "1.111.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "217276b3d948ec05b2726d66b2c9013567ca42751052c287ec45800ee81799c9"
+checksum = "c62d6d9b9c60e08be622a6bfc98e483d75683795caaf9704886970aa07ed8529"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -1199,9 +1253,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-secretsmanager"
-version = "1.107.0"
+version = "1.108.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63da8ec2dca98a68d8bcba971abae5f06e2c9c0017f43097d1ff92cff96adc54"
+checksum = "cd24cfd47bda71881c399a7cc4850d5a61727246163d5cd1a7c0b48ef19983cb"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -1224,9 +1278,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.101.0"
+version = "1.102.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b647baea49ff551960b904f905681e9b4765a6c4ea08631e89dc52d8bd3f5896"
+checksum = "8c82b3ac19f1431854f7ace3a7531674633e286bfdde21976893bfee36fd493b"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -1249,9 +1303,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.103.0"
+version = "1.104.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ae401c65ff288aa7873117fe535cd32b7b1bb0bc43751d28901a1d5f20636b9"
+checksum = "321000d2b4c5519ee573f73167f612efd7329322d9b26969ad1979f0427f1913"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -1274,9 +1328,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.106.0"
+version = "1.107.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c80de7bb7d03e9ca8c9fd7b489f20f3948d3f3be91a7953591347d238115408"
+checksum = "3d0d328ba962af23ecfa3c9f23b98d3d35e325fa218d7f13d17a6bf522f8a560"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -1362,7 +1416,7 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "h2 0.3.27",
- "h2 0.4.14",
+ "h2 0.4.15",
  "http 0.2.12",
  "http 1.4.2",
  "http-body 0.4.6",
@@ -1378,7 +1432,7 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.4",
- "tower 0.5.3",
+ "tower",
  "tracing",
 ]
 
@@ -1464,7 +1518,7 @@ checksum = "8d7396fd9500589e62e460e987ecb671bad374934e55ec3b5f498cc7a8a8a7b7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1480,9 +1534,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.4.9"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53f93074121a1be41317b9aa607143ae17900631f7f59a99f2b905d519d6783b"
+checksum = "32b42fcf341259d85ca10fac9a2f6448a8ec691c6955a18e45bc3b71a85fab85"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -1558,7 +1612,7 @@ dependencies = [
  "sync_wrapper 1.0.2",
  "tokio",
  "tokio-tungstenite",
- "tower 0.5.3",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -1656,7 +1710,7 @@ checksum = "70066e34b8db2c3f0b852c56a99333bd25fdedfb8850cd95dddf930928b47b80"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "tracing",
 ]
 
@@ -1918,9 +1972,9 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
  "hybrid-array",
 ]
@@ -2142,9 +2196,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.63"
+version = "1.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -2160,12 +2214,6 @@ checksum = "060303ef31ef4a522737e1b1ab68c67916f2a787bb2f4f54f383279adba962b5"
 dependencies = [
  "slab",
 ]
-
-[[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -2317,7 +2365,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2748,7 +2796,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2782,7 +2830,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2795,7 +2843,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2806,7 +2854,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2817,7 +2865,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2857,7 +2905,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2974,7 +3022,6 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
- "powerfmt",
  "serde_core",
 ]
 
@@ -2992,7 +3039,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3013,7 +3060,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3023,7 +3070,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3045,7 +3092,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3098,31 +3145,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "did-resolver-cheqd"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2ce2add9e714946d8bcdf76ae71bcfa015be017561ba789781b484cb22eba78"
-dependencies = [
- "chrono",
- "prost",
- "prost-types",
- "serde",
- "serde_json",
- "ssi-dids-core",
- "thiserror 1.0.69",
- "tokio",
- "tonic 0.12.3",
- "url",
-]
-
-[[package]]
 name = "did-scid"
-version = "0.1.8"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6756d834d7d364fd392ff15adf1d99781bcb3d4fb526a3879018937021eccfa7"
+checksum = "ced6101e9cbb1cb55b28ea3a80fbb3027bcfc5f16bd9f17ef067d9816a757aee"
 dependencies = [
  "affinidi-did-common",
- "did-resolver-cheqd",
  "didwebvh-rs",
  "regex",
  "serde_json",
@@ -3136,7 +3164,7 @@ name = "didcomm-test"
 version = "0.6.4"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
- "affinidi-tdk",
+ "affinidi-tdk 0.7.4",
  "clap",
  "ed25519-dalek",
  "ed25519-dalek-bip32",
@@ -3151,9 +3179,9 @@ dependencies = [
 
 [[package]]
 name = "didwebvh-rs"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46448d8c4137746b88b66ef7bdfd67b13a981208703936879af11bdecf742519"
+checksum = "8ad5c39bda74ba720b8aaee3921552be256e773ab8dafc345967a4bdec8208dc"
 dependencies = [
  "affinidi-data-integrity",
  "affinidi-did-common",
@@ -3203,7 +3231,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer 0.12.0",
+ "block-buffer 0.12.1",
  "const-oid 0.10.2",
  "crypto-common 0.2.2",
  "ctutils",
@@ -3238,7 +3266,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3349,7 +3377,7 @@ dependencies = [
  "enum-ordinalize 4.3.2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3428,7 +3456,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3448,7 +3476,7 @@ checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3460,7 +3488,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3814,7 +3842,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3972,9 +4000,9 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-auth"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4595b69c95c727ac896a4f2f16d0cdaa6f547de0bc5d64dbe9201487fc3226d5"
+checksum = "a300d4011cb53573eafe2419630d303ced54aab6c194a6d9e4156de375800372"
 dependencies = [
  "async-trait",
  "aws-lc-rs",
@@ -4044,7 +4072,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
- "tonic 0.14.6",
+ "tonic",
  "tracing",
  "tracing-opentelemetry",
 ]
@@ -4200,9 +4228,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -4542,7 +4570,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.14",
+ "h2 0.4.15",
  "http 1.4.2",
  "http-body 1.0.1",
  "httparse",
@@ -4871,7 +4899,7 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4953,23 +4981,7 @@ checksum = "782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "jni"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
-dependencies = [
- "cesu8",
- "cfg-if",
- "combine",
- "jni-sys 0.3.1",
- "log",
- "thiserror 1.0.69",
- "walkdir",
- "windows-sys 0.45.0",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4981,7 +4993,7 @@ dependencies = [
  "cfg-if",
  "combine",
  "jni-macros",
- "jni-sys 0.4.1",
+ "jni-sys",
  "log",
  "simd_cesu8",
  "thiserror 2.0.18",
@@ -4999,16 +5011,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "jni-sys"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
-dependencies = [
- "jni-sys 0.4.1",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5027,7 +5030,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5042,9 +5045,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.100"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2025f20d7a4fa7785846e7b63d10a76d3f1cee98ee5cb79ea59703f95e42162"
+checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -5386,7 +5389,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
- "tower 0.5.3",
+ "tower",
  "tower-http",
  "tracing",
 ]
@@ -5581,7 +5584,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "static-iref",
- "syn 2.0.117",
+ "syn 2.0.118",
  "thiserror 1.0.69",
 ]
 
@@ -5716,7 +5719,7 @@ checksum = "757aee279b8bdbb9f9e676796fd459e4207a1f986e87886700abf589f5abf771"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5736,9 +5739,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
-version = "2.8.1"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memmem"
@@ -6061,7 +6064,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6171,9 +6174,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.80"
+version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
  "bitflags 2.13.0",
  "cfg-if",
@@ -6191,7 +6194,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6211,9 +6214,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.116"
+version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",
@@ -6365,7 +6368,7 @@ dependencies = [
  "by_address",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6497,7 +6500,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6559,7 +6562,7 @@ dependencies = [
  "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6597,7 +6600,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6751,7 +6754,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6804,38 +6807,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "prost"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
-dependencies = [
- "bytes",
- "prost-derive",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
-dependencies = [
- "anyhow",
- "itertools",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "prost-types"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
-dependencies = [
- "prost",
 ]
 
 [[package]]
@@ -7193,9 +7164,9 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12e6b5f4d8ef33944e833e2b1859ad478deab6e431d7337b30ee2efe21f7543"
+checksum = "f9fd510128eda94d1d49b9f81487744d5c451422431cce41238fe2853d29f4cc"
 dependencies = [
  "ahash 0.8.12",
  "arc-swap",
@@ -7260,7 +7231,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7416,7 +7387,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.14",
+ "h2 0.4.15",
  "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
@@ -7431,7 +7402,7 @@ dependencies = [
  "quinn",
  "rustls 0.23.40",
  "rustls-pki-types",
- "rustls-platform-verifier 0.7.0",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -7439,7 +7410,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.4",
  "tokio-util",
- "tower 0.5.3",
+ "tower",
  "tower-http",
  "tower-service",
  "url",
@@ -7516,7 +7487,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7611,7 +7582,6 @@ dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
- "ring",
  "rustls-pki-types",
  "rustls-webpki 0.103.13",
  "subtle",
@@ -7660,34 +7630,13 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
-dependencies = [
- "core-foundation 0.10.1",
- "core-foundation-sys",
- "jni 0.21.1",
- "log",
- "once_cell",
- "rustls 0.23.40",
- "rustls-native-certs",
- "rustls-platform-verifier-android",
- "rustls-webpki 0.103.13",
- "security-framework",
- "security-framework-sys",
- "webpki-root-certs",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "rustls-platform-verifier"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
- "jni 0.22.4",
+ "jni",
  "log",
  "once_cell",
  "rustls 0.23.40",
@@ -7811,7 +7760,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7843,7 +7792,7 @@ checksum = "1783eabc414609e28a5ba76aee5ddd52199f7107a0b24c2e9746a1ecc34a683d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7997,7 +7946,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -8008,7 +7957,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -8117,7 +8066,7 @@ dependencies = [
  "darling 0.23.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -8373,15 +8322,15 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "smawk"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+checksum = "e8e2fb0f499abb4d162f2bedad68f5ef91a1682b5a03596ddb67efd37768d100"
 
 [[package]]
 name = "socket2"
@@ -8686,7 +8635,7 @@ checksum = "3cc4068497ae43896d41174586dcdc2153a1af2c82856fb308bfaaddc28e5549"
 dependencies = [
  "iref",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -8705,7 +8654,7 @@ dependencies = [
  "quote",
  "serde",
  "sha2 0.10.9",
- "syn 2.0.117",
+ "syn 2.0.118",
  "thiserror 1.0.69",
 ]
 
@@ -8739,7 +8688,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -8761,9 +8710,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8805,7 +8754,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -8984,7 +8933,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -8995,7 +8944,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -9009,12 +8958,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
 dependencies = [
  "deranged",
- "itoa",
  "js-sys",
  "libc",
  "num-conv",
@@ -9027,15 +8975,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d"
 dependencies = [
  "num-conv",
  "time-core",
@@ -9100,7 +9048,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -9238,36 +9186,6 @@ checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tonic"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
-dependencies = [
- "async-trait",
- "base64 0.22.1",
- "bytes",
- "http 1.4.2",
- "http-body 1.0.1",
- "http-body-util",
- "hyper 1.10.1",
- "hyper-timeout",
- "hyper-util",
- "percent-encoding",
- "pin-project",
- "prost",
- "rustls-native-certs",
- "rustls-pemfile 2.2.0",
- "tokio",
- "tokio-rustls 0.26.4",
- "tokio-stream",
- "tower 0.4.13",
- "tower-layer",
- "tower-service",
- "tracing",
- "webpki-roots 0.26.11",
-]
-
-[[package]]
-name = "tonic"
 version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
@@ -9276,7 +9194,7 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "bytes",
- "h2 0.4.14",
+ "h2 0.4.15",
  "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
@@ -9291,27 +9209,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.4",
  "tokio-stream",
- "tower 0.5.3",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
-dependencies = [
- "futures-core",
- "futures-util",
- "indexmap 1.9.3",
- "pin-project",
- "pin-project-lite",
- "rand 0.8.6",
- "slab",
- "tokio",
- "tokio-util",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -9355,7 +9253,7 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
- "tower 0.5.3",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -9386,8 +9284,8 @@ dependencies = [
  "http 1.4.2",
  "pin-project",
  "thiserror 2.0.18",
- "tonic 0.14.6",
- "tower 0.5.3",
+ "tonic",
+ "tower",
  "tracing",
 ]
 
@@ -9411,7 +9309,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -9494,7 +9392,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
- "tower 0.5.3",
+ "tower",
  "trust-tasks-rs",
  "uuid",
 ]
@@ -9518,9 +9416,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-rs"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89cd2a27ae877b61b1727675f5bc4959d54c7a6d842aef1623214243ec424e98"
+checksum = "17672c4815d70f475fe38cd4b25e2f0f68b52e8945f20ddbee977f904da7cd68"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9615,7 +9513,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -9737,7 +9635,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "802d2051a700e3ec894c79f80d2705b69d85844dafbbe5d1a92776f8f48b563a"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -9768,7 +9666,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.117",
+ "syn 2.0.118",
  "toml 0.5.11",
  "uniffi_meta",
 ]
@@ -9922,7 +9820,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.117",
+ "syn 2.0.118",
  "uuid",
 ]
 
@@ -10090,16 +9988,16 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.11.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46a9942f0711f78e450428696b510985affbf6e2c3ccee51b115955aea8435f7"
+checksum = "d026cf4855d906e634970714983057edd900de360f7d00300305202fb38e5681"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-didcomm",
  "affinidi-openid4vci",
  "affinidi-openid4vp",
- "affinidi-tdk",
+ "affinidi-tdk 0.7.4",
  "base64 0.22.1",
  "chrono",
  "curve25519-dalek",
@@ -10132,7 +10030,7 @@ dependencies = [
  "affinidi-sd-jwt",
  "affinidi-sd-jwt-vc",
  "affinidi-secrets-resolver",
- "affinidi-tdk",
+ "affinidi-tdk 0.7.4",
  "affinidi-vc",
  "apple-native-keyring-store",
  "arbitrary",
@@ -10192,7 +10090,7 @@ dependencies = [
  "affinidi-sd-jwt-vc",
  "affinidi-secrets-resolver",
  "affinidi-status-list",
- "affinidi-tdk",
+ "affinidi-tdk 0.7.4",
  "affinidi-tdk-common",
  "argon2",
  "async-trait",
@@ -10237,7 +10135,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "toml 1.1.2+spec-1.1.0",
- "tower 0.5.3",
+ "tower",
  "tower-http",
  "tower_governor",
  "tracing",
@@ -10280,7 +10178,7 @@ dependencies = [
  "affinidi-sd-jwt",
  "affinidi-secrets-resolver",
  "affinidi-status-list",
- "affinidi-tdk",
+ "affinidi-tdk 0.7.4",
  "affinidi-vc",
  "argon2",
  "async-trait",
@@ -10320,7 +10218,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "toml 1.1.2+spec-1.1.0",
- "tower 0.5.3",
+ "tower",
  "tower-http",
  "tower_governor",
  "tracing",
@@ -10347,7 +10245,7 @@ version = "0.10.5"
 dependencies = [
  "aes-gcm",
  "affinidi-did-resolver-cache-sdk",
- "affinidi-tdk",
+ "affinidi-tdk 0.7.4",
  "async-trait",
  "axum",
  "axum-extra",
@@ -10372,7 +10270,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-vsock",
- "tower 0.5.3",
+ "tower",
  "tracing",
  "url",
  "utoipa",
@@ -10392,7 +10290,7 @@ dependencies = [
  "affinidi-messaging-sdk",
  "affinidi-messaging-test-mediator",
  "affinidi-secrets-resolver",
- "affinidi-tdk",
+ "affinidi-tdk 0.7.4",
  "chrono",
  "ed25519-dalek",
  "multibase",
@@ -10493,9 +10391,9 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen 0.57.1",
 ]
@@ -10511,9 +10409,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.123"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a254a4b10c19a76f09a27640e7ffbf9bc30bf67e16a3bf28aaefa4920fe81563"
+checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -10524,9 +10422,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.73"
+version = "0.4.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54568702fabf5d4849ce2b90fadfa64168a097eaf4b351ce9df8b687a0086aaf"
+checksum = "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -10534,9 +10432,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.123"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a40fc75b0ec6f3746ceb10d36f53a93dcd68a93b11b6445983945d79eba0dc"
+checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -10544,22 +10442,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.123"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "908f34bd9b9ce3d4caf07b72dfab63d61504d156856c6bd3cd87fa350cf3985b"
+checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.123"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7acbf7616c27b194bbb550bf77ed0c2c3e5b7fd1260a93082b95fb7f47959b92"
+checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
 dependencies = [
  "unicode-ident",
 ]
@@ -10623,9 +10521,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.100"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e0871acf327f283dc6da28a1696cdc64fb355ba9f935d052021fa77f35cce69"
+checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -10869,7 +10767,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -10880,7 +10778,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -10933,15 +10831,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -10974,21 +10863,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -11041,12 +10915,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -11065,12 +10933,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -11086,12 +10948,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -11125,12 +10981,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -11146,12 +10996,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -11173,12 +11017,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -11194,12 +11032,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -11294,7 +11126,7 @@ dependencies = [
  "heck",
  "indexmap 2.14.0",
  "prettyplease",
- "syn 2.0.117",
+ "syn 2.0.118",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -11310,7 +11142,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -11484,7 +11316,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "synstructure 0.13.2",
 ]
 
@@ -11505,7 +11337,7 @@ checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -11525,28 +11357,28 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "synstructure 0.13.2",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -11579,7 +11411,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10040,6 +10040,7 @@ version = "0.7.4"
 dependencies = [
  "base64 0.22.1",
  "clap",
+ "rustls 0.23.40",
  "serde_json",
  "tokio",
  "tokio-vsock",
@@ -10226,6 +10227,7 @@ dependencies = [
  "p256",
  "rand 0.10.1",
  "reqwest 0.13.4",
+ "rustls 0.23.40",
  "serde",
  "serde_ignored",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10040,7 +10040,6 @@ version = "0.7.4"
 dependencies = [
  "base64 0.22.1",
  "clap",
- "rustls 0.23.40",
  "serde_json",
  "tokio",
  "tokio-vsock",
@@ -10155,6 +10154,7 @@ dependencies = [
  "nitro_attest",
  "reqwest 0.13.4",
  "ring",
+ "rustls 0.23.40",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -10227,7 +10227,6 @@ dependencies = [
  "p256",
  "rand 0.10.1",
  "reqwest 0.13.4",
- "rustls 0.23.40",
  "serde",
  "serde_ignored",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,6 +189,9 @@ base64 = "0.22"
 # HTTP client
 reqwest = { version = "0.13", features = ["json"] }
 
+# tonic 0.12.x forces `ring` on tokio-rustls; explicit dep lets main() install aws-lc-rs as the default provider.
+rustls = { version = "0.23", default-features = false, features = ["aws_lc_rs", "logging", "std", "tls12"] }
+
 # Interactive prompts
 dialoguer = "0.12"
 

--- a/cnm-cli/Cargo.toml
+++ b/cnm-cli/Cargo.toml
@@ -21,7 +21,7 @@ config-session = ["vta-sdk/config-session"]
 azure-secrets = ["vta-sdk/azure-secrets"]
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.14", features = ["session"] }
+vta-sdk = { path = "../vta-sdk", version = "0.14", features = ["session", "crypto-provider"] }
 vta-cli-common = { path = "../vta-cli-common", version = "0.9" }
 affinidi-did-resolver-cache-sdk = { workspace = true }
 clap = { workspace = true, features = ["env"] }

--- a/cnm-cli/src/main.rs
+++ b/cnm-cli/src/main.rs
@@ -806,6 +806,11 @@ fn install_force_exit_handler() {
 
 #[tokio::main]
 async fn main() {
+    // Pin rustls to the aws-lc-rs backend before any TLS object is built;
+    // see `vta_sdk::crypto_init`. Without this, rustls 0.23 panics on
+    // backend auto-detection when both backends are compiled in.
+    vta_sdk::crypto_init::install_default_crypto_provider();
+
     install_force_exit_handler();
 
     let cli = Cli::parse();

--- a/didcomm-test/Cargo.toml
+++ b/didcomm-test/Cargo.toml
@@ -13,7 +13,7 @@ name = "didcomm-test"
 path = "src/main.rs"
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.14", features = ["didcomm"] }
+vta-sdk = { path = "../vta-sdk", version = "0.14", features = ["didcomm", "crypto-provider"] }
 affinidi-tdk = { workspace = true }
 affinidi-did-resolver-cache-sdk = { workspace = true }
 tokio = { workspace = true }

--- a/didcomm-test/src/main.rs
+++ b/didcomm-test/src/main.rs
@@ -64,6 +64,11 @@ struct Args {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Pin rustls to the aws-lc-rs backend before any TLS object is built;
+    // see `vta_sdk::crypto_init`. Without this, rustls 0.23 panics on
+    // backend auto-detection when both backends are compiled in.
+    vta_sdk::crypto_init::install_default_crypto_provider();
+
     let args = Args::parse();
 
     tracing_subscriber::fmt()

--- a/pnm-cli/Cargo.toml
+++ b/pnm-cli/Cargo.toml
@@ -21,7 +21,7 @@ config-session = ["vta-sdk/config-session"]
 azure-secrets = ["vta-sdk/azure-secrets"]
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.14", features = ["session", "sealed-transfer", "attest-verify", "provision-integration"] }
+vta-sdk = { path = "../vta-sdk", version = "0.14", features = ["session", "sealed-transfer", "attest-verify", "provision-integration", "crypto-provider"] }
 affinidi-crypto = { workspace = true }
 base64 = { workspace = true }
 reqwest = { workspace = true }

--- a/pnm-cli/src/main.rs
+++ b/pnm-cli/src/main.rs
@@ -33,6 +33,11 @@ use clap::Parser;
 
 #[tokio::main]
 async fn main() {
+    // Pin rustls to the aws-lc-rs backend before any TLS object is built;
+    // see `vta_sdk::crypto_init`. Without this, rustls 0.23 panics on
+    // backend auto-detection when both backends are compiled in.
+    vta_sdk::crypto_init::install_default_crypto_provider();
+
     install_force_exit_handler();
 
     // Migration cue: the `pnm mediator …` subcommand surface was

--- a/vta-enclave/Cargo.toml
+++ b/vta-enclave/Cargo.toml
@@ -36,6 +36,7 @@ clap = { workspace = true }
 base64 = { workspace = true }
 serde_json = { workspace = true }
 tokio-vsock = { workspace = true, optional = true }
+rustls = { workspace = true }
 
 [lints]
 workspace = true

--- a/vta-enclave/Cargo.toml
+++ b/vta-enclave/Cargo.toml
@@ -36,7 +36,6 @@ clap = { workspace = true }
 base64 = { workspace = true }
 serde_json = { workspace = true }
 tokio-vsock = { workspace = true, optional = true }
-rustls = { workspace = true }
 
 [lints]
 workspace = true

--- a/vta-enclave/src/main.rs
+++ b/vta-enclave/src/main.rs
@@ -39,6 +39,9 @@ struct Cli {
 
 #[tokio::main]
 async fn main() {
+    // tonic 0.12.x forces `ring` on tokio-rustls; without this, rustls 0.23 panics on backend auto-detection.
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
     eprintln!("VTA enclave binary starting...");
 
     let cli = Cli::parse();

--- a/vta-enclave/src/main.rs
+++ b/vta-enclave/src/main.rs
@@ -39,8 +39,11 @@ struct Cli {
 
 #[tokio::main]
 async fn main() {
-    // tonic 0.12.x forces `ring` on tokio-rustls; without this, rustls 0.23 panics on backend auto-detection.
-    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+    // Pin rustls to the aws-lc-rs backend before any TLS object is built;
+    // see `vta_sdk::crypto_init` (re-exported by vta-service). Without this,
+    // rustls 0.23 panics on backend auto-detection when both backends are
+    // compiled in.
+    vta_service::crypto_init::install_default_crypto_provider();
 
     eprintln!("VTA enclave binary starting...");
 

--- a/vta-mcp/Cargo.toml
+++ b/vta-mcp/Cargo.toml
@@ -10,7 +10,7 @@ repository.workspace = true
 publish = false
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.14", features = ["client", "session", "sealed-transfer", "didcomm", "vp"] }
+vta-sdk = { path = "../vta-sdk", version = "0.14", features = ["client", "session", "sealed-transfer", "didcomm", "vp", "crypto-provider"] }
 rmcp = { version = "1.7", features = ["server", "transport-io", "macros", "schemars"] }
 schemars = "1"
 tokio = { workspace = true }

--- a/vta-mcp/src/main.rs
+++ b/vta-mcp/src/main.rs
@@ -82,6 +82,11 @@ struct Args {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    // Pin rustls to the aws-lc-rs backend before any TLS object is built;
+    // see `vta_sdk::crypto_init`. Without this, rustls 0.23 panics on
+    // backend auto-detection when both backends are compiled in.
+    vta_sdk::crypto_init::install_default_crypto_provider();
+
     // stdout is the MCP JSON-RPC channel — logs MUST go to stderr.
     tracing_subscriber::fmt()
         .with_writer(std::io::stderr)

--- a/vta-mobile-core/src/proof.rs
+++ b/vta-mobile-core/src/proof.rs
@@ -22,15 +22,18 @@ pub(crate) fn attach_did_signed_proof<P: Serialize>(
     signer: &dyn Signer,
     created: &str,
 ) -> Result<(), FfiError> {
-    let mut proof_config = DataIntegrityProof {
-        type_: "DataIntegrityProof".to_string(),
-        cryptosuite: CryptoSuite::EddsaJcs2022,
-        created: Some(created.to_string()),
-        verification_method: did_key_vm(&signer.did())?,
-        proof_purpose: "assertionMethod".to_string(),
-        proof_value: None,
-        context: None,
-    };
+    // `DataIntegrityProof` is `#[non_exhaustive]` as of affinidi-data-integrity
+    // 0.7.6 — build via `new` (the in-process `sign` would require the holder
+    // key in Rust, which this flow deliberately avoids). `proof_value` is filled
+    // in below after the native signer produces the signature.
+    let mut proof_config = DataIntegrityProof::new(
+        CryptoSuite::EddsaJcs2022,
+        did_key_vm(&signer.did())?,
+        "assertionMethod".to_string(),
+        None,
+        Some(created.to_string()),
+        None,
+    );
 
     // Library does eddsa-jcs-2022 canonicalization + hashing of (document, proof
     // config); the native enclave signs the result.

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -49,6 +49,15 @@ keyring = [
   "dep:windows-native-keyring-store",
   "dep:dbus-secret-service-keyring-store",
 ]
+# Install the rustls `aws-lc-rs` `CryptoProvider` as the process default.
+# Required by every *binary* that performs TLS: `tonic 0.12.x` (via
+# `affinidi-did-resolver-cache-sdk`) forces the `ring` backend on
+# `rustls 0.23`, so with `aws_lc_rs` also compiled in rustls cannot
+# auto-select and panics. Each binary that enables this feature must call
+# `vta_sdk::crypto_init::install_default_crypto_provider()` once at startup,
+# before any TLS object is built. Off by default and zero-cost when off, so
+# library/mobile consumers that pick their own rustls backend skip it.
+crypto-provider = ["dep:rustls"]
 config-session = []
 azure-secrets = [
   "dep:azure_security_keyvault_secrets",
@@ -145,6 +154,8 @@ thiserror = { workspace = true }
 url = { workspace = true }
 affinidi-tdk = { workspace = true, optional = true }
 reqwest = { workspace = true, optional = true }
+# Only for `crypto_init` (the aws-lc-rs CryptoProvider installer).
+rustls = { workspace = true, optional = true }
 tracing = { workspace = true, optional = true }
 uuid = { workspace = true, optional = true }
 affinidi-did-resolver-cache-sdk = { workspace = true, optional = true }

--- a/vta-sdk/src/crypto_init.rs
+++ b/vta-sdk/src/crypto_init.rs
@@ -1,0 +1,33 @@
+//! Register the rustls `aws-lc-rs` `CryptoProvider` as the process-wide
+//! default.
+//!
+//! `tonic 0.12.x` (pulled in transitively via
+//! `affinidi-did-resolver-cache-sdk`) hardcodes `features = ["ring"]` on
+//! `tokio-rustls`, which propagates the `ring` cargo feature to `rustls
+//! 0.23`. When a binary *also* links the `aws_lc_rs` backend — the
+//! workspace default, dragged in via `kube`, `jsonwebtoken`,
+//! reqwest-rustls, … — `rustls 0.23` ends up with two backends compiled in
+//! and cannot auto-select one. The first call to `ClientConfig::builder()`
+//! then panics with `no process-level CryptoProvider available`, which
+//! happens *before any network connection is made* (e.g. when
+//! `kube-client` initialises its HTTP client for the k8s-secrets backend).
+//!
+//! Every binary must call [`install_default_crypto_provider`] once at the
+//! very top of `main()`, before any async runtime or TLS object is created.
+//! This mirrors [`crate::keyring_init::install_default_store`].
+//!
+//! Note this is distinct from `jsonwebtoken`'s own `CryptoProvider`
+//! (`jsonwebtoken::crypto::aws_lc::DEFAULT_PROVIDER`), which governs JWT
+//! signing — pinning that one does nothing for the rustls TLS panic.
+
+/// Install the `aws-lc-rs` rustls `CryptoProvider` as the process default.
+///
+/// Idempotent: if a default provider is already installed (by a dependency
+/// or a previous call) the redundant install is ignored, so this is safe to
+/// call unconditionally for every build configuration. Returns `true` if
+/// this call installed the provider, `false` if one was already present.
+pub fn install_default_crypto_provider() -> bool {
+    rustls::crypto::aws_lc_rs::default_provider()
+        .install_default()
+        .is_ok()
+}

--- a/vta-sdk/src/lib.rs
+++ b/vta-sdk/src/lib.rs
@@ -105,6 +105,9 @@ pub mod did_templates;
 pub mod didcomm_light;
 #[cfg(feature = "session")]
 pub mod didcomm_session;
+// Pins rustls to the aws-lc-rs backend; every binary calls this at startup.
+#[cfg(feature = "crypto-provider")]
+pub mod crypto_init;
 #[cfg(feature = "keyring")]
 pub mod keyring_init;
 pub mod keys;

--- a/vta-sdk/tests/sd_jwt_vc_smoke.rs
+++ b/vta-sdk/tests/sd_jwt_vc_smoke.rs
@@ -232,11 +232,7 @@ fn tampered_issuer_signature_is_rejected() {
     let swapped = if last == 'A' { 'B' } else { 'A' };
     jws.push(swapped);
 
-    let forged = SdJwt {
-        jws,
-        disclosures: vc.sd_jwt.disclosures.clone(),
-        kb_jwt: vc.sd_jwt.kb_jwt.clone(),
-    };
+    let forged = SdJwt::new(jws, vc.sd_jwt.disclosures.clone(), vc.sd_jwt.kb_jwt.clone());
 
     let opts = VerificationOptions::default();
     let err = verify(&forged, &verifier, &hasher, &opts, None)

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -85,7 +85,7 @@ vti-common = { path = "../vti-common", version = "0.10", features = ["encryption
 # from this crate into a shared crate so external integrations can reuse them).
 # Per-backend features are activated by this crate's matching features below.
 vti-secrets = { path = "../vti-secrets", version = "0.1" }
-vta-sdk = { path = "../vta-sdk", version = "0.14", features = ["didcomm", "sealed-transfer", "provision-integration", "openapi"] }
+vta-sdk = { path = "../vta-sdk", version = "0.14", features = ["didcomm", "sealed-transfer", "provision-integration", "openapi", "crypto-provider"] }
 # DID-VM-resolved WebAuthn assertion verifier — drives the new
 # `vta/auth/passkey-login-{start,finish}/1.0` trust-task handlers.
 # Distinct from `webauthn-rs` (which drives the passkey *enrolment*
@@ -228,7 +228,6 @@ aws-sdk-dynamodb = { version = "1", optional = true }
 # didn't map directly to exploitation, but dropping the dep frees us
 # from the RustCrypto 0.11 ecosystem HOLD above.
 aws-lc-rs = { version = "1", optional = true }
-rustls = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -228,6 +228,7 @@ aws-sdk-dynamodb = { version = "1", optional = true }
 # didn't map directly to exploitation, but dropping the dep frees us
 # from the RustCrypto 0.11 ecosystem HOLD above.
 aws-lc-rs = { version = "1", optional = true }
+rustls = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/vta-service/src/lib.rs
+++ b/vta-service/src/lib.rs
@@ -6,6 +6,11 @@
 //! Front-end binaries import this library and call `server::run()`
 //! with the appropriate store backend and TEE context.
 
+// Re-exported so front-end binaries (e.g. `vta-enclave`, which only depends
+// on this crate) can install the rustls aws-lc-rs CryptoProvider at startup
+// without taking a direct `vta-sdk` dependency.
+pub use vta_sdk::crypto_init;
+
 pub mod acl;
 pub mod acl_sweeper;
 pub mod audit;

--- a/vta-service/src/main.rs
+++ b/vta-service/src/main.rs
@@ -1283,8 +1283,10 @@ enum DrainCommands {
 
 #[tokio::main]
 async fn main() {
-    // tonic 0.12.x forces `ring` on tokio-rustls; without this, rustls 0.23 panics on backend auto-detection.
-    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+    // Pin rustls to the aws-lc-rs backend before any TLS object is built;
+    // see `vta_sdk::crypto_init`. Without this, rustls 0.23 panics on
+    // backend auto-detection when both backends are compiled in.
+    vta_sdk::crypto_init::install_default_crypto_provider();
 
     let cli = Cli::parse();
 

--- a/vta-service/src/main.rs
+++ b/vta-service/src/main.rs
@@ -1283,6 +1283,9 @@ enum DrainCommands {
 
 #[tokio::main]
 async fn main() {
+    // tonic 0.12.x forces `ring` on tokio-rustls; without this, rustls 0.23 panics on backend auto-detection.
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
     let cli = Cli::parse();
 
     #[cfg(feature = "keyring")]

--- a/vta-service/src/trust_tasks/step_up.rs
+++ b/vta-service/src/trust_tasks/step_up.rs
@@ -1055,15 +1055,14 @@ mod tests {
         });
         let mut doc: TrustTask<Value> = serde_json::from_value(doc_json).unwrap();
 
-        let mut di = DataIntegrityProof {
-            type_: "DataIntegrityProof".to_string(),
-            cryptosuite: CryptoSuite::EddsaJcs2022,
-            created: Some("2026-05-31T00:00:00Z".to_string()),
-            verification_method: vm.to_string(),
-            proof_purpose: "assertionMethod".to_string(),
-            proof_value: None,
-            context: None,
-        };
+        let mut di = DataIntegrityProof::new(
+            CryptoSuite::EddsaJcs2022,
+            vm.to_string(),
+            "assertionMethod".to_string(),
+            None,
+            Some("2026-05-31T00:00:00Z".to_string()),
+            None,
+        );
         let input = prepare_sign_input(&doc, &di, CryptoSuite::EddsaJcs2022).unwrap();
         let sig = sk.sign(&input);
         di.proof_value = Some(multibase::encode(Base::Base58Btc, sig.to_bytes()));

--- a/vta-service/tests/authenticate_trust_task.rs
+++ b/vta-service/tests/authenticate_trust_task.rs
@@ -82,17 +82,16 @@ fn signed_authenticate_doc(
         "payload": { "challenge": challenge, "sessionId": session_id },
     });
     let mut doc: TrustTask<Value> = serde_json::from_value(doc_json).unwrap();
-    let mut di = DataIntegrityProof {
-        type_: "DataIntegrityProof".to_string(),
-        cryptosuite: CryptoSuite::EddsaJcs2022,
+    let mut di = DataIntegrityProof::new(
+        CryptoSuite::EddsaJcs2022,
+        vm.to_string(),
+        "authentication".to_string(),
+        None,
         // Safely in the past — DI verify rejects future-dated proofs, and the
         // wall clock sits right on the 2026-06-01 boundary.
-        created: Some("2026-05-31T12:00:00Z".to_string()),
-        verification_method: vm.to_string(),
-        proof_purpose: "authentication".to_string(),
-        proof_value: None,
-        context: None,
-    };
+        Some("2026-05-31T12:00:00Z".to_string()),
+        None,
+    );
     let input = prepare_sign_input(&doc, &di, CryptoSuite::EddsaJcs2022).unwrap();
     di.proof_value = Some(multibase::encode(
         Base::Base58Btc,

--- a/vta-service/tests/step_up_approve_response.rs
+++ b/vta-service/tests/step_up_approve_response.rs
@@ -100,15 +100,14 @@ async fn did_signed_approve_response_elevates_session_to_aal2() {
         },
     });
     let mut doc: TrustTask<Value> = serde_json::from_value(doc_json).unwrap();
-    let mut di = DataIntegrityProof {
-        type_: "DataIntegrityProof".to_string(),
-        cryptosuite: CryptoSuite::EddsaJcs2022,
-        created: Some("2026-05-31T00:00:00Z".to_string()),
-        verification_method: vm,
-        proof_purpose: "assertionMethod".to_string(),
-        proof_value: None,
-        context: None,
-    };
+    let mut di = DataIntegrityProof::new(
+        CryptoSuite::EddsaJcs2022,
+        vm,
+        "assertionMethod".to_string(),
+        None,
+        Some("2026-05-31T00:00:00Z".to_string()),
+        None,
+    );
     let input = prepare_sign_input(&doc, &di, CryptoSuite::EddsaJcs2022).unwrap();
     di.proof_value = Some(multibase::encode(
         Base::Base58Btc,
@@ -231,15 +230,14 @@ async fn did_signed_approve_response_0_2_elevates_session_to_aal2() {
         },
     });
     let mut doc: TrustTask<Value> = serde_json::from_value(doc_json).unwrap();
-    let mut di = DataIntegrityProof {
-        type_: "DataIntegrityProof".to_string(),
-        cryptosuite: CryptoSuite::EddsaJcs2022,
-        created: Some("2026-05-31T00:00:00Z".to_string()),
-        verification_method: vm,
-        proof_purpose: "assertionMethod".to_string(),
-        proof_value: None,
-        context: None,
-    };
+    let mut di = DataIntegrityProof::new(
+        CryptoSuite::EddsaJcs2022,
+        vm,
+        "assertionMethod".to_string(),
+        None,
+        Some("2026-05-31T00:00:00Z".to_string()),
+        None,
+    );
     let input = prepare_sign_input(&doc, &di, CryptoSuite::EddsaJcs2022).unwrap();
     di.proof_value = Some(multibase::encode(
         Base::Base58Btc,
@@ -468,15 +466,14 @@ async fn delegated_approve_response_elevates_the_subjects_session() {
         },
     });
     let mut doc: TrustTask<Value> = serde_json::from_value(doc_json).unwrap();
-    let mut di = DataIntegrityProof {
-        type_: "DataIntegrityProof".to_string(),
-        cryptosuite: CryptoSuite::EddsaJcs2022,
-        created: Some("2026-05-31T00:00:00Z".to_string()),
-        verification_method: approver_vm,
-        proof_purpose: "assertionMethod".to_string(),
-        proof_value: None,
-        context: None,
-    };
+    let mut di = DataIntegrityProof::new(
+        CryptoSuite::EddsaJcs2022,
+        approver_vm,
+        "assertionMethod".to_string(),
+        None,
+        Some("2026-05-31T00:00:00Z".to_string()),
+        None,
+    );
     let input = prepare_sign_input(&doc, &di, CryptoSuite::EddsaJcs2022).unwrap();
     di.proof_value = Some(multibase::encode(
         Base::Base58Btc,
@@ -607,15 +604,14 @@ async fn unauthorized_approver_cannot_elevate() {
         },
     });
     let mut doc: TrustTask<Value> = serde_json::from_value(doc_json).unwrap();
-    let mut di = DataIntegrityProof {
-        type_: "DataIntegrityProof".to_string(),
-        cryptosuite: CryptoSuite::EddsaJcs2022,
-        created: Some("2026-05-31T00:00:00Z".to_string()),
-        verification_method: rogue_vm,
-        proof_purpose: "assertionMethod".to_string(),
-        proof_value: None,
-        context: None,
-    };
+    let mut di = DataIntegrityProof::new(
+        CryptoSuite::EddsaJcs2022,
+        rogue_vm,
+        "assertionMethod".to_string(),
+        None,
+        Some("2026-05-31T00:00:00Z".to_string()),
+        None,
+    );
     let input = prepare_sign_input(&doc, &di, CryptoSuite::EddsaJcs2022).unwrap();
     di.proof_value = Some(multibase::encode(
         Base::Base58Btc,

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -110,6 +110,8 @@ vta-sdk = { path = "../vta-sdk", version = "0.14", features = [
   # `openapi` gates ToSchema on the vta-sdk protocol wire types the VTC
   # surface references (credential-exchange, discovery, etc.).
   "openapi",
+  # Lets `main()` install the rustls aws-lc-rs CryptoProvider at startup.
+  "crypto-provider",
 ] }
 affinidi-tdk = { workspace = true }
 affinidi-messaging-didcomm-service = { workspace = true }

--- a/vtc-service/src/main.rs
+++ b/vtc-service/src/main.rs
@@ -143,6 +143,11 @@ enum AdminCommands {
 
 #[tokio::main]
 async fn main() {
+    // Pin rustls to the aws-lc-rs backend before any TLS object is built;
+    // see `vta_sdk::crypto_init`. Without this, rustls 0.23 panics on
+    // backend auto-detection when both backends are compiled in.
+    vta_sdk::crypto_init::install_default_crypto_provider();
+
     let cli = Cli::parse();
 
     #[cfg(feature = "keyring")]


### PR DESCRIPTION
## Problem

`tonic 0.12.x` (pulled in transitively via `affinidi-did-resolver-cache-sdk`) hardcodes `features = ["ring"]` on `tokio-rustls`. This propagates the `ring` cargo feature to `rustls 0.23`, which then has both `aws_lc_rs` and `ring` backends compiled in and cannot auto-select one.

The result is a panic at the first call to `ClientConfig::builder()` — which happens when `kube-client` initialises its HTTP client (k8s-secrets backend), **before any network connection is made**:

```
thread 'main' panicked at 'no process-level CryptoProvider available'
```

This affects both `vta-service` and `vta-enclave` binaries.

## Fix

- Add `rustls 0.23` as a direct workspace dependency (with `aws_lc_rs` feature, no `ring`).
- Call `rustls::crypto::aws_lc_rs::default_provider().install_default()` at the very top of `main()` in both `vta-service` and `vta-enclave`, before any async runtime or TLS object is created.

The call is idempotent — safe for all build configurations regardless of which features are active.

## Changes

| File | Change |
|---|---|
| `Cargo.toml` | Add `rustls` as a workspace dep |
| `vta-service/Cargo.toml` | Pull `rustls` from workspace |
| `vta-enclave/Cargo.toml` | Pull `rustls` from workspace |
| `vta-service/src/main.rs` | Install provider at startup |
| `vta-enclave/src/main.rs` | Install provider at startup |

## Test plan

- [x] Build with `k8s-secrets` feature enabled and verify no panic on startup
- [x] Build without `k8s-secrets` and confirm the `install_default()` call is a no-op (idempotent)