### PR TITLE
fix(vta-service): bind task-consent grants to the task URI

### DIFF
--- a/vta-service/src/keyspaces.rs
+++ b/vta-service/src/keyspaces.rs
@@ -78,7 +78,7 @@ pub const POLICY: &str = "policy";
 /// approvals keyed by payload digest, and granted consents a re-submitted task
 /// consumes. Distinct from [`CONSENT`] (messaging-bridge conversation consent).
 /// One [`crate::policy::consent::PendingTaskConsent`] per `pending:<digest>` and
-/// [`crate::policy::consent::TaskConsentGrant`] per `grant:<requester>:<digest>`.
+/// [`crate::policy::consent::TaskConsentGrant`] per `grant:<digest>:<requester>`.
 /// Durable operator-facing security state → [`BACKED_UP`].
 pub const TASK_CONSENT: &str = "task_consent";
 

--- a/vta-service/src/policy/consent.rs
+++ b/vta-service/src/policy/consent.rs
@@ -2,16 +2,17 @@
 //! disposition.
 //!
 //! When a policy returns `requireConsent`, a privileged task can't proceed until
-//! one or more named approvers have signed off on **this exact payload**. The
-//! binding is a deterministic digest of the payload (RFC 8785 JCS + SHA-256), so
-//! the approval a re-submitted task consumes provably concerns the same request
-//! — an approver can't be tricked into signing one payload while a different one
-//! executes.
+//! one or more named approvers have signed off on **this exact task**. The
+//! binding is a deterministic digest of the task URI and its payload (RFC 8785
+//! JCS + SHA-256), so the approval a re-submitted task consumes provably
+//! concerns the same request — an approver can't be tricked into signing one
+//! payload while a different one executes, nor into approving a benign task URI
+//! whose payload happens to canonicalize like a destructive one's.
 //!
 //! Two records in the `task_consent` keyspace:
 //! - [`PendingTaskConsent`] (`pending:<digest>`) — an in-flight request
 //!   accumulating approver signatures.
-//! - [`TaskConsentGrant`] (`grant:<requester>:<digest>`) — a completed
+//! - [`TaskConsentGrant`] (`grant:<digest>:<requester>`) — a completed
 //!   authorization the re-submitting requester consumes single-use.
 //!
 //! This mirrors the step-up "reject → approve → re-submit" loop, but the
@@ -25,13 +26,30 @@ use vti_common::store::KeyspaceHandle;
 const PENDING_PREFIX: &[u8] = b"pending:";
 const GRANT_PREFIX: &[u8] = b"grant:";
 
-/// Deterministic digest of a task payload: hex SHA-256 over the RFC 8785 (JCS)
-/// canonical form. Stable across serializers, so the requester's re-submit and
-/// the approver's signed decision agree on what was authorized.
-pub fn payload_digest(payload: &serde_json::Value) -> Result<String, AppError> {
+/// Domain-separation tag: keeps these digests from colliding with any other
+/// SHA-256 over a canonical payload elsewhere in the system.
+const DIGEST_DOMAIN: &[u8] = b"vta/task-consent/v1\0";
+
+/// Deterministic digest of a task: hex SHA-256 over the type URI and the RFC
+/// 8785 (JCS) canonical payload. Stable across serializers, so the requester's
+/// re-submit and the approver's signed decision agree on what was authorized.
+///
+/// The type URI is **part of the digest**, and is length-prefixed so the
+/// URI/payload boundary can't be shifted. Without it, two tasks whose payloads
+/// canonicalize identically — `{"did":…,"contextId":…}` is a plausible payload
+/// for `dids/update`, `dids/rotate-keys` *and* a deactivate — would share a
+/// digest, and an approval for the benign one would authorize the destructive
+/// one. The approver only ever sees an opaque digest, so nothing downstream
+/// could catch the substitution.
+pub fn payload_digest(type_uri: &str, payload: &serde_json::Value) -> Result<String, AppError> {
     let canonical = serde_json_canonicalizer::to_string(payload)
         .map_err(|e| AppError::Internal(format!("payload JCS canonicalization failed: {e}")))?;
-    Ok(hex::encode(Sha256::digest(canonical.as_bytes())))
+    let mut h = Sha256::new();
+    h.update(DIGEST_DOMAIN);
+    h.update((type_uri.len() as u64).to_be_bytes());
+    h.update(type_uri.as_bytes());
+    h.update(canonical.as_bytes());
+    Ok(hex::encode(h.finalize()))
 }
 
 /// An in-flight consent request accumulating approver signatures.
@@ -98,14 +116,24 @@ pub async fn store_pending(ks: &KeyspaceHandle, p: &PendingTaskConsent) -> Resul
     ks.insert(key, p).await
 }
 
+/// Fetch a live pending consent. An expired one is treated as absent and swept
+/// — its TTL is what bounds how long an approver's signature can authorize a
+/// request, so it has to be enforced on the read path, not only by the sweeper.
 pub async fn get_pending(
     ks: &KeyspaceHandle,
     digest: &str,
+    now: u64,
 ) -> Result<Option<PendingTaskConsent>, AppError> {
-    match ks.get_raw(pending_key(digest)).await? {
-        Some(b) => Ok(Some(decode(&b)?)),
-        None => Ok(None),
+    let key = pending_key(digest);
+    let Some(b) = ks.get_raw(key.clone()).await? else {
+        return Ok(None);
+    };
+    let p: PendingTaskConsent = decode(&b)?;
+    if p.expires_at <= now {
+        ks.remove(key).await?;
+        return Ok(None);
     }
+    Ok(Some(p))
 }
 
 pub async fn delete_pending(ks: &KeyspaceHandle, digest: &str) -> Result<(), AppError> {
@@ -113,14 +141,15 @@ pub async fn delete_pending(ks: &KeyspaceHandle, digest: &str) -> Result<(), App
 }
 
 /// Record an approval (idempotent per approver) and return the updated pending.
-/// `Ok(None)` if there is no pending consent for the digest. The caller decides
-/// whether `approvals.len() >= min_approvals` and, if so, issues a grant.
+/// `Ok(None)` if there is no live pending consent for the digest. The caller
+/// decides whether `approvals.len() >= min_approvals` and, if so, issues a grant.
 pub async fn add_approval(
     ks: &KeyspaceHandle,
     digest: &str,
     approver_did: &str,
+    now: u64,
 ) -> Result<Option<PendingTaskConsent>, AppError> {
-    let Some(mut p) = get_pending(ks, digest).await? else {
+    let Some(mut p) = get_pending(ks, digest, now).await? else {
         return Ok(None);
     };
     if !p.approvals.iter().any(|a| a == approver_did) {
@@ -128,6 +157,36 @@ pub async fn add_approval(
         store_pending(ks, &p).await?;
     }
     Ok(Some(p))
+}
+
+/// Prune expired pendings and lapsed grants. Both paths already expire lazily on
+/// read; this bounds the space an unanswered request can hold indefinitely.
+pub async fn sweep_expired(ks: &KeyspaceHandle, now: u64) -> Result<usize, AppError> {
+    let mut pruned = 0usize;
+
+    for (key, value) in ks.prefix_iter_raw("pending:").await? {
+        match serde_json::from_slice::<PendingTaskConsent>(&value) {
+            Ok(p) if p.expires_at <= now => {
+                ks.remove(key).await?;
+                pruned += 1;
+            }
+            Ok(_) => {}
+            Err(e) => tracing::debug!(error = %e, "task-consent sweeper: unreadable pending row"),
+        }
+    }
+
+    for (key, value) in ks.prefix_iter_raw("grant:").await? {
+        match serde_json::from_slice::<TaskConsentGrant>(&value) {
+            Ok(g) if g.expires_at <= now => {
+                ks.remove(key).await?;
+                pruned += 1;
+            }
+            Ok(_) => {}
+            Err(e) => tracing::debug!(error = %e, "task-consent sweeper: unreadable grant row"),
+        }
+    }
+
+    Ok(pruned)
 }
 
 // ── Grant ──────────────────────────────────────────────────────────────────
@@ -141,9 +200,14 @@ pub async fn store_grant(ks: &KeyspaceHandle, g: &TaskConsentGrant) -> Result<()
 /// Consume a valid grant for `(requester, digest)` — single-use: on a hit the
 /// grant is removed before returning. Returns `None` if absent or expired (an
 /// expired grant is also removed). This is the gate's allow-path check.
+///
+/// `type_uri` is re-asserted against the grant even though [`payload_digest`]
+/// already folds it in: the digest binding is the load-bearing defence, and this
+/// is the assertion that fails loudly if that ever regresses.
 pub async fn consume_grant(
     ks: &KeyspaceHandle,
     requester_did: &str,
+    type_uri: &str,
     digest: &str,
     now: u64,
 ) -> Result<Option<TaskConsentGrant>, AppError> {
@@ -156,6 +220,12 @@ pub async fn consume_grant(
     ks.remove(key).await?;
     if grant.expires_at <= now {
         return Ok(None);
+    }
+    if grant.type_uri != type_uri {
+        return Err(AppError::Internal(format!(
+            "task-consent grant type mismatch: granted for '{}', presented for '{type_uri}'",
+            grant.type_uri
+        )));
     }
     Ok(Some(grant))
 }
@@ -176,13 +246,42 @@ mod tests {
         (store.keyspace(crate::keyspaces::TASK_CONSENT).unwrap(), dir)
     }
 
+    const T_UPDATE: &str = "https://trusttasks.org/spec/webvh/dids/update/1.0";
+    const T_ROTATE: &str = "https://trusttasks.org/spec/webvh/dids/rotate-keys/1.0";
+
     #[test]
     fn digest_is_deterministic_and_key_order_independent() {
-        let a = payload_digest(&json!({ "b": 2, "a": 1 })).unwrap();
-        let b = payload_digest(&json!({ "a": 1, "b": 2 })).unwrap();
+        let a = payload_digest(T_UPDATE, &json!({ "b": 2, "a": 1 })).unwrap();
+        let b = payload_digest(T_UPDATE, &json!({ "a": 1, "b": 2 })).unwrap();
         assert_eq!(a, b, "JCS canonicalization must ignore key order");
-        assert_ne!(a, payload_digest(&json!({ "a": 1, "b": 3 })).unwrap());
+        assert_ne!(
+            a,
+            payload_digest(T_UPDATE, &json!({ "a": 1, "b": 3 })).unwrap()
+        );
         assert_eq!(a.len(), 64, "hex sha-256 is 64 chars");
+    }
+
+    /// The bypass this binding exists to close: an identical payload under two
+    /// different task URIs must not share a digest, or an approval for the
+    /// benign task authorizes the destructive one.
+    #[test]
+    fn digest_binds_the_type_uri() {
+        let payload = json!({ "did": "did:webvh:example.com:abc", "contextId": "default" });
+        assert_ne!(
+            payload_digest(T_UPDATE, &payload).unwrap(),
+            payload_digest(T_ROTATE, &payload).unwrap(),
+            "same payload under a different task URI must not collide"
+        );
+    }
+
+    /// Length-prefixing the URI stops a boundary shift between the URI and the
+    /// canonical payload from producing the same preimage.
+    #[test]
+    fn digest_uri_payload_boundary_is_unambiguous() {
+        assert_ne!(
+            payload_digest("ab", &json!("c")).unwrap(),
+            payload_digest("a", &json!("bc")).unwrap(),
+        );
     }
 
     fn pending(digest: &str, min: u32) -> PendingTaskConsent {
@@ -205,19 +304,19 @@ mod tests {
         let (ks, _d) = temp_ks().await;
         store_pending(&ks, &pending("deadbeef", 2)).await.unwrap();
 
-        let p = add_approval(&ks, "deadbeef", "did:key:zA")
+        let p = add_approval(&ks, "deadbeef", "did:key:zA", 200)
             .await
             .unwrap()
             .unwrap();
         assert_eq!(p.approvals.len(), 1);
         // Same approver again → no double count.
-        let p = add_approval(&ks, "deadbeef", "did:key:zA")
+        let p = add_approval(&ks, "deadbeef", "did:key:zA", 200)
             .await
             .unwrap()
             .unwrap();
         assert_eq!(p.approvals.len(), 1);
         // Second distinct approver reaches the threshold.
-        let p = add_approval(&ks, "deadbeef", "did:key:zB")
+        let p = add_approval(&ks, "deadbeef", "did:key:zB", 200)
             .await
             .unwrap()
             .unwrap();
@@ -226,36 +325,76 @@ mod tests {
 
         // No pending for an unknown digest.
         assert!(
-            add_approval(&ks, "nope", "did:key:zA")
+            add_approval(&ks, "nope", "did:key:zA", 200)
                 .await
                 .unwrap()
                 .is_none()
         );
     }
 
+    /// `expires_at` was previously written but never read, so a pending consent
+    /// could be approved indefinitely.
+    #[tokio::test]
+    async fn expired_pending_reads_as_absent_and_cannot_be_approved() {
+        let (ks, _d) = temp_ks().await;
+        store_pending(&ks, &pending("deadbeef", 1)).await.unwrap();
+
+        // expires_at = 1000
+        assert!(get_pending(&ks, "deadbeef", 999).await.unwrap().is_some());
+        assert!(get_pending(&ks, "deadbeef", 1000).await.unwrap().is_none());
+        assert!(
+            add_approval(&ks, "deadbeef", "did:key:zA", 1001)
+                .await
+                .unwrap()
+                .is_none(),
+            "an expired pending must not accept approvals"
+        );
+        // …and the lapsed row is swept on the way out.
+        assert!(get_pending(&ks, "deadbeef", 500).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn sweeper_prunes_lapsed_pendings_and_grants() {
+        let (ks, _d) = temp_ks().await;
+        store_pending(&ks, &pending("d1", 1)).await.unwrap(); // expires_at 1000
+        store_grant(&ks, &grant("d2", 500)).await.unwrap();
+
+        assert_eq!(
+            sweep_expired(&ks, 400).await.unwrap(),
+            0,
+            "nothing lapsed yet"
+        );
+        assert_eq!(sweep_expired(&ks, 2000).await.unwrap(), 2, "both lapsed");
+        assert_eq!(sweep_expired(&ks, 2000).await.unwrap(), 0, "idempotent");
+    }
+
+    fn grant(digest: &str, expires_at: u64) -> TaskConsentGrant {
+        TaskConsentGrant {
+            digest: digest.into(),
+            requester_did: "did:key:zReq".into(),
+            type_uri: T_UPDATE.into(),
+            approvers: vec!["did:key:zA".into()],
+            granted_at: 100,
+            expires_at,
+        }
+    }
+
     #[tokio::test]
     async fn grant_is_single_use_and_expiry_checked() {
         let (ks, _d) = temp_ks().await;
-        let g = TaskConsentGrant {
-            digest: "d1".into(),
-            requester_did: "did:key:zReq".into(),
-            type_uri: "t".into(),
-            approvers: vec!["did:key:zA".into()],
-            granted_at: 100,
-            expires_at: 500,
-        };
+        let g = grant("d1", 500);
         store_grant(&ks, &g).await.unwrap();
 
         // First consume within validity → hit.
         assert!(
-            consume_grant(&ks, "did:key:zReq", "d1", 200)
+            consume_grant(&ks, "did:key:zReq", T_UPDATE, "d1", 200)
                 .await
                 .unwrap()
                 .is_some()
         );
         // Second consume → gone (single-use).
         assert!(
-            consume_grant(&ks, "did:key:zReq", "d1", 200)
+            consume_grant(&ks, "did:key:zReq", T_UPDATE, "d1", 200)
                 .await
                 .unwrap()
                 .is_none()
@@ -264,13 +403,13 @@ mod tests {
         // Expired grant → None, and swept.
         store_grant(&ks, &g).await.unwrap();
         assert!(
-            consume_grant(&ks, "did:key:zReq", "d1", 999)
+            consume_grant(&ks, "did:key:zReq", T_UPDATE, "d1", 999)
                 .await
                 .unwrap()
                 .is_none()
         );
         assert!(
-            consume_grant(&ks, "did:key:zReq", "d1", 200)
+            consume_grant(&ks, "did:key:zReq", T_UPDATE, "d1", 200)
                 .await
                 .unwrap()
                 .is_none()
@@ -279,10 +418,27 @@ mod tests {
         // Wrong requester never matches.
         store_grant(&ks, &g).await.unwrap();
         assert!(
-            consume_grant(&ks, "did:key:zOther", "d1", 200)
+            consume_grant(&ks, "did:key:zOther", T_UPDATE, "d1", 200)
                 .await
                 .unwrap()
                 .is_none()
+        );
+    }
+
+    /// Belt-and-braces on the type binding: even if a digest for one task URI
+    /// were somehow presented for another, consumption must refuse it rather
+    /// than silently authorize.
+    #[tokio::test]
+    async fn grant_refuses_a_different_task_uri() {
+        let (ks, _d) = temp_ks().await;
+        store_grant(&ks, &grant("d1", 500)).await.unwrap();
+
+        let err = consume_grant(&ks, "did:key:zReq", T_ROTATE, "d1", 200)
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("type mismatch"),
+            "expected a type-mismatch refusal, got: {err}"
         );
     }
 }

--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -684,6 +684,7 @@ pub async fn run(
         let acl_ks = apply_encryption(store.keyspace(crate::keyspaces::ACL)?);
         let audit_ks = apply_encryption(store.keyspace(crate::keyspaces::AUDIT)?);
         let consent_ks = apply_encryption(store.keyspace(crate::keyspaces::CONSENT)?);
+        let task_consent_ks = apply_encryption(store.keyspace(crate::keyspaces::TASK_CONSENT)?);
         let vault_ks = apply_encryption(store.keyspace(crate::keyspaces::VAULT)?);
         let backup_bundles_ks = apply_encryption(store.keyspace(crate::keyspaces::BACKUP_BUNDLES)?);
         let backup_blob_dir = config.store.data_dir.join("backups");
@@ -765,6 +766,7 @@ pub async fn run(
         let storage_audit_ks = audit_ks.clone();
         let storage_acl_ks = acl_ks.clone();
         let storage_consent_ks = consent_ks.clone();
+        let storage_task_consent_ks = task_consent_ks.clone();
         let storage_vault_ks = vault_ks.clone();
         let storage_backup_bundles_ks = backup_bundles_ks.clone();
         let storage_backup_blob_dir = backup_blob_dir.clone();
@@ -1141,6 +1143,7 @@ pub async fn run(
                     storage_audit_ks,
                     storage_acl_ks,
                     storage_consent_ks,
+                    storage_task_consent_ks,
                     storage_vault_ks,
                     storage_backup_bundles_ks,
                     storage_backup_blob_dir,
@@ -1239,6 +1242,7 @@ fn run_storage_thread(
     audit_ks: KeyspaceHandle,
     acl_ks: KeyspaceHandle,
     consent_ks: KeyspaceHandle,
+    task_consent_ks: KeyspaceHandle,
     vault_ks: KeyspaceHandle,
     backup_bundles_ks_storage: KeyspaceHandle,
     backup_blob_dir_storage: std::path::PathBuf,
@@ -1290,6 +1294,18 @@ fn run_storage_thread(
                             crate::consent_sweeper::sweep_expired(&consent_ks, &audit_ks).await
                         {
                             warn!("consent sweeper error: {e}");
+                        }
+                        // Same for task-execution consent: an unanswered pending
+                        // would otherwise sit in the keyspace forever, since the
+                        // gate only expires one lazily when its digest is re-read.
+                        let now = std::time::SystemTime::now()
+                            .duration_since(std::time::UNIX_EPOCH)
+                            .map(|d| d.as_secs())
+                            .unwrap_or(0);
+                        match crate::policy::consent::sweep_expired(&task_consent_ks, now).await {
+                            Ok(n) if n > 0 => debug!("task-consent sweeper pruned {n} rows"),
+                            Ok(_) => {}
+                            Err(e) => warn!("task-consent sweeper error: {e}"),
                         }
                         // Expire & retention-prune in-flight backup
                         // bundles (descriptor-pattern slice). TTL

--- a/vta-service/src/trust_tasks/policy_gate.rs
+++ b/vta-service/src/trust_tasks/policy_gate.rs
@@ -188,14 +188,14 @@ async fn consent_gate(
         ));
     };
 
-    let digest = match consent::payload_digest(&doc.payload) {
+    let digest = match consent::payload_digest(type_uri, &doc.payload) {
         Ok(d) => d,
         Err(e) => return Some(app_error_to_reject(doc, e)),
     };
     let now = gate_now_secs();
 
     // Existing valid grant → authorized; consume single-use and proceed.
-    match consent::consume_grant(&state.task_consent_ks, &auth.did, &digest, now).await {
+    match consent::consume_grant(&state.task_consent_ks, &auth.did, type_uri, &digest, now).await {
         Ok(Some(_)) => return None,
         Ok(None) => {}
         Err(e) => return Some(app_error_to_reject(doc, e)),
@@ -225,7 +225,7 @@ async fn consent_gate(
 
     // Reuse an existing pending challenge (idempotent re-submit) or mint one.
     let min_approvals = require.min_approvals.max(1);
-    let challenge = match consent::get_pending(&state.task_consent_ks, &digest).await {
+    let challenge = match consent::get_pending(&state.task_consent_ks, &digest, now).await {
         Ok(Some(p)) => p.challenge,
         Ok(None) => {
             let challenge = format!("{}{}", Uuid::new_v4().simple(), Uuid::new_v4().simple());
@@ -362,7 +362,76 @@ mod tests {
         );
     }
 
+    // A second ungated URI. `doc()` gives both the *same* payload, which is the
+    // whole point: without a type binding in the digest they collide.
+    const OTHER_UNGATED_URI: &str = "https://trusttasks.org/spec/vta/memory/delete/0.1";
+
     const REQUIRE_CONSENT: &str = "package vta.policy\nimport rego.v1\ndecision := {\"decision\": \"requireConsent\", \"requireConsent\": {\"approverSet\": \"ops\"}}";
+
+    /// A grant approved for one task URI must not authorize a *different* task
+    /// URI that happens to carry an identical payload. The approver only ever
+    /// sees an opaque digest, so if the digest didn't bind the type URI, consent
+    /// for a benign task would silently authorize a destructive one.
+    #[tokio::test]
+    async fn grant_for_one_task_uri_does_not_authorize_another() {
+        use crate::policy::consent;
+        let (state, _dir) = crate::test_support::build_signing_test_app_state().await;
+        let auth = crate::test_support::super_admin_claims();
+
+        let approved = doc(UNGATED_URI);
+        let substituted = doc(OTHER_UNGATED_URI);
+        assert_eq!(
+            approved.payload, substituted.payload,
+            "the two tasks must share a payload for this test to mean anything"
+        );
+
+        {
+            let mut cfg = state.config.write().await;
+            cfg.policy.enforcement = true;
+            cfg.policy
+                .approver_sets
+                .insert("ops".into(), vec!["did:key:zApprover".into()]);
+        }
+        crate::policy::storage::store_policy(
+            &state.policy_ks,
+            &module("consent", 0, REQUIRE_CONSENT),
+        )
+        .await
+        .unwrap();
+
+        // Approvers sign off on UNGATED_URI: mint the grant the gate would consume.
+        let now = super::gate_now_secs();
+        let digest = consent::payload_digest(UNGATED_URI, &approved.payload).unwrap();
+        consent::store_grant(
+            &state.task_consent_ks,
+            &consent::TaskConsentGrant {
+                digest: digest.clone(),
+                requester_did: auth.did.clone(),
+                type_uri: UNGATED_URI.into(),
+                approvers: vec!["did:key:zApprover".into()],
+                granted_at: now,
+                expires_at: now + 600,
+            },
+        )
+        .await
+        .unwrap();
+
+        // The substituted task must NOT ride that grant through.
+        assert!(
+            policy_gate(&state, &auth, OTHER_UNGATED_URI, &substituted)
+                .await
+                .is_some(),
+            "a grant for a different task URI must not authorize this one"
+        );
+
+        // …while the task actually approved still passes.
+        assert!(
+            policy_gate(&state, &auth, UNGATED_URI, &approved)
+                .await
+                .is_none(),
+            "the approved task must still consume its own grant"
+        );
+    }
 
     #[tokio::test]
     async fn require_consent_records_pending_then_grant_lets_resubmit_through() {
@@ -390,9 +459,10 @@ mod tests {
             policy_gate(&state, &auth, UNGATED_URI, &d).await.is_some(),
             "first submit must be rejected pending consent"
         );
-        let digest = consent::payload_digest(&d.payload).unwrap();
+        let digest = consent::payload_digest(UNGATED_URI, &d.payload).unwrap();
+        let now = super::gate_now_secs();
         assert!(
-            consent::get_pending(&state.task_consent_ks, &digest)
+            consent::get_pending(&state.task_consent_ks, &digest, now)
                 .await
                 .unwrap()
                 .is_some(),
@@ -400,7 +470,6 @@ mod tests {
         );
 
         // Simulate approvers reaching threshold: store a grant.
-        let now = super::gate_now_secs();
         consent::store_grant(
             &state.task_consent_ks,
             &consent::TaskConsentGrant {

--- a/vta-service/src/trust_tasks/task_consent.rs
+++ b/vta-service/src/trust_tasks/task_consent.rs
@@ -64,8 +64,11 @@ pub(super) async fn handle_decision(
         }
     };
 
+    let now = now_secs();
+
     let ks = &state.task_consent_ks;
-    let pending = match consent::get_pending(ks, &payload.digest).await {
+    // An expired pending reads as absent, so a lapsed request can't be approved.
+    let pending = match consent::get_pending(ks, &payload.digest, now).await {
         Ok(Some(p)) => p,
         Ok(None) => {
             return reject_with(
@@ -120,8 +123,6 @@ pub(super) async fn handle_decision(
         );
     }
 
-    let now = now_secs();
-
     // A denial aborts the request.
     if !payload.approve {
         let _ = consent::delete_pending(ks, &payload.digest).await;
@@ -132,7 +133,7 @@ pub(super) async fn handle_decision(
     }
 
     // Accumulate the approval; at the threshold, issue a single-use grant.
-    let updated = match consent::add_approval(ks, &payload.digest, &approver).await {
+    let updated = match consent::add_approval(ks, &payload.digest, &approver, now).await {
         Ok(Some(p)) => p,
         Ok(None) => {
             return reject_with(


### PR DESCRIPTION
## The bug

The task-consent digest was `SHA-256(JCS(payload))` over the payload **alone**, and `consent_gate` discarded the grant's `type_uri` on consume (binding it with `_`). The grant key is `grant:<digest>:<requester>`.

So two tasks whose payloads canonicalize identically share a digest. `{"did": "...", "contextId": "..."}` is a plausible payload for `webvh/dids/update`, `dids/rotate-keys` **and** a deactivate. An approval collected for the benign task therefore authorized the destructive one — and because the approver only ever sees an opaque hex digest, nothing downstream could catch the substitution.

Enforcement is opt-in (`config.policy.enforcement`), so this is reachable only in deployments that have turned the PDP on.

## The fix

Fold the type URI into the digest, length-prefixed under a domain-separation tag so the URI/payload boundary can't be shifted:

```
SHA-256( "vta/task-consent/v1\0" || len(typeUri) || typeUri || JCS(payload) )
```

and re-assert `type_uri` on consume, so a regression in the digest function fails loudly rather than silently authorizing.

## Two further defects in the same slice

- **`PendingTaskConsent.expires_at` was written but never read.** `get_pending` did no expiry check, `handle_decision` didn't check it, and no sweeper covered the `task_consent` keyspace — a pending request could be approved indefinitely. Now expired on the read path (the TTL is what bounds how long an approver's signature can authorize a request, so it belongs there, not only in a sweeper), plus a sweeper in the storage loop to bound the keyspace.
- The module and keyspace docs described the grant key as `grant:<requester>:<digest>`; the code writes `grant:<digest>:<requester>`. Docs corrected to match.

## Tests

A gate-level regression test asserts a grant minted for one task URI does not let a *different* task URI with an identical payload through. Verified it **fails against the pre-fix digest** (the gate allowed `vta/memory/delete` on a grant approved for `vta/memory/list`) and passes with the binding in place.

Also covers: the type-URI digest split, the URI/payload boundary being unambiguous, expired pendings refusing approvals and being swept, and the sweeper pruning lapsed pendings and grants.

`cargo fmt --all -- --check`, `cargo clippy --workspace -- -D warnings`, and the full `vta-service` suite (1067 tests) all pass.