### PR TITLE
fix(vtc): never reply to a problem-report; log its full details

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10200,7 +10200,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-service"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.10.3"
+version = "0.10.4"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vtc-service/src/messaging.rs
+++ b/vtc-service/src/messaging.rs
@@ -289,6 +289,33 @@ fn problem_report_body(code: &str, comment: impl Into<String>) -> serde_json::Va
     json!({ "code": code, "comment": comment.into() })
 }
 
+/// Pull the human-facing detail out of an inbound DIDComm v2 problem-report
+/// body — `code`, `comment` (which may carry `{1}`/`{2}` placeholders), and the
+/// `args` that fill them — as display strings for logging the *cause* a peer
+/// reported. Missing fields read as `<none>` so the log is explicit about what
+/// the peer omitted rather than silently blank.
+fn problem_report_details(body: &serde_json::Value) -> (String, String, String) {
+    let field = |k: &str| {
+        body.get(k)
+            .and_then(|v| v.as_str())
+            .unwrap_or("<none>")
+            .to_string()
+    };
+    let args = match body.get("args").and_then(|v| v.as_array()) {
+        Some(a) if !a.is_empty() => a
+            .iter()
+            .map(|v| {
+                v.as_str()
+                    .map(str::to_string)
+                    .unwrap_or_else(|| v.to_string())
+            })
+            .collect::<Vec<_>>()
+            .join(", "),
+        _ => "<none>".to_string(),
+    };
+    (field("code"), field("comment"), args)
+}
+
 /// The problem-report `code` for a business-logic [`AppError`],
 /// preserving the 4xx-equivalent distinction (forbidden / unauthorized
 /// / not-found / conflict / bad-request) the same way the REST boundary
@@ -324,11 +351,35 @@ fn app_error_report(thid: String, err: &AppError) -> DIDCommResponse {
 /// unexpected/unsupported message type — e.g. a protocol-version drift between
 /// the client and this VTC — looks like the message "just disappeared". We log
 /// it at `warn!` (visible at the default level) with the type + sender, and
-/// still return a threaded problem-report so the sender isn't left hanging.
+/// (for a genuine unsupported request) return a threaded problem-report so the
+/// sender isn't left hanging.
+///
+/// **Never reply to a problem-report.** Replying to one with our own
+/// (unsupported-type) problem-report makes the peer reply to *that*, and so on —
+/// an unbounded problem-report ping-pong (observed against the mediator). A
+/// problem-report is a terminal notification: log it and stop. Mirrors the VTA's
+/// `handle_unknown` (`vta-service` `messaging::handlers`).
 async fn unhandled_message_handler(
     message: Message,
     _meta: UnpackMetadata,
 ) -> Result<Option<DIDCommResponse>, DIDCommServiceError> {
+    if message.typ.contains("problem-report") {
+        let (code, comment, args) = problem_report_details(&message.body);
+        warn!(
+            from = message.from.as_deref().unwrap_or("<anon>"),
+            thid = message.thid.as_deref().unwrap_or("<none>"),
+            code = %code,
+            comment = %comment,
+            args = %args,
+            // The full body too: we don't always know which fields a peer's
+            // problem-report carries, so log the raw JSON so the *cause* is never
+            // lost to a field-name mismatch.
+            body = %message.body,
+            id = %message.id,
+            "received unhandled problem-report — not replying (a reply would loop)"
+        );
+        return Ok(None);
+    }
     warn!(
         message_type = %message.typ,
         from = message.from.as_deref().unwrap_or("<anon>"),
@@ -755,6 +806,26 @@ mod tests {
 
     const ALICE: &str = "did:key:z6MkAlice";
     const ALICE_SKID: &str = "did:key:z6MkAlice#z6MkAlice";
+
+    #[test]
+    fn problem_report_details_extracts_code_comment_and_args() {
+        let (code, comment, args) = problem_report_details(&json!({
+            "code": "e.p.xfer.cant-use-endpoint",
+            "comment": "Unable to use the {1} endpoint for {2}.",
+            "args": ["https://x.example/finance", "did:example:1234"],
+        }));
+        assert_eq!(code, "e.p.xfer.cant-use-endpoint");
+        assert_eq!(comment, "Unable to use the {1} endpoint for {2}.");
+        assert_eq!(args, "https://x.example/finance, did:example:1234");
+    }
+
+    #[test]
+    fn problem_report_details_marks_missing_fields() {
+        let (code, comment, args) = problem_report_details(&json!({}));
+        assert_eq!(code, "<none>");
+        assert_eq!(comment, "<none>");
+        assert_eq!(args, "<none>");
+    }
 
     #[test]
     fn app_error_maps_to_typed_problem_report_codes() {


### PR DESCRIPTION
## Problem

The VTC's DIDComm fallback (`unhandled_message_handler`) replied to **every** unrouted message with an `unsupported message type` problem-report — **including inbound `report-problem/2.0/problem-report` messages**. A peer that can't route our reply (e.g. the mediator) answers with its own problem-report, which we reply to again → an **unbounded problem-report ping-pong**, observed firing every ~1–2s against the mediator until the other end was shut down.

Per the DIDComm spec a problem-report is a terminal notification and must never be answered with another.

Separately, the reason carried in the problem-report was never logged, so an operator couldn't tell **why** the peer was complaining.

## Fix

1. **Break the loop.** `unhandled_message_handler` now detects an inbound problem-report (`message.typ.contains("problem-report")`) and returns `Ok(None)` — no reply. This mirrors the VTA's `handle_unknown` (`vta-service` `messaging::handlers`), which already does exactly this; the VTC was the outlier.
2. **Log the cause.** New `problem_report_details` extracts `code`, `comment`, and the `args` that fill the comment's `{1}`/`{2}` placeholders; the warn also logs `thid` and the **full raw body**, so a non-standard field can't hide the reason:
   ```
   WARN received unhandled problem-report — not replying (a reply would loop)
        from=… thid=… code=e.p.xfer.cant-use-endpoint comment="Unable to use the {1} endpoint for {2}." args="…, …" body={…}
   ```

## Tests

New `problem_report_details_extracts_code_comment_and_args` + `…_marks_missing_fields`; `cargo test -p vtc-service --lib messaging::` — 10 pass. `cargo check`/`fmt` clean. `vtc-service` 0.10.3 → 0.10.4.