### PR TITLE
feat(vta): ephemeral keys/derive-and-sign trust task

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2441,7 +2441,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.18.6",
+ "vta-sdk 0.18.7",
 ]
 
 [[package]]
@@ -3211,7 +3211,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.18.6",
+ "vta-sdk 0.18.7",
 ]
 
 [[package]]
@@ -6698,7 +6698,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.18.6",
+ "vta-sdk 0.18.7",
 ]
 
 [[package]]
@@ -9964,7 +9964,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.18.6",
+ "vta-sdk 0.18.7",
  "vti-common",
  "x25519-dalek",
 ]
@@ -9997,7 +9997,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.18.6",
+ "vta-sdk 0.18.7",
 ]
 
 [[package]]
@@ -10020,7 +10020,7 @@ dependencies = [
  "tracing-subscriber",
  "trust-tasks-rs",
  "uniffi",
- "vta-sdk 0.18.6",
+ "vta-sdk 0.18.7",
 ]
 
 [[package]]
@@ -10055,7 +10055,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.18.6"
+version = "0.18.7"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10111,7 +10111,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",
@@ -10186,7 +10186,7 @@ dependencies = [
  "utoipa-axum",
  "uuid",
  "vta-cli-common",
- "vta-sdk 0.18.6",
+ "vta-sdk 0.18.7",
  "vta-service",
  "vti-common",
  "vti-secrets",
@@ -10208,7 +10208,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.18.6",
+ "vta-sdk 0.18.7",
 ]
 
 [[package]]
@@ -10280,7 +10280,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.18.6",
+ "vta-sdk 0.18.7",
  "vtc-service",
  "vti-common",
  "vti-secrets",
@@ -10328,7 +10328,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.18.6",
+ "vta-sdk 0.18.7",
  "webauthn-rs",
  "zeroize",
 ]
@@ -10355,7 +10355,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.18.6",
+ "vta-sdk 0.18.7",
  "vta-service",
  "vti-common",
 ]
@@ -10384,7 +10384,7 @@ dependencies = [
  "tokio",
  "tracing",
  "vaultrs",
- "vta-sdk 0.18.6",
+ "vta-sdk 0.18.7",
  "vti-common",
 ]
 

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.18.6"
+version = "0.18.7"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/protocols/key_management/derive_and_sign.rs
+++ b/vta-sdk/src/protocols/key_management/derive_and_sign.rs
@@ -1,0 +1,39 @@
+use serde::{Deserialize, Serialize};
+
+use super::sign::SignAlgorithm;
+use crate::keys::KeyType;
+
+/// Body of an **ephemeral** derive-and-sign request: derive a key at
+/// `derivation_path` from the VTA's seed, sign `payload`, and return the
+/// signature — **without persisting a key record**.
+///
+/// Unlike `sign` (which signs with a stored, registered key), this is a
+/// one-shot oracle over the seed's derivation tree. It lets a trusted admin
+/// (e.g. a fleet manager whose fleet seed *is* this VTA's seed) act as any
+/// derived child identity — such as a per-VTA super-admin at
+/// `m/26'/9'/<idx>'` — without leaving a `KeyRecord` per action. Admin-gated.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct DeriveAndSignBody {
+    /// Key type to derive (currently only `Ed25519` is supported).
+    pub key_type: KeyType,
+    /// BIP-32 derivation path, e.g. `m/26'/9'/0'`.
+    pub derivation_path: String,
+    /// Base64url-encoded payload bytes to sign.
+    pub payload: String,
+    /// Signing algorithm (must match the key type).
+    pub algorithm: SignAlgorithm,
+}
+
+/// Body of a derive-and-sign result.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct DeriveAndSignResultBody {
+    /// The derived public key (multibase, multicodec-prefixed) — so the caller
+    /// learns the `did:key` it just signed as.
+    pub public_key: String,
+    /// Base64url-encoded signature bytes.
+    pub signature: String,
+    /// Algorithm used.
+    pub algorithm: SignAlgorithm,
+}

--- a/vta-sdk/src/protocols/key_management/mod.rs
+++ b/vta-sdk/src/protocols/key_management/mod.rs
@@ -1,4 +1,5 @@
 pub mod create;
+pub mod derive_and_sign;
 pub mod get;
 pub mod list;
 pub mod rename;

--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -294,6 +294,15 @@ pub const TASK_KEYS_REVOKE_1_0: &str = "https://trusttasks.org/spec/vta/keys/rev
 /// Auth: write (Application or higher).
 pub const TASK_KEYS_SIGN_1_0: &str = "https://trusttasks.org/spec/vta/keys/sign/1.0";
 
+/// `spec/vta/keys/derive-and-sign/1.0` — derive a key at a BIP-32 path from the
+/// seed, sign a base64url payload, and return `{ public_key, signature }`
+/// WITHOUT persisting a key record (ephemeral signing oracle over the seed's
+/// derivation tree).
+/// Payload: [`crate::protocols::key_management::derive_and_sign::DeriveAndSignBody`].
+/// Auth: admin.
+pub const TASK_KEYS_DERIVE_AND_SIGN_1_0: &str =
+    "https://trusttasks.org/spec/vta/keys/derive-and-sign/1.0";
+
 // ─── Seeds slice (spec/vta/seeds/*) ──────────────────────────────────────
 
 /// `spec/vta/seeds/list/1.0` — list all seed records.
@@ -1183,6 +1192,7 @@ pub const ALL_URIS: &[&str] = &[
     TASK_KEYS_RENAME_1_0,
     TASK_KEYS_REVOKE_1_0,
     TASK_KEYS_SIGN_1_0,
+    TASK_KEYS_DERIVE_AND_SIGN_1_0,
     // Seeds slice
     TASK_SEEDS_LIST_1_0,
     TASK_SEEDS_ROTATE_1_0,

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.10.4"
+version = "0.10.5"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/operations/keys.rs
+++ b/vta-service/src/operations/keys.rs
@@ -9,6 +9,7 @@ use zeroize::Zeroize;
 
 use vta_sdk::protocols::key_management::{
     create::CreateKeyResultBody,
+    derive_and_sign::DeriveAndSignResultBody,
     list::ListKeysResultBody,
     rename::RenameKeyResultBody,
     revoke::RevokeKeyResultBody,
@@ -952,6 +953,65 @@ pub async fn sign_payload(
     })
 }
 
+/// Ephemeral derive-and-sign: derive an Ed25519 key at `derivation_path` from
+/// the VTA's seed, sign `payload`, and return `{ public_key, signature }`
+/// **without persisting a `KeyRecord`**.
+///
+/// This is the signing oracle that lets a fleet manager (whose fleet seed *is*
+/// this VTA's seed, ideally TEE-sealed) act as any derived child identity — e.g.
+/// a per-VTA super-admin at `m/26'/9'/<idx>'` — so the seed never leaves the
+/// VTA. **Admin-gated** (the strictest gate, like `create_key`): the caller can
+/// derive + sign as *any* path, so it must be a fully-trusted admin.
+pub async fn derive_and_sign(
+    keys_ks: &KeyspaceHandle,
+    seed_store: &Arc<dyn SeedStore>,
+    auth: &AuthClaims,
+    key_type: &KeyType,
+    derivation_path: &str,
+    payload: &[u8],
+    algorithm: &SignAlgorithm,
+    channel: &str,
+) -> Result<DeriveAndSignResultBody, AppError> {
+    auth.require_admin()?;
+
+    if !matches!((algorithm, key_type), (SignAlgorithm::EdDSA, KeyType::Ed25519)) {
+        return Err(AppError::Validation(format!(
+            "derive-and-sign currently supports only EdDSA/Ed25519 (got {algorithm}/{key_type:?})"
+        )));
+    }
+
+    let seed = load_seed_bytes(keys_ks, &**seed_store, None)
+        .await
+        .map_err(|e| AppError::Internal(format!("{e}")))?;
+    let bip32 = ed25519_dalek_bip32::ExtendedSigningKey::from_seed(&seed)
+        .map_err(|e| key_derivation_error(format!("failed to create BIP-32 root key: {e}")))?;
+    let path: ed25519_dalek_bip32::DerivationPath = derivation_path
+        .parse()
+        .map_err(|e| key_derivation_error(format!("invalid derivation path: {e}")))?;
+    let derived = bip32
+        .derive(&path)
+        .map_err(|e| key_derivation_error(format!("derivation failed: {e}")))?;
+    let signing_key = ed25519_dalek::SigningKey::from_bytes(derived.signing_key.as_bytes());
+    let public_key =
+        encode_public_multibase(&KeyType::Ed25519, signing_key.verifying_key().as_bytes());
+
+    use ed25519_dalek::Signer;
+    let signature_bytes = signing_key.sign(payload).to_bytes().to_vec();
+    let signature = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(&signature_bytes);
+
+    info!(
+        channel,
+        derivation_path = %derivation_path,
+        "ephemeral derive-and-sign (no key record persisted)"
+    );
+
+    Ok(DeriveAndSignResultBody {
+        public_key,
+        signature,
+        algorithm: algorithm.clone(),
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1383,6 +1443,75 @@ mod tests {
         assert!(!decoded.is_empty(), "decoded signature must be non-empty");
         // Ed25519 signatures are 64 bytes
         assert_eq!(decoded.len(), 64, "Ed25519 signature should be 64 bytes");
+    }
+
+    #[tokio::test]
+    async fn derive_and_sign_is_ephemeral_admin_only_and_verifies() {
+        use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+
+        let h = TestHarness::new().await;
+        let auth = h.super_admin_auth();
+        let payload = b"fleet super-admin auth challenge";
+
+        let result = derive_and_sign(
+            &h.keys_ks,
+            &h.seed_store,
+            &auth,
+            &KeyType::Ed25519,
+            "m/26'/9'/0'",
+            payload,
+            &SignAlgorithm::EdDSA,
+            "test",
+        )
+        .await
+        .expect("derive_and_sign should succeed for an admin");
+
+        // The signature verifies against the returned (derived) public key.
+        let (_, pk_bytes) = multibase::decode(&result.public_key).expect("multibase pubkey");
+        assert_eq!(&pk_bytes[0..2], &[0xed, 0x01], "ed25519-pub multicodec");
+        let vk = VerifyingKey::from_bytes(pk_bytes[2..].try_into().unwrap()).unwrap();
+        let sig_bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .decode(&result.signature)
+            .unwrap();
+        let sig = Signature::from_bytes(sig_bytes.as_slice().try_into().unwrap());
+        vk.verify(payload, &sig).expect("signature must verify");
+
+        // Ephemeral: no key record was persisted.
+        let listed = list_keys(
+            &h.keys_ks,
+            &auth,
+            ListKeysParams {
+                offset: None,
+                limit: None,
+                status: None,
+                context_id: None,
+            },
+            "test",
+        )
+        .await
+        .expect("list keys");
+        assert!(listed.keys.is_empty(), "derive_and_sign must not persist a key");
+
+        // A non-admin caller is rejected.
+        let non_admin = AuthClaims {
+            role: Role::Application,
+            ..h.super_admin_auth()
+        };
+        assert!(
+            derive_and_sign(
+                &h.keys_ks,
+                &h.seed_store,
+                &non_admin,
+                &KeyType::Ed25519,
+                "m/26'/9'/0'",
+                payload,
+                &SignAlgorithm::EdDSA,
+                "test",
+            )
+            .await
+            .is_err(),
+            "non-admin must be rejected"
+        );
     }
 
     /// Context policy gates the signing oracle as a *resource-bound* guardrail:

--- a/vta-service/src/trust_tasks/keys.rs
+++ b/vta-service/src/trust_tasks/keys.rs
@@ -9,6 +9,7 @@ use base64::Engine as _;
 use serde_json::Value;
 use trust_tasks_rs::{RejectReason, TrustTask};
 use vta_sdk::protocols::key_management::create::CreateKeyBody;
+use vta_sdk::protocols::key_management::derive_and_sign::DeriveAndSignBody;
 use vta_sdk::protocols::key_management::get::GetKeyBody;
 use vta_sdk::protocols::key_management::list::ListKeysBody;
 use vta_sdk::protocols::key_management::rename::RenameKeyBody;
@@ -206,6 +207,53 @@ pub(super) async fn handle_sign(
         &state.seed_store,
         auth,
         &req.key_id,
+        &payload_bytes,
+        &req.algorithm,
+        TRANSPORT_TRUST_TASK,
+    )
+    .await
+    {
+        Ok(body) => success_response(&doc, body),
+        Err(e) => app_error_to_reject(&doc, e),
+    }
+}
+
+/// Handler for `spec/vta/keys/derive-and-sign/1.0`. Admin only.
+///
+/// Ephemeral: derives at the requested BIP-32 path, signs, and returns the
+/// signature + derived public key without persisting a key record.
+pub(super) async fn handle_derive_and_sign(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    if let Err(e) = auth.require_admin() {
+        return app_error_to_reject(&doc, e);
+    }
+    let req: DeriveAndSignBody = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    let payload_bytes = match base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(&req.payload)
+        .or_else(|_| base64::engine::general_purpose::URL_SAFE.decode(&req.payload))
+    {
+        Ok(b) => b,
+        Err(e) => {
+            return reject_with(
+                &doc,
+                RejectReason::MalformedRequest {
+                    reason: format!("invalid base64url payload: {e}"),
+                },
+            );
+        }
+    };
+    match operations::keys::derive_and_sign(
+        &state.keys_ks,
+        &state.seed_store,
+        auth,
+        &req.key_type,
+        &req.derivation_path,
         &payload_bytes,
         &req.algorithm,
         TRANSPORT_TRUST_TASK,

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -517,6 +517,7 @@ dispatch_table! {
     vta_sdk::trust_tasks::TASK_KEYS_RENAME_1_0 => keys::handle_rename,
     vta_sdk::trust_tasks::TASK_KEYS_REVOKE_1_0 => keys::handle_revoke,
     vta_sdk::trust_tasks::TASK_KEYS_SIGN_1_0 => keys::handle_sign,
+    vta_sdk::trust_tasks::TASK_KEYS_DERIVE_AND_SIGN_1_0 => keys::handle_derive_and_sign,
     // ─── Seeds slice ─────────────────────────────────────────────
     vta_sdk::trust_tasks::TASK_SEEDS_LIST_1_0 => seeds::handle_list,
     vta_sdk::trust_tasks::TASK_SEEDS_ROTATE_1_0 => seeds::handle_rotate,


### PR DESCRIPTION
## What

Adds `spec/vta/keys/derive-and-sign/1.0` — an **ephemeral** signing oracle: derive an Ed25519 key at a BIP-32 path from the VTA's seed, sign a payload, and return `{ public_key, signature }` **without persisting a `KeyRecord`**. Admin-gated (the same strict gate as `keys/create`).

## Why

It's the OSS enabler for custodying a **fleet master seed inside a VTA** (TEE recommended). A fleet manager (ENM) whose fleet seed *is* this VTA's seed can ask the VTA to act as any derived child identity — e.g. a per-VTA super-admin at `m/26'/9'/<idx>'` — so **the seed never leaves the VTA**, with no per-action key-registry pollution. `keys/sign` only signs with a stored, registered key; this complements it for the derive-on-demand case.

## Changes

- **vta-sdk** (→ 0.18.7): `DeriveAndSignBody` / `DeriveAndSignResultBody` wire types + `TASK_KEYS_DERIVE_AND_SIGN_1_0`.
- **vta-service** (→ 0.10.5): `operations::keys::derive_and_sign` (admin-gated, ephemeral, Ed25519) + `handle_derive_and_sign` trust-task handler + dispatch registration.

## Testing

`cargo test -p vta-service derive_and_sign` — the signature verifies against the derived pubkey, nothing is persisted, a non-admin caller is rejected. Trust-task dispatch/parity (47) + vta-sdk trust_tasks tests pass.

## Notes

Ed25519 only for now (the fleet super-admin case); P256 can follow. This is the enabler; the ENM-side consumption (a `VtaConnector` that authenticates to managed VTAs using fleet-VTA-produced signatures) is a follow-up in the proprietary repo.