### PR TITLE
fix(ci): refresh the stale crates.io self-pin blocking pnm-cli releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,6 +168,13 @@ jobs:
           fetch-depth: 0
       - name: Version-bump guard for changed publishable crates
         run: bash scripts/check-version-bumps.sh "${{ github.event.pull_request.base.sha }}"
+      # Sibling guard: the bump can be correct and the release still break if
+      # Cargo.lock pins a stale crates.io copy of one of our own crates (a
+      # transitive dev-dep pulls vta-sdk back in from the registry). `cargo
+      # publish --locked` verifies dependents against that pinned copy. See the
+      # script header. Not diff-based, so it needs no base ref.
+      - name: Lockfile self-pin guard
+        run: bash scripts/check-lockfile-self-pins.sh
 
   features:
     # Build the most-used non-default feature combinations so a misuse

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,7 +416,7 @@ dependencies = [
  "trust-tasks-rs",
  "url",
  "uuid",
- "vta-sdk 0.19.11",
+ "vta-sdk 0.19.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -10142,39 +10142,6 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.19.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2ccdc6b7e40d1c6b80a9c656a804177e16df8adebe0a3912d510578ccd1adce"
-dependencies = [
- "affinidi-crypto",
- "affinidi-did-resolver-cache-sdk",
- "affinidi-messaging-core",
- "affinidi-messaging-delivery",
- "affinidi-messaging-didcomm",
- "affinidi-openid4vci",
- "affinidi-openid4vp",
- "affinidi-tdk",
- "base64 0.22.1",
- "chrono",
- "curve25519-dalek",
- "didwebvh-rs",
- "ed25519-dalek",
- "futures-util",
- "getrandom 0.4.3",
- "multibase",
- "reqwest 0.13.4",
- "serde",
- "serde_json",
- "sha2 0.11.0",
- "thiserror 2.0.19",
- "tokio",
- "tracing",
- "url",
- "uuid",
-]
-
-[[package]]
-name = "vta-sdk"
 version = "0.19.12"
 dependencies = [
  "affinidi-bbs",
@@ -10231,6 +10198,39 @@ dependencies = [
  "x25519-dalek",
  "x509-parser 0.18.1",
  "zeroize",
+]
+
+[[package]]
+name = "vta-sdk"
+version = "0.19.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c166f554748e39b6cbd97a4ef8becd3afc1b5913166f35f0e1e4c81727395e"
+dependencies = [
+ "affinidi-crypto",
+ "affinidi-did-resolver-cache-sdk",
+ "affinidi-messaging-core",
+ "affinidi-messaging-delivery",
+ "affinidi-messaging-didcomm",
+ "affinidi-openid4vci",
+ "affinidi-openid4vp",
+ "affinidi-tdk",
+ "base64 0.22.1",
+ "chrono",
+ "curve25519-dalek",
+ "didwebvh-rs",
+ "ed25519-dalek",
+ "futures-util",
+ "getrandom 0.4.3",
+ "multibase",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "thiserror 2.0.19",
+ "tokio",
+ "tracing",
+ "url",
+ "uuid",
 ]
 
 [[package]]

--- a/scripts/check-lockfile-self-pins.sh
+++ b/scripts/check-lockfile-self-pins.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Guard against the "Cargo.lock pins a STALE crates.io copy of one of our own
+# workspace crates" trap that kept the Publish job red on main.
+#
+# This is the sibling failure to the one check-version-bumps.sh catches. There,
+# the version bump was *missing*. Here the bump is present and correct, and the
+# release still breaks.
+#
+# What happened: a transitive DEV-dependency pulls one of our own crates back in
+# from crates.io —
+#
+#   vtc-service [dev-dependencies]
+#     -> affinidi-messaging-test-mediator
+#       -> affinidi-messaging-mediator
+#         -> vta-sdk   (registry, NOT the workspace path copy)
+#
+# so Cargo.lock carries TWO vta-sdk nodes: the workspace path copy at the local
+# version, and a registry copy pinned at whatever was current when that
+# dependency was last resolved.
+#
+# The publish workflow runs `cargo publish --locked`. For a dependent crate
+# (pnm-cli), cargo's verification build swaps the workspace path dep for a
+# registry one — and `--locked` makes it reuse the lockfile's already-pinned
+# registry node rather than resolving the newest match. So pnm-cli 0.11.2 was
+# verified against vta-sdk 0.19.11 even though the same run had just published
+# vta-sdk 0.19.12, and the build failed with E0599 on `TspPingSession::
+# probe_send` — an API that only exists in 0.19.12. pnm-cli then sat unpublished
+# for three releases while the workspace build stayed green the whole time,
+# because the path deps always saw the new source.
+#
+# Dropping `--locked` would "fix" this by making releases non-reproducible.
+# Instead this guard keeps the lockfile honest: whenever a publishable workspace
+# crate also appears in Cargo.lock as a registry package, the two versions must
+# agree. Refreshing the pin is a one-line `cargo update` that the PR author runs
+# alongside the version bump.
+#
+# Usage: scripts/check-lockfile-self-pins.sh
+# Portable to macOS bash 3.2 / BSD userland.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+if [ -t 1 ]; then
+  RED=$'\033[0;31m'; GREEN=$'\033[0;32m'; CYAN=$'\033[0;36m'; NC=$'\033[0m'
+else
+  RED=''; GREEN=''; CYAN=''; NC=''
+fi
+
+if [ ! -f Cargo.lock ]; then
+  echo "${RED}error:${NC} Cargo.lock not found at $ROOT" >&2
+  exit 2
+fi
+
+REGISTRY='https://github.com/rust-lang/crates.io-index'
+
+# Publishable workspace members as  name<TAB>version.
+members=$(cargo metadata --format-version 1 --no-deps 2>/dev/null \
+  | jq -r '.packages[]
+      | select(.publish == null or .publish == ["crates.io"])
+      | "\(.name)\t\(.version)"')
+
+if [ -z "$members" ]; then
+  echo "${RED}error:${NC} could not read workspace members" >&2
+  exit 2
+fi
+
+# Registry-sourced packages in Cargo.lock as  name<TAB>version. Only entries
+# carrying a `source = "registry+..."` line are registry copies; the workspace
+# path copies have no source field.
+locked=$(awk '
+  /^\[\[package\]\]/ { name=""; version=""; src=""; next }
+  /^name = / { gsub(/^name = "|"$/, ""); name=$0; next }
+  /^version = / { gsub(/^version = "|"$/, ""); version=$0; next }
+  /^source = "registry\+/ { src=1;
+    if (name != "" && version != "") print name "\t" version;
+    next }
+' Cargo.lock)
+
+echo "${CYAN}=== Lockfile self-pin guard ===${NC}"
+echo ""
+
+fail=0
+found=0
+while IFS=$'\t' read -r name version; do
+  [ -z "$name" ] && continue
+  # Is this workspace crate also present as a registry package?
+  pinned=$(printf '%s\n' "$locked" | awk -F'\t' -v n="$name" '$1 == n { print $2 }' | head -1)
+  [ -z "$pinned" ] && continue
+  found=1
+  if [ "$pinned" = "$version" ]; then
+    echo "  ${GREEN}ok${NC}   $name: workspace $version == locked registry copy $pinned"
+  else
+    echo "  ${RED}STALE${NC} $name: workspace $version but Cargo.lock pins registry copy at $pinned"
+    echo "         fix: cargo update -p '$REGISTRY#$name@$pinned' --precise $version"
+    fail=1
+  fi
+done <<EOF
+$members
+EOF
+
+echo ""
+if [ "$found" -eq 0 ]; then
+  echo "${GREEN}No workspace crate is pulled back in from crates.io — nothing to check.${NC}"
+  exit 0
+fi
+
+if [ "$fail" -eq 0 ]; then
+  echo "${GREEN}All self-pins match the workspace versions.${NC}"
+else
+  echo "${RED}Cargo.lock pins a stale crates.io copy of a workspace crate.${NC}"
+  echo "\`cargo publish --locked\` verifies dependent crates against that pinned copy,"
+  echo "so a dependent will be built against the OLD source and fail to compile —"
+  echo "silently, since the workspace's own path-dep build stays green."
+  echo "Run the cargo update shown above and commit the Cargo.lock change."
+  exit 1
+fi


### PR DESCRIPTION
`Publish` has been red on **every commit to main since #698** (`42a8b9f`). `pnm-cli` is stuck at 0.11.1 on crates.io while main is at 0.11.4 — three releases never shipped.

```
error[E0599]: no method named `probe_send` found for struct `TspPingSession`
   --> src/commands/health.rs:437:31
error: failed to verify package tarball
```

## Root cause

Not a missing version bump — #698 correctly bumped `vta-sdk` 0.19.11 → 0.19.12 alongside adding `probe_send`, and 0.19.12 **is** on crates.io.

The problem is that a transitive **dev**-dependency pulls one of our own crates back in from the registry:

```
vtc-service [dev-dependencies]
  -> affinidi-messaging-test-mediator
    -> affinidi-messaging-mediator
      -> vta-sdk        (registry, NOT the workspace path copy)
```

So `Cargo.lock` carries **two** `vta-sdk` nodes: the workspace path copy at 0.19.12, and a registry copy pinned at 0.19.11.

The publish workflow runs `cargo publish --locked`. For a dependent crate, cargo's verification build swaps the workspace path dep for a registry one — and `--locked` makes it reuse the lockfile's **already-pinned** registry node rather than resolving the newest match. `pnm-cli` was therefore verified against `vta-sdk` 0.19.11 even though the same run had just published 0.19.12, and `probe_send` only exists in 0.19.12.

Every later run failed identically: `vta-sdk` 0.19.12 was already published so the workflow skipped it ("already on crates.io"), while the lockfile pin stayed at 0.19.11.

This was invisible pre-merge because the workspace's own build uses path deps, which always see the new source. Same blind spot the existing `check-version-bumps.sh` was written for — this is its sibling failure, where the bump is present and correct and the release breaks anyway.

## Fix

1. **Refresh the pin** — `cargo update -p '<registry>#vta-sdk@0.19.11' --precise 0.19.12`.
2. **`scripts/check-lockfile-self-pins.sh`**, wired into the PR `release guards` job: whenever a publishable workspace crate also appears in `Cargo.lock` as a registry package, the two versions must agree. Failure prints the exact `cargo update` to run.

Note the guard deliberately keeps `--locked` rather than dropping it — dropping it would also "fix" this, at the cost of non-reproducible releases. Better to keep the lockfile honest and catch staleness at PR time.

## Verification

The guard on this branch **before** the lockfile fix:

```
STALE vta-sdk: workspace 0.19.12 but Cargo.lock pins registry copy at 0.19.11
       fix: cargo update -p '...#vta-sdk@0.19.11' --precise 0.19.12
```

and after: `ok   vta-sdk: workspace 0.19.12 == locked registry copy 0.19.12`.

`cargo publish --dry-run --locked` (exactly what the workflow runs) now succeeds for all three stuck crates: `pnm-cli` 0.11.4, `cnm-cli` 0.11.2, `vta-cli-common` 0.10.8.

## After merge

The next `Publish` run should ship the backlog: `pnm-cli` 0.11.1 → 0.11.4 and `cnm-cli` → 0.11.2. Worth watching that run.
