### PR TITLE
fix(vtc): log the reason a DIDComm join-request is refused

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10200,7 +10200,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-service"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.10.0"
+version = "0.10.1"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vtc-service/src/messaging.rs
+++ b/vtc-service/src/messaging.rs
@@ -366,6 +366,30 @@ fn inbound_doc_bytes(message: &Message) -> Result<Vec<u8>, DIDCommServiceError> 
         .map_err(|e| DIDCommServiceError::Internal(format!("serialise inbound document: {e}")))
 }
 
+/// Pull the framework reject `code` + human-readable `message` out of a
+/// serialised `trust-task-error` document, for logging. The *reason* a Trust
+/// Task was refused lives in the error document's `payload` (not the HTTP
+/// status), so surfacing it at the dispatch boundary is what makes a refusal
+/// diagnosable. #539 made join refusals loud; #541 moved the reason into the
+/// document body without teaching the log to read it back out — this restores
+/// that visibility. Returns `("<unparseable>", None)` if the bytes aren't a
+/// recognisable error document.
+fn error_doc_summary(body: &[u8]) -> (String, Option<String>) {
+    let Ok(doc) = serde_json::from_slice::<serde_json::Value>(body) else {
+        return ("<unparseable error document>".to_string(), None);
+    };
+    let code = doc
+        .pointer("/payload/code")
+        .and_then(|c| c.as_str())
+        .unwrap_or("<unknown>")
+        .to_string();
+    let message = doc
+        .pointer("/payload/message")
+        .and_then(|m| m.as_str())
+        .map(str::to_string);
+    (code, message)
+}
+
 /// `join-requests/submit/1.0` over DIDComm — the ceremony `request` verb.
 ///
 /// The message body is the Trust Task document; the authcrypt sender is the
@@ -398,14 +422,19 @@ async fn join_request_submit_handler(
     // Outcome observability (preserved from #539): a refused join must be loud —
     // it replies with a `trust-task-error` and stores nothing, so without this
     // it would look like it "silently went nowhere"; a processed one logs at
-    // info. The reply document carries the typed reject code.
+    // info. The reply document carries the typed reject code + reason, which we
+    // unpack so the *why* (expired / malformed / invalid VIC / duplicate) is in
+    // the log, not just the status.
     if outcome.status.is_success() {
         info!(applicant = %applicant_log, thid = %thid, "join-request processed");
     } else {
+        let (code, reason) = error_doc_summary(&outcome.body);
         warn!(
             applicant = %applicant_log,
             thid = %thid,
             status = outcome.status.as_u16(),
+            code = %code,
+            reason = reason.as_deref().unwrap_or("<none>"),
             "join-request refused — trust-task-error returned, no member or pending request created"
         );
     }


### PR DESCRIPTION
## Problem

After upgrading the VTC past #541, an inbound DIDComm join-request now routes to the handler (the earlier `no matching handler` drop is fixed by being on ≥0.10.0), but a *refused* join logs only the HTTP status with no reason:

```
WARN vtc_service::messaging: join-request refused — trust-task-error returned … status=400
```

`status=400` alone can't be diagnosed (malformed? expired? duplicate?).

## Root cause

#539 deliberately made join refusals loud. #541 then converted the ceremony to Trust Task documents and moved the typed reject **code** + human-readable **message** into the `trust-task-error` document body (`payload.code` / `payload.message`) — but the DIDComm submit handler's warn was never updated to read them back out. So the reason the VTC computed is sent to the applicant in the reply, yet never appears in the VTC's own logs.

## Fix

`error_doc_summary()` unpacks `payload.code` + `payload.message` from the serialised error document; the refusal warn now carries them:

```
WARN … join-request refused … status=400 code=expired reason="expiresAt was in the past at the time of evaluation"
```

Observability-only — no behaviour change to the ceremony, the reply document, or the verdict. `vtc-service` 0.10.0 → 0.10.1.

## Notes

- Only the holder `submit` verb has the diagnostic warn (it's the one #539 added); `accept`/`status`/`manifest` reply via the same path but don't log refusals — left as-is to keep this focused.
- A policy `deny` is a 200 Verdict, not a `trust-task-error`, so this log fires only for pre-policy failures (malformed / expired / invalid VIC / duplicate), which is exactly the class that was previously opaque.

## Test

`cargo check -p vtc-service` green; `cargo fmt` clean. The existing DIDComm join round-trip + duplicate-conflict tests in `vtc-service/tests/join_didcomm.rs` exercise both the success and `trust-task-error` reply paths.