### PR TITLE
fix(vta-service): repair broken test build from #731 signature change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10234,7 +10234,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.12.4"
+version = "0.12.5"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.12.4"
+version = "0.12.5"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/operations/did_webvh/update/mod.rs
+++ b/vta-service/src/operations/did_webvh/update/mod.rs
@@ -350,9 +350,16 @@ mod tests {
         .await
         .unwrap();
 
-        let handle = load_active_update_key(&ks, scid, &[Multibase::from(pub_mb.clone())])
-            .await
-            .expect("found via webvh_keys");
+        let seed_store = MockSeedStore(Mutex::new(None));
+        let handle = load_active_update_key(
+            &ks,
+            &seed_store,
+            "m/26'/0'/0'",
+            scid,
+            &[Multibase::from(pub_mb.clone())],
+        )
+        .await
+        .expect("found via webvh_keys");
         assert_eq!(handle.hash, hash);
         assert_eq!(handle.version_id, "1-zV");
     }
@@ -380,9 +387,16 @@ mod tests {
         };
         ks.insert(format!("key:{key_id}"), &record).await.unwrap();
 
-        let handle = load_active_update_key(&ks, scid, &[Multibase::from(pub_mb.clone())])
-            .await
-            .expect("found via legacy fallback");
+        let seed_store = MockSeedStore(Mutex::new(None));
+        let handle = load_active_update_key(
+            &ks,
+            &seed_store,
+            "m/26'/0'/0'",
+            scid,
+            &[Multibase::from(pub_mb.clone())],
+        )
+        .await
+        .expect("found via legacy fallback");
         assert_eq!(handle.public_key, pub_mb);
         assert_eq!(handle.derivation_path, "m/26'/0'/0'/0");
         assert_eq!(handle.version_id, "legacy");
@@ -392,9 +406,19 @@ mod tests {
     async fn load_active_update_key_errors_when_no_match() {
         let ks = test_keys_ks().await;
         let pub_mb = test_pub_multibase();
-        let err = load_active_update_key(&ks, "Q123", &[Multibase::from(pub_mb)])
-            .await
-            .unwrap_err();
+        // A real seed is present, so the recovery fallback runs and re-derives
+        // keys — but none match this foreign pubkey, so it returns None and we
+        // fall through to the terminal "no active update key" error.
+        let seed_store = MockSeedStore(Mutex::new(Some(vec![0x42u8; 32])));
+        let err = load_active_update_key(
+            &ks,
+            &seed_store,
+            "m/26'/0'/0'",
+            "Q123",
+            &[Multibase::from(pub_mb)],
+        )
+        .await
+        .unwrap_err();
         assert!(
             matches!(err, UpdateDidWebvhError::Library(ref m) if m.contains("no active update key"))
         );
@@ -403,7 +427,10 @@ mod tests {
     #[tokio::test]
     async fn load_active_update_key_errors_on_empty_update_keys_list() {
         let ks = test_keys_ks().await;
-        let err = load_active_update_key(&ks, "Q", &[]).await.unwrap_err();
+        let seed_store = MockSeedStore(Mutex::new(None));
+        let err = load_active_update_key(&ks, &seed_store, "m/26'/0'/0'", "Q", &[])
+            .await
+            .unwrap_err();
         assert!(matches!(err, UpdateDidWebvhError::Library(ref m) if m.contains("no update_keys")));
     }
 


### PR DESCRIPTION
## Problem

`main` is red: #731 added `seed_store` and `base_path` parameters to `load_active_update_key` (to support the seed-backed recovery fallback) but did not update the four unit-test call sites in `operations/did_webvh/update/mod.rs`. The `--tests` build fails with:

```
error[E0061]: this function takes 5 arguments but 3 arguments were supplied
error[E0277]: the trait bound `str: vti_secrets::SeedStore` is not satisfied
```

(This slipped through because CI's default build doesn't compile the `webvh` test target.)

## Fix

Thread a `MockSeedStore` + `base_path` through each of the four call sites. The `errors_when_no_match` test gets a **real seed** so the recovery path actually runs, re-derives keys, finds no match for the foreign pubkey, returns `None`, and falls through to the terminal "no active update key" error it asserts on.

Test-only change; no library behavior change. Patch bump 0.12.4 → 0.12.5 to satisfy the version-bump guard.

## Verification

```
cargo test -p vta-service --features webvh   # 943 → all green (previously would not compile)
cargo fmt --check -p vta-service             # clean
```