### PR TITLE
feat(tsp): TSP inbound listener over the mediator websocket

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10153,7 +10153,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.10.12"
+version = "0.10.14"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.10.13"
+version = "0.10.14"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/messaging/auth.rs
+++ b/vta-service/src/messaging/auth.rs
@@ -23,6 +23,23 @@ pub async fn auth_from_message(
         .as_deref()
         .ok_or_else(|| AppError::Authentication("message has no sender (from)".into()))?;
 
+    auth_from_did(did, acl_ks).await
+}
+
+/// Resolve an envelope-authenticated sender DID into unified `AuthClaims`.
+///
+/// This is the DID-based core shared by every intrinsic-sender transport
+/// (DIDComm authcrypt via [`auth_from_message`], raw-TSP via
+/// `messaging::tsp_inbound`). The caller has *already* proven the sender
+/// DID cryptographically — by unpacking an authcrypt envelope, or by
+/// TSP unpack returning the verified `sender_vid` — so this function only
+/// performs ACL lookup + claim construction, never signature verification.
+///
+/// Routes through [`check_acl_full`] (rather than the lower-level
+/// `get_acl_entry`) so that `expires_at` is enforced identically to the
+/// REST path. A time-bounded ACL grant must stop working over every
+/// transport the moment it lapses.
+pub async fn auth_from_did(did: &str, acl_ks: &KeyspaceHandle) -> Result<AuthClaims, AppError> {
     // Strip any fragment (e.g. did:key:z6Mk...#z6Mk... → did:key:z6Mk...)
     let base_did = did.split('#').next().unwrap_or(did);
 
@@ -32,16 +49,17 @@ pub async fn auth_from_message(
         did: base_did.to_string(),
         role,
         allowed_contexts,
-        // DIDComm auth is envelope-authenticated (authcrypt sender),
-        // not JWT-session-backed. Synthesise a sentinel session_id
-        // tagged with the transport + sender DID so log scraping can
-        // still distinguish DIDComm callers. `access_expires_at = 0`
-        // is the "no JWT expiry" sentinel — DIDComm doesn't carry one.
+        // Intrinsic-sender auth is envelope-authenticated (authcrypt
+        // sender / TSP unpack), not JWT-session-backed. Synthesise a
+        // sentinel session_id tagged with the sender DID so log scraping
+        // can still distinguish these callers. `access_expires_at = 0`
+        // is the "no JWT expiry" sentinel — these transports don't carry
+        // one.
         session_id: format!("didcomm:{base_did}"),
         access_expires_at: 0,
-        // DIDComm authcrypt-sender authentication is a single DID-key
-        // factor with no JWT-bound expiry. Mark amr accordingly so
-        // handlers gating on AAL see this as aal1-equivalent.
+        // Authcrypt-sender / TSP-unpack authentication is a single
+        // DID-key factor with no JWT-bound expiry. Mark amr accordingly
+        // so handlers gating on AAL see this as aal1-equivalent.
         amr: vec!["did".to_string()],
         acr: "aal1".to_string(),
     })
@@ -137,6 +155,60 @@ mod tests {
 
         let msg = message_from(&format!("{base}#zBase"));
         let claims = auth_from_message(&msg, &acl_ks).await.unwrap();
+        assert_eq!(claims.did, base);
+    }
+
+    /// `auth_from_did` (the transport-neutral core) resolves a DID with a
+    /// live ACL entry to the right role + contexts. This is the path the
+    /// TSP inbound loop drives directly (sender DID, no DIDComm message).
+    #[tokio::test]
+    async fn auth_from_did_resolves_role_and_contexts() {
+        let (_store, acl_ks, _dir) = fresh_acl_ks().await;
+        let did = "did:key:zDidCore";
+        store_acl_entry(
+            &acl_ks,
+            &AclEntry::new(did, Role::Admin, "test")
+                .with_contexts(vec!["ctx-a".into(), "ctx-b".into()])
+                .with_expires_at(Some(now_epoch() + 3600)),
+        )
+        .await
+        .unwrap();
+
+        let claims = auth_from_did(did, &acl_ks).await.unwrap();
+        assert_eq!(claims.did, did);
+        assert_eq!(claims.role, Role::Admin);
+        assert_eq!(claims.allowed_contexts, vec!["ctx-a", "ctx-b"]);
+    }
+
+    /// A DID with no ACL entry errors (peer not authorized) — the TSP loop
+    /// relies on this to drop unknown senders.
+    #[tokio::test]
+    async fn auth_from_did_unknown_did_errors() {
+        let (_store, acl_ks, _dir) = fresh_acl_ks().await;
+        let err = auth_from_did("did:key:zUnknownPeer", &acl_ks)
+            .await
+            .unwrap_err();
+        // No ACL entry → check_acl_full surfaces a not-found / forbidden
+        // class error; the exact variant is the ACL layer's, we just pin
+        // that it is an error (never silently authorized).
+        assert!(
+            matches!(err, AppError::Forbidden(_) | AppError::NotFound(_)),
+            "expected unauthorized-class error, got {err:?}"
+        );
+    }
+
+    /// Fragmented DID collapses to base for the core too.
+    #[tokio::test]
+    async fn auth_from_did_fragment_collapses() {
+        let (_store, acl_ks, _dir) = fresh_acl_ks().await;
+        let base = "did:key:zCoreBase";
+        store_acl_entry(&acl_ks, &AclEntry::new(base, Role::Reader, "test"))
+            .await
+            .unwrap();
+
+        let claims = auth_from_did(&format!("{base}#zCoreBase"), &acl_ks)
+            .await
+            .unwrap();
         assert_eq!(claims.did, base);
     }
 

--- a/vta-service/src/messaging/mod.rs
+++ b/vta-service/src/messaging/mod.rs
@@ -11,3 +11,5 @@ pub mod registry;
 pub mod router;
 #[cfg(all(feature = "webvh", feature = "didcomm"))]
 pub mod transient_handshake;
+#[cfg(feature = "tsp")]
+pub mod tsp_inbound;

--- a/vta-service/src/messaging/tsp_inbound.rs
+++ b/vta-service/src/messaging/tsp_inbound.rs
@@ -1,0 +1,208 @@
+//! TSP (Trust Spanning Protocol) inbound message loop.
+//!
+//! Background task that receives raw-TSP messages off the mediator
+//! websocket and feeds each one into the shared
+//! [`dispatch_trust_task_core`](crate::trust_tasks) spine — the *same*
+//! spine REST and DIDComm use. TSP is the highest-preference transport
+//! (TSP > DIDComm > REST); this is its receive side.
+//!
+//! ## V1 scope: inbound, one-way
+//!
+//! Each received Trust Task is dispatched and its outcome is logged. This
+//! loop does **not** send a Trust-Task response back over TSP. Returning a
+//! response routes through the normal send path and is a documented
+//! follow-up (see the workspace TSP enablement design note). See the
+//! `NOTE` in [`dispatch_one`].
+//!
+//! ## Runtime verification
+//!
+//! The connect / recv loop cannot be unit-tested without a live mediator
+//! (it needs a real websocket endpoint authenticated against a mediator
+//! DID). [`dispatch_one`] — the per-message bridge — is unit-tested; the
+//! connect/recv/reconnect machinery in [`run_tsp_inbound`] is only
+//! compile-verified here and must be validated against a live mediator.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use affinidi_tdk::messaging::ATM;
+use affinidi_tdk::messaging::profiles::ATMProfile;
+use tokio::sync::watch;
+use tracing::{info, warn};
+
+use crate::messaging::auth::auth_from_did;
+use crate::server::AppState;
+
+/// Initial reconnect backoff. Mirrors the DIDComm listener's
+/// `RestartPolicy::Always { initial_delay_secs: 5 }`.
+const BACKOFF_INITIAL: Duration = Duration::from_secs(5);
+/// Maximum reconnect backoff. Mirrors the DIDComm listener's
+/// `max_delay_secs: 60`.
+const BACKOFF_MAX: Duration = Duration::from_secs(60);
+
+/// Per-message bridge: turn one unpacked TSP message into a dispatched
+/// Trust Task on the shared spine.
+///
+/// `sender_vid` is the **proven** sender DID returned by TSP `unpack_bytes`
+/// (verification already happened inside the TSP stack), so this only needs
+/// to resolve the sender's ACL grant — exactly like the DIDComm
+/// `handle_trust_task` bridge resolves its authcrypt sender. `payload` is
+/// the Trust-Task envelope bytes (identical to the REST `POST
+/// /api/trust-tasks` body and the DIDComm message body).
+///
+/// On an unknown / unauthorized sender (no ACL entry, or an expired grant)
+/// the message is logged and dropped — never silently authorized.
+///
+/// NOTE (V1, one-way): the dispatch outcome is logged but **not** returned
+/// to the sender over TSP. Response-over-TSP routes through the normal send
+/// path and is a documented follow-up; this loop is receive-only.
+pub async fn dispatch_one(app_state: &AppState, payload: &[u8], sender_vid: &str) {
+    match auth_from_did(sender_vid, &app_state.acl_ks).await {
+        Ok(auth) => {
+            let outcome =
+                crate::trust_tasks::dispatch_trust_task_core(app_state, &auth, payload).await;
+            // The outcome's HTTP `status` is the framework result code; on
+            // the one-way TSP path we only log it (the self-describing
+            // response document is dropped — see NOTE above).
+            info!(
+                sender = %sender_vid,
+                status = %outcome.status,
+                "TSP trust-task dispatched"
+            );
+        }
+        Err(e) => {
+            // Peer is not in this VTA's ACL (or grant expired). Drop the
+            // message; do not respond.
+            warn!(
+                sender = %sender_vid,
+                error = %e,
+                "TSP message from unauthorized sender — dropped"
+            );
+        }
+    }
+}
+
+/// The TSP inbound loop: connect to the mediator's raw-TSP websocket,
+/// receive frames, unpack + dispatch each, and reconnect with backoff on
+/// disconnect.
+///
+/// Mirrors the DIDComm listener's restart spirit: backoff starts at
+/// [`BACKOFF_INITIAL`] and doubles up to [`BACKOFF_MAX`], resetting on a
+/// successful connect. A shutdown signal (`shutdown` flipped to `true`)
+/// breaks promptly via `tokio::select!` at every await point. Never panics.
+///
+/// `profile` MUST be a mediator-bearing profile (built with
+/// `Some(mediator_did)`); `connect_websocket` resolves the websocket
+/// endpoint from the profile's mediator config. This is distinct from
+/// `AppState.tsp_profile`, which carries no mediator and is for unpack only.
+pub async fn run_tsp_inbound(
+    app_state: AppState,
+    atm: ATM,
+    profile: Arc<ATMProfile>,
+    mut shutdown: watch::Receiver<bool>,
+) {
+    info!("TSP inbound loop starting");
+    let mut backoff = BACKOFF_INITIAL;
+
+    loop {
+        // Shutdown check before each connect attempt.
+        if *shutdown.borrow() {
+            info!("TSP inbound loop shutting down");
+            return;
+        }
+
+        match atm.tsp().connect_websocket(&profile).await {
+            Ok(mut ws) => {
+                info!("TSP inbound websocket connected");
+                // Successful connect resets the backoff.
+                backoff = BACKOFF_INITIAL;
+
+                // Inner receive loop — runs until the socket closes, errors,
+                // or shutdown is signalled.
+                loop {
+                    tokio::select! {
+                        _ = shutdown.changed() => {
+                            if *shutdown.borrow() {
+                                info!("TSP inbound loop shutting down");
+                                return;
+                            }
+                        }
+                        r = ws.recv() => match r {
+                            Ok(Some(qb2)) => {
+                                match atm.tsp().unpack_bytes(&profile, &qb2).await {
+                                    Ok((payload, sender)) => {
+                                        dispatch_one(&app_state, &payload, &sender).await;
+                                    }
+                                    Err(e) => {
+                                        warn!(error = %e, "TSP unpack failed — dropping frame");
+                                    }
+                                }
+                            }
+                            Ok(None) => {
+                                info!("TSP inbound websocket closed — reconnecting");
+                                break;
+                            }
+                            Err(e) => {
+                                warn!(error = %e, "TSP inbound recv error — reconnecting");
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+            Err(e) => {
+                warn!(
+                    error = %e,
+                    backoff_secs = backoff.as_secs(),
+                    "TSP inbound connect failed — backing off"
+                );
+                // Wait out the backoff, but wake promptly on shutdown.
+                tokio::select! {
+                    _ = shutdown.changed() => {
+                        if *shutdown.borrow() {
+                            info!("TSP inbound loop shutting down");
+                            return;
+                        }
+                    }
+                    _ = tokio::time::sleep(backoff) => {}
+                }
+                backoff = (backoff * 2).min(BACKOFF_MAX);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::acl::{AclEntry, Role, store_acl_entry};
+    use crate::test_support::build_signing_test_app_state;
+
+    /// `dispatch_one` with a sender that has no ACL entry must log + drop
+    /// without panicking (it returns `()`; the assertion is that it
+    /// completes). Exercises the unauthorized-sender path.
+    #[tokio::test]
+    async fn dispatch_one_unknown_sender_drops_without_panic() {
+        let (app_state, _dir) = build_signing_test_app_state().await;
+
+        // No ACL entry for this sender → auth_from_did errors → dispatch_one
+        // logs a warning and returns without dispatching or panicking.
+        dispatch_one(&app_state, b"{}", "did:key:zUnauthorizedTspSender").await;
+    }
+
+    /// An authorized sender reaches `dispatch_trust_task_core`. The empty
+    /// body is rejected by the core's envelope parser, but the point under
+    /// test is that the bridge resolves the ACL grant and drives the spine
+    /// without panicking (one-way: the outcome is logged, not returned).
+    #[tokio::test]
+    async fn dispatch_one_authorized_sender_reaches_spine() {
+        let (app_state, _dir) = build_signing_test_app_state().await;
+
+        let did = "did:key:zAuthorizedTspSender";
+        store_acl_entry(&app_state.acl_ks, &AclEntry::new(did, Role::Admin, "test"))
+            .await
+            .unwrap();
+
+        dispatch_one(&app_state, b"{}", did).await;
+    }
+}

--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -982,6 +982,53 @@ pub async fn run(
         #[cfg(not(feature = "didcomm"))]
         let didcomm_service: Option<()> = None;
 
+        // Start the TSP inbound listener: a raw-TSP websocket to the mediator
+        // (`atm.tsp().connect_websocket`) whose received frames are unpacked
+        // and fed into the same `dispatch_trust_task_core` spine as DIDComm /
+        // REST. Distinct from `AppState.tsp_profile` (built in `init_auth`
+        // without a mediator, for vault-secret unpack): `connect_websocket`
+        // needs a mediator-bearing profile, built here where the messaging
+        // config is in scope. Uses the global `shutdown_rx` watch — a stop
+        // flips it to `true` and the loop breaks promptly. Any build/register
+        // failure just warns; the listener stays down (DIDComm unaffected).
+        #[cfg(feature = "tsp")]
+        if let (Some(atm), Some(vta_did), Some(messaging_config)) =
+            (&app_state.atm, &config.vta_did, &config.messaging)
+        {
+            let atm = atm.clone();
+            let vta_did = vta_did.clone();
+            let mediator_did = messaging_config.mediator_did.clone();
+            match affinidi_tdk::messaging::profiles::ATMProfile::new(
+                &atm,
+                Some("VTA".to_string()),
+                vta_did.clone(),
+                Some(mediator_did),
+            )
+            .await
+            {
+                Ok(profile) => match atm.profile_add(&profile, false).await {
+                    Ok(profile) => {
+                        let task_state = app_state.clone();
+                        let task_atm = atm.clone();
+                        let task_shutdown = shutdown_rx.clone();
+                        tokio::spawn(messaging::tsp_inbound::run_tsp_inbound(
+                            task_state,
+                            task_atm,
+                            profile,
+                            task_shutdown,
+                        ));
+                        info!("TSP inbound listener started for DID {vta_did}");
+                    }
+                    Err(e) => warn!(
+                        "failed to register TSP inbound profile (TSP listener not started): {e}"
+                    ),
+                },
+                Err(e) => {
+                    warn!("failed to build TSP inbound profile (TSP listener not started): {e}")
+                }
+            }
+        }
+
         // Spawn the teardown channel consumer. The drain sweeper
         // sends mediator DIDs over `teardown_rx` whenever a TTL
         // fires; this task translates each signal into a


### PR DESCRIPTION
SDD **PR 6b** — the TSP inbound listener. A background task receives TSP messages off the mediator and feeds them into the **same `dispatch_trust_task_core` spine** REST and DIDComm use. Turn-key now that the TDK exposes `atm.tsp().connect_websocket` (#536). **All gated on `tsp`; feature-off is byte-identical.**

## Changes
- **`messaging/auth.rs`** — extract `auth_from_did(did, acl_ks)` from `auth_from_message` (the transport-neutral core: strip `#fragment`, `check_acl_full`, build `AuthClaims`). `auth_from_message` delegates to it — no behaviour change for DIDComm.
- **`messaging/tsp_inbound.rs`** (new, cfg `tsp`):
  - `dispatch_one(app_state, payload, sender_vid)` — `auth_from_did(sender_vid)` (the proven signer from `unpack_bytes`) → `dispatch_trust_task_core`; logs the outcome. Unauthorized sender → warn + drop.
  - `run_tsp_inbound(app_state, atm, profile, shutdown)` — `connect_websocket → recv() → unpack_bytes → dispatch_one` loop, with reconnect/backoff (5s→60s, reset on connect) and **prompt shutdown** via `tokio::select!` on the global shutdown watch. Never panics.
- **`server.rs` `run()`** — build a **mediator-bearing** `ATMProfile` (`connect_websocket` needs the mediator, unlike 6a's unpack-only `AppState.tsp_profile`), `profile_add`, and spawn `run_tsp_inbound` under the **same `(atm, vta_did, messaging_config)` guard** as the DIDComm listener, wired to the existing `shutdown_rx` watch. Build/register failure just warns; the listener stays down (DIDComm unaffected).

## V1 scope (explicit)
**Inbound, one-way:** each Trust Task is dispatched and its outcome logged. Sending a Trust-Task *response* back over TSP routes through the normal send path and is a **documented follow-up** (NOTE in `dispatch_one`).

## Verification — and the boundary
- ✅ Feature-off and feature-on both build clean; **vta-service suite green in BOTH configs (819 off / 822 on, 0 failures)**; clippy clean; fmt clean. New `auth_from_did` (3) + `dispatch_one` (2) tests pass.
- ⚠️ **The connect/recv/unpack runtime loop cannot be verified without a live mediator** — documented with a `NOTE:`. Safe to land: `tsp` is off by default, the dispatch bridge is unit-tested, the loop mirrors the proven DIDComm-listener restart/shutdown pattern, and the SDK call surface is compiler-verified. This (plus 6a's unpack) is what a **live VTA↔mediator smoke test** should exercise before the feature is ever enabled.

vta-service `0.10.13 → 0.10.14`.

> Note: the `tsp_inbound` module + auth refactor were drafted by a subagent that got rate-limited mid-run (it left the module unregistered with a broken test). I registered the module, **wrote the `server.rs` mount + shutdown wiring myself** (the load-bearing part), fixed the tests to use the canonical `build_signing_test_app_state`, and ran both configs.

This completes the inbound half of PR 6. Next: **PR 6c — auth over TSP** is now mostly already covered (a TSP-delivered `auth/authenticate` Trust Task flows through this same loop → `dispatch_trust_task_core` → `handle_authenticate`); the remaining delta is an audience-isolation test. Then PR 7 (outbound seams), 8 (reporting/health), 9 (setup), 10 (cross-cutting).
