### PR TITLE
fix(vta-service): a webvh document update is destructive

### DIFF
--- a/vta-service/src/operations/did_webvh/update/mod.rs
+++ b/vta-service/src/operations/did_webvh/update/mod.rs
@@ -1990,6 +1990,72 @@ mod pre_rotation_e2e_tests {
         assert_eq!(plan.state_pin().version, plan.prior_version_id);
     }
 
+    /// The classification must agree with what the handler actually does.
+    ///
+    /// This is "code decides, not the registry" turned into a test. The planner
+    /// runs the real handler and reports a key rotation. SPEC §7.3 item 13 calls
+    /// rotation of a sole controlling key *authority-shifting*, and
+    /// authority-shifting is `destructive`. So if the plan says the key rotates,
+    /// the compiled class must say `destructive` — otherwise the value the policy
+    /// engine gates on is contradicted by the code it is gating.
+    ///
+    /// It matters concretely: an approver's device demands a typed digest match
+    /// only for a `destructive` task. Under-classifying this one meant the
+    /// flagship flow — edit a DID document — got a tap where it should have got a
+    /// ceremony.
+    #[tokio::test]
+    async fn the_compiled_class_agrees_with_the_rotation_the_plan_reports() {
+        let (ts, seed_store) = setup("ctx-class").await;
+        let cfg = ts_app_config(&ts);
+        let auth = admin_auth();
+        let resolver = build_resolver().await;
+        let bridge = dummy_bridge();
+        let auth_locks = crate::operations::did_webvh::WebvhAuthLocks::new();
+        let deps = webvh_deps(&ts, &seed_store, &resolver, &bridge, &auth_locks);
+
+        let (did, scid) = create_did(
+            &ts,
+            &seed_store,
+            &cfg,
+            &auth,
+            &resolver,
+            &bridge,
+            "ctx-class",
+            0,
+        )
+        .await;
+        sleep(VERSION_TIME_GAP).await;
+
+        let plan = plan_did_webvh_update(
+            &deps,
+            &auth,
+            &scid,
+            UpdateDidWebvhOptions {
+                document: Some(doc_patch(&did, "class")),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("plan");
+
+        assert!(
+            plan.rotates_update_keys(),
+            "a document change rotates the update key — if that ever stops being \
+             true, the classification should be revisited, not this assert"
+        );
+
+        let class = crate::trust_tasks::class_for(vta_sdk::trust_tasks::TASK_WEBVH_DIDS_UPDATE_1_0)
+            .expect("the update task is in the dispatch table");
+
+        assert_eq!(
+            class.side_effects,
+            crate::policy::SideEffectLevel::Destructive,
+            "the plan says this rotates the DID's controlling key, which SPEC §7.3 \
+             calls authority-shifting; the compiled class must say so too, or the \
+             policy engine gates on a value the code contradicts"
+        );
+    }
+
     /// An update that changes no document, on a DID with no pre-rotation,
     /// rotates no key — so the plan must not claim it does.
     #[tokio::test]

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -821,9 +821,20 @@ dispatch_table! {
     #[cfg(feature = "webvh")]
     vta_sdk::trust_tasks::TASK_WEBVH_DIDS_DELETE_1_0 => webvh::handle_dids_delete
         [ Destructive None false ],
+    // Destructive, not mutating — and the line below is why. A document update
+    // ROTATES the DID's update key: the key that could authorize changes before
+    // this entry cannot afterwards. SPEC §7.3 item 13 names exactly that —
+    // "rotation of a sole controlling key" — as authority-shifting, and
+    // authority-shifting is destructive.
+    //
+    // `dids/rotate-keys` two lines down has always been Destructive. It rotates
+    // the same key. Classing an update as merely `Mutating` said that the same
+    // effect was destructive when you asked for it and recoverable when you got
+    // it as a side effect, which is precisely backwards: the side effect is the
+    // dangerous one, because it is the one nobody asked for.
     #[cfg(feature = "webvh")]
     vta_sdk::trust_tasks::TASK_WEBVH_DIDS_UPDATE_1_0 => webvh::handle_dids_update
-        [ Mutating None false ],
+        [ Destructive None false ],
     #[cfg(feature = "webvh")]
     vta_sdk::trust_tasks::TASK_WEBVH_DIDS_ROTATE_KEYS_1_0 => webvh::handle_dids_rotate_keys
         [ Destructive None false ],


### PR DESCRIPTION
`webvh/dids/update` was classed `[ Mutating None false ]`.

**It rotates the DID's update key.** The key that could authorize changes before the entry cannot afterwards.

SPEC §7.3 item 13 names exactly that — *"rotation of a sole controlling key"* — as an **authority-shifting** effect, and authority-shifting is `destructive`.

## The inconsistency was two lines apart

`dids/rotate-keys` has always been `Destructive`. **It rotates the same key.**

Classing an update as merely `Mutating` said the same effect was destructive when you *asked* for it and recoverable when you got it as a *side effect* — which is precisely backwards. The side effect is the dangerous one, because it's the one nobody asked for. It's the entire reason the dry-run exists.

## This is not academic

An approver's device demands a **typed digest match** only for a `destructive` task; everything else gets a tap.

Under-classifying this one meant the flagship flow — edit a DID document, approve it on your phone — got the **tap**. The cross-device match ceremony, the only check in this design that survives a compromised consent surface, **never fired in the one flow it was built for.**

## The test ties the class to the code

Rather than to a claim about it. The planner dry-runs the real handler, reports that it rotates the update key, and the test asserts the compiled class agrees:

```rust
assert!(plan.rotates_update_keys());
assert_eq!(class_for(TASK_WEBVH_DIDS_UPDATE_1_0).side_effects, Destructive);
```

If the policy engine is going to gate on a value, that value must not be contradicted by the code it is gating. Verified the test fails against the old `Mutating` classification.

## ⚠️ Operator note — behaviour change

This changes behaviour for anyone whose Rego keys on `request.sideEffects`. A policy that required consent only for `destructive` **now catches document updates**.

That is the intended reading — a document update really does rotate your controlling key — but it *is* a change: an update that previously executed silently may now ask for approval.

`cargo fmt --check`, `cargo clippy --workspace --features webvh -- -D warnings`, 1169 tests — clean.