### PR TITLE
fix: SSRF/DoS-harden the issuer status-list fetch (D2 F1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## Unreleased
 
+### vta-sdk (0.19.6) — shared hardened foreign-fetch helper
+
+* New `http::{foreign_fetch_client, read_body_capped, guard_public_url,
+  DEFAULT_MAX_FOREIGN_BODY, ForeignFetchError}`: the single hardened chokepoint
+  for fetching attacker-influenceable URLs — `redirect(none)` (blocks
+  SSRF-via-redirect), bounded timeouts, a chunked response-body cap, and an
+  SSRF URL guard (https-only, no userinfo, rejects loopback/private/link-local/
+  multicast/ULA and cloud-metadata IP targets). Ported from vtc-service's
+  reference implementation so consumers share one guard instead of each rolling
+  their own.
+
+### vta-service (0.11.3) — status-list fetch is SSRF/DoS-hardened
+
+* `HttpStatusListResolver` (the issuer-supplied status-list fetch on the
+  credential-present path) previously used `reqwest::Client::new()`: no timeout,
+  default redirect-following, and `.json()` buffering an unbounded body — a
+  tarpit / SSRF-via-redirect / OOM surface on a hot path. It now guards the URL
+  (`vta_sdk::http::guard_public_url`) before dialing, fetches through the shared
+  hardened client, and reads the body under `DEFAULT_MAX_FOREIGN_BODY`.
+
 ### vta-sdk (0.19.5) — finite timeouts on all REST clients
 
 * Every SDK REST client is now built with request + connect timeouts (new

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2452,7 +2452,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.19.5",
+ "vta-sdk 0.19.6",
 ]
 
 [[package]]
@@ -3254,7 +3254,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.19.5",
+ "vta-sdk 0.19.6",
 ]
 
 [[package]]
@@ -6714,7 +6714,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.19.5",
+ "vta-sdk 0.19.6",
 ]
 
 [[package]]
@@ -10017,7 +10017,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.19.5",
+ "vta-sdk 0.19.6",
  "vti-common",
  "x25519-dalek",
 ]
@@ -10050,7 +10050,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.19.5",
+ "vta-sdk 0.19.6",
 ]
 
 [[package]]
@@ -10073,7 +10073,7 @@ dependencies = [
  "tracing-subscriber",
  "trust-tasks-rs",
  "uniffi",
- "vta-sdk 0.19.5",
+ "vta-sdk 0.19.6",
 ]
 
 [[package]]
@@ -10108,7 +10108,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.19.5"
+version = "0.19.6"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10165,7 +10165,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",
@@ -10243,7 +10243,7 @@ dependencies = [
  "utoipa-axum",
  "uuid",
  "vta-cli-common",
- "vta-sdk 0.19.5",
+ "vta-sdk 0.19.6",
  "vta-service",
  "vti-common",
  "vti-secrets",
@@ -10265,7 +10265,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.19.5",
+ "vta-sdk 0.19.6",
 ]
 
 [[package]]
@@ -10337,7 +10337,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.19.5",
+ "vta-sdk 0.19.6",
  "vtc-service",
  "vti-common",
  "vti-secrets",
@@ -10385,7 +10385,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.19.5",
+ "vta-sdk 0.19.6",
  "webauthn-rs",
  "zeroize",
 ]
@@ -10412,7 +10412,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.19.5",
+ "vta-sdk 0.19.6",
  "vta-service",
  "vti-common",
 ]
@@ -10441,7 +10441,7 @@ dependencies = [
  "tokio",
  "tracing",
  "vaultrs",
- "vta-sdk 0.19.5",
+ "vta-sdk 0.19.6",
  "vti-common",
 ]
 

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.19.5"
+version = "0.19.6"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/http.rs
+++ b/vta-sdk/src/http.rs
@@ -5,6 +5,7 @@
 //! silently dropping packets) would hang the caller forever. Every REST client
 //! in the SDK is built here so the timeouts are applied uniformly.
 
+use std::sync::LazyLock;
 use std::time::Duration;
 
 /// Default total-request timeout for a VTA REST call.
@@ -43,6 +44,149 @@ fn env_secs(var: &str, default: u64) -> Duration {
     Duration::from_secs(secs)
 }
 
+// ── Foreign fetch: attacker-influenceable URLs (status lists, etc.) ──────────
+//
+// Fetching a URL a third party controls (an issuer-supplied status-list URL on
+// the credential-present path) is a privileged operation. It needs strictly
+// more hardening than an ordinary REST call to our own VTA — no redirect
+// following (CWE-918 SSRF-via-redirect), a response-body cap (a hostile host
+// can otherwise stream a multi-GB body to OOM the process), and a URL guard
+// that refuses non-public targets. This is the single shared implementation so
+// every consumer (VTA vault-present, VTC recognise/present) gets the same
+// chokepoint rather than each rolling its own.
+
+/// Timeout for a foreign fetch — deliberately tighter than the REST default.
+const FOREIGN_FETCH_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Default cap on a fetched foreign body. The spec-minimum status list is
+/// ~16 KiB; 2 MiB is generous headroom while refusing an OOM-sized stream.
+pub const DEFAULT_MAX_FOREIGN_BODY: usize = 2 * 1024 * 1024;
+
+/// Errors from the foreign-fetch helpers. Callers map these into their own
+/// error types (e.g. `AppError`, `RecognitionError`).
+#[derive(Debug, thiserror::Error)]
+pub enum ForeignFetchError {
+    /// The URL failed [`guard_public_url`] (bad scheme, userinfo, non-public IP).
+    #[error("{0}")]
+    Blocked(String),
+    /// The response body exceeded the caller's cap.
+    #[error("response body exceeds the {max}-byte cap")]
+    BodyTooLarge { max: usize },
+    /// Reading the response body failed mid-stream.
+    #[error("reading response body failed: {0}")]
+    Read(String),
+}
+
+/// One shared, hardened client for every outbound foreign fetch. `reqwest::Client`
+/// is internally ref-counted, so cloning reuses the connection pool.
+///
+/// - **`redirect(none)`** — [`guard_public_url`] runs once, on the *original*
+///   URL. Following redirects would let a public URL `302` to an internal target
+///   (`127.0.0.1`, `169.254.169.254`) past the guard. With no follow, a
+///   redirecting host yields a non-2xx the caller treats as failure.
+/// - **`timeout` / `connect_timeout`** — bounded so a hung host can't pin a
+///   request open.
+///
+/// Body size is capped per-fetch by [`read_body_capped`] (reqwest has none).
+static FOREIGN_FETCH_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
+    reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .timeout(FOREIGN_FETCH_TIMEOUT)
+        .connect_timeout(FOREIGN_FETCH_TIMEOUT)
+        .build()
+        .expect("hardened foreign-fetch client builds from static config")
+});
+
+/// A clone of the shared hardened foreign-fetch client. Use this — never
+/// `reqwest::Client::new()` — for any fetch of an attacker-influenceable URL.
+pub fn foreign_fetch_client() -> reqwest::Client {
+    FOREIGN_FETCH_CLIENT.clone()
+}
+
+/// Read a response body into memory, refusing anything larger than `max` bytes.
+/// Reads chunk-by-chunk and aborts the moment the cap is crossed — the oversized
+/// body is never fully buffered.
+pub async fn read_body_capped(
+    mut resp: reqwest::Response,
+    max: usize,
+) -> Result<Vec<u8>, ForeignFetchError> {
+    let mut buf = Vec::new();
+    while let Some(chunk) = resp
+        .chunk()
+        .await
+        .map_err(|e| ForeignFetchError::Read(e.to_string()))?
+    {
+        if buf.len() + chunk.len() > max {
+            return Err(ForeignFetchError::BodyTooLarge { max });
+        }
+        buf.extend_from_slice(&chunk);
+    }
+    Ok(buf)
+}
+
+/// Refuse a URL that isn't a plain public HTTPS target before fetching it.
+///
+/// Rejects: non-`https` schemes, embedded userinfo, and IP-literal hosts in
+/// loopback / private / link-local / unspecified / multicast / documentation
+/// ranges (IPv4) or loopback / unspecified / multicast / ULA `fc00::/7` /
+/// link-local `fe80::/10` (IPv6) — including cloud-metadata `169.254.169.254`.
+///
+/// Reaching an internal service by *DNS name* can't be prevented here without a
+/// TOCTOU-prone resolve-at-parse-time; operators behind internal DNS need a
+/// network-level egress filter for full protection. This cuts off the
+/// bulk-attack vectors.
+pub fn guard_public_url(url: &str) -> Result<(), ForeignFetchError> {
+    let parsed = reqwest::Url::parse(url)
+        .map_err(|e| ForeignFetchError::Blocked(format!("invalid url {url}: {e}")))?;
+    if parsed.scheme() != "https" {
+        return Err(ForeignFetchError::Blocked(format!(
+            "url must be https (got scheme {})",
+            parsed.scheme()
+        )));
+    }
+    if parsed.username() != "" || parsed.password().is_some() {
+        return Err(ForeignFetchError::Blocked(
+            "url must not contain userinfo".into(),
+        ));
+    }
+    let host_str = parsed
+        .host_str()
+        .ok_or_else(|| ForeignFetchError::Blocked("url missing host".into()))?;
+    // `host_str()` returns IPv6 hosts bracketed (`[::1]`); strip before parsing.
+    // Domain hosts don't parse as an IP and correctly fall through to allow.
+    let host_normalised = host_str
+        .strip_prefix('[')
+        .and_then(|s| s.strip_suffix(']'))
+        .unwrap_or(host_str);
+    if let Ok(ip) = host_normalised.parse::<std::net::IpAddr>() {
+        use std::net::IpAddr;
+        let private = match ip {
+            IpAddr::V4(v4) => {
+                v4.is_loopback()
+                    || v4.is_private()
+                    || v4.is_link_local()
+                    || v4.is_broadcast()
+                    || v4.is_unspecified()
+                    || v4.is_multicast()
+                    || v4.is_documentation()
+            }
+            IpAddr::V6(v6) => {
+                v6.is_loopback()
+                    || v6.is_unspecified()
+                    || v6.is_multicast()
+                    || (v6.segments()[0] & 0xfe00 == 0xfc00) // ULA fc00::/7
+                    || (v6.segments()[0] & 0xffc0 == 0xfe80) // link-local fe80::/10
+            }
+        };
+        if private {
+            return Err(ForeignFetchError::Blocked(format!(
+                "url points at non-public IP {ip}"
+            )));
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -60,5 +204,51 @@ mod tests {
     fn rest_client_builds() {
         // Building must not panic in a normal environment (TLS backend present).
         let _ = rest_client();
+    }
+
+    #[test]
+    fn guard_allows_public_https() {
+        guard_public_url("https://example.com/status/list").expect("public https ok");
+    }
+
+    #[test]
+    fn guard_blocks_plain_http() {
+        guard_public_url("http://example.com/status").expect_err("http blocked");
+    }
+
+    #[test]
+    fn guard_blocks_loopback() {
+        guard_public_url("https://127.0.0.1/x").expect_err("loopback blocked");
+        guard_public_url("https://127.1/x").expect_err("loopback short form blocked");
+    }
+
+    #[test]
+    fn guard_blocks_private_v4() {
+        guard_public_url("https://10.0.0.1/x").expect_err("10/8 blocked");
+        guard_public_url("https://192.168.1.5/x").expect_err("192.168 blocked");
+        guard_public_url("https://172.16.0.1/x").expect_err("172.16 blocked");
+    }
+
+    #[test]
+    fn guard_blocks_cloud_metadata() {
+        guard_public_url("https://169.254.169.254/latest/meta-data/")
+            .expect_err("link-local metadata blocked");
+    }
+
+    #[test]
+    fn guard_blocks_v6_internal() {
+        guard_public_url("https://[::1]/x").expect_err("v6 loopback blocked");
+        guard_public_url("https://[fc00::1]/x").expect_err("v6 ULA blocked");
+        guard_public_url("https://[fe80::1]/x").expect_err("v6 link-local blocked");
+    }
+
+    #[test]
+    fn guard_blocks_userinfo() {
+        guard_public_url("https://user:pass@example.com/x").expect_err("userinfo blocked");
+    }
+
+    #[test]
+    fn guard_blocks_garbage() {
+        guard_public_url("not a url").expect_err("garbage blocked");
     }
 }

--- a/vta-sdk/src/lib.rs
+++ b/vta-sdk/src/lib.rs
@@ -112,7 +112,7 @@ pub mod didcomm_session;
 #[cfg(feature = "crypto-provider")]
 pub mod crypto_init;
 #[cfg(feature = "client")]
-pub(crate) mod http;
+pub mod http;
 #[cfg(feature = "keyring")]
 pub mod keyring_init;
 pub mod keys;

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.11.2"
+version = "0.11.3"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/vault/status.rs
+++ b/vta-service/src/vault/status.rs
@@ -157,7 +157,11 @@ impl HttpStatusListResolver {
     /// resolution of the status-list credential's signature.
     pub fn new(did_resolver: Option<DIDCacheClient>) -> Self {
         Self {
-            http: reqwest::Client::new(),
+            // The status-list URL is issuer-supplied (attacker-influenceable) and
+            // fetched on the credential-present path. Use the shared hardened
+            // foreign-fetch client — no redirect following (SSRF-via-redirect),
+            // bounded timeout — never a bare `reqwest::Client::new()`.
+            http: vta_sdk::http::foreign_fetch_client(),
             did_resolver,
         }
     }
@@ -171,16 +175,26 @@ impl StatusListResolver for HttpStatusListResolver {
         url: &str,
         expected_issuer: Option<&str>,
     ) -> Result<ResolvedStatusList, AppError> {
-        let body: serde_json::Value = self
+        // Guard the issuer-supplied URL BEFORE dialing (https only, no userinfo,
+        // no non-public IP target), then fetch through the hardened client and
+        // read the body under a cap so a hostile host can't stream a giant
+        // response to OOM the process.
+        vta_sdk::http::guard_public_url(url)
+            .map_err(|e| AppError::Validation(format!("status list `{url}` rejected: {e}")))?;
+        let resp = self
             .http
             .get(url)
             .send()
             .await
             .map_err(|e| AppError::Internal(format!("status list fetch `{url}` failed: {e}")))?
             .error_for_status()
-            .map_err(|e| AppError::Internal(format!("status list `{url}` returned an error: {e}")))?
-            .json()
+            .map_err(|e| {
+                AppError::Internal(format!("status list `{url}` returned an error: {e}"))
+            })?;
+        let bytes = vta_sdk::http::read_body_capped(resp, vta_sdk::http::DEFAULT_MAX_FOREIGN_BODY)
             .await
+            .map_err(|e| AppError::Internal(format!("status list `{url}` body: {e}")))?;
+        let body: serde_json::Value = serde_json::from_slice(&bytes)
             .map_err(|e| AppError::Internal(format!("status list `{url}` is not JSON: {e}")))?;
 
         // Verify the list credential's own issuer signature BEFORE trusting any


### PR DESCRIPTION
## Problem (D2-F1)

`HttpStatusListResolver` fetches an **issuer-supplied** status-list URL on the credential-**present** path with `reqwest::Client::new()`:

- **no timeout** → a tarpit host pins the present request open;
- **default redirect-following** → a public URL can `302` to `127.0.0.1` / `169.254.169.254` (cloud metadata) — **SSRF (CWE-918)**;
- **`.json()` buffers the whole body** → a hostile host streams a multi-GB response to **OOM** the process.

Because the URL comes from a stored credential, presenting a malicious credential is enough to trigger it — a cheap remote DoS / SSRF surface. `vtc-service` already hardened the *identical* fetch on its side (`FOREIGN_FETCH_CLIENT` + `read_body_capped` + `guard_status_list_url`); the VTA side was left open.

## Fix

- **vta-sdk** — new shared `http::{foreign_fetch_client, read_body_capped, guard_public_url, DEFAULT_MAX_FOREIGN_BODY, ForeignFetchError}`: the single hardened chokepoint for attacker-influenceable URLs — `redirect(none)`, bounded timeouts, a chunked response-body cap, and an SSRF URL guard (https-only, no userinfo, rejects loopback / private / link-local / multicast / ULA and cloud-metadata IP literals, v4 and v6). **Logic and tests ported verbatim from vtc-service's reference**, so there's one guard to reason about, not a fresh re-implementation.
- **vta-service** — `HttpStatusListResolver` now calls `guard_public_url` *before* dialing, fetches through the hardened client, and reads the body under `DEFAULT_MAX_FOREIGN_BODY`.

Placed in `vta_sdk::http` (extending the module added in #665) because both `vta-service` and `vtc-service` already depend on vta-sdk — the Decision-4 "single egress spine" without adding a network dep to the foundational `vti-common`.

## Follow-up (noted, not in this PR)

Migrate `vtc-service`'s local `FOREIGN_FETCH_CLIENT` / `read_body_capped` / `guard_status_list_url` to delegate to the shared `vta_sdk::http` helpers, converging on a single implementation. Left out here to keep this security fix focused and avoid churning vtc's working, well-tested code.

## Tests / checks

10 `vta-sdk::http` tests green (incl. 8 SSRF-guard cases: loopback short-form, private v4, metadata IP, v6 ULA/link-local, userinfo, http scheme, garbage). vta-service compiles (default + `webvh`); clippy clean as CI runs it and with `--features webvh`; builds across feature combos. Version-bump guard: vta-sdk 0.19.5→0.19.6, vta-service 0.11.2→0.11.3; CHANGELOG updated.

Note: this makes the status-list fetch **https-only** (matching vtc-service). A dev credential with an `http://` status-list URL will now be rejected — consistent with the VTC side.