### PR TITLE
fix: enclave boot retry + website file-list off-runtime (D9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## Unreleased
 
+### vta-enclave — retry the vsock storage-proxy connect on boot (D9)
+
+* On a cold boot the enclave and the parent-side vsock storage proxy start
+  concurrently; a single `VsockStore::connect` that lost the race would
+  `exit(1)`, and Nitro does not restart the enclave — so a benign ordering race
+  became an outage on every unattended host reboot. The connect now retries with
+  bounded backoff (~80s wait-for-dependency) before giving up. (`publish = false`;
+  no version bump.)
+
+### vtc-service (0.11.4) — website file-list is off-runtime and hashes only the page (D9)
+
+* `GET /v1/website/files` walked the whole site tree and `std::fs::read` +
+  SHA-256'd every file **on the async runtime**, even though the response is
+  paginated to ≤200 entries — pinning a tokio worker with O(total-site-bytes)
+  work on large media bundles, and `TimeoutLayer` couldn't cancel the blocking
+  code. It now walks metadata off the runtime (`spawn_blocking`, O(files), no
+  reads), paginates on that cheap metadata, and hashes **only the returned
+  window** off the runtime.
+
 ### vta-service (0.11.5) — final-mode create fails fast when it can't succeed
 
 * Final-mode `create-did-webvh` (a client-provided, pre-signed `did_log`) is

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10270,7 +10270,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-service"
-version = "0.11.3"
+version = "0.11.4"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/vta-enclave/src/main.rs
+++ b/vta-enclave/src/main.rs
@@ -37,6 +37,45 @@ struct Cli {
     config: Option<std::path::PathBuf>,
 }
 
+/// Connect to the parent instance's vsock storage proxy, retrying with bounded
+/// backoff so a boot-ordering race isn't an outage.
+///
+/// On a cold boot the enclave and the parent-side storage proxy start
+/// concurrently; if the enclave's connect races ahead of the proxy binding its
+/// vsock port, a single attempt would `exit(1)` — and Nitro does **not** restart
+/// the enclave, so a benign ordering race becomes an outage on every unattended
+/// host reboot. Wait for the dependency instead, giving up only after the proxy
+/// is clearly not coming up (~80s total).
+#[cfg(feature = "vsock-store")]
+async fn connect_vsock_with_retry() -> Result<store::VsockStore, String> {
+    use std::time::Duration;
+    const MAX_ATTEMPTS: u32 = 30;
+    const BASE_DELAY: Duration = Duration::from_millis(250);
+    const MAX_DELAY: Duration = Duration::from_secs(3);
+
+    let mut delay = BASE_DELAY;
+    for attempt in 1..=MAX_ATTEMPTS {
+        match store::VsockStore::connect(None).await {
+            Ok(vs) => {
+                if attempt > 1 {
+                    tracing::info!("connected to vsock storage proxy on attempt {attempt}");
+                }
+                return Ok(vs);
+            }
+            Err(e) if attempt < MAX_ATTEMPTS => {
+                tracing::warn!(
+                    "vsock storage proxy not ready (attempt {attempt}/{MAX_ATTEMPTS}): {e}; \
+                     retrying in {delay:?}"
+                );
+                tokio::time::sleep(delay).await;
+                delay = (delay * 2).min(MAX_DELAY);
+            }
+            Err(e) => return Err(e.to_string()),
+        }
+    }
+    unreachable!("the loop returns on the final attempt")
+}
+
 #[tokio::main]
 async fn main() {
     // Pin rustls to the aws-lc-rs backend before any TLS object is built;
@@ -109,10 +148,10 @@ async fn main() {
     // ── Open store (vsock-proxied or local) ──
     #[cfg(feature = "vsock-store")]
     let store = if config.tee.kms.is_some() {
-        match store::VsockStore::connect(None).await {
+        match connect_vsock_with_retry().await {
             Ok(vs) => store::Store::Vsock(vs),
             Err(e) => {
-                tracing::error!("failed to connect to vsock storage proxy: {e}");
+                tracing::error!("failed to connect to vsock storage proxy after retries: {e}");
                 std::process::exit(1);
             }
         }

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.11.3"
+version = "0.11.4"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vtc-service/src/routes/website/files.rs
+++ b/vtc-service/src/routes/website/files.rs
@@ -69,31 +69,58 @@ pub async fn list(
     let limit = query.limit.unwrap_or(50).clamp(1, 200) as usize;
     let cursor = query.cursor.unwrap_or_default();
 
-    let mut entries = collect_entries(&serve_root, &blocklist)?;
-    entries.sort_by(|a, b| a.path.cmp(&b.path));
+    // Walk the tree off the async runtime — O(number of files) stats, with NO
+    // file reads or hashing. Hashing (a SHA-256 over each file's full contents)
+    // is deferred to only the paginated window below, so a large media bundle
+    // no longer costs O(total-site-bytes) on every list — and none of the
+    // blocking I/O pins a tokio worker (the previous version did both).
+    let root_for_walk = serve_root.clone();
+    let bl = blocklist.clone();
+    let mut metas = tokio::task::spawn_blocking(move || collect_file_meta(&root_for_walk, &bl))
+        .await
+        .map_err(|e| AppError::Internal(format!("website file walk task panicked: {e}")))??;
+    metas.sort_by(|a, b| a.rel.cmp(&b.rel));
 
-    // Cursor is an opaque path string — next page starts at the
-    // first entry whose path > cursor.
-    let start_idx = match entries.binary_search_by(|e| e.path.as_str().cmp(cursor.as_str())) {
+    // Cursor is an opaque path string — next page starts at the first entry
+    // whose path > cursor. Paginate on cheap metadata; take one extra to compute
+    // next_cursor, then hash ONLY the window that is actually returned.
+    let start_idx = match metas.binary_search_by(|m| m.rel.as_str().cmp(cursor.as_str())) {
         Ok(i) => i + 1,
         Err(i) => i,
     };
-    let slice = entries
-        .into_iter()
-        .skip(start_idx)
-        .take(limit + 1)
-        .collect::<Vec<_>>();
-    let next_cursor = if slice.len() > limit {
-        Some(slice[limit - 1].path.clone())
+    let mut window: Vec<FileMeta> = metas.into_iter().skip(start_idx).take(limit + 1).collect();
+    let next_cursor = if window.len() > limit {
+        Some(window[limit - 1].rel.clone())
     } else {
         None
     };
-    let items: Vec<FileEntry> = slice.into_iter().take(limit).collect();
+    window.truncate(limit);
+
+    // Read + SHA-256 exactly the returned window, off the runtime.
+    let items = tokio::task::spawn_blocking(move || hash_window(window))
+        .await
+        .map_err(|e| AppError::Internal(format!("website file hash task panicked: {e}")))?;
 
     Ok(Json(ListResponse { items, next_cursor }))
 }
 
-fn collect_entries(root: &Path, blocklist: &[String]) -> Result<Vec<FileEntry>, AppError> {
+/// Per-file metadata gathered by the (blocking) tree walk — everything a listing
+/// needs EXCEPT the etag. The etag is a SHA-256 over the file's full contents, so
+/// it is computed only for the paginated window (see [`hash_window`]), never for
+/// the whole tree.
+struct FileMeta {
+    /// Path relative to the serve root, forward-slashed — the listing key.
+    rel: String,
+    /// Absolute path, for reading the file when its etag is finally computed.
+    abs: PathBuf,
+    size_bytes: u64,
+    modified_at: u64,
+}
+
+/// Walk `root` and collect metadata for every servable file. Blocking (one
+/// `stat` per entry) but **O(number of files), not O(bytes)** — no file is read
+/// here. Call under `spawn_blocking`.
+fn collect_file_meta(root: &Path, blocklist: &[String]) -> Result<Vec<FileMeta>, AppError> {
     use std::time::UNIX_EPOCH;
 
     let mut out = Vec::new();
@@ -133,25 +160,40 @@ fn collect_entries(root: &Path, blocklist: &[String]) -> Result<Vec<FileEntry>, 
             }
             let rel = path.strip_prefix(root).unwrap_or(&path);
             let rel_str = rel.to_string_lossy().replace('\\', "/");
-            let etag = match std::fs::read(&path) {
-                Ok(bytes) => hex::encode(Sha256::digest(&bytes)),
-                Err(_) => continue,
-            };
             let modified_at = meta
                 .modified()
                 .ok()
                 .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
                 .map(|d| d.as_secs())
                 .unwrap_or(0);
-            out.push(FileEntry {
-                path: rel_str,
+            out.push(FileMeta {
+                rel: rel_str,
+                abs: path,
                 size_bytes: meta.len(),
-                etag,
                 modified_at,
             });
         }
     }
     Ok(out)
+}
+
+/// Read + SHA-256 exactly the files in `window`, producing the `FileEntry` rows.
+/// Blocking (file reads + hashing); call under `spawn_blocking`. A file that
+/// can't be read is dropped from the page — the same skip-on-read-error
+/// behaviour the previous single-pass handler had.
+fn hash_window(window: Vec<FileMeta>) -> Vec<FileEntry> {
+    window
+        .into_iter()
+        .filter_map(|m| {
+            let bytes = std::fs::read(&m.abs).ok()?;
+            Some(FileEntry {
+                path: m.rel,
+                size_bytes: m.size_bytes,
+                etag: hex::encode(Sha256::digest(&bytes)),
+                modified_at: m.modified_at,
+            })
+        })
+        .collect()
 }
 
 /// `GET /v1/website/files/{*path}`
@@ -375,3 +417,46 @@ async fn resolve_or_400(state: &AppState, path: &str) -> Result<PathBuf, AppErro
 // `Json::into_response` implicitly via the `?` mapping.
 #[allow(dead_code)]
 fn _unused(_x: impl IntoResponse) {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    /// The D9 fix's core: the tree walk gathers metadata WITHOUT reading/hashing
+    /// files (hidden + blocklisted still excluded), and `hash_window` computes the
+    /// SHA-256 etag only for the files handed to it — never the whole tree.
+    #[test]
+    fn walk_gathers_metadata_and_hash_window_hashes_only_the_window() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        fs::write(root.join("index.html"), b"<h1>hi</h1>").unwrap();
+        fs::create_dir(root.join("assets")).unwrap();
+        fs::write(root.join("assets").join("app.js"), b"console.log(1)").unwrap();
+        fs::write(root.join("deploy.sh"), b"#!/bin/sh").unwrap(); // blocklisted
+        fs::write(root.join(".hidden"), b"secret").unwrap(); // hidden
+
+        let blocklist = vec![".sh".to_string()];
+        let mut metas = collect_file_meta(root, &blocklist).expect("walk");
+        metas.sort_by(|a, b| a.rel.cmp(&b.rel));
+
+        // Hidden + blocklisted excluded; rel paths forward-slashed.
+        let rels: Vec<&str> = metas.iter().map(|m| m.rel.as_str()).collect();
+        assert_eq!(rels, vec!["assets/app.js", "index.html"]);
+        assert_eq!(
+            metas
+                .iter()
+                .find(|m| m.rel == "index.html")
+                .unwrap()
+                .size_bytes,
+            11
+        );
+
+        // hash_window computes the etag only for what it's given.
+        let entries = hash_window(metas);
+        assert_eq!(entries.len(), 2);
+        let idx = entries.iter().find(|e| e.path == "index.html").unwrap();
+        assert_eq!(idx.etag, hex::encode(Sha256::digest(b"<h1>hi</h1>")));
+        assert_eq!(idx.size_bytes, 11);
+    }
+}


### PR DESCRIPTION
Two self-contained runtime-hygiene fixes (deliverable D9), no dependency on the messaging-layer work.

## D9-F1 · Enclave boot no longer turns a race into an outage (`vta-enclave`)

On a cold boot the enclave and the parent-side vsock storage proxy start **concurrently**. `main.rs` did a single `VsockStore::connect(None)` and `std::process::exit(1)` on failure — and **Nitro does not restart the enclave**, so if the enclave's connect raced ahead of the proxy binding its vsock port, a benign ordering race became an outage on every unattended host reboot (recovery required a manual re-run).

Fix: `connect_vsock_with_retry` retries with bounded exponential backoff (250 ms → 3 s, ~80 s total wait-for-dependency) before giving up. Gated on `vsock-store`; compiles on this host and is exercised by CI's Enclave-build job.

## D9-F2 · Website file-list is off-runtime and hashes only the page (`vtc-service`)

`GET /v1/website/files` called `collect_entries` **synchronously on the async runtime**: it walked the whole site tree, `std::fs::read` + SHA-256'd **every file's full contents**, and only *then* paginated to ≤200 entries. So a large media bundle pinned a tokio worker with O(total-site-bytes) blocking work — and because it blocks rather than awaits, `TimeoutLayer` can't cancel it, stalling unrelated handlers on the same runtime.

Fix, split into two off-runtime passes:
- `collect_file_meta` — walks metadata only (**O(files), no reads/hashing**), under `spawn_blocking`;
- paginate on that cheap metadata;
- `hash_window` — reads + SHA-256s **only the returned window**, under `spawn_blocking`.

Pagination/cursor behaviour is unchanged; hidden + blocklisted files are still excluded; an unreadable file in the window is dropped from that page (same skip-on-read-error behaviour as before).

## Tests / checks

New regression test (`walk_gathers_metadata_and_hash_window_hashes_only_the_window`) — the walk excludes hidden/blocklisted files without hashing, and `hash_window` computes the correct etag only for the files it's given; passes under default features. Both crates clippy-clean as CI runs it (`vtc-service` default, `vta-enclave --features vsock-store`). Version-bump guard: vtc-service 0.11.3→0.11.4; vta-enclave is `publish = false`. CHANGELOG updated.

**With this, D9 is complete.**