### PR TITLE
fix(deps): bump serde_with to 3.21.0 in enclave-proxy (GHSA-7gcf-g7xr-8hxj)

### DIFF
--- a/deploy/nitro/enclave-proxy/Cargo.lock
+++ b/deploy/nitro/enclave-proxy/Cargo.lock
@@ -3944,11 +3944,12 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.19.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05839ce67618e14a09b286535c0d9c94e85ef25469b0e13cb4f844e5593eb19"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64 0.22.1",
+ "bs58 0.5.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -3963,9 +3964,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.19.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf2ebbe86054f9b45bc3881e865683ccfaccce97b9b4cb53f3039d67f355a334"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/deploy/nitro/enclave-proxy/Cargo.toml
+++ b/deploy/nitro/enclave-proxy/Cargo.toml
@@ -1,3 +1,9 @@
+# Standalone workspace root: this crate is excluded from the repo's root
+# workspace (Linux-only, see below), so it declares its own empty
+# `[workspace]` table. Without it, cargo run inside this directory walks up
+# to the root manifest and refuses to operate on a non-member package.
+[workspace]
+
 [package]
 name = "enclave-proxy"
 description = "VTA Nitro Enclave parent-instance proxy — bridges vsock, TCP, and TLS"


### PR DESCRIPTION
Clears one of the four open Dependabot alerts — the medium on the Nitro enclave-proxy.

## Fixed

`serde_with < 3.21.0` panics on empty `KeyValueMap` sequence/map entries (GHSA-7gcf-g7xr-8hxj). Lockfile-only bump `3.19.0 → 3.21.0` (+ `serde_with_macros`) in `deploy/nitro/enclave-proxy/Cargo.lock`.

The enclave-proxy is excluded from the root workspace (Linux-only — `tokio-vsock`) but carried no own `[workspace]` table, so `cargo update` inside it walked up to the root manifest and refused to operate on a non-member. Added an empty `[workspace]` table so it's a proper standalone workspace root — a genuine papercut fix that also unblocked this bump. Verified the root workspace still resolves cleanly (`cargo metadata`).

## NOT fixed here — the three `rustls-webpki` alerts (1 high, 2 low)

I dug into these and they are **not** a lockfile fix, contrary to how a dep-bump usually goes. The vulnerable `rustls-webpki 0.101.7` is pulled by `rustls 0.21.12`, which comes from the **AWS SDK's legacy TLS connector** (`aws-smithy-http-client`'s `legacy-rustls-ring` feature → `legacy-hyper-rustls 0.24` → `legacy-rustls 0.21`), used by `vta-service`'s AWS features (KMS / DynamoDB, i.e. the TEE bootstrap path).

- `rustls 0.21` requires webpki `>= 0.101, < 0.102`, so it **cannot** use the patched `0.103.13` — no `cargo update` or `[patch]` resolves it. (The workspace already uses `rustls 0.23` + webpki `0.103.13` directly; the vulnerable copy is a *second* rustls the AWS SDK pulls.)
- The real fix is switching the AWS connector to `rustls-aws-lc` (rustls 0.23) via `aws-config` feature config (`default-features = false` + reconstructing the needed features). That is Cargo.toml surgery on the AWS integration, it risks the **TEE KMS bootstrap** (not testable off a Nitro instance / without AWS), and the enclave build depends on it.
- Practical exploitability is **low**: the CVE is a DoS via panic parsing a malformed CRL `BIT STRING`, and the AWS SDK's rustls config does not enable webpki CRL validation, so the vulnerable code path isn't exercised on the AWS TLS connections this pulls in.

Given low exploitability + a fix that risks an untestable production path, I've left the webpki alerts for a **separate, deliberate PR** that can be validated against the actual AWS/enclave path, rather than bundle a risky connector change with this clean bump. Details for that follow-up are in the commit message.