### PR TITLE
feat(tsp): surface TSP in services list (ServiceState::Tsp)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2478,7 +2478,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.18.12",
+ "vta-sdk 0.18.13",
 ]
 
 [[package]]
@@ -3248,7 +3248,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.18.12",
+ "vta-sdk 0.18.13",
 ]
 
 [[package]]
@@ -6735,7 +6735,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.18.12",
+ "vta-sdk 0.18.13",
 ]
 
 [[package]]
@@ -9983,7 +9983,7 @@ dependencies = [
 
 [[package]]
 name = "vta-cli-common"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "aes-gcm",
  "affinidi-crypto",
@@ -10001,7 +10001,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.18.12",
+ "vta-sdk 0.18.13",
  "vti-common",
  "x25519-dalek",
 ]
@@ -10034,7 +10034,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.18.12",
+ "vta-sdk 0.18.13",
 ]
 
 [[package]]
@@ -10057,7 +10057,7 @@ dependencies = [
  "tracing-subscriber",
  "trust-tasks-rs",
  "uniffi",
- "vta-sdk 0.18.12",
+ "vta-sdk 0.18.13",
 ]
 
 [[package]]
@@ -10092,7 +10092,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.18.12"
+version = "0.18.13"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10148,7 +10148,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.10.9"
+version = "0.10.10"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",
@@ -10223,7 +10223,7 @@ dependencies = [
  "utoipa-axum",
  "uuid",
  "vta-cli-common",
- "vta-sdk 0.18.12",
+ "vta-sdk 0.18.13",
  "vta-service",
  "vti-common",
  "vti-secrets",
@@ -10245,7 +10245,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.18.12",
+ "vta-sdk 0.18.13",
 ]
 
 [[package]]
@@ -10317,7 +10317,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.18.12",
+ "vta-sdk 0.18.13",
  "vtc-service",
  "vti-common",
  "vti-secrets",
@@ -10365,7 +10365,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.18.12",
+ "vta-sdk 0.18.13",
  "webauthn-rs",
  "zeroize",
 ]
@@ -10392,7 +10392,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.18.12",
+ "vta-sdk 0.18.13",
  "vta-service",
  "vti-common",
 ]
@@ -10421,7 +10421,7 @@ dependencies = [
  "tokio",
  "tracing",
  "vaultrs",
- "vta-sdk 0.18.12",
+ "vta-sdk 0.18.13",
  "vti-common",
 ]
 

--- a/vta-cli-common/Cargo.toml
+++ b/vta-cli-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-cli-common"
 description = "Shared CLI command handlers and rendering helpers for VTA CLIs"
 readme = "README.md"
-version = "0.10.1"
+version = "0.10.2"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-cli-common/src/commands/services.rs
+++ b/vta-cli-common/src/commands/services.rs
@@ -34,6 +34,16 @@ pub async fn cmd_services_list(client: &VtaClient) -> Result<(), Box<dyn std::er
     println!();
     for state in &response.services {
         match state {
+            vta_sdk::protocol::services::ServiceState::Tsp {
+                enabled,
+                mediator_did,
+            } => {
+                let on = if *enabled { "on" } else { "off" };
+                println!("  TSP:      {on}");
+                if let Some(m) = mediator_did {
+                    println!("    Mediator:     {m}");
+                }
+            }
             vta_sdk::protocol::services::ServiceState::Didcomm {
                 enabled,
                 mediator_did,

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.18.12"
+version = "0.18.13"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/protocol/services.rs
+++ b/vta-sdk/src/protocol/services.rs
@@ -313,14 +313,23 @@ pub struct ServicesListResponse {
 }
 
 /// State of a single transport kind. The `kind` discriminator is
-/// `"rest"`, `"didcomm"`, or `"webauthn"` on the wire (kebab-case to
-/// align with the rest of the runtime service-management surface).
+/// `"tsp"`, `"rest"`, `"didcomm"`, or `"webauthn"` on the wire (kebab-case
+/// to align with the rest of the runtime service-management surface).
 /// When `enabled` is `false`, the kind-specific config fields are
 /// absent.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[serde(tag = "kind", rename_all = "lowercase")]
 pub enum ServiceState {
+    Tsp {
+        enabled: bool,
+        /// Mediator DID the `#tsp` service advertises (the VTA's TSP
+        /// VID) — TSP uses the same mediator indirection as DIDComm, so
+        /// this is typically the same value as the DIDComm `mediator_did`
+        /// (one dual-protocol mediator). `None` when TSP is disabled.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        mediator_did: Option<String>,
+    },
     Rest {
         enabled: bool,
         /// Currently-published REST URL. `None` when REST is

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.10.9"
+version = "0.10.10"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/config.rs
+++ b/vta-service/src/config.rs
@@ -89,6 +89,13 @@ pub struct ServicesConfig {
     /// want browser-side passkey login flip this on explicitly.
     #[serde(default)]
     pub webauthn: bool,
+    /// Trust Spanning Protocol transport. Additive and `false` by
+    /// default while TSP rolls out gated — DIDComm stays the default
+    /// transport. When enabled, the VTA advertises a `#tsp`
+    /// `TSPTransport` service (pointing at the same mediator as
+    /// DIDComm). See `docs/05-design-notes/tsp-enablement.md`.
+    #[serde(default)]
+    pub tsp: bool,
 }
 
 fn default_true() -> bool {
@@ -101,6 +108,7 @@ impl Default for ServicesConfig {
             rest: true,
             didcomm: true,
             webauthn: false,
+            tsp: false,
         }
     }
 }

--- a/vta-service/src/operations/protocol/list.rs
+++ b/vta-service/src/operations/protocol/list.rs
@@ -28,7 +28,7 @@ use crate::auth::AuthClaims;
 use crate::config::AppConfig;
 use crate::error::AppError;
 use crate::operations::protocol::document::{
-    current_didcomm_service, current_rest_service, current_webauthn_service,
+    current_didcomm_service, current_rest_service, current_tsp_service, current_webauthn_service,
 };
 use crate::store::KeyspaceHandle;
 use crate::webvh_store;
@@ -75,6 +75,7 @@ pub async fn list_services(
             rest_enabled: cfg.services.rest,
             didcomm_enabled: cfg.services.didcomm,
             webauthn_enabled: cfg.services.webauthn,
+            tsp_enabled: cfg.services.tsp,
             vta_did: cfg.vta_did.clone(),
             mediator_did: cfg
                 .messaging
@@ -92,7 +93,13 @@ pub async fn list_services(
     // For non-webvh DIDs (e.g. did:key), there is no on-chain DID document
     // to inspect. Report service state from config only.
     if !vta_did.starts_with("did:webvh:") {
+        // TSP uses the same mediator as DIDComm (D8 — one dual-protocol
+        // mediator), so its endpoint mirrors the DIDComm `mediator_did`.
         let services = vec![
+            ServiceState::Tsp {
+                enabled: cfg_view.tsp_enabled && cfg_view.mediator_did.is_some(),
+                mediator_did: cfg_view.mediator_did.clone(),
+            },
             ServiceState::Didcomm {
                 enabled: cfg_view.didcomm_enabled && cfg_view.mediator_did.is_some(),
                 mediator_did: cfg_view.mediator_did,
@@ -122,16 +129,21 @@ pub async fn list_services(
     // the source of truth for what SDK consumers will resolve.
     let rest_url = current_rest_service(&current_doc).map(|s| s.url);
     let webauthn_url = current_webauthn_service(&current_doc).map(|s| s.url);
+    let tsp_mediator = current_tsp_service(&current_doc).map(|s| s.mediator_did);
     let didcomm = current_didcomm_service(&current_doc);
     let (didcomm_mediator, didcomm_routing_keys) = match didcomm {
         Some(svc) => (Some(svc.mediator_did), svc.routing_keys),
         None => (None, Vec::new()),
     };
 
-    // Canonical order: DIDComm first when present, REST second,
-    // WebAuthn third. Empty kinds (disabled in both config and the
-    // doc) still appear so the operator gets a uniform shape.
+    // Canonical order: TSP first when present, then DIDComm, REST,
+    // WebAuthn (spec §3.3). Empty kinds (disabled in both config and
+    // the doc) still appear so the operator gets a uniform shape.
     let services = vec![
+        ServiceState::Tsp {
+            enabled: cfg_view.tsp_enabled && tsp_mediator.is_some(),
+            mediator_did: tsp_mediator,
+        },
         ServiceState::Didcomm {
             enabled: cfg_view.didcomm_enabled && didcomm_mediator.is_some(),
             mediator_did: didcomm_mediator,
@@ -154,6 +166,7 @@ struct ConfigView {
     rest_enabled: bool,
     didcomm_enabled: bool,
     webauthn_enabled: bool,
+    tsp_enabled: bool,
     vta_did: Option<String>,
     mediator_did: Option<String>,
     public_url: Option<String>,
@@ -272,8 +285,20 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(response.services.len(), 3);
+        assert_eq!(response.services.len(), 4);
+        // TSP first (canonical order); disabled here (config `tsp` is off
+        // by default) though it carries the same mediator as DIDComm.
         match &response.services[0] {
+            ServiceState::Tsp {
+                enabled,
+                mediator_did,
+            } => {
+                assert!(!enabled, "TSP is off by default in config");
+                assert_eq!(mediator_did.as_deref(), Some("did:peer:2.MEDIATOR"));
+            }
+            other => panic!("expected TSP first; got {other:?}"),
+        }
+        match &response.services[1] {
             ServiceState::Didcomm {
                 enabled,
                 mediator_did,
@@ -282,21 +307,21 @@ mod tests {
                 assert!(enabled);
                 assert_eq!(mediator_did.as_deref(), Some("did:peer:2.MEDIATOR"));
             }
-            other => panic!("expected DIDComm first; got {other:?}"),
+            other => panic!("expected DIDComm second; got {other:?}"),
         }
-        match &response.services[1] {
+        match &response.services[2] {
             ServiceState::Rest { enabled, url } => {
                 assert!(!enabled, "REST is disabled in config");
                 assert_eq!(url.as_deref(), Some("https://vta.example.com"));
             }
-            other => panic!("expected REST second; got {other:?}"),
+            other => panic!("expected REST third; got {other:?}"),
         }
-        match &response.services[2] {
+        match &response.services[3] {
             ServiceState::Webauthn { enabled, url } => {
                 assert!(!enabled);
                 assert!(url.is_none());
             }
-            other => panic!("expected WebAuthn third; got {other:?}"),
+            other => panic!("expected WebAuthn fourth; got {other:?}"),
         }
     }
 
@@ -380,11 +405,22 @@ mod tests {
 
         assert_eq!(
             response.services.len(),
-            3,
-            "expected one entry per kind (DIDComm + REST + WebAuthn); got {response:?}"
+            4,
+            "expected one entry per kind (TSP + DIDComm + REST + WebAuthn); got {response:?}"
         );
-        // Canonical order: DIDComm first.
+        // Canonical order: TSP first. The fixture publishes no `#tsp`
+        // service, so it's disabled with no mediator.
         match &response.services[0] {
+            ServiceState::Tsp {
+                enabled,
+                mediator_did,
+            } => {
+                assert!(!enabled);
+                assert!(mediator_did.is_none());
+            }
+            other => panic!("expected TSP first; got {other:?}"),
+        }
+        match &response.services[1] {
             ServiceState::Didcomm {
                 enabled,
                 mediator_did,
@@ -393,23 +429,23 @@ mod tests {
                 assert!(enabled);
                 assert_eq!(mediator_did.as_deref(), Some("did:peer:2.MEDIATOR"));
             }
-            other => panic!("expected DIDComm first; got {other:?}"),
+            other => panic!("expected DIDComm second; got {other:?}"),
         }
-        match &response.services[1] {
+        match &response.services[2] {
             ServiceState::Rest { enabled, url } => {
                 assert!(enabled);
                 assert_eq!(url.as_deref(), Some("https://vta.example/api"));
             }
-            other => panic!("expected REST second; got {other:?}"),
+            other => panic!("expected REST third; got {other:?}"),
         }
-        match &response.services[2] {
+        match &response.services[3] {
             ServiceState::Webauthn { enabled, url } => {
                 // Test fixture doesn't publish a WebAuthn service
                 // entry; assert the "disabled, no URL" baseline.
                 assert!(!enabled);
                 assert!(url.is_none());
             }
-            other => panic!("expected WebAuthn third; got {other:?}"),
+            other => panic!("expected WebAuthn fourth; got {other:?}"),
         }
     }
 }

--- a/vta-service/src/services_cli.rs
+++ b/vta-service/src/services_cli.rs
@@ -258,6 +258,15 @@ pub async fn run_services_list(config_path: Option<PathBuf>) -> CliResult {
     println!();
     for state in &response.services {
         match state {
+            vta_sdk::protocol::services::ServiceState::Tsp {
+                enabled,
+                mediator_did,
+            } => {
+                println!("  TSP:      {}", if *enabled { "on" } else { "off" });
+                if let Some(m) = mediator_did {
+                    println!("    Mediator:     {m}");
+                }
+            }
             vta_sdk::protocol::services::ServiceState::Didcomm {
                 enabled,
                 mediator_did,

--- a/vta-service/src/setup.rs
+++ b/vta-service/src/setup.rs
@@ -258,6 +258,7 @@ mod tests {
             rest: true,
             didcomm: false,
             webauthn: false,
+            tsp: false,
         };
         let out = build_vta_additional_services(&services, url)
             .expect("REST + URL must emit a service entry");
@@ -287,6 +288,7 @@ mod tests {
             rest: false,
             didcomm: true,
             webauthn: false,
+            tsp: false,
         };
         assert!(
             build_vta_additional_services(&services, url).is_none(),
@@ -299,6 +301,7 @@ mod tests {
             rest: false,
             didcomm: false,
             webauthn: false,
+            tsp: false,
         };
         assert!(build_vta_additional_services(&services, None).is_none());
     }

--- a/vta-service/src/setup/from_toml.rs
+++ b/vta-service/src/setup/from_toml.rs
@@ -178,6 +178,9 @@ fn default_services() -> ServicesConfig {
         // `services webauthn enable`, and the existing `services.rest`
         // continues to be the discoverable HTTP surface until they do.
         webauthn: false,
+        // TSP defaults off — operators enable it via `services tsp enable`
+        // (or the setup wizard once it learns TSP). DIDComm stays default.
+        tsp: false,
     }
 }
 

--- a/vta-service/src/setup/interactive.rs
+++ b/vta-service/src/setup/interactive.rs
@@ -973,6 +973,9 @@ async fn gather_inputs(
             rest: enable_rest,
             didcomm: enable_didcomm,
             webauthn,
+            // TSP is enabled post-setup via `services tsp enable` (the
+            // interactive wizard's TSP prompt lands in a later phase).
+            tsp: false,
         },
         server: ServerConfig {
             host,


### PR DESCRIPTION
SDD **PR 5a** — the read/visibility slice of the service-management surface. Lands **`ServiceState::Tsp`** (deferred from PR 2) and the read path so operators can *see* TSP state. The mutation ops (`services tsp {enable,update,disable,rollback}`) + the brick-prevention invariant + `ServiceKind::Tsp` follow in **PR 5b** — I split here because `ServiceKind::Tsp` ripples into the snapshot/rollback dispatch, whereas this read slice is cleanly additive.

## Changes
- **`vta_sdk::protocol::services`** — `ServiceState::Tsp { enabled, mediator_did }` (wire `kind: "tsp"`; mirrors `Didcomm` without `routing_keys`, since TSP uses the same mediator indirection).
- **`vta-service` config** — `ServicesConfig.tsp` (off by default, D6).
- **`list_services`** — emits the TSP entry **first** (canonical TSP > DIDComm > REST > WebAuthn, §3.3), reading the on-chain `#tsp` service for webvh DIDs or the configured mediator for `did:key`. Updated the two ordering tests to `len == 4`.
- **CLI render** — both surfaces (`vta_cli_common::commands::services` for `pnm/cnm`, and the offline `vta services` in `services_cli`) print `TSP: on/off` + mediator.
- Backfilled the new field in every explicit `ServicesConfig` literal (interactive + from-toml setup, tests).

## Verification
- **154** vta-sdk lib tests + the **full vta-service suite (0 failures)** pass (the cross-crate check — config literals, OpenAPI schema, CLI render all compile & pass).
- fmt-clean on all changed files; no new clippy warnings.

Bumps: vta-sdk `0.18.12→0.18.13`, vta-service `0.10.9→0.10.10`, vta-cli-common `0.10.1→0.10.2`.

Next: **PR 5b** — `enable/update/disable/rollback_tsp` ops + `ServiceKind::Tsp` + invariant (TSP counts as a transport) + routes + DIDComm message types + `services tsp` CLI verbs. (TSP has **no drain** — stateless relay — so it skips the drain machinery; `enable_tsp` is reachable over REST *or* DIDComm, unlike `enable_didcomm`.)