### PR TITLE
Close #517, #512, #502: spec-0.2 wire compat, sealed-payload variant, one-way DIDComm send

### DIFF
--- a/pnm-cli/src/bootstrap.rs
+++ b/pnm-cli/src/bootstrap.rs
@@ -245,6 +245,15 @@ pub async fn run_open(
                 "Receive this credential into the holder vault via the credential-exchange flow."
             );
         }
+        SealedPayloadV1::MessagingBridgeCredentials(b) => {
+            println!("Payload: MessagingBridgeCredentials");
+            println!("  Platform:   {}", b.platform);
+            println!("  Fields:     {}", b.fields.len());
+            println!();
+            println!(
+                "Load these platform secrets into the messaging-bridge connector's secret store."
+            );
+        }
     }
 
     Ok(())
@@ -576,6 +585,7 @@ fn variant_name(p: &SealedPayloadV1) -> &'static str {
         SealedPayloadV1::TemplateBootstrap(_) => "TemplateBootstrap",
         SealedPayloadV1::AdminRotation(_) => "AdminRotation",
         SealedPayloadV1::IssuedCredential(_) => "IssuedCredential",
+        SealedPayloadV1::MessagingBridgeCredentials(_) => "MessagingBridgeCredentials",
     }
 }
 

--- a/vta-cli-common/src/sealed_consumer.rs
+++ b/vta-cli-common/src/sealed_consumer.rs
@@ -341,6 +341,12 @@ pub fn extract_admin_credential(
              — receive it into the holder vault via the credential-exchange flow"
                 .into(),
         ),
+        SealedPayloadV1::MessagingBridgeCredentials(_) => Err(
+            "MessagingBridgeCredentials payloads carry a connector's platform secrets, not an \
+             admin CredentialBundle — open via `pnm bootstrap open` and load them into the \
+             connector's secret store"
+                .into(),
+        ),
     }
 }
 

--- a/vta-sdk/src/client/mod.rs
+++ b/vta-sdk/src/client/mod.rs
@@ -750,6 +750,41 @@ impl VtaClient {
         }
     }
 
+    /// Send a one-way (fire-and-forget) DIDComm message of `msg_type` to
+    /// `recipient_did` and return as soon as the mediator accepts it — no
+    /// response is awaited and the body is **not** wrapped in a trust-task
+    /// envelope.
+    ///
+    /// This is the send-side counterpart to [`Self::receive_next`], for
+    /// asynchronous peer-to-peer data planes (e.g. `vti-message-bridge`'s
+    /// agent ⇄ bridge chat messages) where the traffic is one-way, not RPC.
+    /// The message is authcrypt-packed with this client's own keys, so the
+    /// recipient unpacks a cryptographically-authenticated sender DID. Safe to
+    /// call concurrently with a `receive_next` loop — it never touches the
+    /// inbound live stream. See issue #502.
+    ///
+    /// DIDComm-only — a REST client holds no key material to authcrypt with and
+    /// gets a clear [`VtaError::UnsupportedTransport`].
+    #[cfg_attr(not(feature = "session"), allow(unused_variables))]
+    pub async fn send_message(
+        &self,
+        recipient_did: &str,
+        msg_type: &str,
+        body: serde_json::Value,
+    ) -> Result<(), VtaError> {
+        match &self.transport {
+            #[cfg(feature = "session")]
+            Transport::DIDComm { session, .. } => {
+                session.send_one_way(recipient_did, msg_type, body).await
+            }
+            Transport::Rest { .. } => Err(VtaError::UnsupportedTransport(
+                "one-way DIDComm send requires the DIDComm transport \
+                 (REST clients hold no key material to authcrypt with)"
+                    .into(),
+            )),
+        }
+    }
+
     /// Resolve an **arbitrary** DID to its DID document JSON, via the shared
     /// DID-resolver cache (`affinidi-did-resolver-cache-sdk`). Independent of
     /// this client's auth/transport — pure resolution. Requires the `didcomm`

--- a/vta-sdk/src/didcomm_session.rs
+++ b/vta-sdk/src/didcomm_session.rs
@@ -266,6 +266,97 @@ impl DIDCommSession {
         Ok(msg.body)
     }
 
+    /// Pack `body` as an authcrypt DIDComm message of `msg_type` from this
+    /// session to `recipient_did`, wrap it in a `routing/2.0/forward` envelope,
+    /// and ship it through the mediator. Returns once the mediator has accepted
+    /// the forward — it does **not** consume the inbound live stream, so it is
+    /// safe to call concurrently with [`receive_next`](Self::receive_next) /
+    /// [`send_and_wait`](Self::send_and_wait) without racing on inbound
+    /// messages.
+    ///
+    /// Shared by [`send_and_wait`](Self::send_and_wait) (which then waits on the
+    /// live stream for `msg_id`'s response) and
+    /// [`send_one_way`](Self::send_one_way) (which returns immediately). Strict
+    /// mediators (`local_direct_delivery_allowed: false`) refuse direct
+    /// delivery — this is the same `forward_and_send_message` path the
+    /// production VTA-side `affinidi-messaging-didcomm-service` takes.
+    async fn pack_and_forward(
+        &self,
+        recipient_did: &str,
+        msg_id: &str,
+        msg_type: &str,
+        body: serde_json::Value,
+    ) -> Result<(), VtaError> {
+        let msg = Message::build(msg_id.to_string(), msg_type.to_string(), body)
+            .from(self.client_did.clone())
+            .to(recipient_did.to_string())
+            .finalize();
+
+        // Pack encrypted (signed + encrypted to recipient)
+        let (packed, _) = self
+            .atm
+            .pack_encrypted(
+                &msg,
+                recipient_did,
+                Some(&self.client_did),
+                Some(&self.client_did),
+            )
+            .await
+            .map_err(|e| VtaError::DidcommTransport(format!("failed to pack message: {e}")))?;
+
+        debug!(msg_type, msg_id, recipient_did, "sending via DIDComm");
+
+        let mediator_did = self
+            .profile
+            .inner
+            .mediator
+            .as_ref()
+            .as_ref()
+            .map(|m| m.did.clone())
+            .ok_or_else(|| {
+                VtaError::DidcommTransport("no mediator configured on profile".into())
+            })?;
+
+        self.atm
+            .forward_and_send_message(
+                &self.profile,
+                false, // authcrypt the forward envelope (mediator policy)
+                &packed,
+                Some(msg_id),
+                &mediator_did,
+                recipient_did,
+                None,
+                None,
+                false,
+            )
+            .await
+            .map_err(|e| VtaError::DidcommTransport(format!("failed to send message: {e}")))?;
+        Ok(())
+    }
+
+    /// Send a one-way (fire-and-forget) DIDComm message to `recipient_did` and
+    /// return as soon as the mediator accepts it — **no** response is awaited.
+    ///
+    /// This is the unsolicited-send counterpart to
+    /// [`receive_next`](Self::receive_next): the message is authcrypt-packed
+    /// with this session's own keys (so the recipient unpacks a
+    /// cryptographically-authenticated sender DID) and forwarded via the
+    /// mediator, exactly as [`send_and_wait`](Self::send_and_wait) does, minus
+    /// the response wait and minus the trust-task envelope. Because it never
+    /// touches the inbound live stream it is safe to call concurrently with a
+    /// `receive_next` loop (e.g. an async peer-to-peer data plane). See
+    /// issue #502.
+    pub async fn send_one_way(
+        &self,
+        recipient_did: &str,
+        msg_type: &str,
+        body: serde_json::Value,
+    ) -> Result<(), VtaError> {
+        let msg_id = uuid::Uuid::new_v4().to_string();
+        self.pack_and_forward(recipient_did, &msg_id, msg_type, body)
+            .await
+    }
+
     /// Send a DIDComm message and wait for a matching response.
     ///
     /// Packs the message, sends it to the mediator, then uses the WebSocket
@@ -283,55 +374,10 @@ impl DIDCommSession {
         timeout_secs: u64,
     ) -> Result<T, VtaError> {
         let msg_id = uuid::Uuid::new_v4().to_string();
-        let msg = Message::build(msg_id.clone(), msg_type.to_string(), body)
-            .from(self.client_did.clone())
-            .to(self.vta_did.clone())
-            .finalize();
-
-        // Pack encrypted (signed + encrypted to recipient)
-        let (packed, _) = self
-            .atm
-            .pack_encrypted(
-                &msg,
-                &self.vta_did,
-                Some(&self.client_did),
-                Some(&self.client_did),
-            )
-            .await
-            .map_err(|e| VtaError::DidcommTransport(format!("failed to pack message: {e}")))?;
-
-        debug!(msg_type, msg_id, "sending via DIDComm");
-
-        // Wrap the inner JWE in a `routing/2.0/forward` envelope addressed
-        // to the mediator and ship it. Strict mediators
-        // (`local_direct_delivery_allowed: false`) refuse direct delivery
-        // — same path the production VTA-side `affinidi-messaging-didcomm-service`
-        // takes via `forward_and_send_message`.
-        let mediator_did = self
-            .profile
-            .inner
-            .mediator
-            .as_ref()
-            .as_ref()
-            .map(|m| m.did.clone())
-            .ok_or_else(|| {
-                VtaError::DidcommTransport("no mediator configured on profile".into())
-            })?;
-
-        self.atm
-            .forward_and_send_message(
-                &self.profile,
-                false, // authcrypt the forward envelope (mediator policy)
-                &packed,
-                Some(&msg_id),
-                &mediator_did,
-                &self.vta_did,
-                None,
-                None,
-                false,
-            )
-            .await
-            .map_err(|e| VtaError::DidcommTransport(format!("failed to send message: {e}")))?;
+        // Pack + forward through the mediator (to the VTA). The reply is
+        // matched on the live stream below by `thid == msg_id`.
+        self.pack_and_forward(&self.vta_did, &msg_id, msg_type, body)
+            .await?;
 
         // Wait for the response via WebSocket live stream
         let timeout = std::time::Duration::from_secs(timeout_secs);

--- a/vta-sdk/src/provision_integration/http.rs
+++ b/vta-sdk/src/provision_integration/http.rs
@@ -43,14 +43,26 @@ pub struct ProvisionIntegrationRequest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub assertion: Option<AssertionMode>,
     /// Optional override for the VC's validity window (seconds).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    ///
+    /// Emitted snake_case (0.1 wire form); the `vcValiditySeconds` alias
+    /// accepts the `provision/integration/0.2` camelCase wire form on intake.
+    /// Dual-accept keeps a spec-0.2 producer working without a breaking
+    /// emission change (issue #517).
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        alias = "vcValiditySeconds"
+    )]
     pub vc_validity_seconds: Option<i64>,
     /// Create the target context as part of provisioning if it
     /// doesn't already exist. Requires **super-admin** on the VTA;
     /// context-admin callers get `Forbidden` against a missing
     /// context. Idempotent when the context already exists.
     /// Defaults to `false` for compatibility with older clients.
-    #[serde(default, skip_serializing_if = "is_false")]
+    ///
+    /// Emitted snake_case; the `createContext` alias accepts the
+    /// `provision/integration/0.2` camelCase form on intake (issue #517).
+    #[serde(default, skip_serializing_if = "is_false", alias = "createContext")]
     pub create_context: bool,
 }
 
@@ -91,51 +103,71 @@ pub struct ProvisionIntegrationResponse {
     pub summary: ProvisionSummary,
 }
 
+/// Emitted snake_case (0.1 wire form). Each field also carries a camelCase
+/// `alias` so a `provision/integration/0.2` (lowerCamelCase) producer's
+/// summary deserializes too — backwards-compatible dual-accept; emission is
+/// unchanged so existing snake_case consumers are unaffected (issue #517).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case", deny_unknown_fields)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ProvisionSummary {
     /// Ephemeral DID that signed the VP and opens the sealed bundle.
+    #[serde(alias = "clientDid")]
     pub client_did: String,
     /// Long-term admin DID — equals `client_did` when no rollover, or
     /// the VTA-minted DID when the request carried an `adminTemplate`
     /// (or used `AdminRotation`). Older VTAs that pre-date admin
     /// rollover omit this field on the wire; we default it to
     /// `client_did` for backward compat.
-    #[serde(default)]
+    #[serde(default, alias = "adminDid")]
     pub admin_did: String,
     /// True when the VTA minted a fresh long-term admin DID for this
     /// provisioning. Defaults to `false` for backward compatibility
     /// with VTAs that pre-date admin rollover.
-    #[serde(default)]
+    #[serde(default, alias = "adminRolledOver")]
     pub admin_rolled_over: bool,
     /// Integration DID rendered from the integration template. `None`
     /// for the `AdminRotation` ask — that flow only mints an admin
     /// DID and does not produce an integration DID.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        alias = "integrationDid"
+    )]
     pub integration_did: Option<String>,
     /// Name of the integration template that was rendered. `None` for
     /// the `AdminRotation` ask.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        alias = "templateName"
+    )]
     pub template_name: Option<String>,
     /// `kind` field of the integration template. `None` for the
     /// `AdminRotation` ask.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        alias = "templateKind"
+    )]
     pub template_kind: Option<String>,
     /// Name of the admin template, when one was used (i.e. the
     /// request used `adminTemplate` rollover *or* the `AdminRotation`
     /// ask).
-    #[serde(default)]
+    #[serde(default, alias = "adminTemplateName")]
     pub admin_template_name: Option<String>,
+    #[serde(alias = "bundleIdHex")]
     pub bundle_id_hex: String,
+    #[serde(alias = "secretCount")]
     pub secret_count: usize,
+    #[serde(alias = "outputCount")]
     pub output_count: usize,
     /// Resolved id of the registered webvh hosting server the VTA
     /// published the integration's `did.jsonl` to. `None` (default)
     /// means self-hosted at the URL — i.e. no `WEBVH_SERVER` template
     /// var was set, or it was explicitly null. Older VTAs that
     /// pre-date this field omit it on the wire; deserialize as `None`.
-    #[serde(default)]
+    #[serde(default, alias = "webvhServerId")]
     pub webvh_server_id: Option<String>,
     /// `true` when the target context didn't exist before this call
     /// and was created inline because the caller passed
@@ -143,6 +175,90 @@ pub struct ProvisionSummary {
     /// existed (or `create_context` was `false`). Lets operators
     /// see whether `--create-context` actually did something.
     /// Defaults to `false` on the wire for backward compatibility.
-    #[serde(default)]
+    #[serde(default, alias = "contextCreated")]
     pub context_created: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Issue #517: a `provision/integration/0.2` producer sends lowerCamelCase
+    /// field + assertion values. The shared request struct must accept both
+    /// the legacy snake_case (0.1) and the camelCase (0.2) forms; emission
+    /// stays snake_case so existing servers/clients are unaffected.
+    ///
+    /// Builds a real VP-framed [`BootstrapRequest`] (the `request` field has
+    /// `deny_unknown_fields`), then wraps it with the two option-field casings.
+    #[tokio::test]
+    async fn request_accepts_both_camel_and_snake_case() {
+        use crate::provision_integration::ProvisionRequestBuilder;
+
+        let (seed, pub_bytes) = crate::sealed_transfer::generate_ed25519_keypair();
+        let client_did = affinidi_crypto::did_key::ed25519_pub_to_did_key(&pub_bytes);
+        let vp = ProvisionRequestBuilder::new("didcomm-mediator")
+            .sign_with(&seed, &client_did)
+            .await
+            .expect("sign VP");
+        let request_json = serde_json::to_value(&vp).expect("serialize VP");
+
+        // camelCase (0.2) option fields + assertion.
+        let camel = serde_json::json!({
+            "request": request_json,
+            "assertion": "pinnedOnly",
+            "vcValiditySeconds": 3600,
+            "createContext": true,
+        });
+        let req: ProvisionIntegrationRequest = serde_json::from_value(camel).expect("camelCase");
+        assert!(matches!(req.assertion, Some(AssertionMode::PinnedOnly)));
+        assert_eq!(req.vc_validity_seconds, Some(3600));
+        assert!(req.create_context);
+
+        // snake_case (0.1) option fields + assertion.
+        let snake = serde_json::json!({
+            "request": request_json,
+            "assertion": "did-signed",
+            "vc_validity_seconds": 60,
+            "create_context": false,
+        });
+        let req: ProvisionIntegrationRequest = serde_json::from_value(snake).expect("snake_case");
+        assert!(matches!(req.assertion, Some(AssertionMode::DidSigned)));
+        assert_eq!(req.vc_validity_seconds, Some(60));
+        assert!(!req.create_context);
+
+        // Emission stays snake_case (conservative).
+        let out = serde_json::to_value(&req).unwrap();
+        assert!(out.get("vc_validity_seconds").is_some());
+        assert!(out.get("vcValiditySeconds").is_none());
+    }
+
+    /// The summary deserializes from a camelCase (0.2) producer too, while
+    /// still emitting snake_case for existing consumers.
+    #[test]
+    fn summary_accepts_camel_case() {
+        let camel = r#"{
+            "clientDid": "did:key:zClient",
+            "adminDid": "did:key:zAdmin",
+            "adminRolledOver": true,
+            "integrationDid": "did:webvh:x",
+            "templateName": "did-host-http",
+            "templateKind": "did-hosting-server",
+            "bundleIdHex": "deadbeef",
+            "secretCount": 2,
+            "outputCount": 1,
+            "webvhServerId": "srv-1",
+            "contextCreated": true
+        }"#;
+        let s: ProvisionSummary = serde_json::from_str(camel).expect("camelCase summary");
+        assert_eq!(s.client_did, "did:key:zClient");
+        assert_eq!(s.admin_did, "did:key:zAdmin");
+        assert!(s.admin_rolled_over);
+        assert_eq!(s.integration_did.as_deref(), Some("did:webvh:x"));
+        assert_eq!(s.secret_count, 2);
+        assert!(s.context_created);
+
+        let out = serde_json::to_value(&s).unwrap();
+        assert!(out.get("client_did").is_some());
+        assert!(out.get("clientDid").is_none());
+    }
 }

--- a/vta-sdk/src/sealed_transfer/bundle.rs
+++ b/vta-sdk/src/sealed_transfer/bundle.rs
@@ -61,6 +61,36 @@ pub enum SealedPayloadV1 {
     /// known `did:key`; the holder opens it and receives it into its vault. See
     /// [`IssuedCredentialBundle`].
     IssuedCredential(Box<IssuedCredentialBundle>),
+    /// Platform credentials for a `vti-message-bridge` connector — Signal
+    /// registration, bot tokens, SMTP creds, Matrix access tokens, etc.
+    ///
+    /// Per the bridge's design (§10.1) platform secrets never ride in the DID
+    /// template; they normally live in the connector's local `SeedStore`. When
+    /// a connector is provisioned **remotely**, the secrets are delivered
+    /// sealed via sealed-transfer instead — this variant is that payload,
+    /// sealed to the connector's X25519 key-agreement derivation. Additive
+    /// variant — no existing variant changes (issue #512). See
+    /// [`MessagingBridgeCredentialsBundle`].
+    MessagingBridgeCredentials(Box<MessagingBridgeCredentialsBundle>),
+}
+
+/// Platform credentials for a single `vti-message-bridge` connector. Mirrors
+/// the bridge's `provisioning::PlatformCredentials`: `platform` is the
+/// platform key (`signal`, `telegram`, `whatsapp`, `email`, `matrix`, …) and
+/// `fields` carries the platform-specific secret name/value pairs. Sealed to
+/// the connector's key-agreement DID derivation via sealed-transfer.
+///
+/// No `arbitrary` derive (it carries a `serde_json::Map`, same as
+/// [`IssuedCredentialBundle`]); the fuzz harness covers the framing layer, not
+/// this leaf payload.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MessagingBridgeCredentialsBundle {
+    /// Platform key — `signal`, `telegram`, `whatsapp`, `email`, `matrix`, …
+    pub platform: String,
+    /// Platform-specific secret fields (the bridge interprets these per
+    /// `platform`). Free-form so new platforms need no new variant.
+    pub fields: serde_json::Map<String, serde_json::Value>,
 }
 
 /// An issued credential sealed for delivery to a holder the issuer cannot yet

--- a/vta-sdk/src/sealed_transfer/mod.rs
+++ b/vta-sdk/src/sealed_transfer/mod.rs
@@ -22,8 +22,8 @@ pub mod verify;
 
 pub use bundle::{
     ArmoredChunk, AssertionProof, AttestationQuoteAssertion, DidSignedAssertion,
-    IssuedCredentialBundle, LabeledKey, ProducerAssertion, RawPrivateKey, SealedBundle,
-    SealedPayloadV1,
+    IssuedCredentialBundle, LabeledKey, MessagingBridgeCredentialsBundle, ProducerAssertion,
+    RawPrivateKey, SealedBundle, SealedPayloadV1,
 };
 pub use chunk::{ChunkPlaintext, MAX_PAYLOAD_FRAGMENT, VERSION};
 pub use error::SealedTransferError;
@@ -402,6 +402,45 @@ mod tests {
         match opened.payload {
             SealedPayloadV1::AdminKeySet(keys) => assert_eq!(keys.len(), 2048),
             _ => panic!("wrong variant"),
+        }
+    }
+
+    #[tokio::test]
+    async fn round_trip_messaging_bridge_credentials() {
+        // Issue #512: a connector's platform secrets seal/open through the
+        // additive `MessagingBridgeCredentials` variant with no change to the
+        // framing or existing variants.
+        let (recip_sk, recip_pk) = generate_keypair();
+        let (_prod_sk, prod_pk) = generate_ed25519_keypair();
+        let assertion =
+            sample_assertion(affinidi_crypto::did_key::ed25519_pub_to_did_key(&prod_pk));
+        let store = InMemoryNonceStore::new();
+        let bundle_id = [12u8; 16];
+
+        let mut fields = serde_json::Map::new();
+        fields.insert("botToken".into(), serde_json::json!("123:abc"));
+        fields.insert(
+            "registration".into(),
+            serde_json::json!({ "number": "+15551234", "captcha": "tok" }),
+        );
+        let payload = SealedPayloadV1::MessagingBridgeCredentials(Box::new(
+            MessagingBridgeCredentialsBundle {
+                platform: "telegram".to_string(),
+                fields: fields.clone(),
+            },
+        ));
+
+        let bundle = seal_payload(&recip_pk, bundle_id, assertion, &payload, &store)
+            .await
+            .unwrap();
+        let digest = bundle_digest(&bundle);
+        let opened = open_bundle(&recip_sk, &bundle, Some(&digest)).unwrap();
+        match opened.payload {
+            SealedPayloadV1::MessagingBridgeCredentials(b) => {
+                assert_eq!(b.platform, "telegram");
+                assert_eq!(b.fields, fields);
+            }
+            other => panic!("wrong variant: {other:?}"),
         }
     }
 

--- a/vta-service/src/bootstrap_cli.rs
+++ b/vta-service/src/bootstrap_cli.rs
@@ -353,6 +353,11 @@ fn print_opened(
             };
             println!("  Format:     {kind}");
         }
+        SealedPayloadV1::MessagingBridgeCredentials(b) => {
+            println!("Payload: MessagingBridgeCredentials");
+            println!("  Platform:   {}", b.platform);
+            println!("  Fields:     {}", b.fields.len());
+        }
     }
     Ok(())
 }

--- a/vta-service/src/messaging/handlers.rs
+++ b/vta-service/src/messaging/handlers.rs
@@ -1620,9 +1620,26 @@ pub(crate) const STEP_UP_APPROVE_REQUEST_TYPE: &str =
 pub(crate) const STEP_UP_APPROVE_RESPONSE_TYPE: &str =
     "https://trusttasks.org/vta/step-up/approve-response/1.0";
 
-/// Request body for [`handle_step_up_approve`].
+/// Canonical Trust Task **registry** URI for the step-up approval request,
+/// registered on the DIDComm router alongside the legacy `vta/step-up/*` URI
+/// (issue #517). A spec-conformant caller that targets the canonical
+/// `spec/auth/step-up/approve-request/0.1` is now handled too; the response
+/// echoes the request's version family (canonical request → canonical
+/// response), so neither the legacy plugin nor a spec-0.2 caller breaks.
+pub(crate) const STEP_UP_APPROVE_REQUEST_CANONICAL: &str =
+    "https://trusttasks.org/spec/auth/step-up/approve-request/0.1";
+
+/// Canonical Trust Task registry URI for the step-up approval response,
+/// emitted when the request arrived on [`STEP_UP_APPROVE_REQUEST_CANONICAL`].
+pub(crate) const STEP_UP_APPROVE_RESPONSE_CANONICAL: &str =
+    "https://trusttasks.org/spec/auth/step-up/approve-response/0.1";
+
+/// Request body for [`handle_step_up_approve`]. The `rpDid` alias accepts a
+/// spec-conformant (lowerCamelCase) producer; the legacy `rp_did` keeps the
+/// existing plugin working (issue #517).
 #[derive(serde::Deserialize)]
 struct StepUpApproveRequestBody {
+    #[serde(alias = "rpDid")]
     rp_did: String,
     nonce: String,
 }
@@ -1659,6 +1676,15 @@ pub async fn handle_step_up_approve(
                 "step-up approve request has no authenticated sender".into(),
             ))));
         }
+    };
+
+    // Echo the version family of the inbound request so a canonical
+    // (`spec/auth/step-up/…`) caller gets a canonical response and the legacy
+    // (`vta/step-up/…/1.0`) plugin gets the legacy response.
+    let response_type = if message.typ == STEP_UP_APPROVE_REQUEST_CANONICAL {
+        STEP_UP_APPROVE_RESPONSE_CANONICAL
+    } else {
+        STEP_UP_APPROVE_RESPONSE_TYPE
     };
 
     let body: StepUpApproveRequestBody =
@@ -1713,10 +1739,7 @@ pub async fn handle_step_up_approve(
         "issued VTA step-up approval token via DIDComm"
     );
 
-    response(
-        STEP_UP_APPROVE_RESPONSE_TYPE,
-        &StepUpApproveResponseBody { approval_token },
-    )
+    response(response_type, &StepUpApproveResponseBody { approval_token })
 }
 
 /// Holder-side receive of a credential delivered over DIDComm

--- a/vta-service/src/messaging/router.rs
+++ b/vta-service/src/messaging/router.rs
@@ -553,11 +553,21 @@ pub fn build_handler(
     }
 
     // Step-up approval — the VTA vouches (signs as itself) that a holder
-    // may step up their session at a relying party. Always available.
-    router = router.route(
-        handlers::STEP_UP_APPROVE_REQUEST_TYPE,
-        handler_fn(handlers::handle_step_up_approve),
-    )?;
+    // may step up their session at a relying party. Always available. Both
+    // the legacy `vta/step-up/approve-request/1.0` and the canonical
+    // `spec/auth/step-up/approve-request/0.1` registry URIs route to the same
+    // handler, which echoes the request's version family in its response
+    // (issue #517). Registering the canonical URI is additive — the legacy
+    // plugin is unaffected.
+    router = router
+        .route(
+            handlers::STEP_UP_APPROVE_REQUEST_TYPE,
+            handler_fn(handlers::handle_step_up_approve),
+        )?
+        .route(
+            handlers::STEP_UP_APPROVE_REQUEST_CANONICAL,
+            handler_fn(handlers::handle_step_up_approve),
+        )?;
 
     // TEE attestation handlers (feature-gated)
     #[cfg(feature = "tee")]

--- a/vta-service/src/trust_tasks/vault.rs
+++ b/vta-service/src/trust_tasks/vault.rs
@@ -138,17 +138,25 @@ struct VaultUpsertResponseBody {
     created: bool,
 }
 
-/// Wire form of `vault/_shared/0.1/sealed-envelope#/$defs/SealedEnvelope`
+/// Wire form of `vault/_shared/0.2/sealed-envelope#/$defs/SealedEnvelope`
 /// — the pluggable cipher envelope. M2A implements only the
 /// `didcomm-authcrypt` variant; `hpke-armored` and `tsp-message` are
 /// recognised on the wire (so the consumer gets a clean
 /// `envelope_unsupported` reject) but not unsealable here yet.
+///
+/// The `sealedSecret` / `sealedSessionBlob` envelope tag is deliberately
+/// excluded from the `vault/*/0.2` edge transform (it sits next to the
+/// opaque JWE), so this type parses the tag verbatim. The 0.2 spec renamed
+/// the tag values to lowerCamelCase (`didcommAuthcrypt` / `hpkeArmored` /
+/// `tspMessage`); to accept a spec-0.2 producer without a breaking change
+/// we keep emitting kebab (see [`SealedEnvelopeWire`]) but dual-accept both
+/// casings here via `alias` (Postel's law, issue #517).
 #[derive(Debug, Deserialize)]
 #[serde(tag = "envelope", rename_all = "kebab-case")]
 enum SealedEnvelope {
-    DidcommAuthcrypt {
-        jwe: String,
-    },
+    #[serde(alias = "didcommAuthcrypt")]
+    DidcommAuthcrypt { jwe: String },
+    #[serde(alias = "hpkeArmored")]
     HpkeArmored {
         #[serde(default)]
         #[allow(dead_code)]
@@ -157,6 +165,7 @@ enum SealedEnvelope {
         #[allow(dead_code)]
         recipient_key_id: String,
     },
+    #[serde(alias = "tspMessage")]
     TspMessage {
         #[serde(default)]
         #[allow(dead_code)]
@@ -1450,5 +1459,28 @@ fn password_post_error_to_reject(
         PasswordPostError::ResponseParse(msg) => RejectReason::InternalError {
             reason: format!("vault/proxy-login: response parse failure — {msg}"),
         },
+    }
+}
+
+#[cfg(test)]
+mod sealed_envelope_tests {
+    use super::SealedEnvelope;
+
+    /// The `sealedSecret.envelope` tag is excluded from the 0.2 edge
+    /// transform, so this type must natively accept both the legacy kebab tag
+    /// (0.1) and the spec-0.2 lowerCamelCase tag (issue #517). Backwards-compat
+    /// dual-accept — emission stays kebab via `SealedEnvelopeWire`.
+    #[test]
+    fn sealed_envelope_accepts_both_tag_casings() {
+        let kebab: SealedEnvelope =
+            serde_json::from_str(r#"{"envelope":"didcomm-authcrypt","jwe":"x"}"#).unwrap();
+        assert_eq!(kebab.kind_name(), "didcomm-authcrypt");
+        let camel: SealedEnvelope =
+            serde_json::from_str(r#"{"envelope":"didcommAuthcrypt","jwe":"x"}"#).unwrap();
+        assert_eq!(camel.kind_name(), "didcomm-authcrypt");
+
+        // The recognised-but-unsupported variants dual-accept too.
+        assert!(serde_json::from_str::<SealedEnvelope>(r#"{"envelope":"hpkeArmored"}"#).is_ok());
+        assert!(serde_json::from_str::<SealedEnvelope>(r#"{"envelope":"tspMessage"}"#).is_ok());
     }
 }

--- a/vti-common/src/vault/mod.rs
+++ b/vti-common/src/vault/mod.rs
@@ -135,17 +135,27 @@ pub enum SiteTarget {
     },
 }
 
-/// Discriminator for the kind of secret stored. Wire values are kebab-case
-/// (`oauth-tokens`, `did-self-issued`, etc.) per the canonical schema.
+/// Discriminator for the kind of secret stored. Emitted as kebab-case
+/// (`oauth-tokens`, `did-self-issued`, …) for the 0.1 wire form; the
+/// `vault/*/0.2` edge transform up-converts these to the canonical
+/// lowerCamelCase 0.2 values. To stay backwards-compatible while also
+/// accepting a spec-0.2 producer that sends camelCase directly, each
+/// multi-word value carries a camelCase `alias` (Postel's law: liberal in
+/// what we accept, conservative in what we emit). See issue #517.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub enum SecretKind {
     Password,
     Passkey,
+    #[serde(alias = "oauthTokens")]
     OauthTokens,
+    #[serde(alias = "didSelfIssued")]
     DidSelfIssued,
+    #[serde(alias = "didcommPeer")]
     DidcommPeer,
+    #[serde(alias = "bearerToken")]
     BearerToken,
+    #[serde(alias = "sshKey")]
     SshKey,
     Custom,
 }
@@ -207,10 +217,17 @@ pub struct StoredVaultEntry {
 }
 
 /// Cleartext secret material. Field-for-field mirror of
-/// [`vault/_shared/0.1/vault-secret#/$defs/VaultSecret`](https://trusttasks.org/spec/vault/_shared/0.1/vault-secret).
-/// Discriminated by `kind`; wire values are kebab-case per the canonical
-/// schema (`oauth-tokens`, `did-self-issued`, `didcomm-peer`,
-/// `bearer-token`, `ssh-key`).
+/// [`vault/_shared/0.2/vault-secret#/$defs/VaultSecret`](https://trusttasks.org/spec/vault/_shared/0.2/vault-secret).
+/// Discriminated by `kind`. This secret rides **inside** the opaque
+/// authcrypt JWE (`vault/upsert`'s `sealedSecret`), so the `vault/*/0.2`
+/// edge transform cannot reach it — the discriminator is parsed verbatim
+/// here. To accept both a 0.1 producer (kebab `did-self-issued`) and a
+/// spec-0.2 producer (camelCase `didSelfIssued`) without a breaking wire
+/// change, each multi-word variant carries a camelCase `alias`; the
+/// emitted form stays kebab for backwards compatibility (Postel's law).
+/// This is the fix for the half-completed migration in issue #517 — the
+/// variant *fields* were camelCased in `76287a5`, the *discriminator* was
+/// not.
 ///
 /// Sensitive fields (`password`, `private_key`, `refresh_token`,
 /// `secure_notes`, `token`, etc.) MUST be zeroised by handlers as soon as
@@ -262,7 +279,7 @@ pub enum VaultSecret {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         secure_notes: Option<String>,
     },
-    #[serde(rename_all = "camelCase")]
+    #[serde(rename_all = "camelCase", alias = "oauthTokens")]
     OauthTokens {
         provider: String,
         refresh_token: String,
@@ -275,21 +292,21 @@ pub enum VaultSecret {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         secure_notes: Option<String>,
     },
-    #[serde(rename_all = "camelCase")]
+    #[serde(rename_all = "camelCase", alias = "didSelfIssued")]
     DidSelfIssued {
         did: String,
         signing_key_id: String,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         secure_notes: Option<String>,
     },
-    #[serde(rename_all = "camelCase")]
+    #[serde(rename_all = "camelCase", alias = "didcommPeer")]
     DidcommPeer {
         peer_did: String,
         signing_key_id: String,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         secure_notes: Option<String>,
     },
-    #[serde(rename_all = "camelCase")]
+    #[serde(rename_all = "camelCase", alias = "bearerToken")]
     BearerToken {
         token: String,
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -299,7 +316,7 @@ pub enum VaultSecret {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         secure_notes: Option<String>,
     },
-    #[serde(rename_all = "camelCase")]
+    #[serde(rename_all = "camelCase", alias = "sshKey")]
     SshKey {
         private_key: String,
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -433,11 +450,16 @@ impl PasswordLoginConfig {
     }
 }
 
+/// Emitted kebab-case for the 0.1 wire form; accepts the spec-0.2
+/// camelCase `formUrlencoded` via alias. Rides inside the JWE, so the 0.2
+/// edge transform can't reach it — dual-accept here keeps it
+/// backwards-compatible (issue #517).
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "kebab-case")]
 pub enum PasswordLoginFormat {
     #[default]
     Json,
+    #[serde(alias = "formUrlencoded")]
     FormUrlencoded,
 }
 
@@ -566,14 +588,22 @@ pub struct SessionBlob {
     pub refresh_hint: Option<RefreshHint>,
 }
 
+/// Emitted kebab-case for the 0.1 wire form; accepts the spec-0.2
+/// camelCase variants (`maintainerOnly`/`on401`/`beforeExpiry`) via alias.
+/// Inside the sealed session blob, so the 0.2 edge transform can't reach
+/// it — dual-accept keeps it backwards-compatible (issue #517).
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub enum RefreshHint {
     /// Don't refresh on your own; the maintainer drives renewal.
+    #[serde(alias = "maintainerOnly")]
     MaintainerOnly,
     /// Call back to vault/proxy-login when the third party returns 401.
+    /// (kebab-case renders this `on401` — already equal to the spec-0.2
+    /// camelCase form, so no alias is needed.)
     On401,
     /// Pre-emptively refresh shortly before `expiresAt`.
+    #[serde(alias = "beforeExpiry")]
     BeforeExpiry,
 }
 
@@ -809,6 +839,24 @@ mod tests {
     }
 
     #[test]
+    fn secret_kind_also_accepts_spec_0_2_camel_case() {
+        // Backwards-compat dual-accept (issue #517): the 0.2 spec uses
+        // lowerCamelCase discriminator values. Emission stays kebab (above),
+        // but every multi-word camelCase form must deserialize too.
+        let cases = vec![
+            ("\"oauthTokens\"", SecretKind::OauthTokens),
+            ("\"didSelfIssued\"", SecretKind::DidSelfIssued),
+            ("\"didcommPeer\"", SecretKind::DidcommPeer),
+            ("\"bearerToken\"", SecretKind::BearerToken),
+            ("\"sshKey\"", SecretKind::SshKey),
+        ];
+        for (camel, expected) in cases {
+            let back: SecretKind = serde_json::from_str(camel).expect(camel);
+            assert_eq!(back, expected, "camelCase {camel}");
+        }
+    }
+
+    #[test]
     fn filter_matches_intersection_of_criteria() {
         let entry = sample("v1", "ctx_a", Some("2026-05-20T00:00:00Z"));
 
@@ -919,6 +967,98 @@ mod tests {
         assert!(
             re.contains("\"signingKeyId\":\"did:webvh:foo#key-0\""),
             "re-emitted JSON must use camelCase signingKeyId; got {re}"
+        );
+    }
+
+    #[test]
+    fn vault_secret_discriminator_accepts_both_casings() {
+        // Regression for issue #517: the inner sealed `VaultSecret` rides in
+        // the opaque authcrypt JWE, so the 0.2 edge transform can't camelCase
+        // its `kind`. A spec-0.2 producer (e.g. the browser plugin) seals
+        // `{"kind":"didSelfIssued", …}`; before the alias fix this was
+        // rejected with `unknown variant didSelfIssued`. Both the legacy
+        // kebab and the spec-0.2 camelCase discriminator must parse, for every
+        // multi-word kind.
+        let cases: Vec<(&str, &str, SecretKind)> = vec![
+            (
+                r#"{"kind":"oauth-tokens","provider":"google","refreshToken":"r"}"#,
+                r#"{"kind":"oauthTokens","provider":"google","refreshToken":"r"}"#,
+                SecretKind::OauthTokens,
+            ),
+            (
+                r#"{"kind":"did-self-issued","did":"did:webvh:x","signingKeyId":"did:webvh:x#k"}"#,
+                r#"{"kind":"didSelfIssued","did":"did:webvh:x","signingKeyId":"did:webvh:x#k"}"#,
+                SecretKind::DidSelfIssued,
+            ),
+            (
+                r#"{"kind":"didcomm-peer","peerDid":"did:peer:2","signingKeyId":"did:peer:2#k"}"#,
+                r#"{"kind":"didcommPeer","peerDid":"did:peer:2","signingKeyId":"did:peer:2#k"}"#,
+                SecretKind::DidcommPeer,
+            ),
+            (
+                r#"{"kind":"bearer-token","token":"t"}"#,
+                r#"{"kind":"bearerToken","token":"t"}"#,
+                SecretKind::BearerToken,
+            ),
+            (
+                r#"{"kind":"ssh-key","privateKey":"p"}"#,
+                r#"{"kind":"sshKey","privateKey":"p"}"#,
+                SecretKind::SshKey,
+            ),
+        ];
+        for (kebab, camel, expected) in cases {
+            let from_kebab: VaultSecret = serde_json::from_str(kebab).expect(kebab);
+            assert_eq!(from_kebab.kind(), expected, "kebab {kebab}");
+            let from_camel: VaultSecret = serde_json::from_str(camel).expect(camel);
+            assert_eq!(from_camel.kind(), expected, "camel {camel}");
+            // Conservative emission: we still serialize the legacy kebab form
+            // so existing 0.1 openers keep working.
+            let re = serde_json::to_string(&from_camel).unwrap();
+            let kebab_kind = serde_json::to_string(&expected).unwrap();
+            assert!(
+                re.contains(&format!("\"kind\":{kebab_kind}")),
+                "emitted form must keep kebab kind {kebab_kind}; got {re}"
+            );
+        }
+    }
+
+    #[test]
+    fn password_login_format_and_refresh_hint_accept_both_casings() {
+        // Both ride inside the JWE / sealed session blob (issue #517).
+        assert_eq!(
+            serde_json::from_str::<PasswordLoginFormat>("\"form-urlencoded\"").unwrap(),
+            PasswordLoginFormat::FormUrlencoded
+        );
+        assert_eq!(
+            serde_json::from_str::<PasswordLoginFormat>("\"formUrlencoded\"").unwrap(),
+            PasswordLoginFormat::FormUrlencoded
+        );
+        // Emission stays kebab.
+        assert_eq!(
+            serde_json::to_string(&PasswordLoginFormat::FormUrlencoded).unwrap(),
+            "\"form-urlencoded\""
+        );
+
+        for (kebab, camel, val) in [
+            (
+                "\"maintainer-only\"",
+                "\"maintainerOnly\"",
+                RefreshHint::MaintainerOnly,
+            ),
+            // kebab-case of `On401` is `on401` — already the spec-0.2 form.
+            ("\"on401\"", "\"on401\"", RefreshHint::On401),
+            (
+                "\"before-expiry\"",
+                "\"beforeExpiry\"",
+                RefreshHint::BeforeExpiry,
+            ),
+        ] {
+            assert_eq!(serde_json::from_str::<RefreshHint>(kebab).unwrap(), val);
+            assert_eq!(serde_json::from_str::<RefreshHint>(camel).unwrap(), val);
+        }
+        assert_eq!(
+            serde_json::to_string(&RefreshHint::On401).unwrap(),
+            "\"on401\""
         );
     }
 


### PR DESCRIPTION
Addresses three open issues. Backwards-compatible throughout — **accept both old and new wire casings on input, keep emitting the existing form** (Postel's law) so nothing live breaks.

## #512 — `MessagingBridgeCredentials` sealed-payload variant
Additive `SealedPayloadV1::MessagingBridgeCredentials(Box<MessagingBridgeCredentialsBundle{platform, fields}>)` so a messaging-bridge connector's platform secrets can ride sealed-transfer when provisioned remotely (vti-message-bridge design §10.1). No existing variant changes; seal/open round-trip test; exhaustive consumer matches get a descriptive arm.

## #502 — one-way `send_message`
Public fire-and-forget DIDComm send for async peer-to-peer data planes, replacing the `dispatch_trust_task(..., timeout=0)` + timeout-as-delivered + envelope-unwrap workaround. Factors pack-encrypt + `routing/2.0/forward` out of `send_and_wait` into `pack_and_forward`; adds `DIDCommSession::send_one_way` + `VtaClient::send_message`. No response wait, no trust-task envelope, never touches the inbound live stream (safe alongside `receive_next`). DIDComm-only; REST → `UnsupportedTransport`.

## #517 — spec-0.2 lowerCamelCase discriminators (all items)
Framework-0.2 renamed enumerated wire values to lowerCamelCase, but discriminators riding *inside* the opaque authcrypt JWE (or otherwise outside the `vault/*/0.2` edge transform) were left kebab/snake-case, rejecting spec-conformant producers.

- **P0**: `vault/upsert/0.2` accepted any multi-word `VaultSecret.kind` (`didSelfIssued`, `oauthTokens`, `didcommPeer`, `bearerToken`, `sshKey`) via camelCase aliases. `SecretKind` likewise.
- `PasswordLoginConfig.format` + `SessionBlob.refreshHint` camelCase aliases (`formUrlencoded` / `maintainerOnly` / `beforeExpiry`; `on401` already matched).
- `SealedEnvelope` tag dual-accepts `didcommAuthcrypt` / `hpkeArmored` / `tspMessage`.
- `provision/integration` request (`vcValiditySeconds` / `createContext`) + entire `ProvisionSummary` response camelCase aliases (assertion enum was already aliased).
- Step-up: additively register canonical `spec/auth/step-up/approve-request/0.1` alongside legacy `vta/step-up/approve-request/1.0`; handler echoes the request's version family; request body accepts `rpDid`.

Round-trip tests per kind/enum confirm both casings parse and **emission is unchanged**.

**Not in scope here:** the trust-task-error type/code version skew (also listed in #517) is governed by upstream `trust_tasks_rs` (`doc.reject_with` sets the type URI); patching only the one hardcoded path would make rejects inconsistent, so it's left for an upstream fix.

## Verification
- `cargo build` (workspace), `cargo fmt --check`, `cargo clippy` (touched crates) — clean.
- New + existing tests pass: vti-common vault, vta-sdk sealed_transfer/provision, vta-service vault/step-up/provision integration, CLI crates.
- The two `vta-sdk` `session_store` rotation tests that fail do so identically on pristine `origin/main` (stale `acl/swap-key` mock) — pre-existing, unrelated.

## Notes
- No crate version bumps (additive changes across 6 crates; left for a release decision).

Closes #517
Closes #512
Closes #502