### PR TITLE
fix(vta-sdk): declare the task-consent Trust Task family in the URI census

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+### vta-sdk (0.19.2) — declare the `task-consent` Trust Task family
+
+`task-consent/decision/1.0` (PR #645) introduced a new Trust Task family, but
+the `every_uri_in_canonical_namespace` census — which exists to force exactly
+that declaration — was never updated, so it has been failing on `main` since.
+Declares `https://trusttasks.org/spec/task-consent/` with the rationale for it
+being its own family rather than a member of messaging `consent/*` (different
+subject, authority, and grant lifetime), and refreshes the census preamble,
+which had drifted (it claimed five families and omitted `spec/device/`).
+
+Test-only change; no wire or API surface moves.
+
 ### pnm-cli (0.10.7) / cnm-cli (0.10.7) — `--transport rest` recovery flag
 
 Adds a global `--transport <auto|rest>` flag to both CLIs. `rest` forces the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2452,7 +2452,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.19.1",
+ "vta-sdk 0.19.2",
 ]
 
 [[package]]
@@ -3254,7 +3254,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.19.1",
+ "vta-sdk 0.19.2",
 ]
 
 [[package]]
@@ -6714,7 +6714,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.19.1",
+ "vta-sdk 0.19.2",
 ]
 
 [[package]]
@@ -10016,7 +10016,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.19.1",
+ "vta-sdk 0.19.2",
  "vti-common",
  "x25519-dalek",
 ]
@@ -10049,7 +10049,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.19.1",
+ "vta-sdk 0.19.2",
 ]
 
 [[package]]
@@ -10072,7 +10072,7 @@ dependencies = [
  "tracing-subscriber",
  "trust-tasks-rs",
  "uniffi",
- "vta-sdk 0.19.1",
+ "vta-sdk 0.19.2",
 ]
 
 [[package]]
@@ -10107,7 +10107,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10242,7 +10242,7 @@ dependencies = [
  "utoipa-axum",
  "uuid",
  "vta-cli-common",
- "vta-sdk 0.19.1",
+ "vta-sdk 0.19.2",
  "vta-service",
  "vti-common",
  "vti-secrets",
@@ -10264,7 +10264,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.19.1",
+ "vta-sdk 0.19.2",
 ]
 
 [[package]]
@@ -10336,7 +10336,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.19.1",
+ "vta-sdk 0.19.2",
  "vtc-service",
  "vti-common",
  "vti-secrets",
@@ -10384,7 +10384,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.19.1",
+ "vta-sdk 0.19.2",
  "webauthn-rs",
  "zeroize",
 ]
@@ -10411,7 +10411,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.19.1",
+ "vta-sdk 0.19.2",
  "vta-service",
  "vti-common",
 ]
@@ -10440,7 +10440,7 @@ dependencies = [
  "tokio",
  "tracing",
  "vaultrs",
- "vta-sdk 0.19.1",
+ "vta-sdk 0.19.2",
  "vti-common",
 ]
 

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.19.1"
+version = "0.19.2"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -1441,13 +1441,16 @@ mod tests {
     #[test]
     fn every_uri_in_canonical_namespace() {
         // VTA's wire surface canonically lives under
-        // `https://trusttasks.org/spec/<family>/`. Five families are
-        // currently represented:
+        // `https://trusttasks.org/spec/<family>/`. This list IS the census:
+        // a new family is a wire-visible, spec-registry-visible decision, so
+        // adding a URI under an undeclared family fails here until someone
+        // declares the family (and says why) below.
         //
         // - `spec/vta/`            — VTA-specific operations (this
         //                            module is the source of truth).
         // - `spec/auth/`           — cross-cutting auth primitives
         //                            shared with did-hosting / VTC.
+        // - `spec/device/`         — device enrolment / lifecycle.
         // - `spec/did-management/` — canonical DID-hosting protocol
         //                            (PR #139 added the constants;
         //                            Phase 3 migration consumed them).
@@ -1462,7 +1465,17 @@ mod tests {
             "https://trusttasks.org/spec/did-management/",
             "https://trusttasks.org/spec/vault/",
             "https://trusttasks.org/spec/webvh/",
+            // Messaging-bridge consent — gating an inbound *conversation*
+            // (DM / group / channel) before it reaches an agent.
             "https://trusttasks.org/spec/consent/",
+            // Task-execution consent (PR #645) — approvers sign off on a
+            // specific privileged *task*, bound to its payload digest, feeding
+            // the PDP's `requireConsent` disposition. Deliberately its own
+            // family, not a member of `consent/`: different subject (a task,
+            // not a conversation), different authority (the Data-Integrity
+            // proof's signer against a policy-named approver set, not a bridge
+            // enrolment), different lifetime (single-use grant, not standing).
+            "https://trusttasks.org/spec/task-consent/",
             // Framework ACL protocol — the `acl/swap-key` self-service key
             // rotation task (`TASK_ACL_SWAP_KEY_1_0`), now dispatcher-routed.
             "https://trusttasks.org/spec/acl/",


### PR DESCRIPTION
`vta-sdk`'s `trust_tasks::tests::every_uri_in_canonical_namespace` has been failing on `main` since #645 merged:

```
URI must live under one of ["https://trusttasks.org/spec/vta/", …]:
  https://trusttasks.org/spec/task-consent/decision/1.0
```

#645 added `TASK_TASK_CONSENT_DECISION_1_0` under a **new** Trust Task family (`task-consent/`), and the census test — whose entire job is to force a new family to be a deliberate, declared decision rather than something that slips in with a constant — was never updated. The test did exactly what it was built to do; nobody answered it.

## The fix

Declare `https://trusttasks.org/spec/task-consent/` in `ALLOWED_PREFIXES`, with the reasoning for it being its own family rather than a member of messaging `consent/*`:

- **Different subject** — a privileged *task execution*, not an inbound conversation.
- **Different authority** — the Data-Integrity proof's signer, checked against a policy-named approver set, rather than an enrolled bridge.
- **Different lifetime** — a single-use grant bound to the payload digest, not a standing conversation grant.

That's the same split #645 argued for in the code; this just records it where the census can see it.

Also refreshes the census preamble, which had drifted: it claimed "five families" while listing six and omitting `spec/device/` entirely.

## Notes

- Test-only change — no wire format, no public API, no behaviour moves.
- `vta-sdk` 0.19.1 → 0.19.2 because the census is an inline `#[cfg(test)]` module under `src/`, which `scripts/check-version-bumps.sh` (rightly) counts as crate source. Internal deps pin `0.19`, so no dependent bumps needed.
- Found while reviewing #647; unrelated to it, hence a separate PR.