### PR TITLE
feat(vta-mobile-core): signed denial for step-up approve-response

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10054,7 +10054,7 @@ dependencies = [
 
 [[package]]
 name = "vta-mobile-core"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",

--- a/vta-mobile-core/Cargo.toml
+++ b/vta-mobile-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vta-mobile-core"
-version = "0.6.10"
+version = "0.6.11"
 description = "UniFFI engine for the VTA mobile agent (Android/iOS): DIDComm, Trust Tasks, AAL step-up."
 edition.workspace = true
 # Not a crates.io library — the published artifacts are the Android AAR

--- a/vta-mobile-core/src/stepup.rs
+++ b/vta-mobile-core/src/stepup.rs
@@ -75,7 +75,12 @@ pub fn build_approve_response_webauthn(
         authenticator_attachment: None,
         client_extension_results: serde_json::Map::new(),
     });
-    let doc = assemble_doc(&draft, evidence)?;
+    let doc = assemble_doc(
+        &draft,
+        evidence,
+        approve_response::PayloadDecision::Approved,
+        None,
+    )?;
     serialize(&doc)
 }
 
@@ -89,15 +94,44 @@ pub fn build_approve_response_did_signed(
     draft: ApproveResponseDraft,
     signer: Box<dyn Signer>,
 ) -> Result<String, FfiError> {
-    let mut doc = assemble_doc(&draft, approve_response::Evidence::DidSigned)?;
+    let mut doc = assemble_doc(
+        &draft,
+        approve_response::Evidence::DidSigned,
+        approve_response::PayloadDecision::Approved,
+        None,
+    )?;
     attach_did_signed_proof(&mut doc, &*signer, &draft.issued_at)?;
     serialize(&doc)
 }
 
-/// Build the approve-response envelope + payload (no proof) for a given gate.
+/// Build a DID-signed **denial** `auth/step-up/approve-response/0.2`: decision
+/// `denied`, carrying the human `reason`, gated by the same `eddsa-jcs-2022`
+/// proof as an approval. A denial is a *signed refusal* — the VTA verifies the
+/// gate (so an injection can't forge it), audits `step_up_denied`, and elevates
+/// nothing. This is how the operator says "no" from the device.
+#[uniffi::export]
+pub fn build_approve_response_denied(
+    draft: ApproveResponseDraft,
+    reason: String,
+    signer: Box<dyn Signer>,
+) -> Result<String, FfiError> {
+    let mut doc = assemble_doc(
+        &draft,
+        approve_response::Evidence::DidSigned,
+        approve_response::PayloadDecision::Denied,
+        Some(reason),
+    )?;
+    attach_did_signed_proof(&mut doc, &*signer, &draft.issued_at)?;
+    serialize(&doc)
+}
+
+/// Build the approve-response envelope + payload (no proof) for a given gate +
+/// decision.
 fn assemble_doc(
     draft: &ApproveResponseDraft,
     evidence: approve_response::Evidence,
+    decision: approve_response::PayloadDecision,
+    denied_reason: Option<String>,
 ) -> Result<TrustTask<approve_response::Payload>, FfiError> {
     let issued_at = DateTime::parse_from_rfc3339(&draft.issued_at)
         .map_err(|e| FfiError::InvalidInput {
@@ -111,8 +145,8 @@ fn assemble_doc(
             .map_err(conv)?,
         challenge: approve_response::PayloadChallenge::try_from(draft.challenge.clone())
             .map_err(conv)?,
-        decision: approve_response::PayloadDecision::Approved,
-        denied_reason: None,
+        decision,
+        denied_reason,
         granted_acr: draft.granted_acr.clone(),
         evidence: Some(evidence),
         ext: None,
@@ -291,5 +325,67 @@ mod tests {
             affinidi_data_integrity::VerifyOptions::default(),
         )
         .expect("the did-signed proof must verify against the holder's key");
+    }
+
+    /// A denial is a *signed* refusal: decision `denied`, the human reason, a
+    /// didSigned gate, and a verifiable proof (so an injection can't forge it).
+    #[test]
+    fn denied_response_is_signed_and_carries_the_reason() {
+        use affinidi_data_integrity::DataIntegrityProof;
+        use ed25519_dalek::{Signer as _, SigningKey};
+        use multibase::Base;
+
+        let sk = SigningKey::from_bytes(&[9u8; 32]);
+        let pk = sk.verifying_key();
+        let mut mc = vec![0xed, 0x01];
+        mc.extend_from_slice(pk.as_bytes());
+        let mb = multibase::encode(Base::Base58Btc, mc);
+        let did = format!("did:key:{mb}");
+
+        struct EnclaveStub {
+            sk: SigningKey,
+            did: String,
+        }
+        impl Signer for EnclaveStub {
+            fn did(&self) -> String {
+                self.did.clone()
+            }
+            fn sign(&self, payload: Vec<u8>) -> Result<Vec<u8>, FfiError> {
+                Ok(self.sk.sign(&payload).to_bytes().to_vec())
+            }
+        }
+
+        let json = build_approve_response_denied(
+            draft(),
+            "not something I authorized".to_string(),
+            Box::new(EnclaveStub {
+                sk,
+                did: did.clone(),
+            }),
+        )
+        .unwrap();
+
+        let raw: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            raw["type"],
+            "https://trusttasks.org/spec/auth/step-up/approve-response/0.2"
+        );
+        assert_eq!(raw["payload"]["decision"], "denied");
+        assert_eq!(raw["payload"]["deniedReason"], "not something I authorized");
+        assert_eq!(raw["payload"]["evidence"]["kind"], "didSigned");
+
+        // The refusal is cryptographically signed, verifiable against the key.
+        let doc: TrustTask<approve_response::Payload> = serde_json::from_str(&json).unwrap();
+        let proof = doc.proof.clone().expect("a denial must be signed");
+        let di: DataIntegrityProof =
+            serde_json::from_value(serde_json::to_value(&proof).unwrap()).unwrap();
+        let mut unsigned = doc;
+        unsigned.proof = None;
+        di.verify_with_public_key(
+            &unsigned,
+            pk.as_bytes(),
+            affinidi_data_integrity::VerifyOptions::default(),
+        )
+        .expect("the denial's proof must verify against the holder's key");
     }
 }


### PR DESCRIPTION
Add `build_approve_response_denied` so the mobile operator can **say no** from the device — a DID-signed `decision: denied` approve-response carrying the human reason.

## Why
The engine only ever emitted `decision: approved`, so the app could only ratify — there was no deny path. The VTA already handles a denial (`handle_approve_response` verifies the did-signed gate against the approver key, audits `step_up_denied`, and elevates nothing, returning `{status:"rejected", reason}`). This closes the missing half: "the injection can ask; only the human can sign — **or refuse**."

## Change
- `assemble_doc` now takes `decision` + `denied_reason`; the approved builders (`did_signed`, `webauthn`) are unchanged in behaviour.
- New `build_approve_response_denied(draft, reason, signer)` — didSigned gate (a denial is a *signed* refusal, so an injection can't forge it), decision `denied`, `deniedReason` = the human reason.
- Bumps `0.6.10` → `0.6.11`.

## Test
`denied_response_is_signed_and_carries_the_reason` — asserts `/0.2` URI, `decision:denied`, `deniedReason`, `didSigned` evidence, and that the proof verifies against the holder key. Full `vta-mobile-core` suite green, clippy + fmt clean.

## Follow-up
The iOS review-before-approve gate + actionable notification that use this (Tier 1 UX) — separate PR on `vta-mobile-agent-ios`, pinning v0.6.11.