### PR TITLE
fix(vtc-service): send camelCase secretKind on wallet-login vault/list

### DIFF
--- a/vtc-service/admin-ui/src/lib/wallet.ts
+++ b/vtc-service/admin-ui/src/lib/wallet.ts
@@ -32,6 +32,21 @@ export interface VtaWalletLoginResult {
   holderDid: string;
 }
 
+/** Canonical `secretKind` wire values — camelCase, mirroring
+ *  `vault/_shared/0.2/vault-entry.schema.json#/$defs/SecretKind`. The
+ *  maintainer schema-validates this enum before dispatch, so a
+ *  kebab-case value is a payload rejection, not a no-op filter. Keep
+ *  this the single source of truth for outbound `secretKind` filters. */
+export type SecretKind =
+  | "password"
+  | "passkey"
+  | "oauthTokens"
+  | "didSelfIssued"
+  | "didcommPeer"
+  | "bearerToken"
+  | "sshKey"
+  | "custom";
+
 /** A `did-self-issued` vault entry pinned to this RP, eligible for
  *  VTA-proxied SIOP login. */
 export interface ProxyVaultEntry {
@@ -66,7 +81,7 @@ interface VtaWalletProvider {
   vaultList?(params: {
     targetDid?: string;
     targetOriginPrefix?: string;
-    secretKind?: string;
+    secretKind?: SecretKind;
   }): Promise<VaultListWireResult>;
   proxyLogin?(params: {
     entryId: string;
@@ -156,7 +171,7 @@ export async function listProxyCandidates(): Promise<ProxyVaultEntry[]> {
   }
   const wire = await window.vtaWallet!.vaultList!({
     targetDid: await rpDid(),
-    secretKind: "did-self-issued",
+    secretKind: "didSelfIssued",
   });
   return wire.entries.filter((e) => Boolean(e.principalDid));
 }


### PR DESCRIPTION
## Problem

Wallet sign-in to the VTC via the browser extension fails with:

```
Sign-in failed
malformed request: payload does not conform to https://trusttasks.org/spec/vault/list/0.2:
payload failed schema validation: "did-self-issued" is not one of "password", "passkey" or 6 other candidates
```

## Root cause

The admin UI's proxy-login candidate lookup (`admin-ui/src/lib/wallet.ts`) filtered `vault/list/0.2` with `secretKind: "did-self-issued"` — the 0.1 kebab-case value — but the 0.2 wire `SecretKind` enum is camelCase (`didSelfIssued`, per `vault/_shared/0.2/vault-entry.schema.json`). The wallet extension passes the page-supplied filter through verbatim, so the kebab value reached the VTA, which now schema-validates every Trust-Task payload before dispatch and rejects it. The VTA's 0.2 dual-accept edge transform is deliberately downstream of the schema gate, so the client is the right layer to fix.

Same defect and same fix as did-hosting-ui (affinidi-webvh-service#85) — this `wallet.ts` mirrors that file and was copied before the fix landed there.

## Fix

- Send `didSelfIssued` in `listProxyCandidates()`.
- Add a canonical `SecretKind` union mirroring the shared 0.2 schema and type the outbound `vaultList` filter with it, so a kebab-case value fails to compile rather than failing on the wire.

## Testing

- `tsc -b --noEmit` clean in `vtc-service/admin-ui`.