### PR TITLE
feat(tsp): validate + support TSP in declarative setup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10153,7 +10153,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.10.14"
+version = "0.10.16"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.10.15"
+version = "0.10.16"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/setup/from_toml.rs
+++ b/vta-service/src/setup/from_toml.rs
@@ -909,6 +909,21 @@ fn validate_inputs(inputs: &WizardInputs) -> Result<(), Box<dyn std::error::Erro
                 .into(),
         );
     }
+    // TSP advertises the **same** mediator as DIDComm (one dual-protocol
+    // mediator — tsp-enablement.md D8), so `services.tsp = true` without
+    // DIDComm would point the `#tsp` service at a mediator the VTA never
+    // configured. Require DIDComm when TSP is on. (TSP is usually enabled
+    // post-setup via `services tsp enable` once it's been verified; this rule
+    // guards the declarative `--from <toml>` path.)
+    if inputs.services.tsp && !inputs.services.didcomm {
+        errors.push(
+            "services.tsp = true requires services.didcomm = true — TSP advertises \
+             the same mediator as DIDComm. Set services.didcomm = true (and \
+             configure messaging), or leave TSP off here and enable it later with \
+             `services tsp enable`"
+                .into(),
+        );
+    }
     if let MessagingInput::CreateMediator {
         context,
         webvh_url,
@@ -2141,6 +2156,53 @@ mod tests {
         "#;
         let inputs = parse(raw).expect("parses");
         validate_inputs(&inputs).expect("rest disabled means public_url is optional");
+    }
+
+    #[test]
+    fn services_tsp_without_didcomm_is_rejected() {
+        // TSP shares the DIDComm mediator, so it can't be advertised without
+        // DIDComm — the `--from <toml>` path must reject the combination.
+        let raw = r#"
+            config_path = "/tmp/vta-test/config.toml"
+            data_dir    = "/tmp/vta-test/data"
+
+            [services]
+            rest    = false
+            didcomm = false
+            tsp     = true
+
+            [secrets]
+            backend = "keyring"
+        "#;
+        let inputs = parse(raw).expect("parses");
+        let err = validate_inputs(&inputs).expect_err("tsp without didcomm must be rejected");
+        assert!(
+            err.to_string()
+                .contains("services.tsp = true requires services.didcomm = true"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn services_tsp_with_didcomm_passes_and_carries_through() {
+        // The declarative TSP path: `[services] tsp = true` (with DIDComm)
+        // parses, validates, and the flag is carried on `WizardInputs.services`
+        // (which `apply` writes verbatim to `config.services`).
+        let raw = r#"
+            config_path = "/tmp/vta-test/config.toml"
+            data_dir    = "/tmp/vta-test/data"
+
+            [services]
+            rest    = false
+            didcomm = true
+            tsp     = true
+
+            [secrets]
+            backend = "keyring"
+        "#;
+        let inputs = parse(raw).expect("parses");
+        validate_inputs(&inputs).expect("tsp + didcomm should validate");
+        assert!(inputs.services.tsp, "tsp flag must be carried through");
     }
 
     #[test]


### PR DESCRIPTION
SDD **PR 9** (setup wizards).

## What I found + did
The **declarative `setup --from <toml>` path already carries TSP** — `ServicesConfig.tsp` landed in PR 5a (with a serde default), and `apply` writes `inputs.services` verbatim to `config`. So `[services] tsp = true` already flows through. This PR **locks that** and adds a guard:

- **`validate_inputs`:** `services.tsp = true` now **requires `services.didcomm = true`.** TSP advertises the **same mediator as DIDComm** (one dual-protocol mediator, D8), so TSP-without-DIDComm would point `#tsp` at a mediator the VTA never configured. Mirrors the existing `messaging`/`rest` requires-rules; guards the `--from <toml>` path (the interactive wizard blocks it at prompt time).
- **Tests:** `tsp`-without-`didcomm` is rejected; `tsp`+`didcomm` validates and the flag carries through on `WizardInputs.services`.

## Deliberately deferred: the interactive multiselect TSP option
Two reasons:
1. **Premature.** Advertising TSP from first boot while the runtime is still unverified-without-a-mediator is the wrong default. The right operator path is **verify-then-enable** via `pnm services tsp enable` (PR 5).
2. **Churn.** Adding a third multiselect item restructures `prompt_services` and the golden prompt/from-toml **equivalence test** for little gain.

The declarative path (this PR) covers operators who opt in knowingly.

## Verification
2 new tests pass; build clean. vta-service `0.10.15 → 0.10.16`.

> (Process note: my first commit accidentally captured only the version bump — an earlier `git stash` for a diagnostic check failed to `pop`, parking the `from_toml.rs` edits in the stash. I recovered them from the stash, re-verified, and amended/force-pushed. The PR now has the full change.)
