### PR TITLE
feat: add automatic mediator ACL provisioning for DIDComm connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,51 @@
 
 ## Unreleased
 
+### vta-service (0.11.0) — automatic ACL provisioning on startup
+
+* Enabled the SDK's `acl-setup` feature and integrated automatic
+  mediator ACL provisioning into VTA startup.
+* VTA now provisions the required DID-level mediator ACL immediately
+  after establishing its DIDComm listener connection, eliminating the
+  need for manual ACL setup.
+* Reuses the shared ACL provisioning implementation provided by
+  `vta-sdk`.
+* Allows VTA deployments to operate correctly with mediators with
+  stricter ACL enforcement policies.
+* ACL provisioning is performed transparently during startup and does
+  not alter existing DIDComm workflows beyond automatically ensuring
+  the required mediator access rules are present.
+
+
+### cnm-cli (0.11.0) / pnm-cli (0.11.0) — automatic ACL setup on DIDComm connect
+
+* Enabled the SDK's `acl-setup` feature by default in the CLIs.
+* DIDComm connections now automatically provision mediator ACLs during
+  connection establishment.
+* Improves interoperability with mediators enforcing DID-level ACL
+  policies by removing the manual ACL setup requirement.
+* Keeps CLIs workflows unchanged while ensuring ACL provisioning is
+  performed transparently in the background.
+
+### vta-sdk (0.19.3) — automatic mediator ACL provisioning for DIDComm connections
+
+- Added an optional `acl-setup` feature that automatically provisions
+  DID-level mediator ACLs when a DIDComm connection is established.
+  The implementation hashes the client DID (SHA-256), creates an
+  allow-all `MediatorAcl`, and submits it via
+  `atm.trust_tasks().acl_set()` in a non-blocking background task.
+- `connect_with_secrets()` now invokes ACL provisioning after DIDComm
+  transport initialization when the `acl-setup` feature is enabled.
+  Existing behavior is unchanged when the feature is not enabled.
+- Introduced a shared `acl_setup` module containing reusable ACL
+  provisioning logic for SDK consumers.
+- New feature dependencies:
+  `trust-tasks-rs`, `sha2`, `tracing`, and `tokio`
+  (all gated behind `acl-setup`).
+- This change enables SDK consumers to operate against mediators with
+  stricter ACL enforcement policies without requiring manual DID-level
+  ACL configuration.
+
 ### vta-sdk (0.19.2) — declare the `task-consent` Trust Task family
 
 `task-consent/decision/1.0` (PR #645) introduced a new Trust Task family, but

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### vti-common (0.11.5)
+
+* Added `setup_acl: bool` (default `false`) to `MessagingConfig`.
+
+### vtc-service (0.11.3)
+
+* Fixed `MessagingConfig` initialisers to include the new `setup_acl` field.
+
 ### vta-service (0.11.0) — automatic ACL provisioning on startup
 
 * Enabled the SDK's `acl-setup` feature and integrated automatic
@@ -21,7 +29,6 @@
   automatically provisions its per-DID allow-all ACL on the mediator
   after connecting (required for mediators using `ExplicitAllow` mode).
   Defaults to `false`; existing configs are unaffected.
-
 
 ### cnm-cli (0.11.0) / pnm-cli (0.11.0) — automatic ACL setup on DIDComm connect
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@
 * ACL provisioning is performed transparently during startup and does
   not alter existing DIDComm workflows beyond automatically ensuring
   the required mediator access rules are present.
+* Added `setup_acl` boolean to `[messaging]` in `config.toml` and the
+  `vta setup` wizard / `--from <toml>` schema. When `true`, the VTA
+  automatically provisions its per-DID allow-all ACL on the mediator
+  after connecting (required for mediators using `ExplicitAllow` mode).
+  Defaults to `false`; existing configs are unaffected.
 
 
 ### cnm-cli (0.11.0) / pnm-cli (0.11.0) — automatic ACL setup on DIDComm connect

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10269,7 +10269,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-service"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",
@@ -10349,7 +10349,7 @@ dependencies = [
 
 [[package]]
 name = "vti-common"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "aes-gcm",
  "affinidi-did-resolver-cache-sdk",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2438,7 +2438,7 @@ checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cnm-cli"
-version = "0.10.7"
+version = "0.11.0"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "clap",
@@ -2452,7 +2452,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.19.2",
+ "vta-sdk 0.19.3",
 ]
 
 [[package]]
@@ -3254,7 +3254,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.19.2",
+ "vta-sdk 0.19.3",
 ]
 
 [[package]]
@@ -6692,7 +6692,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "pnm-cli"
-version = "0.10.7"
+version = "0.11.0"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-resolver-cache-sdk",
@@ -6714,7 +6714,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.19.2",
+ "vta-sdk 0.19.3",
 ]
 
 [[package]]
@@ -10016,14 +10016,14 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.19.2",
+ "vta-sdk 0.19.3",
  "vti-common",
  "x25519-dalek",
 ]
 
 [[package]]
 name = "vta-enclave"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -10049,7 +10049,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.19.2",
+ "vta-sdk 0.19.3",
 ]
 
 [[package]]
@@ -10072,7 +10072,7 @@ dependencies = [
  "tracing-subscriber",
  "trust-tasks-rs",
  "uniffi",
- "vta-sdk 0.19.2",
+ "vta-sdk 0.19.3",
 ]
 
 [[package]]
@@ -10107,7 +10107,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.19.2"
+version = "0.19.3"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10164,7 +10164,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.10.25"
+version = "0.11.0"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",
@@ -10242,7 +10242,7 @@ dependencies = [
  "utoipa-axum",
  "uuid",
  "vta-cli-common",
- "vta-sdk 0.19.2",
+ "vta-sdk 0.19.3",
  "vta-service",
  "vti-common",
  "vti-secrets",
@@ -10264,7 +10264,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.19.2",
+ "vta-sdk 0.19.3",
 ]
 
 [[package]]
@@ -10336,7 +10336,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.19.2",
+ "vta-sdk 0.19.3",
  "vtc-service",
  "vti-common",
  "vti-secrets",
@@ -10384,7 +10384,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.19.2",
+ "vta-sdk 0.19.3",
  "webauthn-rs",
  "zeroize",
 ]
@@ -10411,7 +10411,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.19.2",
+ "vta-sdk 0.19.3",
  "vta-service",
  "vti-common",
 ]
@@ -10440,7 +10440,7 @@ dependencies = [
  "tokio",
  "tracing",
  "vaultrs",
- "vta-sdk 0.19.2",
+ "vta-sdk 0.19.3",
  "vti-common",
 ]
 

--- a/cnm-cli/Cargo.toml
+++ b/cnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cnm-cli"
 description = "CLI Tool for Verified Trust Agents operating in Verified Trust Communities"
-version = "0.10.7"
+version = "0.11.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -21,7 +21,7 @@ config-session = ["vta-sdk/config-session"]
 azure-secrets = ["vta-sdk/azure-secrets"]
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.19", features = ["session", "crypto-provider"] }
+vta-sdk = { path = "../vta-sdk", version = "0.19", features = ["session", "crypto-provider", "acl-setup"] }
 vta-cli-common = { path = "../vta-cli-common", version = "0.10" }
 affinidi-did-resolver-cache-sdk = { workspace = true }
 clap = { workspace = true, features = ["env"] }

--- a/docs/02-vta/examples/vta-setup.example.toml
+++ b/docs/02-vta/examples/vta-setup.example.toml
@@ -148,10 +148,13 @@ service = "vta-prod"   # default "vta"; use a unique name per VTA on the same ho
 # document at runtime. `mediator_host` is the external hostname the VTA
 # should resolve when dialling — used in TEE network mode where outbound
 # traffic goes via a vsock proxy that needs the upstream hostname for SNI.
+# `setup_acl` provisions a per-DID allow-all ACL on the mediator after
+# connecting (required for mediators using ExplicitAllow mode; default false).
 # [messaging]
 # kind          = "existing"
 # did           = "did:webvh:.../mediator"
 # mediator_host = "mediator.example.com"   # optional; TEE deployments only
+# setup_acl     = false                    # optional; default false
 
 # Mint a new mediator DID using the built-in `didcomm-mediator` template.
 #
@@ -174,6 +177,7 @@ service = "vta-prod"   # default "vta"; use a unique name per VTA on the same ho
 kind      = "create_mediator"
 context   = "mediator"   # default "mediator"; trust context the mediator's keys live in
 url       = "https://mediator.example.com"
+# setup_acl     = false                    # optional; enable for ExplicitAllow mediators
 # webvh_url     = "https://trust.example.com/dids/mediator"
 # mediator_host = "mediator.example.com"
 

--- a/pnm-cli/Cargo.toml
+++ b/pnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pnm-cli"
 description = "CLI Tool for managing a personal Verifiable Trust Agent"
-version = "0.10.7"
+version = "0.11.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -28,7 +28,7 @@ azure-secrets = ["vta-sdk/azure-secrets"]
 tsp = ["vta-sdk/tsp"]
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.19", features = ["session", "sealed-transfer", "attest-verify", "provision-integration", "crypto-provider"] }
+vta-sdk = { path = "../vta-sdk", version = "0.19", features = ["session", "sealed-transfer", "attest-verify", "provision-integration", "crypto-provider", "acl-setup"] }
 affinidi-crypto = { workspace = true }
 base64 = { workspace = true }
 reqwest = { workspace = true }

--- a/vta-enclave/Cargo.toml
+++ b/vta-enclave/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-enclave"
 description = "VTA binary for AWS Nitro Enclaves (TEE mode)"
 readme = "README.md"
-version = "0.7.5"
+version = "0.7.6"
 edition.workspace = true
 # `vta-enclave` is a Linux-only Nitro Enclave binary (vsock-store depends
 # on `tokio-vsock`). Publishing to crates.io would surface "fails on
@@ -30,7 +30,7 @@ vsock-store = ["vta-service/vsock-store"]
 vsock-log = ["dep:tokio-vsock"]
 
 [dependencies]
-vta-service = { path = "../vta-service", version = "0.10", default-features = false, features = ["tee"] }
+vta-service = { path = "../vta-service", version = "0.11", default-features = false, features = ["tee"] }
 vti-common = { path = "../vti-common", version = "0.11", features = ["encryption"] }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.19.2"
+version = "0.19.3"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -138,6 +138,16 @@ provision-client = [
   "session",
   "dep:tracing",
   "dep:trust-tasks-rs",
+]
+# Per-DID mediator ACL configuration on DIDComm connect.
+# Requires a live ATM (`session`) and the trust-tasks wire types (`trust-tasks-rs`).
+# Used by both VTA (after listener connects) and PNM (after DIDComm session opens).
+acl-setup = [
+  "session",
+  "dep:trust-tasks-rs",
+  "dep:sha2",
+  "dep:tracing",
+  "dep:tokio",
 ]
 # DCQL credential selection + holder-bound OID4VP `vp_token` assembly
 # (`vp` module). `select_credentials` wraps the always-compiled

--- a/vta-sdk/src/acl_setup.rs
+++ b/vta-sdk/src/acl_setup.rs
@@ -11,24 +11,30 @@
 //! ## Why this covers both DIDComm *and* TSP
 //!
 //! The mediator ACL is keyed on the **hashed DID** (`sha256(did)`), not on the
-//! transport — it gates the account, not a protocol. A DID gets a **single**
-//! mediator websocket (one socket per DID; a second is evicted as
-//! `duplicate-channel`), and both DIDComm and TSP frames are multiplexed over
-//! that one socket. So provisioning the DID's ACL once, after the socket is up,
-//! authorises the account for *both* transports — there is no separate TSP ACL
-//! to set.
+//! transport — it gates the account, not a protocol. On the VTA, DIDComm and TSP
+//! are multiplexed over the DID's **single** mediator websocket (one socket per
+//! DID; a second is evicted as `duplicate-channel`), so provisioning the DID's
+//! ACL once — from the DIDComm-listener start path, which is also the
+//! TSP-receive path on a `tsp`-compiled VTA — authorises the account for *both*
+//! transports. There is no separate TSP ACL to set.
 //!
-//! On the VTA this is invoked from the DIDComm-listener start path, which is
-//! also the TSP-receive path (a `tsp`-compiled VTA always multiplexes TSP on the
-//! same listener). On the client (PNM/CNM) it is invoked from
-//! [`crate::didcomm_session`], today the only mediator-connect path.
+//! On the client (PNM/CNM) the general request transport (`VtaClient` /
+//! `TransportChoice` in `session.rs`) is DIDComm-or-REST: every *persistent*,
+//! ACL-needing client connect goes through [`crate::didcomm_session`], which
+//! calls this. The SDK's one dedicated *client-side* TSP session,
+//! [`crate::session::TspPingSession`], is a transient `pnm health` liveness
+//! probe on an ephemeral DID — it opens its own short-lived TSP socket and tears
+//! it down, so it deliberately does **not** persist a mediator ACL (that would
+//! litter the mediator with allow-all entries for throwaway probe DIDs). A probe
+//! against an `ExplicitAllow` mediator is expected to require its DID be
+//! pre-authorised.
 //!
-//! TODO(tsp-client): when the SDK grows a *dedicated* client-side TSP transport
-//! (see the `#[non_exhaustive]` `TransportChoice` in `session.rs` — TSP is the
-//! workspace's preferred transport), that connect path must also call
-//! [`set_client_acl_on_connection`], or an `ExplicitAllow` mediator will reject
-//! it exactly as it did before this feature. The provisioning logic lives here
-//! precisely so that future call site can reuse it — only the trigger is missing.
+//! TODO(tsp-client): if/when the general client request transport gains a
+//! *persistent* TSP variant (a `Tsp` arm on the `#[non_exhaustive]`
+//! `TransportChoice`, or `TspPingSession` generalised into a request session),
+//! that connect path must also call [`set_client_acl_on_connection`], or an
+//! `ExplicitAllow` mediator will reject it exactly as it did before this
+//! feature. The provisioning logic lives here so only the trigger is needed.
 
 use std::sync::Arc;
 

--- a/vta-sdk/src/acl_setup.rs
+++ b/vta-sdk/src/acl_setup.rs
@@ -1,4 +1,4 @@
-//! Mediator ACL setup for DIDComm clients.
+//! Mediator ACL setup for DIDComm/TSP clients.
 //!
 //! After a client successfully connects to a mediator, it configures its own per-DID
 //! ACL to accept all messages despite potentially restrictive global ACL defaults.
@@ -7,6 +7,28 @@
 //!
 //! Used by both VTA (server startup) and PNM (on DIDComm connect).
 //! Gated on the `acl-setup` feature which requires `session` + `trust-tasks-rs`.
+//!
+//! ## Why this covers both DIDComm *and* TSP
+//!
+//! The mediator ACL is keyed on the **hashed DID** (`sha256(did)`), not on the
+//! transport — it gates the account, not a protocol. A DID gets a **single**
+//! mediator websocket (one socket per DID; a second is evicted as
+//! `duplicate-channel`), and both DIDComm and TSP frames are multiplexed over
+//! that one socket. So provisioning the DID's ACL once, after the socket is up,
+//! authorises the account for *both* transports — there is no separate TSP ACL
+//! to set.
+//!
+//! On the VTA this is invoked from the DIDComm-listener start path, which is
+//! also the TSP-receive path (a `tsp`-compiled VTA always multiplexes TSP on the
+//! same listener). On the client (PNM/CNM) it is invoked from
+//! [`crate::didcomm_session`], today the only mediator-connect path.
+//!
+//! TODO(tsp-client): when the SDK grows a *dedicated* client-side TSP transport
+//! (see the `#[non_exhaustive]` `TransportChoice` in `session.rs` — TSP is the
+//! workspace's preferred transport), that connect path must also call
+//! [`set_client_acl_on_connection`], or an `ExplicitAllow` mediator will reject
+//! it exactly as it did before this feature. The provisioning logic lives here
+//! precisely so that future call site can reuse it — only the trigger is missing.
 
 use std::sync::Arc;
 
@@ -18,14 +40,20 @@ use trust_tasks_rs::specs::messaging::acl;
 
 /// Set a client's own ACL on the mediator to accept all messages.
 ///
-/// Call this immediately after a DIDComm connection to the mediator succeeds.
-/// The client sets its per-DID ACL to allow all message types, which overrides any
-/// restrictive global ACL settings on the mediator while still respecting per-context
-/// ACLs configured for integrations.
+/// Call this immediately after a connection to the mediator succeeds. The client
+/// sets its per-DID ACL to allow all message types, which overrides any
+/// restrictive global ACL settings on the mediator while still respecting
+/// per-context ACLs configured for integrations.
+///
+/// **Fire-and-forget and fully non-blocking.** The entire operation — including
+/// building the ATM profile and the mediator round-trip — runs on a spawned
+/// background task, so neither VTA startup nor a client connect is delayed. This
+/// returns as soon as the task is spawned; both call sites (VTA and PNM) get the
+/// same non-blocking behaviour.
 ///
 /// # Behavior
-/// - If ATM or required DIDs are not available, this is a no-op (graceful degradation)
-/// - If ACL setting fails, a warning is logged but startup continues (fire-and-forget)
+/// - If building the profile or setting the ACL fails, a warning/debug line is
+///   logged but the caller's startup/connect continues unaffected.
 pub async fn set_client_acl_on_connection(
     atm: &ATM,
     client_did: &str,
@@ -33,19 +61,32 @@ pub async fn set_client_acl_on_connection(
     channel: &str,
     client_name: &str,
 ) {
-    if let Err(e) =
-        set_client_acl_internal(atm, client_did, mediator_did, channel, client_name).await
-    {
-        warn!(
-            channel,
-            error = %e,
-            client = client_name,
-            "failed to set client ACL on mediator (startup continues)"
-        );
-    }
+    // Own everything so the work can outlive the caller's stack frame, then
+    // spawn a single background task. One spawn — not a spawn-inside-a-spawn —
+    // keeps the profile build and the ACL round-trip off the hot path together.
+    let atm = atm.clone();
+    let client_did = client_did.to_string();
+    let mediator_did = mediator_did.to_string();
+    let channel = channel.to_string();
+    let client_name = client_name.to_string();
+
+    tokio::spawn(async move {
+        if let Err(e) =
+            set_client_acl_internal(&atm, &client_did, &mediator_did, &channel, &client_name).await
+        {
+            warn!(
+                channel,
+                error = %e,
+                client = client_name,
+                "failed to set client ACL on mediator (startup continues)"
+            );
+        }
+    });
 }
 
-/// Internal implementation of ACL setup.
+/// Internal implementation of ACL setup. Runs on the background task spawned by
+/// [`set_client_acl_on_connection`]; it is free to `await` the mediator
+/// round-trip directly since nothing on the caller's path is waiting on it.
 async fn set_client_acl_internal(
     atm: &ATM,
     client_did: &str,
@@ -63,8 +104,9 @@ async fn set_client_acl_internal(
     .await
     .map_err(|e| format!("failed to create ATM profile: {e}"))?;
 
-    // Hash the client's DID for the mediator's ACL record (self-reference)
-    // SHA-256 to match the TDK's acl_set convention
+    // Hash the client's DID for the mediator's ACL record (self-reference).
+    // SHA-256 hex to match the mediator's account-key convention
+    // (`sha256::digest(did)` in affinidi-messaging-sdk).
     let mut hasher = Sha256::new();
     hasher.update(client_did);
     let hash_bytes = hasher.finalize();
@@ -73,51 +115,40 @@ async fn set_client_acl_internal(
         .map(|b| format!("{:02x}", b))
         .collect::<String>();
 
-    // Build an "allow all" ACL that accepts every message type.
-    // This is a partial update: only the flags we set matter; the rest left unchanged.
+    // Build an "allow all" ACL that accepts every message type. Fields left
+    // `None` (e.g. the self-manage flags) keep the mediator's existing value.
     let acl = build_allow_all_acl();
 
-    // Apply the ACL to the client's own DID via the mediator's trust-tasks protocol.
-    // Send the request without waiting for response, because receiving the response
-    // requires receive_forwarded permission which we don't have until the ACL is
-    // applied. The mediator will process the request asynchronously anyway.
-    let client_did_copy = client_did.to_string();
-    let client_name_copy = client_name.to_string();
     let atm_profile_arc = Arc::new(atm_profile);
-    let atm_clone = atm.clone();
 
-    // Spawn a background task to send the ACL request fire-and-forget.
-    // Errors are logged at debug level since the mediator may still process it.
-    tokio::spawn(async move {
-        match atm_clone
-            .trust_tasks()
-            .acl_set(&atm_profile_arc, client_did_hash, acl)
-            .await
-        {
-            Ok(_) => {
-                info!(
-                    client_did = %client_did_copy,
-                    client = client_name_copy,
-                    "client ACL configured on mediator"
-                );
-            }
-            Err(e) => {
-                debug!(
-                    client_did = %client_did_copy,
-                    error = %e,
-                    client = client_name_copy,
-                    "client ACL request error (mediator may still process asynchronously)"
-                );
-            }
+    // Apply the ACL to the client's own DID via the mediator's trust-tasks
+    // protocol. `acl_set` waits for a response, which on an `ExplicitAllow`
+    // mediator cannot arrive until this very ACL grants `receive_forwarded` —
+    // so an `Err` here (typically a timeout) does NOT mean the request was
+    // dropped; the mediator still applies it. Hence debug, not warn, on error.
+    match atm
+        .trust_tasks()
+        .acl_set(&atm_profile_arc, client_did_hash, acl)
+        .await
+    {
+        Ok(_) => {
+            info!(
+                channel,
+                client_did = %client_did,
+                client = client_name,
+                "client ACL configured on mediator"
+            );
         }
-    });
-
-    info!(
-        channel,
-        client_did = %client_did,
-        client = client_name,
-        "client ACL configuration request sent to mediator"
-    );
+        Err(e) => {
+            debug!(
+                channel,
+                client_did = %client_did,
+                error = %e,
+                client = client_name,
+                "client ACL request error (mediator may still process asynchronously)"
+            );
+        }
+    }
 
     Ok(())
 }

--- a/vta-sdk/src/acl_setup.rs
+++ b/vta-sdk/src/acl_setup.rs
@@ -1,0 +1,138 @@
+//! Mediator ACL setup for DIDComm clients.
+//!
+//! After a client successfully connects to a mediator, it configures its own per-DID
+//! ACL to accept all messages despite potentially restrictive global ACL defaults.
+//! This allows the client to receive messages while maintaining the flexibility to set
+//! more restrictive ACLs on specific contexts or integrations if needed.
+//!
+//! Used by both VTA (server startup) and PNM (on DIDComm connect).
+//! Gated on the `acl-setup` feature which requires `session` + `trust-tasks-rs`.
+
+use std::sync::Arc;
+
+use affinidi_tdk::messaging::profiles::ATMProfile;
+use affinidi_tdk::messaging::ATM;
+use sha2::{Digest, Sha256};
+use trust_tasks_rs::specs::messaging::acl;
+use tracing::{debug, info, warn};
+
+/// Set a client's own ACL on the mediator to accept all messages.
+///
+/// Call this immediately after a DIDComm connection to the mediator succeeds.
+/// The client sets its per-DID ACL to allow all message types, which overrides any
+/// restrictive global ACL settings on the mediator while still respecting per-context
+/// ACLs configured for integrations.
+///
+/// # Behavior
+/// - If ATM or required DIDs are not available, this is a no-op (graceful degradation)
+/// - If ACL setting fails, a warning is logged but startup continues (fire-and-forget)
+pub async fn set_client_acl_on_connection(
+    atm: &ATM,
+    client_did: &str,
+    mediator_did: &str,
+    channel: &str,
+    client_name: &str,
+) {
+    if let Err(e) = set_client_acl_internal(atm, client_did, mediator_did, channel, client_name).await {
+        warn!(
+            channel,
+            error = %e,
+            client = client_name,
+            "failed to set client ACL on mediator (startup continues)"
+        );
+    }
+}
+
+/// Internal implementation of ACL setup.
+async fn set_client_acl_internal(
+    atm: &ATM,
+    client_did: &str,
+    mediator_did: &str,
+    channel: &str,
+    client_name: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // Build an ATM profile for the client with the mediator as the peer.
+    let atm_profile = ATMProfile::new(atm, None, client_did.to_string(), Some(mediator_did.to_string()))
+        .await
+        .map_err(|e| format!("failed to create ATM profile: {e}"))?;
+
+    // Hash the client's DID for the mediator's ACL record (self-reference)
+    // SHA-256 to match the TDK's acl_set convention
+    let mut hasher = Sha256::new();
+    hasher.update(client_did);
+    let hash_bytes = hasher.finalize();
+    let client_did_hash = hash_bytes
+        .iter()
+        .map(|b| format!("{:02x}", b))
+        .collect::<String>();
+
+    // Build an "allow all" ACL that accepts every message type.
+    // This is a partial update: only the flags we set matter; the rest left unchanged.
+    let acl = build_allow_all_acl();
+
+    // Apply the ACL to the client's own DID via the mediator's trust-tasks protocol.
+    // Send the request without waiting for response, because receiving the response
+    // requires receive_forwarded permission which we don't have until the ACL is
+    // applied. The mediator will process the request asynchronously anyway.
+    let client_did_copy = client_did.to_string();
+    let client_name_copy = client_name.to_string();
+    let atm_profile_arc = Arc::new(atm_profile);
+    let atm_clone = atm.clone();
+
+    // Spawn a background task to send the ACL request fire-and-forget.
+    // Errors are logged at debug level since the mediator may still process it.
+    tokio::spawn(async move {
+        match atm_clone
+            .trust_tasks()
+            .acl_set(&atm_profile_arc, client_did_hash, acl)
+            .await
+        {
+            Ok(_) => {
+                info!(
+                    client_did = %client_did_copy,
+                    client = client_name_copy,
+                    "client ACL configured on mediator"
+                );
+            }
+            Err(e) => {
+                debug!(
+                    client_did = %client_did_copy,
+                    error = %e,
+                    client = client_name_copy,
+                    "client ACL request error (mediator may still process asynchronously)"
+                );
+            }
+        }
+    });
+
+    info!(
+        channel,
+        client_did = %client_did,
+        client = client_name,
+        "client ACL configuration request sent to mediator"
+    );
+
+    Ok(())
+}
+
+/// Build a wire-format ACL that allows all message types.
+///
+/// This creates a `MediatorAcl` wire format (compatible with the trust-tasks
+/// `acl/set/0.1` endpoint) that permits sending, receiving, forwarding, and
+/// anonymous messages. The access-list mode is set to ExplicitDeny (denylist
+/// semantics), allowing all except explicitly denied entries.
+fn build_allow_all_acl() -> acl::set::v0_1::MediatorAcl {
+    acl::set::v0_1::MediatorAcl {
+        blocked: Some(false),
+        local: Some(true),
+        send_messages: Some(true),
+        receive_messages: Some(true),
+        send_forwarded: Some(true),
+        receive_forwarded: Some(true),
+        create_invites: Some(true),
+        anon_receive: Some(true),
+        access_list_mode: Some(acl::set::v0_1::MediatorAclAccessListMode::ExplicitDeny),
+        // Don't set self-manage flags — let the mediator's defaults apply
+        ..Default::default()
+    }
+}

--- a/vta-sdk/src/acl_setup.rs
+++ b/vta-sdk/src/acl_setup.rs
@@ -10,11 +10,11 @@
 
 use std::sync::Arc;
 
-use affinidi_tdk::messaging::profiles::ATMProfile;
 use affinidi_tdk::messaging::ATM;
+use affinidi_tdk::messaging::profiles::ATMProfile;
 use sha2::{Digest, Sha256};
-use trust_tasks_rs::specs::messaging::acl;
 use tracing::{debug, info, warn};
+use trust_tasks_rs::specs::messaging::acl;
 
 /// Set a client's own ACL on the mediator to accept all messages.
 ///
@@ -33,7 +33,9 @@ pub async fn set_client_acl_on_connection(
     channel: &str,
     client_name: &str,
 ) {
-    if let Err(e) = set_client_acl_internal(atm, client_did, mediator_did, channel, client_name).await {
+    if let Err(e) =
+        set_client_acl_internal(atm, client_did, mediator_did, channel, client_name).await
+    {
         warn!(
             channel,
             error = %e,
@@ -52,9 +54,14 @@ async fn set_client_acl_internal(
     client_name: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
     // Build an ATM profile for the client with the mediator as the peer.
-    let atm_profile = ATMProfile::new(atm, None, client_did.to_string(), Some(mediator_did.to_string()))
-        .await
-        .map_err(|e| format!("failed to create ATM profile: {e}"))?;
+    let atm_profile = ATMProfile::new(
+        atm,
+        None,
+        client_did.to_string(),
+        Some(mediator_did.to_string()),
+    )
+    .await
+    .map_err(|e| format!("failed to create ATM profile: {e}"))?;
 
     // Hash the client's DID for the mediator's ACL record (self-reference)
     // SHA-256 to match the TDK's acl_set convention

--- a/vta-sdk/src/didcomm_session.rs
+++ b/vta-sdk/src/didcomm_session.rs
@@ -244,6 +244,29 @@ impl DIDCommSession {
             }
         }
 
+        // Set this client's ACL on the mediator to accept all message types.
+        // Fire-and-forget: spawn a background task since the mediator processes
+        // ACL requests asynchronously. Errors are logged but don't block session setup.
+        // Only compiled-in when the `acl-setup` feature is enabled (requires
+        // `session` + `trust-tasks-rs`). PNM enables `acl-setup`; SDK consumers
+        // that omit it are unaffected.
+        #[cfg(feature = "acl-setup")]
+        {
+            let client_did_str = client_did.to_string();
+            let mediator_did_str = mediator_did.to_string();
+            let atm_clone = Arc::clone(&atm);
+            tokio::spawn(async move {
+                crate::acl_setup::set_client_acl_on_connection(
+                    &*atm_clone,
+                    &client_did_str,
+                    &mediator_did_str,
+                    "didcomm-session",
+                    "pnm",
+                )
+                .await;
+            });
+        }
+
         debug!("DIDComm session connected via mediator {mediator_did} (WebSocket mode)");
 
         let shutdown = Arc::new(AtomicBool::new(false));

--- a/vta-sdk/src/didcomm_session.rs
+++ b/vta-sdk/src/didcomm_session.rs
@@ -257,7 +257,7 @@ impl DIDCommSession {
             let atm_clone = Arc::clone(&atm);
             tokio::spawn(async move {
                 crate::acl_setup::set_client_acl_on_connection(
-                    &*atm_clone,
+                    &atm_clone,
                     &client_did_str,
                     &mediator_did_str,
                     "didcomm-session",

--- a/vta-sdk/src/didcomm_session.rs
+++ b/vta-sdk/src/didcomm_session.rs
@@ -245,27 +245,21 @@ impl DIDCommSession {
         }
 
         // Set this client's ACL on the mediator to accept all message types.
-        // Fire-and-forget: spawn a background task since the mediator processes
-        // ACL requests asynchronously. Errors are logged but don't block session setup.
-        // Only compiled-in when the `acl-setup` feature is enabled (requires
-        // `session` + `trust-tasks-rs`). PNM enables `acl-setup`; SDK consumers
-        // that omit it are unaffected.
+        // `set_client_acl_on_connection` is itself fire-and-forget (it spawns a
+        // background task and returns immediately), so no extra spawn here — the
+        // connect path is not blocked on the mediator round-trip. Only compiled-in
+        // when the `acl-setup` feature is enabled (requires `session` +
+        // `trust-tasks-rs`). PNM enables `acl-setup`; SDK consumers that omit it
+        // are unaffected.
         #[cfg(feature = "acl-setup")]
-        {
-            let client_did_str = client_did.to_string();
-            let mediator_did_str = mediator_did.to_string();
-            let atm_clone = Arc::clone(&atm);
-            tokio::spawn(async move {
-                crate::acl_setup::set_client_acl_on_connection(
-                    &atm_clone,
-                    &client_did_str,
-                    &mediator_did_str,
-                    "didcomm-session",
-                    "pnm",
-                )
-                .await;
-            });
-        }
+        crate::acl_setup::set_client_acl_on_connection(
+            &atm,
+            client_did,
+            mediator_did,
+            "didcomm-session",
+            "pnm",
+        )
+        .await;
 
         debug!("DIDComm session connected via mediator {mediator_did} (WebSocket mode)");
 

--- a/vta-sdk/src/lib.rs
+++ b/vta-sdk/src/lib.rs
@@ -87,6 +87,8 @@ pub mod hex;
 pub mod context_path;
 pub mod identifier;
 
+#[cfg(feature = "acl-setup")]
+pub mod acl_setup;
 #[cfg(feature = "session")]
 pub mod agent_session;
 #[cfg(feature = "attest-verify")]
@@ -106,8 +108,6 @@ pub mod did_templates;
 pub mod didcomm_light;
 #[cfg(feature = "session")]
 pub mod didcomm_session;
-#[cfg(feature = "acl-setup")]
-pub mod acl_setup;
 // Pins rustls to the aws-lc-rs backend; every binary calls this at startup.
 #[cfg(feature = "crypto-provider")]
 pub mod crypto_init;

--- a/vta-sdk/src/lib.rs
+++ b/vta-sdk/src/lib.rs
@@ -106,6 +106,8 @@ pub mod did_templates;
 pub mod didcomm_light;
 #[cfg(feature = "session")]
 pub mod didcomm_session;
+#[cfg(feature = "acl-setup")]
+pub mod acl_setup;
 // Pins rustls to the aws-lc-rs backend; every binary calls this at startup.
 #[cfg(feature = "crypto-provider")]
 pub mod crypto_init;

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.10.25"
+version = "0.11.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -94,7 +94,7 @@ vti-common = { path = "../vti-common", version = "0.11", features = ["encryption
 # from this crate into a shared crate so external integrations can reuse them).
 # Per-backend features are activated by this crate's matching features below.
 vti-secrets = { path = "../vti-secrets", version = "0.1" }
-vta-sdk = { path = "../vta-sdk", version = "0.19", features = ["didcomm", "sealed-transfer", "provision-integration", "openapi", "crypto-provider"] }
+vta-sdk = { path = "../vta-sdk", version = "0.19", features = ["didcomm", "sealed-transfer", "provision-integration", "openapi", "crypto-provider", "acl-setup"] }
 # DID-VM-resolved WebAuthn assertion verifier — drives the new
 # `vta/auth/passkey-login-{start,finish}/1.0` trust-task handlers.
 # Distinct from `webauthn-rs` (which drives the passkey *enrolment*

--- a/vta-service/src/config.rs
+++ b/vta-service/src/config.rs
@@ -570,6 +570,7 @@ impl AppConfig {
                     mediator_url: url,
                     mediator_did: did,
                     mediator_host: None,
+                    setup_acl: false,
                 });
             }
             (Ok(url), Err(_)) => {
@@ -577,6 +578,7 @@ impl AppConfig {
                     mediator_url: String::new(),
                     mediator_did: String::new(),
                     mediator_host: None,
+                    setup_acl: false,
                 });
                 messaging.mediator_url = url;
             }
@@ -585,6 +587,7 @@ impl AppConfig {
                     mediator_url: String::new(),
                     mediator_did: String::new(),
                     mediator_host: None,
+                    setup_acl: false,
                 });
                 messaging.mediator_did = did;
             }

--- a/vta-service/src/operations/backup/mod.rs
+++ b/vta-service/src/operations/backup/mod.rs
@@ -744,6 +744,7 @@ pub async fn apply_import(
                         mediator_url: String::new(),
                         mediator_did: String::new(),
                         mediator_host: None,
+                        setup_acl: false,
                     });
             if let Some(ref url) = payload.config.mediator_url {
                 messaging.mediator_url = url.clone();

--- a/vta-service/src/operations/protocol/enable_didcomm.rs
+++ b/vta-service/src/operations/protocol/enable_didcomm.rs
@@ -262,6 +262,9 @@ async fn persist_didcomm_enabled(
             mediator_url: mediator_endpoint.to_string(),
             mediator_did: mediator_did.to_string(),
             mediator_host: None,
+            // Preserve the existing setup_acl setting if the config already has
+            // a messaging section; otherwise default to false.
+            setup_acl: cfg.messaging.as_ref().is_some_and(|m| m.setup_acl),
         });
         let contents = toml::to_string_pretty(&*cfg)
             .map_err(|e| EnableDidcommError::ConfigPersistence(e.to_string()))?;

--- a/vta-service/src/operations/protocol/list.rs
+++ b/vta-service/src/operations/protocol/list.rs
@@ -271,6 +271,7 @@ mod tests {
             mediator_did: "did:peer:2.MEDIATOR".into(),
             mediator_url: "ws://mediator:7037".into(),
             mediator_host: None,
+            setup_acl: false,
         });
         cfg.config_path = dir.path().join("vta.toml");
         let config = Arc::new(RwLock::new(cfg));

--- a/vta-service/src/operations/protocol/update_didcomm.rs
+++ b/vta-service/src/operations/protocol/update_didcomm.rs
@@ -357,6 +357,9 @@ async fn persist_new_mediator(
             mediator_url: mediator_endpoint.to_string(),
             mediator_did: mediator_did.to_string(),
             mediator_host: None,
+            // Preserve the existing setup_acl setting if the config already has
+            // a messaging section; otherwise default to false.
+            setup_acl: cfg.messaging.as_ref().is_some_and(|m| m.setup_acl),
         });
         let contents = toml::to_string_pretty(&*cfg)
             .map_err(|e| UpdateDidcommError::ConfigPersistence(e.to_string()))?;

--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -42,6 +42,7 @@ use affinidi_messaging_didcomm_service::{
 use affinidi_tdk_common::profiles::TDKProfile;
 #[cfg(feature = "didcomm")]
 use tokio_util::sync::CancellationToken;
+use vta_sdk::acl_setup;
 
 /// TEE context passed by the caller (main.rs or vta-enclave).
 /// None when running outside a TEE.
@@ -1047,6 +1048,20 @@ pub async fn run(
                                     endpoint: messaging_config.mediator_url.clone(),
                                 })
                                 .await;
+
+                            // Set the VTA's own ACL on the mediator to accept all messages.
+                            // This happens after the connection succeeds, so we have a live
+                            // DIDComm transport to send the trust task. The ACL setting is
+                            // non-blocking — if it fails, we log a warning and continue.
+                            acl_setup::set_client_acl_on_connection(
+                                &app_state.atm.as_ref().unwrap(),
+                                &config.vta_did.as_ref().unwrap(),
+                                messaging_config.mediator_did.as_str(),
+                                "vta-main",
+                                "vta"
+                            )
+                            .await;
+
                             info!("DIDComm service started");
                             Some(service)
                         }

--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -1051,19 +1051,28 @@ pub async fn run(
 
                             // Set the VTA's own ACL on the mediator to accept all messages.
                             // This happens after the connection succeeds, so we have a live
-                            // DIDComm transport to send the trust task. The ACL setting is
-                            // non-blocking — if it fails, we log a warning and continue.
+                            // transport to send the trust task. The ACL setting is
+                            // fire-and-forget (spawns internally) — startup is not blocked.
+                            // The ACL is keyed on the VTA's DID, so it authorises the account
+                            // for both DIDComm *and* TSP, which share this one mediator socket.
                             // Only runs when `setup_acl = true` in the messaging config
                             // (set during VTA setup for mediators using ExplicitAllow mode).
                             if messaging_config.setup_acl {
-                                acl_setup::set_client_acl_on_connection(
-                                    app_state.atm.as_ref().unwrap(),
-                                    config.vta_did.as_ref().unwrap(),
-                                    messaging_config.mediator_did.as_str(),
-                                    "vta-main",
-                                    "vta",
-                                )
-                                .await;
+                                if let Some(atm) = app_state.atm.as_ref() {
+                                    acl_setup::set_client_acl_on_connection(
+                                        atm,
+                                        vta_did,
+                                        messaging_config.mediator_did.as_str(),
+                                        "vta-main",
+                                        "vta",
+                                    )
+                                    .await;
+                                } else {
+                                    warn!(
+                                        "setup_acl = true but no ATM available; \
+                                         skipping mediator ACL provisioning"
+                                    );
+                                }
                             }
 
                             info!("DIDComm service started");

--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -1053,14 +1053,18 @@ pub async fn run(
                             // This happens after the connection succeeds, so we have a live
                             // DIDComm transport to send the trust task. The ACL setting is
                             // non-blocking — if it fails, we log a warning and continue.
-                            acl_setup::set_client_acl_on_connection(
-                                app_state.atm.as_ref().unwrap(),
-                                config.vta_did.as_ref().unwrap(),
-                                messaging_config.mediator_did.as_str(),
-                                "vta-main",
-                                "vta",
-                            )
-                            .await;
+                            // Only runs when `setup_acl = true` in the messaging config
+                            // (set during VTA setup for mediators using ExplicitAllow mode).
+                            if messaging_config.setup_acl {
+                                acl_setup::set_client_acl_on_connection(
+                                    app_state.atm.as_ref().unwrap(),
+                                    config.vta_did.as_ref().unwrap(),
+                                    messaging_config.mediator_did.as_str(),
+                                    "vta-main",
+                                    "vta",
+                                )
+                                .await;
+                            }
 
                             info!("DIDComm service started");
                             Some(service)

--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -1054,11 +1054,11 @@ pub async fn run(
                             // DIDComm transport to send the trust task. The ACL setting is
                             // non-blocking — if it fails, we log a warning and continue.
                             acl_setup::set_client_acl_on_connection(
-                                &app_state.atm.as_ref().unwrap(),
-                                &config.vta_did.as_ref().unwrap(),
+                                app_state.atm.as_ref().unwrap(),
+                                config.vta_did.as_ref().unwrap(),
                                 messaging_config.mediator_did.as_str(),
                                 "vta-main",
-                                "vta"
+                                "vta",
                             )
                             .await;
 

--- a/vta-service/src/setup/from_toml.rs
+++ b/vta-service/src/setup/from_toml.rs
@@ -360,6 +360,10 @@ pub enum MessagingInput {
         did: String,
         #[serde(default)]
         mediator_host: Option<String>,
+        /// Automatically provision a per-DID allow-all ACL on the mediator
+        /// after the DIDComm connection is established. Defaults to `false`.
+        #[serde(default)]
+        setup_acl: bool,
     },
     /// Mint a new mediator DID using the built-in `didcomm-mediator`
     /// template. The mediator gets its own trust context (default name
@@ -394,6 +398,10 @@ pub enum MessagingInput {
     /// `url` and cannot be overridden here; `WS_URL` comes from the
     /// `ws_url` field above (or its `url`-derived default), so setting
     /// `WS_URL` in `template_vars` has no effect.
+    ///
+    /// `setup_acl` — when `true`, the VTA automatically provisions a
+    /// per-DID allow-all ACL on the mediator after connecting. Required
+    /// when the mediator uses `ExplicitAllow` mode. Defaults to `false`.
     CreateMediator {
         #[serde(default = "default_mediator_context")]
         context: String,
@@ -406,6 +414,8 @@ pub enum MessagingInput {
         mediator_host: Option<String>,
         #[serde(default)]
         template_vars: HashMap<String, serde_json::Value>,
+        #[serde(default)]
+        setup_acl: bool,
     },
 }
 
@@ -624,10 +634,15 @@ pub async fn apply_inputs(
     // 10. Messaging.
     let messaging = match &inputs.messaging {
         MessagingInput::Skip => None,
-        MessagingInput::Existing { did, mediator_host } => Some(MessagingConfig {
+        MessagingInput::Existing {
+            did,
+            mediator_host,
+            setup_acl,
+        } => Some(MessagingConfig {
             mediator_url: String::new(),
             mediator_did: did.clone(),
             mediator_host: mediator_host.clone(),
+            setup_acl: *setup_acl,
         }),
         MessagingInput::CreateMediator {
             context,
@@ -636,6 +651,7 @@ pub async fn apply_inputs(
             webvh_url,
             mediator_host,
             template_vars,
+            setup_acl,
         } => {
             let _med_ctx =
                 create_seed_context(&contexts_ks, context, "DIDComm Messaging Mediator").await?;
@@ -697,6 +713,7 @@ pub async fn apply_inputs(
                 mediator_url: url.clone(),
                 mediator_did,
                 mediator_host: mediator_host.clone(),
+                setup_acl: *setup_acl,
             })
         }
     };
@@ -1923,6 +1940,75 @@ mod tests {
             other => panic!("expected Existing, got {other:?}"),
         }
         validate_inputs(&inputs).expect("Existing+mediator_host should validate");
+    }
+
+    /// `setup_acl` is optional and defaults to `false` when absent — back-compat
+    /// for existing configs that predate the field.
+    #[test]
+    fn setup_acl_defaults_to_false() {
+        let raw = r#"
+            config_path = "/tmp/vta-test/config.toml"
+            data_dir    = "/tmp/vta-test/data"
+            public_url  = "https://trust.example.com"
+
+            [secrets]
+            backend = "keyring"
+
+            [messaging]
+            kind = "create_mediator"
+            url  = "https://mediator.example.com"
+        "#;
+        let inputs = parse(raw).expect("parses");
+        match &inputs.messaging {
+            MessagingInput::CreateMediator { setup_acl, .. } => {
+                assert!(!setup_acl, "setup_acl must default to false");
+            }
+            other => panic!("expected CreateMediator, got {other:?}"),
+        }
+        validate_inputs(&inputs).expect("absent setup_acl should validate");
+    }
+
+    /// `setup_acl = true` is preserved through parsing and carried into
+    /// `MessagingConfig` — the value in TOML must appear in the final config.
+    #[test]
+    fn setup_acl_true_is_preserved_and_propagates() {
+        use crate::config::MessagingConfig;
+
+        let raw = r#"
+            config_path = "/tmp/vta-test/config.toml"
+            data_dir    = "/tmp/vta-test/data"
+            public_url  = "https://trust.example.com"
+
+            [secrets]
+            backend = "keyring"
+
+            [messaging]
+            kind      = "existing"
+            did       = "did:webvh:scid:mediator.example.com:mediator"
+            setup_acl = true
+        "#;
+        let inputs = parse(raw).expect("parses");
+        let (did, mediator_host, setup_acl) = match &inputs.messaging {
+            MessagingInput::Existing {
+                did,
+                mediator_host,
+                setup_acl,
+            } => (did.clone(), mediator_host.clone(), *setup_acl),
+            other => panic!("expected Existing, got {other:?}"),
+        };
+        assert!(setup_acl, "setup_acl must be true after parsing");
+        validate_inputs(&inputs).expect("setup_acl = true should validate");
+
+        let cfg = MessagingConfig {
+            mediator_url: String::new(),
+            mediator_did: did,
+            mediator_host,
+            setup_acl,
+        };
+        assert!(
+            cfg.setup_acl,
+            "setup_acl must propagate into MessagingConfig"
+        );
     }
 
     #[test]

--- a/vta-service/src/setup/interactive.rs
+++ b/vta-service/src/setup/interactive.rs
@@ -553,7 +553,16 @@ async fn configure_messaging(p: &dyn Prompter) -> Result<MessagingInput, DynErr>
                 }),
             )?;
             let mediator_host = prompt_optional_mediator_host(p)?;
-            Ok(MessagingInput::Existing { did, mediator_host })
+            let setup_acl = p.confirm(
+                "Automatically provision ACL on mediator after connecting? \
+(enable if mediator uses ExplicitAllow mode)",
+                false,
+            )?;
+            Ok(MessagingInput::Existing {
+                did,
+                mediator_host,
+                setup_acl,
+            })
         }
         1 => {
             let context = p
@@ -606,6 +615,12 @@ async fn configure_messaging(p: &dyn Prompter) -> Result<MessagingInput, DynErr>
                 template_vars.insert("ROUTING_KEYS".into(), json!(routing_keys));
             }
 
+            let setup_acl = p.confirm(
+                "Automatically provision ACL on mediator after connecting? \
+(enable if mediator uses ExplicitAllow mode)",
+                false,
+            )?;
+
             Ok(MessagingInput::CreateMediator {
                 context,
                 url,
@@ -613,6 +628,7 @@ async fn configure_messaging(p: &dyn Prompter) -> Result<MessagingInput, DynErr>
                 webvh_url: Some(webvh_url),
                 mediator_host,
                 template_vars,
+                setup_acl,
             })
         }
         _ => Ok(MessagingInput::Skip),
@@ -1143,6 +1159,7 @@ mod tests {
             text("https://dids.example.com/mediator"), // mediator DID URL (split host)
             text(""),                                  // mediator host (skip)
             text(""),                                  // routing keys (skip)
+            Answer::Bool(false),                       // setup_acl (disable)
             Answer::Index(1),                          // VTA DID = did:key
         ];
         let p = ScriptedPrompter::new(answers);
@@ -1185,6 +1202,7 @@ mod tests {
             url       = "https://mediator.example.com"
             ws_url    = "wss://mediator.example.com/ws"
             webvh_url = "https://dids.example.com/mediator"
+            setup_acl = false
 
             [vta_did]
             kind = "create_did_key"

--- a/vta-service/src/trust_tasks/policy_gate.rs
+++ b/vta-service/src/trust_tasks/policy_gate.rs
@@ -694,6 +694,7 @@ mod tests {
                 mediator_url: String::new(),
                 mediator_did: MEDIATOR.into(),
                 mediator_host: None,
+                setup_acl: false,
             });
         }
         crate::policy::storage::store_policy(

--- a/vta-service/tests/api_integration.rs
+++ b/vta-service/tests/api_integration.rs
@@ -377,6 +377,7 @@ async fn didcomm_status_returns_mediator_and_websocket_state_when_enabled() {
             mediator_url: "wss://mediator.example.com".into(),
             mediator_did: "did:peer:2.med".into(),
             mediator_host: None,
+            setup_acl: false,
         });
     }
     let token = ctx.auth_token("did:key:z6MkTest", "admin", vec![]).await;
@@ -3191,6 +3192,7 @@ async fn enable_didcomm_already_enabled_returns_409_with_suggested_fix() {
             mediator_url: "wss://mediator.example.com".into(),
             mediator_did: "did:peer:2.med".into(),
             mediator_host: None,
+            setup_acl: false,
         });
     }
     let (status, body) = app

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.11.2"
+version = "0.11.3"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vtc-service/src/config.rs
+++ b/vtc-service/src/config.rs
@@ -925,6 +925,7 @@ impl AppConfig {
                     mediator_url: url,
                     mediator_did: did,
                     mediator_host: None,
+                    setup_acl: false,
                 });
             }
             (Ok(url), Err(_)) => {
@@ -932,6 +933,7 @@ impl AppConfig {
                     mediator_url: String::new(),
                     mediator_did: String::new(),
                     mediator_host: None,
+                    setup_acl: false,
                 });
                 messaging.mediator_url = url;
             }
@@ -940,6 +942,7 @@ impl AppConfig {
                     mediator_url: String::new(),
                     mediator_did: String::new(),
                     mediator_host: None,
+                    setup_acl: false,
                 });
                 messaging.mediator_did = did;
             }

--- a/vtc-service/src/setup/wizard.rs
+++ b/vtc-service/src/setup/wizard.rs
@@ -557,6 +557,7 @@ fn prompt_messaging(vta_mediator: Option<String>) -> Result<Option<MessagingConf
         mediator_url: String::new(),
         mediator_did,
         mediator_host: None,
+        setup_acl: false,
     }))
 }
 

--- a/vtc-service/src/test_support.rs
+++ b/vtc-service/src/test_support.rs
@@ -255,6 +255,7 @@ impl TestVtcBuilder {
                 mediator_url: String::new(),
                 mediator_did: mediator_did.clone(),
                 mediator_host: None,
+                setup_acl: false,
             });
         }
 

--- a/vti-common/Cargo.toml
+++ b/vti-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-common"
 description = "Shared server-side infrastructure for VTA and VTC services"
 readme = "README.md"
-version = "0.11.4"
+version = "0.11.5"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vti-common/src/config.rs
+++ b/vti-common/src/config.rs
@@ -78,6 +78,12 @@ pub struct MessagingConfig {
     /// Not used by the VTA itself (which connects via the local vsock proxy).
     #[serde(default)]
     pub mediator_host: Option<String>,
+    /// Automatically provision a per-DID allow-all ACL on the mediator after
+    /// establishing the DIDComm connection. Required when the mediator uses
+    /// `ExplicitAllow` mode; harmless (and default-off) with `ExplicitDeny`.
+    /// Set `setup_acl = true` during setup to enable. Defaults to `false`.
+    #[serde(default)]
+    pub setup_acl: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
## Problem

Mediators configured with **`ExplicitAllow`** require DID-level ACL entries before a DID can communicate through the mediator.

VTA and PNM currently do not create these ACLs automatically. As a result, DIDComm communication fails when connecting through mediators that enforce explicit allow policies, because the required ACLs are not present.

## Solution

Adopt the deployment model where VTA/PNM use **`ExplicitDeny`** and automatically create DID-level ACLs whenever a DIDComm connection is established.

This removes the need for manual ACL setup and ensures VTA, PNM, and other SDK consumers can operate correctly in environments where mediator ACL enforcement is enabled.

## Changes

### vta-sdk

#### New `acl-setup` feature

The feature provides automatic ACL provisioning for DIDComm connections while keeping the functionality opt-in for SDK consumers.

#### `acl_setup.rs` (new)

Introduces shared ACL provisioning logic:

* Hashes the connecting DID using SHA-256.
* Creates an allow-all `MediatorAcl`.
* Calls `atm.trust_tasks().acl_set()` to provision the ACL.
* Performs the operation in a fire-and-forget Tokio task so connection establishment is not blocked.

#### `didcomm_session.rs`

In `connect_with_secrets()`, ACL provisioning is triggered automatically after the WebSocket transport is enabled:
When `acl-setup` is enabled, every DIDComm connection automatically provisions the corresponding mediator ACL.

### PNM / CNM CLI

Enabled the SDK's `acl-setup` feature in the CLI feature configuration.

As a result:

* DIDComm connections automatically provision mediator ACLs.
* No manual ACL configuration is required.
* Existing CLI workflows remain unchanged.

### vta-service

Enabled and integrated the SDK's shared `acl-setup` functionality.
VTA now provisions the required mediator ACL after establishing its DIDComm listener connection during startup.

ACL provisioning is now **opt-in via config**: a `setup_acl` boolean field in the `[messaging]` section of `config.toml` (and in the `vta setup` wizard / `--from <toml>` schema) controls whether the VTA provisions its per-DID ACL on connect. Defaults to `false`. Existing configs are unaffected.

## Result

With these changes:

* DID-level ACLs are provisioned automatically whenever DIDComm connections are established  (PNM/CNM always; VTA when `setup_acl = true`).
* VTA and PNM can operate correctly with mediators enforcing ACL policies.
* Manual ACL configuration is no longer required.
* ACL provisioning logic is centralized in vta-sdk and reused by VTA and CLI consumers.