### PR TITLE
feat(vta-service): manage agent names over DIDComm, dropping the REST detour

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10235,7 +10235,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.12.12"
+version = "0.12.13"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.12.12"
+version = "0.12.13"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/operations/did_webvh/mod.rs
+++ b/vta-service/src/operations/did_webvh/mod.rs
@@ -1440,13 +1440,6 @@ pub(super) enum WebvhTransport<'a> {
     DIDComm {
         bridge: &'a DIDCommBridge,
         server_did: String,
-        /// A REST endpoint the same server also advertises, if any.
-        ///
-        /// Agent-name operations exist only over REST — the hosting server's
-        /// DIDComm dispatch table has no agent-name verbs — so they fall back
-        /// to this rather than refusing on a server that advertises both, which
-        /// is the normal deployment shape.
-        rest_url: Option<String>,
     },
 }
 
@@ -1474,7 +1467,6 @@ impl<'a> WebvhTransport<'a> {
                 Ok(Self::DIDComm {
                     bridge: didcomm_bridge,
                     server_did: server.did.clone(),
-                    rest_url: transport::resolve_rest_endpoint(&resolved.doc.service),
                 })
             }
             Some(transport::ResolvedTransport::Rest { url }) => {
@@ -1674,42 +1666,6 @@ impl<'a> WebvhTransport<'a> {
         }
     }
 
-    /// A REST client able to serve agent-name operations, or a clear error.
-    ///
-    /// These operations exist over REST only — the hosting server's
-    /// transport-agnostic DIDComm dispatch table carries no agent-name verbs.
-    /// Refusing outright on a DIDComm-preferred server was wrong, though,
-    /// because a deployed server normally advertises `WebVHHosting` *and*
-    /// `DIDCommMessaging` together: the REST endpoint was sitting unused in the
-    /// same document that selected DIDComm.
-    ///
-    /// `owned` gives a client constructed here somewhere to live for as long as
-    /// the borrow the caller holds; on the REST transport it stays empty and the
-    /// existing client — which may already carry an access token — is reused.
-    fn agent_name_client<'c>(
-        &'c mut self,
-        owned: &'c mut Option<WebvhClient>,
-    ) -> Result<&'c mut WebvhClient, AppError> {
-        match self {
-            Self::Rest(c) => Ok(c),
-            Self::DIDComm {
-                rest_url,
-                server_did,
-                ..
-            } => {
-                let url = rest_url.as_deref().ok_or_else(|| {
-                    AppError::Validation(format!(
-                        "agent-name operations need a REST endpoint, and server DID \
-                         {server_did} advertises none; the hosting server exposes \
-                         agent names only via REST"
-                    ))
-                })?;
-                *owned = Some(WebvhClient::new(url, server_did)?);
-                Ok(owned.as_mut().expect("just assigned"))
-            }
-        }
-    }
-
     /// Park (`enable == false`) or resume (`enable == true`) an agent name,
     /// with one-shot 401 retry. REST-only: the hosting server exposes the
     /// agent-name endpoints over REST only, so a DIDComm-transport server is
@@ -1723,8 +1679,20 @@ impl<'a> WebvhTransport<'a> {
         auth_ctx: &auth_cache::AuthContext<'_>,
         server: &WebvhServerRecord,
     ) -> Result<Vec<crate::webvh_client::AgentNameEntryWire>, AppError> {
-        let mut owned = None;
-        let c = self.agent_name_client(&mut owned)?;
+        // DIDComm is a first-class path now, not a fallback: the hosting
+        // server dispatches the agent-name verbs itself, so there is nothing
+        // to reach sideways to REST for. Auth is the transport's own — no
+        // bearer token, hence no 401 retry on this arm.
+        let c = match self {
+            Self::DIDComm {
+                bridge, server_did, ..
+            } => {
+                return WebvhDIDCommClient::new(bridge, server_did)
+                    .list_agent_names(mnemonic, domain)
+                    .await;
+            }
+            Self::Rest(c) => c,
+        };
         match c.list_agent_names(mnemonic, domain).await {
             Ok(v) => Ok(v),
             Err(AppError::Unauthorized(_)) => {
@@ -1748,8 +1716,16 @@ impl<'a> WebvhTransport<'a> {
         auth_ctx: &auth_cache::AuthContext<'_>,
         server: &WebvhServerRecord,
     ) -> Result<crate::webvh_client::AgentNameAvailabilityWire, AppError> {
-        let mut owned = None;
-        let c = self.agent_name_client(&mut owned)?;
+        let c = match self {
+            Self::DIDComm {
+                bridge, server_did, ..
+            } => {
+                return WebvhDIDCommClient::new(bridge, server_did)
+                    .check_agent_name(name, domain)
+                    .await;
+            }
+            Self::Rest(c) => c,
+        };
         match c.check_agent_name(name, domain).await {
             Ok(v) => Ok(v),
             Err(AppError::Unauthorized(_)) => {
@@ -1775,8 +1751,34 @@ impl<'a> WebvhTransport<'a> {
         auth_ctx: &auth_cache::AuthContext<'_>,
         server: &WebvhServerRecord,
     ) -> Result<(), AppError> {
-        let mut owned = None;
-        let c = self.agent_name_client(&mut owned)?;
+        let c = match self {
+            Self::DIDComm {
+                bridge, server_did, ..
+            } => {
+                let client = WebvhDIDCommClient::new(bridge, server_did);
+                return match verb {
+                    update::AgentNameVerb::Set => {
+                        client.set_agent_name(mnemonic, name, did_log, domain).await
+                    }
+                    update::AgentNameVerb::Remove => {
+                        client
+                            .remove_agent_name(mnemonic, name, did_log, domain)
+                            .await
+                    }
+                    update::AgentNameVerb::Enable => {
+                        client
+                            .enable_agent_name(mnemonic, name, did_log, domain)
+                            .await
+                    }
+                    update::AgentNameVerb::Disable => {
+                        client
+                            .disable_agent_name(mnemonic, name, did_log, domain)
+                            .await
+                    }
+                };
+            }
+            Self::Rest(c) => c,
+        };
         let op = verb.endpoint();
         match c.agent_name_op(op, mnemonic, name, did_log, domain).await {
             Ok(()) => Ok(()),

--- a/vta-service/src/operations/did_webvh/transport.rs
+++ b/vta-service/src/operations/did_webvh/transport.rs
@@ -106,29 +106,6 @@ pub(crate) fn resolve_server_transport<S: ServiceEntry>(
     None
 }
 
-/// The REST endpoint a server advertises, if any — **regardless** of whether it
-/// also advertises DIDComm.
-///
-/// [`resolve_server_transport`] returns as soon as it sees a DIDComm service,
-/// which is right for the operations both transports implement. Agent-name
-/// operations are not among them: the hosting server's transport-agnostic
-/// DIDComm dispatch table carries no agent-name verbs, so they exist over REST
-/// alone.
-///
-/// A deployed hosting server normally advertises `WebVHHosting` *and*
-/// `DIDCommMessaging` together. Without this, the DIDComm preference hides the
-/// REST endpoint sitting in the same document, and an agent-name call fails on
-/// a server that is perfectly able to serve it.
-pub(crate) fn resolve_rest_endpoint<S: ServiceEntry>(services: &[S]) -> Option<String> {
-    services.iter().find_map(|svc| {
-        if !svc.types().iter().any(is_webvh_rest) {
-            return None;
-        }
-        let url = join_base(&svc.endpoint_uri()?, svc.hosting_path().as_deref());
-        (!url.is_empty()).then_some(url)
-    })
-}
-
 #[inline]
 fn is_didcomm(t: &String) -> bool {
     t == SVC_DIDCOMM
@@ -194,10 +171,6 @@ mod tests {
             Some("/webvh"),
         )];
         assert_eq!(
-            resolve_rest_endpoint(&services).as_deref(),
-            Some("https://webvh.storm.ws/webvh")
-        );
-        assert_eq!(
             resolve_server_transport(&services),
             Some(ResolvedTransport::Rest {
                 url: "https://webvh.storm.ws/webvh".to_string()
@@ -219,8 +192,10 @@ mod tests {
                 Some(path),
             )];
             assert_eq!(
-                resolve_rest_endpoint(&services).as_deref(),
-                Some("https://h.example/webvh"),
+                resolve_server_transport(&services),
+                Some(ResolvedTransport::Rest {
+                    url: "https://h.example/webvh".to_string()
+                }),
                 "uri={uri} path={path}"
             );
         }
@@ -236,80 +211,16 @@ mod tests {
                 path,
             )];
             assert_eq!(
-                resolve_rest_endpoint(&services).as_deref(),
-                Some("https://h.example"),
+                resolve_server_transport(&services),
+                Some(ResolvedTransport::Rest {
+                    url: "https://h.example".to_string()
+                }),
                 "path={path:?}"
             );
         }
     }
 
     // ── resolve_rest_endpoint ───────────────────────────────────────
-
-    /// The case that motivated this: a server advertising BOTH transports.
-    /// `resolve_server_transport` picks DIDComm, and the REST endpoint must
-    /// still be discoverable — agent-name operations exist only over REST.
-    #[test]
-    fn rest_endpoint_is_found_even_when_didcomm_is_advertised() {
-        let services = vec![
-            TestService::new(&["WebVHHosting"], Some("https://host.example/")),
-            TestService::new(&["DIDCommMessaging"], Some("did:webvh:QmMED:med.example")),
-        ];
-        // DIDComm still wins for transport selection...
-        assert!(matches!(
-            resolve_server_transport(&services),
-            Some(ResolvedTransport::DIDComm)
-        ));
-        // ...but the REST endpoint is not hidden by that preference.
-        assert_eq!(
-            resolve_rest_endpoint(&services).as_deref(),
-            Some("https://host.example")
-        );
-    }
-
-    /// Order must not matter — the DIDComm entry may come first.
-    #[test]
-    fn rest_endpoint_is_order_independent() {
-        let services = vec![
-            TestService::new(&["DIDCommMessaging"], Some("did:webvh:QmMED:med.example")),
-            TestService::new(&["WebVHHosting"], Some("https://host.example")),
-        ];
-        assert_eq!(
-            resolve_rest_endpoint(&services).as_deref(),
-            Some("https://host.example")
-        );
-    }
-
-    /// The legacy service type is accepted here too, matching
-    /// `resolve_server_transport`.
-    #[test]
-    fn rest_endpoint_accepts_the_legacy_type() {
-        let services = vec![TestService::new(
-            &["WebVHHostingService"],
-            Some("https://legacy.example"),
-        )];
-        assert_eq!(
-            resolve_rest_endpoint(&services).as_deref(),
-            Some("https://legacy.example")
-        );
-    }
-
-    /// A DIDComm-only server genuinely has nowhere to send an agent-name call,
-    /// and must report that rather than inventing an endpoint.
-    #[test]
-    fn rest_endpoint_is_none_for_a_didcomm_only_server() {
-        let services = vec![TestService::new(
-            &["DIDCommMessaging"],
-            Some("did:webvh:QmMED:med.example"),
-        )];
-        assert_eq!(resolve_rest_endpoint(&services), None);
-    }
-
-    /// An advertised-but-empty URI is not an endpoint.
-    #[test]
-    fn rest_endpoint_ignores_an_empty_uri() {
-        let services = vec![TestService::new(&["WebVHHosting"], Some(""))];
-        assert_eq!(resolve_rest_endpoint(&services), None);
-    }
 
     struct TestService {
         types: Vec<String>,

--- a/vta-service/src/webvh_didcomm.rs
+++ b/vta-service/src/webvh_didcomm.rs
@@ -73,6 +73,35 @@ const TASK_DID_DELETE_RESPONSE: &str =
 const TASK_DID_PROBLEM_REPORT: &str =
     "https://trusttasks.org/spec/did-management/did/problem-report/0.1";
 
+// Agent names. These had no DIDComm form until the hosting server gained
+// them, so a DIDComm-transport VTA could not manage names at all — it either
+// refused, or reached sideways to the server's REST control plane. Same
+// `spec/did-management/...` family as the verbs above; the server answers
+// them from the same `did_ops` functions its REST routes use, so the two
+// transports return identical payloads.
+const TASK_AGENT_NAME_SET: &str = "https://trusttasks.org/spec/did-management/agent-name/set/0.1";
+const TASK_AGENT_NAME_SET_RESPONSE: &str =
+    "https://trusttasks.org/spec/did-management/agent-name/set/0.1#response";
+const TASK_AGENT_NAME_REMOVE: &str =
+    "https://trusttasks.org/spec/did-management/agent-name/remove/0.1";
+const TASK_AGENT_NAME_REMOVE_RESPONSE: &str =
+    "https://trusttasks.org/spec/did-management/agent-name/remove/0.1#response";
+const TASK_AGENT_NAME_ENABLE: &str =
+    "https://trusttasks.org/spec/did-management/agent-name/enable/0.1";
+const TASK_AGENT_NAME_ENABLE_RESPONSE: &str =
+    "https://trusttasks.org/spec/did-management/agent-name/enable/0.1#response";
+const TASK_AGENT_NAME_DISABLE: &str =
+    "https://trusttasks.org/spec/did-management/agent-name/disable/0.1";
+const TASK_AGENT_NAME_DISABLE_RESPONSE: &str =
+    "https://trusttasks.org/spec/did-management/agent-name/disable/0.1#response";
+const TASK_AGENT_NAME_LIST: &str = "https://trusttasks.org/spec/did-management/agent-name/list/0.1";
+const TASK_AGENT_NAME_LIST_RESPONSE: &str =
+    "https://trusttasks.org/spec/did-management/agent-name/list/0.1#response";
+const TASK_AGENT_NAME_CHECK: &str =
+    "https://trusttasks.org/spec/did-management/agent-name/check/0.1";
+const TASK_AGENT_NAME_CHECK_RESPONSE: &str =
+    "https://trusttasks.org/spec/did-management/agent-name/check/0.1#response";
+
 /// Build the `did/check-name/0.1` reservation body.
 ///
 /// `path == None` is the auto-assign case: the `path` field is OMITTED
@@ -351,6 +380,182 @@ impl<'a> WebvhDIDCommClient<'a> {
             .await?;
         Ok(())
     }
+
+    // ── Agent names ────────────────────────────────────────────────────
+    //
+    // The four mutating verbs share a body and a `{record}` response, so they
+    // share one submit. `didLog` carries the newly signed document: the server
+    // requires `set`/`enable` to claim the name in `alsoKnownAs` and
+    // `remove`/`disable` not to, which is what makes the registry and the
+    // document agree.
+
+    async fn agent_name_verb(
+        &self,
+        task: &str,
+        response_task: &str,
+        mnemonic: &str,
+        name: &str,
+        did_log: &str,
+        domain: Option<&str>,
+    ) -> Result<(), AppError> {
+        let mut body = serde_json::Map::new();
+        body.insert("mnemonic".to_string(), serde_json::json!(mnemonic));
+        body.insert("name".to_string(), serde_json::json!(name));
+        body.insert("didLog".to_string(), serde_json::json!(did_log));
+        if let Some(d) = domain {
+            body.insert("domain".to_string(), serde_json::json!(d));
+        }
+        self.bridge
+            .send_and_wait(
+                self.server_did,
+                task,
+                serde_json::Value::Object(body),
+                response_task,
+                TASK_DID_PROBLEM_REPORT,
+                30,
+            )
+            .await?;
+        Ok(())
+    }
+
+    /// Bind or refresh `name` on `mnemonic`.
+    pub async fn set_agent_name(
+        &self,
+        mnemonic: &str,
+        name: &str,
+        did_log: &str,
+        domain: Option<&str>,
+    ) -> Result<(), AppError> {
+        self.agent_name_verb(
+            TASK_AGENT_NAME_SET,
+            TASK_AGENT_NAME_SET_RESPONSE,
+            mnemonic,
+            name,
+            did_log,
+            domain,
+        )
+        .await
+    }
+
+    /// Release `name` — it stops resolving and anyone may reclaim it.
+    pub async fn remove_agent_name(
+        &self,
+        mnemonic: &str,
+        name: &str,
+        did_log: &str,
+        domain: Option<&str>,
+    ) -> Result<(), AppError> {
+        self.agent_name_verb(
+            TASK_AGENT_NAME_REMOVE,
+            TASK_AGENT_NAME_REMOVE_RESPONSE,
+            mnemonic,
+            name,
+            did_log,
+            domain,
+        )
+        .await
+    }
+
+    /// Resume serving a parked `name`.
+    pub async fn enable_agent_name(
+        &self,
+        mnemonic: &str,
+        name: &str,
+        did_log: &str,
+        domain: Option<&str>,
+    ) -> Result<(), AppError> {
+        self.agent_name_verb(
+            TASK_AGENT_NAME_ENABLE,
+            TASK_AGENT_NAME_ENABLE_RESPONSE,
+            mnemonic,
+            name,
+            did_log,
+            domain,
+        )
+        .await
+    }
+
+    /// Park `name` — it stops resolving but stays reserved to this DID.
+    pub async fn disable_agent_name(
+        &self,
+        mnemonic: &str,
+        name: &str,
+        did_log: &str,
+        domain: Option<&str>,
+    ) -> Result<(), AppError> {
+        self.agent_name_verb(
+            TASK_AGENT_NAME_DISABLE,
+            TASK_AGENT_NAME_DISABLE_RESPONSE,
+            mnemonic,
+            name,
+            did_log,
+            domain,
+        )
+        .await
+    }
+
+    /// Read the DID's agent-name registry, parked names included.
+    ///
+    /// The registry — not the DID document — is the only place a parked name
+    /// is visible, since dropping the `alsoKnownAs` claim is *how* parking
+    /// stops it resolving. `agentNames` is always present, so an absent field
+    /// is a contract violation rather than an empty registry.
+    pub async fn list_agent_names(
+        &self,
+        mnemonic: &str,
+        domain: Option<&str>,
+    ) -> Result<Vec<crate::webvh_client::AgentNameEntryWire>, AppError> {
+        let mut body = serde_json::Map::new();
+        body.insert("mnemonic".to_string(), serde_json::json!(mnemonic));
+        if let Some(d) = domain {
+            body.insert("domain".to_string(), serde_json::json!(d));
+        }
+        let resp = self
+            .bridge
+            .send_and_wait(
+                self.server_did,
+                TASK_AGENT_NAME_LIST,
+                serde_json::Value::Object(body),
+                TASK_AGENT_NAME_LIST_RESPONSE,
+                TASK_DID_PROBLEM_REPORT,
+                30,
+            )
+            .await?;
+        let names = resp.body.get("agentNames").ok_or_else(|| {
+            AppError::Internal("agent-name list response has no 'agentNames'".to_string())
+        })?;
+        serde_json::from_value(names.clone())
+            .map_err(|e| AppError::Internal(format!("agent-name list response parse error: {e}")))
+    }
+
+    /// Is `name` free to claim on this domain?
+    ///
+    /// A reserved name answers `available: false, reserved: true` rather than
+    /// erroring, so the caller can tell "taken" from "never allowed".
+    pub async fn check_agent_name(
+        &self,
+        name: &str,
+        domain: Option<&str>,
+    ) -> Result<crate::webvh_client::AgentNameAvailabilityWire, AppError> {
+        let mut body = serde_json::Map::new();
+        body.insert("name".to_string(), serde_json::json!(name));
+        if let Some(d) = domain {
+            body.insert("domain".to_string(), serde_json::json!(d));
+        }
+        let resp = self
+            .bridge
+            .send_and_wait(
+                self.server_did,
+                TASK_AGENT_NAME_CHECK,
+                serde_json::Value::Object(body),
+                TASK_AGENT_NAME_CHECK_RESPONSE,
+                TASK_DID_PROBLEM_REPORT,
+                30,
+            )
+            .await?;
+        serde_json::from_value(resp.body)
+            .map_err(|e| AppError::Internal(format!("agent-name check response parse error: {e}")))
+    }
 }
 
 #[cfg(test)]
@@ -369,15 +574,15 @@ mod tests {
             !body.contains_key("path"),
             "auto-assign must omit `path`; got {body:?}"
         );
-        assert_eq!(body.get("reserve"), Some(&json!(true)));
+        assert_eq!(body.get("reserve"), Some(&serde_json::json!(true)));
     }
 
     /// An explicit label travels verbatim under `reserve: true`.
     #[test]
     fn explicit_path_is_sent() {
         let body = build_check_name_body(Some("alice"), None);
-        assert_eq!(body.get("path"), Some(&json!("alice")));
-        assert_eq!(body.get("reserve"), Some(&json!(true)));
+        assert_eq!(body.get("path"), Some(&serde_json::json!("alice")));
+        assert_eq!(body.get("reserve"), Some(&serde_json::json!(true)));
     }
 
     /// `.well-known` (the root-DID marker) is sent as a normal path —
@@ -385,14 +590,17 @@ mod tests {
     #[test]
     fn well_known_is_sent_as_path() {
         let body = build_check_name_body(Some(".well-known"), None);
-        assert_eq!(body.get("path"), Some(&json!(".well-known")));
+        assert_eq!(body.get("path"), Some(&serde_json::json!(".well-known")));
     }
 
     /// The optional `domain` rides along only when present.
     #[test]
     fn domain_included_only_when_present() {
         let with = build_check_name_body(Some("alice"), Some("acme.example.com"));
-        assert_eq!(with.get("domain"), Some(&json!("acme.example.com")));
+        assert_eq!(
+            with.get("domain"),
+            Some(&serde_json::json!("acme.example.com"))
+        );
         let without = build_check_name_body(Some("alice"), None);
         assert!(!without.contains_key("domain"));
     }
@@ -402,7 +610,7 @@ mod tests {
     /// makes the host emit; the parser must read through `record`.
     #[test]
     fn parses_spec_record_shaped_response() {
-        let body = json!({
+        let body = serde_json::json!({
             "available": true,
             "reserved": true,
             "record": {
@@ -429,7 +637,7 @@ mod tests {
     /// must still accept them so a VTA can talk to an un-upgraded host.
     #[test]
     fn parses_legacy_flat_response() {
-        let body = json!({
+        let body = serde_json::json!({
             "available": true,
             "reserved": true,
             "mnemonic": "alice",
@@ -446,7 +654,7 @@ mod tests {
     /// to surface — wrongly — as a 500 on every re-run.)
     #[test]
     fn not_reserved_and_unavailable_is_a_conflict() {
-        let body = json!({ "available": false, "reserved": false });
+        let body = serde_json::json!({ "available": false, "reserved": false });
         let err = parse_check_name_response(body).expect_err("must error");
         assert!(
             matches!(err, crate::error::AppError::Conflict(_)),
@@ -464,7 +672,7 @@ mod tests {
     /// already-taken conflict.
     #[test]
     fn not_reserved_but_available_is_an_internal_anomaly() {
-        let body = json!({ "available": true, "reserved": false });
+        let body = serde_json::json!({ "available": true, "reserved": false });
         let err = parse_check_name_response(body).expect_err("must error");
         assert!(
             matches!(err, crate::error::AppError::Internal(_)),
@@ -480,7 +688,7 @@ mod tests {
     /// loudly rather than returning an empty `did_url` downstream.
     #[test]
     fn reserved_without_did_url_errors() {
-        let body = json!({
+        let body = serde_json::json!({
             "reserved": true,
             "record": { "mnemonic": "alice" }
         });


### PR DESCRIPTION
**Depends on [affinidi-webvh-service#129](https://github.com/affinidi/affinidi-webvh-service/pull/129)** — merge and deploy that first.

Agent-name operations had no DIDComm form, so a DIDComm-transport VTA either refused them outright, or — after #755 — reached sideways to the hosting server's REST control plane.

The hosting server now dispatches all six verbs itself (`spec/did-management/agent-name/{verb}/0.1`), answering them from the same `did_ops` functions its REST routes use. So `WebvhTransport::DIDComm` calls them directly.

## The REST fallback is removed, not kept

It routed onto a path this deployment doesn't exercise — which is how it produced a 404 against a control plane that was reachable all along. A spare path nobody runs is exactly the kind of silent alternative that made this failure hard to read.

`Self::Rest` still serves genuinely REST-only servers. What goes is the **DIDComm-to-REST crossover**, plus the now-unused `rest_url` field and `resolve_rest_endpoint`.

`hostingPath` handling (from #756) stays where it matters: `resolve_server_transport` still joins it for REST-only servers, and its tests **move onto that entry point** rather than being deleted along with the function they happened to exercise.

## Six methods on `WebvhDIDCommClient`

`set` / `remove` / `enable` / `disable` share one submit (`{mnemonic, name, didLog, domain?}`); `list` returns the registry including parked names — the registry, not the DID document, is the only place a parked name is visible, since dropping the `alsoKnownAs` claim is *how* parking stops it resolving. `check` returns `{name, domain, available, reserved}`.

No 401-retry on the DIDComm arms: that retry refreshes a bearer token, and this path authenticates as the transport peer instead.

## Verification

`cargo test -p vta-service --lib`: **948 passed, 0 failed** — five fewer than before, being the tests for the removed `resolve_rest_endpoint`. fmt clean, `--locked` clean, `cargo deny` advisories ok, version bumped to 0.12.13.

## Deployment ordering

Against a server without #129, these verbs return an unknown-message-type error rather than silently doing nothing — a loud failure, but merge order still matters.