### PR TITLE
fix(vtc-service): set drain_inbox_on_start on the missed MessagingConfig initializers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10270,7 +10270,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-service"
-version = "0.11.5"
+version = "0.11.6"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.11.5"
+version = "0.11.6"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vtc-service/src/config.rs
+++ b/vtc-service/src/config.rs
@@ -926,6 +926,7 @@ impl AppConfig {
                     mediator_did: did,
                     mediator_host: None,
                     setup_acl: false,
+                    drain_inbox_on_start: false,
                 });
             }
             (Ok(url), Err(_)) => {
@@ -934,6 +935,7 @@ impl AppConfig {
                     mediator_did: String::new(),
                     mediator_host: None,
                     setup_acl: false,
+                    drain_inbox_on_start: false,
                 });
                 messaging.mediator_url = url;
             }
@@ -943,6 +945,7 @@ impl AppConfig {
                     mediator_did: String::new(),
                     mediator_host: None,
                     setup_acl: false,
+                    drain_inbox_on_start: false,
                 });
                 messaging.mediator_did = did;
             }

--- a/vtc-service/src/setup/wizard.rs
+++ b/vtc-service/src/setup/wizard.rs
@@ -558,6 +558,7 @@ fn prompt_messaging(vta_mediator: Option<String>) -> Result<Option<MessagingConf
         mediator_did,
         mediator_host: None,
         setup_acl: false,
+        drain_inbox_on_start: false,
     }))
 }
 

--- a/vtc-service/src/test_support.rs
+++ b/vtc-service/src/test_support.rs
@@ -256,6 +256,7 @@ impl TestVtcBuilder {
                 mediator_did: mediator_did.clone(),
                 mediator_host: None,
                 setup_acl: false,
+                drain_inbox_on_start: false,
             });
         }
 


### PR DESCRIPTION
## What

**Unblocks `main`.** #674 (`recover from a wedged mediator listener`) added the
`drain_inbox_on_start` field to `MessagingConfig` and updated the **vta-service**
struct-literal initializers, but **missed all five `vtc-service` ones** — so
`vtc-service` no longer compiles (`E0063: missing field drain_inbox_on_start`) and
`main` is red (#674's own merge CI is `failure`; every PR since inherits it).

Add `drain_inbox_on_start: false` at each missed site:
- `config.rs:924/932/941` — the three `VTC_MESSAGING_*` env-override initializers
- `test_support.rs:254` — the test `AppState` builder
- `setup/wizard.rs:556` — the interactive setup wizard

`false` matches what #674 set at **every** vta-service initializer and the field's
own `#[serde(default)]`, so VTC's behaviour is unchanged (it had no drain-on-start
before). Pure merge-miss fix — no behaviour change.

## Verification

`cargo check -p vtc-service --all-targets --all-features` compiles clean; `fmt`
clean; version-bump guard green (`vtc-service 0.11.6`).