### PR TITLE
feat(vtc): surface + purge departed members; allow re-inviting them

### DIFF
--- a/vtc-service/admin-ui/src/plugins/members.tsx
+++ b/vtc-service/admin-ui/src/plugins/members.tsx
@@ -18,6 +18,7 @@ import {
   Check,
   Minus,
   Ticket,
+  Trash2,
   Users as UsersIcon,
 } from "lucide-react";
 
@@ -40,6 +41,10 @@ const TRUST_TASK_SHOW =
   "https://trusttasks.org/openvtc/vtc/members/show/1.0";
 const TRUST_TASK_PROMOTE =
   "https://trusttasks.org/openvtc/vtc/members/promote-to-admin/1.0";
+const TRUST_TASK_REMOVED =
+  "https://trusttasks.org/openvtc/vtc/members/removed/1.0";
+const TRUST_TASK_PURGE =
+  "https://trusttasks.org/openvtc/vtc/members/purge/1.0";
 
 interface MemberRow {
   did: string;
@@ -132,6 +137,107 @@ async function adminRemove(args: {
     trustTask: TRUST_TASK_SHOW,
     body: { reason: args.reason || null },
   });
+}
+
+interface RemovedMemberRow {
+  did: string;
+  removedAt: string;
+  statusListIndex: number | null;
+  status: string;
+}
+
+async function fetchRemovedMembers(): Promise<RemovedMemberRow[]> {
+  return getJson<RemovedMemberRow[]>("/v1/members/removed", {
+    trustTask: TRUST_TASK_REMOVED,
+  });
+}
+
+async function purgeMember(did: string): Promise<void> {
+  await deleteJson<unknown>(
+    `/v1/members/${encodeURIComponent(did)}/purge`,
+    { trustTask: TRUST_TASK_PURGE },
+  );
+}
+
+/// Departed members whose Member row was kept as a tombstone (Tombstone /
+/// Historical disposition). They have no ACL, so they don't show in the active
+/// list — surfaced here so operators can see who left and permanently purge the
+/// lingering rows. Purge is super-admin only (the button 403s otherwise).
+function RemovedMembers() {
+  const queryClient = useQueryClient();
+  const confirm = useConfirm();
+  const query = useQuery({
+    queryKey: ["members-removed"],
+    queryFn: fetchRemovedMembers,
+  });
+
+  const purgeMutation = useMutation({
+    mutationFn: purgeMember,
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["members-removed"] });
+      void queryClient.invalidateQueries({ queryKey: ["members"] });
+    },
+  });
+
+  const rows = query.data ?? [];
+  if (query.isPending || rows.length === 0) {
+    // Hide the section entirely when there are no departed members.
+    return null;
+  }
+
+  return (
+    <section className="card">
+      <h3>Removed members</h3>
+      <p className="muted">
+        Departed members whose record was retained (tombstone). They are no
+        longer members; permanently delete the row to clean up.
+      </p>
+      <table className="data-table">
+        <thead>
+          <tr>
+            <th>DID</th>
+            <th>Removed</th>
+            <th>Revocation slot</th>
+            <th />
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((m) => (
+            <tr key={m.did}>
+              <td>
+                <code>{m.did}</code>
+              </td>
+              <td>{formatDate(m.removedAt)}</td>
+              <td>{m.statusListIndex ?? "—"}</td>
+              <td>
+                <button
+                  type="button"
+                  className="secondary destructive"
+                  disabled={purgeMutation.isPending}
+                  onClick={async () => {
+                    const ok = await confirm({
+                      title: "Permanently delete member?",
+                      message: `This removes the retained record for ${m.did}. This cannot be undone.`,
+                      confirmLabel: "Delete permanently",
+                      destructive: true,
+                    });
+                    if (ok) purgeMutation.mutate(m.did);
+                  }}
+                >
+                  <Trash2 size={16} strokeWidth={1.75} /> Delete permanently
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {purgeMutation.error && (
+        <p className="error">
+          {(purgeMutation.error as Error).message}
+        </p>
+      )}
+    </section>
+  );
 }
 
 
@@ -288,6 +394,8 @@ function MembersList() {
           )}
         </div>
       </section>
+
+      <RemovedMembers />
     </section>
   );
 }

--- a/vtc-service/src/ceremony/mod.rs
+++ b/vtc-service/src/ceremony/mod.rs
@@ -75,7 +75,9 @@ pub use facts::{
     Presentation, Purpose, State, Subject,
 };
 pub use invariant::{Invariant, InvariantViolation};
-pub use orchestrate::{LeaveOutcome, RoleChangeResult, remove_inner, role_change_via_pipeline};
+pub use orchestrate::{
+    LeaveOutcome, RoleChangeResult, purge_member, remove_inner, role_change_via_pipeline,
+};
 pub use verdict::{Allow, Deny, Refer, RequestMore, Verdict};
 pub use verify::{VerifiedFacts, VerifyError};
 

--- a/vtc-service/src/ceremony/orchestrate.rs
+++ b/vtc-service/src/ceremony/orchestrate.rs
@@ -175,6 +175,83 @@ pub struct LeaveOutcome {
     pub removed: bool,
 }
 
+/// Forcefully **purge** a member row — operator cleanup for a lingering
+/// tombstone (a Tombstone/Historical departure left the Member row after its
+/// ACL was deleted), or a hard delete of a live member. Hard-deletes the ACL
+/// (if any) + Member row, decrements the row count, and best-effort flips the
+/// revocation bit. Super-admin only at the route layer.
+///
+/// Unlike [`remove_inner`], this does **not** require an existing ACL (so it can
+/// clean up tombstones) and does **not** run the removal policy — it's a
+/// forceful admin op. The executor's no-last-admin invariant still applies, so
+/// purging the sole admin is refused (`Conflict`).
+pub async fn purge_member(
+    state: &AppState,
+    actor_did: &str,
+    target_did: &str,
+) -> Result<LeaveOutcome, AppError> {
+    let audit_writer = state
+        .audit_writer
+        .as_ref()
+        .ok_or_else(|| AppError::Internal("audit_writer not initialised".into()))?;
+
+    // Must have *something* to purge — a Member row and/or an ACL entry.
+    let has_member = get_member(&state.members_ks, target_did).await?.is_some();
+    let has_acl = get_acl_entry(&state.acl_ks, target_did).await?.is_some();
+    if !has_member && !has_acl {
+        return Err(AppError::NotFound(format!(
+            "no member or tombstone to purge: {target_did}"
+        )));
+    }
+
+    // Reuse the single state-mutating seam with a forced Purge disposition.
+    let EffectOutcome::Departed(outcome) = execute::apply(
+        state,
+        EffectPlan::Depart {
+            subject: target_did.to_string(),
+            disposition: Some("purge".to_string()),
+        },
+        actor_did,
+    )
+    .await?
+    else {
+        return Err(AppError::Internal(
+            "purge effect did not produce a departure outcome".into(),
+        ));
+    };
+
+    audit_writer
+        .write(
+            actor_did,
+            Some(target_did),
+            AuditEvent::MemberRemoved(MemberRemovedData {
+                disposition: "purge".into(),
+                reason: "operator purge".into(),
+            }),
+        )
+        .await?;
+    if let Some(slot) = outcome.revoked_slot {
+        audit_writer
+            .write(
+                actor_did,
+                Some(target_did),
+                AuditEvent::StatusListFlipped(StatusListFlippedData {
+                    purpose: StatusPurpose::Revocation.to_string(),
+                    index: slot,
+                    revoked: true,
+                }),
+            )
+            .await?;
+    }
+
+    info!(actor = actor_did, target = target_did, "member purged");
+    Ok(LeaveOutcome {
+        did: target_did.to_string(),
+        disposition: "purge".into(),
+        removed: true,
+    })
+}
+
 /// The leave ceremony's decide → resolve → effect → audit spine. Returns
 /// `Ok(LeaveOutcome)` on departure, `Err(Forbidden)` when the policy denies, or
 /// `Err(Conflict)` for the executor's no-last-admin invariant.

--- a/vtc-service/src/routes/invitations.rs
+++ b/vtc-service/src/routes/invitations.rs
@@ -29,7 +29,6 @@ use crate::credentials::invitation::{DEFAULT_INVITATION_VALIDITY, issue_invitati
 use crate::credentials::invitation_registry::{
     InvitationRecord, get_invitation, list_invitations, store_invitation,
 };
-use crate::members::get_member;
 use crate::server::AppState;
 use crate::status_list;
 
@@ -105,12 +104,16 @@ pub async fn issue(
     if !body.subject_did.starts_with("did:") {
         return Err(AppError::Validation("subjectDid must be a DID".into()));
     }
-    if get_member(&state.members_ks, &body.subject_did)
+    // "Already a member" means a *current* (ACL-present) member — not a departed
+    // one whose tombstone Member row lingers after a Tombstone/Historical
+    // removal. A departed member can be re-invited (re-join overwrites the
+    // tombstone with a fresh membership), so gate on the ACL, not the Member row.
+    if get_acl_entry(&state.acl_ks, &body.subject_did)
         .await?
         .is_some()
     {
         return Err(AppError::Conflict(format!(
-            "{} is already a member — no invitation needed",
+            "{} is already a current member — no invitation needed",
             body.subject_did
         )));
     }

--- a/vtc-service/src/routes/members/read.rs
+++ b/vtc-service/src/routes/members/read.rs
@@ -184,6 +184,56 @@ pub async fn list_members(
 }
 
 // ---------------------------------------------------------------------------
+// GET /v1/members/removed
+// ---------------------------------------------------------------------------
+
+/// A departed member whose Member row was retained (Tombstone / Historical
+/// disposition) after its ACL was deleted. Surfaced so operators can see who
+/// left and purge the lingering rows.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct RemovedMember {
+    pub did: String,
+    /// When the member departed.
+    pub removed_at: DateTime<Utc>,
+    /// Revocation slot the member held (for audit / re-flip), if any.
+    pub status_list_index: Option<u32>,
+    /// Always `"removed"` — present so the UI can render a uniform status.
+    pub status: String,
+}
+
+/// GET /members/removed — members whose row was kept as a tombstone after
+/// departure (no ACL). Auth: Admin. Full scan (departed members are few and
+/// this is an operator view), newest-departed first.
+#[utoipa::path(
+    get, path = "/members/removed", tag = "members",
+    security(("bearer_jwt" = [])),
+    responses(
+        (status = 200, description = "Departed (tombstoned/historical) members", body = [RemovedMember]),
+        (status = 403, description = "Caller is not an admin"),
+    ),
+)]
+pub async fn list_removed(
+    _auth: AdminAuth,
+    State(state): State<AppState>,
+) -> Result<Json<Vec<RemovedMember>>, AppError> {
+    let mut removed: Vec<RemovedMember> = crate::members::list_members(&state.members_ks)
+        .await?
+        .into_iter()
+        .filter_map(|m| {
+            m.removed_at.map(|removed_at| RemovedMember {
+                did: m.did,
+                removed_at,
+                status_list_index: m.status_list_index,
+                status: "removed".to_string(),
+            })
+        })
+        .collect();
+    removed.sort_by(|a, b| b.removed_at.cmp(&a.removed_at));
+    Ok(Json(removed))
+}
+
+// ---------------------------------------------------------------------------
 // GET /v1/members/{did}
 // ---------------------------------------------------------------------------
 

--- a/vtc-service/src/routes/members/remove.rs
+++ b/vtc-service/src/routes/members/remove.rs
@@ -29,8 +29,8 @@ use serde::{Deserialize, Serialize};
 
 use vti_common::error::AppError;
 
-use crate::auth::{AdminAuth, AuthClaims};
-use crate::ceremony::{LeaveOutcome, remove_inner};
+use crate::auth::{AdminAuth, AuthClaims, SuperAdminAuth};
+use crate::ceremony::{LeaveOutcome, purge_member, remove_inner};
 use crate::members::Disposition;
 use crate::server::AppState;
 
@@ -147,5 +147,34 @@ pub async fn admin_remove(
         )));
     }
     let outcome = remove_inner(&state, &admin.0.did, &target_did, body.disposition, reason).await?;
+    Ok((StatusCode::OK, Json(RemoveResponse::from(outcome))))
+}
+
+// ---------------------------------------------------------------------------
+// DELETE /v1/members/{did}/purge — forceful cleanup (super-admin)
+// ---------------------------------------------------------------------------
+
+/// DELETE /members/{did}/purge — permanently delete a member row, including a
+/// lingering **tombstone** (a departed member whose row was kept after its ACL
+/// was removed). Hard-deletes the ACL (if any) + Member row, decrements the
+/// count, and flips the revocation bit. Auth: **Super-admin** (forceful, skips
+/// the removal policy). Refuses the sole admin (no-last-admin invariant).
+#[utoipa::path(
+    delete, path = "/members/{did}/purge", tag = "members",
+    security(("bearer_jwt" = [])),
+    params(("did" = String, Path, description = "Member DID")),
+    responses(
+        (status = 200, description = "Member purged", body = RemoveResponse),
+        (status = 403, description = "Caller is not a super-admin / would orphan the last admin"),
+        (status = 404, description = "No member or tombstone to purge"),
+    ),
+)]
+pub async fn purge(
+    super_admin: SuperAdminAuth,
+    State(state): State<AppState>,
+    Path(target_did): Path<String>,
+) -> Result<(StatusCode, Json<RemoveResponse>), AppError> {
+    vti_common::identifier::validate_did("did", &target_did)?;
+    let outcome = purge_member(&state, &super_admin.0.did, &target_did).await?;
     Ok((StatusCode::OK, Json(RemoveResponse::from(outcome))))
 }

--- a/vtc-service/src/routes/mod.rs
+++ b/vtc-service/src/routes/mod.rs
@@ -504,6 +504,17 @@ fn build_api_chain(_routing: &RoutingConfig, trust_xff: bool) -> OpenApiRouter<A
             routes!(members::read::list_members),
             "https://trusttasks.org/openvtc/vtc/members/list/1.0",
         ))
+        // Departed (tombstoned/historical) members + forceful purge. The
+        // literal `/removed` must precede the `/{did}` catchall so axum's
+        // path-trie doesn't route "removed" as a DID (same reason as `/me`).
+        .routes(tt(
+            routes!(members::read::list_removed),
+            "https://trusttasks.org/openvtc/vtc/members/removed/1.0",
+        ))
+        .routes(tt(
+            routes!(members::remove::purge),
+            "https://trusttasks.org/openvtc/vtc/members/purge/1.0",
+        ))
         // `/v1/members/me` for self-remove (M1.11.1). Must be
         // declared BEFORE the `/v1/members/{did}` mount otherwise
         // axum's path-trie picks the parameterised route first

--- a/vtc-service/tests/invitations.rs
+++ b/vtc-service/tests/invitations.rs
@@ -197,6 +197,29 @@ async fn inviting_an_existing_member_is_a_conflict() {
 }
 
 #[tokio::test]
+async fn inviting_a_departed_tombstoned_did_is_allowed() {
+    let fix = build().await;
+    // A departed member: a tombstone Member row (removed_at set) with NO ACL —
+    // the ACL was deleted on a Tombstone/Historical departure. Re-inviting them
+    // must succeed (re-join overwrites the tombstone), not 409.
+    let departed = "did:key:z6MkDeparted000000000000000000000000000000000";
+    let mut gone = Member::fresh(departed);
+    gone.tombstone();
+    store_member(&fix._vtc.state.members_ks, &gone)
+        .await
+        .unwrap();
+
+    let req = issue_req(&fix.admin_token, json!({ "subjectDid": departed }));
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    let (status, v) = body_value(resp).await;
+    assert_eq!(
+        status,
+        StatusCode::CREATED,
+        "a departed (tombstoned) DID can be re-invited: {v}"
+    );
+}
+
+#[tokio::test]
 async fn invite_can_grant_a_role_via_scopes() {
     let fix = build().await;
     let req = issue_req(

--- a/vtc-service/tests/members_crud.rs
+++ b/vtc-service/tests/members_crud.rs
@@ -21,6 +21,8 @@ use vtc_service::test_support::TestVtc;
 
 const RP_ORIGIN: &str = "https://vtc.example.com";
 const LIST_TASK: &str = "https://trusttasks.org/openvtc/vtc/members/list/1.0";
+const REMOVED_TASK: &str = "https://trusttasks.org/openvtc/vtc/members/removed/1.0";
+const PURGE_TASK: &str = "https://trusttasks.org/openvtc/vtc/members/purge/1.0";
 const SHOW_TASK: &str = "https://trusttasks.org/openvtc/vtc/members/show/1.0";
 const PROMOTE_TASK: &str = "https://trusttasks.org/openvtc/vtc/members/promote-to-admin/1.0";
 
@@ -247,6 +249,56 @@ async fn list_members_skips_tombstoned_member_with_no_acl() {
     let items = body["items"].as_array().unwrap();
     assert_eq!(items.len(), 1, "tombstoned member is skipped");
     assert_eq!(items[0]["did"], "did:key:zLive");
+}
+
+#[tokio::test]
+async fn list_removed_returns_tombstoned_members_and_purge_deletes_them() {
+    let fix = build_fixture().await;
+    seed_member(&fix, "did:key:zLive", VtcRole::Member).await;
+    // A tombstone: Member row only (no ACL), removed_at set.
+    let mut gone = Member::fresh("did:key:zGone");
+    gone.tombstone();
+    store_member(&fix.members_ks, &gone).await.unwrap();
+
+    // The removed list surfaces the tombstone (and only it).
+    let (status, body) = send(
+        &fix.router,
+        "GET",
+        "/v1/members/removed",
+        REMOVED_TASK,
+        Some(&fix.admin_token),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let removed = body.as_array().unwrap();
+    assert_eq!(removed.len(), 1);
+    assert_eq!(removed[0]["did"], "did:key:zGone");
+    assert_eq!(removed[0]["status"], "removed");
+
+    // Purge it (admin token is super-admin: Admin role + no contexts).
+    let (status, _) = send(
+        &fix.router,
+        "DELETE",
+        "/v1/members/did:key:zGone/purge",
+        PURGE_TASK,
+        Some(&fix.admin_token),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    // Now the removed list is empty — the row is gone for good.
+    let (_, body) = send(
+        &fix.router,
+        "GET",
+        "/v1/members/removed",
+        REMOVED_TASK,
+        Some(&fix.admin_token),
+        None,
+    )
+    .await;
+    assert!(body.as_array().unwrap().is_empty());
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Fixes a confusing trio around the member **tombstone** (a Tombstone/Historical departure keeps the Member row but deletes its ACL): a departed member that's invisible in the UI but still blocks re-invitation, with no way to see or clean it up.

### 1. Re-invite (bug)
The invitation "already a member" check used `get_member(...)`, so a departed member's lingering tombstone returned **409 "already a member"** — even though the members list showed nobody. Now it gates on the **ACL** (current membership). A departed DID can be re-invited; re-join overwrites the tombstone.

### 2. See all members + status
New **`GET /v1/members/removed`** (admin) lists tombstoned/historical members (`{did, removedAt, statusListIndex, status:"removed"}`). The admin-UI **Members** page gains a **"Removed members"** section under the active list.

### 3. Delete completely
New **`DELETE /v1/members/{did}/purge`** (**super-admin**) hard-deletes the ACL (if any) + Member row, decrements the count, and flips the revocation bit. It reuses the Depart/Purge effect seam but **without** the ACL precondition (so it can clean up tombstones) and **without** the removal policy (forceful operator cleanup). The **no-last-admin invariant still applies**. The admin UI gains a **"Delete permanently"** button per removed member.

## Why it happened
`remove_inner` requires an ACL entry (`ok_or NotFound`), so a tombstone (ACL already gone) couldn't be removed again — it just lingered, blocking re-invites and cluttering storage with no UI to see it.

## Tests
- `inviting_a_departed_tombstoned_did_is_allowed` (invitations)
- `list_removed_returns_tombstoned_members_and_purge_deletes_them` (members_crud)
- Existing live-member 409 + tombstone-skip behaviour still hold.
- Admin UI typechecks + bundles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)