### PR TITLE
feat(vtc): phase 2d — repoint acl/*, implementing the canonical semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,50 @@
 
 ## Unreleased
 
+### vtc-service — Phase 2d: `acl/*` repointed, with the canonical semantics implemented
+
+* The two combined mounts (`acl/legacy/{manage,entry}/1.0`) fan out to the five
+  canonical tasks — `spec/acl/{list,grant,show,change-role,revoke}/0.1` — one per
+  verb. Both legacy tasks are **retired** with `supersededBy`.
+* **Breaking (admin API).** Entries are now the canonical `AclEntry`:
+  `did` → `subject`, `allowed_contexts` → `scopes`, and every timestamp is an
+  RFC3339 string rather than a unix epoch (canonical types them
+  `format: date-time`, so an integer would be a silent contract break). List
+  responses gain the canonical-required `truncated` plus an optional `cursor`.
+  The bundled admin UI is updated in step.
+* **`PATCH /v1/acl/{did}` is now `acl/change-role`, and role-only.** It takes
+  `{fromRole, toRole}` and **enforces `fromRole` as a compare-and-swap**,
+  returning 409 when the subject's current role differs. That closes the
+  read-modify-write race the old partial update had: two admins demoting the
+  same subject concurrently could each read `admin`, write different results,
+  and last-writer-wins with no signal. The old body (`role`/`label`/
+  `allowed_contexts`, all optional) is rejected outright rather than being
+  read as a subset of the new one.
+* **Label and scope edits move to `acl/grant`**, which canonical defines as
+  "the entry the maintainer should hold". Re-granting the *same* role rewrites
+  the entry; granting a *different* role to an existing subject is refused with
+  a pointer to `acl/change-role`, so grant cannot be used to bypass the CAS
+  guard. Server-owned provenance (`createdAt`/`createdBy`/`updatedAt`/
+  `updatedBy`) is not accepted from callers.
+* **`DELETE` implements canonical revoke's two modes.** With `?scopes=`, the
+  entry is *scope-reduced* and survives; only an omitted `scopes` removes it.
+  Conflating the two would have stripped far more authority than an operator
+  asked for. Revoking *every* scope is refused rather than executed, because an
+  empty scope set is how a community-wide (super) grant is spelled — revocation
+  must never widen authority. A scope reduction revokes the subject's live
+  sessions, since their tokens still carry the old scopes.
+* `acl/list` gains the canonical `role` / `scope` / `subjectPrefix` filters and
+  `pageSize`/`cursor` paging, with the filters bound into the cursor's HMAC so a
+  page cannot be resumed under a different filter set. The `scope` filter keeps
+  the hierarchy-aware matching the old `context` filter had (an ancestor scope
+  does carry a descendant). Paging degrades gracefully when the audit writer is
+  absent: cursors are signed with the audit key, so without one the full visible
+  set is returned as a single page rather than the endpoint failing — listing the
+  ACL must not depend on audit being configured.
+* `VtcAclEntry` gains `updated_at`/`updated_by` (`#[serde(default)]`, so existing
+  rows decode unchanged and report `None` rather than pretending creation was an
+  update).
+
 ### vtc-service — Phase 2b(ii): `audit/list` repointed, with filters actually implemented
 
 * `GET /v1/audit` now carries `https://trusttasks.org/spec/audit/list/0.1`;

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10341,7 +10341,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-service"
-version = "0.11.15"
+version = "0.11.16"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/trust-tasks/acl/legacy/entry/1.0/spec.md
+++ b/trust-tasks/acl/legacy/entry/1.0/spec.md
@@ -1,7 +1,8 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/acl/legacy/entry/1.0
 title: VTC Legacy — ACL Entry
-status: draft
+status: retired
+supersededBy: https://trusttasks.org/spec/acl/show/0.1
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/acl/legacy/manage/1.0/spec.md
+++ b/trust-tasks/acl/legacy/manage/1.0/spec.md
@@ -1,7 +1,8 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/acl/legacy/manage/1.0
 title: VTC Legacy — ACL Collection
-status: draft
+status: retired
+supersededBy: https://trusttasks.org/spec/acl/list/0.1
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/index.json
+++ b/trust-tasks/index.json
@@ -82,15 +82,17 @@
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/acl/legacy/manage/1.0",
-      "status": "draft",
+      "status": "retired",
       "path": "acl/legacy/manage/1.0",
-      "rest": "GET, POST /v1/acl"
+      "rest": "GET, POST /v1/acl",
+      "supersededBy": "https://trusttasks.org/spec/acl/list/0.1"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/acl/legacy/entry/1.0",
-      "status": "draft",
+      "status": "retired",
       "path": "acl/legacy/entry/1.0",
-      "rest": "GET, PATCH, DELETE /v1/acl/{did}"
+      "rest": "GET, PATCH, DELETE /v1/acl/{did}",
+      "supersededBy": "https://trusttasks.org/spec/acl/show/0.1"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/community/profile/manage/1.0",

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.11.15"
+version = "0.11.16"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vtc-service/admin-ui/src/plugins/acl.tsx
+++ b/vtc-service/admin-ui/src/plugins/acl.tsx
@@ -14,70 +14,94 @@ import {
 } from "@tanstack/react-query";
 import { Copy, Mail, Pencil, Plus, RefreshCw, ShieldCheck, X } from "lucide-react";
 
-import { deleteJson, getJson, patchJson, postJson } from "@/lib/api";
+import { deleteJson, getJson, postJson } from "@/lib/api";
 import { useConfirm } from "@/components/ConfirmDialog";
 import { Field } from "@/components/Field";
-import { formatEpoch, formatIso, shorten, shortenDid } from "@/lib/format";
+import { formatIso, shorten, shortenDid } from "@/lib/format";
 import { useToast } from "@/lib/toast";
 
-const TRUST_TASK_MANAGE =
-  "https://trusttasks.org/openvtc/vtc/acl/legacy/manage/1.0";
-const TRUST_TASK_ENTRY =
-  "https://trusttasks.org/openvtc/vtc/acl/legacy/entry/1.0";
+// One canonical task per verb (the two combined `acl/legacy/*` tasks
+// were retired in phase 2d).
+const TRUST_TASK_LIST = "https://trusttasks.org/spec/acl/list/0.1";
+const TRUST_TASK_GRANT = "https://trusttasks.org/spec/acl/grant/0.1";
+const TRUST_TASK_REVOKE = "https://trusttasks.org/spec/acl/revoke/0.1";
 const TRUST_TASK_INVITES_MANAGE =
   "https://trusttasks.org/openvtc/vtc/admin/invites/manage/1.0";
 const TRUST_TASK_INVITES_REVOKE =
   "https://trusttasks.org/openvtc/vtc/admin/invites/revoke/1.0";
 
+// Canonical `acl/_shared` AclEntry. `did` -> `subject`,
+// `allowed_contexts` -> `scopes`, and every timestamp is now an
+// RFC3339 string rather than a unix epoch.
 interface AclEntry {
-  did: string;
+  subject: string;
   role: string;
-  label: string | null;
-  allowed_contexts: string[];
-  created_at: number;
-  created_by: string;
-  expires_at: number | null;
+  label?: string | null;
+  scopes: string[];
+  createdAt: string;
+  createdBy: string;
+  updatedAt?: string | null;
+  updatedBy?: string | null;
+  expiresAt?: string | null;
 }
 
 interface AclListResponse {
   entries: AclEntry[];
+  truncated: boolean;
+  cursor?: string | null;
 }
 
+// `acl/grant` wraps the entry; server-owned provenance is not settable.
 interface CreateAclRequest {
-  did: string;
-  role: string;
-  label?: string | null;
-  allowed_contexts: string[];
-  expires_at?: number | null;
+  entry: {
+    subject: string;
+    role: string;
+    label?: string | null;
+    scopes: string[];
+    expiresAt?: string | null;
+  };
+  reason?: string;
 }
 
-async function fetchAcl(context: string | null): Promise<AclListResponse> {
+async function fetchAcl(scope: string | null): Promise<AclListResponse> {
   const q = new URLSearchParams();
-  if (context) q.set("context", context);
+  if (scope) q.set("scope", scope);
   const suffix = q.toString();
   return getJson<AclListResponse>(`/v1/acl${suffix ? `?${suffix}` : ""}`, {
-    trustTask: TRUST_TASK_MANAGE,
+    trustTask: TRUST_TASK_LIST,
   });
 }
 
 async function createAcl(req: CreateAclRequest): Promise<AclEntry> {
-  return postJson<AclEntry>("/v1/acl", req, { trustTask: TRUST_TASK_MANAGE });
+  return postJson<AclEntry>("/v1/acl", req, { trustTask: TRUST_TASK_GRANT });
 }
 
-async function deleteAcl(did: string): Promise<void> {
-  await deleteJson<unknown>(`/v1/acl/${encodeURIComponent(did)}`, {
-    trustTask: TRUST_TASK_ENTRY,
+async function deleteAcl(subject: string): Promise<void> {
+  await deleteJson<unknown>(`/v1/acl/${encodeURIComponent(subject)}`, {
+    trustTask: TRUST_TASK_REVOKE,
   });
 }
 
+// A label edit is not a role change, so it goes through `acl/grant`
+// re-stating the entry with its existing role — `acl/change-role` is
+// role-only and would reject this.
 async function patchAclLabel(args: {
-  did: string;
+  entry: AclEntry;
   label: string;
 }): Promise<AclEntry> {
-  return patchJson<AclEntry>(
-    `/v1/acl/${encodeURIComponent(args.did)}`,
-    { label: args.label },
-    { trustTask: TRUST_TASK_ENTRY },
+  return postJson<AclEntry>(
+    "/v1/acl",
+    {
+      entry: {
+        subject: args.entry.subject,
+        role: args.entry.role,
+        label: args.label,
+        scopes: args.entry.scopes,
+        expiresAt: args.entry.expiresAt ?? null,
+      },
+      reason: "label updated from the admin UI",
+    },
+    { trustTask: TRUST_TASK_GRANT },
   );
 }
 
@@ -248,21 +272,21 @@ export function Acl() {
               </tr>
             )}
             {query.data?.entries.map((e) => (
-              <tr key={e.did}>
+              <tr key={e.subject}>
                 <td>
-                  <code title={e.did}>{shortenDid(e.did)}</code>
+                  <code title={e.subject}>{shortenDid(e.subject)}</code>
                 </td>
                 <td>
                   <code>{e.role}</code>
                 </td>
                 <td>
-                  <EditableLabelCell did={e.did} label={e.label} />
+                  <EditableLabelCell entry={e} label={e.label ?? null} />
                 </td>
                 <td>
-                  {e.allowed_contexts.length === 0 ? (
+                  {e.scopes.length === 0 ? (
                     <span className="muted">all</span>
                   ) : (
-                    e.allowed_contexts.map((c) => (
+                    e.scopes.map((c) => (
                       <code key={c} className="chip">
                         {c}
                       </code>
@@ -270,9 +294,9 @@ export function Acl() {
                   )}
                 </td>
                 <td>
-                  {e.expires_at ? (
-                    <span title={String(e.expires_at)}>
-                      {formatEpoch(e.expires_at)}
+                  {e.expiresAt ? (
+                    <span title={String(e.expiresAt)}>
+                      {formatIso(e.expiresAt)}
                     </span>
                   ) : (
                     <span className="muted">never</span>
@@ -286,11 +310,11 @@ export function Acl() {
                     onClick={async () => {
                       const ok = await confirm({
                         title: "Revoke ACL entry?",
-                        message: `${e.did} loses access immediately. This cannot be undone.`,
+                        message: `${e.subject} loses access immediately. This cannot be undone.`,
                         confirmLabel: "Revoke",
                         destructive: true,
                       });
-                      if (ok) revoke.mutate(e.did);
+                      if (ok) revoke.mutate(e.subject);
                     }}
                   >
                     Revoke
@@ -766,7 +790,7 @@ function CreateAclForm({ onSuccess }: { onSuccess: () => void }) {
   const mutation = useMutation({
     mutationFn: createAcl,
     onSuccess: (entry) => {
-      toast.push("success", `Created ACL entry for ${entry.did}`);
+      toast.push("success", `Created ACL entry for ${entry.subject}`);
       onSuccess();
     },
     onError: (err) => toast.pushFromError(err, "Create failed"),
@@ -774,17 +798,27 @@ function CreateAclForm({ onSuccess }: { onSuccess: () => void }) {
 
   const onSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    const allowed_contexts = contexts
+    const scopes = contexts
       .split(",")
       .map((c) => c.trim())
       .filter((c) => c.length > 0);
     const exp = expiresAt.trim();
     mutation.mutate({
-      did: did.trim(),
-      role: role.trim(),
-      label: label.trim() === "" ? null : label.trim(),
-      allowed_contexts,
-      expires_at: exp === "" ? null : Number(exp) || null,
+      entry: {
+        subject: did.trim(),
+        role: role.trim(),
+        label: label.trim() === "" ? null : label.trim(),
+        scopes,
+        // Canonical `expiresAt` is RFC3339. Accept either an ISO
+        // string or a unix epoch typed by the operator and normalise,
+        // rather than sending an integer the server now rejects.
+        expiresAt:
+          exp === ""
+            ? null
+            : /^\d+$/.test(exp)
+              ? new Date(Number(exp) * 1000).toISOString()
+              : exp,
+      },
     });
   };
 
@@ -844,10 +878,10 @@ function CreateAclForm({ onSuccess }: { onSuccess: () => void }) {
 }
 
 function EditableLabelCell({
-  did,
+  entry,
   label,
 }: {
-  did: string;
+  entry: AclEntry;
   label: string | null;
 }) {
   const queryClient = useQueryClient();
@@ -890,7 +924,7 @@ function EditableLabelCell({
       setEditing(false);
       return;
     }
-    mutation.mutate({ did, label: next });
+    mutation.mutate({ entry, label: next });
   };
 
   const cancel = () => {

--- a/vtc-service/src/acl/entry.rs
+++ b/vtc-service/src/acl/entry.rs
@@ -40,6 +40,21 @@ pub struct VtcAclEntry {
     pub allowed_contexts: Vec<String>,
     pub created_at: u64,
     pub created_by: String,
+    /// Unix-epoch seconds of the last mutation, and who made it.
+    ///
+    /// Canonical `acl/_shared` carries `updatedAt`/`updatedBy`, and now
+    /// that role changes (`acl/change-role`) and entry rewrites
+    /// (`acl/grant`) are distinct operations, "when did this last
+    /// change, and by whom" is answerable — previously every entry
+    /// looked as though it had never moved since creation.
+    ///
+    /// `#[serde(default)]` keeps rows written before this field
+    /// deserializable; they report `None` rather than pretending the
+    /// creation time was an update.
+    #[serde(default)]
+    pub updated_at: Option<u64>,
+    #[serde(default)]
+    pub updated_by: Option<String>,
     /// Unix-epoch seconds at which this entry expires and should be
     /// pruned by the background sweeper. `None` is permanent.
     #[serde(default)]
@@ -141,6 +156,8 @@ mod tests {
             allowed_contexts: vec![],
             created_at: 1,
             created_by: "did:key:zAdmin".into(),
+            updated_at: None,
+            updated_by: None,
             expires_at: None,
         };
         let bytes = serde_json::to_vec(&entry).unwrap();
@@ -157,6 +174,8 @@ mod tests {
             allowed_contexts: vec![],
             created_at: 42,
             created_by: "did:key:vtc-install".into(),
+            updated_at: None,
+            updated_by: None,
             expires_at,
         }
     }

--- a/vtc-service/src/acl/storage.rs
+++ b/vtc-service/src/acl/storage.rs
@@ -205,6 +205,8 @@ mod tests {
             allowed_contexts: vec![],
             created_at: 1,
             created_by: "did:key:vtc-install".into(),
+            updated_at: None,
+            updated_by: None,
             expires_at: None,
         }
     }

--- a/vtc-service/src/acl_cli.rs
+++ b/vtc-service/src/acl_cli.rs
@@ -107,6 +107,8 @@ pub async fn run_acl_add(args: AclAddArgs) -> CliResult {
         // Preserve the original creation time on update.
         created_at: existing.as_ref().map(|e| e.created_at).unwrap_or(now),
         created_by: "cli:acl-add".into(),
+        updated_at: None,
+        updated_by: None,
         expires_at: args.expires.map(|ttl| now.saturating_add(ttl)),
     };
     store_acl_entry(&acl_ks, &entry).await?;

--- a/vtc-service/src/ceremony/execute.rs
+++ b/vtc-service/src/ceremony/execute.rs
@@ -204,6 +204,8 @@ async fn admit(
         allowed_contexts: vec![],
         created_at: now_epoch(),
         created_by: actor_did.to_string(),
+        updated_at: None,
+        updated_by: None,
         expires_at: None,
     };
     store_acl_entry(&state.acl_ks, &acl).await?;

--- a/vtc-service/src/ceremony/orchestrate.rs
+++ b/vtc-service/src/ceremony/orchestrate.rs
@@ -513,6 +513,8 @@ mod p0_14_role_change_policy_tests {
                 allowed_contexts: vec![],
                 created_at: crate::auth::session::now_epoch(),
                 created_by: "did:key:vtc-install".into(),
+                updated_at: None,
+                updated_by: None,
                 expires_at: None,
             },
         )

--- a/vtc-service/src/did_key.rs
+++ b/vtc-service/src/did_key.rs
@@ -34,6 +34,8 @@ pub async fn run_create_did_key(args: CreateDidKeyArgs) -> Result<(), Box<dyn st
                 .unwrap()
                 .as_secs(),
             created_by: "cli:create-did-key".into(),
+            updated_at: None,
+            updated_by: None,
             expires_at: None,
         };
         store_acl_entry(&acl_ks, &entry).await?;

--- a/vtc-service/src/main.rs
+++ b/vtc-service/src/main.rs
@@ -439,6 +439,8 @@ async fn run_invite_cli(
             allowed_contexts: vec![],
             created_at: now_epoch(),
             created_by: format!("vtc-cli/{}", env!("CARGO_PKG_VERSION")),
+            updated_at: None,
+            updated_by: None,
             expires_at: None,
         };
         store_acl_entry(&acl_ks, &entry).await?;

--- a/vtc-service/src/routes/acl.rs
+++ b/vtc-service/src/routes/acl.rs
@@ -1,6 +1,7 @@
 use axum::Json;
 use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use tracing::info;
@@ -13,44 +14,128 @@ use crate::auth::{AdminAuth, AuthClaims, ManageAuth, session::now_epoch};
 use crate::error::AppError;
 use crate::server::AppState;
 use vti_common::audit::{AclChangeData, AclRevokedData, AuditEvent};
+use vti_common::pagination::{Cursor, MAX_LIMIT};
 
 // ---------- GET /acl ----------
 
 #[derive(Debug, Serialize, utoipa::ToSchema)]
 pub struct AclListResponse {
     pub entries: Vec<AclEntryResponse>,
+    /// True when more entries match beyond this page; `cursor` is then
+    /// present. Required by canonical `acl/list`.
+    pub truncated: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cursor: Option<String>,
 }
 
+/// Canonical `acl/_shared` **AclEntry**.
+///
+/// Renames from VTC's storage shape: `did` → `subject`,
+/// `allowed_contexts` → `scopes`. Timestamps are RFC3339 strings, not
+/// unix epochs — canonical types them `format: date-time`, and an
+/// integer there would be a silent contract break rather than a
+/// cosmetic one.
 #[derive(Debug, Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct AclEntryResponse {
-    pub did: String,
+    pub subject: String,
     pub role: VtcRole,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub label: Option<String>,
-    pub allowed_contexts: Vec<String>,
-    pub created_at: u64,
+    pub scopes: Vec<String>,
+    pub created_at: String,
     pub created_by: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub expires_at: Option<u64>,
+    pub updated_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub updated_by: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<String>,
+}
+
+/// Unix epoch seconds → RFC3339, for canonical `date-time` fields.
+fn epoch_to_rfc3339(secs: u64) -> String {
+    chrono::DateTime::from_timestamp(secs as i64, 0)
+        .unwrap_or_default()
+        .to_rfc3339()
 }
 
 impl From<VtcAclEntry> for AclEntryResponse {
     fn from(e: VtcAclEntry) -> Self {
         AclEntryResponse {
-            did: e.did,
+            subject: e.did,
             role: e.role,
             label: e.label,
-            allowed_contexts: e.allowed_contexts,
-            created_at: e.created_at,
+            scopes: e.allowed_contexts,
+            created_at: epoch_to_rfc3339(e.created_at),
             created_by: e.created_by,
-            expires_at: e.expires_at,
+            updated_at: e.updated_at.map(epoch_to_rfc3339),
+            updated_by: e.updated_by,
+            expires_at: e.expires_at.map(epoch_to_rfc3339),
         }
     }
 }
 
 #[derive(Debug, Deserialize, utoipa::ToSchema, utoipa::IntoParams)]
+#[serde(rename_all = "camelCase")]
 #[into_params(parameter_in = Query)]
 pub struct ListAclQuery {
-    pub context: Option<String>,
+    /// Return only entries with this role.
+    pub role: Option<String>,
+    /// Return only entries carrying this scope (canonical name for
+    /// what VTC stores as an allowed context).
+    pub scope: Option<String>,
+    /// Return only entries whose subject starts with this prefix.
+    pub subject_prefix: Option<String>,
+    /// Page size. Clamped to `1..=200`. Defaults to 50.
+    pub page_size: Option<usize>,
+    /// Opaque continuation token from a previous page's `cursor`.
+    pub cursor: Option<String>,
+}
+
+impl ListAclQuery {
+    /// Filters folded into the cursor's HMAC (see
+    /// [`vti_common::pagination::Cursor::encode_bound`]) so a page
+    /// cannot be resumed under a different filter set — on an ACL that
+    /// would silently skip entries an operator believes they reviewed.
+    fn cursor_binding(&self) -> Vec<u8> {
+        let mut out = Vec::new();
+        let mut field = |v: Option<&str>| {
+            let b = v.unwrap_or("").as_bytes();
+            out.extend_from_slice(&(b.len() as u32).to_be_bytes());
+            out.extend_from_slice(b);
+        };
+        field(self.role.as_deref());
+        field(self.scope.as_deref());
+        field(self.subject_prefix.as_deref());
+        out
+    }
+
+    fn matches(&self, e: &VtcAclEntry) -> bool {
+        if let Some(role) = &self.role
+            && e.role.to_string() != *role
+        {
+            return false;
+        }
+        // Hierarchy-aware, as the pre-migration `context` filter was: an
+        // entry scoped to an *ancestor* of `scope` does grant `scope`
+        // (`docs/05-design-notes/hierarchical-contexts.md`), so it
+        // genuinely "carries" it. For flat ids this is exact match.
+        if let Some(scope) = &self.scope
+            && !e
+                .allowed_contexts
+                .iter()
+                .any(|allowed| vti_common::context_path::is_ancestor_or_self(allowed, scope))
+        {
+            return false;
+        }
+        if let Some(prefix) = &self.subject_prefix
+            && !e.did.starts_with(prefix.as_str())
+        {
+            return false;
+        }
+        true
+    }
 }
 
 /// GET /acl — list ACL entries visible to the caller. Auth: Manage.
@@ -70,38 +155,100 @@ pub async fn list_acl(
     Query(query): Query<ListAclQuery>,
 ) -> Result<Json<AclListResponse>, AppError> {
     let acl = state.acl_ks.clone();
-    let all_entries = list_acl_entries(&acl).await?;
-    let entries: Vec<AclEntryResponse> = all_entries
+    let limit = query.page_size.unwrap_or(50).clamp(1, MAX_LIMIT);
+
+    // Visibility first (a caller must never learn an entry exists by
+    // watching it fall out of a filter), then the caller's filters.
+    let mut matching: Vec<VtcAclEntry> = list_acl_entries(&acl)
+        .await?
         .into_iter()
         .filter(|e| is_acl_entry_visible(&auth.0, &as_vti_acl_entry(e)))
-        // Hierarchy-aware: an entry scoped to an *ancestor* of `ctx` grants
-        // access to `ctx`, so it's relevant to a query for `ctx`
-        // (`docs/05-design-notes/hierarchical-contexts.md`). For flat ids this
-        // is identical to an exact match.
-        .filter(|e| match &query.context {
-            Some(ctx) => e
-                .allowed_contexts
-                .iter()
-                .any(|allowed| vti_common::context_path::is_ancestor_or_self(allowed, ctx)),
-            None => true,
-        })
-        .map(AclEntryResponse::from)
+        .filter(|e| query.matches(e))
         .collect();
-    info!(caller = %auth.0.did, count = entries.len(), "ACL listed");
-    Ok(Json(AclListResponse { entries }))
+    // Stable order so a cursor means the same thing across calls; the
+    // subject is unique, so this is a total order.
+    matching.sort_by(|a, b| a.did.cmp(&b.did));
+
+    // Cursors are signed with the audit key, but the audit writer is
+    // optional — listing the ACL is a core admin function and must not
+    // stop working because audit is switched off. Without a key we
+    // simply cannot mint or verify a cursor, so the whole visible set
+    // is served as one page (which is what this endpoint did before it
+    // paginated) and a supplied cursor is rejected rather than trusted
+    // unverified.
+    let audit_key = match state.audit_writer.as_ref() {
+        Some(w) => Some(w.active_key().await?),
+        None => None,
+    };
+    let binding = query.cursor_binding();
+
+    let start = match (&query.cursor, &audit_key) {
+        (Some(wire), Some(key)) => {
+            let c = Cursor::decode_bound(wire, &key.key, &binding)?;
+            matching
+                .iter()
+                .position(|e| e.did.as_bytes() > c.last_key.as_slice())
+                .unwrap_or(matching.len())
+        }
+        // A cursor we cannot verify is not a cursor.
+        (Some(_), None) => return Err(AppError::InvalidCursor),
+        (None, _) => 0,
+    };
+
+    let take = if audit_key.is_some() {
+        limit
+    } else {
+        matching.len()
+    };
+    let page: Vec<VtcAclEntry> = matching[start..].iter().take(take).cloned().collect();
+    let truncated = start + page.len() < matching.len();
+    let cursor = match (&audit_key, truncated) {
+        (Some(key), true) => page.last().map(|e| {
+            Cursor::new(e.did.as_bytes().to_vec(), matching.len() as u64)
+                .encode_bound(&key.key, &binding)
+        }),
+        _ => None,
+    };
+
+    let entries: Vec<AclEntryResponse> = page.into_iter().map(AclEntryResponse::from).collect();
+    info!(caller = %auth.0.did, count = entries.len(), truncated, "ACL listed");
+    Ok(Json(AclListResponse {
+        entries,
+        truncated,
+        cursor,
+    }))
 }
 
 // ---------- POST /acl ----------
 
+/// Canonical `acl/grant` request: the entry the maintainer should hold
+/// for the subject, plus an optional operator rationale.
 #[derive(Debug, Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct CreateAclRequest {
-    pub did: String,
+    pub entry: GrantEntry,
+    /// Operator rationale. Emitted on the service log line for this
+    /// change; the audit envelope's data types do not carry a free-text
+    /// reason today, so this is deliberately not described as audited.
+    #[serde(default)]
+    pub reason: Option<String>,
+}
+
+/// The writable subset of a canonical `AclEntry`. Server-owned fields
+/// (`createdAt`/`createdBy`/`updatedAt`/`updatedBy`) are deliberately
+/// absent — a caller must not be able to backdate provenance.
+#[derive(Debug, Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct GrantEntry {
+    pub subject: String,
     pub role: VtcRole,
+    #[serde(default)]
     pub label: Option<String>,
     #[serde(default)]
-    pub allowed_contexts: Vec<String>,
+    pub scopes: Vec<String>,
+    /// RFC3339, per canonical `AclEntry.expiresAt`.
     #[serde(default)]
-    pub expires_at: Option<u64>,
+    pub expires_at: Option<DateTime<Utc>>,
 }
 
 /// POST /acl — create a new ACL entry. Auth: Manage.
@@ -120,29 +267,51 @@ pub async fn create_acl(
     State(state): State<AppState>,
     Json(req): Json<CreateAclRequest>,
 ) -> Result<(StatusCode, Json<AclEntryResponse>), AppError> {
+    let req_entry = req.entry;
     // Block non-admin callers from granting Admin — role + context
     // bound checks must run before we touch storage.
-    validate_vtc_role_assignment(&auth.0, &req.role)?;
-    validate_acl_modification(&auth.0, &req.allowed_contexts)?;
+    validate_vtc_role_assignment(&auth.0, &req_entry.role)?;
+    validate_acl_modification(&auth.0, &req_entry.scopes)?;
 
     let acl = state.acl_ks.clone();
+    let expires_at = req_entry.expires_at.map(|t| t.timestamp() as u64);
 
-    // Check if entry already exists
-    if get_acl_entry(&acl, &req.did).await?.is_some() {
-        return Err(AppError::Conflict(format!(
-            "ACL entry already exists for DID: {}",
-            req.did
-        )));
-    }
+    // Canonical `acl/grant` is "the entry the maintainer should hold":
+    // re-granting the *same* role rewrites the entry's scopes/label,
+    // but a role change is `acl/change-role`'s job and is refused here
+    // — that task carries the `fromRole` compare-and-swap this one has
+    // no way to express.
+    let existing = get_acl_entry(&acl, &req_entry.subject).await?;
+    let (created_at, created_by, status) = match existing {
+        Some(prev) => {
+            if !is_acl_entry_visible(&auth.0, &as_vti_acl_entry(&prev)) {
+                return Err(AppError::NotFound(format!(
+                    "ACL entry not found for DID: {}",
+                    req_entry.subject
+                )));
+            }
+            if prev.role != req_entry.role {
+                return Err(AppError::Conflict(format!(
+                    "ACL entry for {} already holds role {}; use acl/change-role \
+                     (PATCH /v1/acl/{}) to move it to {}",
+                    req_entry.subject, prev.role, req_entry.subject, req_entry.role
+                )));
+            }
+            (prev.created_at, prev.created_by, StatusCode::OK)
+        }
+        None => (now_epoch(), auth.0.did.clone(), StatusCode::CREATED),
+    };
 
     let entry = VtcAclEntry {
-        did: req.did,
-        role: req.role,
-        label: req.label,
-        allowed_contexts: req.allowed_contexts,
-        created_at: now_epoch(),
-        created_by: auth.0.did,
-        expires_at: req.expires_at,
+        did: req_entry.subject,
+        role: req_entry.role,
+        label: req_entry.label,
+        allowed_contexts: req_entry.scopes,
+        created_at,
+        created_by,
+        updated_at: (status == StatusCode::OK).then(now_epoch),
+        updated_by: (status == StatusCode::OK).then(|| auth.0.did.clone()),
+        expires_at,
     };
 
     store_acl_entry(&acl, &entry).await?;
@@ -162,8 +331,15 @@ pub async fn create_acl(
             .await?;
     }
 
-    info!(caller = %entry.created_by, did = %entry.did, role = %entry.role, "ACL entry created");
-    Ok((StatusCode::CREATED, Json(AclEntryResponse::from(entry))))
+    info!(
+        caller = %auth.0.did,
+        did = %entry.did,
+        role = %entry.role,
+        reason = req.reason.as_deref().unwrap_or(""),
+        created = status == StatusCode::CREATED,
+        "ACL entry granted",
+    );
+    Ok((status, Json(AclEntryResponse::from(entry))))
 }
 
 // ---------- GET /acl/{did} ----------
@@ -200,11 +376,28 @@ pub async fn get_acl(
 
 // ---------- PATCH /acl/{did} ----------
 
+/// Canonical `acl/change-role` request.
+///
+/// Role-only, and `fromRole` is a **compare-and-swap guard**, not
+/// decoration: the maintainer must confirm the subject's current role
+/// equals it and refuse otherwise. That closes the read-modify-write
+/// race the previous partial update had — two admins demoting the same
+/// subject concurrently could each read `admin` and write a different
+/// result, last-writer-wins, with no signal.
+///
+/// Label and scope edits are **not** here: they go to `acl/grant` with
+/// the subject's existing role, which is what canonical means by "the
+/// entry the maintainer should hold".
 #[derive(Debug, Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct UpdateAclRequest {
-    pub role: Option<VtcRole>,
-    pub label: Option<String>,
-    pub allowed_contexts: Option<Vec<String>>,
+    pub from_role: VtcRole,
+    pub to_role: VtcRole,
+    /// Operator rationale. Emitted on the service log line for this
+    /// change; the audit envelope's data types do not carry a free-text
+    /// reason today, so this is deliberately not described as audited.
+    #[serde(default)]
+    pub reason: Option<String>,
 }
 
 /// PATCH /acl/{did} — modify an ACL entry. Auth: Admin.
@@ -257,18 +450,19 @@ pub async fn update_acl(
     let prev_role = entry.role.clone();
     let prev_contexts = entry.allowed_contexts.clone();
 
-    if let Some(role) = req.role {
-        validate_vtc_role_assignment(&auth.0, &role)?;
-        entry.role = role;
+    // Compare-and-swap: the subject's current role MUST equal
+    // `fromRole`, else the caller is acting on a stale read.
+    if entry.role != req.from_role {
+        return Err(AppError::Conflict(format!(
+            "state mismatch: {did} currently holds role {}, not {}",
+            entry.role, req.from_role
+        )));
     }
-    if let Some(label) = req.label {
-        entry.label = Some(label);
-    }
-    if let Some(allowed_contexts) = req.allowed_contexts {
-        // Validate the new contexts before applying
-        validate_acl_modification(&auth.0, &allowed_contexts)?;
-        entry.allowed_contexts = allowed_contexts;
-    }
+
+    validate_vtc_role_assignment(&auth.0, &req.to_role)?;
+    entry.role = req.to_role.clone();
+    entry.updated_at = Some(now_epoch());
+    entry.updated_by = Some(auth.0.did.clone());
 
     store_acl_entry(&acl, &entry).await?;
 
@@ -303,13 +497,46 @@ pub async fn update_acl(
             .await?;
     }
 
-    info!(did = %did, "ACL entry updated");
+    info!(
+        did = %did,
+        from = %prev_role,
+        to = %entry.role,
+        reason = req.reason.as_deref().unwrap_or(""),
+        "ACL role changed",
+    );
     Ok(Json(AclEntryResponse::from(entry)))
 }
 
 // ---------- DELETE /acl/{did} ----------
 
-/// DELETE /acl/{did} — remove an ACL entry. Auth: Admin.
+/// Canonical `acl/revoke` parameters. `scopes` is a comma-separated
+/// list; when present the entry is scope-reduced rather than removed.
+#[derive(Debug, Deserialize, utoipa::ToSchema, utoipa::IntoParams)]
+#[serde(rename_all = "camelCase")]
+#[into_params(parameter_in = Query)]
+pub struct RevokeAclQuery {
+    pub scopes: Option<String>,
+    #[serde(default)]
+    pub reason: Option<String>,
+}
+
+impl RevokeAclQuery {
+    fn scopes_list(&self) -> Vec<String> {
+        self.scopes
+            .as_deref()
+            .map(|s| {
+                s.split(',')
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+                    .map(str::to_owned)
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+}
+
+/// DELETE /acl/{did} — revoke: remove the entry, or reduce its scopes
+/// when `scopes` is supplied. Auth: Admin.
 #[utoipa::path(
     delete, path = "/acl/{did}", tag = "acl",
     security(("bearer_jwt" = [])),
@@ -329,6 +556,7 @@ pub async fn delete_acl(
     auth: AdminAuth,
     State(state): State<AppState>,
     Path(did): Path<String>,
+    Query(query): Query<RevokeAclQuery>,
 ) -> Result<StatusCode, AppError> {
     // Prevent self-deletion
     if auth.0.did == did {
@@ -359,6 +587,63 @@ pub async fn delete_acl(
         ));
     }
 
+    // Canonical `acl/revoke` has two modes. With `scopes`, this is a
+    // *scope reduction*: the entry survives, minus those scopes. Only
+    // an omitted `scopes` removes the entry outright. Treating a scope
+    // reduction as a full removal would strip far more authority than
+    // the operator asked for, so the two paths are kept distinct.
+    let reduce = query.scopes_list();
+    if !reduce.is_empty() {
+        let mut entry = entry;
+        let before = entry.allowed_contexts.len();
+        entry.allowed_contexts.retain(|s| !reduce.contains(s));
+        if entry.allowed_contexts.len() == before {
+            return Err(AppError::NotFound(format!(
+                "none of the requested scopes are held by {did}"
+            )));
+        }
+        // Emptying an entry's scopes would silently promote it to
+        // community-wide authority (an empty scope set is how a
+        // super-admin is spelled), which is the opposite of revoking.
+        if entry.allowed_contexts.is_empty() {
+            return Err(AppError::Conflict(format!(
+                "revoking every scope of {did} would leave an unscoped \
+                 (community-wide) entry; omit `scopes` to remove it instead"
+            )));
+        }
+        entry.updated_at = Some(now_epoch());
+        entry.updated_by = Some(auth.0.did.clone());
+        store_acl_entry(&acl, &entry).await?;
+
+        // A shrunk scope set is a privilege reduction; the subject's
+        // live tokens still carry the old scopes.
+        let sessions = state.sessions_ks.clone();
+        let revoked = super::auth::revoke_sessions_for_did(&sessions, &did).await?;
+
+        if let Some(writer) = state.audit_writer.as_ref() {
+            writer
+                .write(
+                    &auth.0.did,
+                    Some(&did),
+                    AuditEvent::AclUpdated(AclChangeData {
+                        did: did.clone(),
+                        role: entry.role.to_string(),
+                        contexts: entry.allowed_contexts.clone(),
+                        expires_at: entry.expires_at.map(|e| e.to_string()),
+                    }),
+                )
+                .await?;
+        }
+
+        info!(
+            caller = %auth.0.did, did = %did, revoked,
+            remaining = entry.allowed_contexts.len(),
+            reason = query.reason.as_deref().unwrap_or(""),
+            "ACL scopes reduced",
+        );
+        return Ok(StatusCode::NO_CONTENT);
+    }
+
     delete_acl_entry(&acl, &did).await?;
 
     if let Some(writer) = state.audit_writer.as_ref() {
@@ -374,7 +659,12 @@ pub async fn delete_acl(
             .await?;
     }
 
-    info!(caller = %auth.0.did, did = %did, "ACL entry deleted");
+    info!(
+        caller = %auth.0.did,
+        did = %did,
+        reason = query.reason.as_deref().unwrap_or(""),
+        "ACL entry revoked",
+    );
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -476,6 +766,8 @@ mod tests {
             allowed_contexts: contexts.iter().map(|c| c.to_string()).collect(),
             created_at: 0,
             created_by: "did:key:zCreator".into(),
+            updated_at: None,
+            updated_by: None,
             expires_at: None,
         }
     }
@@ -570,35 +862,53 @@ mod tests {
     // ── CreateAclRequest ────────────────────────────────────────────
 
     #[test]
-    fn create_acl_request_parses_minimal_body() {
-        let body = json!({ "did": "did:key:zABC", "role": "admin" });
+    fn grant_request_parses_minimal_body() {
+        let body = json!({ "entry": { "subject": "did:key:zABC", "role": "admin" } });
         let req: CreateAclRequest = serde_json::from_value(body).expect("minimal body");
-        assert_eq!(req.did, "did:key:zABC");
-        assert_eq!(req.role, VtcRole::Admin);
-        assert_eq!(req.label, None);
-        assert!(req.allowed_contexts.is_empty(), "defaults to empty");
-        assert_eq!(req.expires_at, None);
+        assert_eq!(req.entry.subject, "did:key:zABC");
+        assert_eq!(req.entry.role, VtcRole::Admin);
+        assert_eq!(req.entry.label, None);
+        assert!(req.entry.scopes.is_empty(), "defaults to empty");
+        assert_eq!(req.entry.expires_at, None);
+        assert_eq!(req.reason, None);
     }
 
     #[test]
-    fn create_acl_request_parses_full_body() {
+    fn grant_request_parses_full_body() {
         let body = json!({
-            "did": "did:key:zABC",
-            "role": "moderator",
-            "label": "ops lead",
-            "allowed_contexts": ["ctx1", "ctx2"],
-            "expires_at": 1_800_000_000u64,
+            "entry": {
+                "subject": "did:key:zABC",
+                "role": "moderator",
+                "label": "ops lead",
+                "scopes": ["ctx1", "ctx2"],
+                "expiresAt": "2027-01-15T00:00:00Z",
+            },
+            "reason": "quarterly review",
         });
         let req: CreateAclRequest = serde_json::from_value(body).expect("full body");
-        assert_eq!(req.role, VtcRole::Moderator);
-        assert_eq!(req.label.as_deref(), Some("ops lead"));
-        assert_eq!(req.allowed_contexts, vec!["ctx1", "ctx2"]);
-        assert_eq!(req.expires_at, Some(1_800_000_000));
+        assert_eq!(req.entry.role, VtcRole::Moderator);
+        assert_eq!(req.entry.label.as_deref(), Some("ops lead"));
+        assert_eq!(req.entry.scopes, vec!["ctx1", "ctx2"]);
+        assert!(req.entry.expires_at.is_some());
+        assert_eq!(req.reason.as_deref(), Some("quarterly review"));
+    }
+
+    /// Server-owned provenance must not be settable by the caller, or a
+    /// grant could backdate who added an entry and when.
+    #[test]
+    fn grant_request_rejects_caller_supplied_provenance() {
+        for field in ["createdAt", "createdBy", "updatedAt", "updatedBy"] {
+            let body = json!({
+                "entry": { "subject": "did:key:zA", "role": "admin", field: "x" }
+            });
+            serde_json::from_value::<CreateAclRequest>(body)
+                .expect_err(&format!("{field} must not be accepted"));
+        }
     }
 
     #[test]
-    fn create_acl_request_rejects_unknown_role() {
-        let body = json!({ "did": "did:key:zA", "role": "godmode" });
+    fn grant_request_rejects_unknown_role() {
+        let body = json!({ "entry": { "subject": "did:key:zA", "role": "godmode" } });
         let err = serde_json::from_value::<CreateAclRequest>(body)
             .expect_err("unknown role must not parse");
         let msg = format!("{err}");
@@ -606,6 +916,20 @@ mod tests {
             msg.contains("godmode") || msg.contains("unknown"),
             "got {msg}"
         );
+    }
+
+    /// `fromRole` is the compare-and-swap guard; omitting it would turn
+    /// change-role back into a blind write.
+    #[test]
+    fn change_role_request_requires_both_roles() {
+        let ok: UpdateAclRequest =
+            serde_json::from_value(json!({ "fromRole": "member", "toRole": "moderator" }))
+                .expect("both roles");
+        assert_eq!(ok.from_role, VtcRole::Member);
+        assert_eq!(ok.to_role, VtcRole::Moderator);
+
+        serde_json::from_value::<UpdateAclRequest>(json!({ "toRole": "admin" }))
+            .expect_err("fromRole is mandatory");
     }
 
     #[test]
@@ -617,31 +941,34 @@ mod tests {
 
     // ── UpdateAclRequest ───────────────────────────────────────────
 
+    /// The pre-migration partial update (`role`/`label`/
+    /// `allowed_contexts`, all optional) is gone: label and scope edits
+    /// belong to `acl/grant`, and a role change now demands its CAS
+    /// guard. An old client body must fail loudly rather than be read
+    /// as some subset of the new one.
     #[test]
-    fn update_acl_request_all_fields_optional() {
-        let empty = json!({});
-        let req: UpdateAclRequest = serde_json::from_value(empty).expect("empty body parses");
-        assert!(req.role.is_none());
-        assert!(req.label.is_none());
-        assert!(req.allowed_contexts.is_none());
-    }
-
-    #[test]
-    fn update_acl_request_parses_role_only() {
-        let body = json!({ "role": "member" });
-        let req: UpdateAclRequest = serde_json::from_value(body).unwrap();
-        assert_eq!(req.role, Some(VtcRole::Member));
+    fn change_role_request_rejects_the_pre_migration_body() {
+        for body in [
+            json!({}),
+            json!({ "role": "member" }),
+            json!({ "label": "ops", "allowed_contexts": ["ctx-a"] }),
+        ] {
+            serde_json::from_value::<UpdateAclRequest>(body.clone())
+                .expect_err(&format!("legacy body must not parse: {body}"));
+        }
     }
 
     // ── ListAclQuery ───────────────────────────────────────────────
 
     #[test]
-    fn list_acl_query_context_is_optional() {
+    fn list_acl_query_filters_are_optional() {
         let q: ListAclQuery = serde_json::from_value(json!({})).unwrap();
-        assert!(q.context.is_none());
+        assert!(q.scope.is_none());
+        assert!(q.role.is_none());
+        assert!(q.subject_prefix.is_none());
 
-        let q: ListAclQuery = serde_json::from_value(json!({ "context": "app1" })).unwrap();
-        assert_eq!(q.context.as_deref(), Some("app1"));
+        let q: ListAclQuery = serde_json::from_value(json!({ "scope": "app1" })).unwrap();
+        assert_eq!(q.scope.as_deref(), Some("app1"));
     }
 
     // ── AclEntryResponse ───────────────────────────────────────────
@@ -655,17 +982,36 @@ mod tests {
             allowed_contexts: vec!["ctx1".into()],
             created_at: 1_700_000_000,
             created_by: "did:key:zSetup".into(),
+            updated_at: None,
+            updated_by: None,
             expires_at: Some(1_800_000_000),
         };
         let resp = AclEntryResponse::from(entry);
         let json = serde_json::to_value(&resp).unwrap();
-        assert_eq!(json["did"], "did:key:zABC");
+        // Canonical `acl/_shared` AclEntry names.
+        assert_eq!(json["subject"], "did:key:zABC");
         assert_eq!(json["role"], "admin");
         assert_eq!(json["label"], "test");
-        assert_eq!(json["allowed_contexts"], json!(["ctx1"]));
-        assert_eq!(json["created_at"], 1_700_000_000);
-        assert_eq!(json["created_by"], "did:key:zSetup");
-        assert_eq!(json["expires_at"], 1_800_000_000);
+        assert_eq!(json["scopes"], json!(["ctx1"]));
+        assert_eq!(json["createdBy"], "did:key:zSetup");
+        // Timestamps are RFC3339 strings — canonical types them
+        // `format: date-time`, so emitting the raw epoch would be a
+        // silent contract break rather than a cosmetic one.
+        assert_eq!(json["createdAt"], "2023-11-14T22:13:20+00:00");
+        assert_eq!(json["expiresAt"], "2027-01-15T08:00:00+00:00");
+        // The pre-migration names must be gone, not merely aliased.
+        for old in [
+            "did",
+            "allowed_contexts",
+            "created_at",
+            "created_by",
+            "expires_at",
+        ] {
+            assert!(
+                json.get(old).is_none(),
+                "{old} should not be emitted: {json}"
+            );
+        }
     }
 
     #[test]
@@ -677,13 +1023,22 @@ mod tests {
             allowed_contexts: vec![],
             created_at: 1_700_000_000,
             created_by: "did:key:zSetup".into(),
+            updated_at: None,
+            updated_by: None,
             expires_at: None,
         };
         let resp = AclEntryResponse::from(entry);
         let json = serde_json::to_value(&resp).unwrap();
         assert!(
-            json.get("expires_at").is_none(),
-            "permanent entries must omit expires_at — got {json}"
+            json.get("expiresAt").is_none() && json.get("expires_at").is_none(),
+            "permanent entries must omit expiresAt — got {json}"
+        );
+        // Canonical names and RFC3339 timestamps, not the storage shape.
+        assert_eq!(json["subject"], "did:key:zPerm");
+        assert!(json.get("did").is_none(), "did renamed to subject: {json}");
+        assert!(
+            json["createdAt"].as_str().unwrap().contains('T'),
+            "createdAt must be RFC3339, not an epoch int: {json}"
         );
     }
 
@@ -692,36 +1047,45 @@ mod tests {
     #[test]
     fn acl_list_response_round_trips() {
         let entries = vec![AclEntryResponse {
-            did: "did:key:zA".into(),
+            subject: "did:key:zA".into(),
             role: VtcRole::Member,
             label: None,
-            allowed_contexts: vec![],
-            created_at: 0,
+            scopes: vec![],
+            created_at: epoch_to_rfc3339(0),
             created_by: "did:key:zS".into(),
+            updated_at: None,
+            updated_by: None,
             expires_at: None,
         }];
-        let resp = AclListResponse { entries };
+        let resp = AclListResponse {
+            entries,
+            truncated: false,
+            cursor: None,
+        };
         let json = serde_json::to_string(&resp).unwrap();
         assert!(json.contains(r#""entries":"#), "got {json}");
         assert!(json.contains(r#""role":"member""#));
+        // `truncated` is canonical-required and must always serialize.
+        assert!(json.contains(r#""truncated":false"#), "got {json}");
     }
 
     #[test]
     fn custom_role_round_trip_through_request_body() {
         let body = json!({
-            "did": "did:key:zEditor",
-            "role": "custom:editor",
+            "entry": { "subject": "did:key:zEditor", "role": "custom:editor" },
         });
         let req: CreateAclRequest = serde_json::from_value(body).expect("custom role parses");
-        assert_eq!(req.role, VtcRole::Custom("editor".into()));
+        assert_eq!(req.entry.role, VtcRole::Custom("editor".into()));
         // Round-trip via the response shape.
         let entry = VtcAclEntry {
-            did: req.did,
-            role: req.role,
+            did: req.entry.subject,
+            role: req.entry.role,
             label: None,
             allowed_contexts: vec![],
             created_at: 0,
             created_by: "did:key:zS".into(),
+            updated_at: None,
+            updated_by: None,
             expires_at: None,
         };
         let resp = AclEntryResponse::from(entry);

--- a/vtc-service/src/routes/admin/bootstrap.rs
+++ b/vtc-service/src/routes/admin/bootstrap.rs
@@ -135,6 +135,8 @@ pub async fn bootstrap(
         allowed_contexts: vec![],
         created_at: now_unix(),
         created_by: "did:key:vtc-install".into(),
+        updated_at: None,
+        updated_by: None,
         expires_at: None,
     };
     store_acl_entry(&state.acl_ks, &acl_entry).await?;

--- a/vtc-service/src/routes/admin/invites.rs
+++ b/vtc-service/src/routes/admin/invites.rs
@@ -195,6 +195,8 @@ pub async fn create_invite(
                 allowed_contexts: vec![],
                 created_at: now_epoch(),
                 created_by: format!("admin-ui/{}", env!("CARGO_PKG_VERSION")),
+                updated_at: None,
+                updated_by: None,
                 expires_at: None,
             };
             store_acl_entry(&state.acl_ks, &entry).await?;

--- a/vtc-service/src/routes/mod.rs
+++ b/vtc-service/src/routes/mod.rs
@@ -390,13 +390,30 @@ fn build_api_chain(_routing: &RoutingConfig, trust_xff: bool) -> OpenApiRouter<A
             "https://trusttasks.org/openvtc/vtc/config/legacy/manage/1.0",
         ))
         // ACL
+        // Each verb carries its own canonical task — the two former
+        // combined mounts fan out to the five `acl/*` tasks. Safe
+        // because `task_routes` layers the *method* router and axum
+        // merges same-path routers per method (pinned by
+        // `vti_common::trust_task::openapi`).
         .routes(tt(
-            routes!(acl::list_acl, acl::create_acl),
-            "https://trusttasks.org/openvtc/vtc/acl/legacy/manage/1.0",
+            routes!(acl::list_acl),
+            "https://trusttasks.org/spec/acl/list/0.1",
         ))
         .routes(tt(
-            routes!(acl::get_acl, acl::update_acl, acl::delete_acl),
-            "https://trusttasks.org/openvtc/vtc/acl/legacy/entry/1.0",
+            routes!(acl::create_acl),
+            "https://trusttasks.org/spec/acl/grant/0.1",
+        ))
+        .routes(tt(
+            routes!(acl::get_acl),
+            "https://trusttasks.org/spec/acl/show/0.1",
+        ))
+        .routes(tt(
+            routes!(acl::update_acl),
+            "https://trusttasks.org/spec/acl/change-role/0.1",
+        ))
+        .routes(tt(
+            routes!(acl::delete_acl),
+            "https://trusttasks.org/spec/acl/revoke/0.1",
         ))
         // Community profile (GET + PUT share one Trust Task today;
         // a spec-aligned split into community/profile/show/1.0 +

--- a/vtc-service/tests/acl_canonical.rs
+++ b/vtc-service/tests/acl_canonical.rs
@@ -1,0 +1,372 @@
+//! Integration coverage for the canonical `acl/*` surface (phase 2d).
+//!
+//! The URI swap is the least interesting part. What needs pinning is
+//! the behaviour the canonical tasks promise and VTC did not previously
+//! implement: a compare-and-swap on role changes, scope *reduction*
+//! that isn't a full removal, and a grant that refuses to be used as a
+//! back door for role changes.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use serde_json::{Value, json};
+use tower::ServiceExt;
+
+use vtc_service::test_support::TestVtc;
+
+const LIST: &str = "https://trusttasks.org/spec/acl/list/0.1";
+const GRANT: &str = "https://trusttasks.org/spec/acl/grant/0.1";
+const SHOW: &str = "https://trusttasks.org/spec/acl/show/0.1";
+const CHANGE_ROLE: &str = "https://trusttasks.org/spec/acl/change-role/0.1";
+const REVOKE: &str = "https://trusttasks.org/spec/acl/revoke/0.1";
+
+struct Fixture {
+    router: axum::Router,
+    vtc: TestVtc,
+}
+
+async fn build() -> Fixture {
+    let vtc = TestVtc::builder().with_audit(true).build().await;
+    Fixture {
+        router: vtc.router.clone(),
+        vtc,
+    }
+}
+
+async fn admin_token(fix: &Fixture) -> String {
+    fix.vtc.token("did:key:z6MkAdmin", "admin", vec![]).await
+}
+
+async fn body_value(resp: axum::response::Response) -> (StatusCode, Value) {
+    let status = resp.status();
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let v: Value = serde_json::from_slice(&bytes)
+        .unwrap_or_else(|_| json!({ "raw": String::from_utf8_lossy(&bytes) }));
+    (status, v)
+}
+
+async fn call(
+    fix: &Fixture,
+    method: &str,
+    uri: &str,
+    task: &str,
+    token: &str,
+    body: Option<Value>,
+) -> (StatusCode, Value) {
+    let mut b = Request::builder()
+        .method(method)
+        .uri(uri)
+        .header("Trust-Task", task)
+        .header("Authorization", format!("Bearer {token}"));
+    if body.is_some() {
+        b = b.header("Content-Type", "application/json");
+    }
+    let req = b
+        .body(body.map_or(Body::empty(), |v| Body::from(v.to_string())))
+        .unwrap();
+    body_value(fix.router.clone().oneshot(req).await.unwrap()).await
+}
+
+async fn grant(fix: &Fixture, token: &str, subject: &str, role: &str, scopes: Value) -> StatusCode {
+    call(
+        fix,
+        "POST",
+        "/v1/acl",
+        GRANT,
+        token,
+        Some(json!({ "entry": { "subject": subject, "role": role, "scopes": scopes } })),
+    )
+    .await
+    .0
+}
+
+#[tokio::test]
+async fn entries_use_canonical_names_and_rfc3339_timestamps() {
+    let fix = build().await;
+    let token = admin_token(&fix).await;
+    assert_eq!(
+        grant(
+            &fix,
+            &token,
+            "did:key:z6MkAlice",
+            "member",
+            json!(["ctx-a"])
+        )
+        .await,
+        StatusCode::CREATED
+    );
+
+    let (status, body) = call(&fix, "GET", "/v1/acl", LIST, &token, None).await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(
+        body.get("truncated").is_some(),
+        "truncated required: {body}"
+    );
+
+    let entry = body["entries"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|e| e["subject"] == "did:key:z6MkAlice")
+        .expect("granted entry present");
+    assert_eq!(entry["scopes"], json!(["ctx-a"]));
+    assert!(
+        entry["createdAt"].as_str().unwrap().contains('T'),
+        "createdAt must be RFC3339: {entry}"
+    );
+    for old in ["did", "allowed_contexts", "created_at"] {
+        assert!(entry.get(old).is_none(), "{old} must be gone: {entry}");
+    }
+}
+
+/// Canonical: a grant against an existing subject with a *different*
+/// role must be refused and point at change-role. Otherwise grant is a
+/// silent bypass of the compare-and-swap guard.
+#[tokio::test]
+async fn grant_refuses_to_change_an_existing_role() {
+    let fix = build().await;
+    let token = admin_token(&fix).await;
+    assert_eq!(
+        grant(&fix, &token, "did:key:z6MkBob", "member", json!(["ctx-a"])).await,
+        StatusCode::CREATED
+    );
+
+    let (status, body) = call(
+        &fix,
+        "POST",
+        "/v1/acl",
+        GRANT,
+        &token,
+        Some(json!({ "entry": { "subject": "did:key:z6MkBob", "role": "moderator", "scopes": ["ctx-a"] } })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CONFLICT, "{body}");
+    let msg = body["error"].as_str().unwrap_or_default();
+    assert!(
+        msg.contains("change-role"),
+        "the refusal should name the right task: {body}"
+    );
+}
+
+/// Re-granting the *same* role is how canonical expresses "the entry
+/// the maintainer should hold" — it rewrites scopes/label.
+#[tokio::test]
+async fn grant_with_the_same_role_rewrites_the_entry() {
+    let fix = build().await;
+    let token = admin_token(&fix).await;
+    grant(
+        &fix,
+        &token,
+        "did:key:z6MkCarol",
+        "member",
+        json!(["ctx-a"]),
+    )
+    .await;
+
+    let (status, body) = call(
+        &fix,
+        "POST",
+        "/v1/acl",
+        GRANT,
+        &token,
+        Some(json!({ "entry": { "subject": "did:key:z6MkCarol", "role": "member", "scopes": ["ctx-a", "ctx-b"] } })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "rewrite, not create: {body}");
+    assert_eq!(body["scopes"], json!(["ctx-a", "ctx-b"]));
+    assert!(
+        body["updatedAt"].as_str().is_some(),
+        "a rewrite must stamp updatedAt: {body}"
+    );
+    assert_eq!(body["updatedBy"], "did:key:z6MkAdmin");
+}
+
+#[tokio::test]
+async fn change_role_enforces_the_from_role_guard() {
+    let fix = build().await;
+    let token = admin_token(&fix).await;
+    grant(&fix, &token, "did:key:z6MkDan", "member", json!(["ctx-a"])).await;
+
+    // Stale read: caller believes Dan is a moderator.
+    let (status, body) = call(
+        &fix,
+        "PATCH",
+        "/v1/acl/did:key:z6MkDan",
+        CHANGE_ROLE,
+        &token,
+        Some(json!({ "fromRole": "moderator", "toRole": "admin" })),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::CONFLICT,
+        "a mismatched fromRole must not apply: {body}"
+    );
+
+    // Correct fromRole applies.
+    let (status, body) = call(
+        &fix,
+        "PATCH",
+        "/v1/acl/did:key:z6MkDan",
+        CHANGE_ROLE,
+        &token,
+        Some(json!({ "fromRole": "member", "toRole": "moderator" })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert_eq!(body["role"], "moderator");
+    assert!(body["updatedAt"].as_str().is_some(), "{body}");
+}
+
+/// Canonical revoke has two modes. `scopes` reduces; omitting it
+/// removes. Conflating them would strip more authority than asked.
+#[tokio::test]
+async fn revoke_with_scopes_reduces_rather_than_removes() {
+    let fix = build().await;
+    let token = admin_token(&fix).await;
+    grant(
+        &fix,
+        &token,
+        "did:key:z6MkErin",
+        "member",
+        json!(["ctx-a", "ctx-b"]),
+    )
+    .await;
+
+    let (status, _) = call(
+        &fix,
+        "DELETE",
+        "/v1/acl/did:key:z6MkErin?scopes=ctx-a",
+        REVOKE,
+        &token,
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::NO_CONTENT);
+
+    // The entry must survive, minus that one scope.
+    let (status, body) = call(&fix, "GET", "/v1/acl/did:key:z6MkErin", SHOW, &token, None).await;
+    assert_eq!(status, StatusCode::OK, "entry must survive: {body}");
+    assert_eq!(body["scopes"], json!(["ctx-b"]));
+}
+
+#[tokio::test]
+async fn revoke_without_scopes_removes_the_entry() {
+    let fix = build().await;
+    let token = admin_token(&fix).await;
+    grant(&fix, &token, "did:key:z6MkFred", "member", json!(["ctx-a"])).await;
+
+    let (status, _) = call(
+        &fix,
+        "DELETE",
+        "/v1/acl/did:key:z6MkFred",
+        REVOKE,
+        &token,
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::NO_CONTENT);
+
+    let (status, _) = call(&fix, "GET", "/v1/acl/did:key:z6MkFred", SHOW, &token, None).await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+}
+
+/// Emptying an entry's scope set would leave an *unscoped* entry —
+/// which is how a community-wide (super) grant is spelled. Revoking
+/// must never widen authority.
+#[tokio::test]
+async fn revoking_every_scope_is_refused_rather_than_unscoping() {
+    let fix = build().await;
+    let token = admin_token(&fix).await;
+    grant(&fix, &token, "did:key:z6MkGina", "member", json!(["ctx-a"])).await;
+
+    let (status, body) = call(
+        &fix,
+        "DELETE",
+        "/v1/acl/did:key:z6MkGina?scopes=ctx-a",
+        REVOKE,
+        &token,
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::CONFLICT, "{body}");
+
+    let (status, body) = call(&fix, "GET", "/v1/acl/did:key:z6MkGina", SHOW, &token, None).await;
+    assert_eq!(status, StatusCode::OK, "entry must be untouched: {body}");
+    assert_eq!(body["scopes"], json!(["ctx-a"]));
+}
+
+#[tokio::test]
+async fn each_verb_rejects_a_siblings_task() {
+    let fix = build().await;
+    let token = admin_token(&fix).await;
+    // GET /v1/acl bound to acl/list must not accept acl/grant.
+    let (status, _) = call(&fix, "GET", "/v1/acl", GRANT, &token, None).await;
+    assert_eq!(status, StatusCode::UNSUPPORTED_MEDIA_TYPE);
+}
+
+#[tokio::test]
+async fn list_filters_and_paginates() {
+    let fix = build().await;
+    let token = admin_token(&fix).await;
+    for who in ["did:key:z6MkP1", "did:key:z6MkP2", "did:key:z6MkP3"] {
+        grant(&fix, &token, who, "member", json!(["ctx-a"])).await;
+    }
+    grant(
+        &fix,
+        &token,
+        "did:key:z6MkQ1",
+        "moderator",
+        json!(["ctx-b"]),
+    )
+    .await;
+
+    // Role filter actually filters.
+    let (_, body) = call(&fix, "GET", "/v1/acl?role=moderator", LIST, &token, None).await;
+    let subjects: Vec<&str> = body["entries"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|e| e["subject"].as_str().unwrap())
+        .collect();
+    assert_eq!(subjects, vec!["did:key:z6MkQ1"], "{body}");
+
+    // Paging, and the cursor must not survive a filter change.
+    let (_, page1) = call(
+        &fix,
+        "GET",
+        "/v1/acl?scope=ctx-a&pageSize=1",
+        LIST,
+        &token,
+        None,
+    )
+    .await;
+    assert_eq!(page1["truncated"], true, "{page1}");
+    let cursor = page1["cursor"].as_str().expect("cursor").to_string();
+
+    let (status, _) = call(
+        &fix,
+        "GET",
+        &format!("/v1/acl?scope=ctx-a&pageSize=1&cursor={cursor}"),
+        LIST,
+        &token,
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "same filters resume");
+
+    let (status, body) = call(
+        &fix,
+        "GET",
+        &format!("/v1/acl?scope=ctx-b&pageSize=1&cursor={cursor}"),
+        LIST,
+        &token,
+        None,
+    )
+    .await;
+    assert_ne!(
+        status,
+        StatusCode::OK,
+        "a cursor must not carry across a filter change: {body}"
+    );
+}

--- a/vtc-service/tests/auth_acl_roles.rs
+++ b/vtc-service/tests/auth_acl_roles.rs
@@ -23,6 +23,8 @@ fn entry(did: &str, role: VtcRole) -> VtcAclEntry {
         allowed_contexts: vec![],
         created_at: 1,
         created_by: "did:key:vtc-install".into(),
+        updated_at: None,
+        updated_by: None,
         expires_at: None,
     }
 }

--- a/vtc-service/tests/auth_audience.rs
+++ b/vtc-service/tests/auth_audience.rs
@@ -54,10 +54,7 @@ async fn vta_audience_token_rejected_by_vtc_route() {
     let req = Request::builder()
         .method("GET")
         .uri("/v1/acl")
-        .header(
-            "Trust-Task",
-            "https://trusttasks.org/openvtc/vtc/acl/legacy/manage/1.0",
-        )
+        .header("Trust-Task", "https://trusttasks.org/spec/acl/list/0.1")
         .header("Authorization", format!("Bearer {foreign_token}"))
         .body(Body::empty())
         .unwrap();
@@ -91,10 +88,7 @@ async fn unknown_audience_token_rejected_by_vtc_route() {
     let req = Request::builder()
         .method("GET")
         .uri("/v1/acl")
-        .header(
-            "Trust-Task",
-            "https://trusttasks.org/openvtc/vtc/acl/legacy/manage/1.0",
-        )
+        .header("Trust-Task", "https://trusttasks.org/spec/acl/list/0.1")
         .header("Authorization", format!("Bearer {foreign_token}"))
         .body(Body::empty())
         .unwrap();
@@ -109,10 +103,7 @@ async fn no_token_rejected_by_vtc_route() {
     let req = Request::builder()
         .method("GET")
         .uri("/v1/acl")
-        .header(
-            "Trust-Task",
-            "https://trusttasks.org/openvtc/vtc/acl/legacy/manage/1.0",
-        )
+        .header("Trust-Task", "https://trusttasks.org/spec/acl/list/0.1")
         .body(Body::empty())
         .unwrap();
     let (status, _body) = request(&router, req).await;

--- a/vtc-service/tests/ceremony_execute.rs
+++ b/vtc-service/tests/ceremony_execute.rs
@@ -103,6 +103,8 @@ async fn admit_duplicate_acl_is_conflict() {
             allowed_contexts: vec![],
             created_at: vtc_service::auth::session::now_epoch(),
             created_by: "did:key:vtc-install".into(),
+            updated_at: None,
+            updated_by: None,
             expires_at: None,
         },
     )
@@ -271,6 +273,8 @@ async fn depart_refuses_the_last_admin() {
             allowed_contexts: vec![],
             created_at: vtc_service::auth::session::now_epoch(),
             created_by: "did:key:vtc-install".into(),
+            updated_at: None,
+            updated_by: None,
             expires_at: None,
         },
     )
@@ -362,6 +366,8 @@ async fn remint_refuses_demoting_the_last_admin() {
             allowed_contexts: vec![],
             created_at: vtc_service::auth::session::now_epoch(),
             created_by: "did:key:vtc-install".into(),
+            updated_at: None,
+            updated_by: None,
             expires_at: None,
         },
     )

--- a/vtc-service/tests/community_profile.rs
+++ b/vtc-service/tests/community_profile.rs
@@ -393,10 +393,7 @@ async fn get_with_wrong_trust_task_returns_415() {
     let req = Request::builder()
         .method("GET")
         .uri("/v1/community/profile")
-        .header(
-            "Trust-Task",
-            "https://trusttasks.org/openvtc/vtc/acl/legacy/manage/1.0",
-        )
+        .header("Trust-Task", "https://trusttasks.org/spec/acl/list/0.1")
         .header("Authorization", format!("Bearer {token}"))
         .body(Body::empty())
         .unwrap();

--- a/vtc-service/tests/cookie_session.rs
+++ b/vtc-service/tests/cookie_session.rs
@@ -31,7 +31,7 @@ use vtc_service::server::AppState;
 use vtc_service::test_support::TestVtc;
 
 const ADMIN_DID: &str = "did:key:z6MkAdminCookie";
-const ACL_TRUST_TASK: &str = "https://trusttasks.org/openvtc/vtc/acl/legacy/manage/1.0";
+const ACL_TRUST_TASK: &str = "https://trusttasks.org/spec/acl/list/0.1";
 
 struct Fixture {
     router: axum::Router,
@@ -59,6 +59,8 @@ async fn build_fixture() -> Fixture {
             allowed_contexts: vec![],
             created_at: now_epoch(),
             created_by: "test".into(),
+            updated_at: None,
+            updated_by: None,
             expires_at: None,
         },
     )

--- a/vtc-service/tests/directory.rs
+++ b/vtc-service/tests/directory.rs
@@ -67,6 +67,8 @@ async fn build_fixture() -> Fixture {
             allowed_contexts: vec![],
             created_at: vtc_service::auth::session::now_epoch(),
             created_by: "did:key:vtc-install".into(),
+            updated_at: None,
+            updated_by: None,
             expires_at: None,
         },
     )
@@ -130,6 +132,8 @@ async fn seed_member(fix: &Fixture, did: &str, role: VtcRole) {
             allowed_contexts: vec![],
             created_at: vtc_service::auth::session::now_epoch(),
             created_by: "did:key:vtc-install".into(),
+            updated_at: None,
+            updated_by: None,
             expires_at: None,
         },
     )

--- a/vtc-service/tests/endorsements.rs
+++ b/vtc-service/tests/endorsements.rs
@@ -85,6 +85,8 @@ async fn build() -> Fixture {
                 allowed_contexts: vec![],
                 created_at: now,
                 created_by: "did:key:vtc-install".into(),
+                updated_at: None,
+                updated_by: None,
                 expires_at: None,
             },
         )

--- a/vtc-service/tests/invitations.rs
+++ b/vtc-service/tests/invitations.rs
@@ -68,6 +68,8 @@ async fn build() -> Fixture {
                 allowed_contexts: vec![],
                 created_at: now,
                 created_by: "did:key:vtc-install".into(),
+                updated_at: None,
+                updated_by: None,
                 expires_at: None,
             },
         )

--- a/vtc-service/tests/join_didcomm.rs
+++ b/vtc-service/tests/join_didcomm.rs
@@ -83,6 +83,8 @@ async fn seed_join_ceremony(mock: &MockVtcDidcomm) -> String {
             allowed_contexts: vec![],
             created_at: now_epoch(),
             created_by: "did:key:vtc-install".into(),
+            updated_at: None,
+            updated_by: None,
             expires_at: None,
         },
     )

--- a/vtc-service/tests/join_requests.rs
+++ b/vtc-service/tests/join_requests.rs
@@ -115,6 +115,8 @@ async fn build_fixture() -> Fixture {
             allowed_contexts: vec![],
             created_at: now,
             created_by: "did:key:vtc-install".into(),
+            updated_at: None,
+            updated_by: None,
             expires_at: None,
         },
     )
@@ -565,6 +567,8 @@ async fn approve_409_when_duplicate_acl_exists() {
             allowed_contexts: vec![],
             created_at: now,
             created_by: "did:key:vtc-install".into(),
+            updated_at: None,
+            updated_by: None,
             expires_at: None,
         },
     )

--- a/vtc-service/tests/members_crud.rs
+++ b/vtc-service/tests/members_crud.rs
@@ -68,6 +68,8 @@ async fn build_fixture() -> Fixture {
             allowed_contexts: vec![],
             created_at: now,
             created_by: "did:key:vtc-install".into(),
+            updated_at: None,
+            updated_by: None,
             expires_at: None,
         },
     )
@@ -135,6 +137,8 @@ async fn seed_member(fix: &Fixture, did: &str, role: VtcRole) {
             allowed_contexts: vec![],
             created_at: now,
             created_by: "did:key:vtc-install".into(),
+            updated_at: None,
+            updated_by: None,
             expires_at: None,
         },
     )

--- a/vtc-service/tests/personhood.rs
+++ b/vtc-service/tests/personhood.rs
@@ -89,6 +89,8 @@ async fn build_fixture() -> Fixture {
                 allowed_contexts: vec![],
                 created_at: now,
                 created_by: "did:key:vtc-install".into(),
+                updated_at: None,
+                updated_by: None,
                 expires_at: None,
             },
         )

--- a/vtc-service/tests/policies.rs
+++ b/vtc-service/tests/policies.rs
@@ -89,6 +89,8 @@ async fn build_fixture() -> Fixture {
             allowed_contexts: vec![],
             created_at: now,
             created_by: "did:key:vtc-install".into(),
+            updated_at: None,
+            updated_by: None,
             expires_at: None,
         },
     )

--- a/vtc-service/tests/relationships.rs
+++ b/vtc-service/tests/relationships.rs
@@ -93,6 +93,8 @@ async fn build_fixture() -> Fixture {
                 allowed_contexts: vec![],
                 created_at: now,
                 created_by: "did:key:vtc-install".into(),
+                updated_at: None,
+                updated_by: None,
                 expires_at: None,
             },
         )
@@ -391,6 +393,8 @@ async fn list_returns_issued_and_received_edges() {
             allowed_contexts: vec![],
             created_at: now_epoch(),
             created_by: "did:key:vtc-install".into(),
+            updated_at: None,
+            updated_by: None,
             expires_at: None,
         },
     )

--- a/vtc-service/tests/removal.rs
+++ b/vtc-service/tests/removal.rs
@@ -81,6 +81,8 @@ async fn build_fixture() -> Fixture {
             allowed_contexts: vec![],
             created_at: now,
             created_by: "did:key:vtc-install".into(),
+            updated_at: None,
+            updated_by: None,
             expires_at: None,
         },
     )
@@ -161,6 +163,8 @@ async fn seed_member_with_session(fix: &Fixture, did: &str, role: VtcRole) -> St
             allowed_contexts: vec![],
             created_at: now,
             created_by: "did:key:vtc-install".into(),
+            updated_at: None,
+            updated_by: None,
             expires_at: None,
         },
     )

--- a/vtc-service/tests/renewal.rs
+++ b/vtc-service/tests/renewal.rs
@@ -81,6 +81,8 @@ async fn build_fixture() -> Fixture {
             allowed_contexts: vec![],
             created_at: now,
             created_by: "did:key:vtc-install".into(),
+            updated_at: None,
+            updated_by: None,
             expires_at: None,
         },
     )

--- a/vtc-service/tests/rotation.rs
+++ b/vtc-service/tests/rotation.rs
@@ -94,6 +94,8 @@ async fn build_fixture() -> Fixture {
             allowed_contexts: vec![],
             created_at: now,
             created_by: "did:key:vtc-install".into(),
+            updated_at: None,
+            updated_by: None,
             expires_at: None,
         },
     )

--- a/vtc-service/tests/wallet_login_siop.rs
+++ b/vtc-service/tests/wallet_login_siop.rs
@@ -59,6 +59,8 @@ async fn build_fixture(holder_did: &str) -> Fixture {
             allowed_contexts: vec![],
             created_at: now_epoch(),
             created_by: "test".into(),
+            updated_at: None,
+            updated_by: None,
             expires_at: None,
         },
     )


### PR DESCRIPTION
Phase 2d of the vtc-service Trust Task migration (#710), completing the `acl/*` family. The two combined mounts fan out to five canonical tasks, one per verb.

| route | was | now |
|---|---|---|
| `GET /v1/acl` | `acl/legacy/manage/1.0` | `spec/acl/list/0.1` |
| `POST /v1/acl` | *(same task)* | `spec/acl/grant/0.1` |
| `GET /v1/acl/{did}` | `acl/legacy/entry/1.0` | `spec/acl/show/0.1` |
| `PATCH /v1/acl/{did}` | *(same task)* | `spec/acl/change-role/0.1` |
| `DELETE /v1/acl/{did}` | *(same task)* | `spec/acl/revoke/0.1` |

Both legacy tasks are **retired** with `supersededBy`. The fan-out is possible because of #724's finding that `task_routes` already enforces per-method tasks on a shared path.

### This is not a rename pass

The canonical tasks promise semantics VTC did not implement. Binding the URIs without them would advertise guarantees that don't hold:

**`change-role` is role-only, with a compare-and-swap.** It takes `{fromRole, toRole}` and returns 409 when the subject's current role differs. That closes a genuine read-modify-write race the old partial update had: two admins demoting the same subject could each read `admin`, write different results, and last-writer-wins with no signal. The pre-migration body (`role`/`label`/`allowed_contexts`, all optional) is rejected outright rather than silently read as a subset of the new one.

**Label and scope edits move to `grant`** — canonical's "the entry the maintainer should hold". Re-granting the *same* role rewrites the entry; a *different* role on an existing subject is refused with a pointer to `change-role`, so grant can't be used as a back door around the CAS guard. Server-owned provenance (`createdAt`/`createdBy`/`updatedAt`/`updatedBy`) is not accepted from callers.

**`revoke` implements both canonical modes.** With `?scopes=`, the entry is *scope-reduced* and survives; only an omitted `scopes` removes it. Conflating those would strip far more authority than asked.

> The sharp edge worth reviewing: revoking a subject's **last** scope is **refused**, not executed. An empty scope set is how a community-wide (super) grant is spelled in this codebase, so a naive "remove these scopes" would have silently **promoted** the subject while the operator believed they were revoking. Revocation must never widen authority. Pinned by `revoking_every_scope_is_refused_rather_than_unscoping`.

A scope reduction also revokes the subject's live sessions, since their tokens still carry the old scopes.

**`list`** gains the canonical `role` / `scope` / `subjectPrefix` filters and `pageSize`/`cursor` paging, with filters bound into the cursor HMAC so a page can't be resumed under a different filter set. The `scope` filter keeps the hierarchy-aware matching the old `context` filter had — an ancestor scope genuinely does carry a descendant, so narrowing it to exact match would have quietly changed results.

### Breaking (admin API)

Entries are the canonical `AclEntry`: `did` → `subject`, `allowed_contexts` → `scopes`, timestamps RFC3339 rather than unix epochs (canonical types them `format: date-time`; an integer there is a silent contract break, not a cosmetic one). List responses gain the required `truncated` and optional `cursor`. `vtc-service/admin-ui/src/plugins/acl.tsx` reads every one of those fields and is rewritten in the same commit.

### A regression I introduced and caught

Paginating meant signing cursors with the audit key — but the audit writer is **optional**, so this initially made ACL listing fail outright on audit-less deployments (caught by three `cookie_session` tests). The fix is not to enable audit in the fixtures: without a key the endpoint serves the full visible set as one page — exactly its pre-migration behaviour — and rejects a supplied cursor rather than trusting it unverified. Listing the ACL must not depend on audit being configured.

Separately, clippy caught `reason` being unread while its doc comment claimed "Recorded on the audit event". The audit data types carry no free-text reason field, so that claim was false; it is now emitted on the service log line and documented as exactly that.

### Testing

New `vtc-service/tests/acl_canonical.rs` (9 tests): canonical names + RFC3339 (asserting the old names are *gone*, not aliased), grant refusing a role change and naming `change-role`, same-role grant rewriting and stamping `updatedAt`, the `fromRole` CAS in both directions, scope reduction leaving the entry alive, full removal, the last-scope refusal, sibling-task rejection, and filter + paging with cursor-replay rejection. Existing unit tests that pinned the old wire shape were rewritten to pin the new one.

`cargo test --workspace` (CI-equivalent): **3625 passed, 0 failed**. `cargo clippy -p vti-common -p vtc-service --all-targets -D warnings` clean. `cargo fmt --all --check` clean. `tsc --noEmit` on the admin UI clean. Self-pin guard green.

Version bumped: `vtc-service` 0.11.16.

### Phase 2 status

- **2a `policy/*`** — the only one left, and **not a repoint**. Canonical binds `(contextId, purpose) → policy` relationally over *mutable* modules with `expectedVersion` optimistic concurrency; VTC has `purpose` as an intrinsic column over *append-only* revisions, with the Rego package name validated against it. Incompatible lifecycle models — this needs a design decision before code moves.
- **2b/2c/2d** — done (#726, #727, #724, this PR).
- **2e `auth/*`** — was already done; the residual `openvtc` auth URIs have no canonical target.
