### PR TITLE
chore: ignore .env files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ Thumbs.db
 # scheduled-task lockfile, settings.local.json, ephemeral worktree
 # dirs. All operator-local, never checked in.
 .claude/
+
+# Secrets and credentials
+.env
+.env.*


### PR DESCRIPTION
Add .env and .env.* to .gitignore so operator-local secrets and credentials from downstream build pipelines are never accidentally checked in.