### PR TITLE
fix(vta-sdk): route DIDCommSession over the delivery layer (D2-F5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2459,7 +2459,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.19.8",
+ "vta-sdk 0.19.9",
 ]
 
 [[package]]
@@ -3261,7 +3261,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.19.8",
+ "vta-sdk 0.19.9",
 ]
 
 [[package]]
@@ -6721,7 +6721,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.19.8",
+ "vta-sdk 0.19.9",
 ]
 
 [[package]]
@@ -10038,7 +10038,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.19.8",
+ "vta-sdk 0.19.9",
  "vti-common",
  "x25519-dalek",
 ]
@@ -10071,7 +10071,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.19.8",
+ "vta-sdk 0.19.9",
 ]
 
 [[package]]
@@ -10094,7 +10094,7 @@ dependencies = [
  "tracing-subscriber",
  "trust-tasks-rs",
  "uniffi",
- "vta-sdk 0.19.8",
+ "vta-sdk 0.19.9",
 ]
 
 [[package]]
@@ -10129,12 +10129,14 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.19.8"
+version = "0.19.9"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
  "affinidi-data-integrity",
  "affinidi-did-resolver-cache-sdk",
+ "affinidi-messaging-core",
+ "affinidi-messaging-delivery",
  "affinidi-messaging-didcomm",
  "affinidi-messaging-sdk",
  "affinidi-openid4vci",
@@ -10157,6 +10159,7 @@ dependencies = [
  "dbus-secret-service-keyring-store",
  "didwebvh-rs",
  "ed25519-dalek",
+ "futures-util",
  "getrandom 0.4.3",
  "hpke",
  "keyring-core",
@@ -10266,7 +10269,7 @@ dependencies = [
  "utoipa-axum",
  "uuid",
  "vta-cli-common",
- "vta-sdk 0.19.8",
+ "vta-sdk 0.19.9",
  "vta-service",
  "vti-common",
  "vti-secrets",
@@ -10288,7 +10291,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.19.8",
+ "vta-sdk 0.19.9",
 ]
 
 [[package]]
@@ -10362,7 +10365,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.19.8",
+ "vta-sdk 0.19.9",
  "vtc-service",
  "vti-common",
  "vti-secrets",
@@ -10414,7 +10417,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.19.8",
+ "vta-sdk 0.19.9",
  "webauthn-rs",
  "zeroize",
 ]
@@ -10441,7 +10444,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.19.8",
+ "vta-sdk 0.19.9",
  "vta-service",
  "vti-common",
 ]
@@ -10470,7 +10473,7 @@ dependencies = [
  "tokio",
  "tracing",
  "vaultrs",
- "vta-sdk 0.19.8",
+ "vta-sdk 0.19.9",
  "vti-common",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,6 +99,10 @@ affinidi-messaging-delivery = "0.1"
 # `ReceivedMessage`, `MessagingError`) the delivery layer builds on. Referenced
 # directly by services that demux `MessagingService::subscribe()` inbound.
 affinidi-messaging-core = "0.1"
+# Async `Stream` combinators (`StreamExt`, `BoxStream`) for draining the
+# delivery layer's `subscribe()` inbound. Matches the `= "0.3"` pin the
+# services already use directly.
+futures-util = "0.3"
 
 # Decentralized Trust Graph Credentials
 dtg-credentials = "0.1.3"

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.19.8"
+version = "0.19.9"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -11,7 +11,20 @@ license.workspace = true
 repository.workspace = true
 
 [features]
-didcomm = ["dep:affinidi-tdk", "dep:affinidi-did-resolver-cache-sdk", "dep:tracing", "dep:uuid", "dep:tokio"]
+didcomm = [
+  "dep:affinidi-tdk",
+  "dep:affinidi-did-resolver-cache-sdk",
+  "dep:tracing",
+  "dep:uuid",
+  "dep:tokio",
+  # The reliable-messaging delivery layer (D2-F5): `DIDCommSession` routes
+  # inbound through `MessagingService` over a `DidCommTransport` instead of
+  # raw ATM live-stream polling, so the dispatcher demuxes replies by `thid`.
+  "dep:affinidi-messaging-delivery",
+  "dep:affinidi-messaging-core",
+  # `StreamExt`/`BoxStream` for the persistent `subscribe()` stream.
+  "dep:futures-util",
+]
 # Trust Spanning Protocol (TSP) support. Pulls the TSP agent + DID-backed VID
 # resolver — `affinidi_tdk::tsp` re-exports the `affinidi-tsp` crate when the
 # TDK's `tsp` feature is on. Mirrors the `didcomm` dep set (TDK runtime +
@@ -185,6 +198,12 @@ multibase = { workspace = true }
 thiserror = { workspace = true }
 url = { workspace = true }
 affinidi-tdk = { workspace = true, optional = true }
+# D2-F5 delivery layer: `DIDCommSession` sends/awaits over `MessagingService`
+# (demux by `thid`) instead of raw ATM live-stream polling. Gated on `didcomm`.
+affinidi-messaging-delivery = { workspace = true, optional = true }
+affinidi-messaging-core = { workspace = true, optional = true }
+# `StreamExt` + `BoxStream` for the persistent delivery-layer `subscribe()` stream.
+futures-util = { workspace = true, optional = true }
 # Feature-only dep: `affinidi-tdk/tsp` pulls the `affinidi-tsp` crate but does
 # NOT flip `affinidi-messaging-sdk/tsp`, which gates the `atm.tsp()` ops the
 # `TspPingSession` needs. Depend on the same crate directly (Cargo unifies to

--- a/vta-sdk/src/didcomm_session.rs
+++ b/vta-sdk/src/didcomm_session.rs
@@ -54,8 +54,6 @@ pub struct DIDCommSession {
     /// Kept solely to `pack_encrypted` outbound messages (the delivery layer
     /// takes already-packed bytes) and to seal/open vault JWEs.
     atm: Arc<ATM>,
-    /// Kept for the mediator DID + packing context on the profile.
-    profile: Arc<ATMProfile>,
     /// The one persistent [`subscribe`] stream feeding [`receive_next`]. Each
     /// subscriber is independent + buffered, so this must be created once (in
     /// [`connect_with_secrets`]) and shared across clones — a fresh `subscribe()`
@@ -318,7 +316,6 @@ impl DIDCommSession {
         Ok(Self {
             service,
             atm,
-            profile,
             subscriber,
             client_did: client_did.to_string(),
             vta_did: vta_did.to_string(),

--- a/vta-sdk/src/didcomm_session.rs
+++ b/vta-sdk/src/didcomm_session.rs
@@ -2,13 +2,17 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
+use affinidi_messaging_core::{Inbound, MessageTransport};
+use affinidi_messaging_delivery::{Delivery, InMemoryOutboxStore, MessagingService, OutboxStore};
 use affinidi_tdk::common::TDKSharedState;
 use affinidi_tdk::common::config::TDKConfig;
 use affinidi_tdk::didcomm::Message;
-use affinidi_tdk::messaging::ATM;
 use affinidi_tdk::messaging::config::ATMConfig;
 use affinidi_tdk::messaging::profiles::ATMProfile;
+use affinidi_tdk::messaging::{ATM, DidCommTransport};
 use affinidi_tdk::secrets_resolver::SecretsResolver;
+use futures_util::StreamExt;
+use futures_util::stream::BoxStream;
 use tracing::{debug, info, warn};
 
 use crate::error::VtaError;
@@ -37,8 +41,30 @@ const MEDIATOR_OP_TIMEOUT: Duration = Duration::from_secs(15);
 /// `WARN` (and trips a `debug_assert!` in debug builds).
 #[derive(Clone)]
 pub struct DIDCommSession {
+    /// The reliable-messaging delivery layer over the mediator socket. Its
+    /// single inbound dispatcher demuxes replies by `thid` to [`request`]
+    /// waiters and hands unsolicited messages to [`subscribe`], deleting each
+    /// message from the mediator exactly once — this is what fixes the F5
+    /// steal-and-destroy bug the old raw `live_stream_next(auto_delete=true)`
+    /// path had when concurrent `send_and_wait`s shared one session.
+    ///
+    /// [`request`]: affinidi_messaging_delivery::MessagingService::request
+    /// [`subscribe`]: affinidi_messaging_delivery::MessagingService::subscribe
+    service: Arc<MessagingService>,
+    /// Kept solely to `pack_encrypted` outbound messages (the delivery layer
+    /// takes already-packed bytes) and to seal/open vault JWEs.
     atm: Arc<ATM>,
+    /// Kept for the mediator DID + packing context on the profile.
     profile: Arc<ATMProfile>,
+    /// The one persistent [`subscribe`] stream feeding [`receive_next`]. Each
+    /// subscriber is independent + buffered, so this must be created once (in
+    /// [`connect_with_secrets`]) and shared across clones — a fresh `subscribe()`
+    /// per `receive_next` call would only see messages that arrive after it.
+    ///
+    /// [`subscribe`]: affinidi_messaging_delivery::MessagingService::subscribe
+    /// [`receive_next`]: Self::receive_next
+    /// [`connect_with_secrets`]: Self::connect_with_secrets
+    subscriber: Arc<tokio::sync::Mutex<BoxStream<'static, Inbound>>>,
     pub(crate) client_did: String,
     pub(crate) vta_did: String,
     /// Set by [`shutdown`](Self::shutdown). Shared across clones so calling
@@ -164,7 +190,8 @@ impl DIDCommSession {
             tdk.secrets_resolver().insert(secret).await;
         }
 
-        // Build ATM (no inbound channel needed — we use REST polling)
+        // Build ATM — inbound is driven by the delivery layer's DidCommTransport,
+        // not by direct ATM polling (see the `MessagingService` wiring below).
         let atm_config = ATMConfig::builder().build()?;
         let atm = ATM::new(atm_config, Arc::new(tdk)).await?;
 
@@ -261,7 +288,26 @@ impl DIDCommSession {
         )
         .await;
 
-        debug!("DIDComm session connected via mediator {mediator_did} (WebSocket mode)");
+        // Build the reliable-messaging delivery layer over the mediator
+        // websocket, mirroring `vta-service`/`vtc-service`'s `build_messaging`:
+        // wrap the (now websocket-enabled) ATM + profile in a `DidCommTransport`,
+        // back an ephemeral in-memory outbox (the client is short-lived — no
+        // durability needed), and start the merged inbound dispatcher via
+        // `MessagingService::new`. The dispatcher is what demuxes replies to
+        // `request` waiters and unsolicited pushes to `subscribe`, deleting each
+        // message from the mediator exactly once (the F5 fix).
+        let transport: Arc<dyn MessageTransport> = Arc::new(
+            DidCommTransport::new((*atm).clone(), profile.clone())
+                .await
+                .map_err(|e| format!("bind DidComm transport: {e}"))?,
+        );
+        let outbox: Arc<dyn OutboxStore> = Arc::new(InMemoryOutboxStore::new());
+        let service = Arc::new(MessagingService::new(transport, outbox));
+        // ONE persistent subscriber for `receive_next` — a per-call `subscribe()`
+        // would miss anything delivered before it started.
+        let subscriber = Arc::new(tokio::sync::Mutex::new(service.subscribe()));
+
+        debug!("DIDComm session connected via mediator {mediator_did} (delivery-layer mode)");
 
         let shutdown = Arc::new(AtomicBool::new(false));
         let leak_guard = Arc::new(LeakGuard {
@@ -270,8 +316,10 @@ impl DIDCommSession {
             vta_did: vta_did.to_string(),
         });
         Ok(Self {
+            service,
             atm,
             profile,
+            subscriber,
             client_did: client_did.to_string(),
             vta_did: vta_did.to_string(),
             shutdown,
@@ -320,26 +368,29 @@ impl DIDCommSession {
     }
 
     /// Pack `body` as an authcrypt DIDComm message of `msg_type` from this
-    /// session to `recipient_did`, wrap it in a `routing/2.0/forward` envelope,
-    /// and ship it through the mediator. Returns once the mediator has accepted
-    /// the forward — it does **not** consume the inbound live stream, so it is
-    /// safe to call concurrently with [`receive_next`](Self::receive_next) /
-    /// [`send_and_wait`](Self::send_and_wait) without racing on inbound
-    /// messages.
+    /// session to `recipient_did` and return the packed JWE string.
     ///
-    /// Shared by [`send_and_wait`](Self::send_and_wait) (which then waits on the
-    /// live stream for `msg_id`'s response) and
-    /// [`send_one_way`](Self::send_one_way) (which returns immediately). Strict
-    /// mediators (`local_direct_delivery_allowed: false`) refuse direct
-    /// delivery — this is the same `forward_and_send_message` path the
-    /// production VTA-side `affinidi-messaging-didcomm-service` takes.
-    async fn pack_and_forward(
+    /// Pack-only: the actual send/forward is done by the delivery layer
+    /// ([`MessagingService::send`] / [`MessagingService::request`]), whose
+    /// [`DidCommTransport`] wraps the message in a `routing/2.0/forward`
+    /// envelope through the mediator internally — so there is no
+    /// `forward_and_send_message` call here anymore. Strict mediators
+    /// (`local_direct_delivery_allowed: false`) still get a forward-wrapped
+    /// message because the transport always routes via the mediator.
+    ///
+    /// Shared by [`send_and_wait`](Self::send_and_wait) (which then awaits the
+    /// reply the dispatcher demuxes to it by `thid`) and
+    /// [`send_one_way`](Self::send_one_way) (which fires and forgets).
+    ///
+    /// [`MessagingService::send`]: affinidi_messaging_delivery::MessagingService::send
+    /// [`MessagingService::request`]: affinidi_messaging_delivery::MessagingService::request
+    async fn pack_message(
         &self,
         recipient_did: &str,
         msg_id: &str,
         msg_type: &str,
         body: serde_json::Value,
-    ) -> Result<(), VtaError> {
+    ) -> Result<String, VtaError> {
         let msg = Message::build(msg_id.to_string(), msg_type.to_string(), body)
             .from(self.client_did.clone())
             .to(recipient_did.to_string())
@@ -357,34 +408,8 @@ impl DIDCommSession {
             .await
             .map_err(|e| VtaError::DidcommTransport(format!("failed to pack message: {e}")))?;
 
-        debug!(msg_type, msg_id, recipient_did, "sending via DIDComm");
-
-        let mediator_did = self
-            .profile
-            .inner
-            .mediator
-            .as_ref()
-            .as_ref()
-            .map(|m| m.did.clone())
-            .ok_or_else(|| {
-                VtaError::DidcommTransport("no mediator configured on profile".into())
-            })?;
-
-        self.atm
-            .forward_and_send_message(
-                &self.profile,
-                false, // authcrypt the forward envelope (mediator policy)
-                &packed,
-                Some(msg_id),
-                &mediator_did,
-                recipient_did,
-                None,
-                None,
-                false,
-            )
-            .await
-            .map_err(|e| VtaError::DidcommTransport(format!("failed to send message: {e}")))?;
-        Ok(())
+        debug!(msg_type, msg_id, recipient_did, "packed DIDComm message");
+        Ok(packed)
     }
 
     /// Send a one-way (fire-and-forget) DIDComm message to `recipient_did` and
@@ -406,8 +431,16 @@ impl DIDCommSession {
         body: serde_json::Value,
     ) -> Result<(), VtaError> {
         let msg_id = uuid::Uuid::new_v4().to_string();
-        self.pack_and_forward(recipient_did, &msg_id, msg_type, body)
+        let packed = self
+            .pack_message(recipient_did, &msg_id, msg_type, body)
+            .await?;
+        // `BestEffort`: one truthful hop send — `Err` if the frame wasn't
+        // transmitted (no silent `Ok` for a dropped frame, per R1.1).
+        self.service
+            .send(recipient_did, packed.into_bytes(), Delivery::BestEffort)
             .await
+            .map_err(|e| VtaError::DidcommTransport(format!("failed to send message: {e}")))?;
+        Ok(())
     }
 
     /// Send a DIDComm message and wait for a matching response.
@@ -427,82 +460,66 @@ impl DIDCommSession {
         timeout_secs: u64,
     ) -> Result<T, VtaError> {
         let msg_id = uuid::Uuid::new_v4().to_string();
-        // Pack + forward through the mediator (to the VTA). The reply is
-        // matched on the live stream below by `thid == msg_id`.
-        self.pack_and_forward(&self.vta_did, &msg_id, msg_type, body)
+        // Pack the message; the delivery layer sends it (forward-wrapped via the
+        // mediator) and awaits the reply the dispatcher demuxes to THIS waiter by
+        // `thid == msg_id`. Concurrent `send_and_wait`s each register their own
+        // waiter, so a peer request's reply can no longer be stolen (F5 fix).
+        let packed = self
+            .pack_message(&self.vta_did, &msg_id, msg_type, body)
             .await?;
 
-        // Wait for the response via WebSocket live stream
-        let timeout = std::time::Duration::from_secs(timeout_secs);
-        let wait_duration = std::time::Duration::from_secs(5);
-        let deadline = tokio::time::Instant::now() + timeout;
+        let received = self
+            .service
+            .request(
+                &self.vta_did,
+                packed.into_bytes(),
+                &msg_id,
+                Duration::from_secs(timeout_secs),
+            )
+            .await
+            .map_err(|e| {
+                // Preserve the exact timeout message callers/tests match on today.
+                if e.to_string().contains("timed out") {
+                    VtaError::DidcommTransport("timeout waiting for DIDComm response".into())
+                } else {
+                    VtaError::DidcommTransport(format!("message pickup error: {e}"))
+                }
+            })?;
 
-        loop {
-            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
-            if remaining.is_zero() {
-                return Err(VtaError::DidcommTransport(
-                    "timeout waiting for DIDComm response".into(),
-                ));
-            }
-            let wait = wait_duration.min(remaining);
+        // `payload` is the full plaintext DIDComm `Message` JSON.
+        let response_msg: Message =
+            serde_json::from_slice(&received.payload).map_err(VtaError::from)?;
 
-            let next = self
-                .atm
-                .message_pickup()
-                .live_stream_next(&self.profile, Some(wait), true)
-                .await
-                .map_err(|e| VtaError::DidcommTransport(format!("message pickup error: {e}")))?;
+        debug!(response_type = %response_msg.typ, "received DIDComm response");
 
-            let (response_msg, _meta) = match next {
-                Some(pair) => pair,
-                None => continue, // No message yet, keep waiting
-            };
-
-            // Check if this is the response we're waiting for (matching thread ID)
-            let response_thid = response_msg.thid.as_deref().unwrap_or("");
-            if response_thid != msg_id {
-                debug!(
-                    response_thid,
-                    expected = msg_id,
-                    response_type = %response_msg.typ,
-                    "received message with non-matching thread ID — skipping"
-                );
-                continue;
-            }
-
-            debug!(response_type = %response_msg.typ, "received DIDComm response");
-
-            // Check for problem report — map the `e.p.msg.*` code to the
-            // matching VtaError variant so callers can `match` on the same
-            // error shapes they get from REST (see `VtaError::from_http`).
-            if response_msg.typ == PROBLEM_REPORT_TYPE
-                || response_msg.typ.contains("problem-report")
-            {
-                let code = response_msg
-                    .body
-                    .get("code")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("unknown");
-                let comment = response_msg
-                    .body
-                    .get("comment")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("")
-                    .to_string();
-                return Err(VtaError::from_problem_report(code, comment));
-            }
-
-            // Verify expected type
-            if response_msg.typ != expected_result_type {
-                return Err(VtaError::Protocol(format!(
-                    "unexpected response type: expected {expected_result_type}, got {}",
-                    response_msg.typ
-                )));
-            }
-
-            // Deserialize response body
-            return serde_json::from_value(response_msg.body).map_err(VtaError::from);
+        // Check for problem report — map the `e.p.msg.*` code to the
+        // matching VtaError variant so callers can `match` on the same
+        // error shapes they get from REST (see `VtaError::from_http`).
+        if response_msg.typ == PROBLEM_REPORT_TYPE || response_msg.typ.contains("problem-report") {
+            let code = response_msg
+                .body
+                .get("code")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown");
+            let comment = response_msg
+                .body
+                .get("comment")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            return Err(VtaError::from_problem_report(code, comment));
         }
+
+        // Verify expected type
+        if response_msg.typ != expected_result_type {
+            return Err(VtaError::Protocol(format!(
+                "unexpected response type: expected {expected_result_type}, got {}",
+                response_msg.typ
+            )));
+        }
+
+        // Deserialize response body
+        serde_json::from_value(response_msg.body).map_err(VtaError::from)
     }
 
     /// Receive the next **unsolicited** inbound DIDComm message — e.g. an
@@ -516,31 +533,27 @@ impl DIDCommSession {
     /// ATM has already decrypted it under the holder key, so the caller works
     /// with plaintext (the application Trust Task rides in `body`).
     pub async fn receive_next(&self, timeout_secs: u64) -> Result<Option<String>, VtaError> {
-        let timeout = std::time::Duration::from_secs(timeout_secs);
-        let wait_duration = std::time::Duration::from_secs(5);
-        let deadline = tokio::time::Instant::now() + timeout;
-
-        loop {
-            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
-            if remaining.is_zero() {
-                return Ok(None);
+        // Pull from the ONE persistent subscriber. This no longer competes with
+        // `send_and_wait`: the dispatcher already routed any thread-correlated
+        // reply to its `request` waiter, so this stream carries only unsolicited
+        // inbound. The lock serialises concurrent `receive_next` calls on the
+        // same session (each message goes to exactly one caller).
+        let mut stream = self.subscriber.lock().await;
+        match tokio::time::timeout(Duration::from_secs(timeout_secs), stream.next()).await {
+            Ok(Some(inbound)) => {
+                // `payload` is the full plaintext DIDComm `Message` JSON;
+                // re-serialise it to preserve the `{ id, type, body, from, … }`
+                // shape callers (`InboundMessage::parse`) expect.
+                let msg: Message =
+                    serde_json::from_slice(&inbound.message.payload).map_err(VtaError::from)?;
+                debug!(msg_type = %msg.typ, "received inbound DIDComm message");
+                let json = serde_json::to_string(&msg).map_err(VtaError::from)?;
+                Ok(Some(json))
             }
-            let wait = wait_duration.min(remaining);
-
-            let next = self
-                .atm
-                .message_pickup()
-                .live_stream_next(&self.profile, Some(wait), true)
-                .await
-                .map_err(|e| VtaError::DidcommTransport(format!("message pickup error: {e}")))?;
-
-            let (msg, _meta) = match next {
-                Some(pair) => pair,
-                None => continue, // nothing yet — keep waiting until the deadline
-            };
-            debug!(msg_type = %msg.typ, "received inbound DIDComm message");
-            let json = serde_json::to_string(&msg).map_err(VtaError::from)?;
-            return Ok(Some(json));
+            // Stream ended (service shut down) — nothing more to receive.
+            Ok(None) => Ok(None),
+            // Poll window elapsed with nothing.
+            Err(_) => Ok(None),
         }
     }
 


### PR DESCRIPTION
## What

Migrates the SDK client's `DIDCommSession` (the session the CLIs and `vta-mcp` use to talk *to* a VTA) from raw ATM live-stream polling to the reliable-messaging **delivery layer** (`MessagingService` + `DidCommTransport`). Fixes **D2-F5**.

## The bug (F5)

`send_and_wait` and `receive_next` both polled `live_stream_next(auto_delete=true)`, and `send_and_wait` **skipped** messages whose `thid != msg_id` *after* the mediator had already deleted them. So a concurrent request's reply — or an unsolicited push — was pulled off the single live stream, deleted, and thrown away. `vta-mcp` shares one session across concurrent tool handlers with no serialization, so concurrent calls stole each other's replies.

## The fix

One dispatcher owns correlation and single-deletion:

| Method | Before | After |
|---|---|---|
| `send_and_wait::<T>` | poll + skip non-thid (destroys them) | `MessagingService::request(vta_did, packed, msg_id, timeout)` — demuxes the reply to **this** waiter by thread id |
| `send_one_way` | `pack_and_forward` | `MessagingService::send(BestEffort)` |
| `receive_next` | competes for the same live stream | one **persistent** `subscribe()` — unsolicited pushes buffered, never stolen |

## Behaviour-preserving

Public API, reply validation (problem-report → `VtaError`, expected-type, body-deserialize), the timeout message, `#[derive(Clone)]`, and the `LeakGuard` shutdown contract are all unchanged — the five consumers (`agent_session`, `provision_client/runner_didcomm`, `provision_integration/didcomm`, `client/mod`) and both CLIs compile untouched. `receive_next`'s JSON shape (`{ id, type, body, from, … }`) is byte-identical.

The concurrency guarantee is `MessagingService::request`'s — covered by the delivery crate's `concurrent_requests_dont_steal_each_others_replies` test — which the session now delegates to. (Acceptance criterion: two concurrent `send_and_wait`s over one session each receive their own reply.)

## Verification

`cargo build -p vta-sdk --features didcomm` + `--features didcomm,tsp`, `clippy --all-targets`, `cargo test -p vta-sdk --features didcomm` (all green), and `pnm-cli`/`vta-mcp` build — all pass.

## Follow-up (noted, not in scope)

`receive_next` still surfaces the plaintext `from` (matching prior behaviour); the delivery layer now provides a *verified* sender (`inbound.message.sender` + `verified`, the #620 guarantee) that a future hardening could stamp — but that's a behaviour change for consumers, out of scope for this F5 fix.

Bumps vta-sdk 0.19.8 → 0.19.9.