### PR TITLE
feat(vta-service): log the cause when a webvh dids/update fails in execute

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10234,7 +10234,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.12.7"
+version = "0.12.8"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.12.7"
+version = "0.12.8"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/trust_tasks/webvh.rs
+++ b/vta-service/src/trust_tasks/webvh.rs
@@ -367,7 +367,21 @@ pub(super) async fn handle_dids_update(
     .await
     {
         Ok(body) => success_response(&doc, body),
-        Err(e) => app_error_to_reject(&doc, AppError::from(e)),
+        Err(e) => {
+            // A Destructive update that passed the consent gate and then failed
+            // in execute previously vanished into a bare 422 — no line named the
+            // cause, so a consent-approved-but-still-looping DID was undiagnosable
+            // from the log. The error's Display distinguishes the sub-causes
+            // (`reconcile publish_did: …`, `webvh server … missing`,
+            // `get_published_version: …`, a signing/library failure), so log it.
+            tracing::warn!(
+                did = %did,
+                error = %e,
+                "webvh dids/update execute failed after the consent gate passed — \
+                 returning task error to requester"
+            );
+            app_error_to_reject(&doc, AppError::from(e))
+        }
     }
 }
 


### PR DESCRIPTION
## Why

The 0.12.7 capture of the `magic-depart` loop proved the consent ceremony **works** — approve → grant → `consent.consumed success` every cycle — yet the dispatch still returns **422**. The task passes the consent gate and then fails inside `execute`, *before* it resolves the signing key (no second `resolving signing key` line). That points at an early execute step — most likely **#730's reconcile guard (step 4b)**, the only step that runs in Execute mode but not Plan mode.

But the exact cause is **invisible**: `handle_dids_update` maps the error straight through `app_error_to_reject` with no log line, so the failure just becomes a bare 422.

## What

Log the error at `WARN` in the `Err` arm before converting it. The `UpdateDidWebvhError` `Display` already distinguishes the sub-causes:
- `reconcile publish_did: …` (4b republish failed)
- `webvh server … missing` / `get_published_version: …` (4b pre-checks)
- a signing / library failure (later steps)

So one `RUST_LOG=vta_service=info` capture of the next attempt will name exactly where execute dies — and tell us whether the fix belongs in the #730 reconcile guard or elsewhere.

## Verification
```
cargo build -p vta-service --features webvh   # clean
cargo fmt --check -p vta-service              # clean
```
Patch bump 0.12.7 → 0.12.8.