### PR TITLE
feat(auth): implement the jti pin so a session's tokens are revocable

### DIFF
--- a/vta-service/src/auth/backend.rs
+++ b/vta-service/src/auth/backend.rs
@@ -92,6 +92,7 @@ impl AuthBackend for VtaAuthBackend {
         acr: &str,
         tee_attested: bool,
         ttl_secs: u64,
+        jti: &str,
     ) -> Result<String, Self::Error> {
         let claims = self
             .jwt_keys
@@ -103,7 +104,8 @@ impl AuthBackend for VtaAuthBackend {
                 ttl_secs,
                 tee_attested,
             )
-            .with_aal(amr.to_vec(), acr.to_string());
+            .with_aal(amr.to_vec(), acr.to_string())
+            .with_jti(jti);
         self.jwt_keys
             .encode(&claims)
             .map_err(|e| AppError::Internal(format!("jwt encode failed: {e:?}")))

--- a/vta-service/tests/session_jti_pin.rs
+++ b/vta-service/tests/session_jti_pin.rs
@@ -1,0 +1,121 @@
+//! Integration test for the **jti pin** — an access token authenticates only
+//! while its `jti` matches the session's `token_id`. Minting a fresh token
+//! rotates `token_id`, so every previously-issued token for the same session is
+//! superseded. This is the mechanism that keeps a session revocable even when
+//! its `session_id` does not rotate. Sessions with an unset `token_id` (legacy
+//! rows, intrinsic-sender sessions) are unaffected — the pin is opt-in.
+//!
+//! Exercises the real `AuthClaims` extractor through the trust-task dispatcher.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use tower::ServiceExt;
+
+use vta_service::test_support::{TestAppContext, build_test_app};
+use vti_common::auth::session::{Session, SessionState, now_epoch, store_session};
+
+async fn seed_admin_acl(ctx: &TestAppContext, did: &str) {
+    let entry = vti_common::acl::AclEntry::new(did, vti_common::acl::Role::Admin, "test")
+        .with_created_at(1);
+    vti_common::acl::store_acl_entry(&ctx.acl_ks, &entry)
+        .await
+        .expect("seed admin ACL");
+}
+
+async fn seed_session(ctx: &TestAppContext, session_id: &str, did: &str, token_id: Option<&str>) {
+    let session = Session {
+        session_id: session_id.into(),
+        did: did.into(),
+        challenge: String::new(),
+        state: SessionState::Authenticated,
+        created_at: now_epoch(),
+        last_seen: now_epoch(),
+        refresh_token: Some(format!("rt-{session_id}")),
+        refresh_expires_at: Some(now_epoch() + 86_400),
+        tee_attested: false,
+        amr: vec!["did".into()],
+        acr: "aal1".into(),
+        acr_expires_at: None,
+        token_id: token_id.map(str::to_string),
+        session_pubkey_b58btc: None,
+    };
+    store_session(&ctx.sessions_ks, &session).await.unwrap();
+}
+
+/// A `whoami` request bearing `did`/`session_id`/`jti`; returns the HTTP status
+/// the extractor + dispatcher produced.
+async fn whoami_status(
+    ctx: &TestAppContext,
+    router: &axum::Router,
+    did: &str,
+    session_id: &str,
+    jti: &str,
+) -> StatusCode {
+    let claims = ctx
+        .jwt_keys
+        .new_claims(
+            did.into(),
+            session_id.into(),
+            "admin".into(),
+            vec![],
+            900,
+            false,
+        )
+        .with_jti(jti);
+    let token = ctx.jwt_keys.encode(&claims).unwrap();
+    let doc = serde_json::json!({
+        "id": "urn:uuid:jti-pin-itest",
+        "type": "https://trusttasks.org/spec/auth/whoami/0.1",
+        "issuer": did,
+        "recipient": "did:key:z6MkTestVTA",
+        "payload": {},
+    });
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/trust-tasks")
+        .header("authorization", format!("Bearer {token}"))
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(&doc).unwrap()))
+        .unwrap();
+    router.clone().oneshot(req).await.unwrap().status()
+}
+
+#[tokio::test]
+async fn matching_jti_authenticates_but_superseded_jti_is_rejected() {
+    let (router, ctx) = build_test_app().await;
+    let did = "did:key:z6MkPinned";
+    seed_admin_acl(&ctx, did).await;
+    seed_session(&ctx, "sess-pin", did, Some("jti-A")).await;
+
+    // Matching jti → authenticated (the route runs).
+    let ok = whoami_status(&ctx, &router, did, "sess-pin", "jti-A").await;
+    assert_eq!(
+        ok,
+        StatusCode::OK,
+        "token whose jti matches token_id must authenticate"
+    );
+
+    // Superseded jti (a token minted before the last rotation) → 401.
+    let stale = whoami_status(&ctx, &router, did, "sess-pin", "jti-OLD").await;
+    assert_eq!(
+        stale,
+        StatusCode::UNAUTHORIZED,
+        "token whose jti != session.token_id must be rejected as superseded"
+    );
+}
+
+#[tokio::test]
+async fn unpinned_session_accepts_any_jti() {
+    let (router, ctx) = build_test_app().await;
+    let did = "did:key:z6MkLegacy";
+    seed_admin_acl(&ctx, did).await;
+    // token_id: None — a legacy / intrinsic-sender session; the pin is skipped.
+    seed_session(&ctx, "sess-legacy", did, None).await;
+
+    let any = whoami_status(&ctx, &router, did, "sess-legacy", "whatever").await;
+    assert_eq!(
+        any,
+        StatusCode::OK,
+        "a session with no token_id must not enforce the pin (back-compat)"
+    );
+}

--- a/vtc-service/src/auth/backend.rs
+++ b/vtc-service/src/auth/backend.rs
@@ -89,6 +89,7 @@ impl AuthBackend for VtcAuthBackend {
         acr: &str,
         tee_attested: bool,
         ttl_secs: u64,
+        jti: &str,
     ) -> Result<String, Self::Error> {
         let claims = self
             .jwt_keys
@@ -100,7 +101,8 @@ impl AuthBackend for VtcAuthBackend {
                 ttl_secs,
                 tee_attested,
             )
-            .with_aal(amr.to_vec(), acr.to_string());
+            .with_aal(amr.to_vec(), acr.to_string())
+            .with_jti(jti);
         self.jwt_keys
             .encode(&claims)
             .map_err(|e| AppError::Internal(format!("jwt encode failed: {e:?}")))

--- a/vtc-service/src/routes/auth.rs
+++ b/vtc-service/src/routes/auth.rs
@@ -613,7 +613,7 @@ pub async fn passkey_login_finish(
         amr: amr.clone(),
         acr: acr.clone(),
         acr_expires_at: None,
-        token_id: None,
+        token_id: Some(minted.token_id.clone()),
         session_pubkey_b58btc: None,
     };
     store_session(&state.sessions_ks, &session).await?;

--- a/vti-common/src/auth/backend.rs
+++ b/vti-common/src/auth/backend.rs
@@ -255,6 +255,7 @@ pub trait AuthBackend: Send + Sync + 'static {
     /// surface. Each backend implements this method using whatever
     /// minter it holds; the canonical handler treats the return
     /// value as an opaque base64url-encoded JWS.
+    #[allow(clippy::too_many_arguments)]
     async fn mint_access_token(
         &self,
         subject: &str,
@@ -265,6 +266,9 @@ pub trait AuthBackend: Send + Sync + 'static {
         acr: &str,
         tee_attested: bool,
         ttl_secs: u64,
+        // Per-issue `jti` nonce; embedded in the token and pinned to the
+        // session's `token_id` so a freshly-minted token supersedes the prior.
+        jti: &str,
     ) -> Result<String, Self::Error>;
 
     // -------- Policy hooks --------

--- a/vti-common/src/auth/extractor.rs
+++ b/vti-common/src/auth/extractor.rs
@@ -110,6 +110,20 @@ impl<S: AuthState> FromRequestParts<S> for AuthClaims {
             return Err(AppError::Unauthorized("session not authenticated".into()));
         }
 
+        // jti pin: when the session records a `token_id`, only the token whose
+        // `jti` matches it authenticates. Minting a fresh token (login, refresh,
+        // step-up) rotates `token_id`, so every previously-issued access token
+        // for this session is superseded immediately — the mechanism that keeps
+        // a non-rotating session_id revocable. Skipped when `token_id` is unset
+        // (sessions written before this field, or intrinsic-sender sessions that
+        // carry no JWT), preserving their existing behaviour.
+        if let Some(ref pinned) = session.token_id
+            && claims.jti != *pinned
+        {
+            warn!(session_id = %claims.session_id, "auth rejected: token superseded (jti mismatch)");
+            return Err(AppError::Unauthorized("token superseded".into()));
+        }
+
         let role = Role::parse(&claims.role)?;
 
         Ok(AuthClaims {

--- a/vti-common/src/auth/handlers/authenticate.rs
+++ b/vti-common/src/auth/handlers/authenticate.rs
@@ -145,6 +145,9 @@ pub async fn handle_authenticate_with_aal<B: AuthBackend>(
     session.refresh_expires_at = Some(minted.refresh_expires_at);
     session.amr = amr.clone();
     session.acr = acr.clone();
+    // Pin the access token to the session: the extractor rejects any token
+    // whose jti != this value, so only the just-minted token authenticates.
+    session.token_id = Some(minted.token_id.clone());
     if let Some(pk) = input.session_pubkey_b58btc {
         session.session_pubkey_b58btc = Some(pk);
     }

--- a/vti-common/src/auth/handlers/mint.rs
+++ b/vti-common/src/auth/handlers/mint.rs
@@ -26,6 +26,10 @@ pub struct MintedTokens {
     pub refresh_expires_at: u64,
     /// Epoch second the tokens were minted at.
     pub issued_at: u64,
+    /// The `jti` embedded in `access_token`. The caller MUST persist this as
+    /// the session's `token_id` so the extractor's pin matches — otherwise the
+    /// freshly-minted token would be rejected as superseded.
+    pub token_id: String,
 }
 
 /// Mint an access + refresh token pair for an already-authenticated
@@ -62,6 +66,7 @@ pub async fn mint_session_tokens<B: AuthBackend>(
         backend.access_token_ttl()
     };
     let refresh_token = Uuid::new_v4().to_string();
+    let token_id = Uuid::new_v4().to_string();
     let refresh_expires_at = now.saturating_add(backend.refresh_token_ttl());
     let access_expires_at = now.saturating_add(access_ttl);
 
@@ -75,6 +80,7 @@ pub async fn mint_session_tokens<B: AuthBackend>(
             acr,
             tee_attested,
             access_ttl,
+            &token_id,
         )
         .await?;
 
@@ -92,6 +98,7 @@ pub async fn mint_session_tokens<B: AuthBackend>(
         access_expires_at,
         refresh_expires_at,
         issued_at: now,
+        token_id,
     })
 }
 
@@ -158,6 +165,7 @@ mod tests {
             _acr: &str,
             _tee_attested: bool,
             ttl_secs: u64,
+            _jti: &str,
         ) -> Result<String, AppError> {
             // Echo the applied TTL so the test can confirm which one was used.
             Ok(format!("token-ttl-{ttl_secs}"))

--- a/vti-common/src/auth/handlers/refresh.rs
+++ b/vti-common/src/auth/handlers/refresh.rs
@@ -113,6 +113,7 @@ pub async fn handle_refresh<B: AuthBackend>(
 
     let new_session_id = Uuid::new_v4().to_string();
     let new_refresh_token = Uuid::new_v4().to_string();
+    let new_token_id = Uuid::new_v4().to_string();
     let new_refresh_expires_at = now.saturating_add(backend.refresh_token_ttl());
     // M2: stepped-up sessions keep the shorter `aal2` TTL
     // across rotation (was previously dropping back to the
@@ -134,6 +135,7 @@ pub async fn handle_refresh<B: AuthBackend>(
             &acr,
             old_session.tee_attested,
             access_ttl,
+            &new_token_id,
         )
         .await?;
 
@@ -150,9 +152,10 @@ pub async fn handle_refresh<B: AuthBackend>(
         amr: amr.clone(),
         acr: acr.clone(),
         acr_expires_at: old_session.acr_expires_at,
+        // Pin the rotated access token to the new session row.
+        token_id: Some(new_token_id.clone()),
         // Inherit the per-session ephemeral pubkey across rotation;
         // the holder's DI-proof key didn't change.
-        token_id: None,
         session_pubkey_b58btc: old_session.session_pubkey_b58btc.clone(),
     };
 

--- a/vti-common/src/auth/jwt.rs
+++ b/vti-common/src/auth/jwt.rs
@@ -60,6 +60,16 @@ pub struct Claims {
     /// Empty when not categorised.
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub acr: String,
+    /// JWT ID (RFC 7519 §4.1.7) — a per-issue nonce that pins this access
+    /// token to the session's current `token_id`. The extractor rejects a
+    /// token whose `jti` does not match `Session.token_id` (when that field is
+    /// set), so minting a fresh token immediately supersedes the prior one for
+    /// the same session. Load-bearing once a session_id stops rotating on
+    /// refresh; harmless before then (each session already has exactly one live
+    /// token). `#[serde(default)]` so pre-`jti` tokens deserialise with an empty
+    /// string and are treated as "no pin" by sessions that predate the field.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub jti: String,
 }
 
 fn is_false(v: &bool) -> bool {
@@ -165,6 +175,7 @@ impl JwtKeys {
             tee_attested,
             amr: Vec::new(),
             acr: String::new(),
+            jti: String::new(),
         }
     }
 }
@@ -184,6 +195,15 @@ impl Claims {
     /// ```ignore
     /// claims = claims.with_aal(vec!["did".into(), "passkey".into()], "aal2");
     /// ```
+    /// Builder-style setter for the `jti` pin. Minters call this after
+    /// [`JwtKeys::new_claims`] with the same value they persist as the
+    /// session's `token_id`, so the extractor's pin check matches. Defaults to
+    /// empty (no pin) when not called.
+    pub fn with_jti(mut self, jti: impl Into<String>) -> Self {
+        self.jti = jti.into();
+        self
+    }
+
     pub fn with_aal(mut self, amr: Vec<String>, acr: impl Into<String>) -> Self {
         self.amr = amr;
         self.acr = acr.into();
@@ -233,6 +253,40 @@ mod tests {
         assert_eq!(decoded.sub, "did:key:z6Mk");
         assert_eq!(decoded.role, "admin");
         assert!(!decoded.tee_attested);
+    }
+
+    #[test]
+    fn jti_defaults_empty_and_round_trips_when_set() {
+        let keys = test_keys();
+        // Default: no pin.
+        let plain = keys.new_claims(
+            "did:key:z6Mk".into(),
+            "s".into(),
+            "admin".into(),
+            vec![],
+            900,
+            false,
+        );
+        assert_eq!(plain.jti, "", "jti defaults empty (unpinned)");
+        assert!(!keys.encode(&plain).unwrap().is_empty());
+
+        // Pinned via the builder: survives encode → decode.
+        let pinned = keys
+            .new_claims(
+                "did:key:z6Mk".into(),
+                "s".into(),
+                "admin".into(),
+                vec![],
+                900,
+                false,
+            )
+            .with_jti("tok-abc123");
+        assert_eq!(pinned.jti, "tok-abc123");
+        let decoded = keys.decode(&keys.encode(&pinned).unwrap()).unwrap();
+        assert_eq!(
+            decoded.jti, "tok-abc123",
+            "jti must round-trip so the extractor pin can match"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Context

First increment of Phase 3 (folding REST onto a single DID-keyed session, following #626/#627). Landed as its own PR because it's self-contained, security-relevant on its own, and a prerequisite for the rest.

## Problem

`Session.token_id` and its documented *"JWT `jti` rotation pin — the extractor compares the JWT's `jti` against this field"* were **dead code**: `Claims` had no `jti`, `token_id` was only ever written `None`, and nothing enforced it. Today an old access token stops working only because refresh deletes-and-remints the session row under a fresh random `session_id` — so revocation rides entirely on `session_id` rotation.

Once REST sessions become DID-keyed (a later phase), `session_id` stops rotating on refresh — and without the pin there is nothing to invalidate a superseded access token for its remaining TTL. This wires the documented mechanism up so it stands on its own.

## Changes

- **`Claims.jti`** (RFC 7519 §4.1.7), `skip_serializing_if` empty for token size + back-compat. `Claims::with_jti` sets it; `new_claims` defaults empty (no churn at its ~12 call sites).
- **`mint_access_token`** takes a per-issue `jti`. **`mint_session_tokens`** generates one, embeds it in the access token, and returns it as `MintedTokens.token_id`. The authenticate / refresh / VTC-auth paths persist that as the session's `token_id`.
- **Extractor** rejects a token whose `jti` != the session's `token_id` (when set) with `token superseded`. Sessions with no `token_id` — legacy rows and intrinsic-sender (DIDComm/TSP) sessions — are unaffected; the pin is **opt-in**.

Net: minting a fresh token (login / refresh / step-up) rotates `token_id` and immediately supersedes every prior token for that session, independent of `session_id`.

## Safety

No behaviour change for REST/VTC today — each session already has exactly one live token, so its jti always matches. Legacy/intrinsic sessions skip the check. Only VTA + VTC implement `AuthBackend`; both updated.

## Tests

`jti` round-trips through encode/decode; a matching jti authenticates, a superseded jti → 401, an unpinned session accepts any jti (new `session_jti_pin` integration test drives the real extractor). No regressions: vti-common **275**, vta-service lib **840**, all VTA auth-flow suites, VTC auth **20**. fmt + clippy clean.

## Follow-ups (Phase 3)

3b challenge/session split · 3c multi-refresh-token per DID session · 3d flip REST `session_id` to the DID (unifying with #627's intrinsic sessions). This PR is the foundation they build on.