### PR TITLE
feat(acl): show an entry's approve-authority in pnm output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+### vta-sdk / vta-service / CLI — surface an entry's approve-authority in output
+
+* The ACL create/get/list echo carried no `approve_scope`, so after
+  `acl create --approve-contexts …` the one field that makes an entry an approver
+  was invisible — you couldn't confirm it was set. The result body
+  (`CreateAclResultBody`) and the client `AclEntryResponse` now echo it as
+  `approve_all_contexts` / `approve_contexts` (both `#[serde(default)]` for
+  pre-approver servers), and `pnm acl create` / `acl get` / `acl list
+  --full-display` print an `Approve:` line (`all contexts` or `contexts [ … ]`),
+  shown only when the entry actually confers something.
+
 ### vti-common / vta-service — least-privilege approvers: separate "may approve" from "may act"
 
 * An approval only *conferred* delegated authority (task-consent

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2459,7 +2459,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.19.7",
+ "vta-sdk 0.19.8",
 ]
 
 [[package]]
@@ -3261,7 +3261,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.19.7",
+ "vta-sdk 0.19.8",
 ]
 
 [[package]]
@@ -6721,7 +6721,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.19.7",
+ "vta-sdk 0.19.8",
 ]
 
 [[package]]
@@ -10020,7 +10020,7 @@ dependencies = [
 
 [[package]]
 name = "vta-cli-common"
-version = "0.10.6"
+version = "0.10.7"
 dependencies = [
  "aes-gcm",
  "affinidi-crypto",
@@ -10038,7 +10038,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.19.7",
+ "vta-sdk 0.19.8",
  "vti-common",
  "x25519-dalek",
 ]
@@ -10071,7 +10071,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.19.7",
+ "vta-sdk 0.19.8",
 ]
 
 [[package]]
@@ -10094,7 +10094,7 @@ dependencies = [
  "tracing-subscriber",
  "trust-tasks-rs",
  "uniffi",
- "vta-sdk 0.19.7",
+ "vta-sdk 0.19.8",
 ]
 
 [[package]]
@@ -10129,7 +10129,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.19.7"
+version = "0.19.8"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10186,7 +10186,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.11.7"
+version = "0.11.8"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",
@@ -10266,7 +10266,7 @@ dependencies = [
  "utoipa-axum",
  "uuid",
  "vta-cli-common",
- "vta-sdk 0.19.7",
+ "vta-sdk 0.19.8",
  "vta-service",
  "vti-common",
  "vti-secrets",
@@ -10288,7 +10288,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.19.7",
+ "vta-sdk 0.19.8",
 ]
 
 [[package]]
@@ -10362,7 +10362,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.19.7",
+ "vta-sdk 0.19.8",
  "vtc-service",
  "vti-common",
  "vti-secrets",
@@ -10414,7 +10414,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.19.7",
+ "vta-sdk 0.19.8",
  "webauthn-rs",
  "zeroize",
 ]
@@ -10441,7 +10441,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.19.7",
+ "vta-sdk 0.19.8",
  "vta-service",
  "vti-common",
 ]
@@ -10470,7 +10470,7 @@ dependencies = [
  "tokio",
  "tracing",
  "vaultrs",
- "vta-sdk 0.19.7",
+ "vta-sdk 0.19.8",
  "vti-common",
 ]
 

--- a/vta-cli-common/Cargo.toml
+++ b/vta-cli-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-cli-common"
 description = "Shared CLI command handlers and rendering helpers for VTA CLIs"
 readme = "README.md"
-version = "0.10.6"
+version = "0.10.7"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-cli-common/src/commands/acl.rs
+++ b/vta-cli-common/src/commands/acl.rs
@@ -23,6 +23,19 @@ pub fn format_role(role: &str, contexts: &[String]) -> String {
     }
 }
 
+/// Human-readable approve-authority — what this entry may *confer* via an
+/// approval (task-consent delegation / step-up ratification) while acting
+/// nowhere. `None` when it confers nothing, so callers omit the line entirely.
+pub fn format_approve_scope(approve_all: bool, approve_contexts: &[String]) -> Option<String> {
+    if approve_all {
+        Some("all contexts".to_string())
+    } else if !approve_contexts.is_empty() {
+        Some(format!("contexts [{}]", approve_contexts.join(", ")))
+    } else {
+        None
+    }
+}
+
 pub fn validate_role(role: &str) -> Result<(), Box<dyn std::error::Error>> {
     match role {
         "admin" | "initiator" | "application" | "reader" => Ok(()),
@@ -59,13 +72,18 @@ pub async fn cmd_acl_list(
             let label = entry.label.as_deref().unwrap_or("—");
             let contexts = format_contexts(&entry.allowed_contexts);
             let role = format_role(&entry.role, &entry.allowed_contexts);
-            print_full_entry(&[
+            let approve = format_approve_scope(entry.approve_all_contexts, &entry.approve_contexts);
+            let mut fields: Vec<(&str, &str)> = vec![
                 ("DID", &entry.did),
                 ("Role", &role),
                 ("Label", label),
                 ("Contexts", &contexts),
-                ("Created By", &entry.created_by),
-            ]);
+            ];
+            if let Some(a) = &approve {
+                fields.push(("Approve", a));
+            }
+            fields.push(("Created By", &entry.created_by));
+            print_full_entry(&fields);
         }
         return Ok(());
     }
@@ -138,6 +156,9 @@ pub async fn cmd_acl_get(client: &VtaClient, did: &str) -> Result<(), Box<dyn st
         "Contexts:         {}",
         format_contexts(&entry.allowed_contexts)
     );
+    if let Some(scope) = format_approve_scope(entry.approve_all_contexts, &entry.approve_contexts) {
+        println!("Approve:          {scope}");
+    }
     println!("Created At:       {}", entry.created_at);
     println!("Created By:       {}", entry.created_by);
     Ok(())
@@ -185,6 +206,9 @@ pub async fn cmd_acl_create(
         println!("  Label:      {label}");
     }
     println!("  Contexts:   {}", format_contexts(&entry.allowed_contexts));
+    if let Some(scope) = format_approve_scope(entry.approve_all_contexts, &entry.approve_contexts) {
+        println!("  Approve:    {scope}");
+    }
     if let Some(approver) = &step_up_approver {
         println!("  Step-up approver: {approver}");
     }
@@ -267,6 +291,24 @@ mod tests {
     #[test]
     fn test_format_contexts_empty_shows_unrestricted() {
         assert_eq!(format_contexts(&[]), "(unrestricted)");
+    }
+
+    #[test]
+    fn test_format_approve_scope() {
+        assert_eq!(
+            format_approve_scope(true, &[]).as_deref(),
+            Some("all contexts")
+        );
+        assert_eq!(
+            format_approve_scope(false, &["openvtc".to_string()]).as_deref(),
+            Some("contexts [openvtc]")
+        );
+        assert_eq!(
+            format_approve_scope(false, &["a".to_string(), "b".to_string()]).as_deref(),
+            Some("contexts [a, b]")
+        );
+        // Confers nothing ⇒ no line.
+        assert_eq!(format_approve_scope(false, &[]), None);
     }
 
     #[test]

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.19.7"
+version = "0.19.8"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/client/types.rs
+++ b/vta-sdk/src/client/types.rs
@@ -322,6 +322,15 @@ pub struct AclEntryResponse {
     /// pre-existing entries on the wire.
     #[serde(default)]
     pub step_up_require: Option<String>,
+    /// Approve-authority over **any** context — may confer via approval while
+    /// acting nowhere. `#[serde(default)]` so entries from pre-approver servers
+    /// (which never send it) read as `false`.
+    #[serde(default)]
+    pub approve_all_contexts: bool,
+    /// Approve-authority scoped to these contexts. Empty = confers nothing
+    /// (unless `approve_all_contexts`). `#[serde(default)]` for older servers.
+    #[serde(default)]
+    pub approve_contexts: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/vta-sdk/src/protocols/acl_management/create.rs
+++ b/vta-sdk/src/protocols/acl_management/create.rs
@@ -86,6 +86,15 @@ pub struct CreateAclResultBody {
     /// if any (echoes the stored `step_up_require`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub step_up_require: Option<String>,
+    /// Approve-authority the entry holds — `true` means it may confer *any*
+    /// context via approval (while acting nowhere). Echoes the stored
+    /// `approve_scope`; takes precedence over `approve_contexts`.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub approve_all_contexts: bool,
+    /// Approve-authority scoped to these contexts (echoes the stored
+    /// `approve_scope`). Empty = confers nothing, unless `approve_all_contexts`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub approve_contexts: Vec<String>,
 }
 
 #[cfg(test)]

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.11.7"
+version = "0.11.8"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/operations/acl.rs
+++ b/vta-service/src/operations/acl.rs
@@ -119,6 +119,11 @@ async fn require_contexts_exist(
 }
 
 fn to_result_body(e: &AclEntry) -> CreateAclResultBody {
+    let (approve_all_contexts, approve_contexts) = match &e.approve_scope {
+        ApproveScope::All => (true, Vec::new()),
+        ApproveScope::Contexts(cs) => (false, cs.clone()),
+        ApproveScope::None => (false, Vec::new()),
+    };
     CreateAclResultBody {
         did: e.did.clone(),
         role: e.role.to_string(),
@@ -129,6 +134,8 @@ fn to_result_body(e: &AclEntry) -> CreateAclResultBody {
         expires_at: e.expires_at,
         step_up_approver: e.step_up_approver.clone(),
         step_up_require: step_up_require_to_wire(e.step_up_require),
+        approve_all_contexts,
+        approve_contexts,
     }
 }
 
@@ -644,6 +651,28 @@ mod tests {
         // All removes, no adds.
         let s = symmetric_difference_contexts(&["x".into()], &[]);
         assert_eq!(s, vec!["x".to_string()]);
+    }
+
+    #[test]
+    fn to_result_body_echoes_approve_scope() {
+        let base = AclEntry::new("did:key:zA", Role::Reader, "did:key:zC");
+
+        let scoped = base
+            .clone()
+            .with_approve_scope(ApproveScope::Contexts(vec!["openvtc".into()]));
+        let body = to_result_body(&scoped);
+        assert!(!body.approve_all_contexts);
+        assert_eq!(body.approve_contexts, vec!["openvtc"]);
+
+        let all = base.clone().with_approve_scope(ApproveScope::All);
+        let body = to_result_body(&all);
+        assert!(body.approve_all_contexts);
+        assert!(body.approve_contexts.is_empty());
+
+        // The default (a non-approver entry) echoes nothing.
+        let body = to_result_body(&base);
+        assert!(!body.approve_all_contexts);
+        assert!(body.approve_contexts.is_empty());
     }
 
     /// Regression test for the eviction-via-shrink bug.


### PR DESCRIPTION
Follow-up to #684. After `pnm acl create --approve-contexts openvtc`, the CLI printed role, contexts, and expiry — but **not** the approve scope, the one field that makes the entry an approver. So an operator had no way to confirm from the output that it was set.

## Change

Echo `approve_scope` end to end:
- `CreateAclResultBody` (the create/get/list echo, reused for all three) and the client `AclEntryResponse` gain `approve_all_contexts` / `approve_contexts`, both `#[serde(default)]` so entries from a pre-approver server read as "confers nothing".
- `to_result_body` populates them from the stored `ApproveScope`.
- `pnm acl create`, `acl get`, and `acl list --full-display` now print an `Approve:` line — `all contexts` or `contexts [ … ]` — shown **only** when the entry actually confers something (ordinary entries are unchanged).

So the entry from #684 now reads back as:

```
ACL entry created:
  DID:        did:key:z6Mkng…
  Role:       reader
  Contexts:   (unrestricted)
  Approve:    contexts [openvtc]
  Expires at: (permanent)
```

## Notes
- The compact `acl list` table is left as-is (5 columns); approve authority surfaces in the detail views (`get`, `create`) and `list --full-display`, which are the verification paths.
- "Contexts: (unrestricted)" on a `reader` remains correct — a reader has no action authority regardless; only the `Approve:` line confers anything.

## Testing
- `cargo clippy --workspace -- -D warnings`: clean. Version-bump guard: ok (vta-sdk 0.19.8, vta-service 0.11.8, vta-cli-common 0.10.7).
- New tests: `to_result_body_echoes_approve_scope` (mapping), `test_format_approve_scope` (CLI formatting). Existing acl/sdk suites pass.