### PR TITLE
feat(mobile): TSP receive session for the mobile approver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2459,7 +2459,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.19.9",
+ "vta-sdk 0.19.10",
 ]
 
 [[package]]
@@ -3261,7 +3261,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.19.9",
+ "vta-sdk 0.19.10",
 ]
 
 [[package]]
@@ -6721,7 +6721,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.19.9",
+ "vta-sdk 0.19.10",
 ]
 
 [[package]]
@@ -10038,7 +10038,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.19.9",
+ "vta-sdk 0.19.10",
  "vti-common",
  "x25519-dalek",
 ]
@@ -10071,12 +10071,12 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.19.9",
+ "vta-sdk 0.19.10",
 ]
 
 [[package]]
 name = "vta-mobile-core"
-version = "0.6.12"
+version = "0.6.13"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -10094,7 +10094,7 @@ dependencies = [
  "tracing-subscriber",
  "trust-tasks-rs",
  "uniffi",
- "vta-sdk 0.19.9",
+ "vta-sdk 0.19.10",
 ]
 
 [[package]]
@@ -10129,7 +10129,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.19.9"
+version = "0.19.10"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10269,7 +10269,7 @@ dependencies = [
  "utoipa-axum",
  "uuid",
  "vta-cli-common",
- "vta-sdk 0.19.9",
+ "vta-sdk 0.19.10",
  "vta-service",
  "vti-common",
  "vti-secrets",
@@ -10291,7 +10291,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.19.9",
+ "vta-sdk 0.19.10",
 ]
 
 [[package]]
@@ -10365,7 +10365,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.19.9",
+ "vta-sdk 0.19.10",
  "vtc-service",
  "vti-common",
  "vti-secrets",
@@ -10417,7 +10417,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.19.9",
+ "vta-sdk 0.19.10",
  "webauthn-rs",
  "zeroize",
 ]
@@ -10444,7 +10444,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.19.9",
+ "vta-sdk 0.19.10",
  "vta-service",
  "vti-common",
 ]
@@ -10473,7 +10473,7 @@ dependencies = [
  "tokio",
  "tracing",
  "vaultrs",
- "vta-sdk 0.19.9",
+ "vta-sdk 0.19.10",
  "vti-common",
 ]
 

--- a/vta-mobile-core/Cargo.toml
+++ b/vta-mobile-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vta-mobile-core"
-version = "0.6.12"
+version = "0.6.13"
 description = "UniFFI engine for the VTA mobile agent (Android/iOS): DIDComm, Trust Tasks, AAL step-up."
 edition.workspace = true
 # Not a crates.io library — the published artifacts are the Android AAR
@@ -61,7 +61,7 @@ affinidi-messaging-didcomm = "0.15"
 # `vta-sdk::DIDCommSession` (connect + receive_next) so the mobile approver can
 # pull VTA-pushed step-up approve-requests off the mediator — reusing the SDK
 # the VTA uses rather than reimplementing the affinidi mediator protocol.
-vta-sdk = { path = "../vta-sdk", version = "0.19", features = ["session"] }
+vta-sdk = { path = "../vta-sdk", version = "0.19", features = ["session", "tsp"] }
 # iOS has no native trust store that `rustls-native-certs` can read, so the
 # mediator WebSocket (tokio-tungstenite, via affinidi-messaging-sdk) fails with
 # "no native root CA certificates found". Declaring tokio-tungstenite here with

--- a/vta-mobile-core/src/lib.rs
+++ b/vta-mobile-core/src/lib.rs
@@ -49,6 +49,7 @@ pub mod resolver;
 pub mod session;
 pub mod stepup;
 pub mod task;
+pub mod tsp;
 
 pub use api::*;
 pub use error::FfiError;

--- a/vta-mobile-core/src/tsp.rs
+++ b/vta-mobile-core/src/tsp.rs
@@ -1,0 +1,78 @@
+//! Mediator-connected **TSP** session for the mobile approver.
+//!
+//! The TSP analogue of [`crate::mediator::MediatorSession`]: same purpose —
+//! connect to the holder's mediator and pull VTA-pushed messages (e.g. a
+//! `task-consent/request/0.1` delivered for a delegated DID edit) — but over
+//! the TSP transport instead of DIDComm. It wraps `vta-sdk`'s
+//! [`TspSession`](vta_sdk::session::TspSession) so the phone rides the same TSP
+//! client the VTA and `pnm health` use, rather than reimplementing TSP framing
+//! in the host language.
+//!
+//! Receive-only for now: TSP inbound is the missing half of "the VTA should use
+//! TSP when it can" for device push. The reply path (a TSP `confirm/decision`
+//! back to the VTA) still rides the existing REST/DIDComm sender; a TSP send
+//! FFI lands with the VTA's outbound TSP work.
+
+use std::sync::Arc;
+
+use vta_sdk::session::TspSession;
+
+use crate::error::FfiError;
+
+/// A live TSP session to a mediator, scoped to one holder identity.
+#[derive(uniffi::Object)]
+pub struct TspMediatorSession {
+    inner: TspSession,
+}
+
+#[uniffi::export(async_runtime = "tokio")]
+impl TspMediatorSession {
+    /// Connect the holder's TSP websocket to `mediator_did` and open delivery.
+    ///
+    /// - `holder_did`: the holder's `did:key`.
+    /// - `holder_signing_private_ed25519`: the holder's 32-byte Ed25519 seed
+    ///   (the key behind its `did:key`). It stays in the engine; only derived
+    ///   TSP secrets reach the client.
+    /// - `mediator_did`: the mediator to connect through — the VTA's `#tsp`
+    ///   service endpoint (the same mediator the VTA is a local account on).
+    ///
+    /// Unlike [`MediatorSession::connect`](crate::mediator::MediatorSession),
+    /// no `vta_did` is needed: a TSP receive session takes whatever the mediator
+    /// delivers to this holder and doesn't gate on a conversing peer. The peer
+    /// DID becomes relevant only for the reply/send path.
+    #[uniffi::constructor]
+    pub async fn connect(
+        holder_did: String,
+        holder_signing_private_ed25519: Vec<u8>,
+        mediator_did: String,
+    ) -> Result<Arc<Self>, FfiError> {
+        let private_key_mb =
+            multibase::encode(multibase::Base::Base58Btc, &holder_signing_private_ed25519);
+        let inner = TspSession::connect(&holder_did, &private_key_mb, &mediator_did)
+            .await
+            .map_err(|e| FfiError::Transport {
+                reason: e.to_string(),
+            })?;
+        Ok(Arc::new(Self { inner }))
+    }
+
+    /// Wait up to `timeout_secs` for the next inbound TSP message from the
+    /// mediator. Returns the unpacked Trust-Task document as JSON — the phone
+    /// parses it exactly as it parses a DIDComm-delivered one (its own
+    /// `type`/`issuer` fields), with the difference that TSP carries the inner
+    /// document directly rather than inside a DIDComm envelope's `body`. Returns
+    /// `None` if nothing arrived within the timeout. Call again to keep polling.
+    pub async fn receive_next(&self, timeout_secs: u64) -> Result<Option<String>, FfiError> {
+        self.inner
+            .receive_next(timeout_secs)
+            .await
+            .map_err(|e| FfiError::Transport {
+                reason: e.to_string(),
+            })
+    }
+
+    /// Gracefully close the mediator connection (the TSP websocket).
+    pub async fn shutdown(&self) {
+        self.inner.shutdown().await;
+    }
+}

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.19.9"
+version = "0.19.10"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/session.rs
+++ b/vta-sdk/src/session.rs
@@ -1679,6 +1679,132 @@ impl TspPingSession {
     }
 }
 
+/// A live, receive-oriented TSP session to a mediator, scoped to one client
+/// identity — the TSP analogue of [`crate::didcomm_session::DIDCommSession`].
+/// Connects the client's TSP websocket to the mediator and yields inbound
+/// Trust-Task frames already unpacked under the client key. This is the receive
+/// primitive the mobile approver uses to collect a VTA-pushed
+/// `task-consent/request` over TSP.
+///
+/// Unlike [`TspPingSession`] (a one-shot send-then-await liveness probe), this
+/// session is long-lived: [`receive_next`](Self::receive_next) can be polled
+/// repeatedly. The websocket lives behind a mutex so the receive/shutdown
+/// methods take `&self` — the session is shared as an `Arc` across the FFI
+/// boundary, mirroring `DIDCommSession::receive_next`.
+#[cfg(feature = "tsp")]
+pub struct TspSession {
+    atm: affinidi_tdk::messaging::ATM,
+    profile: std::sync::Arc<affinidi_tdk::messaging::profiles::ATMProfile>,
+    // `Option` so `shutdown` can `take()` the socket out to `close()` it —
+    // `TspWebSocket::close` consumes `self`, which a `MutexGuard` can't yield.
+    // `None` means already shut down; receive then no-ops.
+    ws: tokio::sync::Mutex<Option<affinidi_tdk::messaging::TspWebSocket>>,
+}
+
+#[cfg(feature = "tsp")]
+impl TspSession {
+    /// Connect the client's TSP websocket to `mediator_did` (the VTA's `#tsp`
+    /// endpoint — the mediator the VTA is a local account on) as `client_did`.
+    /// Same connect path as [`TspPingSession::new`]; the difference is lifetime
+    /// and direction (this one stays open to receive).
+    pub async fn connect(
+        client_did: &str,
+        private_key_multibase: &str,
+        mediator_did: &str,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        use affinidi_tdk::common::TDKSharedState;
+        use affinidi_tdk::common::config::TDKConfig;
+        use affinidi_tdk::messaging::ATM;
+        use affinidi_tdk::messaging::config::ATMConfig;
+        use affinidi_tdk::messaging::profiles::ATMProfile;
+        use std::sync::Arc;
+
+        let seed = crate::did_key::decode_private_key_multibase(private_key_multibase)?;
+        let secrets = crate::did_key::secrets_from_did_key(client_did, &seed)?;
+
+        let tdk = TDKSharedState::new(TDKConfig::builder().build()?).await?;
+        tdk.secrets_resolver().insert(secrets.signing).await;
+        tdk.secrets_resolver().insert(secrets.key_agreement).await;
+
+        let atm = ATM::new(ATMConfig::builder().build()?, Arc::new(tdk)).await?;
+
+        let profile = ATMProfile::new(
+            &atm,
+            None,
+            client_did.to_string(),
+            Some(mediator_did.to_string()),
+        )
+        .await?;
+        let profile = Arc::new(profile);
+
+        let ws = atm.tsp().connect_websocket(&profile).await?;
+
+        Ok(Self {
+            atm,
+            profile,
+            ws: tokio::sync::Mutex::new(Some(ws)),
+        })
+    }
+
+    /// Wait up to `timeout_secs` for the next inbound TSP frame that unpacks to a
+    /// Trust-Task payload, and return that payload as a JSON string — the
+    /// unpacked inner document (e.g. a `task-consent/request`). Returns `None`
+    /// if nothing arrived within the timeout or the websocket closed. TSP
+    /// control frames (which don't unpack to an application payload) are skipped
+    /// within the remaining budget rather than surfaced. Call again to poll on.
+    ///
+    /// The plaintext is the *inner* document the sender packed, not a DIDComm
+    /// envelope: TSP carries the Trust-Task bytes directly, so callers parse the
+    /// returned JSON as the document itself (its own `type`/`issuer` fields),
+    /// not as `{ body: … }`.
+    pub async fn receive_next(
+        &self,
+        timeout_secs: u64,
+    ) -> Result<Option<String>, Box<dyn std::error::Error>> {
+        use std::time::{Duration, Instant};
+
+        let mut guard = self.ws.lock().await;
+        let ws = match guard.as_mut() {
+            Some(w) => w,
+            None => return Ok(None), // already shut down
+        };
+        let budget = Duration::from_secs(timeout_secs);
+        let start = Instant::now();
+        loop {
+            let remaining = match budget.checked_sub(start.elapsed()) {
+                Some(r) => r,
+                None => return Ok(None),
+            };
+            let frame = match tokio::time::timeout(remaining, ws.recv()).await {
+                Ok(Ok(Some(bytes))) => bytes,
+                Ok(Ok(None)) => return Ok(None), // websocket closed
+                Ok(Err(e)) => return Err(Box::new(e)),
+                Err(_) => return Ok(None), // timed out with nothing to hand back
+            };
+            // A frame sealed to us that unpacks to a UTF-8 body is an application
+            // message; hand its plaintext to the caller. Frames that don't unpack
+            // are TSP control/relationship traffic — skip and keep waiting.
+            match self.atm.tsp().unpack_bytes(&self.profile, &frame).await {
+                Ok((payload, _sender)) => {
+                    let json = String::from_utf8(payload)
+                        .map_err(|e| format!("TSP payload was not UTF-8: {e}"))?;
+                    return Ok(Some(json));
+                }
+                Err(_) => continue,
+            }
+        }
+    }
+
+    /// Close the TSP websocket and shut down the ATM connection. Takes `&self`
+    /// (the session is shared across the FFI boundary).
+    pub async fn shutdown(&self) {
+        if let Some(ws) = self.ws.lock().await.take() {
+            let _ = ws.close().await;
+        }
+        self.atm.graceful_shutdown().await;
+    }
+}
+
 fn now_epoch() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)


### PR DESCRIPTION
First slice of Phase 2 ("the VTA should use TSP when it can") on the device side: give the mobile approver the ability to **receive** a VTA-pushed Trust Task over TSP. §3 is settled (3c — relationship-free routed send, confirmed via `pnm health --fresh`), so this needs no relationship FSM.

## What

- **`vta-sdk::session::TspSession`** — a long-lived, receive-oriented TSP session, the TSP analogue of `DIDCommSession`. `connect` opens the client's TSP websocket to the mediator; `receive_next(timeout_secs)` yields the next inbound frame that unpacks to a Trust-Task payload, as JSON (the *inner* document — TSP carries it directly, not inside a DIDComm `body`); `shutdown` closes the socket. The websocket lives behind a `Mutex<Option<…>>` so the methods take `&self` (shared as an `Arc` across the FFI) and `shutdown` can `take()` the socket to `close()` it (which consumes `self`).
- **`vta-mobile-core::tsp::TspMediatorSession`** — the UniFFI object wrapping it (`connect` / `receiveNext` / `shutdown`), mirroring `MediatorSession`. Verified the generated Swift surfaces `TspMediatorSession.connect(holderDid:holderSigningPrivateEd25519:mediatorDid:)` + `receiveNext` + `shutdown`.
- Enable `vta-sdk/tsp` **unconditionally** in the engine (not a cargo feature) so the release xcframework always carries it and the bindings stay consistent — no `package-ios.sh` change needed.

## Cross-compile safety

`tsp` adds only the Rust `affinidi-tsp` crate over the ATM/websocket stack the engine already links. The SDK-requiring C deps (`aws-lc-sys`, `clear_on_drop`) come from the pre-existing resolver/DIDComm stack (`affinidi-did-resolver-cache-sdk`), **not** from `tsp` — so the iOS/Android cross-compile risk is unchanged. The `mobile` CI job validates the actual device/simulator/Android builds (I can't locally — this box has Command Line Tools but no iOS SDK).

## Scope

Receive-only. The reply (a TSP decision back to the VTA) still rides the existing REST/DIDComm sender; the TSP **send** FFI lands with the VTA's outbound TSP work. Engine bumped to 0.6.13 for the release tag.

## Verification

- `cargo build -p vta-mobile-core --lib` clean; `cargo test -p vta-mobile-core` 45 pass / 2 ignored (network).
- `cargo clippy --workspace -- -D warnings` clean; `cargo fmt --check` clean.
- UniFFI bindgen emits the `TspMediatorSession` Swift API.

## Next

Cut `vta-mobile-core-v0.6.13`, then vendor the new binding into `vta-mobile-agent-ios` and wire a TSP inbox alongside the DIDComm `MediatorSession`.