### PR TITLE
feat(vta-sdk): optional P-256 slots in didcomm-mediator template

### DIFF
--- a/vta-sdk/src/did_templates/render.rs
+++ b/vta-sdk/src/did_templates/render.rs
@@ -114,7 +114,26 @@ fn substitute_value(value: &Value, vars: &HashMap<String, Value>) -> Value {
     match value {
         Value::String(s) => substitute_string(s, vars),
         Value::Array(items) => {
-            Value::Array(items.iter().map(|v| substitute_value(v, vars)).collect())
+            // Substitute each element, then prune any that resolved to JSON
+            // `null`. This is the mechanism for *optional* array members: a
+            // template writes a whole-string token (e.g. `"{VM_P256_SIGNING}"`)
+            // as an array element and declares it in `optionalVars` with a
+            // `null` default. When the caller supplies a value the element
+            // renders; when they don't, the `null` default makes it disappear
+            // rather than leaving a literal `null` in the document (which would
+            // be invalid in a `verificationMethod` / `authentication` array).
+            //
+            // Only whole-array-element nulls are pruned — a `null` nested
+            // inside an object value is left untouched. No built-in template
+            // relies on a literal `null` array member, so this is purely
+            // additive.
+            Value::Array(
+                items
+                    .iter()
+                    .map(|v| substitute_value(v, vars))
+                    .filter(|v| !v.is_null())
+                    .collect(),
+            )
         }
         Value::Object(map) => {
             let mut out = Map::with_capacity(map.len());

--- a/vta-sdk/src/did_templates/tests.rs
+++ b/vta-sdk/src/did_templates/tests.rs
@@ -270,6 +270,42 @@ fn placeholders_in_nested_arrays_and_objects() {
 }
 
 #[test]
+fn null_array_elements_are_pruned() {
+    // Optional array members are expressed as whole-string tokens whose
+    // `optionalVars` default is `null`. When the caller omits them the
+    // element resolves to `null` and is dropped, leaving a clean array —
+    // never a literal `null` member (invalid in DID-doc key arrays).
+    let raw = base_template(json!({
+        "optionalVars": { "EXTRA_KEY": null },
+        "document": {
+            "id": "{DID}",
+            "authentication": ["{DID}#key-0", "{EXTRA_KEY}"]
+        }
+    }));
+    let tpl = DidTemplate::from_json(raw).unwrap();
+
+    // Omitted -> pruned.
+    let out = tpl.render(&ambient_vars()).unwrap();
+    assert_eq!(
+        out["authentication"],
+        json!(["did:webvh:abc:example.com#key-0"])
+    );
+
+    // Supplied -> retained. (A supplied value is not recursively
+    // re-substituted, so it must already carry the resolved DID.)
+    let mut vars = ambient_vars();
+    vars.insert_string("EXTRA_KEY", "did:webvh:abc:example.com#key-2");
+    let out = tpl.render(&vars).unwrap();
+    assert_eq!(
+        out["authentication"],
+        json!([
+            "did:webvh:abc:example.com#key-0",
+            "did:webvh:abc:example.com#key-2"
+        ])
+    );
+}
+
+#[test]
 fn provided_token_may_pass_through_as_sentinel() {
     // A caller supplying `DID = "{DID}"` means "leave this literal alone for
     // a downstream library to resolve" — render must not flag it.
@@ -327,6 +363,27 @@ fn didcomm_mediator_builtin_renders_end_to_end() {
 
     let doc = tpl.render(&vars).unwrap();
     assert_eq!(doc["id"], "did:webvh:mediator:example.com");
+
+    // No P-256 vars supplied -> the optional P-256 slots default to `null`
+    // and are pruned: only the Ed25519 + X25519 pair survives, and the
+    // verification-relationship arrays each carry a single key reference.
+    let vms = doc["verificationMethod"].as_array().unwrap();
+    assert_eq!(vms.len(), 2);
+    assert_eq!(vms[0]["id"], "did:webvh:mediator:example.com#key-0");
+    assert_eq!(vms[1]["id"], "did:webvh:mediator:example.com#key-1");
+    assert_eq!(
+        doc["authentication"],
+        json!(["did:webvh:mediator:example.com#key-0"])
+    );
+    assert_eq!(
+        doc["assertionMethod"],
+        json!(["did:webvh:mediator:example.com#key-0"])
+    );
+    assert_eq!(
+        doc["keyAgreement"],
+        json!(["did:webvh:mediator:example.com#key-1"])
+    );
+
     let services = doc["service"].as_array().unwrap();
     assert_eq!(services.len(), 3);
 
@@ -362,6 +419,78 @@ fn didcomm_mediator_builtin_renders_end_to_end() {
     assert_eq!(
         services[2]["serviceEndpoint"],
         "https://mediator.example.com/authenticate"
+    );
+}
+
+#[test]
+fn didcomm_mediator_builtin_renders_p256_slots_when_supplied() {
+    // Opt-in P-256: the caller supplies the optional verification-method
+    // objects (whole-string native-type substitution) plus the
+    // relationship references. The document then carries 4 verification
+    // methods and two-entry authentication/assertionMethod/keyAgreement
+    // arrays — exactly what a P-256-capable counterparty needs. (Supplied
+    // values are not recursively re-substituted, so they carry the resolved
+    // DID rather than the `{DID}` sentinel the local generator would pass.)
+    let tpl = load_embedded("didcomm-mediator").unwrap();
+    let mut vars = TemplateVars::new();
+    vars.insert_string("DID", "did:webvh:mediator:example.com");
+    vars.insert_string("SIGNING_KEY_MB", "z6MkSign");
+    vars.insert_string("KA_KEY_MB", "z6LSKa");
+    vars.insert_string("URL", "https://mediator.example.com");
+    vars.insert_string("WS_URL", "wss://mediator.example.com/ws");
+    vars.insert(
+        "VM_P256_SIGNING",
+        json!({
+            "id": "did:webvh:mediator:example.com#key-2",
+            "type": "Multikey",
+            "controller": "did:webvh:mediator:example.com",
+            "publicKeyMultibase": "zDnaP256Sign"
+        }),
+    );
+    vars.insert(
+        "VM_P256_KA",
+        json!({
+            "id": "did:webvh:mediator:example.com#key-3",
+            "type": "Multikey",
+            "controller": "did:webvh:mediator:example.com",
+            "publicKeyMultibase": "zDnaP256Ka"
+        }),
+    );
+    vars.insert_string("AUTH_P256", "did:webvh:mediator:example.com#key-2");
+    vars.insert_string("ASSERTION_P256", "did:webvh:mediator:example.com#key-2");
+    vars.insert_string("KEYAGREEMENT_P256", "did:webvh:mediator:example.com#key-3");
+
+    let doc = tpl.render(&vars).unwrap();
+
+    let vms = doc["verificationMethod"].as_array().unwrap();
+    assert_eq!(vms.len(), 4);
+    assert_eq!(vms[2]["id"], "did:webvh:mediator:example.com#key-2");
+    assert_eq!(vms[2]["type"], "Multikey");
+    assert_eq!(vms[2]["controller"], "did:webvh:mediator:example.com");
+    assert_eq!(vms[2]["publicKeyMultibase"], "zDnaP256Sign");
+    assert_eq!(vms[3]["id"], "did:webvh:mediator:example.com#key-3");
+    assert_eq!(vms[3]["publicKeyMultibase"], "zDnaP256Ka");
+
+    assert_eq!(
+        doc["authentication"],
+        json!([
+            "did:webvh:mediator:example.com#key-0",
+            "did:webvh:mediator:example.com#key-2"
+        ])
+    );
+    assert_eq!(
+        doc["assertionMethod"],
+        json!([
+            "did:webvh:mediator:example.com#key-0",
+            "did:webvh:mediator:example.com#key-2"
+        ])
+    );
+    assert_eq!(
+        doc["keyAgreement"],
+        json!([
+            "did:webvh:mediator:example.com#key-1",
+            "did:webvh:mediator:example.com#key-3"
+        ])
     );
 }
 

--- a/vta-sdk/templates/didcomm-mediator.json
+++ b/vta-sdk/templates/didcomm-mediator.json
@@ -8,7 +8,12 @@
   "optionalVars": {
     "ROUTING_KEYS": [],
     "ACCEPT": ["didcomm/v2"],
-    "WEBVH_SERVER": null
+    "WEBVH_SERVER": null,
+    "VM_P256_SIGNING": null,
+    "VM_P256_KA": null,
+    "AUTH_P256": null,
+    "ASSERTION_P256": null,
+    "KEYAGREEMENT_P256": null
   },
   "defaults": {
     "preRotationCount": 2,
@@ -34,11 +39,13 @@
         "type": "Multikey",
         "controller": "{DID}",
         "publicKeyMultibase": "{KA_KEY_MB}"
-      }
+      },
+      "{VM_P256_SIGNING}",
+      "{VM_P256_KA}"
     ],
-    "authentication": ["{DID}#key-0"],
-    "assertionMethod": ["{DID}#key-0"],
-    "keyAgreement": ["{DID}#key-1"],
+    "authentication": ["{DID}#key-0", "{AUTH_P256}"],
+    "assertionMethod": ["{DID}#key-0", "{ASSERTION_P256}"],
+    "keyAgreement": ["{DID}#key-1", "{KEYAGREEMENT_P256}"],
     "service": [
       {
         "id": "{DID}#tsp",


### PR DESCRIPTION
## What

Adds **opt-in P-256 (ES256 / ECDH-ES) verification methods** to the `didcomm-mediator` DID template, so a mediator can advertise P-256 identity + key-agreement keys alongside the mandatory Ed25519 + X25519 pair. Needed for counterparties that can't speak Curve25519 (JOSE-first stacks, hardware-backed wallets, ES256 issuers).

## Why this shape

The template renderer is pure `{TOKEN}` substitution with **no conditionals**, so optional keys can't be expressed as `{{#if}}` blocks. Instead this adds **null array-element pruning**: after substitution, an array element that resolved to JSON `null` is dropped. Combined with `optionalVars` that default to `null`, a template can list optional members as whole-string tokens that simply vanish when the caller doesn't supply them.

## Changes

- **`render.rs`** — prune `null` array elements after substitution (purely additive; no built-in template relies on literal `null` array members — verified).
- **`templates/didcomm-mediator.json`** — optional `VM_P256_SIGNING` / `VM_P256_KA` verification-method slots + `AUTH_P256` / `ASSERTION_P256` / `KEYAGREEMENT_P256` relationship references, all defaulting to `null`.
- **tests** — P-256 render test, a focused null-pruning unit test, and the existing default test now asserts the slots prune cleanly (document byte-identical to before when no P-256 vars are supplied).

## Validation

`cargo test -p vta-sdk did_templates` → **43 passed**. Backward compatible: without P-256 vars the rendered `didcomm-mediator` document is unchanged.

## Related

Consumer side (mediator-setup `--key-suite p256`) is in a follow-up PR on `affinidi/affinidi-tdk-rs`, which depends on a release of this `vta-sdk` change.
