### PR TITLE
feat(step-up): carry structured authorizationContext to the approver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10054,7 +10054,7 @@ dependencies = [
 
 [[package]]
 name = "vta-mobile-core"
-version = "0.6.9"
+version = "0.6.10"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",

--- a/vta-mobile-core/Cargo.toml
+++ b/vta-mobile-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vta-mobile-core"
-version = "0.6.9"
+version = "0.6.10"
 description = "UniFFI engine for the VTA mobile agent (Android/iOS): DIDComm, Trust Tasks, AAL step-up."
 edition.workspace = true
 # Not a crates.io library — the published artifacts are the Android AAR

--- a/vta-mobile-core/src/task.rs
+++ b/vta-mobile-core/src/task.rs
@@ -33,7 +33,18 @@ pub struct StepUpRequest {
     /// Whether the request carried WebAuthn options — i.e. the relying party
     /// wants a passkey-backed elevation and supplied the ceremony parameters.
     pub webauthn_requested: bool,
+    /// Structured authorization context (raw JSON), when the request carries one
+    /// under the reverse-DNS `payload.ext` key `org.openvtc.authorization-context`
+    /// — e.g. a Cierge cross-domain share / spend / tool ask. The native layer
+    /// decodes and renders it as the approval card; absent for a plain
+    /// login-elevation step-up (the UI falls back to `reason`).
+    pub authorization_context: Option<String>,
 }
+
+/// Reverse-DNS `payload.ext` key (SPEC §4.5.1) under which the VTA embeds the
+/// structured authorization context. Kept in lockstep with the VTA
+/// (`vta-service` `EXT_KEY_AUTHZ_CONTEXT`).
+const EXT_KEY_AUTHZ_CONTEXT: &str = "org.openvtc.authorization-context";
 
 /// Parse an inbound `auth/step-up/approve-request/0.1` Trust Task document.
 ///
@@ -47,6 +58,20 @@ pub fn parse_step_up_request(json: String) -> Result<StepUpRequest, FfiError> {
         serde_json::from_str(&json).map_err(|e| FfiError::Decode {
             reason: format!("not a valid auth/step-up/approve-request document: {e}"),
         })?;
+    // Pull the structured authorization context (if any) from `payload.ext` by
+    // its reverse-DNS key, as a raw JSON string for the native layer to decode.
+    // Read from a lenient Value copy so we don't depend on the generated `Ext`
+    // newtype's key API; the typed parse above already validated the envelope,
+    // so this re-parse cannot fail.
+    let authorization_context = serde_json::from_str::<serde_json::Value>(&json)
+        .ok()
+        .and_then(|v| {
+            v.get("payload")
+                .and_then(|p| p.get("ext"))
+                .and_then(|e| e.get(EXT_KEY_AUTHZ_CONTEXT))
+                .map(|c| c.to_string())
+        });
+
     let p = doc.payload;
     Ok(StepUpRequest {
         relying_party: doc.issuer,
@@ -62,6 +87,7 @@ pub fn parse_step_up_request(json: String) -> Result<StepUpRequest, FfiError> {
             .map(|e| e.to_string())
             .collect(),
         webauthn_requested: p.webauthn.is_some(),
+        authorization_context,
     })
 }
 
@@ -124,6 +150,44 @@ mod tests {
         assert!(r.acceptable_evidence.is_empty());
         assert!(!r.webauthn_requested);
         assert_eq!(r.target_acr, None);
+        // No ext → no structured context (the UI falls back to `reason`).
+        assert!(r.authorization_context.is_none());
+    }
+
+    #[test]
+    fn parses_authorization_context_from_ext() {
+        // A Cierge share ask carried under the reverse-DNS `ext` key.
+        let json = r#"{
+          "id": "x",
+          "type": "https://trusttasks.org/spec/auth/step-up/approve-request/0.1",
+          "issuer": "did:webvh:vta",
+          "payload": {
+            "subject": "did:webvh:operator",
+            "sessionId": "s1",
+            "challenge": "VHJhbnNmZXJDb25maXJtTm9uY2VYWQ",
+            "reason": "finance wants to share salaryBand with travel",
+            "ext": {
+              "org.openvtc.authorization-context": {
+                "type": "https://openvtc.org/cierge/authorization-context/0.1",
+                "summary": "finance wants to share salaryBand with travel",
+                "risk": "high",
+                "action": { "kind": "share", "from": "finance", "to": "travel", "ttlSeconds": 3600 }
+              }
+            }
+          }
+        }"#;
+        let r = parse_step_up_request(json.to_string()).unwrap();
+        // Surfaced as a raw JSON string for the native layer to decode + render.
+        let ctx = r
+            .authorization_context
+            .expect("authorization_context present");
+        let v: serde_json::Value = serde_json::from_str(&ctx).unwrap();
+        assert_eq!(v["action"]["kind"], "share");
+        assert_eq!(v["risk"], "high");
+        assert_eq!(
+            v["summary"],
+            "finance wants to share salaryBand with travel"
+        );
     }
 
     #[test]

--- a/vta-sdk/src/protocols/credentials_issuance.rs
+++ b/vta-sdk/src/protocols/credentials_issuance.rs
@@ -30,6 +30,12 @@ pub struct IssueCredentialBody {
     /// VC).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub purpose: Option<String>,
+    /// Optional structured authorization context surfaced to the operator's
+    /// step-up device (e.g. a Cierge share/spend/tool ask). Request-only: the
+    /// step-up gate reads it to render *what* is being authorized; it is never
+    /// signed into the issued VC.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub authorization_context: Option<Value>,
 }
 
 /// `spec/vta/credentials/issue/0.1` response body.

--- a/vta-service/src/trust_tasks/step_up.rs
+++ b/vta-service/src/trust_tasks/step_up.rs
@@ -479,6 +479,29 @@ const STEP_UP_TTL_SECS: u64 = 300;
 /// ([`issue_step_up_challenge`]) and the trust-task reject ([`require_step_up`]).
 /// Returns the approve-request document, or `Err(())` if the pending step-up
 /// could not be persisted (the caller maps that to a 5xx / internal-error reject).
+/// The default step-up reason when the gated request carries no structured
+/// authorization context (or one without a `summary`).
+const DEFAULT_STEP_UP_REASON: &str = "this operation requires a stepped-up (AAL2) session";
+
+/// Reverse-DNS `payload.ext` key (SPEC §4.5.1) under which the structured
+/// authorization context rides in the approve-request. The mobile engine reads
+/// the same key.
+const EXT_KEY_AUTHZ_CONTEXT: &str = "org.openvtc.authorization-context";
+
+/// Pick the reason string + optional structured authorization context from a
+/// gated request's payload. A request MAY carry a `payload.authorizationContext`
+/// (e.g. a Cierge share/spend/tool ask); when it does, its human `summary`
+/// becomes the reason so even a context-unaware renderer shows something
+/// meaningful. Pure — unit-tested.
+fn reason_and_context(payload: &Value) -> (&str, Option<&Value>) {
+    let ctx = payload.get("authorizationContext");
+    let reason = ctx
+        .and_then(|c| c.get("summary"))
+        .and_then(|s| s.as_str())
+        .unwrap_or(DEFAULT_STEP_UP_REASON);
+    (reason, ctx)
+}
+
 async fn mint_pending_step_up(
     sessions_ks: &KeyspaceHandle,
     vta_did: &str,
@@ -487,6 +510,13 @@ async fn mint_pending_step_up(
     approver_any: bool,
     session_id: &str,
     reason: &str,
+    // Optional structured context describing *what* is being authorized, shown
+    // to the approver's device verbatim (e.g. a Cierge cross-domain share /
+    // spend / tool ask). Embedded under the spec's `payload.ext` extension map
+    // (the payload is `deny_unknown_fields`, so a bespoke top-level field would
+    // break every typed consumer). `None` leaves the payload byte-identical to
+    // the reason-only form.
+    authorization_context: Option<&Value>,
 ) -> Result<Value, ()> {
     let acceptable = vec!["did-signed".to_string(), "webauthn".to_string()];
 
@@ -536,6 +566,13 @@ async fn mint_pending_step_up(
     if !approver_any && !recipient.is_empty() {
         doc["recipient"] = json!(recipient);
     }
+    // Carry the structured authorization context when the gated op supplied one,
+    // under a reverse-DNS-namespaced `ext` key (SPEC §4.5.1) so the payload stays
+    // spec-valid for `deny_unknown_fields` typed consumers (e.g. the mobile
+    // engine's `parse_step_up_request`).
+    if let Some(ctx) = authorization_context {
+        doc["payload"]["ext"] = json!({ EXT_KEY_AUTHZ_CONTEXT: ctx });
+    }
     Ok(doc)
 }
 
@@ -553,6 +590,7 @@ pub(crate) async fn issue_step_up_challenge(
     approver_any: bool,
     session_id: &str,
     reason: &str,
+    authorization_context: Option<&Value>,
 ) -> Response {
     let approve_request = match mint_pending_step_up(
         sessions_ks,
@@ -562,6 +600,7 @@ pub(crate) async fn issue_step_up_challenge(
         approver_any,
         session_id,
         reason,
+        authorization_context,
     )
     .await
     {
@@ -802,6 +841,13 @@ pub(super) async fn require_step_up(
         .vta_did
         .clone()
         .unwrap_or_default();
+    // A gated request MAY carry a structured authorization context (e.g. a
+    // Cierge cross-domain share / spend / tool ask) at
+    // `payload.authorizationContext`. Thread it into the approve-request so the
+    // approver's device renders *what* is being authorized, and prefer its human
+    // `summary` as the `reason` so a context-unaware renderer still shows
+    // something meaningful.
+    let (reason, authorization_context) = reason_and_context(&doc.payload);
     let reject = match mint_pending_step_up(
         &state.sessions_ks,
         &vta_did,
@@ -809,7 +855,8 @@ pub(super) async fn require_step_up(
         &recipient,
         approver_any,
         &auth.session_id,
-        "this operation requires a stepped-up (AAL2) session",
+        reason,
+        authorization_context,
     )
     .await
     {
@@ -939,6 +986,8 @@ impl<O: StepUpOp> FromRequestParts<AppState> for RequireStepUp<O> {
             approver_any,
             &claims.session_id,
             "this operation requires a stepped-up (AAL2) session",
+            // REST-gated routes carry no structured authorization context.
+            None,
         )
         .await)
     }
@@ -994,6 +1043,7 @@ mod tests {
             false,
             "sess-9",
             "rotate keys",
+            None,
         )
         .await;
         assert_eq!(resp.status(), StatusCode::FORBIDDEN);
@@ -1026,6 +1076,79 @@ mod tests {
         assert_eq!(
             pending.acceptable_evidence,
             vec!["did-signed".to_string(), "webauthn".to_string()]
+        );
+    }
+
+    #[test]
+    fn reason_and_context_prefers_summary_and_passes_context_through() {
+        // No context → generic reason, no context.
+        let no_ctx = json!({ "holder": "did:key:z" });
+        let (r, c) = reason_and_context(&no_ctx);
+        assert_eq!(r, DEFAULT_STEP_UP_REASON);
+        assert!(c.is_none());
+
+        // Context with a summary → the summary IS the reason; context passes through.
+        let payload = json!({
+            "authorizationContext": {
+                "summary": "finance wants to share salaryBand with travel",
+                "action": { "kind": "share", "from": "finance", "to": "travel" }
+            }
+        });
+        let (r, c) = reason_and_context(&payload);
+        assert_eq!(r, "finance wants to share salaryBand with travel");
+        assert_eq!(c.unwrap()["action"]["kind"], "share");
+
+        // Context without a summary → generic reason, but context still carried.
+        let summariless = json!({ "authorizationContext": { "action": {} } });
+        let (r, c) = reason_and_context(&summariless);
+        assert_eq!(r, DEFAULT_STEP_UP_REASON);
+        assert!(c.is_some());
+    }
+
+    #[tokio::test]
+    async fn step_up_challenge_embeds_authorization_context() {
+        use vti_common::config::StoreConfig;
+        use vti_common::store::Store;
+
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(&StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        })
+        .unwrap();
+        let ks = store.keyspace(crate::keyspaces::SESSIONS).unwrap();
+
+        let ctx = json!({
+            "type": "https://openvtc.org/cierge/authorization-context/0.1",
+            "summary": "finance wants to share salaryBand with travel",
+            "risk": "high",
+            "action": { "kind": "share", "from": "finance", "to": "travel", "ttlSeconds": 3600 },
+        });
+        let resp = issue_step_up_challenge(
+            &ks,
+            "did:web:vta.example",
+            "did:key:zHolder",
+            "did:key:zHolder",
+            false,
+            "sess-ctx",
+            "finance wants to share salaryBand with travel",
+            Some(&ctx),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+
+        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        let v: Value = serde_json::from_slice(&bytes).unwrap();
+        let payload = &v["approveRequest"]["payload"];
+        // The structured context rode into the approve-request under the
+        // reverse-DNS `ext` key (spec-valid for deny_unknown_fields consumers)…
+        let ctx = &payload["ext"]["org.openvtc.authorization-context"];
+        assert_eq!(ctx["action"]["kind"], "share");
+        assert_eq!(ctx["risk"], "high");
+        assert_eq!(ctx["action"]["ttlSeconds"], 3600);
+        // …and the reason echoes the human summary.
+        assert_eq!(
+            payload["reason"],
+            "finance wants to share salaryBand with travel"
         );
     }
     use trust_tasks_rs::Proof;


### PR DESCRIPTION
## What

Thread a **structured authorization context** through the step-up so an operator's device can render *what* it is authorizing — not just a flat `reason` string.

Motivation: the phone should be the approval surface for arbitrary AI-agent asks (a Cierge cross-domain share, an over-budget spend, a sensitive tool call), not only login-session elevation. Today's approve-request payload carries only `reason`, which is too thin to authorize meaningfully.

## Changes
- **`vta-service` `step_up.rs`** — `mint_pending_step_up` / `issue_step_up_challenge` / `require_step_up` gain an optional `authorization_context`. `require_step_up` extracts it from the gated request's payload (via the pure `reason_and_context` helper) and prefers its human `summary` as the `reason`. It rides in the approve-request under the reverse-DNS `ext` key **`org.openvtc.authorization-context`** (SPEC §4.5.1), so the payload stays spec-valid for `deny_unknown_fields` typed consumers. `None` ⇒ payload byte-identical to today.
- **`vta-sdk`** — `IssueCredentialBody` gains a request-only `authorization_context` (never signed into the VC) so a Cierge `credentials/issue` request can carry it through the step-up gate.
- **`vta-mobile-core` (0.6.9 → 0.6.10)** — `StepUpRequest` surfaces `authorization_context` (raw JSON), parsed from that `ext` key, for the native approval card. Absent ⇒ the UI falls back to `reason`.

## Why `ext`, not a top-level field
The approve-request `Payload` and `IssueCredentialBody` are both `deny_unknown_fields`. A bespoke top-level field would break every typed consumer (including the mobile engine's own `parse_step_up_request`). The spec's `ext` extension map (reverse-DNS keys) is the sanctioned place.

## Compatibility
Fully additive. Existing step-ups (no context) are byte-identical on the wire. The VTA still accepts everything it did before.

## Tests
- `reason_and_context` (pure): summary→reason selection + passthrough.
- approve-request embedding under the `ext` key via `issue_step_up_challenge`.
- engine `parse_authorization_context_from_ext` + `None` when absent.
- `vta-service` / `vta-sdk` / `vta-mobile-core` suites green; clippy + fmt clean.

## Follow-ups (not in this PR)
- Tag `vta-mobile-core-v0.6.10` → CI publishes the xcframework; bump the iOS pin + build the approval card that renders the context.
- Cierge: `issue_payload` includes `authorizationContext`; wire `PushStepUpApproval` (option A) to provoke the gated issue + poll for elevation.
- Version bumps for `vta-service` / `vta-sdk` left to the usual release commit.