### PR TITLE
feat(vta-service): consent gate mints signed, effects-bearing requests

### DIFF
--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -1152,15 +1152,15 @@ pub const TASK_CONSENT_REQUEST_1_0: &str = "https://trusttasks.org/spec/consent/
 /// bridge-attested).
 pub const TASK_CONSENT_DECISION_1_0: &str = "https://trusttasks.org/spec/consent/decision/1.0";
 
-/// `task-consent/decision/1.0` — an approver signs approval (or denial) of a
+/// `task-consent/decision/0.1` — an approver signs approval (or denial) of a
 /// specific privileged **task execution**, bound to the task's payload digest.
 /// Distinct from `consent/decision` (messaging-bridge conversation consent):
 /// this feeds the Policy Decision Point's `requireConsent` disposition. The
 /// proof's signer must belong to the policy-named approver set; at the required
 /// threshold the VTA issues a single-use grant the requester's re-submit
 /// consumes. Auth: a member of the approver set (Data-Integrity signed).
-pub const TASK_TASK_CONSENT_DECISION_1_0: &str =
-    "https://trusttasks.org/spec/task-consent/decision/1.0";
+pub const TASK_TASK_CONSENT_DECISION_0_1: &str =
+    "https://trusttasks.org/spec/task-consent/decision/0.1";
 
 /// `consent/revoke/1.0` — an operator withdraws a standing grant, reverting the
 /// conversation to default-deny.
@@ -1364,7 +1364,7 @@ pub const ALL_URIS: &[&str] = &[
     // Consent slice
     TASK_CONSENT_REQUEST_1_0,
     TASK_CONSENT_DECISION_1_0,
-    TASK_TASK_CONSENT_DECISION_1_0,
+    TASK_TASK_CONSENT_DECISION_0_1,
     TASK_CONSENT_REVOKE_1_0,
     TASK_CONSENT_LIST_1_0,
     TASK_CONSENT_APPROVER_SET_1_0,
@@ -1482,6 +1482,11 @@ mod tests {
             // ToIP messaging protocol — the transport-agnostic `messaging/ping`
             // liveness/capability probe (`TASK_MESSAGING_PING_0_1`).
             "https://trusttasks.org/spec/messaging/",
+            // Delegated task-execution consent. A separate family from
+            // `consent/*`, which gates an inbound messaging conversation for an
+            // AI agent and whose subject is a platform/conversation pair — it
+            // cannot express "approve this task payload".
+            "https://trusttasks.org/spec/task-consent/",
         ];
         for uri in ALL_URIS {
             assert!(

--- a/vta-service/src/operations/credentials.rs
+++ b/vta-service/src/operations/credentials.rs
@@ -103,7 +103,7 @@ pub async fn issue_credential(
             AppError::Internal("VTA DID not configured; cannot issue".to_string())
         })?;
 
-    let issuer_secret = load_vta_issuer_secret(state, &vta_did).await?;
+    let issuer_secret = load_vta_issuer_secret(state, &vta_did, "credentials-issue").await?;
 
     let now = Utc::now();
     let expires = now + Duration::seconds(params.validity_seconds as i64);
@@ -197,9 +197,13 @@ pub async fn revoke_credential(
 /// [`InternalAuthority`]-gated `get_key_secret_internal`, then reconstruct the
 /// `Secret` from the multibase private key with `id = {vta_did}#key-0` so the
 /// Data-Integrity proof's `verificationMethod` resolves under the VTA DID.
-async fn load_vta_issuer_secret(state: &AppState, vta_did: &str) -> Result<Secret, AppError> {
+pub(crate) async fn load_vta_issuer_secret(
+    state: &AppState,
+    vta_did: &str,
+    purpose: &'static str,
+) -> Result<Secret, AppError> {
     let key_id = format!("{vta_did}#key-0");
-    let authority = InternalAuthority::new("credentials-issue");
+    let authority = InternalAuthority::new(purpose);
     let resp = crate::operations::keys::get_key_secret_internal(
         &state.keys_ks,
         &state.imported_ks,
@@ -207,7 +211,7 @@ async fn load_vta_issuer_secret(state: &AppState, vta_did: &str) -> Result<Secre
         &state.audit_ks,
         authority,
         &key_id,
-        "credentials-issue-internal",
+        purpose,
     )
     .await?;
     // Validate the multibase decodes to a 32-byte Ed25519 seed before

--- a/vta-service/src/policy/consent.rs
+++ b/vta-service/src/policy/consent.rs
@@ -25,6 +25,7 @@ use vti_common::store::KeyspaceHandle;
 
 const PENDING_PREFIX: &[u8] = b"pending:";
 const GRANT_PREFIX: &[u8] = b"grant:";
+const WIRE_INDEX_PREFIX: &[u8] = b"wire:";
 
 /// Domain-separation tag: keeps these digests from colliding with any other
 /// SHA-256 over a canonical payload elsewhere in the system.
@@ -41,22 +42,61 @@ const DIGEST_DOMAIN: &[u8] = b"vta/task-consent/v1\0";
 /// digest, and an approval for the benign one would authorize the destructive
 /// one. The approver only ever sees an opaque digest, so nothing downstream
 /// could catch the substitution.
+/// This digest is **executor-internal**. It never leaves the process: it is the
+/// key under which a pending request and its grant are stored, and the gate must
+/// be able to recompute it on a re-submit *before* it knows the challenge — which
+/// is precisely why it cannot be the salted one. See [`wire_digest`].
 pub fn payload_digest(type_uri: &str, payload: &serde_json::Value) -> Result<String, AppError> {
+    digest_with(type_uri, payload, None)
+}
+
+/// The digest the approver signs, the requester echoes, and the two screens
+/// match: [`payload_digest`] salted with the per-request `challenge`.
+///
+/// Salted because an unsalted digest over a low-entropy payload is a confirmation
+/// oracle. "Deactivate `did:webvh:abc…`" has essentially one canonical form, so
+/// anyone who observes the digest in transit — a compromised, subpoenaed, or
+/// retrospectively-decrypted mediator — can guess the operation and hash to check.
+/// Both screens still derive the same value because both hold the challenge.
+///
+/// The salt is why there are two digests rather than one. Keying storage by the
+/// salted value would be circular: the gate would need the challenge to compute
+/// the key under which the challenge is stored.
+pub fn wire_digest(
+    type_uri: &str,
+    payload: &serde_json::Value,
+    challenge: &str,
+) -> Result<String, AppError> {
+    digest_with(type_uri, payload, Some(challenge))
+}
+
+fn digest_with(
+    type_uri: &str,
+    payload: &serde_json::Value,
+    challenge: Option<&str>,
+) -> Result<String, AppError> {
     let canonical = serde_json_canonicalizer::to_string(payload)
         .map_err(|e| AppError::Internal(format!("payload JCS canonicalization failed: {e}")))?;
     let mut h = Sha256::new();
     h.update(DIGEST_DOMAIN);
     h.update((type_uri.len() as u64).to_be_bytes());
     h.update(type_uri.as_bytes());
+    h.update((canonical.len() as u64).to_be_bytes());
     h.update(canonical.as_bytes());
+    if let Some(c) = challenge {
+        h.update(c.as_bytes());
+    }
     Ok(hex::encode(h.finalize()))
 }
 
 /// An in-flight consent request accumulating approver signatures.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PendingTaskConsent {
-    /// `payload_digest` of the task awaiting consent.
+    /// Internal [`payload_digest`] of the task awaiting consent.
     pub digest: String,
+    /// The salted [`wire_digest`] the approver signs. Stored so a decision can be
+    /// matched without re-deriving it from a payload we deliberately do not keep.
+    pub wire_digest: String,
     /// Type URI of the task (for the approver's display + audit).
     pub type_uri: String,
     /// The DID that submitted the task.
@@ -71,6 +111,18 @@ pub struct PendingTaskConsent {
     pub challenge: String,
     /// Distinct approver DIDs who have approved so far.
     pub approvals: Vec<String>,
+    /// The prior state the effects shown to the approver were computed against.
+    ///
+    /// The payload itself is **not** stored — the requester re-submits it, and the
+    /// digest proves it is the same one. What must be kept is the state the
+    /// effects were computed against, because that is what execution has to
+    /// re-assert: a human in the loop makes the window minutes wide, so the world
+    /// can move underneath an approval.
+    #[serde(default)]
+    pub state_pin: Option<crate::policy::effects::StatePin>,
+    /// Executor-internal preconditions to re-assert at execution.
+    #[serde(default)]
+    pub guards: crate::trust_tasks::planner::Guards,
     pub created_at: u64,
     pub expires_at: u64,
 }
@@ -83,12 +135,28 @@ pub struct TaskConsentGrant {
     pub type_uri: String,
     /// The approver DIDs whose signatures produced this grant.
     pub approvers: Vec<String>,
+    /// Carried from the pending request: what the approvers were shown, and what
+    /// execution must still find true.
+    #[serde(default)]
+    pub state_pin: Option<crate::policy::effects::StatePin>,
+    #[serde(default)]
+    pub guards: crate::trust_tasks::planner::Guards,
     pub granted_at: u64,
     pub expires_at: u64,
 }
 
 fn pending_key(digest: &str) -> Vec<u8> {
     [PENDING_PREFIX, digest.as_bytes()].concat()
+}
+
+/// Index from the salted wire digest back to the internal one.
+///
+/// The approver's decision carries only the wire digest — it is the only digest
+/// that ever left the process — but the pending request is keyed by the internal
+/// one, because the gate has to find it on a re-submit before it knows the
+/// challenge. This index closes that loop.
+fn wire_index_key(wire_digest: &str) -> Vec<u8> {
+    [WIRE_INDEX_PREFIX, wire_digest.as_bytes()].concat()
 }
 
 fn grant_key(requester_did: &str, digest: &str) -> Vec<u8> {
@@ -113,7 +181,30 @@ fn decode<T: for<'de> Deserialize<'de>>(bytes: &[u8]) -> Result<T, AppError> {
 pub async fn store_pending(ks: &KeyspaceHandle, p: &PendingTaskConsent) -> Result<(), AppError> {
     let key = String::from_utf8(pending_key(&p.digest))
         .map_err(|e| AppError::Internal(format!("pending key not utf-8: {e}")))?;
-    ks.insert(key, p).await
+    ks.insert(key, p).await?;
+    // Index the wire digest, since that is the only one an approver's decision
+    // can carry back to us.
+    ks.insert_raw(
+        String::from_utf8(wire_index_key(&p.wire_digest))
+            .map_err(|e| AppError::Internal(format!("wire index key not utf-8: {e}")))?,
+        p.digest.as_bytes().to_vec(),
+    )
+    .await
+}
+
+/// Resolve the salted wire digest an approver signed back to the internal digest
+/// the pending request is keyed by.
+pub async fn pending_by_wire_digest(
+    ks: &KeyspaceHandle,
+    wire_digest: &str,
+    now: u64,
+) -> Result<Option<PendingTaskConsent>, AppError> {
+    let Some(bytes) = ks.get_raw(wire_index_key(wire_digest)).await? else {
+        return Ok(None);
+    };
+    let internal = String::from_utf8(bytes)
+        .map_err(|e| AppError::Internal(format!("wire index value not utf-8: {e}")))?;
+    get_pending(ks, &internal, now).await
 }
 
 /// Fetch a live pending consent. An expired one is treated as absent and swept
@@ -131,13 +222,18 @@ pub async fn get_pending(
     let p: PendingTaskConsent = decode(&b)?;
     if p.expires_at <= now {
         ks.remove(key).await?;
+        ks.remove(wire_index_key(&p.wire_digest)).await?;
         return Ok(None);
     }
     Ok(Some(p))
 }
 
-pub async fn delete_pending(ks: &KeyspaceHandle, digest: &str) -> Result<(), AppError> {
-    ks.remove(pending_key(digest)).await
+/// Delete a pending request and its wire index. Takes the record rather than a
+/// digest so both keys are always removed together — an orphaned index would
+/// resolve to a pending that no longer exists.
+pub async fn delete_pending(ks: &KeyspaceHandle, p: &PendingTaskConsent) -> Result<(), AppError> {
+    ks.remove(pending_key(&p.digest)).await?;
+    ks.remove(wire_index_key(&p.wire_digest)).await
 }
 
 /// Record an approval (idempotent per approver) and return the updated pending.
@@ -168,6 +264,7 @@ pub async fn sweep_expired(ks: &KeyspaceHandle, now: u64) -> Result<usize, AppEr
         match serde_json::from_slice::<PendingTaskConsent>(&value) {
             Ok(p) if p.expires_at <= now => {
                 ks.remove(key).await?;
+                ks.remove(wire_index_key(&p.wire_digest)).await?;
                 pruned += 1;
             }
             Ok(_) => {}
@@ -274,6 +371,73 @@ mod tests {
         );
     }
 
+    /// The wire digest is the one that leaves the process, and it is salted with
+    /// the challenge so it cannot be used as a confirmation oracle: a payload
+    /// like "deactivate did:webvh:abc…" has essentially one canonical form, so an
+    /// unsalted digest is guessable by anyone who observes it in transit.
+    #[test]
+    fn wire_digest_is_salted_and_distinct_from_the_internal_one() {
+        let p = json!({ "did": "did:webvh:example.com:acme" });
+        let internal = payload_digest(T_UPDATE, &p).unwrap();
+        let a = wire_digest(T_UPDATE, &p, "challenge-aaaa").unwrap();
+        let b = wire_digest(T_UPDATE, &p, "challenge-bbbb").unwrap();
+
+        assert_ne!(
+            internal, a,
+            "the wire digest must not equal the storage key"
+        );
+        assert_ne!(
+            a, b,
+            "a different challenge must yield a different wire digest"
+        );
+        // …and it is still deterministic for a given challenge, or the approver's
+        // echo could never be matched.
+        assert_eq!(a, wire_digest(T_UPDATE, &p, "challenge-aaaa").unwrap());
+    }
+
+    /// The wire digest binds the type URI too — the same reason the internal one
+    /// does, and the approver only ever sees this one.
+    #[test]
+    fn wire_digest_binds_the_type_uri() {
+        let p = json!({ "did": "did:webvh:example.com:acme" });
+        assert_ne!(
+            wire_digest(T_UPDATE, &p, "c").unwrap(),
+            wire_digest(T_ROTATE, &p, "c").unwrap()
+        );
+    }
+
+    /// The decision an approver signs carries only the wire digest, so the
+    /// pending request has to be reachable from it.
+    #[tokio::test]
+    async fn a_decision_resolves_its_pending_by_wire_digest() {
+        let (ks, _d) = temp_ks().await;
+        let p = pending("deadbeef", 1);
+        store_pending(&ks, &p).await.unwrap();
+
+        let found = pending_by_wire_digest(&ks, &p.wire_digest, 200)
+            .await
+            .unwrap()
+            .expect("resolved via the wire index");
+        assert_eq!(found.digest, "deadbeef");
+
+        assert!(
+            pending_by_wire_digest(&ks, "not-a-digest", 200)
+                .await
+                .unwrap()
+                .is_none()
+        );
+
+        // Deleting the pending must take its index with it — an orphaned index
+        // would resolve to a request that no longer exists.
+        delete_pending(&ks, &p).await.unwrap();
+        assert!(
+            pending_by_wire_digest(&ks, &p.wire_digest, 200)
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
     /// Length-prefixing the URI stops a boundary shift between the URI and the
     /// canonical payload from producing the same preimage.
     #[test]
@@ -287,6 +451,9 @@ mod tests {
     fn pending(digest: &str, min: u32) -> PendingTaskConsent {
         PendingTaskConsent {
             digest: digest.into(),
+            wire_digest: format!("wire-{digest}"),
+            state_pin: None,
+            guards: Default::default(),
             type_uri: "https://…/dids/update/1.0".into(),
             requester_did: "did:key:zReq".into(),
             approver_set: "operators".into(),
@@ -371,6 +538,8 @@ mod tests {
     fn grant(digest: &str, expires_at: u64) -> TaskConsentGrant {
         TaskConsentGrant {
             digest: digest.into(),
+            state_pin: None,
+            guards: Default::default(),
             requester_did: "did:key:zReq".into(),
             type_uri: T_UPDATE.into(),
             approvers: vec!["did:key:zA".into()],

--- a/vta-service/src/policy/input.rs
+++ b/vta-service/src/policy/input.rs
@@ -21,6 +21,12 @@ const SUBJECT_FIELDS: &[&str] = &["did", "mnemonic", "subject", "target", "crede
 /// Payload fields that carry the trust-context id.
 const CONTEXT_FIELDS: &[&str] = &["contextId", "context_id"];
 
+/// The identifier the task acts on, by the same precedence `PolicyInput` uses —
+/// so the subject a policy authorized is the subject an approver is shown.
+pub fn subject_of(payload: &Value) -> Option<String> {
+    first_string(payload, SUBJECT_FIELDS).map(str::to_string)
+}
+
 fn first_string<'a>(payload: &'a Value, fields: &[&str]) -> Option<&'a str> {
     fields
         .iter()

--- a/vta-service/src/trust_tasks/consent_request.rs
+++ b/vta-service/src/trust_tasks/consent_request.rs
@@ -1,0 +1,117 @@
+//! Mint the `task-consent/request/0.1` document an approver renders and signs.
+//!
+//! The document is **signed by the VTA**, and that signature is the whole point.
+//! A consent surface renders `effects` as the basis of a human's decision, so an
+//! unsigned request would let anyone who can reach the approver's device author
+//! the prose the human reads — including the relying party whose task is being
+//! approved — while every downstream signature still verified.
+//!
+//! Note the contrast with step-up, whose `approveRequest` is deliberately
+//! unsigned: there the challenge is the binding and the approver signs the
+//! *response*, and nothing in the request is load-bearing for the decision.
+//! Here the request *is* the decision's basis, so it has to be attributable.
+
+use affinidi_data_integrity::{DataIntegrityProof, SignOptions, crypto_suites::CryptoSuite};
+use serde_json::{Value, json};
+use vti_common::error::AppError;
+
+use crate::policy::consent::PendingTaskConsent;
+use crate::policy::effects::Effect;
+use crate::policy::types::TaskClass;
+use crate::server::AppState;
+
+pub(super) const TASK_CONSENT_REQUEST_0_1: &str =
+    "https://trusttasks.org/spec/task-consent/request/0.1";
+
+/// Build one signed `task-consent/request` per eligible approver.
+///
+/// One document per approver rather than one broadcast document, because the
+/// envelope names its `recipient` and an approver should be able to verify a
+/// request was addressed to *them* — a document addressed to someone else,
+/// replayed at a second device, would otherwise look identical.
+///
+/// Approvers barred by `excludeRequester` are dropped here rather than left for
+/// the device to refuse: there is no reason to ask someone a question whose
+/// answer we would not accept.
+pub(super) async fn mint_signed_requests(
+    state: &AppState,
+    pending: &PendingTaskConsent,
+    members: &[String],
+    class: TaskClass,
+    effects: &[Effect],
+    subject: Option<&str>,
+    origin: Option<&str>,
+) -> Result<Vec<Value>, AppError> {
+    let vta_did =
+        state.config.read().await.vta_did.clone().ok_or_else(|| {
+            AppError::Internal("VTA DID not configured; cannot sign consent".into())
+        })?;
+
+    let secret =
+        crate::operations::credentials::load_vta_issuer_secret(state, &vta_did, "task-consent")
+            .await?;
+
+    let class_value = serde_json::to_value(class)
+        .map_err(|e| AppError::Internal(format!("serialize task class: {e}")))?;
+    let expires_at = chrono::DateTime::from_timestamp(pending.expires_at as i64, 0)
+        .ok_or_else(|| AppError::Internal("consent expiry out of range".into()))?
+        .to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+
+    let mut signed = Vec::new();
+    for approver in members {
+        if pending.exclude_requester && approver == &pending.requester_did {
+            continue;
+        }
+
+        let mut payload = json!({
+            "challenge": pending.challenge,
+            "taskType": pending.type_uri,
+            // The salted digest — the only one that ever leaves this process.
+            "payloadDigest": pending.wire_digest,
+            "sideEffects": class_value.get("sideEffects"),
+            "exposure": class_value.get("exposure"),
+            "effects": effects,
+            "requester": pending.requester_did,
+            "approverSet": pending.approver_set,
+            "minApprovals": pending.min_approvals,
+            "excludeRequester": pending.exclude_requester,
+            "expiresAt": expires_at,
+        });
+        if let Some(s) = subject {
+            payload["subject"] = json!(s);
+        }
+        if let Some(o) = origin {
+            payload["origin"] = json!(o);
+        }
+        if let Some(pin) = &pending.state_pin {
+            payload["statePin"] = serde_json::to_value(pin)
+                .map_err(|e| AppError::Internal(format!("serialize state pin: {e}")))?;
+        }
+
+        let unsigned = json!({
+            "id": format!("urn:uuid:{}", uuid::Uuid::new_v4()),
+            "type": TASK_CONSENT_REQUEST_0_1,
+            "issuer": vta_did,
+            "recipient": approver,
+            "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+            "payload": payload,
+        });
+
+        let proof = DataIntegrityProof::sign(
+            &unsigned,
+            &secret,
+            SignOptions::new()
+                .with_proof_purpose("assertionMethod")
+                .with_cryptosuite(CryptoSuite::EddsaJcs2022),
+        )
+        .await
+        .map_err(|e| AppError::Internal(format!("sign task-consent request: {e}")))?;
+
+        let mut doc = unsigned;
+        doc["proof"] = serde_json::to_value(&proof)
+            .map_err(|e| AppError::Internal(format!("serialize proof: {e}")))?;
+        signed.push(doc);
+    }
+
+    Ok(signed)
+}

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -50,6 +50,7 @@ mod auth;
 mod backup;
 mod config;
 mod consent;
+mod consent_request;
 mod contexts;
 mod cred_vault;
 mod credential_exchange;
@@ -64,6 +65,7 @@ mod memory;
 mod messaging;
 #[cfg(all(feature = "webvh", feature = "didcomm"))]
 mod passkey_vms;
+pub(crate) mod planner;
 mod policy_gate;
 #[cfg(feature = "webvh")]
 mod provision_integration;
@@ -566,7 +568,7 @@ dispatch_table! {
     // Task-execution consent decision (PDP requireConsent). Records approver
     // signatures; the gate exempts it from re-gating (see policy_gate) so
     // approving a task can't itself require consent.
-    vta_sdk::trust_tasks::TASK_TASK_CONSENT_DECISION_1_0 => task_consent::handle_decision
+    vta_sdk::trust_tasks::TASK_TASK_CONSENT_DECISION_0_1 => task_consent::handle_decision
         [ Mutating None false ],
     // ─── ACL slice ────────────────────────────────────────────────
     vta_sdk::trust_tasks::TASK_ACL_LIST_1_0 => acl::handle_list

--- a/vta-service/src/trust_tasks/planner.rs
+++ b/vta-service/src/trust_tasks/planner.rs
@@ -1,0 +1,233 @@
+//! Dry-run the handler a task is about to invoke, and report what it would do.
+//!
+//! This is the bridge between the PDP's `requireConsent` and the plan/apply
+//! split in the operations layer. When a policy says a task needs human
+//! approval, *something* has to show the human what they are approving — and the
+//! submitted payload is the wrong thing to show them, because a payload says
+//! what was asked for while only the code about to run knows what will happen.
+//!
+//! A handler with no planner yields `None`. That is not "no consequences": it is
+//! "the consequences could not be determined", and the consent surface is
+//! required to say so rather than present the task as harmless.
+
+use serde_json::Value;
+use vti_common::error::AppError;
+
+use crate::auth::AuthClaims;
+use crate::policy::effects::{Effect, StatePin};
+use crate::server::AppState;
+
+/// What a dry-run learned about the task it is about to run.
+#[derive(Debug, Clone, Default, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TaskPlan {
+    /// What executing the task would do, for the approver to read.
+    pub effects: Vec<Effect>,
+    /// The prior state the effects were computed against — shown to the approver
+    /// and asserted at execution.
+    pub state_pin: Option<StatePin>,
+    /// Executor-internal preconditions, re-asserted at execution.
+    ///
+    /// Deliberately *not* shown to the approver. They could not verify these in
+    /// any case — the approver trusts the executor; that is design parameter
+    /// one — and putting them on the wire would only invite a consent surface to
+    /// render a number it cannot interpret.
+    pub guards: Guards,
+}
+
+/// Preconditions the executor checks for itself before committing.
+#[derive(Debug, Clone, Default, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Guards {
+    /// The BIP-32 derivation-path counter the webvh planner peeked, and the
+    /// group it peeked it from.
+    ///
+    /// A peek reserves nothing. If another allocation in the same context lands
+    /// while a human is deciding, the real run derives *different keys* than the
+    /// ones the approver was shown — so the counter has to be pinned and
+    /// re-checked, or the approval authorizes a rotation to a key that never
+    /// existed.
+    pub webvh_path_counter: Option<WebvhPathCounter>,
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WebvhPathCounter {
+    pub base_path: String,
+    pub counter: u32,
+}
+
+/// Dry-run `type_uri`'s handler against `payload`.
+///
+/// `Ok(None)` means this executor has no dry-run for that handler — the caller
+/// must treat the consequences as unknown, never as absent.
+pub(super) async fn plan_task(
+    state: &AppState,
+    auth: &AuthClaims,
+    type_uri: &str,
+    payload: &Value,
+) -> Result<Option<TaskPlan>, AppError> {
+    #[cfg(feature = "webvh")]
+    if type_uri == vta_sdk::trust_tasks::TASK_WEBVH_DIDS_UPDATE_1_0 {
+        return plan_webvh_update(state, auth, payload).await.map(Some);
+    }
+
+    let _ = (state, auth, type_uri, payload);
+    Ok(None)
+}
+
+#[cfg(feature = "webvh")]
+async fn plan_webvh_update(
+    state: &AppState,
+    auth: &AuthClaims,
+    payload: &Value,
+) -> Result<TaskPlan, AppError> {
+    use crate::operations::did_webvh;
+
+    // The handler's own payload type and option conversion — not a second copy.
+    // A planner that parsed the payload differently from the handler could plan
+    // one update and execute another.
+    let req: super::webvh::UpdateDidWithDid = serde_json::from_value(payload.clone())
+        .map_err(|e| AppError::Validation(format!("invalid webvh update payload: {e}")))?;
+    let options = super::webvh::update_body_to_options(req.body)
+        .map_err(|e| AppError::Validation(format!("invalid webvh update options: {e:?}")))?;
+
+    let did_resolver = state
+        .did_resolver
+        .as_ref()
+        .ok_or_else(|| AppError::Internal("DID resolver not available".into()))?;
+    let deps = did_webvh::WebvhDeps::from_app_state(state, did_resolver);
+
+    let plan = did_webvh::plan_did_webvh_update(&deps, auth, &req.did, options)
+        .await
+        .map_err(|e| AppError::Internal(format!("webvh update dry-run failed: {e}")))?;
+
+    Ok(TaskPlan {
+        effects: plan.to_effects(),
+        state_pin: Some(plan.state_pin()),
+        guards: Guards {
+            webvh_path_counter: Some(WebvhPathCounter {
+                base_path: plan.base_path.clone(),
+                counter: plan.path_counter_pin,
+            }),
+        },
+    })
+}
+
+/// Re-run the dry-run at execution and check the world has not moved under the
+/// approval.
+///
+/// A human in the loop makes the window minutes wide, so this is a real race,
+/// not a theoretical one: the DID may have been updated, or another allocation
+/// in the same context may have advanced the derivation counter so that the run
+/// would now install a key nobody approved.
+///
+/// Returns `Err` describing what moved. A handler with no planner has nothing to
+/// re-check and passes.
+pub(super) async fn assert_plan_still_holds(
+    state: &AppState,
+    auth: &AuthClaims,
+    type_uri: &str,
+    payload: &Value,
+    approved_pin: Option<&StatePin>,
+    approved_guards: &Guards,
+) -> Result<(), String> {
+    let current = match plan_task(state, auth, type_uri, payload).await {
+        Ok(Some(p)) => p,
+        // Nothing to re-check.
+        Ok(None) => return Ok(()),
+        Err(e) => return Err(format!("could not re-plan the task at execution: {e}")),
+    };
+    check_unchanged(approved_pin, approved_guards, &current)
+}
+
+/// Compare what the approver was shown against what would happen now.
+fn check_unchanged(
+    approved_pin: Option<&StatePin>,
+    approved_guards: &Guards,
+    current: &TaskPlan,
+) -> Result<(), String> {
+    if current.state_pin.as_ref() != approved_pin {
+        return Err(format!(
+            "the subject's state changed while this task was awaiting approval (approved against \
+             version {}, now {}). Re-submit to be shown the current effects.",
+            approved_pin.map_or("none", |p| p.version.as_str()),
+            current
+                .state_pin
+                .as_ref()
+                .map_or("none", |p| p.version.as_str()),
+        ));
+    }
+
+    if &current.guards != approved_guards {
+        return Err(
+            "the executor's key derivation moved while this task was awaiting approval, so it \
+             would no longer install the keys the approver was shown. Re-submit to be shown the \
+             current effects."
+                .to_string(),
+        );
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pin(v: &str) -> StatePin {
+        StatePin {
+            resource: "did:webvh:example".into(),
+            version: v.into(),
+        }
+    }
+
+    fn guards(counter: u32) -> Guards {
+        Guards {
+            webvh_path_counter: Some(WebvhPathCounter {
+                base_path: "m/1'/2'".into(),
+                counter,
+            }),
+        }
+    }
+
+    fn plan(pin_v: &str, counter: u32) -> TaskPlan {
+        TaskPlan {
+            effects: vec![],
+            state_pin: Some(pin(pin_v)),
+            guards: guards(counter),
+        }
+    }
+
+    #[test]
+    fn an_unmoved_world_passes() {
+        assert!(check_unchanged(Some(&pin("3-Qm")), &guards(7), &plan("3-Qm", 7)).is_ok());
+    }
+
+    /// The lost update. A human in the loop makes this window minutes wide, so
+    /// the DID really can be updated between approval and execution — and the
+    /// effects the approver signed off on were computed against the old state.
+    #[test]
+    fn a_moved_subject_is_refused() {
+        let err = check_unchanged(Some(&pin("3-Qm")), &guards(7), &plan("4-Qm", 7)).unwrap_err();
+        assert!(err.contains("3-Qm") && err.contains("4-Qm"), "{err}");
+    }
+
+    /// The subtler one: the DID has not moved, but another allocation in the same
+    /// context advanced the derivation counter. Execution would now derive
+    /// different keys than the ones the approver was shown — the effects would be
+    /// a lie, and every signature over them would still verify.
+    #[test]
+    fn a_moved_derivation_counter_is_refused() {
+        let err = check_unchanged(Some(&pin("3-Qm")), &guards(7), &plan("3-Qm", 8)).unwrap_err();
+        assert!(err.contains("key derivation moved"), "{err}");
+    }
+
+    /// A task with no planner pins nothing and re-checks nothing — but it must
+    /// not silently accept a pin it never issued.
+    #[test]
+    fn a_pin_appearing_from_nowhere_is_refused() {
+        let unplanned = TaskPlan::default();
+        assert!(check_unchanged(Some(&pin("3-Qm")), &Guards::default(), &unplanned).is_err());
+    }
+}

--- a/vta-service/src/trust_tasks/policy_gate.rs
+++ b/vta-service/src/trust_tasks/policy_gate.rs
@@ -55,7 +55,7 @@ fn gate_now_secs() -> u64 {
 #[allow(deprecated)]
 fn is_ceremony_task(type_uri: &str) -> bool {
     use vta_sdk::trust_tasks as t;
-    type_uri == t::TASK_TASK_CONSENT_DECISION_1_0
+    type_uri == t::TASK_TASK_CONSENT_DECISION_0_1
         || type_uri == t::TASK_AUTH_STEP_UP_APPROVE_RESPONSE_0_1
         || type_uri == t::TASK_AUTH_STEP_UP_APPROVE_RESPONSE_0_2
 }
@@ -164,13 +164,17 @@ pub(super) async fn policy_gate(
 
 /// Resolve the PDP `requireConsent` disposition.
 ///
-/// Proceeds (`None`) if a valid grant for this exact payload already exists
-/// (single-use consume). Otherwise records a pending request and rejects with
-/// the challenge for approvers to sign — the reject carries `{digest, challenge,
-/// approverSet}` so the requester can relay it to the approver set, mirroring
-/// step-up's carried `approve-request` (active push to approver devices is a
-/// follow-up). The approver's signed `task-consent/decision` produces the grant;
-/// the requester re-submits and this consumes it.
+/// Proceeds (`None`) when a valid grant for this exact task already exists — but
+/// only after re-asserting, at the moment of execution, that the world the
+/// approver was shown is still the world the task will run against. Otherwise it
+/// dry-runs the handler, mints a VTA-signed `task-consent/request` carrying the
+/// effects, and rejects with it for the requester to relay to the approver set.
+///
+/// The signed request is what a consent surface renders. It has to come from
+/// here — from the executor — because the requester cannot be allowed to author
+/// the prose on which a human bases the decision, and because the payload alone
+/// does not contain the consequences (a webvh document update silently rotates
+/// the DID's update key).
 async fn consent_gate(
     state: &AppState,
     auth: &AuthClaims,
@@ -194,9 +198,35 @@ async fn consent_gate(
     };
     let now = gate_now_secs();
 
-    // Existing valid grant → authorized; consume single-use and proceed.
+    // An existing grant authorizes this payload — but it was minted minutes ago,
+    // against a world that may have moved. Policy has already been re-evaluated
+    // (this gate runs on every submit, including the re-submit that consumes the
+    // grant); what has not been re-checked is the *data*.
     match consent::consume_grant(&state.task_consent_ks, &auth.did, type_uri, &digest, now).await {
-        Ok(Some(_)) => return None,
+        Ok(Some(grant)) => {
+            if let Err(why) = super::planner::assert_plan_still_holds(
+                state,
+                auth,
+                type_uri,
+                &doc.payload,
+                grant.state_pin.as_ref(),
+                &grant.guards,
+            )
+            .await
+            {
+                // The grant is already consumed — single-use is single-use, even
+                // when we refuse. Re-submitting mints a fresh request and the
+                // approver sees the effects as they now are.
+                return Some(reject_with(
+                    doc,
+                    RejectReason::TaskFailed {
+                        reason: "auth:consent_stale".into(),
+                        details: Some(json!({ "explanation": why })),
+                    },
+                ));
+            }
+            return None;
+        }
         Ok(None) => {}
         Err(e) => return Some(app_error_to_reject(doc, e)),
     }
@@ -223,29 +253,86 @@ async fn consent_gate(
         ));
     }
 
-    // Reuse an existing pending challenge (idempotent re-submit) or mint one.
+    // Dry-run the handler we are about to gate. `None` means this executor has no
+    // dry-run for it — the effects are *unknown*, not absent, and the consent
+    // surface is required to say so.
+    let plan = match super::planner::plan_task(state, auth, type_uri, &doc.payload).await {
+        Ok(p) => p,
+        Err(e) => return Some(app_error_to_reject(doc, e)),
+    };
+    let (effects, state_pin, guards) = match &plan {
+        Some(p) => (p.effects.clone(), p.state_pin.clone(), p.guards.clone()),
+        None => (vec![], None, Default::default()),
+    };
+
     let min_approvals = require.min_approvals.max(1);
-    let challenge = match consent::get_pending(&state.task_consent_ks, &digest, now).await {
-        Ok(Some(p)) => p.challenge,
-        Ok(None) => {
-            let challenge = format!("{}{}", Uuid::new_v4().simple(), Uuid::new_v4().simple());
-            let pending = consent::PendingTaskConsent {
-                digest: digest.clone(),
-                type_uri: type_uri.to_string(),
-                requester_did: auth.did.clone(),
-                approver_set: require.approver_set.clone(),
-                min_approvals,
-                exclude_requester: require.exclude_requester,
-                challenge: challenge.clone(),
-                approvals: vec![],
-                created_at: now,
-                expires_at: now + CONSENT_PENDING_TTL_SECS,
-            };
-            if let Err(e) = consent::store_pending(&state.task_consent_ks, &pending).await {
+
+    // Reuse the pending request — and so the challenge, and so the digest the
+    // approver is being asked to sign — but only while it still describes the
+    // world. If the state moved under it, the effects it was minted with are no
+    // longer what would happen, so it is retired and the approver is asked afresh
+    // rather than left holding a stale question.
+    let existing = match consent::get_pending(&state.task_consent_ks, &digest, now).await {
+        Ok(p) => p,
+        Err(e) => return Some(app_error_to_reject(doc, e)),
+    };
+    let pending = match existing {
+        Some(p) if p.state_pin == state_pin && p.guards == guards => p,
+        Some(stale) => {
+            if let Err(e) = consent::delete_pending(&state.task_consent_ks, &stale).await {
                 return Some(app_error_to_reject(doc, e));
             }
-            challenge
+            match mint_pending(
+                state,
+                auth,
+                doc,
+                type_uri,
+                &require,
+                min_approvals,
+                now,
+                &state_pin,
+                &guards,
+            )
+            .await
+            {
+                Ok(p) => p,
+                Err(e) => return Some(app_error_to_reject(doc, e)),
+            }
         }
+        None => {
+            match mint_pending(
+                state,
+                auth,
+                doc,
+                type_uri,
+                &require,
+                min_approvals,
+                now,
+                &state_pin,
+                &guards,
+            )
+            .await
+            {
+                Ok(p) => p,
+                Err(e) => return Some(app_error_to_reject(doc, e)),
+            }
+        }
+    };
+
+    let class = super::class_for(type_uri).unwrap_or_else(crate::policy::TaskClass::floor);
+    let subject = crate::policy::input::subject_of(&doc.payload);
+    let requests = match super::consent_request::mint_signed_requests(
+        state,
+        &pending,
+        &members,
+        class,
+        &effects,
+        subject.as_deref(),
+        None,
+    )
+    .await
+    {
+        Ok(r) => r,
         Err(e) => return Some(app_error_to_reject(doc, e)),
     };
 
@@ -254,13 +341,56 @@ async fn consent_gate(
         RejectReason::TaskFailed {
             reason: "auth:consent_required".into(),
             details: Some(json!({
-                "digest": digest,
-                "challenge": challenge,
+                // The salted digest: what the approver signs, and what the two
+                // screens compare. The internal one never leaves this process.
+                "payloadDigest": pending.wire_digest,
+                "challenge": pending.challenge,
                 "approverSet": require.approver_set,
                 "minApprovals": min_approvals,
+                // The signed requests to relay. Each is VTA-authored, so the
+                // approver renders effects it can attribute to the executor
+                // rather than to whoever handed it the document.
+                "consentRequests": requests,
             })),
         },
     ))
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn mint_pending(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: &TrustTask<Value>,
+    type_uri: &str,
+    require: &RequireConsent,
+    min_approvals: u32,
+    now: u64,
+    state_pin: &Option<crate::policy::effects::StatePin>,
+    guards: &super::planner::Guards,
+) -> Result<consent::PendingTaskConsent, vti_common::error::AppError> {
+    // 256 bits of entropy. It is both the replay nonce and the digest salt, so
+    // guessing it would both replay a decision and unmask the payload.
+    let challenge = format!("{}{}", Uuid::new_v4().simple(), Uuid::new_v4().simple());
+    let digest = consent::payload_digest(type_uri, &doc.payload)?;
+    let wire_digest = consent::wire_digest(type_uri, &doc.payload, &challenge)?;
+
+    let pending = consent::PendingTaskConsent {
+        digest,
+        wire_digest,
+        type_uri: type_uri.to_string(),
+        requester_did: auth.did.clone(),
+        approver_set: require.approver_set.clone(),
+        min_approvals,
+        exclude_requester: require.exclude_requester,
+        challenge,
+        approvals: vec![],
+        state_pin: state_pin.clone(),
+        guards: guards.clone(),
+        created_at: now,
+        expires_at: now + CONSENT_PENDING_TTL_SECS,
+    };
+    consent::store_pending(&state.task_consent_ks, &pending).await?;
+    Ok(pending)
 }
 
 #[cfg(test)]
@@ -368,6 +498,141 @@ mod tests {
 
     const REQUIRE_CONSENT: &str = "package vta.policy\nimport rego.v1\ndecision := {\"decision\": \"requireConsent\", \"requireConsent\": {\"approverSet\": \"ops\"}}";
 
+    /// The reject must carry VTA-**signed** consent requests.
+    ///
+    /// This is the load-bearing property of the whole flow: a consent surface
+    /// renders `effects` as the basis of a human's decision, so if the requester
+    /// could author that document, the least-trusted party in the system would be
+    /// writing the prose the human reads — while every downstream signature still
+    /// verified. The approver must be able to attribute what it renders to the
+    /// executor.
+    #[tokio::test]
+    async fn consent_reject_carries_vta_signed_requests() {
+        use crate::policy::consent;
+        let (state, _dir) = crate::test_support::build_signing_test_app_state().await;
+        let auth = crate::test_support::super_admin_claims();
+        let d = doc(UNGATED_URI);
+
+        {
+            let mut cfg = state.config.write().await;
+            cfg.policy.enforcement = true;
+            cfg.policy
+                .approver_sets
+                .insert("ops".into(), vec!["did:key:zApprover".into()]);
+        }
+        crate::policy::storage::store_policy(
+            &state.policy_ks,
+            &module("consent", 0, REQUIRE_CONSENT),
+        )
+        .await
+        .unwrap();
+
+        let outcome = policy_gate(&state, &auth, UNGATED_URI, &d)
+            .await
+            .expect("first submit is rejected pending consent");
+        let body: Value = serde_json::from_slice(&outcome.body).expect("reject body");
+        let details = body
+            .pointer("/payload/details")
+            .expect("reject carries details");
+
+        let requests = details["consentRequests"]
+            .as_array()
+            .expect("consentRequests present");
+        assert_eq!(requests.len(), 1, "one request per eligible approver");
+        let req = &requests[0];
+
+        assert!(
+            req.get("proof").is_some(),
+            "the request must be signed — an unsigned one lets anyone author what the human reads"
+        );
+        let vta_did = state.config.read().await.vta_did.clone().unwrap();
+        assert_eq!(req["issuer"], serde_json::json!(vta_did));
+        assert_eq!(req["recipient"], serde_json::json!("did:key:zApprover"));
+        assert_eq!(
+            req["type"],
+            serde_json::json!(super::super::consent_request::TASK_CONSENT_REQUEST_0_1)
+        );
+
+        // The digest on the wire is the salted one, and both the requester's copy
+        // and the approver's agree on it — that is what lets the two screens be
+        // compared.
+        let wire = req["payload"]["payloadDigest"].as_str().unwrap();
+        assert_eq!(details["payloadDigest"].as_str().unwrap(), wire);
+        assert_eq!(
+            req["payload"]["challenge"].as_str().unwrap(),
+            details["challenge"].as_str().unwrap()
+        );
+
+        let challenge = details["challenge"].as_str().unwrap();
+        assert_eq!(
+            wire,
+            consent::wire_digest(UNGATED_URI, &d.payload, challenge).unwrap()
+        );
+        assert_ne!(
+            wire,
+            consent::payload_digest(UNGATED_URI, &d.payload).unwrap(),
+            "the internal digest must never reach the wire"
+        );
+
+        // The authoritative class comes from the **compiled dispatch table**, not
+        // from the registry. If the registry decided this, it would be a consent
+        // kill-switch: publish a version declaring `sideEffects: none` and consent
+        // evaporates for anyone resolving by URI.
+        let compiled = serde_json::to_value(
+            super::super::class_for(UNGATED_URI).expect("this URI is in the dispatch table"),
+        )
+        .unwrap();
+        assert_eq!(req["payload"]["sideEffects"], compiled["sideEffects"]);
+        assert_eq!(req["payload"]["exposure"], compiled["exposure"]);
+
+        // No planner for this task, so no effects. That is "unknown", not
+        // "harmless" — and the spec obliges the surface to say so.
+        assert_eq!(
+            req["payload"]["effects"],
+            serde_json::json!([]),
+            "a handler with no dry-run yields no effects"
+        );
+        assert_eq!(req["payload"]["taskType"], serde_json::json!(UNGATED_URI));
+    }
+
+    /// The approver named by `excludeRequester` is dropped before we ask, rather
+    /// than asked a question whose answer we would refuse.
+    #[tokio::test]
+    async fn the_requester_is_never_asked_to_approve_its_own_task() {
+        let (state, _dir) = crate::test_support::build_signing_test_app_state().await;
+        let auth = crate::test_support::super_admin_claims();
+        let d = doc(UNGATED_URI);
+
+        {
+            let mut cfg = state.config.write().await;
+            cfg.policy.enforcement = true;
+            // The approver set contains ONLY the requester.
+            cfg.policy
+                .approver_sets
+                .insert("ops".into(), vec![auth.did.clone()]);
+        }
+        crate::policy::storage::store_policy(
+            &state.policy_ks,
+            &module("consent", 0, REQUIRE_CONSENT_EXCLUDE_REQUESTER),
+        )
+        .await
+        .unwrap();
+
+        let outcome = policy_gate(&state, &auth, UNGATED_URI, &d).await.unwrap();
+        let body: Value = serde_json::from_slice(&outcome.body).unwrap();
+        let requests = body
+            .pointer("/payload/details/consentRequests")
+            .and_then(Value::as_array)
+            .expect("consentRequests present");
+        assert!(
+            requests.is_empty(),
+            "the only member of the set is the requester, and the policy excludes them — \
+             so there is nobody to ask, and we must not pretend otherwise"
+        );
+    }
+
+    const REQUIRE_CONSENT_EXCLUDE_REQUESTER: &str = "package vta.policy\nimport rego.v1\ndecision := {\"decision\": \"requireConsent\", \"requireConsent\": {\"approverSet\": \"ops\", \"excludeRequester\": true}}";
+
     /// A grant approved for one task URI must not authorize a *different* task
     /// URI that happens to carry an identical payload. The approver only ever
     /// sees an opaque digest, so if the digest didn't bind the type URI, consent
@@ -406,6 +671,8 @@ mod tests {
             &state.task_consent_ks,
             &consent::TaskConsentGrant {
                 digest: digest.clone(),
+                state_pin: None,
+                guards: Default::default(),
                 requester_did: auth.did.clone(),
                 type_uri: UNGATED_URI.into(),
                 approvers: vec!["did:key:zApprover".into()],
@@ -474,6 +741,8 @@ mod tests {
             &state.task_consent_ks,
             &consent::TaskConsentGrant {
                 digest: digest.clone(),
+                state_pin: None,
+                guards: Default::default(),
                 requester_did: auth.did.clone(),
                 type_uri: UNGATED_URI.into(),
                 approvers: vec!["did:key:zApprover".into()],

--- a/vta-service/src/trust_tasks/task_consent.rs
+++ b/vta-service/src/trust_tasks/task_consent.rs
@@ -1,5 +1,5 @@
-//! Inbound `task-consent/decision/1.0` — an approver signs off on a specific
-//! privileged task execution, bound to its payload digest.
+//! Inbound `task-consent/decision/0.1` — an approver signs off on a specific
+//! privileged task execution, bound to the payload digest they were shown.
 //!
 //! This is the decision half of the PDP's `requireConsent` flow (the gate mints
 //! the pending request and wakes approvers). The approver's authority is the
@@ -21,16 +21,32 @@ use crate::server::AppState;
 /// How long a completed grant stays valid for the requester's re-submit.
 const GRANT_TTL_SECS: u64 = 600;
 
+/// `task-consent/decision/0.1`.
 #[derive(Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct DecisionPayload {
-    /// Payload digest of the task being approved (echoes the pending request).
-    digest: String,
-    /// Nonce echoed from the pending request — binds this decision to it.
+    /// Nonce echoed from the request — binds this decision to it.
     challenge: String,
-    /// True to approve, false to deny (a denial aborts the request).
+    /// The **salted** digest the approver was shown and signed. This is the only
+    /// digest that ever leaves the executor; the internal one it indexes is
+    /// resolved from it.
+    payload_digest: String,
+    /// The human's answer. An explicit enum rather than a bool, so that a missing
+    /// or falsy value can never read as assent — silence, timeouts and dismissals
+    /// are denials, and a wire form that lets them decode as approval is a bug
+    /// waiting for a serializer change.
+    decision: Decision,
+    /// Optional note, most useful on a denial.
+    #[allow(dead_code)]
     #[serde(default)]
-    approve: bool,
+    reason: Option<String>,
+}
+
+#[derive(Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+enum Decision {
+    Approve,
+    Deny,
 }
 
 fn now_secs() -> u64 {
@@ -68,14 +84,14 @@ pub(super) async fn handle_decision(
 
     let ks = &state.task_consent_ks;
     // An expired pending reads as absent, so a lapsed request can't be approved.
-    let pending = match consent::get_pending(ks, &payload.digest, now).await {
+    let pending = match consent::pending_by_wire_digest(ks, &payload.payload_digest, now).await {
         Ok(Some(p)) => p,
         Ok(None) => {
             return reject_with(
                 &doc,
                 RejectReason::TaskFailed {
-                    reason: "task-consent:no_pending".into(),
-                    details: Some(json!({ "digest": payload.digest })),
+                    reason: "task-consent/decision:no_pending".into(),
+                    details: Some(json!({ "payloadDigest": payload.payload_digest })),
                 },
             );
         }
@@ -124,22 +140,22 @@ pub(super) async fn handle_decision(
     }
 
     // A denial aborts the request.
-    if !payload.approve {
-        let _ = consent::delete_pending(ks, &payload.digest).await;
+    if payload.decision == Decision::Deny {
+        let _ = consent::delete_pending(ks, &pending).await;
         return success_response(
             &doc,
-            json!({ "status": "denied", "digest": payload.digest }),
+            json!({ "status": "denied", "payloadDigest": payload.payload_digest }),
         );
     }
 
     // Accumulate the approval; at the threshold, issue a single-use grant.
-    let updated = match consent::add_approval(ks, &payload.digest, &approver, now).await {
+    let updated = match consent::add_approval(ks, &pending.digest, &approver, now).await {
         Ok(Some(p)) => p,
         Ok(None) => {
             return reject_with(
                 &doc,
                 RejectReason::TaskFailed {
-                    reason: "task-consent:no_pending".into(),
+                    reason: "task-consent/decision:no_pending".into(),
                     details: None,
                 },
             );
@@ -153,18 +169,25 @@ pub(super) async fn handle_decision(
             requester_did: updated.requester_did.clone(),
             type_uri: updated.type_uri.clone(),
             approvers: updated.approvals.clone(),
+            // Carry what the approvers were shown through to execution, which
+            // re-asserts it before committing. Without this the grant would
+            // authorize the payload but say nothing about the state it was
+            // approved against — and a human in the loop makes that window
+            // minutes wide.
+            state_pin: updated.state_pin.clone(),
+            guards: updated.guards.clone(),
             granted_at: now,
             expires_at: now + GRANT_TTL_SECS,
         };
         if let Err(e) = consent::store_grant(ks, &grant).await {
             return app_error_to_reject(&doc, e);
         }
-        let _ = consent::delete_pending(ks, &payload.digest).await;
+        let _ = consent::delete_pending(ks, &updated).await;
         return success_response(
             &doc,
             json!({
                 "status": "granted",
-                "digest": payload.digest,
+                "payloadDigest": payload.payload_digest,
                 "approvals": updated.approvals.len(),
             }),
         );
@@ -174,7 +197,7 @@ pub(super) async fn handle_decision(
         &doc,
         json!({
             "status": "pending",
-            "digest": payload.digest,
+            "payloadDigest": payload.payload_digest,
             "approvals": updated.approvals.len(),
             "needed": updated.min_approvals,
         }),

--- a/vta-service/src/trust_tasks/webvh.rs
+++ b/vta-service/src/trust_tasks/webvh.rs
@@ -485,7 +485,9 @@ fn map_register_err(e: RegisterDidWithServerError) -> AppError {
 
 // ─── Helpers internal to this slice ─────────────────────────────────────
 
-fn update_body_to_options(body: UpdateDidWebvhBody) -> Result<UpdateDidWebvhOptions, RejectReason> {
+pub(super) fn update_body_to_options(
+    body: UpdateDidWebvhBody,
+) -> Result<UpdateDidWebvhOptions, RejectReason> {
     let witnesses = match body.witnesses {
         Some(v) => match serde_json::from_value::<Witnesses>(v) {
             Ok(w) => Some(w),
@@ -521,8 +523,8 @@ struct RotateKeysWithDid {
 /// Wrapper carrying `UpdateDidWebvhBody` plus the target `did`. Same
 /// rationale as [`RotateKeysWithDid`].
 #[derive(Debug, serde::Deserialize)]
-struct UpdateDidWithDid {
-    did: String,
+pub(super) struct UpdateDidWithDid {
+    pub(super) did: String,
     #[serde(flatten)]
-    body: UpdateDidWebvhBody,
+    pub(super) body: UpdateDidWebvhBody,
 }


### PR DESCRIPTION
Wires the webvh dry-run (#648) into the PDP's `requireConsent`, so a human is asked about what a task will **do** rather than about an opaque hex digest.

## What was there

A `requireConsent` reject carried `{digest, challenge, approverSet, minApprovals}` and nothing else. The approver had **no signable document** — strictly weaker than step-up, which at least carries an `approveRequest` — and no way to learn what they were authorizing. They signed a hash.

## What it does now

The gate dry-runs the handler it is about to gate, and rejects with a **VTA-signed `task-consent/request/0.1`** per eligible approver, carrying the executor-authored `effects`, the task's class, the subject, and the state pin.

**The signature is the load-bearing part.** A consent surface renders `effects` as the basis of a human's decision. An unsigned request would let anyone who can reach the approver's device author the prose the human reads — including the relying party whose task is being approved — while every downstream signature still verified.

Worth noting the deliberate contrast: step-up's `approveRequest` is *unsigned*, and correctly so. There the challenge is the binding and the approver signs the *response*; nothing in the request is load-bearing for the decision. Here the request **is** the decision's basis, so it has to be attributable.

`sideEffects` and `exposure` come from the **compiled dispatch table**, never the registry — asserted in a test. A registry that decided this would be a consent kill-switch, and a downgradeable one.

## Two digests, not one

The digest on the wire is now **salted with the challenge**. An unsalted digest over a low-entropy payload is a confirmation oracle: "deactivate `did:webvh:abc…`" has essentially one canonical form, so anyone who observes the digest in transit — a compromised, subpoenaed, or retrospectively-decrypted mediator — can guess the operation and hash to check.

But salting cannot be applied to the *storage key*: the gate has to recompute it on a re-submit **before it knows the challenge**, which would be circular. So:

- the **internal** digest stays unsalted, is the pending/grant key, and never leaves the process;
- the **wire** digest is salted, and is the only one an approver ever sees or signs;
- a `wire:` index maps one to the other, because a decision can only carry the digest it was shown.

## Time-of-check to time-of-use

Policy was always re-evaluated on the re-submit — the gate runs on every submit, including the one that consumes the grant. The **data** was not.

A grant now carries the state pin and the executor's internal guards, and execution re-plans and refuses if either moved:

- the DID may have been updated while a human deliberated (a lost update), or
- another allocation in the same context may have advanced the key-derivation counter, so the run would install keys **nobody approved** — the failure mode #648 exists to prevent, arriving through the back door.

A pending request whose world has moved is retired and the approver asked afresh, rather than left holding a stale question.

The guards are deliberately **not** on the wire. The approver could not verify them in any case — they trust the executor, that being design parameter one — and putting a derivation counter in front of a consent surface only invites it to render a number it cannot interpret.

## Decision payload

`task-consent/decision` moves to the published `0.1` shape. `decision` is an explicit enum rather than a bool, so a missing or falsy value can never decode as assent — silence, timeouts and dismissals are denials, and a wire form where they aren't is a bug waiting for a serializer change.

## A pre-existing failure

`every_uri_in_canonical_namespace` has been failing on `main` since #645 added the `task-consent` URI without adding its namespace prefix. Fixed here, since this PR touches that constant.

## Tests

- The reject carries VTA-signed requests; issuer is the VTA, recipient the approver, the wire digest matches the requester's copy and is *not* the internal one, and the class matches the compiled dispatch table.
- `excludeRequester` drops the requester **before** we ask, rather than asking someone a question whose answer we would refuse.
- The wire digest is salted, varies by challenge, still binds the type URI, and is deterministic.
- A decision resolves its pending through the wire index; deleting a pending takes its index with it.
- The staleness check: an unmoved world passes; a moved subject is refused; a moved derivation counter is refused; a pin appearing from nowhere is refused.

`cargo fmt --check`, `cargo clippy --workspace -- -D warnings` (default and `--features webvh`), 1165 `vta-service` tests, 168 `vta-sdk`.

## Not in scope

Active push to approver devices — the reject is the relay fallback, and the wake path (`step_up::trigger_gateway_wake`, already reused by messaging consent) is the next PR. Then the approver surface itself.