### PR TITLE
fix(test-support): MockVta webvh stub must emit camelCase `didUrl`

### DIFF
--- a/vta-service/src/test_support.rs
+++ b/vta-service/src/test_support.rs
@@ -1046,7 +1046,13 @@ impl StubWebvhHost {
                 post(|headers: axum::http::HeaderMap| async move {
                     require_bearer(&headers)?;
                     Ok::<_, axum::http::StatusCode>(axum::Json(
-                        json!({ "did_url": STUB_WEBVH_DID_URL, "mnemonic": "stub-mnemonic" }),
+                        // camelCase `didUrl` — the real daemon
+                        // (`did-hosting-common::RequestUriResponse`) serializes
+                        // camelCase, and the client deserializes with
+                        // `rename_all = "camelCase"`. Emitting snake_case here
+                        // made the stub diverge from the wire shape it exists to
+                        // imitate, so the round-trip failed to decode.
+                        json!({ "didUrl": STUB_WEBVH_DID_URL, "mnemonic": "stub-mnemonic" }),
                     ))
                 }),
             )
@@ -1055,7 +1061,13 @@ impl StubWebvhHost {
                 post(|headers: axum::http::HeaderMap| async move {
                     require_bearer(&headers)?;
                     Ok::<_, axum::http::StatusCode>(axum::Json(
-                        json!({ "did_url": STUB_WEBVH_DID_URL, "mnemonic": "stub-mnemonic" }),
+                        // camelCase `didUrl` — the real daemon
+                        // (`did-hosting-common::RequestUriResponse`) serializes
+                        // camelCase, and the client deserializes with
+                        // `rename_all = "camelCase"`. Emitting snake_case here
+                        // made the stub diverge from the wire shape it exists to
+                        // imitate, so the round-trip failed to decode.
+                        json!({ "didUrl": STUB_WEBVH_DID_URL, "mnemonic": "stub-mnemonic" }),
                     ))
                 }),
             )


### PR DESCRIPTION
## Why

Follow-up to #635. With clippy/cargo-deny green, the **`Test`** job is the last red check on `main`:

```
test create_did_webvh_round_trips_against_stub_host ... FAILED
  500 internal error: webvh-server response parse error:
  error decoding response body for url (.../api/dids)
```

Pre-existing (reproduces at `502c2ad`, before #635).

## Root cause — the stub drifted from the wire shape it imitates

The in-process webvh stub host returned snake_case:

```rust
json!({ "did_url": STUB_WEBVH_DID_URL, "mnemonic": "stub-mnemonic" })
```

But the client type it feeds, `webvh_client::RequestUriResponse`, is `#[serde(rename_all = "camelCase")]` and expects **`didUrl`** — matching what the real daemon (`did-hosting-common::RequestUriResponse`) actually serializes. Its own doc comment even says so:

> *"The daemon serializes camelCase, so `did_url` arrives as `didUrl` — match it or the body fails to decode."*

So the round-trip could never decode. Every other field in the same stub (`sessionId`, `expiresAt`) is already camelCase — `did_url` was the lone outlier, i.e. the client was correctly fixed for real-daemon compat and the stub was left behind.

## What

Emit `didUrl` from both `POST /api/dids` and `POST /api/dids/register`. **Test-support only — no production code changes.**

## Test

- `cargo test -p vta-service --test mock_vta` → **6 passed, 0 failed** (was 5 passed / 1 failed).
- `cargo clippy --workspace -- -D warnings` ✅ · `cargo fmt --all --check` ✅

## Heads-up — a second, separate test failure may surface

`cargo test` aborts at the first failing target, so CI never got past `mock_vta`. With it fixed, the run proceeds further — and locally I see `vtc-service --test join_didcomm::didcomm_join_round_trips_submit_manifest_status_approve_and_vmc_delivery` fail (times out after 20s waiting for the VMC push over DIDComm). It also reproduces at `502c2ad`, so it is **not** from #635 or this PR.

I've deliberately not chased it here — it may be local-environment/timing-sensitive rather than a genuine break, and this PR's CI run is the cleanest way to find out. If it goes red in CI too, I'll fix it in a follow-up.