### PR TITLE
ci: trusted publishing to crates.io via GitHub OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,104 @@
+name: Publish
+
+# Trusted Publishing to crates.io via OIDC — no long-lived API token stored
+# in the repo. crates.io mints a short-lived token for each run after
+# verifying the GitHub OIDC claim against the Trusted Publisher config you
+# register per crate (Settings → Trusted Publishing on each crate's page).
+# See docs/05-design-notes/trusted-publishing.md for the one-time setup.
+#
+# The job walks every publishable crate in dependency order and publishes
+# only the versions that are not yet on crates.io. It is therefore
+# idempotent: bump the version(s) you want to release in a PR, merge to
+# main, and exactly those crates ship. Crates whose version already exists
+# are skipped.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch: {}
+
+# Never let two publish runs race — a later push must wait for an in-flight
+# release so dependency ordering across runs stays correct.
+concurrency:
+  group: crates-io-publish
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write # required for the OIDC token exchange with crates.io
+
+jobs:
+  publish:
+    name: Publish to crates.io
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-publish-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-publish-
+            ${{ runner.os }}-cargo-
+
+      # Exchanges the workflow's OIDC identity for a short-lived crates.io
+      # token, exported as CARGO_REGISTRY_TOKEN for the publish step below.
+      - name: Authenticate to crates.io (Trusted Publishing)
+        uses: rust-lang/crates-io-auth-action@v1
+        id: auth
+
+      - name: Publish crates in dependency order
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+        run: |
+          set -euo pipefail
+
+          # Bottom-up topological order. A crate must appear after every
+          # internal crate it depends on so its deps already exist on
+          # crates.io when cargo verifies the upload.
+          CRATES=(
+            vta-sdk
+            vti-webauthn
+            vti-common
+            vti-secrets
+            vta-cli-common
+            vtc-service
+            vta-service
+            pnm-cli
+            cnm-cli
+          )
+
+          UA="verifiable-trust-infrastructure-release (https://github.com/${GITHUB_REPOSITORY})"
+
+          for crate in "${CRATES[@]}"; do
+            version=$(cargo metadata --format-version 1 --no-deps \
+              | jq -r --arg c "$crate" '.packages[] | select(.name == $c) | .version')
+
+            if [ -z "$version" ] || [ "$version" = "null" ]; then
+              echo "::error::could not resolve version for $crate"
+              exit 1
+            fi
+
+            status=$(curl -s -o /dev/null -w '%{http_code}' \
+              -H "User-Agent: $UA" \
+              "https://crates.io/api/v1/crates/${crate}/${version}")
+
+            if [ "$status" = "200" ]; then
+              echo "✓ ${crate} ${version} already on crates.io — skipping"
+              continue
+            fi
+
+            echo "→ publishing ${crate} ${version}"
+            # cargo publish blocks until the new version is queryable in the
+            # index, so the next (dependent) crate sees it.
+            cargo publish -p "$crate" --locked
+          done

--- a/docs/05-design-notes/trusted-publishing.md
+++ b/docs/05-design-notes/trusted-publishing.md
@@ -1,0 +1,68 @@
+# Trusted Publishing to crates.io
+
+The workspace publishes its crates to crates.io using **Trusted Publishing**
+— crates.io accepts the GitHub Actions OIDC identity of the
+`.github/workflows/release.yml` workflow instead of a stored API token.
+There is no `CARGO_REGISTRY_TOKEN` secret in the repo; each run mints a
+short-lived token via the OIDC exchange.
+
+## What auto-publishes
+
+`release.yml` runs on every push to `main` (and on manual dispatch). It
+walks the publishable crates in dependency order and publishes **only the
+versions not already on crates.io**, so the flow is idempotent:
+
+1. Bump the version of each crate you want to release (in a PR).
+2. Merge to `main`.
+3. The workflow publishes exactly those crates; everything else is skipped
+   because its version already exists.
+
+Publish order (bottom-up; each crate after its internal deps):
+
+```
+vta-sdk → vti-webauthn → vti-common → vti-secrets → vta-cli-common
+        → vtc-service → vta-service → pnm-cli → cnm-cli
+```
+
+Non-publishable crates (`publish = false`) are excluded: `vta-mcp`,
+`vta-enclave`, `vta-mobile-core`, `didcomm-test`, `tests/e2e`.
+
+## One-time setup on crates.io (per crate)
+
+Trusted Publishing is configured **per crate** in the crates.io UI by an
+owner. Do this once for each of the nine crates above:
+
+1. Sign in to <https://crates.io> and open the crate, e.g.
+   `https://crates.io/crates/vta-sdk`.
+2. **Settings → Trusted Publishing → Add**.
+3. Fill in:
+   - **Repository owner**: `OpenVTC`
+   - **Repository name**: `verifiable-trust-infrastructure`
+   - **Workflow filename**: `release.yml`
+   - **Environment name**: *(leave blank)* — the workflow does not use a
+     GitHub Environment. If you later add one for protection rules
+     (see below), set it here too; the two must match.
+4. Save.
+
+Repeat for: `vta-sdk`, `vti-webauthn`, `vti-common`, `vti-secrets`,
+`vta-cli-common`, `vtc-service`, `vta-service`, `pnm-cli`, `cnm-cli`.
+
+Until a crate has this config, its publish step fails the OIDC check — the
+others still publish.
+
+## How the workflow authenticates
+
+`release.yml` grants `id-token: write`, then `rust-lang/crates-io-auth-action`
+exchanges the OIDC token for a short-lived crates.io token exported as
+`CARGO_REGISTRY_TOKEN`. The token is valid only for the crates whose
+Trusted Publisher config matches this repo + workflow, and it expires
+shortly after the run.
+
+## Optional hardening: a GitHub Environment
+
+For a manual approval gate or to scope the OIDC claim further, create a
+GitHub Environment (e.g. `release`) with required reviewers, add
+`environment: release` to the `publish` job, and set the same **Environment
+name** in each crate's Trusted Publishing config. Note this makes
+publishing wait for approval rather than running hands-off on every push to
+`main`.


### PR DESCRIPTION
## What

Sets up **Trusted Publishing** to crates.io for all nine publishable crates. crates.io mints a short-lived token from the workflow's GitHub OIDC identity — no `CARGO_REGISTRY_TOKEN` secret is stored in the repo.

## How it works

The publish workflow runs on push to `main` (and manual dispatch), walks the crates bottom-up in dependency order, and publishes only versions not already on crates.io (idempotent).

Excluded (`publish = false`): `vta-mcp`, `vta-enclave`, `vta-mobile-core`, `didcomm-test`, `tests/e2e`.

See `docs/05-design-notes/trusted-publishing.md` for the per-crate crates.io setup.