### PR TITLE
test(vtc): don't assume admission push order in join_didcomm

### DIFF
--- a/vtc-service/tests/join_didcomm.rs
+++ b/vtc-service/tests/join_didcomm.rs
@@ -256,26 +256,56 @@ async fn didcomm_join_round_trips_submit_manifest_status_approve_and_vmc_deliver
 
     // 6. The membership credential lands at the applicant over DIDComm — the
     //    full push the activation path (T6) needs.
-    let (typ, issue_body) = mock
-        .client
-        .next_pushed(Duration::from_secs(20))
-        .await
-        .expect("VMC delivered over DIDComm");
-    assert_eq!(typ, CREDENTIAL_ISSUE_TYPE);
-    let issue: IssueBody = serde_json::from_value(issue_body).expect("issue body");
-    let credential = issue
-        .credential_response
-        .expect("credential_response present")
-        .credential
-        .expect("credential present");
-    let types = credential["type"].as_array().expect("VC type array");
-    assert!(
-        types.iter().any(|t| t == "MembershipCredential"),
-        "delivered credential is a MembershipCredential: {credential}"
-    );
+    //
+    //    Admission delivers *two* credentials (the VMC and the role VEC) as
+    //    independent one-way messages — `deliver_credentials` opens a fresh
+    //    thread per credential, and each is forwarded through the mediator
+    //    separately. Arrival order is therefore not guaranteed, so collect both
+    //    pushes and look for the VMC among them rather than asserting it is the
+    //    first to land (which flaked in CI when the VEC overtook it).
+    let mut delivered = Vec::new();
+    for _ in 0..2 {
+        let (typ, issue_body) = mock
+            .client
+            .next_pushed(Duration::from_secs(20))
+            .await
+            .expect("admission credential delivered over DIDComm");
+        assert_eq!(typ, CREDENTIAL_ISSUE_TYPE);
+        let issue: IssueBody = serde_json::from_value(issue_body).expect("issue body");
+        delivered.push(
+            issue
+                .credential_response
+                .expect("credential_response present")
+                .credential
+                .expect("credential present"),
+        );
+    }
+
+    let has_type = |c: &serde_json::Value, want: &str| {
+        c["type"]
+            .as_array()
+            .expect("VC type array")
+            .iter()
+            .any(|t| t == want)
+    };
+
+    let vmc = delivered
+        .iter()
+        .find(|c| has_type(c, "MembershipCredential"))
+        .unwrap_or_else(|| panic!("a MembershipCredential was delivered: {delivered:#?}"));
     assert_eq!(
-        credential["credentialSubject"]["id"], applicant_did,
+        vmc["credentialSubject"]["id"], applicant_did,
         "VMC subject is the applicant"
+    );
+
+    // The role VEC is the other half of the admission push.
+    let vec_cred = delivered
+        .iter()
+        .find(|c| has_type(c, "EndorsementCredential"))
+        .unwrap_or_else(|| panic!("a role EndorsementCredential was delivered: {delivered:#?}"));
+    assert_eq!(
+        vec_cred["credentialSubject"]["id"], applicant_did,
+        "role VEC subject is the applicant"
     );
 
     mock.shutdown().await;


### PR DESCRIPTION
`didcomm_join_round_trips_submit_manifest_status_approve_and_vmc_delivery` fails intermittently in CI on unrelated PRs (seen on #704):

```
delivered credential is a MembershipCredential: {... "type":["VerifiableCredential","DTGCredential","EndorsementCredential"] ...}
```

## Root cause

Admission delivers **two** credentials. `deliver_membership_credentials` calls `deliver_credentials(state, holder, &[&admit.vmc, &admit.role_vec])`, which sends them as two *independent one-way* DIDComm messages — the code is explicit that each gets its own thread:

```rust
// A fresh thread per delivered credential — `issue` is a one-way deposit,
// not a request/response, so it needs no correlation to a prior thread.
let msg_id = Uuid::new_v4().to_string();
```

Each is then packed and forwarded through the mediator separately, so arrival order at the applicant is not guaranteed. The test's `next_pushed` correlates on nothing (`thid.is_none()`), so it takes **whichever lands first** and asserts it is the MembershipCredential. Under CI load the role VEC overtakes the VMC and the assertion fails.

So the test encodes an ordering guarantee the transport does not provide — the production behaviour is correct.

## Fix

Collect both pushes and assert the VMC is among them, rather than assuming it is first.

This is also strictly stronger coverage: it now additionally asserts the role VEC is delivered and subject-bound to the applicant, which the first-push-only form could never check (it discarded the second message entirely).

Test-only; no production change. `scripts/check-version-bumps.sh` reports no publishable-crate source touched, so no version bump.

## Verification

Full `join_didcomm` suite, 6 consecutive local runs: 3/3 passing each time.

The ordering assumption is now gone by construction rather than by timing, so the race can't resurface under load.

## Note

This is the second recently-observed flake of the same class as #685 — a test asserting something the implementation never promised. Both surfaced as red CI on unrelated PRs.
