### PR TITLE
feat(vtc-admin-ui): abbreviate DIDs in the ACL, keeping the tail visible

### DIFF
--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.10.4"
+version = "0.10.5"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vtc-service/admin-ui/src/lib/format.ts
+++ b/vtc-service/admin-ui/src/lib/format.ts
@@ -19,6 +19,40 @@ export function shorten(value: string, head = 8, tail = 4): string {
 }
 
 /**
+ * Abbreviate a DID for table display by shrinking the long opaque middle
+ * segment — the `did:webvh` SCID (a content hash) or a `did:key` multibase —
+ * while keeping the method prefix and, crucially, the **full tail** (the domain
+ * and human-readable path, e.g. `…:webvh.storm.ws:glenn-vta`), which is the part
+ * that actually identifies the agent. Unlike a CSS `text-overflow` ellipsis
+ * (which clips the *end*), this keeps the end visible. The full DID stays
+ * available via a `title` tooltip / copy.
+ *
+ * - `did:webvh:<scid>:<domain>…:<path>` → SCID abbreviated to `keep` chars + `…`,
+ *   everything after it kept verbatim.
+ * - `did:key:<multibase>` (and other 3-segment DIDs) → middle-truncate the id,
+ *   keeping `keep` head + 6 tail chars.
+ * - Non-DID input and already-short DIDs are returned unchanged.
+ */
+export function shortenDid(did: string, keep = 10): string {
+  if (!did.startsWith("did:")) return did;
+  const parts = did.split(":");
+  if ((parts[1] === "webvh" || parts[1] === "web") && parts.length > 3) {
+    const scid = parts[2] ?? "";
+    if (scid.length > keep + 1) {
+      parts[2] = `${scid.slice(0, keep)}…`;
+    }
+    return parts.join(":");
+  }
+  // did:key and other `did:<method>:<id>` shapes: the id carries no human tail,
+  // so keep head + tail to aid visual comparison.
+  const id = parts.slice(2).join(":");
+  if (id.length > keep + 7) {
+    return `${parts[0]}:${parts[1]}:${id.slice(0, keep)}…${id.slice(-6)}`;
+  }
+  return did;
+}
+
+/**
  * Format an RFC3339 / ISO-8601 timestamp into the operator's
  * locale-string. Used for `joinedAt`, `created_at`, `activated_at`,
  * audit envelope timestamps, etc. Falls back to the raw input on

--- a/vtc-service/admin-ui/src/plugins/acl.tsx
+++ b/vtc-service/admin-ui/src/plugins/acl.tsx
@@ -17,7 +17,7 @@ import { Copy, Mail, Pencil, Plus, RefreshCw, ShieldCheck, X } from "lucide-reac
 import { deleteJson, getJson, patchJson, postJson } from "@/lib/api";
 import { useConfirm } from "@/components/ConfirmDialog";
 import { Field } from "@/components/Field";
-import { formatEpoch, formatIso, shorten } from "@/lib/format";
+import { formatEpoch, formatIso, shorten, shortenDid } from "@/lib/format";
 import { useToast } from "@/lib/toast";
 
 const TRUST_TASK_MANAGE =
@@ -250,9 +250,7 @@ export function Acl() {
             {query.data?.entries.map((e) => (
               <tr key={e.did}>
                 <td>
-                  <code className="truncate" title={e.did}>
-                    {e.did}
-                  </code>
+                  <code title={e.did}>{shortenDid(e.did)}</code>
                 </td>
                 <td>
                   <code>{e.role}</code>
@@ -442,9 +440,7 @@ function InvitesPanel() {
               <tr key={i.jti}>
                 <td>
                   {i.targetDid ? (
-                    <code className="truncate" title={i.targetDid}>
-                      {i.targetDid}
-                    </code>
+                    <code title={i.targetDid}>{shortenDid(i.targetDid)}</code>
                   ) : (
                     <span className="muted">unknown</span>
                   )}


### PR DESCRIPTION
## What

In the admin SPA **Access control** list, DIDs were rendered in a `.truncate` cell — a CSS `text-overflow: ellipsis` that clips the **end**, hiding the human-readable tail (`…:webvh.storm.ws:glenn-vta`) that actually identifies the agent while keeping the long opaque SCID.

This adds `shortenDid` (in `lib/format.ts`): it shrinks the long **middle** segment — the `did:webvh` SCID (a content hash) or a `did:key` multibase — and keeps the method prefix plus the **full tail**, so the end stays visible.

```
did:webvh:QmWoJD2kpP6AJknNtj7UFERUstEen258ywj3ruHoh1ZAqr:webvh.storm.ws:glenn-vta
→ did:webvh:QmWoJD2kpP…:webvh.storm.ws:glenn-vta
```

Applied to the ACL DID column and the admin-invite target DID. The full DID stays available on hover (`title`) and via copy. `did:key` DIDs (no human tail) fall back to head+tail truncation for visual comparison.

## Test

`npm run lint` (tsc -b --noEmit) clean in `admin-ui/`. `vtc-service` 0.10.4 → 0.10.5 (the admin SPA is baked into the binary).