### PR TITLE
feat(vta-service): PDP is the single step-up authority (subsume config floors)

### DIFF
--- a/vta-service/src/policy/engine.rs
+++ b/vta-service/src/policy/engine.rs
@@ -193,6 +193,8 @@ mod tests {
                 device_id: None,
                 last_user_verification_at: None,
                 network_class: None,
+                acr: None,
+                amr: vec![],
             },
         }
     }

--- a/vta-service/src/policy/input.rs
+++ b/vta-service/src/policy/input.rs
@@ -33,11 +33,16 @@ fn first_string<'a>(payload: &'a Value, fields: &[&str]) -> Option<&'a str> {
 /// - `class` is the authoritative classification from `class_for`; `None`
 ///   applies the fail-safe [`TaskClass::floor`].
 /// - `caller_did` is the authenticated consumer's DID (from the auth claims).
+/// - `caller_acr` / `caller_amr` are the session's assurance level + method
+///   references (from the auth claims), so a policy can gate on step-up state.
+///   An empty `caller_acr` is treated as "unset" (omitted).
 /// - `payload` is the inbound task payload, probed for subject + context.
 pub fn build_policy_input(
     type_uri: &str,
     payload: &Value,
     caller_did: &str,
+    caller_acr: &str,
+    caller_amr: &[String],
     class: Option<TaskClass>,
 ) -> PolicyInput {
     let class = class.unwrap_or_else(TaskClass::floor);
@@ -64,6 +69,8 @@ pub fn build_policy_input(
             device_id: None,
             last_user_verification_at: None,
             network_class: None,
+            acr: (!caller_acr.is_empty()).then(|| caller_acr.to_string()),
+            amr: caller_amr.to_vec(),
         },
     }
 }
@@ -82,7 +89,14 @@ mod tests {
             Discloses::None,
             false,
         ));
-        let input = build_policy_input("https://…/delete/0.1", &payload, "did:key:zCaller", class);
+        let input = build_policy_input(
+            "https://…/delete/0.1",
+            &payload,
+            "did:key:zCaller",
+            "",
+            &[],
+            class,
+        );
 
         assert_eq!(input.request.side_effects, SideEffectLevel::Destructive);
         assert_eq!(input.request.subject.as_deref(), Some("did:webvh:abc"));
@@ -92,7 +106,14 @@ mod tests {
 
     #[test]
     fn unclassified_task_gets_the_fail_safe_floor() {
-        let input = build_policy_input("https://…/unknown/0.1", &json!({}), "did:key:z", None);
+        let input = build_policy_input(
+            "https://…/unknown/0.1",
+            &json!({}),
+            "did:key:z",
+            "",
+            &[],
+            None,
+        );
         // floor = mutating / secret / actsAsSubject — maximally consequential.
         assert_eq!(input.request.side_effects, SideEffectLevel::Mutating);
         assert_eq!(input.request.exposure.discloses, Discloses::Secret);
@@ -107,7 +128,7 @@ mod tests {
     #[test]
     fn subject_precedence_prefers_did_over_mnemonic() {
         let payload = json!({ "mnemonic": "alice", "did": "did:webvh:xyz" });
-        let input = build_policy_input("t", &payload, "c", Some(TaskClass::floor()));
+        let input = build_policy_input("t", &payload, "c", "", &[], Some(TaskClass::floor()));
         assert_eq!(input.request.subject.as_deref(), Some("did:webvh:xyz"));
     }
 }

--- a/vta-service/src/policy/mod.rs
+++ b/vta-service/src/policy/mod.rs
@@ -101,6 +101,8 @@ mod tests {
                 device_id: None,
                 last_user_verification_at: None,
                 network_class: None,
+                acr: None,
+                amr: vec![],
             },
         }
     }

--- a/vta-service/src/policy/types.rs
+++ b/vta-service/src/policy/types.rs
@@ -120,6 +120,17 @@ pub struct Consumer {
         skip_serializing_if = "Option::is_none"
     )]
     pub network_class: Option<String>,
+    /// The session's OIDC assurance level (`aal1` / `aal2`), so a policy can
+    /// gate on step-up state — e.g. `sideEffects == "destructive" and
+    /// consumer.acr != "aal2" => requireStepUp`. Extension beyond the 0.3
+    /// schema (which carries `lastUserVerificationAt` as a coarser proxy); to
+    /// be added to the schema.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub acr: Option<String>,
+    /// RFC 8176 authentication method references on the session
+    /// (`did`, `passkey`, …). Lets a policy require a specific factor.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub amr: Vec<String>,
 }
 
 /// The structured input fed to the evaluator before dispatching a task.
@@ -293,6 +304,8 @@ mod tests {
                 device_id: Some("dev-1".into()),
                 last_user_verification_at: None,
                 network_class: None,
+                acr: None,
+                amr: vec![],
             },
         };
         let v = serde_json::to_value(&input).unwrap();

--- a/vta-service/src/trust_tasks/acl.rs
+++ b/vta-service/src/trust_tasks/acl.rs
@@ -59,12 +59,7 @@ pub(super) async fn handle_create(
     if let Err(e) = auth.require_manage() {
         return app_error_to_reject(&doc, e);
     }
-    // ACL grant is gated per the `acl/grant` step-up floor (operator policy).
-    if let Some(resp) =
-        super::step_up::require_step_up(state, auth, super::step_up::op::ACL_GRANT, &doc).await
-    {
-        return resp;
-    }
+    // Step-up (acl/grant floor) is enforced centrally by the PDP gate.
     let req: CreateAclBody = match parse_payload(&doc) {
         Ok(r) => r,
         Err(resp) => return resp,
@@ -130,13 +125,7 @@ pub(super) async fn handle_update(
     if let Err(e) = auth.require_admin() {
         return app_error_to_reject(&doc, e);
     }
-    // ACL change-role is gated per the `acl/change-role` step-up floor.
-    if let Some(resp) =
-        super::step_up::require_step_up(state, auth, super::step_up::op::ACL_CHANGE_ROLE, &doc)
-            .await
-    {
-        return resp;
-    }
+    // Step-up (acl/change-role floor) is enforced centrally by the PDP gate.
     let req: UpdateAclBody = match parse_payload(&doc) {
         Ok(r) => r,
         Err(resp) => return resp,
@@ -186,12 +175,7 @@ pub(super) async fn handle_delete(
     if let Err(e) = auth.require_manage() {
         return app_error_to_reject(&doc, e);
     }
-    // ACL revoke is gated per the `acl/revoke` step-up floor (operator policy).
-    if let Some(resp) =
-        super::step_up::require_step_up(state, auth, super::step_up::op::ACL_REVOKE, &doc).await
-    {
-        return resp;
-    }
+    // Step-up (acl/revoke floor) is enforced centrally by the PDP gate.
     let req: DeleteAclBody = match parse_payload(&doc) {
         Ok(r) => r,
         Err(resp) => return resp,

--- a/vta-service/src/trust_tasks/contexts.rs
+++ b/vta-service/src/trust_tasks/contexts.rs
@@ -193,12 +193,7 @@ pub(super) async fn handle_delete(
     if let Err(e) = auth.require_admin() {
         return app_error_to_reject(&doc, e);
     }
-    // Deleting a context is gated per the `context/delete` step-up floor.
-    if let Some(resp) =
-        super::step_up::require_step_up(state, auth, super::step_up::op::CONTEXT_DELETE, &doc).await
-    {
-        return resp;
-    }
+    // Step-up (context/delete floor) is enforced centrally by the PDP gate.
     let req: DeleteContextBody = match parse_payload(&doc) {
         Ok(r) => r,
         Err(resp) => return resp,

--- a/vta-service/src/trust_tasks/credentials.rs
+++ b/vta-service/src/trust_tasks/credentials.rs
@@ -44,13 +44,7 @@ pub(super) async fn handle_issue(
     if let Err(e) = auth.require_admin() {
         return app_error_to_reject(&doc, e);
     }
-    // 2. Operator step-up (AAL2) gate.
-    if let Some(resp) =
-        super::step_up::require_step_up(state, auth, super::step_up::op::CREDENTIALS_ISSUE, &doc)
-            .await
-    {
-        return resp;
-    }
+    // 2. Operator step-up (credentials/issue floor) — enforced centrally by the PDP gate.
     // 3. Parse the request body.
     let req: IssueCredentialBody = match parse_payload(&doc) {
         Ok(r) => r,
@@ -109,12 +103,7 @@ pub(super) async fn handle_revoke(
     if let Err(e) = auth.require_admin() {
         return app_error_to_reject(&doc, e);
     }
-    if let Some(resp) =
-        super::step_up::require_step_up(state, auth, super::step_up::op::CREDENTIALS_REVOKE, &doc)
-            .await
-    {
-        return resp;
-    }
+    // Step-up (credentials/revoke floor) is enforced centrally by the PDP gate.
     let req: RevokeCredentialBody = match parse_payload(&doc) {
         Ok(r) => r,
         Err(resp) => return resp,
@@ -204,8 +193,12 @@ mod tests {
         });
     }
 
+    // Step-up is now enforced by the central PDP gate, not inline in the
+    // handler (the inline require_step_up was removed). This exercises the
+    // config-floor step-up path through the gate for credentials/issue.
     #[tokio::test]
-    async fn issue_without_step_up_is_rejected() {
+    #[allow(deprecated)]
+    async fn issue_at_aal1_is_rejected_by_the_gate() {
         let (state, _dir) = build_signing_test_app_state().await;
         require_issue_step_up(&state).await;
         // AAL1 admin (acr empty) — capability passes, step-up gate must fire.
@@ -215,12 +208,15 @@ mod tests {
             "claims": { "role": "member" },
             "validitySeconds": 3600u64,
         }));
-        let out = handle_issue(&state, &auth, doc).await;
-        assert!(
-            !out.status.is_success(),
-            "issue at AAL1 must be rejected by the step-up gate, got {}",
-            out.status
-        );
+        let out = super::super::policy_gate::policy_gate(
+            &state,
+            &auth,
+            vta_sdk::trust_tasks::TASK_VTA_CREDENTIALS_ISSUE_0_1,
+            &doc,
+        )
+        .await
+        .expect("the credentials/issue floor must reject an AAL1 caller at the gate");
+        assert!(!out.status.is_success(), "got {}", out.status);
         let body = String::from_utf8_lossy(&out.body);
         assert!(
             body.contains("step_up_required"),

--- a/vta-service/src/trust_tasks/keys.rs
+++ b/vta-service/src/trust_tasks/keys.rs
@@ -145,12 +145,7 @@ pub(super) async fn handle_revoke(
     if let Err(e) = auth.require_admin() {
         return app_error_to_reject(&doc, e);
     }
-    // Revoking (deleting) a key is gated per the `key/revoke` step-up floor.
-    if let Some(resp) =
-        super::step_up::require_step_up(state, auth, super::step_up::op::KEY_REVOKE, &doc).await
-    {
-        return resp;
-    }
+    // Step-up (key/revoke floor) is enforced centrally by the PDP gate.
     let req: RevokeKeyBody = match parse_payload(&doc) {
         Ok(r) => r,
         Err(resp) => return resp,

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -418,9 +418,9 @@ pub(crate) async fn dispatch_trust_task_core(
     // `config.policy.enforcement` is on; when a policy denies (or demands
     // step-up/consent), the task is rejected here and never reaches its handler.
     // A rejected task still flows through the audit tail below.
-    let outcome = match policy_gate::policy_gate(state, auth, &type_uri, &doc.payload).await {
-        Err(reason) => reject_with(&doc, reason),
-        Ok(()) => {
+    let outcome = match policy_gate::policy_gate(state, auth, &type_uri, &doc).await {
+        Some(reject_outcome) => reject_outcome,
+        None => {
             if let Some(spec) = wire_v0_2::lookup_0_2(&type_uri) {
                 let mut doc = doc;
                 wire_v0_2::downconvert_request(&mut doc.payload, spec);

--- a/vta-service/src/trust_tasks/policy_gate.rs
+++ b/vta-service/src/trust_tasks/policy_gate.rs
@@ -1,87 +1,147 @@
-//! The pre-dispatch Policy Decision Point gate.
+//! The pre-dispatch Policy Decision Point gate — the single step-up authority.
 //!
 //! Every dispatched Trust Task routes through [`policy_gate`] before its handler
-//! runs. The gate builds a [`PolicyInput`](crate::policy::PolicyInput) from the
-//! task's authoritative class ([`super::class_for`] — compiled, not the
-//! registry), evaluates the active policy set via [`crate::policy::decide`], and
-//! maps the disposition to proceed-or-reject.
+//! runs. The gate is now the one place step-up is decided, sourcing it from two
+//! places and rejecting-with-`approve-request` if either demands it:
 //!
-//! ## Opt-in, fail-safe
+//! 1. **Config floors** — the existing `[auth.step_up]` floors, via
+//!    [`super::step_up::require_step_up`]. This subsumes the per-handler
+//!    `require_step_up` calls (removed from the slices). Runs for the gated
+//!    op-classes regardless of PDP enforcement, so the config-driven behaviour
+//!    is unchanged; a no-op when no floor applies or the session is already
+//!    `aal2`.
+//! 2. **Rego policy** — when `config.policy.enforcement` is on, a policy may
+//!    return `requireStepUp` (self-approve), `deny`, `requireConsent`, or
+//!    `allow`. The session's assurance (`acr`/`amr`) is fed into
+//!    `PolicyInput.consumer`, so a policy can gate on step-up state.
 //!
-//! When `config.policy.enforcement` is false (the default) the gate is a no-op
-//! that always proceeds — so it lands wired-but-inert and a deployment enables
-//! it deliberately. When enabled, the boot-installed baseline still allows
-//! current flows, so nothing breaks until an operator adds a restrictive
-//! higher-priority policy. Any failure to load the policy set denies
-//! (fail-closed).
+//! ## Ordering note
+//!
+//! The inline `require_step_up` used to run *after* a handler's role check; the
+//! gate runs *before* dispatch, hence before the role check. A caller lacking
+//! the role now sees a step-up challenge before the role denial — they still
+//! can't complete the op, so this is a UX/ordering change, not a security one.
+//! It is inherent to a single pre-dispatch gate.
+//!
+//! ## Opt-in Rego, fail-safe
+//!
+//! The Rego arm is inert unless enforcement is enabled; the config-floor arm
+//! preserves existing behaviour. Any failure to load the policy set denies.
 
 use serde_json::Value;
-use trust_tasks_rs::RejectReason;
+use trust_tasks_rs::{RejectReason, TrustTask};
 
+use super::TrustTaskOutcome;
+use super::helpers::reject_with;
 use crate::auth::AuthClaims;
 use crate::policy::{self, Disposition};
 use crate::server::AppState;
 
-/// Evaluate the PDP for a task about to be dispatched.
+/// The ACR a satisfied step-up reaches. Mirrors `step_up::STEP_UP_TARGET_ACR`.
+const STEP_UP_TARGET_ACR: &str = "aal2";
+
+/// Map a task's Type URI to its step-up operation-class, for the gated ops that
+/// carry a config floor. Only the ops that previously called `require_step_up`
+/// inline are mapped, preserving current behaviour (`acl/swap-key` had no inline
+/// call and stays unmapped). Returns `None` for ungated tasks.
+#[allow(deprecated)]
+fn op_class_for(type_uri: &str) -> Option<&'static str> {
+    use super::step_up::op;
+    use vta_sdk::trust_tasks as t;
+    match type_uri {
+        t::TASK_ACL_CREATE_1_0 => Some(op::ACL_GRANT),
+        t::TASK_ACL_UPDATE_1_0 => Some(op::ACL_CHANGE_ROLE),
+        t::TASK_ACL_DELETE_1_0 => Some(op::ACL_REVOKE),
+        t::TASK_CONTEXTS_DELETE_1_0 => Some(op::CONTEXT_DELETE),
+        t::TASK_KEYS_REVOKE_1_0 => Some(op::KEY_REVOKE),
+        t::TASK_VAULT_RELEASE_0_1 => Some(op::VAULT_RELEASE),
+        t::TASK_VAULT_PROXY_LOGIN_0_1 => Some(op::VAULT_PROXY_LOGIN),
+        t::TASK_VAULT_SIGN_TRUST_TASK_0_1 => Some(op::VAULT_SIGN_TRUST_TASK),
+        t::TASK_VTA_CREDENTIALS_ISSUE_0_1 => Some(op::CREDENTIALS_ISSUE),
+        t::TASK_VTA_CREDENTIALS_REVOKE_0_1 => Some(op::CREDENTIALS_REVOKE),
+        _ => None,
+    }
+}
+
+/// Evaluate the gate for a task about to be dispatched.
 ///
-/// `Ok(())` → proceed to the handler. `Err(reason)` → reject before dispatch
+/// `None` → proceed to the handler. `Some(outcome)` → reject before dispatch
 /// (the caller still audits the rejected task).
 pub(super) async fn policy_gate(
     state: &AppState,
     auth: &AuthClaims,
     type_uri: &str,
-    payload: &Value,
-) -> Result<(), RejectReason> {
-    // Opt-in: inert unless an operator turns enforcement on.
+    doc: &TrustTask<Value>,
+) -> Option<TrustTaskOutcome> {
+    // (1) Config-floor step-up (subsumes the inline require_step_up).
+    if let Some(op_class) = op_class_for(type_uri)
+        && let Some(reject) = super::step_up::require_step_up(state, auth, op_class, doc).await
+    {
+        return Some(reject);
+    }
+
+    // (2) Rego policy — only when enforcement is enabled.
     if !state.config.read().await.policy.enforcement {
-        return Ok(());
+        return None;
     }
 
     let class = super::class_for(type_uri);
-    let input = policy::build_policy_input(type_uri, payload, &auth.did, class);
+    let input = policy::build_policy_input(
+        type_uri,
+        &doc.payload,
+        &auth.did,
+        &auth.acr,
+        &auth.amr,
+        class,
+    );
 
     let policies = match policy::load_active_for_context(&state.policy_ks, &input.context_id).await
     {
         Ok(p) => p,
         Err(e) => {
-            // Fail closed: if we can't load policy, we don't dispatch.
             tracing::error!(error = %e, type_uri, "policy load failed — denying (fail-closed)");
-            return Err(RejectReason::PermissionDenied {
-                reason: "policy evaluation unavailable".to_string(),
-            });
+            return Some(reject_with(
+                doc,
+                RejectReason::PermissionDenied {
+                    reason: "policy evaluation unavailable".to_string(),
+                },
+            ));
         }
     };
 
     let decision = policy::decide(&policies, &input);
     match decision.decision {
-        Disposition::Allow => Ok(()),
-        Disposition::Deny => Err(RejectReason::PermissionDenied {
-            reason: decision
-                .explanation
-                .unwrap_or_else(|| "denied by policy".to_string()),
-        }),
-        // Step-up / consent flows are surfaced as permission-denied with a
-        // reason for now; wiring the actual step-up + approver-set ceremonies
-        // into this decision path is a follow-up. Denying (rather than
-        // proceeding) keeps the gate fail-safe until then.
-        Disposition::RequireStepUp => Err(RejectReason::PermissionDenied {
-            reason: format!(
-                "step-up required: {}",
-                decision
+        Disposition::Allow => None,
+        Disposition::Deny => Some(reject_with(
+            doc,
+            RejectReason::PermissionDenied {
+                reason: decision
                     .explanation
-                    .as_deref()
-                    .unwrap_or("policy requires step-up")
-            ),
-        }),
-        Disposition::RequireConsent => Err(RejectReason::PermissionDenied {
-            reason: format!(
-                "consent required: {}",
-                decision
-                    .explanation
-                    .as_deref()
-                    .unwrap_or("policy requires approver consent")
-            ),
-        }),
+                    .unwrap_or_else(|| "denied by policy".to_string()),
+            },
+        )),
+        Disposition::RequireStepUp => {
+            if auth.acr == STEP_UP_TARGET_ACR {
+                // Already elevated — the requirement is satisfied.
+                None
+            } else {
+                Some(super::step_up::initiate_self_step_up(state, auth, doc).await)
+            }
+        }
+        // Task-execution consent (approver-set + payload-digest binding) is
+        // Phase B; until then surface it as a denial with a clear reason.
+        Disposition::RequireConsent => Some(reject_with(
+            doc,
+            RejectReason::PermissionDenied {
+                reason: format!(
+                    "consent required: {}",
+                    decision
+                        .explanation
+                        .as_deref()
+                        .unwrap_or("policy requires approver consent")
+                ),
+            },
+        )),
     }
 }
 
@@ -108,47 +168,79 @@ mod tests {
     const DENY_ALL: &str = "package vta.policy\nimport rego.v1\ndecision := {\"decision\": \"deny\", \"explanation\": \"blocked\"}";
     const ALLOW_ALL: &str =
         "package vta.policy\nimport rego.v1\ndecision := {\"decision\": \"allow\"}";
+    // Step-up unless the session is already aal2 — the canonical policy shape
+    // the acr feed enables. Explicitly allows at aal2 (an abstaining policy
+    // would default-deny).
+    const STEPUP_IF_NOT_AAL2: &str = "package vta.policy\nimport rego.v1\ndecision := {\"decision\": \"requireStepUp\"} if input.consumer.acr != \"aal2\"\ndecision := {\"decision\": \"allow\"} if input.consumer.acr == \"aal2\"";
+
+    fn doc(type_uri: &str) -> TrustTask<Value> {
+        serde_json::from_value(serde_json::json!({
+            "id": "urn:uuid:00000000-0000-0000-0000-000000000001",
+            "type": type_uri,
+            "issuer": "did:key:zTestAdmin",
+            "recipient": "did:example:vta",
+            "issuedAt": "2026-05-20T00:00:00Z",
+            "payload": { "contextId": "default" }
+        }))
+        .expect("valid trust task")
+    }
+
+    // An ungated task URI (not in op_class_for) so the config-floor arm is a
+    // no-op and only the Rego arm runs.
+    const UNGATED_URI: &str = "https://trusttasks.org/spec/vta/memory/list/0.1";
 
     #[tokio::test]
-    async fn gate_is_inert_when_disabled_and_enforces_when_enabled() {
+    async fn gate_inert_when_disabled_enforces_when_enabled() {
         let (state, _dir) = crate::test_support::build_signing_test_app_state().await;
         let auth = crate::test_support::super_admin_claims();
-        let type_uri = "https://trusttasks.org/spec/vault/release/0.1";
-        let payload = serde_json::json!({ "contextId": "default" });
+        let d = doc(UNGATED_URI);
 
-        // Enforcement OFF (default): proceeds even with an empty policy set,
-        // which would otherwise default-deny. This is the migration-safe flip.
-        assert!(
-            policy_gate(&state, &auth, type_uri, &payload).await.is_ok(),
-            "disabled gate must be inert"
-        );
+        // Disabled: proceed even with an empty policy set.
+        assert!(policy_gate(&state, &auth, UNGATED_URI, &d).await.is_none());
 
-        // Turn enforcement ON. Empty policy set now default-denies.
+        // Enabled + empty set → default-deny.
         state.config.write().await.policy.enforcement = true;
-        assert!(
-            policy_gate(&state, &auth, type_uri, &payload)
-                .await
-                .is_err(),
-            "enabled + no policy must default-deny"
-        );
+        assert!(policy_gate(&state, &auth, UNGATED_URI, &d).await.is_some());
 
-        // A deny policy rejects.
+        // Deny policy → reject.
         crate::policy::storage::store_policy(&state.policy_ks, &module("deny", 0, DENY_ALL))
             .await
             .unwrap();
-        assert!(
-            policy_gate(&state, &auth, type_uri, &payload)
-                .await
-                .is_err()
-        );
+        assert!(policy_gate(&state, &auth, UNGATED_URI, &d).await.is_some());
 
-        // A higher-priority allow overrides it → proceeds.
+        // Higher-priority allow overrides → proceed.
         crate::policy::storage::store_policy(&state.policy_ks, &module("allow", 10, ALLOW_ALL))
             .await
             .unwrap();
+        assert!(policy_gate(&state, &auth, UNGATED_URI, &d).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn rego_requires_step_up_when_session_not_elevated() {
+        let (state, _dir) = crate::test_support::build_signing_test_app_state().await;
+        let mut auth = crate::test_support::super_admin_claims();
+        let d = doc(UNGATED_URI);
+
+        state.config.write().await.policy.enforcement = true;
+        crate::policy::storage::store_policy(
+            &state.policy_ks,
+            &module("su", 0, STEPUP_IF_NOT_AAL2),
+        )
+        .await
+        .unwrap();
+
+        // aal1 session → policy demands step-up → rejected (with approve-request).
+        auth.acr = "aal1".into();
         assert!(
-            policy_gate(&state, &auth, type_uri, &payload).await.is_ok(),
-            "higher-priority allow must let the task proceed"
+            policy_gate(&state, &auth, UNGATED_URI, &d).await.is_some(),
+            "aal1 session must be sent to step-up"
+        );
+
+        // aal2 session → requirement already satisfied → proceed.
+        auth.acr = "aal2".into();
+        assert!(
+            policy_gate(&state, &auth, UNGATED_URI, &d).await.is_none(),
+            "aal2 session must pass the step-up gate"
         );
     }
 }

--- a/vta-service/src/trust_tasks/step_up.rs
+++ b/vta-service/src/trust_tasks/step_up.rs
@@ -918,6 +918,57 @@ pub(super) async fn require_step_up(
     Some(reject_with(doc, reject))
 }
 
+/// Initiate a **self-approve** step-up for a task the Policy Decision Point
+/// decided requires it (a Rego `requireStepUp`), independent of the config
+/// floors. Mints a `PendingStepUp` whose approver is the subject itself and
+/// rejects the task with the `approve-request` — the caller elevates their own
+/// session (via a stronger factor) and re-submits.
+///
+/// This is the policy-driven analogue of [`require_step_up`], which resolves the
+/// approver from config/ACL. Delegated (someone-else-approves) approval is the
+/// job of the consent flow, not step-up.
+pub(super) async fn initiate_self_step_up(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: &TrustTask<Value>,
+) -> TrustTaskOutcome {
+    let vta_did = state
+        .config
+        .read()
+        .await
+        .vta_did
+        .clone()
+        .unwrap_or_default();
+    let (reason, authorization_context) = reason_and_context(&doc.payload);
+    let reject = match mint_pending_step_up(
+        &state.sessions_ks,
+        &vta_did,
+        &auth.did,
+        &auth.did, // self-approve: the subject is its own approver
+        false,
+        &auth.session_id,
+        reason,
+        authorization_context,
+    )
+    .await
+    {
+        Ok(approve_request) => {
+            maybe_push_step_up(state, &auth.did, &auth.did, &approve_request).await;
+            RejectReason::TaskFailed {
+                reason: "auth:step_up_required".to_string(),
+                details: Some(json!({
+                    "requiredAcr": STEP_UP_TARGET_ACR,
+                    "approveRequest": approve_request,
+                })),
+            }
+        }
+        Err(()) => RejectReason::InternalError {
+            reason: "failed to initiate step-up".to_string(),
+        },
+    };
+    reject_with(doc, reject)
+}
+
 /// Stable operation-class identifiers used to resolve step-up floors.
 /// These are the gated VTA operations; they mirror the canonical
 /// `acl/*` / `context/*` / `key/*` slugs the `auth/step-up/policy` spec uses for

--- a/vta-service/src/trust_tasks/vault.rs
+++ b/vta-service/src/trust_tasks/vault.rs
@@ -1437,14 +1437,7 @@ pub(super) async fn handle_release(
     }
 
     // Step-up gate (P0.13): honour an operator-configured `vault/release`
-    // floor before disclosing a stored secret. Placed after the role + scope
-    // checks so a caller lacking permission gets that error first, not a
-    // step-up prompt. Inert under the shipping default (step-up disabled).
-    if let Some(reject) =
-        super::step_up::require_step_up(state, auth, super::step_up::op::VAULT_RELEASE, &doc).await
-    {
-        return reject;
-    }
+    // Step-up (vault/release floor) is enforced centrally by the PDP gate.
 
     // ATM + vta_did readiness — checked here so the error is clearly
     // "infrastructure not configured" rather than a packing failure mid-flow.
@@ -1578,14 +1571,7 @@ pub(super) async fn handle_proxy_login(
         return reject;
     }
 
-    // Step-up gate (P0.13): honour a `vault/proxy-login` floor before
-    // minting a session credential for the site. Inert by default.
-    if let Some(reject) =
-        super::step_up::require_step_up(state, auth, super::step_up::op::VAULT_PROXY_LOGIN, &doc)
-            .await
-    {
-        return reject;
-    }
+    // Step-up (vault/proxy-login floor) is enforced centrally by the PDP gate.
 
     // ATM + vta_did readiness — checked here so the error is clearly
     // "infrastructure not configured" rather than a packing failure mid-flow.
@@ -1766,18 +1752,7 @@ pub(super) async fn handle_sign_trust_task(
         return reject;
     }
 
-    // Step-up gate (P0.13): honour a `vault/sign-trust-task` floor before
-    // signing as the entry's principal DID. Inert by default.
-    if let Some(reject) = super::step_up::require_step_up(
-        state,
-        auth,
-        super::step_up::op::VAULT_SIGN_TRUST_TASK,
-        &doc,
-    )
-    .await
-    {
-        return reject;
-    }
+    // Step-up (vault/sign-trust-task floor) is enforced centrally by the PDP gate.
 
     // Validate the envelope against the entry's principal identity and sign
     // (operations layer; P2.4). The typed `SignTrustTaskError` maps back to the


### PR DESCRIPTION
Phase A of wiring step-up + consent ceremonies into the Policy Decision Point. This one integrates **step-up**; task-execution **consent** (the cross-device, digest-bound approver-set flow) is a separate follow-up.

Builds on the PDP merged in #637.

## What

Wires the PDP's `RequireStepUp` decision to the existing session-elevation ceremony, and makes the pre-dispatch gate the single place step-up is decided — removing the per-handler `require_step_up` calls.

- **`PolicyInput.consumer` gains `acr`/`amr`** (session assurance), fed from the auth claims, so a Rego policy can gate on step-up state:
  `sideEffects == "destructive" and consumer.acr != "aal2" => requireStepUp`.
- **The gate now sources step-up from two places**, rejecting-with-`approve-request` if either demands it:
  1. the config `[auth.step_up]` floors via `require_step_up`, for the gated op-classes (`op_class_for` maps the 10 previously-inline ops) — this **subsumes the inline calls and preserves existing behaviour**;
  2. a Rego `requireStepUp` (self-approve) via the new `step_up::initiate_self_step_up`.
  Already-`aal2` sessions pass.
- **Removed the 10 inline `require_step_up` calls** (acl / contexts / credentials / keys / vault). The whole session-elevation → re-submit ceremony (`mint_pending_step_up`, `approve-response`, 15-min elevation) is reused unchanged.
- The gate returns `Option<TrustTaskOutcome>` (was `Result<(), RejectReason>`) so it can carry the step-up `approve-request` reject.

## Migration safety

Both toggles still ship disabled (`auth.step_up.enabled`, `policy.enforcement`), so **default behaviour is unchanged**. When step-up config is enabled, the gate reproduces the prior config-floor behaviour; Rego step-up only activates under PDP enforcement.

## Ordering change (please review)

The inline `require_step_up` ran *after* each handler's role check; the gate runs *pre-dispatch*, hence before the role check. A caller lacking the role now sees a step-up challenge before the role denial — they still can't complete the op (they'd step up, then hit the role wall), so this is a **UX/ordering change, not a security one**. It is inherent to a single pre-dispatch gate; role-before-step-up would require running the gate per-handler after role checks, defeating centralisation.

## Tests

862 lib tests pass; fmt + clippy clean. The credentials step-up unit test now exercises the gate; a new gate test covers the Rego `acr`-driven path (aal1 → step-up, aal2 → proceed).

## Follow-up (not in this PR)

- **Task-execution consent** — the new `task_consent` keyspace + pending-consent store keyed by payload digest, approver-set with `minApprovals`/`excludeRequester`, digest-bound signed decisions via `verify_trust_task_proof`, and the wake path. The existing `consent/*` tasks are messaging-bridge consent and don't fit; this is a new subsystem.