### PR TITLE
fix(vta-service): re-derive a superseded webvh signing key from the seed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10234,7 +10234,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.12.2"
+version = "0.12.3"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/operations/did_webvh/mod.rs
+++ b/vta-service/src/operations/did_webvh/mod.rs
@@ -14,7 +14,7 @@ mod register_server;
 mod servers;
 mod transport;
 mod update;
-mod webvh_keys;
+pub(crate) mod webvh_keys;
 
 pub use auth_cache::WebvhAuthLocks;
 pub(crate) use auth_cache::{

--- a/vta-service/src/operations/did_webvh/update/keys.rs
+++ b/vta-service/src/operations/did_webvh/update/keys.rs
@@ -16,7 +16,7 @@ use ed25519_dalek_bip32::{DerivationPath, ExtendedSigningKey};
 use super::errors::UpdateDidWebvhError;
 use super::legacy::{legacy_lookup_by_public_key, legacy_lookup_pre_rotation_by_hash};
 use super::options::DerivedWebvhKey;
-use crate::keys::paths::{allocate_paths, peek_paths};
+use crate::keys::paths::{allocate_paths, path_at, peek_path_counter, peek_paths};
 use crate::keys::seed_store::SeedStore;
 use crate::keys::seeds::{get_active_seed_id, load_seed_bytes};
 use crate::operations::did_webvh::webvh_keys::{self, WebvhKeyHandle, WebvhKeyRole};
@@ -205,6 +205,8 @@ fn hash_public_key_multibase(pubkey_multibase: &str) -> Result<String, UpdateDid
 /// `derivation_path` + the active seed.
 pub(in crate::operations::did_webvh) async fn load_active_update_key(
     keys_ks: &KeyspaceHandle,
+    seed_store: &dyn SeedStore,
+    base_path: &str,
     scid: &str,
     update_keys: &[Multibase],
 ) -> Result<WebvhKeyHandle, UpdateDidWebvhError> {
@@ -244,12 +246,77 @@ pub(in crate::operations::did_webvh) async fn load_active_update_key(
         if let Some(handle) = legacy_lookup_by_public_key(keys_ks, scid, pubkey_str, &hash).await? {
             return Ok(handle);
         }
+
+        // Recovery fallback: the handle cache doesn't have it. Re-derive from
+        // the seed. See `recover_signing_key_by_hash`.
+        if let Some(handle) =
+            recover_signing_key_by_hash(keys_ks, seed_store, base_path, scid, &hash).await?
+        {
+            return Ok(handle);
+        }
     }
 
     Err(UpdateDidWebvhError::Library(format!(
-        "no active update key for DID with SCID {scid} found in keys keyspace — \
-         operator may need to restore key material from backup"
+        "no active update key for DID with SCID {scid} found in keys keyspace, and none of \
+         its committed keys could be re-derived from the seed"
     )))
+}
+
+/// Recover a signing key the handle cache can no longer find, by re-deriving it
+/// from the seed.
+///
+/// [`webvh_keys::find_handle_by_hash`] only searches the *active* prefix, and
+/// [`webvh_keys::supersede_keys_for_version`] moves a version's handles to
+/// `superseded:` when a later version rotates past it. A DID that committed
+/// local-only versions that never reached the host (a failed-publish loop) can
+/// therefore end up with the key the host's current entry still requires sitting
+/// in `superseded:` — invisible to the resolver, so every later update fails at
+/// signing and loops.
+///
+/// But webvh keys are deterministic BIP-32 derivations, so the seed *is* the
+/// backup: scan the indices the counter has handed out, derive each, and match
+/// the committed hash. On a hit, return a handle for it (the caller re-derives
+/// the secret from its path). `None` if the hash matches no index the seed
+/// produced — genuinely foreign key material, not ours to sign with.
+async fn recover_signing_key_by_hash(
+    keys_ks: &KeyspaceHandle,
+    seed_store: &dyn SeedStore,
+    base_path: &str,
+    scid: &str,
+    target_hash: &str,
+) -> Result<Option<WebvhKeyHandle>, UpdateDidWebvhError> {
+    let counter = peek_path_counter(keys_ks, base_path).await.map_err(|e| {
+        UpdateDidWebvhError::Persistence(format!("peek_path_counter for key recovery: {e}"))
+    })?;
+    for i in 0..=counter {
+        let path = path_at(base_path, i);
+        let derived =
+            derive_webvh_keys_at(keys_ks, seed_store, std::slice::from_ref(&path)).await?;
+        let Some(key) = derived.into_iter().find(|k| k.hash == target_hash) else {
+            continue;
+        };
+        tracing::info!(
+            scid,
+            target_hash,
+            path = %key.derivation_path,
+            "recovered a signing key by re-deriving it from the seed (handle cache miss)"
+        );
+        return Ok(Some(WebvhKeyHandle {
+            scid: scid.to_string(),
+            // Cosmetic: the resolver matches by hash, and the caller signs via
+            // the derivation path. It becomes a normal active handle again the
+            // moment the next version installs and supersedes.
+            version_id: format!("recovered-{i}"),
+            hash: key.hash,
+            public_key: key.public_key,
+            derivation_path: key.derivation_path,
+            seed_id: Some(key.seed_id),
+            role: WebvhKeyRole::UpdateKey,
+            label: "re-derived from seed (handle cache miss)".to_string(),
+            created_at: Utc::now(),
+        }));
+    }
+    Ok(None)
 }
 
 /// Resolve a webvh signing key whose hash is committed in
@@ -266,6 +333,8 @@ pub(in crate::operations::did_webvh) async fn load_active_update_key(
 /// re-derives the secret via [`derive_secret_for_handle`].
 pub(in crate::operations::did_webvh) async fn load_pre_rotation_signing_key(
     keys_ks: &KeyspaceHandle,
+    seed_store: &dyn SeedStore,
+    base_path: &str,
     scid: &str,
     committed_hashes: &[String],
 ) -> Result<WebvhKeyHandle, UpdateDidWebvhError> {
@@ -309,9 +378,19 @@ pub(in crate::operations::did_webvh) async fn load_pre_rotation_signing_key(
             );
             return Ok(handle);
         }
+
+        // Recovery fallback: re-derive the committed pre-rotation key from the
+        // seed when the handle cache lost it (superseded by a local-only
+        // version). See `recover_signing_key_by_hash`.
+        if let Some(handle) =
+            recover_signing_key_by_hash(keys_ks, seed_store, base_path, scid, hash).await?
+        {
+            return Ok(handle);
+        }
     }
     Err(UpdateDidWebvhError::Library(format!(
-        "no pre-rotation key found for any committed hash: {committed_hashes:?}"
+        "no pre-rotation key found for any committed hash, and none could be re-derived from \
+         the seed: {committed_hashes:?}"
     )))
 }
 

--- a/vta-service/src/operations/did_webvh/update/orchestrator.rs
+++ b/vta-service/src/operations/did_webvh/update/orchestrator.rs
@@ -708,9 +708,23 @@ async fn run_update(
         "update_did_webvh: resolving signing key"
     );
     let signing_handle = if pre_rotation_active {
-        load_pre_rotation_signing_key(keys_ks, scid, &last_next_key_hashes).await?
+        load_pre_rotation_signing_key(
+            keys_ks,
+            seed_store,
+            &context.base_path,
+            scid,
+            &last_next_key_hashes,
+        )
+        .await?
     } else {
-        load_active_update_key(keys_ks, scid, &last_update_keys).await?
+        load_active_update_key(
+            keys_ks,
+            seed_store,
+            &context.base_path,
+            scid,
+            &last_update_keys,
+        )
+        .await?
     };
     tracing::info!(
         scid,

--- a/vta-service/src/test_support.rs
+++ b/vta-service/src/test_support.rs
@@ -1332,6 +1332,22 @@ impl MockVta {
         }
     }
 
+    /// Test-only corruption: move a version's key handles to the `superseded:`
+    /// prefix, reproducing the state a pre-#730 failed-publish loop left — the
+    /// key the host's current entry still requires is no longer in the *active*
+    /// prefix the resolver searches. Proves the seed-re-derivation recovery
+    /// heals a DID the handle cache alone cannot.
+    #[cfg(feature = "webvh")]
+    pub async fn corrupt_supersede_keys(&self, scid: &str, version_id: &str) {
+        crate::operations::did_webvh::webvh_keys::supersede_keys_for_version(
+            &self.ctx.keys_ks,
+            scid,
+            version_id,
+        )
+        .await
+        .expect("supersede keys for test corruption");
+    }
+
     /// Seed a webvh hosting server so a DID-mint / join flow finds a server in
     /// the catalogue. Thin wrapper over [`seed_webvh_server`] against this
     /// mock's keyspace.

--- a/vta-service/tests/mock_vta.rs
+++ b/vta-service/tests/mock_vta.rs
@@ -352,3 +352,91 @@ async fn a_failed_publish_does_not_wedge_the_did_and_the_next_update_recovers() 
 
     mock.shutdown().await;
 }
+
+/// Backward-recovery: a DID whose signing-key handle was superseded out of the
+/// active prefix (the state a pre-#730 failed-publish loop left) still updates,
+/// because the resolver re-derives the committed key from the seed.
+///
+/// Without the recovery fallback this is the permanent wedge: the key the
+/// current entry requires is invisible to `find_handle_by_hash`, so every
+/// update fails at signing and loops.
+#[cfg(feature = "webvh")]
+#[tokio::test]
+async fn a_superseded_signing_key_is_recovered_from_the_seed() {
+    use vta_sdk::client::{CreateDidWebvhRequest, VtaClient};
+    use vta_sdk::protocols::did_management::create::WebvhPathMode;
+    use vta_sdk::protocols::did_management::update::UpdateDidWebvhBody;
+
+    let mock = MockVta::start_with_webvh_host().await;
+    let token = mock
+        .ctx
+        .mint_token("did:key:z6MkWebvhAdmin", "admin", vec![])
+        .await;
+    let client = VtaClient::new(mock.base_url());
+    client.set_token_async(token).await;
+
+    let create = client
+        .create_did_webvh(CreateDidWebvhRequest {
+            context_id: "ctx1".into(),
+            server_id: Some(MockVta::WEBVH_SERVER_ID.into()),
+            url: None,
+            path: None,
+            path_mode: Some(WebvhPathMode::AutoAssign),
+            domain: None,
+            label: None,
+            portable: false,
+            add_mediator_service: false,
+            additional_services: None,
+            pre_rotation_count: 0,
+            did_document: None,
+            did_log: None,
+            set_primary: false,
+            signing_key_id: None,
+            ka_key_id: None,
+            template: None,
+            template_context: None,
+            template_vars: Default::default(),
+        })
+        .await
+        .expect("create server-managed DID");
+    let did = create.did.clone();
+    let scid = create.scid.clone();
+
+    let doc_update = |label: &str| {
+        let scid = scid.clone();
+        let did = did.clone();
+        let client = &client;
+        let body = UpdateDidWebvhBody {
+            document: Some(serde_json::json!({
+                "@context": ["https://www.w3.org/ns/did/v1"],
+                "id": did,
+                "verificationMethod": [{
+                    "id": format!("{did}#key-0"),
+                    "type": "Multikey",
+                    "controller": did,
+                    "publicKeyMultibase": "z6MkExternalPubForTest",
+                }],
+            })),
+            label: Some(label.into()),
+            ..Default::default()
+        };
+        async move { client.update_did_webvh("ctx1", &scid, body).await }
+    };
+
+    // v2: a document update rotates the update key; v2's handle is now active.
+    let v2 = doc_update("v2")
+        .await
+        .expect("first document update succeeds");
+
+    // Corrupt: move v2's key handles to `superseded:` — the exact state a
+    // failed-publish loop leaves the key the next update must sign with.
+    mock.corrupt_supersede_keys(&scid, &v2.new_version_id).await;
+
+    // The next update must still succeed: the resolver can't find v2's handle
+    // in the active prefix, so it re-derives the key from the seed.
+    doc_update("v3-after-corruption")
+        .await
+        .expect("update recovers by re-deriving the superseded signing key from the seed");
+
+    mock.shutdown().await;
+}


### PR DESCRIPTION
## The remaining wedge

After #730, *new* DIDs are fine, but a DID **already corrupted** by the old failed-publish loop still can't be edited — and #730 can't heal it, because #730 fixes a stale *published log*, while this failure is in *building* the next version.

## Root cause

`webvh_keys::find_handle_by_hash` searches only the **active** key prefix. `supersede_keys_for_version` **moves** a version's handles to `superseded:` when a later version rotates past it. The pre-#730 loop committed local-only versions that never reached the host, each superseding the previous — so the key the host's *current* entry still requires ends up in `superseded:`, invisible to the resolver. Every subsequent update then fails at signing:

> `no active update key for DID with SCID … — operator may need to restore key material from backup`

…and loops. This is exactly why your original DID keeps looping while fresh ones work.

## The fix — the seed *is* the backup

webvh keys are deterministic BIP-32 derivations, so a lost/superseded handle cache is not fatal. `load_active_update_key` and `load_pre_rotation_signing_key` now fall back — **after** the active-prefix and legacy lookups miss — to re-deriving the committed key from the seed: scan the indices the counter has handed out, derive each, match the committed hash, sign with it.

- A hash that matches **no** index the seed produced returns `None` — genuinely foreign key material, never ours to sign with. So this only ever recovers the VTA's own keys.
- Once the recovered update lands, the new version's handle is active again, so no re-derivation is needed next time — the scan happens once, on the healing update.

Net: the signing-key resolver is now **self-healing**. A stale or superseded handle cache can't wedge a DID, because the key the log commits to can always be reconstructed from the seed it came from.

## Test

`a_superseded_signing_key_is_recovered_from_the_seed`: create → document-update (rotates the key, supersedes the old) → **force the active version's handles into `superseded:`** (the test harness's `corrupt_supersede_keys`, reproducing the exact wedge) → update again. That last update succeeds *only* because the key is re-derived from the seed — without the fallback it fails with "no active update key." Existing update and mock-host tests are unchanged and green; fmt + clippy clean.

`webvh_keys` widened from private to `pub(crate)` so the harness can reproduce the corruption. vta-service 0.12.2 → 0.12.3.

## Validation

I could reproduce and fix the corruption against the mock, but not against your live `webvh.storm.ws` DID. After this deploys, editing your original wedged DID should now succeed (you'll see a VTA log line `recovered a signing key by re-deriving it from the seed`). If it still fails, grab that log context and the error — there may be a second corruption mode (e.g. a malformed local *log*, distinct from the key handles) that would need the log-rebuild variant of backward-recovery.