### PR TITLE
feat(vta-service): task-execution consent (PDP requireConsent)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10220,6 +10220,7 @@ dependencies = [
  "serde",
  "serde_ignored",
  "serde_json",
+ "serde_json_canonicalizer",
  "sha2 0.11.0",
  "subtle",
  "tempfile",

--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -1152,6 +1152,16 @@ pub const TASK_CONSENT_REQUEST_1_0: &str = "https://trusttasks.org/spec/consent/
 /// bridge-attested).
 pub const TASK_CONSENT_DECISION_1_0: &str = "https://trusttasks.org/spec/consent/decision/1.0";
 
+/// `task-consent/decision/1.0` — an approver signs approval (or denial) of a
+/// specific privileged **task execution**, bound to the task's payload digest.
+/// Distinct from `consent/decision` (messaging-bridge conversation consent):
+/// this feeds the Policy Decision Point's `requireConsent` disposition. The
+/// proof's signer must belong to the policy-named approver set; at the required
+/// threshold the VTA issues a single-use grant the requester's re-submit
+/// consumes. Auth: a member of the approver set (Data-Integrity signed).
+pub const TASK_TASK_CONSENT_DECISION_1_0: &str =
+    "https://trusttasks.org/spec/task-consent/decision/1.0";
+
 /// `consent/revoke/1.0` — an operator withdraws a standing grant, reverting the
 /// conversation to default-deny.
 pub const TASK_CONSENT_REVOKE_1_0: &str = "https://trusttasks.org/spec/consent/revoke/1.0";
@@ -1354,6 +1364,7 @@ pub const ALL_URIS: &[&str] = &[
     // Consent slice
     TASK_CONSENT_REQUEST_1_0,
     TASK_CONSENT_DECISION_1_0,
+    TASK_TASK_CONSENT_DECISION_1_0,
     TASK_CONSENT_REVOKE_1_0,
     TASK_CONSENT_LIST_1_0,
     TASK_CONSENT_APPROVER_SET_1_0,

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -206,6 +206,10 @@ sha2 = { workspace = true }
 # and cloned cheaply per evaluation; `full-opa` brings the stdlib builtins real
 # policies lean on (regex, time).
 regorus = { workspace = true }
+# RFC 8785 JCS canonicalization — deterministic `Value` → bytes for the
+# task-consent payload digest (an approver signs over the exact payload).
+# Same crate vti-webauthn uses for document binding.
+serde_json_canonicalizer = "0.3"
 # Constant-time byte equality. Used by `backup_bundle_store` to
 # verify backup-bundle bearer tokens against their stored
 # `SHA-256(token)` hash without leaking byte-position via timing.

--- a/vta-service/src/config.rs
+++ b/vta-service/src/config.rs
@@ -22,6 +22,12 @@ pub struct PolicyConfig {
     /// restrictive, higher-priority policy (expand-before-contract).
     #[serde(default)]
     pub enforcement: bool,
+    /// Named approver sets a policy's `requireConsent` references by name; each
+    /// maps to the DIDs permitted to approve a task's execution. Empty by
+    /// default — a `requireConsent` naming an unknown or empty set can never be
+    /// satisfied (fail-closed), so operators define sets before using them.
+    #[serde(default)]
+    pub approver_sets: std::collections::HashMap<String, Vec<String>>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/vta-service/src/keyspaces.rs
+++ b/vta-service/src/keyspaces.rs
@@ -74,6 +74,14 @@ pub const MEMORY: &str = "memory";
 /// would silently drop enforcement on restore).
 pub const POLICY: &str = "policy";
 
+/// Task-execution consent for the PDP's `requireConsent` disposition: pending
+/// approvals keyed by payload digest, and granted consents a re-submitted task
+/// consumes. Distinct from [`CONSENT`] (messaging-bridge conversation consent).
+/// One [`crate::policy::consent::PendingTaskConsent`] per `pending:<digest>` and
+/// [`crate::policy::consent::TaskConsentGrant`] per `grant:<requester>:<digest>`.
+/// Durable operator-facing security state → [`BACKED_UP`].
+pub const TASK_CONSENT: &str = "task_consent";
+
 /// Every production keyspace. Partitioned by [`BACKED_UP`] +
 /// [`EXCLUDED_FROM_BACKUP`]; the [`tests::backup_partition_is_total`] guard
 /// asserts the partition stays exhaustive so a newly-added keyspace can't be
@@ -101,6 +109,7 @@ pub const ALL: &[&str] = &[
     ISSUED_CREDENTIALS,
     MEMORY,
     POLICY,
+    TASK_CONSENT,
 ];
 
 /// Keyspaces whose contents a full `export_backup` captures (as typed
@@ -119,6 +128,9 @@ pub const BACKED_UP: &[&str] = &[
     // Operator security policy — must survive a restore, else enforcement
     // silently reverts to whatever defaults boot-install provides.
     POLICY,
+    // Task-consent grants are durable authorizations a re-submitted task
+    // consumes; losing them on restore would strand in-flight approvals.
+    TASK_CONSENT,
 ];
 
 /// Keyspaces deliberately **not** in a backup.

--- a/vta-service/src/policy/consent.rs
+++ b/vta-service/src/policy/consent.rs
@@ -1,0 +1,288 @@
+//! Task-execution consent — the data layer behind the PDP's `requireConsent`
+//! disposition.
+//!
+//! When a policy returns `requireConsent`, a privileged task can't proceed until
+//! one or more named approvers have signed off on **this exact payload**. The
+//! binding is a deterministic digest of the payload (RFC 8785 JCS + SHA-256), so
+//! the approval a re-submitted task consumes provably concerns the same request
+//! — an approver can't be tricked into signing one payload while a different one
+//! executes.
+//!
+//! Two records in the `task_consent` keyspace:
+//! - [`PendingTaskConsent`] (`pending:<digest>`) — an in-flight request
+//!   accumulating approver signatures.
+//! - [`TaskConsentGrant`] (`grant:<requester>:<digest>`) — a completed
+//!   authorization the re-submitting requester consumes single-use.
+//!
+//! This mirrors the step-up "reject → approve → re-submit" loop, but the
+//! authorization is bound to the payload digest rather than the session.
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use vti_common::error::AppError;
+use vti_common::store::KeyspaceHandle;
+
+const PENDING_PREFIX: &[u8] = b"pending:";
+const GRANT_PREFIX: &[u8] = b"grant:";
+
+/// Deterministic digest of a task payload: hex SHA-256 over the RFC 8785 (JCS)
+/// canonical form. Stable across serializers, so the requester's re-submit and
+/// the approver's signed decision agree on what was authorized.
+pub fn payload_digest(payload: &serde_json::Value) -> Result<String, AppError> {
+    let canonical = serde_json_canonicalizer::to_string(payload)
+        .map_err(|e| AppError::Internal(format!("payload JCS canonicalization failed: {e}")))?;
+    Ok(hex::encode(Sha256::digest(canonical.as_bytes())))
+}
+
+/// An in-flight consent request accumulating approver signatures.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PendingTaskConsent {
+    /// `payload_digest` of the task awaiting consent.
+    pub digest: String,
+    /// Type URI of the task (for the approver's display + audit).
+    pub type_uri: String,
+    /// The DID that submitted the task.
+    pub requester_did: String,
+    /// Named approver set the policy required (resolved to members at check time).
+    pub approver_set: String,
+    /// Distinct approvals needed before a grant is issued.
+    pub min_approvals: u32,
+    /// When true, the requester's own DID cannot count toward the threshold.
+    pub exclude_requester: bool,
+    /// Nonce the approver echoes + signs, binding the decision to this request.
+    pub challenge: String,
+    /// Distinct approver DIDs who have approved so far.
+    pub approvals: Vec<String>,
+    pub created_at: u64,
+    pub expires_at: u64,
+}
+
+/// A completed authorization a re-submitted task consumes (single-use).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TaskConsentGrant {
+    pub digest: String,
+    pub requester_did: String,
+    pub type_uri: String,
+    /// The approver DIDs whose signatures produced this grant.
+    pub approvers: Vec<String>,
+    pub granted_at: u64,
+    pub expires_at: u64,
+}
+
+fn pending_key(digest: &str) -> Vec<u8> {
+    [PENDING_PREFIX, digest.as_bytes()].concat()
+}
+
+fn grant_key(requester_did: &str, digest: &str) -> Vec<u8> {
+    // `:` can't appear in a hex digest; the requester DID may contain `:`, so put
+    // it last after the fixed-shape prefix+digest to keep the key unambiguous.
+    [
+        GRANT_PREFIX,
+        digest.as_bytes(),
+        b":",
+        requester_did.as_bytes(),
+    ]
+    .concat()
+}
+
+fn decode<T: for<'de> Deserialize<'de>>(bytes: &[u8]) -> Result<T, AppError> {
+    serde_json::from_slice(bytes)
+        .map_err(|e| AppError::Internal(format!("task-consent decode: {e}")))
+}
+
+// ── Pending ────────────────────────────────────────────────────────────────
+
+pub async fn store_pending(ks: &KeyspaceHandle, p: &PendingTaskConsent) -> Result<(), AppError> {
+    let key = String::from_utf8(pending_key(&p.digest))
+        .map_err(|e| AppError::Internal(format!("pending key not utf-8: {e}")))?;
+    ks.insert(key, p).await
+}
+
+pub async fn get_pending(
+    ks: &KeyspaceHandle,
+    digest: &str,
+) -> Result<Option<PendingTaskConsent>, AppError> {
+    match ks.get_raw(pending_key(digest)).await? {
+        Some(b) => Ok(Some(decode(&b)?)),
+        None => Ok(None),
+    }
+}
+
+pub async fn delete_pending(ks: &KeyspaceHandle, digest: &str) -> Result<(), AppError> {
+    ks.remove(pending_key(digest)).await
+}
+
+/// Record an approval (idempotent per approver) and return the updated pending.
+/// `Ok(None)` if there is no pending consent for the digest. The caller decides
+/// whether `approvals.len() >= min_approvals` and, if so, issues a grant.
+pub async fn add_approval(
+    ks: &KeyspaceHandle,
+    digest: &str,
+    approver_did: &str,
+) -> Result<Option<PendingTaskConsent>, AppError> {
+    let Some(mut p) = get_pending(ks, digest).await? else {
+        return Ok(None);
+    };
+    if !p.approvals.iter().any(|a| a == approver_did) {
+        p.approvals.push(approver_did.to_string());
+        store_pending(ks, &p).await?;
+    }
+    Ok(Some(p))
+}
+
+// ── Grant ──────────────────────────────────────────────────────────────────
+
+pub async fn store_grant(ks: &KeyspaceHandle, g: &TaskConsentGrant) -> Result<(), AppError> {
+    let key = String::from_utf8(grant_key(&g.requester_did, &g.digest))
+        .map_err(|e| AppError::Internal(format!("grant key not utf-8: {e}")))?;
+    ks.insert(key, g).await
+}
+
+/// Consume a valid grant for `(requester, digest)` — single-use: on a hit the
+/// grant is removed before returning. Returns `None` if absent or expired (an
+/// expired grant is also removed). This is the gate's allow-path check.
+pub async fn consume_grant(
+    ks: &KeyspaceHandle,
+    requester_did: &str,
+    digest: &str,
+    now: u64,
+) -> Result<Option<TaskConsentGrant>, AppError> {
+    let key = grant_key(requester_did, digest);
+    let Some(bytes) = ks.get_raw(key.clone()).await? else {
+        return Ok(None);
+    };
+    let grant: TaskConsentGrant = decode(&bytes)?;
+    // Remove either way: a hit is single-use, an expired grant is swept.
+    ks.remove(key).await?;
+    if grant.expires_at <= now {
+        return Ok(None);
+    }
+    Ok(Some(grant))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::StoreConfig;
+    use crate::store::Store;
+    use serde_json::json;
+
+    async fn temp_ks() -> (KeyspaceHandle, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(&StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        })
+        .unwrap();
+        (store.keyspace(crate::keyspaces::TASK_CONSENT).unwrap(), dir)
+    }
+
+    #[test]
+    fn digest_is_deterministic_and_key_order_independent() {
+        let a = payload_digest(&json!({ "b": 2, "a": 1 })).unwrap();
+        let b = payload_digest(&json!({ "a": 1, "b": 2 })).unwrap();
+        assert_eq!(a, b, "JCS canonicalization must ignore key order");
+        assert_ne!(a, payload_digest(&json!({ "a": 1, "b": 3 })).unwrap());
+        assert_eq!(a.len(), 64, "hex sha-256 is 64 chars");
+    }
+
+    fn pending(digest: &str, min: u32) -> PendingTaskConsent {
+        PendingTaskConsent {
+            digest: digest.into(),
+            type_uri: "https://…/dids/update/1.0".into(),
+            requester_did: "did:key:zReq".into(),
+            approver_set: "operators".into(),
+            min_approvals: min,
+            exclude_requester: true,
+            challenge: "nonce123".into(),
+            approvals: vec![],
+            created_at: 100,
+            expires_at: 1000,
+        }
+    }
+
+    #[tokio::test]
+    async fn approvals_accumulate_idempotently() {
+        let (ks, _d) = temp_ks().await;
+        store_pending(&ks, &pending("deadbeef", 2)).await.unwrap();
+
+        let p = add_approval(&ks, "deadbeef", "did:key:zA")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(p.approvals.len(), 1);
+        // Same approver again → no double count.
+        let p = add_approval(&ks, "deadbeef", "did:key:zA")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(p.approvals.len(), 1);
+        // Second distinct approver reaches the threshold.
+        let p = add_approval(&ks, "deadbeef", "did:key:zB")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(p.approvals.len(), 2);
+        assert!(p.approvals.len() as u32 >= p.min_approvals);
+
+        // No pending for an unknown digest.
+        assert!(
+            add_approval(&ks, "nope", "did:key:zA")
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn grant_is_single_use_and_expiry_checked() {
+        let (ks, _d) = temp_ks().await;
+        let g = TaskConsentGrant {
+            digest: "d1".into(),
+            requester_did: "did:key:zReq".into(),
+            type_uri: "t".into(),
+            approvers: vec!["did:key:zA".into()],
+            granted_at: 100,
+            expires_at: 500,
+        };
+        store_grant(&ks, &g).await.unwrap();
+
+        // First consume within validity → hit.
+        assert!(
+            consume_grant(&ks, "did:key:zReq", "d1", 200)
+                .await
+                .unwrap()
+                .is_some()
+        );
+        // Second consume → gone (single-use).
+        assert!(
+            consume_grant(&ks, "did:key:zReq", "d1", 200)
+                .await
+                .unwrap()
+                .is_none()
+        );
+
+        // Expired grant → None, and swept.
+        store_grant(&ks, &g).await.unwrap();
+        assert!(
+            consume_grant(&ks, "did:key:zReq", "d1", 999)
+                .await
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            consume_grant(&ks, "did:key:zReq", "d1", 200)
+                .await
+                .unwrap()
+                .is_none()
+        );
+
+        // Wrong requester never matches.
+        store_grant(&ks, &g).await.unwrap();
+        assert!(
+            consume_grant(&ks, "did:key:zOther", "d1", 200)
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+}

--- a/vta-service/src/policy/mod.rs
+++ b/vta-service/src/policy/mod.rs
@@ -31,6 +31,7 @@
 //! per-request [`types::PolicyInput`] construction, and boot-installed default
 //! policies land alongside this in the same PR series.
 
+pub mod consent;
 pub mod defaults;
 pub mod engine;
 pub mod input;

--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -133,6 +133,9 @@ pub struct AppState {
     /// row, priority-ordered. A migration-safe baseline is boot-installed if
     /// empty. Durable operator security config.
     pub policy_ks: KeyspaceHandle,
+    /// Task-execution consent: pending approvals + granted consents the PDP's
+    /// `requireConsent` disposition uses. Distinct from `consent_ks` (messaging).
+    pub task_consent_ks: KeyspaceHandle,
     /// Persisted drain set for the protocol-management feature
     /// (`docs/05-design-notes/didcomm-protocol-management.md`).
     /// Keyed by mediator DID; replayed at boot.
@@ -327,6 +330,7 @@ pub async fn build_app_state(
         apply_encryption(store.keyspace(crate::keyspaces::ISSUED_CREDENTIALS)?);
     let memory_ks = apply_encryption(store.keyspace(crate::keyspaces::MEMORY)?);
     let policy_ks = apply_encryption(store.keyspace(crate::keyspaces::POLICY)?);
+    let task_consent_ks = apply_encryption(store.keyspace(crate::keyspaces::TASK_CONSENT)?);
     #[cfg(feature = "webvh")]
     let drains_ks = apply_encryption(store.keyspace(crate::keyspaces::DRAINS)?);
     #[cfg(feature = "webvh")]
@@ -394,6 +398,7 @@ pub async fn build_app_state(
         issued_credentials_ks,
         memory_ks,
         policy_ks,
+        task_consent_ks,
         #[cfg(feature = "webvh")]
         drains_ks,
         #[cfg(feature = "webvh")]

--- a/vta-service/src/test_support.rs
+++ b/vta-service/src/test_support.rs
@@ -832,6 +832,7 @@ pub async fn build_test_app_with(opts: TestAppOptions) -> (axum::Router, TestApp
             .unwrap(),
         memory_ks: store.keyspace(crate::keyspaces::MEMORY).unwrap(),
         policy_ks: store.keyspace(crate::keyspaces::POLICY).unwrap(),
+        task_consent_ks: store.keyspace(crate::keyspaces::TASK_CONSENT).unwrap(),
         service_state_ks,
         sealed_nonces_ks,
         backup_bundles_ks: backup_bundles_ks.clone(),

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -69,6 +69,7 @@ mod policy_gate;
 mod provision_integration;
 mod replay;
 mod seeds;
+mod task_consent;
 // `pub(crate)` so the REST routes (`routes::acl`, `routes::contexts`) can
 // reach the `RequireStepUp` extractor + op markers. The step-up *engine* lives
 // in `operations::step_up` (P2.4); this module holds only the transport
@@ -562,6 +563,11 @@ dispatch_table! {
         [ Mutating None false ],
     vta_sdk::trust_tasks::TASK_CONSENT_APPROVER_LIST_1_0 => consent::handle_approver_list
         [ None Metadata false ],
+    // Task-execution consent decision (PDP requireConsent). Records approver
+    // signatures; the gate exempts it from re-gating (see policy_gate) so
+    // approving a task can't itself require consent.
+    vta_sdk::trust_tasks::TASK_TASK_CONSENT_DECISION_1_0 => task_consent::handle_decision
+        [ Mutating None false ],
     // ─── ACL slice ────────────────────────────────────────────────
     vta_sdk::trust_tasks::TASK_ACL_LIST_1_0 => acl::handle_list
         [ None Metadata false ],

--- a/vta-service/src/trust_tasks/policy_gate.rs
+++ b/vta-service/src/trust_tasks/policy_gate.rs
@@ -28,14 +28,37 @@
 //! The Rego arm is inert unless enforcement is enabled; the config-floor arm
 //! preserves existing behaviour. Any failure to load the policy set denies.
 
-use serde_json::Value;
+use serde_json::{Value, json};
 use trust_tasks_rs::{RejectReason, TrustTask};
+use uuid::Uuid;
 
 use super::TrustTaskOutcome;
-use super::helpers::reject_with;
+use super::helpers::{app_error_to_reject, reject_with};
 use crate::auth::AuthClaims;
-use crate::policy::{self, Disposition};
+use crate::policy::{self, Disposition, RequireConsent, consent};
 use crate::server::AppState;
+
+/// How long a pending consent request stays open for approvals.
+const CONSENT_PENDING_TTL_SECS: u64 = 900;
+
+fn gate_now_secs() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// Ceremony tasks carry their own authority (an approver's proof, a step-up
+/// approve-response) and must NOT themselves be gated — else approving a task
+/// could itself require consent/step-up, ad infinitum.
+#[allow(deprecated)]
+fn is_ceremony_task(type_uri: &str) -> bool {
+    use vta_sdk::trust_tasks as t;
+    type_uri == t::TASK_TASK_CONSENT_DECISION_1_0
+        || type_uri == t::TASK_AUTH_STEP_UP_APPROVE_RESPONSE_0_1
+        || type_uri == t::TASK_AUTH_STEP_UP_APPROVE_RESPONSE_0_2
+}
 
 /// The ACR a satisfied step-up reaches. Mirrors `step_up::STEP_UP_TARGET_ACR`.
 const STEP_UP_TARGET_ACR: &str = "aal2";
@@ -73,6 +96,11 @@ pub(super) async fn policy_gate(
     type_uri: &str,
     doc: &TrustTask<Value>,
 ) -> Option<TrustTaskOutcome> {
+    // Ceremony tasks are the mechanism, not a gated operation — never gate them.
+    if is_ceremony_task(type_uri) {
+        return None;
+    }
+
     // (1) Config-floor step-up (subsumes the inline require_step_up).
     if let Some(op_class) = op_class_for(type_uri)
         && let Some(reject) = super::step_up::require_step_up(state, auth, op_class, doc).await
@@ -128,21 +156,111 @@ pub(super) async fn policy_gate(
                 Some(super::step_up::initiate_self_step_up(state, auth, doc).await)
             }
         }
-        // Task-execution consent (approver-set + payload-digest binding) is
-        // Phase B; until then surface it as a denial with a clear reason.
-        Disposition::RequireConsent => Some(reject_with(
+        Disposition::RequireConsent => {
+            consent_gate(state, auth, doc, type_uri, decision.require_consent).await
+        }
+    }
+}
+
+/// Resolve the PDP `requireConsent` disposition.
+///
+/// Proceeds (`None`) if a valid grant for this exact payload already exists
+/// (single-use consume). Otherwise records a pending request and rejects with
+/// the challenge for approvers to sign — the reject carries `{digest, challenge,
+/// approverSet}` so the requester can relay it to the approver set, mirroring
+/// step-up's carried `approve-request` (active push to approver devices is a
+/// follow-up). The approver's signed `task-consent/decision` produces the grant;
+/// the requester re-submits and this consumes it.
+async fn consent_gate(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: &TrustTask<Value>,
+    type_uri: &str,
+    require: Option<RequireConsent>,
+) -> Option<TrustTaskOutcome> {
+    // A requireConsent naming no approver set can never be satisfied — fail closed.
+    let Some(require) = require else {
+        return Some(reject_with(
+            doc,
+            RejectReason::PermissionDenied {
+                reason: "policy requires consent but named no approver set".into(),
+            },
+        ));
+    };
+
+    let digest = match consent::payload_digest(&doc.payload) {
+        Ok(d) => d,
+        Err(e) => return Some(app_error_to_reject(doc, e)),
+    };
+    let now = gate_now_secs();
+
+    // Existing valid grant → authorized; consume single-use and proceed.
+    match consent::consume_grant(&state.task_consent_ks, &auth.did, &digest, now).await {
+        Ok(Some(_)) => return None,
+        Ok(None) => {}
+        Err(e) => return Some(app_error_to_reject(doc, e)),
+    }
+
+    // No grant: the approver set must be defined and non-empty.
+    let members = state
+        .config
+        .read()
+        .await
+        .policy
+        .approver_sets
+        .get(&require.approver_set)
+        .cloned()
+        .unwrap_or_default();
+    if members.is_empty() {
+        return Some(reject_with(
             doc,
             RejectReason::PermissionDenied {
                 reason: format!(
-                    "consent required: {}",
-                    decision
-                        .explanation
-                        .as_deref()
-                        .unwrap_or("policy requires approver consent")
+                    "approver set '{}' is unknown or empty",
+                    require.approver_set
                 ),
             },
-        )),
+        ));
     }
+
+    // Reuse an existing pending challenge (idempotent re-submit) or mint one.
+    let min_approvals = require.min_approvals.max(1);
+    let challenge = match consent::get_pending(&state.task_consent_ks, &digest).await {
+        Ok(Some(p)) => p.challenge,
+        Ok(None) => {
+            let challenge = format!("{}{}", Uuid::new_v4().simple(), Uuid::new_v4().simple());
+            let pending = consent::PendingTaskConsent {
+                digest: digest.clone(),
+                type_uri: type_uri.to_string(),
+                requester_did: auth.did.clone(),
+                approver_set: require.approver_set.clone(),
+                min_approvals,
+                exclude_requester: require.exclude_requester,
+                challenge: challenge.clone(),
+                approvals: vec![],
+                created_at: now,
+                expires_at: now + CONSENT_PENDING_TTL_SECS,
+            };
+            if let Err(e) = consent::store_pending(&state.task_consent_ks, &pending).await {
+                return Some(app_error_to_reject(doc, e));
+            }
+            challenge
+        }
+        Err(e) => return Some(app_error_to_reject(doc, e)),
+    };
+
+    Some(reject_with(
+        doc,
+        RejectReason::TaskFailed {
+            reason: "auth:consent_required".into(),
+            details: Some(json!({
+                "digest": digest,
+                "challenge": challenge,
+                "approverSet": require.approver_set,
+                "minApprovals": min_approvals,
+            })),
+        },
+    ))
 }
 
 #[cfg(test)]
@@ -241,6 +359,71 @@ mod tests {
         assert!(
             policy_gate(&state, &auth, UNGATED_URI, &d).await.is_none(),
             "aal2 session must pass the step-up gate"
+        );
+    }
+
+    const REQUIRE_CONSENT: &str = "package vta.policy\nimport rego.v1\ndecision := {\"decision\": \"requireConsent\", \"requireConsent\": {\"approverSet\": \"ops\"}}";
+
+    #[tokio::test]
+    async fn require_consent_records_pending_then_grant_lets_resubmit_through() {
+        use crate::policy::consent;
+        let (state, _dir) = crate::test_support::build_signing_test_app_state().await;
+        let auth = crate::test_support::super_admin_claims();
+        let d = doc(UNGATED_URI);
+
+        {
+            let mut cfg = state.config.write().await;
+            cfg.policy.enforcement = true;
+            cfg.policy
+                .approver_sets
+                .insert("ops".into(), vec!["did:key:zApprover".into()]);
+        }
+        crate::policy::storage::store_policy(
+            &state.policy_ks,
+            &module("consent", 0, REQUIRE_CONSENT),
+        )
+        .await
+        .unwrap();
+
+        // First submit → consent required (rejected) + a pending is recorded.
+        assert!(
+            policy_gate(&state, &auth, UNGATED_URI, &d).await.is_some(),
+            "first submit must be rejected pending consent"
+        );
+        let digest = consent::payload_digest(&d.payload).unwrap();
+        assert!(
+            consent::get_pending(&state.task_consent_ks, &digest)
+                .await
+                .unwrap()
+                .is_some(),
+            "a pending consent record must exist"
+        );
+
+        // Simulate approvers reaching threshold: store a grant.
+        let now = super::gate_now_secs();
+        consent::store_grant(
+            &state.task_consent_ks,
+            &consent::TaskConsentGrant {
+                digest: digest.clone(),
+                requester_did: auth.did.clone(),
+                type_uri: UNGATED_URI.into(),
+                approvers: vec!["did:key:zApprover".into()],
+                granted_at: now,
+                expires_at: now + 600,
+            },
+        )
+        .await
+        .unwrap();
+
+        // Re-submit → grant consumed → proceed.
+        assert!(
+            policy_gate(&state, &auth, UNGATED_URI, &d).await.is_none(),
+            "a valid grant must let the re-submit proceed"
+        );
+        // Grant was single-use → the next submit needs consent again.
+        assert!(
+            policy_gate(&state, &auth, UNGATED_URI, &d).await.is_some(),
+            "grant is single-use; a further submit re-requires consent"
         );
     }
 }

--- a/vta-service/src/trust_tasks/task_consent.rs
+++ b/vta-service/src/trust_tasks/task_consent.rs
@@ -1,0 +1,181 @@
+//! Inbound `task-consent/decision/1.0` — an approver signs off on a specific
+//! privileged task execution, bound to its payload digest.
+//!
+//! This is the decision half of the PDP's `requireConsent` flow (the gate mints
+//! the pending request and wakes approvers). The approver's authority is the
+//! **proof**, not the bearer token: we verify the Data-Integrity proof, take the
+//! proven signer DID, and require it to be a member of the policy-named approver
+//! set. At the required threshold the VTA issues a single-use grant the
+//! requester's re-submit consumes.
+
+use serde::Deserialize;
+use serde_json::{Value, json};
+use trust_tasks_rs::{RejectReason, TrustTask};
+
+use super::TrustTaskOutcome;
+use super::helpers::{app_error_to_reject, parse_payload, reject_with, success_response};
+use crate::auth::AuthClaims;
+use crate::policy::consent;
+use crate::server::AppState;
+
+/// How long a completed grant stays valid for the requester's re-submit.
+const GRANT_TTL_SECS: u64 = 600;
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DecisionPayload {
+    /// Payload digest of the task being approved (echoes the pending request).
+    digest: String,
+    /// Nonce echoed from the pending request — binds this decision to it.
+    challenge: String,
+    /// True to approve, false to deny (a denial aborts the request).
+    #[serde(default)]
+    approve: bool,
+}
+
+fn now_secs() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+pub(super) async fn handle_decision(
+    state: &AppState,
+    _auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    let payload: DecisionPayload = match parse_payload(&doc) {
+        Ok(p) => p,
+        Err(o) => return o,
+    };
+
+    // Authority is the proof: verify it and take the *proven* signer DID.
+    let approver = match crate::auth::di_proof::verify_trust_task_proof(&doc).await {
+        Ok(did) => did,
+        Err(e) => {
+            return reject_with(
+                &doc,
+                RejectReason::PermissionDenied {
+                    reason: format!("task-consent decision must carry a valid proof: {e}"),
+                },
+            );
+        }
+    };
+
+    let ks = &state.task_consent_ks;
+    let pending = match consent::get_pending(ks, &payload.digest).await {
+        Ok(Some(p)) => p,
+        Ok(None) => {
+            return reject_with(
+                &doc,
+                RejectReason::TaskFailed {
+                    reason: "task-consent:no_pending".into(),
+                    details: Some(json!({ "digest": payload.digest })),
+                },
+            );
+        }
+        Err(e) => return app_error_to_reject(&doc, e),
+    };
+
+    // Bind the decision to this exact request.
+    if payload.challenge != pending.challenge {
+        return reject_with(
+            &doc,
+            RejectReason::PermissionDenied {
+                reason: "challenge does not match the pending request".into(),
+            },
+        );
+    }
+
+    // The proven signer must be a member of the policy-named approver set.
+    let members = state
+        .config
+        .read()
+        .await
+        .policy
+        .approver_sets
+        .get(&pending.approver_set)
+        .cloned()
+        .unwrap_or_default();
+    if !members.iter().any(|m| m == &approver) {
+        return reject_with(
+            &doc,
+            RejectReason::PermissionDenied {
+                reason: format!(
+                    "signer is not a member of approver set '{}'",
+                    pending.approver_set
+                ),
+            },
+        );
+    }
+    // A requester can't approve their own task when the policy excludes them.
+    if pending.exclude_requester && approver == pending.requester_did {
+        return reject_with(
+            &doc,
+            RejectReason::PermissionDenied {
+                reason: "the requester may not approve its own task".into(),
+            },
+        );
+    }
+
+    let now = now_secs();
+
+    // A denial aborts the request.
+    if !payload.approve {
+        let _ = consent::delete_pending(ks, &payload.digest).await;
+        return success_response(
+            &doc,
+            json!({ "status": "denied", "digest": payload.digest }),
+        );
+    }
+
+    // Accumulate the approval; at the threshold, issue a single-use grant.
+    let updated = match consent::add_approval(ks, &payload.digest, &approver).await {
+        Ok(Some(p)) => p,
+        Ok(None) => {
+            return reject_with(
+                &doc,
+                RejectReason::TaskFailed {
+                    reason: "task-consent:no_pending".into(),
+                    details: None,
+                },
+            );
+        }
+        Err(e) => return app_error_to_reject(&doc, e),
+    };
+
+    if updated.approvals.len() as u32 >= updated.min_approvals {
+        let grant = consent::TaskConsentGrant {
+            digest: updated.digest.clone(),
+            requester_did: updated.requester_did.clone(),
+            type_uri: updated.type_uri.clone(),
+            approvers: updated.approvals.clone(),
+            granted_at: now,
+            expires_at: now + GRANT_TTL_SECS,
+        };
+        if let Err(e) = consent::store_grant(ks, &grant).await {
+            return app_error_to_reject(&doc, e);
+        }
+        let _ = consent::delete_pending(ks, &payload.digest).await;
+        return success_response(
+            &doc,
+            json!({
+                "status": "granted",
+                "digest": payload.digest,
+                "approvals": updated.approvals.len(),
+            }),
+        );
+    }
+
+    success_response(
+        &doc,
+        json!({
+            "status": "pending",
+            "digest": payload.digest,
+            "approvals": updated.approvals.len(),
+            "needed": updated.min_approvals,
+        }),
+    )
+}


### PR DESCRIPTION
Phase B of the step-up + consent work: implements the PDP's `requireConsent` disposition — a privileged task the policy gates on consent can't run until named approvers sign off, bound to the exact payload. Builds on the PDP (#637) and step-up (#641).

The existing `consent/*` tasks are messaging-bridge consent (conversation access) and don't fit, so this is a new subsystem — the cross-device, digest-bound, what-you-approve-is-what-runs flow.

## Model

Reject → approvers sign → re-submit, mirroring the proven step-up loop, with the authorization bound to a **deterministic payload digest** (RFC 8785 JCS + SHA-256) rather than the session:

1. Policy returns `requireConsent{approverSet, excludeRequester, minApprovals}`. The gate computes the digest and looks for a valid grant.
2. Grant present → **proceed** (single-use consume). Absent → record a `PendingTaskConsent`, reject with `{digest, challenge, approverSet}`.
3. An approver signs a `task-consent/decision` bound to the digest. The VTA verifies the Data-Integrity proof and takes the **proven signer** (authority is the proof, not a bearer token), requires membership in the policy-named set, checks the challenge + `excludeRequester`, accumulates approvals, and at `minApprovals` issues a single-use `TaskConsentGrant`.
4. The requester re-submits → the gate consumes the grant → proceeds.

## What's here

- **policy/consent.rs** — `payload_digest()`, `PendingTaskConsent` + `TaskConsentGrant` in a new `task_consent` keyspace (in `ALL` + `BACKED_UP`), idempotent `add_approval`, single-use + expiry-checked `consume_grant`.
- **config** — `PolicyConfig.approver_sets` (named set → member DIDs; empty = fail-closed).
- **vta-sdk** — `TASK_TASK_CONSENT_DECISION_1_0` (`task-consent/decision/1.0`), distinct from messaging `consent/decision`.
- **trust_tasks/task_consent.rs** — `handle_decision` (proof-verified, membership + threshold → grant).
- **trust_tasks/policy_gate.rs** — the `requireConsent` arm; ceremony tasks (this decision task, step-up approve-response) are exempted from gating so approving a task can't itself require consent.

## Migration safety

Inert unless `policy.enforcement` is on (default off) and a policy returns `requireConsent`. `serde_json_canonicalizer` added (the RFC 8785 crate `vti-webauthn` already uses).

## Tests

866 lib tests pass (incl. the URI parity harness). Unit tests cover digest determinism, idempotent accumulation, single-use/expiry, and an end-to-end gate flow (require → pending → grant → proceed → single-use).

## Deliberate follow-ups (in the commit)

- **Informed consent is the real end-state** and is intentionally *not* in this PR: the VTA computing per-request effects (dry-run the handler) → an active push carrying those effects to the approver's device → an approver client that renders + signs. Building the push alone, against imagined effects + client contracts, would bake in shapes those pieces would revise. Today the reject carries `{digest, challenge}` for the requester to relay (relay-fallback, same as step-up's carried approve-request) — cryptographically sound (the digest binding defeats tampering), just not yet the informed-consent UX. The active wake belongs with that arc.
- A signed-doc fixture test for `handle_decision`'s proof branch.
- Relaxing `PolicyInput.site` to optional in the 0.3 schema.