### PR TITLE
fix(vta-sdk): acl/create body reads camelCase, rejects unknown fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+### vta-sdk (0.19.4) — acl/create body reads camelCase, rejects unknown fields
+
+* `CreateAclBody` (the `spec/vta/acl/create/1.0` Trust Task payload) now
+  deserializes **camelCase** as its canonical wire form, matching the published
+  spec convention and the sibling `acl/swap-key` body. Snake_case is still
+  accepted via per-field aliases (non-breaking for the REST client and legacy
+  senders), and unknown fields are now rejected (`deny_unknown_fields`).
+* Fixes a silent-drop hazard: a spec-conventional camelCase caller previously
+  had `allowedContexts`/`expiresAt` dropped to defaults. Because an empty
+  `allowed_contexts` on an `Admin` entry is a super-admin, a super-admin caller
+  intending a scoped, expiring grant could instead mint a permanent,
+  unrestricted admin.
+
 ### vti-common (0.11.5)
 
 * Added `setup_acl: bool` (default `false`) to `MessagingConfig`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2452,7 +2452,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.19.3",
+ "vta-sdk 0.19.4",
 ]
 
 [[package]]
@@ -3254,7 +3254,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.19.3",
+ "vta-sdk 0.19.4",
 ]
 
 [[package]]
@@ -6714,7 +6714,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.19.3",
+ "vta-sdk 0.19.4",
 ]
 
 [[package]]
@@ -10017,7 +10017,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.19.3",
+ "vta-sdk 0.19.4",
  "vti-common",
  "x25519-dalek",
 ]
@@ -10050,7 +10050,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.19.3",
+ "vta-sdk 0.19.4",
 ]
 
 [[package]]
@@ -10073,7 +10073,7 @@ dependencies = [
  "tracing-subscriber",
  "trust-tasks-rs",
  "uniffi",
- "vta-sdk 0.19.3",
+ "vta-sdk 0.19.4",
 ]
 
 [[package]]
@@ -10108,7 +10108,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.19.3"
+version = "0.19.4"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10243,7 +10243,7 @@ dependencies = [
  "utoipa-axum",
  "uuid",
  "vta-cli-common",
- "vta-sdk 0.19.3",
+ "vta-sdk 0.19.4",
  "vta-service",
  "vti-common",
  "vti-secrets",
@@ -10265,7 +10265,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.19.3",
+ "vta-sdk 0.19.4",
 ]
 
 [[package]]
@@ -10337,7 +10337,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.19.3",
+ "vta-sdk 0.19.4",
  "vtc-service",
  "vti-common",
  "vti-secrets",
@@ -10385,7 +10385,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.19.3",
+ "vta-sdk 0.19.4",
  "webauthn-rs",
  "zeroize",
 ]
@@ -10412,7 +10412,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.19.3",
+ "vta-sdk 0.19.4",
  "vta-service",
  "vti-common",
 ]
@@ -10441,7 +10441,7 @@ dependencies = [
  "tokio",
  "tracing",
  "vaultrs",
- "vta-sdk 0.19.3",
+ "vta-sdk 0.19.4",
  "vti-common",
 ]
 

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.19.3"
+version = "0.19.4"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/protocols/acl_management/create.rs
+++ b/vta-sdk/src/protocols/acl_management/create.rs
@@ -1,26 +1,49 @@
 use serde::{Deserialize, Serialize};
 
+/// Payload for the `spec/vta/acl/create/1.0` Trust Task.
+///
+/// **Wire casing is camelCase** (the published Trust-Task spec convention,
+/// matching the sibling `acl/swap-key` body). Snake_case is still accepted on
+/// input via per-field aliases so existing/legacy senders keep working, and
+/// `deny_unknown_fields` makes a misspelled or unrecognized field a *loud*
+/// rejection rather than a silent drop.
+///
+/// This matters for authorization safety: a silently-dropped `allowedContexts`
+/// defaults to an empty vec, and an empty `allowed_contexts` on an `Admin`
+/// entry is a **super-admin** (`AclEntry::is_super_admin`). Before camelCase
+/// was accepted, a spec-conventional caller intending a scoped, expiring grant
+/// could have both `allowedContexts` and `expiresAt` dropped and end up
+/// minting a permanent, unrestricted admin.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct CreateAclBody {
     pub did: String,
     pub role: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub label: Option<String>,
-    #[serde(default)]
+    #[serde(default, alias = "allowed_contexts")]
     pub allowed_contexts: Vec<String>,
     /// Unix-epoch seconds at which the entry auto-expires. `None` = permanent.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none", alias = "expires_at")]
     pub expires_at: Option<u64>,
     /// VID authorized to ratify a delegated AAL2 step-up for this subject —
     /// the `recipient` an `auth/step-up/approve-request/0.1` is addressed to
     /// (the holder's mobile/browser approver). Stored on the ACL entry as
     /// `step_up_approver`. `None` = no delegated approver configured.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        alias = "step_up_approver"
+    )]
     pub step_up_approver: Option<String>,
     /// Per-entry step-up override (`"self"` | `"delegated"`) raising the system
     /// floor for this subject. Stored as `step_up_require`. `None` = no override.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        alias = "step_up_require"
+    )]
     pub step_up_require: Option<String>,
 }
 
@@ -44,4 +67,81 @@ pub struct CreateAclResultBody {
     /// if any (echoes the stored `step_up_require`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub step_up_require: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The regression: a spec-conventional **camelCase** `acl/create` payload
+    /// must populate `allowed_contexts`/`expires_at`, not silently drop them.
+    /// A dropped `allowedContexts` on an Admin role is a permanent super-admin.
+    #[test]
+    fn camelcase_payload_populates_scope_and_expiry() {
+        let json = serde_json::json!({
+            "did": "did:key:z6MkSubject",
+            "role": "admin",
+            "allowedContexts": ["ctx-a", "ctx-b"],
+            "expiresAt": 1_800_000_000u64,
+            "stepUpApprover": "did:key:z6MkApprover",
+            "stepUpRequire": "delegated",
+        });
+        let body: CreateAclBody = serde_json::from_value(json).unwrap();
+        assert_eq!(body.allowed_contexts, vec!["ctx-a", "ctx-b"]);
+        assert_eq!(body.expires_at, Some(1_800_000_000));
+        assert_eq!(
+            body.step_up_approver.as_deref(),
+            Some("did:key:z6MkApprover")
+        );
+        assert_eq!(body.step_up_require.as_deref(), Some("delegated"));
+    }
+
+    /// Back-compat: legacy/REST snake_case senders still deserialize via aliases.
+    #[test]
+    fn snakecase_payload_still_accepted_via_alias() {
+        let json = serde_json::json!({
+            "did": "did:key:z6MkSubject",
+            "role": "admin",
+            "allowed_contexts": ["ctx-a"],
+            "expires_at": 1_800_000_000u64,
+            "step_up_approver": "did:key:z6MkApprover",
+        });
+        let body: CreateAclBody = serde_json::from_value(json).unwrap();
+        assert_eq!(body.allowed_contexts, vec!["ctx-a"]);
+        assert_eq!(body.expires_at, Some(1_800_000_000));
+        assert_eq!(
+            body.step_up_approver.as_deref(),
+            Some("did:key:z6MkApprover")
+        );
+    }
+
+    /// A misspelled/unknown scope field is a loud rejection, never a silent
+    /// drop that would default the entry to unrestricted super-admin scope.
+    #[test]
+    fn unknown_field_is_rejected() {
+        let json = serde_json::json!({
+            "did": "did:key:z6MkSubject",
+            "role": "admin",
+            "allowedContext": ["ctx-a"], // note: singular typo
+        });
+        assert!(serde_json::from_value::<CreateAclBody>(json).is_err());
+    }
+
+    /// Serialization emits the canonical camelCase wire form.
+    #[test]
+    fn serializes_as_camelcase() {
+        let body = CreateAclBody {
+            did: "did:key:z6MkSubject".into(),
+            role: "admin".into(),
+            label: None,
+            allowed_contexts: vec!["ctx-a".into()],
+            expires_at: Some(1_800_000_000),
+            step_up_approver: None,
+            step_up_require: None,
+        };
+        let v = serde_json::to_value(&body).unwrap();
+        assert!(v.get("allowedContexts").is_some());
+        assert!(v.get("expiresAt").is_some());
+        assert!(v.get("allowed_contexts").is_none());
+    }
 }


### PR DESCRIPTION
## Problem

`CreateAclBody` — the payload for the `spec/vta/acl/create/1.0` Trust Task — deserialized **snake_case only**, unlike the camelCase published-spec convention and the sibling `acl/swap-key` body (`SwapKeyBody`, which already carries `#[serde(rename_all = "camelCase")]`). This is the same class of defect fixed for the did-management bodies in #658.

A spec-conventional **camelCase** caller therefore had `allowedContexts` and `expiresAt` **silently dropped** to their defaults. Because an empty `allowed_contexts` on an `Admin` entry is a **super-admin** (`AclEntry::is_super_admin`, `vti-common/src/acl/mod.rs`), a super-admin caller who intended a *scoped, expiring* grant could instead mint a **permanent, unrestricted admin**.

Scope note: `create_acl` calls `validate_acl_modification`, so a **context-admin** caller sending camelCase fails closed ("only super admin can create unrestricted accounts"). The escalation is specific to a **super-admin** caller whose scoped intent is silently widened — a privilege *broadening*, not a bypass of the role check.

## Fix

In `vta-sdk/src/protocols/acl_management/create.rs`:

- `#[serde(rename_all = "camelCase")]` — camelCase is now the canonical wire form, matching the spec and the sibling body.
- Per-field `alias = "…"` for the snake_case names — **non-breaking**: the REST client (`CreateAclRequest`) and any legacy sender still deserialize.
- `#[serde(deny_unknown_fields)]` — a misspelled/unknown scope field is now a **loud rejection** rather than a silent drop that would default the entry to unrestricted super-admin scope.

Only `CreateAclBody` (the request) changes; `CreateAclResultBody` (the response) is untouched, so response wire shapes and their tests are unaffected.

## Tests

Adds four regression tests:
- `camelcase_payload_populates_scope_and_expiry` — the exact vulnerability: a camelCase body must populate `allowed_contexts`/`expires_at`.
- `snakecase_payload_still_accepted_via_alias` — back-compat.
- `unknown_field_is_rejected` — deny-unknown-fields.
- `serializes_as_camelcase` — canonical output.

Verified locally: the 4 new tests pass, the full `vta-sdk` lib suite (176 tests) passes, and `vta-service` compiles against the changed body.

## Follow-up (not in this PR)

Registering a schema for `spec/vta/acl/create/1.0` in the schema index would add gate-level validation as defense in depth (guide rule R3.3). The serde change here fully closes the confirmed silent-drop; the schema is a separate, larger change.