### PR TITLE
feat(tsp): add tsp cargo feature across sdk/service/enclave/vtc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,6 +91,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "affinidi-cesr"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e986f772f1639a7de3bf1ba1cf9b99aa87175fa28463d289a4afa5fc1c274266"
+dependencies = [
+ "base64ct",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "affinidi-crypto"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -684,6 +694,7 @@ dependencies = [
  "affinidi-messaging-sdk",
  "affinidi-secrets-resolver",
  "affinidi-tdk-common",
+ "affinidi-tsp",
  "clap",
  "rustls 0.23.40",
  "serde",
@@ -720,6 +731,32 @@ dependencies = [
  "tokio",
  "tracing",
  "windows-native-keyring-store",
+]
+
+[[package]]
+name = "affinidi-tsp"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e08690e51cf42c0915289bd257f020f3727c5da3a45964c191af0715094acac"
+dependencies = [
+ "aes-gcm",
+ "affinidi-cesr",
+ "affinidi-did-common",
+ "affinidi-did-resolver-cache-sdk",
+ "affinidi-encoding",
+ "blake2",
+ "ed25519-dalek",
+ "hex",
+ "hkdf 0.12.4",
+ "rand_core 0.6.4",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "thiserror 2.0.18",
+ "tokio",
+ "url",
+ "x25519-dalek",
+ "zeroize",
 ]
 
 [[package]]
@@ -2441,7 +2478,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.18.9",
+ "vta-sdk 0.18.10",
 ]
 
 [[package]]
@@ -3211,7 +3248,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.18.9",
+ "vta-sdk 0.18.10",
 ]
 
 [[package]]
@@ -6698,7 +6735,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.18.9",
+ "vta-sdk 0.18.10",
 ]
 
 [[package]]
@@ -9964,7 +10001,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.18.9",
+ "vta-sdk 0.18.10",
  "vti-common",
  "x25519-dalek",
 ]
@@ -9997,7 +10034,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.18.9",
+ "vta-sdk 0.18.10",
 ]
 
 [[package]]
@@ -10020,7 +10057,7 @@ dependencies = [
  "tracing-subscriber",
  "trust-tasks-rs",
  "uniffi",
- "vta-sdk 0.18.9",
+ "vta-sdk 0.18.10",
 ]
 
 [[package]]
@@ -10055,7 +10092,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.18.9"
+version = "0.18.10"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10111,7 +10148,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",
@@ -10186,7 +10223,7 @@ dependencies = [
  "utoipa-axum",
  "uuid",
  "vta-cli-common",
- "vta-sdk 0.18.9",
+ "vta-sdk 0.18.10",
  "vta-service",
  "vti-common",
  "vti-secrets",
@@ -10208,12 +10245,12 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.18.9",
+ "vta-sdk 0.18.10",
 ]
 
 [[package]]
 name = "vtc-service"
-version = "0.10.12"
+version = "0.10.13"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",
@@ -10280,7 +10317,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.18.9",
+ "vta-sdk 0.18.10",
  "vtc-service",
  "vti-common",
  "vti-secrets",
@@ -10328,7 +10365,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.18.9",
+ "vta-sdk 0.18.10",
  "webauthn-rs",
  "zeroize",
 ]
@@ -10355,7 +10392,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.18.9",
+ "vta-sdk 0.18.10",
  "vta-service",
  "vti-common",
 ]
@@ -10384,7 +10421,7 @@ dependencies = [
  "tokio",
  "tracing",
  "vaultrs",
- "vta-sdk 0.18.9",
+ "vta-sdk 0.18.10",
  "vti-common",
 ]
 

--- a/vta-enclave/Cargo.toml
+++ b/vta-enclave/Cargo.toml
@@ -22,6 +22,9 @@ path = "src/main.rs"
 default = ["rest", "didcomm"]
 rest = ["vta-service/rest"]
 didcomm = ["vta-service/didcomm"]
+# TSP transport pass-through. Off by default (not in `default`); enable
+# explicitly for a TSP-capable enclave build once the transport lands.
+tsp = ["vta-service/tsp"]
 webvh = ["vta-service/webvh"]
 vsock-store = ["vta-service/vsock-store"]
 vsock-log = ["dep:tokio-vsock"]

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.18.9"
+version = "0.18.10"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -12,6 +12,22 @@ repository.workspace = true
 
 [features]
 didcomm = ["dep:affinidi-tdk", "dep:affinidi-did-resolver-cache-sdk", "dep:tracing", "dep:uuid", "dep:tokio"]
+# Trust Spanning Protocol (TSP) support. Pulls the TSP agent + DID-backed VID
+# resolver — `affinidi_tdk::tsp` re-exports the `affinidi-tsp` crate when the
+# TDK's `tsp` feature is on. Mirrors the `didcomm` dep set (TDK runtime +
+# resolver cache + tracing/uuid/tokio). Additive and OFF by default — DIDComm is
+# unaffected. Later PRs gate the TSP modules + transport selection on this
+# feature. NB: the messaging-SDK's own `tsp` ops (`atm.tsp()`) are a separate
+# upstream toggle the outbound-seam PR must enable. See
+# docs/05-design-notes/tsp-enablement.md.
+tsp = [
+  "dep:affinidi-tdk",
+  "affinidi-tdk/tsp",
+  "dep:affinidi-did-resolver-cache-sdk",
+  "dep:tracing",
+  "dep:uuid",
+  "dep:tokio",
+]
 client = [
   "dep:reqwest",
   "dep:tracing",

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.10.7"
+version = "0.10.8"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -14,6 +14,10 @@ repository.workspace = true
 default = ["setup", "keyring", "rest", "didcomm", "cli-synthesis"]
 rest = []
 didcomm = []
+# Trust Spanning Protocol transport. Additive and OFF by default (TSP rolls out
+# gated; DIDComm stays in `default`). Enables the SDK's `tsp` capability; later
+# PRs add the TSP listener + `services tsp` surface behind this flag.
+tsp = ["vta-sdk/tsp"]
 webvh = ["dep:didwebvh-rs", "dep:url", "dep:reqwest"]
 setup = ["webvh", "dep:tempfile"]
 # BBS+ (`bbs-2023`) credential support in the vault — pulls in the BLS12-381

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.10.12"
+version = "0.10.13"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -12,6 +12,11 @@ repository.workspace = true
 
 [features]
 default = ["setup", "keyring", "website", "admin-ui"]
+# Trust Spanning Protocol transport (additive, OFF by default). Enables the
+# SDK's `tsp` capability for the VTC; later PRs add the TSP listener + the
+# `send_to_member` TSP path behind it. DIDComm stays the VTC's default member
+# transport until the phased flip (docs/05-design-notes/tsp-enablement.md §12).
+tsp = ["vta-sdk/tsp"]
 # Test-harness surface: the `test_support` module (in-process `TestVtc`
 # builder, `MockVtc` listening server, JWT/session minting). Enabled by
 # the crate's own integration tests via a `[dev-dependencies]` self-dep,


### PR DESCRIPTION
First implementation step of the TSP enablement plan — **SDD PR 1** (`docs/05-design-notes/tsp-enablement.md` §13, merged in #579). Establishes the `tsp` cargo feature so subsequent PRs can gate the TSP modules, transport selection, and service surface behind it. **Pure feature/dependency plumbing — no runtime behavior yet.**

## Changes
- **vta-sdk** — new `tsp` feature wiring `affinidi-tdk/tsp`, which re-exports the `affinidi-tsp` crate (TSP agent + DID-backed VID resolver) as `affinidi_tdk::tsp`. Mirrors the `didcomm` dep set (TDK runtime + resolver cache + tracing/uuid/tokio).
- **vta-service** / **vtc-service** — `tsp = ["vta-sdk/tsp"]`.
- **vta-enclave** — `tsp = ["vta-service/tsp"]` pass-through.

## Additive + off by default
TSP is **OFF in every `default` feature set** — DIDComm is unaffected and stays the default transport.

Verified locally:
- `affinidi-tsp` 0.1.6 resolves from crates.io; `cargo check --features tsp` is clean for vta-sdk, vta-service, and vtc-service.
- Default builds unchanged: `affinidi-tsp` is **absent** from the default dependency tree (`cargo tree -i affinidi-tsp` finds nothing without the flag).
- `Cargo.lock` change is purely additive (`affinidi-tsp` + its `affinidi-cesr` dep).

(`vta-enclave` is the Linux-only Nitro binary; its `tsp` feature chain was validated via `cargo tree` rather than a macOS build.)

## Version bumps (publishable crates)
- vta-sdk `0.18.9 → 0.18.10`
- vta-service `0.10.7 → 0.10.8`
- vtc-service `0.10.12 → 0.10.13`

## Notes for later PRs
- The messaging-SDK s own `tsp` ops (`atm.tsp()`) are a **separate** upstream toggle not enabled here — the outbound-seam PR (SDD §7) must add it.
- Consumer CLIs (`pnm-cli`/`cnm-cli`/`vta-cli-common`/`vta-mcp`) get their `tsp` feature when they gain TSP commands (SDD PR 5 / PR 10).

Next up: SDD PR 2 — service primitives (`#tsp` constants/patchers, `ServiceState::Tsp`, sort reorder).