### PR TITLE
feat(pnm): health --fresh — provably-cold TSP relationship probe

### DIFF
--- a/docs/05-design-notes/tsp-outbound-send.md
+++ b/docs/05-design-notes/tsp-outbound-send.md
@@ -76,6 +76,30 @@ mandatory, adopt 3a (lazy, least coupling to the admit flow) with the
 relationship store + the Control-message handler wired into the PR-6b inbound
 loop. Either way this is the decision to lock before the send path is coded.
 
+### 3.0 DECIDED: 3c (relationship-free routed send)
+
+Confirmed against a live mediator (2026-07-19): `pnm health`'s TSP Trust-ping
+returns `pong` — an `atm.tsp().send_routed` to the VTA, with no `form_relationship`
+first, succeeds. **§3 resolves to 3c.** PR 7 carries no relationship store / FSM;
+**PR 7c is dropped**. Outbound TSP is treated like DIDComm (intrinsic per-message
+auth, routed through the mediator).
+
+*Is the ping cold?* Yes, by construction: `TspPingSession::new` builds a fresh
+in-memory ATM/TDK each run (no relationship-store path is configured anywhere in
+the SDK) and `pnm` is a short-lived process, so every run starts from an empty
+relationship store. And 3c holds even if `affinidi_tsp` forms a relationship
+*transparently* on first send — our code still just calls `send_routed`; only a
+hard "no relationship" send failure would refute 3c. To remove all doubt about a
+persisted external store, `pnm health --fresh` (§3.1) probes from a throwaway
+`did:key` minted at probe time, which can hold no prior relationship at all.
+
+Consequence for device push: routing a TSP frame to a `did:key` device works
+via the shared mediator exactly as DIDComm does (`send_routed(&[mediator, dev]`).
+The remaining gate is **not** routing or relationships — it is a *capability
+signal*: a `did:key` device can't advertise `#tsp` in a document, so the VTA
+needs another way to know a device can **receive** TSP before it prefers TSP for
+that device. See the outbound-send tracks below / the Phase-2 plan.
+
 ### 3.1 The probe already exists — how to decide
 
 No new probe is needed. `pnm-cli`'s `health::tsp_probe` (compiled by default —
@@ -87,8 +111,14 @@ runs it automatically whenever the target VTA's DID document advertises a
 `#tsp` (`TSPTransport`) service. Run against a live TSP-enabled VTA:
 
 ```
-pnm health          # (default build already has `tsp`)
+pnm health          # (default build already has `tsp`) — probes from your session DID
+pnm health --fresh  # probes from a throwaway did:key minted at probe time — provably cold
 ```
+
+`--fresh` mints a never-before-seen `did:key`, runs the routed send from it, and
+prints the `Probe DID`. A DID created at that instant can hold no relationship
+(persisted or not), so its `pong` is an unarguable cold, relationship-free send.
+`messaging/ping` is reachability-only, so the throwaway DID needs no ACL entry.
 
 Read the **"VTA TSP → Trust-ping"** line:
 

--- a/pnm-cli/src/cli.rs
+++ b/pnm-cli/src/cli.rs
@@ -105,7 +105,15 @@ pub(crate) enum Commands {
     },
 
     /// Check service health
-    Health,
+    Health {
+        /// Run the TSP probe from a throwaway, never-before-seen `did:key`
+        /// instead of your session identity. A DID minted at probe time can
+        /// have no pre-existing TSP relationship, so a `pong` proves a *cold*
+        /// relationship-free routed send (the §3 test). `messaging/ping` is
+        /// reachability-only, so the fresh DID needs no ACL entry.
+        #[arg(long)]
+        fresh: bool,
+    },
 
     /// Authentication management
     Auth {
@@ -2218,7 +2226,7 @@ pub(crate) fn requires_auth(cmd: &Commands) -> bool {
     }
     !matches!(
         cmd,
-        Commands::Health
+        Commands::Health { .. }
             | Commands::Auth { .. }
             | Commands::Setup { .. }
             | Commands::Vta { .. }

--- a/pnm-cli/src/commands/health.rs
+++ b/pnm-cli/src/commands/health.rs
@@ -17,6 +17,7 @@ use crate::auth;
 pub(crate) async fn run(
     url_override: Option<&str>,
     keyring_key: &str,
+    fresh_tsp_probe: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     use affinidi_did_resolver_cache_sdk::DIDCacheClient;
 
@@ -362,13 +363,28 @@ pub(crate) async fn run(
         && let Some(vta_did) = info.vta_did.as_deref()
     {
         print_section("VTA TSP");
-        tsp_probe(
-            &info.client_did,
-            &info.private_key_multibase,
-            tsp_mediator,
-            vta_did,
-        )
-        .await;
+        // `--fresh`: probe from a throwaway `did:key` minted right here. A DID
+        // that did not exist until this instant can hold no pre-existing TSP
+        // relationship (persisted or otherwise), so a `pong` is an unambiguous
+        // *cold* relationship-free routed send — the §3 test with no reliance
+        // on the in-memory-store assumption. Session identity is used otherwise.
+        if fresh_tsp_probe {
+            let (fresh_did, fresh_key) =
+                vta_cli_common::local_keygen::generate_unbound_admin_did_key();
+            println!(
+                "  {DIM}cold probe — fresh throwaway DID (no prior relationship possible):{RESET}"
+            );
+            println!("  {CYAN}{:<13}{RESET} {fresh_did}", "Probe DID");
+            tsp_probe(&fresh_did, &fresh_key, tsp_mediator, vta_did).await;
+        } else {
+            tsp_probe(
+                &info.client_did,
+                &info.private_key_multibase,
+                tsp_mediator,
+                vta_did,
+            )
+            .await;
+        }
     }
 
     Ok(())

--- a/pnm-cli/src/main.rs
+++ b/pnm-cli/src/main.rs
@@ -268,7 +268,9 @@ async fn main() {
             command: VtaCommands::Restart,
         } => commands::vta::run_restart(&client).await,
         Commands::Vta { .. } => unreachable!("VTA non-restart handled in pre-auth dispatch"),
-        Commands::Health => commands::health::run(effective_url_override, &keyring_key).await,
+        Commands::Health { fresh } => {
+            commands::health::run(effective_url_override, &keyring_key, fresh).await
+        }
         Commands::Auth { command } => commands::auth::run(&keyring_key, command).await,
         Commands::Config { command } => commands::config::run(&client, command).await,
         Commands::Services { command } => commands::services::run(&client, command).await,
@@ -370,7 +372,7 @@ mod tests {
 
     #[test]
     fn test_requires_auth_health_false() {
-        assert!(!requires_auth(&Commands::Health));
+        assert!(!requires_auth(&Commands::Health { fresh: false }));
     }
 
     #[test]


### PR DESCRIPTION
## Why

The TSP Trust-ping in `pnm health` is our §3 test — does an `atm.tsp().send_routed` to the VTA succeed with no `form_relationship` first? It only *proves* relationship-free send if the sending DID has **no pre-existing** TSP relationship with the VTA. The default probe uses your **session identity**, which is cold by construction (the SDK configures no relationship-store persistence and `pnm` is a short-lived process, so every run starts from an empty in-memory store) — but that argument leans on an assumption about the external TDK/TSP crates' defaults.

## What

`pnm health --fresh` mints a **throwaway `did:key` at probe time** and runs the routed send from it. A DID that didn't exist until that instant can hold no relationship — persisted or otherwise — so its `pong` is an unarguable cold, relationship-free send. `messaging/ping` is reachability-only, so the throwaway DID needs no ACL entry. The probe prints the `Probe DID` so you can see it's ephemeral.

```
pnm health          # probes from your session DID (cold by construction)
pnm health --fresh  # probes from a throwaway did:key (provably cold)
```

## Also

Records §3 as **decided → 3c** (relationship-free) in the `tsp-outbound-send` design note, with the coldness reasoning and the `--fresh` definitive test. **3c drops PR 7c** (no relationship store/FSM); outbound TSP is treated like DIDComm, routed through the mediator.

Reuses `vta_cli_common::local_keygen::generate_unbound_admin_did_key` (the same ephemeral-identity minter `pnm setup` uses). No new dependencies; workspace clippy + pnm-cli tests green.