### PR TITLE
fix(vta-sdk): the webvh update body must read camelCase from the wire

### DIFF
--- a/vta-sdk/src/protocols/did_management/update.rs
+++ b/vta-sdk/src/protocols/did_management/update.rs
@@ -14,7 +14,21 @@ use serde_json::Value;
 /// `witnesses` is carried as opaque JSON to keep this crate free of a
 /// `didwebvh-rs` dependency. The vta-service handler deserializes it
 /// into the library's `Witnesses` enum at intake.
+/// Caller-supplied parameters for a webvh DID update.
+///
+/// **camelCase on the wire.** Every other Trust-Task payload in this SDK is
+/// camelCase and so is every published spec; this type was the outlier, and the
+/// cost of that was not theoretical. A caller sending the framework-conventional
+/// `expectedVersionId` had it **silently discarded** — serde matched no field and
+/// nothing rejected the unknown member — so the optimistic-concurrency
+/// precondition simply never applied, and a concurrent update was overwritten by
+/// a chain in which every signature still verified. That is the exact lost-update
+/// this field exists to prevent.
+///
+/// The snake_case names remain accepted as aliases, so callers written against
+/// the old shape keep working.
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct UpdateDidWebvhBody {
     /// New DID document. `None` = keep existing. When `Some`, the VTA
@@ -24,7 +38,7 @@ pub struct UpdateDidWebvhBody {
     pub document: Option<Value>,
     /// Override pre-rotation count. `None` = keep current; `Some(0)`
     /// disables pre-rotation; `Some(n)` uses `n` new commitments.
-    #[serde(default)]
+    #[serde(default, alias = "pre_rotation_count")]
     pub pre_rotation_count: Option<u32>,
     /// New witness configuration as raw JSON (matches the library's
     /// `Witnesses` enum on the wire). The vta-service handler
@@ -50,16 +64,20 @@ pub struct UpdateDidWebvhBody {
     ///
     /// `None` (default) preserves prior behaviour for scripted callers
     /// that don't care about concurrent edits.
-    #[serde(default)]
+    #[serde(default, alias = "expected_version_id")]
     pub expected_version_id: Option<String>,
 }
 
 /// Caller-supplied parameters for a rotate-keys call.
+///
+/// camelCase on the wire, snake_case accepted as an alias — see
+/// [`UpdateDidWebvhBody`].
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct RotateDidWebvhKeysBody {
     /// Override pre-rotation count for the new commitment set.
-    #[serde(default)]
+    #[serde(default, alias = "pre_rotation_count")]
     pub pre_rotation_count: Option<u32>,
     /// Operator-facing audit label.
     #[serde(default)]
@@ -182,5 +200,69 @@ mod tests {
         }"#;
         let r: UpdateDidWebvhResultBody = serde_json::from_str(legacy).unwrap();
         assert!(!r.serverless);
+    }
+}
+
+#[cfg(test)]
+mod casing_tests {
+    use super::*;
+
+    /// The bug this casing fixes, pinned.
+    ///
+    /// `expectedVersionId` is the optimistic-concurrency precondition: it is what
+    /// stops a `get → edit → save` cycle from overwriting somebody else's edit
+    /// with a chain that is structurally valid but based on a stale read.
+    ///
+    /// Before this, the field was snake_case only. A caller sending the
+    /// framework-conventional camelCase had it **silently discarded** — serde
+    /// matched no field, and with no `deny_unknown_fields` nothing rejected the
+    /// unknown member. The precondition never applied. The lost update it exists
+    /// to prevent happened anyway, and every signature in the resulting chain
+    /// still verified.
+    ///
+    /// A silently-ignored safety precondition is worse than an absent one: it
+    /// reads, in the caller's source, as though the danger were handled.
+    #[test]
+    fn the_concurrency_precondition_is_read_from_the_wire() {
+        let camel: UpdateDidWebvhBody =
+            serde_json::from_str(r#"{"expectedVersionId":"3-QmPrior"}"#).expect("camelCase parses");
+        assert_eq!(
+            camel.expected_version_id.as_deref(),
+            Some("3-QmPrior"),
+            "the framework's camelCase is the wire form and MUST reach the field"
+        );
+
+        // Callers written against the old shape keep working.
+        let snake: UpdateDidWebvhBody =
+            serde_json::from_str(r#"{"expected_version_id":"3-QmPrior"}"#)
+                .expect("snake_case still parses");
+        assert_eq!(snake.expected_version_id.as_deref(), Some("3-QmPrior"));
+    }
+
+    #[test]
+    fn pre_rotation_count_reads_from_either_casing() {
+        let camel: UpdateDidWebvhBody =
+            serde_json::from_str(r#"{"preRotationCount":2}"#).expect("camelCase");
+        assert_eq!(camel.pre_rotation_count, Some(2));
+
+        let snake: UpdateDidWebvhBody =
+            serde_json::from_str(r#"{"pre_rotation_count":2}"#).expect("snake_case");
+        assert_eq!(snake.pre_rotation_count, Some(2));
+
+        let rotate: RotateDidWebvhKeysBody =
+            serde_json::from_str(r#"{"preRotationCount":3}"#).expect("camelCase");
+        assert_eq!(rotate.pre_rotation_count, Some(3));
+    }
+
+    /// Single-word members are identical in both casings — no alias needed, and
+    /// this pins that they were not broken by the rename.
+    #[test]
+    fn single_word_members_are_unaffected() {
+        let b: UpdateDidWebvhBody =
+            serde_json::from_str(r#"{"document":{"id":"did:webvh:x"},"ttl":600,"label":"l"}"#)
+                .expect("parses");
+        assert!(b.document.is_some());
+        assert_eq!(b.ttl, Some(600));
+        assert_eq!(b.label.as_deref(), Some("l"));
     }
 }


### PR DESCRIPTION
`UpdateDidWebvhBody` carried no `rename_all`, so serde expected **snake_case**: `expected_version_id`, `pre_rotation_count`.

Every other Trust-Task payload in this SDK is camelCase (`servers.rs`, `auth.rs`, `credentials`), and so is every published spec. This type was the outlier.

## The cost was not theoretical

A caller sending the framework-conventional `expectedVersionId` had it **silently discarded** — serde matched no field, and with no `deny_unknown_fields` nothing rejected the unknown member.

So the **optimistic-concurrency precondition never applied.** A concurrent update was overwritten, and every signature in the resulting chain still verified. That is precisely the lost update the field exists to prevent.

`did-hosting-ui` sends camelCase. Its delegated DID-update path (affinidi-webvh-service#77) has therefore been publishing **with no concurrency protection at all** — while its own source, and my PR description for it, read as though the danger were handled.

> A silently-ignored safety precondition is worse than an absent one. An absent one you notice.

## The fix

camelCase is now the wire form for `UpdateDidWebvhBody` and `RotateDidWebvhKeysBody`, with the snake_case names kept as serde **aliases** so callers written against the old shape keep working. Single-word members (`document`, `ttl`, `label`, `witnesses`, `watchers`) are identical either way.

Three tests pin it: camelCase reaches the field, snake_case still does, and the single-word members were not broken by the rename.

## Left alone, deliberately

`UpdateDidWebvhResultBody` is still snake_case on the wire (`new_version_id`, `update_keys_count`, …). Changing a **response** shape is a break for whoever reads it, and that deserves its own change rather than a ride along with a bug fix. It is inconsistent and should follow.

## Why this matters beyond the bug

This is exactly the class of defect that closed payload schemas exist to catch. The member was not *wrong* — it was **unrecognised**, and nothing was watching for that. It's the third bug found in the delegated-update path by checking the code against the design rather than against the PR description, and it's the strongest argument yet for the schema validation now in progress.

`cargo fmt --check`, `cargo clippy --workspace --features webvh -- -D warnings`, 1172 `vta-service` + 171 `vta-sdk` tests — clean.