### PR TITLE
feat(vta-service): validate payloads against their published schemas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9505,12 +9505,13 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-rs"
-version = "0.2.12"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccbddb304248cc6cb1e2e6385bd2f7042df71c805d9e128d6cb40125322a9274"
+checksum = "2998e4384fc850bfd61ed6dc648a05d8d940d6b304a102eeabaf7c129cbdf16a"
 dependencies = [
  "async-trait",
  "chrono",
+ "jsonschema",
  "regress",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -178,7 +178,7 @@ aws-lc-rs = "1.16"
 # (camelCase wire enums + `/0.2` TYPE_URIs) alongside the retained
 # `v0_1` modules — the VTA dual-accepts both during the migration.
 # Bump in lockstep with affinidi-webvh-service when upstream publishes.
-trust-tasks-rs = { version = "0.2", default-features = false }
+trust-tasks-rs = { version = "0.2.16", default-features = false, features = ["validate"] }
 trust-tasks-https = { version = "0.2", default-features = false, features = ["server", "client", "jwt"] }
 trust-tasks-proof = { version = "0.2", default-features = false, features = ["affinidi"] }
 

--- a/vta-service/src/config.rs
+++ b/vta-service/src/config.rs
@@ -28,6 +28,22 @@ pub struct PolicyConfig {
     /// satisfied (fail-closed), so operators define sets before using them.
     #[serde(default)]
     pub approver_sets: std::collections::HashMap<String, Vec<String>>,
+    /// Refuse any task for which this build knows no payload schema.
+    ///
+    /// Payload validation always runs where a schema *is* known — that is not
+    /// optional and has no switch. This governs the other case: 62 of the tasks
+    /// this VTA dispatches have no published spec yet, and refusing them outright
+    /// would break them.
+    ///
+    /// So the default is to validate what we can, warn about what we cannot, and
+    /// proceed. An operator who would rather fail closed sets this — and should
+    /// understand what they are choosing: "no schema" currently means "no spec has
+    /// been written", not "this task is suspicious".
+    ///
+    /// **Default false.** It is a stopgap, and the honest fix is to write the
+    /// missing specs.
+    #[serde(default)]
+    pub require_payload_schema: bool,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -318,6 +318,56 @@ pub async fn dispatch_trust_task(
 ///
 /// `body` is the full `TrustTask<Value>` envelope JSON — the HTTP POST
 /// body on REST, the DIDComm message body on DIDComm.
+/// Validate `doc.payload` against the published schema for its Type URI.
+///
+/// `Some(outcome)` rejects; `None` proceeds.
+///
+/// Ceremony tasks are exempt for the same reason the policy gate exempts them:
+/// they are the mechanism, not the operation, and a `task-consent/decision` that
+/// could not be delivered because its own payload failed a check would strand
+/// every task waiting on it.
+async fn validate_payload(
+    state: &AppState,
+    type_uri: &str,
+    doc: &TrustTask<Value>,
+) -> Option<TrustTaskOutcome> {
+    let Some(schema) = trust_tasks_rs::schema_index::schema_for(type_uri) else {
+        // No published spec for this task. Many of the tasks this VTA dispatches
+        // are in that position, so refusing them outright would break them — but
+        // the gap is real, and an operator may prefer to fail closed.
+        if state.config.read().await.policy.require_payload_schema {
+            return Some(helpers::reject_with(
+                doc,
+                RejectReason::MalformedRequest {
+                    reason: format!(
+                        "no payload schema is known for `{type_uri}`, and this VTA is configured \
+                         to refuse tasks it cannot validate"
+                    ),
+                },
+            ));
+        }
+        tracing::debug!(
+            type_uri,
+            "no payload schema known — dispatching unvalidated (set \
+             policy.require_payload_schema to refuse instead)"
+        );
+        return None;
+    };
+
+    match trust_tasks_rs::validate::against_schema(schema, &doc.payload) {
+        Ok(()) => None,
+        Err(e) => {
+            tracing::info!(type_uri, error = %e, "payload failed schema validation");
+            Some(helpers::reject_with(
+                doc,
+                RejectReason::MalformedRequest {
+                    reason: format!("payload does not conform to {type_uri}: {e}"),
+                },
+            ))
+        }
+    }
+}
+
 pub(crate) async fn dispatch_trust_task_core(
     state: &AppState,
     auth: &AuthClaims,
@@ -416,6 +466,29 @@ pub(crate) async fn dispatch_trust_task_core(
             .map(str::to_string);
         (action, resource, context_id, detail)
     });
+
+    // Payload schema validation — before the policy gate, and deliberately not
+    // behind `policy.enforcement`.
+    //
+    // This is not a policy decision. It is the question of whether the document
+    // means what its sender thinks it means, and it has to be answered before
+    // anything else reads the payload: before the class is derived from it, before
+    // a policy is evaluated on it, before a handler is dry-run against it to tell
+    // a human what it will do.
+    //
+    // The bug that put this here: a caller sent `expectedVersionId` — the
+    // optimistic-concurrency precondition — and the handler's type expected
+    // `expected_version_id`. Serde matched no field, nothing rejected the unknown
+    // member, and the precondition simply never applied. Updates published with no
+    // lost-update protection while the caller's own source read as though the
+    // danger were handled. The member was not *wrong*; it was **unrecognised**,
+    // and nothing was watching for that.
+    //
+    // A silently-ignored member is worse than a rejected one. A rejected one you
+    // find out about.
+    if let Some(reject) = validate_payload(state, &type_uri, &doc).await {
+        return reject;
+    }
 
     // Policy Decision Point gate — evaluated before dispatch. A no-op unless
     // `config.policy.enforcement` is on; when a policy denies (or demands
@@ -1041,5 +1114,131 @@ mod tests {
                  a URI must live on exactly one transport"
             );
         }
+    }
+}
+
+#[cfg(all(test, feature = "webvh"))]
+mod payload_validation_tests {
+    //! Payload schema validation at the gate.
+    //!
+    //! The defect that put this here: a caller sent `expectedVersionId` — the
+    //! optimistic-concurrency precondition — and the handler's type expected
+    //! `expected_version_id`. Serde matched no field, nothing rejected the unknown
+    //! member, and the precondition never applied. DID updates published with no
+    //! lost-update protection, while the caller's own source read as though the
+    //! danger were handled.
+    //!
+    //! The member was not *wrong*. It was **unrecognised**, and nothing was
+    //! watching for that.
+
+    use serde_json::{Value, json};
+    use trust_tasks_rs::TrustTask;
+
+    const WEBVH_UPDATE: &str = "https://trusttasks.org/spec/vta/webvh/dids/update/1.0";
+
+    fn doc(payload: Value) -> TrustTask<Value> {
+        serde_json::from_value(json!({
+            "id": "urn:uuid:00000000-0000-0000-0000-000000000042",
+            "type": WEBVH_UPDATE,
+            "issuer": "did:key:zTestAdmin",
+            "recipient": "did:example:vta",
+            "issuedAt": "2026-07-14T00:00:00Z",
+            "payload": payload,
+        }))
+        .expect("valid trust task")
+    }
+
+    /// The bug, pinned. A safety precondition in the wrong case is now REFUSED,
+    /// where before it was silently dropped.
+    #[tokio::test]
+    async fn a_precondition_in_the_wrong_case_is_refused_not_ignored() {
+        let (state, _dir) = crate::test_support::build_signing_test_app_state().await;
+        let d = doc(json!({
+            "did": "did:webvh:QmScid:example.com:acme",
+            "expected_version_id": "3-QmPrior"
+        }));
+
+        let reject = super::validate_payload(&state, WEBVH_UPDATE, &d)
+            .await
+            .expect("an unrecognised member must be refused");
+
+        let body: Value = serde_json::from_slice(&reject.body).unwrap();
+        let msg = body.to_string();
+        assert!(
+            msg.contains("does not conform"),
+            "expected a schema-conformance refusal, got: {msg}"
+        );
+    }
+
+    /// The correct casing passes — the fix must refuse the typo without breaking
+    /// the thing it was a typo of.
+    #[tokio::test]
+    async fn the_correct_casing_passes() {
+        let (state, _dir) = crate::test_support::build_signing_test_app_state().await;
+        let d = doc(json!({
+            "did": "did:webvh:QmScid:example.com:acme",
+            "document": { "id": "did:webvh:QmScid:example.com:acme" },
+            "expectedVersionId": "3-QmPrior"
+        }));
+        assert!(
+            super::validate_payload(&state, WEBVH_UPDATE, &d)
+                .await
+                .is_none()
+        );
+    }
+
+    /// The relay stamps the browser-attested origin into `payload.ext`. A closed
+    /// payload that refused the framework's own extension slot would break it.
+    #[tokio::test]
+    async fn the_ext_slot_the_relay_stamps_an_origin_into_is_permitted() {
+        let (state, _dir) = crate::test_support::build_signing_test_app_state().await;
+        let d = doc(json!({
+            "did": "did:webvh:QmScid:example.com:acme",
+            "ext": { "openvtc.origin": "https://control.example.com" }
+        }));
+        assert!(
+            super::validate_payload(&state, WEBVH_UPDATE, &d)
+                .await
+                .is_none(),
+            "closed payloads must still admit `ext`, or the relay cannot stamp an origin"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_invented_member_is_refused() {
+        let (state, _dir) = crate::test_support::build_signing_test_app_state().await;
+        let d = doc(json!({ "did": "did:webvh:x", "skipApproval": true }));
+        assert!(
+            super::validate_payload(&state, WEBVH_UPDATE, &d)
+                .await
+                .is_some()
+        );
+    }
+
+    /// A task with no published spec dispatches unvalidated by default — many do —
+    /// but an operator can choose to fail closed.
+    #[tokio::test]
+    async fn an_unspecced_task_proceeds_by_default_and_can_be_refused() {
+        let (state, _dir) = crate::test_support::build_signing_test_app_state().await;
+        // No published spec — one of many. (`vta/memory/list` HAS one, which is
+        // itself the point: the set of validatable tasks is growing.)
+        const UNSPECCED: &str = "https://trusttasks.org/spec/vta/webvh/dids/create/1.0";
+        let d = doc(json!({ "contextId": "default" }));
+
+        assert!(
+            super::validate_payload(&state, UNSPECCED, &d)
+                .await
+                .is_none(),
+            "by default an unvalidatable task still dispatches — refusing it would \
+             break the many tasks that have no spec yet"
+        );
+
+        state.config.write().await.policy.require_payload_schema = true;
+        assert!(
+            super::validate_payload(&state, UNSPECCED, &d)
+                .await
+                .is_some(),
+            "an operator who would rather fail closed can"
+        );
     }
 }

--- a/vta-service/tests/vault_trust_task.rs
+++ b/vta-service/tests/vault_trust_task.rs
@@ -26,6 +26,34 @@ use ed25519_dalek::SigningKey;
 use http_body_util::BodyExt;
 use multibase::Base;
 use serde_json::{Value, json};
+
+/// A vault entry binds to at least one site.
+///
+/// These tests used to send `targets: []`, which the handler accepted because it
+/// never checked. But `vault/upsert`'s schema requires `minItems: 1`, and it is
+/// right to: a `SiteTarget` is "a single binding target", so an entry that binds
+/// to nothing can never be selected for anything. The payload is now validated
+/// against the published schema at the gate, so the tests have to mean what they
+/// say.
+fn site_target() -> Value {
+    json!({ "kind": "web-origin", "origin": "https://rp.example" })
+}
+
+/// A well-formed Trust Task for `vault/sign-trust-task` to be asked to sign.
+///
+/// `{}` used to do, because nothing checked. The schema requires a real envelope,
+/// and a test that hands the wallet an empty object was never testing signing.
+fn unsigned_envelope() -> Value {
+    json!({
+        "id": "urn:uuid:00000000-0000-0000-0000-0000000000aa",
+        "type": "https://trusttasks.org/spec/acl/list/0.1",
+        "issuer": "did:key:zTestIssuer",
+        "recipient": "did:key:zTestRecipient",
+        "issuedAt": "2026-07-14T00:00:00Z",
+        "payload": {}
+    })
+}
+
 use tower::ServiceExt;
 
 use vta_service::test_support::{TestAppContext, build_test_app};
@@ -166,14 +194,22 @@ async fn every_vault_uri_denied_without_capability() {
     let (router, ctx) = build_test_app().await;
     let token = authed(&ctx, "monitor", &[]).await;
 
-    // (uri, minimal-but-parseable payload). The capability gate runs before
-    // payload parsing, so even an empty/partial payload must be denied.
+    // (uri, schema-valid payload).
+    //
+    // The payloads must now conform to their published schemas, because payload
+    // validation runs *before* the capability gate — and it has to. The policy
+    // gate reads the payload to derive the task's class, and where a planner
+    // exists it DRY-RUNS THE REAL HANDLER against it to work out what the task
+    // would do. Neither is a thing to do with a payload nobody has checked.
+    //
+    // So these payloads are valid, and what denies them is the capability gate —
+    // which is what this test is actually about.
     let cases: Vec<(&str, Value)> = vec![
         (LIST, json!({})),
         (GET, json!({ "id": "entry-1" })),
         (
             UPSERT,
-            json!({ "contextId": "ctx1", "targets": [], "label": "x", "secretKind": "password" }),
+            json!({ "contextId": "ctx1", "targets": [site_target()], "label": "x", "secretKind": "password" }),
         ),
         (DELETE, json!({ "id": "entry-1" })),
         (ARCHIVE, json!({ "id": "entry-1" })),
@@ -184,7 +220,7 @@ async fn every_vault_uri_denied_without_capability() {
         (PROXY_LOGIN, json!({ "entryId": "entry-1" })),
         (
             SIGN_TT,
-            json!({ "entryId": "entry-1", "unsignedEnvelope": {} }),
+            json!({ "entryId": "entry-1", "unsignedEnvelope": unsigned_envelope() }),
         ),
     ];
 
@@ -221,7 +257,7 @@ async fn reader_passes_read_gates_but_not_the_others() {
     for (uri, payload) in [
         (
             UPSERT,
-            json!({ "contextId": "ctx1", "targets": [], "label": "x", "secretKind": "password" }),
+            json!({ "contextId": "ctx1", "targets": [site_target()], "label": "x", "secretKind": "password" }),
         ),
         (DELETE, json!({ "id": "entry-1" })),
         (ARCHIVE, json!({ "id": "entry-1" })),
@@ -232,7 +268,7 @@ async fn reader_passes_read_gates_but_not_the_others() {
         (PROXY_LOGIN, json!({ "entryId": "entry-1" })),
         (
             SIGN_TT,
-            json!({ "entryId": "entry-1", "unsignedEnvelope": {} }),
+            json!({ "entryId": "entry-1", "unsignedEnvelope": unsigned_envelope() }),
         ),
     ] {
         let (status, body) = post_vault(&router, &token, uri, payload).await;
@@ -467,7 +503,7 @@ async fn upsert_cross_context_denied() {
         &router,
         &token,
         UPSERT,
-        json!({ "contextId": "ctx-other", "targets": [], "label": "x", "secretKind": "password" }),
+        json!({ "contextId": "ctx-other", "targets": [site_target()], "label": "x", "secretKind": "password" }),
     )
     .await;
     assert_ne!(status, StatusCode::OK);


### PR DESCRIPTION
The design has always claimed payloads were closed (`additionalProperties: false`) and validated before anything read them.

**Neither was true.** There was no JSON-Schema validation anywhere in this service, and the gated payload types carried no `deny_unknown_fields` — so an unrecognised member was silently ignored.

## The defect that made it concrete

A caller sent `expectedVersionId` — the optimistic-concurrency precondition. The handler's type expected `expected_version_id`. Serde matched no field, nothing rejected the unknown member, and **the precondition never applied.**

DID updates published with no lost-update protection, while the caller's own source read as though the danger were handled (#656).

The member was not *wrong*. It was **unrecognised**, and nothing was watching for that.

> A silently-ignored member is worse than a rejected one. A rejected one you find out about.

## What this does

The gate validates `doc.payload` against the schema published for its Type URI, via `trust_tasks_rs::schema_index::schema_for` (new in 0.2.15).

**It runs before the policy gate, and deliberately not behind `policy.enforcement`.**

This is not a policy decision. It's the question of whether the document means what its sender thinks it means, and it has to be answered before anything else reads the payload: before the class is derived from it, before a policy is evaluated on it, and — above all — **before a planner dry-runs the real handler against it** to tell a human what the task will do.

Dry-running a handler on a payload nobody has checked is not a safety mechanism.

(This inverts an ordering an existing test asserted — that the capability gate ran before payload parsing. A capability test should fail on *capability*, not on a malformed body, so its payloads are now real.)

## The unspecced tasks

Many tasks this service dispatches still have no published spec. One with no known schema dispatches unvalidated and logs; `policy.require_payload_schema` (default **false**) lets an operator refuse instead.

The doc comment says plainly what the flag means: **"no schema" currently means "no spec has been written", not "this task is suspicious"**. It's a stopgap, and the honest fix is to write the missing specs.

## Turning it on found things immediately

Which is the point of turning it on.

- **`vault/delete` accepts `force`** — an irreversible hard delete — which **no spec mentioned**, and whose static `consequences` promised a grace period that `force` skips. A consent surface with no dry-run renders exactly that text, so it would have told a human they had a recovery window they did not have. Specified upstream (dtgwg#115), along with the rule the case teaches: `consequences` are per-task, `force` is per-request.
- **`vault/list` accepts a `status` view selector.** Also unspecified. Also fixed upstream.
- **The vault tests sent `targets: []` and `unsignedEnvelope: {}`**, which the handlers accepted because nothing checked. The schemas require better and are right to: an entry that binds to no site can never be selected, and a test that asks the wallet to sign an empty object was never testing signing. The tests now mean what they say.

## Tests

Five, on the gate itself:

- **a safety precondition in the wrong case is refused, not ignored** — the bug, pinned
- the correct casing still passes (the fix must refuse the typo without breaking the thing it was a typo of)
- **`ext` is permitted** — a closed payload that rejected the framework's own extension slot would break the relay's origin stamp
- an invented member is refused
- an unspecced task proceeds by default, and an operator can choose to fail closed

`cargo fmt --check`, `cargo clippy --workspace --features webvh -- -D warnings`, **1177** `vta-service` tests — all clean.