### PR TITLE
feat(pnm): add --transport rest to recover DIDComm-locked VTAs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,20 +2,39 @@
 
 ## Unreleased
 
-### pnm-cli (0.10.7) — `--transport rest` recovery flag
+### pnm-cli (0.10.7) / cnm-cli (0.10.7) — `--transport rest` recovery flag
 
-Adds a global `--transport <auto|rest>` flag. `rest` forces the REST transport,
-skipping DIDComm even when the VTA advertises it — the recovery path when a
-VTA's mediator is unreachable (auto-selection picks DIDComm and hangs with no
-fallback, locking the operator out). Example: `pnm --transport rest services
-didcomm disable` recovers a VTA that force-enabled DIDComm against a mediator it
-can't reach.
+Adds a global `--transport <auto|rest>` flag to both CLIs. `rest` forces the
+REST transport, skipping DIDComm even when the VTA advertises it and even when
+the local config pins a `mediator_did` — the recovery path when a VTA's mediator
+is unreachable and auto-selection would keep dialling it. Example: `pnm
+--transport rest services didcomm disable` recovers a VTA that enabled DIDComm
+against a mediator it can't reach.
 
-### vta-sdk (0.19.1) — force-REST connect path
+`pnm` also reconciles a pinned `mediator_did` after a successful `services
+didcomm enable|update|disable` (repoint on enable/update, clear on disable). The
+pin is priority 1 of transport selection and never re-reads the DID document, so
+a stale one would keep forcing DIDComm at a mediator that is gone.
+
+Docs: `docs/02-vta/runtime-service-management.md` gains a "Recovery: the mediator
+is unreachable" section.
+
+### vta-sdk (0.19.1) — force-REST connect path + bounded DIDComm connect
 
 - `SessionStore::connect_with_transport` + `TransportChoice { Auto, Rest }`:
   force REST regardless of advertised DIDComm. The existing `connect` is
-  unchanged and delegates with `Auto`. Purely additive.
+  unchanged and delegates with `Auto`. Purely additive. `TransportChoice` is
+  `#[non_exhaustive]` — TSP will land as a variant.
+- Auto-selected DIDComm connects are now bounded (30s default, override with
+  `VTA_DIDCOMM_CONNECT_TIMEOUT_SECS`). The mediator client owns a
+  reconnect/backoff loop, so an unreachable mediator previously hung the CLI
+  indefinitely instead of failing; the timeout error now names
+  `--transport rest`, which is what makes the flag above discoverable.
+- Forced REST resolves `url_override`, else the `#vta-rest` service on the VTA's
+  DID document, and errors asking for `--url` if it finds neither. It
+  deliberately does not fall back to a URL synthesized from the DID's own domain
+  (`resolve_vta_url`'s last resort): for a hosted `did:webvh` that is the DID
+  host, not the VTA, and authenticating against it fails undiagnosably.
 
 ### vta-sdk (0.18.18) — did-host TSP-only DID templates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+### pnm-cli (0.10.7) — `--transport rest` recovery flag
+
+Adds a global `--transport <auto|rest>` flag. `rest` forces the REST transport,
+skipping DIDComm even when the VTA advertises it — the recovery path when a
+VTA's mediator is unreachable (auto-selection picks DIDComm and hangs with no
+fallback, locking the operator out). Example: `pnm --transport rest services
+didcomm disable` recovers a VTA that force-enabled DIDComm against a mediator it
+can't reach.
+
+### vta-sdk (0.19.1) — force-REST connect path
+
+- `SessionStore::connect_with_transport` + `TransportChoice { Auto, Rest }`:
+  force REST regardless of advertised DIDComm. The existing `connect` is
+  unchanged and delegates with `Auto`. Purely additive.
+
 ### vta-sdk (0.18.18) — did-host TSP-only DID templates
 
 Two new built-in `did-host-*` templates let a VTA provision a node whose DID

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2438,7 +2438,7 @@ checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cnm-cli"
-version = "0.10.6"
+version = "0.10.7"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2452,7 +2452,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.19.0",
+ "vta-sdk 0.19.1",
 ]
 
 [[package]]
@@ -3254,7 +3254,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.19.0",
+ "vta-sdk 0.19.1",
 ]
 
 [[package]]
@@ -6692,7 +6692,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "pnm-cli"
-version = "0.10.6"
+version = "0.10.7"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-resolver-cache-sdk",
@@ -6714,7 +6714,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.19.0",
+ "vta-sdk 0.19.1",
 ]
 
 [[package]]
@@ -10016,7 +10016,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.19.0",
+ "vta-sdk 0.19.1",
  "vti-common",
  "x25519-dalek",
 ]
@@ -10049,7 +10049,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.19.0",
+ "vta-sdk 0.19.1",
 ]
 
 [[package]]
@@ -10072,7 +10072,7 @@ dependencies = [
  "tracing-subscriber",
  "trust-tasks-rs",
  "uniffi",
- "vta-sdk 0.19.0",
+ "vta-sdk 0.19.1",
 ]
 
 [[package]]
@@ -10107,7 +10107,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10242,7 +10242,7 @@ dependencies = [
  "utoipa-axum",
  "uuid",
  "vta-cli-common",
- "vta-sdk 0.19.0",
+ "vta-sdk 0.19.1",
  "vta-service",
  "vti-common",
  "vti-secrets",
@@ -10264,7 +10264,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.19.0",
+ "vta-sdk 0.19.1",
 ]
 
 [[package]]
@@ -10336,7 +10336,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.19.0",
+ "vta-sdk 0.19.1",
  "vtc-service",
  "vti-common",
  "vti-secrets",
@@ -10384,7 +10384,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.19.0",
+ "vta-sdk 0.19.1",
  "webauthn-rs",
  "zeroize",
 ]
@@ -10411,7 +10411,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.19.0",
+ "vta-sdk 0.19.1",
  "vta-service",
  "vti-common",
 ]
@@ -10440,7 +10440,7 @@ dependencies = [
  "tokio",
  "tracing",
  "vaultrs",
- "vta-sdk 0.19.0",
+ "vta-sdk 0.19.1",
  "vti-common",
 ]
 

--- a/cnm-cli/Cargo.toml
+++ b/cnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cnm-cli"
 description = "CLI Tool for Verified Trust Agents operating in Verified Trust Communities"
-version = "0.10.6"
+version = "0.10.7"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/cnm-cli/src/auth.rs
+++ b/cnm-cli/src/auth.rs
@@ -116,9 +116,15 @@ pub async fn ensure_authenticated(
 ///
 /// If `url_override` is provided, always uses REST.
 /// Otherwise resolves the VTA DID and prefers DIDComm when available.
+///
+/// `transport` overrides that: [`TransportChoice::Rest`] forces REST even when
+/// the VTA advertises DIDComm (the recovery path for an unreachable mediator).
 pub async fn connect(
     url_override: Option<&str>,
+    transport: vta_sdk::session::TransportChoice,
     keyring_key: &str,
 ) -> Result<vta_sdk::client::VtaClient, Box<dyn std::error::Error>> {
-    store().connect(keyring_key, url_override, None).await
+    store()
+        .connect_with_transport(keyring_key, url_override, None, transport)
+        .await
 }

--- a/cnm-cli/src/main.rs
+++ b/cnm-cli/src/main.rs
@@ -3,7 +3,7 @@ mod backup;
 mod config;
 mod setup;
 
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 use config::{community_keyring_key, resolve_community};
 use vta_sdk::client::VtaClient;
 
@@ -52,8 +52,35 @@ struct Cli {
     #[arg(long, global = true)]
     json: bool,
 
+    /// Force a transport instead of auto-selecting. `rest` skips DIDComm even
+    /// when the VTA advertises it — the recovery path when a mediator is
+    /// unreachable.
+    #[arg(long, value_enum, default_value_t = TransportOpt::Auto, global = true)]
+    transport: TransportOpt,
+
     #[command(subcommand)]
     command: Commands,
+}
+
+/// Transport to use when connecting to the VTA. Mirrors pnm's flag; maps onto
+/// [`vta_sdk::session::TransportChoice`].
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, ValueEnum)]
+enum TransportOpt {
+    /// Prefer DIDComm when the VTA advertises it, else REST.
+    #[default]
+    Auto,
+    /// Force REST even when DIDComm is advertised — recovers a VTA whose
+    /// mediator is unreachable.
+    Rest,
+}
+
+impl From<TransportOpt> for vta_sdk::session::TransportChoice {
+    fn from(opt: TransportOpt) -> Self {
+        match opt {
+            TransportOpt::Auto => Self::Auto,
+            TransportOpt::Rest => Self::Rest,
+        }
+    }
 }
 
 #[derive(Subcommand)]
@@ -957,7 +984,7 @@ async fn main() {
             std::process::exit(1);
         }
 
-        match auth::connect(url_override.as_deref(), &keyring_key).await {
+        match auth::connect(url_override.as_deref(), cli.transport.into(), &keyring_key).await {
             Ok(c) => c,
             Err(e) => {
                 vta_cli_common::render::print_cli_error(e.as_ref());

--- a/docs/02-vta/runtime-service-management.md
+++ b/docs/02-vta/runtime-service-management.md
@@ -660,6 +660,58 @@ The `mediator-management/1.0` namespace is retained for
 the active mediator advertisement, so the original naming is still
 accurate.
 
+## Recovery: the mediator is unreachable
+
+DIDComm is the preferred transport, so `pnm` picks it whenever the
+VTA's DID document advertises it. If that mediator then goes away —
+wrong DID at enable time, mediator decommissioned, network partition —
+every `pnm` command against that VTA tries to reach it. That includes
+the very commands you would use to fix the situation (`services list`,
+`services didcomm disable`), so the VTA looks bricked when it is only
+unreachable *over DIDComm*. Its REST surface is still up.
+
+Two things break the loop.
+
+**The connect is bounded.** An auto-selected DIDComm connect gives the
+mediator 30 seconds and then fails with the recovery command rather than
+retrying forever. Raise the ceiling on slow links with
+`VTA_DIDCOMM_CONNECT_TIMEOUT_SECS`.
+
+**`--transport rest` forces REST.** A global flag on both `pnm` and
+`cnm`. It skips DIDComm even when the DID document advertises it, and
+even when the local config pins a `mediator_did`:
+
+```bash
+# Confirm what the VTA currently advertises.
+pnm --transport rest services list
+
+# Point DIDComm at a mediator that answers …
+pnm --transport rest services didcomm update --to did:web:new-mediator.example.com
+
+# … or stop advertising DIDComm altogether.
+pnm --transport rest services didcomm disable --drain-ttl 0
+```
+
+`--drain-ttl 0` (immediate teardown) is only accepted over REST — which
+is exactly the transport you are on. Over DIDComm the server enforces a
+1h minimum so the response doesn't die with the listener carrying it.
+
+Notes:
+
+- Forcing REST needs a REST endpoint to force. `pnm` uses `--url` if
+  given, else the `#vta-rest` service on the VTA's DID document. If the
+  VTA advertises neither, the command errors and asks for `--url` — it
+  will not guess a URL from the DID's domain, which for a hosted
+  `did:webvh` is the DID host, not the VTA.
+- If your config pins a `mediator_did` (`pnm vta add --mediator-did …`),
+  that pin is priority 1 of transport selection and never re-reads the
+  DID document. A successful `services didcomm enable|update|disable`
+  reconciles the pin for you — disable clears it, enable/update repoint
+  it — so the next command doesn't dial a mediator that is gone.
+- Once DIDComm is disabled, plain `pnm services list` works again; the
+  DID document no longer advertises a mediator, so auto-selection lands
+  on REST on its own.
+
 ## Failure modes
 
 The CLI's error renderer surfaces the typed `VtaError` variant

--- a/pnm-cli/Cargo.toml
+++ b/pnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pnm-cli"
 description = "CLI Tool for managing a personal Verifiable Trust Agent"
-version = "0.10.6"
+version = "0.10.7"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/pnm-cli/src/auth.rs
+++ b/pnm-cli/src/auth.rs
@@ -199,13 +199,17 @@ pub async fn show_token(keyring_key: &str) -> Result<(), Box<dyn std::error::Err
 /// 2. VTA DID doc DIDCommMessaging service → DIDComm (resolved).
 /// 3. `url_override` + REST discovery → DIDComm if available.
 /// 4. `url_override` → REST-only fallback.
+///
+/// `transport` overrides the above: `TransportChoice::Rest` forces REST and
+/// skips priorities 1 & 2 (the recovery path for an unreachable mediator).
 pub async fn connect(
     url_override: Option<&str>,
     mediator_did_hint: Option<&str>,
+    transport: vta_sdk::session::TransportChoice,
     keyring_key: &str,
 ) -> Result<vta_sdk::client::VtaClient, Box<dyn std::error::Error>> {
     store()
-        .connect(keyring_key, url_override, mediator_did_hint)
+        .connect_with_transport(keyring_key, url_override, mediator_did_hint, transport)
         .await
 }
 

--- a/pnm-cli/src/cli.rs
+++ b/pnm-cli/src/cli.rs
@@ -6,7 +6,18 @@
 //! parser-adjacent — they decide *which* dispatcher to call, never *how*
 //! the call is performed.
 
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
+
+/// Transport to use when connecting to the VTA.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, ValueEnum)]
+pub(crate) enum TransportOpt {
+    /// Prefer DIDComm when the VTA advertises it, else REST.
+    #[default]
+    Auto,
+    /// Force REST even when DIDComm is advertised — recovers a VTA whose
+    /// mediator is unreachable.
+    Rest,
+}
 
 #[derive(Parser)]
 #[command(
@@ -36,6 +47,12 @@ pub(crate) struct Cli {
     /// Use this for automation: `pnm acl list --json | jq …`.
     #[arg(long, global = true)]
     pub(crate) json: bool,
+
+    /// Force a transport instead of auto-selecting. `rest` skips DIDComm even
+    /// when the VTA advertises it — the recovery path when a mediator is
+    /// unreachable.
+    #[arg(long, value_enum, default_value_t = TransportOpt::Auto, global = true)]
+    pub(crate) transport: TransportOpt,
 
     #[command(subcommand)]
     pub(crate) command: Commands,
@@ -2273,4 +2290,27 @@ pub(crate) fn install_force_exit_handler() {
             eprintln!("\nShutting down — press Ctrl-C again to force exit.");
         }
     });
+}
+
+#[cfg(test)]
+mod transport_flag_tests {
+    use super::*;
+    use clap::Parser;
+
+    #[test]
+    fn transport_defaults_to_auto() {
+        let cli = Cli::try_parse_from(["pnm", "health"]).unwrap();
+        assert_eq!(cli.transport, TransportOpt::Auto);
+    }
+
+    #[test]
+    fn transport_rest_parses() {
+        let cli = Cli::try_parse_from(["pnm", "--transport", "rest", "health"]).unwrap();
+        assert_eq!(cli.transport, TransportOpt::Rest);
+    }
+
+    #[test]
+    fn transport_rejects_unknown_value() {
+        assert!(Cli::try_parse_from(["pnm", "--transport", "bogus", "health"]).is_err());
+    }
 }

--- a/pnm-cli/src/cli.rs
+++ b/pnm-cli/src/cli.rs
@@ -19,6 +19,15 @@ pub(crate) enum TransportOpt {
     Rest,
 }
 
+impl From<TransportOpt> for vta_sdk::session::TransportChoice {
+    fn from(opt: TransportOpt) -> Self {
+        match opt {
+            TransportOpt::Auto => Self::Auto,
+            TransportOpt::Rest => Self::Rest,
+        }
+    }
+}
+
 #[derive(Parser)]
 #[command(
     name = "pnm-cli",

--- a/pnm-cli/src/main.rs
+++ b/pnm-cli/src/main.rs
@@ -26,8 +26,8 @@ use vta_sdk::client::VtaClient;
 use vta_cli_common::render::{DIM, RESET};
 
 use crate::cli::{
-    Cli, Commands, VtaCommands, install_force_exit_handler, is_online_template_cmd, print_banner,
-    requires_auth, retired_mediator_redirect,
+    Cli, Commands, DidcommCommands, ServicesCommands, VtaCommands, install_force_exit_handler,
+    is_online_template_cmd, print_banner, requires_auth, retired_mediator_redirect,
 };
 use clap::Parser;
 
@@ -198,9 +198,11 @@ async fn main() {
         }
     }
 
-    // Resolve active VTA
+    // Resolve active VTA. Cloned so the immutable borrow of `pnm_config` ends
+    // here — the post-dispatch mediator-hint reconciliation below writes back
+    // into it.
     let (slug, vta_config) = match config::resolve_vta(vta_override.as_deref(), &pnm_config) {
-        Ok(v) => v,
+        Ok((slug, cfg)) => (slug, cfg.clone()),
         Err(e) => {
             eprintln!("Error: {e}");
             std::process::exit(1);
@@ -219,16 +221,12 @@ async fn main() {
     // For did:key VTAs, use the persisted URL as fallback (DID has no service endpoint).
     let effective_url_override = url_override.as_deref().or(vta_config.url.as_deref());
     let mediator_did_hint = vta_config.mediator_did.as_deref();
-    let transport = match transport_override {
-        cli::TransportOpt::Auto => vta_sdk::session::TransportChoice::Auto,
-        cli::TransportOpt::Rest => vta_sdk::session::TransportChoice::Rest,
-    };
 
     let client = if needs_auth {
         match auth::connect(
             effective_url_override,
             mediator_did_hint,
-            transport,
+            transport_override.into(),
             &keyring_key,
         )
         .await
@@ -251,6 +249,13 @@ async fn main() {
         let url = effective_url_override.unwrap_or_default().to_string();
         VtaClient::new(&url)
     };
+
+    // A pinned `mediator_did` in the config is priority 1 of the connect path
+    // and never re-reads the DID document — so after the operator turns DIDComm
+    // off (or repoints it), a stale hint would keep dialling the old mediator
+    // forever, and `--transport rest` would be needed on every subsequent
+    // command. Work out the hint's fate before `command` is moved into dispatch.
+    let mediator_hint_update = pending_mediator_hint(&command, &vta_config);
 
     // ── Post-auth dispatch ────────────────────────────────────────
     let result = match command {
@@ -284,9 +289,73 @@ async fn main() {
 
     client.shutdown().await;
 
+    if result.is_ok()
+        && let Some(new_hint) = mediator_hint_update
+    {
+        apply_mediator_hint(&mut pnm_config, &slug, new_hint);
+    }
+
     if let Err(e) = result {
         vta_cli_common::render::print_cli_error(e.as_ref());
         std::process::exit(1);
+    }
+}
+
+/// What the locally-pinned `mediator_did` should become once `command`
+/// succeeds: `None` = leave it alone, `Some(None)` = clear it, `Some(Some(did))`
+/// = repoint it.
+///
+/// Only VTAs that actually pin a mediator are affected — we never *introduce* a
+/// hint for a VTA that was happily discovering its mediator from the DID doc.
+fn pending_mediator_hint(
+    command: &Commands,
+    vta_config: &config::VtaConfig,
+) -> Option<Option<String>> {
+    vta_config.mediator_did.as_ref()?;
+
+    match command {
+        Commands::Services {
+            command: ServicesCommands::Didcomm { command },
+        } => match command {
+            DidcommCommands::Disable { .. } => Some(None),
+            DidcommCommands::Update {
+                new_mediator_did, ..
+            } => Some(Some(new_mediator_did.clone())),
+            DidcommCommands::Enable { mediator_did, .. } => Some(Some(mediator_did.clone())),
+            // Rollback lands on whichever mediator the snapshot held — the CLI
+            // doesn't know which — and drain list/cancel change nothing. Leave
+            // the pin; `--transport rest` remains the escape hatch.
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+/// Write the reconciled hint back to `~/.config/pnm/config.toml`.
+///
+/// Best-effort: the VTA-side change already succeeded, so a config-write
+/// failure is a warning, not an error — but it has to be loud, because the
+/// operator's next command would otherwise dial a mediator that is gone.
+fn apply_mediator_hint(pnm_config: &mut config::PnmConfig, slug: &str, new_hint: Option<String>) {
+    let Some(cfg) = pnm_config.vtas.get_mut(slug) else {
+        return;
+    };
+    cfg.mediator_did = new_hint.clone();
+
+    if let Err(e) = config::save_config(pnm_config) {
+        eprintln!(
+            "\n  Warning: could not update the pinned mediator DID for '{slug}': {e}\n  \
+             Edit `mediator_did` under [vtas.{slug}] in the PNM config by hand, or \
+             later commands will keep using the old mediator."
+        );
+        return;
+    }
+
+    match new_hint {
+        Some(did) => eprintln!("  {DIM}Repointed pinned mediator DID for '{slug}' → {did}{RESET}"),
+        None => eprintln!(
+            "  {DIM}Cleared the pinned mediator DID for '{slug}' (DIDComm is no longer advertised){RESET}"
+        ),
     }
 }
 
@@ -466,6 +535,83 @@ mod tests {
             command: ConfigCommands::Get,
         };
         assert!(requires_auth(&cmd));
+    }
+
+    // ── Pinned mediator hint reconciliation ───────────────────────
+
+    fn vta_config(mediator_did: Option<&str>) -> config::VtaConfig {
+        config::VtaConfig {
+            name: "test".into(),
+            vta_did: Some("did:webvh:scid:vta.example.com".into()),
+            url: None,
+            mediator_did: mediator_did.map(str::to_string),
+        }
+    }
+
+    fn didcomm(command: DidcommCommands) -> Commands {
+        Commands::Services {
+            command: ServicesCommands::Didcomm { command },
+        }
+    }
+
+    #[test]
+    fn disable_clears_a_pinned_mediator_hint() {
+        let cmd = didcomm(DidcommCommands::Disable { drain_ttl: 0 });
+        assert_eq!(
+            pending_mediator_hint(&cmd, &vta_config(Some("did:web:old-mediator"))),
+            Some(None)
+        );
+    }
+
+    #[test]
+    fn update_repoints_a_pinned_mediator_hint() {
+        let cmd = didcomm(DidcommCommands::Update {
+            new_mediator_did: "did:web:new-mediator".into(),
+            drain_ttl: 86_400,
+            force: false,
+            handshake_timeout: None,
+        });
+        assert_eq!(
+            pending_mediator_hint(&cmd, &vta_config(Some("did:web:old-mediator"))),
+            Some(Some("did:web:new-mediator".into()))
+        );
+    }
+
+    /// A VTA that discovers its mediator from the DID doc must not acquire a
+    /// pin as a side effect of an unrelated `services didcomm` command.
+    #[test]
+    fn unpinned_vta_never_gains_a_hint() {
+        let cmd = didcomm(DidcommCommands::Update {
+            new_mediator_did: "did:web:new-mediator".into(),
+            drain_ttl: 86_400,
+            force: false,
+            handshake_timeout: None,
+        });
+        assert_eq!(pending_mediator_hint(&cmd, &vta_config(None)), None);
+    }
+
+    #[test]
+    fn enable_repoints_a_pinned_mediator_hint() {
+        let cmd = didcomm(DidcommCommands::Enable {
+            mediator_did: "did:web:new-mediator".into(),
+            force: false,
+            handshake_timeout: None,
+        });
+        assert_eq!(
+            pending_mediator_hint(&cmd, &vta_config(Some("did:web:old-mediator"))),
+            Some(Some("did:web:new-mediator".into()))
+        );
+    }
+
+    #[test]
+    fn read_only_commands_leave_the_hint_alone() {
+        let cmd = Commands::Services {
+            command: ServicesCommands::List,
+        };
+        assert_eq!(
+            pending_mediator_hint(&cmd, &vta_config(Some("did:web:old-mediator"))),
+            None
+        );
     }
 
     #[test]

--- a/pnm-cli/src/main.rs
+++ b/pnm-cli/src/main.rs
@@ -123,6 +123,7 @@ async fn main() {
     // borrow-vs-move dance against `cli.command`).
     let url_override = cli.url;
     let vta_override = cli.vta;
+    let transport_override = cli.transport;
     let mut command = cli.command;
 
     // ── Pre-auth dispatch ─────────────────────────────────────────
@@ -218,9 +219,20 @@ async fn main() {
     // For did:key VTAs, use the persisted URL as fallback (DID has no service endpoint).
     let effective_url_override = url_override.as_deref().or(vta_config.url.as_deref());
     let mediator_did_hint = vta_config.mediator_did.as_deref();
+    let transport = match transport_override {
+        cli::TransportOpt::Auto => vta_sdk::session::TransportChoice::Auto,
+        cli::TransportOpt::Rest => vta_sdk::session::TransportChoice::Rest,
+    };
 
     let client = if needs_auth {
-        match auth::connect(effective_url_override, mediator_did_hint, &keyring_key).await {
+        match auth::connect(
+            effective_url_override,
+            mediator_did_hint,
+            transport,
+            &keyring_key,
+        )
+        .await
+        {
             Ok(c) => c,
             Err(e) => {
                 vta_cli_common::render::print_cli_error(e.as_ref());

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.19.0"
+version = "0.19.1"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/session.rs
+++ b/vta-sdk/src/session.rs
@@ -1,5 +1,5 @@
 use std::path::PathBuf;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use affinidi_did_resolver_cache_sdk::DIDCacheClient;
 use affinidi_tdk::didcomm::Message;
@@ -633,9 +633,18 @@ impl SessionStore {
     /// Like [`connect`](Self::connect) but with an explicit transport choice.
     ///
     /// [`TransportChoice::Auto`] keeps the priority order documented on
-    /// [`connect`]. [`TransportChoice::Rest`] forces REST — ignoring the
-    /// mediator hint and any advertised DIDComm — resolving `#vta-rest` (or
-    /// `url_override`). The recovery path for an unreachable mediator.
+    /// [`connect`]. Its DIDComm connects are bounded (see
+    /// [`DIDCOMM_CONNECT_TIMEOUT_DEFAULT`]): an unreachable mediator errors out
+    /// pointing at `--transport rest` rather than hanging.
+    ///
+    /// [`TransportChoice::Rest`] forces REST — ignoring the mediator hint and
+    /// any advertised DIDComm — using `url_override`, else the `#vta-rest`
+    /// service on the VTA's DID document. Errors if the VTA advertises neither
+    /// and no `url_override` was given; unlike the auto path it will *not* fall
+    /// back to a URL synthesized from the DID's domain, which for a hosted
+    /// `did:webvh` points at the DID host rather than the VTA.
+    ///
+    /// This is the recovery path for an unreachable mediator.
     pub async fn connect_with_transport(
         &self,
         key: &str,
@@ -654,7 +663,15 @@ impl SessionStore {
         if transport == TransportChoice::Rest {
             let url = match url_override {
                 Some(u) => u.to_string(),
-                None => resolve_vta_url(&session_vta_did).await?,
+                // Deliberately *not* `resolve_vta_url` — that falls back to a
+                // URL synthesized from the DID's own domain, which for a
+                // `did:webvh` is the DID *host*, not the VTA. Authenticating
+                // against the wrong origin fails in a way no operator can
+                // diagnose, so demand a real advertisement or an explicit
+                // `--url`.
+                None => rest_url_from_did_doc(&session_vta_did)
+                    .await
+                    .ok_or_else(|| no_rest_endpoint_error(&session_vta_did))?,
             };
             debug!(url = %url, "connecting via REST (forced --transport rest)");
             let token = self.ensure_authenticated(&url, key).await?;
@@ -666,7 +683,7 @@ impl SessionStore {
         // Priority 1: Explicit mediator DID from config → DIDComm directly
         if let Some(mediator_did) = mediator_did_hint {
             debug!(mediator_did, "connecting via DIDComm (config mediator_did)");
-            let client = crate::client::VtaClient::connect_didcomm(
+            let client = connect_didcomm_bounded(
                 &session.client_did,
                 &session.private_key,
                 &session_vta_did,
@@ -685,7 +702,7 @@ impl SessionStore {
                 rest_url,
             }) => {
                 debug!("connecting via DIDComm");
-                let client = crate::client::VtaClient::connect_didcomm(
+                let client = connect_didcomm_bounded(
                     &session.client_did,
                     &session.private_key,
                     &vta_did,
@@ -721,7 +738,7 @@ impl SessionStore {
             // Priority 3: DIDComm discovery via the authenticated status endpoint.
             if let Some(mediator_did) = discover_mediator_via_status(&rest_client).await {
                 debug!(mediator_did = %mediator_did, "connecting via DIDComm (REST discovery)");
-                let client = crate::client::VtaClient::connect_didcomm(
+                let client = connect_didcomm_bounded(
                     &session.client_did,
                     &session.private_key,
                     &session_vta_did,
@@ -1106,7 +1123,12 @@ pub enum VtaEndpoint {
 
 /// Operator transport selection for
 /// [`SessionStore::connect_with_transport`] (the `pnm`/`cnm` connect path).
+///
+/// `#[non_exhaustive]`: TSP is the workspace's preferred transport
+/// (TSP > DIDComm > REST) and will land here as a variant, as may an
+/// explicit `Didcomm`. Match with a `_` arm.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum TransportChoice {
     /// Prefer DIDComm when advertised, else REST. The default.
     #[default]
@@ -1114,6 +1136,92 @@ pub enum TransportChoice {
     /// Force REST, ignoring any advertised DIDComm. Recovery path when a VTA's
     /// mediator is unreachable (auto would pick DIDComm and hang).
     Rest,
+}
+
+/// How long an auto-selected DIDComm connect may take before we give up and
+/// tell the operator how to reach the VTA over REST instead.
+///
+/// The mediator client owns a reconnect/backoff loop, so a DIDComm connect
+/// against an unreachable mediator does not fail — it retries, and the CLI
+/// hangs with no output. `pnm health` already caps its DIDComm probes for this
+/// reason; the connect path needs the same ceiling, otherwise
+/// [`TransportChoice::Rest`] is a recovery flag nobody ever gets told about.
+///
+/// Override with `VTA_DIDCOMM_CONNECT_TIMEOUT_SECS` for links slower than the
+/// 30s default.
+const DIDCOMM_CONNECT_TIMEOUT_DEFAULT: Duration = Duration::from_secs(30);
+
+fn didcomm_connect_timeout() -> Duration {
+    parse_connect_timeout(std::env::var("VTA_DIDCOMM_CONNECT_TIMEOUT_SECS").ok())
+}
+
+/// Env-var parsing for [`didcomm_connect_timeout`], split out so it is
+/// testable without touching process environment. Garbage and `0` fall back to
+/// the default — a zero deadline would fail every connect instantly, which is
+/// worse than the hang it replaces.
+fn parse_connect_timeout(raw: Option<String>) -> Duration {
+    raw.and_then(|v| v.trim().parse::<u64>().ok())
+        .filter(|secs| *secs > 0)
+        .map(Duration::from_secs)
+        .unwrap_or(DIDCOMM_CONNECT_TIMEOUT_DEFAULT)
+}
+
+/// [`crate::client::VtaClient::connect_didcomm`] under a deadline.
+///
+/// Every auto-transport DIDComm connect goes through here so an unreachable
+/// mediator surfaces as an error naming the recovery flag rather than as an
+/// indefinite hang. See [`DIDCOMM_CONNECT_TIMEOUT_DEFAULT`].
+async fn connect_didcomm_bounded(
+    client_did: &str,
+    private_key: &str,
+    vta_did: &str,
+    mediator_did: &str,
+    rest_url: Option<String>,
+) -> Result<crate::client::VtaClient, Box<dyn std::error::Error>> {
+    let timeout = didcomm_connect_timeout();
+    match tokio::time::timeout(
+        timeout,
+        crate::client::VtaClient::connect_didcomm(
+            client_did,
+            private_key,
+            vta_did,
+            mediator_did,
+            rest_url,
+        ),
+    )
+    .await
+    {
+        Ok(result) => Ok(result?),
+        Err(_) => Err(mediator_unreachable_error(mediator_did, timeout).into()),
+    }
+}
+
+/// The message an operator sees when their VTA's mediator is down.
+///
+/// Names the recovery command verbatim, per the workspace's "operator errors
+/// should suggest the fix" rule.
+fn mediator_unreachable_error(mediator_did: &str, timeout: Duration) -> String {
+    format!(
+        "Timed out after {}s connecting to the VTA's mediator:\n  {mediator_did}\n\n\
+         The VTA advertises DIDComm, but its mediator did not answer. Reach the VTA \
+         over REST instead:\n  \
+         <cli> --transport rest <command>\n\n\
+         If the mediator is gone for good, stop advertising it:\n  \
+         pnm --transport rest services didcomm disable",
+        timeout.as_secs()
+    )
+}
+
+/// The message an operator sees when `--transport rest` has no REST endpoint
+/// to force.
+fn no_rest_endpoint_error(vta_did: &str) -> Box<dyn std::error::Error> {
+    format!(
+        "--transport rest: VTA '{vta_did}' does not advertise a REST service \
+         (`#vta-rest`) in its DID document, so there is no REST endpoint to \
+         force.\n\nPass the VTA's base URL explicitly:\n  \
+         <cli> --transport rest --url https://vta.example.com <command>"
+    )
+    .into()
 }
 
 /// Resolve a VTA DID to discover available transport endpoints.
@@ -1202,6 +1310,39 @@ async fn discover_mediator_via_status(client: &crate::client::VtaClient) -> Opti
     }
 }
 
+/// The `#vta-rest` service endpoint from the VTA's DID document, if it
+/// advertises one. `None` covers both "resolution failed" and "no REST service"
+/// — neither yields a REST URL we can stand behind.
+///
+/// Strict counterpart of [`resolve_vta_url`], which additionally guesses a URL
+/// from the DID's own domain. That guess is right for a self-hosted `did:web`
+/// VTA and wrong for a `did:webvh` whose DID lives on a hosting server, so the
+/// force-REST path uses this instead.
+async fn rest_url_from_did_doc(vta_did: &str) -> Option<String> {
+    let did_resolver = DIDCacheClient::new(crate::resolver::build_did_cache_config_from_env())
+        .await
+        .inspect_err(|e| debug!(error = %e, "DID resolver init failed"))
+        .ok()?;
+
+    let resolved = did_resolver
+        .resolve(vta_did)
+        .await
+        .inspect_err(|e| debug!(error = %e, "DID resolution failed"))
+        .ok()?;
+
+    let url = resolved
+        .doc
+        .find_service("vta-rest")?
+        .service_endpoint
+        .get_uri()?
+        .trim_matches('"')
+        .trim_end_matches('/')
+        .to_string();
+
+    debug!(url = %url, "found VTA URL from #vta-rest service endpoint");
+    Some(url)
+}
+
 /// Resolve a VTA DID to discover its service URL.
 ///
 /// Resolves the DID document and looks for the `#vta-rest` service endpoint.
@@ -1209,25 +1350,10 @@ async fn discover_mediator_via_status(client: &crate::client::VtaClient) -> Opti
 pub async fn resolve_vta_url(vta_did: &str) -> Result<String, Box<dyn std::error::Error>> {
     debug!(vta_did, "resolving VTA DID to discover service URL");
 
-    let did_resolver = DIDCacheClient::new(crate::resolver::build_did_cache_config_from_env())
-        .await
-        .map_err(|e| format!("DID resolver init failed: {e}"))?;
-
-    match did_resolver.resolve(vta_did).await {
-        Ok(resolved) => {
-            if let Some(svc) = resolved.doc.find_service("vta-rest")
-                && let Some(url) = svc.service_endpoint.get_uri()
-            {
-                let url = url.trim_matches('"').trim_end_matches('/').to_string();
-                debug!(url = %url, "found VTA URL from #vta-rest service endpoint");
-                return Ok(url);
-            }
-            debug!("no #vta-rest service found in DID document, falling back to DID parsing");
-        }
-        Err(e) => {
-            debug!(error = %e, "DID resolution failed, falling back to DID parsing");
-        }
+    if let Some(url) = rest_url_from_did_doc(vta_did).await {
+        return Ok(url);
     }
+    debug!("no #vta-rest service resolved, falling back to DID parsing");
 
     // Fallback: parse domain from did:web or did:webvh DID strings
     url_from_did(vta_did)
@@ -1827,5 +1953,54 @@ mod tests {
         };
         let err = require_vta_did(&pending).unwrap_err();
         assert!(err.to_string().contains("pnm setup continue"));
+    }
+
+    // ── Transport selection ───────────────────────────────────────
+
+    #[test]
+    fn transport_choice_defaults_to_auto() {
+        assert_eq!(TransportChoice::default(), TransportChoice::Auto);
+    }
+
+    #[test]
+    fn connect_timeout_defaults_when_unset_or_junk() {
+        assert_eq!(parse_connect_timeout(None), DIDCOMM_CONNECT_TIMEOUT_DEFAULT);
+        assert_eq!(
+            parse_connect_timeout(Some("not-a-number".into())),
+            DIDCOMM_CONNECT_TIMEOUT_DEFAULT
+        );
+        // Zero would fail every connect instantly — worse than the hang.
+        assert_eq!(
+            parse_connect_timeout(Some("0".into())),
+            DIDCOMM_CONNECT_TIMEOUT_DEFAULT
+        );
+    }
+
+    #[test]
+    fn connect_timeout_honours_env_override() {
+        assert_eq!(
+            parse_connect_timeout(Some(" 90 ".into())),
+            Duration::from_secs(90)
+        );
+    }
+
+    /// The whole point of bounding the connect is that the operator learns the
+    /// recovery flag exists. If this message stops naming it, the timeout is
+    /// just a faster dead end.
+    #[test]
+    fn mediator_timeout_error_names_the_recovery_flag() {
+        let msg =
+            mediator_unreachable_error("did:web:mediator.example.com", Duration::from_secs(30));
+        assert!(msg.contains("--transport rest"));
+        assert!(msg.contains("services didcomm disable"));
+        assert!(msg.contains("did:web:mediator.example.com"));
+        assert!(msg.contains("30s"));
+    }
+
+    #[test]
+    fn no_rest_endpoint_error_tells_operator_to_pass_url() {
+        let msg = no_rest_endpoint_error("did:webvh:scid:host.example.com").to_string();
+        assert!(msg.contains("--url"));
+        assert!(msg.contains("did:webvh:scid:host.example.com"));
     }
 }

--- a/vta-sdk/src/session.rs
+++ b/vta-sdk/src/session.rs
@@ -616,18 +616,52 @@ impl SessionStore {
     /// Note `url_override` is a *fallback hint*, not a force-REST switch: a VTA
     /// DID that resolves to a DIDComm endpoint (priority 2) still uses DIDComm
     /// even when `--url` is supplied. The override only takes effect when DID
-    /// resolution yields nothing usable (e.g. `did:key`).
+    /// resolution yields nothing usable (e.g. `did:key`). To force REST
+    /// regardless of what the DID document advertises, use
+    /// [`connect_with_transport`](Self::connect_with_transport) with
+    /// [`TransportChoice::Rest`].
     pub async fn connect(
         &self,
         key: &str,
         url_override: Option<&str>,
         mediator_did_hint: Option<&str>,
     ) -> Result<crate::client::VtaClient, Box<dyn std::error::Error>> {
+        self.connect_with_transport(key, url_override, mediator_did_hint, TransportChoice::Auto)
+            .await
+    }
+
+    /// Like [`connect`](Self::connect) but with an explicit transport choice.
+    ///
+    /// [`TransportChoice::Auto`] keeps the priority order documented on
+    /// [`connect`]. [`TransportChoice::Rest`] forces REST — ignoring the
+    /// mediator hint and any advertised DIDComm — resolving `#vta-rest` (or
+    /// `url_override`). The recovery path for an unreachable mediator.
+    pub async fn connect_with_transport(
+        &self,
+        key: &str,
+        url_override: Option<&str>,
+        mediator_did_hint: Option<&str>,
+        transport: TransportChoice,
+    ) -> Result<crate::client::VtaClient, Box<dyn std::error::Error>> {
         let session = self.load_session(key).ok_or(
             "Not authenticated.\n\nTo authenticate, import a credential:\n  <cli> auth login <credential-string>",
         )?;
 
         let session_vta_did = require_vta_did(&session)?.to_string();
+
+        // Forced REST: skip DIDComm (priorities 1 & 2). Resolve the REST
+        // endpoint (`--url`, else the DID doc's `#vta-rest`) and auth over HTTP.
+        if transport == TransportChoice::Rest {
+            let url = match url_override {
+                Some(u) => u.to_string(),
+                None => resolve_vta_url(&session_vta_did).await?,
+            };
+            debug!(url = %url, "connecting via REST (forced --transport rest)");
+            let token = self.ensure_authenticated(&url, key).await?;
+            let client = crate::client::VtaClient::new(&url);
+            client.set_token(token);
+            return Ok(client);
+        }
 
         // Priority 1: Explicit mediator DID from config → DIDComm directly
         if let Some(mediator_did) = mediator_did_hint {
@@ -1068,6 +1102,18 @@ pub enum VtaEndpoint {
         mediator_did: String,
         rest_url: Option<String>,
     },
+}
+
+/// Operator transport selection for
+/// [`SessionStore::connect_with_transport`] (the `pnm`/`cnm` connect path).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum TransportChoice {
+    /// Prefer DIDComm when advertised, else REST. The default.
+    #[default]
+    Auto,
+    /// Force REST, ignoring any advertised DIDComm. Recovery path when a VTA's
+    /// mediator is unreachable (auto would pick DIDComm and hang).
+    Rest,
 }
 
 /// Resolve a VTA DID to discover available transport endpoints.


### PR DESCRIPTION
When a VTA advertises DIDComm but its mediator is unreachable, pnm's auto transport selection always picks DIDComm with no REST fallback, locking the operator out (services list / disable / enable all hang). Add a global --transport <auto|rest> flag that forces REST, skipping DIDComm even when it is advertised — e.g. `pnm --transport rest services didcomm disable` recovers a VTA that force-enabled DIDComm against a mediator it can't reach.

- vta-sdk (0.19.1): SessionStore::connect_with_transport + TransportChoice { Auto, Rest }; connect() is unchanged and delegates with Auto.
- pnm-cli (0.10.7): global --transport flag threaded into connect.