### PR TITLE
feat(vtc): member-relationship connections graph in the admin UI

### DIFF
--- a/vtc-service/admin-ui/src/lib/api.ts
+++ b/vtc-service/admin-ui/src/lib/api.ts
@@ -291,6 +291,30 @@ export const revokeInvitation = (
     { trustTask: REVOKE_INVITATION_TASK },
   );
 
+const RELATIONSHIPS_GRAPH_TASK =
+  "https://trusttasks.org/openvtc/vtc/relationships/graph/1.0";
+
+export interface GraphNode {
+  did: string;
+}
+export interface GraphEdge {
+  id: string;
+  issuerDid: string;
+  subjectDid: string;
+  createdAt: string;
+}
+export interface RelationshipsGraph {
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+}
+
+/** The community's member-relationship (VRC) graph — every trust edge between
+ * members, for the connections-graph view. Admin-gated. */
+export const fetchRelationshipsGraph = (): Promise<RelationshipsGraph> =>
+  getJson<RelationshipsGraph>("/v1/relationships/graph", {
+    trustTask: RELATIONSHIPS_GRAPH_TASK,
+  });
+
 const RECOGNITION_CHECK_TASK =
   "https://trusttasks.org/openvtc/vtc/recognition/check/1.0";
 

--- a/vtc-service/admin-ui/src/plugins/index.ts
+++ b/vtc-service/admin-ui/src/plugins/index.ts
@@ -17,6 +17,7 @@ import {
   KeyRound,
   LayoutDashboard,
   Network,
+  Share2,
   ShieldCheck,
   Smartphone,
   Tag,
@@ -36,6 +37,7 @@ import { Members } from "@/plugins/members";
 import { MyPasskeys } from "@/plugins/myPasskeys";
 import { Profile } from "@/plugins/profile";
 import { Recognition } from "@/plugins/recognition";
+import { Relationships } from "@/plugins/relationshipsGraph";
 import { Sessions } from "@/plugins/sessions";
 
 export function registerBuiltinPlugins(): void {
@@ -77,6 +79,14 @@ export function registerBuiltinPlugins(): void {
     path: "/recognition",
     iconComponent: Network,
     reactComponent: Recognition,
+  });
+
+  registerPlugin({
+    id: "relationships",
+    label: "Relationships",
+    path: "/relationships",
+    iconComponent: Share2,
+    reactComponent: Relationships,
   });
 
   registerPlugin({

--- a/vtc-service/admin-ui/src/plugins/relationshipsGraph.tsx
+++ b/vtc-service/admin-ui/src/plugins/relationshipsGraph.tsx
@@ -1,0 +1,212 @@
+// Relationships plugin — a connections graph of the community's member-to-member
+// trust edges (Verifiable Relationship Credentials, VRCs).
+//
+// Unlike the recognition graph (external, query-only), member relationships are
+// local + enumerable, so we can draw the whole thing. Layout is a deterministic
+// circle: members are nodes, each published VRC is a directed edge issuer →
+// subject. Click a node to highlight its connections and list its edges.
+
+import { useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Share2 } from "lucide-react";
+
+import { fetchRelationshipsGraph, type RelationshipsGraph } from "@/lib/api";
+import { shorten } from "@/lib/format";
+
+const SIZE = 600;
+const C = SIZE / 2;
+const R = 240;
+
+interface Placed {
+  did: string;
+  x: number;
+  y: number;
+}
+
+export function Relationships() {
+  const [selected, setSelected] = useState<string | null>(null);
+
+  const query = useQuery<RelationshipsGraph>({
+    queryKey: ["relationships-graph"],
+    queryFn: fetchRelationshipsGraph,
+  });
+
+  const placed = useMemo<Placed[]>(() => {
+    const nodes = query.data?.nodes ?? [];
+    const n = nodes.length;
+    return nodes.map((node, i) => {
+      const a = (i / Math.max(n, 1)) * 2 * Math.PI - Math.PI / 2;
+      return { did: node.did, x: C + R * Math.cos(a), y: C + R * Math.sin(a) };
+    });
+  }, [query.data]);
+
+  const posByDid = useMemo(() => {
+    const m = new Map<string, Placed>();
+    for (const p of placed) m.set(p.did, p);
+    return m;
+  }, [placed]);
+
+  const edges = query.data?.edges ?? [];
+  const selectedEdges = selected
+    ? edges.filter((e) => e.issuerDid === selected || e.subjectDid === selected)
+    : [];
+  const neighbours = new Set<string>(
+    selectedEdges.flatMap((e) => [e.issuerDid, e.subjectDid]),
+  );
+
+  const isEmpty = query.data && placed.length === 0;
+
+  return (
+    <div className="page">
+      <header className="page-header">
+        <h2>
+          <Share2 size={20} strokeWidth={1.75} /> Relationships
+        </h2>
+        <p className="muted">
+          The community's trust graph: each node is a member, each edge a
+          published Verifiable Relationship Credential (VRC), pointing from the
+          asserting member to the member they vouched for. Click a node to
+          highlight its connections.
+        </p>
+      </header>
+
+      {query.isPending && (
+        <section className="card">
+          <p className="muted">Loading…</p>
+        </section>
+      )}
+      {query.isError && (
+        <section className="card">
+          <p className="muted">Could not load the relationships graph.</p>
+        </section>
+      )}
+      {isEmpty && (
+        <section className="card">
+          <p className="muted">
+            No relationships published yet — members haven't issued any VRCs.
+          </p>
+        </section>
+      )}
+
+      {query.data && placed.length > 0 && (
+        <section className="card" style={{ display: "flex", gap: "var(--space-4)", flexWrap: "wrap" }}>
+          <svg
+            viewBox={`0 0 ${SIZE} ${SIZE}`}
+            style={{ width: "min(100%, 560px)", height: "auto" }}
+            role="img"
+            aria-label="Member relationship graph"
+          >
+            <defs>
+              <marker
+                id="rel-arrow"
+                viewBox="0 0 10 10"
+                refX="9"
+                refY="5"
+                markerWidth="6"
+                markerHeight="6"
+                orient="auto-start-reverse"
+              >
+                <path d="M 0 0 L 10 5 L 0 10 z" fill="var(--border-strong)" />
+              </marker>
+            </defs>
+
+            {/* Edges */}
+            {edges.map((e) => {
+              const a = posByDid.get(e.issuerDid);
+              const b = posByDid.get(e.subjectDid);
+              if (!a || !b) return null;
+              const active =
+                !selected || e.issuerDid === selected || e.subjectDid === selected;
+              return (
+                <line
+                  key={e.id}
+                  x1={a.x}
+                  y1={a.y}
+                  x2={b.x}
+                  y2={b.y}
+                  stroke={active ? "var(--brand)" : "var(--border)"}
+                  strokeWidth={active ? 1.5 : 1}
+                  opacity={selected && !active ? 0.25 : 0.8}
+                  markerEnd="url(#rel-arrow)"
+                />
+              );
+            })}
+
+            {/* Nodes */}
+            {placed.map((p) => {
+              const isSel = selected === p.did;
+              const dim = selected && !isSel && !neighbours.has(p.did);
+              return (
+                <g
+                  key={p.did}
+                  transform={`translate(${p.x}, ${p.y})`}
+                  style={{ cursor: "pointer" }}
+                  opacity={dim ? 0.35 : 1}
+                  onClick={() => setSelected(isSel ? null : p.did)}
+                >
+                  <circle
+                    r={isSel ? 9 : 6}
+                    fill={isSel ? "var(--brand)" : "var(--brand-tint-strong)"}
+                    stroke="var(--border-strong)"
+                    strokeWidth={1}
+                  />
+                  <text
+                    x={p.x > C ? 11 : -11}
+                    y={4}
+                    textAnchor={p.x > C ? "start" : "end"}
+                    fontSize="10"
+                    fill="var(--text-muted)"
+                  >
+                    {shorten(p.did, 8, 4)}
+                  </text>
+                </g>
+              );
+            })}
+          </svg>
+
+          <div style={{ flex: "1 1 220px", minWidth: 220 }}>
+            <h3>
+              {selected ? "Connections" : "Overview"}
+            </h3>
+            {!selected && (
+              <p className="muted">
+                {placed.length} member{placed.length === 1 ? "" : "s"} ·{" "}
+                {edges.length} relationship{edges.length === 1 ? "" : "s"}.
+                <br />
+                Select a node to see its edges.
+              </p>
+            )}
+            {selected && (
+              <>
+                <p>
+                  <code className="truncate">{selected}</code>
+                </p>
+                {selectedEdges.length === 0 ? (
+                  <p className="muted">No relationships.</p>
+                ) : (
+                  <ul style={{ paddingLeft: "1.1em", margin: 0 }}>
+                    {selectedEdges.map((e) => (
+                      <li key={e.id} style={{ marginBottom: 4 }}>
+                        {e.issuerDid === selected ? (
+                          <>
+                            → vouched for{" "}
+                            <code>{shorten(e.subjectDid, 8, 4)}</code>
+                          </>
+                        ) : (
+                          <>
+                            ← vouched for by{" "}
+                            <code>{shorten(e.issuerDid, 8, 4)}</code>
+                          </>
+                        )}
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </>
+            )}
+          </div>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/vtc-service/src/relationships/mod.rs
+++ b/vtc-service/src/relationships/mod.rs
@@ -51,7 +51,7 @@ use uuid::Uuid;
 
 pub use storage::{
     RELATIONSHIPS_BY_DID_PREFIX, RELATIONSHIPS_PREFIX, delete_relationship, find_by_hash,
-    get_relationship, list_for_did, store_relationship,
+    get_relationship, list_all, list_for_did, store_relationship,
 };
 
 /// A stored, verified VRC. Field order matches the spec §5.4

--- a/vtc-service/src/relationships/storage.rs
+++ b/vtc-service/src/relationships/storage.rs
@@ -136,6 +136,24 @@ pub async fn find_by_hash(
     Ok(None)
 }
 
+/// List **every** relationship (full primary-keyspace scan). For the admin
+/// connections-graph view, which needs the whole edge set at once. Communities
+/// are small enough (and the graph view is admin-only) that an unpaginated scan
+/// is acceptable here; the per-DID [`list_for_did`] stays the paginated path.
+pub async fn list_all(primary: &KeyspaceHandle) -> Result<Vec<Relationship>, AppError> {
+    let pairs = primary
+        .prefix_iter_raw(RELATIONSHIPS_PREFIX.to_vec())
+        .await?;
+    let mut out = Vec::with_capacity(pairs.len());
+    for (_k, v) in pairs {
+        match decode(&v) {
+            Ok(rel) => out.push(rel),
+            Err(e) => tracing::warn!(error = %e, "skipping unparseable relationship row"),
+        }
+    }
+    Ok(out)
+}
+
 /// Paginated list of relationships where `did` is either
 /// issuer or subject. Walks the secondary index, then loads
 /// the primary rows lazily — orphan index entries (where the
@@ -246,6 +264,20 @@ mod tests {
         store_relationship(&primary, &index, &rel).await.unwrap();
         let got = get_relationship(&primary, rel.id).await.unwrap().unwrap();
         assert_eq!(got, rel);
+    }
+
+    #[tokio::test]
+    async fn list_all_returns_every_edge() {
+        let (primary, index, _audit, _dir) = temp_kss().await;
+        let r1 = fresh("did:key:zA", "did:key:zB");
+        let r2 = fresh("did:key:zB", "did:key:zC");
+        store_relationship(&primary, &index, &r1).await.unwrap();
+        store_relationship(&primary, &index, &r2).await.unwrap();
+
+        let all = list_all(&primary).await.unwrap();
+        assert_eq!(all.len(), 2);
+        let ids: std::collections::HashSet<_> = all.iter().map(|r| r.id).collect();
+        assert!(ids.contains(&r1.id) && ids.contains(&r2.id));
     }
 
     #[tokio::test]

--- a/vtc-service/src/routes/mod.rs
+++ b/vtc-service/src/routes/mod.rs
@@ -556,6 +556,11 @@ fn build_api_chain(_routing: &RoutingConfig, trust_xff: bool) -> OpenApiRouter<A
             routes!(members::relationships::list),
             "https://trusttasks.org/openvtc/vtc/relationships/list/1.0",
         ))
+        // Admin connections-graph view — the member-relationship (VRC) graph.
+        .routes(tt(
+            routes!(relationships::graph),
+            "https://trusttasks.org/openvtc/vtc/relationships/graph/1.0",
+        ))
         .routes(tt(
             routes!(relationships::publish),
             "https://trusttasks.org/openvtc/vtc/relationships/publish/1.0",

--- a/vtc-service/src/routes/relationships.rs
+++ b/vtc-service/src/routes/relationships.rs
@@ -401,6 +401,71 @@ fn canonicalise(v: &JsonValue) -> String {
     serde_json::to_string(&into_sorted(v.clone())).unwrap_or_else(|_| "{}".into())
 }
 
+// ── Connections graph (admin) ──────────────────────────────────────────────
+
+/// One node in the connections graph — a member that is an endpoint of at least
+/// one relationship (VRC). Isolated members (no VRCs) are not surfaced.
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct GraphNode {
+    pub did: String,
+}
+
+/// One directed edge — a published VRC from `issuerDid` (the asserting member)
+/// to `subjectDid`. Body-free (no VRC JSON-LD): the graph shows the shape, not
+/// the credential contents.
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct GraphEdge {
+    pub id: String,
+    pub issuer_did: String,
+    pub subject_did: String,
+    pub created_at: String,
+}
+
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct RelationshipsGraph {
+    pub nodes: Vec<GraphNode>,
+    pub edges: Vec<GraphEdge>,
+}
+
+/// `GET /v1/relationships/graph` — the community's member-relationship (VRC)
+/// graph: every published trust edge between members, for the admin-UI
+/// connections view. Admin-gated; a full scan of the relationships keyspace
+/// (communities are small and this is operator-only). Edge-derived nodes —
+/// members with no VRCs don't appear.
+#[utoipa::path(
+    get, path = "/relationships/graph", tag = "relationships",
+    security(("bearer_jwt" = [])),
+    responses(
+        (status = 200, description = "Member-relationship graph", body = RelationshipsGraph),
+        (status = 403, description = "Caller is not an admin"),
+    ),
+)]
+pub async fn graph(
+    _auth: crate::auth::AdminAuth,
+    State(state): State<AppState>,
+) -> Result<Json<RelationshipsGraph>, AppError> {
+    let rels = crate::relationships::list_all(&state.relationships_ks).await?;
+    let mut nodes = std::collections::BTreeSet::new();
+    let mut edges = Vec::with_capacity(rels.len());
+    for r in rels {
+        nodes.insert(r.issuer_did.clone());
+        nodes.insert(r.subject_did.clone());
+        edges.push(GraphEdge {
+            id: r.id.to_string(),
+            issuer_did: r.issuer_did,
+            subject_did: r.subject_did,
+            created_at: r.created_at.to_rfc3339(),
+        });
+    }
+    Ok(Json(RelationshipsGraph {
+        nodes: nodes.into_iter().map(|did| GraphNode { did }).collect(),
+        edges,
+    }))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary

Adds a **connections graph** to the VTC admin console — a visual map of the community's member-to-member trust edges (Verifiable Relationship Credentials, VRCs). Unlike the recognition graph (external + query-only), member relationships are **local and enumerable**, so the whole graph can be drawn.

## What's included
- **`relationships::storage::list_all`** — full primary-keyspace scan returning every VRC.
- **`GET /v1/relationships/graph`** (admin) — returns `{ nodes, edges }`: directed `issuer → subject` edges and the member DIDs they touch. Body-free (no VRC JSON-LD — the graph shows the shape, not contents).
- **admin-ui `Relationships` plugin** — a deterministic circular SVG graph (members as nodes, VRCs as directed edges with arrowheads). Click a node to highlight its connections and list its in/out edges. No new JS dependency.

## Notes
- **Edge-derived nodes:** members with no VRCs don't appear (it's a *connections* view). A future enhancement could overlay all members (incl. isolated) and/or switch to a force-directed layout.
- This is distinct from the **Recognition** page, which stays a per-DID lookup (the recognition/trust graph lives in the upstream registry and isn't enumerable).

## Tests
`list_all` storage test; `vtc-service` lib green; admin UI typechecks + bundles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)