### PR TITLE
refactor(sdk)!: split base_url() into rest_url() / vta_did() / endpoint_label()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -393,7 +393,7 @@ dependencies = [
  "trust-tasks-rs",
  "url",
  "uuid",
- "vta-sdk 0.18.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vta-sdk 0.18.21",
 ]
 
 [[package]]
@@ -2438,7 +2438,7 @@ checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cnm-cli"
-version = "0.10.5"
+version = "0.10.6"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "clap",
@@ -2452,7 +2452,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.18.21",
+ "vta-sdk 0.19.0",
 ]
 
 [[package]]
@@ -3254,7 +3254,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.18.21",
+ "vta-sdk 0.19.0",
 ]
 
 [[package]]
@@ -6692,7 +6692,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "pnm-cli"
-version = "0.10.5"
+version = "0.10.6"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-resolver-cache-sdk",
@@ -6714,7 +6714,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.18.21",
+ "vta-sdk 0.19.0",
 ]
 
 [[package]]
@@ -9998,7 +9998,7 @@ dependencies = [
 
 [[package]]
 name = "vta-cli-common"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "aes-gcm",
  "affinidi-crypto",
@@ -10016,7 +10016,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.18.21",
+ "vta-sdk 0.19.0",
  "vti-common",
  "x25519-dalek",
 ]
@@ -10049,7 +10049,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.18.21",
+ "vta-sdk 0.19.0",
 ]
 
 [[package]]
@@ -10072,12 +10072,42 @@ dependencies = [
  "tracing-subscriber",
  "trust-tasks-rs",
  "uniffi",
- "vta-sdk 0.18.21",
+ "vta-sdk 0.19.0",
 ]
 
 [[package]]
 name = "vta-sdk"
 version = "0.18.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "feff04a721d51bbfdd5952b2d8d86b17ce24ad7d9891e2a4e5fce2936543218a"
+dependencies = [
+ "affinidi-crypto",
+ "affinidi-did-resolver-cache-sdk",
+ "affinidi-messaging-didcomm",
+ "affinidi-openid4vci",
+ "affinidi-openid4vp",
+ "affinidi-tdk",
+ "base64 0.22.1",
+ "chrono",
+ "curve25519-dalek",
+ "didwebvh-rs",
+ "ed25519-dalek",
+ "getrandom 0.4.3",
+ "multibase",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "vta-sdk"
+version = "0.19.0"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10133,38 +10163,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "vta-sdk"
-version = "0.18.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feff04a721d51bbfdd5952b2d8d86b17ce24ad7d9891e2a4e5fce2936543218a"
-dependencies = [
- "affinidi-crypto",
- "affinidi-did-resolver-cache-sdk",
- "affinidi-messaging-didcomm",
- "affinidi-openid4vci",
- "affinidi-openid4vp",
- "affinidi-tdk",
- "base64 0.22.1",
- "chrono",
- "curve25519-dalek",
- "didwebvh-rs",
- "ed25519-dalek",
- "getrandom 0.4.3",
- "multibase",
- "reqwest 0.13.4",
- "serde",
- "serde_json",
- "sha2 0.11.0",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "url",
- "uuid",
-]
-
-[[package]]
 name = "vta-service"
-version = "0.10.23"
+version = "0.10.24"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",
@@ -10241,7 +10241,7 @@ dependencies = [
  "utoipa-axum",
  "uuid",
  "vta-cli-common",
- "vta-sdk 0.18.21",
+ "vta-sdk 0.19.0",
  "vta-service",
  "vti-common",
  "vti-secrets",
@@ -10255,7 +10255,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-client"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "chrono",
  "reqwest 0.13.4",
@@ -10263,12 +10263,12 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.18.21",
+ "vta-sdk 0.19.0",
 ]
 
 [[package]]
 name = "vtc-service"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",
@@ -10335,7 +10335,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.18.21",
+ "vta-sdk 0.19.0",
  "vtc-service",
  "vti-common",
  "vti-secrets",
@@ -10348,7 +10348,7 @@ dependencies = [
 
 [[package]]
 name = "vti-common"
-version = "0.11.3"
+version = "0.11.4"
 dependencies = [
  "aes-gcm",
  "affinidi-did-resolver-cache-sdk",
@@ -10383,7 +10383,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.18.21",
+ "vta-sdk 0.19.0",
  "webauthn-rs",
  "zeroize",
 ]
@@ -10410,14 +10410,14 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.18.21",
+ "vta-sdk 0.19.0",
  "vta-service",
  "vti-common",
 ]
 
 [[package]]
 name = "vti-secrets"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "aws-config",
  "aws-sdk-secretsmanager",
@@ -10439,7 +10439,7 @@ dependencies = [
  "tokio",
  "tracing",
  "vaultrs",
- "vta-sdk 0.18.21",
+ "vta-sdk 0.19.0",
  "vti-common",
 ]
 

--- a/cnm-cli/Cargo.toml
+++ b/cnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cnm-cli"
 description = "CLI Tool for Verified Trust Agents operating in Verified Trust Communities"
-version = "0.10.5"
+version = "0.10.6"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -21,7 +21,7 @@ config-session = ["vta-sdk/config-session"]
 azure-secrets = ["vta-sdk/azure-secrets"]
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.18", features = ["session", "crypto-provider"] }
+vta-sdk = { path = "../vta-sdk", version = "0.19", features = ["session", "crypto-provider"] }
 vta-cli-common = { path = "../vta-cli-common", version = "0.10" }
 affinidi-did-resolver-cache-sdk = { workspace = true }
 clap = { workspace = true, features = ["env"] }

--- a/cnm-cli/src/backup.rs
+++ b/cnm-cli/src/backup.rs
@@ -26,7 +26,7 @@ const TRUST_TASK_HEADER: &str = "Trust-Task";
 const EXPORT_TASK: &str = "https://trusttasks.org/openvtc/vtc/backup/export/1.0";
 const IMPORT_TASK: &str = "https://trusttasks.org/openvtc/vtc/backup/import/1.0";
 
-/// Authenticated REST POST to a VTC `/v1/backup/*` route. `client.base_url()`
+/// Authenticated REST POST to a VTC `/v1/backup/*` route. `client.rest_url()`
 /// already carries the `/v1` mount, so the path here is relative to it.
 async fn authed_post(
     client: &VtaClient,
@@ -35,10 +35,13 @@ async fn authed_post(
     task: &str,
     body: Value,
 ) -> Result<Value, Box<dyn std::error::Error>> {
+    let base = client
+        .rest_url()
+        .ok_or("VTC backup requires a REST connection to the VTC")?;
     // Refresh / mint a REST bearer token for the VTC (aud = "VTC").
-    let token = auth::ensure_authenticated(client.base_url(), keyring_key).await?;
+    let token = auth::ensure_authenticated(base, keyring_key).await?;
     let resp = reqwest::Client::new()
-        .post(format!("{}{path}", client.base_url()))
+        .post(format!("{base}{path}"))
         .bearer_auth(&token)
         .header(TRUST_TASK_HEADER, task)
         .json(&body)

--- a/cnm-cli/src/main.rs
+++ b/cnm-cli/src/main.rs
@@ -663,7 +663,10 @@ async fn auth_login_sealed(
         opened.bundle_id_hex, opened.digest
     );
     let bundle = vta_cli_common::sealed_consumer::extract_admin_credential(opened.payload)?;
-    auth::login(&bundle, client.base_url(), keyring_key).await
+    let base = client
+        .rest_url()
+        .ok_or("login requires a REST connection to the VTC")?;
+    auth::login(&bundle, base, keyring_key).await
 }
 
 /// Resolve CLI `--recipient` / `--recipient-did` / `--recipient-nonce`
@@ -1424,7 +1427,7 @@ async fn cmd_health(
             return Ok(());
         }
     }
-    println!("  {CYAN}{:<13}{RESET} {}", "URL", client.base_url());
+    println!("  {CYAN}{:<13}{RESET} {}", "URL", client.endpoint_label());
 
     // Create a shared DID resolver for both sections
     let resolver = match DIDCacheClient::new(DIDCacheConfigBuilder::default().build()).await {

--- a/didcomm-test/Cargo.toml
+++ b/didcomm-test/Cargo.toml
@@ -13,7 +13,7 @@ name = "didcomm-test"
 path = "src/main.rs"
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.18", features = ["didcomm", "crypto-provider"] }
+vta-sdk = { path = "../vta-sdk", version = "0.19", features = ["didcomm", "crypto-provider"] }
 affinidi-tdk = { workspace = true }
 affinidi-did-resolver-cache-sdk = { workspace = true }
 tokio = { workspace = true }

--- a/pnm-cli/Cargo.toml
+++ b/pnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pnm-cli"
 description = "CLI Tool for managing a personal Verifiable Trust Agent"
-version = "0.10.5"
+version = "0.10.6"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -28,7 +28,7 @@ azure-secrets = ["vta-sdk/azure-secrets"]
 tsp = ["vta-sdk/tsp"]
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.18", features = ["session", "sealed-transfer", "attest-verify", "provision-integration", "crypto-provider"] }
+vta-sdk = { path = "../vta-sdk", version = "0.19", features = ["session", "sealed-transfer", "attest-verify", "provision-integration", "crypto-provider"] }
 affinidi-crypto = { workspace = true }
 base64 = { workspace = true }
 reqwest = { workspace = true }

--- a/pnm-cli/src/bootstrap.rs
+++ b/pnm-cli/src/bootstrap.rs
@@ -500,7 +500,7 @@ pub async fn run_provision_integration(
 
     eprintln!(
         "Integration provisioned via {} — sealed bundle written to {}",
-        client.base_url(),
+        client.endpoint_label(),
         out.display()
     );
     eprintln!();

--- a/vta-cli-common/Cargo.toml
+++ b/vta-cli-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-cli-common"
 description = "Shared CLI command handlers and rendering helpers for VTA CLIs"
 readme = "README.md"
-version = "0.10.4"
+version = "0.10.5"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -11,7 +11,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.18", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.19", features = [
   "client",
   "sealed-transfer",
   "provision-integration",

--- a/vta-cli-common/src/commands/keys.rs
+++ b/vta-cli-common/src/commands/keys.rs
@@ -105,7 +105,7 @@ pub async fn cmd_key_import(
             "failed to fetch ephemeral wrapping key from {}/keys/import/wrapping-key: {e} \
              — the VTA must support sealed-transfer key import (vta-sdk ≥ 0.8); \
              raw `private_key_multibase` over REST is no longer accepted",
-            client.base_url()
+            client.endpoint_label()
         )
     })?;
     let sealed = seal_private_key(&wrapping_key.x, &key_type, &private_key_multibase).await?;

--- a/vta-mcp/Cargo.toml
+++ b/vta-mcp/Cargo.toml
@@ -10,7 +10,7 @@ repository.workspace = true
 publish = false
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.18", features = ["client", "session", "sealed-transfer", "didcomm", "vp", "crypto-provider"] }
+vta-sdk = { path = "../vta-sdk", version = "0.19", features = ["client", "session", "sealed-transfer", "didcomm", "vp", "crypto-provider"] }
 rmcp = { version = "1.7", features = ["server", "transport-io", "macros", "schemars"] }
 schemars = "1"
 tokio = { workspace = true }

--- a/vta-mobile-core/Cargo.toml
+++ b/vta-mobile-core/Cargo.toml
@@ -61,7 +61,7 @@ affinidi-messaging-didcomm = "0.15"
 # `vta-sdk::DIDCommSession` (connect + receive_next) so the mobile approver can
 # pull VTA-pushed step-up approve-requests off the mediator — reusing the SDK
 # the VTA uses rather than reimplementing the affinidi mediator protocol.
-vta-sdk = { path = "../vta-sdk", version = "0.18", features = ["session"] }
+vta-sdk = { path = "../vta-sdk", version = "0.19", features = ["session"] }
 # iOS has no native trust store that `rustls-native-certs` can read, so the
 # mediator WebSocket (tokio-tungstenite, via affinidi-messaging-sdk) fails with
 # "no native root CA certificates found". Declaring tokio-tungstenite here with

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.18.21"
+version = "0.19.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/client/mod.rs
+++ b/vta-sdk/src/client/mod.rs
@@ -395,12 +395,51 @@ impl VtaClient {
         }
     }
 
-    /// Returns the base URL (REST) or VTA DID (DIDComm).
-    pub fn base_url(&self) -> &str {
+    /// The VTA's HTTP base URL, or `None` if this client has none.
+    ///
+    /// **This is the only accessor you may build an HTTP request from.**
+    /// `Some` on the REST transport. On DIDComm it yields the optional
+    /// REST side-channel (`None` unless the client was constructed with
+    /// one) — a DIDComm client is not guaranteed to know an HTTP URL at
+    /// all, so callers must handle `None` rather than assume one exists.
+    ///
+    /// Replaces the former `base_url()`, which returned the VTA *DID* on
+    /// DIDComm and so silently produced `did:…/some/path` when
+    /// interpolated into a URL.
+    pub fn rest_url(&self) -> Option<&str> {
+        match &self.transport {
+            Transport::Rest { base_url, .. } => Some(base_url),
+            #[cfg(feature = "session")]
+            Transport::DIDComm { rest_url, .. } => rest_url.as_deref(),
+        }
+    }
+
+    /// The VTA's DID, or `None` if this client doesn't know it.
+    ///
+    /// `Some` on the DIDComm transport (the session is established
+    /// against it). `None` on REST — a REST client is never told the
+    /// VTA's DID.
+    pub fn vta_did(&self) -> Option<&str> {
+        match &self.transport {
+            Transport::Rest { .. } => None,
+            #[cfg(feature = "session")]
+            Transport::DIDComm { session, .. } => Some(&session.vta_did),
+        }
+    }
+
+    /// Human-readable identifier for the VTA this client talks to — the
+    /// REST URL, or the VTA DID on a DIDComm client with no REST URL.
+    ///
+    /// **Display and diagnostics only.** The value is a URL on one
+    /// transport and a DID on the other, so never interpolate it into a
+    /// request — use [`rest_url`](Self::rest_url) for that.
+    pub fn endpoint_label(&self) -> &str {
         match &self.transport {
             Transport::Rest { base_url, .. } => base_url,
             #[cfg(feature = "session")]
-            Transport::DIDComm { session, .. } => &session.vta_did,
+            Transport::DIDComm {
+                session, rest_url, ..
+            } => rest_url.as_deref().unwrap_or(&session.vta_did),
         }
     }
 
@@ -1131,19 +1170,19 @@ mod tests {
     #[test]
     fn test_new_strips_trailing_slash() {
         let client = VtaClient::new("http://localhost:3000/");
-        assert_eq!(client.base_url(), "http://localhost:3000");
+        assert_eq!(client.rest_url(), Some("http://localhost:3000"));
     }
 
     #[test]
     fn test_new_strips_multiple_trailing_slashes() {
         let client = VtaClient::new("http://localhost:3000///");
-        assert_eq!(client.base_url(), "http://localhost:3000");
+        assert_eq!(client.rest_url(), Some("http://localhost:3000"));
     }
 
     #[test]
     fn test_new_no_trailing_slash_unchanged() {
         let client = VtaClient::new("http://localhost:3000");
-        assert_eq!(client.base_url(), "http://localhost:3000");
+        assert_eq!(client.rest_url(), Some("http://localhost:3000"));
     }
 
     #[tokio::test]

--- a/vta-sdk/src/integration/auth.rs
+++ b/vta-sdk/src/integration/auth.rs
@@ -263,7 +263,7 @@ async fn try_rest(
         Ok(client) => {
             tracing::info!(
                 context = context_id,
-                vta_url = client.base_url(),
+                vta_url = client.endpoint_label(),
                 "Connected to VTA (REST, auto-refresh enabled)",
             );
             Ok(client)

--- a/vta-sdk/tests/auth_light_rest.rs
+++ b/vta-sdk/tests/auth_light_rest.rs
@@ -320,7 +320,7 @@ async fn from_credential_authenticates_and_exposes_token() {
 
     let client = VtaClient::from_credential(&cred, None).await.unwrap();
     assert_eq!(client.token_expires_at().await, Some(1_700_001_000));
-    assert_eq!(client.base_url(), server.uri().trim_end_matches('/'));
+    assert_eq!(client.rest_url(), Some(server.uri().trim_end_matches('/')));
 }
 
 #[tokio::test]
@@ -336,7 +336,7 @@ async fn from_credential_url_override_wins_over_bundle() {
     let client = VtaClient::from_credential(&cred, Some(&server.uri()))
         .await
         .unwrap();
-    assert_eq!(client.base_url(), server.uri().trim_end_matches('/'));
+    assert_eq!(client.rest_url(), Some(server.uri().trim_end_matches('/')));
 }
 
 /// Exercise `client::ensure_token_valid`'s refresh-on-expiry path:

--- a/vta-sdk/tests/client_rest.rs
+++ b/vta-sdk/tests/client_rest.rs
@@ -1583,12 +1583,12 @@ async fn network_error_when_server_unreachable() {
     assert!(err.is_network(), "got {err:?}");
 }
 
-// ── Base URL accessors ──────────────────────────────────────────────
+// ── REST URL accessors ──────────────────────────────────────────────
 
 #[tokio::test]
-async fn base_url_returned_after_construction() {
+async fn rest_url_returned_after_construction() {
     let c = VtaClient::new("https://vta.example.com");
-    assert_eq!(c.base_url(), "https://vta.example.com");
+    assert_eq!(c.rest_url(), Some("https://vta.example.com"));
 }
 
 #[tokio::test]

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.10.23"
+version = "0.10.24"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -94,7 +94,7 @@ vti-common = { path = "../vti-common", version = "0.11", features = ["encryption
 # from this crate into a shared crate so external integrations can reuse them).
 # Per-backend features are activated by this crate's matching features below.
 vti-secrets = { path = "../vti-secrets", version = "0.1" }
-vta-sdk = { path = "../vta-sdk", version = "0.18", features = ["didcomm", "sealed-transfer", "provision-integration", "openapi", "crypto-provider"] }
+vta-sdk = { path = "../vta-sdk", version = "0.19", features = ["didcomm", "sealed-transfer", "provision-integration", "openapi", "crypto-provider"] }
 # DID-VM-resolved WebAuthn assertion verifier — drives the new
 # `vta/auth/passkey-login-{start,finish}/1.0` trust-task handlers.
 # Distinct from `webauthn-rs` (which drives the passkey *enrolment*
@@ -262,7 +262,7 @@ vta-service = { path = ".", features = ["test-support"] }
 # `provision_admin_rotated_via_rest` + DI-signed REST auth) the `MockVta`
 # bootstrap→provision e2e tests drive (issues #406, DI-auth follow-up). Kept out
 # of the production `vta-sdk` dep above so the server build stays lean.
-vta-sdk = { path = "../vta-sdk", version = "0.18", features = ["provision-client"] }
+vta-sdk = { path = "../vta-sdk", version = "0.19", features = ["provision-client"] }
 # Mock HTTP server for the did-hosting-daemon REST auth flow tests. Each
 # test spins up a real local server bound to a random port, validates
 # the JWS-signed request bodies the daemon would see, and serves

--- a/vtc-client/Cargo.toml
+++ b/vtc-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vtc-client"
 description = "Client SDK for Verifiable Trust Communities (VTC) — auth, members, join, removal, policies"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -14,7 +14,7 @@ repository.workspace = true
 # Reuses the VTA SDK's challenge-response auth (audience-agnostic) and the
 # published join-request protocol types. `session` gates `auth_light` +
 # `protocols`.
-vta-sdk = { path = "../vta-sdk", version = "0.18", features = ["session"] }
+vta-sdk = { path = "../vta-sdk", version = "0.19", features = ["session"] }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.11.1"
+version = "0.11.2"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -102,7 +102,7 @@ vti-common = { path = "../vti-common", version = "0.11", features = [
 # factory + `*SecretStore` names are a thin facade over these). Per-backend
 # features are activated by this crate's matching features above.
 vti-secrets = { path = "../vti-secrets", version = "0.1" }
-vta-sdk = { path = "../vta-sdk", version = "0.18", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.19", features = [
   "didcomm",
   "session",
   "config-session",

--- a/vti-common/Cargo.toml
+++ b/vti-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-common"
 description = "Shared server-side infrastructure for VTA and VTC services"
 readme = "README.md"
-version = "0.11.3"
+version = "0.11.4"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -48,7 +48,7 @@ openapi = ["dep:utoipa", "dep:utoipa-axum"]
 # `default-features = false` skips the optional client transports
 # (didcomm, sealed-transfer, etc.); we only consume the type
 # definitions in the default feature set.
-vta-sdk = { path = "../vta-sdk", version = "0.18", default-features = false }
+vta-sdk = { path = "../vta-sdk", version = "0.19", default-features = false }
 async-trait = "0.1"
 axum = { workspace = true }
 axum-extra = { workspace = true }

--- a/vti-secrets/Cargo.toml
+++ b/vti-secrets/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-secrets"
 description = "Pluggable secret-store backends + integration onboarding flow for Verifiable Trust Infrastructure"
 readme = "README.md"
-version = "0.1.5"
+version = "0.1.6"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -54,7 +54,7 @@ tracing = { workspace = true }
 tokio = { workspace = true }
 
 # Onboarding feature: the SDK session/auth state machine + local did:key mint.
-vta-sdk = { path = "../vta-sdk", version = "0.18", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.19", features = [
   "session",
 ], optional = true }
 ed25519-dalek = { workspace = true, optional = true }


### PR DESCRIPTION
Follow-up to #640, which fixed the symptom. This removes the trap that caused it.

## The trap

```rust
// vta-sdk/src/client/mod.rs — before
/// Returns the base URL (REST) or VTA DID (DIDComm).
pub fn base_url(&self) -> &str {
    match &self.transport {
        Transport::Rest { base_url, .. } => base_url,
        Transport::DIDComm { session, .. } => &session.vta_did,   // a DID, not a URL
    }
}
```

One accessor, one `&str`, two incompatible meanings. Interpolating it into a URL type-checks on both transports and fails at runtime on exactly one of them — which is how #640 shipped: `pnm did-mgmt dids get-log` built `did:webvh:…/did/<did>/log` and reqwest rejected the `did:` scheme. Nothing in the type system stood in the way of the next occurrence.

## The change

Three accessors, each with one meaning:

| accessor | returns | use for |
|---|---|---|
| `rest_url() -> Option<&str>` | REST base URL; on DIDComm the optional REST side-channel, else `None` | **the only one you may build a request from** |
| `vta_did() -> Option<&str>` | `Some` on DIDComm, `None` on REST | the VTA's DID |
| `endpoint_label() -> &str` | URL, or DID when there's no URL | display / diagnostics only |

`rest_url()` returning `Option` is the load-bearing part: a DIDComm client genuinely may not have an HTTP URL, so callers must now handle its absence instead of silently receiving a DID. `endpoint_label()` exists so the display-only sites don't have to unwrap an `Option` just to print something, and is named so that passing it to `format!("{}/path")` reads as wrong.

## Migrated call sites

Display-only, now `endpoint_label()`:
- `vta-sdk/src/integration/auth.rs` — "Connected to VTA" tracing field
- `vta-cli-common/src/commands/keys.rs` — wrapping-key error hint
- `pnm-cli/src/bootstrap.rs` — "Integration provisioned via …" summary

Build real HTTP requests, now `rest_url()` with an explicit `None` error:
- `cnm-cli/src/backup.rs` — VTC `/v1/backup/*` POST
- `cnm-cli/src/main.rs` — VTC login

These were all correct in practice (cnm's client is REST-only), but they were correct by accident; now it's enforced.

## Versioning

Breaking removal of a public method → `vta-sdk` 0.18.21 → **0.19.0**. The workspace pins internal deps `major.minor`, so every `vta-sdk = { version = "0.18" }` pin moves to `"0.19"`, and each publishable dependent gets a version bump:

`vti-common` 0.11.4 · `vti-secrets` 0.1.6 · `vta-cli-common` 0.10.5 · `vta-service` 0.10.24 · `vtc-service` 0.11.2 · `pnm-cli` 0.10.6 · `cnm-cli` 0.10.6 · `vtc-client` 0.1.4

Rebased onto #643. That PR bumped `vti-common` and `vtc-service` too, so those two are bumped once more here on top of its numbers — git merged the identical bumps silently, which left their manifests changed but un-bumped. #643's new `scripts/check-version-bumps.sh` catches exactly that, and now passes on all nine crates.

That accounts for most of the diff; the actual code change is ~40 lines.

## Verification

`cargo check --workspace --all-targets` clean; `cargo test -p vta-sdk` green (183 tests). The SDK's own `base_url` assertions were updated to `rest_url()`.
