### PR TITLE
fix: repair pre-existing red main (CI)

### DIFF
--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -1455,6 +1455,9 @@ mod tests {
             // Framework ACL protocol — the `acl/swap-key` self-service key
             // rotation task (`TASK_ACL_SWAP_KEY_1_0`), now dispatcher-routed.
             "https://trusttasks.org/spec/acl/",
+            // ToIP messaging protocol — the transport-agnostic `messaging/ping`
+            // liveness/capability probe (`TASK_MESSAGING_PING_0_1`).
+            "https://trusttasks.org/spec/messaging/",
         ];
         for uri in ALL_URIS {
             assert!(

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -89,7 +89,9 @@ pub(crate) mod wire_v0_2;
 /// TrustTaskOutcome`.
 pub(crate) use helpers::TrustTaskOutcome;
 use helpers::{body_parse_error_response, method_not_found, reject_with};
-#[cfg(feature = "didcomm")]
+// Used unconditionally by the replay-dedup reject + `reject_trust_task`, not just
+// the didcomm path — keep the import ungated (previously `#[cfg(feature =
+// "didcomm")]`, which broke `--features rest` without `didcomm`).
 use trust_tasks_rs::RejectReason;
 
 /// URIs that the VTA exposes through dedicated unauth REST routes


### PR DESCRIPTION
`main` CI has been red since **#618** on two **non-blocking** checks (which is why #619–#622 merged over them). Both are one-line fixes in code unrelated to those PRs' features.

## 1. Feature combos — `rest` without `didcomm`
`vta-service`'s `RejectReason` import was `#[cfg(feature = "didcomm")]`-gated, but #619's replay-dedup reject (`trust_tasks/mod.rs:329`) uses it **unconditionally**. So `cargo check -p vta-service --no-default-features --features keyring,rest` failed:
```
error[E0433]: cannot find type `RejectReason` in this scope
```
Fix: ungate the import (it's now used on the `rest` path too, and by `reject_trust_task`).

## 2. Test — `every_uri_in_canonical_namespace`
#618 added `TASK_MESSAGING_PING_0_1` (`spec/messaging/ping/0.1`) to `ALL_URIS` but didn't add `spec/messaging/` to the test's `ALLOWED_PREFIXES`, so the test asserted-out:
```
URI must live under one of [...]: https://trusttasks.org/spec/messaging/ping/0.1
```
Fix: add the `messaging/` prefix (a legit ToIP namespace; the const already documents `https://trusttasks.org/spec/messaging/ping/0.1`).

## Verification
- `cargo test -p vta-sdk every_uri_in_canonical_namespace` → passes.
- `cargo check -p vta-service --no-default-features --features keyring,rest` → builds.
- `cargo fmt --check` clean.

Fixes the `Test` and `Feature combos` jobs so `main` goes green again.