### PR TITLE
feat(vta-mobile-core): emit step-up approve-response 0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10054,7 +10054,7 @@ dependencies = [
 
 [[package]]
 name = "vta-mobile-core"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",

--- a/vta-mobile-core/Cargo.toml
+++ b/vta-mobile-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vta-mobile-core"
-version = "0.6.8"
+version = "0.6.9"
 description = "UniFFI engine for the VTA mobile agent (Android/iOS): DIDComm, Trust Tasks, AAL step-up."
 edition.workspace = true
 # Not a crates.io library — the published artifacts are the Android AAR

--- a/vta-mobile-core/src/stepup.rs
+++ b/vta-mobile-core/src/stepup.rs
@@ -11,7 +11,7 @@
 
 use chrono::DateTime;
 use trust_tasks_rs::TrustTask;
-use trust_tasks_rs::specs::auth::step_up::approve_response::v0_1 as approve_response;
+use trust_tasks_rs::specs::auth::step_up::approve_response::v0_2 as approve_response;
 
 use crate::error::FfiError;
 use crate::keys::Signer;
@@ -53,7 +53,7 @@ pub struct ApproveResponseDraft {
     pub granted_acr: Option<String>,
 }
 
-/// Build a passkey-backed `auth/step-up/approve-response/0.1`: decision
+/// Build a passkey-backed `auth/step-up/approve-response/0.2`: decision
 /// `approved`, `evidence.kind = webauthn` carrying `assertion`. The assertion is
 /// the gate, so no framework proof is attached. Returns the serialized Trust
 /// Task JSON for the native layer to send back to the relying party.
@@ -79,8 +79,8 @@ pub fn build_approve_response_webauthn(
     serialize(&doc)
 }
 
-/// Build a DID-signed `auth/step-up/approve-response/0.1`: decision `approved`,
-/// `evidence.kind = did-signed`, gated by a Data Integrity proof
+/// Build a DID-signed `auth/step-up/approve-response/0.2`: decision `approved`,
+/// `evidence.kind = didSigned`, gated by a Data Integrity proof
 /// (`eddsa-jcs-2022`) over the document. `signer` is the native enclave key
 /// (the holder/subject key) — its private material never enters this crate;
 /// it only signs the canonical input produced here.
@@ -172,7 +172,7 @@ mod tests {
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
         assert_eq!(
             v["type"],
-            "https://trusttasks.org/spec/auth/step-up/approve-response/0.1"
+            "https://trusttasks.org/spec/auth/step-up/approve-response/0.2"
         );
         assert_eq!(v["payload"]["decision"], "approved");
         assert_eq!(v["payload"]["evidence"]["kind"], "webauthn");
@@ -260,6 +260,15 @@ mod tests {
             }),
         )
         .unwrap();
+
+        // 0.2 wire form: the type URI is `/0.2` and did-signed evidence
+        // serializes as the camelCase `didSigned` (the sole 0.1→0.2 change).
+        let raw: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            raw["type"],
+            "https://trusttasks.org/spec/auth/step-up/approve-response/0.2"
+        );
+        assert_eq!(raw["payload"]["evidence"]["kind"], "didSigned");
 
         let doc: TrustTask<approve_response::Payload> = serde_json::from_str(&json).unwrap();
         assert!(matches!(


### PR DESCRIPTION
## What

Switch the mobile engine's step-up approve-response emitter from the deprecated `approve-response/0.1` to `0.2`, and bump the crate `0.6.8` → `0.6.9`.

## Why

`TASK_AUTH_STEP_UP_APPROVE_RESPONSE_0_1` is `#[deprecated]` in `vta-sdk` in favour of `0.2`. The mobile engine (and therefore the iOS/Android apps that pin it) still emitted `0.1`. This brings the emitter current so the next mobile-core release the apps adopt is on the supported wire form.

## The change is minimal by construction

The only difference between the `0.1` and `0.2` approve-response wire forms is:
- the version in the `type` URI (`…/approve-response/0.1` → `…/0.2`), and
- the evidence discriminator casing: `evidence.kind: "did-signed"` → `"didSigned"`.

The payload/evidence **field shapes are byte-identical** (verified: `trust-tasks-rs` `v0_1` and `v0_2` expose an identical public item set). So this is a one-line import swap (`approve_response::v0_1` → `v0_2`) plus doc/test updates.

## Compatibility

- Not a flag-day: the VTA dispatches **both** `0.1` and `0.2` to the same `handle_approve_response` and accepts `0.1` inbound during the migration window.
- `approve-request` is untouched — it stays `0.1` (no `0.2` exists).

## Tests

- Updated `stepup.rs` assertions to the `/0.2` URI.
- Added an explicit assertion that did-signed evidence serializes as camelCase `didSigned`.
- Full `vta-mobile-core` suite green (38 passed, 2 ignored), `clippy` clean, `cargo fmt --check` clean.

## Follow-ups (not in this PR)

- Cut the `vta-mobile-core-v0.6.9` tag → the `release-mobile-ios.yml` workflow builds + publishes the xcframework.
- Bump the `vta-mobile-agent-ios` SwiftPM pin (v0.6.1 → v0.6.9) + checksum + re-vendored wrapper.