### PR TITLE
feat(webvh): agent-name list and check Trust Tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2485,7 +2485,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.19.16",
+ "vta-sdk 0.19.17",
 ]
 
 [[package]]
@@ -3286,7 +3286,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.19.16",
+ "vta-sdk 0.19.17",
 ]
 
 [[package]]
@@ -6764,7 +6764,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.19.16",
+ "vta-sdk 0.19.17",
 ]
 
 [[package]]
@@ -10080,7 +10080,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.19",
  "tokio",
- "vta-sdk 0.19.16",
+ "vta-sdk 0.19.17",
  "vti-common",
  "x25519-dalek",
 ]
@@ -10113,7 +10113,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.19.16",
+ "vta-sdk 0.19.17",
 ]
 
 [[package]]
@@ -10136,7 +10136,7 @@ dependencies = [
  "tracing-subscriber",
  "trust-tasks-rs",
  "uniffi",
- "vta-sdk 0.19.16",
+ "vta-sdk 0.19.17",
 ]
 
 [[package]]
@@ -10174,7 +10174,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.19.16"
+version = "0.19.17"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10234,7 +10234,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",
@@ -10314,7 +10314,7 @@ dependencies = [
  "utoipa-axum",
  "uuid",
  "vta-cli-common",
- "vta-sdk 0.19.16",
+ "vta-sdk 0.19.17",
  "vta-service",
  "vti-common",
  "vti-secrets",
@@ -10336,7 +10336,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.19",
  "tokio",
- "vta-sdk 0.19.16",
+ "vta-sdk 0.19.17",
 ]
 
 [[package]]
@@ -10410,7 +10410,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.19.16",
+ "vta-sdk 0.19.17",
  "vtc-service",
  "vti-common",
  "vti-secrets",
@@ -10462,7 +10462,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.19.16",
+ "vta-sdk 0.19.17",
  "webauthn-rs",
  "zeroize",
 ]
@@ -10489,7 +10489,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.19.16",
+ "vta-sdk 0.19.17",
  "vta-service",
  "vti-common",
 ]
@@ -10518,7 +10518,7 @@ dependencies = [
  "tokio",
  "tracing",
  "vaultrs",
- "vta-sdk 0.19.16",
+ "vta-sdk 0.19.17",
  "vti-common",
 ]
 

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.19.16"
+version = "0.19.17"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/protocols/did_management/agent_name.rs
+++ b/vta-sdk/src/protocols/did_management/agent_name.rs
@@ -37,3 +37,68 @@ pub struct AgentNameResultBody {
     /// the distinction is in the request rather than duplicated here.
     pub enabled: bool,
 }
+
+/// One name in a DID's agent-name registry.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct AgentNameEntry {
+    /// The local part, without the `@`.
+    pub name: String,
+    /// Whether the name currently resolves.
+    ///
+    /// `false` means **parked, not gone**: the name is still reserved to this
+    /// DID and nobody else can claim it.
+    pub enabled: bool,
+    /// Unix seconds when the name was first bound to this DID.
+    pub created_at: u64,
+}
+
+/// Body for `spec/vta/webvh/agent-name/list/1.0`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct AgentNameListBody {
+    /// The hosted DID — a full `did:webvh:…` or a bare SCID.
+    pub did: String,
+}
+
+/// Result of `spec/vta/webvh/agent-name/list/1.0` — the DID's registry as the
+/// hosting control plane holds it.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct AgentNameListResultBody {
+    pub did: String,
+    /// Every name bound to this DID, parked ones included.
+    pub names: Vec<AgentNameEntry>,
+}
+
+/// Body for `spec/vta/webvh/agent-name/check/1.0`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct AgentNameCheckBody {
+    /// The DID whose host the name is checked against. Availability is
+    /// domain-scoped, and the domain is the DID's own host — the same rule
+    /// the mutating verbs use.
+    pub did: String,
+    /// The name's local part, without the `@`.
+    pub name: String,
+}
+
+/// Result of `spec/vta/webvh/agent-name/check/1.0`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct AgentNameCheckResultBody {
+    /// The canonicalised local part.
+    pub name: String,
+    /// The domain the answer applies to.
+    pub domain: String,
+    /// Free to claim: neither reserved nor already bound on this domain.
+    pub available: bool,
+    /// On the host's reserved list (`@admin`, `@support`, …) — unavailable
+    /// but well-formed, which is distinct from a malformed name (an error).
+    pub reserved: bool,
+}

--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -958,6 +958,29 @@ pub const TASK_WEBVH_DIDS_ROTATE_KEYS_1_0: &str =
 pub const TASK_WEBVH_DIDS_REGISTER_WITH_SERVER_1_0: &str =
     "https://trusttasks.org/spec/vta/webvh/dids/register-with-server/1.0";
 
+/// `spec/vta/webvh/agent-name/list/1.0` — read a hosted DID's
+/// agent-name registry as the control plane holds it. Payload:
+/// [`crate::protocols::did_management::agent_name::AgentNameListBody`].
+///
+/// Needed because a **parked** name is deliberately absent from the DID
+/// document — that absence is how parking stops it resolving — so a
+/// client that only resolves the document cannot see parked names and
+/// cannot offer "resume" without making the user retype the name from
+/// memory. Read-only. Auth: any authenticated caller on the DID's
+/// context.
+pub const TASK_WEBVH_AGENT_NAME_LIST_1_0: &str =
+    "https://trusttasks.org/spec/vta/webvh/agent-name/list/1.0";
+
+/// `spec/vta/webvh/agent-name/check/1.0` — ask whether a name is free
+/// on the DID's host before signing anything. Payload:
+/// [`crate::protocols::did_management::agent_name::AgentNameCheckBody`].
+///
+/// Without it the only way to discover a collision is to publish a new
+/// signed DID version and have the bind rejected. Reports `reserved`
+/// separately from `available` so a client can say *why*. Read-only.
+pub const TASK_WEBVH_AGENT_NAME_CHECK_1_0: &str =
+    "https://trusttasks.org/spec/vta/webvh/agent-name/check/1.0";
+
 /// `spec/vta/webvh/agent-name/set/1.0` — bind an agent name
 /// (`/@alice`) to a hosted DID: publish a new signed version whose
 /// `alsoKnownAs` claims `https://<domain>/@<name>`, and register the
@@ -1388,6 +1411,8 @@ pub const ALL_URIS: &[&str] = &[
     TASK_WEBVH_DIDS_UPDATE_1_0,
     TASK_WEBVH_DIDS_ROTATE_KEYS_1_0,
     TASK_WEBVH_DIDS_REGISTER_WITH_SERVER_1_0,
+    TASK_WEBVH_AGENT_NAME_LIST_1_0,
+    TASK_WEBVH_AGENT_NAME_CHECK_1_0,
     TASK_WEBVH_AGENT_NAME_SET_1_0,
     TASK_WEBVH_AGENT_NAME_REMOVE_1_0,
     TASK_WEBVH_AGENT_NAME_DISABLE_1_0,

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.12.0"
+version = "0.12.1"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/operations/did_webvh/auth_cache.rs
+++ b/vta-service/src/operations/did_webvh/auth_cache.rs
@@ -354,6 +354,73 @@ pub async fn agent_name_op_on_server(
         .await
 }
 
+/// Authenticate and read a DID's agent-name registry from the hosting server.
+/// Same encapsulation as [`agent_name_op_on_server`], read-only.
+pub async fn list_agent_names_on_server(
+    deps: &super::WebvhDeps<'_>,
+    vta_did: &str,
+    server: &WebvhServerRecord,
+    mnemonic: &str,
+    domain: Option<&str>,
+) -> Result<Vec<crate::webvh_client::AgentNameEntryWire>, AppError> {
+    let identity = load_vta_webvh_signing_identity(
+        deps.keys_ks,
+        deps.imported_ks,
+        deps.seed_store,
+        deps.audit_ks,
+        vta_did,
+    )
+    .await?;
+    let auth_ctx = AuthContext {
+        webvh_ks: deps.webvh_ks,
+        identity: &identity,
+        locks: deps.auth_locks,
+    };
+    let mut transport = super::WebvhTransport::from_server_authenticated(
+        server,
+        deps.did_resolver,
+        deps.didcomm_bridge,
+        &auth_ctx,
+    )
+    .await?;
+    transport
+        .list_agent_names_authenticated(mnemonic, domain, &auth_ctx, server)
+        .await
+}
+
+/// Authenticate and probe agent-name availability on the hosting server.
+pub async fn check_agent_name_on_server(
+    deps: &super::WebvhDeps<'_>,
+    vta_did: &str,
+    server: &WebvhServerRecord,
+    name: &str,
+    domain: Option<&str>,
+) -> Result<crate::webvh_client::AgentNameAvailabilityWire, AppError> {
+    let identity = load_vta_webvh_signing_identity(
+        deps.keys_ks,
+        deps.imported_ks,
+        deps.seed_store,
+        deps.audit_ks,
+        vta_did,
+    )
+    .await?;
+    let auth_ctx = AuthContext {
+        webvh_ks: deps.webvh_ks,
+        identity: &identity,
+        locks: deps.auth_locks,
+    };
+    let mut transport = super::WebvhTransport::from_server_authenticated(
+        server,
+        deps.did_resolver,
+        deps.didcomm_bridge,
+        &auth_ctx,
+    )
+    .await?;
+    transport
+        .check_agent_name_authenticated(name, domain, &auth_ctx, server)
+        .await
+}
+
 /// Load the VTA's signing identity for daemon REST authentication.
 ///
 /// Looks up `{vta_did}#key-0` via `get_key_secret_internal` under

--- a/vta-service/src/operations/did_webvh/mod.rs
+++ b/vta-service/src/operations/did_webvh/mod.rs
@@ -18,8 +18,8 @@ mod webvh_keys;
 
 pub use auth_cache::WebvhAuthLocks;
 pub(crate) use auth_cache::{
-    agent_name_op_on_server, delete_log_on_server, publish_log_to_server,
-    register_did_atomic_on_server,
+    agent_name_op_on_server, check_agent_name_on_server, delete_log_on_server,
+    list_agent_names_on_server, publish_log_to_server, register_did_atomic_on_server,
 };
 
 pub(crate) use concurrency::{RaceDetected, RecordSnapshot};
@@ -37,8 +37,8 @@ pub use servers::{
 };
 pub use update::{
     AgentNameVerb, RotateDidWebvhKeysOptions, UpdateDidWebvhError, UpdateDidWebvhOptions,
-    UpdateDidWebvhResult, UpdatePlan, agent_name_op, plan_did_webvh_update, rotate_did_webvh_keys,
-    state_from_jsonl_pub, update_did_webvh,
+    UpdateDidWebvhResult, UpdatePlan, agent_name_op, check_agent_name, list_agent_names,
+    plan_did_webvh_update, rotate_did_webvh_keys, state_from_jsonl_pub, update_did_webvh,
 };
 
 use std::sync::Arc;
@@ -1660,6 +1660,67 @@ impl<'a> WebvhTransport<'a> {
     /// with one-shot 401 retry. REST-only: the hosting server exposes the
     /// agent-name endpoints over REST only, so a DIDComm-transport server is
     /// refused rather than silently no-op'd.
+    /// Read the DID's agent-name registry from the host, retrying once on a
+    /// stale token exactly as the mutating path does.
+    pub(super) async fn list_agent_names_authenticated(
+        &mut self,
+        mnemonic: &str,
+        domain: Option<&str>,
+        auth_ctx: &auth_cache::AuthContext<'_>,
+        server: &WebvhServerRecord,
+    ) -> Result<Vec<crate::webvh_client::AgentNameEntryWire>, AppError> {
+        let Self::Rest(c) = self else {
+            return Err(AppError::Validation(
+                "agent-name operations are not supported over the DIDComm transport; \
+                 the hosting server exposes them only via REST"
+                    .to_string(),
+            ));
+        };
+        match c.list_agent_names(mnemonic, domain).await {
+            Ok(v) => Ok(v),
+            Err(AppError::Unauthorized(_)) => {
+                info!(
+                    server_id = %server.id,
+                    "webvh list_agent_names got 401; invalidating cache and retrying"
+                );
+                auth_cache::invalidate_cached_token(auth_ctx.webvh_ks, &server.id).await?;
+                auth_cache::ensure_fresh_access_token(auth_ctx, server, c).await?;
+                c.list_agent_names(mnemonic, domain).await
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Probe name availability on the host, with the same 401 retry.
+    pub(super) async fn check_agent_name_authenticated(
+        &mut self,
+        name: &str,
+        domain: Option<&str>,
+        auth_ctx: &auth_cache::AuthContext<'_>,
+        server: &WebvhServerRecord,
+    ) -> Result<crate::webvh_client::AgentNameAvailabilityWire, AppError> {
+        let Self::Rest(c) = self else {
+            return Err(AppError::Validation(
+                "agent-name operations are not supported over the DIDComm transport; \
+                 the hosting server exposes them only via REST"
+                    .to_string(),
+            ));
+        };
+        match c.check_agent_name(name, domain).await {
+            Ok(v) => Ok(v),
+            Err(AppError::Unauthorized(_)) => {
+                info!(
+                    server_id = %server.id,
+                    "webvh check_agent_name got 401; invalidating cache and retrying"
+                );
+                auth_cache::invalidate_cached_token(auth_ctx.webvh_ks, &server.id).await?;
+                auth_cache::ensure_fresh_access_token(auth_ctx, server, c).await?;
+                c.check_agent_name(name, domain).await
+            }
+            Err(e) => Err(e),
+        }
+    }
+
     pub(super) async fn agent_name_authenticated(
         &mut self,
         verb: update::AgentNameVerb,

--- a/vta-service/src/operations/did_webvh/update/mod.rs
+++ b/vta-service/src/operations/did_webvh/update/mod.rs
@@ -43,7 +43,10 @@ mod validate;
 
 pub use errors::UpdateDidWebvhError;
 pub use options::{RotateDidWebvhKeysOptions, UpdateDidWebvhOptions, UpdateDidWebvhResult};
-pub use orchestrator::{AgentNameVerb, agent_name_op, plan_did_webvh_update, update_did_webvh};
+pub use orchestrator::{
+    AgentNameVerb, agent_name_op, check_agent_name, list_agent_names, plan_did_webvh_update,
+    update_did_webvh,
+};
 pub use plan::UpdatePlan;
 pub use rotate::rotate_did_webvh_keys;
 

--- a/vta-service/src/operations/did_webvh/update/orchestrator.rs
+++ b/vta-service/src/operations/did_webvh/update/orchestrator.rs
@@ -136,6 +136,118 @@ impl AgentNameVerb {
     }
 }
 
+/// Resolve a hosted DID to `(record, server, domain)` for the read-only
+/// agent-name operations. Shares `agent_name_op`'s preconditions — the DID
+/// must exist, must not be serverless, and must have a resolvable host — so
+/// the read and write paths agree about which DIDs have agent names at all.
+///
+/// Enforces `require_context` like every other per-DID read
+/// (`get_did_webvh`, `get_did_webvh_log`). These reads are not public: the
+/// registry exposes *parked* names, which are deliberately absent from the
+/// published document, and `check` is a probe against the host. Neither is
+/// inferable from the DID log, so neither may be readable across contexts.
+async fn hosted_agent_name_context(
+    deps: &super::super::WebvhDeps<'_>,
+    auth: &AuthClaims,
+    did: &str,
+) -> Result<
+    (
+        vta_sdk::webvh::WebvhDidRecord,
+        vta_sdk::webvh::WebvhServerRecord,
+        String,
+    ),
+    UpdateDidWebvhError,
+> {
+    let record = find_record_by_scid(deps.webvh_ks, did)
+        .await?
+        .ok_or_else(|| UpdateDidWebvhError::NotFound(format!("DID {did} not found")))?;
+
+    // Forbidden and NotFound both surface as 404, so this does not tell an
+    // unauthorized caller that the DID exists.
+    auth.require_context(&record.context_id)
+        .map_err(|e| UpdateDidWebvhError::Forbidden(e.to_string()))?;
+
+    if record.server_id == "serverless" {
+        return Err(UpdateDidWebvhError::Publish(
+            "agent names require a hosted DID; this DID is serverless \
+             (register it with a server first)"
+                .to_string(),
+        ));
+    }
+
+    let server = webvh_store::get_server(deps.webvh_ks, &record.server_id)
+        .await
+        .map_err(|e| UpdateDidWebvhError::Persistence(format!("get_server: {e}")))?
+        .ok_or_else(|| {
+            UpdateDidWebvhError::Publish(format!(
+                "webvh server `{}` referenced by DID is missing",
+                record.server_id
+            ))
+        })?;
+
+    let domain = domain_from_webvh_did(&record.did).ok_or_else(|| {
+        UpdateDidWebvhError::Library(format!("cannot derive domain from DID {}", record.did))
+    })?;
+
+    Ok((record, server, domain))
+}
+
+/// Read a hosted DID's agent-name registry from the control plane.
+///
+/// The control plane is the source of record for agent names, and this is a
+/// live read of it — not a projection of the local DID record. That matters
+/// for one case in particular: a **parked** name is deliberately absent from
+/// the DID document (dropping the `alsoKnownAs` claim is *how* parking stops
+/// it resolving), so nothing derived from the document can show one. Without
+/// this call a client cannot offer "resume" without making the user retype
+/// the name from memory.
+pub async fn list_agent_names(
+    deps: &super::super::WebvhDeps<'_>,
+    auth: &AuthClaims,
+    did: &str,
+    vta_did: Option<&str>,
+) -> Result<(String, Vec<crate::webvh_client::AgentNameEntryWire>), UpdateDidWebvhError> {
+    let (record, server, domain) = hosted_agent_name_context(deps, auth, did).await?;
+    let vta_did = vta_did.ok_or_else(|| {
+        UpdateDidWebvhError::Library("no VTA DID configured for hosting auth".to_string())
+    })?;
+
+    let names = super::super::list_agent_names_on_server(
+        deps,
+        vta_did,
+        &server,
+        &record.mnemonic,
+        Some(&domain),
+    )
+    .await
+    .map_err(|e| UpdateDidWebvhError::Publish(format!("list_agent_names: {e}")))?;
+
+    Ok((record.did, names))
+}
+
+/// Ask the host whether `name` is free on this DID's domain.
+///
+/// Availability is domain-scoped, and the domain is the DID's own host — the
+/// same rule the mutating verbs follow. Answering this *before* the caller
+/// signs a new DID version is the point: otherwise the only way to discover a
+/// collision is to publish and have the bind rejected.
+pub async fn check_agent_name(
+    deps: &super::super::WebvhDeps<'_>,
+    auth: &AuthClaims,
+    did: &str,
+    name: &str,
+    vta_did: Option<&str>,
+) -> Result<crate::webvh_client::AgentNameAvailabilityWire, UpdateDidWebvhError> {
+    let (_record, server, domain) = hosted_agent_name_context(deps, auth, did).await?;
+    let vta_did = vta_did.ok_or_else(|| {
+        UpdateDidWebvhError::Library("no VTA DID configured for hosting auth".to_string())
+    })?;
+
+    super::super::check_agent_name_on_server(deps, vta_did, &server, name, Some(&domain))
+        .await
+        .map_err(|e| UpdateDidWebvhError::Publish(format!("check_agent_name: {e}")))
+}
+
 /// Bind, release, park or resume an agent name (`/@alice`) on a hosted webvh
 /// DID.
 ///

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -153,6 +153,8 @@ const KNOWN_FEATURE_GATED_URIS: &[&str] = &[
     vta_sdk::trust_tasks::TASK_WEBVH_DIDS_UPDATE_1_0,
     vta_sdk::trust_tasks::TASK_WEBVH_DIDS_ROTATE_KEYS_1_0,
     vta_sdk::trust_tasks::TASK_WEBVH_DIDS_REGISTER_WITH_SERVER_1_0,
+    vta_sdk::trust_tasks::TASK_WEBVH_AGENT_NAME_LIST_1_0,
+    vta_sdk::trust_tasks::TASK_WEBVH_AGENT_NAME_CHECK_1_0,
     vta_sdk::trust_tasks::TASK_WEBVH_AGENT_NAME_SET_1_0,
     vta_sdk::trust_tasks::TASK_WEBVH_AGENT_NAME_REMOVE_1_0,
     vta_sdk::trust_tasks::TASK_WEBVH_AGENT_NAME_DISABLE_1_0,
@@ -943,6 +945,15 @@ dispatch_table! {
     // `remove` earns the classification most directly: it releases the name
     // for anyone to reclaim, so unlike `disable` it is not recoverable by
     // this DID alone.
+    // Read-only: no side effect, metadata-class. A parked name is invisible
+    // in the DID document, so `list` is the only way to see one — and `check`
+    // is what lets a client report a collision before it signs a new version.
+    #[cfg(feature = "webvh")]
+    vta_sdk::trust_tasks::TASK_WEBVH_AGENT_NAME_LIST_1_0 => webvh::handle_agent_name_list
+        [ None Metadata false ],
+    #[cfg(feature = "webvh")]
+    vta_sdk::trust_tasks::TASK_WEBVH_AGENT_NAME_CHECK_1_0 => webvh::handle_agent_name_check
+        [ None Metadata false ],
     #[cfg(feature = "webvh")]
     vta_sdk::trust_tasks::TASK_WEBVH_AGENT_NAME_SET_1_0 => webvh::handle_agent_name_set
         [ Destructive None false ],

--- a/vta-service/src/trust_tasks/webvh.rs
+++ b/vta-service/src/trust_tasks/webvh.rs
@@ -37,7 +37,10 @@ use serde_json::Value;
 use trust_tasks_rs::{RejectReason, TrustTask};
 
 use vta_sdk::protocols::did_management::{
-    agent_name::{AgentNameBody, AgentNameResultBody},
+    agent_name::{
+        AgentNameBody, AgentNameCheckBody, AgentNameCheckResultBody, AgentNameEntry,
+        AgentNameListBody, AgentNameListResultBody, AgentNameResultBody,
+    },
     create::CreateDidWebvhBody,
     delete::DeleteDidWebvhBody,
     get::GetDidWebvhBody,
@@ -364,6 +367,91 @@ pub(super) async fn handle_dids_update(
     .await
     {
         Ok(body) => success_response(&doc, body),
+        Err(e) => app_error_to_reject(&doc, AppError::from(e)),
+    }
+}
+
+/// `spec/vta/webvh/agent-name/list/1.0` — read the DID's agent-name registry
+/// from the hosting control plane, parked names included. Read-only.
+pub(super) async fn handle_agent_name_list(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    let req: AgentNameListBody = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    let did_resolver = match state.did_resolver.as_ref() {
+        Some(r) => r,
+        None => {
+            return app_error_to_reject(
+                &doc,
+                AppError::Internal("DID resolver not available".into()),
+            );
+        }
+    };
+    let vta_did = state.config.read().await.vta_did.clone();
+    let deps = operations::did_webvh::WebvhDeps::from_app_state(state, did_resolver);
+    match operations::did_webvh::list_agent_names(&deps, auth, &req.did, vta_did.as_deref()).await {
+        Ok((did, names)) => success_response(
+            &doc,
+            AgentNameListResultBody {
+                did,
+                names: names
+                    .into_iter()
+                    .map(|e| AgentNameEntry {
+                        name: e.name,
+                        enabled: e.enabled,
+                        created_at: e.created_at,
+                    })
+                    .collect(),
+            },
+        ),
+        Err(e) => app_error_to_reject(&doc, AppError::from(e)),
+    }
+}
+
+/// `spec/vta/webvh/agent-name/check/1.0` — is this name free on the DID's
+/// host? Read-only; lets a client report a collision before signing anything.
+pub(super) async fn handle_agent_name_check(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    let req: AgentNameCheckBody = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    let did_resolver = match state.did_resolver.as_ref() {
+        Some(r) => r,
+        None => {
+            return app_error_to_reject(
+                &doc,
+                AppError::Internal("DID resolver not available".into()),
+            );
+        }
+    };
+    let vta_did = state.config.read().await.vta_did.clone();
+    let deps = operations::did_webvh::WebvhDeps::from_app_state(state, did_resolver);
+    match operations::did_webvh::check_agent_name(
+        &deps,
+        auth,
+        &req.did,
+        &req.name,
+        vta_did.as_deref(),
+    )
+    .await
+    {
+        Ok(a) => success_response(
+            &doc,
+            AgentNameCheckResultBody {
+                name: a.name,
+                domain: a.domain,
+                available: a.available,
+                reserved: a.reserved,
+            },
+        ),
         Err(e) => app_error_to_reject(&doc, AppError::from(e)),
     }
 }

--- a/vta-service/src/webvh_client.rs
+++ b/vta-service/src/webvh_client.rs
@@ -95,6 +95,27 @@ pub struct CheckPathResponse {
     pub available: bool,
 }
 
+/// One entry of the host's `agentNames` array on `GET /api/dids/{mnemonic}`.
+/// Deserialize-only: the VTA reads this registry, the host owns it.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentNameEntryWire {
+    pub name: String,
+    /// `false` = parked: still reserved to this DID, just not resolving.
+    pub enabled: bool,
+    pub created_at: u64,
+}
+
+/// Wire shape of `POST /api/agent-names/check`.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentNameAvailabilityWire {
+    pub name: String,
+    pub domain: String,
+    pub available: bool,
+    pub reserved: bool,
+}
+
 /// The VTA's **internal** token representation — the value
 /// `authenticate()` / `refresh()` return and `auth_cache::persist_tokens`
 /// writes to `WebvhServerAuthRecord`. Not a wire type: it is built from
@@ -644,6 +665,77 @@ impl WebvhClient {
         self.send(req, &format!("POST /api/agent-names/{op}"))
             .await?;
         Ok(())
+    }
+
+    /// GET /api/dids/{mnemonic} — the DID's agent-name registry.
+    ///
+    /// Returns the record's `agentNames`, **parked entries included**. That is
+    /// the whole point: parking works by dropping the name from `alsoKnownAs`,
+    /// so a caller that only resolves the DID document cannot see a parked
+    /// name at all and has nothing to offer "resume" on.
+    ///
+    /// A host that predates the registry omits the field; that is an empty
+    /// list, not an error.
+    pub async fn list_agent_names(
+        &self,
+        mnemonic: &str,
+        domain: Option<&str>,
+    ) -> Result<Vec<AgentNameEntryWire>, AppError> {
+        let url = if let Some(d) = domain {
+            format!(
+                "{}/api/dids/{mnemonic}?domain={}",
+                self.server_url,
+                url::form_urlencoded::byte_serialize(d.as_bytes()).collect::<String>()
+            )
+        } else {
+            format!("{}/api/dids/{mnemonic}", self.server_url)
+        };
+        info!(method = "GET", %url, "webvh: sending via rest");
+        let req = self.with_auth(self.http.get(&url));
+        let body = self
+            .send(req, &format!("GET /api/dids/{mnemonic}"))
+            .await?
+            .json::<serde_json::Value>()
+            .await
+            .map_err(|e| AppError::Internal(format!("webvh-server response parse error: {e}")))?;
+        let Some(names) = body.get("agentNames") else {
+            return Ok(Vec::new());
+        };
+        serde_json::from_value(names.clone())
+            .map_err(|e| AppError::Internal(format!("webvh-server agentNames parse error: {e}")))
+    }
+
+    /// POST /api/agent-names/check — is this name free on `domain`?
+    ///
+    /// `reserved` is reported separately from `available` so a caller can say
+    /// *why* a name is unavailable. A malformed name is an error, not an
+    /// unavailable answer.
+    pub async fn check_agent_name(
+        &self,
+        name: &str,
+        domain: Option<&str>,
+    ) -> Result<AgentNameAvailabilityWire, AppError> {
+        let url = format!("{}/api/agent-names/check", self.server_url);
+        info!(method = "POST", %url, "webvh: sending via rest");
+        let mut body = serde_json::Map::new();
+        body.insert(
+            "name".to_string(),
+            serde_json::Value::String(name.to_string()),
+        );
+        if let Some(d) = domain {
+            body.insert(
+                "domain".to_string(),
+                serde_json::Value::String(d.to_string()),
+            );
+        }
+        let req = self
+            .with_auth(self.http.post(&url))
+            .json(&serde_json::Value::Object(body));
+        self.send(req, "POST /api/agent-names/check")
+            .await?
+            .json::<AgentNameAvailabilityWire>()
+            .await
+            .map_err(|e| AppError::Internal(format!("webvh-server response parse error: {e}")))
     }
 
     /// DELETE /api/dids/{mnemonic}.
@@ -1410,6 +1502,93 @@ mod tests {
                 .await
                 .unwrap_or_else(|e| panic!("{verb} should POST and succeed: {e:?}"));
         }
+    }
+
+    /// The registry read must surface **parked** entries — they are the only
+    /// reason this call exists, since a parked name is absent from the DID
+    /// document by design and cannot be recovered from it.
+    #[tokio::test]
+    async fn list_agent_names_returns_parked_entries() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/dids/slot-one"))
+            .and(header("Authorization", "Bearer tok-1"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "mnemonic": "slot-one",
+                "agentNames": [
+                    { "name": "alice", "enabled": true,  "createdAt": 1 },
+                    { "name": "bob",   "enabled": false, "createdAt": 2 },
+                ],
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let mut client = WebvhClient::new(&server.uri(), "did:web:daemon-mock.example").unwrap();
+        client.set_access_token("tok-1".to_string());
+        let names = client
+            .list_agent_names("slot-one", None)
+            .await
+            .expect("list should succeed");
+        assert_eq!(names.len(), 2);
+        assert!(names.iter().any(|n| n.name == "bob" && !n.enabled));
+    }
+
+    /// A host predating the registry omits the field entirely. That is an
+    /// empty list, not a parse error — otherwise every read against an older
+    /// host fails.
+    #[tokio::test]
+    async fn list_agent_names_tolerates_a_host_without_the_field() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/dids/slot-one"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "mnemonic": "slot-one"
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let mut client = WebvhClient::new(&server.uri(), "did:web:daemon-mock.example").unwrap();
+        client.set_access_token("tok-1".to_string());
+        assert!(
+            client
+                .list_agent_names("slot-one", None)
+                .await
+                .expect("absent agentNames must not be an error")
+                .is_empty()
+        );
+    }
+
+    /// `reserved` has to survive as its own signal — "unavailable because it
+    /// is `@admin`" needs different UI from "unavailable because someone has
+    /// it".
+    #[tokio::test]
+    async fn check_agent_name_reports_reserved_separately() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/agent-names/check"))
+            .and(body_json(
+                json!({ "name": "admin", "domain": "example.com" }),
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "name": "admin",
+                "domain": "example.com",
+                "available": false,
+                "reserved": true,
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let mut client = WebvhClient::new(&server.uri(), "did:web:daemon-mock.example").unwrap();
+        client.set_access_token("tok-1".to_string());
+        let a = client
+            .check_agent_name("admin", Some("example.com"))
+            .await
+            .expect("check should succeed");
+        assert!(!a.available);
+        assert!(a.reserved);
     }
 
     /// A name already held by another DID comes back as a distinguishable


### PR DESCRIPTION
Completes the agent-name lifecycle through the VTA. #722 added the four mutating verbs; these are the two reads a client needs to actually drive them. Rebased on `main` post-#722.

## `agent-name/list/1.0`

The DID's registry as the hosting control plane holds it, parked names included.

This has to be a **live read**, not a projection of the local record, because of one case: a parked name is deliberately absent from the DID document — dropping the `alsoKnownAs` claim is *how* parking stops it resolving — so nothing derived from the document can show one. Without this, a client cannot offer "resume" without making the user retype the name from memory.

## `agent-name/check/1.0`

Is this name free on the DID's host? Availability is domain-scoped and the domain is the DID's own host, the same rule the mutating verbs follow, so the body is `{did, name}`.

`reserved` comes back separately from `available` so a caller can say *why* — "that's `@admin`" needs different UI from "someone already has it". Without this endpoint the only way to discover a collision is to publish a signed new version and have the bind rejected.

## Authorization

Both enforce `require_context` on the DID's record, matching `get_did_webvh` / `get_did_webvh_log`.

That is load-bearing rather than boilerplate, and it's worth being explicit about why: the DID log is public and resolves for anyone, so a cross-context read of it leaks nothing. **The registry is not** — it exposes parked names, which are absent from the published document by design. This is information obtainable no other way, so it must not cross a context boundary, and `check` is a probe against the host on top of that. `Forbidden` and `NotFound` both surface as 404, so the check doesn't reveal that a DID exists either.

The shared `hosted_agent_name_context` also applies the write path's preconditions (exists, not serverless, resolvable host), so the read and write paths agree about which DIDs have agent names at all.

Classified `[None Metadata false]` — read-only, no consent ceremony. The client methods carry the same 401-invalidate-and-retry as the mutating path.

## Tests

Four new, aimed at the two cases most likely to break in the field:

- **a parked entry surviving the round-trip** — the whole reason `list` exists;
- **a host predating the registry omitting `agentNames` entirely** — that's an empty list, not a parse error, or every read against an older host fails;
- `check` reporting `reserved` separately from `available`;
- the `check` request body shape.

`cargo test --workspace` (the CI command): **102/102 targets green**, zero failures. `fmt --check` clean; `clippy --workspace --all-features --all-targets` reports only the two pre-existing warnings in `did_webvh.rs` and `provision_integration/preconditions.rs`.

## Versions

Additive only — no existing signature changes — so patch bumps: **vta-sdk 0.19.17, vta-service 0.12.1**. (#722 needed the minor because it changed `agent_name_op`'s signature; nothing here does.)

## This closes the report

With this merged, all three items the OpenVTC integration asked for on the VTA side are done: `set`/`remove` verbs (#722), the registry read path, and the `check` passthrough.