### PR TITLE
chore(release): bump crate versions for #520

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2400,7 +2400,7 @@ checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cnm-cli"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "clap",
@@ -2414,7 +2414,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.15.0",
+ "vta-sdk 0.16.0",
 ]
 
 [[package]]
@@ -3161,7 +3161,7 @@ dependencies = [
 
 [[package]]
 name = "didcomm-test"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-tdk 0.7.4",
@@ -3174,7 +3174,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.15.0",
+ "vta-sdk 0.16.0",
 ]
 
 [[package]]
@@ -6639,7 +6639,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "pnm-cli"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-resolver-cache-sdk",
@@ -6661,7 +6661,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.15.0",
+ "vta-sdk 0.16.0",
 ]
 
 [[package]]
@@ -9909,7 +9909,7 @@ dependencies = [
 
 [[package]]
 name = "vta-cli-common"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "aes-gcm",
  "affinidi-crypto",
@@ -9927,7 +9927,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.15.0",
+ "vta-sdk 0.16.0",
  "vti-common",
  "x25519-dalek",
 ]
@@ -9949,7 +9949,7 @@ dependencies = [
 
 [[package]]
 name = "vta-mcp"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -9960,12 +9960,12 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.15.0",
+ "vta-sdk 0.16.0",
 ]
 
 [[package]]
 name = "vta-mobile-core"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -9983,7 +9983,7 @@ dependencies = [
  "tracing-subscriber",
  "trust-tasks-rs",
  "uniffi",
- "vta-sdk 0.15.0",
+ "vta-sdk 0.16.0",
 ]
 
 [[package]]
@@ -10018,7 +10018,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10074,7 +10074,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",
@@ -10149,7 +10149,7 @@ dependencies = [
  "utoipa-axum",
  "uuid",
  "vta-cli-common",
- "vta-sdk 0.15.0",
+ "vta-sdk 0.16.0",
  "vta-service",
  "vti-common",
  "vti-secrets",
@@ -10163,7 +10163,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-service"
-version = "0.9.6"
+version = "0.9.7"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",
@@ -10228,7 +10228,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.15.0",
+ "vta-sdk 0.16.0",
  "vtc-service",
  "vti-common",
  "vti-secrets",
@@ -10241,7 +10241,7 @@ dependencies = [
 
 [[package]]
 name = "vti-common"
-version = "0.10.6"
+version = "0.10.7"
 dependencies = [
  "aes-gcm",
  "affinidi-did-resolver-cache-sdk",
@@ -10276,7 +10276,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.15.0",
+ "vta-sdk 0.16.0",
  "webauthn-rs",
  "zeroize",
 ]
@@ -10303,14 +10303,14 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.15.0",
+ "vta-sdk 0.16.0",
  "vta-service",
  "vti-common",
 ]
 
 [[package]]
 name = "vti-secrets"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "aws-config",
  "aws-sdk-secretsmanager",
@@ -10332,7 +10332,7 @@ dependencies = [
  "tokio",
  "tracing",
  "vaultrs",
- "vta-sdk 0.15.0",
+ "vta-sdk 0.16.0",
  "vti-common",
 ]
 

--- a/cnm-cli/Cargo.toml
+++ b/cnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cnm-cli"
 description = "CLI Tool for Verified Trust Agents operating in Verified Trust Communities"
-version = "0.10.2"
+version = "0.10.3"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -21,7 +21,7 @@ config-session = ["vta-sdk/config-session"]
 azure-secrets = ["vta-sdk/azure-secrets"]
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.15", features = ["session", "crypto-provider"] }
+vta-sdk = { path = "../vta-sdk", version = "0.16", features = ["session", "crypto-provider"] }
 vta-cli-common = { path = "../vta-cli-common", version = "0.9" }
 affinidi-did-resolver-cache-sdk = { workspace = true }
 clap = { workspace = true, features = ["env"] }

--- a/didcomm-test/Cargo.toml
+++ b/didcomm-test/Cargo.toml
@@ -2,7 +2,7 @@
 name = "didcomm-test"
 description = "Standalone DIDComm connectivity test — mimics VTA TEE key + messaging flow"
 readme = "README.md"
-version = "0.6.5"
+version = "0.6.6"
 edition.workspace = true
 publish = false
 rust-version.workspace = true
@@ -13,7 +13,7 @@ name = "didcomm-test"
 path = "src/main.rs"
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.15", features = ["didcomm", "crypto-provider"] }
+vta-sdk = { path = "../vta-sdk", version = "0.16", features = ["didcomm", "crypto-provider"] }
 affinidi-tdk = { workspace = true }
 affinidi-did-resolver-cache-sdk = { workspace = true }
 tokio = { workspace = true }

--- a/pnm-cli/Cargo.toml
+++ b/pnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pnm-cli"
 description = "CLI Tool for managing a personal Verifiable Trust Agent"
-version = "0.9.5"
+version = "0.9.6"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -21,7 +21,7 @@ config-session = ["vta-sdk/config-session"]
 azure-secrets = ["vta-sdk/azure-secrets"]
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.15", features = ["session", "sealed-transfer", "attest-verify", "provision-integration", "crypto-provider"] }
+vta-sdk = { path = "../vta-sdk", version = "0.16", features = ["session", "sealed-transfer", "attest-verify", "provision-integration", "crypto-provider"] }
 affinidi-crypto = { workspace = true }
 base64 = { workspace = true }
 reqwest = { workspace = true }

--- a/vta-cli-common/Cargo.toml
+++ b/vta-cli-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-cli-common"
 description = "Shared CLI command handlers and rendering helpers for VTA CLIs"
 readme = "README.md"
-version = "0.9.5"
+version = "0.9.6"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -11,7 +11,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.15", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.16", features = [
   "client",
   "sealed-transfer",
   "provision-integration",

--- a/vta-mcp/Cargo.toml
+++ b/vta-mcp/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-mcp"
 description = "Model Context Protocol (MCP) server exposing a VTA's agent capabilities as tools"
-version = "0.1.2"
+version = "0.1.3"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -10,7 +10,7 @@ repository.workspace = true
 publish = false
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.15", features = ["client", "session", "sealed-transfer", "didcomm", "vp", "crypto-provider"] }
+vta-sdk = { path = "../vta-sdk", version = "0.16", features = ["client", "session", "sealed-transfer", "didcomm", "vp", "crypto-provider"] }
 rmcp = { version = "1.7", features = ["server", "transport-io", "macros", "schemars"] }
 schemars = "1"
 tokio = { workspace = true }

--- a/vta-mobile-core/Cargo.toml
+++ b/vta-mobile-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vta-mobile-core"
-version = "0.6.5"
+version = "0.6.6"
 description = "UniFFI engine for the VTA mobile agent (Android/iOS): DIDComm, Trust Tasks, AAL step-up."
 edition.workspace = true
 # Not a crates.io library — the published artifacts are the Android AAR
@@ -61,7 +61,7 @@ affinidi-messaging-didcomm = "0.15"
 # `vta-sdk::DIDCommSession` (connect + receive_next) so the mobile approver can
 # pull VTA-pushed step-up approve-requests off the mediator — reusing the SDK
 # the VTA uses rather than reimplementing the affinidi mediator protocol.
-vta-sdk = { path = "../vta-sdk", version = "0.15", features = ["session"] }
+vta-sdk = { path = "../vta-sdk", version = "0.16", features = ["session"] }
 # iOS has no native trust store that `rustls-native-certs` can read, so the
 # mediator WebSocket (tokio-tungstenite, via affinidi-messaging-sdk) fails with
 # "no native root CA certificates found". Declaring tokio-tungstenite here with

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.15.0"
+version = "0.16.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.9.8"
+version = "0.9.9"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -85,7 +85,7 @@ vti-common = { path = "../vti-common", version = "0.10", features = ["encryption
 # from this crate into a shared crate so external integrations can reuse them).
 # Per-backend features are activated by this crate's matching features below.
 vti-secrets = { path = "../vti-secrets", version = "0.1" }
-vta-sdk = { path = "../vta-sdk", version = "0.15", features = ["didcomm", "sealed-transfer", "provision-integration", "openapi", "crypto-provider"] }
+vta-sdk = { path = "../vta-sdk", version = "0.16", features = ["didcomm", "sealed-transfer", "provision-integration", "openapi", "crypto-provider"] }
 # DID-VM-resolved WebAuthn assertion verifier — drives the new
 # `vta/auth/passkey-login-{start,finish}/1.0` trust-task handlers.
 # Distinct from `webauthn-rs` (which drives the passkey *enrolment*
@@ -241,7 +241,7 @@ vta-service = { path = ".", features = ["test-support"] }
 # `provision_admin_rotated_via_rest` + DI-signed REST auth) the `MockVta`
 # bootstrap→provision e2e tests drive (issues #406, DI-auth follow-up). Kept out
 # of the production `vta-sdk` dep above so the server build stays lean.
-vta-sdk = { path = "../vta-sdk", version = "0.15", features = ["provision-client"] }
+vta-sdk = { path = "../vta-sdk", version = "0.16", features = ["provision-client"] }
 # Mock HTTP server for the did-hosting-daemon REST auth flow tests. Each
 # test spins up a real local server bound to a random port, validates
 # the JWS-signed request bodies the daemon would see, and serves

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.9.6"
+version = "0.9.7"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -97,7 +97,7 @@ vti-common = { path = "../vti-common", version = "0.10", features = [
 # factory + `*SecretStore` names are a thin facade over these). Per-backend
 # features are activated by this crate's matching features above.
 vti-secrets = { path = "../vti-secrets", version = "0.1" }
-vta-sdk = { path = "../vta-sdk", version = "0.15", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.16", features = [
   "didcomm",
   "session",
   "config-session",

--- a/vti-common/Cargo.toml
+++ b/vti-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-common"
 description = "Shared server-side infrastructure for VTA and VTC services"
 readme = "README.md"
-version = "0.10.6"
+version = "0.10.7"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -48,7 +48,7 @@ openapi = ["dep:utoipa", "dep:utoipa-axum"]
 # `default-features = false` skips the optional client transports
 # (didcomm, sealed-transfer, etc.); we only consume the type
 # definitions in the default feature set.
-vta-sdk = { path = "../vta-sdk", version = "0.15", default-features = false }
+vta-sdk = { path = "../vta-sdk", version = "0.16", default-features = false }
 async-trait = "0.1"
 axum = { workspace = true }
 axum-extra = { workspace = true }

--- a/vti-secrets/Cargo.toml
+++ b/vti-secrets/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-secrets"
 description = "Pluggable secret-store backends + integration onboarding flow for Verifiable Trust Infrastructure"
 readme = "README.md"
-version = "0.1.2"
+version = "0.1.3"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -54,7 +54,7 @@ tracing = { workspace = true }
 tokio = { workspace = true }
 
 # Onboarding feature: the SDK session/auth state machine + local did:key mint.
-vta-sdk = { path = "../vta-sdk", version = "0.15", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.16", features = [
   "session",
 ], optional = true }
 ed25519-dalek = { workspace = true, optional = true }


### PR DESCRIPTION
## Summary

Version-bump release commit for #520 (the spec-0.2 lowerCamelCase emit-side migration), which landed source changes without the per-PR version bumps this workspace requires. Mirrors the #519 pattern for #518.

`vta-sdk` gained a **breaking** public API change in #520 (`provision_integration_didcomm` now takes a `spec_version` arg; new `ProvisionSpecVersion` + `request_body_for_version` / `response_body_for_version`), so it takes a **minor** bump (0.15 → 0.16). Every workspace member pinning `vta-sdk = "0.15"` must move its requirement to `"0.16"` (and take its own patch bump) or a `--workspace` build is unsatisfiable.

## Bumps

| Crate | From → To | Reason |
|---|---|---|
| vta-sdk | 0.15.0 → **0.16.0** | breaking public API (#520) |
| vta-service | 0.9.8 → **0.9.9** | source changes (#520) + pin bump |
| vti-common | 0.10.6 → **0.10.7** | vta-sdk pin cascade |
| vta-cli-common | 0.9.5 → **0.9.6** | vta-sdk pin cascade |
| pnm-cli | 0.9.5 → **0.9.6** | vta-sdk pin cascade |
| cnm-cli | 0.10.2 → **0.10.3** | vta-sdk pin cascade |
| vtc-service | 0.9.6 → **0.9.7** | vta-sdk pin cascade |
| vti-secrets | 0.1.2 → **0.1.3** | vta-sdk pin cascade |
| vta-mcp | 0.1.2 → **0.1.3** | vta-sdk pin cascade (`publish = false`) |
| vta-mobile-core | 0.6.5 → **0.6.6** | vta-sdk pin cascade (`publish = false`) |
| didcomm-test | 0.6.5 → **0.6.6** | vta-sdk pin cascade (`publish = false`) |

**Unchanged:** `vta-enclave` (pins `vta-service = "0.9"` / `vti-common = "0.10"`, both still within minor; no direct `vta-sdk` requirement), `fuzz`, `vti-webauthn`.

## Publish set

The published (non-`publish = false`) crates that get republished from this: **vta-sdk, vta-service, vti-common, vta-cli-common, pnm-cli, cnm-cli, vtc-service, vti-secrets**.

## Validation
- `cargo metadata` resolves the full member graph.
- The `vta-service` chain (→ vta-sdk 0.16.0, vti-common 0.10.7, vti-secrets 0.1.3, vta-cli-common 0.9.6, vta-service 0.9.9) builds clean with `--features webvh,didcomm`.
- `Cargo.lock` updated to match.