### PR TITLE
feat(vtc): phase 2a — repoint policy/*, bridging the purpose model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,51 @@
 
 ## Unreleased
 
+### vtc-service — Phase 2a: `policy/*` repointed to the canonical registry
+
+Completes the vtc-service Trust Task migration's Phase 2. The policy
+family was the hardest of the five because canonical and VTC disagree on
+what a policy *is*, not just on field names.
+
+* `GET /v1/policies` → `spec/policy/list/0.2`, `POST /v1/policies` →
+  `spec/policy/upsert/0.2`, `GET /v1/policies/{id}` →
+  `spec/policy/get/0.1`, `POST /v1/policies/{id}/activate` →
+  `spec/policy/activate/0.1`, plus a new `GET /v1/policies/active` →
+  `spec/policy/active/0.1`. The four superseded `openvtc` tasks are
+  **retired** with `supersededBy`.
+* **`policies/test` deliberately stays on its `openvtc` URI.** Canonical
+  `policy/evaluate` runs the *matching policy set* through the standard
+  `decision` rule; `test` evaluates an operator-chosen Rego query against
+  one stored module. Different verb, not a rename.
+* **Purpose travels in `ext` (`org.openvtc.purpose`), and is required.**
+  Canonical models purpose as a property of the *activation binding* — a
+  module is purpose-agnostic and reusable. VTC cannot follow that: the
+  purpose is baked into the module's own Rego package and validated at
+  upload, because a module in the wrong package compiles cleanly and then
+  silently denies every request for that ceremony. Inference is not an
+  escape either — only 4 of the 10 purposes have an expected package, so
+  6 could never be derived from source. `ext` is exactly what the
+  framework reserves for ecosystem members, so the divergence is
+  documented rather than hidden, and an upsert without it is refused
+  rather than guessed at.
+* **The package↔purpose guard is preserved** on both upsert and activate.
+* **`expectedVersion` is honoured as a real compare-and-swap**: VTC's
+  monotone per-purpose revision counter is the concurrency token, so two
+  operators racing on the same purpose can no longer each append a
+  revision over the other's read.
+* **Breaking (admin API).** Entries are the canonical `PolicyModule`:
+  `regoSource` → `module`, responses wrap in `{policy}` / `{policies,
+  truncated, cursor}` / `{bindings}`, and `limit` → `pageSize`. `sha256`,
+  `authorDid` and `purpose` move under `ext` (the canonical type is
+  `additionalProperties: false`). `isActive` is **gone** — activeness is
+  a binding, read from `policy/active`. The bundled admin UI is updated
+  in step.
+* Canonical members this maintainer cannot honour — `appliesTo`,
+  `priority`, `enabled` on upsert; `contextId`, `enabledOnly` on list;
+  `contextId` on active — are **refused with an error naming them**
+  rather than accepted and ignored. A caller setting `enabled: false`
+  must never have it silently dropped.
+
 ### vtc-service — Phase 2d: `acl/*` repointed, with the canonical semantics implemented
 
 * The two combined mounts (`acl/legacy/{manage,entry}/1.0`) fan out to the five

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10341,7 +10341,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-service"
-version = "0.11.16"
+version = "0.11.17"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/trust-tasks/index.json
+++ b/trust-tasks/index.json
@@ -260,15 +260,17 @@
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/policies/upload/1.0",
-      "status": "draft",
+      "status": "retired",
       "path": "policies/upload/1.0",
-      "rest": "POST /v1/policies"
+      "rest": "POST /v1/policies",
+      "supersededBy": "https://trusttasks.org/spec/policy/upsert/0.2"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/policies/activate/1.0",
-      "status": "draft",
+      "status": "retired",
       "path": "policies/activate/1.0",
-      "rest": "POST /v1/policies/{id}/activate"
+      "rest": "POST /v1/policies/{id}/activate",
+      "supersededBy": "https://trusttasks.org/spec/policy/activate/0.1"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/policies/test/1.0",
@@ -278,15 +280,17 @@
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/policies/list/1.0",
-      "status": "draft",
+      "status": "retired",
       "path": "policies/list/1.0",
-      "rest": "GET /v1/policies"
+      "rest": "GET /v1/policies",
+      "supersededBy": "https://trusttasks.org/spec/policy/list/0.2"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/policies/show/1.0",
-      "status": "draft",
+      "status": "retired",
       "path": "policies/show/1.0",
-      "rest": "GET /v1/policies/{id}"
+      "rest": "GET /v1/policies/{id}",
+      "supersededBy": "https://trusttasks.org/spec/policy/get/0.1"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/members/renew/1.0",

--- a/trust-tasks/policies/activate/1.0/spec.md
+++ b/trust-tasks/policies/activate/1.0/spec.md
@@ -1,7 +1,8 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/policies/activate/1.0
 title: VTC Policies — Activate
-status: draft
+status: retired
+supersededBy: https://trusttasks.org/spec/policy/activate/0.1
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/policies/list/1.0/spec.md
+++ b/trust-tasks/policies/list/1.0/spec.md
@@ -1,7 +1,8 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/policies/list/1.0
 title: VTC Policies — List
-status: draft
+status: retired
+supersededBy: https://trusttasks.org/spec/policy/list/0.2
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/policies/show/1.0/spec.md
+++ b/trust-tasks/policies/show/1.0/spec.md
@@ -1,7 +1,8 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/policies/show/1.0
 title: VTC Policies — Show
-status: draft
+status: retired
+supersededBy: https://trusttasks.org/spec/policy/get/0.1
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/policies/upload/1.0/spec.md
+++ b/trust-tasks/policies/upload/1.0/spec.md
@@ -1,7 +1,8 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/policies/upload/1.0
 title: VTC Policies — Upload
-status: draft
+status: retired
+supersededBy: https://trusttasks.org/spec/policy/upsert/0.2
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.11.16"
+version = "0.11.17"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vtc-service/admin-ui/src/lib/policies-api.ts
+++ b/vtc-service/admin-ui/src/lib/policies-api.ts
@@ -7,10 +7,17 @@
 
 import { getJson, postJson } from "@/lib/api";
 
-const TRUST_TASK_POLICIES =
-  "https://trusttasks.org/openvtc/vtc/policies/upload/1.0";
-const TRUST_TASK_ACTIVATE =
-  "https://trusttasks.org/openvtc/vtc/policies/activate/1.0";
+// One canonical task per verb (the shared upload/1.0 mount was retired
+// in phase 2a).
+const TRUST_TASK_LIST = "https://trusttasks.org/spec/policy/list/0.2";
+const TRUST_TASK_UPSERT = "https://trusttasks.org/spec/policy/upsert/0.2";
+const TRUST_TASK_ACTIVE = "https://trusttasks.org/spec/policy/active/0.1";
+const TRUST_TASK_ACTIVATE = "https://trusttasks.org/spec/policy/activate/0.1";
+
+/// Ecosystem `ext` member carrying the intrinsic purpose. Canonical
+/// treats a module as purpose-agnostic; this maintainer does not (the
+/// purpose is fixed by the module's Rego package), so it travels here.
+const PURPOSE_EXT = "org.openvtc.purpose";
 
 export const ALL_PURPOSES = [
   "join",
@@ -40,48 +47,76 @@ export const OTHER_PURPOSES: Purpose[] = ALL_PURPOSES.filter(
   (p) => !CEREMONY_PURPOSES.includes(p),
 );
 
+// Canonical PolicyModule. Maintainer-specific fields (purpose, source
+// hash, author) ride in `ext` because the canonical type is
+// `additionalProperties: false`.
 export interface PolicyRow {
   id: string;
-  purpose: Purpose;
-  regoSource: string;
-  sha256: string;
-  activatedAt: string | null;
-  authorDid: string;
-  createdAt: string;
+  name: string;
+  module: string;
   version: number;
-  isActive: boolean;
+  createdAt: string;
+  updatedAt: string;
+  ext?: {
+    "org.openvtc.purpose"?: Purpose;
+    "org.openvtc.sha256"?: string;
+    "org.openvtc.authorDid"?: string;
+  };
 }
 
 export interface PoliciesPage {
-  items: PolicyRow[];
-  next_cursor: string | null;
+  policies: PolicyRow[];
+  truncated: boolean;
+  cursor?: string | null;
+}
+
+/// The purpose a module serves, read from its `ext`.
+export function policyPurpose(p: PolicyRow): Purpose | undefined {
+  return p.ext?.[PURPOSE_EXT];
 }
 
 export async function fetchPolicies(purpose: Purpose): Promise<PoliciesPage> {
-  return getJson<PoliciesPage>(`/v1/policies?purpose=${purpose}&limit=100`, {
-    trustTask: TRUST_TASK_POLICIES,
-  });
+  return getJson<PoliciesPage>(
+    `/v1/policies?purpose=${purpose}&pageSize=100`,
+    { trustTask: TRUST_TASK_LIST },
+  );
+}
+
+interface ActiveBindingsResponse {
+  bindings: { purpose: Purpose; policy: PolicyRow }[];
 }
 
 export async function fetchActivePolicy(
   purpose: Purpose,
 ): Promise<PolicyRow | null> {
-  const page = await getJson<PoliciesPage>(
-    `/v1/policies?purpose=${purpose}&status=active&limit=1`,
-    { trustTask: TRUST_TASK_POLICIES },
+  // Activeness is now its own canonical task rather than a flag on the
+  // module — a module carries no isActive field.
+  const res = await getJson<ActiveBindingsResponse>(
+    `/v1/policies/active?purpose=${purpose}`,
+    { trustTask: TRUST_TASK_ACTIVE },
   );
-  return page.items.find((p) => p.isActive) ?? page.items[0] ?? null;
+  return res.bindings.find((b) => b.purpose === purpose)?.policy ?? null;
+}
+
+interface UpsertResponse {
+  policy: PolicyRow;
+  created: boolean;
 }
 
 export async function uploadPolicy(args: {
   purpose: Purpose;
   regoSource: string;
 }): Promise<PolicyRow> {
-  return postJson<PolicyRow>(
+  const res = await postJson<UpsertResponse>(
     "/v1/policies",
-    { purpose: args.purpose, regoSource: args.regoSource },
-    { trustTask: TRUST_TASK_POLICIES },
+    {
+      name: args.purpose,
+      module: args.regoSource,
+      ext: { [PURPOSE_EXT]: args.purpose },
+    },
+    { trustTask: TRUST_TASK_UPSERT },
   );
+  return res.policy;
 }
 
 export async function activatePolicy(id: string): Promise<unknown> {

--- a/vtc-service/admin-ui/src/plugins/ceremonies.tsx
+++ b/vtc-service/admin-ui/src/plugins/ceremonies.tsx
@@ -292,7 +292,7 @@ function CeremonyPanel({ ceremony }: { ceremony: CeremonyManifest }) {
   // The active policy's IR, when it was authored visually — enables the
   // local decision trace.
   const activeIR = policyQuery.data
-    ? parseRego(policyQuery.data.regoSource)
+    ? parseRego(policyQuery.data.module)
     : null;
 
   // Editing the base evidence invalidates any satisfied needs.
@@ -608,6 +608,13 @@ function PolicyManager({
     queryFn: () => fetchPolicies(purpose),
   });
 
+  // Which revision is live is now a separate canonical task
+  // (policy/active) rather than an isActive flag on each module.
+  const activeQuery = useQuery({
+    queryKey: ["active-policy", purpose],
+    queryFn: () => fetchActivePolicy(purpose),
+  });
+
   const activate = useMutation({
     mutationFn: activatePolicy,
     onSuccess: () => {
@@ -631,7 +638,7 @@ function PolicyManager({
     mutationFn: async (row: PolicyRow) => {
       const created = await uploadPolicy({
         purpose,
-        regoSource: row.regoSource,
+        regoSource: row.module,
       });
       await activatePolicy(created.id);
     },
@@ -641,8 +648,10 @@ function PolicyManager({
     },
   });
 
-  const items = query.data?.items ?? [];
-  const active = items.find((p) => p.isActive) ?? null;
+  const items: PolicyRow[] = query.data?.policies ?? [];
+  // Activeness is no longer a flag on the module: the active binding
+  // comes from its own query (policy/active).
+  const active = activeQuery.data ?? null;
   const canAuthor = CEREMONY_PURPOSES.includes(purpose);
 
   if (editing) {
@@ -651,7 +660,7 @@ function PolicyManager({
         purpose={purpose}
         pkg={pkgFor(purpose)}
         initial={
-          (active && parseRego(active.regoSource)) || blankIR(purpose)
+          (active && parseRego(active.module)) || blankIR(purpose)
         }
         saving={saveVisual.isPending}
         onSave={(rego) => saveVisual.mutate(rego)}
@@ -678,11 +687,13 @@ function PolicyManager({
             <span className="cer-chip">
               active <b>v{active.version}</b>
             </span>
-            <span className="cer-chip">
-              sha <b>{active.sha256.slice(0, 12)}…</b>
-            </span>
+            {active.ext?.["org.openvtc.sha256"] && (
+              <span className="cer-chip">
+                sha <b>{active.ext["org.openvtc.sha256"].slice(0, 12)}…</b>
+              </span>
+            )}
           </div>
-          <ActivePolicyView source={active.regoSource} />
+          <ActivePolicyView source={active.module} />
         </>
       )}
       {!query.isLoading && !active && (
@@ -738,7 +749,7 @@ function PolicyManager({
           >
             Author visually ▸
           </button>
-          {active && !parseRego(active.regoSource) && (
+          {active && !parseRego(active.module) && (
             <p className="cer-sub" style={{ fontSize: "var(--text-xs)" }}>
               The active policy was hand-written — opening the editor starts
               from a blank route set.
@@ -788,19 +799,20 @@ function VersionRow({
 }) {
   const [comparing, setComparing] = useState(false);
   const isOlder = active ? row.version < active.version : false;
+  const isActive = active?.id === row.id;
 
   return (
-    <div className={`cer-ver${row.isActive ? " active" : ""}`}>
+    <div className={`cer-ver${isActive ? " active" : ""}`}>
       <div className="cer-ver-head">
         <span className="cer-ver-v">v{row.version}</span>
         <span className="cer-ver-meta">{formatIso(row.createdAt)}</span>
-        {row.isActive ? (
+        {isActive ? (
           <span className="cer-chip" style={{ color: "var(--vd-allow)" }}>
             active
           </span>
         ) : (
           <>
-            {active && !row.isActive && (
+            {active && !isActive && (
               <button
                 type="button"
                 className="cer-ver-compare"
@@ -840,8 +852,8 @@ function VersionDiff({
   from: PolicyRow;
   to: PolicyRow;
 }) {
-  const fromIr = parseRego(from.regoSource);
-  const toIr = parseRego(to.regoSource);
+  const fromIr = parseRego(from.module);
+  const toIr = parseRego(to.module);
   if (!fromIr || !toIr) {
     return (
       <p className="cer-sub" style={{ fontSize: "var(--text-xs)" }}>

--- a/vtc-service/src/ceremony/orchestrate.rs
+++ b/vtc-service/src/ceremony/orchestrate.rs
@@ -565,6 +565,8 @@ mod p0_14_role_change_policy_tests {
                 author_did: "did:key:test".into(),
                 created_at: Utc::now(),
                 version: 1,
+                name: None,
+                description: None,
             },
         )
         .await

--- a/vtc-service/src/policy/model.rs
+++ b/vtc-service/src/policy/model.rs
@@ -78,6 +78,16 @@ pub struct Policy {
     /// purpose is `1`. Audit + the operator UX use this to label
     /// historical revisions ("removal.rego v3 archived").
     pub version: u32,
+    /// Operator-supplied module name and description (canonical
+    /// `PolicyModule.name` / `.description`; `name` is required there).
+    ///
+    /// `#[serde(default)]` keeps rows written before these fields
+    /// deserializable; they fall back to the purpose for `name`, which
+    /// is the only stable human-meaningful identifier such a row has.
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub description: Option<String>,
 }
 
 /// Hard cap on the bytes-on-disk size of [`Policy::rego_source`].
@@ -258,6 +268,8 @@ mod tests {
             author_did: "did:key:zAdmin".into(),
             created_at: Utc::now(),
             version: 7,
+            name: None,
+            description: None,
         };
         let json = serde_json::to_value(&policy).unwrap();
         assert!(json["regoSource"].is_string());

--- a/vtc-service/src/policy/storage.rs
+++ b/vtc-service/src/policy/storage.rs
@@ -206,6 +206,8 @@ pub fn new_policy(
         author_did,
         created_at: Utc::now(),
         version,
+        name: None,
+        description: None,
     }
 }
 

--- a/vtc-service/src/registry/policy.rs
+++ b/vtc-service/src/registry/policy.rs
@@ -231,6 +231,8 @@ mod tests {
             author_did: "did:key:test".into(),
             created_at: chrono::Utc::now(),
             version: 1,
+            name: None,
+            description: None,
         };
         store_policy(policies, &policy).await.unwrap();
         set_active_policy_id(active, PolicyPurpose::Registry, id)

--- a/vtc-service/src/registry/syncer.rs
+++ b/vtc-service/src/registry/syncer.rs
@@ -632,6 +632,8 @@ default publish_on_join := false
             author_did: "did:key:test".into(),
             created_at: chrono::Utc::now(),
             version: 1,
+            name: None,
+            description: None,
         };
         store_policy(&syncer.policies_ks, &policy).await.unwrap();
         set_active_policy_id(&syncer.active_policies_ks, PolicyPurpose::Registry, id)
@@ -693,6 +695,8 @@ default publish_on_join := false
                 author_did: "did:key:test".into(),
                 created_at: chrono::Utc::now(),
                 version: 1,
+                name: None,
+                description: None,
             },
         )
         .await

--- a/vtc-service/src/registry/tail.rs
+++ b/vtc-service/src/registry/tail.rs
@@ -349,6 +349,8 @@ mod tests {
             author_did: "did:key:test".into(),
             created_at: chrono::Utc::now(),
             version: 1,
+            name: None,
+            description: None,
         };
         store_policy(policies, &policy).await.unwrap();
         set_active_policy_id(active, PolicyPurpose::Registry, id)

--- a/vtc-service/src/routes/mod.rs
+++ b/vtc-service/src/routes/mod.rs
@@ -726,19 +726,30 @@ fn build_api_chain(_routing: &RoutingConfig, trust_xff: bool) -> OpenApiRouter<A
         // Trust Tasks. `upload` mints + persists; `activate` flips
         // the per-purpose active pointer; `test` evaluates a stored
         // policy without mutating state.
+        // Each verb now carries its own canonical task. `test` stays
+        // on its openvtc URI: canonical `policy/evaluate` runs the
+        // matching policy set through the standard `decision` rule,
+        // while `test` evaluates an operator-chosen Rego query against
+        // one stored module — a different verb, not a rename.
         .routes(tt(
-            routes!(policies::read::list_policies, policies::admin::upload),
-            "https://trusttasks.org/openvtc/vtc/policies/upload/1.0",
+            routes!(policies::read::list_policies),
+            "https://trusttasks.org/spec/policy/list/0.2",
         ))
         .routes(tt(
-            routes!(policies::read::show_policy), // Reuses the upload task on the shared mount; the
-            // `policies/show/1.0` Trust Task lives in index.json
-            // + on disk for the soft-gate surface (see above).
-            "https://trusttasks.org/openvtc/vtc/policies/upload/1.0",
+            routes!(policies::admin::upload),
+            "https://trusttasks.org/spec/policy/upsert/0.2",
+        ))
+        .routes(tt(
+            routes!(policies::read::active_policies),
+            "https://trusttasks.org/spec/policy/active/0.1",
+        ))
+        .routes(tt(
+            routes!(policies::read::show_policy),
+            "https://trusttasks.org/spec/policy/get/0.1",
         ))
         .routes(tt(
             routes!(policies::admin::activate),
-            "https://trusttasks.org/openvtc/vtc/policies/activate/1.0",
+            "https://trusttasks.org/spec/policy/activate/0.1",
         ))
         .routes(tt(
             routes!(policies::admin::test),

--- a/vtc-service/src/routes/policies/admin.rs
+++ b/vtc-service/src/routes/policies/admin.rs
@@ -60,35 +60,110 @@ static ACTIVATE_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[derive(utoipa::ToSchema)]
+#[serde(deny_unknown_fields)]
 pub struct UploadBody {
-    /// Wire-form camelCase purpose (`"join"`, `"removal"`,
-    /// `"crossCommunityRoles"`, …). Validated by serde against
-    /// [`PolicyPurpose`].
-    pub purpose: PolicyPurpose,
-    /// Full Rego source. Bounded by [`POLICY_SOURCE_MAX_BYTES`];
-    /// uploads above the cap are rejected with 413.
-    pub rego_source: String,
+    /// Human-readable module name (canonical-required).
+    pub name: String,
+    /// Full Rego source — canonical `module`. Bounded by
+    /// [`POLICY_SOURCE_MAX_BYTES`]; uploads above the cap are
+    /// rejected with 413.
+    pub module: String,
+    /// Optimistic-concurrency token. When present it MUST equal the
+    /// current highest revision for this purpose, else the caller is
+    /// writing over a revision it never saw.
+    #[serde(default)]
+    pub expected_version: Option<u32>,
+    #[serde(default)]
+    pub description: Option<String>,
+    /// Canonical members this maintainer does not implement. Present
+    /// so they are *refused* rather than silently dropped — a caller
+    /// that sets `enabled: false` must not have it ignored.
+    #[serde(default)]
+    pub id: Option<Uuid>,
+    #[serde(default)]
+    pub applies_to: Option<Vec<String>>,
+    #[serde(default)]
+    pub priority: Option<i64>,
+    #[serde(default)]
+    pub enabled: Option<bool>,
+    /// Ecosystem extension members. MUST carry
+    /// `org.openvtc.purpose` — see [`crate::routes::policies::read::PURPOSE_EXT_KEY`]
+    /// for why purpose is intrinsic here.
+    #[serde(default)]
+    pub ext: Option<serde_json::Value>,
+}
+
+impl UploadBody {
+    /// The decision slot this module serves.
+    ///
+    /// Canonical `policy/upsert` has no `purpose` — a module there is
+    /// purpose-agnostic and gains meaning only when activated. VTC
+    /// cannot work that way (the purpose is baked into the Rego package
+    /// and guarded), and it cannot be inferred either: only 4 of the 10
+    /// purposes have an expected package. So it is required in `ext`,
+    /// and its absence is an error rather than a guess.
+    fn purpose(&self) -> Result<PolicyPurpose, AppError> {
+        let raw = self
+            .ext
+            .as_ref()
+            .and_then(|e| e.get(crate::routes::policies::read::PURPOSE_EXT_KEY))
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| {
+                AppError::Validation(format!(
+                    "ext.{} is required: this maintainer binds a policy's purpose \
+                     intrinsically (it is fixed by the module's Rego package), so it \
+                     cannot be deferred to activation as canonical policy/upsert assumes",
+                    crate::routes::policies::read::PURPOSE_EXT_KEY,
+                ))
+            })?;
+        serde_json::from_value(serde_json::Value::String(raw.to_owned())).map_err(|e| {
+            AppError::Validation(format!("ext purpose {raw:?} is not a known purpose: {e}"))
+        })
+    }
+
+    fn unsupported(&self) -> Vec<&'static str> {
+        let mut out = Vec::new();
+        if self.applies_to.is_some() {
+            out.push("appliesTo");
+        }
+        if self.priority.is_some() {
+            out.push("priority");
+        }
+        if self.enabled.is_some() {
+            out.push("enabled");
+        }
+        if self.id.is_some() {
+            // Canonical lets a caller target an existing module id.
+            // Here the lineage is the purpose (one active module per
+            // purpose, monotone revisions), and revision ids are
+            // server-allocated — honouring a caller-supplied id would
+            // mean pretending to update a row we actually append past.
+            out.push("id");
+        }
+        out
+    }
 }
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[derive(utoipa::ToSchema)]
 pub struct UploadResponse {
-    pub id: Uuid,
-    /// SHA-256 of the source bytes, lowercase hex. Matches what
-    /// `sha256sum policy.rego` prints — operators can verify the
-    /// upload made it across the wire intact.
-    pub sha256: String,
-    pub purpose: PolicyPurpose,
-    pub version: u32,
+    pub policy: crate::routes::policies::read::PolicyModuleResponse,
+    /// Canonical-required: true when this call created a new module
+    /// lineage rather than revising an existing one. VTC's first
+    /// revision for a purpose is a creation.
+    pub created: bool,
 }
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[derive(utoipa::ToSchema)]
 pub struct ActivateResponse {
-    pub id: Uuid,
+    /// Canonical name for the id of the policy now in force.
+    pub activated: Uuid,
     pub purpose: PolicyPurpose,
+    /// VTC extension: the activated module's source hash, so an
+    /// operator can confirm what went live without a second fetch.
     pub sha256: String,
     /// Predecessor active policy id for this purpose. `null` for
     /// the first activation under a given purpose.
@@ -143,10 +218,22 @@ pub async fn upload(
     State(state): State<AppState>,
     Json(body): Json<UploadBody>,
 ) -> Result<(StatusCode, Json<UploadResponse>), AppError> {
-    if body.rego_source.len() > POLICY_SOURCE_MAX_BYTES {
+    let unsupported = body.unsupported();
+    if !unsupported.is_empty() {
         return Err(AppError::Validation(format!(
-            "rego_source exceeds {POLICY_SOURCE_MAX_BYTES} bytes (got {})",
-            body.rego_source.len(),
+            "this maintainer does not implement {}: it selects a policy by its \
+             activated (purpose) binding, not by appliesTo/priority matching, and \
+             modules carry no enabled flag. Refusing rather than accepting a \
+             selection hint that would never be honoured.",
+            unsupported.join(", "),
+        )));
+    }
+    let purpose = body.purpose()?;
+
+    if body.module.len() > POLICY_SOURCE_MAX_BYTES {
+        return Err(AppError::Validation(format!(
+            "module exceeds {POLICY_SOURCE_MAX_BYTES} bytes (got {})",
+            body.module.len(),
         )));
     }
 
@@ -159,22 +246,33 @@ pub async fn upload(
     // `new_policy` helper also allocates one — we override via
     // `Policy { id, .. }` after compile rather than mint twice.
     let id = Uuid::new_v4();
-    let compiled = compile(&body.rego_source, id)?;
+    let compiled = compile(&body.module, id)?;
     // Reject a module compiled into the wrong package for its declared
     // purpose — it would compile + activate cleanly, then evaluate to
     // `undefined` (silent host default-deny) for that whole ceremony.
-    validate_purpose_package(&compiled, body.purpose)?;
+    validate_purpose_package(&compiled, purpose)?;
     let sha256 = *compiled.source_sha256();
-    let version = max_version_for(&state.policies_ks, body.purpose).await? + 1;
+    let current_version = max_version_for(&state.policies_ks, purpose).await?;
+    // Optimistic concurrency: canonical `expectedVersion` must match the
+    // revision the caller believes is current, else two operators racing
+    // on the same purpose would each append a revision over the other's
+    // read with no signal.
+    if let Some(expected) = body.expected_version
+        && expected != current_version
+    {
+        return Err(AppError::Conflict(format!(
+            "expectedVersion {expected} does not match the current revision \
+             {current_version} for purpose {}",
+            purpose.as_str(),
+        )));
+    }
+    let version = current_version + 1;
+    let created = current_version == 0;
 
-    let mut policy = new_policy(
-        body.purpose,
-        body.rego_source,
-        sha256,
-        admin.0.did.clone(),
-        version,
-    );
+    let mut policy = new_policy(purpose, body.module, sha256, admin.0.did.clone(), version);
     policy.id = id;
+    policy.name = Some(body.name.clone());
+    policy.description = body.description.clone();
     store_policy(&state.policies_ks, &policy).await?;
 
     let sha256_hex = hex::encode(sha256);
@@ -184,7 +282,7 @@ pub async fn upload(
             None,
             AuditEvent::PolicyUploaded(PolicyUploadedData {
                 policy_id: id.to_string(),
-                purpose: body.purpose.as_str().to_string(),
+                purpose: purpose.as_str().to_string(),
                 sha256: sha256_hex.clone(),
                 version,
             }),
@@ -194,19 +292,21 @@ pub async fn upload(
     info!(
         actor = admin.0.did.as_str(),
         policy_id = %id,
-        purpose = body.purpose.as_str(),
+        purpose = purpose.as_str(),
         version,
         sha256 = sha256_hex.as_str(),
         "policy uploaded"
     );
 
     Ok((
-        StatusCode::CREATED,
+        if created {
+            StatusCode::CREATED
+        } else {
+            StatusCode::OK
+        },
         Json(UploadResponse {
-            id,
-            sha256: sha256_hex,
-            purpose: body.purpose,
-            version,
+            policy: (&policy).into(),
+            created,
         }),
     ))
 }
@@ -285,7 +385,7 @@ pub async fn activate(
     );
 
     Ok(Json(ActivateResponse {
-        id,
+        activated: id,
         purpose: policy.purpose,
         sha256: sha256_hex,
         previous_policy_id: previous,

--- a/vtc-service/src/routes/policies/read.rs
+++ b/vtc-service/src/routes/policies/read.rs
@@ -28,7 +28,7 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use vti_common::error::AppError;
-use vti_common::pagination::{Cursor, MAX_LIMIT, Paginated};
+use vti_common::pagination::{Cursor, MAX_LIMIT};
 
 use crate::auth::AdminAuth;
 use crate::policy::{
@@ -57,6 +57,94 @@ pub struct PolicyResponse {
     pub is_active: bool,
 }
 
+/// Canonical `policy/list` response.
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct PolicyListResponse {
+    pub policies: Vec<PolicyModuleResponse>,
+    /// Canonical-required: more matching modules exist beyond this page.
+    pub truncated: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cursor: Option<String>,
+}
+
+/// Canonical `policy/get` response.
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct PolicyGetResponse {
+    pub policy: PolicyModuleResponse,
+}
+
+/// Reverse-DNS-namespaced `ext` member carrying this maintainer's
+/// **intrinsic** policy purpose (SPEC.md §4.5.1).
+///
+/// Canonical models purpose as a property of the *activation binding*,
+/// not of the module — a module is purpose-agnostic and reusable. VTC
+/// cannot follow that: a purpose is baked into the module's own Rego
+/// package name and validated at upload, because a module in the wrong
+/// package compiles cleanly and then silently denies every request for
+/// that ceremony. Inference is not a way out either — only 4 of the 10
+/// purposes have an expected package, so 6 could never be derived from
+/// the source.
+///
+/// So the purpose travels in `ext`, which is exactly what the framework
+/// reserves for ecosystem-defined members. It is a documented
+/// divergence rather than a hidden one: a consumer reading the module
+/// can see that this maintainer binds purpose intrinsically.
+pub const PURPOSE_EXT_KEY: &str = "org.openvtc.purpose";
+
+/// Canonical `policy/_shared` **PolicyModule**.
+///
+/// Field mapping from VTC's storage row:
+/// - `rego_source` → `module`
+/// - `version` (monotone per-purpose revision counter) → `version`,
+///   which canonical also uses as the optimistic-concurrency token.
+/// - `updatedAt` is the activation time when the row has been
+///   activated, else its creation time. A VTC revision is immutable, so
+///   activation is the only thing that can change it after write.
+/// - `sha256` / `authorDid` / the intrinsic `purpose` have no canonical
+///   home and ride in `ext` (the canonical type is
+///   `additionalProperties: false`).
+///
+/// `appliesTo` / `priority` / `enabled` are deliberately **not**
+/// emitted: VTC does no `appliesTo`/`priority` selection, and emitting
+/// empty values would imply a selection model that isn't there.
+#[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct PolicyModuleResponse {
+    pub id: Uuid,
+    pub name: String,
+    pub module: String,
+    pub version: u32,
+    pub created_at: String,
+    pub updated_at: String,
+    pub ext: serde_json::Value,
+}
+
+impl From<&Policy> for PolicyModuleResponse {
+    fn from(p: &Policy) -> Self {
+        Self {
+            id: p.id,
+            // Rows written before `name` existed fall back to the
+            // purpose — the only stable human-meaningful identifier
+            // such a row has, and canonical requires `name`.
+            name: p
+                .name
+                .clone()
+                .unwrap_or_else(|| p.purpose.as_str().to_owned()),
+            module: p.rego_source.clone(),
+            version: p.version,
+            created_at: p.created_at.to_rfc3339(),
+            updated_at: p.activated_at.unwrap_or(p.created_at).to_rfc3339(),
+            ext: serde_json::json!({
+                PURPOSE_EXT_KEY: p.purpose.as_str(),
+                "org.openvtc.sha256": hex::encode(p.sha256),
+                "org.openvtc.authorDid": p.author_did,
+            }),
+        }
+    }
+}
+
 impl PolicyResponse {
     fn from_policy(policy: Policy, is_active: bool) -> Self {
         Self { policy, is_active }
@@ -71,8 +159,17 @@ impl PolicyResponse {
 #[serde(rename_all = "camelCase")]
 #[derive(utoipa::ToSchema, utoipa::IntoParams)]
 pub struct ListPoliciesQuery {
-    /// Filter by purpose (wire-form camelCase).
+    /// Filter by purpose (wire-form camelCase). A VTC extension —
+    /// canonical has no purpose filter because purpose is not a
+    /// property of a module there.
     pub purpose: Option<PolicyPurpose>,
+    /// Canonical `policy/list` parameters this maintainer does not
+    /// implement. Accepting them silently would tell a caller their
+    /// query was narrowed when it was not, so they are refused.
+    pub context_id: Option<String>,
+    pub enabled_only: Option<bool>,
+    /// Canonical page-size name.
+    pub page_size: Option<usize>,
     /// `"active"` — only the row pointed at by each
     /// `active_policies:<purpose>`. `"archived"` — every row that
     /// is *not* the current active pointer. Omitted → all rows.
@@ -96,7 +193,7 @@ pub enum PolicyStatusFilter {
     security(("bearer_jwt" = [])),
     params(ListPoliciesQuery),
     responses(
-        (status = 200, description = "Paginated list of policies", body = Paginated<PolicyResponse>),
+        (status = 200, description = "Paginated list of policies", body = PolicyListResponse),
         (status = 401, description = "Missing or invalid bearer token"),
         (status = 403, description = "Caller is not an admin"),
     ),
@@ -105,7 +202,23 @@ pub async fn list_policies(
     _auth: AdminAuth,
     State(state): State<AppState>,
     Query(query): Query<ListPoliciesQuery>,
-) -> Result<Json<Paginated<PolicyResponse>>, AppError> {
+) -> Result<Json<PolicyListResponse>, AppError> {
+    let mut unsupported = Vec::new();
+    if query.context_id.is_some() {
+        unsupported.push("contextId");
+    }
+    if query.enabled_only.is_some() {
+        unsupported.push("enabledOnly");
+    }
+    if !unsupported.is_empty() {
+        return Err(AppError::Validation(format!(
+            "this maintainer does not implement the {} filter(s): its policy log \
+             is not context-partitioned and modules carry no enabled flag. \
+             Refusing rather than returning an unfiltered list.",
+            unsupported.join(", "),
+        )));
+    }
+
     // `status=active` is resolved directly from the per-purpose active
     // pointers, not the paginated keyspace scan. The purpose/status
     // filters below run *after* pagination, so a small `limit` (the
@@ -126,15 +239,18 @@ pub async fn list_policies(
                 items.push(PolicyResponse::from_policy(p, true));
             }
         }
-        let total = items.len() as u64;
-        return Ok(Json(Paginated {
-            items,
-            next_cursor: None,
-            total_estimate: Some(total),
+        return Ok(Json(PolicyListResponse {
+            policies: items.iter().map(|r| (&r.policy).into()).collect(),
+            truncated: false,
+            cursor: None,
         }));
     }
 
-    let limit = query.limit.unwrap_or(50).clamp(1, MAX_LIMIT);
+    let limit = query
+        .page_size
+        .or(query.limit)
+        .unwrap_or(50)
+        .clamp(1, MAX_LIMIT);
 
     let audit_writer = state
         .audit_writer
@@ -182,10 +298,10 @@ pub async fn list_policies(
         })
         .collect();
 
-    Ok(Json(Paginated {
-        items,
-        next_cursor: page.next_cursor,
-        total_estimate: page.total_estimate,
+    Ok(Json(PolicyListResponse {
+        policies: items.iter().map(|r| (&r.policy).into()).collect(),
+        truncated: page.next_cursor.is_some(),
+        cursor: page.next_cursor,
     }))
 }
 
@@ -198,7 +314,7 @@ pub async fn list_policies(
     security(("bearer_jwt" = [])),
     params(("id" = String, Path, description = "Policy id")),
     responses(
-        (status = 200, description = "Policy", body = PolicyResponse),
+        (status = 200, description = "Policy", body = PolicyGetResponse),
         (status = 401, description = "Missing or invalid bearer token"),
         (status = 403, description = "Caller is not an admin"),
         (status = 404, description = "Policy not found"),
@@ -208,11 +324,85 @@ pub async fn show_policy(
     _auth: AdminAuth,
     State(state): State<AppState>,
     Path(id): Path<Uuid>,
-) -> Result<Json<PolicyResponse>, AppError> {
+) -> Result<Json<PolicyGetResponse>, AppError> {
     let policy = get_policy(&state.policies_ks, id)
         .await?
         .ok_or_else(|| AppError::NotFound(format!("policy not found: {id}")))?;
-    let active_id = get_active_policy_id(&state.active_policies_ks, policy.purpose).await?;
-    let is_active = active_id == Some(id);
-    Ok(Json(PolicyResponse::from_policy(policy, is_active)))
+    Ok(Json(PolicyGetResponse {
+        policy: (&policy).into(),
+    }))
+}
+
+// ---------------------------------------------------------------------------
+// GET /v1/policies/active — canonical `policy/active`
+// ---------------------------------------------------------------------------
+
+/// Canonical `policy/active` response: the `(contextId, purpose) →
+/// module` bindings currently in force.
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ActiveBindingsResponse {
+    pub bindings: Vec<ActiveBinding>,
+}
+
+/// One activation binding. `contextId` is omitted throughout: a VTC is
+/// a single community and does not partition its policy set per trust
+/// context, so every binding is community-wide.
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ActiveBinding {
+    pub purpose: String,
+    pub policy: PolicyModuleResponse,
+}
+
+#[derive(Debug, Deserialize, utoipa::ToSchema, utoipa::IntoParams)]
+#[serde(rename_all = "camelCase")]
+#[into_params(parameter_in = Query)]
+pub struct ActiveQuery {
+    /// Narrow to a single decision slot.
+    pub purpose: Option<PolicyPurpose>,
+    /// Not implemented — a VTC is not context-partitioned. Refused
+    /// rather than ignored, so a caller never reads a community-wide
+    /// binding as one scoped to their context.
+    pub context_id: Option<String>,
+}
+
+#[utoipa::path(
+    get, path = "/policies/active", tag = "policies",
+    security(("bearer_jwt" = [])),
+    params(ActiveQuery),
+    responses(
+        (status = 200, description = "Active policy bindings", body = ActiveBindingsResponse),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller is not an admin"),
+    ),
+)]
+pub async fn active_policies(
+    _auth: AdminAuth,
+    State(state): State<AppState>,
+    Query(query): Query<ActiveQuery>,
+) -> Result<Json<ActiveBindingsResponse>, AppError> {
+    if query.context_id.is_some() {
+        return Err(AppError::Validation(
+            "this maintainer does not implement the contextId filter: a VTC is a \
+             single community and its policy bindings are community-wide."
+                .into(),
+        ));
+    }
+
+    let mut bindings = Vec::new();
+    for purpose in PolicyPurpose::ALL {
+        if query.purpose.is_some_and(|f| f != purpose) {
+            continue;
+        }
+        if let Some(id) = get_active_policy_id(&state.active_policies_ks, purpose).await?
+            && let Some(p) = get_policy(&state.policies_ks, id).await?
+        {
+            bindings.push(ActiveBinding {
+                purpose: purpose.as_str().to_owned(),
+                policy: (&p).into(),
+            });
+        }
+    }
+    Ok(Json(ActiveBindingsResponse { bindings }))
 }

--- a/vtc-service/tests/join_requests.rs
+++ b/vtc-service/tests/join_requests.rs
@@ -51,8 +51,8 @@ const VTC_DID: &str = "did:webvh:vtc.example.com:abc";
 /// Member seed shared by `applicant_pair` (so a `LocalSigner` over the
 /// same seed signs reciprocal VCs that verify against the member did:key).
 const MEMBER_SEED: [u8; 32] = [0xCD; 32];
-const POLICY_UPLOAD_TASK: &str = "https://trusttasks.org/openvtc/vtc/policies/upload/1.0";
-const POLICY_ACTIVATE_TASK: &str = "https://trusttasks.org/openvtc/vtc/policies/activate/1.0";
+const POLICY_UPLOAD_TASK: &str = "https://trusttasks.org/spec/policy/upsert/0.2";
+const POLICY_ACTIVATE_TASK: &str = "https://trusttasks.org/spec/policy/activate/0.1";
 
 const ADMIN_DID: &str = "did:key:zAdmin1";
 
@@ -702,11 +702,17 @@ async fn activate_join_policy(fix: &Fixture, source: &str) {
         "/v1/policies",
         POLICY_UPLOAD_TASK,
         Some(&fix.admin_token),
-        Some(json!({ "purpose": "join", "regoSource": source })),
+        Some(json!({ "name": "join", "module": source, "ext": { "org.openvtc.purpose": "join" } })),
     )
     .await;
-    assert_eq!(status, StatusCode::CREATED, "upload failed: {body}");
-    let id = body["id"].as_str().unwrap();
+    // Canonical upsert: 201 when this is the first revision for the
+    // purpose, 200 when it revises an existing one. Fixtures may have
+    // seeded a policy already, so both are success here.
+    assert!(
+        status == StatusCode::CREATED || status == StatusCode::OK,
+        "upload failed ({status}): {body}"
+    );
+    let id = body["policy"]["id"].as_str().unwrap();
     let (status, body) = send(
         &fix.router,
         "POST",

--- a/vtc-service/tests/policies.rs
+++ b/vtc-service/tests/policies.rs
@@ -23,16 +23,16 @@ use vtc_service::acl::{VtcAclEntry, VtcRole, store_acl_entry};
 use vtc_service::policy::{PolicyPurpose, get_active_policy_id, get_policy};
 use vtc_service::test_support::TestVtc;
 
-const UPLOAD_TASK: &str = "https://trusttasks.org/openvtc/vtc/policies/upload/1.0";
-const ACTIVATE_TASK: &str = "https://trusttasks.org/openvtc/vtc/policies/activate/1.0";
+const UPLOAD_TASK: &str = "https://trusttasks.org/spec/policy/upsert/0.2";
+const ACTIVATE_TASK: &str = "https://trusttasks.org/spec/policy/activate/0.1";
 const TEST_TASK: &str = "https://trusttasks.org/openvtc/vtc/policies/test/1.0";
 /// `/v1/policies` (list) + `/v1/policies/{id}` (show) share their
 /// HTTP mounts with the upload + activate POSTs respectively —
 /// TrustTaskRouter doesn't yet support per-method selectors, so
 /// the GET requests carry the upload task header. See
 /// `vtc-service/src/routes/mod.rs` comment block.
-const LIST_TASK: &str = UPLOAD_TASK;
-const SHOW_TASK: &str = UPLOAD_TASK;
+const LIST_TASK: &str = "https://trusttasks.org/spec/policy/list/0.2";
+const SHOW_TASK: &str = "https://trusttasks.org/spec/policy/get/0.1";
 
 const ADMIN_DID: &str = "did:key:zPolicyAdmin";
 
@@ -139,15 +139,19 @@ async fn upload_policy(fix: &Fixture, purpose: &str, source: &str) -> Value {
         "/v1/policies",
         UPLOAD_TASK,
         &fix.admin_token,
-        json!({ "purpose": purpose, "regoSource": source }),
+        json!({ "name": purpose, "module": source, "ext": { "org.openvtc.purpose": purpose } }),
     );
     let resp = fix.router.clone().oneshot(req).await.unwrap();
-    assert_eq!(
+    // Canonical upsert: 201 on a new lineage, 200 on a revision.
+    assert!(
+        resp.status() == StatusCode::CREATED || resp.status() == StatusCode::OK,
+        "expected 201/200 from upsert, got {}",
         resp.status(),
-        StatusCode::CREATED,
-        "expected 201 from upload"
     );
-    body_json(resp.into_body()).await
+    // Unwrap the canonical `{policy, created}` envelope so callers can
+    // keep reading module fields directly.
+    let body = body_json(resp.into_body()).await;
+    body["policy"].clone()
 }
 
 // ---------------------------------------------------------------------------
@@ -163,9 +167,9 @@ async fn upload_happy_path_persists_policy() {
     let body = upload_policy(&fix, "join", JOIN_ALLOW_POLICY).await;
     let id: Uuid = body["id"].as_str().unwrap().parse().unwrap();
 
-    assert_eq!(body["purpose"], "join");
+    assert_eq!(body["ext"]["org.openvtc.purpose"], "join");
     assert_eq!(body["version"], 1);
-    let sha = body["sha256"].as_str().unwrap();
+    let sha = body["ext"]["org.openvtc.sha256"].as_str().unwrap();
     assert_eq!(sha.len(), 64);
     assert!(
         sha.chars()
@@ -204,7 +208,7 @@ async fn upload_bad_rego_returns_400() {
         "/v1/policies",
         UPLOAD_TASK,
         &fix.admin_token,
-        json!({ "purpose": "join", "regoSource": "@@@ not rego @@@" }),
+        json!({ "name": "join", "module": "@@@ not rego @@@", "ext": { "org.openvtc.purpose": "join" } }),
     );
     let resp = fix.router.clone().oneshot(req).await.unwrap();
     assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
@@ -231,7 +235,7 @@ async fn upload_rejects_purpose_package_mismatch() {
         "/v1/policies",
         UPLOAD_TASK,
         &fix.admin_token,
-        json!({ "purpose": "join", "regoSource": mismatched }),
+        json!({ "name": "join", "module": mismatched, "ext": { "org.openvtc.purpose": "join" } }),
     );
     let resp = fix.router.clone().oneshot(req).await.unwrap();
     assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
@@ -262,7 +266,7 @@ async fn activate_swaps_active_pointer() {
     assert_eq!(resp.status(), StatusCode::OK);
 
     let body = body_json(resp.into_body()).await;
-    assert_eq!(body["id"], id.to_string());
+    assert_eq!(body["activated"], id.to_string());
     assert_eq!(body["purpose"], "join");
     assert!(
         body["previousPolicyId"].is_null(),
@@ -529,13 +533,14 @@ async fn list_returns_all_policies() {
     assert_eq!(resp.status(), StatusCode::OK);
 
     let body = body_json(resp.into_body()).await;
-    let items = body["items"].as_array().expect("items array");
+    let items = body["policies"].as_array().expect("items array");
     assert_eq!(items.len(), 2);
-    let active: Vec<&Value> = items.iter().filter(|i| i["isActive"] == true).collect();
-    assert_eq!(active.len(), 1);
-    assert_eq!(active[0]["id"], a_id);
+    // `isActive` is not a canonical PolicyModule field — activeness is
+    // expressed by the `status=active` filter and by policy/active's
+    // bindings, both covered below.
+    assert!(items.iter().any(|i| i["id"] == a_id));
     // Full row visibility — Rego source is in the response.
-    assert!(items.iter().all(|i| i["regoSource"].is_string()));
+    assert!(items.iter().all(|i| i["module"].is_string()));
 }
 
 /// `?purpose=removal` filters list to that purpose only.
@@ -557,9 +562,9 @@ async fn list_filters_by_purpose() {
         .unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
     let body = body_json(resp.into_body()).await;
-    let items = body["items"].as_array().unwrap();
+    let items = body["policies"].as_array().unwrap();
     assert_eq!(items.len(), 1);
-    assert_eq!(items[0]["purpose"], "removal");
+    assert_eq!(items[0]["ext"]["org.openvtc.purpose"], "removal");
 }
 
 /// `?status=active` returns only rows pointed at by their
@@ -595,10 +600,9 @@ async fn list_filters_by_status() {
         .await
         .unwrap();
     let body = body_json(resp.into_body()).await;
-    let items = body["items"].as_array().unwrap();
+    let items = body["policies"].as_array().unwrap();
     assert_eq!(items.len(), 1);
     assert_eq!(items[0]["id"], join_id);
-    assert_eq!(items[0]["isActive"], true);
 
     // status=archived → just the removal row.
     let resp = fix
@@ -612,10 +616,11 @@ async fn list_filters_by_status() {
         .await
         .unwrap();
     let body = body_json(resp.into_body()).await;
-    let items = body["items"].as_array().unwrap();
+    let items = body["policies"].as_array().unwrap();
     assert_eq!(items.len(), 1);
-    assert_eq!(items[0]["purpose"], "removal");
-    assert_eq!(items[0]["isActive"], false);
+    assert_eq!(items[0]["ext"]["org.openvtc.purpose"], "removal");
+    // The `archived` filter having returned it is the assertion — a
+    // canonical PolicyModule carries no isActive field.
 }
 
 /// Regression: the simulator's active-policy lookup
@@ -659,10 +664,9 @@ async fn list_active_by_purpose_is_exact_under_limit_one() {
             .unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
         let body = body_json(resp.into_body()).await;
-        let items = body["items"].as_array().unwrap();
+        let items = body["policies"].as_array().unwrap();
         assert_eq!(items.len(), 1, "{purpose}: active lookup returns one row");
         assert_eq!(items[0]["id"], id, "{purpose}: active id");
-        assert_eq!(items[0]["isActive"], true);
     }
 }
 
@@ -685,17 +689,12 @@ async fn show_returns_full_row() {
         .unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
 
-    let body = body_json(resp.into_body()).await;
+    let outer = body_json(resp.into_body()).await;
+    let body = &outer["policy"];
     assert_eq!(body["id"], id);
-    assert_eq!(body["purpose"], "join");
+    assert_eq!(body["ext"]["org.openvtc.purpose"], "join");
     assert_eq!(body["version"], 1);
-    assert_eq!(body["isActive"], false);
-    assert!(
-        body["regoSource"]
-            .as_str()
-            .unwrap()
-            .contains("default allow")
-    );
+    assert!(body["module"].as_str().unwrap().contains("default allow"));
 }
 
 /// `GET /v1/policies/{id}` returns 404 for unknown ids.
@@ -731,7 +730,7 @@ async fn upload_without_token_returns_401() {
         .header("trust-task", UPLOAD_TASK)
         .header("content-type", "application/json")
         .body(Body::from(
-            json!({ "purpose": "join", "regoSource": JOIN_ALLOW_POLICY }).to_string(),
+            json!({ "name": "join", "module": JOIN_ALLOW_POLICY, "ext": { "org.openvtc.purpose": "join" } }).to_string(),
         ))
         .unwrap();
     let resp = fix.router.clone().oneshot(req).await.unwrap();

--- a/vtc-service/tests/policy_canonical.rs
+++ b/vtc-service/tests/policy_canonical.rs
@@ -1,0 +1,315 @@
+//! Integration coverage for the canonical `policy/*` surface (phase 2a).
+//!
+//! The interesting part is the model mismatch. Canonical treats a policy
+//! module as purpose-agnostic and mutable, selected at evaluate time;
+//! VTC binds purpose intrinsically (it is fixed by the module's Rego
+//! package) over append-only revisions. These tests pin how that gap is
+//! bridged — and, more importantly, that nothing is silently accepted.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use serde_json::{Value, json};
+use tower::ServiceExt;
+
+use vtc_service::test_support::TestVtc;
+
+const UPSERT: &str = "https://trusttasks.org/spec/policy/upsert/0.2";
+const LIST: &str = "https://trusttasks.org/spec/policy/list/0.2";
+const GET: &str = "https://trusttasks.org/spec/policy/get/0.1";
+const ACTIVE: &str = "https://trusttasks.org/spec/policy/active/0.1";
+const ACTIVATE: &str = "https://trusttasks.org/spec/policy/activate/0.1";
+
+const JOIN_POLICY: &str = "package vtc.join\nimport rego.v1\ndefault allow := true\n";
+
+struct Fixture {
+    router: axum::Router,
+    token: String,
+}
+
+async fn build() -> Fixture {
+    let vtc = TestVtc::builder().with_audit(true).build().await;
+    let token = vtc.token("did:key:z6MkAdmin", "admin", vec![]).await;
+    Fixture {
+        router: vtc.router.clone(),
+        token,
+    }
+}
+
+async fn call(
+    fix: &Fixture,
+    method: &str,
+    uri: &str,
+    task: &str,
+    body: Option<Value>,
+) -> (StatusCode, Value) {
+    let mut b = Request::builder()
+        .method(method)
+        .uri(uri)
+        .header("Trust-Task", task)
+        .header("Authorization", format!("Bearer {}", fix.token));
+    if body.is_some() {
+        b = b.header("Content-Type", "application/json");
+    }
+    let req = b
+        .body(body.map_or(Body::empty(), |v| Body::from(v.to_string())))
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    let status = resp.status();
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let v: Value = serde_json::from_slice(&bytes)
+        .unwrap_or_else(|_| json!({ "raw": String::from_utf8_lossy(&bytes) }));
+    (status, v)
+}
+
+fn upsert_body(purpose: &str, module: &str) -> Value {
+    json!({
+        "name": purpose,
+        "module": module,
+        "ext": { "org.openvtc.purpose": purpose },
+    })
+}
+
+#[tokio::test]
+async fn upsert_returns_a_canonical_policy_module() {
+    let fix = build().await;
+    let (status, body) = call(
+        &fix,
+        "POST",
+        "/v1/policies",
+        UPSERT,
+        Some(upsert_body("join", JOIN_POLICY)),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "{body}");
+    assert_eq!(
+        body["created"], true,
+        "first revision is a creation: {body}"
+    );
+
+    let p = &body["policy"];
+    for f in ["id", "name", "module", "version", "createdAt", "updatedAt"] {
+        assert!(p.get(f).is_some(), "{f} missing: {p}");
+    }
+    // Maintainer-specific fields ride in ext — the canonical type is
+    // additionalProperties:false.
+    assert_eq!(p["ext"]["org.openvtc.purpose"], "join");
+    assert!(p["ext"]["org.openvtc.sha256"].as_str().is_some());
+    assert!(p.get("purpose").is_none(), "purpose is not top-level: {p}");
+    assert!(p.get("regoSource").is_none(), "renamed to module: {p}");
+}
+
+/// Purpose cannot be inferred (only 4 of 10 have an expected package)
+/// and canonical upsert has no purpose field, so it is required in ext.
+/// Guessing would risk filing a module under the wrong decision slot.
+#[tokio::test]
+async fn upsert_without_the_purpose_ext_is_refused() {
+    let fix = build().await;
+    let (status, body) = call(
+        &fix,
+        "POST",
+        "/v1/policies",
+        UPSERT,
+        Some(json!({ "name": "join", "module": JOIN_POLICY })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{body}");
+    assert!(
+        body["error"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("purpose"),
+        "the error should name what is missing: {body}"
+    );
+}
+
+/// The pre-existing guard: a module whose Rego package does not serve
+/// the declared purpose compiles cleanly and then silently denies
+/// everything. It must survive the migration.
+#[tokio::test]
+async fn upsert_still_rejects_a_package_purpose_mismatch() {
+    let fix = build().await;
+    let (status, body) = call(
+        &fix,
+        "POST",
+        "/v1/policies",
+        UPSERT,
+        // A join-purpose upload whose module lives in the removal package.
+        Some(upsert_body(
+            "join",
+            "package vtc.removal\nimport rego.v1\ndefault allow := true\n",
+        )),
+    )
+    .await;
+    assert_ne!(status, StatusCode::CREATED, "must not be accepted: {body}");
+}
+
+/// Canonical members VTC cannot honour must be refused, not ignored —
+/// a caller setting `enabled: false` must never have it dropped.
+#[tokio::test]
+async fn upsert_refuses_selection_hints_it_cannot_honour() {
+    let fix = build().await;
+    for (field, value) in [
+        ("appliesTo", json!(["ctx-a"])),
+        ("priority", json!(10)),
+        ("enabled", json!(false)),
+    ] {
+        let mut body = upsert_body("join", JOIN_POLICY);
+        body[field] = value;
+        let (status, resp) = call(&fix, "POST", "/v1/policies", UPSERT, Some(body)).await;
+        assert_eq!(
+            status,
+            StatusCode::BAD_REQUEST,
+            "{field} must be refused: {resp}"
+        );
+        assert!(
+            resp["error"].as_str().unwrap_or_default().contains(field),
+            "the error should name {field}: {resp}"
+        );
+    }
+}
+
+/// `expectedVersion` is an optimistic-concurrency token: two operators
+/// racing on the same purpose must not each append over the other's
+/// read.
+#[tokio::test]
+async fn expected_version_is_a_real_compare_and_swap() {
+    let fix = build().await;
+    call(
+        &fix,
+        "POST",
+        "/v1/policies",
+        UPSERT,
+        Some(upsert_body("join", JOIN_POLICY)),
+    )
+    .await;
+
+    // Stale: caller believes nothing exists yet.
+    let mut stale = upsert_body("join", JOIN_POLICY);
+    stale["expectedVersion"] = json!(0);
+    let (status, body) = call(&fix, "POST", "/v1/policies", UPSERT, Some(stale)).await;
+    assert_eq!(status, StatusCode::CONFLICT, "{body}");
+
+    // Correct: current revision is 1.
+    let mut fresh = upsert_body("join", JOIN_POLICY);
+    fresh["expectedVersion"] = json!(1);
+    let (status, body) = call(&fix, "POST", "/v1/policies", UPSERT, Some(fresh)).await;
+    assert_eq!(status, StatusCode::OK, "a revision, not a creation: {body}");
+    assert_eq!(body["created"], false, "{body}");
+    assert_eq!(body["policy"]["version"], 2);
+}
+
+#[tokio::test]
+async fn activate_exposes_the_binding_via_policy_active() {
+    let fix = build().await;
+    let (_, up) = call(
+        &fix,
+        "POST",
+        "/v1/policies",
+        UPSERT,
+        Some(upsert_body("join", JOIN_POLICY)),
+    )
+    .await;
+    let id = up["policy"]["id"].as_str().unwrap().to_string();
+
+    let (status, act) = call(
+        &fix,
+        "POST",
+        &format!("/v1/policies/{id}/activate"),
+        ACTIVATE,
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{act}");
+    assert_eq!(
+        act["activated"], id,
+        "canonical names it `activated`: {act}"
+    );
+    assert_eq!(act["purpose"], "join");
+
+    // The binding is now readable as a canonical ActiveBinding.
+    let (status, body) = call(&fix, "GET", "/v1/policies/active", ACTIVE, None).await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    let b = body["bindings"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|b| b["purpose"] == "join")
+        .expect("join binding");
+    assert_eq!(b["policy"]["id"], id);
+}
+
+#[tokio::test]
+async fn unsupported_list_and_active_filters_are_refused() {
+    let fix = build().await;
+    for (uri, task) in [
+        ("/v1/policies?contextId=ctx-a", LIST),
+        ("/v1/policies?enabledOnly=true", LIST),
+        ("/v1/policies/active?contextId=ctx-a", ACTIVE),
+    ] {
+        let (status, body) = call(&fix, "GET", uri, task, None).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST, "{uri}: {body}");
+    }
+}
+
+#[tokio::test]
+async fn list_and_get_return_canonical_envelopes() {
+    let fix = build().await;
+    let (_, up) = call(
+        &fix,
+        "POST",
+        "/v1/policies",
+        UPSERT,
+        Some(upsert_body("join", JOIN_POLICY)),
+    )
+    .await;
+    let id = up["policy"]["id"].as_str().unwrap().to_string();
+
+    let (status, list) = call(&fix, "GET", "/v1/policies", LIST, None).await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(list.get("policies").is_some(), "canonical key: {list}");
+    assert!(list.get("truncated").is_some(), "required: {list}");
+    assert!(list.get("items").is_none(), "old key must be gone: {list}");
+
+    let (status, got) = call(&fix, "GET", &format!("/v1/policies/{id}"), GET, None).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(got["policy"]["id"], id, "wrapped in `policy`: {got}");
+}
+
+/// `name` is canonical-required, so discarding the operator's value and
+/// substituting the purpose would be an accept-and-ignore.
+#[tokio::test]
+async fn the_operator_supplied_name_and_description_survive() {
+    let fix = build().await;
+    let mut body = upsert_body("join", JOIN_POLICY);
+    body["name"] = json!("Join policy — v2 rewrite");
+    body["description"] = json!("stricter age check");
+
+    let (status, resp) = call(&fix, "POST", "/v1/policies", UPSERT, Some(body)).await;
+    assert_eq!(status, StatusCode::CREATED, "{resp}");
+    assert_eq!(resp["policy"]["name"], "Join policy — v2 rewrite");
+
+    // And it survives a re-read, not just the echo.
+    let id = resp["policy"]["id"].as_str().unwrap().to_string();
+    let (_, got) = call(&fix, "GET", &format!("/v1/policies/{id}"), GET, None).await;
+    assert_eq!(got["policy"]["name"], "Join policy — v2 rewrite");
+}
+
+/// Canonical lets a caller target an existing module id; here revision
+/// ids are server-allocated, so honouring one would mean pretending to
+/// update a row we actually append past.
+#[tokio::test]
+async fn upsert_refuses_a_caller_supplied_id() {
+    let fix = build().await;
+    let mut body = upsert_body("join", JOIN_POLICY);
+    body["id"] = json!("11111111-1111-1111-1111-111111111111");
+    let (status, resp) = call(&fix, "POST", "/v1/policies", UPSERT, Some(body)).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{resp}");
+}
+
+#[tokio::test]
+async fn each_verb_rejects_a_siblings_task() {
+    let fix = build().await;
+    let (status, _) = call(&fix, "GET", "/v1/policies", UPSERT, None).await;
+    assert_eq!(status, StatusCode::UNSUPPORTED_MEDIA_TYPE);
+}

--- a/vtc-service/tests/recognise.rs
+++ b/vtc-service/tests/recognise.rs
@@ -50,6 +50,8 @@ async fn install_cross_community_policy(state: &AppState, source: &str) {
         author_did: "did:key:test".into(),
         created_at: Utc::now(),
         version: 1,
+        name: None,
+        description: None,
     };
     store_policy(&state.policies_ks, &policy).await.unwrap();
     set_active_policy_id(

--- a/vtc-service/tests/removal.rs
+++ b/vtc-service/tests/removal.rs
@@ -25,8 +25,8 @@ use vtc_service::test_support::TestVtc;
 const RP_ORIGIN: &str = "https://vtc.example.com";
 const SELF_REMOVE_TASK: &str = "https://trusttasks.org/openvtc/vtc/members/self-remove/1.0";
 const SHOW_TASK: &str = "https://trusttasks.org/openvtc/vtc/members/show/1.0";
-const POLICY_UPLOAD_TASK: &str = "https://trusttasks.org/openvtc/vtc/policies/upload/1.0";
-const POLICY_ACTIVATE_TASK: &str = "https://trusttasks.org/openvtc/vtc/policies/activate/1.0";
+const POLICY_UPLOAD_TASK: &str = "https://trusttasks.org/spec/policy/upsert/0.2";
+const POLICY_ACTIVATE_TASK: &str = "https://trusttasks.org/spec/policy/activate/0.1";
 
 const ADMIN_DID: &str = "did:key:zAdmin1";
 
@@ -572,11 +572,17 @@ async fn activate_removal_policy(fix: &Fixture, source: &str) {
         "/v1/policies",
         POLICY_UPLOAD_TASK,
         Some(&fix.admin_token),
-        Some(json!({ "purpose": "removal", "regoSource": source })),
+        Some(json!({ "name": "removal", "module": source, "ext": { "org.openvtc.purpose": "removal" } })),
     )
     .await;
-    assert_eq!(status, StatusCode::CREATED, "upload failed: {body}");
-    let id = body["id"].as_str().unwrap();
+    // Canonical upsert: 201 when this is the first revision for the
+    // purpose, 200 when it revises an existing one. Fixtures may have
+    // seeded a policy already, so both are success here.
+    assert!(
+        status == StatusCode::CREATED || status == StatusCode::OK,
+        "upload failed ({status}): {body}"
+    );
+    let id = body["policy"]["id"].as_str().unwrap();
     let (status, body) = send(
         &fix.router,
         "POST",

--- a/vtc-service/tests/renewal.rs
+++ b/vtc-service/tests/renewal.rs
@@ -321,6 +321,8 @@ async fn renew_default_downgrades_when_policy_drops_flag() {
         author_did: "did:key:test".into(),
         created_at: chrono::Utc::now(),
         version: 1,
+        name: None,
+        description: None,
     };
     vtc_service::policy::store_policy(&fix.policies_ks, &strict)
         .await

--- a/vtc-service/tests/trust_task_manifest.rs
+++ b/vtc-service/tests/trust_task_manifest.rs
@@ -52,8 +52,6 @@ const UNBOUND_OK: &[(&str, &str)] = &[
         "DELETE shares the personhood mount",
     ),
     ("members/update/1.0", "PATCH shares the members/{did} mount"),
-    ("policies/list/1.0", "GET shares the upload/1.0 mount"),
-    ("policies/show/1.0", "GET shares the upload/1.0 mount"),
     (
         "website/files/delete/1.0",
         "shares the website files show mount",


### PR DESCRIPTION
Completes **Phase 2** of the vtc-service Trust Task migration (#710). The policy family was the hardest of the five, because canonical and VTC disagree on *what a policy is* — not on what its fields are called.

| route | now |
|---|---|
| `GET /v1/policies` | `spec/policy/list/0.2` |
| `POST /v1/policies` | `spec/policy/upsert/0.2` |
| `GET /v1/policies/{id}` | `spec/policy/get/0.1` |
| `GET /v1/policies/active` | `spec/policy/active/0.1` *(new)* |
| `POST /v1/policies/{id}/activate` | `spec/policy/activate/0.1` |

The four superseded `openvtc` tasks are **retired** with `supersededBy`, and the two now-stale `UNBOUND_OK` census exceptions are removed.

**`policies/test` deliberately stays on its `openvtc` URI.** Canonical `policy/evaluate` runs the *matching policy set* through the standard `decision` rule; `test` evaluates an operator-chosen Rego query against one stored module. Different verb — repointing it would advertise something it doesn't do.

### The model mismatch, and why purpose lives in `ext`

Canonical treats a module as **purpose-agnostic and mutable**: purpose lives in a separate `(contextId, purpose) → policy` activation binding, and selection happens at evaluate time via `appliesTo`/`priority`. VTC bakes the purpose into the module's own **Rego package** and validates it at upload — because a module in the wrong package *compiles cleanly and then silently denies every request* for that ceremony.

I investigated inferring purpose from the module, which would have bridged this neatly, and rejected it on evidence: **only 4 of the 10 purposes have an expected package** (`Join`, `Removal`, `RoleChange`, `Directory`). Six could never be derived from source, and guessing risks filing a module under the wrong decision slot — precisely what the guard prevents.

So purpose travels in **`ext` (`org.openvtc.purpose`)** and is **required**. `ext` is exactly what the framework reserves for ecosystem-defined members, which makes this a *documented* divergence rather than a hidden one — a consumer can see that this maintainer binds purpose intrinsically. An upsert without it is refused, not guessed. The package↔purpose guard is preserved on both upsert and activate.

### `expectedVersion` is a real compare-and-swap

VTC's monotone per-purpose revision counter is the concurrency token, so two operators racing on the same purpose can no longer each append a revision over the other's read. That's a safety property VTC didn't previously have, not just conformance.

### Breaking (admin API)

Entries are the canonical `PolicyModule`: `regoSource` → `module`; responses wrap as `{policy, created}` / `{policies, truncated, cursor}` / `{bindings}`; `limit` → `pageSize`. `sha256`, `authorDid` and `purpose` move under `ext` (the canonical type is `additionalProperties: false`).

**`isActive` is gone from the module** — activeness is a *binding*, read from `policy/active` — so the admin UI now queries the binding rather than reading a per-row flag. Rewritten in the same commit.

Note the status-code change: `upsert` returns **201 on a new lineage, 200 on a revision** (that's what `created` reports). Three test fixtures hard-coded 201; the full-workspace run caught it after the targeted suites passed, because `join_requests.rs` and `removal.rs` carry their own copies of the upload helper.

### Nothing accepted-and-ignored

Canonical members this maintainer cannot honour are **refused with an error naming them**: `appliesTo`, `priority`, `enabled` on upsert; `contextId`, `enabledOnly` on list; `contextId` on active. A caller-supplied `id` on upsert is refused too — revision ids are server-allocated, so honouring one would mean pretending to update a row we actually append past.

`Policy` gains `name` + `description` (serde default, no migration). **`name` is canonical-required, and my first cut silently discarded the operator's value** and substituted the purpose — the exact accept-and-ignore this migration has been refusing everywhere else. Clippy's "never read" caught it. Rows predating the field fall back to the purpose, the only stable human-meaningful identifier they have.

### Verification

`cargo test --workspace` (CI-equivalent): **3636 passed, 0 failed**. `cargo clippy -p vtc-service --all-targets -D warnings` clean. `cargo fmt --all --check` clean. `tsc --noEmit` on the admin UI clean. Self-pin guard green.

New `vtc-service/tests/policy_canonical.rs` (11 tests): canonical module shape with maintainer fields in `ext`, purpose-ext required, the package/purpose guard surviving, selection hints refused by name, `expectedVersion` CAS in both directions, activate→`policy/active` binding round-trip, unsupported list/active filters refused, canonical envelopes, sibling-task rejection, operator `name` surviving a re-read, and caller-supplied `id` refused. Plus 17 updated existing policy tests.

Version bumped: `vtc-service` 0.11.17.

### Phase 2 is complete

| sub-phase | status |
|---|---|
| 2a `policy/*` | this PR |
| 2b `audit/*` | #726, #727 |
| 2c `config/*` | #724 |
| 2d `acl/*` | #728 |
| 2e `auth/*` | already done |

Families with no canonical counterpart (`policies/test`, `config/legacy/manage`, `admin/config/{export,import}`, residual auth URIs) are deliberately left on `openvtc/` rather than force-fitted. Remaining migration work is Phase 3 (the `confirm/1.0` management gate in `vti-common`), Phase 5 (retire the manifest, retarget the census), and Phase 6 (downstream SDK + openvtc — note openvtc's `didcomm.rs` regex allowlist would *reject* migrated traffic, so it must land in the same release).
