### PR TITLE
feat(vtc): audit authorization, invitation, session, backup & admin-invite operations

### DIFF
--- a/vtc-service/src/routes/acl.rs
+++ b/vtc-service/src/routes/acl.rs
@@ -12,6 +12,7 @@ use crate::acl::{
 use crate::auth::{AdminAuth, AuthClaims, ManageAuth, session::now_epoch};
 use crate::error::AppError;
 use crate::server::AppState;
+use vti_common::audit::{AclChangeData, AclRevokedData, AuditEvent};
 
 // ---------- GET /acl ----------
 
@@ -146,6 +147,21 @@ pub async fn create_acl(
 
     store_acl_entry(&acl, &entry).await?;
 
+    if let Some(writer) = state.audit_writer.as_ref() {
+        writer
+            .write(
+                &entry.created_by,
+                Some(&entry.did),
+                AuditEvent::AclGranted(AclChangeData {
+                    did: entry.did.clone(),
+                    role: entry.role.to_string(),
+                    contexts: entry.allowed_contexts.clone(),
+                    expires_at: entry.expires_at.map(|e| e.to_string()),
+                }),
+            )
+            .await?;
+    }
+
     info!(caller = %entry.created_by, did = %entry.did, role = %entry.role, "ACL entry created");
     Ok((StatusCode::CREATED, Json(AclEntryResponse::from(entry))))
 }
@@ -272,6 +288,21 @@ pub async fn update_acl(
         info!(did = %did, revoked, "subject sessions revoked after ACL privilege reduction");
     }
 
+    if let Some(writer) = state.audit_writer.as_ref() {
+        writer
+            .write(
+                &auth.0.did,
+                Some(&did),
+                AuditEvent::AclUpdated(AclChangeData {
+                    did: did.clone(),
+                    role: entry.role.to_string(),
+                    contexts: entry.allowed_contexts.clone(),
+                    expires_at: entry.expires_at.map(|e| e.to_string()),
+                }),
+            )
+            .await?;
+    }
+
     info!(did = %did, "ACL entry updated");
     Ok(Json(AclEntryResponse::from(entry)))
 }
@@ -329,6 +360,19 @@ pub async fn delete_acl(
     }
 
     delete_acl_entry(&acl, &did).await?;
+
+    if let Some(writer) = state.audit_writer.as_ref() {
+        writer
+            .write(
+                &auth.0.did,
+                Some(&did),
+                AuditEvent::AclRevoked(AclRevokedData {
+                    did: did.clone(),
+                    prior_role: Some(entry.role.to_string()),
+                }),
+            )
+            .await?;
+    }
 
     info!(caller = %auth.0.did, did = %did, "ACL entry deleted");
     Ok(StatusCode::NO_CONTENT)

--- a/vtc-service/src/routes/admin/invites.rs
+++ b/vtc-service/src/routes/admin/invites.rs
@@ -29,6 +29,7 @@ use chrono::{DateTime, Duration as ChronoDuration, Utc};
 use serde::{Deserialize, Serialize};
 use tracing::info;
 use uuid::Uuid;
+use vti_common::audit::{AdminInviteData, AuditEvent};
 use vti_common::auth::AdminAuth;
 use vti_common::error::AppError;
 
@@ -147,7 +148,7 @@ const MAX_TTL_SECONDS: u64 = 24 * 60 * 60;
     ),
 )]
 pub async fn create_invite(
-    _admin: AdminAuth,
+    admin: AdminAuth,
     State(state): State<AppState>,
     Json(req): Json<CreateInviteRequest>,
 ) -> Result<(StatusCode, Json<CreateInviteResponse>), AppError> {
@@ -230,6 +231,19 @@ pub async fn create_invite(
         minted.jwt
     );
 
+    if let Some(writer) = state.audit_writer.as_ref() {
+        writer
+            .write(
+                &admin.0.did,
+                Some(&req.did),
+                AuditEvent::AdminInviteCreated(AdminInviteData {
+                    jti: minted.jti.to_string(),
+                    admin_did: Some(req.did.clone()),
+                }),
+            )
+            .await?;
+    }
+
     info!(
         target_did = %req.did,
         jti = %minted.jti,
@@ -301,7 +315,7 @@ pub async fn list_invites(
     ),
 )]
 pub async fn revoke_invite(
-    _admin: AdminAuth,
+    admin: AdminAuth,
     State(state): State<AppState>,
     Path(jti_str): Path<String>,
 ) -> Result<(StatusCode, Json<RevokeInviteResponse>), AppError> {
@@ -326,6 +340,19 @@ pub async fn revoke_invite(
         // admin raced us. Surface as NotFound so the caller sees
         // the same outcome they would on a stale jti.
         return Err(AppError::NotFound(format!("no invite for jti {jti}")));
+    }
+
+    if let Some(writer) = state.audit_writer.as_ref() {
+        writer
+            .write(
+                &admin.0.did,
+                None,
+                AuditEvent::AdminInviteRevoked(AdminInviteData {
+                    jti: jti.to_string(),
+                    admin_did: None,
+                }),
+            )
+            .await?;
     }
 
     info!(%jti, "admin invite removed via REST");

--- a/vtc-service/src/routes/auth.rs
+++ b/vtc-service/src/routes/auth.rs
@@ -20,6 +20,7 @@ use crate::error::AppError;
 use crate::routes::acl::as_vti_acl_entry;
 use crate::server::AppState;
 use tracing::{info, warn};
+use vti_common::audit::{AuditEvent, SessionRevokedData};
 use vti_common::store::KeyspaceHandle;
 
 // ---------- POST /auth/challenge ----------
@@ -992,6 +993,18 @@ pub async fn revoke_session(
     }
 
     delete_session(&sessions, &session_id).await?;
+    if let Some(writer) = state.audit_writer.as_ref() {
+        writer
+            .write(
+                &auth.did,
+                Some(&session.did),
+                AuditEvent::SessionRevoked(SessionRevokedData {
+                    session_id: Some(session_id.clone()),
+                    revoked_count: 1,
+                }),
+            )
+            .await?;
+    }
     info!(caller = %auth.did, session_id = %session_id, "session revoked");
     Ok(StatusCode::NO_CONTENT)
 }
@@ -1045,6 +1058,21 @@ pub async fn revoke_sessions_by_did(
 
     let sessions = state.sessions_ks.clone();
     let revoked = revoke_sessions_for_did(&sessions, &query.did).await?;
+
+    if revoked > 0
+        && let Some(writer) = state.audit_writer.as_ref()
+    {
+        writer
+            .write(
+                &auth.0.did,
+                Some(&query.did),
+                AuditEvent::SessionRevoked(SessionRevokedData {
+                    session_id: None,
+                    revoked_count: revoked as u32,
+                }),
+            )
+            .await?;
+    }
 
     info!(caller = %auth.0.did, target_did = %query.did, revoked, "sessions revoked by DID");
     Ok(Json(RevokeByDidResponse { revoked }))

--- a/vtc-service/src/routes/backup.rs
+++ b/vtc-service/src/routes/backup.rs
@@ -14,6 +14,8 @@ use crate::auth::SuperAdminAuth;
 use crate::backup::{self, BackupEnvelope, ImportResult};
 use crate::keys::seed_store::create_secret_store;
 use crate::server::AppState;
+use crate::store::keyspaces;
+use vti_common::audit::{AuditEvent, BackupData};
 use vti_common::error::AppError;
 
 /// `POST /v1/backup/export` body.
@@ -52,13 +54,25 @@ pub struct ImportRequest {
     ),
 )]
 pub async fn export(
-    SuperAdminAuth(_auth): SuperAdminAuth,
+    SuperAdminAuth(auth): SuperAdminAuth,
     State(state): State<AppState>,
     Json(req): Json<ExportRequest>,
 ) -> Result<Json<BackupEnvelope>, AppError> {
     let store = create_secret_store(&*state.config.read().await)?;
     let envelope =
         backup::export_backup(&state, store.as_ref(), &req.password, req.include_audit).await?;
+    if let Some(writer) = state.audit_writer.as_ref() {
+        writer
+            .write(
+                &auth.did,
+                None,
+                AuditEvent::BackupExported(BackupData {
+                    keyspace_count: keyspaces::BACKED_UP.len() as u32,
+                    vtc_did: envelope.source_did.clone(),
+                }),
+            )
+            .await?;
+    }
     Ok(Json(envelope))
 }
 
@@ -75,7 +89,7 @@ pub async fn export(
     ),
 )]
 pub async fn import(
-    SuperAdminAuth(_auth): SuperAdminAuth,
+    SuperAdminAuth(auth): SuperAdminAuth,
     State(state): State<AppState>,
     Json(req): Json<ImportRequest>,
 ) -> Result<Json<ImportResult>, AppError> {
@@ -88,5 +102,20 @@ pub async fn import(
         req.confirm,
     )
     .await?;
+    // Audit only a real restore — `confirm: false` is a preview (no writes).
+    if result.status == "imported"
+        && let Some(writer) = state.audit_writer.as_ref()
+    {
+        writer
+            .write(
+                &auth.did,
+                None,
+                AuditEvent::BackupImported(BackupData {
+                    keyspace_count: result.counts.len() as u32,
+                    vtc_did: result.source_did.clone(),
+                }),
+            )
+            .await?;
+    }
     Ok(Json(result))
 }

--- a/vtc-service/src/routes/invitations.rs
+++ b/vtc-service/src/routes/invitations.rs
@@ -21,6 +21,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use tracing::info;
 
+use vti_common::audit::{AuditEvent, InvitationIssuedData, InvitationRevokedData};
 use vti_common::auth::AuthClaims;
 use vti_common::error::AppError;
 
@@ -183,6 +184,22 @@ pub async fn issue(
     )
     .await?;
 
+    if let Some(writer) = state.audit_writer.as_ref() {
+        writer
+            .write(
+                &auth.did,
+                Some(&body.subject_did),
+                AuditEvent::InvitationIssued(InvitationIssuedData {
+                    invitation_id: id.clone(),
+                    subject_did: body.subject_did.clone(),
+                    role: body.role.clone(),
+                    valid_until: valid_until.clone().unwrap_or_default(),
+                    status_list_index: Some(slot),
+                }),
+            )
+            .await?;
+    }
+
     info!(
         actor = %auth.did,
         subject = %body.subject_did,
@@ -331,6 +348,20 @@ pub async fn revoke(
     let now = Utc::now();
     record.revoked_at = Some(now);
     store_invitation(&state.invitations_ks, &record).await?;
+
+    if let Some(writer) = state.audit_writer.as_ref() {
+        writer
+            .write(
+                &auth.did,
+                Some(&record.subject_did),
+                AuditEvent::InvitationRevoked(InvitationRevokedData {
+                    invitation_id: id.clone(),
+                    subject_did: Some(record.subject_did.clone()),
+                    newly_revoked: true,
+                }),
+            )
+            .await?;
+    }
 
     info!(actor = %auth.did, vic_id = %id, slot, "revoked an invitation credential (VIC)");
 

--- a/vtc-service/tests/invitations.rs
+++ b/vtc-service/tests/invitations.rs
@@ -197,6 +197,43 @@ async fn inviting_an_existing_member_is_a_conflict() {
 }
 
 #[tokio::test]
+async fn issuing_an_invitation_emits_audit() {
+    use vti_common::audit::{AuditEnvelope, AuditEvent};
+
+    let fix = build().await;
+    let req = issue_req(
+        &fix.admin_token,
+        json!({ "subjectDid": INVITEE_DID, "role": "moderator" }),
+    );
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    let (status, _) = body_value(resp).await;
+    assert_eq!(status, StatusCode::CREATED);
+
+    let raw = fix
+        ._vtc
+        .state
+        .audit_ks
+        .prefix_iter_raw(b"2".to_vec())
+        .await
+        .unwrap();
+    let envelopes: Vec<AuditEnvelope> = raw
+        .iter()
+        .map(|(_, v)| serde_json::from_slice(v).unwrap())
+        .collect();
+    let issued: Vec<&AuditEnvelope> = envelopes
+        .iter()
+        .filter(|e| matches!(e.event, AuditEvent::InvitationIssued(_)))
+        .collect();
+    assert_eq!(issued.len(), 1, "exactly one InvitationIssued envelope");
+    assert_eq!(issued[0].target_did_plain.as_deref(), Some(INVITEE_DID));
+    let AuditEvent::InvitationIssued(data) = &issued[0].event else {
+        unreachable!()
+    };
+    assert_eq!(data.subject_did, INVITEE_DID);
+    assert_eq!(data.role.as_deref(), Some("moderator"));
+}
+
+#[tokio::test]
 async fn inviting_a_departed_tombstoned_did_is_allowed() {
     let fix = build().await;
     // A departed member: a tombstone Member row (removed_at set) with NO ACL —

--- a/vti-common/src/audit/event.rs
+++ b/vti-common/src/audit/event.rs
@@ -309,11 +309,148 @@ pub enum AuditEvent {
     /// correlate which build of the admin SPA is currently
     /// serving. Phase 5 M5.7.2.
     AdminUiServed(AdminUiServedData),
+
+    /// An ACL entry was created — a DID was granted a community role
+    /// (`POST /v1/acl`). Authorization grants are the highest-value
+    /// forensic events: this records who now holds what authority,
+    /// scoped to which contexts, until when. Envelope `target_did` is
+    /// the granted DID.
+    AclGranted(AclChangeData),
+
+    /// An existing ACL entry was modified (`PATCH /v1/acl/{did}`) —
+    /// role / contexts / expiry changed. Envelope `target_did` is the
+    /// affected DID; the payload carries the new state.
+    AclUpdated(AclChangeData),
+
+    /// An ACL entry was deleted (`DELETE /v1/acl/{did}`) — the DID lost
+    /// its community authority. Envelope `target_did` is the revoked DID.
+    AclRevoked(AclRevokedData),
+
+    /// A Verifiable Invitation Credential (VIC) was issued
+    /// (`POST /v1/invitations`). Records the invitee, granted role, and
+    /// the revocation slot so the credential's whole lifecycle is
+    /// traceable. Envelope `target_did` is the invitee.
+    InvitationIssued(InvitationIssuedData),
+
+    /// An invitation was revoked (`DELETE /v1/invitations/{id}`) — its
+    /// revocation bit flipped. Envelope `target_did` is the invitee.
+    InvitationRevoked(InvitationRevokedData),
+
+    /// One or more authenticated sessions were revoked by an admin
+    /// (`DELETE /v1/auth/sessions/{id}` or `?did=`). Cutting off access
+    /// is security-relevant and must be attributable. Envelope
+    /// `target_did` is the session owner (when revoking by DID).
+    SessionRevoked(SessionRevokedData),
+
+    /// An encrypted state backup was exported (`POST /v1/backup/export`).
+    BackupExported(BackupData),
+
+    /// An encrypted state backup was imported, restoring community state
+    /// (`POST /v1/backup/import`). A full-state restore is among the most
+    /// sensitive operations — recorded so a restore is never silent.
+    BackupImported(BackupData),
+
+    /// An admin onboarding invite was minted (`POST /v1/admin/invites`),
+    /// optionally pre-creating an ACL grant. Envelope `target_did` is the
+    /// invited admin DID (when bound to one).
+    AdminInviteCreated(AdminInviteData),
+
+    /// An admin onboarding invite was revoked (`DELETE /v1/admin/invites/{jti}`).
+    AdminInviteRevoked(AdminInviteData),
 }
 
 // ---------------------------------------------------------------------------
 // Variant data structs
 // ---------------------------------------------------------------------------
+
+/// Payload for [`AuditEvent::AclGranted`] / [`AuditEvent::AclUpdated`] — the
+/// state of an ACL entry after the change.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct AclChangeData {
+    /// The DID whose authority changed.
+    pub did: String,
+    /// The role granted / now held (e.g. `"admin"`, `"moderator"`, `"member"`).
+    pub role: String,
+    /// Context scoping (empty = super-admin / community-wide).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub contexts: Vec<String>,
+    /// Expiry (RFC3339), if the grant is time-bounded.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<String>,
+}
+
+/// Payload for [`AuditEvent::AclRevoked`].
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct AclRevokedData {
+    pub did: String,
+    /// The role the DID held immediately before revocation, if known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prior_role: Option<String>,
+}
+
+/// Payload for [`AuditEvent::InvitationIssued`].
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct InvitationIssuedData {
+    /// The VIC's `id` (its consumption / revocation handle).
+    pub invitation_id: String,
+    /// The invited DID (`credentialSubject.id`).
+    pub subject_did: String,
+    /// Role the invite grants on redemption, if any.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub role: Option<String>,
+    /// Expiry (RFC3339).
+    pub valid_until: String,
+    /// Revocation status-list slot allocated to this invite.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status_list_index: Option<u32>,
+}
+
+/// Payload for [`AuditEvent::InvitationRevoked`].
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct InvitationRevokedData {
+    pub invitation_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subject_did: Option<String>,
+    /// `true` if this call flipped the bit, `false` if it was already revoked.
+    pub newly_revoked: bool,
+}
+
+/// Payload for [`AuditEvent::SessionRevoked`].
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionRevokedData {
+    /// The specific session id revoked, for a single-session revoke.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    /// Number of sessions revoked (1 for a single id, N for revoke-by-DID).
+    pub revoked_count: u32,
+}
+
+/// Payload for [`AuditEvent::BackupExported`] / [`AuditEvent::BackupImported`].
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct BackupData {
+    /// Number of keyspaces included in the backup.
+    pub keyspace_count: u32,
+    /// The `vtc_did` the backup belongs to (compatibility anchor).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub vtc_did: Option<String>,
+}
+
+/// Payload for [`AuditEvent::AdminInviteCreated`] / [`AuditEvent::AdminInviteRevoked`].
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct AdminInviteData {
+    /// The invite token's `jti`.
+    pub jti: String,
+    /// The admin DID the invite is bound to, if any.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub admin_did: Option<String>,
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]

--- a/vti-common/src/audit/mod.rs
+++ b/vti-common/src/audit/mod.rs
@@ -31,18 +31,19 @@ pub mod writer;
 
 pub use envelope::{AuditEnvelope, EVENT_VERSION, SCHEMA_VERSION};
 pub use event::{
-    AdminPasskeyData, AdminPromotedData, AdminUiServedData, AuditEvent, AuditKeyRotatedData,
-    CommunityInstalledData, CommunityProfileUpdatedData, ConfigChange, ConfigChangedData,
-    ConfigReloadedData, ConfigSource, CredentialIssuedData, CrossCommunitySessionMintedData,
-    CustomEndorsementIssuedData, CustomEndorsementRevokedData, DidRotatedData,
-    EmergencyBootstrapData, EndorsementTypeDeletedData, EndorsementTypeRegisteredData,
-    JoinRequestData, JoinRequestRejectedData, MemberAddedData, MemberRemovedData,
-    MemberUpdatedData, MembershipReciprocatedData, MembershipRenewedData, PersonhoodAssertedData,
-    PersonhoodRevokedData, PolicyActivatedData, PolicyUploadedData, REDACTED_MARKER,
-    RegistryRecordPolicyOverrideData, RegistryStatusChangedData, RegistrySyncOutcomeData,
-    RestartRequestedData, RoleChangedData, StatusListFlippedData, VrcPublishedData, VrcRevokedData,
-    WebsiteBundleDeployedData, WebsiteFileDeletedData, WebsiteFileWrittenData,
-    WebsiteGenerationRolledBackData,
+    AclChangeData, AclRevokedData, AdminInviteData, AdminPasskeyData, AdminPromotedData,
+    AdminUiServedData, AuditEvent, AuditKeyRotatedData, BackupData, CommunityInstalledData,
+    CommunityProfileUpdatedData, ConfigChange, ConfigChangedData, ConfigReloadedData, ConfigSource,
+    CredentialIssuedData, CrossCommunitySessionMintedData, CustomEndorsementIssuedData,
+    CustomEndorsementRevokedData, DidRotatedData, EmergencyBootstrapData,
+    EndorsementTypeDeletedData, EndorsementTypeRegisteredData, InvitationIssuedData,
+    InvitationRevokedData, JoinRequestData, JoinRequestRejectedData, MemberAddedData,
+    MemberRemovedData, MemberUpdatedData, MembershipReciprocatedData, MembershipRenewedData,
+    PersonhoodAssertedData, PersonhoodRevokedData, PolicyActivatedData, PolicyUploadedData,
+    REDACTED_MARKER, RegistryRecordPolicyOverrideData, RegistryStatusChangedData,
+    RegistrySyncOutcomeData, RestartRequestedData, RoleChangedData, SessionRevokedData,
+    StatusListFlippedData, VrcPublishedData, VrcRevokedData, WebsiteBundleDeployedData,
+    WebsiteFileDeletedData, WebsiteFileWrittenData, WebsiteGenerationRolledBackData,
 };
 pub use key_store::{AuditKey, AuditKeyStore, KeyId, RotationReason};
 pub use writer::AuditWriter;


### PR DESCRIPTION
## Summary

An audit-coverage pass over the VTC. The audit envelope is solid (HMAC-hashed actor/target DIDs under a rotating key, RTBF-aware) and **43 event variants** already exist — but a set of **state-changing operations mutated persistent state without writing any audit event**, leaving real gaps in activity tracing. This closes the highest-value ones.

## New audit events (vti-common `AuditEvent` + payload structs)
| Operation | Event | Was |
|---|---|---|
| `POST /v1/acl` | **AclGranted** (did, role, contexts, expiry) | unaudited |
| `PATCH /v1/acl/{did}` | **AclUpdated** | unaudited |
| `DELETE /v1/acl/{did}` | **AclRevoked** (did, prior role) | unaudited |
| `POST /v1/invitations` | **InvitationIssued** (invitee, role, slot) | unaudited |
| `DELETE /v1/invitations/{id}` | **InvitationRevoked** | unaudited |
| `DELETE /v1/auth/sessions/{id}` & `?did=` | **SessionRevoked** (count) | unaudited |
| `POST /v1/backup/export` | **BackupExported** | unaudited |
| `POST /v1/backup/import` (confirm) | **BackupImported** (preview not audited) | unaudited |
| `POST /v1/admin/invites` | **AdminInviteCreated** | unaudited |
| `DELETE /v1/admin/invites/{jti}` | **AdminInviteRevoked** | unaudited |

These are the "who got authority / who lost it / what credentials moved / who restored state / who can onboard" events — the spine of an activity trail. Each writes via the existing `state.audit_writer` seam (actor = caller, target = affected DID), so they inherit the HMAC hashing + RTBF redaction.

## Tests
Added `issuing_an_invitation_emits_audit` (asserts the envelope, actor, target, and payload). `invitations` suite green (9). *(The 4 `admin_ui::tests` failures in a `VTC_SKIP_ADMIN_UI_BUILD` run are unrelated — they need the baked `dist`.)*

## Not in this PR (tracked in a follow-up issue)
- Remaining unaudited mutations: **schemas** (register/delete/accepts), **legacy `PATCH /v1/config`**, **install-claim** (first-admin enrolment).
- **Payload enrichment**: `CommunityProfileUpdated` / `MemberUpdated` record field *names* but not before/after values; `DidRotated` lacks a rotation reason; `JoinRequestRejected` reason is free-form; `MemberRemoved` lacks prior role.
- **No hash-chaining**: envelopes are independently HMAC-verifiable but not linked, so reorder/drop isn't detectable by the audit system itself — worth a design decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)