### PR TITLE
fix(vta-mcp): shut down the DIDComm session on exit

### DIFF
--- a/vta-mcp/src/main.rs
+++ b/vta-mcp/src/main.rs
@@ -147,9 +147,22 @@ async fn main() -> anyhow::Result<()> {
 
     tracing::info!("vta-mcp connected to VTA; serving MCP over stdio");
 
-    let service = VtaMcp::new(Arc::new(agent), holder).serve(stdio()).await?;
-    service.waiting().await?;
-    Ok(())
+    // Keep a handle so the client's DIDComm session can be closed cleanly once
+    // serving ends — however it ends. A DIDComm `VtaClient` owns a live,
+    // auto-reconnecting mediator socket that `Drop` can't close; leaking it
+    // trips a debug-assert and duels the mediator on reconnect. We run serve +
+    // wait, then `shutdown()` unconditionally (idempotent, a no-op for
+    // REST/token clients) *before* propagating any error — a bare `?` on
+    // `waiting()` would skip the cleanup on the common EOF/disconnect path.
+    let agent = Arc::new(agent);
+    let served = async {
+        let service = VtaMcp::new(agent.clone(), holder).serve(stdio()).await?;
+        service.waiting().await?;
+        Ok::<(), anyhow::Error>(())
+    }
+    .await;
+    agent.shutdown().await;
+    served
 }
 
 /// Resolve the four did:key DIDComm-mode params. Returns `Some(..)` when all


### PR DESCRIPTION
## What

`vta-mcp` in did:key DIDComm mode (added in #563) now **shuts down its DIDComm session on exit** instead of leaking it.

## Why

A DIDComm `VtaClient` owns a live, auto-reconnecting mediator WebSocket that `Drop` cannot close. `main()` was letting the `VtaClient` (inside the `AgentSession` → `VtaMcp` → service) simply drop when serving ended, so:

- in **dev builds**, `DIDCommSession`'s leak guard trips its `debug_assert!` — `panicked at vta-sdk/src/didcomm_session.rs:85: DIDComm session … dropped without shutdown()`;
- in **release builds**, the leaked session keeps reconnecting and a later same-DID session duels it on the mediator → dropped in-flight messages / round-trip timeouts (the failure mode #302's guard exists to catch).

## Fix

Hold an `Arc<AgentSession>` and call `shutdown().await` after serving, **before** propagating any error. A bare `?` on `service.waiting().await` skipped cleanup on the common EOF/disconnect path (immediate `stdin` EOF, host disconnect), which is exactly when the leak fired. `shutdown()` is idempotent and a no-op for REST/token clients, so it runs unconditionally.

```rust
let agent = Arc::new(agent);
let served = async {
    let service = VtaMcp::new(agent.clone(), holder).serve(stdio()).await?;
    service.waiting().await?;
    Ok::<(), anyhow::Error>(())
}.await;
agent.shutdown().await;   // close the DIDComm session however serving ended
served
```

## Testing

- `cargo build`, `cargo clippy` clean.
- **Before:** running the DIDComm-mode server and closing its input panics with `dropped without shutdown()` (exit 101).
- **After:** clean teardown — no panic. Verified both the immediate-EOF path and a full MCP round trip driven by an external client (connect → `list_tools` → `list_keys` → disconnect): the server shuts the session down cleanly and the client's calls succeed.
</content>
