### PR TITLE
feat: vta-service preload self DID into resolver cache from local did.jsonl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+### vta-service — reliability: preload VTA self DID into resolver cache
+
+`vta-service` now preloads its own `did:webvh` DID document into the
+`DIDCacheClient` during auth/resolver initialization, using the locally stored
+`did.jsonl` log (`WEBVH` keyspace) as the source of truth.
+
+This avoids self-resolution network round-trips (and related startup/runtime
+failures) when a VTA cannot reach its own public domain from inside private
+network environments.
+
+Behavior is best-effort and non-fatal: if local log state is missing or
+malformed, the service logs a warning and falls back to normal resolver
+behavior.
+
 ### vti-common — security: keyspace values bound to their location (AAD); breaking on-disk format
 
 AES-256-GCM keyspace encryption now authenticates every value against its

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10163,7 +10163,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.10.17"
+version = "0.10.18"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",

--- a/local-dev/vta-pathful-webvh-setup.toml
+++ b/local-dev/vta-pathful-webvh-setup.toml
@@ -1,0 +1,40 @@
+# Local dev setup — VTA with pathful did:webvh identity
+#
+# DID resolves at /tenant/vta/did.jsonl (has path segments after the domain).
+#
+# Run once to initialise:
+#   cargo run -p vta-service --features webvh -- setup --from local-dev/vta-pathful-webvh-setup.toml
+#
+# Then start the service:
+#   cargo run -p vta-service --features webvh -- --config /tmp/vta-dev-path/config.toml
+#
+# Verify:
+#   curl http://localhost:3000/tenant/vta/did.jsonl    → 200 with log
+#   curl http://localhost:3000/.well-known/did.jsonl   → 404 (pathful DID does not use well-known)
+#   curl http://localhost:3000/other/path/did.jsonl    → 404 (wrong path)
+
+config_path     = "/tmp/vta-dev-path/config.toml"
+data_dir        = "/tmp/vta-dev-path/data"
+public_url      = "http://localhost:3000"
+data_dir_exists = "delete"   # re-run friendly; wipes and re-inits on each setup call
+
+[server]
+host = "0.0.0.0"
+port = 3000
+
+[log]
+level  = "debug"
+format = "text"
+
+[secrets]
+# Plaintext file under data_dir — dev only, never for production.
+backend = "plaintext"
+
+[messaging]
+# No mediator for local dev.
+kind = "skip"
+
+[vta_did]
+kind = "create_webvh"
+# Subpath present → pathful DID → resolves at /tenant/vta/did.jsonl
+url  = "http://localhost:3000/tenant/vta"

--- a/local-dev/vta-root-webvh-setup.toml
+++ b/local-dev/vta-root-webvh-setup.toml
@@ -1,0 +1,39 @@
+# Local dev setup — VTA with root did:webvh identity
+#
+# DID resolves at /.well-known/did.jsonl (no path segments after the domain).
+#
+# Run once to initialise:
+#   cargo run -p vta-service --features webvh -- setup --from local-dev/vta-root-webvh-setup.toml
+#
+# Then start the service:
+#   cargo run -p vta-service --features webvh -- --config /tmp/vta-dev-root/config.toml
+#
+# Verify:
+#   curl http://localhost:3000/.well-known/did.jsonl   → 200 with log
+#   curl http://localhost:3000/any/path/did.jsonl      → 404
+
+config_path     = "/tmp/vta-dev-root/config.toml"
+data_dir        = "/tmp/vta-dev-root/data"
+public_url      = "http://localhost:3000"
+data_dir_exists = "delete"   # re-run friendly; wipes and re-inits on each setup call
+
+[server]
+host = "0.0.0.0"
+port = 3000
+
+[log]
+level  = "debug"
+format = "text"
+
+[secrets]
+# Plaintext file under data_dir — dev only, never for production.
+backend = "plaintext"
+
+[messaging]
+# No mediator for local dev.
+kind = "skip"
+
+[vta_did]
+kind = "create_webvh"
+# No subpath → root DID → resolves at /.well-known/did.jsonl
+url  = "http://localhost:3000"

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.10.17"
+version = "0.10.18"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -327,7 +327,16 @@ pub async fn build_app_state(
     let snapshot_ks =
         apply_encryption(store.keyspace(crate::operations::protocol::snapshot::KEYSPACE_NAME)?);
 
-    let auth = init_auth(&config, &*seed_store, &keys_ks).await;
+    let auth = init_auth(
+        &config,
+        &*seed_store,
+        &keys_ks,
+        #[cfg(feature = "webvh")]
+        Some(&webvh_ks),
+        #[cfg(not(feature = "webvh"))]
+        None,
+    )
+    .await;
 
     // Telemetry sink: reuse the run-path's live sink when injected, else a
     // fresh ring buffer for non-axum front-ends.
@@ -1434,6 +1443,8 @@ async fn init_auth(
     config: &AppConfig,
     seed_store: &dyn SeedStore,
     keys_ks: &KeyspaceHandle,
+    #[cfg(feature = "webvh")] webvh_ks: Option<&KeyspaceHandle>,
+    #[cfg(not(feature = "webvh"))] _webvh_ks: Option<&KeyspaceHandle>,
 ) -> AuthInit {
     let vta_did = match &config.vta_did {
         Some(did) => did.clone(),
@@ -1482,13 +1493,23 @@ async fn init_auth(
         }
         builder.build()
     };
-    let did_resolver = match DIDCacheClient::new(resolver_config).await {
+    let mut did_resolver = match DIDCacheClient::new(resolver_config).await {
         Ok(r) => r,
         Err(e) => {
             warn!("failed to create DID resolver: {e} — auth endpoints will not work");
             return AuthInit::empty();
         }
     };
+
+    // 1.2. Preload the VTA's DID document into the resolver so that DIDComm consumers
+    // can resolve it without a network round-trip.
+    preload_self_did_document(
+        &mut did_resolver,
+        &vta_did,
+        #[cfg(feature = "webvh")]
+        webvh_ks,
+    )
+    .await;
 
     // 2. Secrets resolver with VTA's Ed25519 + X25519 secrets
     let (secrets_resolver, _handle) = ThreadedSecretsResolver::new(None).await;
@@ -1733,6 +1754,65 @@ async fn init_auth(
     }
 }
 
+/// Seed the resolver with this VTA's own DID document so it can pack/unpack DIDComm
+/// messages without hitting the network (did:web/did:webvh self-resolution
+/// needs HTTPS, which may be unreachable from the VTA's own network).
+///
+/// If local state is missing or malformed we warn and fall back to normal
+/// resolver behaviour.
+async fn preload_self_did_document(
+    did_resolver: &mut DIDCacheClient,
+    vta_did: &str,
+    #[cfg(feature = "webvh")] webvh_ks: Option<&KeyspaceHandle>,
+) {
+    #[cfg(feature = "webvh")]
+    {
+        if !vta_did.starts_with("did:webvh:") {
+            return;
+        }
+
+        let Some(webvh_ks) = webvh_ks else {
+            warn!(
+                did = %vta_did,
+                "webvh keyspace not available; self DID preload skipped"
+            );
+            return;
+        };
+
+        let Some(did_log) = (match crate::webvh_store::get_did_log(webvh_ks, vta_did).await {
+            Ok(log) => log,
+            Err(e) => {
+                warn!(did = %vta_did, error = %e, "failed to read local did.jsonl for resolver preload");
+                return;
+            }
+        }) else {
+            warn!(did = %vta_did, "no local did.jsonl found for resolver preload");
+            return;
+        };
+
+        let doc_value = match crate::operations::protocol::document::current_document_from_log(
+            &did_log,
+        ) {
+            Ok(doc) => doc,
+            Err(e) => {
+                warn!(did = %vta_did, error = %e, "failed to parse local did.jsonl for resolver preload");
+                return;
+            }
+        };
+
+        let doc = match serde_json::from_value(doc_value) {
+            Ok(doc) => doc,
+            Err(e) => {
+                warn!(did = %vta_did, error = %e, "failed to decode DID document for resolver preload");
+                return;
+            }
+        };
+
+        did_resolver.add_did_document(vta_did, doc).await;
+        info!(did = %vta_did, "preloaded VTA DID into resolver cache from local did.jsonl");
+    }
+}
+
 /// Look up VTA signing and key-agreement derivation paths from stored key records.
 ///
 /// `did:webvh` (and other methods with independently-derived X25519) stores
@@ -1856,6 +1936,9 @@ mod tests {
     use super::*;
     use crate::keys::{KeyType, save_key_record};
     use crate::store::Store;
+    #[cfg(feature = "webvh")]
+    use crate::webvh_store;
+    use affinidi_did_resolver_cache_sdk::config::DIDCacheConfigBuilder;
     use vti_common::config::StoreConfig;
 
     fn temp_keys_ks() -> (Store, KeyspaceHandle, tempfile::TempDir) {
@@ -1868,6 +1951,19 @@ mod tests {
             .keyspace(crate::keyspaces::KEYS)
             .expect("keys keyspace");
         (store, keys_ks, dir)
+    }
+
+    #[cfg(feature = "webvh")]
+    fn temp_webvh_ks() -> (Store, KeyspaceHandle, tempfile::TempDir) {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let store = Store::open(&StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        })
+        .expect("store open");
+        let webvh_ks = store
+            .keyspace(crate::keyspaces::WEBVH)
+            .expect("webvh keyspace");
+        (store, webvh_ks, dir)
     }
 
     /// `did:key` VTAs only store the Ed25519 signing record at `#key-0`;
@@ -2005,5 +2101,67 @@ mod tests {
         assert!(msg.contains("could not be loaded"), "{msg}");
         assert!(msg.contains("did:key:z6MkTest"), "{msg}");
         assert!(msg.contains("--allow-degraded"), "{msg}");
+    }
+
+    /// once we seed the resolver from local did.jsonl,
+    /// resolving the VTA DID is cache-only and does not
+    /// require network reachability to its own public domain.
+    #[cfg(feature = "webvh")]
+    #[tokio::test]
+    async fn preload_self_did_document_makes_vta_did_resolvable_from_cache() {
+        let (_store, webvh_ks, _dir) = temp_webvh_ks();
+        let did = "did:webvh:QmScid:vta.example.com:vta";
+
+        let log_line = serde_json::json!({
+            "versionId": "1-test",
+            "versionTime": "2026-05-06T00:00:00Z",
+            "parameters": {},
+            "state": {
+                "@context": ["https://www.w3.org/ns/did/v1"],
+                "id": did,
+            },
+        });
+        let log = serde_json::to_string(&log_line).expect("serialize log line");
+        webvh_store::store_did_log(&webvh_ks, did, &log)
+            .await
+            .expect("store did log");
+
+        let mut resolver = DIDCacheClient::new(DIDCacheConfigBuilder::default().build())
+            .await
+            .expect("resolver init");
+
+        preload_self_did_document(&mut resolver, did, Some(&webvh_ks)).await;
+
+        let resolved = resolver.resolve(did).await.expect("resolve preloaded did");
+        assert!(
+            resolved.cache_hit,
+            "preloaded DID was not served from cache"
+        );
+        assert_eq!(resolved.doc.id, did);
+    }
+
+    /// Malformed local did.jsonl must be a safe no-op: preload logs a warning
+    /// and leaves resolver behavior unchanged (no poisoned cache entry).
+    #[cfg(feature = "webvh")]
+    #[tokio::test]
+    async fn preload_self_did_document_ignores_malformed_local_log() {
+        let (_store, webvh_ks, _dir) = temp_webvh_ks();
+        let did = "did:webvh:QmBadScid:vta.example.com:vta";
+
+        webvh_store::store_did_log(&webvh_ks, did, "not-json")
+            .await
+            .expect("store malformed did log");
+
+        let mut resolver = DIDCacheClient::new(DIDCacheConfigBuilder::default().build())
+            .await
+            .expect("resolver init");
+
+        preload_self_did_document(&mut resolver, did, Some(&webvh_ks)).await;
+
+        let result = resolver.resolve(did).await;
+        assert!(
+            result.is_err(),
+            "malformed preload input should not seed resolver cache"
+        );
     }
 }

--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -2137,7 +2137,16 @@ mod tests {
             resolved.cache_hit,
             "preloaded DID was not served from cache"
         );
-        assert_eq!(resolved.doc.id, did);
+
+        let expected_value = crate::operations::protocol::document::current_document_from_log(&log)
+            .expect("extract current DID document from did.jsonl");
+        let expected_doc =
+            serde_json::from_value(expected_value).expect("deserialize expected DID document");
+
+        assert_eq!(
+            resolved.doc, expected_doc,
+            "resolved DID document should match local did.jsonl current state"
+        );
     }
 
     /// Malformed local did.jsonl must be a safe no-op: preload logs a warning

--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -1443,8 +1443,10 @@ async fn init_auth(
     config: &AppConfig,
     seed_store: &dyn SeedStore,
     keys_ks: &KeyspaceHandle,
-    #[cfg(feature = "webvh")] webvh_ks: Option<&KeyspaceHandle>,
-    #[cfg(not(feature = "webvh"))] _webvh_ks: Option<&KeyspaceHandle>,
+    // Local `did.jsonl` source for the self-DID resolver preload (webvh only).
+    // Always present in the signature; the caller passes `None` when the
+    // `webvh` feature is off. Keeps the signature identical across feature sets.
+    webvh_ks: Option<&KeyspaceHandle>,
 ) -> AuthInit {
     let vta_did = match &config.vta_did {
         Some(did) => did.clone(),
@@ -1503,13 +1505,7 @@ async fn init_auth(
 
     // 1.2. Preload the VTA's DID document into the resolver so that DIDComm consumers
     // can resolve it without a network round-trip.
-    preload_self_did_document(
-        &mut did_resolver,
-        &vta_did,
-        #[cfg(feature = "webvh")]
-        webvh_ks,
-    )
-    .await;
+    preload_self_did_document(&mut did_resolver, &vta_did, webvh_ks).await;
 
     // 2. Secrets resolver with VTA's Ed25519 + X25519 secrets
     let (secrets_resolver, _handle) = ThreadedSecretsResolver::new(None).await;
@@ -1754,17 +1750,41 @@ async fn init_auth(
     }
 }
 
-/// Seed the resolver with this VTA's own DID document so it can pack/unpack DIDComm
-/// messages without hitting the network (did:web/did:webvh self-resolution
-/// needs HTTPS, which may be unreachable from the VTA's own network).
+/// Seed the resolver with this VTA's own `did:webvh` document so it can
+/// pack/unpack DIDComm messages without a network round-trip. `did:webvh`
+/// self-resolution normally needs HTTPS to the VTA's own public domain, which
+/// may be unreachable from inside the VTA's network (e.g. VPC-internal); the
+/// locally stored `did.jsonl` (WEBVH keyspace) is the authoritative source, so
+/// we seed the cache from it instead.
 ///
-/// If local state is missing or malformed we warn and fall back to normal
-/// resolver behaviour.
+/// Scope: **`did:webvh` only** — the preload reads the local webvh log.
+/// `did:web` and other network-resolved methods have no local log to seed from,
+/// so they are left to normal resolver behaviour.
+///
+/// Staleness: this runs once at init. Runtime `services {…}` operations mutate
+/// the VTA's own DID document (and republish `did.jsonl`), which this seeded
+/// entry does **not** track. That is bounded and safe for the intended purpose:
+/// per the runtime-service-management invariant, `verificationMethod` stays
+/// byte-identical across those mutations, so the keys DIDComm pack/unpack needs
+/// are never stale — only advertised `service` entries could drift in the VTA's
+/// *self*-view. Re-seeding on DID-document mutation is a possible follow-up (the
+/// service-management ops already hold the fresh log).
+///
+/// Best-effort: if local state is missing or malformed we warn and fall back to
+/// normal resolver behaviour (never a poisoned cache).
 async fn preload_self_did_document(
     did_resolver: &mut DIDCacheClient,
     vta_did: &str,
-    #[cfg(feature = "webvh")] webvh_ks: Option<&KeyspaceHandle>,
+    webvh_ks: Option<&KeyspaceHandle>,
 ) {
+    #[cfg(not(feature = "webvh"))]
+    {
+        // Without the `webvh` feature there is no local webvh log to seed from;
+        // nothing to preload. Consume the params so the non-webvh build is
+        // warning-clean under `-D warnings`.
+        let _ = (&did_resolver, vta_did, webvh_ks);
+    }
+
     #[cfg(feature = "webvh")]
     {
         if !vta_did.starts_with("did:webvh:") {


### PR DESCRIPTION
This PR improves VTA startup/runtime reliability for self-resolution of did:webvh in private or constrained network environments.

What changed
1. Added self-DID resolver preload during auth/resolver initialization.
2. The VTA now seeds DIDCacheClient with its own DID document from locally stored did.jsonl (WEBVH keyspace), instead of depending on network fetch of its public DID URL.
3. Added feature-gated wiring for webvh keyspace into init_auth.
4. Added unit tests for:
   1. successful preload and cache-hit resolution
   2. malformed local log as safe no-op (no poisoned cache)

Why
In some deployments (for example EC2/VPC-internal), the VTA may be unable to resolve its own public domain from inside its runtime environment. Preloading self DID from local did.jsonl removes that dependency and prevents avoidable resolution failures.