### PR TITLE
feat(vta-service): cut VTA messaging over to the reliable-messaging delivery layer (D2 P2a)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10172,7 +10172,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.11.5"
+version = "0.11.6"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,9 +305,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-delivery"
-version = "0.1.7"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34313da7d531d72a6ef239b215b392ae5bd9810d651c452e75b5433ca54e8e90"
+checksum = "bb92150efbc0d18868510c2163ab0e314b34e71a16a032688c6f3033eb1f4e14"
 dependencies = [
  "affinidi-messaging-core",
  "async-trait",
@@ -336,30 +336,6 @@ dependencies = [
  "sha2 0.10.9",
  "thiserror 2.0.18",
  "url",
- "uuid",
-]
-
-[[package]]
-name = "affinidi-messaging-didcomm-service"
-version = "0.3.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525bb8c3cb37f5c470ca1ed443d2beebba698b254d7656b8e4783e772355f1f0"
-dependencies = [
- "affinidi-messaging-didcomm",
- "affinidi-messaging-sdk",
- "affinidi-secrets-resolver",
- "affinidi-tdk-common",
- "async-trait",
- "regex",
- "serde",
- "serde_json",
- "sha256",
- "thiserror 2.0.18",
- "tokio",
- "tokio-util",
- "tracing",
- "tracing-subscriber",
- "trust-tasks-rs",
  "uuid",
 ]
 
@@ -478,9 +454,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-sdk"
-version = "0.18.57"
+version = "0.18.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "197dc2c0e495bc94e92f74df980b59cc16668018fe47d6f55e22f9c699e40f00"
+checksum = "22956a9d0183e10019486445ddcc134835be191001c455c8d1d3fed8083c0670"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-authentication",
@@ -2984,7 +2960,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 2.0.118",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4751,7 +4727,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "system-configuration 0.7.0",
  "tokio",
  "tower-service",
@@ -6943,7 +6919,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.41",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6981,7 +6957,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -10204,8 +10180,9 @@ dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
  "affinidi-did-resolver-cache-sdk",
+ "affinidi-messaging-core",
+ "affinidi-messaging-delivery",
  "affinidi-messaging-didcomm",
- "affinidi-messaging-didcomm-service",
  "affinidi-messaging-sdk",
  "affinidi-openid4vci",
  "affinidi-openid4vp",
@@ -10235,6 +10212,7 @@ dependencies = [
  "ed25519-dalek",
  "ed25519-dalek-bip32",
  "fjall",
+ "futures-util",
  "hex",
  "hkdf 0.13.0",
  "hmac 0.13.0",
@@ -10839,7 +10817,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.11.5"
+version = "0.11.6"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -21,7 +21,6 @@ tsp = [
     "vta-sdk/tsp",
     "dep:affinidi-messaging-sdk",
     "affinidi-messaging-sdk/tsp",
-    "affinidi-messaging-didcomm-service/tsp",
 ]
 webvh = ["dep:didwebvh-rs", "dep:url", "dep:reqwest"]
 setup = ["webvh", "dep:tempfile"]
@@ -146,7 +145,16 @@ affinidi-status-list = { workspace = true }
 hkdf = { workspace = true }
 affinidi-tdk = { workspace = true }
 affinidi-messaging-didcomm = "0.15"
-affinidi-messaging-didcomm-service = { workspace = true }
+# D2 P2a cut-over: the reliable-messaging delivery layer replaces the old
+# `affinidi-messaging-didcomm-service` type-routed framework. `MessagingService`
+# (subscribe/send/request over a `DidCommTransport`) drives inbound + outbound;
+# `affinidi-messaging-core` supplies the transport contract types
+# (`MessageTransport`, `Inbound`, `Protocol`); `VtiOutboxStore` (vti-common)
+# backs the outbox. `DidCommTransport` comes from `affinidi-tdk::messaging`.
+affinidi-messaging-delivery = { workspace = true }
+affinidi-messaging-core = { workspace = true }
+# `StreamExt::next` on the `BoxStream` returned by `MessagingService::subscribe`.
+futures-util = "0.3"
 # Direct (optional) dependency only so the `tsp` feature can turn on the
 # messaging-SDK's own `tsp` ops (`atm.tsp()`), which are gated behind that
 # crate's `tsp` feature and are NOT reachable via `affinidi-tdk/tsp`. The crate

--- a/vta-service/src/didcomm_bridge.rs
+++ b/vta-service/src/didcomm_bridge.rs
@@ -1,16 +1,13 @@
-use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
-use affinidi_messaging_didcomm_service::DIDCommService;
+use affinidi_messaging_delivery::{Delivery, MessagingService, MessagingStatus};
 use affinidi_tdk::didcomm::Message;
-use tokio::sync::oneshot;
+use affinidi_tdk::messaging::ATM;
+use tokio::sync::OnceCell;
 
 use crate::error::{AppError, bad_gateway_error};
 use vta_sdk::protocols::{PROBLEM_REPORT_TYPE, extract_problem_report};
-
-/// Map of pending request IDs to oneshot senders for response routing.
-pub type PendingMap = Arc<std::sync::Mutex<HashMap<String, oneshot::Sender<Message>>>>;
 
 /// Translate a remote peer's DIDComm problem-report into a typed [`AppError`].
 ///
@@ -49,103 +46,204 @@ fn problem_report_to_app_error(code: &str, comment: &str) -> AppError {
     }
 }
 
-/// Bridge between REST/DIDComm handlers and the DIDComm service's outbound
-/// send capability.
+/// The live delivery-layer wiring the bridge sends through, published once the
+/// [`MessagingService`] is built in `server::run`.
+struct BridgeInner {
+    /// The one delivery-layer service over the VTA's mediator websocket(s).
+    /// Outbound `send`/`request` route through its current **primary**;
+    /// `request_via` targets a named (candidate) transport for the mediator
+    /// handshake.
+    service: Arc<MessagingService>,
+    /// The ATM used to authcrypt-pack outbound messages (pack sender = the
+    /// VTA's DID).
+    atm: ATM,
+    /// The VTA's own DID — the `from` on every packed outbound message.
+    vta_did: String,
+}
+
+/// Outbound DIDComm adapter over the reliable-messaging delivery layer.
 ///
-/// Provides outbound request-response DIDComm messaging by registering
-/// oneshot channels keyed by message ID. The [`BridgeHandler`] wrapper
-/// calls [`try_complete`](Self::try_complete) on each inbound message to route responses
-/// back to the waiting handler.
+/// **D2 P2a cut-over**: this used to wrap the
+/// `affinidi-messaging-didcomm-service` framework's `DIDCommService` + a
+/// thread-id pending-map. It now wraps the delivery-layer [`MessagingService`]:
+/// `send_and_wait` → [`MessagingService::request`] (the outbound message id is
+/// the correlation thread id), `send_oneway` → [`MessagingService::send`] with
+/// [`Delivery::BestEffort`], `send_and_wait_via` → [`MessagingService::request_via`]
+/// (a named candidate transport, for the mediator handshake). The delivery
+/// dispatcher owns thread-id correlation, so the old pending-map / `try_complete`
+/// / `send_message_with_retry` are gone.
 ///
-/// The bridge starts without a service reference. Call [`set_service`](Self::set_service)
-/// after [`DIDCommService::start`] to enable outbound sends.
-///
-/// [`BridgeHandler`]: crate::messaging::router::BridgeHandler
+/// The public method surface is unchanged so the ~25 WebVH / provision / CLI /
+/// test call-sites that thread `Arc<DIDCommBridge>` compile untouched;
+/// [`placeholder`](Self::placeholder) stays free (offline CLI + tests never
+/// send). The live wiring is published once via [`set_messaging`](Self::set_messaging).
 pub struct DIDCommBridge {
-    service: tokio::sync::OnceCell<DIDCommService>,
-    pending: PendingMap,
+    inner: OnceCell<BridgeInner>,
+    /// The primary transport id (e.g. `"vta-main"`). Retained for parity with
+    /// the old listener id; outbound always routes through the service's
+    /// current primary regardless.
+    #[allow(dead_code)]
     listener_id: String,
 }
 
 impl DIDCommBridge {
-    /// Create a new bridge targeting a specific listener.
-    ///
-    /// Call [`set_service`](Self::set_service) after the DIDComm service starts to enable
-    /// outbound sends.
+    /// Create a new bridge. Call [`set_messaging`](Self::set_messaging) after
+    /// the delivery-layer `MessagingService` starts to enable outbound sends.
     pub fn new(listener_id: impl Into<String>) -> Self {
         Self {
-            service: tokio::sync::OnceCell::new(),
-            pending: Arc::new(std::sync::Mutex::new(HashMap::new())),
+            inner: OnceCell::new(),
             listener_id: listener_id.into(),
         }
     }
 
     /// Create a placeholder bridge for test/CLI contexts that never send.
-    ///
-    /// Attempting to send via a placeholder will return an error.
+    /// Attempting to send via a placeholder returns an error.
     pub fn placeholder() -> Self {
         Self::new("")
     }
 
-    /// Store the DIDComm service reference for outbound sends.
-    ///
-    /// Called once after [`DIDCommService::start`] completes.
-    pub fn set_service(&self, service: DIDCommService) {
-        let _ = self.service.set(service);
+    /// Publish the live delivery-layer wiring. Called once from `server::run`
+    /// after the `MessagingService` is built over the mediator websocket.
+    pub fn set_messaging(&self, service: Arc<MessagingService>, atm: ATM, vta_did: String) {
+        let _ = self.inner.set(BridgeInner {
+            service,
+            atm,
+            vta_did,
+        });
     }
 
-    /// Best-effort accessor for the wrapped service. Returns
-    /// `None` if [`set_service`](Self::set_service) hasn't been
-    /// called (e.g. the bridge is a placeholder, or DIDComm
-    /// hasn't started yet). Used by the live mediator handshake
-    /// prover, which needs to call `add_listener` /
-    /// `wait_connected` against a running service.
-    pub fn try_get_service(&self) -> Option<DIDCommService> {
-        self.service.get().cloned()
+    /// The live [`MessagingService`] handle, or `None` before
+    /// [`set_messaging`](Self::set_messaging). Used by the live mediator
+    /// handshake prover, which drives `add_transport`/`request_via`/`promote`
+    /// against it.
+    pub fn messaging_handle(&self) -> Option<Arc<MessagingService>> {
+        self.inner.get().map(|i| i.service.clone())
     }
 
-    /// Fire-and-forget: pack `body` as a DIDComm message to `recipient_did` and
-    /// send it via the mediator, **without** registering a pending reply. Used
-    /// for the delegated step-up push — the approver's device replies later via
-    /// a separate `approve-response` call, not as a DIDComm reply on this thread.
-    pub async fn send_oneway(
-        &self,
-        listener_id: &str,
-        recipient_did: &str,
+    /// The ATM (for building a candidate transport's profile + packing during
+    /// the mediator handshake), or `None` before the service is published.
+    pub fn atm(&self) -> Option<ATM> {
+        self.inner.get().map(|i| i.atm.clone())
+    }
+
+    /// The VTA's own DID, or `None` before the service is published.
+    pub fn vta_did(&self) -> Option<String> {
+        self.inner.get().map(|i| i.vta_did.clone())
+    }
+
+    /// The live, **non-latched** messaging status (R6.2), or `None` before the
+    /// service is published. Read straight off [`MessagingService::status`],
+    /// which reflects each transport's live connection signal and can go false
+    /// again after boot.
+    pub fn messaging_status_str(&self) -> Option<String> {
+        self.inner.get().map(|i| {
+            match i.service.status() {
+                MessagingStatus::Connected => "connected",
+                MessagingStatus::Degraded => "degraded",
+                // `MessagingStatus` is `#[non_exhaustive]`; treat any other
+                // (including `Disconnected`) as disconnected.
+                _ => "disconnected",
+            }
+            .to_string()
+        })
+    }
+
+    fn inner(&self) -> Result<&BridgeInner, AppError> {
+        self.inner
+            .get()
+            .ok_or_else(|| AppError::Internal("DIDComm messaging not initialized".into()))
+    }
+
+    /// Authcrypt-pack `body` as a DIDComm message from the VTA to `recipient`.
+    /// Returns `(message_id, packed_bytes)`; the id is the correlation thread
+    /// id for a request/reply round trip.
+    async fn pack(
+        inner: &BridgeInner,
+        recipient: &str,
         msg_type: &str,
         body: serde_json::Value,
-    ) -> Result<(), AppError> {
-        let service = self
-            .service
-            .get()
-            .ok_or_else(|| AppError::Internal("DIDComm service not initialized".into()))?;
-        let vta_did = service.listener_did(listener_id).await.ok_or_else(|| {
-            AppError::Internal(format!(
-                "listener '{listener_id}' not found in DIDComm service"
-            ))
-        })?;
+        timeout_secs: Option<u64>,
+    ) -> Result<(String, Vec<u8>), AppError> {
+        let msg_id = uuid::Uuid::new_v4().to_string();
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
             .as_secs();
-        let msg = Message::build(uuid::Uuid::new_v4().to_string(), msg_type.to_string(), body)
-            .from(vta_did)
-            .to(recipient_did.to_string())
-            .created_time(now)
-            .finalize();
-        service
-            .send_message_with_retry(listener_id, msg, recipient_did, 3, Duration::from_secs(2))
+        let mut builder = Message::build(msg_id.clone(), msg_type.to_string(), body)
+            .from(inner.vta_did.clone())
+            .to(recipient.to_string())
+            .created_time(now);
+        if let Some(secs) = timeout_secs {
+            builder = builder.expires_time(now + secs);
+        }
+        let msg = builder.finalize();
+        let (packed, _meta) = inner
+            .atm
+            .pack_encrypted(&msg, recipient, Some(&inner.vta_did), Some(&inner.vta_did))
+            .await
+            .map_err(|e| bad_gateway_error(format!("failed to pack message: {e}")))?;
+        Ok((msg_id, packed.into_bytes()))
+    }
+
+    /// Fire-and-forget: pack `body` as a DIDComm message to `recipient_did` and
+    /// send it via the mediator, **without** awaiting a reply. Used for the
+    /// delegated step-up push — the approver's device replies later via a
+    /// separate `approve-response` call, not as a DIDComm reply on this thread.
+    ///
+    /// `_listener_id` is retained for call-site parity; outbound routes through
+    /// the service's current primary transport.
+    pub async fn send_oneway(
+        &self,
+        _listener_id: &str,
+        recipient_did: &str,
+        msg_type: &str,
+        body: serde_json::Value,
+    ) -> Result<(), AppError> {
+        let inner = self.inner()?;
+        let (_msg_id, packed) = Self::pack(inner, recipient_did, msg_type, body, None).await?;
+        inner
+            .service
+            .send(recipient_did, packed, Delivery::BestEffort)
             .await
             .map_err(|e| bad_gateway_error(format!("failed to send message: {e}")))?;
         Ok(())
     }
 
-    /// Like [`send_and_wait`](Self::send_and_wait) but uses the
-    /// caller-supplied `listener_id` instead of `self.listener_id`.
-    /// Required when the VTA holds multiple listeners (e.g. during
-    /// a mediator migration drain window) — outbound messages must
-    /// be sent through a specific listener and the response routed
-    /// back via the same listener's pending-map entry.
+    /// Send a DIDComm message and await the correlated reply, validating it
+    /// against `expected_type` / `problem_report_type` exactly as before.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn send_and_wait(
+        &self,
+        server_did: &str,
+        msg_type: &str,
+        body: serde_json::Value,
+        expected_type: &str,
+        problem_report_type: &str,
+        timeout_secs: u64,
+    ) -> Result<Message, AppError> {
+        let inner = self.inner()?;
+        let (msg_id, packed) =
+            Self::pack(inner, server_did, msg_type, body, Some(timeout_secs)).await?;
+        // The outbound message id IS the correlation thread id: the reply
+        // threads to it (`thid == request.id`), and the delivery dispatcher
+        // demuxes the reply to this waiter by that thread id.
+        let received = inner
+            .service
+            .request(
+                server_did,
+                packed,
+                &msg_id,
+                Duration::from_secs(timeout_secs),
+            )
+            .await
+            .map_err(|e| bad_gateway_error(format!("failed to send message: {e}")))?;
+        Self::validate_reply(received.payload, expected_type, problem_report_type)
+    }
+
+    /// Like [`send_and_wait`](Self::send_and_wait) but sends over a **named**
+    /// (non-primary) installed transport — the candidate mediator being proven
+    /// during a migration handshake — while still awaiting the correlated reply
+    /// on the merged dispatcher.
     #[allow(clippy::too_many_arguments)]
     pub async fn send_and_wait_via(
         &self,
@@ -157,148 +255,39 @@ impl DIDCommBridge {
         problem_report_type: &str,
         timeout_secs: u64,
     ) -> Result<Message, AppError> {
-        let service = self
+        let inner = self.inner()?;
+        let (msg_id, packed) =
+            Self::pack(inner, recipient_did, msg_type, body, Some(timeout_secs)).await?;
+        let received = inner
             .service
-            .get()
-            .ok_or_else(|| AppError::Internal("DIDComm service not initialized".into()))?;
-
-        let vta_did = service.listener_did(listener_id).await.ok_or_else(|| {
-            AppError::Internal(format!(
-                "listener '{listener_id}' not found in DIDComm service",
-            ))
-        })?;
-
-        let msg_id = uuid::Uuid::new_v4().to_string();
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs();
-        let msg = Message::build(msg_id.clone(), msg_type.to_string(), body)
-            .from(vta_did.clone())
-            .to(recipient_did.to_string())
-            .created_time(now)
-            .expires_time(now + timeout_secs)
-            .finalize();
-
-        let (tx, rx) = oneshot::channel();
-        self.pending.lock().unwrap().insert(msg_id.clone(), tx);
-
-        service
-            .send_message_with_retry(listener_id, msg, recipient_did, 3, Duration::from_secs(2))
-            .await
-            .map_err(|e| {
-                self.pending.lock().unwrap().remove(&msg_id);
-                bad_gateway_error(format!("failed to send message: {e}"))
-            })?;
-
-        let response = tokio::time::timeout(Duration::from_secs(timeout_secs), rx)
-            .await
-            .map_err(|_| {
-                self.pending.lock().unwrap().remove(&msg_id);
-                bad_gateway_error("timeout waiting for DIDComm response".to_string())
-            })?
-            .map_err(|_| bad_gateway_error("pending request channel dropped".to_string()))?;
-
-        if response.typ == problem_report_type || response.typ == PROBLEM_REPORT_TYPE {
-            let (code, comment) = extract_problem_report(&response.body);
-            return Err(problem_report_to_app_error(&code, &comment));
-        }
-
-        if response.typ != expected_type {
-            return Err(bad_gateway_error(format!(
-                "unexpected response type: expected {expected_type}, got {}",
-                response.typ
-            )));
-        }
-
-        Ok(response)
-    }
-
-    /// Try to complete a pending outbound request. Returns true if the
-    /// message was routed to a waiting [`Self::send_and_wait`] caller.
-    pub fn try_complete(&self, msg: &Message) -> bool {
-        if let Some(thid) = &msg.thid
-            && let Some(tx) = self.pending.lock().unwrap().remove(thid)
-        {
-            let _ = tx.send(msg.clone());
-            return true;
-        }
-        false
-    }
-
-    /// Send a DIDComm message and wait for a response matching the thread ID.
-    #[allow(clippy::too_many_arguments)]
-    pub async fn send_and_wait(
-        &self,
-        server_did: &str,
-        msg_type: &str,
-        body: serde_json::Value,
-        expected_type: &str,
-        problem_report_type: &str,
-        timeout_secs: u64,
-    ) -> Result<Message, AppError> {
-        let service = self
-            .service
-            .get()
-            .ok_or_else(|| AppError::Internal("DIDComm service not initialized".into()))?;
-
-        let vta_did = service
-            .listener_did(&self.listener_id)
-            .await
-            .ok_or_else(|| {
-                AppError::Internal(format!(
-                    "listener '{}' not found in DIDComm service",
-                    self.listener_id
-                ))
-            })?;
-
-        let msg_id = uuid::Uuid::new_v4().to_string();
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs();
-        let msg = Message::build(msg_id.clone(), msg_type.to_string(), body)
-            .from(vta_did.clone())
-            .to(server_did.to_string())
-            .created_time(now)
-            .expires_time(now + timeout_secs)
-            .finalize();
-
-        // Register pending before sending
-        let (tx, rx) = oneshot::channel();
-        self.pending.lock().unwrap().insert(msg_id.clone(), tx);
-
-        // Send via the DIDComm service with retry on reconnect
-        service
-            .send_message_with_retry(
-                &self.listener_id,
-                msg,
-                server_did,
-                3,
-                Duration::from_secs(2),
+            .request_via(
+                listener_id,
+                recipient_did,
+                packed,
+                &msg_id,
+                Duration::from_secs(timeout_secs),
             )
             .await
-            .map_err(|e| {
-                self.pending.lock().unwrap().remove(&msg_id);
-                bad_gateway_error(format!("failed to send message: {e}"))
-            })?;
+            .map_err(|e| bad_gateway_error(format!("failed to send message: {e}")))?;
+        Self::validate_reply(received.payload, expected_type, problem_report_type)
+    }
 
-        // Wait for response with timeout
-        let response = tokio::time::timeout(Duration::from_secs(timeout_secs), rx)
-            .await
-            .map_err(|_| {
-                self.pending.lock().unwrap().remove(&msg_id);
-                bad_gateway_error("timeout waiting for DIDComm response".to_string())
-            })?
-            .map_err(|_| bad_gateway_error("pending request channel dropped".to_string()))?;
+    /// Parse a delivery-layer reply payload (the full plaintext DIDComm message
+    /// JSON) and validate it: a problem-report maps through
+    /// [`problem_report_to_app_error`]; any non-`expected_type` reply is a 502.
+    fn validate_reply(
+        payload: Vec<u8>,
+        expected_type: &str,
+        problem_report_type: &str,
+    ) -> Result<Message, AppError> {
+        let response: Message = serde_json::from_slice(&payload)
+            .map_err(|e| bad_gateway_error(format!("failed to parse DIDComm response: {e}")))?;
 
-        // Check for problem report
         if response.typ == problem_report_type || response.typ == PROBLEM_REPORT_TYPE {
             let (code, comment) = extract_problem_report(&response.body);
             return Err(problem_report_to_app_error(&code, &comment));
         }
 
-        // Verify expected type
         if response.typ != expected_type {
             return Err(bad_gateway_error(format!(
                 "unexpected response type: expected {expected_type}, got {}",

--- a/vta-service/src/keyspaces.rs
+++ b/vta-service/src/keyspaces.rs
@@ -82,6 +82,14 @@ pub const POLICY: &str = "policy";
 /// Durable operator-facing security state → [`BACKED_UP`].
 pub const TASK_CONSENT: &str = "task_consent";
 
+/// Durable reliable-messaging outbox backing
+/// [`vti_common::outbox_store::VtiOutboxStore`] for the delivery-layer
+/// `MessagingService` (D2 P2a cut-over). Holds `Guaranteed`-delivery outbox
+/// entries; dormant in P2a (all current sends are `BestEffort`) but wired so
+/// the drain/confirmation loops persist across restarts once P2b adds
+/// guaranteed VTA pushes. Runtime state, not backed up.
+pub const OUTBOX: &str = "outbox";
+
 /// Every production keyspace. Partitioned by [`BACKED_UP`] +
 /// [`EXCLUDED_FROM_BACKUP`]; the [`tests::backup_partition_is_total`] guard
 /// asserts the partition stays exhaustive so a newly-added keyspace can't be
@@ -110,6 +118,7 @@ pub const ALL: &[&str] = &[
     MEMORY,
     POLICY,
     TASK_CONSENT,
+    OUTBOX,
 ];
 
 /// Keyspaces whose contents a full `export_backup` captures (as typed
@@ -156,6 +165,9 @@ pub const EXCLUDED_FROM_BACKUP: &[&str] = &[
     // Durable VTA-issued holder credentials. Like [`VAULT`], a known backup
     // gap — a backup-fidelity follow-up should move it into [`BACKED_UP`].
     ISSUED_CREDENTIALS,
+    // Reliable-messaging outbox: runtime delivery state, re-driven from live
+    // sends, not part of a state backup.
+    OUTBOX,
 ];
 
 /// Test-only keyspaces (descriptor sweeper tests open isolated keyspaces so a

--- a/vta-service/src/messaging/drain_sweeper.rs
+++ b/vta-service/src/messaging/drain_sweeper.rs
@@ -11,8 +11,9 @@
 //!    drop the in-memory drain entry, remove it from the keyspace,
 //!    and emit [`vti_common::telemetry::TelemetryKind::MediatorDrainExpire`].
 //! 2. Sends the mediator DID over a `tokio::sync::mpsc` channel so
-//!    whoever owns the upstream listener (the server bootstrap)
-//!    can call `DIDCommService::remove_listener`.
+//!    whoever owns the delivery-layer service (the server bootstrap)
+//!    can call `MessagingService::remove_transport` to drop the
+//!    drained mediator's transport.
 //!
 //! This keeps the sweeper deterministically testable without standing
 //! up the full DIDComm stack.

--- a/vta-service/src/messaging/handlers.rs
+++ b/vta-service/src/messaging/handlers.rs
@@ -10,11 +10,11 @@ use std::sync::Arc;
 
 use base64::Engine;
 
-use affinidi_messaging_didcomm::Message;
-use affinidi_messaging_didcomm_service::{
+use crate::messaging::shim::{
     DIDCommResponse, DIDCommServiceError, Extension, HandlerContext, ProblemReport,
     ServiceProblemReport,
 };
+use affinidi_messaging_didcomm::Message;
 use tracing::{info, warn};
 
 use crate::acl::Role;

--- a/vta-service/src/messaging/handlers_protocol.rs
+++ b/vta-service/src/messaging/handlers_protocol.rs
@@ -16,11 +16,11 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use affinidi_messaging_didcomm::Message;
-use affinidi_messaging_didcomm_service::{
+use crate::messaging::shim::{
     DIDCommResponse, DIDCommServiceError, Extension, HandlerContext, ProblemReport,
     ServiceProblemReport,
 };
+use affinidi_messaging_didcomm::Message;
 use chrono::{DateTime, Utc};
 use serde::Deserialize;
 

--- a/vta-service/src/messaging/live_prover.rs
+++ b/vta-service/src/messaging/live_prover.rs
@@ -1,46 +1,39 @@
-//! Live `DIDCommService`-backed [`ListenerProver`] implementation.
+//! Live delivery-layer [`ListenerProver`] implementation.
 //!
 //! Spec: `docs/05-design-notes/didcomm-protocol-management.md`
 //! "Mediator handshake before promotion", steps 2–5.
 //!
-//! Steps performed against a running
-//! `affinidi_messaging_didcomm_service::DIDCommService`:
+//! **D2 P2a cut-over**: this used to drive the framework `DIDCommService`
+//! (`add_listener` → `wait_connected` → trust-ping → `remove_listener`). It now
+//! drives the delivery-layer [`MessagingService`] held by the outbound
+//! [`DIDCommBridge`]:
 //!
 //! 1. (Step 1, DID resolution, is performed by
-//!    [`super::handshake::mediator_handshake`] before this prover
-//!    is invoked.)
-//! 2. **Connect + authenticate + register**:
-//!    `service.add_listener(ListenerConfig { id: mediator_did, … })`.
-//!    The upstream library handles the WebSocket + DIDComm
-//!    challenge/response.
-//! 3. **Wait for connection**:
-//!    `service.wait_connected(mediator_did, timeout)`.
-//! 4. **Trust-ping**: build a
-//!    `https://didcomm.org/trust-ping/2.0/ping` from the VTA's DID
-//!    to itself, routed via the new mediator. Sent through
-//!    [`DIDCommBridge::send_and_wait_via`]; response routes back
-//!    through the bridge's thid pending-map.
-//! 5. **Wait for pong**: timeout-bounded.
+//!    [`super::handshake::mediator_handshake`] before this prover is invoked.)
+//! 2. **Connect + register**: build a [`DidCommTransport`] for the candidate
+//!    mediator (a fresh [`ATMProfile`] + bounded websocket on the VTA's existing
+//!    ATM, whose secrets resolver already holds the signing/KA keys) and
+//!    `add_transport(candidate_id, …)` — it starts receiving immediately via the
+//!    merged dispatcher but is NOT yet the outbound primary.
+//! 3. **Trust-ping**: `request_via(candidate_id, self_vta_did, ping, thid,
+//!    timeout)` sends the ping over the CANDIDATE transport and awaits the pong
+//!    on the merged dispatcher (the main inbound loop answers the self-ping).
+//! 4. On success the candidate transport is left installed for the caller
+//!    (`update_didcomm`) to `promote`; on any-stage failure it is
+//!    `remove_transport`-ed so the registry doesn't promote a mediator the VTA
+//!    can't reach.
 //!
-//! On any-stage failure, the listener is removed via
-//! `service.remove_listener` so the registry doesn't promote a
-//! mediator the VTA can't actually reach.
-//!
-//! The construction lives behind the `didcomm` feature gate so
-//! non-DIDComm builds (e.g. REST-only enclave variants) don't
-//! pull in the upstream service surface.
+//! Behind the `didcomm` feature gate so non-DIDComm builds don't pull in the
+//! delivery-layer surface.
 
 #![cfg(feature = "didcomm")]
 
 use std::sync::Arc;
 use std::time::Duration;
 
-use affinidi_messaging_didcomm_service::{
-    DIDCommService, ListenerConfig, RestartPolicy, RetryConfig,
-};
-use affinidi_tdk::common::config::TDKConfig;
-use affinidi_tdk::secrets_resolver::secrets::Secret;
-use affinidi_tdk_common::profiles::TDKProfile;
+use affinidi_messaging_core::MessageTransport;
+use affinidi_tdk::messaging::DidCommTransport;
+use affinidi_tdk::messaging::profiles::ATMProfile;
 use async_trait::async_trait;
 use serde_json::json;
 
@@ -49,51 +42,27 @@ use crate::messaging::handshake::{
     HandshakeStage, ListenerProver, ProverFailure, ResolvedMediator,
 };
 
-/// Trust-ping protocol identifiers from didcomm.org. The upstream
-/// library re-exports these constants but redeclaring them here
-/// keeps this module's intent self-contained.
+/// Trust-ping protocol identifiers from didcomm.org.
 const TRUST_PING_TYPE: &str = "https://didcomm.org/trust-ping/2.0/ping";
 const TRUST_PING_RESPONSE_TYPE: &str = "https://didcomm.org/trust-ping/2.0/ping-response";
 const PROBLEM_REPORT_TYPE: &str = "https://didcomm.org/report-problem/2.0/problem-report";
 
-/// Default reconnect backoff for a listener added during
-/// handshake. The values match the spec's "1s → 60s, factor 2.0"
-/// reconnect contract from the registry doc.
-fn default_backoff() -> RetryConfig {
-    RetryConfig {
-        initial_delay_secs: 1,
-        max_delay_secs: 60,
-    }
-}
-
-/// Builds a [`ListenerConfig`] for the new mediator. The VTA's
-/// secrets and TDK config are caller-supplied (operator's
-/// responsibility — they live in `AppState`'s secrets resolver).
-pub trait ListenerConfigBuilder: Send + Sync {
-    fn build(&self, resolved: &ResolvedMediator) -> ListenerConfig;
-}
-
-/// Live prover: drives the upstream `DIDCommService` through the
-/// real handshake. Use this when DIDComm is already running (i.e.
-/// for `mediator migrate` and `mediator rollback`); use
-/// [`super::handshake::AlwaysOkProver`] when DIDComm isn't running
-/// yet (i.e. for the first `services enable didcomm`).
+/// Live prover over the delivery-layer [`MessagingService`] (via the outbound
+/// [`DIDCommBridge`]). Use when DIDComm is already running (`mediator migrate`,
+/// `mediator rollback`); use [`super::handshake::AlwaysOkProver`] when DIDComm
+/// isn't running yet (first `services enable didcomm`, which goes through
+/// [`super::transient_handshake`]).
 pub struct DIDCommServiceProver {
-    service: DIDCommService,
     bridge: Arc<DIDCommBridge>,
-    config_builder: Arc<dyn ListenerConfigBuilder>,
+    #[allow(dead_code)]
+    vta_did: String,
 }
 
 impl DIDCommServiceProver {
-    pub fn new(
-        service: DIDCommService,
-        bridge: Arc<DIDCommBridge>,
-        config_builder: Arc<dyn ListenerConfigBuilder>,
-    ) -> Self {
+    pub fn new(bridge: Arc<DIDCommBridge>, vta_did: impl Into<String>) -> Self {
         Self {
-            service,
             bridge,
-            config_builder,
+            vta_did: vta_did.into(),
         }
     }
 }
@@ -106,38 +75,75 @@ impl ListenerProver for DIDCommServiceProver {
         vta_did: &str,
         timeout: Duration,
     ) -> Result<(), ProverFailure> {
-        let listener_id = resolved.mediator_did.clone();
-
-        // Step 2-3: connect + authenticate + register the listener.
-        let config = self.config_builder.build(resolved);
-        if let Err(e) = self.service.add_listener(config).await {
-            return Err(ProverFailure {
+        let service = self
+            .bridge
+            .messaging_handle()
+            .ok_or_else(|| ProverFailure {
                 stage: HandshakeStage::Connect,
-                cause: format!("add_listener failed: {e}"),
-            });
-        }
-        if let Err(e) = self.service.wait_connected(&listener_id, timeout).await {
-            // Best-effort cleanup: the listener was added but is
-            // not connected. Remove so the registry doesn't see a
-            // ghost.
-            let _ = self.service.remove_listener(&listener_id).await;
-            return Err(ProverFailure {
-                stage: HandshakeStage::Authenticate,
-                cause: format!("wait_connected failed: {e}"),
-            });
-        }
+                cause: "delivery-layer messaging service is not running".to_string(),
+            })?;
+        let atm = self.bridge.atm().ok_or_else(|| ProverFailure {
+            stage: HandshakeStage::Connect,
+            cause: "ATM unavailable (messaging not started)".to_string(),
+        })?;
+        let candidate_id = resolved.mediator_did.clone();
 
-        // Step 4-5: trust-ping the VTA via the new mediator. The
-        // bridge's thid pending-map routes the pong back to us.
+        // Step 2: build a candidate transport + bounded websocket. The ATM's
+        // secrets resolver already holds the VTA's signing/KA keys, so the
+        // candidate profile needs no fresh secrets.
+        let profile = match ATMProfile::new(
+            &atm,
+            Some(candidate_id.clone()),
+            vta_did.to_string(),
+            Some(candidate_id.clone()),
+        )
+        .await
+        {
+            Ok(p) => Arc::new(p),
+            Err(e) => {
+                return Err(ProverFailure {
+                    stage: HandshakeStage::Connect,
+                    cause: format!("create candidate profile: {e}"),
+                });
+            }
+        };
+        match tokio::time::timeout(timeout, atm.profile_enable_websocket(&profile)).await {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => {
+                return Err(ProverFailure {
+                    stage: HandshakeStage::Connect,
+                    cause: format!("enable candidate websocket: {e}"),
+                });
+            }
+            Err(_) => {
+                return Err(ProverFailure {
+                    stage: HandshakeStage::Connect,
+                    cause: "timeout enabling candidate mediator websocket".to_string(),
+                });
+            }
+        }
+        let transport: Arc<dyn MessageTransport> =
+            match DidCommTransport::new(atm.clone(), profile.clone()).await {
+                Ok(t) => Arc::new(t),
+                Err(e) => {
+                    return Err(ProverFailure {
+                        stage: HandshakeStage::Connect,
+                        cause: format!("bind candidate DidComm transport: {e}"),
+                    });
+                }
+            };
+        service.add_transport(candidate_id.clone(), transport);
+
+        // Steps 4-5: trust-ping the VTA via the candidate transport; the main
+        // inbound loop answers the self-ping and the pong routes back through the
+        // merged dispatcher, demuxed to this waiter by thread id.
         let result = self
             .bridge
             .send_and_wait_via(
-                &listener_id,
-                vta_did, // recipient = self; the mediator forwards back via the listener
+                &candidate_id,
+                vta_did, // recipient = self; the mediator forwards it back
                 TRUST_PING_TYPE,
-                json!({
-                    "response_requested": true,
-                }),
+                json!({ "response_requested": true }),
                 TRUST_PING_RESPONSE_TYPE,
                 PROBLEM_REPORT_TYPE,
                 timeout.as_secs(),
@@ -145,138 +151,48 @@ impl ListenerProver for DIDCommServiceProver {
             .await;
 
         if let Err(e) = result {
-            let _ = self.service.remove_listener(&listener_id).await;
+            // Best-effort cleanup so the registry doesn't promote an
+            // unreachable mediator.
+            service.remove_transport(&candidate_id);
             return Err(ProverFailure {
                 stage: HandshakeStage::TrustPing,
                 cause: format!("trust-ping round-trip failed: {e}"),
             });
         }
 
-        // Listener stays up — caller (`update_didcomm`) will
-        // promote this mediator in the registry on success. On
-        // any subsequent operation-level failure, the route layer
-        // is responsible for cleanup; that's a known v1 gap (no
-        // post-handshake rollback path).
+        // The candidate transport stays installed — the caller (`update_didcomm`)
+        // will `promote` it in the registry + delivery service on success.
         Ok(())
     }
 }
 
-/// Construct a `RestartPolicy::Always` matching the spec's
-/// reconnect-with-backoff contract. Exposed so the
-/// [`ListenerConfigBuilder`] impl can apply it consistently
-/// without duplicating the constants.
-pub fn default_restart_policy() -> RestartPolicy {
-    RestartPolicy::Always {
-        backoff: default_backoff(),
-    }
-}
-
-/// Best-effort assembly of a [`DIDCommServiceProver`] from the
-/// raw prerequisites that live on `AppState` / `VtaState`. Returns
-/// `None` when any required piece is missing — the caller falls
-/// back to [`super::handshake::AlwaysOkProver`] in that case.
+/// Best-effort assembly of a [`DIDCommServiceProver`] from the outbound bridge.
 ///
-/// Centralised here so REST and DIDComm transport handlers (and
-/// future surfaces) build the prover the same way without each
-/// site copying the secrets-resolver / vm-id plumbing.
+/// Returns `None` when the delivery-layer messaging service isn't running yet
+/// (the caller then falls back to [`super::handshake::AlwaysOkProver`]). The
+/// `secrets_resolver` / vm-id parameters are retained for call-site parity —
+/// the ATM behind the bridge already carries the VTA's keys, so the prover no
+/// longer needs them threaded through.
 pub async fn try_build_from_parts(
     bridge: &Arc<DIDCommBridge>,
     vta_did: &str,
-    secrets_resolver: &Arc<affinidi_tdk::secrets_resolver::ThreadedSecretsResolver>,
-    signing_vm_id: &str,
-    ka_vm_id: &str,
+    _secrets_resolver: &Arc<affinidi_tdk::secrets_resolver::ThreadedSecretsResolver>,
+    _signing_vm_id: &str,
+    _ka_vm_id: &str,
 ) -> Option<DIDCommServiceProver> {
-    use affinidi_tdk::secrets_resolver::SecretsResolver;
-
-    let service = bridge.try_get_service()?;
-
-    let mut secrets = Vec::with_capacity(2);
-    if let Some(s) = secrets_resolver.get_secret(signing_vm_id).await {
-        secrets.push(s);
-    }
-    if let Some(s) = secrets_resolver.get_secret(ka_vm_id).await {
-        secrets.push(s);
-    }
-    if secrets.is_empty() {
-        return None;
-    }
-
-    let builder = Arc::new(StaticListenerConfigBuilder::new(vta_did, secrets, None));
-    Some(DIDCommServiceProver::new(
-        service,
-        Arc::clone(bridge),
-        builder,
-    ))
-}
-
-/// Pre-baked listener-config builder that captures the VTA's DID,
-/// secrets, and TDK config at construction time. The route layer
-/// builds one of these per migrate request from the secrets it
-/// pulls out of `AppState.secrets_resolver`.
-pub struct StaticListenerConfigBuilder {
-    vta_did: String,
-    secrets: Vec<Secret>,
-    tdk_config: Option<TDKConfig>,
-}
-
-impl StaticListenerConfigBuilder {
-    pub fn new(
-        vta_did: impl Into<String>,
-        secrets: Vec<Secret>,
-        tdk_config: Option<TDKConfig>,
-    ) -> Self {
-        Self {
-            vta_did: vta_did.into(),
-            secrets,
-            tdk_config,
-        }
-    }
-}
-
-impl ListenerConfigBuilder for StaticListenerConfigBuilder {
-    fn build(&self, resolved: &ResolvedMediator) -> ListenerConfig {
-        let profile = TDKProfile::new(
-            "VTA",
-            &self.vta_did,
-            Some(&resolved.mediator_did),
-            self.secrets.clone(),
-        );
-        ListenerConfig {
-            id: resolved.mediator_did.clone(),
-            profile,
-            restart_policy: default_restart_policy(),
-            tdk_config: self.tdk_config.clone(),
-            ..Default::default()
-        }
-    }
+    // Only meaningful once the delivery-layer service is published.
+    bridge.messaging_handle()?;
+    Some(DIDCommServiceProver::new(Arc::clone(bridge), vta_did))
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use crate::messaging::handshake::HandshakeStage;
 
-    /// The construction shape compiles. The trait-object holding,
-    /// the listener-config-builder injection, and the failure
-    /// stages are wired correctly. End-to-end behaviour against
-    /// a real DIDCommService requires the in-process mock-mediator
-    /// fixture, tracked separately.
+    /// Sentinel: the failure stages this prover produces are still present.
     #[test]
     fn handshake_stages_used_by_prover() {
-        // Sentinel test: catches a future refactor that drops
-        // any of the stages this module produces.
-        let stages = [
-            HandshakeStage::Connect,
-            HandshakeStage::Authenticate,
-            HandshakeStage::TrustPing,
-        ];
-        assert_eq!(stages.len(), 3);
-    }
-
-    #[test]
-    fn default_backoff_matches_spec() {
-        let b = default_backoff();
-        assert_eq!(b.initial_delay_secs, 1);
-        assert_eq!(b.max_delay_secs, 60);
+        let stages = [HandshakeStage::Connect, HandshakeStage::TrustPing];
+        assert_eq!(stages.len(), 2);
     }
 }

--- a/vta-service/src/messaging/mod.rs
+++ b/vta-service/src/messaging/mod.rs
@@ -9,6 +9,12 @@ pub mod handshake;
 pub mod live_prover;
 pub mod registry;
 pub mod router;
+/// Delivery-layer construction + protocol-routed inbound loop (D2 P2a).
+#[cfg(feature = "didcomm")]
+pub mod service;
+/// Local replacements for the `affinidi-messaging-didcomm-service` types the
+/// DIDComm handlers depend on (D2 P2a cut-over). See [`shim`].
+pub mod shim;
 #[cfg(all(feature = "webvh", feature = "didcomm"))]
 pub mod transient_handshake;
 #[cfg(feature = "tsp")]

--- a/vta-service/src/messaging/router.rs
+++ b/vta-service/src/messaging/router.rs
@@ -1,42 +1,65 @@
-//! DIDComm message router built on `affinidi-messaging-didcomm-service`.
+//! DIDComm message dispatch for the delivery-layer inbound loop.
 //!
-//! Replaces the manual `dispatch_message()` match statement with a typed
-//! Router that maps message types to handler functions. Shared state is
-//! injected via `Extension<Arc<VtaState>>`.
+//! **D2 P2a cut-over**: this used to build an
+//! `affinidi-messaging-didcomm-service` `Router` (type-routed handler table +
+//! `MessagePolicy` middleware) wrapped in a `BridgeHandler`. That framework is
+//! gone. [`dispatch`] is now a plain `msg.typ` match that calls the same ~50
+//! handler functions directly — they are unchanged, taking
+//! `(HandlerContext, Message, Extension<T>)` from [`crate::messaging::shim`].
+//! The [`crate::server`] inbound loop drives it off
+//! [`affinidi_messaging_delivery::MessagingService::subscribe`].
+//!
+//! The `MessagePolicy` auth gate (`require_encrypted` + verified-sender-or-none)
+//! now lives in the inbound loop, which sets `Message::from` to the
+//! cryptographically-authenticated sender before calling [`dispatch`] (the
+//! `#620` anti-spoof guarantee), so every handler's `auth_from_message` /
+//! `ctx.sender_did` sees only a proven sender.
 
 use std::sync::Arc;
 
-use affinidi_messaging_didcomm_service::{
-    DIDCommServiceError, MESSAGE_PICKUP_STATUS_TYPE, MessagePolicy, RequestLogging, Router,
-    TRUST_PING_TYPE, handler_fn, ignore_handler, trust_ping_handler,
-};
+use affinidi_messaging_didcomm::Message;
 use tokio::sync::RwLock;
-use tracing::debug;
 
 use affinidi_did_resolver_cache_sdk::DIDCacheClient;
 
 use crate::config::AppConfig;
 use crate::didcomm_bridge::DIDCommBridge;
 use crate::keys::seed_store::SeedStore;
+use crate::messaging::shim::{DIDCommResponse, DIDCommServiceError, HandlerContext, ProblemReport};
+#[cfg(feature = "didcomm")]
+use crate::messaging::shim::{Extension, ServiceProblemReport};
 use crate::server::AppState;
 use crate::store::KeyspaceHandle;
 
+#[cfg(feature = "didcomm")]
 use super::handlers;
 
-#[cfg(feature = "tee")]
+#[cfg(all(feature = "tee", feature = "didcomm"))]
 use vta_sdk::protocols::attestation_management;
-#[cfg(feature = "webvh")]
+#[cfg(all(feature = "webvh", feature = "didcomm"))]
 use vta_sdk::protocols::did_management;
-#[cfg(feature = "webvh")]
+#[cfg(all(feature = "webvh", feature = "didcomm"))]
 use vta_sdk::protocols::protocol_management;
 // `provision-integration` is unconditionally enabled via the
 // `vta-sdk` feature list in vta-service's Cargo.toml — no cfg gate.
-#[cfg(feature = "webvh")]
+#[cfg(all(feature = "webvh", feature = "didcomm"))]
 use vta_sdk::protocols::provision_integration_management;
+#[cfg(feature = "didcomm")]
 use vta_sdk::protocols::{
     self, acl_management, audit_management, context_management, credential_exchange,
     key_management, seed_management, vta_management,
 };
+
+/// Trust-ping protocol identifiers (was the framework's `TRUST_PING_TYPE` /
+/// `TRUST_PONG_TYPE`). Re-declared locally now the framework is gone.
+#[cfg(feature = "didcomm")]
+const TRUST_PING_TYPE: &str = "https://didcomm.org/trust-ping/2.0/ping";
+#[cfg(feature = "didcomm")]
+const TRUST_PONG_TYPE: &str = "https://didcomm.org/trust-ping/2.0/ping-response";
+/// The high-frequency message-pickup status heartbeat (was the framework's
+/// `MESSAGE_PICKUP_STATUS_TYPE`, routed to `ignore_handler`). Dispatched as a
+/// silent no-op.
+pub(crate) const MESSAGE_PICKUP_STATUS_TYPE: &str = "https://didcomm.org/messagepickup/3.0/status";
 
 /// Shared state injected into all DIDComm handlers via `Extension<Arc<VtaState>>`.
 #[derive(Clone)]
@@ -195,435 +218,350 @@ impl From<&AppState> for VtaState {
 }
 
 // ---------------------------------------------------------------------------
-// BridgeHandler — wraps the Router to intercept outbound-response routing
+// Type-routed dispatch (was the framework `Router` + `BridgeHandler`)
 // ---------------------------------------------------------------------------
 
-/// Handler wrapper that bridges the DIDComm listener's ATM to the
-/// outbound [`DIDCommBridge`].
-///
-/// On every inbound message this handler:
-/// 1. Captures the listener's ATM/profile so the bridge can reuse the
-///    same mediator connection for outbound sends.
-/// 2. Checks if the message completes a pending outbound request
-///    (via [`DIDCommBridge::try_complete`]). If so, the message is
-///    consumed and not dispatched to the inner Router.
-/// 3. Otherwise delegates to the inner Router for normal handler dispatch.
-pub struct BridgeHandler {
-    inner: Router,
-    bridge: Arc<DIDCommBridge>,
+/// The handler return shape (unchanged from the framework): a reply, no reply,
+/// or a handler error the dispatch renders as an `internal-error`
+/// problem-report.
+#[cfg(feature = "didcomm")]
+type HandlerResult = Result<Option<DIDCommResponse>, DIDCommServiceError>;
+
+/// Fold a handler's `Result` into the reply the loop sends. A handler `Err`
+/// becomes a threaded `internal-error` problem-report (was the framework's
+/// `DefaultErrorHandler::on_error`).
+#[cfg(feature = "didcomm")]
+fn finish(result: HandlerResult) -> Option<DIDCommResponse> {
+    match result {
+        Ok(opt) => opt,
+        Err(e) => Some(DIDCommResponse::problem_report(
+            ProblemReport::internal_error(e.to_string()),
+        )),
+    }
 }
 
-#[async_trait::async_trait]
-impl affinidi_messaging_didcomm_service::DIDCommHandler for BridgeHandler {
-    async fn handle(
-        &self,
-        ctx: affinidi_messaging_didcomm_service::HandlerContext,
-        message: affinidi_messaging_didcomm::Message,
-        meta: affinidi_messaging_didcomm::UnpackMetadata,
-    ) -> Result<Option<affinidi_messaging_didcomm_service::DIDCommResponse>, DIDCommServiceError>
-    {
-        // Route responses to pending outbound requests before normal dispatch.
-        if self.bridge.try_complete(&message) {
-            return Ok(None);
-        }
+/// Local trust-ping responder (was the framework `trust_ping_handler`). Replies
+/// a `trust-ping/2.0/ping-response` on the ping's thread unless the ping didn't
+/// request a response or has no authenticated sender to reply to.
+#[cfg(feature = "didcomm")]
+fn trust_ping_reply(msg: &Message, sender_did: Option<&str>) -> Option<DIDCommResponse> {
+    #[derive(serde::Deserialize)]
+    struct PingBody {
+        #[serde(default = "default_true")]
+        response_requested: bool,
+    }
+    fn default_true() -> bool {
+        true
+    }
+    let body: PingBody = serde_json::from_value(msg.body.clone()).unwrap_or(PingBody {
+        response_requested: true,
+    });
+    if !body.response_requested {
+        return None;
+    }
+    // Only pong an authenticated ping (no reply to a spoofed/anonymous sender).
+    sender_did?;
+    Some(DIDCommResponse::new(TRUST_PONG_TYPE, serde_json::Value::Null).thid(msg.id.clone()))
+}
 
-        // Log unmatched responses (likely stale messages from a previous session)
-        if message.thid.is_some() {
-            debug!(
-                msg_type = %message.typ,
-                thid = message.thid.as_deref().unwrap_or(""),
-                from = message.from.as_deref().unwrap_or("unknown"),
-                "unmatched response — no pending request for thread (stale message)"
+/// Route one inbound (authenticated-sender-stamped) DIDComm message to its
+/// handler, mirroring the framework route list (same URIs, same feature gates).
+///
+/// `ctx.sender_did` and `msg.from` are the cryptographically-authenticated
+/// sender (or `None`); handlers authorize on those, never on the raw wire
+/// `from`. The `_` arm is the fallback (`handle_unknown`).
+#[cfg(feature = "didcomm")]
+pub async fn dispatch(
+    msg: Message,
+    ctx: HandlerContext,
+    vta_state: Arc<VtaState>,
+    app_state: AppState,
+) -> Option<DIDCommResponse> {
+    let t = msg.typ.clone();
+    let t = t.as_str();
+
+    // Message-pickup status heartbeat: silent no-op (was `ignore_handler`).
+    if t == MESSAGE_PICKUP_STATUS_TYPE {
+        return None;
+    }
+    // Trust-ping (was the built-in `trust_ping_handler`).
+    if t == TRUST_PING_TYPE {
+        return trust_ping_reply(&msg, ctx.sender_did.as_deref());
+    }
+
+    // ── Trust-Tasks envelope (AppState) ──────────────────────────────
+    if t == handlers::TRUST_TASK_ENVELOPE_TYPE {
+        return finish(handlers::handle_trust_task(ctx, msg, Extension(app_state)).await);
+    }
+
+    // ── Key management ───────────────────────────────────────────────
+    if t == key_management::CREATE_KEY {
+        return finish(handlers::handle_create_key(ctx, msg, Extension(vta_state)).await);
+    }
+    if t == key_management::GET_KEY {
+        return finish(handlers::handle_get_key(ctx, msg, Extension(vta_state)).await);
+    }
+    if t == key_management::LIST_KEYS {
+        return finish(handlers::handle_list_keys(ctx, msg, Extension(vta_state)).await);
+    }
+    if t == key_management::RENAME_KEY {
+        return finish(handlers::handle_rename_key(ctx, msg, Extension(vta_state)).await);
+    }
+    if t == key_management::REVOKE_KEY {
+        return finish(handlers::handle_revoke_key(ctx, msg, Extension(vta_state)).await);
+    }
+    if t == key_management::GET_KEY_SECRET {
+        return finish(handlers::handle_get_key_secret(ctx, msg, Extension(vta_state)).await);
+    }
+    if t == key_management::SIGN_REQUEST {
+        return finish(handlers::handle_sign_request(ctx, msg, Extension(vta_state)).await);
+    }
+
+    // ── Seed management ──────────────────────────────────────────────
+    if t == seed_management::LIST_SEEDS {
+        return finish(handlers::handle_list_seeds(ctx, msg, Extension(vta_state)).await);
+    }
+    if t == seed_management::ROTATE_SEED {
+        return finish(handlers::handle_rotate_seed(ctx, msg, Extension(vta_state)).await);
+    }
+
+    // ── Context management ───────────────────────────────────────────
+    if t == context_management::CREATE_CONTEXT {
+        return finish(handlers::handle_create_context(ctx, msg, Extension(vta_state)).await);
+    }
+    if t == context_management::GET_CONTEXT {
+        return finish(handlers::handle_get_context(ctx, msg, Extension(vta_state)).await);
+    }
+    if t == context_management::LIST_CONTEXTS {
+        return finish(handlers::handle_list_contexts(ctx, msg, Extension(vta_state)).await);
+    }
+    if t == context_management::UPDATE_CONTEXT {
+        return finish(handlers::handle_update_context(ctx, msg, Extension(vta_state)).await);
+    }
+    if t == context_management::UPDATE_CONTEXT_DID {
+        return finish(handlers::handle_update_context_did(ctx, msg, Extension(vta_state)).await);
+    }
+    if t == context_management::PREVIEW_DELETE_CONTEXT {
+        return finish(
+            handlers::handle_preview_delete_context(ctx, msg, Extension(vta_state)).await,
+        );
+    }
+    if t == context_management::DELETE_CONTEXT {
+        return finish(handlers::handle_delete_context(ctx, msg, Extension(vta_state)).await);
+    }
+
+    // ── ACL management ───────────────────────────────────────────────
+    if t == acl_management::CREATE_ACL {
+        return finish(handlers::handle_create_acl(ctx, msg, Extension(vta_state)).await);
+    }
+    if t == acl_management::GET_ACL {
+        return finish(handlers::handle_get_acl(ctx, msg, Extension(vta_state)).await);
+    }
+    if t == acl_management::LIST_ACL {
+        return finish(handlers::handle_list_acl(ctx, msg, Extension(vta_state)).await);
+    }
+    if t == acl_management::UPDATE_ACL {
+        return finish(handlers::handle_update_acl(ctx, msg, Extension(vta_state)).await);
+    }
+    if t == acl_management::DELETE_ACL {
+        return finish(handlers::handle_delete_acl(ctx, msg, Extension(vta_state)).await);
+    }
+    // Legacy FPN-private `swap-acl` + canonical Trust Task `acl/swap-key/0.1`
+    // both route to the same handler (dispatches on the incoming type).
+    if t == acl_management::SWAP_ACL || t == acl_management::ACL_SWAP_KEY {
+        return finish(handlers::handle_swap_acl(ctx, msg, Extension(vta_state)).await);
+    }
+
+    // ── Audit management ─────────────────────────────────────────────
+    if t == audit_management::LIST_LOGS {
+        return finish(handlers::handle_list_logs(ctx, msg, Extension(vta_state)).await);
+    }
+    if t == audit_management::GET_RETENTION {
+        return finish(handlers::handle_get_retention(ctx, msg, Extension(vta_state)).await);
+    }
+    if t == audit_management::UPDATE_RETENTION {
+        return finish(handlers::handle_update_retention(ctx, msg, Extension(vta_state)).await);
+    }
+
+    // ── VTA management ───────────────────────────────────────────────
+    if t == vta_management::GET_CONFIG {
+        return finish(handlers::handle_get_config(ctx, msg, Extension(vta_state)).await);
+    }
+    if t == vta_management::UPDATE_CONFIG {
+        return finish(handlers::handle_update_config(ctx, msg, Extension(vta_state)).await);
+    }
+    if t == protocols::PROBLEM_REPORT_TYPE {
+        return finish(handlers::handle_problem_report(ctx, msg).await);
+    }
+    if t == vta_management::RESTART {
+        return finish(handlers::handle_restart(ctx, msg, Extension(vta_state)).await);
+    }
+    if t == protocols::backup_management::EXPORT_BACKUP {
+        return finish(handlers::handle_backup_export(ctx, msg, Extension(vta_state)).await);
+    }
+    if t == protocols::backup_management::IMPORT_BACKUP {
+        return finish(handlers::handle_backup_import(ctx, msg, Extension(vta_state)).await);
+    }
+
+    // ── Credential exchange (AppState) ───────────────────────────────
+    if t == credential_exchange::ISSUE {
+        return finish(handlers::handle_credential_issue(ctx, msg, Extension(app_state)).await);
+    }
+    if t == credential_exchange::QUERY {
+        return finish(handlers::handle_credential_query(ctx, msg, Extension(app_state)).await);
+    }
+    if t == credential_exchange::OFFER {
+        return finish(handlers::handle_credential_offer(ctx, msg, Extension(app_state)).await);
+    }
+
+    // ── DID WebVH management (webvh) ─────────────────────────────────
+    #[cfg(feature = "webvh")]
+    {
+        if t == did_management::CREATE_DID_WEBVH {
+            return finish(handlers::handle_create_did_webvh(ctx, msg, Extension(vta_state)).await);
+        }
+        if t == did_management::GET_DID_WEBVH {
+            return finish(handlers::handle_get_did_webvh(ctx, msg, Extension(vta_state)).await);
+        }
+        if t == did_management::GET_DID_WEBVH_LOG {
+            return finish(
+                handlers::handle_get_did_webvh_log(ctx, msg, Extension(vta_state)).await,
             );
         }
-
-        self.inner.handle(ctx, message, meta).await
+        if t == did_management::LIST_DIDS_WEBVH {
+            return finish(handlers::handle_list_dids_webvh(ctx, msg, Extension(vta_state)).await);
+        }
+        if t == did_management::DELETE_DID_WEBVH {
+            return finish(handlers::handle_delete_did_webvh(ctx, msg, Extension(vta_state)).await);
+        }
+        if t == did_management::ADD_WEBVH_SERVER {
+            return finish(handlers::handle_add_webvh_server(ctx, msg, Extension(vta_state)).await);
+        }
+        if t == did_management::LIST_WEBVH_SERVERS {
+            return finish(
+                handlers::handle_list_webvh_servers(ctx, msg, Extension(vta_state)).await,
+            );
+        }
+        if t == did_management::LIST_WEBVH_SERVER_DOMAINS {
+            return finish(
+                handlers::handle_list_webvh_server_domains(ctx, msg, Extension(vta_state)).await,
+            );
+        }
+        if t == did_management::UPDATE_WEBVH_SERVER {
+            return finish(
+                handlers::handle_update_webvh_server(ctx, msg, Extension(vta_state)).await,
+            );
+        }
+        if t == did_management::REMOVE_WEBVH_SERVER {
+            return finish(
+                handlers::handle_remove_webvh_server(ctx, msg, Extension(vta_state)).await,
+            );
+        }
+        if t == did_management::UPDATE_DID_WEBVH {
+            return finish(handlers::handle_update_did_webvh(ctx, msg, Extension(vta_state)).await);
+        }
+        if t == did_management::ROTATE_DID_WEBVH_KEYS {
+            return finish(
+                handlers::handle_rotate_did_webvh_keys(ctx, msg, Extension(vta_state)).await,
+            );
+        }
+        if t == did_management::REGISTER_DID_WITH_SERVER {
+            return finish(
+                handlers::handle_register_did_with_server(ctx, msg, Extension(vta_state)).await,
+            );
+        }
     }
-}
 
-/// Build the DIDComm message handler with all VTA protocol handlers.
-///
-/// Returns a [`BridgeHandler`] that wraps the Router and integrates
-/// outbound request-response routing via the shared [`DIDCommBridge`].
-pub fn build_handler(
-    state: Arc<VtaState>,
-    app_state: AppState,
-    bridge: Arc<DIDCommBridge>,
-) -> Result<BridgeHandler, DIDCommServiceError> {
-    let mut router = Router::new()
-        .extension(state)
-        // Full REST `AppState`, injected so the generic trust-task
-        // handler can drive the shared `dispatch_trust_task_core`
-        // (which needs keyspaces not mirrored onto `VtaState`).
-        .extension(app_state)
-        // Built-in protocol handlers
-        .route(TRUST_PING_TYPE, handler_fn(trust_ping_handler))?
-        .route(MESSAGE_PICKUP_STATUS_TYPE, handler_fn(ignore_handler))?
-        // Trust-Tasks: one binding envelope type carries every slice's
-        // `TrustTask<P>` in its body; the handler dispatches on the
-        // inner envelope's own `type` via the shared REST dispatcher.
-        .route(
-            handlers::TRUST_TASK_ENVELOPE_TYPE,
-            handler_fn(handlers::handle_trust_task),
-        )?
-        // Key management
-        .route(
-            key_management::CREATE_KEY,
-            handler_fn(handlers::handle_create_key),
-        )?
-        .route(
-            key_management::GET_KEY,
-            handler_fn(handlers::handle_get_key),
-        )?
-        .route(
-            key_management::LIST_KEYS,
-            handler_fn(handlers::handle_list_keys),
-        )?
-        .route(
-            key_management::RENAME_KEY,
-            handler_fn(handlers::handle_rename_key),
-        )?
-        .route(
-            key_management::REVOKE_KEY,
-            handler_fn(handlers::handle_revoke_key),
-        )?
-        .route(
-            key_management::GET_KEY_SECRET,
-            handler_fn(handlers::handle_get_key_secret),
-        )?
-        .route(
-            key_management::SIGN_REQUEST,
-            handler_fn(handlers::handle_sign_request),
-        )?
-        // Seed management
-        .route(
-            seed_management::LIST_SEEDS,
-            handler_fn(handlers::handle_list_seeds),
-        )?
-        .route(
-            seed_management::ROTATE_SEED,
-            handler_fn(handlers::handle_rotate_seed),
-        )?
-        // Context management
-        .route(
-            context_management::CREATE_CONTEXT,
-            handler_fn(handlers::handle_create_context),
-        )?
-        .route(
-            context_management::GET_CONTEXT,
-            handler_fn(handlers::handle_get_context),
-        )?
-        .route(
-            context_management::LIST_CONTEXTS,
-            handler_fn(handlers::handle_list_contexts),
-        )?
-        .route(
-            context_management::UPDATE_CONTEXT,
-            handler_fn(handlers::handle_update_context),
-        )?
-        .route(
-            context_management::UPDATE_CONTEXT_DID,
-            handler_fn(handlers::handle_update_context_did),
-        )?
-        .route(
-            context_management::PREVIEW_DELETE_CONTEXT,
-            handler_fn(handlers::handle_preview_delete_context),
-        )?
-        .route(
-            context_management::DELETE_CONTEXT,
-            handler_fn(handlers::handle_delete_context),
-        )?
-        // ACL management
-        .route(
-            acl_management::CREATE_ACL,
-            handler_fn(handlers::handle_create_acl),
-        )?
-        .route(
-            acl_management::GET_ACL,
-            handler_fn(handlers::handle_get_acl),
-        )?
-        .route(
-            acl_management::LIST_ACL,
-            handler_fn(handlers::handle_list_acl),
-        )?
-        .route(
-            acl_management::UPDATE_ACL,
-            handler_fn(handlers::handle_update_acl),
-        )?
-        .route(
-            acl_management::DELETE_ACL,
-            handler_fn(handlers::handle_delete_acl),
-        )?
-        .route(
-            acl_management::SWAP_ACL,
-            handler_fn(handlers::handle_swap_acl),
-        )?
-        // Canonical Trust Task URI for the same operation — dual-registered
-        // during the deprecation window. Handler dispatches on incoming type.
-        .route(
-            acl_management::ACL_SWAP_KEY,
-            handler_fn(handlers::handle_swap_acl),
-        )?
-        // Audit management
-        .route(
-            audit_management::LIST_LOGS,
-            handler_fn(handlers::handle_list_logs),
-        )?
-        .route(
-            audit_management::GET_RETENTION,
-            handler_fn(handlers::handle_get_retention),
-        )?
-        .route(
-            audit_management::UPDATE_RETENTION,
-            handler_fn(handlers::handle_update_retention),
-        )?
-        // VTA management
-        .route(
-            vta_management::GET_CONFIG,
-            handler_fn(handlers::handle_get_config),
-        )?
-        .route(
-            vta_management::UPDATE_CONFIG,
-            handler_fn(handlers::handle_update_config),
-        )?
-        // Problem reports
-        .route(
-            protocols::PROBLEM_REPORT_TYPE,
-            handler_fn(handlers::handle_problem_report),
-        )?
-        // VTA management — restart
-        .route(
-            vta_management::RESTART,
-            handler_fn(handlers::handle_restart),
-        )?
-        // Backup management
-        .route(
-            protocols::backup_management::EXPORT_BACKUP,
-            handler_fn(handlers::handle_backup_export),
-        )?
-        .route(
-            protocols::backup_management::IMPORT_BACKUP,
-            handler_fn(handlers::handle_backup_import),
-        )?
-        // Credential exchange — holder-side receive of an issued credential
-        // (spec §6 / task 3.3). Uses `AppState` for the credential vault.
-        .route(
-            credential_exchange::ISSUE,
-            handler_fn(handlers::handle_credential_issue),
-        )?
-        // Credential exchange — holder answers a verifier's DCQL query with a
-        // presentation (spec §6 / task 3.5). Uses `AppState` for vault + keys.
-        .route(
-            credential_exchange::QUERY,
-            handler_fn(handlers::handle_credential_query),
-        )?
-        // Credential exchange — holder answers an issuer's offer with a request
-        // (spec §6 / task 3.2). Opt-in via `credential_holder_did`.
-        .route(
-            credential_exchange::OFFER,
-            handler_fn(handlers::handle_credential_offer),
-        )?;
-
-    // WebVH handlers (feature-gated)
+    // ── Protocol management over DIDComm (webvh) ─────────────────────
     #[cfg(feature = "webvh")]
     {
-        router = router
-            .route(
-                did_management::CREATE_DID_WEBVH,
-                handler_fn(handlers::handle_create_did_webvh),
-            )?
-            .route(
-                did_management::GET_DID_WEBVH,
-                handler_fn(handlers::handle_get_did_webvh),
-            )?
-            .route(
-                did_management::GET_DID_WEBVH_LOG,
-                handler_fn(handlers::handle_get_did_webvh_log),
-            )?
-            .route(
-                did_management::LIST_DIDS_WEBVH,
-                handler_fn(handlers::handle_list_dids_webvh),
-            )?
-            .route(
-                did_management::DELETE_DID_WEBVH,
-                handler_fn(handlers::handle_delete_did_webvh),
-            )?
-            .route(
-                did_management::ADD_WEBVH_SERVER,
-                handler_fn(handlers::handle_add_webvh_server),
-            )?
-            .route(
-                did_management::LIST_WEBVH_SERVERS,
-                handler_fn(handlers::handle_list_webvh_servers),
-            )?
-            .route(
-                did_management::LIST_WEBVH_SERVER_DOMAINS,
-                handler_fn(handlers::handle_list_webvh_server_domains),
-            )?
-            .route(
-                did_management::UPDATE_WEBVH_SERVER,
-                handler_fn(handlers::handle_update_webvh_server),
-            )?
-            .route(
-                did_management::REMOVE_WEBVH_SERVER,
-                handler_fn(handlers::handle_remove_webvh_server),
-            )?
-            .route(
-                did_management::UPDATE_DID_WEBVH,
-                handler_fn(handlers::handle_update_did_webvh),
-            )?
-            .route(
-                did_management::ROTATE_DID_WEBVH_KEYS,
-                handler_fn(handlers::handle_rotate_did_webvh_keys),
-            )?
-            .route(
-                did_management::REGISTER_DID_WITH_SERVER,
-                handler_fn(handlers::handle_register_did_with_server),
-            )?;
-
-        // Protocol management over DIDComm. `enable` is REST-only
-        // by nature so it has no DIDComm route; the rest go through
-        // the same operation functions as the REST handlers.
-        // Spec: docs/05-design-notes/didcomm-protocol-management.md.
-        router = router
-            .route(
-                protocol_management::DISABLE_DIDCOMM,
-                handler_fn(super::handlers_protocol::handle_disable_didcomm),
-            )?
-            .route(
-                protocol_management::ENABLE_REST,
-                handler_fn(super::handlers_protocol::handle_enable_rest),
-            )?
-            .route(
-                protocol_management::UPDATE_REST,
-                handler_fn(super::handlers_protocol::handle_update_rest),
-            )?
-            .route(
-                protocol_management::DISABLE_REST,
-                handler_fn(super::handlers_protocol::handle_disable_rest),
-            )?
-            .route(
-                protocol_management::ROLLBACK_REST,
-                handler_fn(super::handlers_protocol::handle_rollback_rest),
-            )?
-            .route(
-                protocol_management::ENABLE_TSP,
-                handler_fn(super::handlers_protocol::handle_enable_tsp),
-            )?
-            .route(
-                protocol_management::UPDATE_TSP,
-                handler_fn(super::handlers_protocol::handle_update_tsp),
-            )?
-            .route(
-                protocol_management::DISABLE_TSP,
-                handler_fn(super::handlers_protocol::handle_disable_tsp),
-            )?
-            .route(
-                protocol_management::ROLLBACK_TSP,
-                handler_fn(super::handlers_protocol::handle_rollback_tsp),
-            )?
-            .route(
-                protocol_management::UPDATE_DIDCOMM,
-                handler_fn(super::handlers_protocol::handle_update_didcomm),
-            )?
-            .route(
-                protocol_management::ROLLBACK_DIDCOMM,
-                handler_fn(super::handlers_protocol::handle_rollback_didcomm),
-            )?
-            .route(
-                protocol_management::LIST_SERVICES,
-                handler_fn(super::handlers_protocol::handle_list_services),
-            )?
-            .route(
-                protocol_management::LIST_DRAIN,
-                handler_fn(super::handlers_protocol::handle_list_drain),
-            )?
-            .route(
-                protocol_management::DRAIN_CANCEL,
-                handler_fn(super::handlers_protocol::handle_drain_cancel),
-            )?
-            .route(
-                protocol_management::MEDIATOR_REPORT,
-                handler_fn(super::handlers_protocol::handle_mediator_report),
-            )?;
+        use super::handlers_protocol as hp;
+        if t == protocol_management::DISABLE_DIDCOMM {
+            return finish(hp::handle_disable_didcomm(ctx, msg, Extension(vta_state)).await);
+        }
+        if t == protocol_management::ENABLE_REST {
+            return finish(hp::handle_enable_rest(ctx, msg, Extension(vta_state)).await);
+        }
+        if t == protocol_management::UPDATE_REST {
+            return finish(hp::handle_update_rest(ctx, msg, Extension(vta_state)).await);
+        }
+        if t == protocol_management::DISABLE_REST {
+            return finish(hp::handle_disable_rest(ctx, msg, Extension(vta_state)).await);
+        }
+        if t == protocol_management::ROLLBACK_REST {
+            return finish(hp::handle_rollback_rest(ctx, msg, Extension(vta_state)).await);
+        }
+        if t == protocol_management::ENABLE_TSP {
+            return finish(hp::handle_enable_tsp(ctx, msg, Extension(vta_state)).await);
+        }
+        if t == protocol_management::UPDATE_TSP {
+            return finish(hp::handle_update_tsp(ctx, msg, Extension(vta_state)).await);
+        }
+        if t == protocol_management::DISABLE_TSP {
+            return finish(hp::handle_disable_tsp(ctx, msg, Extension(vta_state)).await);
+        }
+        if t == protocol_management::ROLLBACK_TSP {
+            return finish(hp::handle_rollback_tsp(ctx, msg, Extension(vta_state)).await);
+        }
+        if t == protocol_management::UPDATE_DIDCOMM {
+            return finish(hp::handle_update_didcomm(ctx, msg, Extension(vta_state)).await);
+        }
+        if t == protocol_management::ROLLBACK_DIDCOMM {
+            return finish(hp::handle_rollback_didcomm(ctx, msg, Extension(vta_state)).await);
+        }
+        if t == protocol_management::LIST_SERVICES {
+            return finish(hp::handle_list_services(ctx, msg, Extension(vta_state)).await);
+        }
+        if t == protocol_management::LIST_DRAIN {
+            return finish(hp::handle_list_drain(ctx, msg, Extension(vta_state)).await);
+        }
+        if t == protocol_management::DRAIN_CANCEL {
+            return finish(hp::handle_drain_cancel(ctx, msg, Extension(vta_state)).await);
+        }
+        if t == protocol_management::MEDIATOR_REPORT {
+            return finish(hp::handle_mediator_report(ctx, msg, Extension(vta_state)).await);
+        }
     }
 
-    // Provision-integration mints WebVH DIDs, so it's `webvh`-gated like the
-    // REST side (`routes::bootstrap`'s `mod provision`). Without webvh the op
-    // can't function, so we don't expose the route (vs the old unconditional
-    // registration that panicked at runtime — see the `From<&VtaState>` note
-    // above).
-    //
-    // Both canonical Trust Task versions (0.1 and 0.2) route to the same
-    // handler; the handler reads the inbound `typ` and emits the matching
-    // `#response` URI (`result_uri_for`). The 0.2 wire form differs only
-    // in camelCase enum casing — including the signed VP's `ask.type`, so
-    // the handler verifies over the bytes as received. The legacy
-    // `firstperson.network` provision URI was retired now that the browser
-    // plugin and Rust CLIs all target the canonical registry.
+    // ── Provision-integration (webvh) ────────────────────────────────
     #[cfg(feature = "webvh")]
     {
-        router = router
-            .route(
-                provision_integration_management::CANONICAL_PROVISION_INTEGRATION,
-                handler_fn(handlers::handle_provision_integration),
-            )?
-            .route(
-                provision_integration_management::CANONICAL_PROVISION_INTEGRATION_0_2,
-                handler_fn(handlers::handle_provision_integration),
-            )?;
+        if t == provision_integration_management::CANONICAL_PROVISION_INTEGRATION
+            || t == provision_integration_management::CANONICAL_PROVISION_INTEGRATION_0_2
+        {
+            return finish(
+                handlers::handle_provision_integration(ctx, msg, Extension(vta_state)).await,
+            );
+        }
     }
 
-    // Step-up approval — the VTA vouches (signs as itself) that a holder
-    // may step up their session at a relying party. Always available. Both
-    // the legacy `vta/step-up/approve-request/1.0` and the canonical
-    // `spec/auth/step-up/approve-request/0.1` registry URIs route to the same
-    // handler, which echoes the request's version family in its response
-    // (issue #517). Registering the canonical URI is additive — the legacy
-    // plugin is unaffected.
-    router = router
-        .route(
-            handlers::STEP_UP_APPROVE_REQUEST_TYPE,
-            handler_fn(handlers::handle_step_up_approve),
-        )?
-        .route(
-            handlers::STEP_UP_APPROVE_REQUEST_CANONICAL,
-            handler_fn(handlers::handle_step_up_approve),
-        )?;
+    // ── Step-up approval (always) ────────────────────────────────────
+    if t == handlers::STEP_UP_APPROVE_REQUEST_TYPE
+        || t == handlers::STEP_UP_APPROVE_REQUEST_CANONICAL
+    {
+        return finish(handlers::handle_step_up_approve(ctx, msg, Extension(vta_state)).await);
+    }
 
-    // TEE attestation handlers (feature-gated)
+    // ── TEE attestation (tee) ────────────────────────────────────────
     #[cfg(feature = "tee")]
     {
-        router = router
-            .route(
-                attestation_management::GET_TEE_STATUS,
-                handler_fn(handlers::handle_tee_status),
-            )?
-            .route(
-                attestation_management::REQUEST_ATTESTATION,
-                handler_fn(handlers::handle_request_attestation),
-            )?;
+        if t == attestation_management::GET_TEE_STATUS {
+            return finish(handlers::handle_tee_status(ctx, msg, Extension(vta_state)).await);
+        }
+        if t == attestation_management::REQUEST_ATTESTATION {
+            return finish(
+                handlers::handle_request_attestation(ctx, msg, Extension(vta_state)).await,
+            );
+        }
     }
 
-    // Discovery (no auth required — the handler doesn't call auth_from_message)
-    router = router.route(
-        protocols::discovery::DISCOVER_CAPABILITIES,
-        handler_fn(handlers::handle_discover_capabilities),
-    )?;
+    // ── Discovery (no auth) ──────────────────────────────────────────
+    if t == protocols::discovery::DISCOVER_CAPABILITIES {
+        return finish(
+            handlers::handle_discover_capabilities(ctx, msg, Extension(vta_state)).await,
+        );
+    }
 
-    // Fallback, middleware, error handling
-    router = router
-        .fallback(handler_fn(handlers::handle_unknown))
-        .layer(
-            MessagePolicy::new()
-                .require_encrypted(true)
-                .require_authenticated(true)
-                .allow_anonymous_sender(false),
-        )
-        .layer(RequestLogging);
-
-    Ok(BridgeHandler {
-        inner: router,
-        bridge,
-    })
+    // ── Fallback ─────────────────────────────────────────────────────
+    finish(handlers::handle_unknown(ctx, msg).await)
 }

--- a/vta-service/src/messaging/service.rs
+++ b/vta-service/src/messaging/service.rs
@@ -1,0 +1,385 @@
+//! Delivery-layer construction + protocol-routed inbound loop (D2 P2a).
+//!
+//! Mirrors `vtc-service::messaging`: build an ATM + bounded-websocket
+//! `ATMProfile` for the VTA's DID against the configured mediator, wrap it in a
+//! [`DidCommTransport`], back an outbox with [`VtiOutboxStore`], and drive
+//! [`MessagingService`]. Inbound is protocol-routed off
+//! [`MessagingService::subscribe`]: DIDComm frames go to
+//! [`super::router::dispatch`] (after the `#620` verified-sender-or-none rule
+//! stamps `Message::from`); TSP frames go to
+//! [`super::tsp_inbound::dispatch_one`] and their reply is sealed + routed back
+//! over the same mediator socket.
+//!
+//! P2a uses [`MessagingService::new`] (consume-only receipts) — no receipt
+//! *emit* yet (that lands with the first `Guaranteed` VTA pushes in P2b); the
+//! consume half is always active, so the VTA still settles its own sends.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use affinidi_did_resolver_cache_sdk::DIDCacheClient;
+use affinidi_did_resolver_cache_sdk::config::DIDCacheConfigBuilder;
+use affinidi_messaging_core::{Inbound, MessageTransport, Protocol};
+use affinidi_messaging_delivery::{Delivery, MessagingService, OutboxStore};
+use affinidi_messaging_didcomm::Message;
+use affinidi_tdk::common::TDKSharedState;
+use affinidi_tdk::common::config::TDKConfig;
+use affinidi_tdk::messaging::config::ATMConfig;
+use affinidi_tdk::messaging::profiles::ATMProfile;
+use affinidi_tdk::messaging::{ATM, DidCommTransport};
+use affinidi_tdk::secrets_resolver::SecretsResolver;
+use affinidi_tdk::secrets_resolver::secrets::Secret;
+use futures_util::StreamExt;
+use tokio_util::sync::CancellationToken;
+use tracing::{info, warn};
+
+use vti_common::outbox_store::VtiOutboxStore;
+
+use crate::messaging::router::{self, VtaState};
+use crate::messaging::shim::{DIDCommResponse, ProblemReport, ServiceProblemReport};
+use crate::server::AppState;
+use crate::store::KeyspaceHandle;
+
+/// The live delivery-layer wiring for the VTA's mediator socket, returned by
+/// [`build_messaging`]. The `service` is published into the outbound bridge and
+/// drives the inbound loop; `atm` + `profile` pack/seal replies (DIDComm via
+/// `pack_encrypted`, TSP via `tsp().send_routed`).
+pub struct VtaMessaging {
+    pub service: Arc<MessagingService>,
+    pub atm: Arc<ATM>,
+    pub profile: Arc<ATMProfile>,
+}
+
+/// Build the delivery-layer [`MessagingService`] over a [`DidCommTransport`]
+/// bound to the VTA's single mediator websocket.
+///
+/// Mirrors `vtc-service::messaging::build_messaging`: a fresh TDK seeded with
+/// the VTA's secrets (and the app's DID resolver, so the listener sees the same
+/// seeded self-DID cache entry the REST path does), an ATM, a profile against
+/// the mediator, then a **bounded** `profile_enable_websocket` (the connect can
+/// hang) before the transport is bound. The `outbox` keyspace backs
+/// `Guaranteed` sends durably (unused by P2a's `BestEffort`-only sends, but
+/// `MessagingService::new` requires a store).
+pub async fn build_messaging(
+    secrets: Vec<Secret>,
+    vta_did: &str,
+    mediator_did: &str,
+    outbox_ks: KeyspaceHandle,
+    did_resolver: Option<&DIDCacheClient>,
+    resolver_url: Option<&str>,
+) -> Result<VtaMessaging, String> {
+    // Reuse the app's initialized resolver when available so the listener sees
+    // the same seeded self-DID cache entry; else fall back to resolver-url mode.
+    let mut builder = TDKConfig::builder().with_load_environment(false);
+    if let Some(dr) = did_resolver {
+        builder = builder.with_did_resolver(dr.clone());
+    } else if let Some(url) = resolver_url {
+        let resolver_config = DIDCacheConfigBuilder::default()
+            .with_network_mode(url)
+            .build();
+        builder = builder.with_did_resolver_config(resolver_config);
+    }
+    let tdk_config = builder
+        .build()
+        .map_err(|e| format!("build TDK config: {e}"))?;
+
+    let tdk = TDKSharedState::new(tdk_config)
+        .await
+        .map_err(|e| format!("create TDK shared state: {e}"))?;
+    for secret in secrets {
+        tdk.secrets_resolver().insert(secret).await;
+    }
+
+    let atm = ATM::new(
+        ATMConfig::builder()
+            .build()
+            .map_err(|e| format!("build ATM config: {e}"))?,
+        Arc::new(tdk),
+    )
+    .await
+    .map_err(|e| format!("create ATM: {e}"))?;
+
+    let profile = Arc::new(
+        ATMProfile::new(
+            &atm,
+            None,
+            vta_did.to_string(),
+            Some(mediator_did.to_string()),
+        )
+        .await
+        .map_err(|e| format!("create ATM profile: {e}"))?,
+    );
+
+    // Bounded — a `did:webvh` mediator websocket connect can hang.
+    match tokio::time::timeout(
+        Duration::from_secs(30),
+        atm.profile_enable_websocket(&profile),
+    )
+    .await
+    {
+        Ok(res) => res.map_err(|e| format!("enable websocket: {e}"))?,
+        Err(_) => {
+            return Err(
+                "timeout enabling websocket to mediator after 30s — mediator may be unreachable"
+                    .to_string(),
+            );
+        }
+    }
+
+    let atm = Arc::new(atm);
+    let transport: Arc<dyn MessageTransport> = Arc::new(
+        DidCommTransport::new((*atm).clone(), profile.clone())
+            .await
+            .map_err(|e| format!("bind DidComm transport: {e}"))?,
+    );
+    let outbox: Arc<dyn OutboxStore> = Arc::new(VtiOutboxStore::new(outbox_ks));
+    // P2a uses `new` (not `with_receipts`) — no layer-receipt *emit* yet (P2b);
+    // the consume half is always active, so the VTA settles its own sends.
+    // Clone transport + outbox before `new` consumes them: the background loops
+    // need their own handles.
+    let service = Arc::new(MessagingService::new(transport.clone(), outbox.clone()));
+    // Durable outbox: drain sends due entries + retries; outbox-drain confirms
+    // Delivered on recipient pickup; confirmation sweep settles expired entries.
+    // Dormant in P2a (no Guaranteed sends yet) but wired for P2b + restart
+    // resilience.
+    tokio::spawn(affinidi_messaging_delivery::drain_loop(
+        outbox.clone(),
+        service.primary_handle(),
+        Duration::from_secs(2),
+    ));
+    tokio::spawn(affinidi_messaging_delivery::outbox_drain_loop(
+        service.primary_handle(),
+        outbox.clone(),
+        Duration::from_secs(10),
+    ));
+    tokio::spawn(affinidi_messaging_delivery::confirmation_loop(
+        outbox.clone(),
+        Duration::from_secs(30),
+    ));
+
+    Ok(VtaMessaging {
+        service,
+        atm,
+        profile,
+    })
+}
+
+/// Drive inbound dispatch off [`MessagingService::subscribe`] until shutdown.
+///
+/// For each inbound: DIDComm → rehydrate the plaintext [`Message`], stamp the
+/// **cryptographically-authenticated** sender onto `from` (`#620`), enforce the
+/// framework `MessagePolicy` equivalent (encrypted AND authenticated
+/// non-anonymous sender, for every type), dispatch, and pack + `send` any reply
+/// authcrypt to the sender. TSP →
+/// [`super::tsp_inbound::dispatch_one`], sealing + routing the reply back over
+/// the same mediator socket.
+pub async fn run_inbound_loop(
+    messaging: Arc<VtaMessaging>,
+    app_state: AppState,
+    vta_did: String,
+    mediator_did: String,
+    shutdown: CancellationToken,
+) {
+    let vta_state = Arc::new(VtaState::from(&app_state));
+    let mut stream = messaging.service.subscribe();
+    info!("VTA messaging connected to mediator — inbound messages will be processed");
+
+    loop {
+        tokio::select! {
+            maybe = stream.next() => {
+                let Some(inbound) = maybe else {
+                    warn!("VTA inbound stream ended — messaging dispatcher stopping");
+                    break;
+                };
+                handle_inbound(
+                    inbound,
+                    &messaging,
+                    &app_state,
+                    &vta_state,
+                    &vta_did,
+                    &mediator_did,
+                )
+                .await;
+            }
+            _ = shutdown.cancelled() => {
+                info!("VTA messaging stopping (shutdown signalled)");
+                break;
+            }
+        }
+    }
+    info!("VTA messaging stopped");
+}
+
+/// Route one inbound frame by protocol. `mediator_did` (and `messaging.profile`)
+/// are used only by the `tsp`-gated arm.
+async fn handle_inbound(
+    inbound: Inbound,
+    messaging: &Arc<VtaMessaging>,
+    app_state: &AppState,
+    vta_state: &Arc<VtaState>,
+    vta_did: &str,
+    mediator_did: &str,
+) {
+    match inbound.message.protocol {
+        Protocol::DIDComm => {
+            let _ = mediator_did;
+            handle_didcomm(inbound, messaging, app_state, vta_state, vta_did).await;
+        }
+        #[cfg(feature = "tsp")]
+        Protocol::TSP => {
+            handle_tsp(inbound, messaging, app_state, mediator_did).await;
+        }
+        #[cfg(not(feature = "tsp"))]
+        Protocol::TSP => {
+            let _ = mediator_did;
+            warn!("received an inbound TSP frame but the `tsp` feature is disabled — dropping");
+        }
+    }
+}
+
+/// DIDComm inbound: rehydrate, stamp the verified sender, gate encryption,
+/// dispatch, pack + send the reply.
+async fn handle_didcomm(
+    inbound: Inbound,
+    messaging: &Arc<VtaMessaging>,
+    app_state: &AppState,
+    vta_state: &Arc<VtaState>,
+    vta_did: &str,
+) {
+    let mut msg: Message = match serde_json::from_slice(&inbound.message.payload) {
+        Ok(m) => m,
+        Err(e) => {
+            warn!(error = %e, "failed to parse inbound DIDComm message — dropping");
+            return;
+        }
+    };
+
+    // #620: the ONLY trusted sender is the cryptographically-authenticated one
+    // (`sender` filtered by `verified`). Capture the plaintext `from` first —
+    // solely as a best-effort *reply address* for anoncrypt public reads
+    // (never for auth) — then overwrite `from` so every handler's
+    // `auth_from_message` / `ctx.sender_did` sees only the proven sender (or
+    // `None`, which those reject).
+    let plaintext_from = msg.from.clone();
+    let auth_sender = inbound
+        .message
+        .sender
+        .clone()
+        .filter(|_| inbound.message.verified);
+    msg.from = auth_sender.clone();
+
+    // The reply target: the authenticated sender when present, else the
+    // plaintext `from` (a public read may arrive anoncrypt).
+    let reply_to = auth_sender.clone().or(plaintext_from);
+    let msg_id = msg.id.clone();
+    let message_type = msg.typ.clone();
+    let start = std::time::Instant::now();
+
+    // Faithful in-loop translation of the framework `MessagePolicy` that gated
+    // EVERY route before dispatch: require_encrypted(true) +
+    // require_authenticated(true) + allow_anonymous_sender(false) (framework
+    // `middleware/policy.rs::check`). Enforced here for ALL message types — not
+    // per-handler — so a handler that doesn't itself call `auth_from_message`
+    // (discovery, TEE status/attestation) cannot be reached by an unauthenticated
+    // or anonymous sender, exactly as the removed middleware layer guaranteed.
+    // `auth_sender` is `Some` iff the sender is cryptographically authenticated
+    // (#620), so its absence collapses the framework's NotAuthenticated /
+    // AnonymousSender / MissingSenderDid violations into one check. There is NO
+    // discovery exemption: the old policy layer required authcrypt for discovery
+    // too, so requiring it here is behaviour-preserving.
+    let reply = if !inbound.message.encrypted {
+        Some(DIDCommResponse::problem_report(ProblemReport::bad_request(
+            "DIDComm message must be encrypted",
+        )))
+    } else if auth_sender.is_none() {
+        Some(DIDCommResponse::problem_report(
+            ProblemReport::unauthorized(
+                "DIDComm message must be authenticated (authcrypt) with a non-anonymous sender",
+            ),
+        ))
+    } else {
+        let ctx = crate::messaging::shim::HandlerContext {
+            sender_did: auth_sender.clone(),
+        };
+        router::dispatch(msg, ctx, vta_state.clone(), app_state.clone()).await
+    };
+
+    info!(
+        target: "didcomm_server::request",
+        message_type = %message_type,
+        sender = %auth_sender.as_deref().unwrap_or("<anon>"),
+        status = if reply.is_some() { "ok(response)" } else { "ok(empty)" },
+        latency = ?start.elapsed(),
+        "Request processed"
+    );
+
+    let Some(reply) = reply else {
+        return;
+    };
+    let Some(to) = reply_to else {
+        warn!(
+            reply_type = %reply.type_,
+            "computed a DIDComm reply but the inbound message had no sender/from to reply to — dropping"
+        );
+        return;
+    };
+
+    let reply_id = uuid::Uuid::new_v4().to_string();
+    let thid = reply.thid.unwrap_or(msg_id);
+    let reply_msg = Message::build(reply_id, reply.type_, reply.body)
+        .from(vta_did.to_string())
+        .to(to.clone())
+        .thid(thid)
+        .finalize();
+    match messaging
+        .atm
+        .pack_encrypted(&reply_msg, &to, Some(vta_did), Some(vta_did))
+        .await
+    {
+        Ok((packed, _)) => {
+            if let Err(e) = messaging
+                .service
+                .send(&to, packed.into_bytes(), Delivery::BestEffort)
+                .await
+            {
+                warn!(recipient = %to, error = %e, "failed to send DIDComm reply");
+            }
+        }
+        Err(e) => warn!(recipient = %to, error = %e, "failed to pack DIDComm reply"),
+    }
+}
+
+/// TSP inbound: dispatch on the shared Trust-Task spine and seal + route the
+/// reply back to the proven sender VID over the same mediator socket
+/// (`send_routed([mediator_did, sender_vid])`), mirroring the framework's
+/// `TspResponse` handling.
+#[cfg(feature = "tsp")]
+async fn handle_tsp(
+    inbound: Inbound,
+    messaging: &Arc<VtaMessaging>,
+    app_state: &AppState,
+    mediator_did: &str,
+) {
+    let Some(sender_vid) = inbound.message.sender.clone() else {
+        warn!("inbound TSP frame has no authenticated sender VID — dropping");
+        return;
+    };
+    let reply = crate::messaging::tsp_inbound::dispatch_one(
+        app_state,
+        &inbound.message.payload,
+        &sender_vid,
+    )
+    .await;
+    if reply.is_empty() {
+        return;
+    }
+    let route = vec![mediator_did.to_string(), sender_vid.clone()];
+    if let Err(e) = messaging
+        .atm
+        .tsp()
+        .send_routed(&messaging.profile, &route, &reply)
+        .await
+    {
+        warn!(recipient = %sender_vid, error = %e, "failed to send TSP reply");
+    }
+}

--- a/vta-service/src/messaging/shim.rs
+++ b/vta-service/src/messaging/shim.rs
@@ -1,0 +1,193 @@
+//! Local replacements for the handful of `affinidi-messaging-didcomm-service`
+//! types the ~50 DIDComm handlers depend on.
+//!
+//! The D2 P2a cut-over removed the `affinidi-messaging-didcomm-service`
+//! framework (its type-routed `Router` + middleware) in favour of the
+//! reliable-messaging delivery layer (`MessagingService`), exactly as the VTC
+//! pilot did. The handler *bodies* in [`super::handlers`] /
+//! [`super::handlers_protocol`] are unchanged: they still take
+//! `(HandlerContext, Message, Extension<T>)` and return
+//! `Result<Option<DIDCommResponse>, DIDCommServiceError>`. This module supplies
+//! those four types locally so the bodies compile verbatim, while
+//! [`super::router::dispatch`] — not a framework `Router` — is what actually
+//! calls them (a `msg.typ` match built directly, so no `handler_fn` /
+//! `FromMessageParts` extraction machinery is needed; `Extension<T>` is a plain
+//! tuple the dispatch constructs at each call site).
+//!
+//! [`ProblemReport`] is re-declared here (byte-identical serde to the framework
+//! / mediator-common shape) rather than re-exported, because the
+//! `affinidi-messaging-sdk` crate is optional in this build (only on under the
+//! `tsp` feature) and the framework re-exported it from there.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// Per-message context handed to each handler. The delivery-layer inbound loop
+/// builds this from the neutral `Inbound`; `sender_did` is the
+/// **cryptographically-authenticated** sender (the `#620` verified-sender-or-
+/// none rule — see [`super::router::dispatch`]), i.e. the same value the loop
+/// stamps onto `Message::from`. Only [`super::handlers::handle_credential_query`]
+/// reads it; every other handler re-derives auth via `auth_from_message`
+/// (which reads that same `from`).
+#[derive(Clone, Default)]
+pub struct HandlerContext {
+    /// The authenticated sender DID, or `None` for an anonymous / spoofed
+    /// (and therefore rejected) sender.
+    pub sender_did: Option<String>,
+}
+
+/// Extractor-shaped wrapper so a handler can destructure its shared state in
+/// the parameter position (`Extension(state): Extension<Arc<VtaState>>`),
+/// exactly as under the framework. The dispatch constructs it directly — there
+/// is no type-map extraction.
+pub struct Extension<T>(pub T);
+
+/// Handler error. The framework surfaced many variants; the handlers only ever
+/// construct [`DIDCommServiceError::Handler`] (via `handler_err`), so that is
+/// the only variant carried forward. Rendered as an `internal-error`
+/// problem-report by the dispatch when a handler returns `Err`.
+#[derive(Debug, thiserror::Error)]
+pub enum DIDCommServiceError {
+    #[error("Handler error: {0}")]
+    Handler(String),
+}
+
+/// A reply a handler asks the loop to pack + send back to the sender.
+///
+/// Replaces the framework `DIDCommResponse`. The delivery-layer inbound loop
+/// reads [`Self::type_`] / [`Self::body`] / [`Self::thid`], builds a plaintext
+/// [`affinidi_tdk::didcomm::Message`] (from = the VTA's DID, to = the request
+/// sender), authcrypt-packs it, and `send`s it `BestEffort`. When `thid` is
+/// `None` the loop threads the reply to the inbound message's id (the
+/// framework's default).
+#[derive(Debug)]
+pub struct DIDCommResponse {
+    pub type_: String,
+    pub body: Value,
+    pub thid: Option<String>,
+}
+
+impl DIDCommResponse {
+    pub fn new(type_: impl Into<String>, body: Value) -> Self {
+        Self {
+            type_: type_.into(),
+            body,
+            thid: None,
+        }
+    }
+
+    /// A problem-report reply. Uses the same DIDComm v2 report-problem type URI
+    /// the framework did (`vta_sdk::protocols::PROBLEM_REPORT_TYPE`).
+    pub fn problem_report(report: ProblemReport) -> Self {
+        Self::new(vta_sdk::protocols::PROBLEM_REPORT_TYPE, report.to_body())
+    }
+
+    /// Thread this reply to `thid` (the request's own id or thread id).
+    pub fn thid(mut self, thid: impl Into<String>) -> Self {
+        self.thid = Some(thid.into());
+        self
+    }
+}
+
+/// DIDComm problem-report body. Byte-identical serde to the framework's
+/// (mediator-common) `ProblemReport`, so on-wire reports are unchanged.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct ProblemReport {
+    pub code: String,
+    pub comment: String,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub args: Vec<String>,
+    #[serde(rename = "escalate_to", skip_serializing_if = "Option::is_none")]
+    pub escalate_to: Option<String>,
+}
+
+/// `e.p.msg.*` problem-report codes (the framework's `problem_report::codes`).
+pub mod codes {
+    pub const ERROR_UNAUTHORIZED: &str = "e.p.msg.unauthorized";
+    pub const ERROR_BAD_REQUEST: &str = "e.p.msg.bad-request";
+    pub const ERROR_NOT_FOUND: &str = "e.p.msg.not-found";
+    pub const ERROR_CONFLICT: &str = "e.p.msg.conflict";
+    pub const ERROR_INTERNAL: &str = "e.p.msg.internal-error";
+}
+
+/// Convenience constructors + `to_body`, mirroring the framework trait of the
+/// same name so the handler call-sites (`ProblemReport::conflict(..)`,
+/// `.to_body()`, etc.) compile unchanged.
+pub trait ServiceProblemReport {
+    fn unauthorized(comment: impl Into<String>) -> Self;
+    fn bad_request(comment: impl Into<String>) -> Self;
+    fn not_found(comment: impl Into<String>) -> Self;
+    fn conflict(comment: impl Into<String>) -> Self;
+    fn internal_error(comment: impl Into<String>) -> Self;
+    fn with_args(self, args: Vec<String>) -> Self;
+    fn with_escalate_to(self, escalate_to: String) -> Self;
+    fn to_body(&self) -> Value;
+}
+
+impl ProblemReport {
+    fn from_code(code: &str, comment: impl Into<String>) -> Self {
+        Self {
+            code: code.to_string(),
+            comment: comment.into(),
+            args: Vec::new(),
+            escalate_to: None,
+        }
+    }
+}
+
+impl ServiceProblemReport for ProblemReport {
+    fn unauthorized(comment: impl Into<String>) -> Self {
+        Self::from_code(codes::ERROR_UNAUTHORIZED, comment)
+    }
+    fn bad_request(comment: impl Into<String>) -> Self {
+        Self::from_code(codes::ERROR_BAD_REQUEST, comment)
+    }
+    fn not_found(comment: impl Into<String>) -> Self {
+        Self::from_code(codes::ERROR_NOT_FOUND, comment)
+    }
+    fn conflict(comment: impl Into<String>) -> Self {
+        Self::from_code(codes::ERROR_CONFLICT, comment)
+    }
+    fn internal_error(comment: impl Into<String>) -> Self {
+        Self::from_code(codes::ERROR_INTERNAL, comment)
+    }
+    fn with_args(mut self, args: Vec<String>) -> Self {
+        self.args = args;
+        self
+    }
+    fn with_escalate_to(mut self, escalate_to: String) -> Self {
+        self.escalate_to = Some(escalate_to);
+        self
+    }
+    fn to_body(&self) -> Value {
+        serde_json::to_value(self).unwrap_or_else(|e| {
+            tracing::warn!(error = %e, "Failed to serialize problem report");
+            serde_json::json!({
+                "code": codes::ERROR_INTERNAL,
+                "comment": "Failed to serialize problem report"
+            })
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn problem_report_serializes_like_the_framework() {
+        // args + escalate_to elided when empty/none (matches mediator-common).
+        let body = ProblemReport::bad_request("nope").to_body();
+        assert_eq!(body["code"], codes::ERROR_BAD_REQUEST);
+        assert_eq!(body["comment"], "nope");
+        assert!(body.get("args").is_none());
+        assert!(body.get("escalate_to").is_none());
+
+        let body = ProblemReport::bad_request("x")
+            .with_args(vec!["a".into()])
+            .with_escalate_to("support".into())
+            .to_body();
+        assert_eq!(body["args"], serde_json::json!(["a"]));
+        assert_eq!(body["escalate_to"], "support");
+    }
+}

--- a/vta-service/src/messaging/transient_handshake.rs
+++ b/vta-service/src/messaging/transient_handshake.rs
@@ -1,52 +1,59 @@
-//! Transient `DIDCommService` for first-enable handshake.
+//! Transient delivery-layer messaging service for the first-enable handshake.
 //!
 //! Spec: `docs/05-design-notes/didcomm-protocol-management.md`
 //! "Mediator handshake before promotion".
 //!
-//! At first-enable time the main `DIDCommService` isn't running
-//! (services.didcomm = false), so the live prover used by
-//! `migrate` can't be reused. This module spins up a minimal
-//! transient service just for the handshake round-trip:
+//! At first-enable time the main [`MessagingService`] isn't running
+//! (`services.didcomm = false`), so the live prover used by `migrate` can't be
+//! reused. This module spins up a **transient** delivery-layer service just for
+//! the handshake round-trip:
 //!
-//! 1. Build a stripped-down `BridgeHandler` with a fresh bridge —
-//!    just enough router surface to route the trust-ping pong via
-//!    the bridge's pending-map. No VtaState needed.
-//! 2. Start `DIDCommService` with an empty listener config and
-//!    a fresh cancellation token.
-//! 3. Hand to [`DIDCommServiceProver`] which runs steps 2-5
-//!    against this transient service.
-//! 4. Cancel the token so the service tears down.
+//! 1. Build an ATM (seeded with the VTA's secrets) + a bounded-websocket
+//!    [`ATMProfile`] against the new mediator, wrap it in a [`DidCommTransport`],
+//!    and drive it with a single-transport [`MessagingService`] over an
+//!    in-memory outbox.
+//! 2. Spawn a minimal trust-ping answerer on `subscribe()` (there is no full
+//!    handler set at first-enable) so the self-ping gets a pong.
+//! 3. Trust-ping the VTA's own DID via the new mediator and await the pong.
+//! 4. Cancel the answerer + drop the service so the websocket tears down.
 //!
-//! On success or failure, the transient service is shut down
-//! before returning. The caller (`enable_didcomm`) then publishes
-//! the LogEntry and persists `services.didcomm = true`; the next
-//! service restart starts the "real" main service which re-
-//! connects to the now-active mediator.
+//! On success or failure the transient service is torn down before returning.
+//! The caller (`enable_didcomm`) then publishes the LogEntry and persists
+//! `services.didcomm = true`; the next restart starts the real
+//! [`crate::messaging::service`] path, which re-connects to the now-active
+//! mediator.
 
 #![cfg(all(feature = "webvh", feature = "didcomm"))]
 
 use std::sync::Arc;
 use std::time::Duration;
 
+use affinidi_messaging_core::{MessageTransport, Protocol};
+use affinidi_messaging_delivery::{Delivery, InMemoryOutboxStore, MessagingService, OutboxStore};
 use affinidi_messaging_didcomm::Message;
-use affinidi_messaging_didcomm_service::{
-    DIDCommHandler, DIDCommResponse, DIDCommService, DIDCommServiceConfig, DIDCommServiceError,
-    HandlerContext, Router, TRUST_PING_TYPE, handler_fn, ignore_handler, trust_ping_handler,
-};
+use affinidi_tdk::common::TDKSharedState;
 use affinidi_tdk::common::config::TDKConfig;
+use affinidi_tdk::messaging::config::ATMConfig;
+use affinidi_tdk::messaging::profiles::ATMProfile;
+use affinidi_tdk::messaging::{ATM, DidCommTransport};
+use affinidi_tdk::secrets_resolver::SecretsResolver;
 use affinidi_tdk::secrets_resolver::secrets::Secret;
+use futures_util::StreamExt;
+use serde_json::{Value as JsonValue, json};
 use tokio_util::sync::CancellationToken;
 use tracing::warn;
-use vti_common::telemetry::SharedTelemetrySink;
+use vti_common::telemetry::{SharedTelemetrySink, TelemetryEvent, TelemetryKind};
 
-use crate::didcomm_bridge::DIDCommBridge;
 use crate::messaging::handshake::{
-    HandshakeError, HandshakeOptions, ResolvedMediator, mediator_handshake,
+    HandshakeError, HandshakeOptions, HandshakeStage, ProverFailure, ResolvedMediator,
+    resolve_mediator,
 };
-use crate::messaging::live_prover::{DIDCommServiceProver, StaticListenerConfigBuilder};
 
-/// Caller-supplied bits the transient service needs to authenticate
-/// the VTA's DID to the new mediator.
+const TRUST_PING_TYPE: &str = "https://didcomm.org/trust-ping/2.0/ping";
+const TRUST_PING_RESPONSE_TYPE: &str = "https://didcomm.org/trust-ping/2.0/ping-response";
+
+/// Caller-supplied bits the transient service needs to authenticate the VTA's
+/// DID to the new mediator.
 pub struct TransientHandshakeContext {
     pub vta_did: String,
     pub secrets: Vec<Secret>,
@@ -54,10 +61,8 @@ pub struct TransientHandshakeContext {
 }
 
 /// Run the full handshake against a freshly-spun-up transient
-/// `DIDCommService`. Returns `Ok(ResolvedMediator)` on success
-/// (caller can use the resolved endpoint for telemetry/registry).
-/// Always tears down the transient service before returning,
-/// regardless of outcome.
+/// [`MessagingService`]. Returns `Ok(ResolvedMediator)` on success. Always tears
+/// down the transient service before returning, regardless of outcome.
 pub async fn run_transient_handshake(
     ctx: TransientHandshakeContext,
     resolver: &affinidi_did_resolver_cache_sdk::DIDCacheClient,
@@ -65,122 +70,261 @@ pub async fn run_transient_handshake(
     mediator_did: &str,
     opts: HandshakeOptions,
 ) -> Result<ResolvedMediator, HandshakeError> {
-    // Fresh bridge for this handshake. Starts with no listeners;
-    // `add_listener` is called by the prover during step 2.
-    let bridge = Arc::new(DIDCommBridge::new(mediator_did));
-
-    let handler = match build_transient_handler(Arc::clone(&bridge)) {
-        Ok(h) => h,
-        Err(e) => {
+    // Step 1 — always resolve.
+    let resolved = match resolve_mediator(resolver, mediator_did).await {
+        Ok(r) => r,
+        Err(cause) => {
+            emit_failed(telemetry, mediator_did, HandshakeStage::Resolve, &cause).await;
             return Err(HandshakeError::Failed {
-                stage: crate::messaging::handshake::HandshakeStage::Connect,
-                cause: format!("transient handler build failed: {e}"),
+                stage: HandshakeStage::Resolve,
+                cause,
             });
         }
     };
 
-    let shutdown = CancellationToken::new();
-    let service_config = DIDCommServiceConfig { listeners: vec![] };
-    let service = match DIDCommService::start(service_config, handler, shutdown.clone()).await {
-        Ok(s) => s,
-        Err(e) => {
-            return Err(HandshakeError::Failed {
-                stage: crate::messaging::handshake::HandshakeStage::Connect,
-                cause: format!("transient DIDCommService::start failed: {e}"),
-            });
+    if opts.force {
+        let _ = telemetry
+            .record(
+                TelemetryEvent::new(TelemetryKind::MediatorHandshakeBypassed)
+                    .with_mediator(mediator_did)
+                    .with_field("endpoint", JsonValue::from(resolved.endpoint.clone())),
+            )
+            .await;
+        return Ok(resolved);
+    }
+
+    // Steps 2–5 against a transient service.
+    match transient_prove(&ctx, mediator_did, opts.timeout).await {
+        Ok(()) => {
+            let _ = telemetry
+                .record(
+                    TelemetryEvent::new(TelemetryKind::MediatorHandshakeOk)
+                        .with_mediator(mediator_did)
+                        .with_field("endpoint", JsonValue::from(resolved.endpoint.clone())),
+                )
+                .await;
+            Ok(resolved)
         }
+        Err(failure) => {
+            emit_failed(telemetry, mediator_did, failure.stage, &failure.cause).await;
+            Err(HandshakeError::Failed {
+                stage: failure.stage,
+                cause: failure.cause,
+            })
+        }
+    }
+}
+
+/// Build a transient single-transport delivery service against `mediator_did`,
+/// prove it with a self trust-ping, then tear it down.
+async fn transient_prove(
+    ctx: &TransientHandshakeContext,
+    mediator_did: &str,
+    timeout: Duration,
+) -> Result<(), ProverFailure> {
+    let connect_fail = |cause: String| ProverFailure {
+        stage: HandshakeStage::Connect,
+        cause,
     };
-    bridge.set_service(service.clone());
 
-    // Build the live prover against the transient service.
-    let config_builder = Arc::new(StaticListenerConfigBuilder::new(
-        &ctx.vta_did,
-        ctx.secrets,
-        ctx.tdk_config,
-    ));
-    let prover = DIDCommServiceProver::new(service.clone(), Arc::clone(&bridge), config_builder);
-
-    let result = mediator_handshake(
-        resolver,
-        &prover,
-        telemetry,
-        mediator_did,
-        &ctx.vta_did,
-        opts,
+    let tdk_config = match ctx.tdk_config.clone() {
+        Some(c) => c,
+        None => TDKConfig::builder()
+            .build()
+            .map_err(|e| connect_fail(format!("build TDK config: {e}")))?,
+    };
+    let tdk = TDKSharedState::new(tdk_config)
+        .await
+        .map_err(|e| connect_fail(format!("create TDK shared state: {e}")))?;
+    for secret in &ctx.secrets {
+        tdk.secrets_resolver().insert(secret.clone()).await;
+    }
+    let atm = ATM::new(
+        ATMConfig::builder()
+            .build()
+            .map_err(|e| connect_fail(format!("build ATM config: {e}")))?,
+        Arc::new(tdk),
     )
-    .await;
+    .await
+    .map_err(|e| connect_fail(format!("create ATM: {e}")))?;
 
-    // Tear down the transient service. The CancellationToken is
-    // the documented shutdown signal; service.shutdown() does the
-    // same thing more verbosely.
-    shutdown.cancel();
-    // Give the transient task a brief window to drop its
-    // listener cleanly. This isn't strictly required for
-    // correctness — the service will tear down on its own — but
-    // it stops a stray-listener warning from racing the next
-    // event log.
+    let profile = Arc::new(
+        ATMProfile::new(
+            &atm,
+            Some(mediator_did.to_string()),
+            ctx.vta_did.clone(),
+            Some(mediator_did.to_string()),
+        )
+        .await
+        .map_err(|e| connect_fail(format!("create transient profile: {e}")))?,
+    );
+    match tokio::time::timeout(timeout, atm.profile_enable_websocket(&profile)).await {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => return Err(connect_fail(format!("enable transient websocket: {e}"))),
+        Err(_) => {
+            return Err(connect_fail(
+                "timeout enabling transient mediator websocket".to_string(),
+            ));
+        }
+    }
+
+    let atm = Arc::new(atm);
+    let transport: Arc<dyn MessageTransport> = Arc::new(
+        DidCommTransport::new((*atm).clone(), profile.clone())
+            .await
+            .map_err(|e| connect_fail(format!("bind transient transport: {e}")))?,
+    );
+    let outbox: Arc<dyn OutboxStore> = Arc::new(InMemoryOutboxStore::new());
+    // Single transport → it is the primary; `send` (the pong) routes through it.
+    let service = Arc::new(MessagingService::new(transport, outbox));
+
+    // Minimal trust-ping answerer (there is no handler set at first-enable).
+    let answerer_shutdown = CancellationToken::new();
+    spawn_ping_answerer(
+        service.clone(),
+        atm.clone(),
+        ctx.vta_did.clone(),
+        answerer_shutdown.clone(),
+    );
+
+    let result = ping_self(&service, &atm, &ctx.vta_did, timeout).await;
+
+    // Tear down the answerer; dropping `service`/`atm` on return closes the
+    // transient websocket.
+    answerer_shutdown.cancel();
     tokio::time::sleep(Duration::from_millis(50)).await;
-
     result
 }
 
-/// Minimal `BridgeHandler`-equivalent for the transient handshake.
-/// The full `BridgeHandler` requires `VtaState` to power the
-/// inner router; for handshake we don't need any of that — just
-/// trust-ping and a fallback that ignores everything else (the
-/// trust-ping pong arrives on the listener and is routed via
-/// `bridge.try_complete` before reaching any handler anyway).
-fn build_transient_handler(
-    bridge: Arc<DIDCommBridge>,
-) -> Result<TransientBridgeHandler, DIDCommServiceError> {
-    let router = Router::new()
-        .route(TRUST_PING_TYPE, handler_fn(trust_ping_handler))?
-        .fallback(handler_fn(ignore_handler));
-    Ok(TransientBridgeHandler {
-        inner: router,
-        bridge,
-    })
-}
+/// Trust-ping the VTA's own DID over the transient service and await the pong.
+async fn ping_self(
+    service: &Arc<MessagingService>,
+    atm: &ATM,
+    vta_did: &str,
+    timeout: Duration,
+) -> Result<(), ProverFailure> {
+    let ping_fail = |cause: String| ProverFailure {
+        stage: HandshakeStage::TrustPing,
+        cause,
+    };
 
-struct TransientBridgeHandler {
-    inner: Router,
-    bridge: Arc<DIDCommBridge>,
-}
+    let msg_id = uuid::Uuid::new_v4().to_string();
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let ping = Message::build(
+        msg_id.clone(),
+        TRUST_PING_TYPE.to_string(),
+        json!({ "response_requested": true }),
+    )
+    .from(vta_did.to_string())
+    .to(vta_did.to_string())
+    .created_time(now)
+    .expires_time(now + timeout.as_secs())
+    .finalize();
+    let (packed, _) = atm
+        .pack_encrypted(&ping, vta_did, Some(vta_did), Some(vta_did))
+        .await
+        .map_err(|e| ping_fail(format!("pack trust-ping: {e}")))?;
 
-#[async_trait::async_trait]
-impl DIDCommHandler for TransientBridgeHandler {
-    async fn handle(
-        &self,
-        ctx: HandlerContext,
-        message: Message,
-        meta: affinidi_messaging_didcomm::UnpackMetadata,
-    ) -> Result<Option<DIDCommResponse>, DIDCommServiceError> {
-        // Route the trust-ping pong via the bridge's pending map
-        // before falling through to the router.
-        if self.bridge.try_complete(&message) {
-            return Ok(None);
-        }
-        // Log unexpected inbound traffic during handshake.
-        if message.thid.is_some() {
-            warn!(
-                msg_type = %message.typ,
-                "transient-handshake: unmatched response (stale or unrelated)"
-            );
-        }
-        self.inner.handle(ctx, message, meta).await
+    let received = service
+        .request(vta_did, packed.into_bytes(), &msg_id, timeout)
+        .await
+        .map_err(|e| ping_fail(format!("trust-ping round-trip failed: {e}")))?;
+
+    let response: Message = serde_json::from_slice(&received.payload)
+        .map_err(|e| ping_fail(format!("parse pong: {e}")))?;
+    if response.typ != TRUST_PING_RESPONSE_TYPE {
+        return Err(ping_fail(format!(
+            "unexpected reply to trust-ping: {}",
+            response.typ
+        )));
     }
+    Ok(())
+}
+
+/// Answer authenticated self trust-pings with a threaded pong over the same
+/// transient service, until `shutdown` fires.
+fn spawn_ping_answerer(
+    service: Arc<MessagingService>,
+    atm: Arc<ATM>,
+    vta_did: String,
+    shutdown: CancellationToken,
+) {
+    tokio::spawn(async move {
+        let mut stream = service.subscribe();
+        loop {
+            tokio::select! {
+                maybe = stream.next() => {
+                    let Some(inbound) = maybe else { break };
+                    if inbound.message.protocol != Protocol::DIDComm {
+                        continue;
+                    }
+                    let Ok(msg) = serde_json::from_slice::<Message>(&inbound.message.payload) else {
+                        continue;
+                    };
+                    if msg.typ != TRUST_PING_TYPE {
+                        continue;
+                    }
+                    // Only pong an authenticated (verified) sender; fall back to
+                    // the plaintext `from` solely as the reply address.
+                    let to = inbound
+                        .message
+                        .sender
+                        .clone()
+                        .filter(|_| inbound.message.verified)
+                        .or_else(|| msg.from.clone());
+                    let Some(to) = to else { continue };
+                    let pong = Message::build(
+                        uuid::Uuid::new_v4().to_string(),
+                        TRUST_PING_RESPONSE_TYPE.to_string(),
+                        JsonValue::Null,
+                    )
+                    .from(vta_did.clone())
+                    .to(to.clone())
+                    .thid(msg.id.clone())
+                    .finalize();
+                    if let Ok((packed, _)) = atm
+                        .pack_encrypted(&pong, &to, Some(&vta_did), Some(&vta_did))
+                        .await
+                        && let Err(e) = service
+                            .send(&to, packed.into_bytes(), Delivery::BestEffort)
+                            .await
+                    {
+                        warn!(error = %e, "transient handshake: failed to send pong");
+                    }
+                }
+                _ = shutdown.cancelled() => break,
+            }
+        }
+    });
+}
+
+async fn emit_failed(
+    telemetry: &SharedTelemetrySink,
+    mediator_did: &str,
+    stage: HandshakeStage,
+    cause: &str,
+) {
+    let _ = telemetry
+        .record(
+            TelemetryEvent::new(TelemetryKind::MediatorHandshakeFailed)
+                .with_mediator(mediator_did)
+                .with_field("stage", JsonValue::from(stage.as_str()))
+                .with_field("cause", JsonValue::from(cause)),
+        )
+        .await;
 }
 
 #[cfg(test)]
 mod tests {
     use crate::messaging::handshake::HandshakeStage;
 
-    /// Sentinel: the construction shape compiles. End-to-end
-    /// behaviour requires a mock mediator (deferred).
+    /// Sentinel: the construction shape compiles + the stages this module
+    /// produces are still present.
     #[test]
     fn transient_handshake_module_compiles() {
-        // Touch each named type to ensure refactors don't drop
-        // the public surface this module is meant to expose.
         let _stage = HandshakeStage::Resolve;
     }
 }

--- a/vta-service/src/messaging/tsp_inbound.rs
+++ b/vta-service/src/messaging/tsp_inbound.rs
@@ -1,6 +1,6 @@
-//! TSP (Trust Spanning Protocol) inbound handler.
+//! TSP (Trust Spanning Protocol) inbound handling.
 //!
-//! [`VtaTspHandler`] receives TSP messages off the VTA's **single** mediator
+//! [`dispatch_one`] receives TSP messages off the VTA's **single** mediator
 //! websocket — the *same* socket the DIDComm listener uses — and feeds each one
 //! into the shared [`dispatch_trust_task_core`](crate::trust_tasks) spine that
 //! REST and DIDComm also use. TSP is the highest-preference transport
@@ -8,28 +8,25 @@
 //!
 //! ## One socket, multiplexed
 //!
-//! The mediator permits **one websocket per DID**. The DIDComm service
-//! (`affinidi-messaging-didcomm-service`, ADR 0005 — `AffinidiMessageService`)
-//! owns that socket, sniffs inbound frames, and routes TSP frames to a
-//! [`TspHandler`]. The VTA registers `VtaTspHandler` via
-//! `DIDCommService::start_with_tsp`. There is **no second websocket** — opening
-//! one (as the earlier standalone loop did) made the mediator evict a
-//! connection as `w.websocket.duplicate-channel`, flapping the VTA.
+//! The mediator permits **one websocket per DID**. The delivery-layer
+//! `DidCommTransport` (D2 P2a) owns that socket and its `inbound()` surfaces
+//! BOTH DIDComm and TSP frames off it (`Inbound.message.protocol` tags which);
+//! the inbound loop (`super::service::handle_tsp`) hands each TSP frame's
+//! cleartext payload + proven `sender_vid` to [`dispatch_one`]. There is **no
+//! second websocket** — opening one (as the earlier standalone loop did) made
+//! the mediator evict a connection as `w.websocket.duplicate-channel`, flapping
+//! the VTA.
 //!
 //! ## Round-trip: the reply routes back over the same socket
 //!
 //! Each received Trust Task is dispatched on the shared spine and its response
-//! envelope is returned to the sender **over TSP** — the message service
-//! (`affinidi-messaging-didcomm-service` ≥ 0.3.14) seals the returned
-//! [`TspResponse`] to the proven `sender_vid` and routes it back over the same
-//! mediator socket (`send_routed([mediator_did, sender_vid])`). This mirrors the
-//! DIDComm `handle_trust_task` bridge, which returns the same framework document
-//! as its reply, so TSP and DIDComm callers get byte-identical round-trip
-//! semantics off the shared `dispatch_trust_task_core`.
+//! envelope is returned to the sender **over TSP** — the inbound loop seals the
+//! returned bytes to the proven `sender_vid` and routes them back over the same
+//! mediator socket (`atm.tsp().send_routed([mediator_did, sender_vid])`). This
+//! mirrors the DIDComm `handle_trust_task` bridge, which returns the same
+//! framework document as its reply, so TSP and DIDComm callers get
+//! byte-identical round-trip semantics off the shared `dispatch_trust_task_core`.
 
-use affinidi_messaging_didcomm_service::{
-    DIDCommServiceError, HandlerContext, TspHandler, TspResponse,
-};
 use tracing::info;
 
 use crate::messaging::auth::auth_from_did;
@@ -70,36 +67,12 @@ pub async fn dispatch_one(app_state: &AppState, payload: &[u8], sender_vid: &str
     outcome.body
 }
 
-/// TSP handler registered on the VTA's message service via
-/// [`AffinidiMessageService::start_with_tsp`](affinidi_messaging_didcomm_service::AffinidiMessageService::start_with_tsp).
-///
-/// The service unpacks the TSP frame off the shared websocket (yielding the
-/// cleartext payload + the cryptographically-authenticated `sender_vid`) and
-/// invokes [`handle`](TspHandler::handle), which bridges to the shared spine via
-/// [`dispatch_one`] and returns the response envelope as a [`TspResponse`]. The
-/// service seals + routes that reply back to the sender over the same socket.
-pub struct VtaTspHandler {
-    app_state: AppState,
-}
-
-impl VtaTspHandler {
-    pub fn new(app_state: AppState) -> Self {
-        Self { app_state }
-    }
-}
-
-#[async_trait::async_trait]
-impl TspHandler for VtaTspHandler {
-    async fn handle(
-        &self,
-        _ctx: HandlerContext,
-        payload: Vec<u8>,
-        sender_vid: String,
-    ) -> Result<Option<TspResponse>, DIDCommServiceError> {
-        let body = dispatch_one(&self.app_state, &payload, &sender_vid).await;
-        Ok(Some(TspResponse::new(body)))
-    }
-}
+// The delivery-layer inbound loop (`super::service::handle_tsp`) unpacks the
+// TSP frame off the shared mediator websocket (via `DidCommTransport`) into a
+// neutral `Inbound` with the proven `sender_vid`, calls [`dispatch_one`]
+// directly, and seals + routes the reply back — so the framework
+// `TspHandler`/`TspResponse` wrapper the old `start_with_tsp` path required is
+// no longer needed.
 
 #[cfg(test)]
 mod tests {

--- a/vta-service/src/routes/protocol.rs
+++ b/vta-service/src/routes/protocol.rs
@@ -237,14 +237,16 @@ pub async fn get_didcomm_status_handler(
         });
     }
 
+    // Live (non-latched, R6.2) messaging status off `MessagingService::status()`
+    // once the delivery-layer service is published; before that it is truthfully
+    // "disconnected" (messaging isn't up yet) — matching the prior latched
+    // default so the reported field is always present under `didcomm`.
     #[cfg(feature = "didcomm")]
     let websocket_status = Some(
         state
-            .didcomm_websocket_status
-            .read()
-            .await
-            .as_str()
-            .to_string(),
+            .didcomm_bridge
+            .messaging_status_str()
+            .unwrap_or_else(|| "disconnected".to_string()),
     );
     #[cfg(not(feature = "didcomm"))]
     let websocket_status: Option<String> = None;

--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -23,8 +23,6 @@ use crate::keys::KeyRecord;
 use crate::keys::derivation::Bip32Extension;
 use crate::keys::seed_store::SeedStore;
 use crate::keys::seeds::load_seed_bytes;
-#[cfg(feature = "didcomm")]
-use crate::messaging;
 #[cfg(feature = "rest")]
 use crate::routes;
 use crate::store::{KeyspaceHandle, Store};
@@ -34,12 +32,11 @@ use tower_http::trace::{DefaultMakeSpan, DefaultOnRequest, DefaultOnResponse, Tr
 use tracing::Level;
 use tracing::{debug, error, info, warn};
 
+// D2 P2a: the reliable-messaging delivery layer replaces the
+// `affinidi-messaging-didcomm-service` framework. `MessagingService` (built in
+// `messaging::service`) drives inbound + outbound over a `DidCommTransport`.
 #[cfg(feature = "didcomm")]
-use affinidi_messaging_didcomm_service::{
-    DIDCommService, DIDCommServiceConfig, ListenerConfig, Protocols, RestartPolicy, RetryConfig,
-};
-#[cfg(feature = "didcomm")]
-use affinidi_tdk_common::profiles::TDKProfile;
+use affinidi_messaging_delivery::MessagingService;
 #[cfg(feature = "didcomm")]
 use tokio_util::sync::CancellationToken;
 use vta_sdk::acl_setup;
@@ -190,11 +187,6 @@ pub struct AppState {
     pub ka_vm_id: Option<String>,
     #[cfg(feature = "didcomm")]
     pub didcomm_bridge: Arc<DIDCommBridge>,
-    /// WebSocket connection status of the DIDComm listener. Only meaningful
-    /// on the axum server path (`run()`); `build_app_state()` (TEE
-    /// front-ends) never wires the event logger that updates this field.
-    #[cfg(feature = "didcomm")]
-    pub didcomm_websocket_status: Arc<RwLock<DidcommWebsocketStatus>>,
     pub jwt_keys: Option<Arc<JwtKeys>>,
     pub atm: Option<ATM>,
     /// VTA's registered TSP profile, used to unpack `tsp-message` sealed
@@ -211,25 +203,6 @@ pub struct AppState {
     /// Prometheus metrics handle for rendering `/metrics` endpoint.
     #[cfg(feature = "rest")]
     pub metrics_handle: Option<crate::metrics::PrometheusHandle>,
-}
-
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub enum DidcommWebsocketStatus {
-    Connected,
-    Connecting,
-    #[default]
-    Disconnected,
-}
-
-impl DidcommWebsocketStatus {
-    #[must_use]
-    pub fn as_str(self) -> &'static str {
-        match self {
-            Self::Connected => "connected",
-            Self::Connecting => "connecting",
-            Self::Disconnected => "disconnected",
-        }
-    }
 }
 
 impl AuthState for AppState {
@@ -425,9 +398,6 @@ pub async fn build_app_state(
         didcomm_bridge: parts
             .didcomm_bridge
             .unwrap_or_else(|| Arc::new(DIDCommBridge::placeholder())),
-        #[cfg(feature = "didcomm")]
-        didcomm_websocket_status: Arc::new(RwLock::new(DidcommWebsocketStatus::Disconnected)),
-
         jwt_keys: auth.jwt_keys,
         atm: auth.atm,
         #[cfg(feature = "tsp")]
@@ -870,16 +840,6 @@ pub async fn run(
             );
         }
 
-        // The DIDComm-transport view of shared state. Derived from the single
-        // `AppState` so REST and DIDComm share the same config `RwLock`,
-        // `WebvhAuthLocks`, registry, sweeper, and telemetry (P1.1).
-        #[cfg(feature = "didcomm")]
-        let vta_state = if config.services.didcomm {
-            Some(Arc::new(messaging::router::VtaState::from(&app_state)))
-        } else {
-            None
-        };
-
         // Spawn REST thread (conditional)
         #[cfg(feature = "rest")]
         let rest_handle = if let Some(ref listener_ref) = std_listener {
@@ -898,9 +858,20 @@ pub async fn run(
         #[cfg(not(feature = "rest"))]
         let rest_handle: Option<std::thread::JoinHandle<()>> = None;
 
-        // Start DIDComm service (conditional)
+        // Start the delivery-layer messaging service (conditional).
+        //
+        // D2 P2a: the `MessagingService` over a `DidCommTransport` (built in
+        // `messaging::service::build_messaging`) replaces the framework
+        // `DIDCommService`. On success it is published into the outbound
+        // `DIDCommBridge` (so REST + DIDComm handlers can send) and drives the
+        // protocol-routed inbound loop; the `Arc<MessagingService>` handle is
+        // retained for drain teardown. `DidCommTransport::inbound()` multiplexes
+        // BOTH DIDComm and TSP frames off the one mediator socket (one socket
+        // per DID — a second would be evicted as `duplicate-channel`), so TSP
+        // receive is always on when compiled with `tsp`; `config.services.tsp`
+        // governs advertisement only.
         #[cfg(feature = "didcomm")]
-        let didcomm_service: Option<DIDCommService> = if let Some(ref vta_state) = vta_state {
+        let messaging_service: Option<Arc<MessagingService>> = if config.services.didcomm {
             match (
                 &app_state.secrets_resolver,
                 &config.vta_did,
@@ -921,83 +892,11 @@ pub async fn run(
                         secrets.push(s);
                     }
 
-                    let profile = TDKProfile::new(
-                        "VTA",
-                        vta_did,
-                        Some(&messaging_config.mediator_did),
-                        secrets,
-                    );
-
-                    // Build a TDKConfig for the DIDComm listener. Reuse the
-                    // already-initialized app-state resolver when available so
-                    // the listener sees the same seeded self-DID cache entry
-                    // (e.g. `preload_self_did_document`), instead of creating
-                    // a fresh resolver that starts cold and may hit network.
-                    // Fall back to resolver-url mode for degraded/startup paths
-                    // where app-state auth init yielded no resolver.
-                    let listener_tdk_config = {
-                        let mut builder = affinidi_tdk::common::config::TDKConfig::builder()
-                            .with_load_environment(false);
-                        if let Some(ref did_resolver) = app_state.did_resolver {
-                            builder = builder.with_did_resolver(did_resolver.clone());
-                        } else if let Some(ref url) = config.resolver_url {
-                            let resolver_config = DIDCacheConfigBuilder::default()
-                                .with_network_mode(url)
-                                .build();
-                            builder = builder.with_did_resolver_config(resolver_config);
-                        }
-                        builder.build().ok()
-                    };
-
-                    // TSP receive-capability is a **compile-time** property, not
-                    // a runtime toggle: a `tsp`-compiled VTA ALWAYS multiplexes
-                    // TSP + DIDComm on its single mediator websocket (one socket
-                    // per DID — a second would be evicted as
-                    // `duplicate-channel`). Gating the listener mode on
-                    // `config.services.tsp` used to leave a split-brain — a VTA
-                    // that advertised `#tsp` (via `services tsp enable`) but
-                    // hadn't rebooted with `[services] tsp = true` ran a
-                    // DIDComm-only receive path that couldn't unpack inbound TSP
-                    // frames, poison-looping them every ~30s. `config.services.tsp`
-                    // now governs **advertisement** only; receive is always on
-                    // when compiled with `tsp`. Build without the `tsp` feature
-                    // to exclude the TSP receive path entirely.
-                    let listen_tsp = cfg!(feature = "tsp");
-
-                    let service_config = DIDCommServiceConfig {
-                        listeners: vec![ListenerConfig {
-                            id: "vta-main".into(),
-                            profile,
-                            restart_policy: RestartPolicy::Always {
-                                backoff: RetryConfig {
-                                    initial_delay_secs: 5,
-                                    max_delay_secs: 60,
-                                },
-                            },
-                            tdk_config: listener_tdk_config,
-                            protocols: if listen_tsp {
-                                Protocols::BOTH
-                            } else {
-                                Protocols::DIDCOMM_ONLY
-                            },
-                            ..Default::default()
-                        }],
-                    };
-
-                    let handler = messaging::router::build_handler(
-                        Arc::clone(vta_state),
-                        app_state.clone(),
-                        didcomm_bridge.clone(),
-                    )
-                    .map_err(|e| {
-                        AppError::Internal(format!("failed to build DIDComm handler: {e}"))
-                    })?;
-
                     // Recovery: optionally clear this DID's mediator inbox over
                     // REST *before* enabling live delivery, so a poison /
                     // undeliverable backlog can't stall the pickup handshake and
-                    // wedge the (shared DIDComm+TSP) listener. Best-effort, and
-                    // off unless `messaging.drain_inbox_on_start` is set.
+                    // wedge the (shared DIDComm+TSP) socket. Best-effort, and off
+                    // unless `messaging.drain_inbox_on_start` is set.
                     if messaging_config.drain_inbox_on_start {
                         match app_state.atm.as_ref() {
                             Some(atm) => {
@@ -1019,74 +918,28 @@ pub async fn run(
                         }
                     }
 
-                    // With `tsp` compiled, always register the TSP handler so
-                    // inbound TSP frames off the shared socket reach the
-                    // trust-task spine — independent of whether TSP is currently
-                    // advertised. Without the feature, the plain DIDComm start.
-                    #[cfg(feature = "tsp")]
-                    let service_start = DIDCommService::start_with_tsp(
-                        service_config,
-                        handler,
-                        messaging::tsp_inbound::VtaTspHandler::new(app_state.clone()),
-                        didcomm_shutdown.clone(),
-                    );
-                    #[cfg(not(feature = "tsp"))]
-                    let service_start =
-                        DIDCommService::start(service_config, handler, didcomm_shutdown.clone());
-
-                    match service_start.await {
-                        Ok(service) => {
-                            {
-                                let mut status = app_state.didcomm_websocket_status.write().await;
-                                *status = DidcommWebsocketStatus::Connecting;
-                            }
-                            // Wait for the mediator connection before accepting traffic.
-                            // Race the wait against shutdown so a Ctrl-C while the
-                            // mediator is unreachable doesn't park us here for the full
-                            // 30s — `wait_connected` is itself signal-deaf upstream.
-                            tokio::select! {
-                                res = service.wait_connected(
-                                    "vta-main",
-                                    Duration::from_secs(30),
-                                ) => {
-                                    if let Err(e) = res {
-                                        let mut status = app_state.didcomm_websocket_status.write().await;
-                                        *status = DidcommWebsocketStatus::Disconnected;
-                                        warn!(
-                                            mediator = %messaging_config.mediator_did,
-                                            error = %e,
-                                            "DIDComm listener did not go live within 30s. Auth + \
-                                             websocket most likely connected, but live-delivery \
-                                             (message-pickup) never completed — and this single \
-                                             listener carries BOTH DIDComm and TSP, so both inbound \
-                                             paths are down. The mediator enforces one live-delivery \
-                                             websocket per DID, so the usual causes are: (1) an \
-                                             active websocket for this DID left by a prior process \
-                                             that wasn't cleanly stopped, or (2) an \
-                                             undeliverable/poison message queued for this DID that \
-                                             stalls the pickup handshake. The VTA keeps serving REST \
-                                             and retries in the background. To recover without \
-                                             touching the mediator, set \
-                                             `messaging.drain_inbox_on_start = true` and restart — \
-                                             the VTA will clear this DID's queued messages over REST \
-                                             before going live."
-                                        );
-                                    } else {
-                                        let mut status = app_state.didcomm_websocket_status.write().await;
-                                        *status = DidcommWebsocketStatus::Connected;
-                                    }
-                                }
-                                _ = didcomm_shutdown.cancelled() => {
-                                    let mut status = app_state.didcomm_websocket_status.write().await;
-                                    *status = DidcommWebsocketStatus::Disconnected;
-                                    info!("shutdown received before mediator connected");
-                                }
-                            }
-                            didcomm_bridge.set_service(service.clone());
-                            spawn_event_logger(
+                    let outbox_ks = apply_encryption(store.keyspace(crate::keyspaces::OUTBOX)?);
+                    match crate::messaging::service::build_messaging(
+                        secrets,
+                        vta_did,
+                        &messaging_config.mediator_did,
+                        outbox_ks,
+                        app_state.did_resolver.as_ref(),
+                        config.resolver_url.as_deref(),
+                    )
+                    .await
+                    {
+                        Ok(messaging) => {
+                            let service = messaging.service.clone();
+                            // Publish the outbound wiring so every REST/DIDComm
+                            // component can send to a peer over this one
+                            // connection (`DIDCommBridge` → `MessagingService`).
+                            app_state.didcomm_bridge.set_messaging(
                                 service.clone(),
-                                Arc::clone(&app_state.didcomm_websocket_status),
+                                (*messaging.atm).clone(),
+                                vta_did.clone(),
                             );
+
                             // Register the config-loaded mediator in the listener
                             // registry so the delegated step-up push (which buffers
                             // outbound through the registry) can reach approvers on
@@ -1105,9 +958,6 @@ pub async fn run(
                                 .await;
 
                             // Set the VTA's own ACL on the mediator to accept all messages.
-                            // This happens after the connection succeeds, so we have a live
-                            // transport to send the trust task. The ACL setting is
-                            // fire-and-forget (spawns internally) — startup is not blocked.
                             // The ACL is keyed on the VTA's DID, so it authorises the account
                             // for both DIDComm *and* TSP, which share this one mediator socket.
                             // Only runs when `setup_acl = true` in the messaging config
@@ -1130,13 +980,23 @@ pub async fn run(
                                 }
                             }
 
-                            info!("DIDComm service started");
+                            // Spawn the protocol-routed inbound loop. It runs until
+                            // `didcomm_shutdown` is cancelled (Ctrl-C or soft
+                            // restart), dispatching DIDComm frames to the handler
+                            // set and TSP frames to the trust-task spine.
+                            tokio::spawn(crate::messaging::service::run_inbound_loop(
+                                Arc::new(messaging),
+                                app_state.clone(),
+                                vta_did.clone(),
+                                messaging_config.mediator_did.clone(),
+                                didcomm_shutdown.clone(),
+                            ));
+
+                            info!("DIDComm messaging started");
                             Some(service)
                         }
                         Err(e) => {
-                            let mut status = app_state.didcomm_websocket_status.write().await;
-                            *status = DidcommWebsocketStatus::Disconnected;
-                            warn!("failed to start DIDComm service: {e}");
+                            warn!("failed to start DIDComm messaging: {e}");
                             None
                         }
                     }
@@ -1150,15 +1010,15 @@ pub async fn run(
             None
         };
         #[cfg(not(feature = "didcomm"))]
-        let didcomm_service: Option<()> = None;
+        let messaging_service: Option<()> = None;
 
-        // TSP inbound is no longer a standalone websocket. When `services.tsp`
-        // is on, the DIDComm service above multiplexes TSP frames off its
-        // single mediator websocket and routes them to `VtaTspHandler`
-        // (registered via `start_with_tsp`). Opening a second socket here — as
-        // the earlier `run_tsp_inbound` loop did — made the mediator evict a
-        // connection as `duplicate-channel`, flapping the VTA. See
-        // `messaging::tsp_inbound`.
+        // TSP inbound is no longer a standalone websocket. The delivery-layer
+        // `DidCommTransport` built above multiplexes TSP frames off its single
+        // mediator websocket (`Inbound.message.protocol` tags DIDComm vs TSP);
+        // the inbound loop routes each TSP frame to `messaging::tsp_inbound`.
+        // Opening a second socket here — as the earlier `run_tsp_inbound` loop
+        // did — made the mediator evict a connection as `duplicate-channel`,
+        // flapping the VTA. See `messaging::tsp_inbound`.
 
         // Spawn the teardown channel consumer. The drain sweeper
         // sends mediator DIDs over `teardown_rx` whenever a TTL
@@ -1169,7 +1029,7 @@ pub async fn run(
         // keyspace level by the sweeper.
         #[cfg(all(feature = "webvh", feature = "didcomm"))]
         let _teardown_handle = {
-            let didcomm_service_ref = didcomm_service.clone();
+            let messaging_service_ref = messaging_service.clone();
             let mut teardown_rx = teardown_rx;
             let mut shutdown_rx_for_teardown = shutdown_rx.clone();
             tokio::spawn(async move {
@@ -1185,23 +1045,21 @@ pub async fn run(
                             match msg {
                                 None => break,
                                 Some(mediator_did) => {
-                                    if let Some(ref svc) = didcomm_service_ref {
-                                        if let Err(e) = svc.remove_listener(&mediator_did).await {
-                                            warn!(
-                                                mediator = %mediator_did,
-                                                error = %e,
-                                                "drain teardown: remove_listener failed"
-                                            );
-                                        } else {
-                                            info!(
-                                                mediator = %mediator_did,
-                                                "drain teardown: listener removed"
-                                            );
-                                        }
+                                    // The drain window kept the OLD mediator's
+                                    // transport installed (still receiving inbound
+                                    // via the merged dispatcher) after promote; its
+                                    // fjall drain-entry TTL has now expired, so drop
+                                    // it from the delivery-layer service.
+                                    if let Some(ref svc) = messaging_service_ref {
+                                        svc.remove_transport(&mediator_did);
+                                        info!(
+                                            mediator = %mediator_did,
+                                            "drain teardown: transport removed"
+                                        );
                                     } else {
                                         debug!(
                                             mediator = %mediator_did,
-                                            "drain teardown: DIDComm not running, skipping remove_listener"
+                                            "drain teardown: DIDComm not running, skipping remove_transport"
                                         );
                                     }
                                 }
@@ -1276,15 +1134,18 @@ pub async fn run(
             }
         }
 
-        // Gracefully shut down the DIDComm service and wait for listeners
-        // to disconnect from the mediator.
+        // Stop DIDComm messaging: cancel the inbound loop's shutdown token.
+        // The delivery-layer background tasks (dispatcher, transport forwarder,
+        // outbox drain loops) are detached — as in the VTC pilot — and wind down
+        // as their `Arc<MessagingService>`/transport handles drop.
         #[cfg(feature = "didcomm")]
-        if let Some(ref service) = didcomm_service {
-            service.shutdown().await;
-            info!("DIDComm service stopped");
+        {
+            didcomm_shutdown.cancel();
+            let _ = &messaging_service;
+            info!("DIDComm messaging stopped");
         }
         #[cfg(not(feature = "didcomm"))]
-        let _ = didcomm_service;
+        let _ = messaging_service;
 
         if any_panic {
             let _ = shutdown_tx.send(true);
@@ -2098,51 +1959,9 @@ async fn drain_mediator_inbox(atm: &ATM, mediator_did: &str, vta_did: &str) -> u
     cleared
 }
 
-/// Spawn a background task that logs DIDComm listener lifecycle events.
-#[cfg(feature = "didcomm")]
-fn spawn_event_logger(
-    service: DIDCommService,
-    websocket_status: Arc<RwLock<DidcommWebsocketStatus>>,
-) {
-    use affinidi_messaging_didcomm_service::ListenerEvent;
-
-    let mut rx = service.subscribe();
-    tokio::spawn(async move {
-        loop {
-            match rx.recv().await {
-                Ok(ListenerEvent::Connected { listener_id }) => {
-                    *websocket_status.write().await = DidcommWebsocketStatus::Connected;
-                    info!(listener = %listener_id, "DIDComm listener connected to mediator");
-                }
-                Ok(ListenerEvent::Disconnected { listener_id, error }) => {
-                    *websocket_status.write().await = DidcommWebsocketStatus::Disconnected;
-                    warn!(
-                        listener = %listener_id,
-                        error = error.as_deref().unwrap_or("none"),
-                        "DIDComm listener disconnected from mediator"
-                    );
-                }
-                Ok(ListenerEvent::Restarting {
-                    listener_id,
-                    attempt,
-                    delay,
-                }) => {
-                    *websocket_status.write().await = DidcommWebsocketStatus::Connecting;
-                    info!(
-                        listener = %listener_id,
-                        attempt,
-                        delay_secs = delay.as_secs(),
-                        "DIDComm listener restarting"
-                    );
-                }
-                Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
-                Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
-                    warn!(skipped = n, "DIDComm event logger lagged");
-                }
-            }
-        }
-    });
-}
+// The framework's `ListenerEvent`-based `spawn_event_logger` is gone with the
+// `DIDCommService`. Messaging connectivity is now read live (non-latched, R6.2)
+// off `MessagingService::status()` via `DIDCommBridge::messaging_status_str`.
 
 async fn shutdown_signal() {
     let ctrl_c = async {

--- a/vta-service/src/test_support.rs
+++ b/vta-service/src/test_support.rs
@@ -872,10 +872,6 @@ pub async fn build_test_app_with(opts: TestAppOptions) -> (axum::Router, TestApp
         ka_vm_id: None,
         #[cfg(feature = "didcomm")]
         didcomm_bridge: Arc::new(DIDCommBridge::placeholder()),
-        #[cfg(feature = "didcomm")]
-        didcomm_websocket_status: Arc::new(tokio::sync::RwLock::new(
-            crate::server::DidcommWebsocketStatus::Disconnected,
-        )),
         jwt_keys: Some(jwt_keys.clone()),
         atm: None,
         #[cfg(feature = "tsp")]


### PR DESCRIPTION
## What

Cuts the VTA's DIDComm messaging off the `affinidi-messaging-didcomm-service` framework and onto the reliable-messaging **delivery layer** (`MessagingService` + `DidCommTransport` + `VtiOutboxStore`), mirroring the merged VTC pilot (`vtc-service/src/messaging.rs`). Closes **F2/F6**.

## How

- **Inbound** — a protocol-routed loop over `MessagingService::subscribe()`. DIDComm frames rehydrate the plaintext `Message` and dispatch by type to the **~50 existing handlers, unchanged**, via a local shim (`messaging::shim` supplies `HandlerContext`/`Extension`/`DIDCommResponse`/`DIDCommServiceError`, so the handler bodies + the `didcomm_handler!` macro compile with only a `use`-line change). TSP frames (`tsp` feature) go to `tsp_inbound::dispatch_one`.
- **Outbound** — `DIDCommBridge` is **repurposed as an adapter** over the delivery layer, keeping its type + public method surface so the ~25 WebVH/provision/CLI/test call-sites (and the free `placeholder()`) are untouched: `send_and_wait` → `request` (the outbound message id is the correlation thread id), `send_oneway` → `send(BestEffort)`, `send_and_wait_via` → `request_via`. The old pending-map / `try_complete` / `send_message_with_retry` are gone — the delivery dispatcher owns thread-id correlation. `problem_report_to_app_error` + its full test module are kept verbatim.
- **Mediator management** over the multi-transport service: `live_prover` (migrate/rollback) = `add_transport(candidate)` → `request_via` self trust-ping → `promote` (`remove_transport` on failure); `transient_handshake` (first-enable) proves a transient single-transport service; **drain** keeps the old transport installed after promote and drops it via `remove_transport` when the fjall drain TTL fires. `services didcomm enable/update/disable/rollback/drain` behaviour preserved.
- **Health** — `didcomm_websocket_status` → live `messaging_status` off `MessagingService::status()` (non-latched, R6.2).
- Uses `MessagingService::new` (consume-only receipts). Layer-receipt *emit* + a `ReceiptPacker` land with Guaranteed VTA pushes in **P2b**. Adds a VTA `OUTBOX` keyspace (excluded from backup). Depends on `affinidi-messaging-delivery` **0.1.11** (the `request_via` primitive, tdk-rs #626).

## Security — auth posture preserved (reviewer note)

The framework `MessagePolicy` layer previously gated **every** route with `require_encrypted` + `require_authenticated` + `allow_anonymous_sender=false`. Removing it and relying on per-handler `auth_from_message` would have silently opened the handlers that don't self-authenticate (TEE status/attestation, discovery) to **anonymous senders**. To prevent that regression, the inbound loop:

1. stamps `Message::from` and `ctx.sender_did` with the cryptographically-authenticated sender **only** (`inbound.message.sender` filtered by `verified` — the #620 guarantee), and
2. rejects, **before dispatch and for all message types**, any frame that is not encrypted or has no authenticated non-anonymous sender.

This is a faithful in-loop translation of the removed middleware (no discovery exemption — the old layer required authcrypt there too). All macro-generated handlers additionally still run `auth_from_message` + their capability `Gate`.

## Verification

- `cargo check -p vta-service` (default) and `--features tsp` — clean.
- `cargo clippy -p vta-service --all-targets` — clean on changed code.
- `cargo test -p vta-service` — **all green** (116 api_integration + 922 lib + the rest; 0 failed). The added auth gate broke no test, confirming no legitimate anonymous-over-DIDComm flow existed.

## Follow-ups

- **P2b** — Guaranteed VTA pushes (step-up / consent / credential issuance) + layer-receipt emit (`with_receipts` + a `ReceiptPacker`).
- The `affinidi-messaging-didcomm-service` dependency line is now unused by the crate; can be pruned separately.