### PR TITLE
feat(vta/credentials): issue + revoke scoped Verifiable Credentials

### DIFF
--- a/vta-sdk/src/client/credentials.rs
+++ b/vta-sdk/src/client/credentials.rs
@@ -1,0 +1,69 @@
+//! Issued-credential lifecycle Trust Task client methods
+//! (`spec/vta/credentials/{issue,revoke}/0.1`).
+//!
+//! Drives the issue / revoke slice through the generic trust-task dispatcher
+//! ([`VtaClient::dispatch_trust_task`]) — there is no dedicated REST route. Both
+//! operations are gated server-side by operator step-up (AAL2) + an admin
+//! capability check; a stepped-up session is required for either to succeed.
+
+use serde_json::{Value, json};
+
+use super::VtaClient;
+use crate::error::VtaError;
+use crate::trust_tasks;
+
+/// Round-trip timeout (seconds) for issued-credential trust tasks.
+const CREDENTIALS_TT_TIMEOUT: u64 = 30;
+
+impl VtaClient {
+    /// `vta/credentials/issue/0.1` — issue a scoped, time-boxed Verifiable
+    /// Credential to `holder`. `claims` is merged into `credentialSubject`;
+    /// `credential_type`, when present, is appended after `VerifiableCredential`
+    /// in the VC `type`. Requires Admin + a stepped-up (AAL2) session.
+    pub async fn issue_credential(
+        &self,
+        holder: &str,
+        claims: Value,
+        credential_type: Option<&str>,
+        validity_seconds: u64,
+        purpose: Option<&str>,
+    ) -> Result<Value, VtaError> {
+        let mut payload = json!({
+            "holder": holder,
+            "claims": claims,
+            "validitySeconds": validity_seconds,
+        });
+        if let Some(ct) = credential_type {
+            payload["credentialType"] = Value::String(ct.to_string());
+        }
+        if let Some(p) = purpose {
+            payload["purpose"] = Value::String(p.to_string());
+        }
+        self.dispatch_trust_task(
+            trust_tasks::TASK_VTA_CREDENTIALS_ISSUE_0_1,
+            payload,
+            CREDENTIALS_TT_TIMEOUT,
+        )
+        .await
+    }
+
+    /// `vta/credentials/revoke/0.1` — revoke a previously-issued credential by
+    /// id. `reason`, when present, is recorded in the audit trail + revocation
+    /// tombstone. Requires Admin + a stepped-up (AAL2) session.
+    pub async fn revoke_credential(
+        &self,
+        credential_id: &str,
+        reason: Option<&str>,
+    ) -> Result<Value, VtaError> {
+        let mut payload = json!({ "credentialId": credential_id });
+        if let Some(r) = reason {
+            payload["reason"] = Value::String(r.to_string());
+        }
+        self.dispatch_trust_task(
+            trust_tasks::TASK_VTA_CREDENTIALS_REVOKE_0_1,
+            payload,
+            CREDENTIALS_TT_TIMEOUT,
+        )
+        .await
+    }
+}

--- a/vta-sdk/src/client/mod.rs
+++ b/vta-sdk/src/client/mod.rs
@@ -106,6 +106,7 @@ mod backup_descriptors;
 mod bootstrap;
 mod consent;
 mod contexts;
+mod credentials;
 mod did_templates;
 mod keys;
 mod secrets;

--- a/vta-sdk/src/protocols/credentials_issuance.rs
+++ b/vta-sdk/src/protocols/credentials_issuance.rs
@@ -1,0 +1,67 @@
+//! Wire payloads for the issued-credential lifecycle Trust Tasks
+//! (`spec/vta/credentials/{issue,revoke}/0.1`).
+//!
+//! These mint / revoke a VTA-signed W3C Verifiable Credential addressed to a
+//! holder DID, distinct from the credential-vault slice (`vault/credentials/*`)
+//! which stores credentials the holder already holds. Both request bodies carry
+//! `deny_unknown_fields` as a forward-compat guard; all fields are camelCase on
+//! the wire.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// `spec/vta/credentials/issue/0.1` request body.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct IssueCredentialBody {
+    /// The holder DID the credential is issued to (`credentialSubject.id`).
+    pub holder: String,
+    /// The credential claims merged into `credentialSubject` (must be a
+    /// non-empty JSON object).
+    pub claims: Value,
+    /// Optional extra credential type appended to
+    /// `["VerifiableCredential", …]`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub credential_type: Option<String>,
+    /// Validity window length in seconds from issuance (`validUntil =
+    /// validFrom + validitySeconds`).
+    pub validity_seconds: u64,
+    /// Optional human-readable purpose (audit trail only; not signed into the
+    /// VC).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub purpose: Option<String>,
+}
+
+/// `spec/vta/credentials/issue/0.1` response body.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IssueCredentialResponse {
+    /// The issued credential's id (also the store key).
+    pub credential_id: String,
+    /// The full signed W3C Verifiable Credential (with its Data-Integrity
+    /// proof).
+    pub credential: Value,
+    /// RFC 3339 expiry (`validUntil`).
+    pub expires_at: String,
+}
+
+/// `spec/vta/credentials/revoke/0.1` request body.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct RevokeCredentialBody {
+    /// The id of the credential to revoke (from the issue response).
+    pub credential_id: String,
+    /// Optional reason (recorded in the audit trail + revocation tombstone).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+/// `spec/vta/credentials/revoke/0.1` response body.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RevokeCredentialResponse {
+    /// The revoked credential's id.
+    pub credential_id: String,
+    /// RFC 3339 timestamp at which the credential was revoked.
+    pub revoked_at: String,
+}

--- a/vta-sdk/src/protocols/mod.rs
+++ b/vta-sdk/src/protocols/mod.rs
@@ -5,6 +5,9 @@ pub mod auth;
 pub mod backup_management;
 pub mod context_management;
 pub mod credential_exchange;
+/// Issued-credential lifecycle (`spec/vta/credentials/{issue,revoke}/0.1`) —
+/// mint + revoke a VTA-signed W3C VC addressed to a holder DID.
+pub mod credentials_issuance;
 pub mod did_management;
 pub mod did_template_management;
 pub mod discovery;

--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -522,6 +522,23 @@ pub const TASK_VAULT_CREDENTIALS_RESTORE_0_1: &str =
 pub const TASK_VAULT_CREDENTIALS_PURGE_0_1: &str =
     "https://trusttasks.org/spec/vault/credentials/purge/0.1";
 
+// Issued-credential lifecycle (canonical `spec/vta/credentials/*` from the
+// merged `dtgwg-trust-tasks-tf` registry). Distinct from the credential-vault
+// slice above (which stores credentials the holder *holds*): these MINT a new
+// VTA-signed W3C VC to a holder DID and revoke it by id. Both are
+// dispatcher-routed and gated by operator step-up (AAL2) + an admin capability
+// check. See `vta-service::trust_tasks::credentials`.
+
+/// `spec/vta/credentials/issue/0.1` — issue a scoped, time-boxed Verifiable
+/// Credential to a holder DID. Auth: Admin + operator step-up (AAL2).
+pub const TASK_VTA_CREDENTIALS_ISSUE_0_1: &str =
+    "https://trusttasks.org/spec/vta/credentials/issue/0.1";
+
+/// `spec/vta/credentials/revoke/0.1` — revoke a previously-issued credential by
+/// id. Auth: Admin + operator step-up (AAL2).
+pub const TASK_VTA_CREDENTIALS_REVOKE_0_1: &str =
+    "https://trusttasks.org/spec/vta/credentials/revoke/0.1";
+
 // ─── DID-management slice (spec/did-management/*) ────────────────────────
 //
 // Canonical Trust Tasks for DID + domain + server + registry management
@@ -1276,6 +1293,9 @@ pub const ALL_URIS: &[&str] = &[
     TASK_CONSENT_LIST_1_0,
     TASK_CONSENT_APPROVER_SET_1_0,
     TASK_CONSENT_APPROVER_LIST_1_0,
+    // Issued-credential lifecycle (spec/vta/credentials/*)
+    TASK_VTA_CREDENTIALS_ISSUE_0_1,
+    TASK_VTA_CREDENTIALS_REVOKE_0_1,
 ];
 
 /// The subset of [`ALL_URIS`] served by **dedicated REST routes** rather than

--- a/vta-service/src/keyspaces.rs
+++ b/vta-service/src/keyspaces.rs
@@ -55,6 +55,11 @@ pub const CONSENT: &str = "consent";
 /// Per-(platform, context) approver bindings — who decides consent and how the
 /// prompt routes (`vti_common::consent::ApproverBinding`).
 pub const CONSENT_APPROVERS: &str = "consent_approvers";
+/// VTA-issued credentials (minted by `vta/credentials/issue/0.1`, revoked by
+/// `vta/credentials/revoke/0.1`). One record per credential keyed `cred:<id>`;
+/// revocation is a tombstone (`revokedAt` set in place), not a delete. Distinct
+/// from [`VAULT`] (which stores credentials the holder *holds*).
+pub const ISSUED_CREDENTIALS: &str = "issued_credentials";
 
 /// Every production keyspace. Partitioned by [`BACKED_UP`] +
 /// [`EXCLUDED_FROM_BACKUP`]; the [`tests::backup_partition_is_total`] guard
@@ -80,6 +85,7 @@ pub const ALL: &[&str] = &[
     BOOTSTRAP,
     CONSENT,
     CONSENT_APPROVERS,
+    ISSUED_CREDENTIALS,
 ];
 
 /// Keyspaces whose contents a full `export_backup` captures (as typed
@@ -115,6 +121,9 @@ pub const EXCLUDED_FROM_BACKUP: &[&str] = &[
     DRAINS,
     SNAPSHOT,
     BOOTSTRAP,
+    // Durable VTA-issued holder credentials. Like [`VAULT`], a known backup
+    // gap — a backup-fidelity follow-up should move it into [`BACKED_UP`].
+    ISSUED_CREDENTIALS,
 ];
 
 /// Test-only keyspaces (descriptor sweeper tests open isolated keyspaces so a

--- a/vta-service/src/operations/credentials.rs
+++ b/vta-service/src/operations/credentials.rs
@@ -1,0 +1,238 @@
+//! Issued-credential lifecycle (operations layer) — mint a VTA-signed W3C
+//! Verifiable Credential to a holder DID and revoke it by id.
+//!
+//! Backs the `vta/credentials/{issue,revoke}/0.1` Trust Tasks
+//! (`crate::trust_tasks::credentials`). The transport/auth ceremony (step-up
+//! gate, capability check, audit) stays in the trust-task handler; this module
+//! owns the privileged minting + the issued-credentials store.
+//!
+//! ## Issuer key
+//!
+//! The VTA issues as its own DID. The issuer signing key is `{vta_did}#key-0`
+//! — the same VC-issuance key the provision-integration flow uses
+//! (`operations::provision_integration::vta_keys::load_vta_vc_issuance_secret`).
+//! It's loaded via [`crate::operations::keys::get_key_secret_internal`] under an
+//! [`InternalAuthority`] (route handlers can't construct one, so the elevation
+//! is reachable only from the operations layer), then the VC is signed with a
+//! `eddsa-jcs-2022` Data-Integrity proof (`proofPurpose = "assertionMethod"`),
+//! mirroring `vault::consent::sign_with` and
+//! `provision_integration::credential::issue_vta_authorization_credential`.
+
+use affinidi_data_integrity::{DataIntegrityProof, SignOptions, crypto_suites::CryptoSuite};
+use affinidi_secrets_resolver::secrets::Secret;
+use chrono::{DateTime, Duration, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+use crate::error::AppError;
+use crate::operations::internal_authority::InternalAuthority;
+use crate::server::AppState;
+use crate::store::KeyspaceHandle;
+use vta_sdk::did_key::decode_private_key_multibase;
+
+/// VC Data Model 2.0 base context — every issued VC carries this.
+const VC_V2_CONTEXT: &str = "https://www.w3.org/ns/credentials/v2";
+
+/// Storage-key prefix for an issued-credential record (`cred:<id>`).
+fn store_key(id: &str) -> String {
+    format!("cred:{id}")
+}
+
+/// A persisted issued-credential record. The signed VC itself is stored
+/// verbatim under `credential`; revocation sets `revoked_at` (+ optional
+/// `reason`) in place rather than deleting (tombstone — the audit/verifier
+/// trail must survive revocation).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IssuedCredentialRecord {
+    pub id: String,
+    pub holder: String,
+    /// The full signed W3C VC (with its Data-Integrity proof).
+    pub credential: Value,
+    pub issued_at: String,
+    pub expires_at: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub revoked_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub revocation_reason: Option<String>,
+}
+
+impl IssuedCredentialRecord {
+    fn is_revoked(&self) -> bool {
+        self.revoked_at.is_some()
+    }
+}
+
+/// Parameters for [`issue_credential`].
+pub struct IssueParams<'a> {
+    pub holder: &'a str,
+    /// The claims merged into `credentialSubject` (must be a non-empty object).
+    pub claims: &'a Value,
+    /// Optional extra type appended after `VerifiableCredential`.
+    pub credential_type: Option<&'a str>,
+    pub validity_seconds: u64,
+}
+
+/// Mint, sign, and store a scoped, time-boxed VC for `params.holder`.
+///
+/// Returns the stored record (its `id`, the signed `credential`, and
+/// `expires_at`). The caller (the trust-task handler) is responsible for the
+/// step-up gate, the capability check, and the audit record.
+pub async fn issue_credential(
+    state: &AppState,
+    params: IssueParams<'_>,
+) -> Result<IssuedCredentialRecord, AppError> {
+    // Validate claims up front: a VC with no subject claims is almost certainly
+    // an operator error, and `deny_unknown_fields` already rejected typos.
+    let claims_obj = params
+        .claims
+        .as_object()
+        .ok_or_else(|| AppError::Validation("claims must be a JSON object".to_string()))?;
+    if claims_obj.is_empty() {
+        return Err(AppError::Validation(
+            "claims must be a non-empty object".to_string(),
+        ));
+    }
+    if params.validity_seconds == 0 {
+        return Err(AppError::Validation(
+            "validitySeconds must be greater than zero".to_string(),
+        ));
+    }
+
+    let vta_did =
+        state.config.read().await.vta_did.clone().ok_or_else(|| {
+            AppError::Internal("VTA DID not configured; cannot issue".to_string())
+        })?;
+
+    let issuer_secret = load_vta_issuer_secret(state, &vta_did).await?;
+
+    let now = Utc::now();
+    let expires = now + Duration::seconds(params.validity_seconds as i64);
+    let id = format!("urn:uuid:{}", uuid::Uuid::new_v4());
+
+    // Build the unsigned VC. `credentialSubject` = the caller's claims with
+    // `id` set to the holder DID (an explicit `id` in claims is overridden — the
+    // subject is whoever the credential is issued to).
+    let mut subject = claims_obj.clone();
+    subject.insert("id".to_string(), Value::String(params.holder.to_string()));
+
+    let mut types = vec![Value::String("VerifiableCredential".to_string())];
+    if let Some(ct) = params.credential_type {
+        types.push(Value::String(ct.to_string()));
+    }
+
+    let mut vc = json!({
+        "@context": [VC_V2_CONTEXT],
+        "id": id,
+        "type": types,
+        "issuer": vta_did,
+        "validFrom": rfc3339(now),
+        "validUntil": rfc3339(expires),
+        "credentialSubject": Value::Object(subject),
+    });
+
+    // Sign with the VTA issuer key (eddsa-jcs-2022, assertionMethod) — same
+    // suite/purpose as `vault::consent` and the provision-integration issuer.
+    let proof = DataIntegrityProof::sign(
+        &vc,
+        &issuer_secret,
+        SignOptions::new()
+            .with_proof_purpose("assertionMethod")
+            .with_cryptosuite(CryptoSuite::EddsaJcs2022),
+    )
+    .await
+    .map_err(|e| AppError::Internal(format!("sign issued credential: {e}")))?;
+    vc.as_object_mut().expect("vc is an object").insert(
+        "proof".to_string(),
+        serde_json::to_value(&proof)
+            .map_err(|e| AppError::Internal(format!("serialize issued-credential proof: {e}")))?,
+    );
+
+    let record = IssuedCredentialRecord {
+        id: id.clone(),
+        holder: params.holder.to_string(),
+        credential: vc,
+        issued_at: rfc3339(now),
+        expires_at: rfc3339(expires),
+        revoked_at: None,
+        revocation_reason: None,
+    };
+
+    store_put(&state.issued_credentials_ks, &record).await?;
+    Ok(record)
+}
+
+/// Revoke a previously-issued credential by id.
+///
+/// - `not_found` if no record exists for `id`.
+/// - `already_revoked` (a [`AppError::Conflict`]) if it already carries a
+///   `revoked_at`.
+///
+/// On success the record's `revoked_at` (+ optional `reason`) is set in place
+/// and the revocation timestamp is returned.
+pub async fn revoke_credential(
+    state: &AppState,
+    credential_id: &str,
+    reason: Option<&str>,
+) -> Result<String, AppError> {
+    let mut record = store_get(&state.issued_credentials_ks, credential_id)
+        .await?
+        .ok_or_else(|| AppError::NotFound(format!("credential {credential_id} not found")))?;
+
+    if record.is_revoked() {
+        return Err(AppError::Conflict(format!(
+            "credential {credential_id} is already revoked"
+        )));
+    }
+
+    let revoked_at = rfc3339(Utc::now());
+    record.revoked_at = Some(revoked_at.clone());
+    record.revocation_reason = reason.map(str::to_string);
+    store_put(&state.issued_credentials_ks, &record).await?;
+    Ok(revoked_at)
+}
+
+/// Load the VTA's `{vta_did}#key-0` VC-issuance key as a signing `Secret`.
+///
+/// Mirrors `provision_integration::vta_keys::load_vta_vc_issuance_secret`: an
+/// [`InternalAuthority`]-gated `get_key_secret_internal`, then reconstruct the
+/// `Secret` from the multibase private key with `id = {vta_did}#key-0` so the
+/// Data-Integrity proof's `verificationMethod` resolves under the VTA DID.
+async fn load_vta_issuer_secret(state: &AppState, vta_did: &str) -> Result<Secret, AppError> {
+    let key_id = format!("{vta_did}#key-0");
+    let authority = InternalAuthority::new("credentials-issue");
+    let resp = crate::operations::keys::get_key_secret_internal(
+        &state.keys_ks,
+        &state.imported_ks,
+        &*state.seed_store,
+        &state.audit_ks,
+        authority,
+        &key_id,
+        "credentials-issue-internal",
+    )
+    .await?;
+    // Validate the multibase decodes to a 32-byte Ed25519 seed before
+    // constructing the Secret (a malformed record would otherwise fail opaquely
+    // at sign time).
+    let _seed: [u8; 32] = decode_private_key_multibase(&resp.private_key_multibase)
+        .map_err(|e| AppError::Internal(format!("decode VTA issuer key {key_id}: {e}")))?;
+    let mut secret = Secret::from_multibase(&resp.private_key_multibase, None)
+        .map_err(|e| AppError::Internal(format!("construct issuer Secret for {key_id}: {e}")))?;
+    secret.id = key_id;
+    Ok(secret)
+}
+
+async fn store_put(ks: &KeyspaceHandle, record: &IssuedCredentialRecord) -> Result<(), AppError> {
+    ks.insert(store_key(&record.id), record).await
+}
+
+async fn store_get(
+    ks: &KeyspaceHandle,
+    id: &str,
+) -> Result<Option<IssuedCredentialRecord>, AppError> {
+    ks.get(store_key(id)).await
+}
+
+/// RFC 3339 with a `Z` suffix (UTC), matching the workspace's VC timestamps.
+fn rfc3339(dt: DateTime<Utc>) -> String {
+    dt.to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+}

--- a/vta-service/src/operations/mod.rs
+++ b/vta-service/src/operations/mod.rs
@@ -7,6 +7,7 @@ pub mod cache;
 pub mod config;
 pub mod contexts;
 pub mod credential_exchange;
+pub mod credentials;
 pub mod device;
 pub mod did_templates;
 #[cfg(feature = "webvh")]

--- a/vta-service/src/operations/step_up.rs
+++ b/vta-service/src/operations/step_up.rs
@@ -28,8 +28,8 @@ use crate::config::AppConfig;
 /// the route module re-exports this in turn for its handlers + extractor).
 pub mod op {
     pub use vti_common::auth::step_up::op_class::{
-        ACL_CHANGE_ROLE, ACL_GRANT, ACL_REVOKE, ACL_SWAP_KEY, CONTEXT_DELETE, KEY_REVOKE,
-        VAULT_PROXY_LOGIN, VAULT_RELEASE, VAULT_SIGN_TRUST_TASK,
+        ACL_CHANGE_ROLE, ACL_GRANT, ACL_REVOKE, ACL_SWAP_KEY, CONTEXT_DELETE, CREDENTIALS_ISSUE,
+        CREDENTIALS_REVOKE, KEY_REVOKE, VAULT_PROXY_LOGIN, VAULT_RELEASE, VAULT_SIGN_TRUST_TASK,
     };
 }
 

--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -120,6 +120,10 @@ pub struct AppState {
     pub consent_ks: KeyspaceHandle,
     /// Per-(platform, context) approver bindings for consent routing.
     pub consent_approvers_ks: KeyspaceHandle,
+    /// VTA-issued credentials minted via `vta/credentials/issue/0.1` and
+    /// revoked via `vta/credentials/revoke/0.1`. Keyed `cred:<id>`; revoke is a
+    /// tombstone (`revokedAt`), not a delete.
+    pub issued_credentials_ks: KeyspaceHandle,
     /// Persisted drain set for the protocol-management feature
     /// (`docs/05-design-notes/didcomm-protocol-management.md`).
     /// Keyed by mediator DID; replayed at boot.
@@ -302,6 +306,8 @@ pub async fn build_app_state(
     let consent_ks = apply_encryption(store.keyspace(crate::keyspaces::CONSENT)?);
     let consent_approvers_ks =
         apply_encryption(store.keyspace(crate::keyspaces::CONSENT_APPROVERS)?);
+    let issued_credentials_ks =
+        apply_encryption(store.keyspace(crate::keyspaces::ISSUED_CREDENTIALS)?);
     #[cfg(feature = "webvh")]
     let drains_ks = apply_encryption(store.keyspace(crate::keyspaces::DRAINS)?);
     #[cfg(feature = "webvh")]
@@ -357,6 +363,7 @@ pub async fn build_app_state(
         passkey_vms_ks,
         consent_ks,
         consent_approvers_ks,
+        issued_credentials_ks,
         #[cfg(feature = "webvh")]
         drains_ks,
         #[cfg(feature = "webvh")]

--- a/vta-service/src/test_support.rs
+++ b/vta-service/src/test_support.rs
@@ -383,6 +383,51 @@ pub async fn bootstrap_test_vta(ts: &TestStore) -> (String, ProvisionIntegration
     (vta_did, deps)
 }
 
+/// Build a full [`crate::server::AppState`] whose VTA signing identity is
+/// provisioned (active seed + `{vta_did}#key-0`), so handlers that **mint**
+/// VTA-signed credentials (e.g. `trust_tasks::credentials::handle_issue`) can
+/// load the issuer key and produce a real Data-Integrity proof.
+///
+/// Returns the `AppState` plus the owning `TempDir` (the caller must keep it
+/// alive — dropping it removes the on-disk fjall store). Uses the canonical
+/// [`build_app_state`](crate::server::build_app_state) constructor so the test
+/// state can't diverge from production wiring.
+pub async fn build_signing_test_app_state() -> (crate::server::AppState, tempfile::TempDir) {
+    use crate::server::{AppStateParts, build_app_state};
+    use tokio::sync::watch;
+
+    init_jwt_provider();
+    let dir = tempfile::tempdir().expect("temp dir");
+    let store = Store::open(&StoreConfig {
+        data_dir: dir.path().to_path_buf(),
+    })
+    .expect("open store");
+
+    // Provision the VTA's `{vta_did}#key-0` VC-issuance key into the keystore
+    // and point the config at the resulting self-resolving did:key.
+    let keys_ks = store.keyspace(crate::keyspaces::KEYS).expect("keys ks");
+    let (vta_did, seed_store) = provision_vta_signing_identity(&keys_ks, dir.path()).await;
+    let seed_store: Arc<dyn crate::keys::seed_store::SeedStore> = seed_store;
+
+    let mut config = test_app_config(dir.path().to_path_buf());
+    config.vta_did = Some(vta_did);
+    config.public_url = Some("https://vta.test".into());
+
+    let (restart_tx, _rx) = watch::channel(false);
+    let state = build_app_state(
+        config,
+        &store,
+        seed_store,
+        None,
+        None,
+        restart_tx,
+        AppStateParts::default(),
+    )
+    .await
+    .expect("build signing app state");
+    (state, dir)
+}
+
 /// The context [`bootstrap_provisionable_test_vta`] registers and the one a
 /// well-formed request should target (`context_hint` + the `context` param).
 pub const PROVISIONABLE_CONTEXT: &str = "provisionable-ctx";
@@ -777,6 +822,9 @@ pub async fn build_test_app_with(opts: TestAppOptions) -> (axum::Router, TestApp
         vault_ks,
         consent_ks: store.keyspace(crate::keyspaces::CONSENT).unwrap(),
         consent_approvers_ks: store.keyspace(crate::keyspaces::CONSENT_APPROVERS).unwrap(),
+        issued_credentials_ks: store
+            .keyspace(crate::keyspaces::ISSUED_CREDENTIALS)
+            .unwrap(),
         service_state_ks,
         sealed_nonces_ks,
         backup_bundles_ks: backup_bundles_ks.clone(),

--- a/vta-service/src/trust_tasks/credentials.rs
+++ b/vta-service/src/trust_tasks/credentials.rs
@@ -1,0 +1,362 @@
+//! Issued-credential lifecycle trust-task slice
+//! (`spec/vta/credentials/{issue,revoke}/0.1`).
+//!
+//! Mints a VTA-signed, scoped, time-boxed W3C Verifiable Credential to a holder
+//! DID and revokes it by id. Distinct from the credential-vault slice
+//! ([`super::cred_vault`]), which stores credentials the holder *holds*; here the
+//! VTA is the issuer and signs the VC with its own `{vta_did}#key-0` key (see
+//! [`crate::operations::credentials`]).
+//!
+//! Both handlers are:
+//! - **Capability-gated** — Admin role required ([`AuthClaims::require_admin`]),
+//!   mirroring the role check the sibling ACL/keys handlers run before their
+//!   step-up gate. Issuing or revoking a credential is a higher-trust action
+//!   than ACL management, so it's Admin-only (not Admin-or-Initiator).
+//! - **Step-up-gated** — operator AAL2 via [`super::step_up::require_step_up`]
+//!   with the `credentials/issue` / `credentials/revoke` op-classes, the exact
+//!   pattern `acl::handle_create` (`op::ACL_GRANT`) uses.
+//! - **Audited** — `credentials.issue` / `credentials.revoke` via
+//!   [`crate::audit::record`].
+
+use serde_json::Value;
+use trust_tasks_rs::TrustTask;
+
+use vta_sdk::protocols::credentials_issuance::{
+    IssueCredentialBody, IssueCredentialResponse, RevokeCredentialBody, RevokeCredentialResponse,
+};
+
+use crate::audit;
+use crate::auth::AuthClaims;
+use crate::operations::credentials::{self, IssueParams};
+use crate::server::AppState;
+
+use super::helpers::{TRANSPORT_TRUST_TASK, app_error_to_reject, parse_payload, success_response};
+
+/// Handler for `spec/vta/credentials/issue/0.1`.
+pub(super) async fn handle_issue(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> super::helpers::TrustTaskOutcome {
+    // 1. Capability gate (before the step-up gate, so a caller lacking the role
+    //    gets a permission error rather than a step-up prompt — same ordering as
+    //    `acl::handle_create`).
+    if let Err(e) = auth.require_admin() {
+        return app_error_to_reject(&doc, e);
+    }
+    // 2. Operator step-up (AAL2) gate.
+    if let Some(resp) =
+        super::step_up::require_step_up(state, auth, super::step_up::op::CREDENTIALS_ISSUE, &doc)
+            .await
+    {
+        return resp;
+    }
+    // 3. Parse the request body.
+    let req: IssueCredentialBody = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+
+    // 4. Mint + store the credential.
+    let record = match credentials::issue_credential(
+        state,
+        IssueParams {
+            holder: &req.holder,
+            claims: &req.claims,
+            credential_type: req.credential_type.as_deref(),
+            validity_seconds: req.validity_seconds,
+        },
+    )
+    .await
+    {
+        Ok(r) => r,
+        Err(e) => return app_error_to_reject(&doc, e),
+    };
+
+    // 5. Audit (`detail` carries the operator-supplied purpose, like the vault
+    //    slice records its `reason`).
+    if let Err(e) = audit::record_with_detail(
+        &state.audit_ks,
+        "credentials.issue",
+        &auth.did,
+        Some(&record.id),
+        "success",
+        Some(TRANSPORT_TRUST_TASK),
+        None,
+        req.purpose.as_deref(),
+    )
+    .await
+    {
+        tracing::warn!(error = %e, "audit record failed for credentials.issue");
+    }
+
+    success_response(
+        &doc,
+        IssueCredentialResponse {
+            credential_id: record.id,
+            credential: record.credential,
+            expires_at: record.expires_at,
+        },
+    )
+}
+
+/// Handler for `spec/vta/credentials/revoke/0.1`.
+pub(super) async fn handle_revoke(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> super::helpers::TrustTaskOutcome {
+    if let Err(e) = auth.require_admin() {
+        return app_error_to_reject(&doc, e);
+    }
+    if let Some(resp) =
+        super::step_up::require_step_up(state, auth, super::step_up::op::CREDENTIALS_REVOKE, &doc)
+            .await
+    {
+        return resp;
+    }
+    let req: RevokeCredentialBody = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+
+    let revoked_at = match credentials::revoke_credential(
+        state,
+        &req.credential_id,
+        req.reason.as_deref(),
+    )
+    .await
+    {
+        Ok(ts) => ts,
+        Err(e) => return app_error_to_reject(&doc, e),
+    };
+
+    if let Err(e) = audit::record_with_detail(
+        &state.audit_ks,
+        "credentials.revoke",
+        &auth.did,
+        Some(&req.credential_id),
+        "success",
+        Some(TRANSPORT_TRUST_TASK),
+        None,
+        req.reason.as_deref(),
+    )
+    .await
+    {
+        tracing::warn!(error = %e, "audit record failed for credentials.revoke");
+    }
+
+    success_response(
+        &doc,
+        RevokeCredentialResponse {
+            credential_id: req.credential_id,
+            revoked_at,
+        },
+    )
+}
+
+#[cfg(any(test, feature = "test-support"))]
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::acl::Role;
+    use crate::test_support::{build_signing_test_app_state, super_admin_claims};
+    use serde_json::json;
+    use trust_tasks_rs::TypeUri;
+    use vta_sdk::trust_tasks::{TASK_VTA_CREDENTIALS_ISSUE_0_1, TASK_VTA_CREDENTIALS_REVOKE_0_1};
+
+    /// AAL2 (stepped-up) admin — passes both the capability + step-up gates.
+    fn stepped_up_admin() -> AuthClaims {
+        AuthClaims {
+            acr: "aal2".to_string(),
+            ..super_admin_claims()
+        }
+    }
+
+    /// Build an `issue` trust-task document for the given payload.
+    fn issue_doc(payload: Value) -> TrustTask<Value> {
+        let uri: TypeUri = TASK_VTA_CREDENTIALS_ISSUE_0_1.parse().expect("issue uri");
+        TrustTask::new(format!("urn:uuid:{}", uuid::Uuid::new_v4()), uri, payload)
+    }
+
+    fn revoke_doc(payload: Value) -> TrustTask<Value> {
+        let uri: TypeUri = TASK_VTA_CREDENTIALS_REVOKE_0_1.parse().expect("revoke uri");
+        TrustTask::new(format!("urn:uuid:{}", uuid::Uuid::new_v4()), uri, payload)
+    }
+
+    /// Extract the `payload` object of a success response document.
+    fn response_payload(out: &super::super::helpers::TrustTaskOutcome) -> Value {
+        let doc: Value = serde_json::from_slice(&out.body).expect("response is JSON");
+        doc.get("payload").cloned().unwrap_or(Value::Null)
+    }
+
+    /// Configure a `credentials/issue` step-up floor (self-approve, AAL2) on the
+    /// state's policy so an AAL1 session is gated. Without an operator floor the
+    /// gate is a no-op (step-up is opt-in, mirroring the ACL/keys handlers).
+    async fn require_issue_step_up(state: &AppState) {
+        use vti_common::auth::step_up::{StepUpFloor, StepUpMode};
+        let mut cfg = state.config.write().await;
+        cfg.auth.step_up.enabled = true;
+        cfg.auth.step_up.floors.push(StepUpFloor {
+            operation: super::super::step_up::op::CREDENTIALS_ISSUE.to_string(),
+            mode: StepUpMode::SelfApprove,
+            allow_aal1_if_non_escalating: false,
+        });
+    }
+
+    #[tokio::test]
+    async fn issue_without_step_up_is_rejected() {
+        let (state, _dir) = build_signing_test_app_state().await;
+        require_issue_step_up(&state).await;
+        // AAL1 admin (acr empty) — capability passes, step-up gate must fire.
+        let auth = super_admin_claims();
+        let doc = issue_doc(json!({
+            "holder": "did:key:zHolder",
+            "claims": { "role": "member" },
+            "validitySeconds": 3600u64,
+        }));
+        let out = handle_issue(&state, &auth, doc).await;
+        assert!(
+            !out.status.is_success(),
+            "issue at AAL1 must be rejected by the step-up gate, got {}",
+            out.status
+        );
+        let body = String::from_utf8_lossy(&out.body);
+        assert!(
+            body.contains("step_up_required"),
+            "rejection should carry the step-up code, got: {body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn issue_non_admin_is_rejected() {
+        let (state, _dir) = build_signing_test_app_state().await;
+        let auth = AuthClaims {
+            role: Role::Reader,
+            acr: "aal2".to_string(),
+            ..super_admin_claims()
+        };
+        let doc = issue_doc(json!({
+            "holder": "did:key:zHolder",
+            "claims": { "role": "member" },
+            "validitySeconds": 3600u64,
+        }));
+        let out = handle_issue(&state, &auth, doc).await;
+        assert!(
+            !out.status.is_success(),
+            "non-admin issue must be rejected by the capability gate"
+        );
+    }
+
+    #[tokio::test]
+    async fn issue_with_step_up_succeeds_and_binds_holder() {
+        let (state, _dir) = build_signing_test_app_state().await;
+        let holder = "did:key:zHolderBindMe";
+        let doc = issue_doc(json!({
+            "holder": holder,
+            "claims": { "role": "member", "level": 2 },
+            "credentialType": "MembershipCredential",
+            "validitySeconds": 3600u64,
+            "purpose": "tier-2 access",
+        }));
+        let out = handle_issue(&state, &stepped_up_admin(), doc).await;
+        assert!(out.status.is_success(), "stepped-up issue should succeed");
+        let payload = response_payload(&out);
+        let cred_id = payload
+            .get("credentialId")
+            .and_then(Value::as_str)
+            .expect("credentialId present");
+        assert!(
+            cred_id.starts_with("urn:uuid:"),
+            "id is a urn:uuid: {cred_id}"
+        );
+        let credential = payload.get("credential").expect("credential present");
+        // The signed VC binds the holder as the subject.
+        assert_eq!(
+            credential
+                .get("credentialSubject")
+                .and_then(|s| s.get("id"))
+                .and_then(Value::as_str),
+            Some(holder),
+            "credentialSubject.id must equal the holder DID"
+        );
+        // And it carries a Data-Integrity proof + the extra type.
+        assert!(credential.get("proof").is_some(), "VC has a proof");
+        let types: Vec<&str> = credential
+            .get("type")
+            .and_then(Value::as_array)
+            .map(|a| a.iter().filter_map(Value::as_str).collect())
+            .unwrap_or_default();
+        assert!(types.contains(&"VerifiableCredential"));
+        assert!(types.contains(&"MembershipCredential"));
+    }
+
+    #[tokio::test]
+    async fn revoke_known_id_succeeds_then_double_revoke_conflicts() {
+        let (state, _dir) = build_signing_test_app_state().await;
+        // Issue first.
+        let issue_out = handle_issue(
+            &state,
+            &stepped_up_admin(),
+            issue_doc(json!({
+                "holder": "did:key:zHolder",
+                "claims": { "role": "member" },
+                "validitySeconds": 3600u64,
+            })),
+        )
+        .await;
+        assert!(issue_out.status.is_success());
+        let cred_id = response_payload(&issue_out)
+            .get("credentialId")
+            .and_then(Value::as_str)
+            .expect("credentialId")
+            .to_string();
+
+        // Revoke it.
+        let revoke_out = handle_revoke(
+            &state,
+            &stepped_up_admin(),
+            revoke_doc(json!({ "credentialId": cred_id, "reason": "policy change" })),
+        )
+        .await;
+        assert!(
+            revoke_out.status.is_success(),
+            "first revoke should succeed"
+        );
+        assert!(
+            response_payload(&revoke_out).get("revokedAt").is_some(),
+            "revoke response carries revokedAt"
+        );
+
+        // Revoke again → already_revoked (Conflict).
+        let again = handle_revoke(
+            &state,
+            &stepped_up_admin(),
+            revoke_doc(json!({ "credentialId": cred_id })),
+        )
+        .await;
+        assert!(!again.status.is_success(), "double revoke must be rejected");
+        let body = String::from_utf8_lossy(&again.body);
+        assert!(
+            body.contains("already revoked"),
+            "second revoke should report already-revoked, got: {body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn revoke_unknown_id_is_not_found() {
+        let (state, _dir) = build_signing_test_app_state().await;
+        let out = handle_revoke(
+            &state,
+            &stepped_up_admin(),
+            revoke_doc(json!({ "credentialId": "urn:uuid:does-not-exist" })),
+        )
+        .await;
+        assert!(!out.status.is_success(), "unknown id must be rejected");
+        let body = String::from_utf8_lossy(&out.body);
+        assert!(
+            body.contains("not found"),
+            "unknown id should report not-found, got: {body}"
+        );
+    }
+}

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -53,6 +53,7 @@ mod consent;
 mod contexts;
 mod cred_vault;
 mod credential_exchange;
+mod credentials;
 mod device;
 mod did_templates;
 mod discovery;
@@ -563,6 +564,10 @@ dispatch_table! {
     vta_sdk::trust_tasks::TASK_VAULT_CREDENTIALS_DELETE_0_1 => cred_vault::handle_delete,
     vta_sdk::trust_tasks::TASK_VAULT_CREDENTIALS_RESTORE_0_1 => cred_vault::handle_restore,
     vta_sdk::trust_tasks::TASK_VAULT_CREDENTIALS_PURGE_0_1 => cred_vault::handle_purge,
+    // ─── Issued-credential lifecycle (spec/vta/credentials/*) ────
+    // Mint + revoke VTA-signed VCs; Admin-gated + operator step-up (AAL2).
+    vta_sdk::trust_tasks::TASK_VTA_CREDENTIALS_ISSUE_0_1 => credentials::handle_issue,
+    vta_sdk::trust_tasks::TASK_VTA_CREDENTIALS_REVOKE_0_1 => credentials::handle_revoke,
     // ─── Config slice ────────────────────────────────────────────
     vta_sdk::trust_tasks::TASK_CONFIG_GET_1_0 => config::handle_get,
     vta_sdk::trust_tasks::TASK_CONFIG_UPDATE_1_0 => config::handle_update,

--- a/vti-common/src/auth/step_up.rs
+++ b/vti-common/src/auth/step_up.rs
@@ -83,6 +83,12 @@ pub mod op_class {
     /// Sign a Trust Task envelope as a vault entry's principal DID
     /// (`vault/sign-trust-task/0.1`).
     pub const VAULT_SIGN_TRUST_TASK: &str = "vault/sign-trust-task";
+    /// Mint a new VTA-signed Verifiable Credential for a holder
+    /// (`vta/credentials/issue/0.1`).
+    pub const CREDENTIALS_ISSUE: &str = "credentials/issue";
+    /// Revoke a previously-issued VTA credential
+    /// (`vta/credentials/revoke/0.1`).
+    pub const CREDENTIALS_REVOKE: &str = "credentials/revoke";
 
     /// Every recognized operation-class (excludes the `*` catch-all).
     pub const ALL: &[&str] = &[
@@ -95,6 +101,8 @@ pub mod op_class {
         VAULT_RELEASE,
         VAULT_PROXY_LOGIN,
         VAULT_SIGN_TRUST_TASK,
+        CREDENTIALS_ISSUE,
+        CREDENTIALS_REVOKE,
     ];
 
     /// Whether `operation` is a floor target the maintainer recognizes: a known


### PR DESCRIPTION
## What

Implements the two `vta/credentials/*` Trust Tasks (spec merged in trustoverip/dtgwg-trust-tasks-tf#100):

- **`vta/credentials/issue/0.1`** — the VTA mints a **scoped, time-boxed W3C Verifiable Credential** to a holder DID with arbitrary `claims`, signed by its own `{vta_did}#key-0` (eddsa-jcs-2022). Gated by **Admin role + operator step-up (AAL2)**.
- **`vta/credentials/revoke/0.1`** — revoke an issued credential by id (tombstone with `revokedAt`; `not_found` / `already_revoked`).

This is the VTA-side primitive that was missing for **operator-approved, scope-limited, time-boxed, revocable cross-context sharing** — distinct from `provision/integration` (bootstrap-only, fixed admin credential) and the credential *vault* (which stores credentials a holder *holds*).

## How

- **vta-sdk**: `TASK_VTA_CREDENTIALS_{ISSUE,REVOKE}_0_1` + `ALL_URIS`; new `protocols::credentials_issuance` payloads (`camelCase`, `deny_unknown_fields` on requests); `VtaClient::{issue_credential, revoke_credential}` via `dispatch_trust_task`.
- **vta-service**: `trust_tasks::credentials` handlers — capability gate (`require_admin`) then step-up gate (`require_step_up`, op-classes `credentials/{issue,revoke}`), mirroring `acl::handle_create`; audited (`credentials.issue` / `.revoke`). `operations::credentials` mints via the same VC-issuance key the provision-integration flow uses, and keeps an `ISSUED_CREDENTIALS` store (`cred:<id>`, revoke = in-place tombstone). New keyspace wired through the single `build_app_state`.
- **vti-common**: `credentials/{issue,revoke}` step-up op-classes (recognised policy-floor targets).

Step-up is opt-in per the operator's policy floor (no floor → `Allow`, like every existing gated op).

## Tests

New handler tests: issue-without-step-up → rejected; non-admin → rejected; issue-with-step-up → success binding `credentialSubject.id == holder` + signed; revoke known → ok, double-revoke → conflict, unknown → not_found. The dispatcher-parity test (`dispatcher_handles_every_vta_sdk_uri`) and keyspace backup-census (`backup_partition_is_total`) pass. Full `vta-service` lib suite green; `cargo fmt` + `clippy` clean.

## Notes

- The merged spec has **no `contextId`** on the request bodies, so issuance is at the VTA level (Admin-gated) and the op-class slugs carry no context segment — matched the spec exactly.
- `ISSUED_CREDENTIALS` is in `EXCLUDED_FROM_BACKUP` (a known gap flagged like `VAULT`) to avoid expanding backup serialization here.
- Consumed by an external project (Affinidi Concierge) to drive operator-approved cross-domain shares; the spec is trustoverip/dtgwg-trust-tasks-tf#100.
