### PR TITLE
fix(vta-sdk): surface a trust-task error carried inside the payload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -401,7 +401,7 @@ dependencies = [
  "trust-tasks-rs",
  "url",
  "uuid",
- "vta-sdk 0.19.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vta-sdk 0.19.21",
 ]
 
 [[package]]
@@ -2486,7 +2486,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.19.21",
+ "vta-sdk 0.19.22",
 ]
 
 [[package]]
@@ -3287,7 +3287,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.19.21",
+ "vta-sdk 0.19.22",
 ]
 
 [[package]]
@@ -6765,7 +6765,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.19.21",
+ "vta-sdk 0.19.22",
 ]
 
 [[package]]
@@ -10081,7 +10081,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.19",
  "tokio",
- "vta-sdk 0.19.21",
+ "vta-sdk 0.19.22",
  "vti-common",
  "x25519-dalek",
 ]
@@ -10114,7 +10114,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.19.21",
+ "vta-sdk 0.19.22",
 ]
 
 [[package]]
@@ -10137,12 +10137,45 @@ dependencies = [
  "tracing-subscriber",
  "trust-tasks-rs",
  "uniffi",
- "vta-sdk 0.19.21",
+ "vta-sdk 0.19.22",
 ]
 
 [[package]]
 name = "vta-sdk"
 version = "0.19.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d3b2566e52e46e0328aeca102ed58d6ca8c9092ea1b1dfc8e9857ccf8dbe0d"
+dependencies = [
+ "affinidi-crypto",
+ "affinidi-did-resolver-cache-sdk",
+ "affinidi-messaging-core",
+ "affinidi-messaging-delivery",
+ "affinidi-messaging-didcomm",
+ "affinidi-openid4vci",
+ "affinidi-openid4vp",
+ "affinidi-tdk",
+ "base64 0.22.1",
+ "chrono",
+ "curve25519-dalek",
+ "didwebvh-rs",
+ "ed25519-dalek",
+ "futures-util",
+ "getrandom 0.4.3",
+ "multibase",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "thiserror 2.0.19",
+ "tokio",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "vta-sdk"
+version = "0.19.22"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10198,39 +10231,6 @@ dependencies = [
  "x25519-dalek",
  "x509-parser 0.18.1",
  "zeroize",
-]
-
-[[package]]
-name = "vta-sdk"
-version = "0.19.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10d3b2566e52e46e0328aeca102ed58d6ca8c9092ea1b1dfc8e9857ccf8dbe0d"
-dependencies = [
- "affinidi-crypto",
- "affinidi-did-resolver-cache-sdk",
- "affinidi-messaging-core",
- "affinidi-messaging-delivery",
- "affinidi-messaging-didcomm",
- "affinidi-openid4vci",
- "affinidi-openid4vp",
- "affinidi-tdk",
- "base64 0.22.1",
- "chrono",
- "curve25519-dalek",
- "didwebvh-rs",
- "ed25519-dalek",
- "futures-util",
- "getrandom 0.4.3",
- "multibase",
- "reqwest 0.13.4",
- "serde",
- "serde_json",
- "sha2 0.11.0",
- "thiserror 2.0.19",
- "tokio",
- "tracing",
- "url",
- "uuid",
 ]
 
 [[package]]
@@ -10315,7 +10315,7 @@ dependencies = [
  "utoipa-axum",
  "uuid",
  "vta-cli-common",
- "vta-sdk 0.19.21",
+ "vta-sdk 0.19.22",
  "vta-service",
  "vti-common",
  "vti-secrets",
@@ -10337,7 +10337,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.19",
  "tokio",
- "vta-sdk 0.19.21",
+ "vta-sdk 0.19.22",
 ]
 
 [[package]]
@@ -10411,7 +10411,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.19.21",
+ "vta-sdk 0.19.22",
  "vtc-service",
  "vti-common",
  "vti-secrets",
@@ -10463,7 +10463,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.19.21",
+ "vta-sdk 0.19.22",
  "webauthn-rs",
  "zeroize",
 ]
@@ -10490,7 +10490,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.19.21",
+ "vta-sdk 0.19.22",
  "vta-service",
  "vti-common",
 ]
@@ -10519,7 +10519,7 @@ dependencies = [
  "tokio",
  "tracing",
  "vaultrs",
- "vta-sdk 0.19.21",
+ "vta-sdk 0.19.22",
  "vti-common",
 ]
 

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.19.21"
+version = "0.19.22"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/client/mod.rs
+++ b/vta-sdk/src/client/mod.rs
@@ -873,6 +873,20 @@ impl VtaClient {
     /// DIDComm path (which drops the HTTP status) still fails loudly.
     fn extract_trust_task_payload(doc: serde_json::Value) -> Result<serde_json::Value, VtaError> {
         if let Some(payload) = doc.get("payload") {
+            // A failed task still carries a `payload` — the error envelope goes
+            // *inside* it (`{ code, message, retryable }`). Treating "a payload
+            // is present" as success therefore hands the caller an error object
+            // to deserialise as a result, and the caller reports whatever field
+            // its result type happened to be missing. The real message — which
+            // may be as specific as "not supported over the DIDComm transport" —
+            // is discarded, and the failure reads like a schema mismatch.
+            //
+            // Keyed on `code` + `message`, mirroring the service's own denial
+            // check (`vta-service`'s trust-task `denial_code`, which reads
+            // `payload.code`).
+            if let Some(err) = Self::trust_task_error(payload) {
+                return Err(err);
+            }
             return Ok(payload.clone());
         }
         let reason = doc
@@ -882,6 +896,19 @@ impl VtaClient {
             .map(str::to_string)
             .unwrap_or_else(|| doc.to_string());
         Err(VtaError::Protocol(format!("trust task rejected: {reason}")))
+    }
+
+    /// Recognise a trust-task error envelope carried inside `payload`.
+    ///
+    /// Requires **both** `code` and `message` to be strings: `code` alone is a
+    /// plausible field on a legitimate result body, so demanding the pair keeps
+    /// a successful response from being mistaken for a failure.
+    fn trust_task_error(payload: &serde_json::Value) -> Option<VtaError> {
+        let code = payload.get("code")?.as_str()?;
+        let message = payload.get("message")?.as_str()?;
+        Some(VtaError::Protocol(format!(
+            "trust task failed [{code}]: {message}"
+        )))
     }
 
     /// Seal a cleartext `VaultSecret` JSON for `vault/upsert`'s `sealedSecret`
@@ -1121,6 +1148,64 @@ impl VtaClient {
 mod tests {
     use super::*;
     use crate::keys::KeyType;
+
+    // ── extract_trust_task_payload ──────────────────────────────────
+
+    /// A successful task returns its payload untouched.
+    #[test]
+    fn extract_returns_a_success_payload() {
+        let doc = serde_json::json!({
+            "id": "urn:uuid:1", "type": "spec/vta/x/1.0",
+            "payload": { "did": "did:webvh:QmScid:example.com", "names": [] },
+        });
+        let got = VtaClient::extract_trust_task_payload(doc).expect("should succeed");
+        assert_eq!(got["did"], "did:webvh:QmScid:example.com");
+    }
+
+    /// The regression: a *failed* task also carries a `payload`, holding the
+    /// error envelope. Returning it as success made callers deserialise an error
+    /// object as a result and report a missing field, hiding the real cause.
+    ///
+    /// This is the exact envelope seen from `list_agent_names`.
+    #[test]
+    fn extract_surfaces_an_error_envelope_inside_the_payload() {
+        let doc = serde_json::json!({
+            "id": "urn:uuid:1", "type": "spec/vta/webvh/agent-name/list/1.0",
+            "payload": {
+                "code": "internalError",
+                "message": "list_agent_names: validation error: agent-name operations \
+                            are not supported over the DIDComm transport; the hosting \
+                            server exposes them only via REST",
+                "retryable": true,
+            },
+        });
+        let err = VtaClient::extract_trust_task_payload(doc).expect_err("must be an error");
+        let msg = err.to_string();
+        assert!(msg.contains("internalError"), "{msg}");
+        assert!(
+            msg.contains("not supported over the DIDComm transport"),
+            "the actionable part of the message must survive: {msg}"
+        );
+    }
+
+    /// `code` without `message` is not treated as an error — a result body may
+    /// legitimately carry a `code`, so both are required before failing.
+    #[test]
+    fn extract_does_not_mistake_a_code_field_for_an_error() {
+        let doc = serde_json::json!({
+            "payload": { "code": "GB", "country": "United Kingdom" },
+        });
+        let got = VtaClient::extract_trust_task_payload(doc).expect("code alone is not an error");
+        assert_eq!(got["code"], "GB");
+    }
+
+    /// A rejection with no payload at all still reports its reason.
+    #[test]
+    fn extract_reports_a_rejection_without_a_payload() {
+        let doc = serde_json::json!({ "id": "urn:uuid:1", "reason": "not authorized" });
+        let err = VtaClient::extract_trust_task_payload(doc).expect_err("must be an error");
+        assert!(err.to_string().contains("not authorized"), "{err}");
+    }
 
     // ── encode_path_segment ─────────────────────────────────────────
 


### PR DESCRIPTION
A failed trust task still returns a `payload` — the error envelope goes **inside** it, as `{ code, message, retryable }`. `extract_trust_task_payload` treated *"a payload is present"* as success, so every caller got an error object to deserialise as a result, and reported whichever field its result type happened to be missing.

The real message was discarded. OpenVTC's agent-name manager showed:

```
Could not load agent names: decoding agent-name list result: missing field `did`
```

when the VTA had actually said:

```
agent-name operations are not supported over the DIDComm transport;
the hosting server exposes them only via REST
```

An actionable, specific diagnosis reduced to a schema complaint.

**This affects every consumer of `dispatch_trust_task`**, not one screen — a denied or failed task has been reading as a contract mismatch everywhere.

## Why this shape

The service already treats this envelope as its failure signal: trust-task `denial_code` reads `payload.code` to classify a denial. Recognising it in the SDK aligns the client with the convention the service is already using.

Keyed on `code` **and** `message` both being strings. `code` alone is plausible on a legitimate result body (a country code, a status code), so requiring the pair stops a successful response being mistaken for a failure — pinned by a test.

## Not addressed here

Agent-name operations genuinely are unimplemented on the VTA's DIDComm path to the hosting server (`vta-service/src/operations/did_webvh/mod.rs` — `Self::Rest(c)` else `AppError::Validation`). This change makes that fact **legible instead of misleading**; it does not make the operation work. That gap needs a separate decision: implement the ops over the DIDComm bridge, or configure affected server records to use REST.

## Verification

`cargo test -p vta-sdk --lib --features client`: **229 passed, 0 failed**. Four new tests — success passthrough, the exact `list_agent_names` envelope, `code`-without-`message` not misread as an error, and a payload-less rejection still reporting its reason.

Worth flagging: `client` is **not** a default feature, so `cargo build -p vta-sdk` does not compile this module at all — a plain build will not type-check changes here.

Version bumped to 0.19.21 per the release guard; `check-lockfile-self-pins.sh` reports no stale pins.