### PR TITLE
feat(tsp): surface tsp_enabled in VTA health/details

### DIFF
--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.10.14"
+version = "0.10.15"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/routes/health.rs
+++ b/vta-service/src/routes/health.rs
@@ -29,6 +29,10 @@ pub struct HealthDetailsResponse {
     tee_status: Option<crate::tee::types::TeeStatus>,
     sealed: bool,
     storage_encrypted: bool,
+    /// Whether this VTA advertises TSP (Trust Spanning Protocol) as a
+    /// transport (`services.tsp`). TSP shares the same mediator as DIDComm
+    /// (`mediator_did` above), so no separate endpoint is reported.
+    tsp_enabled: bool,
 }
 
 /// Minimal health check — no authentication required.
@@ -60,6 +64,8 @@ pub async fn health_details(
     // Check if storage encryption is active
     let storage_encrypted = state.keys_ks.is_encrypted();
 
+    let tsp_enabled = config.services.tsp;
+
     Ok(Json(HealthDetailsResponse {
         status: "ok",
         version: env!("CARGO_PKG_VERSION"),
@@ -69,5 +75,6 @@ pub async fn health_details(
         tee_status: state.tee.as_ref().map(|tc| tc.state.status.clone()),
         sealed,
         storage_encrypted,
+        tsp_enabled,
     }))
 }

--- a/vta-service/tests/api_integration.rs
+++ b/vta-service/tests/api_integration.rs
@@ -317,6 +317,18 @@ async fn health_details_returns_version_with_auth() {
     assert_eq!(status, StatusCode::OK);
     assert_eq!(body["status"], "ok");
     assert!(body["version"].is_string());
+    // TSP is off by default — health surfaces the advertised-transport state.
+    assert_eq!(body["tsp_enabled"], false);
+}
+
+#[tokio::test]
+async fn health_details_reports_tsp_enabled_when_configured() {
+    let (app, ctx) = TestApp::new().await;
+    ctx.inner.config.write().await.services.tsp = true;
+    let token = ctx.auth_token("did:key:z6MkTest", "admin", vec![]).await;
+    let (status, body) = app.request(get_auth("/health/details", &token)).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["tsp_enabled"], true);
 }
 
 #[cfg(feature = "webvh")]


### PR DESCRIPTION
SDD **PR 8** (reporting/health) — the slice that's **testable without a live mediator**.

## What it does
`GET /health/details` now reports **`tsp_enabled`** (from `config.services.tsp`), so operators can see whether the VTA advertises TSP as a transport — alongside the existing `mediator_did` (TSP shares the DIDComm mediator, so no separate endpoint is reported). Always-compiled (reads the config bool, no `tsp` feature gate).

## Deferred (and why — honest)
The richer reporting genuinely needs the running TSP loop / outbound / a live mediator, so it can't be verified here and isn't in this PR:
- **`pnm health` TSP connectivity probe** — needs a live mediator round-trip (parallel to the DIDComm trust-ping).
- **VTC `diagnostics`** — the VTC has **no `services.tsp` flag** (no services-management surface; that's VTA-only). There's nothing TSP to report there until the VTC gets TSP outbound (PR 7).
- **Per-protocol inbound counts** in the mediator report — needs the inbound loop to emit per-message telemetry.

`pnm services list` already shows TSP on/off (PR 5a), so the advertised-transport state is covered from two angles.

## Verification
3 health tests pass, incl. the new `tsp_enabled` true/false cases. vta-service `0.10.14 → 0.10.15`.
