### PR TITLE
feat(vtc-service): headless two-phase setup + explicit secrets backend

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -287,6 +287,35 @@ new flow, update both this section and the relevant `docs/*.md`.
   backend (OS keyring by default; AWS/GCP/Azure via feature flags).
 - **Docs**: `docs/02-vta/cold-start.md`, `docs/02-vta/non-interactive-setup.md`.
 
+### VTC first-boot setup (VTA-provisioned)
+- **What**: Stands up a VTC by provisioning its DID + keys from a running
+  VTA via the `vtc-host` DID template, then writing `config.toml`, the
+  `did.jsonl`, the sealed key bundle, and a one-shot admin install URL.
+  The VTC is **not** the key authority — the VTA mints; the VTC caches.
+- **Entry point**: `vtc setup` (interactive) or, for headless bring-up, a
+  **two-phase** flow mirroring mediator / did-hosting:
+  1. `vtc setup --setup-key-out <path> [--context <id>]` — mint + persist
+     an ephemeral `did:key` (0600) and print the `pnm contexts create …
+     --admin-did` grant command. Reuses the shared SDK helper
+     `vta_sdk::provision_client::driver::run_phase1_init`.
+  2. *(out of band)* an operator / CI step holding VTA admin runs that
+     grant — VTC deliberately never holds a VTA admin credential (no
+     self-grant), same as mediator / did-hosting.
+  3. `vtc setup --from <toml>` — load the now-authorised key
+     (`setup_key_file`) and provision end-to-end (no TTY).
+- **Secrets**: `[secrets] backend = "vault"|"k8s"|"aws"|"gcp"|"azure"|`
+  `"keyring"|"config"|"plaintext"` selects the store explicitly (validated,
+  fail-closed); omit for legacy implicit resolution. All backends except
+  TEE-KMS (a permanent VTC non-goal) are supported. Factory:
+  `vtc-service/src/keys/seed_store/mod.rs::create_secret_store`.
+- **Code**: `vtc-service/src/setup/{wizard,from_toml,phase1}.rs` (both
+  front-ends build one `WizardPlan` → shared `apply`),
+  `vtc-service/src/main.rs` (`setup` subcommand),
+  `vtc-service/src/config.rs` (`SecretBackend`).
+- **Docs**: `docs/03-vtc/non-interactive-setup.md`,
+  `docs/03-vtc/getting-started.md`,
+  `docs/03-vtc/examples/vtc-setup.example.toml`.
+
 ### Admin credential cold-start
 - **What**: Bootstrap the first operator without a running VTA.
 - **Flow**: PNM mints ephemeral `did:key` locally → operator runs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10267,7 +10267,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-service"
-version = "0.10.13"
+version = "0.11.0"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/docs/03-vtc/examples/vtc-setup.example.toml
+++ b/docs/03-vtc/examples/vtc-setup.example.toml
@@ -4,20 +4,27 @@
 # unattended bring-up. Mirrors the decisions the interactive `vtc setup`
 # wizard collects via prompts. See docs/03-vtc/getting-started.md.
 #
-# IMPORTANT — the ephemeral setup key is a TWO-PHASE bridge.
-# Provisioning authenticates to the VTA with an ephemeral did:key whose
-# DID must already be ACL-authorised at the VTA. A non-interactive run
-# can't pause to grant it, so do this first, out of band:
+# IMPORTANT — the ephemeral setup key is a TWO-PHASE bridge (the same
+# shape the mediator and did-hosting services use). Provisioning
+# authenticates to the VTA with an ephemeral did:key whose DID must
+# already be ACL-authorised at the VTA. A non-interactive run can't pause
+# to grant it, so do this first, out of band:
 #
-#   1. Generate + persist an ephemeral setup key (the same JSON `pnm`
-#      writes via EphemeralSetupKey::persist_to), e.g. under
-#      ~/.config/vtc/setup-key.json (0600).
-#   2. Grant its did:key an admin ACL at the VTA:
+#   1. Mint + persist an ephemeral setup key (phase 1):
+#        vtc setup --setup-key-out /srv/vtc/setup-key.json --context <context>
+#      This writes the key (0600) and prints the exact `pnm contexts
+#      create … --admin-did <setup-did>` command to run next.
+#   2. Grant that did:key an admin ACL at the VTA (run the printed command
+#      on a host with PNM authenticated to the VTA):
 #        pnm contexts create --id <context> --name "VTC" \
 #          --admin-did <setup-did> --admin-expires 1h
 #      (or `pnm acl create ...` if the context already exists).
-#   3. Run: vtc setup --from vtc-setup.toml
+#   3. Provision (phase 2):
+#        vtc setup --from vtc-setup.toml
 #      with `setup_key_file` below pointing at that persisted key.
+#
+# See docs/03-vtc/non-interactive-setup.md for the full walkthrough
+# (incl. a Kubernetes example).
 
 # ── Required ────────────────────────────────────────────────────────────
 config_path    = "/srv/vtc/config.toml"
@@ -50,27 +57,57 @@ context = "default"   # the VTA context this community provisions under
 # in config.toml. The choice is security-sensitive — there is no implicit
 # default. Pick exactly one backend; the others are shown commented.
 [secrets]
-# OS keyring (default backend). Change `keyring_service` to run multiple
-# VTC instances on one machine.
+# `backend` selects the store explicitly (recommended for declarative /
+# K8s deploys). When set it wins outright and setup validates that its
+# required field(s) below are present. Accepts:
+#   keyring | vault | k8s | aws | gcp | azure | config | plaintext
+# Omit `backend` to keep the legacy "whichever field is set wins"
+# resolution. TEE-KMS is intentionally not a VTC backend.
+backend = "keyring"
+
+# OS keyring (backend = "keyring", the default). Change `keyring_service`
+# to run multiple VTC instances on one machine.
 keyring_service = "vtc"
 
-# AWS Secrets Manager (aws-secrets feature)
-# aws_secret_name = "vtc/prod/key-bundle"
-# aws_region      = "us-east-1"
+# HashiCorp Vault (backend = "vault", vault-secrets feature). In K8s,
+# `vault_auth_method = "kubernetes"` (the default) uses the pod's
+# ServiceAccount token — no static secret to mount.
+# backend            = "vault"
+# vault_addr         = "https://vault.internal:8200"
+# vault_secret_path  = "vtc/key-bundle"     # path under the KV v2 mount
+# vault_kv_mount     = "secret"             # default
+# vault_secret_key   = "seed"               # field in the KV secret (default)
+# vault_auth_method  = "kubernetes"         # kubernetes | token | approle
+# vault_k8s_role     = "vtc"                # Vault role bound to the SA
+# vault_namespace    = "team-a"             # Vault Enterprise, optional
 
-# GCP Secret Manager (gcp-secrets feature)
-# gcp_project     = "my-project"
-# gcp_secret_name = "vtc-prod-key-bundle"
-
-# Azure Key Vault (azure-secrets feature)
-# azure_vault_url   = "https://my-vault.vault.azure.net"
-# azure_secret_name = "vtc-prod-key-bundle"
-
-# Kubernetes Secret (k8s-secrets feature)
+# Kubernetes Secret (backend = "k8s", k8s-secrets feature). Reads the hex
+# bundle straight from a mounted/API Secret; namespace defaults to the
+# in-cluster ServiceAccount namespace when unset.
+# backend         = "k8s"
 # k8s_secret_name = "vtc-key-bundle"
 # k8s_namespace   = "vtc"
 # k8s_secret_key  = "secret"
 
-# Inline config-secret (dev/test): the hex key bundle is written into
-# this file's [secrets] secret by setup. Read-only at runtime.
-# secret = ""
+# AWS Secrets Manager (backend = "aws", aws-secrets feature)
+# backend         = "aws"
+# aws_secret_name = "vtc/prod/key-bundle"
+# aws_region      = "us-east-1"
+
+# GCP Secret Manager (backend = "gcp", gcp-secrets feature)
+# backend         = "gcp"
+# gcp_project     = "my-project"
+# gcp_secret_name = "vtc-prod-key-bundle"
+
+# Azure Key Vault (backend = "azure", azure-secrets feature)
+# backend           = "azure"
+# azure_vault_url   = "https://my-vault.vault.azure.net"
+# azure_secret_name = "vtc-prod-key-bundle"
+
+# Inline config-secret (backend = "config", dev/test): setup writes the
+# hex key bundle into this file's [secrets] secret. Read-only at runtime.
+# backend = "config"
+
+# Plaintext file (backend = "plaintext", NOT secure — dev/test only): the
+# bundle is written to <data_dir>/secret.plaintext.
+# backend = "plaintext"

--- a/docs/03-vtc/getting-started.md
+++ b/docs/03-vtc/getting-started.md
@@ -158,12 +158,15 @@ for the schema.
 There's one wrinkle: provisioning authenticates to the VTA with an
 ephemeral `did:key` that must be ACL-authorised *before* setup runs, and
 a non-interactive run can't pause to grant it (the interactive wizard's
-"press Enter once authorised" step). So it's a **two-phase** flow:
+"press Enter once authorised" step). So it's a **two-phase** flow — the
+same shape the mediator and did-hosting services use:
 
-1. Generate + persist an ephemeral setup key (the same JSON `pnm` writes)
-   and grant its `did:key` an admin ACL at the VTA:
+1. Mint + persist an ephemeral setup key (phase 1), then grant its
+   `did:key` an admin ACL at the VTA:
 
    ```sh
+   vtc setup --setup-key-out /srv/vtc/setup-key.json --context mycommunity
+   # prints the exact command to run next:
    pnm contexts create --id mycommunity --name "VTC" \
        --admin-did "did:key:z6Mk..." --admin-expires 1h
    # (or `pnm acl create ...` if the context already exists)
@@ -176,6 +179,10 @@ a non-interactive run can't pause to grant it (the interactive wizard's
    terse `key=value` block (including the install URL + claim code).
    The admin private key is **never** printed in non-interactive mode —
    re-run interactively if you need it.
+
+For the full walkthrough — including the secret-store `backend` selector
+and a Kubernetes example — see
+[`non-interactive-setup.md`](non-interactive-setup.md).
 
 ## Step 2 — Start the daemon
 

--- a/docs/03-vtc/non-interactive-setup.md
+++ b/docs/03-vtc/non-interactive-setup.md
@@ -1,0 +1,143 @@
+# Non-interactive VTC setup
+
+`vtc setup` provisions a VTC against an already-running VTA. For CI, an
+immutable image, or a Kubernetes deployment there's no TTY to answer
+prompts, so setup runs **headless in two phases** — the same shape the
+mediator (`mediator-setup --setup-key-out`) and did-hosting
+(`did-hosting-daemon setup --setup-key-out`) services use.
+
+For the guided walkthrough, see [`getting-started.md`](getting-started.md).
+Both paths produce identical on-disk state.
+
+## Why two phases
+
+A VTC is not its own key authority — the VTA mints its DID and keys (via
+the `vtc-host` DID template). To ask the VTA to do that, the VTC first
+authenticates with an **ephemeral `did:key`**, and that DID must already
+be **ACL-authorised at the VTA**. The interactive wizard generates the key
+and pauses for you to grant it. A headless run can't pause, so the grant
+happens out of band, between two commands:
+
+| Phase | Command | What it does |
+|---|---|---|
+| 1 | `vtc setup --setup-key-out <path> [--context <id>]` | Mints an ephemeral `did:key`, persists it to `<path>` (0600), and prints the exact `pnm contexts create … --admin-did` command. Touches nothing else. |
+| — | *(operator / CI step holding VTA admin)* | Runs that `pnm` command to enrol the setup DID at the VTA. |
+| 2 | `vtc setup --from <toml>` | Loads the now-authorised key (via `setup_key_file`) and provisions end-to-end: the VTA mints the VTC DID + keys, swaps in the long-term admin DID, and setup writes `config.toml`, the `did.jsonl`, the key bundle, and a one-shot install URL. |
+
+> **Note.** The between-phases grant needs VTA admin. This flow is
+> deliberately *not* a self-grant — the VTC never holds a VTA admin
+> credential, matching the mediator and did-hosting services. Whatever
+> automation runs step 1½ (a human, a CI job, a K8s init step) is what
+> holds VTA admin.
+
+## Phase 1 — mint the setup key
+
+```bash
+vtc setup --setup-key-out /srv/vtc/setup-key.json --context default
+```
+
+`--context` only shapes the printed grant command; it must match
+`context` in the phase-2 TOML (default `default`). Output (to stderr):
+
+```
+  Setup DID (ephemeral):
+    did:key:z6Mk…
+
+  Key stored at /srv/vtc/setup-key.json (0600)
+
+  Using your Personal Network Manager (PNM) connected to this VTA,
+  create the vtc context and grant admin access to the setup DID:
+
+    pnm contexts create --id default --name "VTC" \
+      --admin-did did:key:z6Mk… --admin-expires 1h
+
+  Then finalise with:
+    vtc setup --from <your-setup.toml>   (with setup_key_file = "/srv/vtc/setup-key.json")
+```
+
+## Phase 1½ — grant at the VTA
+
+Run the printed command on a host with `pnm` authenticated to the VTA (or
+`pnm acl create --did <setup-did> --role admin --contexts <ctx> --expires 1h`
+if the context already exists). The `--admin-expires 1h` grant is promoted
+to permanent on the setup DID's first authenticated call, which phase 2
+performs.
+
+## Phase 2 — provision
+
+Point `setup_key_file` at the phase-1 output and run:
+
+```bash
+vtc setup --from /srv/vtc/vtc-setup.toml
+```
+
+The full TOML schema is
+[`examples/vtc-setup.example.toml`](examples/vtc-setup.example.toml). A
+minimal Vault-backed file:
+
+```toml
+config_path    = "/srv/vtc/config.toml"
+base_url       = "https://vtc.example.com"
+vta_did        = "did:webvh:vta.example.com:abc"
+context        = "default"
+setup_key_file = "/srv/vtc/setup-key.json"
+
+[secrets]
+backend           = "vault"
+vault_addr        = "https://vault.internal:8200"
+vault_secret_path = "vtc/key-bundle"
+vault_auth_method = "kubernetes"   # pod ServiceAccount token — nothing to mount
+vault_k8s_role    = "vtc"
+```
+
+Phase 2 prints a terse, scrape-friendly block (`vtc_did=…`, `admin_did=…`,
+`install_url=…`, `claim_code=…`); it never prints the admin private key.
+
+## Choosing a secret-store backend
+
+Set `[secrets] backend` to select the store **explicitly** — recommended
+for declarative deploys. When set it wins outright and setup validates that
+the backend's required fields are present (rather than silently picking a
+different backend whose field happens to also be set). Omit it to keep the
+legacy "whichever field is set wins" resolution.
+
+| `backend` | Feature | Required field(s) | Notes |
+|---|---|---|---|
+| `keyring` | `keyring` (default) | — | `keyring_service` to run several VTCs on one host. |
+| `vault` | `vault-secrets` | `vault_addr` | KV v2; k8s / token / approle auth. |
+| `k8s` | `k8s-secrets` | `k8s_secret_name` | Reads a Kubernetes `Secret`. |
+| `aws` | `aws-secrets` | `aws_secret_name` | |
+| `gcp` | `gcp-secrets` | `gcp_secret_name` (+ `gcp_project`) | |
+| `azure` | `azure-secrets` | `azure_vault_url` | |
+| `config` | `config-secret` | `secret` (written by setup) | Hex bundle inline in config.toml; read-only at runtime. |
+| `plaintext` | always | — | NOT secure; dev/test only. |
+
+A backend selected on a binary built without its feature is a hard config
+error — never a silent fall-through to keyring/plaintext. (TEE-KMS is
+intentionally not a VTC backend; only the VTA runs in a TEE.)
+
+`[secrets]` is flat here (e.g. `vault_addr`, `k8s_secret_name`), matching
+the runtime `config.toml` — the same table setup writes and the daemon
+reads back at boot.
+
+## Kubernetes
+
+The two phases map cleanly onto a cluster bring-up:
+
+1. **Phase 1** in a short Job (or locally) mints the key and surfaces the
+   setup DID. A step holding VTA admin runs the printed `pnm` grant. In a
+   GitOps flow this is a one-time bootstrap task.
+2. **Phase 2** runs as an init container (or a Job) before the VTC
+   Deployment. Mount the phase-1 key file and the setup TOML, then run
+   `vtc setup --from …`.
+
+For the store itself, the two K8s-native choices are:
+
+- **`backend = "vault"` with `vault_auth_method = "kubernetes"`** — the VTC
+  pod authenticates to Vault with its ServiceAccount token; no static
+  secret to mount.
+- **`backend = "k8s"`** — the VTC reads its key bundle directly from a
+  Kubernetes `Secret` (`k8s_secret_name` in `k8s_namespace`).
+
+Once phase 2 has run, the VTC Deployment starts normally with the written
+`config.toml`; `create_secret_store` honours the same `backend` at boot.

--- a/vtc-service/CLAUDE.md
+++ b/vtc-service/CLAUDE.md
@@ -53,8 +53,11 @@ src/
 ├── routes/             Every HTTP route handler, sub-mounted by feature
 ├── routing/            Security headers, CSRF, body cap, governor middleware
 ├── setup/              `vtc setup` wizard: `wizard.rs` (interactive) +
-│                       `from_toml.rs` (`setup --from <toml>`). Both build one
-│                       `WizardPlan` and share the `apply` effect driver.
+│                       `from_toml.rs` (`setup --from <toml>`, phase 2) +
+│                       `phase1.rs` (`setup --setup-key-out`, mint the
+│                       ephemeral key for headless two-phase bring-up).
+│                       wizard + from_toml build one `WizardPlan` and share
+│                       the `apply` effect driver.
 ├── status_list/        Bitstring status list allocator + storage + serve route
 ├── store/              Re-export of vti-common's keyspace abstractions
 └── website/            Public website handler, bundle + deploy, default site

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.10.13"
+version = "0.11.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vtc-service/src/config.rs
+++ b/vtc-service/src/config.rs
@@ -429,9 +429,51 @@ pub struct ServerConfig {
 // (P0.8). Safe here — `SecretsConfig` carries no serde aliases; the
 // alias-bearing fields live on the parent `AppConfig`, which is intentionally
 // left lenient until the alias audit in the plan.
+/// Explicit secret-store backend selector.
+///
+/// When set on [`SecretsConfig::backend`], it wins outright over the
+/// legacy "whichever selector field is set" implicit resolution — so a
+/// declarative deploy (K8s, an immutable image) states its backend once
+/// and unambiguously, and `create_secret_store` validates that the
+/// backend's required fields are present rather than silently picking a
+/// different backend whose field happens to also be set. When unset
+/// (`None`), resolution is unchanged (implicit priority chain).
+///
+/// Variant → required field: `vault` → `vault_addr`, `k8s` →
+/// `k8s_secret_name`, `aws` → `aws_secret_name`, `gcp` → `gcp_secret_name`
+/// (+ `gcp_project`), `azure` → `azure_vault_url`, `config` → `secret`.
+/// `keyring` and `plaintext` need no field.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SecretBackend {
+    /// OS keyring (the default when nothing is selected).
+    Keyring,
+    /// HashiCorp Vault (KV v2).
+    Vault,
+    /// Kubernetes `Secret`.
+    K8s,
+    /// AWS Secrets Manager.
+    Aws,
+    /// GCP Secret Manager.
+    Gcp,
+    /// Azure Key Vault.
+    Azure,
+    /// Hex secret inlined in `[secrets] secret` in config.toml (read-only).
+    Config,
+    /// Plaintext file under the data dir — NOT secure, dev/test only.
+    Plaintext,
+}
+
 #[derive(Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SecretsConfig {
+    /// Explicit backend selector. When set, it overrides the implicit
+    /// "whichever selector field is set" resolution and `create_secret_store`
+    /// validates the chosen backend's required fields. Omit to keep the
+    /// legacy priority-chain behaviour. Accepts `keyring` | `vault` | `k8s`
+    /// | `aws` | `gcp` | `azure` | `config` | `plaintext`.
+    #[serde(default)]
+    pub backend: Option<SecretBackend>,
     /// Hex-encoded VTC key material (config-secret feature)
     pub secret: Option<String>,
     /// AWS Secrets Manager secret name (aws-secrets feature)
@@ -548,6 +590,7 @@ fn default_vault_approle_mount() -> String {
 impl std::fmt::Debug for SecretsConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SecretsConfig")
+            .field("backend", &self.backend)
             .field("secret", &self.secret.as_ref().map(|_| "<redacted>"))
             .field("aws_secret_name", &self.aws_secret_name)
             .field("aws_region", &self.aws_region)
@@ -587,6 +630,7 @@ impl std::fmt::Debug for SecretsConfig {
 impl Default for SecretsConfig {
     fn default() -> Self {
         Self {
+            backend: None,
             secret: None,
             aws_secret_name: None,
             aws_region: None,
@@ -992,6 +1036,41 @@ impl AppConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn secret_backend_selector_parses_each_variant() {
+        // Every accepted spelling maps to its variant (kebab-case wire form).
+        for (wire, expected) in [
+            ("keyring", SecretBackend::Keyring),
+            ("vault", SecretBackend::Vault),
+            ("k8s", SecretBackend::K8s),
+            ("aws", SecretBackend::Aws),
+            ("gcp", SecretBackend::Gcp),
+            ("azure", SecretBackend::Azure),
+            ("config", SecretBackend::Config),
+            ("plaintext", SecretBackend::Plaintext),
+        ] {
+            let cfg: SecretsConfig =
+                toml::from_str(&format!("backend = \"{wire}\"")).expect("parse backend");
+            assert_eq!(cfg.backend, Some(expected), "wire form {wire:?}");
+        }
+    }
+
+    #[test]
+    fn secret_backend_omitted_is_none() {
+        // Back-compat: an existing `[secrets]` with no `backend` key parses
+        // to None (implicit resolution preserved).
+        let cfg: SecretsConfig = toml::from_str("keyring_service = \"vtc\"").expect("parse");
+        assert_eq!(cfg.backend, None);
+    }
+
+    #[test]
+    fn secret_backend_unknown_is_rejected() {
+        assert!(
+            toml::from_str::<SecretsConfig>("backend = \"hashicorp\"").is_err(),
+            "unknown backend spelling must be a parse error"
+        );
+    }
 
     #[test]
     fn secrets_config_debug_redacts_secret() {

--- a/vtc-service/src/keys/seed_store/mod.rs
+++ b/vtc-service/src/keys/seed_store/mod.rs
@@ -50,7 +50,12 @@ const VTC_PLAINTEXT_FILENAME: &str = "secret.plaintext";
 
 /// Create a secret store backend based on compiled features and configuration.
 ///
-/// Priority:
+/// **Selection.** If `secrets.backend` is set it wins outright — the named
+/// backend is used and its required field(s) are validated (a mismatch is a
+/// hard `Config` error, never a silent pick of a different backend). If it is
+/// unset (`None`), resolution falls back to the legacy implicit priority chain
+/// below, keyed on which selector field is set:
+///
 /// 1. AWS Secrets Manager (if `aws-secrets` compiled + `secrets.aws_secret_name` set)
 /// 2. GCP Secret Manager (if `gcp-secrets` compiled + `secrets.gcp_secret_name` set)
 /// 3. Azure Key Vault (if `azure-secrets` compiled + `secrets.azure_vault_url` set)
@@ -59,53 +64,72 @@ const VTC_PLAINTEXT_FILENAME: &str = "secret.plaintext";
 /// 6. Config file secret (if `config-secret` compiled + `secrets.secret` set)
 /// 7. OS keyring (if `keyring` compiled — the default)
 /// 8. Plaintext file (always available — NOT secure)
+///
+/// Either way, a backend requested on a binary built without its feature is a
+/// hard `Config` error — never a silent fall-through to keyring/plaintext
+/// (P0.8): pre-P0.8 the arm was `#[cfg]`'d away, so a prod config pointing at
+/// AWS on a keyring-only binary booted with an empty store and a mere `warn!`.
 #[allow(unused_variables)]
 pub fn create_secret_store(config: &AppConfig) -> Result<Box<dyn SecretStore>, AppError> {
-    // For every cloud/config backend, a set selector field on a binary that
-    // wasn't compiled with the matching feature is a hard error — never a
-    // silent fall-through to the keyring/plaintext default. Pre-P0.8 the arm
-    // was simply `#[cfg]`'d away, so a production config pointing at AWS on a
-    // keyring-only binary booted with an empty store and a mere `warn!`
-    // (every auth/issue/install call then 503s). Fail closed instead.
+    use crate::config::SecretBackend;
+    let explicit = config.secrets.backend;
+
+    // Is backend `b` the one to build? An explicit selector wins outright;
+    // otherwise fall back to "its selector field is set" implicit resolution.
+    // Used only for the cloud/config backends (keyring/plaintext are the tail
+    // fallbacks, handled separately below).
+    let wants = |b: SecretBackend, field_set: bool| match explicit {
+        Some(sel) => sel == b,
+        None => field_set,
+    };
+
     #[cfg(feature = "aws-secrets")]
-    if config.secrets.aws_secret_name.is_some() {
-        let store = AwsSecretStore::new(
-            config.secrets.aws_secret_name.clone().unwrap(),
-            config.secrets.aws_region.clone(),
-        );
+    if wants(SecretBackend::Aws, config.secrets.aws_secret_name.is_some()) {
+        let name = config.secrets.aws_secret_name.clone().ok_or_else(|| {
+            AppError::Config("secrets.backend = aws requires secrets.aws_secret_name".into())
+        })?;
+        let store = AwsSecretStore::new(name, config.secrets.aws_region.clone());
         return Ok(Box::new(store));
     }
     #[cfg(not(feature = "aws-secrets"))]
-    if config.secrets.aws_secret_name.is_some() {
+    if wants(SecretBackend::Aws, config.secrets.aws_secret_name.is_some()) {
         return Err(AppError::Config(
-            "secrets.aws_secret_name is set but this binary was built without the \
+            "secrets backend 'aws' selected but this binary was built without the \
              'aws-secrets' feature"
                 .into(),
         ));
     }
 
     #[cfg(feature = "gcp-secrets")]
-    if config.secrets.gcp_secret_name.is_some() {
+    if wants(SecretBackend::Gcp, config.secrets.gcp_secret_name.is_some()) {
+        let name = config.secrets.gcp_secret_name.clone().ok_or_else(|| {
+            AppError::Config("secrets.backend = gcp requires secrets.gcp_secret_name".into())
+        })?;
         let project = config.secrets.gcp_project.clone().ok_or_else(|| {
             AppError::Config(
                 "secrets.gcp_project is required when secrets.gcp_secret_name is set".into(),
             )
         })?;
-        let store = GcpSecretStore::new(project, config.secrets.gcp_secret_name.clone().unwrap());
+        let store = GcpSecretStore::new(project, name);
         return Ok(Box::new(store));
     }
     #[cfg(not(feature = "gcp-secrets"))]
-    if config.secrets.gcp_secret_name.is_some() {
+    if wants(SecretBackend::Gcp, config.secrets.gcp_secret_name.is_some()) {
         return Err(AppError::Config(
-            "secrets.gcp_secret_name is set but this binary was built without the \
+            "secrets backend 'gcp' selected but this binary was built without the \
              'gcp-secrets' feature"
                 .into(),
         ));
     }
 
     #[cfg(feature = "azure-secrets")]
-    if config.secrets.azure_vault_url.is_some() {
-        let vault_url = config.secrets.azure_vault_url.clone().unwrap();
+    if wants(
+        SecretBackend::Azure,
+        config.secrets.azure_vault_url.is_some(),
+    ) {
+        let vault_url = config.secrets.azure_vault_url.clone().ok_or_else(|| {
+            AppError::Config("secrets.backend = azure requires secrets.azure_vault_url".into())
+        })?;
         let secret_name = config
             .secrets
             .azure_secret_name
@@ -115,9 +139,12 @@ pub fn create_secret_store(config: &AppConfig) -> Result<Box<dyn SecretStore>, A
         return Ok(Box::new(store));
     }
     #[cfg(not(feature = "azure-secrets"))]
-    if config.secrets.azure_vault_url.is_some() {
+    if wants(
+        SecretBackend::Azure,
+        config.secrets.azure_vault_url.is_some(),
+    ) {
         return Err(AppError::Config(
-            "secrets.azure_vault_url is set but this binary was built without the \
+            "secrets backend 'azure' selected but this binary was built without the \
              'azure-secrets' feature"
                 .into(),
         ));
@@ -127,8 +154,13 @@ pub fn create_secret_store(config: &AppConfig) -> Result<Box<dyn SecretStore>, A
     // VTC's `vault_*` config fields mirror the VTA's, so the auth-method
     // parsing is not duplicated here.
     #[cfg(feature = "vault-secrets")]
-    if config.secrets.vault_addr.is_some() {
+    if wants(SecretBackend::Vault, config.secrets.vault_addr.is_some()) {
         let s = &config.secrets;
+        if s.vault_addr.is_none() {
+            return Err(AppError::Config(
+                "secrets.backend = vault requires secrets.vault_addr".into(),
+            ));
+        }
         let store =
             vti_secrets::seed_store::vault_from_params(&vti_secrets::seed_store::VaultParams {
                 addr: s.vault_addr.as_deref(),
@@ -149,57 +181,79 @@ pub fn create_secret_store(config: &AppConfig) -> Result<Box<dyn SecretStore>, A
         return Ok(Box::new(store));
     }
     #[cfg(not(feature = "vault-secrets"))]
-    if config.secrets.vault_addr.is_some() {
+    if wants(SecretBackend::Vault, config.secrets.vault_addr.is_some()) {
         return Err(AppError::Config(
-            "secrets.vault_addr is set but this binary was built without the \
+            "secrets backend 'vault' selected but this binary was built without the \
              'vault-secrets' feature"
                 .into(),
         ));
     }
 
     #[cfg(feature = "k8s-secrets")]
-    if config.secrets.k8s_secret_name.is_some() {
+    if wants(SecretBackend::K8s, config.secrets.k8s_secret_name.is_some()) {
+        let name = config.secrets.k8s_secret_name.clone().ok_or_else(|| {
+            AppError::Config("secrets.backend = k8s requires secrets.k8s_secret_name".into())
+        })?;
         let store = K8sSecretStore::new(
-            config.secrets.k8s_secret_name.clone().unwrap(),
+            name,
             config.secrets.k8s_namespace.clone(),
             config.secrets.k8s_secret_key.clone(),
         );
         return Ok(Box::new(store));
     }
     #[cfg(not(feature = "k8s-secrets"))]
-    if config.secrets.k8s_secret_name.is_some() {
+    if wants(SecretBackend::K8s, config.secrets.k8s_secret_name.is_some()) {
         return Err(AppError::Config(
-            "secrets.k8s_secret_name is set but this binary was built without the \
+            "secrets backend 'k8s' selected but this binary was built without the \
              'k8s-secrets' feature"
                 .into(),
         ));
     }
 
     #[cfg(feature = "config-secret")]
-    if config.secrets.secret.is_some() {
-        let store = ConfigSecretStore::new(config.secrets.secret.clone().unwrap());
+    if wants(SecretBackend::Config, config.secrets.secret.is_some()) {
+        let secret = config.secrets.secret.clone().ok_or_else(|| {
+            AppError::Config("secrets.backend = config requires secrets.secret".into())
+        })?;
+        let store = ConfigSecretStore::new(secret);
         return Ok(Box::new(store));
     }
     #[cfg(not(feature = "config-secret"))]
-    if config.secrets.secret.is_some() {
+    if wants(SecretBackend::Config, config.secrets.secret.is_some()) {
         return Err(AppError::Config(
-            "secrets.secret is set but this binary was built without the \
+            "secrets backend 'config' selected but this binary was built without the \
              'config-secret' feature"
                 .into(),
         ));
     }
 
+    // Keyring — the implicit default when nothing is selected, or an explicit
+    // `backend = "keyring"`. An explicit keyring selection on a binary built
+    // without the feature is a hard error (mirrors the cloud arms); the
+    // implicit path just falls through to plaintext when keyring isn't compiled.
+    #[cfg(not(feature = "keyring"))]
+    if matches!(explicit, Some(SecretBackend::Keyring)) {
+        return Err(AppError::Config(
+            "secrets backend 'keyring' selected but this binary was built without the \
+             'keyring' feature"
+                .into(),
+        ));
+    }
     #[cfg(feature = "keyring")]
-    {
+    if explicit.is_none() || matches!(explicit, Some(SecretBackend::Keyring)) {
         let store = KeyringSecretStore::new(&config.secrets.keyring_service, "vtc_secret");
         return Ok(Box::new(store));
     }
 
+    // Plaintext — explicit `backend = "plaintext"`, or the unconditional last
+    // resort when no keyring is compiled and nothing else matched.
     #[allow(unreachable_code)]
     {
-        tracing::warn!(
-            "no secure secret store backend available — falling back to plaintext file storage"
-        );
+        if !matches!(explicit, Some(SecretBackend::Plaintext)) {
+            tracing::warn!(
+                "no secure secret store backend available — falling back to plaintext file storage"
+            );
+        }
         let store =
             PlaintextSecretStore::with_filename(&config.store.data_dir, VTC_PLAINTEXT_FILENAME);
         Ok(Box::new(store))
@@ -283,5 +337,68 @@ mod tests {
         // not an error. Guards must only fire when a backend is *requested*.
         let config = base_config();
         assert!(create_secret_store(&config).is_ok());
+    }
+
+    // ---- explicit `secrets.backend` selector ------------------------------
+
+    use crate::config::SecretBackend;
+
+    #[test]
+    fn explicit_backend_uncompiled_is_config_error() {
+        // `backend = "vault"` on the keyring-only default test build fails
+        // closed (vault-secrets not compiled), same as the implicit path.
+        let mut config = base_config();
+        config.secrets.backend = Some(SecretBackend::Vault);
+        assert_config_err_mentions(&config, "vault-secrets");
+    }
+
+    #[test]
+    fn explicit_aws_uncompiled_is_config_error() {
+        let mut config = base_config();
+        config.secrets.backend = Some(SecretBackend::Aws);
+        assert_config_err_mentions(&config, "aws-secrets");
+    }
+
+    #[test]
+    fn explicit_keyring_selects_keyring() {
+        let mut config = base_config();
+        config.secrets.backend = Some(SecretBackend::Keyring);
+        assert!(create_secret_store(&config).is_ok());
+    }
+
+    #[test]
+    fn explicit_plaintext_selects_plaintext() {
+        // Explicit plaintext is honoured even though keyring is compiled —
+        // the keyring arm is skipped when an explicit non-keyring backend is
+        // named.
+        let mut config = base_config();
+        config.secrets.backend = Some(SecretBackend::Plaintext);
+        assert!(create_secret_store(&config).is_ok());
+    }
+
+    #[test]
+    fn explicit_backend_overrides_a_stray_implicit_field() {
+        // A leftover `vault_addr` would make the implicit path error (vault
+        // not compiled here), but an explicit `backend = "keyring"` wins
+        // outright and ignores it — no error, keyring selected.
+        let mut config = base_config();
+        config.secrets.vault_addr = Some("https://vault.internal:8200".into());
+        config.secrets.backend = Some(SecretBackend::Keyring);
+        assert!(
+            create_secret_store(&config).is_ok(),
+            "explicit backend must override a stray selector field"
+        );
+    }
+
+    // Only meaningful when the feature is actually compiled: an explicit
+    // backend whose required field is missing is a clear "requires" error
+    // rather than a silent fall-through.
+    #[cfg(feature = "vault-secrets")]
+    #[test]
+    fn explicit_vault_without_addr_reports_required_field() {
+        let mut config = base_config();
+        config.secrets.backend = Some(SecretBackend::Vault);
+        // vault_addr deliberately left None.
+        assert_config_err_mentions(&config, "requires secrets.vault_addr");
     }
 }

--- a/vtc-service/src/main.rs
+++ b/vtc-service/src/main.rs
@@ -33,12 +33,32 @@ enum Commands {
     /// prompts — suitable for CI, immutable images, or any unattended
     /// bring-up. See `docs/03-vtc/examples/vtc-setup.example.toml` for
     /// the worked schema.
+    ///
+    /// For a fully headless (no-TTY) bring-up, setup is two-phase — the
+    /// same shape the mediator and did-hosting services use:
+    ///
+    /// 1. `--setup-key-out <path>` mints an ephemeral did:key, persists
+    ///    it (0600), and prints the `pnm contexts create … --admin-did`
+    ///    command. An operator (or a CI step holding VTA admin) runs that
+    ///    to enrol the setup DID at the VTA. Exits without touching
+    ///    anything else.
+    /// 2. `--from <toml>` (with `setup_key_file` pointing at that path)
+    ///    provisions end-to-end using the now-authorised key.
     Setup {
         /// Path to a TOML setup-inputs file. When set, setup runs
         /// non-interactively. The ephemeral setup key it references
         /// (`setup_key_file`) must already be ACL-authorised at the VTA.
-        #[arg(long)]
+        #[arg(long, conflicts_with = "setup_key_out")]
         from: Option<PathBuf>,
+        /// Phase 1: mint an ephemeral did:key, persist it to <path>
+        /// (0600), print the `pnm contexts create --admin-did` grant
+        /// command, and exit. Does not touch config or the VTA.
+        #[arg(long, conflicts_with = "from")]
+        setup_key_out: Option<PathBuf>,
+        /// Context id used only to render phase 1's printed grant
+        /// command. Must match `context` in the phase-2 setup TOML.
+        #[arg(long, default_value = "default", requires = "setup_key_out")]
+        context: String,
     },
     /// Show VTC status and statistics
     Status,
@@ -158,12 +178,17 @@ async fn main() {
     print_banner();
 
     match cli.command {
-        Some(Commands::Setup { from }) => {
+        Some(Commands::Setup {
+            from,
+            setup_key_out,
+            context,
+        }) => {
             #[cfg(feature = "setup")]
             {
-                let result = match from {
-                    Some(path) => setup::run_setup_from_file(path).await,
-                    None => setup::run_setup_wizard(cli.config).await,
+                let result = match (setup_key_out, from) {
+                    (Some(out), _) => setup::run_setup_phase1(&out, &context).await,
+                    (None, Some(path)) => setup::run_setup_from_file(path).await,
+                    (None, None) => setup::run_setup_wizard(cli.config).await,
                 };
                 if let Err(e) = result {
                     eprintln!("Setup failed: {e}");
@@ -172,7 +197,7 @@ async fn main() {
             }
             #[cfg(not(feature = "setup"))]
             {
-                let _ = from;
+                let _ = (from, setup_key_out, context);
                 eprintln!("Setup wizard not available (compiled without 'setup' feature)");
                 std::process::exit(1);
             }

--- a/vtc-service/src/setup/mod.rs
+++ b/vtc-service/src/setup/mod.rs
@@ -7,6 +7,9 @@
 //! - [`from_toml`] — non-interactive `vtc setup --from <toml>`
 //!   (feature-gated on `setup`). Builds the same `WizardPlan` the
 //!   interactive wizard does and feeds it to the same `apply`.
+//! - [`phase1`] — `vtc setup --setup-key-out <path>`: phase 1 of the
+//!   headless two-phase flow (mint + persist the ephemeral key, print
+//!   the grant command). Phase 2 is [`from_toml`].
 //!
 //! See `tasks/vtc-mvp/vta-driven-keys.md` for the design that
 //! drove this module's shape.
@@ -15,10 +18,14 @@ pub mod bundle;
 #[cfg(feature = "setup")]
 pub mod from_toml;
 #[cfg(feature = "setup")]
+pub mod phase1;
+#[cfg(feature = "setup")]
 pub mod wizard;
 
 pub use bundle::VtcKeyBundle;
 #[cfg(feature = "setup")]
 pub use from_toml::run_setup_from_file;
+#[cfg(feature = "setup")]
+pub use phase1::run_setup_phase1;
 #[cfg(feature = "setup")]
 pub use wizard::run_setup_wizard;

--- a/vtc-service/src/setup/phase1.rs
+++ b/vtc-service/src/setup/phase1.rs
@@ -1,0 +1,105 @@
+//! Phase 1 of the headless (no-TTY) two-phase setup: mint the ephemeral
+//! setup key.
+//!
+//! `vtc setup --setup-key-out <path> [--context <id>]` mints a fresh
+//! ephemeral `did:key`, persists it to `<path>` (0600), and prints the
+//! `pnm contexts create … --admin-did <did>` command the operator (or a
+//! CI step holding VTA admin) runs to enrol that DID at the VTA. It
+//! touches nothing else — no config, no VTA round-trip.
+//!
+//! This is the counterpart to phase 2
+//! ([`run_setup_from_file`](super::run_setup_from_file)), which loads the
+//! now-authorised key via `setup_key_file` and provisions end-to-end. The
+//! split mirrors the mediator (`mediator-setup --setup-key-out`) and
+//! did-hosting (`did-hosting-daemon setup --setup-key-out`) flows: the
+//! ACL grant between phases is inherently operator-gated, so a fully
+//! headless run persists the key here, an out-of-band step grants it, and
+//! phase 2 finishes the job.
+//!
+//! The heavy lifting (mint → `persist_to` → print the grant block) is the
+//! shared SDK helper [`vta_sdk::provision_client::driver::run_phase1_init`];
+//! this module only supplies the VTC-specific
+//! [`OperatorMessages`](vta_sdk::provision_client::OperatorMessages) impl
+//! and the phase-2 finalise hint.
+
+use std::path::Path;
+
+use vti_common::error::AppError;
+
+use super::wizard::VtcHostMessages;
+
+/// `vtc setup --setup-key-out <out_path> --context <context_id>`: mint +
+/// persist an ephemeral setup key and print the grant command. `context_id`
+/// only shapes the printed `pnm contexts create` line — it must match the
+/// `context` in the phase-2 setup TOML.
+pub async fn run_setup_phase1(out_path: &Path, context_id: &str) -> Result<(), AppError> {
+    let finalise = format!(
+        "vtc setup --from <your-setup.toml>   (with setup_key_file = \"{}\")",
+        out_path.display()
+    );
+    vta_sdk::provision_client::driver::run_phase1_init(
+        &mut std::io::stderr(),
+        out_path,
+        context_id,
+        &VtcHostMessages,
+        Some(&finalise),
+    )
+    .await
+    .map_err(|e| AppError::Internal(format!("phase-1 setup-key mint failed: {e}")))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vta_sdk::provision_client::{EphemeralSetupKey, OperatorMessages, driver::run_phase1_init};
+
+    /// Phase 1 writes a loadable, 0600 ephemeral key at the requested path.
+    #[tokio::test]
+    async fn phase1_persists_loadable_setup_key() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let out = dir.path().join("vtc-setup-key.json");
+
+        run_setup_phase1(&out, "default")
+            .await
+            .expect("phase 1 succeeds");
+
+        // Loadable back as an EphemeralSetupKey with a did:key DID.
+        let key = EphemeralSetupKey::load_from(&out).expect("load persisted key");
+        assert!(
+            key.did.starts_with("did:key:z6Mk"),
+            "expected an Ed25519 did:key, got {}",
+            key.did
+        );
+
+        // Owner-only permissions on unix.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(&out).unwrap().permissions().mode() & 0o777;
+            assert_eq!(mode, 0o600, "setup key must be 0600");
+        }
+    }
+
+    /// The printed block names the context id and the `--admin-did` grant
+    /// so the operator can copy-paste it. Drive the shared helper directly
+    /// with a capturing writer (the VTC entry hard-codes stderr).
+    #[tokio::test]
+    async fn phase1_prints_context_scoped_grant_command() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let out = dir.path().join("key.json");
+        let mut buf: Vec<u8> = Vec::new();
+
+        run_phase1_init(&mut buf, &out, "acme", &VtcHostMessages, None)
+            .await
+            .expect("run_phase1_init");
+
+        let printed = String::from_utf8(buf).expect("utf8");
+        let did = EphemeralSetupKey::load_from(&out).unwrap().did;
+        assert!(printed.contains("pnm contexts create"), "{printed}");
+        assert!(printed.contains("--id acme"), "{printed}");
+        assert!(printed.contains(&format!("--admin-did {did}")), "{printed}");
+        // Sanity: the VTC label drives the printed context wording.
+        assert_eq!(VtcHostMessages.integration_label(), "VTC");
+    }
+}

--- a/vtc-service/src/setup/wizard.rs
+++ b/vtc-service/src/setup/wizard.rs
@@ -221,11 +221,19 @@ pub(crate) async fn apply(plan: WizardPlan) -> Result<SetupOutcome, AppError> {
     //    hex-encode the bundle into the config and let the config write
     //    carry it to disk instead of calling `.set()`.
     //    `secrets_choice_to_config` seeds `secret = Some("")` when the
-    //    operator picks the inline backend, so an `is_some()` secret is the
-    //    signal we took that path. Mirrors the VTA wizard's config-seed
-    //    handling in `vta-service/src/setup/interactive.rs`.
+    //    interactive operator picks the inline backend, so an `is_some()`
+    //    secret is one signal we took that path; an explicit
+    //    `backend = "config"` (the non-interactive selector, where the
+    //    operator leaves `secret` empty because the bundle is minted here)
+    //    is the other. Mirrors the VTA wizard's config-seed handling in
+    //    `vta-service/src/setup/interactive.rs`.
     let bundle_bytes = bundle.to_secret_store_bytes()?;
-    if app_config.secrets.secret.is_some() {
+    let inline_config_backend = app_config.secrets.secret.is_some()
+        || matches!(
+            app_config.secrets.backend,
+            Some(crate::config::SecretBackend::Config)
+        );
+    if inline_config_backend {
         app_config.secrets.secret = Some(hex::encode(&bundle_bytes));
         write_config_toml(&config_path, &app_config)?;
     } else {
@@ -1236,7 +1244,11 @@ fn provision_failed(msg: &str) -> AppError {
 }
 
 /// `OperatorMessages` impl for the vtc-host integration kind.
-struct VtcHostMessages;
+///
+/// Reused by the phase-1 `--setup-key-out` helper
+/// ([`super::run_setup_phase1`]) so the printed grant command matches
+/// the one the interactive/DIDComm provision paths reference.
+pub(crate) struct VtcHostMessages;
 
 impl OperatorMessages for VtcHostMessages {
     fn integration_label(&self) -> &str {


### PR DESCRIPTION
## What & why

Makes the VTC installable **unattended** (CI, immutable image, Kubernetes Job) the same way the mediator and did-hosting services are. Two gaps blocked that; this closes both.

The direction was chosen deliberately to **match mediator/did-hosting exactly** — investigation confirmed neither self-grants; both use an operator-gated two-phase bridge, and the VTC already had phase 2 (`setup --from` + `setup_key_file`) but was missing the phase-1 mint helper.

## Changes

### 1. Phase-1 mint helper (`vtc setup --setup-key-out`)
- `vtc setup --setup-key-out <path> [--context <id>]` mints + persists an ephemeral `did:key` (0600) and prints the exact `pnm contexts create … --admin-did` grant command, then exits. Phase 2 (`setup --from`) is unchanged.
- Reuses the shared SDK helper `vta_sdk::provision_client::driver::run_phase1_init` and the existing `VtcHostMessages` (now `pub(crate)`), so the printed grant matches the interactive/DIDComm paths.
- Stays **operator-gated** — VTC never holds a VTA admin credential (no self-grant), consistent with mediator/did-hosting. Whatever runs the grant between phases is what holds VTA admin.

### 2. Explicit secret-store backend selector
- New `[secrets] backend = "keyring|vault|k8s|aws|gcp|azure|config|plaintext"`. When set it **wins outright** over the legacy "whichever field is set" resolution and validates the chosen backend's required fields (clear error on mismatch). Omit to keep implicit resolution (back-compat).
- Preserves the fail-closed "backend selected without its feature" behavior. All backends except TEE-KMS (a permanent VTC non-goal) are supported — including **HashiCorp Vault** and **Kubernetes Secrets**.

### 3. Docs / tests
- New `docs/03-vtc/non-interactive-setup.md` (two-phase walkthrough + backend table + Kubernetes section).
- Example TOML gains the missing Vault block, the `backend` selector, and the phase-1 header; getting-started cross-link; root `CLAUDE.md` "VTC first-boot setup" flow entry.
- 17 new unit tests (config enum round-trips, factory selection/override/validation, phase-1 key + printed grant).

Bumps `vtc-service` 0.10.13 → 0.11.0 (publishable crate, new feature).

## Verification
- `cargo check` / `cargo clippy` clean on default **and** all-backends feature sets; `cargo fmt --check` clean.
- `cargo test -p vtc-service --lib`: **670 passed**. The only 4 failures are `admin_ui::tests`, which assert the embedded admin-UI dist is present — they fail solely because CI-local builds used `VTC_SKIP_ADMIN_UI_BUILD=1` (no npm build); no admin-UI code was touched. A full build passes them.
- Verified the phase-1 command live: correct DID, 0600 key file, context-scoped grant command, and clap guards (`--from`↔`--setup-key-out` conflict; `--context` requires `--setup-key-out`).

## Note / follow-up
This is **not** a zero-touch self-grant — that would require VTC to hold a VTA admin credential, which no service does today. If desired later, a self-grant helper could be built once and adopted by VTC + mediator + did-hosting together.