### PR TITLE
feat(vtc): phase 4 — repoint the remaining vtc families to spec/vtc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 ## Unreleased
 
+### vtc-service 0.11.19 / vta-sdk 0.19.20 — Phase 4: the remaining vtc families move to `spec/vtc`
+
+* Every remaining VTC Trust Task with a canonical counterpart is repointed:
+  members (list/show/renew/rotate/rotate-challenge/self-remove/personhood),
+  relationships, endorsement-types, install/claim, admin/bootstrap,
+  auth/recognise, website (files/list, generations/list, rollback), and
+  `health/diagnostics` → `spec/vtc/registry/diagnostics/0.1`.
+* **Four shared mounts are now split, one canonical task per verb**:
+  `/members/{did}` (show/update/admin-remove), `/community/profile`
+  (show/update), `/credentials/endorsements` (issue/list) and
+  `/credentials/endorsements/{id}` (show/revoke). Seven of those tasks
+  previously existed only on disk and were never enforced on the wire.
+* **Breaking for clients that sent one verb's task for another.** The
+  bundled admin UI was sending the *show* task on `DELETE /members/{did}`
+  and on `PUT /community/profile`; both are fixed here, but any external
+  client doing the same now gets a 415.
+* `members/self-remove`'s SDK constant moves with the rest of the family
+  (held back from the join-requests change so members migrated as a unit).
+  openvtc needs one more `cargo update` after `vta-sdk 0.19.20` publishes.
+* Not included: website's raw-byte ops (`files/show`, `files/write`,
+  `deploy`) — Phase 4a decided those are not Trust Tasks, so they need
+  de-listing rather than repointing — `website/files/delete` (its mount is
+  a `ttl` chain sharing one layer across three verbs), and the families
+  with no canonical counterpart.
+
 ### vta-sdk 0.19.19 / vtc-service — Phase 4: the join-requests ceremony moves to `spec/vtc`
 
 * The nine join-requests constants move to

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,7 +400,7 @@ dependencies = [
  "trust-tasks-rs",
  "url",
  "uuid",
- "vta-sdk 0.19.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vta-sdk 0.19.19",
 ]
 
 [[package]]
@@ -2485,7 +2485,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.19.19",
+ "vta-sdk 0.19.20",
 ]
 
 [[package]]
@@ -3286,7 +3286,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.19.19",
+ "vta-sdk 0.19.20",
 ]
 
 [[package]]
@@ -6764,7 +6764,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.19.19",
+ "vta-sdk 0.19.20",
 ]
 
 [[package]]
@@ -10080,7 +10080,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.19",
  "tokio",
- "vta-sdk 0.19.19",
+ "vta-sdk 0.19.20",
  "vti-common",
  "x25519-dalek",
 ]
@@ -10113,7 +10113,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.19.19",
+ "vta-sdk 0.19.20",
 ]
 
 [[package]]
@@ -10136,12 +10136,45 @@ dependencies = [
  "tracing-subscriber",
  "trust-tasks-rs",
  "uniffi",
- "vta-sdk 0.19.19",
+ "vta-sdk 0.19.20",
 ]
 
 [[package]]
 name = "vta-sdk"
 version = "0.19.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa4dadface2af16f9146338c6b3e6771381f43d29e2e7829d08ac4f66c4ab66f"
+dependencies = [
+ "affinidi-crypto",
+ "affinidi-did-resolver-cache-sdk",
+ "affinidi-messaging-core",
+ "affinidi-messaging-delivery",
+ "affinidi-messaging-didcomm",
+ "affinidi-openid4vci",
+ "affinidi-openid4vp",
+ "affinidi-tdk",
+ "base64 0.22.1",
+ "chrono",
+ "curve25519-dalek",
+ "didwebvh-rs",
+ "ed25519-dalek",
+ "futures-util",
+ "getrandom 0.4.3",
+ "multibase",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "thiserror 2.0.19",
+ "tokio",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "vta-sdk"
+version = "0.19.20"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10197,39 +10230,6 @@ dependencies = [
  "x25519-dalek",
  "x509-parser 0.18.1",
  "zeroize",
-]
-
-[[package]]
-name = "vta-sdk"
-version = "0.19.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4dadface2af16f9146338c6b3e6771381f43d29e2e7829d08ac4f66c4ab66f"
-dependencies = [
- "affinidi-crypto",
- "affinidi-did-resolver-cache-sdk",
- "affinidi-messaging-core",
- "affinidi-messaging-delivery",
- "affinidi-messaging-didcomm",
- "affinidi-openid4vci",
- "affinidi-openid4vp",
- "affinidi-tdk",
- "base64 0.22.1",
- "chrono",
- "curve25519-dalek",
- "didwebvh-rs",
- "ed25519-dalek",
- "futures-util",
- "getrandom 0.4.3",
- "multibase",
- "reqwest 0.13.4",
- "serde",
- "serde_json",
- "sha2 0.11.0",
- "thiserror 2.0.19",
- "tokio",
- "tracing",
- "url",
- "uuid",
 ]
 
 [[package]]
@@ -10314,7 +10314,7 @@ dependencies = [
  "utoipa-axum",
  "uuid",
  "vta-cli-common",
- "vta-sdk 0.19.19",
+ "vta-sdk 0.19.20",
  "vta-service",
  "vti-common",
  "vti-secrets",
@@ -10336,12 +10336,12 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.19",
  "tokio",
- "vta-sdk 0.19.19",
+ "vta-sdk 0.19.20",
 ]
 
 [[package]]
 name = "vtc-service"
-version = "0.11.18"
+version = "0.11.19"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",
@@ -10410,7 +10410,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.19.19",
+ "vta-sdk 0.19.20",
  "vtc-service",
  "vti-common",
  "vti-secrets",
@@ -10462,7 +10462,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.19.19",
+ "vta-sdk 0.19.20",
  "webauthn-rs",
  "zeroize",
 ]
@@ -10489,7 +10489,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.19.19",
+ "vta-sdk 0.19.20",
  "vta-service",
  "vti-common",
 ]
@@ -10518,7 +10518,7 @@ dependencies = [
  "tokio",
  "tracing",
  "vaultrs",
- "vta-sdk 0.19.19",
+ "vta-sdk 0.19.20",
  "vti-common",
 ]
 

--- a/trust-tasks/admin/bootstrap/1.0/spec.md
+++ b/trust-tasks/admin/bootstrap/1.0/spec.md
@@ -1,7 +1,8 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/admin/bootstrap/1.0
 title: VTC Admin — Bootstrap
-status: draft
+status: retired
+supersededBy: https://trusttasks.org/spec/vtc/admin/bootstrap/0.1
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/auth/recognise/1.0/spec.md
+++ b/trust-tasks/auth/recognise/1.0/spec.md
@@ -1,7 +1,8 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/auth/recognise/1.0
 title: VTC — Cross-Community Session Mint
-status: draft
+status: retired
+supersededBy: https://trusttasks.org/spec/vtc/auth/recognise/0.1
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/community/profile/manage/1.0/spec.md
+++ b/trust-tasks/community/profile/manage/1.0/spec.md
@@ -1,7 +1,8 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/community/profile/manage/1.0
 title: VTC — Community Profile (Show + Update)
-status: draft
+status: retired
+supersededBy: https://trusttasks.org/spec/vtc/community/profile/show/0.1
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/credentials/endorsements/issue/1.0/spec.md
+++ b/trust-tasks/credentials/endorsements/issue/1.0/spec.md
@@ -1,7 +1,8 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/credentials/endorsements/issue/1.0
 title: VTC — Custom Endorsement Issue
-status: draft
+status: retired
+supersededBy: https://trusttasks.org/spec/vtc/endorsements/issue/0.1
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/credentials/endorsements/list/1.0/spec.md
+++ b/trust-tasks/credentials/endorsements/list/1.0/spec.md
@@ -1,7 +1,8 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/credentials/endorsements/list/1.0
 title: VTC — Custom Endorsement List
-status: draft
+status: retired
+supersededBy: https://trusttasks.org/spec/vtc/endorsements/list/0.1
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/credentials/endorsements/revoke/1.0/spec.md
+++ b/trust-tasks/credentials/endorsements/revoke/1.0/spec.md
@@ -1,7 +1,8 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/credentials/endorsements/revoke/1.0
 title: VTC — Custom Endorsement Revoke
-status: draft
+status: retired
+supersededBy: https://trusttasks.org/spec/vtc/endorsements/revoke/0.1
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/credentials/endorsements/show/1.0/spec.md
+++ b/trust-tasks/credentials/endorsements/show/1.0/spec.md
@@ -1,7 +1,8 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/credentials/endorsements/show/1.0
 title: VTC — Custom Endorsement Show
-status: draft
+status: retired
+supersededBy: https://trusttasks.org/spec/vtc/endorsements/show/0.1
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/endorsement-types/delete/1.0/spec.md
+++ b/trust-tasks/endorsement-types/delete/1.0/spec.md
@@ -1,7 +1,8 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/endorsement-types/delete/1.0
 title: VTC — Endorsement Type Delete
-status: draft
+status: retired
+supersededBy: https://trusttasks.org/spec/vtc/endorsement-types/delete/0.1
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/endorsement-types/register/1.0/spec.md
+++ b/trust-tasks/endorsement-types/register/1.0/spec.md
@@ -1,7 +1,8 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/endorsement-types/register/1.0
 title: VTC — Endorsement Type Register
-status: draft
+status: retired
+supersededBy: https://trusttasks.org/spec/vtc/endorsement-types/register/0.1
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/health/diagnostics/1.0/spec.md
+++ b/trust-tasks/health/diagnostics/1.0/spec.md
@@ -1,7 +1,8 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/health/diagnostics/1.0
 title: VTC — Trust-Registry Reconciler Diagnostics
-status: draft
+status: retired
+supersededBy: https://trusttasks.org/spec/vtc/registry/diagnostics/0.1
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/index.json
+++ b/trust-tasks/index.json
@@ -96,9 +96,10 @@
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/community/profile/manage/1.0",
-      "status": "draft",
+      "status": "retired",
       "path": "community/profile/manage/1.0",
-      "rest": "GET, PUT /v1/community/profile"
+      "rest": "GET, PUT /v1/community/profile",
+      "supersededBy": "https://trusttasks.org/spec/vtc/community/profile/show/0.1"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/admin/config/manage/1.0",
@@ -109,21 +110,24 @@
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/install/claim/start/1.0",
-      "status": "draft",
+      "status": "retired",
       "path": "install/claim/start/1.0",
-      "rest": "POST /v1/install/claim/start"
+      "rest": "POST /v1/install/claim/start",
+      "supersededBy": "https://trusttasks.org/spec/vtc/install/claim/start/0.1"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/install/claim/finish/1.0",
-      "status": "draft",
+      "status": "retired",
       "path": "install/claim/finish/1.0",
-      "rest": "POST /v1/install/claim/finish"
+      "rest": "POST /v1/install/claim/finish",
+      "supersededBy": "https://trusttasks.org/spec/vtc/install/claim/finish/0.1"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/admin/bootstrap/1.0",
-      "status": "draft",
+      "status": "retired",
       "path": "admin/bootstrap/1.0",
-      "rest": "POST /v1/admin/bootstrap"
+      "rest": "POST /v1/admin/bootstrap",
+      "supersededBy": "https://trusttasks.org/spec/vtc/admin/bootstrap/0.1"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/admin/passkeys/list/1.0",
@@ -171,21 +175,24 @@
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/members/list/1.0",
-      "status": "draft",
+      "status": "retired",
       "path": "members/list/1.0",
-      "rest": "GET /v1/members"
+      "rest": "GET /v1/members",
+      "supersededBy": "https://trusttasks.org/spec/vtc/members/list/0.1"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/members/show/1.0",
-      "status": "draft",
+      "status": "retired",
       "path": "members/show/1.0",
-      "rest": "GET /v1/members/{did}"
+      "rest": "GET /v1/members/{did}",
+      "supersededBy": "https://trusttasks.org/spec/vtc/members/show/0.1"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/members/update/1.0",
-      "status": "draft",
+      "status": "retired",
       "path": "members/update/1.0",
-      "rest": "PATCH /v1/members/{did}"
+      "rest": "PATCH /v1/members/{did}",
+      "supersededBy": "https://trusttasks.org/spec/vtc/members/update/0.1"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/members/promote-to-admin/1.0",
@@ -255,16 +262,18 @@
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/members/self-remove/1.0",
-      "status": "draft",
+      "status": "retired",
       "path": "members/self-remove/1.0",
       "rest": "DELETE /v1/members/me",
-      "didcomm": "https://trusttasks.org/openvtc/vtc/members/self-remove/1.0"
+      "didcomm": "https://trusttasks.org/openvtc/vtc/members/self-remove/1.0",
+      "supersededBy": "https://trusttasks.org/spec/vtc/members/self-remove/0.1"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/members/admin-remove/1.0",
-      "status": "draft",
+      "status": "retired",
       "path": "members/admin-remove/1.0",
-      "rest": "DELETE /v1/members/{did}"
+      "rest": "DELETE /v1/members/{did}",
+      "supersededBy": "https://trusttasks.org/spec/vtc/members/admin-remove/0.1"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/policies/upload/1.0",
@@ -302,45 +311,52 @@
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/members/renew/1.0",
-      "status": "draft",
+      "status": "retired",
       "path": "members/renew/1.0",
-      "rest": "POST /v1/members/me/renew"
+      "rest": "POST /v1/members/me/renew",
+      "supersededBy": "https://trusttasks.org/spec/vtc/members/renew/0.1"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/members/rotate-challenge/1.0",
-      "status": "draft",
+      "status": "retired",
       "path": "members/rotate-challenge/1.0",
-      "rest": "POST /v1/members/me/rotate/challenge"
+      "rest": "POST /v1/members/me/rotate/challenge",
+      "supersededBy": "https://trusttasks.org/spec/vtc/members/rotate-challenge/0.1"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/members/rotate/1.0",
-      "status": "draft",
+      "status": "retired",
       "path": "members/rotate/1.0",
-      "rest": "POST /v1/members/me/rotate"
+      "rest": "POST /v1/members/me/rotate",
+      "supersededBy": "https://trusttasks.org/spec/vtc/members/rotate/0.1"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/health/diagnostics/1.0",
-      "status": "draft",
+      "status": "retired",
       "path": "health/diagnostics/1.0",
-      "rest": "GET /v1/health/diagnostics"
+      "rest": "GET /v1/health/diagnostics",
+      "supersededBy": "https://trusttasks.org/spec/vtc/registry/diagnostics/0.1"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/auth/recognise/1.0",
-      "status": "draft",
+      "status": "retired",
       "path": "auth/recognise/1.0",
-      "rest": "POST /v1/auth/recognise"
+      "rest": "POST /v1/auth/recognise",
+      "supersededBy": "https://trusttasks.org/spec/vtc/auth/recognise/0.1"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/members/personhood/challenge/1.0",
-      "status": "draft",
+      "status": "retired",
       "path": "members/personhood/challenge/1.0",
-      "rest": "POST /v1/members/{did}/personhood/challenge"
+      "rest": "POST /v1/members/{did}/personhood/challenge",
+      "supersededBy": "https://trusttasks.org/spec/vtc/members/personhood/challenge/0.1"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/members/personhood/assert/1.0",
-      "status": "draft",
+      "status": "retired",
       "path": "members/personhood/assert/1.0",
-      "rest": "POST /v1/members/{did}/personhood"
+      "rest": "POST /v1/members/{did}/personhood",
+      "supersededBy": "https://trusttasks.org/spec/vtc/members/personhood/assert/0.1"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/members/personhood/revoke/1.0",
@@ -350,27 +366,31 @@
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/relationships/publish/1.0",
-      "status": "draft",
+      "status": "retired",
       "path": "relationships/publish/1.0",
-      "rest": "POST /v1/relationships"
+      "rest": "POST /v1/relationships",
+      "supersededBy": "https://trusttasks.org/spec/vtc/relationships/publish/0.1"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/relationships/list/1.0",
-      "status": "draft",
+      "status": "retired",
       "path": "relationships/list/1.0",
-      "rest": "GET /v1/members/{did}/relationships"
+      "rest": "GET /v1/members/{did}/relationships",
+      "supersededBy": "https://trusttasks.org/spec/vtc/relationships/list/0.1"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/relationships/revoke/1.0",
-      "status": "draft",
+      "status": "retired",
       "path": "relationships/revoke/1.0",
-      "rest": "DELETE /v1/relationships/{id}"
+      "rest": "DELETE /v1/relationships/{id}",
+      "supersededBy": "https://trusttasks.org/spec/vtc/relationships/revoke/0.1"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/endorsement-types/register/1.0",
-      "status": "draft",
+      "status": "retired",
       "path": "endorsement-types/register/1.0",
-      "rest": "POST /v1/endorsement-types"
+      "rest": "POST /v1/endorsement-types",
+      "supersededBy": "https://trusttasks.org/spec/vtc/endorsement-types/register/0.1"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/endorsement-types/list/1.0",
@@ -380,39 +400,45 @@
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/endorsement-types/delete/1.0",
-      "status": "draft",
+      "status": "retired",
       "path": "endorsement-types/delete/1.0",
-      "rest": "DELETE /v1/endorsement-types/{type_uri}"
+      "rest": "DELETE /v1/endorsement-types/{type_uri}",
+      "supersededBy": "https://trusttasks.org/spec/vtc/endorsement-types/delete/0.1"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/credentials/endorsements/issue/1.0",
-      "status": "draft",
+      "status": "retired",
       "path": "credentials/endorsements/issue/1.0",
-      "rest": "POST /v1/credentials/endorsements"
+      "rest": "POST /v1/credentials/endorsements",
+      "supersededBy": "https://trusttasks.org/spec/vtc/endorsements/issue/0.1"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/credentials/endorsements/list/1.0",
-      "status": "draft",
+      "status": "retired",
       "path": "credentials/endorsements/list/1.0",
-      "rest": "GET /v1/credentials/endorsements"
+      "rest": "GET /v1/credentials/endorsements",
+      "supersededBy": "https://trusttasks.org/spec/vtc/endorsements/list/0.1"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/credentials/endorsements/show/1.0",
-      "status": "draft",
+      "status": "retired",
       "path": "credentials/endorsements/show/1.0",
-      "rest": "GET /v1/credentials/endorsements/{id}"
+      "rest": "GET /v1/credentials/endorsements/{id}",
+      "supersededBy": "https://trusttasks.org/spec/vtc/endorsements/show/0.1"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/credentials/endorsements/revoke/1.0",
-      "status": "draft",
+      "status": "retired",
       "path": "credentials/endorsements/revoke/1.0",
-      "rest": "DELETE /v1/credentials/endorsements/{id}"
+      "rest": "DELETE /v1/credentials/endorsements/{id}",
+      "supersededBy": "https://trusttasks.org/spec/vtc/endorsements/revoke/0.1"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/website/files/list/1.0",
-      "status": "draft",
+      "status": "retired",
       "path": "website/files/list/1.0",
-      "rest": "GET /v1/website/files"
+      "rest": "GET /v1/website/files",
+      "supersededBy": "https://trusttasks.org/spec/vtc/website/files/list/0.1"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/website/files/show/1.0",
@@ -440,15 +466,17 @@
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/website/generations/list/1.0",
-      "status": "draft",
+      "status": "retired",
       "path": "website/generations/list/1.0",
-      "rest": "GET /v1/website/generations"
+      "rest": "GET /v1/website/generations",
+      "supersededBy": "https://trusttasks.org/spec/vtc/website/generations/list/0.1"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/website/rollback/1.0",
-      "status": "draft",
+      "status": "retired",
       "path": "website/rollback/1.0",
-      "rest": "POST /v1/website/rollback/{gen}"
+      "rest": "POST /v1/website/rollback/{gen}",
+      "supersededBy": "https://trusttasks.org/spec/vtc/website/rollback/0.1"
     }
   ]
 }

--- a/trust-tasks/install/claim/finish/1.0/spec.md
+++ b/trust-tasks/install/claim/finish/1.0/spec.md
@@ -1,7 +1,8 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/install/claim/finish/1.0
 title: VTC Install — Claim (Finish)
-status: draft
+status: retired
+supersededBy: https://trusttasks.org/spec/vtc/install/claim/finish/0.1
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/install/claim/start/1.0/spec.md
+++ b/trust-tasks/install/claim/start/1.0/spec.md
@@ -1,7 +1,8 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/install/claim/start/1.0
 title: VTC Install — Claim (Start)
-status: draft
+status: retired
+supersededBy: https://trusttasks.org/spec/vtc/install/claim/start/0.1
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/members/admin-remove/1.0/spec.md
+++ b/trust-tasks/members/admin-remove/1.0/spec.md
@@ -1,7 +1,8 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/members/admin-remove/1.0
 title: VTC Members — Admin Remove
-status: draft
+status: retired
+supersededBy: https://trusttasks.org/spec/vtc/members/admin-remove/0.1
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/members/list/1.0/spec.md
+++ b/trust-tasks/members/list/1.0/spec.md
@@ -1,7 +1,8 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/members/list/1.0
 title: VTC Members — List
-status: draft
+status: retired
+supersededBy: https://trusttasks.org/spec/vtc/members/list/0.1
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/members/personhood/assert/1.0/spec.md
+++ b/trust-tasks/members/personhood/assert/1.0/spec.md
@@ -1,7 +1,8 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/members/personhood/assert/1.0
 title: VTC — Personhood Assert
-status: draft
+status: retired
+supersededBy: https://trusttasks.org/spec/vtc/members/personhood/assert/0.1
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/members/personhood/challenge/1.0/spec.md
+++ b/trust-tasks/members/personhood/challenge/1.0/spec.md
@@ -1,7 +1,8 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/members/personhood/challenge/1.0
 title: VTC — Personhood Assert Challenge
-status: draft
+status: retired
+supersededBy: https://trusttasks.org/spec/vtc/members/personhood/challenge/0.1
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/members/renew/1.0/spec.md
+++ b/trust-tasks/members/renew/1.0/spec.md
@@ -1,7 +1,8 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/members/renew/1.0
 title: VTC Members — Renew
-status: draft
+status: retired
+supersededBy: https://trusttasks.org/spec/vtc/members/renew/0.1
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/members/rotate-challenge/1.0/spec.md
+++ b/trust-tasks/members/rotate-challenge/1.0/spec.md
@@ -1,7 +1,8 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/members/rotate-challenge/1.0
 title: VTC Members — DID Rotation Challenge
-status: draft
+status: retired
+supersededBy: https://trusttasks.org/spec/vtc/members/rotate-challenge/0.1
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/members/rotate/1.0/spec.md
+++ b/trust-tasks/members/rotate/1.0/spec.md
@@ -1,7 +1,8 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/members/rotate/1.0
 title: VTC Members — DID Rotation
-status: draft
+status: retired
+supersededBy: https://trusttasks.org/spec/vtc/members/rotate/0.1
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/members/self-remove/1.0/spec.md
+++ b/trust-tasks/members/self-remove/1.0/spec.md
@@ -1,7 +1,8 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/members/self-remove/1.0
 title: VTC Members — Self-Remove
-status: draft
+status: retired
+supersededBy: https://trusttasks.org/spec/vtc/members/self-remove/0.1
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/members/show/1.0/spec.md
+++ b/trust-tasks/members/show/1.0/spec.md
@@ -1,7 +1,8 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/members/show/1.0
 title: VTC Members — Show
-status: draft
+status: retired
+supersededBy: https://trusttasks.org/spec/vtc/members/show/0.1
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/members/update/1.0/spec.md
+++ b/trust-tasks/members/update/1.0/spec.md
@@ -1,7 +1,8 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/members/update/1.0
 title: VTC Members — Update
-status: draft
+status: retired
+supersededBy: https://trusttasks.org/spec/vtc/members/update/0.1
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/relationships/list/1.0/spec.md
+++ b/trust-tasks/relationships/list/1.0/spec.md
@@ -1,7 +1,8 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/relationships/list/1.0
 title: VTC — VRC List per Member
-status: draft
+status: retired
+supersededBy: https://trusttasks.org/spec/vtc/relationships/list/0.1
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/relationships/publish/1.0/spec.md
+++ b/trust-tasks/relationships/publish/1.0/spec.md
@@ -1,7 +1,8 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/relationships/publish/1.0
 title: VTC — VRC Publish
-status: draft
+status: retired
+supersededBy: https://trusttasks.org/spec/vtc/relationships/publish/0.1
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/relationships/revoke/1.0/spec.md
+++ b/trust-tasks/relationships/revoke/1.0/spec.md
@@ -1,7 +1,8 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/relationships/revoke/1.0
 title: VTC — VRC Revoke
-status: draft
+status: retired
+supersededBy: https://trusttasks.org/spec/vtc/relationships/revoke/0.1
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/website/files/list/1.0/spec.md
+++ b/trust-tasks/website/files/list/1.0/spec.md
@@ -1,7 +1,8 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/website/files/list/1.0
 title: VTC — Website files list
-status: draft
+status: retired
+supersededBy: https://trusttasks.org/spec/vtc/website/files/list/0.1
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/website/generations/list/1.0/spec.md
+++ b/trust-tasks/website/generations/list/1.0/spec.md
@@ -1,7 +1,8 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/website/generations/list/1.0
 title: VTC — Website generations list
-status: draft
+status: retired
+supersededBy: https://trusttasks.org/spec/vtc/website/generations/list/0.1
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/website/rollback/1.0/spec.md
+++ b/trust-tasks/website/rollback/1.0/spec.md
@@ -1,7 +1,8 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/website/rollback/1.0
 title: VTC — Website generation rollback
-status: draft
+status: retired
+supersededBy: https://trusttasks.org/spec/vtc/website/rollback/0.1
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.19.19"
+version = "0.19.20"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/protocols/join_requests.rs
+++ b/vta-sdk/src/protocols/join_requests.rs
@@ -342,8 +342,7 @@ impl VerdictResponse {
 // ---------------------------------------------------------------------------
 
 /// DIDComm `type` for a member-side self-removal.
-pub const MEMBER_SELF_REMOVE_TYPE: &str =
-    "https://trusttasks.org/openvtc/vtc/members/self-remove/1.0";
+pub const MEMBER_SELF_REMOVE_TYPE: &str = "https://trusttasks.org/spec/vtc/members/self-remove/0.1";
 
 /// VTC's reply with the resolved disposition + audit hint.
 /// Async acknowledgement for a self-remove. Stays on `openvtc/vtc/`

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.11.18"
+version = "0.11.19"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vtc-service/admin-ui/src/lib/api.ts
+++ b/vtc-service/admin-ui/src/lib/api.ts
@@ -202,7 +202,7 @@ export const fetchBuildInfo = (): Promise<BuildInfo> =>
   getJsonExempt<BuildInfo>("/admin/build-info.json");
 
 const DIAGNOSTICS_TASK =
-  "https://trusttasks.org/openvtc/vtc/health/diagnostics/1.0";
+  "https://trusttasks.org/spec/vtc/registry/diagnostics/0.1";
 
 // Admin-gated identity + reconciler diagnostics. The dashboard reads
 // `vta_did` / `mediator_did` from here since P3.7 stripped them off

--- a/vtc-service/admin-ui/src/pages/Install.tsx
+++ b/vtc-service/admin-ui/src/pages/Install.tsx
@@ -21,11 +21,11 @@ import {
 } from "@/lib/webauthn";
 
 const TRUST_TASK_START =
-  "https://trusttasks.org/openvtc/vtc/install/claim/start/1.0";
+  "https://trusttasks.org/spec/vtc/install/claim/start/0.1";
 const TRUST_TASK_FINISH =
-  "https://trusttasks.org/openvtc/vtc/install/claim/finish/1.0";
+  "https://trusttasks.org/spec/vtc/install/claim/finish/0.1";
 const TRUST_TASK_BOOTSTRAP =
-  "https://trusttasks.org/openvtc/vtc/admin/bootstrap/1.0";
+  "https://trusttasks.org/spec/vtc/admin/bootstrap/0.1";
 
 type Phase =
   | { kind: "awaiting-code" }

--- a/vtc-service/admin-ui/src/plugins/members.tsx
+++ b/vtc-service/admin-ui/src/plugins/members.tsx
@@ -32,13 +32,17 @@ import {
 } from "@/lib/webauthn";
 
 const TRUST_TASK_LIST =
-  "https://trusttasks.org/openvtc/vtc/members/list/1.0";
+  "https://trusttasks.org/spec/vtc/members/list/0.1";
 // `members/show/1.0` covers GET + PATCH + DELETE on `/members/{did}`
 // today (TrustTaskRouter limitation). Server-side resolves the
 // actual operation by method; the header just needs to match the
 // router's registered task.
 const TRUST_TASK_SHOW =
-  "https://trusttasks.org/openvtc/vtc/members/show/1.0";
+  "https://trusttasks.org/spec/vtc/members/show/0.1";
+// DELETE /members/{did} is its own canonical task now that each verb on
+// the shared mount carries its own descriptor.
+const TRUST_TASK_ADMIN_REMOVE =
+  "https://trusttasks.org/spec/vtc/members/admin-remove/0.1";
 const TRUST_TASK_PROMOTE =
   "https://trusttasks.org/openvtc/vtc/members/promote-to-admin/1.0";
 const TRUST_TASK_REMOVED =
@@ -157,7 +161,7 @@ async function adminRemove(args: {
   // (`TrustTaskMismatch`, 415). The standalone admin-remove Trust Task still
   // exists on disk for the soft-gate surface.
   await deleteJson<unknown>(`/v1/members/${encodeURIComponent(args.did)}`, {
-    trustTask: TRUST_TASK_SHOW,
+    trustTask: TRUST_TASK_ADMIN_REMOVE,
     body: { reason: args.reason || null },
   });
 }

--- a/vtc-service/admin-ui/src/plugins/profile.tsx
+++ b/vtc-service/admin-ui/src/plugins/profile.tsx
@@ -12,7 +12,10 @@ import { Field } from "@/components/Field";
 import { getJson, putJson } from "@/lib/api";
 
 const TRUST_TASK =
-  "https://trusttasks.org/openvtc/vtc/community/profile/manage/1.0";
+  "https://trusttasks.org/spec/vtc/community/profile/show/0.1";
+// PUT carries the update task — GET and PUT are separate Trust Tasks.
+const TRUST_TASK_UPDATE =
+  "https://trusttasks.org/spec/vtc/community/profile/update/0.1";
 
 // GET /v1/community/profile wire shape: the persisted profile fields
 // are flattened at the top level (server uses `#[serde(flatten)]`),
@@ -51,7 +54,7 @@ async function putProfile(body: ProfileUpdateRequest): Promise<unknown> {
   // it — `onSuccess` invalidates the query, which refetches via
   // `getProfile` and seeds the form from the flat GET shape.
   return putJson<unknown>("/v1/community/profile", body, {
-    trustTask: TRUST_TASK,
+    trustTask: TRUST_TASK_UPDATE,
   });
 }
 

--- a/vtc-service/src/routes/mod.rs
+++ b/vtc-service/src/routes/mod.rs
@@ -348,7 +348,7 @@ fn build_api_chain(_routing: &RoutingConfig, trust_xff: bool) -> OpenApiRouter<A
     let api = OpenApiRouter::<AppState>::new()
         .routes(tt(
             routes!(health::diagnostics),
-            "https://trusttasks.org/openvtc/vtc/health/diagnostics/1.0",
+            "https://trusttasks.org/spec/vtc/registry/diagnostics/0.1",
         ))
         // BitstringStatusList publication (M2.11). Trust-Task-
         // exempt — external verifiers don't carry our extension
@@ -420,11 +420,12 @@ fn build_api_chain(_routing: &RoutingConfig, trust_xff: bool) -> OpenApiRouter<A
         // community/profile/update/1.0 lands when TrustTaskRouter
         // gains per-method task selectors in Phase 1+).
         .routes(tt(
-            routes!(
-                community::profile::get_profile,
-                community::profile::put_profile
-            ),
-            "https://trusttasks.org/openvtc/vtc/community/profile/manage/1.0",
+            routes!(community::profile::get_profile),
+            "https://trusttasks.org/spec/vtc/community/profile/show/0.1",
+        ))
+        .routes(tt(
+            routes!(community::profile::put_profile),
+            "https://trusttasks.org/spec/vtc/community/profile/update/0.1",
         ))
         // Public read of the community profile. Trust-Task-exempt and
         // unauthenticated — visitors landing on the default public
@@ -476,7 +477,7 @@ fn build_api_chain(_routing: &RoutingConfig, trust_xff: bool) -> OpenApiRouter<A
         // because the setup-session JWT IS the auth credential.
         .routes(tt(
             routes!(admin::bootstrap::bootstrap),
-            "https://trusttasks.org/openvtc/vtc/admin/bootstrap/1.0",
+            "https://trusttasks.org/spec/vtc/admin/bootstrap/0.1",
         ))
         // Admin passkey management (M0.6.3). Step-up UV is enforced
         // via the two-phase ceremony: `register/start` and
@@ -530,7 +531,7 @@ fn build_api_chain(_routing: &RoutingConfig, trust_xff: bool) -> OpenApiRouter<A
         // Members (Phase 1 M1.4–M1.6).
         .routes(tt(
             routes!(members::read::list_members),
-            "https://trusttasks.org/openvtc/vtc/members/list/1.0",
+            "https://trusttasks.org/spec/vtc/members/list/0.1",
         ))
         // Departed (tombstoned/historical) members + forceful purge. The
         // literal `/removed` must precede the `/{did}` catchall so axum's
@@ -549,25 +550,25 @@ fn build_api_chain(_routing: &RoutingConfig, trust_xff: bool) -> OpenApiRouter<A
         // and routes "me" as a literal DID.
         .routes(tt(
             routes!(members::remove::self_remove),
-            "https://trusttasks.org/openvtc/vtc/members/self-remove/1.0",
+            "https://trusttasks.org/spec/vtc/members/self-remove/0.1",
         ))
         // Renewal (M2.13). POST on its own mount so the
         // Trust Task header check + per-method selectors are
         // unambiguous.
         .routes(tt(
             routes!(members::renew::renew),
-            "https://trusttasks.org/openvtc/vtc/members/renew/1.0",
+            "https://trusttasks.org/spec/vtc/members/renew/0.1",
         ))
         // DID rotation (M2.15.1). Two-step ceremony — challenge
         // mints a single-use rotation_id, the finish endpoint
         // applies the co-signed swap atomically.
         .routes(tt(
             routes!(members::rotate::challenge),
-            "https://trusttasks.org/openvtc/vtc/members/rotate-challenge/1.0",
+            "https://trusttasks.org/spec/vtc/members/rotate-challenge/0.1",
         ))
         .routes(tt(
             routes!(members::rotate::rotate),
-            "https://trusttasks.org/openvtc/vtc/members/rotate/1.0",
+            "https://trusttasks.org/spec/vtc/members/rotate/0.1",
         ))
         // Reciprocal-VMC request — ask an active member to issue + send the
         // member → community half of the membership pair. The member replies
@@ -583,7 +584,7 @@ fn build_api_chain(_routing: &RoutingConfig, trust_xff: bool) -> OpenApiRouter<A
         // resource; `{did}` is the subject.
         .routes(tt(
             routes!(members::personhood::challenge),
-            "https://trusttasks.org/openvtc/vtc/members/personhood/challenge/1.0",
+            "https://trusttasks.org/spec/vtc/members/personhood/challenge/0.1",
         ))
         .routes(tt(
             routes!(members::personhood::assert, members::personhood::revoke), // POST + DELETE share `personhood/assert/1.0` at
@@ -592,7 +593,7 @@ fn build_api_chain(_routing: &RoutingConfig, trust_xff: bool) -> OpenApiRouter<A
             // exists on disk + in index.json so the soft-gate
             // surface stays complete. (Same workaround as
             // members/{did}'s show + update + admin-remove.)
-            "https://trusttasks.org/openvtc/vtc/members/personhood/assert/1.0",
+            "https://trusttasks.org/spec/vtc/members/personhood/assert/0.1",
         ))
         // Phase 4 M4.6 — VRC trust-graph endpoints. The
         // per-member list mounts under /v1/members/{did}/
@@ -600,7 +601,7 @@ fn build_api_chain(_routing: &RoutingConfig, trust_xff: bool) -> OpenApiRouter<A
         // (same path-trie precedence as personhood).
         .routes(tt(
             routes!(members::relationships::list),
-            "https://trusttasks.org/openvtc/vtc/relationships/list/1.0",
+            "https://trusttasks.org/spec/vtc/relationships/list/0.1",
         ))
         // Admin connections-graph view — the member-relationship (VRC) graph.
         .routes(tt(
@@ -609,11 +610,11 @@ fn build_api_chain(_routing: &RoutingConfig, trust_xff: bool) -> OpenApiRouter<A
         ))
         .routes(tt(
             routes!(relationships::publish),
-            "https://trusttasks.org/openvtc/vtc/relationships/publish/1.0",
+            "https://trusttasks.org/spec/vtc/relationships/publish/0.1",
         ))
         .routes(tt(
             routes!(relationships::revoke),
-            "https://trusttasks.org/openvtc/vtc/relationships/revoke/1.0",
+            "https://trusttasks.org/spec/vtc/relationships/revoke/0.1",
         ))
         // Phase 4 M4.8.1 — operator-uploaded endorsement type
         // registry. Admin-gated CRUD.
@@ -621,11 +622,11 @@ fn build_api_chain(_routing: &RoutingConfig, trust_xff: bool) -> OpenApiRouter<A
             routes!(endorsement_types::register, endorsement_types::list), // POST + GET share `register/1.0` at the router
             // layer pending per-method selectors; standalone
             // `list/1.0` exists on disk + in index.json.
-            "https://trusttasks.org/openvtc/vtc/endorsement-types/register/1.0",
+            "https://trusttasks.org/spec/vtc/endorsement-types/register/0.1",
         ))
         .routes(tt(
             routes!(endorsement_types::delete),
-            "https://trusttasks.org/openvtc/vtc/endorsement-types/delete/1.0",
+            "https://trusttasks.org/spec/vtc/endorsement-types/delete/0.1",
         ))
         // Phase 2 §8 — community schema store (Issues + Accepts
         // registry). Plain admin-gated CRUD (AdminAuth extractor),
@@ -644,10 +645,12 @@ fn build_api_chain(_routing: &RoutingConfig, trust_xff: bool) -> OpenApiRouter<A
         // Phase 4 M4.8.2-4 — custom endorsement issuance +
         // retrieval + revocation. Admin OR Issuer-role member.
         .routes(tt(
-            routes!(endorsements::issue, endorsements::list), // POST + GET share `issue/1.0` at the router
-            // layer pending per-method selectors; standalone
-            // `list/1.0` exists on disk + in index.json.
-            "https://trusttasks.org/openvtc/vtc/credentials/endorsements/issue/1.0",
+            routes!(endorsements::issue),
+            "https://trusttasks.org/spec/vtc/endorsements/issue/0.1",
+        ))
+        .routes(tt(
+            routes!(endorsements::list),
+            "https://trusttasks.org/spec/vtc/endorsements/list/0.1",
         ))
         // Invitation Credential (VIC) issuance + listing — the operator side of
         // the VIC auto-join ceremony. Admin / Moderator / Issuer. POST + GET on
@@ -668,23 +671,30 @@ fn build_api_chain(_routing: &RoutingConfig, trust_xff: bool) -> OpenApiRouter<A
             "https://trusttasks.org/openvtc/vtc/recognition/check/1.0",
         ))
         .routes(tt(
-            routes!(endorsements::show, endorsements::revoke), // GET + DELETE share `show/1.0` at the router
-            // layer pending per-method selectors; standalone
-            // `revoke/1.0` exists on disk + in index.json.
-            "https://trusttasks.org/openvtc/vtc/credentials/endorsements/show/1.0",
+            routes!(endorsements::show),
+            "https://trusttasks.org/spec/vtc/endorsements/show/0.1",
         ))
         .routes(tt(
-            routes!(
-                members::read::show_member,
-                members::update::update_member,
-                members::remove::admin_remove
-            ), // GET + PATCH + DELETE share `members/show/1.0` at the
-            // router layer pending per-method selectors; the
-            // standalone `members/update/1.0` and
-            // `members/admin-remove/1.0` Trust Tasks exist on
-            // disk + in index.json so the soft-gate surface stays
-            // complete.
-            "https://trusttasks.org/openvtc/vtc/members/show/1.0",
+            routes!(endorsements::revoke),
+            "https://trusttasks.org/spec/vtc/endorsements/revoke/0.1",
+        ))
+        // GET / PATCH / DELETE on `/members/{did}` each carry their own
+        // canonical task. They shared `members/show/1.0` while the
+        // router was believed to need per-method selectors; it does not
+        // (`task_routes` layers the method router, axum merges same-path
+        // routers per method), so the three tasks are now enforced
+        // independently instead of one standing in for all three.
+        .routes(tt(
+            routes!(members::read::show_member),
+            "https://trusttasks.org/spec/vtc/members/show/0.1",
+        ))
+        .routes(tt(
+            routes!(members::update::update_member),
+            "https://trusttasks.org/spec/vtc/members/update/0.1",
+        ))
+        .routes(tt(
+            routes!(members::remove::admin_remove),
+            "https://trusttasks.org/spec/vtc/members/admin-remove/0.1",
         ))
         .routes(tt(
             routes!(members::promote::promote_start),
@@ -782,7 +792,7 @@ fn build_api_chain(_routing: &RoutingConfig, trust_xff: bool) -> OpenApiRouter<A
             "/website/files",
             ttl(
                 get(website::files::list),
-                "https://trusttasks.org/openvtc/vtc/website/files/list/1.0",
+                "https://trusttasks.org/spec/vtc/website/files/list/0.1",
             ),
         )
         .route(
@@ -810,14 +820,14 @@ fn build_api_chain(_routing: &RoutingConfig, trust_xff: bool) -> OpenApiRouter<A
             "/website/generations",
             ttl(
                 get(website::generations::list),
-                "https://trusttasks.org/openvtc/vtc/website/generations/list/1.0",
+                "https://trusttasks.org/spec/vtc/website/generations/list/0.1",
             ),
         )
         .route(
             "/website/rollback/{gen_num}",
             ttl(
                 post(website::generations::rollback),
-                "https://trusttasks.org/openvtc/vtc/website/rollback/1.0",
+                "https://trusttasks.org/spec/vtc/website/rollback/0.1",
             ),
         )
     };
@@ -963,11 +973,11 @@ fn build_unauth_routes(trust_xff: bool) -> OpenApiRouter<AppState> {
         ))
         .routes(tt(
             routes!(install::claim_start),
-            "https://trusttasks.org/openvtc/vtc/install/claim/start/1.0",
+            "https://trusttasks.org/spec/vtc/install/claim/start/0.1",
         ))
         .routes(tt(
             routes!(install::claim_finish),
-            "https://trusttasks.org/openvtc/vtc/install/claim/finish/1.0",
+            "https://trusttasks.org/spec/vtc/install/claim/finish/0.1",
         ))
         .routes(tt(
             routes!(recognise::recognise_challenge),
@@ -975,7 +985,7 @@ fn build_unauth_routes(trust_xff: bool) -> OpenApiRouter<AppState> {
         ))
         .routes(tt(
             routes!(recognise::recognise),
-            "https://trusttasks.org/openvtc/vtc/auth/recognise/1.0",
+            "https://trusttasks.org/spec/vtc/auth/recognise/0.1",
         ))
         // The single Trust Task document endpoint (P0.5: governed unauth
         // chain). The holder-facing join ceremony verbs (submit/request,

--- a/vtc-service/tests/admin_bootstrap.rs
+++ b/vtc-service/tests/admin_bootstrap.rs
@@ -34,9 +34,9 @@ use vtc_service::test_support::TestVtc;
 use common::webauthn_harness::SoftEd25519Authenticator;
 
 const RP_ORIGIN: &str = "https://vtc.example.com";
-const START_TASK: &str = "https://trusttasks.org/openvtc/vtc/install/claim/start/1.0";
-const FINISH_TASK: &str = "https://trusttasks.org/openvtc/vtc/install/claim/finish/1.0";
-const BOOTSTRAP_TASK: &str = "https://trusttasks.org/openvtc/vtc/admin/bootstrap/1.0";
+const START_TASK: &str = "https://trusttasks.org/spec/vtc/install/claim/start/0.1";
+const FINISH_TASK: &str = "https://trusttasks.org/spec/vtc/install/claim/finish/0.1";
+const BOOTSTRAP_TASK: &str = "https://trusttasks.org/spec/vtc/admin/bootstrap/0.1";
 
 struct Fixture {
     state: AppState,

--- a/vtc-service/tests/admin_config.rs
+++ b/vtc-service/tests/admin_config.rs
@@ -409,7 +409,7 @@ async fn get_with_wrong_trust_task_returns_415() {
         .uri("/v1/admin/config")
         .header(
             "Trust-Task",
-            "https://trusttasks.org/openvtc/vtc/community/profile/manage/1.0",
+            "https://trusttasks.org/spec/vtc/community/profile/show/0.1",
         )
         .header("Authorization", format!("Bearer {token}"))
         .body(Body::empty())

--- a/vtc-service/tests/audit_list.rs
+++ b/vtc-service/tests/audit_list.rs
@@ -16,7 +16,7 @@ use vtc_service::server::AppState;
 use vtc_service::test_support::TestVtc;
 
 const LIST_TASK: &str = "https://trusttasks.org/spec/audit/list/0.1";
-const PROFILE_TASK: &str = "https://trusttasks.org/openvtc/vtc/community/profile/manage/1.0";
+const PROFILE_TASK: &str = "https://trusttasks.org/spec/vtc/community/profile/update/0.1";
 
 struct Fixture {
     router: axum::Router,

--- a/vtc-service/tests/audit_verify.rs
+++ b/vtc-service/tests/audit_verify.rs
@@ -16,7 +16,7 @@ use vtc_service::server::AppState;
 use vtc_service::test_support::TestVtc;
 
 const VERIFY_TASK: &str = "https://trusttasks.org/spec/audit/verify/0.1";
-const PROFILE_TASK: &str = "https://trusttasks.org/openvtc/vtc/community/profile/manage/1.0";
+const PROFILE_TASK: &str = "https://trusttasks.org/spec/vtc/community/profile/update/0.1";
 
 struct Fixture {
     router: axum::Router,

--- a/vtc-service/tests/community_profile.rs
+++ b/vtc-service/tests/community_profile.rs
@@ -14,7 +14,8 @@ use vtc_service::community::{CommunityProfile, store_profile};
 use vtc_service::server::AppState;
 use vtc_service::test_support::TestVtc;
 
-const PROFILE_TASK: &str = "https://trusttasks.org/openvtc/vtc/community/profile/manage/1.0";
+const PROFILE_TASK: &str = "https://trusttasks.org/spec/vtc/community/profile/show/0.1";
+const PROFILE_UPDATE_TASK: &str = "https://trusttasks.org/spec/vtc/community/profile/update/0.1";
 
 struct Fixture {
     router: axum::Router,
@@ -127,7 +128,7 @@ async fn put_requires_admin_role() {
     let req = Request::builder()
         .method("PUT")
         .uri("/v1/community/profile")
-        .header("Trust-Task", PROFILE_TASK)
+        .header("Trust-Task", PROFILE_UPDATE_TASK)
         .header("Authorization", format!("Bearer {token}"))
         .header("Content-Type", "application/json")
         .body(Body::from(r#"{"name":"Renamed"}"#))
@@ -145,7 +146,7 @@ async fn put_updates_profile_and_lists_changed_fields() {
     let req = Request::builder()
         .method("PUT")
         .uri("/v1/community/profile")
-        .header("Trust-Task", PROFILE_TASK)
+        .header("Trust-Task", PROFILE_UPDATE_TASK)
         .header("Authorization", format!("Bearer {token}"))
         .header("Content-Type", "application/json")
         .body(Body::from(
@@ -173,7 +174,7 @@ async fn put_idempotent_noop_returns_empty_changeset() {
     let req = Request::builder()
         .method("PUT")
         .uri("/v1/community/profile")
-        .header("Trust-Task", PROFILE_TASK)
+        .header("Trust-Task", PROFILE_UPDATE_TASK)
         .header("Authorization", format!("Bearer {token}"))
         .header("Content-Type", "application/json")
         .body(Body::from(body))
@@ -192,7 +193,7 @@ async fn put_returns_404_when_profile_not_initialised() {
     let req = Request::builder()
         .method("PUT")
         .uri("/v1/community/profile")
-        .header("Trust-Task", PROFILE_TASK)
+        .header("Trust-Task", PROFILE_UPDATE_TASK)
         .header("Authorization", format!("Bearer {token}"))
         .header("Content-Type", "application/json")
         .body(Body::from(r#"{"name":"Renamed"}"#))
@@ -218,7 +219,7 @@ async fn put_rejects_oversized_extensions() {
     let req = Request::builder()
         .method("PUT")
         .uri("/v1/community/profile")
-        .header("Trust-Task", PROFILE_TASK)
+        .header("Trust-Task", PROFILE_UPDATE_TASK)
         .header("Authorization", format!("Bearer {token}"))
         .header("Content-Type", "application/json")
         .body(Body::from(body))
@@ -243,7 +244,7 @@ async fn put_does_not_accept_community_did_in_request() {
     let req = Request::builder()
         .method("PUT")
         .uri("/v1/community/profile")
-        .header("Trust-Task", PROFILE_TASK)
+        .header("Trust-Task", PROFILE_UPDATE_TASK)
         .header("Authorization", format!("Bearer {token}"))
         .header("Content-Type", "application/json")
         .body(Body::from(
@@ -274,7 +275,7 @@ async fn put_emits_profile_updated_audit_with_real_actor() {
     let req = Request::builder()
         .method("PUT")
         .uri("/v1/community/profile")
-        .header("Trust-Task", PROFILE_TASK)
+        .header("Trust-Task", PROFILE_UPDATE_TASK)
         .header("Authorization", format!("Bearer {token}"))
         .header("Content-Type", "application/json")
         .body(Body::from(r#"{"name":"Renamed","description":"new"}"#))
@@ -316,7 +317,7 @@ async fn put_503_when_audit_writer_missing() {
     let req = Request::builder()
         .method("PUT")
         .uri("/v1/community/profile")
-        .header("Trust-Task", PROFILE_TASK)
+        .header("Trust-Task", PROFILE_UPDATE_TASK)
         .header("Authorization", format!("Bearer {token}"))
         .header("Content-Type", "application/json")
         .body(Body::from(r#"{"name":"Renamed"}"#))
@@ -335,7 +336,7 @@ async fn put_idempotent_noop_does_not_need_audit_writer() {
     let req = Request::builder()
         .method("PUT")
         .uri("/v1/community/profile")
-        .header("Trust-Task", PROFILE_TASK)
+        .header("Trust-Task", PROFILE_UPDATE_TASK)
         .header("Authorization", format!("Bearer {token}"))
         .header("Content-Type", "application/json")
         .body(Body::from(r#"{"name":"Example Community"}"#)) // already the value

--- a/vtc-service/tests/diagnostics.rs
+++ b/vtc-service/tests/diagnostics.rs
@@ -16,7 +16,7 @@ use vtc_service::registry::{SyncJob, SyncJobKind, SyncJobState, store_sync_job};
 use vtc_service::server::AppState;
 use vtc_service::test_support::TestVtc;
 
-const DIAGNOSTICS_TASK: &str = "https://trusttasks.org/openvtc/vtc/health/diagnostics/1.0";
+const DIAGNOSTICS_TASK: &str = "https://trusttasks.org/spec/vtc/registry/diagnostics/0.1";
 
 struct Fixture {
     router: axum::Router,

--- a/vtc-service/tests/emergency_bootstrap.rs
+++ b/vtc-service/tests/emergency_bootstrap.rs
@@ -59,7 +59,7 @@ use vtc_service::server::AppState;
 use vtc_service::setup::VtcKeyBundle;
 
 const RP_ORIGIN: &str = "https://vtc.example.com";
-const CLAIM_START_TASK: &str = "https://trusttasks.org/openvtc/vtc/install/claim/start/1.0";
+const CLAIM_START_TASK: &str = "https://trusttasks.org/spec/vtc/install/claim/start/0.1";
 
 fn init_jwt_provider() {
     use std::sync::Once;

--- a/vtc-service/tests/endorsements.rs
+++ b/vtc-service/tests/endorsements.rs
@@ -28,10 +28,11 @@ use vtc_service::status_list;
 use vtc_service::test_support::TestVtc;
 
 const PUBLIC_URL: &str = "https://vtc.example.com";
-const REGISTER_TASK: &str = "https://trusttasks.org/openvtc/vtc/endorsement-types/register/1.0";
-const DELETE_TYPE_TASK: &str = "https://trusttasks.org/openvtc/vtc/endorsement-types/delete/1.0";
-const ISSUE_TASK: &str = "https://trusttasks.org/openvtc/vtc/credentials/endorsements/issue/1.0";
-const SHOW_TASK: &str = "https://trusttasks.org/openvtc/vtc/credentials/endorsements/show/1.0";
+const REGISTER_TASK: &str = "https://trusttasks.org/spec/vtc/endorsement-types/register/0.1";
+const DELETE_TYPE_TASK: &str = "https://trusttasks.org/spec/vtc/endorsement-types/delete/0.1";
+const ISSUE_TASK: &str = "https://trusttasks.org/spec/vtc/endorsements/issue/0.1";
+const SHOW_TASK: &str = "https://trusttasks.org/spec/vtc/endorsements/show/0.1";
+const REVOKE_TASK: &str = "https://trusttasks.org/spec/vtc/endorsements/revoke/0.1";
 const ADMIN_DID: &str = "did:key:zEndAdmin";
 const ISSUER_DID: &str = "did:key:zEndIssuer";
 const MEMBER_DID: &str = "did:key:zEndMember";
@@ -467,7 +468,7 @@ async fn revoke_issuer_can_retract() {
         .method("DELETE")
         .uri(format!("/v1/credentials/endorsements/{id}"))
         .header("authorization", format!("Bearer {}", fix.issuer_token))
-        .header("trust-task", SHOW_TASK)
+        .header("trust-task", REVOKE_TASK)
         .body(Body::empty())
         .unwrap();
     let resp = fix.router.clone().oneshot(req).await.unwrap();
@@ -513,7 +514,7 @@ async fn revoke_idempotent_on_already_revoked() {
             .method("DELETE")
             .uri(format!("/v1/credentials/endorsements/{id}"))
             .header("authorization", format!("Bearer {}", fix.admin_token))
-            .header("trust-task", SHOW_TASK)
+            .header("trust-task", REVOKE_TASK)
             .body(Body::empty())
             .unwrap();
         let resp = fix.router.clone().oneshot(req).await.unwrap();
@@ -543,7 +544,7 @@ async fn revoke_non_admin_non_issuer_forbidden() {
         .method("DELETE")
         .uri(format!("/v1/credentials/endorsements/{id}"))
         .header("authorization", format!("Bearer {}", fix.member_token))
-        .header("trust-task", SHOW_TASK)
+        .header("trust-task", REVOKE_TASK)
         .body(Body::empty())
         .unwrap();
     let resp = fix.router.clone().oneshot(req).await.unwrap();

--- a/vtc-service/tests/install_claim.rs
+++ b/vtc-service/tests/install_claim.rs
@@ -24,8 +24,8 @@ use vtc_service::test_support::TestVtc;
 use common::webauthn_harness::SoftEd25519Authenticator;
 
 const RP_ORIGIN: &str = "https://vtc.example.com";
-const START_TASK: &str = "https://trusttasks.org/openvtc/vtc/install/claim/start/1.0";
-const FINISH_TASK: &str = "https://trusttasks.org/openvtc/vtc/install/claim/finish/1.0";
+const START_TASK: &str = "https://trusttasks.org/spec/vtc/install/claim/start/0.1";
+const FINISH_TASK: &str = "https://trusttasks.org/spec/vtc/install/claim/finish/0.1";
 
 struct Fixture {
     router: axum::Router,

--- a/vtc-service/tests/install_flow.rs
+++ b/vtc-service/tests/install_flow.rs
@@ -42,14 +42,13 @@ use common::webauthn_harness::SoftEd25519Authenticator;
 const RP_ORIGIN: &str = "https://vtc.example.com";
 
 // Trust Tasks ------------------------------------------------------
-const CLAIM_START_TASK: &str = "https://trusttasks.org/openvtc/vtc/install/claim/start/1.0";
-const CLAIM_FINISH_TASK: &str = "https://trusttasks.org/openvtc/vtc/install/claim/finish/1.0";
-const BOOTSTRAP_TASK: &str = "https://trusttasks.org/openvtc/vtc/admin/bootstrap/1.0";
+const CLAIM_START_TASK: &str = "https://trusttasks.org/spec/vtc/install/claim/start/0.1";
+const CLAIM_FINISH_TASK: &str = "https://trusttasks.org/spec/vtc/install/claim/finish/0.1";
+const BOOTSTRAP_TASK: &str = "https://trusttasks.org/spec/vtc/admin/bootstrap/0.1";
 const PASSKEY_REGISTER_TASK: &str =
     "https://trusttasks.org/openvtc/vtc/admin/passkeys/register/1.0";
 const PASSKEY_LIST_TASK: &str = "https://trusttasks.org/openvtc/vtc/admin/passkeys/list/1.0";
-const COMMUNITY_PROFILE_TASK: &str =
-    "https://trusttasks.org/openvtc/vtc/community/profile/manage/1.0";
+const COMMUNITY_PROFILE_TASK: &str = "https://trusttasks.org/spec/vtc/community/profile/show/0.1";
 const ADMIN_CONFIG_PATCH_TASK: &str = "https://trusttasks.org/spec/config/patch/0.1";
 const RESTART_TASK: &str = "https://trusttasks.org/spec/config/restart/0.1";
 

--- a/vtc-service/tests/members_crud.rs
+++ b/vtc-service/tests/members_crud.rs
@@ -20,10 +20,11 @@ use vtc_service::members::{Member, store_member};
 use vtc_service::test_support::TestVtc;
 
 const RP_ORIGIN: &str = "https://vtc.example.com";
-const LIST_TASK: &str = "https://trusttasks.org/openvtc/vtc/members/list/1.0";
+const LIST_TASK: &str = "https://trusttasks.org/spec/vtc/members/list/0.1";
 const REMOVED_TASK: &str = "https://trusttasks.org/openvtc/vtc/members/removed/1.0";
 const PURGE_TASK: &str = "https://trusttasks.org/openvtc/vtc/members/purge/1.0";
-const SHOW_TASK: &str = "https://trusttasks.org/openvtc/vtc/members/show/1.0";
+const SHOW_TASK: &str = "https://trusttasks.org/spec/vtc/members/show/0.1";
+const UPDATE_TASK: &str = "https://trusttasks.org/spec/vtc/members/update/0.1";
 const PROMOTE_TASK: &str = "https://trusttasks.org/openvtc/vtc/members/promote-to-admin/1.0";
 
 const ADMIN_DID: &str = "did:key:zAdmin1";
@@ -402,7 +403,7 @@ async fn patch_member_role_member_to_moderator_succeeds_and_emits_audit() {
         &fix.router,
         "PATCH",
         "/v1/members/did:key:zM1",
-        SHOW_TASK,
+        UPDATE_TASK,
         Some(&fix.admin_token),
         Some(json!({ "role": "moderator" })),
     )
@@ -427,7 +428,7 @@ async fn patch_member_role_admin_is_refused_with_promote_hint() {
         &fix.router,
         "PATCH",
         "/v1/members/did:key:zM1",
-        SHOW_TASK,
+        UPDATE_TASK,
         Some(&fix.admin_token),
         Some(json!({ "role": "admin" })),
     )
@@ -449,7 +450,7 @@ async fn patch_member_profile_only_emits_member_updated() {
         &fix.router,
         "PATCH",
         "/v1/members/did:key:zM1",
-        SHOW_TASK,
+        UPDATE_TASK,
         Some(&fix.admin_token),
         Some(json!({
             "publishConsent": true,
@@ -471,7 +472,7 @@ async fn patch_member_404_for_unknown_did() {
         &fix.router,
         "PATCH",
         "/v1/members/did:key:zNobody",
-        SHOW_TASK,
+        UPDATE_TASK,
         Some(&fix.admin_token),
         Some(json!({ "publishConsent": true })),
     )

--- a/vtc-service/tests/personhood.rs
+++ b/vtc-service/tests/personhood.rs
@@ -34,8 +34,8 @@ use vtc_service::status_list;
 use vtc_service::test_support::TestVtc;
 
 const PUBLIC_URL: &str = "https://vtc.example.com";
-const CHALLENGE_TASK: &str = "https://trusttasks.org/openvtc/vtc/members/personhood/challenge/1.0";
-const ASSERT_TASK: &str = "https://trusttasks.org/openvtc/vtc/members/personhood/assert/1.0";
+const CHALLENGE_TASK: &str = "https://trusttasks.org/spec/vtc/members/personhood/challenge/0.1";
+const ASSERT_TASK: &str = "https://trusttasks.org/spec/vtc/members/personhood/assert/0.1";
 const MEMBER_DID: &str = "did:key:zPerson1";
 const OTHER_MEMBER_DID: &str = "did:key:zPerson2";
 const ADMIN_DID: &str = "did:key:zPersonAdmin";

--- a/vtc-service/tests/recognise.rs
+++ b/vtc-service/tests/recognise.rs
@@ -295,7 +295,7 @@ mod holder_binding {
     use vtc_service::test_support::TestVtc;
 
     const VTC_DID: &str = "did:key:z6MkTestVTC";
-    const RECOGNISE_TASK: &str = "https://trusttasks.org/openvtc/vtc/auth/recognise/1.0";
+    const RECOGNISE_TASK: &str = "https://trusttasks.org/spec/vtc/auth/recognise/0.1";
     const CHALLENGE_TASK: &str = "https://trusttasks.org/openvtc/vtc/auth/recognise/challenge/1.0";
 
     async fn test_vtc() -> TestVtc {

--- a/vtc-service/tests/relationships.rs
+++ b/vtc-service/tests/relationships.rs
@@ -33,9 +33,9 @@ use vtc_service::status_list;
 use vtc_service::test_support::TestVtc;
 
 const PUBLIC_URL: &str = "https://vtc.example.com";
-const PUBLISH_TASK: &str = "https://trusttasks.org/openvtc/vtc/relationships/publish/1.0";
-const LIST_TASK: &str = "https://trusttasks.org/openvtc/vtc/relationships/list/1.0";
-const REVOKE_TASK: &str = "https://trusttasks.org/openvtc/vtc/relationships/revoke/1.0";
+const PUBLISH_TASK: &str = "https://trusttasks.org/spec/vtc/relationships/publish/0.1";
+const LIST_TASK: &str = "https://trusttasks.org/spec/vtc/relationships/list/0.1";
+const REVOKE_TASK: &str = "https://trusttasks.org/spec/vtc/relationships/revoke/0.1";
 const ISSUER_DID: &str = "did:key:zVrcIssuer";
 const SUBJECT_DID: &str = "did:key:zVrcSubject";
 const STRANGER_DID: &str = "did:key:zStranger";

--- a/vtc-service/tests/removal.rs
+++ b/vtc-service/tests/removal.rs
@@ -23,8 +23,9 @@ use vtc_service::members::{Member, get_member, store_member};
 use vtc_service::test_support::TestVtc;
 
 const RP_ORIGIN: &str = "https://vtc.example.com";
-const SELF_REMOVE_TASK: &str = "https://trusttasks.org/openvtc/vtc/members/self-remove/1.0";
-const SHOW_TASK: &str = "https://trusttasks.org/openvtc/vtc/members/show/1.0";
+const SELF_REMOVE_TASK: &str = "https://trusttasks.org/spec/vtc/members/self-remove/0.1";
+const SHOW_TASK: &str = "https://trusttasks.org/spec/vtc/members/show/0.1";
+const ADMIN_REMOVE_TASK: &str = "https://trusttasks.org/spec/vtc/members/admin-remove/0.1";
 const POLICY_UPLOAD_TASK: &str = "https://trusttasks.org/spec/policy/upsert/0.2";
 const POLICY_ACTIVATE_TASK: &str = "https://trusttasks.org/spec/policy/activate/0.1";
 
@@ -452,7 +453,7 @@ async fn admin_remove_member_works() {
         &fix.router,
         "DELETE",
         &format!("/v1/members/{target}"),
-        SHOW_TASK,
+        ADMIN_REMOVE_TASK,
         Some(&fix.admin_token),
         Some(json!({ "reason": "policy violation" })),
     )
@@ -469,7 +470,7 @@ async fn admin_remove_self_refused_with_self_remove_hint() {
         &fix.router,
         "DELETE",
         &format!("/v1/members/{ADMIN_DID}"),
-        SHOW_TASK,
+        ADMIN_REMOVE_TASK,
         Some(&fix.admin_token),
         Some(json!({})),
     )
@@ -500,7 +501,7 @@ async fn admin_remove_of_admin_target_is_denied_by_default_policy() {
         &fix.router,
         "DELETE",
         &format!("/v1/members/{second_admin}"),
-        SHOW_TASK,
+        ADMIN_REMOVE_TASK,
         Some(&fix.admin_token),
         Some(json!({ "reason": "ouster" })),
     )
@@ -533,7 +534,7 @@ async fn admin_remove_404_for_unknown_did() {
         &fix.router,
         "DELETE",
         "/v1/members/did:key:zNobody",
-        SHOW_TASK,
+        ADMIN_REMOVE_TASK,
         Some(&fix.admin_token),
         Some(json!({})),
     )
@@ -551,7 +552,7 @@ async fn admin_remove_overlong_reason_rejected() {
         &fix.router,
         "DELETE",
         &format!("/v1/members/{target}"),
-        SHOW_TASK,
+        ADMIN_REMOVE_TASK,
         Some(&fix.admin_token),
         Some(json!({ "reason": "x".repeat(1025) })),
     )
@@ -614,7 +615,7 @@ async fn admin_remove_member_blocked_by_deny_all_policy() {
         &fix.router,
         "DELETE",
         &format!("/v1/members/{target}"),
-        SHOW_TASK,
+        ADMIN_REMOVE_TASK,
         Some(&fix.admin_token),
         Some(json!({ "reason": "policy gate test" })),
     )
@@ -656,7 +657,7 @@ async fn admin_remove_uses_policy_disposition_for_default() {
         &fix.router,
         "DELETE",
         &format!("/v1/members/{target}"),
-        SHOW_TASK,
+        ADMIN_REMOVE_TASK,
         Some(&fix.admin_token),
         Some(json!({})),
     )
@@ -721,7 +722,7 @@ async fn admin_remove_flips_revocation_bit() {
         &fix.router,
         "DELETE",
         &format!("/v1/members/{target}"),
-        SHOW_TASK,
+        ADMIN_REMOVE_TASK,
         Some(&fix.admin_token),
         Some(json!({})),
     )

--- a/vtc-service/tests/renewal.rs
+++ b/vtc-service/tests/renewal.rs
@@ -29,7 +29,7 @@ use vtc_service::test_support::TestVtc;
 
 const VTC_DID: &str = "did:webvh:vtc.example.com:abc";
 const PUBLIC_URL: &str = "https://vtc.example.com";
-const RENEW_TASK: &str = "https://trusttasks.org/openvtc/vtc/members/renew/1.0";
+const RENEW_TASK: &str = "https://trusttasks.org/spec/vtc/members/renew/0.1";
 const MEMBER_DID: &str = "did:key:zRenewMember";
 
 struct Fixture {

--- a/vtc-service/tests/rotation.rs
+++ b/vtc-service/tests/rotation.rs
@@ -27,8 +27,8 @@ use vtc_service::test_support::TestVtc;
 
 const VTC_DID: &str = "did:webvh:vtc.example.com:abc";
 const PUBLIC_URL: &str = "https://vtc.example.com";
-const CHALLENGE_TASK: &str = "https://trusttasks.org/openvtc/vtc/members/rotate-challenge/1.0";
-const ROTATE_TASK: &str = "https://trusttasks.org/openvtc/vtc/members/rotate/1.0";
+const CHALLENGE_TASK: &str = "https://trusttasks.org/spec/vtc/members/rotate-challenge/0.1";
+const ROTATE_TASK: &str = "https://trusttasks.org/spec/vtc/members/rotate/0.1";
 
 struct Fixture {
     router: axum::Router,


### PR DESCRIPTION
Moves every remaining VTC Trust Task that has a canonical counterpart onto the registry, closing out the bulk of Phase 4 (#710).

### Repointed 1:1

members (`list`, `show`, `renew`, `rotate`, `rotate-challenge`, `self-remove`, `personhood/{challenge,assert}`), relationships (`list`/`publish`/`revoke`), endorsement-types (`register`/`delete`), `install/claim/{start,finish}`, `admin/bootstrap`, `auth/recognise`, website (`files/list`, `generations/list`, `rollback`), and `health/diagnostics` → **`spec/vtc/registry/diagnostics/0.1`**.

### Four shared mounts genuinely split — one task per verb

| mount | verbs | now |
|---|---|---|
| `/members/{did}` | GET / PATCH / DELETE | `members/{show,update,admin-remove}` |
| `/community/profile` | GET / PUT | `community/profile/{show,update}` |
| `/credentials/endorsements` | POST / GET | `endorsements/{issue,list}` |
| `/credentials/endorsements/{id}` | GET / DELETE | `endorsements/{show,revoke}` |

**Seven of those canonical tasks existed only on disk "for the soft-gate surface" and were never enforced on the wire.** They shared a descriptor because `TrustTaskRouter` was believed to need per-method selectors — it doesn't (#724).

### The splits found two real client bugs

Which is precisely why enforcing a task per verb is worth doing. The bundled admin UI was sending the **`show`** task on:

- `DELETE /members/{did}` — a destructive removal labelled as a read
- `PUT /community/profile` — a write labelled as a read

Both "worked" while the verbs shared one descriptor; both would now be refused with 415. Fixed here, along with the same class in tests (7 audit tests seeding via `PUT /community/profile`, 3 endorsement `DELETE`s, 4 member `PATCH`es).

⚠️ **Breaking for any external client doing the same** — sending one verb's task for another is now a 415.

### `members/self-remove`

Its SDK constant was deliberately held back from #733 so the family could migrate as a unit (the census caught the half-migrated state at the time). It moves here: **`vta-sdk` 0.19.20**. openvtc needs one more `cargo update` after publish — its router already accepts the prefix, only dispatch is constant-keyed.

### Deliberately not included

- **website raw-byte ops** (`files/show`, `files/write`, `deploy`) — Phase 4a decided these aren't Trust Tasks at all (a JSON payload can't carry file bytes), so the correct move is **de-listing** them, which *removes* a header gate rather than repointing one. Different decision, different risk, own PR.
- **`website/files/delete`** — its canonical task exists, but the mount is a `ttl` chain sharing one body-limit layer across GET/PUT/DELETE, so splitting needs different surgery than the `tt` mounts.
- **Families with no canonical counterpart**: `admin/passkeys/*`, `admin/invites/*`, `admin/config/{export,import}`, `invitations/*`, `members/{promote-to-admin,purge,removed,request-vmc}`, `policies/test`, `recognition/check`, `relationships/graph`, `directory/query`, `backup/*`, `config/legacy/manage`, `auth/{admin-login,admin-session}`, `auth/recognise/challenge`, `ceremonies/list`.

### Verification

`cargo test --workspace`: **3639 passed, 0 failed**. `cargo clippy --workspace -D warnings` clean. `cargo fmt --all --check` clean. `tsc --noEmit` clean. Census (`trust_task_manifest`) green — it caught `members/self-remove` half-migrated and forced the SDK constant to move with the REST mount.

`vtc-service` 0.11.19, `vta-sdk` 0.19.20.
