### PR TITLE
fix(vta-service): consent reject carries a machine-readable reason in details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+### vta-service (0.11.1) — consent rejects carry a machine-readable reason
+
+* The consent-required rejection (`policy_gate`) now includes an explicit
+  `"reason": "auth:consent_required"` in the trust-task-error `details`, so a
+  consumer keys on a stable structured field instead of the standard top-level
+  `code` (`taskFailed`) or the free-text `message`. Additive and
+  backward-compatible — existing `details` fields (`payloadDigest`, `challenge`,
+  `approverSet`, `minApprovals`, `consentRequests`) are unchanged.
+
 ### vta-sdk (0.19.4) — acl/create body reads camelCase, rejects unknown fields
 
 * `CreateAclBody` (the `spec/vta/acl/create/1.0` Trust Task payload) now

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10165,7 +10165,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.11.0"
+version = "0.11.1"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/trust_tasks/policy_gate.rs
+++ b/vta-service/src/trust_tasks/policy_gate.rs
@@ -383,6 +383,11 @@ async fn consent_gate(
         RejectReason::TaskFailed {
             reason: "auth:consent_required".into(),
             details: Some(json!({
+                // The machine-readable reason, so a consumer keys on a stable
+                // field in `details` rather than the standard top-level `code`
+                // (which is `taskFailed` for this rejection) or the free-text
+                // `message`. Mirrors the `RejectReason::TaskFailed.reason` above.
+                "reason": "auth:consent_required",
                 // The salted digest: what the approver signs, and what the two
                 // screens compare. The internal one never leaves this process.
                 "payloadDigest": pending.wire_digest,
@@ -632,6 +637,15 @@ mod tests {
         let details = body
             .pointer("/payload/details")
             .expect("reject carries details");
+
+        // The machine-readable reason a consumer keys on lives in `details`,
+        // not the top-level `code` (`taskFailed`) — so clients don't string-match
+        // the free-text message.
+        assert_eq!(
+            details["reason"].as_str(),
+            Some("auth:consent_required"),
+            "consent rejects must carry a machine-readable reason in details"
+        );
 
         let requests = details["consentRequests"]
             .as_array()


### PR DESCRIPTION
## Context

Companion to OpenVTC/vta-browser-plugin#87 (merged), which fixed the browser wallet's consent detection. This makes the VTA side of that contract explicit.

## Problem

The consent-required rejection (`policy_gate`) is emitted as `RejectReason::TaskFailed`, which serializes to the **standard** Trust Task error code `taskFailed` (`trust-tasks-rs` `ErrorPayload`), with the reason folded into the free-text `message`. A consumer that needs to detect "human approval required" has no stable machine-readable field to key on — the review found the browser wallet matching `auth:consent_required` against the top-level `code`, which never matches, so the consent flow died silently (D8-F1).

## Change

Add an explicit `"reason": "auth:consent_required"` to the trust-task-error `details`, mirroring `RejectReason::TaskFailed.reason`. Consumers now key on a stable structured field instead of the top-level code or a message string (guide rule R3.7).

Additive and backward-compatible: the existing `details` fields (`payloadDigest`, `challenge`, `approverSet`, `minApprovals`, `consentRequests`) are unchanged; the top-level `code` stays `taskFailed`, so no other consumer's behavior changes.

## Rollout independence

The plugin consumer keys on this `details.reason` **with a fallback** to the presence of the executor-signed `details.consentRequests`, so neither side depends on the other's deploy order.

## Tests

Extended `consent_reject_carries_vta_signed_requests` to assert `details.reason == "auth:consent_required"`. Passes (`cargo test -p vta-service`). Version-bump guard: `vta-service 0.11.0 -> 0.11.1`, CHANGELOG updated.