### PR TITLE
feat(vta-service): --flush-queues startup recovery + fail-fast on unsatisfiable consent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10234,7 +10234,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.12.8"
+version = "0.12.9"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",

--- a/vta-enclave/src/main.rs
+++ b/vta-enclave/src/main.rs
@@ -300,6 +300,7 @@ async fn main() {
         storage_encryption_key,
         tee_context,
         true,
+        false, // flush_queues: not applicable to ephemeral enclave boots
     )
     .await
     {

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.12.8"
+version = "0.12.9"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/main.rs
+++ b/vta-service/src/main.rs
@@ -51,6 +51,15 @@ struct Cli {
     #[arg(long)]
     allow_degraded: bool,
 
+    /// On startup, before going live, purge BOTH this DID's mediator inbox and
+    /// its outbound (sender) queue. Recovery for a queue wedged full by a
+    /// message loop: once the mediator's per-sender cap (`limits.queue.sender`)
+    /// trips, it rejects every new send until the backlog is cleared. Implies
+    /// the inbox drain and additionally clears the outbound queue the
+    /// config-driven `drain_inbox_on_start` can't reach. Ignored by subcommands.
+    #[arg(long)]
+    flush_queues: bool,
+
     #[command(subcommand)]
     command: Option<Commands>,
 }
@@ -1989,6 +1998,7 @@ async fn main() {
                 None, // no storage encryption (non-TEE mode)
                 None, // no TEE context (use vta-enclave for TEE mode)
                 cli.allow_degraded,
+                cli.flush_queues,
             )
             .await
             {

--- a/vta-service/src/operations/acl.rs
+++ b/vta-service/src/operations/acl.rs
@@ -45,6 +45,27 @@ pub fn parse_step_up_require(s: Option<&str>) -> Result<Option<StepUpMode>, AppE
     }
 }
 
+/// Whether this ACL entry can **confer** authority over `ctx` in a consented
+/// delegation — either an explicit approve-scope covering it, or admin standing
+/// over it. Set *membership* alone is deliberately not enough: being in an
+/// approver set lets a holder *approve*, but conferring the authority the task
+/// actually needs requires holding it. This is the single predicate behind both
+/// the consent gate's fail-fast pre-check (is this task even satisfiable?) and
+/// grant-time `compute_delegated_contexts` (did the actual approvers confer it?),
+/// so the two can never diverge.
+pub(crate) fn acl_entry_can_confer(entry: &AclEntry, ctx: &str) -> bool {
+    if entry.approve_scope.covers(ctx) {
+        return true;
+    }
+    let claims = AuthClaims {
+        did: entry.did.clone(),
+        role: entry.role.clone(),
+        allowed_contexts: entry.allowed_contexts.clone(),
+        ..Default::default()
+    };
+    claims.role == Role::Admin && claims.has_context_access(ctx)
+}
+
 /// Build an [`ApproveScope`] from the two wire fields. `all` wins over an
 /// explicit context list; both absent ⇒ [`ApproveScope::None`] (confers
 /// nothing, the default).
@@ -673,6 +694,43 @@ mod tests {
         let body = to_result_body(&base);
         assert!(!body.approve_all_contexts);
         assert!(body.approve_contexts.is_empty());
+    }
+
+    /// `acl_entry_can_confer` — the single predicate behind the consent gate's
+    /// fail-fast and grant-time delegation. Locks in the exact production bug: an
+    /// approver whose approve-scope is `[openvtc]` cannot confer `openvtc-glenn`,
+    /// so a consent for a DID in `openvtc-glenn` completes but confers nothing and
+    /// loops. `openvtc` is not an ancestor of `openvtc-glenn` — distinct segments.
+    #[test]
+    fn acl_entry_can_confer_matches_scope_and_admin_but_not_a_sibling_context() {
+        // Approve-scope for `openvtc` covers `openvtc`, not the sibling `openvtc-glenn`.
+        let scoped = AclEntry::new("did:key:zApprover", Role::Reader, "seed")
+            .with_approve_scope(ApproveScope::Contexts(vec!["openvtc".into()]));
+        assert!(acl_entry_can_confer(&scoped, "openvtc"));
+        assert!(
+            !acl_entry_can_confer(&scoped, "openvtc-glenn"),
+            "approve-scope `openvtc` must NOT confer the distinct context `openvtc-glenn`"
+        );
+
+        // `ApproveScope::All` confers any context.
+        let all = AclEntry::new("did:key:zAll", Role::Reader, "seed")
+            .with_approve_scope(ApproveScope::All);
+        assert!(acl_entry_can_confer(&all, "openvtc-glenn"));
+
+        // A context admin confers via admin standing (no approve-scope needed).
+        let ctx_admin = AclEntry::new("did:key:zAdmin", Role::Admin, "seed")
+            .with_contexts(vec!["openvtc-glenn".into()]);
+        assert!(acl_entry_can_confer(&ctx_admin, "openvtc-glenn"));
+        assert!(!acl_entry_can_confer(&ctx_admin, "some-other-context"));
+
+        // A super-admin (Admin + empty contexts) confers anywhere.
+        let super_admin = AclEntry::new("did:key:zSuper", Role::Admin, "seed");
+        assert!(acl_entry_can_confer(&super_admin, "openvtc-glenn"));
+
+        // A plain reader with no approve-scope confers nothing — set membership
+        // alone is not authority.
+        let reader = AclEntry::new("did:key:zReader", Role::Reader, "seed");
+        assert!(!acl_entry_can_confer(&reader, "openvtc-glenn"));
     }
 
     /// Regression test for the eviction-via-shrink bug.

--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -428,6 +428,12 @@ pub async fn run(
     storage_encryption_key: Option<[u8; 32]>,
     tee_context: Option<TeeContext>,
     allow_degraded: bool,
+    // Recovery: when set (via `--flush-queues`), purge BOTH this DID's mediator
+    // inbox and its outbound (sender) queue before going live. The outbound
+    // purge is the piece the config-driven `drain_inbox_on_start` can't do — a
+    // message loop can fill the sender queue at the mediator (`limits.queue.
+    // sender`) so no new sends get through until it's cleared.
+    flush_queues: bool,
 ) -> Result<(), AppError> {
     // Fail fast on a broken config rather than booting a half-started
     // service that passes a port-liveness check but can't function (P0.9).
@@ -905,7 +911,7 @@ pub async fn run(
                     // undeliverable backlog can't stall the pickup handshake and
                     // wedge the (shared DIDComm+TSP) socket. Best-effort, and off
                     // unless `messaging.drain_inbox_on_start` is set.
-                    if messaging_config.drain_inbox_on_start {
+                    if messaging_config.drain_inbox_on_start || flush_queues {
                         match app_state.atm.as_ref() {
                             Some(atm) => {
                                 let cleared = drain_mediator_inbox(
@@ -917,11 +923,38 @@ pub async fn run(
                                 info!(
                                     count = cleared,
                                     mediator = %messaging_config.mediator_did,
-                                    "drain_inbox_on_start: cleared queued mediator messages before going live"
+                                    "cleared queued mediator inbox before going live"
+                                );
+                            }
+                            None => {
+                                warn!("inbox drain requested but no ATM is available; skipping")
+                            }
+                        }
+                    }
+
+                    // `--flush-queues` additionally clears the OUTBOUND (sender)
+                    // queue — messages this DID sent that are still queued at the
+                    // mediator awaiting delivery. A message loop can fill that
+                    // queue (`limits.queue.sender`), after which the mediator
+                    // rejects every new send until it drains. The inbox drain
+                    // above cannot touch it; this does.
+                    if flush_queues {
+                        match app_state.atm.as_ref() {
+                            Some(atm) => {
+                                let cleared = flush_mediator_outbox(
+                                    atm,
+                                    &messaging_config.mediator_did,
+                                    vta_did,
+                                )
+                                .await;
+                                info!(
+                                    count = cleared,
+                                    mediator = %messaging_config.mediator_did,
+                                    "flush_queues: cleared outbound sender queue before going live"
                                 );
                             }
                             None => warn!(
-                                "drain_inbox_on_start is set but no ATM is available; skipping drain"
+                                "--flush-queues set but no ATM is available; skipping outbox flush"
                             ),
                         }
                     }
@@ -1960,6 +1993,76 @@ async fn drain_mediator_inbox(atm: &ATM, mediator_did: &str, vta_did: &str) -> u
             Ok(_) => cleared += ids.len(),
             Err(e) => {
                 warn!(error = %e, cleared, "drain: delete failed; stopping to avoid a loop");
+                break;
+            }
+        }
+    }
+    cleared
+}
+
+/// Clear this DID's OUTBOUND (sender) queue at the mediator — messages it sent
+/// that are still queued for delivery to recipients.
+///
+/// A message loop (e.g. a wedged consent/update retry) can pile these up until
+/// the mediator's per-sender cap (`limits.queue.sender`) trips and rejects every
+/// new send, wedging the VTA's outbound path. [`drain_mediator_inbox`] can't
+/// touch these — they live in the sender's outbox, not this DID's inbox — so
+/// this lists the outbox and deletes each message. The VTA is authorised to
+/// delete them because the mediator's owner check admits the message's `FROM`
+/// (sender), not only its `TO` (recipient). Best-effort; returns how many were
+/// cleared and never panics.
+#[cfg(feature = "didcomm")]
+async fn flush_mediator_outbox(atm: &ATM, mediator_did: &str, vta_did: &str) -> usize {
+    use affinidi_tdk::messaging::messages::{DeleteMessageRequest, Folder};
+
+    let profile = match affinidi_tdk::messaging::profiles::ATMProfile::new(
+        atm,
+        Some("VTA-flush-outbox".to_string()),
+        vta_did.to_string(),
+        Some(mediator_did.to_string()),
+    )
+    .await
+    {
+        Ok(p) => match atm.profile_add(&p, false).await {
+            Ok(arc) => arc,
+            Err(e) => {
+                warn!(error = %e, "flush outbox: could not register mediator profile; skipping");
+                return 0;
+            }
+        },
+        Err(e) => {
+            warn!(error = %e, "flush outbox: could not build mediator profile; skipping");
+            return 0;
+        }
+    };
+
+    let list = match atm.list_messages(&profile, Folder::Outbox).await {
+        Ok(l) => l,
+        Err(e) => {
+            warn!(error = %e, "flush outbox: could not list outbound queue; skipping");
+            return 0;
+        }
+    };
+    let ids: Vec<String> = list.iter().map(|m| m.msg_id.clone()).collect();
+    if ids.is_empty() {
+        return 0;
+    }
+
+    // The mediator caps a single delete request at 100 ids, so batch.
+    let mut cleared = 0usize;
+    for chunk in ids.chunks(100) {
+        match atm
+            .delete_messages_direct(
+                &profile,
+                &DeleteMessageRequest {
+                    message_ids: chunk.to_vec(),
+                },
+            )
+            .await
+        {
+            Ok(r) => cleared += r.success.len(),
+            Err(e) => {
+                warn!(error = %e, cleared, "flush outbox: delete batch failed; stopping");
                 break;
             }
         }

--- a/vta-service/src/trust_tasks/policy_gate.rs
+++ b/vta-service/src/trust_tasks/policy_gate.rs
@@ -363,6 +363,55 @@ async fn consent_gate(
 
     let min_approvals = require.min_approvals.max(1);
 
+    // Fail fast on an *unsatisfiable* elevation. When the requester can't
+    // self-authorize the subject context, the only way this task ever executes
+    // is for enough approvers to CONFER that context. If fewer than
+    // `min_approvals` members of the set even *can* (no approve-scope covering
+    // it, not admin over it), then no approval — however many arrive — will ever
+    // produce a non-empty delegation: the ceremony would complete, the grant
+    // would carry nothing, and execute would forbid. That is the silent
+    // consent-approved-but-still-forbidden loop. Reject now, before minting a
+    // doomed pending, with a message that names the context and the gap.
+    if !requester_authorized && let Some(ctx) = subject_context.as_deref() {
+        let mut eligible = 0u32;
+        for member in &members {
+            if let Ok(Some(entry)) = crate::acl::get_acl_entry(&state.acl_ks, member).await
+                && !entry.is_expired(now)
+                && crate::operations::acl::acl_entry_can_confer(&entry, ctx)
+            {
+                eligible += 1;
+            }
+        }
+        if eligible < min_approvals {
+            crate::audit::record_consent(
+                &state.audit_ks,
+                "consent.required",
+                &auth.did,
+                type_uri,
+                "denied:unsatisfiable",
+                Some(&format!(
+                    "context={ctx}; approverSet={}; eligible={eligible}/{min_approvals}",
+                    require.approver_set
+                )),
+            )
+            .await;
+            return Some(reject_with(
+                doc,
+                RejectReason::PermissionDenied {
+                    reason: format!(
+                        "this task updates context `{ctx}`, which the requester is not authorized \
+                         for and which consent cannot confer: {eligible} of the required \
+                         {min_approvals} member(s) of approver set `{}` hold approve authority \
+                         over `{ctx}`. Grant an approver approve-scope (or admin) over `{ctx}`, \
+                         or run this as a principal that already holds the context — otherwise \
+                         the approval would succeed but the update would still be refused.",
+                        require.approver_set
+                    ),
+                },
+            ));
+        }
+    }
+
     // Reuse the pending request — and so the challenge, and so the digest the
     // approver is being asked to sign — but only while it still describes the
     // world. If the state moved under it, the effects it was minted with are no

--- a/vta-service/src/trust_tasks/task_consent.rs
+++ b/vta-service/src/trust_tasks/task_consent.rs
@@ -14,7 +14,7 @@ use trust_tasks_rs::{RejectReason, TrustTask};
 
 use super::TrustTaskOutcome;
 use super::helpers::{app_error_to_reject, parse_payload, reject_with, success_response};
-use crate::acl::{Role, get_acl_entry};
+use crate::acl::get_acl_entry;
 use crate::auth::AuthClaims;
 use crate::policy::consent;
 use crate::server::AppState;
@@ -98,16 +98,7 @@ async fn compute_delegated_contexts(
         if entry.is_expired(now) {
             continue;
         }
-        let confers = entry.approve_scope.covers(ctx) || {
-            let claims = AuthClaims {
-                did: approver.clone(),
-                role: entry.role.clone(),
-                allowed_contexts: entry.allowed_contexts.clone(),
-                ..Default::default()
-            };
-            claims.role == Role::Admin && claims.has_context_access(ctx)
-        };
-        if confers {
+        if crate::operations::acl::acl_entry_can_confer(&entry, ctx) {
             conferrers += 1;
         }
     }
@@ -376,6 +367,7 @@ pub(super) async fn handle_decision(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::acl::Role;
     use crate::test_support::{build_signing_test_app_state, seed_acl_entry};
 
     const OPENVTC: &str = "openvtc";


### PR DESCRIPTION
One PR, two operability fixes surfaced by the wedged `magic-depart` webvh-update loop.

## 1. `--flush-queues` — queue recovery

A message loop fills this DID's **outbound (sender)** queue at the mediator until the per-sender cap (`limits.queue.sender`) trips, after which the mediator rejects *every* new send and the VTA's outbound path is wedged. The existing config-driven `drain_inbox_on_start` only clears the **inbox** — nothing could clear the outbox.

New `--flush-queues` startup flag: before going live, drains the inbox (existing path) **and** clears the outbound queue via a new `flush_mediator_outbox` — lists `Folder::Outbox` and deletes each message. The VTA is authorised to delete them because the mediator's owner check admits a message's **FROM** (sender), not only its TO (confirmed in `store::{memory,fjall}`: *"Owner must be TO or FROM"*). Threaded through `run()`; the enclave caller passes `false`. No config/schema change, no mediator change.

**Run it:** `vta --flush-queues` (or `pnm --flush-queues`) once, to clear the wedged queue on startup.

## 2. Fail-fast on an unsatisfiable elevation — better permission errors

**Root cause of the loop** (from the live captures): `magic-depart` is in context `openvtc-glenn`; the requester (`z6MkmNxp`) holds only `vta`; the sole approver (`z6MkngmDc`) has approve-scope `[openvtc]` — which does **not** cover `openvtc-glenn` (distinct segments). So consent completed every cycle, the grant conferred an **empty** delegation, and execute forbade — forever, with no actionable error.

The gate already knows at **mint time** whether the task is even satisfiable. New pre-check: when the requester can't self-authorize the subject context and fewer than `min_approvals` members of the approver set can **confer** it, reject immediately — with a message naming the context and the gap — instead of minting a doomed pending that loops:

> this task updates context `openvtc-glenn`, which the requester is not authorized for and which consent cannot confer: 0 of the required 1 member(s) of approver set `…` hold approve authority over `openvtc-glenn`. Grant an approver approve-scope (or admin) over `openvtc-glenn`, or run this as a principal that already holds the context…

The "can confer" predicate is factored into `operations::acl::acl_entry_can_confer`, **shared** with grant-time `compute_delegated_contexts` so the fail-fast and the actual delegation can never diverge. Also emits a `consent.required / denied:unsatisfiable` audit row.

## Tests
- New `acl_entry_can_confer` unit test locks in the exact bug: `openvtc` scope does **not** confer sibling `openvtc-glenn`; `All`/context-admin/super-admin do; a bare reader does not.
- `cargo test -p vta-service --features webvh --lib` → **945 passed**. Enclave builds. `fmt` clean.

Patch bump 0.12.8 → 0.12.9.

---
Note: this fixes the *diagnosis and recovery* — the immediate unblock for `magic-depart` is still a config change (align the approver's approve-scope with the DID's context, or grant the requester the context). This PR makes that situation **fail loudly with a fix-it message** instead of looping silently.