### PR TITLE
feat(tsp): enable the TSP health probe by default in pnm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6692,7 +6692,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "pnm-cli"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-resolver-cache-sdk",

--- a/pnm-cli/Cargo.toml
+++ b/pnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pnm-cli"
 description = "CLI Tool for managing a personal Verifiable Trust Agent"
-version = "0.10.2"
+version = "0.10.3"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -15,14 +15,16 @@ name = "pnm"
 path = "src/main.rs"
 
 [features]
-default = ["keyring"]
+default = ["keyring", "tsp"]
 keyring = ["vta-sdk/keyring"]
 config-session = ["vta-sdk/config-session"]
 azure-secrets = ["vta-sdk/azure-secrets"]
-# Trust Spanning Protocol probe in `pnm health`. Additive and OFF by default
-# (mirrors the gated TSP rollout in vta-service). Enables the SDK's
-# `TspPingSession`; without it `pnm health` still recognises an advertised
-# `TSPTransport` service but notes the probe isn't compiled in.
+# Trust Spanning Protocol probe in `pnm health`. **On by default** — TSP is the
+# preferred transport (TSP > DIDComm > REST), so operators get the round-trip
+# probe out of the box. Enables the SDK's `TspPingSession`. Build with
+# `--no-default-features` (re-adding `keyring`) to drop the TSP deps; without
+# it `pnm health` still recognises an advertised `TSPTransport` service but
+# notes the probe isn't compiled in.
 tsp = ["vta-sdk/tsp"]
 
 [dependencies]


### PR DESCRIPTION
## Summary

Turns the `pnm health` TSP round-trip probe (#610) **on by default** by adding `tsp` to `pnm-cli`'s default features. TSP is the preferred transport (TSP > DIDComm > REST), so operators get the probe out of the box rather than needing a `--features tsp` build.

## Change

```toml
default = ["keyring", "tsp"]   # was ["keyring"]
```

- **On (default):** `pnm health` runs the TSP `TspPingSession` round-trip against a VTA advertising a `TSPTransport` service.
- **Off (`--no-default-features --features keyring`):** the escape hatch still drops the TSP deps (`affinidi-tsp`, `affinidi-messaging-sdk/tsp`); the `cfg(not(feature = "tsp"))` path notes TSP is advertised but not probed.

## Testing

Builds clean both ways (tsp on and off). `pnm-cli` 0.10.2 → **0.10.3**.

Follow-up to #610.