### PR TITLE
fix(ci): green up main — clippy 1.97 lints, RUSTSEC-2026-0204, feature-gated type error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2683,9 +2683,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/vta-service/src/services_cli.rs
+++ b/vta-service/src/services_cli.rs
@@ -637,7 +637,7 @@ pub async fn run_services_didcomm_drain_list(config_path: Option<PathBuf>) -> Cl
     let header_until = "DRAIN UNTIL";
     println!("  {header_did:<60}  {header_until}");
     for e in &response.entries {
-        println!("  {:<60}  {}", &e.mediator_did, e.drains_until);
+        println!("  {:<60}  {}", e.mediator_did, e.drains_until);
     }
     Ok(())
 }
@@ -714,7 +714,7 @@ pub async fn run_services_report(
                 for m in &report.mediators {
                     println!(
                         "    {}  {:>10}  {}",
-                        &m.mediator_did, m.inbound_count, m.last_seen
+                        m.mediator_did, m.inbound_count, m.last_seen
                     );
                 }
             }

--- a/vta-service/src/setup.rs
+++ b/vta-service/src/setup.rs
@@ -174,10 +174,11 @@ pub(crate) fn build_vta_additional_services(
 pub(crate) fn derive_ws_url(http_url: &str) -> Option<String> {
     let scheme_swapped = if let Some(rest) = http_url.strip_prefix("https://") {
         format!("wss://{rest}")
-    } else if let Some(rest) = http_url.strip_prefix("http://") {
-        format!("ws://{rest}")
     } else {
-        return None;
+        // `?` yields `None` for any scheme that is neither https:// nor
+        // http://, matching the previous explicit `return None`.
+        let rest = http_url.strip_prefix("http://")?;
+        format!("ws://{rest}")
     };
     Some(format!("{}/ws", scheme_swapped.trim_end_matches('/')))
 }

--- a/vtc-service/src/credentials/exchange/verify.rs
+++ b/vtc-service/src/credentials/exchange/verify.rs
@@ -645,7 +645,7 @@ async fn verify_bbs_presentation(
         .and_then(|p| p.get("verificationMethod"))
         .and_then(Value::as_str)
         .ok_or_else(|| AppError::Validation("bbs-2023 proof has no `verificationMethod`".into()))?;
-    check_issuer_binding(vm, issuer_did)?;
+    check_issuer_binding(vm, &issuer_did)?;
     let g2 = DidVmResolver::new(did_resolver.cloned())
         .resolve_bbs_g2(vm)
         .await?;


### PR DESCRIPTION
## Why

`main` has been **red on CI independently of any PR** — recent vta-sdk PRs (#633, #634) were merged through it. Three unrelated causes, none of which are anyone's PR:

## What

### 1. Clippy — toolchain bump to 1.97 introduced new lints (`-D warnings` → errors)

All in `vta-service`:
- **`useless_borrows_in_formatting`** ×2 (`services_cli.rs:640`, `:717`) — drop the redundant `&` on `println!` args.
- **`question_mark`** (`setup.rs`, `derive_ws_url`) — rewrite the trailing `else { return None }` using `?`.
  Behaviour-preserving: `?` yields `None` for any scheme that is neither `https://` nor `http://`, exactly as the explicit `return None` did. The existing `derive_ws_url_swaps_scheme_trims_and_appends_ws` test still passes unchanged.

### 2. cargo-deny — a real advisory

**`RUSTSEC-2026-0204`**: invalid pointer dereference in `crossbeam-epoch`'s `fmt::Pointer` impl for `Atomic`/`Shared`. Transitive: `fjall` → `lsm-tree` → `crossbeam-skiplist` → `crossbeam-epoch 0.9.18`.

Fixed with `cargo update -p crossbeam-epoch` (**0.9.18 → 0.9.20**, the patched release). Lockfile-only; no source change.

> Note: `licenses`/`bans`/`sources` were always fine — it was `advisories` failing. Yanked-crate warnings for `fjall`/`lsm-tree` remain but are warnings, not errors.

### 3. Latent `E0308` in `vtc-service` (bonus — not a CI failure, but a real break)

`check_issuer_binding` takes `&str` but was passed a `String` in the bbs-2023 verify path. Only reachable under `--all-features`, so CI's `clippy`/`check` never hit it — but that feature genuinely doesn't compile. One-character borrow fix.

## Test

All run locally against the exact CI invocations:
- `cargo clippy --workspace -- -D warnings` ✅
- `cargo deny check advisories bans sources licenses` → **advisories ok, bans ok, licenses ok, sources ok** ✅
- `cargo fmt --all --check` ✅
- `cargo check --workspace --all-features` ✅ (was failing before, via #3)
- Tests: `vta-service` **840 passed**, `vtc-service` **674 passed**, 0 failed ✅