### PR TITLE
feat(vta-service): declare requireConsent in config, reconciled at boot

### DIFF
--- a/vta-service/src/config.rs
+++ b/vta-service/src/config.rs
@@ -44,6 +44,43 @@ pub struct PolicyConfig {
     /// missing specs.
     #[serde(default)]
     pub require_payload_schema: bool,
+    /// Consent requirements declared in config, reconciled into the PDP at every
+    /// boot.
+    ///
+    /// This is the operator-facing way to require human approval for a task
+    /// *without editing and recompiling the baseline Rego*. The reference
+    /// implementation has no runtime policy-install surface; before this, turning
+    /// on consent meant editing `policies/default.rego`, rebuilding, and booting
+    /// against an empty policy keyspace. That is a source change to express an
+    /// operational choice.
+    ///
+    /// Each rule here becomes a synthesized `requireConsent` policy, installed
+    /// under a reserved id above the permissive baseline, and **reconciled on
+    /// every boot** — so config is the source of truth: add a rule and restart to
+    /// require consent, remove it and restart to stop. Anything the declarative
+    /// form cannot express is still authored as a full Rego policy; this covers
+    /// the common case, which is "a human must approve *this task*".
+    #[serde(default)]
+    pub require_consent: Vec<RequireConsentRule>,
+}
+
+/// A config-declared "this task needs a human" rule. Synthesized into Rego at
+/// boot; see [`PolicyConfig::require_consent`].
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct RequireConsentRule {
+    /// The Type URI to gate, e.g.
+    /// `https://trusttasks.org/spec/vta/webvh/dids/update/1.0`.
+    pub task_type: String,
+    /// Named approver set (must also appear in [`PolicyConfig::approver_sets`],
+    /// or the requirement fails closed at the gate).
+    pub approver_set: String,
+    /// Distinct approvals required. Default 1.
+    #[serde(default)]
+    pub min_approvals: Option<u32>,
+    /// When true, the requesting device may not count toward the threshold,
+    /// forcing cross-device approval. Default false.
+    #[serde(default)]
+    pub exclude_requester: Option<bool>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/vta-service/src/operations/did_webvh/update/state.rs
+++ b/vta-service/src/operations/did_webvh/update/state.rs
@@ -37,9 +37,9 @@ pub(in crate::operations::did_webvh) async fn find_record_by_scid(
         .await
         .map_err(|e| UpdateDidWebvhError::Persistence(format!("list_dids: {e}")))?;
     // Match a bare SCID, or a full DID whose SCID segment matches.
-    Ok(all.into_iter().find(|r| {
-        r.scid == scid_or_did || r.did == scid_or_did
-    }))
+    Ok(all
+        .into_iter()
+        .find(|r| r.scid == scid_or_did || r.did == scid_or_did))
 }
 
 /// Build a [`DIDWebVHState`] from a stored JSONL log string. Splits on

--- a/vta-service/src/policy/defaults.rs
+++ b/vta-service/src/policy/defaults.rs
@@ -57,6 +57,115 @@ pub async fn install_default_policy(
     Ok(())
 }
 
+/// Reserved policy id for the config-synthesized consent rules. Owned entirely by
+/// the reconciler — an operator's own uploads use their own ids and are never
+/// touched.
+pub const CONFIG_CONSENT_POLICY_ID: &str = "config:require-consent";
+
+/// Priority for the synthesized consent policy. Above the permissive baseline (0)
+/// so it fires first for the task types it names, and below a large headroom so an
+/// operator's hand-authored policy can still sit above it.
+const CONFIG_CONSENT_PRIORITY: i32 = 100;
+
+/// Reconcile the config-declared `require_consent` rules into the PDP.
+///
+/// Config is the source of truth, applied on **every** boot: the synthesized
+/// policy is upserted when rules are present and deleted when they are not, so an
+/// operator adds a rule and restarts to require consent, or removes it and
+/// restarts to stop — no source edit, no data-dir wipe, no dependence on the
+/// empty-keyspace install semantics `install_default_policy` relies on.
+///
+/// Runs *after* [`install_default_policy`] so the permissive baseline is present
+/// underneath to handle every task these rules do not name.
+pub async fn reconcile_config_consent_policy(
+    policy_ks: &KeyspaceHandle,
+    rules: &[crate::config::RequireConsentRule],
+    now_rfc3339: &str,
+) -> Result<(), AppError> {
+    if rules.is_empty() {
+        // No consent rules: ensure a previously-synthesized policy is gone, so
+        // removing the config block actually turns consent back off.
+        storage::delete_policy(policy_ks, CONFIG_CONSENT_POLICY_ID).await?;
+        return Ok(());
+    }
+
+    let rego = synthesize_consent_rego(rules);
+    // Compile-check before storing so a malformed synthesis fails loudly at boot
+    // rather than seating an unparseable policy that would deny every task it is
+    // consulted for.
+    super::engine::compile(&rego, CONFIG_CONSENT_POLICY_ID)?;
+
+    let module = PolicyModule {
+        id: CONFIG_CONSENT_POLICY_ID.to_string(),
+        name: "Config-declared consent".to_string(),
+        description: Some(
+            "Synthesized from [policy.require_consent]; reconciled every boot. \
+             Edit config and restart, do not edit this row."
+                .to_string(),
+        ),
+        module: rego,
+        applies_to: Vec::new(),
+        priority: CONFIG_CONSENT_PRIORITY,
+        enabled: true,
+        version: 1,
+        created_at: now_rfc3339.to_string(),
+        updated_at: now_rfc3339.to_string(),
+    };
+    storage::store_policy(policy_ks, &module).await?;
+    tracing::info!(
+        policy = CONFIG_CONSENT_POLICY_ID,
+        rules = rules.len(),
+        "reconciled config-declared consent policy"
+    );
+    Ok(())
+}
+
+/// Turn the declarative rules into a `vta.policy` Rego module.
+///
+/// One `decision` rule per task type, each guarded on `input.request.typeUri`, so
+/// the module fires only for the named tasks and is *undefined* (abstains) for
+/// everything else — which lets `decide()` fall through to the baseline. The
+/// guards are mutually exclusive by construction (distinct URIs), so no two
+/// complete rules ever conflict.
+fn synthesize_consent_rego(rules: &[crate::config::RequireConsentRule]) -> String {
+    let mut out = String::from("package vta.policy\n\nimport rego.v1\n\n");
+    out.push_str(
+        "# Generated from [policy.require_consent] in config.toml. Do not edit — \
+         this row is reconciled on every boot.\n\n",
+    );
+    for rule in rules {
+        let min = rule.min_approvals.unwrap_or(1).max(1);
+        let exclude = rule.exclude_requester.unwrap_or(false);
+        out.push_str(&format!(
+            "decision := {{\n\t\"decision\": \"requireConsent\",\n\t\"requireConsent\": \
+             {{\"approverSet\": {set}, \"minApprovals\": {min}, \"excludeRequester\": {exclude}}},\n\
+             }} if input.request.typeUri == {task}\n\n",
+            set = rego_string(&rule.approver_set),
+            task = rego_string(&rule.task_type),
+        ));
+    }
+    out
+}
+
+/// Encode a string as a Rego string literal, escaping the characters that would
+/// otherwise let operator-supplied config alter the generated policy's meaning.
+fn rego_string(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('"');
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            _ => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -120,5 +229,210 @@ mod tests {
         let all = storage::list_policies(&ks).await.unwrap();
         assert_eq!(all.len(), 1);
         assert_eq!(all[0].id, "operator");
+    }
+
+    use crate::config::RequireConsentRule;
+    use crate::policy::types::{
+        Consumer, Discloses, Disposition, Exposure, PolicyInput, PolicyRequest, SideEffectLevel,
+    };
+
+    const UPDATE_URI: &str = "https://trusttasks.org/spec/vta/webvh/dids/update/1.0";
+    const OTHER_URI: &str = "https://trusttasks.org/spec/vault/release/0.1";
+
+    fn rule(task: &str) -> RequireConsentRule {
+        RequireConsentRule {
+            task_type: task.into(),
+            approver_set: "ops".into(),
+            min_approvals: Some(2),
+            exclude_requester: Some(true),
+        }
+    }
+
+    fn input_for(type_uri: &str) -> PolicyInput {
+        PolicyInput {
+            request: PolicyRequest {
+                type_uri: type_uri.into(),
+                kind: None,
+                subject: None,
+                payload_digest: None,
+                side_effects: SideEffectLevel::Destructive,
+                exposure: Exposure {
+                    discloses: Discloses::None,
+                    acts_as_subject: false,
+                },
+            },
+            site: None,
+            context_id: "default".into(),
+            consumer: Consumer {
+                did: "did:key:zReq".into(),
+                kind: None,
+                device_id: None,
+                last_user_verification_at: None,
+                network_class: None,
+                acr: None,
+                amr: vec![],
+            },
+        }
+    }
+
+    async fn decide_for(ks: &KeyspaceHandle, type_uri: &str) -> crate::policy::PolicyDecision {
+        let policies = storage::load_active_for_context(ks, "default")
+            .await
+            .unwrap();
+        crate::policy::decide(&policies, &input_for(type_uri))
+    }
+
+    /// The whole point: a config rule makes the named task require consent — with
+    /// the operator's approver set, threshold and excludeRequester — through the
+    /// real load + decide path, not just synthesis.
+    #[tokio::test]
+    async fn a_config_rule_requires_consent_for_its_task() {
+        let (ks, _d) = temp_ks().await;
+        install_default_policy(&ks, "2026-07-15T00:00:00Z")
+            .await
+            .unwrap();
+        reconcile_config_consent_policy(&ks, &[rule(UPDATE_URI)], "2026-07-15T00:00:00Z")
+            .await
+            .unwrap();
+
+        let d = decide_for(&ks, UPDATE_URI).await;
+        assert_eq!(d.decision, Disposition::RequireConsent);
+        let rc = d.require_consent.expect("requireConsent carrier");
+        assert_eq!(rc.approver_set, "ops");
+        assert_eq!(rc.min_approvals, 2);
+        assert!(rc.exclude_requester);
+    }
+
+    /// An unnamed task falls through the config module (it abstains) to the
+    /// permissive baseline.
+    #[tokio::test]
+    async fn an_unnamed_task_falls_through_to_the_baseline() {
+        let (ks, _d) = temp_ks().await;
+        install_default_policy(&ks, "2026-07-15T00:00:00Z")
+            .await
+            .unwrap();
+        reconcile_config_consent_policy(&ks, &[rule(UPDATE_URI)], "2026-07-15T00:00:00Z")
+            .await
+            .unwrap();
+        assert_eq!(
+            decide_for(&ks, OTHER_URI).await.decision,
+            Disposition::Allow
+        );
+    }
+
+    /// Config is authoritative every boot: reconciling with no rules removes a
+    /// previously-synthesized policy, so deleting the config block turns consent
+    /// back off without a data-dir wipe.
+    #[tokio::test]
+    async fn removing_the_rule_turns_consent_back_off() {
+        let (ks, _d) = temp_ks().await;
+        install_default_policy(&ks, "2026-07-15T00:00:00Z")
+            .await
+            .unwrap();
+        reconcile_config_consent_policy(&ks, &[rule(UPDATE_URI)], "2026-07-15T00:00:00Z")
+            .await
+            .unwrap();
+        assert_eq!(
+            decide_for(&ks, UPDATE_URI).await.decision,
+            Disposition::RequireConsent
+        );
+
+        reconcile_config_consent_policy(&ks, &[], "2026-07-15T00:00:00Z")
+            .await
+            .unwrap();
+        assert_eq!(
+            decide_for(&ks, UPDATE_URI).await.decision,
+            Disposition::Allow
+        );
+        assert!(
+            storage::get_policy(&ks, CONFIG_CONSENT_POLICY_ID)
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    /// Reconcile is idempotent, and never touches an operator's own policies.
+    #[tokio::test]
+    async fn reconcile_is_idempotent_and_leaves_operator_policies_alone() {
+        let (ks, _d) = temp_ks().await;
+        install_default_policy(&ks, "2026-07-15T00:00:00Z")
+            .await
+            .unwrap();
+
+        let op = PolicyModule {
+            id: "operator-custom".into(),
+            name: "op".into(),
+            description: None,
+            module:
+                "package vta.policy\nimport rego.v1\ndecision := {\"decision\": \"deny\"} if false"
+                    .into(),
+            applies_to: vec![],
+            priority: 5,
+            enabled: true,
+            version: 1,
+            created_at: "2026-07-15T00:00:00Z".into(),
+            updated_at: "2026-07-15T00:00:00Z".into(),
+        };
+        storage::store_policy(&ks, &op).await.unwrap();
+
+        for _ in 0..3 {
+            reconcile_config_consent_policy(&ks, &[rule(UPDATE_URI)], "2026-07-15T00:00:00Z")
+                .await
+                .unwrap();
+        }
+        assert!(
+            storage::get_policy(&ks, "operator-custom")
+                .await
+                .unwrap()
+                .is_some()
+        );
+        assert!(
+            storage::get_policy(&ks, CONFIG_CONSENT_POLICY_ID)
+                .await
+                .unwrap()
+                .is_some()
+        );
+        assert_eq!(
+            decide_for(&ks, UPDATE_URI).await.decision,
+            Disposition::RequireConsent
+        );
+    }
+
+    /// A crafted approver-set name cannot break out of the generated Rego string.
+    ///
+    /// The teeth: an approver_set containing `", "decision": "allow` would, if
+    /// unescaped, close the string literal and inject a second decision key. The
+    /// property that proves it did NOT is that the task still resolves to
+    /// requireConsent with the approver-set name returned *exactly as given* — the
+    /// quote stayed inside the string.
+    #[tokio::test]
+    async fn synthesis_escapes_operator_strings() {
+        let injected = r#"ops", "decision": "allow"#;
+        let nasty = RequireConsentRule {
+            task_type: "https://trusttasks.org/spec/vta/x/1.0".into(),
+            approver_set: injected.into(),
+            min_approvals: None,
+            exclude_requester: None,
+        };
+        let (ks, _d) = temp_ks().await;
+        install_default_policy(&ks, "2026-07-15T00:00:00Z")
+            .await
+            .unwrap();
+        reconcile_config_consent_policy(&ks, std::slice::from_ref(&nasty), "2026-07-15T00:00:00Z")
+            .await
+            .unwrap();
+
+        let d = decide_for(&ks, "https://trusttasks.org/spec/vta/x/1.0").await;
+        assert_eq!(
+            d.decision,
+            Disposition::RequireConsent,
+            "the injection must not turn the decision into allow"
+        );
+        assert_eq!(
+            d.require_consent.unwrap().approver_set,
+            injected,
+            "the crafted quote stayed inside the string — it did not break out"
+        );
     }
 }

--- a/vta-service/src/policy/mod.rs
+++ b/vta-service/src/policy/mod.rs
@@ -39,7 +39,7 @@ pub mod input;
 pub mod storage;
 pub mod types;
 
-pub use defaults::install_default_policy;
+pub use defaults::{install_default_policy, reconcile_config_consent_policy};
 pub use engine::{CompiledPolicy, compile, evaluate_decision};
 pub use input::build_policy_input;
 pub use storage::load_active_for_context;

--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -821,6 +821,17 @@ pub async fn run(
         )
         .await?;
 
+        // Reconcile config-declared consent rules on top of the baseline. Unlike
+        // the baseline install, this runs every boot and config is authoritative —
+        // so requiring consent for a task is a config edit and a restart, not a
+        // source edit and a rebuild.
+        crate::policy::reconcile_config_consent_policy(
+            &app_state.policy_ks,
+            &app_state.config.read().await.policy.require_consent,
+            &chrono::Utc::now().to_rfc3339(),
+        )
+        .await?;
+
         // Fail-closed on missing identity (P0.9b). `init_auth` (inside
         // build_app_state) yields `jwt_keys: Some` only when the VTA has a
         // complete, usable signing identity: a configured `vta_did`, its key


### PR DESCRIPTION
Requiring human approval for a task should be an operational choice, expressed in config. Today it's a **source change**.

This build has no runtime policy-install surface (no `policy/upsert` task, no CLI, no API). The only way to seat a `requireConsent` policy is to edit the compiled-in `policies/default.rego`, **rebuild**, and boot against an **empty policy keyspace** (the baseline installer is a no-op otherwise). So expressing "a human must approve DID updates" means a recompile and a data-dir wipe — and it makes the whole consent feature effectively undemoable without touching source. This came up trying to write a runbook for testing the flow by hand.

## What this adds

```toml
[[policy.require_consent]]
task_type = "https://trusttasks.org/spec/vta/webvh/dids/update/1.0"
approver_set = "ops"
min_approvals = 1
exclude_requester = true
```

Each rule is synthesized into a `vta.policy` Rego module and **reconciled into the PDP on every boot**, under a reserved id (`config:require-consent`, priority 100, above the permissive baseline). Config is authoritative — a rule present upserts the policy, a rule removed deletes it. Requiring consent is now a config edit and a restart.

## Design

- **Abstain-and-fall-through.** Each rule guards on `input.request.typeUri`, so the module fires only for the tasks it names and is *undefined* for everything else. `decide()` iterates descending priority and continues past an abstaining module, so unnamed tasks fall through to the baseline. No `deny`-everything footgun.
- **Injection-safe.** Operator strings are escaped into Rego string literals. The test proves it: an `approver_set` containing `", "decision": "allow` must come back **verbatim as the approver-set name** (the quote stayed inside the string) rather than injecting a second decision — and the test **fails if the escaping is removed** (verified).
- **Never touches operator policies.** The reconciler owns only its reserved id; hand-authored policies under their own ids survive untouched. Full Rego remains the escape hatch for anything the declarative form can't express.

## Tests

Five, through the real `load_active_for_context` → `decide` path (not just synthesis):
- a config rule requires consent for its task, with the declared set / threshold / excludeRequester
- an unnamed task falls through to the baseline `allow`
- removing the rule turns consent back off **and deletes** the synthesized policy
- reconcile is idempotent and leaves an operator's own policy alone
- the injection escape holds

`cargo fmt --check`, `cargo clippy --workspace --features webvh -- -D warnings`, 1182 `vta-service` tests — clean.

## Follow-up

The runbook this unblocks becomes: set `enforcement = true`, add a `[[policy.require_consent]]` block and an `approver_sets` entry, restart. No Rego edit, no rebuild. I'll update the runbook once this merges.