### PR TITLE
fix(vtc): retire superseded auth Trust Tasks, add manifest census

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,11 +168,25 @@ jobs:
           fetch-depth: 0
       - name: Version-bump guard for changed publishable crates
         run: bash scripts/check-version-bumps.sh "${{ github.event.pull_request.base.sha }}"
-      # Sibling guard: the bump can be correct and the release still break if
-      # Cargo.lock pins a stale crates.io copy of one of our own crates (a
-      # transitive dev-dep pulls vta-sdk back in from the registry). `cargo
-      # publish --locked` verifies dependents against that pinned copy. See the
-      # script header. Not diff-based, so it needs no base ref.
+
+  lockfile-self-pins:
+    # Sibling guard to release-guards: the version bump can be correct and the
+    # release still break if Cargo.lock pins a stale crates.io copy of one of
+    # our own crates (a transitive dev-dep pulls vta-sdk back in from the
+    # registry). `cargo publish --locked` verifies dependents against that
+    # pinned copy. See the script header.
+    #
+    # Its own job, and deliberately NOT PR-only. This check compares workspace
+    # manifest versions against Cargo.lock — a whole-tree invariant, not a diff
+    # against a base ref — so it is meaningful on a push. While it lived as a
+    # step inside release-guards it inherited that job's `if: pull_request`,
+    # which meant a merge could leave the lockfile stale, main stayed green,
+    # and the failure surfaced on whichever unrelated PR opened next. That
+    # misattribution happened twice (#706, #711).
+    name: lockfile self-pins
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
       - name: Lockfile self-pin guard
         run: bash scripts/check-lockfile-self-pins.sh
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,7 +416,7 @@ dependencies = [
  "trust-tasks-rs",
  "url",
  "uuid",
- "vta-sdk 0.19.12",
+ "vta-sdk 0.19.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -10142,39 +10142,6 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.19.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c166f554748e39b6cbd97a4ef8becd3afc1b5913166f35f0e1e4c81727395e"
-dependencies = [
- "affinidi-crypto",
- "affinidi-did-resolver-cache-sdk",
- "affinidi-messaging-core",
- "affinidi-messaging-delivery",
- "affinidi-messaging-didcomm",
- "affinidi-openid4vci",
- "affinidi-openid4vp",
- "affinidi-tdk",
- "base64 0.22.1",
- "chrono",
- "curve25519-dalek",
- "didwebvh-rs",
- "ed25519-dalek",
- "futures-util",
- "getrandom 0.4.3",
- "multibase",
- "reqwest 0.13.4",
- "serde",
- "serde_json",
- "sha2 0.11.0",
- "thiserror 2.0.19",
- "tokio",
- "tracing",
- "url",
- "uuid",
-]
-
-[[package]]
-name = "vta-sdk"
 version = "0.19.13"
 dependencies = [
  "affinidi-bbs",
@@ -10231,6 +10198,39 @@ dependencies = [
  "x25519-dalek",
  "x509-parser 0.18.1",
  "zeroize",
+]
+
+[[package]]
+name = "vta-sdk"
+version = "0.19.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8bfad45d6b4c95417240e933bcdaf21502f82cf0b8dfc72d7773815388b94b0"
+dependencies = [
+ "affinidi-crypto",
+ "affinidi-did-resolver-cache-sdk",
+ "affinidi-messaging-core",
+ "affinidi-messaging-delivery",
+ "affinidi-messaging-didcomm",
+ "affinidi-openid4vci",
+ "affinidi-openid4vp",
+ "affinidi-tdk",
+ "base64 0.22.1",
+ "chrono",
+ "curve25519-dalek",
+ "didwebvh-rs",
+ "ed25519-dalek",
+ "futures-util",
+ "getrandom 0.4.3",
+ "multibase",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "thiserror 2.0.19",
+ "tokio",
+ "tracing",
+ "url",
+ "uuid",
 ]
 
 [[package]]

--- a/trust-tasks/acl/legacy/entry/1.0/spec.md
+++ b/trust-tasks/acl/legacy/entry/1.0/spec.md
@@ -1,7 +1,7 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/acl/legacy/entry/1.0
 title: VTC Legacy — ACL Entry
-status: Draft
+status: draft
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/acl/legacy/manage/1.0/spec.md
+++ b/trust-tasks/acl/legacy/manage/1.0/spec.md
@@ -1,7 +1,7 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/acl/legacy/manage/1.0
 title: VTC Legacy — ACL Collection
-status: Draft
+status: draft
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/admin-ui/build-info/1.0/spec.md
+++ b/trust-tasks/admin-ui/build-info/1.0/spec.md
@@ -1,7 +1,7 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/admin-ui/build-info/1.0
 title: VTC — Admin UX build info
-status: Draft
+status: draft
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/admin/bootstrap/1.0/spec.md
+++ b/trust-tasks/admin/bootstrap/1.0/spec.md
@@ -1,7 +1,7 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/admin/bootstrap/1.0
 title: VTC Admin — Bootstrap
-status: Draft
+status: draft
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/admin/config/export/1.0/spec.md
+++ b/trust-tasks/admin/config/export/1.0/spec.md
@@ -1,7 +1,7 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/admin/config/export/1.0
 title: VTC Admin — Export Config
-status: Draft
+status: draft
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/admin/config/import/1.0/spec.md
+++ b/trust-tasks/admin/config/import/1.0/spec.md
@@ -1,7 +1,7 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/admin/config/import/1.0
 title: VTC Admin — Import Config
-status: Draft
+status: draft
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/admin/config/manage/1.0/spec.md
+++ b/trust-tasks/admin/config/manage/1.0/spec.md
@@ -1,7 +1,7 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/admin/config/manage/1.0
 title: VTC — Admin Runtime Configuration (Show + Patch)
-status: Draft
+status: draft
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/admin/config/reload/1.0/spec.md
+++ b/trust-tasks/admin/config/reload/1.0/spec.md
@@ -1,7 +1,7 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/admin/config/reload/1.0
 title: VTC Admin — Reload Config
-status: Draft
+status: draft
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/admin/config/restart/1.0/spec.md
+++ b/trust-tasks/admin/config/restart/1.0/spec.md
@@ -1,7 +1,7 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/admin/config/restart/1.0
 title: VTC Admin — Restart Daemon
-status: Draft
+status: draft
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/admin/passkeys/list/1.0/spec.md
+++ b/trust-tasks/admin/passkeys/list/1.0/spec.md
@@ -1,7 +1,7 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/admin/passkeys/list/1.0
 title: VTC Admin — List Passkeys
-status: Draft
+status: draft
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/admin/passkeys/register/1.0/spec.md
+++ b/trust-tasks/admin/passkeys/register/1.0/spec.md
@@ -1,7 +1,7 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/admin/passkeys/register/1.0
 title: VTC Admin — Register Passkey
-status: Draft
+status: draft
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/admin/passkeys/revoke/1.0/spec.md
+++ b/trust-tasks/admin/passkeys/revoke/1.0/spec.md
@@ -1,7 +1,7 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/admin/passkeys/revoke/1.0
 title: VTC Admin — Revoke Passkey
-status: Draft
+status: draft
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/audit/list/1.0/spec.md
+++ b/trust-tasks/audit/list/1.0/spec.md
@@ -1,7 +1,7 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/audit/list/1.0
 title: VTC — List audit log entries
-status: Draft
+status: draft
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/audit/verify/1.0/spec.md
+++ b/trust-tasks/audit/verify/1.0/spec.md
@@ -1,7 +1,7 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/audit/verify/1.0
 title: VTC — Verify the audit hash chain
-status: Draft
+status: draft
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/auth/admin-login/1.0/spec.md
+++ b/trust-tasks/auth/admin-login/1.0/spec.md
@@ -1,7 +1,7 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/auth/admin-login/1.0
 title: VTC — Admin SPA cookie session mint
-status: Draft
+status: draft
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/auth/legacy/authenticate/1.0/spec.md
+++ b/trust-tasks/auth/legacy/authenticate/1.0/spec.md
@@ -1,7 +1,8 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/auth/legacy/authenticate/1.0
 title: VTC Legacy — Authenticate
-status: Draft
+status: retired
+supersededBy: https://trusttasks.org/spec/auth/authenticate/0.1
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/auth/legacy/challenge/1.0/spec.md
+++ b/trust-tasks/auth/legacy/challenge/1.0/spec.md
@@ -1,7 +1,8 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/auth/legacy/challenge/1.0
 title: VTC Legacy — Auth Challenge
-status: Draft
+status: retired
+supersededBy: https://trusttasks.org/spec/auth/challenge/0.1
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/auth/legacy/refresh/1.0/spec.md
+++ b/trust-tasks/auth/legacy/refresh/1.0/spec.md
@@ -1,7 +1,8 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/auth/legacy/refresh/1.0
 title: VTC Legacy — Refresh Token
-status: Draft
+status: retired
+supersededBy: https://trusttasks.org/spec/auth/refresh/0.1
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/auth/legacy/sessions/manage/1.0/spec.md
+++ b/trust-tasks/auth/legacy/sessions/manage/1.0/spec.md
@@ -1,7 +1,8 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/auth/legacy/sessions/manage/1.0
 title: VTC Legacy — Sessions Management
-status: Draft
+status: retired
+supersededBy: https://trusttasks.org/spec/auth/sessions/list/0.1
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/auth/legacy/sessions/revoke/1.0/spec.md
+++ b/trust-tasks/auth/legacy/sessions/revoke/1.0/spec.md
@@ -1,7 +1,8 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/auth/legacy/sessions/revoke/1.0
 title: VTC Legacy — Revoke Single Session
-status: Draft
+status: retired
+supersededBy: https://trusttasks.org/spec/auth/revoke-session/0.1
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/auth/recognise/1.0/spec.md
+++ b/trust-tasks/auth/recognise/1.0/spec.md
@@ -1,7 +1,7 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/auth/recognise/1.0
 title: VTC — Cross-Community Session Mint
-status: Draft
+status: draft
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/auth/sign-out/1.0/spec.md
+++ b/trust-tasks/auth/sign-out/1.0/spec.md
@@ -1,7 +1,8 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/auth/sign-out/1.0
 title: VTC — Revoke session and clear browser cookies
-status: Draft
+status: retired
+supersededBy: https://trusttasks.org/spec/auth/revoke-session/0.1
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/auth/whoami/1.0/spec.md
+++ b/trust-tasks/auth/whoami/1.0/spec.md
@@ -1,7 +1,8 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/auth/whoami/1.0
 title: VTC — Inspect access-token claims
-status: Draft
+status: retired
+supersededBy: https://trusttasks.org/spec/auth/whoami/0.1
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/community/profile/manage/1.0/spec.md
+++ b/trust-tasks/community/profile/manage/1.0/spec.md
@@ -1,7 +1,7 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/community/profile/manage/1.0
 title: VTC — Community Profile (Show + Update)
-status: Draft
+status: draft
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/config/legacy/manage/1.0/spec.md
+++ b/trust-tasks/config/legacy/manage/1.0/spec.md
@@ -1,7 +1,7 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/config/legacy/manage/1.0
 title: VTC Legacy — Config Management
-status: Draft
+status: draft
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/credential-exchange/issue/1.0/spec.md
+++ b/trust-tasks/credential-exchange/issue/1.0/spec.md
@@ -1,7 +1,7 @@
 ---
 id: https://trusttasks.org/spec/credential-exchange/issue/1.0
 title: Credential Exchange — Issue
-status: Draft
+status: draft
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/credential-exchange/offer/1.0/spec.md
+++ b/trust-tasks/credential-exchange/offer/1.0/spec.md
@@ -1,7 +1,7 @@
 ---
 id: https://trusttasks.org/spec/credential-exchange/offer/1.0
 title: Credential Exchange — Offer
-status: Draft
+status: draft
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/credential-exchange/present/1.0/spec.md
+++ b/trust-tasks/credential-exchange/present/1.0/spec.md
@@ -1,7 +1,7 @@
 ---
 id: https://trusttasks.org/spec/credential-exchange/present/1.0
 title: Credential Exchange — Present
-status: Draft
+status: draft
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/credential-exchange/query/1.0/spec.md
+++ b/trust-tasks/credential-exchange/query/1.0/spec.md
@@ -1,7 +1,7 @@
 ---
 id: https://trusttasks.org/spec/credential-exchange/query/1.0
 title: Credential Exchange — Query
-status: Draft
+status: draft
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/credential-exchange/request/1.0/spec.md
+++ b/trust-tasks/credential-exchange/request/1.0/spec.md
@@ -1,7 +1,7 @@
 ---
 id: https://trusttasks.org/spec/credential-exchange/request/1.0
 title: Credential Exchange — Request
-status: Draft
+status: draft
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/credentials/endorsements/issue/1.0/spec.md
+++ b/trust-tasks/credentials/endorsements/issue/1.0/spec.md
@@ -1,7 +1,7 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/credentials/endorsements/issue/1.0
 title: VTC — Custom Endorsement Issue
-status: Draft
+status: draft
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/credentials/endorsements/list/1.0/spec.md
+++ b/trust-tasks/credentials/endorsements/list/1.0/spec.md
@@ -1,7 +1,7 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/credentials/endorsements/list/1.0
 title: VTC — Custom Endorsement List
-status: Draft
+status: draft
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/credentials/endorsements/revoke/1.0/spec.md
+++ b/trust-tasks/credentials/endorsements/revoke/1.0/spec.md
@@ -1,7 +1,7 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/credentials/endorsements/revoke/1.0
 title: VTC — Custom Endorsement Revoke
-status: Draft
+status: draft
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/credentials/endorsements/show/1.0/spec.md
+++ b/trust-tasks/credentials/endorsements/show/1.0/spec.md
@@ -1,7 +1,7 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/credentials/endorsements/show/1.0
 title: VTC — Custom Endorsement Show
-status: Draft
+status: draft
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/endorsement-types/delete/1.0/spec.md
+++ b/trust-tasks/endorsement-types/delete/1.0/spec.md
@@ -1,7 +1,7 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/endorsement-types/delete/1.0
 title: VTC — Endorsement Type Delete
-status: Draft
+status: draft
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/endorsement-types/list/1.0/spec.md
+++ b/trust-tasks/endorsement-types/list/1.0/spec.md
@@ -1,7 +1,7 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/endorsement-types/list/1.0
 title: VTC — Endorsement Type List
-status: Draft
+status: draft
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/endorsement-types/register/1.0/spec.md
+++ b/trust-tasks/endorsement-types/register/1.0/spec.md
@@ -1,7 +1,7 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/endorsement-types/register/1.0
 title: VTC — Endorsement Type Register
-status: Draft
+status: draft
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/health/diagnostics/1.0/spec.md
+++ b/trust-tasks/health/diagnostics/1.0/spec.md
@@ -1,7 +1,7 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/health/diagnostics/1.0
 title: VTC — Trust-Registry Reconciler Diagnostics
-status: Draft
+status: draft
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/index.json
+++ b/trust-tasks/index.json
@@ -7,435 +7,443 @@
   "tasks": [
     {
       "id": "https://trusttasks.org/openvtc/vtc/auth/legacy/challenge/1.0",
-      "status": "Draft",
+      "status": "retired",
       "path": "auth/legacy/challenge/1.0",
-      "rest": "POST /v1/auth/challenge"
+      "rest": "POST /v1/auth/challenge",
+      "supersededBy": "https://trusttasks.org/spec/auth/challenge/0.1"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/auth/legacy/authenticate/1.0",
-      "status": "Draft",
+      "status": "retired",
       "path": "auth/legacy/authenticate/1.0",
-      "rest": "POST /v1/auth/"
+      "rest": "POST /v1/auth/",
+      "supersededBy": "https://trusttasks.org/spec/auth/authenticate/0.1"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/auth/legacy/refresh/1.0",
-      "status": "Draft",
+      "status": "retired",
       "path": "auth/legacy/refresh/1.0",
-      "rest": "POST /v1/auth/refresh"
+      "rest": "POST /v1/auth/refresh",
+      "supersededBy": "https://trusttasks.org/spec/auth/refresh/0.1"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/auth/admin-login/1.0",
-      "status": "Draft",
+      "status": "draft",
       "path": "auth/admin-login/1.0",
       "rest": "POST /v1/auth/admin-login"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/auth/legacy/sessions/manage/1.0",
-      "status": "Draft",
+      "status": "retired",
       "path": "auth/legacy/sessions/manage/1.0",
-      "rest": "GET, DELETE /v1/auth/sessions"
+      "rest": "GET, DELETE /v1/auth/sessions",
+      "supersededBy": "https://trusttasks.org/spec/auth/sessions/list/0.1"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/auth/legacy/sessions/revoke/1.0",
-      "status": "Draft",
+      "status": "retired",
       "path": "auth/legacy/sessions/revoke/1.0",
-      "rest": "DELETE /v1/auth/sessions/{session_id}"
+      "rest": "DELETE /v1/auth/sessions/{session_id}",
+      "supersededBy": "https://trusttasks.org/spec/auth/revoke-session/0.1"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/auth/whoami/1.0",
-      "status": "Draft",
+      "status": "retired",
       "path": "auth/whoami/1.0",
-      "rest": "GET /v1/auth/whoami"
+      "rest": "GET /v1/auth/whoami",
+      "supersededBy": "https://trusttasks.org/spec/auth/whoami/0.1"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/auth/sign-out/1.0",
-      "status": "Draft",
+      "status": "retired",
       "path": "auth/sign-out/1.0",
-      "rest": "POST /v1/auth/sign-out"
+      "rest": "POST /v1/auth/sign-out",
+      "supersededBy": "https://trusttasks.org/spec/auth/revoke-session/0.1"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/audit/list/1.0",
-      "status": "Draft",
+      "status": "draft",
       "path": "audit/list/1.0",
       "rest": "GET /v1/audit"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/audit/verify/1.0",
-      "status": "Draft",
+      "status": "draft",
       "path": "audit/verify/1.0",
       "rest": "GET /v1/audit/verify"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/config/legacy/manage/1.0",
-      "status": "Draft",
+      "status": "draft",
       "path": "config/legacy/manage/1.0",
       "rest": "GET, PATCH /v1/config"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/acl/legacy/manage/1.0",
-      "status": "Draft",
+      "status": "draft",
       "path": "acl/legacy/manage/1.0",
       "rest": "GET, POST /v1/acl"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/acl/legacy/entry/1.0",
-      "status": "Draft",
+      "status": "draft",
       "path": "acl/legacy/entry/1.0",
       "rest": "GET, PATCH, DELETE /v1/acl/{did}"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/community/profile/manage/1.0",
-      "status": "Draft",
+      "status": "draft",
       "path": "community/profile/manage/1.0",
       "rest": "GET, PUT /v1/community/profile"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/admin/config/manage/1.0",
-      "status": "Draft",
+      "status": "draft",
       "path": "admin/config/manage/1.0",
       "rest": "GET, PATCH /v1/admin/config"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/install/claim/start/1.0",
-      "status": "Draft",
+      "status": "draft",
       "path": "install/claim/start/1.0",
       "rest": "POST /v1/install/claim/start"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/install/claim/finish/1.0",
-      "status": "Draft",
+      "status": "draft",
       "path": "install/claim/finish/1.0",
       "rest": "POST /v1/install/claim/finish"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/admin/bootstrap/1.0",
-      "status": "Draft",
+      "status": "draft",
       "path": "admin/bootstrap/1.0",
       "rest": "POST /v1/admin/bootstrap"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/admin/passkeys/list/1.0",
-      "status": "Draft",
+      "status": "draft",
       "path": "admin/passkeys/list/1.0",
       "rest": "GET /v1/admin/passkeys"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/admin/passkeys/register/1.0",
-      "status": "Draft",
+      "status": "draft",
       "path": "admin/passkeys/register/1.0",
       "rest": "POST /v1/admin/passkeys/register/{start,finish}"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/admin/passkeys/revoke/1.0",
-      "status": "Draft",
+      "status": "draft",
       "path": "admin/passkeys/revoke/1.0",
       "rest": "POST /v1/admin/passkeys/revoke/{start,finish}"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/admin/config/reload/1.0",
-      "status": "Draft",
+      "status": "draft",
       "path": "admin/config/reload/1.0",
       "rest": "POST /v1/admin/config/reload"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/admin/config/restart/1.0",
-      "status": "Draft",
+      "status": "draft",
       "path": "admin/config/restart/1.0",
       "rest": "POST /v1/admin/config/restart"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/admin/config/export/1.0",
-      "status": "Draft",
+      "status": "draft",
       "path": "admin/config/export/1.0",
       "rest": "POST /v1/admin/config/export"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/admin/config/import/1.0",
-      "status": "Draft",
+      "status": "draft",
       "path": "admin/config/import/1.0",
       "rest": "POST /v1/admin/config/import"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/members/list/1.0",
-      "status": "Draft",
+      "status": "draft",
       "path": "members/list/1.0",
       "rest": "GET /v1/members"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/members/show/1.0",
-      "status": "Draft",
+      "status": "draft",
       "path": "members/show/1.0",
       "rest": "GET /v1/members/{did}"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/members/update/1.0",
-      "status": "Draft",
+      "status": "draft",
       "path": "members/update/1.0",
       "rest": "PATCH /v1/members/{did}"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/members/promote-to-admin/1.0",
-      "status": "Draft",
+      "status": "draft",
       "path": "members/promote-to-admin/1.0",
       "rest": "POST /v1/members/{did}/promote-to-admin/{start,finish}"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/spec/join-requests/submit/1.0",
-      "status": "Draft",
+      "status": "draft",
       "path": "join-requests/submit/1.0",
       "rest": "POST /v1/trust-tasks",
       "didcomm": "https://trusttasks.org/openvtc/vtc/spec/join-requests/submit/1.0"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/join-requests/list/1.0",
-      "status": "Draft",
+      "status": "draft",
       "path": "join-requests/list/1.0",
       "rest": "GET /v1/join-requests"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/join-requests/show/1.0",
-      "status": "Draft",
+      "status": "draft",
       "path": "join-requests/show/1.0",
       "rest": "GET /v1/join-requests/{id}"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/join-requests/approve/1.0",
-      "status": "Draft",
+      "status": "draft",
       "path": "join-requests/approve/1.0",
       "rest": "POST /v1/join-requests/{id}/approve"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/join-requests/reject/1.0",
-      "status": "Draft",
+      "status": "draft",
       "path": "join-requests/reject/1.0",
       "rest": "POST /v1/join-requests/{id}/reject"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/spec/join-requests/accept/1.0",
-      "status": "Draft",
+      "status": "draft",
       "path": "join-requests/accept/1.0",
       "rest": "POST /v1/trust-tasks",
       "didcomm": "https://trusttasks.org/openvtc/vtc/spec/join-requests/accept/1.0"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/spec/join-requests/manifest/1.0",
-      "status": "Draft",
+      "status": "draft",
       "path": "join-requests/manifest/1.0",
       "rest": "POST /v1/trust-tasks",
       "didcomm": "https://trusttasks.org/openvtc/vtc/spec/join-requests/manifest/1.0"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/spec/join-requests/status/1.0",
-      "status": "Draft",
+      "status": "draft",
       "path": "join-requests/status/1.0",
       "rest": "POST /v1/trust-tasks",
       "didcomm": "https://trusttasks.org/openvtc/vtc/spec/join-requests/status/1.0"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/members/self-remove/1.0",
-      "status": "Draft",
+      "status": "draft",
       "path": "members/self-remove/1.0",
       "rest": "DELETE /v1/members/me",
       "didcomm": "https://trusttasks.org/openvtc/vtc/members/self-remove/1.0"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/members/admin-remove/1.0",
-      "status": "Draft",
+      "status": "draft",
       "path": "members/admin-remove/1.0",
       "rest": "DELETE /v1/members/{did}"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/policies/upload/1.0",
-      "status": "Draft",
+      "status": "draft",
       "path": "policies/upload/1.0",
       "rest": "POST /v1/policies"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/policies/activate/1.0",
-      "status": "Draft",
+      "status": "draft",
       "path": "policies/activate/1.0",
       "rest": "POST /v1/policies/{id}/activate"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/policies/test/1.0",
-      "status": "Draft",
+      "status": "draft",
       "path": "policies/test/1.0",
       "rest": "POST /v1/policies/{id}/test"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/policies/list/1.0",
-      "status": "Draft",
+      "status": "draft",
       "path": "policies/list/1.0",
       "rest": "GET /v1/policies"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/policies/show/1.0",
-      "status": "Draft",
+      "status": "draft",
       "path": "policies/show/1.0",
       "rest": "GET /v1/policies/{id}"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/members/renew/1.0",
-      "status": "Draft",
+      "status": "draft",
       "path": "members/renew/1.0",
       "rest": "POST /v1/members/me/renew"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/members/rotate-challenge/1.0",
-      "status": "Draft",
+      "status": "draft",
       "path": "members/rotate-challenge/1.0",
       "rest": "POST /v1/members/me/rotate/challenge"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/members/rotate/1.0",
-      "status": "Draft",
+      "status": "draft",
       "path": "members/rotate/1.0",
       "rest": "POST /v1/members/me/rotate"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/status-lists/show/1.0",
-      "status": "Draft",
+      "status": "draft",
       "path": "status-lists/show/1.0",
       "rest": "GET /v1/status-lists/{purpose}",
       "trust_task_header_exempt": true
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/health/diagnostics/1.0",
-      "status": "Draft",
+      "status": "draft",
       "path": "health/diagnostics/1.0",
       "rest": "GET /v1/health/diagnostics"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/auth/recognise/1.0",
-      "status": "Draft",
+      "status": "draft",
       "path": "auth/recognise/1.0",
       "rest": "POST /v1/auth/recognise"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/members/personhood/challenge/1.0",
-      "status": "Draft",
+      "status": "draft",
       "path": "members/personhood/challenge/1.0",
       "rest": "POST /v1/members/{did}/personhood/challenge"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/members/personhood/assert/1.0",
-      "status": "Draft",
+      "status": "draft",
       "path": "members/personhood/assert/1.0",
       "rest": "POST /v1/members/{did}/personhood"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/members/personhood/revoke/1.0",
-      "status": "Draft",
+      "status": "draft",
       "path": "members/personhood/revoke/1.0",
       "rest": "DELETE /v1/members/{did}/personhood"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/relationships/publish/1.0",
-      "status": "Draft",
+      "status": "draft",
       "path": "relationships/publish/1.0",
       "rest": "POST /v1/relationships"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/relationships/list/1.0",
-      "status": "Draft",
+      "status": "draft",
       "path": "relationships/list/1.0",
       "rest": "GET /v1/members/{did}/relationships"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/relationships/revoke/1.0",
-      "status": "Draft",
+      "status": "draft",
       "path": "relationships/revoke/1.0",
       "rest": "DELETE /v1/relationships/{id}"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/endorsement-types/register/1.0",
-      "status": "Draft",
+      "status": "draft",
       "path": "endorsement-types/register/1.0",
       "rest": "POST /v1/endorsement-types"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/endorsement-types/list/1.0",
-      "status": "Draft",
+      "status": "draft",
       "path": "endorsement-types/list/1.0",
       "rest": "GET /v1/endorsement-types"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/endorsement-types/delete/1.0",
-      "status": "Draft",
+      "status": "draft",
       "path": "endorsement-types/delete/1.0",
       "rest": "DELETE /v1/endorsement-types/{type_uri}"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/credentials/endorsements/issue/1.0",
-      "status": "Draft",
+      "status": "draft",
       "path": "credentials/endorsements/issue/1.0",
       "rest": "POST /v1/credentials/endorsements"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/credentials/endorsements/list/1.0",
-      "status": "Draft",
+      "status": "draft",
       "path": "credentials/endorsements/list/1.0",
       "rest": "GET /v1/credentials/endorsements"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/credentials/endorsements/show/1.0",
-      "status": "Draft",
+      "status": "draft",
       "path": "credentials/endorsements/show/1.0",
       "rest": "GET /v1/credentials/endorsements/{id}"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/credentials/endorsements/revoke/1.0",
-      "status": "Draft",
+      "status": "draft",
       "path": "credentials/endorsements/revoke/1.0",
       "rest": "DELETE /v1/credentials/endorsements/{id}"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/website/files/list/1.0",
-      "status": "Draft",
+      "status": "draft",
       "path": "website/files/list/1.0",
       "rest": "GET /v1/website/files"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/website/files/show/1.0",
-      "status": "Draft",
+      "status": "draft",
       "path": "website/files/show/1.0",
       "rest": "GET /v1/website/files/{*path}"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/website/files/write/1.0",
-      "status": "Draft",
+      "status": "draft",
       "path": "website/files/write/1.0",
       "rest": "PUT /v1/website/files/{*path}"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/website/files/delete/1.0",
-      "status": "Draft",
+      "status": "draft",
       "path": "website/files/delete/1.0",
       "rest": "DELETE /v1/website/files/{*path}"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/website/deploy/1.0",
-      "status": "Draft",
+      "status": "draft",
       "path": "website/deploy/1.0",
       "rest": "POST /v1/website/deploy"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/website/generations/list/1.0",
-      "status": "Draft",
+      "status": "draft",
       "path": "website/generations/list/1.0",
       "rest": "GET /v1/website/generations"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/website/rollback/1.0",
-      "status": "Draft",
+      "status": "draft",
       "path": "website/rollback/1.0",
       "rest": "POST /v1/website/rollback/{gen}"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/admin-ui/build-info/1.0",
-      "status": "Draft",
+      "status": "draft",
       "path": "admin-ui/build-info/1.0",
-      "rest": "GET /admin/build-info.json"
+      "rest": "GET /admin/build-info.json",
+      "trust_task_header_exempt": true
     }
   ]
 }

--- a/trust-tasks/install/claim/finish/1.0/spec.md
+++ b/trust-tasks/install/claim/finish/1.0/spec.md
@@ -1,7 +1,7 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/install/claim/finish/1.0
 title: VTC Install — Claim (Finish)
-status: Draft
+status: draft
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/install/claim/start/1.0/spec.md
+++ b/trust-tasks/install/claim/start/1.0/spec.md
@@ -1,7 +1,7 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/install/claim/start/1.0
 title: VTC Install — Claim (Start)
-status: Draft
+status: draft
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/join-requests/accept/1.0/spec.md
+++ b/trust-tasks/join-requests/accept/1.0/spec.md
@@ -1,7 +1,7 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/spec/join-requests/accept/1.0
 title: VTC Join Requests — Accept (reciprocal VMC)
-status: Draft
+status: draft
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/join-requests/approve/1.0/spec.md
+++ b/trust-tasks/join-requests/approve/1.0/spec.md
@@ -1,7 +1,7 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/join-requests/approve/1.0
 title: VTC Join Requests — Approve
-status: Draft
+status: draft
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/join-requests/list/1.0/spec.md
+++ b/trust-tasks/join-requests/list/1.0/spec.md
@@ -1,7 +1,7 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/join-requests/list/1.0
 title: VTC Join Requests — List
-status: Draft
+status: draft
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/join-requests/manifest/1.0/spec.md
+++ b/trust-tasks/join-requests/manifest/1.0/spec.md
@@ -1,7 +1,7 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/spec/join-requests/manifest/1.0
 title: VTC Join Requests — Manifest (discovery)
-status: Draft
+status: draft
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/join-requests/reject/1.0/spec.md
+++ b/trust-tasks/join-requests/reject/1.0/spec.md
@@ -1,7 +1,7 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/join-requests/reject/1.0
 title: VTC Join Requests — Reject
-status: Draft
+status: draft
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/join-requests/show/1.0/spec.md
+++ b/trust-tasks/join-requests/show/1.0/spec.md
@@ -1,7 +1,7 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/join-requests/show/1.0
 title: VTC Join Requests — Show
-status: Draft
+status: draft
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/join-requests/status/1.0/spec.md
+++ b/trust-tasks/join-requests/status/1.0/spec.md
@@ -1,7 +1,7 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/spec/join-requests/status/1.0
 title: VTC Join Requests — Status (applicant poll)
-status: Draft
+status: draft
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/join-requests/submit/1.0/spec.md
+++ b/trust-tasks/join-requests/submit/1.0/spec.md
@@ -1,7 +1,7 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/spec/join-requests/submit/1.0
 title: VTC Join Requests — Submit (the ceremony `request` verb)
-status: Draft
+status: draft
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/members/admin-remove/1.0/spec.md
+++ b/trust-tasks/members/admin-remove/1.0/spec.md
@@ -1,7 +1,7 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/members/admin-remove/1.0
 title: VTC Members — Admin Remove
-status: Draft
+status: draft
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/members/list/1.0/spec.md
+++ b/trust-tasks/members/list/1.0/spec.md
@@ -1,7 +1,7 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/members/list/1.0
 title: VTC Members — List
-status: Draft
+status: draft
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/members/personhood/assert/1.0/spec.md
+++ b/trust-tasks/members/personhood/assert/1.0/spec.md
@@ -1,7 +1,7 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/members/personhood/assert/1.0
 title: VTC — Personhood Assert
-status: Draft
+status: draft
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/members/personhood/challenge/1.0/spec.md
+++ b/trust-tasks/members/personhood/challenge/1.0/spec.md
@@ -1,7 +1,7 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/members/personhood/challenge/1.0
 title: VTC — Personhood Assert Challenge
-status: Draft
+status: draft
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/members/personhood/revoke/1.0/spec.md
+++ b/trust-tasks/members/personhood/revoke/1.0/spec.md
@@ -1,7 +1,7 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/members/personhood/revoke/1.0
 title: VTC — Personhood Revoke
-status: Draft
+status: draft
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/members/promote-to-admin/1.0/spec.md
+++ b/trust-tasks/members/promote-to-admin/1.0/spec.md
@@ -1,7 +1,7 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/members/promote-to-admin/1.0
 title: VTC Members — Promote to Admin
-status: Draft
+status: draft
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/members/renew/1.0/spec.md
+++ b/trust-tasks/members/renew/1.0/spec.md
@@ -1,7 +1,7 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/members/renew/1.0
 title: VTC Members — Renew
-status: Draft
+status: draft
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/members/rotate-challenge/1.0/spec.md
+++ b/trust-tasks/members/rotate-challenge/1.0/spec.md
@@ -1,7 +1,7 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/members/rotate-challenge/1.0
 title: VTC Members — DID Rotation Challenge
-status: Draft
+status: draft
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/members/rotate/1.0/spec.md
+++ b/trust-tasks/members/rotate/1.0/spec.md
@@ -1,7 +1,7 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/members/rotate/1.0
 title: VTC Members — DID Rotation
-status: Draft
+status: draft
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/members/self-remove/1.0/spec.md
+++ b/trust-tasks/members/self-remove/1.0/spec.md
@@ -1,7 +1,7 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/members/self-remove/1.0
 title: VTC Members — Self-Remove
-status: Draft
+status: draft
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/members/show/1.0/spec.md
+++ b/trust-tasks/members/show/1.0/spec.md
@@ -1,7 +1,7 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/members/show/1.0
 title: VTC Members — Show
-status: Draft
+status: draft
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/members/update/1.0/spec.md
+++ b/trust-tasks/members/update/1.0/spec.md
@@ -1,7 +1,7 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/members/update/1.0
 title: VTC Members — Update
-status: Draft
+status: draft
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/policies/activate/1.0/spec.md
+++ b/trust-tasks/policies/activate/1.0/spec.md
@@ -1,7 +1,7 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/policies/activate/1.0
 title: VTC Policies — Activate
-status: Draft
+status: draft
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/policies/list/1.0/spec.md
+++ b/trust-tasks/policies/list/1.0/spec.md
@@ -1,7 +1,7 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/policies/list/1.0
 title: VTC Policies — List
-status: Draft
+status: draft
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/policies/show/1.0/spec.md
+++ b/trust-tasks/policies/show/1.0/spec.md
@@ -1,7 +1,7 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/policies/show/1.0
 title: VTC Policies — Show
-status: Draft
+status: draft
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/policies/test/1.0/spec.md
+++ b/trust-tasks/policies/test/1.0/spec.md
@@ -1,7 +1,7 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/policies/test/1.0
 title: VTC Policies — Test
-status: Draft
+status: draft
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/policies/upload/1.0/spec.md
+++ b/trust-tasks/policies/upload/1.0/spec.md
@@ -1,7 +1,7 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/policies/upload/1.0
 title: VTC Policies — Upload
-status: Draft
+status: draft
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/relationships/list/1.0/spec.md
+++ b/trust-tasks/relationships/list/1.0/spec.md
@@ -1,7 +1,7 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/relationships/list/1.0
 title: VTC — VRC List per Member
-status: Draft
+status: draft
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/relationships/publish/1.0/spec.md
+++ b/trust-tasks/relationships/publish/1.0/spec.md
@@ -1,7 +1,7 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/relationships/publish/1.0
 title: VTC — VRC Publish
-status: Draft
+status: draft
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/relationships/revoke/1.0/spec.md
+++ b/trust-tasks/relationships/revoke/1.0/spec.md
@@ -1,7 +1,7 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/relationships/revoke/1.0
 title: VTC — VRC Revoke
-status: Draft
+status: draft
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/status-lists/show/1.0/spec.md
+++ b/trust-tasks/status-lists/show/1.0/spec.md
@@ -1,7 +1,7 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/status-lists/show/1.0
 title: VTC Status Lists — Show
-status: Draft
+status: draft
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/website/deploy/1.0/spec.md
+++ b/trust-tasks/website/deploy/1.0/spec.md
@@ -1,7 +1,7 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/website/deploy/1.0
 title: VTC — Website bundle deploy
-status: Draft
+status: draft
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/website/files/delete/1.0/spec.md
+++ b/trust-tasks/website/files/delete/1.0/spec.md
@@ -1,7 +1,7 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/website/files/delete/1.0
 title: VTC — Website file delete
-status: Draft
+status: draft
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/website/files/list/1.0/spec.md
+++ b/trust-tasks/website/files/list/1.0/spec.md
@@ -1,7 +1,7 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/website/files/list/1.0
 title: VTC — Website files list
-status: Draft
+status: draft
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/website/files/show/1.0/spec.md
+++ b/trust-tasks/website/files/show/1.0/spec.md
@@ -1,7 +1,7 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/website/files/show/1.0
 title: VTC — Website file show
-status: Draft
+status: draft
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/website/files/write/1.0/spec.md
+++ b/trust-tasks/website/files/write/1.0/spec.md
@@ -1,7 +1,7 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/website/files/write/1.0
 title: VTC — Website file write
-status: Draft
+status: draft
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/website/generations/list/1.0/spec.md
+++ b/trust-tasks/website/generations/list/1.0/spec.md
@@ -1,7 +1,7 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/website/generations/list/1.0
 title: VTC — Website generations list
-status: Draft
+status: draft
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/website/rollback/1.0/spec.md
+++ b/trust-tasks/website/rollback/1.0/spec.md
@@ -1,7 +1,7 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/website/rollback/1.0
 title: VTC — Website generation rollback
-status: Draft
+status: draft
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/vtc-service/tests/auth_audience.rs
+++ b/vtc-service/tests/auth_audience.rs
@@ -147,7 +147,10 @@ async fn mismatched_trust_task_header_returns_415() {
         .uri("/v1/acl")
         .header(
             "Trust-Task",
-            "https://trusttasks.org/openvtc/vtc/auth/legacy/challenge/1.0",
+            // Any well-formed URI the mount does not bind. Deliberately not a
+            // real task — this asserts the mismatch path, so it must not start
+            // passing if the task it names is ever wired here.
+            "https://trusttasks.org/openvtc/vtc/not-a-real-task/1.0",
         )
         .body(Body::empty())
         .unwrap();

--- a/vtc-service/tests/trust_task_manifest.rs
+++ b/vtc-service/tests/trust_task_manifest.rs
@@ -1,0 +1,293 @@
+//! Census: `trust-tasks/index.json` must agree with what the router
+//! actually enforces (#537 follow-up).
+//!
+//! The manifest is the publication source of truth for trusttasks.org.
+//! Nothing previously checked it against the code, so it drifted in both
+//! directions: entries for tasks no route binds, and live routes the
+//! manifest never published.
+//!
+//! Task bindings are attached as tower layers (`tt` / `ttl` in
+//! `routes/mod.rs`), so a built `Router` cannot be enumerated for them.
+//! This census therefore reads the wiring sites as source text. That is
+//! blunt, but the wiring is confined to a small number of files and a
+//! false positive here is a compile-visible string, not a silent pass.
+//!
+//! Both directions allow explicit, reasoned exceptions — see
+//! [`UNBOUND_OK`] and [`UNPUBLISHED_OK`]. Anything not listed there is a
+//! failure. Adding an entry to those tables is a deliberate act with a
+//! stated reason; letting the manifest drift is not.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+
+const PREFIX: &str = "https://trusttasks.org/openvtc/vtc/";
+
+/// Manifest entries that legitimately bind no route.
+///
+/// Overwhelmingly the Phase-0 shared-mount workaround: `TrustTaskRouter`
+/// has no per-method task selector, so two verbs sharing one mount
+/// collapse onto a single task. The unselected task still ships on disk
+/// and in the manifest so the soft-gate surface stays complete.
+const UNBOUND_OK: &[(&str, &str)] = &[
+    // -- shared mount, awaiting per-method Trust-Task selectors --
+    (
+        "credentials/endorsements/list/1.0",
+        "shares the endorsements show mount",
+    ),
+    (
+        "credentials/endorsements/revoke/1.0",
+        "shares the endorsements show mount",
+    ),
+    (
+        "endorsement-types/list/1.0",
+        "GET shares the register/1.0 mount",
+    ),
+    (
+        "join-requests/list/1.0",
+        "admin GET collapses onto submit/1.0",
+    ),
+    ("members/admin-remove/1.0", "shares the members/{did} mount"),
+    (
+        "members/personhood/revoke/1.0",
+        "DELETE shares the personhood mount",
+    ),
+    ("members/update/1.0", "PATCH shares the members/{did} mount"),
+    ("policies/list/1.0", "GET shares the upload/1.0 mount"),
+    ("policies/show/1.0", "GET shares the upload/1.0 mount"),
+    (
+        "website/files/delete/1.0",
+        "shares the website files show mount",
+    ),
+    (
+        "website/files/write/1.0",
+        "shares the website files show mount",
+    ),
+    // -- deliberately carry no Trust-Task descriptor --
+    ("status-lists/show/1.0", "header-exempt: external verifiers"),
+    (
+        "admin-ui/build-info/1.0",
+        "header-exempt: plain admin-UI route",
+    ),
+];
+
+/// Task URIs the code binds that the manifest does not publish.
+///
+/// These are a real backlog, not a design choice: whole feature families
+/// shipped after the manifest was last reconciled. Publishing them needs
+/// a `spec.md` + `schema.json` per task, so it is tracked separately
+/// rather than fixed here. This table exists to stop the backlog growing.
+const UNPUBLISHED_OK: &[(&str, &str)] = &[
+    ("admin/invites/manage/1.0", "unpublished backlog"),
+    ("admin/invites/revoke/1.0", "unpublished backlog"),
+    ("auth/admin-session/1.0", "unpublished backlog"),
+    ("auth/recognise/challenge/1.0", "unpublished backlog"),
+    ("backup/export/1.0", "unpublished backlog"),
+    ("backup/import/1.0", "unpublished backlog"),
+    ("ceremonies/list/1.0", "unpublished backlog"),
+    ("directory/query/1.0", "unpublished backlog"),
+    ("invitations/issue/1.0", "unpublished backlog"),
+    ("invitations/revoke/1.0", "unpublished backlog"),
+    ("members/purge/1.0", "unpublished backlog"),
+    ("members/removed/1.0", "unpublished backlog"),
+    ("members/request-vmc/1.0", "unpublished backlog"),
+    ("members/self-remove-receipt/1.0", "unpublished backlog"),
+    ("recognition/check/1.0", "unpublished backlog"),
+    ("relationships/graph/1.0", "unpublished backlog"),
+    (
+        "spec/join-requests/submit-receipt/1.0",
+        "unpublished backlog",
+    ),
+    ("spec/members/request-vmc/1.0", "unpublished backlog"),
+    ("spec/members/vmc/1.0", "unpublished backlog"),
+    // Phase-0 mount collapse: the admin GET list reuses this slug, while
+    // the real wire task is `spec/join-requests/submit/1.0`.
+    (
+        "join-requests/submit/1.0",
+        "mount-collapse alias of spec/join-requests/submit/1.0",
+    ),
+];
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("vtc-service has a parent")
+        .to_path_buf()
+}
+
+struct Task {
+    status: String,
+    path: String,
+}
+
+fn manifest() -> BTreeMap<String, Task> {
+    let raw = std::fs::read_to_string(workspace_root().join("trust-tasks/index.json"))
+        .expect("read trust-tasks/index.json");
+    let doc: serde_json::Value = serde_json::from_str(&raw).expect("parse index.json");
+    doc["tasks"]
+        .as_array()
+        .expect("tasks array")
+        .iter()
+        .map(|t| {
+            (
+                t["id"].as_str().expect("task id").to_owned(),
+                Task {
+                    status: t["status"].as_str().expect("task status").to_owned(),
+                    path: t["path"].as_str().expect("task path").to_owned(),
+                },
+            )
+        })
+        .collect()
+}
+
+/// Every `https://trusttasks.org/openvtc/vtc/...` literal in the crates
+/// that wire or dispatch tasks. Response types (`#response` suffix) are
+/// not separately published, so the fragment is trimmed off.
+fn bound_task_uris() -> BTreeSet<String> {
+    let root = workspace_root();
+    let mut found = BTreeSet::new();
+    for crate_src in ["vtc-service/src", "vta-sdk/src"] {
+        collect_from_dir(&root.join(crate_src), &mut found);
+    }
+    found
+}
+
+fn collect_from_dir(dir: &Path, out: &mut BTreeSet<String>) {
+    for entry in std::fs::read_dir(dir).expect("read source dir") {
+        let path = entry.expect("dir entry").path();
+        if path.is_dir() {
+            collect_from_dir(&path, out);
+        } else if path.extension().is_some_and(|e| e == "rs") {
+            let text = std::fs::read_to_string(&path).expect("read source file");
+            for (idx, _) in text.match_indices(PREFIX) {
+                // Only string literals count. Doc comments carry `{verb}`-style
+                // URI templates that are documentation, not bindings.
+                if idx == 0 || !text[..idx].ends_with('"') {
+                    continue;
+                }
+                let rest = &text[idx..];
+                let Some(end) = rest.find('"') else { continue };
+                let uri = &rest[..end];
+                // `.../foo/1.0#response` publishes under `.../foo/1.0`.
+                let uri = uri.split('#').next().expect("split yields a head");
+                out.insert(uri.to_owned());
+            }
+        }
+    }
+}
+
+fn exceptions(table: &[(&str, &str)]) -> BTreeSet<String> {
+    table
+        .iter()
+        .map(|(slug, _)| format!("{PREFIX}{slug}"))
+        .collect()
+}
+
+/// A live manifest entry with no route behind it is either drift or a
+/// documented exception. Nothing in between.
+#[test]
+fn every_published_task_is_bound_or_excepted() {
+    let bound = bound_task_uris();
+    let allowed = exceptions(UNBOUND_OK);
+
+    let orphans: Vec<_> = manifest()
+        .iter()
+        .filter(|(_, t)| t.status != "retired")
+        .map(|(id, _)| id.clone())
+        .filter(|id| !bound.contains(id) && !allowed.contains(id))
+        .collect();
+
+    assert!(
+        orphans.is_empty(),
+        "manifest publishes tasks no route binds:\n  {}\n\n\
+         Either wire them, retire them (status + supersededBy, SPEC \u{a7}5.3), \
+         or add them to UNBOUND_OK with a reason.",
+        orphans.join("\n  ")
+    );
+}
+
+/// A task the code enforces but the manifest never published is
+/// invisible to consumers building against trusttasks.org.
+#[test]
+fn every_bound_task_is_published_or_excepted() {
+    let published: BTreeSet<String> = manifest().into_keys().collect();
+    let allowed = exceptions(UNPUBLISHED_OK);
+
+    let missing: Vec<_> = bound_task_uris()
+        .into_iter()
+        .filter(|id| !published.contains(id) && !allowed.contains(id))
+        .collect();
+
+    assert!(
+        missing.is_empty(),
+        "routes enforce tasks the manifest does not publish:\n  {}\n\n\
+         Add a manifest entry (plus spec.md + schema.json on disk), \
+         or add them to UNPUBLISHED_OK with a reason.",
+        missing.join("\n  ")
+    );
+}
+
+/// Retirement is only meaningful if nothing still enforces the task.
+/// This is the assertion that makes the #537 sign-out/whoami class of
+/// drift impossible to reintroduce silently.
+#[test]
+fn retired_tasks_are_not_bound() {
+    let bound = bound_task_uris();
+    let still_wired: Vec<_> = manifest()
+        .iter()
+        .filter(|(id, t)| t.status == "retired" && bound.contains(*id))
+        .map(|(id, _)| id.clone())
+        .collect();
+
+    assert!(
+        still_wired.is_empty(),
+        "retired tasks are still enforced by a route:\n  {}",
+        still_wired.join("\n  ")
+    );
+}
+
+/// SPEC \u{a7}5.3 vocabulary is lowercase, and `retired` is the only status
+/// permitted to carry `supersededBy` (\u{a7}7.3 item 11).
+#[test]
+fn manifest_status_vocabulary_matches_spec() {
+    let raw = std::fs::read_to_string(workspace_root().join("trust-tasks/index.json"))
+        .expect("read index.json");
+    let doc: serde_json::Value = serde_json::from_str(&raw).expect("parse index.json");
+
+    for task in doc["tasks"].as_array().expect("tasks array") {
+        let id = task["id"].as_str().expect("task id");
+        let status = task["status"].as_str().expect("task status");
+        assert!(
+            matches!(status, "draft" | "candidate" | "standard" | "retired"),
+            "{id}: status {status:?} is not SPEC \u{a7}5.3 vocabulary"
+        );
+        let superseded = task.get("supersededBy").is_some();
+        assert_eq!(
+            superseded,
+            status == "retired",
+            "{id}: supersededBy is required on retired specs and forbidden otherwise"
+        );
+    }
+}
+
+/// Every manifest entry must have its spec + schema on disk, or the
+/// published registry links to nothing.
+#[test]
+fn every_manifest_entry_has_files_on_disk() {
+    let root = workspace_root().join("trust-tasks");
+    let missing: Vec<_> = manifest()
+        .into_iter()
+        .flat_map(|(id, t)| {
+            ["spec.md", "schema.json"]
+                .into_iter()
+                .filter(|f| !root.join(&t.path).join(f).exists())
+                .map(|f| format!("{id} -> {}/{f}", t.path))
+                .collect::<Vec<_>>()
+        })
+        .collect();
+
+    assert!(
+        missing.is_empty(),
+        "manifest entries missing files:\n  {}",
+        missing.join("\n  ")
+    );
+}


### PR DESCRIPTION
Follow-up to #537, which closed with an unrelated finding: `trust-tasks/index.json` advertised `openvtc/vtc/auth/sign-out/1.0` for `POST /v1/auth/sign-out` while the router enforced `spec/auth/revoke-session/0.1`.

That turned out to be one instance of a class. The manifest is the publication source of truth for trusttasks.org, and nothing ever checked it against the code, so it had drifted in both directions.

## What changed

**Seven superseded auth tasks retired.** The five `auth/legacy/*` slugs plus `auth/sign-out` and `auth/whoami` were orphaned when the router consolidated onto the canonical `spec/auth/*` registry entries (see the comment at `routes/mod.rs:266-269`), but stayed in the manifest as Draft.

They are **retired, not deleted**. SPEC §5.3 is explicit that retired specs are preserved for historical reference "to keep already-issued documents verifiable", frozen at retirement, declaring `supersededBy`. Each now carries `status: retired` plus a `supersededBy` pointing at the canonical successor, in both the manifest and the on-disk `spec.md` front matter. Verified none is still bound by any route — the new `retired_tasks_are_not_bound` test keeps it that way.

**Status vocabulary aligned.** SPEC §5.3's enum is lowercase; the manifest and all 69 on-disk specs said `Draft`. Safe to change: no CI workflow reads the manifest today.

**`admin-ui/build-info` flagged header-exempt**, matching the already-flagged `status-lists/show`. Both are plain `.route()` mounts carrying no Trust-Task layer, so having only one flagged was inaccurate.

## The census

`vtc-service/tests/trust_task_manifest.rs` pins manifest ↔ router agreement so this class cannot recur silently:

- every published (non-retired) task is bound by a route, or excepted
- every bound task is published, or excepted
- no retired task is still bound
- status vocabulary matches SPEC §5.3, and `supersededBy` appears iff retired
- every manifest entry has `spec.md` + `schema.json` on disk

Both exception tables carry a reason per entry. `UNBOUND_OK` holds the Phase-0 shared-mount collapses (`TrustTaskRouter` has no per-method task selector, so two verbs on one mount share a task) and the two header-exempt routes. `UNPUBLISHED_OK` holds twenty bound-but-unpublished tasks — a real backlog, tracked in #709, tabled here so it cannot grow.

Bindings are attached as tower layers and aren't enumerable from a built `Router`, so the census reads the wiring sites as source text. Blunt, but the wiring is confined to a few files and a false positive is a visible string rather than a silent pass. Mutation-checked: injecting a bogus manifest entry fails two of the five tests.

`auth_audience` used the now-retired `auth/legacy/challenge/1.0` purely as a URI the mount does not bind; switched to an obviously-unreal task so the mismatch assertion cannot start passing for the wrong reason.

## Deliberately not fixed here

**`spec/join-requests/*` are not drift.** They look like stray path segments but are live wire types baked into published `vta-sdk` constants and dispatched at `trust_tasks/mod.rs:112-115`. Editing them would break every client.

**#710 — the URI shape conforms to neither framework form.** The flat form (66 of 71 entries) has no `/spec/` segment, so a consumer following SPEC §6.1 cannot parse the slug; this already broke `TrustTask` deserialization, which is why join-requests was migrated. That migration fixed parsing but not authority — `trusttasks.org/openvtc/vtc/spec/...` is neither the public form (no org segments) nor the private form (§6.5 forbids the `trusttasks.org` domain for private specs). Breaking for every client and a governance decision, so it is filed rather than attempted.

**#709 — twenty unpublished families.** Each needs `spec.md` + `schema.json` authored, and should wait on #710 so the work isn't done twice.

## Testing

`trust_task_manifest` (5 new), `auth_audience`, `audit_signout`, `audit_verify` all pass. `cargo fmt` applied, `cargo clippy -p vtc-service --tests` clean.

---

## Also carried here: two CI commits

Unrelated to the manifest work, but folded in because the first one was blocking this PR's checks.

**`fix(ci)`: refresh the stale `vta-sdk` self-pin left by #707.** #707 bumped `vta-sdk` to 0.19.13 but left `Cargo.lock` pinning the 0.19.12 crates.io copy. `cargo publish --locked` verifies dependents against that pinned copy, so a dependent would build against the old source and fail — silently, since the workspace's own path-dep build stays green. Confirmed inherited rather than introduced by rebasing onto `main` and reproducing there. The lock diff is a single version line.

**`ci`: run the lockfile self-pin guard on pushes, not just PRs.** The root cause of the above reaching this PR at all.

The guard was a step inside `release-guards`, which is `if: github.event_name == 'pull_request'` because its *other* step (the version-bump guard) diffs against the PR base. The self-pin check is not diff-based — it compares workspace manifest versions against `Cargo.lock`, a whole-tree invariant — so it was PR-gated for a reason that never applied to it. The step's own comment already said "Not diff-based, so it needs no base ref."

So a merge could leave the lockfile stale, `main` stayed green because the job was skipped on push, and the breakage surfaced on whichever unrelated PR opened next — reading as *that* PR's failure. #706 and #711 were both this. Now its own unconditional job, so the merge that introduces the staleness is the one that goes red.
