### PR TITLE
feat: recover from a wedged mediator listener (drain-on-start + clearer logging)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## Unreleased
 
+### vta-service — recover from a wedged mediator listener (drain-on-start + clearer logging)
+
+* The mediator enforces one live-delivery websocket per DID, and the VTA's single
+  DIDComm listener carries **both DIDComm and TSP**. So an undeliverable/poison
+  message queued for the VTA's DID — or an active websocket left by a prior
+  process that wasn't cleanly stopped — can stall the live-delivery handshake and
+  wedge the listener indefinitely, taking both inbound paths down while REST stays
+  up. Diagnosing it previously meant dropping to `RUST_LOG` debug.
+* The `not connected after 30s` warning now explains this in the default log:
+  that auth+websocket likely connected but live-delivery didn't complete, that the
+  one listener carries DIDComm *and* TSP, the two usual causes (a lingering active
+  websocket for this DID, or a queued poison message), that the VTA keeps serving
+  REST and retrying, and how to recover.
+* New opt-in `messaging.drain_inbox_on_start` (default **false**). Because REST
+  auth + message-pickup keep working even when the websocket stalls, when set the
+  VTA drains its own mediator inbox over REST **before** enabling the live
+  listener: it fetches queued messages in bounded batches and deletes them,
+  logging each (and loudly logging + stopping if a batch can't be fetched), so a
+  mediator-side backlog can't keep startup wedged. Off by default because it
+  deletes queued messages; turn it on to recover a stuck boot without touching the
+  mediator.
+
 ### vta-service — per-task delegated capability for cross-context trust tasks
 
 * A delegated webvh update failed with `forbidden: caller has no admin role in

--- a/vta-service/src/config.rs
+++ b/vta-service/src/config.rs
@@ -624,6 +624,7 @@ impl AppConfig {
                     mediator_did: did,
                     mediator_host: None,
                     setup_acl: false,
+                    drain_inbox_on_start: false,
                 });
             }
             (Ok(url), Err(_)) => {
@@ -632,6 +633,7 @@ impl AppConfig {
                     mediator_did: String::new(),
                     mediator_host: None,
                     setup_acl: false,
+                    drain_inbox_on_start: false,
                 });
                 messaging.mediator_url = url;
             }
@@ -641,6 +643,7 @@ impl AppConfig {
                     mediator_did: String::new(),
                     mediator_host: None,
                     setup_acl: false,
+                    drain_inbox_on_start: false,
                 });
                 messaging.mediator_did = did;
             }

--- a/vta-service/src/operations/backup/mod.rs
+++ b/vta-service/src/operations/backup/mod.rs
@@ -745,6 +745,7 @@ pub async fn apply_import(
                         mediator_did: String::new(),
                         mediator_host: None,
                         setup_acl: false,
+                        drain_inbox_on_start: false,
                     });
             if let Some(ref url) = payload.config.mediator_url {
                 messaging.mediator_url = url.clone();

--- a/vta-service/src/operations/protocol/enable_didcomm.rs
+++ b/vta-service/src/operations/protocol/enable_didcomm.rs
@@ -265,6 +265,10 @@ async fn persist_didcomm_enabled(
             // Preserve the existing setup_acl setting if the config already has
             // a messaging section; otherwise default to false.
             setup_acl: cfg.messaging.as_ref().is_some_and(|m| m.setup_acl),
+            drain_inbox_on_start: cfg
+                .messaging
+                .as_ref()
+                .is_some_and(|m| m.drain_inbox_on_start),
         });
         let contents = toml::to_string_pretty(&*cfg)
             .map_err(|e| EnableDidcommError::ConfigPersistence(e.to_string()))?;

--- a/vta-service/src/operations/protocol/list.rs
+++ b/vta-service/src/operations/protocol/list.rs
@@ -272,6 +272,7 @@ mod tests {
             mediator_url: "ws://mediator:7037".into(),
             mediator_host: None,
             setup_acl: false,
+            drain_inbox_on_start: false,
         });
         cfg.config_path = dir.path().join("vta.toml");
         let config = Arc::new(RwLock::new(cfg));

--- a/vta-service/src/operations/protocol/update_didcomm.rs
+++ b/vta-service/src/operations/protocol/update_didcomm.rs
@@ -360,6 +360,10 @@ async fn persist_new_mediator(
             // Preserve the existing setup_acl setting if the config already has
             // a messaging section; otherwise default to false.
             setup_acl: cfg.messaging.as_ref().is_some_and(|m| m.setup_acl),
+            drain_inbox_on_start: cfg
+                .messaging
+                .as_ref()
+                .is_some_and(|m| m.drain_inbox_on_start),
         });
         let contents = toml::to_string_pretty(&*cfg)
             .map_err(|e| UpdateDidcommError::ConfigPersistence(e.to_string()))?;

--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -993,6 +993,32 @@ pub async fn run(
                         AppError::Internal(format!("failed to build DIDComm handler: {e}"))
                     })?;
 
+                    // Recovery: optionally clear this DID's mediator inbox over
+                    // REST *before* enabling live delivery, so a poison /
+                    // undeliverable backlog can't stall the pickup handshake and
+                    // wedge the (shared DIDComm+TSP) listener. Best-effort, and
+                    // off unless `messaging.drain_inbox_on_start` is set.
+                    if messaging_config.drain_inbox_on_start {
+                        match app_state.atm.as_ref() {
+                            Some(atm) => {
+                                let cleared = drain_mediator_inbox(
+                                    atm,
+                                    &messaging_config.mediator_did,
+                                    vta_did,
+                                )
+                                .await;
+                                info!(
+                                    count = cleared,
+                                    mediator = %messaging_config.mediator_did,
+                                    "drain_inbox_on_start: cleared queued mediator messages before going live"
+                                );
+                            }
+                            None => warn!(
+                                "drain_inbox_on_start is set but no ATM is available; skipping drain"
+                            ),
+                        }
+                    }
+
                     // With `tsp` compiled, always register the TSP handler so
                     // inbound TSP frames off the shared socket reach the
                     // trust-task spine — independent of whether TSP is currently
@@ -1026,7 +1052,25 @@ pub async fn run(
                                     if let Err(e) = res {
                                         let mut status = app_state.didcomm_websocket_status.write().await;
                                         *status = DidcommWebsocketStatus::Disconnected;
-                                        warn!("DIDComm listener not connected after 30s: {e}");
+                                        warn!(
+                                            mediator = %messaging_config.mediator_did,
+                                            error = %e,
+                                            "DIDComm listener did not go live within 30s. Auth + \
+                                             websocket most likely connected, but live-delivery \
+                                             (message-pickup) never completed — and this single \
+                                             listener carries BOTH DIDComm and TSP, so both inbound \
+                                             paths are down. The mediator enforces one live-delivery \
+                                             websocket per DID, so the usual causes are: (1) an \
+                                             active websocket for this DID left by a prior process \
+                                             that wasn't cleanly stopped, or (2) an \
+                                             undeliverable/poison message queued for this DID that \
+                                             stalls the pickup handshake. The VTA keeps serving REST \
+                                             and retries in the background. To recover without \
+                                             touching the mediator, set \
+                                             `messaging.drain_inbox_on_start = true` and restart — \
+                                             the VTA will clear this DID's queued messages over REST \
+                                             before going live."
+                                        );
                                     } else {
                                         let mut status = app_state.didcomm_websocket_status.write().await;
                                         *status = DidcommWebsocketStatus::Connected;
@@ -1980,6 +2024,78 @@ fn decode_jwt_key(b64: &str) -> Result<JwtKeys, AppError> {
     let keys = JwtKeys::from_ed25519_bytes(&key_bytes, "VTA")?;
     debug!("JWT signing key decoded successfully");
     Ok(keys)
+}
+
+/// Best-effort REST drain of this DID's mediator inbox, run at startup when
+/// `messaging.drain_inbox_on_start` is set.
+///
+/// The mediator allows one live-delivery websocket per DID, so an
+/// undeliverable/poison message queued for this DID can stall the pickup
+/// handshake and wedge the (shared DIDComm + TSP) listener indefinitely. REST
+/// auth + message-pickup keep working even when the websocket stalls, so this
+/// fetches the queued messages over REST and deletes them, clearing the wedge
+/// before the live listener starts. Each cleared message is logged; a batch that
+/// can't be fetched is logged loudly and stops the drain (so it can't spin).
+/// Returns how many were cleared. Never panics — a failure just skips the drain.
+#[cfg(feature = "didcomm")]
+async fn drain_mediator_inbox(atm: &ATM, mediator_did: &str, vta_did: &str) -> usize {
+    // A mediator-connected profile for REST pickup — added without live delivery
+    // (`false`), so this never opens the websocket that's the thing wedging.
+    let profile = match affinidi_tdk::messaging::profiles::ATMProfile::new(
+        atm,
+        Some("VTA-drain".to_string()),
+        vta_did.to_string(),
+        Some(mediator_did.to_string()),
+    )
+    .await
+    {
+        Ok(p) => match atm.profile_add(&p, false).await {
+            Ok(arc) => arc,
+            Err(e) => {
+                warn!(error = %e, "drain: could not register mediator profile; skipping drain");
+                return 0;
+            }
+        },
+        Err(e) => {
+            warn!(error = %e, "drain: could not build mediator profile; skipping drain");
+            return 0;
+        }
+    };
+
+    let mut cleared = 0usize;
+    // Bounded so a mediator that keeps re-queuing can never spin forever.
+    for _round in 0..200 {
+        let batch = match atm
+            .message_pickup()
+            .send_delivery_request(&profile, Some(20), true)
+            .await
+        {
+            Ok(b) => b,
+            Err(e) => {
+                warn!(error = %e, cleared, "drain: delivery-request failed; stopping — a queued message may be un-fetchable, inspect the mediator");
+                break;
+            }
+        };
+        if batch.is_empty() {
+            break;
+        }
+        let ids: Vec<String> = batch.iter().map(|(msg, _meta)| msg.id.clone()).collect();
+        for (msg, _meta) in &batch {
+            warn!(id = %msg.id, msg_type = %msg.typ, "drain: clearing queued mediator message");
+        }
+        match atm
+            .message_pickup()
+            .send_messages_received(&profile, &ids, true)
+            .await
+        {
+            Ok(_) => cleared += ids.len(),
+            Err(e) => {
+                warn!(error = %e, cleared, "drain: delete failed; stopping to avoid a loop");
+                break;
+            }
+        }
+    }
+    cleared
 }
 
 /// Spawn a background task that logs DIDComm listener lifecycle events.

--- a/vta-service/src/setup/from_toml.rs
+++ b/vta-service/src/setup/from_toml.rs
@@ -643,6 +643,7 @@ pub async fn apply_inputs(
             mediator_did: did.clone(),
             mediator_host: mediator_host.clone(),
             setup_acl: *setup_acl,
+            drain_inbox_on_start: false,
         }),
         MessagingInput::CreateMediator {
             context,
@@ -714,6 +715,7 @@ pub async fn apply_inputs(
                 mediator_did,
                 mediator_host: mediator_host.clone(),
                 setup_acl: *setup_acl,
+                drain_inbox_on_start: false,
             })
         }
     };
@@ -2004,6 +2006,7 @@ mod tests {
             mediator_did: did,
             mediator_host,
             setup_acl,
+            drain_inbox_on_start: false,
         };
         assert!(
             cfg.setup_acl,

--- a/vta-service/src/trust_tasks/policy_gate.rs
+++ b/vta-service/src/trust_tasks/policy_gate.rs
@@ -919,6 +919,7 @@ mod tests {
                 mediator_did: MEDIATOR.into(),
                 mediator_host: None,
                 setup_acl: false,
+                drain_inbox_on_start: false,
             });
         }
         crate::policy::storage::store_policy(

--- a/vta-service/tests/api_integration.rs
+++ b/vta-service/tests/api_integration.rs
@@ -378,6 +378,7 @@ async fn didcomm_status_returns_mediator_and_websocket_state_when_enabled() {
             mediator_did: "did:peer:2.med".into(),
             mediator_host: None,
             setup_acl: false,
+            drain_inbox_on_start: false,
         });
     }
     let token = ctx.auth_token("did:key:z6MkTest", "admin", vec![]).await;
@@ -3193,6 +3194,7 @@ async fn enable_didcomm_already_enabled_returns_409_with_suggested_fix() {
             mediator_did: "did:peer:2.med".into(),
             mediator_host: None,
             setup_acl: false,
+            drain_inbox_on_start: false,
         });
     }
     let (status, body) = app

--- a/vti-common/src/config.rs
+++ b/vti-common/src/config.rs
@@ -84,6 +84,22 @@ pub struct MessagingConfig {
     /// Set `setup_acl = true` during setup to enable. Defaults to `false`.
     #[serde(default)]
     pub setup_acl: bool,
+    /// Drain this DID's mediator inbox over REST at startup, *before* the live
+    /// DIDComm/TSP listener enables live delivery.
+    ///
+    /// Recovery lever for a wedged listener: the mediator enforces one live
+    /// websocket stream per DID, and an undeliverable/poison message queued for
+    /// this DID can stall the live-delivery handshake so the listener never comes
+    /// up (taking DIDComm *and* TSP down, since they share the socket). Because
+    /// REST auth + pickup work even when the websocket stalls, the VTA can fetch
+    /// and clear its own queued messages first: each is best-effort processed,
+    /// and anything that fails to unpack/handle is logged loudly and deleted so
+    /// it can't wedge startup again.
+    ///
+    /// **Default off** — it deletes queued messages that can't be handled, so it
+    /// is opt-in. Turn it on when a mediator-side backlog is blocking boot.
+    #[serde(default)]
+    pub drain_inbox_on_start: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
## Recover the VTA from a wedged mediator listener

Diagnosed from a real incident: the VTA's DIDComm listener authenticated and the websocket connected, then hung forever enabling **live-delivery** (message-pickup), so the listener never came up — and since one listener carries **both DIDComm and TSP**, both inbound paths were down while REST stayed healthy.

Root of the wedge: the mediator enforces **one live-delivery websocket per DID**. An undeliverable/poison message queued for the VTA's DID, or an **active websocket left by a prior process that wasn't cleanly stopped**, starves the new live-delivery handshake. It survives VTA restarts, mediator restarts, and version bumps, and previously required `RUST_LOG` debug just to see *where* it was stuck.

### Changes

**1. Actionable startup logging (no debug mode needed).** The `not connected after 30s` warning now says, at default level: auth + websocket most likely connected but live-delivery didn't complete; this one listener carries **DIDComm and TSP**; the two usual causes (a lingering active websocket for this DID, or a queued poison message); that the VTA keeps serving REST and retries; and how to recover.

**2. Opt-in `messaging.drain_inbox_on_start` (default `false`).** The key realisation from the trace: **REST auth + message-pickup keep working even when the websocket stalls.** So when the flag is set, the VTA drains its *own* mediator inbox over REST **before** enabling the live listener:
- authenticates a REST-only pickup profile (never opens the wedging websocket),
- `send_delivery_request` in bounded batches → deletes each via `send_messages_received`, logging every cleared message,
- loudly logs and stops if a batch can't be fetched (a genuinely un-fetchable message), so it can never spin,
- bounded rounds so a re-queuing mediator can't loop forever.

Off by default because it deletes queued messages; you turn it on to recover a stuck boot **without touching the mediator** (which is exactly the ask — no more Redis surgery to unwedge a VTA).

### Also worth knowing (not in this PR)
The mediator gates on *active websockets*, not stored sessions — so a clean stop (SIGTERM → graceful ws close) avoids leaving a zombie that starves the next boot; a hard `kill -9` doesn't. Ensuring graceful shutdown is the complementary operational fix; the drain handles the queued-message case.

### Verification
`cargo build` + CI-style `clippy -D warnings` clean; tests compile. The drain uses the messaging SDK's REST message-pickup accessors (`atm.message_pickup().send_delivery_request` / `send_messages_received`). **The mediator round-trip is validated live** — it's off by default so it can't affect normal boot until an operator opts in.
