### PR TITLE
feat(vault): opt-in enumeration of archived/soft-deleted credentials in cred-vault query

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10111,7 +10111,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",

--- a/docs/05-design-notes/vti-credential-architecture.md
+++ b/docs/05-design-notes/vti-credential-architecture.md
@@ -539,7 +539,19 @@ The plugin is the consent + key + legibility surface:
 ## 14. Security & privacy invariants (do not relax)
 
 1. **No wallet enumeration across a trust boundary.** No endpoint returns
-   a holder's credential list. Discovery is DCQL-targeted only.
+   a holder's credential list. Discovery is DCQL-targeted only. The local
+   search primitive (`vault/credentials/query/0.1`) is **index-scan-driven,
+   not a `list_all`**: every query must name at least one indexed value, and
+   descriptors never carry the body. The archival-lifecycle opt-ins
+   `includeArchived` / `includeDeleted` (added for the holder's own
+   archive/restore/purge UX) do **not** weaken this — they are
+   `VaultRead`-gated, holder-scoped, and *modifiers* (they do not count toward
+   the ≥1-filter requirement), so they relax only the lifecycle post-filter on
+   an already-anchored scan. They surface archived / soft-deleted rows for
+   management-by-id; archived / soft-deleted credentials remain refused at
+   `get`/present, and a revoked/expired row stays excluded regardless
+   (invariant 5). This is a scoped relaxation of the post-filter, never a
+   cross-boundary list of the wallet.
 2. **Consent before disclosure.** The VTA never presents a credential
    without explicit, purpose-bound holder consent.
 3. **Claim minimisation.** Presentations disclose only the DCQL-requested

--- a/vta-sdk/src/client/vault.rs
+++ b/vta-sdk/src/client/vault.rs
@@ -257,6 +257,15 @@ impl VtaClient {
     /// Requires `VaultRead`. `filter` is a DCQL-shaped object (at least one of
     /// `type`, `communityDid`, `issuerDid`, `purpose`, `status`); an unfiltered
     /// query is refused. Returns `{ credentials: [descriptor] }`.
+    ///
+    /// By default only active credentials are returned. Two optional modifier
+    /// keys opt into the archival lifecycle for management UX (they are *not*
+    /// filters, so at least one real filter is still required):
+    /// `includeArchived` and `includeDeleted` (booleans, default `false`).
+    /// When set, archived / soft-deleted rows matching the filter are also
+    /// returned; each descriptor then carries `lifecycle`
+    /// (`active` | `archived` | `deleted`) alongside the existing validity
+    /// `status`, plus `archivedAt` / `deletedAt` / `graceUntil` as applicable.
     pub async fn cred_vault_query(&self, filter: Value) -> Result<Value, VtaError> {
         self.dispatch_trust_task(
             trust_tasks::TASK_VAULT_CREDENTIALS_QUERY_0_1,

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.10.0"
+version = "0.10.1"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/operations/credential_exchange.rs
+++ b/vta-service/src/operations/credential_exchange.rs
@@ -502,10 +502,10 @@ async fn gather_for_query(
                 vault,
                 &VaultQuery {
                     r#type: Some(type_value),
-                    community_did: None,
-                    issuer_did: None,
-                    purpose: None,
-                    status: None,
+                    // Presentation candidate search: active credentials only —
+                    // archived / soft-deleted rows must never be offered to a
+                    // verifier (the include_* opt-ins are management-only).
+                    ..Default::default()
                 },
             )
             .await?;

--- a/vta-service/src/vault/query.rs
+++ b/vta-service/src/vault/query.rs
@@ -40,6 +40,23 @@
 //! three properties; this module gives them only a targeted primitive to
 //! build on, never a firehose.
 //!
+//! ## Archival lifecycle is opt-in, and does not weaken any of the above
+//!
+//! By default search returns only `Active` credentials. The
+//! [`CredentialQuery::include_archived`] / [`CredentialQuery::include_deleted`]
+//! flags let the **holder** (this is a holder-scoped, `VaultRead`-gated
+//! surface — there is no cross-holder enumeration) additionally surface
+//! `Archived` / `Deleted` rows so a management UI can browse the archive,
+//! restore from trash, or purge. This is a **relaxation of the lifecycle
+//! post-filter only**, applied *after* the indexed match — all three
+//! no-enumeration properties stand: at least one real filter is still
+//! required (the include flags are modifiers, not filters, so
+//! `{ includeArchived: true }` alone is still refused), the scan is still
+//! anchored on a named indexed value, and descriptors still never carry the
+//! body. Archived / soft-deleted credentials remain refused at `get` /
+//! present regardless of the flags — surfacing them here only enables
+//! management-by-id, never presentation.
+//!
 //! ## Revoked / expired credentials are never surfaced (§14 invariant 5)
 //!
 //! Search **unconditionally excludes** any matched credential whose
@@ -57,6 +74,7 @@
 
 use vti_common::error::AppError;
 use vti_common::store::KeyspaceHandle;
+use vti_common::vault::{VaultStatus, default_active};
 
 use super::model::{CredentialPurpose, CredentialStatus, IndexField, StoredCredential};
 
@@ -81,14 +99,43 @@ pub struct CredentialDescriptor {
     /// Semantic purpose (invite / membership / role / …), when known.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub purpose: Option<CredentialPurpose>,
-    /// Lifecycle status (valid / expired / revoked / unknown).
+    /// Validity status (valid / expired / revoked / unknown) — the
+    /// status-list-driven dimension. **Orthogonal** to [`Self::lifecycle`]
+    /// below: a credential can be `valid` *and* `archived`.
     pub status: CredentialStatus,
+    /// **Archival** lifecycle state (active / archived / deleted) —
+    /// orthogonal to [`Self::status`] (validity). Lets a management UI
+    /// categorise a row and decide which lifecycle verb applies
+    /// (unarchive / restore / purge). Omitted (and defaulted back to
+    /// `active` on read) for active credentials, so active-only query
+    /// results — the only ones returned without `include_archived` /
+    /// `include_deleted` — are byte-for-byte unchanged from before this
+    /// field existed; present only on the archived / deleted rows that the
+    /// opt-in flags surface.
+    #[serde(
+        default = "default_active",
+        skip_serializing_if = "VaultStatus::is_active"
+    )]
+    pub lifecycle: VaultStatus,
     /// RFC 3339 validity-window start, when the envelope declares one.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub valid_from: Option<String>,
     /// RFC 3339 validity-window end, when the envelope declares one.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub valid_until: Option<String>,
+    /// RFC 3339 — when the credential was archived. Set iff
+    /// `lifecycle == archived`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub archived_at: Option<String>,
+    /// RFC 3339 — when the credential was soft-deleted (moved to trash). Set
+    /// iff `lifecycle == deleted`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deleted_at: Option<String>,
+    /// RFC 3339 purge deadline for a soft-deleted credential — restorable
+    /// while `now < grace_until`, hard-purged by the sweeper afterwards. Set
+    /// iff `lifecycle == deleted`; lets a trash UI show "purges in N days".
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub grace_until: Option<String>,
 }
 
 impl CredentialDescriptor {
@@ -103,8 +150,15 @@ impl CredentialDescriptor {
             issuer_did: cred.issuer_did.clone(),
             purpose: cred.purpose.clone(),
             status: cred.status,
+            lifecycle: cred.lifecycle,
             valid_from: cred.valid_from.clone(),
             valid_until: cred.valid_until.clone(),
+            // The soft-delete `reason` is intentionally *not* surfaced: it is
+            // never persisted on the record (it lands only in the audit row's
+            // `detail` at the dispatch spine), so there is nothing to project.
+            archived_at: cred.archived_at.clone(),
+            deleted_at: cred.deleted_at.clone(),
+            grace_until: cred.grace_until.clone(),
         }
     }
 }
@@ -134,9 +188,24 @@ pub struct CredentialQuery {
     /// Match credentials with this semantic purpose.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub purpose: Option<CredentialPurpose>,
-    /// Match credentials with this lifecycle status.
+    /// Match credentials with this validity status.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub status: Option<CredentialStatus>,
+    /// Opt-in: also return **archived** credentials (default `false`). This is
+    /// a *modifier*, not a filter — it does not count toward the ≥1-filter
+    /// requirement, so `{ includeArchived: true }` alone is still refused as
+    /// an enumeration. With it set, the lifecycle post-filter additionally
+    /// admits `Archived` rows that match the indexed filter(s); the scan is
+    /// still index-driven (archive does not touch the indexed fields, so the
+    /// rows are still reachable).
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub include_archived: bool,
+    /// Opt-in: also return **soft-deleted** (tombstoned) credentials, so a
+    /// trash UI can list them to restore or purge (default `false`). Same
+    /// modifier semantics as [`Self::include_archived`]: not a filter, and
+    /// still index-driven.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub include_deleted: bool,
 }
 
 impl CredentialQuery {
@@ -205,6 +274,12 @@ fn matches_constraint(cred: &StoredCredential, field: IndexField, value: &str) -
 /// already known to match one indexed value; the remaining constraints are
 /// applied as in-memory predicates. Bodies are loaded only to evaluate those
 /// predicates and are **never** placed in the returned descriptors.
+///
+/// By default only `Active` credentials are returned. Set
+/// [`CredentialQuery::include_archived`] / [`CredentialQuery::include_deleted`]
+/// to additionally surface archived / soft-deleted rows for management UX;
+/// these are modifiers, not filters, so they do not satisfy the
+/// at-least-one-filter requirement on their own.
 pub async fn search(
     vault: &KeyspaceHandle,
     query: &CredentialQuery,
@@ -230,11 +305,20 @@ pub async fn search(
 
     let mut out = Vec::new();
     for cred in &candidates {
-        // Archival lifecycle: an archived or soft-deleted credential is hidden
-        // from search the same way revoked/expired ones are — it's not a
-        // candidate to present. (The status index still lists it; the
-        // exclusion is applied here, after the indexed match.)
-        if !cred.is_active() {
+        // Archival lifecycle gate, applied here (after the indexed match): an
+        // archived / soft-deleted credential is hidden by default — it's not a
+        // candidate to present — but the holder can opt into seeing it for
+        // management (browse archive, restore-from-trash, purge) via
+        // `include_archived` / `include_deleted`. The status index still lists
+        // it regardless (archive/soft-delete don't touch the indexed fields),
+        // so the opt-in is a relaxation of *this* post-filter, never a new
+        // scan or a return-all path.
+        let lifecycle_admitted = match cred.lifecycle {
+            VaultStatus::Active => true,
+            VaultStatus::Archived => query.include_archived,
+            VaultStatus::Deleted => query.include_deleted,
+        };
+        if !lifecycle_admitted {
             continue;
         }
         // §14 invariant 5: a revoked (or expired) credential is never a search result,
@@ -257,11 +341,18 @@ pub async fn search(
     Ok(out)
 }
 
-/// `true` for the lifecycle states that must never appear in a search result
-/// (§14 invariant 5). A [`CredentialStatus::Revoked`] credential is unpresentable, and an
-/// [`CredentialStatus::Expired`] one is past its validity window — neither is a
-/// candidate the holder's agent should offer. [`CredentialStatus::Valid`] and
-/// [`CredentialStatus::Unknown`] are surfaced.
+/// `true` for the **validity** states that must never appear in a search
+/// result (§14 invariant 5). A [`CredentialStatus::Revoked`] credential is
+/// unpresentable, and an [`CredentialStatus::Expired`] one is past its
+/// validity window — neither is a candidate the holder's agent should offer.
+/// [`CredentialStatus::Valid`] and [`CredentialStatus::Unknown`] are surfaced.
+///
+/// This exclusion is **orthogonal to the archival lifecycle** and is *not*
+/// relaxed by `include_archived` / `include_deleted`: those flags admit
+/// `Archived` / `Deleted` rows, but a row that is *also* revoked/expired stays
+/// excluded (§14 invariant 5 is load-bearing for the present path and is not in
+/// scope of the management opt-in). Such a credential is still reachable for
+/// management by its id (unarchive / restore / purge take an id, not a query).
 fn is_excluded_status(status: CredentialStatus) -> bool {
     matches!(
         status,
@@ -540,5 +631,177 @@ mod tests {
             ..Default::default()
         };
         assert!(search(&vault, &q).await.unwrap().is_empty());
+    }
+
+    /// By default an archived credential is hidden; `include_archived` opts it
+    /// back in, and the descriptor then carries `lifecycle = archived` plus
+    /// `archived_at`. An active sibling is returned in both cases.
+    #[tokio::test]
+    async fn include_archived_surfaces_archived_rows() {
+        let (_dir, _store, vault) = fresh_vault();
+        let active = sample("cred-active");
+        let mut archived = sample("cred-archived");
+        archived.archive("2026-06-18T10:00:00+00:00").unwrap();
+        put(&vault, &active).await.unwrap();
+        put(&vault, &archived).await.unwrap();
+
+        // Default (active-only): only the active credential, even though both
+        // share the community index row.
+        let base = CredentialQuery {
+            community_did: Some("did:web:acme".into()),
+            ..Default::default()
+        };
+        let hits = search(&vault, &base).await.unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].id, "cred-active");
+        // The active descriptor omits the lifecycle key (defaults to active).
+        assert_eq!(hits[0].lifecycle, VaultStatus::Active);
+
+        // Opt in → both, and the archived one is categorised + timestamped.
+        let q = CredentialQuery {
+            include_archived: true,
+            ..base.clone()
+        };
+        let mut hits = search(&vault, &q).await.unwrap();
+        hits.sort_by(|a, b| a.id.cmp(&b.id));
+        assert_eq!(hits.len(), 2);
+        let arch = hits.iter().find(|d| d.id == "cred-archived").unwrap();
+        assert_eq!(arch.lifecycle, VaultStatus::Archived);
+        assert_eq!(
+            arch.archived_at.as_deref(),
+            Some("2026-06-18T10:00:00+00:00")
+        );
+        assert!(arch.deleted_at.is_none() && arch.grace_until.is_none());
+
+        // include_deleted does NOT pull in an archived row.
+        let q = CredentialQuery {
+            include_deleted: true,
+            ..base
+        };
+        let hits = search(&vault, &q).await.unwrap();
+        assert_eq!(hits.len(), 1, "include_deleted must not surface archived");
+        assert_eq!(hits[0].id, "cred-active");
+    }
+
+    /// `include_deleted` surfaces a soft-delete tombstone for restore/purge UX,
+    /// exposing `lifecycle = deleted`, `deleted_at`, and the `grace_until`
+    /// purge deadline.
+    #[tokio::test]
+    async fn include_deleted_surfaces_tombstones_with_grace() {
+        let (_dir, _store, vault) = fresh_vault();
+        let mut deleted = sample("cred-trash");
+        deleted
+            .soft_delete("2026-06-18T10:00:00+00:00", "2026-07-18T10:00:00+00:00")
+            .unwrap();
+        put(&vault, &deleted).await.unwrap();
+
+        // Hidden by default and from include_archived.
+        let base = CredentialQuery {
+            purpose: Some(CredentialPurpose::Invite),
+            ..Default::default()
+        };
+        assert!(search(&vault, &base).await.unwrap().is_empty());
+        let q = CredentialQuery {
+            include_archived: true,
+            ..base.clone()
+        };
+        assert!(
+            search(&vault, &q).await.unwrap().is_empty(),
+            "include_archived must not surface a tombstone"
+        );
+
+        // Opt in → returned, fully categorised.
+        let q = CredentialQuery {
+            include_deleted: true,
+            ..base
+        };
+        let hits = search(&vault, &q).await.unwrap();
+        assert_eq!(hits.len(), 1);
+        let d = &hits[0];
+        assert_eq!(d.lifecycle, VaultStatus::Deleted);
+        assert_eq!(d.deleted_at.as_deref(), Some("2026-06-18T10:00:00+00:00"));
+        assert_eq!(d.grace_until.as_deref(), Some("2026-07-18T10:00:00+00:00"));
+        assert!(d.archived_at.is_none());
+    }
+
+    /// The include flags are modifiers, not filters: an otherwise-empty query
+    /// is still refused (no-enumeration), so they can never become a
+    /// return-all path.
+    #[tokio::test]
+    async fn include_flags_alone_are_not_a_filter() {
+        let (_dir, _store, vault) = fresh_vault();
+        let mut archived = sample("cred-archived");
+        archived.archive("2026-06-18T10:00:00+00:00").unwrap();
+        put(&vault, &archived).await.unwrap();
+
+        for q in [
+            CredentialQuery {
+                include_archived: true,
+                ..Default::default()
+            },
+            CredentialQuery {
+                include_deleted: true,
+                ..Default::default()
+            },
+            CredentialQuery {
+                include_archived: true,
+                include_deleted: true,
+                ..Default::default()
+            },
+        ] {
+            assert!(q.is_empty(), "include flags must not count as a filter");
+            let err = search(&vault, &q).await.unwrap_err();
+            assert!(
+                matches!(err, AppError::Validation(_)),
+                "an include-only query must still be refused as enumeration"
+            );
+        }
+    }
+
+    /// §14 invariant 5 is orthogonal to the archival opt-in: a credential that
+    /// is *both* archived and revoked stays excluded even with
+    /// `include_archived`. (Manage it by id instead.)
+    #[tokio::test]
+    async fn revoked_archived_row_stays_excluded_even_with_include_archived() {
+        let (_dir, _store, vault) = fresh_vault();
+        let mut cred = sample("cred-archived-revoked");
+        cred.status = CredentialStatus::Revoked;
+        cred.archive("2026-06-18T10:00:00+00:00").unwrap();
+        put(&vault, &cred).await.unwrap();
+
+        let q = CredentialQuery {
+            community_did: Some("did:web:acme".into()),
+            include_archived: true,
+            include_deleted: true,
+            ..Default::default()
+        };
+        assert!(
+            search(&vault, &q).await.unwrap().is_empty(),
+            "a revoked credential is never surfaced by search, even when archived \
+             and explicitly included"
+        );
+    }
+
+    /// Active-only results are byte-for-byte unchanged: the descriptor JSON for
+    /// an active credential carries no `lifecycle` / `archivedAt` / `deletedAt`
+    /// / `graceUntil` keys.
+    #[tokio::test]
+    async fn active_descriptor_omits_lifecycle_keys() {
+        let (_dir, _store, vault) = fresh_vault();
+        put(&vault, &sample("cred-1")).await.unwrap();
+
+        let q = CredentialQuery {
+            issuer_did: Some("did:web:issuer.example".into()),
+            ..Default::default()
+        };
+        let hits = search(&vault, &q).await.unwrap();
+        assert_eq!(hits.len(), 1);
+        let json = serde_json::to_string(&hits[0]).unwrap();
+        for key in ["lifecycle", "archivedAt", "deletedAt", "graceUntil"] {
+            assert!(
+                !json.contains(key),
+                "an active descriptor must omit `{key}`: {json}"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

Closes the gap that blocked the OpenVTC holder-side credential-management surface (archive / restore / purge UX for Verifiable Invitation Credentials et al.): `vault/credentials/query/0.1` could not enumerate non-active credentials, so "browse archived", "restore from trash", and "purge" had nothing to populate, and the descriptor exposed only validity `status`, not the archival lifecycle state.

## Wire contract (as coordinated with OpenVTC)

**`CredentialQuery` — two new opt-in modifier keys (default `false`):**
- `includeArchived` — also return `Archived` rows matching the filter(s).
- `includeDeleted` — also return soft-deleted (tombstoned) rows, so they can be restored or purged.

They are **modifiers, not filters**: they do *not* satisfy the ≥1-filter requirement, so `{ "includeArchived": true }` alone is still refused as enumeration. With both `false`, query behaviour is byte-for-byte unchanged (active-only). The relaxation is applied to the lifecycle post-filter *after* the indexed match — still index-scan-driven, never a `list_all`.

**`CredentialDescriptor` — archival lifecycle exposed, distinct from validity `status`:**
- `lifecycle`: `active` | `archived` | `deleted` (omitted for `active`, so active descriptors are unchanged).
- `archivedAt` / `deletedAt` / `graceUntil` (RFC 3339), set per lifecycle state. `graceUntil` lets a trash UI show "purges in N days".
- The no-body invariant is preserved — descriptors still never carry the credential body.

## Confirmations for the OpenVTC side

- **Stable id across lifecycle transitions** — yes. The descriptor `id` is the primary key (`cred:<id>`); archive / soft-delete only flip `lifecycle`, never the id, so it is a valid handle for unarchive / restore / purge.
- **Purge semantics** — `purge` acts on an entry in **any** state (active / archived / deleted); it does not require a prior soft-delete. (`delete` is the recoverable soft path; `delete --force` and `purge` erase immediately.)
- **Capability/scope** — enumerating inactive entries stays `VaultRead`-gated and holder-scoped; no cross-holder enumeration.
- **Soft-delete `reason`** — **not surfaced**: it is never persisted on the record (it lands only in the audit row's `detail` at the dispatch spine), so there is nothing to project into the descriptor.
- **Revoked/expired** — **not** relaxed by the include flags. §14 invariant 5 (a revoked/expired credential is never surfaced by search) is orthogonal to the archival axis and load-bearing for the present path: a row that is *both* archived and revoked stays excluded. Manage it by id (the lifecycle verbs take an id, not a query). Flag this if you'd prefer the management view to surface revoked-and-archived rows too — that would be a deliberate, separate widening.
- **No SDK change required** — `cred_vault_query(filter: Value)` passes arbitrary JSON through unchanged; the new keys ride the existing free-form filter. (Doc comment updated for discoverability only.) The `pnm/cnm cred-vault query --filter-file` CLI already accepts arbitrary filter JSON, so the keys work there with no CLI change.

## Tests

Added to `vault::query`: include-archived surfacing + descriptor categorisation/timestamps; include-deleted tombstones with `graceUntil`; include-flags-alone still refused (no-enumeration); revoked+archived stays excluded even when included; active descriptor omits the lifecycle keys (byte-for-byte). Full vault suite (138) + credential_exchange (23) green; clippy clean.

## Version

`vta-service` 0.10.0 → **0.10.1** (additive; enclave's `"0.10"` pin still matches, no dependent churn).

## Docs

`docs/05-design-notes/vti-credential-architecture.md` §14 invariant 1 updated to record the holder-scoped, index-driven, opt-in relaxation (not a cross-boundary `list_all`).