### PR TITLE
feat(vta-service): push task-consent requests to approver devices

### DIFF
--- a/vta-service/src/trust_tasks/consent_request.rs
+++ b/vta-service/src/trust_tasks/consent_request.rs
@@ -115,3 +115,92 @@ pub(super) async fn mint_signed_requests(
 
     Ok(signed)
 }
+
+/// Deliver the signed requests to the approvers' devices.
+///
+/// **The same document the reject carries.** The relay fallback and the push are
+/// two transports for one signed object, not two descriptions of one event — a
+/// device must not be able to see different effects depending on how the request
+/// reached it.
+///
+/// Best-effort and fire-and-forget: an approver replies later with a separate
+/// `task-consent/decision`, and the requester still holds the relay copy if none
+/// of this works. A push failure must never turn into a task failure.
+///
+/// Mirrors [`super::step_up::maybe_push_step_up`]: buffer at the approver's
+/// mediator, send it, then ring the doorbell. The buffer alone does not reach a
+/// device, and the wake alone has nothing to collect.
+pub(super) async fn push_signed_requests(state: &AppState, requests: &[Value]) {
+    for request in requests {
+        let Some(approver) = request.get("recipient").and_then(Value::as_str) else {
+            continue;
+        };
+        push_one(state, approver, request).await;
+    }
+}
+
+async fn push_one(
+    state: &AppState,
+    approver: &str,
+    #[cfg_attr(not(feature = "didcomm"), allow(unused))] request: &Value,
+) {
+    let mediator_did = {
+        let cfg = state.config.read().await;
+        super::step_up::approver_mediator(
+            approver,
+            cfg.messaging.as_ref().map(|m| m.mediator_did.as_str()),
+        )
+    };
+    #[cfg_attr(not(feature = "didcomm"), allow(unused))]
+    let Some(mediator_did) = mediator_did else {
+        tracing::debug!(
+            approver = %approver,
+            "no mediator route for consent approver; the relay fallback applies"
+        );
+        return;
+    };
+
+    #[cfg(feature = "didcomm")]
+    {
+        let pending = crate::messaging::registry::PendingResponse {
+            recipient_did: approver.to_string(),
+            message_type: TASK_CONSENT_REQUEST_0_1.to_string(),
+            body: request.clone(),
+            thread_id: request
+                .get("id")
+                .and_then(|v| v.as_str())
+                .map(str::to_string),
+        };
+        if let Err(e) = state
+            .mediator_registry
+            .buffer_outbound(&mediator_did, pending)
+            .await
+        {
+            tracing::warn!(
+                error = %e, approver = %approver, mediator = %mediator_did,
+                "failed to buffer task-consent request; relay fallback applies"
+            );
+        }
+
+        if let Err(e) = state
+            .didcomm_bridge
+            .send_oneway(
+                "vta-main",
+                approver,
+                TASK_CONSENT_REQUEST_0_1,
+                request.clone(),
+            )
+            .await
+        {
+            tracing::warn!(
+                error = %e, approver = %approver,
+                "task-consent request send failed; relay fallback applies"
+            );
+        }
+
+        // Ring the doorbell so a backgrounded device rouses now rather than on
+        // its next voluntary pickup. Contentless by design — the wake says only
+        // "you have mail", never what the task is or who is asking.
+        super::step_up::trigger_gateway_wake(state, approver, &mediator_did).await;
+    }
+}

--- a/vta-service/src/trust_tasks/policy_gate.rs
+++ b/vta-service/src/trust_tasks/policy_gate.rs
@@ -276,8 +276,14 @@ async fn consent_gate(
         Ok(p) => p,
         Err(e) => return Some(app_error_to_reject(doc, e)),
     };
+    // Whether this submit *raised* a new question, as opposed to re-asking one
+    // already outstanding. Only a new question is pushed — see below.
+    let mut newly_raised = true;
     let pending = match existing {
-        Some(p) if p.state_pin == state_pin && p.guards == guards => p,
+        Some(p) if p.state_pin == state_pin && p.guards == guards => {
+            newly_raised = false;
+            p
+        }
         Some(stale) => {
             if let Err(e) = consent::delete_pending(&state.task_consent_ks, &stale).await {
                 return Some(app_error_to_reject(doc, e));
@@ -335,6 +341,21 @@ async fn consent_gate(
         Ok(r) => r,
         Err(e) => return Some(app_error_to_reject(doc, e)),
     };
+
+    // Wake the approvers — but only for a question we have not already asked.
+    //
+    // The reject is deliberately idempotent: a requester re-submitting the same
+    // payload gets the same challenge back, so it can retry without invalidating
+    // an approval already in flight. Pushing on every re-submit would turn that
+    // into a weapon: a relying party could ring an approver's phone as fast as it
+    // can retry a task it knows will be rejected. Consent designs die to
+    // habituation long before they die to cryptography, and an attacker who can
+    // make the prompt appear on demand is the one holding the habituation lever.
+    //
+    // So the push follows the *question*, not the submit.
+    if newly_raised {
+        super::consent_request::push_signed_requests(state, &requests).await;
+    }
 
     Some(reject_with(
         doc,
@@ -632,6 +653,85 @@ mod tests {
     }
 
     const REQUIRE_CONSENT_EXCLUDE_REQUESTER: &str = "package vta.policy\nimport rego.v1\ndecision := {\"decision\": \"requireConsent\", \"requireConsent\": {\"approverSet\": \"ops\", \"excludeRequester\": true}}";
+
+    /// The push must follow the *question*, not the submit.
+    ///
+    /// The reject is deliberately idempotent — a requester re-submitting the same
+    /// payload gets the same challenge back, so a retry cannot invalidate an
+    /// approval already in flight. Pushing on every re-submit would turn that into
+    /// a weapon: a relying party could ring an approver's phone as fast as it can
+    /// retry a task it knows will be rejected. Consent designs die to habituation
+    /// long before they die to cryptography, and an attacker who can summon the
+    /// prompt at will is the one holding that lever.
+    #[cfg(feature = "didcomm")]
+    #[tokio::test]
+    async fn a_resubmit_re_asks_nobody() {
+        use crate::messaging::registry::MediatorBinding;
+
+        const MEDIATOR: &str = "did:example:mediator";
+        const APPROVER: &str = "did:key:zApprover";
+
+        let (state, _dir) = crate::test_support::build_signing_test_app_state().await;
+        let auth = crate::test_support::super_admin_claims();
+        let d = doc(UNGATED_URI);
+
+        // A live mediator the approver routes through, so the push actually lands
+        // somewhere we can observe.
+        state
+            .mediator_registry
+            .record_activate(MediatorBinding {
+                mediator_did: MEDIATOR.into(),
+                endpoint: "https://mediator.test".into(),
+            })
+            .await;
+        {
+            let mut cfg = state.config.write().await;
+            cfg.policy.enforcement = true;
+            cfg.policy
+                .approver_sets
+                .insert("ops".into(), vec![APPROVER.into()]);
+            cfg.messaging = Some(vti_common::config::MessagingConfig {
+                mediator_url: String::new(),
+                mediator_did: MEDIATOR.into(),
+                mediator_host: None,
+            });
+        }
+        crate::policy::storage::store_policy(
+            &state.policy_ks,
+            &module("consent", 0, REQUIRE_CONSENT),
+        )
+        .await
+        .unwrap();
+
+        // First submit raises the question — the approver is asked.
+        assert!(policy_gate(&state, &auth, UNGATED_URI, &d).await.is_some());
+        let pushed = state.mediator_registry.take_outbound(MEDIATOR).await;
+        assert_eq!(pushed.len(), 1, "the approver is asked exactly once");
+        assert_eq!(
+            pushed[0].message_type,
+            super::super::consent_request::TASK_CONSENT_REQUEST_0_1
+        );
+        assert_eq!(pushed[0].recipient_did, APPROVER);
+        assert!(
+            pushed[0].body.get("proof").is_some(),
+            "the pushed document is the same signed one the reject carries — one \
+             document on two transports, so a device cannot be shown different \
+             effects depending on how it arrived"
+        );
+
+        // Re-submitting the identical payload re-asks the same question, and must
+        // not ring the phone again.
+        assert!(policy_gate(&state, &auth, UNGATED_URI, &d).await.is_some());
+        assert!(
+            state
+                .mediator_registry
+                .take_outbound(MEDIATOR)
+                .await
+                .is_empty(),
+            "a re-submit must not re-push — otherwise a relying party can spam an \
+             approver by retrying a task it knows will be rejected"
+        );
+    }
 
     /// A grant approved for one task URI must not authorize a *different* task
     /// URI that happens to carry an identical payload. The approver only ever


### PR DESCRIPTION
The consent gate has been relay-only since #650: the reject carries the signed `task-consent/request` and the requester is expected to hand it on.

That works, but it means **an approver only learns they have been asked when someone tells them — and the party doing the telling is the one whose task is being gated.** A requester with no interest in the task succeeding simply never relays it; one that wants it approved chooses when to ask.

## What this does

On raising a consent request, the gate now buffers the signed document at each approver's mediator, sends it, and rings the push gateway's contentless doorbell. Mirrors `step_up::maybe_push_step_up` — the buffer alone does not reach a device, and a wake alone has nothing to collect, so it is all three.

**The pushed document is the one the reject carries.** One signed object on two transports, not two descriptions of one event: a device must not be able to see different effects depending on how the request reached it. The relay stays as the fallback, and every step of the push is best-effort — a failed push must never become a failed task.

## The push follows the question, not the submit

This is the part worth reviewing.

The reject is deliberately **idempotent**: a requester re-submitting the same payload gets the same challenge back, so a retry cannot invalidate an approval already in flight. Pushing on every re-submit would turn that property into a weapon — a relying party could ring an approver's phone as fast as it can retry a task it *knows* will be rejected.

Consent designs die to habituation long before they die to cryptography, and an attacker who can summon the prompt at will is the one holding that lever. `consent/request:rate_limited` in the existing spec suggests this was already anticipated.

So a push happens only when a pending request is **newly raised** — which includes the case where a stale one is retired because the world moved and the approver must be asked afresh, but not a bare retry.

## Tests

A test observes the approver's mediator buffer directly: exactly one signed request after the first submit, **none** after the re-submit, and the pushed document carries the VTA's proof.

Verified it has teeth — with the newly-raised guard removed, the re-submit rings the approver again and the test fails.

`cargo fmt --check`, `cargo clippy --workspace -- -D warnings` (default and `--features webvh`), 1166 `vta-service` tests.

(`--no-default-features` has two unrelated errors in `server.rs` that predate this branch and are not a configuration CI builds.)

## What's left

The approver surface itself — the browser extension rendering the signed effects and signing the decision. That is the last piece of the informed-consent arc.