### PR TITLE
chore(tsp): bump messaging stack to TSP-capable versions (atm.tsp())

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -396,9 +396,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-mediator-common"
-version = "0.15.15"
+version = "0.15.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de97156c77842ec60f2a3156da1a8aa2a05ef214b12e796c7989eb369b9b5371"
+checksum = "c03122eaf3023dab93a876df19468d37b09e055c3e8692cbdda3e468a366c88f"
 dependencies = [
  "aes-gcm",
  "ahash 0.8.12",
@@ -446,9 +446,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-sdk"
-version = "0.18.12"
+version = "0.18.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2022cd5c4baa0ed5f872f3febd8c9cb7fe7fd92330f0c758d5cf05de6c46368"
+checksum = "9ceee57cd19a86e57d319ff19f05f807119287391f834c5b822b4030ac8c7aeb"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-authentication",
@@ -473,6 +473,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "tracing",
+ "trust-tasks-rs",
  "uuid",
 ]
 
@@ -4731,7 +4732,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "system-configuration 0.7.0",
  "tokio",
  "tower-service",
@@ -6921,7 +6922,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.40",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6959,7 +6960,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -9490,9 +9491,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-rs"
-version = "0.2.7"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70c4de0c2a4edf0014d6a87ffe85392bdb7a8ace6828a012b8ea05e028a02c7f"
+checksum = "ccbddb304248cc6cb1e2e6385bd2f7042df71c805d9e128d6cb40125322a9274"
 dependencies = [
  "async-trait",
  "chrono",
@@ -10826,7 +10827,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]


### PR DESCRIPTION
The foundation for PR 6 (TSP inbound + sealed-envelope unseal): bring the published messaging stack up to versions that actually expose the TSP runtime APIs.

## Why
Before this, the workspace resolved **`affinidi-messaging-sdk 0.18.12`** — which has **no `atm.tsp()` at all**. The TSP runtime work (PR 6a unseal via `atm.tsp().unpack`; PR 6b inbound via `atm.tsp().connect_websocket` / `unpack_bytes`) literally can't compile against it. The TSP-capable versions are now published on crates.io (TDK shipped #528/#533/#534/#536 over the last few days).

## What (Cargo.lock-only — all within existing semver pins, no Cargo.toml change)
| crate | from | to |
|---|---|---|
| `affinidi-messaging-sdk` | 0.18.12 | **0.18.39** |
| `affinidi-messaging-mediator-common` | 0.15.15 | 0.15.19 |
| `trust-tasks-rs` | 0.2.7 | 0.2.12 |

These move **together** — the `affinidi-messaging-sdk 0.18.39` build requires the newer `mediator-common` (`MessageProtocol`) and `trust-tasks-rs` (`specs::messaging`); pinning only the SDK fails to compile inside the SDK.

## Validation
The 27-patch messaging-sdk jump touches the existing DIDComm / Trust-Task paths, so I validated it independently:
- Whole-workspace `cargo build` — clean.
- Full **vta-service** suite (20 result groups, ~800+ tests) + **vta-sdk** — **0 failures**.

No regressions; the bump is safe. This unblocks PR 6a (sealed-envelope TSP unseal) and 6b (inbound websocket), both of which require `atm.tsp()`.
