### PR TITLE
chore(deps): upgrade affinidi-tdk to 0.8 + supporting crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -525,6 +525,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "affinidi-openid4vci"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "757d7cec6db211521d27d3dc75397d674b525fefd0b62c7e6648267aa59efcc4"
+dependencies = [
+ "affinidi-oid4vc-core",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "affinidi-openid4vp"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -568,16 +582,11 @@ dependencies = [
 
 [[package]]
 name = "affinidi-sd-jwt-vc"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c85a1cd2ffb74ee591912a8145f5a83369d2a25aaec2a15163664e15fba6538"
+checksum = "e8c9b05d34d0456f24d858fb346c4e78953da8235618819396eb9987d6e700f7"
 dependencies = [
- "affinidi-sd-jwt",
- "chrono",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "tracing",
+ "affinidi-vc",
 ]
 
 [[package]]
@@ -666,14 +675,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8dff9659362f202835bb155bc7b4c86fe80bc2ad0f1a20b60159338da58cec9c"
 dependencies = [
  "affinidi-crypto",
+ "affinidi-data-integrity",
  "affinidi-did-authentication",
  "affinidi-did-common",
  "affinidi-did-resolver-cache-sdk",
+ "affinidi-meeting-place",
  "affinidi-messaging-didcomm",
+ "affinidi-messaging-sdk",
  "affinidi-secrets-resolver",
  "affinidi-tdk-common",
  "clap",
  "rustls 0.23.40",
+ "serde",
  "serde_json",
  "tokio",
  "tracing",
@@ -711,10 +724,11 @@ dependencies = [
 
 [[package]]
 name = "affinidi-vc"
-version = "0.1.2"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64d37a13101e2361c97cb3059a2b2a200c679274dabc91467ebd92a0a33a1641"
+checksum = "d75626e13a4a50b07b4707f5c88683d9e30917e99f265f62c1f0bc1c34ba7771"
 dependencies = [
+ "affinidi-sd-jwt",
  "chrono",
  "serde",
  "serde_json",
@@ -2413,7 +2427,7 @@ checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cnm-cli"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "clap",
@@ -2427,7 +2441,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.16.1",
+ "vta-sdk 0.17.0",
 ]
 
 [[package]]
@@ -3184,10 +3198,10 @@ dependencies = [
 
 [[package]]
 name = "didcomm-test"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
- "affinidi-tdk 0.7.4",
+ "affinidi-tdk 0.8.3",
  "clap",
  "ed25519-dalek",
  "ed25519-dalek-bip32",
@@ -3197,7 +3211,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.16.1",
+ "vta-sdk 0.17.0",
 ]
 
 [[package]]
@@ -6662,7 +6676,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "pnm-cli"
-version = "0.9.6"
+version = "0.9.7"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-resolver-cache-sdk",
@@ -6684,7 +6698,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.16.1",
+ "vta-sdk 0.17.0",
 ]
 
 [[package]]
@@ -9932,7 +9946,7 @@ dependencies = [
 
 [[package]]
 name = "vta-cli-common"
-version = "0.9.6"
+version = "0.9.7"
 dependencies = [
  "aes-gcm",
  "affinidi-crypto",
@@ -9950,7 +9964,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.16.1",
+ "vta-sdk 0.17.0",
  "vti-common",
  "x25519-dalek",
 ]
@@ -9972,7 +9986,7 @@ dependencies = [
 
 [[package]]
 name = "vta-mcp"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -9983,12 +9997,12 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.16.1",
+ "vta-sdk 0.17.0",
 ]
 
 [[package]]
 name = "vta-mobile-core"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -10006,7 +10020,7 @@ dependencies = [
  "tracing-subscriber",
  "trust-tasks-rs",
  "uniffi",
- "vta-sdk 0.16.1",
+ "vta-sdk 0.17.0",
 ]
 
 [[package]]
@@ -10018,7 +10032,7 @@ dependencies = [
  "affinidi-crypto",
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-didcomm",
- "affinidi-openid4vci",
+ "affinidi-openid4vci 0.1.3",
  "affinidi-openid4vp",
  "affinidi-tdk 0.7.4",
  "base64 0.22.1",
@@ -10041,19 +10055,19 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
  "affinidi-data-integrity",
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-didcomm",
- "affinidi-openid4vci",
+ "affinidi-openid4vci 0.2.1",
  "affinidi-openid4vp",
  "affinidi-sd-jwt",
  "affinidi-sd-jwt-vc",
  "affinidi-secrets-resolver",
- "affinidi-tdk 0.7.4",
+ "affinidi-tdk 0.8.3",
  "affinidi-vc",
  "apple-native-keyring-store",
  "arbitrary",
@@ -10097,7 +10111,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.9.9"
+version = "0.9.10"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",
@@ -10107,13 +10121,13 @@ dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-didcomm",
  "affinidi-messaging-didcomm-service",
- "affinidi-openid4vci",
+ "affinidi-openid4vci 0.2.1",
  "affinidi-openid4vp",
  "affinidi-sd-jwt",
  "affinidi-sd-jwt-vc",
  "affinidi-secrets-resolver",
  "affinidi-status-list",
- "affinidi-tdk 0.7.4",
+ "affinidi-tdk 0.8.3",
  "affinidi-tdk-common",
  "argon2",
  "async-trait",
@@ -10172,7 +10186,7 @@ dependencies = [
  "utoipa-axum",
  "uuid",
  "vta-cli-common",
- "vta-sdk 0.16.1",
+ "vta-sdk 0.17.0",
  "vta-service",
  "vti-common",
  "vti-secrets",
@@ -10186,7 +10200,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-service"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",
@@ -10196,12 +10210,12 @@ dependencies = [
  "affinidi-messaging-didcomm",
  "affinidi-messaging-didcomm-service",
  "affinidi-messaging-test-mediator",
- "affinidi-openid4vci",
+ "affinidi-openid4vci 0.2.1",
  "affinidi-openid4vp",
  "affinidi-sd-jwt",
  "affinidi-secrets-resolver",
  "affinidi-status-list",
- "affinidi-tdk 0.7.4",
+ "affinidi-tdk 0.8.3",
  "affinidi-vc",
  "argon2",
  "async-trait",
@@ -10251,7 +10265,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.16.1",
+ "vta-sdk 0.17.0",
  "vtc-service",
  "vti-common",
  "vti-secrets",
@@ -10264,11 +10278,11 @@ dependencies = [
 
 [[package]]
 name = "vti-common"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [
  "aes-gcm",
  "affinidi-did-resolver-cache-sdk",
- "affinidi-tdk 0.7.4",
+ "affinidi-tdk 0.8.3",
  "async-trait",
  "axum",
  "axum-extra",
@@ -10299,7 +10313,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.16.1",
+ "vta-sdk 0.17.0",
  "webauthn-rs",
  "zeroize",
 ]
@@ -10313,7 +10327,7 @@ dependencies = [
  "affinidi-messaging-sdk",
  "affinidi-messaging-test-mediator",
  "affinidi-secrets-resolver",
- "affinidi-tdk 0.7.4",
+ "affinidi-tdk 0.8.3",
  "chrono",
  "ed25519-dalek",
  "multibase",
@@ -10326,14 +10340,14 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.16.1",
+ "vta-sdk 0.17.0",
  "vta-service",
  "vti-common",
 ]
 
 [[package]]
 name = "vti-secrets"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "aws-config",
  "aws-sdk-secretsmanager",
@@ -10355,7 +10369,7 @@ dependencies = [
  "tokio",
  "tracing",
  "vaultrs",
- "vta-sdk 0.16.1",
+ "vta-sdk 0.17.0",
  "vti-common",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ repository = "https://github.com/OpenVTC/verifiable-trust-infrastructure"
 uniffi = "0.28"
 
 # Affinidi Trust Development Kit
-affinidi-tdk = "0.7"
+affinidi-tdk = "0.8"
 # Raw crypto primitives (ed25519↔x25519 conversion, did:key helpers). Pulled
 # directly so sealed-transfer can use `affinidi_crypto::did_key::*` without
 # going through the higher-level Secret wrapper in secrets-resolver.
@@ -62,7 +62,7 @@ affinidi-crypto = "0.2"
 # W3C VC Data Model 2.0 + Data Integrity proofs. Used by the
 # provision-integration flow (VP-framed bootstrap request, VC-issued
 # admin authorization). See CLAUDE.md "Authorization claims" principle.
-affinidi-vc = "0.1"
+affinidi-vc = "0.2"
 affinidi-data-integrity = "0.7"
 affinidi-status-list = "0.1.3"
 
@@ -82,11 +82,11 @@ affinidi-status-list = "0.1.3"
 # BBS proof path is wired. If you path-override these to the local TDK for an
 # unreleased change (e.g. DCQL), override the whole interdependent set together
 # to avoid a duplicate-version split.
-affinidi-sd-jwt-vc = "0.1.1"
+affinidi-sd-jwt-vc = "0.2"
 affinidi-sd-jwt = "0.1.2"
 affinidi-bbs = "0.3"
 affinidi-openid4vp = "0.1.2"
-affinidi-openid4vci = "0.1.2"
+affinidi-openid4vci = "0.2"
 affinidi-secrets-resolver = "0.5"
 affinidi-messaging-didcomm-service = "0.3"
 

--- a/cnm-cli/Cargo.toml
+++ b/cnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cnm-cli"
 description = "CLI Tool for Verified Trust Agents operating in Verified Trust Communities"
-version = "0.10.3"
+version = "0.10.4"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -21,7 +21,7 @@ config-session = ["vta-sdk/config-session"]
 azure-secrets = ["vta-sdk/azure-secrets"]
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.16", features = ["session", "crypto-provider"] }
+vta-sdk = { path = "../vta-sdk", version = "0.17", features = ["session", "crypto-provider"] }
 vta-cli-common = { path = "../vta-cli-common", version = "0.9" }
 affinidi-did-resolver-cache-sdk = { workspace = true }
 clap = { workspace = true, features = ["env"] }

--- a/didcomm-test/Cargo.toml
+++ b/didcomm-test/Cargo.toml
@@ -2,7 +2,7 @@
 name = "didcomm-test"
 description = "Standalone DIDComm connectivity test — mimics VTA TEE key + messaging flow"
 readme = "README.md"
-version = "0.6.6"
+version = "0.6.7"
 edition.workspace = true
 publish = false
 rust-version.workspace = true
@@ -13,7 +13,7 @@ name = "didcomm-test"
 path = "src/main.rs"
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.16", features = ["didcomm", "crypto-provider"] }
+vta-sdk = { path = "../vta-sdk", version = "0.17", features = ["didcomm", "crypto-provider"] }
 affinidi-tdk = { workspace = true }
 affinidi-did-resolver-cache-sdk = { workspace = true }
 tokio = { workspace = true }

--- a/pnm-cli/Cargo.toml
+++ b/pnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pnm-cli"
 description = "CLI Tool for managing a personal Verifiable Trust Agent"
-version = "0.9.6"
+version = "0.9.7"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -21,7 +21,7 @@ config-session = ["vta-sdk/config-session"]
 azure-secrets = ["vta-sdk/azure-secrets"]
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.16", features = ["session", "sealed-transfer", "attest-verify", "provision-integration", "crypto-provider"] }
+vta-sdk = { path = "../vta-sdk", version = "0.17", features = ["session", "sealed-transfer", "attest-verify", "provision-integration", "crypto-provider"] }
 affinidi-crypto = { workspace = true }
 base64 = { workspace = true }
 reqwest = { workspace = true }

--- a/vta-cli-common/Cargo.toml
+++ b/vta-cli-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-cli-common"
 description = "Shared CLI command handlers and rendering helpers for VTA CLIs"
 readme = "README.md"
-version = "0.9.6"
+version = "0.9.7"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -11,7 +11,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.16", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.17", features = [
   "client",
   "sealed-transfer",
   "provision-integration",

--- a/vta-mcp/Cargo.toml
+++ b/vta-mcp/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-mcp"
 description = "Model Context Protocol (MCP) server exposing a VTA's agent capabilities as tools"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -10,7 +10,7 @@ repository.workspace = true
 publish = false
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.16", features = ["client", "session", "sealed-transfer", "didcomm", "vp", "crypto-provider"] }
+vta-sdk = { path = "../vta-sdk", version = "0.17", features = ["client", "session", "sealed-transfer", "didcomm", "vp", "crypto-provider"] }
 rmcp = { version = "1.7", features = ["server", "transport-io", "macros", "schemars"] }
 schemars = "1"
 tokio = { workspace = true }

--- a/vta-mobile-core/Cargo.toml
+++ b/vta-mobile-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vta-mobile-core"
-version = "0.6.6"
+version = "0.6.7"
 description = "UniFFI engine for the VTA mobile agent (Android/iOS): DIDComm, Trust Tasks, AAL step-up."
 edition.workspace = true
 # Not a crates.io library — the published artifacts are the Android AAR
@@ -61,7 +61,7 @@ affinidi-messaging-didcomm = "0.15"
 # `vta-sdk::DIDCommSession` (connect + receive_next) so the mobile approver can
 # pull VTA-pushed step-up approve-requests off the mediator — reusing the SDK
 # the VTA uses rather than reimplementing the affinidi mediator protocol.
-vta-sdk = { path = "../vta-sdk", version = "0.16", features = ["session"] }
+vta-sdk = { path = "../vta-sdk", version = "0.17", features = ["session"] }
 # iOS has no native trust store that `rustls-native-certs` can read, so the
 # mediator WebSocket (tokio-tungstenite, via affinidi-messaging-sdk) fails with
 # "no native root CA certificates found". Declaring tokio-tungstenite here with

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.16.1"
+version = "0.17.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.9.9"
+version = "0.9.10"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -85,7 +85,7 @@ vti-common = { path = "../vti-common", version = "0.10", features = ["encryption
 # from this crate into a shared crate so external integrations can reuse them).
 # Per-backend features are activated by this crate's matching features below.
 vti-secrets = { path = "../vti-secrets", version = "0.1" }
-vta-sdk = { path = "../vta-sdk", version = "0.16", features = ["didcomm", "sealed-transfer", "provision-integration", "openapi", "crypto-provider"] }
+vta-sdk = { path = "../vta-sdk", version = "0.17", features = ["didcomm", "sealed-transfer", "provision-integration", "openapi", "crypto-provider"] }
 # DID-VM-resolved WebAuthn assertion verifier — drives the new
 # `vta/auth/passkey-login-{start,finish}/1.0` trust-task handlers.
 # Distinct from `webauthn-rs` (which drives the passkey *enrolment*
@@ -241,7 +241,7 @@ vta-service = { path = ".", features = ["test-support"] }
 # `provision_admin_rotated_via_rest` + DI-signed REST auth) the `MockVta`
 # bootstrap→provision e2e tests drive (issues #406, DI-auth follow-up). Kept out
 # of the production `vta-sdk` dep above so the server build stays lean.
-vta-sdk = { path = "../vta-sdk", version = "0.16", features = ["provision-client"] }
+vta-sdk = { path = "../vta-sdk", version = "0.17", features = ["provision-client"] }
 # Mock HTTP server for the did-hosting-daemon REST auth flow tests. Each
 # test spins up a real local server bound to a random port, validates
 # the JWS-signed request bodies the daemon would see, and serves

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.9.7"
+version = "0.9.8"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -97,7 +97,7 @@ vti-common = { path = "../vti-common", version = "0.10", features = [
 # factory + `*SecretStore` names are a thin facade over these). Per-backend
 # features are activated by this crate's matching features above.
 vti-secrets = { path = "../vti-secrets", version = "0.1" }
-vta-sdk = { path = "../vta-sdk", version = "0.16", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.17", features = [
   "didcomm",
   "session",
   "config-session",

--- a/vti-common/Cargo.toml
+++ b/vti-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-common"
 description = "Shared server-side infrastructure for VTA and VTC services"
 readme = "README.md"
-version = "0.10.7"
+version = "0.10.8"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -48,7 +48,7 @@ openapi = ["dep:utoipa", "dep:utoipa-axum"]
 # `default-features = false` skips the optional client transports
 # (didcomm, sealed-transfer, etc.); we only consume the type
 # definitions in the default feature set.
-vta-sdk = { path = "../vta-sdk", version = "0.16", default-features = false }
+vta-sdk = { path = "../vta-sdk", version = "0.17", default-features = false }
 async-trait = "0.1"
 axum = { workspace = true }
 axum-extra = { workspace = true }

--- a/vti-secrets/Cargo.toml
+++ b/vti-secrets/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-secrets"
 description = "Pluggable secret-store backends + integration onboarding flow for Verifiable Trust Infrastructure"
 readme = "README.md"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -54,7 +54,7 @@ tracing = { workspace = true }
 tokio = { workspace = true }
 
 # Onboarding feature: the SDK session/auth state machine + local did:key mint.
-vta-sdk = { path = "../vta-sdk", version = "0.16", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.17", features = [
   "session",
 ], optional = true }
 ed25519-dalek = { workspace = true, optional = true }


### PR DESCRIPTION
## What

Upgrade the Affinidi crate stack to latest for the VTA, and bump our own crate versions accordingly.

### Dependency bumps (workspace `Cargo.toml`)

Four **breaking** 0.x minor bumps pinned up; the rest were already in-range and refreshed to latest via `cargo update`:

| Crate | Old → New |
|---|---|
| affinidi-tdk | 0.7 → **0.8.3** ⚠️ |
| affinidi-vc | 0.1 → **0.2.1** ⚠️ |
| affinidi-sd-jwt-vc | 0.1.1 → **0.2.0** ⚠️ |
| affinidi-openid4vci | 0.1.2 → **0.2.1** ⚠️ |
| affinidi-crypto 0.2.2 · data-integrity 0.7.6 · tdk-common 0.6.5 · secrets-resolver 0.5.8 · messaging-didcomm 0.15.3 · messaging-didcomm-service 0.3.6 · did-resolver-cache 0.8.11 · status-list 0.1.4 · sd-jwt 0.1.4 · bbs 0.3.2 · openid4vp 0.1.3 | compatible |

**No source changes were required** — the breaking bumps did not touch any API the workspace uses. Our VTA stack now resolves to `affinidi-tdk 0.8.3`; the prior 0.7.4/0.8.3 split collapses for our crates (0.7.4 survives only in the published-`vta-sdk`-0.13.2 e2e test subtree, which is isolated).

### Crate version bumps

`affinidi-openid4vci` types are **public struct fields** in `vta-sdk` (`OfferBody`/`RequestBody`/`IssueBody`), so the breaking dep bump is a breaking change to vta-sdk's public API → **minor** bump, cascading per the #520/#521 precedent.

- **vta-sdk 0.16.0 → 0.17.0** (breaking public dep)
- Cascade (`vta-sdk` pin 0.16 → 0.17 + own patch bump): vti-common 0.10.8, vti-secrets 0.1.4, vta-cli-common 0.9.7, vta-service 0.9.10, vtc-service 0.9.8, pnm-cli 0.9.7, cnm-cli 0.10.4, vta-mcp 0.1.4, vta-mobile-core 0.6.7, didcomm-test 0.6.7
- **vta-enclave unchanged** (pins `vta-service "0.9"` / `vti-common "0.10"`, both within minor, no vta-sdk pin); tests/e2e and fuzz use path-only pins.

## Testing

- `cargo check --workspace --all-targets` (incl. the `bbs` feature) — clean
- `cargo metadata` resolves the full member graph