### PR TITLE
feat(vta-service): dry-run a webvh update to compute its real effects

### DIFF
--- a/vta-service/src/keys/paths.rs
+++ b/vta-service/src/keys/paths.rs
@@ -23,6 +23,33 @@ pub async fn allocate_path(keys_ks: &KeyspaceHandle, base: &str) -> Result<Strin
     Ok(path)
 }
 
+/// Read a group's path counter **without** allocating.
+///
+/// Pair with [`peek_paths`] to predict what a subsequent allocation would
+/// derive, and pin this value so the prediction can be re-checked at the point
+/// of use — a peek reserves nothing, so an allocation elsewhere in the same
+/// group moves it.
+pub async fn peek_path_counter(keys_ks: &KeyspaceHandle, base: &str) -> Result<u32, AppError> {
+    counter::peek_u32(keys_ks, &format!("path_counter:{base}")).await
+}
+
+/// The next `count` derivation paths [`allocate_path`] *would* hand out, without
+/// consuming any of them.
+///
+/// This is what makes a read-only dry-run of a key-rotating operation possible.
+/// Deriving via `allocate_path` in order to *show* someone which key would be
+/// used both burns an index and defeats the purpose: the subsequent real run
+/// allocates the *next* index and derives a **different** key than the one that
+/// was shown.
+pub async fn peek_paths(
+    keys_ks: &KeyspaceHandle,
+    base: &str,
+    count: u32,
+) -> Result<Vec<String>, AppError> {
+    let next = peek_path_counter(keys_ks, base).await?;
+    Ok((0..count).map(|i| path_at(base, next + i)).collect())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/vta-service/src/operations/did_webvh/mod.rs
+++ b/vta-service/src/operations/did_webvh/mod.rs
@@ -36,7 +36,8 @@ pub use servers::{
 };
 pub use update::{
     RotateDidWebvhKeysOptions, UpdateDidWebvhError, UpdateDidWebvhOptions, UpdateDidWebvhResult,
-    rotate_did_webvh_keys, state_from_jsonl_pub, update_did_webvh,
+    UpdatePlan, plan_did_webvh_update, rotate_did_webvh_keys, state_from_jsonl_pub,
+    update_did_webvh,
 };
 
 use std::sync::Arc;

--- a/vta-service/src/operations/did_webvh/update/keys.rs
+++ b/vta-service/src/operations/did_webvh/update/keys.rs
@@ -16,16 +16,20 @@ use ed25519_dalek_bip32::{DerivationPath, ExtendedSigningKey};
 use super::errors::UpdateDidWebvhError;
 use super::legacy::{legacy_lookup_by_public_key, legacy_lookup_pre_rotation_by_hash};
 use super::options::DerivedWebvhKey;
-use crate::keys::paths::allocate_path;
+use crate::keys::paths::{allocate_path, peek_paths};
 use crate::keys::seed_store::SeedStore;
 use crate::keys::seeds::{get_active_seed_id, load_seed_bytes};
 use crate::operations::did_webvh::webvh_keys::{self, WebvhKeyHandle, WebvhKeyRole};
 use crate::store::KeyspaceHandle;
 
 /// Derive `count` Ed25519 keys via BIP-32 under `base_path`. Pure —
-/// no keyspace writes. Pair with [`install_derived_webvh_keys`] to
-/// persist once the consuming `update_did` call has produced the
-/// new log entry's `version_id`.
+/// **allocates** `count` derivation paths, consuming them from the group's
+/// counter. Pair with [`install_derived_webvh_keys`] to persist once the
+/// consuming `update_did` call has produced the new log entry's `version_id`.
+///
+/// For a read-only prediction of what this *would* derive, use
+/// [`peek_webvh_keys`] — it shares the derivation below, so the two cannot
+/// disagree about the key at a given path.
 pub(in crate::operations::did_webvh) async fn derive_webvh_keys(
     keys_ks: &KeyspaceHandle,
     seed_store: &dyn SeedStore,
@@ -35,7 +39,52 @@ pub(in crate::operations::did_webvh) async fn derive_webvh_keys(
     if count == 0 {
         return Ok(vec![]);
     }
+    let mut paths = Vec::with_capacity(count as usize);
+    for _ in 0..count {
+        paths.push(
+            allocate_path(keys_ks, base_path)
+                .await
+                .map_err(|e| UpdateDidWebvhError::Persistence(format!("allocate_path: {e}")))?,
+        );
+    }
+    derive_webvh_keys_at(keys_ks, seed_store, &paths).await
+}
 
+/// Predict the keys [`derive_webvh_keys`] would produce, **without** allocating.
+/// Genuinely pure: no keyspace writes.
+///
+/// This is what lets a caller show someone which key a rotation will install
+/// before committing to it. Deriving via [`derive_webvh_keys`] to do that would
+/// be self-defeating — it consumes the path, so the subsequent real run
+/// allocates the *next* one and installs a **different** key than the one that
+/// was shown, while every signature over it still verifies.
+///
+/// A peek reserves nothing. A caller whose correctness depends on the prediction
+/// holding must pin the counter ([`crate::keys::paths::peek_path_counter`]) and
+/// re-check it before committing.
+pub(in crate::operations::did_webvh) async fn peek_webvh_keys(
+    keys_ks: &KeyspaceHandle,
+    seed_store: &dyn SeedStore,
+    base_path: &str,
+    count: u32,
+) -> Result<Vec<DerivedWebvhKey>, UpdateDidWebvhError> {
+    if count == 0 {
+        return Ok(vec![]);
+    }
+    let paths = peek_paths(keys_ks, base_path, count)
+        .await
+        .map_err(|e| UpdateDidWebvhError::Persistence(format!("peek_paths: {e}")))?;
+    derive_webvh_keys_at(keys_ks, seed_store, &paths).await
+}
+
+/// The derivation itself: seed → BIP-32 root → one key per path. Shared by the
+/// allocating and peeking entry points above so a prediction and the run it
+/// predicts cannot drift apart. Pure with respect to the keyspace.
+async fn derive_webvh_keys_at(
+    keys_ks: &KeyspaceHandle,
+    seed_store: &dyn SeedStore,
+    paths: &[String],
+) -> Result<Vec<DerivedWebvhKey>, UpdateDidWebvhError> {
     let seed_id = get_active_seed_id(keys_ks).await.map_err(|e| {
         UpdateDidWebvhError::Persistence(format!("could not load active seed id: {e}"))
     })?;
@@ -46,11 +95,8 @@ pub(in crate::operations::did_webvh) async fn derive_webvh_keys(
     let root = ExtendedSigningKey::from_seed(&seed)
         .map_err(|e| UpdateDidWebvhError::Persistence(format!("BIP-32 root derivation: {e}")))?;
 
-    let mut derived = Vec::with_capacity(count as usize);
-    for _ in 0..count {
-        let path = allocate_path(keys_ks, base_path)
-            .await
-            .map_err(|e| UpdateDidWebvhError::Persistence(format!("allocate_path: {e}")))?;
+    let mut derived = Vec::with_capacity(paths.len());
+    for path in paths {
         let parsed: DerivationPath = path.parse().map_err(|e| {
             UpdateDidWebvhError::Persistence(format!("parse derivation path `{path}`: {e}"))
         })?;
@@ -67,7 +113,7 @@ pub(in crate::operations::did_webvh) async fn derive_webvh_keys(
         derived.push(DerivedWebvhKey {
             public_key,
             hash,
-            derivation_path: path,
+            derivation_path: path.clone(),
             seed_id,
         });
     }

--- a/vta-service/src/operations/did_webvh/update/mod.rs
+++ b/vta-service/src/operations/did_webvh/update/mod.rs
@@ -36,13 +36,15 @@ mod keys;
 mod legacy;
 mod options;
 mod orchestrator;
+mod plan;
 mod rotate;
 mod state;
 mod validate;
 
 pub use errors::UpdateDidWebvhError;
 pub use options::{RotateDidWebvhKeysOptions, UpdateDidWebvhOptions, UpdateDidWebvhResult};
-pub use orchestrator::update_did_webvh;
+pub use orchestrator::{plan_did_webvh_update, update_did_webvh};
+pub use plan::UpdatePlan;
 pub use rotate::rotate_did_webvh_keys;
 
 /// Cross-module accessor for `state_from_jsonl`. `passkey_vms` uses
@@ -583,7 +585,8 @@ mod pre_rotation_e2e_tests {
 
     use super::state::state_from_jsonl;
     use super::{
-        RotateDidWebvhKeysOptions, UpdateDidWebvhOptions, rotate_did_webvh_keys, update_did_webvh,
+        RotateDidWebvhKeysOptions, UpdateDidWebvhOptions, plan_did_webvh_update,
+        rotate_did_webvh_keys, update_did_webvh,
     };
     use crate::auth::AuthClaims;
     use crate::config::AppConfig;
@@ -1710,5 +1713,359 @@ mod pre_rotation_e2e_tests {
         let svc = current_didcomm_service(&final_doc)
             .expect("DIDCommMessaging service advertised after enable");
         assert_eq!(svc.mediator_did, mediator_did);
+    }
+
+    // ── plan/apply: what the plan reports must be what the execution does ────
+    //
+    // If a plan predicts one key and the real run installs another, a human
+    // approved a rotation that never happened — and every signature over that
+    // approval still verifies, so nothing downstream can tell. That is not
+    // hypothetical: `derive_webvh_keys` allocates from a BIP-32 path counter, so
+    // a plan that derived keys the way the real run does would consume an index,
+    // and the real run would then allocate the *next* one and install a
+    // different key than the one shown. Hence `peek_webvh_keys`, and hence these
+    // tests.
+
+    /// A plan must not move any state it reads — no burned derivation path, no
+    /// appended log entry — and must therefore be repeatable.
+    #[tokio::test]
+    async fn planning_is_read_only_and_repeatable() {
+        let (ts, seed_store) = setup("ctx-plan-ro").await;
+        let cfg = ts_app_config(&ts);
+        let auth = admin_auth();
+        let resolver = build_resolver().await;
+        let bridge = dummy_bridge();
+        let auth_locks = crate::operations::did_webvh::WebvhAuthLocks::new();
+        let deps = webvh_deps(&ts, &seed_store, &resolver, &bridge, &auth_locks);
+
+        let (did, scid) = create_did(
+            &ts,
+            &seed_store,
+            &cfg,
+            &auth,
+            &resolver,
+            &bridge,
+            "ctx-plan-ro",
+            0,
+        )
+        .await;
+        sleep(VERSION_TIME_GAP).await;
+
+        let base_path = crate::contexts::get_context(&ts.contexts_ks, "ctx-plan-ro")
+            .await
+            .expect("get_context")
+            .expect("context")
+            .base_path;
+        let opts = || UpdateDidWebvhOptions {
+            document: Some(doc_patch(&did, "planned")),
+            ..Default::default()
+        };
+
+        let counter_before = crate::keys::paths::peek_path_counter(&ts.keys_ks, &base_path)
+            .await
+            .expect("peek");
+        let log_before = crate::webvh_store::get_did_log(&ts.webvh_ks, &did)
+            .await
+            .expect("log");
+
+        let first = plan_did_webvh_update(&deps, &auth, &scid, opts())
+            .await
+            .expect("plan");
+
+        assert_eq!(
+            counter_before,
+            crate::keys::paths::peek_path_counter(&ts.keys_ks, &base_path)
+                .await
+                .expect("peek"),
+            "planning must not consume a derivation path"
+        );
+        assert_eq!(
+            log_before,
+            crate::webvh_store::get_did_log(&ts.webvh_ks, &did)
+                .await
+                .expect("log"),
+            "planning must not append a log entry"
+        );
+
+        let second = plan_did_webvh_update(&deps, &auth, &scid, opts())
+            .await
+            .expect("re-plan");
+        assert_eq!(
+            first.new_update_keys, second.new_update_keys,
+            "re-planning the same update must predict the same keys, not slide \
+             down the counter"
+        );
+    }
+
+    /// The one that matters. Plan an update, execute it, and assert the update
+    /// keys the chain actually committed are the ones the plan showed.
+    #[tokio::test]
+    async fn plan_predicts_the_update_key_that_execution_installs() {
+        let (ts, seed_store) = setup("ctx-plan-keys").await;
+        let cfg = ts_app_config(&ts);
+        let auth = admin_auth();
+        let resolver = build_resolver().await;
+        let bridge = dummy_bridge();
+        let auth_locks = crate::operations::did_webvh::WebvhAuthLocks::new();
+        let deps = webvh_deps(&ts, &seed_store, &resolver, &bridge, &auth_locks);
+
+        let (did, scid) = create_did(
+            &ts,
+            &seed_store,
+            &cfg,
+            &auth,
+            &resolver,
+            &bridge,
+            "ctx-plan-keys",
+            0,
+        )
+        .await;
+        sleep(VERSION_TIME_GAP).await;
+
+        let opts = || UpdateDidWebvhOptions {
+            document: Some(doc_patch(&did, "v2")),
+            ..Default::default()
+        };
+
+        let plan = plan_did_webvh_update(&deps, &auth, &scid, opts())
+            .await
+            .expect("plan");
+        assert!(
+            plan.rotates_update_keys(),
+            "a document change rotates the update key — the effect the payload \
+             never mentions and the plan exists to surface"
+        );
+
+        update_did_webvh(&deps, &auth, &scid, opts(), None, "test")
+            .await
+            .expect("execute");
+
+        let (installed_keys, _) = committed_params(&ts, &did).await;
+        assert_eq!(
+            plan.new_update_keys, installed_keys,
+            "the update key the plan showed the approver MUST be the key the \
+             execution installed — otherwise the approval authorized a rotation \
+             that never happened"
+        );
+    }
+
+    /// Same property, under pre-rotation — where the freshly-derived keys land
+    /// in `next_key_hashes` rather than `update_keys` (the new update key is the
+    /// one *revealed* from the previous entry's commitment). This is the case
+    /// that actually exercises a multi-key peek against a multi-key allocation:
+    /// a planner reading the counter without care would predict the wrong
+    /// commitments here and nothing else in the system would notice.
+    #[tokio::test]
+    async fn plan_predicts_the_pre_rotation_commitments_execution_publishes() {
+        let (ts, seed_store) = setup("ctx-plan-pre").await;
+        let cfg = ts_app_config(&ts);
+        let auth = admin_auth();
+        let resolver = build_resolver().await;
+        let bridge = dummy_bridge();
+        let auth_locks = crate::operations::did_webvh::WebvhAuthLocks::new();
+        let deps = webvh_deps(&ts, &seed_store, &resolver, &bridge, &auth_locks);
+
+        let (did, scid) = create_did(
+            &ts,
+            &seed_store,
+            &cfg,
+            &auth,
+            &resolver,
+            &bridge,
+            "ctx-plan-pre",
+            2,
+        )
+        .await;
+        sleep(VERSION_TIME_GAP).await;
+
+        let opts = || UpdateDidWebvhOptions {
+            document: Some(doc_patch(&did, "pre")),
+            ..Default::default()
+        };
+
+        let plan = plan_did_webvh_update(&deps, &auth, &scid, opts())
+            .await
+            .expect("plan");
+        assert_eq!(
+            plan.new_next_key_hashes.len(),
+            2,
+            "expected two fresh pre-rotation commitments"
+        );
+
+        update_did_webvh(&deps, &auth, &scid, opts(), None, "test")
+            .await
+            .expect("execute");
+
+        let (installed_keys, installed_hashes) = committed_params(&ts, &did).await;
+        assert_eq!(
+            plan.new_next_key_hashes, installed_hashes,
+            "the pre-rotation commitments the plan predicted MUST be the ones the \
+             execution published — they authorize the next rotation, so a wrong \
+             prediction means the approver saw a different future than the one \
+             that now exists"
+        );
+        assert_eq!(
+            plan.new_update_keys, installed_keys,
+            "and the revealed update key must match too"
+        );
+    }
+
+    /// The plan's effects must name the key rotation, not just the document edit.
+    /// A surface rendering only the payload diff would show the verification
+    /// method and hide the fact that the DID's controlling key is changing.
+    #[tokio::test]
+    async fn effects_surface_the_rotation_hidden_in_the_payload() {
+        let (ts, seed_store) = setup("ctx-plan-fx").await;
+        let cfg = ts_app_config(&ts);
+        let auth = admin_auth();
+        let resolver = build_resolver().await;
+        let bridge = dummy_bridge();
+        let auth_locks = crate::operations::did_webvh::WebvhAuthLocks::new();
+        let deps = webvh_deps(&ts, &seed_store, &resolver, &bridge, &auth_locks);
+
+        let (did, scid) = create_did(
+            &ts,
+            &seed_store,
+            &cfg,
+            &auth,
+            &resolver,
+            &bridge,
+            "ctx-plan-fx",
+            2,
+        )
+        .await;
+        sleep(VERSION_TIME_GAP).await;
+
+        let plan = plan_did_webvh_update(
+            &deps,
+            &auth,
+            &scid,
+            UpdateDidWebvhOptions {
+                document: Some(doc_patch(&did, "fx")),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("plan");
+
+        let effects = plan.to_effects();
+        let kinds: Vec<&str> = effects.iter().map(|e| e.kind.as_str()).collect();
+        assert!(
+            kinds.contains(&"documentChange"),
+            "expected the document edit: {kinds:?}"
+        );
+        assert!(
+            kinds.contains(&"keyRotation"),
+            "the rotation is invisible in the payload — the plan must surface it: {kinds:?}"
+        );
+        assert!(
+            kinds.contains(&"preRotationRefresh"),
+            "expected the pre-rotation commitments: {kinds:?}"
+        );
+
+        let rotation = effects
+            .iter()
+            .find(|e| e.kind == "keyRotation")
+            .expect("rotation effect");
+        assert_eq!(
+            rotation.before,
+            Some(serde_json::json!(plan.prior_update_keys))
+        );
+        assert_eq!(
+            rotation.after,
+            Some(serde_json::json!(plan.new_update_keys))
+        );
+        assert_ne!(
+            rotation.before, rotation.after,
+            "a rotation whose before equals its after is not a rotation"
+        );
+
+        // `summary` is the only member a consent surface is guaranteed able to
+        // render, so an effect without one is an effect that can go unseen.
+        for e in &effects {
+            assert!(!e.summary.is_empty(), "effect `{}` has no summary", e.kind);
+        }
+
+        assert_eq!(plan.state_pin().resource, did);
+        assert_eq!(plan.state_pin().version, plan.prior_version_id);
+    }
+
+    /// An update that changes no document, on a DID with no pre-rotation,
+    /// rotates no key — so the plan must not claim it does.
+    #[tokio::test]
+    async fn no_document_change_means_no_rotation() {
+        let (ts, seed_store) = setup("ctx-plan-noop").await;
+        let cfg = ts_app_config(&ts);
+        let auth = admin_auth();
+        let resolver = build_resolver().await;
+        let bridge = dummy_bridge();
+        let auth_locks = crate::operations::did_webvh::WebvhAuthLocks::new();
+        let deps = webvh_deps(&ts, &seed_store, &resolver, &bridge, &auth_locks);
+
+        let (_did, scid) = create_did(
+            &ts,
+            &seed_store,
+            &cfg,
+            &auth,
+            &resolver,
+            &bridge,
+            "ctx-plan-noop",
+            0,
+        )
+        .await;
+        sleep(VERSION_TIME_GAP).await;
+
+        let plan = plan_did_webvh_update(
+            &deps,
+            &auth,
+            &scid,
+            UpdateDidWebvhOptions {
+                ttl: Some(600),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("plan");
+
+        assert!(
+            !plan.rotates_update_keys(),
+            "a metadata-only update with no pre-rotation must not rotate the update key"
+        );
+        assert!(
+            !plan.to_effects().iter().any(|e| e.kind == "keyRotation"),
+            "no rotation effect when nothing rotates"
+        );
+    }
+
+    /// Read back the update keys and pre-rotation commitments actually in force
+    /// after the last entry.
+    ///
+    /// webvh parameters are a *delta* — an entry that does not restate
+    /// `update_keys` leaves the previous entry's standing. So "what is in force"
+    /// is the last entry that restated them, walking backwards, not whatever the
+    /// final entry happens to carry.
+    async fn committed_params(ts: &TestStore, did: &str) -> (Vec<String>, Vec<String>) {
+        let log = crate::webvh_store::get_did_log(&ts.webvh_ks, did)
+            .await
+            .expect("get_did_log")
+            .expect("log present");
+        let state = state_from_jsonl(&log).expect("chain validates");
+
+        let mut keys: Vec<String> = vec![];
+        let mut hashes: Vec<String> = vec![];
+        for entry in state.log_entries() {
+            // The entry's *own* parameters, not `validated_parameters` — the
+            // latter records the delta as resolved during validation and reads
+            // `None` on an entry that restated a value, which is the opposite of
+            // what "in force" means here.
+            let p = didwebvh_rs::log_entry::LogEntryMethods::get_parameters(&entry.log_entry);
+            if let Some(arc) = p.update_keys.as_ref() {
+                keys = arc.iter().map(|k| k.as_ref().to_string()).collect();
+            }
+            if let Some(arc) = p.next_key_hashes.as_ref() {
+                hashes = arc.iter().map(|h| h.as_ref().to_string()).collect();
+            }
+        }
+        (keys, hashes)
     }
 }

--- a/vta-service/src/operations/did_webvh/update/options.rs
+++ b/vta-service/src/operations/did_webvh/update/options.rs
@@ -87,6 +87,7 @@ pub struct UpdateDidWebvhOptions {
 /// re-derivable from `(seed_id, derivation_path)`, so the caller gets
 /// what it needs to persist the handle without holding key material
 /// across the async boundary.
+#[derive(Clone)]
 pub(in crate::operations::did_webvh) struct DerivedWebvhKey {
     pub public_key: String,
     pub hash: String,

--- a/vta-service/src/operations/did_webvh/update/orchestrator.rs
+++ b/vta-service/src/operations/did_webvh/update/orchestrator.rs
@@ -14,28 +14,53 @@ use didwebvh_rs::update::{UpdateDIDConfig, update_did};
 use super::errors::UpdateDidWebvhError;
 use super::keys::{
     derive_secret_for_handle, derive_webvh_keys, install_derived_webvh_keys,
-    load_active_update_key, load_pre_rotation_signing_key,
+    load_active_update_key, load_pre_rotation_signing_key, peek_webvh_keys,
 };
 use super::options::{UpdateDidWebvhOptions, UpdateDidWebvhResult};
+use super::plan::UpdatePlan;
 use super::state::{find_record_by_scid, state_from_jsonl, state_to_jsonl};
 use super::validate::{validate_document_for_update, validate_watchers, validate_witnesses};
 use crate::audit;
 use crate::auth::AuthClaims;
+use crate::keys::paths::peek_path_counter;
 use crate::operations::did_webvh::concurrency::RecordSnapshot;
 use crate::operations::did_webvh::webvh_keys::{self, WebvhKeyHandle, WebvhKeyRole};
 use crate::webvh_store;
 
+/// Plan an update without performing it: run the real path up to — and not
+/// through — its first write, and report what it *would* do.
+///
+/// This exists so a human can be shown the consequences of an update before
+/// authorizing it. It must be the same code as the update itself: a separate
+/// implementation that described the update would drift, and a drifted
+/// description is worse than none, because it misinforms with a straight face.
+///
+/// Read-only. In particular the key derivation *peeks* the BIP-32 path counter
+/// rather than allocating from it — allocating here would both burn an index
+/// and, far worse, cause the subsequent real run to derive a **different** key
+/// than the one reported, which is exactly the deception the plan exists to
+/// prevent. Because a peek reserves nothing, the plan carries
+/// [`UpdatePlan::path_counter_pin`], and a caller that acts on the plan must
+/// re-check it.
+pub async fn plan_did_webvh_update(
+    deps: &super::super::WebvhDeps<'_>,
+    auth: &AuthClaims,
+    scid: &str,
+    opts: UpdateDidWebvhOptions,
+) -> Result<UpdatePlan, UpdateDidWebvhError> {
+    match run_update(deps, auth, scid, opts, None, "plan", Mode::Plan).await? {
+        Outcome::Planned(plan) => Ok(plan),
+        Outcome::Executed(_) => Err(UpdateDidWebvhError::Library(
+            "plan mode committed an update".into(),
+        )),
+    }
+}
+
 /// Drive a webvh DID update end-to-end. See module docs.
 ///
-/// New parameters compared with the pre-PR-113 signature:
-/// - `imported_ks` — needed by the daemon-REST auth flow (step 13)
-///   to load the VTA's signing key via `get_key_secret_internal`.
-/// - `vta_did` — the running VTA's DID (read from `AppConfig::
-///   vta_did` at the call site). `None` means "no VTA identity
-///   configured" — server-managed DID publishes will fail loudly
-///   with `Publish("…")` rather than silently 401.
-/// - `auth_locks` — per-server async mutex for serialising
-///   auth-cache reads. Lives on `AppState`.
+/// - `vta_did` — the running VTA's DID (read from `AppConfig::vta_did` at the
+///   call site). `None` means "no VTA identity configured" — server-managed DID
+///   publishes fail loudly with `Publish("…")` rather than silently 401.
 pub async fn update_did_webvh(
     deps: &super::super::WebvhDeps<'_>,
     auth: &AuthClaims,
@@ -44,6 +69,35 @@ pub async fn update_did_webvh(
     vta_did: Option<&str>,
     channel: &str,
 ) -> Result<UpdateDidWebvhResult, UpdateDidWebvhError> {
+    match run_update(deps, auth, scid, opts, vta_did, channel, Mode::Execute).await? {
+        Outcome::Executed(result) => Ok(result),
+        Outcome::Planned(_) => Err(UpdateDidWebvhError::Library(
+            "execute mode returned a plan".into(),
+        )),
+    }
+}
+
+/// Whether [`run_update`] stops at the last read or goes on to commit.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Mode {
+    Plan,
+    Execute,
+}
+
+enum Outcome {
+    Planned(UpdatePlan),
+    Executed(UpdateDidWebvhResult),
+}
+
+async fn run_update(
+    deps: &super::super::WebvhDeps<'_>,
+    auth: &AuthClaims,
+    scid: &str,
+    opts: UpdateDidWebvhOptions,
+    vta_did: Option<&str>,
+    channel: &str,
+    mode: Mode,
+) -> Result<Outcome, UpdateDidWebvhError> {
     // Re-bind the bundled deps to the historical local names so the (large) body
     // below is unchanged. All fields are `Copy` references — this copies the
     // borrows out of `*deps`; `deps` itself stays usable (the publish step below
@@ -133,6 +187,11 @@ pub async fn update_did_webvh(
         .as_ref()
         .map(|arc| (**arc).clone())
         .unwrap_or_default();
+    // Owned snapshot of the prior state. Taken here because `state` is moved
+    // into the update config below, which ends `last_state`'s borrow — and a
+    // plan needs the before-picture after that point.
+    let prior_version_id = last_state.get_version_id().to_string();
+    let prior_document = last_state.log_entry.get_state().clone();
     // Pre-rotation is "active" when the previous entry committed
     // `next_key_hashes`. The library's `check_signing_key` consults
     // `previous.next_key_hashes` (not `previous.update_keys`) for the
@@ -164,13 +223,47 @@ pub async fn update_did_webvh(
     //    With pre-rotation active, the "auth" key for the new entry is
     //    the *revealed* pre-rotation candidate from the previous entry,
     //    not a freshly-minted key. We pick that handle in step 8 below.
-    let derived_auth = if new_doc.is_some() && !pre_rotation_active {
-        derive_webvh_keys(keys_ks, seed_store, &context.base_path, 1).await?
-    } else {
-        vec![]
+    //
+    //    In Plan mode we *peek* the derivation-path counter instead of
+    //    allocating from it. Allocating would make the plan a mutation —
+    //    and would mean the real run derived a different key than the one
+    //    the plan reported, since it would allocate the *next* index. The
+    //    peeked counter is pinned into the plan so the caller can detect a
+    //    concurrent allocation before acting on it.
+    let path_counter_pin = peek_path_counter(keys_ks, &context.base_path)
+        .await
+        .map_err(|e| UpdateDidWebvhError::Persistence(format!("peek_path_counter: {e}")))?;
+    let auth_count: u32 = u32::from(new_doc.is_some() && !pre_rotation_active);
+    let (derived_auth, derived_pre_rotation) = match mode {
+        // Execute allocates, advancing the counter between the two calls: the
+        // auth key takes index n, the pre-rotation keys take n+1, n+2, …
+        Mode::Execute => {
+            let auth = if auth_count > 0 {
+                derive_webvh_keys(keys_ks, seed_store, &context.base_path, 1).await?
+            } else {
+                vec![]
+            };
+            let pre =
+                derive_webvh_keys(keys_ks, seed_store, &context.base_path, pre_rotation_count)
+                    .await?;
+            (auth, pre)
+        }
+        // Plan must predict exactly that. Peeking twice would not: both peeks
+        // read the same un-advanced counter and would hand back overlapping
+        // paths. Peek the whole contiguous block once and split it where the
+        // allocations would have fallen.
+        Mode::Plan => {
+            let all = peek_webvh_keys(
+                keys_ks,
+                seed_store,
+                &context.base_path,
+                auth_count + pre_rotation_count,
+            )
+            .await?;
+            let (auth, pre) = all.split_at(auth_count as usize);
+            (auth.to_vec(), pre.to_vec())
+        }
     };
-    let derived_pre_rotation =
-        derive_webvh_keys(keys_ks, seed_store, &context.base_path, pre_rotation_count).await?;
 
     // 8. Resolve the signing key.
     //
@@ -209,30 +302,52 @@ pub async fn update_did_webvh(
         // Backdated, index-spaced timestamp so a back-to-back update doesn't
         // collide with the previous entry's second — see `backdated_version_time`.
         .version_time(super::super::backdated_version_time(new_entry_index));
-    if let Some(doc) = new_doc {
-        builder = builder.document(doc);
-        let new_keys: Vec<Multibase> = if pre_rotation_active {
-            // Reveal the pre-rotation key as the new update_keys entry.
-            // `validate_pre_rotation_keys` requires every key in the new
-            // update_keys to have its hash committed in
-            // previous.next_key_hashes — `signing_handle.public_key`
-            // satisfies that by construction (we picked it BY hash).
-            vec![Multibase::from(signing_handle.public_key.clone())]
-        } else {
+    // The update_keys this entry sets, or `None` to leave the previous entry's
+    // in force — webvh parameters are a delta, so "not restated" means
+    // "unchanged", NOT "removed".
+    //
+    // Computed once, here, and consumed by both the builder below and the plan.
+    // Deriving it twice would be the same mistake this whole plan/apply split
+    // exists to avoid: a second implementation of the handler's semantics that
+    // is free to drift from the first.
+    let set_update_keys: Option<Vec<Multibase>> = if new_doc.is_some() && !pre_rotation_active {
+        Some(
             derived_auth
                 .iter()
                 .map(|k| Multibase::from(k.public_key.clone()))
-                .collect()
-        };
-        builder = builder.update_keys(new_keys);
+                .collect(),
+        )
     } else if pre_rotation_active {
-        // Metadata-only update under pre-rotation: still rotate
-        // update_keys to the revealed pre-rotation pubkey so the chain's
-        // active update-keys keep moving forward in lockstep with the
-        // signing-key reveal. Otherwise the next entry's
-        // `previous.next_key_hashes` carries an unused commitment while
-        // the active key on record stays stale.
-        builder = builder.update_keys(vec![Multibase::from(signing_handle.public_key.clone())]);
+        // Reveal the pre-rotation key as the new update_keys entry.
+        // `validate_pre_rotation_keys` requires every key in the new update_keys
+        // to have its hash committed in previous.next_key_hashes —
+        // `signing_handle.public_key` satisfies that by construction (we picked
+        // it BY hash).
+        //
+        // This also covers the metadata-only update under pre-rotation: the
+        // active update-keys must keep moving forward in lockstep with the
+        // signing-key reveal, or the next entry's `previous.next_key_hashes`
+        // carries an unused commitment while the key on record goes stale.
+        Some(vec![Multibase::from(signing_handle.public_key.clone())])
+    } else {
+        None
+    };
+
+    /// The update keys in force *after* this entry: what it sets, or what the
+    /// previous entry left standing.
+    fn effective_update_keys(set: &Option<Vec<Multibase>>, previous: &[Multibase]) -> Vec<String> {
+        set.as_deref()
+            .unwrap_or(previous)
+            .iter()
+            .map(|k| k.as_ref().to_string())
+            .collect()
+    }
+
+    if let Some(doc) = new_doc {
+        builder = builder.document(doc);
+    }
+    if let Some(ref keys) = set_update_keys {
+        builder = builder.update_keys(keys.clone());
     }
     // Always pass next_key_hashes when caller toggled pre-rotation OR
     // when the DID currently uses pre-rotation — keeps the commitment
@@ -289,6 +404,35 @@ pub async fn update_did_webvh(
     snapshot
         .assert_unchanged(&current)
         .map_err(|race| UpdateDidWebvhError::Conflict(race.to_string()))?;
+
+    // ── The seam. Everything above is read-only; everything below commits. ──
+    //
+    // A plan stops here, having run the real path: the same chain load, the
+    // same key derivation, the same `didwebvh_rs::update_did` that minted the
+    // actual next log entry above. What it reports is not a description of the
+    // update — it is the update, uncommitted.
+    if mode == Mode::Plan {
+        return Ok(Outcome::Planned(UpdatePlan {
+            did: record.did.clone(),
+            scid: scid.to_string(),
+            prior_version_id,
+            new_version_id: new_version_id.clone(),
+            prior_document,
+            new_document: new_log_entry.get_state().clone(),
+            prior_update_keys: last_update_keys
+                .iter()
+                .map(|k| k.as_ref().to_string())
+                .collect(),
+            new_update_keys: effective_update_keys(&set_update_keys, &last_update_keys),
+            pre_rotation_count,
+            new_next_key_hashes: derived_pre_rotation
+                .iter()
+                .map(|k| k.hash.clone())
+                .collect(),
+            base_path: context.base_path.clone(),
+            path_counter_pin,
+        }));
+    }
 
     // 12. Persist new log + new key handles + updated record.
     let new_log_jsonl = state_to_jsonl(result.state())?;
@@ -463,16 +607,9 @@ pub async fn update_did_webvh(
         "did:webvh updated"
     );
 
-    let update_keys_count = if !derived_auth.is_empty() {
-        derived_auth.len() as u32
-    } else if pre_rotation_active {
-        // Reveal-only path: we set update_keys = [revealed_pubkey].
-        1
-    } else {
-        last_update_keys.len() as u32
-    };
+    let update_keys_count = effective_update_keys(&set_update_keys, &last_update_keys).len() as u32;
 
-    Ok(UpdateDidWebvhResult {
+    Ok(Outcome::Executed(UpdateDidWebvhResult {
         did: record.did.clone(),
         new_version_id,
         new_scid,
@@ -486,5 +623,5 @@ pub async fn update_did_webvh(
         // gates on and that step 13 above used to decide whether
         // to call the host transport.
         serverless: record.server_id == "serverless",
-    })
+    }))
 }

--- a/vta-service/src/operations/did_webvh/update/plan.rs
+++ b/vta-service/src/operations/did_webvh/update/plan.rs
@@ -1,0 +1,250 @@
+//! What a `webvh/dids/update` would do, computed by running the real update
+//! through to the point of its first write and stopping there.
+//!
+//! This is the plan half of a plan/apply split. It is not a description of the
+//! update — it *is* the update, minus the commit: the same resolve, the same
+//! chain load, the same key derivation, the same `didwebvh_rs::update_did` call
+//! that mints the actual next log entry. A parallel implementation that
+//! described what the handler does would drift, and when it drifted the human
+//! approving it would be confidently misinformed while every signature still
+//! verified.
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value, json};
+
+use crate::policy::effects::{Effect, StatePin};
+
+/// The outcome of planning an update: everything an approver needs to see, plus
+/// the preconditions the executor must re-assert before committing.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdatePlan {
+    pub did: String,
+    pub scid: String,
+
+    /// Version the plan was computed against — the wire [`StatePin`].
+    pub prior_version_id: String,
+    /// Version the update would produce.
+    pub new_version_id: String,
+
+    pub prior_document: Value,
+    pub new_document: Value,
+
+    /// Update keys authorized to sign before this update.
+    pub prior_update_keys: Vec<String>,
+    /// Update keys that would be authorized after it. Differs from
+    /// `prior_update_keys` whenever the document changes — that rotation is the
+    /// consequence the payload does not mention.
+    pub new_update_keys: Vec<String>,
+
+    /// Pre-rotation commitments the update would publish.
+    pub pre_rotation_count: u32,
+    /// The commitments themselves — hashes of the keys that will be authorized
+    /// to sign the *next* rotation.
+    ///
+    /// Under pre-rotation these are the only place the freshly-derived keys
+    /// surface: `new_update_keys` carries the key *revealed* from the previous
+    /// entry's commitment, not a new derivation. So this is what proves a plan's
+    /// peeked derivation agrees with the allocation the real run performs.
+    pub new_next_key_hashes: Vec<String>,
+
+    /// BIP-32 group whose counter the derivation drew from.
+    pub base_path: String,
+    /// Value of that counter when the keys above were derived.
+    ///
+    /// The planner *peeks* the counter rather than allocating, so the plan is
+    /// read-only — but a peek reserves nothing. If another allocation in the
+    /// same context lands before this plan is applied, the real run derives
+    /// different keys than the ones reported here. The executor re-checks this
+    /// value before committing and refuses if it moved, which is what makes the
+    /// keys an approver was shown the keys that actually execute.
+    pub path_counter_pin: u32,
+}
+
+impl UpdatePlan {
+    /// The wire state pin the approver is shown.
+    pub fn state_pin(&self) -> StatePin {
+        StatePin {
+            resource: self.did.clone(),
+            version: self.prior_version_id.clone(),
+        }
+    }
+
+    /// Whether this update rotates the DID's update keys.
+    pub fn rotates_update_keys(&self) -> bool {
+        self.new_update_keys != self.prior_update_keys
+    }
+
+    /// Render the plan as the effects a consent surface shows.
+    ///
+    /// The key rotation and the pre-rotation refresh are the whole point. They
+    /// are invisible in the request payload — a surface diffing the submitted
+    /// document would show only the document change and silently hide the fact
+    /// that the DID's controlling key is being replaced.
+    pub fn to_effects(&self) -> Vec<Effect> {
+        let mut effects = Vec::new();
+
+        for change in document_changes(&self.prior_document, &self.new_document) {
+            effects.push(change);
+        }
+
+        if self.rotates_update_keys() {
+            effects.push(
+                Effect::new(
+                    "keyRotation",
+                    "Rotates this DID's update key. Any change to the document rotates it — the \
+                     current update key stops being able to authorize further changes.",
+                )
+                .before(json!(self.prior_update_keys))
+                .after(json!(self.new_update_keys)),
+            );
+        }
+
+        if self.pre_rotation_count > 0 {
+            let mut detail = Map::new();
+            detail.insert("commitments".into(), json!(self.pre_rotation_count));
+            let plural = if self.pre_rotation_count == 1 {
+                ""
+            } else {
+                "s"
+            };
+            effects.push(
+                Effect::new(
+                    "preRotationRefresh",
+                    format!(
+                        "Publishes {} fresh pre-rotation commitment{plural}, which will authorize \
+                         the next rotation.",
+                        self.pre_rotation_count
+                    ),
+                )
+                .detail(detail),
+            );
+        }
+
+        effects
+    }
+}
+
+/// Top-level document diff, one effect per changed member.
+///
+/// Deliberately shallow: it names *which* members move and shows their before
+/// and after, rather than synthesising a JSON-Pointer-per-leaf diff that reads
+/// precisely but tells a human less. Depth here would be false precision — the
+/// consequences that actually matter (the key rotation) are not in the document
+/// at all.
+fn document_changes(prior: &Value, next: &Value) -> Vec<Effect> {
+    let (Some(prior), Some(next)) = (prior.as_object(), next.as_object()) else {
+        // Not both objects — report wholesale rather than guess.
+        if prior != next {
+            return vec![
+                Effect::new("documentChange", "Replaces the DID document.")
+                    .before(prior.clone())
+                    .after(next.clone()),
+            ];
+        }
+        return vec![];
+    };
+
+    let mut keys: Vec<&String> = prior.keys().chain(next.keys()).collect();
+    keys.sort();
+    keys.dedup();
+
+    let mut effects = Vec::new();
+    for key in keys {
+        let before = prior.get(key);
+        let after = next.get(key);
+        if before == after {
+            continue;
+        }
+        let summary = match (before, after) {
+            (None, Some(_)) => format!("Adds `{key}` to the DID document."),
+            (Some(_), None) => format!("Removes `{key}` from the DID document."),
+            _ => format!("Changes `{key}` in the DID document."),
+        };
+        let mut effect = Effect::new("documentChange", summary).at(format!("/{key}"));
+        if let Some(b) = before {
+            effect = effect.before(b.clone());
+        }
+        if let Some(a) = after {
+            effect = effect.after(a.clone());
+        }
+        effects.push(effect);
+    }
+    effects
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn plan() -> UpdatePlan {
+        UpdatePlan {
+            did: "did:webvh:QmScid:example.com:acme".into(),
+            scid: "QmScid".into(),
+            prior_version_id: "3-QmPrior".into(),
+            new_version_id: "4-QmNext".into(),
+            prior_document: json!({ "id": "did:webvh:QmScid:example.com:acme" }),
+            new_document: json!({
+                "id": "did:webvh:QmScid:example.com:acme",
+                "service": [{ "id": "#files", "type": "FileStore" }]
+            }),
+            prior_update_keys: vec!["z6MkOld".into()],
+            new_update_keys: vec!["z6MkNew".into()],
+            pre_rotation_count: 2,
+            new_next_key_hashes: vec!["QmHashA".into(), "QmHashB".into()],
+            base_path: "m/1'/2'".into(),
+            path_counter_pin: 7,
+        }
+    }
+
+    /// The property the whole design turns on: a payload that adds a service
+    /// endpoint must surface the key rotation it silently causes.
+    #[test]
+    fn a_document_change_surfaces_the_hidden_key_rotation() {
+        let effects = plan().to_effects();
+        let kinds: Vec<&str> = effects.iter().map(|e| e.kind.as_str()).collect();
+        assert_eq!(
+            kinds,
+            ["documentChange", "keyRotation", "preRotationRefresh"]
+        );
+
+        let rotation = &effects[1];
+        assert_eq!(rotation.before, Some(json!(["z6MkOld"])));
+        assert_eq!(rotation.after, Some(json!(["z6MkNew"])));
+        assert!(
+            rotation.summary.contains("stops being able to authorize"),
+            "the summary must say what the rotation costs the holder: {}",
+            rotation.summary
+        );
+    }
+
+    #[test]
+    fn added_member_reports_no_before() {
+        let effects = plan().to_effects();
+        let doc = &effects[0];
+        assert_eq!(doc.path.as_deref(), Some("/service"));
+        assert!(doc.before.is_none(), "an added member has no prior value");
+        assert!(doc.summary.starts_with("Adds `service`"));
+    }
+
+    #[test]
+    fn no_rotation_when_keys_are_unchanged() {
+        let mut p = plan();
+        p.new_update_keys = p.prior_update_keys.clone();
+        p.pre_rotation_count = 0;
+        let kinds: Vec<String> = p.to_effects().iter().map(|e| e.kind.clone()).collect();
+        assert_eq!(kinds, ["documentChange"]);
+    }
+
+    #[test]
+    fn removal_reports_no_after() {
+        let mut p = plan();
+        std::mem::swap(&mut p.prior_document, &mut p.new_document);
+        let doc = &p.to_effects()[0];
+        assert!(
+            doc.after.is_none(),
+            "a removed member has no resulting value"
+        );
+        assert!(doc.summary.starts_with("Removes `service`"));
+    }
+}

--- a/vta-service/src/policy/effects.rs
+++ b/vta-service/src/policy/effects.rs
@@ -1,0 +1,126 @@
+//! Executor-authored effects — what a task will actually do, computed by
+//! dry-running the handler that is about to run it.
+//!
+//! Wire shape of `task-consent/_shared/0.1#Effect` and `#StatePin`.
+//!
+//! The point of these types is that a *payload* says what was asked for, while
+//! only the code about to run knows what will *happen* — and it knows it only
+//! against state the requester cannot see. A `webvh/dids/update` whose payload
+//! adds one service endpoint also rotates the DID's update keys; that
+//! consequence lives in the handler's semantics, not the payload's shape, so no
+//! diff of the payload recovers it.
+//!
+//! An [`Effect`] is therefore produced by running the real handler in plan mode,
+//! never by a second implementation that describes what the handler does. A
+//! second implementation drifts, and when it drifts the human is confidently
+//! misinformed while every signature still verifies.
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+
+/// One consequence of executing a task, authored by the executor.
+///
+/// `kind` is deliberately an open string: handlers evolve faster than any
+/// enum, and an executor must be able to describe a consequence this crate
+/// does not name. `summary` is what makes that safe — it is REQUIRED, it is
+/// human-facing, and a consent surface is obliged to render it even for a
+/// `kind` it does not recognise, so an unknown effect degrades to something
+/// truthful rather than something invisible.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Effect {
+    pub kind: String,
+    pub summary: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub before: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub after: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<Map<String, Value>>,
+}
+
+impl Effect {
+    /// An effect with only the members every surface can render.
+    pub fn new(kind: impl Into<String>, summary: impl Into<String>) -> Self {
+        Self {
+            kind: kind.into(),
+            summary: summary.into(),
+            path: None,
+            before: None,
+            after: None,
+            detail: None,
+        }
+    }
+
+    pub fn at(mut self, path: impl Into<String>) -> Self {
+        self.path = Some(path.into());
+        self
+    }
+
+    /// Prior value. Leave unset to mean "there was none" — an explicit JSON
+    /// `null` is indistinguishable from absence on the wire, so anything the
+    /// distinction matters for belongs in `summary`.
+    pub fn before(mut self, before: Value) -> Self {
+        self.before = Some(before);
+        self
+    }
+
+    pub fn after(mut self, after: Value) -> Self {
+        self.after = Some(after);
+        self
+    }
+
+    pub fn detail(mut self, detail: Map<String, Value>) -> Self {
+        self.detail = Some(detail);
+        self
+    }
+}
+
+/// The prior state a plan's effects were computed against.
+///
+/// Asserted at execution: a human in the loop makes the approval window minutes
+/// wide, so the state can move underneath a pending approval and a lost update
+/// is a real risk rather than a theoretical one.
+///
+/// This is the *wire* pin — what the approver is shown. An executor may hold
+/// further, internal preconditions that it also re-checks at execution (the
+/// webvh planner pins its key-derivation path counter, for instance); those are
+/// its own business, since the approver trusts the executor and cannot verify
+/// its internals in any case.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StatePin {
+    /// Identifier of the pinned resource — usually the subject DID.
+    pub resource: String,
+    /// Opaque version of the prior state. Compared for equality, never ordered.
+    pub version: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn absent_before_is_omitted_not_null() {
+        // The schema promises no null-vs-absent distinction; make sure we don't
+        // accidentally emit one, since a surface would render it as a value.
+        let e = Effect::new("documentChange", "Adds a service endpoint.")
+            .at("/service/0")
+            .after(json!({ "id": "#files" }));
+        let v = serde_json::to_value(&e).unwrap();
+        assert!(!v.as_object().unwrap().contains_key("before"));
+        assert_eq!(v["after"], json!({ "id": "#files" }));
+    }
+
+    #[test]
+    fn round_trips() {
+        let e = Effect::new("keyRotation", "Rotates the update key.")
+            .before(json!(["z6MkA"]))
+            .after(json!(["z6MkB"]));
+        let back: Effect = serde_json::from_value(serde_json::to_value(&e).unwrap()).unwrap();
+        assert_eq!(e, back);
+    }
+}

--- a/vta-service/src/policy/mod.rs
+++ b/vta-service/src/policy/mod.rs
@@ -33,6 +33,7 @@
 
 pub mod consent;
 pub mod defaults;
+pub mod effects;
 pub mod engine;
 pub mod input;
 pub mod storage;

--- a/vta-service/src/webvh_cli.rs
+++ b/vta-service/src/webvh_cli.rs
@@ -447,7 +447,10 @@ pub async fn run_edit_did(
         prompt_webvh_params(edited, Some(&pre_rotation_status))?
     };
 
-    confirm_publish(&body, no_confirm)?;
+    // `confirm_publish` needs the body, but building `opts` below moves out of
+    // it — and the confirmation has to come after the plan, since the plan is
+    // what the operator is confirming.
+    let body_for_confirm = body.clone();
 
     // Convert the wire body into the op-layer options shape. The
     // SDK type carries `witnesses` as opaque JSON to stay
@@ -484,6 +487,37 @@ pub async fn run_edit_did(
         didcomm_bridge: &didcomm_bridge,
         auth_locks: &auth_locks,
     };
+    // Dry-run the real update and show the operator what it will actually do.
+    //
+    // The document diff shown during editing cannot answer this. It is computed
+    // from the document alone, so it can say "you changed `service`" but it has
+    // no way to know that changing *anything* rotates this DID's update key —
+    // that consequence lives in the update handler's semantics, not in the
+    // document's shape. An operator confirming on the strength of the diff is
+    // being asked to approve a key rotation they were never shown.
+    //
+    // So the confirmation is driven by a plan produced by the update code
+    // itself, run up to (and not through) its first write.
+    let plan =
+        crate::operations::did_webvh::plan_did_webvh_update(&deps, &auth, &scid, opts.clone())
+            .await?;
+
+    eprintln!("\nPlanned changes to {}:", plan.did);
+    eprintln!(
+        "  Version: {} → {}",
+        plan.prior_version_id, plan.new_version_id
+    );
+    eprintln!();
+    for effect in plan.to_effects() {
+        eprintln!("  • {}", effect.summary);
+    }
+    if plan.to_effects().is_empty() {
+        eprintln!("  (no effects — this update would change nothing)");
+    }
+    eprintln!();
+
+    confirm_publish(&body_for_confirm, no_confirm)?;
+
     let result = crate::operations::did_webvh::update_did_webvh(
         &deps,
         &auth,

--- a/vti-common/src/store/counter.rs
+++ b/vti-common/src/store/counter.rs
@@ -40,15 +40,7 @@ static COUNTER_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 /// infrequent; the fsync cost is acceptable.
 pub async fn allocate_u32(ks: &KeyspaceHandle, counter_key: &str) -> Result<u32, AppError> {
     let _guard = COUNTER_LOCK.lock().await;
-    let current: u32 = match ks.get_raw(counter_key).await? {
-        Some(bytes) => {
-            let arr: [u8; 4] = bytes
-                .try_into()
-                .map_err(|_| AppError::Internal(format!("corrupt counter at {counter_key}")))?;
-            u32::from_le_bytes(arr)
-        }
-        None => 0,
-    };
+    let current = read_u32(ks, counter_key).await?;
     ks.insert_raw(counter_key, (current + 1).to_le_bytes().to_vec())
         .await?;
     ks.persist().await?;
@@ -57,6 +49,34 @@ pub async fn allocate_u32(ks: &KeyspaceHandle, counter_key: &str) -> Result<u32,
     // No-op unless running in a TEE.
     crate::integrity::reseal_if_active().await?;
     Ok(current)
+}
+
+/// Read the counter at `counter_key` **without** allocating (a missing key reads
+/// as 0) — the value [`allocate_u32`] would return next.
+///
+/// This exists so a caller can compute what it *would* derive without consuming
+/// an index: a dry-run that allocated would both burn a path and, worse, cause
+/// the real run to derive a *different* key than the one the dry-run reported.
+///
+/// A peeked value is a prediction, not a reservation. Nothing stops another
+/// allocation landing in between, so a caller that must guarantee the prediction
+/// held has to pin the counter and re-check it at the point of use.
+pub async fn peek_u32(ks: &KeyspaceHandle, counter_key: &str) -> Result<u32, AppError> {
+    let _guard = COUNTER_LOCK.lock().await;
+    read_u32(ks, counter_key).await
+}
+
+/// Decode the stored counter. Callers hold `COUNTER_LOCK`.
+async fn read_u32(ks: &KeyspaceHandle, counter_key: &str) -> Result<u32, AppError> {
+    match ks.get_raw(counter_key).await? {
+        Some(bytes) => {
+            let arr: [u8; 4] = bytes
+                .try_into()
+                .map_err(|_| AppError::Internal(format!("corrupt counter at {counter_key}")))?;
+            Ok(u32::from_le_bytes(arr))
+        }
+        None => Ok(0),
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Adds the **plan** half of a plan/apply split on `webvh/dids/update`, so a human can be shown what an update will do before authorizing it. This is the executor-side prerequisite for the PDP's `requireConsent` (#645): a consent surface has to render *something*, and the submitted payload is the wrong thing to render.

## Why the payload can't be the basis of consent

A payload says what was *asked for*. Only the code about to run knows what will *happen* — and it knows it only against state the requester cannot see.

An update whose payload adds one service endpoint **also rotates the DID's update key and refreshes its pre-rotation commitments**. That consequence lives in the update handler's semantics, not in the payload's shape, so no diff of the payload recovers it. A surface rendering the payload shows a one-line endpoint addition and silently hides a key rotation.

So `plan_did_webvh_update` runs the **real path** — same resolve, same chain load, same key derivation, same `didwebvh_rs::update_did` that mints the actual next log entry — and stops at the seam immediately before the first write. What it reports is not a description of the update; it *is* the update, uncommitted.

A second implementation that described the handler would drift, and a drifted description is worse than none, because it misinforms with a straight face.

## The interesting part: making the plan read-only

`derive_webvh_keys` **allocates** from a BIP-32 path counter (`allocate_path` → `counter::allocate_u32`, which writes and fsyncs) — despite a doc comment claiming it was *"Pure — no keyspace writes"*.

A plan that derived keys the way the real run does would therefore consume an index, and the real run — taking the *next* one — would install a **different key than the plan reported**. The approver would have authorized a rotation that never happened, and every signature over that approval would still verify.

The dry-run would have introduced exactly the deception it exists to prevent.

Hence `counter::peek_u32` / `paths::peek_paths` / `peek_webvh_keys`: predict the derivation without consuming it, sharing the derivation itself with the allocating path so the two cannot disagree about the key at a given index. A peek reserves nothing, so `UpdatePlan` pins the counter it read (`path_counter_pin`) for a caller to re-check before committing.

A subtlety worth flagging for review: the two derivations (auth key, pre-rotation keys) must be a **single contiguous peek, split where the allocations would fall**. Peeking once per call reads the same un-advanced counter twice and predicts *overlapping* paths — the same class of bug, one level down.

## A latent bug this surfaced

The update-keys decision is now computed once (`set_update_keys`) and consumed by the builder, the plan, and the result count.

Deriving it instead from the minted entry's raw parameters is wrong twice over: webvh parameters are a **delta**, so an entry that doesn't restate `update_keys` leaves the previous entry's standing — which a naive read reports as a *removal*, and therefore as a spurious key rotation on every metadata-only update. (`validated_parameters` doesn't help; it reads `None` on an entry that *did* restate the value.)

## The CLI was already misinforming operators

`pnm did-webvh edit` confirmed against a client-side document diff — which structurally cannot mention the key rotation. Operators were being asked to approve a rotation they were never shown. The confirmation now runs the plan and prints its effects.

## Tests

The property the whole design rests on: **the keys the plan reports are the keys the execution installs.** Asserted for the plain update key, and — under pre-rotation — for the freshly-derived commitments, which is the sharper case: there the derived keys land in `next_key_hashes` rather than `update_keys` (the new update key being the one *revealed* from the previous entry's commitment), so they are the only place a mispredicted derivation would surface at all.

Plus: planning consumes no derivation path, appends no log entry, and is repeatable.

`cargo fmt --check`, `cargo clippy --workspace -- -D warnings` (default **and** `--features webvh`), full suite green — 1156 `vta-service` tests, 276 `vti-common`.

## Not in scope

Wiring the plan into `consent_gate` to mint a signed `task-consent/request` — that's the next PR, and it's why `UpdatePlan` carries the pin and `state_pin()`.