### PR TITLE
feat(consent): per-platform approver registry (Track A)

### DIFF
--- a/affinidi-ai-agents-deck.html
+++ b/affinidi-ai-agents-deck.html
@@ -1,0 +1,301 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Affinidi · Verifiable Trust for AI Agents</title>
+<style>
+  :root{
+    --bg:#0a0e1a; --bg2:#0e1424; --panel:#141d33; --panel2:#101830;
+    --ink:#eef2fb; --muted:#9db0d4; --line:#26314f;
+    --brand:#ff4d6d;          /* Affinidi coral */
+    --brand-soft:#ff7d95;
+    --accent:#5ee0c0;         /* teal secondary */
+    --blue:#6ea8fe;
+  }
+  *{box-sizing:border-box}
+  html,body{margin:0;height:100%}
+  body{
+    background:var(--bg); color:var(--ink);
+    font:16px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+    -webkit-font-smoothing:antialiased; overflow:hidden;
+  }
+  /* deck */
+  .deck{height:100vh;width:100vw;overflow-y:scroll;scroll-snap-type:y mandatory;scroll-behavior:smooth}
+  .slide{
+    height:100vh;width:100vw;scroll-snap-align:start;scroll-snap-stop:always;
+    position:relative;display:flex;flex-direction:column;justify-content:center;
+    padding:clamp(40px,7vw,110px) clamp(28px,8vw,140px);
+    background:
+      radial-gradient(900px 500px at 88% -8%, #ff4d6d18, transparent),
+      radial-gradient(700px 500px at -5% 105%, #5ee0c014, transparent),
+      var(--bg);
+    border-bottom:1px solid #0c1222;
+  }
+  .slide.center{align-items:center;text-align:center}
+  /* brand chrome */
+  .wordmark{position:absolute;top:clamp(20px,4vh,40px);left:clamp(28px,8vw,140px);
+    display:flex;align-items:center;gap:9px;font-weight:800;letter-spacing:-.01em;font-size:19px}
+  .wordmark .mk{width:13px;height:13px;border-radius:50%;background:var(--brand);box-shadow:0 0 16px #ff4d6d99}
+  .wordmark .url{color:var(--muted);font-weight:500;font-size:13px;margin-left:4px}
+  .pageno{position:absolute;bottom:clamp(20px,4vh,40px);right:clamp(28px,8vw,140px);color:var(--muted);font-size:13px;letter-spacing:.05em}
+  .kicker{color:var(--brand-soft);font-weight:700;letter-spacing:.2em;text-transform:uppercase;font-size:12.5px;margin-bottom:18px}
+  h1{font-size:clamp(34px,6.2vw,72px);line-height:1.03;margin:0 0 .3em;letter-spacing:-.02em;font-weight:800}
+  h2{font-size:clamp(26px,4.4vw,46px);line-height:1.07;margin:0 0 .55em;letter-spacing:-.02em;font-weight:800}
+  .lead{font-size:clamp(17px,2.4vw,23px);color:var(--muted);max-width:60ch;margin:0}
+  .grad{background:linear-gradient(92deg,#fff 0%,#ffd0d9 40%,var(--brand) 75%);-webkit-background-clip:text;background-clip:text;color:transparent}
+  /* generic bits */
+  .grid{display:grid;gap:16px;margin-top:8px}
+  .g3{grid-template-columns:repeat(3,1fr)} .g2{grid-template-columns:repeat(2,1fr)}
+  @media(max-width:900px){.g3{grid-template-columns:1fr 1fr}}
+  @media(max-width:620px){.g3,.g2{grid-template-columns:1fr}}
+  .card{background:linear-gradient(180deg,var(--panel),var(--panel2));border:1px solid var(--line);
+    border-radius:16px;padding:20px}
+  .card .ic{font-size:26px;display:block;margin-bottom:10px}
+  .card h3{margin:0 0 6px;font-size:17px}
+  .card p{margin:0;color:var(--muted);font-size:14.5px}
+  .flow{display:flex;gap:12px;flex-wrap:wrap;align-items:stretch;margin-top:14px}
+  .node{flex:1 1 170px;min-width:150px;background:linear-gradient(180deg,var(--panel),var(--panel2));
+    border:1px solid var(--line);border-radius:14px;padding:18px;text-align:center}
+  .node b{display:block;font-size:16px;margin-bottom:5px} .node span{color:var(--muted);font-size:13px}
+  .arrow{align-self:center;color:var(--brand);font-size:24px;font-weight:800}
+  @media(max-width:680px){.arrow{transform:rotate(90deg);align-self:center}}
+  .split{display:grid;grid-template-columns:1fr 1fr;gap:20px;margin-top:8px}
+  @media(max-width:820px){.split{grid-template-columns:1fr}}
+  .lane{border:1px solid var(--line);border-radius:18px;padding:22px;background:linear-gradient(180deg,#111a30,#0d1426)}
+  .lane.personal{border-color:#3a4f86} .lane.enterprise{border-color:#2f5a48}
+  .lane h3{margin:0 0 2px;font-size:21px}
+  .lane .tag{color:var(--muted);font-size:13px;margin:0 0 14px}
+  ul.checks{list-style:none;margin:0;padding:0}
+  ul.checks li{padding:8px 0 8px 26px;position:relative;font-size:15px;color:#dbe6f8;border-top:1px dashed #1e2a47}
+  ul.checks li:first-child{border-top:0}
+  ul.checks li::before{content:"";position:absolute;left:2px;top:13px;width:9px;height:9px;border-radius:3px;background:var(--brand)}
+  .lane.enterprise ul.checks li::before{background:var(--accent)}
+  code{background:#0a1326;border:1px solid var(--line);border-radius:6px;padding:1px 7px;font-size:.84em;color:#ffd0d9}
+  /* walkthrough steps */
+  .steps{display:grid;grid-template-columns:repeat(3,1fr);gap:16px;margin-top:10px}
+  @media(max-width:900px){.steps{grid-template-columns:1fr 1fr}}
+  @media(max-width:600px){.steps{grid-template-columns:1fr}}
+  .step{position:relative;background:linear-gradient(180deg,var(--panel),var(--panel2));border:1px solid var(--line);
+    border-radius:16px;padding:18px 18px 16px}
+  .step .n{position:absolute;top:-13px;left:16px;width:30px;height:30px;border-radius:50%;
+    background:var(--brand);color:#fff;font-weight:800;display:flex;align-items:center;justify-content:center;font-size:14px;
+    box-shadow:0 4px 16px #ff4d6d55}
+  .step h4{margin:10px 0 6px;font-size:15.5px}
+  .step p{margin:0 0 10px;color:var(--muted);font-size:13.5px}
+  .step .cmd{display:block;background:#070d1c;border:1px solid var(--line);border-radius:8px;padding:8px 10px;
+    font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:12px;color:#bfe3d6;white-space:pre-wrap;word-break:break-word}
+  .scenario{display:inline-flex;gap:10px;align-items:center;background:#101a30;border:1px solid var(--line);
+    border-radius:999px;padding:8px 16px;color:var(--muted);font-size:14px;margin-bottom:18px}
+  .scenario b{color:var(--ink)}
+  .statrow{display:flex;gap:26px;flex-wrap:wrap;margin-top:26px}
+  .stat .big{font-size:clamp(30px,5vw,52px);font-weight:800;color:#fff;line-height:1}
+  .stat .lbl{color:var(--muted);font-size:13.5px;max-width:200px}
+  .cta{display:inline-block;margin-top:24px;background:var(--brand);color:#fff;font-weight:700;text-decoration:none;
+    padding:13px 26px;border-radius:12px;box-shadow:0 10px 30px #ff4d6d44}
+  .cta.ghost{background:transparent;border:1px solid var(--line);color:var(--ink);box-shadow:none;margin-left:10px}
+  /* nav dots */
+  .dots{position:fixed;right:18px;top:50%;transform:translateY(-50%);display:flex;flex-direction:column;gap:11px;z-index:20}
+  .dots button{width:9px;height:9px;border-radius:50%;border:0;background:#33405f;cursor:pointer;padding:0;transition:.2s}
+  .dots button.on{background:var(--brand);transform:scale(1.45)}
+  .hint{position:fixed;left:50%;bottom:16px;transform:translateX(-50%);color:#5e6f93;font-size:12px;z-index:20;
+    background:#0c1326cc;border:1px solid var(--line);border-radius:999px;padding:5px 14px;backdrop-filter:blur(6px)}
+  @media print{.dots,.hint{display:none}.deck{overflow:visible;height:auto}.slide{height:auto;min-height:auto;page-break-after:always}body{overflow:visible}}
+</style>
+</head>
+<body>
+<div class="deck" id="deck">
+
+  <!-- 1 TITLE -->
+  <section class="slide center">
+    <div class="kicker">Affinidi · Verifiable Trust Infrastructure</div>
+    <h1 class="grad">Verifiable trust<br/>for AI agents</h1>
+    <p class="lead">Give every AI agent — personal or enterprise — a real identity, scoped
+    permissions, secrets, and a kill switch. Reachable from any agent host over the Model Context Protocol.</p>
+  </section>
+
+  <!-- 2 PROBLEM -->
+  <section class="slide">
+    <div class="kicker">The problem</div>
+    <h2>AI agents can <span class="grad">act</span> — but they have no identity.</h2>
+    <p class="lead">We're handing agents our credentials, our keys, and the authority to do things on
+    our behalf. Today that means shared secrets, static API keys, and no way to say who did what — or to cut an agent off.</p>
+    <div class="grid g3" style="margin-top:34px">
+      <div class="card"><span class="ic">🕳️</span><h3>No identity</h3><p>Agents borrow a human's login or a shared service account. Nothing is attributable.</p></div>
+      <div class="card"><span class="ic">🔓</span><h3>Over-shared secrets</h3><p>Raw API keys and passwords get pasted into prompts and configs.</p></div>
+      <div class="card"><span class="ic">🚫</span><h3>No off switch</h3><p>When an agent goes rogue or a laptop is lost, there's no clean way to revoke it.</p></div>
+    </div>
+  </section>
+
+  <!-- 3 SOLUTION -->
+  <section class="slide center">
+    <div class="kicker">The solution</div>
+    <h2>A Verifiable Trust Agent <span class="grad">+ MCP</span></h2>
+    <p class="lead">Affinidi's VTA gives each agent a cryptographic identity, a permission boundary, a
+    secrets vault, and a signing oracle. <b>vta-mcp</b> exposes all of it to any MCP-speaking host — with zero custom code.</p>
+    <div class="flow" style="max-width:980px">
+      <div class="node"><b>🤖 AI Agent</b><span>Claude, an agent framework, an IDE</span></div>
+      <div class="arrow">→</div>
+      <div class="node"><b>🔌 vta-mcp</b><span>identity · sign · vault · DIDs · present</span></div>
+      <div class="arrow">→</div>
+      <div class="node"><b>🛡️ VTA</b><span>keys · ACL · policy · audit</span></div>
+      <div class="arrow">→</div>
+      <div class="node"><b>🔭 The world</b><span>verifiers · DID hosts · services</span></div>
+    </div>
+  </section>
+
+  <!-- 4 CAPABILITIES -->
+  <section class="slide">
+    <div class="kicker">What an agent can do</div>
+    <h2>Six capabilities, one permission boundary</h2>
+    <div class="grid g3" style="margin-top:22px">
+      <div class="card"><span class="ic">🪪</span><h3>Own a verifiable identity</h3><p>The VTA mints the agent a DID and enrols it as a managed device.</p></div>
+      <div class="card"><span class="ic">✍️</span><h3>Sign without keys</h3><p>The signing oracle signs on its behalf; private keys never leave the VTA.</p></div>
+      <div class="card"><span class="ic">🔐</span><h3>Use secrets safely</h3><p>Release credentials from the vault as sealed, end-to-end-encrypted envelopes.</p></div>
+      <div class="card"><span class="ic">📜</span><h3>Present credentials</h3><p>Build holder-bound Verifiable Presentations (OID4VP) to prove things.</p></div>
+      <div class="card"><span class="ic">🌐</span><h3>Resolve &amp; manage DIDs</h3><p>Resolve any DID; create &amp; publish <code>did:webvh</code>.</p></div>
+      <div class="card"><span class="ic">🛠️</span><h3>Drive the whole VTA</h3><p>Contexts, keys, ACLs, devices, vault, audit, backup — all over MCP.</p></div>
+    </div>
+  </section>
+
+  <!-- 5 SECURITY -->
+  <section class="slide">
+    <div class="kicker">Security model</div>
+    <h2>Autonomy you can <span class="grad">bound and revoke</span></h2>
+    <p class="lead">The trust controls are enforced where it counts — at authentication, not just in a dashboard.</p>
+    <div class="grid g3" style="margin-top:26px">
+      <div class="card"><span class="ic">🧯</span><h3>Real kill switch</h3><p>Disable / wipe is enforced at auth — a revoked agent simply can't authenticate.</p></div>
+      <div class="card"><span class="ic">🎯</span><h3>Least privilege</h3><p>Role + ACL bound every call. Grant <code>sign</code> without <code>delete</code>.</p></div>
+      <div class="card"><span class="ic">🙅</span><h3>No key exposure</h3><p>Keys stay at the VTA or in-process; they never cross MCP.</p></div>
+      <div class="card"><span class="ic">✋</span><h3>Human-in-the-loop</h3><p>Step-up policy can require a passkey approval before high-impact actions.</p></div>
+      <div class="card"><span class="ic">📦</span><h3>Sealed transport</h3><p>Secrets move as DIDComm-authcrypt / HPKE-sealed envelopes.</p></div>
+      <div class="card"><span class="ic">🧾</span><h3>Full audit</h3><p>Every action attributable to the agent's DID, filterable per agent.</p></div>
+    </div>
+  </section>
+
+  <!-- 6 WALKTHROUGH -->
+  <section class="slide">
+    <div class="kicker">Concrete walkthrough</div>
+    <h2>Stand up an agent — and revoke it</h2>
+    <div class="scenario">🧳 Scenario: <b>&nbsp;Nova</b>, a personal travel agent that books flights using your airline credentials.</div>
+    <div class="steps">
+      <div class="step"><div class="n">1</div><h4>Mint its identity</h4>
+        <p>The VTA mints Nova a DID from the <code>ai-agent</code> template.</p>
+        <span class="cmd">pnm bootstrap provision-integration \
+  --template ai-agent --create-context</span></div>
+      <div class="step"><div class="n">2</div><h4>Scope its powers</h4>
+        <p>Grant least privilege — read &amp; release vault secrets, sign on your behalf. Nothing more.</p>
+        <span class="cmd">role: application
+caps: vault-read, fill-release,
+      sign-trust-task</span></div>
+      <div class="step"><div class="n">3</div><h4>Plug into the host</h4>
+        <p>Point the agent host at the MCP bridge. No SDK, no glue code.</p>
+        <span class="cmd">"vta": { "command": "vta-mcp",
+         "args": ["--vta","nova"] }</span></div>
+      <div class="step"><div class="n">4</div><h4>It does the job</h4>
+        <p>Nova releases the airline API key (sealed), signs the booking, proves loyalty tier with a VP.</p>
+        <span class="cmd">vault_release "airline-api"
+sign  "booking#4471"
+issue_vp  loyalty-gold</span></div>
+      <div class="step"><div class="n">5</div><h4>See what it did</h4>
+        <p>Every action is attributable to Nova's DID.</p>
+        <span class="cmd">pnm audit --actor did:webvh:…:nova</span></div>
+      <div class="step"><div class="n">6</div><h4>Revoke instantly</h4>
+        <p>Laptop lost or job done? One command and Nova can no longer authenticate.</p>
+        <span class="cmd">pnm device wipe nova-laptop \
+  --reason "lost" --scope full</span></div>
+    </div>
+  </section>
+
+  <!-- 7 PERSONAL vs ENTERPRISE -->
+  <section class="slide">
+    <div class="kicker">Who it's for</div>
+    <h2>The same bridge — personal &amp; enterprise</h2>
+    <div class="split">
+      <div class="lane personal">
+        <h3>👤 Personal AI agents</h3>
+        <p class="tag">your own side-kick, on your device</p>
+        <ul class="checks">
+          <li>One <code>--vta</code> flag — the agent acts as <em>you</em>, within limits you set.</li>
+          <li>Your secrets stay in <em>your</em> vault; released sealed, only when needed.</li>
+          <li>Lost the laptop? <code>device wipe</code> cuts it off instantly.</li>
+          <li>Signs &amp; presents on your behalf — without ever seeing your keys.</li>
+        </ul>
+      </div>
+      <div class="lane enterprise">
+        <h3>🏢 Enterprise AI agents</h3>
+        <p class="tag">fleets under central governance</p>
+        <ul class="checks">
+          <li>Each agent is a first-class, revocable identity — no shared service accounts.</li>
+          <li>Least-privilege per agent; blast radius bounded by design.</li>
+          <li>Central secrets &amp; signing — rotate or revoke without touching agent code.</li>
+          <li>Complete, attributable audit trail for compliance &amp; incident response.</li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <!-- 8 WHY AFFINIDI / REACH -->
+  <section class="slide">
+    <div class="kicker">Why it stands out</div>
+    <h2>Standards-native, <span class="grad">drop-in</span>, governable</h2>
+    <p class="lead">Built on open standards — DIDs, Verifiable Credentials, OID4VP, DIDComm — so it
+    interoperates across orgs and verifiers instead of locking you into a walled garden.</p>
+    <div class="statrow">
+      <div class="stat"><div class="big">All</div><div class="lbl">VTA operations reachable as MCP tools</div></div>
+      <div class="stat"><div class="big">0</div><div class="lbl">lines of custom integration per host</div></div>
+      <div class="stat"><div class="big">1</div><div class="lbl">role/ACL bounds everything an agent can do</div></div>
+      <div class="stat"><div class="big">∞</div><div class="lbl">agents — each its own revocable identity</div></div>
+    </div>
+  </section>
+
+  <!-- 9 CLOSE -->
+  <section class="slide center">
+    <div class="kicker">Get started</div>
+    <h1 class="grad" style="font-size:clamp(30px,5.4vw,60px)">Trust your agents.<br/>On your terms.</h1>
+    <p class="lead">Verifiable identity, scoped permissions, sealed secrets, and instant revocation —
+    for every AI agent, over MCP.</p>
+    <div>
+      <a class="cta" href="https://www.affinidi.com" target="_blank" rel="noopener">affinidi.com</a>
+      <a class="cta ghost" href="https://www.affinidi.com" target="_blank" rel="noopener">Talk to us</a>
+    </div>
+  </section>
+
+</div>
+
+<div class="dots" id="dots"></div>
+<div class="hint">↑ ↓ / ← → / Space to navigate · S for slide list</div>
+
+<script>
+  const deck=document.getElementById('deck');
+  const slides=[...document.querySelectorAll('.slide')];
+  const dotsWrap=document.getElementById('dots');
+
+  // brand chrome per slide
+  slides.forEach((s,i)=>{
+    const wm=document.createElement('div'); wm.className='wordmark';
+    wm.innerHTML='<span class="mk"></span>affinidi<span class="url">affinidi.com</span>';
+    const pg=document.createElement('div'); pg.className='pageno';
+    pg.textContent=String(i+1).padStart(2,'0')+' / '+String(slides.length).padStart(2,'0');
+    s.appendChild(wm); s.appendChild(pg);
+    const b=document.createElement('button'); b.title='Slide '+(i+1);
+    b.onclick=()=>slides[i].scrollIntoView(); dotsWrap.appendChild(b);
+  });
+  const dots=[...dotsWrap.children];
+
+  let cur=0;
+  const io=new IntersectionObserver((es)=>{
+    es.forEach(e=>{ if(e.isIntersecting){ cur=slides.indexOf(e.target);
+      dots.forEach((d,i)=>d.classList.toggle('on',i===cur)); }});
+  },{threshold:.6});
+  slides.forEach(s=>io.observe(s));
+
+  function go(n){ n=Math.max(0,Math.min(slides.length-1,n)); slides[n].scrollIntoView(); }
+  addEventListener('keydown',(e)=>{
+    if(['ArrowDown','ArrowRight',' ','PageDown'].includes(e.key)){e.preventDefault();go(cur+1);}
+    else if(['ArrowUp','ArrowLeft','PageUp'].includes(e.key)){e.preventDefault();go(cur-1);}
+    else if(e.key==='Home'){go(0);} else if(e.key==='End'){go(slides.length-1);}
+  });
+</script>
+</body>
+</html>

--- a/tasks/test-harness-plan.md
+++ b/tasks/test-harness-plan.md
@@ -1,0 +1,326 @@
+# Virtual Test Environment & Mock Fabric Plan
+
+Source: test-infrastructure inventory of the verifiable-trust-infrastructure
+workspace (2026-06-10), commissioned to answer "how do we stand up mock
+VTA / PNM / VTC services and run virtual integration + deployment tests
+easily." This document is self-contained — it can be executed over time
+without the original conversation. Task checklist:
+`tasks/test-harness-todo.md`. Companion to the VTA/VTC architecture plans
+(`tasks/vta-architecture-plan.md`, `tasks/vtc-architecture-plan.md`); where a
+task here depends on one of those (notably non-interactive VTC setup), it is
+called out.
+
+**Goal:** a single test *fabric* that stands up the whole topology
+(VTA + VTC + mediator + CLIs) in-process for fast CI integration tests, and the
+*same* fabric against real ports/containers for deployment validation — tests
+target uniform **service handles**, not URLs or routers, so one test body runs
+on either backend. Build on the existing `test-support` foundation (mature for
+VTA, absent for VTC); do not reinvent it.
+
+## Where we're starting from (ground truth)
+
+What already exists and is reusable as-is:
+- **VTA `test_support`** (`vta-service/src/test_support.rs`, feature
+  `test-support`): `MockVta::start()` binds `127.0.0.1:0` and serves the
+  **production routes** with real auth gates; `build_test_app()` →
+  `(Router, TestAppContext)`; `build_app_state()` is public
+  (`server.rs:196`); `bootstrap_test_vta()` seeds a fully-provisioned VTA
+  (seed + DID + keys); `TestStore` wraps a tempdir fjall.
+- **Auth seeding**: `tests/api_integration.rs:99-167` mints JWTs/sessions;
+  `AuthClaims::unsafe_local_cli_super_admin` (feature `cli-synthesis`).
+- **Real seal round-trip under test**: `vta-sdk/tests/provision_client_e2e.rs`
+  runs the genuine HPKE `seal_payload` against a wiremock fake VTA — proving
+  `sealed_transfer` works in tests.
+- **Embedded mediator**: `affinidi-messaging-test-mediator`'s
+  `TestMediator::spawn()` + the `TestVtaResponder` pattern
+  (`tests/e2e/tests/common/test_vta_responder.rs`) — the only way to exercise
+  success-path DIDComm today.
+- In-tree libs: `wiremock 0.6`, `tower::oneshot`, `http-body-util`, `tempfile`.
+
+The gaps this plan closes:
+1. **VTC has no `test_support`** — every `vtc-service/tests/*.rs` re-wires ~140
+   LOC of keyspace-opening + JWT init by hand (`tests/common/mod.rs` exports
+   only a webauthn helper).
+2. **No shared multi-service harness** — helpers live inside `vta-service`;
+   there is no orchestrator that stands up N services and wires them.
+3. **No cross-service test** — a VTC has never bootstrapped its signing bundle
+   *from* a VTA in any test (`credential_signer: None` in VTC test AppState).
+4. **DIDComm requires a real mediator** — `DIDCommSession` hard-codes a
+   WebSocket; no in-process loopback, so two services can't DIDComm in a unit
+   test without spawning `TestMediator` + responders.
+5. **CLIs are untested** — `pnm-cli`/`cnm-cli` have no tests and no `assert_cmd`;
+   there is no way to point a CLI at a mock service.
+6. **No deployment-mode story** — no scripted stand-up of real processes; blocked
+   in part by the missing non-interactive `vtc setup` (VTC plan P3.10).
+
+## How to use this plan
+
+- Each task is one PR-sized slice: code + tests that use it + a doc touch,
+  verified before merge.
+- Conventions per workspace CLAUDE.md: `cargo fmt`, DCO-signed commits (`-s`),
+  full CI before a PR, branch off main only after the prior PR merges.
+- Sizes: **S** ≤ ½ day, **M** 1–2 days, **L** 3–5 days, **XL** needs a design note.
+- The fabric is a `publish = false` dev crate — it never ships in a release
+  binary. Keep all of it behind `test-support`/dev-deps so production builds and
+  the TEE enclave never pull it in.
+- Tick items off in the todo file as they merge; record the PR number there.
+
+## Design in one picture
+
+```
+                         TestEnv (the fabric crate: vti-harness)
+        ┌──────────────┬──────────────┬──────────────┐
+        │ VtaHandle    │ VtcHandle    │ MediatorH    │   uniform handles:
+        │ .client()    │ .client()    │ .did()       │   base_url / client /
+        │ .base_url()  │ .seed_acl()  │ .url()       │   seed_* / did / shutdown
+        └──────┬───────┴──────┬───────┴──────┬───────┘
+               │              │              │
+   backend ────┴── Loopback  (ephemeral 127.0.0.1:0 ports + in-proc DIDComm   ← CI
+          │                   broker; tempdir stores; no external deps)
+          └────── Networked  (fixed ports / docker-compose + real mediator;   ← deploy
+                              real config.toml via `setup --from`)
+```
+
+Two backends behind one handle API. Loopback keeps the **real SDK HTTP client**
+unchanged (handles serve on a real loopback port, exactly as `MockVta` already
+does), so we never have to inject a tower service into the SDK. DIDComm is the
+only transport that needs a seam (Phase 2).
+
+---
+
+## Phase 0 — Parity & foundations (unblocks everything)
+
+### P0.1 — VTC `test_support` module at parity with VTA (M)
+**Problem:** `vtc-service` has no test-support surface; `tests/admin_config.rs`,
+`tests/install_flow.rs`, `tests/join_requests.rs` each hand-roll ~140 LOC of
+tempdir store + 20-keyspace open + `AppState` wiring + JWT init + audit writer
+(`tests/common/mod.rs` exports only `webauthn_harness::SoftEd25519Authenticator`).
+The VTA equivalent (`vta-service/src/test_support.rs`) is the proven template.
+**Change:** add `vtc_service::test_support` (feature `test-support` + dev-dep
+self-ref) exposing `TestVtcStore`, `build_test_vtc() -> (Router, TestVtcContext)`
+(reusing the production `routes::router()` + a `build_app_state`-style
+constructor — extract one from `server.rs` if not already separable),
+`MockVtc::start()` (binds `127.0.0.1:0`, production routes), and a
+`TestVtcContext` that can pre-seed ACL/member/session rows and mint tokens.
+Migrate the existing test files onto it (delete the duplicated setup).
+**Accept:** a VTC integration test sets up in ≤ ~10 LOC; `tests/admin_config.rs`
+et al. no longer contain inline keyspace-open boilerplate; `cargo test -p
+vtc-service` green.
+
+### P0.2 — `build_app_state` seam for VTC (S)
+**Problem:** VTA exposes `build_app_state()` publicly so a router can be built
+without `run()` binding TCP/spawning threads; VTC's AppState construction is
+entangled in `server.rs::run()`. P0.1 needs a clean constructor.
+**Change:** extract `vtc_service::server::build_app_state(config, store,
+seed/secret bundle, …) -> Result<AppState>` mirroring `vta-service/src/server.rs:196`;
+`run()` calls it then patches the TCP/DIDComm fields. (This also helps the VTC
+architecture work — single construction point.)
+**Accept:** `build_app_state` is callable from `test_support` with no TCP bind;
+`run()` behavior unchanged (existing VTC e2e green).
+
+### P0.3 — Bootstrap helpers: a provisioned VTC without the wizard (S)
+**Problem:** VTC test AppState runs with `credential_signer: None`, so signing
+routes 503 — no test can issue a VMC/VEC because there's no signing bundle.
+`bootstrap_test_vta()` solves the equivalent for VTA by direct seeding.
+**Change:** `bootstrap_test_vtc()` that injects a deterministic `VtcKeyBundle`
+(integration DID + signing keys) into the secret store the same way
+`bootstrap_test_vta()` seeds the VTA — so a standalone VTC test can sign. (Phase
+1 replaces the synthetic bundle with one minted by a real mock VTA for
+cross-service tests; this is the single-service shortcut.)
+**Accept:** a VTC test issues a VMC end-to-end with a bootstrapped signer; no
+wizard, no real VTA.
+
+### P0.4 — Optional: in-memory store backend (S)
+**Problem:** every test allocates a fresh tempdir + fjall DB
+(`vti-common/src/store/mod.rs:603` `temp_store()`); fine, but a large fabric (VTA
++ VTC + per-test) pays it N times. Not a blocker — note as an optimization.
+**Change:** evaluate whether fjall offers an in-memory/`tmpfs` mode or whether a
+RAM-disk tempdir is enough; if cheap, add `Store::in_memory()` behind
+`test-support`. Skip if fjall has no clean in-memory path — tempdir is acceptable.
+**Accept:** either an `in_memory()` constructor used by the harness, or a recorded
+decision that tempdir is fast enough (with a rough per-service setup cost).
+
+**Checkpoint 0:** VTC has `test_support` at VTA parity; both crates expose a
+TCP-free AppState constructor; a single VTC test can sign. Full CI green.
+
+---
+
+## Phase 1 — The multi-service fabric (in-process, pragmatic DIDComm)
+
+### P1.1 — `vti-harness` crate skeleton + `TestEnv` builder (M)
+**Problem:** test helpers are siloed in `vta-service`; nothing stands up more
+than one service or coordinates them.
+**Change:** new `publish = false` crate `vti-harness` depending on `vta-service`,
+`vtc-service`, `vta-sdk` (all `features = ["test-support"]`). Provide
+`TestEnv::builder().with_vta().with_vtc().build().await -> TestEnv` returning
+`VtaHandle`/`VtcHandle` (each: `base_url()`, `client()` → a configured SDK
+client, `shutdown()`), built on `MockVta`/`MockVtc`. Backend enum
+`Backend::{Loopback, Networked}` with Loopback implemented first.
+**Accept:** a test in `vti-harness/tests/` stands up a VTA + VTC and hits each
+over HTTP via its SDK client in < ~5 LOC of setup; `env.shutdown()` is clean.
+
+### P1.2 — Cross-service provision seeding: VTC bootstraps FROM the mock VTA (M)
+**Problem:** the VTA→VTC bootstrap (real `sealed_transfer`) has never run in a
+test; `provision_client_e2e.rs` only seals against a *wiremock* VTA, and no VTC
+consumes the bundle.
+**Change:** in `TestEnv` builder, when both services are present, run the **real**
+`provision_via_rest` from the VTC against the mock VTA's `base_url()`, receive a
+genuine HPKE-sealed `TemplateBootstrapPayload`, open it, and inject the signing
+bundle into the VTC's secret store. This replaces P0.3's synthetic bundle for
+multi-service tests and exercises seal/open + VP verification for real.
+**Accept:** `TestEnv::builder().with_vta().with_vtc().build()` yields a VTC whose
+`credential_signer` is `Some` and whose DID/keys were minted by the mock VTA; a
+test asserts the VTC can issue a VMC signed with VTA-minted keys.
+
+### P1.3 — Shared identity + seeding helpers (S)
+**Problem:** a cross-service flow needs the same member/holder identity known to
+both services; today each test mints ad-hoc DIDs.
+**Change:** `env.new_holder("alice") -> HolderHandle` (mints a `did:key`, can
+sign VPs/Trust Tasks); `vtc.seed_member(did, role)`, `vta.seed_acl(did, role,
+contexts)`, `*.admin_token()` convenience built on the existing JWT/session
+helpers (`api_integration.rs:99`).
+**Accept:** a holder created once is usable as applicant on the VTC and as a
+recipient on the VTA in the same test.
+
+### P1.4 — Pragmatic DIDComm: one-line embedded mediator (M)
+**Problem:** until the loopback transport (Phase 2) lands, DIDComm flows need a
+real mediator + responder; the e2e suite does this but with heavy per-test setup
+(`TestMediator::spawn()` + a `TestVtaResponder`).
+**Change:** `TestEnv::builder().with_mediator()` spawns the embedded
+`TestMediator` once for the env and registers each service as a listener
+(generalize `TestVtaResponder` into the harness so VTA *and* VTC can listen).
+Services constructed with `with_mediator` advertise/connect DIDComm.
+**Accept:** a join-over-DIDComm test (holder → VTC via mediator) round-trips in
+the harness with `with_mediator()` and no per-test mediator plumbing.
+
+**Checkpoint 1:** the missing cross-service tests now exist — VTA→VTC provision
+(real seal/open) and a holder→VTC join over a real (embedded) mediator. The
+fabric is usable for integration tests today, before the loopback work.
+
+---
+
+## Phase 2 — In-process DIDComm loopback (the real unlock)
+
+### P2.1 — Transport seam at the workspace messaging boundary (L)
+**Problem:** `DIDCommSession` hard-codes a WebSocket to a mediator, so DIDComm
+tests can't avoid spawning real network services — the single biggest cost and
+flake source in the fabric. The crypto (authcrypt pack/unpack, sender auth) does
+not need a network to be exercised; only the wire hop does.
+**Change:** introduce a `Transport` trait at *our* messaging boundary (you
+already have `Transport::Rest`/`Transport::DIDComm` in `VtaClient`): keep
+`WebSocketTransport` as the production impl and add a `LoopbackTransport`. Route
+the VTA `messaging::*` listener and the SDK client send/recv through the trait.
+Pack/unpack stays real — only delivery is swapped. Coordinate the seam with the
+`affinidi-messaging` wrappers (the trait sits in *our* code wrapping ATM, not
+inside the third-party crate).
+**Accept:** the production path is byte-identical (the WebSocket impl is the
+default); the trait is the only delivery seam; existing DIDComm e2e green.
+
+### P2.2 — In-process DIDComm broker (M)
+**Problem:** loopback needs something to route packed messages between registered
+DIDs without HTTP.
+**Change:** an in-process broker (tokio channels keyed by recipient DID) that
+accepts a packed authcrypt envelope from one registered party and delivers it to
+another — the in-memory analogue of a mediator's store-and-forward, minus the
+network. `TestEnv` wires every service + holder to one broker when
+`Backend::Loopback`.
+**Accept:** two services (and a holder) DIDComm to each other in a single test
+with **no `TestMediator`, no port, no WebSocket**; sender authentication still
+verified (a spoofed `from` is rejected — ties to VTC plan P0.3).
+
+### P2.3 — Loopback becomes the default; embedded mediator reserved for fidelity (S)
+**Problem:** once the broker works, most integration tests shouldn't pay for a
+real mediator.
+**Change:** `TestEnv` defaults DIDComm to the loopback broker; keep
+`with_mediator()` (Phase 1) as an explicit opt-in for tests that specifically
+want to exercise mediator behavior (drain windows, sticky routing, offline
+queueing). Document when to use which.
+**Accept:** the join-over-DIDComm test from P1.4 runs with no mediator by
+default; an opt-in variant still runs against the embedded mediator.
+
+**Checkpoint 2:** the integration suite runs DIDComm flows in-process with no
+external dependencies; CI time and flake drop; the real-mediator path remains
+available for fidelity tests.
+
+---
+
+## Phase 3 — CLI harness & deployment mode
+
+### P3.1 — CLI test harness (M)
+**Problem:** `pnm-cli`/`cnm-cli` have zero tests and no `assert_cmd`; there's no
+way to point a CLI at a mock service or isolate its config dir.
+**Change:** add a CLI harness in `vti-harness`: a temp `HOME` → scratch
+`~/.config/{pnm,cnm}`, base-URL injection from a `VtaHandle`/`VtcHandle`, two
+drivers — (a) `assert_cmd` invoking the compiled binary (deployment confidence),
+(b) calling `vta_cli_common` command fns directly against in-process handles
+(fast, no spawn). Because the CLIs are thin wrappers over `vta-cli-common`, this
+is your "mock PNM / mock CNM" — the harness drives the same command surface.
+**Accept:** a test runs `pnm bootstrap` (or the equivalent command fn) against a
+mock VTA in the fabric and asserts the resulting `~/.config/pnm` state; config
+dir is fully isolated (no developer-home writes).
+
+### P3.2 — Non-interactive VTC setup (dependency: VTC plan P3.10) (L)
+**Problem:** the `Networked` deployment backend needs to write real
+`config.toml`s and stand services up without a TTY; `vtc setup` is interactive
+only (the VTC review's P3.10). VTA already has `setup --from <toml>`.
+**Change:** implement `vtc setup --from <toml>` (tracked as VTC-plan P3.10 —
+`WizardPlan` inputs struct + apply engine). The harness's `Networked` backend
+generates a TOML and invokes it.
+**Accept:** the harness can provision a real VTC process from a generated TOML
+with no prompts; covered by VTC-plan P3.10's own acceptance.
+
+### P3.3 — `Networked` backend + deployment smoke suite (M)
+**Problem:** in-process tests don't validate real process boot, port binding,
+config parsing, or container wiring — the things deployment actually breaks on.
+**Change:** implement `Backend::Networked` (bind fixed ports / optional
+`docker-compose.test.yml`, real config files, real embedded or external
+mediator) behind the same handle API. Add a `smoke/` suite asserting the headline
+flows across real processes: cold-start → provision-integration → join →
+recognise. Where the handle API allows, reuse the in-process test bodies.
+**Accept:** `cargo test -p vti-harness --features networked` (or a `make
+smoke`) boots real VTA + VTC + mediator processes and passes the cross-service
+smoke flow; CI job added (can be a slower/optional lane).
+
+### P3.4 — Docs + one worked example (S)
+**Problem:** a fabric nobody knows how to use rots.
+**Change:** `docs/06-testing/test-harness.md` (or similar): the handle API, the
+two backends, when to use loopback vs embedded mediator vs networked, and one
+fully-worked cross-service test (provision → join → recognise) as the copyable
+template. Link it from the root CLAUDE.md "Integration flows" section and each
+crate's CLAUDE.md.
+**Accept:** a new contributor can write a two-service test from the doc without
+reading the harness source.
+
+**Checkpoint 3:** mock PNM/CNM via the CLI harness; a deployment smoke suite over
+real processes; documented entry point. The original goals — mock VTA/PNM/VTC,
+easy virtual integration tests, stand-up of whole environments for deployment
+testing — are all reachable from `TestEnv`.
+
+---
+
+## Invariants any task must preserve (the do-not-break list)
+
+- **The fabric never ships.** `vti-harness`, all `test_support` modules, and
+  every seeding shortcut stay behind `test-support`/dev-deps and `publish =
+  false`. The TEE enclave binary (`vta-enclave`) and any release build must not
+  be able to pull them in (cf. `cli-synthesis` being absent from the enclave).
+- **Mocks serve production routes with real gates.** `MockVta` already does this;
+  `MockVtc` must too. A mock that bypasses auth/ACL is worthless for integration
+  testing — pre-seed credentials, don't disable the gate.
+- **Real crypto in the loopback path.** The DIDComm broker (P2.2) swaps delivery,
+  not packing — authcrypt pack/unpack and sender authentication stay real, so a
+  spoofed `from` is still rejected (the VTC P0.3 invariant must hold under
+  loopback exactly as under a mediator). Likewise the provision seeding (P1.2)
+  runs the genuine HPKE seal/open, not a stub.
+- **Production transport path is the default impl.** The `Transport` seam (P2.1)
+  must leave `WebSocketTransport` byte-identical to today; loopback is additive.
+- **Determinism without weakening crypto.** Deterministic seeds/keys in fixtures
+  are fine for reproducibility, but never introduce a non-CSPRNG or a
+  reduced-rounds KDF on a path shared with production (no test-only crypto
+  shortcuts that could leak into a real build).
+- **Config-dir isolation.** CLI tests must use a temp `HOME`; never read or write
+  the developer's real `~/.config/{pnm,cnm}` or OS keyring.
+- **One handle API across backends.** A test written against `VtaHandle`/
+  `VtcHandle` should run on Loopback and Networked unchanged wherever the flow
+  permits; backend-specific escapes (raw ports, container names) stay out of the
+  common test body.

--- a/tasks/test-harness-todo.md
+++ b/tasks/test-harness-todo.md
@@ -1,0 +1,91 @@
+# Todo: Virtual Test Environment & Mock Fabric
+
+Status legend: `[ ]` not started · `[~]` in progress · `[x]` done · `[!]` blocked
+
+Plan with full problem statements, file references, acceptance criteria, and the
+invariants do-not-break list: `tasks/test-harness-plan.md`.
+Record the PR number next to each task as it merges.
+
+Sizes: S ≤ ½ day · M 1–2 days · L 3–5 days · XL needs a design note first.
+
+Foundation already in place (reuse, don't rebuild): VTA `test_support`
+(`MockVta`, `build_test_app`, `build_app_state`, `bootstrap_test_vta`),
+real HPKE seal round-trip under wiremock (`vta-sdk/tests/provision_client_e2e.rs`),
+embedded `TestMediator` + `TestVtaResponder`, `wiremock`/`tower::oneshot`/`tempfile`.
+
+---
+
+## Phase 0 — Parity & foundations
+
+- `[ ]` **P0.1** (M) `vtc_service::test_support` at VTA parity (`TestVtcStore`,
+  `build_test_vtc`, `MockVtc`, `TestVtcContext`); migrate `tests/*` onto it — PR: ____
+- `[ ]` **P0.2** (S) Extract `vtc_service::server::build_app_state` (TCP-free
+  AppState constructor) — PR: ____
+- `[ ]` **P0.3** (S) `bootstrap_test_vtc()` injects a signing bundle so a
+  standalone VTC can sign (no wizard, no real VTA) — PR: ____
+- `[ ]` **P0.4** (S) In-memory store backend OR a recorded "tempdir is fast
+  enough" decision with measured per-service cost — PR: ____
+
+**Checkpoint 0:** `[ ]` VTC `test_support` at parity; both crates expose a
+TCP-free AppState constructor; a single VTC test can sign; CI green.
+
+## Phase 1 — Multi-service fabric (in-process, pragmatic DIDComm)
+
+- `[ ]` **P1.1** (M) `vti-harness` crate + `TestEnv::builder().with_vta().with_vtc()`;
+  `VtaHandle`/`VtcHandle` (`base_url`/`client`/`shutdown`); `Backend::Loopback` — PR: ____
+- `[ ]` **P1.2** (M) Cross-service provision seeding: VTC runs real
+  `provision_via_rest` against the mock VTA, opens the sealed bundle, gets a
+  VTA-minted signer — PR: ____
+- `[ ]` **P1.3** (S) Shared identity/seeding helpers (`new_holder`, `seed_member`,
+  `seed_acl`, `admin_token`) — PR: ____
+- `[ ]` **P1.4** (M) `with_mediator()` spawns embedded `TestMediator` once;
+  generalize `TestVtaResponder` so VTA + VTC listen — PR: ____
+
+**Checkpoint 1:** `[ ]` cross-service tests exist (VTA→VTC real provision;
+holder→VTC join over embedded mediator); fabric usable for integration tests.
+
+## Phase 2 — In-process DIDComm loopback (the unlock)
+
+- `[ ]` **P2.1** (L) `Transport` trait at the workspace messaging boundary;
+  `WebSocketTransport` (prod, unchanged) + `LoopbackTransport`; route VTA
+  messaging + SDK client through it — PR: ____
+- `[ ]` **P2.2** (M) In-process DIDComm broker (channel-routed packed envelopes,
+  real pack/unpack); wire env + holders to it on `Backend::Loopback` — PR: ____
+- `[ ]` **P2.3** (S) Loopback default for DIDComm; `with_mediator()` reserved for
+  fidelity (drain/sticky/offline) tests — PR: ____
+
+**Checkpoint 2:** `[ ]` DIDComm flows run in-process, no external deps; spoofed
+`from` still rejected under loopback; real-mediator path still available.
+
+## Phase 3 — CLI harness & deployment mode
+
+- `[ ]` **P3.1** (M) CLI harness: temp `HOME`, base-URL injection, dual driver
+  (`assert_cmd` binary + direct `vta_cli_common` fns) → mock PNM/CNM — PR: ____
+- `[ ]` **P3.2** (L) `vtc setup --from <toml>` — **= VTC-plan P3.10** (do it
+  there); the harness `Networked` backend consumes it — deps: VTC P3.10 — PR: ____
+- `[ ]` **P3.3** (M) `Backend::Networked` (fixed ports / compose, real config +
+  mediator) + `smoke/` suite: cold-start → provision → join → recognise across
+  real processes; CI lane — deps: P3.2 — PR: ____
+- `[ ]` **P3.4** (S) `docs/06-testing/test-harness.md` + one worked cross-service
+  example; link from root + crate CLAUDE.md — PR: ____
+
+**Checkpoint 3:** `[ ]` mock PNM/CNM via CLI harness; deployment smoke suite over
+real processes; documented entry point.
+
+---
+
+## Sequencing notes
+
+- **P0.1 is the keystone** — VTC parity unblocks the whole fabric and immediately
+  deletes ~140 LOC/test-file. Do it first.
+- **Phase 1 is usable before Phase 2.** Ship the fabric with the pragmatic
+  embedded mediator (P1.4), then make it fast/dependency-free with the loopback
+  broker (Phase 2). Don't block integration coverage on the transport seam.
+- **P3.2 is shared with the VTC architecture plan (P3.10).** Land it once; both
+  plans benefit. The deployment backend (P3.3) hard-depends on it.
+- **DIDComm loopback (P2.1/P2.2) is the highest-leverage but largest item** —
+  it's what removes the real-mediator dependency from everyday CI. Worth the L.
+- The fabric also becomes the natural home for **regression tests from the VTA/VTC
+  architecture reviews** that need two services (e.g. VTC P0.2 recognise
+  holder-binding, P0.3 DIDComm sender-spoof) — those are easier to write once the
+  fabric exists.

--- a/tasks/vtc-architecture-plan.md
+++ b/tasks/vtc-architecture-plan.md
@@ -1,0 +1,958 @@
+# VTC Architecture Simplification & Hardening Plan
+
+Source: full architecture review of vtc-service (2026-06-10, six-subsystem
+fan-out review covering auth/ACL/install, credentials/status-lists/recognition,
+membership/ceremony/policy, registry/messaging/audit, server/config/setup, and
+the HTTP edge). This document is self-contained — it can be executed over time
+without the original review conversation. Task checklist:
+`tasks/vtc-architecture-todo.md`. Companion to the VTA plan
+(`tasks/vta-architecture-plan.md`) — VTC shares the team's house patterns and
+several of the same bug classes, but is a distinct ~44k-LOC crate.
+
+**Goal:** close the security gaps found (the VTC handles a community's
+irreplaceable social state — members, ACL, endorsements, status lists, audit —
+none of it TEE-protected), make the service harder to misconfigure, and
+converge VTC's divergent surfaces onto the four house patterns it already
+contains but applies inconsistently:
+
+1. `vti-common::auth` extractors/handlers — for *all* token-mint paths
+2. Thin route adapters + `operations`/`ceremony` orchestration — for *all*
+   business logic (the VTC keeps decide→effect→audit spines in `routes/`)
+3. The `VerifiedFacts` / typestate `Verified*` discipline — for *all* wire
+   forms whose claims drive a decision
+4. A single config registry (`config_store`) + single `AppState` — for *all*
+   config mutation and derived runtime state
+
+## How to use this plan
+
+- Each task is one PR-sized vertical slice: root-cause fix + regression test +
+  doc touch, verified before merge. No horizontal "change all signatures" PRs.
+- Conventions per workspace CLAUDE.md: `cargo fmt`, DCO-signed commits (`-s`),
+  full CI (tests, clippy, cargo deny) before opening a PR, branch off main only
+  after the prior PR merges.
+- Sizes: **S** ≤ ½ day, **M** 1–2 days, **L** 3–5 days, **XL** needs its own design note.
+- Order within a phase is flexible unless a dependency is listed. Phase 0 fixes
+  can land any time; don't start a phase's *refactors* until its checkpoint passes.
+- Tick items off in the todo file as they merge; record the PR number there.
+- **VTC never targets TEE** (permanent non-goal). So unlike the VTA, there is no
+  enclave-rollback / KMS-bootstrap / attestation work here — but encryption-at-rest
+  for the keyspaces that hold private keys still matters (P0.7).
+
+## Dependency graph (phase level)
+
+```
+Phase 0 (security/correctness fixes) ──────────────┐  independent, parallelizable
+                                                    ▼
+Phase 1 (kill the divergence engines) ──► Checkpoint 1
+        P1.1 config-mutation unification ─► P2.* (single config surface)
+        P1.4 facts/sig helper extraction ─► P2.4
+                                                    ▼
+Phase 2 (collapse adapter shells + move logic out of routes) ──► Checkpoint 2
+                                                    ▼
+Phase 3 (strategic convergence + hygiene)
+```
+
+---
+
+## Phase 0 — Security & correctness fixes (do regardless of any refactor)
+
+These are bugs/gaps, not refactors. Mostly independent; land in any order.
+Highest severity first.
+
+### P0.1 — Status-list row needs concurrency control: revocations and slot allocations are silently lost (M)
+**Problem:** every status-list mutation is an unsynchronized read-modify-write —
+`get_state` → `allocate`/`flip` in memory → `store_state` whole-row overwrite
+(`status_list/storage.rs:99-119`). The only mutex in that subsystem is
+`LAST_ADMIN_LOCK` (`ceremony/execute.rs:64`), which does **not** cover status
+lists. Call sites that race on the same purpose row interleave as
+last-writer-wins over the entire 16 KiB bitstring + `assigned` mask
+(`ceremony/execute.rs:234-279,466-477`, `routes/endorsements.rs:135-146,349-361`,
+`credentials/invitation.rs:43-70`, `routes/members/renew.rs:100-124`,
+`routes/members/rotate.rs:581`, `routes/members/personhood.rs:286-298`). Two
+concrete failures, both reachable (REST + DIDComm handlers share `AppState`):
+(a) a `revoke` flip racing a concurrent `allocate`+store silently clears the
+revocation bit → a credential the operator believes revoked resolves valid;
+(b) two concurrent `allocate`s read the same row, the second store drops the
+first's `assigned[slot]=true` → future re-allocation aliases two members on the
+bitstring (the exact correlation harm #149's `assigned` mask exists to prevent).
+**Change:** a process-wide `static STATUS_LIST_LOCK` (mirroring `LAST_ADMIN_LOCK`)
+held across get→mutate→store at every call site, or push the RMW into one fjall
+transaction in `storage.rs`. Prefer a `status_list::with_locked(purpose, |row| …)`
+helper so callers can't forget it. Wrap the revoke flip + `mark_revoked`
+(`endorsements.rs:349-366`, `ceremony/execute.rs:466-477` + caller) under the
+same lock so they're atomic together.
+**Accept:** N concurrent `allocate` calls yield N distinct slots and
+`count_assigned() == N`; a `flip(revoke)` interleaved with a concurrent
+`allocate` keeps the revocation bit. Regression shape: `tokio::join!` of two
+issuance futures over a shared `AppState`.
+
+### P0.2 — Cross-community `recognise` is a bearer flow: no holder proof, no VMC↔VEC subject binding, no replay nonce (L)
+**Problem (three bound-together gaps in the most security-sensitive
+cross-org path):**
+(a) `POST /v1/auth/recognise` accepts a raw `(VEC, VMC)` JSON pair and mints a
+session JWT to the VEC's `credentialSubject.id` with **no proof the caller
+controls that subject's key** — no challenge, no nonce, no holder signature, no
+`aud` binding (`routes/recognise.rs:49-53,77-142`, verifier
+`recognition/verify.rs:162-252`). Anyone who observes/exfiltrates a member's
+VEC+VMC (plaintext signed JSON, no holder binding) replays them indefinitely to
+impersonate that subject in every recognising community. Contrast the join
+`present` path, which requires a holder proof bound to a single-use
+`present_challenge` nonce. The `recognise.rs:218` comment calls this "a
+single-factor proof of the subject DID" — but no proof occurs.
+(b) `verify_foreign_vec` checks `vec.issuer == vmc.issuer` but never checks
+`vmc.credentialSubject.id == vec.credentialSubject.id` (`verify.rs:162-252`,
+`extract_role_claim` reads only the VEC). The VMC's only job is the "is a live,
+non-revoked member" gate; without subject-binding, member A's role VEC + any
+other current member B's unrevoked VMC (same issuer) passes the gate even after
+the foreign community revoked A.
+(c) The denied-path audit envelope takes its actor DID from the *unverified*
+VEC subject field on an unauthenticated endpoint (`recognise.rs:112,363-392`,
+`credential_subject_id_for_audit` at `:401-412`) — attacker-controlled actor
+strings injected into the audit trail.
+**Change:** require a holder presentation — issue a single-use challenge (reuse
+`present_challenge`), accept the VEC/VMC inside a holder-signed VP/kb-jwt bound
+to nonce + this VTC's DID, verify via the existing `verify_vp_token`/
+`verify_di_vp`, and require the verified holder DID == VEC subject. Add the
+`vmc.subject == vec.subject` check. Tag denied-path audit actors as untrusted
+(prefix `unverified:` or actor `None` + `claimed_subject` data field). Update
+spec §8.4.
+**Accept:** replaying a captured VEC+VMC without a fresh holder proof → 401/403;
+a VEC for `did:key:zA` + VMC for `did:key:zB` (same issuer) → rejected; a valid
+holder-bound presentation with matching subjects → session minted; denied audit
+envelope carries no unverified DID as a verified actor.
+
+### P0.3 — DIDComm handlers trust the plaintext `from`, not the authenticated sender (M)
+**Problem:** `HandlerContext.sender_did` is populated from the plaintext `from`
+header (upstream listener `message.from.clone()`), not the authcrypt-authenticated
+`skid`/`encrypted_from_kid`. The VTC router installs **no `MessagePolicy`**
+(`messaging.rs:100`), so anoncrypt is accepted and `authenticated` is never
+required, and no handler inspects the `UnpackMetadata` argument
+(`messaging.rs:225-391`). The join-submit, join-accept, self-remove, and status
+handlers all treat `ctx.sender_did` as the proven applicant/member DID
+(`remove_inner(&caller_did, &caller_did, …)` is the worst — self-remove *as the
+victim*). This violates the house invariant that unpacking yields a
+cryptographically-authenticated sender DID.
+**Change:** require `meta.authenticated && !meta.anonymous_sender` and that the
+DID of `meta.encrypted_from_kid` equals `message.from` in each handler — or add
+`.layer(MessagePolicy::new().require_authenticated(true).allow_anonymous_sender(false))`
+to the router AND derive `sender_did` from `encrypted_from_kid`. Fix self-remove
+first.
+**Accept:** a message whose plaintext `from` ≠ the authcrypt key DID is rejected;
+an anoncrypt message to `member_self_remove_handler` is rejected; regression test
+asserts the handler reads `encrypted_from_kid`, not `from`.
+
+### P0.4 — Redirect-following SSRF bypass + no timeout/size-cap on the unauthenticated foreign-fetch path (M)
+**Problem:** `guard_status_list_url` (`recognition/verify.rs:557-655`) is a solid
+allowlist (https-only, rejects IP-literals/RFC1918/metadata/userinfo) but runs
+**once on the original URL**; the fetch uses `reqwest::Client::new()` which
+follows up to 10 redirects by default, so a foreign credential pointing at
+`https://attacker/list` that 302s to `http://127.0.0.1/...` or
+`169.254.169.254` reaches the internal target (`recognise.rs:108`,
+`present.rs:273,275`). The same client has **no `.timeout()`** and reads the body
+with `resp.json()` — no size cap (`verify.rs:643-646`, `upstream.rs:273-277`) —
+on the unauthenticated recognise route; a hostile host stalls the lone REST
+thread or OOMs the daemon with a multi-GB body. `UpstreamRegistryClient::new`
+sets a timeout; recognise/present don't (inconsistent hardening).
+**Change:** one shared client built with `.timeout(...)` +
+`.redirect(Policy::none())` (or a custom policy re-running `guard_status_list_url`
+on every hop), injected into `HttpStatusListFetcher`; read the body against a
+1–2 MB cap before `serde_json`.
+**Accept:** an in-test server that 302s to `127.0.0.1` makes `check_status_bit`
+return `StatusListFailed` (no internal fetch); a hung server trips the timeout;
+an oversized body fails rather than OOMs; no `reqwest::Client::new()` remains on
+these paths.
+
+### P0.5 — Unauthenticated crypto endpoints left on the ungoverned 1 MB chain (M)
+**Problem:** `recognise` was deliberately moved onto `build_unauth_routes`
+(64 KB cap + 5 rps governor) for its attacker-controlled crypto, but three
+sibling endpoints driving identical work were left on the main `api` chain
+(1 MB cap, no limiter): `POST /v1/join-requests` (`submit.rs:100`, Ed25519
+holder-binding verify + Rego eval), `POST /v1/join-requests/{id}/accept`
+(`accept.rs:79`, VC counter-sign verify), `POST /v1/join-requests/{id}/status`
+(`status.rs:46`, holder-binding verify) — all confirmed no auth extractor
+(`routes/mod.rs:669-715`). CPU-amplification/DoS at 16× the body size with no
+per-IP throttle.
+**Change:** move all three POST registrations into `build_unauth_routes`; split
+the shared `/v1/join-requests` mount so the admin `GET` list stays on `api` while
+the unauth `POST` moves to the governed branch.
+**Accept:** a router-enumeration test asserts every handler with no auth
+extractor is on the governed branch; >10 rapid `POST /v1/join-requests` from one
+IP returns 429.
+
+### P0.6 — Join-request retention sweeper is defined but never spawned: VP/PII retained forever (S)
+**Problem:** `RetentionSweeper::spawn` is the documented "sole control on
+inadvertent PII retention" (`join/retention.rs:55-89`) but a workspace search
+shows it is only defined + re-exported, never spawned in `server.rs` (which
+spawns the registry health probe and `MembershipSyncer`). `Rejected`/`Withdrawn`
+join requests — each holding the full submitted VP (up to 256 KiB, PII per the
+docs) — are never purged, and `join_requests:` grows unbounded. Same class:
+`credx-pending:` offers and `present-challenge:` records
+(`credentials/exchange.rs:1144-1196`, `present_challenge.rs:53-95`) have TTLs
+enforced only on the read path and are never swept (the join sweeper lists only
+the `join_requests:` prefix); and registry `Failed` sync jobs are never reaped
+(`syncer.rs:299,338`; `model.rs:143-145` comment claims a sweeper that doesn't
+exist).
+**Change:** spawn `RetentionSweeper` in `server.rs` wired from `JoinRequestsConfig`;
+extend it (or add siblings) to also sweep expired `credx-pending:`/
+`present-challenge:` rows and `Failed` sync jobs past a retention window. Fix the
+`model.rs` comment.
+**Accept:** a `Rejected` row dated 31 days ago is gone after the initial sweep;
+expired `credx-pending`/`present-challenge` rows are GC'd; an old `Failed` sync
+job is reaped; a not-yet-expired row of each kind survives.
+
+### P0.7 — Encryption-at-rest for keyspaces holding private keys / audit keys (M)
+**Problem:** `vti_common::store::KeyspaceHandle::with_encryption` exists and the
+VTA uses it; `rg with_encryption vtc-service/src` → zero hits
+(`server.rs:199-224` opens every keyspace bare). At-rest in plain fjall JSON:
+the install-token ephemeral Ed25519 **private** key
+(`install/state_machine.rs:77-83`, valid until claim/expiry — stealing it plus
+the URL token defeats half the install ceremony), the HMAC `audit_key` keyspace
+(forgeable actor hashes), and WebAuthn `passkey` state. The signing bundle
+correctly lives in the seed-store backend, not a keyspace.
+**Change:** derive a storage key (HKDF from the bundle Ed25519 seed, info
+`vtc-storage-key/v1`) in `init_auth`, apply `with_encryption` to at least
+`install`, `audit_key`, and `passkey`; add a try-decrypt-else-plain read path for
+existing deployments.
+**Accept:** on-disk bytes for an issued install token don't contain the base64
+of the ephemeral key; a boot over a pre-encryption store still reads rows.
+
+### P0.8 — Secret-store factory silently falls back when the backend isn't compiled; typo'd keys ignored (S)
+**Problem:** each backend arm in `create_secret_store`
+(`keys/seed_store/mod.rs:42-95`) is `#[cfg(feature)]`-gated with no `else`. A
+config that sets `secrets.aws_secret_name` on a binary built without
+`aws-secrets` compiles that arm away and silently selects the keyring (or
+plaintext) → empty store → boot proceeds with "no key material found — auth
+endpoints will not work" as a mere `warn!`. No config struct carries
+`deny_unknown_fields` (`config.rs:420-440`), so `aws_secretname` (typo) is
+silently dropped → identical fallback. (The wizard's plaintext path is a proper
+loud opt-in; the runtime factory is the weak link.)
+**Change:** add `#[cfg(not(feature))]` arms returning
+`AppError::Config("secrets.aws_secret_name set but binary built without
+'aws-secrets'")` for every set-but-uncompiled backend field; add
+`#[serde(deny_unknown_fields)]` to `SecretsConfig` (full `AppConfig` needs an
+alias audit first — `community_name`/`community_description` aliases exist).
+**Accept:** per-backend test: field set + feature off → `Err`; unknown key under
+`[secrets]` → parse error naming the key.
+
+### P0.9 — Configured-but-broken identity boots into warn-and-serve-dead instead of failing hard (S)
+**Problem:** `init_auth` (`server.rs:1048-1079`) returns all-`None` (daemon
+serves, auth dead) in four cases: `vtc_did` unset (legitimate pre-setup), secret
+store empty, secret store **errored**, and bundle-DID **mismatch**. The last
+three happen on a daemon that *was* configured (keyring lost, AWS perms broken,
+wrong service name) — the only signal is a log line, while monitoring sees a
+healthy listener and every auth/issue/install call 503s.
+**Change:** distinguish `vtc_did == None` (degraded boot, current behavior) from
+`vtc_did == Some(_)` + secret missing/erroring/mismatched (return `Err` from
+`run()`, exit non-zero with the operator hint).
+**Accept:** config with `vtc_did` set + empty store → `server::run` returns
+`Err`; config with no `vtc_did` → boots.
+
+### P0.10 — Single-threaded REST runtime + synchronous Argon2id + no request timeout (M)
+**Problem:** the REST surface runs on `new_current_thread`
+(`server.rs:921-924`). Store ops are `spawn_blocking` (fine) but CPU-bound work
+runs inline: Argon2id verify on the unauth `/v1/install/claim/start`
+(`claim_secret.rs:63-74`, m=19456 KiB t=2, ~50–200 ms), Rego eval, VC signing —
+each blocks every concurrent request. A handful of distinct source IPs hitting
+claim-start saturate the lone thread (the 5 rps governor is per-IP). No
+`TimeoutLayer` anywhere, so one wedged handler (a registry call without its own
+timeout) holds its connection forever.
+**Change:** wrap `claim_secret::verify`/`hash` (and other CPU-bound calls) in
+`spawn_blocking`; add `tower_http::timeout::TimeoutLayer` (~30 s) to the router
+stack; consider `new_multi_thread().worker_threads(2..4)` for the REST runtime.
+**Accept:** a slow handler doesn't delay a concurrent `/health` past the timeout;
+claim-start verify no longer runs on the async thread.
+
+### P0.11 — `relationships_by_did` index scan leaks other DIDs' rows (colon-prefix collision) (S)
+**Problem:** index key is `relationships_by_did:<did>:<uuid>`, `list_for_did`
+scans prefix `<did>:` (`relationships/storage.rs:27-33,144-186`). `did:webvh`
+DIDs legitimately contain colons: for `did:webvh:scid:host` vs
+`did:webvh:scid:host:acme`, the scan prefix `…host:` matches the second DID's
+keys, and `list_for_did` never post-filters on
+`rel.issuer_did == did || rel.subject_did == did` → returns another DID's
+relationship rows (cross-member information exposure).
+**Change:** length-prefix/escape the DID in the index key, or (minimal)
+post-filter hydrated rows by issuer/subject equality.
+**Accept:** store edges for `did:webvh:s:h` and `did:webvh:s:h:x`;
+`list_for_did("did:webvh:s:h")` returns only the first DID's edges.
+
+### P0.12 — `Presentation.verified = true` stamped over cryptographically-unverified VCs on the submit path (M)
+**Problem:** on the REST/DIDComm join-submit path only the *outer* holder-binding
+signature is checked; the VP's embedded VCs are projected straight from
+attacker-controlled JSON into ceremony `Credential`s and the wrapping
+`Presentation` is stamped `verified: true` (`submit.rs:378-442`, esp. `:396`).
+`facts.rs` documents `Presentation.verified` as "VP proof + holder-binding
+checked out" and `VerifiedFacts::assemble` treats it as the authenticity gate.
+The shipped `join.rego` requires `issuer_trusted` (hardcoded `false` here) so the
+default can't auto-admit — but any operator policy branching on
+`evidence.presentation.credentials[].claims` (e.g. "allow if email ends
+@acme.com") auto-admits on a **fully forged VC**. The verifying `present.rs` path
+makes the inconsistency invisible (identical-looking facts, opposite guarantees).
+**Change:** either cryptographically verify each embedded VC on the submit path
+before projecting (reuse `present.rs`/`recognition` verifier), or set
+`Presentation.verified = false` (or a distinct `holder_binding_only` flag) on the
+raw-VP submit path so a claims-reading policy is fail-safe. Never present
+unverified VC claims under `verified: true`.
+**Accept:** submitting a VP whose embedded VC carries an invalid proof yields
+facts that do **not** carry `presentation.verified == true` (or the request is
+rejected).
+
+### P0.13 — Join-submit holder signature has no freshness/nonce/audience binding (replayable) (S)
+**Problem:** the signed payload is
+`domain_tag || canonical_json({applicantDid, vp, registryConsent, extensions})`
+(`submit.rs:444-512`) — no nonce, no timestamp, no VTC/community DID. A captured
+submit body is replayable indefinitely (each replay persisting a new ≤256 KiB
+row — compounds P0.6) and replayable against a *different* community (no audience
+binding). The `present.rs` path binds a single-use nonce + audience; the legacy
+submit path doesn't. Also: no dedup against an existing open request from the
+same `applicant_did`, and `Pending`/`Deferred` are never retention-eligible
+(`join/mod.rs:54-56` `is_terminal_retainable`).
+**Change:** bind a server-issued single-use challenge (or at minimum the VTC DID
+as audience + a `created` timestamp with a short window) into the signing
+payload; dedup open requests per `applicant_did` (return the existing one or 409)
+and/or cap open requests per applicant.
+**Accept:** replaying a captured submit body, or submitting against a different
+community DID, is rejected; a second submit for the same applicant yields one row
+or a 409.
+
+### P0.14 — Promote-to-admin bypasses the role-change policy entirely (M)
+**Problem:** `update.rs` refuses `role=admin` on PATCH specifically so the
+role-change policy's step-up branch is reached "there" (the promote endpoint),
+but `promote_finish` (`routes/members/promote.rs:131-218`) runs **no policy at
+all** — passkey UV ceremony, then a direct `target_acl.role = VtcRole::Admin`
+write. The operator-authored `vtc.role_change` policy (the documented governance
+surface for the single most privileged grant) is never consulted on the actual
+admin-promotion path; an operator who tightens `role_change.rego` (quorum/tenure)
+is silently ignored.
+**Change:** route promote-to-admin through the role-change ceremony (`decide`
+over `PolicyPurpose::RoleChange` with `step_up: true` after UV passes, then
+`EffectPlan::Remint`) so policy + host invariants apply.
+**Accept:** a `role_change.rego` returning `deny` for an admin promotion causes
+`promote_finish` to 403 even after a valid UV.
+
+### P0.15 — `admit` lacks the serializing lock the other effect arms use: duplicate-credential TOCTOU (S)
+**Problem:** `depart` and `remint` run check-then-write under `LAST_ADMIN_LOCK`,
+but `admit` (`ceremony/execute.rs:177-215`) does a bare `get_acl_entry(...).is_some()`
+guard then writes ACL/member/VMC/slot with no lock. Two concurrent admits for the
+same subject DID (two `Pending` approved in parallel, or a submit auto-admit
+racing an approve) both observe "no ACL row," both proceed → two VMCs minted, two
+status-list slots burned, audit double-counts.
+**Change:** take a per-subject (or the existing global) lock across the existence
+check + writes in `admit`, matching `depart`/`remint`.
+**Accept:** two simultaneous admits for one DID → exactly one VMC and one slot;
+the loser gets `Conflict`.
+
+### P0.16 — Non-admin `VtcRole` ACL rows make the unauth `/auth/challenge` 500 and leak serde internals (M)
+**Problem:** `VtcAuthBackend::check_acl` (`auth/backend.rs:108-112`) resolves
+roles through `vti_common::acl::check_acl_full`, which deserializes the `acl:<did>`
+row into a `vti_common::acl::AclEntry` whose `role` is the VTA taxonomy. VTC
+writes `VtcAclEntry` rows whose role serializes as `moderator`/`issuer`/`member`/
+`custom:<name>` and `POST /v1/acl` permits creating them. When such a DID hits
+the unauthenticated `POST /v1/auth/challenge`, the foreign deserializer fails with
+`unknown variant 'moderator'` → `AppError::Internal` → **HTTP 500 whose body
+leaks the serde text** to an unauthenticated caller, and every non-admin VtcRole
+silently can't authenticate. Fails closed (not an escalation) but is a reachable
+correctness + info-leak bug and the unfinished Phase-2 `VtcRole`↔`Role` migration
+(`acl/storage.rs:9-18`).
+**Change:** make `check_acl` read the VTC row via `crate::acl::get_acl_entry`
+(decodes `VtcAclEntry`), map `VtcRole → vti_common::acl::Role`, apply the VTC
+row's own expiry check, and return a clean `Forbidden`/role instead of letting
+the foreign deserializer 500.
+**Accept:** creating a `moderator` ACL entry then calling `/auth/challenge` for
+that DID → clean 403 (no serde text in body); an admin row still authenticates.
+
+### P0.17 — Secret-bearing files written world-readable (S)
+**Problem:** every `config.toml` contains `auth.jwt_signing_key` (the Ed25519 JWT
+signing seed) and, under the config-secret backend, the hex-encoded `VtcKeyBundle`
+with both private keys — written via `std::fs::write` → default umask (0644)
+(`setup/wizard.rs:1317-1337,189-194`, `routes/config.rs:76`).
+`PlaintextSecretStore::set` likewise writes key material 0644
+(`keys/seed_store/plaintext.rs:59-68`). The workspace pattern elsewhere is 0600 +
+Windows ACL hardening (PNM bootstrap-secrets).
+**Change:** `OpenOptions::mode(0o600)` (or chmod after write) on `config.toml` in
+the wizard and the `/v1/config` save path, and on `secret.plaintext`; reuse the
+PNM 0600 helper.
+**Accept:** unix test — `write_config_toml` and `PlaintextSecretStore::set`
+produce mode-0600 files.
+
+### P0.18 — Rego evaluation has no timeout/instruction budget: DoS on the unauth join path (M)
+**Problem:** `policy/engine.rs:110-124` clones the engine, sets input, and calls
+`eval_query` with no loop/instruction/time bound and no input-size cap. The join
+decision policy is evaluated on the **unauthenticated** submit route against
+attacker-influenced facts (the VP + claim graph flow into `input`). A pathological
+operator-uploaded policy or adversarial input shape burns CPU per request; the
+governor caps to 5 rps/IP but each request stays expensive.
+**Change:** configure a regorus evaluation bound (instruction/loop limit and/or
+wrap each `evaluate` in `tokio::time::timeout` on a blocking task); cap the
+serialized `input` size before evaluation; fail closed (default-deny) on bound
+exceeded.
+**Accept:** a deliberately expensive policy/input aborts with a deny rather than
+hanging the handler; an input-size-cap unit test.
+
+### P0.19 — `vtc status` trust-ping broken for every production deployment (S)
+**Problem:** `status.rs:269-274` (`send_trust_ping`) rejects key material whose
+length ≠ 64 bytes, but the wizard has stored the JSON `VtcKeyBundle` shape since
+the VTA-driven-keys rework, so on any real deployment the status command's
+mediator ping fails with a baffling byte-count error (only legacy/test fixtures
+pass). `decode_secret_store_value` (`server.rs:1333-1362`) already handles both
+shapes.
+**Change:** replace the manual split with `decode_secret_store_value`; move that
+helper out of `server.rs` into `setup::bundle` or `keys`.
+**Accept:** `send_trust_ping`'s key-extraction accepts a JSON bundle fixture; the
+64-byte fixture still works.
+
+### P0.20 — Privilege/scoping gaps in ACL + session management (S)
+**Problem (cluster):** (a) `DELETE /v1/acl/{did}` is gated on `ManageAuth`
+(Admin **or** Initiator) while the strictly-less-destructive `PATCH` is gated on
+`AdminAuth`; neither inspects the *target* entry's existing role, so a
+context-admin of `ctx-a` can delete/downgrade a peer admin whose
+`allowed_contexts` merely overlaps `ctx-a` (`routes/acl.rs:159-229`). (b)
+`revoke_sessions_by_did` and `session_list` (`routes/auth.rs:841-906`) have no
+context scoping — any context-admin can revoke any member's (or a super-admin's)
+sessions community-wide, and `session_list` returns the full member roster +
+session metadata. (c) `update_acl` rewrites the ACL row but doesn't revoke the
+subject's live sessions, and the `AuthClaims` extractor reads role/contexts from
+the still-valid JWT (only refresh re-checks ACL), so a demoted admin keeps admin
+authority for the full access-token TTL.
+**Change:** gate `delete_acl` on `AdminAuth`; when the target is `VtcRole::Admin`
+require super-admin (or assert the caller administers *every* context the target
+holds). Scope `revoke_sessions_by_did`/`session_list` to the caller's visible
+contexts. On any downgrade in `update_acl`, revoke the subject's sessions.
+**Accept:** context-admin of `ctx-a` can't delete an admin scoped to
+`[ctx-a, ctx-b]`; `session_list` for a context-admin omits out-of-context
+sessions; a demoted admin's old bearer is rejected on the next request.
+
+### P0.21 — Install `claim/start` takes the 5-minute ceremony lock before verifying the claim secret (S)
+**Problem:** `claim_start` (`routes/install.rs:122-142`) calls `start_claim(&jti)`
+— which sets `claimed_at` and locks out concurrent claims for 300s
+(`install/state_machine.rs:220-268`) — **before** verifying the OOB claim secret.
+The claim secret exists so "a leaked install URL is not enough," but an attacker
+holding only the URL can POST `claim/start` with a wrong code every 5 minutes;
+each call refreshes the lock and is rejected *after* locking → the legitimate
+operator is held off indefinitely (the 5 rps governor doesn't help).
+**Change:** verify the claim secret (add `peek_secret_hash`/reuse `get_token` +
+`claim_secret::verify`) before acquiring the ceremony lock; never let a
+failed-secret attempt set `claimed_at`.
+**Accept:** `claim/start` with the wrong code followed immediately by the correct
+code succeeds (no lockout).
+
+**Checkpoint 0:** all P0 merged or explicitly deferred with an issue; full CI
+green; `docs/03-vtc/cross-community.md` (recognise holder-binding) and
+`docs/05-design-notes/vtc-mvp.md` §14 updated to reflect P0.2/P0.3/P0.7 status.
+
+---
+
+## Phase 1 — Kill the divergence engines (small PRs, high correctness leverage)
+
+### P1.1 — One config-mutation surface; boot-stable derived state made explicit (L) — DO FIRST
+**Problem:** config mutation is split across three uncoordinated surfaces with
+three auth levels and two audit regimes: legacy `PATCH /v1/config`
+(`routes/config.rs`, super-admin, writes TOML), the `config_store` registry
+overlay (`config_store.rs` + `routes/admin/config.rs`, admin, writes fjall), and
+`CommunityProfile` (`community/profile.rs`, admin, writes the `community`
+keyspace). Symptoms: (a) `PATCH /v1/config` can rewrite `vtc_did`/`vta_did` →
+next-boot auth-dead or recovery-authority re-pointed (`config.rs:42-80`); (b) it
+serializes the env-overlaid struct back to TOML (baking ephemeral `VTC_*`
+overrides in permanently), skips `validate_routing_and_cors`, and writes
+non-atomically (`config.rs:69-76`); (c) community name/description live in **both**
+`config.toml` and the `CommunityProfile` row with nothing synchronizing them; (d)
+five derived values are computed once at boot and silently diverge from runtime
+`PATCH` (`Webauthn` RP handle, `AppState.public_url` snapshot, status-list
+`list_credential_id` URLs, CORS/routing layers, the DIDComm thread's whole-config
+clone — `server.rs:334-349,110-115,260-276,610-611`).
+**Change:** make `config_store` the single canonical overlay; migrate
+`public_url` into it as a `requires_restart` key; declare `CommunityProfile` the
+sole owner of name/description (`GET /v1/config` reads from it, keep serde
+aliases); drop `vtc_did`/`vta_did` from the legacy update body (return 409,
+"identity is set at `vtc setup`"); route all writes through one `save()` that
+resets env-sourced fields, validates, and writes tempfile-then-rename; have
+`update_config` respond with a `requires_restart` indicator for boot-stable keys.
+Delete/410 the legacy PATCH once the admin UI moves.
+**Accept:** one write path per field; PATCH with `vtc_did` → 409 and config.toml
+unchanged; `VTC_*` env overrides don't leak into TOML on a PATCH; name set via
+profile PUT is what `GET /v1/config` returns; PATCH of a boot-stable key returns a
+restart-required indication.
+
+### P1.2 — Config-mutation audit + real actor DID (M)
+**Problem:** `PATCH /v1/admin/config` (the primary runtime-config surface) emits
+**no** audit envelope, though `reload`/`restart`/`import` on the same file do
+(`routes/admin/config.rs:130-132`); legacy `PATCH /v1/config` and
+`PUT /v1/community/profile` are also unaudited while the *import* path for the
+identical profile fields is audited — auditability depends on which of three
+equivalent doors the admin used. Where audit does fire, the actor is the literal
+`"did:key:vtc-admin"` sentinel (`:220,278,586`) though the real DID is in the
+`AdminAuth` extractor every handler already takes.
+**Change:** emit `ConfigChanged` from `patch_config` (the `ConfigChange::redact_if`
+machinery exists), `CommunityProfileUpdated` from `put_profile`; replace every
+sentinel with `_admin.0.did`.
+**Accept:** PATCH admin config and PUT profile each produce an audit row whose
+actor hash matches the calling admin DID; grep for `did:key:vtc-admin` returns
+only the migration note.
+
+### P1.3 — Registry/RTBF audit envelopes must not be fire-and-forget (S)
+**Problem:** `emit_override` (the `RegistryRecordPolicyOverride` RTBF event) and
+`emit_outcome` both `tokio::spawn` a detached write whose only failure handling
+is `warn!` (`registry/syncer.rs:222-246,459-490`). The RTBF override is a
+privacy/compliance record; if the spawned write fails after the registry mutation
+already happened, the audit trail silently misses it, and the cursor advances
+independently so it isn't re-emitted.
+**Change:** make `emit_override` await its write and fail the tick (or persist a
+pending-audit marker) on error so it re-emits next walk; at minimum make the RTBF
+override non-detached.
+**Accept:** injecting an audit-write failure on the override path leaves state
+such that the next tick re-emits rather than dropping it.
+
+### P1.4 — Single token-mint path + AAL2 short-TTL parity; one holder-signature verifier (M)
+**Problem:** `passkey_login_finish` (`routes/auth.rs:471-611`) can't reuse
+`handle_authenticate_with_aal` (no `ChallengeSent` session) so it hand-rolls the
+entire mint and sets the full ~15-min access TTL while stamping `aal2` — the
+canonical handler deliberately mints aal2 tokens at
+`access_token_ttl_for_aal2()` (1/3, min 60s) to bound a leaked elevated token,
+and passkey login is the primary aal2 mint path, so the one token class that
+hardening protects gets the longest exposure. It also emits no `Authenticated`
+audit event. Separately, four copies of the Ed25519 domain-tagged
+holder-signature verifier differ only by canonical struct + domain tag
+(`submit.rs`, `accept.rs`, `status.rs`, `members/rotate.rs`).
+**Change:** extract `mint_session_tokens(backend, did, role, contexts, amr, acr)`
+in `vti-common` called by both the canonical handler and the passkey path
+(computing the AAL2 TTL the same way), and emit the audit event there; extract one
+generic `verify_domain_signed(did, domain_tag, payload, sig)` and route all four
+sites through it.
+**Accept:** passkey-login-finish yields `expires_in == access_token_ttl_for_aal2()`
+and writes an `Authenticated` envelope; one signature verifier with all four
+former sites delegating.
+
+### P1.5 — Policy upload validates package/purpose match (S)
+**Problem:** `upload` (`routes/policies/admin.rs:126-193`) compiles + stores under
+the operator-declared `purpose` but never checks the module's package matches the
+purpose's expected package (`vtc.join`/`vtc.removal`/`vtc.role_change`/
+`vtc.directory`) or defines the expected rule. A mismatch compiles + activates
+cleanly, then evaluates to `undefined` → silent host default-deny for that entire
+ceremony — fails closed but is invisible: the operator sees a successful upload +
+activate and a community that silently denies everything. `default.rs::yields_decision`
+shows the host already knows how to probe this.
+**Change:** in `upload`/`activate`, evaluate the purpose's canonical query against
+a trivial input and reject if the module yields no decision/`allow`, naming the
+expected package.
+**Accept:** uploading a `purpose: join` policy whose package is `vtc.removal` is
+rejected with a clear error.
+
+**Checkpoint 1:** P1.1–P1.5 merged; e2e suite green; admin-UI config/profile
+round-trips unchanged; cross-community recognise smoke unchanged.
+
+---
+
+## Phase 2 — Collapse the adapter shells & move logic out of routes
+
+These assume P1.1 (single config surface) and P1.4 (shared helpers). Tests-before-
+moves discipline applies.
+
+### P2.1 — Move ceremony orchestration out of route handlers (L)
+**Problem:** the full decide→resolve→effect→audit spines for join, leave, and
+role-change live in `routes/` against the thin-adapter house style:
+`submit_inner`/`decide_join`/`realize_join_verdict` (`submit.rs:155-323`),
+`remove_inner` (`remove.rs:140-266`), `role_change_via_pipeline`
+(`update.rs:167-240`). The clean `ceremony/*` pipeline modules exist, but the
+per-ceremony wiring that belongs beside them is scattered through route files —
+which is why the P0 audit-gap (auto-admit), dedup, and freshness fixes each land
+in multiple places.
+**Change:** move the orchestration functions into `ceremony/` (or `operations/`);
+routes become thin adapters that extract auth + body and call them. Fold the
+shared `MemberAdded`/`VmcIssued`/`VecIssued` audit emission (the auto-admit
+under-audit gap, `submit.rs:218-313` vs `decide.rs:117-150`) into one helper used
+by both the auto-admit and manual-approve paths.
+**Depends:** P1.4.
+**Accept:** route handlers contain no policy-load/decide/effect/audit logic; the
+orchestration is unit-testable without axum; an auto-admit produces the same
+audit envelopes as a manual approve.
+
+### P2.2 — One facts-builder + cached member count (M)
+**Problem:** four `Facts` builders (`assemble_*_facts` in `submit.rs:332-371`,
+`remove.rs:288-363`, `update.rs:246-304`, `directory.rs:134-209`) repeat
+community_did load + member_count scan + actor-role lookup + `MemberState`
+construction with small per-purpose deltas. Each also computes `member_count` via
+a full `members:` keyspace walk (`list_members(...).len()`) — on the
+unauthenticated directory + join paths that's an O(members) scan per request.
+**Change:** extract one `assemble_facts(purpose, actor, subject, evidence)` helper
+in `ceremony/`; maintain a cached/persisted member counter (increment on admit,
+decrement on purge) threaded through `Context`.
+**Accept:** one facts-assembly helper; a directory query performs no full member
+scan; ~150–200 LOC removed.
+
+### P2.3 — Split `exchange.rs` (2,316 LOC) into four modules (L)
+**Problem:** one file owns the OID4VCI issuer gate
+(`verify_oid4vci_proof`/`issue_on_request`/`credential_offer`, `:50-232`), the
+OID4VP verifier stack (`verify_presentation`/`verify_vp_token`/`verify_di_vp`/
+`verify_bbs_presentation`/`DidVmResolver`, `:234-1045`), temporal/JWK/segment
+helpers (`:1047-1131`), and the persisted pending-offer store
+(`make_offer`/`redeem`, `:1133-1268`). Mirrors the VTA's `credential_exchange.rs`
+split task.
+**Change:** split into `exchange/{issue,verify,pending,jwt}.rs`, re-exported from
+`exchange/mod.rs` so `credentials/mod.rs:58` is unchanged.
+**Accept:** no public-path changes; `cargo test -p vtc-service` green; each new
+file < ~700 LOC.
+
+### P2.4 — One DID-VM → DI-proof verifier (M)
+**Problem:** three copy-pasted "resolve verificationMethod → verify DI proof"
+implementations: `DidResolverKeyResolver` + `verify_proof`
+(`recognition/verify.rs:254-285,400-433`), `DidVmResolver`
+(`exchange.rs:320-485`), and `relationships::verify_vc_proof`
+(`routes/relationships.rs:290-329`). Three subtly-different copies of
+security-critical key resolution (only `DidVmResolver` handles the bare-`did:key`
+fast path; only `recognition` binds to `issuer_did`) — a divergence hazard.
+**Change:** hoist one resolver into a shared module (`credentials::vm_resolver` or
+`vti-common`) implementing both `VerificationMethodResolver` and the
+`ForeignIssuerKeyResolver` trait; route `recognition` + `relationships` through it.
+**Depends:** P2.3 (exchange split lands the canonical copy).
+**Accept:** one resolver implementation; recognition/relationships tests still
+pass; the issuer-binding check is centralized.
+
+### P2.5 — Keyspace name registry; offline-CLI durability + parity (S)
+**Problem:** keyspace-name string literals are re-typed across 7 non-test files
+(`server.rs:199-224`, `main.rs:375-377`, `emergency.rs:248-250`,
+`status.rs:201-202`, `acl_cli.rs`, `did_key.rs`, `setup/wizard.rs:1339-1356`).
+The cost is real: the wizard's `open_keyspaces` (meant to pre-create partitions
+so first `vtc start` is cheap) opens 8 of the daemon's ~21 and nobody noticed.
+Separately, `run_invite_cli` (`main.rs:374-412`) and `run_emergency_bootstrap`
+write an Admin ACL entry + install token and exit **without** `store.persist()`,
+while `acl_cli`/`did_key` persist — the operator hands out a URL whose token row
+may not be durable across a crash.
+**Change:** `pub mod keyspaces` in `src/store/` with `const` names + `const ALL`;
+`server.rs`, the CLIs, and `open_keyspaces` consume it (`open_keyspaces` iterates
+`ALL`). Add `store.persist()` before printing the URL in `run_invite_cli` and at
+the end of `run_emergency_bootstrap`.
+**Accept:** `rg '\.keyspace\("' src` (excl. tests) shows only the constants
+module; an `ALL.len()` test pinned to the AppState keyspace-field count; every
+offline write path ends with `persist`.
+
+### P2.6 — Per-feature routers + a posture-asserting test (L)
+**Problem:** `routes/mod.rs` (1,202 LOC) declares every route, Trust-Task, body
+cap, and (implicitly) auth gate inline in one function; per-method handlers
+collapse onto a single Trust-Task (`members/{did}` GET+PATCH+DELETE share
+`members/show/1.0`), so auth posture isn't locally legible — which is how the
+P0.5 misplacement slipped in. No test enumerates routes and asserts each one's
+(auth, rate-limit branch, body cap) triple.
+**Change:** split into per-feature router builders each returning routes + a
+static posture descriptor; add a `route_posture` test walking the assembled router
+and asserting the full table. (This is the structural backstop for P0.5 — land
+P0.5's fix first, then make regression impossible.)
+**Accept:** the posture test fails if a route is added without declaring its auth
+gate + branch; ~300–400 LOC net reduction once the repeated
+`TrustTask::new(...).expect(...)` boilerplate is tabular.
+
+### P2.7 — Three near-parallel registry files share an un-extracted fetch-verify-apply skeleton (M)
+**Problem:** `upstream.rs` (HTTP transport), `syncer.rs` (dispatch/apply), and
+`tail.rs` (audit→job) each independently encode the record lifecycle; `run_call`
+and `update_mirror` (`syncer.rs:409-457`) duplicate the exact
+`RegistryRecord::fresh_active`/`departed(... historical ? Some(now) : None)`
+construction — a drift hazard.
+**Change:** extract `RegistryRecord::for_job(&SyncJob) -> Option<RegistryRecord>`
+consumed by both `run_call` and `update_mirror`.
+**Accept:** single source of record-shape; the two no longer duplicate the
+`historical` branch; ~60–100 LOC removed.
+
+### P2.8 — Collapse the DTG credential builders (S)
+**Problem:** `build_vmc`/`build_role_vec`/`build_custom_endorsement`/invitation
+(`credentials/{vmc.rs:153-168,vec.rs:81-100,custom_endorsement.rs:106-155,
+invitation.rs:36-73}`) each assemble params → call `dtg::issue_*` →
+`serde_json::from_value` into `VerifiableCredential` with the same
+`AppError::Internal` mapping; the params structs are 90% identical builder
+boilerplate.
+**Change:** one `dtg::finalize_typed() -> VerifiableCredential` helper for the
+JSON→VC conversion; consider a single `CredentialParams { kind }`.
+**Accept:** builders shrink to param-assembly + one call; builder unit tests
+unchanged.
+
+**Checkpoint 2:** adapter LOC reduction realized; wire behavior pinned by the
+posture test + ceremony orchestration tests; `vtc-service/CLAUDE.md` source-layout
+section updated to reflect new file sizes/locations.
+
+---
+
+## Phase 3 — Strategic convergence + hygiene (ongoing)
+
+### P3.1 — Real host-based surface isolation (or honest docs) (L)
+**Problem:** `host_dispatch` (`routing/host_dispatch.rs:77-119`) only does
+allowlist membership, then routes by path across all mounts regardless of which
+host matched — so `api.example.com/admin/...` still serves the SPA and
+`admin.example.com/` still serves the public website. The config validator
+*allows* admin-UI at `/` in "host mode" on the false premise that host mode
+isolates (`routing_cors.rs:40-62`), and in default path mode the public website
+and admin SPA share one origin with a `Path=/` session cookie, so
+operator-deployed website JS (or stored XSS in marketing content) executes on the
+admin origin and can call authenticated `/v1` endpoints riding the cookie
+(`routes/mod.rs:1160-1190`, `auth.rs:623-636`, `csrf.rs:85-92` same-origin pass).
+There is currently no deployment posture that actually isolates deployed website
+content from the admin session.
+**Change:** implement per-host surface routing (dispatch to a per-host sub-router
+so a host exposes only its own surface) and make host separation the
+required/forced posture when a filesystem website is configured; or scope the
+admin session cookie under the admin mount and stop serving the public website on
+the admin origin. Document in `website-and-admin.md`.
+**Accept:** in host mode `GET admin.example.com/v1/...` and `api.example.com/admin`
+both 404; a script deployed to `/` cannot make an authenticated `/v1/acl` call
+with the admin cookie.
+
+### P3.2 — CSRF: bearer exemption + tighten the exempt list (M)
+**Problem:** `csrf::enforce` (`routing/csrf.rs:49-127`) requires same-origin or a
+double-submit token on every mutating request not in `CSRF_EXEMPT_PATHS`, with
+**no exemption for `Authorization: Bearer`** (structurally CSRF-immune), so
+programmatic CLI/wallet clients get 403. The unauth holder endpoints
+`accept`/`status` aren't exempt (only bare `/v1/join-requests` is, `csrf.rs:50`),
+so the intended CLI/wallet holder is blocked while the browser flow passes.
+**Change:** skip CSRF when an `Authorization: Bearer` header is present
+(cookie-session requests stay gated); add the public join surface
+(`accept`/`status`, or a prefix match) to the exempt set.
+**Accept:** bearer POST with no Sec-Fetch/cookie passes; cookie-session POST with
+no token → 403; CLI-style accept/status passes.
+**Note:** the CSRF layer is attached in `server.rs` but not in the test `router()`,
+so this break is invisible to CI today — wire CSRF into the integration harness as
+part of this task.
+
+### P3.3 — Website single-file `PUT` must use the same safety chain as deploy/serve (M)
+**Problem:** `routes/website/files.rs:182-238` (`write`) doesn't call
+`canonical_within_root` (only checks the parent), explicitly drops the executable
+blocklist (`:228` `let _ = blocklist;`), and has no hidden/control-char/NFC check
+— so an admin can `PUT /.htaccess`, `/evil.php`, `/.git/config` that `deploy` and
+`serve` both reject. Worse, `create_dir_all` runs (`:216-219`) **before** the
+escape check (`:230-238`), so `PUT .../../foo/bar/x` creates directories outside
+the root before rejection (a pre-validation filesystem-mutation primitive,
+admin-gated).
+**Change:** route `write` through the full safety chain (blocklist, hidden,
+control/NFC, canonical-within-root) **before** any `create_dir_all`; reject first,
+create second.
+**Accept:** `PUT .../evil.php` → 403; `PUT .../.hidden` → 400/404; `PUT
+.../../escape` creates no directory and returns 400.
+
+### P3.4 — Validate/clamp per-site CSP override; stop reading it per-request (S)
+**Problem:** `read_csp_override` (`website/serve.rs:131-155`) reads
+`<root>/.vtc-website.toml` on every request and emits its `csp` verbatim with no
+validation, so an operator (or anyone with website write access) can set
+`script-src 'unsafe-inline'` on an origin shared with the admin SPA (path mode),
+neutralizing the default — plus a per-request disk stat/parse on the hot path.
+**Change:** validate against a directive allowlist or refuse to weaken
+`script-src`/`object-src`/`base-uri` below the daemon default; cache the parsed
+override with the content-cache TTL. Tie to P3.1 so a relaxed website CSP can't
+affect the admin origin.
+**Accept:** an override that loosens `script-src` is rejected/clamped; the override
+isn't parsed on every request.
+
+### P3.5 — Cache-control + unauth-scan hygiene on the admin/website edge (S)
+**Problem:** admin `index.html`/SPA-fallback is cached `public, max-age=300` like
+hashed assets (`admin_ui.rs:116`), so after an upgrade a browser serves a stale
+shell pointing at asset hashes the new binary dropped → broken SPA for up to 5
+min. `GET /admin/plugins.json` is unauthenticated and re-scans `plugin_dir`
+(readdir + read every manifest) on every request
+(`routes/admin_ui.rs:101-188`) — an unauth disk-amplification lever. `serve`'s
+doc claims `If-None-Match`→304 but never implements it (`serve.rs:24` vs
+`:64-148`).
+**Change:** serve `index.html`/SPA-fallback `no-cache`, keep the long TTL only for
+content-hashed `/assets/*`; cache the plugin-manifest scan with a short TTL or
+gate it behind auth; implement `If-None-Match`→304.
+**Accept:** `/admin/` carries `no-cache`, `/admin/assets/<hash>.js` keeps the long
+TTL; repeated `plugins.json` doesn't re-readdir every call; a conditional GET with
+matching ETag → 304.
+
+### P3.6 — Typed errors across the registry + DIDComm boundaries (S)
+**Problem:** `RegistryError::{Transient,Permanent,Unreachable}` carries
+retriable/permanent semantics but is documented as mapping all to
+`AppError::Internal(String)` at the route boundary (`registry/client.rs:34-53`,
+`storage.rs`), so `/v1/auth/recognise` returns the same opaque 500 for "registry
+down" as for "internal bug" — against the house rule on preserving typed errors.
+DIDComm handlers collapse every business outcome (forbidden/not-found/conflict/
+malformed) into `DIDCommServiceError::Internal` (`messaging.rs:229-509`), so the
+sender can't distinguish a malformed body from a real failure (and often gets no
+reply).
+**Change:** map `Unreachable`/`Transient` → 503, `Permanent` → 502/422; return
+DIDComm problem-reports with proper codes for the 4xx-equivalent cases, reserving
+`Internal` for true infra failures.
+**Accept:** recognise against an unreachable registry → 503 not 500; a malformed
+`join-request/submit` DIDComm body → a problem-report not a silent `Internal`.
+
+### P3.7 — `/health` minimal liveness; gate infra detail (S)
+**Problem:** `GET /health` (`routes/health.rs:33-51`, mounted at parent root
+outside the governor) returns `vtc_did`, `vta_did`, `mediator_url`, `mediator_did`,
+and the exact build version unauthenticated and unthrottled — a free
+liveness/version/recon oracle; `did.jsonl` at root carries no `nosniff`.
+**Change:** split a minimal `{status, version}` liveness payload (drop
+`mediator_url`); fold the DID/mediator detail behind `AdminAuth` (the diagnostics
+route is already admin-gated + governed); add `nosniff` to `did.jsonl`.
+**Accept:** unauthenticated `/health` no longer returns `mediator_url`; detailed
+identity fields require auth.
+
+### P3.8 — Syncer cost + idempotency (M)
+**Problem:** the syncer tail walk full-scans the entire `audit` keyspace every 5s
+tick (`tail.rs:114` scans from an empty prefix, filters by timestamp) — cost grows
+linearly with total audit history forever, becoming the daemon's dominant
+steady-state cost. And `walk` enqueues jobs with a fresh UUID each and
+`?`-propagates a mid-loop store error without advancing the cursor
+(`tail.rs:163`, `syncer.rs:193-197`), so a partial-walk failure or a crash between
+enqueue and cursor-write re-enqueues fresh-UUID duplicates on the next tick.
+**Change:** seek the tail walk from the cursor key (`<cursor-rfc3339>:` lower
+bound — note the store-layer needs a range/`from`-key API, not just
+`prefix_iter_raw`); derive the `SyncJob` id from the audit `event_id` so a re-walk
+overwrites rather than duplicates.
+**Accept:** walk cost is proportional to new-rows-since-cursor; failing the Nth
+store then re-walking ends with exactly one job per source envelope.
+
+### P3.9 — No backup/restore story (XL — design note first)
+**Problem:** the only export is `POST /v1/admin/config/export` (profile + config
+overrides only, `routes/admin/config.rs:357-388`). Members, ACL, join requests,
+endorsements, relationships, **status lists** (whose loss bricks every issued
+VMC's `credentialStatus` URL), policies, and the audit log have no export/import
+path. The VTA ships full encrypted backup/restore; the VTC — holding the
+community's irreplaceable social state — has nothing. Disk loss = community loss.
+**Change:** design note + port of the VTA backup pattern (iterate all keyspaces
+from the P2.5 registry, Argon2id + AES-256-GCM, `vtc_did` compatibility check on
+import mirroring `check_vta_did_compatibility`).
+**Depends:** P2.5 (keyspace registry so the census can't silently omit a keyspace).
+**Accept:** round-trip — populate every keyspace, export, wipe data dir, import,
+daemon serves identical state; import onto a different `vtc_did` → 409. A
+"keyspace census" test asserts export touches all of `keyspaces::ALL`.
+
+### P3.10 — Non-interactive `vtc setup --from <toml>` (L)
+**Problem:** `vtc setup` is TTY-only (`setup/wizard.rs` prompts at every step via
+`dialoguer`); the crate's own CLAUDE.md claims a "from-TOML" path that doesn't
+exist (misdirects operators + future agents). The VTA has `setup --from`. The
+wizard's *effects* are already pure functions (`build_app_config`,
+`write_did_log`, `write_config_toml`, `mint_initial_install_token`,
+`run_provision_quietly`) — the missing piece is an inputs struct + a driver.
+**Change:** `WizardPlan { inputs, webvh, secrets, messaging }`; `run_setup_wizard`
+= `collect_interactive() → apply(plan)`; add `vtc setup --from <toml>` =
+`parse(toml) → apply(plan)`. Fix CLAUDE.md either way.
+**Accept:** `vtc setup --from fixture.toml` completes against a mock provision flow
+with no TTY; CLAUDE.md matches reality.
+
+### P3.11 — Emergency-bootstrap hardening (S)
+**Problem:** the destructive recovery path
+(`emergency.rs:248-328`) is a non-atomic multi-delete that clears `acl`/`passkey`
+but leaves the `sessions` keyspace intact (refresh tokens for the presumed-
+compromised admins survive), stamps the `EmergencyBootstrapInvoked` audit marker
+*after* the clear (a mid-loop crash leaves the wipe unaudited), and relies on the
+drop path to flush.
+**Change:** stamp the pending-emergency audit marker *before* the destructive
+loop; clear the `sessions` keyspace (all rows, or all for cleared DIDs); call
+`store.persist()` before returning.
+**Accept:** marker written before the first delete; a cleared admin's session row
+is gone and stays gone after a cold reopen; a re-run after a simulated mid-loop
+failure completes cleanly.
+
+### P3.12 — Install `claim/finish` crash-safe delivery (S)
+**Problem:** `finish_claim` (`routes/install.rs:180-297`) flips `Issued→Consumed`
+(durable) at `:218`, then persists the passkey/AdminEntry, then mints + returns
+the `setup_session_token`. A crash between consume and return permanently spends
+the token but leaves the operator without the token needed by `/admin/bootstrap`
+and no admin ACL entry — they must re-run setup. (Consume-first is the
+security-correct direction; this is an availability sharp edge.)
+**Change:** make `claim/finish` idempotent against a `Consumed` row within `exp` —
+re-derive + re-mint the `setup_session_token` from the persisted
+`admin_did`/passkey rather than hard-rejecting.
+**Accept:** calling `claim/finish` twice for the same successful ceremony returns a
+usable token both times; a `start→finish→start` sequence still rejects the second
+`start`.
+
+### P3.13 — Hygiene cleanups (M, several small PRs)
+- **Stale webauthn doc** (`webauthn.rs:1-43`): the header claims "Ed25519-only /
+  rejects non-EDDSA" but `finish_passkey_registration` does no such check and the
+  start helper advertises ES256/RS256/EdDSA — rewrite to match the real posture.
+- **Dead `b64:` inline-secret path** (`setup/bundle.rs:228-248`): exported +
+  documented as the production path, zero callers; the wizard writes hex and
+  `ConfigSecretStore::get` (`keys/seed_store/config.rs:22-30`) only hex-decodes,
+  so a `b64:` value is unbootable. Either teach `get` the prefix + have the wizard
+  use `inline_secret_for_bundle`, or delete the pair and fix the comments.
+- **`Debug` derives on secret-bearing types** (`setup/bundle.rs:49` `VtcKeyBundle`,
+  `config.rs:8` `SecretsConfig`): no current `{:?}` leak, but one future
+  `debug!(?config)` leaks both signing keys — manual redacting `Debug` impls. The
+  wizard prints the admin private key JSON to stdout (`wizard.rs:223-239`) — gate
+  behind an explicit confirm, file the keyring follow-up.
+- **`vtc create-did-key` mislabels fields** (`did_key.rs:48-62`): the credential
+  bundle carries the VTC's DID/URL under `"vtaDid"`/`"vtaUrl"` (copy-paste) →
+  rename to `vtcDid`/`vtcUrl` (check the consumer first).
+- **Unbounded public profile fields** (`community/profile.rs:103-158`): no length
+  caps on `name`/`description`/`logo_url`/`contact_email` (served on the unauth
+  `/v1/community/public-profile`), no scheme check on `logo_url` (admin-only
+  mutators, low sev) — cap + validate in `CommunityProfileUpdate::apply`.
+- **Path-param DIDs as keyspace keys without validation** (`members/read.rs:165`,
+  `remove.rs:106`, `update.rs:52`, `personhood.rs:145`, `directory.rs:83`):
+  normalize/validate through `vti_common::identifier` before use as store keys.
+- **`http://` registry URL accepted** (`registry/upstream.rs:92-108`): `new()`
+  accepts any scheme → recognition answers trusted over cleartext, spoofable by an
+  on-path attacker → reject non-https in `new()`. (Direction note: the recognition
+  *read* should move to DIDComm when the upstream exposes it — house rule prefers
+  authcrypt's intrinsic sender auth over bespoke REST+signature.)
+- **Supervisor restart-on-panic** (`server.rs` spawns the syncer with bare
+  `tokio::spawn`): a panicking syncer loop dies silently with no health signal —
+  add restart-or-surface and reflect a dead syncer in diagnostics.
+
+---
+
+## Invariants any task must preserve (the do-not-break list)
+
+Security/crypto:
+- `LAST_ADMIN_LOCK` spans the no-last-admin check→write in `depart`/`remint`;
+  extend the same discipline (P0.15) to `admit` and (P0.1) to status-list RMW.
+- Issuer-key-binding enforced everywhere a proof is verified: SD-JWT `kid` base ==
+  `iss`; DI VC proof VM under the VC `issuer`; BBS VM under issuer; status-list
+  proof VM under the list's own issuer. Don't relax.
+- Status-list substitution defense: `verify_status_list_signature` binds the
+  fetched list's `issuer` to the credential's issuer and verifies the list's own
+  DI proof before reading any bit.
+- Decoy-slot allocator (#149 fix): `allocate` filters `!assigned && !is_set`;
+  `flip` keeps `assigned[i]=true` so revoked slots are never reallocated; the
+  `assigned` mask survives restart. The status-list serve route sets
+  `Cache-Control: no-store` and never serves the `assigned` mask (occupancy masked
+  by decoys) — preserve.
+- Typestate `Verified*` discipline: `VerifiedPresentation`/`VerifiedFacts`/
+  `VerifiedForeignCredential`/`ProvenHolderProof` only constructable via their
+  verifiers; the evaluate stage only takes `&VerifiedFacts`; holder consistency
+  across a multi-credential vp_token enforced. Add new wire forms this way.
+- Host invariants enforced *around* Rego (`invariant::enforce` privilege-ceiling +
+  step-up; the host `default_deny` backstop in `evaluate.rs`) so a policy edit
+  can't escalate. `execute::apply` is the single state-mutating seam. Preserve.
+- Fail-closed policy loading; `policy_skips_publish` fail-closed (a malformed
+  registry policy skips publish rather than leaking the membership graph).
+- Single-use + freshness: `present_challenge::consume` removes before the expiry
+  check (single-use even when expired); `redeem` consumes only on success; install
+  token single-use under `INSTALL_TOKEN_LOCK` with a non-consuming claim window;
+  emergency-bootstrap marker consumed-on-read.
+- Constant-time compares: challenge (`handlers/mod.rs:72`), Argon2id claim-secret
+  verify, CSRF token (length-gate before `ct_eq`), audit actor-hash. Keep.
+- Refresh tokens SHA-256-hash-indexed, atomic claim-and-delete, single-use
+  rotation; `Session::Debug` redacts. Auth extractor checks server-side session
+  state (existence + `Authenticated`) on every request — the revocation mechanism.
+- JWT: EdDSA pinned, `aud="VTC"` enforced, required claims + exp checked,
+  `aws_lc_rs` provider (no `rsa`). Audience isolation VTA↔VTC — no shared audience.
+- RTBF disposition (`clamp_disposition`/`is_rtbf_purge`): clamp up to the
+  preservation floor, but member self-purge (`actor == target && purge`) overrides
+  the floor; the override audit envelope is emitted only when the clamp would have
+  fired.
+- Boot recovery: syncer `InFlight→Pending` flip on boot; persist `InFlight` before
+  the network call.
+
+Wire/compat:
+- Stored-record evolution additive-only with least-privilege `#[serde(default)]`
+  defaults; keyspace key encoding percent-encodes `:`/`/`/`%` to avoid prefix
+  collisions (the relationships index P0.11 is the one that missed this).
+- `deny_unknown_fields` on the auth TT response payloads and `CommunityProfileUpdate`
+  (community_did deliberately immutable) — don't add fields.
+- Typed `e.p.msg.forbidden` vs `unauthorized`; `suggested_fix` strings are the
+  operator-UX contract.
+
+Runtime topology:
+- Single `AppState` construction (`server.rs:380`) shared by REST, DIDComm, and
+  background tasks — VTC does NOT have the VTA's split-state bug; keep it that way
+  (P1.1 fixes the *derived* boot-stable snapshots, not the Arc sharing).
+- Listener bound once before threads; REST+DIDComm joined in parallel, storage
+  joined last with `persist(SyncAll)`; panic in any thread triggers shutdown.
+- Idempotent, non-clobbering boot heals (default policies, legacy-ceremony upgrade,
+  status-list seed, missing-AdminEntry heal, profile heal) — loudly logged,
+  preserve operator state.
+- Router branch ⇒ posture: unauth crypto routes on the governed 64 KB branch (the
+  P0.5 fix completes this); JWT routes off the limiter; CORS wildcard rejected at
+  load, `allow_credentials` only with an explicit allowlist; admin-UI at `/`
+  refused in path mode (cookie-scope guard) — reconcile with P3.1.
+- Atomic website deploy/rollback: staging-dir + rename (live), symlink+rename swap
+  (managed) — readers never see partial state.
+- `website/paths.rs` traversal chain (NUL/control, NFC, hidden, blocklist,
+  double-canonicalize containment, exec-bit) and `bundle.rs` zip-slip defense
+  (pre-extract `verify_entries` + `Read::take(cap)`) are the reference — route the
+  website `PUT` path through them (P3.3).

--- a/vta-sdk/src/client/consent.rs
+++ b/vta-sdk/src/client/consent.rs
@@ -126,4 +126,56 @@ impl VtaClient {
         )
         .await
     }
+
+    /// `consent/approver-set/1.0` — bind the operator who approves consent for
+    /// `platform` within `context`, and how the prompt routes (`route` is
+    /// `"wake"` or `"bridge-relay"`). Admin-gated.
+    pub async fn consent_approver_set(
+        &self,
+        platform: &str,
+        context: &str,
+        approver: &str,
+        route: Option<&str>,
+        route_hint: Option<&str>,
+    ) -> Result<Value, VtaError> {
+        let mut payload = json!({
+            "platform": platform,
+            "context": context,
+            "approver": approver,
+        });
+        if let Some(r) = route {
+            payload["route"] = json!(r);
+        }
+        if let Some(h) = route_hint {
+            payload["routeHint"] = json!(h);
+        }
+        self.dispatch_trust_task(
+            trust_tasks::TASK_CONSENT_APPROVER_SET_1_0,
+            payload,
+            CONSENT_TT_TIMEOUT,
+        )
+        .await
+    }
+
+    /// `consent/approver-list/1.0` — read the approver bindings, optionally
+    /// filtered by `platform` / `context`.
+    pub async fn consent_approver_list(
+        &self,
+        platform: Option<&str>,
+        context: Option<&str>,
+    ) -> Result<Value, VtaError> {
+        let mut payload = json!({});
+        if let Some(p) = platform {
+            payload["platform"] = json!(p);
+        }
+        if let Some(c) = context {
+            payload["context"] = json!(c);
+        }
+        self.dispatch_trust_task(
+            trust_tasks::TASK_CONSENT_APPROVER_LIST_1_0,
+            payload,
+            CONSENT_TT_TIMEOUT,
+        )
+        .await
+    }
 }

--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -1031,6 +1031,15 @@ pub const TASK_CONSENT_REVOKE_1_0: &str = "https://trusttasks.org/spec/consent/r
 /// so steady-state inbound is a local Allow/Deny lookup. Read-only.
 pub const TASK_CONSENT_LIST_1_0: &str = "https://trusttasks.org/spec/consent/list/1.0";
 
+/// `consent/approver-set/1.0` — an admin binds the operator who approves consent
+/// for a platform within a context (and how the prompt routes). Admin-gated.
+pub const TASK_CONSENT_APPROVER_SET_1_0: &str =
+    "https://trusttasks.org/spec/consent/approver-set/1.0";
+
+/// `consent/approver-list/1.0` — read the approver bindings (optionally filtered).
+pub const TASK_CONSENT_APPROVER_LIST_1_0: &str =
+    "https://trusttasks.org/spec/consent/approver-list/1.0";
+
 // ─── Future slices ───────────────────────────────────────────────────────
 //
 // attestation, services, webvh, did-templates, passkey-vms, backup,
@@ -1200,6 +1209,8 @@ pub const ALL_URIS: &[&str] = &[
     TASK_CONSENT_DECISION_1_0,
     TASK_CONSENT_REVOKE_1_0,
     TASK_CONSENT_LIST_1_0,
+    TASK_CONSENT_APPROVER_SET_1_0,
+    TASK_CONSENT_APPROVER_LIST_1_0,
 ];
 
 /// The subset of [`ALL_URIS`] served by **dedicated REST routes** rather than

--- a/vta-service/src/keyspaces.rs
+++ b/vta-service/src/keyspaces.rs
@@ -52,6 +52,9 @@ pub const BOOTSTRAP: &str = "bootstrap";
 /// Inbound-messaging consent: durable grants + TTL'd pending requests
 /// (`vti_common::consent`). The VTA is the first gate for bridged conversations.
 pub const CONSENT: &str = "consent";
+/// Per-(platform, context) approver bindings — who decides consent and how the
+/// prompt routes (`vti_common::consent::ApproverBinding`).
+pub const CONSENT_APPROVERS: &str = "consent_approvers";
 
 /// Every production keyspace. Partitioned by [`BACKED_UP`] +
 /// [`EXCLUDED_FROM_BACKUP`]; the [`tests::backup_partition_is_total`] guard
@@ -76,11 +79,21 @@ pub const ALL: &[&str] = &[
     SNAPSHOT,
     BOOTSTRAP,
     CONSENT,
+    CONSENT_APPROVERS,
 ];
 
 /// Keyspaces whose contents a full `export_backup` captures (as typed
 /// collections — see `operations::backup`).
-pub const BACKED_UP: &[&str] = &[KEYS, ACL, CONTEXTS, AUDIT, IMPORTED_SECRETS, WEBVH, CONSENT];
+pub const BACKED_UP: &[&str] = &[
+    KEYS,
+    ACL,
+    CONTEXTS,
+    AUDIT,
+    IMPORTED_SECRETS,
+    WEBVH,
+    CONSENT,
+    CONSENT_APPROVERS,
+];
 
 /// Keyspaces deliberately **not** in a backup.
 ///

--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -118,6 +118,8 @@ pub struct AppState {
     pub passkey_vms_ks: KeyspaceHandle,
     /// Inbound-messaging consent store (grants + pending requests).
     pub consent_ks: KeyspaceHandle,
+    /// Per-(platform, context) approver bindings for consent routing.
+    pub consent_approvers_ks: KeyspaceHandle,
     /// Persisted drain set for the protocol-management feature
     /// (`docs/05-design-notes/didcomm-protocol-management.md`).
     /// Keyed by mediator DID; replayed at boot.
@@ -298,6 +300,8 @@ pub async fn build_app_state(
     #[cfg(feature = "webvh")]
     let passkey_vms_ks = apply_encryption(store.keyspace(crate::keyspaces::PASSKEY_VMS)?);
     let consent_ks = apply_encryption(store.keyspace(crate::keyspaces::CONSENT)?);
+    let consent_approvers_ks =
+        apply_encryption(store.keyspace(crate::keyspaces::CONSENT_APPROVERS)?);
     #[cfg(feature = "webvh")]
     let drains_ks = apply_encryption(store.keyspace(crate::keyspaces::DRAINS)?);
     #[cfg(feature = "webvh")]
@@ -352,6 +356,7 @@ pub async fn build_app_state(
         #[cfg(feature = "webvh")]
         passkey_vms_ks,
         consent_ks,
+        consent_approvers_ks,
         #[cfg(feature = "webvh")]
         drains_ks,
         #[cfg(feature = "webvh")]

--- a/vta-service/src/test_support.rs
+++ b/vta-service/src/test_support.rs
@@ -774,6 +774,7 @@ pub async fn build_test_app_with(opts: TestAppOptions) -> (axum::Router, TestApp
         cache_ks,
         vault_ks,
         consent_ks: store.keyspace(crate::keyspaces::CONSENT).unwrap(),
+        consent_approvers_ks: store.keyspace(crate::keyspaces::CONSENT_APPROVERS).unwrap(),
         service_state_ks,
         sealed_nonces_ks,
         backup_bundles_ks: backup_bundles_ks.clone(),

--- a/vta-service/src/trust_tasks/consent.rs
+++ b/vta-service/src/trust_tasks/consent.rs
@@ -7,9 +7,11 @@
 //! (`consent/revoke`). See the `consent/*` family in the dtgwg registry and
 //! `vti_common::consent`.
 //!
-//! Auth (approach A): the approver is a **context admin** (the operator), or the
-//! **enrolled bridge** relaying the operator's out-of-band choice
-//! (bridge-attested). A per-platform approver registry is a follow-up.
+//! Auth: the approver is the operator **bound for the (platform, context)** in
+//! the approver registry (`consent/approver-set`), or the **enrolled bridge**
+//! relaying the operator's out-of-band choice (bridge-attested). With no binding
+//! configured, `consent/request` is default-denied (`noApprover`) and a context
+//! admin is the fallback decider.
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -18,9 +20,10 @@ use uuid::Uuid;
 
 use vti_common::auth::session::now_epoch;
 use vti_common::consent::{
-    ConsentEffect, ConsentGrant, ConsentKind, ConsentScope, ConsentSubject, ConsumeConsent,
-    consume_pending_consent, delete_consent_grant, get_consent_grant, list_consent_grants,
-    new_pending_consent, store_consent_grant, store_pending_consent,
+    ApproverBinding, ConsentEffect, ConsentGrant, ConsentKind, ConsentRoute, ConsentScope,
+    ConsentSubject, ConsumeConsent, consume_pending_consent, delete_consent_grant, get_approver,
+    get_consent_grant, list_approvers, list_consent_grants, new_pending_consent, store_approver,
+    store_consent_grant, store_pending_consent,
 };
 use vti_common::error::AppError;
 
@@ -136,6 +139,65 @@ struct ListResponse {
     grants: Vec<WireGrant>,
 }
 
+// Approver registry (Track A) wire shapes.
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ApproverSetPayload {
+    platform: String,
+    context: String,
+    approver: String,
+    #[serde(default)]
+    route: Option<ConsentRoute>,
+    #[serde(default)]
+    route_hint: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ApproverListPayload {
+    #[serde(default)]
+    platform: Option<String>,
+    #[serde(default)]
+    context: Option<String>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct WireApprover {
+    platform: String,
+    context: String,
+    approver: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    route: Option<ConsentRoute>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    route_hint: Option<String>,
+}
+
+impl From<ApproverBinding> for WireApprover {
+    fn from(b: ApproverBinding) -> Self {
+        WireApprover {
+            platform: b.platform,
+            context: b.context,
+            approver: b.approver,
+            route: b.route,
+            route_hint: b.route_hint,
+        }
+    }
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ApproverSetResponse {
+    status: &'static str,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ApproverListResponse {
+    approvers: Vec<WireApprover>,
+}
+
 fn epoch_to_rfc3339(secs: u64) -> String {
     chrono::DateTime::<chrono::Utc>::from_timestamp(secs as i64, 0)
         .unwrap_or_default()
@@ -201,6 +263,34 @@ pub(super) async fn handle_request(
     let context = payload
         .context_hint
         .or_else(|| auth.default_context().map(str::to_string));
+
+    // Resolve the approver for (platform, context). Default-deny: with no
+    // approver bound, there is no one to route consent to → noApprover. Operators
+    // bind one via consent/approver-set.
+    match &context {
+        Some(ctx) => {
+            match get_approver(&state.consent_approvers_ks, &subject.platform, ctx).await {
+                Ok(Some(_)) => {}
+                Ok(None) => {
+                    return app_error_to_reject(
+                        &doc,
+                        AppError::Forbidden(
+                            "consent/request: no approver configured for this platform/context"
+                                .into(),
+                        ),
+                    );
+                }
+                Err(e) => return app_error_to_reject(&doc, e),
+            }
+        }
+        None => {
+            return app_error_to_reject(
+                &doc,
+                AppError::Forbidden("consent/request: no context to resolve an approver".into()),
+            );
+        }
+    }
+
     let pending = new_pending_consent(
         subject,
         payload.scope,
@@ -212,8 +302,6 @@ pub(super) async fn handle_request(
     if let Err(e) = store_pending_consent(&state.consent_ks, &pending).await {
         return app_error_to_reject(&doc, e);
     }
-    // NB (approach A): a context admin issues `consent/decision`; explicit
-    // operator-notification routing is a follow-up.
     success_response(
         &doc,
         AckResponse {
@@ -253,13 +341,31 @@ pub(super) async fn handle_decision(
                 }
                 let is_bridge = auth.did == p.requested_by;
                 if !is_bridge {
-                    if let Err(e) = auth.require_admin() {
-                        return app_error_to_reject(&doc, e);
-                    }
-                    if let Some(ctx) = &p.context
-                        && let Err(e) = auth.require_context(ctx)
-                    {
-                        return app_error_to_reject(&doc, e);
+                    // The issuer must be the approver bound for this
+                    // (platform, context); fall back to a context admin only
+                    // when no approver is configured.
+                    let ctx = p.context.clone().unwrap_or_default();
+                    match get_approver(&state.consent_approvers_ks, &subject.platform, &ctx).await {
+                        Ok(Some(b)) if b.approver == auth.did => {}
+                        Ok(Some(_)) => {
+                            return app_error_to_reject(
+                                &doc,
+                                AppError::Forbidden(
+                                    "consent/decision: issuer is not the bound approver".into(),
+                                ),
+                            );
+                        }
+                        Ok(None) => {
+                            if let Err(e) = auth.require_admin() {
+                                return app_error_to_reject(&doc, e);
+                            }
+                            if !ctx.is_empty()
+                                && let Err(e) = auth.require_context(&ctx)
+                            {
+                                return app_error_to_reject(&doc, e);
+                            }
+                        }
+                        Err(e) => return app_error_to_reject(&doc, e),
                     }
                 }
                 let evidence = if is_bridge {
@@ -390,6 +496,62 @@ pub(super) async fn handle_list(
     success_response(&doc, ListResponse { grants: wire })
 }
 
+/// `consent/approver-set/1.0` — an admin binds the approver for a
+/// (platform, context). Auth: admin of the context.
+pub(super) async fn handle_approver_set(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    let payload: ApproverSetPayload = match parse_payload(&doc) {
+        Ok(p) => p,
+        Err(resp) => return resp,
+    };
+    if let Err(e) = auth.require_admin() {
+        return app_error_to_reject(&doc, e);
+    }
+    if let Err(e) = auth.require_context(&payload.context) {
+        return app_error_to_reject(&doc, e);
+    }
+    let binding = ApproverBinding {
+        platform: payload.platform,
+        context: payload.context,
+        approver: payload.approver,
+        route: payload.route,
+        route_hint: payload.route_hint,
+    };
+    if let Err(e) = store_approver(&state.consent_approvers_ks, &binding).await {
+        return app_error_to_reject(&doc, e);
+    }
+    success_response(&doc, ApproverSetResponse { status: "set" })
+}
+
+/// `consent/approver-list/1.0` — read the approver bindings. Auth: read.
+pub(super) async fn handle_approver_list(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    if let Err(e) = auth.require_read() {
+        return app_error_to_reject(&doc, e);
+    }
+    let payload: ApproverListPayload = match parse_payload(&doc) {
+        Ok(p) => p,
+        Err(resp) => return resp,
+    };
+    let all = match list_approvers(&state.consent_approvers_ks).await {
+        Ok(v) => v,
+        Err(e) => return app_error_to_reject(&doc, e),
+    };
+    let approvers: Vec<WireApprover> = all
+        .into_iter()
+        .filter(|b| payload.platform.as_ref().is_none_or(|p| &b.platform == p))
+        .filter(|b| payload.context.as_ref().is_none_or(|c| &b.context == c))
+        .map(WireApprover::from)
+        .collect();
+    success_response(&doc, ApproverListResponse { approvers })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -451,5 +613,35 @@ mod tests {
         let s = epoch_to_rfc3339(1_700_000_000);
         assert_eq!(rfc3339_to_epoch(&s), Some(1_700_000_000));
         assert_eq!(rfc3339_to_epoch("not-a-date"), None);
+    }
+
+    #[test]
+    fn approver_set_payload_parses_wire_route() {
+        let v = serde_json::json!({
+            "platform": "signal",
+            "context": "ctx",
+            "approver": "did:web:op",
+            "route": "bridge-relay",
+            "routeHint": "sig-0a1b",
+        });
+        let p: ApproverSetPayload = serde_json::from_value(v).unwrap();
+        assert_eq!(p.route, Some(ConsentRoute::BridgeRelay));
+        assert_eq!(p.route_hint.as_deref(), Some("sig-0a1b"));
+    }
+
+    #[test]
+    fn wire_approver_serializes_camelcase_and_route() {
+        let b = ApproverBinding {
+            platform: "signal".into(),
+            context: "ctx".into(),
+            approver: "did:web:op".into(),
+            route: Some(ConsentRoute::Wake),
+            route_hint: None,
+        };
+        let v = serde_json::to_value(WireApprover::from(b)).unwrap();
+        assert_eq!(v["route"], "wake");
+        assert!(v.get("routeHint").is_none());
+        let list = serde_json::to_value(ApproverListResponse { approvers: vec![] }).unwrap();
+        assert_eq!(list["approvers"], serde_json::json!([]));
     }
 }

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -394,6 +394,8 @@ dispatch_table! {
     vta_sdk::trust_tasks::TASK_CONSENT_DECISION_1_0 => consent::handle_decision,
     vta_sdk::trust_tasks::TASK_CONSENT_REVOKE_1_0 => consent::handle_revoke,
     vta_sdk::trust_tasks::TASK_CONSENT_LIST_1_0 => consent::handle_list,
+    vta_sdk::trust_tasks::TASK_CONSENT_APPROVER_SET_1_0 => consent::handle_approver_set,
+    vta_sdk::trust_tasks::TASK_CONSENT_APPROVER_LIST_1_0 => consent::handle_approver_list,
     // ─── ACL slice ────────────────────────────────────────────────
     vta_sdk::trust_tasks::TASK_ACL_LIST_1_0 => acl::handle_list,
     vta_sdk::trust_tasks::TASK_ACL_CREATE_1_0 => acl::handle_create,

--- a/vti-common/src/consent.rs
+++ b/vti-common/src/consent.rs
@@ -203,6 +203,84 @@ pub fn new_pending_consent(
     }
 }
 
+// ── Approver registry (Track A) ──────────────────────────────────────────────
+
+/// How a consent prompt reaches the approver.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ConsentRoute {
+    /// Push to the approver's device for a DID-signed decision.
+    Wake,
+    /// Render through an enrolled bridge (e.g. a card in the operator's app) for
+    /// a bridge-attested decision.
+    BridgeRelay,
+}
+
+/// Who approves inbound-messaging consent for a platform within a context, and
+/// how the prompt reaches them. Keyed by `(platform, context)`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ApproverBinding {
+    pub platform: String,
+    pub context: String,
+    /// VID of the operator authorized to decide consent.
+    pub approver: String,
+    /// How to deliver the prompt; treated as `bridge-relay` when absent.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub route: Option<ConsentRoute>,
+    /// Optional routing detail — e.g. the operator's opaque conversationRef.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub route_hint: Option<String>,
+}
+
+impl ApproverBinding {
+    fn key(platform: &str, context: &str) -> String {
+        format!("approver:{platform}\u{1f}{context}")
+    }
+}
+
+/// Store (upsert) an approver binding keyed by `(platform, context)`.
+pub async fn store_approver(
+    ks: &KeyspaceHandle,
+    binding: &ApproverBinding,
+) -> Result<(), AppError> {
+    ks.insert(
+        ApproverBinding::key(&binding.platform, &binding.context),
+        binding,
+    )
+    .await
+}
+
+/// Resolve the approver bound for `(platform, context)`, if any.
+pub async fn get_approver(
+    ks: &KeyspaceHandle,
+    platform: &str,
+    context: &str,
+) -> Result<Option<ApproverBinding>, AppError> {
+    ks.get(ApproverBinding::key(platform, context)).await
+}
+
+/// Delete the binding for `(platform, context)`.
+pub async fn delete_approver(
+    ks: &KeyspaceHandle,
+    platform: &str,
+    context: &str,
+) -> Result<(), AppError> {
+    ks.remove(ApproverBinding::key(platform, context)).await
+}
+
+/// All approver bindings. Callers filter by platform / context in memory.
+pub async fn list_approvers(ks: &KeyspaceHandle) -> Result<Vec<ApproverBinding>, AppError> {
+    let rows = ks.prefix_iter_raw("approver:").await?;
+    let mut out = Vec::with_capacity(rows.len());
+    for (_key, value) in rows {
+        match serde_json::from_slice::<ApproverBinding>(&value) {
+            Ok(b) => out.push(b),
+            Err(e) => tracing::warn!(error = %e, "skipping undeserializable approver binding"),
+        }
+    }
+    Ok(out)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -358,5 +436,46 @@ mod tests {
         };
         let s = serde_json::to_string(&g).unwrap();
         assert_eq!(serde_json::from_str::<ConsentGrant>(&s).unwrap(), g);
+    }
+
+    #[tokio::test]
+    async fn approver_store_get_list_delete_round_trip() {
+        let ks = ks().await;
+        assert!(get_approver(&ks, "signal", "ctx").await.unwrap().is_none());
+
+        let b = ApproverBinding {
+            platform: "signal".into(),
+            context: "ctx".into(),
+            approver: "did:web:operator".into(),
+            route: Some(ConsentRoute::BridgeRelay),
+            route_hint: Some("sig-0a1b".into()),
+        };
+        store_approver(&ks, &b).await.unwrap();
+        assert_eq!(
+            get_approver(&ks, "signal", "ctx").await.unwrap(),
+            Some(b.clone())
+        );
+
+        // A second platform in the same context is independent.
+        let mut other = b.clone();
+        other.platform = "slack".into();
+        store_approver(&ks, &other).await.unwrap();
+        assert_eq!(list_approvers(&ks).await.unwrap().len(), 2);
+
+        delete_approver(&ks, "signal", "ctx").await.unwrap();
+        assert!(get_approver(&ks, "signal", "ctx").await.unwrap().is_none());
+        assert_eq!(list_approvers(&ks).await.unwrap().len(), 1);
+    }
+
+    #[test]
+    fn route_serializes_kebab_case() {
+        assert_eq!(
+            serde_json::to_string(&ConsentRoute::BridgeRelay).unwrap(),
+            "\"bridge-relay\""
+        );
+        assert_eq!(
+            serde_json::to_string(&ConsentRoute::Wake).unwrap(),
+            "\"wake\""
+        );
     }
 }


### PR DESCRIPTION
Track A of the consent hardening (`vti-message-bridge/docs/consent-hardening.md`). The VTA now knows **who** approves inbound-messaging consent per `(platform, context)`, so `consent/request` routes to a specific operator instead of "any context admin".

Consumes the `consent/approver-{set,list}` specs from dtgwg #91 — but via **local wire structs**, so it builds against the *current* published `trust-tasks-rs` (no 0.2.5 dependency), same as the consent core did.

## What's here
- **`vti-common`** — `ApproverBinding` + `ConsentRoute` (`wake`|`bridge-relay`) records + store/get/list/delete helpers keyed by `(platform, context)`.
- **`vta-sdk`** — `TASK_CONSENT_APPROVER_{SET,LIST}_1_0` constants (+ `ALL_URIS`) and `consent_approver_set` / `consent_approver_list` client wrappers.
- **`vta-service`** — new backed-up `CONSENT_APPROVERS` keyspace (H2); `handle_approver_set` (admin-gated) / `handle_approver_list` (read) wired into dispatch; **`consent/request` resolves the registry** and default-denies with `noApprover` when none is bound (H3 fail-closed); **`consent/decision` verifies the issuer is the bound approver**, with a context-admin fallback only when no binding exists (back-compat).

## Decisions
H1 per-`(platform, context)` ✔ · H2 new `CONSENT_APPROVERS` keyspace ✔ · H3 fail-closed `noApprover` ✔.

## No bridge change
The bridge already speaks `consent/request`/`list`; it just gets `noApprover` until an operator binds an approver.

## Testing
vti-common 8, vta-service trust_tasks 39 (incl. dispatch parity + keyspace backup-partition); fmt + clippy clean. DCO-signed.

## Follow-ups
- A `pnm consent approver set|list` operator command (no consent CLI surface exists in pnm yet — the `vta-sdk` wrappers are usable now).
- **Track B** (DID-signed `wake` route) layers on this.