### PR TITLE
feat(sdk): match a set of REST service types so non-VTA peers are discoverable

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -79,6 +79,7 @@ jobs:
 
           UA="verifiable-trust-infrastructure-release (https://github.com/${GITHUB_REPOSITORY})"
 
+          REGISTRY='https://github.com/rust-lang/crates.io-index'
           for crate in "${CRATES[@]}"; do
             version=$(cargo metadata --format-version 1 --no-deps \
               | jq -r --arg c "$crate" '.packages[] | select(.name == $c) | .version')
@@ -113,4 +114,28 @@ jobs:
             # cargo publish blocks until the new version is queryable in the
             # index, so the next (dependent) crate sees it.
             cargo publish -p "$crate" --locked $extra
+
+            # Refresh this crate's registry self-pin, if Cargo.lock carries one.
+            #
+            # A transitive dev-dependency pulls some of our crates back in from
+            # crates.io, so the lock holds both a path copy and a registry copy.
+            # `cargo publish --locked` builds a DEPENDENT against that registry
+            # copy — which, until now, still pointed at the PREVIOUS release. A
+            # dependent published later in this same loop was therefore verified
+            # against stale source and failed to compile (the #706 regression:
+            # pnm-cli built against vta-sdk 0.19.11 minutes after 0.19.12 shipped).
+            #
+            # This is the only moment the refresh is possible: the version has
+            # just become resolvable in the index, and a PR cannot do it because
+            # the version does not exist yet (see scripts/check-lockfile-self-pins.sh).
+            pinned=$(awk -v n="$crate" '
+              /^\[\[package\]\]/ { name=""; version=""; next }
+              /^name = / { gsub(/^name = "|"$/, ""); name=$0; next }
+              /^version = / { gsub(/^version = "|"$/, ""); version=$0; next }
+              /^source = "registry\+/ { if (name == n) { print version; exit } }
+            ' Cargo.lock)
+            if [ -n "$pinned" ] && [ "$pinned" != "$version" ]; then
+              echo "  refreshing lockfile self-pin ${crate} ${pinned} -> ${version}"
+              cargo update -p "${REGISTRY}#${crate}@${pinned}" --precise "$version"
+            fi
           done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## Unreleased
 
+### vta-sdk — REST discovery matches a set of service types
+
+* `ServiceCapabilities` matched REST on `"VTARest"` and nothing else. That
+  type is correct for a VTA — it says a VTA's REST API is behind the URL — but
+  it made the type unusable as a generic "this peer speaks REST" marker: any
+  non-VTA service either had to claim to be a VTA or stay undiscoverable. A
+  Trust Registry advertising its own type was invisible, so `select_protocol`
+  returned `NoMatchingProtocol` for a peer that plainly spoke REST.
+  `REST_SERVICE_TYPES` now holds both `VTARest` and `TRQPRest` (a Trust
+  Registry's TRQP-over-REST surface) and matching walks the set. VTAs are
+  unaffected; adding a REST-speaking service type is a one-line change.
+* `vta-mobile-core`'s resolver matched services with
+  `id.ends_with("#vta-rest") || ty == "VTARest"`. Matching on the `#id`
+  fragment violates R4.4 — the fragment is an arbitrary label — so the check
+  both missed valid services (a registry uses `#rest`) and could match the
+  wrong one: a DIDComm entry fragmented `#vta-rest` would have been read as
+  the REST endpoint. It now matches on `type` alone.
+
 ### vta-service — CMS `encryptedContent` unwrap no longer misreads raw ciphertext
 
 * `decrypt_cms_envelope` decided whether KMS had used EXPLICIT tagging on

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,7 +416,7 @@ dependencies = [
  "trust-tasks-rs",
  "url",
  "uuid",
- "vta-sdk 0.19.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vta-sdk 0.19.12",
 ]
 
 [[package]]
@@ -2486,7 +2486,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.19.12",
+ "vta-sdk 0.19.13",
 ]
 
 [[package]]
@@ -3287,7 +3287,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.19.12",
+ "vta-sdk 0.19.13",
 ]
 
 [[package]]
@@ -6765,7 +6765,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.19.12",
+ "vta-sdk 0.19.13",
 ]
 
 [[package]]
@@ -10081,7 +10081,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.19",
  "tokio",
- "vta-sdk 0.19.12",
+ "vta-sdk 0.19.13",
  "vti-common",
  "x25519-dalek",
 ]
@@ -10114,7 +10114,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.19.12",
+ "vta-sdk 0.19.13",
 ]
 
 [[package]]
@@ -10137,12 +10137,45 @@ dependencies = [
  "tracing-subscriber",
  "trust-tasks-rs",
  "uniffi",
- "vta-sdk 0.19.12",
+ "vta-sdk 0.19.13",
 ]
 
 [[package]]
 name = "vta-sdk"
 version = "0.19.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c166f554748e39b6cbd97a4ef8becd3afc1b5913166f35f0e1e4c81727395e"
+dependencies = [
+ "affinidi-crypto",
+ "affinidi-did-resolver-cache-sdk",
+ "affinidi-messaging-core",
+ "affinidi-messaging-delivery",
+ "affinidi-messaging-didcomm",
+ "affinidi-openid4vci",
+ "affinidi-openid4vp",
+ "affinidi-tdk",
+ "base64 0.22.1",
+ "chrono",
+ "curve25519-dalek",
+ "didwebvh-rs",
+ "ed25519-dalek",
+ "futures-util",
+ "getrandom 0.4.3",
+ "multibase",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "thiserror 2.0.19",
+ "tokio",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "vta-sdk"
+version = "0.19.13"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10198,39 +10231,6 @@ dependencies = [
  "x25519-dalek",
  "x509-parser 0.18.1",
  "zeroize",
-]
-
-[[package]]
-name = "vta-sdk"
-version = "0.19.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c166f554748e39b6cbd97a4ef8becd3afc1b5913166f35f0e1e4c81727395e"
-dependencies = [
- "affinidi-crypto",
- "affinidi-did-resolver-cache-sdk",
- "affinidi-messaging-core",
- "affinidi-messaging-delivery",
- "affinidi-messaging-didcomm",
- "affinidi-openid4vci",
- "affinidi-openid4vp",
- "affinidi-tdk",
- "base64 0.22.1",
- "chrono",
- "curve25519-dalek",
- "didwebvh-rs",
- "ed25519-dalek",
- "futures-util",
- "getrandom 0.4.3",
- "multibase",
- "reqwest 0.13.4",
- "serde",
- "serde_json",
- "sha2 0.11.0",
- "thiserror 2.0.19",
- "tokio",
- "tracing",
- "url",
- "uuid",
 ]
 
 [[package]]
@@ -10315,7 +10315,7 @@ dependencies = [
  "utoipa-axum",
  "uuid",
  "vta-cli-common",
- "vta-sdk 0.19.12",
+ "vta-sdk 0.19.13",
  "vta-service",
  "vti-common",
  "vti-secrets",
@@ -10337,7 +10337,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.19",
  "tokio",
- "vta-sdk 0.19.12",
+ "vta-sdk 0.19.13",
 ]
 
 [[package]]
@@ -10411,7 +10411,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.19.12",
+ "vta-sdk 0.19.13",
  "vtc-service",
  "vti-common",
  "vti-secrets",
@@ -10463,7 +10463,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.19.12",
+ "vta-sdk 0.19.13",
  "webauthn-rs",
  "zeroize",
 ]
@@ -10490,7 +10490,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.19.12",
+ "vta-sdk 0.19.13",
  "vta-service",
  "vti-common",
 ]
@@ -10519,7 +10519,7 @@ dependencies = [
  "tokio",
  "tracing",
  "vaultrs",
- "vta-sdk 0.19.12",
+ "vta-sdk 0.19.13",
  "vti-common",
 ]
 

--- a/scripts/check-lockfile-self-pins.sh
+++ b/scripts/check-lockfile-self-pins.sh
@@ -34,6 +34,15 @@
 # agree. Refreshing the pin is a one-line `cargo update` that the PR author runs
 # alongside the version bump.
 #
+# One case is NOT a failure: a PR that bumps a workspace crate sets the local
+# version to something not yet on crates.io, so the pin CANNOT be refreshed —
+# `cargo update --precise <new>` fails with "no matching package". Demanding
+# equality there makes this guard and check-version-bumps.sh mutually
+# unsatisfiable: one requires the bump, the other forbids its consequence. So
+# an unpublished local version is reported and allowed; the publish workflow
+# refreshes the pin immediately after publishing the crate, which is the only
+# moment the refresh is actually possible.
+#
 # Usage: scripts/check-lockfile-self-pins.sh
 # Portable to macOS bash 3.2 / BSD userland.
 set -euo pipefail
@@ -53,6 +62,21 @@ if [ ! -f Cargo.lock ]; then
 fi
 
 REGISTRY='https://github.com/rust-lang/crates.io-index'
+UA='vti-lockfile-guard (https://github.com/OpenVTC/verifiable-trust-infrastructure)'
+
+# Is $1@$2 already on crates.io?  0 = published, 1 = not, 2 = undeterminable.
+# Mirrors the check the publish workflow uses to skip already-published crates.
+crate_is_published() {
+  local name="$1" version="$2" status
+  status=$(curl -s -o /dev/null -w '%{http_code}' --max-time 15 \
+    -H "User-Agent: $UA" \
+    "https://crates.io/api/v1/crates/${name}/${version}" 2>/dev/null) || return 2
+  case "$status" in
+    200) return 0 ;;
+    404) return 1 ;;
+    *) return 2 ;;
+  esac
+}
 
 # Publishable workspace members as  name<TAB>version.
 members=$(cargo metadata --format-version 1 --no-deps 2>/dev/null \
@@ -82,6 +106,7 @@ echo ""
 
 fail=0
 found=0
+bumping=0
 while IFS=$'\t' read -r name version; do
   [ -z "$name" ] && continue
   # Is this workspace crate also present as a registry package?
@@ -91,9 +116,32 @@ while IFS=$'\t' read -r name version; do
   if [ "$pinned" = "$version" ]; then
     echo "  ${GREEN}ok${NC}   $name: workspace $version == locked registry copy $pinned"
   else
-    echo "  ${RED}STALE${NC} $name: workspace $version but Cargo.lock pins registry copy at $pinned"
-    echo "         fix: cargo update -p '$REGISTRY#$name@$pinned' --precise $version"
-    fail=1
+    # `|| published=$?` is required: under `set -e` a bare call returning
+    # non-zero would abort the script before the case statement runs.
+    published=0
+    crate_is_published "$name" "$version" || published=$?
+    case "$published" in
+      1)
+        # Bump in flight: the local version does not exist on crates.io, so the
+        # pin cannot point at it yet. publish.yml refreshes it after publishing.
+        echo "  ${CYAN}bump${NC} $name: workspace $version not yet on crates.io (registry copy pinned at $pinned)"
+        echo "         no action — the publish workflow refreshes this pin once $version is published"
+        bumping=1
+        ;;
+      2)
+        # Could not reach crates.io. Fail closed: a guard that passes when it
+        # cannot verify is not a guard, and this ran green on every other job
+        # in the same workflow, so the network is normally fine.
+        echo "  ${RED}ERROR${NC} $name: could not reach crates.io to check whether $version is published"
+        echo "         re-run the job; if crates.io is down, merge on the other checks"
+        fail=1
+        ;;
+      *)
+        echo "  ${RED}STALE${NC} $name: workspace $version but Cargo.lock pins registry copy at $pinned"
+        echo "         fix: cargo update -p '$REGISTRY#$name@$pinned' --precise $version"
+        fail=1
+        ;;
+    esac
   fi
 done <<EOF
 $members
@@ -106,7 +154,11 @@ if [ "$found" -eq 0 ]; then
 fi
 
 if [ "$fail" -eq 0 ]; then
-  echo "${GREEN}All self-pins match the workspace versions.${NC}"
+  if [ "$bumping" -eq 1 ]; then
+    echo "${GREEN}No stale self-pins.${NC} A pending version bump is awaiting publish (see above)."
+  else
+    echo "${GREEN}All self-pins match the workspace versions.${NC}"
+  fi
 else
   echo "${RED}Cargo.lock pins a stale crates.io copy of a workspace crate.${NC}"
   echo "\`cargo publish --locked\` verifies dependent crates against that pinned copy,"

--- a/vta-mobile-core/src/resolver.rs
+++ b/vta-mobile-core/src/resolver.rs
@@ -12,6 +12,7 @@ use affinidi_did_resolver_cache_sdk::config::DIDCacheConfigBuilder;
 use tokio::sync::OnceCell;
 
 use crate::error::FfiError;
+use vta_sdk::protocol::matching::{DIDCOMM_SERVICE_TYPE, REST_SERVICE_TYPES};
 
 /// One process-wide caching resolver, lazily initialised on first use. The
 /// resolver caches immutable methods (key/peer) indefinitely, so repeated
@@ -55,7 +56,8 @@ pub async fn resolve_did(did: String) -> Result<String, FfiError> {
 /// mediator.
 #[derive(Debug, Clone, uniffi::Record)]
 pub struct VtaEndpoints {
-    /// REST base URL, from the `#vta-rest` (`VTARest`) service. `None` if the
+    /// REST base URL, from a REST service entry (`VTARest` for a VTA,
+    /// `TRQPRest` for a Trust Registry), matched by `type`. `None` if the
     /// VTA advertises no REST service.
     pub rest_base_url: Option<String>,
     /// Mediator DID, from the `#vta-didcomm` (`DIDCommMessaging`) service's
@@ -87,9 +89,16 @@ fn parse_vta_endpoints(doc: &serde_json::Value) -> VtaEndpoints {
             let id = svc.get("id").and_then(|v| v.as_str()).unwrap_or_default();
             let ty = svc.get("type").and_then(|v| v.as_str()).unwrap_or_default();
             let endpoint = svc.get("serviceEndpoint");
-            if id.ends_with("#vta-rest") || ty == "VTARest" {
+            // Match on `type` only. The `#id` fragment is an arbitrary label
+            // (R4.4): the OWF reference TSP implementation names its id
+            // `#tsp-transport` where Affinidi uses `#tsp`, for the same type,
+            // and a Trust Registry uses `#rest` for a `TRQPRest` service. A
+            // fragment check both misses valid services and can match the
+            // wrong one — a `#vta-rest`-fragmented DIDComm entry would have
+            // been read as REST here.
+            if REST_SERVICE_TYPES.contains(&ty) {
                 rest_base_url = endpoint_uri(endpoint);
-            } else if id.ends_with("#vta-didcomm") || ty == "DIDCommMessaging" {
+            } else if ty == DIDCOMM_SERVICE_TYPE {
                 mediator_did = endpoint_uri(endpoint);
             }
         }

--- a/vta-mobile-core/src/resolver.rs
+++ b/vta-mobile-core/src/resolver.rs
@@ -86,7 +86,6 @@ fn parse_vta_endpoints(doc: &serde_json::Value) -> VtaEndpoints {
     let mut mediator_did = None;
     if let Some(services) = doc.get("service").and_then(|s| s.as_array()) {
         for svc in services {
-            let id = svc.get("id").and_then(|v| v.as_str()).unwrap_or_default();
             let ty = svc.get("type").and_then(|v| v.as_str()).unwrap_or_default();
             let endpoint = svc.get("serviceEndpoint");
             // Match on `type` only. The `#id` fragment is an arbitrary label

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.19.12"
+version = "0.19.13"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/protocol/matching.rs
+++ b/vta-sdk/src/protocol/matching.rs
@@ -32,7 +32,29 @@ pub const DIDCOMM_SERVICE_TYPE: &str = "DIDCommMessaging";
 
 /// DID-document service `type` for the VTA REST endpoint. Kept in sync with
 /// `vta_service::operations::protocol::document::REST_SERVICE_TYPE`.
+///
+/// Correct for a VTA, and only for a VTA — it says "a VTA's REST API is behind
+/// this URL". Non-VTA services advertise their own REST type; see
+/// [`TRQP_REST_SERVICE_TYPE`].
 pub const REST_SERVICE_TYPE: &str = "VTARest";
+
+/// DID-document service `type` for a Trust Registry's REST/TRQP surface.
+///
+/// A Trust Registry is not a VTA, so it must not advertise [`REST_SERVICE_TYPE`]
+/// — that would promise a consumer a VTA's endpoints. `TRQPRest` names the
+/// interface actually served (TRQP over REST), matching how the sibling types
+/// name protocols rather than products. Kept in sync with
+/// `trust_registry::didcomm::did_document::REST_SERVICE_TYPE` in
+/// `affinidi-trust-registry-rs`.
+pub const TRQP_REST_SERVICE_TYPE: &str = "TRQPRest";
+
+/// Every service `type` that denotes a REST endpoint, in match order.
+///
+/// Matching a set rather than one string is what lets a consumer discover a
+/// VTA and a Trust Registry without either claiming the other's identity.
+/// Adding a REST-speaking service type here is the only change needed for it
+/// to become discoverable.
+pub const REST_SERVICE_TYPES: [&str; 2] = [REST_SERVICE_TYPE, TRQP_REST_SERVICE_TYPE];
 
 /// A transport protocol, in workspace preference order: TSP, then DIDComm,
 /// then REST. `Ord` follows that order — `Tsp` is the smallest (most
@@ -106,7 +128,7 @@ impl ServiceCapabilities {
                 caps.tsp.get_or_insert(uri);
             } else if service_has_type(svc, DIDCOMM_SERVICE_TYPE) {
                 caps.didcomm.get_or_insert(uri);
-            } else if service_has_type(svc, REST_SERVICE_TYPE) {
+            } else if REST_SERVICE_TYPES.iter().any(|t| service_has_type(svc, t)) {
                 caps.rest.get_or_insert(uri);
             }
         }
@@ -205,6 +227,42 @@ mod tests {
 
     fn doc(services: Value) -> Value {
         json!({ "id": "did:webvh:peer", "service": services })
+    }
+
+    /// A VTA advertises `VTARest`; a Trust Registry advertises `TRQPRest`.
+    /// Both are REST endpoints, and neither should have to claim the other's
+    /// service type to be discovered.
+    #[test]
+    fn both_rest_service_types_are_recognised() {
+        for ty in ["VTARest", "TRQPRest"] {
+            let caps = ServiceCapabilities::from_did_document(&doc(json!([
+                { "id": "did:webvh:peer#rest", "type": ty,
+                  "serviceEndpoint": "https://peer.example" }
+            ])));
+            assert_eq!(
+                caps.rest.as_deref(),
+                Some("https://peer.example"),
+                "{ty} must be recognised as a REST endpoint"
+            );
+            assert_eq!(caps.advertised(), vec![Protocol::Rest]);
+        }
+    }
+
+    /// A registry advertising only `TRQPRest` must be selectable over REST —
+    /// this is the case that previously yielded `NoMatchingProtocol`.
+    #[test]
+    fn trqp_rest_only_peer_is_selectable() {
+        let theirs = ServiceCapabilities::from_did_document(&doc(json!([
+            { "id": "did:webvh:registry#rest", "type": "TRQPRest",
+              "serviceEndpoint": "https://registry.example" }
+        ])));
+        let ours = ServiceCapabilities {
+            rest: Some("https://us.example".into()),
+            ..Default::default()
+        };
+        let chosen = select_protocol(&ours, &theirs, "did:webvh:registry").unwrap();
+        assert_eq!(chosen.protocol, Protocol::Rest);
+        assert_eq!(chosen.peer_endpoint, "https://registry.example");
     }
 
     #[test]


### PR DESCRIPTION
`ServiceCapabilities` matched REST on `"VTARest"` and nothing else (`matching.rs:109`).

That type is correct for a VTA — it says *a VTA's REST API is behind this URL* — but it made the type unusable as a generic "this peer speaks REST" marker. Any non-VTA service either had to **claim to be a VTA** or stay undiscoverable. A Trust Registry advertising its own type was invisible, so `select_protocol` returned `NoMatchingProtocol` for a peer that plainly spoke REST.

## Change

`REST_SERVICE_TYPES` now holds both:

| Type | Meaning |
|---|---|
| `VTARest` | a VTA's REST API — unchanged, still correct |
| `TRQPRest` | a Trust Registry's TRQP-over-REST surface |

Matching walks the set. VTAs are entirely unaffected — no producer changes, no wire change to any VTA DID document. Adding a REST-speaking service type in future is a one-line change to the array.

## Also: a fragment-matching bug in vta-mobile-core

`resolver.rs` matched services with:

```rust
if id.ends_with("#vta-rest") || ty == "VTARest" {
```

Matching on the `#id` fragment violates **R4.4** — the fragment is an arbitrary label. The check both **missed valid services** (a Trust Registry uses `#rest`) and could **match the wrong one**: a DIDComm entry that happened to be fragmented `#vta-rest` would have been read as the REST endpoint. Now matches on `type` alone, via the shared constants.

## Why not rename VTARest

Considered and rejected. `VTARest` is accurate for a VTA, and every deployed VTA has already published it into its `did:webvh` log — removing consumer support would strand them until each DID is updated, which needs each VTA's update key. The category error is only in *reusing* it for non-VTA services, and matching a set fixes exactly that without a wire migration.

## Testing

179 vta-sdk + 45 vta-mobile-core tests pass; clippy clean; `cargo fmt` applied. Two new tests:

- `both_rest_service_types_are_recognised` — a `VTARest` peer and a `TRQPRest` peer are each found
- `trqp_rest_only_peer_is_selectable` — the case that previously yielded `NoMatchingProtocol`

## Related

Counterpart to affinidi/affinidi-trust-registry-rs#100, where the Trust Registry starts advertising `TRQPRest`. **This should land first** — until it does, the registry's REST surface is advertised but not discovered by vta-sdk consumers.