### PR TITLE
feat(tsp): TSP round-trip health probe (VTA responder + pnm health TSP ping)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,9 +311,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-didcomm-service"
-version = "0.3.12"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3600eba2f7e8b1c7ebcaad81c356cee6ffaf8bd03770477fe346025137841ba9"
+checksum = "4d898f2f3b7ae39d3a623d9398c292760a7d5e6016c4fe8ccd413a28b218382d"
 dependencies = [
  "affinidi-messaging-didcomm",
  "affinidi-messaging-sdk",
@@ -2452,7 +2452,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.18.15",
+ "vta-sdk 0.18.16",
 ]
 
 [[package]]
@@ -3254,7 +3254,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.18.15",
+ "vta-sdk 0.18.16",
 ]
 
 [[package]]
@@ -6692,7 +6692,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "pnm-cli"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-resolver-cache-sdk",
@@ -6714,7 +6714,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.18.15",
+ "vta-sdk 0.18.16",
 ]
 
 [[package]]
@@ -10016,7 +10016,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.18.15",
+ "vta-sdk 0.18.16",
  "vti-common",
  "x25519-dalek",
 ]
@@ -10049,7 +10049,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.18.15",
+ "vta-sdk 0.18.16",
 ]
 
 [[package]]
@@ -10072,7 +10072,7 @@ dependencies = [
  "tracing-subscriber",
  "trust-tasks-rs",
  "uniffi",
- "vta-sdk 0.18.15",
+ "vta-sdk 0.18.16",
 ]
 
 [[package]]
@@ -10107,13 +10107,14 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.18.15"
+version = "0.18.16"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
  "affinidi-data-integrity",
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-didcomm",
+ "affinidi-messaging-sdk",
  "affinidi-openid4vci",
  "affinidi-openid4vp",
  "affinidi-sd-jwt",
@@ -10163,7 +10164,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.10.19"
+version = "0.10.20"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",
@@ -10239,7 +10240,7 @@ dependencies = [
  "utoipa-axum",
  "uuid",
  "vta-cli-common",
- "vta-sdk 0.18.15",
+ "vta-sdk 0.18.16",
  "vta-service",
  "vti-common",
  "vti-secrets",
@@ -10261,7 +10262,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.18.15",
+ "vta-sdk 0.18.16",
 ]
 
 [[package]]
@@ -10333,7 +10334,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.18.15",
+ "vta-sdk 0.18.16",
  "vtc-service",
  "vti-common",
  "vti-secrets",
@@ -10381,7 +10382,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.18.15",
+ "vta-sdk 0.18.16",
  "webauthn-rs",
  "zeroize",
 ]
@@ -10408,7 +10409,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.18.15",
+ "vta-sdk 0.18.16",
  "vta-service",
  "vti-common",
 ]
@@ -10437,7 +10438,7 @@ dependencies = [
  "tokio",
  "tracing",
  "vaultrs",
- "vta-sdk 0.18.15",
+ "vta-sdk 0.18.16",
  "vti-common",
 ]
 

--- a/pnm-cli/Cargo.toml
+++ b/pnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pnm-cli"
 description = "CLI Tool for managing a personal Verifiable Trust Agent"
-version = "0.10.1"
+version = "0.10.2"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -19,6 +19,11 @@ default = ["keyring"]
 keyring = ["vta-sdk/keyring"]
 config-session = ["vta-sdk/config-session"]
 azure-secrets = ["vta-sdk/azure-secrets"]
+# Trust Spanning Protocol probe in `pnm health`. Additive and OFF by default
+# (mirrors the gated TSP rollout in vta-service). Enables the SDK's
+# `TspPingSession`; without it `pnm health` still recognises an advertised
+# `TSPTransport` service but notes the probe isn't compiled in.
+tsp = ["vta-sdk/tsp"]
 
 [dependencies]
 vta-sdk = { path = "../vta-sdk", version = "0.18", features = ["session", "sealed-transfer", "attest-verify", "provision-integration", "crypto-provider"] }

--- a/pnm-cli/src/commands/health.rs
+++ b/pnm-cli/src/commands/health.rs
@@ -350,5 +350,90 @@ pub(crate) async fn run(
         println!("  {DIM}(no session){RESET}");
     }
 
+    // ── VTA TSP ────────────────────────────────────────────────────
+    // TSP is the highest-preference transport; probe it when the VTA's DID
+    // document advertises a `TSPTransport` service. That `#tsp` endpoint is the
+    // mediator DID (the VTA is a local account on it — the same mediator the
+    // DIDComm probe used). This runs *after* the DIDComm `TrustPingSession`
+    // above has shut down, so the client DID never holds two mediator sockets at
+    // once (the one-socket-per-DID rule — ADR 0005).
+    let tsp_mediator = caps.as_ref().and_then(|c| c.tsp.as_deref());
+    if let (Some(tsp_mediator), Some(info)) = (tsp_mediator, session.as_ref())
+        && let Some(vta_did) = info.vta_did.as_deref()
+    {
+        print_section("VTA TSP");
+        tsp_probe(
+            &info.client_did,
+            &info.private_key_multibase,
+            tsp_mediator,
+            vta_did,
+        )
+        .await;
+    }
+
     Ok(())
+}
+
+/// Drive the TSP connectivity probe: open the client's TSP websocket to the
+/// mediator, send a Trust Task to the VTA over TSP, and await the response —
+/// proving the full TSP round-trip. Compiled only with the `tsp` feature.
+#[cfg(feature = "tsp")]
+async fn tsp_probe(
+    client_did: &str,
+    private_key_multibase: &str,
+    mediator_did: &str,
+    vta_did: &str,
+) {
+    match tokio::time::timeout(
+        std::time::Duration::from_secs(15),
+        vta_sdk::session::TspPingSession::new(client_did, private_key_multibase, mediator_did),
+    )
+    .await
+    {
+        Ok(Ok(mut session)) => {
+            match session
+                .ping(vta_did, std::time::Duration::from_secs(10))
+                .await
+            {
+                Ok(latency) => {
+                    println!(
+                        "  {CYAN}{:<13}{RESET} {GREEN}✓{RESET} pong ({latency}ms)",
+                        "Trust-ping"
+                    );
+                }
+                Err(e) => {
+                    println!(
+                        "  {CYAN}{:<13}{RESET} {RED}✗{RESET} TSP ping failed: {e}",
+                        "Trust-ping"
+                    );
+                }
+            }
+            session.shutdown().await;
+        }
+        Ok(Err(e)) => {
+            println!(
+                "  {CYAN}{:<13}{RESET} {RED}✗{RESET} TSP setup failed: {e}",
+                "Trust-ping"
+            );
+        }
+        Err(_) => {
+            println!(
+                "  {CYAN}{:<13}{RESET} {RED}✗{RESET} TSP setup timed out",
+                "Trust-ping"
+            );
+        }
+    }
+}
+
+/// Without the `tsp` feature the probe machinery isn't compiled in; note that
+/// TSP is advertised but not exercised so the operator isn't misled into
+/// thinking the transport was tested.
+#[cfg(not(feature = "tsp"))]
+async fn tsp_probe(
+    _client_did: &str,
+    _private_key_multibase: &str,
+    _mediator_did: &str,
+    _vta_did: &str,
+) {
+    println!("  {DIM}advertised — rebuild pnm with `--features tsp` to probe over TSP{RESET}");
 }

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.18.15"
+version = "0.18.16"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -23,6 +23,12 @@ didcomm = ["dep:affinidi-tdk", "dep:affinidi-did-resolver-cache-sdk", "dep:traci
 tsp = [
   "dep:affinidi-tdk",
   "affinidi-tdk/tsp",
+  # `atm.tsp()` + `TspWebSocket` are gated on the messaging SDK's own `tsp`
+  # feature, which `affinidi-tdk/tsp` does not enable — flip it directly.
+  "dep:affinidi-messaging-sdk",
+  "affinidi-messaging-sdk/tsp",
+  # `TspPingSession` builds a `trust_tasks_rs::TrustTask` envelope.
+  "dep:trust-tasks-rs",
   "dep:affinidi-did-resolver-cache-sdk",
   "dep:tracing",
   "dep:uuid",
@@ -169,6 +175,12 @@ multibase = { workspace = true }
 thiserror = { workspace = true }
 url = { workspace = true }
 affinidi-tdk = { workspace = true, optional = true }
+# Feature-only dep: `affinidi-tdk/tsp` pulls the `affinidi-tsp` crate but does
+# NOT flip `affinidi-messaging-sdk/tsp`, which gates the `atm.tsp()` ops the
+# `TspPingSession` needs. Depend on the same crate directly (Cargo unifies to
+# one instance, the one `affinidi_tdk::messaging` re-exports) so the `tsp`
+# feature can turn its `tsp` on — mirrors what `vta-service` does.
+affinidi-messaging-sdk = { version = "0.18", optional = true, default-features = false }
 reqwest = { workspace = true, optional = true }
 # Only for `crypto_init` (the aws-lc-rs CryptoProvider installer).
 rustls = { workspace = true, optional = true }

--- a/vta-sdk/src/session.rs
+++ b/vta-sdk/src/session.rs
@@ -1368,6 +1368,143 @@ impl TrustPingSession {
     }
 }
 
+/// A client-side TSP connectivity probe — the TSP analogue of
+/// [`TrustPingSession`].
+///
+/// Opens the client's **single** TSP websocket to the shared mediator, sends a
+/// Trust Task to the VTA's VID over TSP (routed through the mediator), and
+/// awaits the VTA's response envelope — proving the whole TSP round-trip:
+/// client seal → mediator route → VTA unpack → auth → `dispatch_trust_task_core`
+/// → reply → route back → client receive. This is the receive-capable
+/// counterpart to the outbound-only `atm.tsp().send_*`; the VTA replies via the
+/// symmetric `TspHandler` (`affinidi-messaging-didcomm-service` ≥ 0.3.14).
+///
+/// TSP-only client: no DIDComm listener shares this DID's socket, so
+/// `connect_websocket` is safe here (the one-socket-per-DID rule only bites a
+/// *dual* node — ADR 0005). Callers running a DIDComm [`TrustPingSession`] on
+/// the same client DID must shut it down before opening this.
+#[cfg(feature = "tsp")]
+pub struct TspPingSession {
+    atm: affinidi_tdk::messaging::ATM,
+    profile: std::sync::Arc<affinidi_tdk::messaging::profiles::ATMProfile>,
+    ws: affinidi_tdk::messaging::TspWebSocket,
+    client_did: String,
+    mediator_did: String,
+}
+
+#[cfg(feature = "tsp")]
+impl TspPingSession {
+    /// Connect the client's TSP websocket to `mediator_did` (the VTA's `#tsp`
+    /// service endpoint — the same mediator the VTA is a local account on).
+    pub async fn new(
+        client_did: &str,
+        private_key_multibase: &str,
+        mediator_did: &str,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        use affinidi_tdk::common::TDKSharedState;
+        use affinidi_tdk::common::config::TDKConfig;
+        use affinidi_tdk::messaging::ATM;
+        use affinidi_tdk::messaging::config::ATMConfig;
+        use affinidi_tdk::messaging::profiles::ATMProfile;
+        use std::sync::Arc;
+
+        let seed = crate::did_key::decode_private_key_multibase(private_key_multibase)?;
+        let secrets = crate::did_key::secrets_from_did_key(client_did, &seed)?;
+
+        let tdk = TDKSharedState::new(TDKConfig::builder().build()?).await?;
+        tdk.secrets_resolver().insert(secrets.signing).await;
+        tdk.secrets_resolver().insert(secrets.key_agreement).await;
+
+        let atm = ATM::new(ATMConfig::builder().build()?, Arc::new(tdk)).await?;
+
+        let profile = ATMProfile::new(
+            &atm,
+            None,
+            client_did.to_string(),
+            Some(mediator_did.to_string()),
+        )
+        .await?;
+        let profile = Arc::new(profile);
+
+        let ws = atm.tsp().connect_websocket(&profile).await?;
+
+        Ok(Self {
+            atm,
+            profile,
+            ws,
+            client_did: client_did.to_string(),
+            mediator_did: mediator_did.to_string(),
+        })
+    }
+
+    /// Send a Trust Task to `vta_did` over TSP and await the response envelope.
+    /// Returns latency in milliseconds.
+    ///
+    /// The probe sends an `auth/whoami/0.1` Trust Task (authenticated by the TSP
+    /// unpack's proven sender VID — no holder proof needed on TSP, like DIDComm
+    /// authcrypt). **Any** well-formed response envelope proves the round-trip,
+    /// so the latency is measured to the first frame that unpacks + parses as
+    /// JSON; the probe measures TSP liveness, not whoami success (the DIDComm
+    /// trust-ping is likewise a reachability check, not a semantic one).
+    pub async fn ping(
+        &mut self,
+        vta_did: &str,
+        timeout: std::time::Duration,
+    ) -> Result<u128, Box<dyn std::error::Error>> {
+        use std::time::Instant;
+        use trust_tasks_rs::TrustTask;
+
+        let id = format!("urn:uuid:{}", uuid::Uuid::new_v4());
+        let type_uri = crate::trust_tasks::TASK_AUTH_WHOAMI_0_1
+            .parse()
+            .map_err(|e| format!("whoami type URI parse: {e}"))?;
+        let mut doc: TrustTask<serde_json::Value> =
+            TrustTask::new(id, type_uri, serde_json::json!({}));
+        doc.issuer = Some(self.client_did.clone());
+        doc.recipient = Some(vta_did.to_string());
+        let body = serde_json::to_vec(&doc)?;
+
+        let start = Instant::now();
+        // Route through our mediator to the VTA (a local account on it):
+        // inner sealed end-to-end to the VTA, outer sealed to the mediator.
+        self.atm
+            .tsp()
+            .send_routed(
+                &self.profile,
+                &[self.mediator_did.clone(), vta_did.to_string()],
+                &body,
+            )
+            .await?;
+
+        loop {
+            let remaining = timeout
+                .checked_sub(start.elapsed())
+                .ok_or("TSP ping timed out waiting for reply")?;
+            let frame = match tokio::time::timeout(remaining, self.ws.recv()).await {
+                Ok(Ok(Some(bytes))) => bytes,
+                Ok(Ok(None)) => return Err("TSP websocket closed before reply".into()),
+                Ok(Err(e)) => return Err(Box::new(e)),
+                Err(_) => return Err("TSP ping timed out waiting for reply".into()),
+            };
+            // The VTA's reply is sealed to us; a frame we can unpack and parse
+            // as a JSON trust-task envelope is the pong. (Our ephemeral-ish
+            // client DID has no other TSP traffic, so the first such frame is
+            // our reply.) Frames that don't unpack are skipped.
+            if let Ok((payload, _sender)) = self.atm.tsp().unpack_bytes(&self.profile, &frame).await
+                && serde_json::from_slice::<serde_json::Value>(&payload).is_ok()
+            {
+                return Ok(start.elapsed().as_millis());
+            }
+        }
+    }
+
+    /// Close the TSP websocket and shut down the ATM connection.
+    pub async fn shutdown(self) {
+        let _ = self.ws.close().await;
+        self.atm.graceful_shutdown().await;
+    }
+}
+
 fn now_epoch() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.10.19"
+version = "0.10.20"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/messaging/tsp_inbound.rs
+++ b/vta-service/src/messaging/tsp_inbound.rs
@@ -16,21 +16,27 @@
 //! one (as the earlier standalone loop did) made the mediator evict a
 //! connection as `w.websocket.duplicate-channel`, flapping the VTA.
 //!
-//! ## V1 scope: inbound, one-way
+//! ## Round-trip: the reply routes back over the same socket
 //!
-//! Each received Trust Task is dispatched and its outcome is logged. The
-//! handler does **not** send a Trust-Task response back over TSP; returning a
-//! response routes through the normal send path and is a documented follow-up.
-//! See the `NOTE` in [`dispatch_one`].
+//! Each received Trust Task is dispatched on the shared spine and its response
+//! envelope is returned to the sender **over TSP** — the message service
+//! (`affinidi-messaging-didcomm-service` ≥ 0.3.14) seals the returned
+//! [`TspResponse`] to the proven `sender_vid` and routes it back over the same
+//! mediator socket (`send_routed([mediator_did, sender_vid])`). This mirrors the
+//! DIDComm `handle_trust_task` bridge, which returns the same framework document
+//! as its reply, so TSP and DIDComm callers get byte-identical round-trip
+//! semantics off the shared `dispatch_trust_task_core`.
 
-use affinidi_messaging_didcomm_service::{DIDCommServiceError, HandlerContext, TspHandler};
-use tracing::{info, warn};
+use affinidi_messaging_didcomm_service::{
+    DIDCommServiceError, HandlerContext, TspHandler, TspResponse,
+};
+use tracing::info;
 
 use crate::messaging::auth::auth_from_did;
 use crate::server::AppState;
 
-/// Per-message bridge: turn one unpacked TSP message into a dispatched
-/// Trust Task on the shared spine.
+/// Per-message bridge: turn one unpacked TSP message into a dispatched Trust
+/// Task on the shared spine and return the framework response envelope bytes.
 ///
 /// `sender_vid` is the **proven** sender DID returned by TSP `unpack_bytes`
 /// (verification already happened inside the TSP stack), so this only needs
@@ -39,46 +45,39 @@ use crate::server::AppState;
 /// the Trust-Task envelope bytes (identical to the REST `POST
 /// /api/trust-tasks` body and the DIDComm message body).
 ///
-/// On an unknown / unauthorized sender (no ACL entry, or an expired grant)
-/// the message is logged and dropped — never silently authorized.
-///
-/// NOTE (V1, one-way): the dispatch outcome is logged but **not** returned
-/// to the sender over TSP. Response-over-TSP routes through the normal send
-/// path and is a documented follow-up; this loop is receive-only.
-pub async fn dispatch_one(app_state: &AppState, payload: &[u8], sender_vid: &str) {
-    match auth_from_did(sender_vid, &app_state.acl_ks).await {
-        Ok(auth) => {
-            let outcome =
-                crate::trust_tasks::dispatch_trust_task_core(app_state, &auth, payload).await;
-            // The outcome's HTTP `status` is the framework result code; on
-            // the one-way TSP path we only log it (the self-describing
-            // response document is dropped — see NOTE above).
-            info!(
-                sender = %sender_vid,
-                status = %outcome.status,
-                "TSP trust-task dispatched"
-            );
-        }
-        Err(e) => {
-            // Peer is not in this VTA's ACL (or grant expired). Drop the
-            // message; do not respond.
-            warn!(
-                sender = %sender_vid,
-                error = %e,
-                "TSP message from unauthorized sender — dropped"
-            );
-        }
-    }
+/// The returned `Vec<u8>` is the self-describing framework trust-task document
+/// (its own `type` + status `code`); the caller seals + routes it back to the
+/// sender over TSP. On an unknown / unauthorized sender (no ACL entry, or an
+/// expired grant) the reply is a Trust-Task `permission_denied` **envelope**,
+/// not a drop — the sender VID is cryptographically proven, so there is no
+/// enumeration exposure, and a conformant Trust-Task client only understands
+/// binding envelopes (identical to the DIDComm path).
+pub async fn dispatch_one(app_state: &AppState, payload: &[u8], sender_vid: &str) -> Vec<u8> {
+    let outcome = match auth_from_did(sender_vid, &app_state.acl_ks).await {
+        Ok(auth) => crate::trust_tasks::dispatch_trust_task_core(app_state, &auth, payload).await,
+        Err(e) => crate::trust_tasks::reject_trust_task(
+            payload,
+            trust_tasks_rs::RejectReason::PermissionDenied {
+                reason: e.to_string(),
+            },
+        ),
+    };
+    info!(
+        sender = %sender_vid,
+        status = %outcome.status,
+        "TSP trust-task dispatched"
+    );
+    outcome.body
 }
 
-/// TSP handler registered on the VTA's DIDComm service via
-/// [`DIDCommService::start_with_tsp`](affinidi_messaging_didcomm_service::DIDCommService::start_with_tsp).
+/// TSP handler registered on the VTA's message service via
+/// [`AffinidiMessageService::start_with_tsp`](affinidi_messaging_didcomm_service::AffinidiMessageService::start_with_tsp).
 ///
 /// The service unpacks the TSP frame off the shared websocket (yielding the
 /// cleartext payload + the cryptographically-authenticated `sender_vid`) and
 /// invokes [`handle`](TspHandler::handle), which bridges to the shared spine via
-/// [`dispatch_one`]. Inbound is one-way: the dispatch outcome is logged, not
-/// returned over TSP (see the `NOTE` in [`dispatch_one`]).
+/// [`dispatch_one`] and returns the response envelope as a [`TspResponse`]. The
+/// service seals + routes that reply back to the sender over the same socket.
 pub struct VtaTspHandler {
     app_state: AppState,
 }
@@ -96,9 +95,9 @@ impl TspHandler for VtaTspHandler {
         _ctx: HandlerContext,
         payload: Vec<u8>,
         sender_vid: String,
-    ) -> Result<(), DIDCommServiceError> {
-        dispatch_one(&self.app_state, &payload, &sender_vid).await;
-        Ok(())
+    ) -> Result<Option<TspResponse>, DIDCommServiceError> {
+        let body = dispatch_one(&self.app_state, &payload, &sender_vid).await;
+        Ok(Some(TspResponse::new(body)))
     }
 }
 
@@ -108,24 +107,37 @@ mod tests {
     use crate::acl::{AclEntry, Role, store_acl_entry};
     use crate::test_support::build_signing_test_app_state;
 
-    /// `dispatch_one` with a sender that has no ACL entry must log + drop
-    /// without panicking (it returns `()`; the assertion is that it
-    /// completes). Exercises the unauthorized-sender path.
+    /// A sender with no ACL entry still gets a Trust-Task error **envelope**
+    /// back (not a silent drop) — the sender VID is proven, so we reply like the
+    /// DIDComm path. With this unparseable `{}` body the reject degrades to a
+    /// `malformedRequest` envelope (a well-formed-but-unauthorized request would
+    /// yield `permissionDenied`); either way the round-trip invariant under test
+    /// holds: a non-empty error envelope is produced for the service to route
+    /// back over TSP.
     #[tokio::test]
-    async fn dispatch_one_unknown_sender_drops_without_panic() {
+    async fn dispatch_one_unknown_sender_replies_with_error_envelope() {
         let (app_state, _dir) = build_signing_test_app_state().await;
 
-        // No ACL entry for this sender → auth_from_did errors → dispatch_one
-        // logs a warning and returns without dispatching or panicking.
-        dispatch_one(&app_state, b"{}", "did:key:zUnauthorizedTspSender").await;
+        let body = dispatch_one(&app_state, b"{}", "did:key:zUnauthorizedTspSender").await;
+
+        assert!(
+            !body.is_empty(),
+            "unauthorized sender must get a reply envelope"
+        );
+        let doc: serde_json::Value = serde_json::from_slice(&body).expect("reply is JSON");
+        assert!(
+            doc.get("type").is_some() && doc.get("payload").is_some(),
+            "reply should be a trust-task error envelope, got: {doc}"
+        );
     }
 
-    /// An authorized sender reaches `dispatch_trust_task_core`. The empty
-    /// body is rejected by the core's envelope parser, but the point under
-    /// test is that the bridge resolves the ACL grant and drives the spine
-    /// without panicking (one-way: the outcome is logged, not returned).
+    /// An authorized sender reaches `dispatch_trust_task_core` and the bridge
+    /// returns the framework response envelope bytes for the service to route
+    /// back over TSP. The empty `{}` body is rejected by the core's envelope
+    /// parser, but the point under test is that the ACL grant resolves and the
+    /// spine produces a non-empty reply document.
     #[tokio::test]
-    async fn dispatch_one_authorized_sender_reaches_spine() {
+    async fn dispatch_one_authorized_sender_returns_reply_envelope() {
         let (app_state, _dir) = build_signing_test_app_state().await;
 
         let did = "did:key:zAuthorizedTspSender";
@@ -133,6 +145,12 @@ mod tests {
             .await
             .unwrap();
 
-        dispatch_one(&app_state, b"{}", did).await;
+        let body = dispatch_one(&app_state, b"{}", did).await;
+
+        assert!(
+            !body.is_empty(),
+            "authorized sender must get a reply envelope"
+        );
+        serde_json::from_slice::<serde_json::Value>(&body).expect("reply is JSON");
     }
 }


### PR DESCRIPTION
## Summary

Makes `pnm health` actually **exercise** TSP, not just label it (that was #607). Builds the full client→VTA→client TSP round-trip on the shared Trust-Task spine, consuming the upstream symmetric `TspHandler` (affinidi-messaging-didcomm-service **0.3.14**, affinidi/affinidi-tdk-rs#568).

Three parts:

### 1. VTA-side responder — `vta-service/src/messaging/tsp_inbound.rs`
`VtaTspHandler::handle` now returns the dispatched Trust-Task response envelope as a `TspResponse`; the message service seals + routes it back to the proven `sender_vid` over the same mediator socket. `dispatch_one` returns the framework document (was `()`); an unauthorized — but cryptographically-proven — sender gets a Trust-Task error envelope, **mirroring the DIDComm `handle_trust_task` bridge**. Previously TSP inbound was one-way (the reply was dropped).

### 2. SDK `TspPingSession` — `vta-sdk/src/session.rs` (feature `tsp`)
The TSP analogue of `TrustPingSession`: opens the client's single TSP websocket to the mediator, sends an `auth/whoami/0.1` Trust Task to the VTA VID (routed via the mediator), and awaits the response envelope — measuring full round-trip latency. Any well-formed reply proves liveness (a reachability check, like the DIDComm trust-ping). Adds `affinidi-messaging-sdk` as a **feature-only dep** so the `tsp` feature can flip `affinidi-messaging-sdk/tsp` (which `affinidi-tdk/tsp` does *not*), enabling `atm.tsp()` + `TspWebSocket`.

### 3. `pnm health` wiring — `pnm-cli` (feature `tsp`)
A **"VTA TSP"** section drives the probe when the DID doc advertises a `TSPTransport` service, run *after* the DIDComm `TrustPingSession` shuts down (one socket per DID — ADR 0005). Without the `tsp` feature it notes TSP is advertised but not probed. New `pnm-cli` `tsp` feature (off by default, mirrors the gated rollout).

## Expected output (TSP-enabled VTA, `pnm --features tsp`)

```
── VTA TSP ───────────────────────────────────────
  Trust-ping    ✓ pong (…ms)
```

## Versions

`vta-sdk` 0.18.15→**0.18.16**, `vta-service` 0.10.19→**0.10.20**, `pnm-cli` 0.10.1→**0.10.2**; lock → `affinidi-messaging-didcomm-service` 0.3.14.

## Testing

Builds + clippy clean in **default and `tsp`** configs (`vta-sdk`, `vta-service`, `pnm-cli`); `vta-sdk` lib (159) + `tsp_inbound` tests pass.

**⚠️ Live E2E needs a VTA redeploy:** the round-trip only completes once a VTA running **this** `vta-service` (with the responder) is deployed — a VTA on the old one-way handler won't reply, so `pnm health --features tsp` against it will time out. After deploying: `pnm services … ` unchanged; run `pnm health` (tsp build) against a TSP VTA to see the pong.

Depends on: affinidi/affinidi-tdk-rs#568 (merged, 0.3.14 published).