### PR TITLE
chore(tsp): bump vta-service to 0.10.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10163,7 +10163,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.10.16"
+version = "0.10.17"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.10.16"
+version = "0.10.17"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true


### PR DESCRIPTION
PR #601 (the TSP shared-socket flap fix) changed `vta-service` source — `server.rs`, `tsp_inbound.rs`, `Cargo.toml` — but did not bump its version. `vta-service` is `publish = true`, and our rule is: any source change to a publishable crate needs a version bump, or `cargo publish` breaks (the registry would hold different source at a version it already has).

Bump **0.10.16 → 0.10.17** (+ Cargo.lock).

`vta-enclave` pins `vta-service` at `"0.10"` (path + version) and its own source is unchanged, so the patch bump needs no dependent bump.