### PR TITLE
feat(vta-sdk): make the didcomm-mediator TSPTransport service opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 ## Unreleased
 
+### vta-sdk (0.18.15) — didcomm-mediator template: make the TSPTransport service opt-in
+
+The `didcomm-mediator` built-in template previously advertised a `#tsp`
+`TSPTransport` service **unconditionally**, so every mediator minted from it
+(VTA-managed or self-hosted webvh) published a TSP endpoint even on
+DIDComm-only deployments — misleading peers into routing TSP the mediator can't
+serve.
+
+The `#tsp` service is now an optional slot: a new `SERVICE_TSP` optional var
+(default `null`) rendered as the whole-string array element `"{SERVICE_TSP}"`,
+pruned when unset (the same mechanism as the P-256 verification-method slots).
+Callers that want TSP advertised supply `SERVICE_TSP` as the fully-resolved
+service object, e.g.:
+
+```json
+{ "id": "{DID}#tsp", "type": "TSPTransport", "serviceEndpoint": "https://mediator.example.com" }
+```
+
+The renderer does not recurse into injected values, so the caller resolves the
+endpoint URL itself; `{DID}` stays a sentinel for the did-method layer.
+
+**Breaking for the mint path:** a caller that does not supply `SERVICE_TSP` now
+gets a document without `#tsp`. Provisioning callers that want TSP advertised
+must pass `SERVICE_TSP` in `integration_template_vars` (it flows through the VTA
+provisioning render unchanged). Other built-in templates that advertise TSP
+(`ai-agent`, `did-host-didcomm`, `did-host-http-didcomm`) are unchanged.
+
 ### vta-service — reliability: preload VTA self DID into resolver cache
 
 `vta-service` now preloads its own `did:webvh` DID document into the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -393,7 +393,7 @@ dependencies = [
  "trust-tasks-rs",
  "url",
  "uuid",
- "vta-sdk 0.18.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vta-sdk 0.18.14",
 ]
 
 [[package]]
@@ -2452,7 +2452,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.18.14",
+ "vta-sdk 0.18.15",
 ]
 
 [[package]]
@@ -3254,7 +3254,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.18.14",
+ "vta-sdk 0.18.15",
 ]
 
 [[package]]
@@ -6714,7 +6714,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.18.14",
+ "vta-sdk 0.18.15",
 ]
 
 [[package]]
@@ -10016,7 +10016,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.18.14",
+ "vta-sdk 0.18.15",
  "vti-common",
  "x25519-dalek",
 ]
@@ -10049,7 +10049,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.18.14",
+ "vta-sdk 0.18.15",
 ]
 
 [[package]]
@@ -10072,12 +10072,42 @@ dependencies = [
  "tracing-subscriber",
  "trust-tasks-rs",
  "uniffi",
- "vta-sdk 0.18.14",
+ "vta-sdk 0.18.15",
 ]
 
 [[package]]
 name = "vta-sdk"
 version = "0.18.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bab5ab7ffa4362d8362ef3f9767e965395d54c9f7e0512071231aeb7db6656b"
+dependencies = [
+ "affinidi-crypto",
+ "affinidi-did-resolver-cache-sdk",
+ "affinidi-messaging-didcomm",
+ "affinidi-openid4vci",
+ "affinidi-openid4vp",
+ "affinidi-tdk",
+ "base64 0.22.1",
+ "chrono",
+ "curve25519-dalek",
+ "didwebvh-rs",
+ "ed25519-dalek",
+ "getrandom 0.4.3",
+ "multibase",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "vta-sdk"
+version = "0.18.15"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10129,36 +10159,6 @@ dependencies = [
  "x25519-dalek",
  "x509-parser 0.18.1",
  "zeroize",
-]
-
-[[package]]
-name = "vta-sdk"
-version = "0.18.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bab5ab7ffa4362d8362ef3f9767e965395d54c9f7e0512071231aeb7db6656b"
-dependencies = [
- "affinidi-crypto",
- "affinidi-did-resolver-cache-sdk",
- "affinidi-messaging-didcomm",
- "affinidi-openid4vci",
- "affinidi-openid4vp",
- "affinidi-tdk",
- "base64 0.22.1",
- "chrono",
- "curve25519-dalek",
- "didwebvh-rs",
- "ed25519-dalek",
- "getrandom 0.4.3",
- "multibase",
- "reqwest 0.13.4",
- "serde",
- "serde_json",
- "sha2 0.11.0",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "url",
- "uuid",
 ]
 
 [[package]]
@@ -10239,7 +10239,7 @@ dependencies = [
  "utoipa-axum",
  "uuid",
  "vta-cli-common",
- "vta-sdk 0.18.14",
+ "vta-sdk 0.18.15",
  "vta-service",
  "vti-common",
  "vti-secrets",
@@ -10261,7 +10261,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.18.14",
+ "vta-sdk 0.18.15",
 ]
 
 [[package]]
@@ -10333,7 +10333,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.18.14",
+ "vta-sdk 0.18.15",
  "vtc-service",
  "vti-common",
  "vti-secrets",
@@ -10381,7 +10381,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.18.14",
+ "vta-sdk 0.18.15",
  "webauthn-rs",
  "zeroize",
 ]
@@ -10408,7 +10408,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.18.14",
+ "vta-sdk 0.18.15",
  "vta-service",
  "vti-common",
 ]
@@ -10437,7 +10437,7 @@ dependencies = [
  "tokio",
  "tracing",
  "vaultrs",
- "vta-sdk 0.18.14",
+ "vta-sdk 0.18.15",
  "vti-common",
 ]
 

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.18.14"
+version = "0.18.15"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/did_templates/tests.rs
+++ b/vta-sdk/src/did_templates/tests.rs
@@ -385,25 +385,23 @@ fn didcomm_mediator_builtin_renders_end_to_end() {
     );
 
     let services = doc["service"].as_array().unwrap();
-    assert_eq!(services.len(), 3);
-
-    // TSP service first (canonical preference order, §3.3): id `#tsp`,
-    // type `TSPTransport`, serviceEndpoint a plain-string transport URL.
-    // The mediator's own doc (shape (b)) carries the URL directly, unlike
-    // a consumer doc whose `#tsp` points at this mediator's DID.
-    assert_eq!(services[0]["id"], "did:webvh:mediator:example.com#tsp");
-    assert_eq!(services[0]["type"], "TSPTransport");
-    assert_eq!(
-        services[0]["serviceEndpoint"],
-        "https://mediator.example.com"
+    // No `SERVICE_TSP` supplied -> the optional `#tsp` slot defaults to `null`
+    // and is pruned. A DIDComm-only mediator advertises only DIDComm + auth;
+    // TSP is opt-in (see `..._renders_tsp_service_when_supplied`).
+    assert_eq!(services.len(), 2);
+    assert!(
+        !services
+            .iter()
+            .any(|s| s["type"] == "TSPTransport" || s["type"] == json!(["TSPTransport"])),
+        "TSP must be absent unless SERVICE_TSP is supplied"
     );
 
     // DIDComm service: id `#service`, type as a single-element array,
     // serviceEndpoint as an array of two endpoint objects (HTTP first,
     // WSS second). Each endpoint carries the same accept/routingKeys.
-    assert_eq!(services[1]["id"], "did:webvh:mediator:example.com#service");
-    assert_eq!(services[1]["type"], json!(["DIDCommMessaging"]));
-    let endpoints = services[1]["serviceEndpoint"].as_array().unwrap();
+    assert_eq!(services[0]["id"], "did:webvh:mediator:example.com#service");
+    assert_eq!(services[0]["type"], json!(["DIDCommMessaging"]));
+    let endpoints = services[0]["serviceEndpoint"].as_array().unwrap();
     assert_eq!(endpoints.len(), 2);
     assert_eq!(endpoints[0]["uri"], "https://mediator.example.com");
     assert_eq!(endpoints[0]["accept"], json!(["didcomm/v2"]));
@@ -414,12 +412,50 @@ fn didcomm_mediator_builtin_renders_end_to_end() {
 
     // Authentication service: id `#auth`, type as a single-element array,
     // serviceEndpoint as a plain string at `<URL>/authenticate`.
-    assert_eq!(services[2]["id"], "did:webvh:mediator:example.com#auth");
-    assert_eq!(services[2]["type"], json!(["Authentication"]));
+    assert_eq!(services[1]["id"], "did:webvh:mediator:example.com#auth");
+    assert_eq!(services[1]["type"], json!(["Authentication"]));
     assert_eq!(
-        services[2]["serviceEndpoint"],
+        services[1]["serviceEndpoint"],
         "https://mediator.example.com/authenticate"
     );
+}
+
+#[test]
+fn didcomm_mediator_builtin_renders_tsp_service_when_supplied() {
+    // Opt-in TSP: the caller supplies `SERVICE_TSP` as the fully-resolved
+    // service object (whole-string native-type substitution). Supplied values
+    // are not recursively re-substituted, so — like the P-256 VM slots — they
+    // carry the resolved DID here rather than the `{DID}` sentinel the local
+    // generator would pass in production (which the did-method layer resolves
+    // after SCID computation).
+    let tpl = load_embedded("didcomm-mediator").unwrap();
+    let mut vars = TemplateVars::new();
+    vars.insert_string("DID", "did:webvh:mediator:example.com");
+    vars.insert_string("SIGNING_KEY_MB", "z6MkSign");
+    vars.insert_string("KA_KEY_MB", "z6LSKa");
+    vars.insert_string("URL", "https://mediator.example.com");
+    vars.insert_string("WS_URL", "wss://mediator.example.com/ws");
+    vars.insert(
+        "SERVICE_TSP",
+        json!({
+            "id": "did:webvh:mediator:example.com#tsp",
+            "type": "TSPTransport",
+            "serviceEndpoint": "https://mediator.example.com"
+        }),
+    );
+
+    let doc = tpl.render(&vars).unwrap();
+    let services = doc["service"].as_array().unwrap();
+    // TSP first (canonical preference order), then DIDComm, then auth.
+    assert_eq!(services.len(), 3);
+    assert_eq!(services[0]["id"], "did:webvh:mediator:example.com#tsp");
+    assert_eq!(services[0]["type"], "TSPTransport");
+    assert_eq!(
+        services[0]["serviceEndpoint"],
+        "https://mediator.example.com"
+    );
+    assert_eq!(services[1]["type"], json!(["DIDCommMessaging"]));
+    assert_eq!(services[2]["type"], json!(["Authentication"]));
 }
 
 #[test]
@@ -510,7 +546,8 @@ fn ws_url_is_derived_from_url_when_omitted() {
     // WS_URL deliberately omitted.
 
     let doc = tpl.render(&vars).expect("render with derived WS_URL");
-    let endpoints = doc["service"][1]["serviceEndpoint"].as_array().unwrap();
+    // No SERVICE_TSP -> DIDComm is the first service entry.
+    let endpoints = doc["service"][0]["serviceEndpoint"].as_array().unwrap();
     assert_eq!(
         endpoints[0]["uri"],
         "https://mediator.example.com/mediator/v1"
@@ -534,7 +571,8 @@ fn ws_url_derivation_handles_plain_http_and_trailing_slash() {
     vars.insert_string("URL", "http://mediator.local/");
 
     let doc = tpl.render(&vars).expect("render with derived ws://");
-    let endpoints = doc["service"][1]["serviceEndpoint"].as_array().unwrap();
+    // No SERVICE_TSP -> DIDComm is the first service entry.
+    let endpoints = doc["service"][0]["serviceEndpoint"].as_array().unwrap();
     assert_eq!(endpoints[1]["uri"], "ws://mediator.local/ws");
 }
 
@@ -552,7 +590,8 @@ fn explicit_ws_url_overrides_derivation() {
     vars.insert_string("WS_URL", "wss://ws-gateway.example.net/mediator/ws");
 
     let doc = tpl.render(&vars).unwrap();
-    let endpoints = doc["service"][1]["serviceEndpoint"].as_array().unwrap();
+    // No SERVICE_TSP -> DIDComm is the first service entry.
+    let endpoints = doc["service"][0]["serviceEndpoint"].as_array().unwrap();
     assert_eq!(endpoints[0]["uri"], "https://mediator.example.com");
     assert_eq!(
         endpoints[1]["uri"],

--- a/vta-sdk/templates/didcomm-mediator.json
+++ b/vta-sdk/templates/didcomm-mediator.json
@@ -13,7 +13,8 @@
     "VM_P256_KA": null,
     "AUTH_P256": null,
     "ASSERTION_P256": null,
-    "KEYAGREEMENT_P256": null
+    "KEYAGREEMENT_P256": null,
+    "SERVICE_TSP": null
   },
   "defaults": {
     "preRotationCount": 2,
@@ -47,11 +48,7 @@
     "assertionMethod": ["{DID}#key-0", "{ASSERTION_P256}"],
     "keyAgreement": ["{DID}#key-1", "{KEYAGREEMENT_P256}"],
     "service": [
-      {
-        "id": "{DID}#tsp",
-        "type": "TSPTransport",
-        "serviceEndpoint": "{URL}"
-      },
+      "{SERVICE_TSP}",
       {
         "id": "{DID}#service",
         "type": ["DIDCommMessaging"],


### PR DESCRIPTION
## Problem

The `didcomm-mediator` built-in template advertises a `#tsp` `TSPTransport` service **unconditionally**. Every mediator minted from it — VTA-managed **or** self-hosted webvh — publishes a TSP endpoint even on DIDComm-only deployments, misleading peers into routing TSP the mediator can't serve (its ingress misclassifies it as DIDComm and rejects it).

Discovered while closing out TSP mediator-enablement work in `affinidi-tdk-rs` (the self-hosted side is already handled there by stripping `#tsp` when TSP is off; the mediator runtime now also warns when TSP is advertised without the `tsp` feature). This PR fixes the **source** so VTA-minted mediators can be DIDComm-only too.

## Change

`#tsp` becomes an optional slot:
- new `SERVICE_TSP` optional var (default `null`);
- rendered as the whole-string array element `"{SERVICE_TSP}"`, pruned when unset — the same mechanism the P-256 verification-method slots already use.

Callers that want TSP advertised supply `SERVICE_TSP` as the fully-resolved service object:
```json
{ "id": "{DID}#tsp", "type": "TSPTransport", "serviceEndpoint": "https://mediator.example.com" }
```
The renderer does not recurse into injected values, so the caller resolves the endpoint URL itself; `{DID}` stays a sentinel for the did-method layer (identical to how the P-256 VM slots behave).

## Breaking (mint path)

A caller that does **not** supply `SERVICE_TSP` now gets a document without `#tsp`. Provisioning callers that want TSP advertised must pass `SERVICE_TSP` in `integration_template_vars` — it flows through the VTA provisioning render unchanged (verified: `did_webvh/mod.rs` overlays caller vars last; only `WEBVH_*` keys are stripped).

The paired consumer change lands in `affinidi-tdk-rs` (wizard injects `SERVICE_TSP` when the operator enables TSP). Because TSP+VTA is new with no known production users, the coordination window is low-risk; a DIDComm-only VTA mediator built in the interim simply stops over-advertising TSP (and the `affinidi-tdk-rs` mediator already warns at startup on any mismatch).

Other TSP-advertising built-ins (`ai-agent`, `did-host-didcomm`, `did-host-http-didcomm`) are **unchanged**.

## Testing

- `cargo test -p vta-sdk` — all pass (44 did_templates incl. new `..._renders_tsp_service_when_supplied` + updated end-to-end/WS tests now reflecting DIDComm-first default).
- `cargo clippy -p vta-sdk --all-targets -D warnings` — clean.
- `cargo test -p vta-service --test api_integration create_did_webvh_via_builtin_mediator_template` — passes (finds DIDComm by type, unaffected).

Bumps `vta-sdk` 0.18.14 → 0.18.15. Merge to `main` will publish it via `publish.yml`.