### PR TITLE
fix(vta-service): make delivery-critical VTA pushes Guaranteed (D2 P2b)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10186,7 +10186,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.11.6"
+version = "0.11.7"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.11.6"
+version = "0.11.7"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/didcomm_bridge.rs
+++ b/vta-service/src/didcomm_bridge.rs
@@ -67,8 +67,8 @@ struct BridgeInner {
 /// `affinidi-messaging-didcomm-service` framework's `DIDCommService` + a
 /// thread-id pending-map. It now wraps the delivery-layer [`MessagingService`]:
 /// `send_and_wait` → [`MessagingService::request`] (the outbound message id is
-/// the correlation thread id), `send_oneway` → [`MessagingService::send`] with
-/// [`Delivery::BestEffort`], `send_and_wait_via` → [`MessagingService::request_via`]
+/// the correlation thread id), `send_guaranteed` → [`MessagingService::send`] with
+/// [`Delivery::Guaranteed`], `send_and_wait_via` → [`MessagingService::request_via`]
 /// (a named candidate transport, for the mediator handshake). The delivery
 /// dispatcher owns thread-id correlation, so the old pending-map / `try_complete`
 /// / `send_message_with_retry` are gone.
@@ -185,27 +185,51 @@ impl DIDCommBridge {
         Ok((msg_id, packed.into_bytes()))
     }
 
-    /// Fire-and-forget: pack `body` as a DIDComm message to `recipient_did` and
-    /// send it via the mediator, **without** awaiting a reply. Used for the
-    /// delegated step-up push — the approver's device replies later via a
-    /// separate `approve-response` call, not as a DIDComm reply on this thread.
+    /// Durably enqueue `body` as a **Guaranteed** DIDComm push to
+    /// `recipient_did`: written to the outbox and drained with exponential
+    /// backoff so a websocket reconnect can no longer silently drop it (R1.1 —
+    /// the exact failure a bare `BestEffort` send hid). The push hop-accepts to
+    /// the mediator **once** (then it is `Sent`, never re-sent — only a *failed*
+    /// hop retries), settling `Delivered` on §5a evidence or `Unconfirmed` when
+    /// the `deliver_by` window passes; never a silent success.
     ///
-    /// `_listener_id` is retained for call-site parity; outbound routes through
-    /// the service's current primary transport.
-    pub async fn send_oneway(
+    /// Used for the delegated step-up / task-consent pushes — the approver's
+    /// device replies later via a separate out-of-thread call, so this is
+    /// fire-and-forget from the request thread's point of view, but now
+    /// delivery-durable. `idempotency_key` dedups re-enqueues of the same logical
+    /// push (pass the request/thread id). Returns once durably **queued**, not
+    /// once delivered. `_listener_id` is retained for call-site parity; outbound
+    /// routes through the service's current primary transport.
+    pub async fn send_guaranteed(
         &self,
         _listener_id: &str,
         recipient_did: &str,
         msg_type: &str,
         body: serde_json::Value,
+        idempotency_key: Option<String>,
+        deliver_by: Duration,
     ) -> Result<(), AppError> {
         let inner = self.inner()?;
+        // No DIDComm `expires_time`: `deliver_by` bounds the outbox *hop-retry*
+        // window (how long we retry reaching the mediator), NOT the message's
+        // content validity. A held push must remain collectable until the
+        // request's own `expiresAt` — a shorter message expiry could make the
+        // mediator drop it before an offline device reconnects. (This preserves
+        // the prior `send_oneway` behaviour, which set no expiry.)
         let (_msg_id, packed) = Self::pack(inner, recipient_did, msg_type, body, None).await?;
         inner
             .service
-            .send(recipient_did, packed, Delivery::BestEffort)
+            .send(
+                recipient_did,
+                packed,
+                Delivery::Guaranteed {
+                    idempotency_key,
+                    ordering_key: None,
+                    deliver_by,
+                },
+            )
             .await
-            .map_err(|e| bad_gateway_error(format!("failed to send message: {e}")))?;
+            .map_err(|e| bad_gateway_error(format!("failed to enqueue guaranteed push: {e}")))?;
         Ok(())
     }
 

--- a/vta-service/src/trust_tasks/consent_request.rs
+++ b/vta-service/src/trust_tasks/consent_request.rs
@@ -11,9 +11,19 @@
 //! *response*, and nothing in the request is load-bearing for the decision.
 //! Here the request *is* the decision's basis, so it has to be attributable.
 
+use std::time::Duration;
+
 use affinidi_data_integrity::{DataIntegrityProof, SignOptions, crypto_suites::CryptoSuite};
 use serde_json::{Value, json};
 use vti_common::error::AppError;
+
+/// How long the delivery layer keeps retrying the task-consent push *hop* to the
+/// mediator across websocket reconnects before the outbox entry settles
+/// `Unconfirmed` and the relay fallback carries the request. Bounds hop-retry,
+/// not the request's own validity (the mediator holds a hop-accepted push for
+/// the device to collect whenever it next connects). Matches the step-up push
+/// window (`STEP_UP_TTL_SECS`).
+const CONSENT_PUSH_DELIVER_BY_SECS: u64 = 300;
 
 use crate::policy::consent::PendingTaskConsent;
 use crate::policy::effects::Effect;
@@ -182,19 +192,29 @@ async fn push_one(
             );
         }
 
+        // Delivery-critical, so it goes Guaranteed: durably queued + retried
+        // across websocket reconnects (a bare send silently dropped the frame
+        // mid-reconnect — R1.1), keyed by the request id so retries dedup. The
+        // `deliver_by` bounds how long we retry the *hop* to the mediator (which
+        // then holds it for the device); the relay fallback covers a lapse.
         if let Err(e) = state
             .didcomm_bridge
-            .send_oneway(
+            .send_guaranteed(
                 "vta-main",
                 approver,
                 TASK_CONSENT_REQUEST_0_1,
                 request.clone(),
+                request
+                    .get("id")
+                    .and_then(|v| v.as_str())
+                    .map(str::to_string),
+                Duration::from_secs(CONSENT_PUSH_DELIVER_BY_SECS),
             )
             .await
         {
             tracing::warn!(
                 error = %e, approver = %approver,
-                "task-consent request send failed; relay fallback applies"
+                "task-consent request enqueue failed; relay fallback applies"
             );
         }
 

--- a/vta-service/src/trust_tasks/step_up.rs
+++ b/vta-service/src/trust_tasks/step_up.rs
@@ -15,6 +15,8 @@
 //! pending step-up, dispatches on `evidence.kind`, and elevates the session
 //! lands alongside it.
 
+use std::time::Duration;
+
 use axum::extract::FromRequestParts;
 use axum::http::StatusCode;
 use axum::http::request::Parts;
@@ -739,21 +741,29 @@ async fn maybe_push_step_up(
         // approver's device over the mediator. `buffer_outbound` alone never
         // reaches the device (nothing drains it in steady state); this is the
         // send. The device replies later with a separate approve-response, so
-        // it's fire-and-forget. Best-effort — the reject already carries the
-        // approveRequest as the relay fallback.
+        // it's fire-and-forget from this thread. Delivery-critical, so it goes
+        // Guaranteed: durably queued + retried across websocket reconnects
+        // (a bare send silently dropped the frame mid-reconnect — R1.1), keyed
+        // by the approve-request id so retries dedup. The reject still carries
+        // the approveRequest as the relay fallback if the window elapses.
         if let Err(e) = state
             .didcomm_bridge
-            .send_oneway(
+            .send_guaranteed(
                 "vta-main",
                 recipient,
                 STEP_UP_APPROVE_REQUEST_TYPE,
                 approve_request.clone(),
+                approve_request
+                    .get("id")
+                    .and_then(|v| v.as_str())
+                    .map(str::to_string),
+                Duration::from_secs(STEP_UP_TTL_SECS),
             )
             .await
         {
             tracing::warn!(
                 error = %e, approver = %recipient,
-                "delegated step-up push send failed; relay fallback applies"
+                "delegated step-up push enqueue failed; relay fallback applies"
             );
         }
     }


### PR DESCRIPTION
## What

Upgrades the two delivery-critical VTA **pushes** — the delegated **step-up** approve-request and the **task-consent** request — from fire-and-forget `BestEffort` to `Delivery::Guaranteed`. Remediates **R1.1** for these sites (the workspace CLAUDE.md names `didcomm_bridge.rs send_oneway` explicitly).

## Why

A DIDComm send `Ok` means "accepted locally", not delivered — the messaging layer silently drops a frame during a websocket reconnect. Both pushes carry a human-awaited approval, so a dropped frame meant the approver's device might never see the request, with no retry and no trace.

## How

- New `DIDCommBridge::send_guaranteed` → `MessagingService::send(Delivery::Guaranteed { idempotency_key, ordering_key: None, deliver_by })`, replacing the now-unused `send_oneway`.
- `step_up.rs` and `consent_request.rs` call it with `idempotency_key = request id` and a `deliver_by` window (`STEP_UP_TTL_SECS` / a matching consent const).

**No device spam.** Verified against `affinidi-messaging-delivery` 0.1.11: `due()` returns only `Queued` entries (`outbox.rs:219` + its `due_excludes_..._sent` test). A push hop-accepts to the mediator **once** (→ `Sent`, never re-sent); exponential-backoff retries (1s,2s,4s…cap 60s) happen **only while the VTA→mediator hop is failing** — exactly the reconnect drop. It settles `Delivered` on §5a evidence or `Unconfirmed` when the window elapses — never a silent success. The reject's relay fallback still covers a lapse.

**`deliver_by` ≠ message expiry.** `deliver_by` bounds the outbox hop-retry window only; the push carries **no** DIDComm `expires_time`, so a held message stays collectable until the request's own `expiresAt` (a shorter message expiry could make the mediator drop a push before an offline device reconnects). This preserves the prior send behaviour.

## Verification

- `cargo check` (default + `tsp`), `cargo clippy --all-targets` (only pre-existing warnings, none in changed files), `cargo test -p vta-service` — all green (116 api_integration + all lib suites).

## Scope / follow-ups

- **Deferred: `with_receipts` + a `ReceiptPacker`.** That is the orthogonal "VTA emits layer receipts for *inbound*" concern (lets peers' Guaranteed sends *to* the VTA settle) — not part of fixing the VTA's *outbound* pushes.
- No VTA-as-issuer outbound credential push exists (the credential handlers are all holder-side receives), so step-up + consent are the complete set of delivery-critical pushes.

Depends on delivery 0.1.11 (already on main via P2a #683). Bumps vta-service 0.11.6 → 0.11.7.