### PR TITLE
fix(tee): structural check for CMS encryptedContent OCTET STRING wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ## Unreleased
 
+### vta-service — CMS `encryptedContent` unwrap no longer misreads raw ciphertext
+
+* `decrypt_cms_envelope` decided whether KMS had used EXPLICIT tagging on
+  `encryptedContent [0]` by testing a single byte — `ct_value[0] == 0x04`.
+  Under the normal IMPLICIT tagging that slice is raw AES-GCM ciphertext, i.e.
+  uniformly random bytes, so roughly 1 envelope in 256 was mistaken for an
+  EXPLICIT OCTET STRING wrapper. The misfire either raised a bogus
+  `CMS: truncated length bytes for inner encryptedContent` on a perfectly valid
+  envelope, or — worse — parsed successfully and returned a *truncated*
+  ciphertext, surfacing as a GCM tag mismatch indistinguishable from the KMS
+  ciphertext tampering the JWT-fingerprint guard exists to flag. Both land on
+  the enclave's first-boot path. The check is now structural: the slice is
+  unwrapped only when it is a well-formed OCTET STRING TLV spanning it
+  *exactly*, which random ciphertext cannot satisfy by accident. Measured over
+  500 runs of the wrong-key test: 2 failures before, 0 after (issue #685, filed
+  as CI flake — the flake was this bug).
+* The `encryptedContent` length parse also sliced without bounds checks, so a
+  truncated or malformed envelope panicked instead of returning `AppError`;
+  over-wide long-form lengths are now rejected before they can overflow the
+  shift. Every other parse in this module already returned typed errors.
+
 ### pnm-cli — `bootstrap open --out` writes the credential bundle
 
 * `pnm bootstrap open` decrypted a sealed bundle, printed a summary and exited

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10235,7 +10235,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.11.12"
+version = "0.11.13"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.11.12"
+version = "0.11.13"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/tee/kms_bootstrap.rs
+++ b/vta-service/src/tee/kms_bootstrap.rs
@@ -984,6 +984,11 @@ mod cms_der {
 
         let ct_value = if first_len < 0x80 {
             let len = first_len as usize;
+            if pos + len > eci_data.len() {
+                return Err(tee_attestation_error(
+                    "CMS: encryptedContent overflows EncryptedContentInfo",
+                ));
+            }
             &eci_data[pos..pos + len]
         } else if first_len == 0x80 {
             // Indefinite length on raw octets — take everything remaining,
@@ -999,11 +1004,28 @@ mod cms_der {
             }
         } else {
             let num_bytes = (first_len & 0x7F) as usize;
+            // A length wider than usize can never address a real buffer, and
+            // shifting it in would overflow before the bounds check below.
+            if num_bytes > core::mem::size_of::<usize>() {
+                return Err(tee_attestation_error(
+                    "CMS: oversized length encoding for encryptedContent",
+                ));
+            }
+            if pos + num_bytes > eci_data.len() {
+                return Err(tee_attestation_error(
+                    "CMS: truncated length bytes for encryptedContent",
+                ));
+            }
             let mut len = 0usize;
             for i in 0..num_bytes {
                 len = (len << 8) | (eci_data[pos + i] as usize);
             }
             pos += num_bytes;
+            if pos + len > eci_data.len() {
+                return Err(tee_attestation_error(
+                    "CMS: encryptedContent overflows EncryptedContentInfo",
+                ));
+            }
             &eci_data[pos..pos + len]
         };
 
@@ -1012,15 +1034,38 @@ mod cms_der {
 
         // The ciphertext may be wrapped in an inner OCTET STRING if KMS used
         // EXPLICIT tagging on [0] instead of IMPLICIT. Unwrap if present.
-        let ciphertext = if ct_value.len() > 2 && ct_value[0] == 0x04 {
-            let mut inner_pos = 0;
-            let (_, inner) = read_tlv(ct_value, &mut inner_pos, "inner encryptedContent")?;
-            inner.to_vec()
-        } else {
-            ct_value.to_vec()
-        };
+        let ciphertext =
+            unwrap_explicit_octet_string(ct_value).unwrap_or_else(|| ct_value.to_vec());
 
         Ok((oid, iv, ciphertext))
+    }
+
+    /// If `ct_value` is an EXPLICIT-tagged wrapper, it is a single OCTET STRING
+    /// TLV spanning the whole slice. Return its contents; otherwise `None`.
+    ///
+    /// The check must be structural, not a peek at the first byte. Under the
+    /// (normal) IMPLICIT tagging, `ct_value` is raw AES-GCM ciphertext —
+    /// uniformly random bytes, so roughly 1 in 256 envelopes start with 0x04
+    /// and would be mistaken for a wrapper. That misfire either raised a
+    /// bogus "CMS parse" error on a perfectly valid envelope or, worse,
+    /// silently truncated the ciphertext into a GCM tag mismatch that reads
+    /// like KMS ciphertext tampering.
+    ///
+    /// Requiring the TLV to consume *exactly* the whole slice drops the
+    /// false-positive rate from 2^-8 to negligible: random ciphertext would
+    /// have to encode its own remaining length.
+    fn unwrap_explicit_octet_string(ct_value: &[u8]) -> Option<Vec<u8>> {
+        if ct_value.first() != Some(&0x04) {
+            return None;
+        }
+        let mut pos = 0;
+        let (tag, inner) = read_tlv(ct_value, &mut pos, "inner encryptedContent").ok()?;
+        // read_tlv already bounds-checks; `pos` is the end of the TLV it read.
+        if tag == 0x04 && pos == ct_value.len() {
+            Some(inner.to_vec())
+        } else {
+            None
+        }
     }
 
     /// Parse the AlgorithmIdentifier to extract the OID and IV/nonce.
@@ -1212,6 +1257,72 @@ mod cms_der {
             let data = [0x04, 0x05, 0x01]; // claims 5 bytes but only 1
             let mut pos = 0;
             assert!(read_tlv(&data, &mut pos, "test").is_err());
+        }
+
+        /// A genuine EXPLICIT-tagged wrapper spans the whole slice and unwraps.
+        #[test]
+        fn explicit_octet_string_wrapper_is_unwrapped() {
+            let payload = [0xDE, 0xAD, 0xBE, 0xEF];
+            let mut wrapped = vec![0x04, payload.len() as u8];
+            wrapped.extend_from_slice(&payload);
+            assert_eq!(
+                unwrap_explicit_octet_string(&wrapped),
+                Some(payload.to_vec())
+            );
+        }
+
+        /// Raw ciphertext that merely *starts* with 0x04 is not a wrapper.
+        ///
+        /// Regression for the flaky-CI bug: the old check was
+        /// `ct_value[0] == 0x04`, so ~1 in 256 random AES-GCM ciphertexts was
+        /// misread as an EXPLICIT wrapper.
+        #[test]
+        fn raw_ciphertext_starting_with_0x04_is_not_unwrapped() {
+            // 0x04 0x02 ... — a well-formed TLV, but it does not span the
+            // whole slice, so it is ciphertext rather than a wrapper.
+            let ciphertext = [0x04, 0x02, 0x11, 0x22, 0x33, 0x44];
+            assert_eq!(unwrap_explicit_octet_string(&ciphertext), None);
+
+            // 0x04 followed by a long-form length with too few bytes: the old
+            // code propagated this as "CMS: truncated length bytes for inner
+            // encryptedContent" — the exact error seen in CI.
+            let ciphertext = [0x04, 0x84, 0xFF];
+            assert_eq!(unwrap_explicit_octet_string(&ciphertext), None);
+        }
+
+        /// Every 2-byte prefix must be handled without panicking or erroring —
+        /// covers the whole space the random-ciphertext misfire drew from.
+        #[test]
+        fn no_prefix_of_raw_ciphertext_is_mistaken_for_a_wrapper() {
+            for b0 in 0u8..=255 {
+                for b1 in 0u8..=255 {
+                    let mut ct = vec![b0, b1];
+                    ct.extend_from_slice(&[0x5A; 40]);
+                    // Length 42 can only be spanned by `04 28 <40 bytes>`.
+                    let expect_unwrap = b0 == 0x04 && b1 == 40;
+                    assert_eq!(
+                        unwrap_explicit_octet_string(&ct).is_some(),
+                        expect_unwrap,
+                        "prefix {b0:#04x} {b1:#04x}"
+                    );
+                }
+            }
+        }
+
+        /// Malformed EncryptedContentInfo must error, not panic.
+        #[test]
+        fn truncated_encrypted_content_errors_without_panicking() {
+            // contentType OID, algorithm SEQUENCE, then [0] claiming more
+            // bytes than remain.
+            let mut eci = vec![0x06, 0x01, 0x2A]; // minimal OID
+            eci.extend_from_slice(&[0x30, 0x00]); // empty algorithm SEQUENCE
+            eci.extend_from_slice(&[0x80, 0x40, 0x01, 0x02]); // claims 64, has 2
+            assert!(parse_encrypted_content_info(&eci).is_err());
+
+            // Long-form length wider than usize.
+            let mut eci = vec![0x06, 0x01, 0x2A, 0x30, 0x00];
+            eci.extend_from_slice(&[0x80, 0x9F]); // 31 length bytes
+            assert!(parse_encrypted_content_info(&eci).is_err());
         }
     }
 }


### PR DESCRIPTION
Fixes #685 — but the issue's diagnosis was wrong, and so was its "no production impact" assessment. This fixes the parser, not the assertion.

## Root cause

`decrypt_cms_envelope` decided whether KMS had used EXPLICIT tagging on `encryptedContent [0]` by testing a single byte:

```rust
let ciphertext = if ct_value.len() > 2 && ct_value[0] == 0x04 { /* unwrap TLV */ } else { /* raw */ };
```

Under the normal IMPLICIT tagging, `ct_value` is **raw AES-GCM ciphertext** — uniformly random bytes. So roughly **1 envelope in 256** starts with `0x04` and gets mistaken for an EXPLICIT OCTET STRING wrapper. That is the flake: `read_tlv` then walks random bytes and yields exactly the CI error, `CMS: truncated length bytes for inner encryptedContent`. Nothing to do with a "DER length-boundary case in the fixture".

## Why this is not test-only

The same misfire applies to real KMS-returned CMS on the enclave's first-boot path, with two outcomes:

1. `read_tlv` errors → bootstrap fails with a bogus "CMS parse" error on a perfectly valid envelope.
2. **Worse:** `read_tlv` *succeeds* on the random bytes and returns a truncated `inner` slice → wrong ciphertext → GCM tag mismatch. That is indistinguishable from the KMS ciphertext tampering / key rotation the JWT-fingerprint guard exists to flag, so a 1-in-256 parser bug reads as a security event.

All three fixes suggested in the issue (broaden the accepted-error set / canonicalise the fixture / assert a typed variant) would have hidden this.

## The fix

Make the check structural rather than a byte peek: unwrap only when the slice is a well-formed OCTET STRING TLV that consumes it **exactly**. A genuine EXPLICIT wrapper always does; random ciphertext would have to encode its own remaining length, dropping the false-positive rate from 2^-8 to negligible.

Two adjacent hardening fixes in the same function, since the tests exercise it:

- The `encryptedContent` length parse sliced `&eci_data[pos..pos + len]` with no bounds check, so a truncated or malformed envelope **panicked** instead of returning `AppError`. Every other parse in this module returns typed errors.
- Long-form lengths wider than `usize` are rejected before the accumulating shift can overflow.

## Verification

`cms_decrypt_with_wrong_private_key_fails`, 500 runs of the release binary each way:

| | failures / 500 |
|---|---|
| before | **2** (0.40%) |
| after | **0** |

0.40% matches the predicted 1/256 = 0.39%, which is what pins the diagnosis.

The existing test's assertion is unchanged — it correctly asserts the OAEP path, and now deterministically reaches it. New coverage in `cms_der::tests`:

- `explicit_octet_string_wrapper_is_unwrapped` — the real EXPLICIT case still unwraps.
- `raw_ciphertext_starting_with_0x04_is_not_unwrapped` — including the exact `04 84 FF` shape that produced the CI error.
- `no_prefix_of_raw_ciphertext_is_mistaken_for_a_wrapper` — exhaustive over all 65 536 two-byte prefixes, i.e. the whole space the misfire drew from.
- `truncated_encrypted_content_errors_without_panicking` — the bounds-check paths.

`vta-service` 0.11.12 → 0.11.13 (publishable crate, source change). `vta-enclave` pins `0.11`, so no dependent bump.
