### PR TITLE
feat(vta-sdk): context_policy on the HTTP-client UpdateContextRequest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2441,7 +2441,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.18.4",
+ "vta-sdk 0.18.5",
 ]
 
 [[package]]
@@ -3211,7 +3211,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.18.4",
+ "vta-sdk 0.18.5",
 ]
 
 [[package]]
@@ -6698,7 +6698,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.18.4",
+ "vta-sdk 0.18.5",
 ]
 
 [[package]]
@@ -9946,7 +9946,7 @@ dependencies = [
 
 [[package]]
 name = "vta-cli-common"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "aes-gcm",
  "affinidi-crypto",
@@ -9964,7 +9964,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.18.4",
+ "vta-sdk 0.18.5",
  "vti-common",
  "x25519-dalek",
 ]
@@ -9997,7 +9997,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.18.4",
+ "vta-sdk 0.18.5",
 ]
 
 [[package]]
@@ -10020,7 +10020,7 @@ dependencies = [
  "tracing-subscriber",
  "trust-tasks-rs",
  "uniffi",
- "vta-sdk 0.18.4",
+ "vta-sdk 0.18.5",
 ]
 
 [[package]]
@@ -10055,7 +10055,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.18.4"
+version = "0.18.5"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10186,7 +10186,7 @@ dependencies = [
  "utoipa-axum",
  "uuid",
  "vta-cli-common",
- "vta-sdk 0.18.4",
+ "vta-sdk 0.18.5",
  "vta-service",
  "vti-common",
  "vti-secrets",
@@ -10208,7 +10208,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.18.4",
+ "vta-sdk 0.18.5",
 ]
 
 [[package]]
@@ -10280,7 +10280,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.18.4",
+ "vta-sdk 0.18.5",
  "vtc-service",
  "vti-common",
  "vti-secrets",
@@ -10328,7 +10328,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.18.4",
+ "vta-sdk 0.18.5",
  "webauthn-rs",
  "zeroize",
 ]
@@ -10355,7 +10355,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.18.4",
+ "vta-sdk 0.18.5",
  "vta-service",
  "vti-common",
 ]
@@ -10384,7 +10384,7 @@ dependencies = [
  "tokio",
  "tracing",
  "vaultrs",
- "vta-sdk 0.18.4",
+ "vta-sdk 0.18.5",
  "vti-common",
 ]
 

--- a/docs/05-design-notes/enterprise-fleet-management.md
+++ b/docs/05-design-notes/enterprise-fleet-management.md
@@ -1,0 +1,289 @@
+# Spec: Enterprise fleet management & owner/user separation of duty
+
+Status: **Proposed (design)**
+Owner: Glenn Gore
+Last updated: 2026-06-23
+
+## 1. Objective
+
+Today the VTA is designed for the individual who **owns and uses** their own
+agent — owner and user are the same person, and that works well. This spec
+adds the **enterprise** case: an organisation owns and manages a VTA (or a
+whole fleet of VTAs) that staff *use* day-to-day, with a hard **separation of
+duty** between:
+
+* the **VTA owner** (enterprise manager / IT) — sets policy, controls config,
+  grants and revokes access, manages the fleet at scale; and
+* the **VTA user** (staff member) — operates within the scope the owner
+  defines and **cannot relax** the guardrails placed on them.
+
+The design has two layers:
+
+1. **Single-VTA separation of duty** — express "owner vs user" entirely on
+   the existing super-admin ↔ context-scoped axis, plus one new per-context
+   policy primitive. (§3–§4)
+2. **Fleet management** — an enterprise operator persona (**Enterprise/Fleet
+   Network Manager, ENM**) that manages *N* VTAs at scale via desired-state
+   reconciliation over DIDComm. (§5–§8)
+
+The guiding principle: **do not build an "enterprise mode" as a parallel trust
+root.** Every enterprise concept maps onto primitives already in the workspace
+(super-admin, contexts, capabilities, step-up, templates, bootstrap/attestation,
+the pluggable telemetry sink). The new build is small and additive.
+
+### 1.1 Repository boundary (open-core split)
+
+The work splits across **two repos** along a clean open-core line:
+
+* **This workspace (`verifiable-trust-infrastructure`, OSS)** ships the
+  generic *management surface* — the mechanism that makes any VTA
+  fleet-manageable without prescribing which fleet manager:
+  `ContextPolicy` (§4), admin-over-DIDComm coverage (§6 step 2), the
+  super-admin-only audit query, attested/provision enrollment hooks (already
+  present), and the pluggable `TelemetrySink` (already present). These are
+  separation-of-duty primitives useful to *any* operator.
+* **A new Affinidi-specific repo at `~/devel/<crate>` (proprietary)** ships
+  the opinionated *fleet-management product* — the **ENM** control plane:
+  desired-state model + reconciler, VTA inventory/registry, fleet-seed /
+  per-VTA super-admin orchestration, the telemetry/audit aggregator (consuming
+  the OSS sink trait), and the CLI → control-plane service.
+
+It depends on the OSS crates exactly as `pnm-cli` does — `vta-sdk`,
+`vta-cli-common`, `vti-common` by **path** during development (sibling
+checkout) and by **crates.io version** for release (all three are
+`publish.workspace = true`). It must depend **only** on the published
+crates (`vta-sdk` / `vta-cli-common` / `vti-common`), never on
+`vta-service`/`vtc-service` internals — the reconciler drives VTAs over the
+wire (SDK), it does not link their runtime.
+
+The OSS half (§3–§4, §6 steps 1–2 + audit query) is documented here; the
+detailed ENM product design (§5, §6 steps 3–6) relocates to a design note in
+the new repo once it is scaffolded — this note keeps the boundary + the
+"what the OSS side must expose" contract.
+
+### Why this matters
+
+* Enterprises will not deploy an agent that a staff member can re-configure to
+  exfiltrate keys, present arbitrary credentials, or remove org controls.
+  Separation of duty is the price of entry.
+* At any real headcount this becomes a *fleet* problem: provision, configure,
+  observe, rotate, suspend and decommission hundreds-to-thousands of staff
+  VTAs — most of them intermittently-connected devices behind NAT.
+* The workspace already has the hard parts (DID-native ACL, DIDComm admin
+  surface, mediator store-and-forward, BIP-32 derivation, attested bootstrap,
+  templates, pluggable telemetry). Fleet management is largely *composition*
+  of these, not new cryptography or new trust.
+
+### Non-goals
+
+* **MDM / device management.** This is identity-and-agent management, not OS
+  device management. We manage what the VTA advertises, authorises and
+  attests — not the host OS.
+* **Replacing per-VTA autonomy.** Each managed VTA stays authoritative over
+  its own ACL/policy in steady state (per `CLAUDE.md`). The fleet manager
+  holds *desired state* and reconciles; it is **not** a runtime dependency.
+  A staff VTA must keep working when the control plane is offline.
+* **A new authorization envelope.** Owner→user authorization assertions remain
+  VC/VP-shaped; admin operations remain the existing ACL/policy/service ops.
+* **Cross-tenant trust federation.** One enterprise managing its own fleet.
+  Inter-enterprise trust is the VTC's job, out of scope here.
+
+## 2. Tech stack & codebase context
+
+* Rust workspace, edition 2024, resolver 3, MSRV 1.95.0.
+* Existing modules this builds on (extend, do **not** fork):
+  * `vti-common/src/acl/mod.rs` — `Role`, `Capability`, `AclEntry`,
+    super-admin predicate, visibility filter.
+  * `vti-common/src/auth/{extractor,jwt,step_up}.rs` — request-path auth
+    gates (`SuperAdminAuth`, `AdminAuth`, context checks), `StepUpPolicy`
+    (the additive-strictness lattice to mirror).
+  * `vta-service/src/operations/{acl,contexts}.rs` — ACL/context CRUD and
+    their auth gates.
+  * `vta-service/src/operations/credential_exchange.rs` — `ConsentPolicy`
+    (`trusted_presentation_verifiers`), the present-query enforcement point.
+  * `vta-service/src/trust_tasks/*` + signing-oracle route — the dispatch
+    spine where capabilities are already enforced (where `ContextPolicy`
+    enforcement also lands).
+  * `vta-service/src/operations/protocol/*`, `vta-service/src/messaging/*`,
+    `vta-service/src/routes/protocol.rs` — runtime service management +
+    **admin-over-DIDComm** (the pattern the fleet API fans out).
+  * `vta-service/src/routes/bootstrap.rs`, `vta-service/src/tee/` — Mode B
+    attested bootstrap + provision-integration (the enrollment flows).
+  * `vti-common/src/telemetry/` — pluggable `TelemetrySink` (point at a
+    fleet collector instead of the default ring buffer).
+  * `vta-sdk` — REST + DIDComm client; `did_templates`; `protocol::*` wire
+    types. Consumed by the external ENM repo as its wire transport; not
+    extended here beyond the admin-over-DIDComm coverage in §6.
+  * `vta-cli-common` — shared CLI command impls; `pnm-cli`/`cnm-cli` are the
+    thin-wrapper precedent the external ENM CLI follows.
+
+* Existing invariants that must continue to hold:
+  * The ACL is the steady-state source of authorization truth.
+  * Step-up overrides are **additive-only** (strictest wins; a relaxing
+    override is ignored).
+  * A context-scoped actor cannot mint an unrestricted (super-admin) entry,
+    cannot change VTA config, and cannot see/modify higher-privilege entries.
+  * Audience isolation between VTA and VTC JWTs.
+
+## 3. Functional requirements — single-VTA separation of duty
+
+The owner/user split is **already expressible** with one addition. The mapping:
+
+| Enterprise concept | Existing primitive |
+|---|---|
+| VTA owner (enterprise) | **Super-admin** = `role=Admin` + `allowed_contexts=[]` (`acl/mod.rs:419`) |
+| VTA user (staff) | Context-scoped ACL entry: `role=Application`/`Reader` + `allowed_contexts=[ctx]` + explicit `capabilities` + `expires_at` |
+| Team lead | Context-admin = `role=Admin` scoped to a sub-context |
+| "What you can/can't do" | The 10 `Capability` flags, per-entry (`acl/mod.rs:122`) |
+| "Within the org's scope" | `allowed_contexts` + segment-aware ancestry |
+
+Separation-of-duty guarantees already enforced (no new work):
+
+* Scoped actor **cannot change VTA config** (`SuperAdminAuth`,
+  `routes/config.rs`).
+* Scoped actor **cannot create top-level contexts** (super-admin only,
+  `contexts.rs:91`) nor **mint an unrestricted ACL entry** (`acl.rs:626-629`).
+* Scoped actor **cannot enumerate or modify** the super-admin entry
+  (visibility filter `acl.rs:671-679`).
+* Step-up overrides are additive — staff can be made *stricter*, never looser.
+* `role=Application` can *use* keys (signing oracle never exports) but cannot
+  back up (super-admin only) or mint unrestricted access. No exfiltration path.
+
+### FR-1: `ContextPolicy` — the one missing primitive
+
+Capabilities give coarse on/off of an *operation class*; they cannot say
+"this operation, but only against these targets." The existing policy objects
+(`StepUpPolicy`, `ConsentPolicy`) are **VTA-wide**, which doesn't fit a
+multi-staff or fleet world. Introduce a per-context policy:
+
+```rust
+/// Attached to a context. Mutable only by super-admin; a context-admin with
+/// PolicyAdmin may *narrow* (never widen) it on a sub-context — same additive
+/// discipline as StepUpPolicy.
+pub struct ContextPolicy {
+    /// Verifier DIDs staff in this context may present to. None = inherit.
+    pub trusted_verifiers: Option<BTreeSet<String>>,
+    /// Credential types staff may present. None = inherit; Some = allow-list.
+    pub presentable_types: Option<BTreeSet<String>>,
+    /// Key ids the signing oracle may be invoked on. None = inherit.
+    pub signable_keys: Option<BTreeSet<String>>,
+    /// false = sealed-transfer export disabled for this context.
+    pub export_allowed: bool,
+    /// Per-operation-class rate/quota ceilings. None = inherit.
+    pub quotas: Option<Quotas>,
+}
+```
+
+**Resolution** at the enforcement spine = intersect
+`global ∩ ancestor-contexts ∩ leaf ∩ per-entry-override`, where every step can
+only **narrow**. This mirrors the step-up strictness lattice and makes
+non-removability structural: a deeper/closer actor can tighten but never
+loosen what an ancestor (ultimately the owner) set.
+
+**Enforcement points** (reuse where capabilities are already checked):
+* present/disclosure: `credential_exchange.rs::present_query` + vault release.
+* signing: the signing-oracle route / `key-management/1.0/sign-request`.
+* export: the `sealed_transfer` emit path.
+
+`ContextPolicy` is additive to existing wire types — no reshaping of
+`SealedPayloadV1` or any verified form.
+
+## 4. Single-VTA: what's left to build
+
+1. `ContextPolicy` type, store (alongside the context record), resolution
+   function, enforcement at the three spines above, super-admin CRUD route +
+   `pnm`/`vta` CLI, additive-narrow gate for context-admins.
+2. Super-admin-only, context-scoped **audit query** over the existing audit
+   log (`audit::record`) so the owner can see what staff did.
+3. **Provisioning**: extend `vta setup --from <toml>` to bake in
+   `super-admin = enterprise DID` + the staff context + the scoped staff
+   entry + the initial `ContextPolicy`, so an enterprise can stamp out a
+   pre-configured VTA in one shot.
+
+That alone delivers separation of duty for a single shared or per-staff VTA.
+Everything below scales it to a fleet.
+
+## 5. Fleet management lives in the external Affinidi repo
+
+The fleet-management product — **ENM**, the control plane that manages *N* VTAs
+at scale — is **not** part of this workspace. It is the proprietary,
+Affinidi-specific repo **`affinidi-vti-enm`** (§1.1), built on the OSS crates.
+Its full architecture (identity-as-super-admin + control loop, desired-state
+reconciliation, DIDComm-via-mediator transport, per-VTA super-admin derived
+from a fleet seed, enrollment via Mode B / provision-integration, policy
+profiles as templates, telemetry aggregation, CLI → control-plane service
+staging) is specified there:
+`affinidi-vti-enm/docs/design/fleet-management.md`.
+
+### 5.1 The contract this workspace owes the fleet manager
+
+The OSS side's entire obligation to ENM is to **expose** the surface ENM
+drives. Nothing fleet-specific is built here — these are generic, reusable
+management primitives any operator benefits from:
+
+* **`ContextPolicy`** (§3–§4) — per-context policy + additive-narrow resolution
+  + enforcement at the present/sign/export spines.
+* **Full admin-over-DIDComm coverage** for every admin op (ACL CRUD, policy
+  set, service management) so a fleet can drive a VTA over the mediator.
+* **Super-admin context-scoped audit query** (§4) — the read side ENM
+  aggregates.
+* **Attested / provision enrollment** (already present) and the pluggable
+  **`TelemetrySink`** (already present) pointed at a fleet collector.
+
+## 6. Build order (this workspace)
+
+Only the OSS prerequisites live here; the ENM product steps are in
+`affinidi-vti-enm/docs/design/fleet-management.md` §4.
+
+1. **`ContextPolicy`** (§4) — type, store, additive-narrow resolution,
+   enforcement at the present/sign/export spines, super-admin CRUD route +
+   `pnm`/`vta` CLI, context-admin narrow-only gate. Nothing fleet-wide is
+   meaningful until per-VTA policy exists to distribute.
+2. **Admin-over-DIDComm coverage audit** — confirm every admin op the fleet
+   needs (ACL CRUD, policy set, service management) is reachable over
+   DIDComm-via-mediator; fill gaps. Plus the super-admin context-scoped
+   **audit query** (§4). *Together these are the fleet's actual API.*
+3. **Provisioning** — extend `vta setup --from <toml>` to bake in the
+   enterprise super-admin + staff context + scoped staff entry + initial
+   `ContextPolicy` (§4).
+
+These are the only prerequisites the ENM repo cannot supply itself.
+
+## 7. Key decisions (OSS scope)
+
+* **No enterprise mode / no new trust root** — compose existing primitives.
+* **Owner = super-admin, user = context-scoped actor** — separation of duty is
+  the existing super-admin ↔ scoped axis, made complete by `ContextPolicy`.
+* **Policy is per-context and additive-narrow** — resolution intersects down the
+  tree; deeper actors tighten, never loosen.
+* **Backward-compatible by construction** — `ContextPolicy` absent / empty
+  allow-list = inherit (unrestricted), serde-`default` on new fields. Existing
+  deployments are a no-op; the enterprise split is a new provisioning *choice*,
+  not a change to anything already running.
+
+Fleet-side decisions (reconciliation-over-RPC, DIDComm transport, per-VTA
+fleet-seed super-admin, one-core-two-front-ends) live in
+`affinidi-vti-enm/docs/design/fleet-management.md` §5.
+
+## 8. Open questions (OSS scope)
+
+* **`Quotas` granularity** — per-operation-class counters vs token-bucket;
+  where the counter state lives (per-VTA fjall vs reported to a collector).
+* **Shared-VTA (context-per-staff) vs per-staff-VTA fleet** — both reuse the
+  same spine; affects provisioning shape. ENM assumes per-staff but does not
+  preclude shared tenants on a single VTA.
+
+Fleet-side open questions (group model, kill switch, recovery) live in the ENM
+doc §6.
+
+## 9. Related docs
+
+* `affinidi-vti-enm/docs/design/fleet-management.md` — the ENM fleet-management
+  product design (external Affinidi repo).
+* `docs/05-design-notes/runtime-service-management.md` — the admin-over-DIDComm
+  pattern the fleet API fans out.
+* `docs/05-design-notes/hierarchical-contexts.md` — context tree + ancestry.
+* `docs/05-design-notes/auth-architecture.md` — roles, capabilities, step-up.
+* `docs/02-vta/provision-integration.md`, `sealed-bootstrap.md` — enrollment.
+* `docs/02-vta/did-templates.md` — the author-once/render-everywhere pattern
+  reused for policy profiles.

--- a/docs/vta-step-up-art-of-the-possible.html
+++ b/docs/vta-step-up-art-of-the-possible.html
@@ -1,0 +1,483 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>VTA Step-Up Auth · The Art of the Possible</title>
+<style>
+  :root {
+    --bg: #0a0e1a;
+    --bg-2: #111726;
+    --panel: #161d2f;
+    --panel-2: #1c2540;
+    --line: #2a3450;
+    --ink: #e8edf7;
+    --muted: #94a3c4;
+    --dim: #647196;
+    --accent: #6ea8ff;
+    --accent-2: #58e6c9;
+    --accent-3: #c79bff;
+    --warn: #ffb454;
+    --hard: #ff7a8a;
+    --good: #58e6a8;
+    --shadow: 0 18px 50px rgba(0,0,0,.45);
+  }
+  * { box-sizing: border-box; }
+  html { scroll-behavior: smooth; }
+  body {
+    margin: 0;
+    background: radial-gradient(1200px 700px at 80% -10%, #1a2238 0%, transparent 60%),
+                radial-gradient(1000px 600px at 0% 10%, #16203a 0%, transparent 55%),
+                var(--bg);
+    color: var(--ink);
+    font: 16px/1.6 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    -webkit-font-smoothing: antialiased;
+  }
+  .wrap { max-width: 1180px; margin: 0 auto; padding: 0 28px; }
+  .mono { font-family: "SF Mono", ui-monospace, "JetBrains Mono", Menlo, Consolas, monospace; }
+
+  /* ---------- HERO ---------- */
+  header.hero {
+    padding: 88px 0 64px;
+    border-bottom: 1px solid var(--line);
+    background:
+      linear-gradient(180deg, rgba(110,168,255,.06), transparent 70%);
+  }
+  .eyebrow {
+    display: inline-flex; align-items: center; gap: 8px;
+    font-size: 13px; letter-spacing: .14em; text-transform: uppercase;
+    color: var(--accent-2); font-weight: 600;
+    padding: 6px 14px; border: 1px solid var(--line); border-radius: 999px;
+    background: var(--panel);
+  }
+  h1 {
+    font-size: 52px; line-height: 1.08; margin: 22px 0 14px; letter-spacing: -.02em;
+    background: linear-gradient(110deg, #fff 10%, var(--accent) 55%, var(--accent-3) 95%);
+    -webkit-background-clip: text; background-clip: text; color: transparent;
+    max-width: 18ch;
+  }
+  .lede { font-size: 20px; color: var(--muted); max-width: 70ch; margin: 0; }
+  .hero-tags { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 30px; }
+  .tag {
+    font-size: 13px; color: var(--ink); background: var(--panel-2);
+    border: 1px solid var(--line); border-radius: 8px; padding: 7px 12px;
+  }
+  .tag b { color: var(--accent-2); font-weight: 600; }
+
+  section { padding: 70px 0; border-bottom: 1px solid var(--line); }
+  .kicker { font-size: 13px; letter-spacing: .16em; text-transform: uppercase; color: var(--dim); font-weight: 600; margin: 0 0 10px; }
+  h2 { font-size: 34px; margin: 0 0 14px; letter-spacing: -.015em; }
+  h2 + .sub { color: var(--muted); font-size: 18px; max-width: 72ch; margin: 0 0 36px; }
+
+  /* ---------- WHY / reasoning cards ---------- */
+  .why-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px; }
+  .why {
+    background: linear-gradient(180deg, var(--panel), var(--bg-2));
+    border: 1px solid var(--line); border-radius: 16px; padding: 24px;
+    box-shadow: var(--shadow);
+  }
+  .why .n { font-size: 13px; color: var(--accent); font-weight: 700; letter-spacing: .1em; }
+  .why h3 { margin: 8px 0 8px; font-size: 19px; }
+  .why p { margin: 0; color: var(--muted); font-size: 15px; }
+
+  /* ---------- SEAMS ---------- */
+  .seams { display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px; }
+  .seam {
+    border: 1px solid var(--line); border-radius: 16px; padding: 26px 24px;
+    background: var(--panel); position: relative; overflow: hidden;
+  }
+  .seam::before {
+    content: ""; position: absolute; inset: 0 0 auto 0; height: 4px;
+  }
+  .seam.s1::before { background: linear-gradient(90deg, var(--accent), transparent); }
+  .seam.s2::before { background: linear-gradient(90deg, var(--accent-2), transparent); }
+  .seam.s3::before { background: linear-gradient(90deg, var(--accent-3), transparent); }
+  .seam .dial { font-size: 13px; letter-spacing: .12em; text-transform: uppercase; color: var(--dim); }
+  .seam h3 { font-size: 22px; margin: 6px 0 14px; }
+  .seam ul { margin: 0; padding: 0; list-style: none; }
+  .seam li { padding: 9px 0; border-top: 1px dashed var(--line); color: var(--muted); font-size: 14.5px; display: flex; gap: 9px; }
+  .seam li:first-child { border-top: none; }
+  .pill { font-size: 11px; font-weight: 700; padding: 2px 8px; border-radius: 999px; white-space: nowrap; height: fit-content; margin-top: 2px; }
+  .pill.now { background: rgba(88,230,168,.13); color: var(--good); border: 1px solid rgba(88,230,168,.3); }
+  .pill.next { background: rgba(255,180,84,.12); color: var(--warn); border: 1px solid rgba(255,180,84,.3); }
+  .pill.soon { background: rgba(199,155,255,.12); color: var(--accent-3); border: 1px solid rgba(199,155,255,.3); }
+  .seam-foot { text-align:center; color: var(--dim); font-size: 14px; margin-top: 26px; }
+  .seam-foot b { color: var(--ink); }
+
+  /* ---------- FLOW ---------- */
+  .flow-banner {
+    background: linear-gradient(120deg, rgba(255,122,138,.10), rgba(199,155,255,.08));
+    border: 1px solid var(--line); border-radius: 14px; padding: 18px 22px; margin-bottom: 34px;
+    display: flex; gap: 16px; align-items: center;
+  }
+  .flow-banner .bolt { font-size: 30px; }
+  .flow-banner p { margin: 0; color: var(--muted); }
+  .flow-banner b { color: var(--ink); }
+
+  .lane-legend { display:flex; flex-wrap:wrap; gap: 18px; margin-bottom: 26px; font-size: 13.5px; color: var(--muted); }
+  .lane-legend span { display:inline-flex; align-items:center; gap:8px; }
+  .dot { width: 11px; height: 11px; border-radius: 3px; display:inline-block; }
+  .d-op { background: var(--accent); }
+  .d-vta { background: var(--accent-2); }
+  .d-push { background: var(--warn); }
+  .d-dev { background: var(--accent-3); }
+  .d-hw { background: var(--hard); }
+
+  .steps { position: relative; }
+  .step {
+    display: grid; grid-template-columns: 56px 1fr; gap: 20px; padding: 4px 0;
+  }
+  .step .rail { position: relative; }
+  .step .num {
+    width: 40px; height: 40px; border-radius: 50%; display: grid; place-items: center;
+    font-weight: 700; font-size: 16px; background: var(--panel-2); border: 1px solid var(--line);
+    color: var(--ink); z-index: 2; position: relative;
+  }
+  .step .rail::after {
+    content: ""; position: absolute; left: 19px; top: 40px; bottom: -22px; width: 2px;
+    background: linear-gradient(var(--line), var(--line)); z-index: 1;
+  }
+  .step:last-child .rail::after { display: none; }
+  .step .card {
+    background: var(--panel); border: 1px solid var(--line); border-radius: 14px;
+    padding: 16px 20px; margin-bottom: 22px; box-shadow: var(--shadow);
+  }
+  .step .card .who { font-size: 12px; letter-spacing: .08em; text-transform: uppercase; font-weight: 700; display:inline-flex; align-items:center; gap: 7px; }
+  .who.op { color: var(--accent); }
+  .who.vta { color: var(--accent-2); }
+  .who.push { color: var(--warn); }
+  .who.dev { color: var(--accent-3); }
+  .who.hw { color: var(--hard); }
+  .step .card h4 { margin: 7px 0 5px; font-size: 17px; }
+  .step .card p { margin: 0; color: var(--muted); font-size: 14.5px; }
+  .step .card .wire {
+    margin-top: 10px; font-size: 12.5px; color: var(--accent-2);
+    background: var(--bg); border: 1px solid var(--line); border-radius: 8px;
+    padding: 6px 10px; display: inline-block;
+  }
+  .step .card .wire .hard { color: var(--hard); }
+
+  /* ---------- ROADMAP ---------- */
+  .road { display: grid; grid-template-columns: repeat(4, 1fr); gap: 16px; }
+  .phase {
+    border: 1px solid var(--line); border-radius: 16px; padding: 22px 20px; background: var(--panel);
+    display: flex; flex-direction: column;
+  }
+  .phase .ph-h { display:flex; align-items:center; justify-content: space-between; margin-bottom: 6px; }
+  .phase .ph-tag { font-size: 11.5px; font-weight: 700; padding: 3px 9px; border-radius: 999px; }
+  .phase.p0 { border-color: rgba(88,230,168,.4); }
+  .phase.p0 .ph-tag { background: rgba(88,230,168,.14); color: var(--good); }
+  .phase.p1 .ph-tag { background: rgba(110,168,255,.14); color: var(--accent); }
+  .phase.p2 .ph-tag { background: rgba(255,180,84,.14); color: var(--warn); }
+  .phase.p3 .ph-tag { background: rgba(199,155,255,.14); color: var(--accent-3); }
+  .phase h3 { margin: 2px 0 4px; font-size: 18px; }
+  .phase .when { font-size: 12.5px; color: var(--dim); margin-bottom: 12px; }
+  .phase ul { margin: 0; padding-left: 18px; color: var(--muted); font-size: 14px; }
+  .phase li { margin-bottom: 7px; }
+
+  /* ---------- CLOSING ---------- */
+  .pitch {
+    background: linear-gradient(135deg, rgba(110,168,255,.10), rgba(199,155,255,.08));
+    border: 1px solid var(--line); border-radius: 20px; padding: 40px 44px;
+  }
+  .pitch h2 { font-size: 30px; margin-bottom: 14px; }
+  .pitch p { color: var(--muted); font-size: 18px; max-width: 80ch; }
+  .pitch .punch { color: var(--ink); font-weight: 600; }
+
+  footer { padding: 40px 0 70px; color: var(--dim); font-size: 13px; }
+  footer .wrap { display:flex; justify-content: space-between; flex-wrap: wrap; gap: 12px; }
+
+  @media (max-width: 880px) {
+    h1 { font-size: 38px; }
+    .why-grid, .seams, .road { grid-template-columns: 1fr; }
+  }
+</style>
+</head>
+<body>
+
+<header class="hero">
+  <div class="wrap">
+    <span class="eyebrow">◆ Verifiable Trust Agent · Design Vision</span>
+    <h1>Step-Up Auth: The Art of the Possible</h1>
+    <p class="lede">
+      Step-up authentication in the VTA is not a hardcoded login — it is a <b>composable approval
+      ceremony</b>. Who approves, what proof they must produce, and how they are summoned are three
+      independent dials. This is what becomes possible as we build it out with push-enabled devices
+      and hardware authenticators.
+    </p>
+    <div class="hero-tags">
+      <span class="tag"><b>DIDComm-first</b> transport</span>
+      <span class="tag"><b>WebAuthn</b> hardware gate</span>
+      <span class="tag"><b>Push-wake</b> any device</span>
+      <span class="tag"><b>VC / VP</b> credential approval</span>
+      <span class="tag"><b>Type-enforced</b> verified evidence</span>
+      <span class="tag"><b>Fully audited</b> ceremonies</span>
+    </div>
+  </div>
+</header>
+
+<!-- WHY -->
+<section>
+  <div class="wrap">
+    <p class="kicker">The reasoning</p>
+    <h2>Why design it this way</h2>
+    <p class="sub">A normal session proves <em>you logged in</em>. Step-up proves <em>this exact
+      sensitive action is authorized, by the right party, with sufficient assurance, right now.</em>
+      Three principles make that durable.</p>
+    <div class="why-grid">
+      <div class="why">
+        <div class="n">01 — BLAST RADIUS</div>
+        <h3>High-risk ops deserve more</h3>
+        <p>Granting admin, revoking keys, releasing vault secrets, proxy-login — these can't ride on
+          a 15-minute token. Step-up demands a fresh, explicit, scoped approval bound to that one
+          operation and a single-use challenge.</p>
+      </div>
+      <div class="why">
+        <div class="n">02 — SEPARATION</div>
+        <h3>Four-eyes, by design</h3>
+        <p>Delegated modes mean a different person or device must sign off. The most dangerous
+          actions can require a second human — turning a single compromised session into a dead end
+          for an attacker.</p>
+      </div>
+      <div class="why">
+        <div class="n">03 — FLEXIBILITY</div>
+        <h3>Policy, not plumbing</h3>
+        <p>Raising the assurance bar — from "tap your phone" to "two officers touch hardware keys" —
+          is a configuration change against the same core machinery. No re-architecture, no new
+          subsystem, no bespoke crypto.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- SEAMS -->
+<section>
+  <div class="wrap">
+    <p class="kicker">The architecture</p>
+    <h2>Three composable dials</h2>
+    <p class="sub">Almost any authorization ceremony you can describe is just a point in this
+      three-dimensional space — not a feature we have to build from scratch.
+      <span class="mono" style="color:var(--good)">● live</span>
+      <span class="mono" style="color:var(--warn)">● next</span>
+      <span class="mono" style="color:var(--accent-3)">● horizon</span></p>
+    <div class="seams">
+      <div class="seam s1">
+        <div class="dial">Dial 1</div>
+        <h3>Who approves</h3>
+        <ul>
+          <li><span class="pill now">LIVE</span> Self-approve (second factor, same identity)</li>
+          <li><span class="pill now">LIVE</span> Delegated — a named approver DID</li>
+          <li><span class="pill now">LIVE</span> Delegated-any — any covering admin</li>
+          <li><span class="pill next">NEXT</span> M-of-N quorum on one challenge</li>
+          <li><span class="pill soon">HORIZON</span> Credential-derived approver pools</li>
+          <li><span class="pill soon">HORIZON</span> Escalation chains &amp; break-glass</li>
+        </ul>
+      </div>
+      <div class="seam s2">
+        <div class="dial">Dial 2</div>
+        <h3>What proof counts</h3>
+        <ul>
+          <li><span class="pill now">LIVE</span> DID-signed (eddsa-jcs-2022 proof)</li>
+          <li><span class="pill now">LIVE</span> WebAuthn assertion (passkey / hardware)</li>
+          <li><span class="pill next">NEXT</span> WebAuthn-only enforced per op</li>
+          <li><span class="pill next">NEXT</span> Attestation gate (roaming-key / device-bound)</li>
+          <li><span class="pill soon">HORIZON</span> VC / VP presentation as approval</li>
+          <li><span class="pill soon">HORIZON</span> TEE-attested enclave approval</li>
+        </ul>
+      </div>
+      <div class="seam s3">
+        <div class="dial">Dial 3</div>
+        <h3>How they're reached</h3>
+        <ul>
+          <li><span class="pill now">LIVE</span> Mediator buffer + drain (DIDComm)</li>
+          <li><span class="pill now">LIVE</span> Push-wake via gateway (opaque handle)</li>
+          <li><span class="pill now">LIVE</span> REST / HTTPS gateway fallback</li>
+          <li><span class="pill next">NEXT</span> Multi-device fan-out, first-valid-wins</li>
+          <li><span class="pill next">NEXT</span> Urgency-aware UX (background vs. interrupt)</li>
+          <li><span class="pill soon">HORIZON</span> Dedicated hardware approver appliance</li>
+        </ul>
+      </div>
+    </div>
+    <p class="seam-foot">Pick a value on each dial → you have a ceremony. <b>Quorum × Hardware × Push</b>
+      is the flow below.</p>
+  </div>
+</section>
+
+<!-- FLOW -->
+<section>
+  <div class="wrap">
+    <p class="kicker">End-to-end</p>
+    <h2>Worked example: quorum hardware-key approval for <span class="mono" style="color:var(--hard)">key/revoke</span></h2>
+    <div class="flow-banner">
+      <div class="bolt">⚡</div>
+      <p><b>The scenario.</b> An operator tries to revoke a production signing key. Policy requires
+        <b>2-of-3 security officers</b> to each approve from a <b>push-woken phone</b> by <b>touching a
+        FIDO security key</b> — within a 5-minute window, or the operation is refused.</p>
+    </div>
+    <div class="lane-legend">
+      <span><i class="dot d-op"></i> Operator</span>
+      <span><i class="dot d-vta"></i> VTA</span>
+      <span><i class="dot d-push"></i> Push gateway</span>
+      <span><i class="dot d-dev"></i> Approver device</span>
+      <span><i class="dot d-hw"></i> Hardware key</span>
+    </div>
+
+    <div class="steps">
+      <div class="step">
+        <div class="rail"><div class="num">1</div></div>
+        <div class="card">
+          <span class="who op">● Operator → VTA</span>
+          <h4>Request the sensitive operation</h4>
+          <p>Operator calls <span class="mono">key/revoke</span> on a live, authenticated AAL1 session.
+            The VTA's gate resolves the policy for this op-class and finds a quorum + hardware floor.</p>
+        </div>
+      </div>
+      <div class="step">
+        <div class="rail"><div class="num">2</div></div>
+        <div class="card">
+          <span class="who vta">● VTA</span>
+          <h4>Mint a single-use step-up challenge</h4>
+          <p>A 256-bit challenge is bound to the session, subject, the approver pool, target assurance
+            (<span class="mono">aal2+</span>), required evidence and a 5-minute TTL. The operation parks,
+            pending approval.</p>
+          <span class="wire mono">403 step_up_required · acceptableEvidence: ["webauthn"]</span>
+        </div>
+      </div>
+      <div class="step">
+        <div class="rail"><div class="num">3</div></div>
+        <div class="card">
+          <span class="who vta">● VTA → Mediator + Gateway</span>
+          <h4>Summon the approvers</h4>
+          <p>The VTA buffers an <span class="mono">approve-request</span> for each officer through its
+            mediator <em>and</em> fires a push-wake to each registered gateway. The VTA never sees the
+            APNs/FCM token — only an opaque wake handle.</p>
+          <span class="wire mono">auth/step-up/approve-request/0.1 &nbsp;·&nbsp; push/wake/0.1 (authcrypt)</span>
+        </div>
+      </div>
+      <div class="step">
+        <div class="rail"><div class="num">4</div></div>
+        <div class="card">
+          <span class="who push">● Gateway → Devices</span>
+          <h4>Wake the pocket approvers</h4>
+          <p>Each gateway fires the platform push. Officers' phones wake, connect to the mediator,
+            drain the pending request, and render a consent screen: <em>"Approve revocation of key X?"</em></p>
+        </div>
+      </div>
+      <div class="step">
+        <div class="rail"><div class="num">5</div></div>
+        <div class="card">
+          <span class="who hw">● Device + Hardware key</span>
+          <h4>Touch to authorize</h4>
+          <p>Each officer confirms. The device invokes WebAuthn against the bound challenge; the FIDO
+            key requires a <b>physical touch + user verification</b> before it will sign. The private key
+            never leaves the authenticator.</p>
+          <span class="wire mono">approve-response/0.1 · evidence.kind=<span class="hard">webauthn</span></span>
+        </div>
+      </div>
+      <div class="step">
+        <div class="rail"><div class="num">6</div></div>
+        <div class="card">
+          <span class="who vta">● VTA</span>
+          <h4>Verify evidence &amp; count the quorum</h4>
+          <p>Each assertion is verified against the challenge and resolved to a passkey in the approver's
+            DID document. Verified evidence becomes a distinct type — a call site that forgets to verify
+            won't compile. The VTA counts approvals until the 2-of-3 threshold is met.</p>
+        </div>
+      </div>
+      <div class="step">
+        <div class="rail"><div class="num">7</div></div>
+        <div class="card">
+          <span class="who vta">● VTA → Operator</span>
+          <h4>Elevate, execute, audit</h4>
+          <p>Threshold met inside the window → the session is elevated, the parked
+            <span class="mono">key/revoke</span> executes, and every step — request, wakes, each
+            approval, the outcome — is written to the audit log. Window expires first → the operation
+            is refused, untouched.</p>
+          <span class="wire mono">session → aal2 · operation committed · ceremony audited</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ROADMAP -->
+<section>
+  <div class="wrap">
+    <p class="kicker">The roadmap</p>
+    <h2>From live primitive to full ceremony</h2>
+    <p class="sub">Each phase reuses the same three dials. We are not building new systems — we are
+      turning dials we already designed for.</p>
+    <div class="road">
+      <div class="phase p0">
+        <div class="ph-h"><h3>Foundation</h3><span class="ph-tag">LIVE</span></div>
+        <div class="when">Shipped &amp; tested</div>
+        <ul>
+          <li>Step-up gate + policy engine</li>
+          <li>4 approval modes</li>
+          <li>DID-signed &amp; WebAuthn gates</li>
+          <li>DIDComm approve-request / response</li>
+          <li>Push-wake via gateway</li>
+          <li>Single-use challenge + TTL + audit</li>
+        </ul>
+      </div>
+      <div class="phase p1">
+        <div class="ph-h"><h3>Enforce hardware</h3><span class="ph-tag">NEXT</span></div>
+        <div class="when">Near term</div>
+        <ul>
+          <li>Per-op <span class="mono">webauthn</span>-only floors</li>
+          <li>Attestation gate (roaming-key / device-bound)</li>
+          <li>AAL3-style assurance tiers</li>
+          <li>Richer consent-UI payloads</li>
+          <li>Urgency-aware push</li>
+        </ul>
+      </div>
+      <div class="phase p2">
+        <div class="ph-h"><h3>Quorum &amp; reach</h3><span class="ph-tag">NEXT</span></div>
+        <div class="when">Mid term</div>
+        <ul>
+          <li>M-of-N approvals on one challenge</li>
+          <li>Multi-device fan-out, first-valid-wins</li>
+          <li>Escalation / fallback chains</li>
+          <li>Break-glass JIT delegation</li>
+        </ul>
+      </div>
+      <div class="phase p3">
+        <div class="ph-h"><h3>Credentialed trust</h3><span class="ph-tag">HORIZON</span></div>
+        <div class="when">Forward</div>
+        <ul>
+          <li>VC / VP presentation as approval</li>
+          <li>Credential-derived approver pools</li>
+          <li>TEE-attested enclave approval</li>
+          <li>Dedicated hardware approver appliance</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- CLOSING -->
+<section>
+  <div class="wrap">
+    <div class="pitch">
+      <h2>The one-sentence pitch</h2>
+      <p><span class="punch">Step-up auth in the VTA is a composable ceremony, not a hardcoded
+        login.</span> The same core machinery delivers everything from "tap to confirm on your phone"
+        to "two security officers each touch a FIDO key from attested environments, summoned by push,
+        within five minutes — or the operation is refused." It is standards-native throughout —
+        DIDComm, WebAuthn, VCs/VPs, DIDs — so every future gate interoperates with external verifiers
+        instead of being a scheme we alone must defend. And because verified evidence is enforced by
+        the type system and every ceremony is audited, raising the bar later never risks a silently
+        skipped check.</p>
+    </div>
+  </div>
+</section>
+
+<footer>
+  <div class="wrap">
+    <span>VTA · Verifiable Trust Agent — design vision, forward-looking. Capabilities marked NEXT / HORIZON are not yet shipped.</span>
+    <span class="mono">step-up · push-wake · webauthn · didcomm</span>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/vta-cli-common/Cargo.toml
+++ b/vta-cli-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-cli-common"
 description = "Shared CLI command handlers and rendering helpers for VTA CLIs"
 readme = "README.md"
-version = "0.10.0"
+version = "0.10.1"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-cli-common/src/commands/contexts.rs
+++ b/vta-cli-common/src/commands/contexts.rs
@@ -355,6 +355,7 @@ pub async fn cmd_context_update(
         name,
         did,
         description,
+        context_policy: None,
     };
     let resp = client.update_context(id, req).await?;
     println!("Context updated:");

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.18.4"
+version = "0.18.5"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/client/types.rs
+++ b/vta-sdk/src/client/types.rs
@@ -183,7 +183,7 @@ impl CreateContextRequest {
     }
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Default, Serialize)]
 pub struct UpdateContextRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
@@ -191,6 +191,10 @@ pub struct UpdateContextRequest {
     pub did: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    /// Set this context's policy (super-admin only). Omitted leaves it
+    /// unchanged; send an unrestricted policy to clear constraints.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context_policy: Option<crate::context_policy::ContextPolicy>,
 }
 
 #[derive(Debug, Serialize)]

--- a/vta-sdk/tests/client_rest.rs
+++ b/vta-sdk/tests/client_rest.rs
@@ -744,6 +744,7 @@ async fn update_context_patches() {
         name: Some("Renamed".into()),
         did: None,
         description: None,
+        context_policy: None,
     };
     c.update_context("primary", req).await.unwrap();
 }


### PR DESCRIPTION
## What

The ContextPolicy feature (#566) added `context_policy` to the route's `UpdateContextRequest` and the DIDComm `UpdateContextBody`, but **not** to `vta-sdk`'s HTTP-client `UpdateContextRequest`. So an SDK client — notably the fleet reconciler — can't push a context policy over REST.

This adds the field to the client request type (and derives `Default` so callers can `UpdateContextRequest { context_policy: Some(p), ..Default::default() }`), and updates the two construction sites (`vta-cli-common`, an SDK test).

## Why

Unblocks the ENM reconciler's `SetContextPolicy` op over REST: `client.update_context(id, UpdateContextRequest { context_policy: Some(p), ..Default::default() })` now serializes the policy the route already accepts.

## Testing

`cargo test -p vta-sdk -p vta-cli-common` passes (incl. `update_context_patches`). `cargo fmt` clean.

## Notes

Additive + backward-compatible (`skip_serializing_if = "Option::is_none"`). Bumps `vta-sdk` 0.18.4 → 0.18.5 and `vta-cli-common` 0.10.0 → 0.10.1 (the latter's construction site changed). Internal deps pin major.minor, so no further dependents change.