### PR TITLE
feat(mobile): TspSession.announce — devices declare TSP reachability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2459,7 +2459,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.19.10",
+ "vta-sdk 0.19.11",
 ]
 
 [[package]]
@@ -3261,7 +3261,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.19.10",
+ "vta-sdk 0.19.11",
 ]
 
 [[package]]
@@ -6721,7 +6721,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.19.10",
+ "vta-sdk 0.19.11",
 ]
 
 [[package]]
@@ -10038,7 +10038,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.19.10",
+ "vta-sdk 0.19.11",
  "vti-common",
  "x25519-dalek",
 ]
@@ -10071,12 +10071,12 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.19.10",
+ "vta-sdk 0.19.11",
 ]
 
 [[package]]
 name = "vta-mobile-core"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -10094,7 +10094,7 @@ dependencies = [
  "tracing-subscriber",
  "trust-tasks-rs",
  "uniffi",
- "vta-sdk 0.19.10",
+ "vta-sdk 0.19.11",
 ]
 
 [[package]]
@@ -10129,7 +10129,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.19.10"
+version = "0.19.11"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10269,7 +10269,7 @@ dependencies = [
  "utoipa-axum",
  "uuid",
  "vta-cli-common",
- "vta-sdk 0.19.10",
+ "vta-sdk 0.19.11",
  "vta-service",
  "vti-common",
  "vti-secrets",
@@ -10291,7 +10291,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
- "vta-sdk 0.19.10",
+ "vta-sdk 0.19.11",
 ]
 
 [[package]]
@@ -10365,7 +10365,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.19.10",
+ "vta-sdk 0.19.11",
  "vtc-service",
  "vti-common",
  "vti-secrets",
@@ -10417,7 +10417,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.19.10",
+ "vta-sdk 0.19.11",
  "webauthn-rs",
  "zeroize",
 ]
@@ -10444,7 +10444,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.19.10",
+ "vta-sdk 0.19.11",
  "vta-service",
  "vti-common",
 ]
@@ -10473,7 +10473,7 @@ dependencies = [
  "tokio",
  "tracing",
  "vaultrs",
- "vta-sdk 0.19.10",
+ "vta-sdk 0.19.11",
  "vti-common",
 ]
 

--- a/vta-mobile-core/Cargo.toml
+++ b/vta-mobile-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vta-mobile-core"
-version = "0.6.13"
+version = "0.6.14"
 description = "UniFFI engine for the VTA mobile agent (Android/iOS): DIDComm, Trust Tasks, AAL step-up."
 edition.workspace = true
 # Not a crates.io library — the published artifacts are the Android AAR

--- a/vta-mobile-core/src/tsp.rs
+++ b/vta-mobile-core/src/tsp.rs
@@ -71,6 +71,21 @@ impl TspMediatorSession {
             })
     }
 
+    /// Announce this holder's TSP reachability to `vta_did` (routed through
+    /// `mediator_did`) so the VTA's device-push prefers TSP for this device
+    /// (learn-from-inbound). Sends a session-less ping frame; the VTA records
+    /// our proven DID and replies with a pong that `receive_next` harmlessly
+    /// ignores. Call right after connecting the inbox, and periodically, so the
+    /// VTA's reachability record for this device stays fresh.
+    pub async fn announce(&self, vta_did: String, mediator_did: String) -> Result<(), FfiError> {
+        self.inner
+            .announce(&vta_did, &mediator_did)
+            .await
+            .map_err(|e| FfiError::Transport {
+                reason: e.to_string(),
+            })
+    }
+
     /// Gracefully close the mediator connection (the TSP websocket).
     pub async fn shutdown(&self) {
         self.inner.shutdown().await;

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.19.10"
+version = "0.19.11"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/session.rs
+++ b/vta-sdk/src/session.rs
@@ -1699,6 +1699,8 @@ pub struct TspSession {
     // `TspWebSocket::close` consumes `self`, which a `MutexGuard` can't yield.
     // `None` means already shut down; receive then no-ops.
     ws: tokio::sync::Mutex<Option<affinidi_tdk::messaging::TspWebSocket>>,
+    /// This client's DID — the `issuer` on an [`announce`](Self::announce) frame.
+    client_did: String,
 }
 
 #[cfg(feature = "tsp")]
@@ -1743,7 +1745,49 @@ impl TspSession {
             atm,
             profile,
             ws: tokio::sync::Mutex::new(Some(ws)),
+            client_did: client_did.to_string(),
         })
+    }
+
+    /// Announce this client's TSP reachability to `vta_did` by sending a
+    /// session-less `messaging/ping/0.1` frame (routed through `mediator_did`).
+    /// The point is not the pong — it's that the VTA's inbound dispatcher records
+    /// our **proven** `sender_vid` as TSP-reachable (learn-from-inbound), so its
+    /// device-push prefers TSP for us. The VTA's pong arrives on
+    /// [`receive_next`](Self::receive_next) like any other frame and is ignored
+    /// by the Trust-Task classifier (it's neither a step-up nor a task-consent).
+    ///
+    /// Send-only: unlike a socket read it needs no `ws` lock — `send_routed`
+    /// goes out through the ATM's TSP transport, so it can run concurrently with
+    /// a blocked `receive_next`. Call it on connect (and periodically) to keep
+    /// the VTA's reachability record fresh.
+    pub async fn announce(
+        &self,
+        vta_did: &str,
+        mediator_did: &str,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        use trust_tasks_rs::TrustTask;
+
+        let id = format!("urn:uuid:{}", uuid::Uuid::new_v4());
+        let nonce = uuid::Uuid::new_v4().to_string();
+        let type_uri = crate::trust_tasks::TASK_MESSAGING_PING_0_1
+            .parse()
+            .map_err(|e| format!("messaging/ping type URI parse: {e}"))?;
+        let mut doc: TrustTask<serde_json::Value> =
+            TrustTask::new(id, type_uri, serde_json::json!({ "nonce": nonce }));
+        doc.issuer = Some(self.client_did.clone());
+        doc.recipient = Some(vta_did.to_string());
+        let body = serde_json::to_vec(&doc)?;
+
+        self.atm
+            .tsp()
+            .send_routed(
+                &self.profile,
+                &[mediator_did.to_string(), vta_did.to_string()],
+                &body,
+            )
+            .await?;
+        Ok(())
     }
 
     /// Wait up to `timeout_secs` for the next inbound TSP frame that unpacks to a


### PR DESCRIPTION
Completes the learn-from-inbound loop. The VTA's device-push (#695) learns which devices are on TSP from their **inbound** TSP frames, but the mobile TSP session (#694/#21) was receive-only — so a real device never sent one and the VTA never learned. This adds the send half.

- **`vta-sdk` `TspSession::announce(vta_did, mediator_did)`** — sends a session-less `messaging/ping/0.1` over TSP so the VTA's `dispatch_one` records our **proven** `sender_vid` as TSP-reachable. Send-only (no `ws` lock), so it runs concurrently with a blocked `receive_next`; the VTA's pong lands on `receive_next` and is ignored by the Trust-Task classifier (neither step-up nor task-consent).
- **`vta-mobile-core` `TspMediatorSession::announce(vtaDid, mediatorDid)`** — the FFI wrapper; confirmed it surfaces in the generated Swift (`func announce(vtaDid:mediatorDid:) async throws`).

Engine → `0.6.14`, `vta-sdk` → `0.19.11`. The iOS caller (announce on inbox connect + periodic re-announce to stay within the VTA's reachability TTL) follows once this engine is released.

Verified: `--features tsp` build + clippy clean, fmt clean, mobile-core tests green, bindgen emits `announce`, version guard passes.