### PR TITLE
feat(vtc): phase 2b(i) — repoint audit/verify to the canonical registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## Unreleased
 
+### vtc-service / cnm-cli — Phase 2b(i): `audit/verify` repointed to the canonical registry
+
+* `POST /v1/audit/verify` now carries
+  `https://trusttasks.org/spec/audit/verify/0.1`; the
+  `openvtc/vtc/audit/verify/1.0` task is **retired** with `supersededBy`.
+* **No payload change.** The canonical schema was derived from VTC's
+  `VerifyResponse`: the request is parameterless and every response field
+  (`verified`, `entriesExamined`, `entriesVerified`, `legacySkipped`,
+  `unparseableSkipped`, optional `head` / `chainBreak`) already matched,
+  including `chainBreak.kind`, which VTC already emits as the canonical
+  `tamperedEntry` / `brokenLink` rather than a snake_case variant.
+* `audit/list` is **not** repointed here — it needs a genuine response
+  projection (`{items,next_cursor,total_estimate}` →
+  `{entries,truncated,cursor}`, snake_case envelope → canonical
+  `AuditEnvelope`) plus a rewrite of the `vtc-service/admin-ui` audit
+  plugin that consumes the current shape. It follows as its own change.
+
 ### vta-sdk 0.19.18 — a failed DIDComm connect no longer leaks a live socket
 
 * `DIDCommSession::connect_with_secrets` created an `ATM` and then ran several

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2471,7 +2471,7 @@ checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cnm-cli"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "clap",
@@ -10341,7 +10341,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-service"
-version = "0.11.13"
+version = "0.11.14"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,7 +400,7 @@ dependencies = [
  "trust-tasks-rs",
  "url",
  "uuid",
- "vta-sdk 0.19.17",
+ "vta-sdk 0.19.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -10141,39 +10141,6 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.19.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6453a67174e5456b42a0a986a2477507e28465c61c32bfa4da3ca08a60848496"
-dependencies = [
- "affinidi-crypto",
- "affinidi-did-resolver-cache-sdk",
- "affinidi-messaging-core",
- "affinidi-messaging-delivery",
- "affinidi-messaging-didcomm",
- "affinidi-openid4vci",
- "affinidi-openid4vp",
- "affinidi-tdk",
- "base64 0.22.1",
- "chrono",
- "curve25519-dalek",
- "didwebvh-rs",
- "ed25519-dalek",
- "futures-util",
- "getrandom 0.4.3",
- "multibase",
- "reqwest 0.13.4",
- "serde",
- "serde_json",
- "sha2 0.11.0",
- "thiserror 2.0.19",
- "tokio",
- "tracing",
- "url",
- "uuid",
-]
-
-[[package]]
-name = "vta-sdk"
 version = "0.19.18"
 dependencies = [
  "affinidi-bbs",
@@ -10230,6 +10197,39 @@ dependencies = [
  "x25519-dalek",
  "x509-parser 0.18.1",
  "zeroize",
+]
+
+[[package]]
+name = "vta-sdk"
+version = "0.19.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c189650af46f061f2436fc5378507ec3b1ceadb3f529ebf2c5cb9fd39d8783e8"
+dependencies = [
+ "affinidi-crypto",
+ "affinidi-did-resolver-cache-sdk",
+ "affinidi-messaging-core",
+ "affinidi-messaging-delivery",
+ "affinidi-messaging-didcomm",
+ "affinidi-openid4vci",
+ "affinidi-openid4vp",
+ "affinidi-tdk",
+ "base64 0.22.1",
+ "chrono",
+ "curve25519-dalek",
+ "didwebvh-rs",
+ "ed25519-dalek",
+ "futures-util",
+ "getrandom 0.4.3",
+ "multibase",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "thiserror 2.0.19",
+ "tokio",
+ "tracing",
+ "url",
+ "uuid",
 ]
 
 [[package]]

--- a/cnm-cli/Cargo.toml
+++ b/cnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cnm-cli"
 description = "CLI Tool for Verified Trust Agents operating in Verified Trust Communities"
-version = "0.11.2"
+version = "0.11.3"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/cnm-cli/src/audit.rs
+++ b/cnm-cli/src/audit.rs
@@ -18,7 +18,7 @@ use crate::auth;
 /// Canonical HTTP header carrying the Trust-Task URL (mirrors
 /// `vti_common::trust_task::HEADER_NAME`).
 const TRUST_TASK_HEADER: &str = "Trust-Task";
-const VERIFY_TASK: &str = "https://trusttasks.org/openvtc/vtc/audit/verify/1.0";
+const VERIFY_TASK: &str = "https://trusttasks.org/spec/audit/verify/0.1";
 
 /// `cnm audit verify` — walk the community's audit chain and report.
 ///

--- a/trust-tasks/audit/verify/1.0/spec.md
+++ b/trust-tasks/audit/verify/1.0/spec.md
@@ -1,7 +1,8 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/audit/verify/1.0
 title: VTC — Verify the audit hash chain
-status: draft
+status: retired
+supersededBy: https://trusttasks.org/spec/audit/verify/0.1
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/index.json
+++ b/trust-tasks/index.json
@@ -68,9 +68,10 @@
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/audit/verify/1.0",
-      "status": "draft",
+      "status": "retired",
       "path": "audit/verify/1.0",
-      "rest": "GET /v1/audit/verify"
+      "rest": "GET /v1/audit/verify",
+      "supersededBy": "https://trusttasks.org/spec/audit/verify/0.1"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/config/legacy/manage/1.0",

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.11.13"
+version = "0.11.14"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vtc-service/src/routes/mod.rs
+++ b/vtc-service/src/routes/mod.rs
@@ -382,7 +382,7 @@ fn build_api_chain(_routing: &RoutingConfig, trust_xff: bool) -> OpenApiRouter<A
         ))
         .routes(tt(
             routes!(audit::verify_audit_chain),
-            "https://trusttasks.org/openvtc/vtc/audit/verify/1.0",
+            "https://trusttasks.org/spec/audit/verify/0.1",
         ))
         // Config
         .routes(tt(

--- a/vtc-service/tests/audit_verify.rs
+++ b/vtc-service/tests/audit_verify.rs
@@ -15,7 +15,7 @@ use tower::ServiceExt;
 use vtc_service::server::AppState;
 use vtc_service::test_support::TestVtc;
 
-const VERIFY_TASK: &str = "https://trusttasks.org/openvtc/vtc/audit/verify/1.0";
+const VERIFY_TASK: &str = "https://trusttasks.org/spec/audit/verify/0.1";
 const PROFILE_TASK: &str = "https://trusttasks.org/openvtc/vtc/community/profile/manage/1.0";
 
 struct Fixture {


### PR DESCRIPTION
Phase 2b(i) of the vtc-service Trust Task migration (#710).

`POST /v1/audit/verify` now carries `https://trusttasks.org/spec/audit/verify/0.1`; `openvtc/vtc/audit/verify/1.0` is **retired** with `supersededBy` in both `trust-tasks/index.json` and its `spec.md` (the census test pins that pairing).

### Zero payload change — verified, not assumed

The canonical schema was evidently written *from* VTC's `VerifyResponse`. The request is parameterless on both sides, and every response field already matches: `verified`, `entriesExamined`, `entriesVerified`, `legacySkipped`, `unparseableSkipped`, optional `head` / `chainBreak`.

The one thing worth checking closely was **`chainBreak.kind`**, which canonical declares as a closed enum (`tamperedEntry` | `brokenLink`). That is exactly the shape of the Trust-Task enum-casing drift that has caused real failures elsewhere in this stack, so I traced it to the construction site rather than trusting the type (`kind: String`):

```rust
ChainBreak::TamperedEntry { .. } => ("tamperedEntry", index, event_id),
ChainBreak::BrokenLink   { .. } => ("brokenLink",    index, event_id),
```

Already canonical. No mapping needed.

### Why `audit/list` is not in this PR

`audit/list` is a genuine rewrite, not a repoint, and bundling it here would have made both halves harder to review:

* Response reshape: `{items, next_cursor, total_estimate}` → `{entries, truncated, cursor}`.
* Envelope projection: VTC's `AuditEnvelope` has no `rename_all`, so it serializes snake_case, and carries fields canonical has no home for. Canonical `AuditEnvelope` is `additionalProperties: false`, so `actor_did_hash` / `audit_key_id` / `event_version` must move into `ext`, and the tagged `event` enum has to project to `{action, outcome, detail}`.
* The six canonical filters (`from`, `to`, `action`, `actor`, `outcome`, `contextId`) that VTC does not currently implement — **these will be implemented server-side and bound into the signed cursor**, rather than accepted-and-ignored. For an audit log, silently returning unfiltered data to a caller who asked for `actor = X` is a security-relevant failure mode, not a cosmetic gap.
* `vtc-service/admin-ui/src/plugins/audit.tsx` is a **live consumer** that reads the raw snake_case envelope and `{items, next_cursor}` directly. It changes in the same PR as the reshape, or the audit view breaks.

### Verification

`cargo test --workspace` (CI-equivalent): **3604 passed, 0 failed**. `cargo fmt --all --check` clean. `scripts/check-lockfile-self-pins.sh` green. Directly-affected suites — `audit_verify` (5) and `trust_task_manifest` (5, incl. `retired_tasks_are_not_bound`) — all pass.

Versions bumped (`publish = true`): `vtc-service` 0.11.14, `cnm-cli` 0.11.3.

### Phase 2 status

- **2a `policy/*`** — not a repoint. Canonical uses a relational `(contextId, purpose) → policy` binding over *mutable* modules with `expectedVersion`; VTC has `purpose` as an intrinsic column over *append-only* revisions, with the Rego package name validated against it. Incompatible lifecycle models — needs a design decision before code moves.
- **2b(i)** — this PR.
- **2b(ii) `audit/list`** — next, as described above.
- **2c `config/*`** — done (#724).
- **2d `acl/*`** — unblocked by #724's per-method finding; remaining work is payload reconciliation (`did`→`subject`, `allowed_contexts`→`scopes`, `u64` epoch → RFC3339, add `truncated`).
- **2e `auth/*`** — already done; the residual `openvtc` auth URIs have no canonical target.