### PR TITLE
feat: automatic VTC join via Verifiable Invitation Credential (VIC)

### DIFF
--- a/docs/05-design-notes/examples/join.rego
+++ b/docs/05-design-notes/examples/join.rego
@@ -53,6 +53,7 @@ endorsement_count := count([c |
 
 has_valid_invitation if {
 	input.evidence.invitation.verified
+	input.evidence.invitation.issuer_trusted
 	not input.evidence.invitation.consumed
 }
 

--- a/tasks/vic-join-demo-plan.md
+++ b/tasks/vic-join-demo-plan.md
@@ -1,0 +1,172 @@
+# Demo plan: automatic VTC join via Verifiable Invitation Credential (VIC)
+
+## Demo narrative
+
+An applicant runs **OpenVTC** (`~/devel/openvtc`), holding a **VIC**. They present it
+inside a Verifiable Presentation **over DIDComm** to the VTC's join endpoint. The VTC
+**verifies the VIC**, checks its **trust policy** ("do I trust this invitation's
+issuer?"), and **auto-admits with no human approval** — issuing the VMC + role VEC back
+to the applicant inline.
+
+Two phases (per decision):
+- **M1 — VTC self-issued VIC.** Issuer DID == the community's own DID → trivially trusted.
+- **M2 — 3rd-party issued VIC.** An external issuer mints the VIC; the VTC is configured
+  to trust that issuer DID.
+
+Transport: **DIDComm first** (authcrypt; sender auth intrinsic). REST is a later add.
+
+---
+
+## What already exists (reuse, do not rebuild)
+
+**VTC (`vtc-service`)**
+- VIC *issuance* fully built — `credentials/invitation.rs` (`issue_invitation`, 7-day
+  default, revocation status-list slot) + `credentials/dtg.rs` (`DTGCredential::new_vic`).
+- Join over DIDComm — `join/orchestrate.rs::submit_inner(..., binding: None, ...)`;
+  authcrypt envelope authenticates the sender.
+- Policy engine — embedded `regorus`, purpose-gated `join.rego` (`policy/`).
+- **Auto-admit already works** — `Verdict::Allow` → `EffectPlan::Admit` issues VMC + role
+  VEC inline (`join/orchestrate.rs::realize_join_verdict`).
+- `Facts.evidence.invitation: Option<Invitation { verified, issuer, issuer_role, scopes,
+  consumed }>` already defined (`ceremony/facts.rs`).
+- Verify-gate already rejects an unverified invitation (`ceremony/verify.rs:115`).
+
+**OpenVTC (`~/devel/openvtc`)**
+- Holds `did:webvh` personas, stores `DTGCredential`s per community
+  (`openvtc-core/src/config/account.rs`).
+- Speaks DIDComm fluently via ATM/authcrypt (`openvtc-core/src/lib.rs::pack_and_send`).
+- 10-step join flow that already submits `JOIN_REQUEST_SUBMIT` over DIDComm
+  (`openvtc/src/state_handler/join_flow.rs`, `openvtc-core/src/join.rs`).
+- Depends on `vta-sdk` 0.12 + `dtg-credentials` + `affinidi-tdk` / `affinidi-data-integrity`.
+
+**dtg-credentials** — `new_vic` constructor (fixes `@context`, `type`, subject shape).
+
+---
+
+## The delta — what's missing
+
+The join path **hardcodes `evidence.invitation: None`** at
+`join/orchestrate.rs:328`. A presented VIC is **never extracted, never verified, never
+consumed**, the shipped `policies/default/join.rego` **doesn't reference invitations**, and
+OpenVTC submits a **stub VP** (`join_flow.rs:658`). So the work is *wiring existing pieces
+together*, not a ground-up build.
+
+### A. VTC-side: verify + consume + trust the VIC (core)
+
+1. **VIC extraction + verification** — new module
+   `vtc-service/src/credentials/invitation_verify.rs`.
+   - Extract the `InvitationCredential` from the submitted VP JSON.
+   - Verify the Data-Integrity proof (`eddsa-jcs-2022`) against the **resolved issuer DID**,
+     mirroring the reference typestate `verify_vta_authorization_credential`
+     (`vta-sdk/src/provision_integration/credential.rs:204`).
+   - Return a **`VerifiedInvitation`** typestate (CLAUDE.md typestate discipline).
+   - Checks: type contains `InvitationCredential`; proof valid; `credentialSubject.id ==
+     applicant_did` (holder binding); `validUntil`/`validFrom` window; revocation
+     status-list bit not set; not already consumed (see A4).
+   - VIC is a **Data-Integrity VC, not SD-JWT** — use `affinidi-data-integrity`, not the
+     `present.rs` SD-JWT path.
+
+2. **Issuer-trust resolution** — decide `Invitation.verified` *and* trust:
+   - **M1**: issuer DID == community DID → trusted.
+   - **M2**: issuer DID ∈ operator-configured trusted-invitation-issuers (see section B).
+   - Surface as `Invitation.issuer_trusted` (new field, mirroring `Credential.issuer_trusted`
+     already in `facts.rs`) so the policy can branch on it.
+
+3. **Populate `Facts.evidence.invitation`** — replace the hardcoded `None` at
+   `join/orchestrate.rs:328` with the `VerifiedInvitation` mapped into the `Invitation`
+   facts struct. This is the single highest-leverage change.
+
+4. **Single-use consumption** — new keyspace `consumed_invitations:<vic-id>`.
+   - Check during verification (A1) → reject if present.
+   - Write on `Verdict::Allow` in `realize_join_verdict` (atomic with the admit effects).
+
+5. **Demo join policy** — ship a `join.rego` that auto-admits on a valid invitation:
+   ```rego
+   has_valid_invitation if {
+       input.evidence.invitation.verified
+       input.evidence.invitation.issuer_trusted
+       not input.evidence.invitation.consumed
+   }
+   decision := {"effect": "allow", "with": {"role": "member"}} if { has_valid_invitation }
+   ```
+   The example already exists in `docs/05-design-notes/examples/join.rego`; promote it into a
+   loadable policy (and optionally make it the demo default).
+
+6. *(Optional)* **Manifest advertises invitation acceptance** — extend
+   `routes/join_requests/manifest.rs` so an applicant tool can discover "this community
+   auto-admits on a valid VIC."
+
+### B. Trusted-issuer config — the "policy/config the VTC trusts" bullet
+
+- **M1**: no config needed — community self-trust is implicit (issuer == community DID).
+- **M2**: operator-managed **trusted-invitation-issuers** store + `cnm` CLI command
+  (e.g. `cnm policies trusted-issuers add --did <issuer-did> --kind invitation`).
+  Surfaced into Facts as `issuer_trusted` (A2). Prefer reusing the existing trust-registry /
+  TRQP recognition path (`vtc-service/src/credentials/recognition.rs`) over a brand-new
+  allowlist, if it fits — otherwise a small fjall-backed allowlist keyspace.
+
+### C-pre. Where the VIC lives: the VTA credential vault
+
+The VTA already has a purpose-built **credential vault** (`vta-service/src/vault/`)
+designed to hold "credentials a holder holds (invitations, memberships, roles,
+endorsements …)" with a first-class `CredentialPurpose::Invite` (`vault/model.rs:98`),
+indexing by `{type, community_did, issuer_did, purpose, status}`, encryption-at-rest,
+and `storage`/`receive`/`query`/`present`/`mint` layers already implemented.
+
+- **Holder/recipient copy → VTA vault.** This is the architectural home for the
+  applicant's received VIC. OpenVTC should store-on-receipt and load-at-join from
+  the VTA vault rather than only its local `config.account.credentials` map.
+- **Caveat:** the vault is a *library data plane* today — there are **no vault
+  HTTP/DIDComm routes and no vta-sdk client method** yet. Driving it over the wire
+  needs a thin route + SDK method (new task #8). For a first demo, OpenVTC can use
+  its local credential map and we wire the VTA vault as the immediate follow-up —
+  same join flow either way.
+- **Issuer copy is NOT the vault's job** (the vault holds *held* creds). Issuer
+  bookkeeping stays at the issuer: for M1 that's the VTC's revocation status-list
+  slot + the new consumption store; a 3rd-party VTA issuer (M2) keeps its own
+  issuance log via the `mint` layer.
+
+### C. OpenVTC applicant-side: present a real VP with the VIC
+
+1. **VP builder** — new `openvtc-core/src/presentation.rs`: build a signed
+   `VerifiablePresentation` embedding the held VIC, signed by the persona key
+   (`affinidi-tdk` / `affinidi-data-integrity`).
+2. **Wire into join** — replace the stub VP at `openvtc/src/state_handler/join_flow.rs:658`
+   with a call to the builder.
+3. **Import a VIC** — a way to load a VIC into OpenVTC's per-community credential store
+   for the demo (CLI/TUI import command), since OpenVTC doesn't receive VICs yet.
+
+### D. VIC issuance + delivery for the demo
+
+- **M1**: `cnm` command to issue a VIC for an applicant DID and deliver it (sealed bundle or
+  file) → applicant imports into OpenVTC (C3). VIC issuance already exists; this adds the
+  operator-facing surface + delivery.
+- **M2**: a 3rd-party issuer mints the VIC. Cheapest demo path: a small standalone issuer
+  using `dtg-credentials::new_vic` with its own Ed25519 key (or a second VTC instance).
+  Register that issuer DID as trusted via B.
+
+### E. Glue, tests, demo runbook
+
+- E2E integration test: issue VIC → present over DIDComm → auto-admit (VMC+VEC returned) →
+  **re-use rejected** (consumption) → **untrusted issuer rejected** (M2).
+- Demo runbook: spin VTC, issue VIC, run OpenVTC, join, show admitted membership.
+
+---
+
+## Milestones
+
+- **M1 (self-issued, DIDComm, demoable):** A1–A5, C1–C3, D(M1), E. Smallest path to a
+  working "present VIC → auto-join" demo.
+- **M2 (3rd-party trusted issuer):** B(M2), A2 trust branch, D(M2), plus the untrusted-issuer
+  test. Adds the full "and/or 3rd party" story.
+- **Optional polish:** A6 (manifest discovery), REST transport parity.
+
+## Key design decisions (recommended defaults)
+
+- VIC verification uses **Data-Integrity (`eddsa-jcs-2022`)**, typestate `VerifiedInvitation`,
+  modeled on `verify_vta_authorization_credential`.
+- **Holder binding** enforced: `VIC.credentialSubject.id == applicant_did`.
+- **Single-use** via `consumed_invitations:<vic-id>` keyspace, written atomically on admit.
+- **Revocation** honored by checking the VIC's status-list bit at verify time.
+- Trust is **policy-driven** (Rego), fed by an `issuer_trusted` fact — no hardcoded issuer
+  list in service code.

--- a/tasks/vic-join-demo-runbook.md
+++ b/tasks/vic-join-demo-runbook.md
@@ -102,12 +102,20 @@ OpenVTC (`vic-join` worktree):
 - `--invitation <file>` CLI arg → threaded into the join flow, replacing the VP
   stub; entry-page indicator + submit-time progress message.
 
+## VTA credential vault (the VIC can live in the VTA)
+
+The holder's VIC can be stored in and retrieved from the VTA credential vault via
+a Trust-Task slice (`vault/credentials/{receive,query,get}/0.1`):
+- `vta-service/src/trust_tasks/cred_vault.rs` — receive (verify + store, resolving
+  the issuer key), query (DCQL-shaped, no-enumeration), get (full body).
+- `vta-sdk` client: `cred_vault_receive` / `cred_vault_query` / `cred_vault_get`.
+- A stored VIC is findable by `purpose = invite` (inferred from its type).
+
+OpenVTC could store a received VIC here and load it at join time instead of the
+`--invitation <file>` path (a follow-up wiring on the OpenVTC side).
+
 ## Not done (deliberately deferred)
 
-- **#8 VTA credential-vault route + SDK** — so the holder's VIC lives in the VTA
-  vault (`vta-service/src/vault/`, `CredentialPurpose::Invite`) instead of a file.
-  The vault data plane exists; only the route + `vta-sdk` method are missing.
-  Optional for this demo (the `--invitation` file path covers it).
 - **M2 third-party trusted issuer** — the trust-resolution layer is already
   wired (`invitation_issuer_trusted` consults the registry); M2 just needs the
   operator-facing trusted-invitation-issuer config surfaced.

--- a/tasks/vic-join-demo-runbook.md
+++ b/tasks/vic-join-demo-runbook.md
@@ -114,9 +114,28 @@ a Trust-Task slice (`vault/credentials/{receive,query,get}/0.1`):
 OpenVTC could store a received VIC here and load it at join time instead of the
 `--invitation <file>` path (a follow-up wiring on the OpenVTC side).
 
+## Third-party issuers (M2) — "and/or a 3rd party"
+
+A VIC issued by a **third party** (not the VTC itself) auto-admits when the
+community **trusts that issuer**. Trust is resolved per-verify by
+`invitation_issuer_trusted`:
+- issuer == the community's own DID → trusted (M1, self-issued); else
+- `registry.recognise(issuer)` → trusted iff the issuer is in the community's
+  **trust registry / recognition graph** (M2).
+
+So the operator path for M2 is the *existing* recognition mechanism: add the
+third-party issuer's DID to the community's trust registry (the same surface used
+for cross-community credential trust). No bespoke trusted-invitation-issuer
+config — the recognition graph *is* the config. Proven by
+`invitation_verify::tests::third_party_issuer_trusted_via_registry`.
+
+Demo variant: issue the VIC from a standalone issuer (its own `did:key` +
+`dtg-credentials::new_vic`), register that issuer DID as recognised, then join —
+the applicant is auto-admitted exactly as in the self-issued flow.
+
 ## Not done (deliberately deferred)
 
-- **M2 third-party trusted issuer** — the trust-resolution layer is already
-  wired (`invitation_issuer_trusted` consults the registry); M2 just needs the
-  operator-facing trusted-invitation-issuer config surfaced.
-- Pre-binding a *mint-fresh* persona to the VIC subject (see §0).
+- Pre-binding a *mint-fresh* persona to the VIC subject (see §0) — for now use
+  the reuse-persona path so the presented DID matches the VIC subject.
+- Wiring OpenVTC to load the VIC from the VTA credential vault (above) instead of
+  the `--invitation <file>` path.

--- a/tasks/vic-join-demo-runbook.md
+++ b/tasks/vic-join-demo-runbook.md
@@ -1,0 +1,114 @@
+# Demo runbook — automatic VTC join via Verifiable Invitation Credential (VIC)
+
+What this demonstrates: a community issues an **invitation** to a prospective
+member; the applicant presents it when joining and is **auto-admitted with no
+manual approval**.
+
+Two repos / two worktrees:
+- **VTC** (community + admin UI): `verifiable-trust-infrastructure` worktree
+  `vtc-vic-join` (branch `worktree-vtc-vic-join`).
+- **OpenVTC** (applicant tool): `openvtc` worktree
+  `.claude/worktrees/vic-join` (branch `vic-join`).
+
+---
+
+## 0. One important binding caveat (read first)
+
+A VIC is **holder-bound**: its `credentialSubject.id` must equal the DID the
+applicant presents at join time. OpenVTC's join flow mints a *fresh* `did:webvh`
+persona by default, whose DID can't be known in advance — so a VIC pre-issued to
+it won't match.
+
+**For the demo, present a DID you already know:**
+- Use OpenVTC's **"reuse existing persona"** path so the persona DID is fixed and
+  known before you issue the VIC, **or**
+- Issue the VIC to a `did:key` the applicant controls and presents.
+
+(Improvement for later: let the applicant tell OpenVTC "join as <DID>" / use the
+VIC subject as the persona to present, so mint-fresh can be pre-bound. Tracked as
+follow-up.)
+
+---
+
+## 1. Start the VTC (community)
+
+```bash
+cd <vtc-vic-join worktree>
+cargo run -p vtc-service    # first run: `vtc setup` to mint the community + admin
+```
+
+The default `join.rego` already auto-admits on a valid, trusted, unconsumed
+invitation (`vtc-service/policies/default/join.rego`) — no policy upload needed.
+
+## 2. Get the applicant's persona DID
+
+In OpenVTC, create (or pick) the persona the applicant will present, and note its
+DID (the reuse path shows existing persona DIDs).
+
+## 3. Operator issues the VIC
+
+**Admin UI:** open the admin console → **Invitations** → enter the applicant's
+DID → **Issue invitation** → **Copy** or **Download .json** (QR shown when the
+credential is small enough to scan). Save it as `vic.json`.
+
+**Or via REST:**
+```bash
+curl -sS -X POST https://<vtc>/v1/invitations \
+  -H "Authorization: Bearer <admin-token>" \
+  -H "Trust-Task: https://trusttasks.org/openvtc/vtc/invitations/issue/1.0" \
+  -H "Content-Type: application/json" \
+  -d '{"subjectDid":"<applicant-did>","validityDays":7}' \
+  | jq .vic > vic.json
+```
+
+Hand `vic.json` to the applicant out-of-band.
+
+## 4. Applicant joins, presenting the VIC
+
+```bash
+cd <openvtc vic-join worktree>
+cargo run -p openvtc -- --invitation /path/to/vic.json
+```
+
+In the TUI: start **Join a community**. The entry page shows
+**"✓ Invitation credential loaded — it will be presented to the community."**
+Enter the VTC's DID and choose **reuse** the persona the VIC was issued to.
+
+The join submits over DIDComm with the VIC embedded in the VP. The VTC verifies
+it (issuer signature, holder-binding, validity, revocation, issuer trust) and the
+default policy **auto-admits** — the VMC + role VEC are issued and delivered back.
+
+## 5. Confirm
+
+- OpenVTC: the join completes as **approved/active** (not pending review).
+- Admin UI → **Members**: the new member shows the **invitation badge**
+  (ticket icon). Re-presenting the same VIC is refused (single-use ledger).
+
+---
+
+## What's wired (this work)
+
+VTC (`vtc-vic-join` worktree):
+- VIC verification at join (`credentials/invitation_verify.rs`), threaded into
+  the join decision (`join/orchestrate.rs`), single-use `consumed_invitations`
+  ledger, `Invitation.issuer_trusted` fact.
+- Default `join.rego` auto-admit branch.
+- `POST /v1/invitations` issuance route + admin-UI **Invitations** plugin
+  (issue → copy/download/QR) + member "joined via invitation" badge.
+- Tests: 9 verify unit + 3 policy + 2 E2E + 3 route — all green.
+
+OpenVTC (`vic-join` worktree):
+- `openvtc_core::join::build_join_vp` (embeds the VIC) + 2 unit tests.
+- `--invitation <file>` CLI arg → threaded into the join flow, replacing the VP
+  stub; entry-page indicator + submit-time progress message.
+
+## Not done (deliberately deferred)
+
+- **#8 VTA credential-vault route + SDK** — so the holder's VIC lives in the VTA
+  vault (`vta-service/src/vault/`, `CredentialPurpose::Invite`) instead of a file.
+  The vault data plane exists; only the route + `vta-sdk` method are missing.
+  Optional for this demo (the `--invitation` file path covers it).
+- **M2 third-party trusted issuer** — the trust-resolution layer is already
+  wired (`invitation_issuer_trusted` consults the registry); M2 just needs the
+  operator-facing trusted-invitation-issuer config surfaced.
+- Pre-binding a *mint-fresh* persona to the VIC subject (see §0).

--- a/vta-sdk/src/client/vault.rs
+++ b/vta-sdk/src/client/vault.rs
@@ -124,4 +124,58 @@ impl VtaClient {
         )
         .await
     }
+
+    // ── Credential vault (the holder's held W3C credentials) ──────────────
+    //
+    // Distinct from the password-manager vault methods above: these drive the
+    // `vault/credentials/*` slice that stores + retrieves credentials a holder
+    // *holds* (invitations, memberships, …). A credential body is a presentable
+    // VC, not a raw secret, so these carry plain JSON — no sealed envelope.
+
+    /// `vault/credentials/receive/0.1` — verify + store a received credential
+    /// (e.g. an invitation). Requires `VaultWrite`. `credential` is the VC JSON;
+    /// `id` overrides the storage id (defaults to the VC's `id`). Returns the
+    /// stored credential's descriptor (`{ id, types, purpose, status }`).
+    pub async fn cred_vault_receive(
+        &self,
+        credential: Value,
+        id: Option<&str>,
+    ) -> Result<Value, VtaError> {
+        let mut payload = json!({ "credential": credential });
+        if let Some(id) = id
+            && let Some(obj) = payload.as_object_mut()
+        {
+            obj.insert("id".to_string(), json!(id));
+        }
+        self.dispatch_trust_task(
+            trust_tasks::TASK_VAULT_CREDENTIALS_RECEIVE_0_1,
+            payload,
+            VAULT_TT_TIMEOUT,
+        )
+        .await
+    }
+
+    /// `vault/credentials/query/0.1` — filtered search over held credentials.
+    /// Requires `VaultRead`. `filter` is a DCQL-shaped object (at least one of
+    /// `type`, `communityDid`, `issuerDid`, `purpose`, `status`); an unfiltered
+    /// query is refused. Returns `{ credentials: [descriptor] }`.
+    pub async fn cred_vault_query(&self, filter: Value) -> Result<Value, VtaError> {
+        self.dispatch_trust_task(
+            trust_tasks::TASK_VAULT_CREDENTIALS_QUERY_0_1,
+            filter,
+            VAULT_TT_TIMEOUT,
+        )
+        .await
+    }
+
+    /// `vault/credentials/get/0.1` — fetch one held credential's full body by
+    /// id, for presentation. Requires `VaultRead`. Returns `{ credential }`.
+    pub async fn cred_vault_get(&self, id: &str) -> Result<Value, VtaError> {
+        self.dispatch_trust_task(
+            trust_tasks::TASK_VAULT_CREDENTIALS_GET_0_1,
+            json!({ "id": id }),
+            VAULT_TT_TIMEOUT,
+        )
+        .await
+    }
 }

--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -439,6 +439,29 @@ pub const TASK_VAULT_SIGN_TRUST_TASK_0_1: &str =
 pub const TASK_VAULT_SIGN_TRUST_TASK_0_2: &str =
     "https://trusttasks.org/spec/vault/sign-trust-task/0.2";
 
+// ─── Credential-vault slice (spec/vault/credentials/*) ───────────────────
+//
+// The VTA's *credential* vault — the W3C / SD-JWT-VC credentials a holder
+// holds (invitations, memberships, roles, …), distinct from the
+// password-manager vault above (same keyspace, disjoint `cred:` namespace).
+// Receive verifies + stores; query is a DCQL-shaped filtered search
+// (no-enumeration); get fetches one credential's body for presentation.
+
+/// `spec/vault/credentials/receive/0.1` — verify + store a received credential
+/// (requires `VaultWrite`).
+pub const TASK_VAULT_CREDENTIALS_RECEIVE_0_1: &str =
+    "https://trusttasks.org/spec/vault/credentials/receive/0.1";
+
+/// `spec/vault/credentials/query/0.1` — filtered (DCQL-shaped) search returning
+/// body-free descriptors (requires `VaultRead`).
+pub const TASK_VAULT_CREDENTIALS_QUERY_0_1: &str =
+    "https://trusttasks.org/spec/vault/credentials/query/0.1";
+
+/// `spec/vault/credentials/get/0.1` — fetch one stored credential's full body by
+/// id, for presentation (requires `VaultRead`).
+pub const TASK_VAULT_CREDENTIALS_GET_0_1: &str =
+    "https://trusttasks.org/spec/vault/credentials/get/0.1";
+
 // ─── DID-management slice (spec/did-management/*) ────────────────────────
 //
 // Canonical Trust Tasks for DID + domain + server + registry management

--- a/vta-service/src/trust_tasks/cred_vault.rs
+++ b/vta-service/src/trust_tasks/cred_vault.rs
@@ -1,0 +1,269 @@
+//! Credential-vault trust-task slice — store / query / fetch the W3C credentials
+//! a holder **holds** (invitations, memberships, roles, …) in the VTA's
+//! credential vault (`docs/05-design-notes/vti-credential-architecture.md` §5).
+//!
+//! Distinct from the password-manager vault ([`super::vault`]): both share the
+//! `vault` keyspace but use disjoint key namespaces (`cred:` here, `vault:`
+//! there). The credential body is a presentable VC (not a raw secret like a
+//! password), so it travels as plain JSON — no sealed envelope.
+//!
+//! - **receive** (`VaultWrite`): verify + store a Data-Integrity VC, resolving
+//!   the issuer key from its DID (the wire layer's job — the data plane takes a
+//!   resolved key). `purpose` is inferred from the VC `type` (e.g.
+//!   `InvitationCredential` → invite) so a stored VIC is findable by purpose.
+//! - **query** (`VaultRead`): DCQL-shaped filtered search → body-free
+//!   descriptors. The data plane refuses an unfiltered query (no-enumeration).
+//! - **get** (`VaultRead`): fetch one credential's full body by id, for
+//!   presentation. Not-found is conflated with permission-denied to deny
+//!   enumeration.
+
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use trust_tasks_rs::{RejectReason, TrustTask};
+use uuid::Uuid;
+use vti_common::acl::{Capability, role_has_capability};
+
+use crate::auth::AuthClaims;
+use crate::server::AppState;
+use crate::vault::model::{CredentialPurpose, CredentialStatus};
+use crate::vault::query::{CredentialDescriptor, CredentialQuery, search};
+use crate::vault::{di_verify, receive, storage};
+
+use super::helpers::{
+    TrustTaskOutcome, app_error_to_reject, parse_payload, reject_with, success_response,
+};
+
+/// Capability gate, mirroring [`super::vault::require_capability`] for the
+/// credential-vault surface (kept local so the two vault slices stay
+/// independent).
+fn require_cap(
+    auth: &AuthClaims,
+    doc: &TrustTask<Value>,
+    cap: Capability,
+    action: &str,
+) -> Result<(), TrustTaskOutcome> {
+    if role_has_capability(&auth.role, cap) {
+        Ok(())
+    } else {
+        Err(reject_with(
+            doc,
+            RejectReason::PermissionDenied {
+                reason: format!(
+                    "credential-vault {action} denied: role {} does not carry {cap:?}",
+                    auth.role
+                ),
+            },
+        ))
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ReceiveBody {
+    /// The credential to store — a Data-Integrity W3C VC (object form, with its
+    /// own `proof`).
+    credential: Value,
+    /// Optional explicit storage id; defaults to the VC's top-level `id`, else a
+    /// fresh `urn:uuid`.
+    #[serde(default)]
+    id: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ReceiveResponse {
+    id: String,
+    types: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    purpose: Option<CredentialPurpose>,
+    status: CredentialStatus,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct QueryResponse {
+    credentials: Vec<CredentialDescriptor>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GetBody {
+    id: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct GetResponse {
+    /// The stored credential's full body, for presentation.
+    credential: Value,
+}
+
+/// Handler for `spec/vault/credentials/receive/0.1`.
+pub(super) async fn handle_receive(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    if let Err(r) = require_cap(auth, &doc, Capability::VaultWrite, "receive") {
+        return r;
+    }
+    let req: ReceiveBody = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+
+    let id = resolve_storage_id(req.id, &req.credential);
+
+    // Resolve the issuer's signing key from the credential's DID (did:key
+    // locally, did:webvh / did:web via the cache) — the data plane verifies the
+    // proof against it.
+    let issuer_pub = match di_verify::resolve_di_issuer_key(
+        state.did_resolver.as_ref(),
+        &req.credential,
+    )
+    .await
+    {
+        Ok(k) => k,
+        Err(e) => return app_error_to_reject(&doc, e),
+    };
+
+    let body = match serde_json::to_vec(&req.credential) {
+        Ok(b) => b,
+        Err(e) => {
+            return reject_with(
+                &doc,
+                RejectReason::MalformedRequest {
+                    reason: format!("credential serialise: {e}"),
+                },
+            );
+        }
+    };
+
+    let stored = match receive::receive_di_vc(
+        &state.vault_ks,
+        &id,
+        &body,
+        &issuer_pub,
+        Some("vault/credentials/receive/0.1".to_string()),
+        Utc::now(),
+    )
+    .await
+    {
+        Ok(s) => s,
+        Err(e) => return app_error_to_reject(&doc, e),
+    };
+
+    success_response(
+        &doc,
+        ReceiveResponse {
+            id: stored.id,
+            types: stored.types,
+            purpose: stored.purpose,
+            status: stored.status,
+        },
+    )
+}
+
+/// Handler for `spec/vault/credentials/query/0.1`.
+pub(super) async fn handle_query(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    if let Err(r) = require_cap(auth, &doc, Capability::VaultRead, "query") {
+        return r;
+    }
+    let query: CredentialQuery = match parse_payload(&doc) {
+        Ok(q) => q,
+        Err(resp) => return resp,
+    };
+    match search(&state.vault_ks, &query).await {
+        Ok(credentials) => success_response(&doc, QueryResponse { credentials }),
+        Err(e) => app_error_to_reject(&doc, e),
+    }
+}
+
+/// The storage id for a received credential: an explicit caller-supplied id
+/// wins, else the VC's top-level `id`, else a fresh `urn:uuid`. Kept pure so the
+/// fallback precedence is unit-testable without an `AppState`.
+fn resolve_storage_id(explicit: Option<String>, credential: &Value) -> String {
+    explicit
+        .or_else(|| {
+            credential
+                .get("id")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+        })
+        .unwrap_or_else(|| format!("urn:uuid:{}", Uuid::new_v4()))
+}
+
+/// Handler for `spec/vault/credentials/get/0.1`.
+pub(super) async fn handle_get(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    if let Err(r) = require_cap(auth, &doc, Capability::VaultRead, "get") {
+        return r;
+    }
+    let req: GetBody = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    match storage::get(&state.vault_ks, &req.id).await {
+        Ok(Some(stored)) => match serde_json::from_slice::<Value>(&stored.body) {
+            Ok(credential) => success_response(&doc, GetResponse { credential }),
+            Err(e) => reject_with(
+                &doc,
+                RejectReason::InternalError {
+                    reason: format!("stored credential body is not JSON: {e}"),
+                },
+            ),
+        },
+        // Conflate not-found with permission-denied to deny enumeration.
+        Ok(None) => reject_with(
+            &doc,
+            RejectReason::TaskFailed {
+                reason: "credential not found".to_string(),
+                details: None,
+            },
+        ),
+        Err(e) => app_error_to_reject(&doc, e),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn storage_id_prefers_explicit_then_vc_id_then_uuid() {
+        let vc = json!({ "id": "urn:uuid:from-vc", "type": ["InvitationCredential"] });
+
+        // Explicit id wins.
+        assert_eq!(
+            resolve_storage_id(Some("explicit-id".into()), &vc),
+            "explicit-id"
+        );
+        // Else the VC's own id.
+        assert_eq!(resolve_storage_id(None, &vc), "urn:uuid:from-vc");
+        // Else a generated urn:uuid.
+        let generated = resolve_storage_id(None, &json!({ "type": ["X"] }));
+        assert!(
+            generated.starts_with("urn:uuid:"),
+            "fallback id is a urn:uuid: {generated}"
+        );
+    }
+
+    #[test]
+    fn receive_body_parses_with_and_without_id() {
+        let with_id: ReceiveBody =
+            serde_json::from_value(json!({ "credential": {"id": "x"}, "id": "y" })).unwrap();
+        assert_eq!(with_id.id.as_deref(), Some("y"));
+        let without: ReceiveBody =
+            serde_json::from_value(json!({ "credential": {"id": "x"} })).unwrap();
+        assert_eq!(without.id, None);
+    }
+}

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -50,6 +50,7 @@ mod auth;
 mod backup;
 mod config;
 mod contexts;
+mod cred_vault;
 mod credential_exchange;
 mod device;
 mod did_templates;
@@ -437,6 +438,10 @@ dispatch_table! {
     vta_sdk::trust_tasks::TASK_VAULT_RELEASE_0_1 => vault::handle_release,
     vta_sdk::trust_tasks::TASK_VAULT_PROXY_LOGIN_0_1 => vault::handle_proxy_login,
     vta_sdk::trust_tasks::TASK_VAULT_SIGN_TRUST_TASK_0_1 => vault::handle_sign_trust_task,
+
+    vta_sdk::trust_tasks::TASK_VAULT_CREDENTIALS_RECEIVE_0_1 => cred_vault::handle_receive,
+    vta_sdk::trust_tasks::TASK_VAULT_CREDENTIALS_QUERY_0_1 => cred_vault::handle_query,
+    vta_sdk::trust_tasks::TASK_VAULT_CREDENTIALS_GET_0_1 => cred_vault::handle_get,
     // ─── Config slice ────────────────────────────────────────────
     vta_sdk::trust_tasks::TASK_CONFIG_GET_1_0 => config::handle_get,
     vta_sdk::trust_tasks::TASK_CONFIG_UPDATE_1_0 => config::handle_update,

--- a/vtc-service/admin-ui/package-lock.json
+++ b/vtc-service/admin-ui/package-lock.json
@@ -13,12 +13,14 @@
         "@fontsource/ibm-plex-sans": "^5.2.8",
         "@tanstack/react-query": "^5.62.0",
         "lucide-react": "^0.469.0",
+        "qrcode": "^1.5.4",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-router-dom": "^7.0.0",
         "zustand": "^5.0.0"
       },
       "devDependencies": {
+        "@types/qrcode": "^1.5.5",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "@vitejs/plugin-react": "^6.0.0",
@@ -435,6 +437,26 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/node": {
+      "version": "25.9.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
+      "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/@types/qrcode": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.6.tgz",
+      "integrity": "sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/react": {
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
@@ -481,6 +503,68 @@
         }
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
     "node_modules/cookie": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
@@ -501,6 +585,15 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -510,6 +603,18 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -529,6 +634,19 @@
         }
       }
     },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -542,6 +660,24 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/lightningcss": {
@@ -817,6 +953,18 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/lucide-react": {
       "version": "0.469.0",
       "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.469.0.tgz",
@@ -845,6 +993,51 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -863,6 +1056,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/postcss": {
@@ -892,6 +1094,23 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/react": {
@@ -953,6 +1172,21 @@
         "react-dom": ">=18"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
+    },
     "node_modules/rolldown": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
@@ -993,6 +1227,12 @@
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
+    },
     "node_modules/set-cookie-parser": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
@@ -1007,6 +1247,32 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/tinyglobby": {
@@ -1047,6 +1313,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "8.0.16",
@@ -1124,6 +1397,67 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/zustand": {

--- a/vtc-service/admin-ui/package.json
+++ b/vtc-service/admin-ui/package.json
@@ -16,12 +16,14 @@
     "@fontsource/ibm-plex-sans": "^5.2.8",
     "@tanstack/react-query": "^5.62.0",
     "lucide-react": "^0.469.0",
+    "qrcode": "^1.5.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router-dom": "^7.0.0",
     "zustand": "^5.0.0"
   },
   "devDependencies": {
+    "@types/qrcode": "^1.5.5",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^6.0.0",

--- a/vtc-service/admin-ui/src/lib/api.ts
+++ b/vtc-service/admin-ui/src/lib/api.ts
@@ -232,6 +232,32 @@ export const fetchWhoami = (): Promise<WhoamiResponse> =>
 export const signOut = (): Promise<void> =>
   postJson<void>("/v1/auth/sign-out", undefined, { trustTask: SIGN_OUT_TASK });
 
+// ---------------------------------------------------------------------------
+// Invitations — issue a VIC for a prospective member (operator side of the
+// VIC auto-join ceremony).
+// ---------------------------------------------------------------------------
+
+const ISSUE_INVITATION_TASK =
+  "https://trusttasks.org/openvtc/vtc/invitations/issue/1.0";
+
+export interface IssueInvitationResponse {
+  subjectDid: string;
+  validUntil?: string;
+  /** The signed Invitation Credential — handed to the invitee out-of-band. */
+  vic: unknown;
+}
+
+/** Issue an Invitation Credential bound to `subjectDid`. */
+export const issueInvitation = (
+  subjectDid: string,
+  validityDays?: number,
+): Promise<IssueInvitationResponse> =>
+  postJson<IssueInvitationResponse>(
+    "/v1/invitations",
+    validityDays === undefined ? { subjectDid } : { subjectDid, validityDays },
+    { trustTask: ISSUE_INVITATION_TASK },
+  );
+
 /** Probe: returns the whoami response when signed in, null when not. */
 export async function probeSession(): Promise<WhoamiResponse | null> {
   try {

--- a/vtc-service/admin-ui/src/plugins/index.ts
+++ b/vtc-service/admin-ui/src/plugins/index.ts
@@ -19,6 +19,7 @@ import {
   ShieldCheck,
   Smartphone,
   Tag,
+  Ticket,
   Users,
   Workflow,
 } from "lucide-react";
@@ -28,6 +29,7 @@ import { Acl } from "@/plugins/acl";
 import { Audit } from "@/plugins/audit";
 import { Ceremonies } from "@/plugins/ceremonies";
 import { Dashboard } from "@/plugins/dashboard";
+import { Invitations } from "@/plugins/invitations";
 import { JoinRequests } from "@/plugins/joinRequests";
 import { Members } from "@/plugins/members";
 import { MyPasskeys } from "@/plugins/myPasskeys";
@@ -57,6 +59,14 @@ export function registerBuiltinPlugins(): void {
     path: "/join-requests",
     iconComponent: Inbox,
     reactComponent: JoinRequests,
+  });
+
+  registerPlugin({
+    id: "invitations",
+    label: "Invitations",
+    path: "/invitations",
+    iconComponent: Ticket,
+    reactComponent: Invitations,
   });
 
   registerPlugin({

--- a/vtc-service/admin-ui/src/plugins/invitations.tsx
+++ b/vtc-service/admin-ui/src/plugins/invitations.tsx
@@ -1,0 +1,185 @@
+// Invitations plugin — issue an Invitation Credential (VIC) to a prospective
+// member, then hand it off out-of-band (copy / download / QR).
+//
+// The operator enters an invitee DID (and optional validity); the VTC mints a
+// short-lived, revocable VIC bound to that DID. The invitee presents it back in
+// a join request and is auto-admitted by the default `join.rego` (a verified,
+// trusted, unconsumed invitation → allow). See `routes/invitations.rs`.
+
+import { useEffect, useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { Download, Ticket } from "lucide-react";
+
+import { issueInvitation, type IssueInvitationResponse } from "@/lib/api";
+import { CopyButton } from "@/components/CopyButton";
+import { useToast } from "@/lib/toast";
+
+/// Above this size a QR code becomes unscannable in practice; a full signed VC
+/// usually exceeds it, so we render the QR only when it fits and always offer
+/// copy + download.
+const QR_MAX_CHARS = 1200;
+
+export function Invitations() {
+  const toast = useToast();
+  const [did, setDid] = useState("");
+  const [validityDays, setValidityDays] = useState("");
+
+  const mutation = useMutation<IssueInvitationResponse, Error, void>({
+    mutationFn: () => {
+      const days = validityDays.trim() === "" ? undefined : Number(validityDays);
+      if (days !== undefined && (!Number.isInteger(days) || days < 1)) {
+        return Promise.reject(new Error("Validity must be a whole number of days ≥ 1"));
+      }
+      return issueInvitation(did.trim(), days);
+    },
+    onSuccess: () => toast.push("success", "Invitation issued"),
+    onError: (e) => toast.pushFromError(e),
+  });
+
+  const result = mutation.data;
+  const vicJson = result ? JSON.stringify(result.vic, null, 2) : "";
+
+  return (
+    <div className="page">
+      <header className="page-header">
+        <h2>
+          <Ticket size={20} strokeWidth={1.75} /> Invitations
+        </h2>
+        <p className="muted">
+          Issue a Verifiable Invitation Credential (VIC) for a prospective
+          member. The holder presents it when joining and is auto-admitted — no
+          manual approval needed.
+        </p>
+      </header>
+
+      <section className="card">
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            if (did.trim()) mutation.mutate();
+          }}
+        >
+          <label className="field">
+            <span className="field-label">Invitee DID</span>
+            <input
+              type="text"
+              value={did}
+              onChange={(e) => setDid(e.target.value)}
+              placeholder="did:key:… or did:webvh:…"
+              autoComplete="off"
+              spellCheck={false}
+            />
+          </label>
+          <label className="field">
+            <span className="field-label">Validity (days, optional)</span>
+            <input
+              type="number"
+              min={1}
+              max={90}
+              value={validityDays}
+              onChange={(e) => setValidityDays(e.target.value)}
+              placeholder="7"
+            />
+          </label>
+          <button
+            type="submit"
+            className="btn primary"
+            disabled={!did.trim() || mutation.isPending}
+          >
+            {mutation.isPending ? "Issuing…" : "Issue invitation"}
+          </button>
+        </form>
+      </section>
+
+      {result && (
+        <section className="card">
+          <h3>Invitation for {result.subjectDid}</h3>
+          {result.validUntil && (
+            <p className="muted">
+              Valid until <code>{result.validUntil}</code>
+            </p>
+          )}
+          <div style={{ display: "flex", gap: 8, alignItems: "center", marginBottom: 8 }}>
+            <CopyButton
+              value={vicJson}
+              label="Copy invitation JSON"
+              successMessage="Invitation copied"
+            />
+            <DownloadButton filename={`vic-${shortId(result.subjectDid)}.json`} text={vicJson} />
+          </div>
+          <VicQr text={vicJson} />
+          <textarea
+            readOnly
+            value={vicJson}
+            rows={14}
+            spellCheck={false}
+            style={{ width: "100%", fontFamily: "monospace", fontSize: 12 }}
+          />
+        </section>
+      )}
+    </div>
+  );
+}
+
+function DownloadButton({ filename, text }: { filename: string; text: string }) {
+  const onClick = () => {
+    const blob = new Blob([text], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = filename;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+  return (
+    <button type="button" className="btn" onClick={onClick}>
+      <Download size={16} strokeWidth={1.75} /> Download .json
+    </button>
+  );
+}
+
+/// Renders a QR of the VIC when it's small enough to scan; otherwise explains
+/// that copy/download is the hand-off path. The `qrcode` module is loaded
+/// lazily so it doesn't weigh on the shell bundle.
+function VicQr({ text }: { text: string }) {
+  const [dataUrl, setDataUrl] = useState<string | null>(null);
+  const tooBig = text.length > QR_MAX_CHARS;
+
+  useEffect(() => {
+    let cancelled = false;
+    if (tooBig) {
+      setDataUrl(null);
+      return;
+    }
+    import("qrcode")
+      .then((qr) => qr.toDataURL(text, { margin: 1, width: 240 }))
+      .then((url) => {
+        if (!cancelled) setDataUrl(url);
+      })
+      .catch(() => {
+        if (!cancelled) setDataUrl(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [text, tooBig]);
+
+  if (tooBig) {
+    return (
+      <p className="muted">
+        This invitation is too large for a scannable QR code — use{" "}
+        <strong>Copy</strong> or <strong>Download</strong> to hand it off.
+      </p>
+    );
+  }
+  if (!dataUrl) return null;
+  return (
+    <div style={{ marginBottom: 8 }}>
+      <img src={dataUrl} alt="Invitation QR code" width={240} height={240} />
+    </div>
+  );
+}
+
+function shortId(did: string): string {
+  return did.replace(/[^a-zA-Z0-9]/g, "").slice(-8) || "invite";
+}

--- a/vtc-service/admin-ui/src/plugins/members.tsx
+++ b/vtc-service/admin-ui/src/plugins/members.tsx
@@ -17,6 +17,7 @@ import {
   ArrowRight,
   Check,
   Minus,
+  Ticket,
   Users as UsersIcon,
 } from "lucide-react";
 
@@ -53,6 +54,7 @@ interface MemberRow {
   extensions: unknown;
   personhood: boolean;
   personhoodAssertedAt: string | null;
+  joinedViaInvitation: boolean;
 }
 
 interface MembersPage {
@@ -225,6 +227,15 @@ function MembersList() {
                   <Link to={encodeURIComponent(m.did)}>
                     <code className="truncate">{m.did}</code>
                   </Link>
+                  {m.joinedViaInvitation && (
+                    <Ticket
+                      size={14}
+                      strokeWidth={1.75}
+                      aria-label="Joined via invitation"
+                      className="status-icon ok"
+                      style={{ marginLeft: 6, verticalAlign: "middle" }}
+                    />
+                  )}
                 </td>
                 <td>
                   <code>{m.role}</code>

--- a/vtc-service/policies/default/join.rego
+++ b/vtc-service/policies/default/join.rego
@@ -9,12 +9,14 @@
 # the request as Pending for admin review, `deny` rejects it, and
 # `request_more` defers pending more evidence.
 #
-# Default posture: a submission with a **trusted, valid** credential
-# auto-admits; everything else is referred to the moderator queue for
-# human review (the request lands Pending — the same gate the
-# pre-pipeline `policies.open` default produced). Operators replace this
-# with their own decision policy (e.g. admit on a specific credential
-# type, gate on an invitation, require a code-of-conduct agreement).
+# Default posture: a submission presenting a **valid, trusted, unconsumed
+# invitation** (VIC) auto-admits as a member — the community explicitly
+# invited this DID, so no human review is needed; a submission with a
+# **trusted, valid** credential also auto-admits; everything else is
+# referred to the moderator queue for human review (the request lands
+# Pending — the same gate the pre-pipeline `policies.open` default
+# produced). Operators replace this with their own decision policy (e.g.
+# admit only on an invitation, require a code-of-conduct agreement).
 #
 # The privilege ceiling is host-enforced around this policy: a `join`
 # verdict may never grant `admin`.
@@ -27,14 +29,31 @@ import rego.v1
 # reads the header to render it in plain English, show a decision
 # trace, and open it in the route-card editor. Keep it in step with the
 # body if you hand-edit the Rego.
-# @vtc-rule-ir: eyJwdXJwb3NlIjoiam9pbiIsInJvdXRlcyI6W3sibmFtZSI6IlRydXN0ZWQgY3JlZGVudGlhbCIsIndoZW4iOnsiYWxsIjpbImhvbGRzX2FueV90cnVzdGVkIl19LCJ0aGVuIjp7ImVmZmVjdCI6ImFsbG93Iiwid2l0aCI6eyJyb2xlIjoibWVtYmVyIn19fSx7Im5hbWUiOiJNb2RlcmF0b3IgcmV2aWV3Iiwid2hlbiI6eyJhbGwiOlsiYWx3YXlzIl19LCJ0aGVuIjp7ImVmZmVjdCI6InJlZmVyIiwid2l0aCI6eyJxdWV1ZSI6Im1vZGVyYXRvciJ9fX1dfQ==
+# @vtc-rule-ir: eyJwdXJwb3NlIjoiam9pbiIsInJvdXRlcyI6W3sibmFtZSI6IlZhbGlkIGludml0YXRpb24iLCJ3aGVuIjp7ImFsbCI6WyJoYXNfdmFsaWRfaW52aXRhdGlvbiJdfSwidGhlbiI6eyJlZmZlY3QiOiJhbGxvdyIsIndpdGgiOnsicm9sZSI6Im1lbWJlciJ9fX0seyJuYW1lIjoiVHJ1c3RlZCBjcmVkZW50aWFsIiwid2hlbiI6eyJhbGwiOlsiaG9sZHNfYW55X3RydXN0ZWQiXX0sInRoZW4iOnsiZWZmZWN0IjoiYWxsb3ciLCJ3aXRoIjp7InJvbGUiOiJtZW1iZXIifX19LHsibmFtZSI6Ik1vZGVyYXRvciByZXZpZXciLCJ3aGVuIjp7ImFsbCI6WyJhbHdheXMiXX0sInRoZW4iOnsiZWZmZWN0IjoicmVmZXIiLCJ3aXRoIjp7InF1ZXVlIjoibW9kZXJhdG9yIn19fV19
 
 # structural totality — unmatched submissions go to moderator review
 default decision := {"effect": "refer", "with": {"queue": "moderator"}}
+
+# A valid, trusted, unconsumed invitation (VIC) auto-admits as a member —
+# the community (or a trusted third party) explicitly invited this DID.
+# `verified` / `issuer_trusted` / `consumed` are host-resolved facts:
+# `verified` = signature + holder-binding + validity + revocation all
+# checked; `issuer_trusted` = the issuer is the community itself or a
+# registry-recognised peer; `consumed` = the single-use VIC was already
+# redeemed.
+decision := {"effect": "allow", "with": {"role": "member"}} if {
+	has_valid_invitation
+}
 
 # A presented credential from a trusted issuer auto-admits as a member.
 decision := {"effect": "allow", "with": {"role": "member"}} if {
 	some c in input.evidence.presentation.credentials
 	c.issuer_trusted
 	c.status == "valid"
+}
+
+has_valid_invitation if {
+	input.evidence.invitation.verified
+	input.evidence.invitation.issuer_trusted
+	not input.evidence.invitation.consumed
 }

--- a/vtc-service/src/ceremony/facts.rs
+++ b/vtc-service/src/ceremony/facts.rs
@@ -216,6 +216,15 @@ pub struct Invitation {
     /// delegation.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub issuer_role: Option<String>,
+    /// Host verdict: does the community trust this issuer to issue
+    /// invitations. `true` when the issuer is the community itself
+    /// (self-issued) or a registry-recognised third party. The
+    /// compiled `has_valid_invitation` helper requires this, so a
+    /// genuinely-signed invite from an untrusted issuer is refused.
+    /// `#[serde(default)]` keeps pre-existing facts JSON (no
+    /// `issuer_trusted` key) deserialising as `false`.
+    #[serde(default)]
+    pub issuer_trusted: bool,
     /// Scopes the invitation authorizes (e.g. role bounds,
     /// single-context).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]

--- a/vtc-service/src/ceremony/verify.rs
+++ b/vtc-service/src/ceremony/verify.rs
@@ -240,6 +240,7 @@ mod tests {
             verified: false,
             issuer: "did:webvh:acme.example".into(),
             issuer_role: Some("admin".into()),
+            issuer_trusted: true,
             scopes: vec![],
             consumed: false,
         });

--- a/vtc-service/src/credentials/invitation_verify.rs
+++ b/vtc-service/src/credentials/invitation_verify.rs
@@ -1,0 +1,674 @@
+//! Verify a presented **Invitation Credential** (VIC) at join time — the
+//! verification half of the VIC auto-join ceremony (the issuance half is
+//! [`super::invitation`]).
+//!
+//! [`verify_presented_invitation`] pulls the `InvitationCredential` out of a
+//! submitted VP, cryptographically verifies its issuer Data-Integrity proof
+//! (resolving the issuer DID through the shared [`DidVmResolver`]), and resolves
+//! the host-side facts the join policy decides over:
+//!
+//! - **holder-binding** — the VIC's `credentialSubject.id` must be the
+//!   applicant presenting it (a VIC minted for someone else can't be replayed);
+//! - **temporal validity** — `validFrom <= now < validUntil`;
+//! - **revocation** — the VIC's status-list bit must be clear;
+//! - **issuer trust** — is the issuer the community itself (M1 self-issued) or a
+//!   registry-recognised third party (M2)? Surfaced as `issuer_trusted`.
+//!
+//! It returns a [`VerifiedInvitation`] — the workspace's verified-wire-form
+//! typestate. The only way to obtain one is to pass every check above, so a call
+//! site cannot feed an unverified invitation into the policy. Authenticity
+//! failures (bad proof, wrong subject, expired, revoked) are a hard
+//! [`AppError::Forbidden`] that never reaches policy; **consumption** is left as
+//! a *policy fact* (`Invitation.consumed`) the host attaches separately, so the
+//! single-use rule is the policy's call (`has_valid_invitation` rejects a
+//! consumed invite) rather than a silent abort.
+
+use std::sync::Arc;
+
+use affinidi_data_integrity::{DataIntegrityProof, VerificationMethodResolver, VerifyOptions};
+use affinidi_vc::{SubjectValue, VerifiableCredential};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+use tracing::warn;
+
+use vti_common::error::AppError;
+
+use crate::ceremony::facts::Invitation;
+use crate::credentials::vm_resolver::{DidVmResolver, check_issuer_binding};
+use crate::recognition::{HttpStatusListFetcher, StatusListFetcher};
+use crate::registry::TrustRegistryClient;
+use crate::server::AppState;
+
+/// The VC `type` tag identifying an Invitation Credential, as minted by the DTG
+/// catalog (`dtg::issue_invitation` → `DTGCredential::new_vic`).
+pub const INVITATION_CREDENTIAL_TYPE: &str = "InvitationCredential";
+
+/// A presented invitation that passed cryptographic + binding + validity
+/// verification. Only constructable via [`verify_presented_invitation`] (or its
+/// testable inner), so any code holding one knows the invitation is genuine,
+/// bound to the applicant, in-window, and not revoked.
+///
+/// Whether it has already been **consumed** is deliberately *not* part of this
+/// type — consumption is a join-lifecycle fact the host looks up against the
+/// `consumed_invitations` keyspace and hands to the policy via
+/// [`Self::to_fact`], so the single-use rule stays a policy decision.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerifiedInvitation {
+    /// The VIC's top-level `id` (a `urn:uuid:…`). The consumption key.
+    pub id: String,
+    /// The DID that issued the VIC (`issuer`).
+    pub issuer: String,
+    /// The applicant the VIC is bound to (`credentialSubject.id`), already
+    /// checked to equal the presenter.
+    pub subject: String,
+    /// Host verdict: does the community trust this issuer for invitations.
+    /// `true` when the issuer is the community itself (M1), or a
+    /// registry-recognised third party (M2).
+    pub issuer_trusted: bool,
+    /// Scopes the invitation authorizes (e.g. role bounds), if the VIC carries a
+    /// `credentialSubject.scopes` array. Empty otherwise.
+    pub scopes: Vec<String>,
+    /// The VIC's `validUntil`, surfaced for the policy / audit.
+    pub valid_until: DateTime<Utc>,
+}
+
+impl VerifiedInvitation {
+    /// Project into the policy-facing [`Invitation`] fact. `consumed` is the
+    /// host's single-use lookup against the `consumed_invitations` keyspace —
+    /// `verified` is always `true` here because the value only exists once
+    /// verification passed.
+    pub fn to_fact(&self, consumed: bool) -> Invitation {
+        Invitation {
+            verified: true,
+            issuer: self.issuer.clone(),
+            issuer_role: None,
+            issuer_trusted: self.issuer_trusted,
+            scopes: self.scopes.clone(),
+            consumed,
+        }
+    }
+}
+
+/// A consumed-invitation record (single-use enforcement). Stored in the
+/// `consumed_invitations` keyspace keyed by the VIC `id`; written when a join
+/// admit succeeds, read at verify time to set `Invitation.consumed`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConsumedInvitation {
+    /// The applicant that redeemed the invitation.
+    pub applicant: String,
+    /// When it was consumed.
+    pub consumed_at: DateTime<Utc>,
+    /// The join request that consumed it (audit trail).
+    pub via_join_request_id: String,
+}
+
+/// Has the invitation `vic_id` already been consumed?
+pub async fn is_consumed(
+    ks: &vti_common::store::KeyspaceHandle,
+    vic_id: &str,
+) -> Result<bool, AppError> {
+    Ok(ks
+        .get::<ConsumedInvitation>(vic_id.as_bytes().to_vec())
+        .await?
+        .is_some())
+}
+
+/// Mark `vic_id` consumed. Uses `insert_if_absent` so a concurrent redeem can't
+/// double-consume — returns `true` if this call recorded the consumption,
+/// `false` if it was already consumed.
+pub async fn mark_consumed(
+    ks: &vti_common::store::KeyspaceHandle,
+    vic_id: &str,
+    record: &ConsumedInvitation,
+) -> Result<bool, AppError> {
+    ks.insert_if_absent(vic_id.as_bytes().to_vec(), record)
+        .await
+}
+
+/// Verify a VIC presented inside `vp`, if one is present.
+///
+/// - `Ok(None)` — the VP carried no `InvitationCredential`; the join proceeds
+///   on its other evidence (no invitation fact).
+/// - `Ok(Some(_))` — a VIC was present and verified (proof + holder-binding +
+///   validity + revocation).
+/// - `Err(Forbidden)` — a VIC was present but failed verification; the join is
+///   refused before policy.
+pub async fn verify_presented_invitation(
+    state: &AppState,
+    applicant_did: &str,
+    vp: &JsonValue,
+) -> Result<Option<VerifiedInvitation>, AppError> {
+    let Some(vic_json) = extract_invitation(vp) else {
+        return Ok(None);
+    };
+
+    let own_did = state.config.read().await.vtc_did.clone();
+    let resolver = DidVmResolver::new(state.did_resolver.clone());
+    // Revocation is checked against the issuer's status list (its own URL): the
+    // same fetcher + SSRF guard + issuer-signature verification the recognition
+    // and credential-exchange paths use.
+    let fetcher = match state.did_resolver.clone() {
+        Some(r) => {
+            let key_resolver: Arc<dyn VerificationMethodResolver> =
+                Arc::new(DidVmResolver::new(Some(r)));
+            HttpStatusListFetcher::with_issuer_verification(key_resolver)
+        }
+        None => HttpStatusListFetcher::new(),
+    };
+
+    let verified = verify_invitation_inner(
+        &vic_json,
+        applicant_did,
+        own_did.as_deref(),
+        state.registry_client.as_deref(),
+        &resolver,
+        &fetcher,
+        Utc::now(),
+    )
+    .await?;
+    Ok(Some(verified))
+}
+
+/// Pull the first `InvitationCredential` out of a VP's `verifiableCredential`
+/// array. Object-form VCs only (a bare JWT string VIC isn't supported on this
+/// raw-VP path — VICs are Data-Integrity VCs).
+fn extract_invitation(vp: &JsonValue) -> Option<JsonValue> {
+    vp.get("verifiableCredential")?
+        .as_array()?
+        .iter()
+        .find(|vc| {
+            vc.get("type")
+                .and_then(JsonValue::as_array)
+                .is_some_and(|types| {
+                    types
+                        .iter()
+                        .any(|t| t.as_str() == Some(INVITATION_CREDENTIAL_TYPE))
+                })
+        })
+        .cloned()
+}
+
+/// The testable core: verify one extracted VIC against injected resolver +
+/// fetcher + trust registry. Split out so unit tests can drive it with stubs and
+/// a pinned `now`, without a running `AppState`.
+#[allow(clippy::too_many_arguments)]
+async fn verify_invitation_inner(
+    vic_json: &JsonValue,
+    applicant_did: &str,
+    own_did: Option<&str>,
+    registry: Option<&dyn TrustRegistryClient>,
+    resolver: &dyn VerificationMethodResolver,
+    fetcher: &dyn StatusListFetcher,
+    now: DateTime<Utc>,
+) -> Result<VerifiedInvitation, AppError> {
+    let vic: VerifiableCredential = serde_json::from_value(vic_json.clone())
+        .map_err(|e| forbidden(format!("invitation is not a Verifiable Credential: {e}")))?;
+
+    // Type guard (defensive — extract_invitation already matched on it).
+    if !vic.types.iter().any(|t| t == INVITATION_CREDENTIAL_TYPE) {
+        return Err(forbidden(
+            "credential is not an InvitationCredential".into(),
+        ));
+    }
+
+    let id = vic_json
+        .get("id")
+        .and_then(JsonValue::as_str)
+        .ok_or_else(|| forbidden("invitation has no top-level `id`".into()))?
+        .to_string();
+    let issuer = vic.issuer.id().to_string();
+    let subject = subject_id(&vic)?;
+
+    // 1. Holder-binding: the presenter must be the DID the VIC was minted for.
+    if subject != applicant_did {
+        return Err(forbidden(format!(
+            "invitation is bound to `{subject}`, not the applicant `{applicant_did}`"
+        )));
+    }
+
+    // 2. Temporal validity (cheap; before any network call).
+    let valid_until = parse_required_time(vic.valid_until.as_deref(), "validUntil")?;
+    if let Some(vf) = vic.valid_from.as_deref() {
+        let valid_from = parse_required_time(Some(vf), "validFrom")?;
+        if valid_from > now {
+            return Err(forbidden(format!(
+                "invitation validFrom {valid_from} is in the future"
+            )));
+        }
+    }
+    if valid_until <= now {
+        return Err(forbidden(format!("invitation expired at {valid_until}")));
+    }
+
+    // 3. Issuer Data-Integrity proof: the verificationMethod must sit under the
+    //    issuer, and the signature must verify against the resolved key.
+    verify_invitation_proof(vic_json, &issuer, resolver).await?;
+
+    // 4. Revocation: a VIC always carries a credentialStatus (issuance burns a
+    //    revocation slot). The bit must be clear; an unresolvable status fails
+    //    closed — we will not auto-admit on an invitation we can't check.
+    check_not_revoked(&vic, &issuer, fetcher).await?;
+
+    // 5. Issuer trust (a policy fact, not an abort): community self-issued (M1)
+    //    or registry-recognised third party (M2).
+    let issuer_trusted = invitation_issuer_trusted(own_did, registry, &issuer).await;
+
+    let scopes = extract_scopes(&vic);
+
+    Ok(VerifiedInvitation {
+        id,
+        issuer,
+        subject,
+        issuer_trusted,
+        scopes,
+        valid_until,
+    })
+}
+
+/// Verify the VIC's issuer Data-Integrity proof — mirrors
+/// `recognition::verify::verify_proof`: parse the proof, bind its
+/// `verificationMethod` to the issuer, then let the library resolve the key +
+/// check the signature over the proof-stripped document.
+async fn verify_invitation_proof(
+    vic_json: &JsonValue,
+    issuer_did: &str,
+    resolver: &dyn VerificationMethodResolver,
+) -> Result<(), AppError> {
+    let proof_value = vic_json
+        .get("proof")
+        .ok_or_else(|| forbidden("invitation has no proof".into()))?;
+    let proof: DataIntegrityProof = serde_json::from_value(proof_value.clone())
+        .map_err(|e| forbidden(format!("invitation proof did not parse: {e}")))?;
+    let vm = proof_value
+        .get("verificationMethod")
+        .and_then(JsonValue::as_str)
+        .ok_or_else(|| forbidden("invitation proof missing verificationMethod".into()))?;
+    check_issuer_binding(vm, issuer_did).map_err(|e| forbidden(e.to_string()))?;
+
+    let mut unsigned = vic_json.clone();
+    unsigned
+        .as_object_mut()
+        .ok_or_else(|| forbidden("invitation is not a JSON object".into()))?
+        .remove("proof");
+
+    proof
+        .verify(&unsigned, resolver, VerifyOptions::new())
+        .await
+        .map_err(|e| forbidden(format!("invitation signature did not verify: {e}")))?;
+    Ok(())
+}
+
+/// Fail-closed revocation check. A missing `credentialStatus` is treated as
+/// "not revocable" (the issuer opted out), matching the recognition path; a
+/// present-but-set or unresolvable status is a hard fail.
+async fn check_not_revoked(
+    vic: &VerifiableCredential,
+    issuer_did: &str,
+    fetcher: &dyn StatusListFetcher,
+) -> Result<(), AppError> {
+    let Some(status) = vic.credential_status.as_ref() else {
+        return Ok(());
+    };
+    let url = status.status_list_credential.as_deref().ok_or_else(|| {
+        forbidden("invitation credentialStatus has no statusListCredential URL".into())
+    })?;
+    let index_str = status
+        .status_list_index
+        .as_deref()
+        .ok_or_else(|| forbidden("invitation credentialStatus has no statusListIndex".into()))?;
+    let index: usize = index_str
+        .parse()
+        .map_err(|e| forbidden(format!("invitation statusListIndex {index_str}: {e}")))?;
+
+    match fetcher.check_status_bit(url, index, Some(issuer_did)).await {
+        Ok(false) => Ok(()),
+        Ok(true) => Err(forbidden("invitation has been revoked".into())),
+        Err(e) => {
+            warn!(url = %url, error = %e, "invitation status list did not resolve — failing closed");
+            Err(forbidden(
+                "invitation revocation status could not be verified".into(),
+            ))
+        }
+    }
+}
+
+/// Whether the community trusts `issuer_did` to issue invitations. The
+/// community's own DID is always trusted (M1 self-issued). Any other issuer is
+/// resolved via TRQP `recognise` (M2 third-party). Fail-soft: a flaky registry
+/// yields `false` (untrusted) + a warning rather than erroring the whole join —
+/// the policy decides over the `false`.
+async fn invitation_issuer_trusted(
+    own_did: Option<&str>,
+    registry: Option<&dyn TrustRegistryClient>,
+    issuer_did: &str,
+) -> bool {
+    if own_did == Some(issuer_did) {
+        return true;
+    }
+    let Some(registry) = registry else {
+        return false;
+    };
+    match registry.recognise(issuer_did).await {
+        Ok(trusted) => trusted,
+        Err(e) => {
+            warn!(
+                issuer = %issuer_did,
+                error = %e,
+                "trust-registry recognise failed for invitation issuer — treating as untrusted"
+            );
+            false
+        }
+    }
+}
+
+/// `credentialSubject.id` of the (first) subject.
+fn subject_id(vic: &VerifiableCredential) -> Result<String, AppError> {
+    let subject_map = match &vic.credential_subject {
+        SubjectValue::Single(m) => m.clone(),
+        SubjectValue::Multiple(v) => v
+            .first()
+            .cloned()
+            .ok_or_else(|| forbidden("invitation credentialSubject is empty".into()))?,
+    };
+    subject_map
+        .get("id")
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+        .ok_or_else(|| forbidden("invitation credentialSubject.id missing".into()))
+}
+
+/// Optional `credentialSubject.scopes` string array (forward-compat; the
+/// catalog VIC subject is `{id}` today, so this is usually empty).
+fn extract_scopes(vic: &VerifiableCredential) -> Vec<String> {
+    let subject_map = match &vic.credential_subject {
+        SubjectValue::Single(m) => m,
+        SubjectValue::Multiple(v) => match v.first() {
+            Some(m) => m,
+            None => return Vec::new(),
+        },
+    };
+    subject_map
+        .get("scopes")
+        .and_then(JsonValue::as_array)
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|s| s.as_str().map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn parse_required_time(raw: Option<&str>, field: &str) -> Result<DateTime<Utc>, AppError> {
+    let raw = raw.ok_or_else(|| forbidden(format!("invitation has no {field}")))?;
+    DateTime::parse_from_rfc3339(raw)
+        .map(|dt| dt.with_timezone(&Utc))
+        .map_err(|e| forbidden(format!("invitation {field} `{raw}`: {e}")))
+}
+
+/// Authenticity failures are `Forbidden` (the evidence didn't check out), never
+/// `Validation` — the request was well-formed, its cryptographic claims false.
+fn forbidden(msg: String) -> AppError {
+    AppError::Forbidden(format!("invitation verification failed: {msg}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::credentials::dtg;
+    use crate::credentials::signer::LocalSigner;
+    use crate::credentials::vmc::CredentialStatusRef;
+    use crate::recognition::{RecognitionError, StatusListFetcher};
+    use async_trait::async_trait;
+    use chrono::Duration;
+    use ed25519_dalek::SigningKey;
+
+    const APPLICANT_SEED: [u8; 32] = [0x11; 32];
+    const ISSUER_SEED: [u8; 32] = [0x22; 32];
+    const OTHER_SEED: [u8; 32] = [0x33; 32];
+
+    /// A `did:key` for a seed (so [`DidVmResolver`] resolves it locally, no I/O).
+    /// Used for subject DIDs that don't sign in these tests.
+    fn did_key(seed: &[u8; 32]) -> String {
+        let sk = SigningKey::from_bytes(seed);
+        affinidi_crypto::did_key::ed25519_pub_to_did_key(&sk.verifying_key().to_bytes())
+    }
+
+    /// A `LocalSigner` whose issuer DID is the `did:key` encoding *its own*
+    /// public key, so the proof's `verificationMethod` resolves (via
+    /// [`DidVmResolver`]) to exactly the signing key — independent of how the
+    /// secret derives its pubkey from the seed.
+    fn signer(seed: &[u8; 32]) -> LocalSigner {
+        let tmp = LocalSigner::from_ed25519_seed("did:key:placeholder".into(), seed);
+        let pub_bytes: [u8; 32] = tmp
+            .public_bytes()
+            .try_into()
+            .expect("ed25519 pub is 32 bytes");
+        let dk = affinidi_crypto::did_key::ed25519_pub_to_did_key(&pub_bytes);
+        LocalSigner::from_ed25519_seed(dk, seed)
+    }
+
+    /// Issue a VIC to `subject`, optionally revocable, valid for `validity`.
+    async fn issue_vic(
+        signer: &LocalSigner,
+        subject: &str,
+        status: Option<&CredentialStatusRef>,
+        validity: Duration,
+    ) -> JsonValue {
+        dtg::issue_invitation(
+            signer,
+            subject,
+            Some(&format!("urn:uuid:{}", uuid::Uuid::new_v4())),
+            status,
+            validity,
+        )
+        .await
+        .expect("issue VIC")
+    }
+
+    struct StubFetcher {
+        revoked: bool,
+    }
+    #[async_trait]
+    impl StatusListFetcher for StubFetcher {
+        async fn check_status_bit(
+            &self,
+            _url: &str,
+            _index: usize,
+            _expected_issuer: Option<&str>,
+        ) -> Result<bool, RecognitionError> {
+            Ok(self.revoked)
+        }
+    }
+
+    /// A fetcher that always errors — exercises the fail-closed path.
+    struct ErrFetcher;
+    #[async_trait]
+    impl StatusListFetcher for ErrFetcher {
+        async fn check_status_bit(
+            &self,
+            _url: &str,
+            _index: usize,
+            _expected_issuer: Option<&str>,
+        ) -> Result<bool, RecognitionError> {
+            Err(RecognitionError::StatusListFailed("boom".into()))
+        }
+    }
+
+    fn resolver() -> DidVmResolver {
+        DidVmResolver::new(None) // did:key resolves locally
+    }
+
+    #[test]
+    fn extract_invitation_finds_the_vic() {
+        let vp = serde_json::json!({
+            "verifiableCredential": [
+                { "type": ["VerifiableCredential", "EmailCredential"] },
+                { "type": ["VerifiableCredential", "InvitationCredential"], "id": "x" },
+            ]
+        });
+        let vic = extract_invitation(&vp).expect("finds the VIC");
+        assert_eq!(vic["id"], "x");
+    }
+
+    #[test]
+    fn extract_invitation_absent_is_none() {
+        let vp = serde_json::json!({
+            "verifiableCredential": [{ "type": ["VerifiableCredential", "EmailCredential"] }]
+        });
+        assert!(extract_invitation(&vp).is_none());
+        assert!(extract_invitation(&serde_json::json!({})).is_none());
+    }
+
+    #[tokio::test]
+    async fn self_issued_vic_verifies_and_is_trusted() {
+        let issuer = signer(&ISSUER_SEED);
+        let applicant = did_key(&APPLICANT_SEED);
+        let vic = issue_vic(&issuer, &applicant, None, Duration::days(7)).await;
+
+        let v = verify_invitation_inner(
+            &vic,
+            &applicant,
+            Some(issuer.issuer_did()), // own_did == issuer → M1 self-trust
+            None,
+            &resolver(),
+            &StubFetcher { revoked: false },
+            Utc::now(),
+        )
+        .await
+        .expect("self-issued VIC verifies");
+
+        assert_eq!(v.issuer, issuer.issuer_did());
+        assert_eq!(v.subject, applicant);
+        assert!(v.issuer_trusted, "community self-issued is trusted");
+        let fact = v.to_fact(false);
+        assert!(fact.verified && fact.issuer_trusted && !fact.consumed);
+    }
+
+    #[tokio::test]
+    async fn third_party_issuer_is_untrusted_without_registry() {
+        // A genuinely-signed VIC from an issuer that is NOT the community and not
+        // registry-recognised verifies cryptographically but is untrusted — the
+        // policy (has_valid_invitation) will refuse it.
+        let issuer = signer(&ISSUER_SEED);
+        let applicant = did_key(&APPLICANT_SEED);
+        let vic = issue_vic(&issuer, &applicant, None, Duration::days(7)).await;
+
+        let v = verify_invitation_inner(
+            &vic,
+            &applicant,
+            Some(&did_key(&OTHER_SEED)), // own_did != issuer
+            None,                        // no registry → untrusted
+            &resolver(),
+            &StubFetcher { revoked: false },
+            Utc::now(),
+        )
+        .await
+        .expect("verifies cryptographically");
+        assert!(
+            !v.issuer_trusted,
+            "3rd-party issuer untrusted without registry"
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_wrong_subject_binding() {
+        let issuer = signer(&ISSUER_SEED);
+        let vic = issue_vic(&issuer, &did_key(&APPLICANT_SEED), None, Duration::days(7)).await;
+        // A different applicant presents a VIC minted for someone else.
+        let err = verify_invitation_inner(
+            &vic,
+            &did_key(&OTHER_SEED),
+            Some(issuer.issuer_did()),
+            None,
+            &resolver(),
+            &StubFetcher { revoked: false },
+            Utc::now(),
+        )
+        .await
+        .expect_err("wrong subject must fail");
+        assert!(matches!(err, AppError::Forbidden(_)), "{err:?}");
+    }
+
+    #[tokio::test]
+    async fn rejects_expired_vic() {
+        let issuer = signer(&ISSUER_SEED);
+        let applicant = did_key(&APPLICANT_SEED);
+        let vic = issue_vic(&issuer, &applicant, None, Duration::days(7)).await;
+        // Evaluate "now" 8 days in the future → expired.
+        let err = verify_invitation_inner(
+            &vic,
+            &applicant,
+            Some(issuer.issuer_did()),
+            None,
+            &resolver(),
+            &StubFetcher { revoked: false },
+            Utc::now() + Duration::days(8),
+        )
+        .await
+        .expect_err("expired VIC must fail");
+        assert!(matches!(err, AppError::Forbidden(_)), "{err:?}");
+    }
+
+    #[tokio::test]
+    async fn rejects_tampered_signature() {
+        let issuer = signer(&ISSUER_SEED);
+        let applicant = did_key(&APPLICANT_SEED);
+        let mut vic = issue_vic(&issuer, &applicant, None, Duration::days(7)).await;
+        // Tamper with a signed field after signing → proof must fail.
+        vic["credentialSubject"]["id"] = serde_json::json!(applicant); // keep subject
+        vic["validUntil"] = serde_json::json!("2099-01-01T00:00:00Z"); // covered by proof
+        let err = verify_invitation_inner(
+            &vic,
+            &applicant,
+            Some(issuer.issuer_did()),
+            None,
+            &resolver(),
+            &StubFetcher { revoked: false },
+            Utc::now(),
+        )
+        .await
+        .expect_err("tampered VIC must fail");
+        assert!(matches!(err, AppError::Forbidden(_)), "{err:?}");
+    }
+
+    #[tokio::test]
+    async fn rejects_revoked_vic() {
+        let issuer = signer(&ISSUER_SEED);
+        let applicant = did_key(&APPLICANT_SEED);
+        let status = CredentialStatusRef::revocation("https://vtc.example/status/revocation", 7);
+        let vic = issue_vic(&issuer, &applicant, Some(&status), Duration::days(7)).await;
+        let err = verify_invitation_inner(
+            &vic,
+            &applicant,
+            Some(issuer.issuer_did()),
+            None,
+            &resolver(),
+            &StubFetcher { revoked: true },
+            Utc::now(),
+        )
+        .await
+        .expect_err("revoked VIC must fail");
+        assert!(matches!(err, AppError::Forbidden(_)), "{err:?}");
+    }
+
+    #[tokio::test]
+    async fn unresolvable_status_fails_closed() {
+        let issuer = signer(&ISSUER_SEED);
+        let applicant = did_key(&APPLICANT_SEED);
+        let status = CredentialStatusRef::revocation("https://vtc.example/status/revocation", 7);
+        let vic = issue_vic(&issuer, &applicant, Some(&status), Duration::days(7)).await;
+        let err = verify_invitation_inner(
+            &vic,
+            &applicant,
+            Some(issuer.issuer_did()),
+            None,
+            &resolver(),
+            &ErrFetcher,
+            Utc::now(),
+        )
+        .await
+        .expect_err("unresolvable status must fail closed");
+        assert!(matches!(err, AppError::Forbidden(_)), "{err:?}");
+    }
+}

--- a/vtc-service/src/credentials/invitation_verify.rs
+++ b/vtc-service/src/credentials/invitation_verify.rs
@@ -572,6 +572,38 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn third_party_issuer_trusted_via_registry() {
+        // M2: a VIC from a third-party issuer the community recognises (in its
+        // trust registry / recognition graph) is trusted — so the default policy
+        // auto-admits exactly as for a self-issued invite.
+        use crate::registry::{MockRegistryClient, TrustRegistryClient};
+
+        let issuer = signer(&ISSUER_SEED);
+        let applicant = did_key(&APPLICANT_SEED);
+        let vic = issue_vic(&issuer, &applicant, None, Duration::days(7)).await;
+
+        let registry = MockRegistryClient::new();
+        registry.set_recognised(issuer.issuer_did()).await;
+        let registry: &dyn TrustRegistryClient = &registry;
+
+        let v = verify_invitation_inner(
+            &vic,
+            &applicant,
+            Some(&did_key(&OTHER_SEED)), // own_did != issuer (a genuine third party)
+            Some(registry),              // …but the registry recognises the issuer
+            &resolver(),
+            &StubFetcher { revoked: false },
+            Utc::now(),
+        )
+        .await
+        .expect("verifies cryptographically");
+        assert!(
+            v.issuer_trusted,
+            "a registry-recognised 3rd-party issuer is trusted (M2)"
+        );
+    }
+
+    #[tokio::test]
     async fn rejects_wrong_subject_binding() {
         let issuer = signer(&ISSUER_SEED);
         let vic = issue_vic(&issuer, &did_key(&APPLICANT_SEED), None, Duration::days(7)).await;

--- a/vtc-service/src/credentials/mod.rs
+++ b/vtc-service/src/credentials/mod.rs
@@ -49,6 +49,7 @@ pub mod delivery;
 pub mod dtg;
 pub mod exchange;
 pub mod invitation;
+pub mod invitation_verify;
 pub mod present_challenge;
 pub mod signer;
 pub mod vec;

--- a/vtc-service/src/join/invitation_e2e_test.rs
+++ b/vtc-service/src/join/invitation_e2e_test.rs
@@ -1,0 +1,186 @@
+//! End-to-end test for VIC-driven auto-join (the demo's VTC behaviour).
+//!
+//! Drives the production [`submit_inner`] spine (the shared REST + DIDComm join
+//! path) with a self-issued Invitation Credential presented inside a VP:
+//!
+//!   issue VIC → present in VP over the DIDComm path → auto-admit (VMC + role
+//!   VEC issued) → invitation burned in the single-use ledger.
+//!
+//! Plus the holder-binding guard: a VIC minted for one DID cannot be redeemed by
+//! another. Crypto edges (expired / revoked / tampered / untrusted issuer) are
+//! covered by the unit tests in `credentials::invitation_verify`.
+
+use std::sync::Arc;
+
+use affinidi_status_list::StatusPurpose;
+use chrono::Duration;
+use ed25519_dalek::SigningKey;
+use serde_json::json;
+
+use crate::acl::get_acl_entry;
+use crate::credentials::dtg;
+use crate::credentials::invitation_verify::is_consumed;
+use crate::credentials::signer::LocalSigner;
+use crate::join::{JoinStatus, JoinTransport, submit_inner};
+use crate::status_list::ensure_initial;
+use crate::test_support::TestVtc;
+
+const ISSUER_SEED: [u8; 32] = [0xA1; 32];
+const APPLICANT_SEED: [u8; 32] = [0xB2; 32];
+const OUTSIDER_SEED: [u8; 32] = [0xC3; 32];
+
+/// A `did:key` for a seed — resolves locally (no network), so the VIC's issuer
+/// proof verifies offline.
+fn did_key(seed: &[u8; 32]) -> String {
+    let sk = SigningKey::from_bytes(seed);
+    affinidi_crypto::did_key::ed25519_pub_to_did_key(&sk.verifying_key().to_bytes())
+}
+
+/// A signer whose issuer DID is the `did:key` of its own public key.
+fn signer(seed: &[u8; 32]) -> LocalSigner {
+    let tmp = LocalSigner::from_ed25519_seed("did:key:placeholder".into(), seed);
+    let pub_bytes: [u8; 32] = tmp.public_bytes().try_into().expect("ed25519 pub 32 bytes");
+    LocalSigner::from_ed25519_seed(
+        affinidi_crypto::did_key::ed25519_pub_to_did_key(&pub_bytes),
+        seed,
+    )
+}
+
+/// Build a TestVtc whose `vtc_did` + credential signer are the same `did:key`,
+/// with audit + both status lists + the default join policy installed — the
+/// boot state the join ceremony needs to auto-admit.
+async fn vtc_with_signer(signer: &LocalSigner) -> TestVtc {
+    let tv = TestVtc::builder()
+        .vtc_did(signer.issuer_did().to_string())
+        .with_audit(true)
+        .with_credential_signer(Arc::new(signer.clone()))
+        .build()
+        .await;
+
+    crate::policy::default::install_defaults(&tv.state.policies_ks, &tv.state.active_policies_ks)
+        .await
+        .expect("install default policies");
+    for purpose in [StatusPurpose::Revocation, StatusPurpose::Suspension] {
+        ensure_initial(
+            &tv.state.status_lists_ks,
+            purpose,
+            format!("https://vtc.test/v1/status-lists/{purpose}"),
+        )
+        .await
+        .expect("ensure status list");
+    }
+    tv
+}
+
+/// Issue a self-signed VIC (no `credentialStatus`, so the offline revocation
+/// check is a no-op) bound to `subject`, returning `(vp, vic_id)`.
+async fn issue_vic_vp(signer: &LocalSigner, subject: &str) -> (serde_json::Value, String) {
+    let id = format!("urn:uuid:{}", uuid::Uuid::new_v4());
+    let vic = dtg::issue_invitation(signer, subject, Some(&id), None, Duration::days(7))
+        .await
+        .expect("issue VIC");
+    let vp = json!({
+        "type": "VerifiablePresentation",
+        "holder": subject,
+        "verifiableCredential": [vic],
+    });
+    (vp, id)
+}
+
+#[tokio::test]
+async fn vic_presented_in_vp_auto_admits_and_is_consumed() {
+    let issuer = signer(&ISSUER_SEED);
+    let tv = vtc_with_signer(&issuer).await;
+    let applicant = did_key(&APPLICANT_SEED);
+    let (vp, vic_id) = issue_vic_vp(&issuer, &applicant).await;
+
+    // The DIDComm path: the authcrypt envelope authenticates the sender, so no
+    // holder-binding signature (binding = None).
+    let outcome = submit_inner(
+        &tv.state,
+        applicant.clone(),
+        vp,
+        false,
+        json!({}),
+        None,
+        JoinTransport::DIDComm,
+    )
+    .await
+    .expect("submit succeeds");
+
+    // Auto-admitted: credentials issued inline, request Approved.
+    assert!(
+        outcome.admit.is_some(),
+        "a valid self-issued VIC must auto-admit (issue the VMC inline)"
+    );
+    assert_eq!(outcome.request.status, JoinStatus::Approved);
+
+    // The applicant is now a member in the ACL.
+    let entry = get_acl_entry(&tv.state.acl_ks, &applicant)
+        .await
+        .expect("acl read")
+        .expect("applicant has an ACL entry after admit");
+    assert_eq!(entry.role.to_string(), "member");
+
+    // The member row is flagged invitation-joined (drives the admin-UI badge).
+    let member = crate::members::get_member(&tv.state.members_ks, &applicant)
+        .await
+        .expect("member read")
+        .expect("member row exists after admit");
+    assert!(
+        member.joined_via_invitation,
+        "an invitation-driven admit flags the member"
+    );
+
+    // The single-use VIC is burned in the ledger.
+    assert!(
+        is_consumed(&tv.state.consumed_invitations_ks, &vic_id)
+            .await
+            .expect("consumed lookup"),
+        "the redeemed VIC must be recorded consumed"
+    );
+}
+
+#[tokio::test]
+async fn vic_bound_to_another_did_cannot_be_redeemed() {
+    let issuer = signer(&ISSUER_SEED);
+    let tv = vtc_with_signer(&issuer).await;
+
+    // VIC minted for the applicant…
+    let applicant = did_key(&APPLICANT_SEED);
+    let (vp, vic_id) = issue_vic_vp(&issuer, &applicant).await;
+
+    // …but presented by an outsider. Holder-binding fails → Forbidden, before
+    // any policy runs.
+    let outsider = did_key(&OUTSIDER_SEED);
+    let result = submit_inner(
+        &tv.state,
+        outsider.clone(),
+        vp,
+        false,
+        json!({}),
+        None,
+        JoinTransport::DIDComm,
+    )
+    .await;
+    match result {
+        Err(vti_common::error::AppError::Forbidden(_)) => {}
+        Err(other) => panic!("expected Forbidden, got {other:?}"),
+        Ok(_) => panic!("a VIC bound to someone else must be refused"),
+    }
+
+    // The outsider was not admitted and the VIC was not burned.
+    assert!(
+        get_acl_entry(&tv.state.acl_ks, &outsider)
+            .await
+            .expect("acl read")
+            .is_none(),
+        "outsider must not become a member"
+    );
+    assert!(
+        !is_consumed(&tv.state.consumed_invitations_ks, &vic_id)
+            .await
+            .expect("consumed lookup"),
+        "a refused redeem must not consume the VIC"
+    );
+}

--- a/vtc-service/src/join/mod.rs
+++ b/vtc-service/src/join/mod.rs
@@ -18,6 +18,9 @@ pub mod orchestrate;
 pub mod retention;
 pub mod storage;
 
+#[cfg(test)]
+mod invitation_e2e_test;
+
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;

--- a/vtc-service/src/join/orchestrate.rs
+++ b/vtc-service/src/join/orchestrate.rs
@@ -23,9 +23,13 @@ use vti_common::audit::{
 use vti_common::error::AppError;
 
 use crate::ceremony::execute::{self, AdmitOutcome, top_level_id};
+use crate::ceremony::facts::Invitation;
 use crate::ceremony::{
     Credential, CredentialStatus, EffectOutcome, EffectPlan, Evidence, Facts, FactsInputs,
     Presentation, Purpose, Verdict, VerifiedFacts, assemble_facts,
+};
+use crate::credentials::invitation_verify::{
+    ConsumedInvitation, mark_consumed, verify_presented_invitation,
 };
 use crate::credentials::vec::VEC_TYPE;
 use crate::credentials::vmc::VMC_TYPE;
@@ -135,12 +139,33 @@ pub async fn submit_inner(
     // reads structured Facts instead (assembled below).
     let vp_claims = extract_vp_claims(&vp);
 
-    // 4. Decide: assemble verified Facts (the route-layer holder-binding
+    // 4. Invitation (VIC): if the VP carries an InvitationCredential, verify it
+    // (proof + holder-binding + validity + revocation). A present-but-invalid
+    // invitation is a hard Forbidden here, before policy. A verified invitation
+    // becomes a policy fact, with `consumed` resolved from the single-use ledger
+    // so the policy (`has_valid_invitation`) can reject a redeemed invite. The
+    // VIC `id` is kept so an auto-admit can burn it (step 6).
+    let invitation_fact = match verify_presented_invitation(state, &applicant_did, &vp).await? {
+        Some(vi) => {
+            let consumed = crate::credentials::invitation_verify::is_consumed(
+                &state.consumed_invitations_ks,
+                &vi.id,
+            )
+            .await?;
+            Some((vi.id.clone(), vi.to_fact(consumed)))
+        }
+        None => None,
+    };
+    let consume_invitation_id = invitation_fact.as_ref().map(|(id, _)| id.clone());
+    let invitation = invitation_fact.map(|(_, fact)| fact);
+
+    // 5. Decide: assemble verified Facts (the route-layer holder-binding
     // makes this presentation `verified`) and run the active join policy.
     let presentation = presentation_from_vp(&applicant_did, &vp);
-    let verdict = decide_join(state, &applicant_did, presentation).await?;
+    let verdict = decide_join(state, &applicant_did, presentation, invitation).await?;
 
-    // 5. Realize the verdict (store + audit + auto-admit on allow).
+    // 6. Realize the verdict (store + audit + auto-admit on allow). On an
+    // invitation-driven admit the VIC is burned in the single-use ledger.
     realize_join_verdict(
         state,
         &applicant_did,
@@ -150,6 +175,7 @@ pub async fn submit_inner(
         extensions,
         verdict,
         transport,
+        consume_invitation_id,
     )
     .await
 }
@@ -163,8 +189,9 @@ pub async fn decide_join(
     state: &AppState,
     applicant_did: &str,
     presentation: Presentation,
+    invitation: Option<Invitation>,
 ) -> Result<Verdict, AppError> {
-    let facts = assemble_join_facts(state, applicant_did, presentation).await?;
+    let facts = assemble_join_facts(state, applicant_did, presentation, invitation).await?;
     let verified = VerifiedFacts::assemble(facts)?;
     let policy = load_active_compiled(
         &state.active_policies_ks,
@@ -188,6 +215,7 @@ pub async fn realize_join_verdict(
     extensions: JsonValue,
     verdict: Verdict,
     transport: JoinTransport,
+    consume_invitation_id: Option<String>,
 ) -> Result<JoinSubmitOutcome, AppError> {
     let audit_writer = state
         .audit_writer
@@ -251,6 +279,58 @@ pub async fn realize_join_verdict(
                 )
                 .await?;
                 admit = Some(creds);
+
+                // Burn a single-use invitation now that the admit succeeded. The
+                // `consumed` ledger row blocks a later re-redeem (e.g. re-join
+                // after leaving); best-effort — the member is already admitted,
+                // so a ledger write failure is logged, not fatal.
+                if let Some(vic_id) = consume_invitation_id.as_deref() {
+                    let record = ConsumedInvitation {
+                        applicant: applicant_did.to_string(),
+                        consumed_at: chrono::Utc::now(),
+                        via_join_request_id: request.id.to_string(),
+                    };
+                    match mark_consumed(&state.consumed_invitations_ks, vic_id, &record).await {
+                        Ok(true) => {}
+                        Ok(false) => warn!(
+                            vic_id = %vic_id,
+                            applicant = %applicant_did,
+                            "invitation was already consumed at admit time (concurrent redeem)",
+                        ),
+                        Err(e) => warn!(
+                            vic_id = %vic_id,
+                            error = %e,
+                            "failed to record invitation consumption; member admitted",
+                        ),
+                    }
+
+                    // Flag the freshly-admitted member as invitation-joined so
+                    // the admin UI can badge them. Best-effort metadata patch —
+                    // the member + credentials already exist.
+                    match crate::members::get_member(&state.members_ks, applicant_did).await {
+                        Ok(Some(mut m)) => {
+                            m.joined_via_invitation = true;
+                            if let Err(e) =
+                                crate::members::store_member(&state.members_ks, &m).await
+                            {
+                                warn!(
+                                    applicant = %applicant_did,
+                                    error = %e,
+                                    "failed to flag member joined_via_invitation",
+                                );
+                            }
+                        }
+                        Ok(None) => warn!(
+                            applicant = %applicant_did,
+                            "admitted member row missing when flagging joined_via_invitation",
+                        ),
+                        Err(e) => warn!(
+                            applicant = %applicant_did,
+                            error = %e,
+                            "failed to load member to flag joined_via_invitation",
+                        ),
+                    }
+                }
             }
             request.status = JoinStatus::Approved;
         }
@@ -312,10 +392,13 @@ async fn assemble_join_facts(
     state: &AppState,
     applicant_did: &str,
     presentation: Presentation,
+    invitation: Option<Invitation>,
 ) -> Result<Facts, AppError> {
     // The applicant proved holder-binding (route-layer for the VP path,
     // cryptographic kb-jwt for the credential-exchange path) but is not (yet) a
-    // member, so they carry no community role and no subject member-state.
+    // member, so they carry no community role and no subject member-state. The
+    // `invitation` slot is populated when the applicant presented a verified VIC
+    // (see `verify_presented_invitation`); the policy decides over it.
     assemble_facts(
         state,
         FactsInputs {
@@ -325,7 +408,7 @@ async fn assemble_join_facts(
             subject_did: applicant_did.to_string(),
             subject_member: None,
             evidence: Evidence {
-                invitation: None,
+                invitation,
                 presentation: Some(presentation),
                 request: None,
             },

--- a/vtc-service/src/members/mod.rs
+++ b/vtc-service/src/members/mod.rs
@@ -109,6 +109,14 @@ pub struct Member {
     /// [`Self::reciprocal_vc_id`]; `None` until accept.
     #[serde(default)]
     pub accepted_at: Option<DateTime<Utc>>,
+    /// Whether this member auto-joined by presenting a verified
+    /// Invitation Credential (VIC). Set at admit time on the
+    /// invitation path; surfaced in the admin UI as a "joined via
+    /// invitation" badge. `#[serde(default)]` keeps pre-existing
+    /// member rows (written before this field) deserialising as
+    /// `false`.
+    #[serde(default)]
+    pub joined_via_invitation: bool,
 }
 
 impl Member {
@@ -135,6 +143,7 @@ impl Member {
             personhood_asserted_at: None,
             reciprocal_vc_id: None,
             accepted_at: None,
+            joined_via_invitation: false,
         }
     }
 

--- a/vtc-service/src/members/storage.rs
+++ b/vtc-service/src/members/storage.rs
@@ -203,6 +203,7 @@ mod tests {
             personhood_asserted_at: None,
             reciprocal_vc_id: None,
             accepted_at: None,
+            joined_via_invitation: false,
         };
         let json = serde_json::to_value(&m).unwrap();
         assert!(json["joinedAt"].is_string());
@@ -234,6 +235,7 @@ mod tests {
             personhood_asserted_at: Some(now),
             reciprocal_vc_id: None,
             accepted_at: None,
+            joined_via_invitation: false,
         };
         let json = serde_json::to_value(&m).unwrap();
         assert_eq!(json["personhood"], true);

--- a/vtc-service/src/policy/default.rs
+++ b/vtc-service/src/policy/default.rs
@@ -539,6 +539,84 @@ mod tests {
     }
 
     #[test]
+    fn join_default_admits_on_valid_invitation() {
+        // A verified, trusted, unconsumed invitation (VIC) auto-admits as a
+        // member — no presented credential needed.
+        let c = compile_default(PolicyPurpose::Join);
+        let r = evaluate(
+            &c,
+            "data.vtc.join.decision",
+            json!({
+                "evidence": {
+                    "invitation": {
+                        "verified": true,
+                        "issuer": "did:webvh:acme.example",
+                        "issuer_trusted": true,
+                        "consumed": false
+                    }
+                }
+            }),
+        )
+        .unwrap();
+        assert_eq!(
+            r.pointer("/result/0/expressions/0/value"),
+            Some(&json!({ "effect": "allow", "with": { "role": "member" } })),
+        );
+    }
+
+    #[test]
+    fn join_default_refers_on_consumed_invitation() {
+        // A single-use invitation already redeemed is not a valid admit signal
+        // → falls through to moderator review.
+        let c = compile_default(PolicyPurpose::Join);
+        let r = evaluate(
+            &c,
+            "data.vtc.join.decision",
+            json!({
+                "evidence": {
+                    "invitation": {
+                        "verified": true,
+                        "issuer": "did:webvh:acme.example",
+                        "issuer_trusted": true,
+                        "consumed": true
+                    }
+                }
+            }),
+        )
+        .unwrap();
+        assert_eq!(
+            r.pointer("/result/0/expressions/0/value"),
+            Some(&json!({ "effect": "refer", "with": { "queue": "moderator" } })),
+        );
+    }
+
+    #[test]
+    fn join_default_refers_on_untrusted_invitation_issuer() {
+        // A genuinely-verified invitation from an untrusted issuer does not
+        // auto-admit — it is referred for human review.
+        let c = compile_default(PolicyPurpose::Join);
+        let r = evaluate(
+            &c,
+            "data.vtc.join.decision",
+            json!({
+                "evidence": {
+                    "invitation": {
+                        "verified": true,
+                        "issuer": "did:key:zStranger",
+                        "issuer_trusted": false,
+                        "consumed": false
+                    }
+                }
+            }),
+        )
+        .unwrap();
+        assert_eq!(
+            r.pointer("/result/0/expressions/0/value"),
+            Some(&json!({ "effect": "refer", "with": { "queue": "moderator" } })),
+        );
+    }
+
+    #[test]
     fn join_default_refers_without_trusted_credential() {
         // No trusted credential → referred to the moderator queue
         // (the request lands Pending for admin review).

--- a/vtc-service/src/routes/invitations.rs
+++ b/vtc-service/src/routes/invitations.rs
@@ -1,0 +1,143 @@
+//! `POST /v1/invitations` — issue an **Invitation Credential** (VIC) to a
+//! prospective member (the operator side of the VIC auto-join ceremony).
+//!
+//! The community admin enters an invitee DID; the VTC mints a short-lived,
+//! revocable VIC bound to that DID and signed by the community key, and returns
+//! the signed credential for **out-of-band delivery** (copy / QR) to the
+//! invitee. The invitee later presents it inside a join VP and is auto-admitted
+//! (`credentials::invitation_verify` + the default `join.rego`).
+//!
+//! Auth: Admin / Moderator / Issuer — the roles that grow + vouch for
+//! membership. The issuance itself (slot allocation, signing, schema check)
+//! lives in [`crate::credentials::invitation`]; this is the thin authenticated
+//! REST surface over it.
+
+use axum::Json;
+use axum::extract::State;
+use axum::http::StatusCode;
+use chrono::Duration;
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+use tracing::info;
+
+use vti_common::auth::AuthClaims;
+use vti_common::error::AppError;
+
+use crate::acl::{VtcRole, get_acl_entry};
+use crate::credentials::invitation::{DEFAULT_INVITATION_VALIDITY, issue_invitation};
+use crate::members::get_member;
+use crate::server::AppState;
+
+/// Upper bound on a caller-requested validity — an invite is a short-lived
+/// onboarding artifact, not a standing credential.
+const MAX_VALIDITY_DAYS: i64 = 90;
+
+#[derive(Debug, Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct IssueInvitationBody {
+    /// The DID to invite (a prospective, non-member holder).
+    pub subject_did: String,
+    /// Optional validity in days (1..=90); defaults to the 7-day VIC default.
+    #[serde(default)]
+    pub validity_days: Option<u32>,
+}
+
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct IssueInvitationResponse {
+    /// Echo of the invited DID.
+    pub subject_did: String,
+    /// The VIC's `validUntil` (RFC3339), for the operator UI to display.
+    pub valid_until: Option<String>,
+    /// The signed Invitation Credential — handed to the invitee out-of-band
+    /// (copy / QR). The invitee presents it back in a join request.
+    pub vic: JsonValue,
+}
+
+#[utoipa::path(
+    post, path = "/invitations", tag = "invitations",
+    security(("bearer_jwt" = [])),
+    request_body = IssueInvitationBody,
+    responses(
+        (status = 201, description = "Invitation issued", body = IssueInvitationResponse),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller is not Admin / Moderator / Issuer"),
+        (status = 409, description = "Subject is already a member"),
+    ),
+)]
+pub async fn issue(
+    auth: AuthClaims,
+    State(state): State<AppState>,
+    Json(body): Json<IssueInvitationBody>,
+) -> Result<(StatusCode, Json<IssueInvitationResponse>), AppError> {
+    let signer = state
+        .credential_signer
+        .as_ref()
+        .ok_or_else(|| AppError::Internal("credential signer not configured".into()))?;
+
+    // Auth: Admin / Moderator / Issuer can invite (read the ACL row — the JWT
+    // degrades non-Admin VTC roles to Reader, so it can't distinguish them).
+    let acl = get_acl_entry(&state.acl_ks, &auth.did)
+        .await?
+        .ok_or_else(|| AppError::Forbidden("caller has no ACL row".into()))?;
+    if !matches!(
+        acl.role,
+        VtcRole::Admin | VtcRole::Moderator | VtcRole::Issuer
+    ) {
+        return Err(AppError::Forbidden(
+            "only Admin, Moderator, or Issuer members can issue invitations".into(),
+        ));
+    }
+
+    // An invite is for a *prospective* member.
+    if !body.subject_did.starts_with("did:") {
+        return Err(AppError::Validation("subjectDid must be a DID".into()));
+    }
+    if get_member(&state.members_ks, &body.subject_did)
+        .await?
+        .is_some()
+    {
+        return Err(AppError::Conflict(format!(
+            "{} is already a member — no invitation needed",
+            body.subject_did
+        )));
+    }
+
+    let validity = match body.validity_days {
+        Some(d) if d == 0 || (d as i64) > MAX_VALIDITY_DAYS => {
+            return Err(AppError::Validation(format!(
+                "validityDays must be between 1 and {MAX_VALIDITY_DAYS}"
+            )));
+        }
+        Some(d) => Duration::days(d as i64),
+        None => DEFAULT_INVITATION_VALIDITY,
+    };
+
+    let vic = issue_invitation(
+        signer,
+        &state.status_lists_ks,
+        &state.schemas_ks,
+        &body.subject_did,
+        validity,
+    )
+    .await?;
+    let valid_until = vic
+        .get("validUntil")
+        .and_then(JsonValue::as_str)
+        .map(str::to_string);
+
+    info!(
+        actor = %auth.did,
+        subject = %body.subject_did,
+        "issued an invitation credential (VIC)"
+    );
+
+    Ok((
+        StatusCode::CREATED,
+        Json(IssueInvitationResponse {
+            subject_did: body.subject_did,
+            valid_until,
+            vic,
+        }),
+    ))
+}

--- a/vtc-service/src/routes/join_requests/present.rs
+++ b/vtc-service/src/routes/join_requests/present.rs
@@ -82,8 +82,10 @@ pub async fn present_and_decide_join(
     //    each issuer's trust via TRQP against the community's recognition graph.
     let presentation = presentation_from_verified_set(state, &set).await;
 
-    // 3 + 4. Decide under the active join policy, then realize the verdict.
-    let verdict = decide_join(state, &applicant_did, presentation).await?;
+    // 3 + 4. Decide under the active join policy, then realize the verdict. The
+    // credential-exchange path carries no VIC (invitations ride the VP-submit
+    // path), so no invitation fact and nothing to consume.
+    let verdict = decide_join(state, &applicant_did, presentation, None).await?;
     let vp_claims = vp_claims_from_set(&set);
     realize_join_verdict(
         state,
@@ -94,6 +96,7 @@ pub async fn present_and_decide_join(
         JsonValue::Null,
         verdict,
         transport,
+        None,
     )
     .await
 }

--- a/vtc-service/src/routes/members/read.rs
+++ b/vtc-service/src/routes/members/read.rs
@@ -50,6 +50,11 @@ pub struct MemberResponse {
     /// `personhood` flag.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub personhood_asserted_at: Option<DateTime<Utc>>,
+    /// Whether the member auto-joined by presenting a verified
+    /// Invitation Credential (VIC). Surfaced so the admin UI can
+    /// badge invitation-joined members.
+    #[serde(default)]
+    pub joined_via_invitation: bool,
 }
 
 impl MemberResponse {
@@ -71,6 +76,7 @@ impl MemberResponse {
             extensions: member.extensions,
             personhood: member.personhood,
             personhood_asserted_at: member.personhood_asserted_at,
+            joined_via_invitation: member.joined_via_invitation,
         }
     }
 }

--- a/vtc-service/src/routes/members/update.rs
+++ b/vtc-service/src/routes/members/update.rs
@@ -182,6 +182,7 @@ impl MemberResponse {
             extensions: member.extensions,
             personhood: member.personhood,
             personhood_asserted_at: member.personhood_asserted_at,
+            joined_via_invitation: member.joined_via_invitation,
         }
     }
 }

--- a/vtc-service/src/routes/mod.rs
+++ b/vtc-service/src/routes/mod.rs
@@ -14,6 +14,7 @@ mod endorsement_types;
 mod endorsements;
 mod health;
 pub(crate) mod install;
+mod invitations;
 pub mod join_requests;
 pub(crate) mod members;
 pub(crate) mod policies;
@@ -595,6 +596,12 @@ fn build_api_chain(_routing: &RoutingConfig, trust_xff: bool) -> OpenApiRouter<A
             // layer pending per-method selectors; standalone
             // `list/1.0` exists on disk + in index.json.
             "https://trusttasks.org/openvtc/vtc/credentials/endorsements/issue/1.0",
+        ))
+        // Invitation Credential (VIC) issuance — the operator side of the
+        // VIC auto-join ceremony. Admin / Moderator / Issuer.
+        .routes(tt(
+            routes!(invitations::issue),
+            "https://trusttasks.org/openvtc/vtc/invitations/issue/1.0",
         ))
         .routes(tt(
             routes!(endorsements::show, endorsements::revoke), // GET + DELETE share `show/1.0` at the router

--- a/vtc-service/src/server.rs
+++ b/vtc-service/src/server.rs
@@ -109,6 +109,10 @@ pub struct AppState {
     pub endorsements_ks: KeyspaceHandle,
     pub audit_ks: KeyspaceHandle,
     pub audit_key_ks: KeyspaceHandle,
+    /// Single-use ledger for redeemed Invitation Credentials (VICs).
+    /// Written when a VIC-driven join is admitted; read at verify
+    /// time so a consumed invite can't be replayed.
+    pub consumed_invitations_ks: KeyspaceHandle,
     /// Trust-registry client (Phase 3 M3.2). `None` when
     /// `config.registry.url` is unset — the daemon runs in
     /// "no-registry" mode and `registry_health.status()` stays
@@ -300,6 +304,7 @@ pub async fn run(
     let endorsements_ks = store.keyspace(keyspaces::ENDORSEMENTS)?;
     let audit_ks = store.keyspace(keyspaces::AUDIT)?;
     let audit_key_ks = store.keyspace(keyspaces::AUDIT_KEY)?;
+    let consumed_invitations_ks = store.keyspace(keyspaces::CONSUMED_INVITATIONS)?;
 
     // M2.5: install the workspace-shipped default policies for any
     // PolicyPurpose that lacks an active row. Idempotent — operator
@@ -514,6 +519,7 @@ pub async fn run(
         endorsements_ks,
         audit_ks,
         audit_key_ks,
+        consumed_invitations_ks,
         registry_client: registry_client.clone(),
         registry_health: registry_health.clone(),
         syncer_health: crate::registry::SyncerHealth::new(),

--- a/vtc-service/src/store/keyspaces.rs
+++ b/vtc-service/src/store/keyspaces.rs
@@ -32,6 +32,10 @@ pub const SCHEMAS: &str = "schemas";
 pub const ENDORSEMENTS: &str = "endorsements";
 pub const AUDIT: &str = "audit";
 pub const AUDIT_KEY: &str = "audit_key";
+/// Single-use ledger for redeemed Invitation Credentials (VICs): one
+/// row per consumed VIC `id`, written when a VIC-driven join is
+/// admitted. Read at verify time to set `Invitation.consumed`.
+pub const CONSUMED_INVITATIONS: &str = "consumed_invitations";
 
 /// Every keyspace the daemon opens, in `AppState` field order. The
 /// setup wizard pre-creates exactly this set; `server::run` opens
@@ -58,6 +62,7 @@ pub const ALL: &[&str] = &[
     ENDORSEMENTS,
     AUDIT,
     AUDIT_KEY,
+    CONSUMED_INVITATIONS,
 ];
 
 /// Keyspaces captured by `POST /v1/backup/export` (P3.9). These hold
@@ -84,6 +89,9 @@ pub const BACKED_UP: &[&str] = &[
     ENDORSEMENTS,
     AUDIT,
     AUDIT_KEY,
+    // A consumed VIC must stay consumed across a restore, else a
+    // restored community could re-redeem a single-use invitation.
+    CONSUMED_INVITATIONS,
 ];
 
 /// Keyspaces deliberately omitted from backup (P3.9): ephemeral auth,
@@ -110,7 +118,7 @@ mod tests {
     /// keyspace is added to one without the other, this trips.
     #[test]
     fn all_matches_app_state_keyspace_count() {
-        assert_eq!(ALL.len(), 21, "ALL must list every AppState keyspace");
+        assert_eq!(ALL.len(), 22, "ALL must list every AppState keyspace");
     }
 
     /// The backup census (P3.9): every keyspace is either backed up or

--- a/vtc-service/src/test_support.rs
+++ b/vtc-service/src/test_support.rs
@@ -226,6 +226,9 @@ impl TestVtcBuilder {
         let endorsements_ks = store.keyspace("endorsements").expect("endorsements ks");
         let audit_ks = store.keyspace("audit").expect("audit ks");
         let audit_key_ks = store.keyspace("audit_key").expect("audit_key ks");
+        let consumed_invitations_ks = store
+            .keyspace("consumed_invitations")
+            .expect("consumed_invitations ks");
 
         let jwt_keys =
             Arc::new(JwtKeys::from_ed25519_bytes(&JWT_SEED, "VTC").expect("build VTC JWT keys"));
@@ -337,6 +340,7 @@ impl TestVtcBuilder {
             endorsements_ks,
             audit_ks,
             audit_key_ks,
+            consumed_invitations_ks,
             registry_client: None,
             registry_health: crate::registry::RegistryHealth::new(),
             syncer_health: crate::registry::SyncerHealth::new(),

--- a/vtc-service/tests/invitations.rs
+++ b/vtc-service/tests/invitations.rs
@@ -1,0 +1,195 @@
+//! Integration coverage for `POST /v1/invitations` — the operator-side VIC
+//! issuance route (the admin UI calls this to mint an invitation).
+//!
+//! Covers: admin happy path (a signed, revocable VIC bound to the invitee),
+//! the non-privileged caller 403, and the already-a-member 409.
+
+use std::sync::Arc;
+
+use affinidi_status_list::StatusPurpose;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use serde_json::{Value, json};
+use tower::ServiceExt;
+use uuid::Uuid;
+use vti_common::auth::jwt::JwtKeys;
+use vti_common::auth::session::{Session, SessionState, now_epoch, store_session};
+
+use vtc_service::acl::{VtcAclEntry, VtcRole, store_acl_entry};
+use vtc_service::members::{Member, store_member};
+use vtc_service::status_list;
+use vtc_service::test_support::TestVtc;
+
+const PUBLIC_URL: &str = "https://vtc.example.com";
+const ISSUE_TASK: &str = "https://trusttasks.org/openvtc/vtc/invitations/issue/1.0";
+const ADMIN_DID: &str = "did:key:zInvAdmin";
+const MEMBER_DID: &str = "did:key:zInvMember";
+const INVITEE_DID: &str = "did:key:zInvitee";
+
+struct Fixture {
+    router: axum::Router,
+    admin_token: String,
+    member_token: String,
+    _vtc: TestVtc,
+}
+
+async fn build() -> Fixture {
+    let vtc = TestVtc::builder()
+        .with_audit(true)
+        .with_signers(true)
+        .with_public_url(PUBLIC_URL)
+        .build()
+        .await;
+
+    vtc_service::policy::default::install_defaults(
+        &vtc.state.policies_ks,
+        &vtc.state.active_policies_ks,
+    )
+    .await
+    .unwrap();
+    for purpose in [StatusPurpose::Revocation, StatusPurpose::Suspension] {
+        let url = format!("{PUBLIC_URL}/v1/status-lists/{purpose}");
+        status_list::ensure_initial(&vtc.state.status_lists_ks, purpose, url)
+            .await
+            .unwrap();
+    }
+
+    let now = now_epoch();
+    for (did, role) in [(ADMIN_DID, VtcRole::Admin), (MEMBER_DID, VtcRole::Member)] {
+        store_acl_entry(
+            &vtc.state.acl_ks,
+            &VtcAclEntry {
+                did: did.into(),
+                role,
+                label: None,
+                allowed_contexts: vec![],
+                created_at: now,
+                created_by: "did:key:vtc-install".into(),
+                expires_at: None,
+            },
+        )
+        .await
+        .unwrap();
+        store_member(&vtc.state.members_ks, &Member::fresh(did))
+            .await
+            .unwrap();
+    }
+
+    async fn mint(
+        sessions: &vti_common::store::KeyspaceHandle,
+        jwt_keys: &Arc<JwtKeys>,
+        did: &str,
+        role: &str,
+        now: u64,
+    ) -> String {
+        let session_id = format!("sess-{}", Uuid::new_v4());
+        store_session(
+            sessions,
+            &Session {
+                session_id: session_id.clone(),
+                did: did.into(),
+                challenge: "test".into(),
+                state: SessionState::Authenticated,
+                created_at: now,
+                refresh_token: None,
+                refresh_expires_at: None,
+                tee_attested: false,
+                amr: Vec::new(),
+                acr: String::new(),
+                token_id: None,
+                session_pubkey_b58btc: None,
+            },
+        )
+        .await
+        .unwrap();
+        let claims = jwt_keys.new_claims(did.into(), session_id, role.into(), vec![], 3600, true);
+        jwt_keys.encode(&claims).unwrap()
+    }
+
+    let admin_token = mint(
+        &vtc.state.sessions_ks,
+        &vtc.jwt_keys,
+        ADMIN_DID,
+        "admin",
+        now,
+    )
+    .await;
+    let member_token = mint(
+        &vtc.state.sessions_ks,
+        &vtc.jwt_keys,
+        MEMBER_DID,
+        "reader",
+        now,
+    )
+    .await;
+
+    let router = vtc.router.clone();
+    Fixture {
+        router,
+        admin_token,
+        member_token,
+        _vtc: vtc,
+    }
+}
+
+async fn body_value(resp: axum::response::Response) -> (StatusCode, Value) {
+    let status = resp.status();
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let v: Value = serde_json::from_slice(&bytes)
+        .unwrap_or_else(|_| json!({ "raw": String::from_utf8_lossy(&bytes) }));
+    (status, v)
+}
+
+fn issue_req(token: &str, body: Value) -> Request<Body> {
+    Request::builder()
+        .method("POST")
+        .uri("/v1/invitations")
+        .header("authorization", format!("Bearer {token}"))
+        .header("trust-task", ISSUE_TASK)
+        .header("content-type", "application/json")
+        .body(Body::from(body.to_string()))
+        .unwrap()
+}
+
+#[tokio::test]
+async fn admin_issues_a_revocable_vic_bound_to_the_invitee() {
+    let fix = build().await;
+    let req = issue_req(&fix.admin_token, json!({ "subjectDid": INVITEE_DID }));
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    let (status, v) = body_value(resp).await;
+    assert_eq!(status, StatusCode::CREATED, "{v}");
+
+    assert_eq!(v["subjectDid"], INVITEE_DID);
+    let vic = &v["vic"];
+    assert_eq!(vic["credentialSubject"]["id"], INVITEE_DID);
+    let types: Vec<String> = serde_json::from_value(vic["type"].clone()).unwrap();
+    assert!(
+        types.iter().any(|t| t == "InvitationCredential"),
+        "issued credential is an InvitationCredential: {types:?}"
+    );
+    assert!(
+        vic.get("credentialStatus").is_some(),
+        "the VIC must be revocable"
+    );
+    assert!(vic.get("proof").is_some(), "the VIC must be signed");
+}
+
+#[tokio::test]
+async fn non_privileged_member_cannot_issue() {
+    let fix = build().await;
+    let req = issue_req(&fix.member_token, json!({ "subjectDid": INVITEE_DID }));
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    let (status, _) = body_value(resp).await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn inviting_an_existing_member_is_a_conflict() {
+    let fix = build().await;
+    // MEMBER_DID already has a member row.
+    let req = issue_req(&fix.admin_token, json!({ "subjectDid": MEMBER_DID }));
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    let (status, _) = body_value(resp).await;
+    assert_eq!(status, StatusCode::CONFLICT);
+}


### PR DESCRIPTION
## Summary

Adds **automatic community join via a Verifiable Invitation Credential (VIC)**: an applicant who presents a VIC in their join VP is verified and, per the default policy, **auto-admitted with no manual approval**. Issuance, verification, single-use enforcement, trust, the operator UI, and the VTA credential-vault surface are all wired.

Companion PR (applicant side): OpenVTC `feat(join): present a Verifiable Invitation Credential when joining`.

## What's included

**Auto-admit join on VIC** (`feat(vtc-service)`)
- `credentials/invitation_verify.rs` — extract the `InvitationCredential` from the submitted VP and verify it: issuer Data-Integrity proof (resolved via the shared `DidVmResolver`), holder-binding (`credentialSubject.id == applicant`), temporal validity, revocation (fail-closed), issuer trust. Returns a `VerifiedInvitation` typestate.
- `join/orchestrate.rs` — thread the verified invitation into the join decision (replacing the hardcoded `evidence.invitation: None`) and burn the VIC in a new single-use `consumed_invitations` ledger on auto-admit.
- `ceremony/facts.rs` — `Invitation.issuer_trusted` fact (serde-default).
- `policies/default/join.rego` — auto-admit on a valid, trusted, unconsumed invite (`has_valid_invitation`), rule-IR header kept in step.
- `routes/invitations.rs` — `POST /v1/invitations` (Admin/Moderator/Issuer) issues a VIC for a prospective member.
- members — record + surface `joined_via_invitation` for the admin-UI badge.
- admin-ui — **Invitations** plugin (issue → copy/download/QR) + member badge.

**Credential-vault trust-task slice** (`feat(vta-service)`)
- `vault/credentials/{receive,query,get}/0.1` Trust-Task slice + `vta-sdk` `cred_vault_{receive,query,get}` so a held VIC can live in the VTA credential vault (distinct from the password vault; `cred:` namespace; `purpose=invite` inferred from type).

**Third-party issuer (M2)**
- `invitation_issuer_trusted` already consults the trust registry, so a VIC from a recognised third party auto-admits like a self-issued one — proven by `third_party_issuer_trusted_via_registry`. The recognition graph is the trusted-issuer config (no bespoke surface).

## Tests
9 verify unit + 3 policy + 2 E2E + 3 route (VTC) and the credential-vault dispatcher-parity + storage-id tests (VTA). Full `vtc-service` lib suite: **652 passing**. Admin UI typechecks + bundles.

## Notes / follow-ups (in `tasks/vic-join-demo-runbook.md`)
- A VIC is holder-bound: for the demo use OpenVTC's reuse-persona path so the presented DID matches the VIC subject (mint-fresh can't be pre-bound yet).
- Wiring OpenVTC to load the VIC from the VTA credential vault instead of `--invitation <file>` is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)