### PR TITLE
feat(didcomm): authenticate as a did:webvh agent over DIDComm

### DIFF
--- a/vta-mcp/src/main.rs
+++ b/vta-mcp/src/main.rs
@@ -7,13 +7,19 @@
 //! most hosts spawn the server and speak JSON-RPC over stdin/stdout). All
 //! logging therefore goes to **stderr**; stdout is the protocol channel.
 //!
-//! Auth (three modes):
-//! - **did:key DIDComm** (`--agent-did` + `--agent-key` + `--vta-did` +
-//!   `--mediator-did`): authenticate a scoped agent `did:key` directly over
-//!   DIDComm via a mediator. The canonical path — it works against any VTA,
-//!   including DIDComm-only VTAs that expose no REST endpoint. Use this to run a
-//!   dedicated, context-scoped vta-mcp (the agent's ACL bounds it to its
-//!   context). Takes precedence when fully configured.
+//! Auth (modes):
+//! - **DIDComm** — authenticate a scoped agent directly over DIDComm via a
+//!   mediator (`--vta-did` + `--mediator-did` required). The canonical path —
+//!   it works against any VTA, including DIDComm-only VTAs that expose no REST
+//!   endpoint. Two mutually-exclusive ways to supply the agent identity:
+//!   - **did:webvh bundle** (`--agent-secrets <PATH|JSON>`): a hosted DID whose
+//!     `#key-0` (Ed25519 signing) + `#key-1` (X25519 key-agreement) keys are
+//!     exported as a `DidSecretsBundle` (e.g. by `vta create-did-webvh
+//!     --export-secrets`). The agent's `client_did` is the bundle's `did`.
+//!   - **did:key** (`--agent-did` + `--agent-key`): authenticate a scoped agent
+//!     `did:key` directly. Both keys are derived from the one Ed25519 seed.
+//!     Either runs a dedicated, context-scoped vta-mcp (the agent's ACL bounds
+//!     it to its context). Takes precedence when fully configured.
 //! - **Session**: reuse an existing `pnm`/`cnm` login — `--vta <slug>` selects
 //!   the stored keyring session; the client auto-refreshes its token. This is
 //!   the "log in with pnm, then run vta-mcp" path.
@@ -30,6 +36,7 @@ use rmcp::ServiceExt;
 use rmcp::transport::stdio;
 use vta_sdk::agent_session::{AgentConfig, AgentSession};
 use vta_sdk::client::VtaClient;
+use vta_sdk::did_secrets::DidSecretsBundle;
 use vta_sdk::session::SessionStore;
 
 use server::VtaMcp;
@@ -54,15 +61,25 @@ struct Args {
     sessions_dir: Option<PathBuf>,
 
     /// Override the VTA REST URL (otherwise resolved from the session/DID,
-    /// or required in token mode). Optional in did:key DIDComm mode (REST is a
+    /// or required in token mode). Optional in DIDComm mode (REST is a
     /// fallback there).
     #[arg(long, env = "VTA_URL")]
     url: Option<String>,
 
+    /// did:webvh agent secrets bundle (DIDComm mode) — a path to a JSON
+    /// `DidSecretsBundle` file, or the inline JSON itself. The agent's
+    /// `client_did` is the bundle's `did`; its `#key-0` (Ed25519) +
+    /// `#key-1` (X25519) keys authenticate + decrypt. Requires `--vta-did`
+    /// and `--mediator-did`. Mutually exclusive with `--agent-did`/`--agent-key`.
+    /// Stays in this process; never sent over MCP.
+    #[arg(long, env = "VTA_MCP_AGENT_SECRETS")]
+    agent_secrets: Option<String>,
+
     /// Agent `did:key` to authenticate as, directly over DIDComm (did:key
     /// DIDComm mode). Requires `--agent-key`, `--vta-did`, `--mediator-did`.
     /// Lets a consumer run a dedicated, context-scoped vta-mcp against any VTA —
-    /// including DIDComm-only VTAs with no REST endpoint.
+    /// including DIDComm-only VTAs with no REST endpoint. Mutually exclusive
+    /// with `--agent-secrets`.
     #[arg(long, env = "VTA_MCP_AGENT_DID")]
     agent_did: Option<String>,
 
@@ -71,12 +88,11 @@ struct Args {
     #[arg(long, env = "VTA_MCP_AGENT_KEY")]
     agent_key: Option<String>,
 
-    /// The VTA's DID (did:key DIDComm mode) — the recipient of the DIDComm
-    /// messages.
+    /// The VTA's DID (DIDComm mode) — the recipient of the DIDComm messages.
     #[arg(long, env = "VTA_MCP_VTA_DID")]
     vta_did: Option<String>,
 
-    /// The mediator's DID to route DIDComm through (did:key DIDComm mode).
+    /// The mediator's DID to route DIDComm through (DIDComm mode).
     #[arg(long, env = "VTA_MCP_MEDIATOR_DID")]
     mediator_did: Option<String>,
 
@@ -185,8 +201,49 @@ fn didkey_didcomm_params(
     }
 }
 
+/// Load a [`DidSecretsBundle`] from the `--agent-secrets` argument, which is
+/// either a path to a JSON file or the inline JSON itself. A value that parses
+/// as JSON is taken inline; otherwise it is read as a file path.
+fn load_agent_bundle(raw: &str) -> anyhow::Result<DidSecretsBundle> {
+    let json = if std::path::Path::new(raw).exists() {
+        std::fs::read_to_string(raw)
+            .map_err(|e| anyhow::anyhow!("reading agent secrets bundle from `{raw}`: {e}"))?
+    } else {
+        raw.to_string()
+    };
+    serde_json::from_str(&json).map_err(|e| {
+        anyhow::anyhow!("parsing agent secrets bundle (path or inline JSON expected): {e}")
+    })
+}
+
 /// Build an authenticated [`VtaClient`] from the args/env (see module docs).
 async fn build_client(args: &Args) -> anyhow::Result<VtaClient> {
+    // The two DIDComm agent-identity modes are mutually exclusive.
+    if args.agent_secrets.is_some() && (args.agent_did.is_some() || args.agent_key.is_some()) {
+        anyhow::bail!(
+            "--agent-secrets (did:webvh bundle) and --agent-did/--agent-key (did:key) are \
+             mutually exclusive — pass one identity, not both"
+        );
+    }
+
+    // did:webvh DIDComm mode: authenticate a scoped agent via a hosted-DID
+    // secrets bundle (#key-0 Ed25519 + #key-1 X25519). Requires --vta-did +
+    // --mediator-did. Takes precedence when configured.
+    if let Some(raw) = args.agent_secrets.as_deref() {
+        let bundle = load_agent_bundle(raw)?;
+        let (vta_did, mediator_did) = match (args.vta_did.as_deref(), args.mediator_did.as_deref())
+        {
+            (Some(v), Some(m)) => (v, m),
+            _ => anyhow::bail!(
+                "did:webvh DIDComm mode (--agent-secrets) needs --vta-did and --mediator-did"
+            ),
+        };
+        tracing::info!(agent_did = %bundle.did, %mediator_did, "using did:webvh DIDComm mode");
+        return VtaClient::connect_didcomm_bundle(&bundle, vta_did, mediator_did, args.url.clone())
+            .await
+            .map_err(|e| anyhow::anyhow!("connecting to VTA over DIDComm: {e}"));
+    }
+
     // did:key DIDComm mode: authenticate a scoped agent did:key directly over
     // DIDComm (the canonical transport — works against DIDComm-only VTAs that
     // expose no REST endpoint). Takes precedence when fully configured.
@@ -273,6 +330,31 @@ mod tests {
     #[test]
     fn didkey_didcomm_params_none_set_returns_none() {
         assert_eq!(didkey_didcomm_params(None, None, None, None).unwrap(), None);
+    }
+
+    #[test]
+    fn load_agent_bundle_parses_inline_json() {
+        let json = r#"{"did":"did:webvh:abc:example.com:a","secrets":[
+            {"key_id":"did:webvh:abc:example.com:a#key-0","key_type":"ed25519","private_key_multibase":"z6Mksign"}
+        ]}"#;
+        let bundle = load_agent_bundle(json).unwrap();
+        assert_eq!(bundle.did, "did:webvh:abc:example.com:a");
+        assert_eq!(bundle.secrets.len(), 1);
+        assert_eq!(
+            bundle.secrets[0].key_id,
+            "did:webvh:abc:example.com:a#key-0"
+        );
+    }
+
+    #[test]
+    fn load_agent_bundle_reads_file_path() {
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!("vta-mcp-bundle-{}.json", std::process::id()));
+        std::fs::write(&path, r#"{"did":"did:webvh:f:example.com:b","secrets":[]}"#).unwrap();
+        let bundle = load_agent_bundle(path.to_str().unwrap()).unwrap();
+        assert_eq!(bundle.did, "did:webvh:f:example.com:b");
+        assert!(bundle.secrets.is_empty());
+        let _ = std::fs::remove_file(&path);
     }
 
     #[test]

--- a/vta-sdk/src/client/mod.rs
+++ b/vta-sdk/src/client/mod.rs
@@ -316,6 +316,56 @@ impl VtaClient {
         })
     }
 
+    /// Connect via DIDComm through a mediator using a hosted-DID secrets
+    /// bundle (`did:webvh` and any DID whose signing + key-agreement keys are
+    /// independent, exported as a [`DidSecretsBundle`]).
+    ///
+    /// The DIDComm `client_did` is taken from `bundle.did`; the secrets are
+    /// reconstructed from the bundle's entries via
+    /// [`crate::did_key::secrets_from_bundle`] (signing/key-agreement order
+    /// preserved). This is the bundle counterpart to
+    /// [`connect_didcomm`](Self::connect_didcomm), which derives both keys from
+    /// a single `did:key` seed.
+    ///
+    /// `rest_url` is an optional fallback for REST-only operations like
+    /// `health()`.
+    ///
+    /// # You MUST call [`shutdown`](Self::shutdown) when done
+    ///
+    /// See [`connect_didcomm`](Self::connect_didcomm) — the same live-session
+    /// leak contract applies. Prefer [`with_didcomm`](Self::with_didcomm).
+    ///
+    /// [`DidSecretsBundle`]: crate::did_secrets::DidSecretsBundle
+    #[cfg(feature = "session")]
+    pub async fn connect_didcomm_bundle(
+        bundle: &crate::did_secrets::DidSecretsBundle,
+        vta_did: &str,
+        mediator_did: &str,
+        rest_url: Option<String>,
+    ) -> Result<Self, VtaError> {
+        let secrets = crate::did_key::secrets_from_bundle(bundle)
+            .map_err(|e| VtaError::DidcommTransport(e.to_string()))?;
+
+        let session = crate::didcomm_session::DIDCommSession::connect_with_secrets(
+            &bundle.did,
+            secrets,
+            vta_did,
+            mediator_did,
+        )
+        .await
+        .map_err(|e| VtaError::DidcommTransport(e.to_string()))?;
+
+        let rest_client = rest_url.as_ref().map(|_| Client::new());
+
+        Ok(Self {
+            transport: Transport::DIDComm {
+                session,
+                rest_client,
+                rest_url: rest_url.map(|u| u.trim_end_matches('/').to_string()),
+            },
+        })
+    }
+
     /// Set the Bearer token for authenticated requests (REST only, no-op for DIDComm).
     ///
     /// Can be called from sync or async contexts. For async contexts, use

--- a/vta-sdk/src/did_key.rs
+++ b/vta-sdk/src/did_key.rs
@@ -90,6 +90,56 @@ pub fn secrets_from_did_key(did: &str, seed: &[u8; 32]) -> Result<DidKeySecrets,
     })
 }
 
+/// Build the ordered set of DIDComm [`Secret`]s for a
+/// [`DidSecretsBundle`](crate::did_secrets::DidSecretsBundle).
+///
+/// This is the `did:webvh` (and any hosted-DID) counterpart to
+/// [`secrets_from_did_key`]: rather than *deriving* both keys from one
+/// Ed25519 seed, it reconstructs each verification method's secret from its
+/// own `private_key_multibase`, preserving the bundle's verification-method
+/// ids verbatim. In particular the X25519 key-agreement key is a **separate**
+/// key (not derived from the signing key).
+///
+/// Each entry's `private_key_multibase` is a multicodec-prefixed multibase
+/// string; [`Secret::from_multibase`](affinidi_tdk::secrets_resolver::secrets::Secret::from_multibase)
+/// decodes the prefix and builds the right secret type (Ed25519 via
+/// `generate_ed25519`, X25519 via `generate_x25519`) — the same call the VTA
+/// uses to load its own `#key-1` X25519 secret
+/// (`vta_service::operations::did_webvh::load_key_as_secret`). The returned
+/// secret's id is set to the entry's `key_id`.
+///
+/// The returned `Vec` preserves the bundle's entry order; callers that emit a
+/// signing-first bundle (`create-did-webvh` puts `#key-0` first) therefore get
+/// signing first.
+///
+/// `KeyType::P256` entries are accepted (P-256 is a valid signing key type);
+/// the multicodec prefix in `private_key_multibase` is authoritative for the
+/// actual decode, so the declared `key_type` is used only for an up-front
+/// sanity check that the bundle is well-formed.
+#[cfg(feature = "didcomm")]
+pub fn secrets_from_bundle(
+    bundle: &crate::did_secrets::DidSecretsBundle,
+) -> Result<Vec<affinidi_tdk::secrets_resolver::secrets::Secret>, DidKeyError> {
+    use affinidi_tdk::secrets_resolver::secrets::Secret;
+
+    let mut secrets = Vec::with_capacity(bundle.secrets.len());
+    for entry in &bundle.secrets {
+        // Validate the multibase decodes to a 32-byte key before handing it to
+        // the resolver, so a malformed entry yields our typed error (and the
+        // round-trip is exercised) rather than an opaque resolver string.
+        decode_private_key_multibase(&entry.private_key_multibase)?;
+
+        // `from_multibase` reads the multicodec prefix to pick the secret type
+        // (Ed25519 → generate_ed25519, X25519 → generate_x25519) and sets the
+        // verification-method id to the entry's key_id. This is the same call
+        // the VTA uses to load its own secrets.
+        let secret = Secret::from_multibase(&entry.private_key_multibase, Some(&entry.key_id))
+            .map_err(|e| DidKeyError::SecretConstruction(e.to_string()))?;
+        secrets.push(secret);
+    }
+    Ok(secrets)
+}
+
 #[derive(Debug)]
 pub enum DidKeyError {
     Multibase(String),
@@ -97,6 +147,8 @@ pub enum DidKeyError {
     InvalidDidKey,
     #[cfg(feature = "didcomm")]
     X25519Conversion(String),
+    #[cfg(feature = "didcomm")]
+    SecretConstruction(String),
 }
 
 impl std::fmt::Display for DidKeyError {
@@ -107,6 +159,8 @@ impl std::fmt::Display for DidKeyError {
             Self::InvalidDidKey => write!(f, "invalid did:key format"),
             #[cfg(feature = "didcomm")]
             Self::X25519Conversion(e) => write!(f, "X25519 conversion failed: {e}"),
+            #[cfg(feature = "didcomm")]
+            Self::SecretConstruction(e) => write!(f, "failed to construct secret from bundle: {e}"),
         }
     }
 }
@@ -244,5 +298,132 @@ mod tests {
         let seed = [1u8; 32];
         let result = secrets_from_did_key("did:webvh:abc:example.com:vta", &seed);
         assert!(matches!(result, Err(DidKeyError::InvalidDidKey)));
+    }
+
+    /// A `did:webvh` bundle with an Ed25519 signing key (`#key-0`) and a
+    /// separate X25519 key-agreement key (`#key-1`) must produce two secrets
+    /// whose ids are the entries' `key_id`s verbatim, with the correct key
+    /// types, signing first. This is the contract DIDComm consumers rely on:
+    /// the resolver must have a secret keyed by the exact VM id published in
+    /// the DID document.
+    #[cfg(feature = "didcomm")]
+    #[test]
+    fn test_secrets_from_bundle_ed25519_and_x25519() {
+        use crate::did_secrets::{DidSecretsBundle, SecretEntry};
+        use crate::keys::KeyType;
+        use affinidi_tdk::secrets_resolver::secrets::{KeyType as ResolverKeyType, Secret};
+
+        let did = "did:webvh:QmAbc:example.com:agent";
+
+        // Signing key: Ed25519 seed, multicodec-prefixed.
+        let ed_seed = [11u8; 32];
+        let mut ed_prefixed = Vec::with_capacity(34);
+        ed_prefixed.extend_from_slice(&ED25519_PRIV_CODEC);
+        ed_prefixed.extend_from_slice(&ed_seed);
+        let signing_mb = multibase::encode(multibase::Base::Base58Btc, &ed_prefixed);
+
+        // Key-agreement key: a SEPARATE X25519 scalar, multicodec-prefixed.
+        let x_scalar = [22u8; 32];
+        let mut x_prefixed = Vec::with_capacity(34);
+        x_prefixed.extend_from_slice(&X25519_PRIV_CODEC);
+        x_prefixed.extend_from_slice(&x_scalar);
+        let ka_mb = multibase::encode(multibase::Base::Base58Btc, &x_prefixed);
+
+        let bundle = DidSecretsBundle {
+            did: did.to_string(),
+            secrets: vec![
+                SecretEntry {
+                    key_id: format!("{did}#key-0"),
+                    key_type: KeyType::Ed25519,
+                    private_key_multibase: signing_mb.clone(),
+                },
+                SecretEntry {
+                    key_id: format!("{did}#key-1"),
+                    key_type: KeyType::X25519,
+                    private_key_multibase: ka_mb,
+                },
+            ],
+        };
+
+        let secrets = secrets_from_bundle(&bundle).expect("bundle secrets");
+        assert_eq!(secrets.len(), 2, "signing + key-agreement");
+
+        // Order is preserved: signing (#key-0) first.
+        assert_eq!(secrets[0].id, format!("{did}#key-0"));
+        assert_eq!(secrets[1].id, format!("{did}#key-1"));
+
+        // Key types come out right: Ed25519 signing, X25519 key-agreement.
+        assert_eq!(secrets[0].get_key_type(), ResolverKeyType::Ed25519);
+        assert_eq!(secrets[1].get_key_type(), ResolverKeyType::X25519);
+
+        // The X25519 key-agreement secret is the SEPARATE scalar we supplied,
+        // NOT one derived from the signing seed. Reconstructing the same
+        // scalar via `from_multibase` must yield the same public key, while the
+        // Ed25519-derived X25519 (the did:key path) would differ.
+        let mut x_prefixed2 = Vec::with_capacity(34);
+        x_prefixed2.extend_from_slice(&X25519_PRIV_CODEC);
+        x_prefixed2.extend_from_slice(&x_scalar);
+        let same = Secret::from_multibase(
+            &multibase::encode(multibase::Base::Base58Btc, &x_prefixed2),
+            None,
+        )
+        .unwrap();
+        assert_eq!(
+            secrets[1].get_public_keymultibase().unwrap(),
+            same.get_public_keymultibase().unwrap(),
+        );
+    }
+
+    /// The multibase round-trips: an entry encoded with the X25519 codec
+    /// decodes back to the 32-byte scalar via `decode_private_key_multibase`,
+    /// and the resulting secret is keyed by the entry id.
+    #[cfg(feature = "didcomm")]
+    #[test]
+    fn test_secrets_from_bundle_roundtrips_multibase() {
+        use crate::did_secrets::{DidSecretsBundle, SecretEntry};
+        use crate::keys::KeyType;
+
+        let scalar = [7u8; 32];
+        let mut prefixed = Vec::with_capacity(34);
+        prefixed.extend_from_slice(&X25519_PRIV_CODEC);
+        prefixed.extend_from_slice(&scalar);
+        let mb = multibase::encode(multibase::Base::Base58Btc, &prefixed);
+
+        // Direct decode round-trips to the raw scalar.
+        assert_eq!(decode_private_key_multibase(&mb).unwrap(), scalar);
+
+        let bundle = DidSecretsBundle {
+            did: "did:webvh:x:example.com:a".to_string(),
+            secrets: vec![SecretEntry {
+                key_id: "did:webvh:x:example.com:a#key-1".to_string(),
+                key_type: KeyType::X25519,
+                private_key_multibase: mb,
+            }],
+        };
+        let secrets = secrets_from_bundle(&bundle).unwrap();
+        assert_eq!(secrets.len(), 1);
+        assert_eq!(secrets[0].id, "did:webvh:x:example.com:a#key-1");
+    }
+
+    /// A malformed `private_key_multibase` surfaces our typed error, not an
+    /// opaque resolver string.
+    #[cfg(feature = "didcomm")]
+    #[test]
+    fn test_secrets_from_bundle_rejects_bad_multibase() {
+        use crate::did_secrets::{DidSecretsBundle, SecretEntry};
+        use crate::keys::KeyType;
+
+        let bundle = DidSecretsBundle {
+            did: "did:webvh:x:example.com:a".to_string(),
+            secrets: vec![SecretEntry {
+                key_id: "did:webvh:x:example.com:a#key-0".to_string(),
+                key_type: KeyType::Ed25519,
+                private_key_multibase: "!!!bad!!!".to_string(),
+            }],
+        };
+        assert!(matches!(
+            secrets_from_bundle(&bundle),
+            Err(DidKeyError::Multibase(_))
+        ));
     }
 }

--- a/vta-sdk/src/didcomm_session.rs
+++ b/vta-sdk/src/didcomm_session.rs
@@ -119,14 +119,50 @@ impl DIDCommSession {
         vta_did: &str,
         mediator_did: &str,
     ) -> Result<Self, Box<dyn std::error::Error>> {
-        // Decode private key and build DIDComm secrets
+        // Decode private key and build DIDComm secrets for a `did:key`
+        // (Ed25519 signing + X25519 key-agreement derived from it).
         let seed = crate::did_key::decode_private_key_multibase(private_key_multibase)?;
         let secrets = crate::did_key::secrets_from_did_key(client_did, &seed)?;
 
+        // Delegate to the secrets-driven path (signing first, then KA).
+        Self::connect_with_secrets(
+            client_did,
+            vec![secrets.signing, secrets.key_agreement],
+            vta_did,
+            mediator_did,
+        )
+        .await
+    }
+
+    /// Connect to a VTA via DIDComm using **pre-built** DIDComm secrets.
+    ///
+    /// Same transport behaviour as [`connect`](Self::connect) — a persistent,
+    /// auto-reconnecting WebSocket to the mediator — but the caller supplies
+    /// the [`Secret`](affinidi_tdk::secrets_resolver::secrets::Secret)s rather
+    /// than deriving them from a `did:key` seed. This is the path for hosted
+    /// DIDs (`did:webvh`) whose signing (`#key-0` Ed25519) and key-agreement
+    /// (`#key-1` X25519) keys are *independent* and exported as a
+    /// [`DidSecretsBundle`](crate::did_secrets::DidSecretsBundle) — build the
+    /// secrets with [`crate::did_key::secrets_from_bundle`] and pass them here.
+    ///
+    /// Secrets are inserted into the resolver in the order given; pass signing
+    /// first by convention. Every secret's `id` MUST be a verification-method
+    /// id of `client_did` (`{did}#...`) so the mediator/peer can match inbound
+    /// JWE recipients against it.
+    ///
+    /// The same [`shutdown`](Self::shutdown) contract applies — see
+    /// [`connect`](Self::connect).
+    pub async fn connect_with_secrets(
+        client_did: &str,
+        secrets: Vec<affinidi_tdk::secrets_resolver::secrets::Secret>,
+        vta_did: &str,
+        mediator_did: &str,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
         // Create TDK shared state and insert secrets
         let tdk = TDKSharedState::new(TDKConfig::builder().build()?).await?;
-        tdk.secrets_resolver().insert(secrets.signing).await;
-        tdk.secrets_resolver().insert(secrets.key_agreement).await;
+        for secret in secrets {
+            tdk.secrets_resolver().insert(secret).await;
+        }
 
         // Build ATM (no inbound channel needed — we use REST polling)
         let atm_config = ATMConfig::builder().build()?;

--- a/vta-service/src/did_webvh.rs
+++ b/vta-service/src/did_webvh.rs
@@ -2,13 +2,16 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use dialoguer::{Confirm, Input, Select};
+use didwebvh_rs::url::WebVHURL;
 use serde_json::json;
+use url::Url;
 
 use affinidi_did_resolver_cache_sdk::{DIDCacheClient, config::DIDCacheConfigBuilder};
 
 use vta_sdk::did_secrets::{DidSecretsBundle, SecretEntry};
 use vta_sdk::protocols::did_management::create::WebvhPathMode;
 
+use crate::acl::{AclEntry, Role, store_acl_entry};
 use crate::config::AppConfig;
 use crate::keys::seed_store::create_seed_store;
 use crate::operations;
@@ -21,6 +24,12 @@ pub struct CreateDidWebvhArgs {
     pub config_path: Option<PathBuf>,
     pub context: String,
     pub label: Option<String>,
+    /// Hosting URL. When `Some`, the command runs fully non-interactive.
+    pub url: Option<String>,
+    /// Emit the `DidSecretsBundle` JSON to stdout and skip interactive prompts.
+    pub export_secrets: bool,
+    /// Create an ACL admin entry for the new DID in the target context.
+    pub admin: bool,
 }
 
 pub async fn run_create_did_webvh(
@@ -51,8 +60,21 @@ pub async fn run_create_did_webvh(
 
     let label = args.label.as_deref().unwrap_or(&args.context);
 
-    // Prompt for URL
-    let webvh_url = setup::prompt_webvh_url(label)?;
+    // `--url` selects fully non-interactive mode: no hosting-URL prompt, no
+    // save-log prompt, no export-secrets confirm, and no DID-document
+    // edit/portability/pre-rotation prompts. Without it, behave interactively
+    // exactly as before.
+    let interactive = args.url.is_none();
+
+    // Resolve the hosting URL: from `--url` (non-interactive) or by prompting.
+    let webvh_url = match &args.url {
+        Some(raw) => {
+            let parsed = Url::parse(raw).map_err(|e| format!("invalid --url `{raw}`: {e}"))?;
+            WebVHURL::parse_url(&parsed)
+                .map_err(|e| format!("invalid did:webvh hosting URL `{raw}`: {e}"))?
+        }
+        None => setup::prompt_webvh_url(label)?,
+    };
     let url_str = webvh_url
         .get_http_url(None)
         .map_err(|e| format!("{e}"))?
@@ -85,19 +107,26 @@ pub async fn run_create_did_webvh(
     let mut did_document =
         operations::did_webvh::build_did_document(&derived, &config, false, &None);
 
-    // Interactive service endpoint selection
+    // Service endpoint selection. Interactive: prompt. Non-interactive:
+    // advertise the DIDComm mediator endpoint when messaging is configured
+    // (the same default as the interactive prompt).
     if let Some(ref msg) = config.messaging {
-        let service_options = &[
-            "DIDComm endpoint (references mediator DID for routing)",
-            "No service endpoints",
-        ];
-        let service_choice = Select::new()
-            .with_prompt("Service endpoints")
-            .items(service_options)
-            .default(0)
-            .interact()?;
+        let want_didcomm = if interactive {
+            let service_options = &[
+                "DIDComm endpoint (references mediator DID for routing)",
+                "No service endpoints",
+            ];
+            Select::new()
+                .with_prompt("Service endpoints")
+                .items(service_options)
+                .default(0)
+                .interact()?
+                == 0
+        } else {
+            true
+        };
 
-        if service_choice == 0 {
+        if want_didcomm {
             did_document["service"] = json!([
                 {
                     "id": "{DID}#vta-didcomm",
@@ -118,26 +147,35 @@ pub async fn run_create_did_webvh(
     );
     eprintln!();
 
-    // Offer to edit in $EDITOR
-    if Confirm::new()
-        .with_prompt("Edit DID document in your editor?")
-        .default(false)
-        .interact()?
+    // Offer to edit in $EDITOR (interactive only).
+    if interactive
+        && Confirm::new()
+            .with_prompt("Edit DID document in your editor?")
+            .default(false)
+            .interact()?
     {
         did_document = edit_did_document(did_document)?;
     }
 
-    // Portability
-    let portable = Confirm::new()
-        .with_prompt("Make this DID portable (can move to a different domain later)?")
-        .default(true)
-        .interact()?;
+    // Portability (interactive prompt; non-interactive uses the prompt default).
+    let portable = if interactive {
+        Confirm::new()
+            .with_prompt("Make this DID portable (can move to a different domain later)?")
+            .default(true)
+            .interact()?
+    } else {
+        true
+    };
 
-    // Pre-rotation count
-    let pre_rotation_count: u32 = Input::new()
-        .with_prompt("Number of pre-rotation keys (0 = none, recommended: 1-3)")
-        .default(1u32)
-        .interact_text()?;
+    // Pre-rotation count (interactive prompt; non-interactive uses the default).
+    let pre_rotation_count: u32 = if interactive {
+        Input::new()
+            .with_prompt("Number of pre-rotation keys (0 = none, recommended: 1-3)")
+            .default(1u32)
+            .interact_text()?
+    } else {
+        1
+    };
 
     // Build params and call the operations layer
     let auth = cli_super_admin();
@@ -187,31 +225,62 @@ pub async fn run_create_did_webvh(
     let final_did = &result.did;
     eprintln!("\x1b[1;32mCreated DID:\x1b[0m {final_did}");
 
-    // Persist all writes
-    store.persist().await?;
-
-    // Save did.jsonl
-    if let Some(ref log_entry) = result.log_entry {
-        let default_file = format!("{label}-did.jsonl");
-        let did_file: String = Input::new()
-            .with_prompt("Save DID log to file")
-            .default(default_file)
-            .interact_text()?;
-
-        std::fs::write(&did_file, log_entry)?;
-        eprintln!("  DID log saved to: {did_file}");
-        eprintln!("  Context '{}' updated with DID: {final_did}", args.context);
-        eprintln!();
-        eprintln!("  \x1b[2mTo self-host this DID, upload {did_file} to:");
-        eprintln!("  {url_str}\x1b[0m");
+    // Optionally grant the new DID admin in the target context. Mirrors
+    // `create-did-key --admin` (`vta-service/src/did_key.rs`): same
+    // `AclEntry::new(..).with_label(..).with_contexts(..)` +
+    // `store_acl_entry` call, scoped to the target context.
+    if args.admin {
+        let acl_ks = store.keyspace(crate::keyspaces::ACL)?;
+        let entry = AclEntry::new(final_did.clone(), Role::Admin, "cli:create-did-webvh")
+            .with_label(args.label.clone())
+            .with_contexts(vec![args.context.clone()]);
+        store_acl_entry(&acl_ks, &entry).await?;
+        eprintln!(
+            "ACL entry created: {final_did} (admin, context: {})",
+            args.context
+        );
     }
 
-    // Optionally export secrets bundle
-    if Confirm::new()
-        .with_prompt("Export DID secrets bundle?")
-        .default(false)
-        .interact()?
-    {
+    // Persist all writes (DID + optional ACL entry)
+    store.persist().await?;
+
+    // Save did.jsonl. Interactive: prompt for the filename. Non-interactive
+    // (`--url`): no prompt — the operator wanted automation, and stdout is
+    // reserved for the secrets bundle, so we only note the log on stderr.
+    if let Some(ref log_entry) = result.log_entry {
+        if interactive {
+            let default_file = format!("{label}-did.jsonl");
+            let did_file: String = Input::new()
+                .with_prompt("Save DID log to file")
+                .default(default_file)
+                .interact_text()?;
+
+            std::fs::write(&did_file, log_entry)?;
+            eprintln!("  DID log saved to: {did_file}");
+            eprintln!("  Context '{}' updated with DID: {final_did}", args.context);
+            eprintln!();
+            eprintln!("  \x1b[2mTo self-host this DID, upload {did_file} to:");
+            eprintln!("  {url_str}\x1b[0m");
+        } else {
+            eprintln!("  Context '{}' updated with DID: {final_did}", args.context);
+            eprintln!("  \x1b[2mDID log (did.jsonl) ready; self-host at: {url_str}\x1b[0m");
+        }
+    }
+
+    // Optionally export secrets bundle. `--export-secrets` forces it
+    // unconditionally (no confirm); interactively, prompt. Non-interactive
+    // without the flag emits nothing on stdout.
+    let want_export = if args.export_secrets {
+        true
+    } else if interactive {
+        Confirm::new()
+            .with_prompt("Export DID secrets bundle?")
+            .default(false)
+            .interact()?
+    } else {
+        false
+    };
+    if want_export {
         // Fetch key secrets via the operations layer
         let signing_secret = crate::operations::keys::get_key_secret(
             &keys_ks,
@@ -272,6 +341,122 @@ pub async fn run_create_did_webvh(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::acl::get_acl_entry;
+    use crate::keys::seeds::{SeedRecord, save_seed_record, set_active_seed_id};
+    use vti_common::acl::Role;
+
+    /// `vta create-did-webvh --url <URL> --admin --export-secrets` must run
+    /// fully non-interactive and, in one shot:
+    ///   * mint a did:webvh with #key-0 (Ed25519 signing) + #key-1 (X25519
+    ///     key-agreement),
+    ///   * create an ACL **admin** entry for that DID, scoped to the context,
+    ///   * (export-secrets emits the bundle to stdout — verified by the
+    ///     vta-sdk `secrets_from_bundle` tests; here we assert the store-side
+    ///     effects that prove the non-interactive + ACL wiring).
+    ///
+    /// Gated on `config-seed` so the seed store is the in-config backend (no
+    /// OS keyring), making the test hermetic. Run with:
+    /// `cargo test -p vta-service --bin vta --features config-seed`.
+    #[cfg(feature = "config-seed")]
+    #[tokio::test]
+    async fn create_did_webvh_url_admin_export_is_noninteractive_and_grants_admin() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let data_dir = dir.path().join("data");
+        std::fs::create_dir_all(&data_dir).unwrap();
+        let config_path = dir.path().join("config.toml");
+
+        // Minimal config: local store + a config-seed backend carrying a
+        // fixed hex seed (dev/test only; selected ahead of keyring in the
+        // factory). No messaging, so the DID gets no DIDComm service.
+        let seed_hex = hex::encode([7u8; 64]);
+        std::fs::write(
+            &config_path,
+            format!(
+                "[store]\ndata_dir = \"{}\"\n\n[secrets]\nseed = \"{seed_hex}\"\n",
+                data_dir.display()
+            ),
+        )
+        .unwrap();
+
+        // Bootstrap the seed generation record (the bytes live in the
+        // config-seed backend); record generation 0 as active.
+        let config = AppConfig::load(Some(config_path.clone())).expect("load config");
+        let store = Store::open(&config.store).expect("open store");
+        let keys_ks = store.keyspace(crate::keyspaces::KEYS).unwrap();
+        let contexts_ks = store.keyspace(crate::keyspaces::CONTEXTS).unwrap();
+
+        save_seed_record(
+            &keys_ks,
+            &SeedRecord {
+                id: 0,
+                seed_hex: None,
+                seed_enc: None,
+                created_at: chrono::Utc::now(),
+                retired_at: None,
+            },
+        )
+        .await
+        .unwrap();
+        set_active_seed_id(&keys_ks, 0).await.unwrap();
+
+        // Create the target context up-front (so no "create context?" prompt).
+        crate::contexts::create_context(&contexts_ks, "agents", "Agents")
+            .await
+            .unwrap();
+        store.persist().await.unwrap();
+        // Release the fjall lock fully before the command opens its own Store.
+        drop(keys_ks);
+        drop(contexts_ks);
+        drop(store);
+
+        // Run fully non-interactive: --url set, --admin, --export-secrets.
+        let args = CreateDidWebvhArgs {
+            config_path: Some(config_path.clone()),
+            context: "agents".to_string(),
+            label: Some("agent-1".to_string()),
+            url: Some("https://example.com/agents/agent-1".to_string()),
+            export_secrets: true,
+            admin: true,
+        };
+        run_create_did_webvh(args).await.expect("create-did-webvh");
+
+        // Reopen the store and assert the side effects.
+        let store = Store::open(&config.store).expect("reopen store");
+        let webvh_ks = store.keyspace(crate::keyspaces::WEBVH).unwrap();
+        let acl_ks = store.keyspace(crate::keyspaces::ACL).unwrap();
+
+        // Exactly one did:webvh was created, with #key-0 + #key-1 records.
+        let dids = crate::webvh_store::list_dids(&webvh_ks).await.unwrap();
+        assert_eq!(dids.len(), 1, "one did:webvh minted");
+        let did = &dids[0].did;
+        assert!(did.starts_with("did:webvh:"), "got {did}");
+
+        let keys_ks2 = store.keyspace(crate::keyspaces::KEYS).unwrap();
+        let key0: Option<crate::keys::KeyRecord> = keys_ks2
+            .get(crate::keys::store_key(&format!("{did}#key-0")))
+            .await
+            .unwrap();
+        let key1: Option<crate::keys::KeyRecord> = keys_ks2
+            .get(crate::keys::store_key(&format!("{did}#key-1")))
+            .await
+            .unwrap();
+        assert!(key0.is_some(), "#key-0 (signing) record present");
+        assert!(key1.is_some(), "#key-1 (key-agreement) record present");
+        assert_eq!(key1.unwrap().key_type, crate::keys::KeyType::X25519);
+
+        // The ACL admin entry exists for the new DID, scoped to the context.
+        let entry = get_acl_entry(&acl_ks, did)
+            .await
+            .unwrap()
+            .expect("ACL entry created for the did:webvh");
+        assert_eq!(entry.role, Role::Admin);
+        assert_eq!(entry.allowed_contexts, vec!["agents".to_string()]);
+    }
 }
 
 fn edit_did_document(

--- a/vta-service/src/main.rs
+++ b/vta-service/src/main.rs
@@ -135,7 +135,11 @@ enum Commands {
         #[arg(long)]
         label: Option<String>,
     },
-    /// Create a did:webvh DID for a context (interactive wizard, no server required)
+    /// Create a did:webvh DID for a context (interactive wizard, no server required).
+    ///
+    /// Passing `--url` makes the command fully non-interactive (no prompts) so
+    /// it can be scripted: combine with `--export-secrets` to emit the secrets
+    /// bundle to stdout and `--admin` to grant the new DID admin in the context.
     CreateDidWebvh {
         /// Target context ID
         #[arg(long)]
@@ -143,6 +147,20 @@ enum Commands {
         /// Human-readable label prefix for key records (default: context id)
         #[arg(long)]
         label: Option<String>,
+        /// Hosting URL for the DID (e.g. https://example.com). When set, the
+        /// command runs fully non-interactive — no hosting-URL, save-log, or
+        /// export-secrets prompts.
+        #[arg(long)]
+        url: Option<String>,
+        /// Emit the `DidSecretsBundle` JSON to stdout (the only thing on
+        /// stdout; human text goes to stderr) and skip the save-log /
+        /// export-secrets prompts.
+        #[arg(long)]
+        export_secrets: bool,
+        /// Also create an ACL entry with Admin role for the new did:webvh in
+        /// the target context (mirrors `create-did-key --admin`).
+        #[arg(long)]
+        admin: bool,
     },
     /// Import an external DID and create an ACL entry (offline, no server required)
     ImportDid {
@@ -1414,7 +1432,13 @@ async fn main() {
                 std::process::exit(1);
             }
         }
-        Some(Commands::CreateDidWebvh { context, label }) => {
+        Some(Commands::CreateDidWebvh {
+            context,
+            label,
+            url,
+            export_secrets,
+            admin,
+        }) => {
             // SEALED CHECK: creates keys and DIDs
             check_seal(&cli.config).await;
             #[cfg(feature = "setup")]
@@ -1423,6 +1447,9 @@ async fn main() {
                     config_path: cli.config,
                     context,
                     label,
+                    url,
+                    export_secrets,
+                    admin,
                 };
                 if let Err(e) = did_webvh::run_create_did_webvh(args).await {
                     eprintln!("Error: {e}");
@@ -1431,7 +1458,7 @@ async fn main() {
             }
             #[cfg(not(feature = "setup"))]
             {
-                let _ = (context, label);
+                let _ = (context, label, url, export_secrets, admin);
                 eprintln!("create-did-webvh is not available (compiled without 'setup' feature)");
                 std::process::exit(1);
             }


### PR DESCRIPTION
## What

Lets a DIDComm client authenticate **as a did:webvh agent** — using a full hosted-DID `DidSecretsBundle` (independent `#key-0` Ed25519 signing + `#key-1` X25519 key-agreement) — instead of only a key-derived `did:key`. Scoped agents can now have full, hosted, resolvable DID documents that represent themselves (service endpoints, multiple VMs, rotation), rather than the minimal implicit document of a `did:key`.

## Why

The "DIDComm **as** a did:webvh identity" machinery already exists server-side (the VTA itself runs DIDComm as its own `did:webvh`, with secrets keyed by `{did}#key-0`/`#key-1`). But `vta-sdk`'s `DIDCommSession::connect` hardcoded `secrets_from_did_key` — so a *client/agent* could only ever be a `did:key`. This exposes the existing pattern on the client side.

## How

- **vta-sdk**
  - `secrets_from_bundle(&DidSecretsBundle) -> Vec<Secret>` — builds DIDComm secrets from the bundle's entries, keyed by their `key_id` (`Secret::from_multibase`, the codified precedent; `#key-1` is a real X25519 key, not derived).
  - `DIDCommSession::connect_with_secrets(client_did, secrets, vta_did, mediator_did)` — takes pre-built secrets; `connect()` now delegates to it (public signature unchanged → did:key path untouched).
  - `VtaClient::connect_didcomm_bundle(&bundle, vta_did, mediator_did, rest_url)`.
- **vta-mcp**: `--agent-secrets` / `VTA_MCP_AGENT_SECRETS` (a `DidSecretsBundle` file path or inline JSON) authenticates a did:webvh agent; mutually exclusive with `--agent-did`/`--agent-key`; the "did:key DIDComm mode" wording is generalized.
- **vta-service**: `create-did-webvh` gains `--url` (non-interactive hosting URL), `--export-secrets` (bundle → stdout), and `--admin` (ACL admin grant, mirroring `create-did-key`) — so a minted did:webvh is a usable, authorized, **scriptable** scoped agent identity.

## Tests

`secrets_from_bundle` (ed25519+x25519, multibase round-trip, reject-bad); vta-mcp bundle loading (file + inline); `create-did-webvh --url --admin --export-secrets` is fully non-interactive and grants context admin. Existing did:key DIDComm + did_webvh suites unchanged (vta-sdk 217, vta-service did_webvh 73, api_integration create_did_webvh 19, all green). `cargo fmt`/`clippy` clean.

## Consumer

Affinidi Concierge (Cierge) will switch its per-domain agent provisioning from `create-did-key` to `create-did-webvh`, so every domain agent is a full did:webvh identity.
