### PR TITLE
feat(tsp): implement messaging/ping and use it for the health probe (no more whoami 422)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2452,7 +2452,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.18.16",
+ "vta-sdk 0.18.17",
 ]
 
 [[package]]
@@ -3254,7 +3254,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.18.16",
+ "vta-sdk 0.18.17",
 ]
 
 [[package]]
@@ -6714,7 +6714,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.18.16",
+ "vta-sdk 0.18.17",
 ]
 
 [[package]]
@@ -10016,7 +10016,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.18.16",
+ "vta-sdk 0.18.17",
  "vti-common",
  "x25519-dalek",
 ]
@@ -10049,7 +10049,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.18.16",
+ "vta-sdk 0.18.17",
 ]
 
 [[package]]
@@ -10072,7 +10072,7 @@ dependencies = [
  "tracing-subscriber",
  "trust-tasks-rs",
  "uniffi",
- "vta-sdk 0.18.16",
+ "vta-sdk 0.18.17",
 ]
 
 [[package]]
@@ -10107,7 +10107,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.18.16"
+version = "0.18.17"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10164,7 +10164,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.10.22"
+version = "0.10.23"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",
@@ -10240,7 +10240,7 @@ dependencies = [
  "utoipa-axum",
  "uuid",
  "vta-cli-common",
- "vta-sdk 0.18.16",
+ "vta-sdk 0.18.17",
  "vta-service",
  "vti-common",
  "vti-secrets",
@@ -10262,7 +10262,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.18.16",
+ "vta-sdk 0.18.17",
 ]
 
 [[package]]
@@ -10334,7 +10334,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.18.16",
+ "vta-sdk 0.18.17",
  "vtc-service",
  "vti-common",
  "vti-secrets",
@@ -10382,7 +10382,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.18.16",
+ "vta-sdk 0.18.17",
  "webauthn-rs",
  "zeroize",
 ]
@@ -10409,7 +10409,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.18.16",
+ "vta-sdk 0.18.17",
  "vta-service",
  "vti-common",
 ]
@@ -10438,7 +10438,7 @@ dependencies = [
  "tokio",
  "tracing",
  "vaultrs",
- "vta-sdk 0.18.16",
+ "vta-sdk 0.18.17",
  "vti-common",
 ]
 

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.18.16"
+version = "0.18.17"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/session.rs
+++ b/vta-sdk/src/session.rs
@@ -1440,12 +1440,13 @@ impl TspPingSession {
     /// Send a Trust Task to `vta_did` over TSP and await the response envelope.
     /// Returns latency in milliseconds.
     ///
-    /// The probe sends an `auth/whoami/0.1` Trust Task (authenticated by the TSP
-    /// unpack's proven sender VID — no holder proof needed on TSP, like DIDComm
-    /// authcrypt). **Any** well-formed response envelope proves the round-trip,
-    /// so the latency is measured to the first frame that unpacks + parses as
-    /// JSON; the probe measures TSP liveness, not whoami success (the DIDComm
-    /// trust-ping is likewise a reachability check, not a semantic one).
+    /// The probe sends a `messaging/ping/0.1` Trust Task — the canonical,
+    /// session-less liveness + capability probe (ToIP Trust Tasks). It's
+    /// authenticated intrinsically by the TSP unpack's proven sender VID (no
+    /// holder proof needed on TSP, like DIDComm authcrypt) and requires no
+    /// capability beyond reachability, so it returns a clean `#response` (not a
+    /// 422 like a session-bound task would). A correlation `nonce` is included;
+    /// the round-trip latency is measured to the response frame.
     pub async fn ping(
         &mut self,
         vta_did: &str,
@@ -1455,11 +1456,12 @@ impl TspPingSession {
         use trust_tasks_rs::TrustTask;
 
         let id = format!("urn:uuid:{}", uuid::Uuid::new_v4());
-        let type_uri = crate::trust_tasks::TASK_AUTH_WHOAMI_0_1
+        let nonce = uuid::Uuid::new_v4().to_string();
+        let type_uri = crate::trust_tasks::TASK_MESSAGING_PING_0_1
             .parse()
-            .map_err(|e| format!("whoami type URI parse: {e}"))?;
+            .map_err(|e| format!("messaging/ping type URI parse: {e}"))?;
         let mut doc: TrustTask<serde_json::Value> =
-            TrustTask::new(id, type_uri, serde_json::json!({}));
+            TrustTask::new(id, type_uri, serde_json::json!({ "nonce": nonce }));
         doc.issuer = Some(self.client_did.clone());
         doc.recipient = Some(vta_did.to_string());
         let body = serde_json::to_vec(&doc)?;

--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -1169,6 +1169,14 @@ pub const TASK_CONSENT_APPROVER_LIST_1_0: &str =
 // in docs/05-design-notes/trust-task-uri-registry.md enumerates the
 // full target surface (~75 URIs).
 
+/// `messaging/ping/0.1` — transport-agnostic liveness + capability probe
+/// (ToIP Trust Tasks `messaging/ping`). Session-less by spec: any authenticated
+/// caller gets back `serverTime` / `status` / `protocols` (the transports the
+/// VTA serves), echoing an optional `nonce`. Side-effect-free. This is the
+/// canonical health ping the `pnm health` TSP/DIDComm probes use — see
+/// <https://trusttasks.org/spec/messaging/ping/0.1>.
+pub const TASK_MESSAGING_PING_0_1: &str = "https://trusttasks.org/spec/messaging/ping/0.1";
+
 /// Every URI registered in this module — handy for the dispatcher's
 /// parity harness and for operator tooling that wants to enumerate
 /// the VTA's wire surface programmatically.
@@ -1204,6 +1212,8 @@ pub const ALL_URIS: &[&str] = &[
     TASK_DEVICE_WIPE_0_1,
     TASK_DEVICE_SET_WAKE_0_1,
     TASK_DEVICE_SET_WAKE_0_2,
+    // Messaging slice
+    TASK_MESSAGING_PING_0_1,
     // ACL slice
     TASK_ACL_LIST_1_0,
     TASK_ACL_CREATE_1_0,

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.10.22"
+version = "0.10.23"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/trust_tasks/messaging.rs
+++ b/vta-service/src/trust_tasks/messaging.rs
@@ -1,0 +1,104 @@
+//! Messaging slice trust-task handlers.
+//!
+//! `messaging/ping` — the transport-agnostic liveness + capability probe of the
+//! ToIP Trust Tasks `messaging/*` family. A VTA answers it as a *responder*
+//! (see the generalised spec): any authenticated caller learns the VTA is alive
+//! and which transports it serves, without parsing its DID document. This is the
+//! canonical health ping the `pnm health` TSP/DIDComm probes drive.
+
+use serde_json::{Value, json};
+use trust_tasks_rs::TrustTask;
+
+use crate::auth::AuthClaims;
+use crate::server::AppState;
+
+use super::helpers::{TrustTaskOutcome, success_response};
+
+/// Handler for `messaging/ping/0.1`.
+///
+/// Side-effect-free and **session-less**: the spec requires no capability
+/// beyond reachability ("a ping MUST NOT require the requester to hold any
+/// capability beyond reachability"), so there is no role or session gate — the
+/// caller is already authenticated by the transport (JWT / DIDComm authcrypt /
+/// TSP unpack) to have reached the dispatcher at all. Returns the VTA's
+/// `serverTime`, a coarse `status`, the transport `protocols` it serves, and
+/// echoes an optional request `nonce` for correlation.
+pub(super) async fn handle_ping(
+    state: &AppState,
+    _auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    // Advertised transports, in preference order (TSP > DIDComm > REST).
+    let protocols: Vec<&str> = {
+        let services = &state.config.read().await.services;
+        let mut p = Vec::new();
+        if services.tsp {
+            p.push("tsp");
+        }
+        if services.didcomm {
+            p.push("didcomm");
+        }
+        if services.rest {
+            p.push("rest");
+        }
+        p
+    };
+
+    let mut body = json!({
+        "serverTime": chrono::Utc::now().to_rfc3339(),
+        "status": "ok",
+        "protocols": protocols,
+    });
+    // Echo the caller's correlation nonce verbatim when supplied.
+    if let Some(nonce) = doc.payload.get("nonce").and_then(Value::as_str) {
+        body["nonce"] = json!(nonce);
+    }
+
+    success_response(&doc, body)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::build_signing_test_app_state;
+    use serde_json::json;
+
+    fn ping_doc(nonce: Option<&str>) -> TrustTask<Value> {
+        let payload = match nonce {
+            Some(n) => json!({ "nonce": n }),
+            None => json!({}),
+        };
+        TrustTask::new(
+            "urn:uuid:test-ping".to_string(),
+            vta_sdk::trust_tasks::TASK_MESSAGING_PING_0_1
+                .parse()
+                .unwrap(),
+            payload,
+        )
+    }
+
+    /// A ping from any authenticated caller (no session, no role) returns a
+    /// 200 `#response` with status ok and the echoed nonce.
+    #[tokio::test]
+    async fn ping_is_session_less_and_echoes_nonce() {
+        let (state, _dir) = build_signing_test_app_state().await;
+        // A synthetic intrinsic-sender claim (as TSP/DIDComm produce) — no
+        // stored session, no admin role needed.
+        let auth = crate::auth::AuthClaims {
+            did: "did:key:zPinger".into(),
+            role: crate::acl::Role::Reader,
+            allowed_contexts: vec![],
+            session_id: "didcomm:did:key:zPinger".into(),
+            access_expires_at: 0,
+            amr: vec!["did".into()],
+            acr: "aal1".into(),
+        };
+
+        let out = handle_ping(&state, &auth, ping_doc(Some("abc123"))).await;
+        assert_eq!(out.status, axum::http::StatusCode::OK);
+        let doc: Value = serde_json::from_slice(&out.body).expect("reply is JSON");
+        assert_eq!(doc["payload"]["status"], "ok");
+        assert_eq!(doc["payload"]["nonce"], "abc123");
+        assert!(doc["payload"]["serverTime"].is_string());
+    }
+}

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -61,6 +61,7 @@ mod helpers;
 mod keys;
 mod management;
 mod memory;
+mod messaging;
 #[cfg(all(feature = "webvh", feature = "didcomm"))]
 mod passkey_vms;
 #[cfg(feature = "webvh")]
@@ -503,6 +504,8 @@ dispatch_table! {
     vta_sdk::trust_tasks::TASK_DEVICE_DISABLE_0_1 => device::handle_disable,
     vta_sdk::trust_tasks::TASK_DEVICE_WIPE_0_1 => device::handle_wipe,
     vta_sdk::trust_tasks::TASK_DEVICE_SET_WAKE_0_1 => device::handle_set_wake,
+    // ─── Messaging slice ──────────────────────────────────────────
+    vta_sdk::trust_tasks::TASK_MESSAGING_PING_0_1 => messaging::handle_ping,
     // ─── Contexts slice ──────────────────────────────────────────
     vta_sdk::trust_tasks::TASK_CONTEXTS_LIST_1_0 => contexts::handle_list,
     vta_sdk::trust_tasks::TASK_CONTEXTS_CREATE_1_0 => contexts::handle_create,


### PR DESCRIPTION
## Why

The TSP health probe was sending an `auth/whoami/0.1` Trust Task as its ping. `whoami` looks up a **stored session**, but intrinsic-sender auth (TSP unpack / DIDComm authcrypt) synthesises a session id with no backing session — so it returned **422 Unprocessable Entity** on every health check. Overloading whoami (or any capability-bearing task) as a ping is a hack.

## What

Implement the **canonical `messaging/ping/0.1`** Trust Task (ToIP Trust Tasks) — a purpose-built, **session-less**, side-effect-free liveness + capability probe. The spec is explicit: *"a ping MUST NOT require the requester to hold any capability beyond reachability."*

- **vta-sdk**: add `TASK_MESSAGING_PING_0_1` (+ `ALL_URIS` registration). `TspPingSession::ping` now sends `messaging/ping` with a correlation `nonce` instead of whoami.
- **vta-service**: `trust_tasks::messaging::handle_ping` — no role/session gate; returns `serverTime`, `status: "ok"`, `protocols` (the VTA's advertised transports, TSP > DIDComm > REST), and echoes the request `nonce`. Wired into the dispatch table (parity test covers it).

It's on the shared Trust-Task spine, so it answers identically over **REST / DIDComm / TSP**.

## Result

The VTA now logs `messaging.ping status=200` instead of `whoami 422`, and the probe gets a real, semantically-correct pong.

## Spec

`messaging/ping/0.1` already existed but was scoped to a *Mediator* responder; the companion spec PR generalises it to any messaging endpoint (mediator **or** agent/VTA): trustoverip/dtgwg-trust-tasks-tf#107. Schema unchanged, so this implementation matches both the current and generalised spec.

## Testing

`ping_is_session_less_and_echoes_nonce` + the `dispatcher_handles_every_vta_sdk_uri` parity test pass; clippy `-D`-clean in default and tsp. vta-sdk 0.18.16→**0.18.17**; vta-service 0.10.22→**0.10.23**.

Needs a VTA redeploy + pnm rebuild to take effect.