### PR TITLE
feat(vtc-service): durable Guaranteed credential delivery over the outbox (D2/P1b)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10301,7 +10301,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-service"
-version = "0.11.7"
+version = "0.11.8"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.11.7"
+version = "0.11.8"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vtc-service/src/messaging.rs
+++ b/vtc-service/src/messaging.rs
@@ -205,7 +205,25 @@ async fn build_messaging(
     );
     let outbox: Arc<dyn OutboxStore> = Arc::new(VtiOutboxStore::new(outbox_ks));
     // P1a uses `new` (not `with_receipts`) — no layer-receipt emission yet.
-    let service = Arc::new(MessagingService::new(transport, outbox));
+    // Clone transport + outbox before `new` consumes them: the background
+    // loops need their own handles.
+    let service = Arc::new(MessagingService::new(transport.clone(), outbox.clone()));
+    // Durable outbox: drain sends due entries + retries; outbox-drain confirms
+    // Delivered on recipient pickup; confirmation sweep settles expired entries.
+    tokio::spawn(affinidi_messaging_delivery::drain_loop(
+        outbox.clone(),
+        transport.clone(),
+        std::time::Duration::from_secs(2),
+    ));
+    tokio::spawn(affinidi_messaging_delivery::outbox_drain_loop(
+        transport.clone(),
+        outbox.clone(),
+        std::time::Duration::from_secs(10),
+    ));
+    tokio::spawn(affinidi_messaging_delivery::confirmation_loop(
+        outbox.clone(),
+        std::time::Duration::from_secs(30),
+    ));
     Ok((service, atm))
 }
 
@@ -1029,7 +1047,7 @@ async fn credential_present_handler(msg: &Message, state: &AppState) -> Option<R
         {
             warn!(holder = %holder_did, request = %outcome.request.id, error = %e, "membership-credential delivery failed; credential is issued and can be re-delivered");
         } else {
-            info!(holder = %holder_did, request = %outcome.request.id, "delivered membership credentials to holder over DIDComm");
+            info!(holder = %holder_did, request = %outcome.request.id, "queued membership credentials for guaranteed delivery to holder");
         }
     }
 

--- a/vtc-service/src/routes/join_requests/present.rs
+++ b/vtc-service/src/routes/join_requests/present.rs
@@ -182,9 +182,12 @@ pub struct SendQueryResponse {
     /// The `credential-exchange/query` body to deliver to the holder.
     #[schema(value_type = Object)]
     pub query: QueryBody,
-    /// Whether the VTC pushed the query to the holder over DIDComm. `false` when
-    /// no mediator is configured or the push failed — the caller can still relay
-    /// the returned [`query`](Self::query) out-of-band (relayer ≠ holder).
+    /// Whether the VTC **accepted the query for guaranteed delivery** (durably
+    /// queued to the outbox; the drain loop sends + retries it) — not a
+    /// confirmation that it has been received. `false` when no mediator is
+    /// configured or the enqueue failed — the caller can still relay the returned
+    /// [`query`](Self::query) out-of-band (relayer ≠ holder). The wire field name
+    /// stays `delivered` (camelCase, `deny_unknown_fields`) for API stability.
     pub delivered: bool,
 }
 
@@ -221,7 +224,7 @@ pub async fn send_query(
     let delivered = match push_credential_query(&state, &body.holder_did, &thread_id, &query).await
     {
         Ok(()) => {
-            info!(holder = %body.holder_did, thread = %thread_id, "pushed credential query over DIDComm");
+            info!(holder = %body.holder_did, thread = %thread_id, "queued credential query for guaranteed delivery");
             true
         }
         Err(e) => {

--- a/vtc-service/src/server.rs
+++ b/vtc-service/src/server.rs
@@ -219,10 +219,13 @@ impl AppState {
     /// authcrypt and forwards through the VTC's mediator, exactly as the inbound
     /// reply path does), so outbound never opens a competing socket.
     ///
-    /// `Err` when the listener isn't running yet **or** the send fails — the
-    /// error is surfaced honestly (never swallowed), so a caller that must know
-    /// whether the frame reached the mediator can act on it. Packs authcrypt
-    /// with the VTC's keys and hands off to the delivery-layer
+    /// `Ok(())` once the message is **durably queued** for guaranteed delivery
+    /// (not yet sent) — the delivery-layer drain loop owns sending + retrying it
+    /// until it lands (up to `deliver_by`). `Err` only when the listener isn't
+    /// running yet **or** the enqueue itself fails — surfaced honestly (never
+    /// swallowed), so a caller that must know whether the frame was accepted for
+    /// delivery can act on it. Packs authcrypt with the VTC's keys and hands off
+    /// to the delivery-layer
     /// [`MessagingService`](affinidi_messaging_delivery::MessagingService) over
     /// the one shared mediator websocket.
     pub async fn send_to_member(
@@ -233,6 +236,8 @@ impl AppState {
         let messaging = self.didcomm.get().ok_or_else(|| {
             AppError::Internal("VTC messaging not running — cannot send to member".into())
         })?;
+        // Capture the id before packing — `pack_encrypted` borrows `message`.
+        let idempotency_key = message.id.clone();
         let (packed, _) = messaging
             .atm
             .pack_encrypted(
@@ -250,7 +255,11 @@ impl AppState {
             .send(
                 recipient_did,
                 packed.into_bytes(),
-                affinidi_messaging_delivery::Delivery::BestEffort,
+                affinidi_messaging_delivery::Delivery::Guaranteed {
+                    idempotency_key: Some(idempotency_key),
+                    ordering_key: None,
+                    deliver_by: std::time::Duration::from_secs(24 * 3600),
+                },
             )
             .await
             .map_err(|e| AppError::Internal(format!("DIDComm send to {recipient_did} failed: {e}")))


### PR DESCRIPTION
## What

Make delivery-critical credential sends **`Guaranteed`** (durable outbox +
retry) instead of BestEffort, and stop the F3 "delivered"-off-a-bare-`Ok` lies.
Second half of the VTC pilot (P1a shipped the transport swap).

- **`send_to_member` → `Guaranteed`**: enqueues to the durable outbox
  (`idempotency_key` = the DIDComm message id, 24h window) instead of a one-shot
  send. Returns `Ok` once **durably queued**; the drain loop owns sending +
  retry — so a credential survives a mediator reconnect or a VTC restart rather
  than being silently dropped. Inbound replies stay `BestEffort` (the requester
  retries).
- **`build_messaging` spawns the outbox loops**: `drain_loop` (2s — send due +
  retry), `outbox_drain_loop` (10s — confirm `Delivered` on recipient pickup,
  §5a), `confirmation_loop` (30s — settle expired). The outbox-drain
  `hop_id == outbox msg_id` correlation was re-verified to **hold under the
  forward-delivery fix** (the mediator keys the sender's outbox on `sha256` of
  the inner attachment = the packed bytes).
- **F3 delivery-lies deleted**: "delivered membership credentials over DIDComm"
  and "pushed credential query over DIDComm" now say "queued for guaranteed
  delivery" — the truth, since delivery is async via the drain. The present
  response's `delivered` wire field is kept (API-compat) but re-documented as
  "accepted for guaranteed delivery (durably queued)", not confirmed delivered.

## Behaviour change

Credential delivery is now **async** — a credential arrives ~one drain tick
(≤2s) after enqueue, not synchronously. The `join_didcomm` VMC-delivery round
trip passes end-to-end through the outbox+drain (its 20s receive window
accommodates the tick).

## Scope

**No layer-receipts** (`with_receipts`) — deferred to P2. For VTC→holder, the
holder is a third-party wallet doing standard pickup, so its confirmation is
**outbox-drain**, not a layer receipt; receipts belong with VTA↔VTC peer
traffic. (A latent `payload` mismatch between the receipt recognizer and
`to_inbound` also needs resolving there.)

## Verification

`join_didcomm` 3/3 pass (incl. the async credential delivery); `cargo check
--all-targets` / `clippy` / `fmt` clean; version guard green (`vtc-service
0.11.8`, lock updated). Full vtc-service suite running in CI.

Downstream of #678 (P1a) + #621 (forward fix). Plan:
`../design-docs/vti-phase3-cutover-plan.md` (P1b). Next: P2 (VTA bridge).