### PR TITLE
fix(vta-service): honour the hostingPath a webvh server advertises

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10235,7 +10235,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.12.11"
+version = "0.12.12"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -401,7 +401,7 @@ dependencies = [
  "trust-tasks-rs",
  "url",
  "uuid",
- "vta-sdk 0.19.21",
+ "vta-sdk 0.19.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -10142,39 +10142,6 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.19.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10d3b2566e52e46e0328aeca102ed58d6ca8c9092ea1b1dfc8e9857ccf8dbe0d"
-dependencies = [
- "affinidi-crypto",
- "affinidi-did-resolver-cache-sdk",
- "affinidi-messaging-core",
- "affinidi-messaging-delivery",
- "affinidi-messaging-didcomm",
- "affinidi-openid4vci",
- "affinidi-openid4vp",
- "affinidi-tdk",
- "base64 0.22.1",
- "chrono",
- "curve25519-dalek",
- "didwebvh-rs",
- "ed25519-dalek",
- "futures-util",
- "getrandom 0.4.3",
- "multibase",
- "reqwest 0.13.4",
- "serde",
- "serde_json",
- "sha2 0.11.0",
- "thiserror 2.0.19",
- "tokio",
- "tracing",
- "url",
- "uuid",
-]
-
-[[package]]
-name = "vta-sdk"
 version = "0.19.22"
 dependencies = [
  "affinidi-bbs",
@@ -10231,6 +10198,39 @@ dependencies = [
  "x25519-dalek",
  "x509-parser 0.18.1",
  "zeroize",
+]
+
+[[package]]
+name = "vta-sdk"
+version = "0.19.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90eab9c3036db79750b8113d7439f0d92ddb90f140b3ab5cc07403c0d1d08681"
+dependencies = [
+ "affinidi-crypto",
+ "affinidi-did-resolver-cache-sdk",
+ "affinidi-messaging-core",
+ "affinidi-messaging-delivery",
+ "affinidi-messaging-didcomm",
+ "affinidi-openid4vci",
+ "affinidi-openid4vp",
+ "affinidi-tdk",
+ "base64 0.22.1",
+ "chrono",
+ "curve25519-dalek",
+ "didwebvh-rs",
+ "ed25519-dalek",
+ "futures-util",
+ "getrandom 0.4.3",
+ "multibase",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "thiserror 2.0.19",
+ "tokio",
+ "tracing",
+ "url",
+ "uuid",
 ]
 
 [[package]]

--- a/deny.toml
+++ b/deny.toml
@@ -13,17 +13,6 @@
 [advisories]
 version = 2
 ignore = [
-  { id = "GHSA-cq8v-f236-94qc", reason = """
-  rand 0.8 soundness issue: `rand::rng()` is unsound when wrapped by a
-  custom logger that attempts to source entropy from `ThreadRng` during
-  signal handling. We use `rand::random()` and `rand::rng().fill_bytes()`
-  directly, with no custom logger wrapper — the unsafe interaction does
-  not occur in our code.
-
-  Pulled transitively by jsonwebtoken 10.3.0 (latest), rsa 0.9.10, and
-  ssi-crypto 0.2.1. Drop this ignore when any of those release a version
-  that depends on rand 0.9.3+.
-  """ },
 
   { id = "RUSTSEC-2026-0099", reason = """
   rustls-webpki 0.101.x accepts name constraints for certificates
@@ -60,28 +49,6 @@ ignore = [
   rustls-webpki 0.101 ships a fix.
   """ },
 
-  { id = "GHSA-82j2-j2ch-gfr8", reason = """
-  rustls-webpki: index-out-of-bounds panic in `bit_string_flags()`
-  reachable through `BorrowedCertRevocationList::from_der()` via the
-  `issuingDistributionPoint` CRL extension when the BIT STRING
-  content is exactly `[0x00]`. Fixed in 0.103.13; 0.101.x and 0.102.x
-  branches are not patched.
-
-  Same precondition and same transitive path as RUSTSEC-2026-0104:
-  the upstream advisory is explicit that "CRL checking is opt-in" —
-  only applications that pass `RevocationOptions` to
-  `verify_for_usage()` and load attacker-influenced CRL bytes are
-  affected. Our 0.101.x copy lives behind AWS SDK's
-  `aws-smithy-http-client` → `hyper-rustls` 0.24 → rustls 0.21 used
-  for AWS API endpoint TLS; that path does not enable revocation
-  checking and never fetches CRLs. The default (and our actual)
-  rustls config is unaffected.
-
-  No RUSTSEC ID assigned at the time of writing (advisory published
-  2026-04-24). Drop when AWS SDK retires the rustls 0.21 code path,
-  or when rustls-webpki 0.101 ships a backported fix.
-  """ },
-
   { id = "RUSTSEC-2025-0134", reason = """
   rustls-pemfile is unmaintained. Pulled transitively (in two
   different versions) through the AWS SDK rustls 0.21 path —
@@ -92,22 +59,6 @@ ignore = [
 
   Drop when AWS SDK retires the rustls 0.21 code path; both 0.27
   hyper-rustls and rustls 0.23 have moved to rustls-pki-types.
-  """ },
-
-  { id = "RUSTSEC-2023-0071", reason = """
-  rsa 0.9.x: Marvin Attack — potential key recovery through timing
-  sidechannels in RSA decryption. Pulled transitively by
-  jsonwebtoken 10.3.0; no other path through our graph.
-
-  Not exploitable in our code. JWT verification only checks
-  signatures, never decrypts. Our access tokens use EdDSA
-  (Ed25519), not RSA — the rsa code path is dead in our build.
-  Our only RSA decryption is the KMS CMS unwrap on the Nitro
-  attested bootstrap path, which we deliberately migrated to
-  `aws-lc-rs` in 0.5 specifically to drop this exposure.
-
-  Drop when jsonwebtoken stops depending on `rsa`, or when the
-  `rsa` crate ships a constant-time implementation.
   """ },
 
   { id = "RUSTSEC-2024-0370", reason = """
@@ -151,6 +102,25 @@ ignore = [
   is the only flagged risk.
 
   Drop when uniffi (0.28.x) removes its `paste` dependency.
+  """ },
+
+  { id = "RUSTSEC-2026-0215", reason = """
+  smallstr 0.3.1 is unmaintained. Not a vulnerability — no CVE, no known
+  exploit; the crate is a `SmallVec`-backed string type and the advisory is
+  purely a maintenance-status signal.
+
+  Transitive-only and deep: smallstr <- json-syntax <- json-ld <-
+  ssi-json-ld <- ssi-claims-core <- ssi-dids-core <-
+  affinidi-did-resolver-cache-sdk. Nothing in this workspace names it, and
+  we do not choose it — the `ssi-*` stack does, for JSON-LD parsing.
+
+  No safe upgrade exists (all versions are affected), so there is nothing to
+  bump to. The suggested replacements (compact_str, smol_str) are a change
+  for the `ssi-json-ld`/`json-syntax` maintainers to make, not something we
+  can force from here without forking the JSON-LD stack.
+
+  Drop this ignore when json-syntax releases a version off smallstr and the
+  `ssi-*` chain picks it up.
   """ },
 ]
 

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.12.11"
+version = "0.12.12"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/operations/did_webvh/transport.rs
+++ b/vta-service/src/operations/did_webvh/transport.rs
@@ -43,6 +43,29 @@ pub(crate) const SVC_WEBVH_HOSTING_LEGACY: &str = "WebVHHostingService";
 pub(crate) trait ServiceEntry {
     fn types(&self) -> &[String];
     fn endpoint_uri(&self) -> Option<String>;
+    /// The `hostingPath` the endpoint advertises, if any.
+    ///
+    /// A hosting server may serve its control plane under a prefix rather than
+    /// at the origin root — `webvh.storm.ws` advertises `/webvh`. The DID
+    /// templates have emitted this field all along, and nothing read it, so
+    /// every REST request was built against the bare origin and 404'd on any
+    /// server that uses one.
+    fn hosting_path(&self) -> Option<String> {
+        None
+    }
+}
+
+/// Join an advertised origin and its optional hosting path into a base URL.
+///
+/// Both halves arrive from a DID document, so neither's punctuation can be
+/// assumed: the origin may carry a trailing slash and the path may or may not
+/// lead with one.
+fn join_base(uri: &str, hosting_path: Option<&str>) -> String {
+    let base = uri.trim_matches('"').trim_end_matches('/');
+    match hosting_path.map(|p| p.trim_matches('"').trim_matches('/')) {
+        Some(p) if !p.is_empty() => format!("{base}/{p}"),
+        _ => base.to_string(),
+    }
 }
 
 /// Outcome of walking a server's service array.
@@ -73,7 +96,7 @@ pub(crate) fn resolve_server_transport<S: ServiceEntry>(
         if svc.types().iter().any(is_webvh_rest)
             && let Some(raw) = svc.endpoint_uri()
         {
-            let url = raw.trim_matches('"').trim_end_matches('/').to_string();
+            let url = join_base(&raw, svc.hosting_path().as_deref());
             if url.is_empty() {
                 continue;
             }
@@ -101,11 +124,7 @@ pub(crate) fn resolve_rest_endpoint<S: ServiceEntry>(services: &[S]) -> Option<S
         if !svc.types().iter().any(is_webvh_rest) {
             return None;
         }
-        let url = svc
-            .endpoint_uri()?
-            .trim_matches('"')
-            .trim_end_matches('/')
-            .to_string();
+        let url = join_base(&svc.endpoint_uri()?, svc.hosting_path().as_deref());
         (!url.is_empty()).then_some(url)
     })
 }
@@ -140,11 +159,89 @@ impl ServiceEntry for affinidi_tdk::did_common::service::Service {
     fn endpoint_uri(&self) -> Option<String> {
         self.service_endpoint.get_uri()
     }
+    fn hosting_path(&self) -> Option<String> {
+        // `Endpoint` models only `uri`; `hostingPath` sits beside it in the
+        // same object, reachable through the untyped map form.
+        use affinidi_tdk::did_common::service::Endpoint;
+        let Endpoint::Map(value) = &self.service_endpoint else {
+            return None;
+        };
+        let obj = match value {
+            serde_json::Value::Array(a) => a.first()?,
+            other => other,
+        };
+        obj.get("hostingPath")
+            .and_then(|v| v.as_str())
+            .map(str::to_string)
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── hostingPath ─────────────────────────────────────────────────
+
+    /// The live failure this fixes: `webvh.storm.ws` advertises
+    /// `{"uri":"https://webvh.storm.ws","hostingPath":"/webvh"}`, and every
+    /// REST request was built against the bare origin — so the control plane at
+    /// `/webvh/api/...` answered 404.
+    #[test]
+    fn rest_base_includes_the_advertised_hosting_path() {
+        let services = vec![TestService::with_hosting_path(
+            &["WebVHHosting"],
+            Some("https://webvh.storm.ws"),
+            Some("/webvh"),
+        )];
+        assert_eq!(
+            resolve_rest_endpoint(&services).as_deref(),
+            Some("https://webvh.storm.ws/webvh")
+        );
+        assert_eq!(
+            resolve_server_transport(&services),
+            Some(ResolvedTransport::Rest {
+                url: "https://webvh.storm.ws/webvh".to_string()
+            })
+        );
+    }
+
+    /// Neither half's punctuation can be assumed — both come from a document.
+    #[test]
+    fn rest_base_join_is_slash_tolerant() {
+        for (uri, path) in [
+            ("https://h.example/", "/webvh"),
+            ("https://h.example", "webvh"),
+            ("https://h.example/", "webvh/"),
+        ] {
+            let services = vec![TestService::with_hosting_path(
+                &["WebVHHosting"],
+                Some(uri),
+                Some(path),
+            )];
+            assert_eq!(
+                resolve_rest_endpoint(&services).as_deref(),
+                Some("https://h.example/webvh"),
+                "uri={uri} path={path}"
+            );
+        }
+    }
+
+    /// A server serving at the origin root is unchanged — no empty segment.
+    #[test]
+    fn rest_base_is_unchanged_without_a_hosting_path() {
+        for path in [None, Some(""), Some("/")] {
+            let services = vec![TestService::with_hosting_path(
+                &["WebVHHosting"],
+                Some("https://h.example"),
+                path,
+            )];
+            assert_eq!(
+                resolve_rest_endpoint(&services).as_deref(),
+                Some("https://h.example"),
+                "path={path:?}"
+            );
+        }
+    }
 
     // ── resolve_rest_endpoint ───────────────────────────────────────
 
@@ -217,18 +314,29 @@ mod tests {
     struct TestService {
         types: Vec<String>,
         uri: Option<String>,
+        hosting_path: Option<String>,
     }
     impl TestService {
         fn new(types: &[&str], uri: Option<&str>) -> Self {
             Self {
                 types: types.iter().map(|s| s.to_string()).collect(),
                 uri: uri.map(String::from),
+                hosting_path: None,
+            }
+        }
+        fn with_hosting_path(types: &[&str], uri: Option<&str>, path: Option<&str>) -> Self {
+            Self {
+                hosting_path: path.map(String::from),
+                ..Self::new(types, uri)
             }
         }
     }
     impl ServiceEntry for TestService {
         fn types(&self) -> &[String] {
             &self.types
+        }
+        fn hosting_path(&self) -> Option<String> {
+            self.hosting_path.clone()
         }
         fn endpoint_uri(&self) -> Option<String> {
             self.uri.clone()


### PR DESCRIPTION
A hosting server may serve its control plane under a path prefix rather than at the origin root. `webvh.storm.ws` advertises exactly that:

```json
{"type":"WebVHHosting",
 "serviceEndpoint":{"uri":"https://webvh.storm.ws","hostingPath":"/webvh"}}
```

The DID templates have emitted `hostingPath` all along — it's in all three `did-host-http*` templates — and **nothing ever read it**. Transport resolution took `serviceEndpoint.uri` alone, so every REST request was built against the bare origin:

```
GET https://webvh.storm.ws/api/dids/magic-depart        -> 404
GET https://webvh.storm.ws/webvh/api/dids/magic-depart     (the real route)
```

That 404 is the live failure behind the agent-name manager error.

## Why it went unnoticed

Operations both transports implement prefer DIDComm, so the REST base was rarely exercised against a server that uses a prefix. Agent-name operations have no DIDComm form, so they were the first to depend on that base being correct.

## Change

`ServiceEntry` gains `hosting_path`, and `join_base` joins the two halves tolerantly — neither's punctuation can be assumed, since both come from a document a third party wrote (`https://h/` + `webvh`, `https://h` + `/webvh`, etc. all resolve alike).

Both `resolve_server_transport` and `resolve_rest_endpoint` go through it, so a REST-only server benefits too. A server advertising no prefix (absent, empty, or `"/"`) resolves exactly as before — pinned by a test.

`Endpoint` models only `uri`, so `hostingPath` is read from the untyped map form it sits beside.

## Verification

`cargo test -p vta-service --lib`: **953 passed, 0 failed** (22 in `transport`). fmt clean, `--locked` clean, version bumped to 0.12.12 per the release guard.

## Note

Separately, agent-name verbs are being added to the hosting server's DIDComm dispatch table so they stop depending on REST at all. This fix stands on its own regardless: it repairs the REST base for every server that advertises a prefix.