### PR TITLE
feat(tsp): device push over TSP via learn-from-inbound

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,6 +200,8 @@ jobs:
         run: cargo check -p vta-service --no-default-features --features aws-secrets,keyring,rest
       - name: vta-service azure-secrets
         run: cargo check -p vta-service --no-default-features --features azure-secrets,keyring,rest
+      - name: vta-service tsp transport
+        run: cargo check -p vta-service --features tsp
       - name: vta-sdk attest-verify
         run: cargo check -p vta-sdk --features attest-verify
       - name: vta-sdk client + sealed-transfer + provision-integration

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10189,7 +10189,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.11.9"
+version = "0.11.10"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",

--- a/docs/05-design-notes/tsp-outbound-send.md
+++ b/docs/05-design-notes/tsp-outbound-send.md
@@ -152,6 +152,36 @@ separate probe here.
    advertises DIDComm, the matcher simply picks DIDComm — the VTC never builds a
    bridge envelope.
 
+### 4.1 IMPLEMENTED — device push: learn-from-inbound (not document selection)
+
+Document-based `select_protocol` (§4) works for **node peers** that advertise a
+`#tsp` service. It does **not** work for the immediate outbound consumer — the
+device push to a `did:key` approver/requester — because a `did:key` has no
+service block to advertise `#tsp`, and the device picks its inbox transport at
+*runtime* (the mobile app's DIDComm/TSP toggle). So the document can never carry
+the answer. Instead the VTA **learns from inbound**:
+
+- `messaging::tsp_reach::TspReachability` — an in-memory, self-expiring map of
+  DIDs last seen sending over TSP (TTL-bounded; never persisted).
+- `messaging::tsp_inbound::dispatch_one` records the **proven** `sender_vid` on
+  every inbound TSP frame — cryptographic proof that DID is on TSP right now.
+- The device-push sites (`consent_request::push_one` and
+  `step_up::maybe_push_step_up`) call `step_up::try_push_over_tsp`: if the
+  recipient is fresh in the map, route the **bare** Trust-Task doc over TSP via
+  `atm.tsp().send_routed([mediator, recipient])` (§3 = 3c, no relationship);
+  otherwise fall through to the existing DIDComm `send_guaranteed`. A TSP send
+  error also falls back to DIDComm.
+
+`push_granted` stays DIDComm-only: it targets the browser **requester** (which
+doesn't speak TSP), and its notice body isn't a full Trust-Task envelope, so the
+device's TSP inbox — which classifies by the doc's own `type` — would ignore it.
+
+The device announces its TSP-reachability by sending the VTA a TSP frame; that
+"announce on connect" is a small mobile follow-up (the iOS TSP session in
+vta-mobile-agent-ios #21 is receive-only for now), so until it lands the first
+contact is DIDComm and this arm activates for any DID that has sent inbound TSP
+(e.g. exercised via `pnm`).
+
 ## 5. The abstraction change
 
 The seam takes a built `didcomm::Message` today; TSP needs the **raw payload**

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.11.9"
+version = "0.11.10"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/messaging/mod.rs
+++ b/vta-service/src/messaging/mod.rs
@@ -19,3 +19,5 @@ pub mod shim;
 pub mod transient_handshake;
 #[cfg(feature = "tsp")]
 pub mod tsp_inbound;
+#[cfg(feature = "tsp")]
+pub mod tsp_reach;

--- a/vta-service/src/messaging/tsp_inbound.rs
+++ b/vta-service/src/messaging/tsp_inbound.rs
@@ -50,6 +50,12 @@ use crate::server::AppState;
 /// enumeration exposure, and a conformant Trust-Task client only understands
 /// binding envelopes (identical to the DIDComm path).
 pub async fn dispatch_one(app_state: &AppState, payload: &[u8], sender_vid: &str) -> Vec<u8> {
+    // Learn-from-inbound: this frame is proof `sender_vid` is reachable over TSP
+    // right now (the VID is cryptographically proven by TSP unpack), so record it
+    // — device-push then prefers TSP over DIDComm for this DID while the record
+    // stays fresh. Recorded regardless of authorization: reachability is a
+    // transport fact, and only DIDs we later push to are ever queried.
+    app_state.tsp_reach.record(sender_vid);
     let outcome = match auth_from_did(sender_vid, &app_state.acl_ks, &app_state.sessions_ks).await {
         Ok(auth) => crate::trust_tasks::dispatch_trust_task_core(app_state, &auth, payload).await,
         Err(e) => crate::trust_tasks::reject_trust_task(

--- a/vta-service/src/messaging/tsp_reach.rs
+++ b/vta-service/src/messaging/tsp_reach.rs
@@ -1,0 +1,75 @@
+//! Learn-from-inbound TSP reachability for device push.
+//!
+//! A `did:key` device can't advertise a `#tsp` service in a document, and it
+//! picks its inbox transport at runtime (the mobile app's DIDComm/TSP toggle),
+//! so the VTA can't discover from the document whether a device is *currently*
+//! reachable over TSP. Instead it **learns from inbound**: TSP `unpack_bytes`
+//! yields a cryptographically-proven `sender_vid`, so any TSP frame a device
+//! sends the VTA is proof that DID is, right now, listening on TSP. The inbound
+//! dispatcher records that here; the device-push paths read it to prefer TSP
+//! over DIDComm for a recently-seen DID.
+//!
+//! Runtime state only — in-memory, per-process, self-expiring. It never
+//! persists: on restart the map is empty and devices re-announce on their next
+//! inbound frame, which is exactly the safe default (fall back to DIDComm until
+//! we have fresh proof of TSP reachability). The TTL bounds how long a stale
+//! entry can misroute after a device flips back to DIDComm — a TSP frame sent
+//! to a DID no longer listening on TSP is accepted by the mediator but never
+//! unpacked by the device, a silent miss with no error to fall back on, so the
+//! window is deliberately short and the device re-announces well within it.
+
+use std::collections::HashMap;
+use std::sync::RwLock;
+use std::time::{Duration, Instant};
+
+/// How long a DID stays "TSP-reachable" after its last inbound TSP frame.
+/// Short on purpose (see the module note): the device re-announces on every
+/// inbox (re)connect, so a live device stays fresh, while a device that toggled
+/// back to DIDComm decays to the DIDComm path within this window.
+const TSP_REACH_TTL: Duration = Duration::from_secs(300);
+
+/// In-memory record of which DIDs were last seen sending over TSP.
+#[derive(Default)]
+pub struct TspReachability {
+    seen: RwLock<HashMap<String, Instant>>,
+}
+
+impl TspReachability {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Note that `did` just sent us a TSP frame — it is reachable over TSP now.
+    /// Called with the **proven** `sender_vid` from TSP unpack, so it can't be
+    /// spoofed into marking someone else reachable.
+    pub fn record(&self, did: &str) {
+        if let Ok(mut seen) = self.seen.write() {
+            seen.insert(did.to_string(), Instant::now());
+        }
+    }
+
+    /// Whether `did` sent a TSP frame within the TTL — i.e. push should prefer
+    /// TSP for it. A poisoned lock or a missing/stale entry both read as "not
+    /// fresh", so the caller safely falls back to DIDComm.
+    pub fn fresh(&self, did: &str) -> bool {
+        self.seen
+            .read()
+            .ok()
+            .and_then(|seen| seen.get(did).map(|t| t.elapsed() < TSP_REACH_TTL))
+            .unwrap_or(false)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn records_and_reads_back_fresh() {
+        let r = TspReachability::new();
+        assert!(!r.fresh("did:key:zDevice"));
+        r.record("did:key:zDevice");
+        assert!(r.fresh("did:key:zDevice"));
+        assert!(!r.fresh("did:key:zOther"));
+    }
+}

--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -187,6 +187,12 @@ pub struct AppState {
     pub ka_vm_id: Option<String>,
     #[cfg(feature = "didcomm")]
     pub didcomm_bridge: Arc<DIDCommBridge>,
+
+    /// Learn-from-inbound TSP reachability: which device DIDs were last seen
+    /// sending over TSP, so device-push can prefer TSP over DIDComm for them.
+    /// Populated by the inbound TSP dispatcher from the proven `sender_vid`.
+    #[cfg(feature = "tsp")]
+    pub tsp_reach: Arc<crate::messaging::tsp_reach::TspReachability>,
     pub jwt_keys: Option<Arc<JwtKeys>>,
     pub atm: Option<ATM>,
     /// VTA's registered TSP profile, used to unpack `tsp-message` sealed
@@ -398,6 +404,8 @@ pub async fn build_app_state(
         didcomm_bridge: parts
             .didcomm_bridge
             .unwrap_or_else(|| Arc::new(DIDCommBridge::placeholder())),
+        #[cfg(feature = "tsp")]
+        tsp_reach: Arc::new(crate::messaging::tsp_reach::TspReachability::new()),
         jwt_keys: auth.jwt_keys,
         atm: auth.atm,
         #[cfg(feature = "tsp")]

--- a/vta-service/src/test_support.rs
+++ b/vta-service/src/test_support.rs
@@ -872,6 +872,8 @@ pub async fn build_test_app_with(opts: TestAppOptions) -> (axum::Router, TestApp
         ka_vm_id: None,
         #[cfg(feature = "didcomm")]
         didcomm_bridge: Arc::new(DIDCommBridge::placeholder()),
+        #[cfg(feature = "tsp")]
+        tsp_reach: Arc::new(crate::messaging::tsp_reach::TspReachability::new()),
         jwt_keys: Some(jwt_keys.clone()),
         atm: None,
         #[cfg(feature = "tsp")]

--- a/vta-service/src/trust_tasks/consent_request.rs
+++ b/vta-service/src/trust_tasks/consent_request.rs
@@ -158,7 +158,7 @@ pub(super) async fn push_signed_requests(state: &AppState, requests: &[Value]) {
 async fn push_one(
     state: &AppState,
     approver: &str,
-    #[cfg_attr(not(feature = "didcomm"), allow(unused))] request: &Value,
+    #[cfg_attr(not(any(feature = "didcomm", feature = "tsp")), allow(unused))] request: &Value,
 ) {
     let mediator_did = {
         let cfg = state.config.read().await;
@@ -167,7 +167,7 @@ async fn push_one(
             cfg.messaging.as_ref().map(|m| m.mediator_did.as_str()),
         )
     };
-    #[cfg_attr(not(feature = "didcomm"), allow(unused))]
+    #[cfg_attr(not(any(feature = "didcomm", feature = "tsp")), allow(unused))]
     let Some(mediator_did) = mediator_did else {
         tracing::debug!(
             approver = %approver,
@@ -175,6 +175,15 @@ async fn push_one(
         );
         return;
     };
+
+    // Prefer TSP when the approver's device was recently seen on it
+    // (learn-from-inbound); otherwise fall through to DIDComm below.
+    #[cfg(feature = "tsp")]
+    if super::step_up::try_push_over_tsp(state, approver, &mediator_did, request).await {
+        #[cfg(feature = "didcomm")]
+        super::step_up::trigger_gateway_wake(state, approver, &mediator_did).await;
+        return;
+    }
 
     #[cfg(feature = "didcomm")]
     {

--- a/vta-service/src/trust_tasks/step_up.rs
+++ b/vta-service/src/trust_tasks/step_up.rs
@@ -686,6 +686,56 @@ pub(super) fn approver_mediator(approver_did: &str, configured: Option<&str>) ->
     configured.filter(|m| !m.is_empty()).map(str::to_string)
 }
 
+/// Deliver a signed Trust-Task document to `recipient` over **TSP** when we have
+/// fresh learn-from-inbound proof it's listening on TSP (a `did:key` device
+/// can't advertise `#tsp`, so its inbound TSP frames are the only signal — see
+/// [`crate::messaging::tsp_reach`]). Routes the bare document bytes through the
+/// shared mediator; §3 resolved to 3c (relationship-free routed send — see
+/// `docs/05-design-notes/tsp-outbound-send.md`), so no relationship setup is
+/// needed. Returns `true` if delivered over TSP, `false` to fall back to DIDComm
+/// (not TSP-reachable, TSP transport not connected on this node, or a send error).
+#[cfg(feature = "tsp")]
+pub(super) async fn try_push_over_tsp(
+    state: &AppState,
+    recipient: &str,
+    mediator_did: &str,
+    doc: &Value,
+) -> bool {
+    if !state.tsp_reach.fresh(recipient) {
+        return false;
+    }
+    let (Some(atm), Some(profile)) = (state.atm.as_ref(), state.tsp_profile.as_ref()) else {
+        return false; // TSP transport not connected on this node
+    };
+    let body = match serde_json::to_vec(doc) {
+        Ok(b) => b,
+        Err(e) => {
+            tracing::warn!(error = %e, recipient = %recipient, "serialising TSP push failed; DIDComm fallback");
+            return false;
+        }
+    };
+    // inner sealed end-to-end to the device, outer sealed to the mediator — the
+    // same routed shape the inbound loop uses for its replies.
+    match atm
+        .tsp()
+        .send_routed(
+            profile,
+            &[mediator_did.to_string(), recipient.to_string()],
+            &body,
+        )
+        .await
+    {
+        Ok(_) => {
+            tracing::debug!(recipient = %recipient, "delivered Trust-Task over TSP (learn-from-inbound)");
+            true
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, recipient = %recipient, "TSP push failed; falling back to DIDComm");
+            false
+        }
+    }
+}
+
 /// Best-effort proactive delivery of a delegated step-up approve-request to the
 /// approver's device over DIDComm, by buffering a forward through the resolved
 /// mediator. No-op for self-approval (`recipient == caller`). Failures are
@@ -695,7 +745,8 @@ async fn maybe_push_step_up(
     state: &AppState,
     recipient: &str,
     caller_did: &str,
-    #[cfg_attr(not(feature = "didcomm"), allow(unused))] approve_request: &Value,
+    #[cfg_attr(not(any(feature = "didcomm", feature = "tsp")), allow(unused))]
+    approve_request: &Value,
 ) {
     if recipient == caller_did {
         return; // self mode — the caller satisfies its own step-up.
@@ -707,7 +758,7 @@ async fn maybe_push_step_up(
             cfg.messaging.as_ref().map(|m| m.mediator_did.as_str()),
         )
     };
-    #[cfg_attr(not(feature = "didcomm"), allow(unused))]
+    #[cfg_attr(not(any(feature = "didcomm", feature = "tsp")), allow(unused))]
     let Some(mediator_did) = mediator_did else {
         tracing::debug!(
             approver = %recipient,
@@ -715,6 +766,15 @@ async fn maybe_push_step_up(
         );
         return;
     };
+    // Prefer TSP when the device was recently seen on it (learn-from-inbound);
+    // a fresh hit delivers over TSP and rings the doorbell, otherwise fall
+    // through to the DIDComm path below.
+    #[cfg(feature = "tsp")]
+    if try_push_over_tsp(state, recipient, &mediator_did, approve_request).await {
+        #[cfg(feature = "didcomm")]
+        trigger_gateway_wake(state, recipient, &mediator_did).await;
+        return;
+    }
     #[cfg(feature = "didcomm")]
     {
         let pending = crate::messaging::registry::PendingResponse {


### PR DESCRIPTION
The **outbound** half of Phase 2 device TSP ("the VTA should use TSP when it can"): the VTA now delivers a task-consent / step-up push over **TSP** when the target device is reachable on it, falling back to DIDComm otherwise. Pairs with the device *receive* half (vta-mobile-agent-ios #21) and the SDK/engine session (#694).

## The signal: learn-from-inbound

A `did:key` device can't advertise `#tsp` in a document, and it picks its inbox transport at **runtime** (the mobile app's DIDComm/TSP toggle) — so the document can never carry the answer. Instead the VTA learns from inbound: TSP `unpack_bytes` yields a **cryptographically-proven** `sender_vid`, so any TSP frame a device sends is proof it's on TSP right now.

- **`messaging::tsp_reach::TspReachability`** — in-memory, self-expiring (TTL) map of DIDs last seen over TSP. Never persisted: empty on restart → the safe DIDComm default until a device re-announces. (+ unit test.)
- **`messaging::tsp_inbound::dispatch_one`** records the proven `sender_vid` on every inbound TSP frame.
- **`step_up::try_push_over_tsp`** — routes the **bare** Trust-Task doc via `atm.tsp().send_routed([mediator, recipient])`, reusing `AppState`'s existing `atm` + `tsp_profile` (no bridge change). §3 resolved to **3c**, so no relationship setup. Falls back to DIDComm when not fresh, TSP not wired, or on send error.
- Wired into **`push_one`** (task-consent) and **`maybe_push_step_up`** (step-up). **`push_granted`** stays DIDComm-only — it targets the browser *requester* (doesn't speak TSP), and its notice isn't a full Trust-Task envelope, so the device's type-classifying TSP inbox would ignore it.

## CI gap closed

No CI job exercised `tsp` before — this whole path was **uncompiled in CI**. Added a `vta-service tsp transport` check (`cargo check -p vta-service --features tsp`) to the `features` job.

## Scope

The device announces reachability by sending the VTA a TSP frame; that "announce on connect" is a small mobile follow-up (the iOS TSP session in #21 is receive-only for now). Until it lands, first contact is DIDComm and this arm is exercised via any inbound TSP sender (e.g. `pnm`). Design note §4.1 records the rationale.

## Verification

`--features tsp` build + clippy + tests green (incl. the `tsp_reach` unit test); default build clean; fmt clean; cfg-gating holds across feature combos; version-bump guard passes (vta-service 0.11.9 → 0.11.10).