### PR TITLE
fix(ci): open the self-pin refresh as an auto-merge PR, not a main push

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,10 +24,12 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  # `write` so the self-pin refresh can be committed back to main. Without
-  # that commit the refresh lives only in the runner's working copy and is
-  # discarded when the job ends — see the "Commit refreshed self-pins" step.
+  # `contents: write` to push the refresh branch; `pull-requests: write` to
+  # open + auto-merge the refresh PR. The refresh cannot push to main directly
+  # — the main ruleset (required status checks) rejects it — so it goes via a
+  # PR. See the "Open self-pin refresh PR" step.
   contents: write
+  pull-requests: write
   id-token: write # required for the OIDC token exchange with crates.io
 
 jobs:
@@ -143,62 +145,76 @@ jobs:
             fi
           done
 
-      # The refresh above happens in the runner's working copy. Until this
-      # step existed it was never committed, so main kept the stale pin and
-      # `scripts/check-lockfile-self-pins.sh` failed on the NEXT pull request
-      # — attributing a release-time problem to an unrelated author. It hit
-      # #706, #711 and #714 that way.
+      # The refresh above happens in the runner's working copy. It cannot be
+      # committed to main directly: the main branch is governed by an org
+      # ruleset (required status checks), which rejects any push the workflow
+      # makes — a `[skip ci]` commit runs no checks and so can never satisfy
+      # the rule. (An earlier version of this step pushed to main and was
+      # rejected every release; the stale pin then failed the NEXT unrelated
+      # PR's guard — #706/#711/#714/#720.)
       #
-      # CI on the release commit cannot prevent this: the guard deliberately
-      # allows a pin it cannot refresh, and the new version only becomes
-      # resolvable partway through this job, after that CI has finished. So
-      # the fix has to be here, not in a gate.
+      # CI on the release commit cannot prevent the staleness either: the guard
+      # deliberately allows a pin it cannot refresh, and the new version only
+      # becomes resolvable partway through this job, after that CI has finished.
+      # So the fix has to be here — but as a PR, not a direct push.
       #
-      # `[skip ci]` keeps the commit from re-triggering CI and this workflow.
-      # Re-running Publish would be harmless (every version is on crates.io
-      # by now, so the loop skips them all) but it is pure waste, and the
-      # commit's only content is a mechanical `cargo update --precise` to a
-      # version this job just published successfully against.
-      - name: Commit refreshed self-pins
+      # The refresh therefore opens a PR (a new branch is not ruleset-blocked)
+      # and enables auto-merge, so it lands once the required checks pass. One
+      # caveat: GitHub suppresses workflow runs for GITHUB_TOKEN-authored
+      # events, so with the default token the PR opens but CI does not run and
+      # it waits for a one-click human merge. Set a PAT / GitHub App token in
+      # the `SELF_PIN_REFRESH_TOKEN` secret to make the PR trigger CI and
+      # auto-merge unattended. Either way this is strictly better than the old
+      # rejected-push-then-buried-warning: the refresh is a visible PR, not a
+      # silently stale main.
+      - name: Open self-pin refresh PR
+        env:
+          GH_TOKEN: ${{ secrets.SELF_PIN_REFRESH_TOKEN || github.token }}
+          REFRESH_TOKEN: ${{ secrets.SELF_PIN_REFRESH_TOKEN || github.token }}
         run: |
           set -euo pipefail
 
           if git diff --quiet -- Cargo.lock; then
-            echo "no self-pin refresh to commit"
+            echo "no self-pin refresh needed"
             exit 0
           fi
 
-          echo "::notice::committing refreshed lockfile self-pins"
+          echo "::notice::opening a self-pin refresh PR"
           git diff --stat -- Cargo.lock
 
+          branch="chore/self-pin-refresh-${GITHUB_RUN_ID}"
           git config user.name  'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-
+          git switch -c "$branch"
           git add Cargo.lock
-          git commit -s -m 'chore(release): refresh crates.io self-pins [skip ci]' \
-            -m 'Published versions have just become resolvable, so the registry self-pins in Cargo.lock can finally point at them. Committed by the publish workflow because no pull request can do it — the versions do not exist on crates.io until this job runs.'
+          git commit -s -m 'chore(release): refresh crates.io self-pins' \
+            -m 'Published versions have just become resolvable, so the registry
+          self-pins in Cargo.lock can finally point at them. Opened by the publish
+          workflow as a PR: the versions do not exist on crates.io until this job
+          runs (so no pre-release PR can refresh them), and the main ruleset
+          forbids the workflow pushing to main directly.'
 
-          # Another push may have landed while crates were uploading. Rebase
-          # onto it rather than clobbering; the only local change is Cargo.lock.
-          for attempt in 1 2 3; do
-            if git push origin "HEAD:${GITHUB_REF_NAME}"; then
-              echo "self-pin refresh pushed"
-              exit 0
-            fi
-            echo "push rejected (attempt ${attempt}); rebasing onto ${GITHUB_REF_NAME}"
+          # Push the refresh branch with REFRESH_TOKEN (a new branch is not
+          # ruleset-blocked). With a PAT/App token this push triggers CI on the
+          # PR; with GITHUB_TOKEN it does not. Token is embedded in the remote
+          # URL rather than the persisted checkout credential so a PAT actually
+          # takes effect; GitHub masks it in the log.
+          if ! git push "https://x-access-token:${REFRESH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:refs/heads/${branch}"; then
+            echo "::warning::could not push the refresh branch — main still holds a stale self-pin; run scripts/check-lockfile-self-pins.sh locally and commit the fix"
+            exit 0
+          fi
 
-            # A concurrent Cargo.lock edit conflicts here. Abort out of the
-            # rebase rather than leaving the repo mid-operation, and stop
-            # retrying — `set -e` would otherwise fail this step and make a
-            # successful release look like a failed one.
-            if ! git pull --rebase origin "${GITHUB_REF_NAME}"; then
-              git rebase --abort || true
-              echo "rebase conflicted — giving up on the automatic refresh"
-              break
-            fi
-          done
+          pr_url=$(gh pr create --base "${GITHUB_REF_NAME}" --head "$branch" \
+            --title 'chore(release): refresh crates.io self-pins' \
+            --body 'Automated post-release refresh of the Cargo.lock registry self-pins (single-line lockfile change; see the commit body). Auto-merge is enabled — it lands once required checks pass. A PAT / GitHub App token in the SELF_PIN_REFRESH_TOKEN secret is what lets CI run on this bot PR; without it, merge manually.') || {
+            echo "::warning::pushed ${branch} but could not open the PR — open it manually"
+            exit 0
+          }
+          echo "opened ${pr_url}"
 
-          # Publishing already succeeded — failing the job here would imply the
-          # release did not ship. Warn loudly instead; the next PR's guard will
-          # catch the stale pin, which is the status quo this step improves on.
-          echo "::warning::could not push the refreshed Cargo.lock after 3 attempts — main still holds a stale self-pin; run scripts/check-lockfile-self-pins.sh locally and commit the fix"
+          # Enable auto-merge. Try squash then merge so it works whatever the
+          # repo's allowed methods are; a failure here is non-fatal (the PR is
+          # open and can be merged by hand).
+          gh pr merge "$pr_url" --auto --squash \
+            || gh pr merge "$pr_url" --auto --merge \
+            || echo "::warning::opened ${pr_url} but could not enable auto-merge — merge it manually once checks pass"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,7 +400,7 @@ dependencies = [
  "trust-tasks-rs",
  "url",
  "uuid",
- "vta-sdk 0.19.14",
+ "vta-sdk 0.19.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -10141,39 +10141,6 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.19.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "173406252db2bf6a3be9996ea256913d47ef426ff73f60f663daf61674efb038"
-dependencies = [
- "affinidi-crypto",
- "affinidi-did-resolver-cache-sdk",
- "affinidi-messaging-core",
- "affinidi-messaging-delivery",
- "affinidi-messaging-didcomm",
- "affinidi-openid4vci",
- "affinidi-openid4vp",
- "affinidi-tdk",
- "base64 0.22.1",
- "chrono",
- "curve25519-dalek",
- "didwebvh-rs",
- "ed25519-dalek",
- "futures-util",
- "getrandom 0.4.3",
- "multibase",
- "reqwest 0.13.4",
- "serde",
- "serde_json",
- "sha2 0.11.0",
- "thiserror 2.0.19",
- "tokio",
- "tracing",
- "url",
- "uuid",
-]
-
-[[package]]
-name = "vta-sdk"
 version = "0.19.15"
 dependencies = [
  "affinidi-bbs",
@@ -10230,6 +10197,39 @@ dependencies = [
  "x25519-dalek",
  "x509-parser 0.18.1",
  "zeroize",
+]
+
+[[package]]
+name = "vta-sdk"
+version = "0.19.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965e2b5dbac71f50c3da28c01e83ec68e6da097fc4e0ba4c20989818ab455121"
+dependencies = [
+ "affinidi-crypto",
+ "affinidi-did-resolver-cache-sdk",
+ "affinidi-messaging-core",
+ "affinidi-messaging-delivery",
+ "affinidi-messaging-didcomm",
+ "affinidi-openid4vci",
+ "affinidi-openid4vp",
+ "affinidi-tdk",
+ "base64 0.22.1",
+ "chrono",
+ "curve25519-dalek",
+ "didwebvh-rs",
+ "ed25519-dalek",
+ "futures-util",
+ "getrandom 0.4.3",
+ "multibase",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "thiserror 2.0.19",
+ "tokio",
+ "tracing",
+ "url",
+ "uuid",
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes the recurring `lockfile self-pins` failure at its root. #720 just inherited it; #706/#711/#714 before that.

## Root cause (confirmed from the #718 publish log)

#715 made the publish workflow refresh the stale `Cargo.lock` self-pin after a release and **push it to main**. That push has been **rejected every release**:

```
! [remote rejected] HEAD -> main (push declined due to repository rule violations)
```

`main` is governed by an **org-level ruleset** (`required_status_checks`). The refresh commit is `[skip ci]`, so it runs no checks and can *never* satisfy the rule — the push is rejected, the step soft-fails with a buried warning, and main stays stale. The next unrelated PR's guard then fails (the 0.19.15 release from #718 is the currently-stale one; #720 inherited it). `main` was *unprotected* when #715 was written — the ruleset was added since, which is why the mechanism silently stopped working.

## The fix

Refresh via a **PR with auto-merge** instead of a direct push:
- Create a branch (a new branch is **not** ruleset-blocked) → open a PR → `gh pr merge --auto` so it lands once required checks pass.
- Adds `pull-requests: write`.

**One documented caveat:** GitHub suppresses workflow runs for `GITHUB_TOKEN`-authored events, so with the default token the PR opens but CI doesn't run and it waits for a **one-click human merge**. A PAT / GitHub App token in a new **`SELF_PIN_REFRESH_TOKEN`** secret makes the PR trigger CI and auto-merge unattended.

Either way it's strictly better than the old rejected-push + silently-stale main: the refresh is now a **visible PR**, and it degrades gracefully at every failure point (push / PR-create / auto-merge) so a shipped release never reports as failed.

## To get fully-unattended auto-merge (optional, your call)

Add a fine-grained PAT or GitHub App token as the `SELF_PIN_REFRESH_TOKEN` repo secret, with `contents: write` + `pull-requests: write`. Without it, the refresh PR opens for a manual merge.

## Testing

The GitHub-API calls only run in a real release, but I verified the git plumbing + all three control-flow paths against a throwaway repo:
- **clean tree** → no-op, exit 0.
- **dirty, push fails** → warns, exit 0, repo left clean (no mid-rebase state).
- **dirty, push succeeds** → branch pushed, `gh pr create` + `gh pr merge --auto --squash` reached.

Plus `ruby -ryaml` parse and `bash -n` on the step. Includes the same one-line `0.19.14 → 0.19.15` pin refresh this branch inherited, so its own guard passes.