### PR TITLE
feat(vtc): phase 2b(ii) — repoint audit/list, implementing its filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,43 @@
 
 ## Unreleased
 
+### vtc-service — Phase 2b(ii): `audit/list` repointed, with filters actually implemented
+
+* `GET /v1/audit` now carries `https://trusttasks.org/spec/audit/list/0.1`;
+  `openvtc/vtc/audit/list/1.0` is **retired** with `supersededBy`.
+* **Breaking (admin API).** The response is the canonical envelope —
+  `{entries, truncated, cursor}` replaces `{items, next_cursor,
+  total_estimate}` — and each entry is a canonical `AuditEnvelope`:
+  `eventId` / `recordedAt` / `action` / `actor` / `target` / `detail`,
+  camelCase throughout. `limit` is renamed `pageSize`. The bundled
+  admin UI is updated in step.
+* Because the canonical envelope is `additionalProperties: false`,
+  VTC's maintainer-specific fields (`actorDidHash`, `targetDidHash`,
+  `auditKeyId`, `eventVersion`) move under `ext.vtc` rather than being
+  dropped. `action` is the serde tag already stored on the envelope
+  (e.g. `MemberRemoved`) and `detail` is that variant's payload.
+* `prevHash` / `entryHash` are emitted as **hex**, matching the encoding
+  `audit/verify` already uses for `head`. They are base64 in storage, so
+  a caller comparing `verify.head` with the newest entry's `entryHash`
+  would otherwise see a spurious mismatch; a test now pins the two
+  together.
+* **Filters are implemented, not accepted-and-ignored.** `from`, `to`,
+  `action` and `actor` filter server-side. `outcome` and `contextId` —
+  which this maintainer has no data for (there is no envelope-level
+  outcome, and a VTC is a single community, so the log is not
+  context-partitioned) — are **refused with an error naming them**.
+  Returning an unfiltered page to a caller who asked for
+  `actor=X&outcome=denied` would invite exactly the wrong conclusion.
+* `truncated` reports whether more *matching* entries remain, not
+  whether more rows remain, so a filtered query can't hand back a cursor
+  that leads only to an empty tail.
+* Cursors are bound to their filter set: `Cursor::{encode,decode}_bound`
+  fold the active filters into the HMAC without putting them on the
+  wire, so resuming a page under different filters fails as a tampered
+  cursor. Canonical requires filters not change mid-pagination; unbound
+  `encode`/`decode` stay byte-compatible, so other paginated endpoints
+  are unaffected.
+
 ### vtc-service / cnm-cli — Phase 2b(i): `audit/verify` repointed to the canonical registry
 
 * `POST /v1/audit/verify` now carries

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10341,7 +10341,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-service"
-version = "0.11.14"
+version = "0.11.15"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",
@@ -10423,7 +10423,7 @@ dependencies = [
 
 [[package]]
 name = "vti-common"
-version = "0.11.11"
+version = "0.11.12"
 dependencies = [
  "aes-gcm",
  "affinidi-data-integrity",

--- a/trust-tasks/audit/list/1.0/spec.md
+++ b/trust-tasks/audit/list/1.0/spec.md
@@ -1,7 +1,8 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/audit/list/1.0
 title: VTC — List audit log entries
-status: draft
+status: retired
+supersededBy: https://trusttasks.org/spec/audit/list/0.1
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/index.json
+++ b/trust-tasks/index.json
@@ -62,9 +62,10 @@
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/audit/list/1.0",
-      "status": "draft",
+      "status": "retired",
       "path": "audit/list/1.0",
-      "rest": "GET /v1/audit"
+      "rest": "GET /v1/audit",
+      "supersededBy": "https://trusttasks.org/spec/audit/list/0.1"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/audit/verify/1.0",

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.11.14"
+version = "0.11.15"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vtc-service/admin-ui/src/plugins/audit.tsx
+++ b/vtc-service/admin-ui/src/plugins/audit.tsx
@@ -78,42 +78,54 @@ const SYSTEM_EVENT_KINDS = new Set([
   "RegistrySyncFailed",
 ]);
 
-const TRUST_TASK = "https://trusttasks.org/openvtc/vtc/audit/list/1.0";
+const TRUST_TASK = "https://trusttasks.org/spec/audit/list/0.1";
 
-interface AuditEnvelope {
-  event_id: string;
-  event_version: number;
-  schema_version: number;
-  timestamp: string;
-  audit_key_id: string;
-  actor_did_hash: string;
-  actor_did_plain: string | null;
-  target_did_hash: string | null;
-  target_did_plain: string | null;
-  event: Record<string, unknown> | string;
+// Canonical `audit/list/0.1` entry shape. The maintainer-specific
+// fields VTC used to expose at the top level (keyed actor/target
+// hashes, the audit key id, the per-variant version) now live under
+// `ext.vtc`, because the canonical envelope is
+// `additionalProperties: false`.
+interface AuditEntry {
+  eventId: string;
+  recordedAt: string;
+  action: string;
+  actor: string | null;
+  target?: string | null;
+  schemaVersion: number;
+  prevHash: string;
+  entryHash: string;
+  detail: Record<string, unknown>;
+  ext?: {
+    vtc?: {
+      eventVersion?: number;
+      auditKeyId?: string;
+      actorDidHash?: string;
+      targetDidHash?: string | null;
+    };
+  };
 }
 
-interface Paginated<T> {
-  items: T[];
-  next_cursor?: string | null;
-  total_estimate?: number | null;
+interface AuditListResponse {
+  entries: AuditEntry[];
+  truncated: boolean;
+  cursor?: string | null;
 }
 
 async function fetchAuditPage(
   cursor: string | null,
-  limit: number,
-): Promise<Paginated<AuditEnvelope>> {
+  pageSize: number,
+): Promise<AuditListResponse> {
   const q = new URLSearchParams();
   if (cursor) q.set("cursor", cursor);
-  q.set("limit", String(limit));
-  return getJson<Paginated<AuditEnvelope>>(`/v1/audit?${q}`, {
+  q.set("pageSize", String(pageSize));
+  return getJson<AuditListResponse>(`/v1/audit?${q}`, {
     trustTask: TRUST_TASK,
   });
 }
 
 export function Audit() {
   const [cursor, setCursor] = useState<string | null>(null);
-  const [items, setItems] = useState<AuditEnvelope[]>([]);
+  const [items, setItems] = useState<AuditEntry[]>([]);
   const [nextCursor, setNextCursor] = useState<string | null>(null);
   const [showSystem, setShowSystem] = useState(false);
   const [filterText, setFilterText] = useState("");
@@ -131,11 +143,11 @@ export function Audit() {
   useEffect(() => {
     if (!query.data) return;
     if (cursor === null) {
-      setItems(query.data.items);
+      setItems(query.data.entries);
     } else {
-      setItems((prev) => [...prev, ...query.data!.items]);
+      setItems((prev) => [...prev, ...query.data!.entries]);
     }
-    setNextCursor(query.data.next_cursor ?? null);
+    setNextCursor(query.data.cursor ?? null);
   }, [query.data, cursor]);
 
   useEffect(() => {
@@ -150,14 +162,14 @@ export function Audit() {
   const visibleItems = useMemo(() => {
     const needle = filterText.trim().toLowerCase();
     return items.filter((env) => {
-      const kind = eventKind(env.event);
+      const kind = env.action;
       if (!showSystem && SYSTEM_EVENT_KINDS.has(kind)) return false;
       if (!needle) return true;
       const haystack = [
         kind,
         EVENT_DESCRIPTIONS[kind] ?? "",
-        env.actor_did_plain ?? "",
-        env.target_did_plain ?? "",
+        env.actor ?? "",
+        env.target ?? "",
       ]
         .join(" ")
         .toLowerCase();
@@ -225,8 +237,8 @@ export function Audit() {
               setNextCursor(null);
               const result = await query.refetch();
               if (result.data) {
-                setItems(result.data.items);
-                setNextCursor(result.data.next_cursor ?? null);
+                setItems(result.data.entries);
+                setNextCursor(result.data.cursor ?? null);
               }
             }}
           >
@@ -275,7 +287,7 @@ export function Audit() {
               </tr>
             )}
             {visibleItems.map((env) => (
-              <AuditRow key={env.event_id} env={env} />
+              <AuditRow key={env.eventId} env={env} />
             ))}
           </tbody>
         </table>
@@ -297,14 +309,14 @@ export function Audit() {
   );
 }
 
-function AuditRow({ env }: { env: AuditEnvelope }) {
+function AuditRow({ env }: { env: AuditEntry }) {
   const [open, setOpen] = useState(false);
-  const kind = eventKind(env.event);
+  const kind = env.action;
   const description = EVENT_DESCRIPTIONS[kind];
   return (
     <>
       <tr>
-        <td title={env.timestamp}>{formatIso(env.timestamp)}</td>
+        <td title={env.recordedAt}>{formatIso(env.recordedAt)}</td>
         <td>
           <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
             <span>{description ?? kind}</span>
@@ -319,9 +331,9 @@ function AuditRow({ env }: { env: AuditEnvelope }) {
           </div>
         </td>
         <td>
-          {env.actor_did_plain ? (
-            <code className="truncate" title={env.actor_did_plain}>
-              {env.actor_did_plain}
+          {env.actor ? (
+            <code className="truncate" title={env.actor}>
+              {env.actor}
             </code>
           ) : (
             <span className="muted" title="Redacted by RTBF">
@@ -330,11 +342,11 @@ function AuditRow({ env }: { env: AuditEnvelope }) {
           )}
         </td>
         <td>
-          {env.target_did_plain ? (
-            <code className="truncate" title={env.target_did_plain}>
-              {env.target_did_plain}
+          {env.target ? (
+            <code className="truncate" title={env.target}>
+              {env.target}
             </code>
-          ) : env.target_did_hash ? (
+          ) : env.ext?.vtc?.targetDidHash ? (
             <span className="muted" title="Redacted by RTBF">
               redacted
             </span>
@@ -364,21 +376,11 @@ function AuditRow({ env }: { env: AuditEnvelope }) {
   );
 }
 
-function eventKind(event: AuditEnvelope["event"]): string {
-  // The event field is serde-tagged: `{ kind: "MemberAdded", … }`
-  // or `"MemberAdded"` for unit variants. Surface the tag for the
-  // table column; the JSON detail row shows the full payload.
-  if (typeof event === "string") return event;
-  if (event && typeof event === "object") {
-    const obj = event as Record<string, unknown>;
-    for (const key of Object.keys(obj)) {
-      return key;
-    }
-  }
-  return "Unknown";
-}
+// `eventKind` used to dig the serde tag out of the nested `event`
+// object. Canonical `audit/list` hands back `action` as a plain string
+// and the payload separately as `detail`, so the helper is gone.
 
-function formatEvent(env: AuditEnvelope): string {
+function formatEvent(env: AuditEntry): string {
   try {
     return JSON.stringify(env, null, 2);
   } catch {

--- a/vtc-service/src/routes/audit.rs
+++ b/vtc-service/src/routes/audit.rs
@@ -17,11 +17,12 @@
 
 use axum::Json;
 use axum::extract::{Query, State};
-use serde::Deserialize;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
 
 use vti_common::audit::{AuditEnvelope, ChainBreak, ChainVerifier};
 use vti_common::error::AppError;
-use vti_common::pagination::{Cursor, MAX_LIMIT, Paginated};
+use vti_common::pagination::{Cursor, MAX_LIMIT};
 
 use crate::auth::SuperAdminAuth;
 use crate::server::AppState;
@@ -32,10 +33,171 @@ use tracing::info;
 #[derive(utoipa::ToSchema, utoipa::IntoParams)]
 #[into_params(parameter_in = Query)]
 pub struct AuditQuery {
+    /// Return only entries recorded at or after this time.
+    pub from: Option<DateTime<Utc>>,
+    /// Return only entries recorded strictly before this time.
+    pub to: Option<DateTime<Utc>>,
+    /// Return only entries whose `action` equals this value — the
+    /// event variant name, e.g. `MemberRemoved`.
+    pub action: Option<String>,
+    /// Return only entries whose actor DID equals this value. Matches
+    /// the plaintext, so RTBF-redacted rows are never returned by an
+    /// actor filter (canonical requires exactly this).
+    pub actor: Option<String>,
+    /// Not supported by this maintainer — see [`unsupported_filters`].
+    pub outcome: Option<String>,
+    /// Not supported by this maintainer — see [`unsupported_filters`].
+    pub context_id: Option<String>,
+    /// Page size. Clamped to `1..=200`. Defaults to 50.
+    pub page_size: Option<usize>,
     /// Pagination cursor (returned by a previous call).
     pub cursor: Option<String>,
-    /// Page size. Clamped to `1..=200`. Defaults to 50.
-    pub limit: Option<usize>,
+}
+
+impl AuditQuery {
+    /// Canonical `audit/list` defines `outcome` and `contextId`, but this
+    /// maintainer tracks neither: the envelope has no envelope-level
+    /// outcome (only one variant carries an `outcome` inside its own
+    /// `data`), and the audit log is not partitioned per trust context —
+    /// a VTC *is* a single community.
+    ///
+    /// Accepting and ignoring them would be the dangerous option: a
+    /// caller asking for `actor=X&outcome=denied` would receive every
+    /// entry for X and could reasonably read that as "no denials". So
+    /// they are refused rather than silently dropped.
+    fn unsupported_filters(&self) -> Vec<&'static str> {
+        let mut bad = Vec::new();
+        if self.outcome.is_some() {
+            bad.push("outcome");
+        }
+        if self.context_id.is_some() {
+            bad.push("contextId");
+        }
+        bad
+    }
+
+    /// The bytes a cursor is bound to. Canonical forbids changing the
+    /// filters while paging — the filters are part of the cursor's
+    /// position — so they are folded into the cursor's HMAC. Resuming
+    /// with a different filter set fails verification.
+    ///
+    /// Length-prefixed so that `action="a&actor=b"` cannot collide with
+    /// `action="a", actor="b"`.
+    fn cursor_binding(&self) -> Vec<u8> {
+        let mut out = Vec::new();
+        let mut field = |v: Option<&str>| {
+            let bytes = v.unwrap_or("").as_bytes();
+            out.extend_from_slice(&(bytes.len() as u32).to_be_bytes());
+            out.extend_from_slice(bytes);
+        };
+        field(self.from.map(|t| t.to_rfc3339()).as_deref());
+        field(self.to.map(|t| t.to_rfc3339()).as_deref());
+        field(self.action.as_deref());
+        field(self.actor.as_deref());
+        out
+    }
+
+    /// Does this envelope pass every supplied filter?
+    fn matches(&self, env: &AuditEnvelope) -> bool {
+        if let Some(from) = self.from
+            && env.timestamp < from
+        {
+            return false;
+        }
+        if let Some(to) = self.to
+            && env.timestamp >= to
+        {
+            return false;
+        }
+        if let Some(action) = &self.action
+            && action_of(env) != action.as_str()
+        {
+            return false;
+        }
+        if let Some(actor) = &self.actor
+            && env.actor_did_plain.as_deref() != Some(actor.as_str())
+        {
+            return false;
+        }
+        true
+    }
+}
+
+/// The canonical `action` for an envelope: the event's variant name.
+///
+/// Canonical calls `action` "a maintainer-defined action name", so the
+/// variant name is used verbatim rather than being re-spelled into
+/// `member.removed` form — that keeps it identical to the `type` tag
+/// already on the stored envelope and to what the admin UI filters on.
+fn action_of(env: &AuditEnvelope) -> &'static str {
+    env.event.variant_name()
+}
+
+/// One entry in the canonical `audit/list` response.
+///
+/// `additionalProperties: false` on the canonical envelope means VTC's
+/// extra fields cannot ride along at the top level, so the keyed hashes
+/// and the per-variant version move into `ext`.
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AuditEntry {
+    pub event_id: String,
+    pub recorded_at: String,
+    pub action: String,
+    pub actor: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target: Option<String>,
+    pub schema_version: u32,
+    /// Hex, matching the encoding `audit/verify` uses for `head` — a
+    /// caller comparing the two must not have to reconcile hex against
+    /// the base64 the stored envelope uses.
+    pub prev_hash: String,
+    pub entry_hash: String,
+    pub detail: serde_json::Value,
+    pub ext: serde_json::Value,
+}
+
+impl From<&AuditEnvelope> for AuditEntry {
+    fn from(env: &AuditEnvelope) -> Self {
+        // The stored event is `{"type": Variant, "data": {...}}`; the
+        // canonical split is `action` + `detail`.
+        let detail = serde_json::to_value(&env.event)
+            .ok()
+            .and_then(|mut v| v.get_mut("data").map(serde_json::Value::take))
+            .unwrap_or(serde_json::Value::Object(Default::default()));
+
+        Self {
+            event_id: env.event_id.to_string(),
+            recorded_at: env.timestamp.to_rfc3339(),
+            action: action_of(env).to_owned(),
+            actor: env.actor_did_plain.clone(),
+            target: env.target_did_plain.clone(),
+            schema_version: env.schema_version,
+            prev_hash: hex::encode(env.prev_hash),
+            entry_hash: hex::encode(env.entry_hash),
+            detail,
+            ext: serde_json::json!({
+                "vtc": {
+                    "eventVersion": env.event_version,
+                    "auditKeyId": env.audit_key_id.to_string(),
+                    "actorDidHash": hex::encode(env.actor_did_hash),
+                    "targetDidHash": env.target_did_hash.map(hex::encode),
+                }
+            }),
+        }
+    }
+}
+
+/// Canonical `audit/list` response.
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AuditListResponse {
+    pub entries: Vec<AuditEntry>,
+    /// True when more entries match beyond this page; `cursor` is then
+    /// present.
+    pub truncated: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cursor: Option<String>,
 }
 
 /// GET /audit — newest-first paginated audit envelopes. Auth: Super-admin.
@@ -53,8 +215,17 @@ pub async fn list_audit(
     auth: SuperAdminAuth,
     State(state): State<AppState>,
     Query(query): Query<AuditQuery>,
-) -> Result<Json<Paginated<AuditEnvelope>>, AppError> {
-    let limit = query.limit.unwrap_or(50).clamp(1, MAX_LIMIT);
+) -> Result<Json<AuditListResponse>, AppError> {
+    let unsupported = query.unsupported_filters();
+    if !unsupported.is_empty() {
+        return Err(AppError::Validation(format!(
+            "this maintainer does not implement the {} filter(s); \
+             refusing rather than returning unfiltered results",
+            unsupported.join(", "),
+        )));
+    }
+
+    let limit = query.page_size.unwrap_or(50).clamp(1, MAX_LIMIT);
 
     let audit_writer = state
         .audit_writer
@@ -62,8 +233,11 @@ pub async fn list_audit(
         .ok_or_else(|| AppError::Internal("audit_writer not initialised".into()))?;
     let audit_key = audit_writer.active_key().await?;
 
+    // The filters are bound into the cursor's HMAC, so resuming a page
+    // under a different filter set fails as a tampered cursor.
+    let binding = query.cursor_binding();
     let decoded_cursor = match &query.cursor {
-        Some(s) => Some(Cursor::decode(s, &audit_key.key)?),
+        Some(s) => Some(Cursor::decode_bound(s, &audit_key.key, &binding)?),
         None => None,
     };
 
@@ -85,15 +259,20 @@ pub async fn list_audit(
         None => 0,
     };
 
-    let mut items: Vec<AuditEnvelope> = Vec::with_capacity(limit);
+    let mut entries: Vec<AuditEntry> = Vec::with_capacity(limit);
     let mut last_seen_key: Option<Vec<u8>> = None;
     let mut idx = start;
-    while items.len() < limit && idx < pairs.len() {
+    while entries.len() < limit && idx < pairs.len() {
         let (key, value) = &pairs[idx];
         match serde_json::from_slice::<AuditEnvelope>(value) {
             Ok(env) => {
-                items.push(env);
-                last_seen_key = Some(key.clone());
+                // Filter *after* deserializing: the predicates read
+                // envelope fields, and an unparseable row can't be
+                // judged either way (it is skipped below, as before).
+                if query.matches(&env) {
+                    entries.push(AuditEntry::from(&env));
+                    last_seen_key = Some(key.clone());
+                }
             }
             Err(err) => {
                 tracing::warn!(
@@ -106,24 +285,40 @@ pub async fn list_audit(
         idx += 1;
     }
 
+    // `truncated` must mean "more *matching* entries remain", not "more
+    // rows remain" — with a filter applied the tail may hold nothing
+    // that matches, and handing back a cursor for an empty next page
+    // would make a caller believe results were withheld. Scan ahead only
+    // until the first further match.
+    let mut more_matches = false;
+    while idx < pairs.len() {
+        if let Ok(env) = serde_json::from_slice::<AuditEnvelope>(&pairs[idx].1)
+            && query.matches(&env)
+        {
+            more_matches = true;
+            break;
+        }
+        idx += 1;
+    }
+
     let snapshot_id: u64 = pairs.len() as u64;
-    let next_cursor = if idx < pairs.len() {
-        last_seen_key.map(|k| Cursor::new(k, snapshot_id).encode(&audit_key.key))
+    let cursor = if more_matches {
+        last_seen_key.map(|k| Cursor::new(k, snapshot_id).encode_bound(&audit_key.key, &binding))
     } else {
         None
     };
 
     info!(
         caller = %auth.0.did,
-        count = items.len(),
-        has_more = next_cursor.is_some(),
+        count = entries.len(),
+        has_more = cursor.is_some(),
         "audit listed",
     );
 
-    Ok(Json(Paginated {
-        items,
-        next_cursor,
-        total_estimate: None,
+    Ok(Json(AuditListResponse {
+        truncated: cursor.is_some(),
+        entries,
+        cursor,
     }))
 }
 

--- a/vtc-service/src/routes/mod.rs
+++ b/vtc-service/src/routes/mod.rs
@@ -378,7 +378,7 @@ fn build_api_chain(_routing: &RoutingConfig, trust_xff: bool) -> OpenApiRouter<A
         // Audit log read (super-admin only).
         .routes(tt(
             routes!(audit::list_audit),
-            "https://trusttasks.org/openvtc/vtc/audit/list/1.0",
+            "https://trusttasks.org/spec/audit/list/0.1",
         ))
         .routes(tt(
             routes!(audit::verify_audit_chain),

--- a/vtc-service/tests/audit_list.rs
+++ b/vtc-service/tests/audit_list.rs
@@ -1,0 +1,293 @@
+//! Integration coverage for `GET /v1/audit` — canonical
+//! `spec/audit/list/0.1` (phase 2b(ii)).
+//!
+//! What matters here is not the URI swap but the three things the
+//! repoint introduced: the canonical response/envelope shape, filters
+//! that are actually applied (rather than accepted and ignored), and a
+//! cursor that refuses to be reused under a different filter set.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use serde_json::{Value, json};
+use tower::ServiceExt;
+
+use vtc_service::server::AppState;
+use vtc_service::test_support::TestVtc;
+
+const LIST_TASK: &str = "https://trusttasks.org/spec/audit/list/0.1";
+const PROFILE_TASK: &str = "https://trusttasks.org/openvtc/vtc/community/profile/manage/1.0";
+
+struct Fixture {
+    router: axum::Router,
+    state: AppState,
+    vtc: TestVtc,
+}
+
+async fn build() -> Fixture {
+    let vtc = TestVtc::builder().with_audit(true).build().await;
+    Fixture {
+        router: vtc.router.clone(),
+        state: vtc.state.clone(),
+        vtc,
+    }
+}
+
+async fn super_admin_token(fix: &Fixture) -> String {
+    fix.vtc.token("did:key:z6MkAdmin", "admin", vec![]).await
+}
+
+async fn body_value(resp: axum::response::Response) -> (StatusCode, Value) {
+    let status = resp.status();
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let v: Value = serde_json::from_slice(&bytes)
+        .unwrap_or_else(|_| json!({ "raw": String::from_utf8_lossy(&bytes) }));
+    (status, v)
+}
+
+async fn list(fix: &Fixture, token: &str, query: &str) -> (StatusCode, Value) {
+    let uri = if query.is_empty() {
+        "/v1/audit".to_string()
+    } else {
+        format!("/v1/audit?{query}")
+    };
+    let req = Request::builder()
+        .method("GET")
+        .uri(uri)
+        .header("Trust-Task", LIST_TASK)
+        .header("Authorization", format!("Bearer {token}"))
+        .body(Body::empty())
+        .unwrap();
+    body_value(fix.router.clone().oneshot(req).await.unwrap()).await
+}
+
+/// Emit real `CommunityProfileUpdated` envelopes through a live route.
+async fn seed(fix: &Fixture, token: &str, count: usize) {
+    let profile = vtc_service::community::CommunityProfile::new(
+        "did:webvh:vtc.example.com:abc",
+        "Example Community",
+    );
+    vtc_service::community::store_profile(&fix.state.community_ks, &profile)
+        .await
+        .unwrap();
+    for i in 0..count {
+        let req = Request::builder()
+            .method("PUT")
+            .uri("/v1/community/profile")
+            .header("Trust-Task", PROFILE_TASK)
+            .header("Authorization", format!("Bearer {token}"))
+            .header("Content-Type", "application/json")
+            .body(Body::from(format!(r#"{{"name":"Rename {i}"}}"#)))
+            .unwrap();
+        let resp = fix.router.clone().oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK, "seed write {i}");
+    }
+}
+
+#[tokio::test]
+async fn response_and_entries_are_the_canonical_shape() {
+    let fix = build().await;
+    let token = super_admin_token(&fix).await;
+    seed(&fix, &token, 2).await;
+
+    let (status, body) = list(&fix, &token, "").await;
+    assert_eq!(status, StatusCode::OK);
+
+    // Canonical response envelope, not the old Paginated wrapper.
+    assert!(body.get("entries").is_some(), "entries: {body}");
+    assert!(body.get("truncated").is_some(), "truncated: {body}");
+    assert!(
+        body.get("items").is_none() && body.get("next_cursor").is_none(),
+        "the pre-migration Paginated shape must be gone: {body}"
+    );
+
+    let entry = &body["entries"][0];
+    for field in ["eventId", "recordedAt", "action", "schemaVersion"] {
+        assert!(entry.get(field).is_some(), "{field} missing: {entry}");
+    }
+    // Maintainer-specific fields moved under ext — canonical
+    // AuditEnvelope is additionalProperties:false.
+    assert!(entry.get("actor_did_hash").is_none(), "{entry}");
+    assert!(entry.get("timestamp").is_none(), "{entry}");
+    assert!(
+        entry["ext"]["vtc"].get("actorDidHash").is_some(),
+        "keyed hash should ride in ext: {entry}"
+    );
+    // action is the serde tag; detail is the variant payload.
+    assert_eq!(entry["action"], "CommunityProfileUpdated");
+    assert!(entry["detail"].is_object(), "{entry}");
+}
+
+/// `verify` reports `head` as hex; a caller comparing it against the
+/// newest entry's `entryHash` must not have to reconcile encodings.
+#[tokio::test]
+async fn entry_hashes_are_hex_matching_audit_verify_head() {
+    let fix = build().await;
+    let token = super_admin_token(&fix).await;
+    seed(&fix, &token, 2).await;
+
+    let (_, list_body) = list(&fix, &token, "").await;
+    let newest = list_body["entries"][0]["entryHash"].as_str().unwrap();
+
+    let req = Request::builder()
+        .method("GET")
+        .uri("/v1/audit/verify")
+        .header("Trust-Task", "https://trusttasks.org/spec/audit/verify/0.1")
+        .header("Authorization", format!("Bearer {token}"))
+        .body(Body::empty())
+        .unwrap();
+    let (_, verify_body) = body_value(fix.router.clone().oneshot(req).await.unwrap()).await;
+
+    assert_eq!(
+        verify_body["head"].as_str().unwrap(),
+        newest,
+        "audit/verify head and audit/list entryHash must agree"
+    );
+}
+
+#[tokio::test]
+async fn action_filter_is_actually_applied() {
+    let fix = build().await;
+    let token = super_admin_token(&fix).await;
+    seed(&fix, &token, 3).await;
+
+    let (status, body) = list(&fix, &token, "action=CommunityProfileUpdated").await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(!body["entries"].as_array().unwrap().is_empty());
+
+    // A filter that matches nothing must return nothing — not the
+    // unfiltered log.
+    let (status, body) = list(&fix, &token, "action=NoSuchEvent").await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(
+        body["entries"].as_array().unwrap().is_empty(),
+        "an unmatched action filter must not fall back to everything: {body}"
+    );
+    assert_eq!(body["truncated"], false);
+    assert!(body.get("cursor").is_none() || body["cursor"].is_null());
+}
+
+#[tokio::test]
+async fn actor_filter_is_actually_applied() {
+    let fix = build().await;
+    let token = super_admin_token(&fix).await;
+    seed(&fix, &token, 2).await;
+
+    let (_, body) = list(&fix, &token, "actor=did:key:z6MkAdmin").await;
+    assert!(!body["entries"].as_array().unwrap().is_empty());
+
+    let (_, body) = list(&fix, &token, "actor=did:key:z6MkSomeoneElse").await;
+    assert!(
+        body["entries"].as_array().unwrap().is_empty(),
+        "unmatched actor filter must return nothing: {body}"
+    );
+}
+
+#[tokio::test]
+async fn time_window_filters_are_applied() {
+    let fix = build().await;
+    let token = super_admin_token(&fix).await;
+    seed(&fix, &token, 2).await;
+
+    // Everything was written just now, so a window that closes in the
+    // past must be empty and one that opens in the past must not be.
+    let (_, past) = list(&fix, &token, "to=2000-01-01T00:00:00Z").await;
+    assert!(
+        past["entries"].as_array().unwrap().is_empty(),
+        "`to` in the far past should exclude everything: {past}"
+    );
+
+    let (_, since) = list(&fix, &token, "from=2000-01-01T00:00:00Z").await;
+    assert!(!since["entries"].as_array().unwrap().is_empty());
+}
+
+/// Canonical defines `outcome` and `contextId`; VTC tracks neither.
+/// Accepting them silently would hand back unfiltered rows to a caller
+/// who believes they filtered.
+#[tokio::test]
+async fn unsupported_filters_are_refused_not_ignored() {
+    let fix = build().await;
+    let token = super_admin_token(&fix).await;
+    seed(&fix, &token, 1).await;
+
+    for q in ["outcome=denied", "contextId=ctx-1"] {
+        let (status, body) = list(&fix, &token, q).await;
+        assert_eq!(
+            status,
+            StatusCode::BAD_REQUEST,
+            "{q} must be refused, got {status}: {body}"
+        );
+        // The refusal has to name the offending filter, or an operator
+        // cannot tell which of their filters this maintainer dropped.
+        let msg = body["error"].as_str().unwrap_or_default();
+        let named = q.split('=').next().unwrap();
+        assert!(msg.contains(named), "error should name `{named}`: {body}");
+    }
+}
+
+/// Canonical: "A consumer that supplies a `cursor` MUST NOT also change
+/// the filters, which are bound into the cursor's position." Changing
+/// them mid-pagination would silently skip entries.
+#[tokio::test]
+async fn a_cursor_cannot_be_replayed_under_different_filters() {
+    let fix = build().await;
+    let token = super_admin_token(&fix).await;
+    seed(&fix, &token, 4).await;
+
+    // Page 1 of 2, filtered.
+    let (status, page1) = list(&fix, &token, "action=CommunityProfileUpdated&pageSize=1").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(page1["truncated"], true, "expected more pages: {page1}");
+    let cursor = page1["cursor"].as_str().expect("cursor").to_string();
+
+    // Same filters → resumes.
+    let (status, page2) = list(
+        &fix,
+        &token,
+        &format!("action=CommunityProfileUpdated&pageSize=1&cursor={cursor}"),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "same filters must resume: {page2}");
+
+    // Different filters, same cursor → rejected.
+    let (status, body) = list(
+        &fix,
+        &token,
+        &format!("action=MemberAdded&pageSize=1&cursor={cursor}"),
+    )
+    .await;
+    assert_ne!(
+        status,
+        StatusCode::OK,
+        "a cursor must not carry across a filter change: {body}"
+    );
+
+    // Dropping the filter entirely is also a change.
+    let (status, body) = list(&fix, &token, &format!("pageSize=1&cursor={cursor}")).await;
+    assert_ne!(
+        status,
+        StatusCode::OK,
+        "dropping the filter must invalidate the cursor: {body}"
+    );
+}
+
+#[tokio::test]
+async fn truncated_reflects_matching_entries_not_raw_rows() {
+    let fix = build().await;
+    let token = super_admin_token(&fix).await;
+    seed(&fix, &token, 3).await;
+
+    // A filter matching nothing, with rows still unread behind the
+    // page: `truncated` must be false, or the caller pages forever
+    // into an empty tail believing results were withheld.
+    let (_, body) = list(&fix, &token, "action=NoSuchEvent&pageSize=1").await;
+    assert_eq!(body["truncated"], false, "{body}");
+}
+
+#[tokio::test]
+async fn non_super_admin_is_refused() {
+    let fix = build().await;
+    let token = fix.vtc.token("did:key:z6MkReader", "reader", vec![]).await;
+    let (status, _) = list(&fix, &token, "").await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+}

--- a/vti-common/Cargo.toml
+++ b/vti-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-common"
 description = "Shared server-side infrastructure for VTA and VTC services"
 readme = "README.md"
-version = "0.11.11"
+version = "0.11.12"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vti-common/src/audit/event.rs
+++ b/vti-common/src/audit/event.rs
@@ -379,6 +379,77 @@ pub enum AuditEvent {
     SchemaDeleted(SchemaChangeData),
 }
 
+impl AuditEvent {
+    /// The serde tag for this variant — the same string that appears as
+    /// `{"type": ...}` on the stored envelope.
+    ///
+    /// This is what the canonical `audit/list` Trust Task exposes as
+    /// `action`, and what `audit/list`'s `action` filter matches on, so
+    /// it must stay identical to the serialized tag. Kept as an explicit
+    /// match (rather than round-tripping through `serde_json`) so listing
+    /// does not pay a serialization per row just to learn the name.
+    pub fn variant_name(&self) -> &'static str {
+        match self {
+            Self::CommunityInstalled(..) => "CommunityInstalled",
+            Self::EmergencyBootstrapInvoked(..) => "EmergencyBootstrapInvoked",
+            Self::AdminPasskeyRegistered(..) => "AdminPasskeyRegistered",
+            Self::AdminPasskeyRevoked(..) => "AdminPasskeyRevoked",
+            Self::ConfigChanged(..) => "ConfigChanged",
+            Self::ConfigReloaded(..) => "ConfigReloaded",
+            Self::RestartRequested(..) => "RestartRequested",
+            Self::CommunityProfileUpdated(..) => "CommunityProfileUpdated",
+            Self::AuditKeyRotated(..) => "AuditKeyRotated",
+            Self::MemberUpdated(..) => "MemberUpdated",
+            Self::RoleChanged(..) => "RoleChanged",
+            Self::AdminPromoted(..) => "AdminPromoted",
+            Self::JoinRequestSubmitted(..) => "JoinRequestSubmitted",
+            Self::JoinRequestApproved(..) => "JoinRequestApproved",
+            Self::JoinRequestRejected(..) => "JoinRequestRejected",
+            Self::MemberAdded(..) => "MemberAdded",
+            Self::MemberRemoved(..) => "MemberRemoved",
+            Self::MembershipReciprocated(..) => "MembershipReciprocated",
+            Self::PolicyUploaded(..) => "PolicyUploaded",
+            Self::PolicyActivated(..) => "PolicyActivated",
+            Self::VmcIssued(..) => "VmcIssued",
+            Self::VecIssued(..) => "VecIssued",
+            Self::MembershipRenewed(..) => "MembershipRenewed",
+            Self::StatusListFlipped(..) => "StatusListFlipped",
+            Self::DidRotated(..) => "DidRotated",
+            Self::RegistryStatusChanged(..) => "RegistryStatusChanged",
+            Self::RegistrySyncSucceeded(..) => "RegistrySyncSucceeded",
+            Self::RegistrySyncFailed(..) => "RegistrySyncFailed",
+            Self::RegistryRecordPolicyOverride(..) => "RegistryRecordPolicyOverride",
+            Self::CrossCommunitySessionMinted(..) => "CrossCommunitySessionMinted",
+            Self::VrcPublished(..) => "VrcPublished",
+            Self::VrcRevoked(..) => "VrcRevoked",
+            Self::PersonhoodAsserted(..) => "PersonhoodAsserted",
+            Self::PersonhoodRevoked(..) => "PersonhoodRevoked",
+            Self::CustomEndorsementIssued(..) => "CustomEndorsementIssued",
+            Self::CustomEndorsementRevoked(..) => "CustomEndorsementRevoked",
+            Self::EndorsementTypeRegistered(..) => "EndorsementTypeRegistered",
+            Self::EndorsementTypeDeleted(..) => "EndorsementTypeDeleted",
+            Self::WebsiteFileWritten(..) => "WebsiteFileWritten",
+            Self::WebsiteFileDeleted(..) => "WebsiteFileDeleted",
+            Self::WebsiteBundleDeployed(..) => "WebsiteBundleDeployed",
+            Self::WebsiteGenerationRolledBack(..) => "WebsiteGenerationRolledBack",
+            Self::AdminUiServed(..) => "AdminUiServed",
+            Self::AclGranted(..) => "AclGranted",
+            Self::AclUpdated(..) => "AclUpdated",
+            Self::AclRevoked(..) => "AclRevoked",
+            Self::InvitationIssued(..) => "InvitationIssued",
+            Self::InvitationRevoked(..) => "InvitationRevoked",
+            Self::SessionRevoked(..) => "SessionRevoked",
+            Self::SignedOut(..) => "SignedOut",
+            Self::BackupExported(..) => "BackupExported",
+            Self::BackupImported(..) => "BackupImported",
+            Self::AdminInviteCreated(..) => "AdminInviteCreated",
+            Self::AdminInviteRevoked(..) => "AdminInviteRevoked",
+            Self::SchemaRegistered(..) => "SchemaRegistered",
+            Self::SchemaDeleted(..) => "SchemaDeleted",
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Variant data structs
 // ---------------------------------------------------------------------------

--- a/vti-common/src/pagination/mod.rs
+++ b/vti-common/src/pagination/mod.rs
@@ -160,6 +160,24 @@ impl Cursor {
     /// Encode + sign the cursor under `audit_key`. Returns the
     /// base64url-encoded wire form ready for `next_cursor`.
     pub fn encode(&self, audit_key: &[u8; 32]) -> String {
+        self.encode_bound(audit_key, &[])
+    }
+
+    /// As [`Cursor::encode`], but additionally binds `binding` into the
+    /// HMAC — without placing it on the wire.
+    ///
+    /// This is how a paginated query pins the filters a cursor was minted
+    /// under. The bytes are covered by the tag but not transmitted, so the
+    /// wire format is unchanged and a caller cannot rewrite them. Resuming
+    /// with a *different* binding fails verification and surfaces as
+    /// [`AppError::InvalidCursor`], which is what stops a consumer from
+    /// paging with one filter set and continuing with another — a silent
+    /// way to skip entries that must never happen on an audit log.
+    ///
+    /// Callers with no binding use [`Cursor::encode`], which passes an
+    /// empty slice and is therefore wire- and tag-compatible with cursors
+    /// minted before this method existed.
+    pub fn encode_bound(&self, audit_key: &[u8; 32], binding: &[u8]) -> String {
         let mut buf = Vec::with_capacity(4 + self.last_key.len() + 8 + HMAC_TAG_LEN);
         buf.extend_from_slice(&(self.last_key.len() as u32).to_be_bytes());
         buf.extend_from_slice(&self.last_key);
@@ -167,6 +185,7 @@ impl Cursor {
 
         let mut mac = HmacSha256::new_from_slice(audit_key).expect("32-byte HMAC key");
         mac.update(&buf);
+        mac.update(binding);
         let tag = mac.finalize().into_bytes();
         buf.extend_from_slice(&tag);
 
@@ -178,6 +197,18 @@ impl Cursor {
     /// tampered, or signed under a different key) — the error
     /// deliberately doesn't reveal which.
     pub fn decode(wire: &str, audit_key: &[u8; 32]) -> Result<Self, AppError> {
+        Self::decode_bound(wire, audit_key, &[])
+    }
+
+    /// As [`Cursor::decode`], but requires the cursor to have been minted
+    /// with the same `binding` (see [`Cursor::encode_bound`]). A mismatch
+    /// is indistinguishable from a tampered cursor and yields
+    /// [`AppError::InvalidCursor`].
+    pub fn decode_bound(
+        wire: &str,
+        audit_key: &[u8; 32],
+        binding: &[u8],
+    ) -> Result<Self, AppError> {
         let raw = B64.decode(wire).map_err(|_| AppError::InvalidCursor)?;
         if raw.len() <= HMAC_TAG_LEN + 4 + 8 {
             return Err(AppError::InvalidCursor);
@@ -189,6 +220,7 @@ impl Cursor {
 
         let mut mac = HmacSha256::new_from_slice(audit_key).expect("32-byte HMAC key");
         mac.update(payload);
+        mac.update(binding);
         mac.verify_slice(received_tag)
             .map_err(|_| AppError::InvalidCursor)?;
 
@@ -310,6 +342,45 @@ mod tests {
 
     const KEY_A: [u8; 32] = [0xAA; 32];
     const KEY_B: [u8; 32] = [0xBB; 32];
+
+    /// A bound cursor only decodes under the same binding. This is what
+    /// stops a filtered listing from being resumed under different
+    /// filters — a silent way to skip entries.
+    #[test]
+    fn a_bound_cursor_rejects_a_different_binding() {
+        let c = Cursor::new(b"audit:2026-01-01:abc".to_vec(), 7);
+        let wire = c.encode_bound(&KEY_A, b"action=MemberAdded");
+
+        assert_eq!(
+            Cursor::decode_bound(&wire, &KEY_A, b"action=MemberAdded").unwrap(),
+            c
+        );
+        assert!(matches!(
+            Cursor::decode_bound(&wire, &KEY_A, b"action=MemberRemoved"),
+            Err(AppError::InvalidCursor)
+        ));
+        // Dropping the binding entirely is also a change.
+        assert!(matches!(
+            Cursor::decode(&wire, &KEY_A),
+            Err(AppError::InvalidCursor)
+        ));
+        // And the key still has to match.
+        assert!(matches!(
+            Cursor::decode_bound(&wire, &KEY_B, b"action=MemberAdded"),
+            Err(AppError::InvalidCursor)
+        ));
+    }
+
+    /// Unbound encode/decode must stay byte-compatible with cursors
+    /// minted before binding existed, so other paginated endpoints
+    /// (e.g. policy list) are unaffected.
+    #[test]
+    fn an_unbound_cursor_round_trips_as_before() {
+        let c = Cursor::new(b"policy:001".to_vec(), 3);
+        let wire = c.encode(&KEY_A);
+        assert_eq!(Cursor::decode(&wire, &KEY_A).unwrap(), c);
+        assert_eq!(wire, c.encode_bound(&KEY_A, &[]));
+    }
 
     fn make_pairs(count: usize) -> Vec<RawKvPair> {
         (0..count)


### PR DESCRIPTION
Phase 2b(ii) of the vtc-service Trust Task migration (#710), completing the `audit/*` family. Unlike 2b(i), this is a rewrite rather than a URI swap.

`GET /v1/audit` now carries `https://trusttasks.org/spec/audit/list/0.1`; `openvtc/vtc/audit/list/1.0` is **retired** with `supersededBy`.

### Breaking (admin API)

| | was | now |
|---|---|---|
| response | `{items, next_cursor, total_estimate}` | `{entries, truncated, cursor}` |
| entry | snake_case VTC envelope | canonical `AuditEnvelope`, camelCase |
| page size param | `limit` | `pageSize` |

The bundled admin UI read *every one* of those fields, so `vtc-service/admin-ui/src/plugins/audit.tsx` is rewritten in the same commit — shipping them apart would leave the audit view broken. Its `eventKind()` helper is gone: canonical hands back `action` as a plain string instead of a nested serde tag to dig out.

Canonical `AuditEnvelope` is `additionalProperties: false`, so VTC's maintainer-specific fields (`actorDidHash`, `targetDidHash`, `auditKeyId`, `eventVersion`) move under **`ext.vtc`** rather than being dropped. `action` is the serde tag already on the stored envelope and `detail` is that variant's payload — nothing invented, nothing lost.

### Filters are implemented, not accepted-and-ignored

`from`, `to`, `action`, `actor` filter server-side.

`outcome` and `contextId` are **refused with an error naming the field**. This maintainer has no data for either: there is no envelope-level outcome (exactly one of 56 variants carries an `outcome` inside its own `data`), and a VTC *is* a single community, so the log is not context-partitioned. Accepting them silently was the tempting option and the wrong one — a caller querying `actor=X&outcome=denied` would receive every entry for X and could reasonably read that as *"no denials"*. On an audit log that is a security-relevant failure, not a cosmetic gap.

Relatedly, `truncated` reports whether more **matching** entries remain, not whether more rows remain — otherwise a filtered query hands back a cursor leading to an empty tail, which reads as "results withheld".

### Cursors are bound to their filter set

Canonical: *"A consumer that supplies a `cursor` MUST NOT also change the filters, which are bound into the cursor's position."* Enforced rather than documented: `Cursor::{encode,decode}_bound` fold the active filters into the **HMAC input without putting them on the wire**, so a caller cannot rewrite them and resuming under a different filter set fails as a tampered cursor. Paging with `actor=X` and continuing with `actor=Y` would otherwise silently skip entries.

Unbound `encode`/`decode` delegate with an empty binding and stay byte- and tag-compatible, so the other paginated endpoints sharing this cursor (policy list) are untouched — covered by a test.

### A hash-encoding trap worth calling out

`audit/verify` reports `head` as **hex**; the stored envelope serializes its hashes as **base64**. A naive projection would have emitted base64 `entryHash`, so a caller comparing `verify.head` against the newest entry's `entryHash` would see a spurious mismatch for the very same entry. The projection emits hex, and `entry_hashes_are_hex_matching_audit_verify_head` pins the two endpoints together.

### Testing

New `vtc-service/tests/audit_list.rs` (9 tests): canonical response + entry shape (asserting the old `Paginated` shape is *gone* and the hashes landed in `ext`), each filter actually filtering, an unmatched filter returning nothing rather than falling back to everything, unsupported filters refused with the field named, cursor-replay rejected across a filter change *and* across dropping the filter, `truncated` honesty, and the verify/list hex agreement. Plus 2 `vti-common` cursor unit tests (binding rejects a different binding; unbound round-trips as before).

`cargo test --workspace` (CI-equivalent): **3615 passed, 0 failed**. `cargo clippy -p vti-common -p vtc-service --all-targets -D warnings` clean. `cargo fmt --all --check` clean. `tsc --noEmit` on the admin UI clean. Self-pin guard green.

Versions bumped (`publish = true`): `vti-common` 0.11.12, `vtc-service` 0.11.15.

### Phase 2 status

- **2a `policy/*`** — still open, and **not a repoint**: canonical models `purpose` as a relational `(contextId, purpose) → policy` binding over *mutable* modules with `expectedVersion`, while VTC has it as an intrinsic column over *append-only* revisions with the Rego package name validated against it. Incompatible lifecycle models; wants a design decision, not a mechanical PR.
- **2b** — complete with this PR.
- **2c `config/*`** — done (#724).
- **2d `acl/*`** — unblocked by #724's per-method finding; remaining work is payload reconciliation (`did`→`subject`, `allowed_contexts`→`scopes`, `u64` epoch → RFC3339, add `truncated`).
- **2e `auth/*`** — already done; residual `openvtc` auth URIs have no canonical target.