### PR TITLE
feat(pnm): bootstrap open --out writes the credential bundle to a file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## Unreleased
 
+### pnm-cli — `bootstrap open --out` writes the credential bundle
+
+* `pnm bootstrap open` decrypted a sealed bundle, printed a summary and exited
+  without writing anything, and had no flag to do otherwise. File-based
+  consumers of a `CredentialBundle` — notably the trust registry's
+  `TR_VTA_CREDENTIAL`, documented as a `file://` URI — therefore had no
+  supported way to obtain one: `extract_admin_credential` existed but was
+  reachable only from `cnm-cli`, which feeds it straight into the keyring.
+  `--out <PATH>` now writes the extracted bundle as JSON, opened at `0600` so
+  the private key is never briefly world-readable. Serde renames on
+  `CredentialBundle` mean the output is already the documented wire shape
+  (`privateKeyMultibase` / `vtaDid` / `vtaUrl`). Accepts `AdminCredential` and
+  `ContextProvision` payloads; other variants keep their existing per-variant
+  rejection. Because opening consumes the single-use bootstrap secret, the
+  omit-`--out` path now says plainly that nothing was written and how to get a
+  file, rather than pointing only at the online `connect` flow.
+
 ### vta-mobile-core — task-consent approver FFI (mobile as a 2nd device, phase 1)
 
 * New `consent.rs` exposes the FFI the mobile agent needs to act as a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6743,7 +6743,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "pnm-cli"
-version = "0.11.3"
+version = "0.11.4"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-resolver-cache-sdk",

--- a/docs/03-vtc/trust-registry-deployment.md
+++ b/docs/03-vtc/trust-registry-deployment.md
@@ -335,15 +335,18 @@ channel.
 ### Registry operator — open the bundle
 
 ```bash
+sudo mkdir -p /etc/trust-registry
+
 pnm bootstrap open \
   --bundle tr-sealed.txt \
-  --expect-digest <sha256-hex>
+  --expect-digest <sha256-hex> \
+  --out /etc/trust-registry/vta-credential.json
 ```
 
 The digest check is mandatory; there is no trust-on-first-use.
 `--no-verify-digest` exists for testing only.
 
-The recovered bundle:
+`--out` writes the credential bundle as JSON at `0600`:
 
 ```json
 {
@@ -354,12 +357,24 @@ The recovered bundle:
 }
 ```
 
-Install it with restrictive permissions:
+> **`--out` is not optional in practice.** Without it, `bootstrap
+> open` only inspects the bundle — it prints a payload summary and
+> writes nothing. `privateKeyMultibase` is never printed, so the
+> credential cannot be recovered from terminal output.
+>
+> Opening also consumes the single-use bootstrap secret under
+> `~/.config/pnm/bootstrap-secrets/`. A second `open` on the same
+> file fails. Recovering from a forgotten `--out` means a fresh
+> `pnm bootstrap request` **and** a fresh `pnm contexts provision`
+> — the whole ceremony, from the top.
 
-```bash
-sudo install -m 600 -D /dev/stdin \
-  /etc/trust-registry/vta-credential.json < bundle.json
-```
+Both `AdminCredential` and `ContextProvision` payloads yield a
+credential; `pnm contexts provision` produces the latter. Other
+payload variants are rejected with a per-variant message.
+
+`--out` requires a `pnm` build that carries the flag. Older builds
+reject it at argument parsing and have no file-writing path at
+all, so upgrade rather than working around it.
 
 ### Configure the registry
 
@@ -497,6 +512,8 @@ be treated restrictively rather than as transport failure.
 | Peers cannot reach the registry | `did:webvh` generated but never hosted |
 | VTC green, membership never syncs | DIDComm write defect above |
 | Cross-community mint 503s forever | `recognized` mismatch above |
+| `bootstrap open` produced no file | `--out` omitted; the bundle is now spent, start over from `bootstrap request` |
+| Second `bootstrap open` fails | single-use secret already consumed by the first open |
 | Docker image ignores VTA settings | `vta` not compiled into the shipped image |
 | Keys still in plaintext `.env` | setup tool writes both, cloud backend or not |
 | "fjall support was not compiled" | missing `--features storage-fjall` on this build |

--- a/pnm-cli/Cargo.toml
+++ b/pnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pnm-cli"
 description = "CLI Tool for managing a personal Verifiable Trust Agent"
-version = "0.11.3"
+version = "0.11.4"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/pnm-cli/src/bootstrap.rs
+++ b/pnm-cli/src/bootstrap.rs
@@ -12,6 +12,7 @@
 //! available but prints a warning — there is no silent TOFU.
 
 use std::fs;
+use std::io::Write;
 use std::path::PathBuf;
 
 use serde::Deserialize;
@@ -131,6 +132,7 @@ fn parse_var(raw: &str) -> Result<(String, serde_json::Value), Box<dyn std::erro
 /// `pnm bootstrap open --bundle <PATH> [--expect-digest <HEX>] [--no-verify-digest]`
 pub async fn run_open(
     bundle_path: PathBuf,
+    out: Option<PathBuf>,
     expect_digest: Option<String>,
     no_verify_digest: bool,
     expect_vta_did: Option<String>,
@@ -158,17 +160,27 @@ pub async fn run_open(
             if let Some(ref u) = c.vta_url {
                 println!("  VTA URL: {u}");
             }
-            println!();
-            println!("To install this credential, use the online bootstrap flow:");
-            println!(
-                "  pnm bootstrap connect --vta-url <url> [--expect-digest <sha256>] \
-                 [--expect-pcr0 <hex>] [--expect-pcr8 <hex>]"
-            );
+            if out.is_none() {
+                println!();
+                println!("Nothing was written. To install this credential either:");
+                println!("  - re-open with --out <path> for a file-based consumer, or");
+                println!(
+                    "  - use the online flow: pnm bootstrap connect --vta-url <url> \
+                     [--expect-digest <sha256>] [--expect-pcr0 <hex>] [--expect-pcr8 <hex>]"
+                );
+            }
         }
         SealedPayloadV1::ContextProvision(p) => {
             println!("Payload: ContextProvision");
             println!("  Context:   {} ({})", p.context_id, p.context_name);
             println!("  Admin DID: {}", p.admin_did);
+            if out.is_none() {
+                println!();
+                println!(
+                    "Nothing was written — this payload carries an admin credential. \
+                     Re-open with --out <path> to write it as JSON."
+                );
+            }
         }
         SealedPayloadV1::DidSecrets(s) => {
             println!("Payload: DidSecrets");
@@ -256,6 +268,53 @@ pub async fn run_open(
         }
     }
 
+    if let Some(path) = out {
+        // Rejects any payload variant that isn't an admin identity, with a
+        // per-variant message. The bundle is already spent by this point, so
+        // failing here still costs the operator a fresh request cycle — hence
+        // the up-front warning in the `--out` help text.
+        let bundle = vta_cli_common::sealed_consumer::extract_admin_credential(opened.payload)?;
+        write_credential_bundle(&path, &bundle)?;
+        println!();
+        println!("Credential written to {} (0600).", path.display());
+    }
+
+    Ok(())
+}
+
+/// Serialize a [`CredentialBundle`] to `path`, owner-readable only.
+///
+/// Field names come from the type's serde renames (`privateKeyMultibase`,
+/// `vtaDid`, `vtaUrl`), so the output is exactly the shape file-based
+/// consumers expect — e.g. the trust registry's `TR_VTA_CREDENTIAL`.
+fn write_credential_bundle(
+    path: &std::path::Path,
+    bundle: &vta_sdk::credentials::CredentialBundle,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let json = serde_json::to_vec_pretty(bundle)?;
+
+    let mut opts = fs::OpenOptions::new();
+    opts.create(true).write(true).truncate(true);
+    // Open at 0600 so the private key is never briefly world-readable
+    // between create and chmod — same rationale as `write_secret` in
+    // vta-cli-common's sealed_consumer.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        opts.mode(0o600);
+    }
+    let mut file = opts.open(path)?;
+    file.write_all(&json)?;
+    file.write_all(b"\n")?;
+    drop(file);
+
+    if let Err(e) = vta_cli_common::secure_file::restrict_file_to_owner(path) {
+        eprintln!(
+            "warning: could not restrict {} to owner ({e}) — the private key may be \
+             readable by other local users",
+            path.display()
+        );
+    }
     Ok(())
 }
 
@@ -626,5 +685,87 @@ mod tests {
     #[test]
     fn parse_var_empty_key_errors() {
         assert!(parse_var("=value").is_err());
+    }
+
+    fn scratch_path(name: &str) -> std::path::PathBuf {
+        let mut p = std::env::temp_dir();
+        p.push(format!("pnm-open-out-{name}-{}.json", std::process::id()));
+        p
+    }
+
+    fn sample_bundle() -> vta_sdk::credentials::CredentialBundle {
+        vta_sdk::credentials::CredentialBundle {
+            did: "did:key:z6MkTest".into(),
+            private_key_multibase: "z3SecretTest".into(),
+            vta_did: "did:webvh:QmTest:vta.example.com:vta".into(),
+            vta_url: Some("https://vta.example.com".into()),
+        }
+    }
+
+    /// The on-disk field names are the contract with file-based consumers
+    /// (the trust registry's `TR_VTA_CREDENTIAL` parses exactly these), so
+    /// assert the serde renames rather than the Rust field names.
+    #[test]
+    fn written_credential_uses_wire_field_names() {
+        let path = scratch_path("fields");
+        super::write_credential_bundle(&path, &sample_bundle()).unwrap();
+
+        let v: Value = serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        assert_eq!(v["did"], "did:key:z6MkTest");
+        assert_eq!(v["privateKeyMultibase"], "z3SecretTest");
+        assert_eq!(v["vtaDid"], "did:webvh:QmTest:vta.example.com:vta");
+        assert_eq!(v["vtaUrl"], "https://vta.example.com");
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    /// `vtaUrl` is `skip_serializing_if = "Option::is_none"`, so an absent
+    /// URL must omit the key entirely rather than emit `null` — the
+    /// registry's loader treats an explicit null as a parse error.
+    #[test]
+    fn written_credential_omits_absent_vta_url() {
+        let path = scratch_path("nourl");
+        let mut bundle = sample_bundle();
+        bundle.vta_url = None;
+        super::write_credential_bundle(&path, &bundle).unwrap();
+
+        let v: Value = serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        assert!(v.get("vtaUrl").is_none());
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn written_credential_is_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let path = scratch_path("perms");
+        super::write_credential_bundle(&path, &sample_bundle()).unwrap();
+
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode();
+        assert_eq!(
+            mode & 0o777,
+            0o600,
+            "credential file must not be group/world readable"
+        );
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    /// Writing must overwrite, not append — re-running against an existing
+    /// path would otherwise produce trailing garbage after valid JSON.
+    #[cfg(unix)]
+    #[test]
+    fn written_credential_truncates_existing_file() {
+        let path = scratch_path("truncate");
+        std::fs::write(&path, vec![b'x'; 4096]).unwrap();
+        super::write_credential_bundle(&path, &sample_bundle()).unwrap();
+
+        // Parses cleanly => no leftover bytes from the longer previous file.
+        let v: Value = serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        assert_eq!(v["did"], "did:key:z6MkTest");
+
+        std::fs::remove_file(&path).ok();
     }
 }

--- a/pnm-cli/src/cli.rs
+++ b/pnm-cli/src/cli.rs
@@ -297,10 +297,23 @@ pub(crate) enum BootstrapCommands {
     ///
     /// `--expect-digest <hex>` is required by default. Use `--no-verify-digest`
     /// to opt out (with a warning) — there is no silent TOFU.
+    ///
+    /// By default this only inspects the bundle: the payload summary is
+    /// printed and nothing is written. Pass `--out <PATH>` to also write
+    /// the admin `CredentialBundle` as JSON for services that read one
+    /// from a file (e.g. the trust registry's `TR_VTA_CREDENTIAL`).
+    ///
+    /// Opening consumes the single-use bootstrap secret, so a bundle can
+    /// only be opened once — decide up front whether you need `--out`.
     Open {
         /// Path to the armored bundle file.
         #[arg(long)]
         bundle: std::path::PathBuf,
+        /// Write the extracted admin credential to this path as JSON
+        /// (created 0600). Only valid for `AdminCredential` and
+        /// `ContextProvision` payloads.
+        #[arg(long)]
+        out: Option<std::path::PathBuf>,
         /// Expected SHA-256 digest, communicated out-of-band by the producer.
         #[arg(long)]
         expect_digest: Option<String>,

--- a/pnm-cli/src/commands/bootstrap.rs
+++ b/pnm-cli/src/commands/bootstrap.rs
@@ -26,12 +26,14 @@ pub(crate) async fn run_offline(
         }
         BootstrapCommands::Open {
             bundle,
+            out,
             expect_digest,
             no_verify_digest,
             expect_vta_did,
         } => Some(
             bootstrap::run_open(
                 bundle.clone(),
+                out.clone(),
                 expect_digest.clone(),
                 *no_verify_digest,
                 expect_vta_did.clone(),


### PR DESCRIPTION
`pnm bootstrap open` decrypted the sealed bundle, printed a summary and exited without writing anything, and had no flag to do otherwise. File-based consumers of a `CredentialBundle` — notably the trust registry's `TR_VTA_CREDENTIAL`, documented as a `file://` URI — therefore had **no supported way to obtain one**.

The extraction logic already existed: `sealed_consumer::extract_admin_credential` handles both `AdminCredential` and `ContextProvision` payloads. Its only callers were in `cnm-cli`, which feeds the bundle straight into the keyring. `pnm` never called it.

## Change

Add `--out <PATH>` to `pnm bootstrap open`, writing the extracted bundle as JSON at `0600`.

`CredentialBundle`'s serde renames mean the output is already the documented wire shape (`privateKeyMultibase` / `vtaDid` / `vtaUrl`) — no mapping layer, and the tests assert that contract rather than the Rust field names.

Also corrects the no-`--out` output. It previously pointed only at `pnm bootstrap connect`, which is the TEE first-boot flow and not applicable to a `ContextProvision` bundle; it now says plainly that nothing was written.

## Notes for review

- **The file is opened at `0600` atomically** via `OpenOptions::mode` rather than chmod-after-create, so the private key is never briefly world-readable. Same rationale as `write_secret` in `vta-cli-common`.
- **Failure after the bundle is spent.** Opening consumes the single-use secret, so an `--out` rejection on a non-credential payload still costs a fresh request cycle. Handled by warning up front in the `--out` help text rather than by reordering — extraction can't run before the payload is decrypted.
- Tests use `std::env::temp_dir`; `pnm-cli` has no `dev-dependencies` and this avoids adding `tempfile` for four tests.

## Testing

`cargo test -p pnm-cli` — 51 passed. Clippy clean, `cargo fmt` applied.

| Test | Guards |
|---|---|
| `written_credential_uses_wire_field_names` | serde renames, not Rust field names |
| `written_credential_omits_absent_vta_url` | `skip_serializing_if` → key absent, not `null` |
| `written_credential_is_owner_only` | mode `0600` |
| `written_credential_truncates_existing_file` | overwrite, not append |

Docs follow in a stacked PR.