### PR TITLE
feat(vtc): VIC follow-ups — role-on-invite, revocation, recognition view, subject-linkage

### DIFF
--- a/vtc-service/admin-ui/src/lib/api.ts
+++ b/vtc-service/admin-ui/src/lib/api.ts
@@ -247,15 +247,66 @@ export interface IssueInvitationResponse {
   vic: unknown;
 }
 
-/** Issue an Invitation Credential bound to `subjectDid`. */
+/** Issue an Invitation Credential bound to `subjectDid`, optionally granting a
+ * role (`member` / `moderator` / `issuer`; `admin` is refused server-side). */
 export const issueInvitation = (
   subjectDid: string,
   validityDays?: number,
-): Promise<IssueInvitationResponse> =>
-  postJson<IssueInvitationResponse>(
-    "/v1/invitations",
-    validityDays === undefined ? { subjectDid } : { subjectDid, validityDays },
-    { trustTask: ISSUE_INVITATION_TASK },
+  role?: string,
+): Promise<IssueInvitationResponse> => {
+  const body: Record<string, unknown> = { subjectDid };
+  if (validityDays !== undefined) body.validityDays = validityDays;
+  if (role) body.role = role;
+  return postJson<IssueInvitationResponse>("/v1/invitations", body, {
+    trustTask: ISSUE_INVITATION_TASK,
+  });
+};
+
+const REVOKE_INVITATION_TASK =
+  "https://trusttasks.org/openvtc/vtc/invitations/revoke/1.0";
+
+export interface InvitationListItem {
+  id: string;
+  subjectDid: string;
+  role?: string;
+  issuedBy: string;
+  issuedAt: string;
+  validUntil?: string;
+  revokedAt?: string;
+}
+
+/** List issued invitations (newest first). Reuses the issue Trust Task (GET +
+ * POST share the /invitations mount). */
+export const listInvitations = (): Promise<{ invitations: InvitationListItem[] }> =>
+  getJson<{ invitations: InvitationListItem[] }>("/v1/invitations", {
+    trustTask: ISSUE_INVITATION_TASK,
+  });
+
+/** Revoke an outstanding invitation by VIC id (flips its revocation bit). */
+export const revokeInvitation = (
+  id: string,
+): Promise<{ id: string; revokedAt: string; newlyRevoked: boolean }> =>
+  deleteJson<{ id: string; revokedAt: string; newlyRevoked: boolean }>(
+    `/v1/invitations/${encodeURIComponent(id)}`,
+    { trustTask: REVOKE_INVITATION_TASK },
+  );
+
+const RECOGNITION_CHECK_TASK =
+  "https://trusttasks.org/openvtc/vtc/recognition/check/1.0";
+
+export interface RecognitionCheck {
+  did: string;
+  recognised: boolean;
+  registryConfigured: boolean;
+  error?: string;
+}
+
+/** Ask whether this community recognises (trusts) a foreign issuer/community
+ * DID — the operator's per-DID window into the recognition graph. */
+export const checkRecognition = (did: string): Promise<RecognitionCheck> =>
+  getJson<RecognitionCheck>(
+    `/v1/recognition/check?did=${encodeURIComponent(did)}`,
+    { trustTask: RECOGNITION_CHECK_TASK },
   );
 
 /** Probe: returns the whoami response when signed in, null when not. */

--- a/vtc-service/admin-ui/src/plugins/index.ts
+++ b/vtc-service/admin-ui/src/plugins/index.ts
@@ -16,6 +16,7 @@ import {
   Inbox,
   KeyRound,
   LayoutDashboard,
+  Network,
   ShieldCheck,
   Smartphone,
   Tag,
@@ -34,6 +35,7 @@ import { JoinRequests } from "@/plugins/joinRequests";
 import { Members } from "@/plugins/members";
 import { MyPasskeys } from "@/plugins/myPasskeys";
 import { Profile } from "@/plugins/profile";
+import { Recognition } from "@/plugins/recognition";
 import { Sessions } from "@/plugins/sessions";
 
 export function registerBuiltinPlugins(): void {
@@ -67,6 +69,14 @@ export function registerBuiltinPlugins(): void {
     path: "/invitations",
     iconComponent: Ticket,
     reactComponent: Invitations,
+  });
+
+  registerPlugin({
+    id: "recognition",
+    label: "Recognition",
+    path: "/recognition",
+    iconComponent: Network,
+    reactComponent: Recognition,
   });
 
   registerPlugin({

--- a/vtc-service/admin-ui/src/plugins/invitations.tsx
+++ b/vtc-service/admin-ui/src/plugins/invitations.tsx
@@ -7,10 +7,16 @@
 // trusted, unconsumed invitation → allow). See `routes/invitations.rs`.
 
 import { useEffect, useState } from "react";
-import { useMutation } from "@tanstack/react-query";
-import { Download, Ticket } from "lucide-react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Download, Ticket, Trash2 } from "lucide-react";
 
-import { issueInvitation, type IssueInvitationResponse } from "@/lib/api";
+import {
+  issueInvitation,
+  listInvitations,
+  revokeInvitation,
+  type InvitationListItem,
+  type IssueInvitationResponse,
+} from "@/lib/api";
 import { CopyButton } from "@/components/CopyButton";
 import { useToast } from "@/lib/toast";
 
@@ -21,8 +27,24 @@ const QR_MAX_CHARS = 1200;
 
 export function Invitations() {
   const toast = useToast();
+  const queryClient = useQueryClient();
   const [did, setDid] = useState("");
   const [validityDays, setValidityDays] = useState("");
+  const [role, setRole] = useState("member");
+
+  const invitations = useQuery({
+    queryKey: ["invitations"],
+    queryFn: async () => (await listInvitations()).invitations,
+  });
+
+  const revoke = useMutation<unknown, Error, string>({
+    mutationFn: (id: string) => revokeInvitation(id),
+    onSuccess: () => {
+      toast.push("success", "Invitation revoked");
+      void queryClient.invalidateQueries({ queryKey: ["invitations"] });
+    },
+    onError: (e) => toast.pushFromError(e),
+  });
 
   const mutation = useMutation<IssueInvitationResponse, Error, void>({
     mutationFn: () => {
@@ -30,9 +52,13 @@ export function Invitations() {
       if (days !== undefined && (!Number.isInteger(days) || days < 1)) {
         return Promise.reject(new Error("Validity must be a whole number of days ≥ 1"));
       }
-      return issueInvitation(did.trim(), days);
+      // "member" is the server default — send a role only when it differs.
+      return issueInvitation(did.trim(), days, role === "member" ? undefined : role);
     },
-    onSuccess: () => toast.push("success", "Invitation issued"),
+    onSuccess: () => {
+      toast.push("success", "Invitation issued");
+      void queryClient.invalidateQueries({ queryKey: ["invitations"] });
+    },
     onError: (e) => toast.pushFromError(e),
   });
 
@@ -81,6 +107,14 @@ export function Invitations() {
               placeholder="7"
             />
           </label>
+          <label className="field">
+            <span className="field-label">Role on join</span>
+            <select value={role} onChange={(e) => setRole(e.target.value)}>
+              <option value="member">member</option>
+              <option value="moderator">moderator</option>
+              <option value="issuer">issuer</option>
+            </select>
+          </label>
           <button
             type="submit"
             className="btn primary"
@@ -117,6 +151,61 @@ export function Invitations() {
           />
         </section>
       )}
+
+      <section className="card">
+        <h3>Issued invitations</h3>
+        {invitations.isPending && <p className="muted">Loading…</p>}
+        {invitations.isError && (
+          <p className="muted">Could not load invitations.</p>
+        )}
+        {invitations.data && invitations.data.length === 0 && (
+          <p className="muted">No invitations issued yet.</p>
+        )}
+        {invitations.data && invitations.data.length > 0 && (
+          <table className="data-table">
+            <thead>
+              <tr>
+                <th>Invitee</th>
+                <th>Role</th>
+                <th>Issued</th>
+                <th>Status</th>
+                <th />
+              </tr>
+            </thead>
+            <tbody>
+              {invitations.data.map((inv: InvitationListItem) => (
+                <tr key={inv.id}>
+                  <td>
+                    <code className="truncate">{inv.subjectDid}</code>
+                  </td>
+                  <td>{inv.role ?? "member"}</td>
+                  <td>{inv.issuedAt.slice(0, 10)}</td>
+                  <td>
+                    {inv.revokedAt ? (
+                      <span className="muted">revoked</span>
+                    ) : (
+                      "live"
+                    )}
+                  </td>
+                  <td>
+                    {!inv.revokedAt && (
+                      <button
+                        type="button"
+                        className="btn"
+                        disabled={revoke.isPending}
+                        onClick={() => revoke.mutate(inv.id)}
+                        title="Revoke this invitation"
+                      >
+                        <Trash2 size={16} strokeWidth={1.75} /> Revoke
+                      </button>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </section>
     </div>
   );
 }

--- a/vtc-service/admin-ui/src/plugins/recognition.tsx
+++ b/vtc-service/admin-ui/src/plugins/recognition.tsx
@@ -1,0 +1,127 @@
+// Recognition plugin — the operator's view of the trust (recognition) graph.
+//
+// TRQP recognition is a per-DID query against the upstream trust registry (not
+// a listable set), so this surfaces the configured-registry status plus a
+// lookup tool: enter an issuer / community DID and see whether this community
+// recognises it. That recognition verdict is what decides whether a third-party
+// invitation issuer is trusted (M2).
+
+import { useState } from "react";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { Check, Network, X } from "lucide-react";
+
+import {
+  checkRecognition,
+  fetchDiagnostics,
+  type RecognitionCheck,
+} from "@/lib/api";
+import { useToast } from "@/lib/toast";
+
+export function Recognition() {
+  const toast = useToast();
+  const [did, setDid] = useState("");
+
+  const diagnostics = useQuery({
+    queryKey: ["diagnostics"],
+    queryFn: fetchDiagnostics,
+  });
+
+  const lookup = useMutation<RecognitionCheck, Error, string>({
+    mutationFn: (d: string) => checkRecognition(d),
+    onError: (e) => toast.pushFromError(e),
+  });
+
+  const result = lookup.data;
+
+  return (
+    <div className="page">
+      <header className="page-header">
+        <h2>
+          <Network size={20} strokeWidth={1.75} /> Recognition
+        </h2>
+        <p className="muted">
+          The trust (recognition) graph decides which foreign issuers and
+          communities this community trusts — including which third parties may
+          issue invitations that auto-admit. Recognition is queried per-DID
+          against the trust registry.
+        </p>
+      </header>
+
+      <section className="card">
+        <h3>Trust registry</h3>
+        {diagnostics.isPending && <p className="muted">Loading…</p>}
+        {diagnostics.data && (
+          <dl>
+            <dt>Status</dt>
+            <dd>
+              <code>{diagnostics.data.registry_status}</code>
+            </dd>
+          </dl>
+        )}
+      </section>
+
+      <section className="card">
+        <h3>Check recognition</h3>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            if (did.trim()) lookup.mutate(did.trim());
+          }}
+        >
+          <label className="field">
+            <span className="field-label">Issuer / community DID</span>
+            <input
+              type="text"
+              value={did}
+              onChange={(e) => setDid(e.target.value)}
+              placeholder="did:webvh:… or did:key:…"
+              autoComplete="off"
+              spellCheck={false}
+            />
+          </label>
+          <button
+            type="submit"
+            className="btn primary"
+            disabled={!did.trim() || lookup.isPending}
+          >
+            {lookup.isPending ? "Checking…" : "Check"}
+          </button>
+        </form>
+
+        {result && (
+          <p style={{ marginTop: 12 }}>
+            {result.recognised ? (
+              <span>
+                <Check
+                  size={16}
+                  strokeWidth={1.75}
+                  className="status-icon ok"
+                  aria-label="Recognised"
+                />{" "}
+                <strong>Recognised</strong> — <code>{result.did}</code> is
+                trusted by this community.
+              </span>
+            ) : (
+              <span>
+                <X
+                  size={16}
+                  strokeWidth={1.75}
+                  aria-label="Not recognised"
+                />{" "}
+                <strong>Not recognised</strong> — <code>{result.did}</code> is
+                not in the recognition graph
+                {result.registryConfigured ? "" : " (no trust registry configured)"}.
+              </span>
+            )}
+            {result.error && (
+              <span className="muted">
+                {" "}
+                (registry error: {result.error})
+              </span>
+            )}
+          </p>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/vtc-service/policies/default/join.rego
+++ b/vtc-service/policies/default/join.rego
@@ -34,14 +34,15 @@ import rego.v1
 # structural totality — unmatched submissions go to moderator review
 default decision := {"effect": "refer", "with": {"queue": "moderator"}}
 
-# A valid, trusted, unconsumed invitation (VIC) auto-admits as a member —
-# the community (or a trusted third party) explicitly invited this DID.
-# `verified` / `issuer_trusted` / `consumed` are host-resolved facts:
-# `verified` = signature + holder-binding + validity + revocation all
+# A valid, trusted, unconsumed invitation (VIC) auto-admits at the role the
+# invitation grants — the community (or a trusted third party) explicitly
+# invited this DID. `verified` / `issuer_trusted` / `consumed` are host-resolved
+# facts: `verified` = signature + holder-binding + validity + revocation all
 # checked; `issuer_trusted` = the issuer is the community itself or a
 # registry-recognised peer; `consumed` = the single-use VIC was already
-# redeemed.
-decision := {"effect": "allow", "with": {"role": "member"}} if {
+# redeemed. The granted role comes from the VIC's `scopes` (`role:<name>`,
+# default `member`); the host's privilege ceiling still forbids `admin` on join.
+decision := {"effect": "allow", "with": {"role": invited_role}} if {
 	has_valid_invitation
 }
 
@@ -56,4 +57,14 @@ has_valid_invitation if {
 	input.evidence.invitation.verified
 	input.evidence.invitation.issuer_trusted
 	not input.evidence.invitation.consumed
+}
+
+# The role an invitation grants: the first `role:<name>` scope it carries,
+# else `member`.
+default invited_role := "member"
+
+invited_role := role if {
+	some s in input.evidence.invitation.scopes
+	startswith(s, "role:")
+	role := substring(s, 5, -1)
 }

--- a/vtc-service/src/credentials/dtg.rs
+++ b/vtc-service/src/credentials/dtg.rs
@@ -60,6 +60,7 @@ async fn finalize(
     dtg: DTGCredential,
     id: Option<&str>,
     status_ref: Option<&CredentialStatusRef>,
+    subject_scopes: &[String],
 ) -> Result<Value, AppError> {
     // The wire VC is the catalog's `DTGCommon` body; the `DTGCredential`
     // wrapper's `type_`/`version` helpers are not part of the credential.
@@ -77,8 +78,21 @@ async fn finalize(
             .map_err(|e| AppError::Internal(format!("credentialStatus -> value: {e}")))?;
         obj.insert("credentialStatus".into(), status);
     }
+    // Splice `scopes` into credentialSubject (covered by the signature). The
+    // catalog subject is `{ id }`; this is additive — used by invitations to
+    // carry an authorized role (`role:<name>`).
+    if !subject_scopes.is_empty()
+        && let Some(subject) = obj
+            .get_mut("credentialSubject")
+            .and_then(Value::as_object_mut)
+    {
+        subject.insert(
+            "scopes".into(),
+            Value::Array(subject_scopes.iter().cloned().map(Value::String).collect()),
+        );
+    }
 
-    // Sign the full document (covers id + credentialStatus).
+    // Sign the full document (covers id + credentialStatus + subject scopes).
     signer.sign_doc(&mut doc).await?;
     Ok(doc)
 }
@@ -103,7 +117,7 @@ pub async fn issue_membership(
         Some(valid_until),
         personhood,
     );
-    finalize(signer, dtg, id, status_ref).await
+    finalize(signer, dtg, id, status_ref, &[]).await
 }
 
 /// Issue a signed **role-grant** Endorsement credential (VEC) as JSON.
@@ -147,7 +161,7 @@ pub async fn issue_endorsement(
         Some(valid_until),
         endorsement,
     );
-    finalize(signer, dtg, id, status_ref).await
+    finalize(signer, dtg, id, status_ref, &[]).await
 }
 
 /// Issue a signed **Invitation** credential (VIC) as JSON to a `subject_did`
@@ -160,6 +174,7 @@ pub async fn issue_invitation(
     id: Option<&str>,
     status_ref: Option<&CredentialStatusRef>,
     validity: Duration,
+    subject_scopes: &[String],
 ) -> Result<Value, AppError> {
     let (valid_from, valid_until) = window(validity);
     let dtg = DTGCredential::new_vic(
@@ -168,7 +183,7 @@ pub async fn issue_invitation(
         valid_from,
         Some(valid_until),
     );
-    finalize(signer, dtg, id, status_ref).await
+    finalize(signer, dtg, id, status_ref, subject_scopes).await
 }
 
 #[cfg(test)]
@@ -292,6 +307,7 @@ mod tests {
             Some("urn:uuid:vic-1"),
             Some(&status),
             Duration::days(7),
+            &[],
         )
         .await
         .expect("issue VIC");

--- a/vtc-service/src/credentials/invitation.rs
+++ b/vtc-service/src/credentials/invitation.rs
@@ -39,6 +39,7 @@ pub async fn issue_invitation(
     schemas_ks: &KeyspaceHandle,
     subject_did: &str,
     validity: Duration,
+    role: Option<&str>,
 ) -> Result<Value, AppError> {
     // Hold the status-list write lock across allocate → build → store
     // (P0.1). The raw guard (not `with_locked`) is needed because the VIC
@@ -64,9 +65,21 @@ pub async fn issue_invitation(
     let status_ref = CredentialStatusRef::revocation(row.list_credential_id.clone(), slot);
     let id = format!("urn:uuid:{}", Uuid::new_v4());
 
+    // An optional role grant rides in `credentialSubject.scopes` as
+    // `role:<name>` — the join policy reads it to admit the invitee at that
+    // role (bounded by the host's no-admin-via-join privilege ceiling).
+    let scopes: Vec<String> = role.map(|r| vec![format!("role:{r}")]).unwrap_or_default();
+
     // Build first; persist the burned slot only on success.
-    let vic =
-        dtg::issue_invitation(signer, subject_did, Some(&id), Some(&status_ref), validity).await?;
+    let vic = dtg::issue_invitation(
+        signer,
+        subject_did,
+        Some(&id),
+        Some(&status_ref),
+        validity,
+        &scopes,
+    )
+    .await?;
 
     // Issue-time schema validation (task 2.3): if an InvitationCredential schema
     // is registered in the schema store, the VIC must conform before the slot is
@@ -123,9 +136,16 @@ mod tests {
             .unwrap()
             .count_assigned();
 
-        let vic = issue_invitation(&s, &ks, &schemas_ks, "did:key:zInvitee", Duration::days(7))
-            .await
-            .expect("issue VIC");
+        let vic = issue_invitation(
+            &s,
+            &ks,
+            &schemas_ks,
+            "did:key:zInvitee",
+            Duration::days(7),
+            None,
+        )
+        .await
+        .expect("issue VIC");
 
         // Catalog Invitation type + revocable + subject is the invitee.
         let types: Vec<String> = serde_json::from_value(vic["type"].clone()).unwrap();
@@ -164,9 +184,16 @@ mod tests {
         let ks = store.keyspace("status_lists").unwrap();
         let schemas_ks = store.keyspace("schemas").unwrap();
         let s = signer();
-        let err = issue_invitation(&s, &ks, &schemas_ks, "did:key:zInvitee", Duration::days(7))
-            .await
-            .expect_err("must refuse without a provisioned list");
+        let err = issue_invitation(
+            &s,
+            &ks,
+            &schemas_ks,
+            "did:key:zInvitee",
+            Duration::days(7),
+            None,
+        )
+        .await
+        .expect_err("must refuse without a provisioned list");
         assert!(matches!(err, AppError::Internal(_)), "{err:?}");
     }
 
@@ -204,9 +231,16 @@ mod tests {
             .unwrap()
             .count_assigned();
 
-        let err = issue_invitation(&s, &ks, &schemas_ks, "did:key:zInvitee", Duration::days(7))
-            .await
-            .expect_err("non-conforming VIC must be refused");
+        let err = issue_invitation(
+            &s,
+            &ks,
+            &schemas_ks,
+            "did:key:zInvitee",
+            Duration::days(7),
+            None,
+        )
+        .await
+        .expect_err("non-conforming VIC must be refused");
         assert!(matches!(err, AppError::Validation(_)), "{err:?}");
 
         let after = get_state(&ks, StatusPurpose::Revocation)

--- a/vtc-service/src/credentials/invitation_registry.rs
+++ b/vtc-service/src/credentials/invitation_registry.rs
@@ -1,0 +1,135 @@
+//! Registry of **issued** Invitation Credentials (VICs) — the durable record
+//! the list + revoke operator surfaces read.
+//!
+//! One row per VIC `id`, recording its revocation status-list slot (so a revoke
+//! can flip the right bit), the invitee, the granted role, who issued it, and
+//! its revocation state. Stored in the `invitations` keyspace.
+//!
+//! This is the issuer-side counterpart to the redeemed-VIC ledger
+//! ([`super::invitation_verify::ConsumedInvitation`], `consumed_invitations`):
+//! one tracks invitations we *issued*, the other tracks invitations someone
+//! *redeemed*.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use vti_common::error::AppError;
+use vti_common::store::KeyspaceHandle;
+
+const PREFIX: &[u8] = b"invitation:";
+
+fn key(id: &str) -> Vec<u8> {
+    let mut k = PREFIX.to_vec();
+    k.extend_from_slice(id.as_bytes());
+    k
+}
+
+/// A persisted record of one issued VIC.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InvitationRecord {
+    /// The VIC `id` (`urn:uuid:…`).
+    pub id: String,
+    /// The invited (subject) DID.
+    pub subject_did: String,
+    /// Revocation status-list slot this VIC occupies — the bit a revoke flips.
+    pub slot: u32,
+    /// The role the invitation grants on join, if any (`member` when absent).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub role: Option<String>,
+    /// The operator DID that issued it.
+    pub issued_by: String,
+    /// When it was issued.
+    pub issued_at: DateTime<Utc>,
+    /// The VIC's `validUntil` (RFC3339), echoed for display.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub valid_until: Option<String>,
+    /// When it was revoked, if it has been. `None` = live.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub revoked_at: Option<DateTime<Utc>>,
+}
+
+impl InvitationRecord {
+    /// Whether this invitation has been revoked.
+    pub fn is_revoked(&self) -> bool {
+        self.revoked_at.is_some()
+    }
+}
+
+/// Persist (or overwrite) an invitation record.
+pub async fn store_invitation(
+    ks: &KeyspaceHandle,
+    record: &InvitationRecord,
+) -> Result<(), AppError> {
+    ks.insert(key(&record.id), record).await
+}
+
+/// Fetch one invitation record by VIC `id`.
+pub async fn get_invitation(
+    ks: &KeyspaceHandle,
+    id: &str,
+) -> Result<Option<InvitationRecord>, AppError> {
+    ks.get::<InvitationRecord>(key(id)).await
+}
+
+/// List every issued invitation record (newest first).
+pub async fn list_invitations(ks: &KeyspaceHandle) -> Result<Vec<InvitationRecord>, AppError> {
+    let raw = ks.prefix_iter_raw(PREFIX.to_vec()).await?;
+    let mut out: Vec<InvitationRecord> = Vec::with_capacity(raw.len());
+    for (_k, v) in raw {
+        match serde_json::from_slice::<InvitationRecord>(&v) {
+            Ok(r) => out.push(r),
+            Err(e) => tracing::warn!(error = %e, "skipping unparseable invitation row"),
+        }
+    }
+    out.sort_by(|a, b| b.issued_at.cmp(&a.issued_at));
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vti_common::config::StoreConfig;
+    use vti_common::store::Store;
+
+    async fn ks() -> (tempfile::TempDir, Store, KeyspaceHandle) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(&StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        })
+        .unwrap();
+        let ks = store.keyspace("invitations").unwrap();
+        (dir, store, ks)
+    }
+
+    fn rec(id: &str, at: &str) -> InvitationRecord {
+        InvitationRecord {
+            id: id.into(),
+            subject_did: "did:key:zInvitee".into(),
+            slot: 7,
+            role: Some("moderator".into()),
+            issued_by: "did:key:zAdmin".into(),
+            issued_at: at.parse().unwrap(),
+            valid_until: None,
+            revoked_at: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn round_trip_and_list_newest_first() {
+        let (_d, _s, ks) = ks().await;
+        store_invitation(&ks, &rec("urn:uuid:a", "2026-01-01T00:00:00Z"))
+            .await
+            .unwrap();
+        store_invitation(&ks, &rec("urn:uuid:b", "2026-02-01T00:00:00Z"))
+            .await
+            .unwrap();
+
+        let got = get_invitation(&ks, "urn:uuid:a").await.unwrap().unwrap();
+        assert_eq!(got.slot, 7);
+        assert!(!got.is_revoked());
+
+        let all = list_invitations(&ks).await.unwrap();
+        assert_eq!(all.len(), 2);
+        assert_eq!(all[0].id, "urn:uuid:b", "newest first");
+    }
+}

--- a/vtc-service/src/credentials/invitation_verify.rs
+++ b/vtc-service/src/credentials/invitation_verify.rs
@@ -157,6 +157,22 @@ pub async fn verify_presented_invitation(
         None => HttpStatusListFetcher::new(),
     };
 
+    // Subject-linkage (#1b): when the presenter is not the DID the VIC was
+    // minted for, the VP must carry a `subjectLinkage` proof in which the VIC
+    // subject authorizes this presenter. Verified here (where the concrete
+    // resolver lives) and the verdict threaded into the binding check.
+    let subject = vic_json
+        .pointer("/credentialSubject/id")
+        .and_then(JsonValue::as_str);
+    let vic_id = vic_json.get("id").and_then(JsonValue::as_str);
+    let linkage_authorized = match (subject, vic_id) {
+        (Some(subject), Some(vic_id)) if subject != applicant_did => {
+            verify_subject_linkage(vp, subject, vic_id, applicant_did, &resolver).await?;
+            true
+        }
+        _ => false,
+    };
+
     let verified = verify_invitation_inner(
         &vic_json,
         applicant_did,
@@ -165,9 +181,80 @@ pub async fn verify_presented_invitation(
         &resolver,
         &fetcher,
         Utc::now(),
+        linkage_authorized,
     )
     .await?;
     Ok(Some(verified))
+}
+
+/// Domain tag the VIC subject signs over for a subject-linkage proof — binds
+/// the proof to this protocol so it can't be cross-protocol replayed.
+pub const SUBJECT_LINKAGE_DOMAIN_TAG: &[u8] = b"vtc-invitation-subject-linkage/v1\0";
+
+/// Verify a **subject-linkage proof**: the VIC subject (`subject`) signed
+/// `TAG || vic_id || presenter` with a key under their DID, authorizing
+/// `presenter` to redeem this specific invitation. Lets a holder redeem under a
+/// different / freshly-minted DID without re-issuing the VIC (#1b), at the cost
+/// of linking the two DIDs at this community.
+///
+/// The proof rides in the VP as
+/// `subjectLinkage: { verificationMethod, signature }` (hex Ed25519).
+async fn verify_subject_linkage(
+    vp: &JsonValue,
+    subject: &str,
+    vic_id: &str,
+    presenter: &str,
+    resolver: &DidVmResolver,
+) -> Result<(), AppError> {
+    let linkage = vp
+        .get("subjectLinkage")
+        .and_then(JsonValue::as_object)
+        .ok_or_else(|| {
+            forbidden(format!(
+                "invitation subject `{subject}` differs from the presenter `{presenter}` \
+             and the VP carries no `subjectLinkage` proof"
+            ))
+        })?;
+    let vm = linkage
+        .get("verificationMethod")
+        .and_then(JsonValue::as_str)
+        .ok_or_else(|| forbidden("subjectLinkage is missing `verificationMethod`".into()))?;
+    let signature_hex = linkage
+        .get("signature")
+        .and_then(JsonValue::as_str)
+        .ok_or_else(|| forbidden("subjectLinkage is missing `signature`".into()))?;
+
+    // The linkage MUST be signed by a key under the VIC subject — a key
+    // controlled by some other DID cannot authorize a presenter.
+    if vm.split('#').next().unwrap_or(vm) != subject {
+        return Err(forbidden(format!(
+            "subjectLinkage verificationMethod `{vm}` is not under the invitation subject `{subject}`"
+        )));
+    }
+
+    let key = resolver.resolve_ed25519(vm).await?;
+    let key: [u8; 32] = key
+        .as_slice()
+        .try_into()
+        .map_err(|_| forbidden("subject-linkage key is not a 32-byte Ed25519 key".into()))?;
+    let verifying_key = ed25519_dalek::VerifyingKey::from_bytes(&key)
+        .map_err(|e| forbidden(format!("subject-linkage key is invalid: {e}")))?;
+    let sig_bytes = hex::decode(signature_hex)
+        .map_err(|e| forbidden(format!("subjectLinkage signature is not hex: {e}")))?;
+    let signature = ed25519_dalek::Signature::from_slice(&sig_bytes)
+        .map_err(|e| forbidden(format!("subjectLinkage signature is malformed: {e}")))?;
+
+    // Signed payload: TAG || vic_id || NUL || presenter — binds the proof to
+    // this exact invitation and presenter.
+    let mut signed = SUBJECT_LINKAGE_DOMAIN_TAG.to_vec();
+    signed.extend_from_slice(vic_id.as_bytes());
+    signed.push(0);
+    signed.extend_from_slice(presenter.as_bytes());
+
+    use ed25519_dalek::Verifier;
+    verifying_key
+        .verify(&signed, &signature)
+        .map_err(|_| forbidden("subjectLinkage signature did not verify".into()))
 }
 
 /// Pull the first `InvitationCredential` out of a VP's `verifiableCredential`
@@ -201,6 +288,9 @@ async fn verify_invitation_inner(
     resolver: &dyn VerificationMethodResolver,
     fetcher: &dyn StatusListFetcher,
     now: DateTime<Utc>,
+    // True when the presenter is not the VIC subject but a verified subject
+    // linkage proof authorized them (the dual-control / fresh-DID path, #1b).
+    linkage_authorized: bool,
 ) -> Result<VerifiedInvitation, AppError> {
     let vic: VerifiableCredential = serde_json::from_value(vic_json.clone())
         .map_err(|e| forbidden(format!("invitation is not a Verifiable Credential: {e}")))?;
@@ -220,10 +310,13 @@ async fn verify_invitation_inner(
     let issuer = vic.issuer.id().to_string();
     let subject = subject_id(&vic)?;
 
-    // 1. Holder-binding: the presenter must be the DID the VIC was minted for.
-    if subject != applicant_did {
+    // 1. Holder-binding: the presenter must be the DID the VIC was minted for,
+    // OR a verified subject-linkage proof authorized this presenter (#1b — the
+    // invited DID consented to a different/fresh presenting DID).
+    if subject != applicant_did && !linkage_authorized {
         return Err(forbidden(format!(
-            "invitation is bound to `{subject}`, not the applicant `{applicant_did}`"
+            "invitation is bound to `{subject}`, not the applicant `{applicant_did}` \
+             (and no valid subject-linkage proof was provided)"
         )));
     }
 
@@ -461,6 +554,7 @@ mod tests {
             Some(&format!("urn:uuid:{}", uuid::Uuid::new_v4())),
             status,
             validity,
+            &[],
         )
         .await
         .expect("issue VIC")
@@ -534,6 +628,7 @@ mod tests {
             &resolver(),
             &StubFetcher { revoked: false },
             Utc::now(),
+            false,
         )
         .await
         .expect("self-issued VIC verifies");
@@ -562,6 +657,7 @@ mod tests {
             &resolver(),
             &StubFetcher { revoked: false },
             Utc::now(),
+            false,
         )
         .await
         .expect("verifies cryptographically");
@@ -594,6 +690,7 @@ mod tests {
             &resolver(),
             &StubFetcher { revoked: false },
             Utc::now(),
+            false,
         )
         .await
         .expect("verifies cryptographically");
@@ -616,6 +713,7 @@ mod tests {
             &resolver(),
             &StubFetcher { revoked: false },
             Utc::now(),
+            false,
         )
         .await
         .expect_err("wrong subject must fail");
@@ -636,6 +734,7 @@ mod tests {
             &resolver(),
             &StubFetcher { revoked: false },
             Utc::now() + Duration::days(8),
+            false,
         )
         .await
         .expect_err("expired VIC must fail");
@@ -658,6 +757,7 @@ mod tests {
             &resolver(),
             &StubFetcher { revoked: false },
             Utc::now(),
+            false,
         )
         .await
         .expect_err("tampered VIC must fail");
@@ -678,6 +778,7 @@ mod tests {
             &resolver(),
             &StubFetcher { revoked: true },
             Utc::now(),
+            false,
         )
         .await
         .expect_err("revoked VIC must fail");
@@ -698,9 +799,73 @@ mod tests {
             &resolver(),
             &ErrFetcher,
             Utc::now(),
+            false,
         )
         .await
         .expect_err("unresolvable status must fail closed");
+        assert!(matches!(err, AppError::Forbidden(_)), "{err:?}");
+    }
+
+    // ── #1b subject-linkage proof ─────────────────────────────────────────
+
+    /// Build a `subjectLinkage` proof: the VIC subject (`a_seed`) signs
+    /// `TAG || vic_id || NUL || presenter`. Returns `(subject_did, vp)`.
+    fn linkage_vp(a_seed: &[u8; 32], vic_id: &str, presenter: &str) -> (String, JsonValue) {
+        use ed25519_dalek::{Signer, SigningKey};
+        let sk = SigningKey::from_bytes(a_seed);
+        let a_did =
+            affinidi_crypto::did_key::ed25519_pub_to_did_key(&sk.verifying_key().to_bytes());
+        let mut signed = SUBJECT_LINKAGE_DOMAIN_TAG.to_vec();
+        signed.extend_from_slice(vic_id.as_bytes());
+        signed.push(0);
+        signed.extend_from_slice(presenter.as_bytes());
+        let sig = sk.sign(&signed);
+        let vp = serde_json::json!({
+            "subjectLinkage": {
+                "verificationMethod": a_did,
+                "signature": hex::encode(sig.to_bytes()),
+            }
+        });
+        (a_did, vp)
+    }
+
+    #[tokio::test]
+    async fn subject_linkage_authorizes_a_different_presenter() {
+        let presenter = did_key(&OTHER_SEED);
+        let (a_did, vp) = linkage_vp(&APPLICANT_SEED, "urn:uuid:vic-1", &presenter);
+        verify_subject_linkage(&vp, &a_did, "urn:uuid:vic-1", &presenter, &resolver())
+            .await
+            .expect("a valid subject-linkage proof authorizes the presenter");
+    }
+
+    #[tokio::test]
+    async fn subject_linkage_rejects_a_different_presenter_than_signed() {
+        // The proof binds OUTSIDER, but someone else tries to use it.
+        let signed_presenter = did_key(&OTHER_SEED);
+        let (a_did, vp) = linkage_vp(&APPLICANT_SEED, "urn:uuid:vic-1", &signed_presenter);
+        let err = verify_subject_linkage(
+            &vp,
+            &a_did,
+            "urn:uuid:vic-1",
+            "did:key:zSomeoneElse",
+            &resolver(),
+        )
+        .await
+        .expect_err("a linkage bound to another presenter must not verify");
+        assert!(matches!(err, AppError::Forbidden(_)), "{err:?}");
+    }
+
+    #[tokio::test]
+    async fn subject_linkage_absent_is_rejected() {
+        let err = verify_subject_linkage(
+            &serde_json::json!({}),
+            "did:key:zSubject",
+            "urn:uuid:vic-1",
+            "did:key:zPresenter",
+            &resolver(),
+        )
+        .await
+        .expect_err("missing subjectLinkage must fail");
         assert!(matches!(err, AppError::Forbidden(_)), "{err:?}");
     }
 }

--- a/vtc-service/src/credentials/mod.rs
+++ b/vtc-service/src/credentials/mod.rs
@@ -49,6 +49,7 @@ pub mod delivery;
 pub mod dtg;
 pub mod exchange;
 pub mod invitation;
+pub mod invitation_registry;
 pub mod invitation_verify;
 pub mod present_challenge;
 pub mod signer;

--- a/vtc-service/src/join/invitation_e2e_test.rs
+++ b/vtc-service/src/join/invitation_e2e_test.rs
@@ -76,7 +76,7 @@ async fn vtc_with_signer(signer: &LocalSigner) -> TestVtc {
 /// check is a no-op) bound to `subject`, returning `(vp, vic_id)`.
 async fn issue_vic_vp(signer: &LocalSigner, subject: &str) -> (serde_json::Value, String) {
     let id = format!("urn:uuid:{}", uuid::Uuid::new_v4());
-    let vic = dtg::issue_invitation(signer, subject, Some(&id), None, Duration::days(7))
+    let vic = dtg::issue_invitation(signer, subject, Some(&id), None, Duration::days(7), &[])
         .await
         .expect("issue VIC");
     let vp = json!({

--- a/vtc-service/src/policy/default.rs
+++ b/vtc-service/src/policy/default.rs
@@ -565,6 +565,58 @@ mod tests {
     }
 
     #[test]
+    fn join_default_grants_invited_role() {
+        // A VIC carrying a `role:moderator` scope auto-admits at that role.
+        let c = compile_default(PolicyPurpose::Join);
+        let r = evaluate(
+            &c,
+            "data.vtc.join.decision",
+            json!({
+                "evidence": {
+                    "invitation": {
+                        "verified": true,
+                        "issuer": "did:webvh:acme.example",
+                        "issuer_trusted": true,
+                        "consumed": false,
+                        "scopes": ["role:moderator"]
+                    }
+                }
+            }),
+        )
+        .unwrap();
+        assert_eq!(
+            r.pointer("/result/0/expressions/0/value"),
+            Some(&json!({ "effect": "allow", "with": { "role": "moderator" } })),
+        );
+    }
+
+    #[test]
+    fn join_default_invitation_without_role_scope_grants_member() {
+        // A non-role scope (or no scopes) defaults to member.
+        let c = compile_default(PolicyPurpose::Join);
+        let r = evaluate(
+            &c,
+            "data.vtc.join.decision",
+            json!({
+                "evidence": {
+                    "invitation": {
+                        "verified": true,
+                        "issuer": "did:webvh:acme.example",
+                        "issuer_trusted": true,
+                        "consumed": false,
+                        "scopes": ["single-context"]
+                    }
+                }
+            }),
+        )
+        .unwrap();
+        assert_eq!(
+            r.pointer("/result/0/expressions/0/value"),
+            Some(&json!({ "effect": "allow", "with": { "role": "member" } })),
+        );
+    }
+
+    #[test]
     fn join_default_refers_on_consumed_invitation() {
         // A single-use invitation already redeemed is not a valid admit signal
         // → falls through to moderator review.

--- a/vtc-service/src/routes/invitations.rs
+++ b/vtc-service/src/routes/invitations.rs
@@ -13,9 +13,10 @@
 //! REST surface over it.
 
 use axum::Json;
+use axum::extract::Path;
 use axum::extract::State;
 use axum::http::StatusCode;
-use chrono::Duration;
+use chrono::{Duration, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use tracing::info;
@@ -25,8 +26,12 @@ use vti_common::error::AppError;
 
 use crate::acl::{VtcRole, get_acl_entry};
 use crate::credentials::invitation::{DEFAULT_INVITATION_VALIDITY, issue_invitation};
+use crate::credentials::invitation_registry::{
+    InvitationRecord, get_invitation, list_invitations, store_invitation,
+};
 use crate::members::get_member;
 use crate::server::AppState;
+use crate::status_list;
 
 /// Upper bound on a caller-requested validity — an invite is a short-lived
 /// onboarding artifact, not a standing credential.
@@ -40,6 +45,13 @@ pub struct IssueInvitationBody {
     /// Optional validity in days (1..=90); defaults to the 7-day VIC default.
     #[serde(default)]
     pub validity_days: Option<u32>,
+    /// Optional role to grant the invitee on join (e.g. `member`, `moderator`,
+    /// `issuer`). Carried in the VIC's `credentialSubject.scopes` as
+    /// `role:<name>` and honored by the join policy. `admin` is refused — the
+    /// no-admin-via-join privilege ceiling would deny it anyway. Defaults to
+    /// `member` (absent scope).
+    #[serde(default)]
+    pub role: Option<String>,
 }
 
 #[derive(Debug, Serialize, utoipa::ToSchema)]
@@ -113,12 +125,27 @@ pub async fn issue(
         None => DEFAULT_INVITATION_VALIDITY,
     };
 
+    // A role grant on the invite must parse to a known role and may never be
+    // `admin` — a join can't grant admin (host privilege ceiling), so we refuse
+    // it at issuance rather than mint an invite that would be denied on redeem.
+    if let Some(role) = body.role.as_deref() {
+        let parsed = role
+            .parse::<VtcRole>()
+            .map_err(|_| AppError::Validation(format!("unknown role `{role}`")))?;
+        if matches!(parsed, VtcRole::Admin) {
+            return Err(AppError::Validation(
+                "an invitation may not grant `admin` (no admin via join)".into(),
+            ));
+        }
+    }
+
     let vic = issue_invitation(
         signer,
         &state.status_lists_ks,
         &state.schemas_ks,
         &body.subject_did,
         validity,
+        body.role.as_deref(),
     )
     .await?;
     let valid_until = vic
@@ -126,9 +153,37 @@ pub async fn issue(
         .and_then(JsonValue::as_str)
         .map(str::to_string);
 
+    // Record the issued VIC so it can be listed + revoked. The id + revocation
+    // slot are read back from the freshly-signed credential.
+    let id = vic
+        .get("id")
+        .and_then(JsonValue::as_str)
+        .ok_or_else(|| AppError::Internal("issued VIC has no `id`".into()))?
+        .to_string();
+    let slot = vic
+        .pointer("/credentialStatus/statusListIndex")
+        .and_then(JsonValue::as_str)
+        .and_then(|s| s.parse::<u32>().ok())
+        .ok_or_else(|| AppError::Internal("issued VIC has no usable statusListIndex".into()))?;
+    store_invitation(
+        &state.invitations_ks,
+        &InvitationRecord {
+            id: id.clone(),
+            subject_did: body.subject_did.clone(),
+            slot,
+            role: body.role.clone(),
+            issued_by: auth.did.clone(),
+            issued_at: Utc::now(),
+            valid_until: valid_until.clone(),
+            revoked_at: None,
+        },
+    )
+    .await?;
+
     info!(
         actor = %auth.did,
         subject = %body.subject_did,
+        vic_id = %id,
         "issued an invitation credential (VIC)"
     );
 
@@ -140,4 +195,145 @@ pub async fn issue(
             vic,
         }),
     ))
+}
+
+// ── List + revoke ─────────────────────────────────────────────────────────
+
+/// One row of the invitation list (the registry record, body-free).
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct InvitationListItem {
+    pub id: String,
+    pub subject_did: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub role: Option<String>,
+    pub issued_by: String,
+    pub issued_at: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub valid_until: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub revoked_at: Option<String>,
+}
+
+impl From<InvitationRecord> for InvitationListItem {
+    fn from(r: InvitationRecord) -> Self {
+        Self {
+            id: r.id,
+            subject_did: r.subject_did,
+            role: r.role,
+            issued_by: r.issued_by,
+            issued_at: r.issued_at.to_rfc3339(),
+            valid_until: r.valid_until,
+            revoked_at: r.revoked_at.map(|t| t.to_rfc3339()),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct InvitationListResponse {
+    pub invitations: Vec<InvitationListItem>,
+}
+
+/// Auth gate shared by the invitation ops: Admin / Moderator / Issuer.
+async fn require_inviter(state: &AppState, did: &str) -> Result<(), AppError> {
+    let acl = get_acl_entry(&state.acl_ks, did)
+        .await?
+        .ok_or_else(|| AppError::Forbidden("caller has no ACL row".into()))?;
+    if !matches!(
+        acl.role,
+        VtcRole::Admin | VtcRole::Moderator | VtcRole::Issuer
+    ) {
+        return Err(AppError::Forbidden(
+            "only Admin, Moderator, or Issuer members can manage invitations".into(),
+        ));
+    }
+    Ok(())
+}
+
+#[utoipa::path(
+    get, path = "/invitations", tag = "invitations",
+    security(("bearer_jwt" = [])),
+    responses(
+        (status = 200, description = "Issued invitations", body = InvitationListResponse),
+        (status = 403, description = "Caller is not Admin / Moderator / Issuer"),
+    ),
+)]
+pub async fn list(
+    auth: AuthClaims,
+    State(state): State<AppState>,
+) -> Result<Json<InvitationListResponse>, AppError> {
+    require_inviter(&state, &auth.did).await?;
+    let invitations = list_invitations(&state.invitations_ks)
+        .await?
+        .into_iter()
+        .map(InvitationListItem::from)
+        .collect();
+    Ok(Json(InvitationListResponse { invitations }))
+}
+
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct RevokeResponse {
+    pub id: String,
+    pub revoked_at: String,
+    /// True if this call performed the revocation; false if it was already
+    /// revoked (idempotent).
+    pub newly_revoked: bool,
+}
+
+#[utoipa::path(
+    delete, path = "/invitations/{id}", tag = "invitations",
+    params(("id" = String, Path, description = "VIC id (urn:uuid)")),
+    security(("bearer_jwt" = [])),
+    responses(
+        (status = 200, description = "Invitation revoked", body = RevokeResponse),
+        (status = 403, description = "Caller is not Admin / Moderator / Issuer"),
+        (status = 404, description = "No such invitation"),
+    ),
+)]
+pub async fn revoke(
+    auth: AuthClaims,
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<Json<RevokeResponse>, AppError> {
+    require_inviter(&state, &auth.did).await?;
+
+    let mut record = get_invitation(&state.invitations_ks, &id)
+        .await?
+        .ok_or_else(|| AppError::NotFound(format!("no invitation with id {id}")))?;
+
+    // Idempotent: an already-revoked invite reports its prior revocation.
+    if let Some(revoked_at) = record.revoked_at {
+        return Ok(Json(RevokeResponse {
+            id,
+            revoked_at: revoked_at.to_rfc3339(),
+            newly_revoked: false,
+        }));
+    }
+
+    // Flip the revocation status-list bit at the VIC's slot — locked RMW so a
+    // concurrent allocate/flip can't clobber it (P0.1).
+    let slot = record.slot;
+    status_list::with_locked(
+        &state.status_lists_ks,
+        affinidi_status_list::StatusPurpose::Revocation,
+        |sl| {
+            status_list::flip(sl, slot, true)
+                .map_err(|e| AppError::Internal(format!("flip revocation bit {slot}: {e}")))
+        },
+    )
+    .await?;
+
+    let now = Utc::now();
+    record.revoked_at = Some(now);
+    store_invitation(&state.invitations_ks, &record).await?;
+
+    info!(actor = %auth.did, vic_id = %id, slot, "revoked an invitation credential (VIC)");
+
+    Ok(Json(RevokeResponse {
+        id,
+        revoked_at: now.to_rfc3339(),
+        newly_revoked: true,
+    }))
 }

--- a/vtc-service/src/routes/mod.rs
+++ b/vtc-service/src/routes/mod.rs
@@ -19,6 +19,7 @@ pub mod join_requests;
 pub(crate) mod members;
 pub(crate) mod policies;
 pub mod recognise;
+mod recognition_admin;
 mod relationships;
 mod schemas;
 pub(crate) mod status_lists;
@@ -597,11 +598,23 @@ fn build_api_chain(_routing: &RoutingConfig, trust_xff: bool) -> OpenApiRouter<A
             // `list/1.0` exists on disk + in index.json.
             "https://trusttasks.org/openvtc/vtc/credentials/endorsements/issue/1.0",
         ))
-        // Invitation Credential (VIC) issuance — the operator side of the
-        // VIC auto-join ceremony. Admin / Moderator / Issuer.
+        // Invitation Credential (VIC) issuance + listing — the operator side of
+        // the VIC auto-join ceremony. Admin / Moderator / Issuer. POST + GET on
+        // /invitations share the `issue/1.0` mount; the standalone `list/1.0`
+        // task is declared on disk for the soft-gate surface.
         .routes(tt(
-            routes!(invitations::issue),
+            routes!(invitations::issue, invitations::list),
             "https://trusttasks.org/openvtc/vtc/invitations/issue/1.0",
+        ))
+        // Revoke an outstanding invitation (flips its revocation bit).
+        .routes(tt(
+            routes!(invitations::revoke),
+            "https://trusttasks.org/openvtc/vtc/invitations/revoke/1.0",
+        ))
+        // Recognition (trust-graph) lookup — admin window into TRQP recognise.
+        .routes(tt(
+            routes!(recognition_admin::check),
+            "https://trusttasks.org/openvtc/vtc/recognition/check/1.0",
         ))
         .routes(tt(
             routes!(endorsements::show, endorsements::revoke), // GET + DELETE share `show/1.0` at the router

--- a/vtc-service/src/routes/recognition_admin.rs
+++ b/vtc-service/src/routes/recognition_admin.rs
@@ -1,0 +1,77 @@
+//! `GET /v1/recognition/check` — the operator's window into the trust
+//! (recognition) graph.
+//!
+//! TRQP recognition is a **per-DID query** against the upstream trust registry,
+//! not a listable set — the recognition graph lives in the registry, and a VTC
+//! asks "do I recognise issuer X?" one DID at a time (`recognise`). This admin
+//! lookup exposes exactly that: enter an issuer / community DID, get back
+//! whether this community recognises it (the same verdict that decides whether a
+//! third-party invitation issuer is trusted, M2). The configured-registry status
+//! comes from `GET /v1/health/diagnostics`.
+
+use axum::Json;
+use axum::extract::{Query, State};
+use serde::{Deserialize, Serialize};
+use tracing::warn;
+
+use vti_common::auth::AdminAuth;
+use vti_common::error::AppError;
+
+use crate::server::AppState;
+
+#[derive(Debug, Deserialize, utoipa::IntoParams)]
+#[serde(rename_all = "camelCase")]
+pub struct CheckQuery {
+    /// The issuer / community DID to test for recognition.
+    pub did: String,
+}
+
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct RecognitionCheck {
+    /// Echo of the queried DID.
+    pub did: String,
+    /// Whether this community recognises the DID (TRQP `recognise`). `false`
+    /// when no registry is configured or the query came back not-found.
+    pub recognised: bool,
+    /// Whether a trust registry is configured at all (no-registry mode → every
+    /// foreign DID is unrecognised).
+    pub registry_configured: bool,
+    /// Set when the registry query failed (unreachable / parse) rather than
+    /// returning a clean recognised/not-recognised verdict.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+#[utoipa::path(
+    get, path = "/recognition/check", tag = "recognition",
+    params(CheckQuery),
+    security(("bearer_jwt" = [])),
+    responses(
+        (status = 200, description = "Recognition verdict", body = RecognitionCheck),
+        (status = 403, description = "Caller is not an admin"),
+    ),
+)]
+pub async fn check(
+    _auth: AdminAuth,
+    State(state): State<AppState>,
+    Query(q): Query<CheckQuery>,
+) -> Result<Json<RecognitionCheck>, AppError> {
+    let registry_configured = state.registry_client.is_some();
+    let (recognised, error) = match state.registry_client.as_deref() {
+        Some(registry) => match registry.recognise(&q.did).await {
+            Ok(verdict) => (verdict, None),
+            Err(e) => {
+                warn!(did = %q.did, error = %e, "recognition check failed");
+                (false, Some(e.to_string()))
+            }
+        },
+        None => (false, None),
+    };
+    Ok(Json(RecognitionCheck {
+        did: q.did,
+        recognised,
+        registry_configured,
+        error,
+    }))
+}

--- a/vtc-service/src/server.rs
+++ b/vtc-service/src/server.rs
@@ -113,6 +113,9 @@ pub struct AppState {
     /// Written when a VIC-driven join is admitted; read at verify
     /// time so a consumed invite can't be replayed.
     pub consumed_invitations_ks: KeyspaceHandle,
+    /// Registry of issued Invitation Credentials (id → slot / subject /
+    /// role / revocation state). Drives the invitation list + revoke ops.
+    pub invitations_ks: KeyspaceHandle,
     /// Trust-registry client (Phase 3 M3.2). `None` when
     /// `config.registry.url` is unset — the daemon runs in
     /// "no-registry" mode and `registry_health.status()` stays
@@ -305,6 +308,7 @@ pub async fn run(
     let audit_ks = store.keyspace(keyspaces::AUDIT)?;
     let audit_key_ks = store.keyspace(keyspaces::AUDIT_KEY)?;
     let consumed_invitations_ks = store.keyspace(keyspaces::CONSUMED_INVITATIONS)?;
+    let invitations_ks = store.keyspace(keyspaces::INVITATIONS)?;
 
     // M2.5: install the workspace-shipped default policies for any
     // PolicyPurpose that lacks an active row. Idempotent — operator
@@ -520,6 +524,7 @@ pub async fn run(
         audit_ks,
         audit_key_ks,
         consumed_invitations_ks,
+        invitations_ks,
         registry_client: registry_client.clone(),
         registry_health: registry_health.clone(),
         syncer_health: crate::registry::SyncerHealth::new(),

--- a/vtc-service/src/store/keyspaces.rs
+++ b/vtc-service/src/store/keyspaces.rs
@@ -36,6 +36,10 @@ pub const AUDIT_KEY: &str = "audit_key";
 /// row per consumed VIC `id`, written when a VIC-driven join is
 /// admitted. Read at verify time to set `Invitation.consumed`.
 pub const CONSUMED_INVITATIONS: &str = "consumed_invitations";
+/// Registry of *issued* Invitation Credentials: one row per VIC `id`
+/// recording its revocation-list slot, subject, granted role, and
+/// revocation state — drives the list + revoke operator surfaces.
+pub const INVITATIONS: &str = "invitations";
 
 /// Every keyspace the daemon opens, in `AppState` field order. The
 /// setup wizard pre-creates exactly this set; `server::run` opens
@@ -63,6 +67,7 @@ pub const ALL: &[&str] = &[
     AUDIT,
     AUDIT_KEY,
     CONSUMED_INVITATIONS,
+    INVITATIONS,
 ];
 
 /// Keyspaces captured by `POST /v1/backup/export` (P3.9). These hold
@@ -92,6 +97,9 @@ pub const BACKED_UP: &[&str] = &[
     // A consumed VIC must stay consumed across a restore, else a
     // restored community could re-redeem a single-use invitation.
     CONSUMED_INVITATIONS,
+    // Issued-invitation registry — durable so revocation + listing
+    // survive a restore.
+    INVITATIONS,
 ];
 
 /// Keyspaces deliberately omitted from backup (P3.9): ephemeral auth,
@@ -118,7 +126,7 @@ mod tests {
     /// keyspace is added to one without the other, this trips.
     #[test]
     fn all_matches_app_state_keyspace_count() {
-        assert_eq!(ALL.len(), 22, "ALL must list every AppState keyspace");
+        assert_eq!(ALL.len(), 23, "ALL must list every AppState keyspace");
     }
 
     /// The backup census (P3.9): every keyspace is either backed up or

--- a/vtc-service/src/test_support.rs
+++ b/vtc-service/src/test_support.rs
@@ -229,6 +229,7 @@ impl TestVtcBuilder {
         let consumed_invitations_ks = store
             .keyspace("consumed_invitations")
             .expect("consumed_invitations ks");
+        let invitations_ks = store.keyspace("invitations").expect("invitations ks");
 
         let jwt_keys =
             Arc::new(JwtKeys::from_ed25519_bytes(&JWT_SEED, "VTC").expect("build VTC JWT keys"));
@@ -341,6 +342,7 @@ impl TestVtcBuilder {
             audit_ks,
             audit_key_ks,
             consumed_invitations_ks,
+            invitations_ks,
             registry_client: None,
             registry_health: crate::registry::RegistryHealth::new(),
             syncer_health: crate::registry::SyncerHealth::new(),

--- a/vtc-service/tests/invitations.rs
+++ b/vtc-service/tests/invitations.rs
@@ -23,6 +23,8 @@ use vtc_service::test_support::TestVtc;
 
 const PUBLIC_URL: &str = "https://vtc.example.com";
 const ISSUE_TASK: &str = "https://trusttasks.org/openvtc/vtc/invitations/issue/1.0";
+const LIST_TASK: &str = "https://trusttasks.org/openvtc/vtc/invitations/issue/1.0";
+const REVOKE_TASK: &str = "https://trusttasks.org/openvtc/vtc/invitations/revoke/1.0";
 const ADMIN_DID: &str = "did:key:zInvAdmin";
 const MEMBER_DID: &str = "did:key:zInvMember";
 const INVITEE_DID: &str = "did:key:zInvitee";
@@ -192,4 +194,108 @@ async fn inviting_an_existing_member_is_a_conflict() {
     let resp = fix.router.clone().oneshot(req).await.unwrap();
     let (status, _) = body_value(resp).await;
     assert_eq!(status, StatusCode::CONFLICT);
+}
+
+#[tokio::test]
+async fn invite_can_grant_a_role_via_scopes() {
+    let fix = build().await;
+    let req = issue_req(
+        &fix.admin_token,
+        json!({ "subjectDid": INVITEE_DID, "role": "moderator" }),
+    );
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    let (status, v) = body_value(resp).await;
+    assert_eq!(status, StatusCode::CREATED, "{v}");
+    let scopes = v["vic"]["credentialSubject"]["scopes"]
+        .as_array()
+        .expect("VIC carries credentialSubject.scopes");
+    assert!(
+        scopes.iter().any(|s| s == "role:moderator"),
+        "role rides in scopes: {scopes:?}"
+    );
+}
+
+#[tokio::test]
+async fn issue_list_revoke_round_trip() {
+    let fix = build().await;
+
+    // Issue → the registry lists it as live.
+    let req = issue_req(&fix.admin_token, json!({ "subjectDid": INVITEE_DID }));
+    let (status, v) = body_value(fix.router.clone().oneshot(req).await.unwrap()).await;
+    assert_eq!(status, StatusCode::CREATED, "{v}");
+    let vic_id = v["vic"]["id"].as_str().expect("vic id").to_string();
+
+    let list_req = Request::builder()
+        .method("GET")
+        .uri("/v1/invitations")
+        .header("authorization", format!("Bearer {}", fix.admin_token))
+        .header("trust-task", LIST_TASK)
+        .body(Body::empty())
+        .unwrap();
+    let (status, v) = body_value(fix.router.clone().oneshot(list_req).await.unwrap()).await;
+    assert_eq!(status, StatusCode::OK, "{v}");
+    let row = v["invitations"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|i| i["id"] == json!(vic_id))
+        .expect("issued invitation is listed");
+    assert!(
+        row.get("revokedAt").is_none(),
+        "live invite has no revokedAt"
+    );
+
+    // Revoke → 200, newlyRevoked.
+    let del = Request::builder()
+        .method("DELETE")
+        .uri(format!("/v1/invitations/{vic_id}"))
+        .header("authorization", format!("Bearer {}", fix.admin_token))
+        .header("trust-task", REVOKE_TASK)
+        .body(Body::empty())
+        .unwrap();
+    let (status, v) = body_value(fix.router.clone().oneshot(del).await.unwrap()).await;
+    assert_eq!(status, StatusCode::OK, "{v}");
+    assert_eq!(v["newlyRevoked"], json!(true));
+
+    // Revoking again is idempotent (newlyRevoked = false).
+    let del2 = Request::builder()
+        .method("DELETE")
+        .uri(format!("/v1/invitations/{vic_id}"))
+        .header("authorization", format!("Bearer {}", fix.admin_token))
+        .header("trust-task", REVOKE_TASK)
+        .body(Body::empty())
+        .unwrap();
+    let (status, v) = body_value(fix.router.clone().oneshot(del2).await.unwrap()).await;
+    assert_eq!(status, StatusCode::OK, "{v}");
+    assert_eq!(v["newlyRevoked"], json!(false));
+}
+
+#[tokio::test]
+async fn revoke_unknown_invitation_is_404() {
+    let fix = build().await;
+    let del = Request::builder()
+        .method("DELETE")
+        .uri("/v1/invitations/urn:uuid:does-not-exist")
+        .header("authorization", format!("Bearer {}", fix.admin_token))
+        .header("trust-task", REVOKE_TASK)
+        .body(Body::empty())
+        .unwrap();
+    let (status, _) = body_value(fix.router.clone().oneshot(del).await.unwrap()).await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn invite_refuses_admin_role() {
+    let fix = build().await;
+    let req = issue_req(
+        &fix.admin_token,
+        json!({ "subjectDid": INVITEE_DID, "role": "admin" }),
+    );
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    let (status, _) = body_value(resp).await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "an invite may not grant admin"
+    );
 }


### PR DESCRIPTION
## Summary

Follow-ups to the VIC auto-join feature (#522): role-on-invite, invitation revocation, a recognition (trust-graph) admin view, and the subject-linkage binding model.

Companion PR (applicant side): OpenVTC `feat(join): join-as-subject + paste-a-VIC`.

## What's included

**#4 — Honor VIC scopes (role on invite).** `POST /v1/invitations` accepts an optional `role` (`admin` refused — the no-admin-via-join ceiling would deny it). The role rides in the VIC's `credentialSubject.scopes` as `role:<name>`; the default `join.rego` admits at that role (ceiling-bounded). Admin-UI issue form gains a role select.

**#5 — Invitation revocation.** New durable `invitations` registry keyspace (id → slot / subject / role / revocation state). `GET /v1/invitations` lists issued invites; `DELETE /v1/invitations/{id}` flips the revocation bit (idempotent). Admin-UI gains a list + Revoke control.

**#7 — Recognition (trust-graph) admin view.** `GET /v1/recognition/check?did=` runs a TRQP `recognise` (per-DID — the graph lives upstream, not listable) so the operator can see whether a foreign issuer/community is trusted (the M2 trust verdict). New admin-UI **Recognition** plugin (registry status + lookup).

**#1b — Subject-linkage binding (VTC verify).** A presenter who is not the VIC subject may redeem it by presenting a `subjectLinkage` proof in which the subject signs `TAG‖vic_id‖presenter`, verified against the subject's resolved key. Lets a holder join under a fresh DID without re-issuing the VIC (linking the two DIDs at the community).

## Tests
+role/list/revoke route tests, +role/scope policy tests, +3 linkage unit tests. `vtc-service` lib **658** + invitations **7** green; admin UI typechecks + bundles. Keyspace census updated to 23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)