### PR TITLE
feat: least-privilege approvers — separate 'may approve' from 'may act'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 ## Unreleased
 
+### vti-common / vta-service — least-privilege approvers: separate "may approve" from "may act"
+
+* An approval only *conferred* delegated authority (task-consent
+  `compute_delegated_contexts`, step-up `delegated_any_approver_covers`) if the
+  approver was `Role::Admin` of the subject's context — which is also the power
+  to change DIDs in it directly, and approving across all contexts required a
+  super-admin. The reviewer had to hold the maximal power to make the very change
+  it was meant to check.
+* **Fix 1** — new `ApproveScope` (`none` | `all` | `contexts([...])`) on the ACL
+  entry, read only by the two conferral paths and never by
+  `require_admin`/`has_context_access`. An approver can now be `role: reader`,
+  `allowed_contexts: []` (acts nowhere) with `approve_scope: all` (authorizes
+  anywhere). Both conferral paths honour it in addition to the existing admin
+  path (backward compatible; pre-existing rows deserialise as `none`,
+  fail-closed). Granting it is privilege-checked: `all` is super-admin-only, a
+  scoped grant requires the caller to hold each context. Exposed on the ACL
+  create surface (trust-task / DIDComm / REST) and the CLI (`--approve-all` /
+  `--approve-contexts`).
+* **Fix 2** — new `AuthClaims::with_delegated_authority`: a consumed consent
+  grant now lifts the ephemeral role to `Admin` (not just the context) for the
+  single bound dispatch, so a purely unprivileged requester can execute a task an
+  approver blessed. The webvh update guard is relaxed to match: Plan mode needs
+  only `require_read` (a dry-run reveals just the public DID-document diff), and
+  Execute is satisfied by the delegated grant. The requester (e.g. the browser
+  plugin) can therefore hold no standing admin — every cross-context edit is
+  gated on a live approval. The widening stays single-dispatch and is never
+  persisted to the session, JWT, or ACL.
+
 ### vta-service — recover from a wedged mediator listener (drain-on-start + clearer logging)
 
 * The mediator enforces one live-delivery websocket per DID, and the VTA's single

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2469,7 +2469,7 @@ checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cnm-cli"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "clap",
@@ -2483,7 +2483,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.19.6",
+ "vta-sdk 0.19.7",
 ]
 
 [[package]]
@@ -3285,7 +3285,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.19.6",
+ "vta-sdk 0.19.7",
 ]
 
 [[package]]
@@ -6723,7 +6723,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "pnm-cli"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-resolver-cache-sdk",
@@ -6745,7 +6745,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.19.6",
+ "vta-sdk 0.19.7",
 ]
 
 [[package]]
@@ -10030,7 +10030,7 @@ dependencies = [
 
 [[package]]
 name = "vta-cli-common"
-version = "0.10.5"
+version = "0.10.6"
 dependencies = [
  "aes-gcm",
  "affinidi-crypto",
@@ -10048,7 +10048,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.19.6",
+ "vta-sdk 0.19.7",
  "vti-common",
  "x25519-dalek",
 ]
@@ -10081,7 +10081,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.19.6",
+ "vta-sdk 0.19.7",
 ]
 
 [[package]]
@@ -10104,7 +10104,7 @@ dependencies = [
  "tracing-subscriber",
  "trust-tasks-rs",
  "uniffi",
- "vta-sdk 0.19.6",
+ "vta-sdk 0.19.7",
 ]
 
 [[package]]
@@ -10139,7 +10139,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.19.6"
+version = "0.19.7"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10196,7 +10196,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.11.5"
+version = "0.11.6"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",
@@ -10274,7 +10274,7 @@ dependencies = [
  "utoipa-axum",
  "uuid",
  "vta-cli-common",
- "vta-sdk 0.19.6",
+ "vta-sdk 0.19.7",
  "vta-service",
  "vti-common",
  "vti-secrets",
@@ -10296,7 +10296,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.19.6",
+ "vta-sdk 0.19.7",
 ]
 
 [[package]]
@@ -10370,7 +10370,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.19.6",
+ "vta-sdk 0.19.7",
  "vtc-service",
  "vti-common",
  "vti-secrets",
@@ -10383,7 +10383,7 @@ dependencies = [
 
 [[package]]
 name = "vti-common"
-version = "0.11.6"
+version = "0.11.7"
 dependencies = [
  "aes-gcm",
  "affinidi-did-resolver-cache-sdk",
@@ -10419,7 +10419,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.19.6",
+ "vta-sdk 0.19.7",
  "webauthn-rs",
  "zeroize",
 ]
@@ -10446,7 +10446,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.19.6",
+ "vta-sdk 0.19.7",
  "vta-service",
  "vti-common",
 ]
@@ -10475,7 +10475,7 @@ dependencies = [
  "tokio",
  "tracing",
  "vaultrs",
- "vta-sdk 0.19.6",
+ "vta-sdk 0.19.7",
  "vti-common",
 ]
 

--- a/cnm-cli/Cargo.toml
+++ b/cnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cnm-cli"
 description = "CLI Tool for Verified Trust Agents operating in Verified Trust Communities"
-version = "0.11.0"
+version = "0.11.1"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/cnm-cli/src/main.rs
+++ b/cnm-cli/src/main.rs
@@ -1124,9 +1124,20 @@ async fn main() {
                 .transpose()
             {
                 Ok(expires_at) => {
-                    // cnm does not expose the per-entry step-up flags.
-                    acl::cmd_acl_create(&client, did, role, label, contexts, expires_at, None, None)
-                        .await
+                    // cnm does not expose the per-entry step-up or approve flags.
+                    acl::cmd_acl_create(
+                        &client,
+                        did,
+                        role,
+                        label,
+                        contexts,
+                        expires_at,
+                        None,
+                        None,
+                        false,
+                        Vec::new(),
+                    )
+                    .await
                 }
                 Err(e) => Err(format!("--expires: {e}").into()),
             },

--- a/pnm-cli/Cargo.toml
+++ b/pnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pnm-cli"
 description = "CLI Tool for managing a personal Verifiable Trust Agent"
-version = "0.11.0"
+version = "0.11.1"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/pnm-cli/src/cli.rs
+++ b/pnm-cli/src/cli.rs
@@ -1669,6 +1669,16 @@ pub(crate) enum AclCommands {
         /// floor for this subject (`stepUp.require`). Omit for none.
         #[arg(long)]
         step_up_require: Option<String>,
+        /// Grant approve-authority over ALL contexts: this DID may *approve*
+        /// (confer) a change across every context while being able to *act* in
+        /// none. Super-admin only. Pair with `--role reader --contexts ''`.
+        #[arg(long)]
+        approve_all: bool,
+        /// Grant approve-authority scoped to these contexts (comma-separated):
+        /// may confer them via approval, cannot act in them. Ignored when
+        /// `--approve-all` is set.
+        #[arg(long, value_delimiter = ',')]
+        approve_contexts: Vec<String>,
     },
     /// Update an ACL entry
     Update {

--- a/pnm-cli/src/commands/acl.rs
+++ b/pnm-cli/src/commands/acl.rs
@@ -20,6 +20,8 @@ pub(crate) async fn run(
             expires,
             step_up_approver,
             step_up_require,
+            approve_all,
+            approve_contexts,
         } => match resolve_expires_at(expires.as_deref()) {
             Ok(expires_at) => {
                 acl::cmd_acl_create(
@@ -31,6 +33,8 @@ pub(crate) async fn run(
                     expires_at,
                     step_up_approver,
                     step_up_require,
+                    approve_all,
+                    approve_contexts,
                 )
                 .await
             }

--- a/vta-cli-common/Cargo.toml
+++ b/vta-cli-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-cli-common"
 description = "Shared CLI command handlers and rendering helpers for VTA CLIs"
 readme = "README.md"
-version = "0.10.5"
+version = "0.10.6"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-cli-common/src/commands/acl.rs
+++ b/vta-cli-common/src/commands/acl.rs
@@ -152,6 +152,8 @@ pub async fn cmd_acl_create(
     expires_at: Option<u64>,
     step_up_approver: Option<String>,
     step_up_require: Option<String>,
+    approve_all: bool,
+    approve_contexts: Vec<String>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     validate_role(&role)?;
     let mut req = CreateAclRequest::new(did, role).contexts(contexts);
@@ -166,6 +168,11 @@ pub async fn cmd_acl_create(
     }
     if let Some(ref require) = step_up_require {
         req = req.step_up_require(require.clone());
+    }
+    if approve_all {
+        req = req.approve_all();
+    } else if !approve_contexts.is_empty() {
+        req = req.approve_contexts(approve_contexts);
     }
     let entry = client.create_acl(req).await?;
     println!("ACL entry created:");

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.19.6"
+version = "0.19.7"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/client/mod.rs
+++ b/vta-sdk/src/client/mod.rs
@@ -1251,6 +1251,8 @@ mod tests {
             expires_at: None,
             step_up_approver: None,
             step_up_require: None,
+            approve_all_contexts: false,
+            approve_contexts: vec![],
         };
         let json = serde_json::to_value(&req).unwrap();
         assert_eq!(json["did"], "did:key:z6Mk123");

--- a/vta-sdk/src/client/types.rs
+++ b/vta-sdk/src/client/types.rs
@@ -350,6 +350,13 @@ pub struct CreateAclRequest {
     /// floor for this subject. Omit for none.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub step_up_require: Option<String>,
+    /// Approve-authority over any context (confer via approval, act nowhere).
+    /// Super-admin-only to grant. Takes precedence over `approve_contexts`.
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub approve_all_contexts: bool,
+    /// Approve-authority scoped to these contexts. Empty = confers nothing.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub approve_contexts: Vec<String>,
 }
 
 impl CreateAclRequest {
@@ -362,6 +369,8 @@ impl CreateAclRequest {
             expires_at: None,
             step_up_approver: None,
             step_up_require: None,
+            approve_all_contexts: false,
+            approve_contexts: Vec::new(),
         }
     }
     pub fn label(mut self, label: impl Into<String>) -> Self {
@@ -385,6 +394,17 @@ impl CreateAclRequest {
     /// `"delegated"`), which raises the system floor for this subject.
     pub fn step_up_require(mut self, require: impl Into<String>) -> Self {
         self.step_up_require = Some(require.into());
+        self
+    }
+    /// Grant approve-authority over **all** contexts (confer via approval, act
+    /// nowhere). Super-admin-only on the server.
+    pub fn approve_all(mut self) -> Self {
+        self.approve_all_contexts = true;
+        self
+    }
+    /// Grant approve-authority scoped to these contexts.
+    pub fn approve_contexts(mut self, contexts: Vec<String>) -> Self {
+        self.approve_contexts = contexts;
         self
     }
 }

--- a/vta-sdk/src/protocols/acl_management/create.rs
+++ b/vta-sdk/src/protocols/acl_management/create.rs
@@ -45,6 +45,25 @@ pub struct CreateAclBody {
         alias = "step_up_require"
     )]
     pub step_up_require: Option<String>,
+    /// Approve-authority: this DID may **confer** access via an approval
+    /// (task-consent delegation / step-up ratification) over any context,
+    /// **without** any authority to act. Granting this is super-admin-only.
+    /// Takes precedence over `approve_contexts`. Stored as `approve_scope`.
+    #[serde(
+        default,
+        skip_serializing_if = "std::ops::Not::not",
+        alias = "approve_all_contexts"
+    )]
+    pub approve_all_contexts: bool,
+    /// Approve-authority scoped to these contexts (and their subtrees): the DID
+    /// may confer them via approval but cannot act in them. Ignored when
+    /// `approve_all_contexts` is set. Empty = confers nothing (the default).
+    #[serde(
+        default,
+        skip_serializing_if = "Vec::is_empty",
+        alias = "approve_contexts"
+    )]
+    pub approve_contexts: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -138,10 +157,42 @@ mod tests {
             expires_at: Some(1_800_000_000),
             step_up_approver: None,
             step_up_require: None,
+            approve_all_contexts: false,
+            approve_contexts: vec![],
         };
         let v = serde_json::to_value(&body).unwrap();
         assert!(v.get("allowedContexts").is_some());
         assert!(v.get("expiresAt").is_some());
         assert!(v.get("allowed_contexts").is_none());
+    }
+
+    /// Approve-authority fields round-trip via camelCase, and snake_case aliases
+    /// are still accepted; the boolean/list default to off so an omitted scope
+    /// confers nothing.
+    #[test]
+    fn approve_scope_fields_round_trip_and_default_off() {
+        let json = serde_json::json!({
+            "did": "did:key:z6MkApprover",
+            "role": "reader",
+            "approveAllContexts": true,
+        });
+        let body: CreateAclBody = serde_json::from_value(json).unwrap();
+        assert!(body.approve_all_contexts);
+        assert!(body.approve_contexts.is_empty());
+
+        let json = serde_json::json!({
+            "did": "did:key:z6MkApprover",
+            "role": "reader",
+            "approve_contexts": ["openvtc"],
+        });
+        let body: CreateAclBody = serde_json::from_value(json).unwrap();
+        assert!(!body.approve_all_contexts);
+        assert_eq!(body.approve_contexts, vec!["openvtc"]);
+
+        // Absent ⇒ confers nothing.
+        let json = serde_json::json!({ "did": "did:key:zX", "role": "reader" });
+        let body: CreateAclBody = serde_json::from_value(json).unwrap();
+        assert!(!body.approve_all_contexts);
+        assert!(body.approve_contexts.is_empty());
     }
 }

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.11.5"
+version = "0.11.6"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/messaging/handlers.rs
+++ b/vta-service/src/messaging/handlers.rs
@@ -594,6 +594,10 @@ didcomm_handler!(
             body.expires_at,
             body.step_up_approver,
             body.step_up_require,
+            operations::acl::approve_scope_from_wire(
+                body.approve_all_contexts,
+                body.approve_contexts,
+            ),
             "didcomm",
         )
         .await

--- a/vta-service/src/operations/acl.rs
+++ b/vta-service/src/operations/acl.rs
@@ -8,8 +8,9 @@ use vta_sdk::protocols::acl_management::{
 };
 
 use crate::acl::{
-    AclEntry, Role, delete_acl_entry, get_acl_entry, is_acl_entry_visible, list_acl_entries,
-    store_acl_entry, validate_acl_modification, validate_role_assignment,
+    AclEntry, ApproveScope, Role, delete_acl_entry, get_acl_entry, is_acl_entry_visible,
+    list_acl_entries, store_acl_entry, validate_acl_modification, validate_approve_scope_grant,
+    validate_role_assignment,
 };
 use crate::auth::AuthClaims;
 use crate::auth::session::now_epoch;
@@ -41,6 +42,19 @@ pub fn parse_step_up_require(s: Option<&str>) -> Result<Option<StepUpMode>, AppE
         Some(other) => Err(AppError::Validation(format!(
             "invalid stepUp.require '{other}': must be 'self' or 'delegated'"
         ))),
+    }
+}
+
+/// Build an [`ApproveScope`] from the two wire fields. `all` wins over an
+/// explicit context list; both absent ⇒ [`ApproveScope::None`] (confers
+/// nothing, the default).
+pub fn approve_scope_from_wire(all: bool, contexts: Vec<String>) -> ApproveScope {
+    if all {
+        ApproveScope::All
+    } else if !contexts.is_empty() {
+        ApproveScope::Contexts(contexts)
+    } else {
+        ApproveScope::None
     }
 }
 
@@ -131,12 +145,19 @@ pub async fn create_acl(
     expires_at: Option<u64>,
     step_up_approver: Option<String>,
     step_up_require: Option<String>,
+    approve_scope: ApproveScope,
     channel: &str,
 ) -> Result<CreateAclResultBody, AppError> {
     auth.require_manage()?;
     validate_role_assignment(auth, &role)?;
     validate_acl_modification(auth, &allowed_contexts)?;
+    // Granting approve-authority is its own privilege check: `all` is
+    // super-admin-only, a scoped grant requires the caller to hold each context.
+    validate_approve_scope_grant(auth, &approve_scope)?;
     require_contexts_exist(contexts_ks, &allowed_contexts).await?;
+    if let ApproveScope::Contexts(cs) = &approve_scope {
+        require_contexts_exist(contexts_ks, cs).await?;
+    }
     let step_up_require = parse_step_up_require(step_up_require.as_deref())?;
 
     if get_acl_entry(acl_ks, did).await?.is_some() {
@@ -150,7 +171,8 @@ pub async fn create_acl(
         .with_contexts(allowed_contexts)
         .with_expires_at(expires_at)
         .with_step_up_approver(step_up_approver)
-        .with_step_up_require(step_up_require);
+        .with_step_up_require(step_up_require)
+        .with_approve_scope(approve_scope);
 
     store_acl_entry(acl_ks, &entry).await?;
 
@@ -760,6 +782,7 @@ mod tests {
             None,
             None,
             None,
+            ApproveScope::None,
             "test",
         )
         .await
@@ -794,6 +817,7 @@ mod tests {
             None,
             None,
             None,
+            ApproveScope::None,
             "test",
         )
         .await

--- a/vta-service/src/operations/did_webvh/update/orchestrator.rs
+++ b/vta-service/src/operations/did_webvh/update/orchestrator.rs
@@ -155,14 +155,34 @@ async fn run_update(
     // *before* anyone holds the authority to commit it. Whether the requester
     // self-authorized rides out on `UpdatePlan.requester_authorized` so the gate
     // knows to demand a context-admin approver.
-    auth.require_admin()
-        .map_err(|e| UpdateDidWebvhError::Forbidden(format!("admin required: {e}")))?;
-    let requester_authorized = auth.has_context_access(&record.context_id);
-    if mode == Mode::Execute && !requester_authorized {
-        return Err(UpdateDidWebvhError::Forbidden(format!(
-            "caller has no admin role in context `{}`",
-            record.context_id
-        )));
+    // Whether the caller can authorize this update on its **own standing** —
+    // admin role AND access to the DID's context. In Execute mode `auth` may
+    // already have been widened for this one dispatch by a consented delegation
+    // (`AuthClaims::with_delegated_authority`, which confers *both* admin and the
+    // context), so a requester that held neither on its own token passes here iff
+    // an approver conferred them. This is what lets a purely unprivileged agent
+    // execute a task an approver blessed.
+    let requester_authorized =
+        auth.require_admin().is_ok() && auth.has_context_access(&record.context_id);
+    match mode {
+        // A dry-run reveals only the public DID-document diff and reserves
+        // nothing, so any known (Reader+) principal may run it to surface the
+        // effects a consent surface must show — including for a context the
+        // caller cannot self-authorize. That is precisely how the consent gate
+        // shows an approver a delegated update before anyone holds the authority
+        // to commit it. `requester_authorized` still rides out on
+        // `UpdatePlan.requester_authorized` so the gate knows to demand a
+        // conferring approver.
+        Mode::Plan => auth.require_read().map_err(|e| {
+            UpdateDidWebvhError::Forbidden(format!("read access required to plan an update: {e}"))
+        })?,
+        Mode::Execute if !requester_authorized => {
+            return Err(UpdateDidWebvhError::Forbidden(format!(
+                "caller is not authorized to update DIDs in context `{}`, and no consented delegation conferred it",
+                record.context_id
+            )));
+        }
+        Mode::Execute => {}
     }
 
     // 3. Validate caller-supplied inputs (cheap; do before key derivation).

--- a/vta-service/src/operations/provision_integration/mod.rs
+++ b/vta-service/src/operations/provision_integration/mod.rs
@@ -630,6 +630,7 @@ pub async fn provision_integration(
         None,
         None,
         None,
+        crate::acl::ApproveScope::None,
         "provision-integration",
     )
     .await
@@ -900,6 +901,7 @@ async fn provision_admin_rotation(
         None,
         None,
         None,
+        crate::acl::ApproveScope::None,
         "provision-integration",
     )
     .await

--- a/vta-service/src/routes/acl.rs
+++ b/vta-service/src/routes/acl.rs
@@ -58,6 +58,13 @@ pub struct CreateAclRequest {
     /// floor for this subject. Omit for none.
     #[serde(default)]
     pub step_up_require: Option<String>,
+    /// Approve-authority over any context (confer via approval, act nowhere).
+    /// Super-admin-only to grant. Takes precedence over `approve_contexts`.
+    #[serde(default)]
+    pub approve_all_contexts: bool,
+    /// Approve-authority scoped to these contexts. Empty = confers nothing.
+    #[serde(default)]
+    pub approve_contexts: Vec<String>,
 }
 
 /// POST /acl — create a new ACL entry for a DID. Auth: Admin or Initiator.
@@ -92,6 +99,7 @@ pub async fn create_acl(
         req.expires_at,
         req.step_up_approver,
         req.step_up_require,
+        operations::acl::approve_scope_from_wire(req.approve_all_contexts, req.approve_contexts),
         "rest",
     )
     .await?;

--- a/vta-service/src/trust_tasks/acl.rs
+++ b/vta-service/src/trust_tasks/acl.rs
@@ -87,6 +87,7 @@ pub(super) async fn handle_create(
         req.expires_at,
         req.step_up_approver,
         req.step_up_require,
+        operations::acl::approve_scope_from_wire(req.approve_all_contexts, req.approve_contexts),
         TRANSPORT_TRUST_TASK,
     )
     .await

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -494,10 +494,13 @@ pub(crate) async fn dispatch_trust_task_core(
     // `config.policy.enforcement` is on; when a policy denies (or demands
     // step-up/consent), the task is rejected here and never reaches its handler.
     // A rejected task still flows through the audit tail below.
-    // Filled by the gate only when a consumed consent grant *delegated* a context
+    // Filled by the gate only when a consumed consent grant *delegated* authority
     // the requester's own token lacked. When non-empty, this dispatch — and only
-    // this dispatch — runs under the requester's identity widened to include the
-    // delegated context; the widening is never written back to the session.
+    // this dispatch — runs under the requester's identity widened to full admin
+    // over the delegated context (`with_delegated_authority`), because the grant
+    // authorizes the exact bound task in full. This is what lets a purely
+    // unprivileged requester execute a task an approver blessed; the widening is
+    // never written back to the session.
     let mut delegated_contexts: Vec<String> = Vec::new();
     let outcome =
         match policy_gate::policy_gate(state, auth, &type_uri, &doc, &mut delegated_contexts).await
@@ -505,7 +508,7 @@ pub(crate) async fn dispatch_trust_task_core(
             Some(reject_outcome) => reject_outcome,
             None => {
                 let delegated_auth = (!delegated_contexts.is_empty())
-                    .then(|| auth.with_delegated_contexts(&delegated_contexts));
+                    .then(|| auth.with_delegated_authority(&delegated_contexts));
                 let auth = delegated_auth.as_ref().unwrap_or(auth);
                 if let Some(spec) = wire_v0_2::lookup_0_2(&type_uri) {
                     let mut doc = doc;

--- a/vta-service/src/trust_tasks/task_consent.rs
+++ b/vta-service/src/trust_tasks/task_consent.rs
@@ -14,7 +14,7 @@ use trust_tasks_rs::{RejectReason, TrustTask};
 
 use super::TrustTaskOutcome;
 use super::helpers::{app_error_to_reject, parse_payload, reject_with, success_response};
-use crate::acl::{Role, check_acl_full};
+use crate::acl::{Role, get_acl_entry};
 use crate::auth::AuthClaims;
 use crate::policy::consent;
 use crate::server::AppState;
@@ -63,17 +63,24 @@ fn now_secs() -> u64 {
 ///
 /// Empty unless the task was a cross-context proposal (`requester_authorized ==
 /// false`) with a known `subject_context`. When it was, an approver confers that
-/// context **only if they actually administer it**: resolved against live ACL
-/// state, requiring `Role::Admin` *and* context access (super-admin, or the
-/// context/an ancestor in `allowed_contexts`). This is attenuation — an approver
-/// can never delegate authority they do not hold, and set membership alone is
-/// not authority. The context is conferred only if enough such admins approved
-/// to meet the same `min_approvals` threshold the task required; otherwise the
-/// grant carries nothing and execution still fails the requester's own
-/// `require_context`.
+/// context **only if they hold authority over it**, resolved against live ACL
+/// state, by *either* of two paths:
+///   1. **Explicit approve authority** — an `approve_scope` covering the context.
+///      This is the least-privilege approver: it may confer without any power to
+///      act (`role: Reader`, no `allowed_contexts`).
+///   2. **Admin of the context** — `Role::Admin` with context access (super-admin,
+///      or the context/an ancestor in `allowed_contexts`). The backward-compatible
+///      path: an admin confers what it already holds.
+///
+/// This is attenuation — an approver can never delegate authority it does not
+/// hold, and set membership alone is not authority. The context is conferred only
+/// if enough such approvers met the same `min_approvals` threshold the task
+/// required; otherwise the grant carries nothing and execution still fails the
+/// requester's own authorization.
 async fn compute_delegated_contexts(
     state: &AppState,
     pending: &consent::PendingTaskConsent,
+    now: u64,
 ) -> Vec<String> {
     if pending.requester_authorized {
         return Vec::new();
@@ -81,23 +88,30 @@ async fn compute_delegated_contexts(
     let Some(ctx) = pending.subject_context.as_deref() else {
         return Vec::new();
     };
-    let mut context_admins = 0u32;
+    let mut conferrers = 0u32;
     for approver in &pending.approvals {
-        // A DID absent from the ACL (or expired) resolves to an error and
-        // confers nothing — a random approver device cannot grant authority.
-        if let Ok((role, contexts)) = check_acl_full(&state.acl_ks, approver).await {
+        // A DID absent from the ACL (or expired) confers nothing — a random
+        // approver device cannot grant authority.
+        let Ok(Some(entry)) = get_acl_entry(&state.acl_ks, approver).await else {
+            continue;
+        };
+        if entry.is_expired(now) {
+            continue;
+        }
+        let confers = entry.approve_scope.covers(ctx) || {
             let claims = AuthClaims {
                 did: approver.clone(),
-                role,
-                allowed_contexts: contexts,
+                role: entry.role.clone(),
+                allowed_contexts: entry.allowed_contexts.clone(),
                 ..Default::default()
             };
-            if claims.role == Role::Admin && claims.has_context_access(ctx) {
-                context_admins += 1;
-            }
+            claims.role == Role::Admin && claims.has_context_access(ctx)
+        };
+        if confers {
+            conferrers += 1;
         }
     }
-    if context_admins >= pending.min_approvals {
+    if conferrers >= pending.min_approvals {
         vec![ctx.to_string()]
     } else {
         Vec::new()
@@ -215,7 +229,7 @@ pub(super) async fn handle_decision(
         // task's context, the approvals confer execution authority for it — but
         // only if the approvers actually hold admin there. Resolved here, at the
         // moment the grant is minted, against live ACL state.
-        let delegated_contexts = compute_delegated_contexts(state, &updated).await;
+        let delegated_contexts = compute_delegated_contexts(state, &updated, now).await;
         let grant = consent::TaskConsentGrant {
             digest: updated.digest.clone(),
             requester_did: updated.requester_did.clone(),
@@ -296,7 +310,7 @@ mod tests {
 
         let pending = cross_context_pending(vec![ADMIN_A.into()], 1);
         assert_eq!(
-            compute_delegated_contexts(&state, &pending).await,
+            compute_delegated_contexts(&state, &pending, 1000).await,
             vec![OPENVTC.to_string()],
             "an admin of the context confers it"
         );
@@ -315,7 +329,7 @@ mod tests {
 
         let pending = cross_context_pending(vec![ADMIN_OTHER.into()], 1);
         assert!(
-            compute_delegated_contexts(&state, &pending)
+            compute_delegated_contexts(&state, &pending, 1000)
                 .await
                 .is_empty(),
             "an admin of a different context cannot delegate this one"
@@ -330,7 +344,7 @@ mod tests {
 
         let pending = cross_context_pending(vec![READER.into()], 1);
         assert!(
-            compute_delegated_contexts(&state, &pending)
+            compute_delegated_contexts(&state, &pending, 1000)
                 .await
                 .is_empty(),
             "a reader of the context is not an admin of it"
@@ -342,7 +356,7 @@ mod tests {
         let (state, _dir) = build_signing_test_app_state().await;
         let pending = cross_context_pending(vec![STRANGER.into()], 1);
         assert!(
-            compute_delegated_contexts(&state, &pending)
+            compute_delegated_contexts(&state, &pending, 1000)
                 .await
                 .is_empty(),
             "a signer with no ACL entry has no authority to delegate"
@@ -358,7 +372,7 @@ mod tests {
 
         let pending = cross_context_pending(vec![ADMIN_A.into(), READER.into()], 2);
         assert!(
-            compute_delegated_contexts(&state, &pending)
+            compute_delegated_contexts(&state, &pending, 1000)
                 .await
                 .is_empty(),
             "one context-admin cannot meet a threshold of two"
@@ -373,7 +387,7 @@ mod tests {
 
         let pending = cross_context_pending(vec![ADMIN_A.into()], 1);
         assert_eq!(
-            compute_delegated_contexts(&state, &pending).await,
+            compute_delegated_contexts(&state, &pending, 1000).await,
             vec![OPENVTC.to_string()],
         );
     }
@@ -386,10 +400,45 @@ mod tests {
         let mut pending = cross_context_pending(vec![ADMIN_A.into()], 1);
         pending.requester_authorized = true;
         assert!(
-            compute_delegated_contexts(&state, &pending)
+            compute_delegated_contexts(&state, &pending, 1000)
                 .await
                 .is_empty(),
             "the requester already held the context — nothing to delegate"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_pure_approver_with_approve_scope_confers_without_admin() {
+        // Fix 1: a least-privilege approver — a Reader that can act nowhere —
+        // still confers the context through explicit `approve_scope`.
+        let (state, _dir) = build_signing_test_app_state().await;
+        let entry = crate::acl::AclEntry::new(ADMIN_A, Role::Reader, "did:key:zSetup")
+            .with_approve_scope(crate::acl::ApproveScope::Contexts(vec![OPENVTC.into()]));
+        crate::acl::store_acl_entry(&state.acl_ks, &entry)
+            .await
+            .unwrap();
+
+        let pending = cross_context_pending(vec![ADMIN_A.into()], 1);
+        assert_eq!(
+            compute_delegated_contexts(&state, &pending, 1000).await,
+            vec![OPENVTC.to_string()],
+            "a non-admin approver with approve authority still confers the context"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_approve_all_approver_confers_any_context_without_admin() {
+        let (state, _dir) = build_signing_test_app_state().await;
+        let entry = crate::acl::AclEntry::new(ADMIN_A, Role::Reader, "did:key:zSetup")
+            .with_approve_scope(crate::acl::ApproveScope::All);
+        crate::acl::store_acl_entry(&state.acl_ks, &entry)
+            .await
+            .unwrap();
+
+        let pending = cross_context_pending(vec![ADMIN_A.into()], 1);
+        assert_eq!(
+            compute_delegated_contexts(&state, &pending, 1000).await,
+            vec![OPENVTC.to_string()],
         );
     }
 }

--- a/vti-common/Cargo.toml
+++ b/vti-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-common"
 description = "Shared server-side infrastructure for VTA and VTC services"
 readme = "README.md"
-version = "0.11.6"
+version = "0.11.7"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vti-common/src/acl/mod.rs
+++ b/vti-common/src/acl/mod.rs
@@ -260,6 +260,88 @@ impl DeviceBinding {
     }
 }
 
+/// A DID's authority to **confer** access through an approval — task-consent
+/// delegation (`compute_delegated_contexts`) and delegated step-up ratification
+/// ([`delegated_any_approver_covers`]) — **without** any authority to act.
+///
+/// Read only by those two conferral paths; it never feeds `require_admin` or
+/// `has_context_access`, so an approver can bless a change in a context while
+/// being unable to make one. This is the axis that lets an approver be
+/// least-privilege: `role: Reader`, `allowed_contexts: []` (acts nowhere),
+/// `approve_scope: All` (may authorize anywhere).
+///
+/// Default [`ApproveScope::None`]: an entry confers nothing unless explicitly
+/// granted this — strictly additive and fail-closed. Pre-existing rows omit the
+/// field and deserialise as `None`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case", tag = "kind", content = "contexts")]
+pub enum ApproveScope {
+    /// Confers nothing (the default).
+    #[default]
+    None,
+    /// May confer any context — a cross-context authorizer. Granting this is
+    /// super-admin-only (see [`validate_approve_scope_grant`]).
+    All,
+    /// May confer these contexts (and their subtrees), and only these.
+    Contexts(Vec<String>),
+}
+
+impl ApproveScope {
+    /// Whether an approval by a holder of this scope may confer `context_id`.
+    ///
+    /// Segment-aware ancestry, matching [`AuthClaims::has_context_access`], so an
+    /// approver scoped to a parent context covers its whole subtree.
+    pub fn covers(&self, context_id: &str) -> bool {
+        match self {
+            ApproveScope::None => false,
+            ApproveScope::All => true,
+            ApproveScope::Contexts(cs) => cs
+                .iter()
+                .any(|c| crate::context_path::is_ancestor_or_self(c, context_id)),
+        }
+    }
+
+    /// Whether this scope confers nothing.
+    pub fn confers_nothing(&self) -> bool {
+        matches!(self, ApproveScope::None)
+    }
+}
+
+/// Validate that `caller` may grant `scope` on an ACL entry.
+///
+/// Mirrors [`validate_acl_modification`]'s context rule: `All` is a
+/// cross-context authorizer, so only a super-admin may confer it; a scoped
+/// `Contexts` grant requires the caller to administer every listed context.
+/// `None` is always allowed.
+pub fn validate_approve_scope_grant(
+    caller: &AuthClaims,
+    scope: &ApproveScope,
+) -> Result<(), AppError> {
+    match scope {
+        ApproveScope::None => Ok(()),
+        ApproveScope::All => {
+            if caller.is_super_admin() {
+                Ok(())
+            } else {
+                Err(AppError::Forbidden(
+                    "only super admin can grant approve-all authority".into(),
+                ))
+            }
+        }
+        ApproveScope::Contexts(cs) => {
+            if cs.is_empty() {
+                return Err(AppError::Forbidden(
+                    "approve scope must name at least one context (or use 'all')".into(),
+                ));
+            }
+            for c in cs {
+                caller.require_context(c)?;
+            }
+            Ok(())
+        }
+    }
+}
+
 /// An entry in the Access Control List.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AclEntry {
@@ -324,6 +406,14 @@ pub struct AclEntry {
     /// override; the system floor applies unchanged).
     #[serde(default)]
     pub step_up_require: Option<StepUpMode>,
+    /// Authority to **confer** access via an approval, decoupled from the
+    /// authority to act. Read only by the two conferral paths
+    /// (`compute_delegated_contexts`, [`delegated_any_approver_covers`]); it
+    /// never feeds `require_admin`/`has_context_access`. Lets an approver be
+    /// least-privilege (act nowhere, authorize across contexts). `#[serde(default)]`
+    /// ⇒ pre-existing rows deserialise as [`ApproveScope::None`].
+    #[serde(default)]
+    pub approve_scope: ApproveScope,
 }
 
 impl AclEntry {
@@ -350,6 +440,7 @@ impl AclEntry {
             version: 0,
             step_up_approver: None,
             step_up_require: None,
+            approve_scope: ApproveScope::None,
         }
     }
 
@@ -405,6 +496,13 @@ impl AclEntry {
     /// Set the per-entry step-up override (`stepUp.require`).
     pub fn with_step_up_require(mut self, require: Option<StepUpMode>) -> Self {
         self.step_up_require = require;
+        self
+    }
+
+    /// Set the approve-authority scope (what this DID may confer via approval,
+    /// without any authority to act).
+    pub fn with_approve_scope(mut self, approve_scope: ApproveScope) -> Self {
+        self.approve_scope = approve_scope;
         self
     }
 
@@ -648,6 +746,28 @@ pub fn validate_acl_modification(
 /// Non-admins never qualify. Expiry is the caller's responsibility (it should
 /// skip an expired approver entry before calling this).
 pub fn delegated_any_approver_covers(approver: &AclEntry, subject: &AclEntry) -> bool {
+    // Explicit approve authority (a least-privilege approver): covers by scope,
+    // independent of role or `allowed_contexts`. `All` covers any subject; a
+    // scoped grant covers a context-scoped subject all of whose contexts fall
+    // within the scope. A global (empty-context) subject is never covered by a
+    // scoped grant — only by `All` or a super-admin.
+    match &approver.approve_scope {
+        ApproveScope::All => return true,
+        ApproveScope::Contexts(_) => {
+            if !subject.allowed_contexts.is_empty()
+                && subject
+                    .allowed_contexts
+                    .iter()
+                    .all(|c| approver.approve_scope.covers(c))
+            {
+                return true;
+            }
+            // Fall through: the approver may still qualify via the admin path.
+        }
+        ApproveScope::None => {}
+    }
+
+    // Backward-compatible admin path: an admin confers what it holds.
     if !approver.is_admin() {
         return false;
     }
@@ -756,6 +876,70 @@ mod delegated_any_tests {
                 &subject(Role::Reader, &["ctx-a"])
             ));
         }
+    }
+
+    // ── ApproveScope: a least-privilege approver confers without acting ──
+
+    /// A Reader with no contexts and no admin — it can *act* nowhere. Its only
+    /// authority is the approve scope layered on top.
+    fn pure_approver(scope: ApproveScope) -> AclEntry {
+        AclEntry::new("did:key:zApprover", Role::Reader, "did:key:zCreator")
+            .with_approve_scope(scope)
+    }
+
+    #[test]
+    fn approve_scope_covers_semantics() {
+        assert!(!ApproveScope::None.covers("ctx-a"));
+        assert!(ApproveScope::All.covers("anything"));
+        let scoped = ApproveScope::Contexts(vec!["ctx-a".into()]);
+        assert!(scoped.covers("ctx-a"));
+        assert!(!scoped.covers("ctx-b"));
+    }
+
+    #[test]
+    fn approve_all_confers_for_any_subject_without_any_admin_authority() {
+        // The whole point: an approver that holds no admin (acts nowhere) may
+        // still ratify across contexts, including a global subject.
+        let approver = pure_approver(ApproveScope::All);
+        assert!(
+            !approver.is_admin(),
+            "the approver holds no admin authority"
+        );
+        assert!(delegated_any_approver_covers(
+            &approver,
+            &subject(Role::Reader, &["ctx-a"])
+        ));
+        assert!(delegated_any_approver_covers(
+            &approver,
+            &subject(Role::Admin, &[])
+        ));
+    }
+
+    #[test]
+    fn scoped_approve_authority_covers_only_within_scope() {
+        let approver = pure_approver(ApproveScope::Contexts(vec!["ctx-a".into()]));
+        assert!(delegated_any_approver_covers(
+            &approver,
+            &subject(Role::Reader, &["ctx-a"])
+        ));
+        assert!(!delegated_any_approver_covers(
+            &approver,
+            &subject(Role::Reader, &["ctx-b"])
+        ));
+        // A global subject needs `All` (or a super-admin), never a scoped grant.
+        assert!(!delegated_any_approver_covers(
+            &approver,
+            &subject(Role::Admin, &[])
+        ));
+    }
+
+    #[test]
+    fn no_approve_scope_and_no_admin_confers_nothing() {
+        let reader = pure_approver(ApproveScope::None);
+        assert!(!delegated_any_approver_covers(
+            &reader,
+            &subject(Role::Reader, &["ctx-a"])
+        ));
     }
 }
 
@@ -1267,5 +1451,65 @@ mod tests {
         }"#;
         let entry: AclEntry = serde_json::from_str(legacy).expect("legacy shape must deserialize");
         assert!(entry.allowed_contexts.is_empty());
+    }
+
+    #[test]
+    fn acl_entry_without_approve_scope_defaults_to_none() {
+        // Pre-approver rows omit `approve_scope`; they must load as `None`
+        // (confers nothing) — fail-closed.
+        let legacy = r#"{
+            "did": "did:key:zLegacy",
+            "role": "reader",
+            "label": null,
+            "created_at": 1700000000,
+            "created_by": "did:key:zSetup"
+        }"#;
+        let entry: AclEntry = serde_json::from_str(legacy).expect("legacy shape must deserialize");
+        assert_eq!(entry.approve_scope, ApproveScope::None);
+        assert!(entry.approve_scope.confers_nothing());
+    }
+
+    #[test]
+    fn approve_scope_round_trips_on_the_wire() {
+        for scope in [
+            ApproveScope::None,
+            ApproveScope::All,
+            ApproveScope::Contexts(vec!["ctx-a".into(), "ctx-b".into()]),
+        ] {
+            let e = AclEntry::new("did:key:zA", Role::Reader, "did:key:zC")
+                .with_approve_scope(scope.clone());
+            let json = serde_json::to_string(&e).unwrap();
+            let back: AclEntry = serde_json::from_str(&json).unwrap();
+            assert_eq!(back.approve_scope, scope);
+        }
+    }
+
+    #[test]
+    fn validate_approve_scope_grant_authority() {
+        // `All` is a cross-context authorizer: super-admin only.
+        validate_approve_scope_grant(&super_admin_claims(), &ApproveScope::All)
+            .expect("super admin may grant approve-all");
+        assert!(
+            validate_approve_scope_grant(&context_admin_claims(&["ctx-a"]), &ApproveScope::All)
+                .is_err(),
+            "a context admin must not grant approve-all"
+        );
+
+        // A scoped grant requires the caller to hold each context.
+        let ctx_admin = context_admin_claims(&["ctx-a"]);
+        validate_approve_scope_grant(&ctx_admin, &ApproveScope::Contexts(vec!["ctx-a".into()]))
+            .expect("own context ok");
+        assert!(
+            validate_approve_scope_grant(&ctx_admin, &ApproveScope::Contexts(vec!["ctx-b".into()]))
+                .is_err(),
+            "foreign context must be rejected"
+        );
+
+        // `None` is always allowed; an empty context list is rejected.
+        validate_approve_scope_grant(&ctx_admin, &ApproveScope::None).expect("none ok");
+        assert!(
+            validate_approve_scope_grant(&ctx_admin, &ApproveScope::Contexts(vec![])).is_err(),
+            "empty scope must name a context or use all"
+        );
     }
 }

--- a/vti-common/src/auth/extractor.rs
+++ b/vti-common/src/auth/extractor.rs
@@ -239,6 +239,35 @@ impl AuthClaims {
         claims
     }
 
+    /// Realize a **consented grant** for a single dispatch: the approval conferred
+    /// full authority over `extra`, so the requester need hold **no standing
+    /// admin at all**.
+    ///
+    /// Unlike [`with_delegated_contexts`] — which widens context but keeps the
+    /// requester's role — this also lifts the role to [`Role::Admin`], because
+    /// the grant authorizes the exact bound task in full. That is what lets a
+    /// purely unprivileged agent (a Reader that can act nowhere) execute a task an
+    /// approver blessed: the approval *is* the authority. Ephemeral in exactly the
+    /// same way as the context widening — built for one dispatch, never persisted
+    /// to the session, JWT, or ACL — so the agent accrues no standing power.
+    ///
+    /// A no-op when `extra` is empty (nothing was delegated — an ordinary
+    /// same-context, already-authorized execution) and for a super-admin (already
+    /// unrestricted; adding to the empty list would wrongly narrow it).
+    pub fn with_delegated_authority(&self, extra: &[String]) -> Self {
+        let mut claims = self.clone();
+        if extra.is_empty() || claims.is_super_admin() {
+            return claims;
+        }
+        claims.role = Role::Admin;
+        for ctx in extra {
+            if !claims.allowed_contexts.iter().any(|c| c == ctx) {
+                claims.allowed_contexts.push(ctx.clone());
+            }
+        }
+        claims
+    }
+
     /// Check that the caller has access to the given context.
     ///
     /// Admins with an empty `allowed_contexts` list have unrestricted access.
@@ -556,6 +585,52 @@ mod tests {
         let after = sa.with_delegated_contexts(&["openvtc".into()]);
         assert!(after.is_super_admin(), "super-admin stays unrestricted");
         assert!(after.allowed_contexts.is_empty());
+    }
+
+    #[test]
+    fn with_delegated_authority_lifts_a_non_admin_for_one_dispatch() {
+        // Fix 2: a purely unprivileged agent (Reader, acts nowhere) executes a
+        // task an approver blessed — the grant confers both admin and context.
+        let reader = AuthClaims {
+            role: Role::Reader,
+            allowed_contexts: vec![],
+            ..Default::default()
+        };
+        assert!(reader.require_admin().is_err());
+        assert!(!reader.has_context_access("openvtc"));
+
+        let widened = reader.with_delegated_authority(&["openvtc".into()]);
+        assert!(widened.require_admin().is_ok(), "grant confers admin");
+        assert!(
+            widened.has_context_access("openvtc"),
+            "grant confers the context"
+        );
+
+        // The original is untouched — no standing elevation persists.
+        assert!(reader.require_admin().is_err());
+        assert!(!reader.has_context_access("openvtc"));
+    }
+
+    #[test]
+    fn with_delegated_authority_is_a_noop_for_empty_or_super_admin() {
+        let reader = AuthClaims {
+            role: Role::Reader,
+            allowed_contexts: vec![],
+            ..Default::default()
+        };
+        // Empty delegation changes nothing (an ordinary self-authorized execution).
+        let after = reader.with_delegated_authority(&[]);
+        assert_eq!(after.role, Role::Reader);
+        assert!(after.allowed_contexts.is_empty());
+
+        // A super-admin is already unrestricted; never narrow it to a scoped list.
+        let sa = AuthClaims {
+            role: Role::Admin,
+            ..Default::default()
+        };
+        assert!(sa.is_super_admin());
+        let after = sa.with_delegated_authority(&["openvtc".into()]);
+        assert!(after.is_super_admin(), "super-admin stays unrestricted");
     }
 
     #[test]


### PR DESCRIPTION
Implements Fix 1 and Fix 2 from the delegated-capability design note: pull the two authorities that were both bolted to `Role::Admin` apart, so an **approver** can authorize across contexts while acting nowhere, and the **acting agent** (browser plugin worker) can hold no standing admin at all.

## Fix 1 — approve-authority, decoupled from acting (`feat(acl)`)

Before, an approval only *conferred* authority (`compute_delegated_contexts`, step-up `delegated_any_approver_covers`) if the approver was `Role::Admin` of the subject's context — and admin-of-a-context is also the power to change DIDs in it. Approving across all contexts required a super-admin. The reviewer was the crown jewels.

- New `ApproveScope` (`None` | `All` | `Contexts([...])`) on `AclEntry`, read **only** by the two conferral paths — never by `require_admin`/`has_context_access`. An approver becomes `role: reader, allowed_contexts: [], approve_scope: all`: authorizes anywhere, acts nowhere.
- Both conferral paths honour it **in addition** to the existing admin path (backward compatible; pre-existing rows deserialise as `None`, fail-closed).
- Granting it is privilege-checked (`validate_approve_scope_grant`): `all` is super-admin-only; a scoped grant requires the caller to hold each context.
- Wired through the ACL create surface (trust-task / DIDComm / REST bodies) and the CLI: `vta acl create --did … --role reader --approve-contexts openvtc` (or `--approve-all`).

## Fix 2 — a consented grant authorizes the bound task in full (`feat(webvh)`)

Before, delegation widened *context* but never *role*, and the webvh update called `require_admin()` unconditionally — even to dry-run. So the worker had to be an admin of some context to propose at all; it could never be a purely unprivileged agent.

- New `AuthClaims::with_delegated_authority`: like `with_delegated_contexts` but also lifts the ephemeral role to `Admin`, because a consumed grant authorizes the exact bound task. Single-dispatch, never persisted; no-op for empty delegation or a super-admin. The webvh dispatch uses it in place of the context-only widening.
- Orchestrator guard relaxed: **Plan** mode requires only `require_read` (a dry-run reveals just the public DID-document diff and reserves nothing), **Execute** is gated on `require_admin && has_context_access` — which a delegated grant satisfies for that one dispatch. `requester_authorized` becomes "can self-authorize", so a non-admin correctly routes through delegation.

Net: the browser plugin's worker DID can be a `reader` that holds no admin anywhere; **every** cross-context edit is gated on a live approval.

## Safety properties preserved

- Delegation is still ephemeral — built for one dispatch, never written to the session, JWT, or ACL.
- Attenuation holds: an approver confers only what its `approve_scope` (or admin) covers; `all` is super-admin-gated to grant.
- The grant remains payload-digest-bound and single-use, so a delegated context confers admin-*in*-context only for the exact approved task.

## Testing

- `cargo fmt`, `cargo clippy --workspace -- -D warnings` (CI-equivalent): clean.
- vta-service lib: 924 passed (incl. 56 webvh-update auth tests unchanged). vti-common: 295 passed. vta-sdk: passing.
- New tests: `ApproveScope` semantics + wire round-trip + grant-authorization (`vti-common/acl`); a non-admin approver with `approve_scope` confers (`task_consent`); `with_delegated_authority` lifts a Reader for one dispatch and no-ops otherwise (`auth::extractor`); approve-scope wire fields default off (`vta-sdk`).
- End-to-end verification of a `reader` worker executing a cross-context edit via approval is pending manual test.

Design note (before/after + the two fixes): `delegated-capability-guide.html`.