### PR TITLE
feat: membership lifecycle hooks — capability grant relay (vti-common + vtc-service)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 ## Unreleased
 
+### vti-common 0.11.7 — `capability_client`: shared capability Trust Task primitives
+
+* New `capability_client` module: transport-free document builders, `eddsa-jcs-2022`
+  Data-Integrity signing (canonical form matching the trust registry's verifier),
+  DIDComm envelope parsing, and reply classification for the capability Trust Task
+  families (`governance/capability/*`, `git-trust/*`). `WriteOutcome::IdempotentSuccess`
+  classifies the registry's `already_granted`/`not_granted` answers as success, making
+  redelivered capability writes safe. First consumer: the vtc-service membership hooks;
+  the openvtc TUI's duplicate copy migrates in a follow-up.
+
+### vtc-service 0.11.9 — membership lifecycle hooks (capability grant relay)
+
+* New `hooks` module (`design-docs/vtc-membership-hooks.md`): membership audit events
+  (`MemberAdded`/`MemberRemoved`/`RoleChanged`) map through the operator's
+  `[hooks.git-trust] grant_on_role` configuration into `git-trust/grant|revoke`
+  capability writes, drained by `HookRelay` — a second audit-tail consumer with its own
+  cursor and queue, modeled on the `MembershipSyncer` so crash-replay is inherited.
+  Exactly-once-effective (idempotency root = the audit row key), FIFO-ordered including
+  within one event's revoke→grant pair, revocation retries indefinitely on transient
+  failures (delivery-critical), grants carry a bounded retry budget, and registry
+  rejections are terminal and loud. Absent `[hooks]` config, the relay is not spawned.
+  The production DIDComm `CapabilityWriter` plus server wiring land in the follow-up.
+
+
 ### vta-service — recover from a wedged mediator listener (drain-on-start + clearer logging)
 
 * The mediator enforces one live-delivery websocket per DID, and the VTA's single

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10386,6 +10386,7 @@ name = "vti-common"
 version = "0.11.6"
 dependencies = [
  "aes-gcm",
+ "affinidi-data-integrity",
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-delivery",
  "affinidi-tdk",
@@ -10415,6 +10416,7 @@ dependencies = [
  "tokio-vsock",
  "tower",
  "tracing",
+ "trust-tasks-rs",
  "url",
  "utoipa",
  "utoipa-axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10301,7 +10301,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-service"
-version = "0.11.8"
+version = "0.11.9"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",
@@ -10383,7 +10383,7 @@ dependencies = [
 
 [[package]]
 name = "vti-common"
-version = "0.11.6"
+version = "0.11.7"
 dependencies = [
  "aes-gcm",
  "affinidi-data-integrity",

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.11.8"
+version = "0.11.9"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vtc-service/src/hooks/mod.rs
+++ b/vtc-service/src/hooks/mod.rs
@@ -1,0 +1,518 @@
+//! Membership lifecycle hooks — capability grant propagation.
+//!
+//! Design: `design-docs/vtc-membership-hooks.md`. Membership changes emitted
+//! to the audit log (`MemberAdded` / `MemberRemoved` / `RoleChanged`) are
+//! mapped through the operator's hook configuration into capability writes —
+//! today, `git-trust/grant|revoke` Trust Tasks against the community's trust
+//! registry — and drained by a durable relay modeled on the registry
+//! [`MembershipSyncer`](crate::registry::syncer::MembershipSyncer): a second
+//! audit-tail consumer with its own cursor and fjall queue, so crash-replay
+//! is inherited rather than reimplemented.
+//!
+//! Semantics:
+//! - **Exactly-once-effective**: the job's idempotency root is the audit
+//!   row key (`<timestamp>:<event_id>`); redelivery is safe because the
+//!   registry answers `already_granted` / `not_granted`, which classify as
+//!   [`WriteOutcome::IdempotentSuccess`].
+//! - **Ordered**: queue keys are `<created_at>:<uuid>` and dispatch walks
+//!   them in order, preserving per-member revoke→grant ordering for role
+//!   changes.
+//! - **Revocation is delivery-critical (R7.2)**: revoke jobs never fail out
+//!   on transient/unreachable errors — they retry with capped backoff until
+//!   the registry answers. Grants exhaust a retry budget and surface as
+//!   `Failed`. Permanent rejections (e.g. the capability is disabled at the
+//!   registry) fail immediately and loudly for both.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use tokio::sync::watch;
+use tracing::{debug, info, warn};
+use uuid::Uuid;
+use vti_common::audit::{AuditEnvelope, AuditEvent};
+use vti_common::capability_client::WriteOutcome;
+use vti_common::error::AppError;
+use vti_common::store::KeyspaceHandle;
+
+/// Default drain tick.
+pub const DEFAULT_TICK_INTERVAL_SECONDS: u64 = 5;
+/// Backoff: `5s * 2^attempts`, capped at one hour (syncer parity).
+const BACKOFF_BASE_SECONDS: u64 = 5;
+const BACKOFF_CAP_SECONDS: u64 = 3600;
+/// Grants give up after this many attempts; revokes never give up on
+/// transient failures.
+const GRANT_MAX_ATTEMPTS: u32 = 20;
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+/// Operator hook configuration (`[hooks.git-trust]` in the service config).
+/// Absent config = no hooks — the relay is not even spawned (R5.1).
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct HooksConfig {
+    #[serde(default, rename = "git-trust")]
+    pub git_trust: Option<GitTrustHooksConfig>,
+}
+
+/// The git-trust mapping: which community roles produce which
+/// commit-signing grants.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct GitTrustHooksConfig {
+    /// role → the TRQP `resource` the grant covers (an org, or an
+    /// `org/repo` slug). Roles not listed produce no grant.
+    pub grant_on_role: BTreeMap<String, String>,
+    /// Revoke every mapped grant when membership ends. Default true.
+    #[serde(default = "default_true")]
+    pub revoke_with_membership: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+// ---------------------------------------------------------------------------
+// Job model
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HookOp {
+    Grant,
+    Revoke,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HookJobState {
+    Pending,
+    InFlight,
+    Failed,
+}
+
+/// One durable capability write derived from one audit event.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HookJob {
+    pub id: Uuid,
+    /// The audit row this job derives from (`<rfc3339>:<event_id>`) — the
+    /// idempotency root and replay guard.
+    pub audit_seq: String,
+    pub op: HookOp,
+    pub subject_did: String,
+    pub resource: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    /// Position within the source audit event's job batch. Part of the
+    /// queue key so revoke→grant pairs from one event keep their order
+    /// (they share `created_at`, and a UUID tiebreak would be random).
+    #[serde(default)]
+    pub order: u32,
+    pub created_at: DateTime<Utc>,
+    pub attempts: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_error: Option<String>,
+    pub next_attempt_at: DateTime<Utc>,
+    pub state: HookJobState,
+}
+
+impl HookJob {
+    fn new(
+        audit_seq: String,
+        op: HookOp,
+        subject_did: String,
+        resource: String,
+        reason: Option<String>,
+        created_at: DateTime<Utc>,
+    ) -> Self {
+        Self {
+            id: Uuid::new_v4(),
+            audit_seq,
+            op,
+            subject_did,
+            resource,
+            reason,
+            order: 0,
+            created_at,
+            attempts: 0,
+            last_error: None,
+            next_attempt_at: created_at,
+            state: HookJobState::Pending,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Audit → jobs mapping
+// ---------------------------------------------------------------------------
+
+/// Map one membership audit envelope to hook jobs under `config`.
+///
+/// - `MemberAdded{role}` → grant, when the role is mapped.
+/// - `RoleChanged{previous, new}` → revoke(previous) then grant(new), for
+///   whichever sides are mapped, skipping the no-op when both map to the
+///   same resource.
+/// - `MemberRemoved` → one revoke per **distinct** mapped resource, when
+///   `revoke_with_membership` (role history is not tracked, so every mapped
+///   resource is revoked — `not_granted` replies classify as idempotent
+///   success for the ones the member never held).
+pub fn jobs_for_event(config: &GitTrustHooksConfig, envelope: &AuditEnvelope) -> Vec<HookJob> {
+    let mut jobs = jobs_for_event_unordered(config, envelope);
+    for (i, job) in jobs.iter_mut().enumerate() {
+        job.order = i as u32;
+    }
+    jobs
+}
+
+fn jobs_for_event_unordered(
+    config: &GitTrustHooksConfig,
+    envelope: &AuditEnvelope,
+) -> Vec<HookJob> {
+    let Some(subject) = envelope.target_did_plain.clone() else {
+        return Vec::new();
+    };
+    let seq = format!("{}:{}", envelope.timestamp.to_rfc3339(), envelope.event_id);
+    let at = envelope.timestamp;
+    let job = |op, resource: &String, reason: Option<String>| {
+        HookJob::new(
+            seq.clone(),
+            op,
+            subject.clone(),
+            resource.clone(),
+            reason,
+            at,
+        )
+    };
+
+    match &envelope.event {
+        AuditEvent::MemberAdded(data) => config
+            .grant_on_role
+            .get(&data.role)
+            .map(|resource| vec![job(HookOp::Grant, resource, None)])
+            .unwrap_or_default(),
+        AuditEvent::RoleChanged(data) => {
+            let previous = config.grant_on_role.get(&data.previous_role);
+            let new = config.grant_on_role.get(&data.new_role);
+            match (previous, new) {
+                (Some(p), Some(n)) if p == n => Vec::new(),
+                (previous, new) => {
+                    let mut jobs = Vec::new();
+                    if let Some(p) = previous {
+                        jobs.push(job(
+                            HookOp::Revoke,
+                            p,
+                            Some(format!("role changed to {}", data.new_role)),
+                        ));
+                    }
+                    if let Some(n) = new {
+                        jobs.push(job(HookOp::Grant, n, None));
+                    }
+                    jobs
+                }
+            }
+        }
+        AuditEvent::MemberRemoved(_) => {
+            if !config.revoke_with_membership {
+                return Vec::new();
+            }
+            let mut resources: Vec<&String> = config.grant_on_role.values().collect();
+            resources.sort();
+            resources.dedup();
+            resources
+                .into_iter()
+                .map(|r| job(HookOp::Revoke, r, Some("membership ended".to_string())))
+                .collect()
+        }
+        _ => Vec::new(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Storage (hooks_queue + hooks_cursor keyspaces)
+// ---------------------------------------------------------------------------
+
+const CURSOR_KEY: &[u8] = b"hooks_cursor";
+
+/// Queue key: `<created_at rfc3339>:<order>:<uuid>` — chronological
+/// iteration preserves enqueue order, with `order` breaking the tie between
+/// jobs born from the same audit event (same timestamp).
+fn job_key(job: &HookJob) -> String {
+    format!(
+        "{}:{:03}:{}",
+        job.created_at.to_rfc3339(),
+        job.order,
+        job.id
+    )
+}
+
+pub async fn store_job(ks: &KeyspaceHandle, job: &HookJob) -> Result<(), AppError> {
+    ks.insert(job_key(job), job).await
+}
+
+pub async fn delete_job(ks: &KeyspaceHandle, job: &HookJob) -> Result<(), AppError> {
+    ks.remove(job_key(job).into_bytes()).await
+}
+
+/// All jobs, in queue-key (chronological) order.
+pub async fn list_jobs(ks: &KeyspaceHandle) -> Result<Vec<HookJob>, AppError> {
+    let pairs = ks.prefix_iter_raw(Vec::new()).await?;
+    let mut out = Vec::with_capacity(pairs.len());
+    for (_k, v) in pairs {
+        match serde_json::from_slice::<HookJob>(&v) {
+            Ok(job) => out.push(job),
+            Err(err) => warn!(error = %err, "skipping unparseable hook job row"),
+        }
+    }
+    Ok(out)
+}
+
+pub async fn get_cursor(ks: &KeyspaceHandle) -> Result<Option<DateTime<Utc>>, AppError> {
+    let Some(bytes) = ks.get_raw(CURSOR_KEY.to_vec()).await? else {
+        return Ok(None);
+    };
+    let s = std::str::from_utf8(&bytes)
+        .map_err(|e| AppError::Internal(format!("hooks_cursor not utf-8: {e}")))?;
+    Ok(Some(
+        DateTime::parse_from_rfc3339(s)
+            .map_err(|e| AppError::Internal(format!("hooks_cursor not rfc3339: {e}")))?
+            .with_timezone(&Utc),
+    ))
+}
+
+pub async fn set_cursor(ks: &KeyspaceHandle, ts: DateTime<Utc>) -> Result<(), AppError> {
+    ks.insert_raw(CURSOR_KEY.to_vec(), ts.to_rfc3339().into_bytes())
+        .await
+}
+
+// ---------------------------------------------------------------------------
+// The writer seam
+// ---------------------------------------------------------------------------
+
+/// Transport failures a capability write can hit before the registry answers.
+/// A registry *answer* — including a rejection — is a [`WriteOutcome`], not
+/// an error.
+#[derive(Debug, Clone, PartialEq)]
+pub enum HookWriteError {
+    /// The write may succeed if retried (send failed, reply window elapsed).
+    Transient(String),
+    /// The registry could not be reached at all.
+    Unreachable(String),
+}
+
+impl std::fmt::Display for HookWriteError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Transient(e) => write!(f, "transient: {e}"),
+            Self::Unreachable(e) => write!(f, "unreachable: {e}"),
+        }
+    }
+}
+
+/// Performs one capability write for a job and returns the registry's
+/// classified answer. The production implementation signs a
+/// `git-trust/grant|revoke` document with the VTC authority key and sends it
+/// over the DIDComm trust-task envelope, correlating the reply by
+/// `threadId`; tests substitute a mock.
+#[async_trait]
+pub trait CapabilityWriter: Send + Sync {
+    async fn write(&self, job: &HookJob) -> Result<WriteOutcome, HookWriteError>;
+}
+
+// ---------------------------------------------------------------------------
+// The relay
+// ---------------------------------------------------------------------------
+
+/// The supervised drainer: tail-walks the audit log into the hooks queue and
+/// dispatches due jobs FIFO through the [`CapabilityWriter`].
+pub struct HookRelay {
+    audit_ks: KeyspaceHandle,
+    queue_ks: KeyspaceHandle,
+    cursor_ks: KeyspaceHandle,
+    config: GitTrustHooksConfig,
+    writer: Arc<dyn CapabilityWriter>,
+    tick_interval: Duration,
+}
+
+impl HookRelay {
+    pub fn new(
+        audit_ks: KeyspaceHandle,
+        queue_ks: KeyspaceHandle,
+        cursor_ks: KeyspaceHandle,
+        config: GitTrustHooksConfig,
+        writer: Arc<dyn CapabilityWriter>,
+    ) -> Self {
+        Self {
+            audit_ks,
+            queue_ks,
+            cursor_ks,
+            config,
+            writer,
+            tick_interval: Duration::from_secs(DEFAULT_TICK_INTERVAL_SECONDS),
+        }
+    }
+
+    pub fn with_tick_interval(mut self, interval: Duration) -> Self {
+        self.tick_interval = interval;
+        self
+    }
+
+    /// Run until `shutdown` flips true. Boot recovery flips `InFlight` rows
+    /// back to `Pending` (crash between dispatch and outcome), then every
+    /// tick tail-walks and dispatches.
+    pub async fn run(self, mut shutdown: watch::Receiver<bool>) {
+        info!(
+            tick_interval_secs = self.tick_interval.as_secs(),
+            "membership hook relay starting"
+        );
+        if let Err(e) = self.recover_in_flight().await {
+            warn!("hook relay boot recovery failed: {e}");
+        }
+        let mut tick = tokio::time::interval(self.tick_interval);
+        loop {
+            tokio::select! {
+                _ = tick.tick() => {
+                    if let Err(e) = self.walk_audit_tail().await {
+                        warn!("hook tail walk failed: {e}");
+                    }
+                    if let Err(e) = self.dispatch_due().await {
+                        warn!("hook dispatch failed: {e}");
+                    }
+                }
+                _ = shutdown.changed() => {
+                    if *shutdown.borrow() {
+                        info!("membership hook relay stopping");
+                        return;
+                    }
+                }
+            }
+        }
+    }
+
+    async fn recover_in_flight(&self) -> Result<(), AppError> {
+        for mut job in list_jobs(&self.queue_ks).await? {
+            if job.state == HookJobState::InFlight {
+                job.state = HookJobState::Pending;
+                store_job(&self.queue_ks, &job).await?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Walk audit envelopes newer than the cursor into hook jobs.
+    ///
+    /// v1 scans the audit keyspace and filters by timestamp (the seek
+    /// optimization the registry tail uses, P3.8, is a follow-up); rows are
+    /// already deduplicated by the cursor plus the per-row `audit_seq`.
+    async fn walk_audit_tail(&self) -> Result<(), AppError> {
+        let cursor = get_cursor(&self.cursor_ks).await?;
+        let pairs = self.audit_ks.prefix_iter_raw(Vec::new()).await?;
+        let mut newest = cursor;
+        for (_k, v) in pairs {
+            let Ok(envelope) = serde_json::from_slice::<AuditEnvelope>(&v) else {
+                continue;
+            };
+            if cursor.is_some_and(|c| envelope.timestamp <= c) {
+                continue;
+            }
+            for job in jobs_for_event(&self.config, &envelope) {
+                debug!(
+                    op = ?job.op,
+                    subject = %job.subject_did,
+                    resource = %job.resource,
+                    "hook job enqueued"
+                );
+                store_job(&self.queue_ks, &job).await?;
+            }
+            if newest.is_none_or(|n| envelope.timestamp > n) {
+                newest = Some(envelope.timestamp);
+            }
+        }
+        if let Some(ts) = newest
+            && Some(ts) != cursor
+        {
+            set_cursor(&self.cursor_ks, ts).await?;
+        }
+        Ok(())
+    }
+
+    /// Dispatch every due `Pending` job, in queue order.
+    async fn dispatch_due(&self) -> Result<(), AppError> {
+        let now = Utc::now();
+        for mut job in list_jobs(&self.queue_ks).await? {
+            if job.state != HookJobState::Pending || job.next_attempt_at > now {
+                continue;
+            }
+            job.state = HookJobState::InFlight;
+            store_job(&self.queue_ks, &job).await?;
+
+            match self.writer.write(&job).await {
+                Ok(WriteOutcome::Success) | Ok(WriteOutcome::IdempotentSuccess) => {
+                    delete_job(&self.queue_ks, &job).await?;
+                    info!(
+                        op = ?job.op,
+                        subject = %job.subject_did,
+                        resource = %job.resource,
+                        "hook write applied"
+                    );
+                }
+                Ok(WriteOutcome::Rejected { code, message }) => {
+                    // The registry answered no — retrying the same document
+                    // cannot help (R1.4). Loud, terminal.
+                    job.state = HookJobState::Failed;
+                    job.last_error = Some(format!("rejected: {code}{}", detail_suffix(&message)));
+                    store_job(&self.queue_ks, &job).await?;
+                    warn!(
+                        op = ?job.op,
+                        subject = %job.subject_did,
+                        resource = %job.resource,
+                        code = %code,
+                        "hook write rejected by the registry"
+                    );
+                }
+                Err(e) => {
+                    job.attempts += 1;
+                    job.last_error = Some(e.to_string());
+                    let give_up = job.op == HookOp::Grant && job.attempts >= GRANT_MAX_ATTEMPTS;
+                    if give_up {
+                        job.state = HookJobState::Failed;
+                        warn!(
+                            subject = %job.subject_did,
+                            resource = %job.resource,
+                            attempts = job.attempts,
+                            "hook grant exhausted its retry budget"
+                        );
+                    } else {
+                        // Revokes retry indefinitely (delivery-critical,
+                        // R7.2); grants retry within budget.
+                        job.state = HookJobState::Pending;
+                        job.next_attempt_at = now + backoff(job.attempts);
+                    }
+                    store_job(&self.queue_ks, &job).await?;
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+fn detail_suffix(message: &Option<String>) -> String {
+    message
+        .as_ref()
+        .map(|m| format!(" — {m}"))
+        .unwrap_or_default()
+}
+
+fn backoff(attempts: u32) -> chrono::Duration {
+    let secs = BACKOFF_BASE_SECONDS
+        .saturating_mul(2u64.saturating_pow(attempts.min(16)))
+        .min(BACKOFF_CAP_SECONDS);
+    chrono::Duration::seconds(secs as i64)
+}
+
+#[cfg(test)]
+mod tests;

--- a/vtc-service/src/hooks/tests.rs
+++ b/vtc-service/src/hooks/tests.rs
@@ -1,0 +1,305 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use super::*;
+use std::collections::VecDeque;
+use std::sync::Mutex;
+use vti_common::audit::{
+    AuditKeyStore, AuditWriter, MemberAddedData, MemberRemovedData, RoleChangedData,
+};
+use vti_common::config::StoreConfig;
+use vti_common::store::Store;
+
+const VTC: &str = "did:webvh:vtc.example";
+const ALICE: &str = "did:webvh:alice.example";
+
+struct TestKs {
+    audit: KeyspaceHandle,
+    queue: KeyspaceHandle,
+    cursor: KeyspaceHandle,
+    writer: AuditWriter,
+    _dir: tempfile::TempDir,
+}
+
+async fn temp_keyspaces() -> TestKs {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open(&StoreConfig {
+        data_dir: dir.path().to_path_buf(),
+    })
+    .expect("store");
+    let audit = store.keyspace("audit").unwrap();
+    let audit_key = store.keyspace("audit_key").unwrap();
+    let queue = store.keyspace("hooks_queue").unwrap();
+    let cursor = store.keyspace("hooks_cursor").unwrap();
+    let key_store = AuditKeyStore::new(audit_key);
+    key_store.ensure_initial(&[0xAB; 32]).await.unwrap();
+    let writer = AuditWriter::new(audit.clone(), key_store);
+    TestKs {
+        audit,
+        queue,
+        cursor,
+        writer,
+        _dir: dir,
+    }
+}
+
+fn config() -> GitTrustHooksConfig {
+    GitTrustHooksConfig {
+        grant_on_role: BTreeMap::from([
+            ("maintainer".to_string(), "openvtc".to_string()),
+            ("committer".to_string(), "openvtc/openvtc".to_string()),
+        ]),
+        revoke_with_membership: true,
+    }
+}
+
+/// Scripted mock: pops outcomes from a queue (default: Success) and records
+/// every job it was asked to write.
+#[derive(Default)]
+struct MockWriter {
+    outcomes: Mutex<VecDeque<Result<WriteOutcome, HookWriteError>>>,
+    written: Mutex<Vec<HookJob>>,
+}
+
+impl MockWriter {
+    fn script(&self, outcome: Result<WriteOutcome, HookWriteError>) {
+        self.outcomes.lock().unwrap().push_back(outcome);
+    }
+    fn written(&self) -> Vec<HookJob> {
+        self.written.lock().unwrap().clone()
+    }
+}
+
+#[async_trait]
+impl CapabilityWriter for MockWriter {
+    async fn write(&self, job: &HookJob) -> Result<WriteOutcome, HookWriteError> {
+        self.written.lock().unwrap().push(job.clone());
+        self.outcomes
+            .lock()
+            .unwrap()
+            .pop_front()
+            .unwrap_or(Ok(WriteOutcome::Success))
+    }
+}
+
+fn relay(ks: &TestKs, writer: Arc<MockWriter>) -> HookRelay {
+    HookRelay::new(
+        ks.audit.clone(),
+        ks.queue.clone(),
+        ks.cursor.clone(),
+        config(),
+        writer,
+    )
+}
+
+async fn add_member(ks: &TestKs, role: &str) {
+    ks.writer
+        .write(
+            VTC,
+            Some(ALICE),
+            AuditEvent::MemberAdded(MemberAddedData {
+                role: role.into(),
+                via_join_request_id: None,
+            }),
+        )
+        .await
+        .unwrap();
+}
+
+// --- mapping ------------------------------------------------------------------
+
+#[tokio::test]
+async fn member_added_grants_only_mapped_roles() {
+    let ks = temp_keyspaces().await;
+    add_member(&ks, "maintainer").await;
+    let writer = Arc::new(MockWriter::default());
+    let relay = relay(&ks, writer.clone());
+
+    relay.walk_audit_tail().await.unwrap();
+    let jobs = list_jobs(&ks.queue).await.unwrap();
+    assert_eq!(jobs.len(), 1);
+    assert_eq!(jobs[0].op, HookOp::Grant);
+    assert_eq!(jobs[0].subject_did, ALICE);
+    assert_eq!(jobs[0].resource, "openvtc");
+
+    // Unmapped role produces nothing.
+    let ks2 = temp_keyspaces().await;
+    add_member(&ks2, "member").await;
+    let relay2 = relay_for(&ks2);
+    relay2.walk_audit_tail().await.unwrap();
+    assert!(list_jobs(&ks2.queue).await.unwrap().is_empty());
+}
+
+fn relay_for(ks: &TestKs) -> HookRelay {
+    relay(ks, Arc::new(MockWriter::default()))
+}
+
+#[tokio::test]
+async fn role_change_enqueues_revoke_then_grant_in_order() {
+    let ks = temp_keyspaces().await;
+    ks.writer
+        .write(
+            VTC,
+            Some(ALICE),
+            AuditEvent::RoleChanged(RoleChangedData {
+                previous_role: "committer".into(),
+                new_role: "maintainer".into(),
+            }),
+        )
+        .await
+        .unwrap();
+    let relay = relay_for(&ks);
+    relay.walk_audit_tail().await.unwrap();
+
+    let jobs = list_jobs(&ks.queue).await.unwrap();
+    assert_eq!(jobs.len(), 2);
+    assert_eq!(jobs[0].op, HookOp::Revoke);
+    assert_eq!(jobs[0].resource, "openvtc/openvtc");
+    assert_eq!(jobs[1].op, HookOp::Grant);
+    assert_eq!(jobs[1].resource, "openvtc");
+}
+
+#[tokio::test]
+async fn member_removed_revokes_every_mapped_resource() {
+    let ks = temp_keyspaces().await;
+    ks.writer
+        .write(
+            VTC,
+            Some(ALICE),
+            AuditEvent::MemberRemoved(MemberRemovedData {
+                disposition: "tombstone".into(),
+                reason: String::new(),
+                prior_role: None,
+            }),
+        )
+        .await
+        .unwrap();
+    let relay = relay_for(&ks);
+    relay.walk_audit_tail().await.unwrap();
+
+    let jobs = list_jobs(&ks.queue).await.unwrap();
+    assert_eq!(jobs.len(), 2, "one revoke per distinct mapped resource");
+    assert!(jobs.iter().all(|j| j.op == HookOp::Revoke));
+}
+
+// --- relay semantics ----------------------------------------------------------
+
+#[tokio::test]
+async fn tail_walk_is_cursor_deduplicated_and_dispatch_drains() {
+    let ks = temp_keyspaces().await;
+    add_member(&ks, "maintainer").await;
+    let writer = Arc::new(MockWriter::default());
+    let relay = relay(&ks, writer.clone());
+
+    relay.walk_audit_tail().await.unwrap();
+    relay.walk_audit_tail().await.unwrap(); // second walk: cursor blocks re-enqueue
+    assert_eq!(list_jobs(&ks.queue).await.unwrap().len(), 1);
+
+    relay.dispatch_due().await.unwrap();
+    assert!(list_jobs(&ks.queue).await.unwrap().is_empty());
+    assert_eq!(writer.written().len(), 1);
+}
+
+#[tokio::test]
+async fn idempotent_success_completes_the_job() {
+    let ks = temp_keyspaces().await;
+    add_member(&ks, "maintainer").await;
+    let writer = Arc::new(MockWriter::default());
+    writer.script(Ok(WriteOutcome::IdempotentSuccess));
+    let relay = relay(&ks, writer.clone());
+
+    relay.walk_audit_tail().await.unwrap();
+    relay.dispatch_due().await.unwrap();
+    assert!(
+        list_jobs(&ks.queue).await.unwrap().is_empty(),
+        "already_granted/not_granted means the end state holds — job done"
+    );
+}
+
+#[tokio::test]
+async fn rejection_is_terminal_and_loud() {
+    let ks = temp_keyspaces().await;
+    add_member(&ks, "maintainer").await;
+    let writer = Arc::new(MockWriter::default());
+    writer.script(Ok(WriteOutcome::Rejected {
+        code: "unsupportedType".into(),
+        message: Some("git-trust is not enabled".into()),
+    }));
+    let relay = relay(&ks, writer.clone());
+
+    relay.walk_audit_tail().await.unwrap();
+    relay.dispatch_due().await.unwrap();
+
+    let jobs = list_jobs(&ks.queue).await.unwrap();
+    assert_eq!(jobs.len(), 1);
+    assert_eq!(jobs[0].state, HookJobState::Failed);
+    assert!(jobs[0].last_error.as_deref().unwrap().contains("rejected"));
+}
+
+#[tokio::test]
+async fn revokes_retry_past_the_grant_budget_grants_do_not() {
+    let ks = temp_keyspaces().await;
+
+    // A revoke that has already burned well past the grant budget…
+    let mut revoke = HookJob::new(
+        "seq-r".into(),
+        HookOp::Revoke,
+        ALICE.into(),
+        "openvtc".into(),
+        None,
+        Utc::now(),
+    );
+    revoke.attempts = GRANT_MAX_ATTEMPTS + 5;
+    store_job(&ks.queue, &revoke).await.unwrap();
+    // …and a grant exactly one attempt from its budget.
+    let mut grant = HookJob::new(
+        "seq-g".into(),
+        HookOp::Grant,
+        ALICE.into(),
+        "openvtc".into(),
+        None,
+        Utc::now(),
+    );
+    grant.attempts = GRANT_MAX_ATTEMPTS - 1;
+    store_job(&ks.queue, &grant).await.unwrap();
+
+    let writer = Arc::new(MockWriter::default());
+    writer.script(Err(HookWriteError::Unreachable("registry down".into())));
+    writer.script(Err(HookWriteError::Unreachable("registry down".into())));
+    let relay = relay(&ks, writer.clone());
+    relay.dispatch_due().await.unwrap();
+
+    let jobs = list_jobs(&ks.queue).await.unwrap();
+    let revoke_after = jobs.iter().find(|j| j.op == HookOp::Revoke).unwrap();
+    let grant_after = jobs.iter().find(|j| j.op == HookOp::Grant).unwrap();
+    assert_eq!(
+        revoke_after.state,
+        HookJobState::Pending,
+        "revocation is delivery-critical: it retries indefinitely"
+    );
+    assert!(revoke_after.next_attempt_at > Utc::now());
+    assert_eq!(
+        grant_after.state,
+        HookJobState::Failed,
+        "grants exhaust their retry budget"
+    );
+}
+
+#[tokio::test]
+async fn boot_recovery_flips_in_flight_back_to_pending() {
+    let ks = temp_keyspaces().await;
+    let mut job = HookJob::new(
+        "seq-x".into(),
+        HookOp::Grant,
+        ALICE.into(),
+        "openvtc".into(),
+        None,
+        Utc::now(),
+    );
+    job.state = HookJobState::InFlight;
+    store_job(&ks.queue, &job).await.unwrap();
+
+    let relay = relay_for(&ks);
+    relay.recover_in_flight().await.unwrap();
+    let jobs = list_jobs(&ks.queue).await.unwrap();
+    assert_eq!(jobs[0].state, HookJobState::Pending);
+}

--- a/vtc-service/src/lib.rs
+++ b/vtc-service/src/lib.rs
@@ -30,6 +30,7 @@ pub mod endorsement_types;
 pub mod endorsements;
 pub mod error;
 pub mod holder_signature;
+pub mod hooks;
 pub mod install;
 pub mod join;
 pub mod keys;

--- a/vti-common/Cargo.toml
+++ b/vti-common/Cargo.toml
@@ -78,6 +78,8 @@ bytes = "1"
 
 # Secrets resolver (for error type)
 affinidi-tdk = { workspace = true }
+affinidi-data-integrity = { workspace = true }
+trust-tasks-rs = { workspace = true }
 # DID resolution for SIOPv2 id_token verification (auth::siop). The
 # resolver + `DocumentExt` (from affinidi-tdk) turn an `iss` DID into the
 # Ed25519 verifying key. multibase decodes the `did:key` key for pinning.

--- a/vti-common/Cargo.toml
+++ b/vti-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-common"
 description = "Shared server-side infrastructure for VTA and VTC services"
 readme = "README.md"
-version = "0.11.6"
+version = "0.11.7"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vti-common/src/capability_client.rs
+++ b/vti-common/src/capability_client.rs
@@ -1,0 +1,263 @@
+//! Client-side primitives for capability Trust Tasks (`governance/capability/*`,
+//! `git-trust/*`): document building, Data-Integrity signing, DIDComm envelope
+//! parsing, and reply classification.
+//!
+//! Transport-free by design — each consumer (vtc-service hooks, the openvtc
+//! TUI) already owns its send plumbing; this module owns the wire *documents*
+//! so the two sides cannot drift. Writes carry an `eddsa-jcs-2022` proof
+//! signed by the caller's authority key, bound to the document `issuer` (the
+//! registry enforces the binding plus its admin ACL).
+
+use affinidi_data_integrity::{DataIntegrityProof, SignOptions};
+use affinidi_tdk::secrets_resolver::secrets::Secret;
+use serde_json::Value;
+use trust_tasks_rs::TrustTask;
+use uuid::Uuid;
+
+/// The `trust-tasks-didcomm` binding envelope type (what the registry's
+/// DIDComm Trust Task handler listens for). Kept in sync with
+/// `trust_tasks_didcomm::ENVELOPE_TYPE`.
+pub const TRUST_TASK_ENVELOPE_TYPE: &str = "https://trusttasks.org/binding/didcomm/0.1/envelope";
+
+/// `git-trust/*` type URIs.
+pub const GIT_TRUST_GRANT_TYPE: &str = "https://trusttasks.org/spec/git-trust/grant/0.1";
+pub const GIT_TRUST_REVOKE_TYPE: &str = "https://trusttasks.org/spec/git-trust/revoke/0.1";
+
+/// Errors from document construction/signing.
+#[derive(Debug, thiserror::Error)]
+pub enum CapabilityClientError {
+    #[error("capability document error: {0}")]
+    Document(String),
+    #[error("capability document signing failed: {0}")]
+    Signing(String),
+}
+
+/// Build a capability Trust Task addressed `issuer` → `recipient`.
+pub fn build_document(
+    issuer_did: &str,
+    recipient_did: &str,
+    type_uri: &str,
+    payload: Value,
+) -> Result<TrustTask<Value>, CapabilityClientError> {
+    let type_uri = type_uri
+        .parse()
+        .map_err(|e| CapabilityClientError::Document(format!("invalid type URI: {e}")))?;
+    let mut doc = TrustTask::new(format!("urn:uuid:{}", Uuid::new_v4()), type_uri, payload);
+    doc.issuer = Some(issuer_did.to_string());
+    doc.recipient = Some(recipient_did.to_string());
+    doc.issued_at = Some(chrono::Utc::now());
+    Ok(doc)
+}
+
+/// Build a `git-trust/grant` document: grant `subject` commit-signing trust
+/// for `resource` (an org or `org/repo` slug).
+pub fn build_git_trust_grant(
+    authority_did: &str,
+    registry_did: &str,
+    subject_did: &str,
+    resource: &str,
+) -> Result<TrustTask<Value>, CapabilityClientError> {
+    build_document(
+        authority_did,
+        registry_did,
+        GIT_TRUST_GRANT_TYPE,
+        serde_json::json!({ "subject": subject_did, "resource": resource }),
+    )
+}
+
+/// Build a `git-trust/revoke` document.
+pub fn build_git_trust_revoke(
+    authority_did: &str,
+    registry_did: &str,
+    subject_did: &str,
+    resource: &str,
+    reason: Option<&str>,
+) -> Result<TrustTask<Value>, CapabilityClientError> {
+    let mut payload = serde_json::json!({ "subject": subject_did, "resource": resource });
+    if let Some(reason) = reason {
+        payload["reason"] = serde_json::json!(reason);
+    }
+    build_document(authority_did, registry_did, GIT_TRUST_REVOKE_TYPE, payload)
+}
+
+/// Attach an `eddsa-jcs-2022` Data-Integrity proof over `doc` minus its
+/// `proof` member — the exact canonical form the registry's verifier checks.
+/// The secret's key id becomes the verification method and must belong to
+/// the document `issuer`.
+pub async fn sign_document(
+    doc: &mut TrustTask<Value>,
+    signing_secret: &Secret,
+) -> Result<(), CapabilityClientError> {
+    let mut doc_value = serde_json::to_value(&*doc)
+        .map_err(|e| CapabilityClientError::Document(format!("serialise document: {e}")))?;
+    if let Some(obj) = doc_value.as_object_mut() {
+        obj.remove("proof");
+    }
+    let proof = DataIntegrityProof::sign(&doc_value, signing_secret, SignOptions::default())
+        .await
+        .map_err(|e| CapabilityClientError::Signing(e.to_string()))?;
+    let proof_value = serde_json::to_value(&proof)
+        .map_err(|e| CapabilityClientError::Signing(format!("serialise proof: {e}")))?;
+    doc.proof = Some(
+        serde_json::from_value(proof_value)
+            .map_err(|e| CapabilityClientError::Signing(format!("convert proof: {e}")))?,
+    );
+    Ok(())
+}
+
+/// Parse a DIDComm envelope body into `(threadId, document)`. `None` when
+/// the body is not a threaded Trust Task document.
+pub fn parse_envelope_document(body: &Value) -> Option<(String, TrustTask<Value>)> {
+    let doc: TrustTask<Value> = serde_json::from_value(body.clone()).ok()?;
+    let thid = doc.thread_id.clone()?;
+    Some((thid, doc))
+}
+
+/// The hook-facing classification of a capability write reply.
+///
+/// `IdempotentSuccess` is the load-bearing variant: redelivered jobs make the
+/// registry answer `already_granted` (grant) or `not_granted` (revoke) — the
+/// desired end state already holds, so the job is done, not failed.
+#[derive(Debug, Clone, PartialEq)]
+pub enum WriteOutcome {
+    /// The `#response` document acknowledged the write.
+    Success,
+    /// The registry rejected the write because the end state already holds.
+    IdempotentSuccess,
+    /// Any other rejection: the machine-readable trust-task code plus the
+    /// human detail. Permanent from the hook's perspective.
+    Rejected {
+        code: String,
+        message: Option<String>,
+    },
+}
+
+/// Classify the reply to a `git-trust/grant` or `git-trust/revoke` write.
+/// `None` when `doc` is neither the matching `#response` nor an error doc —
+/// i.e. not a reply to this family at all.
+pub fn classify_git_trust_reply(doc: &TrustTask<Value>) -> Option<WriteOutcome> {
+    let slug = doc.type_uri.slug();
+    if slug == "trust-task-error" {
+        let code = doc
+            .payload
+            .get("code")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown")
+            .to_string();
+        let message = doc
+            .payload
+            .get("message")
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        // The registry encodes the idempotent cases as taskFailed with a
+        // documented `already_granted:` / `not_granted:` reason marker (the
+        // wire message arrives as "task failed: already_granted: …").
+        let reason = message.as_deref().unwrap_or("");
+        if code == "taskFailed"
+            && (reason.contains("already_granted:") || reason.contains("not_granted:"))
+        {
+            return Some(WriteOutcome::IdempotentSuccess);
+        }
+        return Some(WriteOutcome::Rejected { code, message });
+    }
+    if doc.type_uri.is_response() && matches!(slug, "git-trust/grant" | "git-trust/revoke") {
+        return Some(WriteOutcome::Success);
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+
+    use super::*;
+    use trust_tasks_rs::RejectReason;
+
+    #[test]
+    fn grant_and_revoke_documents_are_well_formed() {
+        let grant = build_git_trust_grant(
+            "did:example:authority",
+            "did:example:registry",
+            "did:example:signer",
+            "openvtc",
+        )
+        .unwrap();
+        assert_eq!(grant.issuer.as_deref(), Some("did:example:authority"));
+        assert_eq!(grant.recipient.as_deref(), Some("did:example:registry"));
+        assert_eq!(grant.type_uri.slug(), "git-trust/grant");
+        assert_eq!(grant.payload["subject"], "did:example:signer");
+
+        let revoke = build_git_trust_revoke(
+            "did:example:authority",
+            "did:example:registry",
+            "did:example:signer",
+            "openvtc",
+            Some("membership ended"),
+        )
+        .unwrap();
+        assert_eq!(revoke.type_uri.slug(), "git-trust/revoke");
+        assert_eq!(revoke.payload["reason"], "membership ended");
+    }
+
+    fn reserialize(doc: &trust_tasks_rs::ErrorResponse) -> TrustTask<Value> {
+        serde_json::from_value(serde_json::to_value(doc).unwrap()).unwrap()
+    }
+
+    #[test]
+    fn reply_classification_matches_hook_semantics() {
+        let grant = build_git_trust_grant("did:a", "did:r", "did:s", "org").unwrap();
+
+        let ok = grant.respond_with(
+            "urn:uuid:r".to_string(),
+            serde_json::json!({ "subject": "did:s", "resource": "org", "granted": true }),
+        );
+        assert_eq!(classify_git_trust_reply(&ok), Some(WriteOutcome::Success));
+
+        let already = reserialize(
+            &grant.reject_with(
+                "urn:uuid:e".to_string(),
+                RejectReason::TaskFailed {
+                    reason: "already_granted: an active grant exists for this subject and resource"
+                        .to_string(),
+                    details: None,
+                },
+            ),
+        );
+        assert_eq!(
+            classify_git_trust_reply(&already),
+            Some(WriteOutcome::IdempotentSuccess)
+        );
+
+        let denied = reserialize(&grant.reject_with(
+            "urn:uuid:e2".to_string(),
+            RejectReason::PermissionDenied {
+                reason: "not on the admin ACL".to_string(),
+            },
+        ));
+        assert!(matches!(
+            classify_git_trust_reply(&denied),
+            Some(WriteOutcome::Rejected { .. })
+        ));
+
+        let foreign = TrustTask::new(
+            "urn:uuid:f".to_string(),
+            "https://trusttasks.org/spec/registry/authorization/0.1#response"
+                .parse()
+                .unwrap(),
+            serde_json::json!({}),
+        );
+        assert_eq!(classify_git_trust_reply(&foreign), None);
+    }
+
+    #[test]
+    fn envelope_parse_requires_a_thread_id() {
+        let grant = build_git_trust_grant("did:a", "did:r", "did:s", "org").unwrap();
+        let reply = grant.respond_with("urn:uuid:r".to_string(), serde_json::json!({}));
+        let body = serde_json::to_value(&reply).unwrap();
+        let (thid, _) = parse_envelope_document(&body).unwrap();
+        assert_eq!(thid, grant.id);
+
+        let unthreaded = serde_json::to_value(&grant).unwrap();
+        assert!(parse_envelope_document(&unthreaded).is_none());
+    }
+}

--- a/vti-common/src/lib.rs
+++ b/vti-common/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod acl;
 pub mod audit;
 pub mod auth;
+pub mod capability_client;
 pub mod config;
 pub mod consent;
 pub mod context_path;


### PR DESCRIPTION
## What

The membership→capability bridge from `design-docs/vtc-membership-hooks.md`: joining a VTC as a mapped role automatically grants commit-signing trust in the community's registry; losing membership revokes it. Two commits:

### 1. `vti-common::capability_client` (shared, transport-free)

Document builders, `eddsa-jcs-2022` signing (canonical form matching the registry verifier), DIDComm envelope parsing, and reply classification for the capability Trust Task families. `WriteOutcome::IdempotentSuccess` is the load-bearing piece: `already_granted`/`not_granted` rejections classify as success, giving redelivery-safe semantics. (The openvtc TUI's duplicate copy swaps to this in a follow-up — decision D-H1.)

### 2. `vtc-service::hooks` — the `HookRelay`

A **second audit-tail consumer** (own `hooks_cursor` + `hooks_queue`), deliberately copying the `MembershipSyncer` shape (the house pattern: per-concern fjall queue + cursor + supervised drainer ⇒ crash-replay inherited):

- `MemberAdded{role}` → grant per `[hooks.git-trust] grant_on_role`; `RoleChanged` → ordered revoke(old)→grant(new); `MemberRemoved` → revoke every mapped resource (unheld ones resolve as idempotent success).
- **Exactly-once-effective** (idempotency root = audit row key), **ordered** (queue key carries an intra-event sequence — a UUID tiebreak between same-timestamp jobs was provably flaky and is pinned by test now), **revocation delivery-critical** (retries indefinitely on transient/unreachable per R7.2; grants have a 20-attempt budget; registry rejections are terminal + loud), **off by default** (no `[hooks]` config ⇒ relay not spawned, R5.1).
- Boot recovery flips `InFlight` back to `Pending` (crash between dispatch and outcome).

## Split noted

The `CapabilityWriter` trait is the transport seam; this PR ships the relay core against it with a scripted mock. The **follow-up PR** adds the production DIDComm writer (signed via `capability_client`, thid-correlated replies through the existing MessagingService demux) + keyspace registration + `serve()` wiring + health surface — same core-then-bindings split as the registry's CapabilitySet (#97/#98).

## Testing

11 new tests (3 client + 8 relay): mapping matrix, cursor dedup, FIFO drain, idempotent completion, terminal rejection, revoke-outlives-grant-budget, boot recovery. Full `vti-common` + `vtc-service` lib suites green (994 tests); clippy clean under `-D warnings`.