### PR TITLE
feat(vta-sdk): did-host TSP-only DID templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ## Unreleased
 
+### vta-sdk (0.18.18) — did-host TSP-only DID templates
+
+Two new built-in `did-host-*` templates let a VTA provision a node whose DID
+advertises **TSP without DIDComm**, closing the gap where the only
+mediator-carrying `did-host-*` templates advertised both transports
+unconditionally.
+
+Highlights:
+- Added `did-host-http-tsp` (WebVHHosting + TSPTransport, no DIDComm) and
+  `did-host-tsp` (TSPTransport only — no HTTP, no DIDComm), the TSP-only
+  siblings of `did-host-http-didcomm` / `did-host-didcomm`.
+- Registered both as built-ins (`BUILTIN_NAMES`, `load_embedded`) and exposed
+  curated `ProvisionAsk::did_host_http_tsp` / `did_host_tsp` builders plus
+  `BUILTIN_DID_HOST_HTTP_TSP_TEMPLATE` / `BUILTIN_DID_HOST_TSP_TEMPLATE`
+  constants.
+- The `#tsp` `TSPTransport` service points at the shared mediator, matching the
+  existing dual-transport templates; a rendered-shape fixture
+  (`did-host-tsp.rendered.json`) and per-template tests lock the document shape.
+- Purely additive — existing templates, names, and rendered shapes are
+  unchanged.
+
 ### vta-service (0.10.22) — self DID resolver refresh after runtime DID-log mutations
 
 `vta-service` now keeps its in-process resolver cache for the VTA's own DID in

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2452,7 +2452,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.18.17",
+ "vta-sdk 0.18.18",
 ]
 
 [[package]]
@@ -3254,7 +3254,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.18.17",
+ "vta-sdk 0.18.18",
 ]
 
 [[package]]
@@ -6714,7 +6714,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.18.17",
+ "vta-sdk 0.18.18",
 ]
 
 [[package]]
@@ -10016,7 +10016,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.18.17",
+ "vta-sdk 0.18.18",
  "vti-common",
  "x25519-dalek",
 ]
@@ -10049,7 +10049,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.18.17",
+ "vta-sdk 0.18.18",
 ]
 
 [[package]]
@@ -10072,7 +10072,7 @@ dependencies = [
  "tracing-subscriber",
  "trust-tasks-rs",
  "uniffi",
- "vta-sdk 0.18.17",
+ "vta-sdk 0.18.18",
 ]
 
 [[package]]
@@ -10107,7 +10107,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.18.17"
+version = "0.18.18"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10240,7 +10240,7 @@ dependencies = [
  "utoipa-axum",
  "uuid",
  "vta-cli-common",
- "vta-sdk 0.18.17",
+ "vta-sdk 0.18.18",
  "vta-service",
  "vti-common",
  "vti-secrets",
@@ -10262,7 +10262,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.18.17",
+ "vta-sdk 0.18.18",
 ]
 
 [[package]]
@@ -10334,7 +10334,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.18.17",
+ "vta-sdk 0.18.18",
  "vtc-service",
  "vti-common",
  "vti-secrets",
@@ -10382,7 +10382,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.18.17",
+ "vta-sdk 0.18.18",
  "webauthn-rs",
  "zeroize",
 ]
@@ -10409,7 +10409,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.18.17",
+ "vta-sdk 0.18.18",
  "vta-service",
  "vti-common",
 ]
@@ -10438,7 +10438,7 @@ dependencies = [
  "tokio",
  "tracing",
  "vaultrs",
- "vta-sdk 0.18.17",
+ "vta-sdk 0.18.18",
  "vti-common",
 ]
 

--- a/docs/02-vta/did-templates.md
+++ b/docs/02-vta/did-templates.md
@@ -15,7 +15,7 @@ consumer gets the new shape on the next create. No redeploy.
 - **Data, not code.** An operator can ship a new agent kind by dropping a JSON
   file, no recompile. The built-ins (`ai-agent`, `didcomm-mediator`,
   `push-gateway`, `vta-admin`, `vtc-host`, `did-host-http-didcomm`,
-  `did-host-http`, `did-host-didcomm`)
+  `did-host-http`, `did-host-didcomm`, `did-host-http-tsp`, `did-host-tsp`)
   are baseline shapes, not the only shapes.
 - **Method-agnostic.** Same format works for `did:webvh`, `did:web`, or
   `did:key` — the loader only knows about `{TOKEN}` placeholders. Method-
@@ -163,8 +163,9 @@ template without explicit scope is **context → global → builtin**:
     trailing slash.
     The `did-host-*` names describe the DID-document shape the template
     mints — `http` = a `WebVHHosting` (HTTP resolution) endpoint,
-    `didcomm` = a `DIDCommMessaging` endpoint — not the service that uses
-    it.
+    `didcomm` = a `DIDCommMessaging` endpoint, `tsp` = a `TSPTransport`
+    endpoint — not the service that uses it. `didcomm` and `tsp` both route
+    through the shared mediator.
   - `did-host-http-didcomm` — node whose DID exposes both a `WebVHHosting`
     service (URL-based) **and** a `DIDCommMessaging` service routed through
     a mediator. Use for nodes that publish DID logs over HTTP and accept
@@ -175,6 +176,14 @@ template without explicit scope is **context → global → builtin**:
   - `did-host-didcomm` — node whose DID exposes a `DIDCommMessaging` service
     via a shared mediator and **no** HTTP resolution endpoint. Use for
     witness, watcher, or any service consumed via DIDComm only.
+  - `did-host-http-tsp` — TSP-only sibling of `did-host-http-didcomm`:
+    exposes a `WebVHHosting` service **and** a `TSPTransport` service via a
+    mediator, but **no** DIDComm. Use for a TSP-only node that also
+    publishes DID logs over HTTP.
+  - `did-host-tsp` — TSP-only sibling of `did-host-didcomm`: exposes a single
+    `TSPTransport` service via a shared mediator and **no** HTTP resolution
+    endpoint or DIDComm. Use for a witness, watcher, or any service consumed
+    over TSP only.
 
   Legacy template names from two earlier generations still resolve to the
   renamed templates for one release: `webvh-control` / `webvh-daemon` /

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.18.17"
+version = "0.18.18"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/did_templates/builtin.rs
+++ b/vta-sdk/src/did_templates/builtin.rs
@@ -14,6 +14,8 @@ pub const BUILTIN_NAMES: &[&str] = &[
     "did-host-didcomm",
     "did-host-http",
     "did-host-http-didcomm",
+    "did-host-http-tsp",
+    "did-host-tsp",
     "didcomm-mediator",
     "push-gateway",
     "vta-admin",
@@ -29,6 +31,8 @@ const VTC_HOST: &str = include_str!("../../templates/vtc-host.json");
 const DID_HOST_HTTP_DIDCOMM: &str = include_str!("../../templates/did-host-http-didcomm.json");
 const DID_HOST_HTTP: &str = include_str!("../../templates/did-host-http.json");
 const DID_HOST_DIDCOMM: &str = include_str!("../../templates/did-host-didcomm.json");
+const DID_HOST_HTTP_TSP: &str = include_str!("../../templates/did-host-http-tsp.json");
+const DID_HOST_TSP: &str = include_str!("../../templates/did-host-tsp.json");
 
 /// Load a built-in template by name. Returns [`TemplateError::BuiltinNotFound`]
 /// for any name not in [`BUILTIN_NAMES`]. The legacy `webvh-*` / `did-hosting-*`
@@ -45,6 +49,8 @@ pub fn load_embedded(name: &str) -> Result<DidTemplate, TemplateError> {
         "did-host-http-didcomm" => DID_HOST_HTTP_DIDCOMM,
         "did-host-http" => DID_HOST_HTTP,
         "did-host-didcomm" => DID_HOST_DIDCOMM,
+        "did-host-http-tsp" => DID_HOST_HTTP_TSP,
+        "did-host-tsp" => DID_HOST_TSP,
         _ => return Err(TemplateError::BuiltinNotFound(name.to_string())),
     };
     let value: serde_json::Value = serde_json::from_str(raw)?;

--- a/vta-sdk/src/did_templates/mod.rs
+++ b/vta-sdk/src/did_templates/mod.rs
@@ -261,7 +261,7 @@ pub enum TemplateError {
     ReservedVar(String),
 
     #[error(
-        "builtin template '{0}' not found (available: ai-agent, ai-agent-peer, did-host-didcomm, did-host-http, did-host-http-didcomm, didcomm-mediator, vta-admin, vtc-host)"
+        "builtin template '{0}' not found (available: ai-agent, ai-agent-peer, did-host-didcomm, did-host-http, did-host-http-didcomm, did-host-http-tsp, did-host-tsp, didcomm-mediator, vta-admin, vtc-host)"
     )]
     BuiltinNotFound(String),
 }

--- a/vta-sdk/src/did_templates/tests.rs
+++ b/vta-sdk/src/did_templates/tests.rs
@@ -1002,3 +1002,183 @@ fn ai_agent_builtin_missing_mediator_did_errors() {
         "got: {err}"
     );
 }
+
+// ─── did-host-http-tsp built-in ──────────────────────────────────────
+//
+// TSP-only sibling of did-host-http-didcomm: advertises WebVHHosting +
+// TSPTransport but NO DIDCommMessaging, for nodes that speak TSP over the
+// mediator and publish DID logs over HTTP.
+
+fn did_host_http_tsp_fixture_vars() -> TemplateVars {
+    let mut vars = TemplateVars::new();
+    vars.insert_string("DID", "did:webvh:QmTEST:example.com");
+    vars.insert_string("SIGNING_KEY_MB", "z6MkTESTsigning");
+    vars.insert_string("KA_KEY_MB", "z6LSTESTka");
+    vars.insert_string("URL", "https://host.example.com");
+    vars.insert_string(
+        "MEDIATOR_DID",
+        "did:webvh:QmMED:mediator.example.com:mediator",
+    );
+    vars
+}
+
+#[test]
+fn did_host_http_tsp_builtin_loads_and_validates() {
+    let tpl = load_embedded("did-host-http-tsp").expect("load_embedded");
+    assert_eq!(tpl.name, "did-host-http-tsp");
+    assert_eq!(tpl.kind, "did-host-http-tsp");
+    assert_eq!(tpl.methods, vec!["webvh", "web"]);
+    assert_eq!(tpl.required_vars, vec!["URL", "MEDIATOR_DID"]);
+    tpl.validate().expect("validate after load");
+}
+
+#[test]
+fn did_host_http_tsp_advertises_hosting_then_tsp_only() {
+    let tpl = load_embedded("did-host-http-tsp").unwrap();
+    let doc = tpl.render(&did_host_http_tsp_fixture_vars()).unwrap();
+    let services = doc["service"].as_array().expect("service is array");
+    assert_eq!(
+        services.len(),
+        2,
+        "expected exactly two service entries (hosting + tsp), got {}: {services:?}",
+        services.len()
+    );
+    // HTTP resolution endpoint first, then TSP; no DIDComm entry.
+    assert_eq!(services[0]["type"], "WebVHHosting");
+    assert_eq!(
+        services[0]["serviceEndpoint"]["hostingPath"],
+        "/webvh",
+        "default hosting path applied"
+    );
+    assert_eq!(services[1]["id"], "did:webvh:QmTEST:example.com#tsp");
+    assert_eq!(services[1]["type"], "TSPTransport");
+    assert_eq!(
+        services[1]["serviceEndpoint"],
+        "did:webvh:QmMED:mediator.example.com:mediator"
+    );
+    assert!(
+        !services
+            .iter()
+            .any(|s| s["type"] == "DIDCommMessaging"
+                || s["type"] == json!(["DIDCommMessaging"])),
+        "did-host-http-tsp must not advertise DIDComm"
+    );
+}
+
+#[test]
+fn did_host_http_tsp_missing_mediator_did_errors() {
+    let tpl = load_embedded("did-host-http-tsp").unwrap();
+    let mut vars = TemplateVars::new();
+    vars.insert_string("DID", "did:webvh:QmTEST:example.com");
+    vars.insert_string("SIGNING_KEY_MB", "z6MkTESTsigning");
+    vars.insert_string("KA_KEY_MB", "z6LSTESTka");
+    vars.insert_string("URL", "https://host.example.com");
+    // MEDIATOR_DID deliberately omitted.
+
+    let err = tpl
+        .render(&vars)
+        .expect_err("missing MEDIATOR_DID must error");
+    assert!(
+        matches!(&err, TemplateError::MissingVars(m) if m.contains("MEDIATOR_DID")),
+        "got: {err}"
+    );
+}
+
+// ─── did-host-tsp built-in ───────────────────────────────────────────
+//
+// TSP-only sibling of did-host-didcomm: a single TSPTransport service,
+// no HTTP and no DIDComm. The rendered-fixture comparison is a shape
+// regression guard — downstream services build against this exact shape.
+
+const DID_HOST_TSP_RENDERED_FIXTURE: &str =
+    include_str!("../../tests/fixtures/did-host-tsp.rendered.json");
+
+fn did_host_tsp_fixture_vars() -> TemplateVars {
+    let mut vars = TemplateVars::new();
+    vars.insert_string("DID", "did:webvh:QmTEST:example.com");
+    vars.insert_string("SIGNING_KEY_MB", "z6MkTESTsigning");
+    vars.insert_string("KA_KEY_MB", "z6LSTESTka");
+    vars.insert_string(
+        "MEDIATOR_DID",
+        "did:webvh:QmMED:mediator.example.com:mediator",
+    );
+    vars
+}
+
+#[test]
+fn did_host_tsp_builtin_loads_and_validates() {
+    let tpl = load_embedded("did-host-tsp").expect("load_embedded");
+    assert_eq!(tpl.name, "did-host-tsp");
+    assert_eq!(tpl.kind, "did-host-tsp");
+    assert_eq!(tpl.methods, vec!["webvh"]);
+    assert_eq!(tpl.required_vars, vec!["MEDIATOR_DID"]);
+    tpl.validate().expect("validate after load");
+}
+
+#[test]
+fn did_host_tsp_builtin_renders_exact_document_shape() {
+    let tpl = load_embedded("did-host-tsp").unwrap();
+    let out = tpl.render(&did_host_tsp_fixture_vars()).unwrap();
+    let expected: Value =
+        serde_json::from_str(DID_HOST_TSP_RENDERED_FIXTURE).expect("fixture parses as JSON");
+    assert_eq!(
+        out, expected,
+        "rendered document diverged from fixture — if intentional, update tests/fixtures/did-host-tsp.rendered.json"
+    );
+}
+
+#[test]
+fn did_host_tsp_builtin_advertises_single_tsp_transport() {
+    // Exactly one service: TSP via the mediator. No HTTP, no DIDComm.
+    let tpl = load_embedded("did-host-tsp").unwrap();
+    let doc = tpl.render(&did_host_tsp_fixture_vars()).unwrap();
+    let services = doc["service"].as_array().expect("service is array");
+    assert_eq!(
+        services.len(),
+        1,
+        "expected exactly one service entry (tsp), got {}: {services:?}",
+        services.len()
+    );
+    assert_eq!(services[0]["id"], "did:webvh:QmTEST:example.com#tsp");
+    assert_eq!(services[0]["type"], "TSPTransport");
+    assert_eq!(
+        services[0]["serviceEndpoint"],
+        "did:webvh:QmMED:mediator.example.com:mediator"
+    );
+    assert!(
+        !services.iter().any(|s| s["type"] == "DIDCommMessaging"
+            || s["type"] == "WebVHHosting"),
+        "did-host-tsp must advertise neither DIDComm nor HTTP hosting"
+    );
+}
+
+#[test]
+fn did_host_tsp_builtin_context_is_did_v1_plus_cid_v1() {
+    let tpl = load_embedded("did-host-tsp").unwrap();
+    let doc = tpl.render(&did_host_tsp_fixture_vars()).unwrap();
+    assert_eq!(
+        doc["@context"],
+        json!([
+            "https://www.w3.org/ns/did/v1",
+            "https://www.w3.org/ns/cid/v1"
+        ])
+    );
+}
+
+#[test]
+fn did_host_tsp_builtin_missing_mediator_did_errors() {
+    let tpl = load_embedded("did-host-tsp").unwrap();
+    let mut vars = TemplateVars::new();
+    vars.insert_string("DID", "did:webvh:QmTEST:example.com");
+    vars.insert_string("SIGNING_KEY_MB", "z6MkTESTsigning");
+    vars.insert_string("KA_KEY_MB", "z6LSTESTka");
+    // MEDIATOR_DID deliberately omitted.
+
+    let err = tpl
+        .render(&vars)
+        .expect_err("missing MEDIATOR_DID must error");
+    assert!(
+        matches!(&err, TemplateError::MissingVars(m) if m.contains("MEDIATOR_DID")),
+        "got: {err}"
+    );
+}

--- a/vta-sdk/src/provision_client/ask.rs
+++ b/vta-sdk/src/provision_client/ask.rs
@@ -32,6 +32,8 @@ pub const BUILTIN_VTA_ADMIN_TEMPLATE: &str = "vta-admin";
 pub const BUILTIN_DID_HOST_HTTP_DIDCOMM_TEMPLATE: &str = "did-host-http-didcomm";
 pub const BUILTIN_DID_HOST_HTTP_TEMPLATE: &str = "did-host-http";
 pub const BUILTIN_DID_HOST_DIDCOMM_TEMPLATE: &str = "did-host-didcomm";
+pub const BUILTIN_DID_HOST_HTTP_TSP_TEMPLATE: &str = "did-host-http-tsp";
+pub const BUILTIN_DID_HOST_TSP_TEMPLATE: &str = "did-host-tsp";
 
 /// Default validity on a wizard-issued VP for the online path — chosen to
 /// comfortably cover the round-trip with the verifier's ±5min skew margin
@@ -140,6 +142,40 @@ impl ProvisionAsk {
             Value::String(mediator_did.into()),
         );
         Self::for_template(BUILTIN_DID_HOST_DIDCOMM_TEMPLATE, vars, context)
+    }
+
+    /// Curated builder for the built-in `did-host-http-tsp` template.
+    /// Mints a node's DID with both a `WebVHHosting` service (HTTP
+    /// resolution endpoint) at `host_url` and a `TSPTransport` service
+    /// routed through `mediator_did` — but no DIDComm. Use for a TSP-only
+    /// node that also publishes DID logs over HTTP. Use
+    /// [`Self::did_host_http_didcomm`] if the node must also accept DIDComm.
+    pub fn did_host_http_tsp(
+        context: impl Into<String>,
+        host_url: impl Into<String>,
+        mediator_did: impl Into<String>,
+    ) -> Self {
+        let mut vars = BTreeMap::new();
+        vars.insert("URL".to_string(), Value::String(host_url.into()));
+        vars.insert(
+            "MEDIATOR_DID".to_string(),
+            Value::String(mediator_did.into()),
+        );
+        Self::for_template(BUILTIN_DID_HOST_HTTP_TSP_TEMPLATE, vars, context)
+    }
+
+    /// Curated builder for the built-in `did-host-tsp` template.
+    /// Mints a witness/watcher/server DID that talks TSP through
+    /// `mediator_did` and exposes neither an HTTP resolution endpoint nor
+    /// DIDComm. The DID document carries only a `TSPTransport` service.
+    /// Use [`Self::did_host_didcomm`] if the node needs DIDComm instead.
+    pub fn did_host_tsp(context: impl Into<String>, mediator_did: impl Into<String>) -> Self {
+        let mut vars = BTreeMap::new();
+        vars.insert(
+            "MEDIATOR_DID".to_string(),
+            Value::String(mediator_did.into()),
+        );
+        Self::for_template(BUILTIN_DID_HOST_TSP_TEMPLATE, vars, context)
     }
 
     /// Curated builder for the built-in `vta-admin` template — mint a

--- a/vta-sdk/templates/did-host-http-tsp.json
+++ b/vta-sdk/templates/did-host-http-tsp.json
@@ -1,0 +1,57 @@
+{
+  "schemaVersion": 1,
+  "name": "did-host-http-tsp",
+  "kind": "did-host-http-tsp",
+  "description": "DID-hosting node whose DID advertises both an HTTP resolution endpoint (WebVHHosting) AND a TSP endpoint (TSPTransport via a shared mediator) — but NO DIDComm. Use this for a TSP-only node that also publishes DID logs over HTTP (admin RPC, witness coordination, control-plane traffic all carried over TSP). A node that must also accept DIDComm should use 'did-host-http-didcomm'; a TSP-only node with no public URL should use 'did-host-tsp'; an HTTP-only node with no messaging transport should use 'did-host-http'.",
+  "methods": ["webvh", "web"],
+  "requiredVars": ["URL", "MEDIATOR_DID"],
+  "optionalVars": {
+    "HOSTING_PATH": "/webvh",
+    "WEBVH_SERVER": null
+  },
+  "defaults": {
+    "preRotationCount": 2,
+    "portable": false,
+    "addMediatorService": false
+  },
+  "document": {
+    "@context": [
+      "https://www.w3.org/ns/did/v1",
+      "https://www.w3.org/ns/cid/v1",
+      "https://w3id.org/security/multikey/v1"
+    ],
+    "id": "{DID}",
+    "verificationMethod": [
+      {
+        "id": "{DID}#key-0",
+        "type": "Multikey",
+        "controller": "{DID}",
+        "publicKeyMultibase": "{SIGNING_KEY_MB}"
+      },
+      {
+        "id": "{DID}#key-1",
+        "type": "Multikey",
+        "controller": "{DID}",
+        "publicKeyMultibase": "{KA_KEY_MB}"
+      }
+    ],
+    "assertionMethod": ["{DID}#key-0"],
+    "authentication": ["{DID}#key-0"],
+    "keyAgreement": ["{DID}#key-1"],
+    "service": [
+      {
+        "id": "{DID}#webvh-hosting",
+        "type": "WebVHHosting",
+        "serviceEndpoint": {
+          "uri": "{URL}",
+          "hostingPath": "{HOSTING_PATH}"
+        }
+      },
+      {
+        "id": "{DID}#tsp",
+        "type": "TSPTransport",
+        "serviceEndpoint": "{MEDIATOR_DID}"
+      }
+    ]
+  }
+}

--- a/vta-sdk/templates/did-host-tsp.json
+++ b/vta-sdk/templates/did-host-tsp.json
@@ -1,0 +1,47 @@
+{
+  "schemaVersion": 1,
+  "name": "did-host-tsp",
+  "kind": "did-host-tsp",
+  "description": "DID-hosting node whose DID advertises a TSP endpoint (TSPTransport via a shared mediator) only — no HTTP resolution endpoint and no DIDComm. Use this for a witness, watcher, or any service whose role is consumed over TSP rather than an inbound URL or DIDComm. The DID document carries a single TSPTransport service pointing at the mediator. URL or WEBVH_SERVER is still required at provision time so the VTA knows where to publish the did:webvh log itself, but neither appears in the rendered document. Nodes that also need DIDComm should use 'did-host-didcomm'; nodes that advertise an HTTP endpoint alongside TSP should use 'did-host-http-tsp'.",
+  "methods": ["webvh"],
+  "requiredVars": ["MEDIATOR_DID"],
+  "optionalVars": {
+    "URL": null,
+    "WEBVH_SERVER": null
+  },
+  "defaults": {
+    "preRotationCount": 2,
+    "portable": true
+  },
+  "document": {
+    "@context": [
+      "https://www.w3.org/ns/did/v1",
+      "https://www.w3.org/ns/cid/v1"
+    ],
+    "id": "{DID}",
+    "verificationMethod": [
+      {
+        "id": "{DID}#key-0",
+        "type": "Multikey",
+        "controller": "{DID}",
+        "publicKeyMultibase": "{SIGNING_KEY_MB}"
+      },
+      {
+        "id": "{DID}#key-1",
+        "type": "Multikey",
+        "controller": "{DID}",
+        "publicKeyMultibase": "{KA_KEY_MB}"
+      }
+    ],
+    "assertionMethod": ["{DID}#key-0"],
+    "authentication": ["{DID}#key-0"],
+    "keyAgreement": ["{DID}#key-1"],
+    "service": [
+      {
+        "id": "{DID}#tsp",
+        "type": "TSPTransport",
+        "serviceEndpoint": "{MEDIATOR_DID}"
+      }
+    ]
+  }
+}

--- a/vta-sdk/tests/fixtures/did-host-tsp.rendered.json
+++ b/vta-sdk/tests/fixtures/did-host-tsp.rendered.json
@@ -1,0 +1,31 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    "https://www.w3.org/ns/cid/v1"
+  ],
+  "id": "did:webvh:QmTEST:example.com",
+  "verificationMethod": [
+    {
+      "id": "did:webvh:QmTEST:example.com#key-0",
+      "type": "Multikey",
+      "controller": "did:webvh:QmTEST:example.com",
+      "publicKeyMultibase": "z6MkTESTsigning"
+    },
+    {
+      "id": "did:webvh:QmTEST:example.com#key-1",
+      "type": "Multikey",
+      "controller": "did:webvh:QmTEST:example.com",
+      "publicKeyMultibase": "z6LSTESTka"
+    }
+  ],
+  "assertionMethod": ["did:webvh:QmTEST:example.com#key-0"],
+  "authentication": ["did:webvh:QmTEST:example.com#key-0"],
+  "keyAgreement": ["did:webvh:QmTEST:example.com#key-1"],
+  "service": [
+    {
+      "id": "did:webvh:QmTEST:example.com#tsp",
+      "type": "TSPTransport",
+      "serviceEndpoint": "did:webvh:QmMED:mediator.example.com:mediator"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds two built-in `did-host-*` DID templates that advertise **TSP without DIDComm**, closing the gap where the only mediator-carrying `did-host-*` templates (`did-host-http-didcomm`, `did-host-didcomm`) advertised **both** transports unconditionally. This is the upstream half needed so a VTA can provision a **TSP-only** node — e.g. a `did-hosting` service run in TSP-only mode.

## What changed

- **`did-host-http-tsp`** — `WebVHHosting` + `TSPTransport` (via a shared mediator), **no** DIDComm. TSP-only sibling of `did-host-http-didcomm`.
- **`did-host-tsp`** — `TSPTransport` only, **no** HTTP and **no** DIDComm. TSP-only sibling of `did-host-didcomm`.
- Registered both as built-ins (`BUILTIN_NAMES`, `load_embedded`, `BuiltinNotFound` help text).
- Exposed curated `ProvisionAsk::did_host_http_tsp` / `ProvisionAsk::did_host_tsp` builders plus `BUILTIN_DID_HOST_HTTP_TSP_TEMPLATE` / `BUILTIN_DID_HOST_TSP_TEMPLATE` constants, matching the existing typed-builder surface.
- Rendered-shape fixture (`tests/fixtures/did-host-tsp.rendered.json`) + per-template tests lock the document shape (service count, `#tsp` `TSPTransport` endpoint, `@context`, missing-`MEDIATOR_DID` error).
- Updated `docs/02-vta/did-templates.md` and `CHANGELOG.md`; bumped `vta-sdk` 0.18.17 → 0.18.18.

The `#tsp` service `type` is `TSPTransport` and points at the shared mediator, consistent with the existing dual-transport templates and the `tsp-enablement` design note (type-based discovery, `#tsp` id fragment).

## Compatibility

Purely additive — existing templates, names, rendered shapes, and builders are unchanged. `Cargo.lock` only reflects the version bump.

## Downstream

Pairs with `affinidi-webvh-service` PR #64 (TSP-only transport selection). Once this publishes, the webvh-service wizard/recipe can select `did-host-http-tsp` / `did-host-tsp` for VTA-provisioned TSP-only nodes, so the VTA-provisioned DID document advertises only the transport(s) the node actually listens on.

## Testing

- `cargo test -p vta-sdk` — 168 pass, 0 fail (incl. 8 new template tests)
- `cargo clippy -p vta-sdk --all-targets -- -D warnings` — clean