### PR TITLE
feat(vtc): log the invitation facts behind a VIC join's verdict

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10200,7 +10200,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-service"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.10.2"
+version = "0.10.3"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vtc-service/src/join/orchestrate.rs
+++ b/vtc-service/src/join/orchestrate.rs
@@ -159,6 +159,38 @@ pub async fn submit_inner(
     let consume_invitation_id = invitation_fact.as_ref().map(|(id, _)| id.clone());
     let invitation = invitation_fact.map(|(_, fact)| fact);
 
+    // Diagnostic: "my VIC-bearing join is still pending" almost always comes down
+    // to one of the three policy facts below. The default `join.rego` auto-admits
+    // only on `verified && issuer_trusted && !consumed`; a verified invitation
+    // that still refers failed `issuer_trusted` (issuer ≠ this VTC's own DID and
+    // not registry-recognised) or `consumed` (single-use, already redeemed). Log
+    // the facts + the issuer-vs-own-DID comparison so the cause is in the record,
+    // not inferred. A VP that carried `verifiableCredential` but produced no
+    // invitation fact is logged too — the credential wasn't an InvitationCredential.
+    match &invitation {
+        Some(inv) => {
+            let own_did = state.config.read().await.vtc_did.clone();
+            info!(
+                applicant = %applicant_did,
+                vic_issuer = %inv.issuer,
+                vtc_own_did = own_did.as_deref().unwrap_or("<unset>"),
+                verified = inv.verified,
+                issuer_trusted = inv.issuer_trusted,
+                consumed = inv.consumed,
+                "join: invitation presented — auto-admit needs verified && issuer_trusted && !consumed"
+            );
+        }
+        None => {
+            if vp.get("verifiableCredential").is_some() {
+                info!(
+                    applicant = %applicant_did,
+                    "join: VP carried `verifiableCredential` but no InvitationCredential was \
+                     extracted — auto-admit-on-invitation cannot fire"
+                );
+            }
+        }
+    }
+
     // 5. Decide: assemble verified Facts (the route-layer holder-binding
     // makes this presentation `verified`) and run the active join policy.
     let presentation = presentation_from_vp(&applicant_did, &vp);

--- a/vtc-service/src/join/orchestrate.rs
+++ b/vtc-service/src/join/orchestrate.rs
@@ -181,9 +181,27 @@ pub async fn submit_inner(
             );
         }
         None => {
-            if vp.get("verifiableCredential").is_some() {
+            if let Some(vc) = vp.get("verifiableCredential") {
+                // Dump the shape + each credential's `type` so a VIC that wasn't
+                // recognised is self-explanatory: a missing `InvitationCredential`
+                // tag, a non-array `verifiableCredential`, or the lossy `vp_claims`
+                // projection mistakenly sent as the VP all show up here.
+                let cred_types: Vec<String> = vc
+                    .as_array()
+                    .map(|arr| {
+                        arr.iter()
+                            .map(|c| {
+                                c.get("type")
+                                    .map(|t| t.to_string())
+                                    .unwrap_or_else(|| "<no type>".to_string())
+                            })
+                            .collect()
+                    })
+                    .unwrap_or_default();
                 info!(
                     applicant = %applicant_did,
+                    is_array = vc.is_array(),
+                    credential_types = ?cred_types,
                     "join: VP carried `verifiableCredential` but no InvitationCredential was \
                      extracted — auto-admit-on-invitation cannot fire"
                 );


### PR DESCRIPTION
## Why

A join that presents a **valid VIC** but still lands in moderator review (`verdict=refer`) is the last silent spot in the join path. The default `join.rego` auto-admits only on `verified && issuer_trusted && !consumed`; when a verified invitation still refers, the cause is one of:

- **`issuer_trusted == false`** — the VIC issuer ≠ this VTC's own DID (`config.vtc_did`) and no trust registry recognizes it, or
- **`consumed == true`** — the single-use VIC was already redeemed.

Both are evaluated inside the policy with nothing in the log to say which.

## Change

Right after the invitation fact is resolved in `submit_inner`, log the three policy facts plus the **issuer-vs-own-DID** comparison that drives `issuer_trusted`:

```
INFO join: invitation presented — auto-admit needs verified && issuer_trusted && !consumed
     applicant=… vic_issuer=did:webvh:…:first-vtc vtc_own_did=did:webvh:…:first-vtc
     verified=true issuer_trusted=true consumed=false
```

A VP that carried a `verifiableCredential` but produced **no** invitation fact (the credential wasn't an `InvitationCredential`) is logged too.

Observability only — no change to verification, the verdict, or consumption. Completes the join-debugging series (#544 reject-reason logging, #545 malformed-VP errors).

## Test

`cargo test -p vtc-service --lib join::` — 23 pass. `cargo check` + `cargo fmt` clean. `vtc-service` 0.10.2 → 0.10.3.