### PR TITLE
refactor(vtc): delegate foreign status-list fetch to shared vta_sdk::http (D2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+### vtc-service (0.11.5) — foreign status-list fetch delegates to the shared SSRF chokepoint (D2)
+
+* The recognise/present path's SSRF guard, hardened HTTP client, and
+  response-body cap were a verbatim copy of the shared `vta_sdk::http` helpers.
+  `verify.rs` now delegates `guard_status_list_url` → `vta_sdk::http::guard_public_url`,
+  `foreign_fetch_client` → `vta_sdk::http::foreign_fetch_client`, and
+  `read_body_capped` → `vta_sdk::http::read_body_capped` (mapping
+  `ForeignFetchError` → `RecognitionError::StatusListFailed`), so the VTA
+  vault-present and VTC recognise paths share one CWE-918 guard implementation
+  instead of two that could drift. Behaviour and error surface are unchanged;
+  the local `FOREIGN_FETCH_CLIENT` / timeout const / body-cap const were removed.
+
 ### vta-enclave — retry the vsock storage-proxy connect on boot (D9)
 
 * On a cold boot the enclave and the parent-side vsock storage proxy start

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.11.4"
+version = "0.11.5"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vtc-service/src/recognition/verify.rs
+++ b/vtc-service/src/recognition/verify.rs
@@ -28,8 +28,7 @@
 //! Both are injected, so `verify_foreign_vec` is unit-testable
 //! without a live DID resolver or status-list host.
 
-use std::sync::{Arc, LazyLock};
-use std::time::Duration;
+use std::sync::Arc;
 
 use affinidi_data_integrity::{DataIntegrityProof, VerificationMethodResolver, VerifyOptions};
 use affinidi_vc::VerifiableCredential;
@@ -37,6 +36,7 @@ use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use serde_json::Value as JsonValue;
 use thiserror::Error;
+use vta_sdk::http::ForeignFetchError;
 
 use crate::credentials::vm_resolver::check_issuer_binding;
 use crate::registry::{RegistryError, TrustRegistryClient};
@@ -450,73 +450,43 @@ impl Default for HttpStatusListFetcher {
     }
 }
 
-/// Total deadline for a single foreign status-list fetch. A hostile host on the
-/// unauthenticated recognise path must not be able to stall the lone REST
-/// thread indefinitely.
-const FOREIGN_FETCH_TIMEOUT: Duration = Duration::from_secs(10);
+/// Cap on a fetched status-list body — the shared foreign-fetch default
+/// ([`vta_sdk::http::DEFAULT_MAX_FOREIGN_BODY`], 2 MiB). The spec-minimum list
+/// is ~16 KiB compressed; the cap refuses the multi-GB body a hostile host on
+/// the unauthenticated recognise path could otherwise stream to OOM the daemon.
+const MAX_STATUS_LIST_BODY: usize = vta_sdk::http::DEFAULT_MAX_FOREIGN_BODY;
 
-/// Hard cap on a fetched status-list body. The spec-minimum list is ~16 KiB
-/// compressed; 2 MiB is generous headroom while refusing the multi-GB body a
-/// hostile host could otherwise stream to OOM the daemon.
-const MAX_STATUS_LIST_BODY: usize = 2 * 1024 * 1024;
+/// Map a shared-layer [`ForeignFetchError`] (SSRF-guard rejection, body-cap
+/// breach, mid-stream read failure) into a `RecognitionError`, tagging it with
+/// the offending `url`. The route layer surfaces `StatusListFailed` as HTTP 403.
+fn foreign_fetch_failed(url: &str, e: ForeignFetchError) -> RecognitionError {
+    RecognitionError::StatusListFailed(format!("status list {url}: {e}"))
+}
 
-/// One shared, hardened HTTP client for every outbound foreign status-list
-/// fetch on the unauthenticated recognise / present paths. `reqwest::Client`
-/// is internally ref-counted, so cloning the shared instance reuses its
-/// connection pool.
-///
-/// Hardening (P0.4 / CWE-918):
-/// - **`redirect(none)`** — [`guard_status_list_url`] runs once, on the
-///   *original* URL. Following redirects would let a public URL `302` to an
-///   internal target (`127.0.0.1`, `169.254.169.254`) past the guard. With no
-///   follow, a redirecting host yields a non-2xx response, which
-///   [`HttpStatusListFetcher::check_status_bit`] maps to `StatusListFailed` —
-///   the daemon never fetches the redirect target.
-/// - **`timeout` / `connect_timeout`** — bounded so a hung host can't pin a
-///   request open.
-///
-/// Response-body size is capped per-fetch by [`read_body_capped`] (reqwest has
-/// no built-in response-size limit).
-static FOREIGN_FETCH_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
-    reqwest::Client::builder()
-        .redirect(reqwest::redirect::Policy::none())
-        .timeout(FOREIGN_FETCH_TIMEOUT)
-        .connect_timeout(FOREIGN_FETCH_TIMEOUT)
-        .build()
-        .expect("hardened foreign-fetch client builds from static config")
-});
-
-/// A clone of the shared hardened foreign-fetch client (see
-/// [`FOREIGN_FETCH_CLIENT`]). The only client used on the attacker-controlled
-/// status-list fetch path — no bare `reqwest::Client::new()`.
+/// A clone of the shared hardened foreign-fetch client
+/// ([`vta_sdk::http::foreign_fetch_client`]) — `redirect(none)` + finite
+/// timeouts. The only client used on the attacker-controlled status-list fetch
+/// path; no bare `reqwest::Client::new()`. Not following redirects closes the
+/// SSRF-via-redirect bypass (CWE-918): a `3xx` lands as a non-2xx that
+/// [`HttpStatusListFetcher::check_status_bit`] maps to `StatusListFailed`, so
+/// the redirect target is never fetched. Consolidated with the VTA's
+/// vault-present path so both share one chokepoint.
 pub(crate) fn foreign_fetch_client() -> reqwest::Client {
-    FOREIGN_FETCH_CLIENT.clone()
+    vta_sdk::http::foreign_fetch_client()
 }
 
 /// Read a response body into memory, refusing anything larger than `max` bytes.
-/// reqwest has no built-in response-size cap and the recognise path is
-/// unauthenticated, so a hostile host could otherwise stream a multi-GB body
-/// and OOM the daemon. Reads chunk-by-chunk and aborts the moment the cap is
-/// crossed — the oversized body is never fully buffered.
+/// Delegates to the shared [`vta_sdk::http::read_body_capped`] — chunk-by-chunk,
+/// aborting the instant the cap is crossed so the oversized body is never fully
+/// buffered — and tags any failure with `url`.
 async fn read_body_capped(
-    mut resp: reqwest::Response,
+    resp: reqwest::Response,
     max: usize,
     url: &str,
 ) -> Result<Vec<u8>, RecognitionError> {
-    let mut buf = Vec::new();
-    while let Some(chunk) = resp
-        .chunk()
+    vta_sdk::http::read_body_capped(resp, max)
         .await
-        .map_err(|e| RecognitionError::StatusListFailed(format!("read {url}: {e}")))?
-    {
-        if buf.len() + chunk.len() > max {
-            return Err(RecognitionError::StatusListFailed(format!(
-                "status list {url} body exceeds the {max}-byte cap"
-            )));
-        }
-        buf.extend_from_slice(&chunk);
-    }
-    Ok(buf)
+        .map_err(|e| foreign_fetch_failed(url, e))
 }
 
 /// Verify a fetched `BitstringStatusListCredential`'s own `eddsa-jcs-2022` issuer
@@ -584,81 +554,20 @@ async fn verify_status_list_signature(
     Ok(())
 }
 
-/// Reject URLs that don't pass the SSRF allowlist. Returns `Ok(())`
-/// for safe URLs, `Err(RecognitionError::StatusListFailed)` for
-/// anything we don't want the recognise handler reaching out to:
-/// non-HTTPS schemes, IP-literal hosts (incl. RFC1918, link-local,
-/// loopback, IPv4-mapped IPv6), and credentials/userinfo embedded
-/// in the authority.
+/// Reject URLs that don't pass the SSRF allowlist before the recognise handler
+/// fetches them. Delegates to the shared [`vta_sdk::http::guard_public_url`] —
+/// one chokepoint shared with the VTA's vault-present path — which refuses
+/// non-HTTPS schemes, embedded userinfo, and IP-literal hosts in loopback /
+/// private / link-local / cloud-metadata (`169.254.169.254`) ranges for both
+/// IPv4 and IPv6. Any rejection becomes `RecognitionError::StatusListFailed`.
 ///
-/// `/v1/auth/recognise` is unauthenticated; the URL comes straight
-/// from an attacker-controlled foreign credential. Without this
-/// guard the daemon could be turned into an SSRF proxy hitting
-/// internal hosts (CWE-918).
+/// `/v1/auth/recognise` is unauthenticated and the URL comes straight from an
+/// attacker-controlled foreign credential; without this guard the daemon could
+/// be turned into an SSRF proxy hitting internal hosts (CWE-918). Reaching an
+/// internal host by *DNS name* still needs a network-level egress filter — the
+/// guard can't resolve at parse time without a TOCTOU window.
 pub(crate) fn guard_status_list_url(url: &str) -> Result<(), RecognitionError> {
-    let parsed = reqwest::Url::parse(url)
-        .map_err(|e| RecognitionError::StatusListFailed(format!("invalid url {url}: {e}")))?;
-    if parsed.scheme() != "https" {
-        return Err(RecognitionError::StatusListFailed(format!(
-            "status-list url must be https (got scheme {})",
-            parsed.scheme()
-        )));
-    }
-    if parsed.username() != "" || parsed.password().is_some() {
-        return Err(RecognitionError::StatusListFailed(
-            "status-list url must not contain userinfo".into(),
-        ));
-    }
-    use std::net::IpAddr;
-    let host_str = parsed
-        .host_str()
-        .ok_or_else(|| RecognitionError::StatusListFailed("status-list url missing host".into()))?;
-    {
-        // Reject IP-literal hosts outright. Reaching internal
-        // services by DNS is harder to prevent here (we can't
-        // resolve at parse time without TOCTOU); operators
-        // deploying behind internal DNS must use a network-level
-        // egress filter for full protection. This guard cuts off
-        // the bulk-attack vectors: `http://10.0.0.1`, `http://127.1`,
-        // `http://[::1]`, `http://0.0.0.0`, `http://169.254.169.254`
-        // (cloud metadata) etc.
-        //
-        // `host_str()` returns IPv6 hosts in bracketed URL form
-        // (`[::1]`) which `IpAddr::parse` rejects — strip the
-        // brackets before parsing. Domain hosts get neither
-        // parse hit (correctly fall through to allow).
-        let host_normalised = host_str
-            .strip_prefix('[')
-            .and_then(|s| s.strip_suffix(']'))
-            .unwrap_or(host_str);
-        if let Ok(ip) = host_normalised.parse::<IpAddr>() {
-            let private = match ip {
-                IpAddr::V4(v4) => {
-                    v4.is_loopback()
-                        || v4.is_private()
-                        || v4.is_link_local()
-                        || v4.is_broadcast()
-                        || v4.is_unspecified()
-                        || v4.is_multicast()
-                        || v4.is_documentation()
-                }
-                IpAddr::V6(v6) => {
-                    v6.is_loopback()
-                        || v6.is_unspecified()
-                        || v6.is_multicast()
-                        // Unique local + link-local fc00::/7, fe80::/10.
-                        || (v6.segments()[0] & 0xfe00 == 0xfc00)
-                        || (v6.segments()[0] & 0xffc0 == 0xfe80)
-                }
-            };
-            if private {
-                return Err(RecognitionError::StatusListFailed(format!(
-                    "status-list url points at non-public IP {ip}"
-                )));
-            }
-        }
-    }
-    Ok(())
+    vta_sdk::http::guard_public_url(url).map_err(|e| foreign_fetch_failed(url, e))
 }
 
 #[async_trait]
@@ -799,6 +708,8 @@ mod ssrf_guard_tests {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use super::*;
     use crate::acl::VtcRole;
     use crate::credentials::{


### PR DESCRIPTION
## What

`vtc-service`'s recognise/present path (`src/recognition/verify.rs`) carried a
**verbatim copy** of the shared foreign-fetch SSRF hardening that already lives
in `vta_sdk::http` (added in the D2-F1 consolidation). Two copies of a CWE-918
guard can drift — a fix or a new bypass closed in one is silently missed in the
other.

This migrates vtc to delegate to the single shared implementation:

| vtc local (removed) | now delegates to |
|---|---|
| `guard_status_list_url` body (scheme/userinfo/IP-literal checks) | `vta_sdk::http::guard_public_url` |
| `FOREIGN_FETCH_CLIENT` static + `foreign_fetch_client()` | `vta_sdk::http::foreign_fetch_client` |
| `read_body_capped` chunked body loop | `vta_sdk::http::read_body_capped` |
| `MAX_STATUS_LIST_BODY` / `FOREIGN_FETCH_TIMEOUT` consts | `vta_sdk::http::DEFAULT_MAX_FOREIGN_BODY` (+ the shared client's own timeout) |

The three vtc entry points keep their existing names, signatures, and
`pub(crate)` visibility as **thin wrappers**, so call sites and tests are
untouched. A small `foreign_fetch_failed(url, ForeignFetchError)` helper maps the
shared error into `RecognitionError::StatusListFailed` (the route layer still
surfaces it as HTTP 403), preserving the URL-tagged error text — including the
`"cap"` substring the body-cap test asserts on.

## Why it's safe

- **Behaviour unchanged.** The shared helpers are the same logic vtc had
  (`redirect(none)`, finite timeouts, 2 MiB cap, identical IPv4/IPv6 private-range
  matching incl. `169.254.169.254`).
- **Feature already on.** `vta_sdk::http` is gated on the `client` feature;
  vtc-service enables `session`, which transitively enables `client`. No
  Cargo.toml feature change needed.
- **Tests.** All 30 `recognition::` tests pass — the 8 SSRF-guard cases and the
  redirect / oversized-body / within-cap / slow-host-timeout foreign-fetch cases
  now exercise the delegated helpers.

## Checks

- `cargo fmt`, `cargo clippy -p vtc-service --lib` and `--tests` clean.
- Version-bump guard: `vtc-service 0.11.4 -> 0.11.5` + CHANGELOG.

Part of the D2 networking-remediation deliverable (one SSRF chokepoint).