### PR TITLE
fix(release): unstick Publish — bump drifted crates, refresh stale vta-sdk pin, add version-bump guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,29 @@ jobs:
         with:
           command: check advisories bans sources licenses
 
+  release-guards:
+    # Fail a PR that edits a published crate's source without bumping its
+    # version. The publish workflow SKIPS any crate whose version is already
+    # on crates.io, so an unbumped source edit leaves the registry holding
+    # stale code — and the next crate published against it fails its
+    # registry-resolved verify build. That is exactly how vti-common 0.11.2
+    # and vtc-service 0.11.0 went stale and kept Publish red, while the
+    # path-dep workspace build stayed green and hid it. See the script header.
+    #
+    # PR-only: the guard diffs against the PR base, which a push to main has
+    # no meaningful equivalent of.
+    name: release guards
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Full history so the guard can diff against, and read manifests
+          # from, the PR's base commit.
+          fetch-depth: 0
+      - name: Version-bump guard for changed publishable crates
+        run: bash scripts/check-version-bumps.sh "${{ github.event.pull_request.base.sha }}"
+
   features:
     # Build the most-used non-default feature combinations so a misuse
     # of `cfg(feature = "...")` doesn't silently rot. Default-feature

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -393,7 +393,7 @@ dependencies = [
  "trust-tasks-rs",
  "url",
  "uuid",
- "vta-sdk 0.18.14",
+ "vta-sdk 0.18.21 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -10077,36 +10077,6 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.18.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bab5ab7ffa4362d8362ef3f9767e965395d54c9f7e0512071231aeb7db6656b"
-dependencies = [
- "affinidi-crypto",
- "affinidi-did-resolver-cache-sdk",
- "affinidi-messaging-didcomm",
- "affinidi-openid4vci",
- "affinidi-openid4vp",
- "affinidi-tdk",
- "base64 0.22.1",
- "chrono",
- "curve25519-dalek",
- "didwebvh-rs",
- "ed25519-dalek",
- "getrandom 0.4.3",
- "multibase",
- "reqwest 0.13.4",
- "serde",
- "serde_json",
- "sha2 0.11.0",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "url",
- "uuid",
-]
-
-[[package]]
-name = "vta-sdk"
 version = "0.18.21"
 dependencies = [
  "affinidi-bbs",
@@ -10160,6 +10130,36 @@ dependencies = [
  "x25519-dalek",
  "x509-parser 0.18.1",
  "zeroize",
+]
+
+[[package]]
+name = "vta-sdk"
+version = "0.18.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "feff04a721d51bbfdd5952b2d8d86b17ce24ad7d9891e2a4e5fce2936543218a"
+dependencies = [
+ "affinidi-crypto",
+ "affinidi-did-resolver-cache-sdk",
+ "affinidi-messaging-didcomm",
+ "affinidi-openid4vci",
+ "affinidi-openid4vp",
+ "affinidi-tdk",
+ "base64 0.22.1",
+ "chrono",
+ "curve25519-dalek",
+ "didwebvh-rs",
+ "ed25519-dalek",
+ "getrandom 0.4.3",
+ "multibase",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
+ "uuid",
 ]
 
 [[package]]
@@ -10268,7 +10268,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-service"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",
@@ -10348,7 +10348,7 @@ dependencies = [
 
 [[package]]
 name = "vti-common"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "aes-gcm",
  "affinidi-did-resolver-cache-sdk",

--- a/scripts/check-version-bumps.sh
+++ b/scripts/check-version-bumps.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# Guard against the "edited a published crate's source but forgot to bump its
+# version" trap that kept the Publish job red on main.
+#
+# What happened: vti-common's source gained `Session::last_seen` /
+# `acr_expires_at`, `resolve_did_session`, `Claims::with_jti` and a new
+# `mint_access_token` arity, but its version stayed at 0.11.2 — which was
+# already on crates.io. The publish workflow skips any crate whose version is
+# already published ("already on crates.io — skipping"), so the registry kept
+# the PRE-change 0.11.2 source. vta-service was then published at a fresh
+# version, and `cargo publish`'s registry-resolved verify build (which ignores
+# the workspace's path deps) compiled it against that stale vti-common and hit
+# E0432/E0050/E0560/E0609/E0599 — blocking the whole release. The local
+# path-dep workspace build was green the entire time, so nothing caught it
+# pre-merge. vtc-service had drifted the same way.
+#
+# This guard runs on PRs: for every PUBLISHABLE workspace crate whose *source*
+# changed between the base ref and HEAD, it requires the crate's Cargo.toml
+# `version` to differ from the base ref's version. Forcing a bump alongside any
+# source edit means main never accumulates an unpublished source delta against a
+# stale crates.io version — the release pipeline then publishes the new source
+# at a fresh version and the registry never goes incompatible.
+#
+# "Source" = anything under the crate dir EXCEPT tests/, benches/, examples/,
+# *.md and CHANGELOG* (test-/doc-only changes get no bump, per repo convention).
+# `publish = false` crates are skipped — they never reach crates.io, so a stale
+# registry source is impossible for them.
+#
+# Usage: scripts/check-version-bumps.sh [BASE_REF]   (default: origin/main)
+# Portable to macOS bash 3.2 / BSD userland.
+set -euo pipefail
+
+BASE="${1:-origin/main}"
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+if [ -t 1 ]; then
+  RED=$'\033[0;31m'; GREEN=$'\033[0;32m'; YELLOW=$'\033[1;33m'; CYAN=$'\033[0;36m'; NC=$'\033[0m'
+else
+  RED=''; GREEN=''; YELLOW=''; CYAN=''; NC=''
+fi
+
+if ! git rev-parse --verify --quiet "$BASE" >/dev/null; then
+  echo "${RED}error:${NC} base ref '$BASE' not found. Pass a reachable ref, e.g. origin/main." >&2
+  exit 2
+fi
+
+# Files changed between the merge-base of BASE and HEAD (three-dot = PR diff).
+changed=$(git diff --name-only "$BASE"...HEAD)
+if [ -z "$changed" ]; then
+  echo "${GREEN}No changes vs $BASE — nothing to check.${NC}"
+  exit 0
+fi
+
+# ALL crates as  pub<TAB>name<TAB>relative-crate-dir  lines, longest dir first
+# so the most specific crate wins for nested manifests (e.g. affinidi-tdk vs
+# affinidi-tdk/common). `pub` is 1 for publishable, 0 otherwise.
+#
+# We include non-publishable crates here (not just publishable ones) so a file
+# under a nested `publish = false` package (e.g. the mediator-setup tool nested
+# in the publishable affinidi-messaging-mediator dir) is attributed to that
+# nested package and skipped — rather than bubbling up to the publishable parent
+# and demanding a spurious bump for source that never reaches crates.io.
+crates=$(cargo metadata --format-version 1 --no-deps 2>/dev/null \
+  | jq -r '.packages[]
+      | (if (.publish == null or .publish == ["crates.io"]) then "1" else "0" end) as $pub
+      | "\($pub)\t\(.name)\t\(.manifest_path)"' \
+  | sed "s|\t$ROOT/|\t|; s|/Cargo.toml\$||" \
+  | awk -F'\t' '{ print length($3)"\t"$0 }' \
+  | sort -rn \
+  | cut -f2-)
+
+# classify a path (relative to a crate dir) as source-or-not
+is_source() {
+  case "$1" in
+    tests/*|*/tests/*) return 1 ;;
+    benches/*|*/benches/*) return 1 ;;
+    examples/*|*/examples/*) return 1 ;;
+    *.md) return 1 ;;
+    CHANGELOG*|*/CHANGELOG*) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+# attribute a changed file to its most-specific crate dir (publishable or not)
+crate_of() { # $1 = changed path -> prints "pub<TAB>name<TAB>dir" or nothing
+  local path="$1" pub name dir
+  while IFS=$'\t' read -r pub name dir; do
+    [ -z "$dir" ] && continue
+    case "$path" in
+      "$dir"/*) printf '%s\t%s\t%s\n' "$pub" "$name" "$dir"; return 0 ;;
+    esac
+  done <<EOF
+$crates
+EOF
+}
+
+# collect publishable crates with a real source change (newline-separated "name\tdir")
+touched=""
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  hit=$(crate_of "$f") || true
+  [ -z "$hit" ] && continue
+  pub=$(printf '%s' "$hit" | cut -f1)
+  name=$(printf '%s' "$hit" | cut -f2)
+  dir=$(printf '%s' "$hit" | cut -f3)
+  # A file whose most-specific owner is a non-publishable crate never reaches
+  # crates.io (even when nested under a publishable parent dir) — skip it.
+  [ "$pub" = "1" ] || continue
+  rel=${f#"$dir"/}
+  is_source "$rel" || continue
+  case "
+$touched" in
+    *"
+$name	$dir"*) : ;;            # already recorded
+    *) touched="$touched
+$name	$dir" ;;
+  esac
+done <<EOF
+$changed
+EOF
+
+touched=$(printf '%s\n' "$touched" | sed '/^$/d')
+
+if [ -z "$touched" ]; then
+  echo "${GREEN}No publishable-crate source changed vs $BASE — nothing to check.${NC}"
+  exit 0
+fi
+
+echo "${CYAN}=== Version-bump guard (base: $BASE) ===${NC}"
+echo ""
+
+fail=0
+while IFS=$'\t' read -r name dir; do
+  [ -z "$name" ] && continue
+  manifest="$dir/Cargo.toml"
+  cur=$(grep -E '^[[:space:]]*version[[:space:]]*=' "$manifest" | head -1 | sed -E 's/.*"([^"]+)".*/\1/')
+  base=$(git show "$BASE:$manifest" 2>/dev/null | grep -E '^[[:space:]]*version[[:space:]]*=' | head -1 | sed -E 's/.*"([^"]+)".*/\1/' || true)
+  if [ -z "$base" ]; then
+    echo "  ${GREEN}ok${NC}   $name: new crate (no version at $BASE) -> $cur"
+  elif [ "$cur" != "$base" ]; then
+    echo "  ${GREEN}ok${NC}   $name: $base -> $cur"
+  else
+    echo "  ${RED}MISS${NC} $name: source changed but version still $cur (unchanged from $BASE)"
+    fail=1
+  fi
+done <<EOF
+$touched
+EOF
+
+echo ""
+if [ "$fail" -eq 0 ]; then
+  echo "${GREEN}All changed publishable crates were version-bumped.${NC}"
+else
+  echo "${RED}Some changed publishable crates were NOT version-bumped.${NC}"
+  echo "Bump the crate's Cargo.toml version (and CHANGELOG) so the source change actually"
+  echo "publishes. If the change is genuinely test-/doc-only, move it out of the crate's"
+  echo "source paths or adjust this guard's exclusions."
+  exit 1
+fi

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.11.0"
+version = "0.11.1"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vti-common/Cargo.toml
+++ b/vti-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-common"
 description = "Shared server-side infrastructure for VTA and VTC services"
 readme = "README.md"
-version = "0.11.2"
+version = "0.11.3"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true


### PR DESCRIPTION
## Why

The **Publish** job has been red on `main` independently of any PR (the identical errors appear in the 07-11 run, before the recent CI work). It fails packaging `vta-service` with 8 compile errors.

## Root cause — the publish script *skips* already-published versions

```bash
if [ "$status" = "200" ]; then
  echo "✓ ${crate} ${version} already on crates.io — skipping"
```

So **a source edit without a version bump leaves the registry holding the PRE-edit code.** `vti-common` had drifted exactly that way — its source gained `Session::last_seen` / `acr_expires_at`, `resolve_did_session`, `Claims::with_jti`, and a new `mint_access_token` arity, but stayed at **0.11.2**, already published.

`vta-service` **is** at a fresh version (0.10.23, unpublished), so it *does* get verified — and `cargo publish`'s registry-resolved verify build compiled it against that stale vti-common:

```
error[E0432]: unresolved import `crate::auth::session::resolve_did_session`
error[E0560]: struct `vti_common::auth::session::Session` has no field named `last_seen`
error[E0599]: no method named `with_jti` found for struct `Claims`
... (6 total, all vti-common)
```

(`vta-service/src/auth/session.rs` is `pub use vti_common::auth::session::*;` — hence even the "own-crate" `E0432`.)

**The path-dep workspace build was green the entire time**, which is exactly why nothing caught it.

## What

**1. Bump the drifted crates.** I diffed *every* published crate against its local source rather than guessing. Exactly two had drifted:

| crate | | |
|---|---|---|
| `vti-common` | 0.11.2 → **0.11.3** | published copy stale |
| `vtc-service` | 0.11.0 → **0.11.1** | published copy stale |

(All consumers use caret `"0.11"`, so both remain satisfied.)

**2. Refresh a stale lock pin.** The lock carried a *second*, registry copy of `vta-sdk` at **0.18.14** (via `affinidi-messaging-mediator`), and `cargo publish --locked` used it for the verify — so `TASK_ACL_SWAP_KEY_1_0` / `TASK_MESSAGING_PING_0_1` were missing (2 of the 8 errors). Repinned to 0.18.21. Confirmed by reproducing the verify locally: **8 errors → 6**.

**3. Add the guard.** `scripts/check-version-bumps.sh` (ported from `affinidi-tdk-rs`, which added it after the same class of break) runs as a PR-only **`release-guards`** job: any publishable crate whose *source* changes must also change its version. `tests/`, `benches/`, `examples/`, `*.md`, `CHANGELOG*` excluded; `publish = false` crates skipped.

Verified **both directions** — it passes the two bumps here, and correctly flags an unbumped edit:

```
  ok   vtc-service: 0.11.0 -> 0.11.1
  ok   vti-common: 0.11.2 -> 0.11.3
  MISS vti-secrets: source changed but version still 0.1.5
```

## What I could *not* verify locally — stated plainly

The remaining 6 errors can't be reproduced away on my machine: `cargo package` resolves `vti-common` from the **registry**, and 0.11.3 isn't published yet (`[patch.crates-io]` is ignored by the verify build — I tried).

They resolve in CI because the publish script walks crates in **topological order** (`vti-common` before `vta-service`) and `cargo publish` blocks until each version is queryable in the index. `cargo check -p vta-service` against the local vti-common — byte-identical to what 0.11.3 will contain — is clean.

So: **the first Publish run on merge is the real proof.** If anything else has drifted behind these two, it'll surface there, and the guard stops it recurring.

`Cargo.lock` is regenerated and `cargo check --workspace --locked` passes, so `cargo publish --locked` won't hit the lock-drift failure that sank vta-sdk 0.18.19.