### PR TITLE
fix(vta-service): use the REST endpoint a server already advertises for agent names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10235,7 +10235,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.12.10"
+version = "0.12.11"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.12.10"
+version = "0.12.11"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/operations/did_webvh/mod.rs
+++ b/vta-service/src/operations/did_webvh/mod.rs
@@ -1440,6 +1440,13 @@ pub(super) enum WebvhTransport<'a> {
     DIDComm {
         bridge: &'a DIDCommBridge,
         server_did: String,
+        /// A REST endpoint the same server also advertises, if any.
+        ///
+        /// Agent-name operations exist only over REST — the hosting server's
+        /// DIDComm dispatch table has no agent-name verbs — so they fall back
+        /// to this rather than refusing on a server that advertises both, which
+        /// is the normal deployment shape.
+        rest_url: Option<String>,
     },
 }
 
@@ -1467,6 +1474,7 @@ impl<'a> WebvhTransport<'a> {
                 Ok(Self::DIDComm {
                     bridge: didcomm_bridge,
                     server_did: server.did.clone(),
+                    rest_url: transport::resolve_rest_endpoint(&resolved.doc.service),
                 })
             }
             Some(transport::ResolvedTransport::Rest { url }) => {
@@ -1495,7 +1503,9 @@ impl<'a> WebvhTransport<'a> {
     ) -> Result<RequestUriResponse, AppError> {
         match self {
             Self::Rest(c) => c.request_uri(path, domain).await,
-            Self::DIDComm { bridge, server_did } => {
+            Self::DIDComm {
+                bridge, server_did, ..
+            } => {
                 WebvhDIDCommClient::new(bridge, server_did)
                     .request_uri(path, domain)
                     .await
@@ -1511,7 +1521,9 @@ impl<'a> WebvhTransport<'a> {
     ) -> Result<(), AppError> {
         match self {
             Self::Rest(c) => c.publish_did(mnemonic, log_content, domain).await,
-            Self::DIDComm { bridge, server_did } => {
+            Self::DIDComm {
+                bridge, server_did, ..
+            } => {
                 WebvhDIDCommClient::new(bridge, server_did)
                     .publish_did(mnemonic, log_content, domain)
                     .await
@@ -1586,7 +1598,9 @@ impl<'a> WebvhTransport<'a> {
                 }
                 Err(e) => Err(e),
             },
-            Self::DIDComm { bridge, server_did } => {
+            Self::DIDComm {
+                bridge, server_did, ..
+            } => {
                 WebvhDIDCommClient::new(bridge, server_did)
                     .publish_did(mnemonic, log_content, domain)
                     .await
@@ -1616,7 +1630,9 @@ impl<'a> WebvhTransport<'a> {
                 }
                 Err(e) => Err(e),
             },
-            Self::DIDComm { bridge, server_did } => {
+            Self::DIDComm {
+                bridge, server_did, ..
+            } => {
                 WebvhDIDCommClient::new(bridge, server_did)
                     .delete_did(mnemonic, domain)
                     .await
@@ -1648,10 +1664,48 @@ impl<'a> WebvhTransport<'a> {
                 }
                 Err(e) => Err(e),
             },
-            Self::DIDComm { bridge, server_did } => {
+            Self::DIDComm {
+                bridge, server_did, ..
+            } => {
                 WebvhDIDCommClient::new(bridge, server_did)
                     .register_did_atomic(path, did_log, force, domain)
                     .await
+            }
+        }
+    }
+
+    /// A REST client able to serve agent-name operations, or a clear error.
+    ///
+    /// These operations exist over REST only — the hosting server's
+    /// transport-agnostic DIDComm dispatch table carries no agent-name verbs.
+    /// Refusing outright on a DIDComm-preferred server was wrong, though,
+    /// because a deployed server normally advertises `WebVHHosting` *and*
+    /// `DIDCommMessaging` together: the REST endpoint was sitting unused in the
+    /// same document that selected DIDComm.
+    ///
+    /// `owned` gives a client constructed here somewhere to live for as long as
+    /// the borrow the caller holds; on the REST transport it stays empty and the
+    /// existing client — which may already carry an access token — is reused.
+    fn agent_name_client<'c>(
+        &'c mut self,
+        owned: &'c mut Option<WebvhClient>,
+    ) -> Result<&'c mut WebvhClient, AppError> {
+        match self {
+            Self::Rest(c) => Ok(c),
+            Self::DIDComm {
+                rest_url,
+                server_did,
+                ..
+            } => {
+                let url = rest_url.as_deref().ok_or_else(|| {
+                    AppError::Validation(format!(
+                        "agent-name operations need a REST endpoint, and server DID \
+                         {server_did} advertises none; the hosting server exposes \
+                         agent names only via REST"
+                    ))
+                })?;
+                *owned = Some(WebvhClient::new(url, server_did)?);
+                Ok(owned.as_mut().expect("just assigned"))
             }
         }
     }
@@ -1669,13 +1723,8 @@ impl<'a> WebvhTransport<'a> {
         auth_ctx: &auth_cache::AuthContext<'_>,
         server: &WebvhServerRecord,
     ) -> Result<Vec<crate::webvh_client::AgentNameEntryWire>, AppError> {
-        let Self::Rest(c) = self else {
-            return Err(AppError::Validation(
-                "agent-name operations are not supported over the DIDComm transport; \
-                 the hosting server exposes them only via REST"
-                    .to_string(),
-            ));
-        };
+        let mut owned = None;
+        let c = self.agent_name_client(&mut owned)?;
         match c.list_agent_names(mnemonic, domain).await {
             Ok(v) => Ok(v),
             Err(AppError::Unauthorized(_)) => {
@@ -1699,13 +1748,8 @@ impl<'a> WebvhTransport<'a> {
         auth_ctx: &auth_cache::AuthContext<'_>,
         server: &WebvhServerRecord,
     ) -> Result<crate::webvh_client::AgentNameAvailabilityWire, AppError> {
-        let Self::Rest(c) = self else {
-            return Err(AppError::Validation(
-                "agent-name operations are not supported over the DIDComm transport; \
-                 the hosting server exposes them only via REST"
-                    .to_string(),
-            ));
-        };
+        let mut owned = None;
+        let c = self.agent_name_client(&mut owned)?;
         match c.check_agent_name(name, domain).await {
             Ok(v) => Ok(v),
             Err(AppError::Unauthorized(_)) => {
@@ -1731,13 +1775,8 @@ impl<'a> WebvhTransport<'a> {
         auth_ctx: &auth_cache::AuthContext<'_>,
         server: &WebvhServerRecord,
     ) -> Result<(), AppError> {
-        let Self::Rest(c) = self else {
-            return Err(AppError::Validation(
-                "agent-name operations are not supported over the DIDComm transport; \
-                 the hosting server exposes them only via REST"
-                    .to_string(),
-            ));
-        };
+        let mut owned = None;
+        let c = self.agent_name_client(&mut owned)?;
         let op = verb.endpoint();
         match c.agent_name_op(op, mnemonic, name, did_log, domain).await {
             Ok(()) => Ok(()),

--- a/vta-service/src/operations/did_webvh/transport.rs
+++ b/vta-service/src/operations/did_webvh/transport.rs
@@ -83,6 +83,33 @@ pub(crate) fn resolve_server_transport<S: ServiceEntry>(
     None
 }
 
+/// The REST endpoint a server advertises, if any — **regardless** of whether it
+/// also advertises DIDComm.
+///
+/// [`resolve_server_transport`] returns as soon as it sees a DIDComm service,
+/// which is right for the operations both transports implement. Agent-name
+/// operations are not among them: the hosting server's transport-agnostic
+/// DIDComm dispatch table carries no agent-name verbs, so they exist over REST
+/// alone.
+///
+/// A deployed hosting server normally advertises `WebVHHosting` *and*
+/// `DIDCommMessaging` together. Without this, the DIDComm preference hides the
+/// REST endpoint sitting in the same document, and an agent-name call fails on
+/// a server that is perfectly able to serve it.
+pub(crate) fn resolve_rest_endpoint<S: ServiceEntry>(services: &[S]) -> Option<String> {
+    services.iter().find_map(|svc| {
+        if !svc.types().iter().any(is_webvh_rest) {
+            return None;
+        }
+        let url = svc
+            .endpoint_uri()?
+            .trim_matches('"')
+            .trim_end_matches('/')
+            .to_string();
+        (!url.is_empty()).then_some(url)
+    })
+}
+
 #[inline]
 fn is_didcomm(t: &String) -> bool {
     t == SVC_DIDCOMM
@@ -118,6 +145,74 @@ impl ServiceEntry for affinidi_tdk::did_common::service::Service {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── resolve_rest_endpoint ───────────────────────────────────────
+
+    /// The case that motivated this: a server advertising BOTH transports.
+    /// `resolve_server_transport` picks DIDComm, and the REST endpoint must
+    /// still be discoverable — agent-name operations exist only over REST.
+    #[test]
+    fn rest_endpoint_is_found_even_when_didcomm_is_advertised() {
+        let services = vec![
+            TestService::new(&["WebVHHosting"], Some("https://host.example/")),
+            TestService::new(&["DIDCommMessaging"], Some("did:webvh:QmMED:med.example")),
+        ];
+        // DIDComm still wins for transport selection...
+        assert!(matches!(
+            resolve_server_transport(&services),
+            Some(ResolvedTransport::DIDComm)
+        ));
+        // ...but the REST endpoint is not hidden by that preference.
+        assert_eq!(
+            resolve_rest_endpoint(&services).as_deref(),
+            Some("https://host.example")
+        );
+    }
+
+    /// Order must not matter — the DIDComm entry may come first.
+    #[test]
+    fn rest_endpoint_is_order_independent() {
+        let services = vec![
+            TestService::new(&["DIDCommMessaging"], Some("did:webvh:QmMED:med.example")),
+            TestService::new(&["WebVHHosting"], Some("https://host.example")),
+        ];
+        assert_eq!(
+            resolve_rest_endpoint(&services).as_deref(),
+            Some("https://host.example")
+        );
+    }
+
+    /// The legacy service type is accepted here too, matching
+    /// `resolve_server_transport`.
+    #[test]
+    fn rest_endpoint_accepts_the_legacy_type() {
+        let services = vec![TestService::new(
+            &["WebVHHostingService"],
+            Some("https://legacy.example"),
+        )];
+        assert_eq!(
+            resolve_rest_endpoint(&services).as_deref(),
+            Some("https://legacy.example")
+        );
+    }
+
+    /// A DIDComm-only server genuinely has nowhere to send an agent-name call,
+    /// and must report that rather than inventing an endpoint.
+    #[test]
+    fn rest_endpoint_is_none_for_a_didcomm_only_server() {
+        let services = vec![TestService::new(
+            &["DIDCommMessaging"],
+            Some("did:webvh:QmMED:med.example"),
+        )];
+        assert_eq!(resolve_rest_endpoint(&services), None);
+    }
+
+    /// An advertised-but-empty URI is not an endpoint.
+    #[test]
+    fn rest_endpoint_ignores_an_empty_uri() {
+        let services = vec![TestService::new(&["WebVHHosting"], Some(""))];
+        assert_eq!(resolve_rest_endpoint(&services), None);
+    }
 
     struct TestService {
         types: Vec<String>,


### PR DESCRIPTION
Managing an agent name failed on a server perfectly able to serve the request:

```
agent-name operations are not supported over the DIDComm transport;
the hosting server exposes them only via REST
```

Both halves of that sentence are true. Together they were still the wrong conclusion.

## What was happening

`resolve_server_transport` returns `DIDComm` the moment it sees a `DIDCommMessaging` service, without looking further ([`transport.rs:69`](../blob/main/vta-service/src/operations/did_webvh/transport.rs)) — correct for every operation both transports implement.

Agent names are not among them. The hosting server's transport-agnostic DIDComm dispatch table handles nine `MSG_*` types and **no agent-name verbs**, so `set`/`remove`/`enable`/`disable`/`list`/`check` exist over REST alone.

But a deployed hosting server advertises `WebVHHosting` **and** `DIDCommMessaging` together — the normal shape, not an edge case:

```json
"service": [
  {"type": "WebVHHosting",      "serviceEndpoint": {"uri": "https://host.example"}},
  {"type": "TSPTransport",      ...},
  {"type": "DIDCommMessaging",  ...}
]
```

So the DIDComm preference was **hiding a REST endpoint in the very same document that selected DIDComm**, and the operation was refused rather than sent somewhere it would have worked.

## The fix

- `resolve_rest_endpoint` finds that endpoint regardless of the DIDComm preference.
- `WebvhTransport::DIDComm` carries it.
- The three agent-name methods go through `agent_name_client`, which prefers the existing REST client (keeping any access token it already holds) and otherwise builds one from the advertised URL.

401-retry and auth-cache behaviour around them is unchanged.

A DIDComm-only server still fails — there is genuinely nowhere to send the request — but now says so in those terms and names the server DID, instead of implying the operation is impossible anywhere.

## Not addressed

Implementing the agent-name verbs over DIDComm. That needs them in the hosting server's dispatch table first, and is a larger change across two repos. This makes the operation work on the deployment shape actually in use.

## Verification

`cargo test -p vta-service --lib`: **950 passed, 0 failed**. Five new resolver tests — the both-transports case that motivated this, order-independence, the legacy `WebVHHostingService` type, a DIDComm-only server correctly yielding `None`, and an empty URI not counting as an endpoint.

Version bumped to 0.12.11 per the release guard. Pre-existing clippy warnings in `did_peer.rs`/`did_webvh.rs` are untouched and unrelated.

**Companion:** #753 makes the *reporting* of failures like this legible — without it, this error still surfaces in OpenVTC as a bogus `missing field` decode error.