### PR TITLE
feat(vtc): phase 4 — repoint the join-requests ceremony to spec/vtc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ## Unreleased
 
+### vta-sdk 0.19.19 / vtc-service — Phase 4: the join-requests ceremony moves to `spec/vtc`
+
+* The nine join-requests constants move to
+  `spec/vtc/join-requests/{submit,accept,status,manifest}/0.1` (and their
+  `#response` forms); the four admin REST mounts move to
+  `spec/vtc/join-requests/{list,show,approve,reject}/0.1`.
+* **Breaking for DIDComm/document peers**: the Trust Task `type` a holder
+  sends changes. `OpenVTC/openvtc#171` (merged) already teaches the
+  OpenVTC router to accept both prefixes; an openvtc build must take
+  vta-sdk 0.19.19 to *dispatch* the new types, since it matches on these
+  constants.
+* The GET list carries its own task instead of borrowing `submit`'s
+  descriptor — the shared-mount workaround was never necessary (axum
+  merges same-path method routers per method).
+* The two `*_RECEIPT_TYPE` constants stay on the `openvtc` authority:
+  a receipt is a fire-and-forget ack, not a Trust Task response, and the
+  registry publishes no receipt task.
+* `members/self-remove` is untouched here — moving only its DIDComm
+  constant would have left its REST mount on the old authority. The
+  members family moves as a unit in its own change.
+
 ### vtc-service — Phase 2a: `policy/*` repointed to the canonical registry
 
 Completes the vtc-service Trust Task migration's Phase 2. The policy

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,7 +400,7 @@ dependencies = [
  "trust-tasks-rs",
  "url",
  "uuid",
- "vta-sdk 0.19.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vta-sdk 0.19.18",
 ]
 
 [[package]]
@@ -2485,7 +2485,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.19.18",
+ "vta-sdk 0.19.19",
 ]
 
 [[package]]
@@ -3286,7 +3286,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.19.18",
+ "vta-sdk 0.19.19",
 ]
 
 [[package]]
@@ -6764,7 +6764,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.19.18",
+ "vta-sdk 0.19.19",
 ]
 
 [[package]]
@@ -10080,7 +10080,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.19",
  "tokio",
- "vta-sdk 0.19.18",
+ "vta-sdk 0.19.19",
  "vti-common",
  "x25519-dalek",
 ]
@@ -10113,7 +10113,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.19.18",
+ "vta-sdk 0.19.19",
 ]
 
 [[package]]
@@ -10136,12 +10136,45 @@ dependencies = [
  "tracing-subscriber",
  "trust-tasks-rs",
  "uniffi",
- "vta-sdk 0.19.18",
+ "vta-sdk 0.19.19",
 ]
 
 [[package]]
 name = "vta-sdk"
 version = "0.19.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c189650af46f061f2436fc5378507ec3b1ceadb3f529ebf2c5cb9fd39d8783e8"
+dependencies = [
+ "affinidi-crypto",
+ "affinidi-did-resolver-cache-sdk",
+ "affinidi-messaging-core",
+ "affinidi-messaging-delivery",
+ "affinidi-messaging-didcomm",
+ "affinidi-openid4vci",
+ "affinidi-openid4vp",
+ "affinidi-tdk",
+ "base64 0.22.1",
+ "chrono",
+ "curve25519-dalek",
+ "didwebvh-rs",
+ "ed25519-dalek",
+ "futures-util",
+ "getrandom 0.4.3",
+ "multibase",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "thiserror 2.0.19",
+ "tokio",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "vta-sdk"
+version = "0.19.19"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10197,39 +10230,6 @@ dependencies = [
  "x25519-dalek",
  "x509-parser 0.18.1",
  "zeroize",
-]
-
-[[package]]
-name = "vta-sdk"
-version = "0.19.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c189650af46f061f2436fc5378507ec3b1ceadb3f529ebf2c5cb9fd39d8783e8"
-dependencies = [
- "affinidi-crypto",
- "affinidi-did-resolver-cache-sdk",
- "affinidi-messaging-core",
- "affinidi-messaging-delivery",
- "affinidi-messaging-didcomm",
- "affinidi-openid4vci",
- "affinidi-openid4vp",
- "affinidi-tdk",
- "base64 0.22.1",
- "chrono",
- "curve25519-dalek",
- "didwebvh-rs",
- "ed25519-dalek",
- "futures-util",
- "getrandom 0.4.3",
- "multibase",
- "reqwest 0.13.4",
- "serde",
- "serde_json",
- "sha2 0.11.0",
- "thiserror 2.0.19",
- "tokio",
- "tracing",
- "url",
- "uuid",
 ]
 
 [[package]]
@@ -10314,7 +10314,7 @@ dependencies = [
  "utoipa-axum",
  "uuid",
  "vta-cli-common",
- "vta-sdk 0.19.18",
+ "vta-sdk 0.19.19",
  "vta-service",
  "vti-common",
  "vti-secrets",
@@ -10336,12 +10336,12 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.19",
  "tokio",
- "vta-sdk 0.19.18",
+ "vta-sdk 0.19.19",
 ]
 
 [[package]]
 name = "vtc-service"
-version = "0.11.17"
+version = "0.11.18"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",
@@ -10410,7 +10410,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.19.18",
+ "vta-sdk 0.19.19",
  "vtc-service",
  "vti-common",
  "vti-secrets",
@@ -10462,7 +10462,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.19.18",
+ "vta-sdk 0.19.19",
  "webauthn-rs",
  "zeroize",
 ]
@@ -10489,7 +10489,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.19.18",
+ "vta-sdk 0.19.19",
  "vta-service",
  "vti-common",
 ]
@@ -10518,7 +10518,7 @@ dependencies = [
  "tokio",
  "tracing",
  "vaultrs",
- "vta-sdk 0.19.18",
+ "vta-sdk 0.19.19",
  "vti-common",
 ]
 

--- a/trust-tasks/index.json
+++ b/trust-tasks/index.json
@@ -195,55 +195,63 @@
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/spec/join-requests/submit/1.0",
-      "status": "draft",
+      "status": "retired",
       "path": "join-requests/submit/1.0",
       "rest": "POST /v1/trust-tasks",
-      "didcomm": "https://trusttasks.org/openvtc/vtc/spec/join-requests/submit/1.0"
+      "didcomm": "https://trusttasks.org/openvtc/vtc/spec/join-requests/submit/1.0",
+      "supersededBy": "https://trusttasks.org/spec/vtc/join-requests/submit/0.1"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/join-requests/list/1.0",
-      "status": "draft",
+      "status": "retired",
       "path": "join-requests/list/1.0",
-      "rest": "GET /v1/join-requests"
+      "rest": "GET /v1/join-requests",
+      "supersededBy": "https://trusttasks.org/spec/vtc/join-requests/list/0.1"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/join-requests/show/1.0",
-      "status": "draft",
+      "status": "retired",
       "path": "join-requests/show/1.0",
-      "rest": "GET /v1/join-requests/{id}"
+      "rest": "GET /v1/join-requests/{id}",
+      "supersededBy": "https://trusttasks.org/spec/vtc/join-requests/show/0.1"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/join-requests/approve/1.0",
-      "status": "draft",
+      "status": "retired",
       "path": "join-requests/approve/1.0",
-      "rest": "POST /v1/join-requests/{id}/approve"
+      "rest": "POST /v1/join-requests/{id}/approve",
+      "supersededBy": "https://trusttasks.org/spec/vtc/join-requests/approve/0.1"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/join-requests/reject/1.0",
-      "status": "draft",
+      "status": "retired",
       "path": "join-requests/reject/1.0",
-      "rest": "POST /v1/join-requests/{id}/reject"
+      "rest": "POST /v1/join-requests/{id}/reject",
+      "supersededBy": "https://trusttasks.org/spec/vtc/join-requests/reject/0.1"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/spec/join-requests/accept/1.0",
-      "status": "draft",
+      "status": "retired",
       "path": "join-requests/accept/1.0",
       "rest": "POST /v1/trust-tasks",
-      "didcomm": "https://trusttasks.org/openvtc/vtc/spec/join-requests/accept/1.0"
+      "didcomm": "https://trusttasks.org/openvtc/vtc/spec/join-requests/accept/1.0",
+      "supersededBy": "https://trusttasks.org/spec/vtc/join-requests/accept/0.1"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/spec/join-requests/manifest/1.0",
-      "status": "draft",
+      "status": "retired",
       "path": "join-requests/manifest/1.0",
       "rest": "POST /v1/trust-tasks",
-      "didcomm": "https://trusttasks.org/openvtc/vtc/spec/join-requests/manifest/1.0"
+      "didcomm": "https://trusttasks.org/openvtc/vtc/spec/join-requests/manifest/1.0",
+      "supersededBy": "https://trusttasks.org/spec/vtc/join-requests/manifest/0.1"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/spec/join-requests/status/1.0",
-      "status": "draft",
+      "status": "retired",
       "path": "join-requests/status/1.0",
       "rest": "POST /v1/trust-tasks",
-      "didcomm": "https://trusttasks.org/openvtc/vtc/spec/join-requests/status/1.0"
+      "didcomm": "https://trusttasks.org/openvtc/vtc/spec/join-requests/status/1.0",
+      "supersededBy": "https://trusttasks.org/spec/vtc/join-requests/status/0.1"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/members/self-remove/1.0",

--- a/trust-tasks/join-requests/accept/1.0/spec.md
+++ b/trust-tasks/join-requests/accept/1.0/spec.md
@@ -1,7 +1,8 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/spec/join-requests/accept/1.0
 title: VTC Join Requests — Accept (reciprocal VMC)
-status: draft
+status: retired
+supersededBy: https://trusttasks.org/spec/vtc/join-requests/accept/0.1
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/join-requests/approve/1.0/spec.md
+++ b/trust-tasks/join-requests/approve/1.0/spec.md
@@ -1,7 +1,8 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/join-requests/approve/1.0
 title: VTC Join Requests — Approve
-status: draft
+status: retired
+supersededBy: https://trusttasks.org/spec/vtc/join-requests/approve/0.1
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/join-requests/list/1.0/spec.md
+++ b/trust-tasks/join-requests/list/1.0/spec.md
@@ -1,7 +1,8 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/join-requests/list/1.0
 title: VTC Join Requests — List
-status: draft
+status: retired
+supersededBy: https://trusttasks.org/spec/vtc/join-requests/list/0.1
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/join-requests/manifest/1.0/spec.md
+++ b/trust-tasks/join-requests/manifest/1.0/spec.md
@@ -1,7 +1,8 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/spec/join-requests/manifest/1.0
 title: VTC Join Requests — Manifest (discovery)
-status: draft
+status: retired
+supersededBy: https://trusttasks.org/spec/vtc/join-requests/manifest/0.1
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/join-requests/reject/1.0/spec.md
+++ b/trust-tasks/join-requests/reject/1.0/spec.md
@@ -1,7 +1,8 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/join-requests/reject/1.0
 title: VTC Join Requests — Reject
-status: draft
+status: retired
+supersededBy: https://trusttasks.org/spec/vtc/join-requests/reject/0.1
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/join-requests/show/1.0/spec.md
+++ b/trust-tasks/join-requests/show/1.0/spec.md
@@ -1,7 +1,8 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/join-requests/show/1.0
 title: VTC Join Requests — Show
-status: draft
+status: retired
+supersededBy: https://trusttasks.org/spec/vtc/join-requests/show/0.1
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/join-requests/status/1.0/spec.md
+++ b/trust-tasks/join-requests/status/1.0/spec.md
@@ -1,7 +1,8 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/spec/join-requests/status/1.0
 title: VTC Join Requests — Status (applicant poll)
-status: draft
+status: retired
+supersededBy: https://trusttasks.org/spec/vtc/join-requests/status/0.1
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/join-requests/submit/1.0/spec.md
+++ b/trust-tasks/join-requests/submit/1.0/spec.md
@@ -1,7 +1,8 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/spec/join-requests/submit/1.0
 title: VTC Join Requests — Submit (the ceremony `request` verb)
-status: draft
+status: retired
+supersededBy: https://trusttasks.org/spec/vtc/join-requests/submit/0.1
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.19.18"
+version = "0.19.19"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/protocols/join_requests.rs
+++ b/vta-sdk/src/protocols/join_requests.rs
@@ -7,17 +7,22 @@
 //! failures are framework `trust-task-error` documents, never DIDComm
 //! problem-reports.
 //!
-//! ## URI shape (framework-canonical, private-registry authority)
+//! ## URI shape (canonical registry)
 //!
 //! ```text
-//! https://trusttasks.org/openvtc/vtc/spec/join-requests/{verb}/{maj}.{min}
+//! https://trusttasks.org/spec/vtc/join-requests/{verb}/{maj}.{min}
 //! ```
 //!
-//! Authority `https://trusttasks.org/openvtc/vtc` (SPEC §6.5 private
-//! registry) + the mandatory `/spec/<slug>/<maj.min>` path shape, so the
-//! URIs parse as [`trust_tasks_rs::TypeUri`]. The earlier flat form (no
-//! `/spec/`) deserialised as a `&str` but failed
-//! `serde_json::from_slice::<TrustTask<Value>>`. The success-response
+//! These moved off the private `trusttasks.org/openvtc/vtc` authority
+//! (SPEC §6.5) and onto the canonical registry, where the ceremony's
+//! tasks are published as `spec/vtc/join-requests/*`. The path keeps the
+//! `/spec/<slug>/<maj.min>` shape the framework requires, so the URIs
+//! still parse as [`trust_tasks_rs::TypeUri`].
+//!
+//! The two `*_RECEIPT_TYPE` consts stay on the old authority on purpose:
+//! a receipt is a fire-and-forget ack rather than a Trust Task response,
+//! and the registry publishes no receipt task — emitting a canonical URI
+//! for one would name a spec that does not exist. The success-response
 //! variant is the same URI with a `#response` fragment (the
 //! `*_RESPONSE_TYPE` consts), minted by `TrustTask::respond_with`.
 //!
@@ -37,17 +42,24 @@ use uuid::Uuid;
 /// Trust Task `type` for a join-request submission (the ceremony `request`
 /// verb). Payload [`JoinRequestSubmitBody`]; response [`VerdictResponse`].
 pub const JOIN_REQUEST_SUBMIT_TYPE: &str =
-    "https://trusttasks.org/openvtc/vtc/spec/join-requests/submit/1.0";
+    "https://trusttasks.org/spec/vtc/join-requests/submit/0.1";
 
 /// `#response` variant of [`JOIN_REQUEST_SUBMIT_TYPE`] — the type of the
 /// success document `respond_with` mints; carries a [`VerdictResponse`].
 pub const JOIN_REQUEST_SUBMIT_RESPONSE_TYPE: &str =
-    "https://trusttasks.org/openvtc/vtc/spec/join-requests/submit/1.0#response";
+    "https://trusttasks.org/spec/vtc/join-requests/submit/0.1#response";
 
 /// Reply `type` used by the **credential-exchange** join close-the-loop
 /// (`credential-exchange/present`), which results in a join and echoes this
 /// receipt. Distinct from the Trust Task `submit` conversion above; retained
 /// for that not-yet-converted path. Carries a [`JoinRequestSubmitReceiptBody`].
+/// Async acknowledgement sent by the VTC after a submit. Deliberately
+/// still on the `openvtc/vtc/` authority: the canonical registry has no
+/// receipt task — the ceremony's canonical surface is
+/// submit/accept/status/manifest plus their `#response` forms, and a
+/// receipt is a separate fire-and-forget ack, not a Trust Task response.
+/// Inventing `spec/vtc/join-requests/submit-receipt` here would mean
+/// emitting a URI that resolves to nothing in the registry.
 pub const JOIN_REQUEST_SUBMIT_RECEIPT_TYPE: &str =
     "https://trusttasks.org/openvtc/vtc/spec/join-requests/submit-receipt/1.0";
 
@@ -85,12 +97,12 @@ pub struct JoinRequestSubmitBody {
 /// edge. `memberDid` is the TrustTask `issuer` (DIDComm authcrypt sender /
 /// REST document proof).
 pub const JOIN_REQUEST_ACCEPT_TYPE: &str =
-    "https://trusttasks.org/openvtc/vtc/spec/join-requests/accept/1.0";
+    "https://trusttasks.org/spec/vtc/join-requests/accept/0.1";
 
 /// `#response` variant of [`JOIN_REQUEST_ACCEPT_TYPE`] — carries a
 /// [`JoinRequestAcceptReceiptBody`].
 pub const JOIN_REQUEST_ACCEPT_RESPONSE_TYPE: &str =
-    "https://trusttasks.org/openvtc/vtc/spec/join-requests/accept/1.0#response";
+    "https://trusttasks.org/spec/vtc/join-requests/accept/0.1#response";
 
 /// Body of the accept message. `memberDid` comes from the DIDComm
 /// `from` field (the authcrypt sender) — the envelope binds the member,
@@ -128,12 +140,12 @@ pub struct JoinRequestAcceptReceiptBody {
 /// Trust Task `type` for a join-request manifest request: discover the
 /// community's join evidence requirements. Public read; empty payload.
 pub const JOIN_REQUEST_MANIFEST_TYPE: &str =
-    "https://trusttasks.org/openvtc/vtc/spec/join-requests/manifest/1.0";
+    "https://trusttasks.org/spec/vtc/join-requests/manifest/0.1";
 
 /// `#response` variant of [`JOIN_REQUEST_MANIFEST_TYPE`] — carries a
 /// [`JoinRequestManifestResponseBody`].
 pub const JOIN_REQUEST_MANIFEST_RESPONSE_TYPE: &str =
-    "https://trusttasks.org/openvtc/vtc/spec/join-requests/manifest/1.0#response";
+    "https://trusttasks.org/spec/vtc/join-requests/manifest/0.1#response";
 
 /// One community evidence requirement — a named DCQL Presentation
 /// Definition the applicant may present against.
@@ -163,12 +175,12 @@ pub struct JoinRequestManifestResponseBody {
 /// Trust Task `type` for an applicant status poll. The applicant DID is
 /// the TrustTask `issuer` (DIDComm authcrypt sender / REST document proof).
 pub const JOIN_REQUEST_STATUS_TYPE: &str =
-    "https://trusttasks.org/openvtc/vtc/spec/join-requests/status/1.0";
+    "https://trusttasks.org/spec/vtc/join-requests/status/0.1";
 
 /// `#response` variant of [`JOIN_REQUEST_STATUS_TYPE`] — carries a
 /// [`JoinRequestStatusResponseBody`].
 pub const JOIN_REQUEST_STATUS_RESPONSE_TYPE: &str =
-    "https://trusttasks.org/openvtc/vtc/spec/join-requests/status/1.0#response";
+    "https://trusttasks.org/spec/vtc/join-requests/status/0.1#response";
 
 /// Body of the status message (DIDComm). Over REST the `{id}` is the
 /// path segment; over DIDComm it travels here.
@@ -334,6 +346,9 @@ pub const MEMBER_SELF_REMOVE_TYPE: &str =
     "https://trusttasks.org/openvtc/vtc/members/self-remove/1.0";
 
 /// VTC's reply with the resolved disposition + audit hint.
+/// Async acknowledgement for a self-remove. Stays on `openvtc/vtc/`
+/// for the same reason as [`JOIN_REQUEST_SUBMIT_RECEIPT_TYPE`] — no
+/// canonical receipt task exists.
 pub const MEMBER_SELF_REMOVE_RECEIPT_TYPE: &str =
     "https://trusttasks.org/openvtc/vtc/members/self-remove-receipt/1.0";
 

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.11.17"
+version = "0.11.18"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vtc-service/admin-ui/src/plugins/ceremonies.tsx
+++ b/vtc-service/admin-ui/src/plugins/ceremonies.tsx
@@ -53,7 +53,7 @@ import {
 
 const TRUST_TASK_TEST = "https://trusttasks.org/openvtc/vtc/policies/test/1.0";
 const TRUST_TASK_JOIN_REQUESTS =
-  "https://trusttasks.org/openvtc/vtc/join-requests/submit/1.0";
+  "https://trusttasks.org/spec/vtc/join-requests/list/0.1";
 
 // Queues a refer verdict can route to that map to an actionable admin
 // surface. The moderator queue is the join-requests inbox.

--- a/vtc-service/admin-ui/src/plugins/joinRequests.tsx
+++ b/vtc-service/admin-ui/src/plugins/joinRequests.tsx
@@ -19,13 +19,13 @@ import { useConfirm } from "@/components/ConfirmDialog";
 import { formatIso as formatDate } from "@/lib/format";
 
 const TRUST_TASK_SUBMIT =
-  "https://trusttasks.org/openvtc/vtc/join-requests/submit/1.0";
+  "https://trusttasks.org/spec/vtc/join-requests/list/0.1";
 const TRUST_TASK_SHOW =
-  "https://trusttasks.org/openvtc/vtc/join-requests/show/1.0";
+  "https://trusttasks.org/spec/vtc/join-requests/show/0.1";
 const TRUST_TASK_APPROVE =
-  "https://trusttasks.org/openvtc/vtc/join-requests/approve/1.0";
+  "https://trusttasks.org/spec/vtc/join-requests/approve/0.1";
 const TRUST_TASK_REJECT =
-  "https://trusttasks.org/openvtc/vtc/join-requests/reject/1.0";
+  "https://trusttasks.org/spec/vtc/join-requests/reject/0.1";
 
 type JoinStatus = "pending" | "approved" | "rejected" | "withdrawn" | "deferred";
 

--- a/vtc-service/src/routes/mod.rs
+++ b/vtc-service/src/routes/mod.rs
@@ -288,12 +288,12 @@ fn build_api_chain(_routing: &RoutingConfig, trust_xff: bool) -> OpenApiRouter<A
     // TrustTaskRouter doesn't support per-method Trust-Task
     // selectors yet. The standalone task exists on disk +
     // index.json so the soft-gate surface stays complete.
-    // POST + GET share `/v1/join-requests`. The `join-requests/list/1.0`
-    // Trust Task exists in index.json + on-disk spec/schema so the
-    // soft-gate surface stays complete; the wire enforcement here
-    // collapses to `join-requests/submit/1.0` until TrustTaskRouter
-    // gains per-method selectors (same workaround community/profile,
-    // admin/config, members/{did} use).
+    // POST + GET share `/v1/join-requests`, each carrying its own Trust
+    // Task. The earlier note here said enforcement had to collapse onto
+    // `submit` until TrustTaskRouter gained per-method selectors; that
+    // was mistaken — `task_routes` layers the *method* router and axum
+    // merges same-path routers per method, so both verbs are enforced
+    // independently.
     // The unauthenticated `/join-requests` POST submit, `/accept`, and
     // `/status` move to `build_unauth_routes` (P0.5) so the governor + 64 KiB
     // cap apply; their Trust Tasks are declared there. The admin GET list keeps
@@ -696,23 +696,26 @@ fn build_api_chain(_routing: &RoutingConfig, trust_xff: bool) -> OpenApiRouter<A
         ))
         // Join requests (Phase 1 M1.7–M1.10). The unauth POST submit /
         // accept / status live on the governed branch (`build_unauth_routes`,
-        // P0.5); the admin GET list keeps this `/join-requests` mount (axum
-        // merges this GET with the governed-branch POST submit).
+        // P0.5). The admin GET list shares the `/join-requests` path with
+        // the governed-branch POST submit, but now carries its OWN task:
+        // axum merges same-path method routers per method, so each verb
+        // enforces its own URI (see `vti_common::trust_task::openapi`).
+        // It no longer has to borrow `submit`'s descriptor.
         .routes(tt(
             routes!(join_requests::read::list_join_requests),
-            "https://trusttasks.org/openvtc/vtc/join-requests/submit/1.0",
+            "https://trusttasks.org/spec/vtc/join-requests/list/0.1",
         ))
         .routes(tt(
             routes!(join_requests::read::show_join_request),
-            "https://trusttasks.org/openvtc/vtc/join-requests/show/1.0",
+            "https://trusttasks.org/spec/vtc/join-requests/show/0.1",
         ))
         .routes(tt(
             routes!(join_requests::decide::approve),
-            "https://trusttasks.org/openvtc/vtc/join-requests/approve/1.0",
+            "https://trusttasks.org/spec/vtc/join-requests/approve/0.1",
         ))
         .routes(tt(
             routes!(join_requests::decide::reject),
-            "https://trusttasks.org/openvtc/vtc/join-requests/reject/1.0",
+            "https://trusttasks.org/spec/vtc/join-requests/reject/0.1",
         ))
         // (Manifest discovery moved to the single `POST /v1/trust-tasks`
         // document endpoint — `join-requests/manifest/1.0` is now a Trust

--- a/vtc-service/tests/join_didcomm.rs
+++ b/vtc-service/tests/join_didcomm.rs
@@ -47,7 +47,7 @@ fn response_payload(doc: serde_json::Value) -> serde_json::Value {
 use vta_sdk::vp::{HeldCredential, build_vp_token, select_credentials};
 
 const ADMIN_DID: &str = "did:key:z6MkJoinAdmin";
-const APPROVE_TASK: &str = "https://trusttasks.org/openvtc/vtc/join-requests/approve/1.0";
+const APPROVE_TASK: &str = "https://trusttasks.org/spec/vtc/join-requests/approve/0.1";
 
 /// Seed the join ceremony the same way `server::run` does at boot: default
 /// policies (so `join.rego` evaluates instead of failing closed), both status

--- a/vtc-service/tests/join_requests.rs
+++ b/vtc-service/tests/join_requests.rs
@@ -35,16 +35,16 @@ use vtc_service::test_support::TestVtc;
 const RP_ORIGIN: &str = "https://vtc.example.com";
 // The holder-facing verbs are now Trust Task **document** types (the `/spec/`
 // canonical form the dispatcher routes on).
-const SUBMIT_TASK: &str = "https://trusttasks.org/openvtc/vtc/spec/join-requests/submit/1.0";
-const ACCEPT_TASK: &str = "https://trusttasks.org/openvtc/vtc/spec/join-requests/accept/1.0";
-const MANIFEST_TASK: &str = "https://trusttasks.org/openvtc/vtc/spec/join-requests/manifest/1.0";
-const STATUS_TASK: &str = "https://trusttasks.org/openvtc/vtc/spec/join-requests/status/1.0";
+const SUBMIT_TASK: &str = "https://trusttasks.org/spec/vtc/join-requests/submit/0.1";
+const ACCEPT_TASK: &str = "https://trusttasks.org/spec/vtc/join-requests/accept/0.1";
+const MANIFEST_TASK: &str = "https://trusttasks.org/spec/vtc/join-requests/manifest/0.1";
+const STATUS_TASK: &str = "https://trusttasks.org/spec/vtc/join-requests/status/0.1";
 // The admin verbs remain header-gated REST routes (unchanged) — flat URIs.
 // The admin GET list shares the submit mount, so it gates on the flat submit URI.
-const LIST_TASK: &str = "https://trusttasks.org/openvtc/vtc/join-requests/submit/1.0";
-const SHOW_TASK: &str = "https://trusttasks.org/openvtc/vtc/join-requests/show/1.0";
-const APPROVE_TASK: &str = "https://trusttasks.org/openvtc/vtc/join-requests/approve/1.0";
-const REJECT_TASK: &str = "https://trusttasks.org/openvtc/vtc/join-requests/reject/1.0";
+const LIST_TASK: &str = "https://trusttasks.org/spec/vtc/join-requests/list/0.1";
+const SHOW_TASK: &str = "https://trusttasks.org/spec/vtc/join-requests/show/0.1";
+const APPROVE_TASK: &str = "https://trusttasks.org/spec/vtc/join-requests/approve/0.1";
+const REJECT_TASK: &str = "https://trusttasks.org/spec/vtc/join-requests/reject/0.1";
 /// The VTC DID the fixture configures — the issuer of every VMC and the
 /// community a reciprocal VC must acknowledge.
 const VTC_DID: &str = "did:webvh:vtc.example.com:abc";


### PR DESCRIPTION
**Step 2 of 3** in the cross-repo VTC Trust Task migration (#710). Step 1 — [OpenVTC/openvtc#171](https://github.com/OpenVTC/openvtc/pull/171), merged — taught openvtc's router to accept the canonical prefix. Step 3 bumps openvtc onto this SDK.

### What moves

**vta-sdk** — 9 constants → `spec/vtc/join-requests/{submit,accept,status,manifest}/0.1` + their `#response` forms.
**vtc-service** — 4 admin REST mounts → `spec/vtc/join-requests/{list,show,approve,reject}/0.1`.

Dispatch needed **no changes**: both `messaging.rs` and `trust_tasks/mod.rs` key on the SDK constants rather than URI literals, so they retarget automatically.

The **GET list finally carries its own task**. It had been borrowing `submit/1.0`'s descriptor because it shares a mount with the governed POST — on the belief that `TrustTaskRouter` needed per-method selectors. That was wrong (`task_routes` layers the *method* router; axum merges same-path routers per method), and this was the third copy of that stale comment. Corrected.

### Deliberately not moved

- **The two `*_RECEIPT_TYPE` constants** stay on the `openvtc` authority. A receipt is a fire-and-forget ack, not a Trust Task response, and the registry publishes **no receipt task** — minting `spec/vtc/join-requests/submit-receipt` would name a spec that doesn't exist. Both are commented so it doesn't read as an oversight.
- **`members/self-remove`**, even though its canonical task exists. The census caught that changing only its DIDComm constant would leave its REST mount on the old authority — splitting one task across two registries. The members family moves as a unit in its own PR. (`retired_tasks_are_not_bound` from #711 earned its keep here.)

### A trap for whoever does the remaining families

This family has **two URI shapes**: REST mounts used `openvtc/vtc/join-requests/{verb}/1.0`, while the *document* types used `openvtc/vtc/spec/join-requests/{verb}/1.0` — the extra `/spec/` infix is what makes them parse as a `TypeUri`. A rewrite matching only the first form leaves the document constants behind, and every holder-facing verb silently stops routing. 31 tests caught exactly that here.

### Verification

`cargo test --workspace`: **3638 passed, 0 failed**. `cargo clippy --workspace -D warnings` (as CI runs it) clean. `cargo fmt --all --check` clean. `tsc --noEmit` on the admin UI clean. Census green.

Note: `cargo clippy --workspace --all-targets` surfaces 6 pre-existing unused-import errors — I confirmed they reproduce on pristine `main` and they're invisible to CI, so they're out of scope here.

`vta-sdk` 0.19.19, `vtc-service` 0.11.18. The self-pin guard correctly reports a *pending* bump awaiting publish rather than failing.

### ⚠️ Deployment order

openvtc's **routing** already accepts the canonical prefix, but its **dispatch** compares against constants from whatever `vta-sdk` version it has pinned. It must take **0.19.19** before a migrated VTC talks to it — otherwise messages reach the handler and then fall through the type match. Step 3 is that bump.
