### PR TITLE
feat(vtc): receive a member-issued reciprocal VMC + admin request flow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2441,7 +2441,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.18.1",
+ "vta-sdk 0.18.2",
 ]
 
 [[package]]
@@ -3211,7 +3211,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.18.1",
+ "vta-sdk 0.18.2",
 ]
 
 [[package]]
@@ -6698,7 +6698,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.18.1",
+ "vta-sdk 0.18.2",
 ]
 
 [[package]]
@@ -9964,7 +9964,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.18.1",
+ "vta-sdk 0.18.2",
  "vti-common",
  "x25519-dalek",
 ]
@@ -9997,7 +9997,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.18.1",
+ "vta-sdk 0.18.2",
 ]
 
 [[package]]
@@ -10020,7 +10020,7 @@ dependencies = [
  "tracing-subscriber",
  "trust-tasks-rs",
  "uniffi",
- "vta-sdk 0.18.1",
+ "vta-sdk 0.18.2",
 ]
 
 [[package]]
@@ -10055,7 +10055,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10186,7 +10186,7 @@ dependencies = [
  "utoipa-axum",
  "uuid",
  "vta-cli-common",
- "vta-sdk 0.18.1",
+ "vta-sdk 0.18.2",
  "vta-service",
  "vti-common",
  "vti-secrets",
@@ -10200,7 +10200,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-service"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",
@@ -10267,7 +10267,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.18.1",
+ "vta-sdk 0.18.2",
  "vtc-service",
  "vti-common",
  "vti-secrets",
@@ -10315,7 +10315,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.18.1",
+ "vta-sdk 0.18.2",
  "webauthn-rs",
  "zeroize",
 ]
@@ -10342,7 +10342,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.18.1",
+ "vta-sdk 0.18.2",
  "vta-service",
  "vti-common",
 ]
@@ -10371,7 +10371,7 @@ dependencies = [
  "tokio",
  "tracing",
  "vaultrs",
- "vta-sdk 0.18.1",
+ "vta-sdk 0.18.2",
  "vti-common",
 ]
 

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.18.1"
+version = "0.18.2"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/protocols/members.rs
+++ b/vta-sdk/src/protocols/members.rs
@@ -1,0 +1,75 @@
+//! Member-side membership-credential exchange (`members/*`).
+//!
+//! Membership between a persona DID and a VTC is a **pair of VMCs**: the VTC
+//! issues a `VerifiableMembershipCredential` to the member at admission
+//! (community → member), and the member issues one back to the VTC
+//! (member → community), so each side holds a credential asserting the other's
+//! membership edge. The join-ceremony `accept` step records a member-issued
+//! *acknowledgement*; this family carries the **full reciprocal VMC** and lets
+//! it be (re)exchanged at any point after admission:
+//!
+//! - [`MEMBER_REQUEST_VMC_TYPE`] — VTC → member: "please issue + send your VMC".
+//!   Admin-triggered from the VTC; delivered over DIDComm to the member's agent.
+//! - [`MEMBER_VMC_TYPE`] — member → VTC: the member-issued VMC (a Data-Integrity
+//!   VC whose `issuer` is the member and whose `credentialSubject.id` is the
+//!   community DID). The VTC verifies the proof + binding and stores it.
+//! - [`MEMBER_VMC_RESPONSE_TYPE`] — VTC → member: a receipt acknowledging the
+//!   stored VMC.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// The `type` array tag a member-issued membership credential must carry
+/// (alongside `VerifiableCredential`). Same credential type the VTC issues for
+/// its half of the pair — the direction is given by `issuer` /
+/// `credentialSubject.id`, not the type.
+pub const VERIFIABLE_MEMBERSHIP_CREDENTIAL_TYPE: &str = "VerifiableMembershipCredential";
+
+/// VTC → member: request that the member issue and send their reciprocal VMC.
+pub const MEMBER_REQUEST_VMC_TYPE: &str =
+    "https://trusttasks.org/openvtc/vtc/spec/members/request-vmc/1.0";
+
+/// Member → VTC: a member-issued [`VERIFIABLE_MEMBERSHIP_CREDENTIAL_TYPE`] VMC,
+/// the member → community half of the membership pair.
+pub const MEMBER_VMC_TYPE: &str = "https://trusttasks.org/openvtc/vtc/spec/members/vmc/1.0";
+
+/// VTC → member: receipt acknowledging a stored member VMC. The `#response`
+/// variant of [`MEMBER_VMC_TYPE`].
+pub const MEMBER_VMC_RESPONSE_TYPE: &str =
+    "https://trusttasks.org/openvtc/vtc/spec/members/vmc/1.0#response";
+
+/// Body of a [`MEMBER_REQUEST_VMC_TYPE`] request. The member should issue a VMC
+/// whose `credentialSubject.id` is `community_did` and send it back as a
+/// [`MEMBER_VMC_TYPE`] message.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RequestMemberVmcBody {
+    /// The community (VTC) DID the member's VMC must name as its subject.
+    pub community_did: String,
+    /// Optional operator-supplied reason ("renewal", "audit", …) surfaced to
+    /// the member's agent / log.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+/// Body of a [`MEMBER_VMC_TYPE`] submission: the member-issued VMC verbatim.
+/// `vc.issuer` is the member DID (the authcrypt sender / DI-proof signer) and
+/// `vc.credentialSubject.id` is the community DID.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MemberVmcBody {
+    /// The member-issued membership credential (a Data-Integrity VC).
+    pub vc: Value,
+}
+
+/// Body of a [`MEMBER_VMC_RESPONSE_TYPE`] receipt.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MemberVmcReceiptBody {
+    /// The member whose VMC was stored.
+    pub member_did: String,
+    /// The stored VMC's top-level `id`.
+    pub vmc_id: String,
+    /// Always `"stored"` on success.
+    pub status: String,
+}

--- a/vta-sdk/src/protocols/mod.rs
+++ b/vta-sdk/src/protocols/mod.rs
@@ -11,6 +11,9 @@ pub mod discovery;
 #[cfg(feature = "didcomm")]
 pub mod join_requests;
 pub mod key_management;
+/// Member-side membership-credential exchange (`members/*`) — the member → VTC
+/// reciprocal VMC and the VTC's request for it.
+pub mod members;
 /// Passkey-based login flow (`vta/auth/passkey-login-{start,finish}/1.0`).
 pub mod passkey_login;
 pub mod protocol_management;

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.10.7"
+version = "0.10.8"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vtc-service/admin-ui/src/plugins/members.tsx
+++ b/vtc-service/admin-ui/src/plugins/members.tsx
@@ -45,6 +45,8 @@ const TRUST_TASK_REMOVED =
   "https://trusttasks.org/openvtc/vtc/members/removed/1.0";
 const TRUST_TASK_PURGE =
   "https://trusttasks.org/openvtc/vtc/members/purge/1.0";
+const TRUST_TASK_REQUEST_VMC =
+  "https://trusttasks.org/openvtc/vtc/members/request-vmc/1.0";
 
 interface MemberRow {
   did: string;
@@ -60,6 +62,10 @@ interface MemberRow {
   personhood: boolean;
   personhoodAssertedAt: string | null;
   joinedViaInvitation: boolean;
+  /** Top-level `id` of the member-issued reciprocal VMC, once received. */
+  memberVmcId?: string | null;
+  /** When the member's reciprocal VMC was received + stored. */
+  memberVmcReceivedAt?: string | null;
 }
 
 interface MembersPage {
@@ -86,6 +92,23 @@ async function fetchMember(did: string): Promise<MemberRow> {
   return getJson<MemberRow>(`/v1/members/${encodeURIComponent(did)}`, {
     trustTask: TRUST_TASK_SHOW,
   });
+}
+
+interface RequestVmcResponse {
+  memberDid: string;
+  requested: boolean;
+  threadId: string;
+}
+
+/** Ask an active member to issue + send their reciprocal VMC (member →
+ * community half of the pair). The member answers asynchronously over the
+ * `members/vmc/1.0` DIDComm surface; this only dispatches the request. */
+async function requestMemberVmc(did: string): Promise<RequestVmcResponse> {
+  return postJson<RequestVmcResponse>(
+    `/v1/members/${encodeURIComponent(did)}/request-vmc`,
+    {},
+    { trustTask: TRUST_TASK_REQUEST_VMC },
+  );
 }
 
 interface PromoteStartResponse {
@@ -430,6 +453,10 @@ function MemberDetail() {
     },
   });
 
+  const requestVmcMutation = useMutation({
+    mutationFn: requestMemberVmc,
+  });
+
   return (
     <section className="page">
       <button type="button" className="link" onClick={() => navigate("..")}>
@@ -508,6 +535,24 @@ function MemberDetail() {
                   "—"
                 )}
               </dd>
+              <dt>Member VMC (member → VTC)</dt>
+              <dd>
+                {query.data.memberVmcId ? (
+                  <>
+                    <code>{query.data.memberVmcId}</code>
+                    {query.data.memberVmcReceivedAt && (
+                      <span className="muted">
+                        {" "}
+                        · received {formatDate(query.data.memberVmcReceivedAt)}
+                      </span>
+                    )}
+                  </>
+                ) : (
+                  <span className="muted">
+                    not received — the member hasn't sent their reciprocal VMC
+                  </span>
+                )}
+              </dd>
             </dl>
           </section>
 
@@ -546,6 +591,19 @@ function MemberDetail() {
               </section>
             )}
 
+            {requestVmcMutation.error && (
+              <section className="card error">
+                <h3>Request failed</h3>
+                <p>{(requestVmcMutation.error as Error).message}</p>
+              </section>
+            )}
+            {requestVmcMutation.isSuccess && (
+              <p className="muted">
+                Requested the member's reciprocal VMC. They'll send it back
+                asynchronously; refresh to see it under Credentials.
+              </p>
+            )}
+
             <div className="form-actions">
               <button
                 type="button"
@@ -569,6 +627,19 @@ function MemberDetail() {
                   : query.data.role === "admin"
                     ? "Already admin"
                     : "Promote to admin"}
+              </button>
+              <button
+                type="button"
+                className="secondary"
+                disabled={requestVmcMutation.isPending}
+                title="Ask this member to issue and send their reciprocal VMC (member → VTC half of the membership pair)"
+                onClick={() => requestVmcMutation.mutate(decoded)}
+              >
+                {requestVmcMutation.isPending
+                  ? "Requesting…"
+                  : query.data.memberVmcId
+                    ? "Re-request member VMC"
+                    : "Request member VMC"}
               </button>
             </div>
 

--- a/vtc-service/src/members/inbound_vmc.rs
+++ b/vtc-service/src/members/inbound_vmc.rs
@@ -1,0 +1,175 @@
+//! Receive + verify a member-issued **VMC** (member → community half of the
+//! membership pair) and record it on the member's row.
+//!
+//! The VTC issues a `VerifiableMembershipCredential` to each member at
+//! admission; this is the reciprocal the member issues back, naming the
+//! community as its `credentialSubject`. The `eddsa-jcs-2022` issuer proof (key
+//! under the member's DID, resolved via [`DidVmResolver`] so `did:webvh`
+//! personas verify, not just `did:key`) IS the authentication of the
+//! credential. Over DIDComm the authcrypt sender independently authenticates
+//! `member_did`; the two must agree.
+//!
+//! Shared by the DIDComm `members/vmc/1.0` handler (the only transport today —
+//! members speak DIDComm).
+
+use affinidi_data_integrity::{DataIntegrityProof, VerifyOptions};
+use serde_json::Value as JsonValue;
+use tracing::info;
+
+use vti_common::error::AppError;
+
+use vta_sdk::protocols::members::VERIFIABLE_MEMBERSHIP_CREDENTIAL_TYPE;
+
+use crate::credentials::vm_resolver::{DidVmResolver, check_issuer_binding};
+use crate::members::{get_member, store_member};
+use crate::server::AppState;
+
+/// What [`receive_member_vmc_inner`] recorded.
+pub struct MemberVmcOutcome {
+    pub member_did: String,
+    pub vmc_id: String,
+    /// `false` when the same VMC was already stored (idempotent re-send) — the
+    /// caller skips re-auditing / re-logging the store.
+    pub recorded: bool,
+}
+
+/// Verify a member-issued VMC and store it on the member's row.
+///
+/// Checks: the member exists and is active; `vc.issuer == member_did`; `type`
+/// includes [`VERIFIABLE_MEMBERSHIP_CREDENTIAL_TYPE`];
+/// `credentialSubject.id == <this VTC's DID>`; the issuer DI proof's
+/// `verificationMethod` is under the member and verifies against the resolved
+/// key. Idempotent: re-sending the same `id` is a no-op.
+pub async fn receive_member_vmc_inner(
+    state: &AppState,
+    member_did: String,
+    vc: JsonValue,
+) -> Result<MemberVmcOutcome, AppError> {
+    // The community DID the member's VMC must name as its subject.
+    let community_did = state
+        .config
+        .read()
+        .await
+        .vtc_did
+        .clone()
+        .filter(|d| !d.is_empty())
+        .ok_or_else(|| {
+            AppError::Internal("VTC DID not configured — cannot accept a member VMC".into())
+        })?;
+
+    let vmc_id = verify_member_vmc(state, &vc, &member_did, &community_did).await?;
+
+    // The member must exist and be active.
+    let mut member = get_member(&state.members_ks, &member_did)
+        .await?
+        .filter(|m| !m.is_removed())
+        .ok_or_else(|| AppError::NotFound(format!("no active member: {member_did}")))?;
+
+    // Idempotency: the same VMC re-sent is a no-op; a *different* VMC replaces
+    // the stored one (a renewal — the member rotated/reissued their half).
+    if member.member_vmc_id.as_deref() == Some(vmc_id.as_str()) {
+        return Ok(MemberVmcOutcome {
+            member_did,
+            vmc_id,
+            recorded: false,
+        });
+    }
+
+    member.record_member_vmc(vmc_id.clone(), vc);
+    store_member(&state.members_ks, &member).await?;
+
+    info!(
+        member = %member_did,
+        vmc_id = %vmc_id,
+        "stored member-issued VMC (member → community half of the pair)"
+    );
+
+    Ok(MemberVmcOutcome {
+        member_did,
+        vmc_id,
+        recorded: true,
+    })
+}
+
+/// Verify the member-issued VMC and return its top-level `id`.
+async fn verify_member_vmc(
+    state: &AppState,
+    vc: &JsonValue,
+    member_did: &str,
+    community_did: &str,
+) -> Result<String, AppError> {
+    let obj = vc
+        .as_object()
+        .ok_or_else(|| AppError::Validation("member vmc is not a JSON object".into()))?;
+
+    // Issuer must be the member (the authcrypt sender / proof signer).
+    let issuer = match obj.get("issuer") {
+        Some(JsonValue::String(s)) => s.clone(),
+        Some(JsonValue::Object(o)) => o
+            .get("id")
+            .and_then(JsonValue::as_str)
+            .unwrap_or_default()
+            .to_string(),
+        _ => String::new(),
+    };
+    if issuer != member_did {
+        return Err(AppError::Validation(format!(
+            "member vmc issuer `{issuer}` is not the member `{member_did}`"
+        )));
+    }
+
+    // Type discriminator.
+    let has_type = obj
+        .get("type")
+        .and_then(JsonValue::as_array)
+        .is_some_and(|a| {
+            a.iter()
+                .filter_map(JsonValue::as_str)
+                .any(|t| t == VERIFIABLE_MEMBERSHIP_CREDENTIAL_TYPE)
+        });
+    if !has_type {
+        return Err(AppError::Validation(format!(
+            "member vmc `type` must include `{VERIFIABLE_MEMBERSHIP_CREDENTIAL_TYPE}`"
+        )));
+    }
+
+    // Subject must be THIS community.
+    let subject_id = obj
+        .get("credentialSubject")
+        .and_then(JsonValue::as_object)
+        .and_then(|s| s.get("id"))
+        .and_then(JsonValue::as_str)
+        .unwrap_or_default();
+    if subject_id != community_did {
+        return Err(AppError::Validation(format!(
+            "member vmc subject `{subject_id}` is not this community `{community_did}`"
+        )));
+    }
+
+    // Cryptographic issuer proof: key under the member, resolved (did:key +
+    // did:webvh) and verified.
+    let proof_value = obj
+        .get("proof")
+        .ok_or_else(|| AppError::Validation("member vmc has no issuer `proof`".into()))?;
+    let proof: DataIntegrityProof = serde_json::from_value(proof_value.clone()).map_err(|e| {
+        AppError::Validation(format!("member vmc proof is not Data-Integrity: {e}"))
+    })?;
+    check_issuer_binding(&proof.verification_method, member_did)?;
+
+    let resolver = DidVmResolver::new(state.did_resolver.clone());
+    let mut unsigned = vc.clone();
+    if let Some(o) = unsigned.as_object_mut() {
+        o.remove("proof");
+    }
+    proof
+        .verify(&unsigned, &resolver, VerifyOptions::new())
+        .await
+        .map_err(|e| {
+            AppError::Validation(format!("member vmc issuer proof did not verify: {e}"))
+        })?;
+
+    obj.get("id")
+        .and_then(JsonValue::as_str)
+        .map(str::to_string)
+        .ok_or_else(|| AppError::Validation("member vmc has no top-level `id`".into()))
+}

--- a/vtc-service/src/members/mod.rs
+++ b/vtc-service/src/members/mod.rs
@@ -26,6 +26,7 @@
 //! from day one; the resolver indirection lives at the removal
 //! call site.
 
+pub mod inbound_vmc;
 pub mod storage;
 
 use chrono::{DateTime, Utc};
@@ -117,6 +118,23 @@ pub struct Member {
     /// `false`.
     #[serde(default)]
     pub joined_via_invitation: bool,
+    /// The member → community half of the membership VMC pair: the
+    /// member-issued `VerifiableMembershipCredential` (a Data-Integrity VC
+    /// whose `issuer` is this member and `credentialSubject.id` is the
+    /// community DID), received over the `members/vmc/1.0` exchange and
+    /// verified before storage. `None` until the member sends one. Distinct
+    /// from [`Self::reciprocal_vc_id`], which is the join-ceremony
+    /// acknowledgement; this is the full reciprocal VMC.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub member_vmc: Option<JsonValue>,
+    /// Top-level `id` of [`Self::member_vmc`], for display / dedup without
+    /// reparsing the body. `None` until a member VMC is stored.
+    #[serde(default)]
+    pub member_vmc_id: Option<String>,
+    /// When the member VMC was received + stored. Paired with
+    /// [`Self::member_vmc`].
+    #[serde(default)]
+    pub member_vmc_received_at: Option<DateTime<Utc>>,
 }
 
 impl Member {
@@ -144,7 +162,19 @@ impl Member {
             reciprocal_vc_id: None,
             accepted_at: None,
             joined_via_invitation: false,
+            member_vmc: None,
+            member_vmc_id: None,
+            member_vmc_received_at: None,
         }
+    }
+
+    /// Record the member-issued reciprocal VMC (member → community half of the
+    /// pair), stamping the receipt time. The caller verifies the credential
+    /// (issuer, subject binding, proof) before calling this.
+    pub fn record_member_vmc(&mut self, vmc_id: impl Into<String>, vmc: JsonValue) {
+        self.member_vmc_id = Some(vmc_id.into());
+        self.member_vmc = Some(vmc);
+        self.member_vmc_received_at = Some(Utc::now());
     }
 
     /// Record the member-issued reciprocal VC that closes the
@@ -185,6 +215,11 @@ impl Member {
         // a re-admitted member reciprocates afresh.
         self.reciprocal_vc_id = None;
         self.accepted_at = None;
+        // The member-issued VMC names the (now departed) membership edge —
+        // drop it; a re-admitted member sends a fresh one.
+        self.member_vmc = None;
+        self.member_vmc_id = None;
+        self.member_vmc_received_at = None;
     }
 
     /// Mark the row historical — keep all fields verbatim, just

--- a/vtc-service/src/members/storage.rs
+++ b/vtc-service/src/members/storage.rs
@@ -204,6 +204,9 @@ mod tests {
             reciprocal_vc_id: None,
             accepted_at: None,
             joined_via_invitation: false,
+            member_vmc: None,
+            member_vmc_id: None,
+            member_vmc_received_at: None,
         };
         let json = serde_json::to_value(&m).unwrap();
         assert!(json["joinedAt"].is_string());
@@ -236,6 +239,9 @@ mod tests {
             reciprocal_vc_id: None,
             accepted_at: None,
             joined_via_invitation: false,
+            member_vmc: None,
+            member_vmc_id: None,
+            member_vmc_received_at: None,
         };
         let json = serde_json::to_value(&m).unwrap();
         assert_eq!(json["personhood"], true);

--- a/vtc-service/src/messaging.rs
+++ b/vtc-service/src/messaging.rs
@@ -28,6 +28,9 @@ use vta_sdk::protocols::join_requests::{
     MEMBER_SELF_REMOVE_RECEIPT_TYPE, MEMBER_SELF_REMOVE_TYPE, SelfRemoveBody,
     SelfRemoveReceiptBody,
 };
+use vta_sdk::protocols::members::{
+    MEMBER_VMC_RESPONSE_TYPE, MEMBER_VMC_TYPE, MemberVmcBody, MemberVmcReceiptBody,
+};
 use vta_sdk::protocols::{PROBLEM_REPORT_TYPE, problem_report_codes as codes};
 
 use crate::ceremony::remove_inner;
@@ -130,6 +133,7 @@ pub async fn run_didcomm_service(
                 handler_fn(member_self_remove_handler),
             )
         })
+        .and_then(|r| r.route(MEMBER_VMC_TYPE, handler_fn(member_vmc_handler)))
         .and_then(|r| {
             r.route(
                 CREDENTIAL_REQUEST_TYPE,
@@ -596,6 +600,52 @@ async fn member_self_remove_handler(
         .map_err(|e| DIDCommServiceError::Internal(format!("receipt serialise: {e}")))?;
     Ok(Some(
         DIDCommResponse::new(MEMBER_SELF_REMOVE_RECEIPT_TYPE, body).thid(message.id),
+    ))
+}
+
+/// `members/vmc/1.0` over DIDComm — a member submits their reciprocal VMC
+/// (member → community half of the membership pair), prompted or unprompted.
+///
+/// The authcrypt sender is the proven member; the body carries the member-issued
+/// VMC. [`receive_member_vmc_inner`](crate::members::inbound_vmc::receive_member_vmc_inner)
+/// verifies the issuer / subject binding + the DI proof and stores it on the
+/// member row. Replies with a receipt, or a threaded problem-report on failure.
+async fn member_vmc_handler(
+    message: Message,
+    meta: UnpackMetadata,
+    Extension(state): Extension<AppState>,
+) -> Result<Option<DIDCommResponse>, DIDCommServiceError> {
+    let thid = message.id.clone();
+    let member_did = authenticated_sender_did(&message, &meta)?;
+
+    let body: MemberVmcBody = match serde_json::from_value(message.body.clone()) {
+        Ok(b) => b,
+        Err(e) => {
+            return Ok(Some(problem_report(
+                thid,
+                codes::BAD_REQUEST,
+                format!("malformed member-vmc body: {e}"),
+            )));
+        }
+    };
+
+    let outcome =
+        match crate::members::inbound_vmc::receive_member_vmc_inner(&state, member_did, body.vc)
+            .await
+        {
+            Ok(o) => o,
+            Err(e) => return Ok(Some(app_error_report(thid, &e))),
+        };
+
+    let receipt = MemberVmcReceiptBody {
+        member_did: outcome.member_did,
+        vmc_id: outcome.vmc_id,
+        status: "stored".to_string(),
+    };
+    let body = serde_json::to_value(&receipt)
+        .map_err(|e| DIDCommServiceError::Internal(format!("receipt serialise: {e}")))?;
+    Ok(Some(
+        DIDCommResponse::new(MEMBER_VMC_RESPONSE_TYPE, body).thid(message.id),
     ))
 }
 

--- a/vtc-service/src/routes/members/mod.rs
+++ b/vtc-service/src/routes/members/mod.rs
@@ -22,5 +22,6 @@ pub mod read;
 pub mod relationships;
 pub mod remove;
 pub mod renew;
+pub mod request_vmc;
 pub mod rotate;
 pub mod update;

--- a/vtc-service/src/routes/members/read.rs
+++ b/vtc-service/src/routes/members/read.rs
@@ -55,6 +55,15 @@ pub struct MemberResponse {
     /// badge invitation-joined members.
     #[serde(default)]
     pub joined_via_invitation: bool,
+    /// Top-level `id` of the member-issued reciprocal VMC (member → community
+    /// half of the pair), once the member has sent it over `members/vmc/1.0`.
+    /// `None` until then. The VMC body itself is not echoed on this response.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub member_vmc_id: Option<String>,
+    /// When the member VMC was received + stored. Paired with
+    /// [`Self::member_vmc_id`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub member_vmc_received_at: Option<DateTime<Utc>>,
 }
 
 impl MemberResponse {
@@ -77,6 +86,8 @@ impl MemberResponse {
             personhood: member.personhood,
             personhood_asserted_at: member.personhood_asserted_at,
             joined_via_invitation: member.joined_via_invitation,
+            member_vmc_id: member.member_vmc_id,
+            member_vmc_received_at: member.member_vmc_received_at,
         }
     }
 }

--- a/vtc-service/src/routes/members/request_vmc.rs
+++ b/vtc-service/src/routes/members/request_vmc.rs
@@ -1,0 +1,105 @@
+//! `POST /v1/members/{did}/request-vmc` — ask an active member to issue and
+//! send their reciprocal VMC (member → community half of the membership pair).
+//!
+//! Admin-triggered. The VTC sends a `members/request-vmc/1.0` DIDComm message
+//! to the member's agent naming the community DID the VMC must subject; the
+//! member answers asynchronously with `members/vmc/1.0` (handled by
+//! [`crate::members::inbound_vmc`]). This endpoint only dispatches the request —
+//! it does not block on the member's reply.
+
+use axum::Json;
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use vta_sdk::protocols::members::{MEMBER_REQUEST_VMC_TYPE, RequestMemberVmcBody};
+use vti_common::error::AppError;
+
+use crate::auth::AdminAuth;
+use crate::members::get_member;
+use crate::server::AppState;
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
+pub struct RequestVmcBody {
+    /// Optional operator note ("renewal", "audit", …) relayed to the member.
+    #[serde(default)]
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
+pub struct RequestVmcResponse {
+    pub member_did: String,
+    /// Always `true` — the request was dispatched to the member's agent. The
+    /// member replies asynchronously over `members/vmc/1.0`.
+    pub requested: bool,
+    /// DIDComm thread id of the dispatched request, for correlation.
+    pub thread_id: String,
+}
+
+/// POST /members/{did}/request-vmc — dispatch a reciprocal-VMC request.
+#[utoipa::path(
+    post, path = "/members/{did}/request-vmc", tag = "members",
+    params(("did" = String, Path, description = "Member DID")),
+    request_body = RequestVmcBody,
+    responses(
+        (status = 202, description = "Request dispatched to the member", body = RequestVmcResponse),
+        (status = 404, description = "No active member with that DID"),
+        (status = 502, description = "Could not deliver the request to the member"),
+    ),
+)]
+pub async fn request_vmc(
+    _auth: AdminAuth,
+    State(state): State<AppState>,
+    Path(member_did): Path<String>,
+    Json(body): Json<RequestVmcBody>,
+) -> Result<(StatusCode, Json<RequestVmcResponse>), AppError> {
+    vti_common::identifier::validate_did("did", &member_did)?;
+
+    // Only an active member has a membership edge to reciprocate.
+    get_member(&state.members_ks, &member_did)
+        .await?
+        .filter(|m| !m.is_removed())
+        .ok_or_else(|| AppError::NotFound(format!("no active member: {member_did}")))?;
+
+    let community_did = state
+        .config
+        .read()
+        .await
+        .vtc_did
+        .clone()
+        .filter(|d| !d.is_empty())
+        .ok_or_else(|| {
+            AppError::Internal("VTC DID not configured — cannot request a member VMC".into())
+        })?;
+
+    let thread_id = Uuid::new_v4().to_string();
+    let request = RequestMemberVmcBody {
+        community_did,
+        reason: body.reason,
+    };
+    let request_body = serde_json::to_value(&request)
+        .map_err(|e| AppError::Internal(format!("serialise request-vmc body: {e}")))?;
+
+    crate::credentials::delivery::push_to_holder(
+        &state,
+        &member_did,
+        &thread_id,
+        MEMBER_REQUEST_VMC_TYPE,
+        request_body,
+    )
+    .await?;
+
+    Ok((
+        StatusCode::ACCEPTED,
+        Json(RequestVmcResponse {
+            member_did,
+            requested: true,
+            thread_id,
+        }),
+    ))
+}

--- a/vtc-service/src/routes/members/update.rs
+++ b/vtc-service/src/routes/members/update.rs
@@ -183,6 +183,8 @@ impl MemberResponse {
             personhood: member.personhood,
             personhood_asserted_at: member.personhood_asserted_at,
             joined_via_invitation: member.joined_via_invitation,
+            member_vmc_id: member.member_vmc_id,
+            member_vmc_received_at: member.member_vmc_received_at,
         }
     }
 }

--- a/vtc-service/src/routes/mod.rs
+++ b/vtc-service/src/routes/mod.rs
@@ -542,6 +542,13 @@ fn build_api_chain(_routing: &RoutingConfig, trust_xff: bool) -> OpenApiRouter<A
             routes!(members::rotate::rotate),
             "https://trusttasks.org/openvtc/vtc/members/rotate/1.0",
         ))
+        // Reciprocal-VMC request — ask an active member to issue + send the
+        // member → community half of the membership pair. The member replies
+        // asynchronously over the `members/vmc/1.0` DIDComm surface.
+        .routes(tt(
+            routes!(members::request_vmc::request_vmc),
+            "https://trusttasks.org/openvtc/vtc/members/request-vmc/1.0",
+        ))
         // Phase 4 M4.3 + M4.4 — personhood lifecycle. Three
         // mounts on the same path prefix; declared BEFORE
         // `/v1/members/{did}` so axum's path-trie matches the


### PR DESCRIPTION
## What

Membership between a persona DID and a VTC is a **pair of VMCs**: the VTC issues one to the member at admission (community → member), and the member issues one back (member → community). Until now only the VTC → member half existed — the join-accept step recorded a member *`MembershipAcknowledgement`*, not a full VMC. This adds the **member → community half as a full `VerifiableMembershipCredential`**, plus an **admin-triggered request** for it.

Per the agreed plan: **VTC side first** (the openVTC member client that answers the request lands in a follow-up; today the VTC dispatches the request and verifies/stores whatever a member sends).

## Changes

**vta-sdk** (`protocols::members`, additive → 0.18.1 → 0.18.2; satisfies all `"0.18"` pins)
- `MEMBER_REQUEST_VMC_TYPE` (`members/request-vmc/1.0`, VTC → member), `MEMBER_VMC_TYPE` (`members/vmc/1.0`, member → VTC) + `#response` receipt, and their bodies.

**vtc-service** (0.10.5 → 0.10.6)
- `Member` gains `member_vmc` / `member_vmc_id` / `member_vmc_received_at` (cleared on tombstone); `record_member_vmc`.
- `members::inbound_vmc::receive_member_vmc_inner` verifies the member-issued VMC — `issuer == member`, `type` ⊇ `VerifiableMembershipCredential`, `credentialSubject.id == this VTC`, and the DI proof resolved via `DidVmResolver` (so **did:webvh** members verify, not just did:key) — and stores it. Idempotent re-send; a different VMC replaces (renewal).
- `POST /v1/members/{did}/request-vmc` (AdminAuth) dispatches the request to the member's agent over DIDComm (`push_to_holder`).
- DIDComm `members/vmc/1.0` handler → `receive_member_vmc_inner`, replies with a receipt or a threaded problem-report.
- `MemberResponse` surfaces `memberVmcId` / `memberVmcReceivedAt`.
- Admin UI: member detail shows the held member VMC and a **Request member VMC** button.

## Tests

`cargo test -p vtc-service --lib members::` — 15 pass (incl. Member round-trip with the new fields). `cargo check --all-targets`, `cargo fmt`, admin-ui `tsc` all clean. Verification mirrors the well-tested join-accept reciprocal path.

## Follow-ups

- openVTC member client: handle `members/request-vmc/1.0` and answer with `members/vmc/1.0`.
- A dedicated `AuditEvent::MemberVmcReceived` (kept out of this PR to avoid a vti-common version cascade; receipt is logged + persisted on the member row for now).