### PR TITLE
feat: per-task delegated capability for cross-context trust tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 ## Unreleased
 
+### vta-service — per-task delegated capability for cross-context trust tasks
+
+* A delegated webvh update failed with `forbidden: caller has no admin role in
+  context` whenever the requester wasn't an admin of the DID's context. The only
+  ways to make it pass were to grant the (agent) requester standing admin in
+  every context it touches, or make it a super-admin — both put durable, broad
+  authority on a long-lived credential. Authority was a standing property of the
+  requester, checked at both plan and execute; consent was collected but never
+  load-bearing (the approver's authority was never consulted).
+* Authority can now flow **per task** from an approver who holds it. When a
+  requester can't self-authorize the DID's context, the plan dry-run still runs
+  (its only output is the public DID-document diff, so an approver can be shown
+  the effects), and the task is executable only via consent. At the approval
+  threshold, `task-consent/decision` resolves each approver against the live ACL
+  and — attenuation only — confers the DID's context **iff** enough approvers are
+  admins of it (`Role::Admin` + context access; set membership alone is not
+  authority). The consumed grant then widens the requester's `AuthClaims` for
+  that single dispatch via `AuthClaims::with_delegated_contexts`; the widening is
+  payload-bound, state-pinned, single-use, short-lived, and never written back to
+  the session. The agent holds no standing context authority.
+* An approval from a set member who is *not* an admin of the context confers
+  nothing, so the re-submit still can't execute. Same-context consent is
+  unchanged. New fields carry the delegation through: `UpdatePlan` /
+  `TaskPlan.{subject_context, requester_authorized}`,
+  `PendingTaskConsent.{subject_context, requester_authorized}`, and
+  `TaskConsentGrant.delegated_contexts` (all `#[serde(default)]`, so older stored
+  pendings/grants read as non-delegated). Covered by unit tests for the
+  attenuation rule and two `mocks-nothing` e2e flows (a context-admin approval
+  lets a cross-context requester execute; a non-context-admin approval does not).
+
 ### vtc-service (0.11.5) — foreign status-list fetch delegates to the shared SSRF chokepoint (D2)
 
 * The recognise/present path's SSRF guard, hardened HTTP client, and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10270,7 +10270,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-service"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/vta-service/src/operations/did_webvh/update/orchestrator.rs
+++ b/vta-service/src/operations/did_webvh/update/orchestrator.rs
@@ -139,14 +139,31 @@ async fn run_update(
 
     // 2. Auth gate. Forbidden + NotFound both surface as 404 at the
     //    wire boundary — see `From<UpdateDidWebvhError> for AppError`.
+    //
+    // `require_admin` always holds: only an admin (of *some* context) may
+    // propose an update at all. `require_context` is the per-DID authority. In
+    // Execute mode it is mandatory — but note the caller may have widened `auth`
+    // for this one dispatch via a consented delegation
+    // (`AuthClaims::with_delegated_contexts`), so a requester who lacked the
+    // context on their own token passes here iff an approver conferred it.
+    //
+    // In Plan mode the check is *recorded, not enforced*: the plan is a
+    // read-only dry-run whose only outputs are the DID-document diff (public —
+    // webvh logs resolve for anyone) and a reserving-nothing key-counter peek.
+    // Letting it run for a context the requester can't self-authorize is what
+    // lets the consent gate show an approver the effects of a delegated update
+    // *before* anyone holds the authority to commit it. Whether the requester
+    // self-authorized rides out on `UpdatePlan.requester_authorized` so the gate
+    // knows to demand a context-admin approver.
     auth.require_admin()
         .map_err(|e| UpdateDidWebvhError::Forbidden(format!("admin required: {e}")))?;
-    auth.require_context(&record.context_id).map_err(|_| {
-        UpdateDidWebvhError::Forbidden(format!(
+    let requester_authorized = auth.has_context_access(&record.context_id);
+    if mode == Mode::Execute && !requester_authorized {
+        return Err(UpdateDidWebvhError::Forbidden(format!(
             "caller has no admin role in context `{}`",
             record.context_id
-        ))
-    })?;
+        )));
+    }
 
     // 3. Validate caller-supplied inputs (cheap; do before key derivation).
     let new_doc = match opts.document {
@@ -438,6 +455,8 @@ async fn run_update(
                 .collect(),
             base_path: context.base_path.clone(),
             path_counter_pin,
+            subject_context: record.context_id.clone(),
+            requester_authorized,
         }));
     }
 

--- a/vta-service/src/operations/did_webvh/update/plan.rs
+++ b/vta-service/src/operations/did_webvh/update/plan.rs
@@ -59,6 +59,15 @@ pub struct UpdatePlan {
     /// value before committing and refuses if it moved, which is what makes the
     /// keys an approver was shown the keys that actually execute.
     pub path_counter_pin: u32,
+
+    /// The context the updated DID belongs to (`record.context_id`). The consent
+    /// gate needs it to know which context an approver must administer to
+    /// authorize this update via delegation.
+    pub subject_context: String,
+    /// Whether the requester's own token authorized `subject_context`. `false`
+    /// means the update is a cross-context proposal — executable only via a
+    /// consented delegation from an approver who holds that context.
+    pub requester_authorized: bool,
 }
 
 impl UpdatePlan {
@@ -194,6 +203,8 @@ mod tests {
             new_next_key_hashes: vec!["QmHashA".into(), "QmHashB".into()],
             base_path: "m/1'/2'".into(),
             path_counter_pin: 7,
+            subject_context: "ctx-test".into(),
+            requester_authorized: true,
         }
     }
 

--- a/vta-service/src/policy/consent.rs
+++ b/vta-service/src/policy/consent.rs
@@ -123,8 +123,23 @@ pub struct PendingTaskConsent {
     /// Executor-internal preconditions to re-assert at execution.
     #[serde(default)]
     pub guards: crate::trust_tasks::planner::Guards,
+    /// The context whose admin authority the task acts under (webvh update: the
+    /// DID's context), when the planner could determine it. An approver must
+    /// administer this context for their approval to confer execution authority.
+    #[serde(default)]
+    pub subject_context: Option<String>,
+    /// Whether the requester's own token authorized `subject_context`. `false`
+    /// marks a cross-context proposal whose execution requires a delegation from
+    /// a context-admin approver. Defaults `true` so pre-feature pendings (and
+    /// tasks with no context subject) are never treated as delegated.
+    #[serde(default = "default_true")]
+    pub requester_authorized: bool,
     pub created_at: u64,
     pub expires_at: u64,
+}
+
+fn default_true() -> bool {
+    true
 }
 
 /// A completed authorization a re-submitted task consumes (single-use).
@@ -141,6 +156,14 @@ pub struct TaskConsentGrant {
     pub state_pin: Option<crate::policy::effects::StatePin>,
     #[serde(default)]
     pub guards: crate::trust_tasks::planner::Guards,
+    /// Contexts this grant confers admin authority in for the single execution
+    /// that consumes it. Empty for an ordinary same-context consent (the
+    /// requester already held the context); populated only when the approvals
+    /// came from admins of a context the requester lacked — the per-task
+    /// delegation. Consumed by widening the executing `AuthClaims` via
+    /// [`crate::auth::AuthClaims::with_delegated_contexts`], never persisted.
+    #[serde(default)]
+    pub delegated_contexts: Vec<String>,
     pub granted_at: u64,
     pub expires_at: u64,
 }
@@ -461,6 +484,8 @@ mod tests {
             exclude_requester: true,
             challenge: "nonce123".into(),
             approvals: vec![],
+            subject_context: None,
+            requester_authorized: true,
             created_at: 100,
             expires_at: 1000,
         }
@@ -543,6 +568,7 @@ mod tests {
             requester_did: "did:key:zReq".into(),
             type_uri: T_UPDATE.into(),
             approvers: vec!["did:key:zA".into()],
+            delegated_contexts: vec![],
             granted_at: 100,
             expires_at,
         }

--- a/vta-service/src/trust_tasks/credentials.rs
+++ b/vta-service/src/trust_tasks/credentials.rs
@@ -213,6 +213,7 @@ mod tests {
             &auth,
             vta_sdk::trust_tasks::TASK_VTA_CREDENTIALS_ISSUE_0_1,
             &doc,
+            &mut Vec::new(),
         )
         .await
         .expect("the credentials/issue floor must reject an AAL1 caller at the gate");

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -494,26 +494,36 @@ pub(crate) async fn dispatch_trust_task_core(
     // `config.policy.enforcement` is on; when a policy denies (or demands
     // step-up/consent), the task is rejected here and never reaches its handler.
     // A rejected task still flows through the audit tail below.
-    let outcome = match policy_gate::policy_gate(state, auth, &type_uri, &doc).await {
-        Some(reject_outcome) => reject_outcome,
-        None => {
-            if let Some(spec) = wire_v0_2::lookup_0_2(&type_uri) {
-                let mut doc = doc;
-                wire_v0_2::downconvert_request(&mut doc.payload, spec);
-                if let Ok(uri_0_1) = spec.uri_0_1.parse() {
-                    doc.type_uri = uri_0_1;
+    // Filled by the gate only when a consumed consent grant *delegated* a context
+    // the requester's own token lacked. When non-empty, this dispatch — and only
+    // this dispatch — runs under the requester's identity widened to include the
+    // delegated context; the widening is never written back to the session.
+    let mut delegated_contexts: Vec<String> = Vec::new();
+    let outcome =
+        match policy_gate::policy_gate(state, auth, &type_uri, &doc, &mut delegated_contexts).await
+        {
+            Some(reject_outcome) => reject_outcome,
+            None => {
+                let delegated_auth = (!delegated_contexts.is_empty())
+                    .then(|| auth.with_delegated_contexts(&delegated_contexts));
+                let auth = delegated_auth.as_ref().unwrap_or(auth);
+                if let Some(spec) = wire_v0_2::lookup_0_2(&type_uri) {
+                    let mut doc = doc;
+                    wire_v0_2::downconvert_request(&mut doc.payload, spec);
+                    if let Ok(uri_0_1) = spec.uri_0_1.parse() {
+                        doc.type_uri = uri_0_1;
+                    }
+                    let outcome = WIRE_VERSION
+                        .scope(WireVersion::V0_2, dispatch_typed(state, auth, doc))
+                        .await;
+                    wire_v0_2::upconvert_response(outcome, spec)
+                } else {
+                    WIRE_VERSION
+                        .scope(WireVersion::V0_1, dispatch_typed(state, auth, doc))
+                        .await
                 }
-                let outcome = WIRE_VERSION
-                    .scope(WireVersion::V0_2, dispatch_typed(state, auth, doc))
-                    .await;
-                wire_v0_2::upconvert_response(outcome, spec)
-            } else {
-                WIRE_VERSION
-                    .scope(WireVersion::V0_1, dispatch_typed(state, auth, doc))
-                    .await
             }
-        }
-    };
+        };
 
     if let Some((action, resource, context_id, detail)) = vault_audit {
         let label = vault_audit_outcome_label(&outcome);

--- a/vta-service/src/trust_tasks/planner.rs
+++ b/vta-service/src/trust_tasks/planner.rs
@@ -33,6 +33,25 @@ pub struct TaskPlan {
     /// one — and putting them on the wire would only invite a consent surface to
     /// render a number it cannot interpret.
     pub guards: Guards,
+    /// The context whose admin authority this task acts under, when the executor
+    /// can determine it (webvh update: the DID's context). Lets the consent gate
+    /// require an approver who administers it before a delegation can confer
+    /// execution authority. `None` for tasks with no context-scoped subject.
+    pub subject_context: Option<String>,
+    /// Whether the requester's own authority already covered the task. When
+    /// `false`, the task is a cross-context proposal, executable only via a
+    /// consented delegation from a context-admin approver.
+    ///
+    /// The serde default is `true` so wire/stored plans missing the field (and
+    /// tasks with no delegation-aware planner) are never mistaken for delegated
+    /// proposals. Do not read the derived `Default` (`false`) as a delegation
+    /// signal — always extract via the `Option<TaskPlan>`-aware path in the gate.
+    #[serde(default = "default_true")]
+    pub requester_authorized: bool,
+}
+
+fn default_true() -> bool {
+    true
 }
 
 /// Preconditions the executor checks for itself before committing.
@@ -111,6 +130,8 @@ async fn plan_webvh_update(
                 counter: plan.path_counter_pin,
             }),
         },
+        subject_context: Some(plan.subject_context.clone()),
+        requester_authorized: plan.requester_authorized,
     })
 }
 
@@ -196,6 +217,8 @@ mod tests {
             effects: vec![],
             state_pin: Some(pin(pin_v)),
             guards: guards(counter),
+            subject_context: None,
+            requester_authorized: true,
         }
     }
 

--- a/vta-service/src/trust_tasks/policy_gate.rs
+++ b/vta-service/src/trust_tasks/policy_gate.rs
@@ -95,6 +95,10 @@ pub(super) async fn policy_gate(
     auth: &AuthClaims,
     type_uri: &str,
     doc: &TrustTask<Value>,
+    // Out: contexts a consumed delegated grant confers on this execution (see
+    // `consent_gate`). Only the consent path ever writes it; every other gate
+    // outcome leaves it empty.
+    delegated_out: &mut Vec<String>,
 ) -> Option<TrustTaskOutcome> {
     // Ceremony tasks are the mechanism, not a gated operation — never gate them.
     if is_ceremony_task(type_uri) {
@@ -157,7 +161,15 @@ pub(super) async fn policy_gate(
             }
         }
         Disposition::RequireConsent => {
-            consent_gate(state, auth, doc, type_uri, decision.require_consent).await
+            consent_gate(
+                state,
+                auth,
+                doc,
+                type_uri,
+                decision.require_consent,
+                delegated_out,
+            )
+            .await
         }
     }
 }
@@ -181,6 +193,13 @@ async fn consent_gate(
     doc: &TrustTask<Value>,
     type_uri: &str,
     require: Option<RequireConsent>,
+    // Out: filled with the contexts a consumed *delegated* grant confers on this
+    // one execution, so the caller can widen `auth` for the dispatch. Left empty
+    // for an ordinary same-context consent (the requester already held the
+    // context). The bodies below never widen authority themselves — they only
+    // report what the approvers conferred, keeping the augmentation on one
+    // explicit, auditable path.
+    delegated_out: &mut Vec<String>,
 ) -> Option<TrustTaskOutcome> {
     // A requireConsent naming no approver set can never be satisfied — fail closed.
     let Some(require) = require else {
@@ -263,6 +282,10 @@ async fn consent_gate(
                     },
                 ));
             }
+            // The grant is authorized and the world still matches. If it carries
+            // a delegation (approvers conferred a context the requester lacked),
+            // hand it to the caller to widen `auth` for this one dispatch.
+            *delegated_out = grant.delegated_contexts;
             return None;
         }
         Ok(None) => {}
@@ -276,9 +299,17 @@ async fn consent_gate(
         Ok(p) => p,
         Err(e) => return Some(app_error_to_reject(doc, e)),
     };
-    let (effects, state_pin, guards) = match &plan {
-        Some(p) => (p.effects.clone(), p.state_pin.clone(), p.guards.clone()),
-        None => (vec![], None, Default::default()),
+    let (effects, state_pin, guards, subject_context, requester_authorized) = match &plan {
+        Some(p) => (
+            p.effects.clone(),
+            p.state_pin.clone(),
+            p.guards.clone(),
+            p.subject_context.clone(),
+            p.requester_authorized,
+        ),
+        // No planner ⇒ no delegation concept: treat as self-authorized so the
+        // approver-authority path below never engages for an unplanned task.
+        None => (vec![], None, Default::default(), None, true),
     };
 
     let min_approvals = require.min_approvals.max(1);
@@ -314,6 +345,8 @@ async fn consent_gate(
                 now,
                 &state_pin,
                 &guards,
+                &subject_context,
+                requester_authorized,
             )
             .await
             {
@@ -332,6 +365,8 @@ async fn consent_gate(
                 now,
                 &state_pin,
                 &guards,
+                &subject_context,
+                requester_authorized,
             )
             .await
             {
@@ -470,6 +505,8 @@ async fn mint_pending(
     now: u64,
     state_pin: &Option<crate::policy::effects::StatePin>,
     guards: &super::planner::Guards,
+    subject_context: &Option<String>,
+    requester_authorized: bool,
 ) -> Result<consent::PendingTaskConsent, vti_common::error::AppError> {
     // 256 bits of entropy. It is both the replay nonce and the digest salt, so
     // guessing it would both replay a decision and unmask the payload.
@@ -489,6 +526,8 @@ async fn mint_pending(
         approvals: vec![],
         state_pin: state_pin.clone(),
         guards: guards.clone(),
+        subject_context: subject_context.clone(),
+        requester_authorized,
         created_at: now,
         expires_at: now + CONSENT_PENDING_TTL_SECS,
     };
@@ -547,23 +586,39 @@ mod tests {
         let d = doc(UNGATED_URI);
 
         // Disabled: proceed even with an empty policy set.
-        assert!(policy_gate(&state, &auth, UNGATED_URI, &d).await.is_none());
+        assert!(
+            policy_gate(&state, &auth, UNGATED_URI, &d, &mut Vec::new())
+                .await
+                .is_none()
+        );
 
         // Enabled + empty set → default-deny.
         state.config.write().await.policy.enforcement = true;
-        assert!(policy_gate(&state, &auth, UNGATED_URI, &d).await.is_some());
+        assert!(
+            policy_gate(&state, &auth, UNGATED_URI, &d, &mut Vec::new())
+                .await
+                .is_some()
+        );
 
         // Deny policy → reject.
         crate::policy::storage::store_policy(&state.policy_ks, &module("deny", 0, DENY_ALL))
             .await
             .unwrap();
-        assert!(policy_gate(&state, &auth, UNGATED_URI, &d).await.is_some());
+        assert!(
+            policy_gate(&state, &auth, UNGATED_URI, &d, &mut Vec::new())
+                .await
+                .is_some()
+        );
 
         // Higher-priority allow overrides → proceed.
         crate::policy::storage::store_policy(&state.policy_ks, &module("allow", 10, ALLOW_ALL))
             .await
             .unwrap();
-        assert!(policy_gate(&state, &auth, UNGATED_URI, &d).await.is_none());
+        assert!(
+            policy_gate(&state, &auth, UNGATED_URI, &d, &mut Vec::new())
+                .await
+                .is_none()
+        );
     }
 
     #[tokio::test]
@@ -583,14 +638,18 @@ mod tests {
         // aal1 session → policy demands step-up → rejected (with approve-request).
         auth.acr = "aal1".into();
         assert!(
-            policy_gate(&state, &auth, UNGATED_URI, &d).await.is_some(),
+            policy_gate(&state, &auth, UNGATED_URI, &d, &mut Vec::new())
+                .await
+                .is_some(),
             "aal1 session must be sent to step-up"
         );
 
         // aal2 session → requirement already satisfied → proceed.
         auth.acr = "aal2".into();
         assert!(
-            policy_gate(&state, &auth, UNGATED_URI, &d).await.is_none(),
+            policy_gate(&state, &auth, UNGATED_URI, &d, &mut Vec::new())
+                .await
+                .is_none(),
             "aal2 session must pass the step-up gate"
         );
     }
@@ -630,7 +689,7 @@ mod tests {
         .await
         .unwrap();
 
-        let outcome = policy_gate(&state, &auth, UNGATED_URI, &d)
+        let outcome = policy_gate(&state, &auth, UNGATED_URI, &d, &mut Vec::new())
             .await
             .expect("first submit is rejected pending consent");
         let body: Value = serde_json::from_slice(&outcome.body).expect("reject body");
@@ -735,7 +794,9 @@ mod tests {
         .await
         .unwrap();
 
-        let outcome = policy_gate(&state, &auth, UNGATED_URI, &d).await.unwrap();
+        let outcome = policy_gate(&state, &auth, UNGATED_URI, &d, &mut Vec::new())
+            .await
+            .unwrap();
         let body: Value = serde_json::from_slice(&outcome.body).unwrap();
         let req = &body.pointer("/payload/details/consentRequests").unwrap()[0];
 
@@ -769,7 +830,9 @@ mod tests {
         .await
         .unwrap();
 
-        let outcome = policy_gate(&state, &auth, UNGATED_URI, &d).await.unwrap();
+        let outcome = policy_gate(&state, &auth, UNGATED_URI, &d, &mut Vec::new())
+            .await
+            .unwrap();
         let body: Value = serde_json::from_slice(&outcome.body).unwrap();
         let req = &body.pointer("/payload/details/consentRequests").unwrap()[0];
         assert!(req["payload"].get("origin").is_none());
@@ -798,7 +861,9 @@ mod tests {
         .await
         .unwrap();
 
-        let outcome = policy_gate(&state, &auth, UNGATED_URI, &d).await.unwrap();
+        let outcome = policy_gate(&state, &auth, UNGATED_URI, &d, &mut Vec::new())
+            .await
+            .unwrap();
         let body: Value = serde_json::from_slice(&outcome.body).unwrap();
         let requests = body
             .pointer("/payload/details/consentRequests")
@@ -864,7 +929,11 @@ mod tests {
         .unwrap();
 
         // First submit raises the question — the approver is asked.
-        assert!(policy_gate(&state, &auth, UNGATED_URI, &d).await.is_some());
+        assert!(
+            policy_gate(&state, &auth, UNGATED_URI, &d, &mut Vec::new())
+                .await
+                .is_some()
+        );
         let pushed = state.mediator_registry.take_outbound(MEDIATOR).await;
         assert_eq!(pushed.len(), 1, "the approver is asked exactly once");
         assert_eq!(
@@ -881,7 +950,11 @@ mod tests {
 
         // Re-submitting the identical payload re-asks the same question, and must
         // not ring the phone again.
-        assert!(policy_gate(&state, &auth, UNGATED_URI, &d).await.is_some());
+        assert!(
+            policy_gate(&state, &auth, UNGATED_URI, &d, &mut Vec::new())
+                .await
+                .is_some()
+        );
         assert!(
             state
                 .mediator_registry
@@ -934,6 +1007,7 @@ mod tests {
             approvers: vec!["did:key:zApprover".into()],
             state_pin: None,
             guards: Default::default(),
+            delegated_contexts: vec![],
             granted_at: now,
             expires_at: now + 600,
         };
@@ -950,7 +1024,9 @@ mod tests {
         }
 
         assert!(
-            policy_gate(&state, &auth, UNGATED_URI, &d).await.is_some(),
+            policy_gate(&state, &auth, UNGATED_URI, &d, &mut Vec::new())
+                .await
+                .is_some(),
             "a grant signed by a now-revoked approver must NOT carry the task through"
         );
     }
@@ -989,6 +1065,7 @@ mod tests {
                 approvers: vec!["did:key:zApprover".into()],
                 state_pin: None,
                 guards: Default::default(),
+                delegated_contexts: vec![],
                 granted_at: now,
                 expires_at: now + 600,
             },
@@ -997,7 +1074,9 @@ mod tests {
         .unwrap();
 
         assert!(
-            policy_gate(&state, &auth, UNGATED_URI, &d).await.is_none(),
+            policy_gate(&state, &auth, UNGATED_URI, &d, &mut Vec::new())
+                .await
+                .is_none(),
             "an approver still in the set must carry the task through"
         );
     }
@@ -1038,6 +1117,7 @@ mod tests {
                 approvers: vec!["did:key:zA".into()],
                 state_pin: None,
                 guards: Default::default(),
+                delegated_contexts: vec![],
                 granted_at: now,
                 expires_at: now + 600,
             },
@@ -1046,7 +1126,9 @@ mod tests {
         .unwrap();
 
         assert!(
-            policy_gate(&state, &auth, UNGATED_URI, &d).await.is_some(),
+            policy_gate(&state, &auth, UNGATED_URI, &d, &mut Vec::new())
+                .await
+                .is_some(),
             "a single approval must not satisfy a threshold that has since risen to two"
         );
     }
@@ -1096,6 +1178,7 @@ mod tests {
                 requester_did: auth.did.clone(),
                 type_uri: UNGATED_URI.into(),
                 approvers: vec!["did:key:zApprover".into()],
+                delegated_contexts: vec![],
                 granted_at: now,
                 expires_at: now + 600,
             },
@@ -1105,15 +1188,21 @@ mod tests {
 
         // The substituted task must NOT ride that grant through.
         assert!(
-            policy_gate(&state, &auth, OTHER_UNGATED_URI, &substituted)
-                .await
-                .is_some(),
+            policy_gate(
+                &state,
+                &auth,
+                OTHER_UNGATED_URI,
+                &substituted,
+                &mut Vec::new()
+            )
+            .await
+            .is_some(),
             "a grant for a different task URI must not authorize this one"
         );
 
         // …while the task actually approved still passes.
         assert!(
-            policy_gate(&state, &auth, UNGATED_URI, &approved)
+            policy_gate(&state, &auth, UNGATED_URI, &approved, &mut Vec::new())
                 .await
                 .is_none(),
             "the approved task must still consume its own grant"
@@ -1143,7 +1232,9 @@ mod tests {
 
         // First submit → consent required (rejected) + a pending is recorded.
         assert!(
-            policy_gate(&state, &auth, UNGATED_URI, &d).await.is_some(),
+            policy_gate(&state, &auth, UNGATED_URI, &d, &mut Vec::new())
+                .await
+                .is_some(),
             "first submit must be rejected pending consent"
         );
         let digest = consent::payload_digest(UNGATED_URI, &d.payload).unwrap();
@@ -1166,6 +1257,7 @@ mod tests {
                 requester_did: auth.did.clone(),
                 type_uri: UNGATED_URI.into(),
                 approvers: vec!["did:key:zApprover".into()],
+                delegated_contexts: vec![],
                 granted_at: now,
                 expires_at: now + 600,
             },
@@ -1175,12 +1267,16 @@ mod tests {
 
         // Re-submit → grant consumed → proceed.
         assert!(
-            policy_gate(&state, &auth, UNGATED_URI, &d).await.is_none(),
+            policy_gate(&state, &auth, UNGATED_URI, &d, &mut Vec::new())
+                .await
+                .is_none(),
             "a valid grant must let the re-submit proceed"
         );
         // Grant was single-use → the next submit needs consent again.
         assert!(
-            policy_gate(&state, &auth, UNGATED_URI, &d).await.is_some(),
+            policy_gate(&state, &auth, UNGATED_URI, &d, &mut Vec::new())
+                .await
+                .is_some(),
             "grant is single-use; a further submit re-requires consent"
         );
     }

--- a/vta-service/src/trust_tasks/task_consent.rs
+++ b/vta-service/src/trust_tasks/task_consent.rs
@@ -14,6 +14,7 @@ use trust_tasks_rs::{RejectReason, TrustTask};
 
 use super::TrustTaskOutcome;
 use super::helpers::{app_error_to_reject, parse_payload, reject_with, success_response};
+use crate::acl::{Role, check_acl_full};
 use crate::auth::AuthClaims;
 use crate::policy::consent;
 use crate::server::AppState;
@@ -55,6 +56,52 @@ fn now_secs() -> u64 {
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_secs())
         .unwrap_or(0)
+}
+
+/// Contexts these approvals may confer on the single execution that consumes the
+/// grant — the per-task delegation.
+///
+/// Empty unless the task was a cross-context proposal (`requester_authorized ==
+/// false`) with a known `subject_context`. When it was, an approver confers that
+/// context **only if they actually administer it**: resolved against live ACL
+/// state, requiring `Role::Admin` *and* context access (super-admin, or the
+/// context/an ancestor in `allowed_contexts`). This is attenuation — an approver
+/// can never delegate authority they do not hold, and set membership alone is
+/// not authority. The context is conferred only if enough such admins approved
+/// to meet the same `min_approvals` threshold the task required; otherwise the
+/// grant carries nothing and execution still fails the requester's own
+/// `require_context`.
+async fn compute_delegated_contexts(
+    state: &AppState,
+    pending: &consent::PendingTaskConsent,
+) -> Vec<String> {
+    if pending.requester_authorized {
+        return Vec::new();
+    }
+    let Some(ctx) = pending.subject_context.as_deref() else {
+        return Vec::new();
+    };
+    let mut context_admins = 0u32;
+    for approver in &pending.approvals {
+        // A DID absent from the ACL (or expired) resolves to an error and
+        // confers nothing — a random approver device cannot grant authority.
+        if let Ok((role, contexts)) = check_acl_full(&state.acl_ks, approver).await {
+            let claims = AuthClaims {
+                did: approver.clone(),
+                role,
+                allowed_contexts: contexts,
+                ..Default::default()
+            };
+            if claims.role == Role::Admin && claims.has_context_access(ctx) {
+                context_admins += 1;
+            }
+        }
+    }
+    if context_admins >= pending.min_approvals {
+        vec![ctx.to_string()]
+    } else {
+        Vec::new()
+    }
 }
 
 pub(super) async fn handle_decision(
@@ -164,6 +211,11 @@ pub(super) async fn handle_decision(
     };
 
     if updated.approvals.len() as u32 >= updated.min_approvals {
+        // Per-task delegation. When the requester could not self-authorize the
+        // task's context, the approvals confer execution authority for it — but
+        // only if the approvers actually hold admin there. Resolved here, at the
+        // moment the grant is minted, against live ACL state.
+        let delegated_contexts = compute_delegated_contexts(state, &updated).await;
         let grant = consent::TaskConsentGrant {
             digest: updated.digest.clone(),
             requester_did: updated.requester_did.clone(),
@@ -176,6 +228,7 @@ pub(super) async fn handle_decision(
             // minutes wide.
             state_pin: updated.state_pin.clone(),
             guards: updated.guards.clone(),
+            delegated_contexts,
             granted_at: now,
             expires_at: now + GRANT_TTL_SECS,
         };
@@ -202,4 +255,141 @@ pub(super) async fn handle_decision(
             "needed": updated.min_approvals,
         }),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::{build_signing_test_app_state, seed_acl_entry};
+
+    const OPENVTC: &str = "openvtc";
+    const ADMIN_A: &str = "did:key:zAdminOpenvtc";
+    const ADMIN_OTHER: &str = "did:key:zAdminElsewhere";
+    const READER: &str = "did:key:zReaderOpenvtc";
+    const STRANGER: &str = "did:key:zNotInAcl";
+
+    /// A cross-context pending awaiting `min` approvals for `OPENVTC`.
+    fn cross_context_pending(approvals: Vec<String>, min: u32) -> consent::PendingTaskConsent {
+        consent::PendingTaskConsent {
+            digest: "d".into(),
+            wire_digest: "w".into(),
+            type_uri: "https://…/dids/update/1.0".into(),
+            requester_did: "did:key:zAgent".into(),
+            approver_set: "openvtc-admins".into(),
+            min_approvals: min,
+            exclude_requester: true,
+            challenge: "nonce".into(),
+            approvals,
+            state_pin: None,
+            guards: Default::default(),
+            subject_context: Some(OPENVTC.into()),
+            requester_authorized: false,
+            created_at: 0,
+            expires_at: u64::MAX,
+        }
+    }
+
+    #[tokio::test]
+    async fn context_admin_approval_confers_the_context() {
+        let (state, _dir) = build_signing_test_app_state().await;
+        seed_acl_entry(&state.acl_ks, ADMIN_A, Role::Admin, vec![OPENVTC.into()]).await;
+
+        let pending = cross_context_pending(vec![ADMIN_A.into()], 1);
+        assert_eq!(
+            compute_delegated_contexts(&state, &pending).await,
+            vec![OPENVTC.to_string()],
+            "an admin of the context confers it"
+        );
+    }
+
+    #[tokio::test]
+    async fn approval_from_admin_of_another_context_confers_nothing() {
+        let (state, _dir) = build_signing_test_app_state().await;
+        seed_acl_entry(
+            &state.acl_ks,
+            ADMIN_OTHER,
+            Role::Admin,
+            vec!["some-other-ctx".into()],
+        )
+        .await;
+
+        let pending = cross_context_pending(vec![ADMIN_OTHER.into()], 1);
+        assert!(
+            compute_delegated_contexts(&state, &pending)
+                .await
+                .is_empty(),
+            "an admin of a different context cannot delegate this one"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_reader_of_the_context_confers_nothing() {
+        // Attenuation: holding the context as a non-admin is not authority to delegate.
+        let (state, _dir) = build_signing_test_app_state().await;
+        seed_acl_entry(&state.acl_ks, READER, Role::Reader, vec![OPENVTC.into()]).await;
+
+        let pending = cross_context_pending(vec![READER.into()], 1);
+        assert!(
+            compute_delegated_contexts(&state, &pending)
+                .await
+                .is_empty(),
+            "a reader of the context is not an admin of it"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_approver_absent_from_the_acl_confers_nothing() {
+        let (state, _dir) = build_signing_test_app_state().await;
+        let pending = cross_context_pending(vec![STRANGER.into()], 1);
+        assert!(
+            compute_delegated_contexts(&state, &pending)
+                .await
+                .is_empty(),
+            "a signer with no ACL entry has no authority to delegate"
+        );
+    }
+
+    #[tokio::test]
+    async fn delegation_requires_meeting_the_threshold_with_context_admins() {
+        // Two approvals required, but only one is a context-admin ⇒ no delegation.
+        let (state, _dir) = build_signing_test_app_state().await;
+        seed_acl_entry(&state.acl_ks, ADMIN_A, Role::Admin, vec![OPENVTC.into()]).await;
+        seed_acl_entry(&state.acl_ks, READER, Role::Reader, vec![OPENVTC.into()]).await;
+
+        let pending = cross_context_pending(vec![ADMIN_A.into(), READER.into()], 2);
+        assert!(
+            compute_delegated_contexts(&state, &pending)
+                .await
+                .is_empty(),
+            "one context-admin cannot meet a threshold of two"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_super_admin_approver_can_confer_any_context() {
+        let (state, _dir) = build_signing_test_app_state().await;
+        // Empty contexts + Admin role = super-admin (unrestricted).
+        seed_acl_entry(&state.acl_ks, ADMIN_A, Role::Admin, vec![]).await;
+
+        let pending = cross_context_pending(vec![ADMIN_A.into()], 1);
+        assert_eq!(
+            compute_delegated_contexts(&state, &pending).await,
+            vec![OPENVTC.to_string()],
+        );
+    }
+
+    #[tokio::test]
+    async fn a_self_authorized_task_never_delegates() {
+        let (state, _dir) = build_signing_test_app_state().await;
+        seed_acl_entry(&state.acl_ks, ADMIN_A, Role::Admin, vec![OPENVTC.into()]).await;
+
+        let mut pending = cross_context_pending(vec![ADMIN_A.into()], 1);
+        pending.requester_authorized = true;
+        assert!(
+            compute_delegated_contexts(&state, &pending)
+                .await
+                .is_empty(),
+            "the requester already held the context — nothing to delegate"
+        );
+    }
 }

--- a/vta-service/tests/delegated_consent_e2e.rs
+++ b/vta-service/tests/delegated_consent_e2e.rs
@@ -465,6 +465,213 @@ async fn the_requester_cannot_approve_its_own_task() {
     );
 }
 
+/// Per-task delegated capability, end to end: a requester with **no authority
+/// over the DID's context** proposes an update, an admin **of that context**
+/// approves, and the update executes — under authority the approval conferred
+/// for that one task, never standing on the requester's token.
+///
+/// This is the flow the whole redesign exists for: the agent holds nothing, and
+/// authority arrives per-task from someone who actually has it.
+#[tokio::test]
+async fn a_context_admin_approval_lets_a_cross_context_requester_execute() {
+    let (router, ctx) = build_test_app_with(TestAppOptions {
+        provisionable_vta: true,
+        ..Default::default()
+    })
+    .await;
+
+    // Setup: mint the DID in context `default` using a super-admin (the
+    // provisioning identity a deployment already trusts).
+    let admin_token = ctx
+        .mint_token("did:key:z6MkTestRequester", "admin", vec![])
+        .await;
+    let (did, _scid) = create_did(&router, &ctx, &admin_token).await;
+    let keys_before = update_keys_in_force(&ctx, &did).await;
+
+    // The requester is an admin — but of `other-ctx`, NOT `default`. On its own
+    // token it cannot touch this DID.
+    let requester = "did:key:z6MkCrossCtxAgent";
+    let deleg_token = ctx
+        .mint_token(requester, "admin", vec!["other-ctx".into()])
+        .await;
+
+    // The approver is an admin of `default` in the ACL — the authority a
+    // delegation can draw on.
+    let ops = approver(21);
+    vta_service::test_support::seed_acl_entry(
+        &ctx.acl_ks,
+        &ops.did,
+        vta_service::acl::Role::Admin,
+        vec!["default".into()],
+    )
+    .await;
+
+    {
+        let mut cfg = ctx.config.write().await;
+        cfg.policy.enforcement = true;
+        cfg.policy
+            .approver_sets
+            .insert("operators".into(), vec![ops.did.clone()]);
+    }
+    install_policy(&ctx, REQUIRE_CONSENT).await;
+
+    // 1. The cross-context requester proposes the edit. The dry-run must succeed
+    //    *despite* the requester lacking the context (plan tolerance) so an
+    //    approver can be shown the effects.
+    let update = envelope(
+        WEBVH_UPDATE,
+        requester,
+        &ctx.vta_did,
+        json!({
+            "did": did,
+            "document": { "@context": ["https://www.w3.org/ns/did/v1"], "id": did, "alsoKnownAs": ["did:example:delegated"] }
+        }),
+    );
+    let (status, rejected) = post(&router, &deleg_token, &update).await;
+    assert_eq!(
+        status,
+        StatusCode::UNPROCESSABLE_ENTITY,
+        "a cross-context proposal must require consent, not fail or execute: {rejected}"
+    );
+    let d = &rejected["payload"]["details"];
+    let payload_digest = d["payloadDigest"].as_str().expect("digest");
+    let challenge = d["challenge"].as_str().expect("challenge");
+    assert_eq!(
+        d["consentRequests"].as_array().map(Vec::len),
+        Some(1),
+        "the context admin must be asked: {rejected}"
+    );
+
+    // 2. The context admin approves.
+    let decision = sign_as(
+        &ops,
+        envelope(
+            TASK_CONSENT_DECISION,
+            &ops.did,
+            &ctx.vta_did,
+            json!({ "challenge": challenge, "payloadDigest": payload_digest, "decision": "approve" }),
+        ),
+    );
+    let (status, granted) = post(&router, &deleg_token, &decision).await;
+    assert_eq!(status, StatusCode::OK, "decision accepted: {granted}");
+    assert_eq!(granted["payload"]["status"], "granted", "{granted}");
+
+    // 3. The cross-context requester re-submits — and it now executes, under the
+    //    context authority the approval conferred for this one task.
+    let resubmit = envelope(
+        WEBVH_UPDATE,
+        requester,
+        &ctx.vta_did,
+        update["payload"].clone(),
+    );
+    let (status, executed) = post(&router, &deleg_token, &resubmit).await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "the delegated task must execute for a requester who never held the context: {executed}"
+    );
+
+    // 4. It really ran: a webvh update rotates the update key, so the log moved.
+    let keys_after = update_keys_in_force(&ctx, &did).await;
+    assert_ne!(
+        keys_after, keys_before,
+        "the delegated update must have committed to the log"
+    );
+}
+
+/// The dual: an approval from someone who is a set member but is **not** an admin
+/// of the DID's context confers nothing. The decision is accepted (they are in
+/// the set), but the re-submit cannot execute — authority can only be delegated
+/// by someone who holds it.
+#[tokio::test]
+async fn an_approval_from_a_non_context_admin_confers_no_execution() {
+    let (router, ctx) = build_test_app_with(TestAppOptions {
+        provisionable_vta: true,
+        ..Default::default()
+    })
+    .await;
+
+    let admin_token = ctx
+        .mint_token("did:key:z6MkTestRequester", "admin", vec![])
+        .await;
+    let (did, _scid) = create_did(&router, &ctx, &admin_token).await;
+    let keys_before = update_keys_in_force(&ctx, &did).await;
+
+    let requester = "did:key:z6MkCrossCtxAgent";
+    let deleg_token = ctx
+        .mint_token(requester, "admin", vec!["other-ctx".into()])
+        .await;
+
+    // The approver administers a DIFFERENT context, not `default`.
+    let ops = approver(23);
+    vta_service::test_support::seed_acl_entry(
+        &ctx.acl_ks,
+        &ops.did,
+        vta_service::acl::Role::Admin,
+        vec!["some-other-ctx".into()],
+    )
+    .await;
+
+    {
+        let mut cfg = ctx.config.write().await;
+        cfg.policy.enforcement = true;
+        cfg.policy
+            .approver_sets
+            .insert("operators".into(), vec![ops.did.clone()]);
+    }
+    install_policy(&ctx, REQUIRE_CONSENT).await;
+
+    let update = envelope(
+        WEBVH_UPDATE,
+        requester,
+        &ctx.vta_did,
+        json!({
+            "did": did,
+            "document": { "@context": ["https://www.w3.org/ns/did/v1"], "id": did, "alsoKnownAs": ["did:example:nope"] }
+        }),
+    );
+    let (_, rejected) = post(&router, &deleg_token, &update).await;
+    let d = &rejected["payload"]["details"];
+
+    // The approver is in the set, so the decision itself is accepted and a grant
+    // is minted — but it carries no delegated context.
+    let decision = sign_as(
+        &ops,
+        envelope(
+            TASK_CONSENT_DECISION,
+            &ops.did,
+            &ctx.vta_did,
+            json!({ "challenge": d["challenge"], "payloadDigest": d["payloadDigest"], "decision": "approve" }),
+        ),
+    );
+    let (status, _granted) = post(&router, &deleg_token, &decision).await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "a set member's decision is accepted"
+    );
+
+    // The re-submit must NOT execute: the grant conferred no authority over
+    // `default`, and the requester never held it.
+    let resubmit = envelope(
+        WEBVH_UPDATE,
+        requester,
+        &ctx.vta_did,
+        update["payload"].clone(),
+    );
+    let (status, refused) = post(&router, &deleg_token, &resubmit).await;
+    assert_ne!(
+        status,
+        StatusCode::OK,
+        "an approval from a non-context-admin must not confer execution: {refused}"
+    );
+    assert_eq!(
+        update_keys_in_force(&ctx, &did).await,
+        keys_before,
+        "nothing may have committed to the log"
+    );
+}
+
 // ─── setup ───────────────────────────────────────────────────────────────────
 
 async fn install_policy(ctx: &TestAppContext, rego: &str) {

--- a/vti-common/src/auth/extractor.rs
+++ b/vti-common/src/auth/extractor.rs
@@ -213,6 +213,32 @@ impl AuthClaims {
                 .any(|allowed| crate::context_path::is_ancestor_or_self(allowed, context_id))
     }
 
+    /// Clone these claims with `extra` contexts merged into `allowed_contexts`.
+    ///
+    /// This is how a **consented per-task delegation** is realized: an approver
+    /// who holds admin in a context authorizes one specific task, and the
+    /// executor runs *that one dispatch* under the requester's identity widened
+    /// to include the delegated context. The widening lives only for the single
+    /// consented, payload-bound, single-use execution — it is never persisted
+    /// onto the session or the JWT, so the agent accrues no standing authority.
+    ///
+    /// Never *widens* a super-admin (empty `allowed_contexts` already means "all
+    /// contexts", so there is nothing to add and replacing the empty list would
+    /// wrongly *narrow* it) and is a no-op when `extra` is empty. Duplicates are
+    /// dropped so repeated delegation can't bloat the list.
+    pub fn with_delegated_contexts(&self, extra: &[String]) -> Self {
+        let mut claims = self.clone();
+        if extra.is_empty() || claims.is_super_admin() {
+            return claims;
+        }
+        for ctx in extra {
+            if !claims.allowed_contexts.iter().any(|c| c == ctx) {
+                claims.allowed_contexts.push(ctx.clone());
+            }
+        }
+        claims
+    }
+
     /// Check that the caller has access to the given context.
     ///
     /// Admins with an empty `allowed_contexts` list have unrestricted access.
@@ -486,6 +512,61 @@ mod tests {
 
         assert!(claims.require_context("acme/eng/team-a").is_ok());
         assert!(claims.require_context("acme/ops").is_err());
+    }
+
+    #[test]
+    fn with_delegated_contexts_widens_a_scoped_admin_for_one_call() {
+        let base = AuthClaims {
+            role: Role::Admin,
+            allowed_contexts: vec!["ctx-a".into()],
+            ..Default::default()
+        };
+        // Before: no access to the delegated context.
+        assert!(base.require_context("openvtc").is_err());
+
+        let widened = base.with_delegated_contexts(&["openvtc".into()]);
+        assert!(widened.require_context("openvtc").is_ok());
+        assert!(
+            widened.require_context("ctx-a").is_ok(),
+            "keeps its own context"
+        );
+        // The delegation is a fresh value — the caller's own claims are untouched.
+        assert!(base.require_context("openvtc").is_err());
+    }
+
+    #[test]
+    fn with_delegated_contexts_is_a_noop_for_empty_or_super_admin() {
+        let scoped = AuthClaims {
+            role: Role::Admin,
+            allowed_contexts: vec!["ctx-a".into()],
+            ..Default::default()
+        };
+        // Empty delegation changes nothing.
+        assert_eq!(
+            scoped.with_delegated_contexts(&[]).allowed_contexts,
+            scoped.allowed_contexts
+        );
+        // A super-admin (empty list = all contexts) must never be narrowed to a
+        // scoped list by a delegation.
+        let sa = AuthClaims {
+            role: Role::Admin,
+            ..Default::default()
+        };
+        assert!(sa.is_super_admin());
+        let after = sa.with_delegated_contexts(&["openvtc".into()]);
+        assert!(after.is_super_admin(), "super-admin stays unrestricted");
+        assert!(after.allowed_contexts.is_empty());
+    }
+
+    #[test]
+    fn with_delegated_contexts_dedups() {
+        let base = AuthClaims {
+            role: Role::Admin,
+            allowed_contexts: vec!["ctx-a".into()],
+            ..Default::default()
+        };
+        let widened = base.with_delegated_contexts(&["ctx-a".into(), "openvtc".into()]);
+        assert_eq!(widened.allowed_contexts, vec!["ctx-a", "openvtc"]);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

A delegated webvh update failed with `forbidden: caller has no admin role in context ` + "`openvtc`" whenever the requester wasn't an admin of the DID's context. For an agent (e.g. the browser plugin) that manages DIDs across many contexts, the only ways to make it pass were:

- grant the agent standing admin in **every** context it touches (re-granted by hand, grows forever), or
- make it a **super-admin** (unrestricted access to every context, present and future).

Both put durable, broad authority on a long-lived credential. Authority was a **standing property of the requester** — checked at both plan *and* execute — and consent was collected but never load-bearing: the approver's authority was never consulted.

## Approach

Authority now flows **per task**, from an approver who actually holds it. The agent holds no standing context authority.

- **Plan tolerance.** `run_update` still requires `require_admin`, but `require_context` is enforced only in `Mode::Execute`. In `Mode::Plan` it's recorded (`requester_authorized`), not enforced — so the consent gate can dry-run a cross-context proposal and show an approver the effects. This is safe: a plan's only outputs are the **public** DID-document diff (webvh logs resolve for anyone) and a reserving-nothing key-counter peek.
- **Attenuated conferral.** At the approval threshold, `task-consent/decision` resolves each approver against the **live ACL** and confers the DID's context **iff** at least `minApprovals` approvers are admins of it (`Role::Admin` + context access — super-admin or the context/an ancestor). Set membership alone is not authority; an approver can never delegate authority they don't hold.
- **Per-dispatch widening.** The consumed grant carries `delegated_contexts`; the dispatch runs under `auth.with_delegated_contexts(...)` — the requester's identity widened to include the delegated context for that **one** execution. It's payload-bound (`payloadDigest`), state-pinned (`statePin`), single-use, short-lived, and never written back to the session or token.

A set member who is **not** a context admin confers nothing, so the re-submit still can't execute. Same-context consent is unchanged.

## Shape of the change

New delegation fields thread through, all `#[serde(default)]` so older stored pendings/grants read as non-delegated:
- `UpdatePlan` / `TaskPlan`: `subject_context`, `requester_authorized`
- `PendingTaskConsent`: `subject_context`, `requester_authorized`
- `TaskConsentGrant`: `delegated_contexts`

The gate reports the consumed grant's delegated contexts to the dispatch spine via an out-parameter, keeping the widening on one explicit, auditable path; every non-consent gate outcome leaves it empty.

## Security properties

- **Attenuation, never amplification** — conferral requires the approver to actually administer the context, checked at approval time against live ACL.
- **Confused-deputy contained** — the widening is bound to the exact payload digest and the state the approver saw; it can't authorize a different or moved-on change.
- **No durable elevation** — the widened identity exists only for the single dispatch; a compromised agent gains nothing replayable.
- **Dry-run leaks nothing private** — a webvh DID document is already publicly resolvable.

## Tests

- Unit (`with_delegated_contexts`): widens a scoped admin for one call; no-op for empty/super-admin; dedups.
- Unit (`compute_delegated_contexts`): context-admin confers; admin-of-another-context, reader-of-the-context, and not-in-ACL confer nothing; threshold must be met by context-admins; super-admin confers; self-authorized never delegates.
- E2E (`delegated_consent_e2e.rs`, mocks nothing — real router, real DI proofs, real webvh log): a context-admin approval lets a cross-context requester execute (log commits); a non-context-admin approval confers no execution (log unchanged).

`cargo fmt`, `clippy -D warnings` (CI invocation), and the full `vta-service` + `vti-common` suites (**1522 tests**) all pass.
