### PR TITLE
fix(acl): make `acl list --context` answer the same way on both surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 ## Unreleased
 
+### vti-common 0.11.15 / vta-service 0.12.19 — make `acl list --context` answer the same way on both surfaces
+
+* The two implementations of the context filter disagreed on exactly one input
+  class, and disagreed totally. Offline (`vta acl list --context`) matched
+  `allowed_contexts.is_empty() || contains(ctx)`, so an **empty list matched
+  every context**. Online (`operations::acl::list_acl`) matched
+  `contains(ctx)`, so an **empty list matched none**. Same command, opposite
+  answers.
+
+* Neither was right. An empty list means unrestricted for `Role::Admin` and
+  *nothing at all* for every other role, so the correct filter includes
+  super-admins (offline had them, online silently dropped them — an operator
+  auditing "who can reach context X" never saw the entries with the most
+  authority over it) and excludes acts-nowhere entries (online had this right,
+  offline listed them under every context).
+
+* Both also compared with `contains`, missing entries scoped to an *ancestor*
+  of the queried context, which do grant it. The VTC's equivalent filter has
+  been hierarchy-aware all along; the VTA's now matches.
+
+* One `acl_entry_can_act_in` predicate in `vti-common` now backs both call
+  sites, so they cannot drift again.
+
+### vta-service 0.12.17 — fix a vault scope gate that ignored the caller's role
 ### vta-service 0.12.18 — fix a vault scope gate that ignored the caller's role
 
 * **Security.** `enforce_context_scope`, the gate on every vault trust task,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10202,7 +10202,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.12.18"
+version = "0.12.19"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",
@@ -10391,7 +10391,7 @@ dependencies = [
 
 [[package]]
 name = "vti-common"
-version = "0.11.14"
+version = "0.11.15"
 dependencies = [
  "aes-gcm",
  "affinidi-data-integrity",

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.12.18"
+version = "0.12.19"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/acl_cli.rs
+++ b/vta-service/src/acl_cli.rs
@@ -1,6 +1,6 @@
 use crate::acl::{
-    AclEntry, ApproveScope, Role, delete_acl_entry, get_acl_entry, list_acl_entries,
-    store_acl_entry,
+    AclEntry, ApproveScope, Role, acl_entry_can_act_in, delete_acl_entry, get_acl_entry,
+    list_acl_entries, store_acl_entry,
 };
 use crate::config::AppConfig;
 use crate::store::Store;
@@ -134,7 +134,10 @@ pub async fn run_acl_list(
         entries.retain(|e| &e.role == role);
     }
     if let Some(ref ctx) = context {
-        entries.retain(|e| e.allowed_contexts.is_empty() || e.allowed_contexts.contains(ctx));
+        // Shared with the online `list_acl` so the two surfaces cannot answer
+        // the same question differently. The previous `is_empty() ||
+        // contains()` matched an *acts-nowhere* entry under every context.
+        entries.retain(|e| acl_entry_can_act_in(e, ctx));
     }
 
     if entries.is_empty() {

--- a/vta-service/src/operations/acl.rs
+++ b/vta-service/src/operations/acl.rs
@@ -8,9 +8,9 @@ use vta_sdk::protocols::acl_management::{
 };
 
 use crate::acl::{
-    AclEntry, ApproveScope, Role, delete_acl_entry, get_acl_entry, is_acl_entry_visible,
-    list_acl_entries, store_acl_entry, validate_acl_modification, validate_approve_scope_grant,
-    validate_role_assignment,
+    AclEntry, ApproveScope, Role, acl_entry_can_act_in, delete_acl_entry, get_acl_entry,
+    is_acl_entry_visible, list_acl_entries, store_acl_entry, validate_acl_modification,
+    validate_approve_scope_grant, validate_role_assignment,
 };
 use crate::auth::AuthClaims;
 use crate::auth::session::now_epoch;
@@ -267,8 +267,13 @@ pub async fn list_acl(
     let entries: Vec<CreateAclResultBody> = all_entries
         .iter()
         .filter(|e| is_acl_entry_visible(auth, e))
+        // Shared with the offline `vta acl list` so the two surfaces cannot
+        // answer the same question differently. The previous `contains()`
+        // omitted super-admin entries, which do hold every context — an
+        // operator auditing "who can reach context X" never saw them — and
+        // missed entries scoped to an ancestor of X.
         .filter(|e| match context_filter {
-            Some(ctx) => e.allowed_contexts.contains(&ctx.to_string()),
+            Some(ctx) => acl_entry_can_act_in(e, ctx),
             None => true,
         })
         .map(to_result_body)

--- a/vti-common/Cargo.toml
+++ b/vti-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-common"
 description = "Shared server-side infrastructure for VTA and VTC services"
 readme = "README.md"
-version = "0.11.14"
+version = "0.11.15"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vti-common/src/acl/mod.rs
+++ b/vti-common/src/acl/mod.rs
@@ -762,6 +762,32 @@ pub fn delegated_any_approver_covers(approver: &AclEntry, subject: &AclEntry) ->
             .all(|c| approver.allowed_contexts.contains(c))
 }
 
+/// Whether `entry` holds authority to act in `context_id` — the predicate
+/// behind every "which entries are relevant to this context?" filter.
+///
+/// One function because the two `acl list --context` implementations answered
+/// this differently, and both were wrong in a different direction. The offline
+/// CLI matched `allowed_contexts.is_empty() || contains(ctx)`, so an
+/// **empty list matched every context**; the online operation matched
+/// `contains(ctx)`, so an **empty list matched none**. Same command, opposite
+/// answers, and neither is the truth: an empty list means unrestricted for
+/// [`Role::Admin`] (a super-admin does hold every context) and *nothing at all*
+/// for every other role (which therefore holds none).
+///
+/// Ancestry is segment-aware, matching [`AuthClaims::has_context_access`] and
+/// the VTC's equivalent filter: an entry scoped to a parent context does grant
+/// its subtree, so it genuinely carries a child id. Both VTA filters compared
+/// with `contains`, so neither surfaced it.
+pub fn acl_entry_can_act_in(entry: &AclEntry, context_id: &str) -> bool {
+    if entry.is_super_admin() {
+        return true;
+    }
+    entry
+        .allowed_contexts
+        .iter()
+        .any(|allowed| crate::context_path::is_ancestor_or_self(allowed, context_id))
+}
+
 /// Check whether an ACL entry is visible to the caller.
 ///
 /// Super admins see all entries. Context admins only see entries whose
@@ -1349,6 +1375,65 @@ mod tests {
         let err = validate_acl_modification(&caller, &["ctx1".into(), "ctx3".into()])
             .expect_err("mixed own+foreign must be rejected");
         assert!(matches!(err, AppError::Forbidden(_)), "got {err:?}");
+    }
+
+    // ── acl_entry_can_act_in ────────────────────────────────────────
+
+    /// A super-admin holds every context, so a context filter must surface it.
+    /// The online `list_acl` used a bare `contains()` and omitted these — an
+    /// operator auditing "who can reach context X" never saw the entries with
+    /// the most authority over it.
+    #[test]
+    fn can_act_in_includes_super_admins() {
+        let super_admin = sample_entry("did:key:zSuper", Role::Admin);
+        assert!(acl_entry_can_act_in(&super_admin, "anything"));
+    }
+
+    /// An acts-nowhere entry holds none. The offline `vta acl list` matched
+    /// `is_empty() || contains()` and surfaced these under *every* context.
+    #[test]
+    fn can_act_in_excludes_acts_nowhere_entries() {
+        for role in [Role::Reader, Role::Application, Role::Initiator] {
+            let entry = sample_entry("did:key:zNowhere", role.clone());
+            assert!(
+                !acl_entry_can_act_in(&entry, "anything"),
+                "{role:?} with no contexts acts nowhere"
+            );
+        }
+    }
+
+    /// Hierarchy-aware, matching `has_context_access` and the VTC's filter.
+    /// Both VTA filters used `contains`, so neither surfaced a parent-scoped
+    /// entry under a child id.
+    #[test]
+    fn can_act_in_covers_the_subtree() {
+        let entry = scoped_entry("did:key:zParent", Role::Reader, &["parent"]);
+        assert!(acl_entry_can_act_in(&entry, "parent"), "self");
+        assert!(acl_entry_can_act_in(&entry, "parent/child"), "subtree");
+        assert!(!acl_entry_can_act_in(&entry, "other"), "unrelated");
+        assert!(
+            !acl_entry_can_act_in(&entry, "parentless"),
+            "a string prefix is not an ancestor"
+        );
+    }
+
+    /// The two implementations this replaces disagreed on exactly one input
+    /// class — an empty `allowed_contexts` — and the disagreement was total:
+    /// one matched every context, the other none. Pin both halves together so
+    /// a future edit cannot reintroduce either reading.
+    #[test]
+    fn can_act_in_resolves_the_offline_online_disagreement() {
+        let ctx = "openvtc";
+        // Offline said yes to this, online said no. Correct answer: yes.
+        assert!(acl_entry_can_act_in(
+            &sample_entry("did:key:zA", Role::Admin),
+            ctx
+        ));
+        // Offline said yes to this, online said no. Correct answer: no.
+        assert!(!acl_entry_can_act_in(
+            &sample_entry("did:key:zB", Role::Reader),
+            ctx
+        ));
     }
 
     // ── is_acl_entry_visible ────────────────────────────────────────


### PR DESCRIPTION
> Stacked on #769 — review that first. Base will retarget to `main` once it merges.

## The divergence

The two implementations of the context filter disagreed on exactly one input class, and disagreed totally.

| | offline `vta acl list --context` | online `list_acl` |
|---|---|---|
| filter | `allowed_contexts.is_empty() \|\| contains(ctx)` | `contains(ctx)` |
| empty list | matches **every** context | matches **none** |

Same command, opposite answers.

## Neither was right

An empty `allowed_contexts` means unrestricted for `Role::Admin` and *nothing at all* for every other role, so the correct filter is neither of the above:

| entry | offline | online | correct |
|---|---|---|---|
| `admin`, no contexts (super-admin) | matched | **missed** | match — holds every context |
| `reader`, no contexts (acts nowhere) | **matched** | missed | no match — holds none |
| scoped to `parent`, filter `parent/child` | **missed** | **missed** | match — ancestry grants the subtree |

The online miss is the one with audit consequences: an operator asking "who can reach context X" was never shown the super-admin rows, which are exactly the entries with the most authority over X.

The ancestry gap is a third defect both shared — they compared with `contains`, so an entry scoped to an ancestor of the queried context never surfaced, even though it does grant it. The VTC's equivalent filter has been hierarchy-aware all along (`is_ancestor_or_self`, per `docs/05-design-notes/hierarchical-contexts.md`); the VTA was the outlier.

## The fix

One `acl_entry_can_act_in(entry, context_id)` predicate in `vti-common`, used by both call sites, so they cannot drift again.

Visibility is unaffected — `is_acl_entry_visible` still runs first on the online path, so this changes which of the entries a caller is *entitled* to see are shown under a filter, not which entries they may see at all.

## Tests

Four cases in `vti-common`: super-admins included, acts-nowhere entries excluded, subtree covered (with `parentless` pinning that a string prefix is not an ancestor), and one that pins both halves of the old disagreement together so neither reading can come back.

`cargo test -p vti-common -p vta-service`: **1583 passed, 0 failed**. Clippy and fmt clean.

## Follow-up

`acl_entry_can_act_in` is deliberately shaped to be absorbed by the `ActScope` work: its body becomes `entry.act_scope().covers(context_id)` and neither call site moves.