### PR TITLE
feat(consent): VTA consent store — first-gate for inbound bridged messaging

### DIFF
--- a/vta-sdk/src/client/consent.rs
+++ b/vta-sdk/src/client/consent.rs
@@ -1,0 +1,129 @@
+//! `consent/*` Trust Task client methods.
+//!
+//! Drive the VTA consent gate from a messaging bridge (or operator tooling)
+//! through the generic dispatcher ([`VtaClient::dispatch_trust_task`]) — there
+//! is no dedicated REST route. See `vta-service`'s consent store and the
+//! `consent/*` family in the dtgwg registry.
+//!
+//! `subject` is the platform-agnostic `{platform, conversationRef, kind, agent}`
+//! object; `conversationRef` is the bridge's OPAQUE handle — never a raw
+//! platform address.
+
+use serde_json::{Value, json};
+
+use super::VtaClient;
+use crate::error::VtaError;
+use crate::trust_tasks;
+
+/// Round-trip timeout (seconds) for consent trust tasks.
+const CONSENT_TT_TIMEOUT: u64 = 30;
+
+impl VtaClient {
+    /// `consent/request/1.0` — ask the VTA to gate an inbound conversation for an
+    /// agent. Default-deny: if no live grant exists, a pending consent is minted
+    /// for an approver. `scope` is `"receive"` or `"converse"`. `challenge` (≥128
+    /// bits) is echoed by the matching decision.
+    pub async fn consent_request(
+        &self,
+        subject: Value,
+        scope: &str,
+        challenge: &str,
+        display_hint: Option<&str>,
+        context_hint: Option<&str>,
+    ) -> Result<Value, VtaError> {
+        let mut payload = json!({
+            "subject": subject,
+            "scope": scope,
+            "challenge": challenge,
+        });
+        if let Some(h) = display_hint {
+            payload["displayHint"] = json!(h);
+        }
+        if let Some(c) = context_hint {
+            payload["contextHint"] = json!(c);
+        }
+        self.dispatch_trust_task(
+            trust_tasks::TASK_CONSENT_REQUEST_1_0,
+            payload,
+            CONSENT_TT_TIMEOUT,
+        )
+        .await
+    }
+
+    /// `consent/decision/1.0` — allow or deny a conversation; records a grant.
+    /// `effect` is `"allow"` or `"deny"`; `scope` (`"receive"`/`"converse"`) is
+    /// required for allow. Echo `challenge` to answer a specific request;
+    /// `expires_at` is an optional RFC-3339 grant TTL.
+    pub async fn consent_decision(
+        &self,
+        subject: Value,
+        effect: &str,
+        scope: Option<&str>,
+        challenge: Option<&str>,
+        expires_at: Option<&str>,
+    ) -> Result<Value, VtaError> {
+        let mut payload = json!({
+            "subject": subject,
+            "effect": effect,
+        });
+        if let Some(s) = scope {
+            payload["scope"] = json!(s);
+        }
+        if let Some(c) = challenge {
+            payload["challenge"] = json!(c);
+        }
+        if let Some(e) = expires_at {
+            payload["expiresAt"] = json!(e);
+        }
+        self.dispatch_trust_task(
+            trust_tasks::TASK_CONSENT_DECISION_1_0,
+            payload,
+            CONSENT_TT_TIMEOUT,
+        )
+        .await
+    }
+
+    /// `consent/revoke/1.0` — withdraw a standing grant (revert to default-deny).
+    pub async fn consent_revoke(
+        &self,
+        subject: Value,
+        reason: Option<&str>,
+    ) -> Result<Value, VtaError> {
+        let mut payload = json!({ "subject": subject });
+        if let Some(r) = reason {
+            payload["reason"] = json!(r);
+        }
+        self.dispatch_trust_task(
+            trust_tasks::TASK_CONSENT_REVOKE_1_0,
+            payload,
+            CONSENT_TT_TIMEOUT,
+        )
+        .await
+    }
+
+    /// `consent/list/1.0` — sync / point-check the grants a bridge enforces. All
+    /// filters are optional; pass a full `subject` for a point-check.
+    pub async fn consent_list(
+        &self,
+        agent: Option<&str>,
+        platform: Option<&str>,
+        subject: Option<Value>,
+    ) -> Result<Value, VtaError> {
+        let mut payload = json!({});
+        if let Some(a) = agent {
+            payload["agent"] = json!(a);
+        }
+        if let Some(p) = platform {
+            payload["platform"] = json!(p);
+        }
+        if let Some(s) = subject {
+            payload["subject"] = s;
+        }
+        self.dispatch_trust_task(
+            trust_tasks::TASK_CONSENT_LIST_1_0,
+            payload,
+            CONSENT_TT_TIMEOUT,
+        )
+        .await
+    }
+}

--- a/vta-sdk/src/client/mod.rs
+++ b/vta-sdk/src/client/mod.rs
@@ -104,6 +104,7 @@ mod auto_connect;
 mod backup;
 mod backup_descriptors;
 mod bootstrap;
+mod consent;
 mod contexts;
 mod did_templates;
 mod keys;

--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -981,6 +981,33 @@ pub const TASK_ATTESTATION_STATUS_1_0: &str =
 pub const TASK_ATTESTATION_REPORT_1_0: &str =
     "https://trusttasks.org/spec/vta/attestation/report/1.0";
 
+// ─── Consent slice (spec/consent/*) ──────────────────────────────────────
+//
+// Generic, platform-agnostic consent gating for inbound messaging: a bridge
+// asks the VTA whether an inbound conversation (DM / group / channel, on any
+// platform) may reach an AI agent — default-deny, with operator consent on
+// first contact. The decision is recorded as a grant the bridge enforces.
+// Canonical specs: the `consent/*` family in the dtgwg-trust-tasks-tf registry.
+
+/// `consent/request/1.0` — a bridge asks the VTA to gate an inbound
+/// conversation; the message is held until an operator decision lands.
+/// Auth: an enrolled bridge permitted to gate the named agent.
+pub const TASK_CONSENT_REQUEST_1_0: &str = "https://trusttasks.org/spec/consent/request/1.0";
+
+/// `consent/decision/1.0` — an approver allows/denies a conversation; the VTA
+/// records a [`ConsentGrant`](https://trusttasks.org/spec/consent/_shared).
+/// Auth: an approver for the subject's platform/context (operator-signed, or
+/// bridge-attested).
+pub const TASK_CONSENT_DECISION_1_0: &str = "https://trusttasks.org/spec/consent/decision/1.0";
+
+/// `consent/revoke/1.0` — an operator withdraws a standing grant, reverting the
+/// conversation to default-deny.
+pub const TASK_CONSENT_REVOKE_1_0: &str = "https://trusttasks.org/spec/consent/revoke/1.0";
+
+/// `consent/list/1.0` — a bridge syncs / point-checks the grants it enforces,
+/// so steady-state inbound is a local Allow/Deny lookup. Read-only.
+pub const TASK_CONSENT_LIST_1_0: &str = "https://trusttasks.org/spec/consent/list/1.0";
+
 // ─── Future slices ───────────────────────────────────────────────────────
 //
 // attestation, services, webvh, did-templates, passkey-vms, backup,
@@ -1145,6 +1172,11 @@ pub const ALL_URIS: &[&str] = &[
     // Attestation slice (REST-routed, unauthenticated)
     TASK_ATTESTATION_STATUS_1_0,
     TASK_ATTESTATION_REPORT_1_0,
+    // Consent slice
+    TASK_CONSENT_REQUEST_1_0,
+    TASK_CONSENT_DECISION_1_0,
+    TASK_CONSENT_REVOKE_1_0,
+    TASK_CONSENT_LIST_1_0,
 ];
 
 /// The subset of [`ALL_URIS`] served by **dedicated REST routes** rather than
@@ -1231,6 +1263,7 @@ mod tests {
             "https://trusttasks.org/spec/did-management/",
             "https://trusttasks.org/spec/vault/",
             "https://trusttasks.org/spec/webvh/",
+            "https://trusttasks.org/spec/consent/",
         ];
         for uri in ALL_URIS {
             assert!(

--- a/vta-service/src/consent_sweeper.rs
+++ b/vta-service/src/consent_sweeper.rs
@@ -1,0 +1,88 @@
+//! Background pruning of expired consent records.
+//!
+//! Called from the storage thread's interval loop. Removes pending consent
+//! requests that were never answered before their TTL — the main unbounded-
+//! growth risk, since `vti_common::consent::consume_pending_consent` only prunes
+//! on access — and grants whose optional TTL has lapsed. Each removal is
+//! recorded in the audit log as `consent.expire` (actor `system:sweeper`), the
+//! same trail the ACL sweeper leaves.
+
+use tracing::{debug, info, warn};
+
+use vti_common::consent::{ConsentGrant, PendingConsent};
+
+use crate::error::AppError;
+use crate::store::KeyspaceHandle;
+
+fn now_epoch() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// Sweep the consent keyspace: delete expired pending requests and lapsed
+/// grants. Audit-record failures are warn-logged but don't abort the sweep.
+pub async fn sweep_expired(
+    consent_ks: &KeyspaceHandle,
+    audit_ks: &KeyspaceHandle,
+) -> Result<(), AppError> {
+    let now = now_epoch();
+    let mut pruned = 0usize;
+
+    // Expired pending requests (raised but never answered).
+    for (key, value) in consent_ks.prefix_iter_raw("consent_pending:").await? {
+        let pending: PendingConsent = match serde_json::from_slice(&value) {
+            Ok(p) => p,
+            Err(e) => {
+                debug!(error = %e, "consent sweeper: skipping unreadable pending row");
+                continue;
+            }
+        };
+        if now >= pending.expires_at {
+            consent_ks.remove(key).await?;
+            pruned += 1;
+            audit_expire(audit_ks, &pending.subject.agent).await;
+        }
+    }
+
+    // Grants whose optional TTL has lapsed.
+    for (key, value) in consent_ks.prefix_iter_raw("grant:").await? {
+        let grant: ConsentGrant = match serde_json::from_slice(&value) {
+            Ok(g) => g,
+            Err(e) => {
+                debug!(error = %e, "consent sweeper: skipping unreadable grant row");
+                continue;
+            }
+        };
+        if grant.is_expired(now) {
+            consent_ks.remove(key).await?;
+            pruned += 1;
+            audit_expire(audit_ks, &grant.subject.agent).await;
+        }
+    }
+
+    if pruned > 0 {
+        info!(
+            consent_pruned = pruned,
+            "consent sweeper pruned expired records"
+        );
+    }
+    Ok(())
+}
+
+async fn audit_expire(audit_ks: &KeyspaceHandle, agent: &str) {
+    if let Err(e) = crate::audit::record(
+        audit_ks,
+        "consent.expire",
+        "system:sweeper",
+        Some(agent),
+        "success",
+        None,
+        None,
+    )
+    .await
+    {
+        warn!(error = %e, "consent sweeper: deletion succeeded but audit::record failed");
+    }
+}

--- a/vta-service/src/keyspaces.rs
+++ b/vta-service/src/keyspaces.rs
@@ -49,6 +49,9 @@ pub const DRAINS: &str = "drains";
 pub const SNAPSHOT: &str = "service_prev_config";
 /// KMS-protected, unencrypted boot keyspace (TEE integrity manifest, etc.).
 pub const BOOTSTRAP: &str = "bootstrap";
+/// Inbound-messaging consent: durable grants + TTL'd pending requests
+/// (`vti_common::consent`). The VTA is the first gate for bridged conversations.
+pub const CONSENT: &str = "consent";
 
 /// Every production keyspace. Partitioned by [`BACKED_UP`] +
 /// [`EXCLUDED_FROM_BACKUP`]; the [`tests::backup_partition_is_total`] guard
@@ -72,11 +75,12 @@ pub const ALL: &[&str] = &[
     DRAINS,
     SNAPSHOT,
     BOOTSTRAP,
+    CONSENT,
 ];
 
 /// Keyspaces whose contents a full `export_backup` captures (as typed
 /// collections — see `operations::backup`).
-pub const BACKED_UP: &[&str] = &[KEYS, ACL, CONTEXTS, AUDIT, IMPORTED_SECRETS, WEBVH];
+pub const BACKED_UP: &[&str] = &[KEYS, ACL, CONTEXTS, AUDIT, IMPORTED_SECRETS, WEBVH, CONSENT];
 
 /// Keyspaces deliberately **not** in a backup.
 ///

--- a/vta-service/src/lib.rs
+++ b/vta-service/src/lib.rs
@@ -18,6 +18,7 @@ pub mod auth;
 pub mod backup_bundle_store;
 pub mod backup_bundle_sweeper;
 pub mod config;
+pub mod consent_sweeper;
 pub mod contexts;
 pub mod did_templates;
 pub mod didcomm_bridge;

--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -634,6 +634,7 @@ pub async fn run(
         let sessions_ks = apply_encryption(store.keyspace(crate::keyspaces::SESSIONS)?);
         let acl_ks = apply_encryption(store.keyspace(crate::keyspaces::ACL)?);
         let audit_ks = apply_encryption(store.keyspace(crate::keyspaces::AUDIT)?);
+        let consent_ks = apply_encryption(store.keyspace(crate::keyspaces::CONSENT)?);
         let vault_ks = apply_encryption(store.keyspace(crate::keyspaces::VAULT)?);
         let backup_bundles_ks = apply_encryption(store.keyspace(crate::keyspaces::BACKUP_BUNDLES)?);
         let backup_blob_dir = config.store.data_dir.join("backups");
@@ -714,6 +715,7 @@ pub async fn run(
         let storage_sessions_ks = sessions_ks.clone();
         let storage_audit_ks = audit_ks.clone();
         let storage_acl_ks = acl_ks.clone();
+        let storage_consent_ks = consent_ks.clone();
         let storage_vault_ks = vault_ks.clone();
         let storage_backup_bundles_ks = backup_bundles_ks.clone();
         let storage_backup_blob_dir = backup_blob_dir.clone();
@@ -1017,6 +1019,7 @@ pub async fn run(
                     storage_sessions_ks,
                     storage_audit_ks,
                     storage_acl_ks,
+                    storage_consent_ks,
                     storage_vault_ks,
                     storage_backup_bundles_ks,
                     storage_backup_blob_dir,
@@ -1114,6 +1117,7 @@ fn run_storage_thread(
     sessions_ks: KeyspaceHandle,
     audit_ks: KeyspaceHandle,
     acl_ks: KeyspaceHandle,
+    consent_ks: KeyspaceHandle,
     vault_ks: KeyspaceHandle,
     backup_bundles_ks_storage: KeyspaceHandle,
     backup_blob_dir_storage: std::path::PathBuf,
@@ -1157,6 +1161,14 @@ fn run_storage_thread(
                             crate::acl_sweeper::sweep_expired(&acl_ks, &audit_ks).await
                         {
                             warn!("acl sweeper error: {e}");
+                        }
+                        // Prune expired pending consents (never answered) and
+                        // lapsed grants, so the consent keyspace can't grow
+                        // unbounded at inbound-message rate.
+                        if let Err(e) =
+                            crate::consent_sweeper::sweep_expired(&consent_ks, &audit_ks).await
+                        {
+                            warn!("consent sweeper error: {e}");
                         }
                         // Expire & retention-prune in-flight backup
                         // bundles (descriptor-pattern slice). TTL

--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -116,6 +116,8 @@ pub struct AppState {
     /// at finish.
     #[cfg(feature = "webvh")]
     pub passkey_vms_ks: KeyspaceHandle,
+    /// Inbound-messaging consent store (grants + pending requests).
+    pub consent_ks: KeyspaceHandle,
     /// Persisted drain set for the protocol-management feature
     /// (`docs/05-design-notes/didcomm-protocol-management.md`).
     /// Keyed by mediator DID; replayed at boot.
@@ -295,6 +297,7 @@ pub async fn build_app_state(
     let webvh_ks = apply_encryption(store.keyspace(crate::keyspaces::WEBVH)?);
     #[cfg(feature = "webvh")]
     let passkey_vms_ks = apply_encryption(store.keyspace(crate::keyspaces::PASSKEY_VMS)?);
+    let consent_ks = apply_encryption(store.keyspace(crate::keyspaces::CONSENT)?);
     #[cfg(feature = "webvh")]
     let drains_ks = apply_encryption(store.keyspace(crate::keyspaces::DRAINS)?);
     #[cfg(feature = "webvh")]
@@ -348,6 +351,7 @@ pub async fn build_app_state(
         webvh_ks,
         #[cfg(feature = "webvh")]
         passkey_vms_ks,
+        consent_ks,
         #[cfg(feature = "webvh")]
         drains_ks,
         #[cfg(feature = "webvh")]

--- a/vta-service/src/test_support.rs
+++ b/vta-service/src/test_support.rs
@@ -773,6 +773,7 @@ pub async fn build_test_app_with(opts: TestAppOptions) -> (axum::Router, TestApp
         imported_ks,
         cache_ks,
         vault_ks,
+        consent_ks: store.keyspace(crate::keyspaces::CONSENT).unwrap(),
         service_state_ks,
         sealed_nonces_ks,
         backup_bundles_ks: backup_bundles_ks.clone(),

--- a/vta-service/src/trust_tasks/consent.rs
+++ b/vta-service/src/trust_tasks/consent.rs
@@ -389,3 +389,67 @@ pub(super) async fn handle_list(
         .collect();
     success_response(&doc, ListResponse { grants: wire })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wire_subject_parses_camelcase_and_maps() {
+        let v = serde_json::json!({
+            "platform": "signal",
+            "conversationRef": "sig-1a2b3c4d",
+            "kind": "group",
+            "agent": "did:key:zA",
+        });
+        let s: ConsentSubject = serde_json::from_value::<WireSubject>(v).unwrap().into();
+        assert_eq!(s.conversation_ref, "sig-1a2b3c4d");
+        assert_eq!(s.kind, ConsentKind::Group);
+    }
+
+    #[test]
+    fn request_payload_parses_full_wire() {
+        let v = serde_json::json!({
+            "subject": {"platform":"signal","conversationRef":"sig-1","kind":"dm","agent":"did:key:zA"},
+            "scope": "converse",
+            "challenge": "Q29uc2VudENoYWxsZW5nZQ",
+            "displayHint": "Signal DM",
+            "contextHint": "ctx",
+        });
+        let p: RequestPayload = serde_json::from_value(v).unwrap();
+        assert_eq!(p.scope, ConsentScope::Converse);
+        assert_eq!(p.context_hint.as_deref(), Some("ctx"));
+    }
+
+    #[test]
+    fn wire_grant_serializes_camelcase() {
+        let g = ConsentGrant {
+            subject: ConsentSubject {
+                platform: "signal".into(),
+                conversation_ref: "sig-1".into(),
+                kind: ConsentKind::Dm,
+                agent: "did:key:zA".into(),
+            },
+            effect: ConsentEffect::Allow,
+            scope: Some(ConsentScope::Converse),
+            granted_by: "did:web:op".into(),
+            granted_at: 1_700_000_000, // 2023-11-14
+            expires_at: None,
+            evidence: "did-signed".into(),
+        };
+        let v = serde_json::to_value(WireGrant::from(g)).unwrap();
+        assert_eq!(v["subject"]["conversationRef"], "sig-1");
+        assert_eq!(v["effect"], "allow");
+        assert_eq!(v["scope"], "converse");
+        assert_eq!(v["grantedBy"], "did:web:op");
+        assert!(v["grantedAt"].as_str().unwrap().starts_with("2023-11"));
+        assert!(v.get("expiresAt").is_none());
+    }
+
+    #[test]
+    fn epoch_rfc3339_round_trips() {
+        let s = epoch_to_rfc3339(1_700_000_000);
+        assert_eq!(rfc3339_to_epoch(&s), Some(1_700_000_000));
+        assert_eq!(rfc3339_to_epoch("not-a-date"), None);
+    }
+}

--- a/vta-service/src/trust_tasks/consent.rs
+++ b/vta-service/src/trust_tasks/consent.rs
@@ -1,0 +1,391 @@
+//! `consent/*` slice trust-task handlers — the VTA consent store.
+//!
+//! The VTA is the first gate for inbound bridged messaging: a bridge asks
+//! whether a conversation may reach an AI agent (`consent/request`,
+//! **default-deny**); an approver decides (`consent/decision`); the grant is
+//! recorded and the bridge syncs it (`consent/list`) or it is withdrawn
+//! (`consent/revoke`). See the `consent/*` family in the dtgwg registry and
+//! `vti_common::consent`.
+//!
+//! Auth (approach A): the approver is a **context admin** (the operator), or the
+//! **enrolled bridge** relaying the operator's out-of-band choice
+//! (bridge-attested). A per-platform approver registry is a follow-up.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use trust_tasks_rs::TrustTask;
+use uuid::Uuid;
+
+use vti_common::auth::session::now_epoch;
+use vti_common::consent::{
+    ConsentEffect, ConsentGrant, ConsentKind, ConsentScope, ConsentSubject, ConsumeConsent,
+    consume_pending_consent, delete_consent_grant, get_consent_grant, list_consent_grants,
+    new_pending_consent, store_consent_grant, store_pending_consent,
+};
+use vti_common::error::AppError;
+
+use super::helpers::{TrustTaskOutcome, app_error_to_reject, parse_payload, success_response};
+use crate::auth::AuthClaims;
+use crate::server::AppState;
+
+/// How long a pending consent stays answerable.
+const PENDING_TTL_SECS: u64 = 600;
+
+// ── Wire shapes (camelCase) ──────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct WireSubject {
+    platform: String,
+    conversation_ref: String,
+    kind: ConsentKind,
+    agent: String,
+}
+
+impl From<WireSubject> for ConsentSubject {
+    fn from(w: WireSubject) -> Self {
+        ConsentSubject {
+            platform: w.platform,
+            conversation_ref: w.conversation_ref,
+            kind: w.kind,
+            agent: w.agent,
+        }
+    }
+}
+
+impl From<&ConsentSubject> for WireSubject {
+    fn from(s: &ConsentSubject) -> Self {
+        WireSubject {
+            platform: s.platform.clone(),
+            conversation_ref: s.conversation_ref.clone(),
+            kind: s.kind,
+            agent: s.agent.clone(),
+        }
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RequestPayload {
+    subject: WireSubject,
+    scope: ConsentScope,
+    challenge: String,
+    #[serde(default)]
+    context_hint: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DecisionPayload {
+    subject: WireSubject,
+    effect: ConsentEffect,
+    #[serde(default)]
+    scope: Option<ConsentScope>,
+    #[serde(default)]
+    challenge: Option<String>,
+    #[serde(default)]
+    expires_at: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RevokePayload {
+    subject: WireSubject,
+    #[serde(default)]
+    reason: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ListPayload {
+    #[serde(default)]
+    agent: Option<String>,
+    #[serde(default)]
+    platform: Option<String>,
+    #[serde(default)]
+    subject: Option<WireSubject>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AckResponse {
+    status: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    request_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    grant_id: Option<String>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct WireGrant {
+    subject: WireSubject,
+    effect: ConsentEffect,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    scope: Option<ConsentScope>,
+    granted_by: String,
+    granted_at: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    expires_at: Option<String>,
+    evidence: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ListResponse {
+    grants: Vec<WireGrant>,
+}
+
+fn epoch_to_rfc3339(secs: u64) -> String {
+    chrono::DateTime::<chrono::Utc>::from_timestamp(secs as i64, 0)
+        .unwrap_or_default()
+        .to_rfc3339()
+}
+
+fn rfc3339_to_epoch(s: &str) -> Option<u64> {
+    chrono::DateTime::parse_from_rfc3339(s)
+        .ok()
+        .map(|d| d.timestamp().max(0) as u64)
+}
+
+impl From<ConsentGrant> for WireGrant {
+    fn from(g: ConsentGrant) -> Self {
+        WireGrant {
+            subject: WireSubject::from(&g.subject),
+            effect: g.effect,
+            scope: g.scope,
+            granted_by: g.granted_by,
+            granted_at: epoch_to_rfc3339(g.granted_at),
+            expires_at: g.expires_at.map(epoch_to_rfc3339),
+            evidence: g.evidence,
+        }
+    }
+}
+
+// ── Handlers ─────────────────────────────────────────────────────────────────
+
+/// `consent/request/1.0` — a bridge asks the VTA to gate a conversation.
+/// Default-deny: if no live grant exists, a pending consent is minted for an
+/// approver to decide. Auth: an authenticated, write-capable bridge.
+pub(super) async fn handle_request(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    if let Err(e) = auth.require_write() {
+        return app_error_to_reject(&doc, e);
+    }
+    let payload: RequestPayload = match parse_payload(&doc) {
+        Ok(p) => p,
+        Err(resp) => return resp,
+    };
+    let subject: ConsentSubject = payload.subject.into();
+    let now = now_epoch();
+
+    // Already decided (allow or deny, not expired) → don't re-prompt.
+    match get_consent_grant(&state.consent_ks, &subject).await {
+        Ok(Some(g)) if !g.is_expired(now) => {
+            return success_response(
+                &doc,
+                AckResponse {
+                    status: "accepted",
+                    request_id: Some("existing-grant".to_string()),
+                    grant_id: None,
+                },
+            );
+        }
+        Ok(_) => {}
+        Err(e) => return app_error_to_reject(&doc, e),
+    }
+
+    let context = payload
+        .context_hint
+        .or_else(|| auth.default_context().map(str::to_string));
+    let pending = new_pending_consent(
+        subject,
+        payload.scope,
+        payload.challenge.clone(),
+        auth.did.clone(),
+        context,
+        PENDING_TTL_SECS,
+    );
+    if let Err(e) = store_pending_consent(&state.consent_ks, &pending).await {
+        return app_error_to_reject(&doc, e);
+    }
+    // NB (approach A): a context admin issues `consent/decision`; explicit
+    // operator-notification routing is a follow-up.
+    success_response(
+        &doc,
+        AckResponse {
+            status: "accepted",
+            request_id: Some(payload.challenge),
+            grant_id: None,
+        },
+    )
+}
+
+/// `consent/decision/1.0` — an approver allows/denies; records a grant.
+/// Auth: the enrolled bridge that requested (bridge-attested), or a context
+/// admin (operator, did-signed).
+pub(super) async fn handle_decision(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    let payload: DecisionPayload = match parse_payload(&doc) {
+        Ok(p) => p,
+        Err(resp) => return resp,
+    };
+    let subject: ConsentSubject = payload.subject.into();
+    let now = now_epoch();
+
+    // Resolve + consume the pending request this decision answers (when echoed).
+    let (evidence, scope_default, context) = if let Some(challenge) = &payload.challenge {
+        match consume_pending_consent(&state.consent_ks, challenge, now).await {
+            Ok(ConsumeConsent::Found(p)) => {
+                if p.subject != subject {
+                    return app_error_to_reject(
+                        &doc,
+                        AppError::Validation(
+                            "consent/decision: challenge does not match subject".into(),
+                        ),
+                    );
+                }
+                let is_bridge = auth.did == p.requested_by;
+                if !is_bridge {
+                    if let Err(e) = auth.require_admin() {
+                        return app_error_to_reject(&doc, e);
+                    }
+                    if let Some(ctx) = &p.context
+                        && let Err(e) = auth.require_context(ctx)
+                    {
+                        return app_error_to_reject(&doc, e);
+                    }
+                }
+                let evidence = if is_bridge {
+                    "bridge-attested"
+                } else {
+                    "did-signed"
+                };
+                (evidence, Some(p.scope), p.context.clone())
+            }
+            Ok(_) => {
+                return app_error_to_reject(
+                    &doc,
+                    AppError::Validation(
+                        "consent/decision: no pending request matches the challenge".into(),
+                    ),
+                );
+            }
+            Err(e) => return app_error_to_reject(&doc, e),
+        }
+    } else {
+        // Operator pre-authorization (no challenge): admins only.
+        if let Err(e) = auth.require_admin() {
+            return app_error_to_reject(&doc, e);
+        }
+        ("did-signed", None, None)
+    };
+    let _ = context;
+
+    let scope = match payload.effect {
+        ConsentEffect::Allow => Some(
+            payload
+                .scope
+                .or(scope_default)
+                .unwrap_or(ConsentScope::Converse),
+        ),
+        ConsentEffect::Deny => None,
+    };
+    let grant = ConsentGrant {
+        subject,
+        effect: payload.effect,
+        scope,
+        granted_by: auth.did.clone(),
+        granted_at: now,
+        expires_at: payload.expires_at.as_deref().and_then(rfc3339_to_epoch),
+        evidence: evidence.to_string(),
+    };
+    if let Err(e) = store_consent_grant(&state.consent_ks, &grant).await {
+        return app_error_to_reject(&doc, e);
+    }
+    success_response(
+        &doc,
+        AckResponse {
+            status: "recorded",
+            request_id: None,
+            grant_id: Some(format!("urn:uuid:{}", Uuid::new_v4())),
+        },
+    )
+}
+
+/// `consent/revoke/1.0` — an operator withdraws a standing grant. Auth: admin.
+pub(super) async fn handle_revoke(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    if let Err(e) = auth.require_admin() {
+        return app_error_to_reject(&doc, e);
+    }
+    let payload: RevokePayload = match parse_payload(&doc) {
+        Ok(p) => p,
+        Err(resp) => return resp,
+    };
+    let _ = &payload.reason;
+    let subject: ConsentSubject = payload.subject.into();
+    match get_consent_grant(&state.consent_ks, &subject).await {
+        Ok(Some(_)) => {}
+        Ok(None) => {
+            return app_error_to_reject(
+                &doc,
+                AppError::NotFound("consent/revoke: no grant for subject".into()),
+            );
+        }
+        Err(e) => return app_error_to_reject(&doc, e),
+    }
+    if let Err(e) = delete_consent_grant(&state.consent_ks, &subject).await {
+        return app_error_to_reject(&doc, e);
+    }
+    success_response(
+        &doc,
+        AckResponse {
+            status: "revoked",
+            request_id: None,
+            grant_id: None,
+        },
+    )
+}
+
+/// `consent/list/1.0` — a bridge syncs the grants it enforces. Auth: read.
+pub(super) async fn handle_list(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    if let Err(e) = auth.require_read() {
+        return app_error_to_reject(&doc, e);
+    }
+    let payload: ListPayload = match parse_payload(&doc) {
+        Ok(p) => p,
+        Err(resp) => return resp,
+    };
+    let subject_filter: Option<ConsentSubject> = payload.subject.map(Into::into);
+    let grants = match list_consent_grants(&state.consent_ks).await {
+        Ok(g) => g,
+        Err(e) => return app_error_to_reject(&doc, e),
+    };
+    let wire: Vec<WireGrant> = grants
+        .into_iter()
+        .filter(|g| payload.agent.as_ref().is_none_or(|a| &g.subject.agent == a))
+        .filter(|g| {
+            payload
+                .platform
+                .as_ref()
+                .is_none_or(|p| &g.subject.platform == p)
+        })
+        .filter(|g| subject_filter.as_ref().is_none_or(|s| &g.subject == s))
+        .map(WireGrant::from)
+        .collect();
+    success_response(&doc, ListResponse { grants: wire })
+}

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -49,6 +49,7 @@ mod audit;
 mod auth;
 mod backup;
 mod config;
+mod consent;
 mod contexts;
 mod credential_exchange;
 mod device;
@@ -387,6 +388,11 @@ dispatch_table! {
         | vta_sdk::trust_tasks::TASK_AUTH_STEP_UP_APPROVE_RESPONSE_0_2
         => step_up::handle_approve_response,
     vta_sdk::trust_tasks::TASK_AUTH_STEP_UP_POLICY_0_2 => step_up_policy::handle_set_step_up_policy,
+    // ─── Consent slice ────────────────────────────────────────────
+    vta_sdk::trust_tasks::TASK_CONSENT_REQUEST_1_0 => consent::handle_request,
+    vta_sdk::trust_tasks::TASK_CONSENT_DECISION_1_0 => consent::handle_decision,
+    vta_sdk::trust_tasks::TASK_CONSENT_REVOKE_1_0 => consent::handle_revoke,
+    vta_sdk::trust_tasks::TASK_CONSENT_LIST_1_0 => consent::handle_list,
     // ─── ACL slice ────────────────────────────────────────────────
     vta_sdk::trust_tasks::TASK_ACL_LIST_1_0 => acl::handle_list,
     vta_sdk::trust_tasks::TASK_ACL_CREATE_1_0 => acl::handle_create,

--- a/vti-common/src/consent.rs
+++ b/vti-common/src/consent.rs
@@ -206,6 +206,8 @@ pub fn new_pending_consent(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::StoreConfig;
+    use crate::store::Store;
 
     fn subject() -> ConsentSubject {
         ConsentSubject {
@@ -214,6 +216,99 @@ mod tests {
             kind: ConsentKind::Group,
             agent: "did:key:z6MkAgent".into(),
         }
+    }
+
+    async fn ks() -> KeyspaceHandle {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let dir = Box::leak(Box::new(dir)); // outlive the test
+        let store = Store::open(&StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        })
+        .expect("open store");
+        store.keyspace("consent").expect("keyspace")
+    }
+
+    fn grant(effect: ConsentEffect) -> ConsentGrant {
+        ConsentGrant {
+            subject: subject(),
+            effect,
+            scope: matches!(effect, ConsentEffect::Allow).then_some(ConsentScope::Converse),
+            granted_by: "did:web:operator".into(),
+            granted_at: 1_000,
+            expires_at: None,
+            evidence: "bridge-attested".into(),
+        }
+    }
+
+    #[tokio::test]
+    async fn grant_store_get_delete_round_trip() {
+        let ks = ks().await;
+        // Default-deny: nothing stored yet.
+        assert!(get_consent_grant(&ks, &subject()).await.unwrap().is_none());
+
+        let g = grant(ConsentEffect::Allow);
+        store_consent_grant(&ks, &g).await.unwrap();
+        assert_eq!(get_consent_grant(&ks, &subject()).await.unwrap(), Some(g));
+
+        delete_consent_grant(&ks, &subject()).await.unwrap();
+        assert!(get_consent_grant(&ks, &subject()).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn list_returns_all_grants() {
+        let ks = ks().await;
+        store_consent_grant(&ks, &grant(ConsentEffect::Allow))
+            .await
+            .unwrap();
+        let mut other = grant(ConsentEffect::Deny);
+        other.subject.conversation_ref = "sig-99999999".into();
+        store_consent_grant(&ks, &other).await.unwrap();
+        assert_eq!(list_consent_grants(&ks).await.unwrap().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn pending_consume_is_single_use_and_ttl_aware() {
+        let ks = ks().await;
+        let p = new_pending_consent(
+            subject(),
+            ConsentScope::Converse,
+            "chal-1",
+            "did:webvh:bridge",
+            None,
+            300,
+        );
+        store_pending_consent(&ks, &p).await.unwrap();
+
+        // Live match → Found, and consumed (single-use).
+        match consume_pending_consent(&ks, "chal-1", p.created_at + 1)
+            .await
+            .unwrap()
+        {
+            ConsumeConsent::Found(found) => assert_eq!(found.subject, subject()),
+            other => panic!("expected Found, got {other:?}"),
+        }
+        assert_eq!(
+            consume_pending_consent(&ks, "chal-1", p.created_at + 1)
+                .await
+                .unwrap(),
+            ConsumeConsent::NotFound,
+        );
+
+        // Expired match → Expired (and still removed).
+        let p2 = new_pending_consent(subject(), ConsentScope::Receive, "chal-2", "b", None, 10);
+        store_pending_consent(&ks, &p2).await.unwrap();
+        assert_eq!(
+            consume_pending_consent(&ks, "chal-2", p2.expires_at + 1)
+                .await
+                .unwrap(),
+            ConsumeConsent::Expired,
+        );
+        assert_eq!(
+            consume_pending_consent(&ks, "chal-2", p2.expires_at + 1)
+                .await
+                .unwrap(),
+            ConsumeConsent::NotFound,
+        );
     }
 
     #[test]

--- a/vti-common/src/consent.rs
+++ b/vti-common/src/consent.rs
@@ -1,0 +1,267 @@
+//! Consent store — records + KV helpers for VTA-gated inbound messaging.
+//!
+//! Generic across platforms / agents / interaction kinds (see the `consent/*`
+//! Trust Task family). A messaging bridge asks the VTA to gate a conversation
+//! (**default-deny**); an approver's decision is recorded as a [`ConsentGrant`]
+//! the bridge then enforces. The pending-request store mirrors the step-up
+//! pattern in [`crate::auth::step_up`] (challenge-keyed, single-use, TTL'd).
+
+use serde::{Deserialize, Serialize};
+
+use crate::auth::session::now_epoch;
+use crate::error::AppError;
+use crate::store::KeyspaceHandle;
+
+/// Interaction kind — a 1:1 DM, a multi-party group, or a broadcast channel.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ConsentKind {
+    Dm,
+    Group,
+    Channel,
+}
+
+/// What the agent may do on a conversation: read inbound, or read and reply.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ConsentScope {
+    Receive,
+    Converse,
+}
+
+/// Allow or deny. The ABSENCE of a grant is treated as deny (default-deny).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ConsentEffect {
+    Allow,
+    Deny,
+}
+
+/// Platform-agnostic identifier of WHAT consent is about: one conversation, for
+/// one agent. `conversation_ref` is the bridge's OPAQUE handle — never a raw
+/// platform address.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConsentSubject {
+    pub platform: String,
+    pub conversation_ref: String,
+    pub kind: ConsentKind,
+    pub agent: String,
+}
+
+impl ConsentSubject {
+    /// Storage key for a grant over this subject. Unit-separator (`\x1f`) joined
+    /// so the colons in `agent` (a DID) can't collide with the field delimiter.
+    fn grant_key(&self) -> String {
+        format!(
+            "grant:{}\u{1f}{}\u{1f}{}",
+            self.platform, self.conversation_ref, self.agent
+        )
+    }
+}
+
+/// A recorded consent decision over a [`ConsentSubject`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConsentGrant {
+    pub subject: ConsentSubject,
+    pub effect: ConsentEffect,
+    /// Granted scope; present when `effect == Allow`.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub scope: Option<ConsentScope>,
+    /// VID of the approver who made the decision.
+    pub granted_by: String,
+    pub granted_at: u64,
+    /// Optional TTL; after this the grant lapses and the subject re-consents.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub expires_at: Option<u64>,
+    /// How the decision was authorized, e.g. `"did-signed"` | `"bridge-attested"`.
+    pub evidence: String,
+}
+
+impl ConsentGrant {
+    pub fn is_expired(&self, now: u64) -> bool {
+        self.expires_at.is_some_and(|e| now >= e)
+    }
+
+    /// Effective allow: an `allow` grant that has not expired.
+    pub fn allows(&self, now: u64) -> bool {
+        self.effect == ConsentEffect::Allow && !self.is_expired(now)
+    }
+}
+
+/// A pending consent request awaiting an approver decision. Keyed by challenge,
+/// single-use, TTL'd — mirrors [`crate::auth::step_up::PendingStepUp`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PendingConsent {
+    pub subject: ConsentSubject,
+    pub scope: ConsentScope,
+    pub challenge: String,
+    /// The bridge DID that raised the request.
+    pub requested_by: String,
+    /// The VTA context the subject was scoped to (drives approver resolution).
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub context: Option<String>,
+    pub created_at: u64,
+    pub expires_at: u64,
+}
+
+fn pending_key(challenge: &str) -> String {
+    format!("consent_pending:{challenge}")
+}
+
+/// Outcome of consuming a pending consent by challenge.
+#[derive(Debug, PartialEq)]
+pub enum ConsumeConsent {
+    NotFound,
+    Expired,
+    Found(Box<PendingConsent>),
+}
+
+// ── Grants ───────────────────────────────────────────────────────────────────
+
+/// Store (upsert) a consent grant keyed by its subject.
+pub async fn store_consent_grant(
+    ks: &KeyspaceHandle,
+    grant: &ConsentGrant,
+) -> Result<(), AppError> {
+    ks.insert(grant.subject.grant_key(), grant).await
+}
+
+/// Read the grant for a subject, if any.
+pub async fn get_consent_grant(
+    ks: &KeyspaceHandle,
+    subject: &ConsentSubject,
+) -> Result<Option<ConsentGrant>, AppError> {
+    ks.get(subject.grant_key()).await
+}
+
+/// Delete the grant for a subject (revert to default-deny).
+pub async fn delete_consent_grant(
+    ks: &KeyspaceHandle,
+    subject: &ConsentSubject,
+) -> Result<(), AppError> {
+    ks.remove(subject.grant_key()).await
+}
+
+/// All grants. Callers filter by agent / platform / subject in memory.
+pub async fn list_consent_grants(ks: &KeyspaceHandle) -> Result<Vec<ConsentGrant>, AppError> {
+    let rows = ks.prefix_iter_raw("grant:").await?;
+    let mut out = Vec::with_capacity(rows.len());
+    for (_key, value) in rows {
+        match serde_json::from_slice::<ConsentGrant>(&value) {
+            Ok(g) => out.push(g),
+            Err(e) => tracing::warn!(error = %e, "skipping undeserializable consent grant"),
+        }
+    }
+    Ok(out)
+}
+
+// ── Pending ──────────────────────────────────────────────────────────────────
+
+/// Store a pending consent keyed by its challenge.
+pub async fn store_pending_consent(
+    ks: &KeyspaceHandle,
+    pending: &PendingConsent,
+) -> Result<(), AppError> {
+    ks.insert(pending_key(&pending.challenge), pending).await
+}
+
+/// Locate and **consume** the pending consent matching `challenge` (single-use).
+pub async fn consume_pending_consent(
+    ks: &KeyspaceHandle,
+    challenge: &str,
+    now: u64,
+) -> Result<ConsumeConsent, AppError> {
+    let key = pending_key(challenge);
+    let Some(pending): Option<PendingConsent> = ks.get(key.clone()).await? else {
+        return Ok(ConsumeConsent::NotFound);
+    };
+    ks.remove(key).await?; // single-use, live or expired
+    if now >= pending.expires_at {
+        return Ok(ConsumeConsent::Expired);
+    }
+    Ok(ConsumeConsent::Found(Box::new(pending)))
+}
+
+/// Build a pending consent expiring `ttl_secs` from now.
+pub fn new_pending_consent(
+    subject: ConsentSubject,
+    scope: ConsentScope,
+    challenge: impl Into<String>,
+    requested_by: impl Into<String>,
+    context: Option<String>,
+    ttl_secs: u64,
+) -> PendingConsent {
+    let created_at = now_epoch();
+    PendingConsent {
+        subject,
+        scope,
+        challenge: challenge.into(),
+        requested_by: requested_by.into(),
+        context,
+        created_at,
+        expires_at: created_at + ttl_secs,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn subject() -> ConsentSubject {
+        ConsentSubject {
+            platform: "signal".into(),
+            conversation_ref: "sig-1a2b3c4d".into(),
+            kind: ConsentKind::Group,
+            agent: "did:key:z6MkAgent".into(),
+        }
+    }
+
+    #[test]
+    fn allow_grant_is_effective_until_expiry() {
+        let g = ConsentGrant {
+            subject: subject(),
+            effect: ConsentEffect::Allow,
+            scope: Some(ConsentScope::Converse),
+            granted_by: "did:web:operator".into(),
+            granted_at: 1_000,
+            expires_at: Some(2_000),
+            evidence: "bridge-attested".into(),
+        };
+        assert!(g.allows(1_500));
+        assert!(!g.allows(2_000)); // expired
+        let deny = ConsentGrant {
+            effect: ConsentEffect::Deny,
+            scope: None,
+            ..g.clone()
+        };
+        assert!(!deny.allows(1_500));
+    }
+
+    #[test]
+    fn pending_ttl_is_set_from_now() {
+        let p = new_pending_consent(
+            subject(),
+            ConsentScope::Converse,
+            "chal",
+            "did:webvh:bridge",
+            Some("ctx".into()),
+            300,
+        );
+        assert_eq!(p.expires_at, p.created_at + 300);
+    }
+
+    #[test]
+    fn grant_round_trips_through_json() {
+        let g = ConsentGrant {
+            subject: subject(),
+            effect: ConsentEffect::Allow,
+            scope: Some(ConsentScope::Receive),
+            granted_by: "did:web:operator".into(),
+            granted_at: 42,
+            expires_at: None,
+            evidence: "did-signed".into(),
+        };
+        let s = serde_json::to_string(&g).unwrap();
+        assert_eq!(serde_json::from_str::<ConsentGrant>(&s).unwrap(), g);
+    }
+}

--- a/vti-common/src/lib.rs
+++ b/vti-common/src/lib.rs
@@ -2,6 +2,7 @@ pub mod acl;
 pub mod audit;
 pub mod auth;
 pub mod config;
+pub mod consent;
 pub mod context_path;
 pub mod error;
 pub mod idempotency;


### PR DESCRIPTION
## Summary

Phase 2 of VTA-gated inbound messaging consent: makes the **VTA the first gate** for bridged conversations. A messaging bridge asks whether a conversation may reach an AI agent (**default-deny**); an approver decides; the grant is recorded and the bridge enforces it. Generic across platforms (Signal/WhatsApp/Slack/…), agents, and interaction kinds (DM/group/channel).

Builds on the `consent/*` Trust Task family (trustoverip/dtgwg-trust-tasks-tf#90) and the design in `affinidi/vti-message-bridge` `docs/design-consent.md`.

## What's here (4 commits)

- **`vta-sdk`** — 4 `TASK_CONSENT_*` URI constants (in `ALL_URIS` + namespace allowlist) + `VtaClient` client wrappers (`consent_request`/`decision`/`revoke`/`list`).
- **`vti-common`** — `ConsentSubject` / `ConsentGrant` / `PendingConsent` records + KV store helpers (grant get/store/list/delete; pending store/consume, single-use + TTL'd), mirroring the step-up pattern. `conversation_ref` is opaque — the VTA never sees a raw address.
- **`vta-service`** — `CONSENT` keyspace (backed-up) + `AppState` wiring + `consent.rs` handlers (`request`/`decision`/`revoke`/`list`) in `dispatch_table!` + a pending/grant sweeper on the storage thread (audited as `consent.expire`).

### Auth (approach A)
The approver is a **context admin** (the operator), or the **enrolled bridge** relaying the operator's out-of-band choice (recorded as `evidence: "bridge-attested"` vs `"did-signed"`). A per-platform approver registry is a documented follow-up.

## Testing
- vti-common: store round-trips + pending single-use/TTL against a real keyspace.
- vta-service: wire-contract tests (camelCase ↔ types, enum values, RFC-3339) + the dispatch-parity harness stays green.
- **vta-sdk 135 / vti-common 254 / vta-service trust_tasks 35** pass; fmt + clippy + full build clean.

## Notes
- A `chore(release)` version bump will be needed at merge (repo release pattern) — this branch deliberately doesn't touch versions.
- Phase 3 (the bridge PEP — `ConsentGate` at the inbound chokepoint, hold/release via the durable queue, BridgeRelay decision through the approval cards) consumes the `vta-sdk` consent wrappers added here, so it needs a `vta-sdk` release first.