### PR TITLE
docs(tsp): update inbound design note for native TDK TSP auth

### DIFF
--- a/docs/05-design-notes/tsp-inbound-receive.md
+++ b/docs/05-design-notes/tsp-inbound-receive.md
@@ -1,12 +1,45 @@
 # Design note: how a VTA receives TSP inbound
 
-**Status:** DRAFT for review — gates SDD PR 6 (inbound listener + auth) and
-informs PR 7 (outbound). No code until approved.
+**Status:** Decision record — gates SDD PR 6 (inbound listener + auth) and
+informs PR 7 (outbound).
 **Owner:** Glenn Gore
 **Created:** 2026-06-26
+**Updated:** 2026-06-26 — **the TDK gained native TSP support that resolves both
+load-bearing open questions** (see §0 + §3). `affinidi-messaging-sdk` 0.18.37
+graduated TSP from experimental to supported (TDK #528) and added turn-key
+client auth + live-stream CESR sniffing. The recommendation (Option A) stands
+but is now much closer to turn-key.
 **Context:** `docs/05-design-notes/tsp-enablement.md` §6 assumed "add a TSP
 listener alongside the DIDComm one." This note records why that's not a drop-in
 and specifies the actual receive path.
+
+---
+
+## 0. Update (2026-06-26): native TDK TSP support landed
+
+Two TDK capabilities resolve the open questions this note originally flagged:
+
+- **Turn-key TSP client auth** — `affinidi_messaging_sdk::TspAuthHandler` (TDK
+  #533): a pure-TSP `CustomAuthHandler` that signs a challenge to the mediator's
+  `POST /tsp/authenticate`; afterwards the usual `atm.tsp()` ops authenticate
+  transparently. **Resolves §3 open-Q2.**
+- **Live-stream CESR sniffing** — the SDK websocket transport
+  (`transports/websockets/websocket.rs::process_inbound_didcomm_message`) now
+  sniffs `atm.tsp().is_tsp(frame)` and, for a TSP frame, surfaces it as
+  `WebSocketResponses::PackedMessageReceived` (un-unpacked) instead of failing
+  the DIDComm unpack and dropping it. **Resolves §3 open-Q1 (the load-bearing
+  one): the live-stream *does* surface TSP, gracefully, as a packed frame the
+  consumer unpacks via `atm.tsp()`.**
+
+**Net effect on the plan:** Option A (below) is unchanged in shape but no longer
+needs a bespoke pickup loop *or* an upstream change — the VTA already holds a
+mediator websocket via its DIDComm listener, and that stream now carries TSP
+frames. The **only** remaining seam is whether the VTA's `DIDCommService`-based
+listener exposes those `PackedMessageReceived` TSP frames to a VTI handler (vs.
+only routing unpacked DIDComm `Message`s). If `DIDCommService` doesn't surface
+packed frames, the fallback is a `direct_channel` / pickup consumer on the same
+authenticated session — still no upstream change. Verify which against the
+0.18.37 `DIDCommService` API when implementing PR 6b.
 
 ---
 
@@ -80,15 +113,16 @@ owned by `AppState`) that:
   consumer to reason about (must not double-consume vs. the DIDComm pickup —
   see §3).
 
-### Option B — pre-unpack sniff hook in `DIDCommService` (upstream change)
+### Option B — live websocket delivery (now largely shipped upstream)
 
-Add a middleware/hook in `affinidi-messaging-didcomm-service` that sniffs the
-CESR magic on raw inbound bytes and routes TSP out *before* DIDComm unpack, into
-a VTI-supplied TSP handler.
-
-- **Pros:** live (websocket-push) latency; one inbound connection.
-- **Cons:** requires an **upstream change** to the messaging-service crate;
-  couples our rollout to their release cadence. Defer to a v2 optimization.
+Originally framed as "needs an upstream pre-unpack hook." **Update (§0): the
+sniff already shipped** — the SDK websocket transport detects TSP frames and
+surfaces them as `PackedMessageReceived` rather than dropping them. So live
+delivery is available *if* the VTA's listener exposes packed frames to a VTI
+consumer. This collapses Option A and Option B into one approach over the
+existing authenticated websocket; the choice is now just *where* the VTA taps
+the packed TSP frames (DIDCommService handler surface vs. a `direct_channel`
+consumer), not push-vs-poll.
 
 ### Option C — mediator bridges all TSP→DIDComm at the recipient
 
@@ -103,27 +137,30 @@ into a DIDComm `forward`.
 
 ## 3. Recommendation & open questions
 
-**Adopt Option A (TSP fetch/pickup loop) for PR 6**, with Option B as a future
-live-delivery optimization once (and if) the upstream hook lands.
+**Adopt Option A** — receive TSP off the VTA's existing authenticated mediator
+connection (no bespoke pickup loop, no upstream change), filter `is_tsp`, unpack
+via `atm.tsp()`, and feed `dispatch_trust_task_core`.
 
-Resolve before/while implementing:
+Original open questions — status after the §0 TDK update:
 
-1. **Mailbox partition (the load-bearing one).** Does the existing DIDComm
-   live-stream / pickup also surface the stored **TSP** blobs (which
-   `DIDCommService` cannot unpack and would error/drop)? Two sub-cases:
-   - If the mediator's live-stream only pushes DIDComm and TSP is pickup-only →
-     clean: Option A's loop owns TSP, `DIDCommService` owns DIDComm.
-   - If the live-stream pushes TSP blobs too → we must ensure `DIDCommService`
-     **ignores** non-DIDComm bytes (an `ignore`/error-handler tweak) rather than
-     erroring, and that pickup doesn't double-consume. **Verify against the
-     running mediator before coding the loop.**
-2. **TSP client auth to the mediator.** Per the upstream dual-protocol mediator
-   SDD (D1), a TSP client performs a TSP handshake that mints the **same** EdDSA
-   `SessionClaims` JWT used by DIDComm. Confirm the VTA establishes that session
-   (and the relationship/`is_tsp` pickup auth) at listener start.
-3. **VID registration.** Confirm the ATM `tsp()` agent accepts the VTA's
-   existing DID + secrets as a `PrivateVid` (it should — `affinidi-tsp` has a
-   `did-resolver` feature and the keys are standard Ed25519/X25519).
+1. ~~Mailbox partition (the load-bearing one)~~ **RESOLVED (§0).** The SDK
+   websocket sniffs `is_tsp` and surfaces TSP frames as `PackedMessageReceived`
+   instead of failing the DIDComm unpack — so the live-stream carries TSP
+   *and* DIDComm without dropping or double-unpacking. No mediator-behavior
+   verification needed; the SDK handles the partition.
+2. ~~TSP client auth to the mediator~~ **RESOLVED (§0).** `TspAuthHandler`
+   (`POST /tsp/authenticate`) is turn-key; `atm.tsp()` authenticates
+   transparently afterwards.
+3. ~~VID registration~~ **Effectively resolved.** `atm.tsp().unpack(profile,
+   stored)` extracts the profile's Ed25519+X25519 keys from the secrets resolver
+   directly — no separate `PrivateVid` registration. The VTA's existing DID
+   profile is the VID.
+
+**The one remaining seam** (narrow, no upstream dep): does the VTA's
+`DIDCommService`-based listener (0.18.37) expose `PackedMessageReceived` TSP
+frames to a VTI handler, or must the VTA tap a `direct_channel` on the same
+session? Determine this against the live `DIDCommService` API when coding PR 6b —
+it's a "where do we attach the consumer" question, not a design risk.
 
 ---
 
@@ -147,19 +184,38 @@ The vault `SealedEnvelope::TspMessage` unseal (`trust_tasks/vault.rs`,
 `operations/vault/upsert.rs`) does **not** depend on the inbound listener. It's a
 request-scoped unpack: when a `vault/upsert` Trust Task carries a `tsp-message`
 sealed secret, add a `TspMessage` arm beside `DidcommAuthcrypt` that calls a
-`unseal_tsp_secret(atm, caller_did, message)` (mirroring `unseal_secret`):
-`atm.tsp().unpack` with the VTA's VID + the sender-vs-caller cross-check, then
-the existing cleartext deserialize. This is a clean, self-contained, testable PR
-that can land **before** the listener — recommend doing it as the first concrete
-PR 6 increment while the §3 mailbox question is verified.
+`unseal_tsp_secret(atm, profile, caller_did, message)` (mirroring
+`unseal_secret`): `atm.tsp().unpack(profile, message)` → `(payload, sender_vid)`,
+sender-vs-caller cross-check, then `serde_json::from_slice(&payload)` into the
+cleartext `VaultSecret`.
+
+**One plumbing wrinkle to resolve in PR 6a (found while scoping):** unlike the
+DIDComm `atm.unpack(jwe)` (no profile arg), `atm.tsp().unpack` requires an
+`Arc<ATMProfile>`, and the VTA's profile is **not** currently held in `AppState`
+— it's created inline for the DIDComm listener (`server.rs`) and the vault-context
+ATM (`state.atm`) is built separately without a registered profile (no
+`profile_add` in `vta-service` today). So PR 6a must either (a) thread the VTA's
+`Arc<ATMProfile>` into `AppState`, or (b) construct it on demand in
+`unseal_tsp_secret` from the VTA DID + secrets resolver. (a) is cleaner and also
+serves PR 6b/7. This makes 6a slightly more than a pure mirror of
+`unseal_secret`, but it's still self-contained and listener-independent.
 
 ---
 
 ## 6. Resulting PR plan (supersedes the single "PR 6" in tsp-enablement.md §13)
 
 - **PR 6a — sealed-envelope TSP unseal** (§5). Self-contained; no listener dep.
-- **PR 6b — TSP inbound fetch/pickup loop** (§2 Option A) feeding
-  `dispatch_trust_task_core`, after the §3.1 mailbox question is verified.
+  Includes the `Arc<ATMProfile>`-into-`AppState` plumbing (§5).
+- **PR 6b — TSP inbound over the existing mediator websocket** (§2 Option A):
+  tap `PackedMessageReceived` TSP frames (or a `direct_channel` consumer on the
+  same session), `is_tsp`-filter, `atm.tsp().unpack`, feed
+  `dispatch_trust_task_core`. Wire `TspAuthHandler` at listener start. The §3
+  open questions are resolved by the §0 TDK update — the only thing to confirm is
+  the `DIDCommService` 0.18.37 packed-frame surface.
 - **PR 6c — auth over TSP** (§4): mostly a consequence of 6b; the delta is the
   proven-signer plumbing + an audience-isolation test. May fold into 6b.
-- Option B (live pre-unpack hook) is a later optimization, gated on upstream.
+
+**Dependency bump:** PR 6 requires `affinidi-messaging-sdk` ≥ 0.18.37 (TSP
+graduated to supported, #528; `TspAuthHandler`, #533; websocket CESR sniff). The
+workspace pins `affinidi-tdk = "0.8"`; verify the resolved messaging-sdk patch is
+≥ 0.18.37 (or bump) when starting 6a/6b.

--- a/docs/05-design-notes/tsp-inbound-receive.md
+++ b/docs/05-design-notes/tsp-inbound-receive.md
@@ -41,6 +41,30 @@ packed frames, the fallback is a `direct_channel` / pickup consumer on the same
 authenticated session — still no upstream change. Verify which against the
 0.18.37 `DIDCommService` API when implementing PR 6b.
 
+### 0a. Update (2026-06-26, later): raw-TSP WebSocket delivery mode (mediator)
+
+TDK #534 (`affinidi-messaging-mediator` **0.16.31**) adds a **second, cleaner
+inbound mode** — but **mediator-side only for now**:
+
+- A WebSocket client opts in by offering the **`tsp` subprotocol** (alongside
+  `bearer.{token}`). The socket then carries **raw TSP `Message::Binary`
+  frames**, with a **flush-on-connect + delete-on-successful-send** contract
+  (queued TSP is drained on connect; a frame is deleted from the inbox only once
+  its send succeeds → **at-least-once** delivery). This is a dedicated TSP
+  channel, separate from the DIDComm-text websocket of §0/Mode 1.
+- **The `affinidi-messaging-sdk` client was NOT changed by #534** (it's
+  mediator + test-mediator only; the e2e test drives it with a raw
+  tokio-tungstenite socket). So there is **no turn-key ATM API to *open* this
+  raw-TSP websocket yet** — using it means a raw-ws client or a future SDK
+  helper.
+
+**Decision: PR 6b stays on Mode 1** (the existing DIDComm-text websocket +
+`is_tsp` sniff → `PackedMessageReceived`), which is fully turn-key in the
+published SDK 0.18.37/.38. **Mode 2 (raw-TSP WS, at-least-once) is the preferred
+target once the SDK client exposes opening it** — track for a follow-up; it
+gives cleaner delivery semantics and a clean channel separation. No VTI code
+change is blocked on it.
+
 ---
 
 ## 1. The problem

--- a/docs/05-design-notes/tsp-inbound-receive.md
+++ b/docs/05-design-notes/tsp-inbound-receive.md
@@ -58,12 +58,42 @@ inbound mode** — but **mediator-side only for now**:
   raw-TSP websocket yet** — using it means a raw-ws client or a future SDK
   helper.
 
-**Decision: PR 6b stays on Mode 1** (the existing DIDComm-text websocket +
-`is_tsp` sniff → `PackedMessageReceived`), which is fully turn-key in the
-published SDK 0.18.37/.38. **Mode 2 (raw-TSP WS, at-least-once) is the preferred
-target once the SDK client exposes opening it** — track for a follow-up; it
-gives cleaner delivery semantics and a clean channel separation. No VTI code
-change is blocked on it.
+### 0b. Update (2026-06-27): SDK client consumer for Mode 2 landed (#536) — this is now the plan
+
+TDK #536 (`affinidi-messaging-sdk` **0.18.39**) adds the turn-key **client
+consumer** for the raw-TSP WebSocket mode that #534 added server-side. **Mode 2
+is now fully available client-side, so PR 6b adopts it** (superseding the Mode 1
+sniff path):
+
+- `atm.tsp().connect_websocket(profile) -> TspWebSocket` — opens the raw-TSP WS
+  to the mediator; **authenticates internally** (calls the TDK authentication →
+  `TspAuthHandler` path) and the server runs flush-on-connect + delete-on-send.
+- `TspWebSocket::recv()` → `Option<Vec<u8>>` next **raw qb2 TSP** message (`None`
+  on close; skips ping/pong); `.send(&[u8])` for outbound.
+- `atm.tsp().unpack_bytes(profile, qb2)` → `(payload, sender_vid)` — `payload`
+  is the inner Trust Task doc; `sender_vid` is the **proven signer**.
+
+**PR 6b inbound loop (turn-key):**
+
+```rust
+let ws = atm.tsp().connect_websocket(&profile).await?;
+while let Some(qb2) = ws.recv().await? {
+    let (payload, sender_vid) = atm.tsp().unpack_bytes(&profile, &qb2).await?;
+    // sender_vid = intrinsic proven signer (like DIDComm msg.from)
+    dispatch_trust_task_core(&app_state, sender_vid, payload).await;
+}
+// recv() == None → reconnect with backoff (mirror the DIDComm RestartPolicy)
+```
+
+So PR 6b is: own this loop as a background task in `AppState` (gated on the
+`tsp` feature + a configured TSP mediator), with reconnect/backoff, feeding the
+existing spine. **No DIDComm-stream sniffing, no mailbox-partition concern, no
+`DIDCommService` hook question** — those are all moot under Mode 2. Both
+`connect_websocket` and `unpack_bytes` take `Arc<ATMProfile>`, confirming the
+profile-into-`AppState` plumbing (§5) serves 6a, 6b, **and** outbound (PR 7).
+
+**Dependency floor rises to `affinidi-messaging-sdk` ≥ 0.18.39** for PR 6b
+(6a/unseal only needs ≥ 0.18.37 + `unpack`/`unpack_bytes`).
 
 ---
 
@@ -230,16 +260,16 @@ serves PR 6b/7. This makes 6a slightly more than a pure mirror of
 
 - **PR 6a — sealed-envelope TSP unseal** (§5). Self-contained; no listener dep.
   Includes the `Arc<ATMProfile>`-into-`AppState` plumbing (§5).
-- **PR 6b — TSP inbound over the existing mediator websocket** (§2 Option A):
-  tap `PackedMessageReceived` TSP frames (or a `direct_channel` consumer on the
-  same session), `is_tsp`-filter, `atm.tsp().unpack`, feed
-  `dispatch_trust_task_core`. Wire `TspAuthHandler` at listener start. The §3
-  open questions are resolved by the §0 TDK update — the only thing to confirm is
-  the `DIDCommService` 0.18.37 packed-frame surface.
+- **PR 6b — TSP inbound via `atm.tsp().connect_websocket`** (§0b — Mode 2, the
+  current plan): a background task in `AppState` (gated on `tsp` + a configured
+  TSP mediator) that runs the `recv()` → `unpack_bytes` → `dispatch_trust_task_core`
+  loop with reconnect/backoff. No DIDComm-stream sniffing, no
+  `DIDCommService`-hook question — Mode 2 is a dedicated channel. `connect_websocket`
+  handles TSP auth internally (`TspAuthHandler`).
 - **PR 6c — auth over TSP** (§4): mostly a consequence of 6b; the delta is the
   proven-signer plumbing + an audience-isolation test. May fold into 6b.
 
-**Dependency bump:** PR 6 requires `affinidi-messaging-sdk` ≥ 0.18.37 (TSP
-graduated to supported, #528; `TspAuthHandler`, #533; websocket CESR sniff). The
-workspace pins `affinidi-tdk = "0.8"`; verify the resolved messaging-sdk patch is
-≥ 0.18.37 (or bump) when starting 6a/6b.
+**Dependency floor:** PR 6a (unseal) needs `affinidi-messaging-sdk` ≥ 0.18.37
+(`atm.tsp().unpack`); **PR 6b needs ≥ 0.18.39** (`connect_websocket` /
+`unpack_bytes`, #536). The workspace pins `affinidi-tdk = "0.8"`; verify the
+resolved messaging-sdk patch (or bump) when starting each.


### PR DESCRIPTION
Reviewing the **updated TDK** (it now has **native TSP auth**) against the inbound design note (#591) — and it **resolves both load-bearing open questions**.

## What changed in the TDK (`affinidi-messaging-sdk` 0.18.37)
- **TSP graduated experimental → supported** (TDK #528).
- **`TspAuthHandler`** (#533) — turn-key pure-TSP client auth via the mediator's `POST /tsp/authenticate`; `atm.tsp()` ops then authenticate transparently. → resolves design-note **open-Q2**.
- **The SDK websocket transport now sniffs `is_tsp`** and surfaces TSP frames as `WebSocketResponses::PackedMessageReceived` instead of failing the DIDComm unpack and dropping them (`transports/websockets/websocket.rs`). → resolves design-note **open-Q1** (the load-bearing one): the live-stream carries TSP gracefully.

## Net effect on the plan
Inbound rides the VTA's **existing authenticated mediator websocket** — **no bespoke pickup loop, no upstream change** (Option A and the old "Option B upstream hook" collapse into one). The only remaining seam is *where* the VTA taps the packed TSP frames (`DIDCommService` handler surface vs. a `direct_channel` consumer) — a "where to attach" question, not a design risk.

## Also recorded
- **PR 6a finding:** `atm.tsp().unpack` needs an `Arc<ATMProfile>` (unlike DIDComm `atm.unpack(jwe)`), and the VTA's profile isn't in `AppState` today — so 6a threads the profile into `AppState` (also serves 6b/7). No separate VID registration (keys come from the secrets resolver).
- **Dependency floor:** PR 6 needs `affinidi-messaging-sdk ≥ 0.18.37`; verify/bump the resolved patch under the `affinidi-tdk = "0.8"` pin.

This is a docs-only update to the merged design note. (Branch name is `tsp-vault-unseal` — I'd started scoping 6a when the TDK update prompted this status review; the unseal implementation will follow.)
