### PR TITLE
feat(vta-service): name inbound trust-task type + emit consent audit to log

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10234,7 +10234,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.12.6"
+version = "0.12.7"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.12.6"
+version = "0.12.7"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/audit.rs
+++ b/vta-service/src/audit.rs
@@ -129,6 +129,13 @@ pub async fn record_with_detail(
 /// A missing audit row must never change a gate/decision outcome — same contract
 /// as the orchestrator's post-update emission — so errors are logged and
 /// swallowed rather than propagated.
+///
+/// Emits to the `audit` tracing target *as well as* persisting to the keyspace.
+/// [`record_with_detail`] alone only writes to storage — the log-stream line
+/// comes from the [`audit!`] macro, which the other audit call sites invoke
+/// alongside `record`. Without emitting here, `consent.*` rows were queryable
+/// via the audit API but invisible in `RUST_LOG` output, so a live capture of a
+/// consent loop showed no consent activity at all. Emit both.
 pub async fn record_consent(
     audit_ks: &KeyspaceHandle,
     action: &str,
@@ -137,6 +144,29 @@ pub async fn record_consent(
     outcome: &str,
     detail: Option<&str>,
 ) {
+    // Emit to the `audit` target at a level that reflects the outcome: a denied
+    // decision/consume is ERROR (like the `audit!` macro's failure arm), while
+    // normal ceremony progress (pending raised, approval, grant, consume) is
+    // INFO — a Destructive task requiring consent is expected, not an error.
+    if outcome.starts_with("denied") {
+        tracing::event!(
+            target: "audit",
+            tracing::Level::ERROR,
+            action,
+            actor,
+            resource,
+            outcome,
+        );
+    } else {
+        tracing::event!(
+            target: "audit",
+            tracing::Level::INFO,
+            action,
+            actor,
+            resource,
+            outcome,
+        );
+    }
     if let Err(e) = record_with_detail(
         audit_ks,
         action,

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -451,6 +451,19 @@ pub(crate) async fn dispatch_trust_task_core(
     use wire_v0_2::{WIRE_VERSION, WireVersion};
     let type_uri = doc.type_uri.to_string();
 
+    // Name every inbound trust task at the one point all three transports (TSP,
+    // DIDComm, REST) converge, after the envelope parses. Without this the
+    // per-transport dispatch logs report only sender + status, so you cannot
+    // tell a `dids/update` submit from a `task-consent/decision` — which made a
+    // consent loop (requester re-submits pile up, the approver's decision never
+    // arrives) impossible to distinguish from the log alone.
+    tracing::info!(
+        type_uri = %type_uri,
+        actor = %auth.did,
+        id = %doc.id,
+        "trust-task received"
+    );
+
     // Blanket vault audit: capture the audit context BEFORE `doc` is moved
     // into dispatch. Every password-vault and credential-vault task — read or
     // write, success or denied — produces exactly one persisted audit row here


### PR DESCRIPTION
## Why

Diagnosing the webvh-update consent loop from a live VTA capture surfaced two observability holes that forced us to *infer* what was happening instead of *seeing* it:

1. **Inbound dispatch logs don't name the task type.** `TSP trust-task dispatched sender=… status=422` tells you a task arrived and its status, but not *what* it was. During the loop, we couldn't distinguish 'the requester keeps re-submitting `dids/update`' from 'the approver's `task-consent/decision` arrived and got rejected' — the single most important fork in the whole investigation.

2. **#738's `consent.*` audit rows persist but don't log.** `record_consent` wrote to the audit keyspace but never emitted the log-stream line (that comes from the `audit!` macro, which it didn't call). So a live `RUST_LOG` capture of the loop showed **no consent activity at all**, even though the rows were being written.

## What

- **One `trust-task received` INFO** at `dispatch_trust_task_core` — the single point all three transports (TSP, DIDComm, REST) converge, right after the envelope parses — naming `type_uri`, `actor`, `id`. Every inbound task is now named exactly once, regardless of transport.
- **`record_consent` now emits to the `audit` target** as well as persisting (denied → ERROR, normal ceremony progress → INFO). So `consent.required` / `consent.decision` / `consent.granted` / `consent.consumed` show up under `RUST_LOG=audit=info`.

## Payoff

A single `RUST_LOG=vta_service=info,audit=info` capture now names every inbound task and every consent-ceremony step. The next capture of the loop will show definitively whether a `task-consent/decision` ever reaches the VTA — which the current capture strongly suggests it does **not** (every inbound task is the requester's update re-submit; no decision, no grant, ever).

## Verification

```
cargo build -p vta-service --features webvh    # clean
cargo test  -p vta-service --features webvh --lib   # 944 passed
cargo fmt --check -p vta-service               # clean
```

Patch bump 0.12.6 → 0.12.7.