### PR TITLE
fix(vta-service): stop reading hostingPath as the REST base, and stop emitting it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## Unreleased
 
+### vta-service 0.12.14 / vta-sdk 0.19.23 — `hostingPath` is retired, not reinterpreted
+
+* **`hostingPath` never meant anything, and 0.12.12 gave it a meaning the live
+  deployment contradicts.** No caller ever supplied `HOSTING_PATH`
+  (`build_webvh_provision_ask` sets `URL` alone), so every document carrying the
+  field carries the `did-host-http*` templates' own default, `/webvh`; and
+  nothing in `affinidi-webvh-service`, `didwebvh-rs`, or the TDK ever read it
+  back. A field with no producer and no consumer, in permanent signed documents.
+* **`join_base` is reverted.** The REST base for a `WebVHHosting` endpoint is
+  `serviceEndpoint.uri` alone. Reading the prefix as the control-plane base
+  would have 404'd every REST-only server advertising one — it sat on
+  `resolve_server_transport`, not just the agent-name path that motivated it,
+  and that path had already moved to DIDComm, so nothing was exercising it.
+  `webvh.storm.ws` answers `/api/health` with 200 and `/webvh/api/health` with
+  404; `did-hosting-control` nests its whole API at `/api` off the origin root
+  with no prefix setting to configure.
+* **The three `did-host-http*` templates no longer emit the field**, so new
+  documents stop making a claim nothing backs. Existing documents keep it
+  harmlessly — the read side ignores it. `docs/02-vta/did-templates.md` replaces
+  the (never-true) "where a hosting server publishes DID logs" definition with a
+  retirement note carrying the evidence. (#759, #762)
+
 ### vta-service 0.12.13 — agent names over DIDComm, dropping the REST detour
 
 * Agent-name operations had no DIDComm form, so a DIDComm-transport VTA either
@@ -9,11 +31,15 @@
   The hosting server now dispatches all six verbs itself
   (`spec/did-management/agent-name/{verb}/0.1`), so the detour is gone. (#758)
 
-### vta-service 0.12.12 — honour the `hostingPath` a webvh server advertises
+### vta-service 0.12.12 — honour the `hostingPath` a webvh server advertises — **reverted in 0.12.14**
 
 * A hosting server may serve its control plane under a path prefix rather than
   at the origin root, and `webvh.storm.ws` advertises exactly that. The DID
   templates have emitted `hostingPath` all along; it is now actually used. (#756)
+* **Superseded.** That premise was never checked against a live server and is
+  wrong — `webvh.storm.ws` serves its control plane at the origin root, and the
+  advertised `/webvh` was this workspace's own template default rather than
+  anything the server published. Do not build on this entry; see 0.12.14. (#759)
 
 ### vta-service 0.12.11 — use the REST endpoint a server already advertises for agent names
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10142,7 +10142,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.19.22"
+version = "0.19.23"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10202,7 +10202,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.12.13"
+version = "0.12.14"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",

--- a/docs/02-vta/did-templates.md
+++ b/docs/02-vta/did-templates.md
@@ -129,7 +129,34 @@ Anything else. Declare them in `requiredVars` (must be provided) or
 - `URL` — the public endpoint (mediator URL, hosting URL, etc.)
 - `ACCEPT` — DIDComm accept list
 - `ROUTING_KEYS` — DIDComm routing DIDs
-- `HOSTING_PATH` — where a hosting server publishes DID logs
+
+### Retired: `HOSTING_PATH` / `hostingPath`
+
+The `did-host-http*` templates used to stamp a `hostingPath` beside `uri` in
+the `WebVHHosting` endpoint. **It has been removed, and a `hostingPath` found
+in an existing document carries no meaning — ignore it.**
+
+It never had one. No caller ever supplied `HOSTING_PATH`
+(`build_webvh_provision_ask` in `affinidi-webvh-service` sets `URL` and nothing
+else), so every document that carries the field carries this template's own
+default, `/webvh`. No server in the ecosystem ever read it back. It described
+neither of the two paths a reader might assume:
+
+- **Not the DID-log location.** That is derived from the DID identifier itself
+  — `did:webvh:<scid>:<domain>[:<path>]` resolves to
+  `https://<domain>/<path>/did.jsonl`. `webvh.storm.ws` advertises
+  `hostingPath: "/webvh"` and serves its logs at the root
+  (`/magic-depart/did.jsonl` → 200, `/webvh/magic-depart/did.jsonl` → 404).
+- **Not the REST control-plane base.** The hosting service nests its whole API
+  at `/api` off the origin root and has no prefix setting to configure
+  (`/api/health` → 200, `/webvh/api/health` → 404 on that same host).
+
+The REST base for a `WebVHHosting` endpoint is **`serviceEndpoint.uri`, alone**.
+#756 joined the prefix onto it on the untested assumption that it was the
+control-plane base, which would have 404'd every REST-only server advertising
+one; #759 settled it against the live deployment and reverted the join. Add a
+field to a signed, permanent document only once something writes it *and*
+something reads it.
 
 ## Scopes and resolution
 

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.19.22"
+version = "0.19.23"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/did_templates/tests.rs
+++ b/vta-sdk/src/did_templates/tests.rs
@@ -659,10 +659,20 @@ fn did_host_http_builtin_renders_end_to_end() {
 
     let doc = tpl.render(&vars).unwrap();
     assert_eq!(doc["service"][0]["type"], "WebVHHosting");
-    // Default path applied.
     assert_eq!(
-        doc["service"][0]["serviceEndpoint"]["hostingPath"],
-        "/webvh"
+        doc["service"][0]["serviceEndpoint"]["uri"],
+        "https://host.example.com"
+    );
+    // The endpoint carries the origin and nothing else. `hostingPath`
+    // used to sit beside it, always at this template's own default —
+    // no caller ever set HOSTING_PATH and no server ever read it back —
+    // until a consumer mistook it for the REST base and 404'd (#759).
+    assert!(
+        doc["service"][0]["serviceEndpoint"]
+            .get("hostingPath")
+            .is_none(),
+        "hostingPath must not be emitted: {}",
+        doc["service"][0]["serviceEndpoint"]
     );
 }
 
@@ -1045,9 +1055,10 @@ fn did_host_http_tsp_advertises_hosting_then_tsp_only() {
     );
     // HTTP resolution endpoint first, then TSP; no DIDComm entry.
     assert_eq!(services[0]["type"], "WebVHHosting");
-    assert_eq!(
-        services[0]["serviceEndpoint"]["hostingPath"], "/webvh",
-        "default hosting path applied"
+    assert!(
+        services[0]["serviceEndpoint"].get("hostingPath").is_none(),
+        "hostingPath must not be emitted (#759): {}",
+        services[0]["serviceEndpoint"]
     );
     assert_eq!(services[1]["id"], "did:webvh:QmTEST:example.com#tsp");
     assert_eq!(services[1]["type"], "TSPTransport");

--- a/vta-sdk/templates/did-host-http-didcomm.json
+++ b/vta-sdk/templates/did-host-http-didcomm.json
@@ -7,7 +7,6 @@
   "requiredVars": ["URL", "MEDIATOR_DID"],
   "optionalVars": {
     "ACCEPT": ["didcomm/v2"],
-    "HOSTING_PATH": "/webvh",
     "WEBVH_SERVER": null
   },
   "defaults": {
@@ -44,8 +43,7 @@
         "id": "{DID}#webvh-hosting",
         "type": "WebVHHosting",
         "serviceEndpoint": {
-          "uri": "{URL}",
-          "hostingPath": "{HOSTING_PATH}"
+          "uri": "{URL}"
         }
       },
       {

--- a/vta-sdk/templates/did-host-http-tsp.json
+++ b/vta-sdk/templates/did-host-http-tsp.json
@@ -6,7 +6,6 @@
   "methods": ["webvh", "web"],
   "requiredVars": ["URL", "MEDIATOR_DID"],
   "optionalVars": {
-    "HOSTING_PATH": "/webvh",
     "WEBVH_SERVER": null
   },
   "defaults": {
@@ -43,8 +42,7 @@
         "id": "{DID}#webvh-hosting",
         "type": "WebVHHosting",
         "serviceEndpoint": {
-          "uri": "{URL}",
-          "hostingPath": "{HOSTING_PATH}"
+          "uri": "{URL}"
         }
       },
       {

--- a/vta-sdk/templates/did-host-http.json
+++ b/vta-sdk/templates/did-host-http.json
@@ -6,7 +6,6 @@
   "methods": ["webvh", "web"],
   "requiredVars": ["URL"],
   "optionalVars": {
-    "HOSTING_PATH": "/webvh",
     "WEBVH_SERVER": null
   },
   "defaults": {
@@ -42,8 +41,7 @@
         "id": "{DID}#webvh-hosting",
         "type": "WebVHHosting",
         "serviceEndpoint": {
-          "uri": "{URL}",
-          "hostingPath": "{HOSTING_PATH}"
+          "uri": "{URL}"
         }
       }
     ]

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.12.13"
+version = "0.12.14"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/operations/did_webvh/transport.rs
+++ b/vta-service/src/operations/did_webvh/transport.rs
@@ -25,6 +25,26 @@
 //! entry, wherever it sits, wins over every REST entry. This keeps
 //! third-party DIDs that emit non-canonical orderings working
 //! without surprising the operator.
+//!
+//! ## `hostingPath` is not the REST base
+//!
+//! The `did-host-http*` templates used to stamp a `hostingPath` beside
+//! `uri` in the `WebVHHosting` endpoint. It described nothing: no
+//! caller ever set the `HOSTING_PATH` var, so every document carried
+//! the template's own default (`/webvh`), and no server in the
+//! ecosystem ever read the field back. #756 mistook it for a
+//! control-plane prefix and joined it onto the base; the live
+//! deployment says otherwise —
+//!
+//! ```text
+//! GET https://webvh.storm.ws/api/health        -> 200 {"status":"ok"}
+//! GET https://webvh.storm.ws/webvh/api/health  -> 404
+//! ```
+//!
+//! — and the hosting service nests its whole API at `/api` off the
+//! origin root, with no prefix setting to configure. The REST base is
+//! `serviceEndpoint.uri` alone. `hostingPath` is ignored on read, and
+//! the templates no longer emit it (#759).
 
 /// Service-type string emitted on DIDComm endpoints (per DIDComm v2).
 pub(crate) const SVC_DIDCOMM: &str = "DIDCommMessaging";
@@ -43,29 +63,6 @@ pub(crate) const SVC_WEBVH_HOSTING_LEGACY: &str = "WebVHHostingService";
 pub(crate) trait ServiceEntry {
     fn types(&self) -> &[String];
     fn endpoint_uri(&self) -> Option<String>;
-    /// The `hostingPath` the endpoint advertises, if any.
-    ///
-    /// A hosting server may serve its control plane under a prefix rather than
-    /// at the origin root — `webvh.storm.ws` advertises `/webvh`. The DID
-    /// templates have emitted this field all along, and nothing read it, so
-    /// every REST request was built against the bare origin and 404'd on any
-    /// server that uses one.
-    fn hosting_path(&self) -> Option<String> {
-        None
-    }
-}
-
-/// Join an advertised origin and its optional hosting path into a base URL.
-///
-/// Both halves arrive from a DID document, so neither's punctuation can be
-/// assumed: the origin may carry a trailing slash and the path may or may not
-/// lead with one.
-fn join_base(uri: &str, hosting_path: Option<&str>) -> String {
-    let base = uri.trim_matches('"').trim_end_matches('/');
-    match hosting_path.map(|p| p.trim_matches('"').trim_matches('/')) {
-        Some(p) if !p.is_empty() => format!("{base}/{p}"),
-        _ => base.to_string(),
-    }
 }
 
 /// Outcome of walking a server's service array.
@@ -96,7 +93,7 @@ pub(crate) fn resolve_server_transport<S: ServiceEntry>(
         if svc.types().iter().any(is_webvh_rest)
             && let Some(raw) = svc.endpoint_uri()
         {
-            let url = join_base(&raw, svc.hosting_path().as_deref());
+            let url = raw.trim_matches('"').trim_end_matches('/').to_string();
             if url.is_empty() {
                 continue;
             }
@@ -136,118 +133,59 @@ impl ServiceEntry for affinidi_tdk::did_common::service::Service {
     fn endpoint_uri(&self) -> Option<String> {
         self.service_endpoint.get_uri()
     }
-    fn hosting_path(&self) -> Option<String> {
-        // `Endpoint` models only `uri`; `hostingPath` sits beside it in the
-        // same object, reachable through the untyped map form.
-        use affinidi_tdk::did_common::service::Endpoint;
-        let Endpoint::Map(value) = &self.service_endpoint else {
-            return None;
-        };
-        let obj = match value {
-            serde_json::Value::Array(a) => a.first()?,
-            other => other,
-        };
-        obj.get("hostingPath")
-            .and_then(|v| v.as_str())
-            .map(str::to_string)
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    // ── hostingPath ─────────────────────────────────────────────────
+    // ── hostingPath is not the REST base ────────────────────────────
 
-    /// The live failure this fixes: `webvh.storm.ws` advertises
-    /// `{"uri":"https://webvh.storm.ws","hostingPath":"/webvh"}`, and every
-    /// REST request was built against the bare origin — so the control plane at
-    /// `/webvh/api/...` answered 404.
+    /// Regression guard for #756/#759, pinned against the live document.
+    ///
+    /// This is the verbatim `WebVHHosting` entry `webvh.storm.ws` publishes,
+    /// parsed by the same concrete `Service` type the resolver hands us. #756
+    /// read the `hostingPath` beside `uri` as a control-plane prefix and
+    /// dialled `https://webvh.storm.ws/webvh/api/...`; that server answers
+    /// `/api/health` with 200 and `/webvh/api/health` with 404, so the base is
+    /// the origin alone. Anyone tempted to join the two halves again should
+    /// re-probe a live server first.
     #[test]
-    fn rest_base_includes_the_advertised_hosting_path() {
-        let services = vec![TestService::with_hosting_path(
-            &["WebVHHosting"],
-            Some("https://webvh.storm.ws"),
-            Some("/webvh"),
-        )];
+    fn advertised_hosting_path_is_ignored_on_the_live_document() {
+        let svc: affinidi_tdk::did_common::service::Service = serde_json::from_str(
+            r#"{
+                "id": "did:webvh:QmUcyd...:webvh.storm.ws#webvh-hosting",
+                "type": "WebVHHosting",
+                "serviceEndpoint": {
+                    "hostingPath": "/webvh",
+                    "uri": "https://webvh.storm.ws"
+                }
+            }"#,
+        )
+        .expect("the live WebVHHosting entry parses");
         assert_eq!(
-            resolve_server_transport(&services),
+            resolve_server_transport(std::slice::from_ref(&svc)),
             Some(ResolvedTransport::Rest {
-                url: "https://webvh.storm.ws/webvh".to_string()
+                url: "https://webvh.storm.ws".to_string()
             })
         );
     }
 
-    /// Neither half's punctuation can be assumed — both come from a document.
-    #[test]
-    fn rest_base_join_is_slash_tolerant() {
-        for (uri, path) in [
-            ("https://h.example/", "/webvh"),
-            ("https://h.example", "webvh"),
-            ("https://h.example/", "webvh/"),
-        ] {
-            let services = vec![TestService::with_hosting_path(
-                &["WebVHHosting"],
-                Some(uri),
-                Some(path),
-            )];
-            assert_eq!(
-                resolve_server_transport(&services),
-                Some(ResolvedTransport::Rest {
-                    url: "https://h.example/webvh".to_string()
-                }),
-                "uri={uri} path={path}"
-            );
-        }
-    }
-
-    /// A server serving at the origin root is unchanged — no empty segment.
-    #[test]
-    fn rest_base_is_unchanged_without_a_hosting_path() {
-        for path in [None, Some(""), Some("/")] {
-            let services = vec![TestService::with_hosting_path(
-                &["WebVHHosting"],
-                Some("https://h.example"),
-                path,
-            )];
-            assert_eq!(
-                resolve_server_transport(&services),
-                Some(ResolvedTransport::Rest {
-                    url: "https://h.example".to_string()
-                }),
-                "path={path:?}"
-            );
-        }
-    }
-
-    // ── resolve_rest_endpoint ───────────────────────────────────────
-
     struct TestService {
         types: Vec<String>,
         uri: Option<String>,
-        hosting_path: Option<String>,
     }
     impl TestService {
         fn new(types: &[&str], uri: Option<&str>) -> Self {
             Self {
                 types: types.iter().map(|s| s.to_string()).collect(),
                 uri: uri.map(String::from),
-                hosting_path: None,
-            }
-        }
-        fn with_hosting_path(types: &[&str], uri: Option<&str>, path: Option<&str>) -> Self {
-            Self {
-                hosting_path: path.map(String::from),
-                ..Self::new(types, uri)
             }
         }
     }
     impl ServiceEntry for TestService {
         fn types(&self) -> &[String] {
             &self.types
-        }
-        fn hosting_path(&self) -> Option<String> {
-            self.hosting_path.clone()
         }
         fn endpoint_uri(&self) -> Option<String> {
             self.uri.clone()


### PR DESCRIPTION
Closes #759.

## What `hostingPath` means

Nothing. That is the finding, and it holds on both readings the issue asked about.

**No producer.** No caller has ever supplied `HOSTING_PATH`. `build_webvh_provision_ask` in `affinidi-webvh-service` — the one builder that mints server, control and daemon DIDs — sets `URL` and nothing else, so every document carrying the field carries the `did-host-http*` templates' own default, `/webvh`.

**No consumer.** `hostingPath` appears nowhere in `affinidi-webvh-service`, `didwebvh-rs`, or the TDK. Before #756 nothing in the ecosystem read it.

A field with no producer and no consumer, stamped into permanent signed documents.

## What the live server says

#756 read it as the REST control-plane base and joined it onto the origin, reasoning that a server may serve its control plane under a prefix. That was never checked against a live server. `webvh.storm.ws` — the host that motivated the change — settles it. `/api/health` is unauthenticated, so this needed no credentials:

```
GET https://webvh.storm.ws/api/health                     -> 200 {"status":"ok","version":"0.8.2"}
GET https://webvh.storm.ws/webvh/api/health               -> 404
GET https://webvh.storm.ws/magic-depart/did.jsonl         -> 200
GET https://webvh.storm.ws/webvh/magic-depart/did.jsonl   -> 404
```

Answering the issue's three questions:

1. **The control plane is at `/api/...` off the origin root.** `did-hosting-control` builds `Router::new().nest("/api", api)` with no prefix setting to configure — there is no deployment knob that could put it under `/webvh`.
2. **`hostingPath` denotes neither.** Not the control-plane base, per above; not the log location either.
3. **Logs serve from the root because the DID identifier determines the log path** — `did:webvh:<scid>:<domain>[:<path>]` resolves to `https://<domain>/<path>/did.jsonl`. `/webvh` was never part of it.

## Changes

**`vta-service` — revert `join_base`.** The REST base is `serviceEndpoint.uri` alone, as before #756. The `hosting_path` accessor goes with it. As #759 noted, `join_base` sat on `resolve_server_transport`, so this affected every REST-only server advertising a `hostingPath`, not just the agent-name flow that motivated it — and that flow has since moved to DIDComm (#758), so nothing was exercising the broken base to catch it.

The regression guard parses the verbatim `WebVHHosting` entry `webvh.storm.ws` publishes, through the same concrete `Service` type the resolver is handed, and pins that the advertised prefix is ignored. Its comment says to re-probe a live server before joining the halves again.

**Templates — stop emitting the field.** The three `did-host-http*` templates drop `hostingPath` and `HOSTING_PATH`, so new documents stop making a claim nothing backs. Existing documents keep it harmlessly, since the read side now ignores it.

**Docs — pin the meaning.** `docs/02-vta/did-templates.md:132` defined it as "where a hosting server publishes DID logs", which was never true. Replaced with a retirement note carrying the evidence above, so the next reader does not rediscover it as #756 did.

## Verification

- `cargo test -p vta-service -p vta-sdk --lib` — 1367 passed, 0 failed
- `cargo clippy -p vta-service -p vta-sdk --lib --all-features` — clean
- Live probes above, re-run against `webvh.storm.ws` at the time of writing

Signed-off-by: Glenn Gore <glenn.g@affinidi.com>
