### PR TITLE
feat(vtc): audit sign-out, expose chain verification, record rotation reason

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2472,7 +2472,7 @@ checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cnm-cli"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "clap",
@@ -10342,7 +10342,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-service"
-version = "0.11.11"
+version = "0.11.12"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",
@@ -10424,7 +10424,7 @@ dependencies = [
 
 [[package]]
 name = "vti-common"
-version = "0.11.9"
+version = "0.11.10"
 dependencies = [
  "aes-gcm",
  "affinidi-data-integrity",

--- a/cnm-cli/Cargo.toml
+++ b/cnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cnm-cli"
 description = "CLI Tool for Verified Trust Agents operating in Verified Trust Communities"
-version = "0.11.1"
+version = "0.11.2"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/cnm-cli/src/audit.rs
+++ b/cnm-cli/src/audit.rs
@@ -1,0 +1,111 @@
+//! `cnm audit verify` — check the VTC's audit hash chain.
+//!
+//! The community's audit log is a community-admin concern (unlike the
+//! VTA's own audit tail, which lives on `pnm`), so the verification
+//! surface belongs here.
+//!
+//! Like `cnm backup`, this is a REST-only super-admin route, so we make
+//! a direct authenticated GET (forcing REST regardless of the session's
+//! preferred transport) and attach the `Trust-Task` header the route
+//! requires.
+
+use serde_json::Value;
+use vta_cli_common::render::{DIM, GREEN, RED, RESET};
+use vta_sdk::client::VtaClient;
+
+use crate::auth;
+
+/// Canonical HTTP header carrying the Trust-Task URL (mirrors
+/// `vti_common::trust_task::HEADER_NAME`).
+const TRUST_TASK_HEADER: &str = "Trust-Task";
+const VERIFY_TASK: &str = "https://trusttasks.org/openvtc/vtc/audit/verify/1.0";
+
+/// `cnm audit verify` — walk the community's audit chain and report.
+///
+/// Exits non-zero when the chain does not verify, so this is usable as
+/// a scheduled check (`cnm audit verify || alert`).
+pub async fn cmd_verify(
+    client: &VtaClient,
+    keyring_key: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let base = client
+        .rest_url()
+        .ok_or("VTC audit verify requires a REST connection to the VTC")?;
+    let token = auth::ensure_authenticated(base, keyring_key).await?;
+
+    let resp = reqwest::Client::new()
+        .get(format!("{base}/audit/verify"))
+        .bearer_auth(&token)
+        .header(TRUST_TASK_HEADER, VERIFY_TASK)
+        .send()
+        .await?;
+    let status = resp.status();
+    let text = resp.text().await.unwrap_or_default();
+    if !status.is_success() {
+        return Err(format!("VTC audit verify failed ({status}): {text}").into());
+    }
+    let body: Value = serde_json::from_str(&text)
+        .map_err(|e| format!("could not parse VTC response: {e} (body: {text})"))?;
+
+    let verified = body["verified"].as_bool().unwrap_or(false);
+    let examined = body["entriesExamined"].as_u64().unwrap_or(0);
+    let chain_verified = body["entriesVerified"].as_u64().unwrap_or(0);
+    let legacy = body["legacySkipped"].as_u64().unwrap_or(0);
+    let unparseable = body["unparseableSkipped"].as_u64().unwrap_or(0);
+
+    if verified {
+        println!("{GREEN}✓ audit chain verified{RESET}");
+    } else {
+        println!("{RED}✗ audit chain BROKEN{RESET}");
+    }
+    println!("  {DIM}entries examined:{RESET} {examined}");
+    println!("  {DIM}chain-verified:  {RESET} {chain_verified}");
+    if let Some(head) = body["head"].as_str() {
+        println!("  {DIM}chain head:      {RESET} {head}");
+    }
+
+    // Skipped rows are not a pass — they are rows nothing checked.
+    // Surface them at the same prominence as a break so a clean-looking
+    // "verified" over a log full of skips can't be misread.
+    if legacy > 0 {
+        println!(
+            "  {RED}legacy rows skipped: {legacy}{RESET} \
+             {DIM}(pre-v2 rows are not chain-checked — on a store that should\n\
+             \x20  have none, this is itself a finding){RESET}"
+        );
+    }
+    if unparseable > 0 {
+        println!(
+            "  {RED}unparseable rows skipped: {unparseable}{RESET} \
+             {DIM}(corrupt or forward-version rows, also unchecked){RESET}"
+        );
+    }
+
+    if let Some(brk) = body.get("chainBreak").filter(|v| !v.is_null()) {
+        let kind = brk["kind"].as_str().unwrap_or("?");
+        let index = brk["index"].as_u64().unwrap_or(0);
+        let event_id = brk["eventId"].as_str().unwrap_or("?");
+        println!();
+        println!("  {RED}break:{RESET} {kind} at index {index} (event {event_id})");
+        match kind {
+            "tamperedEntry" => {
+                println!("  {DIM}That envelope's content changed after it was written.{RESET}")
+            }
+            "brokenLink" => println!(
+                "  {DIM}An entry was reordered, dropped, or inserted at this point.{RESET}"
+            ),
+            _ => {}
+        }
+    }
+
+    if !verified {
+        println!();
+        println!(
+            "{DIM}Note: a passing chain proves internal consistency, not authenticity —\n\
+             the chain is unsigned, so an adversary with store write access can\n\
+             restamp a forged suffix. Verify an out-of-band copy before concluding.{RESET}"
+        );
+        return Err("audit chain verification failed".into());
+    }
+    Ok(())
+}

--- a/cnm-cli/src/main.rs
+++ b/cnm-cli/src/main.rs
@@ -1,3 +1,4 @@
+mod audit;
 mod auth;
 mod backup;
 mod config;
@@ -19,8 +20,9 @@ use vta_cli_common::render::{CYAN, DIM, GREEN, RED, RESET, YELLOW, print_section
     long_about = "Community Network Manager — community-admin-scoped CLI for the VTA.\n\
                   \n\
                   CNM is deliberately a reduced surface compared to `pnm`:\n\
-                  - No `webvh` / `audit` / `keys import` — those are VTA-operator\n\
-                    concerns, not community-admin concerns, and live on pnm.\n\
+                  - No `webvh` / `keys import`, and no VTA audit *tail* — those are\n\
+                    VTA-operator concerns and live on pnm. (`cnm audit verify` IS\n\
+                    here: it checks the *community's* own audit chain.)\n\
                   - `backup` IS here: it backs up the *community's* state (the VTC),\n\
                     a community-admin concern, distinct from pnm's VTA backup.\n\
                   - DID-template management is mirrored here because community admins\n\
@@ -137,6 +139,12 @@ enum Commands {
     Backup {
         #[command(subcommand)]
         command: BackupCommands,
+    },
+
+    /// Audit-trail integrity checks for the community.
+    Audit {
+        #[command(subcommand)]
+        command: AuditCommands,
     },
 
     /// Sealed-transfer bootstrap (consumer side).
@@ -266,6 +274,16 @@ fn is_online_template_cmd(cmd: &DidTemplateCommands) -> bool {
             | DidTemplateCommands::Init { .. }
             | DidTemplateCommands::ListBuiltins
     )
+}
+
+#[derive(Subcommand)]
+enum AuditCommands {
+    /// Verify the community's audit hash chain end to end.
+    ///
+    /// Exits non-zero when the chain does not verify, so this works
+    /// as a scheduled check. Note that a pass proves internal
+    /// consistency, not authenticity — the chain is unsigned.
+    Verify,
 }
 
 #[derive(Subcommand)]
@@ -1179,6 +1197,9 @@ async fn main() {
             BackupCommands::Import { file, preview } => {
                 backup::cmd_import(&client, &keyring_key, file, preview).await
             }
+        },
+        Commands::Audit { command } => match command {
+            AuditCommands::Verify => audit::cmd_verify(&client, &keyring_key).await,
         },
         Commands::Bootstrap { command } => match command {
             BootstrapCommands::Request { out, label } => bootstrap_request(out, label),

--- a/docs/03-vtc/architecture.md
+++ b/docs/03-vtc/architecture.md
@@ -134,6 +134,42 @@ cloned cheaply into handlers. The complete list:
 | `audit` | HMAC-actor-hashing audit envelopes |
 | `audit_key` | HMAC audit key + rotation history |
 
+### Audit tamper-evidence
+
+Every audit envelope from schema version 2 carries `prevHash` (its
+predecessor's `entryHash`) and `entryHash` (a SHA-256 over its own
+immutable content), so the log is a hash chain.
+
+Verify it with either:
+
+```bash
+cnm audit verify              # exits non-zero on a break
+curl -H "Authorization: Bearer $TOKEN" \
+     -H "Trust-Task: https://trusttasks.org/openvtc/vtc/audit/verify/1.0" \
+     "$VTC_URL/v1/audit/verify"
+```
+
+Both report `entriesExamined`, `entriesVerified`, `legacySkipped`,
+`unparseableSkipped`, the chain `head`, and — when the chain is
+broken — where.
+
+**Read the skip counters.** Pre-v2 (`legacySkipped`) and
+undeserializable (`unparseableSkipped`) rows are *not* checked; they
+are stepped over. On a store written entirely by a current daemon both
+should be zero, and a non-zero count is itself the finding rather than
+a footnote to a passing result.
+
+**What a pass proves.** Internal consistency — no reorder, drop,
+duplicate, or content edit. It is **not** an authenticity proof: the
+chain is unsigned (`chain_digest` takes no key), so an adversary with
+write access to the `audit` keyspace can restamp a forged suffix, and
+truncating the log to a valid prefix is undetectable. Closing that
+needs signed checkpoints — see
+[`vtc-audit-checkpoints.md`](../05-design-notes/vtc-audit-checkpoints.md).
+Until then, treat `cnm audit verify` as detecting accident and
+careless tampering, and verify an out-of-band copy when the answer
+actually matters.
+
 ## Three-thread runtime
 
 `vtc-service` runs three named OS threads, mirroring the VTA's

--- a/docs/05-design-notes/vtc-audit-checkpoints.md
+++ b/docs/05-design-notes/vtc-audit-checkpoints.md
@@ -1,0 +1,143 @@
+# Signed audit checkpoints
+
+**Status:** proposed — not implemented.
+**Context:** issue #537 tier 3. The `prev_hash` chain shipped in #555;
+`GET /v1/audit/verify` (this PR) exposes it. This note covers what is
+still missing and why it matters.
+
+## The problem the chain does not solve
+
+Each audit envelope carries `prev_hash` (its predecessor's
+`entry_hash`) and `entry_hash` (a SHA-256 over its own immutable
+content). `verify_chain` walks the log and checks both. That detects
+reordering, dropping, duplication, and content edits.
+
+It does not detect a competent adversary, because **`chain_digest` is
+unkeyed**. From `vti-common/src/audit/envelope.rs`:
+
+```rust
+pub fn chain_digest(&self) -> [u8; 32] {
+    let mut h = Sha256::new();
+    h.update(CHAIN_DOMAIN);
+    h.update(self.prev_hash);
+    // ... no key material anywhere ...
+}
+```
+
+An attacker who can write to the `audit` keyspace holds everything
+needed to recompute it. Two attacks follow directly:
+
+1. **Restamping.** Edit or insert an envelope, recompute its
+   `entry_hash`, then walk forward restamping every subsequent
+   envelope's `prev_hash`/`entry_hash`. The result verifies cleanly.
+   Cost is O(entries after the edit) and needs no secret.
+2. **Truncation.** Delete every envelope after some point. The
+   remaining prefix is a valid chain. Nothing records how long the log
+   *should* be, so a truncated log is indistinguishable from a
+   community that went quiet.
+
+Truncation is the more serious one: it is the cheapest way to erase an
+incident, and it requires no forgery at all.
+
+The HMAC over actor/target DIDs does not help here. It protects
+attribution (and enables RTBF via key rotation), not sequence
+integrity — and the writer holds that key anyway.
+
+## Proposal
+
+Periodically persist a **checkpoint**: the chain head at a point in
+time, signed by a key the store-level adversary does not hold.
+
+```rust
+struct AuditCheckpoint {
+    /// entry_hash of the newest envelope at checkpoint time.
+    head: [u8; 32],
+    /// Total chainable envelopes written up to `head`. This is what
+    /// makes truncation detectable — a shorter log contradicts it.
+    entry_count: u64,
+    /// event_id of the envelope at `head`, so a verifier can locate
+    /// the anchor point without recomputing the whole chain.
+    head_event_id: Uuid,
+    checkpoint_at: DateTime<Utc>,
+    /// Previous checkpoint's own hash — checkpoints chain too, so
+    /// deleting one is itself detectable.
+    prev_checkpoint: Option<[u8; 32]>,
+    /// Ed25519 signature by the community signing key over a
+    /// domain-tagged encoding of every field above.
+    signature: Vec<u8>,
+}
+```
+
+Stored in a dedicated `audit_checkpoint` keyspace keyed by
+`<rfc3339>:<uuid>`, matching the audit keyspace's convention.
+
+### Signer: the community Ed25519 key
+
+Two candidates were considered.
+
+| | Audit HMAC key | Community Ed25519 key |
+|---|---|---|
+| New key handling | none — reuses `audit_key` | reuses `LocalSigner` |
+| Verifiable by | the daemon only | anyone with the community DID |
+| Forgeable by store-adversary | **yes** — key is in the same store | no |
+
+The audit HMAC key is rejected: it lives in the same store the
+adversary is assumed to have reached, and symmetric verification means
+whoever can check a checkpoint can also forge one. That reduces to the
+status quo.
+
+**Decision: sign with the community Ed25519 signing key** — the same
+`LocalSigner` that issues VMCs and VECs. It gives externally-verifiable
+checkpoints: an auditor holding only the community's DID can confirm
+the log has not been truncated or rewritten, with no shared secret and
+no access to the daemon. That is the property worth having, and it
+matches the workspace's existing preference for VC/VP-shaped,
+independently-verifiable claims over bespoke internal assertions.
+
+Consequence to accept: checkpoint verification depends on the community
+DID resolving, and on key rotation being handled (a checkpoint signed
+under a retired key must stay verifiable — the DID document history
+already provides this for `did:webvh`).
+
+### Verification
+
+`verify_chain` gains a checkpoint-aware mode:
+
+1. Load checkpoints, verify each signature, verify the checkpoint chain.
+2. For the newest checkpoint, confirm the audit log still contains an
+   envelope with `head_event_id` whose `entry_hash` equals `head`.
+3. Confirm the log's chainable count is **>=** `entry_count`. Fewer
+   means truncation — the finding this whole mechanism exists for.
+4. Verify the envelope chain as today.
+
+Step 3 is the one that cannot be spoofed without the signing key.
+
+## Open questions
+
+- **Cadence.** Time-based (hourly), count-based (every N envelopes), or
+  both? Both, probably: a low-traffic community should still checkpoint
+  daily so a truncation window stays bounded, and a busy one should not
+  wait an hour. The window between checkpoints is the attacker's free
+  truncation range, so it directly sets the residual risk.
+- **External anchoring.** Checkpoints protect against a store-level
+  adversary but not one who also holds the signing key. Publishing the
+  head somewhere append-only (the community's own `did.jsonl`, a
+  transparency log, a peer VTC) would close that. Out of scope here;
+  the signature is the prerequisite.
+- **Backup interaction.** `vtc-service/src/backup.rs` backs up the
+  `audit` keyspace. Checkpoints must be included, or a restore looks
+  like mass truncation.
+- **Chain head durability.** `load_chain_head` currently recovers the
+  head by scanning the whole keyspace and taking the last row — O(n) at
+  first write after restart, and it re-derives trust from the same
+  store an adversary may control. A checkpoint keyspace gives a cheap
+  persisted head pointer as a side effect.
+
+## Prerequisite already handled
+
+Pre-v2 envelopes are skipped by `verify_chain` (`schema_version < 2`),
+which makes them an insertion point: a forged row marked
+`schemaVersion: 1` passes untouched. `GET /v1/audit/verify` reports
+`legacySkipped` so this is at least visible. Before checkpoints are
+worth much, confirm deployed stores hold no v1 rows — otherwise a
+signed checkpoint attests to a chain with holes in it.

--- a/trust-tasks/audit/verify/1.0/schema.json
+++ b/trust-tasks/audit/verify/1.0/schema.json
@@ -1,0 +1,7 @@
+{
+  "$id": "https://trusttasks.org/openvtc/vtc/audit/verify/1.0/schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "VTC — Verify the audit hash chain",
+  "description": "GET /v1/audit/verify has no request body and no query parameters. Response is shaped by vtc_service::routes::audit::VerifyResponse.",
+  "type": "null"
+}

--- a/trust-tasks/audit/verify/1.0/spec.md
+++ b/trust-tasks/audit/verify/1.0/spec.md
@@ -1,0 +1,91 @@
+---
+id: https://trusttasks.org/openvtc/vtc/audit/verify/1.0
+title: VTC — Verify the audit hash chain
+status: Draft
+version: "1.0"
+authors:
+  - did:webvh:openvtc.org
+applies_to:
+  - rest: GET /v1/audit/verify
+inputs:
+  - Authenticated request — caller MUST be super-admin
+    (Admin role with empty `allowed_contexts`). No request body,
+    no query parameters.
+outputs:
+  - >-
+    HTTP 200 with a `VerifyResponse` body: `verified`,
+    `entriesExamined`, `entriesVerified`, `legacySkipped`,
+    `unparseableSkipped`, optional `head` (hex), and optional
+    `chainBreak` (`{kind, index, eventId}`).
+trust_assumptions:
+  - >-
+    A `verified: true` proves internal consistency of the chain,
+    NOT authenticity. `chain_digest` is an unkeyed SHA-256, so an
+    adversary with write access to the audit keyspace can forge a
+    suffix and restamp every subsequent envelope, and a truncation
+    to a valid prefix is indistinguishable from a quiet period.
+    Treat this endpoint as detecting accident and careless tampering,
+    not a determined adversary.
+  - >-
+    `legacySkipped > 0` is itself a finding on any store that should
+    hold no pre-v2 rows. Verification skips those envelopes rather
+    than checking them, so they are an insertion point.
+  - >-
+    The result reflects the store the daemon is reading. An adversary
+    who can rewrite the store can also rewrite what this endpoint
+    reads; an independent copy verified out-of-band is the stronger
+    check.
+related:
+  - https://trusttasks.org/openvtc/vtc/audit/list/1.0
+---
+
+# VTC — Verify the audit hash chain
+
+Every audit envelope from schema version 2 onward carries
+`prevHash` (its predecessor's `entryHash`) and `entryHash` (a
+SHA-256 commitment over its own immutable content). This endpoint
+walks the whole audit keyspace in ascending — i.e. chronological —
+key order and checks both properties for every envelope.
+
+It detects:
+
+- **Tampering** — an envelope whose content changed after writing,
+  since `entryHash` no longer re-derives (`kind: "tamperedEntry"`).
+- **Reorder, drop, or insertion** — an envelope whose `prevHash`
+  does not point at its predecessor's `entryHash`
+  (`kind: "brokenLink"`). Duplication is caught by the same check:
+  a repeated envelope's `prevHash` cannot equal the preceding
+  copy's own `entryHash`.
+
+## What it does not detect
+
+The chain is unsigned. An adversary with write access to the audit
+keyspace holds no secret they need — `chain_digest` takes no key,
+so they can recompute it for a forged suffix and restamp every
+envelope after their edit, and the result verifies cleanly.
+Truncating the log to any valid prefix is likewise undetectable.
+
+Closing that gap requires periodically signing the chain head with
+a key the store-level adversary does not hold. See
+`docs/05-design-notes/vtc-audit-checkpoints.md`.
+
+## Cost
+
+The walk is O(n) over the audit keyspace and reads every row. The
+verifier itself folds in constant memory (`ChainVerifier`), but the
+keyspace scan currently materialises the row set, matching
+`GET /v1/audit`. On a large log, prefer running this on a schedule
+rather than per-request.
+
+## Interpreting the counters
+
+| Field | Meaning |
+|---|---|
+| `entriesExamined` | Rows walked, chainable or not |
+| `entriesVerified` | v2+ rows that verified |
+| `legacySkipped` | Pre-v2 rows skipped — non-zero is a finding |
+| `unparseableSkipped` | Rows that would not deserialize — also a finding |
+
+`entriesExamined` will exceed `entriesVerified` exactly when
+`legacySkipped` or `unparseableSkipped` is non-zero. On a store
+written entirely by a v2+ daemon they should be equal.

--- a/trust-tasks/index.json
+++ b/trust-tasks/index.json
@@ -60,6 +60,12 @@
       "rest": "GET /v1/audit"
     },
     {
+      "id": "https://trusttasks.org/openvtc/vtc/audit/verify/1.0",
+      "status": "Draft",
+      "path": "audit/verify/1.0",
+      "rest": "GET /v1/audit/verify"
+    },
+    {
       "id": "https://trusttasks.org/openvtc/vtc/config/legacy/manage/1.0",
       "status": "Draft",
       "path": "config/legacy/manage/1.0",

--- a/trust-tasks/members/rotate/1.0/schema.json
+++ b/trust-tasks/members/rotate/1.0/schema.json
@@ -1,28 +1,81 @@
 {
   "$id": "https://trusttasks.org/openvtc/vtc/members/rotate/1.0/schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "title": "VTC Members — DID Rotation",
+  "title": "VTC Members \u2014 DID Rotation",
   "type": "object",
   "properties": {
     "request": {
       "type": "object",
-      "required": ["rotationId", "oldDid", "newDid", "oldSignature", "newSignature"],
+      "required": [
+        "rotationId",
+        "oldDid",
+        "newDid",
+        "oldSignature",
+        "newSignature"
+      ],
       "properties": {
-        "rotationId": { "type": "string", "format": "uuid" },
-        "oldDid": { "type": "string" },
-        "newDid": { "type": "string" },
-        "oldSignature": { "type": "string", "pattern": "^[0-9a-f]+$" },
-        "newSignature": { "type": "string", "pattern": "^[0-9a-f]+$" }
+        "rotationId": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "oldDid": {
+          "type": "string"
+        },
+        "newDid": {
+          "type": "string"
+        },
+        "oldSignature": {
+          "type": "string",
+          "pattern": "^[0-9a-f]+$"
+        },
+        "newSignature": {
+          "type": "string",
+          "pattern": "^[0-9a-f]+$"
+        }
       }
     },
     "response": {
       "type": "object",
-      "required": ["newDid", "method", "vmc", "roleVec"],
+      "required": [
+        "newDid",
+        "method",
+        "vmc",
+        "roleVec"
+      ],
       "properties": {
-        "newDid": { "type": "string" },
-        "method": { "type": "string", "enum": ["did:key", "did:webvh"] },
-        "vmc": { "type": "object" },
-        "roleVec": { "type": "object" }
+        "newDid": {
+          "type": "string"
+        },
+        "method": {
+          "type": "string",
+          "enum": [
+            "did:key",
+            "did:webvh"
+          ]
+        },
+        "vmc": {
+          "type": "object"
+        },
+        "roleVec": {
+          "type": "object"
+        }
+      }
+    },
+    "challengeRequest": {
+      "type": "object",
+      "description": "Optional body for POST /v1/members/me/rotate/challenge. Omitting the body entirely is valid and equivalent to reason: unspecified.",
+      "properties": {
+        "reason": {
+          "type": "string",
+          "enum": [
+            "routine",
+            "compromise",
+            "deviceLoss",
+            "migration",
+            "unspecified"
+          ],
+          "description": "Self-asserted motive for the rotation. Recorded on the DidRotated audit envelope. NOT covered by either rotation signature \u2014 it is bound to the authenticated session that opened the ceremony, not proven."
+        }
       }
     }
   }

--- a/trust-tasks/members/rotate/1.0/spec.md
+++ b/trust-tasks/members/rotate/1.0/spec.md
@@ -26,6 +26,28 @@ the equivalent "new key holder is in control" guarantee. The
 deviation is documented for M2.16's spec-clarification
 pass.)
 
+## Challenge request (optional body)
+
+```
+POST /v1/members/me/rotate/challenge
+Content-Type: application/json
+
+{
+  "reason": "routine" | "compromise" | "deviceLoss" | "migration" | "unspecified"
+}
+```
+
+The body is optional; omitting it means `unspecified`. The reason
+is recorded on the resulting `DidRotated` audit envelope.
+
+It is deliberately collected **here** rather than on the finish
+request: the rotation signatures cover only `{rotationId, oldDid,
+newDid, expiresAt}`, so a reason submitted at finish would be
+unauthenticated and alterable by whoever relays that request.
+Captured at challenge time it is bound to the authenticated
+session that opened the ceremony. It remains **self-asserted** —
+the member's own claim about their motive, never evidence of it.
+
 ## Request
 
 ```
@@ -65,8 +87,8 @@ challenge response.
    existing status-list slot** (spec §6.2 — no new slot
    allocation on rotation).
 7. Emit `DidRotated { oldDid, newDid, method, vmcId,
-   roleVecId }` audit envelope. Actor is the **new** DID
-   (future principal).
+   roleVecId, priorRole, rotationReason }` audit envelope.
+   Actor is the **new** DID (future principal).
 
 ## Response (`200 OK`)
 

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.11.11"
+version = "0.11.12"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vtc-service/src/routes/audit.rs
+++ b/vtc-service/src/routes/audit.rs
@@ -19,7 +19,7 @@ use axum::Json;
 use axum::extract::{Query, State};
 use serde::Deserialize;
 
-use vti_common::audit::AuditEnvelope;
+use vti_common::audit::{AuditEnvelope, ChainBreak, ChainVerifier};
 use vti_common::error::AppError;
 use vti_common::pagination::{Cursor, MAX_LIMIT, Paginated};
 
@@ -125,4 +125,154 @@ pub async fn list_audit(
         next_cursor,
         total_estimate: None,
     }))
+}
+
+/// Result of a chain verification pass.
+#[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
+pub struct VerifyResponse {
+    /// Whether every chainable envelope verified.
+    pub verified: bool,
+    /// Envelopes examined, chainable or not.
+    pub entries_examined: usize,
+    /// Envelopes that carried a chain link and verified.
+    pub entries_verified: usize,
+    /// Pre-v2 envelopes skipped as unchainable.
+    ///
+    /// **Non-zero is a finding on a store that should hold none.**
+    /// `verify_chain` skips these rows rather than verifying them, so
+    /// they are an insertion point: an envelope forged with
+    /// `schemaVersion: 1` passes untouched.
+    pub legacy_skipped: usize,
+    /// Rows that would not deserialize into an envelope at all. Also
+    /// skipped, and also a finding — reported separately from
+    /// `legacySkipped` because the cause differs (corruption or a
+    /// forward-version row, versus a pre-chain row).
+    pub unparseable_skipped: usize,
+    /// Head of the verified chain, hex-encoded. `None` when nothing
+    /// chainable was found.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub head: Option<String>,
+    /// Where the chain broke. Absent when `verified` is true.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub chain_break: Option<ChainBreakReport>,
+}
+
+/// A detected break, flattened for the wire.
+///
+/// `ChainBreak` itself is deliberately not `Serialize` in
+/// `vti-common`, so this is the REST projection of it.
+#[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
+pub struct ChainBreakReport {
+    /// `tamperedEntry` — the envelope's content was altered after it
+    /// was written; or `brokenLink` — an entry was reordered,
+    /// dropped, or inserted.
+    pub kind: String,
+    /// Position in the ascending walk, counting skipped rows.
+    pub index: usize,
+    /// `event_id` of the offending envelope.
+    pub event_id: String,
+}
+
+/// GET /audit/verify — verify the audit hash chain. Auth: Super-admin.
+///
+/// Walks the whole audit keyspace in ascending (chronological) key
+/// order and folds it through [`ChainVerifier`], so memory stays
+/// constant regardless of log size.
+///
+/// **What a `verified: true` does and does not mean.** The chain
+/// links each envelope to its predecessor, so a reorder, drop, or
+/// duplicate is detected. It is *not* a signature: `chain_digest` is
+/// an unkeyed SHA-256, so an adversary with write access to the store
+/// can forge a suffix and restamp every envelope after it, and a
+/// truncation to a valid prefix is indistinguishable from a quiet
+/// period. Closing that needs signed checkpoints — see
+/// `docs/05-design-notes/vtc-audit-checkpoints.md`.
+#[utoipa::path(
+    get, path = "/audit/verify", tag = "audit",
+    security(("bearer_jwt" = [])),
+    responses(
+        (status = 200, description = "Chain verification result", body = VerifyResponse),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller is not a super-admin"),
+    ),
+)]
+pub async fn verify_audit_chain(
+    auth: SuperAdminAuth,
+    State(state): State<AppState>,
+) -> Result<Json<VerifyResponse>, AppError> {
+    // Ascending key order is chronological write order, which is what
+    // the verifier requires — note this is the opposite of
+    // `list_audit`'s newest-first sort.
+    let mut pairs = state.audit_ks.prefix_iter_raw(Vec::new()).await?;
+    pairs.sort_by(|(a, _), (b, _)| a.cmp(b));
+
+    let mut verifier = ChainVerifier::new();
+    let mut unparseable = 0usize;
+    let mut chain_break = None;
+
+    for (key, value) in &pairs {
+        let env = match serde_json::from_slice::<AuditEnvelope>(value) {
+            Ok(env) => env,
+            Err(err) => {
+                // Matches `list_audit`: one bad row must not abort the
+                // whole pass. Counted and surfaced, not swallowed.
+                unparseable += 1;
+                tracing::warn!(
+                    error = %err,
+                    key = %String::from_utf8_lossy(key),
+                    "skipping unparseable audit envelope during verify",
+                );
+                continue;
+            }
+        };
+        if let Err(brk) = verifier.push(&env) {
+            let (kind, index, event_id) = match brk {
+                ChainBreak::TamperedEntry { index, event_id } => ("tamperedEntry", index, event_id),
+                ChainBreak::BrokenLink { index, event_id } => ("brokenLink", index, event_id),
+            };
+            chain_break = Some(ChainBreakReport {
+                kind: kind.to_string(),
+                index,
+                event_id: event_id.to_string(),
+            });
+            break;
+        }
+    }
+
+    let verified = chain_break.is_none();
+    let response = VerifyResponse {
+        verified,
+        entries_examined: verifier.index(),
+        entries_verified: verifier.verified(),
+        legacy_skipped: verifier.skipped_legacy(),
+        unparseable_skipped: unparseable,
+        head: verifier.head().map(hex::encode),
+        chain_break,
+    };
+
+    // Warn, not info, on failure: a broken audit chain is the kind of
+    // thing that should be visible in logs even if nobody is reading
+    // the response.
+    if verified {
+        info!(
+            caller = %auth.0.did,
+            examined = response.entries_examined,
+            verified = response.entries_verified,
+            legacy_skipped = response.legacy_skipped,
+            "audit chain verified",
+        );
+    } else {
+        tracing::warn!(
+            caller = %auth.0.did,
+            examined = response.entries_examined,
+            chain_break = ?response.chain_break,
+            "audit chain verification FAILED",
+        );
+    }
+
+    Ok(Json(response))
 }

--- a/vtc-service/src/routes/auth.rs
+++ b/vtc-service/src/routes/auth.rs
@@ -20,7 +20,7 @@ use crate::error::AppError;
 use crate::routes::acl::as_vti_acl_entry;
 use crate::server::AppState;
 use tracing::{info, warn};
-use vti_common::audit::{AuditEvent, SessionRevokedData};
+use vti_common::audit::{AuditEvent, SessionRevokedData, SignedOutData};
 use vti_common::store::KeyspaceHandle;
 
 // ---------- POST /auth/challenge ----------
@@ -894,10 +894,28 @@ pub async fn sign_out(
     use axum::http::header::SET_COOKIE;
 
     let sessions = state.sessions_ks.clone();
-    // Best-effort delete — the session may already have been
-    // revoked from another tab. Either way we set the expiry
-    // cookies so this browser stops sending the stale JWT.
+    // Best-effort delete — a failure still falls through to the
+    // cookie clearing below, so the browser stops sending the stale
+    // JWT either way. (The session is known to exist: `AuthClaims`
+    // rejects a token whose session row is gone.)
     let _ = delete_session(&sessions, &auth.session_id).await;
+
+    // Audit the session ending. Best-effort like the delete above: a
+    // failed audit write must not leave the caller holding a live
+    // cookie pair they were told was cleared.
+    if let Some(writer) = state.audit_writer.as_ref()
+        && let Err(e) = writer
+            .write(
+                &auth.did,
+                Some(&auth.did),
+                AuditEvent::SignedOut(SignedOutData {
+                    session_id: auth.session_id.clone(),
+                }),
+            )
+            .await
+    {
+        tracing::warn!(error = %e, did = %auth.did, "sign-out audit write failed");
+    }
     info!(did = %auth.did, session_id = %auth.session_id, "sign-out");
 
     let mut response = StatusCode::NO_CONTENT.into_response();

--- a/vtc-service/src/routes/members/rotate.rs
+++ b/vtc-service/src/routes/members/rotate.rs
@@ -88,7 +88,7 @@ use serde_json::Value as JsonValue;
 use tracing::{info, warn};
 use uuid::Uuid;
 
-use vti_common::audit::{AuditEvent, DidRotatedData};
+use vti_common::audit::{AuditEvent, DidRotatedData, DidRotationReason};
 use vti_common::auth::session::{delete_session, list_sessions};
 use vti_common::error::AppError;
 
@@ -126,6 +126,15 @@ struct RotationChallenge {
     id: Uuid,
     did: String,
     expires_at: DateTime<Utc>,
+    /// Reason declared when the challenge was requested. Held on the
+    /// server-side row rather than read from the finish body: the
+    /// rotation signatures cover only `{rotationId, oldDid, newDid,
+    /// expiresAt}`, so a reason submitted at finish would be
+    /// unauthenticated and alterable by whoever relays that request.
+    /// Captured here it is bound to the authenticated session that
+    /// opened the ceremony.
+    #[serde(default)]
+    reason: Option<DidRotationReason>,
 }
 
 fn challenge_key(id: Uuid) -> Vec<u8> {
@@ -173,11 +182,28 @@ pub struct ChallengeResponse {
     pub canonical_template: JsonValue,
 }
 
+/// Optional body for the challenge request.
+///
+/// Absent body, absent field, and `unspecified` all mean the same
+/// thing — the member declined to say. The endpoint predates this
+/// field, so clients that send no body at all stay valid.
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
+pub struct ChallengeBody {
+    /// Why the member is rotating. Self-asserted — see
+    /// [`DidRotatedData::rotation_reason`] for what this is and is not
+    /// evidence of.
+    #[serde(default)]
+    pub reason: Option<DidRotationReason>,
+}
+
 /// POST /members/me/rotate/challenge — mint a DID-rotation challenge.
 /// Auth: any authenticated member.
 #[utoipa::path(
     post, path = "/members/me/rotate/challenge", tag = "members",
     security(("bearer_jwt" = [])),
+    request_body = Option<ChallengeBody>,
     responses(
         (status = 200, description = "Rotation challenge issued", body = ChallengeResponse),
         (status = 401, description = "Missing or invalid bearer token"),
@@ -187,7 +213,9 @@ pub struct ChallengeResponse {
 pub async fn challenge(
     auth: AuthClaims,
     State(state): State<AppState>,
+    body: Option<Json<ChallengeBody>>,
 ) -> Result<(StatusCode, Json<ChallengeResponse>), AppError> {
+    let reason = body.and_then(|Json(b)| b.reason);
     // Caller must be a current member — anyone with a session
     // could mint a challenge otherwise.
     let _acl = get_acl_entry(&state.acl_ks, &auth.did)
@@ -201,6 +229,7 @@ pub async fn challenge(
         id,
         did: auth.did.clone(),
         expires_at,
+        reason,
     };
     store_challenge(&state, &challenge).await?;
 
@@ -215,6 +244,7 @@ pub async fn challenge(
     info!(
         rotation_id = %id,
         did = %auth.did,
+        reason = ?reason,
         "DID rotation challenge issued"
     );
 
@@ -457,6 +487,7 @@ pub async fn rotate(
                 vmc_id,
                 role_vec_id: vec_id,
                 prior_role: Some(acl.role.to_string()),
+                rotation_reason: challenge.reason,
             }),
         )
         .await?;

--- a/vtc-service/src/routes/mod.rs
+++ b/vtc-service/src/routes/mod.rs
@@ -380,6 +380,10 @@ fn build_api_chain(_routing: &RoutingConfig, trust_xff: bool) -> OpenApiRouter<A
             routes!(audit::list_audit),
             "https://trusttasks.org/openvtc/vtc/audit/list/1.0",
         ))
+        .routes(tt(
+            routes!(audit::verify_audit_chain),
+            "https://trusttasks.org/openvtc/vtc/audit/verify/1.0",
+        ))
         // Config
         .routes(tt(
             routes!(config::get_config, config::update_config),

--- a/vtc-service/tests/audit_signout.rs
+++ b/vtc-service/tests/audit_signout.rs
@@ -1,0 +1,144 @@
+//! `POST /v1/auth/sign-out` must leave an audit trail (#537 tier 1).
+//!
+//! Sign-out ends a session, and "when did this principal's access
+//! stop" is a question the audit log has to be able to answer. It was
+//! the one session-lifecycle mutation still writing only an `info!`.
+
+mod common;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use tower::ServiceExt;
+use vti_common::audit::{AuditEnvelope, AuditEvent};
+
+use vtc_service::server::AppState;
+use vtc_service::test_support::TestVtc;
+
+// The router enforces the canonical cross-service task URI here, not
+// the openvtc-scoped one `trust-tasks/index.json` lists for this route.
+const SIGN_OUT_TASK: &str = "https://trusttasks.org/spec/auth/revoke-session/0.1";
+const MEMBER_DID: &str = "did:key:z6MkSignsOut";
+
+struct Fixture {
+    router: axum::Router,
+    state: AppState,
+    vtc: TestVtc,
+}
+
+async fn build() -> Fixture {
+    let vtc = TestVtc::builder().with_audit(true).build().await;
+    Fixture {
+        router: vtc.router.clone(),
+        state: vtc.state.clone(),
+        vtc,
+    }
+}
+
+async fn sign_out(fix: &Fixture, token: &str) -> StatusCode {
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/auth/sign-out")
+        .header("Trust-Task", SIGN_OUT_TASK)
+        .header("Authorization", format!("Bearer {token}"))
+        // Sign-out takes no body, but the router's content-type gate
+        // still applies to POST — without this it 415s before the
+        // handler runs.
+        .header("Content-Type", "application/json")
+        .body(Body::empty())
+        .unwrap();
+    fix.router.clone().oneshot(req).await.unwrap().status()
+}
+
+/// Every `SignedOut` envelope in the store.
+async fn signed_out_events(fix: &Fixture) -> Vec<AuditEnvelope> {
+    let raw = fix
+        .state
+        .audit_ks
+        .prefix_iter_raw(Vec::new())
+        .await
+        .unwrap();
+    raw.iter()
+        .filter_map(|(_, v)| serde_json::from_slice::<AuditEnvelope>(v).ok())
+        .filter(|e| matches!(e.event, AuditEvent::SignedOut(_)))
+        .collect()
+}
+
+#[tokio::test]
+async fn sign_out_emits_a_signed_out_envelope() {
+    let fix = build().await;
+    // `TestVtc::token` persists the session row it mints, so this
+    // exercises the "session existed" arm.
+    let token = fix.vtc.token(MEMBER_DID, "application", vec![]).await;
+
+    assert_eq!(sign_out(&fix, &token).await, StatusCode::NO_CONTENT);
+
+    let events = signed_out_events(&fix).await;
+    assert_eq!(events.len(), 1, "exactly one SignedOut envelope");
+    let env = &events[0];
+
+    // Actor and target are both the caller — this is a self-initiated
+    // action, which is precisely what distinguishes it from a revoke.
+    assert_eq!(env.actor_did_plain.as_deref(), Some(MEMBER_DID));
+    assert_eq!(env.target_did_plain.as_deref(), Some(MEMBER_DID));
+
+    let AuditEvent::SignedOut(data) = &env.event else {
+        unreachable!()
+    };
+    assert!(!data.session_id.is_empty(), "session id is recorded");
+}
+
+#[tokio::test]
+async fn sign_out_is_distinct_from_session_revoked() {
+    // The whole point of a separate variant: a SIEM rule counting
+    // forced revocations must not pick up voluntary sign-outs.
+    let fix = build().await;
+    let token = fix.vtc.token(MEMBER_DID, "application", vec![]).await;
+    assert_eq!(sign_out(&fix, &token).await, StatusCode::NO_CONTENT);
+
+    let raw = fix
+        .state
+        .audit_ks
+        .prefix_iter_raw(Vec::new())
+        .await
+        .unwrap();
+    let envelopes: Vec<AuditEnvelope> = raw
+        .iter()
+        .filter_map(|(_, v)| serde_json::from_slice(v).ok())
+        .collect();
+
+    assert!(
+        envelopes
+            .iter()
+            .any(|e| matches!(e.event, AuditEvent::SignedOut(_))),
+        "a SignedOut envelope was written"
+    );
+    assert!(
+        !envelopes
+            .iter()
+            .any(|e| matches!(e.event, AuditEvent::SessionRevoked(_))),
+        "sign-out must not masquerade as an admin revocation"
+    );
+}
+
+#[tokio::test]
+async fn a_second_sign_out_is_rejected_and_not_audited_twice() {
+    // Sign-out deletes the session row, and `AuthClaims` refuses a
+    // token whose session is gone — so the same token cannot sign out
+    // twice. This is why `SignedOutData` carries no "did it exist"
+    // flag: the handler only ever runs against a live session.
+    let fix = build().await;
+    let token = fix.vtc.token(MEMBER_DID, "application", vec![]).await;
+
+    assert_eq!(sign_out(&fix, &token).await, StatusCode::NO_CONTENT);
+    assert_eq!(
+        sign_out(&fix, &token).await,
+        StatusCode::UNAUTHORIZED,
+        "the token dies with its session"
+    );
+
+    assert_eq!(
+        signed_out_events(&fix).await.len(),
+        1,
+        "the rejected retry must not add a second envelope"
+    );
+}

--- a/vtc-service/tests/audit_verify.rs
+++ b/vtc-service/tests/audit_verify.rs
@@ -1,0 +1,203 @@
+//! Integration coverage for `GET /v1/audit/verify` — the audit
+//! hash-chain verification surface (#537 tier 3).
+//!
+//! The chain itself is unit-tested in `vti_common::audit::envelope`;
+//! what matters here is that the endpoint walks the *store* in the
+//! right order, reports honest counters, and actually catches a
+//! tampered row rather than rubber-stamping whatever it reads.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use serde_json::{Value, json};
+use tower::ServiceExt;
+
+use vtc_service::server::AppState;
+use vtc_service::test_support::TestVtc;
+
+const VERIFY_TASK: &str = "https://trusttasks.org/openvtc/vtc/audit/verify/1.0";
+const PROFILE_TASK: &str = "https://trusttasks.org/openvtc/vtc/community/profile/manage/1.0";
+
+struct Fixture {
+    router: axum::Router,
+    state: AppState,
+    vtc: TestVtc,
+}
+
+async fn build() -> Fixture {
+    let vtc = TestVtc::builder().with_audit(true).build().await;
+    Fixture {
+        router: vtc.router.clone(),
+        state: vtc.state.clone(),
+        vtc,
+    }
+}
+
+/// Super-admin = Admin role with empty `allowed_contexts`.
+async fn super_admin_token(fix: &Fixture) -> String {
+    fix.vtc.token("did:key:z6MkAdmin", "admin", vec![]).await
+}
+
+async fn body_value(resp: axum::response::Response) -> (StatusCode, Value) {
+    let status = resp.status();
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let v: Value = serde_json::from_slice(&bytes)
+        .unwrap_or_else(|_| json!({ "raw": String::from_utf8_lossy(&bytes) }));
+    (status, v)
+}
+
+async fn verify(fix: &Fixture, token: &str) -> (StatusCode, Value) {
+    let req = Request::builder()
+        .method("GET")
+        .uri("/v1/audit/verify")
+        .header("Trust-Task", VERIFY_TASK)
+        .header("Authorization", format!("Bearer {token}"))
+        .body(Body::empty())
+        .unwrap();
+    body_value(fix.router.clone().oneshot(req).await.unwrap()).await
+}
+
+/// Write some real audit envelopes by exercising a route that emits
+/// them, so the chain under test is one the daemon actually produced.
+async fn seed_audit_rows(fix: &Fixture, token: &str, count: usize) {
+    let profile = vtc_service::community::CommunityProfile::new(
+        "did:webvh:vtc.example.com:abc",
+        "Example Community",
+    );
+    vtc_service::community::store_profile(&fix.state.community_ks, &profile)
+        .await
+        .unwrap();
+
+    for i in 0..count {
+        let req = Request::builder()
+            .method("PUT")
+            .uri("/v1/community/profile")
+            .header("Trust-Task", PROFILE_TASK)
+            .header("Authorization", format!("Bearer {token}"))
+            .header("Content-Type", "application/json")
+            .body(Body::from(format!(r#"{{"name":"Rename {i}"}}"#)))
+            .unwrap();
+        let resp = fix.router.clone().oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK, "seed write {i} succeeded");
+    }
+}
+
+#[tokio::test]
+async fn empty_log_verifies_vacuously() {
+    let fix = build().await;
+    let token = super_admin_token(&fix).await;
+    let (status, body) = verify(&fix, &token).await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["verified"], true);
+    assert_eq!(body["entriesExamined"], 0);
+    assert_eq!(body["entriesVerified"], 0);
+    // Nothing chainable seen, so there is no head to report.
+    assert!(body.get("head").is_none() || body["head"].is_null());
+}
+
+#[tokio::test]
+async fn a_real_chain_verifies_and_reports_its_head() {
+    let fix = build().await;
+    let token = super_admin_token(&fix).await;
+    seed_audit_rows(&fix, &token, 3).await;
+
+    let (status, body) = verify(&fix, &token).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["verified"], true, "body: {body}");
+
+    let verified = body["entriesVerified"].as_u64().unwrap();
+    assert!(
+        verified >= 3,
+        "at least the three seeded writes: {verified}"
+    );
+    assert_eq!(
+        body["entriesExamined"], body["entriesVerified"],
+        "a v2-only store must have nothing skipped"
+    );
+    assert_eq!(body["legacySkipped"], 0);
+    assert_eq!(body["unparseableSkipped"], 0);
+    assert!(
+        body["head"].as_str().is_some_and(|h| h.len() == 64),
+        "head is a hex-encoded SHA-256"
+    );
+}
+
+#[tokio::test]
+async fn a_tampered_envelope_is_caught() {
+    let fix = build().await;
+    let token = super_admin_token(&fix).await;
+    seed_audit_rows(&fix, &token, 3).await;
+
+    // Rewrite one stored envelope's payload in place, leaving its
+    // `entry_hash` as written — exactly what an adversary editing the
+    // store would produce.
+    let mut rows = fix
+        .state
+        .audit_ks
+        .prefix_iter_raw(Vec::new())
+        .await
+        .unwrap();
+    rows.sort_by(|(a, _), (b, _)| a.cmp(b));
+    let (key, value) = rows.into_iter().next().expect("at least one envelope");
+    let mut env: Value = serde_json::from_slice(&value).unwrap();
+    env["actorDidPlain"] = json!("did:key:z6MkNotWhoActedAtAll");
+    // `actor_did_plain` is excluded from chain_digest (RTBF), so to
+    // actually break the digest we must alter a covered field.
+    env["timestamp"] = json!("2020-01-01T00:00:00Z");
+    fix.state
+        .audit_ks
+        .insert_raw(key, serde_json::to_vec(&env).unwrap())
+        .await
+        .unwrap();
+
+    let (status, body) = verify(&fix, &token).await;
+    assert_eq!(status, StatusCode::OK, "tamper is a finding, not an error");
+    assert_eq!(body["verified"], false, "body: {body}");
+    let brk = &body["chainBreak"];
+    assert!(!brk.is_null(), "a break must be reported: {body}");
+    assert!(
+        brk["kind"] == "tamperedEntry" || brk["kind"] == "brokenLink",
+        "unexpected break kind: {brk}"
+    );
+}
+
+#[tokio::test]
+async fn a_dropped_envelope_breaks_the_link() {
+    let fix = build().await;
+    let token = super_admin_token(&fix).await;
+    seed_audit_rows(&fix, &token, 4).await;
+
+    // Delete a middle row — the classic "cover my tracks" edit.
+    let mut rows = fix
+        .state
+        .audit_ks
+        .prefix_iter_raw(Vec::new())
+        .await
+        .unwrap();
+    rows.sort_by(|(a, _), (b, _)| a.cmp(b));
+    assert!(rows.len() >= 3, "need a middle row to drop");
+    let (key, _) = rows.remove(rows.len() / 2);
+    fix.state.audit_ks.remove(key).await.unwrap();
+
+    let (status, body) = verify(&fix, &token).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["verified"], false, "body: {body}");
+    assert_eq!(body["chainBreak"]["kind"], "brokenLink");
+}
+
+#[tokio::test]
+async fn non_super_admin_is_refused() {
+    let fix = build().await;
+    // Context-scoped admin: Admin role, but not community-wide.
+    let scoped = fix
+        .vtc
+        .token("did:key:z6MkScoped", "admin", vec!["some-ctx".into()])
+        .await;
+    let (status, _) = verify(&fix, &scoped).await;
+    assert_eq!(
+        status,
+        StatusCode::FORBIDDEN,
+        "the audit chain is the community-wide god view"
+    );
+}

--- a/vtc-service/tests/rotation.rs
+++ b/vtc-service/tests/rotation.rs
@@ -38,6 +38,7 @@ struct Fixture {
     members_ks: vti_common::store::KeyspaceHandle,
     acl_ks: vti_common::store::KeyspaceHandle,
     sessions_ks: vti_common::store::KeyspaceHandle,
+    audit_ks: vti_common::store::KeyspaceHandle,
     signer: Arc<LocalSigner>,
     // Owns the temp data dir + serves `router`'s state; must outlive them.
     _vtc: TestVtc,
@@ -138,6 +139,7 @@ async fn build_fixture() -> Fixture {
     let members_ks = vtc.state.members_ks.clone();
     let acl_ks = vtc.state.acl_ks.clone();
     let sessions_ks = vtc.state.sessions_ks.clone();
+    let audit_ks = vtc.state.audit_ks.clone();
     let router = vtc.router.clone();
 
     Fixture {
@@ -148,6 +150,7 @@ async fn build_fixture() -> Fixture {
         members_ks,
         acl_ks,
         sessions_ks,
+        audit_ks,
         signer,
         _vtc: vtc,
     }
@@ -185,13 +188,25 @@ fn signing_bytes(rotation_id: &str, old_did: &str, new_did: &str, expires_at: i6
 }
 
 async fn mint_challenge(fix: &Fixture) -> (String, i64) {
-    let req = Request::builder()
+    mint_challenge_with_reason(fix, None).await
+}
+
+/// `reason` mirrors the optional `ChallengeBody`. `None` sends no body
+/// at all — the pre-existing wire shape, which must keep working.
+async fn mint_challenge_with_reason(fix: &Fixture, reason: Option<&str>) -> (String, i64) {
+    let mut builder = Request::builder()
         .method("POST")
         .uri("/v1/members/me/rotate/challenge")
         .header("authorization", format!("Bearer {}", fix.member_token))
-        .header("trust-task", CHALLENGE_TASK)
-        .body(Body::empty())
-        .unwrap();
+        .header("trust-task", CHALLENGE_TASK);
+    let body = match reason {
+        Some(r) => {
+            builder = builder.header("content-type", "application/json");
+            Body::from(json!({ "reason": r }).to_string())
+        }
+        None => Body::empty(),
+    };
+    let req = builder.body(body).unwrap();
     let resp = fix.router.clone().oneshot(req).await.unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
     let body = body_json(resp.into_body()).await;
@@ -443,4 +458,115 @@ async fn rotation_id_is_single_use() {
         "second call must not succeed, got {}",
         resp.status()
     );
+}
+
+/// The reason is declared at challenge time and must survive to the
+/// `DidRotated` envelope — it is collected there, rather than on the
+/// finish request, because the rotation signatures do not cover it.
+#[tokio::test]
+async fn rotation_reason_reaches_the_audit_envelope() {
+    use vti_common::audit::{AuditEnvelope, AuditEvent, DidRotationReason};
+
+    let fix = build_fixture().await;
+
+    let new_signing = SigningKey::from_bytes(&[0xCC; 32]);
+    let new_did =
+        affinidi_crypto::did_key::ed25519_pub_to_did_key(&new_signing.verifying_key().to_bytes());
+
+    let (rotation_id, expires_at) = mint_challenge_with_reason(&fix, Some("compromise")).await;
+    let payload = signing_bytes(&rotation_id, &fix.member_did, &new_did, expires_at);
+    let old_sig = hex::encode(fix.member_signing.sign(&payload).to_bytes());
+    let new_sig = hex::encode(new_signing.sign(&payload).to_bytes());
+
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/members/me/rotate")
+        .header("authorization", format!("Bearer {}", fix.member_token))
+        .header("trust-task", ROTATE_TASK)
+        .header("content-type", "application/json")
+        .body(Body::from(
+            json!({
+                "rotationId": rotation_id,
+                "oldDid": fix.member_did,
+                "newDid": new_did,
+                "oldSignature": old_sig,
+                "newSignature": new_sig,
+            })
+            .to_string(),
+        ))
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let raw = fix
+        .audit_ks
+        .prefix_iter_raw(Vec::new())
+        .await
+        .expect("read audit keyspace");
+    let rotated: Vec<AuditEnvelope> = raw
+        .iter()
+        .filter_map(|(_, v)| serde_json::from_slice::<AuditEnvelope>(v).ok())
+        .filter(|e| matches!(e.event, AuditEvent::DidRotated(_)))
+        .collect();
+    assert_eq!(rotated.len(), 1, "one DidRotated envelope");
+    let AuditEvent::DidRotated(data) = &rotated[0].event else {
+        unreachable!()
+    };
+    assert_eq!(
+        data.rotation_reason,
+        Some(DidRotationReason::Compromise),
+        "the reason declared at challenge time survives to the audit row"
+    );
+}
+
+/// Omitting the body leaves the reason unset rather than defaulting to
+/// something that reads as a claim the member never made.
+#[tokio::test]
+async fn rotation_without_a_reason_records_none() {
+    use vti_common::audit::{AuditEnvelope, AuditEvent};
+
+    let fix = build_fixture().await;
+
+    let new_signing = SigningKey::from_bytes(&[0xDD; 32]);
+    let new_did =
+        affinidi_crypto::did_key::ed25519_pub_to_did_key(&new_signing.verifying_key().to_bytes());
+
+    let (rotation_id, expires_at) = mint_challenge(&fix).await;
+    let payload = signing_bytes(&rotation_id, &fix.member_did, &new_did, expires_at);
+    let old_sig = hex::encode(fix.member_signing.sign(&payload).to_bytes());
+    let new_sig = hex::encode(new_signing.sign(&payload).to_bytes());
+
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/members/me/rotate")
+        .header("authorization", format!("Bearer {}", fix.member_token))
+        .header("trust-task", ROTATE_TASK)
+        .header("content-type", "application/json")
+        .body(Body::from(
+            json!({
+                "rotationId": rotation_id,
+                "oldDid": fix.member_did,
+                "newDid": new_did,
+                "oldSignature": old_sig,
+                "newSignature": new_sig,
+            })
+            .to_string(),
+        ))
+        .unwrap();
+    assert_eq!(
+        fix.router.clone().oneshot(req).await.unwrap().status(),
+        StatusCode::OK
+    );
+
+    let raw = fix.audit_ks.prefix_iter_raw(Vec::new()).await.unwrap();
+    let rotated: Vec<AuditEnvelope> = raw
+        .iter()
+        .filter_map(|(_, v)| serde_json::from_slice::<AuditEnvelope>(v).ok())
+        .filter(|e| matches!(e.event, AuditEvent::DidRotated(_)))
+        .collect();
+    assert_eq!(rotated.len(), 1);
+    let AuditEvent::DidRotated(data) = &rotated[0].event else {
+        unreachable!()
+    };
+    assert_eq!(data.rotation_reason, None);
 }

--- a/vti-common/Cargo.toml
+++ b/vti-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-common"
 description = "Shared server-side infrastructure for VTA and VTC services"
 readme = "README.md"
-version = "0.11.9"
+version = "0.11.10"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vti-common/src/audit/envelope.rs
+++ b/vti-common/src/audit/envelope.rs
@@ -184,12 +184,80 @@ pub enum ChainBreak {
 /// Pre-v2 envelopes (written before the chain existed) carry no hashes
 /// and are skipped; the chain re-anchors at the first v2 envelope.
 pub fn verify_chain(envelopes: &[AuditEnvelope]) -> Result<(), ChainBreak> {
-    let mut prev: Option<[u8; 32]> = None;
-    for (index, env) in envelopes.iter().enumerate() {
+    let mut verifier = ChainVerifier::new();
+    for env in envelopes {
+        verifier.push(env)?;
+    }
+    Ok(())
+}
+
+/// Incremental form of [`verify_chain`], for callers that stream the
+/// audit log rather than materialising it.
+///
+/// A full audit log does not fit comfortably in memory on a busy
+/// community, and the verification is a strict left fold — each
+/// envelope needs only its predecessor's `entry_hash`. Feeding
+/// envelopes in ascending write order through [`Self::push`] keeps
+/// memory constant regardless of log size.
+///
+/// The fold state is just `(prev_hash, index)`, so verification can
+/// also be **resumed** across pages via [`Self::resume`] — pass the
+/// [`Self::head`] and [`Self::index`] returned by the previous page.
+/// A resumed verifier is only as trustworthy as the head it is given:
+/// resuming from a head an adversary supplied verifies nothing about
+/// the entries before it.
+#[derive(Debug, Clone)]
+pub struct ChainVerifier {
+    prev: Option<[u8; 32]>,
+    index: usize,
+    verified: usize,
+    skipped_legacy: usize,
+}
+
+impl Default for ChainVerifier {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ChainVerifier {
+    /// Start at the genesis anchor — the first v2+ envelope pushed
+    /// must carry [`GENESIS_HASH`] as its `prev_hash`.
+    pub fn new() -> Self {
+        Self {
+            prev: None,
+            index: 0,
+            verified: 0,
+            skipped_legacy: 0,
+        }
+    }
+
+    /// Resume from a previously-returned [`Self::head`] and
+    /// [`Self::index`], so a page of envelopes can be verified as a
+    /// continuation of the page before it.
+    pub fn resume(head: [u8; 32], index: usize) -> Self {
+        Self {
+            prev: Some(head),
+            index,
+            verified: 0,
+            skipped_legacy: 0,
+        }
+    }
+
+    /// Verify one envelope as the successor of everything pushed so
+    /// far. Envelopes must arrive in ascending write order.
+    ///
+    /// On `Err` the verifier is left at the breaking entry and must
+    /// not be reused — the chain past a break carries no meaning.
+    pub fn push(&mut self, env: &AuditEnvelope) -> Result<(), ChainBreak> {
+        let index = self.index;
+        self.index += 1;
+
         if env.schema_version < 2 {
             // Predates the chain — nothing to verify, and it must not
             // become the predecessor of a v2 link.
-            continue;
+            self.skipped_legacy += 1;
+            return Ok(());
         }
         if env.chain_digest() != env.entry_hash {
             return Err(ChainBreak::TamperedEntry {
@@ -197,16 +265,45 @@ pub fn verify_chain(envelopes: &[AuditEnvelope]) -> Result<(), ChainBreak> {
                 event_id: env.event_id,
             });
         }
-        let expected_prev = prev.unwrap_or(GENESIS_HASH);
+        let expected_prev = self.prev.unwrap_or(GENESIS_HASH);
         if env.prev_hash != expected_prev {
             return Err(ChainBreak::BrokenLink {
                 index,
                 event_id: env.event_id,
             });
         }
-        prev = Some(env.entry_hash);
+        self.prev = Some(env.entry_hash);
+        self.verified += 1;
+        Ok(())
     }
-    Ok(())
+
+    /// `entry_hash` of the last verified v2+ envelope — the head of
+    /// the chain so far. `None` if nothing chainable has been pushed.
+    pub fn head(&self) -> Option<[u8; 32]> {
+        self.prev
+    }
+
+    /// Number of envelopes pushed, chainable or not. Pass to
+    /// [`Self::resume`] so a continuation reports absolute indices.
+    pub fn index(&self) -> usize {
+        self.index
+    }
+
+    /// Count of v2+ envelopes that verified.
+    pub fn verified(&self) -> usize {
+        self.verified
+    }
+
+    /// Count of pre-v2 envelopes skipped as unchainable.
+    ///
+    /// **Read this, don't ignore it.** Legacy rows are skipped rather
+    /// than verified, so they are an insertion point: a forged
+    /// envelope marked `schema_version: 1` passes untouched. A store
+    /// that should hold no legacy rows reporting a non-zero count
+    /// here is itself the finding.
+    pub fn skipped_legacy(&self) -> usize {
+        self.skipped_legacy
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -413,6 +510,80 @@ mod tests {
         let a = chained_envelope(GENESIS_HASH, 0x01);
         let b = chained_envelope(a.entry_hash, 0x02);
         assert!(verify_chain(&[legacy, a, b]).is_ok());
+    }
+
+    #[test]
+    fn incremental_verifier_matches_the_slice_form() {
+        let a = chained_envelope(GENESIS_HASH, 0x01);
+        let b = chained_envelope(a.entry_hash, 0x02);
+        let c = chained_envelope(b.entry_hash, 0x03);
+
+        let mut v = ChainVerifier::new();
+        for env in [&a, &b, &c] {
+            v.push(env).expect("chain verifies");
+        }
+        assert_eq!(v.verified(), 3);
+        assert_eq!(v.index(), 3);
+        assert_eq!(v.skipped_legacy(), 0);
+        assert_eq!(v.head(), Some(c.entry_hash));
+        assert!(verify_chain(&[a, b, c]).is_ok(), "slice form agrees");
+    }
+
+    #[test]
+    fn resumed_verifier_continues_across_a_page_boundary() {
+        // The point of `resume`: page 1 verified separately from page
+        // 2 must reach the same verdict as one contiguous pass.
+        let a = chained_envelope(GENESIS_HASH, 0x01);
+        let b = chained_envelope(a.entry_hash, 0x02);
+        let c = chained_envelope(b.entry_hash, 0x03);
+
+        let mut page1 = ChainVerifier::new();
+        page1.push(&a).expect("a verifies");
+        page1.push(&b).expect("b verifies");
+
+        let mut page2 = ChainVerifier::resume(page1.head().expect("head"), page1.index());
+        page2
+            .push(&c)
+            .expect("c continues the chain from page 1's head");
+        assert_eq!(page2.head(), Some(c.entry_hash));
+        // Absolute index carries across, so a break on page 2 reports
+        // its position in the whole log rather than within the page.
+        assert_eq!(page2.index(), 3);
+    }
+
+    #[test]
+    fn resumed_verifier_rejects_a_page_that_does_not_follow() {
+        let a = chained_envelope(GENESIS_HASH, 0x01);
+        let b = chained_envelope(a.entry_hash, 0x02);
+        // `c` chains from `b`, but we resume from `a` — a dropped
+        // entry across the page boundary must still be caught.
+        let c = chained_envelope(b.entry_hash, 0x03);
+
+        let mut page2 = ChainVerifier::resume(a.entry_hash, 1);
+        match page2.push(&c) {
+            Err(ChainBreak::BrokenLink { index, .. }) => assert_eq!(index, 1),
+            other => panic!("expected BrokenLink, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn legacy_rows_are_counted_not_silently_dropped() {
+        // The skip is an insertion point, so the count has to be
+        // observable — an operator seeing a non-zero legacy count on a
+        // v2-only store is looking at the finding itself.
+        let mut legacy = sample_envelope();
+        legacy.schema_version = 1;
+        legacy.prev_hash = GENESIS_HASH;
+        legacy.entry_hash = GENESIS_HASH;
+        let a = chained_envelope(GENESIS_HASH, 0x01);
+
+        let mut v = ChainVerifier::new();
+        v.push(&legacy)
+            .expect("legacy row is skipped, not an error");
+        v.push(&a).expect("chain anchors at genesis after the skip");
+        assert_eq!(v.skipped_legacy(), 1);
+        assert_eq!(v.verified(), 1);
+        assert_eq!(v.index(), 2, "index counts skipped rows too");
     }
 
     #[test]

--- a/vti-common/src/audit/event.rs
+++ b/vti-common/src/audit/event.rs
@@ -342,6 +342,17 @@ pub enum AuditEvent {
     /// `target_did` is the session owner (when revoking by DID).
     SessionRevoked(SessionRevokedData),
 
+    /// A principal ended their **own** session (`POST
+    /// /v1/auth/sign-out`).
+    ///
+    /// Deliberately distinct from [`Self::SessionRevoked`] rather than
+    /// a flag on it: voluntary sign-out is routine, admin-forced
+    /// revocation is a security signal, and a SIEM rule that has to
+    /// tell them apart by comparing actor to target will get it wrong
+    /// the first time an admin revokes their own session. Same
+    /// reasoning as [`Self::AdminPromoted`] versus [`Self::RoleChanged`].
+    SignedOut(SignedOutData),
+
     /// An encrypted state backup was exported (`POST /v1/backup/export`).
     BackupExported(BackupData),
 
@@ -437,6 +448,19 @@ pub struct SessionRevokedData {
     pub session_id: Option<String>,
     /// Number of sessions revoked (1 for a single id, N for revoke-by-DID).
     pub revoked_count: u32,
+}
+
+/// Payload for [`AuditEvent::SignedOut`].
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SignedOutData {
+    /// Session ended. Always known — the caller's own JWT names it.
+    ///
+    /// There is deliberately no "did it exist" flag: the `AuthClaims`
+    /// extractor rejects a token whose session row is gone, so the
+    /// handler only ever runs against a live session. A second
+    /// sign-out with the same token 401s and never reaches here.
+    pub session_id: String,
 }
 
 /// Payload for [`AuditEvent::BackupExported`] / [`AuditEvent::BackupImported`].
@@ -1125,6 +1149,47 @@ pub struct DidRotatedData {
     /// rotated key inherits. `None` on pre-enrichment rows.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub prior_role: Option<String>,
+    /// Why the member rotated, as declared when they requested the
+    /// rotation challenge. `None` on pre-enrichment rows and whenever
+    /// the member declined to say.
+    ///
+    /// **Self-asserted, not proven.** The rotation signatures cover
+    /// `{rotationId, oldDid, newDid, expiresAt}` and nothing else, so
+    /// this value is the member's own claim about their motive. It is
+    /// bound to the authenticated session that opened the ceremony and
+    /// cannot be altered by whoever submits the finish request, but a
+    /// member who lies about *why* they rotated will be recorded
+    /// faithfully lying. Treat it as intent, never as evidence.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rotation_reason: Option<DidRotationReason>,
+}
+
+/// Why a member rotated their DID, as declared at challenge time.
+///
+/// Separate from [`crate::audit::RotationReason`], which describes
+/// *audit-HMAC-key* rotation: that enum serializes PascalCase, is
+/// already persisted in `audit_key:` rows (so it cannot be re-cased),
+/// and its variants (`Initial`, `Routine` meaning "the background task
+/// fired") carry no sensible reading in this domain.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
+pub enum DidRotationReason {
+    /// Routine hygiene — scheduled or self-directed key refresh, no
+    /// suspected compromise.
+    Routine,
+    /// The old key is believed exposed. The security-relevant value:
+    /// a SIEM rule keying on this should escalate, and everything the
+    /// old DID did before the rotation is suspect.
+    Compromise,
+    /// The device holding the old key was lost, destroyed, or
+    /// replaced. Distinct from `Compromise` — no exposure claimed.
+    DeviceLoss,
+    /// Moving between DID methods or hosts (e.g. `did:key` →
+    /// `did:webvh`), the identity being otherwise unchanged.
+    Migration,
+    /// The member gave no reason.
+    Unspecified,
 }
 
 /// Payload for [`AuditEvent::PolicyActivated`].
@@ -1480,6 +1545,7 @@ mod tests {
             vmc_id: Some("urn:uuid:vmc-2".into()),
             role_vec_id: Some("urn:uuid:vec-2".into()),
             prior_role: Some("member".into()),
+            rotation_reason: Some(DidRotationReason::Compromise),
         });
         let v = wire_value(&e);
         assert_eq!(v["type"], "DidRotated");
@@ -1499,6 +1565,7 @@ mod tests {
             vmc_id: None,
             role_vec_id: None,
             prior_role: None,
+            rotation_reason: None,
         });
         let v = wire_value(&e);
         assert!(v["data"].get("vmcId").is_none());
@@ -1903,6 +1970,7 @@ mod tests {
                     vmc_id: None,
                     role_vec_id: None,
                     prior_role: None,
+                    rotation_reason: None,
                 }),
                 "DidRotated",
             ),

--- a/vti-common/src/audit/mod.rs
+++ b/vti-common/src/audit/mod.rs
@@ -30,21 +30,22 @@ pub mod key_store;
 pub mod writer;
 
 pub use envelope::{
-    AuditEnvelope, ChainBreak, EVENT_VERSION, GENESIS_HASH, SCHEMA_VERSION, verify_chain,
+    AuditEnvelope, ChainBreak, ChainVerifier, EVENT_VERSION, GENESIS_HASH, SCHEMA_VERSION,
+    verify_chain,
 };
 pub use event::{
     AclChangeData, AclRevokedData, AdminInviteData, AdminPasskeyData, AdminPromotedData,
     AdminUiServedData, AuditEvent, AuditKeyRotatedData, BackupData, CommunityInstalledData,
     CommunityProfileUpdatedData, ConfigChange, ConfigChangedData, ConfigReloadedData, ConfigSource,
     CredentialIssuedData, CrossCommunitySessionMintedData, CustomEndorsementIssuedData,
-    CustomEndorsementRevokedData, DidRotatedData, EmergencyBootstrapData,
+    CustomEndorsementRevokedData, DidRotatedData, DidRotationReason, EmergencyBootstrapData,
     EndorsementTypeDeletedData, EndorsementTypeRegisteredData, FieldChange, InvitationIssuedData,
     InvitationRevokedData, JoinRequestData, JoinRequestRejectedData, MemberAddedData,
     MemberRemovedData, MemberUpdatedData, MembershipReciprocatedData, MembershipRenewedData,
     PersonhoodAssertedData, PersonhoodRevokedData, PolicyActivatedData, PolicyUploadedData,
     REDACTED_MARKER, RegistryRecordPolicyOverrideData, RegistryStatusChangedData,
     RegistrySyncOutcomeData, RestartRequestedData, RoleChangedData, SchemaChangeData,
-    SessionRevokedData, StatusListFlippedData, VrcPublishedData, VrcRevokedData,
+    SessionRevokedData, SignedOutData, StatusListFlippedData, VrcPublishedData, VrcRevokedData,
     WebsiteBundleDeployedData, WebsiteFileDeletedData, WebsiteFileWrittenData,
     WebsiteGenerationRolledBackData,
 };


### PR DESCRIPTION
Closes the three tractable items left in #537 after #538 and #555 (see the [re-validation comment](https://github.com/OpenVTC/verifiable-trust-infrastructure/issues/537#issuecomment-5016224392)). Signed checkpoints — item 4 — are written up as a design note rather than built.

## 1. Sign-out is audited

`POST /v1/auth/sign-out` was the last session-lifecycle mutation writing only an `info!` line.

New `SignedOut` variant rather than reusing `SessionRevoked`: voluntary sign-out is routine, admin-forced revocation is a security signal, and a SIEM rule distinguishing them by comparing actor to target breaks the first time an admin revokes their own session. Same reasoning the enum already applies to `AdminPromoted` vs `RoleChanged`.

**What didn't ship:** `SignedOutData` initially carried a `session_existed` flag. Writing the test surfaced that `AuthClaims` (`extractor.rs:101`) rejects a token whose session row is gone — so the handler only ever runs against a live session, and the field was structurally always `true`. Removed rather than shipped as a field that cannot vary. There's now a test pinning that a second sign-out 401s instead.

## 2. `verify_chain` is actually reachable

The chain landed in #555 but had **zero non-test callers** — tamper was detectable, and nothing detected it.

- `GET /v1/audit/verify` (super-admin), Trust-Task `audit/verify/1.0`
- `cnm audit verify` — exits non-zero on a break, so it works as a scheduled check

Both report `entriesExamined` / `entriesVerified` / `legacySkipped` / `unparseableSkipped` / `head`, and where the chain broke. **The skip counters are surfaced at the same prominence as a break**: pre-v2 and unparseable rows are stepped over rather than verified, so a `verified: true` over a log full of skips must not read as clean. `legacySkipped > 0` on a current store is itself the finding.

Verification folds through a new incremental `ChainVerifier` rather than the slice form, so memory is constant over a large log; `resume()` lets a paged walk continue across boundaries.

**Stated plainly in the endpoint docs, the CLI output, the Trust-Task spec, and the operator doc:** a pass proves internal consistency, not authenticity. `chain_digest` is unkeyed, so a store-level adversary can restamp a forged suffix, and truncation to a valid prefix is undetectable.

## 3. `DidRotated` records a rotation reason

Collected at **challenge** time, not on the finish request. The rotation signatures cover only `{rotationId, oldDid, newDid, expiresAt}` — a reason submitted at finish would be unauthenticated and alterable by whoever relays that request. Captured at challenge time it is bound to the authenticated session that opened the ceremony.

It remains **self-asserted**, and the field docs say so: intent, never evidence.

Uses a new `DidRotationReason` (`routine` / `compromise` / `deviceLoss` / `migration` / `unspecified`) rather than the existing `RotationReason`, whose variants describe *audit-key* rotation (`Initial`, `Routine` = "the background task fired"), whose PascalCase serialization is frozen by already-stored `audit_key:` rows, and which would couple the DID-rotation wire format to the audit subsystem.

Backward compatible: the challenge body is optional and existing bodiless requests still pass (pinned by the pre-existing rotation tests, unmodified).

## 4. Signed checkpoints — design note only

`docs/05-design-notes/vtc-audit-checkpoints.md`. Proposes signing the chain head + entry count with the **community Ed25519 key**, not the audit HMAC key — the HMAC key lives in the same store the adversary is assumed to have reached, and symmetric verification means whoever can check a checkpoint can forge one. The entry count is what makes truncation detectable.

## Testing

Full `cargo test -p vti-common -p vtc-service -p cnm-cli`: 46 suites, 0 failures. Clippy clean.

New coverage: 4 `ChainVerifier` unit tests (incremental parity, resume across pages, resume rejects a non-following page, legacy rows counted); 5 endpoint integration tests (empty log, real chain, tampered row, dropped row, non-super-admin refused); 3 sign-out tests; 2 rotation-reason tests.

Versions: `vti-common` 0.11.10, `vtc-service` 0.11.12, `cnm-cli` 0.11.2.

## Incidental finding

`trust-tasks/index.json` lists `openvtc/vtc/auth/sign-out/1.0` for `POST /v1/auth/sign-out`, but the router enforces `spec/auth/revoke-session/0.1` (`routes/mod.rs:376`). The manifest and the route disagree. Not touched here — flagging it as its own small fix.