### PR TITLE
fix(vtc): deliver to members over HTTP, not a duplicate mediator websocket

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10200,7 +10200,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-service"
-version = "0.10.4"
+version = "0.10.7"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.10.5"
+version = "0.10.7"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vtc-service/src/credentials/delivery.rs
+++ b/vtc-service/src/credentials/delivery.rs
@@ -166,16 +166,23 @@ const DELIVERY_RETRY_BACKOFF: [Duration; 3] = [
     Duration::from_secs(2),
 ];
 
-/// Enable the websocket, pack the message authcrypt to the holder, and forward
-/// it through the VTC's mediator — retrying the whole send on failure with the
+/// Pack the message authcrypt to the holder and forward it through the VTC's
+/// mediator over **HTTP**, retrying the whole send on failure with the
 /// [`DELIVERY_RETRY_BACKOFF`] schedule.
 ///
-/// Mediator delivery over a websocket is exactly where a transient reset
-/// (`ConnectionReset` / a dropped/`Disconnected` socket) shows up, and any of the
-/// three steps can surface it, so each attempt re-runs all three: re-enabling the
-/// websocket reconnects a socket the previous attempt may have lost, and the pack
-/// is cheap to redo. On success it returns immediately; once the attempts are
-/// exhausted it returns the last error (the caller logs it best-effort).
+/// We deliberately do **not** enable a websocket here. The VTC's `state.atm`
+/// shares the VTC DID with the inbound `DIDCommService` listener, which already
+/// holds the one websocket the mediator permits per DID; enabling a second one
+/// on this ATM made the mediator terminate a connection as a
+/// `w.websocket.duplicate-channel`, and because the SDK socket auto-reconnects,
+/// the two then duelled indefinitely. `forward_and_send_message` →
+/// `send_message` falls back to the mediator's REST endpoint when no websocket
+/// is enabled (and we pass `wait_for_response = false`, a one-shot POST), so the
+/// forward is delivered over HTTP without ever opening a competing socket.
+///
+/// Retried because an HTTP forward can still hit a transient mediator blip; the
+/// pack is cheap to redo. On success it returns immediately; once the attempts
+/// are exhausted it returns the last error (the caller logs it best-effort).
 async fn send_with_retry(
     atm: &affinidi_tdk::messaging::ATM,
     profile: &Arc<ATMProfile>,
@@ -188,10 +195,6 @@ async fn send_with_retry(
     let mut attempt = 0usize;
     loop {
         let result: Result<(), AppError> = async {
-            atm.profile_enable_websocket(profile)
-                .await
-                .map_err(|e| AppError::Internal(format!("mediator websocket failed: {e}")))?;
-
             let (jwe, _meta) = atm
                 .pack_encrypted(msg, holder_did, Some(vtc_did), None)
                 .await


### PR DESCRIPTION
## Problem

The VTC kept logging `w.websocket.duplicate-channel` problem-reports from its mediator every ~1–2s ("A new duplicate websocket connection for this DID has caused this websocket to terminate") — not an orphaned process.

Root cause: the mediator allows **one websocket per DID**, but the VTC opened two for its own DID:
- the inbound `DIDCommService` listener holds a persistent websocket;
- `credentials/delivery.rs::push_to_holder` → `send_with_retry` called `atm.profile_enable_websocket(...)` on the long-lived `state.atm` (same VTC DID) for every outbound send, and **never disabled it**.

The mediator terminated one socket as a duplicate; the SDK auto-reconnects both, so the listener and the delivery socket then duelled indefinitely (the continuous problem-reports + a flapping inbound listener). One credential delivery was enough to start it.

## Fix

Drop `profile_enable_websocket` from the delivery path. `forward_and_send_message` → `send_message` uses the websocket **only if one is enabled**, otherwise it POSTs to the mediator's REST `/inbound` endpoint (`send_didcomm_message`, which self-authenticates via the profile). Delivery passes `wait_for_response = false` (a one-shot forward), so HTTP is the right transport — the forward is delivered without ever opening a second socket, and the inbound listener keeps the sole websocket.

This also surfaced cleanly thanks to #547 (logging the problem-report `code`/`comment`).

## Caveat / follow-up

- A mediator exposing **only** `wss://` (no REST) would now fail outbound delivery; affinidi mediators expose both ws + REST, and the retry logs best-effort on failure.
- The architecturally clean fix is a **single shared ATM/connection** for inbound + outbound (so there's only ever one socket); that's a larger refactor of `run_didcomm_service` + the delivery path, left as a follow-up.

## Test

`cargo check -p vtc-service`, `cargo fmt`, `cargo test --lib credentials::delivery` all clean. `vtc-service` 0.10.5 → 0.10.7 (0.10.6 is the open #549).