### PR TITLE
fix(webvh): authenticate to the hosting server when publishing agent DIDs

### DIFF
--- a/vta-service/src/did_webvh.rs
+++ b/vta-service/src/did_webvh.rs
@@ -41,6 +41,7 @@ pub async fn run_create_did_webvh(
     let imported_ks = store.keyspace(crate::keyspaces::IMPORTED_SECRETS)?;
     let contexts_ks = store.keyspace(crate::keyspaces::CONTEXTS)?;
     let webvh_ks = store.keyspace(crate::keyspaces::WEBVH)?;
+    let audit_ks = store.keyspace(crate::keyspaces::AUDIT)?;
     let did_templates_ks = store.keyspace(crate::keyspaces::DID_TEMPLATES)?;
 
     // Resolve context
@@ -209,16 +210,23 @@ pub async fn run_create_did_webvh(
         is_vta_identity: false,
     };
 
+    // Offline CLI: no shared AppState, so create a local per-server
+    // auth-lock registry. This path is serverless (`server_id: None`),
+    // so it won't authenticate to a hosting server, but the deps bundle
+    // requires the field.
+    let auth_locks = operations::did_webvh::WebvhAuthLocks::new();
     let deps = operations::did_webvh::CreateDidWebvhDeps {
         keys_ks: &keys_ks,
         imported_ks: &imported_ks,
         contexts_ks: &contexts_ks,
         webvh_ks: &webvh_ks,
         did_templates_ks: &did_templates_ks,
+        audit_ks: &audit_ks,
         seed_store: &*seed_store,
         config: &config,
         did_resolver: &did_resolver,
         didcomm_bridge: &no_bridge,
+        auth_locks: &auth_locks,
     };
     let result = operations::did_webvh::create_did_webvh(&deps, &auth, params, "cli").await?;
 

--- a/vta-service/src/messaging/router.rs
+++ b/vta-service/src/messaging/router.rs
@@ -130,6 +130,7 @@ impl From<&VtaState> for crate::operations::provision_integration::ProvisionInte
             config: state.config.clone(),
             did_resolver: state.did_resolver.clone(),
             didcomm_bridge: state.didcomm_bridge.clone(),
+            webvh_auth_locks: state.webvh_auth_locks.clone(),
         }
     }
 }

--- a/vta-service/src/operations/did_webvh/mod.rs
+++ b/vta-service/src/operations/did_webvh/mod.rs
@@ -165,10 +165,18 @@ pub struct CreateDidWebvhDeps<'a> {
     pub contexts_ks: &'a KeyspaceHandle,
     pub webvh_ks: &'a KeyspaceHandle,
     pub did_templates_ks: &'a KeyspaceHandle,
+    /// Audit keyspace — needed to load the VTA's own signing identity
+    /// (`load_vta_webvh_signing_identity`) when authenticating a
+    /// server publish. Only touched on the non-serverless path.
+    pub audit_ks: &'a KeyspaceHandle,
     pub seed_store: &'a dyn SeedStore,
     pub config: &'a AppConfig,
     pub did_resolver: &'a DIDCacheClient,
     pub didcomm_bridge: &'a Arc<DIDCommBridge>,
+    /// Per-server auth-cache mutex registry — serialises token
+    /// refresh/reauth against a hosting daemon. Only used when
+    /// publishing to a registered server (not serverless / did:key).
+    pub auth_locks: &'a WebvhAuthLocks,
 }
 
 impl<'a> CreateDidWebvhDeps<'a> {
@@ -187,10 +195,12 @@ impl<'a> CreateDidWebvhDeps<'a> {
             contexts_ks: &s.contexts_ks,
             webvh_ks: &s.webvh_ks,
             did_templates_ks: &s.did_templates_ks,
+            audit_ks: &s.audit_ks,
             seed_store: &*s.seed_store,
             config,
             did_resolver,
             didcomm_bridge: &s.didcomm_bridge,
+            auth_locks: &s.webvh_auth_locks,
         }
     }
 
@@ -208,10 +218,12 @@ impl<'a> CreateDidWebvhDeps<'a> {
             contexts_ks: &s.contexts_ks,
             webvh_ks: &s.webvh_ks,
             did_templates_ks: &s.did_templates_ks,
+            audit_ks: &s.audit_ks,
             seed_store: &*s.seed_store,
             config,
             did_resolver,
             didcomm_bridge: &s.didcomm_bridge,
+            auth_locks: &s.webvh_auth_locks,
         }
     }
 }
@@ -458,6 +470,61 @@ fn document_has_didcomm_service(doc: &serde_json::Value) -> bool {
         })
 }
 
+/// Build an *authenticated* hosting-server transport for a create-DID
+/// publish/request-uri call.
+///
+/// This is the create-path analogue of the `auth_cache::*_on_server`
+/// helpers (which take a [`WebvhDeps`], not a [`CreateDidWebvhDeps`]).
+/// It loads the VTA's own signing identity via `config.vta_did`,
+/// constructs an [`auth_cache::AuthContext`], and hands it to
+/// [`WebvhTransport::from_server_authenticated`], which applies a fresh
+/// Bearer token for REST transports and no-ops for DIDComm (authcrypt
+/// authenticates at the envelope layer).
+///
+/// The returned transport does not borrow the (locally-owned) signing
+/// identity — `from_server_authenticated` consumes the `AuthContext`
+/// synchronously while minting/refreshing the token, so the identity can
+/// be dropped as soon as this helper returns.
+///
+/// Returns a clear [`AppError`] when `config.vta_did` is `None`: a server
+/// publish requires the VTA to authenticate to the hosting daemon with
+/// its own DID, and there is no identity to sign the auth challenge with.
+#[allow(clippy::too_many_arguments)]
+async fn authenticated_server_transport<'a>(
+    keys_ks: &KeyspaceHandle,
+    imported_ks: &KeyspaceHandle,
+    seed_store: &dyn SeedStore,
+    audit_ks: &KeyspaceHandle,
+    webvh_ks: &KeyspaceHandle,
+    did_resolver: &DIDCacheClient,
+    didcomm_bridge: &'a Arc<DIDCommBridge>,
+    auth_locks: &WebvhAuthLocks,
+    vta_did: Option<&str>,
+    server: &WebvhServerRecord,
+) -> Result<WebvhTransport<'a>, AppError> {
+    let vta_did = vta_did.ok_or_else(|| {
+        AppError::Validation(
+            "vta_did is not configured; the VTA needs its own DID to authenticate to a webvh \
+             hosting server (set `vta_did` in config / VTA_DID)"
+                .into(),
+        )
+    })?;
+    let identity = auth_cache::load_vta_webvh_signing_identity(
+        keys_ks,
+        imported_ks,
+        seed_store,
+        audit_ks,
+        vta_did,
+    )
+    .await?;
+    let auth_ctx = auth_cache::AuthContext {
+        webvh_ks,
+        identity: &identity,
+        locks: auth_locks,
+    };
+    WebvhTransport::from_server_authenticated(server, did_resolver, didcomm_bridge, &auth_ctx).await
+}
+
 pub async fn create_did_webvh(
     deps: &CreateDidWebvhDeps<'_>,
     auth: &AuthClaims,
@@ -473,10 +540,12 @@ pub async fn create_did_webvh(
         contexts_ks,
         webvh_ks,
         did_templates_ks,
+        audit_ks,
         seed_store,
         config,
         did_resolver,
         didcomm_bridge,
+        auth_locks,
     } = *deps;
 
     auth.require_admin()?;
@@ -554,8 +623,19 @@ pub async fn create_did_webvh(
                 .ok_or_else(|| {
                     AppError::NotFound(format!("webvh server not found: {server_id}"))
                 })?;
-            let transport =
-                WebvhTransport::from_server(&server, did_resolver, didcomm_bridge).await?;
+            let transport = authenticated_server_transport(
+                keys_ks,
+                imported_ks,
+                seed_store,
+                audit_ks,
+                webvh_ks,
+                did_resolver,
+                didcomm_bridge,
+                auth_locks,
+                config.vta_did.as_deref(),
+                &server,
+            )
+            .await?;
             // Final mode has no mnemonic from a server request — use the SCID as identifier
             // Background publish (final-mode rotation push): no
             // domain override; the remote uses the slot's recorded
@@ -773,7 +853,19 @@ pub async fn create_did_webvh(
             .await?
             .ok_or_else(|| AppError::NotFound(format!("webvh server not found: {server_id}")))?;
 
-        let transport = WebvhTransport::from_server(&server, did_resolver, didcomm_bridge).await?;
+        let transport = authenticated_server_transport(
+            keys_ks,
+            imported_ks,
+            seed_store,
+            audit_ks,
+            webvh_ks,
+            did_resolver,
+            didcomm_bridge,
+            auth_locks,
+            config.vta_did.as_deref(),
+            &server,
+        )
+        .await?;
         // Domain selection: `params.domain` is the explicit caller-
         // supplied override (pnm CLI `--domain`). When omitted, the
         // remote resolves via caller's ACL default → system default.
@@ -1131,7 +1223,19 @@ pub async fn create_did_webvh(
             .await?
             .ok_or_else(|| AppError::NotFound(format!("webvh server not found: {server_id}")))?;
 
-        let transport = WebvhTransport::from_server(&server, did_resolver, didcomm_bridge).await?;
+        let transport = authenticated_server_transport(
+            keys_ks,
+            imported_ks,
+            seed_store,
+            audit_ks,
+            webvh_ks,
+            did_resolver,
+            didcomm_bridge,
+            auth_locks,
+            config.vta_did.as_deref(),
+            &server,
+        )
+        .await?;
         // Reuse the same `params.domain` selection the request_uri
         // call above used. The remote already knows the slot's domain
         // from the reservation, so this is a redundant override —

--- a/vta-service/src/operations/did_webvh/update/mod.rs
+++ b/vta-service/src/operations/did_webvh/update/mod.rs
@@ -677,16 +677,21 @@ mod pre_rotation_e2e_tests {
         context_id: &str,
         pre_rotation_count: u32,
     ) -> (String, String) {
+        // Serverless create helper — no server publish, so a fresh local
+        // auth-lock registry suffices.
+        let auth_locks = crate::operations::did_webvh::WebvhAuthLocks::new();
         let deps = CreateDidWebvhDeps {
             keys_ks: &ts.keys_ks,
             imported_ks: &ts.imported_ks,
             contexts_ks: &ts.contexts_ks,
             webvh_ks: &ts.webvh_ks,
             did_templates_ks: &ts.did_templates_ks,
+            audit_ks: &ts.audit_ks,
             seed_store,
             config: cfg,
             did_resolver: resolver,
             didcomm_bridge: bridge,
+            auth_locks: &auth_locks,
         };
         let result = create_did_webvh(
             &deps,

--- a/vta-service/src/operations/provision_integration/mod.rs
+++ b/vta-service/src/operations/provision_integration/mod.rs
@@ -122,6 +122,11 @@ pub struct ProvisionIntegrationDeps {
     pub config: Arc<RwLock<AppConfig>>,
     pub did_resolver: Option<DIDCacheClient>,
     pub didcomm_bridge: Arc<DIDCommBridge>,
+    /// Per-server webvh auth-cache mutex registry, shared with the rest
+    /// of the process via `AppState`. Needed so a provisioned
+    /// server-managed DID authenticates its publish to the hosting
+    /// daemon (challenge → VTA-signed JWS → Bearer token).
+    pub webvh_auth_locks: crate::operations::did_webvh::WebvhAuthLocks,
 }
 
 impl From<&AppState> for ProvisionIntegrationDeps {
@@ -139,6 +144,7 @@ impl From<&AppState> for ProvisionIntegrationDeps {
             config: state.config.clone(),
             did_resolver: state.did_resolver.clone(),
             didcomm_bridge: state.didcomm_bridge.clone(),
+            webvh_auth_locks: state.webvh_auth_locks.clone(),
         }
     }
 }
@@ -417,17 +423,19 @@ pub async fn provision_integration(
             .as_ref()
             .ok_or_else(|| AppError::Internal("DID resolver not initialized".into()))?;
         // `state` is a `ProvisionIntegrationDeps`, not an `AppState`, so build
-        // the create-deps by hand (it carries all nine fields).
+        // the create-deps by hand (it carries all the fields).
         let create_deps = super::did_webvh::CreateDidWebvhDeps {
             keys_ks: &state.keys_ks,
             imported_ks: &state.imported_ks,
             contexts_ks: &state.contexts_ks,
             webvh_ks: &state.webvh_ks,
             did_templates_ks: &state.did_templates_ks,
+            audit_ks: &state.audit_ks,
             seed_store: &*state.seed_store,
             config: &config,
             did_resolver,
             didcomm_bridge: &state.didcomm_bridge,
+            auth_locks: &state.webvh_auth_locks,
         };
         let create_result = super::did_webvh::create_did_webvh(
             &create_deps,

--- a/vta-service/src/setup/from_toml.rs
+++ b/vta-service/src/setup/from_toml.rs
@@ -562,6 +562,7 @@ pub async fn apply_inputs(
     let imported_ks = store.keyspace(crate::keyspaces::IMPORTED_SECRETS)?;
     let contexts_ks = store.keyspace(crate::keyspaces::CONTEXTS)?;
     let webvh_ks = store.keyspace(crate::keyspaces::WEBVH)?;
+    let audit_ks = store.keyspace(crate::keyspaces::AUDIT)?;
     let did_templates_ks = store.keyspace(crate::keyspaces::DID_TEMPLATES)?;
 
     let mut vta_ctx = create_seed_context(&contexts_ks, "vta", "Verifiable Trust Agent").await?;
@@ -685,6 +686,7 @@ pub async fn apply_inputs(
                 &imported_ks,
                 &contexts_ks,
                 &webvh_ks,
+                &audit_ks,
                 &did_templates_ks,
                 &*wizard_seed_store,
                 &wizard_config,
@@ -773,6 +775,7 @@ pub async fn apply_inputs(
                 &imported_ks,
                 &contexts_ks,
                 &webvh_ks,
+                &audit_ks,
                 &did_templates_ks,
                 &*wizard_seed_store,
                 &wizard_config,
@@ -1373,6 +1376,7 @@ async fn create_simple_webvh_did(
     imported_ks: &KeyspaceHandle,
     contexts_ks: &KeyspaceHandle,
     webvh_ks: &KeyspaceHandle,
+    audit_ks: &KeyspaceHandle,
     did_templates_ks: &KeyspaceHandle,
     seed_store: &dyn SeedStore,
     config: &AppConfig,
@@ -1413,16 +1417,23 @@ async fn create_simple_webvh_did(
         is_vta_identity,
     };
 
+    // Setup wizard: no shared AppState, so create a local per-server
+    // auth-lock registry. This path is serverless (mints from a URL),
+    // so it won't authenticate to a hosting server, but the deps bundle
+    // requires the field.
+    let auth_locks = operations::did_webvh::WebvhAuthLocks::new();
     let deps = operations::did_webvh::CreateDidWebvhDeps {
         keys_ks,
         imported_ks,
         contexts_ks,
         webvh_ks,
         did_templates_ks,
+        audit_ks,
         seed_store,
         config,
         did_resolver: &did_resolver,
         didcomm_bridge: &no_bridge,
+        auth_locks: &auth_locks,
     };
     let result = operations::did_webvh::create_did_webvh(&deps, &auth, params, "setup")
         .await

--- a/vta-service/src/test_support.rs
+++ b/vta-service/src/test_support.rs
@@ -158,6 +158,7 @@ pub fn test_deps(ts: &TestStore) -> ProvisionIntegrationDeps {
         config: Arc::new(RwLock::new(test_app_config(ts.data_dir.clone()))),
         did_resolver: None,
         didcomm_bridge: Arc::new(DIDCommBridge::placeholder()),
+        webvh_auth_locks: crate::operations::did_webvh::WebvhAuthLocks::new(),
     }
 }
 
@@ -379,6 +380,7 @@ pub async fn bootstrap_test_vta(ts: &TestStore) -> (String, ProvisionIntegration
         config: Arc::new(RwLock::new(config)),
         did_resolver: Some(resolver),
         didcomm_bridge: Arc::new(DIDCommBridge::placeholder()),
+        webvh_auth_locks: crate::operations::did_webvh::WebvhAuthLocks::new(),
     };
     (vta_did, deps)
 }
@@ -981,6 +983,23 @@ impl StubWebvhHost {
         use axum::routing::{post, put};
         use serde_json::json;
 
+        /// Reject a request that arrives without an `Authorization: Bearer`
+        /// header. The real hosting daemon returns 401 "missing or invalid
+        /// Authorization header" here; the stub mirrors that so a test can
+        /// prove the VTA's publish path actually authenticates (regression
+        /// guard for the `from_server` → `from_server_authenticated` fix).
+        fn require_bearer(headers: &axum::http::HeaderMap) -> Result<(), axum::http::StatusCode> {
+            let ok = headers
+                .get(axum::http::header::AUTHORIZATION)
+                .and_then(|v| v.to_str().ok())
+                .is_some_and(|v| v.starts_with("Bearer ") && v.len() > "Bearer ".len());
+            if ok {
+                Ok(())
+            } else {
+                Err(axum::http::StatusCode::UNAUTHORIZED)
+            }
+        }
+
         async fn tokens() -> axum::Json<serde_json::Value> {
             axum::Json(json!({
                 "sessionId": "stub-session",
@@ -1007,28 +1026,39 @@ impl StubWebvhHost {
             .route("/api/auth/refresh", post(tokens))
             .route(
                 "/api/dids",
-                post(|| async {
-                    axum::Json(
+                post(|headers: axum::http::HeaderMap| async move {
+                    require_bearer(&headers)?;
+                    Ok::<_, axum::http::StatusCode>(axum::Json(
                         json!({ "did_url": STUB_WEBVH_DID_URL, "mnemonic": "stub-mnemonic" }),
-                    )
+                    ))
                 }),
             )
             .route(
                 "/api/dids/register",
-                post(|| async {
-                    axum::Json(
+                post(|headers: axum::http::HeaderMap| async move {
+                    require_bearer(&headers)?;
+                    Ok::<_, axum::http::StatusCode>(axum::Json(
                         json!({ "did_url": STUB_WEBVH_DID_URL, "mnemonic": "stub-mnemonic" }),
-                    )
+                    ))
                 }),
             )
             .route(
                 "/api/dids/check",
-                post(|| async { axum::Json(json!({ "available": true })) }),
+                post(|headers: axum::http::HeaderMap| async move {
+                    require_bearer(&headers)?;
+                    Ok::<_, axum::http::StatusCode>(axum::Json(json!({ "available": true })))
+                }),
             )
             .route(
                 "/api/dids/{mnemonic}",
-                put(|| async { axum::http::StatusCode::OK })
-                    .delete(|| async { axum::http::StatusCode::OK }),
+                put(|headers: axum::http::HeaderMap| async move {
+                    require_bearer(&headers)?;
+                    Ok::<_, axum::http::StatusCode>(axum::http::StatusCode::OK)
+                })
+                .delete(|headers: axum::http::HeaderMap| async move {
+                    require_bearer(&headers)?;
+                    Ok::<_, axum::http::StatusCode>(axum::http::StatusCode::OK)
+                }),
             );
 
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0")

--- a/vta-service/src/webvh_cli.rs
+++ b/vta-service/src/webvh_cli.rs
@@ -150,6 +150,7 @@ pub async fn run_create_did(
     let imported_ks = store.keyspace(crate::keyspaces::IMPORTED_SECRETS)?;
     let contexts_ks = store.keyspace(crate::keyspaces::CONTEXTS)?;
     let webvh_ks = store.keyspace(crate::keyspaces::WEBVH)?;
+    let audit_ks = store.keyspace(crate::keyspaces::AUDIT)?;
     let did_templates_ks = store.keyspace(crate::keyspaces::DID_TEMPLATES)?;
     let seed_store: Arc<dyn crate::keys::seed_store::SeedStore> =
         Arc::from(create_seed_store(&config)?);
@@ -190,16 +191,22 @@ pub async fn run_create_did(
 
     let did_resolver = DIDCacheClient::new(DIDCacheConfigBuilder::default().build()).await?;
     let no_bridge: Arc<DIDCommBridge> = Arc::new(DIDCommBridge::placeholder());
+    // Offline CLI: no shared AppState, so create a local per-server
+    // auth-lock registry for any daemon-REST authentication a publish
+    // may need.
+    let auth_locks = operations::did_webvh::WebvhAuthLocks::new();
     let deps = operations::did_webvh::CreateDidWebvhDeps {
         keys_ks: &keys_ks,
         imported_ks: &imported_ks,
         contexts_ks: &contexts_ks,
         webvh_ks: &webvh_ks,
         did_templates_ks: &did_templates_ks,
+        audit_ks: &audit_ks,
         seed_store: &*seed_store,
         config: &config,
         did_resolver: &did_resolver,
         didcomm_bridge: &no_bridge,
+        auth_locks: &auth_locks,
     };
     let result = operations::did_webvh::create_did_webvh(&deps, &auth, params, "cli").await?;
     store.persist().await?;


### PR DESCRIPTION
## Problem

Provisioning a `did:webvh` with a registered `WEBVH_SERVER` (e.g. an `ai-agent` via provision-integration) fails: the hosting daemon returns **401 "missing or invalid Authorization header"** on `POST /api/dids`.

## Root cause

`create_did_webvh` built the hosting-server transport with the **unauthenticated** `WebvhTransport::from_server(...)` at all three publish sites (`request_uri` for the path reservation, plus the two `publish_did` paths). Those REST calls apply a Bearer token only if the client has one, but `from_server` never authenticates — so the request goes out with no `Authorization` header and the daemon rejects it. The authenticated path (`from_server_authenticated` → `auth_cache::ensure_fresh_access_token`) already existed and was used by the `auth_cache` helpers, just not here.

## Fix

- New helper `authenticated_server_transport` loads the VTA's own signing identity via `config.vta_did`, builds the `auth_cache::AuthContext`, and delegates to the existing `WebvhTransport::from_server_authenticated` (which authenticates for REST and **no-ops for DIDComm** — authcrypt handles it at the envelope layer). All three publish sites now use it.
- `CreateDidWebvhDeps` gains `audit_ks` + `auth_locks` (threaded through its constructors); `ProvisionIntegrationDeps` gains `webvh_auth_locks`, sourced from `AppState`/`VtaState` (which already hold it).
- A server publish with `vta_did` unset now returns a clear validation error instead of a silent 401. Serverless / did:key paths are unchanged.

## Regression guard

`StubWebvhHost` now **requires** an `Authorization: Bearer` header on its mutating routes (mirroring the real daemon), so `create_did_webvh_round_trips_against_stub_host` only passes because the authenticated transport applies the token minted against the stub's `/api/auth` endpoint.

## Testing

- `cargo build -p vta-service --features webvh,didcomm` — green
- `cargo test -p vta-service --features webvh,didcomm` — all pass
- `cargo clippy --all-targets` — no new warnings
- `cargo fmt`