### PR TITLE
chore: bump messaging stack for the offline-sync TSP fix (sdk 0.18.47 / didcomm-service 0.3.16)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,9 +311,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-didcomm-service"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be37a0227fb1b08a0b73c92ad068955b7197335074b86ccc7a38e11b0a4004a"
+checksum = "525bb8c3cb37f5c470ca1ed443d2beebba698b254d7656b8e4783e772355f1f0"
 dependencies = [
  "affinidi-messaging-didcomm",
  "affinidi-messaging-sdk",
@@ -448,9 +448,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-sdk"
-version = "0.18.42"
+version = "0.18.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23dc09e11e17725c058593221810b65b86705f33570285c1bb9a195c0242957c"
+checksum = "cac096a2ce0775d8f5858bc9c0b94d0a30a5dc9e6a4bf0310488d319209639b4"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-authentication",


### PR DESCRIPTION
Bumps the committed lockfile to `affinidi-messaging-sdk` **0.18.47** + `affinidi-messaging-didcomm-service` **0.3.16** to pull in the offline-sync poison-loop fix (affinidi/affinidi-tdk-rs#580).

That fix makes the VTA's periodic offline/backlog drain TSP-aware: it routes queued TSP frames to the same `TspHandler` the live loop uses and acks **all** fetched frames, instead of blindly DIDComm-unpacking them (which failed on TSP frames and never deleted them → the `Cannot parse message as JSON` loop every ~30s).

Lockfile only — no crate source change. `vta-service --features tsp` builds clean against both.

Third and final upstream fix in the TSP-inbound chain (#574 siblings, #578 live-loop decode, #580 offline-sync drain). Redeploy glenn-vta from `main` after this merges and the 30s loop should be gone.