### PR TITLE
fix(vta-service): self-recover a webvh update after a failed publish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10234,7 +10234,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.12.1"
+version = "0.12.2"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/operations/did_webvh/update/orchestrator.rs
+++ b/vta-service/src/operations/did_webvh/update/orchestrator.rs
@@ -572,6 +572,70 @@ async fn run_update(
         .unwrap_or_default();
     let pre_rotation_active = !last_next_key_hashes.is_empty();
 
+    // 4b. Reconcile a prior failed publish before building anything new.
+    //
+    // This function commits local state (the derivation counter, the installed
+    // keys, the stored log) *before* it can confirm the host received the new
+    // version — see the seam below. So a publish that failed for any reason (a
+    // host blip, a 500, a timeout) leaves the local head ahead of what the host
+    // actually serves. Building a *new* version on that divergence, and burning
+    // a fresh key index to do it, is exactly what turns one failed publish into
+    // an unrecoverable loop: every retry advances the counter, so the consent
+    // gate re-mints and never converges.
+    //
+    // So before doing anything that moves state, make the host whole. The host
+    // accepts any valid full log (it re-verifies the chain and replaces its
+    // copy), so re-publishing the current local head is idempotent and heals a
+    // divergence of any depth in one call. Only once it lands do we record it
+    // as confirmed and go on to build the new version. If it fails we return
+    // here — before a single key is derived or allocated — so nothing moves and
+    // the next attempt starts clean. That is what makes a failed attempt
+    // self-recover instead of wedging the DID.
+    if mode == Mode::Execute && record.server_id != "serverless" {
+        let confirmed = webvh_store::get_published_version(webvh_ks, &record.did)
+            .await
+            .map_err(|e| UpdateDidWebvhError::Persistence(format!("get_published_version: {e}")))?;
+        if confirmed.as_deref() != Some(prior_version_id.as_str()) {
+            let server = webvh_store::get_server(webvh_ks, &record.server_id)
+                .await
+                .map_err(|e| UpdateDidWebvhError::Persistence(format!("get_server: {e}")))?
+                .ok_or_else(|| {
+                    UpdateDidWebvhError::Publish(format!(
+                        "webvh server `{}` referenced by DID is missing",
+                        record.server_id
+                    ))
+                })?;
+            let vta_did_ref = vta_did.ok_or_else(|| {
+                UpdateDidWebvhError::Publish(
+                    "VTA DID is not configured — cannot authenticate to webvh hosting \
+                     server to reconcile a pending publish."
+                        .to_string(),
+                )
+            })?;
+            tracing::info!(
+                did = %record.did,
+                local_head = %prior_version_id,
+                ?confirmed,
+                "reconcile: re-publishing an unconfirmed local head before updating"
+            );
+            super::super::publish_log_to_server(
+                deps,
+                vta_did_ref,
+                &server,
+                &record.mnemonic,
+                &did_log,
+                None,
+            )
+            .await
+            .map_err(|e| UpdateDidWebvhError::Publish(format!("reconcile publish_did: {e}")))?;
+            webvh_store::set_published_version(webvh_ks, &record.did, &prior_version_id)
+                .await
+                .map_err(|e| {
+                    UpdateDidWebvhError::Persistence(format!("set_published_version: {e}"))
+                })?;
+        }
+    }
+
     // 5. Resolve effective pre-rotation count.
     let pre_rotation_count = opts.pre_rotation_count.unwrap_or(record.pre_rotation_count);
 
@@ -958,6 +1022,15 @@ async fn run_update(
                 .map_err(|e| UpdateDidWebvhError::Publish(format!("agent_name: {e}")))?;
             }
         }
+
+        // The host has this version now. Record it so the next update's
+        // reconcile check (step 4b) knows the local head is published and does
+        // not needlessly re-publish. A publish failure above returns before
+        // this line, leaving the marker at the prior version — which is what
+        // makes the next attempt re-publish and self-heal.
+        webvh_store::set_published_version(webvh_ks, &record.did, &new_version_id)
+            .await
+            .map_err(|e| UpdateDidWebvhError::Persistence(format!("set_published_version: {e}")))?;
     }
 
     // 14. Audit emission. Best-effort — a missing audit row should

--- a/vta-service/src/test_support.rs
+++ b/vta-service/src/test_support.rs
@@ -987,6 +987,10 @@ pub const STUB_WEBVH_DID_URL: &str = "https://webvh-host.test/dids/persona/did.j
 #[cfg(feature = "webvh")]
 pub struct StubWebvhHost {
     base_url: String,
+    /// Number of upcoming `PUT /api/dids/{mnemonic}` publishes to fail with a
+    /// 500 before accepting again — lets a test simulate a transient host
+    /// outage and assert the VTA self-recovers. Shared with the route handler.
+    fail_puts: std::sync::Arc<std::sync::atomic::AtomicUsize>,
     shutdown: Option<tokio::sync::oneshot::Sender<()>>,
     handle: Option<tokio::task::JoinHandle<()>>,
 }
@@ -997,6 +1001,13 @@ impl StubWebvhHost {
     pub async fn start() -> StubWebvhHost {
         use axum::routing::{post, put};
         use serde_json::json;
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        // Shared publish-failure budget: the PUT handler fails while this is
+        // > 0, decrementing each time, so a test can outage the host for N
+        // publishes and watch the VTA recover afterwards.
+        let fail_puts = Arc::new(AtomicUsize::new(0));
 
         /// Reject a request that arrives without an `Authorization: Bearer`
         /// header. The real hosting daemon returns 401 "missing or invalid
@@ -1091,9 +1102,26 @@ impl StubWebvhHost {
             )
             .route(
                 "/api/dids/{mnemonic}",
-                put(|headers: axum::http::HeaderMap| async move {
-                    require_bearer(&headers)?;
-                    Ok::<_, axum::http::StatusCode>(axum::http::StatusCode::OK)
+                put({
+                    let fail_puts = fail_puts.clone();
+                    move |headers: axum::http::HeaderMap| {
+                        let fail_puts = fail_puts.clone();
+                        async move {
+                            require_bearer(&headers)?;
+                            // Simulate a transient host outage while the budget
+                            // lasts. The real daemon commits nothing on a 500,
+                            // so this mirrors "the publish didn't land".
+                            if fail_puts
+                                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |n| {
+                                    n.checked_sub(1)
+                                })
+                                .is_ok()
+                            {
+                                return Err(axum::http::StatusCode::INTERNAL_SERVER_ERROR);
+                            }
+                            Ok::<_, axum::http::StatusCode>(axum::http::StatusCode::OK)
+                        }
+                    }
                 })
                 .delete(|headers: axum::http::HeaderMap| async move {
                     require_bearer(&headers)?;
@@ -1118,6 +1146,7 @@ impl StubWebvhHost {
 
         StubWebvhHost {
             base_url,
+            fail_puts,
             shutdown: Some(tx),
             handle: Some(handle),
         }
@@ -1127,6 +1156,12 @@ impl StubWebvhHost {
     /// goes into the seeded server DID's `WebVHHosting` service endpoint.
     pub fn base_url(&self) -> &str {
         &self.base_url
+    }
+
+    /// Fail the next `n` publishes (`PUT /api/dids/{mnemonic}`) with a 500,
+    /// then accept again — a transient outage a test can recover from.
+    pub fn fail_next_publishes(&self, n: usize) {
+        self.fail_puts.store(n, std::sync::atomic::Ordering::SeqCst);
     }
 }
 
@@ -1285,6 +1320,16 @@ impl MockVta {
     /// [`base_url`](Self::base_url) to a URL-direct provision entry point.
     pub fn vta_did(&self) -> &str {
         &self.ctx.vta_did
+    }
+
+    /// Fail the stub host's next `n` publishes with a 500 — simulate a
+    /// transient outage so a test can assert the VTA recovers on retry.
+    /// Only meaningful for a mock started via [`start_with_webvh_host`].
+    #[cfg(feature = "webvh")]
+    pub fn fail_next_publishes(&self, n: usize) {
+        if let Some(host) = &self.webvh_host {
+            host.fail_next_publishes(n);
+        }
     }
 
     /// Seed a webvh hosting server so a DID-mint / join flow finds a server in

--- a/vta-service/src/webvh_store.rs
+++ b/vta-service/src/webvh_store.rs
@@ -21,6 +21,21 @@ fn log_key(did: &str) -> String {
     format!("log:{did}")
 }
 
+/// The version id last **confirmed published** to the hosting server for this
+/// DID. Kept in a service-private key rather than on the record so it never
+/// leaks to `list` responses or backups, and so adding it needs no change to
+/// the published `WebvhDidRecord` type.
+///
+/// Its job is recovery: a webvh update commits local state (counter, keys, log)
+/// before it can confirm the host received it, so a failed publish leaves the
+/// local head ahead of the host. Comparing the local head against this marker
+/// tells the next update to *re-publish* the pending log rather than build a
+/// new version on top of a divergence — which is what lets a failed attempt
+/// self-heal instead of wedging the DID.
+fn published_key(did: &str) -> String {
+    format!("published:{did}")
+}
+
 /// Cached daemon REST auth state for a single webvh server. Kept in
 /// a service-private keyspace prefix (`server-auth:`) — never on the
 /// public [`WebvhServerRecord`] type — so bearer tokens cannot leak
@@ -162,6 +177,28 @@ pub async fn store_did_log(
         .await
 }
 
+/// Read the version id last confirmed published to the host (see
+/// [`published_key`]). `None` means never confirmed — treat the local head as
+/// unpublished and re-publish before building on it.
+pub async fn get_published_version(
+    ks: &KeyspaceHandle,
+    did: &str,
+) -> Result<Option<String>, AppError> {
+    let bytes = ks.get_raw(published_key(did)).await?;
+    Ok(bytes.map(|b| String::from_utf8_lossy(&b).into_owned()))
+}
+
+/// Record that `version_id` is now confirmed present on the host. Called only
+/// after a publish returns success.
+pub async fn set_published_version(
+    ks: &KeyspaceHandle,
+    did: &str,
+    version_id: &str,
+) -> Result<(), AppError> {
+    ks.insert_raw(published_key(did), version_id.as_bytes().to_vec())
+        .await
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -177,6 +214,36 @@ mod tests {
         .unwrap();
         let ks = store.keyspace(crate::keyspaces::WEBVH).unwrap();
         (dir, ks)
+    }
+
+    /// The reconcile marker: absent until a publish is confirmed, then it
+    /// round-trips and overwrites. The update path compares it against the
+    /// local head to decide whether to re-publish before building anew.
+    #[tokio::test]
+    async fn published_version_marker_round_trips() {
+        let (_dir, ks) = setup_ks().await;
+        let did = "did:webvh:abc:host.example:alice";
+
+        // Absent by default — the update path reads this as "unconfirmed" and
+        // re-publishes, which is the safe assumption for a DID that has never
+        // confirmed a publish (including one whose create-time publish failed).
+        assert_eq!(get_published_version(&ks, did).await.unwrap(), None);
+
+        set_published_version(&ks, did, "3-QmHead").await.unwrap();
+        assert_eq!(
+            get_published_version(&ks, did).await.unwrap().as_deref(),
+            Some("3-QmHead")
+        );
+
+        // Overwrites, so a later confirmed version replaces the earlier one.
+        set_published_version(&ks, did, "4-QmNext").await.unwrap();
+        assert_eq!(
+            get_published_version(&ks, did).await.unwrap().as_deref(),
+            Some("4-QmNext")
+        );
+
+        // Its own key prefix — it must not collide with the log or record.
+        assert_eq!(get_did_log(&ks, did).await.unwrap(), None);
     }
 
     fn sample_server(id: &str) -> WebvhServerRecord {

--- a/vta-service/tests/mock_vta.rs
+++ b/vta-service/tests/mock_vta.rs
@@ -234,3 +234,121 @@ async fn create_did_webvh_round_trips_against_stub_host() {
 
     mock.shutdown().await;
 }
+
+/// Self-recovery from a failed publish (the DTTE / update path).
+///
+/// A webvh update commits local state before it can confirm the host received
+/// the new version, so a publish that fails leaves the local head ahead of the
+/// host. This must not wedge the DID: the confirmed-published marker must not
+/// advance on a failed publish, and the next update must reconcile (re-publish
+/// the pending log) and succeed. Before the reconcile guard, a failed publish
+/// advanced the key counter and the DID looped forever.
+#[cfg(feature = "webvh")]
+#[tokio::test]
+async fn a_failed_publish_does_not_wedge_the_did_and_the_next_update_recovers() {
+    use vta_sdk::client::{CreateDidWebvhRequest, VtaClient};
+    use vta_sdk::protocols::did_management::create::WebvhPathMode;
+    use vta_sdk::protocols::did_management::update::UpdateDidWebvhBody;
+
+    let mock = MockVta::start_with_webvh_host().await;
+    let token = mock
+        .ctx
+        .mint_token("did:key:z6MkWebvhAdmin", "admin", vec![])
+        .await;
+    let client = VtaClient::new(mock.base_url());
+    client.set_token_async(token).await;
+
+    let create = client
+        .create_did_webvh(CreateDidWebvhRequest {
+            context_id: "ctx1".into(),
+            server_id: Some(MockVta::WEBVH_SERVER_ID.into()),
+            url: None,
+            path: None,
+            path_mode: Some(WebvhPathMode::AutoAssign),
+            domain: None,
+            label: None,
+            portable: false,
+            add_mediator_service: false,
+            additional_services: None,
+            pre_rotation_count: 0,
+            did_document: None,
+            did_log: None,
+            set_primary: false,
+            signing_key_id: None,
+            ka_key_id: None,
+            template: None,
+            template_context: None,
+            template_vars: Default::default(),
+        })
+        .await
+        .expect("create server-managed DID against the stub host");
+    let did = create.did;
+    let scid = create.scid;
+
+    let confirmed = |did: &str| {
+        let did = did.to_string();
+        let ks = mock.ctx.webvh_ks.clone();
+        async move {
+            vta_service::webvh_store::get_published_version(&ks, &did)
+                .await
+                .unwrap()
+        }
+    };
+    // Drive *document* updates (the "Edit DID" case), which rotate the update
+    // key — the exact path that burned a key index on every failed publish.
+    let update = |label: &str| {
+        let scid = scid.clone();
+        let did = did.clone();
+        let client = &client;
+        let body = UpdateDidWebvhBody {
+            document: Some(serde_json::json!({
+                "@context": ["https://www.w3.org/ns/did/v1"],
+                "id": did,
+                "verificationMethod": [{
+                    "id": format!("{did}#key-0"),
+                    "type": "Multikey",
+                    "controller": did,
+                    "publicKeyMultibase": "z6MkExternalPubForTest",
+                }],
+            })),
+            label: Some(label.into()),
+            ..Default::default()
+        };
+        async move { client.update_did_webvh("ctx1", &scid, body).await }
+    };
+
+    // A first update lands normally and confirms a published version.
+    update("u1").await.expect("first update succeeds");
+    let after_u1 = confirmed(&did).await;
+    assert!(
+        after_u1.is_some(),
+        "a successful update records a confirmed-published version"
+    );
+
+    // Fail the next publish. The update builds a new version locally, but the
+    // host rejects it — so the confirmed marker must NOT advance.
+    mock.fail_next_publishes(1);
+    assert!(
+        update("u2-fails").await.is_err(),
+        "a publish failure surfaces as an error, not a silent success"
+    );
+    assert_eq!(
+        confirmed(&did).await,
+        after_u1,
+        "a failed publish must not advance the confirmed-published marker \
+         (that divergence is what the reconcile heals)"
+    );
+
+    // The DID is diverged (local ahead of host) but not wedged: the next update
+    // reconciles the pending publish and succeeds, advancing the marker.
+    update("u3-recovers")
+        .await
+        .expect("the next update self-recovers instead of looping");
+    assert_ne!(
+        confirmed(&did).await,
+        after_u1,
+        "recovery re-publishes the pending log and advances past the pre-failure version"
+    );
+
+    mock.shutdown().await;
+}


### PR DESCRIPTION
## The bug (the DTTE approval loop)

A webvh update commits local state — the BIP-32 key counter, the installed keys, the stored log — **before** it can confirm the host received the new version. The execute path's own step-13 comment admits it:

> *Local state is already committed, so a publish failure … doesn't undo the local update; operators can retry the publish out-of-band by re-issuing the same update.*

That documented recovery is **broken**: re-issuing the update builds a *new* version and burns a fresh key index, so the divergence deepens, and the consent gate — which pins that counter in `guards.webvh_path_counter` — re-mints on every attempt. That's the endless approval loop the report hit: a single intermittent publish failure, **even on a first edit**, wedges the DID permanently. It's intermittent because it only bites when a publish doesn't cleanly succeed (which is also why a fresh DID "worked" — its publish happened to land first try).

## The fix — additive reconcile guard

Before an update derives or allocates anything, it reconciles:

- A new `published:{did}` marker in the webvh keyspace records the version last **confirmed** on the host (a service-private key, so no change to the published `WebvhDidRecord` type or its construction sites).
- If the local head isn't that version, the update first **re-publishes the current full local log** — which the host accepts idempotently, because its `prepare_republish` re-verifies the chain and replaces its copy (it does *not* require version continuity). One republish heals a divergence of any depth.
- If that re-publish fails, the update returns **before any key is derived or allocated** — so nothing moves, the counter doesn't advance, the consent gate doesn't re-mint, and the next attempt is clean.
- The marker is set **only after a publish returns success**, so a failed publish leaves it at the prior version — which is what makes the next update re-publish and recover.

Net: a failed publish self-recovers instead of wedging, and an **already-wedged DID heals itself** the first time its host is reachable again — no manual reset.

It's deliberately *additive* — a guard at the top of the update, not surgery on the commit sequence — so it lands without live-testing the key-rotation core.

## Tests

- **Integration** (`a_failed_publish_does_not_wedge_the_did_and_the_next_update_recovers`): drives create → update → **failed publish** → update against a stub host with a new controllable failure budget (`MockVta::fail_next_publishes`). Asserts the confirmed-published marker does **not** advance on the failed publish, and that the next update **recovers** rather than looping. Uses *document* updates — the exact "Edit DID" path that rotated a key on every failed attempt.
- **Unit**: the `published:{did}` marker helpers round-trip and default to absent.
- Existing serverless update tests (the commit path) and the server-managed create round-trip are unchanged and green. Full `mock_vta` + `api_integration` suites pass.

## Honest scope

This is the **additive guard** (the safer of the two options discussed). It stops the loop and self-heals, but it doesn't prevent the *one-time* counter burn on the very first failed publish — the local version still commits before that publish. The complete fix (reorder: publish before **any** local commit, so a failed publish leaves zero trace) is a follow-up that reworks the key-rotation commit order and should be validated against a live host before landing.

Two smaller notes:
- A freshly-created DID's first update does one harmless extra republish of its create-time version (the marker isn't set at create). Correct (it also heals a failed create), just slightly wasteful; setting the marker at the create/register publish site is an easy optimization.
- Metadata-only update *chains* surfaced a separate, pre-existing "log entry has no update_keys" quirk (no key rotation → no restated update_keys). Orthogonal to this fix and not the reported scenario; flagging it for a separate look.

vta-service 0.12.1 → 0.12.2 (additive).