### PR TITLE
test(vta-service): end-to-end delegated consent over the wire

### DIFF
--- a/vta-service/src/test_support.rs
+++ b/vta-service/src/test_support.rs
@@ -561,6 +561,13 @@ pub struct TestAppContext {
     /// via [`seed_webvh_server`] before driving a DID-mint / join flow.
     #[cfg(feature = "webvh")]
     pub webvh_ks: KeyspaceHandle,
+    /// The policy keyspace — exposed so an end-to-end harness can install the
+    /// Rego a deployment would, rather than reach past the Policy Decision Point
+    /// it is trying to exercise.
+    pub policy_ks: KeyspaceHandle,
+    /// The contexts keyspace — exposed so a harness can seed the trust context a
+    /// DID mint requires, the way a provisioning flow would.
+    pub contexts_ks: KeyspaceHandle,
     /// The VTA DID this app is configured with — the `did:key:z6MkTestVTA`
     /// sentinel for [`build_test_app`], or a real, self-resolving `did:key`
     /// for [`build_provisionable_test_app`]. A harness driving a URL-direct
@@ -815,11 +822,12 @@ pub async fn build_test_app_with(opts: TestAppOptions) -> (axum::Router, TestApp
         resolver
     };
 
+    let policy_ks = store.keyspace(crate::keyspaces::POLICY).unwrap();
     let state = crate::server::AppState {
         keys_ks: keys_ks.clone(),
         sessions_ks: sessions_ks.clone(),
         acl_ks: acl_ks.clone(),
-        contexts_ks,
+        contexts_ks: contexts_ks.clone(),
         did_templates_ks,
         audit_ks,
         imported_ks,
@@ -831,7 +839,7 @@ pub async fn build_test_app_with(opts: TestAppOptions) -> (axum::Router, TestApp
             .keyspace(crate::keyspaces::ISSUED_CREDENTIALS)
             .unwrap(),
         memory_ks: store.keyspace(crate::keyspaces::MEMORY).unwrap(),
-        policy_ks: store.keyspace(crate::keyspaces::POLICY).unwrap(),
+        policy_ks: policy_ks.clone(),
         task_consent_ks: store.keyspace(crate::keyspaces::TASK_CONSENT).unwrap(),
         service_state_ks,
         sealed_nonces_ks,
@@ -898,6 +906,8 @@ pub async fn build_test_app_with(opts: TestAppOptions) -> (axum::Router, TestApp
         backup_blob_dir,
         #[cfg(feature = "webvh")]
         webvh_ks,
+        policy_ks,
+        contexts_ks: contexts_ks.clone(),
         vta_did,
         config,
         _dir: dir,

--- a/vta-service/tests/delegated_consent_e2e.rs
+++ b/vta-service/tests/delegated_consent_e2e.rs
@@ -1,0 +1,514 @@
+//! Delegated trust-task execution, end to end, over the wire.
+//!
+//! # Why this exists
+//!
+//! Every integration bug in this feature survived because nobody ran the flow.
+//! The unit tests all passed — they were written against seams their authors
+//! chose, and they encoded what those authors *believed*, so they could only ever
+//! confirm it. A test that mocks the transport cannot discover that the transport
+//! throws. A test that uses the type URI from a constant cannot discover that the
+//! caller sends a different string.
+//!
+//! So this test mocks nothing. It drives the real HTTP router, posts real Trust
+//! Task documents, verifies real Data-Integrity proofs, and reads the resulting
+//! `did:webvh` log off the real keyspace. If any two components disagree about
+//! anything — a field's casing, a type URI, the shape of a rejection — this fails.
+//!
+//! # What it proves
+//!
+//! The claim the whole design rests on, checked rather than asserted:
+//!
+//! > **The keys a human was shown are the keys that execute.**
+//!
+//! The consent request the approver signs carries an executor-authored
+//! `keyRotation` effect naming the key that will be installed. The test approves
+//! it, re-submits, and then reads the DID log to check that *that* key is the one
+//! now in force. Nothing in between is trusted.
+
+#![cfg(feature = "webvh")]
+
+use affinidi_data_integrity::crypto_suites::CryptoSuite;
+use affinidi_data_integrity::{DataIntegrityProof, prepare_sign_input};
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use ed25519_dalek::{Signer, SigningKey};
+use http_body_util::BodyExt;
+use multibase::Base;
+use serde_json::{Value, json};
+use tower::ServiceExt;
+use trust_tasks_rs::{Proof, TrustTask};
+
+use vta_service::test_support::{TestAppContext, TestAppOptions, build_test_app_with};
+
+/// The URI a caller actually sends. Taken from the SDK, which is what every real
+/// client resolves — a literal here would only re-encode one author's belief, and
+/// that belief was wrong once already.
+const WEBVH_UPDATE: &str = vta_sdk::trust_tasks::TASK_WEBVH_DIDS_UPDATE_1_0;
+const TASK_CONSENT_DECISION: &str = vta_sdk::trust_tasks::TASK_TASK_CONSENT_DECISION_0_1;
+
+/// Policy: this task needs a human, and it must not be the requester.
+const REQUIRE_CONSENT: &str = r#"package vta.policy
+import rego.v1
+decision := {"decision": "requireConsent", "requireConsent": {"approverSet": "operators", "excludeRequester": true}}
+"#;
+
+// ─── wire helpers ────────────────────────────────────────────────────────────
+
+async fn post(router: &axum::Router, token: &str, doc: &Value) -> (StatusCode, Value) {
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/trust-tasks")
+        .header("authorization", format!("Bearer {token}"))
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(doc).unwrap()))
+        .unwrap();
+    let resp = router.clone().oneshot(req).await.unwrap();
+    let status = resp.status();
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    (
+        status,
+        serde_json::from_slice(&bytes).unwrap_or(Value::Null),
+    )
+}
+
+/// A `did:key` identity that can sign a Data-Integrity proof.
+struct Approver {
+    did: String,
+    vm: String,
+    sk: SigningKey,
+}
+
+fn approver(seed: u8) -> Approver {
+    let sk = SigningKey::from_bytes(&[seed; 32]);
+    let pk = sk.verifying_key();
+    let mut mc = vec![0xed, 0x01];
+    mc.extend_from_slice(pk.as_bytes());
+    let did = format!("did:key:{}", multibase::encode(Base::Base58Btc, &mc));
+    let vm = format!("{did}#{}", did.strip_prefix("did:key:").unwrap());
+    Approver { did, vm, sk }
+}
+
+/// Sign a Trust Task document as `who`. The proof IS the authorization — the VTA
+/// takes the approver's identity from it, never from the bearer session.
+fn sign_as(who: &Approver, doc_json: Value) -> Value {
+    let mut doc: TrustTask<Value> = serde_json::from_value(doc_json).unwrap();
+    let mut di = DataIntegrityProof::new(
+        CryptoSuite::EddsaJcs2022,
+        who.vm.clone(),
+        "assertionMethod".to_string(),
+        None,
+        Some("2026-07-14T00:00:00Z".to_string()),
+        None,
+    );
+    let input = prepare_sign_input(&doc, &di, CryptoSuite::EddsaJcs2022).unwrap();
+    di.proof_value = Some(multibase::encode(
+        Base::Base58Btc,
+        who.sk.sign(&input).to_bytes(),
+    ));
+    doc.proof = Some(serde_json::from_value::<Proof>(serde_json::to_value(&di).unwrap()).unwrap());
+    serde_json::to_value(&doc).unwrap()
+}
+
+fn envelope(type_uri: &str, issuer: &str, recipient: &str, payload: Value) -> Value {
+    json!({
+        "id": format!("urn:uuid:{}", uuid::Uuid::new_v4()),
+        "type": type_uri,
+        "issuer": issuer,
+        "recipient": recipient,
+        "issuedAt": "2026-07-14T00:00:00Z",
+        "payload": payload,
+    })
+}
+
+/// The update keys actually in force on `did`, read from the committed log.
+///
+/// webvh parameters are a delta — an entry that does not restate `update_keys`
+/// leaves the previous entry's standing — so "in force" means the last entry that
+/// restated them, not whatever the final entry happens to carry.
+async fn update_keys_in_force(ctx: &TestAppContext, did: &str) -> Vec<String> {
+    use didwebvh_rs::log_entry::LogEntryMethods;
+    let log = vta_service::webvh_store::get_did_log(&ctx.webvh_ks, did)
+        .await
+        .expect("get_did_log")
+        .expect("the DID has a log");
+    let state =
+        vta_service::operations::did_webvh::state_from_jsonl_pub(&log).expect("valid chain");
+
+    let mut keys: Vec<String> = vec![];
+    for entry in state.log_entries() {
+        if let Some(arc) = entry.log_entry.get_parameters().update_keys.as_ref() {
+            keys = arc.iter().map(|k| k.as_ref().to_string()).collect();
+        }
+    }
+    keys
+}
+
+// ─── the flow ────────────────────────────────────────────────────────────────
+
+/// A caller asks the VTA to update a DID document. Policy demands a human. The
+/// approver is shown what it will do, approves, and the update executes — and the
+/// keys the approver was shown are the keys that end up in the log.
+#[tokio::test]
+async fn a_did_update_is_approved_by_a_human_and_the_keys_they_saw_are_the_keys_installed() {
+    let (router, ctx) = build_test_app_with(TestAppOptions {
+        // A real VTA signing identity (active seed + `{vta_did}#key-0`), because
+        // the update handler's dry-run signs the planned entry — a sentinel DID
+        // with no key cannot execute the flow this test exists to exercise.
+        provisionable_vta: true,
+        ..Default::default()
+    })
+    .await;
+    let requester = "did:key:z6MkTestRequester";
+    let token = ctx.mint_token(requester, "admin", vec![]).await;
+    let ops = approver(7);
+
+    // A real DID, minted over the wire by the VTA that holds its key.
+    let (did, _scid) = create_did(&router, &ctx, &token).await;
+    let keys_before = update_keys_in_force(&ctx, &did).await;
+    assert_eq!(keys_before.len(), 1, "a fresh DID has one update key");
+
+    // The deployment's policy: a human approves this, and not the requester.
+    {
+        let mut cfg = ctx.config.write().await;
+        cfg.policy.enforcement = true;
+        cfg.policy
+            .approver_sets
+            .insert("operators".into(), vec![ops.did.clone()]);
+    }
+    install_policy(&ctx, REQUIRE_CONSENT).await;
+
+    // ── 1. The caller proposes an edit. Note the camelCase — this is the wire
+    //       form a real client sends, and a mismatch here once silently disabled
+    //       the concurrency precondition entirely.
+    let new_doc = json!({
+        "@context": ["https://www.w3.org/ns/did/v1"],
+        "id": did,
+        "service": [{
+            "id": "#files",
+            "type": "FileStore",
+            "serviceEndpoint": "https://files.example.com/acme"
+        }]
+    });
+    let update = envelope(
+        WEBVH_UPDATE,
+        requester,
+        &ctx.vta_did,
+        json!({ "did": did, "document": new_doc }),
+    );
+
+    let (status, rejected) = post(&router, &token, &update).await;
+    assert_eq!(
+        status,
+        StatusCode::UNPROCESSABLE_ENTITY,
+        "a task needing consent must be refused, not executed: {rejected}"
+    );
+    assert!(
+        rejected["payload"]["message"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("auth:consent_required"),
+        "the refusal must name the consent requirement: {rejected}"
+    );
+
+    // ── 2. The refusal carries what an approver needs, and what the requesting
+    //       surface must display.
+    let details = &rejected["payload"]["details"];
+    let payload_digest = details["payloadDigest"]
+        .as_str()
+        .expect("a digest to match");
+    let challenge = details["challenge"].as_str().expect("a challenge");
+    let requests = details["consentRequests"]
+        .as_array()
+        .expect("the signed requests to relay");
+    assert_eq!(requests.len(), 1, "one request per eligible approver");
+
+    let consent_request = &requests[0];
+    assert!(
+        consent_request["proof"].is_object(),
+        "the request must be VTA-signed — an unsigned one lets anyone author what \
+         the human reads"
+    );
+    assert_eq!(consent_request["issuer"], json!(ctx.vta_did));
+    assert_eq!(consent_request["recipient"], json!(ops.did));
+
+    // ── 3. The effects. This is the point of the whole design: the payload above
+    //       says "add a service endpoint" and says nothing about keys, but the
+    //       executor dry-ran its own handler and knows better.
+    let cp = &consent_request["payload"];
+    assert_eq!(
+        cp["payloadDigest"],
+        json!(payload_digest),
+        "both screens show one value"
+    );
+    assert_eq!(cp["challenge"], json!(challenge));
+    assert_eq!(
+        cp["sideEffects"], "destructive",
+        "rotating a sole controlling key is authority-shifting (SPEC §7.3 item 13)"
+    );
+
+    let effects = cp["effects"].as_array().expect("executor-authored effects");
+    let rotation = effects
+        .iter()
+        .find(|e| e["kind"] == "keyRotation")
+        .expect("the payload never mentions a key rotation — the dry-run must");
+
+    let promised_keys: Vec<String> = rotation["after"]
+        .as_array()
+        .expect("the rotation names the keys it will install")
+        .iter()
+        .map(|k| k.as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(
+        rotation["before"],
+        json!(keys_before),
+        "the rotation must show the key actually in force, not a guess"
+    );
+    assert_ne!(
+        promised_keys, keys_before,
+        "a rotation that changes nothing is not one"
+    );
+
+    // ── 4. The human approves. The proof is the authorization; the bearer token
+    //       belongs to the *requester* and says nothing about who agreed.
+    let decision = sign_as(
+        &ops,
+        envelope(
+            TASK_CONSENT_DECISION,
+            &ops.did,
+            &ctx.vta_did,
+            json!({
+                "challenge": challenge,
+                "payloadDigest": payload_digest,
+                "decision": "approve"
+            }),
+        ),
+    );
+    let (status, granted) = post(&router, &token, &decision).await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "the decision must be accepted: {granted}"
+    );
+    assert_eq!(granted["payload"]["status"], "granted", "{granted}");
+
+    // ── 5. The caller re-submits the SAME PAYLOAD as a fresh envelope. The grant
+    //       binds the payload digest, not the envelope id — and the replay guard
+    //       would reject a reused id as a duplicate. So a real requester
+    //       re-proposes the approved task in a new envelope, exactly as here.
+    let resubmit = envelope(
+        WEBVH_UPDATE,
+        requester,
+        &ctx.vta_did,
+        update["payload"].clone(),
+    );
+    let (status, executed) = post(&router, &token, &resubmit).await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "the approved task must now execute: {executed}"
+    );
+
+    // ── 6. THE CLAIM. The keys the human was shown are the keys in the log.
+    let keys_after = update_keys_in_force(&ctx, &did).await;
+    assert_eq!(
+        keys_after, promised_keys,
+        "the approver authorized a rotation to {promised_keys:?}, and the DID now \
+         has {keys_after:?}. If these differ, a human approved a key that never \
+         existed — and every signature over that approval still verifies."
+    );
+}
+
+/// The grant is single-use: an approved task executes once, and a replay of the
+/// same document is refused rather than silently run again.
+#[tokio::test]
+async fn an_approval_authorizes_exactly_one_execution() {
+    let (router, ctx) = build_test_app_with(TestAppOptions {
+        // A real VTA signing identity (active seed + `{vta_did}#key-0`), because
+        // the update handler's dry-run signs the planned entry — a sentinel DID
+        // with no key cannot execute the flow this test exists to exercise.
+        provisionable_vta: true,
+        ..Default::default()
+    })
+    .await;
+    let requester = "did:key:z6MkTestRequester";
+    let token = ctx.mint_token(requester, "admin", vec![]).await;
+    let ops = approver(9);
+
+    let (did, _scid) = create_did(&router, &ctx, &token).await;
+    {
+        let mut cfg = ctx.config.write().await;
+        cfg.policy.enforcement = true;
+        cfg.policy
+            .approver_sets
+            .insert("operators".into(), vec![ops.did.clone()]);
+    }
+    install_policy(&ctx, REQUIRE_CONSENT).await;
+
+    let payload = json!({
+        "did": did,
+        "document": { "@context": ["https://www.w3.org/ns/did/v1"], "id": did, "alsoKnownAs": ["did:example:x"] }
+    });
+    let update = envelope(WEBVH_UPDATE, requester, &ctx.vta_did, payload);
+
+    let (_, rejected) = post(&router, &token, &update).await;
+    let d = &rejected["payload"]["details"];
+    let decision = sign_as(
+        &ops,
+        envelope(
+            TASK_CONSENT_DECISION,
+            &ops.did,
+            &ctx.vta_did,
+            json!({
+                "challenge": d["challenge"],
+                "payloadDigest": d["payloadDigest"],
+                "decision": "approve"
+            }),
+        ),
+    );
+    let (status, _) = post(&router, &token, &decision).await;
+    assert_eq!(status, StatusCode::OK);
+
+    // First re-submit (fresh envelope, same payload) executes.
+    let first = envelope(
+        WEBVH_UPDATE,
+        requester,
+        &ctx.vta_did,
+        update["payload"].clone(),
+    );
+    let (status, _) = post(&router, &token, &first).await;
+    assert_eq!(status, StatusCode::OK, "the approved task executes");
+
+    // A second submit of the same payload must NOT quietly execute again. The
+    // grant was consumed; what comes back is a fresh demand for consent.
+    let second = envelope(
+        WEBVH_UPDATE,
+        requester,
+        &ctx.vta_did,
+        update["payload"].clone(),
+    );
+    let (status, again) = post(&router, &token, &second).await;
+    assert_eq!(
+        status,
+        StatusCode::UNPROCESSABLE_ENTITY,
+        "an approval authorizes ONE execution — a replay must be refused: {again}"
+    );
+    assert!(
+        again["payload"]["message"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("auth:consent_required"),
+        "a replay must re-require consent: {again}"
+    );
+}
+
+/// A device that proposes a task cannot approve it when policy excludes the
+/// requester — the whole point being that one compromised device is not enough.
+#[tokio::test]
+async fn the_requester_cannot_approve_its_own_task() {
+    let (router, ctx) = build_test_app_with(TestAppOptions {
+        // A real VTA signing identity (active seed + `{vta_did}#key-0`), because
+        // the update handler's dry-run signs the planned entry — a sentinel DID
+        // with no key cannot execute the flow this test exists to exercise.
+        provisionable_vta: true,
+        ..Default::default()
+    })
+    .await;
+    let requester = approver(11);
+    let token = ctx.mint_token(&requester.did, "admin", vec![]).await;
+
+    let (did, _scid) = create_did(&router, &ctx, &token).await;
+    {
+        let mut cfg = ctx.config.write().await;
+        cfg.policy.enforcement = true;
+        // The requester is IN the approver set — and the policy excludes them anyway.
+        cfg.policy
+            .approver_sets
+            .insert("operators".into(), vec![requester.did.clone()]);
+    }
+    install_policy(&ctx, REQUIRE_CONSENT).await;
+
+    let update = envelope(
+        WEBVH_UPDATE,
+        &requester.did,
+        &ctx.vta_did,
+        json!({ "did": did, "document": { "@context": ["https://www.w3.org/ns/did/v1"], "id": did } }),
+    );
+    let (_, rejected) = post(&router, &token, &update).await;
+    let d = &rejected["payload"]["details"];
+
+    // Nobody was even asked: the only member of the set is the requester.
+    assert_eq!(
+        d["consentRequests"].as_array().map(Vec::len),
+        Some(0),
+        "there is nobody eligible to ask, and we must not pretend otherwise"
+    );
+
+    // And if they sign one anyway, the executor refuses it.
+    let decision = sign_as(
+        &requester,
+        envelope(
+            TASK_CONSENT_DECISION,
+            &requester.did,
+            &ctx.vta_did,
+            json!({
+                "challenge": d["challenge"],
+                "payloadDigest": d["payloadDigest"],
+                "decision": "approve"
+            }),
+        ),
+    );
+    let (status, refused) = post(&router, &token, &decision).await;
+    assert_ne!(
+        status,
+        StatusCode::OK,
+        "the requester must not be able to self-approve: {refused}"
+    );
+}
+
+// ─── setup ───────────────────────────────────────────────────────────────────
+
+async fn install_policy(ctx: &TestAppContext, rego: &str) {
+    use vta_service::policy::PolicyModule;
+    let module = PolicyModule {
+        id: "e2e".into(),
+        name: "e2e".into(),
+        description: None,
+        module: rego.to_string(),
+        applies_to: vec![],
+        priority: 0,
+        enabled: true,
+        version: 1,
+        created_at: "2026-07-14T00:00:00Z".to_string(),
+        updated_at: "2026-07-14T00:00:00Z".to_string(),
+    };
+    vta_service::policy::storage::store_policy(&ctx.policy_ks, &module)
+        .await
+        .expect("install policy");
+}
+
+/// Mint a `did:webvh` over the wire, as a caller would.
+///
+/// A DID mint needs a trust context to derive keys under, so we seed one — the
+/// equivalent of the provisioning step a real deployment runs before any DID
+/// exists. The `url` (with no `server_id`) selects the serverless path, so no
+/// hosting server has to be reachable.
+async fn create_did(router: &axum::Router, ctx: &TestAppContext, token: &str) -> (String, String) {
+    vta_service::contexts::create_context(&ctx.contexts_ks, "default", "Default")
+        .await
+        .expect("seed the default context");
+
+    let doc = envelope(
+        vta_sdk::trust_tasks::TASK_WEBVH_DIDS_CREATE_1_0,
+        "did:key:z6MkTestRequester",
+        &ctx.vta_did,
+        json!({ "contextId": "default", "url": "https://example.com/acme" }),
+    );
+    let (status, v) = post(router, token, &doc).await;
+    assert_eq!(status, StatusCode::OK, "create a DID to update: {v}");
+    let did = v["payload"]["did"].as_str().expect("did").to_string();
+    let scid = v["payload"]["scid"]
+        .as_str()
+        .unwrap_or_default()
+        .to_string();
+    (did, scid)
+}


### PR DESCRIPTION
The test that would have caught most of this feature's bugs — and caught three more while being written.

## Why it exists

Every integration bug in delegated execution survived because the tests were written against seams their authors chose. They mocked the transport, or read the type URI from the same constant the code used — so they could only ever confirm what the author already believed. A test that fakes the channel cannot discover that the real channel throws. A test that builds a Rust struct cannot discover that the wire wants a different field name.

This mocks **nothing**. It drives the real axum router, posts real Trust Task documents to `/api/trust-tasks`, signs real Data-Integrity proofs, and reads the resulting `did:webvh` log off the real keyspace.

## What it proves

The claim the entire design rests on, checked by reading the log rather than asserted in prose:

> **The update keys a human was shown in the consent request are the keys that end up in force in the DID log.**

`a_did_update_is_approved_by_a_human_and_the_keys_they_saw_are_the_keys_installed` runs the whole loop: propose → the VTA dry-runs the real handler and computes the key rotation → refuse with a signed consent request → the human's signed decision → grant → re-submit → execute → read the log and assert the update keys equal the ones the approver saw.

Plus: an approval authorizes exactly one execution (a replay re-requires consent), and a device cannot approve its own task under `excludeRequester`.

## What writing it found

Three bugs no struct-level test could see (all fixed in their own merged PRs — this branch is now just the test):

- **#658** — `vta/webvh/dids/create` expected snake_case; a camelCase client had its required `contextId` silently dropped.
- **#659** — the update handler looked a DID up by SCID only, but a remote caller holds the full DID, so every delegated update would have failed "SCID not found." The demo path was dead, silently.
- A documented subtlety: the re-submit after approval needs a **fresh envelope id with the same payload** — the grant binds the payload digest, the replay guard rejects a reused envelope id, and nothing had spelled out that a requester re-proposes rather than literally re-sends. The test documents it in place.

## Harness changes

Exposes `policy_ks` and `contexts_ks` on `TestAppContext`, so a harness can install policy and seed a context the way a deployment does — rather than reaching past the machinery it means to exercise. Uses the provisionable app (a real VTA signing identity), because the dry-run signs the planned entry and a sentinel DID with no key cannot execute the flow.

`cargo fmt --check`, harness is `clippy -D warnings` clean, all three pass.