### PR TITLE
feat(acl): make approve scope changeable, and give the offline CLI a create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 ## Unreleased
 
+### vta-sdk 0.19.24 / vti-common 0.11.14 / vta-service 0.12.17 / vta-cli-common 0.10.10 / pnm-cli 0.11.6 / cnm-cli 0.11.4 — approve scope is changeable, and the offline CLI can create
+
+* **`approve_scope` was settable at create time only**, on every surface — REST,
+  DIDComm, `pnm`, offline `vta`. Narrowing, widening or revoking an approver
+  meant delete-and-recreate, which is worse than it sounds for exactly these
+  entries: `ApproveScope::All` is super-admin-only to grant, so a non-super-admin
+  operator whose recreate is refused has already landed the delete and left the
+  DID with **no ACL entry at all**. It is also non-atomic over DIDComm, where an
+  `Ok` means accepted-locally rather than applied, and it loses
+  `created_at` / `created_by`. All four update paths now carry it. (#744)
+* **Clearing is `Some(ApproveScope::None)`, not absence.** The update bodies
+  carry the enum rather than mirroring create's `approve_all_contexts: bool` +
+  `approve_contexts: Vec<String>` pair, because two independent fields cannot
+  distinguish "revoke this approver" from "leave it alone" — and revoking is the
+  case that matters most. On the CLIs that is an explicit `--approve-none`
+  flag, for the same reason: an empty list cannot mean both.
+* **`ApproveScope` moves to `vta-sdk`** (`vta_sdk::acl`), re-exported from
+  `vti-common` — the arrangement already used for `context_path`. The DIDComm
+  `UpdateAclBody` lives in the SDK and must be constructible by clients that
+  never link the server crates. Only the shape moves; every authorization rule
+  over it (`validate_approve_scope_grant`) stays in `vti-common`. The wire shape
+  is unchanged and now pinned by a round-trip test.
+* **`vta acl create` exists.** The offline surface had `list`/`get`/`update`/
+  `delete` but no create, and the only offline entry-minting path (`vta
+  import-did`) hardcodes an admin role with empty contexts behind the bootstrap
+  seal — so there was no offline route to an approver entry at all. Like the
+  existing offline `update`, it is **break-glass: no authorization check**,
+  because the surface has no authenticated caller (it is direct store access by
+  whoever holds the filesystem). The help text says so, so the absent
+  super-admin check does not read as an oversight. Context-id *shape* validation
+  still applies — that is not an authorization check, and the break-glass path
+  should not be the one that plants a malformed id in the store. (#745)
+
 ### vti-common 0.11.13 / vta-cli-common 0.10.9 / vta-service 0.12.16 / pnm-cli 0.11.5 — ACL contexts: say what an empty list means, and stop storing a blank one
 
 * **An empty `allowed_contexts` rendered as `(unrestricted)` for every role,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2472,7 +2472,7 @@ checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cnm-cli"
-version = "0.11.3"
+version = "0.11.4"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "clap",
@@ -6743,7 +6743,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "pnm-cli"
-version = "0.11.5"
+version = "0.11.6"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-resolver-cache-sdk",
@@ -10063,7 +10063,7 @@ dependencies = [
 
 [[package]]
 name = "vta-cli-common"
-version = "0.10.9"
+version = "0.10.10"
 dependencies = [
  "aes-gcm",
  "affinidi-crypto",
@@ -10142,7 +10142,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.19.23"
+version = "0.19.24"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10202,7 +10202,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.12.16"
+version = "0.12.17"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",
@@ -10391,7 +10391,7 @@ dependencies = [
 
 [[package]]
 name = "vti-common"
-version = "0.11.13"
+version = "0.11.14"
 dependencies = [
  "aes-gcm",
  "affinidi-data-integrity",

--- a/cnm-cli/Cargo.toml
+++ b/cnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cnm-cli"
 description = "CLI Tool for Verified Trust Agents operating in Verified Trust Communities"
-version = "0.11.3"
+version = "0.11.4"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/cnm-cli/src/main.rs
+++ b/cnm-cli/src/main.rs
@@ -1164,7 +1164,11 @@ async fn main() {
                 role,
                 label,
                 contexts,
-            } => acl::cmd_acl_update(&client, &did, role, label, contexts, None, None).await,
+            } => {
+                // cnm exposes no approve-scope flags; pass `None` so the
+                // scope is left unchanged rather than silently cleared.
+                acl::cmd_acl_update(&client, &did, role, label, contexts, None, None, None).await
+            }
             AclCommands::Delete { did } => acl::cmd_acl_delete(&client, &did).await,
         },
         Commands::AuthCredential { command } => match command {

--- a/pnm-cli/Cargo.toml
+++ b/pnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pnm-cli"
 description = "CLI Tool for managing a personal Verifiable Trust Agent"
-version = "0.11.5"
+version = "0.11.6"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/pnm-cli/src/cli.rs
+++ b/pnm-cli/src/cli.rs
@@ -1733,6 +1733,21 @@ pub(crate) enum AclCommands {
         /// empty string to clear it; omit to leave it unchanged.
         #[arg(long)]
         step_up_require: Option<String>,
+        /// Grant approve-authority over ALL contexts. Super-admin only.
+        #[arg(long, conflicts_with_all = ["approve_contexts", "approve_none"])]
+        approve_all: bool,
+        /// Replace approve-authority with exactly these contexts
+        /// (comma-separated). Requires the caller to administer each.
+        #[arg(long, value_delimiter = ',', conflicts_with = "approve_none")]
+        approve_contexts: Option<Vec<String>>,
+        /// Revoke this entry's approve-authority entirely.
+        ///
+        /// An explicit flag rather than an empty list, because "confer
+        /// nothing" and "leave the scope alone" are different intents and an
+        /// empty value cannot mean both. Omitting all three approve flags
+        /// leaves the scope unchanged.
+        #[arg(long)]
+        approve_none: bool,
     },
     /// Delete an ACL entry
     Delete {

--- a/pnm-cli/src/commands/acl.rs
+++ b/pnm-cli/src/commands/acl.rs
@@ -47,7 +47,12 @@ pub(crate) async fn run(
             contexts,
             step_up_approver,
             step_up_require,
+            approve_all,
+            approve_contexts,
+            approve_none,
         } => {
+            let approve_scope =
+                acl::approve_scope_from_flags(approve_all, approve_contexts, approve_none);
             acl::cmd_acl_update(
                 client,
                 &did,
@@ -56,6 +61,7 @@ pub(crate) async fn run(
                 contexts,
                 step_up_approver,
                 step_up_require,
+                approve_scope,
             )
             .await
         }

--- a/tests/e2e/tests/client_didcomm.rs
+++ b/tests/e2e/tests/client_didcomm.rs
@@ -521,6 +521,7 @@ async fn update_acl_via_didcomm() {
         allowed_contexts: None,
         step_up_approver: None,
         step_up_require: None,
+        approve_scope: None,
     };
     client.update_acl("did:key:zAdmin", req).await.unwrap();
 

--- a/vta-cli-common/Cargo.toml
+++ b/vta-cli-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-cli-common"
 description = "Shared CLI command handlers and rendering helpers for VTA CLIs"
 readme = "README.md"
-version = "0.10.9"
+version = "0.10.10"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-cli-common/src/commands/acl.rs
+++ b/vta-cli-common/src/commands/acl.rs
@@ -3,6 +3,7 @@ use ratatui::{
     style::{Color, Modifier, Style},
     widgets::{Block, Cell, Row, Table},
 };
+use vta_sdk::acl::ApproveScope;
 use vta_sdk::prelude::*;
 
 use crate::render::{is_full_display, print_full_entry, print_full_list_title, print_widget};
@@ -246,6 +247,26 @@ pub async fn cmd_acl_create(
     Ok(())
 }
 
+/// Resolve the three mutually-exclusive approve flags into the wire value.
+///
+/// `None` means "leave unchanged" — which is why revoking needs its own flag
+/// rather than an empty `--approve-contexts`: an empty list cannot mean both
+/// "confer nothing" and "don't touch it".
+pub fn approve_scope_from_flags(
+    approve_all: bool,
+    approve_contexts: Option<Vec<String>>,
+    approve_none: bool,
+) -> Option<ApproveScope> {
+    if approve_none {
+        Some(ApproveScope::None)
+    } else if approve_all {
+        Some(ApproveScope::All)
+    } else {
+        approve_contexts.map(ApproveScope::Contexts)
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
 pub async fn cmd_acl_update(
     client: &VtaClient,
     did: &str,
@@ -254,16 +275,19 @@ pub async fn cmd_acl_update(
     contexts: Option<Vec<String>>,
     step_up_approver: Option<String>,
     step_up_require: Option<String>,
+    approve_scope: Option<ApproveScope>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     if let Some(ref r) = role {
         validate_role(r)?;
     }
+    let approve_scope_echo = approve_scope.clone();
     let req = UpdateAclRequest {
         role,
         label,
         allowed_contexts: contexts,
         step_up_approver: step_up_approver.clone(),
         step_up_require: step_up_require.clone(),
+        approve_scope,
     };
     let entry = client.update_acl(did, req).await?;
     println!("ACL entry updated:");
@@ -292,6 +316,16 @@ pub async fn cmd_acl_update(
         } else {
             println!("  Step-up require:  {require}");
         }
+    }
+    // Echo the scope only when this call set it, so "unchanged" is visibly
+    // different from "set to confer nothing".
+    if let Some(scope) = &approve_scope_echo {
+        let rendered = match scope {
+            ApproveScope::None => "(revoked — confers nothing)".to_string(),
+            ApproveScope::All => "all contexts".to_string(),
+            ApproveScope::Contexts(cs) => format!("contexts [{}]", cs.join(", ")),
+        };
+        println!("  Approve:  {rendered}");
     }
     Ok(())
 }

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.19.23"
+version = "0.19.24"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/acl.rs
+++ b/vta-sdk/src/acl.rs
@@ -1,0 +1,108 @@
+//! ACL wire types shared between the VTA and its clients.
+//!
+//! These live here — rather than in `vti-common` alongside the ACL storage and
+//! authorization logic — because the DIDComm and Trust Task bodies in
+//! [`crate::protocols::acl_management`] are part of the wire contract and must
+//! be constructible by clients that never link the server crates. `vti-common`
+//! depends on this crate (never the reverse) and re-exports what it needs, the
+//! same arrangement already used for [`crate::context_path`].
+//!
+//! Authorization over these types stays server-side: `validate_approve_scope_grant`
+//! and friends remain in `vti-common`. Only the shape is shared.
+
+use serde::{Deserialize, Serialize};
+
+/// A DID's authority to **confer** access through an approval — task-consent
+/// delegation (`compute_delegated_contexts`) and delegated step-up ratification
+/// (`delegated_any_approver_covers`) — **without** any authority to act.
+///
+/// Read only by those two conferral paths; it never feeds `require_admin` or
+/// `has_context_access`, so an approver can bless a change in a context while
+/// being unable to make one. This is the axis that lets an approver be
+/// least-privilege: `role: Reader`, `allowed_contexts: []` (acts nowhere),
+/// `approve_scope: All` (may authorize anywhere).
+///
+/// Default [`ApproveScope::None`]: an entry confers nothing unless explicitly
+/// granted this — strictly additive and fail-closed. Pre-existing rows omit the
+/// field and deserialise as `None`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "snake_case", tag = "kind", content = "contexts")]
+pub enum ApproveScope {
+    /// Confers nothing (the default).
+    #[default]
+    None,
+    /// May confer any context — a cross-context authorizer. Granting this is
+    /// super-admin-only (see `vti_common::acl::validate_approve_scope_grant`).
+    All,
+    /// May confer these contexts (and their subtrees), and only these.
+    Contexts(Vec<String>),
+}
+
+impl ApproveScope {
+    /// Whether an approval by a holder of this scope may confer `context_id`.
+    ///
+    /// Segment-aware ancestry, matching `AuthClaims::has_context_access`, so an
+    /// approver scoped to a parent context covers its whole subtree.
+    pub fn covers(&self, context_id: &str) -> bool {
+        match self {
+            ApproveScope::None => false,
+            ApproveScope::All => true,
+            ApproveScope::Contexts(cs) => cs
+                .iter()
+                .any(|c| crate::context_path::is_ancestor_or_self(c, context_id)),
+        }
+    }
+
+    /// Whether this scope confers nothing.
+    pub fn confers_nothing(&self) -> bool {
+        matches!(self, ApproveScope::None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The wire shape is a contract: stored ACL rows and DIDComm bodies both
+    /// carry it, so a change here silently reinterprets existing entries.
+    #[test]
+    fn wire_shape_is_pinned() {
+        let cases = [
+            (ApproveScope::None, r#"{"kind":"none"}"#),
+            (ApproveScope::All, r#"{"kind":"all"}"#),
+            (
+                ApproveScope::Contexts(vec!["a".into(), "b/c".into()]),
+                r#"{"kind":"contexts","contexts":["a","b/c"]}"#,
+            ),
+        ];
+        for (scope, json) in cases {
+            assert_eq!(serde_json::to_string(&scope).unwrap(), json);
+            assert_eq!(
+                serde_json::from_str::<ApproveScope>(json).unwrap(),
+                scope,
+                "round trip for {json}"
+            );
+        }
+    }
+
+    /// Absent ⇒ `None`, so rows written before the field existed stay
+    /// fail-closed rather than deserialising into some conferring shape.
+    #[test]
+    fn absent_defaults_to_conferring_nothing() {
+        assert_eq!(ApproveScope::default(), ApproveScope::None);
+        assert!(ApproveScope::default().confers_nothing());
+    }
+
+    #[test]
+    fn covers_is_subtree_aware() {
+        let scope = ApproveScope::Contexts(vec!["acme".into()]);
+        assert!(scope.covers("acme"));
+        assert!(scope.covers("acme/eng"));
+        assert!(!scope.covers("acme-corp"), "sibling must not match");
+        assert!(!scope.covers("other"));
+
+        assert!(ApproveScope::All.covers("anything"));
+        assert!(!ApproveScope::None.covers("anything"));
+    }
+}

--- a/vta-sdk/src/client/mod.rs
+++ b/vta-sdk/src/client/mod.rs
@@ -1356,6 +1356,7 @@ mod tests {
             allowed_contexts: None,
             step_up_approver: None,
             step_up_require: None,
+            approve_scope: None,
         };
         let json = serde_json::to_value(&req).unwrap();
         let obj = json.as_object().unwrap();

--- a/vta-sdk/src/client/types.rs
+++ b/vta-sdk/src/client/types.rs
@@ -451,6 +451,11 @@ pub struct UpdateAclRequest {
     /// an empty string to clear; `None` leaves the current value unchanged.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub step_up_require: Option<String>,
+    /// Set the approve scope to exactly this value; `None` leaves it unchanged.
+    /// Clearing is `Some(ApproveScope::None)` — an explicit value, since an
+    /// empty list cannot mean both "confer nothing" and "leave alone".
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub approve_scope: Option<crate::acl::ApproveScope>,
 }
 
 // ── WebVH server types ──────────────────────────────────────────────

--- a/vta-sdk/src/lib.rs
+++ b/vta-sdk/src/lib.rs
@@ -84,6 +84,7 @@ pub mod error;
 pub mod hex;
 // Pure, dependency-light validators shared with clients so they apply the
 // VTA's canonical context-path / identifier rules without mirroring them.
+pub mod acl;
 pub mod context_path;
 pub mod identifier;
 

--- a/vta-sdk/src/protocols/acl_management/update.rs
+++ b/vta-sdk/src/protocols/acl_management/update.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
 
+use crate::acl::ApproveScope;
+
 use super::create::CreateAclResultBody;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -21,6 +23,20 @@ pub struct UpdateAclBody {
     /// sets it; `None` leaves it unchanged (consistent with the other fields).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub step_up_require: Option<String>,
+    /// Set the approve scope to exactly this value; omit to leave unchanged.
+    ///
+    /// Unlike the create body — which takes `approve_all_contexts` +
+    /// `approve_contexts` as two independent fields — this carries the enum
+    /// itself, because **clearing has to be expressible**. With two flat fields
+    /// there is no way to distinguish "revoke this approver's authority" from
+    /// "leave it alone", and revoking is the case that matters most: before
+    /// this existed, the only way to narrow or drop an approve scope was to
+    /// delete the ACL entry and recreate it, which leaves the DID with no entry
+    /// at all if the recreate fails.
+    ///
+    /// Clear is `Some(ApproveScope::None)` — an explicit value, not absence.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub approve_scope: Option<ApproveScope>,
 }
 
 pub type UpdateAclResultBody = CreateAclResultBody;

--- a/vta-sdk/tests/client_rest.rs
+++ b/vta-sdk/tests/client_rest.rs
@@ -642,6 +642,7 @@ async fn update_acl_patches() {
         allowed_contexts: Some(vec!["ctx-b".into()]),
         step_up_approver: None,
         step_up_require: None,
+        approve_scope: None,
     };
     let resp = c.update_acl("did:key:zAdmin", req).await.unwrap();
     assert_eq!(resp.did, "did:key:zAdmin");

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.12.16"
+version = "0.12.17"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/acl_cli.rs
+++ b/vta-service/src/acl_cli.rs
@@ -1,11 +1,120 @@
 use crate::acl::{
-    AclEntry, Role, delete_acl_entry, get_acl_entry, list_acl_entries, store_acl_entry,
+    AclEntry, ApproveScope, Role, delete_acl_entry, get_acl_entry, list_acl_entries,
+    store_acl_entry,
 };
 use crate::config::AppConfig;
 use crate::store::Store;
 use chrono::{TimeZone, Utc};
 use dialoguer::Confirm;
 use std::path::PathBuf;
+
+/// Create an ACL entry directly in the store.
+///
+/// **Break-glass: no authorization check is performed.** There is no
+/// authenticated caller on this surface — it is direct store access by whoever
+/// holds the filesystem — so `validate_role_assignment`,
+/// `validate_acl_modification` and `validate_approve_scope_grant` are not
+/// consulted. That matches what `run_acl_update` already does, and it is the
+/// point of the surface rather than an omission: this is the path that exists
+/// when the daemon is down and the online `pnm acl create` cannot be reached.
+/// The `Create` help text states it so nobody reads the missing super-admin
+/// check as a bug.
+///
+/// The gap this closes: `vta import-did` was the only offline entry-minting
+/// path, and it hardcodes an admin role with empty contexts behind the
+/// bootstrap seal. It cannot mint a reader entry and cannot set an approve
+/// scope — so with `update` unable to change `approve_scope` either (until
+/// now), there was no offline route to an approver entry at all.
+#[allow(clippy::too_many_arguments)]
+pub async fn run_acl_create(
+    config_path: Option<PathBuf>,
+    did: String,
+    role: String,
+    label: Option<String>,
+    contexts: Vec<String>,
+    expires: Option<String>,
+    step_up_approver: Option<String>,
+    step_up_require: Option<String>,
+    approve_all: bool,
+    approve_contexts: Vec<String>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let role = Role::parse(&role)?;
+    let expires_at = expires
+        .as_deref()
+        .map(parse_duration_to_expiry)
+        .transpose()?;
+    let step_up_require =
+        crate::operations::acl::parse_step_up_require(step_up_require.as_deref())?;
+    let approve_scope = if approve_all {
+        ApproveScope::All
+    } else if !approve_contexts.is_empty() {
+        ApproveScope::Contexts(approve_contexts)
+    } else {
+        ApproveScope::None
+    };
+
+    // Shape validation still applies — it is not an authorization check. A
+    // context id of `""` or `a//b` is unstorable through every other path
+    // (#747), and the break-glass surface should not be the one that plants a
+    // malformed id in the store.
+    for ctx in contexts.iter().chain(match &approve_scope {
+        ApproveScope::Contexts(cs) => cs.iter(),
+        _ => [].iter(),
+    }) {
+        vti_common::context_path::validate_context_path(ctx)?;
+    }
+
+    let config = AppConfig::load(config_path)?;
+    let store = Store::open(&config.store)?;
+    let acl_ks = store.keyspace(crate::keyspaces::ACL)?;
+
+    if get_acl_entry(&acl_ks, &did).await?.is_some() {
+        return Err(format!(
+            "an ACL entry already exists for {did} — use 'vta acl update' to change it"
+        )
+        .into());
+    }
+
+    let entry = AclEntry::new(&did, role, "vta-cli (break-glass)")
+        .with_label(label)
+        .with_contexts(contexts)
+        .with_expires_at(expires_at)
+        .with_step_up_approver(step_up_approver)
+        .with_step_up_require(step_up_require)
+        .with_approve_scope(approve_scope);
+
+    store_acl_entry(&acl_ks, &entry).await?;
+    store.persist().await?;
+
+    eprintln!("ACL entry created:\n");
+    print_entry_details(&entry);
+    Ok(())
+}
+
+/// `N[s|m|h|d|w]` (or bare seconds) from now, as an absolute epoch. Mirrors
+/// `vta_cli_common::duration`, which this crate does not depend on.
+fn parse_duration_to_expiry(s: &str) -> Result<u64, Box<dyn std::error::Error>> {
+    let s = s.trim();
+    if s.is_empty() {
+        return Err("empty --expires value".into());
+    }
+    let (num, mult) = match s.as_bytes().last().copied() {
+        Some(b's') => (&s[..s.len() - 1], 1u64),
+        Some(b'm') => (&s[..s.len() - 1], 60),
+        Some(b'h') => (&s[..s.len() - 1], 3_600),
+        Some(b'd') => (&s[..s.len() - 1], 86_400),
+        Some(b'w') => (&s[..s.len() - 1], 604_800),
+        Some(c) if c.is_ascii_digit() => (s, 1),
+        _ => return Err(format!("invalid --expires '{s}' (use N[s|m|h|d|w])").into()),
+    };
+    let n: u64 = num
+        .parse()
+        .map_err(|_| format!("invalid --expires number in '{s}'"))?;
+    if n == 0 {
+        return Err("--expires must be positive".into());
+    }
+    Ok(crate::auth::session::now_epoch().saturating_add(n.saturating_mul(mult)))
+}
 
 pub async fn run_acl_list(
     config_path: Option<PathBuf>,
@@ -64,6 +173,24 @@ pub async fn run_acl_get(
     Ok(())
 }
 
+/// Resolve the three mutually-exclusive approve flags into a wire value.
+/// `None` leaves the scope unchanged; revoking needs its own flag because an
+/// empty list cannot mean both "confer nothing" and "don't touch it".
+fn approve_scope_from_flags(
+    approve_all: bool,
+    approve_contexts: Option<Vec<String>>,
+    approve_none: bool,
+) -> Option<ApproveScope> {
+    if approve_none {
+        Some(ApproveScope::None)
+    } else if approve_all {
+        Some(ApproveScope::All)
+    } else {
+        approve_contexts.map(ApproveScope::Contexts)
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
 pub async fn run_acl_update(
     config_path: Option<PathBuf>,
     did: String,
@@ -72,15 +199,21 @@ pub async fn run_acl_update(
     contexts: Option<Vec<String>>,
     step_up_approver: Option<String>,
     step_up_require: Option<String>,
+    approve_all: bool,
+    approve_contexts: Option<Vec<String>>,
+    approve_none: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    let approve_scope = approve_scope_from_flags(approve_all, approve_contexts, approve_none);
     if role.is_none()
         && label.is_none()
         && contexts.is_none()
         && step_up_approver.is_none()
         && step_up_require.is_none()
+        && approve_scope.is_none()
     {
         return Err("nothing to update — specify --role, --label, --contexts, \
-             --step-up-approver, or --step-up-require"
+             --step-up-approver, --step-up-require, --approve-all, \
+             --approve-contexts, or --approve-none"
             .into());
     }
 
@@ -118,6 +251,10 @@ pub async fn run_acl_update(
         } else {
             crate::operations::acl::parse_step_up_require(Some(&require))?
         };
+    }
+
+    if let Some(scope) = approve_scope {
+        entry.approve_scope = scope;
     }
 
     store_acl_entry(&acl_ks, &entry).await?;

--- a/vta-service/src/main.rs
+++ b/vta-service/src/main.rs
@@ -1199,6 +1199,49 @@ enum AuthCommands {
 
 #[derive(Subcommand)]
 enum AclCommands {
+    /// Create an ACL entry.
+    ///
+    /// **Break-glass: no authorization check is performed.** There is no
+    /// authenticated caller on this surface — it is direct store access by
+    /// whoever holds the filesystem, so `validate_role_assignment`,
+    /// `validate_acl_modification` and `validate_approve_scope_grant` are not
+    /// consulted, exactly as `vta acl update` already does. That is deliberate
+    /// and is the point of the surface; it is stated here so its absence does
+    /// not read as an oversight.
+    ///
+    /// `vta import-did` is not a substitute: it hardcodes an admin role with
+    /// empty contexts and sits behind the bootstrap seal, so it cannot mint a
+    /// reader entry or set an approve scope.
+    Create {
+        /// The DID this entry authorizes
+        #[arg(long)]
+        did: String,
+        /// Role (admin, initiator, application, reader)
+        #[arg(long)]
+        role: String,
+        /// Human-readable label
+        #[arg(long)]
+        label: Option<String>,
+        /// Comma-separated context IDs. Omit for an empty list, which is
+        /// unrestricted for `--role admin` and no access at all otherwise.
+        #[arg(long, value_delimiter = ',')]
+        contexts: Vec<String>,
+        /// Optional expiry — `N[s|m|h|d|w]` (e.g. `24h`, `7d`).
+        #[arg(long)]
+        expires: Option<String>,
+        /// Delegated step-up approver VID (`stepUp.approver`).
+        #[arg(long)]
+        step_up_approver: Option<String>,
+        /// Per-entry step-up override (`self` | `delegated`).
+        #[arg(long)]
+        step_up_require: Option<String>,
+        /// Grant approve-authority over ALL contexts.
+        #[arg(long, conflicts_with = "approve_contexts")]
+        approve_all: bool,
+        /// Grant approve-authority scoped to these contexts (comma-separated).
+        #[arg(long, value_delimiter = ',')]
+        approve_contexts: Vec<String>,
+    },
     /// List all ACL entries
     List {
         /// Filter by context
@@ -1235,6 +1278,17 @@ enum AclCommands {
         /// `stepUp.require`). Empty string clears it; omit to keep unchanged.
         #[arg(long)]
         step_up_require: Option<String>,
+        /// Grant approve-authority over ALL contexts.
+        #[arg(long, conflicts_with_all = ["approve_contexts", "approve_none"])]
+        approve_all: bool,
+        /// Replace approve-authority with exactly these contexts.
+        #[arg(long, value_delimiter = ',', conflicts_with = "approve_none")]
+        approve_contexts: Option<Vec<String>>,
+        /// Revoke this entry's approve-authority entirely. An explicit flag,
+        /// because an empty list cannot mean both "confer nothing" and "leave
+        /// unchanged".
+        #[arg(long)]
+        approve_none: bool,
     },
     /// Delete an ACL entry
     Delete {
@@ -1726,7 +1780,11 @@ async fn main() {
             // SEALED CHECK: update and delete modify ACL
             match &command {
                 AclCommands::List { .. } | AclCommands::Get { .. } => {}
-                AclCommands::Update { .. } | AclCommands::Delete { .. } => {
+                AclCommands::Create { .. }
+                | AclCommands::Update { .. }
+                | AclCommands::Delete { .. } => {
+                    // Create modifies the ACL, so it is sealed like the other
+                    // two writes rather than treated as a read.
                     check_seal(&cli.config).await;
                 }
             }
@@ -1735,6 +1793,31 @@ async fn main() {
                     acl_cli::run_acl_list(cli.config, context, role).await
                 }
                 AclCommands::Get { did } => acl_cli::run_acl_get(cli.config, did).await,
+                AclCommands::Create {
+                    did,
+                    role,
+                    label,
+                    contexts,
+                    expires,
+                    step_up_approver,
+                    step_up_require,
+                    approve_all,
+                    approve_contexts,
+                } => {
+                    acl_cli::run_acl_create(
+                        cli.config,
+                        did,
+                        role,
+                        label,
+                        contexts,
+                        expires,
+                        step_up_approver,
+                        step_up_require,
+                        approve_all,
+                        approve_contexts,
+                    )
+                    .await
+                }
                 AclCommands::Update {
                     did,
                     role,
@@ -1742,6 +1825,9 @@ async fn main() {
                     contexts,
                     step_up_approver,
                     step_up_require,
+                    approve_all,
+                    approve_contexts,
+                    approve_none,
                 } => {
                     acl_cli::run_acl_update(
                         cli.config,
@@ -1751,6 +1837,9 @@ async fn main() {
                         contexts,
                         step_up_approver,
                         step_up_require,
+                        approve_all,
+                        approve_contexts,
+                        approve_none,
                     )
                     .await
                 }

--- a/vta-service/src/messaging/handlers.rs
+++ b/vta-service/src/messaging/handlers.rs
@@ -750,6 +750,7 @@ didcomm_handler!(
                 allowed_contexts: body.allowed_contexts,
                 step_up_approver: body.step_up_approver,
                 step_up_require: body.step_up_require,
+                approve_scope: body.approve_scope,
             },
             "didcomm",
         )

--- a/vta-service/src/operations/acl.rs
+++ b/vta-service/src/operations/acl.rs
@@ -28,6 +28,17 @@ pub struct UpdateAclParams {
     /// `Some` sets the per-entry step-up override (empty string clears); `None`
     /// leaves it unchanged.
     pub step_up_require: Option<String>,
+    /// `Some` sets the approve scope to exactly that value; `None` leaves it
+    /// unchanged.
+    ///
+    /// The patch-semantics question this settles: **clear is
+    /// `Some(ApproveScope::None)`, not absence.** Reusing the wire enum rather
+    /// than mirroring create's `approve_all_contexts: bool` +
+    /// `approve_contexts: Vec<String>` pair is what makes that expressible —
+    /// with two independent fields there is no way to distinguish "revoke this
+    /// approver's authority" from "don't touch it", and revoking is the case
+    /// that matters most.
+    pub approve_scope: Option<ApproveScope>,
 }
 
 /// Parse a wire `stepUp.require` value into a [`StepUpMode`]. Only `self` and
@@ -356,6 +367,21 @@ pub async fn update_acl(
         entry.allowed_contexts = allowed_contexts;
     }
 
+    if let Some(scope) = params.approve_scope {
+        // The same grant check `create` applies, unchanged: `All` stays
+        // super-admin-only and a scoped grant still requires the caller to hold
+        // each context. Nothing about reaching this by update rather than by
+        // create relaxes who may confer what.
+        validate_approve_scope_grant(auth, &scope)?;
+        // Contexts named in an approve scope must exist, as on create — a scope
+        // naming a context that was never provisioned confers nothing and reads
+        // as though it does.
+        if let ApproveScope::Contexts(ref cs) = scope {
+            require_contexts_exist(contexts_ks, cs).await?;
+        }
+        entry.approve_scope = scope;
+    }
+
     store_acl_entry(acl_ks, &entry).await?;
 
     info!(channel, did = %did, "ACL entry updated");
@@ -610,6 +636,12 @@ mod tests {
         }
     }
 
+    /// Admin with no context restriction — `is_super_admin` is exactly that
+    /// pair, which is the whole subject of #746.
+    fn super_admin(did: &str) -> AuthClaims {
+        ctx_admin(did, &[])
+    }
+
     async fn seed_target(acl_ks: &KeyspaceHandle, did: &str, contexts: &[&str]) {
         store_acl_entry(
             acl_ks,
@@ -741,6 +773,205 @@ mod tests {
     /// has no admin rights over ctx-B. Pre-fix `update_acl` accepted
     /// this because it only validated the *new* set against caller
     /// scope; the new symmetric-diff check rejects it.
+    /// #744: before this, `approve_scope` was settable only at create time,
+    /// so narrowing or revoking an approver meant delete-and-recreate — and a
+    /// failed recreate leaves the DID with no ACL entry at all.
+    #[tokio::test]
+    async fn update_acl_sets_and_revokes_approve_scope() {
+        let (_store, acl_ks, audit_ks, contexts_ks, _dir) = fresh_store().await;
+        seed_contexts(&contexts_ks, &["ctx-a", "ctx-b"]).await;
+        let target = "did:key:zApprover";
+        seed_target(&acl_ks, target, &["ctx-a"]).await;
+
+        let admin = super_admin("did:key:zRoot");
+        let set = |scope| UpdateAclParams {
+            role: None,
+            label: None,
+            allowed_contexts: None,
+            step_up_approver: None,
+            step_up_require: None,
+            approve_scope: Some(scope),
+        };
+
+        // Narrow: All -> a single context, without touching the entry.
+        update_acl(
+            &acl_ks,
+            &audit_ks,
+            &contexts_ks,
+            &admin,
+            target,
+            set(ApproveScope::All),
+            "test",
+        )
+        .await
+        .expect("super admin may grant approve-all");
+        assert_eq!(
+            get_acl_entry(&acl_ks, target)
+                .await
+                .unwrap()
+                .unwrap()
+                .approve_scope,
+            ApproveScope::All
+        );
+
+        update_acl(
+            &acl_ks,
+            &audit_ks,
+            &contexts_ks,
+            &admin,
+            target,
+            set(ApproveScope::Contexts(vec!["ctx-b".into()])),
+            "test",
+        )
+        .await
+        .expect("narrowing to a scoped grant");
+        assert_eq!(
+            get_acl_entry(&acl_ks, target)
+                .await
+                .unwrap()
+                .unwrap()
+                .approve_scope,
+            ApproveScope::Contexts(vec!["ctx-b".into()])
+        );
+
+        // Revoke — the case that has to be expressible, and is `Some(None)`
+        // rather than absence.
+        update_acl(
+            &acl_ks,
+            &audit_ks,
+            &contexts_ks,
+            &admin,
+            target,
+            set(ApproveScope::None),
+            "test",
+        )
+        .await
+        .expect("revoking confers nothing");
+        assert_eq!(
+            get_acl_entry(&acl_ks, target)
+                .await
+                .unwrap()
+                .unwrap()
+                .approve_scope,
+            ApproveScope::None
+        );
+    }
+
+    /// Omitting the field leaves the existing scope alone — the distinction
+    /// that made a flat bool/list pair unusable for this.
+    #[tokio::test]
+    async fn update_acl_leaves_approve_scope_alone_when_absent() {
+        let (_store, acl_ks, audit_ks, contexts_ks, _dir) = fresh_store().await;
+        seed_contexts(&contexts_ks, &["ctx-a"]).await;
+        let target = "did:key:zApprover";
+        seed_target(&acl_ks, target, &["ctx-a"]).await;
+        let admin = super_admin("did:key:zRoot");
+
+        update_acl(
+            &acl_ks,
+            &audit_ks,
+            &contexts_ks,
+            &admin,
+            target,
+            UpdateAclParams {
+                role: None,
+                label: None,
+                allowed_contexts: None,
+                step_up_approver: None,
+                step_up_require: None,
+                approve_scope: Some(ApproveScope::All),
+            },
+            "test",
+        )
+        .await
+        .unwrap();
+
+        // A label-only edit must not disturb the scope.
+        update_acl(
+            &acl_ks,
+            &audit_ks,
+            &contexts_ks,
+            &admin,
+            target,
+            UpdateAclParams {
+                role: None,
+                label: Some("renamed".into()),
+                allowed_contexts: None,
+                step_up_approver: None,
+                step_up_require: None,
+                approve_scope: None,
+            },
+            "test",
+        )
+        .await
+        .unwrap();
+
+        let entry = get_acl_entry(&acl_ks, target).await.unwrap().unwrap();
+        assert_eq!(entry.label.as_deref(), Some("renamed"));
+        assert_eq!(
+            entry.approve_scope,
+            ApproveScope::All,
+            "scope must survive an unrelated edit"
+        );
+    }
+
+    /// The grant check is the same one `create` applies — reaching it by
+    /// update does not relax who may confer what.
+    #[tokio::test]
+    async fn update_acl_applies_the_same_approve_grant_check_as_create() {
+        let (_store, acl_ks, audit_ks, contexts_ks, _dir) = fresh_store().await;
+        seed_contexts(&contexts_ks, &["ctx-a", "ctx-b"]).await;
+        let target = "did:key:zApprover";
+        seed_target(&acl_ks, target, &["ctx-a"]).await;
+
+        let ctx_admin_a = ctx_admin("did:key:zCallerA", &["ctx-a"]);
+        let err = update_acl(
+            &acl_ks,
+            &audit_ks,
+            &contexts_ks,
+            &ctx_admin_a,
+            target,
+            UpdateAclParams {
+                role: None,
+                label: None,
+                allowed_contexts: None,
+                step_up_approver: None,
+                step_up_require: None,
+                approve_scope: Some(ApproveScope::All),
+            },
+            "test",
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            matches!(err, AppError::Forbidden(_)),
+            "approve-all is super-admin only: {err:?}"
+        );
+
+        let err = update_acl(
+            &acl_ks,
+            &audit_ks,
+            &contexts_ks,
+            &ctx_admin_a,
+            target,
+            UpdateAclParams {
+                role: None,
+                label: None,
+                allowed_contexts: None,
+                step_up_approver: None,
+                step_up_require: None,
+                approve_scope: Some(ApproveScope::Contexts(vec!["ctx-b".into()])),
+            },
+            "test",
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            matches!(err, AppError::Forbidden(_)),
+            "cannot confer a context it lacks: {err:?}"
+        );
+    }
+
     #[tokio::test]
     async fn update_acl_rejects_shrink_across_caller_scope() {
         let (_store, acl_ks, audit_ks, contexts_ks, _dir) = fresh_store().await;
@@ -761,6 +992,7 @@ mod tests {
                 step_up_approver: None,
                 step_up_require: None,
                 allowed_contexts: Some(vec!["ctx-a".into()]),
+                approve_scope: None,
             },
             "test",
         )
@@ -796,6 +1028,7 @@ mod tests {
                 step_up_approver: None,
                 step_up_require: None,
                 allowed_contexts: Some(vec!["ctx-a".into()]),
+                approve_scope: None,
             },
             "test",
         )
@@ -828,6 +1061,7 @@ mod tests {
                 step_up_approver: None,
                 step_up_require: None,
                 allowed_contexts: Some(vec!["ctx-a".into(), "ctx-b".into()]),
+                approve_scope: None,
             },
             "test",
         )
@@ -996,6 +1230,7 @@ mod tests {
                 step_up_approver: None,
                 step_up_require: None,
                 allowed_contexts: Some(vec!["ctx-a".into(), "ctx-ghost".into()]),
+                approve_scope: None,
             },
             "test",
         )

--- a/vta-service/src/routes/acl.rs
+++ b/vta-service/src/routes/acl.rs
@@ -5,7 +5,7 @@ use serde::Deserialize;
 
 use vta_sdk::protocols::acl_management::{create::CreateAclResultBody, list::ListAclResultBody};
 
-use crate::acl::Role;
+use crate::acl::{ApproveScope, Role};
 use crate::auth::{AdminAuth, AuthClaims, ManageAuth};
 use crate::error::AppError;
 use crate::operations;
@@ -139,6 +139,15 @@ pub struct UpdateAclRequest {
     /// string clears; `None` leaves unchanged).
     #[serde(default)]
     pub step_up_require: Option<String>,
+    /// Set the approve scope to exactly this value; omit to leave unchanged.
+    ///
+    /// Clearing is `{"kind":"none"}` — an explicit value, not absence. Unlike
+    /// create, which takes `approve_all_contexts` + `approve_contexts` as two
+    /// independent fields, the update path carries the enum itself: with two
+    /// fields there is no way to distinguish "revoke this approver" from
+    /// "leave it alone", and revoking is the case that matters most.
+    #[serde(default)]
+    pub approve_scope: Option<ApproveScope>,
 }
 
 /// PATCH /acl/{did} — update role, label, or allowed contexts for an ACL entry.
@@ -175,6 +184,7 @@ pub async fn update_acl(
             allowed_contexts: req.allowed_contexts,
             step_up_approver: req.step_up_approver,
             step_up_require: req.step_up_require,
+            approve_scope: req.approve_scope,
         },
         "rest",
     )

--- a/vta-service/src/trust_tasks/acl.rs
+++ b/vta-service/src/trust_tasks/acl.rs
@@ -157,6 +157,7 @@ pub(super) async fn handle_update(
             allowed_contexts: req.allowed_contexts,
             step_up_approver: req.step_up_approver,
             step_up_require: req.step_up_require,
+            approve_scope: req.approve_scope,
         },
         TRANSPORT_TRUST_TASK,
     )

--- a/vti-common/Cargo.toml
+++ b/vti-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-common"
 description = "Shared server-side infrastructure for VTA and VTC services"
 readme = "README.md"
-version = "0.11.13"
+version = "0.11.14"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vti-common/src/acl/mod.rs
+++ b/vti-common/src/acl/mod.rs
@@ -260,52 +260,15 @@ impl DeviceBinding {
     }
 }
 
-/// A DID's authority to **confer** access through an approval — task-consent
-/// delegation (`compute_delegated_contexts`) and delegated step-up ratification
-/// ([`delegated_any_approver_covers`]) — **without** any authority to act.
+/// A DID's authority to **confer** access through an approval, re-exported
+/// from the SDK.
 ///
-/// Read only by those two conferral paths; it never feeds `require_admin` or
-/// `has_context_access`, so an approver can bless a change in a context while
-/// being unable to make one. This is the axis that lets an approver be
-/// least-privilege: `role: Reader`, `allowed_contexts: []` (acts nowhere),
-/// `approve_scope: All` (may authorize anywhere).
-///
-/// Default [`ApproveScope::None`]: an entry confers nothing unless explicitly
-/// granted this — strictly additive and fail-closed. Pre-existing rows omit the
-/// field and deserialise as `None`.
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case", tag = "kind", content = "contexts")]
-pub enum ApproveScope {
-    /// Confers nothing (the default).
-    #[default]
-    None,
-    /// May confer any context — a cross-context authorizer. Granting this is
-    /// super-admin-only (see [`validate_approve_scope_grant`]).
-    All,
-    /// May confer these contexts (and their subtrees), and only these.
-    Contexts(Vec<String>),
-}
-
-impl ApproveScope {
-    /// Whether an approval by a holder of this scope may confer `context_id`.
-    ///
-    /// Segment-aware ancestry, matching [`AuthClaims::has_context_access`], so an
-    /// approver scoped to a parent context covers its whole subtree.
-    pub fn covers(&self, context_id: &str) -> bool {
-        match self {
-            ApproveScope::None => false,
-            ApproveScope::All => true,
-            ApproveScope::Contexts(cs) => cs
-                .iter()
-                .any(|c| crate::context_path::is_ancestor_or_self(c, context_id)),
-        }
-    }
-
-    /// Whether this scope confers nothing.
-    pub fn confers_nothing(&self) -> bool {
-        matches!(self, ApproveScope::None)
-    }
-}
+/// The type lives in `vta-sdk` because the DIDComm and Trust Task update
+/// bodies carry it and must be constructible by clients that never link the
+/// server crates. Only the *shape* is shared — every authorization rule over
+/// it ([`validate_approve_scope_grant`] below) stays here. Same arrangement as
+/// [`crate::context_path`].
+pub use vta_sdk::acl::ApproveScope;
 
 /// Validate that `caller` may grant `scope` on an ACL entry.
 ///


### PR DESCRIPTION
Closes #744 and #745. They're one piece of work: without both, there is no offline route to an approver entry at all.

## #744 — `approve_scope` was create-only on every surface

REST, DIDComm, `pnm`, and the offline `vta` CLI all set it at create time; none could change it. The delete-and-recreate workaround is worse than it looks for exactly the entries this field exists on:

- `ApproveScope::All` is super-admin-only to grant — so a non-super-admin operator whose recreate is refused has **already landed the delete**, and the DID is left with no ACL entry at all.
- There's a window where the DID confers nothing; an approver wired into a `min_approvals` threshold silently stops being a conferrer.
- Over DIDComm an `Ok` means accepted-locally, not applied (R1.1), so a timed-out delete leaves the operator unable to tell whether to recreate.
- It discards `created_at` / `created_by`.

All four update paths now carry the field. The grant check is the one `create` already applies — `validate_approve_scope_grant` unchanged — so `All` stays super-admin-only and a scoped grant still requires the caller to hold each context. Reaching it by update relaxes nothing; there's a test pinning that.

### The patch-semantics question, settled

**Clearing is `Some(ApproveScope::None)` — an explicit value, not absence.**

The update bodies carry the enum rather than mirroring create's `approve_all_contexts: bool` + `approve_contexts: Vec<String>` pair, because two independent fields cannot distinguish *"revoke this approver's authority"* from *"leave it alone"* — and revoking is the case that matters most. On the CLIs that's an explicit `--approve-none` flag, for the same reason an empty `--contexts` was the wrong spelling in #747: an empty list can't mean both "confer nothing" and "don't touch it".

### Why `ApproveScope` moved to `vta-sdk`

The DIDComm `UpdateAclBody` lives in `vta-sdk`, which cannot reference `vti-common` — the dependency runs the other way. So the type moves to `vta_sdk::acl` and `vti-common` re-exports it, the arrangement already used for `context_path`. Only the *shape* moves; every authorization rule over it stays in `vti-common`. The wire shape is unchanged and now pinned by a round-trip test — stored ACL rows carry it, so a change would silently reinterpret existing entries.

## #745 — the offline CLI had no `create`

`vta acl` had `list`/`get`/`update`/`delete`. The only offline entry-minting path, `vta import-did`, hardcodes an admin role with empty contexts behind the bootstrap seal — it can't mint a reader entry or set an approve scope. Combined with update being unable to change `approve_scope`, that left **no offline route to an approver entry at all**, on the surface that exists precisely for when the daemon is unreachable.

`vta acl create` mirrors `pnm acl create`'s flags. Authorization follows the documented break-glass convention the offline `update` already uses: the validators are **not** consulted, because this surface has no authenticated caller — it's direct store access by whoever holds the filesystem. The help text says so, so the absent super-admin check doesn't read as an oversight.

Context-id *shape* validation does still apply — that isn't an authorization check. After #747 a malformed id is unstorable through every other path, and the break-glass surface shouldn't be the one that plants one in the store.

## Verification

`cargo test -p vti-common -p vta-cli-common -p vta-service -p vta-sdk --lib` — 1774 passed, 0 failed. Clippy `--workspace --all-targets` and fmt clean. Three new tests cover set/narrow/revoke, leave-unchanged-when-absent, and the grant check.

## Coordination

A parallel workstream is adding an `ActScope` type (the read-side counterpart to `ApproveScope`, computed from `role` + `allowed_contexts`) plus a fix for a scope gate in `vault.rs`. **`ActScope` should land in `vta-sdk/src/acl.rs` beside `ApproveScope`** — this PR is what puts `ApproveScope` there, so it should merge first.

Signed-off-by: Glenn Gore <glenn.g@affinidi.com>
