### PR TITLE
chore(vta-sdk): bump 0.18.0 -> 0.18.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2441,7 +2441,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.18.0",
+ "vta-sdk 0.18.1",
 ]
 
 [[package]]
@@ -3211,7 +3211,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.18.0",
+ "vta-sdk 0.18.1",
 ]
 
 [[package]]
@@ -6698,7 +6698,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.18.0",
+ "vta-sdk 0.18.1",
 ]
 
 [[package]]
@@ -9964,7 +9964,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.18.0",
+ "vta-sdk 0.18.1",
  "vti-common",
  "x25519-dalek",
 ]
@@ -9997,7 +9997,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.18.0",
+ "vta-sdk 0.18.1",
 ]
 
 [[package]]
@@ -10020,7 +10020,7 @@ dependencies = [
  "tracing-subscriber",
  "trust-tasks-rs",
  "uniffi",
- "vta-sdk 0.18.0",
+ "vta-sdk 0.18.1",
 ]
 
 [[package]]
@@ -10055,7 +10055,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10186,7 +10186,7 @@ dependencies = [
  "utoipa-axum",
  "uuid",
  "vta-cli-common",
- "vta-sdk 0.18.0",
+ "vta-sdk 0.18.1",
  "vta-service",
  "vti-common",
  "vti-secrets",
@@ -10267,7 +10267,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.18.0",
+ "vta-sdk 0.18.1",
  "vtc-service",
  "vti-common",
  "vti-secrets",
@@ -10315,7 +10315,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.18.0",
+ "vta-sdk 0.18.1",
  "webauthn-rs",
  "zeroize",
 ]
@@ -10342,7 +10342,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.18.0",
+ "vta-sdk 0.18.1",
  "vta-service",
  "vti-common",
 ]
@@ -10371,7 +10371,7 @@ dependencies = [
  "tokio",
  "tracing",
  "vaultrs",
- "vta-sdk 0.18.0",
+ "vta-sdk 0.18.1",
  "vti-common",
 ]
 

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.18.0"
+version = "0.18.1"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true


### PR DESCRIPTION
## Why

#542 added a doc comment to `vta-sdk/src/client/vault.rs` (documenting the new `includeArchived` / `includeDeleted` query keys) but did **not** bump the `vta-sdk` version. Its source now differs from the published `0.18.0`, so `cargo publish` for `vta-sdk` is blocked / would ship altered content under an existing version.

## Fix

Patch-bump `vta-sdk` 0.18.0 → **0.18.1** (doc-only source change → patch is correct semver).

All workspace dependents pin `vta-sdk = { version = "0.18", ... }` (major.minor), so `0.18.1` still satisfies every requirement — **no dependent Cargo.toml edits needed**. `Cargo.lock` updated.

This unblocks publishing both `vta-sdk` 0.18.1 and `vta-service` 0.10.1.