### PR TITLE
feat(provision): mint self-contained did:peer agents via provision-integration

### DIFF
--- a/vta-sdk/src/did_templates/builtin.rs
+++ b/vta-sdk/src/did_templates/builtin.rs
@@ -10,6 +10,7 @@ use super::{DidTemplate, TemplateError};
 /// `BuiltinNotFound` errors so callers see what's available.
 pub const BUILTIN_NAMES: &[&str] = &[
     "ai-agent",
+    "ai-agent-peer",
     "did-host-didcomm",
     "did-host-http",
     "did-host-http-didcomm",
@@ -20,6 +21,7 @@ pub const BUILTIN_NAMES: &[&str] = &[
 ];
 
 const AI_AGENT: &str = include_str!("../../templates/ai-agent.json");
+const AI_AGENT_PEER: &str = include_str!("../../templates/ai-agent-peer.json");
 const DIDCOMM_MEDIATOR: &str = include_str!("../../templates/didcomm-mediator.json");
 const PUSH_GATEWAY: &str = include_str!("../../templates/push-gateway.json");
 const VTA_ADMIN: &str = include_str!("../../templates/vta-admin.json");
@@ -35,6 +37,7 @@ const DID_HOST_DIDCOMM: &str = include_str!("../../templates/did-host-didcomm.js
 pub fn load_embedded(name: &str) -> Result<DidTemplate, TemplateError> {
     let raw = match name {
         "ai-agent" => AI_AGENT,
+        "ai-agent-peer" => AI_AGENT_PEER,
         "didcomm-mediator" => DIDCOMM_MEDIATOR,
         "push-gateway" => PUSH_GATEWAY,
         "vta-admin" => VTA_ADMIN,

--- a/vta-sdk/src/did_templates/mod.rs
+++ b/vta-sdk/src/did_templates/mod.rs
@@ -261,7 +261,7 @@ pub enum TemplateError {
     ReservedVar(String),
 
     #[error(
-        "builtin template '{0}' not found (available: ai-agent, did-host-didcomm, did-host-http, did-host-http-didcomm, didcomm-mediator, vta-admin, vtc-host)"
+        "builtin template '{0}' not found (available: ai-agent, ai-agent-peer, did-host-didcomm, did-host-http, did-host-http-didcomm, didcomm-mediator, vta-admin, vtc-host)"
     )]
     BuiltinNotFound(String),
 }

--- a/vta-sdk/templates/ai-agent-peer.json
+++ b/vta-sdk/templates/ai-agent-peer.json
@@ -1,0 +1,53 @@
+{
+  "schemaVersion": 1,
+  "name": "ai-agent-peer",
+  "kind": "ai-agent",
+  "description": "Self-contained did:peer personal AI agent identity (open-claw / nano-claw / hermes and the like). The did:peer counterpart to the 'ai-agent' template: it mints an agent DID whose keys and DIDCommMessaging service are encoded directly in the identifier, so there is NO WebVH hosting, no did.jsonl, and no publish step — the DID resolves locally. Use this for agents that authenticate to the VTA over DIDComm and are never resolved by outside HTTPS parties. MEDIATOR_DID is required at provision time and is advertised as the DIDCommMessaging service endpoint (matching how the 'ai-agent' did:webvh template advertises DIDComm), so a minted did:peer agent connects to the VTA over the mediator identically to a did:webvh agent. WEBVH_SERVER / URL are not accepted — there is nothing to host.",
+  "methods": ["peer"],
+  "requiredVars": ["MEDIATOR_DID"],
+  "optionalVars": {
+    "ACCEPT": ["didcomm/v2"],
+    "ROUTING_KEYS": [],
+    "LABEL": null
+  },
+  "defaults": {
+    "portable": true
+  },
+  "document": {
+    "@context": [
+      "https://www.w3.org/ns/did/v1",
+      "https://www.w3.org/ns/cid/v1"
+    ],
+    "id": "{DID}",
+    "verificationMethod": [
+      {
+        "id": "{DID}#key-1",
+        "type": "Multikey",
+        "controller": "{DID}",
+        "publicKeyMultibase": "{SIGNING_KEY_MB}"
+      },
+      {
+        "id": "{DID}#key-2",
+        "type": "Multikey",
+        "controller": "{DID}",
+        "publicKeyMultibase": "{KA_KEY_MB}"
+      }
+    ],
+    "assertionMethod": ["{DID}#key-1"],
+    "authentication": ["{DID}#key-1"],
+    "keyAgreement": ["{DID}#key-2"],
+    "service": [
+      {
+        "id": "{DID}#vta-didcomm",
+        "type": "DIDCommMessaging",
+        "serviceEndpoint": [
+          {
+            "accept": "{ACCEPT}",
+            "routingKeys": "{ROUTING_KEYS}",
+            "uri": "{MEDIATOR_DID}"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/vta-service/src/did_peer.rs
+++ b/vta-service/src/did_peer.rs
@@ -1,14 +1,13 @@
 use std::path::PathBuf;
 
-use affinidi_tdk::dids::{
-    DID, KeyType, OneOrMany, PeerKeyRole, PeerService, PeerServiceEndpoint, PeerServiceEndpointLong,
-};
+use affinidi_tdk::dids::{OneOrMany, PeerService, PeerServiceEndpoint, PeerServiceEndpointLong};
 use affinidi_tdk::secrets_resolver::secrets::Secret;
 
-use vta_sdk::did_secrets::{DidSecretsBundle, SecretEntry};
+use vta_sdk::did_secrets::DidSecretsBundle;
 
 use crate::acl::{AclEntry, Role, store_acl_entry};
 use crate::config::AppConfig;
+use crate::operations::did_peer::{mint_did_peer_with_services, peer_secrets_to_entries};
 use crate::store::Store;
 
 pub struct CreateDidPeerArgs {
@@ -64,16 +63,12 @@ pub async fn run_create_did_peer(
     // (id "#auth").
     let services = mediator_services(&args.mediator_url)?;
 
-    // did:peer key shape: Ed25519 verification (#key-1) + X25519 encryption
-    // (#key-2). Matches `mediator-setup`'s generator exactly.
-    let keys = vec![
-        (PeerKeyRole::Verification, KeyType::Ed25519),
-        (PeerKeyRole::Encryption, KeyType::X25519),
-    ];
-
-    let (did, secrets): (String, Vec<Secret>) =
-        DID::generate_did_peer_with_services(keys, Some(services))
-            .map_err(|e| format!("failed to generate did:peer: {e}"))?;
+    // did:peer key shape (Ed25519 #key-1 + X25519 #key-2) and the actual
+    // did:peer:2 encoding live in the shared library construction
+    // (`operations::did_peer::mint_did_peer_with_services`) so this offline
+    // CLI and the online provision-integration path can't drift. Only the
+    // `services` differ (URL-style here; MEDIATOR_DID-style online).
+    let (did, secrets): (String, Vec<Secret>) = mint_did_peer_with_services(services)?;
 
     eprintln!("\x1b[1;32mCreated DID:\x1b[0m {did}");
 
@@ -105,35 +100,9 @@ pub async fn run_create_did_peer(
     // Optionally export the secrets bundle. `--export-secrets` forces it
     // unconditionally; without the flag nothing is emitted on stdout.
     if args.export_secrets {
-        let mut entries = Vec::with_capacity(secrets.len());
-        for s in &secrets {
-            // `Secret::get_key_type()` returns `affinidi_crypto::KeyType`;
-            // `SecretEntry.key_type` is `vta_sdk::keys::KeyType` — map across
-            // the two enums. Only Ed25519 / X25519 are produced by the key
-            // shape above; reject anything else loudly.
-            let key_type = match s.get_key_type() {
-                affinidi_tdk::secrets_resolver::secrets::KeyType::Ed25519 => {
-                    vta_sdk::keys::KeyType::Ed25519
-                }
-                affinidi_tdk::secrets_resolver::secrets::KeyType::X25519 => {
-                    vta_sdk::keys::KeyType::X25519
-                }
-                other => {
-                    return Err(format!(
-                        "unexpected key type {other:?} in generated did:peer secret {}",
-                        s.id
-                    )
-                    .into());
-                }
-            };
-            entries.push(SecretEntry {
-                key_id: s.id.clone(),
-                key_type,
-                private_key_multibase: s
-                    .get_private_keymultibase()
-                    .map_err(|e| format!("failed to encode private key for {}: {e}", s.id))?,
-            });
-        }
+        // Map the generated secrets to bundle entries via the shared helper
+        // (Ed25519 #key-1 then X25519 #key-2; rejects any other key type).
+        let entries = peer_secrets_to_entries(&secrets)?;
 
         let bundle = DidSecretsBundle {
             did: did.clone(),
@@ -303,32 +272,11 @@ mod tests {
     #[test]
     fn bundle_has_two_entries_ed25519_then_x25519() {
         let services = mediator_services("http://127.0.0.1:61881/mediator/v1").unwrap();
-        let keys = vec![
-            (PeerKeyRole::Verification, KeyType::Ed25519),
-            (PeerKeyRole::Encryption, KeyType::X25519),
-        ];
-        let (did, secrets) =
-            DID::generate_did_peer_with_services(keys, Some(services)).expect("generate did:peer");
+        let (did, secrets) = mint_did_peer_with_services(services).expect("generate did:peer");
         assert!(did.starts_with("did:peer:2"), "got {did}");
         assert_eq!(secrets.len(), 2);
 
-        let mut entries = Vec::new();
-        for s in &secrets {
-            let key_type = match s.get_key_type() {
-                affinidi_tdk::secrets_resolver::secrets::KeyType::Ed25519 => {
-                    vta_sdk::keys::KeyType::Ed25519
-                }
-                affinidi_tdk::secrets_resolver::secrets::KeyType::X25519 => {
-                    vta_sdk::keys::KeyType::X25519
-                }
-                other => panic!("unexpected key type {other:?}"),
-            };
-            entries.push(SecretEntry {
-                key_id: s.id.clone(),
-                key_type,
-                private_key_multibase: s.get_private_keymultibase().unwrap(),
-            });
-        }
+        let entries = peer_secrets_to_entries(&secrets).expect("map secrets to entries");
 
         assert_eq!(entries.len(), 2);
         assert!(entries[0].key_id.contains("#key-1"));

--- a/vta-service/src/operations/did_peer.rs
+++ b/vta-service/src/operations/did_peer.rs
@@ -1,0 +1,251 @@
+//! Shared, method-pure `did:peer:2` construction.
+//!
+//! A `did:peer:2` is self-contained: its keys and service endpoints are
+//! encoded in the identifier itself, so it resolves locally with no hosting,
+//! no `did.jsonl`, and no publish step. This module owns the *one* place
+//! where the DID gets minted from an Ed25519 signing key + an X25519
+//! key-agreement key + a set of services, so both consumers share the exact
+//! same encoding:
+//!
+//! - the offline operator CLI (`vta create-did-peer`, in the binary's
+//!   `did_peer` module) — builds a mediator-*URL*-style DIDComm service;
+//! - the online provision-integration flow
+//!   ([`crate::operations::provision_integration`]) — builds a mediator-*DID*
+//!   -style DIDComm service, matching how the built-in `ai-agent` did:webvh
+//!   template advertises DIDComm (`serviceEndpoint` = `MEDIATOR_DID`) so a
+//!   minted did:peer agent reaches the VTA over the mediator identically.
+//!
+//! The key shape is fixed: `#key-1` is the Ed25519 verification key
+//! (authentication + assertion), `#key-2` is the X25519 key-agreement key
+//! (authcrypt + sealed-transfer). This mirrors the mediator-setup generator
+//! and the byte-for-byte behaviour of the existing offline CLI.
+
+use affinidi_tdk::dids::{
+    DID, KeyType, OneOrMany, PeerKeyRole, PeerService, PeerServiceEndpoint, PeerServiceEndpointLong,
+};
+use affinidi_tdk::secrets_resolver::secrets::Secret;
+
+use vta_sdk::did_secrets::SecretEntry;
+use vta_sdk::sealed_transfer::template_bootstrap::{DidKeyMaterial, KeyPair};
+
+/// Errors from the shared did:peer construction / secret-mapping helpers.
+#[derive(Debug, thiserror::Error)]
+pub enum DidPeerError {
+    #[error("failed to generate did:peer: {0}")]
+    Generate(String),
+    #[error("failed to encode key material for {key_id}: {source}")]
+    Encode {
+        key_id: String,
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+    #[error("unexpected key type {key_type:?} in generated did:peer secret {key_id}")]
+    UnexpectedKeyType {
+        key_id: String,
+        key_type: affinidi_tdk::secrets_resolver::secrets::KeyType,
+    },
+    #[error(
+        "generated did:peer produced {found} secrets, expected 2 (Ed25519 #key-1 + X25519 #key-2)"
+    )]
+    SecretCount { found: usize },
+    #[error("generated did:peer has no {role} secret ({key_type:?})")]
+    MissingKey {
+        role: &'static str,
+        key_type: vta_sdk::keys::KeyType,
+    },
+}
+
+/// Fixed `did:peer:2` key shape: an Ed25519 verification key followed by an
+/// X25519 encryption key. The two secrets returned by
+/// [`DID::generate_did_peer_with_services`] land at `#key-1` / `#key-2`
+/// respectively.
+fn peer_key_shape() -> Vec<(PeerKeyRole, KeyType)> {
+    vec![
+        (PeerKeyRole::Verification, KeyType::Ed25519),
+        (PeerKeyRole::Encryption, KeyType::X25519),
+    ]
+}
+
+/// Mint a self-contained `did:peer:2` from freshly-generated keys plus the
+/// supplied service entries. Returns the DID string and its secrets
+/// (`#key-1` Ed25519, `#key-2` X25519).
+///
+/// The VTA mints the key material here — callers never supply private keys.
+/// This is the single shared construction point: the offline CLI and the
+/// online provision path both call it, differing only in the `services`
+/// they pass.
+pub fn mint_did_peer_with_services(
+    services: Vec<PeerService>,
+) -> Result<(String, Vec<Secret>), DidPeerError> {
+    DID::generate_did_peer_with_services(peer_key_shape(), Some(services))
+        .map_err(|e| DidPeerError::Generate(e.to_string()))
+}
+
+/// Build the DIDComm service for a did:peer agent that routes through a
+/// mediator identified by its *DID* — matching how the built-in `ai-agent`
+/// did:webvh template advertises `DIDCommMessaging` (`serviceEndpoint.uri` =
+/// `MEDIATOR_DID`). A minted did:peer agent then connects to the VTA over the
+/// mediator exactly like a did:webvh agent does; `AgentSession` reads the
+/// mediator DID from this service and dials through it.
+///
+/// The service `type` is `DIDCommMessaging` (the DID document is authoritative
+/// for which protocols a party speaks — matched on `type`, per the workspace
+/// transport rules), carried as a single long-form endpoint.
+pub fn mediator_did_didcomm_service(
+    mediator_did: &str,
+    accept: Vec<String>,
+    routing_keys: Vec<String>,
+) -> Vec<PeerService> {
+    vec![PeerService {
+        type_: "DIDCommMessaging".into(),
+        endpoint: PeerServiceEndpoint::Long(OneOrMany::One(PeerServiceEndpointLong {
+            uri: mediator_did.to_string(),
+            accept,
+            routing_keys,
+        })),
+        id: None,
+    }]
+}
+
+/// Map a TDK [`Secret`]'s key type onto the SDK [`vta_sdk::keys::KeyType`],
+/// rejecting anything other than the Ed25519 / X25519 the did:peer key shape
+/// produces.
+fn sdk_key_type(secret: &Secret) -> Result<vta_sdk::keys::KeyType, DidPeerError> {
+    match secret.get_key_type() {
+        affinidi_tdk::secrets_resolver::secrets::KeyType::Ed25519 => {
+            Ok(vta_sdk::keys::KeyType::Ed25519)
+        }
+        affinidi_tdk::secrets_resolver::secrets::KeyType::X25519 => {
+            Ok(vta_sdk::keys::KeyType::X25519)
+        }
+        other => Err(DidPeerError::UnexpectedKeyType {
+            key_id: secret.id.clone(),
+            key_type: other,
+        }),
+    }
+}
+
+/// Convert generated did:peer secrets into [`SecretEntry`] values for a
+/// [`vta_sdk::did_secrets::DidSecretsBundle`] (the offline CLI export shape).
+pub fn peer_secrets_to_entries(secrets: &[Secret]) -> Result<Vec<SecretEntry>, DidPeerError> {
+    let mut entries = Vec::with_capacity(secrets.len());
+    for s in secrets {
+        let key_type = sdk_key_type(s)?;
+        entries.push(SecretEntry {
+            key_id: s.id.clone(),
+            key_type,
+            private_key_multibase: s.get_private_keymultibase().map_err(|e| {
+                DidPeerError::Encode {
+                    key_id: s.id.clone(),
+                    source: Box::new(e),
+                }
+            })?,
+        });
+    }
+    Ok(entries)
+}
+
+/// Convert generated did:peer secrets into the sealed-bundle
+/// [`DidKeyMaterial`] shape a did:webvh / did:key agent gets — a single DID
+/// with a signing (Ed25519) keypair and a key-agreement (X25519) keypair, so
+/// an unchanged consumer opening the bundle with the ephemeral holder key
+/// works for both methods.
+///
+/// The key ids are the secrets' own ids (`{did}#key-1` / `#key-2`), which
+/// equal the verification-method ids in the resolved did:peer document.
+pub fn peer_secrets_to_did_key_material(
+    did: &str,
+    secrets: &[Secret],
+) -> Result<DidKeyMaterial, DidPeerError> {
+    if secrets.len() != 2 {
+        return Err(DidPeerError::SecretCount {
+            found: secrets.len(),
+        });
+    }
+    let mut signing: Option<KeyPair> = None;
+    let mut key_agreement: Option<KeyPair> = None;
+    for s in secrets {
+        let key_type = sdk_key_type(s)?;
+        let public_key_multibase =
+            s.get_public_keymultibase()
+                .map_err(|e| DidPeerError::Encode {
+                    key_id: s.id.clone(),
+                    source: Box::new(e),
+                })?;
+        let private_key_multibase =
+            s.get_private_keymultibase()
+                .map_err(|e| DidPeerError::Encode {
+                    key_id: s.id.clone(),
+                    source: Box::new(e),
+                })?;
+        let kp = KeyPair {
+            key_id: s.id.clone(),
+            public_key_multibase,
+            private_key_multibase,
+        };
+        match key_type {
+            vta_sdk::keys::KeyType::Ed25519 => signing = Some(kp),
+            vta_sdk::keys::KeyType::X25519 => key_agreement = Some(kp),
+            _ => {
+                return Err(DidPeerError::UnexpectedKeyType {
+                    key_id: s.id.clone(),
+                    key_type: s.get_key_type(),
+                });
+            }
+        }
+    }
+    Ok(DidKeyMaterial {
+        did: did.to_string(),
+        signing_key: signing.ok_or(DidPeerError::MissingKey {
+            role: "signing",
+            key_type: vta_sdk::keys::KeyType::Ed25519,
+        })?,
+        ka_key: key_agreement.ok_or(DidPeerError::MissingKey {
+            role: "key-agreement",
+            key_type: vta_sdk::keys::KeyType::X25519,
+        })?,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mint_with_mediator_did_service_yields_peer2_and_two_keys() {
+        let services = mediator_did_didcomm_service(
+            "did:peer:2.Ezmediator.Vzmediator",
+            vec!["didcomm/v2".into()],
+            vec![],
+        );
+        let (did, secrets) = mint_did_peer_with_services(services).expect("mint did:peer");
+        assert!(did.starts_with("did:peer:2"), "got {did}");
+        assert_eq!(secrets.len(), 2);
+
+        let material = peer_secrets_to_did_key_material(&did, &secrets).expect("material");
+        assert_eq!(material.did, did);
+        assert!(material.signing_key.key_id.contains("#key-1"));
+        assert!(!material.signing_key.public_key_multibase.is_empty());
+        assert!(!material.signing_key.private_key_multibase.is_empty());
+        assert!(material.ka_key.key_id.contains("#key-2"));
+        assert!(!material.ka_key.public_key_multibase.is_empty());
+        assert!(!material.ka_key.private_key_multibase.is_empty());
+    }
+
+    #[test]
+    fn secrets_map_to_entries_ed25519_then_x25519() {
+        let services = mediator_did_didcomm_service(
+            "did:peer:2.Ezmediator",
+            vec!["didcomm/v2".into()],
+            vec![],
+        );
+        let (_did, secrets) = mint_did_peer_with_services(services).expect("mint did:peer");
+        let entries = peer_secrets_to_entries(&secrets).expect("entries");
+        assert_eq!(entries.len(), 2);
+        assert!(entries[0].key_id.contains("#key-1"));
+        assert_eq!(entries[0].key_type, vta_sdk::keys::KeyType::Ed25519);
+        assert!(!entries[0].private_key_multibase.is_empty());
+        assert!(entries[1].key_id.contains("#key-2"));
+        assert_eq!(entries[1].key_type, vta_sdk::keys::KeyType::X25519);
+        assert!(!entries[1].private_key_multibase.is_empty());
+    }
+}

--- a/vta-service/src/operations/mod.rs
+++ b/vta-service/src/operations/mod.rs
@@ -9,6 +9,7 @@ pub mod contexts;
 pub mod credential_exchange;
 pub mod credentials;
 pub mod device;
+pub mod did_peer;
 pub mod did_templates;
 #[cfg(feature = "webvh")]
 pub mod did_webvh;

--- a/vta-service/src/operations/provision_integration/mod.rs
+++ b/vta-service/src/operations/provision_integration/mod.rs
@@ -357,17 +357,32 @@ pub async fn provision_integration(
             )),
             other => other,
         })?;
+    // A `methods` list containing `"peer"` selects the self-contained
+    // did:peer path (no WebVH hosting, no did.jsonl, no publish). Checked
+    // before the did:key / did:webvh dispatch.
+    let use_did_peer = templates::template_targets_did_peer(&integration_template);
     let use_did_key = templates::template_targets_did_key_only(&integration_template);
 
-    // When the did:key path runs, we already hold the full
+    // When the did:key or did:peer path runs, we already hold the full
     // `DidKeyMaterial` (signing + KA public/private) from the mint
     // helper — there's no keystore round-trip for the KA key because
-    // X25519 is derived from the Ed25519 seed, not BIP-32 derived at
-    // its own path. Capture it here so the readback section below can
-    // skip `get_key_secret` on this branch.
+    // X25519 is derived from the Ed25519 seed (did:key) or minted directly
+    // as the peer's `#key-2` (did:peer), not BIP-32 derived at its own
+    // path. Capture it here so the readback section below can skip
+    // `get_key_secret` on those branches.
     let mut did_key_material: Option<DidKeyMaterial> = None;
 
-    let (integration_did, signing_key_id, ka_key_id, did_document, did_log) = if use_did_key {
+    let (integration_did, signing_key_id, ka_key_id, did_document, did_log) = if use_did_peer {
+        // did:peer path — self-contained. Mint an Ed25519 signing key +
+        // X25519 key-agreement key and encode them into a did:peer:2 with
+        // a DIDCommMessaging service on MEDIATOR_DID (matching how the
+        // `ai-agent` did:webvh template advertises DIDComm), so the agent
+        // reaches the VTA over the mediator identically. `WEBVH_SERVER` /
+        // `WEBVH_PATH` / `URL` are forbidden — there is nothing to host.
+        let (did, skid, kkid, doc, material) = provision_did_peer(state, &template_vars).await?;
+        did_key_material = Some(material);
+        (did, skid, kkid, doc, None)
+    } else if use_did_key {
         // did:key path — no webvh publication. `WEBVH_SERVER` /
         // `WEBVH_PATH` / `URL` are all irrelevant here; the template's
         // `methods: ["key"]` is load-bearing metadata, not the URL.
@@ -486,10 +501,10 @@ pub async fn provision_integration(
         )
     };
 
-    // did:key path: set the minted DID as primary when the context has
-    // none. The webvh path already handles this inside create_did_webvh
-    // via `set_primary`.
-    if use_did_key && set_primary {
+    // did:key / did:peer paths: set the minted DID as primary when the
+    // context has none. The webvh path already handles this inside
+    // create_did_webvh via `set_primary`.
+    if (use_did_key || use_did_peer) && set_primary {
         let mut ctx = ctx_before_mint.clone();
         ctx.did = Some(integration_did.clone());
         ctx.updated_at = chrono::Utc::now();
@@ -990,6 +1005,123 @@ async fn provision_admin_rotation(
             webvh_server_id: None,
         },
     })
+}
+
+/// Step 2 of the flow for the `did:peer` method — the self-contained
+/// counterpart to `create_did_webvh` (webvh) / `mint_integration_via_did_key_template`
+/// (did:key). Steps 1/3/4/5 around it are DID-method-agnostic and run
+/// unchanged.
+///
+/// Mints an Ed25519 signing key + X25519 key-agreement key and encodes
+/// them into a `did:peer:2` whose only service is a `DIDCommMessaging`
+/// endpoint on `MEDIATOR_DID` (matching how the `ai-agent` did:webvh
+/// template advertises DIDComm), so the minted agent reaches the VTA over
+/// the mediator identically to a did:webvh agent. Nothing is hosted or
+/// published — the DID resolves locally.
+///
+/// Returns the tuple the caller destructures in place of the webvh /
+/// did:key branches: `(did, signing_key_id, ka_key_id, did_document,
+/// material)`. `did_log` is always `None` for did:peer (no did.jsonl).
+///
+/// Forbids `WEBVH_SERVER` / `URL` — a did:peer has no hosting target, so
+/// their presence is an operator error worth surfacing loudly rather than
+/// silently ignoring.
+async fn provision_did_peer(
+    state: &ProvisionIntegrationDeps,
+    template_vars: &BTreeMap<String, Value>,
+) -> Result<(String, String, String, Value, DidKeyMaterial), AppError> {
+    use crate::operations::did_peer::{
+        mediator_did_didcomm_service, mint_did_peer_with_services, peer_secrets_to_did_key_material,
+    };
+
+    // MEDIATOR_DID is required — it is the DIDComm service endpoint the
+    // agent routes through. Same var + role as the `ai-agent` did:webvh
+    // template's `requiredVars`.
+    let mediator_did = template_vars
+        .get("MEDIATOR_DID")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| {
+            AppError::Validation(
+                "did:peer agent template requires a non-empty 'MEDIATOR_DID' var — it becomes \
+                 the agent's DIDCommMessaging service endpoint. Pass `--var MEDIATOR_DID=<did>`."
+                    .into(),
+            )
+        })?
+        .to_string();
+
+    // A did:peer is self-contained: there is nothing to host, so webvh
+    // vars are meaningless here. Reject them rather than silently drop —
+    // their presence means the operator picked the wrong template.
+    for forbidden in ["WEBVH_SERVER", "URL", "WEBVH_PATH", "WEBVH_DOMAIN"] {
+        if template_vars.get(forbidden).is_some_and(|v| !v.is_null()) {
+            return Err(AppError::Validation(format!(
+                "did:peer agent template does not accept '{forbidden}' — a did:peer is \
+                 self-contained (no WebVH hosting, no did.jsonl, no publish). Remove it, or \
+                 use the did:webvh 'ai-agent' template if you need hosting."
+            )));
+        }
+    }
+
+    // ACCEPT / ROUTING_KEYS mirror the `ai-agent` template's DIDComm
+    // service optionals: string list of accepted media types, and DIDComm
+    // routing keys. Defaults match the template's `optionalVars`.
+    let accept =
+        string_list_var(template_vars, "ACCEPT").unwrap_or_else(|| vec!["didcomm/v2".into()]);
+    let routing_keys = string_list_var(template_vars, "ROUTING_KEYS").unwrap_or_default();
+
+    let services = mediator_did_didcomm_service(&mediator_did, accept, routing_keys);
+    let (did, secrets) = mint_did_peer_with_services(services)
+        .map_err(|e| AppError::Internal(format!("mint did:peer: {e}")))?;
+
+    let material = peer_secrets_to_did_key_material(&did, &secrets)
+        .map_err(|e| AppError::Internal(format!("map did:peer secrets: {e}")))?;
+
+    // Resolve the freshly-minted did:peer to its DID document for the
+    // sealed payload's `config.did_document`. did:peer resolves locally
+    // (no network), so this never leaves the process.
+    let resolver = state
+        .did_resolver
+        .as_ref()
+        .ok_or_else(|| AppError::Internal("DID resolver not initialized".into()))?;
+    let resolved = resolver
+        .resolve(&did)
+        .await
+        .map_err(|e| AppError::Internal(format!("resolve minted did:peer '{did}': {e}")))?;
+    let did_document = serde_json::to_value(&resolved.doc)
+        .map_err(|e| AppError::Internal(format!("serialize did:peer document: {e}")))?;
+
+    info!(
+        did = %did,
+        mediator_did = %mediator_did,
+        "minted did:peer agent via provision-integration"
+    );
+
+    Ok((
+        did,
+        material.signing_key.key_id.clone(),
+        material.ka_key.key_id.clone(),
+        did_document,
+        material,
+    ))
+}
+
+/// Extract a template var as a `Vec<String>`: accepts a JSON array of
+/// strings (native shape) or a single string (coerced to a one-element
+/// vec). Returns `None` when absent / null / wrong-typed, letting the
+/// caller apply its default.
+fn string_list_var(vars: &BTreeMap<String, Value>, key: &str) -> Option<Vec<String>> {
+    match vars.get(key) {
+        Some(Value::Array(items)) => Some(
+            items
+                .iter()
+                .filter_map(|v| v.as_str().map(str::to_string))
+                .collect(),
+        ),
+        Some(Value::String(s)) => Some(vec![s.clone()]),
+        _ => None,
+    }
 }
 
 /// Find a `verificationMethod.id` whose `publicKeyMultibase` matches
@@ -1667,6 +1799,172 @@ mod tests {
             Some(integration_did),
             "did:key path must set context primary when ctx.did was None"
         );
+    }
+
+    #[tokio::test]
+    async fn provision_integration_mints_did_peer_when_template_methods_is_peer() {
+        // The did:peer path: a template declaring `methods: ["peer"]`
+        // yields a self-contained did:peer:2 agent — no WebVH hosting,
+        // no webvh log — whose DIDComm service routes through MEDIATOR_DID
+        // exactly like the did:webvh `ai-agent` template. Runs the SAME
+        // step 1/3/4/5 as the webvh path (VP precondition + holder ACL +
+        // seal); only step 2 (DID construction) differs.
+        use super::sealed_transfer_open::open_for_test;
+
+        let ts = open_test_store().await;
+        let (_vta_did, deps) = bootstrap_test_vta(&ts).await;
+        crate::contexts::create_context(&ts.contexts_ks, "agents", "Agents")
+            .await
+            .expect("create context");
+
+        // A plausible mediator DID — used only as the DIDCommMessaging
+        // service endpoint (a uri), so it need not resolve.
+        let mediator_did = "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM8m1jhSw9UZTQY.Vz6MkqRYqQ";
+        let mut vars = BTreeMap::new();
+        vars.insert(
+            "MEDIATOR_DID".into(),
+            Value::String(mediator_did.to_string()),
+        );
+
+        let auth = super_admin_claims();
+        let request = signed_request_with_vars("ai-agent-peer", "agents", vars).await;
+        let client_did = request.holder().to_string();
+
+        let output = provision_integration(
+            &deps,
+            &auth,
+            ProvisionIntegrationParams {
+                request,
+                context: "agents".into(),
+                assertion_mode: AssertionMode::PinnedOnly,
+                vc_validity: None,
+            },
+        )
+        .await
+        .expect("provision_integration did:peer");
+
+        let integration_did = output
+            .summary
+            .integration_did
+            .as_deref()
+            .expect("TemplateBootstrap path must yield Some(integration_did)");
+
+        // (1) The returned DID is a valid did:peer:2 with a DIDCommMessaging
+        //     service on MEDIATOR_DID.
+        assert!(
+            integration_did.starts_with("did:peer:2"),
+            "integration DID must be a did:peer:2, got {integration_did}"
+        );
+        assert_eq!(
+            output.summary.output_count, 0,
+            "did:peer path emits no webvh log — outputs must be empty"
+        );
+
+        // (2) The sealed bundle opens with the holder key to a
+        //     DidSecretsBundle-equivalent DidKeyMaterial carrying the
+        //     signing + key-agreement keys.
+        let payload = open_for_test(&output.armored, &output.digest, &[7u8; 32]);
+        assert_eq!(output.summary.secret_count, 1, "one minted did:peer");
+        let material = payload
+            .secrets
+            .get(integration_did)
+            .expect("did:peer secrets present in bundle");
+        assert_eq!(material.did, integration_did);
+        assert!(
+            material.signing_key.key_id.contains("#key-1"),
+            "signing key id: {}",
+            material.signing_key.key_id
+        );
+        assert!(!material.signing_key.private_key_multibase.is_empty());
+        assert!(
+            material.ka_key.key_id.contains("#key-2"),
+            "ka key id: {}",
+            material.ka_key.key_id
+        );
+        assert!(!material.ka_key.private_key_multibase.is_empty());
+
+        // The rendered did:peer document carries a DIDCommMessaging service
+        // whose endpoint is the MEDIATOR_DID.
+        // The resolved did:peer document expresses `service.type` as an
+        // array (`["DIDCommMessaging"]`) per did:peer resolution — match on
+        // the type appearing there, not on an exact string, and confirm the
+        // endpoint uri is the MEDIATOR_DID.
+        let doc = &payload.config.did_document;
+        let services = doc["service"].as_array().expect("service array");
+        let didcomm = services
+            .iter()
+            .find(|s| {
+                let t = &s["type"];
+                t == "DIDCommMessaging"
+                    || t.as_array()
+                        .is_some_and(|a| a.iter().any(|v| v == "DIDCommMessaging"))
+            })
+            .expect("DIDCommMessaging service present");
+        let endpoint_str = serde_json::to_string(&didcomm["serviceEndpoint"]).unwrap();
+        assert!(
+            endpoint_str.contains(mediator_did),
+            "DIDCommMessaging endpoint must route through MEDIATOR_DID; got {endpoint_str}"
+        );
+
+        // (3) A context-admin ACL entry exists for the holder (step 4 ran
+        //     unchanged — no admin rollover, so admin_did == client_did).
+        assert!(!output.summary.admin_rolled_over);
+        assert_eq!(output.summary.admin_did, client_did);
+        let acl = crate::acl::get_acl_entry(&ts.acl_ks, &client_did)
+            .await
+            .unwrap()
+            .expect("holder ACL entry created");
+        assert_eq!(acl.role, Role::Admin);
+        assert!(acl.allowed_contexts.contains(&"agents".to_string()));
+
+        // did:peer is self-contained → set as context primary when none.
+        let ctx_after = crate::contexts::get_context(&ts.contexts_ks, "agents")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(ctx_after.did.as_deref(), Some(integration_did));
+    }
+
+    #[tokio::test]
+    async fn provision_integration_did_peer_rejects_webvh_vars() {
+        // A did:peer template must reject WEBVH_SERVER / URL — a did:peer
+        // is self-contained, so their presence is an operator error.
+        let ts = open_test_store().await;
+        let (_vta_did, deps) = bootstrap_test_vta(&ts).await;
+        crate::contexts::create_context(&ts.contexts_ks, "agents", "Agents")
+            .await
+            .expect("create context");
+
+        let mut vars = BTreeMap::new();
+        vars.insert(
+            "MEDIATOR_DID".into(),
+            Value::String("did:peer:2.Ez6LSm".into()),
+        );
+        vars.insert(
+            "URL".into(),
+            Value::String("https://should-not-be-here.example".into()),
+        );
+
+        let auth = super_admin_claims();
+        let request = signed_request_with_vars("ai-agent-peer", "agents", vars).await;
+
+        let result = provision_integration(
+            &deps,
+            &auth,
+            ProvisionIntegrationParams {
+                request,
+                context: "agents".into(),
+                assertion_mode: AssertionMode::PinnedOnly,
+                vc_validity: None,
+            },
+        )
+        .await;
+        let err = match result {
+            Ok(_) => panic!("did:peer must reject URL"),
+            Err(e) => e,
+        };
+        assert!(matches!(err, AppError::Validation(_)), "got: {err:?}");
+        assert!(err.to_string().contains("URL"), "got: {err}");
     }
 
     #[tokio::test]

--- a/vta-service/src/operations/provision_integration/templates.rs
+++ b/vta-service/src/operations/provision_integration/templates.rs
@@ -74,6 +74,15 @@ pub(super) fn template_targets_did_key_only(
     !template.methods.is_empty() && template.methods.iter().all(|m| m == "key")
 }
 
+/// Returns `true` when the template declares `methods` containing `"peer"`
+/// — i.e. the operator intends a self-contained `did:peer` integration (no
+/// WebVH hosting, no did.jsonl, no publish). Selected before the did:key /
+/// did:webvh dispatch. An empty `methods` list is not peer (back-compat
+/// default stays on the did:webvh path).
+pub(super) fn template_targets_did_peer(template: &vta_sdk::did_templates::DidTemplate) -> bool {
+    template.methods.iter().any(|m| m == "peer")
+}
+
 /// Resolve only the `kind` field of a template (context → global →
 /// builtin). Used for the VC's `credentialSubject.integrationKind`
 /// without the cost of parsing the full template body.


### PR DESCRIPTION
## Why

The built-in `ai-agent` template yields a **did:webvh**, which requires external WebVH hosting (a hosting daemon, publish auth, resolution infra). For agents that only authenticate to the VTA **over DIDComm** — never resolved by outside HTTPS parties — a **did:peer** is self-contained: no hosting, no publish. This adds a did:peer path to provision-integration so a caller (over DIDComm, while the daemon runs) can mint one, sealed to the ephemeral holder exactly like the did:webvh path.

Motivating consumer: cierge's `OnlineVtaProvisioner` currently mints hosted did:webvh agents; this lets it mint self-contained did:peer agents instead, dropping the entire hosting dependency for that case.

## Design — reuse, don't fork

The flow's steps **1/3/4/5 are DID-method-agnostic and run unchanged** for the peer path:
- **1 — verify VP-framed request + authz:** `preconditions::preconditions(...)` (before the method dispatch).
- **3 — readback into the sealed bundle:** the peer branch sets `did_key_material` at mint time (like the did:key branch), so the existing readback folds it in.
- **4 — holder as context admin:** `acl::create_acl(..., Role::Admin, ...)`.
- **5 — seal:** `seal::seal_provision_payload(...)`, `SealedPayloadV1::TemplateBootstrap`, DidSigned by `{vta_did}#sealed-transfer-0`.

Only **step 2** branches: `provision_did_peer` mints Ed25519(`#key-1`)+X25519(`#key-2`), builds a `DIDCommMessaging` service on `MEDIATOR_DID`, constructs the `did:peer:2`, and resolves it locally for `config.did_document`. It **requires** `MEDIATOR_DID` and **rejects** `WEBVH_SERVER`/`URL`/`WEBVH_PATH`/`WEBVH_DOMAIN`.

Branch point: `provision_integration/mod.rs` — `template_targets_did_peer(...)` → `if use_did_peer { provision_did_peer(...) } else if use_did_key { ... } else { webvh }`.

## No duplication

The did:peer:2 encoding lives in a new `vta-service/src/operations/did_peer.rs` module (`mint_did_peer_with_services`, `peer_secrets_to_entries`, `peer_secrets_to_did_key_material`, `mediator_did_didcomm_service`), used by **both** this online path and the offline `create-did-peer` CLI. The CLI keeps its URL-style mediator service **byte-for-byte**; the online path uses the MEDIATOR_DID-style `DIDCommMessaging` service so a minted did:peer reaches the VTA over the mediator identically to a did:webvh `ai-agent`.

## Caller signal

New built-in template **`ai-agent-peer`** (`vta-sdk/templates/ai-agent-peer.json`): `methods: ["peer"]`, `requiredVars: ["MEDIATOR_DID"]`, no WEBVH vars, DIDComm service on `{MEDIATOR_DID}`. **No vta-sdk code change** — it's a template name + `MEDIATOR_DID` var through the existing `provision_integration` call, and the sealed `DidSecretsBundle` shape is identical, so an unchanged consumer opens both did:webvh and did:peer bundles.

## Tests

- New: `provision_integration_mints_did_peer_when_template_methods_is_peer` (valid did:peer:2, `DIDCommMessaging` on `MEDIATOR_DID`, sealed bundle opens with the holder key to signing+KA keys, holder context-admin ACL entry, context primary bound), `provision_integration_did_peer_rejects_webvh_vars`, plus module unit tests for the shared mint + secret-mapping.
- Regression green: `provision_integration` **52 passed** (did:webvh unchanged), `did_peer` CLI **4 passed** (unchanged), `did_templates` **44**, vta-sdk **160**, vta-service lib **832**.
- `cargo fmt` clean; `clippy` no new warnings.

## Additive

The did:webvh provision-integration path and the offline `create-did-peer` CLI are unchanged; the peer path runs the same VP-verify / holder-ACL / seal steps.