### PR TITLE
feat: notify the requester when a task-consent grant is minted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+### vta-service — notify the requester when a task-consent grant is minted
+
+* A requester had no way to learn that its task had been approved except to
+  re-submit and see whether the grant existed — which meant the caller polled.
+  On reaching the approval threshold, the VTA now pushes a lightweight
+  `task-consent/granted/0.1` notice (carrying the salted `payloadDigest` the
+  requester already holds) to the requester's DID over the mediator, using the
+  same Guaranteed delivery + doorbell as the consent-request push. It is
+  best-effort and non-load-bearing — the single-use grant check remains the real
+  gate, so a lost or spurious notice costs at most one re-submit — and it lets a
+  requester act the instant an approval lands (same browser or another device)
+  instead of polling.
+
 ### vta-sdk / vta-service / CLI — surface an entry's approve-authority in output
 
 * The ACL create/get/list echo carried no `approve_scope`, so after

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10186,7 +10186,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.11.8"
+version = "0.11.9"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.11.8"
+version = "0.11.9"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/trust_tasks/consent_request.rs
+++ b/vta-service/src/trust_tasks/consent_request.rs
@@ -33,6 +33,12 @@ use crate::server::AppState;
 pub(super) const TASK_CONSENT_REQUEST_0_1: &str =
     "https://trusttasks.org/spec/task-consent/request/0.1";
 
+/// Fire-and-forget notice to the **requester** that its task is now approved and
+/// a grant is ready. Lets the requester re-submit the moment the approval lands
+/// instead of polling for it.
+pub(super) const TASK_CONSENT_GRANTED_0_1: &str =
+    "https://trusttasks.org/spec/task-consent/granted/0.1";
+
 /// Build one signed `task-consent/request` per eligible approver.
 ///
 /// One document per approver rather than one broadcast document, because the
@@ -222,5 +228,82 @@ async fn push_one(
         // its next voluntary pickup. Contentless by design — the wake says only
         // "you have mail", never what the task is or who is asking.
         super::step_up::trigger_gateway_wake(state, approver, &mediator_did).await;
+    }
+}
+
+/// Notify the **requester** that its task has reached the approval threshold and
+/// a grant is waiting, so it can re-submit immediately rather than poll.
+///
+/// Best-effort and **non-load-bearing**: the requester still re-submits and the
+/// single-use grant check is the real gate, so a lost or spurious notice costs
+/// at most one poll cycle — the authcrypt sender (this VTA) is the only
+/// attribution the device needs, and it carries only the salted `wire_digest`
+/// the requester already holds. Mirrors [`push_one`]: buffer at the requester's
+/// mediator, send Guaranteed, ring the doorbell.
+pub(super) async fn push_granted(
+    state: &AppState,
+    #[cfg_attr(not(feature = "didcomm"), allow(unused))] requester: &str,
+    #[cfg_attr(not(feature = "didcomm"), allow(unused))] wire_digest: &str,
+    #[cfg_attr(not(feature = "didcomm"), allow(unused))] type_uri: &str,
+) {
+    let mediator_did = {
+        let cfg = state.config.read().await;
+        super::step_up::approver_mediator(
+            requester,
+            cfg.messaging.as_ref().map(|m| m.mediator_did.as_str()),
+        )
+    };
+    #[cfg_attr(not(feature = "didcomm"), allow(unused))]
+    let Some(mediator_did) = mediator_did else {
+        tracing::debug!(
+            requester = %requester,
+            "no mediator route for consent requester; skipping granted notice (it will re-submit on its own)"
+        );
+        return;
+    };
+
+    #[cfg(feature = "didcomm")]
+    {
+        let body = serde_json::json!({
+            "status": "granted",
+            "payloadDigest": wire_digest,
+            "taskType": type_uri,
+        });
+        let pending = crate::messaging::registry::PendingResponse {
+            recipient_did: requester.to_string(),
+            message_type: TASK_CONSENT_GRANTED_0_1.to_string(),
+            body: body.clone(),
+            thread_id: Some(wire_digest.to_string()),
+        };
+        if let Err(e) = state
+            .mediator_registry
+            .buffer_outbound(&mediator_did, pending)
+            .await
+        {
+            tracing::warn!(
+                error = %e, requester = %requester, mediator = %mediator_did,
+                "failed to buffer granted notice; requester falls back to re-submit"
+            );
+        }
+
+        if let Err(e) = state
+            .didcomm_bridge
+            .send_guaranteed(
+                "vta-main",
+                requester,
+                TASK_CONSENT_GRANTED_0_1,
+                body,
+                Some(format!("granted:{wire_digest}")),
+                Duration::from_secs(CONSENT_PUSH_DELIVER_BY_SECS),
+            )
+            .await
+        {
+            tracing::warn!(
+                error = %e, requester = %requester,
+                "granted notice enqueue failed; requester falls back to re-submit"
+            );
+        }
+
+        super::step_up::trigger_gateway_wake(state, requester, &mediator_did).await;
     }
 }

--- a/vta-service/src/trust_tasks/task_consent.rs
+++ b/vta-service/src/trust_tasks/task_consent.rs
@@ -250,6 +250,16 @@ pub(super) async fn handle_decision(
             return app_error_to_reject(&doc, e);
         }
         let _ = consent::delete_pending(ks, &updated).await;
+        // Nudge the requester that a grant is ready, so it re-submits at once
+        // instead of polling. Best-effort — the grant is already durable; a lost
+        // notice only costs the requester a poll cycle.
+        super::consent_request::push_granted(
+            state,
+            &updated.requester_did,
+            &updated.wire_digest,
+            &updated.type_uri,
+        )
+        .await;
         return success_response(
             &doc,
             json!({


### PR DESCRIPTION
First piece of the event-driven (pub/sub) replacement for the controller-UI poll (#99). Follows the least-privilege-approver work (#684) and the approve-scope echo (#687).

## Problem
A requester could only discover that its task had been approved by re-submitting and checking whether the grant existed. That's why the controller UI polls the re-submit every few seconds.

## Change
On reaching the approval threshold in `handle_decision`, the VTA now pushes a lightweight `task-consent/granted/0.1` notice to the **requester's** DID over the mediator — carrying the salted `payloadDigest` the requester already holds — reusing the exact consent-request push path (`send_guaranteed` durable delivery + the contentless doorbell wake).

- **Best-effort and non-load-bearing.** The single-use grant check remains the real gate, so a lost or spurious notice costs at most one re-submit. Attribution is the authcrypt sender (this VTA); the notice carries no new secret (the digest already left the process in the consent request).
- Lets a requester act the **instant** an approval lands — whether it came from the same browser (local relay) or a separate approving device (the notice always goes to the requester, regardless of where the decision came from).

## Next pieces (separate PRs)
- **Plugin**: the worker inbox handles `task-consent/granted` and broadcasts a `vtawallet:consentgranted` page event (the page-event channel already exists).
- **Website**: subscribe to that event and re-submit immediately; relax the poll to a slow fallback.

## Testing
- `cargo fmt`, `cargo clippy --workspace -- -D warnings`: clean. Version-bump guard: ok (vta-service 0.11.9).
- Existing task-consent tests pass (9/9). The push mirrors the already-shipped `push_one` and is not independently unit-tested (IO-bound, matches repo convention).

https://claude.ai/code/session_01Kf83pLyZZ8mqCm7K3FWavy