### PR TITLE
feat(tsp): TSP service-management operations (server-side)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10148,7 +10148,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.10.10"
+version = "0.10.11"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",
@@ -10330,7 +10330,7 @@ dependencies = [
 
 [[package]]
 name = "vti-common"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "aes-gcm",
  "affinidi-did-resolver-cache-sdk",

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.10.10"
+version = "0.10.11"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/operations/protocol/disable_didcomm.rs
+++ b/vta-service/src/operations/protocol/disable_didcomm.rs
@@ -304,6 +304,7 @@ async fn read_preconditions(
                 cfg.services.rest,
                 cfg.services.didcomm,
                 cfg.services.webauthn,
+                cfg.services.tsp,
             ),
             ProposedOp::disable(ServiceKind::Didcomm),
         ) {

--- a/vta-service/src/operations/protocol/disable_tsp.rs
+++ b/vta-service/src/operations/protocol/disable_tsp.rs
@@ -1,20 +1,20 @@
-//! `disable_rest` operation.
+//! `disable_tsp` operation.
 //!
-//! Spec: `docs/05-design-notes/runtime-service-management.md` §3.2, §3.4.
-//! Shares the disable skeleton (brick-prevention → preconditions → snapshot →
-//! patch-remove → publish) with [`super::disable_webauthn`] via the
-//! [`service_lifecycle`](super::service_lifecycle) helpers; the REST-specific
+//! Spec: `docs/05-design-notes/runtime-service-management.md` §3.2, §3.4 +
+//! `docs/05-design-notes/tsp-enablement.md`. Shares the disable skeleton
+//! (brick-prevention → preconditions → snapshot → patch-remove → publish) with
+//! [`super::disable_rest`] / [`super::disable_webauthn`] via the
+//! [`service_lifecycle`](super::service_lifecycle) helpers; the TSP-specific
 //! persist (runtime-state + in-memory flag) and telemetry stay here.
 //!
 //! Sequence (under [`PROTOCOL_LOCK`]):
 //! 1. super-admin → 2. brick-prevention (refuse if it would leave no advertised
-//!    transport) → 3. snapshot `RestSnapshot::Enabled { prior_url }` (rollback
-//!    target) → 4. remove `#vta-rest` + publish → 5. persist `services.rest =
-//!    false` → 6. telemetry.
+//!    transport) → 3. snapshot `TspSnapshot::Enabled { prior_mediator_did }`
+//!    (rollback target) → 4. remove `#tsp` + publish → 5. persist
+//!    `services.tsp = false` → 6. telemetry.
 //!
-//! REST has no drain semantics — the Axum process stays running (it's a
-//! process-level binding), so the local CLI can still reach the VTA; only the
-//! *advertisement* is removed.
+//! TSP has no drain semantics — like REST, only the *advertisement* is
+//! removed; there is no in-flight-message window to wind down.
 
 use serde_json::Value as JsonValue;
 use thiserror::Error;
@@ -29,29 +29,29 @@ use crate::error::AppError;
 use crate::operations::did_webvh::UpdateDidWebvhError;
 use crate::operations::protocol::document::DocumentPatchError;
 use crate::operations::protocol::service_lifecycle::{
-    DisableMutationError, RestService, ServiceLifecycle, check_disable_preconditions, publish_patch,
+    DisableMutationError, ServiceLifecycle, TspService, check_disable_preconditions, publish_patch,
 };
 use crate::operations::protocol::{OpContext, ServiceOpDeps};
 use crate::operations::protocol::{PROTOCOL_LOCK, snapshot};
 
 #[derive(Debug, Clone, Default)]
-pub struct DisableRestParams;
+pub struct DisableTspParams;
 
 #[derive(Debug, Clone)]
-pub struct DisableRestResult {
+pub struct DisableTspResult {
     pub new_version_id: String,
-    /// Pre-disable URL — recorded so callers / telemetry / audit can graph
-    /// what was just unadvertised.
-    pub prior_url: String,
-    /// The VTA's own DID. See [`super::enable_rest::EnableRestResult`].
+    /// Pre-disable mediator DID — recorded so callers / telemetry / audit
+    /// can graph what was just unadvertised.
+    pub prior_mediator_did: String,
+    /// The VTA's own DID. See [`super::enable_tsp::EnableTspResult`].
     pub vta_did: String,
     /// True when the VTA's DID is self-hosted.
     pub serverless: bool,
 }
 
 #[derive(Debug, Error)]
-pub enum DisableRestError {
-    #[error("REST is not currently enabled — nothing to disable.")]
+pub enum DisableTspError {
+    #[error("TSP is not currently enabled — nothing to disable.")]
     ServiceNotPresent,
     #[error(
         "refusing operation: would leave the VTA with no advertised services. \
@@ -79,14 +79,14 @@ pub enum DisableRestError {
     Storage(String),
 }
 
-impl From<AppError> for DisableRestError {
+impl From<AppError> for DisableTspError {
     fn from(value: AppError) -> Self {
         Self::Storage(value.to_string())
     }
 }
 
 impl From<crate::operations::protocol::preconditions::ProtocolPreconditionError>
-    for DisableRestError
+    for DisableTspError
 {
     fn from(value: crate::operations::protocol::preconditions::ProtocolPreconditionError) -> Self {
         use crate::operations::protocol::preconditions::ProtocolPreconditionError as E;
@@ -104,7 +104,7 @@ impl From<crate::operations::protocol::preconditions::ProtocolPreconditionError>
 /// typed variant. Other [`VtaError`] shapes shouldn't surface here — the helper
 /// is total over its inputs — but if one ever does we route it through
 /// `Storage` so it isn't silently swallowed.
-impl From<VtaError> for DisableRestError {
+impl From<VtaError> for DisableTspError {
     fn from(value: VtaError) -> Self {
         match value {
             VtaError::LastServiceRefused => Self::LastServiceRefused,
@@ -113,66 +113,60 @@ impl From<VtaError> for DisableRestError {
     }
 }
 
-impl DisableMutationError for DisableRestError {
+impl DisableMutationError for DisableTspError {
     fn not_present() -> Self {
         Self::ServiceNotPresent
     }
 }
 
-pub async fn disable_rest(
+pub async fn disable_tsp(
     deps: &ServiceOpDeps<'_>,
     auth: &AuthClaims,
-    _params: DisableRestParams,
+    _params: DisableTspParams,
     ctx: OpContext,
     channel: &str,
-) -> Result<DisableRestResult, DisableRestError> {
+) -> Result<DisableTspResult, DisableTspError> {
     auth.require_super_admin()
-        .map_err(|e| DisableRestError::Auth(e.to_string()))?;
+        .map_err(|e| DisableTspError::Auth(e.to_string()))?;
 
     let _guard = PROTOCOL_LOCK.lock().await;
 
-    // Brick-prevention (§3.2) + preconditions, capturing the prior URL.
-    let (state, prior_url) =
-        check_disable_preconditions::<RestService, DisableRestError>(deps.config, deps.webvh_ks)
+    // Brick-prevention (§3.2) + preconditions, capturing the prior mediator.
+    let (state, prior_mediator_did) =
+        check_disable_preconditions::<TspService, DisableTspError>(deps.config, deps.webvh_ks)
             .await?;
 
-    // Snapshot BEFORE the mutation (spec §3.5a): pre-state is the prior URL.
+    // Snapshot BEFORE the mutation (spec §3.5a): pre-state is the prior mediator.
     snapshot::write(
         deps.snapshot_ks,
-        RestService::snapshot_enabled(prior_url.clone()),
+        TspService::snapshot_enabled(prior_mediator_did.clone()),
     )
     .await
-    .map_err(|e| DisableRestError::Storage(format!("snapshot write: {e}")))?;
+    .map_err(|e| DisableTspError::Storage(format!("snapshot write: {e}")))?;
 
-    let patched = RestService::without_service(state.current_doc);
-    let update_result = publish_patch::<DisableRestError>(
-        deps,
-        auth,
-        &state.scid,
-        &state.vta_did,
-        patched,
-        channel,
-    )
-    .await?;
+    let patched = TspService::without_service(state.current_doc);
+    let update_result =
+        publish_patch::<DisableTspError>(deps, auth, &state.scid, &state.vta_did, patched, channel)
+            .await?;
 
-    // Persist services.rest = false to fjall (authoritative runtime state) +
+    // Persist services.tsp = false to fjall (authoritative runtime state) +
     // mirror into the in-memory config. Same post-publish risk window as the
     // other ops if this fails — operator retries.
-    crate::operations::protocol::runtime_state::set_rest_enabled(deps.service_state_ks, false)
+    crate::operations::protocol::runtime_state::set_tsp_enabled(deps.service_state_ks, false)
         .await
-        .map_err(|e| DisableRestError::Storage(format!("runtime state: {e}")))?;
+        .map_err(|e| DisableTspError::Storage(format!("runtime state: {e}")))?;
     {
         let mut cfg = deps.config.write().await;
-        cfg.services.rest = false;
+        cfg.services.tsp = false;
     }
 
-    let mut event = TelemetryEvent::new(TelemetryKind::ServicesRestDisable)
+    let mut event = TelemetryEvent::new(TelemetryKind::ServicesTspDisable)
         .with_field("channel", JsonValue::from(channel))
         .with_field(
             "new_version_id",
             JsonValue::from(update_result.new_version_id.clone()),
         )
-        .with_field("prior_url", JsonValue::from(prior_url.clone()));
+        .with_field("prior_url", JsonValue::from(prior_mediator_did.clone()));
     if let Some(tag) = ctx.telemetry_triggered_by() {
         event = event.with_field("triggered_by", JsonValue::from(tag));
     }
@@ -180,15 +174,15 @@ pub async fn disable_rest(
 
     info!(
         channel,
-        prior_url = %prior_url,
+        prior_mediator_did = %prior_mediator_did,
         new_version_id = %update_result.new_version_id,
         vta_did = %state.vta_did,
-        "REST disabled"
+        "TSP disabled"
     );
 
-    Ok(DisableRestResult {
+    Ok(DisableTspResult {
         new_version_id: update_result.new_version_id,
-        prior_url,
+        prior_mediator_did,
         vta_did: state.vta_did,
         serverless: update_result.serverless,
     })
@@ -209,8 +203,8 @@ mod tests {
     use crate::store::{KeyspaceHandle, Store};
     use vti_common::config::StoreConfig as VtiStoreConfig;
 
-    /// Mirrors the test fixture in enable_rest / update_rest — owns the fjall
-    /// store so a single test can derive multiple keyspaces from one handle.
+    /// Mirrors the test fixture in disable_rest — owns the fjall store so a
+    /// single test can derive multiple keyspaces from one handle.
     struct TestFixture {
         _dir: tempfile::TempDir,
         config: Arc<RwLock<AppConfig>>,
@@ -223,12 +217,17 @@ mod tests {
         }
     }
 
-    fn build_fixture(rest_initially: bool, didcomm_initially: bool) -> TestFixture {
+    fn build_fixture(tsp_initially: bool, didcomm_initially: bool) -> TestFixture {
         use crate::test_support::test_app_config;
         let dir = tempfile::tempdir().unwrap();
         let mut cfg = test_app_config(dir.path().into());
-        cfg.services.rest = rest_initially;
+        cfg.services.tsp = tsp_initially;
         cfg.services.didcomm = didcomm_initially;
+        // REST defaults on in `test_app_config`; turn it off so DIDComm is
+        // the only *other* transport — that makes the "TSP on, DIDComm off"
+        // case a genuine brick (mirrors the disable_rest fixture, where REST
+        // and DIDComm are the only two transports under test).
+        cfg.services.rest = false;
         cfg.vta_did = Some("did:webvh:scid123:host:vta".into());
         cfg.config_path = dir.path().join("vta.toml");
         let initial = toml::to_string_pretty(&cfg).unwrap();
@@ -246,74 +245,57 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn preconditions_reject_when_rest_disabled() {
+    async fn preconditions_reject_when_tsp_disabled() {
         let fx = build_fixture(false, true);
-        let err = check_disable_preconditions::<RestService, DisableRestError>(
-            &fx.config,
-            &fx.webvh_ks(),
-        )
-        .await
-        .unwrap_err();
-        assert!(matches!(err, DisableRestError::ServiceNotPresent));
+        let err =
+            check_disable_preconditions::<TspService, DisableTspError>(&fx.config, &fx.webvh_ks())
+                .await
+                .unwrap_err();
+        assert!(matches!(err, DisableTspError::ServiceNotPresent));
     }
 
-    /// Brick-prevention runs before the doc load: "REST on, DIDComm off"
+    /// Brick-prevention runs before the doc load: "TSP on, DIDComm off"
     /// surfaces as `LastServiceRefused` (not a missing-vta_did storage error).
     #[tokio::test]
     async fn preconditions_reject_when_would_brick() {
         let fx = build_fixture(true, false);
-        let err = check_disable_preconditions::<RestService, DisableRestError>(
-            &fx.config,
-            &fx.webvh_ks(),
-        )
-        .await
-        .unwrap_err();
-        assert!(matches!(err, DisableRestError::LastServiceRefused));
+        let err =
+            check_disable_preconditions::<TspService, DisableTspError>(&fx.config, &fx.webvh_ks())
+                .await
+                .unwrap_err();
+        assert!(matches!(err, DisableTspError::LastServiceRefused));
     }
 
     #[tokio::test]
     async fn preconditions_reject_without_vta_did() {
         let fx = build_fixture(true, true);
         fx.config.write().await.vta_did = None;
-        let err = check_disable_preconditions::<RestService, DisableRestError>(
-            &fx.config,
-            &fx.webvh_ks(),
-        )
-        .await
-        .unwrap_err();
-        assert!(matches!(err, DisableRestError::VtaDidNotConfigured));
+        let err =
+            check_disable_preconditions::<TspService, DisableTspError>(&fx.config, &fx.webvh_ks())
+                .await
+                .unwrap_err();
+        assert!(matches!(err, DisableTspError::VtaDidNotConfigured));
     }
 
     /// The brick-prevention helper is wired correctly: invoking it from a
-    /// "REST on, DIDComm off" state with a disable-rest op must surface as
-    /// `LastServiceRefused`.
+    /// "TSP on, everything else off" state with a disable-tsp op must surface
+    /// as `LastServiceRefused`.
     #[test]
-    fn brick_prevention_rejects_disable_rest_when_didcomm_off() {
+    fn brick_prevention_rejects_disable_tsp_when_others_off() {
         let result = would_violate_last_service(
-            &CurrentServices::new(true, false, false, false),
-            ProposedOp::disable(ServiceKind::Rest),
+            &CurrentServices::new(false, false, false, true),
+            ProposedOp::disable(ServiceKind::Tsp),
         );
-        let err = DisableRestError::from(result.unwrap_err());
-        assert!(matches!(err, DisableRestError::LastServiceRefused));
+        let err = DisableTspError::from(result.unwrap_err());
+        assert!(matches!(err, DisableTspError::LastServiceRefused));
     }
 
-    /// Conversely, brick-prevention accepts disabling REST when DIDComm is on.
+    /// Conversely, brick-prevention accepts disabling TSP when DIDComm is on.
     #[test]
-    fn brick_prevention_allows_disable_rest_when_didcomm_on() {
+    fn brick_prevention_allows_disable_tsp_when_didcomm_on() {
         let result = would_violate_last_service(
-            &CurrentServices::new(true, true, false, false),
-            ProposedOp::disable(ServiceKind::Rest),
-        );
-        assert!(result.is_ok());
-    }
-
-    /// Disabling REST is also allowed when WebAuthn alone is on — WebAuthn
-    /// counts as a transport for invariant purposes.
-    #[test]
-    fn brick_prevention_allows_disable_rest_when_webauthn_on() {
-        let result = would_violate_last_service(
-            &CurrentServices::new(true, false, true, false),
-            ProposedOp::disable(ServiceKind::Rest),
+            &CurrentServices::new(false, true, false, true),
+            ProposedOp::disable(ServiceKind::Tsp),
         );
         assert!(result.is_ok());
     }
@@ -322,11 +304,11 @@ mod tests {
     /// `LastServiceRefused` round-trips into our error variant, and any other
     /// VtaError shape lands in `Storage` (defensive).
     #[test]
-    fn vta_error_to_disable_rest_error_mapping_is_typed() {
-        let mapped = DisableRestError::from(VtaError::LastServiceRefused);
-        assert!(matches!(mapped, DisableRestError::LastServiceRefused));
+    fn vta_error_to_disable_tsp_error_mapping_is_typed() {
+        let mapped = DisableTspError::from(VtaError::LastServiceRefused);
+        assert!(matches!(mapped, DisableTspError::LastServiceRefused));
 
-        let mapped = DisableRestError::from(VtaError::ServiceNotPresent);
-        assert!(matches!(mapped, DisableRestError::Storage(_)));
+        let mapped = DisableTspError::from(VtaError::ServiceNotPresent);
+        assert!(matches!(mapped, DisableTspError::Storage(_)));
     }
 }

--- a/vta-service/src/operations/protocol/enable_tsp.rs
+++ b/vta-service/src/operations/protocol/enable_tsp.rs
@@ -1,0 +1,252 @@
+//! `enable_tsp` operation.
+//!
+//! Spec: `docs/05-design-notes/runtime-service-management.md` §3.4 +
+//! `docs/05-design-notes/tsp-enablement.md`. A thin wrapper over the shared
+//! [`service_lifecycle`](super::service_lifecycle) engine — see [`run_enable`]
+//! for the full sequence (super-admin → PROTOCOL_LOCK → validate mediator DID →
+//! preconditions → snapshot → patch → publish → persist `services.tsp = true` →
+//! telemetry).
+//!
+//! TSP advertises a **mediator DID** (the VTA's TSP VID), not a URL — so the
+//! validate hook checks for a `did:...` string rather than an HTTPS URL. Like
+//! REST, TSP has no drain and no handshake.
+//!
+//! Brick-prevention is **not** consulted — enabling can only add a transport
+//! service, never remove one, so the §3.2 invariant is preserved by
+//! construction.
+
+use thiserror::Error;
+
+use crate::auth::AuthClaims;
+use crate::error::AppError;
+use crate::operations::did_webvh::UpdateDidWebvhError;
+use crate::operations::protocol::document::DocumentPatchError;
+use crate::operations::protocol::service_lifecycle::{
+    EnableMutationError, ServiceMutationError, TspService, run_enable,
+};
+use crate::operations::protocol::{OpContext, ServiceOpDeps};
+
+#[derive(Debug, Clone)]
+pub struct EnableTspParams {
+    /// Mediator DID the VTA will advertise on its `#tsp` service entry
+    /// (the VTA's TSP VID). Validated as a `did:...` string before any
+    /// runtime mutation occurs.
+    pub mediator_did: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct EnableTspResult {
+    pub new_version_id: String,
+    /// The validated mediator DID that was published.
+    pub mediator_did: String,
+    /// The VTA's own DID — subject of the LogEntry this enable wrote.
+    /// Propagated so route + DIDComm response shapes can emit the
+    /// "fetch did.jsonl + redeploy" hint for serverless deployments.
+    pub vta_did: String,
+    /// True when `record.server_id == "serverless"` — the new LogEntry
+    /// is local-only.
+    pub serverless: bool,
+}
+
+#[derive(Debug, Error)]
+pub enum EnableTspError {
+    #[error(
+        "TSP is already enabled. Use `services tsp update --mediator-did <did>` to change the mediator."
+    )]
+    ServiceAlreadyEnabled,
+    #[error("invalid mediator DID: {0}")]
+    Validation(String),
+    #[error("VTA DID is not configured — run `vta setup` first")]
+    VtaDidNotConfigured,
+    #[error("VTA DID `{0}` has no webvh record")]
+    VtaDidRecordMissing(String),
+    #[error("VTA DID `{0}` has no published log")]
+    VtaDidLogMissing(String),
+    #[error("VTA DID log is empty")]
+    EmptyLog,
+    #[error("DID document patch failed: {0}")]
+    DocumentPatch(#[from] DocumentPatchError),
+    #[error("WebVH update failed: {0}")]
+    WebVHUpdate(#[from] UpdateDidWebvhError),
+    #[error("config persistence failed: {0}")]
+    ConfigPersistence(String),
+    #[error("auth: {0}")]
+    Auth(String),
+    #[error("storage error: {0}")]
+    Storage(String),
+}
+
+impl From<AppError> for EnableTspError {
+    fn from(value: AppError) -> Self {
+        Self::Storage(value.to_string())
+    }
+}
+
+impl From<crate::operations::protocol::preconditions::ProtocolPreconditionError>
+    for EnableTspError
+{
+    fn from(value: crate::operations::protocol::preconditions::ProtocolPreconditionError) -> Self {
+        use crate::operations::protocol::preconditions::ProtocolPreconditionError as E;
+        match value {
+            E::VtaDidNotConfigured => Self::VtaDidNotConfigured,
+            E::VtaDidRecordMissing(s) => Self::VtaDidRecordMissing(s),
+            E::VtaDidLogMissing(s) => Self::VtaDidLogMissing(s),
+            E::EmptyLog => Self::EmptyLog,
+            E::Storage(s) | E::DocumentParse(s) => Self::Storage(s),
+        }
+    }
+}
+
+impl ServiceMutationError for EnableTspError {
+    fn validation(msg: String) -> Self {
+        Self::Validation(msg)
+    }
+    fn auth(msg: String) -> Self {
+        Self::Auth(msg)
+    }
+    fn storage(msg: String) -> Self {
+        Self::Storage(msg)
+    }
+}
+
+impl EnableMutationError for EnableTspError {
+    fn already_enabled() -> Self {
+        Self::ServiceAlreadyEnabled
+    }
+    fn config_persistence(msg: String) -> Self {
+        Self::ConfigPersistence(msg)
+    }
+}
+
+pub async fn enable_tsp(
+    deps: &ServiceOpDeps<'_>,
+    auth: &AuthClaims,
+    params: EnableTspParams,
+    ctx: OpContext,
+    channel: &str,
+) -> Result<EnableTspResult, EnableTspError> {
+    // TSP persists "enabled" as runtime state (fjall) + the in-memory flag.
+    // If this fails after publish, the LogEntry advertises TSP but config
+    // disagrees — same risk window as REST; operator retries.
+    let ok = run_enable::<TspService, EnableTspError>(
+        deps,
+        auth,
+        &params.mediator_did,
+        ctx,
+        channel,
+        || async {
+            crate::operations::protocol::runtime_state::set_tsp_enabled(
+                deps.service_state_ks,
+                true,
+            )
+            .await
+            .map_err(|e| format!("runtime state: {e}"))?;
+            deps.config.write().await.services.tsp = true;
+            Ok(())
+        },
+    )
+    .await?;
+
+    Ok(EnableTspResult {
+        new_version_id: ok.new_version_id,
+        mediator_did: ok.canonical_url,
+        vta_did: ok.vta_did,
+        serverless: ok.serverless,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use tokio::sync::RwLock;
+
+    use super::*;
+    use crate::config::AppConfig;
+    use crate::operations::protocol::service_lifecycle::{TspService, check_enable_preconditions};
+    use crate::operations::protocol::snapshot::{self, ServiceKind};
+    use crate::store::{KeyspaceHandle, Store};
+    use vti_common::config::StoreConfig as VtiStoreConfig;
+
+    /// Owns the on-disk fjall store so all keyspaces a test reaches for
+    /// share a single open handle (fjall locks the data dir on each open).
+    struct TestFixture {
+        _dir: tempfile::TempDir,
+        config: Arc<RwLock<AppConfig>>,
+        store: Store,
+    }
+
+    impl TestFixture {
+        fn snapshot_ks(&self) -> KeyspaceHandle {
+            self.store.keyspace(snapshot::KEYSPACE_NAME).unwrap()
+        }
+        fn webvh_ks(&self) -> KeyspaceHandle {
+            self.store.keyspace(crate::keyspaces::WEBVH).unwrap()
+        }
+    }
+
+    fn build_fixture(tsp_initially: bool) -> TestFixture {
+        use crate::test_support::test_app_config;
+        let dir = tempfile::tempdir().unwrap();
+        let mut cfg = test_app_config(dir.path().into());
+        cfg.services.tsp = tsp_initially;
+        // §3.2 brick-prevention: keep DIDComm on so an enable-tsp test
+        // never needs to consider the no-transport edge case.
+        cfg.services.didcomm = true;
+        cfg.vta_did = Some("did:webvh:scid123:host:vta".into());
+        cfg.config_path = dir.path().join("vta.toml");
+        let initial = toml::to_string_pretty(&cfg).unwrap();
+        std::fs::write(&cfg.config_path, initial).unwrap();
+
+        let store = Store::open(&VtiStoreConfig {
+            data_dir: dir.path().into(),
+        })
+        .unwrap();
+        TestFixture {
+            _dir: dir,
+            config: Arc::new(RwLock::new(cfg)),
+            store,
+        }
+    }
+
+    #[tokio::test]
+    async fn preconditions_reject_when_already_enabled() {
+        let fx = build_fixture(true);
+        let err =
+            check_enable_preconditions::<TspService, EnableTspError>(&fx.config, &fx.webvh_ks())
+                .await
+                .unwrap_err();
+        assert!(matches!(err, EnableTspError::ServiceAlreadyEnabled));
+    }
+
+    #[tokio::test]
+    async fn preconditions_reject_without_vta_did() {
+        let fx = build_fixture(false);
+        fx.config.write().await.vta_did = None;
+        let err =
+            check_enable_preconditions::<TspService, EnableTspError>(&fx.config, &fx.webvh_ks())
+                .await
+                .unwrap_err();
+        assert!(matches!(err, EnableTspError::VtaDidNotConfigured));
+    }
+
+    /// Mediator-DID validation runs first, before any storage reads. A
+    /// non-DID value never reaches the snapshot layer.
+    #[tokio::test]
+    async fn enable_tsp_did_validation_runs_before_persist() {
+        use crate::operations::protocol::service_lifecycle::ServiceLifecycle;
+        let fx = build_fixture(false);
+        let snapshot_ks = fx.snapshot_ks();
+
+        let validated = TspService::validate("https://not-a-did.example.com");
+        assert!(validated.is_err(), "non-did:... must be rejected");
+
+        assert!(
+            snapshot::read(&snapshot_ks, ServiceKind::Tsp)
+                .await
+                .unwrap()
+                .is_none(),
+            "validation error must abort before snapshot write",
+        );
+    }
+}

--- a/vta-service/src/operations/protocol/invariant.rs
+++ b/vta-service/src/operations/protocol/invariant.rs
@@ -2,8 +2,8 @@
 //!
 //! Spec: `docs/05-design-notes/runtime-service-management.md` §3.2.
 //!
-//! At least one transport service (REST, DIDComm, or WebAuthn) must
-//! be advertised in the VTA's DID document at all times. Disable /
+//! At least one transport service (REST, DIDComm, WebAuthn, or TSP)
+//! must be advertised in the VTA's DID document at all times. Disable /
 //! rollback paths funnel through [`would_violate_last_service`] to
 //! enforce this — there is no `--force` escape hatch and no
 //! per-call-site duplication of the predicate.
@@ -37,14 +37,21 @@ pub struct CurrentServices {
     pub rest_enabled: bool,
     pub didcomm_enabled: bool,
     pub webauthn_enabled: bool,
+    pub tsp_enabled: bool,
 }
 
 impl CurrentServices {
-    pub const fn new(rest_enabled: bool, didcomm_enabled: bool, webauthn_enabled: bool) -> Self {
+    pub const fn new(
+        rest_enabled: bool,
+        didcomm_enabled: bool,
+        webauthn_enabled: bool,
+        tsp_enabled: bool,
+    ) -> Self {
         Self {
             rest_enabled,
             didcomm_enabled,
             webauthn_enabled,
+            tsp_enabled,
         }
     }
 }
@@ -98,24 +105,33 @@ impl ProposedOp {
 /// over the supplied state, making it cheap to call defensively
 /// (e.g. as the first thing inside a mutation entry point).
 pub fn would_violate_last_service(state: &CurrentServices, op: ProposedOp) -> Result<(), VtaError> {
-    let (rest_after, didcomm_after, webauthn_after) = match op.kind {
+    let (rest_after, didcomm_after, webauthn_after, tsp_after) = match op.kind {
         ServiceKind::Rest => (
             op.kind_will_be_enabled,
             state.didcomm_enabled,
             state.webauthn_enabled,
+            state.tsp_enabled,
         ),
         ServiceKind::Didcomm => (
             state.rest_enabled,
             op.kind_will_be_enabled,
             state.webauthn_enabled,
+            state.tsp_enabled,
         ),
         ServiceKind::Webauthn => (
             state.rest_enabled,
             state.didcomm_enabled,
             op.kind_will_be_enabled,
+            state.tsp_enabled,
+        ),
+        ServiceKind::Tsp => (
+            state.rest_enabled,
+            state.didcomm_enabled,
+            state.webauthn_enabled,
+            op.kind_will_be_enabled,
         ),
     };
-    if !rest_after && !didcomm_after && !webauthn_after {
+    if !rest_after && !didcomm_after && !webauthn_after && !tsp_after {
         return Err(VtaError::LastServiceRefused);
     }
     Ok(())
@@ -132,10 +148,10 @@ mod tests {
     /// state). Webauthn is always off in S0/S1/S2/S3 — the
     /// post-WebAuthn truth table is exercised by
     /// `full_truth_table_with_webauthn` below.
-    const S0: CurrentServices = CurrentServices::new(false, false, false);
-    const S1: CurrentServices = CurrentServices::new(true, false, false); // rest only
-    const S2: CurrentServices = CurrentServices::new(false, true, false); // didcomm only
-    const S3: CurrentServices = CurrentServices::new(true, true, false);
+    const S0: CurrentServices = CurrentServices::new(false, false, false, false);
+    const S1: CurrentServices = CurrentServices::new(true, false, false, false); // rest only
+    const S2: CurrentServices = CurrentServices::new(false, true, false, false); // didcomm only
+    const S3: CurrentServices = CurrentServices::new(true, true, false, false);
 
     /// Disabling either kind from S3 leaves the other on — never
     /// rejects.
@@ -185,6 +201,7 @@ mod tests {
                 ServiceKind::Rest,
                 ServiceKind::Didcomm,
                 ServiceKind::Webauthn,
+                ServiceKind::Tsp,
             ] {
                 assert!(
                     would_violate_last_service(state, ProposedOp::enable(*kind)).is_ok(),
@@ -199,7 +216,7 @@ mod tests {
     /// would.
     #[test]
     fn webauthn_only_state_cannot_disable_webauthn() {
-        let s_w = CurrentServices::new(false, false, true);
+        let s_w = CurrentServices::new(false, false, true, false);
         let err = would_violate_last_service(&s_w, ProposedOp::disable(ServiceKind::Webauthn))
             .unwrap_err();
         assert!(matches!(err, VtaError::LastServiceRefused));
@@ -209,27 +226,49 @@ mod tests {
     /// both off — disabling either of them must be accepted.
     #[test]
     fn webauthn_keeps_invariant_when_other_two_disabled() {
-        let s_w = CurrentServices::new(false, false, true);
+        let s_w = CurrentServices::new(false, false, true, false);
         assert!(would_violate_last_service(&s_w, ProposedOp::disable(ServiceKind::Rest)).is_ok());
         assert!(
             would_violate_last_service(&s_w, ProposedOp::disable(ServiceKind::Didcomm)).is_ok()
         );
     }
 
-    /// With all three on, disabling any single kind is fine.
+    /// With all four on, disabling any single kind is fine.
     #[test]
     fn all_three_on_any_single_disable_is_ok() {
-        let s_all = CurrentServices::new(true, true, true);
+        let s_all = CurrentServices::new(true, true, true, true);
         for kind in &[
             ServiceKind::Rest,
             ServiceKind::Didcomm,
             ServiceKind::Webauthn,
+            ServiceKind::Tsp,
         ] {
             assert!(
                 would_violate_last_service(&s_all, ProposedOp::disable(*kind)).is_ok(),
                 "all-on, disable {kind:?} must be accepted",
             );
         }
+    }
+
+    /// TSP-only state — disabling TSP would brick the VTA the same
+    /// way disabling the only-enabled REST or DIDComm would.
+    #[test]
+    fn tsp_only_state_cannot_disable_tsp() {
+        let s_t = CurrentServices::new(false, false, false, true);
+        let err =
+            would_violate_last_service(&s_t, ProposedOp::disable(ServiceKind::Tsp)).unwrap_err();
+        assert!(matches!(err, VtaError::LastServiceRefused));
+    }
+
+    /// TSP keeps a VTA alive even when REST and DIDComm are both off
+    /// — disabling either of them must be accepted.
+    #[test]
+    fn tsp_keeps_invariant_when_other_two_disabled() {
+        let s_t = CurrentServices::new(false, false, false, true);
+        assert!(would_violate_last_service(&s_t, ProposedOp::disable(ServiceKind::Rest)).is_ok());
+        assert!(
+            would_violate_last_service(&s_t, ProposedOp::disable(ServiceKind::Didcomm)).is_ok()
+        );
     }
 
     /// From S0 (already bricked), enabling either kind brings the

--- a/vta-service/src/operations/protocol/mod.rs
+++ b/vta-service/src/operations/protocol/mod.rs
@@ -8,11 +8,13 @@
 
 pub mod disable_didcomm;
 pub mod disable_rest;
+pub mod disable_tsp;
 pub mod disable_webauthn;
 pub mod document;
 pub mod drain_cancel;
 pub mod enable_didcomm;
 pub mod enable_rest;
+pub mod enable_tsp;
 pub mod enable_webauthn;
 pub mod invariant;
 pub mod list;
@@ -22,12 +24,14 @@ pub mod preconditions;
 pub mod report;
 pub mod rollback_didcomm;
 pub mod rollback_rest;
+pub mod rollback_tsp;
 pub mod rollback_webauthn;
 pub mod runtime_state;
 pub(crate) mod service_lifecycle;
 pub mod snapshot;
 pub mod update_didcomm;
 pub mod update_rest;
+pub mod update_tsp;
 pub mod update_webauthn;
 
 /// Process-wide lock serializing every service-management mutation

--- a/vta-service/src/operations/protocol/rollback_tsp.rs
+++ b/vta-service/src/operations/protocol/rollback_tsp.rs
@@ -1,0 +1,385 @@
+//! `rollback_tsp` operation — fail-forward dispatch.
+//!
+//! Spec: `docs/05-design-notes/runtime-service-management.md` §3.5a +
+//! `docs/05-design-notes/tsp-enablement.md`.
+//!
+//! Reads the per-kind snapshot store for `tsp` and dispatches into the
+//! equivalent **forward** operation that returns the VTA's TSP advertisement to
+//! the pre-mutation state. WebVH is append-only; rollback never rewinds the
+//! chain — it appends a new LogEntry whose `service[]` matches the snapshot.
+//!
+//! Dispatch table (mirrors [`super::rollback_rest`], mediator DID in place of
+//! URL):
+//!
+//! | snapshot         | current state    | dispatched op            |
+//! |------------------|------------------|--------------------------|
+//! | `Disabled`       | enabled          | `disable_tsp`            |
+//! | `Enabled { X }`  | disabled         | `enable_tsp` with X      |
+//! | `Enabled { X }`  | enabled with Y   | `update_tsp` with X      |
+//! | `Disabled`       | disabled         | no-op (snapshot≡current) |
+//! | `Enabled { X }`  | enabled with X   | no-op (snapshot≡current) |
+//!
+//! No-op rollbacks happen when (a) a previous mutation crashed between
+//! snapshot persist and runtime mutation, or (b) the operator runs `rollback`
+//! twice in a row. Both are valid; the operator sees a result with
+//! `new_version_id: None` and a `kind == NoOp` marker.
+//!
+//! Brick-prevention is enforced by the dispatched forward op (its disable path
+//! already calls [`would_violate_last_service`]). The §7a.5 rollback histories
+//! that resolve to `LastServiceRefused` surface the typed error from the
+//! forward op verbatim.
+
+use std::sync::Arc;
+
+use thiserror::Error;
+use tokio::sync::RwLock;
+use tracing::info;
+
+use crate::auth::AuthClaims;
+use crate::config::AppConfig;
+use crate::error::AppError;
+use crate::operations::did_webvh::UpdateDidWebvhError;
+use crate::operations::protocol::disable_tsp::{DisableTspError, DisableTspParams, disable_tsp};
+use crate::operations::protocol::document::{DocumentPatchError, current_tsp_service};
+use crate::operations::protocol::enable_tsp::{EnableTspError, EnableTspParams, enable_tsp};
+use crate::operations::protocol::snapshot::{
+    self, ServiceConfigSnapshot, ServiceKind, TspSnapshot,
+};
+use crate::operations::protocol::update_tsp::{UpdateTspError, UpdateTspParams, update_tsp};
+use crate::operations::protocol::{OpContext, ServiceOpDeps};
+use crate::store::KeyspaceHandle;
+
+#[derive(Debug, Clone, Default)]
+pub struct RollbackTspParams;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RollbackKind {
+    /// Snapshot was `Disabled`; rollback re-disabled TSP.
+    Disabled,
+    /// Snapshot was `Enabled { mediator_did }`; rollback re-enabled TSP
+    /// at the prior mediator (forward operation: enable_tsp).
+    Enabled,
+    /// Snapshot was `Enabled { mediator_did }`; rollback restored the
+    /// prior mediator on an existing entry (forward operation: update_tsp).
+    Updated,
+    /// Snapshot ≡ current state. No LogEntry was published.
+    NoOp,
+}
+
+#[derive(Debug, Clone)]
+pub struct RollbackTspResult {
+    /// `Some(version_id)` when a LogEntry was published, `None` when the
+    /// rollback was a no-op (snapshot ≡ current).
+    pub new_version_id: Option<String>,
+    pub kind: RollbackKind,
+    /// The VTA's own DID. Empty for no-op rollbacks (no LogEntry was
+    /// written). See [`super::enable_tsp::EnableTspResult`].
+    pub vta_did: String,
+    /// True when the VTA's DID is self-hosted. `false` on no-op rollbacks
+    /// (no follow-up redeploy needed).
+    pub serverless: bool,
+}
+
+#[derive(Debug, Error)]
+pub enum RollbackTspError {
+    #[error(
+        "no prior mutation for `services tsp` to roll back from. \
+         Use `services tsp enable / update / disable` directly instead."
+    )]
+    NoPriorMutation,
+    #[error("VTA DID is not configured — run `vta setup` first")]
+    VtaDidNotConfigured,
+    #[error("VTA DID `{0}` has no webvh record")]
+    VtaDidRecordMissing(String),
+    #[error("VTA DID `{0}` has no published log")]
+    VtaDidLogMissing(String),
+    #[error("VTA DID log is empty")]
+    EmptyLog,
+
+    /// Forward dispatch into `enable_tsp` failed. The inner error carries
+    /// any typed variants the operator should act on (e.g. `Validation` if
+    /// the snapshotted mediator DID is malformed — shouldn't happen since
+    /// the snapshot was written by an already-validated forward op, but
+    /// defensive).
+    #[error(transparent)]
+    EnableForward(#[from] EnableTspError),
+    /// Forward dispatch into `update_tsp` failed.
+    #[error(transparent)]
+    UpdateForward(#[from] UpdateTspError),
+    /// Forward dispatch into `disable_tsp` failed. Includes
+    /// `LastServiceRefused` (rollback would brick the VTA per spec §7a.5 —
+    /// operator must enable another transport first).
+    #[error(transparent)]
+    DisableForward(#[from] DisableTspError),
+
+    /// Document patch failed mid-rollback. Surfaced separately so the CLI
+    /// can distinguish a snapshot-corruption from a pre-mutation refusal.
+    #[error("DID document patch failed: {0}")]
+    DocumentPatch(#[from] DocumentPatchError),
+    #[error("WebVH update failed: {0}")]
+    WebVHUpdate(#[from] UpdateDidWebvhError),
+    #[error("auth: {0}")]
+    Auth(String),
+    #[error("storage error: {0}")]
+    Storage(String),
+}
+
+impl From<AppError> for RollbackTspError {
+    fn from(value: AppError) -> Self {
+        Self::Storage(value.to_string())
+    }
+}
+
+impl From<crate::operations::protocol::preconditions::ProtocolPreconditionError>
+    for RollbackTspError
+{
+    fn from(value: crate::operations::protocol::preconditions::ProtocolPreconditionError) -> Self {
+        use crate::operations::protocol::preconditions::ProtocolPreconditionError as E;
+        match value {
+            E::VtaDidNotConfigured => Self::VtaDidNotConfigured,
+            E::VtaDidRecordMissing(s) => Self::VtaDidRecordMissing(s),
+            E::VtaDidLogMissing(s) => Self::VtaDidLogMissing(s),
+            E::EmptyLog => Self::EmptyLog,
+            E::Storage(s) | E::DocumentParse(s) => Self::Storage(s),
+        }
+    }
+}
+
+pub async fn rollback_tsp(
+    deps: &ServiceOpDeps<'_>,
+    auth: &AuthClaims,
+    _params: RollbackTspParams,
+    channel: &str,
+) -> Result<RollbackTspResult, RollbackTspError> {
+    auth.require_super_admin()
+        .map_err(|e| RollbackTspError::Auth(e.to_string()))?;
+
+    // 1. Read the snapshot. None → NoPriorMutation. Note: we do NOT take
+    //    PROTOCOL_LOCK here because the dispatched forward op takes it;
+    //    holding it twice would deadlock.
+    let snap = snapshot::read(deps.snapshot_ks, ServiceKind::Tsp)
+        .await
+        .map_err(|e| RollbackTspError::Storage(format!("snapshot read: {e}")))?
+        .ok_or(RollbackTspError::NoPriorMutation)?;
+    let tsp_snap = match snap {
+        ServiceConfigSnapshot::Tsp(s) => s,
+        other => {
+            // `snapshot::read` already validates the variant tag matches the
+            // requested kind; if we land here the snapshot module's invariant
+            // is broken. Surface it.
+            return Err(RollbackTspError::Storage(format!(
+                "snapshot kind mismatch: stored {other:?}, requested Tsp",
+            )));
+        }
+    };
+
+    // 2. Read the current TSP state from the on-chain DID document. It's
+    //    authoritative for the rollback decision (it's what the snapshot is
+    //    compared against); config is asserted to match by the forward ops'
+    //    precondition checks.
+    let current_mediator = read_current_tsp_mediator(deps.config, deps.webvh_ks).await?;
+
+    // 3. Dispatch table (see module doc).
+    info!(
+        channel,
+        snapshot = ?tsp_snap,
+        current = ?current_mediator,
+        "rollback_tsp dispatching",
+    );
+    match (tsp_snap, current_mediator.as_deref()) {
+        // Snapshot says off, currently on → disable.
+        (TspSnapshot::Disabled, Some(_)) => {
+            let result =
+                disable_tsp(deps, auth, DisableTspParams, OpContext::Rollback, channel).await?;
+            Ok(RollbackTspResult {
+                new_version_id: Some(result.new_version_id),
+                kind: RollbackKind::Disabled,
+                vta_did: result.vta_did,
+                serverless: result.serverless,
+            })
+        }
+
+        // Snapshot says on with mediator X, currently off → enable.
+        (TspSnapshot::Enabled { mediator_did }, None) => {
+            let result = enable_tsp(
+                deps,
+                auth,
+                EnableTspParams {
+                    mediator_did: mediator_did.clone(),
+                },
+                OpContext::Rollback,
+                channel,
+            )
+            .await?;
+            Ok(RollbackTspResult {
+                new_version_id: Some(result.new_version_id),
+                kind: RollbackKind::Enabled,
+                vta_did: result.vta_did,
+                serverless: result.serverless,
+            })
+        }
+
+        // Snapshot says on with mediator X, currently on with Y where
+        // X != Y → update.
+        (TspSnapshot::Enabled { mediator_did }, Some(current)) if mediator_did != current => {
+            let result = update_tsp(
+                deps,
+                auth,
+                UpdateTspParams {
+                    mediator_did: mediator_did.clone(),
+                },
+                OpContext::Rollback,
+                channel,
+            )
+            .await?;
+            Ok(RollbackTspResult {
+                new_version_id: Some(result.new_version_id),
+                kind: RollbackKind::Updated,
+                vta_did: result.vta_did,
+                serverless: result.serverless,
+            })
+        }
+
+        // Snapshot ≡ current state. No LogEntry, no telemetry.
+        _ => {
+            info!(
+                channel,
+                "rollback_tsp: snapshot matches current state — no-op"
+            );
+            Ok(RollbackTspResult {
+                new_version_id: None,
+                kind: RollbackKind::NoOp,
+                vta_did: String::new(),
+                serverless: false,
+            })
+        }
+    }
+}
+
+/// Read the currently-advertised TSP mediator DID from the on-chain DID
+/// document. Returns `None` when no `#tsp` entry is present.
+async fn read_current_tsp_mediator(
+    config: &Arc<RwLock<AppConfig>>,
+    webvh_ks: &KeyspaceHandle,
+) -> Result<Option<String>, RollbackTspError> {
+    let state = super::preconditions::load_vta_doc_state(config, webvh_ks).await?;
+    Ok(current_tsp_service(&state.current_doc).map(|svc| svc.mediator_did))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::Store;
+    use vti_common::config::StoreConfig as VtiStoreConfig;
+
+    /// Owns the fjall store so a test can derive multiple keyspace handles
+    /// from the same open instance — fjall locks the data dir on each open.
+    struct TestFixture {
+        _dir: tempfile::TempDir,
+        _config: Arc<RwLock<AppConfig>>,
+        store: Store,
+    }
+
+    impl TestFixture {
+        fn snapshot_ks(&self) -> KeyspaceHandle {
+            self.store.keyspace(snapshot::KEYSPACE_NAME).unwrap()
+        }
+    }
+
+    fn build_fixture(tsp: bool, didcomm: bool) -> TestFixture {
+        use crate::test_support::test_app_config;
+        let dir = tempfile::tempdir().unwrap();
+        let mut cfg = test_app_config(dir.path().into());
+        cfg.services.tsp = tsp;
+        cfg.services.didcomm = didcomm;
+        cfg.vta_did = Some("did:webvh:scid123:host:vta".into());
+        cfg.config_path = dir.path().join("vta.toml");
+        let initial = toml::to_string_pretty(&cfg).unwrap();
+        std::fs::write(&cfg.config_path, initial).unwrap();
+        let store = Store::open(&VtiStoreConfig {
+            data_dir: dir.path().into(),
+        })
+        .unwrap();
+        TestFixture {
+            _dir: dir,
+            _config: Arc::new(RwLock::new(cfg)),
+            store,
+        }
+    }
+
+    /// `rollback_tsp` returns `NoPriorMutation` when the snapshot keyspace
+    /// is empty.
+    #[tokio::test]
+    async fn no_prior_mutation_when_snapshot_empty() {
+        let fx = build_fixture(true, true);
+        let snapshot_ks = fx.snapshot_ks();
+        let snap = snapshot::read(&snapshot_ks, ServiceKind::Tsp)
+            .await
+            .unwrap();
+        assert!(snap.is_none());
+
+        let err = RollbackTspError::NoPriorMutation;
+        let msg = err.to_string();
+        assert!(msg.contains("no prior mutation"));
+    }
+
+    /// Round-trip: write `Disabled` snapshot → reading it back and
+    /// inspecting the variant matches the expected dispatch arm.
+    #[tokio::test]
+    async fn snapshot_disabled_round_trips() {
+        let fx = build_fixture(true, true);
+        let snapshot_ks = fx.snapshot_ks();
+        snapshot::write(
+            &snapshot_ks,
+            ServiceConfigSnapshot::Tsp(TspSnapshot::Disabled),
+        )
+        .await
+        .unwrap();
+
+        let read = snapshot::read(&snapshot_ks, ServiceKind::Tsp)
+            .await
+            .unwrap()
+            .unwrap();
+        match read {
+            ServiceConfigSnapshot::Tsp(TspSnapshot::Disabled) => {}
+            other => panic!("expected Tsp(Disabled), got {other:?}"),
+        }
+    }
+
+    /// Round-trip: write `Enabled { mediator_did: X }` snapshot → reading it
+    /// back returns the mediator X.
+    #[tokio::test]
+    async fn snapshot_enabled_with_mediator_round_trips() {
+        let fx = build_fixture(true, true);
+        let snapshot_ks = fx.snapshot_ks();
+        snapshot::write(
+            &snapshot_ks,
+            ServiceConfigSnapshot::Tsp(TspSnapshot::Enabled {
+                mediator_did: "did:webvh:scid:host:prior-mediator".into(),
+            }),
+        )
+        .await
+        .unwrap();
+
+        let read = snapshot::read(&snapshot_ks, ServiceKind::Tsp)
+            .await
+            .unwrap()
+            .unwrap();
+        match read {
+            ServiceConfigSnapshot::Tsp(TspSnapshot::Enabled { mediator_did }) => {
+                assert_eq!(mediator_did, "did:webvh:scid:host:prior-mediator");
+            }
+            other => panic!("expected Tsp(Enabled {{ mediator_did }}), got {other:?}"),
+        }
+    }
+
+    /// `RollbackKind` discriminants cover the four cases the dispatch table
+    /// produces. Pin the public surface so the CLI layer can rely on it.
+    #[test]
+    fn rollback_kind_variants_are_distinct() {
+        assert_ne!(RollbackKind::Disabled, RollbackKind::Enabled);
+        assert_ne!(RollbackKind::Enabled, RollbackKind::Updated);
+        assert_ne!(RollbackKind::Updated, RollbackKind::NoOp);
+        assert_ne!(RollbackKind::NoOp, RollbackKind::Disabled);
+    }
+}

--- a/vta-service/src/operations/protocol/runtime_state.rs
+++ b/vta-service/src/operations/protocol/runtime_state.rs
@@ -21,6 +21,7 @@ use crate::store::KeyspaceHandle;
 
 const REST_KEY: &str = "runtime-state:service:rest";
 const DIDCOMM_KEY: &str = "runtime-state:service:didcomm";
+const TSP_KEY: &str = "runtime-state:service:tsp";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct ServiceState {
@@ -48,6 +49,19 @@ pub async fn is_didcomm_enabled(ks: &KeyspaceHandle) -> Result<bool, AppError> {
         .unwrap_or(true))
 }
 
+/// True if TSP should be active (advertised + bridged to a mediator).
+/// Defaults to **disabled** when no state has been written yet — TSP is
+/// additive and off-by-default while it rolls out gated (see
+/// `docs/05-design-notes/tsp-enablement.md`), so a freshly-built VTA does
+/// not advertise TSP until the operator enables it explicitly.
+pub async fn is_tsp_enabled(ks: &KeyspaceHandle) -> Result<bool, AppError> {
+    Ok(ks
+        .get::<ServiceState>(TSP_KEY.to_string())
+        .await?
+        .map(|s| s.enabled)
+        .unwrap_or(false))
+}
+
 pub async fn set_rest_enabled(ks: &KeyspaceHandle, enabled: bool) -> Result<(), AppError> {
     ks.insert(REST_KEY.to_string(), &ServiceState { enabled })
         .await
@@ -55,6 +69,11 @@ pub async fn set_rest_enabled(ks: &KeyspaceHandle, enabled: bool) -> Result<(), 
 
 pub async fn set_didcomm_enabled(ks: &KeyspaceHandle, enabled: bool) -> Result<(), AppError> {
     ks.insert(DIDCOMM_KEY.to_string(), &ServiceState { enabled })
+        .await
+}
+
+pub async fn set_tsp_enabled(ks: &KeyspaceHandle, enabled: bool) -> Result<(), AppError> {
+    ks.insert(TSP_KEY.to_string(), &ServiceState { enabled })
         .await
 }
 
@@ -77,6 +96,9 @@ pub async fn migrate_from_config(ks: &KeyspaceHandle, config: &AppConfig) -> Res
         .is_none()
     {
         set_didcomm_enabled(ks, config.services.didcomm).await?;
+    }
+    if ks.get::<ServiceState>(TSP_KEY.to_string()).await?.is_none() {
+        set_tsp_enabled(ks, config.services.tsp).await?;
     }
     Ok(())
 }

--- a/vta-service/src/operations/protocol/service_lifecycle.rs
+++ b/vta-service/src/operations/protocol/service_lifecycle.rs
@@ -65,6 +65,13 @@ pub(crate) trait ServiceLifecycle {
     /// Telemetry kind emitted on a successful update.
     const UPDATE_TELEMETRY: TelemetryKind;
 
+    /// Validate + canonicalize the operator-supplied advertised value,
+    /// returning the canonical form to publish or an error message.
+    ///
+    /// REST / WebAuthn validate an HTTPS URL (`validate_service_url`); TSP
+    /// validates a mediator **DID** (the endpoint is a `did:...` VID, not a
+    /// URL), so it can't reuse the URL validator.
+    fn validate(input: &str) -> Result<String, String>;
     /// Is this service currently flagged on in the live config?
     fn config_enabled(cfg: &AppConfig) -> bool;
     /// The URL this service currently advertises in the DID document, if any.
@@ -243,7 +250,7 @@ where
     E: DisableMutationError,
 {
     // Brick-prevention runs FIRST — cheap config-only check before any I/O.
-    let (rest, didcomm, webauthn) = {
+    let (rest, didcomm, webauthn, tsp) = {
         let cfg = config.read().await;
         if !S::config_enabled(&cfg) {
             return Err(E::not_present());
@@ -252,10 +259,11 @@ where
             cfg.services.rest,
             cfg.services.didcomm,
             cfg.services.webauthn,
+            cfg.services.tsp,
         )
     };
     would_violate_last_service(
-        &CurrentServices::new(rest, didcomm, webauthn),
+        &CurrentServices::new(rest, didcomm, webauthn, tsp),
         ProposedOp::disable(S::KIND),
     )?;
 
@@ -288,9 +296,7 @@ where
 
     let _guard = PROTOCOL_LOCK.lock().await;
 
-    let canonical_url = validate_service_url(url)
-        .map_err(|e| E::validation(e.to_string()))?
-        .to_string();
+    let canonical_url = S::validate(url).map_err(E::validation)?;
 
     let state = check_enable_preconditions::<S, E>(deps.config, deps.webvh_ks).await?;
 
@@ -352,9 +358,7 @@ where
 
     let _guard = PROTOCOL_LOCK.lock().await;
 
-    let canonical_url = validate_service_url(url)
-        .map_err(|e| E::validation(e.to_string()))?
-        .to_string();
+    let canonical_url = S::validate(url).map_err(E::validation)?;
 
     let (state, prior_url) = check_update_preconditions::<S, E>(deps.config, deps.webvh_ks).await?;
 
@@ -429,6 +433,11 @@ impl ServiceLifecycle for RestService {
     const ENABLE_TELEMETRY: TelemetryKind = TelemetryKind::ServicesRestEnable;
     const UPDATE_TELEMETRY: TelemetryKind = TelemetryKind::ServicesRestUpdate;
 
+    fn validate(input: &str) -> Result<String, String> {
+        validate_service_url(input)
+            .map(|u| u.to_string())
+            .map_err(|e| e.to_string())
+    }
     fn config_enabled(cfg: &AppConfig) -> bool {
         cfg.services.rest
     }
@@ -460,6 +469,11 @@ impl ServiceLifecycle for WebauthnService {
     const ENABLE_TELEMETRY: TelemetryKind = TelemetryKind::ServicesWebauthnEnable;
     const UPDATE_TELEMETRY: TelemetryKind = TelemetryKind::ServicesWebauthnUpdate;
 
+    fn validate(input: &str) -> Result<String, String> {
+        validate_service_url(input)
+            .map(|u| u.to_string())
+            .map_err(|e| e.to_string())
+    }
     fn config_enabled(cfg: &AppConfig) -> bool {
         cfg.services.webauthn
     }
@@ -480,6 +494,53 @@ impl ServiceLifecycle for WebauthnService {
     fn snapshot_enabled(prior_url: String) -> ServiceConfigSnapshot {
         ServiceConfigSnapshot::Webauthn(
             crate::operations::protocol::snapshot::WebauthnSnapshot::Enabled { url: prior_url },
+        )
+    }
+}
+
+/// TSP transport (`#tsp`, `TSPTransport`).
+///
+/// Unlike REST / WebAuthn the advertised value is a **mediator DID** (the
+/// VTA's TSP VID), not a URL — so `validate` checks for a non-empty
+/// `did:...` string rather than running `validate_service_url`. TSP has no
+/// drain and no handshake, so (like REST) it needs only the shared
+/// enable/update/disable skeleton. The lifecycle hooks' `*_url` naming is
+/// kept (it's the engine's generic "advertised value" slot); the value
+/// carried is the mediator DID.
+pub(crate) struct TspService;
+
+impl ServiceLifecycle for TspService {
+    const LABEL: &'static str = "TSP";
+    const KIND: ServiceKind = ServiceKind::Tsp;
+    const ENABLE_TELEMETRY: TelemetryKind = TelemetryKind::ServicesTspEnable;
+    const UPDATE_TELEMETRY: TelemetryKind = TelemetryKind::ServicesTspUpdate;
+
+    fn validate(input: &str) -> Result<String, String> {
+        if input.is_empty() || !input.starts_with("did:") {
+            return Err("TSP mediator must be a DID (did:...)".into());
+        }
+        Ok(input.to_string())
+    }
+    fn config_enabled(cfg: &AppConfig) -> bool {
+        cfg.services.tsp
+    }
+    fn current_service_url(doc: &JsonValue) -> Option<String> {
+        crate::operations::protocol::document::current_tsp_service(doc).map(|s| s.mediator_did)
+    }
+    fn with_service(doc: JsonValue, url: &str) -> Result<JsonValue, DocumentPatchError> {
+        crate::operations::protocol::document::with_tsp_service(doc, url)
+    }
+    fn without_service(doc: JsonValue) -> JsonValue {
+        crate::operations::protocol::document::without_tsp_service(doc)
+    }
+    fn snapshot_disabled() -> ServiceConfigSnapshot {
+        ServiceConfigSnapshot::Tsp(crate::operations::protocol::snapshot::TspSnapshot::Disabled)
+    }
+    fn snapshot_enabled(prior_url: String) -> ServiceConfigSnapshot {
+        ServiceConfigSnapshot::Tsp(
+            crate::operations::protocol::snapshot::TspSnapshot::Enabled {
+                mediator_did: prior_url,
+            },
         )
     }
 }

--- a/vta-service/src/operations/protocol/snapshot.rs
+++ b/vta-service/src/operations/protocol/snapshot.rs
@@ -53,6 +53,7 @@ pub enum ServiceKind {
     Rest,
     Didcomm,
     Webauthn,
+    Tsp,
 }
 
 impl ServiceKind {
@@ -63,6 +64,7 @@ impl ServiceKind {
             ServiceKind::Rest => "rest",
             ServiceKind::Didcomm => "didcomm",
             ServiceKind::Webauthn => "webauthn",
+            ServiceKind::Tsp => "tsp",
         }
     }
 }
@@ -79,6 +81,7 @@ pub enum ServiceConfigSnapshot {
     Rest(RestSnapshot),
     Didcomm(DidcommSnapshot),
     Webauthn(WebauthnSnapshot),
+    Tsp(TspSnapshot),
 }
 
 impl ServiceConfigSnapshot {
@@ -87,6 +90,7 @@ impl ServiceConfigSnapshot {
             ServiceConfigSnapshot::Rest(_) => ServiceKind::Rest,
             ServiceConfigSnapshot::Didcomm(_) => ServiceKind::Didcomm,
             ServiceConfigSnapshot::Webauthn(_) => ServiceKind::Webauthn,
+            ServiceConfigSnapshot::Tsp(_) => ServiceKind::Tsp,
         }
     }
 }
@@ -124,6 +128,17 @@ pub enum DidcommSnapshot {
 #[serde(tag = "state", rename_all = "lowercase")]
 pub enum WebauthnSnapshot {
     Enabled { url: String },
+    Disabled,
+}
+
+/// Pre-mutation state for the TSP (`TSPTransport`) kind. Mirrors
+/// [`RestSnapshot`] — the TSP surface has the same single-value shape on
+/// the DID document — but the advertised value is the **mediator DID**
+/// (the VTA's TSP VID), not a URL, so the field is named `mediator_did`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "state", rename_all = "lowercase")]
+pub enum TspSnapshot {
+    Enabled { mediator_did: String },
     Disabled,
 }
 
@@ -260,6 +275,30 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn write_then_read_round_trips_tsp_enabled() {
+        let (_dir, ks) = empty_snapshot_keyspace().await;
+
+        let snap = ServiceConfigSnapshot::Tsp(TspSnapshot::Enabled {
+            mediator_did: "did:webvh:scid:host:mediator".into(),
+        });
+        write(&ks, snap.clone()).await.unwrap();
+
+        let restored = read(&ks, ServiceKind::Tsp).await.unwrap().unwrap();
+        assert_eq!(restored, snap);
+    }
+
+    #[tokio::test]
+    async fn write_then_read_round_trips_tsp_disabled() {
+        let (_dir, ks) = empty_snapshot_keyspace().await;
+
+        let snap = ServiceConfigSnapshot::Tsp(TspSnapshot::Disabled);
+        write(&ks, snap.clone()).await.unwrap();
+
+        let restored = read(&ks, ServiceKind::Tsp).await.unwrap().unwrap();
+        assert_eq!(restored, snap);
+    }
+
+    #[tokio::test]
     async fn second_write_overwrites_first_for_same_kind() {
         let (_dir, ks) = empty_snapshot_keyspace().await;
 
@@ -363,6 +402,21 @@ mod tests {
         let snap = ServiceConfigSnapshot::Didcomm(DidcommSnapshot::Disabled);
         let json = serde_json::to_value(&snap).unwrap();
         assert_eq!(json["kind"], "didcomm");
+        assert_eq!(json["state"], "disabled");
+
+        // TSP enabled — advertises a mediator DID, not a URL
+        let snap = ServiceConfigSnapshot::Tsp(TspSnapshot::Enabled {
+            mediator_did: "did:webvh:scid:host:mediator".into(),
+        });
+        let json = serde_json::to_value(&snap).unwrap();
+        assert_eq!(json["kind"], "tsp");
+        assert_eq!(json["state"], "enabled");
+        assert_eq!(json["mediator_did"], "did:webvh:scid:host:mediator");
+
+        // TSP disabled — no extra fields
+        let snap = ServiceConfigSnapshot::Tsp(TspSnapshot::Disabled);
+        let json = serde_json::to_value(&snap).unwrap();
+        assert_eq!(json["kind"], "tsp");
         assert_eq!(json["state"], "disabled");
     }
 

--- a/vta-service/src/operations/protocol/update_tsp.rs
+++ b/vta-service/src/operations/protocol/update_tsp.rs
@@ -1,0 +1,255 @@
+//! `update_tsp` operation.
+//!
+//! Spec: `docs/05-design-notes/runtime-service-management.md` §3.4 +
+//! `docs/05-design-notes/tsp-enablement.md`. A thin wrapper over the shared
+//! [`service_lifecycle`](super::service_lifecycle) engine — see [`run_update`]
+//! for the sequence (super-admin → PROTOCOL_LOCK → validate mediator DID →
+//! preconditions → snapshot prior mediator → patch → publish → telemetry). No
+//! `services.tsp` config flip — TSP stays enabled across an update; only the
+//! advertised mediator DID changes. Brick-prevention is not consulted (update
+//! can't change the on/off state).
+
+use thiserror::Error;
+
+use crate::auth::AuthClaims;
+use crate::error::AppError;
+use crate::operations::did_webvh::UpdateDidWebvhError;
+use crate::operations::protocol::document::DocumentPatchError;
+use crate::operations::protocol::service_lifecycle::{
+    ServiceMutationError, TspService, UpdateMutationError, run_update,
+};
+use crate::operations::protocol::{OpContext, ServiceOpDeps};
+
+#[derive(Debug, Clone)]
+pub struct UpdateTspParams {
+    /// New mediator DID for the `#tsp` service entry. Validated as a
+    /// `did:...` string before any runtime mutation.
+    pub mediator_did: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct UpdateTspResult {
+    pub new_version_id: String,
+    /// Pre-update mediator DID — captured from the on-chain DID document
+    /// and surfaced so callers / telemetry can join the before-and-after.
+    pub prior_mediator_did: String,
+    /// The validated new mediator DID that was published.
+    pub mediator_did: String,
+    /// The VTA's own DID. See [`super::enable_tsp::EnableTspResult`].
+    pub vta_did: String,
+    /// True when the VTA's DID is self-hosted.
+    pub serverless: bool,
+}
+
+#[derive(Debug, Error)]
+pub enum UpdateTspError {
+    #[error(
+        "TSP is not currently enabled. Use `services tsp enable --mediator-did <did>` to bring it online first."
+    )]
+    ServiceNotPresent,
+    #[error("invalid mediator DID: {0}")]
+    Validation(String),
+    #[error("VTA DID is not configured — run `vta setup` first")]
+    VtaDidNotConfigured,
+    #[error("VTA DID `{0}` has no webvh record")]
+    VtaDidRecordMissing(String),
+    #[error("VTA DID `{0}` has no published log")]
+    VtaDidLogMissing(String),
+    #[error("VTA DID log is empty")]
+    EmptyLog,
+    #[error("DID document patch failed: {0}")]
+    DocumentPatch(#[from] DocumentPatchError),
+    #[error("WebVH update failed: {0}")]
+    WebVHUpdate(#[from] UpdateDidWebvhError),
+    #[error("auth: {0}")]
+    Auth(String),
+    #[error("storage error: {0}")]
+    Storage(String),
+}
+
+impl From<AppError> for UpdateTspError {
+    fn from(value: AppError) -> Self {
+        Self::Storage(value.to_string())
+    }
+}
+
+impl From<crate::operations::protocol::preconditions::ProtocolPreconditionError>
+    for UpdateTspError
+{
+    fn from(value: crate::operations::protocol::preconditions::ProtocolPreconditionError) -> Self {
+        use crate::operations::protocol::preconditions::ProtocolPreconditionError as E;
+        match value {
+            E::VtaDidNotConfigured => Self::VtaDidNotConfigured,
+            E::VtaDidRecordMissing(s) => Self::VtaDidRecordMissing(s),
+            E::VtaDidLogMissing(s) => Self::VtaDidLogMissing(s),
+            E::EmptyLog => Self::EmptyLog,
+            E::Storage(s) | E::DocumentParse(s) => Self::Storage(s),
+        }
+    }
+}
+
+impl ServiceMutationError for UpdateTspError {
+    fn validation(msg: String) -> Self {
+        Self::Validation(msg)
+    }
+    fn auth(msg: String) -> Self {
+        Self::Auth(msg)
+    }
+    fn storage(msg: String) -> Self {
+        Self::Storage(msg)
+    }
+}
+
+impl UpdateMutationError for UpdateTspError {
+    fn not_present() -> Self {
+        Self::ServiceNotPresent
+    }
+}
+
+pub async fn update_tsp(
+    deps: &ServiceOpDeps<'_>,
+    auth: &AuthClaims,
+    params: UpdateTspParams,
+    ctx: OpContext,
+    channel: &str,
+) -> Result<UpdateTspResult, UpdateTspError> {
+    let ok =
+        run_update::<TspService, UpdateTspError>(deps, auth, &params.mediator_did, ctx, channel)
+            .await?;
+
+    Ok(UpdateTspResult {
+        new_version_id: ok.new_version_id,
+        // `run_update` always sets `prior_url` to `Some` on success.
+        prior_mediator_did: ok.prior_url.unwrap_or_default(),
+        mediator_did: ok.canonical_url,
+        vta_did: ok.vta_did,
+        serverless: ok.serverless,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use tokio::sync::RwLock;
+
+    use super::*;
+    use crate::config::AppConfig;
+    use crate::operations::protocol::service_lifecycle::{TspService, check_update_preconditions};
+    use crate::operations::protocol::snapshot::{
+        self, ServiceConfigSnapshot, ServiceKind, TspSnapshot,
+    };
+    use crate::store::{KeyspaceHandle, Store};
+    use vti_common::config::StoreConfig as VtiStoreConfig;
+
+    struct TestFixture {
+        _dir: tempfile::TempDir,
+        config: Arc<RwLock<AppConfig>>,
+        store: Store,
+    }
+
+    impl TestFixture {
+        fn snapshot_ks(&self) -> KeyspaceHandle {
+            self.store.keyspace(snapshot::KEYSPACE_NAME).unwrap()
+        }
+        fn webvh_ks(&self) -> KeyspaceHandle {
+            self.store.keyspace(crate::keyspaces::WEBVH).unwrap()
+        }
+    }
+
+    fn build_fixture(tsp_initially: bool) -> TestFixture {
+        use crate::test_support::test_app_config;
+        let dir = tempfile::tempdir().unwrap();
+        let mut cfg = test_app_config(dir.path().into());
+        cfg.services.tsp = tsp_initially;
+        cfg.services.didcomm = true;
+        cfg.vta_did = Some("did:webvh:scid123:host:vta".into());
+        cfg.config_path = dir.path().join("vta.toml");
+        let initial = toml::to_string_pretty(&cfg).unwrap();
+        std::fs::write(&cfg.config_path, initial).unwrap();
+
+        let store = Store::open(&VtiStoreConfig {
+            data_dir: dir.path().into(),
+        })
+        .unwrap();
+        TestFixture {
+            _dir: dir,
+            config: Arc::new(RwLock::new(cfg)),
+            store,
+        }
+    }
+
+    #[tokio::test]
+    async fn preconditions_reject_when_tsp_disabled() {
+        let fx = build_fixture(false);
+        let err =
+            check_update_preconditions::<TspService, UpdateTspError>(&fx.config, &fx.webvh_ks())
+                .await
+                .unwrap_err();
+        assert!(matches!(err, UpdateTspError::ServiceNotPresent));
+    }
+
+    #[tokio::test]
+    async fn preconditions_reject_without_vta_did() {
+        let fx = build_fixture(true);
+        fx.config.write().await.vta_did = None;
+        let err =
+            check_update_preconditions::<TspService, UpdateTspError>(&fx.config, &fx.webvh_ks())
+                .await
+                .unwrap_err();
+        assert!(matches!(err, UpdateTspError::VtaDidNotConfigured));
+    }
+
+    /// Mediator-DID validation runs first, before any storage reads or
+    /// snapshot writes — a non-DID value means the snapshot keyspace stays
+    /// untouched.
+    #[tokio::test]
+    async fn invalid_mediator_did_aborts_before_snapshot_write() {
+        use crate::operations::protocol::service_lifecycle::ServiceLifecycle;
+        let fx = build_fixture(true);
+        let snapshot_ks = fx.snapshot_ks();
+
+        let validated = TspService::validate("not-a-did");
+        assert!(validated.is_err(), "non-did:... must be rejected");
+
+        assert!(
+            snapshot::read(&snapshot_ks, ServiceKind::Tsp)
+                .await
+                .unwrap()
+                .is_none(),
+            "validation error must abort before snapshot write",
+        );
+    }
+
+    /// After a successful update, the snapshot records the *prior* mediator
+    /// DID (the rollback target), not the new one.
+    #[tokio::test]
+    async fn snapshot_records_prior_mediator_for_rollback() {
+        let fx = build_fixture(true);
+        let snapshot_ks = fx.snapshot_ks();
+        let prior = "did:webvh:scid:host:old-mediator".to_string();
+
+        snapshot::write(
+            &snapshot_ks,
+            ServiceConfigSnapshot::Tsp(TspSnapshot::Enabled {
+                mediator_did: prior.clone(),
+            }),
+        )
+        .await
+        .unwrap();
+
+        let read_back = snapshot::read(&snapshot_ks, ServiceKind::Tsp)
+            .await
+            .unwrap()
+            .unwrap();
+        match read_back {
+            ServiceConfigSnapshot::Tsp(TspSnapshot::Enabled { mediator_did }) => {
+                assert_eq!(
+                    mediator_did, prior,
+                    "rollback target must be prior mediator"
+                );
+            }
+            other => panic!("unexpected snapshot variant: {other:?}"),
+        }
+    }
+}

--- a/vti-common/Cargo.toml
+++ b/vti-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-common"
 description = "Shared server-side infrastructure for VTA and VTC services"
 readme = "README.md"
-version = "0.11.1"
+version = "0.11.2"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vti-common/src/telemetry/mod.rs
+++ b/vti-common/src/telemetry/mod.rs
@@ -96,6 +96,9 @@ pub enum TelemetryKind {
     ServicesWebauthnEnable,
     ServicesWebauthnUpdate,
     ServicesWebauthnDisable,
+    ServicesTspEnable,
+    ServicesTspUpdate,
+    ServicesTspDisable,
 }
 
 #[derive(Debug, Clone, Default)]


### PR DESCRIPTION
SDD **PR 5b** — the server-side TSP mutation surface, mirroring the REST ops through the shared `service_lifecycle` engine. **No routes / CLI / wire-types yet** (PR 5c) — these are internal `pub` ops exercised by their own unit tests.

## Engine change (the one non-mechanical bit)
The shared engine hardcoded `validate_service_url`, which rejects a `did:` mediator. Added a **`validate` hook** to the `ServiceLifecycle` trait:
- `RestService` / `WebauthnService` delegate to `validate_service_url` — **behavior unchanged**.
- `TspService` validates a mediator **DID** (`did:` prefix), since TSPs advertised endpoint is a mediator DID, not a URL.

## What landed
- **`TspService`** lifecycle impl (uses the PR-2 `with_tsp_service`/`without_tsp_service`/`current_tsp_service`; config flag off by default).
- **snapshot**: `ServiceKind::Tsp` + `ServiceConfigSnapshot::Tsp` + `TspSnapshot { Enabled { mediator_did }, Disabled }`.
- **invariant**: `CurrentServices` gains `tsp_enabled` (4-arg `new` — all callers updated); `would_violate_last_service` counts TSP as a transport (so TSP keeps another transport disable-able and cant be silently bricked).
- **runtime_state**: `is_tsp_enabled`/`set_tsp_enabled` (defaults **false** — additive) + migrate-from-config seeding.
- **telemetry**: `ServicesTsp{Enable,Update,Disable}` (vti-common). Rollback dispatches into the forward op and emits the forward kind with `triggered_by=rollback`, same as REST.
- **`enable_tsp` / `update_tsp` / `disable_tsp` / `rollback_tsp`** ops + unit tests.

## TSP specifics
**No drain** (stateless relay) and **no handshake** (simpler than DIDComm — modeled on REST).

## Verification
- Full **vta-service** (816 lib + integration) **and vti-common** suites pass — **0 failures**.
- clippy clean (only the pre-existing `contexts/mod.rs` `collapsible_if` from a newer-than-CI local toolchain, in an untouched file); fmt-clean on changed files.
- Implemented via a subagent mirroring the REST pattern; I independently reviewed the engine `validate` hook, the invariant ripple + all `CurrentServices::new` callers, the disable brick-prevention path, and the rollback dispatch, and re-ran the suites.

Bumps: vta-service `0.10.10→0.10.11`, vti-common `0.11.1→0.11.2`.

Next: **PR 5c** — `/services/tsp/*` routes + `vta_sdk::protocol::services` request/response types + DIDComm message types + `services tsp {enable,update,disable,rollback}` CLI verbs.