### PR TITLE
feat(vta-sdk): expose DI-signed REST auth (challenge_response_di)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2441,7 +2441,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.18.5",
+ "vta-sdk 0.18.6",
 ]
 
 [[package]]
@@ -3211,7 +3211,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.18.5",
+ "vta-sdk 0.18.6",
 ]
 
 [[package]]
@@ -6698,7 +6698,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.18.5",
+ "vta-sdk 0.18.6",
 ]
 
 [[package]]
@@ -9964,7 +9964,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.18.5",
+ "vta-sdk 0.18.6",
  "vti-common",
  "x25519-dalek",
 ]
@@ -9997,7 +9997,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.18.5",
+ "vta-sdk 0.18.6",
 ]
 
 [[package]]
@@ -10020,7 +10020,7 @@ dependencies = [
  "tracing-subscriber",
  "trust-tasks-rs",
  "uniffi",
- "vta-sdk 0.18.5",
+ "vta-sdk 0.18.6",
 ]
 
 [[package]]
@@ -10055,7 +10055,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.18.5"
+version = "0.18.6"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10186,7 +10186,7 @@ dependencies = [
  "utoipa-axum",
  "uuid",
  "vta-cli-common",
- "vta-sdk 0.18.5",
+ "vta-sdk 0.18.6",
  "vta-service",
  "vti-common",
  "vti-secrets",
@@ -10208,7 +10208,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.18.5",
+ "vta-sdk 0.18.6",
 ]
 
 [[package]]
@@ -10280,7 +10280,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.18.5",
+ "vta-sdk 0.18.6",
  "vtc-service",
  "vti-common",
  "vti-secrets",
@@ -10328,7 +10328,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.18.5",
+ "vta-sdk 0.18.6",
  "webauthn-rs",
  "zeroize",
 ]
@@ -10355,7 +10355,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.18.5",
+ "vta-sdk 0.18.6",
  "vta-service",
  "vti-common",
 ]
@@ -10384,7 +10384,7 @@ dependencies = [
  "tokio",
  "tracing",
  "vaultrs",
- "vta-sdk 0.18.5",
+ "vta-sdk 0.18.6",
  "vti-common",
 ]
 

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.18.5"
+version = "0.18.6"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/provision_client/auth_rest.rs
+++ b/vta-sdk/src/provision_client/auth_rest.rs
@@ -43,7 +43,12 @@ fn did_key_to_vm(did: &str) -> Option<String> {
 /// `client_did` must be a `did:key` whose private seed is
 /// `private_key_multibase` (the holder/setup key); `vta_did` is the VTA the
 /// document is addressed to. No DIDComm / mediator is involved.
-pub(crate) async fn challenge_response_di(
+///
+/// This is the cryptographically-sound REST auth (the key signs the request),
+/// suitable for any client that *holds* a key — e.g. a fleet manager
+/// authenticating as a per-VTA super-admin. Re-exported as
+/// [`crate::provision_client::challenge_response_di`].
+pub async fn challenge_response_di(
     base_url: &str,
     client_did: &str,
     private_key_multibase: &str,

--- a/vta-sdk/src/provision_client/mod.rs
+++ b/vta-sdk/src/provision_client/mod.rs
@@ -75,6 +75,11 @@ pub use ask::{
     BUILTIN_DID_HOST_HTTP_TEMPLATE, BUILTIN_MEDIATOR_TEMPLATE, BUILTIN_VTA_ADMIN_TEMPLATE,
     DEFAULT_VALIDITY, ProvisionAsk,
 };
+/// Cryptographically-sound DI-signed (`eddsa-jcs-2022`) REST authentication for
+/// any client holding a key (e.g. a fleet manager authenticating as a per-VTA
+/// super-admin). The key signs an `auth/authenticate/0.1` Trust Task — no
+/// DIDComm/mediator, and unlike the anoncrypt light path the sender is proven.
+pub use auth_rest::challenge_response_di;
 pub use diagnostics::{
     ConnectedInfo, DiagCheck, DiagEntry, DiagStatus, Protocol, apply_update, pending_list,
 };


### PR DESCRIPTION
## What

Make the cryptographically-sound DI-signed REST auth public. `provision_client::auth_rest::challenge_response_di` becomes `pub` and is re-exported as `vta_sdk::provision_client::challenge_response_di`.

## Why

The holder key **signs** an `auth/authenticate/0.1` Trust Task (`eddsa-jcs-2022`), so the sender is cryptographically proven — unlike the anoncrypt light path (`auth_light::challenge_response_light`), which ignores the private key. Any client that *holds* a key needs this; concretely, the fleet manager (ENM) authenticating to each VTA as its per-VTA super-admin (derived from the fleet seed) must use it, not the light path.

## Change

- `pub(crate)` -> `pub` on `challenge_response_di`; `pub use` it from `provision_client`.
- Doc note on the function + re-export.
- Bumps vta-sdk 0.18.6.

## Testing

`cargo check -p vta-sdk --features provision-client,client` clean. Additive/backward-compatible — only widens visibility.
EOF
