### PR TITLE
feat(auth): key REST sessions on the DID, unifying with intrinsic sessions

### DIFF
--- a/vta-service/tests/authenticate_trust_task.rs
+++ b/vta-service/tests/authenticate_trust_task.rs
@@ -156,8 +156,19 @@ async fn di_signed_authenticate_issues_tokens() {
         "an access token is issued: {body}"
     );
 
-    // The session transitioned to Authenticated (so a replay can't re-auth).
-    let stored = vti_common::auth::session::get_session(&ctx.sessions_ks, &session_id)
+    // The response session is keyed on the DID (canonical, transport-agnostic).
+    assert_eq!(body["payload"]["session"]["id"], did, "{body}");
+
+    // The single-use challenge row is consumed (so a replay can't re-auth), and
+    // the authenticated session now lives under the DID, not the challenge id.
+    assert!(
+        vti_common::auth::session::get_session(&ctx.sessions_ks, &session_id)
+            .await
+            .unwrap()
+            .is_none(),
+        "the ephemeral challenge row must be consumed on authenticate"
+    );
+    let stored = vti_common::auth::session::get_session(&ctx.sessions_ks, &did)
         .await
         .unwrap()
         .unwrap();
@@ -165,6 +176,7 @@ async fn di_signed_authenticate_issues_tokens() {
         stored.state,
         vti_common::auth::session::SessionState::Authenticated
     );
+    assert_eq!(stored.session_id, did, "session is keyed on the DID");
 
     // Replay the exact same document: the session is no longer ChallengeSent.
     let (replay_status, _) = send(&router, post("/auth/", serde_json::to_vec(&doc).unwrap())).await;
@@ -172,6 +184,51 @@ async fn di_signed_authenticate_issues_tokens() {
         replay_status,
         StatusCode::OK,
         "replaying the authenticate document must not re-authenticate"
+    );
+}
+
+/// Coalesce-per-DID: a second login for the same identity resolves the **same**
+/// `session:{did}` row (one session per DID), and the latest login's refresh
+/// token wins (last-write-wins).
+#[tokio::test]
+async fn second_login_for_same_did_coalesces_into_one_session() {
+    let (router, ctx) = build_test_app().await;
+    let sk = SigningKey::from_bytes(&[9u8; 32]);
+    let (did, mb) = did_key(&sk);
+    let vm = format!("{did}#{mb}");
+    seed_admin_acl(&ctx, &did).await;
+
+    // First login.
+    let (sid1, ch1) = obtain_challenge(&router, &did).await;
+    let doc1 = signed_authenticate_doc(&sk, &did, &vm, &ch1, &sid1);
+    let (s1, b1) = send(&router, post("/auth/", serde_json::to_vec(&doc1).unwrap())).await;
+    assert_eq!(s1, StatusCode::OK, "first login: {b1}");
+    let rt1 = b1["payload"]["tokens"]["refreshToken"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // Second login for the same DID.
+    let (sid2, ch2) = obtain_challenge(&router, &did).await;
+    let doc2 = signed_authenticate_doc(&sk, &did, &vm, &ch2, &sid2);
+    let (s2, b2) = send(&router, post("/auth/", serde_json::to_vec(&doc2).unwrap())).await;
+    assert_eq!(s2, StatusCode::OK, "second login: {b2}");
+    let rt2 = b2["payload"]["tokens"]["refreshToken"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // One canonical session, keyed on the DID, holding the latest refresh token.
+    let stored = vti_common::auth::session::get_session(&ctx.sessions_ks, &did)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(stored.session_id, did);
+    assert_ne!(rt1, rt2, "each login mints a distinct refresh token");
+    assert_eq!(
+        stored.refresh_token.as_deref(),
+        Some(rt2.as_str()),
+        "coalesce-per-DID: the latest login's refresh token wins"
     );
 }
 

--- a/vti-common/src/auth/handlers/authenticate.rs
+++ b/vti-common/src/auth/handlers/authenticate.rs
@@ -29,7 +29,7 @@ use vta_sdk::protocols::auth::{
 
 use crate::auth::AuthError;
 use crate::auth::backend::{AuthBackend, AuthenticateInput, SessionStore};
-use crate::auth::session::{SessionState, now_epoch};
+use crate::auth::session::{Session, SessionState, now_epoch};
 
 /// Default first-factor AMR; the transport layer (or step-up
 /// handler) can override by passing different values to
@@ -58,7 +58,7 @@ pub async fn handle_authenticate_with_aal<B: AuthBackend>(
 ) -> Result<AuthenticateResponse, B::Error> {
     // ---- Load + state-check session ----
 
-    let mut session = backend
+    let session = backend
         .sessions()
         .get_session(&input.session_id)
         .await
@@ -122,14 +122,19 @@ pub async fn handle_authenticate_with_aal<B: AuthBackend>(
 
     // ---- Mint tokens (acr-dependent TTL + Authenticated audit) ----
     //
-    // The shared minter centralises the `aal2` short-TTL hardening
-    // (M2 from the May 2026 security review — bound the blast radius
-    // of a leaked elevated token) so every mint path applies it
-    // identically.
+    // The authenticated session is **canonical and transport-agnostic**: keyed
+    // on the identity (the DID), not the ephemeral challenge handle. So the JWT
+    // `session_id` is the DID, and this session unifies with the intrinsic-
+    // sender (DIDComm/TSP) session for the same DID.
+    //
+    // The shared minter centralises the `aal2` short-TTL hardening (M2 from the
+    // May 2026 security review — bound the blast radius of a leaked elevated
+    // token) so every mint path applies it identically.
+    let did = session.did.clone();
     let minted = super::mint::mint_session_tokens(
         backend,
-        &session.did,
-        &session.session_id,
+        &did,
+        &did,
         &role_resolution.role,
         &role_resolution.contexts,
         &amr,
@@ -138,28 +143,48 @@ pub async fn handle_authenticate_with_aal<B: AuthBackend>(
     )
     .await?;
 
-    // ---- Transition session + persist refresh index ----
-
-    session.state = SessionState::Authenticated;
-    session.refresh_token = Some(minted.refresh_token.clone());
-    session.refresh_expires_at = Some(minted.refresh_expires_at);
-    session.amr = amr.clone();
-    session.acr = acr.clone();
-    // Pin the access token to the session: the extractor rejects any token
-    // whose jti != this value, so only the just-minted token authenticates.
-    session.token_id = Some(minted.token_id.clone());
-    if let Some(pk) = input.session_pubkey_b58btc {
-        session.session_pubkey_b58btc = Some(pk);
-    }
+    // ---- Create the authenticated session, replace the challenge row ----
+    //
+    // Coalesce-per-DID: a fresh login overwrites any prior session for this
+    // identity, so one DID has one active refresh token (last-write-wins). The
+    // access token is pinned via `token_id` (the jti), so the previous login's
+    // access token is superseded immediately. The single-use challenge row (a
+    // distinct, ephemeral, uuid-keyed record) is deleted.
+    let auth_session = Session {
+        session_id: did.clone(),
+        did: did.clone(),
+        challenge: String::new(),
+        state: SessionState::Authenticated,
+        created_at: now,
+        last_seen: now,
+        refresh_token: Some(minted.refresh_token.clone()),
+        refresh_expires_at: Some(minted.refresh_expires_at),
+        tee_attested: session.tee_attested,
+        amr: amr.clone(),
+        acr: acr.clone(),
+        acr_expires_at: None,
+        token_id: Some(minted.token_id.clone()),
+        session_pubkey_b58btc: input
+            .session_pubkey_b58btc
+            .or(session.session_pubkey_b58btc.clone()),
+    };
 
     backend
         .sessions()
-        .store_session(&session)
+        .store_session(&auth_session)
         .await
         .map_err(|e| AuthError::Internal(format!("store_session failed: {e:?}")))?;
+    // Remove the single-use challenge row (keyed on the ephemeral handle).
+    if input.session_id != did {
+        backend
+            .sessions()
+            .delete_session(&input.session_id)
+            .await
+            .map_err(|e| AuthError::Internal(format!("delete_session failed: {e:?}")))?;
+    }
     backend
         .sessions()
-        .store_refresh_index(&minted.refresh_token, &session.session_id)
+        .store_refresh_index(&minted.refresh_token, &did)
         .await
         .map_err(|e| AuthError::Internal(format!("store_refresh_index failed: {e:?}")))?;
 
@@ -167,8 +192,8 @@ pub async fn handle_authenticate_with_aal<B: AuthBackend>(
 
     Ok(AuthenticateResponse {
         session: WireSession {
-            id: session.session_id.clone(),
-            subject: session.did,
+            id: did.clone(),
+            subject: did,
             issued_at: epoch_to_rfc3339(minted.issued_at),
             expires_at: epoch_to_rfc3339(minted.access_expires_at),
             amr,

--- a/vti-common/src/auth/handlers/refresh.rs
+++ b/vti-common/src/auth/handlers/refresh.rs
@@ -97,21 +97,20 @@ pub async fn handle_refresh<B: AuthBackend>(
 
     let (amr, acr) = super::refresh_amr_acr(&old_session);
 
-    // ---- 7. Delete old session ----
-
-    backend
-        .sessions()
-        .delete_session(&old_session.session_id)
-        .await
-        .map_err(|e| AuthError::Internal(format!("delete_session failed: {e:?}")))?;
-
-    // ---- 8. Re-look-up ACL role ----
+    // ---- 7. Re-look-up ACL role ----
 
     let role_resolution = backend.check_acl(&old_session.did).await?;
 
-    // ---- 9. Mint new session + tokens ----
-
-    let new_session_id = Uuid::new_v4().to_string();
+    // ---- 8. Mint rotated tokens ----
+    //
+    // The `session_id` is **stable** — it is the caller's DID, the canonical
+    // transport-agnostic session key. Only the refresh token and the access
+    // token's `jti` (`token_id`) rotate; the old refresh index was already
+    // claimed-and-deleted atomically in step 4, and the old access token is
+    // superseded by the new `token_id` pin. We overwrite `session:{did}` in
+    // place rather than delete-then-recreate, so a concurrent authed request
+    // never observes a momentarily-missing session.
+    let new_session_id = old_session.session_id.clone();
     let new_refresh_token = Uuid::new_v4().to_string();
     let new_token_id = Uuid::new_v4().to_string();
     let new_refresh_expires_at = now.saturating_add(backend.refresh_token_ttl());

--- a/vti-common/src/auth/session.rs
+++ b/vti-common/src/auth/session.rs
@@ -384,18 +384,24 @@ pub async fn cleanup_expired_sessions(
         let expired = match session.state {
             SessionState::ChallengeSent => now.saturating_sub(session.created_at) > challenge_ttl,
             SessionState::Authenticated => {
-                if session.session_id == session.did {
+                if session.refresh_token.is_some() {
+                    // REST/JWT session (has a refresh token) — bounded by its
+                    // refresh-token deadline. Now that REST sessions are also
+                    // DID-keyed, the presence of a refresh token, not the key
+                    // shape, is what marks a JWT session.
+                    session
+                        .refresh_expires_at
+                        .is_none_or(|expires| now > expires)
+                } else if session.session_id == session.did {
                     // Intrinsic-sender (DIDComm/TSP) canonical session — keyed on
-                    // the DID itself (session_id == did), no refresh token,
-                    // reaped on idle. Fall back to created_at for pre-migration
-                    // rows whose last_seen is unset (0).
+                    // the DID, no refresh token, reaped on idle. Fall back to
+                    // created_at for pre-migration rows whose last_seen is 0.
                     let last = session.last_seen.max(session.created_at);
                     now.saturating_sub(last) > INTRINSIC_SESSION_IDLE_TTL_SECS
                 } else {
-                    // REST/JWT session (UUID session_id): bounded by its
-                    // refresh-token deadline. Unchanged behaviour, including
-                    // recognise-style sessions with no refresh token, which
-                    // still expire on the next pass.
+                    // Transient authenticated rows with neither a refresh token
+                    // nor a DID key (e.g. VTC cross-community recognise sessions)
+                    // — unchanged: expire on the next pass.
                     session
                         .refresh_expires_at
                         .is_none_or(|expires| now > expires)


### PR DESCRIPTION
## Context

Final increment of Phase 3 — the transport-agnostic session model (following #626/#627/#628). It folds the planned 3b (challenge/session split) and 3d (flip-to-DID) into one change, and **eliminates 3c** (multi-refresh-token): since sessions coalesce per-DID, one identity has one active refresh token, so the single `refresh_token` field suffices.

## What changes

An authenticated REST session is now keyed on the caller's **DID** (`session:{did}`) — the same key the intrinsic-sender (DIDComm/TSP) resolver already uses (#627). One identity, one canonical session, across every transport: a step-up performed over DIDComm and a REST call now share the same session row.

Previously `/auth/` transitioned the ephemeral challenge row *in place*, so the authenticated `session_id` was the random challenge handle — the coupling that blocked DID-keying.

- **Challenge decoupled** — `/auth/` consumes the single-use challenge row (still uuid-keyed + ephemeral, so concurrent `/auth/challenge` for one DID never collide and per-DID rate limiting is unchanged) and creates a distinct `session:{did}` row, deleting the challenge row. Replay protection is preserved (the challenge is gone).
- **Coalesce-per-DID** — a fresh login overwrites any prior session for the identity (last-write-wins); the prior access token is superseded by the new `token_id` jti pin (#628).
- **Refresh keeps `session_id` stable** (the DID) and overwrites in place instead of delete-then-recreate, so a concurrent authed request never observes a missing session; only the refresh token + jti rotate.
- **Sweeper discriminator** flips from `session_id == did` (now true for REST) to `refresh_token.is_some()` → REST (refresh deadline) vs DID-keyed intrinsic (idle TTL) vs transient rows (VTC recognise — unchanged).

Applies to every caller of the shared handlers — VTA REST, VTA passkey (`handle_authenticate_with_aal`), and VTC — so all authenticated sessions are DID-canonical.

## Wire

The authenticate response's `session.id` and the JWT `session_id` claim are now the DID rather than the challenge handle. Clients use the JWT's `session_id` for authed calls and the refresh token for refresh; neither assumes the authenticated id equals the challenge id.

## Tests

Remarkably non-breaking — the entire existing auth suite passed with a **single intended update** (the challenge row is consumed, not transitioned in place). Adds a coalesce-per-DID integration test (two logins for one DID → one `session:{did}`, latest refresh token wins). vti-common **275**, vta-service lib **840**, all VTA auth suites (auth_flow/authenticate/refresh/whoami/sessions-list/jti-pin/api-integration), VTC auth + fixtures green; clippy/fmt clean.

## Phase 3 complete

3a jti pin (#628) · 3b+3d this PR · 3c eliminated by coalesce. Together with #627 (intrinsic sessions) the session model is now fully transport-agnostic and DID-canonical.