### PR TITLE
feat(vta-service): tell the approver which site asked

### DIFF
--- a/vta-service/src/policy/input.rs
+++ b/vta-service/src/policy/input.rs
@@ -27,6 +27,27 @@ pub fn subject_of(payload: &Value) -> Option<String> {
     first_string(payload, SUBJECT_FIELDS).map(str::to_string)
 }
 
+/// Framework `ext` key under which an enrolled consumer records the origin of the
+/// page that proposed a task. Written by the *device*, from the value its runtime
+/// attested — never by the page about itself.
+pub const ORIGIN_EXT_KEY: &str = "openvtc.origin";
+
+/// The web origin that proposed this task, if it came from a relying party.
+///
+/// Read from `payload.ext`, which means it is inside the payload digest: the
+/// origin an approver is shown is bound to the payload that executes, and cannot
+/// be swapped after the approval. It is only as trustworthy as the enrolled
+/// device that stamped it — which is exactly the trust the VTA already places in
+/// that device by authenticating it, and no more.
+pub fn origin_of(payload: &Value) -> Option<String> {
+    payload
+        .get("ext")
+        .and_then(|e| e.get(ORIGIN_EXT_KEY))
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+}
+
 fn first_string<'a>(payload: &'a Value, fields: &[&str]) -> Option<&'a str> {
     fields
         .iter()

--- a/vta-service/src/trust_tasks/policy_gate.rs
+++ b/vta-service/src/trust_tasks/policy_gate.rs
@@ -327,6 +327,11 @@ async fn consent_gate(
 
     let class = super::class_for(type_uri).unwrap_or_else(crate::policy::TaskClass::floor);
     let subject = crate::policy::input::subject_of(&doc.payload);
+    // The page that proposed this, when one did. Stamped into `payload.ext` by the
+    // enrolled device from the origin its browser attested — so the approver is
+    // told *which site* is asking, and told it by the only party in the chain with
+    // any standing to say.
+    let origin = crate::policy::input::origin_of(&doc.payload);
     let requests = match super::consent_request::mint_signed_requests(
         state,
         &pending,
@@ -334,7 +339,7 @@ async fn consent_gate(
         class,
         &effects,
         subject.as_deref(),
-        None,
+        origin.as_deref(),
     )
     .await
     {
@@ -614,6 +619,74 @@ mod tests {
             "a handler with no dry-run yields no effects"
         );
         assert_eq!(req["payload"]["taskType"], serde_json::json!(UNGATED_URI));
+    }
+
+    /// The approver is told which site is asking — and told it by the device,
+    /// which is the only party in the chain with any standing to say.
+    ///
+    /// The origin rides in `payload.ext`, so it is inside the digest the approver
+    /// signs: the site shown to the human is bound to the payload that executes
+    /// and cannot be swapped after the fact.
+    #[tokio::test]
+    async fn the_consent_request_names_the_origin_that_proposed_the_task() {
+        let (state, _dir) = crate::test_support::build_signing_test_app_state().await;
+        let auth = crate::test_support::super_admin_claims();
+
+        let mut d = doc(UNGATED_URI);
+        d.payload["ext"] = json!({ "openvtc.origin": "https://control.example.com" });
+
+        {
+            let mut cfg = state.config.write().await;
+            cfg.policy.enforcement = true;
+            cfg.policy
+                .approver_sets
+                .insert("ops".into(), vec!["did:key:zApprover".into()]);
+        }
+        crate::policy::storage::store_policy(
+            &state.policy_ks,
+            &module("consent", 0, REQUIRE_CONSENT),
+        )
+        .await
+        .unwrap();
+
+        let outcome = policy_gate(&state, &auth, UNGATED_URI, &d).await.unwrap();
+        let body: Value = serde_json::from_slice(&outcome.body).unwrap();
+        let req = &body.pointer("/payload/details/consentRequests").unwrap()[0];
+
+        assert_eq!(
+            req["payload"]["origin"],
+            json!("https://control.example.com"),
+            "the approver must be able to see which site asked"
+        );
+    }
+
+    /// A task nobody proposed from a page carries no origin — and we do not invent
+    /// one. An origin the approver cannot rely on is worse than none: it invites
+    /// them to weigh a fact that is not a fact.
+    #[tokio::test]
+    async fn a_task_with_no_page_behind_it_carries_no_origin() {
+        let (state, _dir) = crate::test_support::build_signing_test_app_state().await;
+        let auth = crate::test_support::super_admin_claims();
+        let d = doc(UNGATED_URI);
+
+        {
+            let mut cfg = state.config.write().await;
+            cfg.policy.enforcement = true;
+            cfg.policy
+                .approver_sets
+                .insert("ops".into(), vec!["did:key:zApprover".into()]);
+        }
+        crate::policy::storage::store_policy(
+            &state.policy_ks,
+            &module("consent", 0, REQUIRE_CONSENT),
+        )
+        .await
+        .unwrap();
+
+        let outcome = policy_gate(&state, &auth, UNGATED_URI, &d).await.unwrap();
+        let body: Value = serde_json::from_slice(&outcome.body).unwrap();
+        let req = &body.pointer("/payload/details/consentRequests").unwrap()[0];
+        assert!(req["payload"].get("origin").is_none());
     }
 
     /// The approver named by `excludeRequester` is dropped before we ask, rather


### PR DESCRIPTION
The `task-consent/request` has carried an optional `origin` since the spec landed, and the gate has been sending `None`. The relay now stamps it (OpenVTC/vta-browser-plugin#84), so read it.

## Where it comes from, and why that matters

`payload.ext["openvtc.origin"]`, written by the **enrolled device** from the origin its browser attested — never by the page about itself.

Riding in the payload rather than beside it means it is **inside the digest the approver signs**. The site shown to the human is bound to the payload that executes, and cannot be swapped after the approval.

It is only as trustworthy as the device that stamped it — which is exactly the trust the VTA already places in that device by authenticating it, and no more. That is the honest ceiling here, and it is worth being clear about: this tells an approver which site asked *according to their own device*, which is a different and weaker claim than a cryptographic binding to the site itself. It is still worth having, because the alternative is telling them nothing.

## No invented origins

A task with no page behind it (a CLI, a scheduled job, another agent) carries no origin, and the gate does not fabricate one. An origin an approver cannot rely on is worse than none: it invites them to weigh a fact that is not a fact.

## Tests

- the consent request names the origin that proposed the task
- a task with no page behind it carries no origin

`cargo fmt --check`, `cargo clippy --workspace --features webvh -- -D warnings`, 1168 `vta-service` tests — all clean.