### PR TITLE
chore(deps): bump affinidi-messaging-sdk to 0.18.56 (+ affinidi-crypto 0.2.5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,9 +102,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-crypto"
-version = "0.2.2"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213efdc9d9a0851b2c5d8f9e28d5bfbea3d5109d3fd8e7e7c112b335eb423abb"
+checksum = "39e7ea1c5a572bab1a8af43b517e4a7674d57c061dd75e61799ec9fc9f356b4e"
 dependencies = [
  "aes 0.8.4",
  "affinidi-encoding",
@@ -478,15 +478,16 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-sdk"
-version = "0.18.47"
+version = "0.18.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cac096a2ce0775d8f5858bc9c0b94d0a30a5dc9e6a4bf0310488d319209639b4"
+checksum = "4f46fbfc0492e04bc651f9f27ef34e303e8e928688a3da79b3033c8960069020"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-authentication",
  "affinidi-did-common",
  "affinidi-did-resolver-cache-sdk",
  "affinidi-encoding",
+ "affinidi-messaging-core",
  "affinidi-messaging-didcomm",
  "affinidi-messaging-mediator-common",
  "affinidi-secrets-resolver",
@@ -2983,7 +2984,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 2.0.118",
+ "syn 1.0.109",
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Coordinated `affinidi-*` bump the D2 cut-over needs, isolated from the VTC code
change so its workspace-wide ripple is reviewed on its own.

- **`affinidi-messaging-sdk 0.18.47 → 0.18.56`** — provides `DidCommTransport`
  (0.18.53), `outbox_message_ids` (0.18.54), the connect-deadlock fix (0.18.55),
  and a cryptographically-authenticated inbound sender (0.18.56).
- **`affinidi-crypto 0.2.2 → 0.2.5`** — required in lockstep: sdk 0.18.49+ calls
  `affinidi_crypto::KeyType::key_agreement_curve`, absent in 0.2.2, so without
  this the sdk itself fails to compile (`E0599`).

Lock-only change. `cargo check --workspace --locked` is green.

## Behaviour change it carries (R1.1)

Since **sdk 0.18.52 the websocket send is truthful** — a frame dropped during a
reconnect returns `Err` instead of a false `Ok(EmptyResponse)`. This reaches
`vta-service` (the `DIDCommBridge` send path) and `vtc-service` today. Callers
already return the `Result`, so a previously-silent dropped send now surfaces as
an honest error rather than a false "delivered". The delivery-layer outbox
absorbs this for `Guaranteed` sends in the per-service cut-over (P1a onward) —
this PR just stops the lie.

The 0.18.56 authenticated-sender change only affects `DidCommTransport::to_inbound`,
which nothing consumes yet (lands with P1a), so it's inert here.

## Why separate from P1a

The truthful-send ripple touches `vta-service`, not just the VTC — a distinct
blast radius from "the VTC adopts `MessagingService`". Keeping them apart makes
each reviewable and lets CI validate the dependency upgrade on its own.

Prerequisite for **P1a** (the VTC pilot). Plan: `../design-docs/vti-phase3-cutover-plan.md`.