### PR TITLE
fix(vta-sdk): make startup fallback-reason non-breaking (0.18.21)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2452,7 +2452,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.18.20",
+ "vta-sdk 0.18.21",
 ]
 
 [[package]]
@@ -3254,7 +3254,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.18.20",
+ "vta-sdk 0.18.21",
 ]
 
 [[package]]
@@ -6714,7 +6714,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.18.20",
+ "vta-sdk 0.18.21",
 ]
 
 [[package]]
@@ -10016,7 +10016,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.18.20",
+ "vta-sdk 0.18.21",
  "vti-common",
  "x25519-dalek",
 ]
@@ -10049,7 +10049,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.18.20",
+ "vta-sdk 0.18.21",
 ]
 
 [[package]]
@@ -10072,7 +10072,7 @@ dependencies = [
  "tracing-subscriber",
  "trust-tasks-rs",
  "uniffi",
- "vta-sdk 0.18.20",
+ "vta-sdk 0.18.21",
 ]
 
 [[package]]
@@ -10107,7 +10107,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.18.20"
+version = "0.18.21"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10240,7 +10240,7 @@ dependencies = [
  "utoipa-axum",
  "uuid",
  "vta-cli-common",
- "vta-sdk 0.18.20",
+ "vta-sdk 0.18.21",
  "vta-service",
  "vti-common",
  "vti-secrets",
@@ -10262,7 +10262,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.18.20",
+ "vta-sdk 0.18.21",
 ]
 
 [[package]]
@@ -10334,7 +10334,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.18.20",
+ "vta-sdk 0.18.21",
  "vtc-service",
  "vti-common",
  "vti-secrets",
@@ -10382,7 +10382,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.18.20",
+ "vta-sdk 0.18.21",
  "webauthn-rs",
  "zeroize",
 ]
@@ -10409,7 +10409,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.18.20",
+ "vta-sdk 0.18.21",
  "vta-service",
  "vti-common",
 ]
@@ -10438,7 +10438,7 @@ dependencies = [
  "tokio",
  "tracing",
  "vaultrs",
- "vta-sdk 0.18.20",
+ "vta-sdk 0.18.21",
  "vti-common",
 ]
 

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.18.20"
+version = "0.18.21"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/integration/mod.rs
+++ b/vta-sdk/src/integration/mod.rs
@@ -222,8 +222,9 @@ pub enum SecretSource {
     Cache,
 }
 
-/// Why [`startup`] fell back to the local cache instead of loading fresh
-/// secrets from the VTA. Present only when [`SecretSource::Cache`].
+/// Why [`startup_with_reason`] fell back to the local cache instead of
+/// loading fresh secrets from the VTA. Returned alongside a
+/// [`SecretSource::Cache`] result.
 ///
 /// Callers use this to log the right severity and take the right action:
 /// [`AuthDenied`](Self::AuthDenied) is an authorization problem the
@@ -275,14 +276,6 @@ pub struct StartupResult {
     /// further DIDComm round-trips; open a fresh scoped client
     /// ([`with_didcomm`](crate::client::VtaClient::with_didcomm)) for those.
     pub client: Option<crate::client::VtaClient>,
-    /// Why a VTA round-trip *failed* and forced the cached bundle. `Some`
-    /// only with [`SecretSource::Cache`], distinguishing an authorization
-    /// denial ([`FallbackReason::AuthDenied`]) from transient
-    /// unreachability so callers can log/alert appropriately. `None` when
-    /// secrets are fresh from the VTA ([`SecretSource::Vta`]) **or** when a
-    /// caller loaded the cache without attempting the VTA at all (no
-    /// failure to report).
-    pub fallback: Option<FallbackReason>,
 }
 
 /// Errors from the VTA integration startup flow.
@@ -333,7 +326,10 @@ impl From<VtaError> for VtaIntegrationError {
 /// If the VTA is unreachable, falls back to the last cached bundle.
 ///
 /// Returns a [`StartupResult`] containing the service DID, secrets bundle,
-/// and whether the secrets are fresh or cached.
+/// and whether the secrets are fresh or cached. Callers that need to know
+/// *why* a cache fallback happened (to log/alert differently for an
+/// authorization denial vs. transient unreachability) should use
+/// [`startup_with_reason`].
 ///
 /// The DIDComm session used to fetch the bundle is **transient**: it is
 /// shut down before this function returns, so no auto-reconnecting
@@ -342,6 +338,28 @@ pub async fn startup(
     config: &VtaServiceConfig,
     cache: &(impl SecretCache + ?Sized),
 ) -> Result<StartupResult, VtaIntegrationError> {
+    startup_with_reason(config, cache)
+        .await
+        .map(|(result, _reason)| result)
+}
+
+/// Like [`startup`], but also reports **why** it fell back to the cache.
+///
+/// On success the second tuple element is `None`. When the VTA round-trip
+/// fails and a cached bundle is served, it is `Some(reason)` —
+/// [`FallbackReason::AuthDenied`] for a 401/403, [`FallbackReason::Timeout`]
+/// when the round-trip timed out, or [`FallbackReason::Unreachable`] for any
+/// other transport/VTA error. Lets a caller (e.g. the mediator's periodic
+/// refresh) warn loudly on a standing authorization problem while keeping
+/// transient unreachability quiet.
+///
+/// Split out from [`startup`] rather than added to [`StartupResult`] so the
+/// struct's public shape is unchanged — adding a required field would break
+/// every downstream crate that constructs a `StartupResult`.
+pub async fn startup_with_reason(
+    config: &VtaServiceConfig,
+    cache: &(impl SecretCache + ?Sized),
+) -> Result<(StartupResult, Option<FallbackReason>), VtaIntegrationError> {
     let timeout = config.auth.timeout.unwrap_or(DEFAULT_STARTUP_TIMEOUT);
     let context_id = &config.context.id;
 
@@ -386,13 +404,15 @@ pub async fn startup(
             // returned client stays usable for REST-backed follow-ups
             // (e.g. `health()`, which never uses the live session).
             client.shutdown().await;
-            Ok(StartupResult {
-                did: bundle.did.clone(),
-                bundle,
-                source: SecretSource::Vta,
-                client: Some(client),
-                fallback: None,
-            })
+            Ok((
+                StartupResult {
+                    did: bundle.did.clone(),
+                    bundle,
+                    source: SecretSource::Vta,
+                    client: Some(client),
+                },
+                None,
+            ))
         }
         Ok(Err(e)) => {
             let reason = FallbackReason::from_vta_error(&e);
@@ -402,7 +422,9 @@ pub async fn startup(
                 reason = ?reason,
                 "VTA call failed; attempting fallback to last-known cached bundle",
             );
-            load_from_cache(cache, context_id, reason).await
+            load_from_cache(cache, context_id)
+                .await
+                .map(|result| (result, Some(reason)))
         }
         Err(_elapsed) => {
             tracing::warn!(
@@ -410,7 +432,9 @@ pub async fn startup(
                 timeout_secs = timeout.as_secs(),
                 "VTA startup timed out; attempting fallback to last-known cached bundle",
             );
-            load_from_cache(cache, context_id, FallbackReason::Timeout).await
+            load_from_cache(cache, context_id)
+                .await
+                .map(|result| (result, Some(FallbackReason::Timeout)))
         }
     }
 }
@@ -418,7 +442,6 @@ pub async fn startup(
 async fn load_from_cache(
     cache: &(impl SecretCache + ?Sized),
     context: &str,
-    reason: FallbackReason,
 ) -> Result<StartupResult, VtaIntegrationError> {
     match cache.load().await {
         Ok(Some(bundle)) => {
@@ -436,7 +459,6 @@ async fn load_from_cache(
                 bundle,
                 source: SecretSource::Cache,
                 client: None,
-                fallback: Some(reason),
             })
         }
         Ok(None) => {
@@ -542,17 +564,12 @@ mod tests {
     #[tokio::test]
     async fn load_from_cache_returns_fresh_bundle_when_present() {
         let cache = MockSecretCache::with_cached(sample_bundle());
-        let result = load_from_cache(&cache, "prod-mediator", FallbackReason::AuthDenied)
+        let result = load_from_cache(&cache, "prod-mediator")
             .await
             .expect("cache hit returns StartupResult");
         assert_eq!(result.source, SecretSource::Cache);
         assert_eq!(result.did, "did:key:z6MkSampleIntegration");
         assert_eq!(result.bundle.secrets.len(), 1);
-        assert_eq!(
-            result.fallback,
-            Some(FallbackReason::AuthDenied),
-            "cache fallback carries the reason it was triggered",
-        );
         assert!(
             result.client.is_none(),
             "Cache-source startup never carries a live VtaClient",
@@ -591,7 +608,7 @@ mod tests {
     #[tokio::test]
     async fn load_from_cache_empty_returns_no_cached_secrets() {
         let cache = MockSecretCache::empty();
-        let result = load_from_cache(&cache, "prod-mediator", FallbackReason::Unreachable).await;
+        let result = load_from_cache(&cache, "prod-mediator").await;
         match result {
             Err(VtaIntegrationError::NoCachedSecrets) => {}
             Err(other) => panic!("expected NoCachedSecrets, got {other:?}"),
@@ -602,7 +619,7 @@ mod tests {
     #[tokio::test]
     async fn load_from_cache_io_error_becomes_cache_error() {
         let cache = MockSecretCache::failing("keyring unavailable");
-        let result = load_from_cache(&cache, "prod-mediator", FallbackReason::Unreachable).await;
+        let result = load_from_cache(&cache, "prod-mediator").await;
         match result {
             Err(VtaIntegrationError::CacheError(msg)) => {
                 assert!(msg.contains("keyring unavailable"), "got: {msg}")
@@ -621,7 +638,7 @@ mod tests {
             did: "did:key:zEmpty".into(),
             secrets: vec![],
         });
-        let result = load_from_cache(&cache, "prod-mediator", FallbackReason::Timeout).await;
+        let result = load_from_cache(&cache, "prod-mediator").await;
         match result {
             Err(VtaIntegrationError::EmptySecretsBundle(ctx)) => {
                 assert_eq!(ctx, "prod-mediator")


### PR DESCRIPTION
## Urgent — un-breaks published consumers

0.18.20 (#633) added a **required** `fallback` field to the public `StartupResult`. That is a **breaking** change: any downstream crate that *constructs* a `StartupResult` stops compiling. `affinidi-messaging-mediator` does exactly that in its self-mediated bootstrap path, and it pins `vta-sdk = "0.18"` — so the caret auto-upgraded the **already-published mediator 0.16.44** to 0.18.20 and broke it in the wild:

\`\`\`
error[E0063]: missing field \`fallback\` in initializer of \`StartupResult\`
 --> affinidi-messaging-mediator-0.16.44/src/common/config/vta_bootstrap.rs:135
\`\`\`

This is hitting users building the mediator today, and affinidi-tdk-rs `main`.

## Fix — move the reason off the struct

- **`StartupResult` reverts to its original four public fields**, so every existing construction site compiles again unchanged (this is the actual un-break).
- New **`startup_with_reason()`** returns `(StartupResult, Option<FallbackReason>)`. `startup()` becomes a thin wrapper that discards the reason — signature and behaviour unchanged.
- `FallbackReason` and the REST reactive re-auth/retry-once from 0.18.20 are untouched (both additive).

Net API delta vs. 0.18.19: **purely additive** (one new enum + one new function). Publishing **0.18.21** restores compatibility for every `"0.18"` consumer on a fresh resolve.

## Follow-up

**0.18.20 should be yanked** (`cargo yank --version 0.18.20 vta-sdk`) so nothing resolves to the breaking build. 0.18.21 supersedes it for caret resolves regardless.

## Test

- `cargo clippy -p vta-sdk --all-features --all-targets` clean; `cargo test -p vta-sdk --all-features --lib` green (incl. the `FallbackReason` classification test).
- (Unrelated: `vtc-service` fails `--all-features --all-targets` on clean `main` too — a pre-existing issuer-binding type error, not touched here.)