### PR TITLE
feat(webvh): agent-name park/resume Trust Tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,7 +400,7 @@ dependencies = [
  "trust-tasks-rs",
  "url",
  "uuid",
- "vta-sdk 0.19.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vta-sdk 0.19.14",
 ]
 
 [[package]]
@@ -2485,7 +2485,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.19.14",
+ "vta-sdk 0.19.15",
 ]
 
 [[package]]
@@ -3286,7 +3286,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.19.14",
+ "vta-sdk 0.19.15",
 ]
 
 [[package]]
@@ -6764,7 +6764,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.19.14",
+ "vta-sdk 0.19.15",
 ]
 
 [[package]]
@@ -10080,7 +10080,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.19",
  "tokio",
- "vta-sdk 0.19.14",
+ "vta-sdk 0.19.15",
  "vti-common",
  "x25519-dalek",
 ]
@@ -10113,7 +10113,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.19.14",
+ "vta-sdk 0.19.15",
 ]
 
 [[package]]
@@ -10136,12 +10136,45 @@ dependencies = [
  "tracing-subscriber",
  "trust-tasks-rs",
  "uniffi",
- "vta-sdk 0.19.14",
+ "vta-sdk 0.19.15",
 ]
 
 [[package]]
 name = "vta-sdk"
 version = "0.19.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173406252db2bf6a3be9996ea256913d47ef426ff73f60f663daf61674efb038"
+dependencies = [
+ "affinidi-crypto",
+ "affinidi-did-resolver-cache-sdk",
+ "affinidi-messaging-core",
+ "affinidi-messaging-delivery",
+ "affinidi-messaging-didcomm",
+ "affinidi-openid4vci",
+ "affinidi-openid4vp",
+ "affinidi-tdk",
+ "base64 0.22.1",
+ "chrono",
+ "curve25519-dalek",
+ "didwebvh-rs",
+ "ed25519-dalek",
+ "futures-util",
+ "getrandom 0.4.3",
+ "multibase",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "thiserror 2.0.19",
+ "tokio",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "vta-sdk"
+version = "0.19.15"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10200,41 +10233,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "vta-sdk"
-version = "0.19.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "173406252db2bf6a3be9996ea256913d47ef426ff73f60f663daf61674efb038"
-dependencies = [
- "affinidi-crypto",
- "affinidi-did-resolver-cache-sdk",
- "affinidi-messaging-core",
- "affinidi-messaging-delivery",
- "affinidi-messaging-didcomm",
- "affinidi-openid4vci",
- "affinidi-openid4vp",
- "affinidi-tdk",
- "base64 0.22.1",
- "chrono",
- "curve25519-dalek",
- "didwebvh-rs",
- "ed25519-dalek",
- "futures-util",
- "getrandom 0.4.3",
- "multibase",
- "reqwest 0.13.4",
- "serde",
- "serde_json",
- "sha2 0.11.0",
- "thiserror 2.0.19",
- "tokio",
- "tracing",
- "url",
- "uuid",
-]
-
-[[package]]
 name = "vta-service"
-version = "0.11.13"
+version = "0.11.14"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",
@@ -10314,7 +10314,7 @@ dependencies = [
  "utoipa-axum",
  "uuid",
  "vta-cli-common",
- "vta-sdk 0.19.14",
+ "vta-sdk 0.19.15",
  "vta-service",
  "vti-common",
  "vti-secrets",
@@ -10336,7 +10336,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.19",
  "tokio",
- "vta-sdk 0.19.14",
+ "vta-sdk 0.19.15",
 ]
 
 [[package]]
@@ -10410,7 +10410,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.19.14",
+ "vta-sdk 0.19.15",
  "vtc-service",
  "vti-common",
  "vti-secrets",
@@ -10462,7 +10462,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.19.14",
+ "vta-sdk 0.19.15",
  "webauthn-rs",
  "zeroize",
 ]
@@ -10489,7 +10489,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.19.14",
+ "vta-sdk 0.19.15",
  "vta-service",
  "vti-common",
 ]
@@ -10518,7 +10518,7 @@ dependencies = [
  "tokio",
  "tracing",
  "vaultrs",
- "vta-sdk 0.19.14",
+ "vta-sdk 0.19.15",
  "vti-common",
 ]
 

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.19.14"
+version = "0.19.15"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/protocols/did_management/agent_name.rs
+++ b/vta-sdk/src/protocols/did_management/agent_name.rs
@@ -1,0 +1,30 @@
+use serde::{Deserialize, Serialize};
+
+/// Body for the agent-name enable/disable Trust Tasks
+/// (`spec/vta/webvh/agent-name/{enable,disable}/1.0`).
+///
+/// Both verbs carry the same shape: the hosted DID and the name's local
+/// part (the `alice` in `/@alice`, without the leading `@`). The agent
+/// resolves the current DID document, edits its `alsoKnownAs` to
+/// claim/no-longer-claim `https://<domain>/@<name>`, signs a new version,
+/// and submits it to the hosting server's `agent-name/{enable,disable}`
+/// endpoint. The hosting domain is the DID's own host — derived from the
+/// `did:webvh` identifier, not carried here.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct AgentNameBody {
+    pub did: String,
+    pub name: String,
+}
+
+/// Result of an agent-name enable/disable Trust Task.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct AgentNameResultBody {
+    pub did: String,
+    pub name: String,
+    /// `true` for enable (now served), `false` for disable (parked).
+    pub enabled: bool,
+}

--- a/vta-sdk/src/protocols/did_management/mod.rs
+++ b/vta-sdk/src/protocols/did_management/mod.rs
@@ -1,3 +1,4 @@
+pub mod agent_name;
 pub mod create;
 pub mod delete;
 pub mod get;

--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -958,6 +958,24 @@ pub const TASK_WEBVH_DIDS_ROTATE_KEYS_1_0: &str =
 pub const TASK_WEBVH_DIDS_REGISTER_WITH_SERVER_1_0: &str =
     "https://trusttasks.org/spec/vta/webvh/dids/register-with-server/1.0";
 
+/// `spec/vta/webvh/agent-name/disable/1.0` — park an agent name
+/// (`/@alice`) on a hosted DID: publish a new signed version whose
+/// `alsoKnownAs` no longer claims it (so the host stops serving the
+/// redirect) while keeping it reserved to this DID. Payload:
+/// [`crate::protocols::did_management::agent_name::AgentNameBody`].
+/// Destructive (drops a public binding + rotates the update key like
+/// any update). Auth: Admin role on the DID's context.
+pub const TASK_WEBVH_AGENT_NAME_DISABLE_1_0: &str =
+    "https://trusttasks.org/spec/vta/webvh/agent-name/disable/1.0";
+
+/// `spec/vta/webvh/agent-name/enable/1.0` — resume serving a parked
+/// agent name: publish a new signed version whose `alsoKnownAs` claims
+/// it again. Payload:
+/// [`crate::protocols::did_management::agent_name::AgentNameBody`].
+/// Auth: Admin role on the DID's context.
+pub const TASK_WEBVH_AGENT_NAME_ENABLE_1_0: &str =
+    "https://trusttasks.org/spec/vta/webvh/agent-name/enable/1.0";
+
 // ─── DID-templates slice (spec/vta/did-templates/*) ──────────────────────
 //
 // Global-scope template CRUD + render. Mirrored under
@@ -1337,6 +1355,8 @@ pub const ALL_URIS: &[&str] = &[
     TASK_WEBVH_DIDS_UPDATE_1_0,
     TASK_WEBVH_DIDS_ROTATE_KEYS_1_0,
     TASK_WEBVH_DIDS_REGISTER_WITH_SERVER_1_0,
+    TASK_WEBVH_AGENT_NAME_DISABLE_1_0,
+    TASK_WEBVH_AGENT_NAME_ENABLE_1_0,
     // DID-templates slice (global)
     TASK_DID_TEMPLATES_LIST_1_0,
     TASK_DID_TEMPLATES_CREATE_1_0,

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.11.13"
+version = "0.11.14"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/operations/did_webvh/auth_cache.rs
+++ b/vta-service/src/operations/did_webvh/auth_cache.rs
@@ -315,6 +315,45 @@ pub async fn register_did_atomic_on_server(
         .await
 }
 
+/// Authenticate and park (`enable == false`) or resume (`enable == true`) an
+/// agent name on the hosting server, submitting the signed new `did.jsonl`.
+/// Same encapsulation as [`publish_log_to_server`].
+#[allow(clippy::too_many_arguments)]
+pub async fn agent_name_op_on_server(
+    deps: &super::WebvhDeps<'_>,
+    vta_did: &str,
+    server: &WebvhServerRecord,
+    enable: bool,
+    mnemonic: &str,
+    name: &str,
+    did_log: &str,
+    domain: Option<&str>,
+) -> Result<(), AppError> {
+    let identity = load_vta_webvh_signing_identity(
+        deps.keys_ks,
+        deps.imported_ks,
+        deps.seed_store,
+        deps.audit_ks,
+        vta_did,
+    )
+    .await?;
+    let auth_ctx = AuthContext {
+        webvh_ks: deps.webvh_ks,
+        identity: &identity,
+        locks: deps.auth_locks,
+    };
+    let mut transport = super::WebvhTransport::from_server_authenticated(
+        server,
+        deps.did_resolver,
+        deps.didcomm_bridge,
+        &auth_ctx,
+    )
+    .await?;
+    transport
+        .agent_name_authenticated(enable, mnemonic, name, did_log, domain, &auth_ctx, server)
+        .await
+}
+
 /// Load the VTA's signing identity for daemon REST authentication.
 ///
 /// Looks up `{vta_did}#key-0` via `get_key_secret_internal` under

--- a/vta-service/src/operations/did_webvh/mod.rs
+++ b/vta-service/src/operations/did_webvh/mod.rs
@@ -18,7 +18,8 @@ mod webvh_keys;
 
 pub use auth_cache::WebvhAuthLocks;
 pub(crate) use auth_cache::{
-    delete_log_on_server, publish_log_to_server, register_did_atomic_on_server,
+    agent_name_op_on_server, delete_log_on_server, publish_log_to_server,
+    register_did_atomic_on_server,
 };
 
 pub(crate) use concurrency::{RaceDetected, RecordSnapshot};
@@ -36,7 +37,7 @@ pub use servers::{
 };
 pub use update::{
     RotateDidWebvhKeysOptions, UpdateDidWebvhError, UpdateDidWebvhOptions, UpdateDidWebvhResult,
-    UpdatePlan, plan_did_webvh_update, rotate_did_webvh_keys, state_from_jsonl_pub,
+    UpdatePlan, agent_name_op, plan_did_webvh_update, rotate_did_webvh_keys, state_from_jsonl_pub,
     update_did_webvh,
 };
 
@@ -1652,6 +1653,51 @@ impl<'a> WebvhTransport<'a> {
                     .register_did_atomic(path, did_log, force, domain)
                     .await
             }
+        }
+    }
+
+    /// Park (`enable == false`) or resume (`enable == true`) an agent name,
+    /// with one-shot 401 retry. REST-only: the hosting server exposes the
+    /// agent-name endpoints over REST only, so a DIDComm-transport server is
+    /// refused rather than silently no-op'd.
+    pub(super) async fn agent_name_authenticated(
+        &mut self,
+        enable: bool,
+        mnemonic: &str,
+        name: &str,
+        did_log: &str,
+        domain: Option<&str>,
+        auth_ctx: &auth_cache::AuthContext<'_>,
+        server: &WebvhServerRecord,
+    ) -> Result<(), AppError> {
+        let Self::Rest(c) = self else {
+            return Err(AppError::Validation(
+                "agent-name enable/disable is not supported over the DIDComm transport; \
+                 the hosting server exposes it only via REST"
+                    .to_string(),
+            ));
+        };
+        let first = if enable {
+            c.enable_agent_name(mnemonic, name, did_log, domain).await
+        } else {
+            c.disable_agent_name(mnemonic, name, did_log, domain).await
+        };
+        match first {
+            Ok(()) => Ok(()),
+            Err(AppError::Unauthorized(_)) => {
+                info!(
+                    server_id = %server.id,
+                    "webvh agent_name got 401; invalidating cache and retrying"
+                );
+                auth_cache::invalidate_cached_token(auth_ctx.webvh_ks, &server.id).await?;
+                auth_cache::ensure_fresh_access_token(auth_ctx, server, c).await?;
+                if enable {
+                    c.enable_agent_name(mnemonic, name, did_log, domain).await
+                } else {
+                    c.disable_agent_name(mnemonic, name, did_log, domain).await
+                }
+            }
+            Err(e) => Err(e),
         }
     }
 }

--- a/vta-service/src/operations/did_webvh/update/mod.rs
+++ b/vta-service/src/operations/did_webvh/update/mod.rs
@@ -43,7 +43,7 @@ mod validate;
 
 pub use errors::UpdateDidWebvhError;
 pub use options::{RotateDidWebvhKeysOptions, UpdateDidWebvhOptions, UpdateDidWebvhResult};
-pub use orchestrator::{plan_did_webvh_update, update_did_webvh};
+pub use orchestrator::{agent_name_op, plan_did_webvh_update, update_did_webvh};
 pub use plan::UpdatePlan;
 pub use rotate::rotate_did_webvh_keys;
 

--- a/vta-service/src/operations/did_webvh/update/orchestrator.rs
+++ b/vta-service/src/operations/did_webvh/update/orchestrator.rs
@@ -48,7 +48,18 @@ pub async fn plan_did_webvh_update(
     scid: &str,
     opts: UpdateDidWebvhOptions,
 ) -> Result<UpdatePlan, UpdateDidWebvhError> {
-    match run_update(deps, auth, scid, opts, None, "plan", Mode::Plan).await? {
+    match run_update(
+        deps,
+        auth,
+        scid,
+        opts,
+        None,
+        "plan",
+        Mode::Plan,
+        PublishTarget::DidLog,
+    )
+    .await?
+    {
         Outcome::Planned(plan) => Ok(plan),
         Outcome::Executed(_) => Err(UpdateDidWebvhError::Library(
             "plan mode committed an update".into(),
@@ -69,12 +80,153 @@ pub async fn update_did_webvh(
     vta_did: Option<&str>,
     channel: &str,
 ) -> Result<UpdateDidWebvhResult, UpdateDidWebvhError> {
-    match run_update(deps, auth, scid, opts, vta_did, channel, Mode::Execute).await? {
+    match run_update(
+        deps,
+        auth,
+        scid,
+        opts,
+        vta_did,
+        channel,
+        Mode::Execute,
+        PublishTarget::DidLog,
+    )
+    .await?
+    {
         Outcome::Executed(result) => Ok(result),
         Outcome::Planned(_) => Err(UpdateDidWebvhError::Library(
             "execute mode returned a plan".into(),
         )),
     }
+}
+
+/// Park or resume an agent name (`/@alice`) on a hosted webvh DID.
+///
+/// Reads the DID's current document, edits its `alsoKnownAs` to no-longer-claim
+/// (`enable == false`) or claim again (`enable == true`)
+/// `https://<domain>/@<name>`, then runs the *same* signing path as an update
+/// and submits the new version to the host's `agent-name/{disable,enable}`
+/// endpoint — which republishes it AND toggles the name registry atomically.
+///
+/// `did` may be a full `did:webvh:…` or a bare SCID. Refused for serverless
+/// DIDs (no host serves their names).
+pub async fn agent_name_op(
+    deps: &super::super::WebvhDeps<'_>,
+    auth: &AuthClaims,
+    did: &str,
+    name: &str,
+    enable: bool,
+    vta_did: Option<&str>,
+    channel: &str,
+) -> Result<UpdateDidWebvhResult, UpdateDidWebvhError> {
+    let record = find_record_by_scid(deps.webvh_ks, did)
+        .await?
+        .ok_or_else(|| UpdateDidWebvhError::NotFound(format!("DID {did} not found")))?;
+
+    if record.server_id == "serverless" {
+        return Err(UpdateDidWebvhError::Publish(
+            "agent names require a hosted DID; this DID is serverless \
+             (register it with a server first)"
+                .to_string(),
+        ));
+    }
+
+    let did_log = webvh_store::get_did_log(deps.webvh_ks, &record.did)
+        .await
+        .map_err(|e| UpdateDidWebvhError::Persistence(format!("get_did_log: {e}")))?
+        .ok_or_else(|| {
+            UpdateDidWebvhError::NotFound(format!("no did.jsonl stored for {}", record.did))
+        })?;
+    let mut document =
+        crate::operations::protocol::document::current_document_from_log(&did_log)
+            .map_err(|e| UpdateDidWebvhError::Library(format!("read current document: {e}")))?;
+
+    let domain = domain_from_webvh_did(&record.did).ok_or_else(|| {
+        UpdateDidWebvhError::Library(format!("cannot derive domain from DID {}", record.did))
+    })?;
+    edit_agent_name(&mut document, &domain, name, enable);
+
+    let opts = UpdateDidWebvhOptions {
+        document: Some(document),
+        label: Some(format!(
+            "agent-name/{}",
+            if enable { "enable" } else { "disable" }
+        )),
+        ..Default::default()
+    };
+
+    match run_update(
+        deps,
+        auth,
+        &record.scid,
+        opts,
+        vta_did,
+        channel,
+        Mode::Execute,
+        PublishTarget::AgentName {
+            name: name.to_string(),
+            enable,
+        },
+    )
+    .await?
+    {
+        Outcome::Executed(result) => Ok(result),
+        Outcome::Planned(_) => Err(UpdateDidWebvhError::Library(
+            "execute mode returned a plan".into(),
+        )),
+    }
+}
+
+/// Extract the hosting domain (host authority) from a
+/// `did:webvh:{scid}:{host}:…` identifier, percent-decoding an encoded port
+/// (`localhost%3A8534` → `localhost:8534`). `None` if the shape is unexpected.
+fn domain_from_webvh_did(did: &str) -> Option<String> {
+    let rest = did.strip_prefix("did:webvh:")?;
+    let host = rest.split(':').nth(1)?;
+    if host.is_empty() {
+        return None;
+    }
+    Some(host.replace("%3A", ":").replace("%3a", ":"))
+}
+
+/// Edit a DID document's `alsoKnownAs` to claim (`enable`) or drop (`!enable`)
+/// the agent name `https://<domain>/@<name>`. Idempotent.
+fn edit_agent_name(document: &mut serde_json::Value, domain: &str, name: &str, enable: bool) {
+    let entry = format!("https://{domain}/@{name}");
+    let Some(obj) = document.as_object_mut() else {
+        return;
+    };
+    if enable {
+        let arr = obj
+            .entry("alsoKnownAs")
+            .or_insert_with(|| serde_json::Value::Array(Vec::new()));
+        if let Some(list) = arr.as_array_mut()
+            && !list.iter().any(|v| is_agent_name(v, domain, name))
+        {
+            list.push(serde_json::Value::String(entry));
+        }
+    } else if let Some(serde_json::Value::Array(list)) = obj.get_mut("alsoKnownAs") {
+        list.retain(|v| !is_agent_name(v, domain, name));
+        if list.is_empty() {
+            obj.remove("alsoKnownAs");
+        }
+    }
+}
+
+/// Whether a JSON value is the agent name `<name>` on `<domain>` (host match
+/// case-insensitive; local part exact, per the spec's case-sensitive rule).
+fn is_agent_name(v: &serde_json::Value, domain: &str, name: &str) -> bool {
+    let Some(s) = v.as_str() else {
+        return false;
+    };
+    let no_scheme = s
+        .strip_prefix("https://")
+        .or_else(|| s.strip_prefix("http://"))
+        .unwrap_or(s);
+    let Some((host, rest)) = no_scheme.split_once("/@") else {
+        return false;
+    };
+    let local = rest.split('/').next().unwrap_or("");
+    host.eq_ignore_ascii_case(domain) && local == name
 }
 
 /// Whether [`run_update`] stops at the last read or goes on to commit.
@@ -89,6 +241,20 @@ enum Outcome {
     Executed(UpdateDidWebvhResult),
 }
 
+/// Where [`run_update`]'s freshly-signed log gets published (Execute mode).
+///
+/// Both variants publish the *same* signed `did.jsonl` a normal update
+/// produces; they differ only in which host endpoint receives it. Agent-name
+/// ops build the mutated document (`alsoKnownAs` edited) and pass it as
+/// `opts.document`, so the signing path is byte-for-byte the update path.
+enum PublishTarget {
+    /// `PUT /api/dids/{mnemonic}` — every plain document update.
+    DidLog,
+    /// `POST /api/agent-names/{disable,enable}` — the host republishes the log
+    /// AND toggles the name registry in one commit.
+    AgentName { name: String, enable: bool },
+}
+
 async fn run_update(
     deps: &super::super::WebvhDeps<'_>,
     auth: &AuthClaims,
@@ -97,6 +263,7 @@ async fn run_update(
     vta_did: Option<&str>,
     channel: &str,
     mode: Mode,
+    publish: PublishTarget,
 ) -> Result<Outcome, UpdateDidWebvhError> {
     // Re-bind the bundled deps to the historical local names so the (large) body
     // below is unchanged. All fields are `Copy` references — this copies the
@@ -601,21 +768,44 @@ async fn run_update(
                     .to_string(),
             )
         })?;
-        super::super::publish_log_to_server(
-            deps,
-            vta_did,
-            &server,
-            &record.mnemonic,
-            &new_log_jsonl,
-            // Update paths follow the slot's existing domain — the
-            // remote already records it on the slot. Passing None
-            // lets the remote use the recorded value; a host that
-            // does per-domain mnemonic namespacing would resolve via
-            // the slot lookup.
-            None,
-        )
-        .await
-        .map_err(|e| UpdateDidWebvhError::Publish(format!("publish_did: {e}")))?;
+        match &publish {
+            PublishTarget::DidLog => {
+                super::super::publish_log_to_server(
+                    deps,
+                    vta_did,
+                    &server,
+                    &record.mnemonic,
+                    &new_log_jsonl,
+                    // Update paths follow the slot's existing domain — the
+                    // remote already records it on the slot. Passing None
+                    // lets the remote use the recorded value; a host that
+                    // does per-domain mnemonic namespacing would resolve via
+                    // the slot lookup.
+                    None,
+                )
+                .await
+                .map_err(|e| UpdateDidWebvhError::Publish(format!("publish_did: {e}")))?;
+            }
+            PublishTarget::AgentName { name, enable } => {
+                // The host both republishes this signed log AND toggles the
+                // name registry, so we must name the domain explicitly (it is
+                // the DID's own host) — unlike a plain publish, which lets the
+                // slot lookup supply it.
+                let domain = domain_from_webvh_did(&record.did);
+                super::super::agent_name_op_on_server(
+                    deps,
+                    vta_did,
+                    &server,
+                    *enable,
+                    &record.mnemonic,
+                    name,
+                    &new_log_jsonl,
+                    domain.as_deref(),
+                )
+                .await
+                .map_err(|e| UpdateDidWebvhError::Publish(format!("agent_name: {e}")))?;
+            }
+        }
     }
 
     // 14. Audit emission. Best-effort — a missing audit row should
@@ -670,4 +860,107 @@ async fn run_update(
         // to call the host transport.
         serverless: record.server_id == "serverless",
     }))
+}
+
+#[cfg(test)]
+mod agent_name_tests {
+    use super::{domain_from_webvh_did, edit_agent_name, is_agent_name};
+    use serde_json::{Value, json};
+
+    #[test]
+    fn domain_parses_host_and_decodes_port() {
+        assert_eq!(
+            domain_from_webvh_did("did:webvh:QmScid:example.com:alice").as_deref(),
+            Some("example.com")
+        );
+        // Percent-encoded port is decoded to match the form a name carries.
+        assert_eq!(
+            domain_from_webvh_did("did:webvh:QmScid:localhost%3A8534:staff:bob").as_deref(),
+            Some("localhost:8534")
+        );
+        assert_eq!(domain_from_webvh_did("did:key:z6Mk").as_deref(), None);
+        assert_eq!(domain_from_webvh_did("did:webvh:QmScid").as_deref(), None);
+    }
+
+    #[test]
+    fn is_agent_name_matches_host_ci_local_exact() {
+        let v = |s: &str| Value::String(s.to_string());
+        assert!(is_agent_name(
+            &v("https://example.com/@alice"),
+            "example.com",
+            "alice"
+        ));
+        // Scheme-less and host case-insensitive both match.
+        assert!(is_agent_name(
+            &v("example.com/@alice"),
+            "EXAMPLE.com",
+            "alice"
+        ));
+        // Local part is case-sensitive.
+        assert!(!is_agent_name(
+            &v("https://example.com/@Alice"),
+            "example.com",
+            "alice"
+        ));
+        // Wrong domain / not an agent name.
+        assert!(!is_agent_name(
+            &v("https://other.com/@alice"),
+            "example.com",
+            "alice"
+        ));
+        assert!(!is_agent_name(
+            &v("did:web:example.com"),
+            "example.com",
+            "alice"
+        ));
+    }
+
+    #[test]
+    fn enable_adds_canonical_entry_idempotently() {
+        let mut doc = json!({ "id": "did:webvh:x:example.com:me" });
+        edit_agent_name(&mut doc, "example.com", "alice", true);
+        assert_eq!(
+            doc["alsoKnownAs"],
+            json!(["https://example.com/@alice"]),
+            "enable creates the array with the canonical entry"
+        );
+        // Idempotent: a second enable does not duplicate.
+        edit_agent_name(&mut doc, "example.com", "alice", true);
+        assert_eq!(doc["alsoKnownAs"], json!(["https://example.com/@alice"]));
+    }
+
+    #[test]
+    fn enable_preserves_unrelated_also_known_as() {
+        let mut doc = json!({ "alsoKnownAs": ["did:web:example.com", "https://example.com/@bob"] });
+        edit_agent_name(&mut doc, "example.com", "alice", true);
+        assert_eq!(
+            doc["alsoKnownAs"],
+            json!([
+                "did:web:example.com",
+                "https://example.com/@bob",
+                "https://example.com/@alice"
+            ])
+        );
+    }
+
+    #[test]
+    fn disable_removes_the_name_in_any_form_and_prunes_empty() {
+        // A scheme-less stored form is still removed.
+        let mut doc = json!({ "alsoKnownAs": ["example.com/@alice"] });
+        edit_agent_name(&mut doc, "example.com", "alice", false);
+        assert!(
+            doc.get("alsoKnownAs").is_none(),
+            "an emptied alsoKnownAs is dropped, not left as []"
+        );
+
+        // Only the target name goes; other entries stay.
+        let mut doc = json!({
+            "alsoKnownAs": ["https://example.com/@alice", "https://example.com/@bob", "did:web:x"]
+        });
+        edit_agent_name(&mut doc, "example.com", "alice", false);
+        assert_eq!(
+            doc["alsoKnownAs"],
+            json!(["https://example.com/@bob", "did:web:x"])
+        );
+    }
 }

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -153,6 +153,8 @@ const KNOWN_FEATURE_GATED_URIS: &[&str] = &[
     vta_sdk::trust_tasks::TASK_WEBVH_DIDS_UPDATE_1_0,
     vta_sdk::trust_tasks::TASK_WEBVH_DIDS_ROTATE_KEYS_1_0,
     vta_sdk::trust_tasks::TASK_WEBVH_DIDS_REGISTER_WITH_SERVER_1_0,
+    vta_sdk::trust_tasks::TASK_WEBVH_AGENT_NAME_DISABLE_1_0,
+    vta_sdk::trust_tasks::TASK_WEBVH_AGENT_NAME_ENABLE_1_0,
     // did-management Trust-Task spec URIs — declared in vta-sdk by
     // PR #139 ("PR 1 of N") as the shared vocabulary for the
     // cross-repo did-management migration (vta-sdk + vta-service +
@@ -928,6 +930,19 @@ dispatch_table! {
     vta_sdk::trust_tasks::TASK_WEBVH_DIDS_REGISTER_WITH_SERVER_1_0
         => webvh::handle_dids_register_with_server
         [ Mutating None false ],
+    // Agent-name park/resume. Both publish a new signed version (and so
+    // rotate the update key exactly like any update), and both change a
+    // public name binding — Destructive, like `dids/update`, per the
+    // rationale above. Classifying them Destructive is what makes the
+    // wallet force a cross-device type-to-confirm, which is the elevation
+    // for these ops (the hosting endpoint is deliberately not step-up-gated
+    // — the VTA can't hold an aal2 session).
+    #[cfg(feature = "webvh")]
+    vta_sdk::trust_tasks::TASK_WEBVH_AGENT_NAME_DISABLE_1_0 => webvh::handle_agent_name_disable
+        [ Destructive None false ],
+    #[cfg(feature = "webvh")]
+    vta_sdk::trust_tasks::TASK_WEBVH_AGENT_NAME_ENABLE_1_0 => webvh::handle_agent_name_enable
+        [ Destructive None false ],
 }
 
 #[cfg(test)]

--- a/vta-service/src/trust_tasks/webvh.rs
+++ b/vta-service/src/trust_tasks/webvh.rs
@@ -37,6 +37,7 @@ use serde_json::Value;
 use trust_tasks_rs::{RejectReason, TrustTask};
 
 use vta_sdk::protocols::did_management::{
+    agent_name::{AgentNameBody, AgentNameResultBody},
     create::CreateDidWebvhBody,
     delete::DeleteDidWebvhBody,
     get::GetDidWebvhBody,
@@ -363,6 +364,71 @@ pub(super) async fn handle_dids_update(
     .await
     {
         Ok(body) => success_response(&doc, body),
+        Err(e) => app_error_to_reject(&doc, AppError::from(e)),
+    }
+}
+
+/// `spec/vta/webvh/agent-name/disable/1.0` — park an agent name: publish a new
+/// signed version dropping it from `alsoKnownAs` and tell the host to keep it
+/// reserved. Destructive.
+pub(super) async fn handle_agent_name_disable(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    handle_agent_name(state, auth, doc, false).await
+}
+
+/// `spec/vta/webvh/agent-name/enable/1.0` — resume serving a parked name:
+/// publish a new signed version that claims it again.
+pub(super) async fn handle_agent_name_enable(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    handle_agent_name(state, auth, doc, true).await
+}
+
+async fn handle_agent_name(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+    enable: bool,
+) -> TrustTaskOutcome {
+    let req: AgentNameBody = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    let did_resolver = match state.did_resolver.as_ref() {
+        Some(r) => r,
+        None => {
+            return app_error_to_reject(
+                &doc,
+                AppError::Internal("DID resolver not available".into()),
+            );
+        }
+    };
+    let vta_did = state.config.read().await.vta_did.clone();
+    let deps = operations::did_webvh::WebvhDeps::from_app_state(state, did_resolver);
+    match operations::did_webvh::agent_name_op(
+        &deps,
+        auth,
+        &req.did,
+        &req.name,
+        enable,
+        vta_did.as_deref(),
+        TRANSPORT_TRUST_TASK,
+    )
+    .await
+    {
+        Ok(_) => success_response(
+            &doc,
+            AgentNameResultBody {
+                did: req.did,
+                name: req.name,
+                enabled: enable,
+            },
+        ),
         Err(e) => app_error_to_reject(&doc, AppError::from(e)),
     }
 }

--- a/vta-service/src/webvh_client.rs
+++ b/vta-service/src/webvh_client.rs
@@ -597,6 +597,74 @@ impl WebvhClient {
         Ok(())
     }
 
+    /// POST /api/agent-names/{op} — park (`disable`) or resume (`enable`) an
+    /// agent name via a signed new DID version.
+    ///
+    /// `op` is `"disable"` or `"enable"`. `did_log` is the full new signed
+    /// `did.jsonl` whose `alsoKnownAs` no longer claims (disable) or claims
+    /// again (enable) the name; the host verifies that, republishes it as a new
+    /// version, and toggles the name registry in one commit.
+    async fn agent_name_op(
+        &self,
+        op: &str,
+        mnemonic: &str,
+        name: &str,
+        did_log: &str,
+        domain: Option<&str>,
+    ) -> Result<(), AppError> {
+        let url = format!("{}/api/agent-names/{op}", self.server_url);
+        info!(method = "POST", %url, "webvh: sending via rest");
+        let mut body = serde_json::Map::new();
+        body.insert(
+            "mnemonic".to_string(),
+            serde_json::Value::String(mnemonic.to_string()),
+        );
+        body.insert(
+            "name".to_string(),
+            serde_json::Value::String(name.to_string()),
+        );
+        body.insert(
+            "didLog".to_string(),
+            serde_json::Value::String(did_log.to_string()),
+        );
+        if let Some(d) = domain {
+            body.insert(
+                "domain".to_string(),
+                serde_json::Value::String(d.to_string()),
+            );
+        }
+        let req = self
+            .with_auth(self.http.post(&url))
+            .json(&serde_json::Value::Object(body));
+        self.send(req, &format!("POST /api/agent-names/{op}"))
+            .await?;
+        Ok(())
+    }
+
+    /// Park an agent name (kept reserved, stops resolving).
+    pub async fn disable_agent_name(
+        &self,
+        mnemonic: &str,
+        name: &str,
+        did_log: &str,
+        domain: Option<&str>,
+    ) -> Result<(), AppError> {
+        self.agent_name_op("disable", mnemonic, name, did_log, domain)
+            .await
+    }
+
+    /// Resume serving a parked agent name.
+    pub async fn enable_agent_name(
+        &self,
+        mnemonic: &str,
+        name: &str,
+        did_log: &str,
+        domain: Option<&str>,
+    ) -> Result<(), AppError> {
+        self.agent_name_op("enable", mnemonic, name, did_log, domain)
+            .await
+    }
+
     /// DELETE /api/dids/{mnemonic}.
     pub async fn delete_did(&self, mnemonic: &str, domain: Option<&str>) -> Result<(), AppError> {
         let url = if let Some(d) = domain {
@@ -1288,6 +1356,47 @@ mod tests {
         assert!(
             matches!(err, AppError::Internal(msg) if msg.contains("refreshToken")),
             "missing refreshToken must be a typed Internal error"
+        );
+    }
+
+    #[tokio::test]
+    async fn agent_name_disable_posts_bearer_authed_body() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/agent-names/disable"))
+            .and(header("Authorization", "Bearer tok-1"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "record": {} })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let mut client = WebvhClient::new(&server.uri(), "did:web:daemon-mock.example").unwrap();
+        client.set_access_token("tok-1".to_string());
+        client
+            .disable_agent_name("alice", "alice", "<jsonl>", Some("example.com"))
+            .await
+            .expect("disable should POST and succeed");
+    }
+
+    #[tokio::test]
+    async fn agent_name_enable_maps_403_to_forbidden() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/agent-names/enable"))
+            .respond_with(ResponseTemplate::new(403).set_body_string("not the owner"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let mut client = WebvhClient::new(&server.uri(), "did:web:daemon-mock.example").unwrap();
+        client.set_access_token("tok-1".to_string());
+        let err = client
+            .enable_agent_name("alice", "alice", "<jsonl>", None)
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, AppError::Forbidden(_)),
+            "a 403 from the host maps to Forbidden, got {err:?}"
         );
     }
 }


### PR DESCRIPTION
Adds two VTA Trust Tasks — `vta/webvh/agent-name/{disable,enable}` — so a DID's agent can **park** an agent name (`/@alice`: stop serving the redirect, keep the name reserved) or **resume** it. This is the piece that unlocks park/disable in a UI.

## Why this lives in the VTA
The browser can't produce a signed DID version — the DID's update key lives in the VTA. So park/disable can't be a direct browser→host REST call; the VTA must sign. And the VTA's own **`Destructive`-class consent** (the wallet's cross-device type-to-confirm) *is* the elevation — a human approving a destructive op on a second device. The hosting endpoint is deliberately **not** HTTP step-up-gated (the VTA authenticates by DID and can't hold an aal2 session); see the companion webvh change dropping that gate.

## What each task does
Resolve the DID's current document → edit `alsoKnownAs` to drop (disable) or re-add (enable) `https://<domain>/@<name>` → sign a new version via the **exact** update path → submit to the host's `POST /api/agent-names/{disable,enable}`, which republishes the log **and** toggles the name registry in one commit. Serverless DIDs are refused (no host serves their names).

## Reuse, not duplication
Rather than copy `run_update`'s signing spine, this adds a `PublishTarget` parameter to it: the agent-name path reuses the whole read→sign→store pipeline and only swaps step 13's publish from `PUT /api/dids` to the agent-name endpoint. The caller builds the mutated document and passes it as `opts.document`, so the signing is byte-for-byte the update path. The new `agent_name_op` orchestrates the read/edit/sign.

## Surface
- **vta-sdk:** `TASK_WEBVH_AGENT_NAME_{DISABLE,ENABLE}_1_0` (+ `ALL_URIS`) and `AgentNameBody`/`AgentNameResultBody`.
- **vta-service:** `WebvhClient::{disable,enable}_agent_name`, the authenticated transport wrapper (401-retry, REST-only — the endpoints have no DIDComm equivalent), the `auth_cache` `on_server` helper, two handlers, two `Destructive` dispatch arms, and the feature-gated URI allowlist entries.

## Tests
`alsoKnownAs`-edit / domain-parse / name-match unit tests; wiremock coverage of the client methods (bearer-authed POST; 403 → `Forbidden`); the URI parity/census guards now cover the new URIs; and **the 61 update-module tests still pass**, confirming the `run_update` refactor is behaviour-preserving. `cargo fmt` + `clippy` clean; webvh-off build verified.

## Series
Depends on webvh-service #108 (drops the uncallable aal2 gate on `/api/agent-names/{remove,disable}`). Followed by a `did-hosting-ui` change wiring the park/disable/enable buttons to `window.vtaWallet.requestTask` with these task types.