### PR TITLE
fix(vta-service): close the key-derivation race between plan and execute

### DIFF
--- a/vta-service/src/keys/paths.rs
+++ b/vta-service/src/keys/paths.rs
@@ -50,6 +50,28 @@ pub async fn peek_paths(
     Ok((0..count).map(|i| path_at(base, next + i)).collect())
 }
 
+/// Allocate `count` **contiguous** paths in one atomic step, asserting the block
+/// starts at `expected_start` if given.
+///
+/// This is the allocating counterpart to [`peek_paths`], and it is what makes a
+/// plan/apply split *sound* rather than merely plausible. Allocating the paths
+/// one at a time lets a concurrent allocation split the block, and pinning the
+/// counter in a caller that then allocates separately lets one slip in between
+/// the check and the use. Both put keys nobody approved into the chain. Doing the
+/// whole thing under one lock — the assertion and the block allocation together —
+/// is the only way to promise the approver that the keys they saw are the keys
+/// that execute.
+pub async fn allocate_paths(
+    keys_ks: &KeyspaceHandle,
+    base: &str,
+    count: u32,
+    expected_start: Option<u32>,
+) -> Result<Vec<String>, AppError> {
+    let counter_key = format!("path_counter:{base}");
+    let start = counter::allocate_u32_block(keys_ks, &counter_key, count, expected_start).await?;
+    Ok((0..count).map(|i| path_at(base, start + i)).collect())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/vta-service/src/operations/did_webvh/update/keys.rs
+++ b/vta-service/src/operations/did_webvh/update/keys.rs
@@ -16,7 +16,7 @@ use ed25519_dalek_bip32::{DerivationPath, ExtendedSigningKey};
 use super::errors::UpdateDidWebvhError;
 use super::legacy::{legacy_lookup_by_public_key, legacy_lookup_pre_rotation_by_hash};
 use super::options::DerivedWebvhKey;
-use crate::keys::paths::{allocate_path, peek_paths};
+use crate::keys::paths::{allocate_paths, peek_paths};
 use crate::keys::seed_store::SeedStore;
 use crate::keys::seeds::{get_active_seed_id, load_seed_bytes};
 use crate::operations::did_webvh::webvh_keys::{self, WebvhKeyHandle, WebvhKeyRole};
@@ -36,17 +36,37 @@ pub(in crate::operations::did_webvh) async fn derive_webvh_keys(
     base_path: &str,
     count: u32,
 ) -> Result<Vec<DerivedWebvhKey>, UpdateDidWebvhError> {
+    derive_webvh_keys_block(keys_ks, seed_store, base_path, count, None).await
+}
+
+/// Allocate and derive `count` keys as **one contiguous block**, optionally
+/// asserting the block starts at `expected_start`.
+///
+/// This is the sound version of [`derive_webvh_keys`], and the two differences
+/// from a loop of single allocations are the two halves of the race this closes:
+///
+/// - **one block, not `count` allocations** — so a concurrent update cannot split
+///   the auth key from the pre-rotation keys, which a plan peeked as adjacent;
+/// - **`expected_start`** — so if anything moved the counter between the plan that
+///   was shown to a human and this execution, the allocation fails with a
+///   `Conflict` rather than silently installing keys the approver never saw.
+///
+/// `expected_start` is the value the plan peeked
+/// ([`crate::keys::paths::peek_path_counter`]). Passing it is what turns "the
+/// keys the approver saw are *probably* the keys that execute" into a guarantee.
+pub(in crate::operations::did_webvh) async fn derive_webvh_keys_block(
+    keys_ks: &KeyspaceHandle,
+    seed_store: &dyn SeedStore,
+    base_path: &str,
+    count: u32,
+    expected_start: Option<u32>,
+) -> Result<Vec<DerivedWebvhKey>, UpdateDidWebvhError> {
     if count == 0 {
         return Ok(vec![]);
     }
-    let mut paths = Vec::with_capacity(count as usize);
-    for _ in 0..count {
-        paths.push(
-            allocate_path(keys_ks, base_path)
-                .await
-                .map_err(|e| UpdateDidWebvhError::Persistence(format!("allocate_path: {e}")))?,
-        );
-    }
+    let paths = allocate_paths(keys_ks, base_path, count, expected_start)
+        .await
+        .map_err(|e| UpdateDidWebvhError::Persistence(format!("allocate_paths: {e}")))?;
     derive_webvh_keys_at(keys_ks, seed_store, &paths).await
 }
 

--- a/vta-service/src/operations/did_webvh/update/mod.rs
+++ b/vta-service/src/operations/did_webvh/update/mod.rs
@@ -1797,8 +1797,61 @@ mod pre_rotation_e2e_tests {
         );
     }
 
-    /// The one that matters. Plan an update, execute it, and assert the update
-    /// keys the chain actually committed are the ones the plan showed.
+    /// The race, closed at the allocation itself.
+    ///
+    /// `derive_webvh_keys_block` allocates a contiguous block in one atomic step,
+    /// and refuses if the counter it is pinned to has moved. This is the guard the
+    /// gate's re-plan cannot provide: it holds even inside a single execution, in
+    /// the window the old two-call allocation left open between deriving the auth
+    /// key and the pre-rotation keys.
+    #[tokio::test]
+    async fn a_moved_counter_refuses_to_derive_the_wrong_keys() {
+        use super::keys::derive_webvh_keys_block;
+
+        let (ts, seed_store) = setup("ctx-race").await;
+        let base_path = crate::contexts::get_context(&ts.contexts_ks, "ctx-race")
+            .await
+            .expect("get_context")
+            .expect("context")
+            .base_path;
+
+        // A caller peeks the counter, intending to derive a block starting there.
+        let pinned = crate::keys::paths::peek_path_counter(&ts.keys_ks, &base_path)
+            .await
+            .unwrap();
+
+        // A concurrent update in the same context allocates first — the exact race
+        // a human-in-the-loop approval window makes real.
+        crate::keys::paths::allocate_path(&ts.keys_ks, &base_path)
+            .await
+            .unwrap();
+
+        // The first caller now tries to derive against its stale pin. It must
+        // refuse: deriving would install a key nobody predicted.
+        let result =
+            derive_webvh_keys_block(&ts.keys_ks, &seed_store, &base_path, 2, Some(pinned)).await;
+        match result {
+            Err(e) => assert!(
+                format!("{e}").contains("moved"),
+                "expected a counter-moved conflict, got: {e}"
+            ),
+            Ok(_) => panic!("a moved counter must refuse, not derive the wrong keys"),
+        }
+
+        // The refusal consumed nothing — re-pinning to the current value works.
+        let now = crate::keys::paths::peek_path_counter(&ts.keys_ks, &base_path)
+            .await
+            .unwrap();
+        assert_eq!(
+            now,
+            pinned + 1,
+            "only the concurrent allocation advanced it"
+        );
+        derive_webvh_keys_block(&ts.keys_ks, &seed_store, &base_path, 2, Some(now))
+            .await
+            .expect("re-pinned derivation succeeds");
+    }
+
     #[tokio::test]
     async fn plan_predicts_the_update_key_that_execution_installs() {
         let (ts, seed_store) = setup("ctx-plan-keys").await;

--- a/vta-service/src/operations/did_webvh/update/orchestrator.rs
+++ b/vta-service/src/operations/did_webvh/update/orchestrator.rs
@@ -13,8 +13,8 @@ use didwebvh_rs::update::{UpdateDIDConfig, update_did};
 
 use super::errors::UpdateDidWebvhError;
 use super::keys::{
-    derive_secret_for_handle, derive_webvh_keys, install_derived_webvh_keys,
-    load_active_update_key, load_pre_rotation_signing_key, peek_webvh_keys,
+    derive_secret_for_handle, install_derived_webvh_keys, load_active_update_key,
+    load_pre_rotation_signing_key, peek_webvh_keys,
 };
 use super::options::{UpdateDidWebvhOptions, UpdateDidWebvhResult};
 use super::plan::UpdatePlan;
@@ -234,36 +234,32 @@ async fn run_update(
         .await
         .map_err(|e| UpdateDidWebvhError::Persistence(format!("peek_path_counter: {e}")))?;
     let auth_count: u32 = u32::from(new_doc.is_some() && !pre_rotation_active);
-    let (derived_auth, derived_pre_rotation) = match mode {
-        // Execute allocates, advancing the counter between the two calls: the
-        // auth key takes index n, the pre-rotation keys take n+1, n+2, …
+    let total_keys = auth_count + pre_rotation_count;
+
+    // Plan and execute derive the *same contiguous block* and split it the same
+    // way — that symmetry is what makes the prediction sound.
+    //
+    // Plan peeks the block (read-only); execute allocates it in one atomic step,
+    // pinned to the counter the plan peeked. If anything advanced the counter in
+    // between — a concurrent update in the same context, minutes later, while a
+    // human was deciding — the allocation fails rather than installing keys the
+    // approver never saw. Allocating the auth and pre-rotation keys separately, as
+    // this once did, left a window for exactly that between the two calls.
+    let derived_all = match mode {
+        Mode::Plan => peek_webvh_keys(keys_ks, seed_store, &context.base_path, total_keys).await?,
         Mode::Execute => {
-            let auth = if auth_count > 0 {
-                derive_webvh_keys(keys_ks, seed_store, &context.base_path, 1).await?
-            } else {
-                vec![]
-            };
-            let pre =
-                derive_webvh_keys(keys_ks, seed_store, &context.base_path, pre_rotation_count)
-                    .await?;
-            (auth, pre)
-        }
-        // Plan must predict exactly that. Peeking twice would not: both peeks
-        // read the same un-advanced counter and would hand back overlapping
-        // paths. Peek the whole contiguous block once and split it where the
-        // allocations would have fallen.
-        Mode::Plan => {
-            let all = peek_webvh_keys(
+            super::keys::derive_webvh_keys_block(
                 keys_ks,
                 seed_store,
                 &context.base_path,
-                auth_count + pre_rotation_count,
+                total_keys,
+                Some(path_counter_pin),
             )
-            .await?;
-            let (auth, pre) = all.split_at(auth_count as usize);
-            (auth.to_vec(), pre.to_vec())
+            .await?
         }
     };
+    let (auth_slice, pre_slice) = derived_all.split_at(auth_count as usize);
+    let (derived_auth, derived_pre_rotation) = (auth_slice.to_vec(), pre_slice.to_vec());
 
     // 8. Resolve the signing key.
     //

--- a/vta-service/src/operations/did_webvh/update/state.rs
+++ b/vta-service/src/operations/did_webvh/update/state.rs
@@ -37,9 +37,9 @@ pub(in crate::operations::did_webvh) async fn find_record_by_scid(
         .await
         .map_err(|e| UpdateDidWebvhError::Persistence(format!("list_dids: {e}")))?;
     // Match a bare SCID, or a full DID whose SCID segment matches.
-    Ok(all.into_iter().find(|r| {
-        r.scid == scid_or_did || r.did == scid_or_did
-    }))
+    Ok(all
+        .into_iter()
+        .find(|r| r.scid == scid_or_did || r.did == scid_or_did))
 }
 
 /// Build a [`DIDWebVHState`] from a stored JSONL log string. Splits on

--- a/vti-common/src/store/counter.rs
+++ b/vti-common/src/store/counter.rs
@@ -39,9 +39,56 @@ static COUNTER_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 /// counters that is silent private-key reuse. Allocation is
 /// infrequent; the fsync cost is acceptable.
 pub async fn allocate_u32(ks: &KeyspaceHandle, counter_key: &str) -> Result<u32, AppError> {
+    allocate_u32_block(ks, counter_key, 1, None).await
+}
+
+/// Atomically allocate a **contiguous block** of `count` values, returning the
+/// first, and optionally assert the block starts exactly where the caller
+/// expects.
+///
+/// Two problems, one primitive.
+///
+/// **Contiguity.** A caller needing several adjacent indices cannot get them from
+/// a loop of [`allocate_u32`]: the lock is released between calls, so a concurrent
+/// allocator can land in the middle and the "block" is no longer a block. Anything
+/// that predicted those indices — a dry-run — is then wrong about all of them.
+///
+/// **Expectation.** `expected` closes the gap between predicting an allocation and
+/// performing it. A peek reserves nothing, so between a prediction and its use
+/// another allocation can move the counter and the caller silently derives
+/// something other than what it predicted. Passing the peeked value here makes
+/// that a `Conflict` instead: the check and the allocation happen under one lock
+/// acquisition, so nothing can slip between them.
+///
+/// This matters where the prediction was shown to a **human**. An approver who
+/// authorized a rotation to key `n` must not have key `n+1` installed, and
+/// "unlikely" is not the bar — the entire point of showing them the key is that
+/// it is the key that executes.
+///
+/// A failed assertion consumes nothing. Gaps are safe; reuse is not.
+pub async fn allocate_u32_block(
+    ks: &KeyspaceHandle,
+    counter_key: &str,
+    count: u32,
+    expected: Option<u32>,
+) -> Result<u32, AppError> {
     let _guard = COUNTER_LOCK.lock().await;
     let current = read_u32(ks, counter_key).await?;
-    ks.insert_raw(counter_key, (current + 1).to_le_bytes().to_vec())
+
+    if let Some(expected) = expected
+        && current != expected
+    {
+        return Err(AppError::Conflict(format!(
+            "derivation counter at `{counter_key}` moved from {expected} to {current} while a \
+             decision was pending — the keys this would derive are not the keys that were approved"
+        )));
+    }
+
+    if count == 0 {
+        return Ok(current);
+    }
+
+    ks.insert_raw(counter_key, (current + count).to_le_bytes().to_vec())
         .await?;
     ks.persist().await?;
     // Re-seal the TEE integrity manifest so the counter bump is reflected in the
@@ -122,5 +169,68 @@ mod tests {
         for expect in 0..3u32 {
             assert_eq!(allocate_u32(&ks, "counter:y").await.unwrap(), expect);
         }
+    }
+}
+
+#[cfg(test)]
+mod block_tests {
+    use super::*;
+    use crate::config::StoreConfig;
+    use crate::store::Store;
+
+    async fn ks() -> (crate::store::KeyspaceHandle, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(&StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        })
+        .unwrap();
+        (store.keyspace("keys").unwrap(), dir)
+    }
+
+    #[tokio::test]
+    async fn a_block_is_contiguous() {
+        let (ks, _d) = ks().await;
+        // First block of 3 starts at 0; the counter then stands at 3.
+        assert_eq!(allocate_u32_block(&ks, "c", 3, None).await.unwrap(), 0);
+        // A single allocation continues from there — no gap, no overlap.
+        assert_eq!(allocate_u32(&ks, "c").await.unwrap(), 3);
+        assert_eq!(allocate_u32_block(&ks, "c", 2, None).await.unwrap(), 4);
+    }
+
+    /// The race, closed. A caller pins the counter it peeked and passes it as
+    /// `expected`. If anything advanced the counter in the meantime, the
+    /// allocation refuses rather than handing back a block that starts somewhere
+    /// the caller did not predict.
+    #[tokio::test]
+    async fn an_expectation_that_no_longer_holds_is_refused() {
+        let (ks, _d) = ks().await;
+
+        // A caller peeks: the next value is 0. It intends to allocate a block
+        // starting there.
+        assert_eq!(peek_u32(&ks, "c").await.unwrap(), 0);
+
+        // But a concurrent allocator lands first.
+        assert_eq!(allocate_u32(&ks, "c").await.unwrap(), 0);
+
+        // The first caller's pinned expectation (0) no longer holds. It must NOT
+        // get a block — it would derive keys nobody predicted.
+        let err = allocate_u32_block(&ks, "c", 2, Some(0)).await.unwrap_err();
+        assert!(
+            matches!(err, AppError::Conflict(_)),
+            "a moved counter must be a Conflict, got: {err:?}"
+        );
+
+        // And the failure consumed nothing: the counter is still where the
+        // concurrent allocator left it. Gaps are safe; a burned index would not be.
+        assert_eq!(peek_u32(&ks, "c").await.unwrap(), 1);
+
+        // Re-peeking and re-pinning to the current value succeeds.
+        assert_eq!(allocate_u32_block(&ks, "c", 2, Some(1)).await.unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn a_matching_expectation_allocates() {
+        let (ks, _d) = ks().await;
+        assert_eq!(allocate_u32_block(&ks, "c", 2, Some(0)).await.unwrap(), 0);
     }
 }


### PR DESCRIPTION
The dry-run's promise — **the update keys a human was shown are the keys that execute** — had a hole. Found by the adversarial re-read of the design note against the code.

## Two windows, both leaking unapproved keys into the chain

1. **Gate → handler.** The counter pin was checked in the pre-dispatch gate (`assert_plan_still_holds`), then the handler allocated fresh keys **with no reference to it**. Anything that advanced the counter in between installed a key nobody approved.

2. **Within execute.** The auth key and the pre-rotation keys were allocated in **two separate calls**. A concurrent update in the same context could land between them and split a block the plan had peeked as contiguous — so plan and execute disagreed about keys `n, n+1, n+2`.

Either way: keys nobody approved, in a chain where every signature still verifies. The exact failure the dry-run exists to prevent, reintroduced by the mechanism meant to prevent it.

## One atomic primitive closes both

`counter::allocate_u32_block(ks, key, count, expected)`:
- allocates a **contiguous block** under a single lock acquisition, and
- given `expected`, **refuses with `Conflict`** if the counter has moved.

`paths::allocate_paths` and `keys::derive_webvh_keys_block` build on it, and execute now derives the whole block in one call, pinned to the counter the plan peeked.

- **Contiguity** — auth + pre-rotation are one block; no concurrent allocation can split them. Plan and execute derive the same block and split it identically — the symmetry is now structural, not coincidental.
- **Expectation** — the pin is asserted *at the allocation*, under the lock, so nothing can slip between check and use. This holds even inside a single execution, which the gate's re-plan cannot reach.

A failed pin consumes nothing. Counters only move forward; gaps are safe, reuse is not.

## Tests, both verified to fail without the guard

- **Primitive** (`vti-common`): a block is contiguous; a pinned expectation that no longer holds is refused; the refusal burns no index.
- **Orchestrator** (`vta-service`): a concurrent `allocate_path` between peek and derive makes the webvh key derivation **refuse** rather than install the wrong keys — verified it panics without the pin check.

`cargo fmt --check`, `cargo clippy --workspace --features webvh -- -D warnings`, 278 `vti-common` + 1178 `vta-service` tests — clean.

This was §5 / §15's "dry-run desynchronised from the run — race narrowed, not closed" in the design note. Now closed.