### PR TITLE
feat(vta-service): audit the DTTE consent ceremony end to end

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10234,7 +10234,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.12.5"
+version = "0.12.6"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.12.5"
+version = "0.12.6"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/audit.rs
+++ b/vta-service/src/audit.rs
@@ -117,6 +117,47 @@ pub async fn record_with_detail(
     audit_ks.insert(key, &entry).await
 }
 
+/// Best-effort audit write for the DTTE consent ceremony.
+///
+/// The consent gate and the approver-decision handler are security-relevant but
+/// were entirely un-audited: a request raised, an approver's decision, a grant
+/// minted/consumed, and every rejection left no durable trace, so a looped or
+/// failed elevation was invisible after the fact. This records the whole chain
+/// (`consent.required` → `consent.decision` → `consent.granted` →
+/// `consent.consumed`) under stable action names.
+///
+/// A missing audit row must never change a gate/decision outcome — same contract
+/// as the orchestrator's post-update emission — so errors are logged and
+/// swallowed rather than propagated.
+pub async fn record_consent(
+    audit_ks: &KeyspaceHandle,
+    action: &str,
+    actor: &str,
+    resource: &str,
+    outcome: &str,
+    detail: Option<&str>,
+) {
+    if let Err(e) = record_with_detail(
+        audit_ks,
+        action,
+        actor,
+        Some(resource),
+        outcome,
+        None,
+        None,
+        detail,
+    )
+    .await
+    {
+        tracing::warn!(
+            action,
+            actor,
+            error = %e,
+            "DTTE consent audit emission failed; ceremony outcome is unaffected"
+        );
+    }
+}
+
 /// Remove audit log entries older than `retention_days`.
 pub async fn cleanup_expired_logs(
     audit_ks: &KeyspaceHandle,

--- a/vta-service/src/trust_tasks/policy_gate.rs
+++ b/vta-service/src/trust_tasks/policy_gate.rs
@@ -259,6 +259,15 @@ async fn consent_gate(
             // we go on to refuse. Re-submitting mints a fresh request, and the
             // approver is asked again against the world as it now is.
             if let Err(why) = approvals_still_authorize(&require, &members, &grant, &auth.did) {
+                crate::audit::record_consent(
+                    &state.audit_ks,
+                    "consent.consumed",
+                    &auth.did,
+                    type_uri,
+                    "denied:approver_no_longer_authorized",
+                    Some(&format!("digest={digest}; {why}")),
+                )
+                .await;
                 return Some(reject_with(
                     doc,
                     RejectReason::PermissionDenied { reason: why },
@@ -284,6 +293,15 @@ async fn consent_gate(
                     "consent-diag: grant CONSUMED but the re-planned world no longer matches it \
                      — re-raising consent. If this line repeats, THIS is the loop."
                 );
+                crate::audit::record_consent(
+                    &state.audit_ks,
+                    "consent.consumed",
+                    &auth.did,
+                    type_uri,
+                    "denied:plan_changed",
+                    Some(&format!("digest={digest}; {why}")),
+                )
+                .await;
                 return Some(reject_with(
                     doc,
                     RejectReason::TaskFailed {
@@ -295,6 +313,18 @@ async fn consent_gate(
             // The grant is authorized and the world still matches. If it carries
             // a delegation (approvers conferred a context the requester lacked),
             // hand it to the caller to widen `auth` for this one dispatch.
+            crate::audit::record_consent(
+                &state.audit_ks,
+                "consent.consumed",
+                &auth.did,
+                type_uri,
+                "success",
+                Some(&format!(
+                    "digest={digest}; approvers={}",
+                    grant.approvers.join(",")
+                )),
+            )
+            .await;
             *delegated_out = grant.delegated_contexts;
             return None;
         }
@@ -452,6 +482,28 @@ async fn consent_gate(
     if newly_raised {
         super::consent_request::push_signed_requests(state, &requests).await;
     }
+
+    // Durable record that a Destructive task was gated behind consent. Auditing
+    // on every re-submit (not just the newly-raised one) is deliberate: a wedged
+    // elevation shows up here as a run of `consent.required` rows with a stable
+    // digest and no matching `consent.consumed` — the loop, made visible after
+    // the fact without needing live logs.
+    crate::audit::record_consent(
+        &state.audit_ks,
+        "consent.required",
+        &auth.did,
+        type_uri,
+        if newly_raised {
+            "pending:raised"
+        } else {
+            "pending:reasked"
+        },
+        Some(&format!(
+            "digest={digest}; approverSet={}; minApprovals={min_approvals}; challenge={}",
+            require.approver_set, pending.challenge
+        )),
+    )
+    .await;
 
     Some(reject_with(
         doc,

--- a/vta-service/src/trust_tasks/task_consent.rs
+++ b/vta-service/src/trust_tasks/task_consent.rs
@@ -148,6 +148,18 @@ pub(super) async fn handle_decision(
     let pending = match consent::pending_by_wire_digest(ks, &payload.payload_digest, now).await {
         Ok(Some(p)) => p,
         Ok(None) => {
+            crate::audit::record_consent(
+                &state.audit_ks,
+                "consent.decision",
+                &approver,
+                &payload.payload_digest,
+                "denied:no_pending",
+                Some(
+                    "approver decided on a request that no longer exists (expired, \
+                      already resolved, or re-minted under a new challenge)",
+                ),
+            )
+            .await;
             return reject_with(
                 &doc,
                 RejectReason::TaskFailed {
@@ -161,6 +173,15 @@ pub(super) async fn handle_decision(
 
     // Bind the decision to this exact request.
     if payload.challenge != pending.challenge {
+        crate::audit::record_consent(
+            &state.audit_ks,
+            "consent.decision",
+            &approver,
+            &pending.type_uri,
+            "denied:challenge_mismatch",
+            Some(&format!("digest={}", pending.digest)),
+        )
+        .await;
         return reject_with(
             &doc,
             RejectReason::PermissionDenied {
@@ -180,6 +201,15 @@ pub(super) async fn handle_decision(
         .cloned()
         .unwrap_or_default();
     if !members.iter().any(|m| m == &approver) {
+        crate::audit::record_consent(
+            &state.audit_ks,
+            "consent.decision",
+            &approver,
+            &pending.type_uri,
+            "denied:not_a_member",
+            Some(&format!("approverSet={}", pending.approver_set)),
+        )
+        .await;
         return reject_with(
             &doc,
             RejectReason::PermissionDenied {
@@ -192,6 +222,15 @@ pub(super) async fn handle_decision(
     }
     // A requester can't approve their own task when the policy excludes them.
     if pending.exclude_requester && approver == pending.requester_did {
+        crate::audit::record_consent(
+            &state.audit_ks,
+            "consent.decision",
+            &approver,
+            &pending.type_uri,
+            "denied:requester_excluded",
+            None,
+        )
+        .await;
         return reject_with(
             &doc,
             RejectReason::PermissionDenied {
@@ -203,6 +242,15 @@ pub(super) async fn handle_decision(
     // A denial aborts the request.
     if payload.decision == Decision::Deny {
         let _ = consent::delete_pending(ks, &pending).await;
+        crate::audit::record_consent(
+            &state.audit_ks,
+            "consent.decision",
+            &approver,
+            &pending.type_uri,
+            "success:deny",
+            Some(&format!("digest={}", pending.digest)),
+        )
+        .await;
         return success_response(
             &doc,
             json!({ "status": "denied", "payloadDigest": payload.payload_digest }),
@@ -250,6 +298,36 @@ pub(super) async fn handle_decision(
             return app_error_to_reject(&doc, e);
         }
         let _ = consent::delete_pending(ks, &updated).await;
+        // The approval that crossed the threshold, then the grant it minted:
+        // two rows so the trail shows both the final approver and the single-use
+        // grant the requester will consume.
+        crate::audit::record_consent(
+            &state.audit_ks,
+            "consent.decision",
+            &approver,
+            &updated.type_uri,
+            "success:approve",
+            Some(&format!(
+                "digest={}; approvals={}/{}",
+                updated.digest,
+                updated.approvals.len(),
+                updated.min_approvals
+            )),
+        )
+        .await;
+        crate::audit::record_consent(
+            &state.audit_ks,
+            "consent.granted",
+            &updated.requester_did,
+            &updated.type_uri,
+            "success",
+            Some(&format!(
+                "digest={}; approvers={}",
+                updated.digest,
+                updated.approvals.join(",")
+            )),
+        )
+        .await;
         // Nudge the requester that a grant is ready, so it re-submits at once
         // instead of polling. Best-effort — the grant is already durable; a lost
         // notice only costs the requester a poll cycle.
@@ -270,6 +348,20 @@ pub(super) async fn handle_decision(
         );
     }
 
+    crate::audit::record_consent(
+        &state.audit_ks,
+        "consent.decision",
+        &approver,
+        &updated.type_uri,
+        "success:approve_partial",
+        Some(&format!(
+            "digest={}; approvals={}/{}",
+            updated.digest,
+            updated.approvals.len(),
+            updated.min_approvals
+        )),
+    )
+    .await;
     success_response(
         &doc,
         json!({


### PR DESCRIPTION
## Why

You asked: *are we writing all DTTE action requests and responses to the VTA audit trail?* The answer was **no** — there was not a single `audit::record` call in `policy_gate.rs`, `task_consent.rs`, or the consent stores. The only DTTE-adjacent audit write is the orchestrator's post-update row, and it fires **only on success, after publish**. So a consent request raised, an approver's decision, a grant minted/consumed, and every rejection left **no durable trace** — which is exactly why the webvh-update approval loop has been so hard to diagnose (invisible after the fact, and only reachable with live `RUST_LOG`).

This closes that gap and, in doing so, turns the audit trail into the diagnostic instrument we've been missing.

## What

A best-effort `audit::record_consent` helper, threaded through the whole ceremony under stable action names:

| action | when | outcomes |
|---|---|---|
| `consent.required` | task gated, approver(s) notified | `pending:raised` / `pending:reasked` |
| `consent.decision` | an approver decides | `success:approve` · `success:approve_partial` · `success:deny` · `denied:no_pending` · `denied:challenge_mismatch` · `denied:not_a_member` · `denied:requester_excluded` |
| `consent.granted` | threshold met, single-use grant minted | `success` |
| `consent.consumed` | requester consumes the grant | `success` · `denied:plan_changed` · `denied:approver_no_longer_authorized` |

Each row carries the internal digest, the requester/approver DID, the approver set, and the challenge in `detail`.

## The diagnostic payoff

Auditing on **every** re-submit (not just the newly-raised one) is deliberate. A wedged elevation now shows up in the trail as a run of `consent.required` rows with a **stable digest and no matching `consent.consumed`** — the loop, made visible after the fact. And when an approver's decision lands on a re-minted pending, we'll see `consent.decision / denied:no_pending` (or `denied:challenge_mismatch`) instead of having to guess — which is the leading hypothesis for the stuck DID.

## Contract

Same as the orchestrator's post-update emission: **a missing audit row never changes a gate/decision outcome** (log + swallow). Purely additive.

## Verification

```
cargo build -p vta-service --features webvh    # clean
cargo test  -p vta-service --features webvh    # all green (48 consent tests + full suite)
cargo fmt --check -p vta-service               # clean
```

Patch bump 0.12.5 → 0.12.6.