### PR TITLE
fix(deps): bump affinidi-messaging-sdk to 0.18.61 for websocket lifecycle fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,9 +455,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-sdk"
-version = "0.18.60"
+version = "0.18.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d435cbd3fabbca6bfdc7ecb56af0974cee5f5d4d8283436ba304aae1066b4368"
+checksum = "2944919beb7c602d439dcc8da10d13a346cd5637c2d96bba08c1854f5d1c90f6"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-authentication",


### PR DESCRIPTION
## Problem

TSP submissions to a deployed VTA round-trip only **intermittently**: the send reports success and the reply never arrives, in multi-minute bursts, while DIDComm over the same mediator stays reliable throughout. Failures are silent — nothing errors on either end.

## Why this bump

`affinidi-messaging-sdk` 0.18.61 fixes three websocket-lifecycle bugs. One describes the mechanism directly:

> **Reconnect backoff no longer resets on a connection that doesn't survive.** `connect_delay` was zeroed the moment a socket connected, and only escalated on connect *failures*. A socket that connects and is then closed by the mediator therefore never backed off past the first step. Two clients authenticated as the same DID duelling over the mediator's one-socket-per-DID slot each saw "connect → success → evicted", pinning both at a ~1s reconnect loop indefinitely (**observed: ~40 connects/sec sustained against a production mediator**).

A client stuck in an evict/reconnect storm holds no stable socket, so frames routed to it during the churn are lost with no error surfaced — which matches the observed good/bad windows. The other two fixes are in the same area:

- `graceful_shutdown` no longer leaves auto-reconnecting websockets holding the profile's mediator slot.
- `stop_websocket` no longer leaves a stale channel that made a stopped profile permanently unable to reconnect.

## Scope

**Lockfile-only.** `affinidi-messaging-sdk` is declared as `"0.18"` in both `vta-sdk` and `vta-service`, so this is a patch bump within the existing range — no manifest change.

## Verification

| Check | Result |
| --- | --- |
| `cargo check --workspace` | ✅ clean |
| `vta-service` tests | ✅ 1221 passed, 0 failed |
| `vta-sdk` tests | ✅ 386 passed |
| `vta-mobile-core` tests | ✅ 45 passed |
| `scripts/check-lockfile-self-pins.sh` | ✅ passes |

## What this does *not* do

- **Production impact is unverified.** Confirming it resolves the intermittency needs a redeploy and a re-run against the live VTA. The reasoning is the upstream changelog plus a matching symptom profile, not a live before/after.
- **It does not fix a second, distinct TSP receive bug.** That one reproduces *deterministically* against an embedded mediator: the mediator accepts, stores, and live-streams the frame to the client socket (its logs show `Sent message to client`), but the SDK's `live_stream_next_frame` never surfaces it as `InboundFrame::Tsp`. That is the same shape as the upstream `tsp_live_stream.rs` regression, recurring on the message-pickup path, and likely warrants an upstream issue against `affinidi-messaging-sdk`. A local reproduction exists and is not included here.

Two separate bugs wearing the same silent-drop mask; this PR addresses only the first.