### PR TITLE
fix(vta-sdk): shut the ATM down when a DIDComm connect fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 ## Unreleased
 
+### vta-sdk 0.19.18 — a failed DIDComm connect no longer leaks a live socket
+
+* `DIDCommSession::connect_with_secrets` created an `ATM` and then ran several
+  fallible steps against it — profile creation, the 15s-bounded
+  `profile_enable_websocket`, binding `DidCommTransport`. Every one of those
+  error paths returned without calling `graceful_shutdown()`. Dropping the
+  handles does **not** stop the ATM's background tasks: the websocket transport
+  survives, reconnects on its own timer, and goes on holding the mediator's
+  one-socket-per-DID slot for `client_did` for the life of the process. The
+  `LeakGuard` only catches a *successfully built* session that is dropped
+  without `shutdown()` — it never saw these, because the session was never
+  built.
+* Why it bit: a service that opens a session per refresh cycle accumulates one
+  ghost socket per failed connect. Several of them, all authenticated as the
+  same DID, then duel over that DID's slot — each eviction triggering an
+  immediate reconnect. A mediator was observed taking ~40 connects/sec from its
+  own admin DID this way.
+* Fix: the fallible tail moved into `finish_connect`, with a single error path
+  that shuts the ATM down. The outcome is stringified before the shutdown await
+  because `Box<dyn Error>` is not `Send` and would otherwise make the connect
+  future non-`Send`.
+* The same omission is fixed in the three probe paths in `session.rs`
+  (`ping_over_didcomm`, `TrustPingSession::connect`, the TSP probe): each now
+  tears its ATM down when setup fails, not only when it succeeds.
+* Pairs with `affinidi-messaging-sdk` 0.18.61 (client backoff no longer resets
+  on an immediately-closed socket) and `affinidi-messaging-mediator` 0.17.6
+  (refresh over REST when self-mediated; server-side duel damper).
+
 ### vtc-service — Phase 2c: config Trust Tasks repointed to the canonical registry
 
 * `GET /v1/admin/config` now carries `https://trusttasks.org/spec/config/show/0.1`,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,7 +400,7 @@ dependencies = [
  "trust-tasks-rs",
  "url",
  "uuid",
- "vta-sdk 0.19.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vta-sdk 0.19.17",
 ]
 
 [[package]]
@@ -2485,7 +2485,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.19.17",
+ "vta-sdk 0.19.18",
 ]
 
 [[package]]
@@ -3286,7 +3286,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.19.17",
+ "vta-sdk 0.19.18",
 ]
 
 [[package]]
@@ -6764,7 +6764,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.19.17",
+ "vta-sdk 0.19.18",
 ]
 
 [[package]]
@@ -10080,7 +10080,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.19",
  "tokio",
- "vta-sdk 0.19.17",
+ "vta-sdk 0.19.18",
  "vti-common",
  "x25519-dalek",
 ]
@@ -10113,7 +10113,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.19.17",
+ "vta-sdk 0.19.18",
 ]
 
 [[package]]
@@ -10136,12 +10136,45 @@ dependencies = [
  "tracing-subscriber",
  "trust-tasks-rs",
  "uniffi",
- "vta-sdk 0.19.17",
+ "vta-sdk 0.19.18",
 ]
 
 [[package]]
 name = "vta-sdk"
 version = "0.19.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6453a67174e5456b42a0a986a2477507e28465c61c32bfa4da3ca08a60848496"
+dependencies = [
+ "affinidi-crypto",
+ "affinidi-did-resolver-cache-sdk",
+ "affinidi-messaging-core",
+ "affinidi-messaging-delivery",
+ "affinidi-messaging-didcomm",
+ "affinidi-openid4vci",
+ "affinidi-openid4vp",
+ "affinidi-tdk",
+ "base64 0.22.1",
+ "chrono",
+ "curve25519-dalek",
+ "didwebvh-rs",
+ "ed25519-dalek",
+ "futures-util",
+ "getrandom 0.4.3",
+ "multibase",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "thiserror 2.0.19",
+ "tokio",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "vta-sdk"
+version = "0.19.18"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10197,39 +10230,6 @@ dependencies = [
  "x25519-dalek",
  "x509-parser 0.18.1",
  "zeroize",
-]
-
-[[package]]
-name = "vta-sdk"
-version = "0.19.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6453a67174e5456b42a0a986a2477507e28465c61c32bfa4da3ca08a60848496"
-dependencies = [
- "affinidi-crypto",
- "affinidi-did-resolver-cache-sdk",
- "affinidi-messaging-core",
- "affinidi-messaging-delivery",
- "affinidi-messaging-didcomm",
- "affinidi-openid4vci",
- "affinidi-openid4vp",
- "affinidi-tdk",
- "base64 0.22.1",
- "chrono",
- "curve25519-dalek",
- "didwebvh-rs",
- "ed25519-dalek",
- "futures-util",
- "getrandom 0.4.3",
- "multibase",
- "reqwest 0.13.4",
- "serde",
- "serde_json",
- "sha2 0.11.0",
- "thiserror 2.0.19",
- "tokio",
- "tracing",
- "url",
- "uuid",
 ]
 
 [[package]]
@@ -10314,7 +10314,7 @@ dependencies = [
  "utoipa-axum",
  "uuid",
  "vta-cli-common",
- "vta-sdk 0.19.17",
+ "vta-sdk 0.19.18",
  "vta-service",
  "vti-common",
  "vti-secrets",
@@ -10336,7 +10336,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.19",
  "tokio",
- "vta-sdk 0.19.17",
+ "vta-sdk 0.19.18",
 ]
 
 [[package]]
@@ -10410,7 +10410,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.19.17",
+ "vta-sdk 0.19.18",
  "vtc-service",
  "vti-common",
  "vti-secrets",
@@ -10462,7 +10462,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.19.17",
+ "vta-sdk 0.19.18",
  "webauthn-rs",
  "zeroize",
 ]
@@ -10489,7 +10489,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.19.17",
+ "vta-sdk 0.19.18",
  "vta-service",
  "vti-common",
 ]
@@ -10518,7 +10518,7 @@ dependencies = [
  "tokio",
  "tracing",
  "vaultrs",
- "vta-sdk 0.19.17",
+ "vta-sdk 0.19.18",
  "vti-common",
 ]
 

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.19.17"
+version = "0.19.18"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/didcomm_session.rs
+++ b/vta-sdk/src/didcomm_session.rs
@@ -191,19 +191,54 @@ impl DIDCommSession {
         // Build ATM — inbound is driven by the delivery layer's DidCommTransport,
         // not by direct ATM polling (see the `MessagingService` wiring below).
         let atm_config = ATMConfig::builder().build()?;
-        let atm = ATM::new(atm_config, Arc::new(tdk)).await?;
+        let atm = Arc::new(ATM::new(atm_config, Arc::new(tdk)).await?);
 
+        // Past this point we own live background tasks: the ATM's deletion
+        // handler, and shortly a websocket transport that reconnects on its own
+        // timer. Dropping the handles does NOT stop them. An abandoned transport
+        // keeps holding — and fighting other sessions for — the mediator's
+        // one-socket-per-DID slot for `client_did`, for the life of the process.
+        //
+        // So every fallible step runs inside `finish_connect`, and a failure
+        // tears the ATM down here. One place to get right, rather than one per
+        // `?` (a timeout arm that forgot this is exactly how a service that
+        // reconnects on a schedule accumulates duelling ghost sockets).
+        // `map_err` to a `String` before the match: the boxed error is not
+        // `Send`, so holding it across the `graceful_shutdown().await` below
+        // would make this whole future non-`Send` and break callers that
+        // `tokio::spawn` a connect.
+        let outcome = Self::finish_connect(&atm, client_did, vta_did, mediator_did)
+            .await
+            .map_err(|e| e.to_string());
+
+        match outcome {
+            Ok(session) => Ok(session),
+            Err(msg) => {
+                atm.graceful_shutdown().await;
+                Err(msg.into())
+            }
+        }
+    }
+
+    /// Fallible tail of [`connect_with_secrets`]: everything that needs a live
+    /// ATM. Split out so a single error path can shut that ATM down — see the
+    /// call site.
+    async fn finish_connect(
+        atm: &Arc<ATM>,
+        client_did: &str,
+        vta_did: &str,
+        mediator_did: &str,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
         // Create profile with mediator
-        let profile = ATMProfile::new(
-            &atm,
-            None,
-            client_did.to_string(),
-            Some(mediator_did.to_string()),
-        )
-        .await?;
-        let profile = Arc::new(profile);
-
-        let atm = Arc::new(atm);
+        let profile = Arc::new(
+            ATMProfile::new(
+                atm,
+                None,
+                client_did.to_string(),
+                Some(mediator_did.to_string()),
+            )
+            .await?,
+        );
 
         // Flush stale messages from the inbox (accumulated between CLI runs)
         {
@@ -278,7 +313,7 @@ impl DIDCommSession {
         // are unaffected.
         #[cfg(feature = "acl-setup")]
         crate::acl_setup::set_client_acl_on_connection(
-            &atm,
+            atm,
             client_did,
             mediator_did,
             "didcomm-session",
@@ -295,7 +330,7 @@ impl DIDCommSession {
         // `request` waiters and unsolicited pushes to `subscribe`, deleting each
         // message from the mediator exactly once (the F5 fix).
         let transport: Arc<dyn MessageTransport> = Arc::new(
-            DidCommTransport::new((*atm).clone(), profile.clone())
+            DidCommTransport::new((**atm).clone(), profile.clone())
                 .await
                 .map_err(|e| format!("bind DidComm transport: {e}"))?,
         );
@@ -315,7 +350,7 @@ impl DIDCommSession {
         });
         Ok(Self {
             service,
-            atm,
+            atm: Arc::clone(atm),
             subscriber,
             client_did: client_did.to_string(),
             vta_did: vta_did.to_string(),

--- a/vta-sdk/src/session.rs
+++ b/vta-sdk/src/session.rs
@@ -1403,32 +1403,45 @@ pub async fn send_trust_ping(
 
     let atm = ATM::new(ATMConfig::builder().build()?, Arc::new(tdk)).await?;
 
-    let profile = ATMProfile::new(
-        &atm,
-        None,
-        client_did.to_string(),
-        Some(mediator_did.to_string()),
-    )
-    .await?;
-    let profile = Arc::new(profile);
+    // Run the probe to completion, then shut down on EVERY path. An early `?`
+    // here used to return while the ATM's websocket transport kept running and
+    // auto-reconnecting for the life of the process — a failed probe must not
+    // leave a ghost socket contending for this DID's slot on the mediator.
+    //
+    // The outcome is stringified before the shutdown await: the boxed error is
+    // not `Send`, and holding it across an await would make this future non-Send.
+    let outcome = async {
+        let profile = Arc::new(
+            ATMProfile::new(
+                &atm,
+                None,
+                client_did.to_string(),
+                Some(mediator_did.to_string()),
+            )
+            .await?,
+        );
 
-    atm.profile_enable_websocket(&profile).await?;
+        atm.profile_enable_websocket(&profile).await?;
 
-    let start = Instant::now();
-    TrustPing::default()
-        .send_ping(
-            &atm,
-            &profile,
-            target_did.unwrap_or(mediator_did),
-            true,
-            true,
-            true,
-        )
-        .await?;
-    let elapsed = start.elapsed().as_millis();
+        let start = Instant::now();
+        TrustPing::default()
+            .send_ping(
+                &atm,
+                &profile,
+                target_did.unwrap_or(mediator_did),
+                true,
+                true,
+                true,
+            )
+            .await?;
+
+        Ok::<u128, Box<dyn std::error::Error>>(start.elapsed().as_millis())
+    }
+    .await
+    .map_err(|e| e.to_string());
 
     atm.graceful_shutdown().await;
-    Ok(elapsed)
+    outcome.map_err(Into::into)
 }
 
 /// Resolve the VTA DID document and extract the mediator DID from the
@@ -1502,16 +1515,33 @@ impl TrustPingSession {
 
         let atm = ATM::new(ATMConfig::builder().build()?, Arc::new(tdk)).await?;
 
-        let profile = ATMProfile::new(
-            &atm,
-            None,
-            client_did.to_string(),
-            Some(mediator_did.to_string()),
-        )
-        .await?;
-        let profile = Arc::new(profile);
+        // Build the profile + socket behind a single fallible step so a failure
+        // can tear the ATM down. Without this, a session that fails to connect
+        // still leaves an auto-reconnecting websocket task running — see
+        // `ping_over_didcomm` above.
+        let prepared = async {
+            let profile = Arc::new(
+                ATMProfile::new(
+                    &atm,
+                    None,
+                    client_did.to_string(),
+                    Some(mediator_did.to_string()),
+                )
+                .await?,
+            );
+            atm.profile_enable_websocket(&profile).await?;
+            Ok::<_, Box<dyn std::error::Error>>(profile)
+        }
+        .await
+        .map_err(|e| e.to_string());
 
-        atm.profile_enable_websocket(&profile).await?;
+        let profile = match prepared {
+            Ok(profile) => profile,
+            Err(msg) => {
+                atm.graceful_shutdown().await;
+                return Err(msg.into());
+            }
+        };
 
         Ok(Self {
             atm,
@@ -1589,16 +1619,31 @@ impl TspPingSession {
 
         let atm = ATM::new(ATMConfig::builder().build()?, Arc::new(tdk)).await?;
 
-        let profile = ATMProfile::new(
-            &atm,
-            None,
-            client_did.to_string(),
-            Some(mediator_did.to_string()),
-        )
-        .await?;
-        let profile = Arc::new(profile);
+        // As in `TrustPingSession::connect`: any failure past `ATM::new` must
+        // shut the ATM down rather than abandon its background tasks.
+        let prepared = async {
+            let profile = Arc::new(
+                ATMProfile::new(
+                    &atm,
+                    None,
+                    client_did.to_string(),
+                    Some(mediator_did.to_string()),
+                )
+                .await?,
+            );
+            let ws = atm.tsp().connect_websocket(&profile).await?;
+            Ok::<_, Box<dyn std::error::Error>>((profile, ws))
+        }
+        .await
+        .map_err(|e| e.to_string());
 
-        let ws = atm.tsp().connect_websocket(&profile).await?;
+        let (profile, ws) = match prepared {
+            Ok(pair) => pair,
+            Err(msg) => {
+                atm.graceful_shutdown().await;
+                return Err(msg.into());
+            }
+        };
 
         Ok(Self {
             atm,


### PR DESCRIPTION
## The leak

`DIDCommSession::connect_with_secrets` built an `ATM` and then ran several fallible steps against it — profile creation, the 15s-bounded `profile_enable_websocket`, binding `DidCommTransport`. **Every one of those error paths returned without calling `graceful_shutdown()`.**

Dropping the handles does not stop the ATM's background tasks. The websocket transport survives, reconnects on its own timer, and goes on holding the mediator's one-socket-per-DID slot for `client_did` for the life of the process.

The `LeakGuard` could never catch this: it fires for a *successfully built* session dropped without `shutdown()`. Here the session was never built.

## Why it mattered

A service that opens a session per refresh cycle accumulates one ghost socket per failed connect. Several of them, all authenticated as the same DID, then duel over that DID's slot — each eviction triggering an immediate reconnect from the loser.

A production mediator was observed taking **~40 connects/sec from its own admin DID** this way. (The mediator's admin DID is also its VTA credential, so its own VTA refresh loop was the client.)

## The fix

The fallible tail moves into `finish_connect`, with a single error path that shuts the ATM down. One place to get right, rather than one per `?` — a timeout arm that forgets this is exactly how the ghosts accumulated.

The outcome is stringified before the shutdown await: `Box<dyn Error>` is not `Send`, and holding it across an await would make the connect future non-`Send`, breaking callers that `tokio::spawn` a connect (`provision_client/runner.rs` does).

The same omission is fixed in the three probe paths in `session.rs` — `ping_over_didcomm`, `TrustPingSession::connect`, and the TSP probe. Each shut its ATM down only on success; now they do it on every path.

## Verification

- `cargo clippy --all-features --all-targets -D warnings` clean, and clean without features
- 179 unit tests pass
- vta-sdk 0.19.17 → 0.19.18; `Cargo.lock` re-resolved, registry self-pin node preserved (this workspace deliberately has no `[patch.crates-io]` — `cargo publish --locked` needs that node)

## Companion PR

affinidi/affinidi-tdk-rs#644 fixes the other three legs of the same storm: the mediator's VTA refresh now uses REST when self-mediated, SDK reconnect backoff no longer resets on a socket that is immediately closed, `graceful_shutdown` stops websockets first and cannot hang, and the mediator damps sustained duplicate-socket duels server-side.

This one should land and publish first — the TDK mediator builds against the published vta-sdk, so the fix only reaches it once 0.19.16 is on crates.io.
