### PR TITLE
fix: remove the vta-sdk lockfile self-pin instead of chasing it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -401,7 +401,7 @@ dependencies = [
  "trust-tasks-rs",
  "url",
  "uuid",
- "vta-sdk 0.19.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vta-sdk",
 ]
 
 [[package]]
@@ -2486,7 +2486,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.19.22",
+ "vta-sdk",
 ]
 
 [[package]]
@@ -3287,7 +3287,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.19.22",
+ "vta-sdk",
 ]
 
 [[package]]
@@ -6765,7 +6765,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.19.22",
+ "vta-sdk",
 ]
 
 [[package]]
@@ -10081,7 +10081,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.19",
  "tokio",
- "vta-sdk 0.19.22",
+ "vta-sdk",
  "vti-common",
  "x25519-dalek",
 ]
@@ -10114,7 +10114,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.19.22",
+ "vta-sdk",
 ]
 
 [[package]]
@@ -10137,7 +10137,7 @@ dependencies = [
  "tracing-subscriber",
  "trust-tasks-rs",
  "uniffi",
- "vta-sdk 0.19.22",
+ "vta-sdk",
 ]
 
 [[package]]
@@ -10198,39 +10198,6 @@ dependencies = [
  "x25519-dalek",
  "x509-parser 0.18.1",
  "zeroize",
-]
-
-[[package]]
-name = "vta-sdk"
-version = "0.19.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90eab9c3036db79750b8113d7439f0d92ddb90f140b3ab5cc07403c0d1d08681"
-dependencies = [
- "affinidi-crypto",
- "affinidi-did-resolver-cache-sdk",
- "affinidi-messaging-core",
- "affinidi-messaging-delivery",
- "affinidi-messaging-didcomm",
- "affinidi-openid4vci",
- "affinidi-openid4vp",
- "affinidi-tdk",
- "base64 0.22.1",
- "chrono",
- "curve25519-dalek",
- "didwebvh-rs",
- "ed25519-dalek",
- "futures-util",
- "getrandom 0.4.3",
- "multibase",
- "reqwest 0.13.4",
- "serde",
- "serde_json",
- "sha2 0.11.0",
- "thiserror 2.0.19",
- "tokio",
- "tracing",
- "url",
- "uuid",
 ]
 
 [[package]]
@@ -10315,7 +10282,7 @@ dependencies = [
  "utoipa-axum",
  "uuid",
  "vta-cli-common",
- "vta-sdk 0.19.22",
+ "vta-sdk",
  "vta-service",
  "vti-common",
  "vti-secrets",
@@ -10337,7 +10304,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.19",
  "tokio",
- "vta-sdk 0.19.22",
+ "vta-sdk",
 ]
 
 [[package]]
@@ -10411,7 +10378,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.19.22",
+ "vta-sdk",
  "vtc-service",
  "vti-common",
  "vti-secrets",
@@ -10463,7 +10430,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.19.22",
+ "vta-sdk",
  "webauthn-rs",
  "zeroize",
 ]
@@ -10490,7 +10457,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.19.22",
+ "vta-sdk",
  "vta-service",
  "vti-common",
 ]
@@ -10519,7 +10486,7 @@ dependencies = [
  "tokio",
  "tracing",
  "vaultrs",
- "vta-sdk 0.19.22",
+ "vta-sdk",
  "vti-common",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -321,3 +321,47 @@ unsafe_op_in_unsafe_fn = "warn"
 needless_pass_by_value = "allow"
 too_many_arguments = "allow"
 type_complexity = "allow"
+
+# Make the workspace copy of `vta-sdk` the ONLY one in the graph.
+#
+# A transitive dev-dependency pulls our own crate back in from crates.io —
+#
+#   vtc-service [dev-dependencies]
+#     -> affinidi-messaging-test-mediator
+#       -> affinidi-messaging-mediator
+#         -> vta-sdk   (registry, NOT the workspace path copy)
+#
+# so without this, Cargo.lock carries two `vta-sdk` nodes: the path copy at the
+# local version and a registry copy pinned at whatever was current when that
+# dependency was last resolved. That second node is a standing hazard. It goes
+# stale the instant we publish, `cargo publish --locked` verifies dependents
+# against it, and a dependent therefore gets built against the PREVIOUS
+# release's source — silently, because the workspace's own path-dep build stays
+# green throughout. That is how pnm-cli 0.11.2 was verified against vta-sdk
+# 0.19.11 minutes after 0.19.12 shipped, and sat unpublished for three releases.
+#
+# Refreshing the pin after each publish was the previous fix, and it can only
+# happen in the publish job (the version does not exist until then), which means
+# committing to a protected branch from CI — blocked by the org ruleset, so the
+# refresh PR could not be opened and main kept going stale. Seven releases in a
+# row ended that way.
+#
+# Patching removes the second node instead of chasing it. Note the patch is
+# workspace-local: `cargo publish`'s packaged verification build does not see it
+# and resolves `vta-sdk` from the registry, picking the newest published
+# version — which, in a release run, is the one published moments earlier in the
+# same loop. So the property the self-pin was trying to guarantee now holds by
+# construction.
+#
+# Trade-off worth knowing: the published `affinidi-messaging-mediator` now
+# compiles against our local `vta-sdk` rather than the published one. A
+# `vta-sdk` change that breaks it surfaces here immediately instead of after a
+# release — but it is a combination that does not exist in the wild, so a
+# breaking change within `0.19.x` shows up as a confusing build failure in a
+# third-party crate.
+#
+# One entry per crate that gets pulled back in. `scripts/check-lockfile-self-pins.sh`
+# is what tells you a new one has appeared: it now passes with "nothing to
+# check", and that is the expected steady state.
+[patch.crates-io]
+vta-sdk = { path = "vta-sdk" }

--- a/scripts/check-lockfile-self-pins.sh
+++ b/scripts/check-lockfile-self-pins.sh
@@ -43,6 +43,16 @@
 # refreshes the pin immediately after publishing the crate, which is the only
 # moment the refresh is actually possible.
 #
+# STATUS: the workspace now carries a `[patch.crates-io]` entry for every crate
+# that was being pulled back in (see the root Cargo.toml), so the registry
+# copies no longer exist and this guard passes with "nothing to check". That is
+# the expected steady state, not a sign the check has been defeated.
+#
+# Keep it anyway. It is the tripwire that says a NEW self-pin has appeared —
+# a fresh dev-dependency chain reaching one of our crates — and needs its own
+# patch entry. Without it, the first sign would be a dependent published against
+# stale source.
+#
 # Usage: scripts/check-lockfile-self-pins.sh
 # Portable to macOS bash 3.2 / BSD userland.
 set -euo pipefail


### PR DESCRIPTION
Closes the recurring `lockfile self-pins` failure — by deleting the thing that
goes stale rather than refreshing it.

## The problem

A transitive dev-dependency pulls our own crate back in from crates.io:

```
vtc-service [dev-dependencies]
  -> affinidi-messaging-test-mediator
    -> affinidi-messaging-mediator
      -> vta-sdk   (registry, NOT the workspace path copy)
```

So `Cargo.lock` carried **two** `vta-sdk` nodes. The registry one goes stale the
instant we publish, `cargo publish --locked` verifies dependents against it, and
a dependent therefore gets built against the **previous** release's source —
silently, because the workspace's own path-dep build stays green throughout.
That is #706: pnm-cli 0.11.2 verified against vta-sdk 0.19.11 minutes after
0.19.12 shipped, then sat unpublished for three releases.

The refresh can only run inside the publish job, since the version doesn't exist
on crates.io until then. That means committing to a protected branch from CI —
forbidden by the org ruleset — so the workflow opens a PR instead, and can't:

```
pull request create failed: GraphQL: GitHub Actions is not permitted
to create or approve pull requests (createPullRequest)
```

**Seven** consecutive releases ended with an orphaned
`chore/self-pin-refresh-*` branch and a stale `main`. #752 and #754 were both
humans doing it by hand.

## The fix

```toml
[patch.crates-io]
vta-sdk = { path = "vta-sdk" }
```

One `vta-sdk` node in the lock. Nothing to go stale, no refresh to run, and — the
point — **no token, no org setting, no repo permission required**.

## Publishing still works, for a better reason

The patch is workspace-local, so `cargo publish`'s packaged verification build
doesn't see it and resolves `vta-sdk` from the registry, picking the **newest
published** version — which in a release run is the one published moments
earlier in the same loop.

Verified rather than assumed — `cargo publish -p pnm-cli --dry-run --locked`:

```
Compiling vta-sdk v0.19.22          ← no path: resolved from crates.io
Compiling pnm-cli v0.11.4 (…/target/package/pnm-cli-0.11.4)
    Finished `dev` profile
```

The property the self-pin was trying to guarantee now holds by construction.

## Trade-off

The published `affinidi-messaging-mediator` now compiles against our local
`vta-sdk` rather than the published one.

- **Better:** a `vta-sdk` change that breaks it surfaces in CI immediately
  instead of after a release.
- **Worse:** it's a combination that doesn't exist in the wild, so a breaking
  change within `0.19.x` (possible at `0.x`) will present as a confusing build
  failure inside a third-party crate.

## The guard stays

It now passes with *"No workspace crate is pulled back in from crates.io —
nothing to check"*, and its header explains that this is the expected steady
state. Its remaining job is to catch a **new** self-pin appearing — another
dev-dependency chain reaching one of our crates — so that one gets its own patch
entry. Removing it would make the first symptom a dependent published against
stale source.

## Notes

- Lockfile change is one removed package, via a targeted
  `cargo update -p '<registry>#vta-sdk@0.19.21'`. Adding a `[patch]` does **not**
  invalidate an existing lockfile — `cargo update -w` reports "Locking 0
  packages" and changes nothing — so the node must be re-resolved explicitly.
  Worth knowing for anyone reproducing this.
- The publish workflow's in-job refresh and PR step are left in place. Both
  become no-ops (there is no registry pin to refresh), and they remain a safety
  net if the patch is ever removed.
- The seven orphaned `chore/self-pin-refresh-*` branches on origin are now
  permanently useless and can be deleted; I've left them alone.
- No crate source changed, so no version bump is due.

Verified: workspace `cargo check --all-targets`, `vtc-service --tests` (the chain
that pulls the registry copy), `mediator_smoke` 10/10, `tsp_ping_correlation`
11/11, and both release guards.
