### PR TITLE
feat(vta-sdk): reactive re-auth on 401/403 + startup fallback reason (0.18.20)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2452,7 +2452,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.18.18",
+ "vta-sdk 0.18.20",
 ]
 
 [[package]]
@@ -3254,7 +3254,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.18.18",
+ "vta-sdk 0.18.20",
 ]
 
 [[package]]
@@ -6714,7 +6714,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.18.18",
+ "vta-sdk 0.18.20",
 ]
 
 [[package]]
@@ -10016,7 +10016,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.18.18",
+ "vta-sdk 0.18.20",
  "vti-common",
  "x25519-dalek",
 ]
@@ -10049,7 +10049,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.18.18",
+ "vta-sdk 0.18.20",
 ]
 
 [[package]]
@@ -10072,7 +10072,7 @@ dependencies = [
  "tracing-subscriber",
  "trust-tasks-rs",
  "uniffi",
- "vta-sdk 0.18.18",
+ "vta-sdk 0.18.20",
 ]
 
 [[package]]
@@ -10107,7 +10107,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.18.18"
+version = "0.18.20"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10240,7 +10240,7 @@ dependencies = [
  "utoipa-axum",
  "uuid",
  "vta-cli-common",
- "vta-sdk 0.18.18",
+ "vta-sdk 0.18.20",
  "vta-service",
  "vti-common",
  "vti-secrets",
@@ -10262,7 +10262,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.18.18",
+ "vta-sdk 0.18.20",
 ]
 
 [[package]]
@@ -10334,7 +10334,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.18.18",
+ "vta-sdk 0.18.20",
  "vtc-service",
  "vti-common",
  "vti-secrets",
@@ -10382,7 +10382,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.18.18",
+ "vta-sdk 0.18.20",
  "webauthn-rs",
  "zeroize",
 ]
@@ -10409,7 +10409,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.18.18",
+ "vta-sdk 0.18.20",
  "vta-service",
  "vti-common",
 ]
@@ -10438,7 +10438,7 @@ dependencies = [
  "tokio",
  "tracing",
  "vaultrs",
- "vta-sdk 0.18.18",
+ "vta-sdk 0.18.20",
  "vti-common",
 ]
 

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.18.19"
+version = "0.18.20"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/client/mod.rs
+++ b/vta-sdk/src/client/mod.rs
@@ -15,6 +15,7 @@ use reqwest::{Client, RequestBuilder};
 // ── Internal transport ──────────────────────────────────────────────
 
 /// Stored credential for automatic token refresh.
+#[derive(Clone)]
 pub(super) struct AuthCredential {
     pub(super) did: String,
     pub(super) private_key_multibase: String,
@@ -538,6 +539,107 @@ impl VtaClient {
         Ok(())
     }
 
+    /// Force a **full** re-authentication (challenge-response), discarding
+    /// the cached access token *and* the refresh token. Unlike
+    /// [`ensure_token_valid`](Self::ensure_token_valid) — which trusts the
+    /// locally stored expiry — this is the reaction to the VTA actually
+    /// rejecting a request (401/403): the token the local clock believed
+    /// valid is stale server-side (clock skew, a VTA restart, or a
+    /// refresh-rotation desync), so both cached tokens are cleared before
+    /// re-authenticating from the stored credential.
+    ///
+    /// Returns `Ok(true)` if a re-auth ran, `Ok(false)` if no credential is
+    /// stored (nothing to retry with — e.g. a client given only a bare
+    /// token via [`set_token`](Self::set_token)).
+    pub(super) async fn force_reauth(
+        client: &Client,
+        base_url: &str,
+        auth: &tokio::sync::Mutex<RestAuth>,
+    ) -> Result<bool, VtaError> {
+        let cred = {
+            let mut guard = auth.lock().await;
+            let Some(cred) = guard.credential.clone() else {
+                return Ok(false);
+            };
+            // Invalidate every cached token up front so a racing
+            // `ensure_token_valid` can't hand back the just-rejected token.
+            guard.token = None;
+            guard.expires_at = None;
+            guard.refresh_token = None;
+            guard.refresh_expires_at = None;
+            cred
+        };
+
+        let result = crate::auth_light::challenge_response_light(
+            client,
+            base_url,
+            &cred.did,
+            &cred.private_key_multibase,
+            &cred.vta_did,
+        )
+        .await?;
+
+        let mut guard = auth.lock().await;
+        guard.token = Some(result.access_token);
+        guard.expires_at = Some(result.access_expires_at);
+        guard.refresh_token = result.refresh_token;
+        guard.refresh_expires_at = result.refresh_expires_at;
+        Ok(true)
+    }
+
+    /// Send an authenticated REST request, with a single reactive
+    /// re-auth-and-retry on a 401/403.
+    ///
+    /// Proactive refresh ([`ensure_token_valid`](Self::ensure_token_valid))
+    /// only reacts to the *local* clock; it can't catch a token the VTA
+    /// invalidated out-of-band. So if the response is `401`/`403`, we
+    /// [`force_reauth`](Self::force_reauth) once and replay the request,
+    /// turning a transient auth rejection into a self-heal instead of a
+    /// propagated error. The retry needs a cloneable request body
+    /// ([`RequestBuilder::try_clone`]); JSON bodies clone fine, streaming
+    /// bodies don't and simply skip the retry. A persistent denial (e.g. an
+    /// expired ACL entry) still surfaces — the replay is rejected too.
+    ///
+    /// `req` must be the request **before** the bearer token is attached;
+    /// this helper attaches it (and re-attaches the fresh one on retry).
+    pub(super) async fn send_authed(
+        client: &Client,
+        base_url: &str,
+        auth: &tokio::sync::Mutex<RestAuth>,
+        req: RequestBuilder,
+    ) -> Result<reqwest::Response, VtaError> {
+        Self::ensure_token_valid(client, base_url, auth).await?;
+        let retry_req = req.try_clone();
+        let token = auth.lock().await.token.clone();
+        let resp = Self::with_auth_token(req, &token).send().await?;
+
+        let status = resp.status();
+        if matches!(
+            status,
+            reqwest::StatusCode::UNAUTHORIZED | reqwest::StatusCode::FORBIDDEN
+        ) && let Some(retry_req) = retry_req
+        {
+            match Self::force_reauth(client, base_url, auth).await {
+                Ok(true) => {
+                    let token = auth.lock().await.token.clone();
+                    return Ok(Self::with_auth_token(retry_req, &token).send().await?);
+                }
+                // No credential to re-auth with — surface the original 401/403.
+                Ok(false) => {}
+                // Re-auth itself failed — keep the original response rather
+                // than masking the server's verdict with a transport error.
+                Err(e) => {
+                    tracing::debug!(
+                        %status,
+                        error = %e,
+                        "re-auth after auth rejection failed; surfacing original response"
+                    );
+                }
+            }
+        }
+        Ok(resp)
+    }
+
     /// Dispatch an RPC call via REST (using `build_rest`) or DIDComm (using
     /// `msg_type`/`body`/`result_type`), returning a deserialized response.
     #[allow(unused_variables)]
@@ -555,10 +657,8 @@ impl VtaClient {
                 base_url,
                 auth,
             } => {
-                Self::ensure_token_valid(client, base_url, auth).await?;
-                let token = auth.lock().await.token.clone();
                 let req = build_rest(client, base_url);
-                let resp = Self::with_auth_token(req, &token).send().await?;
+                let resp = Self::send_authed(client, base_url, auth, req).await?;
                 Self::handle_response(resp).await
             }
             #[cfg(feature = "session")]
@@ -586,10 +686,8 @@ impl VtaClient {
                 base_url,
                 auth,
             } => {
-                Self::ensure_token_valid(client, base_url, auth).await?;
-                let token = auth.lock().await.token.clone();
                 let req = build_rest(client, base_url);
-                let resp = Self::with_auth_token(req, &token).send().await?;
+                let resp = Self::send_authed(client, base_url, auth, req).await?;
                 Self::handle_delete_response(resp).await
             }
             #[cfg(feature = "session")]
@@ -624,10 +722,8 @@ impl VtaClient {
                 base_url,
                 auth,
             } => {
-                Self::ensure_token_valid(client, base_url, auth).await?;
-                let token = auth.lock().await.token.clone();
                 let req = build_rest(client, base_url);
-                let resp = Self::with_auth_token(req, &token).send().await?;
+                let resp = Self::send_authed(client, base_url, auth, req).await?;
                 Self::handle_response(resp).await
             }
             #[cfg(feature = "session")]
@@ -655,10 +751,8 @@ impl VtaClient {
                 base_url,
                 auth,
             } => {
-                Self::ensure_token_valid(client, base_url, auth).await?;
-                let token = auth.lock().await.token.clone();
                 let req = build_rest(client, base_url);
-                let resp = Self::with_auth_token(req, &token).send().await?;
+                let resp = Self::send_authed(client, base_url, auth, req).await?;
                 Self::handle_delete_response(resp).await
             }
             #[cfg(feature = "session")]
@@ -705,12 +799,10 @@ impl VtaClient {
                 base_url,
                 auth,
             } => {
-                Self::ensure_token_valid(client, base_url, auth).await?;
-                let token = auth.lock().await.token.clone();
                 let req = client
                     .post(format!("{base_url}/api/trust-tasks"))
                     .json(&doc);
-                let resp = Self::with_auth_token(req, &token).send().await?;
+                let resp = Self::send_authed(client, base_url, auth, req).await?;
                 if !resp.status().is_success() {
                     let status = resp.status();
                     let body = resp.text().await.unwrap_or_default();

--- a/vta-sdk/src/integration/mod.rs
+++ b/vta-sdk/src/integration/mod.rs
@@ -222,6 +222,41 @@ pub enum SecretSource {
     Cache,
 }
 
+/// Why [`startup`] fell back to the local cache instead of loading fresh
+/// secrets from the VTA. Present only when [`SecretSource::Cache`].
+///
+/// Callers use this to log the right severity and take the right action:
+/// [`AuthDenied`](Self::AuthDenied) is an authorization problem the
+/// operator must fix (the VTA rejected an otherwise-reachable request),
+/// whereas [`Unreachable`](Self::Unreachable)/[`Timeout`](Self::Timeout)
+/// are transient connectivity that a later refresh clears on its own.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FallbackReason {
+    /// The VTA answered but **rejected** the request — HTTP 401/403 or the
+    /// DIDComm `unauthorized`/`forbidden` problem-report. The credential or
+    /// its authorization (e.g. an expired ACL entry) needs attention;
+    /// re-fetching won't self-heal until that's resolved.
+    AuthDenied,
+    /// The VTA could not be reached (network/transport error, DIDComm
+    /// session failure, non-auth VTA error). Typically transient.
+    Unreachable,
+    /// The startup round-trip exceeded the configured timeout.
+    Timeout,
+}
+
+impl FallbackReason {
+    /// Classify a [`VtaError`] surfaced by a failed VTA round-trip into the
+    /// reason `startup` fell back to cache. `Auth` (401 / `unauthorized`)
+    /// and `Forbidden` (403 / `forbidden`) are authorization denials;
+    /// everything else is treated as unreachable.
+    fn from_vta_error(err: &VtaIntegrationError) -> Self {
+        match err {
+            VtaIntegrationError::Vta(e) if e.is_auth() => FallbackReason::AuthDenied,
+            _ => FallbackReason::Unreachable,
+        }
+    }
+}
+
 /// Successful result from [`startup`].
 pub struct StartupResult {
     /// The service's DID, as recorded in the VTA context.
@@ -240,6 +275,14 @@ pub struct StartupResult {
     /// further DIDComm round-trips; open a fresh scoped client
     /// ([`with_didcomm`](crate::client::VtaClient::with_didcomm)) for those.
     pub client: Option<crate::client::VtaClient>,
+    /// Why a VTA round-trip *failed* and forced the cached bundle. `Some`
+    /// only with [`SecretSource::Cache`], distinguishing an authorization
+    /// denial ([`FallbackReason::AuthDenied`]) from transient
+    /// unreachability so callers can log/alert appropriately. `None` when
+    /// secrets are fresh from the VTA ([`SecretSource::Vta`]) **or** when a
+    /// caller loaded the cache without attempting the VTA at all (no
+    /// failure to report).
+    pub fallback: Option<FallbackReason>,
 }
 
 /// Errors from the VTA integration startup flow.
@@ -348,15 +391,18 @@ pub async fn startup(
                 bundle,
                 source: SecretSource::Vta,
                 client: Some(client),
+                fallback: None,
             })
         }
         Ok(Err(e)) => {
+            let reason = FallbackReason::from_vta_error(&e);
             tracing::warn!(
                 context = context_id,
                 error = %e,
+                reason = ?reason,
                 "VTA call failed; attempting fallback to last-known cached bundle",
             );
-            load_from_cache(cache, context_id).await
+            load_from_cache(cache, context_id, reason).await
         }
         Err(_elapsed) => {
             tracing::warn!(
@@ -364,7 +410,7 @@ pub async fn startup(
                 timeout_secs = timeout.as_secs(),
                 "VTA startup timed out; attempting fallback to last-known cached bundle",
             );
-            load_from_cache(cache, context_id).await
+            load_from_cache(cache, context_id, FallbackReason::Timeout).await
         }
     }
 }
@@ -372,6 +418,7 @@ pub async fn startup(
 async fn load_from_cache(
     cache: &(impl SecretCache + ?Sized),
     context: &str,
+    reason: FallbackReason,
 ) -> Result<StartupResult, VtaIntegrationError> {
     match cache.load().await {
         Ok(Some(bundle)) => {
@@ -389,6 +436,7 @@ async fn load_from_cache(
                 bundle,
                 source: SecretSource::Cache,
                 client: None,
+                fallback: Some(reason),
             })
         }
         Ok(None) => {
@@ -494,22 +542,56 @@ mod tests {
     #[tokio::test]
     async fn load_from_cache_returns_fresh_bundle_when_present() {
         let cache = MockSecretCache::with_cached(sample_bundle());
-        let result = load_from_cache(&cache, "prod-mediator")
+        let result = load_from_cache(&cache, "prod-mediator", FallbackReason::AuthDenied)
             .await
             .expect("cache hit returns StartupResult");
         assert_eq!(result.source, SecretSource::Cache);
         assert_eq!(result.did, "did:key:z6MkSampleIntegration");
         assert_eq!(result.bundle.secrets.len(), 1);
+        assert_eq!(
+            result.fallback,
+            Some(FallbackReason::AuthDenied),
+            "cache fallback carries the reason it was triggered",
+        );
         assert!(
             result.client.is_none(),
             "Cache-source startup never carries a live VtaClient",
         );
     }
 
+    #[test]
+    fn fallback_reason_classifies_auth_errors() {
+        use crate::error::VtaError;
+        // 401 / 403 → the VTA rejected the request: an authorization problem.
+        assert_eq!(
+            FallbackReason::from_vta_error(&VtaIntegrationError::Vta(VtaError::Forbidden(
+                "acl expired".into()
+            ))),
+            FallbackReason::AuthDenied,
+        );
+        assert_eq!(
+            FallbackReason::from_vta_error(&VtaIntegrationError::Vta(VtaError::Auth(
+                "token rejected".into()
+            ))),
+            FallbackReason::AuthDenied,
+        );
+        // Anything else is treated as (transient) unreachability.
+        assert_eq!(
+            FallbackReason::from_vta_error(&VtaIntegrationError::Vta(VtaError::NotFound(
+                "no context".into()
+            ))),
+            FallbackReason::Unreachable,
+        );
+        assert_eq!(
+            FallbackReason::from_vta_error(&VtaIntegrationError::NoCachedSecrets),
+            FallbackReason::Unreachable,
+        );
+    }
+
     #[tokio::test]
     async fn load_from_cache_empty_returns_no_cached_secrets() {
         let cache = MockSecretCache::empty();
-        let result = load_from_cache(&cache, "prod-mediator").await;
+        let result = load_from_cache(&cache, "prod-mediator", FallbackReason::Unreachable).await;
         match result {
             Err(VtaIntegrationError::NoCachedSecrets) => {}
             Err(other) => panic!("expected NoCachedSecrets, got {other:?}"),
@@ -520,7 +602,7 @@ mod tests {
     #[tokio::test]
     async fn load_from_cache_io_error_becomes_cache_error() {
         let cache = MockSecretCache::failing("keyring unavailable");
-        let result = load_from_cache(&cache, "prod-mediator").await;
+        let result = load_from_cache(&cache, "prod-mediator", FallbackReason::Unreachable).await;
         match result {
             Err(VtaIntegrationError::CacheError(msg)) => {
                 assert!(msg.contains("keyring unavailable"), "got: {msg}")
@@ -539,7 +621,7 @@ mod tests {
             did: "did:key:zEmpty".into(),
             secrets: vec![],
         });
-        let result = load_from_cache(&cache, "prod-mediator").await;
+        let result = load_from_cache(&cache, "prod-mediator", FallbackReason::Timeout).await;
         match result {
             Err(VtaIntegrationError::EmptySecretsBundle(ctx)) => {
                 assert_eq!(ctx, "prod-mediator")


### PR DESCRIPTION
## Why

Fixes the *"works, then hourly 403"* failure mode a mediator hits when refreshing secrets from the VTA. Two independent robustness gaps:

1. **No reactive re-auth on a rejected token.** `ensure_token_valid` only reacts to the *local* clock, so a token the VTA invalidated out-of-band (clock skew, VTA restart, refresh-rotation desync) produced a hard 401/403 with no self-heal.
2. **`integration::startup` swallowed the reason it fell back to cache.** A 403, a timeout, and a network outage all collapsed into `SecretSource::Cache` with the error dropped, so callers (e.g. the mediator's hourly refresh) couldn't distinguish an *authorization denial* from *transient unreachability* — and logged both as "VTA unreachable".

## What

**1. REST reactive re-auth + retry-once (401/403).**
New `send_authed` helper `try_clone`s the request and, on a 401/403, runs a full `force_reauth` (clears the cached access **and** refresh token) then replays the request a single time. Wired into `rpc` / `rpc_void` / `rpc_tt` / `rpc_tt_void` / `dispatch_trust_task`.
- A persistent denial (e.g. an expired ACL entry) still surfaces — the replay is rejected too.
- Streaming bodies that can't `try_clone` simply skip the retry.
- The **DIDComm** `Forbidden` path stays non-retried: it's an application-layer authz problem-report, not a stale transport token, so reconnecting wouldn't clear it.

**2. `FallbackReason` on `StartupResult`.**
New `FallbackReason` enum (`AuthDenied` / `Unreachable` / `Timeout`) exposed via `StartupResult.fallback`, populated on the `Ok(Err)` and timeout arms of `startup` by classifying the `VtaError` (`is_auth()` → `AuthDenied`, else `Unreachable`). Lets a caller log/alert at the right severity.

## Compatibility

Additive: a new enum, a new struct field on `StartupResult`, and a reused `VtaError::is_auth()`. Bumped to **0.18.20**.

Downstream `affinidi-messaging-mediator` consumes `StartupResult.fallback` to surface a VTA 403 loudly instead of masking it — that PR requires this release to be published first.

## Test

- `cargo build`/`clippy --all-features --all-targets` clean.
- `cargo test --lib --all-features`: 429 passed, incl. a new `fallback_reason_classifies_auth_errors` unit test and updated `load_from_cache` tests.