### PR TITLE
refactor(acl): decode an entry's authority to act in one place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 ## Unreleased
 
+### vta-sdk 0.19.25 / vti-common 0.11.16 / vta-cli-common 0.10.11 / vta-service 0.12.20 — decode an ACL entry's authority to act in one place
+
+* **`allowed_contexts` means opposite things depending on the role** —
+  unrestricted for `Role::Admin`, *nothing at all* for every other role — and
+  call sites kept reading it without the role. That produced a display calling
+  a least-privilege approver "unrestricted" (#746), two `acl list --context`
+  filters that disagreed with each other and with the truth (#770), and a vault
+  scope gate that handed an authorized-nowhere entry credential-vault reads in
+  every context (#769). Three bugs, one cause: the decode was open-coded at
+  every call site.
+
+* **`ActScope`** (`None` / `All` / `Contexts`) is now that decode, done once.
+  It sits in `vta-sdk/src/acl.rs` beside `ApproveScope`, with deliberately
+  identical variants, an identical `covers()`, and the same fail-closed
+  default — so "what may this DID do" and "what may it confer" read as one
+  model rather than an enum and a convention.
+
+* **Nothing is stored or sent in the new shape.** Unlike `ApproveScope`, the
+  act axis stays `(role, allowed_contexts)` on disk and on the wire;
+  `ActScope` is computed on read via `vti_common::acl::act_scope_for`, reached
+  through `AclEntry::act_scope()` / `AuthClaims::act_scope()`. No migration, no
+  wire change, existing rows untouched. The decode lives server-side because it
+  needs `Role`, which `vta-sdk` cannot see — the same shape/policy split #768
+  used for `ApproveScope`.
+
+* `is_super_admin`, `has_context_access`, `can_act_in`, `is_acl_entry_visible`,
+  `acl_entry_can_act_in`, `delegated_any_approver_covers` and both ACL displays
+  now route through it. Behaviour is unchanged throughout — including two
+  conflations preserved deliberately and flagged in place, since removing
+  either is an authorization change rather than a structural one.
+
+* `docs/05-design-notes/acl-scope-semantics.md` documents the model and what
+  remains; CLAUDE.md gains the workspace rule.
+
 ### vti-common 0.11.15 / vta-service 0.12.19 — make `acl list --context` answer the same way on both surfaces
 
 * The two implementations of the context filter disagreed on exactly one input

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -682,6 +682,18 @@ new flow, update both this section and the relevant `docs/*.md`.
 
 These are load-bearing — know they exist before adjusting nearby code.
 
+- **Never test `allowed_contexts.is_empty()`.** An empty context list on
+  an ACL entry means *unrestricted* for `Role::Admin` and *authorized
+  nowhere* for every other role, so any check that omits the role gets
+  one of the two backwards. That has already produced a display calling
+  a least-privilege approver "unrestricted" (#746), two `acl list
+  --context` filters that disagreed (#770), and a vault scope gate that
+  handed an authorized-nowhere entry cross-context credential reads
+  (#769). Go through `AclEntry::act_scope()` / `AuthClaims::act_scope()`
+  — or `has_context_access` / `can_act_in` / `is_super_admin`, which are
+  built on them — and match on the `ActScope`. Same shape as the
+  `ApproveScope` axis beside it in `vta-sdk/src/acl.rs`: act vs confer.
+  See `docs/05-design-notes/acl-scope-semantics.md`.
 - **Rate limit** on all unauth routes: `tower-governor` at 5 rps + 10
   burst per source IP (`vta-service/src/routes/mod.rs`). Keep JWT-gated
   routes off the limiter — auth is the gate.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10063,7 +10063,7 @@ dependencies = [
 
 [[package]]
 name = "vta-cli-common"
-version = "0.10.10"
+version = "0.10.11"
 dependencies = [
  "aes-gcm",
  "affinidi-crypto",
@@ -10142,7 +10142,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.19.24"
+version = "0.19.25"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10202,7 +10202,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.12.19"
+version = "0.12.20"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",
@@ -10391,7 +10391,7 @@ dependencies = [
 
 [[package]]
 name = "vti-common"
-version = "0.11.15"
+version = "0.11.16"
 dependencies = [
  "aes-gcm",
  "affinidi-data-integrity",

--- a/docs/05-design-notes/acl-scope-semantics.md
+++ b/docs/05-design-notes/acl-scope-semantics.md
@@ -1,0 +1,111 @@
+# ACL scope semantics — the two axes
+
+**Status:** implemented for the VTA. The VTC's parallel ACL surface still
+decodes by hand — see [Remaining work](#remaining-work).
+
+An ACL entry answers two independent questions, and they must never be
+conflated:
+
+| Axis | Question | Type |
+|---|---|---|
+| **Act** | In which contexts may this DID *make* a change? | `ActScope` |
+| **Approve** | In which contexts may this DID *bless* someone else's change? | `ApproveScope` |
+
+Both live in `vta-sdk/src/acl.rs`, are three-valued, and share the same
+variants, the same `covers()` predicate (segment-aware, so authority over a
+parent context covers its subtree), and the same fail-closed default:
+
+```rust
+enum ActScope     { None, All, Contexts(Vec<String>) }   // default None
+enum ApproveScope { None, All, Contexts(Vec<String>) }   // default None
+```
+
+An entry can hold either axis without the other. A **least-privilege approver**
+is the shape that motivates the split: acts nowhere (`ActScope::None`), confers
+via `ApproveScope::All` or `ApproveScope::Contexts([...])`. It carries authority
+to authorize and none to act.
+
+## The asymmetry: one is stored, one is computed
+
+`ApproveScope` is a real serialized field with a pinned wire shape.
+
+`ActScope` is **not stored and not sent**. The act axis is stored as
+`(role, allowed_contexts)`, and `ActScope` is computed from that pair on read:
+
+| `role` | `allowed_contexts` | `ActScope` |
+|---|---|---|
+| `Admin` | `[]` | `All` — this is how a super-admin is spelled |
+| any other | `[]` | `None` — authorized nowhere |
+| any | non-empty | `Contexts([...])` |
+
+That decode is `vti_common::acl::act_scope_for`, reached in practice via
+`AclEntry::act_scope()` / `AuthClaims::act_scope()`. Storage, JWT claims, and
+every wire body are unchanged — this is a read-path abstraction, not a
+migration.
+
+The type and its `covers()` predicate live in `vta-sdk` beside `ApproveScope`,
+so the two axes read as one model. The *decode* stays in `vti-common` because
+it needs `Role`, which the SDK cannot see. Shape and predicate are shared;
+authorization policy over them is server-side. Same split #768 used for
+`ApproveScope` and `validate_approve_scope_grant`.
+
+## The rule
+
+**Never test `allowed_contexts.is_empty()` at a call site.** It is only
+meaningful paired with the role, and every place that forgot the pairing has
+been a bug:
+
+- an ACL display that rendered a least-privilege approver as `(unrestricted)`,
+  on a screen operators audit grants with (#746, fixed in #764);
+- two `acl list --context` filters that disagreed on whether an empty list
+  matches every context or none — and neither was right, since both also
+  ignored ancestry (#770);
+- a vault trust-task scope gate that read any empty list as super-admin scope,
+  granting an authorized-nowhere entry credential-vault access in **every**
+  context. `Role::Reader` derives `Capability::VaultRead`, so the
+  least-privilege approver shape reached it; `Role::Initiator` derives
+  `VaultWrite`, so it reached the write path too (#769).
+
+Go through `act_scope()` — or `has_context_access` / `can_act_in` /
+`is_super_admin`, which are built on it — and match on the result.
+
+## What this does *not* change
+
+Two conflations are preserved deliberately, because removing either is a
+change in authorization rather than in structure:
+
+1. **`validate_acl_modification` still refuses an empty target to any
+   non-super-admin.** It receives `target_contexts` without a role, so it
+   cannot distinguish "grant nothing" (`None`) from "grant everything"
+   (`All`) — and refuses both. The consequence is that only a super-admin can
+   create a least-privilege approver, which is the very shape the CLI
+   recommends.
+
+2. **The admin path in `delegated_any_approver_covers` matches contexts with
+   exact membership, not `covers()`.** The approve-scope path in the same
+   function is ancestry-aware, so a context admin's conferral is narrower than
+   an equivalent explicit `ApproveScope` grant. Probably an oversight, but
+   widening it changes who may ratify a step-up.
+
+Both are flagged where they occur.
+
+## Remaining work
+
+- **The two widenings above**, each as its own reviewed change.
+- **A read/manage split.** `is_acl_entry_visible` gates *both* the list/get
+  reads and the update/delete mutations. Because it follows only the act axis,
+  a least-privilege approver is invisible to the very context admins whose
+  contexts it can confer — an admin cannot audit who may authorize a change in
+  their own context. The fix is a second, read-only predicate that also follows
+  the approve axis; it must **not** be a wider `is_acl_entry_visible`, because
+  an entry can administer someone else's context while conferring into yours,
+  and folding the two would make that entry deletable by you.
+- **The VTC.** `vtc-service` has a parallel ACL surface with the same idiom
+  (`routes/acl.rs`, `acl_cli.rs`). It needs its own `act_scope()` accessor
+  because `VtcAclEntry` is a distinct type with its own role enum, mapped via
+  `as_vti_role`. Until then the two services can still drift on what an empty
+  scope set means.
+- **`reader + All`** ("may read every context, admin nowhere") is expressible
+  in the type but unreachable through the decode table, since `All` requires
+  `Role::Admin`. If it is ever wanted it needs a stored representation — i.e.
+  the migration this design deliberately avoided.

--- a/vta-cli-common/Cargo.toml
+++ b/vta-cli-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-cli-common"
 description = "Shared CLI command handlers and rendering helpers for VTA CLIs"
 readme = "README.md"
-version = "0.10.10"
+version = "0.10.11"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-cli-common/src/commands/acl.rs
+++ b/vta-cli-common/src/commands/acl.rs
@@ -5,6 +5,7 @@ use ratatui::{
 };
 use vta_sdk::acl::ApproveScope;
 use vta_sdk::prelude::*;
+use vti_common::acl::{Role, act_scope_for};
 
 use crate::render::{is_full_display, print_full_entry, print_full_list_title, print_widget};
 
@@ -21,16 +22,14 @@ use crate::render::{is_full_display, print_full_entry, print_full_list_title, pr
 /// looked like a blanket grant, and an operator auditing for over-broad
 /// access saw `(unrestricted)` on rows that were in fact inert.
 pub fn format_contexts(role: &str, contexts: &[String]) -> String {
-    if !contexts.is_empty() {
-        return contexts.join(", ");
-    }
-    if role == "admin" {
-        // `format_role` already renders this entry's role as "super admin",
-        // so the two columns read together without repeating the term.
-        "(unrestricted)".to_string()
-    } else {
-        "(none — acts nowhere)".to_string()
-    }
+    // The wire form carries the role as a string, so parse it back before
+    // decoding. An unrecognised role falls to the most restrictive reading:
+    // a display must never invent authority it cannot confirm.
+    //
+    // `format_role` already renders an unrestricted admin as "super admin", so
+    // the two columns read together without repeating the term.
+    let role = Role::parse(role).unwrap_or(Role::Monitor);
+    act_scope_for(&role, contexts).to_string()
 }
 
 pub fn format_role(role: &str, contexts: &[String]) -> String {

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.19.24"
+version = "0.19.25"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/acl.rs
+++ b/vta-sdk/src/acl.rs
@@ -12,6 +12,96 @@
 
 use serde::{Deserialize, Serialize};
 
+/// A DID's authority to **act** — the contexts in which it may make a change.
+/// The sibling axis to [`ApproveScope`], with deliberately identical variants,
+/// an identical [`covers`](ActScope::covers) predicate, and the same
+/// fail-closed [`None`](ActScope::None) default.
+///
+/// # Why this exists
+///
+/// Unlike [`ApproveScope`], this is **not** a stored or wire field. The act
+/// axis is stored as `(role, allowed_contexts)`, where an **empty**
+/// `allowed_contexts` means opposite things depending on the role: unrestricted
+/// for an admin (that *is* how a super-admin is spelled), and *nothing at all*
+/// for every other role. Reading the raw field without the role is therefore a
+/// bug, and has repeatedly been one — a display that called a least-privilege
+/// approver `(unrestricted)`, two `acl list --context` filters that disagreed
+/// on whether an empty list matches every context or none, and a vault scope
+/// gate that granted cross-context reads to an entry authorized nowhere.
+///
+/// This type makes the three cases distinguishable so that decode happens in
+/// one place instead of at every call site. The decode itself is server-side
+/// (`vti_common::acl::act_scope_for`), because it needs `Role`; only the shape
+/// and the predicate are shared, exactly as for [`ApproveScope`].
+///
+/// It lives beside [`ApproveScope`] so the two axes — what a DID may *do* and
+/// what it may *confer* — read as one model rather than an enum and a
+/// convention.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum ActScope {
+    /// Authorized in no context at all (the fail-closed default). The shape of
+    /// a least-privilege approver: acts nowhere, may still confer via its
+    /// [`ApproveScope`].
+    #[default]
+    None,
+    /// Authorized in every context. Combined with the admin role this is a
+    /// super-admin.
+    All,
+    /// Authorized in these contexts and their subtrees, and only these.
+    Contexts(Vec<String>),
+}
+
+impl ActScope {
+    /// Whether a holder of this scope may act in `context_id`.
+    ///
+    /// Segment-aware ancestry, identical to [`ApproveScope::covers`], so
+    /// authority over a parent context covers its whole subtree.
+    pub fn covers(&self, context_id: &str) -> bool {
+        match self {
+            ActScope::None => false,
+            ActScope::All => true,
+            ActScope::Contexts(cs) => cs
+                .iter()
+                .any(|c| crate::context_path::is_ancestor_or_self(c, context_id)),
+        }
+    }
+
+    /// Whether this scope authorizes every context (the super-admin condition
+    /// when paired with the admin role).
+    pub fn is_unrestricted(&self) -> bool {
+        matches!(self, ActScope::All)
+    }
+
+    /// Whether this scope authorizes nothing.
+    pub fn acts_nowhere(&self) -> bool {
+        matches!(self, ActScope::None)
+    }
+
+    /// The contexts named by this scope, or an empty slice for
+    /// [`None`](ActScope::None) / [`All`](ActScope::All) — neither of which is
+    /// expressible as a list.
+    pub fn named_contexts(&self) -> &[String] {
+        match self {
+            ActScope::Contexts(cs) => cs,
+            _ => &[],
+        }
+    }
+}
+
+impl std::fmt::Display for ActScope {
+    /// Operator-facing rendering. The unrestricted and acts-nowhere cases are
+    /// spelled out rather than both collapsing to `(unrestricted)`, which is
+    /// what made them indistinguishable on ACL displays. The wording matches
+    /// what `vta-cli-common`'s `format_contexts` already prints.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ActScope::None => f.write_str("(none — acts nowhere)"),
+            ActScope::All => f.write_str("(unrestricted)"),
+            ActScope::Contexts(cs) => f.write_str(&cs.join(", ")),
+        }
+    }
+}
+
 /// A DID's authority to **confer** access through an approval — task-consent
 /// delegation (`compute_delegated_contexts`) and delegated step-up ratification
 /// (`delegated_any_approver_covers`) — **without** any authority to act.
@@ -92,6 +182,53 @@ mod tests {
     fn absent_defaults_to_conferring_nothing() {
         assert_eq!(ApproveScope::default(), ApproveScope::None);
         assert!(ApproveScope::default().confers_nothing());
+    }
+
+    /// The two axes must agree on what a scope covers — same predicate, same
+    /// answers — or "act" and "confer" stop being comparable.
+    #[test]
+    fn act_and_approve_agree_on_coverage() {
+        for ctx in ["acme", "acme/eng", "acme-corp", "other"] {
+            assert_eq!(
+                ActScope::Contexts(vec!["acme".into()]).covers(ctx),
+                ApproveScope::Contexts(vec!["acme".into()]).covers(ctx),
+                "disagreement on {ctx}"
+            );
+        }
+        assert_eq!(ActScope::All.covers("x"), ApproveScope::All.covers("x"));
+        assert_eq!(ActScope::None.covers("x"), ApproveScope::None.covers("x"));
+    }
+
+    /// Fail-closed: an unset act scope authorizes nothing, matching
+    /// `ApproveScope`'s default.
+    #[test]
+    fn act_scope_defaults_to_nothing() {
+        assert_eq!(ActScope::default(), ActScope::None);
+        assert!(ActScope::default().acts_nowhere());
+        assert!(!ActScope::default().is_unrestricted());
+    }
+
+    /// The display defect this type closes: both empty cases rendered
+    /// `(unrestricted)`, so an acts-nowhere entry read as blanket access.
+    #[test]
+    fn display_distinguishes_nothing_from_everything() {
+        assert_eq!(ActScope::All.to_string(), "(unrestricted)");
+        assert_eq!(ActScope::None.to_string(), "(none — acts nowhere)");
+        assert_ne!(ActScope::None.to_string(), ActScope::All.to_string());
+        assert_eq!(
+            ActScope::Contexts(vec!["a".into(), "b".into()]).to_string(),
+            "a, b"
+        );
+    }
+
+    #[test]
+    fn named_contexts_is_empty_for_the_unlistable_variants() {
+        assert!(ActScope::All.named_contexts().is_empty());
+        assert!(ActScope::None.named_contexts().is_empty());
+        assert_eq!(
+            ActScope::Contexts(vec!["a".into()]).named_contexts(),
+            ["a".to_string()]
+        );
     }
 
     #[test]

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.12.19"
+version = "0.12.20"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/acl_cli.rs
+++ b/vta-service/src/acl_cli.rs
@@ -320,18 +320,11 @@ fn print_entry_details(entry: &AclEntry) {
 /// Rendering both as `(unrestricted)` said the opposite of the truth for every
 /// non-admin entry.
 fn format_contexts(entry: &AclEntry) -> String {
-    if !entry.allowed_contexts.is_empty() {
-        return entry.allowed_contexts.join(", ");
-    }
-    if entry.role == Role::Admin {
-        "(unrestricted)".into()
-    } else {
-        "(none — acts nowhere)".into()
-    }
+    entry.act_scope().to_string()
 }
 
 fn format_role(entry: &AclEntry) -> String {
-    if entry.role == Role::Admin && entry.allowed_contexts.is_empty() {
+    if entry.is_super_admin() {
         "admin (super admin)".into()
     } else {
         entry.role.to_string()

--- a/vta-service/src/main.rs
+++ b/vta-service/src/main.rs
@@ -2249,10 +2249,7 @@ async fn run_bootstrap_admin(
 
     // Check no existing super admins
     let entries = acl::list_acl_entries(&acl_ks).await?;
-    let existing_super_admins: Vec<_> = entries
-        .iter()
-        .filter(|e| e.role == acl::Role::Admin && e.allowed_contexts.is_empty())
-        .collect();
+    let existing_super_admins: Vec<_> = entries.iter().filter(|e| e.is_super_admin()).collect();
 
     if !existing_super_admins.is_empty() {
         eprintln!(

--- a/vta-service/src/seal.rs
+++ b/vta-service/src/seal.rs
@@ -31,7 +31,9 @@ use ed25519_dalek::{Signature, Verifier, VerifyingKey};
 use serde::{Deserialize, Serialize};
 use tracing::info;
 
-use crate::acl::{self, Role};
+#[cfg(test)]
+use crate::acl::Role;
+use crate::acl::{self};
 use crate::config::StoreConfig;
 use crate::error::AppError;
 use crate::store::{KeyspaceHandle, Store};
@@ -127,10 +129,8 @@ pub(crate) async fn read_unseal_state(
         .ok_or_else(|| AppError::Config("VTA is not sealed — nothing to unseal".into()))?;
 
     let entries = acl::list_acl_entries(&acl_ks).await?;
-    let super_admins: Vec<acl::AclEntry> = entries
-        .into_iter()
-        .filter(|e| e.role == Role::Admin && e.allowed_contexts.is_empty())
-        .collect();
+    let super_admins: Vec<acl::AclEntry> =
+        entries.into_iter().filter(|e| e.is_super_admin()).collect();
 
     if super_admins.is_empty() {
         return Err(AppError::Config(

--- a/vta-service/src/setup/from_toml.rs
+++ b/vta-service/src/setup/from_toml.rs
@@ -1528,10 +1528,7 @@ async fn seed_initial_admin(
     }
 
     let entries = acl::list_acl_entries(&acl_ks).await?;
-    let existing_super_admins: Vec<_> = entries
-        .iter()
-        .filter(|e| e.role == acl::Role::Admin && e.allowed_contexts.is_empty())
-        .collect();
+    let existing_super_admins: Vec<_> = entries.iter().filter(|e| e.is_super_admin()).collect();
     if !existing_super_admins.is_empty() {
         return Err(format!(
             "found {} existing super admin(s); refusing to seed another during setup",

--- a/vti-common/Cargo.toml
+++ b/vti-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-common"
 description = "Shared server-side infrastructure for VTA and VTC services"
 readme = "README.md"
-version = "0.11.15"
+version = "0.11.16"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vti-common/src/acl/mod.rs
+++ b/vti-common/src/acl/mod.rs
@@ -268,7 +268,33 @@ impl DeviceBinding {
 /// server crates. Only the *shape* is shared — every authorization rule over
 /// it ([`validate_approve_scope_grant`] below) stays here. Same arrangement as
 /// [`crate::context_path`].
-pub use vta_sdk::acl::ApproveScope;
+pub use vta_sdk::acl::{ActScope, ApproveScope};
+
+/// Decode the stored `(role, allowed_contexts)` pair into an explicit
+/// [`ActScope`].
+///
+/// This is the one and only interpretation of an empty `allowed_contexts`:
+///
+/// | role | `allowed_contexts` | scope |
+/// |---|---|---|
+/// | [`Role::Admin`] | `[]` | [`ActScope::All`] — super-admin |
+/// | any other | `[]` | [`ActScope::None`] — authorized nowhere |
+/// | any | non-empty | [`ActScope::Contexts`] |
+///
+/// Server-side rather than an inherent method on [`ActScope`], because the
+/// decode needs [`Role`], which lives here — `vta-sdk` shares the shape and the
+/// `covers` predicate, not the authorization policy over them.
+///
+/// **Call this (or one of the accessors built on it) instead of testing
+/// `allowed_contexts.is_empty()`.** That test is only correct when paired with
+/// the role, and every place that forgot the pairing has been a bug.
+pub fn act_scope_for(role: &Role, allowed_contexts: &[String]) -> ActScope {
+    match (role, allowed_contexts) {
+        (_, cs) if !cs.is_empty() => ActScope::Contexts(cs.to_vec()),
+        (Role::Admin, _) => ActScope::All,
+        _ => ActScope::None,
+    }
+}
 
 /// Validate that `caller` may grant `scope` on an ACL entry.
 ///
@@ -479,11 +505,22 @@ impl AclEntry {
         matches!(self.role, Role::Admin)
     }
 
-    /// Whether this entry is a **super-admin**: an admin with no context
-    /// restriction (empty `allowed_contexts` ⇒ unrestricted), mirroring
-    /// [`AuthClaims::is_super_admin`].
+    /// This entry's authority to **act**, decoded from `(role,
+    /// allowed_contexts)`. Use this rather than reading `allowed_contexts`
+    /// directly — see [`ActScope`] for why.
+    pub fn act_scope(&self) -> ActScope {
+        act_scope_for(&self.role, &self.allowed_contexts)
+    }
+
+    /// Whether this entry may act in `context_id`, honouring context ancestry.
+    pub fn can_act_in(&self, context_id: &str) -> bool {
+        self.act_scope().covers(context_id)
+    }
+
+    /// Whether this entry is a **super-admin**: an admin whose [`ActScope`] is
+    /// unrestricted, mirroring [`AuthClaims::is_super_admin`].
     pub fn is_super_admin(&self) -> bool {
-        self.is_admin() && self.allowed_contexts.is_empty()
+        self.is_admin() && self.act_scope().is_unrestricted()
     }
 
     /// Set the optimistic-concurrency version (defaults to 0).
@@ -732,9 +769,11 @@ pub fn delegated_any_approver_covers(approver: &AclEntry, subject: &AclEntry) ->
     match &approver.approve_scope {
         ApproveScope::All => return true,
         ApproveScope::Contexts(_) => {
-            if !subject.allowed_contexts.is_empty()
-                && subject
-                    .allowed_contexts
+            // A scoped grant covers a context-scoped subject all of whose
+            // contexts fall within the scope. A global (unrestricted) or
+            // acts-nowhere subject has no `Contexts` scope to match here.
+            if let ActScope::Contexts(subject_ctxs) = subject.act_scope()
+                && subject_ctxs
                     .iter()
                     .all(|c| approver.approve_scope.covers(c))
             {
@@ -749,17 +788,23 @@ pub fn delegated_any_approver_covers(approver: &AclEntry, subject: &AclEntry) ->
     if !approver.is_admin() {
         return false;
     }
-    if approver.allowed_contexts.is_empty() {
-        return true; // super-admin: covers all contexts
+    match approver.act_scope() {
+        // Super-admin: covers all contexts.
+        ActScope::All => true,
+        // Context admin: the subject must itself be context-scoped, and every
+        // one of its contexts must fall within the approver's. A global subject
+        // needs a super-admin approver (handled above). Exact membership, not
+        // ancestry — preserved verbatim from the pre-`ActScope` code; widening
+        // it to `covers` would be a behaviour change, not a refactor.
+        ActScope::Contexts(approver_ctxs) => match subject.act_scope() {
+            ActScope::Contexts(subject_ctxs) => {
+                subject_ctxs.iter().all(|c| approver_ctxs.contains(c))
+            }
+            _ => false,
+        },
+        // Unreachable: an admin is never acts-nowhere. Fail closed regardless.
+        ActScope::None => false,
     }
-    // Context admin: the subject must itself be context-scoped, and every one of
-    // its contexts must fall within the approver's. A global subject (empty
-    // contexts) requires a super-admin approver, handled by the branch above.
-    !subject.allowed_contexts.is_empty()
-        && subject
-            .allowed_contexts
-            .iter()
-            .all(|c| approver.allowed_contexts.contains(c))
 }
 
 /// Whether `entry` holds authority to act in `context_id` — the predicate
@@ -779,13 +824,7 @@ pub fn delegated_any_approver_covers(approver: &AclEntry, subject: &AclEntry) ->
 /// its subtree, so it genuinely carries a child id. Both VTA filters compared
 /// with `contains`, so neither surfaced it.
 pub fn acl_entry_can_act_in(entry: &AclEntry, context_id: &str) -> bool {
-    if entry.is_super_admin() {
-        return true;
-    }
-    entry
-        .allowed_contexts
-        .iter()
-        .any(|allowed| crate::context_path::is_ancestor_or_self(allowed, context_id))
+    entry.act_scope().covers(context_id)
 }
 
 /// Check whether an ACL entry is visible to the caller.
@@ -797,7 +836,8 @@ pub fn is_acl_entry_visible(caller: &AuthClaims, entry: &AclEntry) -> bool {
         return true;
     }
     entry
-        .allowed_contexts
+        .act_scope()
+        .named_contexts()
         .iter()
         .any(|ctx| caller.has_context_access(ctx))
 }

--- a/vti-common/src/auth/extractor.rs
+++ b/vti-common/src/auth/extractor.rs
@@ -7,7 +7,7 @@ use axum_extra::headers::Authorization;
 use axum_extra::headers::authorization::Bearer;
 use tracing::warn;
 
-use crate::acl::Role;
+use crate::acl::{ActScope, Role, act_scope_for};
 use crate::auth::jwt::JwtKeys;
 use crate::auth::session::{SessionState, get_session};
 use crate::error::AppError;
@@ -189,16 +189,28 @@ impl AuthClaims {
         }
     }
 
-    /// Returns `true` if the caller is an admin with unrestricted access
-    /// (empty `allowed_contexts`).
-    pub fn is_super_admin(&self) -> bool {
-        self.role == Role::Admin && self.allowed_contexts.is_empty()
+    /// This caller's authority to **act**, decoded from `(role,
+    /// allowed_contexts)`.
+    ///
+    /// Use this — or [`has_context_access`](Self::has_context_access), which is
+    /// built on it — rather than inspecting `allowed_contexts` directly. An
+    /// empty list means *unrestricted* for [`Role::Admin`] and *nothing at all*
+    /// for every other role; a call site that tests `is_empty()` without the
+    /// role gets one of those two cases backwards. See [`ActScope`].
+    pub fn act_scope(&self) -> ActScope {
+        act_scope_for(&self.role, &self.allowed_contexts)
     }
 
-    /// Returns `true` if the caller has access to the given context — as a super
-    /// admin, or because one of their `allowed_contexts` is `context_id` itself
-    /// **or an ancestor of it** (folder-level authority: admin of a parent
-    /// context covers the whole subtree).
+    /// Returns `true` if the caller is an admin whose [`ActScope`] is
+    /// unrestricted.
+    pub fn is_super_admin(&self) -> bool {
+        self.role == Role::Admin && self.act_scope().is_unrestricted()
+    }
+
+    /// Returns `true` if the caller may act in the given context — because
+    /// their [`ActScope`] is unrestricted, or because it names `context_id`
+    /// itself **or an ancestor of it** (folder-level authority: admin of a
+    /// parent context covers the whole subtree).
     ///
     /// Ancestry is the segment-aware
     /// [`is_ancestor_or_self`](crate::context_path::is_ancestor_or_self) — a
@@ -206,11 +218,7 @@ impl AuthClaims {
     /// (single-segment, childless) contexts this is identical to the previous
     /// exact match.
     pub fn has_context_access(&self, context_id: &str) -> bool {
-        self.is_super_admin()
-            || self
-                .allowed_contexts
-                .iter()
-                .any(|allowed| crate::context_path::is_ancestor_or_self(allowed, context_id))
+        self.act_scope().covers(context_id)
     }
 
     /// Clone these claims with `extra` contexts merged into `allowed_contexts`.


### PR DESCRIPTION
## The cause behind three merged fixes

`allowed_contexts` means opposite things depending on the role:

| role | `allowed_contexts` | meaning |
|---|---|---|
| `Admin` | `[]` | unrestricted — this *is* how a super-admin is spelled |
| any other | `[]` | authorized **nowhere** |
| any | non-empty | those contexts and their subtrees |

Call sites kept reading the field without the role, and each time got one of the two empty cases exactly backwards:

- **#746** — a display rendered a least-privilege approver as `(unrestricted)`, on a screen operators audit grants with.
- **#770** — two `acl list --context` filters disagreed on whether an empty list matches every context or none. Neither was right; both also ignored ancestry.
- **#769** — a vault scope gate read any empty list as super-admin scope, handing an authorized-nowhere entry credential-vault reads in **every** context.

Each was fixed at its own call site. This removes the shared cause.

## The type

`ActScope` (`None` / `All` / `Contexts`) is the decode, done once. It lives in `vta-sdk/src/acl.rs` **beside `ApproveScope`**, with deliberately identical variants, an identical `covers()`, and the same fail-closed default — so "what may this DID do" and "what may it confer" read as one model rather than an enum and a convention. A test pins that the two agree on coverage.

## Nothing is stored or sent in the new shape

Unlike `ApproveScope`, the act axis stays `(role, allowed_contexts)` on disk and on the wire. `ActScope` is computed on read:

```rust
AclEntry::act_scope()      // -> ActScope
AuthClaims::act_scope()    // -> ActScope
```

No migration, no wire change, no stored row touched.

The *decode* (`act_scope_for`) stays in `vti-common` because it needs `Role`, which `vta-sdk` cannot see. That is the same shape-in-SDK / policy-in-common split #768 used for `ApproveScope` and `validate_approve_scope_grant`, not a special case.

`is_super_admin`, `has_context_access`, `can_act_in`, `is_acl_entry_visible`, `acl_entry_can_act_in`, `delegated_any_approver_covers` and both ACL displays now route through it.

## Strictly structural

Behaviour is unchanged everywhere. Two conflations are preserved **deliberately** and flagged in place, because removing either is an authorization change rather than a structural one:

1. **`validate_acl_modification` refuses an empty target to any non-super-admin.** It receives `target_contexts` without a role, so it cannot distinguish "grant nothing" from "grant everything". The consequence is that only a super-admin can create a least-privilege approver — the very shape the CLI recommends.
2. **The admin path in `delegated_any_approver_covers` matches contexts by exact membership**, while the approve-scope path in the same function is ancestry-aware. Probably an oversight, but widening it changes who may ratify a step-up.

Both are listed in the design note as follow-ups.

## Verified load-bearing

A refactor whose tests pass either way protects nothing. Sabotaging the decode to ignore the role fails immediately:

```
can_act_in_excludes_acts_nowhere_entries          ... FAILED
can_act_in_resolves_the_offline_online_disagreement ... FAILED
```

`cargo test -p vta-sdk -p vti-common -p vta-cli-common -p vta-service`: **2205 passed, 0 failed**. Clippy and fmt clean.

## Scope

**VTA only.** `vtc-service` has the same idiom (`routes/acl.rs`, `acl_cli.rs`) but `VtcAclEntry` is a distinct type with its own role enum, needing its own accessor via `as_vti_role`. Porting it doubles the review surface on security-critical code, so it is listed as remaining work rather than silently skipped — the two services can still drift until it lands.

## Docs

`docs/05-design-notes/acl-scope-semantics.md` documents the model, the stored-vs-computed asymmetry, and what remains. CLAUDE.md gains the workspace rule: never test `allowed_contexts.is_empty()`.