### PR TITLE
fix(vtc): accept the DTG-canonical MembershipCredential tag in VMC verifiers (#553)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2441,7 +2441,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.18.2",
+ "vta-sdk 0.18.3",
 ]
 
 [[package]]
@@ -3211,7 +3211,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.18.2",
+ "vta-sdk 0.18.3",
 ]
 
 [[package]]
@@ -6698,7 +6698,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.18.2",
+ "vta-sdk 0.18.3",
 ]
 
 [[package]]
@@ -9964,7 +9964,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.18.2",
+ "vta-sdk 0.18.3",
  "vti-common",
  "x25519-dalek",
 ]
@@ -9997,7 +9997,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.18.2",
+ "vta-sdk 0.18.3",
 ]
 
 [[package]]
@@ -10020,7 +10020,7 @@ dependencies = [
  "tracing-subscriber",
  "trust-tasks-rs",
  "uniffi",
- "vta-sdk 0.18.2",
+ "vta-sdk 0.18.3",
 ]
 
 [[package]]
@@ -10055,7 +10055,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.18.2"
+version = "0.18.3"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10186,7 +10186,7 @@ dependencies = [
  "utoipa-axum",
  "uuid",
  "vta-cli-common",
- "vta-sdk 0.18.2",
+ "vta-sdk 0.18.3",
  "vta-service",
  "vti-common",
  "vti-secrets",
@@ -10200,7 +10200,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-service"
-version = "0.10.8"
+version = "0.10.10"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",
@@ -10267,7 +10267,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.18.2",
+ "vta-sdk 0.18.3",
  "vtc-service",
  "vti-common",
  "vti-secrets",
@@ -10315,7 +10315,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.18.2",
+ "vta-sdk 0.18.3",
  "webauthn-rs",
  "zeroize",
 ]
@@ -10342,7 +10342,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.18.2",
+ "vta-sdk 0.18.3",
  "vta-service",
  "vti-common",
 ]
@@ -10371,7 +10371,7 @@ dependencies = [
  "tokio",
  "tracing",
  "vaultrs",
- "vta-sdk 0.18.2",
+ "vta-sdk 0.18.3",
  "vti-common",
 ]
 

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.18.2"
+version = "0.18.3"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/protocols/members.rs
+++ b/vta-sdk/src/protocols/members.rs
@@ -1,7 +1,7 @@
 //! Member-side membership-credential exchange (`members/*`).
 //!
 //! Membership between a persona DID and a VTC is a **pair of VMCs**: the VTC
-//! issues a `VerifiableMembershipCredential` to the member at admission
+//! issues a `MembershipCredential` to the member at admission
 //! (community → member), and the member issues one back to the VTC
 //! (member → community), so each side holds a credential asserting the other's
 //! membership edge. The join-ceremony `accept` step records a member-issued
@@ -23,7 +23,14 @@ use serde_json::Value;
 /// (alongside `VerifiableCredential`). Same credential type the VTC issues for
 /// its half of the pair — the direction is given by `issuer` /
 /// `credentialSubject.id`, not the type.
-pub const VERIFIABLE_MEMBERSHIP_CREDENTIAL_TYPE: &str = "VerifiableMembershipCredential";
+///
+/// The value is the canonical DTG / W3C tag `MembershipCredential` — exactly
+/// what `dtg-credentials` emits (`DTGCredentialType::Membership`) and what the
+/// VTC's own issuance stamps. The `VERIFIABLE_` prefix in the *name* is
+/// historical; the *tag* is `MembershipCredential`, not
+/// `VerifiableMembershipCredential`, so a credential built with the typed
+/// `dtg-credentials` API verifies without hand-rolling the VC JSON.
+pub const VERIFIABLE_MEMBERSHIP_CREDENTIAL_TYPE: &str = "MembershipCredential";
 
 /// VTC → member: request that the member issue and send their reciprocal VMC.
 pub const MEMBER_REQUEST_VMC_TYPE: &str =

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.10.9"
+version = "0.10.10"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vtc-service/src/credentials/vmc.rs
+++ b/vtc-service/src/credentials/vmc.rs
@@ -9,7 +9,7 @@
 //!     "https://www.w3.org/ns/credentials/v2",
 //!     "https://openvtc.org/contexts/dtg-membership-v1.jsonld"
 //!   ],
-//!   "type": ["VerifiableCredential", "VerifiableMembershipCredential"],
+//!   "type": ["VerifiableCredential", "MembershipCredential"],
 //!   "issuer": "did:webvh:vtc.example.com:abc",
 //!   "validFrom": "2026-05-12T00:00:00Z",
 //!   "validUntil": "2026-06-11T00:00:00Z",
@@ -189,7 +189,7 @@ mod tests {
             .expect("build VMC");
 
         // Type array contains both `VerifiableCredential` (the
-        // builder adds it implicitly) and `VerifiableMembershipCredential`.
+        // builder adds it implicitly) and `MembershipCredential`.
         assert!(vc.types.iter().any(|t| t == "VerifiableCredential"));
         assert!(vc.types.iter().any(|t| t == VMC_TYPE));
 

--- a/vtc-service/src/members/inbound_vmc.rs
+++ b/vtc-service/src/members/inbound_vmc.rs
@@ -1,7 +1,7 @@
 //! Receive + verify a member-issued **VMC** (member → community half of the
 //! membership pair) and record it on the member's row.
 //!
-//! The VTC issues a `VerifiableMembershipCredential` to each member at
+//! The VTC issues a `MembershipCredential` to each member at
 //! admission; this is the reciprocal the member issues back, naming the
 //! community as its `credentialSubject`. The `eddsa-jcs-2022` issuer proof (key
 //! under the member's DID, resolved via [`DidVmResolver`] so `did:webvh`

--- a/vtc-service/src/members/mod.rs
+++ b/vtc-service/src/members/mod.rs
@@ -119,7 +119,7 @@ pub struct Member {
     #[serde(default)]
     pub joined_via_invitation: bool,
     /// The member → community half of the membership VMC pair: the
-    /// member-issued `VerifiableMembershipCredential` (a Data-Integrity VC
+    /// member-issued `MembershipCredential` (a Data-Integrity VC
     /// whose `issuer` is this member and `credentialSubject.id` is the
     /// community DID), received over the `members/vmc/1.0` exchange and
     /// verified before storage. `None` until the member sends one. Distinct

--- a/vtc-service/src/recognition/mod.rs
+++ b/vtc-service/src/recognition/mod.rs
@@ -4,7 +4,7 @@
 //! members to the trust registry; this module is the **inverse**
 //! path — taking a foreign community's
 //! `VerifiableEndorsementCredential` +
-//! `VerifiableMembershipCredential` and deciding whether the
+//! `MembershipCredential` and deciding whether the
 //! local VTC should mint a session for the bearer.
 //!
 //! ## Session-mint hardening (fail-closed)

--- a/vtc-service/src/routes/recognise.rs
+++ b/vtc-service/src/routes/recognise.rs
@@ -69,6 +69,7 @@ use crate::recognition::{
 };
 use crate::server::AppState;
 use affinidi_vc::VerifiableCredential;
+use vta_sdk::protocols::members::VERIFIABLE_MEMBERSHIP_CREDENTIAL_TYPE;
 
 /// Request body for `POST /v1/auth/recognise`. The caller supplies a
 /// holder-signed W3C Verifiable Presentation that embeds the foreign VEC and
@@ -310,9 +311,9 @@ fn extract_vec_vmc(
         } else if cred
             .types
             .iter()
-            .any(|t| t == "VerifiableMembershipCredential")
+            .any(|t| t == VERIFIABLE_MEMBERSHIP_CREDENTIAL_TYPE)
         {
-            (&mut vmc_cred, "VerifiableMembershipCredential")
+            (&mut vmc_cred, VERIFIABLE_MEMBERSHIP_CREDENTIAL_TYPE)
         } else {
             continue;
         };
@@ -327,7 +328,9 @@ fn extract_vec_vmc(
         AppError::Validation("presentation has no VerifiableEndorsementCredential".into())
     })?;
     let vmc = vmc_cred.ok_or_else(|| {
-        AppError::Validation("presentation has no VerifiableMembershipCredential".into())
+        AppError::Validation(format!(
+            "presentation has no {VERIFIABLE_MEMBERSHIP_CREDENTIAL_TYPE}"
+        ))
     })?;
     Ok((vec, vmc))
 }


### PR DESCRIPTION
Fixes #553.

## Problem

The member-VMC verifier (`members/inbound_vmc.rs`) and the cross-community recognition gate (`routes/recognise.rs`) required a `type` tag of `VerifiableMembershipCredential`. But the **DTG spec** — the source of truth, per the `dtg-credentials` reference impl (context `https://firstperson.network/credentials/dtg/v1`) — defines the membership type as **`MembershipCredential`**. There is no `VerifiableMembershipCredential` in the DTG enum; the full conformant array is `["VerifiableCredential", "DTGCredential", "MembershipCredential"]`.

All VTC issuance already flows through the DTG catalog (`build_vmc` → `dtg::issue_membership` → `DTGCredential::new_vmc`), so the VTC's own VMCs — and any member-issued VMC built with the typed `dtg-credentials` API — were being rejected by its own verifier.

## Fix

- `VERIFIABLE_MEMBERSHIP_CREDENTIAL_TYPE` now holds `"MembershipCredential"`. The const **name** is kept (no breaking `vta-sdk` API change; openvtc matches the literal, not the const, so both repos now agree); a doc note records that the `VERIFIABLE_` prefix is historical.
- `routes/recognise.rs` routes its VMC slot through the SDK const instead of a string literal, fixing the same mismatch in the recognition path.
- Stale `VerifiableMembershipCredential` doc comments corrected.
- Version bumps: `vta-sdk` 0.18.2 → 0.18.3, `vtc-service` 0.10.9 → 0.10.10.

No issuance change needed — issuance is already DTG-conformant; the verifiers were the only thing out of step.

## Verification

- `cargo check -p vta-sdk -p vtc-service` clean.
- `cargo test -p vtc-service` — VMC, member, and recognition suites pass (7 + 75 tests).

https://claude.ai/code/session_012LP9Wxjs4PWL66oYDUfn71