### PR TITLE
feat(vti-common): VtiOutboxStore — durable OutboxStore for the delivery layer (D2/P0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,6 +290,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "affinidi-messaging-core"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7cdce5ec80c3d3826420a787f2a325c60864888ed0b33b128766699adfba40"
+dependencies = [
+ "async-trait",
+ "futures-util",
+ "serde",
+ "thiserror 2.0.18",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "affinidi-messaging-delivery"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34313da7d531d72a6ef239b215b392ae5bd9810d651c452e75b5433ca54e8e90"
+dependencies = [
+ "affinidi-messaging-core",
+ "async-trait",
+ "futures-util",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "affinidi-messaging-didcomm"
 version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10350,10 +10380,11 @@ dependencies = [
 
 [[package]]
 name = "vti-common"
-version = "0.11.5"
+version = "0.11.6"
 dependencies = [
  "aes-gcm",
  "affinidi-did-resolver-cache-sdk",
+ "affinidi-messaging-delivery",
  "affinidi-tdk",
  "async-trait",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,10 @@ affinidi-openid4vp = "0.1.2"
 affinidi-openid4vci = "0.2"
 affinidi-secrets-resolver = "0.5"
 affinidi-messaging-didcomm-service = "0.3"
+# Reliable messaging delivery layer (durable outbox + drain + §5a confirmation)
+# over the MessageTransport contract — the D1 delivery layer the VTI cut-over
+# (D2) wires in. `VtiOutboxStore` (vti-common) backs its OutboxStore with fjall.
+affinidi-messaging-delivery = "0.1"
 
 # Decentralized Trust Graph Credentials
 dtg-credentials = "0.1.3"

--- a/vti-common/Cargo.toml
+++ b/vti-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-common"
 description = "Shared server-side infrastructure for VTA and VTC services"
 readme = "README.md"
-version = "0.11.5"
+version = "0.11.6"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -50,6 +50,9 @@ openapi = ["dep:utoipa", "dep:utoipa-axum"]
 # definitions in the default feature set.
 vta-sdk = { path = "../vta-sdk", version = "0.19", default-features = false }
 async-trait = "0.1"
+# Durable OutboxStore backend (`outbox_store::VtiOutboxStore`) for the D1
+# delivery layer — the Guaranteed-send outbox, persisted via `store::Store`.
+affinidi-messaging-delivery = { workspace = true }
 axum = { workspace = true }
 axum-extra = { workspace = true }
 chrono = { workspace = true }

--- a/vti-common/src/lib.rs
+++ b/vti-common/src/lib.rs
@@ -8,6 +8,7 @@ pub mod error;
 pub mod idempotency;
 pub mod identifier;
 pub mod integrity;
+pub mod outbox_store;
 pub mod pagination;
 pub mod secure_file;
 pub mod seed_store;

--- a/vti-common/src/outbox_store.rs
+++ b/vti-common/src/outbox_store.rs
@@ -1,0 +1,253 @@
+//! Durable [`OutboxStore`] for the D1 delivery layer, backed by the workspace
+//! [`Store`](crate::store::Store) (local fjall or vsock-proxied).
+//!
+//! The delivery layer's `Guaranteed` sends are written to a durable outbox so a
+//! process restart does not lose delivery-critical work (the layer's
+//! `InMemoryOutboxStore` is dev-only). A service backs the outbox with one
+//! keyspace via [`VtiOutboxStore::new`] and drives it with the delivery layer's
+//! `drain_loop` / `confirmation_loop`.
+//!
+//! Schema (matches the workspace keyspace pattern, cf.
+//! `vta-service::messaging::drain_store`):
+//! - Key:   `outbox:{idempotency_key}`
+//! - Value: JSON-serialized delivery [`OutboxEntry`]
+//!
+//! The scanning reads ([`OutboxStore::due`], [`OutboxStore::awaiting_confirmation`])
+//! prefix-scan the keyspace and filter in memory, replicating the semantics of
+//! the reference `InMemoryOutboxStore` — including the per-`ordering_key` FIFO
+//! head gate in `due`.
+
+use std::collections::HashMap;
+
+use affinidi_messaging_delivery::{OutboxEntry, OutboxError, OutboxState, OutboxStore};
+use async_trait::async_trait;
+
+use crate::error::AppError;
+use crate::store::KeyspaceHandle;
+
+const PREFIX: &str = "outbox:";
+
+fn outbox_key(idempotency_key: &str) -> String {
+    format!("{PREFIX}{idempotency_key}")
+}
+
+/// Map a store-backend [`AppError`] to the delivery layer's [`OutboxError`].
+fn backend(e: AppError) -> OutboxError {
+    OutboxError::Backend(e.to_string())
+}
+
+/// A durable [`OutboxStore`] over one [`KeyspaceHandle`].
+///
+/// Cheap to clone-by-`Arc`: the handle is a shared reference to the keyspace,
+/// so a service can hand the same store to the drain, confirmation, and send
+/// paths.
+pub struct VtiOutboxStore {
+    ks: KeyspaceHandle,
+}
+
+impl VtiOutboxStore {
+    /// Back the outbox with `ks` (one keyspace per service, e.g. `"outbox"`).
+    pub fn new(ks: KeyspaceHandle) -> Self {
+        Self { ks }
+    }
+
+    /// Every persisted entry, decoded — the basis for the scanning reads.
+    async fn all(&self) -> Result<Vec<OutboxEntry>, OutboxError> {
+        let raw = self.ks.prefix_iter_raw(PREFIX).await.map_err(backend)?;
+        let mut out = Vec::with_capacity(raw.len());
+        for (_key, value) in raw {
+            let entry = serde_json::from_slice(&value)
+                .map_err(|e| OutboxError::Backend(format!("outbox decode: {e}")))?;
+            out.push(entry);
+        }
+        Ok(out)
+    }
+}
+
+#[async_trait]
+impl OutboxStore for VtiOutboxStore {
+    async fn put(&self, entry: OutboxEntry) -> Result<(), OutboxError> {
+        self.ks
+            .insert(outbox_key(&entry.idempotency_key), &entry)
+            .await
+            .map_err(backend)
+    }
+
+    async fn get(&self, idempotency_key: &str) -> Result<Option<OutboxEntry>, OutboxError> {
+        self.ks
+            .get(outbox_key(idempotency_key))
+            .await
+            .map_err(backend)
+    }
+
+    async fn due(&self, now_ms: u64) -> Result<Vec<OutboxEntry>, OutboxError> {
+        let entries = self.all().await?;
+
+        // Per ordering-key FIFO head: the earliest-enqueued NON-TERMINAL entry
+        // for each key gates the rest. Entries with no ordering key are
+        // independent. (Mirrors `InMemoryOutboxStore::due`.)
+        let mut head_created_at: HashMap<&str, u64> = HashMap::new();
+        for e in &entries {
+            if e.state.is_terminal() {
+                continue;
+            }
+            if let Some(key) = &e.ordering_key {
+                let head = head_created_at
+                    .entry(key.as_str())
+                    .or_insert(e.created_at_ms);
+                if e.created_at_ms < *head {
+                    *head = e.created_at_ms;
+                }
+            }
+        }
+
+        let mut due: Vec<OutboxEntry> = entries
+            .iter()
+            .filter(|e| e.state == OutboxState::Queued && e.next_attempt_at_ms <= now_ms)
+            .filter(|e| match &e.ordering_key {
+                // Only the FIFO head for this key is eligible.
+                Some(key) => head_created_at.get(key.as_str()) == Some(&e.created_at_ms),
+                None => true,
+            })
+            .cloned()
+            .collect();
+
+        // Oldest-first, tie-broken by key for determinism.
+        due.sort_by(|a, b| {
+            a.created_at_ms
+                .cmp(&b.created_at_ms)
+                .then_with(|| a.idempotency_key.cmp(&b.idempotency_key))
+        });
+        Ok(due)
+    }
+
+    async fn awaiting_confirmation(&self) -> Result<Vec<OutboxEntry>, OutboxError> {
+        Ok(self
+            .all()
+            .await?
+            .into_iter()
+            .filter(|e| e.state == OutboxState::Sent)
+            .collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::StoreConfig;
+    use crate::store::Store;
+    use tempfile::{TempDir, tempdir};
+
+    fn fresh() -> (TempDir, KeyspaceHandle) {
+        let dir = tempdir().unwrap();
+        let store = Store::open(&StoreConfig {
+            data_dir: dir.path().into(),
+        })
+        .unwrap();
+        let ks = store.keyspace("outbox").unwrap();
+        (dir, ks)
+    }
+
+    fn entry(key: &str, created: u64) -> OutboxEntry {
+        OutboxEntry::new(
+            key,
+            "did:example:bob",
+            vec![1, 2, 3],
+            created,
+            created + 60_000,
+        )
+    }
+
+    #[tokio::test]
+    async fn put_get_roundtrip() {
+        let (_dir, ks) = fresh();
+        let store = VtiOutboxStore::new(ks);
+        store.put(entry("k1", 1_000)).await.unwrap();
+
+        let got = store.get("k1").await.unwrap().unwrap();
+        assert_eq!(got.idempotency_key, "k1");
+        assert_eq!(got.dest_did, "did:example:bob");
+        assert_eq!(got.packed, vec![1, 2, 3]);
+        assert_eq!(got.state, OutboxState::Queued);
+        assert!(store.get("missing").await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn entries_survive_reopening_the_store() {
+        // The whole point of a durable outbox: a restart must not lose queued
+        // work. Write, drop the store, reopen the same data dir, read it back.
+        let dir = tempdir().unwrap();
+        let cfg = StoreConfig {
+            data_dir: dir.path().into(),
+        };
+        {
+            let store = VtiOutboxStore::new(Store::open(&cfg).unwrap().keyspace("outbox").unwrap());
+            store.put(entry("persisted", 1_000)).await.unwrap();
+        }
+        let reopened = VtiOutboxStore::new(Store::open(&cfg).unwrap().keyspace("outbox").unwrap());
+        assert_eq!(
+            reopened
+                .get("persisted")
+                .await
+                .unwrap()
+                .unwrap()
+                .idempotency_key,
+            "persisted"
+        );
+    }
+
+    #[tokio::test]
+    async fn due_returns_queued_eligible_entries_oldest_first() {
+        let (_dir, ks) = fresh();
+        let store = VtiOutboxStore::new(ks);
+        store.put(entry("b", 2_000)).await.unwrap();
+        store.put(entry("a", 1_000)).await.unwrap();
+        // A future-scheduled retry is not yet due.
+        let mut later = entry("c", 3_000);
+        later.next_attempt_at_ms = 10_000;
+        store.put(later).await.unwrap();
+
+        let due = store.due(5_000).await.unwrap();
+        let keys: Vec<_> = due.iter().map(|e| e.idempotency_key.as_str()).collect();
+        assert_eq!(keys, vec!["a", "b"]); // oldest-first, "c" not yet due
+    }
+
+    #[tokio::test]
+    async fn due_honors_per_ordering_key_fifo_head() {
+        let (_dir, ks) = fresh();
+        let store = VtiOutboxStore::new(ks);
+        // Two entries share an ordering key; only the earliest is eligible.
+        store
+            .put(entry("head", 1_000).with_ordering_key("ord"))
+            .await
+            .unwrap();
+        store
+            .put(entry("tail", 2_000).with_ordering_key("ord"))
+            .await
+            .unwrap();
+
+        let due = store.due(5_000).await.unwrap();
+        let keys: Vec<_> = due.iter().map(|e| e.idempotency_key.as_str()).collect();
+        assert_eq!(keys, vec!["head"]); // tail gated behind the FIFO head
+    }
+
+    #[tokio::test]
+    async fn awaiting_confirmation_returns_only_sent() {
+        let (_dir, ks) = fresh();
+        let store = VtiOutboxStore::new(ks);
+        store.put(entry("queued", 1_000)).await.unwrap();
+        let mut sent = entry("sent", 1_000);
+        sent.state = OutboxState::Sent;
+        store.put(sent).await.unwrap();
+        let mut delivered = entry("delivered", 1_000);
+        delivered.state = OutboxState::Delivered;
+        store.put(delivered).await.unwrap();
+
+        let awaiting = store.awaiting_confirmation().await.unwrap();
+        let keys: Vec<_> = awaiting
+            .iter()
+            .map(|e| e.idempotency_key.as_str())
+            .collect();
+        assert_eq!(keys, vec!["sent"]);
+    }
+}


### PR DESCRIPTION
## What

Foundation for the D1 Phase-3 cut-over (**D2**): wire the reliable-messaging
**delivery layer** (`affinidi-messaging-delivery`) into the workspace and add
**`VtiOutboxStore`** — a durable `OutboxStore` backed by the existing
`Store`/`KeyspaceHandle` (local fjall or vsock).

The delivery layer's `Guaranteed` sends must survive a process restart (the
layer's `InMemoryOutboxStore` is dev-only, loses queued work on crash), so the
VTI services back the outbox with this on-disk store. This is the durable backend
the design's decision #1 calls for ("VTI implements `OutboxStore` with fjall
(`vti_common::Store`)").

- **Schema** mirrors the existing `vta-service::messaging::drain_store` idiom:
  key `outbox:{idempotency_key}`, JSON value, prefix-scan for the reads.
- `due()` replicates `InMemoryOutboxStore`'s per-`ordering_key` FIFO head gate;
  `awaiting_confirmation()` returns the `Sent` entries the confirmation sweep
  checks.

## Scope — foundation only, no behaviour change

**No SDK touch.** `VtiOutboxStore` needs only the delivery crate's `OutboxStore`
trait — not `-core` or the messaging SDK. Deliberately deferred to the
per-service cut-over (P1 onward):

- The **`affinidi-messaging-sdk` bump `0.18.47 → 0.18.55`** is *not* a no-op —
  0.18.52 made websocket send truthful (`Err` for a dropped frame), so it must be
  coupled with each service's send-path rewire so the new error is absorbed by
  the delivery layer's retry/outbox. (0.18.55 also carries the connect-deadlock
  fix.) Lands in **P1 (VTC)** first.
- `ReceiptPacker` (over `atm.pack_encrypted`) and the transport construction need
  a live `ATM` → also P1.

## Verification

- **5 tests** incl. **durability across store reopen** (write → drop → reopen the
  same data dir → entry survives — the whole point), `due` oldest-first +
  future-retry exclusion, `due` per-`ordering_key` FIFO head, and
  `awaiting_confirmation` `Sent`-only filtering.
- `cargo check`/`fmt` clean; version-bump guard green (`vti-common 0.11.6` — a
  patch bump, so no dependent re-pin under `major.minor` pinning). Additive.

Plan: `../design-docs/vti-phase3-cutover-plan.md` (P0b). Next: **P1 — VTC
pilot** (construct the transport + `MessagingService`, rewire `send_to_member`,
bump the SDK).