### PR TITLE
docs(tsp): operator guide + services tsp in service-management doc

### DIFF
--- a/docs/02-vta/runtime-service-management.md
+++ b/docs/02-vta/runtime-service-management.md
@@ -34,6 +34,7 @@ copy-pasteable suggestion instead of a generic parse error.
 | (no equivalent) | `pnm services list` |
 | (no equivalent) | `pnm services didcomm drain list` |
 | (no equivalent) | `pnm services rest {enable,update,disable,rollback}` |
+| (no equivalent) | `pnm services tsp {enable,update,disable,rollback}` |
 
 **Default `--drain-ttl` is now 24h** (was 1h). The 1h floor for
 DIDComm-transport delivery is unchanged.
@@ -53,9 +54,11 @@ The `--to` muscle memory is partially preserved on `update`:
 ## Operations at a glance
 
 All commands require **super-admin** privileges on the target VTA.
-All twelve operations are reachable over both REST and DIDComm
-transports, except `services didcomm enable` which is REST-only by
-nature (DIDComm isn't running yet at first-enable).
+The operations are reachable over both REST and DIDComm transports,
+except `services didcomm enable` which is REST-only by nature (DIDComm
+isn't running yet at first-enable). `services tsp enable` — unlike
+`services didcomm enable` — is reachable over **either** transport, since
+enabling TSP doesn't depend on TSP already running.
 
 ### Inspect
 
@@ -103,6 +106,22 @@ exposes the same `mediator_did`.
 | Disable DIDComm (drain, then tear down) | `pnm services didcomm disable [--drain-ttl 86400]` |
 | Roll back the most recent DIDComm mutation | `pnm services didcomm rollback [--drain-ttl 86400]` |
 | Cancel an in-flight drain early | `pnm services didcomm drain cancel --mediator-did <did>` |
+
+### Mutate TSP
+
+TSP (Trust Spanning Protocol) is the **preferred** transport wherever both
+parties advertise it — see [`tsp.md`](./tsp.md) for the full picture. It is
+**off by default** and gated behind the `tsp` build feature. TSP advertises the
+**same mediator** as DIDComm (the `#tsp` service's `serviceEndpoint` is the
+mediator DID), so enable DIDComm first. Unlike DIDComm, TSP has **no drain** (its
+inter-mediator relay is stateless) and **no first-enable handshake**.
+
+| Task | Command |
+|---|---|
+| Add `#tsp` service entry | `pnm services tsp enable --mediator-did <did>` |
+| Change the advertised mediator | `pnm services tsp update --mediator-did <did>` |
+| Remove the `#tsp` entry | `pnm services tsp disable` |
+| Roll back the most recent TSP mutation | `pnm services tsp rollback` |
 
 ## How service changes touch the DID document
 

--- a/docs/02-vta/tsp.md
+++ b/docs/02-vta/tsp.md
@@ -1,0 +1,99 @@
+# TSP (Trust Spanning Protocol) — operator guide
+
+TSP is an additive transport for VTI, rolling out **alongside** DIDComm. This
+guide is the operator-facing summary; the design records live under
+`docs/05-design-notes/tsp-*.md`.
+
+> **Status: experimental, off by default.** TSP is gated behind the `tsp` build
+> feature and `services.tsp` is `false` unless you enable it. DIDComm keeps
+> working exactly as before — TSP changes nothing until you turn it on. The
+> service-management surface (advertise / inspect TSP) is complete; the runtime
+> message paths are gated and should be validated against a live mediator before
+> you enable TSP in production (see [Current status](#current-status)).
+
+## Why TSP
+
+Preference order for inter-component transport is **TSP > DIDComm > REST**. TSP
+is preferred where both parties advertise it because it gives **metadata-private
+routing** (intermediaries don't learn the final recipient) at **bounded** message
+size (CESR + HPKE add roughly additive per-hop overhead, versus DIDComm-nested's
+multiplicative base64 blow-up), while keeping DIDs as VIDs so one identity works
+in both stacks. DIDComm remains the fully-supported fallback for peers that don't
+speak TSP; REST is the last resort. The long-term goal is to deprecate DIDComm in
+favour of TSP — phased, with no peer stranded mid-migration.
+
+## How the protocol is chosen
+
+**The DID document is authoritative.** Both sides' capability is read from their
+advertised services, matched on the service **`type`** — `TSPTransport` → TSP,
+`DIDCommMessaging` → DIDComm, `VTARest` → REST — **never** on the `#id` fragment
+(an arbitrary label). The protocol used is the highest-preference one present in
+**both** parties' DID documents. If the advertised sets don't intersect, the
+stack raises a typed **"no matching protocol"** error rather than silently
+downgrading past what a peer advertises.
+
+TSP mirrors DIDComm's **mediator indirection**: a VTA's `#tsp` service
+`serviceEndpoint` is its **mediator's DID** (the same mediator DIDComm uses — one
+dual-protocol mediator), and the real transport URL lives in the mediator's own
+DID document. So a `did:key` VTA (no service block) can't advertise TSP without a
+hosted DID, exactly as it can't advertise REST/DIDComm without one.
+
+## Enabling TSP
+
+TSP shares the DIDComm mediator, so **enable DIDComm first**. Two paths:
+
+- **Runtime (recommended):** once you've verified TSP against your mediator,
+  `pnm services tsp enable --mediator-did <did>` advertises a `#tsp` service on
+  the VTA's DID document. `update` / `disable` / `rollback` mirror the other
+  transports. See [runtime-service-management.md](./runtime-service-management.md).
+  Unlike `services didcomm enable`, `services tsp enable` works over **either**
+  transport. TSP has **no drain** and **no handshake**.
+- **Declarative setup:** in a `vta setup --from <toml>` file, `[services] tsp =
+  true` (which **requires** `services.didcomm = true`). The interactive `vta
+  setup` wizard does **not** prompt for TSP yet — prefer enabling it post-setup
+  via `services tsp enable`, after verification.
+
+`pnm services list` shows TSP on/off + its mediator; `GET /health/details`
+reports `tsp_enabled`.
+
+## Rollout posture
+
+TSP is **verify-then-enable**, not on-by-default. Advertise TSP only once it's
+exercised against your mediator — a peer that sees `#tsp` will prefer it, so an
+unverified TSP path would fail real traffic. DIDComm remains advertised and is
+the automatic fallback for any peer that doesn't speak TSP.
+
+## Current status
+
+| Area | State |
+|---|---|
+| DID-document `#tsp` service + canonical ordering (TSP first) | ✅ shipped |
+| Protocol matching engine (`select_protocol`, match-by-type) | ✅ shipped (`vta_sdk::protocol::matching`) |
+| `services tsp {enable,update,disable,rollback}` (REST + DIDComm + CLI + offline) | ✅ shipped |
+| DID templates advertise `#tsp` | ✅ shipped |
+| Health `tsp_enabled` + `services list` | ✅ shipped |
+| Inbound: `tsp-message` vault unseal | ✅ shipped (feature-gated; live unpack pending verification) |
+| Inbound: TSP listener (raw-TSP websocket → trust-task spine) | ✅ shipped (feature-gated; live loop pending verification) |
+| Auth over TSP | ✅ by construction (rides the inbound spine → `handle_authenticate`) |
+| **Outbound: TSP send from `send_to_member` / VTA** | ⏳ designed, not built — see `tsp-outbound-send.md` |
+| Live connectivity reporting / per-protocol counts | ⏳ pending the running loop |
+
+**Before enabling `tsp` in production:** run a live VTA↔mediator smoke test (one
+real TSP message round-trip). It validates the inbound unpack + listener paths
+that ship feature-gated, and answers the open outbound question (whether TSP send
+requires a Bidirectional relationship — `tsp-outbound-send.md` §3).
+
+## Not yet addressed (by design)
+
+- **Push-gateway TSP.** The `WakeHandle` gateway still disambiguates DIDComm-vs-REST
+  by DID-vs-URL shape. Once a TSP push gateway exists, that needs an explicit
+  protocol tag (a TSP VID is a DID too) — deferred until there's a consumer.
+- **`vta-mcp` / `didcomm-test`** TSP wiring — deferred until they have a
+  TSP-specific path to exercise.
+
+## References
+
+- `docs/05-design-notes/tsp-enablement.md` — the rollout SDD (decisions D1–D9).
+- `docs/05-design-notes/tsp-inbound-receive.md` — inbound receive design.
+- `docs/05-design-notes/tsp-outbound-send.md` — outbound send design (open
+  questions for PR 7).


### PR DESCRIPTION
SDD **PR 10** (cross-cutting) — scoped to the **non-speculative** part: documentation that completes the surface for the TSP work that's actually shipped.

## Changes
- **New `docs/02-vta/tsp.md`** — the operator guide: why TSP (TSP > DIDComm > REST; metadata-private at bounded size), how the protocol is chosen (DID doc authoritative, **match by service `type`**, mediator indirection), how to enable (`services tsp enable` / declarative setup), the **verify-then-enable** rollout posture, and a **shipped-vs-pending status table**. It flags the **live VTA↔mediator smoke test** as the gate before enabling `tsp` in production.
- **`runtime-service-management.md`** — new **Mutate TSP** section + migration-table row, and the note that `services tsp enable` works over **either** transport (unlike `services didcomm enable`). No drain, no handshake.

## Deliberately *not* included (and why)
Per the team's dislike of speculative building, I didn't add changes with **no current consumer**:
- **WakeHandle DID-vs-URL → protocol tag** — there's no TSP push gateway yet, so changing the push-binding wire format now would be speculative. Documented as deferred in `tsp.md`.
- **`vta-mcp` / `didcomm-test` TSP flags** — nothing TSP-specific to exercise there yet. Deferred.
- **VTC backup keyspace census** — **N/A**: TSP added no VTC keyspaces (inbound was VTA-only; outbound isn't built).

Docs-only; no version bump.

## Where the rollout stands
This completes the **unblocked** TSP work. **19 PRs.** What remains is **blocked on the live-mediator smoke test**:
- **Outbound (PR 7b/7c)** — designed (`tsp-outbound-send.md`), gated on the §3 relationship question that the smoke test answers.
- **End-to-end validation of 6a (unpack) + 6b (inbound loop)** — both ship feature-gated; the smoke test is what flips them from "compiles" to "verified."

The `tsp.md` status table is the single place to see shipped-vs-pending.
