### PR TITLE
fix(acl): say what an empty context list means, and stop storing a blank one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 ## Unreleased
 
+### vti-common 0.11.13 / vta-cli-common 0.10.9 / vta-service 0.12.16 / pnm-cli 0.11.5 — ACL contexts: say what an empty list means, and stop storing a blank one
+
+* **An empty `allowed_contexts` rendered as `(unrestricted)` for every role,
+  which is the opposite of the truth for all but one.** `is_super_admin`
+  requires `Role::Admin` *and* an empty list; `has_context_access` otherwise
+  iterates the list, and an empty list matches nothing. So a least-privilege
+  approver — the shape the `--approve-all` help text itself recommends —
+  displayed as holding blanket read access while able to act nowhere, and an
+  operator auditing for over-broad grants saw `(unrestricted)` on rows that were
+  inert. `format_contexts` is now role-aware in both copies (`pnm` and the
+  offline `vta acl`), rendering `(none — acts nowhere)` for non-admin. The test
+  that asserted the old behaviour pinned the bug, not the contract. (#746)
+* **`--contexts ''` stores a context named empty-string.** Verified against
+  clap 4 rather than assumed: the empty value parses to `[""]`, not `[]`. That
+  one-element list cleared every `is_empty()` guard while naming no context, and
+  **nothing on the ACL write path validated a context id's shape at all** —
+  `validate_context_path` existed and was never called there. A super admin
+  reached it most easily, since its authority check returns before any
+  per-context work. Both `validate_acl_modification` and
+  `validate_approve_scope_grant` now validate each id, which also rejects
+  `/ctx`, `ctx/`, `a//b` and ids containing spaces. The `--approve-all` help no
+  longer recommends the broken invocation — omit `--contexts` instead. (#747)
+
 ### vta-service 0.12.15 — the consent decisions that reached no audit row
 
 * Two decision paths recorded nothing, so a decision that *arrived* looked

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6743,7 +6743,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "pnm-cli"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-resolver-cache-sdk",
@@ -10063,7 +10063,7 @@ dependencies = [
 
 [[package]]
 name = "vta-cli-common"
-version = "0.10.8"
+version = "0.10.9"
 dependencies = [
  "aes-gcm",
  "affinidi-crypto",
@@ -10202,7 +10202,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.12.15"
+version = "0.12.16"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",
@@ -10391,7 +10391,7 @@ dependencies = [
 
 [[package]]
 name = "vti-common"
-version = "0.11.12"
+version = "0.11.13"
 dependencies = [
  "aes-gcm",
  "affinidi-data-integrity",

--- a/pnm-cli/Cargo.toml
+++ b/pnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pnm-cli"
 description = "CLI Tool for managing a personal Verifiable Trust Agent"
-version = "0.11.4"
+version = "0.11.5"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/pnm-cli/src/cli.rs
+++ b/pnm-cli/src/cli.rs
@@ -1679,7 +1679,11 @@ pub(crate) enum AclCommands {
         /// Human-readable label
         #[arg(long)]
         label: Option<String>,
-        /// Comma-separated context IDs (empty = unrestricted)
+        /// Comma-separated context IDs. Omit the flag entirely to leave the
+        /// list empty — which means *unrestricted* only for `--role admin`
+        /// (super admin) and *no access at all* for every other role. Do not
+        /// pass `--contexts ''`: that parses to one context named empty-string,
+        /// not to an empty list, and is rejected.
         #[arg(long, value_delimiter = ',')]
         contexts: Vec<String>,
         /// Optional expiry — accepts `N[s|m|h|d|w]` (e.g. `24h`, `7d`). When
@@ -1698,7 +1702,8 @@ pub(crate) enum AclCommands {
         step_up_require: Option<String>,
         /// Grant approve-authority over ALL contexts: this DID may *approve*
         /// (confer) a change across every context while being able to *act* in
-        /// none. Super-admin only. Pair with `--role reader --contexts ''`.
+        /// none. Super-admin only. Pair with `--role reader` and simply omit
+        /// `--contexts`.
         #[arg(long)]
         approve_all: bool,
         /// Grant approve-authority scoped to these contexts (comma-separated):

--- a/vta-cli-common/Cargo.toml
+++ b/vta-cli-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-cli-common"
 description = "Shared CLI command handlers and rendering helpers for VTA CLIs"
 readme = "README.md"
-version = "0.10.8"
+version = "0.10.9"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-cli-common/src/commands/acl.rs
+++ b/vta-cli-common/src/commands/acl.rs
@@ -7,11 +7,28 @@ use vta_sdk::prelude::*;
 
 use crate::render::{is_full_display, print_full_entry, print_full_list_title, print_widget};
 
-pub fn format_contexts(contexts: &[String]) -> String {
-    if contexts.is_empty() {
+/// Human-readable context list — **role-aware**, because an empty
+/// `allowed_contexts` means opposite things depending on the role.
+///
+/// `AuthClaims::is_super_admin` requires `Role::Admin` *and* an empty list;
+/// `has_context_access` otherwise iterates `allowed_contexts`, and an empty
+/// list matches nothing. So empty means "every context" for an admin and
+/// "no context at all" for every other role.
+///
+/// Rendering both as `(unrestricted)` misled in both directions on a
+/// security-relevant display: a correctly-scoped least-privilege approver
+/// looked like a blanket grant, and an operator auditing for over-broad
+/// access saw `(unrestricted)` on rows that were in fact inert.
+pub fn format_contexts(role: &str, contexts: &[String]) -> String {
+    if !contexts.is_empty() {
+        return contexts.join(", ");
+    }
+    if role == "admin" {
+        // `format_role` already renders this entry's role as "super admin",
+        // so the two columns read together without repeating the term.
         "(unrestricted)".to_string()
     } else {
-        contexts.join(", ")
+        "(none — acts nowhere)".to_string()
     }
 }
 
@@ -70,7 +87,7 @@ pub async fn cmd_acl_list(
         print_full_list_title("ACL Entries", resp.entries.len());
         for entry in &resp.entries {
             let label = entry.label.as_deref().unwrap_or("—");
-            let contexts = format_contexts(&entry.allowed_contexts);
+            let contexts = format_contexts(&entry.role, &entry.allowed_contexts);
             let role = format_role(&entry.role, &entry.allowed_contexts);
             let approve = format_approve_scope(entry.approve_all_contexts, &entry.approve_contexts);
             let mut fields: Vec<(&str, &str)> = vec![
@@ -100,7 +117,7 @@ pub async fn cmd_acl_list(
         .iter()
         .map(|entry| {
             let label = entry.label.clone().unwrap_or_else(|| "\u{2014}".into());
-            let contexts = format_contexts(&entry.allowed_contexts);
+            let contexts = format_contexts(&entry.role, &entry.allowed_contexts);
 
             Row::new(vec![
                 Cell::from(entry.did.clone()).style(Style::default().fg(Color::DarkGray)),
@@ -154,7 +171,7 @@ pub async fn cmd_acl_get(client: &VtaClient, did: &str) -> Result<(), Box<dyn st
     );
     println!(
         "Contexts:         {}",
-        format_contexts(&entry.allowed_contexts)
+        format_contexts(&entry.role, &entry.allowed_contexts)
     );
     if let Some(scope) = format_approve_scope(entry.approve_all_contexts, &entry.approve_contexts) {
         println!("Approve:          {scope}");
@@ -205,7 +222,10 @@ pub async fn cmd_acl_create(
     if let Some(label) = &entry.label {
         println!("  Label:      {label}");
     }
-    println!("  Contexts:   {}", format_contexts(&entry.allowed_contexts));
+    println!(
+        "  Contexts:   {}",
+        format_contexts(&entry.role, &entry.allowed_contexts)
+    );
     if let Some(scope) = format_approve_scope(entry.approve_all_contexts, &entry.approve_contexts) {
         println!("  Approve:    {scope}");
     }
@@ -255,7 +275,10 @@ pub async fn cmd_acl_update(
     if let Some(label) = &entry.label {
         println!("  Label:    {label}");
     }
-    println!("  Contexts: {}", format_contexts(&entry.allowed_contexts));
+    println!(
+        "  Contexts: {}",
+        format_contexts(&entry.role, &entry.allowed_contexts)
+    );
     if let Some(approver) = &step_up_approver {
         if approver.is_empty() {
             println!("  Step-up approver: (cleared)");
@@ -288,9 +311,36 @@ mod tests {
 
     // ── format_contexts ────────────────────────────────────────────
 
+    /// Empty means "every context" only for an admin. This test previously
+    /// asserted `(unrestricted)` for an empty list regardless of role, which
+    /// pinned the bug rather than the behaviour.
     #[test]
-    fn test_format_contexts_empty_shows_unrestricted() {
-        assert_eq!(format_contexts(&[]), "(unrestricted)");
+    fn test_format_contexts_empty_is_role_dependent() {
+        assert_eq!(format_contexts("admin", &[]), "(unrestricted)");
+        for role in ["reader", "initiator", "application"] {
+            assert_eq!(
+                format_contexts(role, &[]),
+                "(none — acts nowhere)",
+                "empty contexts must not read as unrestricted for role {role}"
+            );
+        }
+    }
+
+    /// The shape the `--approve-all` help text itself recommends: a reader
+    /// with no contexts whose authority is entirely `approve_scope`. It acts
+    /// nowhere, and the display must not suggest otherwise.
+    #[test]
+    fn test_least_privilege_approver_does_not_read_as_unrestricted() {
+        let contexts: Vec<String> = vec![];
+        assert_eq!(
+            format_contexts("reader", &contexts),
+            "(none — acts nowhere)"
+        );
+        assert_eq!(format_role("reader", &contexts), "reader");
+        assert_eq!(
+            format_approve_scope(false, &["openvtc".to_string()]).as_deref(),
+            Some("contexts [openvtc]")
+        );
     }
 
     #[test]
@@ -314,13 +364,13 @@ mod tests {
     #[test]
     fn test_format_contexts_single() {
         let ctx = vec!["vta".to_string()];
-        assert_eq!(format_contexts(&ctx), "vta");
+        assert_eq!(format_contexts("reader", &ctx), "vta");
     }
 
     #[test]
     fn test_format_contexts_multiple() {
         let ctx = vec!["vta".to_string(), "payments".to_string()];
-        assert_eq!(format_contexts(&ctx), "vta, payments");
+        assert_eq!(format_contexts("reader", &ctx), "vta, payments");
     }
 
     // ── format_role ────────────────────────────────────────────────

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.12.15"
+version = "0.12.16"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/acl_cli.rs
+++ b/vta-service/src/acl_cli.rs
@@ -40,7 +40,7 @@ pub async fn run_acl_list(
         if let Some(label) = &entry.label {
             eprintln!("  Label:    {label}");
         }
-        eprintln!("  Contexts: {}", format_contexts(&entry.allowed_contexts));
+        eprintln!("  Contexts: {}", format_contexts(entry));
         eprintln!("  Created:  {}", format_timestamp(entry.created_at));
         eprintln!();
     }
@@ -167,17 +167,26 @@ fn print_entry_details(entry: &AclEntry) {
     if let Some(label) = &entry.label {
         eprintln!("  Label:      {label}");
     }
-    eprintln!("  Contexts:   {}", format_contexts(&entry.allowed_contexts));
+    eprintln!("  Contexts:   {}", format_contexts(entry));
     eprintln!("  Created:    {}", format_timestamp(entry.created_at));
     eprintln!("  Created by: {}", entry.created_by);
     eprintln!();
 }
 
-fn format_contexts(contexts: &[String]) -> String {
-    if contexts.is_empty() {
+/// Role-aware, for the same reason as the `pnm` copy in
+/// `vta-cli-common::commands::acl`: an empty `allowed_contexts` grants every
+/// context to an admin (`is_super_admin`) and none to any other role
+/// (`has_context_access` iterates the list, and an empty list matches nothing).
+/// Rendering both as `(unrestricted)` said the opposite of the truth for every
+/// non-admin entry.
+fn format_contexts(entry: &AclEntry) -> String {
+    if !entry.allowed_contexts.is_empty() {
+        return entry.allowed_contexts.join(", ");
+    }
+    if entry.role == Role::Admin {
         "(unrestricted)".into()
     } else {
-        contexts.join(", ")
+        "(none — acts nowhere)".into()
     }
 }
 

--- a/vti-common/Cargo.toml
+++ b/vti-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-common"
 description = "Shared server-side infrastructure for VTA and VTC services"
 readme = "README.md"
-version = "0.11.12"
+version = "0.11.13"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vti-common/src/acl/mod.rs
+++ b/vti-common/src/acl/mod.rs
@@ -334,6 +334,11 @@ pub fn validate_approve_scope_grant(
                     "approve scope must name at least one context (or use 'all')".into(),
                 ));
             }
+            // `--approve-contexts ''` parses to `[""]`, which is not empty and
+            // so cleared the check above while naming no context at all.
+            for c in cs {
+                crate::context_path::validate_context_path(c)?;
+            }
             for c in cs {
                 caller.require_context(c)?;
             }
@@ -718,6 +723,16 @@ pub fn validate_acl_modification(
     caller: &AuthClaims,
     target_contexts: &[String],
 ) -> Result<(), AppError> {
+    // Shape first, for every caller. `validate_context_path` existed all along
+    // but was never called on the ACL write path, so a malformed id — most
+    // reachably `""`, which is what `--contexts ''` actually parses to — was
+    // storable. Super admins reached it most easily, since their check below
+    // returns before any per-context work happens. An empty id is not an
+    // identifier and matches nothing in `has_context_access`, so an entry
+    // holding one is inert while looking scoped.
+    for ctx in target_contexts {
+        crate::context_path::validate_context_path(ctx)?;
+    }
     if caller.is_super_admin() {
         return Ok(());
     }
@@ -1511,5 +1526,49 @@ mod tests {
             validate_approve_scope_grant(&ctx_admin, &ApproveScope::Contexts(vec![])).is_err(),
             "empty scope must name a context or use all"
         );
+    }
+
+    /// `--contexts ''` / `--approve-contexts ''` parse to `[""]`, not to `[]`
+    /// — verified against clap 4 rather than assumed. A one-element list of
+    /// the empty string cleared every `is_empty()` guard while naming no
+    /// context, and nothing on the ACL write path validated the id's shape.
+    /// A super admin hit this most easily: its authority check returns before
+    /// any per-context work.
+    #[test]
+    fn blank_context_ids_are_rejected_on_every_acl_write_path() {
+        let blank = vec![String::new()];
+
+        assert!(
+            validate_acl_modification(&super_admin_claims(), &blank).is_err(),
+            "a super admin must not store a context named empty-string"
+        );
+        assert!(
+            validate_acl_modification(&context_admin_claims(&["ctx-a"]), &blank).is_err(),
+            "nor may a context admin"
+        );
+        assert!(
+            validate_approve_scope_grant(
+                &super_admin_claims(),
+                &ApproveScope::Contexts(blank.clone())
+            )
+            .is_err(),
+            "an approve scope of [\"\"] names no context"
+        );
+
+        // Other malformed shapes go the same way, now that the write path
+        // validates at all.
+        for bad in ["/ctx", "ctx/", "a//b", "ev il"] {
+            assert!(
+                validate_acl_modification(&super_admin_claims(), &[bad.to_string()]).is_err(),
+                "{bad} must be rejected"
+            );
+        }
+
+        // The legitimate shapes still pass, including the empty *list* that
+        // means super admin.
+        validate_acl_modification(&super_admin_claims(), &[])
+            .expect("an empty list is still how super admin is expressed");
+        validate_acl_modification(&super_admin_claims(), &["acme/eng".to_string()])
+            .expect("a well-formed nested path is still accepted");
     }
 }


### PR DESCRIPTION
Closes #746 and #747 — two issues in the same code path, both about `allowed_contexts`.

## #746 — the display said the opposite of the truth

An empty `allowed_contexts` rendered as `(unrestricted)` for **every** role. That's right for exactly one of them:

- `AuthClaims::is_super_admin` requires `Role::Admin` **and** an empty list.
- `has_context_access` otherwise iterates `allowed_contexts` — and an empty list matches nothing.

So for every non-admin role, empty means access to *nothing*, and the display said the reverse. It misled in both directions on a security-relevant screen:

- A least-privilege approver — the shape the `--approve-all` help text itself recommends, whose authority is entirely `approve_scope` — showed as holding blanket read access.
- An operator auditing for over-broad grants saw `(unrestricted)` on rows that were inert, with the genuinely unrestricted admin rows lost among them.

`format_contexts` is now role-aware in **both** copies — `vta-cli-common` (`pnm`) and the separate one in `vta-service/src/acl_cli.rs` (offline `vta acl`), which had the identical bug and wasn't mentioned in the issue. Non-admin + empty reads `(none — acts nowhere)`; admin keeps `(unrestricted)`, which reads alongside the `super admin` that `format_role` already prints.

The existing `test_format_contexts_empty_shows_unrestricted` asserted the old behaviour with no role at all — it pinned the bug rather than the contract, so it's replaced with one covering both branches.

## #747 — `--contexts ''` stores a context named empty-string

The issue asked for this to be **verified, not assumed**, since clap's behaviour has changed across versions. Verified against clap 4:

```
["--contexts", ""]    -> [""]      (len 1)
["--contexts", "a,b"] -> ["a","b"] (len 2)
[]                    -> []        (len 0)
```

So the recommended invocation does store a context named empty-string. That one-element list is not empty, so it cleared every `is_empty()` guard while naming no context.

Chasing the issue's open question — "whether context ids are validated on the ACL write path at all" — the answer is **no**. `validate_context_path` (which rejects empty, leading/trailing/doubled separators, and invalid segment characters) existed all along and was never called from the ACL path. A super admin reached this most easily, because `validate_acl_modification` returns on the super-admin check *before* any per-context work.

Both `validate_acl_modification` and `validate_approve_scope_grant` now validate every id, which also closes `/ctx`, `ctx/`, `a//b`, and ids containing spaces. Existing stored entries are unaffected — this validates on write, not read.

Help text: `--approve-all` no longer recommends the broken invocation (omitting `--contexts` yields `Vec::new()`, unambiguously the intended state), and `--contexts` now states what an empty list means per role instead of "empty = unrestricted" — the same untruth as #746.

## Verification

`cargo test -p vti-common -p vta-cli-common -p vta-service --lib` — 1347 passed, 0 failed. `pnm-cli` builds; clippy and fmt clean.

## Note

#744 and #745 (the other two ACL issues) are the surface-level half — approve_scope having no update path, and the offline CLI having no `create`. Those are next, in a separate PR; this one is display and validation only.

Signed-off-by: Glenn Gore <glenn.g@affinidi.com>
