### PR TITLE
feat(consent): wake-route approvers for did-signed decisions (Track B)

### DIFF
--- a/vta-service/src/trust_tasks/consent.rs
+++ b/vta-service/src/trust_tasks/consent.rs
@@ -267,29 +267,27 @@ pub(super) async fn handle_request(
     // Resolve the approver for (platform, context). Default-deny: with no
     // approver bound, there is no one to route consent to → noApprover. Operators
     // bind one via consent/approver-set.
-    match &context {
-        Some(ctx) => {
-            match get_approver(&state.consent_approvers_ks, &subject.platform, ctx).await {
-                Ok(Some(_)) => {}
-                Ok(None) => {
-                    return app_error_to_reject(
-                        &doc,
-                        AppError::Forbidden(
-                            "consent/request: no approver configured for this platform/context"
-                                .into(),
-                        ),
-                    );
-                }
-                Err(e) => return app_error_to_reject(&doc, e),
-            }
-        }
-        None => {
+    let Some(ctx) = context.clone() else {
+        return app_error_to_reject(
+            &doc,
+            AppError::Forbidden("consent/request: no context to resolve an approver".into()),
+        );
+    };
+    let binding = match get_approver(&state.consent_approvers_ks, &subject.platform, &ctx).await {
+        Ok(Some(b)) => b,
+        Ok(None) => {
             return app_error_to_reject(
                 &doc,
-                AppError::Forbidden("consent/request: no context to resolve an approver".into()),
+                AppError::Forbidden(
+                    "consent/request: no approver configured for this platform/context".into(),
+                ),
             );
         }
-    }
+        Err(e) => return app_error_to_reject(&doc, e),
+    };
+
+    // Snapshot the prompt subject (camelCase) before `subject` is moved.
+    let wire_subject = serde_json::to_value(WireSubject::from(&subject)).unwrap_or_default();
 
     let pending = new_pending_consent(
         subject,
@@ -302,6 +300,21 @@ pub(super) async fn handle_request(
     if let Err(e) = store_pending_consent(&state.consent_ks, &pending).await {
         return app_error_to_reject(&doc, e);
     }
+
+    // Track B: a `wake`-routed approver is roused on their device with the prompt
+    // to sign a did-signed `consent/decision`. Best-effort — the mediator queue
+    // and the bridge-relay card remain fallbacks.
+    if binding.route == Some(ConsentRoute::Wake) {
+        maybe_wake_consent_approver(
+            state,
+            &binding.approver,
+            wire_subject,
+            payload.scope,
+            &payload.challenge,
+        )
+        .await;
+    }
+
     success_response(
         &doc,
         AckResponse {
@@ -310,6 +323,74 @@ pub(super) async fn handle_request(
             grant_id: None,
         },
     )
+}
+
+/// DIDComm message type carrying a consent prompt to a `wake`-routed approver's
+/// device, which renders it and replies with a signed `consent/decision`.
+#[cfg(feature = "didcomm")]
+const CONSENT_APPROVE_REQUEST_TYPE: &str =
+    "https://trusttasks.org/spec/consent/approve-request/0.1";
+
+/// Rouse a `wake`-routed approver: buffer the consent prompt to their mediator
+/// and ring the push-gateway doorbell. Best-effort; mirrors the step-up wake
+/// path (`maybe_push_step_up` + `trigger_gateway_wake`).
+#[cfg(feature = "didcomm")]
+async fn maybe_wake_consent_approver(
+    state: &AppState,
+    approver: &str,
+    subject: Value,
+    scope: ConsentScope,
+    challenge: &str,
+) {
+    let mediator_did = {
+        let cfg = state.config.read().await;
+        super::step_up::approver_mediator(
+            approver,
+            cfg.messaging.as_ref().map(|m| m.mediator_did.as_str()),
+        )
+    };
+    let Some(mediator_did) = mediator_did else {
+        tracing::debug!(
+            approver = %approver,
+            "no mediator route for wake approver; mediator pickup / relay fallback applies"
+        );
+        return;
+    };
+    let approve_request = serde_json::json!({
+        "id": format!("urn:uuid:{}", Uuid::new_v4()),
+        "type": CONSENT_APPROVE_REQUEST_TYPE,
+        "payload": { "subject": subject, "scope": scope, "challenge": challenge },
+    });
+    let pending = crate::messaging::registry::PendingResponse {
+        recipient_did: approver.to_string(),
+        message_type: CONSENT_APPROVE_REQUEST_TYPE.to_string(),
+        body: approve_request.clone(),
+        thread_id: approve_request
+            .get("id")
+            .and_then(|v| v.as_str())
+            .map(str::to_string),
+    };
+    if let Err(e) = state
+        .mediator_registry
+        .buffer_outbound(&mediator_did, pending)
+        .await
+    {
+        tracing::warn!(
+            error = %e, approver = %approver, mediator = %mediator_did,
+            "failed to buffer consent approve-request; mediator pickup applies"
+        );
+    }
+    super::step_up::trigger_gateway_wake(state, approver, &mediator_did).await;
+}
+
+#[cfg(not(feature = "didcomm"))]
+async fn maybe_wake_consent_approver(
+    _state: &AppState,
+    _approver: &str,
+    _subject: Value,
+    _scope: ConsentScope,
+    _challenge: &str,
+) {
 }
 
 /// `consent/decision/1.0` — an approver allows/denies; records a grant.

--- a/vta-service/src/trust_tasks/step_up.rs
+++ b/vta-service/src/trust_tasks/step_up.rs
@@ -625,7 +625,7 @@ const STEP_UP_APPROVE_REQUEST_TYPE: &str =
 /// same mediator and picks the message up there. Future `did:peer` / `did:webvh`
 /// approvers advertise their own mediator service and route there instead (not
 /// yet wired → `None`, so the relay fallback applies).
-fn approver_mediator(approver_did: &str, configured: Option<&str>) -> Option<String> {
+pub(super) fn approver_mediator(approver_did: &str, configured: Option<&str>) -> Option<String> {
     if !approver_did.starts_with("did:key:") {
         return None;
     }
@@ -698,7 +698,11 @@ async fn maybe_push_step_up(
 /// a DID. The VTA authenticates to the gateway as the authcrypt sender (it is on
 /// the handle's allowlist, provisioned at set-wake).
 #[cfg(feature = "didcomm")]
-async fn trigger_gateway_wake(state: &AppState, recipient: &str, approver_mediator: &str) {
+pub(super) async fn trigger_gateway_wake(
+    state: &AppState,
+    recipient: &str,
+    approver_mediator: &str,
+) {
     /// DIDComm message type that carries a Trust Task envelope in its body.
     const TRUST_TASK_ENVELOPE_TYPE: &str = "https://trusttasks.org/binding/didcomm/0.1/envelope";
 


### PR DESCRIPTION
Track B of the consent hardening (`vti-message-bridge/docs/consent-hardening.md`). When an `ApproverBinding` routes via **`wake`**, `consent/request` now rouses the approver on their own device to sign a **did-signed** `consent/decision` — instead of relying on a bridge relaying their out-of-band choice.

## The verification half already shipped with Track A
An operator's `consent/decision` is itself a **DID-signed Trust Task** (proof verified at dispatch); `handle_decision` already records `evidence: did-signed` for the bound approver. So Track B's real new piece is the **routing**.

## What's here
- **`consent/request`** resolves the binding (Track A) and, for `route == wake`, **buffers a consent approve-request to the approver's mediator + rings the push-gateway doorbell** — reusing the step-up wake machinery (`approver_mediator` + `trigger_gateway_wake`, now `pub(super)`). Best-effort: the mediator queue and the bridge-relay card (Phase 3b) remain fallbacks.
- New device contract: the **`consent/approve-request/0.1`** DIDComm envelope — a wake-routed device renders it and replies with a signed `consent/decision` echoing the challenge.

## External dependency (out of scope here)
The **device/wallet** rendering the approve-request + producing the signed decision lives outside these repos — the same surface that handles step-up approve-requests today. This PR is the VTA half (rouse + verify).

## Testing
Both feature modes build (`didcomm` / default); `trust_tasks::consent` tests pass; clippy + fmt clean both modes. DCO-signed.

## Status
This completes the **VTA portion of both hardening tracks**. Remaining: the `pnm consent approver` CLI (deferred) and the device-side approve-request rendering (external).