### PR TITLE
docs: bring the changelog current and enforce it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,6 +169,9 @@ jobs:
       - name: Version-bump guard for changed publishable crates
         run: bash scripts/check-version-bumps.sh "${{ github.event.pull_request.base.sha }}"
 
+      - name: Changelog guard for bumped publishable crates
+        run: bash scripts/check-changelogs.sh "${{ github.event.pull_request.base.sha }}"
+
   lockfile-self-pins:
     # Sibling guard to release-guards: the version bump can be correct and the
     # release still break if Cargo.lock pins a stale crates.io copy of one of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,81 @@
 
 ## Unreleased
 
+### vta-service 0.12.13 — agent names over DIDComm, dropping the REST detour
+
+* Agent-name operations had no DIDComm form, so a DIDComm-transport VTA either
+  refused them or reached sideways to the hosting server's REST control plane.
+  The hosting server now dispatches all six verbs itself
+  (`spec/did-management/agent-name/{verb}/0.1`), so the detour is gone. (#758)
+
+### vta-service 0.12.12 — honour the `hostingPath` a webvh server advertises
+
+* A hosting server may serve its control plane under a path prefix rather than
+  at the origin root, and `webvh.storm.ws` advertises exactly that. The DID
+  templates have emitted `hostingPath` all along; it is now actually used. (#756)
+
+### vta-service 0.12.11 — use the REST endpoint a server already advertises for agent names
+
+* Managing an agent name failed on a server perfectly able to serve the request:
+  agent-name operations are not supported over DIDComm, and the hosting server
+  exposes them only via REST. Both true, and together the wrong conclusion —
+  the advertised REST endpoint is now used. (#755)
+
+### vta-sdk 0.19.22 — surface a trust-task error carried inside the payload
+
+* A failed trust task still returns a `payload`, with the error envelope
+  *inside* it as `{ code, message, retryable }`. `extract_trust_task_payload`
+  treated the presence of a payload as success, so callers deserialised an error
+  object as a result and reported whichever field their result type happened to
+  be missing — while the real message was discarded. (#753)
+
+### Release hygiene — the `vta-sdk` lockfile self-pin is gone, not refreshed
+
+* A transitive dev-dependency (`vtc-service` → `affinidi-messaging-test-mediator`
+  → `affinidi-messaging-mediator` → `vta-sdk`) pulled our own crate back in from
+  crates.io, so `Cargo.lock` carried a second, registry-sourced `vta-sdk` node.
+  It went stale the instant we published, and `cargo publish --locked` verifies
+  dependents against it — which is how pnm-cli 0.11.2 was built against vta-sdk
+  0.19.11 minutes after 0.19.12 shipped.
+* Refreshing it can only happen inside the publish job, which means committing to
+  a protected branch from CI; the org ruleset forbids that, so the workflow opens
+  a PR instead and cannot ("GitHub Actions is not permitted to create or approve
+  pull requests"). Seven consecutive releases ended with an orphaned refresh
+  branch and a stale `main`, cleared by hand each time (#754 was the last of
+  those); the seven orphaned branches have been deleted.
+* `[patch.crates-io] vta-sdk = { path = "vta-sdk" }` removes the second node
+  entirely — nothing to go stale, no refresh to run, no token or org setting
+  required. Publishing is unaffected: the patch is workspace-local, so
+  `cargo publish`'s verification build resolves `vta-sdk` from the registry and
+  picks the newest published version, which in a release run is the one published
+  moments earlier in the same loop. (#757)
+* Trade-off: the published `affinidi-messaging-mediator` now compiles against the
+  local `vta-sdk`. A breaking change within `0.19.x` surfaces in CI rather than
+  after a release, but as a build failure inside a third-party crate.
+
+### vta-service 0.12.10 — the consent e2e test matches #748's fail-fast contract
+
+* #748 made an unsatisfiable elevation fail at submission instead of minting a
+  consent ceremony that could never execute, but the test asserting the old
+  behaviour was not updated, so `main` was red. The test now asserts the new
+  contract: the task is refused up front, the refusal names the context and the
+  approver set that cannot confer it, and no challenge is minted. (#752)
+
+### vta-sdk 0.19.21 — the TSP ping measures its own reply
+
+* `TspPingSession::ping` accepted the first frame that unpacked and parsed as
+  JSON. The mediator inbox is durable, so a reply an earlier probe never
+  collected is flushed onto the socket on connect — meaning the probe could
+  report a healthy round trip, at an invented latency, off a pong from a previous
+  run. That is what disguised a total TSP delivery outage as intermittent.
+* The reply is now correlated on the Trust-Task `threadId` (falling back to the
+  echoed `nonce`), so a stale frame cannot satisfy a probe. (#750)
+* The underlying transport faults were upstream in `affinidi-tdk-rs`
+  (affinidi/affinidi-tdk-rs#646): the mediator never marked raw-TSP websockets
+  live, so anything arriving after connect was stored and never pushed, and the
+  SDK separately dropped packed frames that landed between polls. Fixed and
+  published in mediator 0.17.7 / messaging-sdk 0.18.62.
+
 ### vtc-service 0.11.19 / vta-sdk 0.19.20 — Phase 4: the remaining vtc families move to `spec/vtc`
 
 * Every remaining VTC Trust Task with a canonical counterpart is repointed:

--- a/scripts/check-changelogs.sh
+++ b/scripts/check-changelogs.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Guard: a published version with no changelog entry.
+#
+# Sibling to check-version-bumps.sh, which enforces the other half of the same
+# convention. That script already tells you to bump the version; nothing ever
+# checked that the change was written down. It stopped being written down —
+# vta-sdk 0.19.21 and 0.19.22 and vta-service 0.12.10 through 0.12.13 all shipped
+# with no entry, including a `vta-sdk` behavioural change and a release-process
+# change.
+#
+# This matters beyond tidiness. Sibling repos (openvtc, the mediator, webvh)
+# pin these crates loosely, so a behavioural change is breaking for them even
+# when no signature changes, and CHANGELOG.md is where they find out.
+#
+# The rule: if a publishable crate's VERSION changed in this PR, the root
+# CHANGELOG.md must MENTION THE NEW VERSION.
+#
+# Deliberately not the weaker "the changelog was touched": a PR that edits the
+# changelog for one reason and bumps a version for another would satisfy that
+# and still ship an undocumented release.
+#
+# Not circular with check-version-bumps.sh — that script excludes CHANGELOG*
+# from "source changes", so a changelog-only PR needs no bump and a bump needs a
+# changelog. The two guards meet in the middle.
+#
+# Usage: scripts/check-changelogs.sh [base-ref]
+# Portable to macOS bash 3.2 / BSD userland.
+set -euo pipefail
+
+BASE="${1:-origin/main}"
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+if [ -t 1 ]; then
+  RED=$'\033[0;31m'; GREEN=$'\033[0;32m'; CYAN=$'\033[0;36m'; NC=$'\033[0m'
+else
+  RED=''; GREEN=''; CYAN=''; NC=''
+fi
+
+if ! git rev-parse --verify --quiet "$BASE" >/dev/null; then
+  echo "${RED}error:${NC} base ref '$BASE' not found. Pass a reachable ref, e.g. origin/main." >&2
+  exit 2
+fi
+
+CHANGELOG="CHANGELOG.md"
+
+echo "=== Changelog guard (base: $BASE) ==="
+echo
+
+changed=$(git diff --name-only "$BASE"...HEAD)
+if [ -z "$changed" ]; then
+  echo "${GREEN}No changes vs $BASE — nothing to check.${NC}"
+  exit 0
+fi
+
+if [ ! -f "$CHANGELOG" ]; then
+  echo "${RED}error:${NC} $CHANGELOG not found at $ROOT" >&2
+  exit 2
+fi
+
+# Publishable crates as  name<TAB>relative-crate-dir. Non-publishable crates are
+# irrelevant: nothing reaches a consumer, so there is no contract to record.
+crates=$(cargo metadata --format-version 1 --no-deps 2>/dev/null \
+  | jq -r '.packages[]
+      | select(.publish == null or .publish == ["crates.io"])
+      | "\(.name)\t\(.manifest_path)"' \
+  | sed "s|\t$ROOT/|\t|; s|/Cargo.toml\$||")
+
+version_of() {
+  awk '/^\[/{ in_pkg = ($0 == "[package]") } in_pkg && /^version = / { gsub(/^version = "|"$/, ""); print; exit }'
+}
+
+fail=0
+found=0
+
+while IFS="$(printf '\t')" read -r name dir; do
+  [ -n "$name" ] || continue
+  manifest="$dir/Cargo.toml"
+
+  old_version=$(git show "$BASE:$manifest" 2>/dev/null | version_of)
+  new_version=$(version_of < "$manifest" 2>/dev/null)
+
+  [ -n "$new_version" ] || continue
+  [ "$old_version" != "$new_version" ] || continue
+
+  found=1
+  # Match the version as a whole token: a plain substring search would let
+  # `0.1.30`'s entry satisfy a bump to `0.1.3`.
+  escaped=$(printf '%s' "$new_version" | sed 's/\./\\./g')
+  if grep -qE "(^|[^0-9.])$escaped([^0-9.]|\$)" "$CHANGELOG"; then
+    echo "  ${GREEN}ok${NC}   $name: ${old_version:-<new>} -> $new_version (documented)"
+  else
+    echo "  ${RED}MISSING${NC} $name: ${old_version:-<new>} -> $new_version, but $new_version does not appear in $CHANGELOG"
+    fail=1
+  fi
+done <<EOF
+$crates
+EOF
+
+echo
+if [ "$found" -eq 0 ]; then
+  echo "${GREEN}No publishable crate versions changed — nothing to check.${NC}"
+  exit 0
+fi
+
+if [ "$fail" -ne 0 ]; then
+  echo "${RED}A crate is being published with no record of what changed.${NC}"
+  echo "Sibling repos pin these crates loosely, so a behavioural change is breaking"
+  echo "for them even when no signature changes — ${CYAN}$CHANGELOG${NC} is where they find out."
+  echo "Add an entry naming the new version, e.g. '### $name <version> — <summary>'."
+  exit 1
+fi
+
+echo "${GREEN}Every version bump in this PR has a changelog entry.${NC}"


### PR DESCRIPTION
Six published versions have no changelog entry.

| crate | shipped, undocumented |
|---|---|
| `vta-sdk` | 0.19.21, 0.19.22 |
| `vta-service` | 0.12.10, 0.12.11, 0.12.12, 0.12.13 |

That includes a `vta-sdk` behavioural change — the TSP ping now correlates its
reply, so a stale queued frame can no longer satisfy a probe — and a change to
how releases work, the `vta-sdk` lockfile self-pin being removed rather than
refreshed.

It matters beyond tidiness: sibling repos (openvtc, the mediator, webvh) pin
these crates loosely, so a behavioural change is breaking for them even when no
signature changes, and `CHANGELOG.md` is where they find out.

## What's added

Entries for #750, #752, #753, #754, #755, #756, #757 and #758 — written from
each change's own commit body rather than its subject line, so the entries say
what actually changed for a consumer.

## Why it kept happening

`check-version-bumps.sh` enforces the version half of the convention. Nothing
ever checked that the change was described — so the mechanical part was
guaranteed and the part needing a human was not.

`scripts/check-changelogs.sh` closes it, wired into the existing `release-guards`
job:

> if a publishable crate's version changed in this PR, the root `CHANGELOG.md`
> must **mention the new version**

Requiring the version *string*, not merely that the file was touched, is
deliberate: a PR that edits the changelog for one reason and bumps a version for
another would satisfy the weaker rule and still ship an undocumented release.
(That is not hypothetical — the first draft of this guard, in the sibling repo,
passed exactly such a bump.)

Verified in all three directions:

```
1. changelog-only PR   → No publishable crate versions changed — nothing to check.
2. bump, undocumented  → MISSING vta-sdk: 0.19.22 -> 0.19.23, but 0.19.23
                         does not appear in CHANGELOG.md            (exit 1)
3. bump, documented    → ok   vta-sdk: 0.19.22 -> 0.19.23 (documented)
```

The match is token-boundaried, so a `0.1.30` entry cannot satisfy a bump to
`0.1.3`. Not circular with the version guard: that script excludes `CHANGELOG*`
from "source changes", so a changelog-only PR needs no bump and a bump needs a
changelog — the two meet in the middle.

The same guard is going into `affinidi-tdk-rs`, where the same convention had
drifted the same way (affinidi/affinidi-tdk-rs#657).
