### PR TITLE
fix(ci): commit the self-pin refresh the publish workflow already computes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,10 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: read
+  # `write` so the self-pin refresh can be committed back to main. Without
+  # that commit the refresh lives only in the runner's working copy and is
+  # discarded when the job ends — see the "Commit refreshed self-pins" step.
+  contents: write
   id-token: write # required for the OIDC token exchange with crates.io
 
 jobs:
@@ -139,3 +142,63 @@ jobs:
               cargo update -p "${REGISTRY}#${crate}@${pinned}" --precise "$version"
             fi
           done
+
+      # The refresh above happens in the runner's working copy. Until this
+      # step existed it was never committed, so main kept the stale pin and
+      # `scripts/check-lockfile-self-pins.sh` failed on the NEXT pull request
+      # — attributing a release-time problem to an unrelated author. It hit
+      # #706, #711 and #714 that way.
+      #
+      # CI on the release commit cannot prevent this: the guard deliberately
+      # allows a pin it cannot refresh, and the new version only becomes
+      # resolvable partway through this job, after that CI has finished. So
+      # the fix has to be here, not in a gate.
+      #
+      # `[skip ci]` keeps the commit from re-triggering CI and this workflow.
+      # Re-running Publish would be harmless (every version is on crates.io
+      # by now, so the loop skips them all) but it is pure waste, and the
+      # commit's only content is a mechanical `cargo update --precise` to a
+      # version this job just published successfully against.
+      - name: Commit refreshed self-pins
+        run: |
+          set -euo pipefail
+
+          if git diff --quiet -- Cargo.lock; then
+            echo "no self-pin refresh to commit"
+            exit 0
+          fi
+
+          echo "::notice::committing refreshed lockfile self-pins"
+          git diff --stat -- Cargo.lock
+
+          git config user.name  'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+          git add Cargo.lock
+          git commit -s -m 'chore(release): refresh crates.io self-pins [skip ci]' \
+            -m 'Published versions have just become resolvable, so the registry self-pins in Cargo.lock can finally point at them. Committed by the publish workflow because no pull request can do it — the versions do not exist on crates.io until this job runs.'
+
+          # Another push may have landed while crates were uploading. Rebase
+          # onto it rather than clobbering; the only local change is Cargo.lock.
+          for attempt in 1 2 3; do
+            if git push origin "HEAD:${GITHUB_REF_NAME}"; then
+              echo "self-pin refresh pushed"
+              exit 0
+            fi
+            echo "push rejected (attempt ${attempt}); rebasing onto ${GITHUB_REF_NAME}"
+
+            # A concurrent Cargo.lock edit conflicts here. Abort out of the
+            # rebase rather than leaving the repo mid-operation, and stop
+            # retrying — `set -e` would otherwise fail this step and make a
+            # successful release look like a failed one.
+            if ! git pull --rebase origin "${GITHUB_REF_NAME}"; then
+              git rebase --abort || true
+              echo "rebase conflicted — giving up on the automatic refresh"
+              break
+            fi
+          done
+
+          # Publishing already succeeded — failing the job here would imply the
+          # release did not ship. Warn loudly instead; the next PR's guard will
+          # catch the stale pin, which is the status quo this step improves on.
+          echo "::warning::could not push the refreshed Cargo.lock after 3 attempts — main still holds a stale self-pin; run scripts/check-lockfile-self-pins.sh locally and commit the fix"


### PR DESCRIPTION
Closes the release-time hole that has now misattributed a failure to three unrelated PRs (#706, #711, #714).

## Root cause

The publish loop has refreshed each crate's `Cargo.lock` registry self-pin since #706 — lines 118-140 of `publish.yml`. But it does so **only in the runner's working copy**. Nothing ever committed it, so the change was discarded when the job ended and `main` kept the stale pin.

The in-run refresh still did its job (a dependent published later in the same loop verifies against the fresh registry copy — the actual #706 regression). It just never persisted.

## Why CI can't catch it

`scripts/check-lockfile-self-pins.sh` deliberately allows a pin it cannot refresh — until the new version is on crates.io there is nothing to point at. And the version only becomes resolvable partway through the publish job, *after* the release commit's CI has finished. So:

1. Release PR merges. CI runs, new version unpublished, guard correctly allows the pin. **main green.**
2. Publish runs and uploads the crate.
3. The pin is now both stale and refreshable — but CI doesn't run again on main.
4. The next PR inherits the failure and its author debugs someone else's release.

#711 made this guard run on pushes instead of PRs only. That was a real gap, but a different one — no gating change closes this, because the only fixable moment is inside the publish run.

## The fix

Commit and push the refresh from the publish job, where it is computed.

- `permissions: contents: write` so the job can push.
- `[skip ci]` on the commit, so it doesn't re-trigger CI and this workflow. A second publish run would be harmless — every version is on crates.io by then, so the loop skips them all — but it is pure waste.
- Push contention is handled by rebasing onto whatever landed while crates were uploading.
- A **conflicting** concurrent `Cargo.lock` edit aborts the rebase and warns rather than failing the step. Publishing has already succeeded at that point; failing here would report a shipped release as broken. It leaves the stale pin for the next PR to catch — exactly today's behaviour — so the worst case is no worse than the status quo.

## Testing

Exercised against a throwaway bare remote, all three paths:

| Path | Result |
|---|---|
| Clean push | commits with `[skip ci]`, pushes, remote has refreshed content |
| Push rejected by a concurrent unrelated commit | rebases, pushes, both changes preserved |
| Rebase conflicts on `Cargo.lock` | aborts rebase, warns, **exit 0**, no rebase left in progress |

Also confirmed `main` is unprotected, so a direct push from the workflow is permitted.