### PR TITLE
feat(vta/memory): per-context KV store for agent memory

### DIFF
--- a/vta-sdk/src/client/memory.rs
+++ b/vta-sdk/src/client/memory.rs
@@ -1,0 +1,66 @@
+//! Agent-memory Trust Task client methods
+//! (`spec/vta/memory/{put,list,delete}/0.1`).
+//!
+//! Drives the memory slice through the generic trust-task dispatcher
+//! ([`VtaClient::dispatch_trust_task`]) — there is no dedicated REST route. All
+//! three operations are gated server-side on **context access**: the caller
+//! must be permitted to act in `context_id`.
+
+use serde_json::{Value, json};
+
+use super::VtaClient;
+use crate::error::VtaError;
+use crate::trust_tasks;
+
+/// Round-trip timeout (seconds) for agent-memory trust tasks.
+const MEMORY_TT_TIMEOUT: u64 = 30;
+
+impl VtaClient {
+    /// `vta/memory/put/0.1` — upsert `value` under `(context_id, key)`. Requires
+    /// access to `context_id`.
+    pub async fn memory_put(
+        &self,
+        context_id: &str,
+        key: &str,
+        value: &str,
+    ) -> Result<Value, VtaError> {
+        let payload = json!({
+            "contextId": context_id,
+            "key": key,
+            "value": value,
+        });
+        self.dispatch_trust_task(
+            trust_tasks::TASK_VTA_MEMORY_PUT_0_1,
+            payload,
+            MEMORY_TT_TIMEOUT,
+        )
+        .await
+    }
+
+    /// `vta/memory/list/0.1` — list every entry in `context_id`. Requires access
+    /// to `context_id`.
+    pub async fn memory_list(&self, context_id: &str) -> Result<Value, VtaError> {
+        let payload = json!({ "contextId": context_id });
+        self.dispatch_trust_task(
+            trust_tasks::TASK_VTA_MEMORY_LIST_0_1,
+            payload,
+            MEMORY_TT_TIMEOUT,
+        )
+        .await
+    }
+
+    /// `vta/memory/delete/0.1` — remove the entry at `key` in `context_id`
+    /// (`not_found` if absent). Requires access to `context_id`.
+    pub async fn memory_delete(&self, context_id: &str, key: &str) -> Result<Value, VtaError> {
+        let payload = json!({
+            "contextId": context_id,
+            "key": key,
+        });
+        self.dispatch_trust_task(
+            trust_tasks::TASK_VTA_MEMORY_DELETE_0_1,
+            payload,
+            MEMORY_TT_TIMEOUT,
+        )
+        .await
+    }
+}

--- a/vta-sdk/src/client/mod.rs
+++ b/vta-sdk/src/client/mod.rs
@@ -109,6 +109,7 @@ mod contexts;
 mod credentials;
 mod did_templates;
 mod keys;
+mod memory;
 mod secrets;
 mod vault;
 mod vta_management;

--- a/vta-sdk/src/protocols/memory.rs
+++ b/vta-sdk/src/protocols/memory.rs
@@ -1,0 +1,82 @@
+//! Wire payloads for the agent-memory Trust Tasks
+//! (`spec/vta/memory/{put,list,delete}/0.1`).
+//!
+//! A per-context key/value store for AI-agent memory: `put` upserts a value
+//! under a `(contextId, key)` pair, `list` enumerates every entry in a context,
+//! and `delete` removes one by key. The three request bodies carry
+//! `deny_unknown_fields` as a forward-compat guard; all fields are camelCase on
+//! the wire.
+//!
+//! Access is gated on **context** (not operator step-up like the issued-
+//! credential slice): the caller must be permitted to act in `contextId` — the
+//! same context-ACL check the context-scoped key tasks use
+//! ([`AuthClaims::require_context`] server-side). This enforces per-domain
+//! memory isolation: a context-A agent cannot read, write, or delete context-B
+//! memory.
+
+use serde::{Deserialize, Serialize};
+
+/// `spec/vta/memory/put/0.1` request body. Upsert: re-putting the same
+/// `(contextId, key)` replaces the stored value.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct MemoryPutBody {
+    /// The context the entry belongs to. The caller must have ACL access to it.
+    pub context_id: String,
+    /// The entry key (unique within the context).
+    pub key: String,
+    /// The value to store.
+    pub value: String,
+}
+
+/// `spec/vta/memory/put/0.1` response body.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MemoryPutResponse {
+    /// The key that was upserted.
+    pub key: String,
+}
+
+/// `spec/vta/memory/list/0.1` request body.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct MemoryListBody {
+    /// The context whose entries to list. The caller must have ACL access to it.
+    pub context_id: String,
+}
+
+/// A single stored memory entry returned by `spec/vta/memory/list/0.1`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MemoryItem {
+    /// The entry key.
+    pub key: String,
+    /// The stored value.
+    pub value: String,
+}
+
+/// `spec/vta/memory/list/0.1` response body.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MemoryListResponse {
+    /// Every entry in the context, in ascending key order.
+    pub items: Vec<MemoryItem>,
+}
+
+/// `spec/vta/memory/delete/0.1` request body.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct MemoryDeleteBody {
+    /// The context the entry belongs to. The caller must have ACL access to it.
+    pub context_id: String,
+    /// The entry key to delete. `not_found` if absent.
+    pub key: String,
+}
+
+/// `spec/vta/memory/delete/0.1` response body.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MemoryDeleteResponse {
+    /// The key that was deleted.
+    pub key: String,
+}

--- a/vta-sdk/src/protocols/mod.rs
+++ b/vta-sdk/src/protocols/mod.rs
@@ -17,6 +17,9 @@ pub mod key_management;
 /// Member-side membership-credential exchange (`members/*`) — the member → VTC
 /// reciprocal VMC and the VTC's request for it.
 pub mod members;
+/// Per-context key/value store for AI-agent memory
+/// (`spec/vta/memory/{put,list,delete}/0.1`).
+pub mod memory;
 /// Passkey-based login flow (`vta/auth/passkey-login-{start,finish}/1.0`).
 pub mod passkey_login;
 pub mod protocol_management;

--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -539,6 +539,30 @@ pub const TASK_VTA_CREDENTIALS_ISSUE_0_1: &str =
 pub const TASK_VTA_CREDENTIALS_REVOKE_0_1: &str =
     "https://trusttasks.org/spec/vta/credentials/revoke/0.1";
 
+// ─── Agent-memory slice (spec/vta/memory/*) ──────────────────────────────
+//
+// A per-context key/value store for AI-agent memory. Dispatcher-routed like
+// the issued-credential slice above, but gated on **context access** (the
+// caller must be permitted to act in `payload.contextId`, the same
+// `require_context` ACL check the context-scoped key tasks use) rather than
+// operator step-up. The context gate enforces per-domain memory isolation: a
+// context-A agent cannot touch context-B memory. See
+// `vta-service::trust_tasks::memory`.
+
+/// `spec/vta/memory/put/0.1` — upsert a value under a `(contextId, key)` pair.
+/// Auth: context access (`require_context(contextId)`). Payload:
+/// [`crate::protocols::memory::MemoryPutBody`].
+pub const TASK_VTA_MEMORY_PUT_0_1: &str = "https://trusttasks.org/spec/vta/memory/put/0.1";
+
+/// `spec/vta/memory/list/0.1` — list every entry in a context. Auth: context
+/// access. Payload: [`crate::protocols::memory::MemoryListBody`].
+pub const TASK_VTA_MEMORY_LIST_0_1: &str = "https://trusttasks.org/spec/vta/memory/list/0.1";
+
+/// `spec/vta/memory/delete/0.1` — remove one entry by key (`not_found` if
+/// absent). Auth: context access. Payload:
+/// [`crate::protocols::memory::MemoryDeleteBody`].
+pub const TASK_VTA_MEMORY_DELETE_0_1: &str = "https://trusttasks.org/spec/vta/memory/delete/0.1";
+
 // ─── DID-management slice (spec/did-management/*) ────────────────────────
 //
 // Canonical Trust Tasks for DID + domain + server + registry management
@@ -1296,6 +1320,10 @@ pub const ALL_URIS: &[&str] = &[
     // Issued-credential lifecycle (spec/vta/credentials/*)
     TASK_VTA_CREDENTIALS_ISSUE_0_1,
     TASK_VTA_CREDENTIALS_REVOKE_0_1,
+    // Agent-memory slice (spec/vta/memory/*)
+    TASK_VTA_MEMORY_PUT_0_1,
+    TASK_VTA_MEMORY_LIST_0_1,
+    TASK_VTA_MEMORY_DELETE_0_1,
 ];
 
 /// The subset of [`ALL_URIS`] served by **dedicated REST routes** rather than

--- a/vta-service/src/keyspaces.rs
+++ b/vta-service/src/keyspaces.rs
@@ -61,6 +61,12 @@ pub const CONSENT_APPROVERS: &str = "consent_approvers";
 /// from [`VAULT`] (which stores credentials the holder *holds*).
 pub const ISSUED_CREDENTIALS: &str = "issued_credentials";
 
+/// Per-context key/value store for AI-agent memory (`vta/memory/{put,list,
+/// delete}/0.1`). One record per `(contextId, key)` pair, keyed
+/// `mem:<contextId>:<key>`; `list` is a `mem:<contextId>:` prefix scan. Durable
+/// user data → in [`BACKED_UP`].
+pub const MEMORY: &str = "memory";
+
 /// Every production keyspace. Partitioned by [`BACKED_UP`] +
 /// [`EXCLUDED_FROM_BACKUP`]; the [`tests::backup_partition_is_total`] guard
 /// asserts the partition stays exhaustive so a newly-added keyspace can't be
@@ -86,6 +92,7 @@ pub const ALL: &[&str] = &[
     CONSENT,
     CONSENT_APPROVERS,
     ISSUED_CREDENTIALS,
+    MEMORY,
 ];
 
 /// Keyspaces whose contents a full `export_backup` captures (as typed
@@ -99,6 +106,8 @@ pub const BACKED_UP: &[&str] = &[
     WEBVH,
     CONSENT,
     CONSENT_APPROVERS,
+    // Durable agent memory is user data and must survive a restore.
+    MEMORY,
 ];
 
 /// Keyspaces deliberately **not** in a backup.

--- a/vta-service/src/operations/memory.rs
+++ b/vta-service/src/operations/memory.rs
@@ -1,0 +1,175 @@
+//! Agent-memory store (operations layer) — a per-context key/value store for
+//! AI-agent memory.
+//!
+//! Backs the `vta/memory/{put,list,delete}/0.1` Trust Tasks
+//! (`crate::trust_tasks::memory`). The transport/auth ceremony (the context-ACL
+//! gate, audit) stays in the trust-task handler; this module owns the store
+//! operations.
+//!
+//! ## Layout
+//!
+//! Entries live in the [`MEMORY`](crate::keyspaces::MEMORY) keyspace, one record
+//! per `(contextId, key)` pair, stored under the key
+//! `mem:<contextId>:<key>`. The stored value is a small JSON `MemoryRecord`
+//! `{ key, value }` carrying the entry key verbatim, so `list` can return the
+//! original key without having to parse it back out of the (delimiter-bearing)
+//! storage key.
+//!
+//! - [`put`] upserts (a second `put` of the same `(contextId, key)` overwrites).
+//! - [`list`] is a `mem:<contextId>:` prefix scan, returning every entry in the
+//!   context. Because the prefix includes the trailing `:`, a `list` of context
+//!   `a` never returns context `b`'s entries (per-domain isolation in the store
+//!   layer, on top of the context-ACL gate in the handler).
+//! - [`delete`] removes one entry, returning [`AppError::NotFound`] when the key
+//!   is absent.
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::AppError;
+use crate::store::KeyspaceHandle;
+use vta_sdk::protocols::memory::MemoryItem;
+
+/// The stored value for one memory entry. The `key` is held verbatim so `list`
+/// can reconstruct the original entry key without parsing the storage key
+/// (context ids and entry keys may both contain the `:` delimiter).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct MemoryRecord {
+    key: String,
+    value: String,
+}
+
+/// Storage key for one `(context_id, key)` entry: `mem:<context_id>:<key>`.
+fn store_key(context_id: &str, key: &str) -> String {
+    format!("mem:{context_id}:{key}")
+}
+
+/// Storage-key prefix for every entry in `context_id`: `mem:<context_id>:`.
+/// The trailing `:` makes the scan context-exact (a prefix of `a:` never
+/// matches `ab:`).
+fn context_prefix(context_id: &str) -> String {
+    format!("mem:{context_id}:")
+}
+
+/// Upsert `value` under `(context_id, key)`. A second `put` of the same pair
+/// overwrites the stored value.
+pub async fn put(
+    memory_ks: &KeyspaceHandle,
+    context_id: &str,
+    key: &str,
+    value: &str,
+) -> Result<(), AppError> {
+    let record = MemoryRecord {
+        key: key.to_string(),
+        value: value.to_string(),
+    };
+    memory_ks.insert(store_key(context_id, key), &record).await
+}
+
+/// List every entry in `context_id`, in ascending storage-key order. A prefix
+/// scan over `mem:<context_id>:` — never returns another context's entries.
+pub async fn list(
+    memory_ks: &KeyspaceHandle,
+    context_id: &str,
+) -> Result<Vec<MemoryItem>, AppError> {
+    let pairs = memory_ks
+        .prefix_iter_raw(context_prefix(context_id))
+        .await?;
+    let mut items = Vec::with_capacity(pairs.len());
+    for (_key_bytes, value_bytes) in pairs {
+        let record: MemoryRecord = serde_json::from_slice(&value_bytes)
+            .map_err(|e| AppError::Internal(format!("decode memory record: {e}")))?;
+        items.push(MemoryItem {
+            key: record.key,
+            value: record.value,
+        });
+    }
+    Ok(items)
+}
+
+/// Delete the entry at `(context_id, key)`. Returns [`AppError::NotFound`] when
+/// the key is absent (so the handler can surface `not_found`).
+pub async fn delete(
+    memory_ks: &KeyspaceHandle,
+    context_id: &str,
+    key: &str,
+) -> Result<(), AppError> {
+    let sk = store_key(context_id, key);
+    if memory_ks.get_raw(sk.clone()).await?.is_none() {
+        return Err(AppError::NotFound(format!(
+            "memory entry `{key}` not found in context `{context_id}`"
+        )));
+    }
+    memory_ks.remove(sk).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vti_common::config::StoreConfig;
+    use vti_common::store::Store;
+
+    async fn open() -> (tempfile::TempDir, KeyspaceHandle) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(&StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        })
+        .unwrap();
+        let ks = store.keyspace(crate::keyspaces::MEMORY).unwrap();
+        (dir, ks)
+    }
+
+    #[tokio::test]
+    async fn put_then_list_returns_the_entry() {
+        let (_d, ks) = open().await;
+        put(&ks, "ctx-a", "name", "Ada").await.unwrap();
+        let items = list(&ks, "ctx-a").await.unwrap();
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].key, "name");
+        assert_eq!(items[0].value, "Ada");
+    }
+
+    #[tokio::test]
+    async fn put_same_key_twice_upserts() {
+        let (_d, ks) = open().await;
+        put(&ks, "ctx-a", "name", "Ada").await.unwrap();
+        put(&ks, "ctx-a", "name", "Grace").await.unwrap();
+        let items = list(&ks, "ctx-a").await.unwrap();
+        assert_eq!(items.len(), 1, "second put must replace, not append");
+        assert_eq!(items[0].value, "Grace");
+    }
+
+    #[tokio::test]
+    async fn delete_removes_and_unknown_is_not_found() {
+        let (_d, ks) = open().await;
+        put(&ks, "ctx-a", "k", "v").await.unwrap();
+        delete(&ks, "ctx-a", "k").await.unwrap();
+        assert!(list(&ks, "ctx-a").await.unwrap().is_empty());
+        let err = delete(&ks, "ctx-a", "k").await.unwrap_err();
+        assert!(matches!(err, AppError::NotFound(_)), "{err:?}");
+    }
+
+    #[tokio::test]
+    async fn context_a_memory_is_not_returned_listing_context_b() {
+        let (_d, ks) = open().await;
+        put(&ks, "ctx-a", "secret", "a-only").await.unwrap();
+        put(&ks, "ctx-b", "secret", "b-only").await.unwrap();
+        let a = list(&ks, "ctx-a").await.unwrap();
+        let b = list(&ks, "ctx-b").await.unwrap();
+        assert_eq!(a.len(), 1);
+        assert_eq!(a[0].value, "a-only");
+        assert_eq!(b.len(), 1);
+        assert_eq!(b[0].value, "b-only");
+    }
+
+    #[tokio::test]
+    async fn prefix_scan_is_context_exact() {
+        // `ctx` must not match `ctx-extra` — the trailing `:` in the prefix
+        // guards against a sibling-prefix bleed.
+        let (_d, ks) = open().await;
+        put(&ks, "ctx", "k", "short").await.unwrap();
+        put(&ks, "ctx-extra", "k", "long").await.unwrap();
+        let items = list(&ks, "ctx").await.unwrap();
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].value, "short");
+    }
+}

--- a/vta-service/src/operations/mod.rs
+++ b/vta-service/src/operations/mod.rs
@@ -25,6 +25,11 @@ pub mod export;
 pub mod holder_keys;
 pub mod internal_authority;
 pub mod keys;
+/// Per-context key/value store for AI-agent memory. Backs the
+/// `vta/memory/{put,list,delete}/0.1` Trust Tasks. Entries are keyed
+/// `mem:<contextId>:<key>` in the [`MEMORY`](crate::keyspaces::MEMORY) keyspace;
+/// `list` is a `mem:<contextId>:` prefix scan.
+pub mod memory;
 /// Passkey login — DID-VM-resolved WebAuthn assertion verification.
 /// Drives `vta/auth/passkey-login-{start,finish}/1.0` trust-tasks.
 /// Distinct from [`passkey_vms`] which handles VM *enrolment*.

--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -124,6 +124,10 @@ pub struct AppState {
     /// revoked via `vta/credentials/revoke/0.1`. Keyed `cred:<id>`; revoke is a
     /// tombstone (`revokedAt`), not a delete.
     pub issued_credentials_ks: KeyspaceHandle,
+    /// Per-context key/value store for AI-agent memory (`vta/memory/{put,list,
+    /// delete}/0.1`). Entries keyed `mem:<contextId>:<key>`; gated on context
+    /// access. Durable user data.
+    pub memory_ks: KeyspaceHandle,
     /// Persisted drain set for the protocol-management feature
     /// (`docs/05-design-notes/didcomm-protocol-management.md`).
     /// Keyed by mediator DID; replayed at boot.
@@ -308,6 +312,7 @@ pub async fn build_app_state(
         apply_encryption(store.keyspace(crate::keyspaces::CONSENT_APPROVERS)?);
     let issued_credentials_ks =
         apply_encryption(store.keyspace(crate::keyspaces::ISSUED_CREDENTIALS)?);
+    let memory_ks = apply_encryption(store.keyspace(crate::keyspaces::MEMORY)?);
     #[cfg(feature = "webvh")]
     let drains_ks = apply_encryption(store.keyspace(crate::keyspaces::DRAINS)?);
     #[cfg(feature = "webvh")]
@@ -364,6 +369,7 @@ pub async fn build_app_state(
         consent_ks,
         consent_approvers_ks,
         issued_credentials_ks,
+        memory_ks,
         #[cfg(feature = "webvh")]
         drains_ks,
         #[cfg(feature = "webvh")]

--- a/vta-service/src/test_support.rs
+++ b/vta-service/src/test_support.rs
@@ -825,6 +825,7 @@ pub async fn build_test_app_with(opts: TestAppOptions) -> (axum::Router, TestApp
         issued_credentials_ks: store
             .keyspace(crate::keyspaces::ISSUED_CREDENTIALS)
             .unwrap(),
+        memory_ks: store.keyspace(crate::keyspaces::MEMORY).unwrap(),
         service_state_ks,
         sealed_nonces_ks,
         backup_bundles_ks: backup_bundles_ks.clone(),

--- a/vta-service/src/trust_tasks/memory.rs
+++ b/vta-service/src/trust_tasks/memory.rs
@@ -1,0 +1,286 @@
+//! Agent-memory trust-task slice (`spec/vta/memory/{put,list,delete}/0.1`).
+//!
+//! A per-context key/value store for AI-agent memory. Each handler is:
+//! - **Context-gated** — the caller must be permitted to act in
+//!   `payload.contextId`, enforced via [`AuthClaims::require_context`], the
+//!   exact ACL gate the context-scoped key tasks use
+//!   (`operations::holder_keys::resolve_holder_keys` / `operations::keys`). On
+//!   failure `require_context` returns [`AppError::Forbidden`], which
+//!   [`app_error_to_reject`] maps to the framework `permission_denied`. This is
+//!   the privilege boundary: a context-A agent cannot read, write, or delete
+//!   context-B memory. **Not** operator step-up-gated (unlike the issued-
+//!   credential slice).
+//! - **Audited** — `memory.put` / `memory.list` / `memory.delete` via
+//!   [`crate::audit::record`] (with the context id), mirroring the
+//!   credentials/vault handlers.
+
+use serde_json::Value;
+use trust_tasks_rs::TrustTask;
+
+use vta_sdk::protocols::memory::{
+    MemoryDeleteBody, MemoryDeleteResponse, MemoryListBody, MemoryListResponse, MemoryPutBody,
+    MemoryPutResponse,
+};
+
+use crate::audit;
+use crate::auth::AuthClaims;
+use crate::operations::memory;
+use crate::server::AppState;
+
+use super::helpers::{TRANSPORT_TRUST_TASK, app_error_to_reject, parse_payload, success_response};
+
+/// Handler for `spec/vta/memory/put/0.1`.
+pub(super) async fn handle_put(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> super::helpers::TrustTaskOutcome {
+    let req: MemoryPutBody = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    // Context-access gate (per-domain isolation). Same `require_context` ACL
+    // check the context-scoped key tasks use.
+    if let Err(e) = auth.require_context(&req.context_id) {
+        return app_error_to_reject(&doc, e);
+    }
+    if let Err(e) = memory::put(&state.memory_ks, &req.context_id, &req.key, &req.value).await {
+        return app_error_to_reject(&doc, e);
+    }
+    audit_memory(state, "memory.put", auth, &req.key, &req.context_id).await;
+    success_response(&doc, MemoryPutResponse { key: req.key })
+}
+
+/// Handler for `spec/vta/memory/list/0.1`.
+pub(super) async fn handle_list(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> super::helpers::TrustTaskOutcome {
+    let req: MemoryListBody = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    if let Err(e) = auth.require_context(&req.context_id) {
+        return app_error_to_reject(&doc, e);
+    }
+    let items = match memory::list(&state.memory_ks, &req.context_id).await {
+        Ok(items) => items,
+        Err(e) => return app_error_to_reject(&doc, e),
+    };
+    audit_memory(state, "memory.list", auth, &req.context_id, &req.context_id).await;
+    success_response(&doc, MemoryListResponse { items })
+}
+
+/// Handler for `spec/vta/memory/delete/0.1`.
+pub(super) async fn handle_delete(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> super::helpers::TrustTaskOutcome {
+    let req: MemoryDeleteBody = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    if let Err(e) = auth.require_context(&req.context_id) {
+        return app_error_to_reject(&doc, e);
+    }
+    if let Err(e) = memory::delete(&state.memory_ks, &req.context_id, &req.key).await {
+        return app_error_to_reject(&doc, e);
+    }
+    audit_memory(state, "memory.delete", auth, &req.key, &req.context_id).await;
+    success_response(&doc, MemoryDeleteResponse { key: req.key })
+}
+
+/// Record a `memory.*` audit row (best-effort; a failed write never fails the
+/// op). `resource` is the entry key (put/delete) or the context id (list).
+async fn audit_memory(
+    state: &AppState,
+    action: &str,
+    auth: &AuthClaims,
+    resource: &str,
+    context_id: &str,
+) {
+    if let Err(e) = audit::record(
+        &state.audit_ks,
+        action,
+        &auth.did,
+        Some(resource),
+        "success",
+        Some(TRANSPORT_TRUST_TASK),
+        Some(context_id),
+    )
+    .await
+    {
+        tracing::warn!(error = %e, action = %action, "audit record failed for memory task");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::acl::Role;
+    use crate::test_support::build_signing_test_app_state;
+    use serde_json::json;
+    use trust_tasks_rs::TypeUri;
+    use vta_sdk::trust_tasks::{
+        TASK_VTA_MEMORY_DELETE_0_1, TASK_VTA_MEMORY_LIST_0_1, TASK_VTA_MEMORY_PUT_0_1,
+    };
+
+    /// An admin whose ACL grants exactly `ctx` (not a super-admin — a
+    /// super-admin's empty `allowed_contexts` would reach every context, which
+    /// is what we must NOT do for the isolation test).
+    fn admin_of(ctx: &str) -> AuthClaims {
+        AuthClaims {
+            did: "did:key:zCtxAdmin".into(),
+            role: Role::Admin,
+            allowed_contexts: vec![ctx.to_string()],
+            session_id: "test-session".into(),
+            access_expires_at: 0,
+            amr: Vec::new(),
+            acr: String::new(),
+        }
+    }
+
+    fn doc(uri: &str, payload: Value) -> TrustTask<Value> {
+        let uri: TypeUri = uri.parse().expect("memory uri");
+        TrustTask::new(format!("urn:uuid:{}", uuid::Uuid::new_v4()), uri, payload)
+    }
+
+    fn put_doc(ctx: &str, key: &str, value: &str) -> TrustTask<Value> {
+        doc(
+            TASK_VTA_MEMORY_PUT_0_1,
+            json!({ "contextId": ctx, "key": key, "value": value }),
+        )
+    }
+    fn list_doc(ctx: &str) -> TrustTask<Value> {
+        doc(TASK_VTA_MEMORY_LIST_0_1, json!({ "contextId": ctx }))
+    }
+    fn delete_doc(ctx: &str, key: &str) -> TrustTask<Value> {
+        doc(
+            TASK_VTA_MEMORY_DELETE_0_1,
+            json!({ "contextId": ctx, "key": key }),
+        )
+    }
+
+    fn response_payload(out: &super::super::helpers::TrustTaskOutcome) -> Value {
+        let doc: Value = serde_json::from_slice(&out.body).expect("response is JSON");
+        doc.get("payload").cloned().unwrap_or(Value::Null)
+    }
+
+    #[tokio::test]
+    async fn put_then_list_returns_the_item() {
+        let (state, _dir) = build_signing_test_app_state().await;
+        let auth = admin_of("acme");
+        let out = handle_put(&state, &auth, put_doc("acme", "name", "Ada")).await;
+        assert!(out.status.is_success(), "put should succeed");
+        assert_eq!(
+            response_payload(&out).get("key").and_then(Value::as_str),
+            Some("name")
+        );
+
+        let list = handle_list(&state, &auth, list_doc("acme")).await;
+        assert!(list.status.is_success());
+        let items = response_payload(&list)
+            .get("items")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default();
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].get("key").and_then(Value::as_str), Some("name"));
+        assert_eq!(items[0].get("value").and_then(Value::as_str), Some("Ada"));
+    }
+
+    #[tokio::test]
+    async fn put_same_key_twice_upserts() {
+        let (state, _dir) = build_signing_test_app_state().await;
+        let auth = admin_of("acme");
+        handle_put(&state, &auth, put_doc("acme", "name", "Ada")).await;
+        handle_put(&state, &auth, put_doc("acme", "name", "Grace")).await;
+        let list = handle_list(&state, &auth, list_doc("acme")).await;
+        let items = response_payload(&list)
+            .get("items")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default();
+        assert_eq!(items.len(), 1, "re-put must replace, not append");
+        assert_eq!(items[0].get("value").and_then(Value::as_str), Some("Grace"));
+    }
+
+    #[tokio::test]
+    async fn delete_removes_then_unknown_is_not_found() {
+        let (state, _dir) = build_signing_test_app_state().await;
+        let auth = admin_of("acme");
+        handle_put(&state, &auth, put_doc("acme", "k", "v")).await;
+        let del = handle_delete(&state, &auth, delete_doc("acme", "k")).await;
+        assert!(del.status.is_success(), "delete of present key succeeds");
+        assert!(
+            handle_list(&state, &auth, list_doc("acme"))
+                .await
+                .status
+                .is_success()
+        );
+
+        let again = handle_delete(&state, &auth, delete_doc("acme", "k")).await;
+        assert!(!again.status.is_success(), "delete of absent key must fail");
+        let body = String::from_utf8_lossy(&again.body);
+        assert!(
+            body.contains("not found"),
+            "unknown key should report not-found, got: {body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn caller_without_context_access_is_refused() {
+        let (state, _dir) = build_signing_test_app_state().await;
+        // Admin of `other` must not touch `acme` memory — the privilege boundary.
+        let intruder = admin_of("other");
+        let out = handle_put(&state, &intruder, put_doc("acme", "k", "v")).await;
+        assert!(
+            !out.status.is_success(),
+            "a caller without access to the context must be refused"
+        );
+        let body = String::from_utf8_lossy(&out.body);
+        assert!(
+            body.contains("permissionDenied"),
+            "context refusal should carry the permissionDenied reject code, got: {body}"
+        );
+        // And nothing was written: an authorised admin sees an empty context.
+        let list = handle_list(&state, &admin_of("acme"), list_doc("acme")).await;
+        let items = response_payload(&list)
+            .get("items")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default();
+        assert!(items.is_empty(), "refused put must not have written");
+    }
+
+    #[tokio::test]
+    async fn memory_in_context_a_is_not_listed_for_context_b() {
+        let (state, _dir) = build_signing_test_app_state().await;
+        handle_put(
+            &state,
+            &admin_of("ctx-a"),
+            put_doc("ctx-a", "secret", "a-only"),
+        )
+        .await;
+        handle_put(
+            &state,
+            &admin_of("ctx-b"),
+            put_doc("ctx-b", "secret", "b-only"),
+        )
+        .await;
+
+        let a = handle_list(&state, &admin_of("ctx-a"), list_doc("ctx-a")).await;
+        let items = response_payload(&a)
+            .get("items")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default();
+        assert_eq!(items.len(), 1, "context A lists only its own entry");
+        assert_eq!(
+            items[0].get("value").and_then(Value::as_str),
+            Some("a-only")
+        );
+    }
+}

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -60,6 +60,7 @@ mod discovery;
 mod helpers;
 mod keys;
 mod management;
+mod memory;
 #[cfg(all(feature = "webvh", feature = "didcomm"))]
 mod passkey_vms;
 #[cfg(feature = "webvh")]
@@ -568,6 +569,12 @@ dispatch_table! {
     // Mint + revoke VTA-signed VCs; Admin-gated + operator step-up (AAL2).
     vta_sdk::trust_tasks::TASK_VTA_CREDENTIALS_ISSUE_0_1 => credentials::handle_issue,
     vta_sdk::trust_tasks::TASK_VTA_CREDENTIALS_REVOKE_0_1 => credentials::handle_revoke,
+    // ─── Agent-memory slice (spec/vta/memory/*) ──────────────────
+    // Per-context key/value store; gated on context access (require_context),
+    // NOT operator step-up.
+    vta_sdk::trust_tasks::TASK_VTA_MEMORY_PUT_0_1 => memory::handle_put,
+    vta_sdk::trust_tasks::TASK_VTA_MEMORY_LIST_0_1 => memory::handle_list,
+    vta_sdk::trust_tasks::TASK_VTA_MEMORY_DELETE_0_1 => memory::handle_delete,
     // ─── Config slice ────────────────────────────────────────────
     vta_sdk::trust_tasks::TASK_CONFIG_GET_1_0 => config::handle_get,
     vta_sdk::trust_tasks::TASK_CONFIG_UPDATE_1_0 => config::handle_update,


### PR DESCRIPTION
## What

Implements the `vta/memory/*` Trust Tasks (spec merged in trustoverip/dtgwg-trust-tasks-tf#102) — a **generic per-context key/value store for AI-agent memory**:

- **`vta/memory/put/0.1`** — `{contextId, key, value}` → `{key}` (upsert).
- **`vta/memory/list/0.1`** — `{contextId}` → `{items: [{key, value}]}`.
- **`vta/memory/delete/0.1`** — `{contextId, key}` → `{key}` (`not_found` if absent).

## Why

An agent should remember across sessions, but its memory must stay **scoped to one context** — a fact learned in the finance domain must be invisible to the work domain. The password vault (`vault/*`) and credential store are the wrong shape for free-form memory; this is a plain per-context KV.

## How

- **Context-isolated + ACL-gated**: each handler calls the same `AuthClaims::require_context(contextId)` ACL gate the context-scoped key tasks use — a caller can only touch a context it can access (segment-aware: parent-context admin reaches children; super-admin reaches all). **Not** step-up gated (memory is lower-trust than credential issuance). This is what enforces per-domain memory isolation, verified by tests.
- **Storage**: a new `MEMORY` keyspace, `mem:<contextId>:<key>`, context-exact prefix scan for `list`. In `BACKED_UP` (durable user data). Audited (`memory.put`/`.list`/`.delete`).
- **vta-sdk**: `TASK_VTA_MEMORY_{PUT,LIST,DELETE}_0_1` + `protocols::memory` (camelCase, `deny_unknown_fields`) + client methods.

## Tests

put → list returns it; upsert (same key once); delete then unknown → not_found; **a caller without access to the context is refused**; **context-A memory is not listed for context-B** (isolation). Dispatcher-parity (`dispatcher_handles_every_vta_sdk_uri`), keyspace census (`backup_partition_is_total`), and the vta-sdk suite all pass; `cargo fmt`/`clippy` clean.

## Notes

Consumed by Affinidi Concierge (`cierge-memory`) to make agent memory VTA-managed (durable, audited, context-isolated) rather than a local file — behind the existing `MemoryVault` seam. Mirrors the `vta/credentials` slice (#573).
