### PR TITLE
feat(health): report steady-state ping latency (warm-up + measured)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6692,7 +6692,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "pnm-cli"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-resolver-cache-sdk",

--- a/pnm-cli/Cargo.toml
+++ b/pnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pnm-cli"
 description = "CLI Tool for managing a personal Verifiable Trust Agent"
-version = "0.10.3"
+version = "0.10.4"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/pnm-cli/src/commands/health.rs
+++ b/pnm-cli/src/commands/health.rs
@@ -279,10 +279,10 @@ pub(crate) async fn run(
                 .await
                 {
                     Ok(Ok(session)) => {
-                        // Ping mediator
+                        // Ping mediator (steady-state: warm-up + measured)
                         match tokio::time::timeout(
-                            std::time::Duration::from_secs(10),
-                            session.ping(None),
+                            std::time::Duration::from_secs(20),
+                            steady_ping(&session, None),
                         )
                         .await
                         {
@@ -297,12 +297,12 @@ pub(crate) async fn run(
                             }
                         }
 
-                        // Ping VTA through the same session
+                        // Ping VTA through the same session (steady-state)
                         print_section("VTA DIDComm");
 
                         match tokio::time::timeout(
-                            std::time::Duration::from_secs(15),
-                            session.ping(Some(vta_did)),
+                            std::time::Duration::from_secs(30),
+                            steady_ping(&session, Some(vta_did)),
                         )
                         .await
                         {
@@ -374,6 +374,20 @@ pub(crate) async fn run(
     Ok(())
 }
 
+/// Ping `target` twice through `session`, discarding the first and returning the
+/// second — a **steady-state** latency. The first ping pays one-time costs the
+/// steady state shouldn't be blamed for (resolving the target's DID + routing on
+/// first send), which is why a cold VTA ping reads far higher than the
+/// already-connected mediator ping. If the warm-up fails, its error is returned
+/// (the endpoint is down; measuring twice adds nothing).
+async fn steady_ping(
+    session: &vta_sdk::session::TrustPingSession,
+    target: Option<&str>,
+) -> Result<u128, Box<dyn std::error::Error>> {
+    session.ping(target).await?; // warm-up (propagates a genuine failure)
+    session.ping(target).await // measured
+}
+
 /// Drive the TSP connectivity probe: open the client's TSP websocket to the
 /// mediator, send a Trust Task to the VTA over TSP, and await the response —
 /// proving the full TSP round-trip. Compiled only with the `tsp` feature.
@@ -391,10 +405,15 @@ async fn tsp_probe(
     .await
     {
         Ok(Ok(mut session)) => {
-            match session
-                .ping(vta_did, std::time::Duration::from_secs(10))
-                .await
-            {
+            // Warm-up ping (pays the first-send VID/route resolution), then a
+            // measured one — a steady-state latency comparable to the DIDComm
+            // probe. A warm-up failure is reported straight away.
+            let ping_timeout = std::time::Duration::from_secs(10);
+            let measured = match session.ping(vta_did, ping_timeout).await {
+                Ok(_) => session.ping(vta_did, ping_timeout).await,
+                Err(e) => Err(e),
+            };
+            match measured {
                 Ok(latency) => {
                     println!(
                         "  {CYAN}{:<13}{RESET} {GREEN}✓{RESET} pong ({latency}ms)",


### PR DESCRIPTION
## Why

`pnm health` showed the VTA DIDComm ping at ~1825ms vs the mediator ping at ~270ms. The measurement was already ping-only (`TrustPingSession::ping` wraps just `send_ping`; session/websocket setup happens once in `::new`), so the gap was **real first-hit overhead** — the first send to a target resolves its DID + routing — not a setup double-count.

## Change

Ping each target twice and report the **second** (steady-state), discarding the warm-up that pays the one-time resolution cost:
- New `steady_ping` helper for the mediator + VTA DIDComm pings.
- The TSP probe does the same (warm-up, then measured).
- A warm-up failure is reported immediately (no point measuring a dead endpoint twice); timeouts widened to cover the extra round-trip.

Output format is unchanged (`✓ pong (Nms)`); `N` is now a steady-state number, so the VTA ping should read much closer to the mediator ping.

## Testing

Builds + clippy clean in default and `tsp` configs. pnm-cli 0.10.3 → **0.10.4**.