### PR TITLE
chore(vta-service): log the consent gate's mint/reuse/stale decision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10234,7 +10234,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.12.3"
+version = "0.12.4"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/trust_tasks/policy_gate.rs
+++ b/vta-service/src/trust_tasks/policy_gate.rs
@@ -274,6 +274,16 @@ async fn consent_gate(
             )
             .await
             {
+                tracing::info!(
+                    consent_diag = true,
+                    type_uri,
+                    digest = %digest.chars().take(12).collect::<String>(),
+                    grant_state_pin = ?grant.state_pin,
+                    grant_guards = ?grant.guards,
+                    %why,
+                    "consent-diag: grant CONSUMED but the re-planned world no longer matches it \
+                     — re-raising consent. If this line repeats, THIS is the loop."
+                );
                 return Some(reject_with(
                     doc,
                     RejectReason::TaskFailed {
@@ -288,7 +298,16 @@ async fn consent_gate(
             *delegated_out = grant.delegated_contexts;
             return None;
         }
-        Ok(None) => {}
+        Ok(None) => {
+            tracing::info!(
+                consent_diag = true,
+                type_uri,
+                requester = %auth.did,
+                digest = %digest.chars().take(12).collect::<String>(),
+                "consent-diag: no grant found for (requester, digest) — the approval has not landed \
+                 for this exact payload; will mint/reuse a pending below"
+            );
+        }
         Err(e) => return Some(app_error_to_reject(doc, e)),
     }
 
@@ -329,9 +348,30 @@ async fn consent_gate(
     let pending = match existing {
         Some(p) if p.state_pin == state_pin && p.guards == guards => {
             newly_raised = false;
+            tracing::info!(
+                consent_diag = true,
+                type_uri,
+                digest = %digest.chars().take(12).collect::<String>(),
+                "consent-diag: REUSING the outstanding pending (state_pin + guards unchanged) — \
+                 the code should stay the same; waiting on the approver's grant"
+            );
             p
         }
         Some(stale) => {
+            tracing::info!(
+                consent_diag = true,
+                type_uri,
+                digest = %digest.chars().take(12).collect::<String>(),
+                state_pin_changed = stale.state_pin != state_pin,
+                guards_changed = stale.guards != guards,
+                old_guards = ?stale.guards,
+                new_guards = ?guards,
+                old_state_pin = ?stale.state_pin,
+                new_state_pin = ?state_pin,
+                "consent-diag: RE-MINTING — the outstanding pending went stale, so a fresh code is \
+                 issued. `guards_changed`/`state_pin_changed` say which drifted. If this repeats, \
+                 THIS is why the code changes every time."
+            );
             if let Err(e) = consent::delete_pending(&state.task_consent_ks, &stale).await {
                 return Some(app_error_to_reject(doc, e));
             }


### PR DESCRIPTION
**Diagnostic only — no behavioural change.** This is the fast step before building the DID recovery, so I build the *right* recovery instead of inferring the corruption a third time.

## Why

A webvh update on certain existing DIDs loops on the consent ceremony: the gate re-raises `auth:consent_required` (→ 422 `taskFailed`) on every attempt, and the confirmation code changes each time. The DID is stuck at v1, its signing key resolves fine, and fresh DIDs work — so it's neither the publish path (#730) nor the key handles (#731). It's the consent gate re-minting, and the INFO logs don't reveal which of the three causes it is:

- no grant found (the approval never landed for this payload),
- grant consumed but the re-planned world no longer matches it (`assert_plan_still_holds` fails → `consent_stale`),
- the pending was re-minted because `state_pin` or `guards` drifted.

## What

Three INFO lines, all tagged `consent_diag=true`, at the gate's decision points:

- **no-grant** — logs requester + digest.
- **grant-stale** — logs the grant's pinned `state_pin`/`guards` and the reason the re-plan rejected it. *"If this repeats, THIS is the loop."*
- **reuse vs re-mint** — logs `guards_changed` / `state_pin_changed` and the before/after values, so a re-mint says exactly which field drifted.

One capture of a single failing edit on a stuck DID now pins the mechanism, so the startup self-heal / resync resets precisely the corrupted state.

vta-service 0.12.3 → 0.12.4.