### PR TITLE
feat(vtc): audit payload enrichment + tamper-evidence hash chain (#537)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10200,7 +10200,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-service"
-version = "0.10.10"
+version = "0.10.11"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",
@@ -10280,7 +10280,7 @@ dependencies = [
 
 [[package]]
 name = "vti-common"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "aes-gcm",
  "affinidi-did-resolver-cache-sdk",

--- a/docs/05-design-notes/vtc-mvp.md
+++ b/docs/05-design-notes/vtc-mvp.md
@@ -985,12 +985,14 @@ See §6.4.
 struct AuditEnvelope {
     event_id: Uuid,
     event_version: u32,        // bumped on breaking shape change
-    schema_version: u32,
+    schema_version: u32,       // 2 = hash-chained (see below)
     timestamp: DateTime<Utc>,
     actor_did_hash:  [u8; 32], // HMAC-SHA256(audit_key, did_bytes)
     actor_did_plain: Option<String>,
     target_did_hash:  Option<[u8; 32]>,
     target_did_plain: Option<String>,
+    prev_hash:  [u8; 32],      // entry_hash of the previous envelope
+    entry_hash: [u8; 32],      // SHA-256 commitment to this envelope
     event: AuditEvent,         // tagged enum, see §11.4
 }
 ```
@@ -1000,10 +1002,26 @@ separately from the audit log (own keyspace, encrypted under the
 VTC seed), per-community. Plain SHA-256 over a DID is reversible by
 enumeration (DIDs are a small public space).
 
+**Tamper-evidence (hash chain).** Each envelope's `entry_hash` is a
+domain-tagged SHA-256 commitment over its *immutable* fields, and
+`prev_hash` points at the previous envelope's `entry_hash` — a
+per-row chain anchored at `GENESIS_HASH` (all zeros). Reordering,
+dropping, duplicating, or editing any envelope is detectable by
+`audit::verify_chain`, which walks the keyspace in `<timestamp>:
+<event_id>` order. Writes are serialised process-wide (the single
+`AuditWriter` holds the chain head under a lock; it recovers the head
+from storage on restart), so concurrent events can't fork the chain.
+The digest **excludes** `entry_hash` itself and the `*_plain` fields,
+so RTBF redaction (below) does not break the chain — the HMAC hashes
+it covers are immutable. Pre-v2 envelopes carry no chain fields
+(`serde` defaults them to `GENESIS_HASH`); `verify_chain` skips them
+and re-anchors at the first v2 entry.
+
 **RTBF.** Right-to-be-forgotten requests null the `*_plain` fields
 and **rotate the `audit_key`**. Pre-rotation hashes become opaque to
 anyone without the prior key; post-rotation events use the new key.
-Audit chain integrity preserved via the per-envelope `event_id`.
+Nulling `*_plain` leaves the hash chain intact (the digest excludes
+those fields).
 
 ### 11.2 Query
 

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.10.10"
+version = "0.10.11"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vtc-service/src/ceremony/orchestrate.rs
+++ b/vtc-service/src/ceremony/orchestrate.rs
@@ -197,7 +197,8 @@ pub async fn purge_member(
 
     // Must have *something* to purge — a Member row and/or an ACL entry.
     let has_member = get_member(&state.members_ks, target_did).await?.is_some();
-    let has_acl = get_acl_entry(&state.acl_ks, target_did).await?.is_some();
+    let prior_acl = get_acl_entry(&state.acl_ks, target_did).await?;
+    let has_acl = prior_acl.is_some();
     if !has_member && !has_acl {
         return Err(AppError::NotFound(format!(
             "no member or tombstone to purge: {target_did}"
@@ -227,6 +228,7 @@ pub async fn purge_member(
             AuditEvent::MemberRemoved(MemberRemovedData {
                 disposition: "purge".into(),
                 reason: "operator purge".into(),
+                prior_role: prior_acl.as_ref().map(|a| a.role.to_string()),
             }),
         )
         .await?;
@@ -351,6 +353,7 @@ pub async fn remove_inner(
             AuditEvent::MemberRemoved(MemberRemovedData {
                 disposition: disposition_str.into(),
                 reason: reason.clone(),
+                prior_role: Some(target_acl.role.to_string()),
             }),
         )
         .await?;

--- a/vtc-service/src/community/profile.rs
+++ b/vtc-service/src/community/profile.rs
@@ -224,6 +224,79 @@ pub async fn store_profile(
     ks.insert(PROFILE_STORAGE_KEY.to_vec(), profile).await
 }
 
+/// Iterate profile fields as `(key, old_value, new_value)` triples
+/// (camelCase keys — wire-stable). Includes `community_did` so a
+/// mismatched-but-allowed (fresh-install) import surfaces it in the
+/// diff. The single source of truth for "which profile fields exist"
+/// — both the admin-config import preview and the audit before/after
+/// enrichment build on it.
+pub(crate) fn profile_field_pairs(
+    current: Option<&CommunityProfile>,
+    incoming: &CommunityProfile,
+) -> Vec<(&'static str, Option<Value>, Option<Value>)> {
+    let s = |v: &str| Value::String(v.to_string());
+    let opt_s = |v: &Option<String>| match v {
+        Some(s) => Value::String(s.clone()),
+        None => Value::Null,
+    };
+    vec![
+        (
+            "communityDid",
+            current.map(|p| s(&p.community_did)),
+            Some(s(&incoming.community_did)),
+        ),
+        ("name", current.map(|p| s(&p.name)), Some(s(&incoming.name))),
+        (
+            "description",
+            current.map(|p| s(&p.description)),
+            Some(s(&incoming.description)),
+        ),
+        (
+            "logoUrl",
+            current.map(|p| opt_s(&p.logo_url)),
+            Some(opt_s(&incoming.logo_url)),
+        ),
+        (
+            "publicUrl",
+            current.map(|p| opt_s(&p.public_url)),
+            Some(opt_s(&incoming.public_url)),
+        ),
+        (
+            "contactEmail",
+            current.map(|p| opt_s(&p.contact_email)),
+            Some(opt_s(&incoming.contact_email)),
+        ),
+        (
+            "language",
+            current.map(|p| s(&p.language)),
+            Some(s(&incoming.language)),
+        ),
+        (
+            "extensions",
+            current.map(|p| p.extensions.clone()),
+            Some(incoming.extensions.clone()),
+        ),
+    ]
+}
+
+/// Before/after [`FieldChange`]s for the fields that actually changed
+/// between `prior` and `incoming`. Powers the `changes` enrichment on
+/// the `CommunityProfileUpdated` audit event.
+pub(crate) fn profile_changes(
+    prior: Option<&CommunityProfile>,
+    incoming: &CommunityProfile,
+) -> Vec<vti_common::audit::FieldChange> {
+    profile_field_pairs(prior, incoming)
+        .into_iter()
+        .filter(|(_, old, new)| old != new)
+        .map(|(field, old, new)| vti_common::audit::FieldChange {
+            field: field.to_string(),
+            old,
+            new,
+        })
+        .collect()
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------

--- a/vtc-service/src/join/orchestrate.rs
+++ b/vtc-service/src/join/orchestrate.rs
@@ -405,6 +405,9 @@ pub async fn realize_join_verdict(
                 AuditEvent::JoinRequestRejected(JoinRequestRejectedData {
                     request_id: request.id.to_string(),
                     reason: "policy denied".into(),
+                    // The serialized Deny verdict (with its `code`) the
+                    // policy returned, recorded above on the request.
+                    policy_decision: request.policy_decision.clone(),
                 }),
             )
             .await?;

--- a/vtc-service/src/registry/syncer.rs
+++ b/vtc-service/src/registry/syncer.rs
@@ -710,6 +710,7 @@ default publish_on_join := false
                 AuditEvent::MemberRemoved(MemberRemovedData {
                     disposition: "purge".into(),
                     reason: String::new(),
+                    prior_role: None,
                 }),
             )
             .await

--- a/vtc-service/src/registry/tail.rs
+++ b/vtc-service/src/registry/tail.rs
@@ -369,6 +369,7 @@ mod tests {
                 AuditEvent::MemberRemoved(MemberRemovedData {
                     disposition: disposition.into(),
                     reason: String::new(),
+                    prior_role: None,
                 }),
             )
             .await
@@ -397,6 +398,7 @@ mod tests {
                 AuditEvent::MemberRemoved(MemberRemovedData {
                     disposition: disposition.into(),
                     reason: String::new(),
+                    prior_role: None,
                 }),
             )
             .await

--- a/vtc-service/src/routes/admin/config.rs
+++ b/vtc-service/src/routes/admin/config.rs
@@ -579,7 +579,9 @@ pub async fn import_config(
     let mut rejected: Vec<RejectedKey> = Vec::new();
 
     if let Some(incoming) = &req.community_profile {
-        for (key, old, new) in profile_field_pairs(current_profile.as_ref(), incoming) {
+        for (key, old, new) in
+            crate::community::profile::profile_field_pairs(current_profile.as_ref(), incoming)
+        {
             if old != new {
                 profile_diff.push(FieldDiff {
                     key: key.into(),
@@ -701,6 +703,16 @@ pub async fn import_config(
                 None,
                 AuditEvent::CommunityProfileUpdated(CommunityProfileUpdatedData {
                     fields_changed: community_profile_applied.clone(),
+                    // Reuse the diff already computed above for the
+                    // import preview — each FieldDiff is a before/after.
+                    changes: profile_diff
+                        .iter()
+                        .map(|d| vti_common::audit::FieldChange {
+                            field: d.key.clone(),
+                            old: d.old_value.clone(),
+                            new: d.new_value.clone(),
+                        })
+                        .collect(),
                 }),
             )
             .await?;
@@ -785,59 +797,6 @@ async fn apply_profile_import(
         store_profile(&state.community_ks, &updated).await?;
     }
     Ok(changed)
-}
-
-/// Iterate profile fields as `(key, old_value, new_value)` triples.
-/// Includes `community_did` so a mismatched-but-allowed (i.e.,
-/// fresh-install) import surfaces it in the diff for the operator's
-/// review.
-fn profile_field_pairs(
-    current: Option<&CommunityProfile>,
-    incoming: &CommunityProfile,
-) -> Vec<(&'static str, Option<Value>, Option<Value>)> {
-    let s = |v: &str| Value::String(v.to_string());
-    let opt_s = |v: &Option<String>| match v {
-        Some(s) => Value::String(s.clone()),
-        None => Value::Null,
-    };
-    vec![
-        (
-            "communityDid",
-            current.map(|p| s(&p.community_did)),
-            Some(s(&incoming.community_did)),
-        ),
-        ("name", current.map(|p| s(&p.name)), Some(s(&incoming.name))),
-        (
-            "description",
-            current.map(|p| s(&p.description)),
-            Some(s(&incoming.description)),
-        ),
-        (
-            "logoUrl",
-            current.map(|p| opt_s(&p.logo_url)),
-            Some(opt_s(&incoming.logo_url)),
-        ),
-        (
-            "publicUrl",
-            current.map(|p| opt_s(&p.public_url)),
-            Some(opt_s(&incoming.public_url)),
-        ),
-        (
-            "contactEmail",
-            current.map(|p| opt_s(&p.contact_email)),
-            Some(opt_s(&incoming.contact_email)),
-        ),
-        (
-            "language",
-            current.map(|p| s(&p.language)),
-            Some(s(&incoming.language)),
-        ),
-        (
-            "extensions",
-            current.map(|p| p.extensions.clone()),
-            Some(incoming.extensions.clone()),
-        ),
-    ]
 }
 
 // ---------------------------------------------------------------------------

--- a/vtc-service/src/routes/community/profile.rs
+++ b/vtc-service/src/routes/community/profile.rs
@@ -179,6 +179,7 @@ pub async fn put_profile(
         AppError::NotFound("community profile not initialised — cannot PUT before bootstrap".into())
     })?;
 
+    let prior = profile.clone();
     let fields_changed = update.apply(&mut profile)?;
 
     if fields_changed.is_empty() {
@@ -215,6 +216,7 @@ pub async fn put_profile(
             None,
             AuditEvent::CommunityProfileUpdated(CommunityProfileUpdatedData {
                 fields_changed: fields_changed.clone(),
+                changes: crate::community::profile::profile_changes(Some(&prior), &profile),
             }),
         )
         .await?;

--- a/vtc-service/src/routes/config.rs
+++ b/vtc-service/src/routes/config.rs
@@ -189,6 +189,10 @@ pub async fn update_config(
                 None,
                 AuditEvent::CommunityProfileUpdated(CommunityProfileUpdatedData {
                     fields_changed: fields_changed.clone(),
+                    // Legacy PATCH applies fields individually (+ a
+                    // public_url overlay); before/after capture lives on
+                    // the canonical PUT /v1/community/profile path.
+                    changes: Vec::new(),
                 }),
             )
             .await?;

--- a/vtc-service/src/routes/endorsement_types.rs
+++ b/vtc-service/src/routes/endorsement_types.rs
@@ -226,6 +226,7 @@ pub async fn delete(
             None,
             AuditEvent::EndorsementTypeDeleted(EndorsementTypeDeletedData {
                 type_uri: type_uri.clone(),
+                live_endorsements_at_delete: in_use as u32,
             }),
         )
         .await?;

--- a/vtc-service/src/routes/join_requests/decide.rs
+++ b/vtc-service/src/routes/join_requests/decide.rs
@@ -237,6 +237,9 @@ pub async fn reject(
             AuditEvent::JoinRequestRejected(JoinRequestRejectedData {
                 request_id: id.to_string(),
                 reason: reason.clone(),
+                // Manual admin reject — `reason` is the operator's words;
+                // there is no policy verdict to record.
+                policy_decision: None,
             }),
         )
         .await?;

--- a/vtc-service/src/routes/members/rotate.rs
+++ b/vtc-service/src/routes/members/rotate.rs
@@ -456,6 +456,7 @@ pub async fn rotate(
                 method: method.to_string(),
                 vmc_id,
                 role_vec_id: vec_id,
+                prior_role: Some(acl.role.to_string()),
             }),
         )
         .await?;

--- a/vtc-service/src/routes/members/update.rs
+++ b/vtc-service/src/routes/members/update.rs
@@ -17,7 +17,7 @@ use axum::extract::{Path, State};
 use serde::Deserialize;
 use serde_json::Value as JsonValue;
 
-use vti_common::audit::{AuditEvent, MemberUpdatedData, RoleChangedData};
+use vti_common::audit::{AuditEvent, FieldChange, MemberUpdatedData, RoleChangedData};
 
 use crate::acl::{VtcAclEntry, VtcRole, get_acl_entry};
 use crate::auth::AdminAuth;
@@ -86,21 +86,38 @@ pub async fn update_member(
     // Persisted *before* any role change so the Remint executor (which
     // re-reads the member to repoint its role VEC) sees them.
     let mut fields_changed: Vec<String> = Vec::new();
+    let mut changes: Vec<FieldChange> = Vec::new();
     if let Some(consent) = req.publish_consent
         && consent != member.publish_consent
     {
+        changes.push(FieldChange {
+            field: "publishConsent".into(),
+            old: Some(JsonValue::Bool(member.publish_consent)),
+            new: Some(JsonValue::Bool(consent)),
+        });
         member.publish_consent = consent;
         fields_changed.push("publishConsent".into());
     }
     if let Some(pref) = req.departure_preference
         && pref != member.departure_preference
     {
+        changes.push(FieldChange {
+            field: "departurePreference".into(),
+            old: serde_json::to_value(member.departure_preference).ok(),
+            new: serde_json::to_value(pref).ok(),
+            // (Disposition is Copy; values captured before the move below.)
+        });
         member.departure_preference = pref;
         fields_changed.push("departurePreference".into());
     }
     if let Some(extensions) = req.extensions
         && extensions != member.extensions
     {
+        changes.push(FieldChange {
+            field: "extensions".into(),
+            old: Some(member.extensions.clone()),
+            new: Some(extensions.clone()),
+        });
         member.extensions = extensions;
         fields_changed.push("extensions".into());
     }
@@ -144,6 +161,7 @@ pub async fn update_member(
                 Some(&did),
                 AuditEvent::MemberUpdated(MemberUpdatedData {
                     fields_changed: fields_changed.clone(),
+                    changes,
                 }),
             )
             .await?;

--- a/vtc-service/src/server.rs
+++ b/vtc-service/src/server.rs
@@ -855,6 +855,7 @@ pub async fn run(
                         index_sha256: (*info.index_sha256).clone(),
                         file_count: info.file_count,
                         mode: (*info.mode).clone(),
+                        daemon_version: Some(env!("CARGO_PKG_VERSION").to_string()),
                     },
                 ),
             )

--- a/vti-common/Cargo.toml
+++ b/vti-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-common"
 description = "Shared server-side infrastructure for VTA and VTC services"
 readme = "README.md"
-version = "0.11.0"
+version = "0.11.1"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vti-common/src/audit/envelope.rs
+++ b/vti-common/src/audit/envelope.rs
@@ -16,14 +16,34 @@
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
 use super::event::AuditEvent;
 use super::key_store::KeyId;
 
 /// Envelope schema version. Bumps **only** on a breaking-shape change
-/// to [`AuditEnvelope`] itself. Phase 0 ships v1.
-pub const SCHEMA_VERSION: u32 = 1;
+/// to [`AuditEnvelope`] itself. Phase 0 shipped v1; v2 adds the
+/// tamper-evidence hash chain ([`AuditEnvelope::prev_hash`] /
+/// [`AuditEnvelope::entry_hash`]).
+pub const SCHEMA_VERSION: u32 = 2;
+
+/// Domain-separation tag mixed into every [`AuditEnvelope::chain_digest`]
+/// so a digest can never be confused with any other SHA-256 in the
+/// system. Bump the suffix if the digest's covered-field set changes.
+const CHAIN_DOMAIN: &[u8] = b"vtc-audit-chain/v1\0";
+
+/// The all-zero hash that anchors the chain: the `prev_hash` of the
+/// first chained envelope (and the `entry_hash` left on pre-v2
+/// envelopes that predate the chain).
+pub const GENESIS_HASH: [u8; 32] = [0u8; 32];
+
+/// serde `default` for the chain-hash fields so envelopes written
+/// before SCHEMA_VERSION 2 (which lack the fields entirely) still
+/// deserialize — they come back anchored at [`GENESIS_HASH`].
+fn genesis_hash() -> [u8; 32] {
+    GENESIS_HASH
+}
 
 /// Default event version, applied when an event variant doesn't pin
 /// its own value. Per-variant overrides are added when an existing
@@ -82,8 +102,111 @@ pub struct AuditEnvelope {
     /// [`Self::actor_did_plain`].
     pub target_did_plain: Option<String>,
 
+    /// Tamper-evidence chain: the [`Self::entry_hash`] of the
+    /// immediately-preceding envelope, or [`GENESIS_HASH`] for the
+    /// first one. Linking each entry to its predecessor makes a
+    /// reorder/drop/duplicate of any envelope detectable by
+    /// [`verify_chain`]. `default` keeps pre-v2 rows deserializable.
+    #[serde(with = "hash32_b64", default = "genesis_hash")]
+    pub prev_hash: [u8; 32],
+
+    /// Tamper-evidence chain: SHA-256 commitment to this envelope's
+    /// **immutable** content (see [`Self::chain_digest`]). Stamped at
+    /// write time; the next envelope's [`Self::prev_hash`] points here.
+    /// `default` keeps pre-v2 rows deserializable (they come back as
+    /// [`GENESIS_HASH`], i.e. unchained).
+    #[serde(with = "hash32_b64", default = "genesis_hash")]
+    pub entry_hash: [u8; 32],
+
     /// The tagged event payload.
     pub event: AuditEvent,
+}
+
+impl AuditEnvelope {
+    /// SHA-256 commitment over this envelope's **immutable** content,
+    /// used to stamp [`Self::entry_hash`] at write time and to
+    /// re-derive it during [`verify_chain`].
+    ///
+    /// Deliberately covers `prev_hash` (so the link is part of the
+    /// commitment) but **excludes**:
+    /// - `entry_hash` itself (it *is* this digest — self-reference),
+    /// - `actor_did_plain` / `target_did_plain`, which RTBF nulls
+    ///   after the fact. The HMAC *hashes* are covered, so attribution
+    ///   stays chained while a redaction of the plaintext does not
+    ///   break the chain.
+    ///
+    /// The `event` payload is hashed via its `serde_json` encoding,
+    /// which is canonical in this workspace (maps serialize sorted,
+    /// and the store round-trips through the same encoder).
+    pub fn chain_digest(&self) -> [u8; 32] {
+        let mut h = Sha256::new();
+        h.update(CHAIN_DOMAIN);
+        h.update(self.prev_hash);
+        h.update(self.event_id.as_bytes());
+        h.update(self.event_version.to_be_bytes());
+        h.update(self.schema_version.to_be_bytes());
+        h.update(self.timestamp.to_rfc3339().as_bytes());
+        h.update(self.audit_key_id.0.as_bytes());
+        h.update(self.actor_did_hash);
+        match self.target_did_hash {
+            Some(t) => {
+                h.update([1u8]);
+                h.update(t);
+            }
+            None => h.update([0u8]),
+        }
+        let event_bytes = serde_json::to_vec(&self.event).expect("AuditEvent serializes");
+        h.update((event_bytes.len() as u64).to_be_bytes());
+        h.update(&event_bytes);
+        h.finalize().into()
+    }
+}
+
+/// A detected break in the audit hash chain.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ChainBreak {
+    /// `envelopes[index].entry_hash` does not match a recompute of
+    /// [`AuditEnvelope::chain_digest`] — the envelope's content was
+    /// altered after it was written.
+    TamperedEntry { index: usize, event_id: Uuid },
+    /// `envelopes[index].prev_hash` does not point at the previous
+    /// envelope's `entry_hash` — an entry was reordered, dropped, or
+    /// inserted.
+    BrokenLink { index: usize, event_id: Uuid },
+}
+
+/// Verify the tamper-evidence chain over `envelopes`, which must be in
+/// ascending write order (the audit keyspace's `<timestamp>:<event_id>`
+/// key order). Each v2+ envelope must (a) re-derive its own
+/// `entry_hash` and (b) carry a `prev_hash` equal to the previous v2+
+/// envelope's `entry_hash` (or [`GENESIS_HASH`] for the first link).
+///
+/// Pre-v2 envelopes (written before the chain existed) carry no hashes
+/// and are skipped; the chain re-anchors at the first v2 envelope.
+pub fn verify_chain(envelopes: &[AuditEnvelope]) -> Result<(), ChainBreak> {
+    let mut prev: Option<[u8; 32]> = None;
+    for (index, env) in envelopes.iter().enumerate() {
+        if env.schema_version < 2 {
+            // Predates the chain — nothing to verify, and it must not
+            // become the predecessor of a v2 link.
+            continue;
+        }
+        if env.chain_digest() != env.entry_hash {
+            return Err(ChainBreak::TamperedEntry {
+                index,
+                event_id: env.event_id,
+            });
+        }
+        let expected_prev = prev.unwrap_or(GENESIS_HASH);
+        if env.prev_hash != expected_prev {
+            return Err(ChainBreak::BrokenLink {
+                index,
+                event_id: env.event_id,
+            });
+        }
+        prev = Some(env.entry_hash);
+    }
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -154,12 +277,26 @@ mod tests {
             actor_did_plain: Some("did:key:z6Mk".into()),
             target_did_hash: Some([0xCD; 32]),
             target_did_plain: Some("did:key:z6Mk2".into()),
+            prev_hash: GENESIS_HASH,
+            entry_hash: GENESIS_HASH,
             event: AuditEvent::CommunityProfileUpdated(
                 crate::audit::event::CommunityProfileUpdatedData {
                     fields_changed: vec!["name".into()],
+                    ..Default::default()
                 },
             ),
         }
+    }
+
+    /// Build a sample envelope whose `entry_hash` is correctly stamped
+    /// from `prev`, as the writer does.
+    fn chained_envelope(prev: [u8; 32], seed: u8) -> AuditEnvelope {
+        let mut e = sample_envelope();
+        e.event_id = Uuid::from_bytes([seed; 16]);
+        e.actor_did_hash = [seed; 32];
+        e.prev_hash = prev;
+        e.entry_hash = e.chain_digest();
+        e
     }
 
     #[test]
@@ -205,5 +342,89 @@ mod tests {
         assert!(back.target_did_plain.is_none());
         assert_eq!(back.actor_did_hash, [0xAB; 32]);
         assert_eq!(back.target_did_hash, Some([0xCD; 32]));
+    }
+
+    #[test]
+    fn rtbf_redaction_does_not_break_the_chain() {
+        // entry_hash excludes the plaintext fields, so nulling them
+        // (RTBF) must leave the chain intact.
+        let e = chained_envelope(GENESIS_HASH, 0x11);
+        let mut redacted = e.clone();
+        redacted.actor_did_plain = None;
+        redacted.target_did_plain = None;
+        assert_eq!(redacted.chain_digest(), e.entry_hash);
+        assert!(verify_chain(&[redacted]).is_ok());
+    }
+
+    #[test]
+    fn well_formed_chain_verifies() {
+        let a = chained_envelope(GENESIS_HASH, 0x01);
+        let b = chained_envelope(a.entry_hash, 0x02);
+        let c = chained_envelope(b.entry_hash, 0x03);
+        assert!(verify_chain(&[a, b, c]).is_ok());
+    }
+
+    #[test]
+    fn tampered_entry_is_detected() {
+        let a = chained_envelope(GENESIS_HASH, 0x01);
+        let mut b = chained_envelope(a.entry_hash, 0x02);
+        // Mutate covered content without restamping entry_hash.
+        b.event =
+            AuditEvent::CommunityProfileUpdated(crate::audit::event::CommunityProfileUpdatedData {
+                fields_changed: vec!["logoUrl".into()],
+                ..Default::default()
+            });
+        match verify_chain(&[a, b]) {
+            Err(ChainBreak::TamperedEntry { index, .. }) => assert_eq!(index, 1),
+            other => panic!("expected TamperedEntry, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn dropped_entry_breaks_the_link() {
+        let a = chained_envelope(GENESIS_HASH, 0x01);
+        let b = chained_envelope(a.entry_hash, 0x02);
+        let c = chained_envelope(b.entry_hash, 0x03);
+        // Drop `b`: c.prev_hash now points at a missing predecessor.
+        match verify_chain(&[a, c]) {
+            Err(ChainBreak::BrokenLink { index, .. }) => assert_eq!(index, 1),
+            other => panic!("expected BrokenLink, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn reordered_entries_break_the_link() {
+        let a = chained_envelope(GENESIS_HASH, 0x01);
+        let b = chained_envelope(a.entry_hash, 0x02);
+        match verify_chain(&[b, a]) {
+            Err(ChainBreak::BrokenLink { index, .. }) => assert_eq!(index, 0),
+            other => panic!("expected BrokenLink, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn pre_v2_envelopes_are_skipped_then_chain_reanchors() {
+        // A legacy row (schema_version 1, no hashes) followed by a
+        // fresh v2 chain that anchors at genesis.
+        let mut legacy = sample_envelope();
+        legacy.schema_version = 1;
+        legacy.prev_hash = GENESIS_HASH;
+        legacy.entry_hash = GENESIS_HASH;
+        let a = chained_envelope(GENESIS_HASH, 0x01);
+        let b = chained_envelope(a.entry_hash, 0x02);
+        assert!(verify_chain(&[legacy, a, b]).is_ok());
+    }
+
+    #[test]
+    fn pre_v2_envelope_deserializes_without_hash_fields() {
+        // Old wire form: an envelope JSON object missing prev_hash /
+        // entry_hash entirely must still parse (serde default).
+        let mut v = serde_json::to_value(sample_envelope()).unwrap();
+        let obj = v.as_object_mut().unwrap();
+        obj.remove("prev_hash");
+        obj.remove("entry_hash");
+        let back: AuditEnvelope = serde_json::from_value(v).unwrap();
+        assert_eq!(back.prev_hash, GENESIS_HASH);
+        assert_eq!(back.entry_hash, GENESIS_HASH);
     }
 }

--- a/vti-common/src/audit/event.rs
+++ b/vti-common/src/audit/event.rs
@@ -581,13 +581,31 @@ pub struct RestartRequestedData {
     pub drain_timeout_seconds: u64,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// One field's before/after change, recorded on enrichable "Updated"
+/// audit events so the log can reconstruct *what* changed, not just
+/// which field. `old` / `new` are JSON values; either is omitted when
+/// the field was newly set or cleared.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct FieldChange {
+    pub field: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub old: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub new: Option<Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct CommunityProfileUpdatedData {
     /// Names of fields that changed (e.g. `name`, `description`,
-    /// `logo_url`, `extensions`). Values themselves stay out of the
-    /// audit log.
+    /// `logo_url`, `extensions`).
     pub fields_changed: Vec<String>,
+    /// Before/after values for each changed field. Additive over
+    /// `fields_changed` (kept for back-compat); empty on pre-enrichment
+    /// rows and emitters that don't diff.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub changes: Vec<FieldChange>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -602,12 +620,13 @@ pub struct AuditKeyRotatedData {
 #[serde(rename_all = "camelCase")]
 pub struct MemberUpdatedData {
     /// Names of the fields changed on this PATCH (e.g.
-    /// `["publishConsent", "departurePreference"]`). Field values
-    /// stay out of the audit log — operator-facing extensions data
-    /// can be arbitrarily large, and the metadata `publish_consent`
-    /// / `departure_preference` shifts are individually
-    /// non-sensitive.
+    /// `["publishConsent", "departurePreference"]`).
     pub fields_changed: Vec<String>,
+    /// Before/after values for each changed field, so the change is
+    /// reconstructable. Additive over `fields_changed`; empty on
+    /// pre-enrichment rows.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub changes: Vec<FieldChange>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -650,6 +669,11 @@ pub struct JoinRequestRejectedData {
     /// Operator-supplied reason, capped at 1024 chars at the
     /// route layer. May be empty.
     pub reason: String,
+    /// Structured policy verdict that drove an automatic rejection
+    /// (the serialized `Verdict::Deny`, incl. its `code`). `None` for
+    /// a manual admin reject, where `reason` is the operator's words.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub policy_decision: Option<Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -677,6 +701,12 @@ pub struct MemberRemovedData {
     /// for self-removal.
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub reason: String,
+    /// Role the member held immediately before removal (e.g.
+    /// `"admin"`, `"member"`). `None` when removing a tombstone that
+    /// no longer has an ACL row. The credential-revocation cascade is
+    /// audited separately via the paired `StatusListFlipped` event.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prior_role: Option<String>,
 }
 
 /// Payload for [`AuditEvent::PolicyUploaded`].
@@ -966,6 +996,12 @@ pub struct EndorsementTypeRegisteredData {
 #[serde(rename_all = "camelCase")]
 pub struct EndorsementTypeDeletedData {
     pub type_uri: String,
+    /// Count of live endorsements of this type at deletion. Deletion
+    /// is refused while any exist, so this is `0` on success — recorded
+    /// so the audit trail documents that the no-orphans precondition
+    /// held. `default` keeps pre-enrichment rows parseable.
+    #[serde(default)]
+    pub live_endorsements_at_delete: u32,
 }
 
 /// Payload for [`AuditEvent::WebsiteFileWritten`]. Phase 5 M5.5.2.
@@ -1042,6 +1078,11 @@ pub struct AdminUiServedData {
     /// `"embedded"` or `"external"`. Embedded serves the baked
     /// SPA; external delegates to an operator-supplied origin.
     pub mode: String,
+    /// Daemon build version (`CARGO_PKG_VERSION`) that served this
+    /// SPA, so the running admin-UI build correlates with a specific
+    /// release. `None` on pre-enrichment rows.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub daemon_version: Option<String>,
 }
 
 /// Payload for [`AuditEvent::RegistryStatusChanged`]. Phase 3
@@ -1079,6 +1120,11 @@ pub struct DidRotatedData {
     /// New role VEC id minted in the same transaction.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub role_vec_id: Option<String>,
+    /// Role the rotating member held before the rotation, carried
+    /// across unchanged. Lets a reviewer see the privilege level a
+    /// rotated key inherits. `None` on pre-enrichment rows.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prior_role: Option<String>,
 }
 
 /// Payload for [`AuditEvent::PolicyActivated`].
@@ -1222,10 +1268,17 @@ mod tests {
     fn community_profile_updated_round_trip() {
         let e = AuditEvent::CommunityProfileUpdated(CommunityProfileUpdatedData {
             fields_changed: vec!["name".into(), "logo_url".into()],
+            changes: vec![FieldChange {
+                field: "name".into(),
+                old: Some(json!("Old Name")),
+                new: Some(json!("New Name")),
+            }],
         });
         let v = wire_value(&e);
         assert_eq!(v["type"], "CommunityProfileUpdated");
         assert_eq!(v["data"]["fieldsChanged"][0], "name");
+        assert_eq!(v["data"]["changes"][0]["field"], "name");
+        assert_eq!(v["data"]["changes"][0]["new"], "New Name");
         round_trip(&e);
     }
 
@@ -1426,6 +1479,7 @@ mod tests {
             method: "did:key".into(),
             vmc_id: Some("urn:uuid:vmc-2".into()),
             role_vec_id: Some("urn:uuid:vec-2".into()),
+            prior_role: Some("member".into()),
         });
         let v = wire_value(&e);
         assert_eq!(v["type"], "DidRotated");
@@ -1444,6 +1498,7 @@ mod tests {
             method: "did:key".into(),
             vmc_id: None,
             role_vec_id: None,
+            prior_role: None,
         });
         let v = wire_value(&e);
         assert!(v["data"].get("vmcId").is_none());
@@ -1712,6 +1767,7 @@ mod tests {
     fn endorsement_type_deleted_round_trip() {
         let e = AuditEvent::EndorsementTypeDeleted(EndorsementTypeDeletedData {
             type_uri: "https://example.com/v1/skills/rust".into(),
+            live_endorsements_at_delete: 0,
         });
         let v = wire_value(&e);
         assert_eq!(v["type"], "EndorsementTypeDeleted");
@@ -1773,6 +1829,7 @@ mod tests {
             (
                 AuditEvent::CommunityProfileUpdated(CommunityProfileUpdatedData {
                     fields_changed: vec![],
+                    changes: vec![],
                 }),
                 "CommunityProfileUpdated",
             ),
@@ -1845,6 +1902,7 @@ mod tests {
                     method: "did:key".into(),
                     vmc_id: None,
                     role_vec_id: None,
+                    prior_role: None,
                 }),
                 "DidRotated",
             ),
@@ -1947,6 +2005,7 @@ mod tests {
             (
                 AuditEvent::EndorsementTypeDeleted(EndorsementTypeDeletedData {
                     type_uri: "https://x/v1/t".into(),
+                    live_endorsements_at_delete: 0,
                 }),
                 "EndorsementTypeDeleted",
             ),
@@ -1986,6 +2045,7 @@ mod tests {
                     index_sha256: "deadbeef".into(),
                     file_count: 3,
                     mode: "embedded".into(),
+                    daemon_version: None,
                 }),
                 "AdminUiServed",
             ),

--- a/vti-common/src/audit/mod.rs
+++ b/vti-common/src/audit/mod.rs
@@ -29,14 +29,16 @@ pub mod event;
 pub mod key_store;
 pub mod writer;
 
-pub use envelope::{AuditEnvelope, EVENT_VERSION, SCHEMA_VERSION};
+pub use envelope::{
+    AuditEnvelope, ChainBreak, EVENT_VERSION, GENESIS_HASH, SCHEMA_VERSION, verify_chain,
+};
 pub use event::{
     AclChangeData, AclRevokedData, AdminInviteData, AdminPasskeyData, AdminPromotedData,
     AdminUiServedData, AuditEvent, AuditKeyRotatedData, BackupData, CommunityInstalledData,
     CommunityProfileUpdatedData, ConfigChange, ConfigChangedData, ConfigReloadedData, ConfigSource,
     CredentialIssuedData, CrossCommunitySessionMintedData, CustomEndorsementIssuedData,
     CustomEndorsementRevokedData, DidRotatedData, EmergencyBootstrapData,
-    EndorsementTypeDeletedData, EndorsementTypeRegisteredData, InvitationIssuedData,
+    EndorsementTypeDeletedData, EndorsementTypeRegisteredData, FieldChange, InvitationIssuedData,
     InvitationRevokedData, JoinRequestData, JoinRequestRejectedData, MemberAddedData,
     MemberRemovedData, MemberUpdatedData, MembershipReciprocatedData, MembershipRenewedData,
     PersonhoodAssertedData, PersonhoodRevokedData, PolicyActivatedData, PolicyUploadedData,

--- a/vti-common/src/audit/writer.rs
+++ b/vti-common/src/audit/writer.rs
@@ -3,12 +3,15 @@
 //! that walks key history to confirm a candidate DID matches an
 //! envelope's hash.
 
+use std::sync::Arc;
+
 use chrono::Utc;
 use hmac::{Hmac, KeyInit, Mac};
 use sha2::Sha256;
+use tokio::sync::Mutex;
 use uuid::Uuid;
 
-use super::envelope::{AuditEnvelope, EVENT_VERSION, SCHEMA_VERSION};
+use super::envelope::{AuditEnvelope, EVENT_VERSION, GENESIS_HASH, SCHEMA_VERSION};
 use super::event::AuditEvent;
 use super::key_store::AuditKeyStore;
 use crate::error::AppError;
@@ -26,10 +29,23 @@ pub fn envelope_storage_key(env: &AuditEnvelope) -> Vec<u8> {
 /// Persistent writer that combines an `audit` keyspace with the
 /// matching [`AuditKeyStore`]. Cheap to clone — every field is
 /// reference-counted internally.
+///
+/// Production constructs exactly one writer (held in `AppState` and
+/// cloned), so the shared `chain_head` below serialises every audit
+/// write process-wide: each envelope's `prev_hash` is the
+/// immediately-preceding envelope's `entry_hash`, forming the
+/// tamper-evidence chain verified by
+/// [`super::envelope::verify_chain`].
 #[derive(Clone)]
 pub struct AuditWriter {
     audit_ks: KeyspaceHandle,
     key_store: AuditKeyStore,
+    /// Cached `entry_hash` of the last-written envelope (the chain
+    /// head). `None` until the first write loads it from storage
+    /// (restart recovery). Guarded by an async mutex so the
+    /// read-head → stamp → insert → update-head sequence is atomic
+    /// across concurrent writers.
+    chain_head: Arc<Mutex<Option<[u8; 32]>>>,
 }
 
 impl AuditWriter {
@@ -37,6 +53,7 @@ impl AuditWriter {
         Self {
             audit_ks,
             key_store,
+            chain_head: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -67,7 +84,16 @@ impl AuditWriter {
         let actor_did_hash = hmac_did(&key.key, actor_did);
         let target_did_hash = target_did.map(|d| hmac_did(&key.key, d));
 
-        let envelope = AuditEnvelope {
+        // Hold the chain lock across the whole read-head → stamp →
+        // insert → update-head sequence so concurrent writers can't
+        // fork the chain (two envelopes sharing one `prev_hash`).
+        let mut head = self.chain_head.lock().await;
+        let prev_hash = match *head {
+            Some(h) => h,
+            None => self.load_chain_head().await?,
+        };
+
+        let mut envelope = AuditEnvelope {
             event_id: Uuid::new_v4(),
             event_version: EVENT_VERSION,
             schema_version: SCHEMA_VERSION,
@@ -77,13 +103,34 @@ impl AuditWriter {
             actor_did_plain: Some(actor_did.to_string()),
             target_did_hash,
             target_did_plain: target_did.map(str::to_string),
+            prev_hash,
+            entry_hash: GENESIS_HASH, // placeholder; stamped next
             event,
         };
+        envelope.entry_hash = envelope.chain_digest();
 
         self.audit_ks
             .insert(envelope_storage_key(&envelope), &envelope)
             .await?;
+        *head = Some(envelope.entry_hash);
         Ok(envelope)
+    }
+
+    /// Recover the chain head from storage on the first write after a
+    /// (re)start. The audit keyspace is keyed by
+    /// `<rfc3339-timestamp>:<event_id>`, so the last pair in ascending
+    /// key order is the most recently written envelope; its
+    /// `entry_hash` is the head. An empty (or pre-v2) log anchors at
+    /// [`GENESIS_HASH`].
+    async fn load_chain_head(&self) -> Result<[u8; 32], AppError> {
+        let pairs = self.audit_ks.prefix_iter_raw(Vec::new()).await?;
+        match pairs.last() {
+            Some((_, raw)) => {
+                let env: AuditEnvelope = serde_json::from_slice(raw)?;
+                Ok(env.entry_hash)
+            }
+            None => Ok(GENESIS_HASH),
+        }
     }
 
     /// Verify that `candidate_did` matches the actor recorded on
@@ -178,6 +225,7 @@ mod tests {
     fn sample_event() -> AuditEvent {
         AuditEvent::CommunityProfileUpdated(crate::audit::event::CommunityProfileUpdatedData {
             fields_changed: vec!["name".into()],
+            ..Default::default()
         })
     }
 
@@ -284,6 +332,89 @@ mod tests {
         // Post-rotation envelope verifies against bob via the new key.
         assert!(f.writer.verify_actor(&post, "did:key:bob").await.unwrap());
         assert!(!f.writer.verify_actor(&post, "did:key:alice").await.unwrap());
+    }
+
+    /// Read every envelope back in ascending storage-key order.
+    async fn read_chain(ks: &KeyspaceHandle) -> Vec<AuditEnvelope> {
+        let mut pairs = ks.prefix_iter_raw(Vec::new()).await.unwrap();
+        pairs.sort_by(|(a, _), (b, _)| a.cmp(b));
+        pairs
+            .iter()
+            .map(|(_, v)| serde_json::from_slice(v).unwrap())
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn writes_form_a_verifiable_chain() {
+        use crate::audit::envelope::{GENESIS_HASH, verify_chain};
+        let f = fixture();
+        f.key_store.ensure_initial(&[0x07; 32]).await.unwrap();
+
+        for i in 0..5u8 {
+            f.writer
+                .write(&format!("did:key:actor{i}"), None, sample_event())
+                .await
+                .unwrap();
+        }
+
+        let chain = read_chain(&f.writer.audit_ks).await;
+        assert_eq!(chain.len(), 5);
+        assert_eq!(chain[0].prev_hash, GENESIS_HASH);
+        // Each link points at its predecessor.
+        for w in chain.windows(2) {
+            assert_eq!(w[1].prev_hash, w[0].entry_hash);
+        }
+        verify_chain(&chain).expect("chain must verify");
+    }
+
+    #[tokio::test]
+    async fn tamper_after_write_is_detected() {
+        use crate::audit::envelope::{ChainBreak, verify_chain};
+        let f = fixture();
+        f.key_store.ensure_initial(&[0x08; 32]).await.unwrap();
+        for i in 0..3u8 {
+            f.writer
+                .write(&format!("did:key:a{i}"), None, sample_event())
+                .await
+                .unwrap();
+        }
+
+        let mut chain = read_chain(&f.writer.audit_ks).await;
+        // Forge a different event on the middle row without restamping.
+        chain[1].event =
+            AuditEvent::CommunityProfileUpdated(crate::audit::event::CommunityProfileUpdatedData {
+                fields_changed: vec!["forged".into()],
+                ..Default::default()
+            });
+        assert!(matches!(
+            verify_chain(&chain),
+            Err(ChainBreak::TamperedEntry { index: 1, .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn chain_head_recovers_after_restart() {
+        use crate::audit::envelope::verify_chain;
+        let f = fixture();
+        f.key_store.ensure_initial(&[0x09; 32]).await.unwrap();
+        f.writer
+            .write("did:key:before", None, sample_event())
+            .await
+            .unwrap();
+
+        // Simulate a restart: a fresh writer over the same keyspace
+        // with an empty in-memory head. Its first write must link to
+        // the persisted head, not restart at genesis.
+        let restarted = AuditWriter::new(f.writer.audit_ks.clone(), f.key_store.clone());
+        restarted
+            .write("did:key:after", None, sample_event())
+            .await
+            .unwrap();
+
+        let chain = read_chain(&f.writer.audit_ks).await;
+        assert_eq!(chain.len(), 2);
+        assert_eq!(chain[1].prev_hash, chain[0].entry_hash);
+        verify_chain(&chain).expect("chain survives restart");
     }
 
     #[tokio::test]


### PR DESCRIPTION
Completes the remaining tiers of #537 (Tier 1 — schema/config/install-claim audit events — shipped in #538). Closes #537.

## Tier 2 — payload enrichment

Audit events now carry forensic before/after detail, not just field names:

| Event | Added |
|---|---|
| `CommunityProfileUpdated` / `MemberUpdated` | `changes: [FieldChange]` — old/new per changed field |
| `DidRotated` | `prior_role` — privilege the rotated key inherits |
| `JoinRequestRejected` | `policy_decision` — the serialized Deny verdict on auto-rejects (`None` for manual admin rejects) |
| `MemberRemoved` | `prior_role` (credential-revocation cascade stays audited via the paired `StatusListFlipped`) |
| `EndorsementTypeDeleted` | `live_endorsements_at_delete` — `0` on success, records the no-orphans precondition held |
| `AdminUiServed` | `daemon_version` — correlate the running SPA build |

All new fields are additive (`serde` default + skip-if-empty): pre-enrichment rows deserialize unchanged and `fields_changed` stays populated. The community-profile field list is centralised in `community::profile::profile_field_pairs` (moved out of `routes/admin/config`) so the import preview and the audit diff share one source of truth.

## Tier 3 — tamper-evidence (per-envelope `prev_hash` chain)

`AuditEnvelope` gains `prev_hash` + `entry_hash`. Each entry is a domain-tagged SHA-256 commitment to its immutable content and links to its predecessor (anchored at `GENESIS_HASH`). `audit::verify_chain` detects reorder / drop / duplicate / edit. `SCHEMA_VERSION` 1 → 2.

Key design decisions (this was the issue's "needs a design decision" item):

- **Concurrency:** production has exactly one `AuditWriter` (Arc-shared via `AppState`). It holds the chain head under an async mutex so read-head → stamp → insert → update-head is atomic and concurrent events can't fork the chain.
- **Restart recovery:** the head is lazily recovered from the last stored envelope on the first write after boot.
- **RTBF compatibility:** the digest **excludes** `entry_hash` itself and the mutable `*_plain` fields, so right-to-be-forgotten redaction (which nulls `*_plain`) does **not** break the chain — the HMAC hashes it covers are immutable.
- **Backward compatibility:** pre-v2 envelopes carry no chain fields (serde-defaulted to `GENESIS_HASH`); `verify_chain` skips them and re-anchors at the first v2 entry.

Follow-up (not in this PR): an operator-facing `verify_chain` surface (admin route / CLI). The library function is public and unit-tested; wiring an endpoint is a small separate change.

## Tests

- New chain unit tests (vti-common): well-formed chain verifies; tampered-entry / dropped / reordered detected; RTBF redaction does not break the chain; restart recovery; pre-v2 skip + deserialize.
- Enrichment exercised via the existing audit round-trip/census tests.
- `cargo test -p vti-common` and `-p vtc-service` green (the admin-ui tests pass with the SPA built; they only fail under `VTC_SKIP_ADMIN_UI_BUILD=1`). `cargo clippy` clean for the changed code; `cargo check --workspace` clean.

Bumps `vti-common` 0.11.0 → 0.11.1, `vtc-service` 0.10.10 → 0.10.11.
