### PR TITLE
chore(release): refresh the vta-sdk self-pin to 0.19.19

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,7 +400,7 @@ dependencies = [
  "trust-tasks-rs",
  "url",
  "uuid",
- "vta-sdk 0.19.18",
+ "vta-sdk 0.19.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -10141,39 +10141,6 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.19.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c189650af46f061f2436fc5378507ec3b1ceadb3f529ebf2c5cb9fd39d8783e8"
-dependencies = [
- "affinidi-crypto",
- "affinidi-did-resolver-cache-sdk",
- "affinidi-messaging-core",
- "affinidi-messaging-delivery",
- "affinidi-messaging-didcomm",
- "affinidi-openid4vci",
- "affinidi-openid4vp",
- "affinidi-tdk",
- "base64 0.22.1",
- "chrono",
- "curve25519-dalek",
- "didwebvh-rs",
- "ed25519-dalek",
- "futures-util",
- "getrandom 0.4.3",
- "multibase",
- "reqwest 0.13.4",
- "serde",
- "serde_json",
- "sha2 0.11.0",
- "thiserror 2.0.19",
- "tokio",
- "tracing",
- "url",
- "uuid",
-]
-
-[[package]]
-name = "vta-sdk"
 version = "0.19.19"
 dependencies = [
  "affinidi-bbs",
@@ -10230,6 +10197,39 @@ dependencies = [
  "x25519-dalek",
  "x509-parser 0.18.1",
  "zeroize",
+]
+
+[[package]]
+name = "vta-sdk"
+version = "0.19.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa4dadface2af16f9146338c6b3e6771381f43d29e2e7829d08ac4f66c4ab66f"
+dependencies = [
+ "affinidi-crypto",
+ "affinidi-did-resolver-cache-sdk",
+ "affinidi-messaging-core",
+ "affinidi-messaging-delivery",
+ "affinidi-messaging-didcomm",
+ "affinidi-openid4vci",
+ "affinidi-openid4vp",
+ "affinidi-tdk",
+ "base64 0.22.1",
+ "chrono",
+ "curve25519-dalek",
+ "didwebvh-rs",
+ "ed25519-dalek",
+ "futures-util",
+ "getrandom 0.4.3",
+ "multibase",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "thiserror 2.0.19",
+ "tokio",
+ "tracing",
+ "url",
+ "uuid",
 ]
 
 [[package]]


### PR DESCRIPTION
`vta-sdk 0.19.19` published with #733, so `Cargo.lock`'s registry self-pin can finally point at it. **Without this, `lockfile self-pins` fails on every branch cut from main** — this is the fifth time (#706, #711, #714, #720, now).

**One-line change**: the `vta-sdk` registry pin `0.19.18` → `0.19.19`. Guard now reports `ok vta-sdk: workspace 0.19.19 == locked registry copy 0.19.19`.

### Why this was opened by hand

The publish workflow tried and got as far as pushing its branch, then failed:

```
[new branch]  HEAD -> chore/self-pin-refresh-29908692772
##[warning]pushed chore/self-pin-refresh-29908692772 but could not open the PR — open it manually
```

The workflow declares `pull-requests: write` and the repo's `default_workflow_permissions` is `write`, so the blocker isn't token scope — it's the org/repo setting **"Allow GitHub Actions to create and approve pull requests"** (reflected as `can_approve_pull_request_reviews: false`). With that off, `gh pr create` from Actions is refused outright.

That's a **third** requirement for #721's mechanism to work unattended, alongside the two already known:

| setting | state | effect if unset |
|---|---|---|
| Allow Actions to create PRs | ❌ off | PR never opens (**current blocker**) |
| `allow_auto_merge` | ❌ off | PR opens but can't auto-merge |
| `SELF_PIN_REFRESH_TOKEN` | ❌ unset | PR opens, but no CI runs on it, so auto-merge never fires |

All three are needed; fixing only the token wouldn't have helped.

### ⚠️ Why not just merge the workflow's branch

Merging `chore/self-pin-refresh-29908692772` as-is would **delete `docs/05-design-notes/tee-dual-unlock.md` (557 lines)**. The workflow cuts its branch mid-run, and #736 merged in the meantime, so that branch carries a pre-#736 tree. This PR is a fresh branch off current main and touches `Cargo.lock` only.

There are now **four orphaned `chore/self-pin-refresh-*` branches** from previous failed releases, all safe to delete.
