### PR TITLE
test(did-webvh): regression tests for same-second versionTime collision (#600)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10163,7 +10163,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.10.18"
+version = "0.10.19"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.10.18"
+version = "0.10.19"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/operations/did_webvh/mod.rs
+++ b/vta-service/src/operations/did_webvh/mod.rs
@@ -1574,6 +1574,46 @@ mod tests {
     use vti_common::acl::Role;
     use vti_common::config::StoreConfig as VtiStoreConfig;
 
+    /// `backdated_version_time` must yield timestamps that are (a) in
+    /// the past (did:webvh rejects future `versionTime`) and (b)
+    /// strictly increasing by entry index at *second* granularity, so
+    /// a genesis-create and a follow-on update minted in the same
+    /// wall-clock second don't collide. This is the helper behind the
+    /// `services didcomm enable`-right-after-`setup` fix (PR #600).
+    #[test]
+    fn backdated_version_time_is_past_and_strictly_increasing() {
+        let now = chrono::Utc::now();
+
+        let t0 = backdated_version_time(0);
+        let t1 = backdated_version_time(1);
+        let t2 = backdated_version_time(2);
+
+        // Backdated — comfortably in the past (roughly a day).
+        assert!(
+            t0 < now.fixed_offset(),
+            "genesis timestamp must be in the past"
+        );
+        assert!(
+            t2 < now.fixed_offset(),
+            "later timestamps must still be in the past"
+        );
+
+        // Strictly increasing by index …
+        assert!(t0 < t1, "entry 1 must be strictly after entry 0");
+        assert!(t1 < t2, "entry 2 must be strictly after entry 1");
+
+        // … and distinct even after did:webvh's second-granularity
+        // truncation — index spacing (a minute apart) guarantees a
+        // whole-second gap, which is what the same-second collision
+        // needed. Compare truncated-to-second Unix timestamps.
+        assert_ne!(
+            t0.timestamp(),
+            t1.timestamp(),
+            "entries must differ at second precision"
+        );
+        assert_ne!(t1.timestamp(), t2.timestamp());
+    }
+
     /// Pin the post-fetch context-scoping invariant that `delete_did_webvh`
     /// enforces. A context-A admin must not be able to delete a DID record
     /// owned by context B, even when the record exists and the caller has

--- a/vta-service/src/operations/did_webvh/update/mod.rs
+++ b/vta-service/src/operations/did_webvh/update/mod.rs
@@ -1546,4 +1546,104 @@ mod pre_rotation_e2e_tests {
         assert!(result.new_version_id.starts_with("2-"));
         assert_chain_validates(&ts, &did).await;
     }
+
+    /// Regression test for the same-second `versionTime` collision
+    /// (PR #600, `backdated_version_time`).
+    ///
+    /// The VTA creates its `did:webvh` at `vta setup` and updates it
+    /// moments later — e.g. `services didcomm enable` patching in the
+    /// DIDComm mediator service. `did:webvh` serialises `versionTime`
+    /// at *second* granularity and requires each entry to be strictly
+    /// later than the previous, so two entries minted in the same
+    /// wall-clock second serialise identically and make the DID
+    /// unresolvable ("versionTime must be greater than previous") —
+    /// surfacing only when a client fetches `did.jsonl`. The
+    /// user-visible symptom was that `services didcomm enable` reported
+    /// success and wrote `config.toml`, yet the resolved DID document
+    /// still advertised REST-only at version 1.
+    ///
+    /// Every other test in this module dodges the collision by sleeping
+    /// past the second boundary ([`VERSION_TIME_GAP`]); operators
+    /// running `setup` then `enable` back-to-back had no such luxury.
+    /// This test deliberately drives create → didcomm-enable **with no
+    /// sleep in between** and asserts the chain still validates and
+    /// advertises DIDCommMessaging at version 2 — i.e.
+    /// `backdated_version_time` keeps the log strictly increasing
+    /// regardless of how fast the entries are minted.
+    #[tokio::test]
+    async fn create_then_didcomm_enable_back_to_back_resolves() {
+        use crate::operations::protocol::document::{
+            current_didcomm_service, current_document_from_log, with_didcomm_service,
+        };
+
+        let (ts, seed_store) = setup("ctx-vtime").await;
+        let cfg = ts_app_config(&ts);
+        let auth = admin_auth();
+        let resolver = build_resolver().await;
+        let bridge = dummy_bridge();
+        let auth_locks = crate::operations::did_webvh::WebvhAuthLocks::new();
+        let deps = webvh_deps(&ts, &seed_store, &resolver, &bridge, &auth_locks);
+
+        // Genesis entry — mirrors `vta setup`'s `create_webvh` (no
+        // pre-rotation, the plain serverless case from the bug report).
+        let (did, scid) = create_did(
+            &ts,
+            &seed_store,
+            &cfg,
+            &auth,
+            &resolver,
+            &bridge,
+            "ctx-vtime",
+            0,
+        )
+        .await;
+
+        // NO `sleep(VERSION_TIME_GAP)` here — reproducing the operator's
+        // back-to-back `setup` → `services didcomm enable`. Read the
+        // genesis document and patch in the DIDComm mediator service
+        // exactly as `enable_didcomm` does, via the shared patcher.
+        let genesis_log = crate::webvh_store::get_did_log(&ts.webvh_ks, &did)
+            .await
+            .expect("get_did_log")
+            .expect("genesis log present");
+        let genesis_doc = current_document_from_log(&genesis_log).expect("read genesis doc");
+        let mediator_did = "did:web:mediator.example.com";
+        let patched =
+            with_didcomm_service(genesis_doc, mediator_did).expect("patch didcomm service");
+
+        let result = update_did_webvh(
+            &deps,
+            &auth,
+            &scid,
+            UpdateDidWebvhOptions {
+                document: Some(patched),
+                ..Default::default()
+            },
+            Some(did.as_str()),
+            "test",
+        )
+        .await
+        .expect("didcomm-enable update immediately after create must succeed");
+        assert!(
+            result.new_version_id.starts_with("2-"),
+            "expected version 2, got {}",
+            result.new_version_id
+        );
+
+        // The load-bearing assertion: re-parsing the persisted log runs
+        // didwebvh-rs' chain validation, including the strict
+        // `versionTime` monotonicity check that collided pre-#600.
+        assert_chain_validates(&ts, &did).await;
+
+        // And the resolved document actually advertises DIDCommMessaging
+        // — the whole point of `services didcomm enable`.
+        let final_log = crate::webvh_store::get_did_log(&ts.webvh_ks, &did)
+            .await
+            .expect("get_did_log")
+            .expect("log present");
+        let final_doc = current_document_from_log(&final_log).expect("read final doc");
+        let svc = current_didcomm_service(&final_doc)
+            .expect("DIDCommMessaging service advertised after enable");
+        assert_eq!(svc.mediator_did, mediator_did);
+    }
 }


### PR DESCRIPTION
## Root cause

Investigating the reported bug — offline `vta services didcomm enable` updates config but the VTA's did:webvh document keeps advertising REST only (versionId stays `1-`) — traced to the **same-second `versionTime` collision**, not an offline-vs-online split.

- The offline path (`services_cli::run_services_didcomm_enable` → `enable_didcomm` → `update_did_webvh`) **does** reach the WebVH LogEntry publish step; it has since the op was written. It is *not* "returns after only writing config" — `update_did_webvh` runs first, then config.toml is written.
- The genesis entry (from `vta setup`) and the enable's update entry are minted in the **same wall-clock second**. did:webvh serialises `versionTime` at second granularity and requires each entry to be strictly later than the previous, so entry 2 collides. `config.toml` still gets written because the library stamps the entry without validating strict-increase at build time — the failure only surfaces when a client **resolves** `did.jsonl`, which truncates the log back to the version-1 REST-only state.
- This affects **both** transports (online `pnm services didcomm enable` and offline `vta …`) — any create-then-update in the same second.
- The double-quoted `mediator_url` from the report is **not** reproducible on current code: `resolve_mediator` extracts the endpoint via `ServiceEndpoint::get_uri()` (clean string). It points at a double-encoded `serviceEndpoint` on the mediator side, not a VTA config-writer bug.

## Already fixed on main

The bug is **already fixed** by PR #600 (`c73d9db`, "backdate + space the VTA's webvh versionTime"), which landed after v0.10.11 (the build in the report). The user should upgrade to ≥ the build containing #600 (main is now 0.10.19). #600 backdates + index-spaces `versionTime` on both `create_did_webvh` (genesis) and `update_did_webvh`, via `backdated_version_time`.

## What this PR adds

#600 shipped with only manual end-to-end validation and **no automated regression test**. This closes that gap:

- **`create_then_didcomm_enable_back_to_back_resolves`** (did_webvh e2e): drives create → didcomm-enable **with no sleep in between** (every other e2e test in the module dodges the bug by sleeping past the second boundary), then asserts the chain validates and advertises `DIDCommMessaging` at version 2. Temporarily neutering `backdated_version_time` makes it fail with the exact didwebvh-rs error: `Current versionTime (...) must be greater than previous versionTime (...). Log truncated at 2-...` — proving it's a genuine guard, not a vacuous pass.
- **`backdated_version_time_is_past_and_strictly_increasing`** (unit): pins the helper's contract — timestamps are in the past and strictly increasing by entry index at second precision.

Reuses the shared `with_didcomm_service` patcher rather than hand-rolling a service-array edit (per workspace CLAUDE.md).

## Validation

- `cargo fmt` clean
- `cargo clippy -p vta-service --all-targets` — no new warnings (2 pre-existing, unrelated, in `provision_integration/preconditions.rs`)
- `cargo test -p vta-service` — all green
- Bumps vta-service 0.10.18 → 0.10.19

https://claude.ai/code/session_01HoRff8BDqXuSfQ7RNjm3ic