### PR TITLE
test(tsp): reachability TTL + learn-hook tests, e2e plan

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10189,7 +10189,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.11.10"
+version = "0.11.11"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",

--- a/docs/05-design-notes/tsp-device-push-e2e-test.md
+++ b/docs/05-design-notes/tsp-device-push-e2e-test.md
@@ -1,0 +1,90 @@
+# TSP device-push — end-to-end test plan
+
+Verifies "the VTA should use TSP when it can" for the mobile approver: a
+TSP-capable device announces reachability, the VTA learns it, and a task-consent
+/ step-up push routes to the device over TSP (falling back to DIDComm). Built on
+§3 = 3c (relationship-free routed send — see `tsp-outbound-send.md`).
+
+The loop, once assembled:
+
+```
+device toggles TSP ──▶ inbox connects & announces (ping over TSP)
+        │
+        ▼
+VTA dispatch_one records the PROVEN sender_vid as TSP-reachable (300s TTL)
+        │
+        ▼
+next push (push_one / maybe_push_step_up): tsp_reach.fresh(dev)?
+        ├─ yes ▶ send_routed over TSP  ── device receives on its TSP inbox
+        └─ no  ▶ send_guaranteed over DIDComm (fallback)
+```
+
+## 0. What's already covered by automated tests
+
+Run (no mediator needed):
+
+```
+cargo test -p vta-service --features tsp messaging::tsp_reach
+cargo test -p vta-service --features tsp dispatch_one_records_sender
+```
+
+- `tsp_reach::records_and_reads_back_fresh` — record → fresh; unknown DID → not fresh.
+- `tsp_reach::entry_expires_after_ttl` — a record goes stale after the TTL (the decay that makes push fall back to DIDComm).
+- `tsp_reach::record_refreshes_the_window` — a re-announce before expiry keeps a device continuously reachable.
+- `tsp_inbound::dispatch_one_records_sender_as_tsp_reachable` — the learn hook records the proven `sender_vid`.
+
+What these **don't** cover (and why this plan exists): the live `atm.tsp().send_routed` round-trip and the device receive path can't be exercised without a real mediator + device.
+
+## 1. Prerequisites
+
+- A **TSP-enabled VTA**: built with `--features tsp`, its DID document advertising a `#tsp` (`TSPTransport`) service on your mediator. Run at `RUST_LOG=vta_service=debug` so the learn/push logs below appear.
+- A **mediator** both the VTA and the device are local accounts on.
+- **`pnm`** built with the (default) `tsp` feature — used for the VTA-side smoke in §2.
+- For §3: the **iOS app** (`vta-mobile-agent-ios` ≥ the announce-on-connect build) on a device/simulator, paired to the same VTA + mediator, with an **approver ACL entry** for its holder DID (`vta acl create --did <holder> --role reader --approve-contexts <ctx>`).
+
+## 2. VTA-side smoke (no device) — proves learn + selection fire live
+
+Confirms the reachability record and the TSP send arm against a real mediator,
+using `pnm` as a stand-in TSP sender.
+
+1. **Baseline reachability probe.** `pnm health` against the TSP VTA → the *VTA TSP → Trust-ping* line reads `✓ pong`. In the VTA log:
+   ```
+   DEBUG … recorded TSP reachability (learn-from-inbound) sender=did:key:z<pnm-client>
+   INFO  … TSP trust-task dispatched sender=did:key:z<pnm-client>
+   ```
+   That `sender` is now fresh in `tsp_reach` for 300s.
+
+2. **Make that DID a push target.** Give the `pnm` client DID an approver ACL entry and drive a task-consent whose approver is it (or a step-up addressed to it). Within the 300s window, the VTA log shows the push chose TSP:
+   ```
+   DEBUG … delivered Trust-Task over TSP (learn-from-inbound) recipient=did:key:z<pnm-client>
+   ```
+   (No `send_guaranteed`/DIDComm-buffer line for that push.)
+
+3. **Fallback on decay.** Wait > 300s (no re-announce) and repeat the push. The TSP line is **absent**; the DIDComm path runs instead — the record went stale, so `try_push_over_tsp` returned `false`. This is the safety net that protects a device that toggled back to DIDComm.
+
+## 3. Full device end-to-end
+
+1. **DIDComm baseline.** Device with **TSP off** (default). Trigger a delegated DID edit / step-up that pushes to this device. It arrives over DIDComm as today. VTA log: no TSP delivery line.
+2. **Enable TSP.** In the app: Settings → **Receive over TSP** on. The listener re-opens on TSP (`restartListeningIfActive`) and announces. VTA log:
+   ```
+   DEBUG … recorded TSP reachability (learn-from-inbound) sender=did:key:z<holder>
+   ```
+3. **Push over TSP.** Trigger another push to this device within 300s. Expect:
+   - VTA: `DEBUG … delivered Trust-Task over TSP … recipient=did:key:z<holder>`.
+   - Device: the consent / step-up sheet appears (received on the TSP inbox, classified by `nextInboundTsp`).
+   - Approve with Face ID → the decision still returns over the existing reply path (REST/DIDComm — the reply is not yet TSP).
+4. **Staying fresh.** Leave the app listening > 5 min. The 150s re-announce keeps the device continuously reachable, so pushes keep choosing TSP (watch for a repeated `recorded TSP reachability` every ~150s).
+5. **Toggle-off fallback.** Turn **Receive over TSP** off. The device drops its TSP socket; within 300s the VTA's record expires and pushes revert to DIDComm. Confirm the next push arrives on the DIDComm inbox and the VTA log shows no TSP delivery line.
+
+## 4. Pass criteria
+
+- §2.1 / §3.2: an inbound TSP frame produces `recorded TSP reachability`.
+- §2.2 / §3.3: a push to a fresh DID produces `delivered Trust-Task over TSP` and the device receives it over TSP.
+- §2.3 / §3.5: after TTL decay (or toggle-off), the same push silently reverts to DIDComm — **no lost message**.
+- Nothing pushes over TSP to a device that has never announced (first contact is always DIDComm).
+
+## 5. Known limitations at this stage
+
+- **Reply is not TSP.** The device's decision returns over REST/DIDComm; only the VTA→device push is TSP. A TSP reply is future work.
+- **`push_granted` is DIDComm-only** by design (targets the browser requester, which doesn't speak TSP).
+- **In-memory, per-process reachability.** A VTA restart empties the map; devices re-announce within one 150s cycle. No persistence by design.

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.11.10"
+version = "0.11.11"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/messaging/tsp_inbound.rs
+++ b/vta-service/src/messaging/tsp_inbound.rs
@@ -56,6 +56,7 @@ pub async fn dispatch_one(app_state: &AppState, payload: &[u8], sender_vid: &str
     // stays fresh. Recorded regardless of authorization: reachability is a
     // transport fact, and only DIDs we later push to are ever queried.
     app_state.tsp_reach.record(sender_vid);
+    tracing::debug!(sender = %sender_vid, "recorded TSP reachability (learn-from-inbound)");
     let outcome = match auth_from_did(sender_vid, &app_state.acl_ks, &app_state.sessions_ks).await {
         Ok(auth) => crate::trust_tasks::dispatch_trust_task_core(app_state, &auth, payload).await,
         Err(e) => crate::trust_tasks::reject_trust_task(
@@ -131,5 +132,28 @@ mod tests {
             "authorized sender must get a reply envelope"
         );
         serde_json::from_slice::<serde_json::Value>(&body).expect("reply is JSON");
+    }
+
+    /// The learn-from-inbound hook: dispatching any inbound TSP frame records its
+    /// **proven** `sender_vid` as TSP-reachable, so subsequent device-push
+    /// prefers TSP for that DID. Reachability is a transport fact recorded
+    /// regardless of the auth outcome, so an unknown sender (which still gets a
+    /// reply envelope) is marked reachable just the same.
+    #[tokio::test]
+    async fn dispatch_one_records_sender_as_tsp_reachable() {
+        let (app_state, _dir) = build_signing_test_app_state().await;
+        let did = "did:key:zTspDevice";
+
+        assert!(
+            !app_state.tsp_reach.fresh(did),
+            "a DID we've never seen over TSP is not reachable"
+        );
+
+        let _ = dispatch_one(&app_state, b"{}", did).await;
+
+        assert!(
+            app_state.tsp_reach.fresh(did),
+            "an inbound TSP frame must mark its proven sender TSP-reachable"
+        );
     }
 }

--- a/vta-service/src/messaging/tsp_reach.rs
+++ b/vta-service/src/messaging/tsp_reach.rs
@@ -29,14 +29,30 @@ use std::time::{Duration, Instant};
 const TSP_REACH_TTL: Duration = Duration::from_secs(300);
 
 /// In-memory record of which DIDs were last seen sending over TSP.
-#[derive(Default)]
 pub struct TspReachability {
     seen: RwLock<HashMap<String, Instant>>,
+    ttl: Duration,
+}
+
+impl Default for TspReachability {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl TspReachability {
+    /// Production constructor — the standard [`TSP_REACH_TTL`] window.
     pub fn new() -> Self {
-        Self::default()
+        Self::with_ttl(TSP_REACH_TTL)
+    }
+
+    /// Construct with an explicit TTL. Used by tests to exercise expiry without
+    /// waiting out the production window.
+    pub fn with_ttl(ttl: Duration) -> Self {
+        Self {
+            seen: RwLock::new(HashMap::new()),
+            ttl,
+        }
     }
 
     /// Note that `did` just sent us a TSP frame — it is reachable over TSP now.
@@ -55,7 +71,7 @@ impl TspReachability {
         self.seen
             .read()
             .ok()
-            .and_then(|seen| seen.get(did).map(|t| t.elapsed() < TSP_REACH_TTL))
+            .and_then(|seen| seen.get(did).map(|t| t.elapsed() < self.ttl))
             .unwrap_or(false)
     }
 }
@@ -71,5 +87,34 @@ mod tests {
         r.record("did:key:zDevice");
         assert!(r.fresh("did:key:zDevice"));
         assert!(!r.fresh("did:key:zOther"));
+    }
+
+    #[test]
+    fn entry_expires_after_ttl() {
+        // Tiny TTL so the record goes stale almost immediately — this is the
+        // decay a device toggling back to DIDComm relies on for push to revert.
+        let r = TspReachability::with_ttl(Duration::from_millis(20));
+        r.record("did:key:zDevice");
+        assert!(r.fresh("did:key:zDevice"), "fresh right after record");
+        std::thread::sleep(Duration::from_millis(40));
+        assert!(
+            !r.fresh("did:key:zDevice"),
+            "must go stale once the TTL elapses so push falls back to DIDComm"
+        );
+    }
+
+    #[test]
+    fn record_refreshes_the_window() {
+        let r = TspReachability::with_ttl(Duration::from_millis(40));
+        r.record("did:key:zDevice");
+        std::thread::sleep(Duration::from_millis(25));
+        // A re-announce before expiry resets the clock, so the device that keeps
+        // announcing stays continuously TSP-reachable.
+        r.record("did:key:zDevice");
+        std::thread::sleep(Duration::from_millis(25));
+        assert!(
+            r.fresh("did:key:zDevice"),
+            "re-record within the window keeps it fresh past the original expiry"
+        );
     }
 }


### PR DESCRIPTION
Automated coverage for the learn-from-inbound device-push (#695) plus the manual end-to-end plan for the parts that need a live mediator.

## Runnable tests (all green locally)

```
cargo test -p vta-service --features tsp messaging::tsp_reach
cargo test -p vta-service --features tsp dispatch_one_records_sender
```

- **`tsp_reach`** — made the TTL injectable (`with_ttl`) so expiry is deterministic without a 300s wait, then:
  - `records_and_reads_back_fresh`
  - `entry_expires_after_ttl` — the decay that makes push revert to DIDComm
  - `record_refreshes_the_window` — a re-announce keeps a device continuously reachable
- **`tsp_inbound::dispatch_one_records_sender_as_tsp_reachable`** — the learn hook records the proven `sender_vid`.
- Added a `recorded TSP reachability (learn-from-inbound)` **debug log** at the hook so the live smoke has something to grep.

## E2E plan

`docs/05-design-notes/tsp-device-push-e2e-test.md` covers what unit tests can't reach:
- **§2 VTA-side smoke (no device)** — use `pnm health` as a TSP sender to prove the record fires, then push to that DID and watch it choose TSP, then let the TTL lapse and watch it fall back to DIDComm.
- **§3 full device E2E** — toggle TSP on → announce → push over TSP → approve; re-announce keeps it fresh; toggle off → decay → DIDComm fallback.
- Exact log lines + pass criteria + known limitations (reply still DIDComm, `push_granted` DIDComm-only, in-memory reachability).

Verified: `--features tsp` clippy + fmt clean, new tests pass, version guard passes (vta-service 0.11.10 → 0.11.11).