### PR TITLE
fix(vtc): stop warn-logging tombstoned members as orphaned rows

### DIFF
--- a/vtc-service/src/routes/members/read.rs
+++ b/vtc-service/src/routes/members/read.rs
@@ -154,10 +154,20 @@ pub async fn list_members(
                 }
                 items.push(MemberResponse::from_pair(acl, member));
             }
+            None if member.removed_at.is_some() => {
+                // Expected: a Tombstone / Historical departure deletes the ACL
+                // row but retains the Member row (PII cleared, `removed_at`
+                // set) as a "who was a member" record. It legitimately has no
+                // ACL — skip it from the active-member list without alarming.
+                tracing::debug!(
+                    did = %member.did,
+                    "skipping tombstoned/historical member (no ACL) in list response"
+                );
+            }
             None => {
-                // Member row without an ACL row would mean an
-                // out-of-band corruption. Log + skip rather than
-                // 500 — the page should still be returnable.
+                // A *live* member row with no ACL row is genuine out-of-band
+                // corruption (e.g. an interrupted purge). Log + skip rather
+                // than 500 — the page should still be returnable.
                 tracing::warn!(
                     did = %member.did,
                     "member row has no matching ACL entry; skipping in list response"

--- a/vtc-service/tests/members_crud.rs
+++ b/vtc-service/tests/members_crud.rs
@@ -223,6 +223,33 @@ async fn list_members_returns_seeded_members() {
 }
 
 #[tokio::test]
+async fn list_members_skips_tombstoned_member_with_no_acl() {
+    // A Tombstone/Historical departure deletes the ACL row but keeps the Member
+    // row (`removed_at` set). The list join must skip it cleanly (not 500, not
+    // surface it) — and, per the read path, without a corruption warning.
+    let fix = build_fixture().await;
+    seed_member(&fix, "did:key:zLive", VtcRole::Member).await;
+    // A tombstoned member: Member row only (no ACL entry), `removed_at` set.
+    let mut gone = Member::fresh("did:key:zGone");
+    gone.tombstone();
+    store_member(&fix.members_ks, &gone).await.unwrap();
+
+    let (status, body) = send(
+        &fix.router,
+        "GET",
+        "/v1/members",
+        LIST_TASK,
+        Some(&fix.admin_token),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let items = body["items"].as_array().unwrap();
+    assert_eq!(items.len(), 1, "tombstoned member is skipped");
+    assert_eq!(items[0]["did"], "did:key:zLive");
+}
+
+#[tokio::test]
 async fn list_members_filter_by_role_drops_non_matching() {
     let fix = build_fixture().await;
     seed_member(&fix, "did:key:zMember1", VtcRole::Member).await;


### PR DESCRIPTION
## Summary

Fixes the noisy warning:
```
WARN ...routes::members::read: member row has no matching ACL entry; skipping in list response did=...
```

**Root cause — not leftover data.** A **Tombstone / Historical** member departure (`ceremony::execute::depart`) deletes the member's **ACL** row but **intentionally keeps the Member row** (PII cleared, `removed_at` set) as a "who was a member" record — only **Purge** deletes the row. The members-list join (`routes/members/read.rs`) treated *any* ACL-less Member row as out-of-band corruption and logged a `WARN` + skipped it — so every departed-but-retained member trips it on **every** `GET /v1/members`.

## Fix
Split the no-ACL case:
- `removed_at.is_some()` (tombstoned / historical) → **expected**, skipped at `debug!` (no alarm).
- `removed_at.is_none()` (a *live* member row with no ACL — e.g. an interrupted purge) → **genuine corruption**, keeps the `warn!`.

List behaviour is otherwise unchanged (both are skipped from the active-member list).

## Notes
- If you want a departed member's row **gone** entirely, remove with the **Purge** disposition.
- Optional follow-up (not in this PR): *surface* tombstoned members in the list with a `removed` flag instead of hiding them.

## Tests
Added `list_members_skips_tombstoned_member_with_no_acl`; `members_crud` suite green (15).

🤖 Generated with [Claude Code](https://claude.com/claude-code)