### PR TITLE
fix(vta-service): log the consent decisions that currently reach no audit row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+### vta-service 0.12.15 — the consent decisions that reached no audit row
+
+* Two decision paths recorded nothing, so a decision that *arrived* looked
+  identical to one that never did. **Proof-verification failure** returns
+  through `reject_with`, which does not log, and cannot write an audit row —
+  there is no proven actor to attribute it to, and an unverified `from` is not
+  an identity. It is now a `warn!`, because a broken proof (rotated key, wrong
+  signer, malformed payload) and a wallet/routing failure have opposite causes
+  and previously looked the same from the VTA side. The **`add_approval` race**
+  (pending read, then gone before the approval lands) now records an audit row
+  under the existing `denied:no_pending` outcome. (#760)
+* Everything else #760 proposed was discarded deliberately: `record_consent`
+  (#739) already instruments every other decision outcome and emits it to the
+  `audit` target, so five of that patch's six lines would have been duplicates.
+
 ### vta-service 0.12.14 / vta-sdk 0.19.23 — `hostingPath` is retired, not reinterpreted
 
 * **`hostingPath` never meant anything, and 0.12.12 gave it a meaning the live

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10202,7 +10202,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.12.14"
+version = "0.12.15"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.12.14"
+version = "0.12.15"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/trust_tasks/task_consent.rs
+++ b/vta-service/src/trust_tasks/task_consent.rs
@@ -123,6 +123,20 @@ pub(super) async fn handle_decision(
     let approver = match crate::auth::di_proof::verify_trust_task_proof(&doc).await {
         Ok(did) => did,
         Err(e) => {
+            // The only decision path that reaches no audit row: every later
+            // rejection records one, but this one has no *proven* actor to
+            // attribute it to, and an unverified `from` is not an identity.
+            //
+            // Log it anyway. Without this line, a decision that arrives and
+            // fails verification is indistinguishable from one that never
+            // arrived — and those have opposite causes: a broken proof (key
+            // rotated, wrong signer, malformed payload) versus wallet/routing.
+            // An operator watching an update loop needs to tell them apart.
+            tracing::warn!(
+                error = %e,
+                "task-consent decision arrived but failed proof verification; \
+                 no approver could be attributed"
+            );
             return reject_with(
                 &doc,
                 RejectReason::PermissionDenied {
@@ -252,6 +266,20 @@ pub(super) async fn handle_decision(
     let updated = match consent::add_approval(ks, &pending.digest, &approver, now).await {
         Ok(Some(p)) => p,
         Ok(None) => {
+            // The pending was read above but is gone by the time the approval
+            // is recorded — it lapsed, or a concurrent decision resolved it.
+            // Rare, and the only rejection after a proven signer that recorded
+            // nothing, which made it look identical to a decision that never
+            // arrived.
+            crate::audit::record_consent(
+                &state.audit_ks,
+                "consent.decision",
+                &approver,
+                &pending.type_uri,
+                "denied:no_pending",
+                Some("the pending vanished between lookup and approval (lapsed or concurrently resolved)"),
+            )
+            .await;
             return reject_with(
                 &doc,
                 RejectReason::TaskFailed {


### PR DESCRIPTION
Closes #760 — but not by landing the patch it describes.

## Why most of the patch is now redundant

#760 preserved ~52 lines of consent-gate tracing written during a debugging session and never committed. Reviewed against current `main` rather than the tree it was written on, **five of its six log lines are already covered**.

`crate::audit::record_consent` (#739) instruments every decision outcome — `denied:no_pending`, `denied:challenge_mismatch`, `denied:not_a_member`, `denied:requester_excluded`, `success:approve`, `success:deny` — and emits each to the `audit` tracing target (ERROR for denials, INFO otherwise) as well as persisting it.

So any `consent.decision` row already proves the approver's decision arrived, and its `outcome` field names exactly which check refused it. That is the question #760 exists to answer, in structured form, already answered. Landing the patch as written would have duplicated all of it at `info!`.

## What genuinely was missing

Two paths record nothing, which is what made an arriving decision look identical to one that never arrived:

**1. Proof-verification failure.** A decision failing `verify_trust_task_proof` returns through `reject_with` — which does not log — and cannot write an audit row, because there is no *proven* actor to attribute it to and an unverified `from` is not an identity. This is the real "did it arrive at all" gap and the line #760 was reaching for. A broken proof (rotated key, wrong signer, malformed payload) and a wallet/routing failure have opposite causes and were indistinguishable from the VTA side. Now a `warn!`.

**2. The `add_approval` race.** The pending is read, then is gone by the time the approval is recorded — lapsed, or a concurrent decision resolved it. The only rejection after a proven signer that recorded nothing. Now an audit row, reusing the existing `denied:no_pending` outcome vocabulary rather than inventing a new one.

## The rest is discarded deliberately

#760 explicitly allowed for "land it (or discard it deliberately)". This is the discard, with the reasoning recorded so the patch is not resurrected later on the assumption it was lost by accident. The `/private/tmp/claude-501/vta-diag` worktree it lived in can now go.

## Verification

`cargo test -p vta-service --lib` — 946 passed, 0 failed. Clippy and fmt clean.

Signed-off-by: Glenn Gore <glenn.g@affinidi.com>
