### PR TITLE
chore: bump affinidi-messaging-didcomm-service to 0.3.15 (inbound-TSP decode fix)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,9 +311,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-didcomm-service"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d898f2f3b7ae39d3a623d9398c292760a7d5e6016c4fe8ccd413a28b218382d"
+checksum = "3be37a0227fb1b08a0b73c92ad068955b7197335074b86ccc7a38e11b0a4004a"
 dependencies = [
  "affinidi-messaging-didcomm",
  "affinidi-messaging-sdk",


### PR DESCRIPTION
Bumps the committed lockfile from `affinidi-messaging-didcomm-service` 0.3.14 → **0.3.15** to pull in the inbound-TSP decode fix (affinidi/affinidi-tdk-rs#578): `dispatch_tsp` now decodes the qb64 pickup frame before `unpack`, so a `tsp`-built VTA completes the TSP round-trip instead of failing with `missing -E envelope wrapper`.

The `"0.3"` version pin already permitted it; this just moves the lock reproducible/CI builds use, so a **VTA redeploy from `main` actually includes the fix**. Lockfile only — no crate source change. `vta-service --features tsp` builds clean against 0.3.15.

Last piece before glenn-vta can be redeployed to get `pnm health` → `✓ pong` on the VTA TSP line.