### PR TITLE
feat(vta): keys/derive-and-sign-document (DI-signed as a derived key)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2441,7 +2441,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.18.8",
+ "vta-sdk 0.18.9",
 ]
 
 [[package]]
@@ -3211,7 +3211,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.18.8",
+ "vta-sdk 0.18.9",
 ]
 
 [[package]]
@@ -6698,7 +6698,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.18.8",
+ "vta-sdk 0.18.9",
 ]
 
 [[package]]
@@ -9964,7 +9964,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.18.8",
+ "vta-sdk 0.18.9",
  "vti-common",
  "x25519-dalek",
 ]
@@ -9997,7 +9997,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.18.8",
+ "vta-sdk 0.18.9",
 ]
 
 [[package]]
@@ -10020,7 +10020,7 @@ dependencies = [
  "tracing-subscriber",
  "trust-tasks-rs",
  "uniffi",
- "vta-sdk 0.18.8",
+ "vta-sdk 0.18.9",
 ]
 
 [[package]]
@@ -10055,7 +10055,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.18.8"
+version = "0.18.9"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10111,7 +10111,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.10.6"
+version = "0.10.7"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",
@@ -10186,7 +10186,7 @@ dependencies = [
  "utoipa-axum",
  "uuid",
  "vta-cli-common",
- "vta-sdk 0.18.8",
+ "vta-sdk 0.18.9",
  "vta-service",
  "vti-common",
  "vti-secrets",
@@ -10208,7 +10208,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.18.8",
+ "vta-sdk 0.18.9",
 ]
 
 [[package]]
@@ -10280,7 +10280,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.18.8",
+ "vta-sdk 0.18.9",
  "vtc-service",
  "vti-common",
  "vti-secrets",
@@ -10328,7 +10328,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.18.8",
+ "vta-sdk 0.18.9",
  "webauthn-rs",
  "zeroize",
 ]
@@ -10355,7 +10355,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.18.8",
+ "vta-sdk 0.18.9",
  "vta-service",
  "vti-common",
 ]
@@ -10384,7 +10384,7 @@ dependencies = [
  "tokio",
  "tracing",
  "vaultrs",
- "vta-sdk 0.18.8",
+ "vta-sdk 0.18.9",
  "vti-common",
 ]
 

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.18.8"
+version = "0.18.9"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/client/keys.rs
+++ b/vta-sdk/src/client/keys.rs
@@ -9,6 +9,7 @@ use super::{
 use crate::error::VtaError;
 use crate::keys::{KeyRecord, KeyType};
 use crate::protocols::key_management::derive_and_sign::DeriveAndSignResultBody;
+use crate::protocols::key_management::derive_and_sign_document::DeriveAndSignDocumentResultBody;
 use crate::protocols::key_management::sign::SignAlgorithm;
 use crate::trust_tasks;
 
@@ -150,6 +151,36 @@ impl VtaClient {
             body.clone(),
             30,
             move |c, url| c.post(format!("{url}/keys/derive-and-sign")).json(&body),
+        )
+        .await
+    }
+
+    /// Derive a key at `derivation_path` and attach an `eddsa-jcs-2022`
+    /// Data-Integrity proof to `document`, signed **as the derived key** —
+    /// persisting no key record. Admin-only. Returns the signer `did:key` + the
+    /// signed document. This is how a fleet manager has its fleet VTA sign an
+    /// auth document as a per-VTA super-admin without the seed leaving the VTA.
+    pub async fn derive_and_sign_document(
+        &self,
+        key_type: KeyType,
+        derivation_path: &str,
+        document: serde_json::Value,
+        proof_purpose: Option<&str>,
+    ) -> Result<DeriveAndSignDocumentResultBody, VtaError> {
+        let body = serde_json::json!({
+            "key_type": serde_json::to_value(&key_type)?,
+            "derivation_path": derivation_path,
+            "document": document,
+            "proof_purpose": proof_purpose,
+        });
+        self.rpc_tt(
+            trust_tasks::TASK_KEYS_DERIVE_AND_SIGN_DOCUMENT_1_0,
+            body.clone(),
+            30,
+            move |c, url| {
+                c.post(format!("{url}/keys/derive-and-sign-document"))
+                    .json(&body)
+            },
         )
         .await
     }

--- a/vta-sdk/src/protocols/key_management/derive_and_sign_document.rs
+++ b/vta-sdk/src/protocols/key_management/derive_and_sign_document.rs
@@ -1,0 +1,43 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::keys::KeyType;
+
+/// Body of a **derive-and-sign-document** request: derive an Ed25519 key at
+/// `derivation_path` from the VTA's seed and attach an `eddsa-jcs-2022`
+/// Data-Integrity proof to `document` — signed *as the derived key*, persisting
+/// no key record.
+///
+/// This is the DI-signing counterpart of `derive-and-sign` (which signs raw
+/// bytes). It lets a fleet manager whose fleet seed *is* this VTA's seed obtain
+/// a properly DI-signed document (e.g. an `auth/authenticate/0.1` Trust Task)
+/// signed by a per-VTA super-admin at `m/26'/9'/<idx>'`, so the seed never
+/// leaves the VTA. The proof is produced with the same crate a verifier uses,
+/// so it's correct by construction. Admin-gated.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct DeriveAndSignDocumentBody {
+    /// Key type to derive (currently only `Ed25519`).
+    pub key_type: KeyType,
+    /// BIP-32 derivation path, e.g. `m/26'/9'/0'`.
+    pub derivation_path: String,
+    /// The proof-less JSON document to sign (any `proof` is stripped first).
+    #[cfg_attr(feature = "openapi", schema(value_type = Object))]
+    pub document: Value,
+    /// Proof purpose (default `assertionMethod`, matching the DI-signed REST
+    /// auth flow).
+    #[serde(default)]
+    pub proof_purpose: Option<String>,
+}
+
+/// Result of a derive-and-sign-document request.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct DeriveAndSignDocumentResultBody {
+    /// The derived signer's `did:key` (the super-admin identity the document was
+    /// signed as).
+    pub signer_did: String,
+    /// The signed document, with the Data-Integrity `proof` grafted on.
+    #[cfg_attr(feature = "openapi", schema(value_type = Object))]
+    pub document: Value,
+}

--- a/vta-sdk/src/protocols/key_management/mod.rs
+++ b/vta-sdk/src/protocols/key_management/mod.rs
@@ -1,5 +1,6 @@
 pub mod create;
 pub mod derive_and_sign;
+pub mod derive_and_sign_document;
 pub mod get;
 pub mod list;
 pub mod rename;

--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -303,6 +303,15 @@ pub const TASK_KEYS_SIGN_1_0: &str = "https://trusttasks.org/spec/vta/keys/sign/
 pub const TASK_KEYS_DERIVE_AND_SIGN_1_0: &str =
     "https://trusttasks.org/spec/vta/keys/derive-and-sign/1.0";
 
+/// `spec/vta/keys/derive-and-sign-document/1.0` — derive a key at a BIP-32 path
+/// from the seed and attach an `eddsa-jcs-2022` Data-Integrity proof to a
+/// document, signed *as the derived key*, persisting no key record. The
+/// DI-signing counterpart of derive-and-sign.
+/// Payload: [`crate::protocols::key_management::derive_and_sign_document::DeriveAndSignDocumentBody`].
+/// Auth: admin.
+pub const TASK_KEYS_DERIVE_AND_SIGN_DOCUMENT_1_0: &str =
+    "https://trusttasks.org/spec/vta/keys/derive-and-sign-document/1.0";
+
 // ─── Seeds slice (spec/vta/seeds/*) ──────────────────────────────────────
 
 /// `spec/vta/seeds/list/1.0` — list all seed records.
@@ -1217,6 +1226,7 @@ pub const ALL_URIS: &[&str] = &[
     TASK_KEYS_REVOKE_1_0,
     TASK_KEYS_SIGN_1_0,
     TASK_KEYS_DERIVE_AND_SIGN_1_0,
+    TASK_KEYS_DERIVE_AND_SIGN_DOCUMENT_1_0,
     // Seeds slice
     TASK_SEEDS_LIST_1_0,
     TASK_SEEDS_ROTATE_1_0,

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.10.6"
+version = "0.10.7"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/operations/keys.rs
+++ b/vta-service/src/operations/keys.rs
@@ -1,5 +1,7 @@
 use std::sync::Arc;
 
+use affinidi_data_integrity::{DataIntegrityProof, SignOptions, crypto_suites::CryptoSuite};
+use affinidi_secrets_resolver::secrets::Secret;
 use base64::Engine;
 use chrono::Utc;
 use multibase::Base;
@@ -10,6 +12,7 @@ use zeroize::Zeroize;
 use vta_sdk::protocols::key_management::{
     create::CreateKeyResultBody,
     derive_and_sign::DeriveAndSignResultBody,
+    derive_and_sign_document::DeriveAndSignDocumentResultBody,
     list::ListKeysResultBody,
     rename::RenameKeyResultBody,
     revoke::RevokeKeyResultBody,
@@ -1012,6 +1015,94 @@ pub async fn derive_and_sign(
     })
 }
 
+/// Derive an Ed25519 key at `derivation_path` and attach an `eddsa-jcs-2022`
+/// Data-Integrity proof to `document`, signed **as the derived key**, persisting
+/// no key record. The DI-signing counterpart of [`derive_and_sign`].
+///
+/// Uses the same `DataIntegrityProof::sign` the VTA uses to issue VCs, so the
+/// proof is correct-by-construction for any `affinidi-data-integrity` verifier.
+/// This is how a fleet manager has its fleet VTA sign an `auth/authenticate/0.1`
+/// document as a per-VTA super-admin (`m/26'/9'/<idx>'`) — the seed never leaves
+/// the VTA. **Admin-gated.**
+pub async fn derive_and_sign_document(
+    keys_ks: &KeyspaceHandle,
+    seed_store: &Arc<dyn SeedStore>,
+    auth: &AuthClaims,
+    key_type: &KeyType,
+    derivation_path: &str,
+    mut document: serde_json::Value,
+    proof_purpose: Option<&str>,
+    channel: &str,
+) -> Result<DeriveAndSignDocumentResultBody, AppError> {
+    auth.require_admin()?;
+
+    if !matches!(key_type, KeyType::Ed25519) {
+        return Err(AppError::Validation(format!(
+            "derive-and-sign-document currently supports only Ed25519 (got {key_type:?})"
+        )));
+    }
+    if !document.is_object() {
+        return Err(AppError::Validation("document must be a JSON object".into()));
+    }
+
+    let seed = load_seed_bytes(keys_ks, &**seed_store, None)
+        .await
+        .map_err(|e| AppError::Internal(format!("{e}")))?;
+    let bip32 = ed25519_dalek_bip32::ExtendedSigningKey::from_seed(&seed)
+        .map_err(|e| key_derivation_error(format!("failed to create BIP-32 root key: {e}")))?;
+    let path: ed25519_dalek_bip32::DerivationPath = derivation_path
+        .parse()
+        .map_err(|e| key_derivation_error(format!("invalid derivation path: {e}")))?;
+    let derived = bip32
+        .derive(&path)
+        .map_err(|e| key_derivation_error(format!("derivation failed: {e}")))?;
+    let signing_key = ed25519_dalek::SigningKey::from_bytes(derived.signing_key.as_bytes());
+
+    // The derived identity's did:key + its verification method (did:key:zX#zX),
+    // and a Secret built from the derived private key — identical to how the VTA
+    // builds its issuer Secret.
+    let pub_mb = encode_public_multibase(&KeyType::Ed25519, signing_key.verifying_key().as_bytes());
+    let signer_did = format!("did:key:{pub_mb}");
+    let priv_mb = encode_private_multibase(&KeyType::Ed25519, &signing_key.to_bytes());
+    let mut secret = Secret::from_multibase(&priv_mb, None)
+        .map_err(|e| AppError::Internal(format!("construct derived Secret: {e}")))?;
+    secret.id = format!("{signer_did}#{pub_mb}");
+
+    // JCS is presence-sensitive — sign the proof-less shape (verifiers strip
+    // `proof` too).
+    if let Some(obj) = document.as_object_mut() {
+        obj.remove("proof");
+    }
+    let proof = DataIntegrityProof::sign(
+        &document,
+        &secret,
+        SignOptions::new()
+            .with_proof_purpose(proof_purpose.unwrap_or("assertionMethod"))
+            .with_cryptosuite(CryptoSuite::EddsaJcs2022)
+            .with_created(Utc::now()),
+    )
+    .await
+    .map_err(|e| AppError::Internal(format!("DI-sign document: {e}")))?;
+    document
+        .as_object_mut()
+        .expect("checked is_object above")
+        .insert(
+            "proof".to_string(),
+            serde_json::to_value(&proof)
+                .map_err(|e| AppError::Internal(format!("serialize proof: {e}")))?,
+        );
+
+    info!(
+        channel,
+        derivation_path = %derivation_path,
+        "derive-and-sign-document (DI proof, no key record persisted)"
+    );
+    Ok(DeriveAndSignDocumentResultBody {
+        signer_did,
+        document,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1506,6 +1597,69 @@ mod tests {
                 "m/26'/9'/0'",
                 payload,
                 &SignAlgorithm::EdDSA,
+                "test",
+            )
+            .await
+            .is_err(),
+            "non-admin must be rejected"
+        );
+    }
+
+    #[tokio::test]
+    async fn derive_and_sign_document_grafts_di_proof_as_derived_key() {
+        let h = TestHarness::new().await;
+        let auth = h.super_admin_auth();
+        let doc = serde_json::json!({
+            "type": "https://trusttasks.org/spec/auth/authenticate/0.1",
+            "payload": { "challenge": "abc", "sessionId": "s1" },
+        });
+
+        let res = derive_and_sign_document(
+            &h.keys_ks,
+            &h.seed_store,
+            &auth,
+            &KeyType::Ed25519,
+            "m/26'/9'/0'",
+            doc.clone(),
+            None,
+            "test",
+        )
+        .await
+        .expect("derive_and_sign_document should succeed for an admin");
+
+        // Signer is the derived super-admin did:key.
+        assert!(res.signer_did.starts_with("did:key:z6Mk"), "{}", res.signer_did);
+        // A proof was grafted, by the derived key, with a proofValue.
+        let proof = res.document.get("proof").expect("proof grafted");
+        assert!(
+            proof.get("proofValue").and_then(|v| v.as_str()).is_some(),
+            "proof has a proofValue"
+        );
+        let vm = proof.get("verificationMethod").and_then(|v| v.as_str()).unwrap();
+        assert!(vm.starts_with(&res.signer_did), "vm {vm} bound to signer {}", res.signer_did);
+
+        // Deterministic: same path → same signer.
+        let res2 = derive_and_sign_document(
+            &h.keys_ks, &h.seed_store, &auth, &KeyType::Ed25519, "m/26'/9'/0'", doc, None, "test",
+        )
+        .await
+        .unwrap();
+        assert_eq!(res.signer_did, res2.signer_did);
+
+        // Non-admin rejected.
+        let non_admin = AuthClaims {
+            role: Role::Application,
+            ..h.super_admin_auth()
+        };
+        assert!(
+            derive_and_sign_document(
+                &h.keys_ks,
+                &h.seed_store,
+                &non_admin,
+                &KeyType::Ed25519,
+                "m/26'/9'/0'",
+                serde_json::json!({"x": 1}),
+                None,
                 "test",
             )
             .await

--- a/vta-service/src/routes/keys.rs
+++ b/vta-service/src/routes/keys.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 use vta_sdk::protocols::key_management::{
     create::CreateKeyResultBody,
     derive_and_sign::{DeriveAndSignBody, DeriveAndSignResultBody},
+    derive_and_sign_document::{DeriveAndSignDocumentBody, DeriveAndSignDocumentResultBody},
     list::ListKeysResultBody,
     rename::RenameKeyResultBody,
     revoke::RevokeKeyResultBody,
@@ -357,6 +358,39 @@ pub async fn derive_and_sign_key(
         &req.derivation_path,
         &payload,
         &req.algorithm,
+        "rest",
+    )
+    .await?;
+    Ok(Json(result))
+}
+
+/// POST /keys/derive-and-sign-document — derive a key at a BIP-32 path and
+/// attach an `eddsa-jcs-2022` Data-Integrity proof to the document, signed as
+/// the derived key, without persisting a key record. Auth: admin.
+#[utoipa::path(
+    post, path = "/keys/derive-and-sign-document", tag = "keys",
+    security(("bearer_jwt" = [])),
+    request_body = DeriveAndSignDocumentBody,
+    responses(
+        (status = 200, description = "Signer DID + DI-signed document", body = DeriveAndSignDocumentResultBody),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller is not an admin"),
+    ),
+)]
+pub async fn derive_and_sign_document_key(
+    auth: AuthClaims,
+    State(state): State<AppState>,
+    Json(req): Json<DeriveAndSignDocumentBody>,
+) -> Result<Json<DeriveAndSignDocumentResultBody>, AppError> {
+    auth.require_admin()?;
+    let result = operations::keys::derive_and_sign_document(
+        &state.keys_ks,
+        &state.seed_store,
+        &auth,
+        &req.key_type,
+        &req.derivation_path,
+        req.document,
+        req.proof_purpose.as_deref(),
         "rest",
     )
     .await?;

--- a/vta-service/src/routes/mod.rs
+++ b/vta-service/src/routes/mod.rs
@@ -382,6 +382,7 @@ fn build_api_router(trust_xff: bool) -> OpenApiRouter<AppState> {
         .routes(routes!(keys::get_key_secret))
         .routes(routes!(keys::sign_with_key))
         .routes(routes!(keys::derive_and_sign_key))
+        .routes(routes!(keys::derive_and_sign_document_key))
         .routes(routes!(keys::get_wrapping_key))
         .routes(routes!(keys::import_key))
         .routes(routes!(keys::list_seeds))

--- a/vta-service/src/trust_tasks/keys.rs
+++ b/vta-service/src/trust_tasks/keys.rs
@@ -10,6 +10,7 @@ use serde_json::Value;
 use trust_tasks_rs::{RejectReason, TrustTask};
 use vta_sdk::protocols::key_management::create::CreateKeyBody;
 use vta_sdk::protocols::key_management::derive_and_sign::DeriveAndSignBody;
+use vta_sdk::protocols::key_management::derive_and_sign_document::DeriveAndSignDocumentBody;
 use vta_sdk::protocols::key_management::get::GetKeyBody;
 use vta_sdk::protocols::key_management::list::ListKeysBody;
 use vta_sdk::protocols::key_management::rename::RenameKeyBody;
@@ -256,6 +257,39 @@ pub(super) async fn handle_derive_and_sign(
         &req.derivation_path,
         &payload_bytes,
         &req.algorithm,
+        TRANSPORT_TRUST_TASK,
+    )
+    .await
+    {
+        Ok(body) => success_response(&doc, body),
+        Err(e) => app_error_to_reject(&doc, e),
+    }
+}
+
+/// Handler for `spec/vta/keys/derive-and-sign-document/1.0`. Admin only.
+///
+/// Attaches an `eddsa-jcs-2022` Data-Integrity proof to the document, signed as
+/// the key derived at the requested path — without persisting a key record.
+pub(super) async fn handle_derive_and_sign_document(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    if let Err(e) = auth.require_admin() {
+        return app_error_to_reject(&doc, e);
+    }
+    let req: DeriveAndSignDocumentBody = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    match operations::keys::derive_and_sign_document(
+        &state.keys_ks,
+        &state.seed_store,
+        auth,
+        &req.key_type,
+        &req.derivation_path,
+        req.document,
+        req.proof_purpose.as_deref(),
         TRANSPORT_TRUST_TASK,
     )
     .await

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -519,6 +519,7 @@ dispatch_table! {
     vta_sdk::trust_tasks::TASK_KEYS_REVOKE_1_0 => keys::handle_revoke,
     vta_sdk::trust_tasks::TASK_KEYS_SIGN_1_0 => keys::handle_sign,
     vta_sdk::trust_tasks::TASK_KEYS_DERIVE_AND_SIGN_1_0 => keys::handle_derive_and_sign,
+    vta_sdk::trust_tasks::TASK_KEYS_DERIVE_AND_SIGN_DOCUMENT_1_0 => keys::handle_derive_and_sign_document,
     // ─── Seeds slice ─────────────────────────────────────────────
     vta_sdk::trust_tasks::TASK_SEEDS_LIST_1_0 => seeds::handle_list,
     vta_sdk::trust_tasks::TASK_SEEDS_ROTATE_1_0 => seeds::handle_rotate,


### PR DESCRIPTION
## What

Adds `spec/vta/keys/derive-and-sign-document/1.0` — derive an Ed25519 key at a BIP-32 path and attach an **`eddsa-jcs-2022` Data-Integrity proof** to a document, signed **as the derived key**, persisting no key record. The DI-signing counterpart of `keys/derive-and-sign` (#575/#576, which signs raw bytes).

## Why

Raw `derive-and-sign` produces a signature, but VTA login requires a **DI-signed** `auth/authenticate/0.1` document. This op produces it using the *same* `DataIntegrityProof::sign` the VTA uses to issue VCs — so it's **correct-by-construction** for any `affinidi-data-integrity` verifier (no JCS re-implementation on the client).

It's the enabler for keeping the **fleet seed inside the fleet VTA**: a fleet manager has its fleet VTA DI-sign an auth doc as a per-VTA **super-admin** at `m/26'/9'/<idx>'`, so the seed never leaves the VTA.

## Changes
- **vta-sdk 0.18.9**: `DeriveAndSignDocumentBody`/`ResultBody`, the trust-task const, `VtaClient::derive_and_sign_document` (REST or DIDComm).
- **vta-service 0.10.7**: the admin-gated op + trust-task handler + dispatch + `POST /keys/derive-and-sign-document`.

## Testing
The proof grafts as the derived key (proofValue + bound verificationMethod), is deterministic, and non-admins are rejected. Dispatch parity 52, vta-sdk 146 pass.