### PR TITLE
fix(contexts): enforce the slug rule on the setup-time create path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10235,7 +10235,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.11.11"
+version = "0.11.12"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",

--- a/docs/02-vta/non-interactive-setup.md
+++ b/docs/02-vta/non-interactive-setup.md
@@ -106,6 +106,11 @@ admin_did   = "did:key:z6MkOWNER..."
 backend = "keyring"
 
 # A staff member, bounded to the `sales` context.
+#
+# `context` must be a slug: lowercase letters, digits and hyphens, no
+# leading or trailing hyphen, 64 chars max. Setup fails on anything
+# else rather than creating a context that `pnm contexts create` would
+# later refuse.
 [[staff]]
 did     = "did:key:z6MkSTAFF..."
 context = "sales"

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.11.11"
+version = "0.11.12"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/contexts/mod.rs
+++ b/vta-service/src/contexts/mod.rs
@@ -144,12 +144,57 @@ pub async fn allocate_context_index(
     Ok((current, base_path))
 }
 
+/// Validate a **single** context id segment.
+///
+/// Deliberately stricter than
+/// [`vti_common::identifier::validate_identifier`], which also admits
+/// uppercase, `.` and `_`. Context ids surface in DID paths, derivation
+/// labels and operator commands, so they are held to one canonical
+/// lowercase-slug spelling rather than several that differ only by case
+/// or punctuation.
+///
+/// **Segment-only.** A hierarchical id (`acme/eng`) is the *stored*
+/// form, built by `context_path::child_path` from an already-validated
+/// parent plus a leaf validated here. Never call this on a full path —
+/// the `/` would be rejected.
+pub fn validate_slug(id: &str) -> Result<(), AppError> {
+    if id.is_empty() {
+        return Err(AppError::Validation("context id cannot be empty".into()));
+    }
+    if id.len() > 64 {
+        return Err(AppError::Validation(
+            "context id must be 64 characters or fewer".into(),
+        ));
+    }
+    if !id
+        .chars()
+        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+    {
+        return Err(AppError::Validation(
+            "context id must contain only lowercase alphanumeric characters and hyphens".into(),
+        ));
+    }
+    if id.starts_with('-') || id.ends_with('-') {
+        return Err(AppError::Validation(
+            "context id must not start or end with a hyphen".into(),
+        ));
+    }
+    Ok(())
+}
+
 /// Create a new top-level application context and store it.
+///
+/// Applies the same [`validate_slug`] gate as the authenticated
+/// `operations::contexts::create_context`. Both must, or setup-time
+/// callers (`setup::from_toml`, `tee::did_autogen`) could persist ids
+/// the operator-facing API would later refuse — leaving a deployment
+/// whose own CLI rejects a context it already has.
 pub async fn create_context(
     contexts_ks: &KeyspaceHandle,
     id: &str,
     name: &str,
 ) -> Result<ContextRecord, Box<dyn std::error::Error>> {
+    validate_slug(id).map_err(|e| format!("{e}"))?;
     let (index, base_path) = allocate_context_index(contexts_ks, CONTEXT_KEY_BASE, "ctx_counter")
         .await
         .map_err(|e| format!("{e}"))?;
@@ -278,5 +323,56 @@ mod tests {
             stored.base_path, winners[0].base_path,
             "stored record must be the winner's — no overwrite by losers"
         );
+    }
+
+    #[test]
+    fn validate_slug_accepts_canonical_shapes() {
+        for ok in ["a", "vta", "trust-registry", "ctx-1", "a1-b2-c3"] {
+            validate_slug(ok).unwrap_or_else(|e| panic!("{ok:?} should be valid: {e}"));
+        }
+        validate_slug(&"a".repeat(64)).expect("64 chars is the limit, not over it");
+    }
+
+    #[test]
+    fn validate_slug_rejects_non_canonical_shapes() {
+        // Uppercase, `.` and `_` are accepted by the *looser*
+        // `validate_identifier` used for parent path segments. Context
+        // ids are held to the narrower slug rule, so these must fail
+        // here even though they are legal identifiers elsewhere.
+        for bad in [
+            "MyApp", "ctx.v2", "my_app", "-lead", "trail-", "", "a/b", "a b",
+        ] {
+            assert!(
+                validate_slug(bad).is_err(),
+                "{bad:?} must be rejected as a context id"
+            );
+        }
+        assert!(validate_slug(&"a".repeat(65)).is_err(), "65 chars is over");
+    }
+
+    /// The setup-time path (`setup::from_toml`, `tee::did_autogen`)
+    /// must not be able to persist an id that the authenticated
+    /// `operations::contexts::create_context` would refuse — otherwise
+    /// a deployment ends up with a context its own CLI rejects.
+    #[tokio::test]
+    async fn low_level_create_context_enforces_the_slug_rule() {
+        let (ks, _dir) = temp_ks();
+
+        let err = create_context(&ks, "MyApp", "My App")
+            .await
+            .expect_err("non-slug id must be refused");
+        assert!(
+            err.to_string().contains("lowercase"),
+            "error should name the rule, got: {err}"
+        );
+
+        assert!(
+            get_context(&ks, "MyApp").await.expect("get").is_none(),
+            "a rejected id must not have been persisted"
+        );
+
+        create_context(&ks, "myapp", "My App")
+            .await
+            .expect("the slug form is accepted");
     }
 }

--- a/vta-service/src/operations/contexts.rs
+++ b/vta-service/src/operations/contexts.rs
@@ -26,31 +26,6 @@ pub struct UpdateContextParams {
     pub context_policy: Option<vta_sdk::context_policy::ContextPolicy>,
 }
 
-fn validate_slug(id: &str) -> Result<(), AppError> {
-    if id.is_empty() {
-        return Err(AppError::Validation("context id cannot be empty".into()));
-    }
-    if id.len() > 64 {
-        return Err(AppError::Validation(
-            "context id must be 64 characters or fewer".into(),
-        ));
-    }
-    if !id
-        .chars()
-        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
-    {
-        return Err(AppError::Validation(
-            "context id must contain only lowercase alphanumeric characters and hyphens".into(),
-        ));
-    }
-    if id.starts_with('-') || id.ends_with('-') {
-        return Err(AppError::Validation(
-            "context id must not start or end with a hyphen".into(),
-        ));
-    }
-    Ok(())
-}
-
 fn to_result_body(r: &ContextRecord) -> CreateContextResultBody {
     CreateContextResultBody {
         id: r.id.clone(),
@@ -88,7 +63,7 @@ pub async fn create_context(
     channel: &str,
 ) -> Result<CreateContextResultBody, AppError> {
     // The leaf id is always a single slug segment.
-    validate_slug(id)?;
+    crate::contexts::validate_slug(id)?;
 
     let (full_id, parent_field, base_prefix, counter_key) = match &parent {
         None => {

--- a/vta-service/src/operations/provision_integration/preconditions.rs
+++ b/vta-service/src/operations/provision_integration/preconditions.rs
@@ -390,12 +390,12 @@ mod tests {
         let (_dir, _store, ks) = fresh_contexts_ks().await;
         // Seed multiple contexts to confirm the inference doesn't reach
         // for rule 2's fallback when rule 1 already resolves.
-        seed_context(&ks, "ctx_a").await;
-        seed_context(&ks, "ctx_b").await;
+        seed_context(&ks, "ctx-a").await;
+        seed_context(&ks, "ctx-b").await;
 
-        let a = auth(Role::Admin, vec!["ctx_b"]);
+        let a = auth(Role::Admin, vec!["ctx-b"]);
         let result = infer_target_context(&a, &ks).await.expect("ok");
-        assert_eq!(result.expect("not ambiguous"), "ctx_b");
+        assert_eq!(result.expect("not ambiguous"), "ctx-b");
     }
 
     /// Rule 2: super-admin grant + maintainer has exactly one context →
@@ -419,9 +419,9 @@ mod tests {
     #[tokio::test]
     async fn infer_super_admin_with_multiple_contexts_is_ambiguous() {
         let (_dir, _store, ks) = fresh_contexts_ks().await;
-        seed_context(&ks, "ctx_a").await;
-        seed_context(&ks, "ctx_b").await;
-        seed_context(&ks, "ctx_c").await;
+        seed_context(&ks, "ctx-a").await;
+        seed_context(&ks, "ctx-b").await;
+        seed_context(&ks, "ctx-c").await;
 
         let a = auth(Role::Admin, vec![]);
 
@@ -430,9 +430,9 @@ mod tests {
         assert_eq!(
             ambiguous.candidates,
             vec![
-                "ctx_a".to_string(),
-                "ctx_b".to_string(),
-                "ctx_c".to_string()
+                "ctx-a".to_string(),
+                "ctx-b".to_string(),
+                "ctx-c".to_string()
             ]
         );
         assert!(ambiguous.message.contains("3 contexts"));
@@ -444,13 +444,13 @@ mod tests {
     async fn infer_multi_context_grant_is_ambiguous() {
         let (_dir, _store, ks) = fresh_contexts_ks().await;
 
-        let a = auth(Role::Admin, vec!["ctx_x", "ctx_y"]);
+        let a = auth(Role::Admin, vec!["ctx-x", "ctx-y"]);
 
         let result = infer_target_context(&a, &ks).await.expect("ok");
         let ambiguous = result.expect_err("two contexts → ambiguous");
         assert_eq!(
             ambiguous.candidates,
-            vec!["ctx_x".to_string(), "ctx_y".to_string()]
+            vec!["ctx-x".to_string(), "ctx-y".to_string()]
         );
     }
 
@@ -479,14 +479,14 @@ mod tests {
     #[tokio::test]
     async fn resolve_uses_requested_existing_context() {
         let (_dir, _store, ks) = fresh_contexts_ks().await;
-        seed_context(&ks, "ctx_a").await;
-        let a = auth(Role::Admin, vec!["ctx_a"]);
+        seed_context(&ks, "ctx-a").await;
+        let a = auth(Role::Admin, vec!["ctx-a"]);
 
-        let (context, created) = resolve_target_context(&a, &ks, Some("ctx_a".into()), false)
+        let (context, created) = resolve_target_context(&a, &ks, Some("ctx-a".into()), false)
             .await
             .map_err(|_| ())
             .expect("resolves");
-        assert_eq!(context, "ctx_a");
+        assert_eq!(context, "ctx-a");
         assert!(!created);
     }
 
@@ -516,7 +516,7 @@ mod tests {
     #[tokio::test]
     async fn resolve_propagates_ambiguous_inference() {
         let (_dir, _store, ks) = fresh_contexts_ks().await;
-        let a = auth(Role::Admin, vec!["ctx_x", "ctx_y"]);
+        let a = auth(Role::Admin, vec!["ctx-x", "ctx-y"]);
 
         let err = resolve_target_context(&a, &ks, None, false)
             .await
@@ -526,7 +526,7 @@ mod tests {
             ResolveContextError::Ambiguous(amb) => {
                 assert_eq!(
                     amb.candidates,
-                    vec!["ctx_x".to_string(), "ctx_y".to_string()]
+                    vec!["ctx-x".to_string(), "ctx-y".to_string()]
                 );
             }
             ResolveContextError::Op(e) => panic!("expected Ambiguous, got Op({e:?})"),
@@ -537,9 +537,9 @@ mod tests {
     #[tokio::test]
     async fn resolve_missing_context_without_create_is_op_not_found() {
         let (_dir, _store, ks) = fresh_contexts_ks().await;
-        let a = auth(Role::Admin, vec!["ctx_absent"]);
+        let a = auth(Role::Admin, vec!["ctx-absent"]);
 
-        let err = resolve_target_context(&a, &ks, Some("ctx_absent".into()), false)
+        let err = resolve_target_context(&a, &ks, Some("ctx-absent".into()), false)
             .await
             .err()
             .expect("not found");


### PR DESCRIPTION
Follow-up to the asymmetry noticed while working on #699.

## The defect

`validate_slug` gated only `operations::contexts::create_context` —
the authenticated REST/Trust-Task path. The *low-level*
`contexts::create_context` (`contexts/mod.rs`) did no validation at
all, and `setup::from_toml:1572` passes it an operator-supplied id
straight from the setup TOML:

```rust
let mut record = crate::contexts::create_context(&contexts_ks, &s.context, &name).await?;
```

So a setup TOML with `context = "MyApp"` created a context that
`pnm contexts create --id MyApp` would refuse — a deployment whose own
CLI rejects an id it already has. `tee::did_autogen` uses the same
unvalidated helper.

## Not a security issue

Worth stating explicitly, since "validation was missing" reads worse
than this is. Both validators reject the separator characters that
would matter — `/` (path separator) and `:` (keyspace-prefix
separator) and whitespace — so neither permits traversal or prefix
collision. Store keys are byte-exact, so `MyApp` and `myapp` are two
distinct records rather than an aliasing bug. The gap is a
consistency defect, not a boundary one.

## The change

Lifts `validate_slug` into `contexts/mod.rs` so there is a single
definition, and applies it in the low-level create path.

**Kept segment-only.** The stored hierarchical id (`acme/eng`) is
built by `child_path` from an already-validated parent plus a leaf
validated here. Validating the full stored path would reject `/` and
break nested contexts entirely — the leaf-only contract is
load-bearing.

## Compatibility

Audited every context id literal in the repo. Zero shipped example
configs, docs, or `.toml` fixtures violate the rule, so this is not
breaking for existing deployments. Six test ids in
`preconditions.rs` used underscores (`ctx_a`) and only passed because
they went through the unvalidated helper — renamed to hyphens. Those
look like unintentional Rust-identifier-style naming rather than
deliberate coverage.

Also documents the rule in the setup TOML example, since setup now
fails hard on a bad id instead of silently accepting it.

## Testing

Full `cargo test -p vta-service` green (928 + integration suites, 0
failures). Clippy clean. New tests pin the accepted/rejected shapes
and assert the low-level path refuses a non-slug id without
persisting it. `vta-service` 0.11.11 → 0.11.12.