### PR TITLE
feat(tsp): advertise #tsp TSPTransport in DID templates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2478,7 +2478,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.18.11",
+ "vta-sdk 0.18.12",
 ]
 
 [[package]]
@@ -3248,7 +3248,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.18.11",
+ "vta-sdk 0.18.12",
 ]
 
 [[package]]
@@ -6735,7 +6735,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.18.11",
+ "vta-sdk 0.18.12",
 ]
 
 [[package]]
@@ -10001,7 +10001,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.18.11",
+ "vta-sdk 0.18.12",
  "vti-common",
  "x25519-dalek",
 ]
@@ -10034,7 +10034,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.18.11",
+ "vta-sdk 0.18.12",
 ]
 
 [[package]]
@@ -10057,7 +10057,7 @@ dependencies = [
  "tracing-subscriber",
  "trust-tasks-rs",
  "uniffi",
- "vta-sdk 0.18.11",
+ "vta-sdk 0.18.12",
 ]
 
 [[package]]
@@ -10092,7 +10092,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.18.11"
+version = "0.18.12"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10223,7 +10223,7 @@ dependencies = [
  "utoipa-axum",
  "uuid",
  "vta-cli-common",
- "vta-sdk 0.18.11",
+ "vta-sdk 0.18.12",
  "vta-service",
  "vti-common",
  "vti-secrets",
@@ -10245,7 +10245,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.18.11",
+ "vta-sdk 0.18.12",
 ]
 
 [[package]]
@@ -10317,7 +10317,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.18.11",
+ "vta-sdk 0.18.12",
  "vtc-service",
  "vti-common",
  "vti-secrets",
@@ -10365,7 +10365,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.18.11",
+ "vta-sdk 0.18.12",
  "webauthn-rs",
  "zeroize",
 ]
@@ -10392,7 +10392,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.18.11",
+ "vta-sdk 0.18.12",
  "vta-service",
  "vti-common",
 ]
@@ -10421,7 +10421,7 @@ dependencies = [
  "tokio",
  "tracing",
  "vaultrs",
- "vta-sdk 0.18.11",
+ "vta-sdk 0.18.12",
  "vti-common",
 ]
 

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.18.11"
+version = "0.18.12"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/did_templates/tests.rs
+++ b/vta-sdk/src/did_templates/tests.rs
@@ -328,14 +328,25 @@ fn didcomm_mediator_builtin_renders_end_to_end() {
     let doc = tpl.render(&vars).unwrap();
     assert_eq!(doc["id"], "did:webvh:mediator:example.com");
     let services = doc["service"].as_array().unwrap();
-    assert_eq!(services.len(), 2);
+    assert_eq!(services.len(), 3);
+
+    // TSP service first (canonical preference order, §3.3): id `#tsp`,
+    // type `TSPTransport`, serviceEndpoint a plain-string transport URL.
+    // The mediator's own doc (shape (b)) carries the URL directly, unlike
+    // a consumer doc whose `#tsp` points at this mediator's DID.
+    assert_eq!(services[0]["id"], "did:webvh:mediator:example.com#tsp");
+    assert_eq!(services[0]["type"], "TSPTransport");
+    assert_eq!(
+        services[0]["serviceEndpoint"],
+        "https://mediator.example.com"
+    );
 
     // DIDComm service: id `#service`, type as a single-element array,
     // serviceEndpoint as an array of two endpoint objects (HTTP first,
     // WSS second). Each endpoint carries the same accept/routingKeys.
-    assert_eq!(services[0]["id"], "did:webvh:mediator:example.com#service");
-    assert_eq!(services[0]["type"], json!(["DIDCommMessaging"]));
-    let endpoints = services[0]["serviceEndpoint"].as_array().unwrap();
+    assert_eq!(services[1]["id"], "did:webvh:mediator:example.com#service");
+    assert_eq!(services[1]["type"], json!(["DIDCommMessaging"]));
+    let endpoints = services[1]["serviceEndpoint"].as_array().unwrap();
     assert_eq!(endpoints.len(), 2);
     assert_eq!(endpoints[0]["uri"], "https://mediator.example.com");
     assert_eq!(endpoints[0]["accept"], json!(["didcomm/v2"]));
@@ -346,10 +357,10 @@ fn didcomm_mediator_builtin_renders_end_to_end() {
 
     // Authentication service: id `#auth`, type as a single-element array,
     // serviceEndpoint as a plain string at `<URL>/authenticate`.
-    assert_eq!(services[1]["id"], "did:webvh:mediator:example.com#auth");
-    assert_eq!(services[1]["type"], json!(["Authentication"]));
+    assert_eq!(services[2]["id"], "did:webvh:mediator:example.com#auth");
+    assert_eq!(services[2]["type"], json!(["Authentication"]));
     assert_eq!(
-        services[1]["serviceEndpoint"],
+        services[2]["serviceEndpoint"],
         "https://mediator.example.com/authenticate"
     );
 }
@@ -370,7 +381,7 @@ fn ws_url_is_derived_from_url_when_omitted() {
     // WS_URL deliberately omitted.
 
     let doc = tpl.render(&vars).expect("render with derived WS_URL");
-    let endpoints = doc["service"][0]["serviceEndpoint"].as_array().unwrap();
+    let endpoints = doc["service"][1]["serviceEndpoint"].as_array().unwrap();
     assert_eq!(
         endpoints[0]["uri"],
         "https://mediator.example.com/mediator/v1"
@@ -394,7 +405,7 @@ fn ws_url_derivation_handles_plain_http_and_trailing_slash() {
     vars.insert_string("URL", "http://mediator.local/");
 
     let doc = tpl.render(&vars).expect("render with derived ws://");
-    let endpoints = doc["service"][0]["serviceEndpoint"].as_array().unwrap();
+    let endpoints = doc["service"][1]["serviceEndpoint"].as_array().unwrap();
     assert_eq!(endpoints[1]["uri"], "ws://mediator.local/ws");
 }
 
@@ -412,7 +423,7 @@ fn explicit_ws_url_overrides_derivation() {
     vars.insert_string("WS_URL", "wss://ws-gateway.example.net/mediator/ws");
 
     let doc = tpl.render(&vars).unwrap();
-    let endpoints = doc["service"][0]["serviceEndpoint"].as_array().unwrap();
+    let endpoints = doc["service"][1]["serviceEndpoint"].as_array().unwrap();
     assert_eq!(endpoints[0]["uri"], "https://mediator.example.com");
     assert_eq!(
         endpoints[1]["uri"],
@@ -540,7 +551,9 @@ fn did_host_didcomm_builtin_accept_is_native_array_not_string() {
     // accept list as an array; a stringified version breaks them silently.
     let tpl = load_embedded("did-host-didcomm").unwrap();
     let doc = tpl.render(&did_host_didcomm_fixture_vars()).unwrap();
-    let endpoint = &doc["service"][0]["serviceEndpoint"][0];
+    // The DIDComm entry is at [1] (the `#tsp` TSP entry sorts first); its
+    // first serviceEndpoint object carries the `accept` array.
+    let endpoint = &doc["service"][1]["serviceEndpoint"][0];
     let accept = &endpoint["accept"];
     assert!(
         accept.is_array(),
@@ -550,25 +563,35 @@ fn did_host_didcomm_builtin_accept_is_native_array_not_string() {
 }
 
 #[test]
-fn did_host_didcomm_builtin_has_exactly_one_service_entry() {
-    // Older mediator setups emitted an unnamed duplicate DIDCommMessaging
-    // service alongside the named one. Lock the invariant here so this
-    // template never regresses into that.
+fn did_host_didcomm_builtin_has_exactly_one_entry_per_transport() {
+    // Two transports advertised: TSP (`#tsp`, preferred) then DIDComm
+    // (`#vta-didcomm`), both pointing at the same mediator DID (D8 — one
+    // dual-protocol mediator). Older mediator setups emitted an unnamed
+    // duplicate DIDCommMessaging service; lock exactly one entry per type
+    // so the template never regresses into that.
     let tpl = load_embedded("did-host-didcomm").unwrap();
     let doc = tpl.render(&did_host_didcomm_fixture_vars()).unwrap();
     let services = doc["service"].as_array().expect("service is array");
     assert_eq!(
         services.len(),
-        1,
-        "expected exactly one service entry, got {}: {:?}",
+        2,
+        "expected exactly two service entries (tsp + didcomm), got {}: {:?}",
         services.len(),
         services
     );
+    // TSP first (canonical order): plain-string mediator-DID endpoint.
+    assert_eq!(services[0]["id"], "did:webvh:QmTEST:example.com#tsp");
+    assert_eq!(services[0]["type"], "TSPTransport");
     assert_eq!(
-        services[0]["id"],
+        services[0]["serviceEndpoint"],
+        "did:webvh:QmMED:mediator.example.com:mediator"
+    );
+    // DIDComm second, same mediator.
+    assert_eq!(
+        services[1]["id"],
         "did:webvh:QmTEST:example.com#vta-didcomm"
     );
-    assert_eq!(services[0]["type"], "DIDCommMessaging");
+    assert_eq!(services[1]["type"], "DIDCommMessaging");
 }
 
 #[test]
@@ -616,7 +639,10 @@ fn did_host_didcomm_builtin_rejects_unknown_placeholder_in_template() {
     // required/optional vars.
     let tpl = load_embedded("did-host-didcomm").unwrap();
     let mut doc = tpl.document.clone();
-    doc["service"][0]["serviceEndpoint"][0]["extra"] =
+    // Inject into the DIDComm entry at [1] (whose serviceEndpoint is an
+    // array of objects); [0] is now the `#tsp` entry with a plain-string
+    // endpoint that can't take a nested key.
+    doc["service"][1]["serviceEndpoint"][0]["extra"] =
         Value::String("{UNDECLARED_TOKEN}".to_string());
 
     let raw = serde_json::json!({
@@ -765,22 +791,30 @@ fn ai_agent_builtin_has_key_agreement_for_authcrypt() {
 }
 
 #[test]
-fn ai_agent_builtin_has_exactly_one_didcomm_service_via_mediator() {
+fn ai_agent_builtin_advertises_tsp_then_didcomm_via_mediator() {
     let tpl = load_embedded("ai-agent").unwrap();
     let doc = tpl.render(&ai_agent_fixture_vars()).unwrap();
     let services = doc["service"].as_array().expect("service is array");
     assert_eq!(
         services.len(),
-        1,
-        "expected one service entry: {services:?}"
+        2,
+        "expected two service entries (tsp + didcomm): {services:?}"
     );
-    assert_eq!(services[0]["type"], "DIDCommMessaging");
+    // TSP first (canonical preference): plain-string mediator-DID endpoint —
+    // inbound TSP routes through the same mediator as DIDComm (D8).
+    assert_eq!(services[0]["type"], "TSPTransport");
     assert_eq!(
-        services[0]["serviceEndpoint"][0]["uri"], "did:webvh:QmMED:mediator.example.com:mediator",
+        services[0]["serviceEndpoint"],
+        "did:webvh:QmMED:mediator.example.com:mediator"
+    );
+    // DIDComm second, through the same mediator.
+    assert_eq!(services[1]["type"], "DIDCommMessaging");
+    assert_eq!(
+        services[1]["serviceEndpoint"][0]["uri"], "did:webvh:QmMED:mediator.example.com:mediator",
         "inbound traffic must route through the operator's mediator"
     );
     // Whole-string-placeholder contract: accept substitutes to an array.
-    assert!(services[0]["serviceEndpoint"][0]["accept"].is_array());
+    assert!(services[1]["serviceEndpoint"][0]["accept"].is_array());
 }
 
 #[test]

--- a/vta-sdk/templates/ai-agent.json
+++ b/vta-sdk/templates/ai-agent.json
@@ -41,6 +41,11 @@
     "keyAgreement": ["{DID}#key-1"],
     "service": [
       {
+        "id": "{DID}#tsp",
+        "type": "TSPTransport",
+        "serviceEndpoint": "{MEDIATOR_DID}"
+      },
+      {
         "id": "{DID}#vta-didcomm",
         "type": "DIDCommMessaging",
         "serviceEndpoint": [

--- a/vta-sdk/templates/did-host-didcomm.json
+++ b/vta-sdk/templates/did-host-didcomm.json
@@ -39,6 +39,11 @@
     "keyAgreement": ["{DID}#key-1"],
     "service": [
       {
+        "id": "{DID}#tsp",
+        "type": "TSPTransport",
+        "serviceEndpoint": "{MEDIATOR_DID}"
+      },
+      {
         "id": "{DID}#vta-didcomm",
         "type": "DIDCommMessaging",
         "serviceEndpoint": [

--- a/vta-sdk/templates/did-host-http-didcomm.json
+++ b/vta-sdk/templates/did-host-http-didcomm.json
@@ -49,6 +49,11 @@
         }
       },
       {
+        "id": "{DID}#tsp",
+        "type": "TSPTransport",
+        "serviceEndpoint": "{MEDIATOR_DID}"
+      },
+      {
         "id": "{DID}#vta-didcomm",
         "type": "DIDCommMessaging",
         "serviceEndpoint": [

--- a/vta-sdk/templates/didcomm-mediator.json
+++ b/vta-sdk/templates/didcomm-mediator.json
@@ -41,6 +41,11 @@
     "keyAgreement": ["{DID}#key-1"],
     "service": [
       {
+        "id": "{DID}#tsp",
+        "type": "TSPTransport",
+        "serviceEndpoint": "{URL}"
+      },
+      {
         "id": "{DID}#service",
         "type": ["DIDCommMessaging"],
         "serviceEndpoint": [

--- a/vta-sdk/tests/fixtures/did-host-didcomm.rendered.json
+++ b/vta-sdk/tests/fixtures/did-host-didcomm.rendered.json
@@ -23,6 +23,11 @@
   "keyAgreement": ["did:webvh:QmTEST:example.com#key-1"],
   "service": [
     {
+      "id": "did:webvh:QmTEST:example.com#tsp",
+      "type": "TSPTransport",
+      "serviceEndpoint": "did:webvh:QmMED:mediator.example.com:mediator"
+    },
+    {
       "id": "did:webvh:QmTEST:example.com#vta-didcomm",
       "type": "DIDCommMessaging",
       "serviceEndpoint": [


### PR DESCRIPTION
SDD **PR 4** (`docs/05-design-notes/tsp-enablement.md` §5). Adds a `#tsp` `TSPTransport` service to the built-in DID templates that advertise a transport, so VTA-minted DIDs offer TSP alongside DIDComm. **Additive — DIDComm entries unchanged.**

## Two template shapes (per SDD §2)
- **Consumer-via-mediator** templates — `did-host-didcomm`, `did-host-http-didcomm`, `ai-agent` — gain a `#tsp` whose `serviceEndpoint` **reuses the same `{MEDIATOR_DID}`** the DIDComm entry binds (D8 — one dual-protocol mediator; **no new template var**).
- **The mediators own** template — `didcomm-mediator` — gains a `#tsp` whose `serviceEndpoint` is the mediator transport **`{URL}`** (shape (b): the mediators doc carries the URL directly).
- TSP is listed **first** per the canonical order (spec §3.3 — TSP > DIDComm > REST).

## Skipped (deliberately)
- **`vta-admin`** — `did:key`, no service block; cant advertise TSP (SDD §2).
- **`push-gateway`** — its TSP path is a separate deployment concern.
- **`render`/`validate` unchanged** — both placeholders (`{MEDIATOR_DID}`, `{URL}`) are already declared, so no new-var plumbing.

## Tests
- Updated the `did-host-didcomm.rendered.json` golden fixture + the structural tests that index services (TSP now sorts first → DIDComm indices shift; renamed two tests to reflect the two-transport shape).
- All **154** vta-sdk lib tests pass; the **full vta-service suite (795 + 115 + …, 0 failures)** confirms no template consumer (setup, provision-integration) broke.

Version: vta-sdk `0.18.11 → 0.18.12`.

Next: SDD PR 5 — service-management ops + CLI (`services tsp {enable,update,disable,rollback}`, `ServiceState::Tsp`).