### PR TITLE
Emit lowerCamelCase on 0.2 endpoints — complete #518 emit side (refs #517)

### DIFF
--- a/vta-sdk/src/client/bootstrap.rs
+++ b/vta-sdk/src/client/bootstrap.rs
@@ -52,6 +52,7 @@ impl VtaClient {
                     req.assertion,
                     req.vc_validity_seconds,
                     req.create_context,
+                    crate::protocols::provision_integration_management::ProvisionSpecVersion::V0_1,
                 )
                 .await
             }

--- a/vta-sdk/src/protocols/provision_integration_management.rs
+++ b/vta-sdk/src/protocols/provision_integration_management.rs
@@ -87,6 +87,117 @@ pub mod result {
     pub use crate::provision_integration::http::{ProvisionIntegrationResponse, ProvisionSummary};
 }
 
+use serde_json::Value;
+
+use crate::provision_integration::http::{
+    ProvisionIntegrationRequest, ProvisionIntegrationResponse,
+};
+
+/// Which casing convention a provision-integration body is emitted under. The
+/// 0.1 wire form is snake_case fields + kebab-case `assertion`; the 0.2 form is
+/// lowerCamelCase throughout, per `dtgwg-trust-tasks-tf`'s
+/// `provision/integration/0.2` schema.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProvisionSpecVersion {
+    V0_1,
+    V0_2,
+}
+
+impl ProvisionSpecVersion {
+    /// The canonical request URI to address this version at.
+    pub fn request_uri(self) -> &'static str {
+        match self {
+            ProvisionSpecVersion::V0_1 => CANONICAL_PROVISION_INTEGRATION,
+            ProvisionSpecVersion::V0_2 => CANONICAL_PROVISION_INTEGRATION_0_2,
+        }
+    }
+}
+
+fn is_v0_2(request_uri: &str) -> bool {
+    request_uri == CANONICAL_PROVISION_INTEGRATION_0_2
+}
+
+/// `foo_bar_baz` → `fooBarBaz`. A single-word key is returned unchanged.
+fn snake_to_lower_camel(key: &str) -> String {
+    delimited_to_lower_camel(key, '_')
+}
+
+/// `did-signed` → `didSigned`. A single-word value is returned unchanged.
+fn kebab_to_lower_camel(value: &str) -> String {
+    delimited_to_lower_camel(value, '-')
+}
+
+fn delimited_to_lower_camel(s: &str, delim: char) -> String {
+    let mut parts = s.split(delim);
+    let mut out = String::with_capacity(s.len());
+    if let Some(first) = parts.next() {
+        out.push_str(first);
+    }
+    for p in parts {
+        let mut chars = p.chars();
+        if let Some(f) = chars.next() {
+            out.extend(f.to_uppercase());
+            out.push_str(chars.as_str());
+        }
+    }
+    out
+}
+
+/// Rewrite the keys of an object in place via `snake_to_lower_camel`, leaving
+/// the values untouched. Shallow on purpose: the caller decides which subtrees
+/// (e.g. the signed VP) must stay byte-identical.
+fn recase_object_keys_shallow(map: &mut serde_json::Map<String, Value>) {
+    let renamed: Vec<(String, Value)> = std::mem::take(map)
+        .into_iter()
+        .map(|(k, v)| (snake_to_lower_camel(&k), v))
+        .collect();
+    map.extend(renamed);
+}
+
+/// Serialise a provision-integration **request** body in the casing
+/// `request_uri` implies. For 0.2 the optional fields are camelCased
+/// (`vc_validity_seconds` → `vcValiditySeconds`, `create_context` →
+/// `createContext`) and the `assertion` value is camelCased (`did-signed` →
+/// `didSigned`).
+///
+/// The signed `request` VP subtree is **never** touched — it carries the
+/// holder's `DataIntegrityProof` over its exact bytes, and a 0.2 holder already
+/// signs camelCase casing inside it (see [`crate::provision_integration::request`]).
+pub fn request_body_for_version(
+    req: &ProvisionIntegrationRequest,
+    request_uri: &str,
+) -> Result<Value, serde_json::Error> {
+    let mut v = serde_json::to_value(req)?;
+    if is_v0_2(request_uri)
+        && let Value::Object(map) = &mut v
+    {
+        // `request` (the signed VP) has no underscore, so the shallow rename
+        // leaves both its key and value intact.
+        recase_object_keys_shallow(map);
+        if let Some(Value::String(a)) = map.get_mut("assertion") {
+            *a = kebab_to_lower_camel(a);
+        }
+    }
+    Ok(v)
+}
+
+/// Serialise a provision-integration **response** body in the casing
+/// `request_uri` implies. For 0.2 the `summary` object's keys are camelCased
+/// (`client_did` → `clientDid`, `bundle_id_hex` → `bundleIdHex`, …). The
+/// top-level `bundle`/`digest` are opaque single-word fields and unchanged.
+pub fn response_body_for_version(
+    resp: &ProvisionIntegrationResponse,
+    request_uri: &str,
+) -> Result<Value, serde_json::Error> {
+    let mut v = serde_json::to_value(resp)?;
+    if is_v0_2(request_uri)
+        && let Some(Value::Object(summary)) = v.get_mut("summary")
+    {
+        recase_object_keys_shallow(summary);
+    }
+    Ok(v)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -140,5 +251,117 @@ mod tests {
             CANONICAL_PROVISION_INTEGRATION_0_2_RESULT,
             "https://trusttasks.org/spec/provision/integration/0.2#response"
         );
+    }
+
+    #[test]
+    fn snake_and_kebab_to_lower_camel() {
+        assert_eq!(snake_to_lower_camel("client_did"), "clientDid");
+        assert_eq!(snake_to_lower_camel("bundle_id_hex"), "bundleIdHex");
+        assert_eq!(
+            snake_to_lower_camel("vc_validity_seconds"),
+            "vcValiditySeconds"
+        );
+        assert_eq!(snake_to_lower_camel("bundle"), "bundle"); // single word
+        assert_eq!(kebab_to_lower_camel("did-signed"), "didSigned");
+        assert_eq!(kebab_to_lower_camel("pinned-only"), "pinnedOnly");
+    }
+
+    /// Build a real VP-framed request so the `request` subtree carries a
+    /// genuine `DataIntegrityProof` — the casing helpers must leave it intact.
+    async fn sample_request(
+        assertion: Option<crate::provision_integration::http::AssertionMode>,
+        vc_validity_seconds: Option<i64>,
+        create_context: bool,
+    ) -> (ProvisionIntegrationRequest, Value) {
+        use crate::provision_integration::ProvisionRequestBuilder;
+        let (seed, pub_bytes) = crate::sealed_transfer::generate_ed25519_keypair();
+        let client_did = affinidi_crypto::did_key::ed25519_pub_to_did_key(&pub_bytes);
+        let vp = ProvisionRequestBuilder::new("didcomm-mediator")
+            .sign_with(&seed, &client_did)
+            .await
+            .expect("sign VP");
+        let vp_value = serde_json::to_value(&vp).expect("serialize VP");
+        let req = ProvisionIntegrationRequest {
+            request: vp,
+            context: Some("ctx".into()),
+            assertion,
+            vc_validity_seconds,
+            create_context,
+        };
+        (req, vp_value)
+    }
+
+    #[tokio::test]
+    async fn request_body_v0_1_stays_snake_case_and_kebab_assertion() {
+        let (req, _) = sample_request(
+            Some(crate::provision_integration::http::AssertionMode::DidSigned),
+            Some(3600),
+            true,
+        )
+        .await;
+        let v = request_body_for_version(&req, CANONICAL_PROVISION_INTEGRATION).unwrap();
+        assert_eq!(v["assertion"], "did-signed");
+        assert_eq!(v["vc_validity_seconds"], 3600);
+        assert_eq!(v["create_context"], true);
+        assert!(v.get("vcValiditySeconds").is_none());
+    }
+
+    #[tokio::test]
+    async fn request_body_v0_2_camelizes_opts_and_assertion_but_not_signed_vp() {
+        let (req, vp_value) = sample_request(
+            Some(crate::provision_integration::http::AssertionMode::PinnedOnly),
+            Some(60),
+            false,
+        )
+        .await;
+        let v = request_body_for_version(&req, CANONICAL_PROVISION_INTEGRATION_0_2).unwrap();
+        // Opt keys + assertion value camelized.
+        assert_eq!(v["assertion"], "pinnedOnly");
+        assert_eq!(v["vcValiditySeconds"], 60);
+        assert!(v.get("vc_validity_seconds").is_none());
+        // `create_context: false` is skipped on the wire (is_false) — absent.
+        assert!(v.get("createContext").is_none());
+        assert!(v.get("create_context").is_none());
+        // Single-word keys unchanged.
+        assert_eq!(v["context"], "ctx");
+        // The signed VP subtree is byte-identical — the proof still covers it.
+        assert_eq!(v["request"], vp_value);
+    }
+
+    #[test]
+    fn response_body_v0_1_stays_snake_case_v0_2_camelizes_summary() {
+        let resp = ProvisionIntegrationResponse {
+            bundle: "armored".into(),
+            digest: "deadbeef".into(),
+            summary: crate::provision_integration::http::ProvisionSummary {
+                client_did: "did:key:zClient".into(),
+                admin_did: "did:key:zAdmin".into(),
+                admin_rolled_over: true,
+                integration_did: Some("did:webvh:x".into()),
+                template_name: Some("tmpl".into()),
+                template_kind: Some("kind".into()),
+                admin_template_name: None,
+                bundle_id_hex: "abc".into(),
+                secret_count: 2,
+                output_count: 1,
+                webvh_server_id: None,
+                context_created: true,
+            },
+        };
+        // 0.1 — snake_case preserved.
+        let v01 = response_body_for_version(&resp, CANONICAL_PROVISION_INTEGRATION).unwrap();
+        assert_eq!(v01["summary"]["client_did"], "did:key:zClient");
+        assert_eq!(v01["summary"]["bundle_id_hex"], "abc");
+        assert!(v01["summary"].get("clientDid").is_none());
+        // 0.2 — summary keys camelized; values and opaque bundle/digest intact.
+        let v02 = response_body_for_version(&resp, CANONICAL_PROVISION_INTEGRATION_0_2).unwrap();
+        assert_eq!(v02["summary"]["clientDid"], "did:key:zClient");
+        assert_eq!(v02["summary"]["bundleIdHex"], "abc");
+        assert_eq!(v02["summary"]["secretCount"], 2);
+        assert_eq!(v02["summary"]["adminRolledOver"], true);
+        assert_eq!(v02["summary"]["contextCreated"], true);
+        assert!(v02["summary"].get("client_did").is_none());
+        assert_eq!(v02["bundle"], "armored");
+        assert_eq!(v02["digest"], "deadbeef");
     }
 }

--- a/vta-sdk/src/provision_client/runner_didcomm.rs
+++ b/vta-sdk/src/provision_client/runner_didcomm.rs
@@ -15,6 +15,7 @@ use crate::did_key::decode_private_key_multibase;
 use crate::didcomm_session::DIDCommSession;
 use crate::protocols::did_management::servers::ListWebvhServersResultBody;
 use crate::protocols::did_management::{LIST_WEBVH_SERVERS, LIST_WEBVH_SERVERS_RESULT};
+use crate::protocols::provision_integration_management::ProvisionSpecVersion;
 use crate::provision_integration::didcomm::provision_integration_didcomm;
 
 use super::ask::ProvisionAsk;
@@ -65,6 +66,7 @@ pub async fn provision_via_didcomm(
             None,
             None,
             false,
+            ProvisionSpecVersion::V0_1,
         )
         .await?;
         response_to_result(&seed, nonce, response)
@@ -393,6 +395,7 @@ pub async fn provision_admin_rotation_via_didcomm(
             None,
             None,
             false,
+            ProvisionSpecVersion::V0_1,
         )
         .await?;
         crate::provision_client::result::admin_rotation_response_to_reply(&seed, nonce, response)

--- a/vta-sdk/src/provision_integration/didcomm.rs
+++ b/vta-sdk/src/provision_integration/didcomm.rs
@@ -30,7 +30,7 @@
 use crate::didcomm_session::DIDCommSession;
 use crate::error::VtaError;
 use crate::protocols::provision_integration_management::{
-    CANONICAL_PROVISION_INTEGRATION, CANONICAL_PROVISION_INTEGRATION_RESULT,
+    ProvisionSpecVersion, request_body_for_version, result_uri_for,
 };
 
 use super::BootstrapRequest;
@@ -69,6 +69,13 @@ const DEFAULT_TIMEOUT_SECS: u64 = 60;
 /// don't track the maintainer's context layout. See
 /// [`crate::provision_integration::http::ProvisionIntegrationRequest::context`]
 /// for the full inference rules + error semantics.
+///
+/// `spec_version` selects the Trust Task wire version. [`ProvisionSpecVersion::V0_1`]
+/// emits the legacy snake_case option fields + kebab `assertion` under the
+/// `provision/integration/0.1` URI; [`ProvisionSpecVersion::V0_2`] emits
+/// lowerCamelCase (`vcValiditySeconds` / `createContext` / `didSigned`) under
+/// the `0.2` URI. The signed VP carried in `request` is left byte-identical
+/// either way — its casing is the holder's, and the VTA dual-accepts both.
 pub async fn provision_integration_didcomm(
     session: &DIDCommSession,
     request: BootstrapRequest,
@@ -76,6 +83,7 @@ pub async fn provision_integration_didcomm(
     assertion: Option<AssertionMode>,
     vc_validity_seconds: Option<i64>,
     create_context: bool,
+    spec_version: ProvisionSpecVersion,
 ) -> Result<ProvisionIntegrationResponse, VtaError> {
     // No "session DID must equal VP holder" pre-check. The flow is
     // intentionally layered (outer authcrypt = relayer, inner VP =
@@ -87,13 +95,14 @@ pub async fn provision_integration_didcomm(
         vc_validity_seconds,
         create_context,
     };
-    let body = serde_json::to_value(&body_struct).map_err(VtaError::from)?;
+    let request_uri = spec_version.request_uri();
+    let body = request_body_for_version(&body_struct, request_uri).map_err(VtaError::from)?;
 
     session
         .send_and_wait::<ProvisionIntegrationResponse>(
-            CANONICAL_PROVISION_INTEGRATION,
+            request_uri,
             body,
-            CANONICAL_PROVISION_INTEGRATION_RESULT,
+            result_uri_for(request_uri),
             DEFAULT_TIMEOUT_SECS,
         )
         .await

--- a/vta-service/src/messaging/handlers.rs
+++ b/vta-service/src/messaging/handlers.rs
@@ -1481,7 +1481,15 @@ pub async fn handle_provision_integration(
         "provision-integration completed via DIDComm"
     );
 
-    response(result_uri, &result)
+    // Emit the body in the casing the request version requires: a 0.2 request
+    // (`…/provision/integration/0.2`) gets a lowerCamelCase `summary`; a 0.1
+    // request keeps the snake_case form. The REST endpoint stays 0.1/snake_case.
+    let body = vta_sdk::protocols::provision_integration_management::response_body_for_version(
+        &result,
+        &message.typ,
+    )
+    .map_err(handler_err)?;
+    response(result_uri, &body)
 }
 
 /// Envelope used by the DIDComm update + rotate-keys messages.

--- a/vta-service/src/operations/vault/proxy_login.rs
+++ b/vta-service/src/operations/vault/proxy_login.rs
@@ -13,6 +13,7 @@
 //! reject mapping; the driver dispatch + sealing live here.
 
 use affinidi_tdk::messaging::ATM;
+use serde_json::Value;
 
 use vti_common::vault::{
     RequestHeader, SessionBlob, SiteTarget, StoredVaultEntry, VaultSecret, put_stored_vault_entry,
@@ -21,6 +22,7 @@ use vti_common::vault::{
 use crate::error::AppError;
 use crate::keys::seed_store::SeedStore;
 use crate::store::KeyspaceHandle;
+use crate::trust_tasks::wire_v0_2::{WireVersion, camelize_paths};
 
 /// Password-POST session TTL ceiling (seconds). The caller's `ttlSecondsHint`
 /// is honoured up to this and silently truncated above it.
@@ -65,7 +67,7 @@ impl From<AppError> for ProxyLoginError {
 /// The caller has already gated capability + context scope + step-up,
 /// bounds-checked `nonce`, and resolved `atm` / `vta_did`.
 #[allow(clippy::too_many_arguments)]
-pub async fn proxy_login(
+pub(crate) async fn proxy_login(
     atm: &ATM,
     vault_ks: &KeyspaceHandle,
     keys_ks: &KeyspaceHandle,
@@ -78,6 +80,7 @@ pub async fn proxy_login(
     target: Option<SiteTarget>,
     nonce: Option<String>,
     ttl_hint: Option<u32>,
+    wire: WireVersion,
 ) -> Result<ProxyLoginOutput, ProxyLoginError> {
     // Driver dispatch. Each arm produces a `SessionBlob` (+ session_id +
     // expires_at); the shared tail below authcrypts + persists.
@@ -162,11 +165,10 @@ pub async fn proxy_login(
         }
     };
 
-    let session_body = serde_json::to_value(&session_blob).map_err(|e| {
-        ProxyLoginError::App(AppError::Internal(format!(
-            "vault/proxy-login: failed to serialise SessionBlob: {e}"
-        )))
-    })?;
+    // The SessionBlob rides inside the opaque JWE, so the edge transform can't
+    // reach its `refreshHint`; emit the version-appropriate casing here.
+    let session_body =
+        session_blob_cleartext_for_wire(&session_blob, wire).map_err(ProxyLoginError::App)?;
 
     let jwe = super::authcrypt_to_holder(
         atm,
@@ -292,9 +294,84 @@ fn resolve_siop_audience(
     entry_origin.clone().map(|o| (o, entry_origin))
 }
 
+/// Serialise a `SessionBlob` into the JWE cleartext JSON in the casing the
+/// negotiated wire version requires. `SessionBlob` always serialises its 0.1
+/// (kebab) `refreshHint` value; for a 0.2 session we up-convert it (the field
+/// name `refreshHint` is already camelCase via the struct's `rename_all`).
+/// Pure + synchronous so the casing is unit-testable without an ATM/JWE.
+fn session_blob_cleartext_for_wire(
+    blob: &SessionBlob,
+    wire: WireVersion,
+) -> Result<Value, AppError> {
+    let mut body = serde_json::to_value(blob).map_err(|e| {
+        AppError::Internal(format!(
+            "vault/proxy-login: failed to serialise SessionBlob: {e}"
+        ))
+    })?;
+    if wire == WireVersion::V0_2 {
+        camelize_paths(&mut body, &["refreshHint"]);
+    }
+    Ok(body)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use vti_common::vault::RefreshHint;
+
+    fn blob_with_hint(hint: Option<RefreshHint>) -> SessionBlob {
+        SessionBlob {
+            session_id: "s1".into(),
+            expires_at: "2026-06-17T00:00:00Z".into(),
+            cookies: vec![],
+            headers: vec![],
+            local_storage: vec![],
+            session_storage: vec![],
+            bind_origin: None,
+            refresh_hint: hint,
+        }
+    }
+
+    #[test]
+    fn v0_1_session_blob_keeps_kebab_refresh_hint() {
+        let body = session_blob_cleartext_for_wire(
+            &blob_with_hint(Some(RefreshHint::BeforeExpiry)),
+            WireVersion::V0_1,
+        )
+        .unwrap();
+        assert_eq!(body["refreshHint"], "before-expiry");
+    }
+
+    #[test]
+    fn v0_2_session_blob_camelizes_refresh_hint() {
+        let body = session_blob_cleartext_for_wire(
+            &blob_with_hint(Some(RefreshHint::BeforeExpiry)),
+            WireVersion::V0_2,
+        )
+        .unwrap();
+        assert_eq!(body["refreshHint"], "beforeExpiry");
+        // `on401` is identical in both casings; `maintainer-only` → `maintainerOnly`.
+        let on401 = session_blob_cleartext_for_wire(
+            &blob_with_hint(Some(RefreshHint::On401)),
+            WireVersion::V0_2,
+        )
+        .unwrap();
+        assert_eq!(on401["refreshHint"], "on401");
+        let maint = session_blob_cleartext_for_wire(
+            &blob_with_hint(Some(RefreshHint::MaintainerOnly)),
+            WireVersion::V0_2,
+        )
+        .unwrap();
+        assert_eq!(maint["refreshHint"], "maintainerOnly");
+    }
+
+    #[test]
+    fn session_blob_without_hint_is_unaffected() {
+        // `refresh_hint: None` is skipped on the wire — camelize is a safe no-op.
+        let body =
+            session_blob_cleartext_for_wire(&blob_with_hint(None), WireVersion::V0_2).unwrap();
+        assert!(body.get("refreshHint").is_none());
+    }
 
     fn web(o: &str) -> SiteTarget {
         SiteTarget::WebOrigin {

--- a/vta-service/src/operations/vault/release.rs
+++ b/vta-service/src/operations/vault/release.rs
@@ -8,11 +8,13 @@
 //! operations work.
 
 use affinidi_tdk::messaging::ATM;
+use serde_json::Value;
 
-use vti_common::vault::{SecretKind, StoredVaultEntry, put_stored_vault_entry};
+use vti_common::vault::{SecretKind, StoredVaultEntry, VaultSecret, put_stored_vault_entry};
 
 use crate::error::AppError;
 use crate::store::KeyspaceHandle;
+use crate::trust_tasks::wire_v0_2::{WireVersion, camelize_paths};
 
 /// M2A.3 release TTL ceiling (seconds). A higher client hint silently caps
 /// rather than rejecting.
@@ -36,23 +38,25 @@ pub struct ReleasedSecret {
 ///
 /// The caller has already gated capability + context scope + step-up and
 /// resolved `atm` / `vta_did`.
-pub async fn release_secret(
+pub(crate) async fn release_secret(
     atm: &ATM,
     vault_ks: &KeyspaceHandle,
     vta_did: &str,
     holder_did: &str,
     mut stored: StoredVaultEntry,
     ttl_hint: Option<u32>,
+    wire: WireVersion,
 ) -> Result<ReleasedSecret, AppError> {
     let ttl_seconds = ttl_hint
         .map(|t| t.min(TTL_CEILING_SECS))
         .unwrap_or(TTL_CEILING_SECS);
 
     // Per the canonical sealed-envelope schema, the cleartext inside the JWE is
-    // the `VaultSecret` JSON directly.
-    let secret_body = serde_json::to_value(&stored.secret).map_err(|e| {
-        AppError::Internal(format!("vault/release: failed to serialise secret: {e}"))
-    })?;
+    // the `VaultSecret` JSON directly. The 0.2 spec renamed the `kind`
+    // discriminator and `loginConfig.format` to camelCase; this body rides
+    // inside the opaque JWE, so the edge transform can't reach it — we emit the
+    // version-appropriate casing here.
+    let secret_body = secret_cleartext_for_wire(&stored.secret, wire)?;
 
     let jwe = super::authcrypt_to_holder(
         atm,
@@ -81,4 +85,83 @@ pub async fn release_secret(
         secret_kind,
         ttl_seconds,
     })
+}
+
+/// Serialise a `VaultSecret` into the cleartext JSON that goes inside the JWE,
+/// in the casing the negotiated wire version requires.
+///
+/// `VaultSecret` always serialises its 0.1 (kebab) form; for a 0.2 release we
+/// up-convert the enum values the 0.2 spec renamed — the `kind` discriminator
+/// and (on `password` entries) `loginConfig.format`. Pure + synchronous so the
+/// casing is unit-testable without an ATM or a real JWE.
+fn secret_cleartext_for_wire(secret: &VaultSecret, wire: WireVersion) -> Result<Value, AppError> {
+    let mut body = serde_json::to_value(secret).map_err(|e| {
+        AppError::Internal(format!("vault/release: failed to serialise secret: {e}"))
+    })?;
+    if wire == WireVersion::V0_2 {
+        camelize_paths(&mut body, &["kind", "loginConfig.format"]);
+    }
+    Ok(body)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vti_common::vault::{PasswordLoginConfig, PasswordLoginFormat};
+
+    #[test]
+    fn v0_1_release_keeps_kebab_kind_and_format() {
+        let secret = VaultSecret::OauthTokens {
+            provider: "google".into(),
+            refresh_token: "r".into(),
+            access_token: None,
+            access_token_expires_at: None,
+            scopes: vec![],
+            secure_notes: None,
+        };
+        let body = secret_cleartext_for_wire(&secret, WireVersion::V0_1).unwrap();
+        assert_eq!(body["kind"], "oauth-tokens");
+    }
+
+    #[test]
+    fn v0_2_release_camelizes_kind_and_login_config_format() {
+        let secret = VaultSecret::Password {
+            username: Some("u".into()),
+            password: "p".into(),
+            totp: None,
+            login_config: Some(PasswordLoginConfig {
+                login_url: "https://example.com/login".into(),
+                format: PasswordLoginFormat::FormUrlencoded,
+                username_field: None,
+                password_field: None,
+                totp_field: None,
+                extra_fields: None,
+                success_status: None,
+            }),
+            secure_notes: None,
+            custom_fields: vec![],
+        };
+        // 0.1 stays kebab.
+        let v01 = secret_cleartext_for_wire(&secret, WireVersion::V0_1).unwrap();
+        assert_eq!(v01["kind"], "password");
+        assert_eq!(v01["loginConfig"]["format"], "form-urlencoded");
+        // 0.2 up-converts the renamed values; the single-word `kind`
+        // (`password`) is unchanged either way.
+        let v02 = secret_cleartext_for_wire(&secret, WireVersion::V0_2).unwrap();
+        assert_eq!(v02["kind"], "password");
+        assert_eq!(v02["loginConfig"]["format"], "formUrlencoded");
+    }
+
+    #[test]
+    fn v0_2_release_camelizes_multiword_kind() {
+        let secret = VaultSecret::DidSelfIssued {
+            did: "did:webvh:x".into(),
+            signing_key_id: "did:webvh:x#k".into(),
+            secure_notes: None,
+        };
+        let v02 = secret_cleartext_for_wire(&secret, WireVersion::V0_2).unwrap();
+        assert_eq!(v02["kind"], "didSelfIssued");
+        // Variant fields are already camelCase (serde `rename_all`) and untouched.
+        assert_eq!(v02["signingKeyId"], "did:webvh:x#k");
+    }
 }

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -75,7 +75,7 @@ pub(crate) use step_up::{
 mod vault;
 #[cfg(feature = "webvh")]
 mod webvh;
-mod wire_v0_2;
+pub(crate) mod wire_v0_2;
 
 /// The transport-neutral dispatch result — see [`helpers::TrustTaskOutcome`].
 /// Re-exported so both transports (`routes`-mounted REST handler + DIDComm
@@ -328,6 +328,12 @@ pub(crate) async fn dispatch_trust_task_core(
     // dispatched through the existing 0.1 handler, and the response
     // up-converted back to 0.2 (see `wire_v0_2`). Signed-payload specs are NOT
     // routed here — they have typed 0.2 arms in `dispatch_typed`.
+    // The negotiated wire version is scoped around `dispatch_typed` via a
+    // `task_local` so the two JWE-sealing handlers (`vault/release`,
+    // `vault/proxy-login`) can serialise the *sealed* cleartext in the right
+    // casing — the edge transform can't reach inside ciphertext. Every other
+    // handler ignores it.
+    use wire_v0_2::{WIRE_VERSION, WireVersion};
     let type_uri = doc.type_uri.to_string();
     if let Some(spec) = wire_v0_2::lookup_0_2(&type_uri) {
         let mut doc = doc;
@@ -335,10 +341,14 @@ pub(crate) async fn dispatch_trust_task_core(
         if let Ok(uri_0_1) = spec.uri_0_1.parse() {
             doc.type_uri = uri_0_1;
         }
-        let outcome = dispatch_typed(state, auth, doc).await;
+        let outcome = WIRE_VERSION
+            .scope(WireVersion::V0_2, dispatch_typed(state, auth, doc))
+            .await;
         return wire_v0_2::upconvert_response(outcome, spec);
     }
-    dispatch_typed(state, auth, doc).await
+    WIRE_VERSION
+        .scope(WireVersion::V0_1, dispatch_typed(state, auth, doc))
+        .await
 }
 
 /// Build a Trust-Task rejection `Response` for a request whose envelope

--- a/vta-service/src/trust_tasks/vault.rs
+++ b/vta-service/src/trust_tasks/vault.rs
@@ -995,7 +995,10 @@ pub(super) async fn handle_release(
         }
     };
 
-    // Seal the secret to the holder (operations layer; P2.4).
+    // Seal the secret to the holder (operations layer; P2.4). The negotiated
+    // wire version decides whether the `VaultSecret.kind` sealed inside the JWE
+    // is emitted kebab (0.1) or camelCase (0.2) — the edge transform can't
+    // reach ciphertext, so the seal step does it.
     match crate::operations::vault::release::release_secret(
         atm,
         &state.vault_ks,
@@ -1003,6 +1006,7 @@ pub(super) async fn handle_release(
         &auth.did,
         stored,
         req.ttl_seconds_hint,
+        super::wire_v0_2::current_wire_version(),
     )
     .await
     {
@@ -1142,6 +1146,7 @@ pub(super) async fn handle_proxy_login(
         req.target,
         req.nonce,
         req.ttl_seconds_hint,
+        super::wire_v0_2::current_wire_version(),
     )
     .await
     {

--- a/vta-service/src/trust_tasks/wire_v0_2.rs
+++ b/vta-service/src/trust_tasks/wire_v0_2.rs
@@ -36,6 +36,36 @@ use serde_json::Value;
 
 use super::TrustTaskOutcome;
 
+/// The Trust-Task wire version a request was received under. Threaded to the
+/// two vault handlers that seal values *inside* a JWE (`vault/release`,
+/// `vault/proxy-login`): the edge transform can rewrite plaintext enum paths
+/// but not ciphertext, so those handlers serialise the sealed cleartext in a
+/// version-aware way — kebab for 0.1, camelCase for 0.2.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum WireVersion {
+    V0_1,
+    V0_2,
+}
+
+tokio::task_local! {
+    /// Request-scoped negotiated wire version. Set by the dispatcher
+    /// ([`super::dispatch_trust_task_core`]) around each `dispatch_typed`
+    /// call and read by the JWE-sealing handlers via [`current_wire_version`].
+    ///
+    /// A `task_local` rather than a threaded parameter because only two of the
+    /// ~25 dispatch handlers need it; plumbing an unused `WireVersion` through
+    /// every handler signature (or pulling these two out of the `dispatch_table!`
+    /// macro, which would desync the `dispatched_uris()` parity harness) would
+    /// be far more invasive than this one contained read.
+    pub(crate) static WIRE_VERSION: WireVersion;
+}
+
+/// The wire version for the in-flight request, defaulting to [`WireVersion::V0_1`]
+/// when read outside a [`WIRE_VERSION`] scope (e.g. a direct unit test).
+pub(crate) fn current_wire_version() -> WireVersion {
+    WIRE_VERSION.try_with(|v| *v).unwrap_or(WireVersion::V0_1)
+}
+
 /// One spec's 0.1 ⇄ 0.2 mapping. Paths are `.`-separated and relative to the
 /// document `payload`; a `*` segment fans out over every array element or
 /// object value.
@@ -90,10 +120,18 @@ pub(super) const WIRE_SPECS_V0_2: &[WireSpecV02] = &[
     // ── vault slice ─────────────────────────────────────────────────
     // SecretKind (`oauth-tokens`, `did-self-issued`, …) and the SiteTarget
     // `kind` discriminator (`web-origin`, `ios-app`, `android-app`) carry the
-    // renamed values. `sealedSecret`/`sealedSessionBlob` envelope tags
-    // (`didcomm-authcrypt`, …) are NOT renamed in 0.2, and the JWE / step-up
-    // proof / signed-envelope payloads are opaque — none are on enum paths, so
-    // they pass through byte-exact.
+    // renamed values. The `sealedSecret`/`sealedSessionBlob` envelope tag
+    // (`didcomm-authcrypt`, …) IS renamed in 0.2 (the canonical 0.2
+    // `sealed-envelope.schema.json` declares `didcommAuthcrypt`/`hpkeArmored`/
+    // `tspMessage`) — it sits next to the opaque JWE as a plaintext object key,
+    // so it's reachable on an enum path (`sealedSecret.envelope`) and handled
+    // by this transform. What the transform CANNOT reach are the values sealed
+    // *inside* the JWE ciphertext (the released `VaultSecret.kind`, the
+    // `SessionBlob.refreshHint`, `PasswordLoginConfig.format`); those get
+    // version-aware serialisation at seal time (see [`WireVersion`] +
+    // `operations::vault::{release,proxy_login}`). The step-up proof / signed-
+    // envelope payloads are opaque and on no enum path, so they pass through
+    // byte-exact.
     WireSpecV02 {
         uri_0_1: "https://trusttasks.org/spec/vault/list/0.1",
         uri_0_2: "https://trusttasks.org/spec/vault/list/0.2",
@@ -109,20 +147,25 @@ pub(super) const WIRE_SPECS_V0_2: &[WireSpecV02] = &[
     WireSpecV02 {
         uri_0_1: "https://trusttasks.org/spec/vault/upsert/0.1",
         uri_0_2: "https://trusttasks.org/spec/vault/upsert/0.2",
-        request_paths: &["secretKind", "targets.*.kind"],
+        request_paths: &["secretKind", "targets.*.kind", "sealedSecret.envelope"],
         response_paths: &["entry.secretKind", "entry.targets.*.kind"],
     },
     WireSpecV02 {
         uri_0_1: "https://trusttasks.org/spec/vault/release/0.1",
         uri_0_2: "https://trusttasks.org/spec/vault/release/0.2",
         request_paths: &["target.kind"],
-        response_paths: &["secretKind"],
+        // `secretKind` is the outer echo; `sealedSecret.envelope` is the
+        // pluggable-cipher tag wrapping the JWE. The `VaultSecret.kind` *inside*
+        // the JWE is camelCased at seal time, not here (it's ciphertext).
+        response_paths: &["secretKind", "sealedSecret.envelope"],
     },
     WireSpecV02 {
         uri_0_1: "https://trusttasks.org/spec/vault/proxy-login/0.1",
         uri_0_2: "https://trusttasks.org/spec/vault/proxy-login/0.2",
         request_paths: &["target.kind"],
-        response_paths: &[],
+        // The `sealedSessionBlob.envelope` tag wraps the JWE; the
+        // `SessionBlob.refreshHint` inside it is camelCased at seal time.
+        response_paths: &["sealedSessionBlob.envelope"],
     },
     WireSpecV02 {
         // Request/response carry the unsigned/signed Trust-Task envelope verbatim
@@ -243,6 +286,18 @@ pub(super) fn downconvert_request(payload: &mut Value, spec: &WireSpecV02) {
 /// original 0.2 document.
 pub(super) fn kebabize_paths(payload: &mut Value, paths: &[&str]) {
     apply_paths(payload, paths, kebabize);
+}
+
+/// Up-convert (kebab→camel) the enum values at `paths` in `payload`.
+///
+/// Exposed for the JWE-sealing operations (`vault/release`, `vault/proxy-login`):
+/// the released `VaultSecret` / `SessionBlob` cleartext rides inside ciphertext
+/// the edge transform can't reach, so the seal step camelizes the relevant
+/// enum paths itself when emitting a 0.2 response. Reuses the same
+/// path-targeted [`camelize`] the response up-converter uses, so a 0.1 seal is
+/// a no-op (kebab is left intact).
+pub(crate) fn camelize_paths(payload: &mut Value, paths: &[&str]) {
+    apply_paths(payload, paths, camelize);
 }
 
 /// Up-convert a dispatch outcome: retype `…/0.1#response` → `…/0.2#response`
@@ -488,6 +543,110 @@ mod tests {
         assert_eq!(v["payload"]["entries"][0]["targets"][0]["kind"], "iosApp");
         // Free-text label coinciding with a token stays put.
         assert_eq!(v["payload"]["entries"][0]["label"], "oauth-tokens");
+    }
+
+    #[tokio::test]
+    async fn vault_release_response_camelizes_sealed_secret_envelope_tag() {
+        // The `sealedSecret.envelope` tag sits next to the JWE as a plaintext
+        // key, so the edge transform must up-convert it to the canonical 0.2
+        // `didcommAuthcrypt`. (The `VaultSecret.kind` inside the JWE is opaque
+        // here — it's camelCased at seal time, exercised in the ops tests.)
+        let spec = lookup_0_2("https://trusttasks.org/spec/vault/release/0.2").unwrap();
+        let doc = serde_json::json!({
+            "id": "urn:uuid:7",
+            "type": "https://trusttasks.org/spec/vault/release/0.1#response",
+            "payload": {
+                "sealedSecret": { "envelope": "didcomm-authcrypt", "jwe": "opaque.jwe.bytes" },
+                "secretKind": "oauth-tokens",
+                "ttlSeconds": 60
+            }
+        });
+        let outcome = TrustTaskOutcome {
+            status: axum::http::StatusCode::OK,
+            body: serde_json::to_vec(&doc).unwrap(),
+        };
+        let out = upconvert_response(outcome, spec);
+        let v: Value = serde_json::from_slice(&out.body).unwrap();
+        assert_eq!(
+            v["type"],
+            "https://trusttasks.org/spec/vault/release/0.2#response"
+        );
+        assert_eq!(
+            v["payload"]["sealedSecret"]["envelope"], "didcommAuthcrypt",
+            "envelope tag up-converted"
+        );
+        assert_eq!(v["payload"]["secretKind"], "oauthTokens");
+        // The opaque JWE bytes are NOT a string on any enum path beyond the
+        // `envelope` key, so they pass through verbatim.
+        assert_eq!(v["payload"]["sealedSecret"]["jwe"], "opaque.jwe.bytes");
+    }
+
+    #[tokio::test]
+    async fn vault_proxy_login_response_camelizes_sealed_session_blob_envelope_tag() {
+        let spec = lookup_0_2("https://trusttasks.org/spec/vault/proxy-login/0.2").unwrap();
+        let doc = serde_json::json!({
+            "id": "urn:uuid:8",
+            "type": "https://trusttasks.org/spec/vault/proxy-login/0.1#response",
+            "payload": {
+                "sealedSessionBlob": { "envelope": "didcomm-authcrypt", "jwe": "opaque" },
+                "sessionId": "s1",
+                "expiresAt": "2026-06-17T00:00:00Z"
+            }
+        });
+        let outcome = TrustTaskOutcome {
+            status: axum::http::StatusCode::OK,
+            body: serde_json::to_vec(&doc).unwrap(),
+        };
+        let out = upconvert_response(outcome, spec);
+        let v: Value = serde_json::from_slice(&out.body).unwrap();
+        assert_eq!(
+            v["payload"]["sealedSessionBlob"]["envelope"],
+            "didcommAuthcrypt"
+        );
+    }
+
+    #[test]
+    fn vault_upsert_request_downconverts_sealed_secret_envelope_tag() {
+        // A 0.2 producer sends `sealedSecret.envelope: "didcommAuthcrypt"`;
+        // down-convert hands the existing 0.1 handler the kebab tag it parses.
+        let spec = lookup_0_2("https://trusttasks.org/spec/vault/upsert/0.2").unwrap();
+        let mut payload = serde_json::json!({
+            "contextId": "personal",
+            "secretKind": "oauthTokens",
+            "targets": [],
+            "label": "x",
+            "sealedSecret": { "envelope": "didcommAuthcrypt", "jwe": "opaque" }
+        });
+        downconvert_request(&mut payload, spec);
+        assert_eq!(payload["sealedSecret"]["envelope"], "didcomm-authcrypt");
+        assert_eq!(payload["secretKind"], "oauth-tokens");
+    }
+
+    #[test]
+    fn camelize_paths_is_a_noop_on_kebab_for_v0_1_seal() {
+        // The seal path calls `camelize_paths` only for 0.2; on a 0.1 secret
+        // body the values are already kebab and untouched.
+        let mut secret = serde_json::json!({
+            "kind": "oauth-tokens",
+            "loginConfig": { "format": "form-urlencoded" }
+        });
+        camelize_paths(&mut secret, &["kind", "loginConfig.format"]);
+        assert_eq!(secret["kind"], "oauthTokens");
+        assert_eq!(secret["loginConfig"]["format"], "formUrlencoded");
+    }
+
+    #[tokio::test]
+    async fn current_wire_version_reads_scoped_value_and_defaults_to_v0_1() {
+        assert_eq!(
+            current_wire_version(),
+            WireVersion::V0_1,
+            "default outside scope"
+        );
+        WIRE_VERSION
+            .scope(WireVersion::V0_2, async {
+                assert_eq!(current_wire_version(), WireVersion::V0_2);
+            })
+            .await;
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Completes the Framework-0.2 lowerCamelCase migration on the **EMIT** side of the VTA. #518 (issue #517) made the VTA *accept* camelCase 0.2 discriminators/fields via `#[serde(alias)]` but deliberately left outbound serialization in the legacy form. Per the canonical spec (`dtgwg-trust-tasks-tf` `SPEC.md §4.10` item 4 + the `_shared/0.2` schemas), every **0.2** endpoint must emit lowerCamelCase. This finishes that: **0.2 output = lowerCamelCase; 0.1 output stays byte-identical** (kebab/snake/Pascal).

## Guiding principle

**No `#[serde(rename_all)]` and no variant/field renames anywhere** — so 0.1 wire output is byte-identical by construction. 0.2 camelCase is produced by two mechanisms:
- **Outer plaintext fields** → the existing `wire_v0_2` edge transform.
- **JWE-internal values + provision** → version-aware serialization at seal/emit time.

This honours the architectural constraint: outer `secretKind`/`targets.*.kind` are already up-converted by the transform, so flipping `rename_all` would double-convert. Only the sites the transform/seal didn't already cover are touched.

## Changes

**1. SealedEnvelope tag (outer, via edge transform)**
The 0.2 `sealed-envelope.schema.json` renames the tag to camelCase (`didcommAuthcrypt`/`hpkeArmored`/`tspMessage`), contradicting the old `wire_v0_2.rs` comment that claimed it was "NOT renamed in 0.2". **Reconciled per the canonical spec** (spec is authoritative): added `sealedSecret.envelope` / `sealedSessionBlob.envelope` to the release/proxy-login **response** paths and the upsert **request** path, and fixed the stale comment. `SealedEnvelopeWire` itself is unchanged (keeps emitting kebab; the transform up-converts for 0.2 only).

**2. JWE-internal values (version-aware at seal time)**
`VaultSecret.kind` (vault/release), `PasswordLoginConfig.format`, and `SessionBlob.refreshHint` (vault/proxy-login) ride inside the authcrypt JWE — ciphertext the edge transform can't reach. Threaded the negotiated wire version to the two sealing handlers via a request-scoped `tokio::task_local!` (`WIRE_VERSION`) set by the dispatcher around `dispatch_typed`. The seal step (`secret_cleartext_for_wire` / `session_blob_cleartext_for_wire`, pure + unit-testable) camelizes the relevant enum paths on 0.2 and leaves kebab on 0.1.

**3. Provision (separate dispatch; version known at emit)**
- **Server**: `handle_provision_integration` now emits a lowerCamelCase `summary` when the request arrived under `provision/integration/0.2` (snake_case for 0.1). The REST endpoint is untouched (stays 0.1/snake_case).
- **Client**: `provision_integration_didcomm` gained a `ProvisionSpecVersion` selector — 0.2 emits camelCase option fields (`vcValiditySeconds`/`createContext`) + assertion (`didSigned`/`pinnedOnly`) under the 0.2 URI. The signed VP subtree is **never** re-cased (its casing is the holder's and is dual-accepted server-side).

Shared snake↔camel emission helpers live in `provision_integration_management.rs`.

## Compatibility
- 0.1 wire output is byte-identical (no serde renames changed).
- The #518 intake aliases are unchanged — both casings still deserialize on every type.

## Tests
Round-trip tests added per type (0.2 emits camel, 0.1 emits legacy, both still deserialize either casing):
- `wire_v0_2`: envelope-tag up-convert (release/proxy-login) + down-convert (upsert); `WIRE_VERSION` scoping.
- `operations::vault::{release,proxy_login}`: `*_cleartext_for_wire` camelize `kind`/`loginConfig.format`/`refreshHint` on 0.2, kebab on 0.1.
- `provision_integration_management`: request/response emit helpers camelCase on 0.2, snake/kebab on 0.1, **signed VP subtree byte-identical**.

`cargo fmt --check`, `cargo clippy`, and the full suites pass: vti-common (248), vta-sdk (234), vta-service `--features webvh,didcomm` (997, 0 failed) including the dispatcher parity harness. (Two pre-existing `err().expect()` clippy warnings in `preconditions.rs` are untouched by this PR.)

Refs #517. Completes the emit side of #518.