### PR TITLE
chore: refresh the vta-sdk lockfile self-pin to 0.19.21

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -401,7 +401,7 @@ dependencies = [
  "trust-tasks-rs",
  "url",
  "uuid",
- "vta-sdk 0.19.20",
+ "vta-sdk 0.19.21 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -10142,39 +10142,6 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.19.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89bfd9bbf74ea936a57729e01a1c69e14f74d06d22b70aa3872798dc723e6804"
-dependencies = [
- "affinidi-crypto",
- "affinidi-did-resolver-cache-sdk",
- "affinidi-messaging-core",
- "affinidi-messaging-delivery",
- "affinidi-messaging-didcomm",
- "affinidi-openid4vci",
- "affinidi-openid4vp",
- "affinidi-tdk",
- "base64 0.22.1",
- "chrono",
- "curve25519-dalek",
- "didwebvh-rs",
- "ed25519-dalek",
- "futures-util",
- "getrandom 0.4.3",
- "multibase",
- "reqwest 0.13.4",
- "serde",
- "serde_json",
- "sha2 0.11.0",
- "thiserror 2.0.19",
- "tokio",
- "tracing",
- "url",
- "uuid",
-]
-
-[[package]]
-name = "vta-sdk"
 version = "0.19.21"
 dependencies = [
  "affinidi-bbs",
@@ -10231,6 +10198,39 @@ dependencies = [
  "x25519-dalek",
  "x509-parser 0.18.1",
  "zeroize",
+]
+
+[[package]]
+name = "vta-sdk"
+version = "0.19.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d3b2566e52e46e0328aeca102ed58d6ca8c9092ea1b1dfc8e9857ccf8dbe0d"
+dependencies = [
+ "affinidi-crypto",
+ "affinidi-did-resolver-cache-sdk",
+ "affinidi-messaging-core",
+ "affinidi-messaging-delivery",
+ "affinidi-messaging-didcomm",
+ "affinidi-openid4vci",
+ "affinidi-openid4vp",
+ "affinidi-tdk",
+ "base64 0.22.1",
+ "chrono",
+ "curve25519-dalek",
+ "didwebvh-rs",
+ "ed25519-dalek",
+ "futures-util",
+ "getrandom 0.4.3",
+ "multibase",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "thiserror 2.0.19",
+ "tokio",
+ "tracing",
+ "url",
+ "uuid",
 ]
 
 [[package]]


### PR DESCRIPTION
`main` is red on `lockfile self-pins`, and so is every open PR (#753), since
vta-sdk 0.19.21 published from #750.

```
STALE vta-sdk: workspace 0.19.21 but Cargo.lock pins registry copy at 0.19.20
       fix: cargo update -p 'https://github.com/rust-lang/crates.io-index#vta-sdk@0.19.20' --precise 0.19.21
```

This is that one-line refresh.

## Why it went stale now

Nothing changed in the lockfile — publication did. While 0.19.21 was unpublished
the guard took its documented carve-out (a local version not yet on crates.io
*cannot* be pinned, so it is reported and allowed). The moment 0.19.21 hit
crates.io the same state became a hard failure, which is correct: from then on
the pin is refreshable and a stale one is a real release hazard.

The publish workflow is meant to refresh this itself right after publishing —
the only moment the refresh is possible — but opened no PR. That's the known
org-ruleset blocker (GitHub Actions cannot create PRs), the same one behind #706
and #711.

## Scope

Only the `vta-sdk` registry package moves: version, `source`, checksum, its
dependency list, and the single dependent line that references it. No crate
source changes, so no version bump is due — `check-version-bumps.sh` agrees.
`cargo check -p vtc-service --tests` (the dev-dep chain that pulls the registry
copy: `vtc-service` → `affinidi-messaging-test-mediator` → `affinidi-messaging-mediator`
→ `vta-sdk`) compiles.

## Why it matters

Per the guard's own header: `cargo publish --locked` verifies a dependent
against the pinned registry copy, so the dependent is built against the OLD
vta-sdk source and fails — silently, because the workspace's path-dep build
stays green throughout. That's how pnm-cli sat unpublished for three releases.

Unblocks #753. Note this will recur on the next vta-sdk publish until the
workflow can open its own refresh PR.
