### PR TITLE
fix(vta-service): webvh update keys off the canonical SCID (D4 F1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+### vta-service (0.11.4) — webvh update keys off the canonical SCID
+
+* Fixed a keyspace bifurcation (#659 regression): `run_update` accepted a full
+  `did:webvh:…` (delegated path) or a bare SCID (CLI) but then keyed the
+  `webvh_keys` handle store off the raw argument. A DID updated via one path
+  installed its key handles under a prefix the other path couldn't find, so a
+  delegated update left the DID un-updatable from the CLI ("no active update key
+  … restore from backup"). `run_update` now canonicalizes the identifier to the
+  record's bare SCID before any key-handle op. Adds a regression test that both
+  identifier forms resolve to the same canonical SCID.
+
 ### vta-sdk (0.19.6) — shared hardened foreign-fetch helper
 
 * New `http::{foreign_fetch_client, read_body_capped, guard_public_url,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10165,7 +10165,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.11.3"
+version = "0.11.4"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.11.3"
+version = "0.11.4"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/operations/did_webvh/update/orchestrator.rs
+++ b/vta-service/src/operations/did_webvh/update/orchestrator.rs
@@ -123,6 +123,17 @@ async fn run_update(
     let mut record = find_record_by_scid(webvh_ks, scid)
         .await?
         .ok_or_else(|| UpdateDidWebvhError::NotFound(format!("SCID {scid} not found")))?;
+    // `scid` may arrive as a full `did:webvh:…` (the delegated-update path,
+    // `trust_tasks/webvh.rs`) or as a bare SCID (the CLI path). `find_record_by_scid`
+    // accepts either form for lookup, but the `webvh_keys` handle keyspace is
+    // ALWAYS keyed by the canonical bare SCID (`record.scid`). Keying it off the
+    // raw argument bifurcates the keyspace — a DID updated via one path installs
+    // its handles under a prefix the other path can't find, so the DID becomes
+    // un-updatable that way (#659 regression). Canonicalize the identifier here so
+    // every `webvh_keys` op below (load/install/supersede) and every derived DID
+    // string uses the SCID, whichever caller we came from.
+    let canonical_scid = record.scid.clone();
+    let scid = canonical_scid.as_str();
     let initial_log_entry_count = record.log_entry_count;
     let snapshot = RecordSnapshot::capture(&record);
 

--- a/vta-service/src/operations/did_webvh/update/state.rs
+++ b/vta-service/src/operations/did_webvh/update/state.rs
@@ -88,3 +88,66 @@ pub(in crate::operations::did_webvh) fn state_to_jsonl(
     }
     Ok(out)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::Store;
+    use vti_common::config::StoreConfig as VtiStoreConfig;
+
+    async fn setup_ks() -> (tempfile::TempDir, KeyspaceHandle) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(&VtiStoreConfig {
+            data_dir: dir.path().into(),
+        })
+        .unwrap();
+        let ks = store.keyspace(crate::keyspaces::WEBVH).unwrap();
+        (dir, ks)
+    }
+
+    fn record(scid: &str, did: &str) -> WebvhDidRecord {
+        WebvhDidRecord {
+            did: did.into(),
+            server_id: "serverless".into(),
+            mnemonic: "irrelevant".into(),
+            scid: scid.into(),
+            context_id: "vta".into(),
+            portable: true,
+            log_entry_count: 1,
+            pre_rotation_count: 0,
+            next_fragment_id: 0,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        }
+    }
+
+    /// The property `run_update`'s key-handle canonicalization relies on: whether
+    /// looked up by full DID (delegated path) or bare SCID (CLI path), the record
+    /// returned carries the SAME canonical bare `scid`. Keying `webvh_keys` off
+    /// `record.scid` therefore lands in one keyspace regardless of caller — the
+    /// fix for the #659 keyspace bifurcation.
+    #[tokio::test]
+    async fn both_identifier_forms_resolve_to_the_same_canonical_scid() {
+        let (_dir, ks) = setup_ks().await;
+        let scid = "QmScidHash";
+        let did = "did:webvh:QmScidHash:webvh.example.com:agent";
+        webvh_store::store_did(&ks, &record(scid, did))
+            .await
+            .unwrap();
+
+        let by_did = find_record_by_scid(&ks, did)
+            .await
+            .unwrap()
+            .expect("lookup by full DID resolves");
+        let by_scid = find_record_by_scid(&ks, scid)
+            .await
+            .unwrap()
+            .expect("lookup by bare SCID resolves");
+
+        // The canonical bare SCID is identical for both entry forms — so the
+        // webvh_keys prefix built from `record.scid` never bifurcates.
+        assert_eq!(by_did.scid, scid);
+        assert_eq!(by_scid.scid, scid);
+        assert_eq!(by_did.scid, by_scid.scid);
+    }
+}


### PR DESCRIPTION
## Problem (D4-F1, a #659 regression)

`run_update` (the webvh DID-update orchestrator) receives an identifier that is a **full `did:webvh:…`** from the delegated-update path (`trust_tasks/webvh.rs`) or a **bare SCID** from the CLI path. `find_record_by_scid` deliberately resolves either form — but the `webvh_keys` handle store was then keyed off the **raw argument** (`load_active_update_key`, `install_derived_webvh_keys`, `supersede_keys_for_version`), not `record.scid`.

Result: the key-handle keyspace **bifurcates by identifier form**. A DID updated via the delegated (full-DID) path installs its handles under a `webvh:did:webvh:…:` prefix; a later CLI (bare-SCID) update scans the `webvh:<scid>:` prefix and can't find them — the update aborts with *"no active update key for DID with SCID … operator may need to restore key material from backup"*. The DID becomes un-updatable from the other path.

## Fix

Canonicalize the identifier to the record's bare SCID immediately after `find_record_by_scid`:

```rust
let canonical_scid = record.scid.clone();
let scid = canonical_scid.as_str();
```

Shadowing the arg means every downstream `webvh_keys` op — and every derived DID string — keys off the canonical SCID regardless of which caller we came from, landing in one keyspace. Minimal and self-contained; no behavior change for the common (CLI) path, which already passed the bare SCID.

## Test

Adds a regression test (`state.rs`) proving the property the fix relies on: a record looked up by its **full DID** and by its **bare SCID** returns the **same canonical `scid`** — so the `webvh_keys` prefix never bifurcates. Runs under default features (`cargo test --workspace`).

## Verification

`cargo test` green (new test passes), clippy clean as CI runs it and with `--features webvh`, compiles both feature sets. Version-bump guard: vta-service 0.11.3→0.11.4; CHANGELOG updated.

## D4 remaining (separate PRs)

F3 (versionTime overflow >1440 entries), F5 (`?domain=` ignored server-side — affinidi-webvh-service), F2 (final-mode create impossible — cross-repo). **F4** (publish-fail divergence) is outbox/reconcile-shaped and better folded into the D1 Delivery-Layer work than patched here.