### PR TITLE
feat(cli): pnm contexts provision --did-path; docs: fjall trust-registry runbook

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6743,7 +6743,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "pnm-cli"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-resolver-cache-sdk",
@@ -10063,7 +10063,7 @@ dependencies = [
 
 [[package]]
 name = "vta-cli-common"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [
  "aes-gcm",
  "affinidi-crypto",

--- a/docs/02-vta/cold-start.md
+++ b/docs/02-vta/cold-start.md
@@ -461,6 +461,12 @@ pnm contexts provision \
 # → prints an armored VTA SEALED BUNDLE + SHA-256 digest
 ```
 
+When the DID is hosted on a registered server (`--server`), the host
+allocates its path label by default. Add `--did-path <label>` to pick
+the label yourself — the same selector as `pnm did-mgmt dids create
+--path`, so `.well-known` claims the reserved root slot and any other
+value becomes an explicit path segment.
+
 **Back on the client's host**:
 
 ```bash

--- a/docs/03-vtc/trust-registry-deployment.md
+++ b/docs/03-vtc/trust-registry-deployment.md
@@ -46,7 +46,7 @@ those to reach the mediator. Identity custody, nothing more.
 
 | Stage | Establishes | Gate |
 |---|---|---|
-| 1 | Registry runs standalone, TRQP answers | `curl /health`, `POST /recognition` |
+| 1 | Registry runs standalone, fjall store opens | `curl /health`, `POST /recognition` → 404 |
 | 2 | Real DID, mediator connection | `/.well-known/did.json` resolves |
 | 3 | Trust Tasks round-trip | `test-trust-registry` mediator tests |
 | 4 | Identity sourced from the VTA | stages 1–3 pass again, new identity |
@@ -85,6 +85,11 @@ curl -s https://webvh.example/mediator/did.json | jq .
 Proves the binary, storage layer, and HTTP surface with no DIDComm
 involved.
 
+This runbook assumes the **fjall** backend: an embedded LSM store,
+no external database, state on local disk. See
+[storage backends](#storage-backends) for how it differs from the
+CSV and DynamoDB paths — the differences affect stages 1 and 2.
+
 ```bash
 cd affinidi-trust-registry-rs
 cp .env.example .env
@@ -93,19 +98,31 @@ cp .env.example .env
 Reduce `.env` to:
 
 ```dotenv
-TR_STORAGE_BACKEND=csv
-FILE_STORAGE_PATH=./sample-data/data.csv
+TR_STORAGE_BACKEND=fjall
+TR_FJALL_PATH=/var/lib/trust-registry/records.fjall
 LISTEN_ADDRESS=127.0.0.1:3232
 CORS_ALLOWED_ORIGINS=*
 AUDIT_LOG_FORMAT=json
 ```
 
-Setting `ENABLE_DIDCOMM=false` short-circuits before any mediator
-or profile variable is read:
+`TR_FJALL_PATH` defaults to `./trust_records.fjall` — relative to
+the working directory, which is rarely what a service unit wants.
+Set it explicitly to a durable, writable, **backed-up** location.
+Delete the `FILE_STORAGE_PATH` and `DDB_TABLE_NAME` lines inherited
+from `.env.example`; they are ignored under fjall and only mislead.
+
+fjall is behind a Cargo feature. It must be on **every** build and
+run command from here on:
 
 ```bash
-ENABLE_DIDCOMM=false RUST_LOG=info cargo run --bin trust-registry
+ENABLE_DIDCOMM=false RUST_LOG=info \
+  cargo run --bin trust-registry --features storage-fjall
 ```
+
+Omitting it is at least a clean failure — the storage factory
+returns *"TR_STORAGE_BACKEND=fjall selected but fjall support was
+not compiled; rebuild with --features storage-fjall"* rather than
+silently falling back to CSV.
 
 The registry exposes five routes: `/health`, `/recognition`,
 `/authorization`, `/trust-tasks`, and `/.well-known/did.json`.
@@ -123,18 +140,37 @@ curl -s -X POST localhost:3232/recognition \
        "resource":"resource3"}' | jq .
 ```
 
-Those identifiers are the `recognition`-type row in
-`sample-data/data.csv`; the `entity1/authority1/action1/resource1`
-row is the `authorization` one.
+**A fresh fjall store is empty**, so that query returns **404
+`Trust record not found`** — and on a new deployment that *is* the
+correct answer. There is no import path from `sample-data/data.csv`
+into fjall; records arrive only via Trust Tasks, which is stage 3.
 
-**Gate:** both calls return 200 with a record.
+**Gate:** `/health` returns `{"status":"OK"}`, the process creates
+the directory at `TR_FJALL_PATH`, and `/recognition` returns a
+well-formed 404 rather than a 500. A 500 here means the store
+could not be opened — check permissions on the parent directory.
+
+If you want the query path proven against real data before
+touching DIDComm, run this stage once with
+`TR_STORAGE_BACKEND=csv` and `FILE_STORAGE_PATH=./sample-data/data.csv`
+(no rebuild required — CSV is in the default feature set). The
+`entity3/authority3/action3/resource3` row is the `recognition`
+record; `entity1/…` is the `authorization` one. Then switch back
+to fjall. The two backends share no state, so nothing carries over.
 
 ---
 
 ## Stage 2 — Real DID and mediator
 
 Use the provisioning CLI rather than hand-authoring
-`PROFILE_CONFIG`:
+`PROFILE_CONFIG`.
+
+> **The setup CLI cannot express a fjall configuration.**
+> `--storage-backend` carries `value_parser = ["csv", "ddb",
+> "redis"]`, so `--storage-backend fjall` is rejected by clap
+> before the tool runs. Its storage arguments are therefore a
+> throwaway here — run it for the *identity* work and re-apply the
+> storage settings afterwards.
 
 ```bash
 cargo run --bin setup-trust-registry --features dev-tools -- \
@@ -143,11 +179,23 @@ cargo run --bin setup-trust-registry --features dev-tools -- \
   --didweb-url https://webvh.example.com \
   --admin-dids "did:peer:2.Vz6Mk…" \
   --storage-backend csv \
-  --file-storage-path ./sample-data/data.csv \
   --acl-mode ExplicitDeny \
   --audit-log-format json \
   --non-interactive
 ```
+
+The tool **rewrites `.env` wholesale**, seeded from
+`.env.example` — so it will overwrite the fjall settings from
+stage 1 with `TR_STORAGE_BACKEND=csv`. Put them back:
+
+```dotenv
+TR_STORAGE_BACKEND=fjall
+TR_FJALL_PATH=/var/lib/trust-registry/records.fjall
+```
+
+and delete the `FILE_STORAGE_PATH` line it wrote. Re-check this
+after *any* future `setup-trust-registry` run; it is not
+idempotent with respect to storage.
 
 Points worth knowing:
 
@@ -164,7 +212,7 @@ Points worth knowing:
   `TSPTransport` service entry to the generated DID document.
 
 ```bash
-RUST_LOG=info cargo run --bin trust-registry
+RUST_LOG=info cargo run --bin trust-registry --features storage-fjall
 curl -s localhost:3232/.well-known/did.json | jq .
 ```
 
@@ -193,8 +241,15 @@ The routed tests are `#[ignore]`d by default. Add `--features tsp`
 for the TSP-multiplexed variant. This uses an in-process test
 mediator, so it exercises the code path without your real one.
 
-**Gate:** green. A failure here is in the registry, not your
-configuration.
+These tests use their own in-process storage, not your fjall
+store — passing here says the Trust Task path works, not that
+fjall persists correctly. Confirm that separately: write a record
+via a Trust Task, restart the process, then re-run the stage-1
+`/recognition` query. It should now return 200 with the record
+rather than 404. That round trip is the only real proof the store
+is durable and that `TR_FJALL_PATH` points where you think.
+
+**Gate:** tests green, and a written record survives a restart.
 
 ---
 
@@ -207,15 +262,26 @@ general sealed-transfer pattern.
 
 ### Build with the feature
 
+Features accumulate — `storage-fjall` must be carried forward
+alongside `vta`:
+
 ```bash
-cargo build --release --bin trust-registry --features vta
+cargo build --release --bin trust-registry \
+  --features "vta,storage-fjall"
 ```
 
 `vta` is in neither the default build nor the Docker image — the
 shipped `docker-compose.yaml` cannot run VTA mode. Containerised
-deployments need a custom image. Append a secrets backend, e.g.
-`--features "vta,secrets-aws"`, to keep the offline cache off
-local disk.
+deployments need a custom image, and that image must carry
+`storage-fjall` too. Append a secrets backend, e.g.
+`--features "vta,storage-fjall,secrets-aws"`, to keep the offline
+cache off local disk.
+
+Note that fjall and the VTA offline cache are **separate stores**
+with separate paths: `TR_FJALL_PATH` holds trust records,
+`TR_SECRETS_DATA_DIR` (default `./.trust-registry`) holds the
+cached credential bundle. Both need durable storage; neither is a
+backup of the other.
 
 ### Registry operator — recipient request
 
@@ -296,11 +362,17 @@ ENABLE_DIDCOMM=true
 MEDIATOR_DID=did:webvh:Qm…:webvh.example:mediator
 TR_VTA_CREDENTIAL=file:///etc/trust-registry/vta-credential.json
 TR_VTA_CONTEXT_ID=trust-registry
+TR_STORAGE_BACKEND=fjall
+TR_FJALL_PATH=/var/lib/trust-registry/records.fjall
 LISTEN_ADDRESS=0.0.0.0:3232
 ACL_MODE=ExplicitDeny
 AUDIT_LOG_FORMAT=json
 RUST_LOG=info
 ```
+
+`.env.vta.example` does not mention storage at all, so the two
+fjall lines must be added by hand when starting from that
+template.
 
 Four traps, all silent:
 
@@ -419,6 +491,58 @@ be treated restrictively rather than as transport failure.
 | Cross-community mint 503s forever | `recognized` mismatch above |
 | Docker image ignores VTA settings | `vta` not compiled into the shipped image |
 | Keys still in plaintext `.env` | setup tool writes both, cloud backend or not |
+| "fjall support was not compiled" | missing `--features storage-fjall` on this build |
+| Registry looks empty after a restart | `TR_FJALL_PATH` relative → resolved against a different working directory |
+| Records silently absent, no error | `TR_STORAGE_BACKEND` typo → silent fallback to `csv` |
+| Storage config reverted to CSV | a `setup-trust-registry` run rewrote `.env` |
+| 500 on every query at first boot | fjall cannot open the store — parent directory permissions |
+| Second replica fails or corrupts | fjall is single-writer; only one process per directory |
+
+## Storage backends
+
+`TR_STORAGE_BACKEND` selects the store. Anything unrecognised
+falls back to `csv` **silently** — there is no error for a typo,
+so `fjal` or `Fjall-db` yields a CSV registry that looks like it
+started fine.
+
+| Backend | Value | Extra config | Feature |
+|---|---|---|---|
+| CSV file | `csv` (default) | `FILE_STORAGE_PATH`, `FILE_STORAGE_UPDATE_INTERVAL_SEC` | built in |
+| DynamoDB | `ddb` / `dynamodb` | `DDB_TABLE_NAME`, `AWS_REGION`, `AWS_ENDPOINT` | built in |
+| Redis | `redis` | `REDIS_URL` | built in |
+| fjall | `fjall` | `TR_FJALL_PATH` | `storage-fjall` |
+
+### Why fjall, and what it costs
+
+fjall is an embedded LSM store: no external database, no network
+dependency in the read path, state on local disk. That makes it a
+good fit for a single-node registry where DynamoDB is unwanted
+operational surface.
+
+The trade-offs are worth stating plainly, because the rest of this
+runbook assumes you have accepted them:
+
+- **Single-writer, single-node.** The store is embedded in the
+  process. You cannot run two registry replicas over one fjall
+  directory, so horizontal scaling and rolling restarts both need
+  rethinking. Use DynamoDB if you need more than one instance.
+- **Backups are your problem.** No managed snapshots. Back up
+  `TR_FJALL_PATH` on whatever schedule your record durability
+  requires, and test a restore.
+- **The node becomes stateful.** Container deployments need a
+  persistent volume mounted at `TR_FJALL_PATH`; the shipped
+  `docker-compose.yaml` mounts `./sample-data` for the CSV path
+  and has no volume suitable for fjall.
+- **No seed-data import.** CSV starts populated from
+  `sample-data/data.csv`; fjall starts empty and is filled only by
+  Trust Tasks.
+- **The feature must be compiled in** on every build, including
+  any custom Docker image.
+
+Also note that the CSV backend rewrites its file on an interval
+(`FILE_STORAGE_UPDATE_INTERVAL_SEC`, default 60s) while fjall
+writes are durable per-operation. Migrating between the two means
+replaying Trust Tasks; there is no converter.
 
 ## Configuration notes
 

--- a/docs/03-vtc/trust-registry-deployment.md
+++ b/docs/03-vtc/trust-registry-deployment.md
@@ -308,6 +308,7 @@ pnm contexts provision \
   --id trust-registry \
   --name "Trust Registry" \
   --server https://webvh.example.com \
+  --did-path trust-registry \
   --mediator-service \
   --recipient tr-request.json
 ```
@@ -317,6 +318,13 @@ pnm contexts provision \
   service endpoint the registry needs to connect over DIDComm.
 - `--server` creates the registry's `did:webvh` on that host; use
   `--did-url` when self-hosting.
+- `--did-path` fixes the DID's path label on the hosting server, so
+  the registry's DID reads
+  `did:webvh:<scid>:webvh.example.com:trust-registry` rather than
+  whatever label the host would otherwise allocate. Optional, but
+  worth setting for a long-lived service other communities will
+  recognise by DID. Requires `--server` or `--did-url`. Pass
+  `.well-known` to claim the host's reserved root slot.
 - `--pre-rotation <N>` pre-generates rotation keys. Decide now;
   retrofitting is harder.
 

--- a/pnm-cli/Cargo.toml
+++ b/pnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pnm-cli"
 description = "CLI Tool for managing a personal Verifiable Trust Agent"
-version = "0.11.2"
+version = "0.11.3"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/pnm-cli/src/cli.rs
+++ b/pnm-cli/src/cli.rs
@@ -1574,6 +1574,12 @@ pub(crate) enum ContextCommands {
         /// Create a DID at this URL for self-hosting (mutually exclusive with --server)
         #[arg(long)]
         did_url: Option<String>,
+        /// Explicit path label for the DID on the hosting server (e.g.
+        /// `acme-eng`). Omit to let the host auto-assign one. Pass
+        /// `.well-known` for the reserved root slot. Same selector as
+        /// `pnm did-mgmt dids create --path`.
+        #[arg(long)]
+        did_path: Option<String>,
         /// Make the DID portable (default: true)
         #[arg(long, default_value = "true")]
         portable: bool,

--- a/pnm-cli/src/commands/contexts.rs
+++ b/pnm-cli/src/commands/contexts.rs
@@ -72,6 +72,7 @@ pub(crate) async fn run(
             admin_label,
             server,
             did_url,
+            did_path,
             portable,
             mediator_service,
             pre_rotation,
@@ -81,6 +82,12 @@ pub(crate) async fn run(
         } => {
             if server.is_some() && did_url.is_some() {
                 Err("--server and --did-url are mutually exclusive".into())
+            } else if did_path.is_some() && server.is_none() && did_url.is_none() {
+                // No DID is minted without --server/--did-url, so a path
+                // label would be silently discarded. Say so rather than
+                // provisioning a context the operator thinks is hosted
+                // at their chosen path.
+                Err("--did-path requires --server or --did-url".into())
             } else {
                 let recipient_spec = resolve_recipient(
                     recipient.as_deref(),
@@ -94,6 +101,7 @@ pub(crate) async fn run(
                             _ => Some(contexts::ProvisionDidOptions {
                                 server_id: server,
                                 did_url,
+                                did_path,
                                 portable,
                                 add_mediator_service: mediator_service,
                                 pre_rotation_count: pre_rotation,

--- a/vta-cli-common/Cargo.toml
+++ b/vta-cli-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-cli-common"
 description = "Shared CLI command handlers and rendering helpers for VTA CLIs"
 readme = "README.md"
-version = "0.10.7"
+version = "0.10.8"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-cli-common/src/commands/contexts.rs
+++ b/vta-cli-common/src/commands/contexts.rs
@@ -8,6 +8,7 @@ use ratatui::{
 use vta_sdk::client::{ContextResponse, CreateDidWebvhRequest, UpdateContextRequest};
 use vta_sdk::context_provision::{ContextProvisionBundle, ProvisionedDid};
 use vta_sdk::prelude::*;
+use vta_sdk::protocols::did_management::create::WebvhPathMode;
 use vta_sdk::sealed_transfer::SealedPayloadV1;
 
 use crate::render::{is_full_display, print_full_entry, print_full_list_title, print_widget};
@@ -16,6 +17,10 @@ use crate::sealed_producer::{SealedRecipient, seal_for_recipient};
 pub struct ProvisionDidOptions {
     pub server_id: Option<String>,
     pub did_url: Option<String>,
+    /// Explicit path label for the DID on the hosting server. `None`
+    /// leaves the host to auto-assign one; `.well-known` selects the
+    /// reserved root slot. Mirrors `pnm did-mgmt dids create --path`.
+    pub did_path: Option<String>,
     pub portable: bool,
     pub add_mediator_service: bool,
     pub pre_rotation_count: u32,
@@ -523,9 +528,12 @@ pub async fn cmd_context_provision(
             server_id: opts.server_id,
             url: opts.did_url,
             path: None,
-            // No explicit path-mode override; the absent legacy `path`
-            // resolves to auto-assign server-side.
-            path_mode: None,
+            // `--did-path` maps onto the canonical path-mode selector:
+            // absent → auto-assign server-side, `.well-known` → the
+            // reserved root slot, anything else → an explicit label.
+            // `WebvhPathMode::from(String)` owns that trimming/mapping
+            // so the contexts surface can't drift from `dids create`.
+            path_mode: opts.did_path.map(WebvhPathMode::from),
             // Context-bootstrap path: no per-DID domain override.
             // The server's caller-default → system-default resolves.
             domain: None,


### PR DESCRIPTION
Two independent changes.

## `pnm contexts provision --did-path`

`cmd_context_provision` hardcoded `path: None, path_mode: None`, which
resolves to `WebvhPathMode::AutoAssign` — so a context-scoped
`did:webvh` always got a host-allocated path label. Operators had no
way to choose one short of dropping to `pnm did-mgmt dids create`
after the fact.

The selector already existed; it just was not plumbed into the
contexts surface. `ProvisionDidOptions` gains `did_path`, mapped via
`WebvhPathMode::from(String)` — reusing that conversion keeps contexts
from drifting from `dids create`, since it already owns the trimming,
the `.well-known` special case, and empty-string → auto-assign.

```bash
pnm contexts provision --id myservice --name "My service" \
    --server webvh-1 --did-path acme-eng --recipient request.json
```

`--did-path` without `--server`/`--did-url` is rejected rather than
silently discarded, since no DID is minted in that case.

No change to the offline `vta` CLI: `vta contexts create` does not
mint a DID at all, and `vta did-mgmt dids create --path` already
covers offline path-picking.

## Trust-registry fjall runbook

`docs/03-vtc/trust-registry-deployment.md` walked all four stages on
the CSV backend, leaving fjall deployments to guess at the
differences — several of which fail silently. Rewrites stages 1-4
around fjall and adds a storage-backends section covering all four
stores.

Traps now documented: `TR_STORAGE_BACKEND` falls back to `csv`
silently on a typo; `--features storage-fjall` is required on every
build; a fresh store is empty so the stage-1 query correctly 404s;
and `setup-trust-registry` rewrites `.env` wholesale, so storage
settings need re-applying after any run.

## Testing

`cargo build`, `cargo test -p vta-cli-common -p pnm-cli` (68 passed),
and clippy clean. Versions bumped: `vta-cli-common` 0.10.8, `pnm-cli`
0.11.3.