### PR TITLE
fix(vta): offline `services` builds seed store from configured secrets backend (#564)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10111,7 +10111,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.10.3"
+version = "0.10.4"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/services_cli.rs
+++ b/vta-service/src/services_cli.rs
@@ -44,7 +44,7 @@ use vti_common::telemetry::{RingBufferTelemetry, SharedTelemetrySink};
 use crate::auth::AuthClaims;
 use crate::config::AppConfig;
 use crate::didcomm_bridge::DIDCommBridge;
-use crate::keys::seed_store::PlaintextSeedStore;
+use crate::keys::seed_store::{SeedStore, create_seed_store};
 use crate::messaging::drain_sweeper::{DrainSweeper, teardown_channel};
 use crate::messaging::handshake::AlwaysOkProver;
 use crate::messaging::registry::MediatorListenerRegistry;
@@ -84,7 +84,7 @@ struct OfflineDeps {
     drains_ks: KeyspaceHandle,
     snapshot_ks: KeyspaceHandle,
     service_state_ks: KeyspaceHandle,
-    seed_store: PlaintextSeedStore,
+    seed_store: Box<dyn SeedStore>,
     did_resolver: DIDCacheClient,
     didcomm_bridge: Arc<DIDCommBridge>,
     telemetry: SharedTelemetrySink,
@@ -114,7 +114,7 @@ impl OfflineDeps {
             snapshot_ks: &self.snapshot_ks,
             service_state_ks: &self.service_state_ks,
             drains_ks: &self.drains_ks,
-            seed_store: &self.seed_store,
+            seed_store: &*self.seed_store,
             did_resolver: &self.did_resolver,
             didcomm_bridge: &self.didcomm_bridge,
             telemetry: &self.telemetry,
@@ -168,7 +168,15 @@ async fn build_offline_deps(
     config.services.didcomm =
         crate::operations::protocol::runtime_state::is_didcomm_enabled(&service_state_ks).await?;
 
-    let seed_store = PlaintextSeedStore::new(&data_dir);
+    // Build the seed store from the configured `[secrets]` backend
+    // (keyring / AWS / GCP / Vault / plaintext / …) exactly as the
+    // daemon and every other offline command (`keys`, `contexts`,
+    // `create-did-key`, `webvh`) do. WebVH-mutating service ops
+    // (enable/disable/update DIDComm) re-sign the DID log and need
+    // the master seed; hardcoding `PlaintextSeedStore(data_dir)`
+    // meant any non-plaintext backend failed with
+    // "no seed found in external store" (#564).
+    let seed_store = create_seed_store(&config)?;
     let did_resolver = DIDCacheClient::new(DIDCacheConfigBuilder::default().build()).await?;
     let didcomm_bridge = Arc::new(DIDCommBridge::placeholder());
     let telemetry: SharedTelemetrySink = Arc::new(RingBufferTelemetry::new());


### PR DESCRIPTION
## Summary

Fixes #564. Offline `vta services didcomm enable/disable/update` failed with `could not load seed: no seed found in external store` whenever the VTA was set up with a non-plaintext secrets backend (or the `plaintext` backend storing the seed outside `data_dir`).

## Root cause

`vta-service/src/services_cli.rs` constructed its seed store as `PlaintextSeedStore::new(&data_dir)` unconditionally, ignoring the configured `[secrets]` backend. WebVH-mutating service ops re-sign the DID log and need the master seed, so on any backend that doesn't write a plaintext seed file under `data_dir` the lookup missed.

Every other offline command (`keys`, `contexts`, `create-did-key`, `webvh`) already builds the seed store via the shared `create_seed_store(&config)` factory — `services_cli` was the lone outlier.

## Fix

- `build_offline_deps` now calls `create_seed_store(&config)` so the configured backend (keyring / AWS / GCP / Vault / plaintext / …) is honoured offline, exactly as the daemon and sibling commands do.
- `OfflineDeps.seed_store`: `PlaintextSeedStore` → `Box<dyn SeedStore>`. `ServiceOpDeps.seed_store` is already `&dyn SeedStore`, so this is a drop-in.
- Bumped `vta-service` 0.10.3 → 0.10.4 (publishable crate, source change). `vta-enclave` pins `0.10`, so no dependent bump.

## Testing

- `cargo check --package vta-service` passes; `cargo fmt --check` clean.
- No automated test added: there is no existing harness for the offline `run_services_*` path (needs a fully provisioned data dir + WebVH DID). This change aligns `services_cli` with the already-covered sibling commands.