### PR TITLE
fix(vtc): send to members over the shared listener connection, not HTTP

### DIFF
--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.10.8"
+version = "0.10.9"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vtc-service/src/credentials/delivery.rs
+++ b/vtc-service/src/credentials/delivery.rs
@@ -16,12 +16,8 @@
 //! persisted, so the caller logs a delivery failure rather than unwinding the
 //! decision.
 
-use std::sync::Arc;
-use std::time::Duration;
-
 use affinidi_messaging_didcomm::Message;
 use affinidi_openid4vci::issuer::create_credential_response;
-use affinidi_tdk::messaging::profiles::ATMProfile;
 use affinidi_vc::VerifiableCredential;
 use serde_json::Value as JsonValue;
 use uuid::Uuid;
@@ -82,16 +78,18 @@ fn issue_message_body(credential_json: JsonValue) -> Result<JsonValue, AppError>
         .map_err(|e| AppError::Internal(format!("issue body serialise: {e}")))
 }
 
-/// Pack `body` as a DIDComm message (`msg_id` / `msg_type`) authcrypt to
-/// `holder_did`, wrap it in a mediator forward, and send it.
+/// Pack `body` as a DIDComm message (`msg_id` / `msg_type`) from the VTC to
+/// `holder_did` and send it over the VTC's **shared inbound mediator
+/// connection** via [`AppState::send_to_member`].
 ///
-/// The forward is addressed to the **holder's own mediator** (resolved from the
-/// holder's DID document) and sent through the **VTC's own mediator** — the
-/// mediator the VTC has a connection to. The VTC's mediator routes the forward
-/// onward to the holder's mediator, which delivers it. When the holder advertises
-/// no mediator, the VTC's own mediator is used as the forward target (the
-/// shared-mediator deployment). Shared by the credential-query push and the
-/// issued-credential delivery.
+/// This is the single outbound funnel — credential-query push, issued-credential
+/// delivery, and the member-VMC request all go through it. Routing the send
+/// through the running listener's connection is deliberate: the mediator allows
+/// one websocket per DID, so an outbound path must reuse that connection rather
+/// than open its own (a second one made the mediator terminate connections with
+/// `w.websocket.duplicate-channel`, and the auto-reconnecting sockets then
+/// duelled). The listener packs authcrypt and forwards through the VTC's
+/// mediator — the same path inbound replies already take to reach members.
 pub(crate) async fn push_to_holder(
     state: &AppState,
     holder_did: &str,
@@ -99,166 +97,21 @@ pub(crate) async fn push_to_holder(
     msg_type: &str,
     body: JsonValue,
 ) -> Result<(), AppError> {
-    let atm = state
-        .atm
-        .as_ref()
-        .ok_or_else(|| AppError::Internal("messaging (ATM) not configured".into()))?;
-
-    let (vtc_did, mediator_did) = {
-        let config = state.config.read().await;
-        let vtc_did = config
-            .vtc_did
-            .clone()
-            .ok_or_else(|| AppError::Internal("VTC DID not configured".into()))?;
-        let mediator_did = config
-            .messaging
-            .as_ref()
-            .map(|m| m.mediator_did.clone())
-            .ok_or_else(|| AppError::Internal("no mediator configured for messaging".into()))?;
-        (vtc_did, mediator_did)
-    };
-
-    // Resolve the holder's own mediator from its DID document; fall back to the
-    // VTC's mediator (shared-mediator deployment) when the holder has none.
-    let target_mediator = resolve_holder_mediator(state, holder_did)
+    let vtc_did = state
+        .config
+        .read()
         .await
-        .unwrap_or_else(|| mediator_did.clone());
+        .vtc_did
+        .clone()
+        .filter(|d| !d.is_empty())
+        .ok_or_else(|| AppError::Internal("VTC DID not configured".into()))?;
 
-    // The VTC sends through its OWN mediator (the profile's connection); the
-    // forward, addressed to the holder's mediator, is routed onward from there.
-    let profile = Arc::new(
-        ATMProfile::new(atm, None, vtc_did.clone(), Some(mediator_did.clone()))
-            .await
-            .map_err(|e| AppError::Internal(format!("ATM profile setup failed: {e}")))?,
-    );
-
-    let msg = Message::build(msg_id.to_string(), msg_type.to_string(), body)
-        .from(vtc_did.clone())
+    let message = Message::build(msg_id.to_string(), msg_type.to_string(), body)
+        .from(vtc_did)
         .to(holder_did.to_string())
         .finalize();
 
-    // Send with a bounded retry. A transient mediator WebSocket failure (e.g.
-    // "Connection reset by peer" / a disconnected socket) right around the
-    // forward must not permanently drop an already-issued credential — nothing
-    // re-pushes it, so the member would be stuck "Pending" forever. Each attempt
-    // re-enables the websocket (the previous connection may be gone) and re-packs
-    // the message; on the final attempt the error is returned so the caller can
-    // log the best-effort failure.
-    send_with_retry(
-        atm,
-        &profile,
-        &msg,
-        msg_id,
-        holder_did,
-        &vtc_did,
-        &target_mediator,
-    )
-    .await
-}
-
-/// Backoff between credential-delivery send attempts. The schedule is the wait
-/// *before* attempts 2, 3, and 4 — total of four attempts. Kept short and
-/// in-request (this runs on the approve/admit path), so it rides out a transient
-/// mediator WebSocket blip without holding the caller for long.
-const DELIVERY_RETRY_BACKOFF: [Duration; 3] = [
-    Duration::from_millis(500),
-    Duration::from_secs(1),
-    Duration::from_secs(2),
-];
-
-/// Pack the message authcrypt to the holder and forward it through the VTC's
-/// mediator over **HTTP**, retrying the whole send on failure with the
-/// [`DELIVERY_RETRY_BACKOFF`] schedule.
-///
-/// We deliberately do **not** enable a websocket here. The VTC's `state.atm`
-/// shares the VTC DID with the inbound `DIDCommService` listener, which already
-/// holds the one websocket the mediator permits per DID; enabling a second one
-/// on this ATM made the mediator terminate a connection as a
-/// `w.websocket.duplicate-channel`, and because the SDK socket auto-reconnects,
-/// the two then duelled indefinitely. `forward_and_send_message` →
-/// `send_message` falls back to the mediator's REST endpoint when no websocket
-/// is enabled (and we pass `wait_for_response = false`, a one-shot POST), so the
-/// forward is delivered over HTTP without ever opening a competing socket.
-///
-/// Retried because an HTTP forward can still hit a transient mediator blip; the
-/// pack is cheap to redo. On success it returns immediately; once the attempts
-/// are exhausted it returns the last error (the caller logs it best-effort).
-async fn send_with_retry(
-    atm: &affinidi_tdk::messaging::ATM,
-    profile: &Arc<ATMProfile>,
-    msg: &Message,
-    msg_id: &str,
-    holder_did: &str,
-    vtc_did: &str,
-    target_mediator: &str,
-) -> Result<(), AppError> {
-    let mut attempt = 0usize;
-    loop {
-        let result: Result<(), AppError> = async {
-            let (jwe, _meta) = atm
-                .pack_encrypted(msg, holder_did, Some(vtc_did), None)
-                .await
-                .map_err(|e| AppError::Internal(format!("pack_encrypted failed: {e}")))?;
-
-            atm.forward_and_send_message(
-                profile,
-                false,
-                &jwe,
-                Some(msg_id),
-                target_mediator,
-                holder_did,
-                None,
-                None,
-                false,
-            )
-            .await
-            .map_err(|e| AppError::Internal(format!("mediator forward failed: {e}")))?;
-
-            Ok(())
-        }
-        .await;
-
-        match result {
-            Ok(()) => return Ok(()),
-            Err(e) => match DELIVERY_RETRY_BACKOFF.get(attempt) {
-                Some(delay) => {
-                    tracing::warn!(
-                        holder_did,
-                        msg_id,
-                        attempt = attempt + 1,
-                        error = %e,
-                        "credential delivery send failed; retrying after backoff"
-                    );
-                    tokio::time::sleep(*delay).await;
-                    attempt += 1;
-                }
-                // Backoff schedule exhausted (all attempts used) — surface the
-                // last error for the caller's best-effort log.
-                None => return Err(e),
-            },
-        }
-    }
-}
-
-/// Resolve the holder's own DIDComm mediator from its DID document — the `did:`
-/// `uri` of its `DIDCommMessaging` service. Returns `None` when the holder
-/// advertises no mediator (so the caller routes through its own).
-async fn resolve_holder_mediator(state: &AppState, holder_did: &str) -> Option<String> {
-    let resolver = state.did_resolver.as_ref()?;
-    let resolved = resolver.resolve(holder_did).await.ok()?;
-    for svc in &resolved.doc.service {
-        if svc.type_.iter().any(|t| t == "DIDCommMessaging")
-            && let Some(mediator) = svc
-                .service_endpoint
-                .get_uris()
-                .into_iter()
-                .map(|u| u.trim_matches('"').to_string())
-                .find(|u| u.starts_with("did:"))
-        {
-            return Some(mediator);
-        }
-    }
-    None
+    state.send_to_member(holder_did, message).await
 }
 
 #[cfg(test)]

--- a/vtc-service/src/messaging.rs
+++ b/vtc-service/src/messaging.rs
@@ -40,6 +40,11 @@ use crate::members::Disposition;
 use crate::server::AppState;
 use crate::trust_tasks::{JoinAuthCtx, TrustTaskOutcome, dispatch_trust_task_core};
 
+/// Id of the VTC's single inbound DIDComm listener. Used both to register the
+/// listener and, via [`AppState::send_to_member`](crate::server::AppState::send_to_member),
+/// to send outbound over that same connection.
+pub const VTC_LISTENER_ID: &str = "vtc-main";
+
 /// Start the DIDComm service and block until shutdown.
 ///
 /// Uses `DIDCommService` for automatic mediator connection management,
@@ -56,6 +61,10 @@ pub async fn run_didcomm_service(
     state: AppState,
     shutdown_rx: &mut watch::Receiver<bool>,
 ) {
+    // The slot every outbound `AppState::send_to_member` reads — published
+    // below once the service starts, so all `AppState` clones share the one
+    // listener connection. Captured before `state` moves into the router.
+    let didcomm_slot = state.didcomm.clone();
     let mediator_did = match &config.messaging {
         Some(m) => &m.mediator_did,
         None => {
@@ -84,7 +93,7 @@ pub async fn run_didcomm_service(
 
     let service_config = DIDCommServiceConfig {
         listeners: vec![ListenerConfig {
-            id: "vtc-main".into(),
+            id: VTC_LISTENER_ID.into(),
             profile,
             restart_policy: RestartPolicy::Always {
                 backoff: RetryConfig {
@@ -174,7 +183,7 @@ pub async fn run_didcomm_service(
     let shutdown_token = CancellationToken::new();
     let service = match DIDCommService::start(service_config, router, shutdown_token.clone()).await
     {
-        Ok(s) => s,
+        Ok(s) => Arc::new(s),
         Err(e) => {
             warn!("failed to start DIDComm service: {e}");
             let _ = shutdown_rx.changed().await;
@@ -182,13 +191,20 @@ pub async fn run_didcomm_service(
         }
     };
 
+    // Publish the service so any VTC component can send to a member over this
+    // one connection (`AppState::send_to_member`) instead of opening its own
+    // websocket. Set-once; the service object persists across reconnects.
+    if didcomm_slot.set(service.clone()).is_err() {
+        warn!("DIDComm service handle was already published — outbound sends use the existing one");
+    }
+
     // Wait for the mediator connection
     match service
-        .wait_connected("vtc-main", Duration::from_secs(30))
+        .wait_connected(VTC_LISTENER_ID, Duration::from_secs(30))
         .await
     {
         Ok(()) => info!(
-            listener = "vtc-main",
+            listener = VTC_LISTENER_ID,
             "DIDComm listener connected to mediator — inbound messages will be processed"
         ),
         Err(e) => warn!(

--- a/vtc-service/src/routes/members/request_vmc.rs
+++ b/vtc-service/src/routes/members/request_vmc.rs
@@ -44,6 +44,7 @@ pub struct RequestVmcResponse {
 /// POST /members/{did}/request-vmc — dispatch a reciprocal-VMC request.
 #[utoipa::path(
     post, path = "/members/{did}/request-vmc", tag = "members",
+    security(("bearer_jwt" = [])),
     params(("did" = String, Path, description = "Member DID")),
     request_body = RequestVmcBody,
     responses(

--- a/vtc-service/src/server.rs
+++ b/vtc-service/src/server.rs
@@ -4,6 +4,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 use affinidi_did_resolver_cache_sdk::{DIDCacheClient, config::DIDCacheConfigBuilder};
+use affinidi_messaging_didcomm_service::DIDCommService;
 use affinidi_tdk::common::TDKSharedState;
 use affinidi_tdk::common::config::TDKConfig;
 use affinidi_tdk::messaging::ATM;
@@ -170,6 +171,14 @@ pub struct AppState {
     /// `Some(Manual)` / `None` without racing other tests on the
     /// shared `std::env`.
     pub supervisor: Option<SupervisorKind>,
+    /// Shared handle to the running inbound DIDComm listener, published by
+    /// [`crate::messaging::run_didcomm_service`] once it starts. Every outbound
+    /// message to a member goes through this (see [`Self::send_to_member`]) so
+    /// it reuses the listener's single mediator websocket — the mediator permits
+    /// only one connection per DID, and opening a second made it terminate one
+    /// as `w.websocket.duplicate-channel`. Unset until the listener boots (and
+    /// when messaging is disabled), so sends are best-effort.
+    pub didcomm: Arc<tokio::sync::OnceCell<Arc<DIDCommService>>>,
 }
 
 impl AppState {
@@ -195,6 +204,36 @@ impl AppState {
             .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |n| {
                 Some(n.saturating_sub(1))
             });
+    }
+
+    /// Send a proactive DIDComm message to a member/holder over the VTC's
+    /// **single inbound mediator connection** (the running listener). This is
+    /// the one channel any VTC component uses to initiate an interaction with a
+    /// member — credential delivery, the credential-exchange query, the
+    /// reciprocal-VMC request. It reuses the listener's websocket (the SDK packs
+    /// authcrypt and forwards through the VTC's mediator, exactly as the inbound
+    /// reply path does), so outbound never opens a competing socket.
+    ///
+    /// `Err` when the listener isn't running/connected yet; callers treat
+    /// delivery as best-effort.
+    pub async fn send_to_member(
+        &self,
+        recipient_did: &str,
+        message: affinidi_messaging_didcomm::Message,
+    ) -> Result<(), AppError> {
+        let service = self.didcomm.get().ok_or_else(|| {
+            AppError::Internal("DIDComm listener not running — cannot send to member".into())
+        })?;
+        service
+            .send_message_with_retry(
+                crate::messaging::VTC_LISTENER_ID,
+                message,
+                recipient_did,
+                3,
+                std::time::Duration::from_secs(2),
+            )
+            .await
+            .map_err(|e| AppError::Internal(format!("DIDComm send to {recipient_did} failed: {e}")))
     }
 }
 
@@ -541,6 +580,7 @@ pub async fn run(
         audit_writer,
         shutdown_tx: shutdown_tx.clone(),
         supervisor: detect_supervisor(),
+        didcomm: Arc::new(tokio::sync::OnceCell::new()),
     };
 
     // Heal missing AdminEntries: any DID with an Admin ACL grant +

--- a/vtc-service/src/test_support.rs
+++ b/vtc-service/src/test_support.rs
@@ -359,6 +359,7 @@ impl TestVtcBuilder {
             audit_writer,
             shutdown_tx: watch::channel(false).0,
             supervisor: self.supervisor,
+            didcomm: Arc::new(tokio::sync::OnceCell::new()),
         };
 
         let router = crate::routes::router().with_state(state.clone());

--- a/vtc-service/tests/emergency_bootstrap.rs
+++ b/vtc-service/tests/emergency_bootstrap.rs
@@ -332,6 +332,7 @@ async fn build_fixture(public_url: Option<&str>) -> Fixture {
         audit_writer,
         shutdown_tx: tokio::sync::watch::channel(false).0,
         supervisor: None,
+        didcomm: std::sync::Arc::new(tokio::sync::OnceCell::new()),
     };
 
     let router = routes::router().with_state(state);

--- a/vtc-service/tests/passkey_state.rs
+++ b/vtc-service/tests/passkey_state.rs
@@ -107,6 +107,7 @@ fn build_state(public_url: Option<&str>) -> (AppState, tempfile::TempDir) {
         audit_writer: None,
         shutdown_tx: tokio::sync::watch::channel(false).0,
         supervisor: None,
+        didcomm: std::sync::Arc::new(tokio::sync::OnceCell::new()),
     };
     (state, dir)
 }


### PR DESCRIPTION
## Why

#550 stopped the `w.websocket.duplicate-channel` duel by routing outbound member sends over **HTTP**. But the VTC already holds a DIDComm websocket to its mediator (the inbound listener), and HTTP fallback goes against the workspace's "prefer DIDComm" rule. As @-you noted: it should just use the connection we already have.

This makes outbound reuse the inbound listener's single mediator connection — so **any** VTC component can channel an interaction with a member through the one socket, all over DIDComm authcrypt.

## How

- **`AppState.didcomm`**: a shared `Arc<OnceCell<Arc<DIDCommService>>>`, published by `run_didcomm_service` once the listener starts (captured before `state` moves into the router so all clones see it).
- **`AppState::send_to_member(recipient, message)`**: sends via `DIDCommService::send_message_with_retry(VTC_LISTENER_ID, …)`. The SDK packs authcrypt and forwards through the VTC's mediator over the **existing** socket — *"Uses the same ATM connection as the listener, avoiding duplicate websocket sessions"* (its own doc). This is the exact path inbound replies (`transport::send_response`) already take to reach members, so routing is proven.
- **`push_to_holder`** — the single outbound funnel (credential delivery, credential-exchange query, member-VMC request) — now builds the message and calls `send_to_member`. The bespoke ATM/profile construction, websocket-or-HTTP send, retry loop, and holder-mediator resolution are deleted.

Net: no second connection is ever opened (so the duplicate-channel duel can't recur), and outbound is DIDComm, not HTTP — superseding #550's stopgap.

## Drive-by

The `request-vmc` route (added in #549) was missing `security(("bearer_jwt" = []))` on its `#[utoipa::path]`, so the P0.5 OpenAPI backstop (`every_unauthenticated_route_is_classified`) flagged it as an unclassified unauth route even though it's `AdminAuth`-gated. Added the annotation.

## Test

`cargo check --all-targets`, `cargo fmt` clean. `cargo test -p vtc-service --lib` — 660 pass; the only failures are the 4 `admin_ui::tests::*` embed checks, which require the admin SPA `dist/` (skipped here via `VTC_SKIP_ADMIN_UI_BUILD=1`; a full CI build embeds it and they pass). The OpenAPI classification test now passes.

`vtc-service` 0.10.8 → 0.10.9.