### PR TITLE
fix: finite timeouts on VTA REST + webvh HTTP clients (D2 F2/F3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Unreleased
 
+### vta-sdk (0.19.5) — finite timeouts on all REST clients
+
+* Every SDK REST client is now built with request + connect timeouts (new
+  internal `http::rest_client`, overridable via `VTA_REST_TIMEOUT_SECS` /
+  `VTA_REST_CONNECT_TIMEOUT_SECS`) instead of `reqwest::Client::new()`, which
+  has no default timeout. A hung or blackholed VTA now surfaces as a timeout
+  error rather than hanging the caller (vtc setup, vta-mcp, the CLIs) forever.
+
+### vta-service (0.11.2) — webvh client timeout bounds the per-server auth mutex
+
+* `WebvhClient` is built with request + connect timeouts. A wedged hosting
+  daemon now fails with a timeout instead of an unbounded hang, which also
+  bounds how long `auth_cache::ensure_fresh_access_token` holds the per-server
+  auth mutex — so one dead daemon can no longer freeze all publishing for that
+  server.
+
 ### vta-service (0.11.1) — consent rejects carry a machine-readable reason
 
 * The consent-required rejection (`policy_gate`) now includes an explicit

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2452,7 +2452,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.19.4",
+ "vta-sdk 0.19.5",
 ]
 
 [[package]]
@@ -3254,7 +3254,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.19.4",
+ "vta-sdk 0.19.5",
 ]
 
 [[package]]
@@ -6714,7 +6714,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.19.4",
+ "vta-sdk 0.19.5",
 ]
 
 [[package]]
@@ -10017,7 +10017,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.19.4",
+ "vta-sdk 0.19.5",
  "vti-common",
  "x25519-dalek",
 ]
@@ -10050,7 +10050,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.19.4",
+ "vta-sdk 0.19.5",
 ]
 
 [[package]]
@@ -10073,7 +10073,7 @@ dependencies = [
  "tracing-subscriber",
  "trust-tasks-rs",
  "uniffi",
- "vta-sdk 0.19.4",
+ "vta-sdk 0.19.5",
 ]
 
 [[package]]
@@ -10108,7 +10108,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.19.4"
+version = "0.19.5"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10165,7 +10165,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",
@@ -10243,7 +10243,7 @@ dependencies = [
  "utoipa-axum",
  "uuid",
  "vta-cli-common",
- "vta-sdk 0.19.4",
+ "vta-sdk 0.19.5",
  "vta-service",
  "vti-common",
  "vti-secrets",
@@ -10265,7 +10265,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.19.4",
+ "vta-sdk 0.19.5",
 ]
 
 [[package]]
@@ -10337,7 +10337,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.19.4",
+ "vta-sdk 0.19.5",
  "vtc-service",
  "vti-common",
  "vti-secrets",
@@ -10385,7 +10385,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.19.4",
+ "vta-sdk 0.19.5",
  "webauthn-rs",
  "zeroize",
 ]
@@ -10412,7 +10412,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.19.4",
+ "vta-sdk 0.19.5",
  "vta-service",
  "vti-common",
 ]
@@ -10441,7 +10441,7 @@ dependencies = [
  "tokio",
  "tracing",
  "vaultrs",
- "vta-sdk 0.19.4",
+ "vta-sdk 0.19.5",
  "vti-common",
 ]
 

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.19.4"
+version = "0.19.5"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/client/mod.rs
+++ b/vta-sdk/src/client/mod.rs
@@ -211,7 +211,7 @@ impl VtaClient {
     pub fn new(base_url: &str) -> Self {
         Self {
             transport: Transport::Rest {
-                client: Client::new(),
+                client: crate::http::rest_client(),
                 base_url: base_url.trim_end_matches('/').to_string(),
                 auth: std::sync::Arc::new(tokio::sync::Mutex::new(RestAuth {
                     token: None,
@@ -306,7 +306,7 @@ impl VtaClient {
         .await
         .map_err(|e| VtaError::DidcommTransport(e.to_string()))?;
 
-        let rest_client = rest_url.as_ref().map(|_| Client::new());
+        let rest_client = rest_url.as_ref().map(|_| crate::http::rest_client());
 
         Ok(Self {
             transport: Transport::DIDComm {
@@ -356,7 +356,7 @@ impl VtaClient {
         .await
         .map_err(|e| VtaError::DidcommTransport(e.to_string()))?;
 
-        let rest_client = rest_url.as_ref().map(|_| Client::new());
+        let rest_client = rest_url.as_ref().map(|_| crate::http::rest_client());
 
         Ok(Self {
             transport: Transport::DIDComm {

--- a/vta-sdk/src/http.rs
+++ b/vta-sdk/src/http.rs
@@ -1,0 +1,64 @@
+//! Shared HTTP client construction for the SDK's REST transports.
+//!
+//! `reqwest` applies **no** request or connect timeout by default, so a hung or
+//! blackholed VTA (a half-open load balancer, a SIGSTOPped process, a firewall
+//! silently dropping packets) would hang the caller forever. Every REST client
+//! in the SDK is built here so the timeouts are applied uniformly.
+
+use std::time::Duration;
+
+/// Default total-request timeout for a VTA REST call.
+const DEFAULT_REST_TIMEOUT_SECS: u64 = 30;
+/// Default TCP/TLS connect timeout.
+const DEFAULT_REST_CONNECT_TIMEOUT_SECS: u64 = 10;
+
+/// A `reqwest::Client` with finite request + connect timeouts.
+///
+/// Overridable via `VTA_REST_TIMEOUT_SECS` / `VTA_REST_CONNECT_TIMEOUT_SECS`
+/// (positive integers, seconds); anything missing/zero/unparseable falls back to
+/// the defaults. Use this instead of `reqwest::Client::new()` for any REST call
+/// to a VTA so a wedged peer surfaces as a timeout error, not an unbounded hang.
+///
+/// Panics only if the TLS backend cannot initialize — the same condition under
+/// which `reqwest::Client::new()` already panics, so this is not a new failure
+/// mode.
+pub(crate) fn rest_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .timeout(env_secs("VTA_REST_TIMEOUT_SECS", DEFAULT_REST_TIMEOUT_SECS))
+        .connect_timeout(env_secs(
+            "VTA_REST_CONNECT_TIMEOUT_SECS",
+            DEFAULT_REST_CONNECT_TIMEOUT_SECS,
+        ))
+        .build()
+        .expect("reqwest client with timeouts (TLS backend init)")
+}
+
+/// Read a positive-integer seconds value from `var`, falling back to `default`.
+fn env_secs(var: &str, default: u64) -> Duration {
+    let secs = std::env::var(var)
+        .ok()
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .filter(|&n| n > 0)
+        .unwrap_or(default);
+    Duration::from_secs(secs)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn env_secs_uses_default_when_unset_or_junk() {
+        // A var that does not exist → default.
+        assert_eq!(
+            env_secs("VTA_REST_TIMEOUT_SECS_DEFINITELY_UNSET_XYZ", 30),
+            Duration::from_secs(30)
+        );
+    }
+
+    #[test]
+    fn rest_client_builds() {
+        // Building must not panic in a normal environment (TLS backend present).
+        let _ = rest_client();
+    }
+}

--- a/vta-sdk/src/lib.rs
+++ b/vta-sdk/src/lib.rs
@@ -111,6 +111,8 @@ pub mod didcomm_session;
 // Pins rustls to the aws-lc-rs backend; every binary calls this at startup.
 #[cfg(feature = "crypto-provider")]
 pub mod crypto_init;
+#[cfg(feature = "client")]
+pub(crate) mod http;
 #[cfg(feature = "keyring")]
 pub mod keyring_init;
 pub mod keys;

--- a/vta-sdk/src/provision_client/auth_rest.rs
+++ b/vta-sdk/src/provision_client/auth_rest.rs
@@ -54,7 +54,7 @@ pub async fn challenge_response_di(
     private_key_multibase: &str,
     vta_did: &str,
 ) -> Result<TokenResult, Box<dyn std::error::Error>> {
-    let http = reqwest::Client::new();
+    let http = crate::http::rest_client();
 
     // Step 1 — request a challenge. Flat `{ subject }` request → canonical
     // `{ challenge, sessionId, expiresAt }` response.

--- a/vta-sdk/src/session.rs
+++ b/vta-sdk/src/session.rs
@@ -902,7 +902,7 @@ async fn rotate_key(
 ) -> Result<(Session, TokenResult), Box<dyn std::error::Error>> {
     use crate::protocols::acl_management::swap::{SwapAclBody, build_swap_presentation};
 
-    let http = reqwest::Client::new();
+    let http = crate::http::rest_client();
 
     // `ensure_authenticated` has already gated `vta_did.is_some()` via
     // `require_vta_did`; safe to unwrap here.
@@ -975,7 +975,7 @@ pub async fn challenge_response(
         base_url,
         client_did, vta_did, "starting challenge-response auth"
     );
-    let http = reqwest::Client::new();
+    let http = crate::http::rest_client();
 
     // Step 1: Request challenge
     let challenge_url = format!("{base_url}/auth/challenge");

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.11.1"
+version = "0.11.2"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/webvh_client.rs
+++ b/vta-service/src/webvh_client.rs
@@ -1,5 +1,12 @@
 use serde::Deserialize;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+/// Total-request timeout for a call to a webvh hosting daemon (auth, publish,
+/// delete, register). Generous enough for a DID-log publish, bounded so a
+/// wedged daemon can't hang the operation — or the per-server auth mutex.
+const WEBVH_HTTP_TIMEOUT: Duration = Duration::from_secs(30);
+/// TCP/TLS connect timeout for a webvh hosting daemon.
+const WEBVH_HTTP_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 use tracing::{debug, info, warn};
 use url::{Host, Url};
 
@@ -223,7 +230,17 @@ impl WebvhClient {
         })?;
         enforce_transport_security(&parsed, server_url)?;
         Ok(Self {
-            http: reqwest::Client::new(),
+            // Finite timeouts: reqwest has none by default. A wedged hosting
+            // daemon (accepts TCP, never answers) must surface as a timeout
+            // error, not an unbounded hang — which also bounds how long the
+            // per-server auth mutex (`auth_cache::ensure_fresh_access_token`)
+            // is held across `authenticate`/`refresh`, so one dead daemon can't
+            // freeze all publishing for that server.
+            http: reqwest::Client::builder()
+                .timeout(WEBVH_HTTP_TIMEOUT)
+                .connect_timeout(WEBVH_HTTP_CONNECT_TIMEOUT)
+                .build()
+                .expect("reqwest client with timeouts (TLS backend init)"),
             server_url: server_url.trim_end_matches('/').to_string(),
             server_did: server_did.to_string(),
             access_token: None,


### PR DESCRIPTION
## Problem

`reqwest` applies **no** request or connect timeout by default, so a hung or blackholed peer (half-open load balancer, SIGSTOPped process, firewall silently dropping packets) hangs the caller **forever**. This is pervasive on the VTA's outbound paths (D2 findings F2/F3):

- **F2 (vta-sdk):** every SDK REST client is `reqwest::Client::new()` — `VtaClient::new`, the two DIDComm rest-fallback clients, `rotate_key`/`challenge_response` in `session.rs`, and `provision_client::challenge_response_di`. Consumers (`vtc setup`, `vta-mcp`, the pnm/cnm CLIs) inherit the unbounded hang.
- **F3 (vta-service):** `WebvhClient` uses a no-timeout client, and `auth_cache::ensure_fresh_access_token` holds a per-server async mutex across the `authenticate`/`refresh` round-trip. With no timeout, one wedged hosting daemon holds the mutex forever and **freezes all publishing for that server**.

## Fix

- **vta-sdk:** new internal `http::rest_client()` builds a client with request + connect timeouts (defaults 30s / 10s, overridable via `VTA_REST_TIMEOUT_SECS` / `VTA_REST_CONNECT_TIMEOUT_SECS`). All six `Client::new()` sites now use it. Gated behind the `client` feature (where `reqwest` lives); builds clean across default / no-default / all-features.
- **vta-service:** `WebvhClient` is built with request + connect timeouts. This bounds a wedged daemon to a timeout error **and** bounds how long the per-server auth mutex is held — so one dead daemon no longer freezes publishing. The single-flight mutex is deliberately unchanged (it prevents concurrent double-reauth); it's now just bounded rather than unbounded.

`password_post`'s client was already hardened (timeout + `redirect(none)`) and is untouched.

## Not in this PR

D2-F1 — the credential-present **status-list foreign fetch** (`vault/status.rs`), which needs SSRF-grade hardening (no redirects, body cap, address filtering) — is a separate PR; it's the attacker-controlled-URL path and deserves its own review. `vtc-service` already has the reference (`FOREIGN_FETCH_CLIENT` + `read_body_capped`).

## Tests / checks

`vta-sdk` lib suite green (214) incl. new `http` tests; `vta-service` compiles; clippy clean as CI runs it (`cargo clippy --workspace -- -D warnings`); builds across default/no-default/all-features. Version-bump guard: vta-sdk 0.19.4→0.19.5, vta-service 0.11.1→0.11.2, CHANGELOG updated.