### PR TITLE
feat(vault): archival lifecycle + full audit for both VTA vault stores

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -493,6 +493,46 @@ new flow, update both this section and the relevant `docs/*.md`.
   (EdDSA or ES256). Key derived BIP-32 → signature → memory zeroized.
 - **DIDComm**: `key-management/1.0/sign-request`.
 
+### Vault archival lifecycle (archive / soft-delete / restore / purge)
+- **What**: Full lifecycle for **both** VTA stores — the password
+  vault (`vault:` keyspace, `vti_common::vault::VaultEntry`) and the
+  credential store (`cred:` keyspace, `vta-service::vault::model::
+  StoredCredential`). Adds archive (reversible hide), a **recoverable**
+  soft `delete` (tombstone + grace window, default 30d via
+  `VaultConfig.grace_days`), `restore` (undelete within grace),
+  `purge` (irreversible), and `delete --force` (immediate hard delete).
+  Archival state (`VaultStatus {Active,Archived,Deleted}`) is orthogonal
+  to a credential's *validity* (`CredentialStatus`); non-Active entries
+  drop out of list/query and are refused for use (release / proxy-login
+  / sign / present).
+- **Trust Tasks** (openvtc 0.1 extensions): password vault
+  `vault/{archive,unarchive,restore,purge}/0.1` (`VaultWrite`);
+  credential store `vault/credentials/{archive,unarchive,delete,restore,
+  purge}/0.1` gated on the **new `CredentialWrite`** capability (removing
+  a holder's credentials is higher-trust than receiving them).
+  `vault/delete/0.1` body gained `force: bool`; response `graceUntil`
+  is now a real deadline.
+- **Sweeper**: `vault_sweeper::sweep_expired` (storage-thread interval,
+  alongside acl/consent sweepers) hard-purges grace-expired tombstones in
+  both stores; credential purge tears down the `idx:` secondary index via
+  `vault::storage::delete`.
+- **Audit**: every vault Trust Task (read or write, success or denied) is
+  audited **once at the dispatch spine** (`vault.*` / `vault.cred.*`
+  actions); the operator `reason` lands in the audit row's new `detail`
+  field (`audit::record_with_detail`).
+- **Brick-prevention**: `upsert` refuses to overwrite a non-Active entry
+  (would wipe lifecycle state); `restore` re-checks the grace window
+  before writing; non-Active entries conflate to `not_found` on the
+  consumer use paths (enumeration resistance).
+- **Code**: `vti-common/src/vault/mod.rs` (`VaultStatus`, lifecycle
+  methods, `LifecycleError`), `vta-service/src/trust_tasks/{vault,
+  cred_vault,mod}.rs`, `vta-service/src/vault/{model,status,query,
+  present}.rs`, `vta-service/src/vault_sweeper.rs`,
+  `vta_sdk::client::vault`, `vta_cli_common::commands::{vault,cred_vault}`
+  (`pnm vault {archive,unarchive,restore,purge}`, `delete --force`,
+  `list --status`; `pnm cred-vault {receive,query,get,archive,unarchive,
+  delete,restore,purge}` — the credential store's operator surface).
+
 ### Backup / restore
 - **What**: Encrypted full-state dump + restore.
 - **Endpoints**: `POST /backup/export`, `POST /backup/import`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2427,7 +2427,7 @@ checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cnm-cli"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "clap",
@@ -2441,7 +2441,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.17.0",
+ "vta-sdk 0.18.0",
 ]
 
 [[package]]
@@ -3198,7 +3198,7 @@ dependencies = [
 
 [[package]]
 name = "didcomm-test"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-tdk 0.8.3",
@@ -3211,7 +3211,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.17.0",
+ "vta-sdk 0.18.0",
 ]
 
 [[package]]
@@ -6676,7 +6676,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "pnm-cli"
-version = "0.9.7"
+version = "0.10.0"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-resolver-cache-sdk",
@@ -6698,7 +6698,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.17.0",
+ "vta-sdk 0.18.0",
 ]
 
 [[package]]
@@ -9946,7 +9946,7 @@ dependencies = [
 
 [[package]]
 name = "vta-cli-common"
-version = "0.9.7"
+version = "0.10.0"
 dependencies = [
  "aes-gcm",
  "affinidi-crypto",
@@ -9964,14 +9964,14 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.17.0",
+ "vta-sdk 0.18.0",
  "vti-common",
  "x25519-dalek",
 ]
 
 [[package]]
 name = "vta-enclave"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -9986,7 +9986,7 @@ dependencies = [
 
 [[package]]
 name = "vta-mcp"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -9997,12 +9997,12 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.17.0",
+ "vta-sdk 0.18.0",
 ]
 
 [[package]]
 name = "vta-mobile-core"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -10020,7 +10020,7 @@ dependencies = [
  "tracing-subscriber",
  "trust-tasks-rs",
  "uniffi",
- "vta-sdk 0.17.0",
+ "vta-sdk 0.18.0",
 ]
 
 [[package]]
@@ -10055,7 +10055,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10111,7 +10111,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.9.10"
+version = "0.10.0"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",
@@ -10186,7 +10186,7 @@ dependencies = [
  "utoipa-axum",
  "uuid",
  "vta-cli-common",
- "vta-sdk 0.17.0",
+ "vta-sdk 0.18.0",
  "vta-service",
  "vti-common",
  "vti-secrets",
@@ -10200,7 +10200,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-service"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",
@@ -10265,7 +10265,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.17.0",
+ "vta-sdk 0.18.0",
  "vtc-service",
  "vti-common",
  "vti-secrets",
@@ -10278,7 +10278,7 @@ dependencies = [
 
 [[package]]
 name = "vti-common"
-version = "0.10.8"
+version = "0.11.0"
 dependencies = [
  "aes-gcm",
  "affinidi-did-resolver-cache-sdk",
@@ -10313,7 +10313,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.17.0",
+ "vta-sdk 0.18.0",
  "webauthn-rs",
  "zeroize",
 ]
@@ -10340,14 +10340,14 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.17.0",
+ "vta-sdk 0.18.0",
  "vta-service",
  "vti-common",
 ]
 
 [[package]]
 name = "vti-secrets"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "aws-config",
  "aws-sdk-secretsmanager",
@@ -10369,7 +10369,7 @@ dependencies = [
  "tokio",
  "tracing",
  "vaultrs",
- "vta-sdk 0.17.0",
+ "vta-sdk 0.18.0",
  "vti-common",
 ]
 

--- a/cnm-cli/Cargo.toml
+++ b/cnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cnm-cli"
 description = "CLI Tool for Verified Trust Agents operating in Verified Trust Communities"
-version = "0.10.4"
+version = "0.10.5"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -21,8 +21,8 @@ config-session = ["vta-sdk/config-session"]
 azure-secrets = ["vta-sdk/azure-secrets"]
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.17", features = ["session", "crypto-provider"] }
-vta-cli-common = { path = "../vta-cli-common", version = "0.9" }
+vta-sdk = { path = "../vta-sdk", version = "0.18", features = ["session", "crypto-provider"] }
+vta-cli-common = { path = "../vta-cli-common", version = "0.10" }
 affinidi-did-resolver-cache-sdk = { workspace = true }
 clap = { workspace = true, features = ["env"] }
 dialoguer = { workspace = true }

--- a/didcomm-test/Cargo.toml
+++ b/didcomm-test/Cargo.toml
@@ -2,7 +2,7 @@
 name = "didcomm-test"
 description = "Standalone DIDComm connectivity test — mimics VTA TEE key + messaging flow"
 readme = "README.md"
-version = "0.6.7"
+version = "0.6.8"
 edition.workspace = true
 publish = false
 rust-version.workspace = true
@@ -13,7 +13,7 @@ name = "didcomm-test"
 path = "src/main.rs"
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.17", features = ["didcomm", "crypto-provider"] }
+vta-sdk = { path = "../vta-sdk", version = "0.18", features = ["didcomm", "crypto-provider"] }
 affinidi-tdk = { workspace = true }
 affinidi-did-resolver-cache-sdk = { workspace = true }
 tokio = { workspace = true }

--- a/docs/05-design-notes/trust-task-uri-registry.md
+++ b/docs/05-design-notes/trust-task-uri-registry.md
@@ -577,6 +577,29 @@ challenge,revoke-session,whoami,sessions/list}`, `device/{disable,wipe}`,
 contexts, keys, seeds, audit, config, …) are not framework specs and are
 unaffected.
 
+### Vault archival lifecycle (openvtc extension, 0.1)
+
+The vault gained a full archival lifecycle on top of the canonical
+`vault/delete`. These URIs are **openvtc-defined** (no upstream framework
+spec); they stay on `0.1`:
+
+- **Password vault** (`VaultWrite`): `vault/archive`, `vault/unarchive`,
+  `vault/restore`, `vault/purge`. `vault/delete` is now a **recoverable
+  soft delete** (tombstone + grace window); its body gained `force: bool`
+  for an immediate hard delete. The wire response is unchanged — the
+  previously-cosmetic `graceUntil` is now a real deadline.
+- **Credential store** (`CredentialWrite`, a new capability — removing a
+  holder's credentials is higher-trust than `vault/credentials/receive`'s
+  `VaultWrite`): `vault/credentials/{archive,unarchive,delete,restore,purge}`.
+
+Archival state (`Active`/`Archived`/`Deleted`) is orthogonal to a
+credential's *validity* (`CredentialStatus`); non-`Active` entries are
+excluded from list/query and refused for use (release / proxy-login /
+sign / present). A background sweeper hard-purges grace-expired tombstones.
+Every vault Trust Task — read or write, success or denied — is audited once
+at the dispatch spine (`vault.*` / `vault.cred.*` actions; the `reason`
+field lands in the audit row's `detail`).
+
 Two mechanisms, split by whether the payload is signed:
 
 - **Edge transform** (`routes/trust_tasks/wire_v0_2.rs`) — for

--- a/pnm-cli/Cargo.toml
+++ b/pnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pnm-cli"
 description = "CLI Tool for managing a personal Verifiable Trust Agent"
-version = "0.9.7"
+version = "0.10.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -21,12 +21,12 @@ config-session = ["vta-sdk/config-session"]
 azure-secrets = ["vta-sdk/azure-secrets"]
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.17", features = ["session", "sealed-transfer", "attest-verify", "provision-integration", "crypto-provider"] }
+vta-sdk = { path = "../vta-sdk", version = "0.18", features = ["session", "sealed-transfer", "attest-verify", "provision-integration", "crypto-provider"] }
 affinidi-crypto = { workspace = true }
 base64 = { workspace = true }
 reqwest = { workspace = true }
 sha2 = { workspace = true }
-vta-cli-common = { path = "../vta-cli-common", version = "0.9" }
+vta-cli-common = { path = "../vta-cli-common", version = "0.10" }
 affinidi-did-resolver-cache-sdk = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true, features = ["env"] }

--- a/pnm-cli/src/cli.rs
+++ b/pnm-cli/src/cli.rs
@@ -140,6 +140,15 @@ pub(crate) enum Commands {
         command: VaultCommands,
     },
 
+    /// Credential store — the W3C credentials the holder *holds*
+    /// (invitations, memberships, roles). Distinct from `vault` (secrets):
+    /// receive/query/get plus the archival lifecycle
+    /// (archive/delete/restore/purge).
+    CredVault {
+        #[command(subcommand)]
+        command: CredVaultCommands,
+    },
+
     /// Generate auth credentials for applications and services
     AuthCredential {
         #[command(subcommand)]
@@ -1730,25 +1739,83 @@ pub(crate) enum DeviceCommands {
 /// (`upsert`, `release`) use `didcomm-authcrypt` and require DIDComm transport.
 #[derive(Subcommand)]
 pub(crate) enum VaultCommands {
-    /// List vault-entry metadata (no secrets). `VaultRead`.
+    /// List vault-entry metadata (no secrets). `VaultRead`. By default only
+    /// active entries are shown — use `--status` for the archive/trash views.
     List {
         /// Path to a JSON filter object (or `-` for stdin). Omit for all.
         #[arg(long)]
         filters_file: Option<String>,
+        /// Lifecycle view: `active` (default), `archived`, `deleted`, or `all`.
+        #[arg(long)]
+        status: Option<String>,
     },
     /// Show a single entry's metadata by id (no secret). `VaultRead`.
     Get {
         /// The vault entry id.
         id: String,
     },
-    /// Delete an entry by id, with optional optimistic-concurrency check.
-    /// `VaultWrite`.
+    /// Delete an entry by id. Default is a RECOVERABLE soft delete (restore
+    /// with `vault restore` until the grace window lapses); `--force` makes it
+    /// an immediate, irreversible hard delete. `VaultWrite`.
     Delete {
         /// The vault entry id.
         id: String,
         /// Expected current version (reject on mismatch).
         #[arg(long)]
         expected_version: Option<u32>,
+        /// Skip the grace window and hard-delete immediately (NO recovery).
+        #[arg(long)]
+        force: bool,
+        /// Rationale recorded in the audit trail.
+        #[arg(long)]
+        reason: Option<String>,
+    },
+    /// Archive an entry: hide it from the default list and refuse it for use,
+    /// while keeping it restorable with `vault unarchive`. `VaultWrite`.
+    Archive {
+        /// The vault entry id.
+        id: String,
+        /// Expected current version (reject on mismatch).
+        #[arg(long)]
+        expected_version: Option<u32>,
+        /// Rationale recorded in the audit trail.
+        #[arg(long)]
+        reason: Option<String>,
+    },
+    /// Return an archived entry to active. `VaultWrite`.
+    Unarchive {
+        /// The vault entry id.
+        id: String,
+        /// Expected current version (reject on mismatch).
+        #[arg(long)]
+        expected_version: Option<u32>,
+        /// Rationale recorded in the audit trail.
+        #[arg(long)]
+        reason: Option<String>,
+    },
+    /// Restore (undelete) a soft-deleted entry — only works inside the grace
+    /// window before the sweeper purges it. `VaultWrite`.
+    Restore {
+        /// The vault entry id.
+        id: String,
+        /// Expected current version (reject on mismatch).
+        #[arg(long)]
+        expected_version: Option<u32>,
+        /// Rationale recorded in the audit trail.
+        #[arg(long)]
+        reason: Option<String>,
+    },
+    /// Permanently purge an entry, skipping any grace window. IRREVERSIBLE.
+    /// `VaultWrite`.
+    Purge {
+        /// The vault entry id.
+        id: String,
+        /// Expected current version (reject on mismatch).
+        #[arg(long)]
+        expected_version: Option<u32>,
+        /// Rationale recorded in the audit trail.
+        #[arg(long)]
+        reason: Option<String>,
     },
     /// Create/update an entry. `VaultWrite`. `--entry-file` carries the entry
     /// fields (`contextId`, `targets`, `label`, `secretKind`, …);
@@ -1783,6 +1850,86 @@ pub(crate) enum VaultCommands {
         /// Path to the request JSON (or `-` for stdin).
         #[arg(long)]
         file: String,
+    },
+}
+
+/// Credential-store subcommands (`pnm cred-vault …`). The store holds the
+/// W3C credentials the holder *holds*; bodies are presentable VCs (plain
+/// JSON, no sealed envelope). Read paths gate on `VaultRead`, `receive` on
+/// `VaultWrite`, and the archival lifecycle on the new `CredentialWrite`.
+#[derive(Subcommand)]
+pub(crate) enum CredVaultCommands {
+    /// Verify + store a received credential (e.g. an invitation). `VaultWrite`.
+    Receive {
+        /// Path to the credential VC JSON (or `-` for stdin).
+        #[arg(long)]
+        credential_file: String,
+        /// Storage id override (defaults to the VC's own `id`).
+        #[arg(long)]
+        id: Option<String>,
+    },
+    /// Filtered (DCQL-shaped) search over held credentials → body-free
+    /// descriptors. At least one filter field is required. `VaultRead`.
+    Query {
+        /// Path to a JSON filter object (or `-` for stdin): any of `type`,
+        /// `communityDid`, `issuerDid`, `purpose`, `status`.
+        #[arg(long)]
+        filter_file: String,
+    },
+    /// Fetch one held credential's full body by id, for presentation.
+    /// `VaultRead`.
+    Get {
+        /// The credential id.
+        id: String,
+    },
+    /// Archive a credential: hide it from query and refuse presentation,
+    /// while keeping it restorable with `cred-vault unarchive`.
+    /// `CredentialWrite`.
+    Archive {
+        /// The credential id.
+        id: String,
+        /// Rationale recorded in the audit trail.
+        #[arg(long)]
+        reason: Option<String>,
+    },
+    /// Return an archived credential to active. `CredentialWrite`.
+    Unarchive {
+        /// The credential id.
+        id: String,
+        /// Rationale recorded in the audit trail.
+        #[arg(long)]
+        reason: Option<String>,
+    },
+    /// Delete a credential. Default is a RECOVERABLE soft delete (restore
+    /// with `cred-vault restore` until the grace window lapses); `--force`
+    /// hard-deletes immediately (no recovery). `CredentialWrite`.
+    Delete {
+        /// The credential id.
+        id: String,
+        /// Skip the grace window and hard-delete immediately (NO recovery).
+        #[arg(long)]
+        force: bool,
+        /// Rationale recorded in the audit trail.
+        #[arg(long)]
+        reason: Option<String>,
+    },
+    /// Restore (undelete) a soft-deleted credential — only inside the grace
+    /// window before the sweeper purges it. `CredentialWrite`.
+    Restore {
+        /// The credential id.
+        id: String,
+        /// Rationale recorded in the audit trail.
+        #[arg(long)]
+        reason: Option<String>,
+    },
+    /// Permanently purge a credential (and its index rows), skipping any
+    /// grace window. IRREVERSIBLE. `CredentialWrite`.
+    Purge {
+        /// The credential id.
+        id: String,
+        /// Rationale recorded in the audit trail.
+        #[arg(long)]
+        reason: Option<String>,
     },
 }
 

--- a/pnm-cli/src/commands/cred_vault.rs
+++ b/pnm-cli/src/commands/cred_vault.rs
@@ -1,0 +1,51 @@
+//! `pnm cred-vault …` dispatch — thin shim over the shared credential-store
+//! commands. `receive`/`query` take a `--*-file` JSON input (`-` for stdin);
+//! the lifecycle verbs operate on a credential id.
+
+use std::io::Read;
+
+use vta_cli_common::commands::cred_vault as cv;
+use vta_sdk::prelude::*;
+
+use crate::cli::CredVaultCommands;
+
+pub(crate) async fn run(
+    client: &VtaClient,
+    command: CredVaultCommands,
+) -> Result<(), Box<dyn std::error::Error>> {
+    match command {
+        CredVaultCommands::Receive {
+            credential_file,
+            id,
+        } => {
+            let credential = read_json(&credential_file)?;
+            cv::cmd_cred_receive(client, credential, id).await
+        }
+        CredVaultCommands::Query { filter_file } => {
+            let filter = read_json(&filter_file)?;
+            cv::cmd_cred_query(client, filter).await
+        }
+        CredVaultCommands::Get { id } => cv::cmd_cred_get(client, id).await,
+        CredVaultCommands::Archive { id, reason } => cv::cmd_cred_archive(client, id, reason).await,
+        CredVaultCommands::Unarchive { id, reason } => {
+            cv::cmd_cred_unarchive(client, id, reason).await
+        }
+        CredVaultCommands::Delete { id, force, reason } => {
+            cv::cmd_cred_delete(client, id, force, reason).await
+        }
+        CredVaultCommands::Restore { id, reason } => cv::cmd_cred_restore(client, id, reason).await,
+        CredVaultCommands::Purge { id, reason } => cv::cmd_cred_purge(client, id, reason).await,
+    }
+}
+
+/// Read a JSON document from a file path, or stdin when `path` is `-`.
+fn read_json(path: &str) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
+    let contents = if path == "-" {
+        let mut buf = String::new();
+        std::io::stdin().read_to_string(&mut buf)?;
+        buf
+    } else {
+        std::fs::read_to_string(path).map_err(|e| format!("{path}: {e}"))?
+    };
+    serde_json::from_str(&contents).map_err(|e| format!("{path}: invalid JSON: {e}").into())
+}

--- a/pnm-cli/src/commands/mod.rs
+++ b/pnm-cli/src/commands/mod.rs
@@ -16,6 +16,7 @@ pub(crate) mod backup;
 pub(crate) mod bootstrap;
 pub(crate) mod config;
 pub(crate) mod contexts;
+pub(crate) mod cred_vault;
 pub(crate) mod device;
 pub(crate) mod did_templates;
 pub(crate) mod health;

--- a/pnm-cli/src/commands/vault.rs
+++ b/pnm-cli/src/commands/vault.rs
@@ -17,15 +17,40 @@ pub(crate) async fn run(
     command: VaultCommands,
 ) -> Result<(), Box<dyn std::error::Error>> {
     match command {
-        VaultCommands::List { filters_file } => {
+        VaultCommands::List {
+            filters_file,
+            status,
+        } => {
             let filters = filters_file.as_deref().map(read_json).transpose()?;
-            v::cmd_vault_list(client, filters).await
+            v::cmd_vault_list(client, filters, status).await
         }
         VaultCommands::Get { id } => v::cmd_vault_get(client, id).await,
         VaultCommands::Delete {
             id,
             expected_version,
-        } => v::cmd_vault_delete(client, id, expected_version).await,
+            force,
+            reason,
+        } => v::cmd_vault_delete(client, id, expected_version, force, reason).await,
+        VaultCommands::Archive {
+            id,
+            expected_version,
+            reason,
+        } => v::cmd_vault_archive(client, id, expected_version, reason).await,
+        VaultCommands::Unarchive {
+            id,
+            expected_version,
+            reason,
+        } => v::cmd_vault_unarchive(client, id, expected_version, reason).await,
+        VaultCommands::Restore {
+            id,
+            expected_version,
+            reason,
+        } => v::cmd_vault_restore(client, id, expected_version, reason).await,
+        VaultCommands::Purge {
+            id,
+            expected_version,
+            reason,
+        } => v::cmd_vault_purge(client, id, expected_version, reason).await,
         VaultCommands::Upsert {
             entry_file,
             secret_file,

--- a/pnm-cli/src/main.rs
+++ b/pnm-cli/src/main.rs
@@ -260,6 +260,7 @@ async fn main() {
         Commands::StepUp { command } => commands::step_up::run(&client, command).await,
         Commands::Device { command } => commands::device::run(&client, command).await,
         Commands::Vault { command } => commands::vault::run(&client, command).await,
+        Commands::CredVault { command } => commands::cred_vault::run(&client, command).await,
         Commands::AuthCredential { command } => {
             commands::auth_credential::run(&client, command).await
         }

--- a/vta-cli-common/Cargo.toml
+++ b/vta-cli-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-cli-common"
 description = "Shared CLI command handlers and rendering helpers for VTA CLIs"
 readme = "README.md"
-version = "0.9.7"
+version = "0.10.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -11,13 +11,13 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.17", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.18", features = [
   "client",
   "sealed-transfer",
   "provision-integration",
 ] }
 # Owner-only file-permission helper (`secure_file`), shared workspace-wide.
-vti-common = { path = "../vti-common", version = "0.10" }
+vti-common = { path = "../vti-common", version = "0.11" }
 affinidi-crypto = { workspace = true }
 chrono = { workspace = true }
 ed25519-dalek = { workspace = true }

--- a/vta-cli-common/src/commands/cred_vault.rs
+++ b/vta-cli-common/src/commands/cred_vault.rs
@@ -1,0 +1,131 @@
+//! `cred-vault …` operator/agent commands (online, via the trust-task
+//! dispatcher) for the **credential store** — the W3C credentials a holder
+//! *holds* (invitations, memberships, roles, …), distinct from the
+//! password-manager `vault` commands.
+//!
+//! Thin wrappers over the `VtaClient::cred_vault_*` methods. Credential bodies
+//! are presentable VCs (plain JSON), so — unlike the secrets `vault` — there
+//! is no sealed envelope to build or open here.
+//!
+//! Capability gates (server-side): query/get → `VaultRead`, receive →
+//! `VaultWrite`, archive/unarchive/delete/restore/purge → `CredentialWrite`.
+
+use serde_json::Value;
+use vta_sdk::client::VtaClient;
+
+use crate::render::{DIM, RESET, is_json_output, print_json};
+
+fn print_result(label: &str, value: &Value) -> Result<(), Box<dyn std::error::Error>> {
+    if is_json_output() {
+        print_json(value)?;
+    } else {
+        println!("{label}");
+        println!("{}", serde_json::to_string_pretty(value)?);
+    }
+    Ok(())
+}
+
+/// `cred-vault receive` — verify + store a received credential. `credential`
+/// is the VC JSON; `id` overrides the storage id (defaults to the VC's `id`).
+pub async fn cmd_cred_receive(
+    client: &VtaClient,
+    credential: Value,
+    id: Option<String>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let result = client.cred_vault_receive(credential, id.as_deref()).await?;
+    print_result("Stored credential:", &result)
+}
+
+/// `cred-vault query` — filtered search over held credentials. `filter` is a
+/// DCQL-shaped object (at least one of `type`, `communityDid`, `issuerDid`,
+/// `purpose`, `status`); an unfiltered query is refused server-side.
+pub async fn cmd_cred_query(
+    client: &VtaClient,
+    filter: Value,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let result = client.cred_vault_query(filter).await?;
+    print_result("Credentials:", &result)
+}
+
+/// `cred-vault get` — fetch one held credential's full body by id.
+pub async fn cmd_cred_get(
+    client: &VtaClient,
+    id: String,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let result = client.cred_vault_get(&id).await?;
+    print_result("Credential:", &result)
+}
+
+/// `cred-vault archive` — soft-disable a credential (restorable with
+/// `cred-vault unarchive`).
+pub async fn cmd_cred_archive(
+    client: &VtaClient,
+    id: String,
+    reason: Option<String>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let result = client.cred_vault_archive(&id, reason.as_deref()).await?;
+    println!("{DIM}Credential {id} archived — restore with `cred-vault unarchive {id}`.{RESET}");
+    print_result("Result:", &result)
+}
+
+/// `cred-vault unarchive` — return an archived credential to active.
+pub async fn cmd_cred_unarchive(
+    client: &VtaClient,
+    id: String,
+    reason: Option<String>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let result = client.cred_vault_unarchive(&id, reason.as_deref()).await?;
+    println!("{DIM}Credential {id} unarchived.{RESET}");
+    print_result("Result:", &result)
+}
+
+/// `cred-vault delete` — recoverable soft-delete by default; `force`
+/// hard-deletes irreversibly.
+pub async fn cmd_cred_delete(
+    client: &VtaClient,
+    id: String,
+    force: bool,
+    reason: Option<String>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let result = client
+        .cred_vault_delete(&id, force, reason.as_deref())
+        .await?;
+    if force {
+        println!("{DIM}Credential {id} permanently hard-deleted (no recovery).{RESET}");
+    } else {
+        let grace = result.get("graceUntil").and_then(Value::as_str);
+        match grace {
+            Some(g) => println!(
+                "{DIM}Credential {id} moved to trash — recoverable with `cred-vault restore {id}` until {g}.{RESET}"
+            ),
+            None => println!(
+                "{DIM}Credential {id} soft-deleted — recoverable with `cred-vault restore {id}`.{RESET}"
+            ),
+        }
+    }
+    print_result("Result:", &result)
+}
+
+/// `cred-vault restore` — undelete a soft-deleted credential (only within the
+/// grace window).
+pub async fn cmd_cred_restore(
+    client: &VtaClient,
+    id: String,
+    reason: Option<String>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let result = client.cred_vault_restore(&id, reason.as_deref()).await?;
+    println!("{DIM}Credential {id} restored to active.{RESET}");
+    print_result("Result:", &result)
+}
+
+/// `cred-vault purge` — irreversibly hard-delete a credential, skipping any
+/// grace window.
+pub async fn cmd_cred_purge(
+    client: &VtaClient,
+    id: String,
+    reason: Option<String>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let result = client.cred_vault_purge(&id, reason.as_deref()).await?;
+    println!("{DIM}Credential {id} permanently purged (no recovery).{RESET}");
+    print_result("Result:", &result)
+}

--- a/vta-cli-common/src/commands/mod.rs
+++ b/vta-cli-common/src/commands/mod.rs
@@ -2,6 +2,7 @@ pub mod acl;
 pub mod audit;
 pub mod config;
 pub mod contexts;
+pub mod cred_vault;
 pub mod credentials;
 pub mod device;
 pub mod did_templates;

--- a/vta-cli-common/src/commands/vault.rs
+++ b/vta-cli-common/src/commands/vault.rs
@@ -27,14 +27,21 @@ fn print_result(label: &str, value: &Value) -> Result<(), Box<dyn std::error::Er
 }
 
 /// `vault list` — metadata only (no secrets). `filters` is the wire filter
-/// object (`None` → all entries).
+/// object (`None` → all entries). `status` selects the lifecycle view
+/// (`active` default / `archived` / `deleted` / `all`) and is merged into the
+/// filter object.
 pub async fn cmd_vault_list(
     client: &VtaClient,
     filters: Option<Value>,
+    status: Option<String>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let result = client
-        .vault_list(filters.unwrap_or_else(|| json!({})))
-        .await?;
+    let mut filters = filters.unwrap_or_else(|| json!({}));
+    if let Some(s) = status
+        && let Some(obj) = filters.as_object_mut()
+    {
+        obj.insert("status".to_string(), json!(s));
+    }
+    let result = client.vault_list(filters).await?;
     print_result("Vault entries:", &result)
 }
 
@@ -47,15 +54,89 @@ pub async fn cmd_vault_get(
     print_result("Vault entry:", &result)
 }
 
-/// `vault delete` — delete an entry by id, with optional optimistic-concurrency
-/// version check.
+/// `vault delete` — soft-delete (recoverable) by default; `force` hard-deletes
+/// irreversibly. Optional optimistic-concurrency version check + audit reason.
 pub async fn cmd_vault_delete(
     client: &VtaClient,
     id: String,
     expected_version: Option<u32>,
+    force: bool,
+    reason: Option<String>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let result = client.vault_delete(&id, expected_version).await?;
-    println!("{DIM}Vault entry {id} deleted.{RESET}");
+    let result = client
+        .vault_delete(&id, expected_version, force, reason.as_deref())
+        .await?;
+    if force {
+        println!("{DIM}Vault entry {id} permanently hard-deleted (no recovery).{RESET}");
+    } else {
+        let grace = result.get("graceUntil").and_then(Value::as_str);
+        match grace {
+            Some(g) => println!(
+                "{DIM}Vault entry {id} moved to trash — recoverable with `vault restore {id}` until {g}.{RESET}"
+            ),
+            None => println!(
+                "{DIM}Vault entry {id} soft-deleted — recoverable with `vault restore {id}`.{RESET}"
+            ),
+        }
+    }
+    print_result("Result:", &result)
+}
+
+/// `vault archive` — soft-disable an entry (restorable with `vault unarchive`).
+pub async fn cmd_vault_archive(
+    client: &VtaClient,
+    id: String,
+    expected_version: Option<u32>,
+    reason: Option<String>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let result = client
+        .vault_archive(&id, expected_version, reason.as_deref())
+        .await?;
+    println!("{DIM}Vault entry {id} archived — restore with `vault unarchive {id}`.{RESET}");
+    print_result("Result:", &result)
+}
+
+/// `vault unarchive` — return an archived entry to active.
+pub async fn cmd_vault_unarchive(
+    client: &VtaClient,
+    id: String,
+    expected_version: Option<u32>,
+    reason: Option<String>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let result = client
+        .vault_unarchive(&id, expected_version, reason.as_deref())
+        .await?;
+    println!("{DIM}Vault entry {id} unarchived.{RESET}");
+    print_result("Result:", &result)
+}
+
+/// `vault restore` — undelete a soft-deleted entry (only within the grace
+/// window).
+pub async fn cmd_vault_restore(
+    client: &VtaClient,
+    id: String,
+    expected_version: Option<u32>,
+    reason: Option<String>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let result = client
+        .vault_restore(&id, expected_version, reason.as_deref())
+        .await?;
+    println!("{DIM}Vault entry {id} restored to active.{RESET}");
+    print_result("Result:", &result)
+}
+
+/// `vault purge` — irreversibly hard-delete an entry, skipping any grace
+/// window.
+pub async fn cmd_vault_purge(
+    client: &VtaClient,
+    id: String,
+    expected_version: Option<u32>,
+    reason: Option<String>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let result = client
+        .vault_purge(&id, expected_version, reason.as_deref())
+        .await?;
+    println!("{DIM}Vault entry {id} permanently purged (no recovery).{RESET}");
     print_result("Result:", &result)
 }
 

--- a/vta-enclave/Cargo.toml
+++ b/vta-enclave/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-enclave"
 description = "VTA binary for AWS Nitro Enclaves (TEE mode)"
 readme = "README.md"
-version = "0.7.4"
+version = "0.7.5"
 edition.workspace = true
 # `vta-enclave` is a Linux-only Nitro Enclave binary (vsock-store depends
 # on `tokio-vsock`). Publishing to crates.io would surface "fails on
@@ -27,8 +27,8 @@ vsock-store = ["vta-service/vsock-store"]
 vsock-log = ["dep:tokio-vsock"]
 
 [dependencies]
-vta-service = { path = "../vta-service", version = "0.9", default-features = false, features = ["tee"] }
-vti-common = { path = "../vti-common", version = "0.10", features = ["encryption"] }
+vta-service = { path = "../vta-service", version = "0.10", default-features = false, features = ["tee"] }
+vti-common = { path = "../vti-common", version = "0.11", features = ["encryption"] }
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/vta-mcp/Cargo.toml
+++ b/vta-mcp/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-mcp"
 description = "Model Context Protocol (MCP) server exposing a VTA's agent capabilities as tools"
-version = "0.1.4"
+version = "0.1.5"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -10,7 +10,7 @@ repository.workspace = true
 publish = false
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.17", features = ["client", "session", "sealed-transfer", "didcomm", "vp", "crypto-provider"] }
+vta-sdk = { path = "../vta-sdk", version = "0.18", features = ["client", "session", "sealed-transfer", "didcomm", "vp", "crypto-provider"] }
 rmcp = { version = "1.7", features = ["server", "transport-io", "macros", "schemars"] }
 schemars = "1"
 tokio = { workspace = true }

--- a/vta-mobile-core/Cargo.toml
+++ b/vta-mobile-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vta-mobile-core"
-version = "0.6.7"
+version = "0.6.8"
 description = "UniFFI engine for the VTA mobile agent (Android/iOS): DIDComm, Trust Tasks, AAL step-up."
 edition.workspace = true
 # Not a crates.io library — the published artifacts are the Android AAR
@@ -61,7 +61,7 @@ affinidi-messaging-didcomm = "0.15"
 # `vta-sdk::DIDCommSession` (connect + receive_next) so the mobile approver can
 # pull VTA-pushed step-up approve-requests off the mediator — reusing the SDK
 # the VTA uses rather than reimplementing the affinidi mediator protocol.
-vta-sdk = { path = "../vta-sdk", version = "0.17", features = ["session"] }
+vta-sdk = { path = "../vta-sdk", version = "0.18", features = ["session"] }
 # iOS has no native trust store that `rustls-native-certs` can read, so the
 # mediator WebSocket (tokio-tungstenite, via affinidi-messaging-sdk) fails with
 # "no native root CA certificates found". Declaring tokio-tungstenite here with

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.17.0"
+version = "0.18.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/client/vault.rs
+++ b/vta-sdk/src/client/vault.rs
@@ -72,14 +72,25 @@ impl VtaClient {
 
     /// `vault/delete/0.1` — delete an entry by id. Requires `VaultWrite`.
     /// `expected_version` enables optimistic-concurrency (reject on mismatch).
+    ///
+    /// Default (`force == false`) is a **recoverable** soft delete: the entry
+    /// becomes a `Deleted` tombstone, restorable via [`Self::vault_restore`]
+    /// until the sweeper purges it at the returned `graceUntil`. `force ==
+    /// true` **hard-deletes immediately** (no recovery) — equivalent to
+    /// [`Self::vault_purge`]. `reason` is recorded in the audit trail.
     pub async fn vault_delete(
         &self,
         id: &str,
         expected_version: Option<u32>,
+        force: bool,
+        reason: Option<&str>,
     ) -> Result<Value, VtaError> {
-        let mut payload = json!({ "id": id });
+        let mut payload = json!({ "id": id, "force": force });
         if let Some(v) = expected_version {
             payload["expectedVersion"] = json!(v);
+        }
+        if let Some(r) = reason {
+            payload["reason"] = json!(r);
         }
         self.dispatch_trust_task(
             trust_tasks::TASK_VAULT_DELETE_0_1,
@@ -87,6 +98,93 @@ impl VtaClient {
             VAULT_TT_TIMEOUT,
         )
         .await
+    }
+
+    /// `vault/archive/0.1` — soft-disable an entry (hidden from default list,
+    /// refused for use, restorable). Requires `VaultWrite`.
+    pub async fn vault_archive(
+        &self,
+        id: &str,
+        expected_version: Option<u32>,
+        reason: Option<&str>,
+    ) -> Result<Value, VtaError> {
+        self.vault_lifecycle(
+            trust_tasks::TASK_VAULT_ARCHIVE_0_1,
+            id,
+            expected_version,
+            reason,
+        )
+        .await
+    }
+
+    /// `vault/unarchive/0.1` — return an archived entry to active. Requires
+    /// `VaultWrite`.
+    pub async fn vault_unarchive(
+        &self,
+        id: &str,
+        expected_version: Option<u32>,
+        reason: Option<&str>,
+    ) -> Result<Value, VtaError> {
+        self.vault_lifecycle(
+            trust_tasks::TASK_VAULT_UNARCHIVE_0_1,
+            id,
+            expected_version,
+            reason,
+        )
+        .await
+    }
+
+    /// `vault/restore/0.1` — undelete a soft-deleted entry (only within the
+    /// grace window). Requires `VaultWrite`.
+    pub async fn vault_restore(
+        &self,
+        id: &str,
+        expected_version: Option<u32>,
+        reason: Option<&str>,
+    ) -> Result<Value, VtaError> {
+        self.vault_lifecycle(
+            trust_tasks::TASK_VAULT_RESTORE_0_1,
+            id,
+            expected_version,
+            reason,
+        )
+        .await
+    }
+
+    /// `vault/purge/0.1` — irreversibly hard-delete an entry, skipping the
+    /// grace window. Requires `VaultWrite`.
+    pub async fn vault_purge(
+        &self,
+        id: &str,
+        expected_version: Option<u32>,
+        reason: Option<&str>,
+    ) -> Result<Value, VtaError> {
+        self.vault_lifecycle(
+            trust_tasks::TASK_VAULT_PURGE_0_1,
+            id,
+            expected_version,
+            reason,
+        )
+        .await
+    }
+
+    /// Shared body for the password-vault archival lifecycle verbs.
+    async fn vault_lifecycle(
+        &self,
+        task: &str,
+        id: &str,
+        expected_version: Option<u32>,
+        reason: Option<&str>,
+    ) -> Result<Value, VtaError> {
+        let mut payload = json!({ "id": id });
+        if let Some(v) = expected_version {
+            payload["expectedVersion"] = json!(v);
+        }
+        if let Some(r) = reason {
+            payload["reason"] = json!(r);
+        }
+        self.dispatch_trust_task(task, payload, VAULT_TT_TIMEOUT)
+            .await
     }
 
     /// `vault/release/0.1` — release a secret sealed to the caller. Requires the
@@ -177,5 +275,105 @@ impl VtaClient {
             VAULT_TT_TIMEOUT,
         )
         .await
+    }
+
+    /// `vault/credentials/archive/0.1` — soft-disable a held credential
+    /// (hidden from query, refused for presentation, restorable). Requires
+    /// `CredentialWrite`.
+    pub async fn cred_vault_archive(
+        &self,
+        id: &str,
+        reason: Option<&str>,
+    ) -> Result<Value, VtaError> {
+        self.cred_lifecycle(
+            trust_tasks::TASK_VAULT_CREDENTIALS_ARCHIVE_0_1,
+            id,
+            false,
+            reason,
+        )
+        .await
+    }
+
+    /// `vault/credentials/unarchive/0.1` — return an archived credential to
+    /// active. Requires `CredentialWrite`.
+    pub async fn cred_vault_unarchive(
+        &self,
+        id: &str,
+        reason: Option<&str>,
+    ) -> Result<Value, VtaError> {
+        self.cred_lifecycle(
+            trust_tasks::TASK_VAULT_CREDENTIALS_UNARCHIVE_0_1,
+            id,
+            false,
+            reason,
+        )
+        .await
+    }
+
+    /// `vault/credentials/delete/0.1` — soft-delete a held credential
+    /// (recoverable tombstone). `force == true` hard-deletes immediately.
+    /// Requires `CredentialWrite`.
+    pub async fn cred_vault_delete(
+        &self,
+        id: &str,
+        force: bool,
+        reason: Option<&str>,
+    ) -> Result<Value, VtaError> {
+        self.cred_lifecycle(
+            trust_tasks::TASK_VAULT_CREDENTIALS_DELETE_0_1,
+            id,
+            force,
+            reason,
+        )
+        .await
+    }
+
+    /// `vault/credentials/restore/0.1` — undelete a soft-deleted credential
+    /// (only within the grace window). Requires `CredentialWrite`.
+    pub async fn cred_vault_restore(
+        &self,
+        id: &str,
+        reason: Option<&str>,
+    ) -> Result<Value, VtaError> {
+        self.cred_lifecycle(
+            trust_tasks::TASK_VAULT_CREDENTIALS_RESTORE_0_1,
+            id,
+            false,
+            reason,
+        )
+        .await
+    }
+
+    /// `vault/credentials/purge/0.1` — irreversibly hard-delete a held
+    /// credential and its index rows. Requires `CredentialWrite`.
+    pub async fn cred_vault_purge(
+        &self,
+        id: &str,
+        reason: Option<&str>,
+    ) -> Result<Value, VtaError> {
+        self.cred_lifecycle(
+            trust_tasks::TASK_VAULT_CREDENTIALS_PURGE_0_1,
+            id,
+            false,
+            reason,
+        )
+        .await
+    }
+
+    /// Shared body for the credential archival lifecycle verbs. `force` is
+    /// meaningful only for `delete`.
+    async fn cred_lifecycle(
+        &self,
+        task: &str,
+        id: &str,
+        force: bool,
+        reason: Option<&str>,
+    ) -> Result<Value, VtaError> {
+        let mut payload = json!({ "id": id, "force": force });
+        if let Some(r) = reason {
+            payload["reason"] = json!(r);
+        }
+        self.dispatch_trust_task(task, payload, VAULT_TT_TIMEOUT)
+            .await
     }
 }

--- a/vta-sdk/src/protocols/audit_management/list.rs
+++ b/vta-sdk/src/protocols/audit_management/list.rs
@@ -15,6 +15,11 @@ pub struct AuditLogEntry {
     pub channel: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub context_id: Option<String>,
+    /// Optional human-readable rationale supplied by the actor (e.g. the
+    /// `reason` on a `vault.delete` / `vault.archive`). `#[serde(default)]`
+    /// so log rows written before this field existed deserialize cleanly.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
 }
 
 /// Request body for listing audit logs with filtering and pagination.

--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -388,9 +388,34 @@ pub const TASK_VAULT_UPSERT_0_1: &str = "https://trusttasks.org/spec/vault/upser
 /// `spec/vault/upsert/0.2` — successor to [`TASK_VAULT_UPSERT_0_1`].
 pub const TASK_VAULT_UPSERT_0_2: &str = "https://trusttasks.org/spec/vault/upsert/0.2";
 
-/// `spec/vault/delete/0.1` — tombstone an entry with a maintainer-defined
-/// grace window. Auth: VaultWrite. No 0.2 spec exists upstream; stays on 0.1.
+/// `spec/vault/delete/0.1` — soft-delete (tombstone) an entry with a
+/// maintainer-defined grace window; the entry stays recoverable via
+/// [`TASK_VAULT_RESTORE_0_1`] until the sweeper hard-purges it at
+/// `grace_until`. A `force: true` body bypasses the window and hard-deletes
+/// immediately (no recovery), equivalent to [`TASK_VAULT_PURGE_0_1`]. Auth:
+/// VaultWrite. No 0.2 spec exists upstream; stays on 0.1.
 pub const TASK_VAULT_DELETE_0_1: &str = "https://trusttasks.org/spec/vault/delete/0.1";
+
+/// `spec/vault/archive/0.1` — soft-disable an entry: it is hidden from the
+/// default `vault/list` and refused for use (release / proxy-login /
+/// sign-trust-task) but fully restorable via [`TASK_VAULT_UNARCHIVE_0_1`].
+/// Auth: VaultWrite. openvtc lifecycle extension (no upstream 0.2).
+pub const TASK_VAULT_ARCHIVE_0_1: &str = "https://trusttasks.org/spec/vault/archive/0.1";
+
+/// `spec/vault/unarchive/0.1` — return an `Archived` entry to `Active`.
+/// Auth: VaultWrite. openvtc lifecycle extension.
+pub const TASK_VAULT_UNARCHIVE_0_1: &str = "https://trusttasks.org/spec/vault/unarchive/0.1";
+
+/// `spec/vault/restore/0.1` — undelete a soft-deleted (`Deleted`) entry back
+/// to `Active`, allowed only while still inside the grace window. Auth:
+/// VaultWrite. openvtc lifecycle extension.
+pub const TASK_VAULT_RESTORE_0_1: &str = "https://trusttasks.org/spec/vault/restore/0.1";
+
+/// `spec/vault/purge/0.1` — irreversibly hard-delete an entry (typically an
+/// already-`Deleted` tombstone, but valid on any entry), skipping the grace
+/// window. The secret bytes are zeroised on removal; no recovery. Auth:
+/// VaultWrite. openvtc lifecycle extension.
+pub const TASK_VAULT_PURGE_0_1: &str = "https://trusttasks.org/spec/vault/purge/0.1";
 
 /// `spec/vault/release/0.1` — release the cleartext secret material of an
 /// entry inside a pluggable cipher envelope sealed to the requesting
@@ -461,6 +486,41 @@ pub const TASK_VAULT_CREDENTIALS_QUERY_0_1: &str =
 /// id, for presentation (requires `VaultRead`).
 pub const TASK_VAULT_CREDENTIALS_GET_0_1: &str =
     "https://trusttasks.org/spec/vault/credentials/get/0.1";
+
+// Credential archival lifecycle (openvtc extension). Mirrors the
+// password-vault lifecycle above but gated on `CredentialWrite` (not
+// `VaultWrite`) — removing a holder's credentials is a higher-trust action
+// than receiving them. The archival `lifecycle` state is orthogonal to a
+// credential's `CredentialStatus` (validity, status-list driven); query/get
+// exclude non-Active credentials by default.
+
+/// `spec/vault/credentials/archive/0.1` — soft-disable a credential (hidden
+/// from default query, refused for presentation, restorable). Auth:
+/// CredentialWrite.
+pub const TASK_VAULT_CREDENTIALS_ARCHIVE_0_1: &str =
+    "https://trusttasks.org/spec/vault/credentials/archive/0.1";
+
+/// `spec/vault/credentials/unarchive/0.1` — return an archived credential to
+/// `Active`. Auth: CredentialWrite.
+pub const TASK_VAULT_CREDENTIALS_UNARCHIVE_0_1: &str =
+    "https://trusttasks.org/spec/vault/credentials/unarchive/0.1";
+
+/// `spec/vault/credentials/delete/0.1` — soft-delete (tombstone) a credential
+/// with a grace window; recoverable via restore until the sweeper purges it.
+/// `force: true` hard-deletes immediately (tears down the `idx:` secondary
+/// index too). Auth: CredentialWrite.
+pub const TASK_VAULT_CREDENTIALS_DELETE_0_1: &str =
+    "https://trusttasks.org/spec/vault/credentials/delete/0.1";
+
+/// `spec/vault/credentials/restore/0.1` — undelete a soft-deleted credential
+/// while still inside the grace window. Auth: CredentialWrite.
+pub const TASK_VAULT_CREDENTIALS_RESTORE_0_1: &str =
+    "https://trusttasks.org/spec/vault/credentials/restore/0.1";
+
+/// `spec/vault/credentials/purge/0.1` — irreversibly hard-delete a credential
+/// (and its index rows), skipping the grace window. Auth: CredentialWrite.
+pub const TASK_VAULT_CREDENTIALS_PURGE_0_1: &str =
+    "https://trusttasks.org/spec/vault/credentials/purge/0.1";
 
 // ─── DID-management slice (spec/did-management/*) ────────────────────────
 //
@@ -1124,6 +1184,11 @@ pub const ALL_URIS: &[&str] = &[
     TASK_VAULT_UPSERT_0_1,
     TASK_VAULT_UPSERT_0_2,
     TASK_VAULT_DELETE_0_1,
+    // Vault archival lifecycle (openvtc 0.1 extension).
+    TASK_VAULT_ARCHIVE_0_1,
+    TASK_VAULT_UNARCHIVE_0_1,
+    TASK_VAULT_RESTORE_0_1,
+    TASK_VAULT_PURGE_0_1,
     TASK_VAULT_RELEASE_0_1,
     TASK_VAULT_RELEASE_0_2,
     TASK_VAULT_PROXY_LOGIN_0_1,

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.9.10"
+version = "0.10.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -80,12 +80,12 @@ path = "src/main.rs"
 required-features = ["cli-synthesis"]
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.10", features = ["encryption", "passkey", "openapi"] }
+vti-common = { path = "../vti-common", version = "0.11", features = ["encryption", "passkey", "openapi"] }
 # Seed-store backends + `create_seed_store` factory + `SecretsConfig` (lifted
 # from this crate into a shared crate so external integrations can reuse them).
 # Per-backend features are activated by this crate's matching features below.
 vti-secrets = { path = "../vti-secrets", version = "0.1" }
-vta-sdk = { path = "../vta-sdk", version = "0.17", features = ["didcomm", "sealed-transfer", "provision-integration", "openapi", "crypto-provider"] }
+vta-sdk = { path = "../vta-sdk", version = "0.18", features = ["didcomm", "sealed-transfer", "provision-integration", "openapi", "crypto-provider"] }
 # DID-VM-resolved WebAuthn assertion verifier — drives the new
 # `vta/auth/passkey-login-{start,finish}/1.0` trust-task handlers.
 # Distinct from `webauthn-rs` (which drives the passkey *enrolment*
@@ -105,7 +105,7 @@ trust-tasks-proof = { workspace = true }
 # generation, bundle opening). Used by `vta bootstrap request` /
 # `vta bootstrap open` so cold-start clients can run the offline flow
 # without depending on `pnm`.
-vta-cli-common = { path = "../vta-cli-common", version = "0.9" }
+vta-cli-common = { path = "../vta-cli-common", version = "0.10" }
 affinidi-crypto = { workspace = true }
 # Low-level `Secret` type for loading the VTA's signing key at
 # provision time. Already transitively present via affinidi-tdk; made
@@ -241,7 +241,7 @@ vta-service = { path = ".", features = ["test-support"] }
 # `provision_admin_rotated_via_rest` + DI-signed REST auth) the `MockVta`
 # bootstrap→provision e2e tests drive (issues #406, DI-auth follow-up). Kept out
 # of the production `vta-sdk` dep above so the server build stays lean.
-vta-sdk = { path = "../vta-sdk", version = "0.17", features = ["provision-client"] }
+vta-sdk = { path = "../vta-sdk", version = "0.18", features = ["provision-client"] }
 # Mock HTTP server for the did-hosting-daemon REST auth flow tests. Each
 # test spins up a real local server bound to a random port, validates
 # the JWS-signed request bodies the daemon would see, and serves

--- a/vta-service/src/audit.rs
+++ b/vta-service/src/audit.rs
@@ -74,6 +74,26 @@ pub async fn record(
     channel: Option<&str>,
     context_id: Option<&str>,
 ) -> Result<(), AppError> {
+    record_with_detail(
+        audit_ks, action, actor, resource, outcome, channel, context_id, None,
+    )
+    .await
+}
+
+/// Like [`record`], but also persists an operator-supplied `detail` (e.g. the
+/// `reason` on a `vault.delete`/`vault.archive`). Kept as a separate function
+/// so the existing `record(...)` call sites stay untouched.
+#[allow(clippy::too_many_arguments)]
+pub async fn record_with_detail(
+    audit_ks: &KeyspaceHandle,
+    action: &str,
+    actor: &str,
+    resource: Option<&str>,
+    outcome: &str,
+    channel: Option<&str>,
+    context_id: Option<&str>,
+    detail: Option<&str>,
+) -> Result<(), AppError> {
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
@@ -89,6 +109,7 @@ pub async fn record(
         outcome: outcome.to_string(),
         channel: channel.map(String::from),
         context_id: context_id.map(String::from),
+        detail: detail.map(String::from),
     };
 
     // Key: zero-padded timestamp for lexicographic time ordering

--- a/vta-service/src/config.rs
+++ b/vta-service/src/config.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 // Re-export shared config types
 pub use vti_common::config::{
-    AuditConfig, AuthConfig, LogConfig, LogFormat, MessagingConfig, StoreConfig,
+    AuditConfig, AuthConfig, LogConfig, LogFormat, MessagingConfig, StoreConfig, VaultConfig,
 };
 // The `[secrets]` config shape + its seed-store backends live in the shared
 // `vti-secrets` crate (issue #501). Re-exported here so `AppConfig.secrets`
@@ -37,6 +37,10 @@ pub struct AppConfig {
     pub auth: AuthConfig,
     #[serde(default)]
     pub audit: AuditConfig,
+    /// Vault lifecycle tuning (soft-delete grace window). Shared by the
+    /// password vault and the credential store.
+    #[serde(default)]
+    pub vault: VaultConfig,
     #[serde(default)]
     pub secrets: SecretsConfig,
     /// Verifier DIDs the holder **auto-consents** to when answering a

--- a/vta-service/src/lib.rs
+++ b/vta-service/src/lib.rs
@@ -45,6 +45,7 @@ pub mod tee;
 /// here, so it lives at the crate root rather than under `routes::` (P2.4).
 pub mod trust_tasks;
 pub mod vault;
+pub mod vault_sweeper;
 #[cfg(feature = "webvh")]
 pub mod webvh_auth;
 #[cfg(feature = "webvh")]

--- a/vta-service/src/operations/credential_exchange.rs
+++ b/vta-service/src/operations/credential_exchange.rs
@@ -1764,6 +1764,10 @@ mod tests {
             source: None,
             tags: Default::default(),
             body: serde_json::to_vec(&vc).unwrap(),
+            lifecycle: vti_common::vault::VaultStatus::Active,
+            archived_at: None,
+            deleted_at: None,
+            grace_until: None,
         };
         crate::vault::storage::put(vault, &cred)
             .await

--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -1205,6 +1205,14 @@ fn run_storage_thread(
                             Ok(_) => {}
                             Err(e) => warn!("pending-present sweeper error: {e}"),
                         }
+                        // Hard-purge grace-expired vault + credential tombstones
+                        // (soft-deleted entries past their recovery window), so
+                        // the trash can't linger forever. Audits each purge.
+                        if let Err(e) =
+                            crate::vault_sweeper::sweep_expired(&vault_ks, &audit_ks).await
+                        {
+                            warn!("vault sweeper error: {e}");
+                        }
                     }
                     _ = shutdown_rx.changed() => {
                         info!("storage thread shutting down");

--- a/vta-service/src/setup/from_toml.rs
+++ b/vta-service/src/setup/from_toml.rs
@@ -785,6 +785,7 @@ pub async fn apply_inputs(
             ..AuthConfig::default()
         },
         audit: inputs.audit.clone(),
+        vault: Default::default(),
         secrets: secrets_config,
         #[cfg(feature = "tee")]
         tee: Default::default(),
@@ -1196,6 +1197,7 @@ fn scratch_config_for_seed_store(
         messaging: None,
         auth: AuthConfig::default(),
         audit: Default::default(),
+        vault: Default::default(),
         secrets,
         #[cfg(feature = "tee")]
         tee: Default::default(),

--- a/vta-service/src/test_support.rs
+++ b/vta-service/src/test_support.rs
@@ -132,6 +132,7 @@ pub fn test_app_config(data_dir: PathBuf) -> AppConfig {
         services: Default::default(),
         auth: Default::default(),
         audit: Default::default(),
+        vault: Default::default(),
         secrets: Default::default(),
         #[cfg(feature = "tee")]
         tee: Default::default(),

--- a/vta-service/src/trust_tasks/cred_vault.rs
+++ b/vta-service/src/trust_tasks/cred_vault.rs
@@ -23,6 +23,7 @@ use serde_json::Value;
 use trust_tasks_rs::{RejectReason, TrustTask};
 use uuid::Uuid;
 use vti_common::acl::{Capability, role_has_capability};
+use vti_common::vault::{LifecycleError, VaultStatus};
 
 use crate::auth::AuthClaims;
 use crate::server::AppState;
@@ -212,17 +213,22 @@ pub(super) async fn handle_get(
         Err(resp) => return resp,
     };
     match storage::get(&state.vault_ks, &req.id).await {
-        Ok(Some(stored)) => match serde_json::from_slice::<Value>(&stored.body) {
-            Ok(credential) => success_response(&doc, GetResponse { credential }),
-            Err(e) => reject_with(
-                &doc,
-                RejectReason::InternalError {
-                    reason: format!("stored credential body is not JSON: {e}"),
-                },
-            ),
-        },
-        // Conflate not-found with permission-denied to deny enumeration.
-        Ok(None) => reject_with(
+        // An archived / soft-deleted credential's body must not be handed out
+        // for presentation — conflate it with not-found (same enumeration
+        // stance as a genuinely absent id).
+        Ok(Some(stored)) if stored.is_active() => {
+            match serde_json::from_slice::<Value>(&stored.body) {
+                Ok(credential) => success_response(&doc, GetResponse { credential }),
+                Err(e) => reject_with(
+                    &doc,
+                    RejectReason::InternalError {
+                        reason: format!("stored credential body is not JSON: {e}"),
+                    },
+                ),
+            }
+        }
+        // Conflate not-found (and not-active) with permission-denied to deny enumeration.
+        Ok(_) => reject_with(
             &doc,
             RejectReason::TaskFailed {
                 reason: "credential not found".to_string(),
@@ -231,6 +237,221 @@ pub(super) async fn handle_get(
         ),
         Err(e) => app_error_to_reject(&doc, e),
     }
+}
+
+/// Shared request body for the credential archival lifecycle verbs
+/// (`archive` / `unarchive` / `delete` / `restore` / `purge`). `reason` is
+/// lifted into the audit row's `detail` by the dispatch spine; `force` is
+/// honoured only by `delete` (skip the grace window → immediate hard delete).
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CredLifecycleBody {
+    id: String,
+    #[serde(default)]
+    #[allow(dead_code)] // read generically by the spine for the audit `detail`
+    reason: Option<String>,
+    #[serde(default)]
+    force: bool,
+}
+
+/// Post-transition view for archive / unarchive / delete / restore.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CredLifecycleResponse {
+    id: String,
+    lifecycle: VaultStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    grace_until: Option<String>,
+}
+
+/// `not_found` rejection for a missing credential id on a lifecycle verb.
+fn cred_not_found(doc: &TrustTask<Value>, verb: &str, id: &str) -> TrustTaskOutcome {
+    reject_with(
+        doc,
+        RejectReason::TaskFailed {
+            reason: format!("vault/credentials/{verb}:not_found — no credential at id {id}"),
+            details: None,
+        },
+    )
+}
+
+/// Map a [`LifecycleError`] to a Trust-Task rejection with an operator hint.
+fn cred_lifecycle_reject(
+    doc: &TrustTask<Value>,
+    verb: &str,
+    id: &str,
+    err: LifecycleError,
+) -> TrustTaskOutcome {
+    let hint = match err {
+        LifecycleError::NotActive => "credential is not active (already archived or deleted)",
+        LifecycleError::NotArchived => "credential is not archived",
+        LifecycleError::AlreadyDeleted => {
+            "credential is already in the trash — restore it or purge it"
+        }
+        LifecycleError::NotDeleted => "credential is not in the trash",
+        LifecycleError::GraceExpired => {
+            "the grace window has elapsed — the credential has been (or is about to be) purged"
+        }
+    };
+    reject_with(
+        doc,
+        RejectReason::TaskFailed {
+            reason: format!("vault/credentials/{verb}:{} — {hint} (id {id})", err.code()),
+            details: None,
+        },
+    )
+}
+
+fn cred_lifecycle_response(cred: &crate::vault::model::StoredCredential) -> CredLifecycleResponse {
+    CredLifecycleResponse {
+        id: cred.id.clone(),
+        lifecycle: cred.lifecycle,
+        grace_until: cred.grace_until.clone(),
+    }
+}
+
+/// Handler for `spec/vault/credentials/archive/0.1`. Auth: CredentialWrite.
+pub(super) async fn handle_archive(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    let now = Utc::now().to_rfc3339();
+    cred_transition(state, auth, doc, "archive", move |cred| cred.archive(&now)).await
+}
+
+/// Handler for `spec/vault/credentials/unarchive/0.1`. Auth: CredentialWrite.
+pub(super) async fn handle_unarchive(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    cred_transition(state, auth, doc, "unarchive", |cred| cred.unarchive()).await
+}
+
+/// Handler for `spec/vault/credentials/restore/0.1`. Auth: CredentialWrite.
+pub(super) async fn handle_restore(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    let now = Utc::now().to_rfc3339();
+    cred_transition(state, auth, doc, "restore", move |cred| cred.restore(&now)).await
+}
+
+/// Shared load → transition → re-store body for archive / unarchive / restore.
+/// `storage::put` re-indexes, so a status/lifecycle change never orphans an
+/// index row. Credentials carry no optimistic-concurrency version, so (unlike
+/// the password vault) there is no `expectedVersion` gate here.
+async fn cred_transition(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+    verb: &str,
+    transition: impl FnOnce(&mut crate::vault::model::StoredCredential) -> Result<(), LifecycleError>,
+) -> TrustTaskOutcome {
+    if let Err(r) = require_cap(auth, &doc, Capability::CredentialWrite, verb) {
+        return r;
+    }
+    let req: CredLifecycleBody = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    let mut cred = match storage::get(&state.vault_ks, &req.id).await {
+        Ok(Some(c)) => c,
+        Ok(None) => return cred_not_found(&doc, verb, &req.id),
+        Err(e) => return app_error_to_reject(&doc, e),
+    };
+    if let Err(e) = transition(&mut cred) {
+        return cred_lifecycle_reject(&doc, verb, &req.id, e);
+    }
+    if let Err(e) = storage::put(&state.vault_ks, &cred).await {
+        return app_error_to_reject(&doc, e);
+    }
+    success_response(&doc, cred_lifecycle_response(&cred))
+}
+
+/// Handler for `spec/vault/credentials/delete/0.1`. Default: recoverable soft
+/// delete (tombstone + grace window). `force: true` → immediate hard delete
+/// (tears down the `idx:` index too). Auth: CredentialWrite.
+pub(super) async fn handle_delete(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    if let Err(r) = require_cap(auth, &doc, Capability::CredentialWrite, "delete") {
+        return r;
+    }
+    let req: CredLifecycleBody = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+
+    // Forced hard delete bypasses the grace window entirely (and works even on
+    // an absent id — idempotent, like the storage primitive).
+    if req.force {
+        if let Err(e) = storage::delete(&state.vault_ks, &req.id).await {
+            return app_error_to_reject(&doc, e);
+        }
+        return success_response(
+            &doc,
+            CredLifecycleResponse {
+                id: req.id,
+                lifecycle: VaultStatus::Deleted,
+                grace_until: None,
+            },
+        );
+    }
+
+    let mut cred = match storage::get(&state.vault_ks, &req.id).await {
+        Ok(Some(c)) => c,
+        Ok(None) => return cred_not_found(&doc, "delete", &req.id),
+        Err(e) => return app_error_to_reject(&doc, e),
+    };
+    let now = Utc::now();
+    let grace_days = state.config.read().await.vault.grace_days;
+    let grace_until = (now + chrono::Duration::days(grace_days as i64)).to_rfc3339();
+    if let Err(e) = cred.soft_delete(&now.to_rfc3339(), &grace_until) {
+        return cred_lifecycle_reject(&doc, "delete", &req.id, e);
+    }
+    if let Err(e) = storage::put(&state.vault_ks, &cred).await {
+        return app_error_to_reject(&doc, e);
+    }
+    success_response(&doc, cred_lifecycle_response(&cred))
+}
+
+/// Handler for `spec/vault/credentials/purge/0.1` — irreversible hard delete
+/// (record + all index rows). Auth: CredentialWrite.
+pub(super) async fn handle_purge(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    if let Err(r) = require_cap(auth, &doc, Capability::CredentialWrite, "purge") {
+        return r;
+    }
+    let req: CredLifecycleBody = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    // `storage::delete` is idempotent (absent id is a no-op); surface a
+    // not_found only when there was genuinely nothing to purge.
+    match storage::get(&state.vault_ks, &req.id).await {
+        Ok(Some(_)) => {}
+        Ok(None) => return cred_not_found(&doc, "purge", &req.id),
+        Err(e) => return app_error_to_reject(&doc, e),
+    }
+    if let Err(e) = storage::delete(&state.vault_ks, &req.id).await {
+        return app_error_to_reject(&doc, e);
+    }
+    success_response(
+        &doc,
+        CredLifecycleResponse {
+            id: req.id,
+            lifecycle: VaultStatus::Deleted,
+            grace_until: None,
+        },
+    )
 }
 
 #[cfg(test)]

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -337,7 +337,30 @@ pub(crate) async fn dispatch_trust_task_core(
     // handler ignores it.
     use wire_v0_2::{WIRE_VERSION, WireVersion};
     let type_uri = doc.type_uri.to_string();
-    if let Some(spec) = wire_v0_2::lookup_0_2(&type_uri) {
+
+    // Blanket vault audit: capture the audit context BEFORE `doc` is moved
+    // into dispatch. Every password-vault and credential-vault task — read or
+    // write, success or denied — produces exactly one persisted audit row here
+    // (the one place that sees the type URI, the authenticated actor, and the
+    // final outcome). Non-vault tasks audit through their own handlers/ops.
+    let vault_audit = vault_audit_action(&type_uri).map(|action| {
+        let resource = vault_audit_resource(&doc.payload);
+        let context_id = doc
+            .payload
+            .get("contextId")
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        // Operator-supplied rationale (the `reason` field that delete/archive/
+        // restore/purge carry) — persisted so "audit the reason" is satisfied.
+        let detail = doc
+            .payload
+            .get("reason")
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        (action, resource, context_id, detail)
+    });
+
+    let outcome = if let Some(spec) = wire_v0_2::lookup_0_2(&type_uri) {
         let mut doc = doc;
         wire_v0_2::downconvert_request(&mut doc.payload, spec);
         if let Ok(uri_0_1) = spec.uri_0_1.parse() {
@@ -346,11 +369,80 @@ pub(crate) async fn dispatch_trust_task_core(
         let outcome = WIRE_VERSION
             .scope(WireVersion::V0_2, dispatch_typed(state, auth, doc))
             .await;
-        return wire_v0_2::upconvert_response(outcome, spec);
-    }
-    WIRE_VERSION
-        .scope(WireVersion::V0_1, dispatch_typed(state, auth, doc))
+        wire_v0_2::upconvert_response(outcome, spec)
+    } else {
+        WIRE_VERSION
+            .scope(WireVersion::V0_1, dispatch_typed(state, auth, doc))
+            .await
+    };
+
+    if let Some((action, resource, context_id, detail)) = vault_audit {
+        let label = vault_audit_outcome_label(&outcome);
+        if let Err(e) = crate::audit::record_with_detail(
+            &state.audit_ks,
+            &action,
+            &auth.did,
+            resource.as_deref(),
+            &label,
+            Some(helpers::TRANSPORT_TRUST_TASK),
+            context_id.as_deref(),
+            detail.as_deref(),
+        )
         .await
+        {
+            // Audit is best-effort: a failed write must never fail the op.
+            tracing::warn!(error = %e, action = %action, "vault audit record failed");
+        }
+    }
+
+    outcome
+}
+
+/// Audit action string for a vault-family Trust Task, or `None` for any task
+/// outside the vault family (those audit through their own handlers/ops).
+///
+/// `…/spec/vault/<verb>/<ver>` → `vault.<verb>` (e.g. `vault.delete`);
+/// `…/spec/vault/credentials/<verb>/<ver>` → `vault.cred.<verb>`. Version is
+/// ignored, so a 0.2 password-vault URI and its 0.1 form audit identically.
+fn vault_audit_action(type_uri: &str) -> Option<String> {
+    let rest = type_uri.split("/spec/vault/").nth(1)?;
+    let segs: Vec<&str> = rest.split('/').filter(|s| !s.is_empty()).collect();
+    match segs.as_slice() {
+        ["credentials", verb, ..] => Some(format!("vault.cred.{verb}")),
+        [verb, ..] => Some(format!("vault.{verb}")),
+        _ => None,
+    }
+}
+
+/// Best-effort resource id for the audit row, pulled generically from the
+/// request payload (`id` / `entryId` / `credentialId`). `None` for list/query
+/// tasks that carry no single-entry id.
+fn vault_audit_resource(payload: &Value) -> Option<String> {
+    for key in ["id", "entryId", "credentialId"] {
+        if let Some(v) = payload.get(key).and_then(Value::as_str) {
+            return Some(v.to_string());
+        }
+    }
+    None
+}
+
+/// Map a dispatch outcome to an audit outcome label: `"success"` on a 2xx,
+/// otherwise `"denied:<code>"` with the framework reject code lifted from the
+/// error document (falling back to `"denied"` if it can't be read). The audit
+/// sink keys INFO vs ERROR on the `"success"` prefix.
+fn vault_audit_outcome_label(outcome: &TrustTaskOutcome) -> String {
+    if outcome.status.is_success() {
+        return "success".to_string();
+    }
+    if let Ok(v) = serde_json::from_slice::<Value>(&outcome.body)
+        && let Some(code) = v
+            .get("payload")
+            .and_then(|p| p.get("code"))
+            .and_then(Value::as_str)
+    {
+        return format!("denied:{code}");
+    }
+    "denied".to_string()
 }
 
 /// Build a Trust-Task rejection `Response` for a request whose envelope
@@ -456,10 +548,21 @@ dispatch_table! {
     vta_sdk::trust_tasks::TASK_VAULT_RELEASE_0_1 => vault::handle_release,
     vta_sdk::trust_tasks::TASK_VAULT_PROXY_LOGIN_0_1 => vault::handle_proxy_login,
     vta_sdk::trust_tasks::TASK_VAULT_SIGN_TRUST_TASK_0_1 => vault::handle_sign_trust_task,
+    // Vault archival lifecycle (openvtc extension). `delete` above is now soft.
+    vta_sdk::trust_tasks::TASK_VAULT_ARCHIVE_0_1 => vault::handle_archive,
+    vta_sdk::trust_tasks::TASK_VAULT_UNARCHIVE_0_1 => vault::handle_unarchive,
+    vta_sdk::trust_tasks::TASK_VAULT_RESTORE_0_1 => vault::handle_restore,
+    vta_sdk::trust_tasks::TASK_VAULT_PURGE_0_1 => vault::handle_purge,
 
     vta_sdk::trust_tasks::TASK_VAULT_CREDENTIALS_RECEIVE_0_1 => cred_vault::handle_receive,
     vta_sdk::trust_tasks::TASK_VAULT_CREDENTIALS_QUERY_0_1 => cred_vault::handle_query,
     vta_sdk::trust_tasks::TASK_VAULT_CREDENTIALS_GET_0_1 => cred_vault::handle_get,
+    // Credential archival lifecycle (openvtc extension; CredentialWrite-gated).
+    vta_sdk::trust_tasks::TASK_VAULT_CREDENTIALS_ARCHIVE_0_1 => cred_vault::handle_archive,
+    vta_sdk::trust_tasks::TASK_VAULT_CREDENTIALS_UNARCHIVE_0_1 => cred_vault::handle_unarchive,
+    vta_sdk::trust_tasks::TASK_VAULT_CREDENTIALS_DELETE_0_1 => cred_vault::handle_delete,
+    vta_sdk::trust_tasks::TASK_VAULT_CREDENTIALS_RESTORE_0_1 => cred_vault::handle_restore,
+    vta_sdk::trust_tasks::TASK_VAULT_CREDENTIALS_PURGE_0_1 => cred_vault::handle_purge,
     // ─── Config slice ────────────────────────────────────────────
     vta_sdk::trust_tasks::TASK_CONFIG_GET_1_0 => config::handle_get,
     vta_sdk::trust_tasks::TASK_CONFIG_UPDATE_1_0 => config::handle_update,

--- a/vta-service/src/trust_tasks/vault.rs
+++ b/vta-service/src/trust_tasks/vault.rs
@@ -26,8 +26,8 @@ use trust_tasks_rs::TrustTask;
 use uuid::Uuid;
 use vti_common::acl::{Capability, role_has_capability};
 use vti_common::vault::{
-    SecretKind, SiteTarget, StoredVaultEntry, VaultEntry, VaultListFilter, VaultSecret,
-    delete_vault_entry, get_stored_vault_entry, get_vault_entry,
+    LifecycleError, SecretKind, SiteTarget, StoredVaultEntry, VaultEntry, VaultListFilter,
+    VaultSecret, VaultStatus, delete_vault_entry, get_stored_vault_entry, get_vault_entry,
     list_vault_entries as list_entries_store, put_stored_vault_entry,
 };
 
@@ -46,6 +46,17 @@ use trust_tasks_rs::RejectReason;
 /// returns up to `page_size` entries with `truncated: false` and no cursor.
 /// Real cursor-based pagination lands when the vault grows past a few
 /// thousand entries; for M1 with hand-seeded test data it's overkill.
+/// Archival-lifecycle view selector on `vault/list`. Omitted → `Active`
+/// (archived and soft-deleted entries are hidden from the normal listing).
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum VaultListStatusFilter {
+    Active,
+    Archived,
+    Deleted,
+    All,
+}
+
 #[derive(Debug, Default, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct VaultListBody {
@@ -60,6 +71,9 @@ struct VaultListBody {
     never_used: Option<bool>,
     expires_before: Option<String>,
     breached: Option<bool>,
+    /// Lifecycle view: `active` (default), `archived`, `deleted`, or `all`.
+    #[serde(default)]
+    status: Option<VaultListStatusFilter>,
     page_size: Option<u32>,
     // `cursor` accepted on the wire for forward-compat but ignored in M1.
     #[serde(default)]
@@ -202,13 +216,19 @@ enum ClearableField {
 struct VaultDeleteBody {
     id: String,
     expected_version: Option<u32>,
-    /// Human-readable rationale recorded in the audit trail. M2A.2 doesn't
-    /// have audit-log wiring for vault yet, so this field is accepted but
-    /// only echoed back; full audit landed when the audit module gains a
-    /// vault.delete event type.
+    /// Human-readable rationale persisted to the audit trail (the dispatch
+    /// spine lifts `reason` into the audit row's `detail`). Optional.
     #[serde(default)]
-    #[allow(dead_code)]
+    #[allow(dead_code)] // read generically by the spine, not by this handler
     reason: Option<String>,
+    /// When `true`, skip the grace window and **hard-delete** immediately —
+    /// the secret bytes are zeroised and the entry is unrecoverable
+    /// (equivalent to `vault/purge`). When `false` (default), perform a
+    /// recoverable soft delete: the entry becomes a `Deleted` tombstone,
+    /// restorable via `vault/restore` until the sweeper purges it at
+    /// `graceUntil`.
+    #[serde(default)]
+    force: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -216,12 +236,47 @@ struct VaultDeleteBody {
 struct VaultDeleteResponseBody {
     id: String,
     deleted_at: String,
-    /// M2A.2 performs a hard delete (no multi-device sync clients exist
-    /// yet, so there's nothing to fan tombstones to). `graceUntil ==
-    /// deletedAt` indicates "no grace window". When sync (M5) lands, this
-    /// gains a real grace window and the storage layer keeps a tombstone
-    /// record until then.
+    /// Deadline after which the sweeper hard-purges the soft-deleted entry —
+    /// the entry is recoverable via `vault/restore` until then. For a forced
+    /// hard delete (`force: true`) there is no recovery, so `graceUntil ==
+    /// deletedAt` signals "no grace window".
     grace_until: String,
+}
+
+/// Shared request body for the archival lifecycle verbs `vault/archive`,
+/// `vault/unarchive`, `vault/restore`, and `vault/purge`. Each targets a
+/// single entry by id, honours optimistic concurrency, and carries an
+/// optional `reason` the dispatch spine lifts into the audit row's `detail`.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct VaultLifecycleBody {
+    id: String,
+    #[serde(default)]
+    expected_version: Option<u32>,
+    #[serde(default)]
+    #[allow(dead_code)] // read generically by the spine for the audit `detail`
+    reason: Option<String>,
+}
+
+/// Response for `vault/archive`, `vault/unarchive`, and `vault/restore` — the
+/// post-transition lifecycle view. `graceUntil` is present only while the
+/// entry is a `Deleted` tombstone.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct VaultLifecycleResponseBody {
+    id: String,
+    status: VaultStatus,
+    version: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    grace_until: Option<String>,
+}
+
+/// Response for `vault/purge` — the entry is gone for good.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct VaultPurgeResponseBody {
+    id: String,
+    purged: bool,
 }
 
 /// Request body for `vault/release/0.1`. Mirrors the canonical schema.
@@ -397,6 +452,111 @@ fn enforce_context_scope(
     ))
 }
 
+/// `not_found` rejection used by the operator-facing lifecycle verbs
+/// (delete / archive / unarchive / restore / purge) for a missing id. These
+/// are `VaultWrite`-gated, so surfacing a distinct `not_found` (rather than
+/// conflating it like the consumer-facing release/proxy/sign paths) isn't an
+/// enumeration vector.
+fn vault_not_found(doc: &TrustTask<Value>, verb: &str, id: &str) -> TrustTaskOutcome {
+    reject_with(
+        doc,
+        RejectReason::TaskFailed {
+            reason: format!("vault/{verb}:not_found — no entry at id {id}"),
+            details: None,
+        },
+    )
+}
+
+/// Optimistic-concurrency gate shared by the lifecycle verbs. Returns
+/// `Some(reject)` on a version mismatch, `None` when the write may proceed.
+fn check_expected_version(
+    doc: &TrustTask<Value>,
+    verb: &str,
+    current: u32,
+    expected: Option<u32>,
+) -> Option<TrustTaskOutcome> {
+    match expected {
+        Some(v) if v != current => Some(reject_with(
+            doc,
+            RejectReason::TaskFailed {
+                reason: format!(
+                    "vault/{verb}:version_conflict — expectedVersion {v} != current version {current}"
+                ),
+                details: Some(serde_json::json!({ "currentVersion": current })),
+            },
+        )),
+        _ => None,
+    }
+}
+
+/// Map a [`LifecycleError`] from an illegal archival transition to a
+/// Trust-Task rejection carrying an operator hint and the stable error code.
+fn lifecycle_reject(
+    doc: &TrustTask<Value>,
+    verb: &str,
+    id: &str,
+    err: LifecycleError,
+) -> TrustTaskOutcome {
+    let hint = match err {
+        LifecycleError::NotActive => "entry is not active (already archived or deleted)",
+        LifecycleError::NotArchived => "entry is not archived",
+        LifecycleError::AlreadyDeleted => {
+            "entry is already in the trash — restore it (vault/restore) or purge it (vault/purge)"
+        }
+        LifecycleError::NotDeleted => "entry is not in the trash",
+        LifecycleError::GraceExpired => {
+            "the grace window has elapsed — the entry has been (or is about to be) purged"
+        }
+    };
+    reject_with(
+        doc,
+        RejectReason::TaskFailed {
+            reason: format!("vault/{verb}:{} — {hint} (id {id})", err.code()),
+            details: None,
+        },
+    )
+}
+
+/// Post-transition lifecycle view returned by archive / unarchive / restore.
+fn lifecycle_response(entry: &VaultEntry) -> VaultLifecycleResponseBody {
+    VaultLifecycleResponseBody {
+        id: entry.id.clone(),
+        status: entry.status,
+        version: entry.version,
+        grace_until: entry.grace_until.clone(),
+    }
+}
+
+/// The consumer-facing use paths (release / proxy-login / sign-trust-task)
+/// refuse an archived or soft-deleted entry. Returns `Some(reject)` shaped as
+/// the **same `not_found`** a missing entry yields — a consumer must not be
+/// able to tell "archived/deleted" from "absent" (enumeration resistance,
+/// matching the existing missing-entry conflation on these paths). The real
+/// lifecycle state is logged for operators (the persisted audit row, emitted
+/// by the spine, records the op + `not_found` outcome).
+fn refuse_if_not_active(
+    doc: &TrustTask<Value>,
+    op: &str,
+    entry: &VaultEntry,
+) -> Option<TrustTaskOutcome> {
+    if entry.status.is_active() {
+        return None;
+    }
+    tracing::info!(
+        entry_id = %entry.id,
+        status = ?entry.status,
+        op = %op,
+        "vault: refusing a non-active entry on a use path (reported to caller as not_found)"
+    );
+    Some(reject_with(
+        doc,
+        RejectReason::TaskFailed {
+            reason: format!("vault/{op}:not_found — no entry at id {}", entry.id),
+            details: None,
+        },
+    ))
+}
+
 /// Handler for `spec/vault/list/0.1`.
 pub(super) async fn handle_list(
     state: &AppState,
@@ -426,6 +586,15 @@ pub(super) async fn handle_list(
         return r;
     }
 
+    // Translate the wire lifecycle selector to the store filter. Omitted →
+    // Active-only (archived/deleted hidden); `all` returns every state.
+    let (status, any_status) = match req.status.unwrap_or(VaultListStatusFilter::Active) {
+        VaultListStatusFilter::Active => (Some(VaultStatus::Active), false),
+        VaultListStatusFilter::Archived => (Some(VaultStatus::Archived), false),
+        VaultListStatusFilter::Deleted => (Some(VaultStatus::Deleted), false),
+        VaultListStatusFilter::All => (None, true),
+    };
+
     let filter = VaultListFilter {
         context_id: req.context_id.as_deref(),
         target_origin_prefix: req.target_origin_prefix.as_deref(),
@@ -438,6 +607,8 @@ pub(super) async fn handle_list(
         never_used: req.never_used,
         expires_before: req.expires_before.as_deref(),
         breached: req.breached,
+        status,
+        any_status,
     };
 
     let mut entries = match list_entries_store(&state.vault_ks, &filter).await {
@@ -558,6 +729,36 @@ pub(super) async fn handle_upsert(
                     req.id.as_deref().unwrap_or("(none)")
                 ),
                 details: None,
+            },
+        );
+    }
+
+    // Upsert refuses to silently resurrect an archived / soft-deleted entry —
+    // overwriting it would wipe its lifecycle state (`status`, `deletedAt`,
+    // `graceUntil`). The operator must explicitly `unarchive` / `restore`
+    // (or `purge` then recreate) first. Active rows fall through unchanged.
+    if let Some(e) = existing.as_ref()
+        && e.entry.status != VaultStatus::Active
+    {
+        let (state_word, hint) = match e.entry.status {
+            VaultStatus::Archived => (
+                "archived",
+                "unarchive it first (vault/unarchive) before editing",
+            ),
+            VaultStatus::Deleted => (
+                "deleted",
+                "restore it first (vault/restore), or vault/purge and recreate",
+            ),
+            VaultStatus::Active => unreachable!("guarded by the != Active check above"),
+        };
+        return reject_with(
+            &doc,
+            RejectReason::TaskFailed {
+                reason: format!(
+                    "vault/upsert:entry_{state_word} — entry {} is {state_word}; {hint}",
+                    e.entry.id
+                ),
+                details: Some(serde_json::json!({ "status": e.entry.status })),
             },
         );
     }
@@ -800,6 +1001,13 @@ pub(super) async fn handle_upsert(
         // upsert + rotation. Stays in sync with the actual signing key
         // for did-self-issued / didcomm-peer entries.
         principal_did: VaultEntry::principal_did_from_secret(&secret),
+        // Upsert only ever writes Active rows: a create is Active, and an
+        // update is guarded above to reject non-Active existing entries, so we
+        // never clobber a tombstone here.
+        status: VaultStatus::Active,
+        archived_at: None,
+        deleted_at: None,
+        grace_until: None,
     };
 
     let record = StoredVaultEntry {
@@ -821,20 +1029,20 @@ pub(super) async fn handle_upsert(
 
 /// Handler for `spec/vault/delete/0.1`.
 ///
-/// M2A.2 performs a hard delete — the row is removed from the keyspace
-/// and the secret bytes are zeroised by the keyspace handle's `remove`
-/// implementation. There's no multi-device sync yet (M5 territory), so
-/// no tombstone-with-grace machinery is needed. The response's
-/// `graceUntil` field equals `deletedAt` to signal "no grace window";
-/// callers that re-sync after M5 will see a real grace window.
+/// Default (soft) delete moves the entry to a **recoverable** `Deleted`
+/// tombstone: the row and its secret are retained but blocked from use
+/// (release / proxy-login / sign-trust-task all refuse it), and it is
+/// restorable via `vault/restore` until the vault sweeper hard-purges it at
+/// `graceUntil` (= now + `vault.grace_days`, default 30). `force: true`
+/// bypasses the window and **hard-deletes immediately** — the secret bytes
+/// are zeroised by the keyspace `remove` and there is no recovery
+/// (equivalent to `vault/purge`).
 ///
-/// Enumeration-resistance: a missing entry returns `not_found`
-/// regardless of whether the consumer would actually have had read
-/// access to it — the consumer can't probe id space by deleting.
+/// Enumeration-resistance: a missing entry returns `not_found` regardless of
+/// whether the caller would have had read access to it.
 ///
-/// Audit-log wiring for vault events lands when the audit module gains
-/// a `vault.*` event variant. For M2A.2 the `reason` field is accepted
-/// and ignored.
+/// The audit row (action `vault.delete`, plus the `reason` as `detail`) is
+/// emitted by the dispatch spine, covering success and denied paths alike.
 pub(super) async fn handle_delete(
     state: &AppState,
     auth: &AuthClaims,
@@ -849,17 +1057,9 @@ pub(super) async fn handle_delete(
         Err(resp) => return resp,
     };
 
-    let existing = match get_stored_vault_entry(&state.vault_ks, &req.id).await {
+    let mut existing = match get_stored_vault_entry(&state.vault_ks, &req.id).await {
         Ok(Some(e)) => e,
-        Ok(None) => {
-            return reject_with(
-                &doc,
-                RejectReason::TaskFailed {
-                    reason: format!("vault/delete:not_found — no entry at id {}", req.id),
-                    details: None,
-                },
-            );
-        }
+        Ok(None) => return vault_not_found(&doc, "delete", &req.id),
         Err(e) => return app_error_to_reject(&doc, e),
     };
 
@@ -868,33 +1068,172 @@ pub(super) async fn handle_delete(
     if let Err(r) = enforce_context_scope(auth, Some(&existing.entry.context_id), &doc) {
         return r;
     }
-
-    if let Some(v) = req.expected_version
-        && v != existing.entry.version
+    if let Some(r) =
+        check_expected_version(&doc, "delete", existing.entry.version, req.expected_version)
     {
-        return reject_with(
+        return r;
+    }
+
+    let now = chrono::Utc::now();
+    let now_str = now.to_rfc3339();
+
+    // Forced hard delete (== purge): irreversible, zeroises the secret.
+    if req.force {
+        if let Err(e) = delete_vault_entry(&state.vault_ks, &req.id).await {
+            return app_error_to_reject(&doc, e);
+        }
+        return success_response(
             &doc,
-            RejectReason::TaskFailed {
-                reason: format!(
-                    "vault/delete:version_conflict — expectedVersion {v} != current version {}",
-                    existing.entry.version
-                ),
-                details: Some(serde_json::json!({ "currentVersion": existing.entry.version })),
+            VaultDeleteResponseBody {
+                id: req.id,
+                deleted_at: now_str.clone(),
+                grace_until: now_str, // == deletedAt → no grace window
             },
         );
     }
 
-    if let Err(e) = delete_vault_entry(&state.vault_ks, &req.id).await {
+    // Recoverable soft delete (tombstone with a real grace window).
+    let grace_days = state.config.read().await.vault.grace_days;
+    let grace_until = (now + chrono::Duration::days(grace_days as i64)).to_rfc3339();
+    if let Err(e) = existing
+        .entry
+        .soft_delete(&now_str, &grace_until, Some(&auth.did))
+    {
+        return lifecycle_reject(&doc, "delete", &req.id, e);
+    }
+    if let Err(e) = put_stored_vault_entry(&state.vault_ks, &existing).await {
         return app_error_to_reject(&doc, e);
     }
-
-    let now = chrono::Utc::now().to_rfc3339();
     success_response(
         &doc,
         VaultDeleteResponseBody {
             id: req.id,
-            deleted_at: now.clone(),
-            grace_until: now,
+            deleted_at: now_str,
+            grace_until,
+        },
+    )
+}
+
+/// Handler for `spec/vault/archive/0.1` — soft-disable an `Active` entry so
+/// it drops out of the default `vault/list` and is refused for use, while
+/// staying restorable via `vault/unarchive`. Auth: VaultWrite.
+pub(super) async fn handle_archive(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    handle_lifecycle_transition(state, auth, doc, "archive", |entry, now, actor| {
+        entry.archive(now, actor)
+    })
+    .await
+}
+
+/// Handler for `spec/vault/unarchive/0.1` — return an `Archived` entry to
+/// `Active`. Auth: VaultWrite.
+pub(super) async fn handle_unarchive(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    handle_lifecycle_transition(state, auth, doc, "unarchive", |entry, now, actor| {
+        entry.unarchive(now, actor)
+    })
+    .await
+}
+
+/// Handler for `spec/vault/restore/0.1` — undelete a soft-deleted entry back
+/// to `Active`, allowed only while still inside the grace window. A
+/// `grace_expired` rejection means the sweeper has (or is about to) purge it.
+/// Auth: VaultWrite.
+pub(super) async fn handle_restore(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    handle_lifecycle_transition(state, auth, doc, "restore", |entry, now, actor| {
+        entry.restore(now, actor)
+    })
+    .await
+}
+
+/// Shared body for `archive` / `unarchive` / `restore`: load → context-scope
+/// → optimistic-concurrency → apply the in-place [`VaultEntry`] transition →
+/// persist → return the post-transition lifecycle view. The transition
+/// closure is the only per-verb difference.
+async fn handle_lifecycle_transition(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+    verb: &str,
+    transition: impl Fn(&mut VaultEntry, &str, Option<&str>) -> Result<(), LifecycleError>,
+) -> TrustTaskOutcome {
+    if let Err(r) = require_capability(auth, &doc, Capability::VaultWrite, verb) {
+        return r;
+    }
+    let req: VaultLifecycleBody = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    let mut existing = match get_stored_vault_entry(&state.vault_ks, &req.id).await {
+        Ok(Some(e)) => e,
+        Ok(None) => return vault_not_found(&doc, verb, &req.id),
+        Err(e) => return app_error_to_reject(&doc, e),
+    };
+    if let Err(r) = enforce_context_scope(auth, Some(&existing.entry.context_id), &doc) {
+        return r;
+    }
+    if let Some(r) =
+        check_expected_version(&doc, verb, existing.entry.version, req.expected_version)
+    {
+        return r;
+    }
+    let now = chrono::Utc::now().to_rfc3339();
+    if let Err(e) = transition(&mut existing.entry, &now, Some(&auth.did)) {
+        return lifecycle_reject(&doc, verb, &req.id, e);
+    }
+    if let Err(e) = put_stored_vault_entry(&state.vault_ks, &existing).await {
+        return app_error_to_reject(&doc, e);
+    }
+    success_response(&doc, lifecycle_response(&existing.entry))
+}
+
+/// Handler for `spec/vault/purge/0.1` — irreversibly hard-delete an entry
+/// (typically an already-`Deleted` tombstone, but valid on any entry),
+/// skipping the grace window. The secret bytes are zeroised on removal.
+/// Auth: VaultWrite.
+pub(super) async fn handle_purge(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    if let Err(r) = require_capability(auth, &doc, Capability::VaultWrite, "purge") {
+        return r;
+    }
+    let req: VaultLifecycleBody = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    let existing = match get_stored_vault_entry(&state.vault_ks, &req.id).await {
+        Ok(Some(e)) => e,
+        Ok(None) => return vault_not_found(&doc, "purge", &req.id),
+        Err(e) => return app_error_to_reject(&doc, e),
+    };
+    if let Err(r) = enforce_context_scope(auth, Some(&existing.entry.context_id), &doc) {
+        return r;
+    }
+    if let Some(r) =
+        check_expected_version(&doc, "purge", existing.entry.version, req.expected_version)
+    {
+        return r;
+    }
+    if let Err(e) = delete_vault_entry(&state.vault_ks, &req.id).await {
+        return app_error_to_reject(&doc, e);
+    }
+    success_response(
+        &doc,
+        VaultPurgeResponseBody {
+            id: req.id,
+            purged: true,
         },
     )
 }
@@ -957,6 +1296,12 @@ pub(super) async fn handle_release(
 
     if let Err(r) = enforce_context_scope(auth, Some(&stored.entry.context_id), &doc) {
         return r;
+    }
+
+    // Archived / soft-deleted entries are not releasable — refuse as
+    // not_found (a consumer can't distinguish lifecycle state from absence).
+    if let Some(reject) = refuse_if_not_active(&doc, "release", &stored.entry) {
+        return reject;
     }
 
     // Step-up gate (P0.13): honour an operator-configured `vault/release`
@@ -1093,6 +1438,12 @@ pub(super) async fn handle_proxy_login(
 
     if let Err(r) = enforce_context_scope(auth, Some(&stored.entry.context_id), &doc) {
         return r;
+    }
+
+    // Archived / soft-deleted entries can't be proxy-logged-in — refuse as
+    // not_found (enumeration resistance).
+    if let Some(reject) = refuse_if_not_active(&doc, "proxy-login", &stored.entry) {
+        return reject;
     }
 
     // Step-up gate (P0.13): honour a `vault/proxy-login` floor before
@@ -1275,6 +1626,12 @@ pub(super) async fn handle_sign_trust_task(
 
     if let Err(r) = enforce_context_scope(auth, Some(&stored.entry.context_id), &doc) {
         return r;
+    }
+
+    // Archived / soft-deleted entries can't sign — refuse as not_found
+    // (enumeration resistance).
+    if let Some(reject) = refuse_if_not_active(&doc, "sign-trust-task", &stored.entry) {
+        return reject;
     }
 
     // Step-up gate (P0.13): honour a `vault/sign-trust-task` floor before

--- a/vta-service/src/vault/bbs.rs
+++ b/vta-service/src/vault/bbs.rs
@@ -253,6 +253,10 @@ fn build_stored_bbs(
         source,
         tags: std::collections::BTreeMap::new(),
         body: vc_json.to_vec(),
+        lifecycle: vti_common::vault::VaultStatus::Active,
+        archived_at: None,
+        deleted_at: None,
+        grace_until: None,
     }
 }
 
@@ -845,6 +849,10 @@ mod tests {
             source: None,
             tags: std::collections::BTreeMap::new(),
             body: vec![],
+            lifecycle: vti_common::vault::VaultStatus::Active,
+            archived_at: None,
+            deleted_at: None,
+            grace_until: None,
         };
         assert_eq!(holder_pseudonym_secrets(&cred).unwrap(), None);
         cred.tags.insert(

--- a/vta-service/src/vault/model.rs
+++ b/vta-service/src/vault/model.rs
@@ -23,6 +23,7 @@
 //!   primitives to build on.
 
 use serde::{Deserialize, Serialize};
+use vti_common::vault::{LifecycleError, VaultStatus, default_active};
 
 /// Reserved [`StoredCredential::tags`] key holding the BBS pseudonym holder
 /// link secret (`prover_nym`), base64url-no-pad. See [`StoredCredential::tags`].
@@ -189,6 +190,87 @@ pub struct StoredCredential {
     /// byte vector; the format-agnostic store makes no assumption about
     /// whether it is a UTF-8 JWT, CBOR, or anything else.
     pub body: Vec<u8>,
+    /// **Archival** lifecycle state — orthogonal to `status` (which is
+    /// *validity*, status-list driven and overwritten by
+    /// [`crate::vault::status::refresh_status`]). Reuses the password-vault
+    /// [`VaultStatus`]. `Active` by default (and for records stored before
+    /// the lifecycle existed). `Archived`/`Deleted` credentials are excluded
+    /// from query/present; a `Deleted` credential is a recoverable tombstone
+    /// the sweeper hard-purges (index rows and all) at `grace_until`.
+    #[serde(
+        default = "default_active",
+        skip_serializing_if = "VaultStatus::is_active"
+    )]
+    pub lifecycle: VaultStatus,
+    /// RFC 3339 — set iff `lifecycle == Archived`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub archived_at: Option<String>,
+    /// RFC 3339 — set iff `lifecycle == Deleted`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deleted_at: Option<String>,
+    /// RFC 3339 purge deadline — recoverable via restore while `now <
+    /// grace_until`. Set iff `lifecycle == Deleted`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub grace_until: Option<String>,
+}
+
+impl StoredCredential {
+    /// `true` when the credential is in normal use (not archived/deleted) —
+    /// the only state from which it may be presented.
+    pub fn is_active(&self) -> bool {
+        self.lifecycle.is_active()
+    }
+
+    /// `Active → Archived`. Refused (`NotActive`) otherwise.
+    pub fn archive(&mut self, now: &str) -> Result<(), LifecycleError> {
+        if self.lifecycle != VaultStatus::Active {
+            return Err(LifecycleError::NotActive);
+        }
+        self.lifecycle = VaultStatus::Archived;
+        self.archived_at = Some(now.to_string());
+        Ok(())
+    }
+
+    /// `Archived → Active`. Refused (`NotArchived`) otherwise.
+    pub fn unarchive(&mut self) -> Result<(), LifecycleError> {
+        if self.lifecycle != VaultStatus::Archived {
+            return Err(LifecycleError::NotArchived);
+        }
+        self.lifecycle = VaultStatus::Active;
+        self.archived_at = None;
+        Ok(())
+    }
+
+    /// `Active|Archived → Deleted` (recoverable tombstone). Refused
+    /// (`AlreadyDeleted`) if already a tombstone — restore or purge instead.
+    pub fn soft_delete(&mut self, now: &str, grace_until: &str) -> Result<(), LifecycleError> {
+        if self.lifecycle == VaultStatus::Deleted {
+            return Err(LifecycleError::AlreadyDeleted);
+        }
+        self.lifecycle = VaultStatus::Deleted;
+        self.archived_at = None;
+        self.deleted_at = Some(now.to_string());
+        self.grace_until = Some(grace_until.to_string());
+        Ok(())
+    }
+
+    /// `Deleted → Active`, only while still inside the grace window. Refused
+    /// `NotDeleted` if not a tombstone, or `GraceExpired` if `now >=
+    /// grace_until`. Lexical RFC 3339 comparison (house style).
+    pub fn restore(&mut self, now: &str) -> Result<(), LifecycleError> {
+        if self.lifecycle != VaultStatus::Deleted {
+            return Err(LifecycleError::NotDeleted);
+        }
+        if let Some(grace) = self.grace_until.as_deref()
+            && now >= grace
+        {
+            return Err(LifecycleError::GraceExpired);
+        }
+        self.lifecycle = VaultStatus::Active;
+        self.deleted_at = None;
+        self.grace_until = None;
+        Ok(())
+    }
 }
 
 impl StoredCredential {
@@ -242,5 +324,95 @@ impl IndexField {
             IndexField::Purpose => "purpose",
             IndexField::Status => "status",
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample() -> StoredCredential {
+        StoredCredential {
+            id: "cred-1".into(),
+            format: CredentialFormat::SdJwtVc,
+            types: vec!["MembershipCredential".into()],
+            schema_id: None,
+            community_did: Some("did:web:acme".into()),
+            subject_did: None,
+            issuer_did: Some("did:web:issuer".into()),
+            purpose: Some(CredentialPurpose::Membership),
+            status: CredentialStatus::Valid,
+            valid_from: None,
+            valid_until: None,
+            received_at: "2026-06-03T00:00:00Z".into(),
+            source: None,
+            tags: std::collections::BTreeMap::new(),
+            body: b"opaque".to_vec(),
+            lifecycle: VaultStatus::Active,
+            archived_at: None,
+            deleted_at: None,
+            grace_until: None,
+        }
+    }
+
+    #[test]
+    fn legacy_credential_without_lifecycle_defaults_active() {
+        // A record persisted before the lifecycle existed lacks the new keys.
+        let legacy = r#"{
+            "id":"c","format":"sd-jwt-vc","types":[],"status":"valid",
+            "receivedAt":"2026-01-01T00:00:00Z","body":[1,2,3]
+        }"#;
+        let cred: StoredCredential = serde_json::from_str(legacy).expect("parse legacy");
+        assert_eq!(cred.lifecycle, VaultStatus::Active);
+        assert!(cred.is_active());
+        // Active credentials re-emit without the lifecycle key (wire stays clean).
+        let re = serde_json::to_string(&cred).unwrap();
+        assert!(
+            !re.contains("lifecycle"),
+            "active cred omits lifecycle: {re}"
+        );
+    }
+
+    #[test]
+    fn credential_lifecycle_transitions() {
+        let t0 = "2026-06-18T10:00:00+00:00";
+        let grace = "2026-07-18T10:00:00+00:00";
+
+        // archive / unarchive.
+        let mut c = sample();
+        c.archive(t0).unwrap();
+        assert_eq!(c.lifecycle, VaultStatus::Archived);
+        assert_eq!(c.archived_at.as_deref(), Some(t0));
+        assert!(!c.is_active());
+        assert_eq!(c.archive(t0), Err(LifecycleError::NotActive));
+        c.unarchive().unwrap();
+        assert!(c.is_active() && c.archived_at.is_none());
+        assert_eq!(c.unarchive(), Err(LifecycleError::NotArchived));
+
+        // soft delete / restore inside the window.
+        let mut c = sample();
+        c.soft_delete(t0, grace).unwrap();
+        assert_eq!(c.lifecycle, VaultStatus::Deleted);
+        assert_eq!(c.grace_until.as_deref(), Some(grace));
+        assert_eq!(
+            c.soft_delete(t0, grace),
+            Err(LifecycleError::AlreadyDeleted)
+        );
+        c.restore(t0).unwrap();
+        assert!(c.is_active());
+        assert_eq!(c.restore(t0), Err(LifecycleError::NotDeleted));
+
+        // restore after grace is refused (sweeper owns it).
+        let mut c = sample();
+        c.soft_delete(t0, grace).unwrap();
+        assert_eq!(
+            c.restore("2026-08-01T00:00:00+00:00"),
+            Err(LifecycleError::GraceExpired)
+        );
+        assert_eq!(
+            c.lifecycle,
+            VaultStatus::Deleted,
+            "failed restore is a no-op"
+        );
     }
 }

--- a/vta-service/src/vault/present.rs
+++ b/vta-service/src/vault/present.rs
@@ -263,6 +263,14 @@ pub(super) async fn gate_present(
         cred
     };
 
+    // Archived / soft-deleted credentials are not presentable — archival
+    // lifecycle is orthogonal to validity but equally disqualifying.
+    if !cred.is_active() {
+        return Err(AppError::Forbidden(format!(
+            "credential `{credential_id}` is archived or deleted; cannot present"
+        )));
+    }
+
     // Never present a revoked / temporally-invalid credential (§14.5).
     if cred.status != CredentialStatus::Valid {
         return Err(AppError::Forbidden(format!(
@@ -578,6 +586,10 @@ mod tests {
             source: None,
             tags: Default::default(),
             body: compact.into_bytes(),
+            lifecycle: vti_common::vault::VaultStatus::Active,
+            archived_at: None,
+            deleted_at: None,
+            grace_until: None,
         };
         storage::put(vault, &cred).await.expect("put");
     }
@@ -1633,6 +1645,10 @@ mod tests {
             source: None,
             tags: Default::default(),
             body: serde_json::to_vec(&vc).unwrap(),
+            lifecycle: vti_common::vault::VaultStatus::Active,
+            archived_at: None,
+            deleted_at: None,
+            grace_until: None,
         };
         storage::put(vault, &cred).await.expect("put DI VC");
     }
@@ -1669,6 +1685,10 @@ mod tests {
             source: None,
             tags: Default::default(),
             body: serde_json::to_vec(&vc).unwrap(),
+            lifecycle: vti_common::vault::VaultStatus::Active,
+            archived_at: None,
+            deleted_at: None,
+            grace_until: None,
         };
         storage::put(vault, &cred).await.expect("put DI VC");
     }

--- a/vta-service/src/vault/query.rs
+++ b/vta-service/src/vault/query.rs
@@ -230,6 +230,13 @@ pub async fn search(
 
     let mut out = Vec::new();
     for cred in &candidates {
+        // Archival lifecycle: an archived or soft-deleted credential is hidden
+        // from search the same way revoked/expired ones are — it's not a
+        // candidate to present. (The status index still lists it; the
+        // exclusion is applied here, after the indexed match.)
+        if !cred.is_active() {
+            continue;
+        }
         // §14 invariant 5: a revoked (or expired) credential is never a search result,
         // regardless of the filter — not even when the caller explicitly asks
         // for `status = revoked`. This is the load-bearing exclusion that keeps
@@ -299,6 +306,10 @@ mod tests {
             source: Some("exchange:thread-42".into()),
             tags: std::collections::BTreeMap::from([("label".into(), "alice-invite".into())]),
             body: b"opaque.credential.bytes".to_vec(),
+            lifecycle: vti_common::vault::VaultStatus::Active,
+            archived_at: None,
+            deleted_at: None,
+            grace_until: None,
         }
     }
 

--- a/vta-service/src/vault/receive.rs
+++ b/vta-service/src/vault/receive.rs
@@ -247,6 +247,10 @@ pub async fn receive_sd_jwt_vc(
         // Store the credential verbatim as the holder received it, so a later
         // present/refresh re-parses the exact bytes. Opaque to the store.
         body: compact.as_bytes().to_vec(),
+        lifecycle: vti_common::vault::VaultStatus::Active,
+        archived_at: None,
+        deleted_at: None,
+        grace_until: None,
     };
 
     // Single, final side effect. Reached only after both checks passed, so
@@ -362,6 +366,10 @@ pub async fn receive_di_vc(
         source,
         tags: std::collections::BTreeMap::new(),
         body: vc_json.to_vec(),
+        lifecycle: vti_common::vault::VaultStatus::Active,
+        archived_at: None,
+        deleted_at: None,
+        grace_until: None,
     };
 
     storage::put(vault, &cred).await?;

--- a/vta-service/src/vault/status.rs
+++ b/vta-service/src/vault/status.rs
@@ -526,6 +526,13 @@ pub async fn refresh_status<R: StatusListResolver + ?Sized>(
         .await?
         .ok_or_else(|| AppError::NotFound(format!("no stored credential with id `{id}`")))?;
 
+    // Archival lifecycle short-circuit: a non-Active credential (archived or
+    // soft-deleted) is out of use, so its validity status is neither resolved
+    // nor rewritten — a refresh must never flip/resurrect a tombstoned cred.
+    if !cred.is_active() {
+        return Ok(RefreshOutcome::NotTracked);
+    }
+
     let Some(status_ref) = extract_status_ref(&cred)? else {
         return Ok(RefreshOutcome::NotTracked);
     };
@@ -739,6 +746,10 @@ mod tests {
             source: None,
             tags: BTreeMap::new(),
             body: serde_json::to_vec(&body).unwrap(),
+            lifecycle: vti_common::vault::VaultStatus::Active,
+            archived_at: None,
+            deleted_at: None,
+            grace_until: None,
         }
     }
 

--- a/vta-service/src/vault/storage.rs
+++ b/vta-service/src/vault/storage.rs
@@ -143,6 +143,10 @@ mod tests {
             source: Some("exchange:thread-42".into()),
             tags: std::collections::BTreeMap::from([("label".into(), "alice-invite".into())]),
             body: b"opaque.credential.bytes".to_vec(),
+            lifecycle: vti_common::vault::VaultStatus::Active,
+            archived_at: None,
+            deleted_at: None,
+            grace_until: None,
         }
     }
 

--- a/vta-service/src/vault_cli.rs
+++ b/vta-service/src/vault_cli.rs
@@ -15,8 +15,8 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use vti_common::vault::{
-    SecretKind, SiteTarget, StoredVaultEntry, VaultEntry, VaultSecret, get_vault_entry,
-    put_stored_vault_entry,
+    SecretKind, SiteTarget, StoredVaultEntry, VaultEntry, VaultSecret, VaultStatus,
+    get_vault_entry, put_stored_vault_entry,
 };
 
 use crate::config::AppConfig;
@@ -187,6 +187,10 @@ fn demo_records(context_id: &str) -> Vec<StoredVaultEntry> {
                 version: 1,
                 // Maintainer-derived; passkey has no principal DID concept.
                 principal_did: None,
+                status: VaultStatus::Active,
+                archived_at: None,
+                deleted_at: None,
+                grace_until: None,
             },
             secret: placeholder_passkey(),
         },
@@ -215,6 +219,10 @@ fn demo_records(context_id: &str) -> Vec<StoredVaultEntry> {
                 last_used_at: Some(now.clone()),
                 version: 1,
                 principal_did: None,
+                status: VaultStatus::Active,
+                archived_at: None,
+                deleted_at: None,
+                grace_until: None,
             },
             secret: placeholder_password(),
         },
@@ -243,6 +251,10 @@ fn demo_records(context_id: &str) -> Vec<StoredVaultEntry> {
                 last_used_at: None,
                 version: 1,
                 principal_did: None,
+                status: VaultStatus::Active,
+                archived_at: None,
+                deleted_at: None,
+                grace_until: None,
             },
             secret: placeholder_password(),
         },

--- a/vta-service/src/vault_sweeper.rs
+++ b/vta-service/src/vault_sweeper.rs
@@ -1,0 +1,143 @@
+//! Background hard-purge of grace-expired vault tombstones.
+//!
+//! Both the password vault (`vault:` → [`StoredVaultEntry`]) and the
+//! credential store (`cred:` → [`StoredCredential`]) soft-delete to a
+//! `Deleted` tombstone carrying a `grace_until` deadline. This sweeper — run
+//! from the storage thread's interval loop alongside the ACL/consent sweepers
+//! — hard-purges any tombstone whose grace window has elapsed: the password
+//! entry's secret is zeroised by the keyspace `remove`, and a credential's
+//! secondary index is torn down by [`crate::vault::storage::delete`].
+//!
+//! Each purge is audited as `vault.purge` / `vault.cred.purge` (actor
+//! `system:sweeper`, outcome `success:grace-expired`) — the same trail shape
+//! the ACL and consent sweepers leave. Audit-record failures are warn-logged
+//! but never abort the sweep.
+
+use tracing::{debug, info, warn};
+
+use vti_common::vault::{StoredVaultEntry, VaultStatus, delete_vault_entry};
+
+use crate::error::AppError;
+use crate::store::KeyspaceHandle;
+use crate::vault::model::StoredCredential;
+use crate::vault::storage as cred_storage;
+
+/// Sweep the shared `vault` keyspace, hard-purging every soft-deleted password
+/// entry and credential whose grace window has elapsed.
+pub async fn sweep_expired(
+    vault_ks: &KeyspaceHandle,
+    audit_ks: &KeyspaceHandle,
+) -> Result<(), AppError> {
+    let now = chrono::Utc::now().to_rfc3339();
+    let mut purged = 0usize;
+
+    // Password-vault tombstones (`vault:` records).
+    for (_key, value) in vault_ks.prefix_iter_raw("vault:").await? {
+        let stored: StoredVaultEntry = match serde_json::from_slice(&value) {
+            Ok(s) => s,
+            Err(e) => {
+                debug!(error = %e, "vault sweeper: skipping unreadable vault row");
+                continue;
+            }
+        };
+        if is_purgeable(
+            stored.entry.status,
+            stored.entry.grace_until.as_deref(),
+            &now,
+        ) {
+            delete_vault_entry(vault_ks, &stored.entry.id).await?;
+            purged += 1;
+            audit_purge(
+                audit_ks,
+                "vault.purge",
+                &stored.entry.id,
+                Some(stored.entry.context_id.as_str()),
+            )
+            .await;
+        }
+    }
+
+    // Credential-store tombstones (`cred:` records). `cred_storage::delete`
+    // removes the record AND its secondary-index rows.
+    for (_key, value) in vault_ks.prefix_iter_raw("cred:").await? {
+        let cred: StoredCredential = match serde_json::from_slice(&value) {
+            Ok(c) => c,
+            Err(e) => {
+                debug!(error = %e, "vault sweeper: skipping unreadable cred row");
+                continue;
+            }
+        };
+        if is_purgeable(cred.lifecycle, cred.grace_until.as_deref(), &now) {
+            cred_storage::delete(vault_ks, &cred.id).await?;
+            purged += 1;
+            audit_purge(
+                audit_ks,
+                "vault.cred.purge",
+                &cred.id,
+                cred.community_did.as_deref(),
+            )
+            .await;
+        }
+    }
+
+    if purged > 0 {
+        info!(
+            vault_purged = purged,
+            "vault sweeper purged grace-expired tombstones"
+        );
+    }
+    Ok(())
+}
+
+/// A tombstone is purgeable once it is `Deleted` and `now >= grace_until`.
+/// Lexical RFC 3339 comparison, consistent with the rest of the vault layer.
+fn is_purgeable(status: VaultStatus, grace_until: Option<&str>, now: &str) -> bool {
+    matches!(status, VaultStatus::Deleted) && grace_until.is_some_and(|g| now >= g)
+}
+
+async fn audit_purge(audit_ks: &KeyspaceHandle, action: &str, id: &str, context_id: Option<&str>) {
+    if let Err(e) = crate::audit::record(
+        audit_ks,
+        action,
+        "system:sweeper",
+        Some(id),
+        "success:grace-expired",
+        None,
+        context_id,
+    )
+    .await
+    {
+        warn!(error = %e, action, "vault sweeper: purge succeeded but audit::record failed");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn purgeable_only_when_deleted_and_past_grace() {
+        let now = "2026-06-18T12:00:00+00:00";
+        // Active / archived are never purged regardless of any stray grace.
+        assert!(!is_purgeable(VaultStatus::Active, None, now));
+        assert!(!is_purgeable(
+            VaultStatus::Archived,
+            Some("2020-01-01T00:00:00+00:00"),
+            now
+        ));
+        // Deleted but still inside the window → keep.
+        assert!(!is_purgeable(
+            VaultStatus::Deleted,
+            Some("2026-07-18T12:00:00+00:00"),
+            now
+        ));
+        // Deleted and past the window → purge.
+        assert!(is_purgeable(
+            VaultStatus::Deleted,
+            Some("2026-06-01T00:00:00+00:00"),
+            now
+        ));
+        // Deleted with no grace recorded → not purgeable (defensive).
+        assert!(!is_purgeable(VaultStatus::Deleted, None, now));
+    }
+}

--- a/vta-service/tests/vault_present.rs
+++ b/vta-service/tests/vault_present.rs
@@ -171,6 +171,10 @@ async fn mint_and_put(
         source: None,
         tags: Default::default(),
         body: compact.into_bytes(),
+        lifecycle: vti_common::vault::VaultStatus::Active,
+        archived_at: None,
+        deleted_at: None,
+        grace_until: None,
     };
     storage::put(vault, &cred).await.expect("put");
 }

--- a/vta-service/tests/vault_trust_task.rs
+++ b/vta-service/tests/vault_trust_task.rs
@@ -31,7 +31,8 @@ use tower::ServiceExt;
 use vta_service::test_support::{TestAppContext, build_test_app};
 use vti_common::auth::session::{Session, SessionState, now_epoch, store_session};
 use vti_common::vault::{
-    SecretKind, SiteTarget, StoredVaultEntry, VaultEntry, VaultSecret, put_stored_vault_entry,
+    SecretKind, SiteTarget, StoredVaultEntry, VaultEntry, VaultSecret, VaultStatus,
+    put_stored_vault_entry,
 };
 
 // URIs (kept as literals so a constant rename in the SDK surfaces here too).
@@ -39,6 +40,10 @@ const LIST: &str = "https://trusttasks.org/spec/vault/list/0.1";
 const GET: &str = "https://trusttasks.org/spec/vault/get/0.1";
 const UPSERT: &str = "https://trusttasks.org/spec/vault/upsert/0.1";
 const DELETE: &str = "https://trusttasks.org/spec/vault/delete/0.1";
+const ARCHIVE: &str = "https://trusttasks.org/spec/vault/archive/0.1";
+const UNARCHIVE: &str = "https://trusttasks.org/spec/vault/unarchive/0.1";
+const RESTORE: &str = "https://trusttasks.org/spec/vault/restore/0.1";
+const PURGE: &str = "https://trusttasks.org/spec/vault/purge/0.1";
 const RELEASE: &str = "https://trusttasks.org/spec/vault/release/0.1";
 const PROXY_LOGIN: &str = "https://trusttasks.org/spec/vault/proxy-login/0.1";
 const SIGN_TT: &str = "https://trusttasks.org/spec/vault/sign-trust-task/0.1";
@@ -135,6 +140,10 @@ async fn seed_entry(ctx: &TestAppContext, id: &str, context_id: &str) {
             last_used_at: None,
             version: 1,
             principal_did: None,
+            status: VaultStatus::Active,
+            archived_at: None,
+            deleted_at: None,
+            grace_until: None,
         },
         secret: VaultSecret::Password {
             username: Some("alice".to_string()),
@@ -165,6 +174,10 @@ async fn every_vault_uri_denied_without_capability() {
             json!({ "contextId": "ctx1", "targets": [], "label": "x", "secretKind": "password" }),
         ),
         (DELETE, json!({ "id": "entry-1" })),
+        (ARCHIVE, json!({ "id": "entry-1" })),
+        (UNARCHIVE, json!({ "id": "entry-1" })),
+        (RESTORE, json!({ "id": "entry-1" })),
+        (PURGE, json!({ "id": "entry-1" })),
         (RELEASE, json!({ "entryId": "entry-1" })),
         (PROXY_LOGIN, json!({ "entryId": "entry-1" })),
         (
@@ -209,6 +222,10 @@ async fn reader_passes_read_gates_but_not_the_others() {
             json!({ "contextId": "ctx1", "targets": [], "label": "x", "secretKind": "password" }),
         ),
         (DELETE, json!({ "id": "entry-1" })),
+        (ARCHIVE, json!({ "id": "entry-1" })),
+        (UNARCHIVE, json!({ "id": "entry-1" })),
+        (RESTORE, json!({ "id": "entry-1" })),
+        (PURGE, json!({ "id": "entry-1" })),
         (RELEASE, json!({ "entryId": "entry-1" })),
         (PROXY_LOGIN, json!({ "entryId": "entry-1" })),
         (
@@ -255,21 +272,154 @@ async fn get_happy_path_returns_entry_metadata() {
 }
 
 #[tokio::test]
-async fn delete_happy_path_removes_entry() {
+async fn delete_is_recoverable_soft_delete() {
     let (router, ctx) = build_test_app().await;
     seed_entry(&ctx, "entry-c", "ctx1").await;
     let token = authed(&ctx, "admin", &[]).await;
 
+    // Soft delete → tombstone with a real grace window (graceUntil > deletedAt).
     let (status, body) = post_vault(&router, &token, DELETE, json!({ "id": "entry-c" })).await;
     assert_eq!(status, StatusCode::OK, "{body}");
+    let v: Value = serde_json::from_str(&body).unwrap();
+    let deleted_at = v["payload"]["deletedAt"].as_str().unwrap();
+    let grace_until = v["payload"]["graceUntil"].as_str().unwrap();
+    assert!(
+        grace_until > deleted_at,
+        "soft delete has a real grace window: {body}"
+    );
 
-    // A subsequent get is now not-found (conflated with permission-denied).
-    let (get_status, _) = post_vault(&router, &token, GET, json!({ "id": "entry-c" })).await;
-    assert_ne!(
+    // The entry is still retrievable (status=deleted), restorable...
+    let (get_status, get_body) = post_vault(&router, &token, GET, json!({ "id": "entry-c" })).await;
+    assert_eq!(
         get_status,
         StatusCode::OK,
-        "entry should be gone after delete"
+        "tombstone is still gettable: {get_body}"
     );
+    let g: Value = serde_json::from_str(&get_body).unwrap();
+    assert_eq!(g["payload"]["entry"]["status"], "deleted", "{get_body}");
+
+    // ...but excluded from the default (active-only) list.
+    let (_, list_body) = post_vault(&router, &token, LIST, json!({})).await;
+    assert!(
+        !list_body.contains("entry-c"),
+        "default list hides tombstones: {list_body}"
+    );
+    // ...and visible under the trash view.
+    let (_, trash_body) = post_vault(&router, &token, LIST, json!({ "status": "deleted" })).await;
+    assert!(
+        trash_body.contains("entry-c"),
+        "trash view shows tombstones: {trash_body}"
+    );
+
+    // Restore brings it back to active.
+    let (rs, rb) = post_vault(&router, &token, RESTORE, json!({ "id": "entry-c" })).await;
+    assert_eq!(rs, StatusCode::OK, "{rb}");
+    let (_, list2) = post_vault(&router, &token, LIST, json!({})).await;
+    assert!(
+        list2.contains("entry-c"),
+        "restored entry is active again: {list2}"
+    );
+}
+
+#[tokio::test]
+async fn delete_force_hard_deletes_immediately() {
+    let (router, ctx) = build_test_app().await;
+    seed_entry(&ctx, "entry-f", "ctx1").await;
+    let token = authed(&ctx, "admin", &[]).await;
+
+    let (status, body) = post_vault(
+        &router,
+        &token,
+        DELETE,
+        json!({ "id": "entry-f", "force": true }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    // Forced delete is gone for good — no grace window, not gettable.
+    let v: Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(
+        v["payload"]["graceUntil"], v["payload"]["deletedAt"],
+        "forced → no grace window"
+    );
+    let (get_status, _) = post_vault(&router, &token, GET, json!({ "id": "entry-f" })).await;
+    assert_ne!(get_status, StatusCode::OK, "force-deleted entry is gone");
+}
+
+#[tokio::test]
+async fn archive_hides_and_blocks_then_unarchive_restores() {
+    let (router, ctx) = build_test_app().await;
+    seed_entry(&ctx, "entry-a", "ctx1").await;
+    let token = authed(&ctx, "admin", &[]).await;
+
+    // Archive → dropped from default list, refused for release.
+    let (status, body) = post_vault(&router, &token, ARCHIVE, json!({ "id": "entry-a" })).await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    let (_, list_body) = post_vault(&router, &token, LIST, json!({})).await;
+    assert!(
+        !list_body.contains("entry-a"),
+        "archived entry hidden from default list"
+    );
+    let (rel_status, _) =
+        post_vault(&router, &token, RELEASE, json!({ "entryId": "entry-a" })).await;
+    assert_ne!(
+        rel_status,
+        StatusCode::OK,
+        "archived entry refuses release (not_found)"
+    );
+
+    // Double-archive is rejected.
+    let (again, again_body) =
+        post_vault(&router, &token, ARCHIVE, json!({ "id": "entry-a" })).await;
+    assert_ne!(
+        again,
+        StatusCode::OK,
+        "double-archive rejected: {again_body}"
+    );
+
+    // Unarchive returns it to active + listable.
+    let (us, ub) = post_vault(&router, &token, UNARCHIVE, json!({ "id": "entry-a" })).await;
+    assert_eq!(us, StatusCode::OK, "{ub}");
+    let (_, list2) = post_vault(&router, &token, LIST, json!({})).await;
+    assert!(
+        list2.contains("entry-a"),
+        "unarchived entry is active again"
+    );
+}
+
+#[tokio::test]
+async fn purge_is_irreversible() {
+    let (router, ctx) = build_test_app().await;
+    seed_entry(&ctx, "entry-p", "ctx1").await;
+    let token = authed(&ctx, "admin", &[]).await;
+
+    // Soft-delete then purge the tombstone.
+    let (_, _) = post_vault(&router, &token, DELETE, json!({ "id": "entry-p" })).await;
+    let (ps, pb) = post_vault(&router, &token, PURGE, json!({ "id": "entry-p" })).await;
+    assert_eq!(ps, StatusCode::OK, "{pb}");
+    // Gone from every view.
+    let (get_status, _) = post_vault(&router, &token, GET, json!({ "id": "entry-p" })).await;
+    assert_ne!(get_status, StatusCode::OK, "purged entry is gone");
+    let (_, trash_body) = post_vault(&router, &token, LIST, json!({ "status": "deleted" })).await;
+    assert!(
+        !trash_body.contains("entry-p"),
+        "purged entry gone from trash too"
+    );
+}
+
+#[tokio::test]
+async fn restore_of_active_entry_is_rejected() {
+    let (router, ctx) = build_test_app().await;
+    seed_entry(&ctx, "entry-r", "ctx1").await;
+    let token = authed(&ctx, "admin", &[]).await;
+
+    // Restoring an entry that was never deleted is a no-op error.
+    let (status, body) = post_vault(&router, &token, RESTORE, json!({ "id": "entry-r" })).await;
+    assert_ne!(
+        status,
+        StatusCode::OK,
+        "restore of an active entry is rejected: {body}"
+    );
+    assert!(body.contains("not_deleted"), "{body}");
 }
 
 // ── cross-context-denied ──

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.9.8"
+version = "0.9.9"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -80,7 +80,7 @@ name = "vtc"
 path = "src/main.rs"
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.10", features = [
+vti-common = { path = "../vti-common", version = "0.11", features = [
   "passkey",
   # `setup` gates the shared dialoguer-driven secrets-prompt helper
   # the wizard calls into.
@@ -97,7 +97,7 @@ vti-common = { path = "../vti-common", version = "0.10", features = [
 # factory + `*SecretStore` names are a thin facade over these). Per-backend
 # features are activated by this crate's matching features above.
 vti-secrets = { path = "../vti-secrets", version = "0.1" }
-vta-sdk = { path = "../vta-sdk", version = "0.17", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.18", features = [
   "didcomm",
   "session",
   "config-session",

--- a/vti-common/Cargo.toml
+++ b/vti-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-common"
 description = "Shared server-side infrastructure for VTA and VTC services"
 readme = "README.md"
-version = "0.10.8"
+version = "0.11.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -48,7 +48,7 @@ openapi = ["dep:utoipa", "dep:utoipa-axum"]
 # `default-features = false` skips the optional client transports
 # (didcomm, sealed-transfer, etc.); we only consume the type
 # definitions in the default feature set.
-vta-sdk = { path = "../vta-sdk", version = "0.17", default-features = false }
+vta-sdk = { path = "../vta-sdk", version = "0.18", default-features = false }
 async-trait = "0.1"
 axum = { workspace = true }
 axum-extra = { workspace = true }

--- a/vti-common/src/acl/mod.rs
+++ b/vti-common/src/acl/mod.rs
@@ -134,6 +134,14 @@ pub enum Capability {
     /// operators grant proxy-login without sign-trust-task to limit
     /// blast radius on Service consumers (AI agents, etc.).
     SignTrustTask,
+    /// Mutating the **archival lifecycle** of a stored credential — the
+    /// `vault/credentials/{archive,unarchive,delete,restore,purge}/0.1`
+    /// tasks. Distinct from `VaultWrite` (which gates `vault/credentials/
+    /// receive` and the password-vault writes) so an operator can grant a
+    /// consumer the ability to *receive* credentials without the ability to
+    /// *remove* them — removal of a holder's credentials is a higher-trust
+    /// action. Granted to the same roles that hold `VaultWrite`.
+    CredentialWrite,
 }
 
 /// Returns true if `role` is granted `cap` by the default capability
@@ -153,6 +161,7 @@ pub fn derived_capabilities_for_role(role: &Role) -> Vec<Capability> {
         Role::Admin => vec![
             Capability::VaultRead,
             Capability::VaultWrite,
+            Capability::CredentialWrite,
             Capability::ProxyLogin,
             Capability::FillRelease,
             Capability::PolicyAdmin,
@@ -164,6 +173,7 @@ pub fn derived_capabilities_for_role(role: &Role) -> Vec<Capability> {
         Role::Initiator => vec![
             Capability::VaultRead,
             Capability::VaultWrite,
+            Capability::CredentialWrite,
             Capability::ProxyLogin,
             Capability::FillRelease,
             Capability::DeviceAdmin,

--- a/vti-common/src/config.rs
+++ b/vti-common/src/config.rs
@@ -99,6 +99,31 @@ impl Default for AuditConfig {
     }
 }
 
+/// Vault lifecycle tuning. Shared shape so both the VTA password vault and
+/// the VTA credential store read the same grace window.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VaultConfig {
+    /// Days a soft-deleted (tombstoned) vault entry or credential remains
+    /// recoverable before the sweeper hard-purges it. Applied at delete time
+    /// (`grace_until = now + grace_days`); the sweeper only compares against
+    /// the stored `grace_until`. Default 30. A `delete --force` / `purge`
+    /// bypasses the window entirely.
+    #[serde(default = "default_vault_grace_days")]
+    pub grace_days: u32,
+}
+
+fn default_vault_grace_days() -> u32 {
+    30
+}
+
+impl Default for VaultConfig {
+    fn default() -> Self {
+        Self {
+            grace_days: default_vault_grace_days(),
+        }
+    }
+}
+
 #[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum LogFormat {

--- a/vti-common/src/vault/mod.rs
+++ b/vti-common/src/vault/mod.rs
@@ -21,6 +21,43 @@ use serde::{Deserialize, Serialize};
 use crate::error::AppError;
 use crate::store::KeyspaceHandle;
 
+/// Lifecycle state of a vault entry (and, reused, of a stored credential).
+/// This is **archival** state — orthogonal to a credential's *validity*
+/// (`CredentialStatus`) and to a password entry's `breached_at`/`expires_at`.
+///
+/// - `Active` — the normal, usable state. Default for any record persisted
+///   before this field existed (`#[serde(default)]` → [`default_active`]).
+/// - `Archived` — hidden from default listing and refused for use
+///   (release / proxy-login / sign / present), but fully restorable.
+/// - `Deleted` — a recoverable tombstone: the row (and its secret) is
+///   retained but blocked from use, restorable until `grace_until`, after
+///   which the vault sweeper hard-purges it. `delete --force` / `purge`
+///   skip this state and erase immediately.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum VaultStatus {
+    #[default]
+    Active,
+    Archived,
+    Deleted,
+}
+
+impl VaultStatus {
+    /// `true` for the normal usable state — the only state from which a
+    /// secret may be released / a credential presented.
+    pub fn is_active(&self) -> bool {
+        matches!(self, VaultStatus::Active)
+    }
+}
+
+/// Serde default for the `status` field so records persisted before the
+/// lifecycle existed (which lack the key) deserialize as [`VaultStatus::Active`].
+/// Named rather than relying on `#[serde(default)]` + `Default` so the intent
+/// is explicit at the field.
+pub fn default_active() -> VaultStatus {
+    VaultStatus::Active
+}
+
 /// Public metadata view of a single vault entry. Direct wire-form match for
 /// the `VaultEntry` `$def` in the canonical Trust Task shared schema.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -88,6 +125,24 @@ pub struct VaultEntry {
     /// without releasing the secret.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub principal_did: Option<String>,
+    /// Archival lifecycle state. Absent on the wire for `Active` entries
+    /// (`skip_serializing_if`) and defaulted in for records written before
+    /// the lifecycle existed. See [`VaultStatus`].
+    #[serde(
+        default = "default_active",
+        skip_serializing_if = "VaultStatus::is_active"
+    )]
+    pub status: VaultStatus,
+    /// RFC 3339 timestamp the entry was archived (set iff `status == Archived`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub archived_at: Option<String>,
+    /// RFC 3339 timestamp the entry was (soft-)deleted (set iff `status == Deleted`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deleted_at: Option<String>,
+    /// RFC 3339 deadline after which the sweeper hard-purges a `Deleted`
+    /// entry. Restorable while `now < grace_until`. Set iff `status == Deleted`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub grace_until: Option<String>,
 }
 
 impl VaultEntry {
@@ -106,6 +161,113 @@ impl VaultEntry {
             | VaultSecret::BearerToken { .. }
             | VaultSecret::SshKey { .. }
             | VaultSecret::Custom { .. } => None,
+        }
+    }
+
+    /// Bump the optimistic-concurrency version + modification stamps. Every
+    /// lifecycle transition is a user-visible mutation, so it advances
+    /// `version` (the M5 sync seq baseline) and `updated_at`/`updated_by`.
+    fn bump_revision(&mut self, now: &str, actor: Option<&str>) {
+        self.version = self.version.saturating_add(1);
+        self.updated_at = now.to_string();
+        if let Some(a) = actor {
+            self.updated_by = Some(a.to_string());
+        }
+    }
+
+    /// `Active → Archived`. Refused (`NotActive`) for any other source state.
+    pub fn archive(&mut self, now: &str, actor: Option<&str>) -> Result<(), LifecycleError> {
+        if self.status != VaultStatus::Active {
+            return Err(LifecycleError::NotActive);
+        }
+        self.status = VaultStatus::Archived;
+        self.archived_at = Some(now.to_string());
+        self.bump_revision(now, actor);
+        Ok(())
+    }
+
+    /// `Archived → Active`. Refused (`NotArchived`) for any other source state.
+    pub fn unarchive(&mut self, now: &str, actor: Option<&str>) -> Result<(), LifecycleError> {
+        if self.status != VaultStatus::Archived {
+            return Err(LifecycleError::NotArchived);
+        }
+        self.status = VaultStatus::Active;
+        self.archived_at = None;
+        self.bump_revision(now, actor);
+        Ok(())
+    }
+
+    /// `Active|Archived → Deleted` (recoverable tombstone). `grace_until` is
+    /// the caller-computed `now + grace_days` deadline. Refused
+    /// (`AlreadyDeleted`) if the entry is already a tombstone — the operator
+    /// should `restore` or `purge` instead (a hard `delete --force` bypasses
+    /// this method entirely).
+    pub fn soft_delete(
+        &mut self,
+        now: &str,
+        grace_until: &str,
+        actor: Option<&str>,
+    ) -> Result<(), LifecycleError> {
+        if self.status == VaultStatus::Deleted {
+            return Err(LifecycleError::AlreadyDeleted);
+        }
+        self.status = VaultStatus::Deleted;
+        self.archived_at = None;
+        self.deleted_at = Some(now.to_string());
+        self.grace_until = Some(grace_until.to_string());
+        self.bump_revision(now, actor);
+        Ok(())
+    }
+
+    /// `Deleted → Active`, but only while still inside the grace window.
+    /// Refused `NotDeleted` if the entry isn't a tombstone, or `GraceExpired`
+    /// if `now >= grace_until` (the sweeper has purged it or is about to).
+    /// The `now >= grace_until` comparison is lexical over RFC 3339 strings —
+    /// consistent with the rest of this module's timestamp handling (both
+    /// stamps are produced by `chrono::Utc::now().to_rfc3339()`).
+    pub fn restore(&mut self, now: &str, actor: Option<&str>) -> Result<(), LifecycleError> {
+        if self.status != VaultStatus::Deleted {
+            return Err(LifecycleError::NotDeleted);
+        }
+        if let Some(grace) = self.grace_until.as_deref()
+            && now >= grace
+        {
+            return Err(LifecycleError::GraceExpired);
+        }
+        self.status = VaultStatus::Active;
+        self.deleted_at = None;
+        self.grace_until = None;
+        self.bump_revision(now, actor);
+        Ok(())
+    }
+}
+
+/// Why an archival-lifecycle transition on a [`VaultEntry`] (or stored
+/// credential) was refused. Handlers map each variant to a Trust-Task reject
+/// reason; `code()` gives the stable token used in those messages.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LifecycleError {
+    /// `archive` on an entry that isn't `Active`.
+    NotActive,
+    /// `unarchive` on an entry that isn't `Archived`.
+    NotArchived,
+    /// soft `delete` on an entry that is already a `Deleted` tombstone.
+    AlreadyDeleted,
+    /// `restore` on an entry that isn't a `Deleted` tombstone.
+    NotDeleted,
+    /// `restore` after the grace window elapsed.
+    GraceExpired,
+}
+
+impl LifecycleError {
+    /// Stable token embedded in handler reject messages (e.g. `not_active`).
+    pub fn code(&self) -> &'static str {
+        match self {
+            LifecycleError::NotActive => "not_active",
+            LifecycleError::NotArchived => "not_archived",
+            LifecycleError::AlreadyDeleted => "already_deleted",
+            LifecycleError::NotDeleted => "not_deleted",
+            LifecycleError::GraceExpired => "grace_expired",
         }
     }
 }
@@ -194,6 +356,28 @@ pub struct VaultListFilter<'a> {
     pub never_used: Option<bool>,
     pub expires_before: Option<&'a str>,
     pub breached: Option<bool>,
+    /// Archival-lifecycle filter. `None` (the default) returns only
+    /// [`VaultStatus::Active`] entries — archived and (soft-)deleted entries
+    /// are hidden from normal listing. Pass `Some(status)` to list a specific
+    /// state (e.g. the trash view via `Some(Deleted)`), or use
+    /// [`VaultListFilter::any_status`] to include every state.
+    pub status: Option<VaultStatus>,
+    /// When `true`, the `status` filter is ignored and entries of every
+    /// lifecycle state are returned (the explicit "show all" view). Defaults
+    /// to `false` so callers get the Active-only behaviour for free.
+    pub any_status: bool,
+}
+
+impl VaultListFilter<'_> {
+    /// The lifecycle state this filter selects, applying the Active-only
+    /// default. Returns `None` when every state is requested (`any_status`).
+    fn status_selector(&self) -> Option<VaultStatus> {
+        if self.any_status {
+            None
+        } else {
+            Some(self.status.unwrap_or(VaultStatus::Active))
+        }
+    }
 }
 
 /// Full record persisted in the `vault:` keyspace. `VaultEntry` is the
@@ -672,6 +856,13 @@ pub async fn list_vault_entries(
 }
 
 fn matches_filter(entry: &VaultEntry, filter: &VaultListFilter<'_>) -> bool {
+    // Archival lifecycle first: by default only Active entries are listed, so
+    // archived / soft-deleted entries never leak into a normal `vault/list`.
+    if let Some(want) = filter.status_selector()
+        && entry.status != want
+    {
+        return false;
+    }
     if let Some(ctx) = filter.context_id
         && entry.context_id != ctx
     {
@@ -780,6 +971,10 @@ mod tests {
             last_used_at: last_used.map(String::from),
             version: 1,
             principal_did: None,
+            status: VaultStatus::Active,
+            archived_at: None,
+            deleted_at: None,
+            grace_until: None,
         }
     }
 
@@ -1131,5 +1326,119 @@ mod tests {
                 s.kind()
             );
         }
+    }
+
+    #[test]
+    fn entry_without_status_field_deserialises_as_active() {
+        // Back-compat: a record persisted before the lifecycle existed has no
+        // `status`/`archivedAt`/`deletedAt`/`graceUntil` keys. It MUST default
+        // to Active so existing vaults keep working after upgrade.
+        let legacy = r#"{
+            "id":"v1","contextId":"ctx","targets":[],"label":"x",
+            "secretKind":"password","createdAt":"2026-01-01T00:00:00Z",
+            "updatedAt":"2026-01-01T00:00:00Z","version":1
+        }"#;
+        let entry: VaultEntry = serde_json::from_str(legacy).expect("parse legacy");
+        assert_eq!(entry.status, VaultStatus::Active);
+        assert!(entry.archived_at.is_none());
+        assert!(entry.deleted_at.is_none());
+        assert!(entry.grace_until.is_none());
+        // And an Active entry re-emits WITHOUT the status keys (wire stays clean).
+        let re = serde_json::to_string(&entry).unwrap();
+        assert!(
+            !re.contains("status"),
+            "active entry must not emit status; got {re}"
+        );
+    }
+
+    #[test]
+    fn list_filter_excludes_non_active_by_default() {
+        let active = sample("a", "ctx", None);
+        let mut archived = sample("b", "ctx", None);
+        archived.status = VaultStatus::Archived;
+        let mut deleted = sample("c", "ctx", None);
+        deleted.status = VaultStatus::Deleted;
+
+        // Default filter → Active only.
+        let f = VaultListFilter::default();
+        assert!(matches_filter(&active, &f));
+        assert!(!matches_filter(&archived, &f));
+        assert!(!matches_filter(&deleted, &f));
+
+        // Explicit status selects exactly that state.
+        let f = VaultListFilter {
+            status: Some(VaultStatus::Deleted),
+            ..Default::default()
+        };
+        assert!(!matches_filter(&active, &f));
+        assert!(matches_filter(&deleted, &f));
+
+        // any_status returns everything.
+        let f = VaultListFilter {
+            any_status: true,
+            ..Default::default()
+        };
+        assert!(matches_filter(&active, &f));
+        assert!(matches_filter(&archived, &f));
+        assert!(matches_filter(&deleted, &f));
+    }
+
+    #[test]
+    fn lifecycle_transitions_follow_the_state_table() {
+        let t0 = "2026-06-18T10:00:00+00:00";
+        let t1 = "2026-06-18T11:00:00+00:00";
+        let grace = "2026-07-18T10:00:00+00:00";
+
+        // archive: Active → Archived, bumps version, stamps archived_at.
+        let mut e = sample("v", "ctx", None);
+        let v0 = e.version;
+        e.archive(t0, Some("did:key:op")).unwrap();
+        assert_eq!(e.status, VaultStatus::Archived);
+        assert_eq!(e.archived_at.as_deref(), Some(t0));
+        assert_eq!(e.version, v0 + 1);
+        assert_eq!(e.updated_by.as_deref(), Some("did:key:op"));
+        // double-archive refused.
+        assert_eq!(e.archive(t1, None), Err(LifecycleError::NotActive));
+        // unarchive: Archived → Active.
+        e.unarchive(t1, None).unwrap();
+        assert_eq!(e.status, VaultStatus::Active);
+        assert!(e.archived_at.is_none());
+        // unarchive of Active refused.
+        assert_eq!(e.unarchive(t1, None), Err(LifecycleError::NotArchived));
+
+        // soft delete: Active → Deleted with grace, restorable in-window.
+        let mut e = sample("v", "ctx", None);
+        e.soft_delete(t0, grace, None).unwrap();
+        assert_eq!(e.status, VaultStatus::Deleted);
+        assert_eq!(e.deleted_at.as_deref(), Some(t0));
+        assert_eq!(e.grace_until.as_deref(), Some(grace));
+        // re-delete refused.
+        assert_eq!(
+            e.soft_delete(t1, grace, None),
+            Err(LifecycleError::AlreadyDeleted)
+        );
+        // restore inside the window.
+        e.restore(t1, None).unwrap();
+        assert_eq!(e.status, VaultStatus::Active);
+        assert!(e.deleted_at.is_none() && e.grace_until.is_none());
+        // restore of a non-deleted entry refused.
+        assert_eq!(e.restore(t1, None), Err(LifecycleError::NotDeleted));
+
+        // restore AFTER grace is refused (the sweeper owns it now).
+        let mut e = sample("v", "ctx", None);
+        e.soft_delete(t0, grace, None).unwrap();
+        let after_grace = "2026-08-01T00:00:00+00:00";
+        assert_eq!(
+            e.restore(after_grace, None),
+            Err(LifecycleError::GraceExpired)
+        );
+        assert_eq!(e.status, VaultStatus::Deleted, "failed restore is a no-op");
+
+        // delete is reachable from Archived too (Archived → Deleted).
+        let mut e = sample("v", "ctx", None);
+        e.archive(t0, None).unwrap();
+        e.soft_delete(t1, grace, None).unwrap();
+        assert_eq!(e.status, VaultStatus::Deleted);
+        assert!(e.archived_at.is_none(), "archived_at cleared on delete");
     }
 }

--- a/vti-secrets/Cargo.toml
+++ b/vti-secrets/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-secrets"
 description = "Pluggable secret-store backends + integration onboarding flow for Verifiable Trust Infrastructure"
 readme = "README.md"
-version = "0.1.4"
+version = "0.1.5"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -47,14 +47,14 @@ onboarding = [
 ]
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.10" }
+vti-common = { path = "../vti-common", version = "0.11" }
 serde = { workspace = true }
 hex = { workspace = true }
 tracing = { workspace = true }
 tokio = { workspace = true }
 
 # Onboarding feature: the SDK session/auth state machine + local did:key mint.
-vta-sdk = { path = "../vta-sdk", version = "0.17", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.18", features = [
   "session",
 ], optional = true }
 ed25519-dalek = { workspace = true, optional = true }


### PR DESCRIPTION
## What & why

The VTA's two stores had weak removal stories: the **password vault** (`vault:`) had an irreversible hard `delete` masquerading as a grace-window delete, and the **credential store** (`cred:`) had **no operator-facing removal at all**. This adds a full archival lifecycle to both, plus complete audit coverage for vault operations.

## Lifecycle

- New `VaultStatus {Active,Archived,Deleted}` in `vti-common`, reused as an orthogonal `lifecycle` field on `StoredCredential` — separate from its `CredentialStatus` *validity* (`status::refresh_status` skips non-Active so a revocation refresh can't un-archive a tombstone).
- `vault/delete/0.1` is now a **recoverable soft delete** (tombstone + grace window via `VaultConfig.grace_days`, default 30); its body gains `force` for an immediate hard delete. New verbs:
  - **Password vault** (`VaultWrite`): `vault/{archive,unarchive,restore,purge}/0.1`
  - **Credential store** (new **`CredentialWrite`** capability — removing a holder's credentials is higher-trust than receiving them): `vault/credentials/{archive,unarchive,delete,restore,purge}/0.1`
- `vault_sweeper` (storage-thread interval, alongside acl/consent sweepers) hard-purges grace-expired tombstones in both stores; credential purge tears down the `idx:` secondary index via `vault::storage::delete`.

## Safety

- Non-Active entries drop out of list/query and are refused for use (release / proxy-login / sign / present), conflated to `not_found` for enumeration resistance.
- `upsert` refuses to overwrite a non-Active entry (would wipe lifecycle state); `restore` re-checks the grace window before writing.

## Audit

- **Every** vault Trust Task — read or write, success or denied — is audited **once at the dispatch spine** (`vault.*` / `vault.cred.*` actions). The operator `reason` lands in a new `AuditLogEntry.detail` (`audit::record_with_detail`).

## Operator surface

- SDK client methods for both stores.
- `pnm vault {archive,unarchive,restore,purge}`, `delete --force`, `list --status`.
- New **`pnm cred-vault`** namespace: `receive`/`query`/`get` + the credential lifecycle.
- Docs: workspace `CLAUDE.md` "Vault archival lifecycle" flow + `docs/05-design-notes/trust-task-uri-registry.md`.

## Compatibility

- New struct fields are `#[serde(default)]` — records persisted before the lifecycle deserialize as `Active` (covered by tests). Active entries re-emit without the new keys, so the wire form is unchanged for existing consumers.
- New `major.minor` version bumps: `vti-common` 0.11, `vta-sdk` 0.18, `vta-cli-common`/`vta-service`/`pnm-cli` 0.10, with patch bumps + pin updates across dependents.

## Testing

- `cargo build --workspace`, `cargo fmt --check`, and `cargo clippy` are clean.
- New unit + integration tests: back-compat deserialization, the full state-transition table, list/query lifecycle filtering, the sweeper, credential lifecycle, and wire-level capability/lifecycle behaviour. All vault/credential/SDK/CLI suites pass.

### Note (pre-existing, unrelated)

`cargo test --workspace` is blocked at compile time by `vtc-service` test helpers (`passkey_state`, `emergency_bootstrap`, …) whose `AppState` literals predate the `invitations_ks`/`consumed_invitations_ks` fields. This fails identically on `main` and is untouched here.