### PR TITLE
fix(vta-service): update the webvh update-key test call sites for the 5-arg signature

### DIFF
--- a/vta-service/src/operations/did_webvh/update/mod.rs
+++ b/vta-service/src/operations/did_webvh/update/mod.rs
@@ -350,9 +350,16 @@ mod tests {
         .await
         .unwrap();
 
-        let handle = load_active_update_key(&ks, scid, &[Multibase::from(pub_mb.clone())])
-            .await
-            .expect("found via webvh_keys");
+        let seed_store = MockSeedStore(Mutex::new(Some(vec![0x42u8; 32])));
+        let handle = load_active_update_key(
+            &ks,
+            &seed_store,
+            "m/26'/0'/0'",
+            scid,
+            &[Multibase::from(pub_mb.clone())],
+        )
+        .await
+        .expect("found via webvh_keys");
         assert_eq!(handle.hash, hash);
         assert_eq!(handle.version_id, "1-zV");
     }
@@ -380,9 +387,16 @@ mod tests {
         };
         ks.insert(format!("key:{key_id}"), &record).await.unwrap();
 
-        let handle = load_active_update_key(&ks, scid, &[Multibase::from(pub_mb.clone())])
-            .await
-            .expect("found via legacy fallback");
+        let seed_store = MockSeedStore(Mutex::new(Some(vec![0x42u8; 32])));
+        let handle = load_active_update_key(
+            &ks,
+            &seed_store,
+            "m/26'/0'/0'",
+            scid,
+            &[Multibase::from(pub_mb.clone())],
+        )
+        .await
+        .expect("found via legacy fallback");
         assert_eq!(handle.public_key, pub_mb);
         assert_eq!(handle.derivation_path, "m/26'/0'/0'/0");
         assert_eq!(handle.version_id, "legacy");
@@ -392,9 +406,16 @@ mod tests {
     async fn load_active_update_key_errors_when_no_match() {
         let ks = test_keys_ks().await;
         let pub_mb = test_pub_multibase();
-        let err = load_active_update_key(&ks, "Q123", &[Multibase::from(pub_mb)])
-            .await
-            .unwrap_err();
+        let seed_store = MockSeedStore(Mutex::new(Some(vec![0x42u8; 32])));
+        let err = load_active_update_key(
+            &ks,
+            &seed_store,
+            "m/26'/0'/0'",
+            "Q123",
+            &[Multibase::from(pub_mb)],
+        )
+        .await
+        .unwrap_err();
         assert!(
             matches!(err, UpdateDidWebvhError::Library(ref m) if m.contains("no active update key"))
         );
@@ -403,7 +424,10 @@ mod tests {
     #[tokio::test]
     async fn load_active_update_key_errors_on_empty_update_keys_list() {
         let ks = test_keys_ks().await;
-        let err = load_active_update_key(&ks, "Q", &[]).await.unwrap_err();
+        let seed_store = MockSeedStore(Mutex::new(Some(vec![0x42u8; 32])));
+        let err = load_active_update_key(&ks, &seed_store, "m/26'/0'/0'", "Q", &[])
+            .await
+            .unwrap_err();
         assert!(matches!(err, UpdateDidWebvhError::Library(ref m) if m.contains("no update_keys")));
     }
 


### PR DESCRIPTION
**`main` does not currently compile its `vta-service` lib-test target**, so every branch cut after #731 inherits a red `Test` job. This unblocks it.

### What happened

#731 gave `load_active_update_key` a `seed_store` + `base_path` so it can re-derive a superseded signing key. It updated the real caller in `orchestrator.rs` and the two tests it added — but **four older unit-test call sites in `update/mod.rs` kept the 3-arg form**:

```
error[E0061]: this function takes 5 arguments but 3 arguments were supplied
error[E0277]: the trait bound `str: vti_secrets::SeedStore` is not satisfied
```

(the `SeedStore` error is the positional fallout — `scid` lands where `seed_store` is expected).

### Why it got through

The breakage exists **only in the test target**. `cargo check` and `cargo clippy --workspace` — without `--all-targets` — compile the lib fine, so the fast gates stay green. Only the full `cargo test --workspace` that CI runs surfaces it.

### The fix

`MockSeedStore` already exists in that same test module (#731 added it for its own tests), so this just passes it plus the module's conventional `base_path` (`m/26'/0'/0'`).

All four tests exercise the `webvh_keys` fast path and never reach the re-derive fallback, so **the mock's seed is never consulted** and no assertion changes — this is purely making the call sites match the signature.

### Verification

`cargo test -p vta-service --lib did_webvh`: **98 passed, 0 failed**.
`cargo test --workspace`: **3639 passed, 0 failed**.
`cargo fmt --all --check` clean.

Kept deliberately separate from the VTC migration work in #733, which is blocked on this — an unrelated fix buried inside a migration PR would be harder to review and harder to revert.
