### PR TITLE
fix(vta): surface remote DID-hosting rejections with their real status

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10164,7 +10164,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.10.24"
+version = "0.10.25"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.10.24"
+version = "0.10.25"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/didcomm_bridge.rs
+++ b/vta-service/src/didcomm_bridge.rs
@@ -12,6 +12,43 @@ use vta_sdk::protocols::{PROBLEM_REPORT_TYPE, extract_problem_report};
 /// Map of pending request IDs to oneshot senders for response routing.
 pub type PendingMap = Arc<std::sync::Mutex<HashMap<String, oneshot::Sender<Message>>>>;
 
+/// Translate a remote peer's DIDComm problem-report into a typed [`AppError`].
+///
+/// Every problem report used to collapse into a 502, which made a remote's
+/// "you sent an invalid path" indistinguishable from a genuine upstream
+/// outage: both reached the operator as a 5xx, and the SDK maps *any* 5xx to
+/// `VtaError::Server`, whose CLI hint reads "This is a VTA-side failure.
+/// Check server logs or contact the operator." That is precisely the wrong
+/// thing to tell someone whose request the *host* rejected for a reason they
+/// can act on.
+///
+/// Codes are namespaced per protocol (`e.p.did.*`, `e.p.registration.*`,
+/// `e.p.msg.*`) but the trailing segment is the shared vocabulary, so match
+/// on that. The did-hosting service's `AppError::didcomm_code()` is the
+/// authoritative producer for the `e.p.did.*` arm; this is its inverse.
+///
+/// Unrecognised codes — and every `internal-error` — stay a 502. A failure we
+/// can't attribute to the caller *is* a gateway failure, and silently
+/// re-labelling an upstream crash as a 400 would be a worse lie than the one
+/// being fixed.
+///
+/// Remote auth denials map to [`AppError::Forbidden`] (403), never
+/// `Unauthorized` (401): the caller's credential to *this* VTA is valid — it
+/// is the VTA's own DID that lacks rights on the host. A 401 would make the
+/// CLI print a misleading "token may be expired" hint (see the
+/// `e.p.msg.forbidden` note in the workspace CLAUDE.md).
+fn problem_report_to_app_error(code: &str, comment: &str) -> AppError {
+    let detail = format!("remote peer rejected the request: {comment} [{code}]");
+    match code.rsplit('.').next().unwrap_or_default() {
+        "unauthorized" | "forbidden" => AppError::Forbidden(detail),
+        "path-unavailable" | "conflict" => AppError::Conflict(detail),
+        "mnemonic-not-found" | "not-found" => AppError::NotFound(detail),
+        "path-invalid" | "invalid-log" | "witness-invalid" | "validation-error" | "bad-request"
+        | "replay-detected" | "size-exceeded" | "quota-exceeded" => AppError::Validation(detail),
+        _ => bad_gateway_error(detail),
+    }
+}
+
 /// Bridge between REST/DIDComm handlers and the DIDComm service's outbound
 /// send capability.
 ///
@@ -164,7 +201,7 @@ impl DIDCommBridge {
 
         if response.typ == problem_report_type || response.typ == PROBLEM_REPORT_TYPE {
             let (code, comment) = extract_problem_report(&response.body);
-            return Err(bad_gateway_error(format!("{code}: {comment}")));
+            return Err(problem_report_to_app_error(&code, &comment));
         }
 
         if response.typ != expected_type {
@@ -258,7 +295,7 @@ impl DIDCommBridge {
         // Check for problem report
         if response.typ == problem_report_type || response.typ == PROBLEM_REPORT_TYPE {
             let (code, comment) = extract_problem_report(&response.body);
-            return Err(bad_gateway_error(format!("{code}: {comment}")));
+            return Err(problem_report_to_app_error(&code, &comment));
         }
 
         // Verify expected type
@@ -270,5 +307,96 @@ impl DIDCommBridge {
         }
 
         Ok(response)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::StatusCode;
+    use axum::response::IntoResponse;
+
+    /// The status the operator actually receives — drive the real
+    /// `IntoResponse` rather than re-asserting the variant, so a future
+    /// change to `AppError`'s status mapping can't quietly re-break this.
+    fn status_of(code: &str) -> StatusCode {
+        problem_report_to_app_error(code, "boom")
+            .into_response()
+            .status()
+    }
+
+    /// The did-hosting service's `AppError::didcomm_code()` is the
+    /// authoritative producer of these codes; this pins our inverse of it.
+    /// The bug this fixes: every one of these used to come back 502, and the
+    /// SDK maps any 5xx to `VtaError::Server` → "This is a VTA-side failure",
+    /// which is a lie when the *host* rejected an actionable request.
+    #[test]
+    fn remote_client_errors_keep_their_meaning() {
+        // The exact code from the root-DID register failure.
+        assert_eq!(status_of("e.p.did.path-invalid"), StatusCode::BAD_REQUEST);
+        assert_eq!(status_of("e.p.did.invalid-log"), StatusCode::BAD_REQUEST);
+        assert_eq!(
+            status_of("e.p.did.witness-invalid"),
+            StatusCode::BAD_REQUEST
+        );
+        assert_eq!(
+            status_of("e.p.did.validation-error"),
+            StatusCode::BAD_REQUEST
+        );
+        assert_eq!(status_of("e.p.did.quota-exceeded"), StatusCode::BAD_REQUEST);
+        assert_eq!(status_of("e.p.did.size-exceeded"), StatusCode::BAD_REQUEST);
+        assert_eq!(
+            status_of("e.p.did.replay-detected"),
+            StatusCode::BAD_REQUEST
+        );
+
+        // Slot taken → the operator needs `--force`, not a bug report.
+        assert_eq!(status_of("e.p.did.path-unavailable"), StatusCode::CONFLICT);
+        assert_eq!(
+            status_of("e.p.did.mnemonic-not-found"),
+            StatusCode::NOT_FOUND
+        );
+    }
+
+    /// Remote auth denials are 403, never 401 — the caller's token for *this*
+    /// VTA is fine; it's the VTA's DID that lacks rights on the host. A 401
+    /// would make the CLI print a misleading "token may be expired" hint.
+    #[test]
+    fn remote_auth_denial_is_forbidden_not_unauthorized() {
+        for code in [
+            "e.p.did.unauthorized",
+            "e.p.registration.unauthorized",
+            "e.p.stats.unauthorized",
+            "e.p.msg.forbidden",
+        ] {
+            assert_eq!(status_of(code), StatusCode::FORBIDDEN, "code {code}");
+        }
+    }
+
+    /// A genuine upstream failure stays a 502. Re-labelling an upstream crash
+    /// as a caller error would be a worse lie than the one being fixed.
+    #[test]
+    fn upstream_failures_and_unknown_codes_stay_bad_gateway() {
+        for code in [
+            "e.p.did.internal-error",
+            "e.p.registration.internal-error",
+            "e.p.did.some-code-we-have-never-seen",
+            "",
+        ] {
+            assert_eq!(status_of(code), StatusCode::BAD_GATEWAY, "code {code}");
+        }
+    }
+
+    /// The remote's comment and code both survive into the operator-visible
+    /// message — without them the error is unactionable.
+    #[test]
+    fn detail_carries_remote_comment_and_code() {
+        let err = problem_report_to_app_error(
+            "e.p.did.path-invalid",
+            "path segments must contain only lowercase letters, digits, and hyphens",
+        );
+        let msg = err.to_string();
+        assert!(msg.contains("lowercase letters"), "lost comment: {msg}");
+        assert!(msg.contains("e.p.did.path-invalid"), "lost code: {msg}");
     }
 }

--- a/vta-service/src/messaging/handlers.rs
+++ b/vta-service/src/messaging/handlers.rs
@@ -1030,7 +1030,10 @@ fn register_err_to_app_error(e: operations::did_webvh::RegisterDidWithServerErro
             AppError::NotFound(msg)
         }
         E::AlreadyServerManaged { .. } | E::Conflict(_) => AppError::Conflict(e.to_string()),
-        E::Transport(msg) | E::Publish(msg) => AppError::Internal(format!("publish: {msg}")),
+        E::Transport(msg) => AppError::Internal(format!("publish: {msg}")),
+        // Pass the host's typed rejection through untouched — see
+        // `RegisterDidWithServerError::Publish`.
+        E::Publish(e) => e,
         E::DidUrlParse { .. } => AppError::Validation(e.to_string()),
         E::Storage(msg) => AppError::Internal(msg),
     }

--- a/vta-service/src/operations/did_webvh/register_server.rs
+++ b/vta-service/src/operations/did_webvh/register_server.rs
@@ -85,8 +85,14 @@ pub enum RegisterDidWithServerError {
     LogMissing(String),
     #[error("transport setup failed: {0}")]
     Transport(String),
+    /// The hosting server rejected the publish. Carries the typed
+    /// [`AppError`] the bridge built from the remote's problem report, so
+    /// its status survives to the operator: a remote "invalid path" stays a
+    /// 400 and a remote "needs force" stays a 409, instead of every upstream
+    /// rejection flattening into a 500 "VTA-side failure". Stringifying this
+    /// is what made the real cause unreachable.
     #[error("publish to server failed: {0}")]
-    Publish(String),
+    Publish(AppError),
     #[error("storage error: {0}")]
     Storage(String),
     #[error("could not derive URL from DID `{did}`: {reason}")]
@@ -196,7 +202,7 @@ pub async fn register_did_with_server(
         params.domain.as_deref(),
     )
     .await
-    .map_err(|e| RegisterDidWithServerError::Publish(e.to_string()))?;
+    .map_err(RegisterDidWithServerError::Publish)?;
 
     // 6. Optimistic-concurrency check. Re-load the record and assert
     //    nothing changed between the initial read and now (where we're

--- a/vta-service/src/routes/did_webvh.rs
+++ b/vta-service/src/routes/did_webvh.rs
@@ -508,7 +508,12 @@ fn map_register_err(e: RegisterDidWithServerError) -> AppError {
             AppError::NotFound(msg)
         }
         E::AlreadyServerManaged { .. } | E::Conflict(_) => AppError::Conflict(e.to_string()),
-        E::Transport(msg) | E::Publish(msg) => AppError::Internal(format!("publish: {msg}")),
+        E::Transport(msg) => AppError::Internal(format!("publish: {msg}")),
+        // Pass the host's typed rejection through untouched. Wrapping it in
+        // `Internal` told the operator the VTA had failed when in fact the
+        // hosting server had refused their request for a reason they can act
+        // on. See `RegisterDidWithServerError::Publish`.
+        E::Publish(e) => e,
         E::DidUrlParse { .. } => AppError::Validation(e.to_string()),
         E::Storage(msg) => AppError::Internal(msg),
     }

--- a/vta-service/src/trust_tasks/webvh.rs
+++ b/vta-service/src/trust_tasks/webvh.rs
@@ -474,7 +474,10 @@ fn map_register_err(e: RegisterDidWithServerError) -> AppError {
             AppError::NotFound(msg)
         }
         E::AlreadyServerManaged { .. } | E::Conflict(_) => AppError::Conflict(e.to_string()),
-        E::Transport(msg) | E::Publish(msg) => AppError::Internal(format!("publish: {msg}")),
+        E::Transport(msg) => AppError::Internal(format!("publish: {msg}")),
+        // Pass the host's typed rejection through untouched — see
+        // `RegisterDidWithServerError::Publish`.
+        E::Publish(e) => e,
         E::DidUrlParse { .. } => AppError::Validation(e.to_string()),
         E::Storage(msg) => AppError::Internal(msg),
     }


### PR DESCRIPTION
Companion to **affinidi/affinidi-webvh-service#72**, which fixes the root-DID registration itself. This fixes how the VTA *reports* any rejection from a DID-hosting server.

## Problem

Registering a root did:webvh printed this:

```
✗ Server error (HTTP 500): internal error: publish: bad gateway:
  e.p.did.path-invalid: validation error: [path] path segments must
  contain only lowercase letters, digits, and hyphens
  This is a VTA-side failure. Check server logs or contact the operator.
```

The VTA had not failed. The **hosting server** had refused the request, for a reason the operator could act on — and the message told them to go read the VTA's logs.

## Root cause

Two layers of mislabelling, stacked:

1. `didcomm_bridge.rs` collapsed **every** problem report into `bad_gateway_error` (502), regardless of what the remote actually said.
2. `register_did_with_server` then did `.map_err(|e| Publish(e.to_string()))`, and the three mapping sites wrapped that in `AppError::Internal` → **500**.

Since `VtaError::from_http` maps *any* status ≥ 500 to `VtaError::Server`, whose CLI hint is "This is a VTA-side failure", an actionable upstream rejection and a genuine upstream outage became indistinguishable. This is also what the workspace CLAUDE.md forbids: *"Preserve the type information through both REST and DIDComm transports; never collapse a Conflict into a string."*

## Fix

Translate the problem report into a typed `AppError` **at the bridge**, so every DIDComm-bridged op benefits rather than just register:

| remote code (trailing segment) | becomes | status |
|---|---|---|
| `unauthorized`, `forbidden` | `Forbidden` | 403 |
| `path-unavailable`, `conflict` | `Conflict` | 409 |
| `mnemonic-not-found`, `not-found` | `NotFound` | 404 |
| `path-invalid`, `invalid-log`, `witness-invalid`, `validation-error`, `bad-request`, `replay-detected`, `size-exceeded`, `quota-exceeded` | `Validation` | 400 |
| `internal-error`, anything unrecognised | `ServiceError` | 502 (unchanged) |

Codes are namespaced per protocol (`e.p.did.*`, `e.p.registration.*`, `e.p.msg.*`) but the trailing segment is the shared vocabulary, so the match keys on that. The hosting service's `AppError::didcomm_code()` is the authoritative producer for the `e.p.did.*` arm — this is its documented inverse.

`RegisterDidWithServerError::Publish` now carries the `AppError` rather than a `String`, and the three mapping sites (REST `routes/did_webvh.rs`, DIDComm `messaging/handlers.rs`, trust-task `trust_tasks/webvh.rs`) pass it through instead of wrapping it in `Internal`.

### Two deliberate choices

- **Unrecognised codes and `internal-error` stay 502.** Silently re-labelling an upstream crash as a caller error would be a worse lie than the one being fixed. Only codes we can positively attribute to the caller get downgraded to 4xx.
- **Remote auth denials become 403, never 401.** The caller's credential for *this* VTA is valid; it's the VTA's own DID that lacks rights on the host. A 401 would make the CLI print a misleading "token may be expired" hint — exactly the failure mode the `e.p.msg.forbidden` note in CLAUDE.md warns about.

## Why it matters beyond the original bug

With the hosting-service fix in place, an operator registering a root DID whose slot is already occupied by the server's own bootstrap DID gets a genuinely useful refusal — *"admin takeover of a slot owned by another DID requires force=true"* — which today would still surface as `500 internal error … contact the operator`. After this change it's a 409 carrying that sentence.

## Tests

Four new unit tests in `didcomm_bridge`, asserting the status the operator actually receives (driving the real `IntoResponse`, so a future change to `AppError`'s status mapping can't quietly re-break it):
- `remote_client_errors_keep_their_meaning` — every `e.p.did.*` client-error code, including the `path-invalid` from the original report
- `remote_auth_denial_is_forbidden_not_unauthorized` — 403, never 401
- `upstream_failures_and_unknown_codes_stay_bad_gateway` — `internal-error` and unknown codes stay 502
- `detail_carries_remote_comment_and_code` — the remote's comment and code both survive into the operator-visible message

`cargo test -p vta-service` green (865 + 116 + suites); clippy clean.

## Note

Bumps `vta-service` 0.10.23 → 0.10.24, which will conflict with #642's bump of the same line. Trivial rebase for whichever lands second.