### PR TITLE
fix(tsp): always listen for TSP when compiled (kill the enable-without-restart poison loop)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10164,7 +10164,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.10.20"
+version = "0.10.21"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.10.20"
+version = "0.10.21"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -908,10 +908,20 @@ pub async fn run(
                         builder.build().ok()
                     };
 
-                    // When TSP is advertised, the listener multiplexes TSP +
-                    // DIDComm on its single mediator websocket (one socket per
-                    // DID — a second would be evicted as `duplicate-channel`).
-                    let tsp_enabled = config.services.tsp;
+                    // TSP receive-capability is a **compile-time** property, not
+                    // a runtime toggle: a `tsp`-compiled VTA ALWAYS multiplexes
+                    // TSP + DIDComm on its single mediator websocket (one socket
+                    // per DID — a second would be evicted as
+                    // `duplicate-channel`). Gating the listener mode on
+                    // `config.services.tsp` used to leave a split-brain — a VTA
+                    // that advertised `#tsp` (via `services tsp enable`) but
+                    // hadn't rebooted with `[services] tsp = true` ran a
+                    // DIDComm-only receive path that couldn't unpack inbound TSP
+                    // frames, poison-looping them every ~30s. `config.services.tsp`
+                    // now governs **advertisement** only; receive is always on
+                    // when compiled with `tsp`. Build without the `tsp` feature
+                    // to exclude the TSP receive path entirely.
+                    let listen_tsp = cfg!(feature = "tsp");
 
                     let service_config = DIDCommServiceConfig {
                         listeners: vec![ListenerConfig {
@@ -924,7 +934,7 @@ pub async fn run(
                                 },
                             },
                             tdk_config: listener_tdk_config,
-                            protocols: if tsp_enabled {
+                            protocols: if listen_tsp {
                                 Protocols::BOTH
                             } else {
                                 Protocols::DIDCOMM_ONLY
@@ -942,24 +952,17 @@ pub async fn run(
                         AppError::Internal(format!("failed to build DIDComm handler: {e}"))
                     })?;
 
-                    // With `tsp` compiled and advertised, register the TSP
-                    // handler so inbound TSP frames off the shared socket reach
-                    // the trust-task spine; otherwise the plain DIDComm start.
+                    // With `tsp` compiled, always register the TSP handler so
+                    // inbound TSP frames off the shared socket reach the
+                    // trust-task spine — independent of whether TSP is currently
+                    // advertised. Without the feature, the plain DIDComm start.
                     #[cfg(feature = "tsp")]
-                    let service_start = async {
-                        if tsp_enabled {
-                            DIDCommService::start_with_tsp(
-                                service_config,
-                                handler,
-                                messaging::tsp_inbound::VtaTspHandler::new(app_state.clone()),
-                                didcomm_shutdown.clone(),
-                            )
-                            .await
-                        } else {
-                            DIDCommService::start(service_config, handler, didcomm_shutdown.clone())
-                                .await
-                        }
-                    };
+                    let service_start = DIDCommService::start_with_tsp(
+                        service_config,
+                        handler,
+                        messaging::tsp_inbound::VtaTspHandler::new(app_state.clone()),
+                        didcomm_shutdown.clone(),
+                    );
                     #[cfg(not(feature = "tsp"))]
                     let service_start =
                         DIDCommService::start(service_config, handler, didcomm_shutdown.clone());


### PR DESCRIPTION
## The bug (hit live)

A TSP-enabled VTA poison-looped on every inbound TSP frame, logging every ~30s:

```
Error processing message ... Received packed message when expecting unpacked message. Use live_stream_next_packed()
Error unpacking message: DidcommError("Cannot parse message as JSON", "invalid number at line 1 column 2")   ← repeats forever
```

**Root cause — split-brain.** The DIDComm listener picks `Protocols::BOTH` vs `DIDCOMM_ONLY` from `config.services.tsp` **at boot** (`server.rs:914`). But `services tsp enable` writes the DID doc (`#tsp`) + the fjall runtime flag — **not** the config file. So a VTA that enabled + advertised TSP, but booted with `[services] tsp` unset, ran a **DIDComm-only** receive path (`live_stream_next`). That path can't unpack a packed TSP frame — it errors, and its failure branch never deletes the message, so the mediator redelivers it forever.

## Fix

Make TSP **receive-capability a compile-time property**: when built with the `tsp` feature, the VTA always boots `Protocols::BOTH` and registers `VtaTspHandler`. It then pulls frames via `live_stream_next_frame`, which classifies at the transport layer (`PackedMessageReceived → InboundFrame::Tsp`) and **auto-deletes before dispatch** — so nothing loops, even for a frame that later fails to unpack.

`config.services.tsp` now governs **advertisement only**, not receive. Consequences:
- `services tsp enable` takes effect immediately — no restart, no `[services] tsp = true` needed for the *listener*.
- No split-brain: a VTA can always receive TSP it's compiled for; it just advertises when configured.
- Build without `tsp` to exclude the receive path entirely (unchanged `DIDCOMM_ONLY`).

## Testing

Builds + clippy clean in default and `tsp` configs. vta-service 0.10.20 → **0.10.21**.

## Note

This fully resolves the poison loop **for the VTA**. A companion upstream hardening (affinidi-messaging-sdk: make the DIDComm-only `live_stream_next` delete + skip an unexpected packed frame instead of erroring-without-delete) follows separately as defense-in-depth for any DIDComm-only consumer.