### PR TITLE
fix(cli): route `dids get-log` through VtaClient so it works on DIDComm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6692,7 +6692,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "pnm-cli"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-resolver-cache-sdk",
@@ -9998,7 +9998,7 @@ dependencies = [
 
 [[package]]
 name = "vta-cli-common"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "aes-gcm",
  "affinidi-crypto",

--- a/pnm-cli/Cargo.toml
+++ b/pnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pnm-cli"
 description = "CLI Tool for managing a personal Verifiable Trust Agent"
-version = "0.10.4"
+version = "0.10.5"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/pnm-cli/src/commands/webvh.rs
+++ b/pnm-cli/src/commands/webvh.rs
@@ -123,9 +123,7 @@ pub(crate) async fn run(
         }
         WebvhCommands::GetDid { did } => webvh::cmd_webvh_did_get(client, &did).await,
         WebvhCommands::DeleteDid { did } => webvh::cmd_webvh_did_delete(client, &did).await,
-        WebvhCommands::DidLog { did, out } => {
-            webvh::cmd_webvh_did_log(client.base_url(), &did, out).await
-        }
+        WebvhCommands::DidLog { did, out } => webvh::cmd_webvh_did_log(client, &did, out).await,
         WebvhCommands::ListDomains { server } => cmd_list_domains(client, &server).await,
     }
 }

--- a/vta-cli-common/Cargo.toml
+++ b/vta-cli-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-cli-common"
 description = "Shared CLI command handlers and rendering helpers for VTA CLIs"
 readme = "README.md"
-version = "0.10.3"
+version = "0.10.4"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-cli-common/src/commands/webvh.rs
+++ b/vta-cli-common/src/commands/webvh.rs
@@ -523,34 +523,22 @@ pub async fn cmd_webvh_did_delete(
     Ok(())
 }
 
-/// `pnm webvh did-log <did> [--out <path>]` — fetch the raw `did.jsonl`
-/// log from the VTA's public `GET /did/{did}/log` endpoint.
+/// `pnm did-mgmt dids get-log <did> [--out <path>]` — fetch the raw
+/// `did.jsonl` log for a DID the VTA knows.
 ///
-/// Unauthenticated — matches webvh's world-readable log model. Reads
-/// the VTA base URL off the caller's current session (no token needed
-/// for this endpoint specifically).
+/// Goes through the authenticated, transport-agnostic client method so
+/// it works on both REST and DIDComm sessions. (The VTA also mirrors
+/// the log unauthenticated at `GET /did/{did}/log` for resolvers, but a
+/// DIDComm client has no HTTP base URL to build that request from.)
 pub async fn cmd_webvh_did_log(
-    vta_base_url: &str,
+    client: &VtaClient,
     did: &str,
     out: Option<std::path::PathBuf>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    // Cheap URL-path-segment escaping for DIDs. DIDs use `:` (reserved
-    // but safe in a path segment) and possibly `#` / `?` — we only need
-    // to handle `#` and `?` (both would terminate the path) and `%`
-    // (escape char). Keep `:` as-is.
-    let escaped_did = did
-        .replace('%', "%25")
-        .replace('#', "%23")
-        .replace('?', "%3F");
-    let url = format!("{vta_base_url}/did/{escaped_did}/log");
-    let http = reqwest::Client::new();
-    let resp = http.get(&url).send().await?;
-    let status = resp.status();
-    if !status.is_success() {
-        let body = resp.text().await.unwrap_or_default();
-        return Err(format!("GET {url} failed ({status}): {body}").into());
-    }
-    let log = resp.text().await?;
+    let resp = client.get_did_webvh_log(did).await?;
+    let log = resp
+        .log
+        .ok_or_else(|| format!("no did.jsonl log stored for {did}"))?;
 
     match out {
         Some(path) => {


### PR DESCRIPTION
## Problem

`pnm did-mgmt dids get-log <did>` fails on any **DIDComm** session:

```
✗ Error: builder error for url (did:webvh:QmWoJD…:webvh.storm.ws:glenn-vta/did/did:webvh:QmUcyd…:webvh.storm.ws/log)
  caused by: URL scheme is not allowed
```

## Root cause

`cmd_webvh_did_log` was the one webvh command that bypassed `VtaClient` entirely and hand-rolled a raw `reqwest` GET against the VTA's public, unauthenticated `GET /did/{did}/log` mirror, using `client.base_url()` as the base.

`VtaClient::base_url()` does not return a URL on the DIDComm transport — it returns the VTA's **DID**:

```rust
// vta-sdk/src/client/mod.rs:399
pub fn base_url(&self) -> &str {
    match &self.transport {
        Transport::Rest { base_url, .. } => base_url,
        Transport::DIDComm { session, .. } => &session.vta_did,  // a DID, not a URL
    }
}
```

So the CLI built `did:webvh:…/did/<did>/log` and reqwest rejected the `did:` scheme. The failure is transport-dependent, not DID-dependent — it worked on REST sessions, which is why it slipped through.

Every sibling command (`list`, `get`, `create`, `register`) goes through `VtaClient::rpc()`, which only builds a REST URL on the `Transport::Rest` arm and routes over the session otherwise. `get-log` was the odd one out.

## Fix

The SDK already exposed the correct transport-agnostic method — `VtaClient::get_did_webvh_log()` — fully wired on all three paths (REST route `GET /webvh/dids/{did}/log`, DIDComm handler, `webvh/dids/get-log/1.0` trust task). The CLI simply never called it.

- `vta-cli-common/src/commands/webvh.rs` — `cmd_webvh_did_log` now takes `&VtaClient` and calls `client.get_did_webvh_log(did)`. Drops the bespoke `reqwest::Client` and the ad-hoc DID path-escaping (`encode_path_segment` handles that).
- `pnm-cli/src/commands/webvh.rs` — passes `client` rather than `client.base_url()`.
- Version bumps: `vta-cli-common` 0.10.3 → 0.10.4, `pnm-cli` 0.10.4 → 0.10.5. Dependents pin `"0.10"`, so nothing else needs touching.

## Behavioural note

`get-log` is now **authenticated** rather than hitting the world-readable mirror. This matches every other `did-mgmt` command, and the endpoint is authed-any-user server-side, so it is not a new restriction in practice — but `get-log` no longer works without a session, whereas on REST it nominally could have.

The public unauth `GET /did/{did}/log` mirror is untouched and remains the DID-resolver failover path.

## Also audited

The two other `base_url()` callers (`pnm-cli/src/bootstrap.rs:503`, `vta-cli-common/src/commands/keys.rs:108`) only interpolate it into human-readable output, so a DID there is cosmetic, not broken. Left alone.

## Verification

`cargo clippy` clean. Driven end-to-end against a live DIDComm VTA — the exact failing command now succeeds and writes a valid 2-entry `did.jsonl` for the requested DID:

```
DID log written to did.jsonl (4427 bytes)

1-QmahACr3J49EFS3aQy1SYZyeTjjdrgQbkRb4gH1fEdViPp  2026-04-30T03:37:21Z
2-QmUS8hg3zYLqcPxa3DJheh2ynVGVU7FfHLLCctFVJz4p9N  2026-07-12T03:01:43Z
```