### PR TITLE
fix(vta-service): update the consent e2e test to #748's fail-fast contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,7 +400,7 @@ dependencies = [
  "trust-tasks-rs",
  "url",
  "uuid",
- "vta-sdk 0.19.19",
+ "vta-sdk 0.19.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -10141,39 +10141,6 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.19.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4dadface2af16f9146338c6b3e6771381f43d29e2e7829d08ac4f66c4ab66f"
-dependencies = [
- "affinidi-crypto",
- "affinidi-did-resolver-cache-sdk",
- "affinidi-messaging-core",
- "affinidi-messaging-delivery",
- "affinidi-messaging-didcomm",
- "affinidi-openid4vci",
- "affinidi-openid4vp",
- "affinidi-tdk",
- "base64 0.22.1",
- "chrono",
- "curve25519-dalek",
- "didwebvh-rs",
- "ed25519-dalek",
- "futures-util",
- "getrandom 0.4.3",
- "multibase",
- "reqwest 0.13.4",
- "serde",
- "serde_json",
- "sha2 0.11.0",
- "thiserror 2.0.19",
- "tokio",
- "tracing",
- "url",
- "uuid",
-]
-
-[[package]]
-name = "vta-sdk"
 version = "0.19.20"
 dependencies = [
  "affinidi-bbs",
@@ -10230,6 +10197,39 @@ dependencies = [
  "x25519-dalek",
  "x509-parser 0.18.1",
  "zeroize",
+]
+
+[[package]]
+name = "vta-sdk"
+version = "0.19.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89bfd9bbf74ea936a57729e01a1c69e14f74d06d22b70aa3872798dc723e6804"
+dependencies = [
+ "affinidi-crypto",
+ "affinidi-did-resolver-cache-sdk",
+ "affinidi-messaging-core",
+ "affinidi-messaging-delivery",
+ "affinidi-messaging-didcomm",
+ "affinidi-openid4vci",
+ "affinidi-openid4vp",
+ "affinidi-tdk",
+ "base64 0.22.1",
+ "chrono",
+ "curve25519-dalek",
+ "didwebvh-rs",
+ "ed25519-dalek",
+ "futures-util",
+ "getrandom 0.4.3",
+ "multibase",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "thiserror 2.0.19",
+ "tokio",
+ "tracing",
+ "url",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10234,7 +10234,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.12.9"
+version = "0.12.10"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.12.9"
+version = "0.12.10"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/tests/delegated_consent_e2e.rs
+++ b/vta-service/tests/delegated_consent_e2e.rs
@@ -579,12 +579,21 @@ async fn a_context_admin_approval_lets_a_cross_context_requester_execute() {
     );
 }
 
-/// The dual: an approval from someone who is a set member but is **not** an admin
-/// of the DID's context confers nothing. The decision is accepted (they are in
-/// the set), but the re-submit cannot execute — authority can only be delegated
-/// by someone who holds it.
+/// The dual: when the only set member is **not** an admin of the DID's context,
+/// there is no approval anyone could give that would let the task execute —
+/// authority can only be delegated by someone who holds it.
+///
+/// The task is therefore refused **at submission**, before any consent ceremony
+/// is minted (#748). It used to mint a pending, accept the approval, hand back a
+/// grant carrying an empty delegation, and only then forbid the re-submit — a
+/// ceremony whose outcome was decided before it began, and which in production
+/// looped: approved, still forbidden, no actionable error.
+///
+/// So the guarantee under test is unchanged and strictly stronger: a
+/// non-context-admin's approval confers no execution. What moved is *when* we
+/// say so, and that the refusal now names the context and the gap.
 #[tokio::test]
-async fn an_approval_from_a_non_context_admin_confers_no_execution() {
+async fn an_unsatisfiable_elevation_is_refused_before_any_consent_ceremony() {
     let (router, ctx) = build_test_app_with(TestAppOptions {
         provisionable_vta: true,
         ..Default::default()
@@ -630,41 +639,39 @@ async fn an_approval_from_a_non_context_admin_confers_no_execution() {
             "document": { "@context": ["https://www.w3.org/ns/did/v1"], "id": did, "alsoKnownAs": ["did:example:nope"] }
         }),
     );
-    let (_, rejected) = post(&router, &deleg_token, &update).await;
-    let d = &rejected["payload"]["details"];
-
-    // The approver is in the set, so the decision itself is accepted and a grant
-    // is minted — but it carries no delegated context.
-    let decision = sign_as(
-        &ops,
-        envelope(
-            TASK_CONSENT_DECISION,
-            &ops.did,
-            &ctx.vta_did,
-            json!({ "challenge": d["challenge"], "payloadDigest": d["payloadDigest"], "decision": "approve" }),
-        ),
-    );
-    let (status, _granted) = post(&router, &deleg_token, &decision).await;
-    assert_eq!(
-        status,
-        StatusCode::OK,
-        "a set member's decision is accepted"
-    );
-
-    // The re-submit must NOT execute: the grant conferred no authority over
-    // `default`, and the requester never held it.
-    let resubmit = envelope(
-        WEBVH_UPDATE,
-        requester,
-        &ctx.vta_did,
-        update["payload"].clone(),
-    );
-    let (status, refused) = post(&router, &deleg_token, &resubmit).await;
+    let (status, refused) = post(&router, &deleg_token, &update).await;
     assert_ne!(
         status,
         StatusCode::OK,
-        "an approval from a non-context-admin must not confer execution: {refused}"
+        "an elevation no approver can confer must be refused, not executed: {refused}"
     );
+
+    // The refusal has to be actionable: an operator reading it must learn which
+    // context is missing and who would have to hold it. A bare "forbidden" is
+    // what sent this into a loop in production.
+    let payload = refused["payload"].to_string();
+    assert!(
+        payload.contains("consent cannot confer"),
+        "the refusal must say the elevation is unsatisfiable, not merely forbidden: {refused}"
+    );
+    assert!(
+        payload.contains("`default`"),
+        "the refusal must name the context the requester lacks: {refused}"
+    );
+    assert!(
+        payload.contains("`operators`"),
+        "the refusal must name the approver set that cannot confer it: {refused}"
+    );
+
+    // Nothing to approve: no ceremony was minted, so there is no challenge for
+    // an approver to sign. This is the part that used to happen and shouldn't.
+    let details = &refused["payload"]["details"];
+    assert!(
+        details["challenge"].is_null() && details["consentRequests"].is_null(),
+        "no consent ceremony may be minted for a task that could never execute: {refused}"
+    );
+
+    // And of course nothing ran.
     assert_eq!(
         update_keys_in_force(&ctx, &did).await,
         keys_before,


### PR DESCRIPTION
Fixes #751 — `main` has been red since #748 (`02e26ffe`), which blocks every PR
branched from it.

```
thread 'an_approval_from_a_non_context_admin_confers_no_execution'
  panicked at vta-service/tests/delegated_consent_e2e.rs:648:5:
assertion `left == right` failed: a set member's decision is accepted
  left: 400
 right: 200
```

## Why it broke

Not a flake, and not a behaviour regression — the test asserts what #748
deliberately replaced.

#748 added a fail-fast to `policy_gate::consent_gate`: when the requester can't
self-authorize the subject context and fewer than `min_approvals` members of the
approver set can *confer* it, reject at submission rather than mint a pending
that can never execute. The test builds precisely that scenario on purpose — the
sole approver administers `some-other-ctx` while the subject context is
`default` — and then asserted the ceremony proceeds and the decision returns
200. With fail-fast the original `webvh-update` is refused up front, so no
pending exists, so the decision references a challenge that was never minted →
400.

## What changed

The guarantee the test protects is unchanged and strictly stronger: an approval
from a non-context-admin confers no execution. What moved is *when* the system
says so. Renamed to `an_unsatisfiable_elevation_is_refused_before_any_consent_ceremony`
and re-pointed at the new contract:

- the `webvh-update` is refused at submission;
- the refusal is **actionable** — it says the elevation is unsatisfiable rather
  than merely forbidden, and names both the context (`` `default` ``) and the
  approver set (`` `operators` ``) that cannot confer it. A bare "forbidden" is
  exactly what sent this into the production loop #748 was fixing, so it's worth
  a test;
- **no challenge and no `consentRequests` are minted** — there is nothing for an
  approver to sign. This is the part that used to happen and shouldn't;
- nothing committed to the log.

## Checks

All five tests in the file pass. The other four were checked for the same
dependency on a mintable-but-doomed pending; none has it. Full `vta-service`
suite green, `cargo fmt --check` clean, and no new clippy warnings (the
pre-existing unused-import warnings in `did_peer.rs` / `did_webvh.rs` are
untouched and not in this file).

Patch bump 0.12.9 → 0.12.10.

Unblocks #750, which is otherwise green and inherits only this failure.
