### PR TITLE
fix(vta-service): final-mode create fails fast when server-managed (D4 F2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+### vta-service (0.11.5) — final-mode create fails fast when it can't succeed
+
+* Final-mode `create-did-webvh` (a client-provided, pre-signed `did_log`) is
+  serverless-only. Combined with a hosting `server_id` it published using the
+  base58 SCID as the mnemonic path with no prior slot reservation, which the
+  host always rejects (mixed-case mnemonic + unreserved slot) — so it could
+  never succeed. No first-party flow uses that combination (`vta setup`'s
+  advanced `did_log` path is always serverless). The VTA now rejects it up front
+  with an actionable error ("…only supported serverless… use template or
+  did_document mode") instead of a confusing downstream host failure. (D4-F2)
+
 ### vta-service (0.11.4) — webvh update keys off the canonical SCID
 
 * Fixed a keyspace bifurcation (#659 regression): `run_update` accepted a full

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10165,7 +10165,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.11.4"
+version = "0.11.5"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/operations/did_webvh/mod.rs
+++ b/vta-service/src/operations/did_webvh/mod.rs
@@ -664,6 +664,23 @@ pub async fn create_did_webvh(
 
     // ── Final mode: client-provided pre-signed log entry ────────────
     if let Some(ref did_log) = params.did_log {
+        // Final mode (a client-provided, pre-signed did.jsonl) is serverless-only.
+        // Publishing a pre-signed log to a hosting server would use the SCID as the
+        // mnemonic path segment with no prior slot reservation — which the host
+        // rejects (a base58 SCID is mixed-case, and the slot was never registered)
+        // — so a server-managed final-mode create can never succeed. No first-party
+        // flow uses it (setup's advanced `did_log` path is always serverless). Fail
+        // fast, before parsing the log, with an actionable error instead of a
+        // confusing downstream mnemonic-validation failure at the host. (D4-F2)
+        if !serverless {
+            return Err(AppError::Validation(
+                "final-mode create (a pre-signed `did_log`) is only supported \
+                 serverless — `server_id` must be unset. To create a server-hosted \
+                 DID, use template or did_document mode instead."
+                    .into(),
+            ));
+        }
+
         let log_entry = LogEntry::deserialize_string(did_log, None)
             .map_err(|e| AppError::Validation(format!("invalid did_log: {e}")))?;
 
@@ -675,38 +692,6 @@ pub async fn create_did_webvh(
             .ok_or_else(|| AppError::Validation("DID document missing 'id' field".into()))?
             .to_string();
         let scid = log_entry.get_scid().unwrap_or_default().to_string();
-
-        // Publish to server if not serverless
-        if !serverless {
-            let server_id = params.server_id.as_ref().ok_or_else(|| {
-                AppError::Validation(
-                    "server_id is required when serverless=false (final-mode publish path)".into(),
-                )
-            })?;
-            let server = webvh_store::get_server(webvh_ks, server_id)
-                .await?
-                .ok_or_else(|| {
-                    AppError::NotFound(format!("webvh server not found: {server_id}"))
-                })?;
-            let transport = authenticated_server_transport(
-                keys_ks,
-                imported_ks,
-                seed_store,
-                audit_ks,
-                webvh_ks,
-                did_resolver,
-                didcomm_bridge,
-                auth_locks,
-                config.vta_did.as_deref(),
-                &server,
-            )
-            .await?;
-            // Final mode has no mnemonic from a server request — use the SCID as identifier
-            // Background publish (final-mode rotation push): no
-            // domain override; the remote uses the slot's recorded
-            // domain on lookup.
-            transport.publish_did(&scid, did_log, None).await?;
-        }
 
         // Optionally set as primary DID
         if params.set_primary {


### PR DESCRIPTION
## Context (D4-F2, investigated)

The review flagged that final-mode `create-did-webvh` (a client-provided, pre-signed `did_log`) can never succeed against a hosting server: it publishes using the base58 SCID as the mnemonic path segment with **no prior slot reservation**, which the host rejects (`validate_mnemonic` refuses the mixed-case SCID, and the slot was never registered).

**Investigation result:** final-mode is reachable only **serverless** in practice — the one first-party flow that supplies a `did_log` is `vta setup --from`'s advanced `did_log_file` option, which builds the request with `server_id: None` (the code comment confirms it's serverless). No first-party flow pairs `did_log` with a hosting `server_id`; that combination is only reachable by a hand-crafted raw API request, and it already fails *closed* — just with a confusing downstream error.

Per the decision, rather than building an unused server-managed final-mode publish path (register-then-publish), this **fails fast** at the create boundary.

## Fix

At the top of the final-mode block (before parsing the log), reject `did_log` combined with a non-serverless `server_id`:

> `final-mode create (a pre-signed did_log) is only supported serverless — server_id must be unset. To create a server-hosted DID, use template or did_document mode instead.`

This replaces the doomed SCID-mnemonic publish branch (removed) with an actionable, up-front `AppError::Validation`. Serverless final mode (the only path anything uses) is unchanged.

## Tests / checks

Compiles (default + `webvh`); clippy clean as CI runs it and with `--features webvh`; no unused-variable fallout from removing the publish branch (`scid`/`final_did` are still used in the stored record). A full `create_did_webvh` integration test is a disproportionate lift for an early-return boolean guard given the function's dependency bundle; the guard is self-evident and compile-checked. Version-bump guard: vta-service 0.11.4→0.11.5; CHANGELOG updated.

## D4 status

With this, D4 code work is complete: **F1** (#667) and **F5** (webvh#94) shipped, **F3** dismissed (test-only), **F2** this PR. **F4** (publish-fail divergence) is outbox/reconcile-shaped and folds into the D1 Delivery-Layer work.