### PR TITLE
fix: green up CI on main (e2e tsp fixture, clippy, rustfmt)

### DIFF
--- a/tests/e2e/tests/common/state_fixtures.rs
+++ b/tests/e2e/tests/common/state_fixtures.rs
@@ -130,6 +130,7 @@ pub async fn setup_vta_in_state(state: ServiceState) -> StateFixture {
         rest,
         didcomm,
         webauthn: false,
+        tsp: false,
     };
     config.vta_did = Some("did:webvh:scid123:host:vta".into());
 

--- a/vta-service/src/contexts/mod.rs
+++ b/vta-service/src/contexts/mod.rs
@@ -39,10 +39,10 @@ pub async fn effective_context_policy(
 
     let mut policies: Vec<ContextPolicy> = Vec::new();
     for id in &ids {
-        if let Some(rec) = get_context(ks, id).await? {
-            if let Some(policy) = rec.context_policy {
-                policies.push(policy);
-            }
+        if let Some(rec) = get_context(ks, id).await?
+            && let Some(policy) = rec.context_policy
+        {
+            policies.push(policy);
         }
     }
     Ok(ContextPolicy::resolve(policies.iter()))

--- a/vta-service/src/operations/keys.rs
+++ b/vta-service/src/operations/keys.rs
@@ -977,7 +977,10 @@ pub async fn derive_and_sign(
 ) -> Result<DeriveAndSignResultBody, AppError> {
     auth.require_admin()?;
 
-    if !matches!((algorithm, key_type), (SignAlgorithm::EdDSA, KeyType::Ed25519)) {
+    if !matches!(
+        (algorithm, key_type),
+        (SignAlgorithm::EdDSA, KeyType::Ed25519)
+    ) {
         return Err(AppError::Validation(format!(
             "derive-and-sign currently supports only EdDSA/Ed25519 (got {algorithm}/{key_type:?})"
         )));
@@ -1042,7 +1045,9 @@ pub async fn derive_and_sign_document(
         )));
     }
     if !document.is_object() {
-        return Err(AppError::Validation("document must be a JSON object".into()));
+        return Err(AppError::Validation(
+            "document must be a JSON object".into(),
+        ));
     }
 
     let seed = load_seed_bytes(keys_ks, &**seed_store, None)
@@ -1581,7 +1586,10 @@ mod tests {
         )
         .await
         .expect("list keys");
-        assert!(listed.keys.is_empty(), "derive_and_sign must not persist a key");
+        assert!(
+            listed.keys.is_empty(),
+            "derive_and_sign must not persist a key"
+        );
 
         // A non-admin caller is rejected.
         let non_admin = AuthClaims {
@@ -1628,19 +1636,37 @@ mod tests {
         .expect("derive_and_sign_document should succeed for an admin");
 
         // Signer is the derived super-admin did:key.
-        assert!(res.signer_did.starts_with("did:key:z6Mk"), "{}", res.signer_did);
+        assert!(
+            res.signer_did.starts_with("did:key:z6Mk"),
+            "{}",
+            res.signer_did
+        );
         // A proof was grafted, by the derived key, with a proofValue.
         let proof = res.document.get("proof").expect("proof grafted");
         assert!(
             proof.get("proofValue").and_then(|v| v.as_str()).is_some(),
             "proof has a proofValue"
         );
-        let vm = proof.get("verificationMethod").and_then(|v| v.as_str()).unwrap();
-        assert!(vm.starts_with(&res.signer_did), "vm {vm} bound to signer {}", res.signer_did);
+        let vm = proof
+            .get("verificationMethod")
+            .and_then(|v| v.as_str())
+            .unwrap();
+        assert!(
+            vm.starts_with(&res.signer_did),
+            "vm {vm} bound to signer {}",
+            res.signer_did
+        );
 
         // Deterministic: same path → same signer.
         let res2 = derive_and_sign_document(
-            &h.keys_ks, &h.seed_store, &auth, &KeyType::Ed25519, "m/26'/9'/0'", doc, None, "test",
+            &h.keys_ks,
+            &h.seed_store,
+            &auth,
+            &KeyType::Ed25519,
+            "m/26'/9'/0'",
+            doc,
+            None,
+            "test",
         )
         .await
         .unwrap();

--- a/vtc-service/src/credentials/invitation_registry.rs
+++ b/vtc-service/src/credentials/invitation_registry.rs
@@ -81,7 +81,7 @@ pub async fn list_invitations(ks: &KeyspaceHandle) -> Result<Vec<InvitationRecor
             Err(e) => tracing::warn!(error = %e, "skipping unparseable invitation row"),
         }
     }
-    out.sort_by(|a, b| b.issued_at.cmp(&a.issued_at));
+    out.sort_by_key(|b| std::cmp::Reverse(b.issued_at));
     Ok(out)
 }
 

--- a/vtc-service/src/routes/members/read.rs
+++ b/vtc-service/src/routes/members/read.rs
@@ -240,7 +240,7 @@ pub async fn list_removed(
             })
         })
         .collect();
-    removed.sort_by(|a, b| b.removed_at.cmp(&a.removed_at));
+    removed.sort_by_key(|b| std::cmp::Reverse(b.removed_at));
     Ok(Json(removed))
 }
 


### PR DESCRIPTION
## What

Greens up CI on `main` (its own `CI` workflow run is currently red). Three pre-existing failures, none related to feature work:

1. **`fix:` Test — add `tsp` to the e2e `ServicesConfig` fixture.** `ServicesConfig` gained a `tsp` field (TSP transport, default `false`), but `tests/e2e/.../state_fixtures.rs` still built it without one → `E0063`, failing `cargo test --workspace`. Production constructors already set `tsp`; only the fixture was missed.

2. **`fix:` Clippy — resolve three `-D warnings` lints.** Two descending sorts written as `sort_by(|a,b| b.x.cmp(&a.x))` → `sort_by_key(|b| Reverse(b.x))` (`unnecessary_sort_by`), and a nested `if let` → let-chain (`collapsible_if`). No behavioural change.

3. **`style:` Format — `cargo fmt` on `vta-service/src/operations/keys.rs`.** Pre-existing rustfmt drift.

## Validation

- `cargo clippy --workspace -- -D warnings` → clean (was 3 errors).
- `cargo fmt --all --check` → clean.
- `cargo test -p vti-e2e-tests --no-run` → compiles (was `E0063`).
- All commits DCO-signed.
