### PR TITLE
feat(webvh): agent-name set and remove Trust Tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,7 +400,7 @@ dependencies = [
  "trust-tasks-rs",
  "url",
  "uuid",
- "vta-sdk 0.19.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vta-sdk 0.19.15",
 ]
 
 [[package]]
@@ -2485,7 +2485,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.19.15",
+ "vta-sdk 0.19.16",
 ]
 
 [[package]]
@@ -3286,7 +3286,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.19.15",
+ "vta-sdk 0.19.16",
 ]
 
 [[package]]
@@ -6764,7 +6764,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.19.15",
+ "vta-sdk 0.19.16",
 ]
 
 [[package]]
@@ -10080,7 +10080,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.19",
  "tokio",
- "vta-sdk 0.19.15",
+ "vta-sdk 0.19.16",
  "vti-common",
  "x25519-dalek",
 ]
@@ -10113,7 +10113,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.19.15",
+ "vta-sdk 0.19.16",
 ]
 
 [[package]]
@@ -10136,12 +10136,45 @@ dependencies = [
  "tracing-subscriber",
  "trust-tasks-rs",
  "uniffi",
- "vta-sdk 0.19.15",
+ "vta-sdk 0.19.16",
 ]
 
 [[package]]
 name = "vta-sdk"
 version = "0.19.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965e2b5dbac71f50c3da28c01e83ec68e6da097fc4e0ba4c20989818ab455121"
+dependencies = [
+ "affinidi-crypto",
+ "affinidi-did-resolver-cache-sdk",
+ "affinidi-messaging-core",
+ "affinidi-messaging-delivery",
+ "affinidi-messaging-didcomm",
+ "affinidi-openid4vci",
+ "affinidi-openid4vp",
+ "affinidi-tdk",
+ "base64 0.22.1",
+ "chrono",
+ "curve25519-dalek",
+ "didwebvh-rs",
+ "ed25519-dalek",
+ "futures-util",
+ "getrandom 0.4.3",
+ "multibase",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "thiserror 2.0.19",
+ "tokio",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "vta-sdk"
+version = "0.19.16"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10200,41 +10233,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "vta-sdk"
-version = "0.19.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "965e2b5dbac71f50c3da28c01e83ec68e6da097fc4e0ba4c20989818ab455121"
-dependencies = [
- "affinidi-crypto",
- "affinidi-did-resolver-cache-sdk",
- "affinidi-messaging-core",
- "affinidi-messaging-delivery",
- "affinidi-messaging-didcomm",
- "affinidi-openid4vci",
- "affinidi-openid4vp",
- "affinidi-tdk",
- "base64 0.22.1",
- "chrono",
- "curve25519-dalek",
- "didwebvh-rs",
- "ed25519-dalek",
- "futures-util",
- "getrandom 0.4.3",
- "multibase",
- "reqwest 0.13.4",
- "serde",
- "serde_json",
- "sha2 0.11.0",
- "thiserror 2.0.19",
- "tokio",
- "tracing",
- "url",
- "uuid",
-]
-
-[[package]]
 name = "vta-service"
-version = "0.11.14"
+version = "0.12.0"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",
@@ -10314,7 +10314,7 @@ dependencies = [
  "utoipa-axum",
  "uuid",
  "vta-cli-common",
- "vta-sdk 0.19.15",
+ "vta-sdk 0.19.16",
  "vta-service",
  "vti-common",
  "vti-secrets",
@@ -10336,7 +10336,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.19",
  "tokio",
- "vta-sdk 0.19.15",
+ "vta-sdk 0.19.16",
 ]
 
 [[package]]
@@ -10410,7 +10410,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.19.15",
+ "vta-sdk 0.19.16",
  "vtc-service",
  "vti-common",
  "vti-secrets",
@@ -10462,7 +10462,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.19.15",
+ "vta-sdk 0.19.16",
  "webauthn-rs",
  "zeroize",
 ]
@@ -10489,7 +10489,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.19.15",
+ "vta-sdk 0.19.16",
  "vta-service",
  "vti-common",
 ]
@@ -10518,7 +10518,7 @@ dependencies = [
  "tokio",
  "tracing",
  "vaultrs",
- "vta-sdk 0.19.15",
+ "vta-sdk 0.19.16",
  "vti-common",
 ]
 

--- a/vta-enclave/Cargo.toml
+++ b/vta-enclave/Cargo.toml
@@ -30,7 +30,7 @@ vsock-store = ["vta-service/vsock-store"]
 vsock-log = ["dep:tokio-vsock"]
 
 [dependencies]
-vta-service = { path = "../vta-service", version = "0.11", default-features = false, features = ["tee"] }
+vta-service = { path = "../vta-service", version = "0.12", default-features = false, features = ["tee"] }
 vti-common = { path = "../vti-common", version = "0.11", features = ["encryption"] }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.19.15"
+version = "0.19.16"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/protocols/did_management/agent_name.rs
+++ b/vta-sdk/src/protocols/did_management/agent_name.rs
@@ -1,15 +1,18 @@
 use serde::{Deserialize, Serialize};
 
-/// Body for the agent-name enable/disable Trust Tasks
-/// (`spec/vta/webvh/agent-name/{enable,disable}/1.0`).
+/// Body for the four agent-name Trust Tasks
+/// (`spec/vta/webvh/agent-name/{set,remove,enable,disable}/1.0`).
 ///
-/// Both verbs carry the same shape: the hosted DID and the name's local
+/// All four carry the same shape: the hosted DID and the name's local
 /// part (the `alice` in `/@alice`, without the leading `@`). The agent
 /// resolves the current DID document, edits its `alsoKnownAs` to
 /// claim/no-longer-claim `https://<domain>/@<name>`, signs a new version,
-/// and submits it to the hosting server's `agent-name/{enable,disable}`
+/// and submits it to the hosting server's matching `agent-name/{op}`
 /// endpoint. The hosting domain is the DID's own host — derived from the
 /// `did:webvh` identifier, not carried here.
+///
+/// The verb lives in the task's `type` URI, not in this body, so the
+/// wallet's consent screen can classify each one independently.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
@@ -18,13 +21,19 @@ pub struct AgentNameBody {
     pub name: String,
 }
 
-/// Result of an agent-name enable/disable Trust Task.
+/// Result of an agent-name Trust Task.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct AgentNameResultBody {
     pub did: String,
     pub name: String,
-    /// `true` for enable (now served), `false` for disable (parked).
+    /// Whether the name resolves after the operation: `true` for `set`
+    /// and `enable`, `false` for `disable` and `remove`.
+    ///
+    /// It does **not** distinguish parked from released — `disable` and
+    /// `remove` both report `false`, and they differ in whether the name
+    /// stays reserved to this DID. The caller knows which verb it sent, so
+    /// the distinction is in the request rather than duplicated here.
     pub enabled: bool,
 }

--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -958,6 +958,39 @@ pub const TASK_WEBVH_DIDS_ROTATE_KEYS_1_0: &str =
 pub const TASK_WEBVH_DIDS_REGISTER_WITH_SERVER_1_0: &str =
     "https://trusttasks.org/spec/vta/webvh/dids/register-with-server/1.0";
 
+/// `spec/vta/webvh/agent-name/set/1.0` — bind an agent name
+/// (`/@alice`) to a hosted DID: publish a new signed version whose
+/// `alsoKnownAs` claims `https://<domain>/@<name>`, and register the
+/// binding with the host. Payload:
+/// [`crate::protocols::did_management::agent_name::AgentNameBody`].
+///
+/// Deliberately a distinct verb rather than a plain `dids/update` with
+/// an edited `alsoKnownAs`. The host's `set` endpoint applies checks
+/// the publish path does not express — the name must not be reserved,
+/// and must not already belong to another DID — so binding this way is
+/// what makes `name_taken` / `name_reserved` reportable instead of the
+/// bind appearing to succeed and the name never resolving.
+///
+/// Destructive (publishes a new version, so it rotates the update key
+/// like any update, and it creates a public binding). Auth: Admin role
+/// on the DID's context.
+pub const TASK_WEBVH_AGENT_NAME_SET_1_0: &str =
+    "https://trusttasks.org/spec/vta/webvh/agent-name/set/1.0";
+
+/// `spec/vta/webvh/agent-name/remove/1.0` — release an agent name:
+/// publish a new signed version whose `alsoKnownAs` no longer claims
+/// it, and tell the host to drop the reservation so anyone may reclaim
+/// the name. Payload:
+/// [`crate::protocols::did_management::agent_name::AgentNameBody`].
+///
+/// The irreversible counterpart to `disable`: parking keeps the name
+/// reserved to this DID, removing gives it up. Once released, the only
+/// way back is to re-`set` it — and someone else may have taken it
+/// first. Destructive; carries the same classification as `disable`,
+/// with more reason. Auth: Admin role on the DID's context.
+pub const TASK_WEBVH_AGENT_NAME_REMOVE_1_0: &str =
+    "https://trusttasks.org/spec/vta/webvh/agent-name/remove/1.0";
+
 /// `spec/vta/webvh/agent-name/disable/1.0` — park an agent name
 /// (`/@alice`) on a hosted DID: publish a new signed version whose
 /// `alsoKnownAs` no longer claims it (so the host stops serving the
@@ -1355,6 +1388,8 @@ pub const ALL_URIS: &[&str] = &[
     TASK_WEBVH_DIDS_UPDATE_1_0,
     TASK_WEBVH_DIDS_ROTATE_KEYS_1_0,
     TASK_WEBVH_DIDS_REGISTER_WITH_SERVER_1_0,
+    TASK_WEBVH_AGENT_NAME_SET_1_0,
+    TASK_WEBVH_AGENT_NAME_REMOVE_1_0,
     TASK_WEBVH_AGENT_NAME_DISABLE_1_0,
     TASK_WEBVH_AGENT_NAME_ENABLE_1_0,
     // DID-templates slice (global)

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.11.14"
+version = "0.12.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/operations/did_webvh/auth_cache.rs
+++ b/vta-service/src/operations/did_webvh/auth_cache.rs
@@ -323,7 +323,7 @@ pub async fn agent_name_op_on_server(
     deps: &super::WebvhDeps<'_>,
     vta_did: &str,
     server: &WebvhServerRecord,
-    enable: bool,
+    verb: super::update::AgentNameVerb,
     mnemonic: &str,
     name: &str,
     did_log: &str,
@@ -350,7 +350,7 @@ pub async fn agent_name_op_on_server(
     )
     .await?;
     transport
-        .agent_name_authenticated(enable, mnemonic, name, did_log, domain, &auth_ctx, server)
+        .agent_name_authenticated(verb, mnemonic, name, did_log, domain, &auth_ctx, server)
         .await
 }
 

--- a/vta-service/src/operations/did_webvh/mod.rs
+++ b/vta-service/src/operations/did_webvh/mod.rs
@@ -36,9 +36,9 @@ pub use servers::{
     update_webvh_server,
 };
 pub use update::{
-    RotateDidWebvhKeysOptions, UpdateDidWebvhError, UpdateDidWebvhOptions, UpdateDidWebvhResult,
-    UpdatePlan, agent_name_op, plan_did_webvh_update, rotate_did_webvh_keys, state_from_jsonl_pub,
-    update_did_webvh,
+    AgentNameVerb, RotateDidWebvhKeysOptions, UpdateDidWebvhError, UpdateDidWebvhOptions,
+    UpdateDidWebvhResult, UpdatePlan, agent_name_op, plan_did_webvh_update, rotate_did_webvh_keys,
+    state_from_jsonl_pub, update_did_webvh,
 };
 
 use std::sync::Arc;
@@ -1662,7 +1662,7 @@ impl<'a> WebvhTransport<'a> {
     /// refused rather than silently no-op'd.
     pub(super) async fn agent_name_authenticated(
         &mut self,
-        enable: bool,
+        verb: update::AgentNameVerb,
         mnemonic: &str,
         name: &str,
         did_log: &str,
@@ -1672,30 +1672,23 @@ impl<'a> WebvhTransport<'a> {
     ) -> Result<(), AppError> {
         let Self::Rest(c) = self else {
             return Err(AppError::Validation(
-                "agent-name enable/disable is not supported over the DIDComm transport; \
-                 the hosting server exposes it only via REST"
+                "agent-name operations are not supported over the DIDComm transport; \
+                 the hosting server exposes them only via REST"
                     .to_string(),
             ));
         };
-        let first = if enable {
-            c.enable_agent_name(mnemonic, name, did_log, domain).await
-        } else {
-            c.disable_agent_name(mnemonic, name, did_log, domain).await
-        };
-        match first {
+        let op = verb.endpoint();
+        match c.agent_name_op(op, mnemonic, name, did_log, domain).await {
             Ok(()) => Ok(()),
             Err(AppError::Unauthorized(_)) => {
                 info!(
                     server_id = %server.id,
+                    %op,
                     "webvh agent_name got 401; invalidating cache and retrying"
                 );
                 auth_cache::invalidate_cached_token(auth_ctx.webvh_ks, &server.id).await?;
                 auth_cache::ensure_fresh_access_token(auth_ctx, server, c).await?;
-                if enable {
-                    c.enable_agent_name(mnemonic, name, did_log, domain).await
-                } else {
-                    c.disable_agent_name(mnemonic, name, did_log, domain).await
-                }
+                c.agent_name_op(op, mnemonic, name, did_log, domain).await
             }
             Err(e) => Err(e),
         }

--- a/vta-service/src/operations/did_webvh/update/mod.rs
+++ b/vta-service/src/operations/did_webvh/update/mod.rs
@@ -43,7 +43,7 @@ mod validate;
 
 pub use errors::UpdateDidWebvhError;
 pub use options::{RotateDidWebvhKeysOptions, UpdateDidWebvhOptions, UpdateDidWebvhResult};
-pub use orchestrator::{agent_name_op, plan_did_webvh_update, update_did_webvh};
+pub use orchestrator::{AgentNameVerb, agent_name_op, plan_did_webvh_update, update_did_webvh};
 pub use plan::UpdatePlan;
 pub use rotate::rotate_did_webvh_keys;
 

--- a/vta-service/src/operations/did_webvh/update/orchestrator.rs
+++ b/vta-service/src/operations/did_webvh/update/orchestrator.rs
@@ -99,13 +99,56 @@ pub async fn update_did_webvh(
     }
 }
 
-/// Park or resume an agent name (`/@alice`) on a hosted webvh DID.
+/// Which agent-name operation [`agent_name_op`] performs.
 ///
-/// Reads the DID's current document, edits its `alsoKnownAs` to no-longer-claim
-/// (`enable == false`) or claim again (`enable == true`)
+/// The four verbs share one document-level behaviour — claim the name in
+/// `alsoKnownAs` or drop it — and differ in the registry effect the host
+/// applies. `claims_name` mirrors did-hosting's own
+/// `AgentNameOp::requires_claim` exactly; if the two ever disagree the host
+/// rejects the submitted document with `also_known_as_mismatch`, which is the
+/// invariant keeping the served state and the signed document from diverging.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AgentNameVerb {
+    /// Bind the name to this DID.
+    Set,
+    /// Release the name for anyone to reclaim.
+    Remove,
+    /// Resume serving a parked name.
+    Enable,
+    /// Park the name: stops resolving, stays reserved to this DID.
+    Disable,
+}
+
+impl AgentNameVerb {
+    /// The host endpoint segment — `POST /api/agent-names/{op}`.
+    pub fn endpoint(self) -> &'static str {
+        match self {
+            Self::Set => "set",
+            Self::Remove => "remove",
+            Self::Enable => "enable",
+            Self::Disable => "disable",
+        }
+    }
+
+    /// Whether the published document must claim the name.
+    pub fn claims_name(self) -> bool {
+        matches!(self, Self::Set | Self::Enable)
+    }
+}
+
+/// Bind, release, park or resume an agent name (`/@alice`) on a hosted webvh
+/// DID.
+///
+/// Reads the DID's current document, edits its `alsoKnownAs` to claim
+/// (`set`/`enable`) or no-longer-claim (`remove`/`disable`)
 /// `https://<domain>/@<name>`, then runs the *same* signing path as an update
-/// and submits the new version to the host's `agent-name/{disable,enable}`
-/// endpoint — which republishes it AND toggles the name registry atomically.
+/// and submits the new version to the host's `agent-name/{op}` endpoint —
+/// which republishes it AND applies the registry change atomically.
+///
+/// Binding through `set` rather than a plain `dids/update` with an edited
+/// `alsoKnownAs` is deliberate: the host's `set` endpoint enforces the
+/// reserved-name and already-taken checks, so a collision comes back as
+/// `name_taken` / `name_reserved` instead of a bind that appears to succeed.
 ///
 /// `did` may be a full `did:webvh:…` or a bare SCID. Refused for serverless
 /// DIDs (no host serves their names).
@@ -114,7 +157,7 @@ pub async fn agent_name_op(
     auth: &AuthClaims,
     did: &str,
     name: &str,
-    enable: bool,
+    verb: AgentNameVerb,
     vta_did: Option<&str>,
     channel: &str,
 ) -> Result<UpdateDidWebvhResult, UpdateDidWebvhError> {
@@ -143,14 +186,11 @@ pub async fn agent_name_op(
     let domain = domain_from_webvh_did(&record.did).ok_or_else(|| {
         UpdateDidWebvhError::Library(format!("cannot derive domain from DID {}", record.did))
     })?;
-    edit_agent_name(&mut document, &domain, name, enable);
+    edit_agent_name(&mut document, &domain, name, verb.claims_name());
 
     let opts = UpdateDidWebvhOptions {
         document: Some(document),
-        label: Some(format!(
-            "agent-name/{}",
-            if enable { "enable" } else { "disable" }
-        )),
+        label: Some(format!("agent-name/{}", verb.endpoint())),
         ..Default::default()
     };
 
@@ -164,7 +204,7 @@ pub async fn agent_name_op(
         Mode::Execute,
         PublishTarget::AgentName {
             name: name.to_string(),
-            enable,
+            verb,
         },
     )
     .await?
@@ -188,14 +228,14 @@ fn domain_from_webvh_did(did: &str) -> Option<String> {
     Some(host.replace("%3A", ":").replace("%3a", ":"))
 }
 
-/// Edit a DID document's `alsoKnownAs` to claim (`enable`) or drop (`!enable`)
+/// Edit a DID document's `alsoKnownAs` to claim (`claim`) or drop (`!claim`)
 /// the agent name `https://<domain>/@<name>`. Idempotent.
-fn edit_agent_name(document: &mut serde_json::Value, domain: &str, name: &str, enable: bool) {
+fn edit_agent_name(document: &mut serde_json::Value, domain: &str, name: &str, claim: bool) {
     let entry = format!("https://{domain}/@{name}");
     let Some(obj) = document.as_object_mut() else {
         return;
     };
-    if enable {
+    if claim {
         let arr = obj
             .entry("alsoKnownAs")
             .or_insert_with(|| serde_json::Value::Array(Vec::new()));
@@ -250,9 +290,9 @@ enum Outcome {
 enum PublishTarget {
     /// `PUT /api/dids/{mnemonic}` — every plain document update.
     DidLog,
-    /// `POST /api/agent-names/{disable,enable}` — the host republishes the log
-    /// AND toggles the name registry in one commit.
-    AgentName { name: String, enable: bool },
+    /// `POST /api/agent-names/{set,remove,enable,disable}` — the host
+    /// republishes the log AND applies the registry change in one commit.
+    AgentName { name: String, verb: AgentNameVerb },
 }
 
 async fn run_update(
@@ -786,17 +826,17 @@ async fn run_update(
                 .await
                 .map_err(|e| UpdateDidWebvhError::Publish(format!("publish_did: {e}")))?;
             }
-            PublishTarget::AgentName { name, enable } => {
-                // The host both republishes this signed log AND toggles the
-                // name registry, so we must name the domain explicitly (it is
-                // the DID's own host) — unlike a plain publish, which lets the
-                // slot lookup supply it.
+            PublishTarget::AgentName { name, verb } => {
+                // The host both republishes this signed log AND applies the
+                // name registry change, so we must name the domain explicitly
+                // (it is the DID's own host) — unlike a plain publish, which
+                // lets the slot lookup supply it.
                 let domain = domain_from_webvh_did(&record.did);
                 super::super::agent_name_op_on_server(
                     deps,
                     vta_did,
                     &server,
-                    *enable,
+                    *verb,
                     &record.mnemonic,
                     name,
                     &new_log_jsonl,
@@ -864,8 +904,73 @@ async fn run_update(
 
 #[cfg(test)]
 mod agent_name_tests {
-    use super::{domain_from_webvh_did, edit_agent_name, is_agent_name};
+    use super::{AgentNameVerb, domain_from_webvh_did, edit_agent_name, is_agent_name};
     use serde_json::{Value, json};
+
+    /// Each verb maps to its own host endpoint. A transposition here would
+    /// send `remove` to `disable` — releasing a name the caller meant to
+    /// park, or the reverse — and nothing downstream could detect it.
+    #[test]
+    fn verbs_map_to_distinct_endpoints() {
+        assert_eq!(AgentNameVerb::Set.endpoint(), "set");
+        assert_eq!(AgentNameVerb::Remove.endpoint(), "remove");
+        assert_eq!(AgentNameVerb::Enable.endpoint(), "enable");
+        assert_eq!(AgentNameVerb::Disable.endpoint(), "disable");
+    }
+
+    /// The document direction per verb, which must match did-hosting's
+    /// `AgentNameOp::requires_claim` exactly — the host rejects the submitted
+    /// document with `also_known_as_mismatch` if it doesn't, and that
+    /// agreement is what keeps a served name and the signed document that
+    /// claims it from ever diverging.
+    #[test]
+    fn claim_direction_matches_the_hosts_rule() {
+        assert!(AgentNameVerb::Set.claims_name());
+        assert!(AgentNameVerb::Enable.claims_name());
+        assert!(!AgentNameVerb::Remove.claims_name());
+        assert!(!AgentNameVerb::Disable.claims_name());
+    }
+
+    /// End-to-end on the document: for every verb, the `alsoKnownAs` the VTA
+    /// signs claims the name iff that verb claims it.
+    #[test]
+    fn edited_document_matches_the_verbs_claim_direction() {
+        for verb in [
+            AgentNameVerb::Set,
+            AgentNameVerb::Remove,
+            AgentNameVerb::Enable,
+            AgentNameVerb::Disable,
+        ] {
+            // Start from a document that already claims the name, so both
+            // directions are a real change for at least one verb.
+            let mut doc = json!({ "alsoKnownAs": ["https://example.com/@alice"] });
+            edit_agent_name(&mut doc, "example.com", "alice", verb.claims_name());
+            let claimed = doc
+                .get("alsoKnownAs")
+                .and_then(|v| v.as_array())
+                .is_some_and(|l| l.iter().any(|v| is_agent_name(v, "example.com", "alice")));
+            assert_eq!(
+                claimed,
+                verb.claims_name(),
+                "{} must leave the document {} the name",
+                verb.endpoint(),
+                if verb.claims_name() {
+                    "claiming"
+                } else {
+                    "not claiming"
+                }
+            );
+
+            // …and from a document that does not claim it.
+            let mut doc = json!({});
+            edit_agent_name(&mut doc, "example.com", "alice", verb.claims_name());
+            let claimed = doc
+                .get("alsoKnownAs")
+                .and_then(|v| v.as_array())
+                .is_some_and(|l| l.iter().any(|v| is_agent_name(v, "example.com", "alice")));
+            assert_eq!(claimed, verb.claims_name(), "{}", verb.endpoint());
+        }
+    }
 
     #[test]
     fn domain_parses_host_and_decodes_port() {

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -153,6 +153,8 @@ const KNOWN_FEATURE_GATED_URIS: &[&str] = &[
     vta_sdk::trust_tasks::TASK_WEBVH_DIDS_UPDATE_1_0,
     vta_sdk::trust_tasks::TASK_WEBVH_DIDS_ROTATE_KEYS_1_0,
     vta_sdk::trust_tasks::TASK_WEBVH_DIDS_REGISTER_WITH_SERVER_1_0,
+    vta_sdk::trust_tasks::TASK_WEBVH_AGENT_NAME_SET_1_0,
+    vta_sdk::trust_tasks::TASK_WEBVH_AGENT_NAME_REMOVE_1_0,
     vta_sdk::trust_tasks::TASK_WEBVH_AGENT_NAME_DISABLE_1_0,
     vta_sdk::trust_tasks::TASK_WEBVH_AGENT_NAME_ENABLE_1_0,
     // did-management Trust-Task spec URIs — declared in vta-sdk by
@@ -930,13 +932,23 @@ dispatch_table! {
     vta_sdk::trust_tasks::TASK_WEBVH_DIDS_REGISTER_WITH_SERVER_1_0
         => webvh::handle_dids_register_with_server
         [ Mutating None false ],
-    // Agent-name park/resume. Both publish a new signed version (and so
-    // rotate the update key exactly like any update), and both change a
-    // public name binding — Destructive, like `dids/update`, per the
-    // rationale above. Classifying them Destructive is what makes the
+    // Agent-name bind/release/park/resume. All four publish a new signed
+    // version (and so rotate the update key exactly like any update), and all
+    // four change a public name binding — Destructive, like `dids/update`,
+    // per the rationale above. Classifying them Destructive is what makes the
     // wallet force a cross-device type-to-confirm, which is the elevation
     // for these ops (the hosting endpoint is deliberately not step-up-gated
     // — the VTA can't hold an aal2 session).
+    //
+    // `remove` earns the classification most directly: it releases the name
+    // for anyone to reclaim, so unlike `disable` it is not recoverable by
+    // this DID alone.
+    #[cfg(feature = "webvh")]
+    vta_sdk::trust_tasks::TASK_WEBVH_AGENT_NAME_SET_1_0 => webvh::handle_agent_name_set
+        [ Destructive None false ],
+    #[cfg(feature = "webvh")]
+    vta_sdk::trust_tasks::TASK_WEBVH_AGENT_NAME_REMOVE_1_0 => webvh::handle_agent_name_remove
+        [ Destructive None false ],
     #[cfg(feature = "webvh")]
     vta_sdk::trust_tasks::TASK_WEBVH_AGENT_NAME_DISABLE_1_0 => webvh::handle_agent_name_disable
         [ Destructive None false ],

--- a/vta-service/src/trust_tasks/webvh.rs
+++ b/vta-service/src/trust_tasks/webvh.rs
@@ -54,8 +54,8 @@ use crate::auth::AuthClaims;
 use crate::error::AppError;
 use crate::operations;
 use crate::operations::did_webvh::{
-    RegisterDidWithServerError, RegisterDidWithServerParams, RotateDidWebvhKeysOptions,
-    UpdateDidWebvhOptions, register_did_with_server,
+    AgentNameVerb, RegisterDidWithServerError, RegisterDidWithServerParams,
+    RotateDidWebvhKeysOptions, UpdateDidWebvhOptions, register_did_with_server,
 };
 use crate::server::AppState;
 
@@ -368,6 +368,30 @@ pub(super) async fn handle_dids_update(
     }
 }
 
+/// `spec/vta/webvh/agent-name/set/1.0` — bind an agent name: publish a new
+/// signed version claiming it in `alsoKnownAs` and register the binding with
+/// the host, which refuses a reserved name or one another DID already holds.
+/// Destructive.
+pub(super) async fn handle_agent_name_set(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    handle_agent_name(state, auth, doc, AgentNameVerb::Set).await
+}
+
+/// `spec/vta/webvh/agent-name/remove/1.0` — release an agent name: publish a
+/// new signed version dropping it from `alsoKnownAs` and tell the host to drop
+/// the reservation, so anyone may reclaim it. Destructive — and unlike
+/// `disable`, not recoverable by this DID alone.
+pub(super) async fn handle_agent_name_remove(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    handle_agent_name(state, auth, doc, AgentNameVerb::Remove).await
+}
+
 /// `spec/vta/webvh/agent-name/disable/1.0` — park an agent name: publish a new
 /// signed version dropping it from `alsoKnownAs` and tell the host to keep it
 /// reserved. Destructive.
@@ -376,7 +400,7 @@ pub(super) async fn handle_agent_name_disable(
     auth: &AuthClaims,
     doc: TrustTask<Value>,
 ) -> TrustTaskOutcome {
-    handle_agent_name(state, auth, doc, false).await
+    handle_agent_name(state, auth, doc, AgentNameVerb::Disable).await
 }
 
 /// `spec/vta/webvh/agent-name/enable/1.0` — resume serving a parked name:
@@ -386,14 +410,14 @@ pub(super) async fn handle_agent_name_enable(
     auth: &AuthClaims,
     doc: TrustTask<Value>,
 ) -> TrustTaskOutcome {
-    handle_agent_name(state, auth, doc, true).await
+    handle_agent_name(state, auth, doc, AgentNameVerb::Enable).await
 }
 
 async fn handle_agent_name(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
-    enable: bool,
+    verb: AgentNameVerb,
 ) -> TrustTaskOutcome {
     let req: AgentNameBody = match parse_payload(&doc) {
         Ok(r) => r,
@@ -415,7 +439,7 @@ async fn handle_agent_name(
         auth,
         &req.did,
         &req.name,
-        enable,
+        verb,
         vta_did.as_deref(),
         TRANSPORT_TRUST_TASK,
     )
@@ -426,7 +450,9 @@ async fn handle_agent_name(
             AgentNameResultBody {
                 did: req.did,
                 name: req.name,
-                enabled: enable,
+                // Whether the name resolves now — `remove` reports `false`
+                // like `disable`; the caller knows which verb it sent.
+                enabled: verb.claims_name(),
             },
         ),
         Err(e) => app_error_to_reject(&doc, AppError::from(e)),

--- a/vta-service/src/webvh_client.rs
+++ b/vta-service/src/webvh_client.rs
@@ -597,14 +597,19 @@ impl WebvhClient {
         Ok(())
     }
 
-    /// POST /api/agent-names/{op} — park (`disable`) or resume (`enable`) an
-    /// agent name via a signed new DID version.
+    /// POST /api/agent-names/{op} — bind (`set`), release (`remove`), park
+    /// (`disable`) or resume (`enable`) an agent name via a signed new DID
+    /// version.
     ///
-    /// `op` is `"disable"` or `"enable"`. `did_log` is the full new signed
-    /// `did.jsonl` whose `alsoKnownAs` no longer claims (disable) or claims
-    /// again (enable) the name; the host verifies that, republishes it as a new
-    /// version, and toggles the name registry in one commit.
-    async fn agent_name_op(
+    /// `did_log` is the full new signed `did.jsonl` whose `alsoKnownAs` claims
+    /// (`set`/`enable`) or no longer claims (`remove`/`disable`) the name; the
+    /// host verifies that direction matches the verb, republishes the log as a
+    /// new version, and applies the registry change in one commit.
+    ///
+    /// One generic call rather than four wrappers: the request body is
+    /// identical for every verb, so the only thing a wrapper would add is a
+    /// place for the endpoint and the document direction to disagree.
+    pub async fn agent_name_op(
         &self,
         op: &str,
         mnemonic: &str,
@@ -639,30 +644,6 @@ impl WebvhClient {
         self.send(req, &format!("POST /api/agent-names/{op}"))
             .await?;
         Ok(())
-    }
-
-    /// Park an agent name (kept reserved, stops resolving).
-    pub async fn disable_agent_name(
-        &self,
-        mnemonic: &str,
-        name: &str,
-        did_log: &str,
-        domain: Option<&str>,
-    ) -> Result<(), AppError> {
-        self.agent_name_op("disable", mnemonic, name, did_log, domain)
-            .await
-    }
-
-    /// Resume serving a parked agent name.
-    pub async fn enable_agent_name(
-        &self,
-        mnemonic: &str,
-        name: &str,
-        did_log: &str,
-        domain: Option<&str>,
-    ) -> Result<(), AppError> {
-        self.agent_name_op("enable", mnemonic, name, did_log, domain)
-            .await
     }
 
     /// DELETE /api/dids/{mnemonic}.
@@ -894,7 +875,7 @@ mod tests {
     use crate::webvh_auth::VtaSigningIdentity;
     use ed25519_dalek::SigningKey;
     use serde_json::json;
-    use wiremock::matchers::{header, method, path};
+    use wiremock::matchers::{body_json, header, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     fn signing_identity() -> ([u8; 32], String, String) {
@@ -1373,7 +1354,7 @@ mod tests {
         let mut client = WebvhClient::new(&server.uri(), "did:web:daemon-mock.example").unwrap();
         client.set_access_token("tok-1".to_string());
         client
-            .disable_agent_name("alice", "alice", "<jsonl>", Some("example.com"))
+            .agent_name_op("disable", "alice", "alice", "<jsonl>", Some("example.com"))
             .await
             .expect("disable should POST and succeed");
     }
@@ -1391,12 +1372,72 @@ mod tests {
         let mut client = WebvhClient::new(&server.uri(), "did:web:daemon-mock.example").unwrap();
         client.set_access_token("tok-1".to_string());
         let err = client
-            .enable_agent_name("alice", "alice", "<jsonl>", None)
+            .agent_name_op("enable", "alice", "alice", "<jsonl>", None)
             .await
             .unwrap_err();
         assert!(
             matches!(err, AppError::Forbidden(_)),
             "a 403 from the host maps to Forbidden, got {err:?}"
+        );
+    }
+
+    /// Every verb hits its own endpoint and carries the same body. The name
+    /// is what the caller passes, not a fixed `alice` — a wrapper that
+    /// transposed arguments would still pass a same-value test.
+    #[tokio::test]
+    async fn agent_name_op_routes_each_verb_to_its_endpoint() {
+        for verb in ["set", "remove", "enable", "disable"] {
+            let server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .and(path(format!("/api/agent-names/{verb}")))
+                .and(header("Authorization", "Bearer tok-1"))
+                .and(body_json(json!({
+                    "mnemonic": "slot-one",
+                    "name": "bob",
+                    "didLog": "<jsonl>",
+                    "domain": "example.com",
+                })))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "record": {} })))
+                .expect(1)
+                .mount(&server)
+                .await;
+
+            let mut client =
+                WebvhClient::new(&server.uri(), "did:web:daemon-mock.example").unwrap();
+            client.set_access_token("tok-1".to_string());
+            client
+                .agent_name_op(verb, "slot-one", "bob", "<jsonl>", Some("example.com"))
+                .await
+                .unwrap_or_else(|e| panic!("{verb} should POST and succeed: {e:?}"));
+        }
+    }
+
+    /// A name already held by another DID comes back as a distinguishable
+    /// error, not a generic failure — the client has to render "pick another
+    /// name" differently from "you don't control this DID".
+    #[tokio::test]
+    async fn agent_name_set_surfaces_a_taken_name() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/agent-names/set"))
+            .respond_with(ResponseTemplate::new(409).set_body_json(json!({
+                "code": "did-management:name_taken",
+                "message": "agent name is already taken",
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let mut client = WebvhClient::new(&server.uri(), "did:web:daemon-mock.example").unwrap();
+        client.set_access_token("tok-1".to_string());
+        let err = client
+            .agent_name_op("set", "slot-one", "alice", "<jsonl>", None)
+            .await
+            .unwrap_err();
+        let rendered = format!("{err:?}");
+        assert!(
+            rendered.contains("name_taken") || rendered.contains("already taken"),
+            "the host's reason must survive into the error, got {rendered}"
         );
     }
 }


### PR DESCRIPTION
Requested by the OpenVTC integration, which reaches webvh only through the VTA and so could park and resume an agent name but never bind or release one.

## Why these need to be explicit verbs

Binding *appears* to work already: the hosting UI binds by sending a plain `webvh/dids/update` with `alsoKnownAs` edited, and did-hosting reconciles the registry on publish. That path is now correct (affinidi-webvh-service#113 closed the hole where it skipped every guard), but it is still the wrong thing to build a client on — **its errors are not the agent-name taxonomy**. Going through the explicit verb is what makes `name_taken` and `name_reserved` reportable, so a client can tell "pick another name" from "you don't control this DID" from "the host is down".

## Shape

The four verbs share one document-level behaviour and differ only in the registry effect, so the `bool` threaded from the trust-task handler through the orchestrator to the transport becomes an `AgentNameVerb`:

| verb | `claims_name()` | endpoint |
|---|---|---|
| `set` | ✅ | `POST /api/agent-names/set` |
| `enable` | ✅ | `…/enable` |
| `disable` | ❌ | `…/disable` |
| `remove` | ❌ | `…/remove` |

`claims_name()` mirrors did-hosting's `AgentNameOp::requires_claim` exactly. If the two ever disagree the host rejects the document with `also_known_as_mismatch` — that agreement is the invariant keeping the served state and the signed document from diverging, so it is pinned by a test.

The four `WebvhClient` wrappers collapse into the generic `agent_name_op`, whose body was already identical for every verb. Four wrappers only add four places for the endpoint and the document direction to disagree.

## Consent classification

All four are `Destructive`, which is what makes the wallet force a cross-device type-to-confirm. That **is** the elevation for these ops — the hosting endpoint deliberately isn't step-up-gated, because the VTA's did-hosting session is aal1 by construction (webvh-service#108). `remove` earns the classification most directly: it releases the name for anyone to reclaim, so unlike `disable` it is not recoverable by this DID alone.

Serverless DIDs stay refused, and the new verbs inherit that from the shared `agent_name_op`.

## Two judgement calls worth reviewing

**`vta-service` → `0.12.0`, not a patch.** `agent_name_op` is `pub` and its signature changes (a `bool` cannot carry four verbs). Shipping a breaking change as a patch is exactly what broke published consumers with `StartupResult` in 0.18.20, so this takes the minor. `vta-enclave` pins `"0.11"` and is updated to `"0.12"`; it is `publish = false`, so the version-bump guard skips it. `vta-sdk` is purely additive → `0.19.16`.

**`AgentNameResultBody` is unchanged.** The request asked me to confirm `enabled` reads sensibly for the new verbs or widen the result. `enabled` answers "does the name resolve now", so `remove` reports `false` like `disable` — it does not distinguish parked from released. Widening means adding a field to a struct that is not `non_exhaustive`, i.e. a breaking change, for a distinction the caller already has (it knows which verb it sent). I documented the semantics instead. Easy to overturn — say the word and it's a one-line follow-up on the same minor bump.

## Tests

- Each verb routes to its own endpoint with an identical body, asserted with `body_json` and a name that differs from the mnemonic (a transposed-argument wrapper would still pass a same-value test).
- `claims_name()` matches the host's rule per verb.
- Per verb, the edited document claims the name iff that verb claims it — from both a document that already claims it and one that doesn't.
- `set` against a `409 name_taken` surfaces the host's reason rather than a generic failure.

`cargo test --workspace` (the CI command) is green: 40 targets, zero failures. `fmt --check` clean; `clippy --workspace --all-features --all-targets` reports only two pre-existing warnings in `did_webvh.rs` and `provision_integration/preconditions.rs`, both untouched here.

> Note for anyone re-running locally: `cargo test --workspace --all-features` fails on this repo at any commit, including unmodified `main`. The `keys::seed_store::tests::*_without_feature_is_config_error` family asserts an error *when a backend's feature is absent*, and `--all-features` compiles every backend. Use the CI command.

## Follow-ups from the same report, not in this PR

The registry read path (surfacing `agentNames` per DID so a client can offer "resume" without the user retyping a parked name from memory) and the `/agent-names/check` availability passthrough. Both are additive and independent of this change.