### PR TITLE
chore(deps): bump affinidi-messaging-sdk 0.18.58 -> 0.18.59 (TSP inbound fix)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -454,9 +454,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-sdk"
-version = "0.18.58"
+version = "0.18.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22956a9d0183e10019486445ddcc134835be191001c455c8d1d3fed8083c0670"
+checksum = "287828215c5b633c0945debee987a3de26103e623bbd3b0c5522a25280bd9429"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-authentication",
@@ -2960,7 +2960,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4727,7 +4727,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "system-configuration 0.7.0",
  "tokio",
  "tower-service",
@@ -6919,7 +6919,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.41",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6957,7 +6957,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -10832,7 +10832,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Bumps `affinidi-messaging-sdk` 0.18.58 → **0.18.59** (lock-only) so the VTA picks up the TSP inbound fix from [affinidi-tdk-rs #627](https://github.com/affinidi/affinidi-tdk-rs/pull/627).

## Why

0.18.58's `DidCommTransport` (the delivery-layer transport the VTA runs after the D2/P2a cutover) **dropped every inbound TSP frame**: the multiplexed pickup socket surfaces a TSP frame as the qb64 stored string (`-E…` text), but `tsp_to_inbound` unpacked it as raw qb2 (`unpack_bytes(packed.as_bytes())`), failing with `missing -E envelope wrapper` and silently skipping it. Symptom observed live — the VTA never answered a TSP trust-ping; the peer saw `TSP websocket closed before reply`. 0.18.59 calls `atm.tsp().unpack(profile, packed)` (base64url-decodes first).

## Scope

- **Lock-only** — no crate source changed, so no version bump required by the release guard.
- `cargo build -p vta-service --features tsp` compiles against 0.18.59.
- TSP-only fix; the DIDComm path was unaffected.