### PR TITLE
fix(vta): serve /attestation/did-log as text/jsonl, not text/plain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10111,7 +10111,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.10.2"
+version = "0.10.3"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/routes/attestation.rs
+++ b/vta-service/src/routes/attestation.rs
@@ -1,5 +1,8 @@
 use axum::Json;
+use axum::body::Body;
 use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::Response;
 
 use crate::auth::SuperAdminAuth;
 use crate::error::{AppError, tee_attestation_error};
@@ -81,11 +84,11 @@ pub async fn cached_report(
 #[utoipa::path(
     get, path = "/attestation/did-log", tag = "attestation",
     responses(
-        (status = 200, description = "Auto-generated did.jsonl", content_type = "application/jsonl"),
+        (status = 200, description = "Auto-generated did.jsonl", content_type = "text/jsonl"),
         (status = 404, description = "No auto-generated DID log"),
     ),
 )]
-pub async fn did_log(State(state): State<AppState>) -> Result<String, AppError> {
+pub async fn did_log(State(state): State<AppState>) -> Result<Response, AppError> {
     let log_bytes = state.keys_ks.get_raw("tee:did_log").await?.ok_or_else(|| {
         AppError::NotFound(
             "no auto-generated DID log found — the VTA may not have \
@@ -94,8 +97,19 @@ pub async fn did_log(State(state): State<AppState>) -> Result<String, AppError> 
         )
     })?;
 
-    String::from_utf8(log_bytes)
-        .map_err(|e| AppError::Internal(format!("DID log is not valid UTF-8: {e}")))
+    let log = String::from_utf8(log_bytes)
+        .map_err(|e| AppError::Internal(format!("DID log is not valid UTF-8: {e}")))?;
+
+    // did:webvh v1.0 SHOULDs text/jsonl for the log file (DID-to-HTTPS
+    // Transformation §6); previously this returned a bare String, which axum
+    // served as text/plain, contradicting the OpenAPI annotation. nosniff
+    // matches the other did.jsonl-serving routes (see routes::self_hosted_did).
+    Ok(Response::builder()
+        .status(StatusCode::OK)
+        .header("content-type", "text/jsonl")
+        .header("x-content-type-options", "nosniff")
+        .body(Body::from(log))
+        .expect("static headers + owned body always build a valid response"))
 }
 
 /// GET /attestation/mnemonic — Check mnemonic export window status (super admin only).


### PR DESCRIPTION
### Summary
Follow-up to #559. Fixes a pre-existing content-type mismatch on the TEE `GET /attestation/did-log` endpoint.

### Problem
The handler returned a bare `String`, which axum serves as `text/plain; charset=utf-8` — but its OpenAPI annotation advertised `application/jsonl`. So the documented type, the actual type, and the spec recommendation all disagreed.

### Fix
Build the response explicitly with:
- `content-type: text/jsonl` — did:webvh v1.0 SHOULDs this for the log file (DID-to-HTTPS Transformation §6)
- `x-content-type-options: nosniff` — the endpoint is served at the router root, outside any security-headers middleware

…and align the `#[utoipa::path]` annotation. This matches the other did.jsonl-serving routes (`routes::self_hosted_did`, `vtc-service` `did_log`), so all three now serve the same resource identically.

### Notes
- The route is `tee`-gated; the handler itself compiles in all configs. Verified `cargo check`/`clippy` clean under both default and `--features tee`.
- No automated test added: the route is only registered under the `tee` feature and `AppState` isn't exposed to the test harness, so a router test would mean pulling the heavy `tee` feature or refactoring `test_support` — disproportionate for this. The change uses the identical `Response::builder` pattern already asserted to yield a single `text/jsonl` header by the `self_hosted_did` tests merged in #559.
- Bumps `vta-service` 0.10.2 → 0.10.3.