### PR TITLE
fix(vta-sdk): shut down transient DIDComm session in integration::startup

### DIFF
--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.18.18"
+version = "0.18.19"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/integration/mod.rs
+++ b/vta-sdk/src/integration/mod.rs
@@ -232,7 +232,13 @@ pub struct StartupResult {
     pub source: SecretSource,
     /// The authenticated VTA client, if secrets were fetched live.
     /// `None` when secrets came from the local cache.
-    /// Services can use this for additional VTA calls (e.g., health checks).
+    ///
+    /// Its live DIDComm mediator session (if any) has **already been shut
+    /// down** by [`startup`] — the client is retained only for
+    /// REST-backed follow-up calls such as [`health`](crate::client::VtaClient::health),
+    /// which never touch the live session. Do **not** rely on it for
+    /// further DIDComm round-trips; open a fresh scoped client
+    /// ([`with_didcomm`](crate::client::VtaClient::with_didcomm)) for those.
     pub client: Option<crate::client::VtaClient>,
 }
 
@@ -285,6 +291,10 @@ impl From<VtaError> for VtaIntegrationError {
 ///
 /// Returns a [`StartupResult`] containing the service DID, secrets bundle,
 /// and whether the secrets are fresh or cached.
+///
+/// The DIDComm session used to fetch the bundle is **transient**: it is
+/// shut down before this function returns, so no auto-reconnecting
+/// mediator socket outlives the call. See [`StartupResult::client`].
 pub async fn startup(
     config: &VtaServiceConfig,
     cache: &(impl SecretCache + ?Sized),
@@ -305,6 +315,10 @@ pub async fn startup(
     match vta_result {
         Ok(Ok((client, bundle))) => {
             if bundle.secrets.is_empty() {
+                // Tear the transient session down before bailing — the
+                // early return would otherwise drop `client` without
+                // `shutdown()`, leaking a live session (see below).
+                client.shutdown().await;
                 return Err(VtaIntegrationError::EmptySecretsBundle(context_id.clone()));
             }
             if let Err(e) = cache.store(&bundle).await {
@@ -315,6 +329,20 @@ pub async fn startup(
                 secrets = bundle.secrets.len(),
                 "Loaded fresh secrets from VTA",
             );
+            // The bundle fetch is the only thing that needs the live
+            // DIDComm session. Shut it down here, at the source, so the
+            // auto-reconnecting mediator socket a DIDComm `VtaClient` owns
+            // can never outlive this call — regardless of whether the
+            // caller remembers to `shutdown()`. Callers (mediator boot +
+            // hourly `vta_refresh`) that drop `StartupResult.client`
+            // without shutting it down were leaking one live session per
+            // `startup()`; two live sessions for the same DID displace
+            // each other forever at the mediator's one-socket-per-DID
+            // gate, producing an endless duplicate-WebSocket churn storm.
+            // `shutdown()` is a no-op for REST and idempotent, so the
+            // returned client stays usable for REST-backed follow-ups
+            // (e.g. `health()`, which never uses the live session).
+            client.shutdown().await;
             Ok(StartupResult {
                 did: bundle.did.clone(),
                 bundle,


### PR DESCRIPTION
## Problem

A VTA's mediator was stuck in a dual-WebSocket **churn storm** — the mediator logged **3,164 \"Duplicate WebSocket connection\" replacements in ~2 hours** (~1 flip every 2s, 93% flagged `churn=true`), all for a single `did:key` (the mediator's own hourly VTA-refresh client).

## Root cause

`vta_sdk::integration::startup()` fetches the secrets bundle over a DIDComm `VtaClient`, which **owns a live, auto-reconnecting mediator WebSocket session** (documented at `client/mod.rs:406` — *"failing to call `shutdown` leaks the session and causes duplicate-WebSocket mediator duels"*).

`startup()` handed that live client back in `StartupResult.client`. Its callers in the mediator (`vta_refresh.rs` hourly + boot `config/mod.rs`) read only `.bundle`/`.source` and **dropped the client without calling `.shutdown()`** — leaking one live session per `startup()`. Two+ live sessions for the same DID displace each other forever at the mediator's one-socket-per-DID gate → endless churn.

The SDK's exponential reconnect backoff never dampens this because it resets to 0 on every *successful* connect, and a displacement is a successful-then-immediately-closed connect.

## Fix

`startup()` now shuts the transient DIDComm session down **before returning**, at the source, so no auto-reconnecting socket can outlive the call — regardless of whether callers remember to `shutdown()`. `health()` uses the REST fallback (not the live session), so the mediator's post-startup circular-dependency health check still works.

- `vta-sdk` 0.18.18 → 0.18.19 (internal deps pin `0.18`, no dependent bumps)

## Testing

- `cargo check -p vta-sdk --features integration` ✅
- `cargo test -p vta-sdk --features integration --lib integration::` — 9 passed ✅

## Related

Companion mediator-side log-noise fix in affinidi-tdk-rs (`fix-ws-churn-noise`): rapid duplicate-WebSocket churn logged at DEBUG instead of WARN.