### PR TITLE
fix(webvh): decode the daemon's camelCase DID-management response

### DIFF
--- a/vta-service/src/webvh_client.rs
+++ b/vta-service/src/webvh_client.rs
@@ -73,7 +73,11 @@ fn enforce_transport_security(parsed: &Url, raw: &str) -> Result<(), AppError> {
     )))
 }
 
+/// Wire shape of `POST /api/dids` (and `/api/dids/register`) responses.
+/// The daemon (`did-hosting-common::RequestUriResponse`) serializes camelCase,
+/// so `did_url` arrives as `didUrl` — match it or the body fails to decode.
 #[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct RequestUriResponse {
     pub did_url: String,
     pub mnemonic: String,
@@ -1175,6 +1179,20 @@ mod tests {
             serde_json::from_str(body).expect("flat daemon challenge body must deserialize");
         assert_eq!(parsed.challenge, "abc");
         assert_eq!(parsed.session_id, "sess-1");
+    }
+
+    #[test]
+    fn request_uri_response_deserializes_camelcase_daemon_body() {
+        // The daemon's `POST /api/dids` (+ `/api/dids/register`) response
+        // (did-hosting-common::RequestUriResponse) is camelCase, so `did_url`
+        // arrives as `didUrl`. Regression guard for the wire-format bug where
+        // the mirror lacked `#[serde(rename_all = "camelCase")]` and the body
+        // failed to decode on the publish path.
+        let body = r#"{"mnemonic":"apple-banana-cherry","didUrl":"did:webvh:Qm...:host%3A8534"}"#;
+        let parsed: RequestUriResponse =
+            serde_json::from_str(body).expect("camelCase daemon request-uri body must deserialize");
+        assert_eq!(parsed.mnemonic, "apple-banana-cherry");
+        assert_eq!(parsed.did_url, "did:webvh:Qm...:host%3A8534");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

After a VTA authenticates + is authorized to a `did-hosting-daemon` (via #604, #606, and affinidi-webvh-service#55), the publish path fails at path reservation: `webvh-server response parse error: error decoding response body for POST /api/dids`.

The daemon's `RequestUriResponse` (`did-hosting-common/src/types.rs`) carries `#[serde(rename_all = "camelCase")]`, so it serializes `did_url` as **`didUrl`**. The VTA's mirror `RequestUriResponse` (`vta-service/src/webvh_client.rs`) lacked the rename and expected snake_case `did_url` → serde fails to decode → the whole publish path (both `POST /api/dids` and `POST /api/dids/register`, which reuse this type) breaks.

## Fix

Add `#[serde(rename_all = "camelCase")]` to the VTA's `RequestUriResponse` — the same wire-alignment #606 applied to the auth response types. One attribute; no behavior change beyond decoding the daemon's actual shape.

## Test

`request_uri_response_deserializes_camelcase_daemon_body` deserializes the daemon's real body `{"mnemonic":"...","didUrl":"..."}` and asserts both fields populate.

`cargo test/clippy/fmt -p vta-service --features webvh,didcomm` green.

## Context

Found in a live cross-service run (a VTA provisioning a `did:webvh` agent with a `WEBVH_SERVER`). With this, path reservation decodes and the flow proceeds to log publication. (A separate daemon-side issue then surfaces: the publish path's IDNA host validation rejects the percent-encoded `host%3Aport` form of a `did:webvh` identifier for non-standard-port hosts — filed/handled separately.)