### PR TITLE
feat(vtc-client): update_member_extensions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10200,7 +10200,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-client"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "chrono",
  "reqwest 0.13.4",

--- a/vtc-client/Cargo.toml
+++ b/vtc-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vtc-client"
 description = "Client SDK for Verifiable Trust Communities (VTC) — auth, members, join, removal, policies"
-version = "0.1.2"
+version = "0.1.3"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vtc-client/src/lib.rs
+++ b/vtc-client/src/lib.rs
@@ -315,6 +315,31 @@ impl VtcClient {
         Ok(resp.json().await?)
     }
 
+    /// Update a member's community-defined `extensions` (opaque JSON) via
+    /// `PATCH /members/{did}`. A fleet manager records per-member operational
+    /// state here — e.g. the assigned `fleet_index` at enrollment, which the
+    /// roster then carries (see [`MemberRecord::extensions`]). Admin token.
+    pub async fn update_member_extensions(
+        &self,
+        did: &str,
+        extensions: serde_json::Value,
+    ) -> Result<(), VtcError> {
+        let token = self.token()?;
+        let resp = self
+            .http
+            .patch(format!("{}/members/{did}", self.base_url))
+            .bearer_auth(token)
+            .json(&serde_json::json!({ "extensions": extensions }))
+            .send()
+            .await?;
+        if !resp.status().is_success() {
+            let status = resp.status().as_u16();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(VtcError::Http { status, body });
+        }
+        Ok(())
+    }
+
     /// Submit a join request (the applicant side): POST the VP-framed
     /// `body` to `/join-requests`. The VP's holder-binding proof authenticates
     /// the applicant, so this does not require a bearer token. Returns the
@@ -582,6 +607,12 @@ mod tests {
         ));
         assert!(matches!(
             client.activate_policy("p1").await,
+            Err(VtcError::NotAuthenticated)
+        ));
+        assert!(matches!(
+            client
+                .update_member_extensions("did:key:z", serde_json::json!({}))
+                .await,
             Err(VtcError::NotAuthenticated)
         ));
     }


### PR DESCRIPTION
## What

`VtcClient::update_member_extensions(did, extensions)` — `PATCH /members/{did}` with `{ extensions }` (admin token). The VTC already supports writing member extensions via that route; this exposes it on the client.

## Why

A fleet manager records per-member state — the assigned **fleet_index** — on the VTC member at enrollment, so the roster carries it. `VtcInventory` already reads `MemberRecord.extensions["fleet_index"]`; this is the write half, enabling auto-assignment of a stable index at enroll (no operator-chosen index).

## Testing
`cargo test -p vtc-client` (7) — incl. a no-token auth guard for the new method. Bumps vtc-client 0.1.3.