### PR TITLE
feat: production DIDComm capability writer + hook relay wiring (vtc-service)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+### vtc-service 0.11.10 — membership hooks: production DIDComm writer + wiring
+
+* Completes the membership hook relay (`design-docs/vtc-membership-hooks.md`): the
+  `DidcommCapabilityWriter` signs `git-trust/grant|revoke` documents with the VTC's
+  credential signer (the community is the authority its grants are issued under; the
+  signer's canonical form matches the trust registry verifier's exactly) and sends them
+  to the registry over the delivery-layer messaging, correlating the reply by `threadId`
+  through a shared pending-reply map completed in the inbound demux.
+* New config: `registry.did` (the registry's DIDComm DID — required for the relay) and a
+  `[hooks.git-trust]` section (`grant_on_role`, `revoke_with_membership`). `serve()`
+  spawns the relay under a panic-restart supervisor **only** when git-trust hooks, the
+  registry DID, and the VTC credential signer are all present — absent any, no relay.
+* New keyspaces `hooks_queue` / `hooks_cursor`.
+
+
 ### vti-common 0.11.7 — `capability_client`: shared capability Trust Task primitives
 
 * New `capability_client` module: transport-free document builders, `eddsa-jcs-2022`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10301,7 +10301,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-service"
-version = "0.11.9"
+version = "0.11.10"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.11.9"
+version = "0.11.10"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vtc-service/src/config.rs
+++ b/vtc-service/src/config.rs
@@ -35,6 +35,10 @@ pub struct AppConfig {
     /// the registry at boot and on a periodic interval.
     #[serde(default)]
     pub registry: RegistryConfig,
+    /// Membership lifecycle hooks — capability grant propagation
+    /// (`design-docs/vtc-membership-hooks.md`). Absent ⇒ no hook relay.
+    #[serde(default)]
+    pub hooks: crate::hooks::HooksConfig,
     /// Renewal-path settings (Phase 4 M4.2.2). Currently
     /// gates the renewal-time behaviour when `personhood.rego`
     /// flips a previously-asserted member's flag to `false`.
@@ -244,6 +248,11 @@ pub struct RegistryConfig {
     /// `"degraded"`, sync is skipped.
     #[serde(default)]
     pub url: Option<String>,
+    /// DID of the trust registry — the recipient of DIDComm capability
+    /// writes (`governance/capability/*`, `git-trust/*`). Required for the
+    /// membership hook relay; unset ⇒ hooks are not spawned.
+    #[serde(default)]
+    pub did: Option<String>,
     /// Period (seconds) between background health probes.
     /// `0` disables the periodic probe (only boot-time probe
     /// runs). Default: 60s.
@@ -289,6 +298,7 @@ impl Default for RegistryConfig {
         // construction.
         Self {
             url: None,
+            did: None,
             health_probe_interval_seconds: default_health_probe_interval(),
             http_timeout_seconds: default_registry_http_timeout(),
             rtbf_batch_window_hours: default_rtbf_batch_window_hours(),

--- a/vtc-service/src/hooks/mod.rs
+++ b/vtc-service/src/hooks/mod.rs
@@ -514,5 +514,11 @@ fn backoff(attempts: u32) -> chrono::Duration {
     chrono::Duration::seconds(secs as i64)
 }
 
+pub mod reply;
+pub mod writer;
+
+pub use reply::PendingReplies;
+pub use writer::DidcommCapabilityWriter;
+
 #[cfg(test)]
 mod tests;

--- a/vtc-service/src/hooks/reply.rs
+++ b/vtc-service/src/hooks/reply.rs
@@ -1,0 +1,61 @@
+//! Reply correlation for capability writes.
+//!
+//! A capability write is sent as a DIDComm envelope and its reply arrives
+//! asynchronously on the shared inbound stream. The [`CapabilityWriter`] and
+//! the inbound demux (`messaging::dispatch`) share one [`PendingReplies`]: the
+//! writer registers a waiter keyed by the request document id before sending;
+//! the demux completes it when a reply whose `threadId` matches arrives.
+//!
+//! [`CapabilityWriter`]: super::CapabilityWriter
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use serde_json::Value;
+use tokio::sync::oneshot;
+use trust_tasks_rs::TrustTask;
+
+/// Shared map of in-flight capability writes awaiting their reply, keyed by
+/// request document id (== the reply's `threadId`).
+#[derive(Clone, Default)]
+pub struct PendingReplies {
+    inner: Arc<Mutex<HashMap<String, oneshot::Sender<TrustTask<Value>>>>>,
+}
+
+impl PendingReplies {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a waiter for `request_id` before the request is sent, so a
+    /// fast reply cannot race the registration.
+    pub fn register(&self, request_id: &str) -> oneshot::Receiver<TrustTask<Value>> {
+        let (tx, rx) = oneshot::channel();
+        self.lock().insert(request_id.to_string(), tx);
+        rx
+    }
+
+    /// Drop the waiter for `request_id` (send failure or timeout).
+    pub fn abandon(&self, request_id: &str) {
+        self.lock().remove(request_id);
+    }
+
+    /// Complete the waiter registered under `document`'s `threadId`. Returns
+    /// `true` if a waiter received it (i.e. this was one of our replies).
+    pub fn complete(&self, document: TrustTask<Value>) -> bool {
+        let Some(thread_id) = document.thread_id.clone() else {
+            return false;
+        };
+        let waiter = self.lock().remove(&thread_id);
+        match waiter {
+            Some(tx) => tx.send(document).is_ok(),
+            None => false,
+        }
+    }
+
+    fn lock(
+        &self,
+    ) -> std::sync::MutexGuard<'_, HashMap<String, oneshot::Sender<TrustTask<Value>>>> {
+        self.inner.lock().unwrap_or_else(|p| p.into_inner())
+    }
+}

--- a/vtc-service/src/hooks/writer.rs
+++ b/vtc-service/src/hooks/writer.rs
@@ -1,0 +1,286 @@
+//! The production [`CapabilityWriter`]: signs a `git-trust/grant|revoke`
+//! document with the VTC's assertion key and sends it to the community's
+//! trust registry over DIDComm, correlating the reply by `threadId`.
+//!
+//! Durability lives in the hook queue, not here: this send is `BestEffort`
+//! and a job is complete only when a correlated reply classifies as success —
+//! no reply within the window is a [`HookWriteError::Transient`], which the
+//! relay retries (R1.1: an `Ok` from a send is never treated as delivery).
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use affinidi_messaging_delivery::Delivery;
+use affinidi_messaging_didcomm::Message;
+use async_trait::async_trait;
+use tokio::sync::OnceCell;
+use uuid::Uuid;
+use vti_common::capability_client::{
+    self, TRUST_TASK_ENVELOPE_TYPE, WriteOutcome, build_git_trust_grant, build_git_trust_revoke,
+};
+
+use crate::credentials::LocalSigner;
+use crate::messaging::VtcMessaging;
+
+use super::reply::PendingReplies;
+use super::{CapabilityWriter, HookJob, HookOp, HookWriteError};
+
+/// Default wait for the registry's reply before a write is deemed transient.
+pub const DEFAULT_REPLY_TIMEOUT_SECONDS: u64 = 60;
+
+/// Signs and sends capability writes to the trust registry over the VTC's
+/// DIDComm messaging, awaiting the correlated reply.
+pub struct DidcommCapabilityWriter {
+    /// The VTC messaging handle (`None` until the listener is up — a not-yet-
+    /// running messaging is a transient condition, not a permanent failure).
+    didcomm: Arc<OnceCell<Arc<VtcMessaging>>>,
+    /// The VTC's assertion signer (`{vtc_did}#key-0`) — the same identity
+    /// that mints VMC/VEC. The community is the authority its grants are
+    /// issued under, so this is exactly the right key.
+    signer: Arc<LocalSigner>,
+    /// DID of the community's trust registry (the write recipient).
+    registry_did: String,
+    replies: PendingReplies,
+    reply_timeout: Duration,
+}
+
+impl DidcommCapabilityWriter {
+    pub fn new(
+        didcomm: Arc<OnceCell<Arc<VtcMessaging>>>,
+        signer: Arc<LocalSigner>,
+        registry_did: String,
+        replies: PendingReplies,
+    ) -> Self {
+        Self {
+            didcomm,
+            signer,
+            registry_did,
+            replies,
+            reply_timeout: Duration::from_secs(DEFAULT_REPLY_TIMEOUT_SECONDS),
+        }
+    }
+
+    #[cfg(test)]
+    pub fn with_reply_timeout(mut self, timeout: Duration) -> Self {
+        self.reply_timeout = timeout;
+        self
+    }
+}
+
+#[async_trait]
+impl CapabilityWriter for DidcommCapabilityWriter {
+    async fn write(&self, job: &HookJob) -> Result<WriteOutcome, HookWriteError> {
+        let messaging = self.didcomm.get().ok_or_else(|| {
+            HookWriteError::Transient("VTC messaging not running yet".to_string())
+        })?;
+        let issuer = messaging.vtc_did.clone();
+        let doc = self.build_signed_document(&issuer, job).await?;
+
+        // Register the waiter before sending so a fast reply cannot be lost.
+        let receiver = self.replies.register(&doc.id);
+
+        if let Err(e) = self.send_envelope(messaging, &doc).await {
+            self.replies.abandon(&doc.id);
+            return Err(e);
+        }
+
+        match tokio::time::timeout(self.reply_timeout, receiver).await {
+            Ok(Ok(reply)) => capability_client::classify_git_trust_reply(&reply).ok_or_else(|| {
+                // A reply we correlated but can't classify is a contract bug on
+                // the registry side; retrying can't fix it, but treating it as
+                // permanent would strand the job — surface transient + loud.
+                HookWriteError::Transient(format!(
+                    "uninterpretable reply type `{}`",
+                    reply.type_uri
+                ))
+            }),
+            Ok(Err(_closed)) => {
+                self.replies.abandon(&doc.id);
+                Err(HookWriteError::Transient(
+                    "reply channel closed".to_string(),
+                ))
+            }
+            Err(_elapsed) => {
+                self.replies.abandon(&doc.id);
+                Err(HookWriteError::Transient(format!(
+                    "no reply within {}s",
+                    self.reply_timeout.as_secs()
+                )))
+            }
+        }
+    }
+}
+
+impl DidcommCapabilityWriter {
+    /// Build the `git-trust/grant|revoke` document for `job` (issued by
+    /// `issuer`, the VTC) and attach the VTC's Data-Integrity proof. Signing
+    /// reuses the VTC's credential signer, whose canonical form (remove
+    /// `proof`, eddsa-jcs-2022, reinsert) matches the registry verifier's
+    /// exactly — so a document built here verifies at the registry.
+    async fn build_signed_document(
+        &self,
+        issuer: &str,
+        job: &HookJob,
+    ) -> Result<trust_tasks_rs::TrustTask<serde_json::Value>, HookWriteError> {
+        let doc = match job.op {
+            HookOp::Grant => {
+                build_git_trust_grant(issuer, &self.registry_did, &job.subject_did, &job.resource)
+            }
+            HookOp::Revoke => build_git_trust_revoke(
+                issuer,
+                &self.registry_did,
+                &job.subject_did,
+                &job.resource,
+                job.reason.as_deref(),
+            ),
+        }
+        .map_err(|e| HookWriteError::Transient(format!("build capability document: {e}")))?;
+
+        let mut doc_value = serde_json::to_value(&doc)
+            .map_err(|e| HookWriteError::Transient(format!("serialise document: {e}")))?;
+        self.signer
+            .sign_doc(&mut doc_value)
+            .await
+            .map_err(|e| HookWriteError::Transient(format!("sign document: {e}")))?;
+        serde_json::from_value(doc_value)
+            .map_err(|e| HookWriteError::Transient(format!("reparse signed document: {e}")))
+    }
+
+    /// Pack the signed document in the trust-task envelope and hand it to the
+    /// delivery layer (`BestEffort` — the hook queue owns durability).
+    async fn send_envelope(
+        &self,
+        messaging: &VtcMessaging,
+        doc: &trust_tasks_rs::TrustTask<serde_json::Value>,
+    ) -> Result<(), HookWriteError> {
+        let body = serde_json::to_value(doc)
+            .map_err(|e| HookWriteError::Transient(format!("serialise envelope body: {e}")))?;
+        let envelope = Message::build(
+            format!("urn:uuid:{}", Uuid::new_v4()),
+            TRUST_TASK_ENVELOPE_TYPE.to_string(),
+            body,
+        )
+        .from(messaging.vtc_did.clone())
+        .to(self.registry_did.clone())
+        .thid(doc.id.clone())
+        .finalize();
+
+        let (packed, _) = messaging
+            .atm
+            .pack_encrypted(
+                &envelope,
+                &self.registry_did,
+                Some(&messaging.vtc_did),
+                Some(&messaging.vtc_did),
+            )
+            .await
+            .map_err(|e| HookWriteError::Unreachable(format!("pack failed: {e}")))?;
+
+        messaging
+            .service
+            .send(
+                &self.registry_did,
+                packed.into_bytes(),
+                Delivery::BestEffort,
+            )
+            .await
+            .map_err(|e| HookWriteError::Unreachable(format!("send failed: {e}")))?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+
+    use super::*;
+    use crate::hooks::reply::PendingReplies;
+    use std::time::Duration;
+    use trust_tasks_rs::TrustTask;
+
+    const VTC: &str = "did:webvh:vtc.example";
+    const REGISTRY: &str = "did:webvh:registry.example";
+
+    fn writer() -> DidcommCapabilityWriter {
+        DidcommCapabilityWriter::new(
+            Arc::new(OnceCell::new()),
+            Arc::new(LocalSigner::from_ed25519_seed(VTC.into(), &[0x11; 32])),
+            REGISTRY.into(),
+            PendingReplies::new(),
+        )
+        .with_reply_timeout(Duration::from_millis(50))
+    }
+
+    fn grant_job() -> HookJob {
+        HookJob::new(
+            "seq".into(),
+            HookOp::Grant,
+            "did:example:signer".into(),
+            "openvtc".into(),
+            None,
+            chrono::Utc::now(),
+        )
+    }
+
+    #[tokio::test]
+    async fn signed_document_verifies_against_the_vtc_key() {
+        let w = writer();
+        let doc = w.build_signed_document(VTC, &grant_job()).await.unwrap();
+        assert_eq!(doc.type_uri.slug(), "git-trust/grant");
+        assert_eq!(doc.issuer.as_deref(), Some(VTC));
+        assert_eq!(doc.recipient.as_deref(), Some(REGISTRY));
+
+        // The proof verifies over the canonical form (doc minus proof) with
+        // the VTC's public key — the same check the registry runs.
+        let proof = doc.proof.clone().expect("document is signed");
+        let mut value = serde_json::to_value(&doc).unwrap();
+        value.as_object_mut().unwrap().remove("proof");
+        let di_proof: affinidi_data_integrity::DataIntegrityProof =
+            serde_json::from_value(serde_json::to_value(&proof).unwrap()).unwrap();
+        let signer = LocalSigner::from_ed25519_seed(VTC.into(), &[0x11; 32]);
+        di_proof
+            .verify_with_public_key(
+                &value,
+                signer.public_bytes(),
+                affinidi_data_integrity::VerifyOptions::new(),
+            )
+            .expect("proof verifies with the VTC key");
+    }
+
+    #[tokio::test]
+    async fn write_is_transient_when_messaging_is_not_up() {
+        let w = writer();
+        // Empty OnceCell = listener not yet running.
+        let err = w.write(&grant_job()).await.unwrap_err();
+        assert!(matches!(err, HookWriteError::Transient(_)), "got {err}");
+    }
+
+    #[tokio::test]
+    async fn pending_replies_correlate_by_thread_id() {
+        let replies = PendingReplies::new();
+        let rx = replies.register("urn:uuid:req");
+
+        // A reply with the wrong threadId completes nobody.
+        let mut wrong: TrustTask<serde_json::Value> = TrustTask::new(
+            "urn:uuid:x".to_string(),
+            "https://trusttasks.org/spec/git-trust/grant/0.1#response"
+                .parse()
+                .unwrap(),
+            serde_json::json!({}),
+        );
+        wrong.thread_id = Some("urn:uuid:other".into());
+        assert!(!replies.complete(wrong));
+
+        // The matching reply resolves the waiter.
+        let mut right: TrustTask<serde_json::Value> = TrustTask::new(
+            "urn:uuid:y".to_string(),
+            "https://trusttasks.org/spec/git-trust/grant/0.1#response"
+                .parse()
+                .unwrap(),
+            serde_json::json!({}),
+        );
+        right.thread_id = Some("urn:uuid:req".into());
+        assert!(replies.complete(right));
+        assert!(rx.await.is_ok());
+    }
+}

--- a/vtc-service/src/messaging.rs
+++ b/vtc-service/src/messaging.rs
@@ -392,6 +392,19 @@ async fn dispatch(inbound: Inbound, state: &AppState) -> Option<Reply> {
         return None;
     }
 
+    // Capability write replies (git-trust/*, governance/capability/*): the
+    // hook relay's writer registered a waiter keyed by the request document
+    // id; complete it and reply nothing. A reply we don't recognise (no
+    // matching waiter) is dropped here rather than problem-reported.
+    if msg.typ == vti_common::capability_client::TRUST_TASK_ENVELOPE_TYPE {
+        if let Some((_thid, doc)) =
+            vti_common::capability_client::parse_envelope_document(&msg.body)
+        {
+            state.capability_replies.complete(doc);
+        }
+        return None;
+    }
+
     let auth_sender = inbound
         .message
         .sender

--- a/vtc-service/src/server.rs
+++ b/vtc-service/src/server.rs
@@ -91,6 +91,13 @@ pub struct AppState {
     /// Singleton row tracking the audit-log tail's last-seen
     /// timestamp for boot-time replay (Phase 3 M3.3).
     pub sync_cursor_ks: KeyspaceHandle,
+    /// Durable queue of membership-hook capability-grant jobs.
+    pub hooks_queue_ks: KeyspaceHandle,
+    /// Singleton audit-tail cursor for the hook relay.
+    pub hooks_cursor_ks: KeyspaceHandle,
+    /// In-flight capability writes awaiting their DIDComm reply — shared
+    /// between the hook relay's writer and the inbound demux.
+    pub capability_replies: crate::hooks::PendingReplies,
     /// VRC trust-edge rows (Phase 4 M4.5). Primary keyspace.
     pub relationships_ks: KeyspaceHandle,
     /// VRC per-DID secondary index (Phase 4 M4.5). Keyed by
@@ -365,6 +372,8 @@ pub async fn run(
     let registry_records_ks = store.keyspace(keyspaces::REGISTRY_RECORDS)?;
     let sync_queue_ks = store.keyspace(keyspaces::SYNC_QUEUE)?;
     let sync_cursor_ks = store.keyspace(keyspaces::SYNC_CURSOR)?;
+    let hooks_queue_ks = store.keyspace(keyspaces::HOOKS_QUEUE)?;
+    let hooks_cursor_ks = store.keyspace(keyspaces::HOOKS_CURSOR)?;
     let relationships_ks = store.keyspace(keyspaces::RELATIONSHIPS)?;
     let relationships_by_did_ks = store.keyspace(keyspaces::RELATIONSHIPS_BY_DID)?;
     let endorsement_types_ks = store.keyspace(keyspaces::ENDORSEMENT_TYPES)?;
@@ -586,6 +595,9 @@ pub async fn run(
         registry_records_ks,
         sync_queue_ks,
         sync_cursor_ks,
+        hooks_queue_ks,
+        hooks_cursor_ks,
+        capability_replies: crate::hooks::PendingReplies::new(),
         relationships_ks,
         relationships_by_did_ks,
         endorsement_types_ks,
@@ -813,6 +825,54 @@ pub async fn run(
                 }
             }
             health.mark_stopped();
+        });
+    }
+
+    // Membership hook relay: propagate membership changes to capability grants
+    // in the community's trust registry. Spawned only when git-trust hooks are
+    // configured AND the registry DID + the VTC credential signer are present —
+    // absent any of these the relay is not started (R5.1: no config, no relay).
+    if let (Some(git_trust_cfg), Some(registry_did), Some(signer)) = (
+        boot_cfg.hooks.git_trust.clone(),
+        boot_cfg.registry.did.clone(),
+        state.credential_signer.clone(),
+    ) {
+        let writer = std::sync::Arc::new(crate::hooks::DidcommCapabilityWriter::new(
+            state.didcomm.clone(),
+            signer,
+            registry_did,
+            state.capability_replies.clone(),
+        ));
+        let audit_ks = state.audit_ks.clone();
+        let queue_ks = state.hooks_queue_ks.clone();
+        let cursor_ks = state.hooks_cursor_ks.clone();
+        let mut supervisor_shutdown = shutdown_rx.clone();
+        tokio::spawn(async move {
+            loop {
+                if *supervisor_shutdown.borrow() {
+                    break;
+                }
+                let relay = crate::hooks::HookRelay::new(
+                    audit_ks.clone(),
+                    queue_ks.clone(),
+                    cursor_ks.clone(),
+                    git_trust_cfg.clone(),
+                    writer.clone(),
+                );
+                let run_shutdown = supervisor_shutdown.clone();
+                let child = tokio::spawn(async move { relay.run(run_shutdown).await });
+                match child.await {
+                    Ok(()) => break,
+                    Err(join_err) if join_err.is_panic() => {
+                        error!(error = %join_err, "HookRelay task panicked — restarting after backoff");
+                        tokio::select! {
+                            _ = tokio::time::sleep(std::time::Duration::from_secs(5)) => {}
+                            _ = supervisor_shutdown.changed() => break,
+                        }
+                    }
+                    Err(_) => break,
+                }
+            }
         });
     }
 

--- a/vtc-service/src/store/keyspaces.rs
+++ b/vtc-service/src/store/keyspaces.rs
@@ -19,6 +19,10 @@ pub const PASSKEY: &str = "passkey";
 pub const INSTALL: &str = "install";
 pub const MEMBERS: &str = "members";
 pub const JOIN_REQUESTS: &str = "join_requests";
+/// Durable queue of pending capability-grant hook jobs (membership → grant).
+pub const HOOKS_QUEUE: &str = "hooks_queue";
+/// Singleton audit-tail cursor for the hook relay.
+pub const HOOKS_CURSOR: &str = "hooks_cursor";
 pub const POLICIES: &str = "policies";
 pub const ACTIVE_POLICIES: &str = "active_policies";
 pub const STATUS_LISTS: &str = "status_lists";

--- a/vtc-service/src/test_support.rs
+++ b/vtc-service/src/test_support.rs
@@ -215,6 +215,8 @@ impl TestVtcBuilder {
             .expect("registry_records ks");
         let sync_queue_ks = store.keyspace("sync_queue").expect("sync_queue ks");
         let sync_cursor_ks = store.keyspace("sync_cursor").expect("sync_cursor ks");
+        let hooks_queue_ks = store.keyspace("hooks_queue").expect("hooks_queue ks");
+        let hooks_cursor_ks = store.keyspace("hooks_cursor").expect("hooks_cursor ks");
         let relationships_ks = store.keyspace("relationships").expect("relationships ks");
         let relationships_by_did_ks = store
             .keyspace("relationships_by_did")
@@ -337,6 +339,9 @@ impl TestVtcBuilder {
             registry_records_ks,
             sync_queue_ks,
             sync_cursor_ks,
+            hooks_queue_ks,
+            hooks_cursor_ks,
+            capability_replies: crate::hooks::PendingReplies::new(),
             relationships_ks,
             relationships_by_did_ks,
             endorsement_types_ks,

--- a/vtc-service/tests/emergency_bootstrap.rs
+++ b/vtc-service/tests/emergency_bootstrap.rs
@@ -216,6 +216,8 @@ async fn build_fixture(public_url: Option<&str>) -> Fixture {
     let registry_records_ks = store.keyspace("registry_records").unwrap();
     let sync_queue_ks = store.keyspace("sync_queue").unwrap();
     let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
+    let hooks_queue_ks = store.keyspace("hooks_queue").unwrap();
+    let hooks_cursor_ks = store.keyspace("hooks_cursor").unwrap();
     let relationships_ks = store.keyspace("relationships").unwrap();
     let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
     let endorsement_types_ks = store.keyspace("endorsement_types").unwrap();
@@ -308,6 +310,9 @@ async fn build_fixture(public_url: Option<&str>) -> Fixture {
         registry_records_ks: registry_records_ks.clone(),
         sync_queue_ks: sync_queue_ks.clone(),
         sync_cursor_ks: sync_cursor_ks.clone(),
+        hooks_queue_ks: hooks_queue_ks.clone(),
+        hooks_cursor_ks: hooks_cursor_ks.clone(),
+        capability_replies: vtc_service::hooks::PendingReplies::new(),
         relationships_ks: relationships_ks.clone(),
         relationships_by_did_ks: relationships_by_did_ks.clone(),
         endorsement_types_ks: endorsement_types_ks.clone(),

--- a/vtc-service/tests/passkey_state.rs
+++ b/vtc-service/tests/passkey_state.rs
@@ -45,6 +45,8 @@ fn build_state(public_url: Option<&str>) -> (AppState, tempfile::TempDir) {
     let registry_records_ks = store.keyspace("registry_records").unwrap();
     let sync_queue_ks = store.keyspace("sync_queue").unwrap();
     let sync_cursor_ks = store.keyspace("sync_cursor").unwrap();
+    let hooks_queue_ks = store.keyspace("hooks_queue").unwrap();
+    let hooks_cursor_ks = store.keyspace("hooks_cursor").unwrap();
     let relationships_ks = store.keyspace("relationships").unwrap();
     let relationships_by_did_ks = store.keyspace("relationships_by_did").unwrap();
     let endorsement_types_ks = store.keyspace("endorsement_types").unwrap();
@@ -83,6 +85,9 @@ fn build_state(public_url: Option<&str>) -> (AppState, tempfile::TempDir) {
         registry_records_ks: registry_records_ks.clone(),
         sync_queue_ks: sync_queue_ks.clone(),
         sync_cursor_ks: sync_cursor_ks.clone(),
+        hooks_queue_ks: hooks_queue_ks.clone(),
+        hooks_cursor_ks: hooks_cursor_ks.clone(),
+        capability_replies: vtc_service::hooks::PendingReplies::new(),
         relationships_ks: relationships_ks.clone(),
         relationships_by_did_ks: relationships_by_did_ks.clone(),
         endorsement_types_ks: endorsement_types_ks.clone(),

--- a/vtc-service/tests/routing_cors.rs
+++ b/vtc-service/tests/routing_cors.rs
@@ -28,6 +28,7 @@ fn cfg_with(routing: RoutingConfig, cors: CorsConfig) -> AppConfig {
         vtc_did: None,
         vta_did: None,
         vtc_name: None,
+        hooks: Default::default(),
         vtc_description: None,
         public_url: None,
         server: Default::default(),


### PR DESCRIPTION
## What

The follow-up to #680 that makes the membership hook loop **run end to end**: a member joining a VTC as a mapped role now results in a signed `git-trust/grant` landing in the community's trust registry, with no human step.

- **`DidcommCapabilityWriter`** (the production `CapabilityWriter`): builds a `git-trust/grant|revoke` document, signs it with the VTC's **existing credential signer** (`{vtc_did}#key-0` — the same key that mints VMC/VEC; the community is the authority its grants are issued under), sends it over the delivery-layer messaging, and awaits the reply correlated by `threadId`. The signer reuse is safe because `LocalSigner::sign_doc`'s canonical form (remove `proof` → eddsa-jcs-2022 → reinsert) is byte-identical to the registry verifier's — pinned by a test that verifies the produced proof with the VTC public key.
- **Reply correlation**: a shared `PendingReplies` map — the writer registers a waiter before sending; the inbound demux (`messaging::dispatch`) completes it on a matching `TRUST_TASK_ENVELOPE_TYPE` reply and replies nothing.
- **Durability stays in the hook queue** (R1.1): the send is `BestEffort`; a job completes only on a classified success reply (`Success`/`IdempotentSuccess`); no reply in 60s is a `Transient` the relay retries — a bare send `Ok` is never treated as delivery.
- **Wiring**: new `registry.did` config + `[hooks.git-trust]` section; `hooks_queue`/`hooks_cursor` keyspaces; `serve()` spawns the relay under a panic-restart supervisor (mirroring the `MembershipSyncer`) **only** when git-trust hooks + registry DID + VTC signer are all present — absent any, no relay (R5.1).

## Testing

11 hooks tests green (994 lib total): the signer-reuse proof-verifies test, `write()` degrades to `Transient` when messaging isn't up, `PendingReplies` correlation, plus the relay/mapping suite from #680. The full send↔reply↔classify round trip needs a live mediator (integration territory). Clippy clean under `-D warnings` across lib + all test targets. vtc-service bumped 0.11.9 → 0.11.10 with a CHANGELOG entry; DCO signed.

## After this

The loop is complete on the service side. Remaining tidy-up: swap the openvtc TUI's duplicate capability-client code to `vti-common::capability_client` (decision D-H1), and the operator runbook for enabling hooks (`registry.did` + `[hooks.git-trust]` + enrolling the VTC authority DID in the registry admin ACL).