### PR TITLE
fix(vta-service): release setup store lock before admin/staff seeding

### DIFF
--- a/vta-service/src/setup/from_toml.rs
+++ b/vta-service/src/setup/from_toml.rs
@@ -803,6 +803,7 @@ pub async fn apply_inputs(
     drop(imported_ks);
     drop(contexts_ks);
     drop(webvh_ks);
+    drop(audit_ks);
     drop(did_templates_ks);
     drop(store);
 


### PR DESCRIPTION
## Summary
- Fixes a setup locking bug where non-interactive setup could fail with `FjallError: Locked` after DID creation, during admin or staff provisioning.

## Root cause
- In setup apply flow, the store is intentionally closed before later steps re-open it.
- One keyspace handle remained alive, so Fjall lock was still held and reopen failed on the same data directory.

## Changes
- Setup lock release fix in from_toml.rs