### PR TITLE
Transport hardening: dispatcher-route acl/swap-key, replay dedup, deprecate redundant REST routes

### DIFF
--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -222,6 +222,16 @@ pub const TASK_ACL_UPDATE_1_0: &str = "https://trusttasks.org/spec/vta/acl/updat
 /// Auth: Admin or Initiator.
 pub const TASK_ACL_DELETE_1_0: &str = "https://trusttasks.org/spec/vta/acl/delete/1.0";
 
+/// `spec/acl/swap-key/0.1` — self-service rotation of the caller's own ACL
+/// entry onto a new subject DID, proven by a `link_proof` VP-JWT. Payload:
+/// [`crate::protocols::acl_management::swap::SwapKeyBody`]. Auth: any
+/// authenticated caller (the operation binds `currentSubject` to the sender).
+///
+/// Registry alias of [`crate::protocols::acl_management::ACL_SWAP_KEY`] so the
+/// dispatcher can route it through the shared spine (previously it was bespoke
+/// on both REST `/acl/swap` and the DIDComm router).
+pub const TASK_ACL_SWAP_KEY_1_0: &str = crate::protocols::acl_management::ACL_SWAP_KEY;
+
 // ─── Contexts slice (spec/vta/contexts/*) ────────────────────────────────
 
 /// `spec/vta/contexts/list/1.0` — list contexts visible to caller.
@@ -1220,6 +1230,7 @@ pub const ALL_URIS: &[&str] = &[
     TASK_ACL_GET_1_0,
     TASK_ACL_UPDATE_1_0,
     TASK_ACL_DELETE_1_0,
+    TASK_ACL_SWAP_KEY_1_0,
     // Contexts slice
     TASK_CONTEXTS_LIST_1_0,
     TASK_CONTEXTS_CREATE_1_0,
@@ -1441,6 +1452,9 @@ mod tests {
             "https://trusttasks.org/spec/vault/",
             "https://trusttasks.org/spec/webvh/",
             "https://trusttasks.org/spec/consent/",
+            // Framework ACL protocol — the `acl/swap-key` self-service key
+            // rotation task (`TASK_ACL_SWAP_KEY_1_0`), now dispatcher-routed.
+            "https://trusttasks.org/spec/acl/",
         ];
         for uri in ALL_URIS {
             assert!(

--- a/vta-service/src/deprecation.rs
+++ b/vta-service/src/deprecation.rs
@@ -1,0 +1,31 @@
+//! Deprecation signalling for legacy REST routes that a canonical
+//! `/api/trust-tasks` Trust-Task now supersedes.
+//!
+//! These routes keep working — the deprecation is advisory. We add response
+//! headers so clients can detect the deprecation and migrate, and increment a
+//! hit counter (`deprecated_route_requests_total`, labelled by route) so that
+//! removal can be gated on **observed usage dropping to zero** rather than a
+//! guessed calendar date. (No `Sunset` date is emitted for that reason.)
+//!
+//! The canonical replacement for every route marked here is the same operation
+//! dispatched as a Trust-Task via `POST /api/trust-tasks` (reachable over REST,
+//! DIDComm, and TSP through the shared `dispatch_trust_task_core` spine).
+
+use axum::http::{HeaderMap, HeaderValue};
+use metrics::counter;
+
+/// Build the deprecation response headers for a legacy `route`, pointing at the
+/// successor Trust-Task URI, and record a hit for that route.
+///
+/// Emits `Deprecation: true` and `Link: <successor>; rel="successor-version"`
+/// (RFC 8288). Attach the returned [`HeaderMap`] to the handler's response.
+pub fn superseded(route: &'static str, successor: &'static str) -> HeaderMap {
+    counter!("deprecated_route_requests_total", "route" => route).increment(1);
+
+    let mut headers = HeaderMap::new();
+    headers.insert("deprecation", HeaderValue::from_static("true"));
+    if let Ok(link) = HeaderValue::from_str(&format!("<{successor}>; rel=\"successor-version\"")) {
+        headers.insert("link", link);
+    }
+    headers
+}

--- a/vta-service/src/lib.rs
+++ b/vta-service/src/lib.rs
@@ -20,6 +20,7 @@ pub mod backup_bundle_sweeper;
 pub mod config;
 pub mod consent_sweeper;
 pub mod contexts;
+pub mod deprecation;
 pub mod did_templates;
 pub mod didcomm_bridge;
 pub mod error;

--- a/vta-service/src/routes/contexts.rs
+++ b/vta-service/src/routes/contexts.rs
@@ -1,6 +1,6 @@
 use axum::Json;
 use axum::extract::{Path, Query, State};
-use axum::http::StatusCode;
+use axum::http::{HeaderMap, StatusCode};
 use serde::Deserialize;
 
 use vta_sdk::protocols::context_management::{
@@ -54,9 +54,15 @@ pub struct DeleteContextQuery {
 pub async fn list_contexts_handler(
     auth: AuthClaims,
     State(state): State<AppState>,
-) -> Result<Json<ListContextsResultBody>, AppError> {
+) -> Result<(HeaderMap, Json<ListContextsResultBody>), AppError> {
     let result = operations::contexts::list_contexts(&state.contexts_ks, &auth, "rest").await?;
-    Ok(Json(result))
+    // Deprecated: superseded by the `contexts/list/1.0` Trust-Task via
+    // /api/trust-tasks. See `crate::deprecation`.
+    let headers = crate::deprecation::superseded(
+        "GET /contexts",
+        vta_sdk::trust_tasks::TASK_CONTEXTS_LIST_1_0,
+    );
+    Ok((headers, Json(result)))
 }
 
 /// POST /contexts — create a context. Auth: **admin** (the operation enforces
@@ -76,7 +82,7 @@ pub async fn create_context_handler(
     auth: AdminAuth,
     State(state): State<AppState>,
     Json(req): Json<CreateContextRequest>,
-) -> Result<(StatusCode, Json<CreateContextResultBody>), AppError> {
+) -> Result<(StatusCode, HeaderMap, Json<CreateContextResultBody>), AppError> {
     let result = operations::contexts::create_context(
         &state.contexts_ks,
         &auth.0,
@@ -87,7 +93,12 @@ pub async fn create_context_handler(
         "rest",
     )
     .await?;
-    Ok((StatusCode::CREATED, Json(result)))
+    // Deprecated: superseded by the `contexts/create/1.0` Trust-Task.
+    let headers = crate::deprecation::superseded(
+        "POST /contexts",
+        vta_sdk::trust_tasks::TASK_CONTEXTS_CREATE_1_0,
+    );
+    Ok((StatusCode::CREATED, headers, Json(result)))
 }
 
 /// GET /contexts/{id} — retrieve a single context by ID. Auth: any authenticated user.

--- a/vta-service/src/routes/did_webvh.rs
+++ b/vta-service/src/routes/did_webvh.rs
@@ -1,6 +1,6 @@
 use axum::Json;
 use axum::extract::{Path, Query, State};
-use axum::http::StatusCode;
+use axum::http::{HeaderMap, StatusCode};
 use serde::Deserialize;
 
 use vta_sdk::protocols::did_management::{
@@ -200,7 +200,7 @@ pub async fn create_did_handler(
     auth: AdminAuth,
     State(state): State<AppState>,
     Json(body): Json<CreateDidWebvhBody>,
-) -> Result<(StatusCode, Json<CreateDidWebvhResultBody>), AppError> {
+) -> Result<(StatusCode, HeaderMap, Json<CreateDidWebvhResultBody>), AppError> {
     let config = state.config.read().await;
     let params = body.into();
     let did_resolver = state
@@ -210,7 +210,12 @@ pub async fn create_did_handler(
     let deps =
         operations::did_webvh::CreateDidWebvhDeps::from_app_state(&state, &config, did_resolver);
     let result = operations::did_webvh::create_did_webvh(&deps, &auth.0, params, "rest").await?;
-    Ok((StatusCode::CREATED, Json(result)))
+    // Deprecated: superseded by the `vta/webvh/dids/create/1.0` Trust-Task.
+    let headers = crate::deprecation::superseded(
+        "POST /webvh/dids",
+        vta_sdk::trust_tasks::TASK_WEBVH_DIDS_CREATE_1_0,
+    );
+    Ok((StatusCode::CREATED, headers, Json(result)))
 }
 
 /// GET /webvh/dids — list webvh DIDs with optional filters. Auth: any authenticated user.
@@ -227,7 +232,7 @@ pub async fn list_dids_handler(
     auth: AuthClaims,
     State(state): State<AppState>,
     Query(query): Query<ListDidsQuery>,
-) -> Result<Json<ListDidsWebvhResultBody>, AppError> {
+) -> Result<(HeaderMap, Json<ListDidsWebvhResultBody>), AppError> {
     let result = operations::did_webvh::list_dids_webvh(
         &state.webvh_ks,
         &auth,
@@ -236,7 +241,12 @@ pub async fn list_dids_handler(
         "rest",
     )
     .await?;
-    Ok(Json(result))
+    // Deprecated: superseded by the `vta/webvh/dids/list/1.0` Trust-Task.
+    let headers = crate::deprecation::superseded(
+        "GET /webvh/dids",
+        vta_sdk::trust_tasks::TASK_WEBVH_DIDS_LIST_1_0,
+    );
+    Ok((headers, Json(result)))
 }
 
 /// GET /webvh/dids/{did} — retrieve a single webvh DID record. Auth: any authenticated user.

--- a/vta-service/src/trust_tasks/acl.rs
+++ b/vta-service/src/trust_tasks/acl.rs
@@ -4,17 +4,20 @@
 //! Initiator for list/create/get/delete; Admin-only for update.
 
 use super::helpers::TrustTaskOutcome;
-use serde_json::Value;
+use serde_json::{Value, json};
 use trust_tasks_rs::{RejectReason, TrustTask};
 use vta_sdk::protocols::acl_management::create::CreateAclBody;
 use vta_sdk::protocols::acl_management::delete::DeleteAclBody;
 use vta_sdk::protocols::acl_management::get::GetAclBody;
 use vta_sdk::protocols::acl_management::list::ListAclBody;
+use vta_sdk::protocols::acl_management::swap::SwapKeyBody;
 use vta_sdk::protocols::acl_management::update::UpdateAclBody;
 
 use crate::acl::Role;
 use crate::auth::AuthClaims;
+use crate::error::AppError;
 use crate::operations;
+use crate::operations::step_up::{StepUpDecision, op, resolve_step_up};
 use crate::server::AppState;
 
 use super::helpers::{
@@ -203,6 +206,117 @@ pub(super) async fn handle_delete(
     .await
     {
         Ok(body) => success_response(&doc, body),
+        Err(e) => app_error_to_reject(&doc, e),
+    }
+}
+
+/// Handler for the canonical `acl/swap-key/0.1` Trust Task — self-service
+/// rotation of the caller's own ACL entry onto a new subject DID. Consolidates
+/// the bespoke REST `/acl/swap` handler and the DIDComm `handle_swap_acl` onto
+/// the shared dispatcher (so it works over REST, DIDComm, and TSP identically).
+///
+/// No `require_manage()`: the caller only moves their own grant. The
+/// transport-authenticated sender (REST bearer / DIDComm authcrypt / TSP VID)
+/// is bound to `currentSubject`; the `link_proof` VP-JWT proves control of
+/// `newSubject`.
+pub(super) async fn handle_swap_key(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    let req: SwapKeyBody = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+
+    // The authenticated caller must equal the declared currentSubject — stops a
+    // sender from claiming to rotate someone else's entry.
+    if req.current_subject != auth.did {
+        return reject_with(
+            &doc,
+            RejectReason::MalformedRequest {
+                reason: format!(
+                    "acl/swap-key: currentSubject {} does not equal authenticated caller {}",
+                    req.current_subject, auth.did
+                ),
+            },
+        );
+    }
+
+    // Step-up floor WITH the non-escalating carve-out (swap-key is self-service).
+    // Deliberately NOT the escalating `require_step_up` helper: with the default
+    // no-floor policy this resolves to `Allow`, so AAL1 sender-authenticated
+    // transports (DIDComm/TSP) proceed. A floor that genuinely requires step-up
+    // rejects here with guidance to use the REST session (which can reach AAL2).
+    if !matches!(
+        resolve_step_up(
+            &state.config,
+            &state.acl_ks,
+            op::ACL_SWAP_KEY,
+            &auth.did,
+            true, // swap-key is non-escalating
+        )
+        .await,
+        StepUpDecision::Allow
+    ) {
+        return reject_with(
+            &doc,
+            RejectReason::TaskFailed {
+                reason: "auth:step_up_required".to_string(),
+                details: Some(json!({
+                    "requiredAcr": "aal2",
+                    "reason": "acl/swap-key requires a stepped-up (AAL2) session under this \
+                               VTA's step-up policy. Sender-authenticated transports \
+                               (DIDComm/TSP) are AAL1 and cannot be elevated in-band — perform \
+                               this self-service rotation over the authenticated REST session.",
+                })),
+            },
+        );
+    }
+
+    let did_resolver = match state.did_resolver.as_ref() {
+        Some(r) => r,
+        None => {
+            return app_error_to_reject(
+                &doc,
+                AppError::Internal("DID resolver not available".into()),
+            );
+        }
+    };
+    let vta_did = match state.config.read().await.vta_did.clone() {
+        Some(v) => v,
+        None => {
+            return app_error_to_reject(&doc, AppError::Internal("VTA DID not configured".into()));
+        }
+    };
+
+    match operations::acl::swap_acl(
+        &state.acl_ks,
+        &state.audit_ks,
+        auth,
+        &req.link_proof,
+        did_resolver,
+        &vta_did,
+        TRANSPORT_TRUST_TASK,
+    )
+    .await
+    {
+        Ok(result) => {
+            // Cross-check the declared newSubject matches the VP holder the
+            // operation actually verified (defence-in-depth over the proof).
+            if req.new_subject != result.did {
+                return reject_with(
+                    &doc,
+                    RejectReason::MalformedRequest {
+                        reason: format!(
+                            "acl/swap-key: newSubject {} does not match verified VP holder {}",
+                            req.new_subject, result.did
+                        ),
+                    },
+                );
+            }
+            success_response(&doc, result)
+        }
         Err(e) => app_error_to_reject(&doc, e),
     }
 }

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -66,6 +66,7 @@ mod messaging;
 mod passkey_vms;
 #[cfg(feature = "webvh")]
 mod provision_integration;
+mod replay;
 mod seeds;
 // `pub(crate)` so the REST routes (`routes::acl`, `routes::contexts`) can
 // reach the `RequireStepUp` extractor + op markers. The step-up *engine* lives
@@ -315,6 +316,25 @@ pub(crate) async fn dispatch_trust_task_core(
         // No vta_did configured → service is in setup; skip
         // the recipient check (no identity to bind against).
         // Production VTAs always have vta_did set by `vta setup`.
+    }
+
+    // 2b. Replay dedup. Reject a re-submitted `(actor, envelope-id)` within the
+    //     dedup window so a retry — including a client's cross-transport
+    //     fallback — cannot double-apply a mutating task. Ids are unique per
+    //     request, so this only fires on a genuine resubmission of the same
+    //     envelope. Record-before-dispatch = at-most-once (see `replay`).
+    if !replay::check_and_record(&auth.did, &doc.id) {
+        return reject_with(
+            &doc,
+            RejectReason::TaskFailed {
+                reason: "duplicate".to_string(),
+                details: Some(serde_json::json!({
+                    "id": doc.id,
+                    "reason": "this request id was already submitted; the prior submission is \
+                               authoritative — do not retry with the same id",
+                })),
+            },
+        );
     }
 
     // 3. Session-pubkey binding pre-check.

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -497,6 +497,7 @@ dispatch_table! {
     vta_sdk::trust_tasks::TASK_ACL_GET_1_0 => acl::handle_get,
     vta_sdk::trust_tasks::TASK_ACL_UPDATE_1_0 => acl::handle_update,
     vta_sdk::trust_tasks::TASK_ACL_DELETE_1_0 => acl::handle_delete,
+    vta_sdk::trust_tasks::TASK_ACL_SWAP_KEY_1_0 => acl::handle_swap_key,
     // ─── Device slice ─────────────────────────────────────────────
     vta_sdk::trust_tasks::TASK_DEVICE_REGISTER_0_1 => device::handle_register,
     vta_sdk::trust_tasks::TASK_DEVICE_HEARTBEAT_0_1 => device::handle_heartbeat,

--- a/vta-service/src/trust_tasks/replay.rs
+++ b/vta-service/src/trust_tasks/replay.rs
@@ -1,0 +1,80 @@
+//! Trust-task replay dedup.
+//!
+//! The dispatcher records each `(actor, envelope-id)` it processes and rejects a
+//! re-submission of the same id within a short window, so a retry — including a
+//! client's cross-transport fallback (TSP → DIDComm → REST) — cannot
+//! double-apply a *mutating* task. Envelope ids are unique per request (a fresh
+//! UUID), so this only ever fires on a genuine resubmission of the identical
+//! request, never on two distinct requests.
+//!
+//! **Semantics: record-before-dispatch (at-most-once).** The id is recorded
+//! before the handler runs, so a crash between recording and the effect landing
+//! leaves the retry rejected rather than double-applied — the safe direction for
+//! mutating operations.
+//!
+//! **Bounded, in-memory, best-effort.** The dedup window (`TTL`) comfortably
+//! covers retries/fallback (seconds); genuinely old replays are already caught
+//! by the dispatcher's `validate_basic` expiry check. The cache is size-capped
+//! and does not persist across restarts — cross-restart replay is not the threat
+//! model here (an expired envelope is rejected regardless). A persistent,
+//! result-caching *idempotency* layer (return the prior response on replay,
+//! enabling automatic retry-with-result) is a deliberate follow-up.
+
+use std::collections::HashMap;
+use std::sync::{LazyLock, Mutex};
+use std::time::{Duration, Instant};
+
+/// How long a processed `(actor, id)` is remembered. Comfortably longer than any
+/// retry/fallback window; shorter than the dispatcher's own expiry enforcement.
+const TTL: Duration = Duration::from_secs(600);
+
+/// Upper bound on remembered entries — prevents unbounded growth under load.
+/// When exceeded, expired entries are pruned before inserting.
+const MAX_ENTRIES: usize = 100_000;
+
+static SEEN: LazyLock<Mutex<HashMap<String, Instant>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// Record `(actor, id)` and report whether it is **fresh**.
+///
+/// Returns `true` if this is the first time `(actor, id)` has been seen within
+/// the dedup window (and records it), or `false` if it is a replay of an id
+/// already processed within `TTL`.
+pub(super) fn check_and_record(actor: &str, id: &str) -> bool {
+    let key = format!("{actor}|{id}");
+    let now = Instant::now();
+    let mut seen = SEEN.lock().unwrap_or_else(|p| p.into_inner());
+
+    if let Some(&recorded) = seen.get(&key)
+        && now.duration_since(recorded) < TTL
+    {
+        return false; // replay within the window
+    }
+
+    // Fresh (or the prior record has aged out). Prune before growing past the cap.
+    if seen.len() >= MAX_ENTRIES {
+        seen.retain(|_, &mut t| now.duration_since(t) < TTL);
+    }
+    seen.insert(key, now);
+    true
+}
+
+#[cfg(test)]
+pub(super) fn reset_for_test() {
+    SEEN.lock().unwrap_or_else(|p| p.into_inner()).clear();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn first_submission_is_fresh_replay_is_not() {
+        reset_for_test();
+        assert!(check_and_record("did:web:a", "id-1"), "first is fresh");
+        assert!(!check_and_record("did:web:a", "id-1"), "replay is caught");
+        // A different id, or a different actor with the same id, is independent.
+        assert!(check_and_record("did:web:a", "id-2"));
+        assert!(check_and_record("did:web:b", "id-1"));
+    }
+}


### PR DESCRIPTION
Server-side changes so the trust-task dispatcher is the single, safe path for every operation across REST, DIDComm, and TSP. Companion to the browser-plugin transport-agnostic work (channels + `VtaSession` priority chain TSP > DIDComm > REST).

## Changes

### A2 — route `acl/swap-key` through the shared dispatcher
`acl/swap-key/0.1` was the one operation bypassing `dispatch_trust_task_core` on **both** transports: a bespoke REST handler (`/acl/swap`) and a direct DIDComm router registration. It's now a dispatched Trust-Task, so it rides the same spine as everything else and clients can collapse their doubled swap paths onto the generic channel.

- `vta-sdk`: `TASK_ACL_SWAP_KEY_1_0` (alias of `acl_management::ACL_SWAP_KEY`) added to `ALL_URIS`; `/spec/acl/` added to the canonical-namespace allow-list (swap-key is a framework, not `/spec/vta/`, URI).
- `vta-service`: `dispatch_table!` arm → new `acl::handle_swap_key`, which binds the authenticated sender to `currentSubject`, applies the step-up floor **with the non-escalating carve-out** (`resolve_step_up(non_escalating=true)` — so AAL1 DIDComm/TSP proceed by default; a genuine floor rejects with REST-fallback guidance — deliberately **not** the escalating `require_step_up` helper), calls `operations::acl::swap_acl`, and cross-checks `newSubject` against the verified VP holder.
- The bespoke `/acl/swap` + DIDComm registration **stay** for now (deprecation window) — they get deprecated once clients migrate to the dispatched form.

### B3 — reject-based trust-task replay dedup
The dispatcher had no envelope-`id` dedup (`validate_basic` checks only expiry + recipient), so a re-submitted task re-applies — unsafe for cross-transport retry/fallback on mutating ops.

- `trust_tasks/replay.rs`: a bounded in-memory TTL cache (600s window, 100k cap) keyed `(actor, envelope-id)`, **record-before-dispatch = at-most-once**. The window covers retries/fallback (seconds); genuinely old replays are already caught by `validate_basic`'s expiry check, so no persistence/sweeper is needed.
- `dispatch_trust_task_core` rejects a duplicate with `TaskFailed{reason:"duplicate"}`. Ids are unique per request, so this only fires on a genuine resubmission of the same envelope.
- This is the **reject-based v1**: it prevents double-apply. A persistent, result-caching *idempotency* layer (return the prior response on replay, so a retry succeeds with the result and automatic fallback is fully safe) is a deliberate follow-up.

### C4 — deprecate REST routes superseded by trust-tasks
`/contexts` (list/create) and `/webvh/dids` (list/create) each duplicate an operation already reachable via `/api/trust-tasks`.

- `deprecation::superseded(route, successor)` adds `Deprecation: true` + `Link: rel="successor-version"` headers and increments `deprecated_route_requests_total{route}` — so removal is gated on **observed usage dropping to zero** rather than a guessed date (no `Sunset` emitted). Advisory only; the routes keep working.
- `/acl/swap` is intentionally **not** deprecated here — it only gets a dispatched replacement via A2, and clients haven't migrated yet.

## Testing
- `cargo check -p vta-service` green.
- Full `cargo test -p vta-service`: **833 lib tests + all integration binaries pass**, plus 53 trust-task dispatcher tests (added the swap-key arm + a replay unit test) and the `vta-sdk` registry/namespace tests.
- One pre-existing failure remains, unrelated to this PR: `mock_vta::create_did_webvh_round_trips_against_stub_host` (webvh-server stub response parse error) — **fails identically on `main`**.