### PR TITLE
fix: deliver delegated step-up push to approver device

### DIFF
--- a/vta-service/src/didcomm_bridge.rs
+++ b/vta-service/src/didcomm_bridge.rs
@@ -67,6 +67,42 @@ impl DIDCommBridge {
         self.service.get().cloned()
     }
 
+    /// Fire-and-forget: pack `body` as a DIDComm message to `recipient_did` and
+    /// send it via the mediator, **without** registering a pending reply. Used
+    /// for the delegated step-up push — the approver's device replies later via
+    /// a separate `approve-response` call, not as a DIDComm reply on this thread.
+    pub async fn send_oneway(
+        &self,
+        listener_id: &str,
+        recipient_did: &str,
+        msg_type: &str,
+        body: serde_json::Value,
+    ) -> Result<(), AppError> {
+        let service = self
+            .service
+            .get()
+            .ok_or_else(|| AppError::Internal("DIDComm service not initialized".into()))?;
+        let vta_did = service.listener_did(listener_id).await.ok_or_else(|| {
+            AppError::Internal(format!(
+                "listener '{listener_id}' not found in DIDComm service"
+            ))
+        })?;
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let msg = Message::build(uuid::Uuid::new_v4().to_string(), msg_type.to_string(), body)
+            .from(vta_did)
+            .to(recipient_did.to_string())
+            .created_time(now)
+            .finalize();
+        service
+            .send_message_with_retry(listener_id, msg, recipient_did, 3, Duration::from_secs(2))
+            .await
+            .map_err(|e| bad_gateway_error(format!("failed to send message: {e}")))?;
+        Ok(())
+    }
+
     /// Like [`send_and_wait`](Self::send_and_wait) but uses the
     /// caller-supplied `listener_id` instead of `self.listener_id`.
     /// Required when the VTA holds multiple listeners (e.g. during

--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -1009,6 +1009,22 @@ pub async fn run(
                                 service.clone(),
                                 Arc::clone(&app_state.didcomm_websocket_status),
                             );
+                            // Register the config-loaded mediator in the listener
+                            // registry so the delegated step-up push (which buffers
+                            // outbound through the registry) can reach approvers on
+                            // this mediator. The runtime `services didcomm enable`
+                            // path calls `record_activate`; a mediator loaded from
+                            // config at boot did not, so `buffer_outbound` failed
+                            // with `NotRegistered` and the delegated push never
+                            // reached the device.
+                            #[cfg(feature = "webvh")]
+                            app_state
+                                .mediator_registry
+                                .record_activate(crate::messaging::registry::MediatorBinding {
+                                    mediator_did: messaging_config.mediator_did.clone(),
+                                    endpoint: messaging_config.mediator_url.clone(),
+                                })
+                                .await;
                             info!("DIDComm service started");
                             Some(service)
                         }

--- a/vta-service/src/trust_tasks/step_up.rs
+++ b/vta-service/src/trust_tasks/step_up.rs
@@ -721,6 +721,28 @@ async fn maybe_push_step_up(
                 "failed to buffer delegated step-up push; relay fallback applies"
             );
         }
+
+        // Actually deliver it: send the approve-request straight to the
+        // approver's device over the mediator. `buffer_outbound` alone never
+        // reaches the device (nothing drains it in steady state); this is the
+        // send. The device replies later with a separate approve-response, so
+        // it's fire-and-forget. Best-effort — the reject already carries the
+        // approveRequest as the relay fallback.
+        if let Err(e) = state
+            .didcomm_bridge
+            .send_oneway(
+                "vta-main",
+                recipient,
+                STEP_UP_APPROVE_REQUEST_TYPE,
+                approve_request.clone(),
+            )
+            .await
+        {
+            tracing::warn!(
+                error = %e, approver = %recipient,
+                "delegated step-up push send failed; relay fallback applies"
+            );
+        }
     }
 
     // VTA-trigger: wake the approver's device via its push gateway so a


### PR DESCRIPTION
## Problem

The delegated step-up push (VTA → approver's device) verified correctly end-to-end but the approve-request **never reached the device**. Two independent gaps:

1. `maybe_push_step_up` only called `buffer_outbound`, which has no steady-state drain — nothing actually sent the buffered message.
2. A mediator loaded from **config at boot** was never registered in the listener registry (only the runtime `services didcomm enable` path calls `record_activate`), so `buffer_outbound` failed with `NotRegistered` anyway.

Net effect: a delegated approver (e.g. a Cierge mobile authorizer) was pushed nothing; the flow only worked if the caller manually relayed the `approveRequest` carried in the reject.

## Fix

- **`server.rs`** — register the config-loaded mediator via `record_activate` at boot (webvh-gated), mirroring the runtime enable path, so the registry can route delegated pushes on it.
- **`didcomm_bridge.rs`** — add `DIDCommBridge::send_oneway`: pack `body` as a DIDComm message to a recipient and send via the mediator with retry, **without** registering a pending reply (the device answers later with a separate `approve-response`, not a thread reply).
- **`trust_tasks/step_up.rs`** — call `send_oneway` from `maybe_push_step_up` to actually deliver the approve-request. Best-effort; the reject still carries the `approveRequest` as a relay fallback.

## Validation

Validated end-to-end against a live mediator + an iOS approver: the approve-request now reaches the device automatically and renders the authorization card. `cargo test -p vta-service --lib step_up` green (18 passed); fmt + build clean.

## Note

This lands the **delivery** half of the delegated push. A follow-up PR makes the *elevation* half work over intrinsic-sender transports (unified transport-agnostic session handler) — today a DIDComm/TSP-authenticated caller has no persistent session for the verified approval to elevate.