### PR TITLE
fix(vtc): recognise tests must sign the VMC with its real tag, MembershipCredential

### DIFF
--- a/vtc-service/tests/recognise.rs
+++ b/vtc-service/tests/recognise.rs
@@ -289,6 +289,7 @@ mod holder_binding {
     use serde_json::{Value, json};
     use tower::ServiceExt;
 
+    use vta_sdk::protocols::members::VERIFIABLE_MEMBERSHIP_CREDENTIAL_TYPE;
     use vtc_service::test_support::TestVtc;
 
     const VTC_DID: &str = "did:key:z6MkTestVTC";
@@ -360,7 +361,20 @@ mod holder_binding {
         let subject_did = did_for(subject_seed);
         let holder_did = did_for(holder_seed);
         let vec = sign_vc(issuer_seed, "VerifiableEndorsementCredential", &subject_did).await;
-        let vmc = sign_vc(issuer_seed, "VerifiableMembershipCredential", &subject_did).await;
+        // The VMC's wire tag is `MembershipCredential` — NOT
+        // `VerifiableMembershipCredential`. The `VERIFIABLE_` prefix lives in the
+        // constant's *name* only (it's historical); the tag is what
+        // `dtg-credentials` emits and what the VTC stamps, and it's what
+        // `routes::recognise` matches on. Hand-rolling the wrong string here made
+        // every VP that got as far as the credential lookup 400 with
+        // "presentation has no MembershipCredential" — so the three holder-binding
+        // assertions below could never be reached. Use the constant, not a literal.
+        let vmc = sign_vc(
+            issuer_seed,
+            VERIFIABLE_MEMBERSHIP_CREDENTIAL_TYPE,
+            &subject_did,
+        )
+        .await;
         let mut vp = json!({
             "@context": ["https://www.w3.org/ns/credentials/v2"],
             "type": ["VerifiablePresentation"],


### PR DESCRIPTION
## Why

The last red on `main`. Completes the CI green-up (#635 → #636 → #638 → this).

The `holder_binding` VP builder hand-rolled the membership credential's type as `VerifiableMembershipCredential`. The tag the route actually matches on is **`MembershipCredential`** — as `vta_sdk::protocols::members` spells out in the constant's own doc:

> *"The `VERIFIABLE_` prefix in the **name** is historical; the **tag** is `MembershipCredential`, not `VerifiableMembershipCredential`, so a credential built with the typed `dtg-credentials` API verifies without hand-rolling the VC JSON."*

The test hand-rolled the VC JSON with exactly the string that doc warns against. (The VEC alongside it is genuinely `VerifiableEndorsementCredential` — the two types really are named asymmetrically, which is the trap.)

## This was worse than a failing test

Every VP that got as far as the credential lookup was rejected `400 "presentation has no MembershipCredential"` — **before** reaching any of the assertions. So the three security properties these tests exist to prove:

- an attacker re-wrapping a **victim's** VMC in a VP signed with their own holder key must be refused,
- a **matching** holder must clear the binding gate,
- a **consumed** challenge must not replay,

…were never actually exercised. They weren't just red — they were **vacuous**. The holder-binding gate had no real coverage.

## What

Sign the VMC with `VERIFIABLE_MEMBERSHIP_CREDENTIAL_TYPE` instead of re-typing the literal, so the test can't drift from the constant again. Test-only change.

## Test

- `cargo test -p vtc-service --test recognise` → **15 passed, 0 failed** (was 12 passed / 3 failed), and the holder-binding assertions now genuinely run against the gate.
- **`cargo test --workspace --no-fail-fast` → fully green.**
- `cargo clippy --workspace -- -D warnings` ✅ · `cargo fmt --all --check` ✅

With this, the whole OpenVTC suite — Clippy, cargo-deny, Format, MSRV, Check, all-features, and the full test suite — is green.