### PR TITLE
feat(vtc): audit schema, install-claim & legacy-config mutations (#537 Tier 1)

### DIFF
--- a/vtc-service/src/routes/config.rs
+++ b/vtc-service/src/routes/config.rs
@@ -30,6 +30,7 @@ use crate::community::{CommunityProfileUpdate, load_profile, store_profile};
 use crate::config_store::ConfigStore;
 use crate::error::AppError;
 use crate::server::AppState;
+use vti_common::audit::{AuditEvent, CommunityProfileUpdatedData};
 
 #[derive(Debug, Serialize, utoipa::ToSchema)]
 pub struct ConfigResponse {
@@ -141,6 +142,7 @@ pub async fn update_config(
     }
 
     let mut pending_restart = Vec::new();
+    let mut fields_changed: Vec<String> = Vec::new();
 
     // name/description → the CommunityProfile (sole owner). One write path.
     if req.vtc_name.is_some() || req.vtc_description.is_some() {
@@ -159,6 +161,7 @@ pub async fn update_config(
         let changed = patch.apply(&mut profile)?;
         if !changed.is_empty() {
             store_profile(&state.community_ks, &profile).await?;
+            fields_changed.extend(changed);
         }
     }
 
@@ -174,6 +177,21 @@ pub async fn update_config(
             .put("public_url", &serde_json::Value::String(public_url))
             .await?;
         pending_restart.push("public_url".into());
+        fields_changed.push("publicUrl".into());
+    }
+
+    if !fields_changed.is_empty()
+        && let Some(writer) = state.audit_writer.as_ref()
+    {
+        writer
+            .write(
+                &auth.0.did,
+                None,
+                AuditEvent::CommunityProfileUpdated(CommunityProfileUpdatedData {
+                    fields_changed: fields_changed.clone(),
+                }),
+            )
+            .await?;
     }
 
     let (vtc_name, vtc_description) = resolved_name_description(&state).await?;

--- a/vtc-service/src/routes/install.rs
+++ b/vtc-service/src/routes/install.rs
@@ -336,6 +336,25 @@ pub async fn claim_finish(
     };
     store_admin_entry(&state.passkey_ks, &admin_entry).await?;
 
+    // Audit the first-admin passkey enrolment — the install-claim flow is the
+    // only place an invited admin's passkey is registered, so without this the
+    // device that gained admin authority leaves no audit trail.
+    if let Some(writer) = state.audit_writer.as_ref() {
+        writer
+            .write(
+                &admin_did,
+                Some(&admin_did),
+                vti_common::audit::AuditEvent::AdminPasskeyRegistered(
+                    vti_common::audit::AdminPasskeyData {
+                        credential_id_hex: cred_id_hex.clone(),
+                        label: "install".into(),
+                        transports: Vec::new(),
+                    },
+                ),
+            )
+            .await?;
+    }
+
     info!(jti = %jti, %admin_did, "install claim ceremony completed");
 
     issue_setup_session(&state, signer, admin_did, &jti).await

--- a/vtc-service/src/routes/schemas.rs
+++ b/vtc-service/src/routes/schemas.rs
@@ -21,6 +21,7 @@ use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use tracing::info;
+use vti_common::audit::{AuditEvent, SchemaChangeData};
 use vti_common::auth::AdminAuth;
 use vti_common::error::AppError;
 
@@ -87,6 +88,18 @@ pub async fn register(
         created_by_did: auth.0.did.clone(),
     };
     store_schema(&state.schemas_ks, &entry).await?;
+    if let Some(writer) = state.audit_writer.as_ref() {
+        writer
+            .write(
+                &auth.0.did,
+                None,
+                AuditEvent::SchemaRegistered(SchemaChangeData {
+                    id: uri.to_string(),
+                    kind: "schema".into(),
+                }),
+            )
+            .await?;
+    }
     info!(type_uri = %uri, kind = ?entry.kind, by = %auth.0.did, "schema registered");
     Ok((StatusCode::CREATED, Json(entry)))
 }
@@ -159,6 +172,18 @@ pub async fn delete_one(
         return Err(AppError::NotFound(format!("schema `{type_uri}` not found")));
     }
     delete_schema(&state.schemas_ks, &type_uri).await?;
+    if let Some(writer) = state.audit_writer.as_ref() {
+        writer
+            .write(
+                &auth.0.did,
+                None,
+                AuditEvent::SchemaDeleted(SchemaChangeData {
+                    id: type_uri.clone(),
+                    kind: "schema".into(),
+                }),
+            )
+            .await?;
+    }
     info!(type_uri = %type_uri, by = %auth.0.did, "schema deleted");
     Ok((StatusCode::OK, Json(DeleteResponse { id: type_uri })))
 }
@@ -207,6 +232,18 @@ pub async fn register_accepts(
         created_by_did: auth.0.did.clone(),
     };
     store_accepts(&state.schemas_ks, &criterion).await?;
+    if let Some(writer) = state.audit_writer.as_ref() {
+        writer
+            .write(
+                &auth.0.did,
+                None,
+                AuditEvent::SchemaRegistered(SchemaChangeData {
+                    id: id.to_string(),
+                    kind: "accepts".into(),
+                }),
+            )
+            .await?;
+    }
     info!(id = %id, by = %auth.0.did, "accepts criterion registered");
     Ok((StatusCode::CREATED, Json(criterion)))
 }
@@ -274,6 +311,18 @@ pub async fn delete_accepts_route(
         )));
     }
     delete_accepts(&state.schemas_ks, &id).await?;
+    if let Some(writer) = state.audit_writer.as_ref() {
+        writer
+            .write(
+                &auth.0.did,
+                None,
+                AuditEvent::SchemaDeleted(SchemaChangeData {
+                    id: id.clone(),
+                    kind: "accepts".into(),
+                }),
+            )
+            .await?;
+    }
     info!(id = %id, by = %auth.0.did, "accepts criterion deleted");
     Ok((StatusCode::OK, Json(DeleteResponse { id })))
 }

--- a/vti-common/src/audit/event.rs
+++ b/vti-common/src/audit/event.rs
@@ -357,6 +357,15 @@ pub enum AuditEvent {
 
     /// An admin onboarding invite was revoked (`DELETE /v1/admin/invites/{jti}`).
     AdminInviteRevoked(AdminInviteData),
+
+    /// A credential schema or accepts-criterion was registered
+    /// (`POST /v1/schemas` or `/v1/schemas/accepts`) — what the community
+    /// accepts/recognises changed.
+    SchemaRegistered(SchemaChangeData),
+
+    /// A credential schema or accepts-criterion was deleted
+    /// (`DELETE /v1/schemas/{type_uri}` or `/v1/schemas/accepts/{id}`).
+    SchemaDeleted(SchemaChangeData),
 }
 
 // ---------------------------------------------------------------------------
@@ -450,6 +459,16 @@ pub struct AdminInviteData {
     /// The admin DID the invite is bound to, if any.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub admin_did: Option<String>,
+}
+
+/// Payload for [`AuditEvent::SchemaRegistered`] / [`AuditEvent::SchemaDeleted`].
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SchemaChangeData {
+    /// The schema `type_uri` or accepts-criterion id.
+    pub id: String,
+    /// `"schema"` or `"accepts"`.
+    pub kind: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/vti-common/src/audit/mod.rs
+++ b/vti-common/src/audit/mod.rs
@@ -41,9 +41,10 @@ pub use event::{
     MemberRemovedData, MemberUpdatedData, MembershipReciprocatedData, MembershipRenewedData,
     PersonhoodAssertedData, PersonhoodRevokedData, PolicyActivatedData, PolicyUploadedData,
     REDACTED_MARKER, RegistryRecordPolicyOverrideData, RegistryStatusChangedData,
-    RegistrySyncOutcomeData, RestartRequestedData, RoleChangedData, SessionRevokedData,
-    StatusListFlippedData, VrcPublishedData, VrcRevokedData, WebsiteBundleDeployedData,
-    WebsiteFileDeletedData, WebsiteFileWrittenData, WebsiteGenerationRolledBackData,
+    RegistrySyncOutcomeData, RestartRequestedData, RoleChangedData, SchemaChangeData,
+    SessionRevokedData, StatusListFlippedData, VrcPublishedData, VrcRevokedData,
+    WebsiteBundleDeployedData, WebsiteFileDeletedData, WebsiteFileWrittenData,
+    WebsiteGenerationRolledBackData,
 };
 pub use key_store::{AuditKey, AuditKeyStore, KeyId, RotationReason};
 pub use writer::AuditWriter;


### PR DESCRIPTION
## Summary

Tier 1 of #537 (follow-up to #536) — closes the remaining **unaudited state-changing operations** so every mutation hits the audit trail.

| Operation | Event | Was |
|---|---|---|
| `POST /v1/schemas`, `POST /v1/schemas/accepts` | **SchemaRegistered** (new; `kind` = schema/accepts) | unaudited |
| `DELETE /v1/schemas/{type_uri}`, `DELETE /v1/schemas/accepts/{id}` | **SchemaDeleted** (new) | unaudited |
| install `claim/finish` (first-admin passkey enrolment) | **AdminPasskeyRegistered** (reused) | unaudited |
| legacy `PATCH /v1/config` | **CommunityProfileUpdated** (reused; lists changed fields) | unaudited |

- **Install claim** was the only place an invited admin's passkey is registered, and it left no audit trail — now recorded with the credential id.
- **Legacy `/v1/config`** mirrors what the modern `/v1/admin/config` already audits.

All via the existing `audit_writer` seam (actor = caller / new admin).

## Remaining in #537 (next tiers)
- Payload enrichment: before/after values on `*Updated` events, `DidRotated` reason, structured `JoinRequestRejected`, prior role on `MemberRemoved`.
- Hash-chaining design decision (tamper-evident ordering).

## Tests
Builds clean. Audit emission follows the established `audit_writer` pattern (covered by the `issuing_an_invitation_emits_audit` test added in #536); no schema-specific integration harness exists yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)