### PR TITLE
fix(vta-sdk): correlate the TSP ping reply instead of taking the first frame

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -341,9 +341,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-mediator"
-version = "0.17.5"
+version = "0.17.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff1c3bcbd1c3bc5ef993c8d181cb010ead46d130aa31c4340821190946cc5800"
+checksum = "cac110108e4019d850ad9a75c65e5598ab8406a1f6868137165c2512c73b6c04"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-common",
@@ -356,6 +356,7 @@ dependencies = [
  "affinidi-rate-limit",
  "affinidi-secrets-resolver",
  "affinidi-task-utils",
+ "affinidi-tsp",
  "ahash 0.8.12",
  "async-convert",
  "async-trait",
@@ -400,7 +401,7 @@ dependencies = [
  "trust-tasks-rs",
  "url",
  "uuid",
- "vta-sdk 0.19.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vta-sdk 0.19.20",
 ]
 
 [[package]]
@@ -455,9 +456,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-sdk"
-version = "0.18.61"
+version = "0.18.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2944919beb7c602d439dcc8da10d13a346cd5637c2d96bba08c1854f5d1c90f6"
+checksum = "1f14872999e626152a24f87dcfc611f78a41f1f53c1f38895ad400e2165b62d0"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-authentication",
@@ -493,9 +494,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-test-mediator"
-version = "0.2.39"
+version = "0.2.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1dcf7fd903356e230912801b3b0f92633e6e76a8fea8f9b36438be3f4c39359"
+checksum = "288c2bda86e2c0e3689d03af8a1ea40cb8100974a71d49446fdf75e0bb148e1f"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-didcomm",
@@ -2485,7 +2486,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.19.20",
+ "vta-sdk 0.19.21",
 ]
 
 [[package]]
@@ -3286,7 +3287,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.19.20",
+ "vta-sdk 0.19.21",
 ]
 
 [[package]]
@@ -6764,7 +6765,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.19.20",
+ "vta-sdk 0.19.21",
 ]
 
 [[package]]
@@ -10080,7 +10081,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.19",
  "tokio",
- "vta-sdk 0.19.20",
+ "vta-sdk 0.19.21",
  "vti-common",
  "x25519-dalek",
 ]
@@ -10113,7 +10114,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.19.20",
+ "vta-sdk 0.19.21",
 ]
 
 [[package]]
@@ -10136,12 +10137,45 @@ dependencies = [
  "tracing-subscriber",
  "trust-tasks-rs",
  "uniffi",
- "vta-sdk 0.19.20",
+ "vta-sdk 0.19.21",
 ]
 
 [[package]]
 name = "vta-sdk"
 version = "0.19.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89bfd9bbf74ea936a57729e01a1c69e14f74d06d22b70aa3872798dc723e6804"
+dependencies = [
+ "affinidi-crypto",
+ "affinidi-did-resolver-cache-sdk",
+ "affinidi-messaging-core",
+ "affinidi-messaging-delivery",
+ "affinidi-messaging-didcomm",
+ "affinidi-openid4vci",
+ "affinidi-openid4vp",
+ "affinidi-tdk",
+ "base64 0.22.1",
+ "chrono",
+ "curve25519-dalek",
+ "didwebvh-rs",
+ "ed25519-dalek",
+ "futures-util",
+ "getrandom 0.4.3",
+ "multibase",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "thiserror 2.0.19",
+ "tokio",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "vta-sdk"
+version = "0.19.21"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10197,39 +10231,6 @@ dependencies = [
  "x25519-dalek",
  "x509-parser 0.18.1",
  "zeroize",
-]
-
-[[package]]
-name = "vta-sdk"
-version = "0.19.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89bfd9bbf74ea936a57729e01a1c69e14f74d06d22b70aa3872798dc723e6804"
-dependencies = [
- "affinidi-crypto",
- "affinidi-did-resolver-cache-sdk",
- "affinidi-messaging-core",
- "affinidi-messaging-delivery",
- "affinidi-messaging-didcomm",
- "affinidi-openid4vci",
- "affinidi-openid4vp",
- "affinidi-tdk",
- "base64 0.22.1",
- "chrono",
- "curve25519-dalek",
- "didwebvh-rs",
- "ed25519-dalek",
- "futures-util",
- "getrandom 0.4.3",
- "multibase",
- "reqwest 0.13.4",
- "serde",
- "serde_json",
- "sha2 0.11.0",
- "thiserror 2.0.19",
- "tokio",
- "tracing",
- "url",
- "uuid",
 ]
 
 [[package]]
@@ -10314,7 +10315,7 @@ dependencies = [
  "utoipa-axum",
  "uuid",
  "vta-cli-common",
- "vta-sdk 0.19.20",
+ "vta-sdk 0.19.21",
  "vta-service",
  "vti-common",
  "vti-secrets",
@@ -10336,7 +10337,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.19",
  "tokio",
- "vta-sdk 0.19.20",
+ "vta-sdk 0.19.21",
 ]
 
 [[package]]
@@ -10410,7 +10411,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.19.20",
+ "vta-sdk 0.19.21",
  "vtc-service",
  "vti-common",
  "vti-secrets",
@@ -10462,7 +10463,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.19.20",
+ "vta-sdk 0.19.21",
  "webauthn-rs",
  "zeroize",
 ]
@@ -10489,7 +10490,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.19.20",
+ "vta-sdk 0.19.21",
  "vta-service",
  "vti-common",
 ]
@@ -10518,7 +10519,7 @@ dependencies = [
  "tokio",
  "tracing",
  "vaultrs",
- "vta-sdk 0.19.20",
+ "vta-sdk 0.19.21",
  "vti-common",
 ]
 

--- a/tests/e2e/Cargo.toml
+++ b/tests/e2e/Cargo.toml
@@ -19,13 +19,13 @@ autobins = false
 
 [dev-dependencies]
 # Embedded mediator fixture from affinidi-tdk-rs.
-affinidi-messaging-test-mediator = "0.2"
+affinidi-messaging-test-mediator = { version = "0.2", features = ["tsp"] }
 
 # VTA: enable the `test-support` feature so we can stand up complete VTA
 # state (in-memory keyspaces, default `AppConfig`, bootstrap helpers)
 # from outside the crate.
 vta-service = { path = "../../vta-service", features = ["test-support", "didcomm", "webvh", "rest"] }
-vta-sdk = { path = "../../vta-sdk", features = ["client", "didcomm", "session", "sealed-transfer", "provision-integration", "provision-client"] }
+vta-sdk = { path = "../../vta-sdk", features = ["client", "didcomm", "session", "tsp", "sealed-transfer", "provision-integration", "provision-client"] }
 vti-common = { path = "../../vti-common" }
 
 affinidi-tdk = { workspace = true }

--- a/tests/e2e/tests/tsp_ping_correlation.rs
+++ b/tests/e2e/tests/tsp_ping_correlation.rs
@@ -1,0 +1,183 @@
+//! A TSP ping must measure *its own* reply, not whatever was in the inbox.
+//!
+//! ## Why this exists
+//!
+//! `pnm health`'s TSP probe used to accept the first frame that unpacked and
+//! parsed as JSON. That looks harmless until you remember the mediator inbox is
+//! durable: every reply an earlier probe failed to collect is still queued, and
+//! the mediator flushes the backlog onto the socket the instant it connects. So
+//! the probe could hand back a pong from a previous run — a green tick and a
+//! fabricated latency for a round trip that never happened on this run. During
+//! the TSP delivery outage (mediator never marked raw-TSP sockets live, so
+//! replies were stored and never pushed) that is exactly what happened: the
+//! warm-up ping "succeeded" off the backlog and the measured ping then failed,
+//! which is what made the fault look intermittent instead of total.
+//!
+//! A health probe that can be satisfied by a stale frame cannot be trusted to
+//! report a broken transport, so this pins the correlation.
+//!
+//! ## Version note
+//!
+//! [`a_stale_inbox_frame_does_not_satisfy_a_ping`] runs against any mediator —
+//! it only needs flush-on-connect. [`a_correlated_reply_satisfies_the_ping`] is
+//! a live TSP round trip, so it needs a mediator that actually pushes frames to
+//! a connected raw-TSP socket: `affinidi-messaging-mediator` >= 0.17.7 /
+//! `affinidi-messaging-sdk` >= 0.18.62. Against older versions it fails for the
+//! upstream reason, not this one.
+
+use std::time::Duration;
+
+use affinidi_messaging_test_mediator::TestMediator;
+use ed25519_dalek::SigningKey;
+use vta_sdk::did_key::ed25519_multibase_pubkey;
+use vta_sdk::session::{TspPingSession, TspSession};
+
+mod common;
+
+/// Deterministic `did:key` + matching multibase private key from a seed byte.
+fn did_key_from_seed(seed_byte: u8) -> (String, String) {
+    let seed = [seed_byte; 32];
+    let sk = SigningKey::from_bytes(&seed);
+    let pk = sk.verifying_key().to_bytes();
+    let did = format!("did:key:{}", ed25519_multibase_pubkey(&pk));
+    let mut buf = vec![0x80, 0x26];
+    buf.extend_from_slice(&seed);
+    let priv_mb = multibase::encode(multibase::Base::Base58Btc, &buf);
+    (did, priv_mb)
+}
+
+/// A well-formed Trust-Task response document that belongs to *someone else's*
+/// exchange — the shape a leftover reply from an earlier probe has.
+fn stale_reply(peer_did: &str, client_did: &str) -> Vec<u8> {
+    serde_json::to_vec(&serde_json::json!({
+        "id": "urn:uuid:stale-response-from-an-earlier-run",
+        "threadId": "urn:uuid:a-ping-this-process-never-sent",
+        "type": "https://trusttasks.org/spec/messaging/ping/0.1#response",
+        "issuer": peer_did,
+        "recipient": client_did,
+        "payload": { "nonce": "a-nonce-from-an-earlier-run" },
+    }))
+    .expect("serialize stale reply")
+}
+
+/// Queue a stale reply for the prober *before* it connects, then ping a peer
+/// that never answers. The stale frame is flushed onto the socket on connect,
+/// so an uncorrelated probe reports success off it; a correlated one must let
+/// the ping time out.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_stale_inbox_frame_does_not_satisfy_a_ping() {
+    common::init_tracing();
+
+    let (client_did, client_priv) = did_key_from_seed(0x71);
+    let (peer_did, peer_priv) = did_key_from_seed(0x72);
+
+    let mediator = TestMediator::builder()
+        .local_did(client_did.clone())
+        .local_did(peer_did.clone())
+        .spawn()
+        .await
+        .expect("spawn test mediator");
+
+    // The peer plants a reply for the client and goes silent — it will not
+    // answer the ping that follows.
+    let peer = TspSession::connect(&peer_did, &peer_priv, mediator.did())
+        .await
+        .expect("peer TSP session connects");
+    peer.send_document(
+        &client_did,
+        mediator.did(),
+        &stale_reply(&peer_did, &client_did),
+    )
+    .await
+    .expect("stale reply is accepted by the mediator");
+    peer.shutdown().await;
+
+    // Give the mediator a moment to store it, so it is genuinely waiting in the
+    // inbox when the prober connects and gets the flush-on-connect drain.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let mut prober = TspPingSession::new(&client_did, &client_priv, mediator.did())
+        .await
+        .expect("prober TSP session connects");
+    let result = prober.ping(&peer_did, Duration::from_secs(3)).await;
+    prober.shutdown().await;
+
+    mediator.shutdown();
+    mediator.join().await.expect("mediator joins cleanly");
+
+    match result {
+        Ok(latency) => panic!(
+            "ping reported success ({latency}ms) off a stale inbox frame — nobody answered \
+             this ping, so a health probe built on this would show green against a dead \
+             transport"
+        ),
+        Err(e) => {
+            let msg = e.to_string();
+            assert!(
+                msg.contains("timed out"),
+                "expected the ping to time out having skipped the uncorrelated frame, got: {msg}"
+            );
+        }
+    }
+}
+
+/// The other half of the contract: a correctly-threaded reply still satisfies
+/// the ping. Without this, "reject everything" would pass the test above.
+///
+/// The peer plays the VTA: it reads the ping off its own TSP inbox and answers
+/// with `threadId` set to the request id, exactly as `doc.respond_with` does on
+/// the real dispatch spine.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_correlated_reply_satisfies_the_ping() {
+    common::init_tracing();
+
+    let (client_did, client_priv) = did_key_from_seed(0x73);
+    let (peer_did, peer_priv) = did_key_from_seed(0x74);
+
+    let mediator = TestMediator::builder()
+        .local_did(client_did.clone())
+        .local_did(peer_did.clone())
+        .spawn()
+        .await
+        .expect("spawn test mediator");
+
+    let peer = TspSession::connect(&peer_did, &peer_priv, mediator.did())
+        .await
+        .expect("peer TSP session connects");
+
+    let mediator_did = mediator.did().to_string();
+    let client_for_peer = client_did.clone();
+    let peer_did_for_task = peer_did.clone();
+    let responder = tokio::spawn(async move {
+        let Ok(Some(frame)) = peer.receive_next(20).await else {
+            return;
+        };
+        let doc: serde_json::Value = serde_json::from_str(&frame).expect("ping is JSON");
+        let request_id = doc.get("id").and_then(|v| v.as_str()).unwrap_or_default();
+        let reply = serde_json::to_vec(&serde_json::json!({
+            "id": "urn:uuid:the-response",
+            "threadId": request_id,
+            "type": "https://trusttasks.org/spec/messaging/ping/0.1#response",
+            "issuer": peer_did_for_task,
+            "recipient": client_for_peer,
+            "payload": { "status": "ok" },
+        }))
+        .expect("serialize reply");
+        peer.send_document(&client_for_peer, &mediator_did, &reply)
+            .await
+            .expect("reply is accepted");
+        peer.shutdown().await;
+    });
+
+    let mut prober = TspPingSession::new(&client_did, &client_priv, mediator.did())
+        .await
+        .expect("prober TSP session connects");
+    let result = prober.ping(&peer_did, Duration::from_secs(20)).await;
+    prober.shutdown().await;
+    let _ = responder.await;
+
+    mediator.shutdown();
+    mediator.join().await.expect("mediator joins cleanly");
+
+    result.expect("a reply threaded to our request id must satisfy the ping");
+}

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.19.20"
+version = "0.19.21"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/session.rs
+++ b/vta-sdk/src/session.rs
@@ -1678,7 +1678,7 @@ impl TspPingSession {
             .parse()
             .map_err(|e| format!("messaging/ping type URI parse: {e}"))?;
         let mut doc: TrustTask<serde_json::Value> =
-            TrustTask::new(id, type_uri, serde_json::json!({ "nonce": nonce }));
+            TrustTask::new(id.clone(), type_uri, serde_json::json!({ "nonce": nonce }));
         doc.issuer = Some(self.client_did.clone());
         doc.recipient = Some(vta_did.to_string());
         let body = serde_json::to_vec(&doc)?;
@@ -1705,15 +1705,48 @@ impl TspPingSession {
                 Ok(Err(e)) => return Err(Box::new(e)),
                 Err(_) => return Err("TSP ping timed out waiting for reply".into()),
             };
-            // The VTA's reply is sealed to us; a frame we can unpack and parse
-            // as a JSON trust-task envelope is the pong. (Our ephemeral-ish
-            // client DID has no other TSP traffic, so the first such frame is
-            // our reply.) Frames that don't unpack are skipped.
-            if let Ok((payload, _sender)) = self.atm.tsp().unpack_bytes(&self.profile, &frame).await
-                && serde_json::from_slice::<serde_json::Value>(&payload).is_ok()
-            {
+            // The VTA's reply is sealed to us. Unpack it, then check it is *our*
+            // reply before believing it.
+            //
+            // "First frame that unpacks and parses as JSON" is not good enough:
+            // this DID's mediator inbox is durable, so every reply that a
+            // previous probe never collected is still queued and gets flushed
+            // onto the socket the moment we connect. Accepting the first frame
+            // meant a probe could measure a pong from an earlier run — reporting
+            // a healthy round trip, at an invented latency, against a VTA that
+            // might not have answered at all. A stale frame must not be able to
+            // turn a broken transport green.
+            //
+            // Correlation is the Trust-Task `threadId`, which the responder sets
+            // to our request `id` (`doc.respond_with`); the echoed `nonce` is
+            // accepted as a fallback for a responder that replies with a fresh
+            // document instead of a threaded `#response`. Anything else is
+            // someone else's traffic or a leftover: skip it and keep waiting
+            // within the caller's budget.
+            let Ok((payload, _sender)) = self.atm.tsp().unpack_bytes(&self.profile, &frame).await
+            else {
+                continue; // not sealed to us / not TSP — not our business
+            };
+            let Ok(doc) = serde_json::from_slice::<serde_json::Value>(&payload) else {
+                continue; // not a Trust-Task document
+            };
+
+            let threaded = doc.get("threadId").and_then(|v| v.as_str()) == Some(id.as_str());
+            let echoed_nonce = doc
+                .get("payload")
+                .and_then(|p| p.get("nonce"))
+                .and_then(|v| v.as_str())
+                == Some(nonce.as_str());
+            if threaded || echoed_nonce {
                 return Ok(start.elapsed().as_millis());
             }
+            tracing::debug!(
+                thread_id = doc
+                    .get("threadId")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("<none>"),
+                "TSP ping: skipping an uncorrelated frame (stale inbox entry or other traffic)"
+            );
         }
     }
 
@@ -1859,12 +1892,42 @@ impl TspSession {
         doc.recipient = Some(vta_did.to_string());
         let body = serde_json::to_vec(&doc)?;
 
+        self.send_document(vta_did, mediator_did, &body).await
+    }
+
+    /// Send an already-built Trust-Task document to `vta_did`, routed through
+    /// `mediator_did`. `body` is the serialized document itself — TSP carries
+    /// the Trust-Task bytes directly, with no DIDComm envelope around them (the
+    /// VTA's `tsp_inbound::dispatch_one` hands the payload straight to
+    /// `dispatch_trust_task_core`).
+    ///
+    /// This is the generalisation of [`announce`](Self::announce), which is
+    /// just this with a `messaging/ping/0.1` body. The same properties hold:
+    ///
+    /// - **Send-only, lock-free.** It never touches `ws`, so it is safe to call
+    ///   while a `receive_next` is blocked holding that lock — which is the
+    ///   normal state of a client running an inbox loop.
+    /// - **Fire-and-forget.** The VTA seals its reply and routes it back over
+    ///   TSP, so the response document arrives on
+    ///   [`receive_next`](Self::receive_next) like any other frame. There is no
+    ///   correlation here; a caller that needs the reply must match it off the
+    ///   inbox itself (e.g. on the document's `id`/`type`).
+    ///
+    /// The sender is proven by TSP itself, so the VTA derives authorization
+    /// from the sealed `sender_vid` (intrinsic-sender auth) — no bearer token
+    /// and no prior REST authentication is involved.
+    pub async fn send_document(
+        &self,
+        vta_did: &str,
+        mediator_did: &str,
+        body: &[u8],
+    ) -> Result<(), Box<dyn std::error::Error>> {
         self.atm
             .tsp()
             .send_routed(
                 &self.profile,
                 &[mediator_did.to_string(), vta_did.to_string()],
-                &body,
+                body,
             )
             .await?;
         Ok(())
@@ -1872,10 +1935,20 @@ impl TspSession {
 
     /// Wait up to `timeout_secs` for the next inbound TSP frame that unpacks to a
     /// Trust-Task payload, and return that payload as a JSON string — the
-    /// unpacked inner document (e.g. a `task-consent/request`). Returns `None`
-    /// if nothing arrived within the timeout or the websocket closed. TSP
-    /// control frames (which don't unpack to an application payload) are skipped
-    /// within the remaining budget rather than surfaced. Call again to poll on.
+    /// unpacked inner document (e.g. a `task-consent/request`). TSP control
+    /// frames (which don't unpack to an application payload) are skipped within
+    /// the remaining budget rather than surfaced. Call again to poll on.
+    ///
+    /// Three outcomes, deliberately distinct:
+    /// - `Ok(Some(doc))` — an application message.
+    /// - `Ok(None)` — **idle**: nothing arrived within `timeout_secs`, or the
+    ///   session was already [`shutdown`](Self::shutdown). Poll again.
+    /// - `Err(_)` — the connection is **gone** (closed by the mediator, or a
+    ///   socket error). Polling again cannot help; reconnect.
+    ///
+    /// A closed socket used to be reported as `Ok(None)`, which made a dead
+    /// inbox look exactly like a quiet one — callers spun on it forever instead
+    /// of reconnecting. Keep these three cases distinct.
     ///
     /// The plaintext is the *inner* document the sender packed, not a DIDComm
     /// envelope: TSP carries the Trust-Task bytes directly, so callers parse the
@@ -1901,7 +1974,22 @@ impl TspSession {
             };
             let frame = match tokio::time::timeout(remaining, ws.recv()).await {
                 Ok(Ok(Some(bytes))) => bytes,
-                Ok(Ok(None)) => return Ok(None), // websocket closed
+                // Closed socket is an ERROR, not `Ok(None)`.
+                //
+                // `Ok(None)` means "nothing arrived, ask again" — the caller's
+                // normal idle path. A closed websocket is the opposite: asking
+                // again can never produce anything. Conflating them meant a
+                // dropped inbox was indistinguishable from a quiet one, so a
+                // polling loop would spin on `recv()` returning `None`
+                // immediately, forever — burning CPU and never reconnecting,
+                // because nothing ever signalled that the connection had gone.
+                //
+                // Surfacing it as `Err` lets the supervisor do its job: the
+                // mobile listen loop already treats an error as a drop and
+                // reconnects with backoff.
+                Ok(Ok(None)) => {
+                    return Err("TSP websocket closed by the mediator".into());
+                }
                 Ok(Err(e)) => return Err(Box::new(e)),
                 Err(_) => return Ok(None), // timed out with nothing to hand back
             };


### PR DESCRIPTION
`TspPingSession::ping` accepted the first frame that unpacked and parsed as JSON.
The mediator inbox is durable, so every reply an earlier probe failed to collect
is still queued and gets flushed onto the socket the instant we connect — the
probe could report a healthy round trip, at an invented latency, off a pong from
a previous run.

That is what disguised the TSP delivery outage as intermittent. `pnm health`
sends a warm-up ping then a measured one; the warm-up "succeeded" off the
backlog and the measured one failed, so the transport looked flaky when it was
in fact totally broken (0 of 10 frames delivered in a local reproduction). A
probe a stale frame can satisfy cannot be trusted to report a broken transport.

## The fix

Correlate on the Trust-Task `threadId` — a responder sets it to our request id
via `doc.respond_with` — with the echoed `nonce` as a fallback for a responder
that replies with a fresh document rather than a threaded `#response`.
Uncorrelated frames are skipped and we keep waiting within the caller's budget,
so a backlog delays the probe rather than faking it.

## Tests

`tests/e2e/tests/tsp_ping_correlation.rs`:

- **`a_stale_inbox_frame_does_not_satisfy_a_ping`** — plants a reply for the
  prober *before* it connects, then pings a peer that never answers. Without the
  fix it reports success in 9ms off the planted frame; with it, the ping times
  out. Runs against any mediator, since it only needs flush-on-connect.
- **`a_correlated_reply_satisfies_the_ping`** — the other half, so "reject
  everything" can't pass. A live round trip, so it needs mediator 0.17.7.

## Also included

Only what those tests need from the TSP session work in flight:

- `TspSession::send_document` — send an arbitrary Trust-Task document over TSP,
  the generalisation of `announce`.
- `TspSession::receive_next` reports a dropped connection as `Err`, not
  `Ok(None)`. Conflating "socket closed" with "nothing arrived yet" made a dead
  inbox look like a quiet one, so a polling loop spun instead of reconnecting.

Deliberately **not** included: the `vta-mobile-core`, `vta-service` inbound
concurrency, and `didcomm_session` work from the same investigation.

## Upstream

The transport faults themselves were in affinidi-tdk-rs and are fixed and
published — see affinidi/affinidi-tdk-rs#646 (the mediator never marked raw-TSP
websockets live, so anything arriving after connect was stored and never pushed;
and the SDK dropped packed frames that landed between polls). The mediator has
been redeployed on 0.17.7 and `pnm health` now gets a real TSP pong.

Lockfile moves to the published fixes: mediator 0.17.7, sdk 0.18.62,
test-mediator 0.2.40. **Note:** updating sdk and test-mediator alone does *not*
move `affinidi-messaging-mediator` — it is transitive through test-mediator and
needs its own `cargo update`. Without that the e2e round trip still fails, with
the entire server-side fix absent.

vta-sdk 0.19.21. Refs #749.
