### PR TITLE
feat(vta): REST route + SDK client for keys/derive-and-sign

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2441,7 +2441,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.18.7",
+ "vta-sdk 0.18.8",
 ]
 
 [[package]]
@@ -3211,7 +3211,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.18.7",
+ "vta-sdk 0.18.8",
 ]
 
 [[package]]
@@ -6698,7 +6698,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.18.7",
+ "vta-sdk 0.18.8",
 ]
 
 [[package]]
@@ -9964,7 +9964,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.18.7",
+ "vta-sdk 0.18.8",
  "vti-common",
  "x25519-dalek",
 ]
@@ -9997,7 +9997,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.18.7",
+ "vta-sdk 0.18.8",
 ]
 
 [[package]]
@@ -10020,7 +10020,7 @@ dependencies = [
  "tracing-subscriber",
  "trust-tasks-rs",
  "uniffi",
- "vta-sdk 0.18.7",
+ "vta-sdk 0.18.8",
 ]
 
 [[package]]
@@ -10055,7 +10055,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.18.7"
+version = "0.18.8"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10111,7 +10111,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.10.5"
+version = "0.10.6"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",
@@ -10186,7 +10186,7 @@ dependencies = [
  "utoipa-axum",
  "uuid",
  "vta-cli-common",
- "vta-sdk 0.18.7",
+ "vta-sdk 0.18.8",
  "vta-service",
  "vti-common",
  "vti-secrets",
@@ -10208,7 +10208,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.18.7",
+ "vta-sdk 0.18.8",
 ]
 
 [[package]]
@@ -10280,7 +10280,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.18.7",
+ "vta-sdk 0.18.8",
  "vtc-service",
  "vti-common",
  "vti-secrets",
@@ -10328,7 +10328,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.18.7",
+ "vta-sdk 0.18.8",
  "webauthn-rs",
  "zeroize",
 ]
@@ -10355,7 +10355,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.18.7",
+ "vta-sdk 0.18.8",
  "vta-service",
  "vti-common",
 ]
@@ -10384,7 +10384,7 @@ dependencies = [
  "tokio",
  "tracing",
  "vaultrs",
- "vta-sdk 0.18.7",
+ "vta-sdk 0.18.8",
  "vti-common",
 ]
 

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.18.7"
+version = "0.18.8"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/client/keys.rs
+++ b/vta-sdk/src/client/keys.rs
@@ -7,8 +7,10 @@ use super::{
     WrappingKeyResponse, encode_path_segment,
 };
 use crate::error::VtaError;
-use crate::keys::KeyRecord;
+use crate::keys::{KeyRecord, KeyType};
+use crate::protocols::key_management::derive_and_sign::DeriveAndSignResultBody;
 use crate::protocols::key_management::sign::SignAlgorithm;
+use crate::trust_tasks;
 
 #[cfg(feature = "client")]
 use crate::protocols::{key_management, seed_management};
@@ -115,6 +117,39 @@ impl VtaClient {
                         "algorithm": algorithm,
                     }))
             },
+        )
+        .await
+    }
+
+    /// Ephemerally derive a key at `derivation_path` and sign `payload` —
+    /// **without persisting a key record**. Admin-only on the VTA. Returns the
+    /// derived public key + signature.
+    ///
+    /// This is how a client (e.g. a fleet manager whose fleet seed *is* this
+    /// VTA's seed) acts as a derived child identity — e.g. a per-VTA super-admin
+    /// at `m/26'/9'/<idx>'` — so the seed never leaves the VTA. REST:
+    /// `POST /keys/derive-and-sign`; DIDComm: the `keys/derive-and-sign/1.0`
+    /// trust task.
+    pub async fn derive_and_sign(
+        &self,
+        key_type: KeyType,
+        derivation_path: &str,
+        payload: &[u8],
+        algorithm: SignAlgorithm,
+    ) -> Result<DeriveAndSignResultBody, VtaError> {
+        use base64::Engine;
+        let payload_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(payload);
+        let body = serde_json::json!({
+            "key_type": serde_json::to_value(&key_type)?,
+            "derivation_path": derivation_path,
+            "payload": payload_b64,
+            "algorithm": algorithm,
+        });
+        self.rpc_tt(
+            trust_tasks::TASK_KEYS_DERIVE_AND_SIGN_1_0,
+            body.clone(),
+            30,
+            move |c, url| c.post(format!("{url}/keys/derive-and-sign")).json(&body),
         )
         .await
     }

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.10.5"
+version = "0.10.6"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/routes/keys.rs
+++ b/vta-service/src/routes/keys.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use vta_sdk::protocols::key_management::{
     create::CreateKeyResultBody,
+    derive_and_sign::{DeriveAndSignBody, DeriveAndSignResultBody},
     list::ListKeysResultBody,
     rename::RenameKeyResultBody,
     revoke::RevokeKeyResultBody,
@@ -316,6 +317,44 @@ pub async fn sign_with_key(
         &state.seed_store,
         &auth,
         &key_id,
+        &payload,
+        &req.algorithm,
+        "rest",
+    )
+    .await?;
+    Ok(Json(result))
+}
+
+/// POST /keys/derive-and-sign — ephemerally derive a key at a BIP-32 path, sign a
+/// base64url payload, and return `{ public_key, signature }` without persisting a
+/// key record. Auth: admin.
+#[utoipa::path(
+    post, path = "/keys/derive-and-sign", tag = "keys",
+    security(("bearer_jwt" = [])),
+    request_body = DeriveAndSignBody,
+    responses(
+        (status = 200, description = "Derived public key + signature", body = DeriveAndSignResultBody),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller is not an admin"),
+    ),
+)]
+pub async fn derive_and_sign_key(
+    auth: AuthClaims,
+    State(state): State<AppState>,
+    Json(req): Json<DeriveAndSignBody>,
+) -> Result<Json<DeriveAndSignResultBody>, AppError> {
+    auth.require_admin()?;
+    use base64::Engine;
+    let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(&req.payload)
+        .map_err(|e| AppError::Validation(format!("invalid base64url payload: {e}")))?;
+
+    let result = operations::keys::derive_and_sign(
+        &state.keys_ks,
+        &state.seed_store,
+        &auth,
+        &req.key_type,
+        &req.derivation_path,
         &payload,
         &req.algorithm,
         "rest",

--- a/vta-service/src/routes/mod.rs
+++ b/vta-service/src/routes/mod.rs
@@ -381,6 +381,7 @@ fn build_api_router(trust_xff: bool) -> OpenApiRouter<AppState> {
         ))
         .routes(routes!(keys::get_key_secret))
         .routes(routes!(keys::sign_with_key))
+        .routes(routes!(keys::derive_and_sign_key))
         .routes(routes!(keys::get_wrapping_key))
         .routes(routes!(keys::import_key))
         .routes(routes!(keys::list_seeds))


### PR DESCRIPTION
## What

Completes the `keys/derive-and-sign` surface from #575 (which shipped DIDComm-only) so it matches every other key op:

- **vta-service** (→ 0.10.6): `POST /keys/derive-and-sign` (admin-gated) → `DeriveAndSignResultBody`.
- **vta-sdk** (→ 0.18.8): `VtaClient::derive_and_sign(key_type, derivation_path, payload, algorithm)` — works over **REST** (the new route) or **DIDComm** (the `keys/derive-and-sign/1.0` trust task via `rpc_tt`).

## Why

The ergonomic, discoverable call site clients need. In particular it's how a fleet manager (ENM) — whose fleet seed *is* its fleet VTA's seed — will ask the VTA to sign as a per-VTA **super-admin** at `m/26'/9'/<idx>'`, so the seed never leaves the VTA.

## Testing

`cargo test -p vta-service` (788) + `-p vta-sdk` (146) pass. The route is admin-gated; the operation derives ephemerally and persists nothing (covered by #575's op test).