### PR TITLE
ci: publish vtc-service with --no-verify

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -98,7 +98,19 @@ jobs:
             fi
 
             echo "→ publishing ${crate} ${version}"
+
+            # vtc-service's build.rs runs `npm install` + `npm run build` for
+            # the bundled admin-ui, which writes admin-ui/node_modules into the
+            # source tree. cargo's publish verification build rejects that
+            # ("source directory was modified by build.rs"). The Node build is
+            # irrelevant to packaging the crate, so skip verification for it.
+            # All other crates verify normally.
+            extra=""
+            if [ "$crate" = "vtc-service" ]; then
+              extra="--no-verify"
+            fi
+
             # cargo publish blocks until the new version is queryable in the
             # index, so the next (dependent) crate sees it.
-            cargo publish -p "$crate" --locked
+            cargo publish -p "$crate" --locked $extra
           done


### PR DESCRIPTION
The publish workflow failed on `vtc-service` ([run](https://github.com/OpenVTC/verifiable-trust-infrastructure/actions/runs/27936705675/job/82660007701)):

```
error: failed to verify package tarball
Source directory was modified by build.rs during cargo publish.
Build scripts should not modify anything outside of OUT_DIR.
  .../vtc-service-0.10.11/admin-ui/node_modules
```

**Cause:** `vtc-service/build.rs` runs `npm install` + `npm run build` for the bundled `admin-ui`, which writes `admin-ui/node_modules` into the source tree. cargo's publish *verification build* runs that build script, sees the source dir change, and aborts. The Node build is irrelevant to packaging the crate for crates.io.

**Fix:** pass `--no-verify` for `vtc-service` only. All other crates still get a full verification build. Scoped via a per-crate flag in the publish loop — `vtc-service` is the only crate in the workspace with a Node-based `build.rs`.