### PR TITLE
feat(display): show names where we used to show DIDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,65 @@
 
 ## Unreleased
 
+### vta-sdk 0.19.26 / vta-cli-common 0.10.12 / pnm-cli 0.11.7 / cnm-cli 0.11.5 / vta-service 0.12.21 / vtc-service 0.11.20 — show names where we used to show DIDs
+
+* Operators read DIDs constantly and cannot. Roughly ninety sites across the
+  three CLIs printed raw DIDs, and each abbreviated them its own way: a
+  29-*byte* slice in `audit` (which would panic on a multi-byte character),
+  50- and 60-char truncations in `services`, and a fourth strategy again in the
+  VTC admin console. Nothing anywhere mapped a DID to a human name at render
+  time.
+
+* New `vta_sdk::display_name`. A `NameBook` is a `DID → name` map a command
+  fills from a response it has *already fetched*, then queries while
+  rendering — not a resolver, and it performs no lookups of its own. That
+  shape is what makes naming free: an ACL listing names every subject from its
+  label and, with no extra request, the `Created By` column too, since a
+  granting admin is nearly always another entry's subject.
+
+* `shorten_did` replaces all four truncators. It abbreviates the opaque
+  `did:webvh` SCID and keeps the domain/path tail — the half that actually
+  identifies the agent — instead of clipping the end. Ported from the admin
+  console's `shortenDid`, with a vector table pinning the two to identical
+  output; an operator moving between a terminal and the console should not
+  have to re-identify the same DID.
+
+* Tables gain a `Name` column only when at least one row has a name. On a VTA
+  where nothing has been labelled, a column of dashes is worse than no column.
+  DIDs are never *replaced* by names — the name leads, the identifier follows,
+  and `--full-display` and `--json` still carry every DID in full. A name the
+  operator cannot cross-check against an identifier is a name they cannot
+  audit, and these are the screens where ACL grants get approved.
+
+* `--json` output is unchanged. No field was renamed, removed, or reshaped, so
+  scripts piping `pnm acl list --json` through `jq` are unaffected.
+
+* Named DIDs now appear in: `pnm/cnm acl list|get`, `audit` (actor), `services
+  didcomm drain list`, `services report` (mediators + senders), the
+  context-delete confirmation — where an operator is deciding which principals
+  lose access — `vtc acl list`, and the VTC console's members, ACL, sessions,
+  join-requests, invitations, audit and relationship-graph views.
+
+* **Agent names are wired but inert.** New optional `agent-names` feature on
+  `vta-sdk` reads the names a DID's document claims via `alsoKnownAs`. Those
+  claims are *self-asserted* — the agent-name specification's two-sided binding
+  protects the name→DID direction, not the reverse — so a hostile DID can
+  claim `mybank.com/@treasury`. Every claim is round-tripped (resolve the name
+  forward, require it to lead back to the same DID) before being shown
+  unqualified; one that fails surfaces as unverified, ranks below every local
+  source, and never renders bare. Nothing in this workspace publishes
+  `alsoKnownAs` yet, so no agent name resolves here today — this is the
+  consumer half, built so that minting names lights up every surface without
+  touching a display site.
+
+* `PATCH /v1/members/{did}` accepts `label`. The VTC's only human name for a
+  member lives on the ACL row, which meant correcting a typo in a display name
+  took a full `acl/grant` re-grant.
+
+* Breaking, internal: `vta_cli_common::commands::contexts::render_delete_context_preview`
+  takes a `&NameBook`. Both call sites (the online `pnm contexts delete` and
+  the offline `vta contexts delete`) are updated.
+
 ### vta-sdk 0.19.25 / vti-common 0.11.16 / vta-cli-common 0.10.11 / vta-service 0.12.20 — decode an ACL entry's authority to act in one place
 
 * **`allowed_contexts` means opposite things depending on the role** —

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10079,7 +10079,7 @@ dependencies = [
 
 [[package]]
 name = "vta-cli-common"
-version = "0.10.11"
+version = "0.10.12"
 dependencies = [
  "aes-gcm",
  "affinidi-crypto",
@@ -10158,7 +10158,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.19.25"
+version = "0.19.26"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10220,7 +10220,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.12.20"
+version = "0.12.21"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,6 +205,7 @@ dependencies = [
  "affinidi-did-resolver-traits",
  "affinidi-did-web",
  "affinidi-task-utils",
+ "agent-names",
  "ahash 0.8.12",
  "base64 0.22.1",
  "did-ethr",
@@ -762,6 +763,21 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.19",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "agent-names"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b7e2b7857b1f2aadbf3216a02046bef6a66fed4b199108d46d29953b5b487b0"
+dependencies = [
+ "affinidi-did-common",
+ "reqwest 0.13.4",
+ "serde_json",
+ "thiserror 2.0.19",
+ "tokio",
  "tracing",
  "url",
 ]
@@ -10147,6 +10163,7 @@ dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
  "affinidi-data-integrity",
+ "affinidi-did-common",
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-core",
  "affinidi-messaging-delivery",
@@ -10159,6 +10176,7 @@ dependencies = [
  "affinidi-secrets-resolver",
  "affinidi-tdk",
  "affinidi-vc",
+ "agent-names",
  "apple-native-keyring-store",
  "arbitrary",
  "aws-nitro-enclaves-nsm-api 0.5.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2488,7 +2488,7 @@ checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cnm-cli"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "clap",
@@ -6759,7 +6759,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "pnm-cli"
-version = "0.11.6"
+version = "0.11.7"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-resolver-cache-sdk",
@@ -10327,7 +10327,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-service"
-version = "0.11.19"
+version = "0.11.20"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -280,6 +280,19 @@ k8s-openapi = { version = "0.27", features = ["latest"] }
 # that want the offline-only cache can opt out via `default-features = false`.
 affinidi-did-resolver-cache-sdk = { version = "0.8", features = ["network"] }
 
+# Agent names — human-memorable `example.com/@alice` shortcuts that resolve to
+# DIDs. Consumed by `vta_sdk::display_name` (feature `agent-names`) for the
+# *reverse* direction only: reading the names a DID's document claims via
+# `alsoKnownAs`, then round-tripping each claim to confirm it leads back to
+# that same DID. Nothing in this workspace publishes an `alsoKnownAs` entry
+# yet, so today this resolves nothing — it is wired so that minting names
+# (a separate piece of work, in `affinidi-webvh-service`) lights up every
+# operator surface without touching a display site.
+agent-names = "0.1.3"
+# The `Document` type `agent-names` and the resolver cache both speak. Only
+# needed where we hand a resolved document to `extract_agent_names`.
+affinidi-did-common = "0.4"
+
 # WebAuthn / passkey infrastructure. Used by vti-common's `passkey` feature
 # for shared enrolment + login ceremonies — both VTA (admin auth, later) and
 # VTC (install + admin login) consume it. The version pin matches what

--- a/cnm-cli/Cargo.toml
+++ b/cnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cnm-cli"
 description = "CLI Tool for Verified Trust Agents operating in Verified Trust Communities"
-version = "0.11.4"
+version = "0.11.5"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/cnm-cli/src/main.rs
+++ b/cnm-cli/src/main.rs
@@ -1686,6 +1686,15 @@ async fn print_did_resolution(
 
     println!("                {GREEN}✓{RESET} resolves ({method})");
 
+    // Agent names the document claims via `alsoKnownAs`. Free to report — we
+    // already hold the document — and genuinely diagnostic in a doctor
+    // command. Reported as *claims*, not as this DID's name: `alsoKnownAs` is
+    // self-asserted, and confirming one means resolving it forward and
+    // checking it leads back here (`vta_sdk::display_name::agent_name`).
+    for claim in &resolved.doc.also_known_as {
+        println!("                {DIM}claims (unverified): {claim}{RESET}");
+    }
+
     for ka in &resolved.doc.key_agreement {
         println!("                {DIM}keyAgreement: {}{RESET}", ka.get_id());
     }

--- a/pnm-cli/Cargo.toml
+++ b/pnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pnm-cli"
 description = "CLI Tool for managing a personal Verifiable Trust Agent"
-version = "0.11.6"
+version = "0.11.7"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/pnm-cli/src/commands/health.rs
+++ b/pnm-cli/src/commands/health.rs
@@ -39,12 +39,21 @@ pub(crate) async fn run(
                 println!("  {CYAN}{:<13}{RESET} {vta_did}", "DID");
                 if let Some(ref resolver) = did_resolver {
                     match resolver.resolve(vta_did).await {
-                        Ok(_) => {
+                        Ok(resolved) => {
                             let method = vta_did
                                 .strip_prefix("did:")
                                 .and_then(|s| s.split(':').next())
                                 .unwrap_or("?");
                             println!("                {GREEN}✓{RESET} resolves ({method})");
+                            // Names the document claims via `alsoKnownAs`.
+                            // Free — the document is already in hand — and
+                            // marked as claims because that half of the
+                            // binding is self-asserted until resolved forward.
+                            for claim in &resolved.doc.also_known_as {
+                                println!(
+                                    "                {DIM}claims (unverified): {claim}{RESET}"
+                                );
+                            }
                         }
                         Err(e) => {
                             println!("                {RED}✗{RESET} resolution failed: {e}")

--- a/pnm-cli/src/main.rs
+++ b/pnm-cli/src/main.rs
@@ -210,8 +210,12 @@ async fn main() {
     };
     let keyring_key = config::vta_keyring_key(&slug);
 
-    // Print VTA info banner
+    // Print VTA info banner. The configured name is the operator's own label
+    // for this VTA — show it when it says more than the slug already does.
     eprintln!("  {DIM}VTA: {slug}{RESET}");
+    if !vta_config.name.is_empty() && vta_config.name != slug {
+        eprintln!("  {DIM}Name: {}{RESET}", vta_config.name);
+    }
     if let Some(ref did) = vta_config.vta_did {
         eprintln!("  {DIM}DID: {did}{RESET}");
     }

--- a/vta-cli-common/Cargo.toml
+++ b/vta-cli-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-cli-common"
 description = "Shared CLI command handlers and rendering helpers for VTA CLIs"
 readme = "README.md"
-version = "0.10.11"
+version = "0.10.12"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-cli-common/src/commands/acl.rs
+++ b/vta-cli-common/src/commands/acl.rs
@@ -7,7 +7,11 @@ use vta_sdk::acl::ApproveScope;
 use vta_sdk::prelude::*;
 use vti_common::acl::{Role, act_scope_for};
 
-use crate::render::{is_full_display, print_full_entry, print_full_list_title, print_widget};
+use crate::display::{
+    NAME_HEADER, NameBook, NameSource, book_from_acl, did_cell, full_display_pairs, name_cell,
+    named_did_cell,
+};
+use crate::render::{is_full_display, print_full_entry_owned, print_full_list_title, print_widget};
 
 /// Human-readable context list — **role-aware**, because an empty
 /// `allowed_contexts` means opposite things depending on the role.
@@ -83,74 +87,95 @@ pub async fn cmd_acl_list(
         return Ok(());
     }
 
+    // One pass over the entries names every subject from its label — and,
+    // for free, the `Created By` column too, since a granting admin nearly
+    // always holds an ACL entry of their own.
+    let mut book = NameBook::new();
+    book_from_acl(&mut book, &resp.entries);
+
     if is_full_display() {
         print_full_list_title("ACL Entries", resp.entries.len());
         for entry in &resp.entries {
-            let label = entry.label.as_deref().unwrap_or("—");
             let contexts = format_contexts(&entry.role, &entry.allowed_contexts);
             let role = format_role(&entry.role, &entry.allowed_contexts);
             let approve = format_approve_scope(entry.approve_all_contexts, &entry.approve_contexts);
-            let mut fields: Vec<(&str, &str)> = vec![
-                ("DID", &entry.did),
-                ("Role", &role),
-                ("Label", label),
-                ("Contexts", &contexts),
-            ];
-            if let Some(a) = &approve {
+
+            // Name + full DID. Full display exists so an operator can copy a
+            // complete identifier, so the DID is never abbreviated here.
+            let mut fields = full_display_pairs(&book, &entry.did);
+            fields.push(("Role", role));
+            // The raw label is normally what the Name line already shows; keep
+            // it only when something higher-ranked (an agent name) displaced it.
+            if let Some(label) = entry.label.as_deref()
+                && book.name_of(&entry.did).as_deref() != Some(label)
+            {
+                fields.push(("Label", label.to_string()));
+            }
+            fields.push(("Contexts", contexts));
+            if let Some(a) = approve {
                 fields.push(("Approve", a));
             }
-            fields.push(("Created By", &entry.created_by));
-            print_full_entry(&fields);
+            fields.push(("Created By", book.render_inline(&entry.created_by)));
+            print_full_entry_owned(&fields);
         }
         return Ok(());
     }
 
+    // Only give up a column to names if at least one entry has one — on a VTA
+    // where nothing has been labelled, a column of dashes is worse than no
+    // column.
+    let show_names = book.names_any(resp.entries.iter().map(|e| e.did.as_str()));
+
     let header_style = Style::default()
         .fg(Color::White)
         .add_modifier(Modifier::BOLD);
-    let header = Row::new(vec!["DID", "Role", "Label", "Contexts", "Created By"])
-        .style(header_style)
-        .bottom_margin(1);
+    let mut header_cells = vec!["DID", "Role", "Contexts", "Created By"];
+    if show_names {
+        header_cells.insert(0, NAME_HEADER);
+    }
+    let header = Row::new(header_cells).style(header_style).bottom_margin(1);
 
     let rows: Vec<Row> = resp
         .entries
         .iter()
         .map(|entry| {
-            let label = entry.label.clone().unwrap_or_else(|| "\u{2014}".into());
             let contexts = format_contexts(&entry.role, &entry.allowed_contexts);
-
-            Row::new(vec![
-                Cell::from(entry.did.clone()).style(Style::default().fg(Color::DarkGray)),
+            let mut cells = vec![
+                did_cell(&entry.did),
                 Cell::from(format_role(&entry.role, &entry.allowed_contexts)),
-                Cell::from(label),
                 Cell::from(contexts),
-                Cell::from(entry.created_by.clone()).style(Style::default().fg(Color::DarkGray)),
-            ])
+                named_did_cell(&book, &entry.created_by),
+            ];
+            if show_names {
+                cells.insert(0, name_cell(&book, &entry.did));
+            }
+            Row::new(cells)
         })
         .collect();
 
     let title = format!(" ACL Entries ({}) ", resp.entries.len());
 
-    // `Created By` and `DID` hold full did:key values (~57 chars); use
-    // `Min` rather than fixed `Length` so they expand on wide terminals
-    // instead of truncating. Role / Contexts are short and bounded.
-    let table = Table::new(
-        rows,
-        [
-            Constraint::Min(60),    // DID
-            Constraint::Length(12), // Role
-            Constraint::Min(16),    // Label
-            Constraint::Length(24), // Contexts
-            Constraint::Min(52),    // Created By
-        ],
-    )
-    .header(header)
-    .column_spacing(2)
-    .block(
-        Block::bordered()
-            .title(title)
-            .border_style(Style::default().fg(Color::DarkGray)),
-    );
+    // DIDs are abbreviated by `shorten_did` (SCID squeezed, domain tail kept),
+    // which frees the width the name column needs. `--full-display` and
+    // `--json` still carry every DID in full.
+    let mut constraints = vec![
+        Constraint::Min(34),    // DID
+        Constraint::Length(12), // Role
+        Constraint::Length(24), // Contexts
+        Constraint::Min(30),    // Created By
+    ];
+    if show_names {
+        constraints.insert(0, Constraint::Min(16));
+    }
+
+    let table = Table::new(rows, constraints)
+        .header(header)
+        .column_spacing(2)
+        .block(
+            Block::bordered()
+                .title(title)
+                .border_style(Style::default().fg(Color::DarkGray)),
+        );
 
     let height = resp.entries.len() as u16 + 4;
     print_widget(table, height);
@@ -160,15 +185,30 @@ pub async fn cmd_acl_list(
 
 pub async fn cmd_acl_get(client: &VtaClient, did: &str) -> Result<(), Box<dyn std::error::Error>> {
     let entry = client.get_acl(did).await?;
-    println!("DID:              {}", entry.did);
+
+    let mut book = NameBook::new();
+    book.insert_opt(&entry.did, entry.label.as_deref(), NameSource::AclLabel);
+
+    // Name above DID, DID in full — a single-entry view is where an operator
+    // copies an identifier from.
+    match book.name_of(&entry.did) {
+        Some(name) => {
+            println!("Name:             {name}");
+            println!("DID:              {}", entry.did);
+        }
+        None => println!("DID:              {}", entry.did),
+    }
     println!(
         "Role:             {}",
         format_role(&entry.role, &entry.allowed_contexts)
     );
-    println!(
-        "Label:            {}",
-        entry.label.as_deref().unwrap_or("(not set)")
-    );
+    // Normally the Name line above; shown separately only when something
+    // higher-ranked (a verified agent name) displaced the operator's label.
+    if let Some(label) = entry.label.as_deref()
+        && book.name_of(&entry.did).as_deref() != Some(label)
+    {
+        println!("Label:            {label}");
+    }
     println!(
         "Contexts:         {}",
         format_contexts(&entry.role, &entry.allowed_contexts)

--- a/vta-cli-common/src/commands/audit.rs
+++ b/vta-cli-common/src/commands/audit.rs
@@ -4,7 +4,8 @@ use ratatui::text::Span;
 use ratatui::widgets::{Cell, Row, Table};
 use vta_sdk::prelude::*;
 
-use crate::render::{is_full_display, print_full_entry, print_full_list_title, print_widget};
+use crate::display::{NameBook, book_from_acl, named_did_cell};
+use crate::render::{is_full_display, print_full_entry_owned, print_full_list_title, print_widget};
 
 /// Display audit logs with beautiful colored formatting.
 pub async fn cmd_list_audit_logs(
@@ -16,6 +17,15 @@ pub async fn cmd_list_audit_logs(
     if result.entries.is_empty() {
         println!("  No audit log entries found.");
         return Ok(());
+    }
+
+    // Audit rows carry only an actor DID — "who did this" is exactly the
+    // question a log is read to answer, so it is worth one extra request to
+    // put names on them. Best-effort: an operator may hold audit-read without
+    // ACL-read, and a naming failure must never fail the command.
+    let mut book = NameBook::new();
+    if let Ok(acl) = client.list_acl(None).await {
+        book_from_acl(&mut book, &acl.entries);
     }
 
     if is_full_display() {
@@ -31,16 +41,21 @@ pub async fn cmd_list_audit_logs(
             let resource = entry.resource.as_deref().unwrap_or("—");
             let channel = entry.channel.as_deref().unwrap_or("—");
             let context = entry.context_id.as_deref().unwrap_or("—");
-            print_full_entry(&[
-                ("ID", &entry.id),
-                ("Timestamp", &ts),
-                ("Action", &entry.action),
-                ("Actor", &entry.actor),
-                ("Resource", resource),
-                ("Channel", channel),
-                ("Context", context),
-                ("Outcome", &entry.outcome),
-            ]);
+            let mut fields = vec![
+                ("ID", entry.id.clone()),
+                ("Timestamp", ts),
+                ("Action", entry.action.clone()),
+            ];
+            if let Some(name) = book.name_of(&entry.actor) {
+                fields.push(("Actor", name));
+            }
+            // Actor DID stays in full — an audit trail is evidence.
+            fields.push(("Actor DID", entry.actor.clone()));
+            fields.push(("Resource", resource.to_string()));
+            fields.push(("Channel", channel.to_string()));
+            fields.push(("Context", context.to_string()));
+            fields.push(("Outcome", entry.outcome.clone()));
+            print_full_entry_owned(&fields);
         }
         return Ok(());
     }
@@ -81,22 +96,15 @@ pub async fn cmd_list_audit_logs(
                 Style::default()
             };
 
-            // Truncate actor DID for display
-            let actor_display = if entry.actor.len() > 30 {
-                format!("{}…", &entry.actor[..29])
-            } else {
-                entry.actor.clone()
-            };
-
+            // Actor: the entry's name when we have one, else the shortened
+            // DID. (The previous `&entry.actor[..29]` sliced on a byte
+            // boundary and would panic on a multi-byte character.)
             let resource_display = entry.resource.as_deref().unwrap_or("\u{2014}");
 
             Row::new(vec![
                 Cell::from(Span::styled(ts, Style::default().fg(Color::DarkGray))),
                 Cell::from(Span::styled(entry.action.clone(), action_style)),
-                Cell::from(Span::styled(
-                    actor_display,
-                    Style::default().fg(Color::DarkGray),
-                )),
+                named_did_cell(&book, &entry.actor),
                 Cell::from(resource_display.to_string()),
                 Cell::from(Span::styled(entry.outcome.clone(), outcome_style)),
             ])

--- a/vta-cli-common/src/commands/contexts.rs
+++ b/vta-cli-common/src/commands/contexts.rs
@@ -11,6 +11,7 @@ use vta_sdk::prelude::*;
 use vta_sdk::protocols::did_management::create::WebvhPathMode;
 use vta_sdk::sealed_transfer::SealedPayloadV1;
 
+use crate::display::{NameBook, book_from_acl, inline};
 use crate::render::{is_full_display, print_full_entry, print_full_list_title, print_widget};
 use crate::sealed_producer::{SealedRecipient, seal_for_recipient};
 
@@ -396,6 +397,7 @@ pub async fn cmd_context_update_did(
 pub fn render_delete_context_preview(
     id: &str,
     preview: &vta_sdk::protocols::context_management::delete::DeleteContextPreviewResultBody,
+    book: &NameBook,
 ) -> bool {
     let has_resources = !preview.keys.is_empty()
         || !preview.webvh_dids.is_empty()
@@ -418,10 +420,14 @@ pub fn render_delete_context_preview(
         }
     }
 
+    // This is a destructive confirmation: the operator is deciding whether
+    // these principals should lose access. A list of opaque DIDs is the
+    // hardest possible form in which to make that call, so every DID here
+    // renders name-first with its identifier alongside.
     if !preview.webvh_dids.is_empty() {
         println!("  WebVH DIDs ({}):", preview.webvh_dids.len());
         for did in &preview.webvh_dids {
-            println!("    - {did}");
+            println!("    - {}", inline(book, did));
         }
     }
 
@@ -431,7 +437,7 @@ pub fn render_delete_context_preview(
             preview.acl_entries_removed.len()
         );
         for did in &preview.acl_entries_removed {
-            println!("    - {did}");
+            println!("    - {}", inline(book, did));
         }
     }
 
@@ -441,7 +447,7 @@ pub fn render_delete_context_preview(
             preview.acl_entries_updated.len()
         );
         for did in &preview.acl_entries_updated {
-            println!("    - {did}");
+            println!("    - {}", inline(book, did));
         }
     }
 
@@ -469,7 +475,14 @@ pub async fn cmd_context_delete(
     // Fetch a preview of what will be removed
     let preview = client.preview_delete_context(id).await?;
 
-    let has_resources = render_delete_context_preview(id, &preview);
+    // Best-effort naming for the confirmation prompt — a failure here must
+    // never block a deletion the operator is entitled to perform.
+    let mut book = NameBook::new();
+    if let Ok(acl) = client.list_acl(None).await {
+        book_from_acl(&mut book, &acl.entries);
+    }
+
+    let has_resources = render_delete_context_preview(id, &preview, &book);
 
     if has_resources && !force && !confirm_destructive("Proceed with deletion?")? {
         println!("Aborted.");

--- a/vta-cli-common/src/commands/services.rs
+++ b/vta-cli-common/src/commands/services.rs
@@ -25,6 +25,8 @@ use vta_sdk::protocol::{
     DisableDidcommRequest, EnableDidcommConflictBody, EnableDidcommRequest, UpdateDidcommRequest,
 };
 
+use crate::display::{NAME_HEADER, NameBook, UNNAMED, book_from_acl, inline, shorten_did};
+
 // ── services list ──────────────────────────────────────────────────
 
 /// `pnm services list` — show current REST + DIDComm advertisements.
@@ -334,6 +336,23 @@ pub async fn cmd_services_didcomm_rollback(
     Ok(())
 }
 
+/// Best-effort names for mediator / peer DIDs.
+///
+/// Neither the drain set nor the telemetry report carries a label, so the only
+/// local source is the ACL — which does cover mediators an operator has
+/// granted an entry to. Peer *senders* are not in our ACL and stay bare until
+/// agent names exist; they are the clearest case for that feature.
+///
+/// Failure is ignored on purpose. Naming is decoration, and an operator who
+/// can read the drain set but not the ACL must still get their table.
+async fn mediator_name_book(client: &VtaClient) -> NameBook {
+    let mut book = NameBook::new();
+    if let Ok(acl) = client.list_acl(None).await {
+        book_from_acl(&mut book, &acl.entries);
+    }
+    book
+}
+
 // ── services didcomm drain {list, cancel} ─────────────────────────
 
 pub async fn cmd_services_didcomm_drain_list(
@@ -346,15 +365,27 @@ pub async fn cmd_services_didcomm_drain_list(
     }
     println!("Drain set ({} mediator(s)):", resp.entries.len());
     println!();
+
+    let book = mediator_name_book(client).await;
+    let show_names = book.names_any(resp.entries.iter().map(|e| e.mediator_did.as_str()));
+
     let header_did = "MEDIATOR DID";
     let header_until = "DRAIN UNTIL";
-    println!("  {header_did:<60}  {header_until}");
+    if show_names {
+        println!("  {:<24}  {header_did:<46}  {header_until}", NAME_HEADER);
+    } else {
+        println!("  {header_did:<46}  {header_until}");
+    }
     for e in &resp.entries {
-        println!(
-            "  {:<60}  {}",
-            truncate(&e.mediator_did, 60),
-            e.drains_until
-        );
+        let did = shorten_did(&e.mediator_did);
+        if show_names {
+            let name = book
+                .name_of(&e.mediator_did)
+                .unwrap_or_else(|| UNNAMED.into());
+            println!("  {:<24}  {:<46}  {}", name, did, e.drains_until);
+        } else {
+            println!("  {:<46}  {}", did, e.drains_until);
+        }
     }
     Ok(())
 }
@@ -394,30 +425,52 @@ pub async fn cmd_services_report(
                 println!("  Window: (all time) → {}", report.until);
             }
             println!();
+            // Peer sender DIDs have no label anywhere in our store, so most
+            // will stay bare until agent names land — which is exactly the
+            // surface they are for.
+            let book = mediator_name_book(client).await;
+
             if report.mediators.is_empty() {
                 println!("  No inbound DIDComm messages recorded.");
             } else {
                 println!("  Per-mediator inbound counts (most recent first):");
+                let show_names =
+                    book.names_any(report.mediators.iter().map(|m| m.mediator_did.as_str()));
                 let header_did = "MEDIATOR DID";
                 let header_count = "INBOUND";
-                println!("    {header_did:<60}  {header_count:>10}  LAST SEEN");
-                for m in &report.mediators {
+                if show_names {
                     println!(
-                        "    {:<60}  {:>10}  {}",
-                        truncate(&m.mediator_did, 60),
-                        m.inbound_count,
-                        m.last_seen
+                        "    {:<24}  {header_did:<46}  {header_count:>10}  LAST SEEN",
+                        NAME_HEADER
                     );
+                } else {
+                    println!("    {header_did:<46}  {header_count:>10}  LAST SEEN");
+                }
+                for m in &report.mediators {
+                    let did = shorten_did(&m.mediator_did);
+                    if show_names {
+                        let name = book
+                            .name_of(&m.mediator_did)
+                            .unwrap_or_else(|| UNNAMED.into());
+                        println!(
+                            "    {:<24}  {:<46}  {:>10}  {}",
+                            name, did, m.inbound_count, m.last_seen
+                        );
+                    } else {
+                        println!("    {:<46}  {:>10}  {}", did, m.inbound_count, m.last_seen);
+                    }
                 }
             }
             if !report.senders.is_empty() {
                 println!();
                 println!("  Senders by last-seen mediator:");
                 for s in &report.senders {
+                    // Prose, not a fixed-width column, so both sides carry
+                    // their DID alongside the name.
                     println!(
                         "    {} → {} (at {})",
-                        truncate(&s.sender_did, 50),
-                        truncate(&s.last_seen_mediator, 50),
+                        inline(&book, &s.sender_did),
+                        inline(&book, &s.last_seen_mediator),
                         s.last_seen_at
                     );
                 }
@@ -487,15 +540,5 @@ impl std::str::FromStr for ReportFormat {
             "table" => Ok(Self::Table),
             other => Err(format!("unknown format `{other}` — use `json` or `table`")),
         }
-    }
-}
-
-fn truncate(s: &str, max: usize) -> String {
-    if s.chars().count() <= max {
-        s.to_string()
-    } else {
-        let mut out: String = s.chars().take(max - 1).collect();
-        out.push('…');
-        out
     }
 }

--- a/vta-cli-common/src/display.rs
+++ b/vta-cli-common/src/display.rs
@@ -1,0 +1,201 @@
+//! Terminal rendering for DIDs and their display names.
+//!
+//! The naming logic itself lives in [`vta_sdk::display_name`] — this module is
+//! the thin CLI layer on top: ANSI colour, ratatui cells, and the decision
+//! about whether a table gets a NAME column at all.
+//!
+//! # Usage
+//!
+//! A command builds a [`NameBook`] from the response it already has, then
+//! renders through it:
+//!
+//! ```ignore
+//! let mut book = NameBook::new();
+//! book_from_acl(&mut book, &resp.entries);   // one pass, no extra requests
+//! let show_names = book.names_any(resp.entries.iter().map(|e| e.did.as_str()));
+//! ```
+//!
+//! The `book_from_*` helpers are the payoff: filling the book from an ACL
+//! listing also names the `Created By` column, because a granting admin is
+//! very often another entry's subject. No lookup, no round trip.
+
+use ratatui::{
+    style::{Color, Style},
+    widgets::Cell,
+};
+
+pub use vta_sdk::display_name::{DisplayName, NameBook, NameSource, shorten_did};
+
+use crate::render::{DIM, RESET, YELLOW};
+
+/// Column heading for the name column. One constant so every table agrees.
+pub const NAME_HEADER: &str = "Name";
+
+/// Placeholder for a row with no name, used only when *some* other row in the
+/// same table has one.
+pub const UNNAMED: &str = "\u{2014}";
+
+/// A DID rendered for a fixed-width table cell: shortened, dimmed.
+#[must_use]
+pub fn did_cell(did: &str) -> Cell<'static> {
+    Cell::from(shorten_did(did)).style(Style::default().fg(Color::DarkGray))
+}
+
+/// A name cell for `did`.
+///
+/// Unverified agent names are yellow — see [`vta_sdk::display_name`] for why
+/// they must stay visually distinct from a name the operator can rely on.
+#[must_use]
+pub fn name_cell(book: &NameBook, did: &str) -> Cell<'static> {
+    match book.get(did) {
+        Some(n) if n.is_trusted() => Cell::from(n.name.clone()),
+        Some(_) => Cell::from(book.name_of(did).unwrap_or_default())
+            .style(Style::default().fg(Color::Yellow)),
+        None => Cell::from(UNNAMED).style(Style::default().fg(Color::DarkGray)),
+    }
+}
+
+/// A cell for a DID that may carry a name — used where a column holds a
+/// *reference* to some other principal (`Created By`, `Actor`, a sender)
+/// rather than the row's own subject, so there is no room for a paired name
+/// column. Falls back to the shortened DID.
+#[must_use]
+pub fn named_did_cell(book: &NameBook, did: &str) -> Cell<'static> {
+    match book.name_of(did) {
+        Some(name) => {
+            let style = if book.get(did).is_some_and(DisplayName::is_trusted) {
+                Style::default()
+            } else {
+                Style::default().fg(Color::Yellow)
+            };
+            Cell::from(name).style(style)
+        }
+        None => did_cell(did),
+    }
+}
+
+/// Plain-text name-or-DID for a fixed-width column.
+///
+/// No ANSI: these go through `{:<60}`-style padding, which counts escape
+/// bytes as width and would wreck the alignment.
+#[must_use]
+pub fn name_or_did(book: &NameBook, did: &str) -> String {
+    book.name_of(did).unwrap_or_else(|| shorten_did(did))
+}
+
+/// One-line rendering for prose, confirmations and progress messages:
+/// `mediator-prod (did:webvh:QmXk…9f2:example.com)`.
+///
+/// Colours the name when it is an unverified claim; leaves it plain
+/// otherwise. Falls back to the shortened DID alone.
+#[must_use]
+pub fn inline(book: &NameBook, did: &str) -> String {
+    match book.name_of(did) {
+        Some(name) => {
+            let short = shorten_did(did);
+            if book.get(did).is_some_and(DisplayName::is_trusted) {
+                format!("{name} {DIM}({short}){RESET}")
+            } else {
+                format!("{YELLOW}{name}{RESET} {DIM}({short}){RESET}")
+            }
+        }
+        None => shorten_did(did),
+    }
+}
+
+/// Key-value pairs for a `--full-display` block: a `Name` line *above* the
+/// `DID` line, and the DID in full — abbreviating it is the one thing full
+/// display exists to avoid.
+///
+/// Returns just the DID pair when the DID has no name, so unnamed entries
+/// don't grow a `Name: —` line.
+#[must_use]
+pub fn full_display_pairs(book: &NameBook, did: &str) -> Vec<(&'static str, String)> {
+    match book.name_of(did) {
+        Some(name) => vec![("Name", name), ("DID", did.to_string())],
+        None => vec![("DID", did.to_string())],
+    }
+}
+
+// ── Book builders ───────────────────────────────────────────────────
+//
+// Each takes a response the command already fetched. Adding one here is
+// preferable to naming DIDs at the call site, so that every command that
+// touches the same response type gets the same names.
+
+/// Fill `book` from an ACL listing.
+///
+/// Names every entry's subject from its `label`. The `created_by` DIDs are
+/// *not* inserted — they carry no label of their own — but they resolve
+/// anyway whenever the granting admin also holds an ACL entry, which is the
+/// common case.
+pub fn book_from_acl(book: &mut NameBook, entries: &[vta_sdk::client::AclEntryResponse]) {
+    for entry in entries {
+        book.insert_opt(&entry.did, entry.label.as_deref(), NameSource::AclLabel);
+    }
+}
+
+/// Fill `book` from a context listing: each context's `name` names its DID.
+pub fn book_from_contexts(book: &mut NameBook, contexts: &[vta_sdk::contexts::ContextRecord]) {
+    for ctx in contexts {
+        if let Some(did) = &ctx.did {
+            book.insert(did, DisplayName::new(&ctx.name, NameSource::ContextName));
+        }
+    }
+}
+
+/// Fill `book` from a webvh hosting-server listing.
+pub fn book_from_webvh_servers(book: &mut NameBook, servers: &[vta_sdk::webvh::WebvhServerRecord]) {
+    for s in servers {
+        book.insert_opt(&s.did, s.label.as_deref(), NameSource::ServerLabel);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const DID: &str = "did:webvh:QmScidAbCdEfGhIj:example.com:ops";
+
+    #[test]
+    fn full_display_keeps_the_did_whole() {
+        let mut book = NameBook::new();
+        book.insert(DID, DisplayName::new("ops", NameSource::AclLabel));
+        let pairs = full_display_pairs(&book, DID);
+        assert_eq!(pairs[0], ("Name", "ops".to_string()));
+        assert_eq!(
+            pairs[1],
+            ("DID", DID.to_string()),
+            "full display must never abbreviate — that is what it is for"
+        );
+    }
+
+    #[test]
+    fn unnamed_entries_get_no_name_line() {
+        let book = NameBook::new();
+        let pairs = full_display_pairs(&book, DID);
+        assert_eq!(pairs.len(), 1);
+        assert_eq!(pairs[0].0, "DID");
+    }
+
+    #[test]
+    fn inline_marks_an_unverified_claim() {
+        let mut book = NameBook::new();
+        book.insert(
+            DID,
+            DisplayName::new(
+                "mybank.com/@treasury",
+                NameSource::AgentName { verified: false },
+            ),
+        );
+        let out = inline(&book, DID);
+        assert!(out.contains("unverified"));
+        assert!(out.contains(YELLOW), "an unchecked claim must stand out");
+    }
+
+    #[test]
+    fn inline_falls_back_to_the_shortened_did() {
+        let book = NameBook::new();
+        assert_eq!(inline(&book, DID), shorten_did(DID));
+    }
+}

--- a/vta-cli-common/src/lib.rs
+++ b/vta-cli-common/src/lib.rs
@@ -1,4 +1,7 @@
 pub mod commands;
+// Terminal rendering for DIDs + their display names. The CLI layer over
+// `vta_sdk::display_name`.
+pub mod display;
 pub mod duration;
 pub mod local_keygen;
 pub mod render;

--- a/vta-cli-common/src/render.rs
+++ b/vta-cli-common/src/render.rs
@@ -71,6 +71,15 @@ pub fn print_full_entry(pairs: &[(&str, &str)]) {
     println!();
 }
 
+/// [`print_full_entry`] for owned values. `crate::display::full_display_pairs`
+/// builds `(&'static str, String)` pairs — it has to, since a display name is
+/// computed rather than borrowed from the response — so this saves every call
+/// site the same re-borrowing dance.
+pub fn print_full_entry_owned(pairs: &[(&str, String)]) {
+    let borrowed: Vec<(&str, &str)> = pairs.iter().map(|(l, v)| (*l, v.as_str())).collect();
+    print_full_entry(&borrowed);
+}
+
 /// Print a bold section heading used above a list of full-display
 /// entries. Matches the title style of the table-mode block borders.
 pub fn print_full_list_title(title: &str, count: usize) {

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -47,6 +47,23 @@ tsp = [
   "dep:uuid",
   "dep:tokio",
 ]
+# Verified agent names in `display_name`. Reads the `alsoKnownAs` entries a
+# resolved DID Document claims and round-trips each one — resolving the name
+# forward and requiring it to lead back to the same DID — before any of them
+# is shown unqualified. `alsoKnownAs` on its own is self-asserted: the
+# agent-name specification's two-sided binding protects the name→DID
+# direction, not the reverse, so a document claiming
+# `mybank.com/@treasury` proves nothing without the round trip.
+#
+# Off by default because each lookup costs a DID resolution plus an outbound
+# HTTPS fetch per claimed name. Turn it on (and pass `--resolve-agent-names`)
+# once DIDs in this workspace actually publish names.
+agent-names = [
+  "dep:agent-names",
+  "dep:affinidi-did-common",
+  "dep:affinidi-did-resolver-cache-sdk",
+  "affinidi-did-resolver-cache-sdk/agent-names",
+]
 client = [
   "dep:reqwest",
   "dep:tracing",
@@ -216,6 +233,9 @@ rustls = { workspace = true, optional = true }
 tracing = { workspace = true, optional = true }
 uuid = { workspace = true, optional = true }
 affinidi-did-resolver-cache-sdk = { workspace = true, optional = true }
+# `display_name::agent_name` only — see the `agent-names` feature.
+agent-names = { workspace = true, optional = true }
+affinidi-did-common = { workspace = true, optional = true }
 keyring-core = { workspace = true, optional = true }
 azure_security_keyvault_secrets = { workspace = true, optional = true }
 azure_identity = { workspace = true, optional = true }

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.19.25"
+version = "0.19.26"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/display_name/agent_name.rs
+++ b/vta-sdk/src/display_name/agent_name.rs
@@ -1,0 +1,217 @@
+//! Verified agent names, the network-backed [`super::NameSource`].
+//!
+//! An agent name is a human-memorable URL — `example.com/@alice` — that
+//! resolves to a DID. This module implements the **reverse** direction, which
+//! is the one a display layer needs: given a DID, what name should we show?
+//!
+//! # Why a round trip is mandatory
+//!
+//! The obvious implementation is to resolve the DID, read the `alsoKnownAs`
+//! entries its document claims, and print one. That is wrong, and the way it
+//! is wrong is not subtle.
+//!
+//! Agent names are secured by a *two-sided* binding. Resolving a name to a DID
+//! requires both that the name's domain redirects to that DID **and** that the
+//! DID's document claims the name back. The first half stops a domain owner
+//! pointing a name at somebody else's identity; the second half is what the
+//! resolver checks. But the second half **on its own is a bare self-assertion**
+//! — anybody can put anything in their own `alsoKnownAs`. Nothing stops a
+//! hostile DID from claiming `mybank.com/@treasury`, and a display layer that
+//! prints that claim has told the operator, in an authoritative voice, that
+//! they are looking at the bank. In this workspace those operators are
+//! approving ACL grants and admitting community members.
+//!
+//! So every claim is round-tripped: resolve the claimed name forward and
+//! require it to lead back to *this* DID. Only then is the name shown
+//! unqualified. A claim that fails still surfaces — as
+//! [`NameSource::AgentName { verified: false }`], which ranks below every
+//! local source and renders with an `[unverified]` tag — because a DID
+//! *attempting* to present as `mybank.com/@treasury` is something an operator
+//! should see, just not something they should believe.
+//!
+//! There is deliberately no path that guesses a name from a DID's domain. The
+//! `agent-names` crate omits such a helper on purpose: the name→DID link is a
+//! web redirect and is not derivable from DID structure, so a constructed
+//! "likely name" would be an unverified guess wearing an authoritative API.
+//!
+//! # Nothing publishes names yet
+//!
+//! No DID template, DID document, or webvh record in this workspace emits an
+//! `alsoKnownAs` entry, so [`lookup`] returns `None` for every DID here today.
+//! That is expected: this is the consumer half, built so that minting names
+//! lights up every operator surface without a single display site changing.
+
+use affinidi_did_common::Document;
+use affinidi_did_resolver_cache_sdk::DIDCacheClient;
+use agent_names::extract_agent_names;
+
+use super::{DisplayName, NameSource};
+
+/// Most claimed names round-tripped for one DID.
+///
+/// A document may claim arbitrarily many names and each check is an outbound
+/// HTTPS fetch to a host the *document's author* chose — the same
+/// amplification primitive the agent-name specification bounds with a
+/// concurrency ceiling on the server side. Cap it here for the same reason.
+/// Documents in practice claim one.
+pub const MAX_CLAIMS_CHECKED: usize = 4;
+
+/// The names `doc` claims, in document order, capped at
+/// [`MAX_CLAIMS_CHECKED`].
+///
+/// Entries that are not well-formed agent names (a `did:` URI, say) are
+/// skipped rather than treated as errors — `alsoKnownAs` legitimately holds
+/// other identifier types.
+#[must_use]
+pub fn claimed_names(doc: &Document) -> Vec<String> {
+    extract_agent_names(doc)
+        .into_iter()
+        .take(MAX_CLAIMS_CHECKED)
+        .map(|n| n.as_str().to_string())
+        .collect()
+}
+
+/// Choose what to display, given each claimed name and the DID it actually
+/// resolved to.
+///
+/// `outcomes` is `(claimed_name, resolved_did)` in document order, where
+/// `None` means the name did not resolve at all. Split out from [`lookup`] so
+/// the security-relevant decision is testable without a network.
+///
+/// The first claim that resolves back to `did` wins. If none does, the first
+/// claim is reported unverified so the operator can see what the DID is
+/// asserting.
+#[must_use]
+pub fn select<'a>(
+    did: &str,
+    outcomes: impl IntoIterator<Item = (&'a str, Option<&'a str>)>,
+) -> Option<DisplayName> {
+    let mut first_claim: Option<&str> = None;
+
+    for (name, resolved) in outcomes {
+        if resolved == Some(did) {
+            return Some(DisplayName::new(
+                name,
+                NameSource::AgentName { verified: true },
+            ));
+        }
+        first_claim.get_or_insert(name);
+    }
+
+    first_claim.map(|name| DisplayName::new(name, NameSource::AgentName { verified: false }))
+}
+
+/// Resolve a display name for `did` from the agent names its document claims.
+///
+/// Returns `None` when the DID does not resolve or claims no agent name.
+/// Errors are swallowed rather than propagated: this is a *display* helper, and
+/// an unreachable name server must degrade to showing the DID, never fail the
+/// operator's command.
+///
+/// Costs one DID resolution plus up to [`MAX_CLAIMS_CHECKED`] outbound
+/// fetches, so callers gate it behind an explicit opt-in.
+pub async fn lookup(client: &DIDCacheClient, did: &str) -> Option<DisplayName> {
+    let resolved = client.resolve(did).await.ok()?;
+    let claims = claimed_names(&resolved.doc);
+    if claims.is_empty() {
+        return None;
+    }
+
+    // Resolve each claim forward. `resolve_any` performs the specification's
+    // mandatory `alsoKnownAs` check internally — but against whatever document
+    // *it* landed on, which is why the DID it returns still has to be compared
+    // with ours. A name that legitimately belongs to somebody else will
+    // resolve perfectly well; it just won't resolve to us.
+    let mut outcomes: Vec<(String, Option<String>)> = Vec::with_capacity(claims.len());
+    for name in claims {
+        let landed = client.resolve_any(&name).await.ok().map(|r| r.did);
+        let matched = landed.as_deref() == Some(did);
+        outcomes.push((name, landed));
+        if matched {
+            break; // Verified — no reason to fetch the rest.
+        }
+    }
+
+    select(
+        did,
+        outcomes.iter().map(|(n, d)| (n.as_str(), d.as_deref())),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const OURS: &str = "did:webvh:QmScidAbCdEfGh:example.com";
+    const THEIRS: &str = "did:webvh:QmOtherXyZ123:evil.example";
+
+    #[test]
+    fn a_round_tripping_claim_is_verified() {
+        let name = select(OURS, [("https://example.com/@alice", Some(OURS))]).unwrap();
+        assert_eq!(name.source, NameSource::AgentName { verified: true });
+        assert_eq!(name.name, "https://example.com/@alice");
+        assert!(name.is_trusted());
+    }
+
+    #[test]
+    fn a_claim_that_lands_on_another_did_is_not_verified() {
+        // The spoof this whole module exists for: our DID claims the bank's
+        // name, and the bank's name legitimately resolves to the bank.
+        let name = select(THEIRS, [("https://mybank.com/@treasury", Some(OURS))]).unwrap();
+        assert_eq!(name.source, NameSource::AgentName { verified: false });
+        assert!(
+            !name.is_trusted(),
+            "a name belonging to somebody else must never be shown as this DID's"
+        );
+    }
+
+    #[test]
+    fn a_claim_that_does_not_resolve_is_not_verified() {
+        let name = select(OURS, [("https://gone.example/@alice", None)]).unwrap();
+        assert_eq!(name.source, NameSource::AgentName { verified: false });
+    }
+
+    #[test]
+    fn the_verified_claim_wins_over_earlier_failures() {
+        let name = select(
+            OURS,
+            [
+                ("https://gone.example/@alice", None),
+                ("https://mybank.com/@treasury", Some(THEIRS)),
+                ("https://example.com/@real", Some(OURS)),
+            ],
+        )
+        .unwrap();
+        assert_eq!(name.source, NameSource::AgentName { verified: true });
+        assert_eq!(name.name, "https://example.com/@real");
+    }
+
+    #[test]
+    fn with_no_verified_claim_the_first_is_reported_unverified() {
+        // Surfacing the attempt is the point — an operator seeing
+        // `mybank.com/@treasury [unverified]` learns something a bare DID
+        // would not have told them.
+        let name = select(
+            OURS,
+            [
+                ("https://mybank.com/@treasury", Some(THEIRS)),
+                ("https://other.example/@x", None),
+            ],
+        )
+        .unwrap();
+        assert_eq!(name.source, NameSource::AgentName { verified: false });
+        assert_eq!(name.name, "https://mybank.com/@treasury");
+    }
+
+    #[test]
+    fn no_claims_means_no_name() {
+        assert!(select(OURS, []).is_none());
+    }
+
+    #[test]
+    fn a_document_claiming_nothing_yields_no_names() {
+        // The state of every DID in this workspace today.
+        let doc = Document::default();
+        assert!(claimed_names(&doc).is_empty());
+    }
+}

--- a/vta-sdk/src/display_name/mod.rs
+++ b/vta-sdk/src/display_name/mod.rs
@@ -1,0 +1,533 @@
+//! DID → human-readable display name.
+//!
+//! Operators read DIDs constantly and can't. Every operator-facing surface in
+//! the workspace — the PNM/CNM CLIs, the VTC operator CLI, the VTC admin UI —
+//! prints raw DIDs, each truncating them its own way. This module is the one
+//! seam they all render through.
+//!
+//! # The model: a book the caller fills, not a resolver that fetches
+//!
+//! [`NameBook`] is a plain `DID → name` map. Commands populate it from data
+//! they *already hold* and then query it while rendering. That shape is what
+//! keeps naming free: `acl list` already receives every entry with its
+//! `label`, so filling the book from that one response also names the
+//! `created_by` column — a DID that has no label of its own but is very often
+//! another entry's subject. No extra request, no N+1 lookup.
+//!
+//! Nothing here performs I/O. The one source that needs the network — a
+//! verified agent name — lives in [`agent_name`] behind the `agent-names`
+//! feature and hands its result back as a [`DisplayName`] like any other.
+//!
+//! # Where names come from today
+//!
+//! No DID document in this workspace currently publishes an `alsoKnownAs`
+//! entry, so there are no agent names to show yet. The names that exist are
+//! local: `AclEntry.label`, `ContextRecord.name`, `WebvhServerRecord.label`,
+//! the PNM/CNM per-VTA config `name`. [`NameSource`] keeps them distinguished
+//! rather than flattening them to a string, because they are not equally
+//! trustworthy — see below.
+//!
+//! # Trust
+//!
+//! A name is a claim, and the claims differ in who is making them.
+//!
+//! A local label was typed by the operator into their own store. A *verified*
+//! agent name round-tripped: the DID's document claimed it and resolving the
+//! name led back to that same DID.
+//!
+//! An **unverified** agent name is neither. `alsoKnownAs` is self-asserted —
+//! the two-sided binding in the agent-name specification protects the
+//! name→DID direction, not the reverse — so a hostile DID can claim
+//! `alsoKnownAs: ["mybank.com/@treasury"]` and anything that renders that
+//! bare has just told the operator a lie in an authoritative voice. Such
+//! names sort *below* every local source in [`NameSource::rank`] and report
+//! [`DisplayName::is_trusted`] `== false`, and [`NameBook::render_inline`]
+//! tags them. Surfaces must not strip that tag.
+
+use std::collections::HashMap;
+
+#[cfg(feature = "agent-names")]
+pub mod agent_name;
+
+/// Where a display name came from.
+///
+/// Kept as a distinct type rather than folding everything into a `String`
+/// because the sources are not equally trustworthy, and the difference has to
+/// survive all the way to the pixel — see the module-level note on trust.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NameSource {
+    /// An `alsoKnownAs` entry on the DID's own document.
+    ///
+    /// `verified` means the name was resolved forward and led back to this
+    /// same DID. `verified == false` is a bare self-assertion and is the
+    /// least trustworthy source there is.
+    AgentName { verified: bool },
+    /// `AclEntry.label` / `VtcAclEntry.label` — operator-typed, our store.
+    AclLabel,
+    /// A `DeviceBinding.display_name` from an agent device registration.
+    DeviceName,
+    /// The `name` of a locally-configured VTA / community (`~/.config/{pnm,cnm}`).
+    LocalAlias,
+    /// `WebvhServerRecord.label` — names a DID-hosting server.
+    ServerLabel,
+    /// `ContextRecord.name` — names a context, used for the context's own DID.
+    ContextName,
+}
+
+impl NameSource {
+    /// Precedence when two sources name the same DID. Higher wins.
+    ///
+    /// A verified agent name outranks everything: it is globally meaningful
+    /// and cryptographically bound to the DID, where a local label is one
+    /// operator's private note. An *unverified* agent name ranks below every
+    /// local source for the reason in the module docs — the operator's own
+    /// data must never be displaced by a stranger's unchecked claim.
+    #[must_use]
+    pub fn rank(self) -> u8 {
+        match self {
+            Self::AgentName { verified: true } => 100,
+            Self::AclLabel => 60,
+            Self::LocalAlias => 50,
+            Self::DeviceName => 45,
+            Self::ServerLabel => 40,
+            Self::ContextName => 30,
+            Self::AgentName { verified: false } => 10,
+        }
+    }
+
+    /// Stable machine-readable tag, used for the `nameSource` field in
+    /// `--json` output. Kebab-case so it reads well through `jq`.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::AgentName { verified: true } => "agent-name",
+            Self::AgentName { verified: false } => "agent-name-unverified",
+            Self::AclLabel => "acl-label",
+            Self::DeviceName => "device-name",
+            Self::LocalAlias => "local-alias",
+            Self::ServerLabel => "server-label",
+            Self::ContextName => "context-name",
+        }
+    }
+
+    /// Whether a name from this source may be shown without qualification.
+    ///
+    /// False only for an unverified agent name.
+    #[must_use]
+    pub fn is_trusted(self) -> bool {
+        !matches!(self, Self::AgentName { verified: false })
+    }
+}
+
+impl serde::Serialize for NameSource {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(self.as_str())
+    }
+}
+
+/// A name for a DID, and the provenance of that name.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DisplayName {
+    pub name: String,
+    pub source: NameSource,
+}
+
+impl DisplayName {
+    pub fn new(name: impl Into<String>, source: NameSource) -> Self {
+        Self {
+            name: name.into(),
+            source,
+        }
+    }
+
+    /// See [`NameSource::is_trusted`].
+    #[must_use]
+    pub fn is_trusted(&self) -> bool {
+        self.source.is_trusted()
+    }
+}
+
+/// Marker appended to a name that has not been verified. Surfaces may
+/// restyle it (the CLI colours it yellow) but must not drop it.
+pub const UNVERIFIED_SUFFIX: &str = " [unverified]";
+
+/// A `DID → name` map, populated by the caller from data it already holds.
+///
+/// Insertion is idempotent and order-independent: a lower-ranked source never
+/// displaces a higher-ranked one, so a command can fill the book from several
+/// responses in whatever order they arrive without the result depending on
+/// that order.
+#[derive(Debug, Clone, Default)]
+pub struct NameBook {
+    entries: HashMap<String, DisplayName>,
+}
+
+impl NameBook {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record a name for `did`, keeping whichever source ranks higher.
+    ///
+    /// Empty and whitespace-only names are dropped rather than stored: an
+    /// unset label deserialises as `Some("")` often enough that storing it
+    /// would put a blank string where the DID should be.
+    pub fn insert(&mut self, did: impl Into<String>, name: DisplayName) {
+        if name.name.trim().is_empty() {
+            return;
+        }
+        let did = did.into();
+        match self.entries.get(&did) {
+            Some(existing) if existing.source.rank() >= name.source.rank() => {}
+            _ => {
+                self.entries.insert(did, name);
+            }
+        }
+    }
+
+    /// Convenience for the common case: an `Option<String>` label straight
+    /// off a response struct.
+    pub fn insert_opt(&mut self, did: impl Into<String>, name: Option<&str>, source: NameSource) {
+        if let Some(n) = name {
+            self.insert(did, DisplayName::new(n, source));
+        }
+    }
+
+    #[must_use]
+    pub fn get(&self, did: &str) -> Option<&DisplayName> {
+        self.entries.get(did)
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Whether any DID in `dids` has a name.
+    ///
+    /// Table renderers call this to decide whether to emit a NAME column at
+    /// all — on a VTA where nothing has been labelled, a column of dashes is
+    /// worse than no column.
+    pub fn names_any<'a>(&self, dids: impl IntoIterator<Item = &'a str>) -> bool {
+        dids.into_iter().any(|d| self.entries.contains_key(d))
+    }
+
+    /// The name for `did` as a bare string, tagged when unverified.
+    ///
+    /// Returns `None` when the DID has no name, so callers can decide between
+    /// a placeholder and the shortened DID.
+    #[must_use]
+    pub fn name_of(&self, did: &str) -> Option<String> {
+        self.entries.get(did).map(|n| {
+            if n.is_trusted() {
+                n.name.clone()
+            } else {
+                format!("{}{UNVERIFIED_SUFFIX}", n.name)
+            }
+        })
+    }
+
+    /// One-line rendering for prose and confirmations:
+    /// `mediator-prod (did:webvh:QmXk…9f2:example.com)`.
+    ///
+    /// Falls back to the shortened DID alone when there is no name. The DID is
+    /// always present — a name the operator cannot cross-check against an
+    /// identifier is a name they cannot audit.
+    #[must_use]
+    pub fn render_inline(&self, did: &str) -> String {
+        match self.name_of(did) {
+            Some(name) => format!("{name} ({})", shorten_did(did)),
+            None => shorten_did(did),
+        }
+    }
+}
+
+/// Shorten a DID for a fixed-width cell while keeping the part that
+/// identifies it.
+///
+/// A `did:webvh` / `did:web` carries its meaning in the *tail* — the domain
+/// and path, e.g. `…:webvh.storm.ws:glenn-vta` — and its noise in the middle:
+/// the SCID, a content hash. So the SCID is abbreviated and everything after
+/// it kept verbatim. That is the opposite of a CSS-style trailing ellipsis,
+/// which clips off precisely the informative half.
+///
+/// Other methods (`did:key` and friends) have no human tail, so the opaque id
+/// is middle-truncated instead, keeping a head and a tail so an operator can
+/// still tell two of them apart at a glance.
+///
+/// Inputs that aren't DIDs, and DIDs already short enough, are returned
+/// unchanged. This is a port of `shortenDid` in
+/// `vtc-service/admin-ui/src/lib/format.ts`; the two are pinned to identical
+/// output by a shared vector table (see the tests below and `format.test.ts`).
+#[must_use]
+pub fn shorten_did(did: &str) -> String {
+    shorten_did_keep(did, DEFAULT_KEEP)
+}
+
+/// Number of leading characters kept from an opaque DID segment.
+pub const DEFAULT_KEEP: usize = 10;
+
+/// Trailing characters kept when middle-truncating a non-`webvh` DID.
+const TAIL: usize = 6;
+
+#[must_use]
+pub fn shorten_did_keep(did: &str, keep: usize) -> String {
+    if !did.starts_with("did:") {
+        return did.to_string();
+    }
+    let parts: Vec<&str> = did.split(':').collect();
+    let method = parts.get(1).copied().unwrap_or_default();
+
+    if (method == "webvh" || method == "web") && parts.len() > 3 {
+        let scid = parts[2];
+        if char_len(scid) <= keep + 1 {
+            return did.to_string();
+        }
+        let mut out = parts.clone();
+        let abbreviated = format!("{}…", take_chars(scid, keep));
+        out[2] = &abbreviated;
+        return out.join(":");
+    }
+
+    // `did:<method>:<id>`, where `<id>` may itself contain colons.
+    let id = parts[2..].join(":");
+    if char_len(&id) <= keep + TAIL + 1 {
+        return did.to_string();
+    }
+    format!(
+        "{}:{}:{}…{}",
+        parts[0],
+        method,
+        take_chars(&id, keep),
+        take_last_chars(&id, TAIL)
+    )
+}
+
+fn char_len(s: &str) -> usize {
+    s.chars().count()
+}
+
+fn take_chars(s: &str, n: usize) -> String {
+    s.chars().take(n).collect()
+}
+
+fn take_last_chars(s: &str, n: usize) -> String {
+    let len = char_len(s);
+    s.chars().skip(len.saturating_sub(n)).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── shorten_did ─────────────────────────────────────────────────
+    //
+    // This table is duplicated verbatim in
+    // `vtc-service/admin-ui/src/lib/format.test.ts`. The Rust CLI and the
+    // React admin UI show the same operator the same DIDs; if they abbreviate
+    // differently, the operator cannot tell whether two screens are showing
+    // one identity or two. Change one side and you must change the other.
+    const VECTORS: &[(&str, &str)] = &[
+        // Not a DID — untouched.
+        ("alice", "alice"),
+        ("https://example.com/@alice", "https://example.com/@alice"),
+        // webvh: SCID abbreviated, domain + path tail kept in full.
+        (
+            "did:webvh:QmXkAbCdEfGhIjKlMnOp:webvh.storm.ws:glenn-vta",
+            "did:webvh:QmXkAbCdEf…:webvh.storm.ws:glenn-vta",
+        ),
+        // web: same rule.
+        (
+            "did:web:QmXkAbCdEfGhIjKlMnOp:example.com",
+            "did:web:QmXkAbCdEf…:example.com",
+        ),
+        // webvh with a short SCID — nothing to gain, left alone.
+        ("did:webvh:Qm123:example.com", "did:webvh:Qm123:example.com"),
+        // did:key — no human tail, so middle-truncate head + tail.
+        (
+            "did:key:z6MkfrQjWzPQrTuVwXyZaBcDeFgHiJkLmNoPqRsTuVwXyZ4rT",
+            "did:key:z6MkfrQjWz…XyZ4rT",
+        ),
+        // Short did:key — under the threshold, untouched.
+        ("did:key:z6MkfrQjWz", "did:key:z6MkfrQjWz"),
+        // A webvh DID with only 3 segments has no domain tail to protect, so
+        // it falls through to the generic middle-truncating arm.
+        (
+            "did:webvh:QmXkAbCdEfGhIjKlMnOpQrSt",
+            "did:webvh:QmXkAbCdEf…OpQrSt",
+        ),
+    ];
+
+    #[test]
+    fn shorten_did_matches_shared_vectors() {
+        for (input, expected) in VECTORS {
+            assert_eq!(&shorten_did(input), expected, "input: {input}");
+        }
+    }
+
+    #[test]
+    fn shorten_did_is_char_safe() {
+        // Non-ASCII in the opaque segment must not panic on a byte boundary.
+        let did = "did:key:zÄÖÜäöüßÅÆØåæøΩμλ0123456789";
+        let out = shorten_did(did);
+        assert!(out.starts_with("did:key:"));
+        assert!(out.contains('…'));
+    }
+
+    // ── NameSource precedence ───────────────────────────────────────
+
+    #[test]
+    fn verified_agent_name_outranks_local_label() {
+        assert!(
+            NameSource::AgentName { verified: true }.rank() > NameSource::AclLabel.rank(),
+            "a cryptographically bound global name beats one operator's private note"
+        );
+    }
+
+    #[test]
+    fn unverified_agent_name_ranks_below_every_local_source() {
+        let unverified = NameSource::AgentName { verified: false }.rank();
+        for local in [
+            NameSource::AclLabel,
+            NameSource::DeviceName,
+            NameSource::LocalAlias,
+            NameSource::ServerLabel,
+            NameSource::ContextName,
+        ] {
+            assert!(
+                local.rank() > unverified,
+                "{local:?} must not be displaced by an unchecked claim"
+            );
+        }
+    }
+
+    #[test]
+    fn only_unverified_agent_names_are_untrusted() {
+        assert!(!NameSource::AgentName { verified: false }.is_trusted());
+        assert!(NameSource::AgentName { verified: true }.is_trusted());
+        assert!(NameSource::AclLabel.is_trusted());
+    }
+
+    // ── NameBook ────────────────────────────────────────────────────
+
+    const DID_A: &str = "did:key:z6MkfrQjWzPQrTuVwXyZaBcDeFgHiJkLmNoPqRsTuVwXyZ4rT";
+
+    #[test]
+    fn insert_is_order_independent() {
+        let strong = DisplayName::new(
+            "agent.example/@ops",
+            NameSource::AgentName { verified: true },
+        );
+        let weak = DisplayName::new("my-note", NameSource::AclLabel);
+
+        let mut a = NameBook::new();
+        a.insert(DID_A, weak.clone());
+        a.insert(DID_A, strong.clone());
+
+        let mut b = NameBook::new();
+        b.insert(DID_A, strong.clone());
+        b.insert(DID_A, weak);
+
+        assert_eq!(a.get(DID_A), b.get(DID_A));
+        assert_eq!(a.get(DID_A), Some(&strong));
+    }
+
+    #[test]
+    fn unverified_claim_never_displaces_an_operator_label() {
+        let mut book = NameBook::new();
+        book.insert(DID_A, DisplayName::new("payroll-bot", NameSource::AclLabel));
+        book.insert(
+            DID_A,
+            DisplayName::new(
+                "mybank.com/@treasury",
+                NameSource::AgentName { verified: false },
+            ),
+        );
+        assert_eq!(
+            book.get(DID_A).map(|n| n.name.as_str()),
+            Some("payroll-bot")
+        );
+    }
+
+    #[test]
+    fn unverified_names_are_tagged_when_rendered() {
+        let mut book = NameBook::new();
+        book.insert(
+            DID_A,
+            DisplayName::new(
+                "mybank.com/@treasury",
+                NameSource::AgentName { verified: false },
+            ),
+        );
+        let rendered = book.name_of(DID_A).unwrap();
+        assert!(
+            rendered.contains("unverified"),
+            "a self-asserted name must never render bare: {rendered}"
+        );
+        assert!(book.render_inline(DID_A).contains("unverified"));
+    }
+
+    #[test]
+    fn blank_labels_are_not_stored() {
+        let mut book = NameBook::new();
+        book.insert(DID_A, DisplayName::new("", NameSource::AclLabel));
+        book.insert(DID_A, DisplayName::new("   ", NameSource::AclLabel));
+        assert!(book.is_empty(), "a blank label must not shadow the DID");
+    }
+
+    #[test]
+    fn insert_opt_skips_none() {
+        let mut book = NameBook::new();
+        book.insert_opt(DID_A, None, NameSource::AclLabel);
+        assert!(book.is_empty());
+        book.insert_opt(DID_A, Some("ops"), NameSource::AclLabel);
+        assert_eq!(book.len(), 1);
+    }
+
+    #[test]
+    fn render_inline_always_shows_the_did() {
+        let mut book = NameBook::new();
+        book.insert(DID_A, DisplayName::new("ops", NameSource::AclLabel));
+        let rendered = book.render_inline(DID_A);
+        assert!(rendered.starts_with("ops ("));
+        assert!(
+            rendered.contains("did:key:"),
+            "the operator must be able to audit the name against an identifier"
+        );
+    }
+
+    #[test]
+    fn render_inline_falls_back_to_the_shortened_did() {
+        let book = NameBook::new();
+        assert_eq!(book.render_inline(DID_A), shorten_did(DID_A));
+    }
+
+    #[test]
+    fn names_any_drives_the_optional_name_column() {
+        let mut book = NameBook::new();
+        assert!(!book.names_any([DID_A, "did:key:zOther"]));
+        book.insert(DID_A, DisplayName::new("ops", NameSource::AclLabel));
+        assert!(book.names_any([DID_A, "did:key:zOther"]));
+        assert!(!book.names_any(["did:key:zOther"]));
+    }
+
+    #[test]
+    fn name_source_json_tags_are_stable() {
+        // These strings appear in `--json` output; scripts key off them.
+        assert_eq!(
+            serde_json::to_string(&NameSource::AgentName { verified: false }).unwrap(),
+            "\"agent-name-unverified\""
+        );
+        assert_eq!(
+            serde_json::to_string(&NameSource::AclLabel).unwrap(),
+            "\"acl-label\""
+        );
+    }
+}

--- a/vta-sdk/src/display_name/mod.rs
+++ b/vta-sdk/src/display_name/mod.rs
@@ -263,9 +263,14 @@ impl NameBook {
 /// still tell two of them apart at a glance.
 ///
 /// Inputs that aren't DIDs, and DIDs already short enough, are returned
-/// unchanged. This is a port of `shortenDid` in
-/// `vtc-service/admin-ui/src/lib/format.ts`; the two are pinned to identical
-/// output by a shared vector table (see the tests below and `format.test.ts`).
+/// unchanged.
+///
+/// This is a port of `shortenDid` in
+/// `vtc-service/admin-ui/src/lib/format.ts`. The two must agree — an operator
+/// moves between a terminal and the admin console looking at the same
+/// community, and a DID abbreviated two ways is one they re-identify on every
+/// switch. The vector table in the tests below is the authority (the console
+/// has no test runner); it is reproduced in that file's doc comment.
 #[must_use]
 pub fn shorten_did(did: &str) -> String {
     shorten_did_keep(did, DEFAULT_KEEP)
@@ -329,8 +334,9 @@ mod tests {
 
     // ── shorten_did ─────────────────────────────────────────────────
     //
-    // This table is duplicated verbatim in
-    // `vtc-service/admin-ui/src/lib/format.test.ts`. The Rust CLI and the
+    // These vectors are reproduced in the doc comment on `shortenDid` in
+    // `vtc-service/admin-ui/src/lib/format.ts`, which has no test runner of
+    // its own — this test is the authority for both. The Rust CLIs and the
     // React admin UI show the same operator the same DIDs; if they abbreviate
     // differently, the operator cannot tell whether two screens are showing
     // one identity or two. Change one side and you must change the other.

--- a/vta-sdk/src/lib.rs
+++ b/vta-sdk/src/lib.rs
@@ -105,10 +105,15 @@ pub mod credentials;
 pub mod did_key;
 pub mod did_secrets;
 pub mod did_templates;
+// DID → human-readable display name. The single seam every operator-facing
+// surface (PNM/CNM CLIs, VTC operator CLI, VTC admin UI) renders DIDs
+// through. Core is dependency-light and always compiled; the one source that
+// needs the network (a verified agent name) is behind `agent-names`.
 #[cfg(feature = "client")]
 pub mod didcomm_light;
 #[cfg(feature = "session")]
 pub mod didcomm_session;
+pub mod display_name;
 // Pins rustls to the aws-lc-rs backend; every binary calls this at startup.
 #[cfg(feature = "crypto-provider")]
 pub mod crypto_init;

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.12.20"
+version = "0.12.21"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/bootstrap_cli.rs
+++ b/vta-service/src/bootstrap_cli.rs
@@ -946,6 +946,7 @@ pub async fn run_context_delete(
     use crate::auth::AuthClaims;
     use crate::operations::Keyspaces;
     use vta_cli_common::commands::contexts::{confirm_destructive, render_delete_context_preview};
+    use vta_cli_common::display::{NameBook, NameSource};
 
     let app_config = AppConfig::load(config_path)?;
     let store = Store::open(&app_config.store)?;
@@ -973,7 +974,18 @@ pub async fn run_context_delete(
     )
     .await?;
 
-    let has_resources = render_delete_context_preview(&id, &preview);
+    // Name the DIDs in the confirmation prompt from the local ACL rows. The
+    // offline path is exactly as destructive as the online one, so it gets
+    // the same help deciding. Best-effort — a read failure degrades to bare
+    // DIDs rather than blocking the delete.
+    let mut book = NameBook::new();
+    if let Ok(entries) = vti_common::acl::list_acl_entries(&acl_ks).await {
+        for entry in &entries {
+            book.insert_opt(&entry.did, entry.label.as_deref(), NameSource::AclLabel);
+        }
+    }
+
+    let has_resources = render_delete_context_preview(&id, &preview, &book);
     if has_resources && !force && !confirm_destructive("Proceed with deletion?")? {
         println!("Aborted.");
         return Ok(());

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.11.19"
+version = "0.11.20"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vtc-service/admin-ui/src/App.tsx
+++ b/vtc-service/admin-ui/src/App.tsx
@@ -7,6 +7,7 @@ import { getPlugins, subscribePlugins, type PluginManifest } from "@/plugin-api"
 import { PluginHost } from "@/components/PluginHost";
 import { ThemeSwitcher } from "@/components/ThemeSwitcher";
 import { probeSession, signOut, WhoamiResponse } from "@/lib/api";
+import { shortenDid } from "@/lib/format";
 import { reloadThirdPartyPlugins } from "@/lib/plugin-loader";
 import { useToast } from "@/lib/toast";
 import { Install } from "@/pages/Install";
@@ -282,7 +283,7 @@ function SessionBadge({ whoami }: { whoami: WhoamiResponse }) {
     <div className="session-badge">
       <div className="session-did" title={whoami.did}>
         <span className="session-label">Signed in as</span>
-        <code>{shortDid(whoami.did)}</code>
+        <code>{shortenDid(whoami.did)}</code>
       </div>
       <button
         type="button"
@@ -336,14 +337,6 @@ function ReloadPluginsButton() {
       </button>
     </div>
   );
-}
-
-function shortDid(did: string): string {
-  // `did:key:z6Mk…XYZ` — keep the method prefix readable + the
-  // last 6 chars so two distinct admins are still visually
-  // distinguishable in the navbar.
-  if (did.length <= 20) return did;
-  return `${did.slice(0, 12)}…${did.slice(-6)}`;
 }
 
 function SignInLoading() {

--- a/vtc-service/admin-ui/src/components/NamedDid.tsx
+++ b/vtc-service/admin-ui/src/components/NamedDid.tsx
@@ -1,0 +1,53 @@
+// Render a DID as its name, with the identifier still visible.
+//
+// One component so every table, dialog and detail pane in the console agrees
+// on what a principal looks like. Drop-in for the `<code className="truncate"
+// title={did}>{did}</code>` pattern the plugins used before.
+//
+// Two rules it enforces, both from `vta_sdk::display_name`:
+//
+//   * **The DID is never hidden.** A name the operator cannot cross-check
+//     against an identifier is a name they cannot audit — and these screens
+//     are where ACL grants get approved and members admitted. The name leads,
+//     the abbreviated DID follows, the full DID is in the tooltip.
+//
+//   * **An unverified name is marked.** `alsoKnownAs` is self-asserted, so a
+//     name that has not round-tripped carries its `[unverified]` suffix and a
+//     warning style. Seeing that a DID *claims* to be `mybank.com/@treasury`
+//     is useful; being told it *is* would be a lie.
+
+import { shortenDid } from "@/lib/format";
+import { isTrusted, type NameBook } from "@/lib/names";
+
+interface NamedDidProps {
+  book: NameBook;
+  did: string;
+  /** Omit the abbreviated DID and show the name alone. Only for places that
+   *  render the DID separately in the same row — never to save space. */
+  nameOnly?: boolean;
+  className?: string;
+}
+
+export function NamedDid({ book, did, nameOnly, className }: NamedDidProps) {
+  const entry = book.get(did);
+  const name = book.nameOf(did);
+
+  if (!name) {
+    return (
+      <code className={`truncate ${className ?? ""}`} title={did}>
+        {shortenDid(did)}
+      </code>
+    );
+  }
+
+  const untrusted = entry && !isTrusted(entry.source);
+
+  return (
+    <span className={`named-did ${className ?? ""}`} title={did}>
+      <span className={untrusted ? "named-did-name unverified" : "named-did-name"}>
+        {name}
+      </span>
+      {!nameOnly && <code className="named-did-id">{shortenDid(did)}</code>}
+    </span>
+  );
+}

--- a/vtc-service/admin-ui/src/lib/format.ts
+++ b/vtc-service/admin-ui/src/lib/format.ts
@@ -32,6 +32,28 @@ export function shorten(value: string, head = 8, tail = 4): string {
  * - `did:key:<multibase>` (and other 3-segment DIDs) → middle-truncate the id,
  *   keeping `keep` head + 6 tail chars.
  * - Non-DID input and already-short DIDs are returned unchanged.
+ *
+ * ## Kept in step with Rust
+ *
+ * `vta_sdk::display_name::shorten_did` is a port of this function, used by
+ * `pnm`, `cnm` and the `vtc` CLI. An operator moves between a terminal and
+ * this console looking at the same community; if the two abbreviate
+ * differently, every DID has to be re-identified on the way across.
+ *
+ * The vectors below are asserted in `shorten_did_matches_shared_vectors`
+ * (`vta-sdk/src/display_name/mod.rs`), which is the authority — this console
+ * has no test runner. Change either implementation and check both:
+ *
+ *   "alice"                                        -> "alice"
+ *   "did:webvh:QmXkAbCdEfGhIjKlMnOp:webvh.storm.ws:glenn-vta"
+ *                          -> "did:webvh:QmXkAbCdEf…:webvh.storm.ws:glenn-vta"
+ *   "did:web:QmXkAbCdEfGhIjKlMnOp:example.com"
+ *                                    -> "did:web:QmXkAbCdEf…:example.com"
+ *   "did:webvh:Qm123:example.com"           -> "did:webvh:Qm123:example.com"
+ *   "did:key:z6MkfrQjWzPQrTuVwXyZaBcDeFgHiJkLmNoPqRsTuVwXyZ4rT"
+ *                                       -> "did:key:z6MkfrQjWz…XyZ4rT"
+ *   "did:key:z6MkfrQjWz"                       -> "did:key:z6MkfrQjWz"
+ *   "did:webvh:QmXkAbCdEfGhIjKlMnOpQrSt" -> "did:webvh:QmXkAbCdEf…OpQrSt"
  */
 export function shortenDid(did: string, keep = 10): string {
   if (!did.startsWith("did:")) return did;

--- a/vtc-service/admin-ui/src/lib/names.ts
+++ b/vtc-service/admin-ui/src/lib/names.ts
@@ -1,0 +1,185 @@
+// DID → human-readable display name, for the admin console.
+//
+// Mirrors `vta_sdk::display_name` on the Rust side — same sources, same
+// precedence, same trust rules. The two must agree: an operator moves between
+// `vtc acl list` in a terminal and this console looking at the same community,
+// and a DID that is "payroll-bot" in one place and an opaque string in the
+// other is a DID they have to re-identify every time they switch.
+//
+// # The model
+//
+// A `NameBook` is a `DID → name` map built from responses the console has
+// already fetched. It is not a resolver and performs no lookups of its own:
+// `useNameBook()` reads the members and ACL listings — two requests, shared
+// and cached by react-query across every plugin — and every DID rendered
+// anywhere in the console resolves against that.
+//
+// # Trust
+//
+// Sources are not equally trustworthy, so `NameSource` is kept rather than
+// flattened to a string. A label was typed by an operator into this
+// community's own store. A *verified* agent name round-tripped: the DID's
+// document claimed it and resolving that name led back to the same DID.
+//
+// An **unverified** agent name is neither. `alsoKnownAs` is self-asserted —
+// the agent-name specification's two-sided binding protects the name→DID
+// direction, not the reverse — so a hostile DID can claim
+// `mybank.com/@treasury`. Such names rank below every local source and must
+// render with their `[unverified]` marker intact; `nameOf` attaches it, and
+// no caller should strip it.
+//
+// Nothing in this deployment publishes `alsoKnownAs` yet, so agent names do
+// not appear here today. The shape is in place so they light up without a
+// change to any render site.
+
+import { useQuery } from "@tanstack/react-query";
+
+import { getJson } from "@/lib/api";
+import { shortenDid } from "@/lib/format";
+
+export type NameSource =
+  | "agent-name"
+  | "agent-name-unverified"
+  | "acl-label"
+  | "device-name"
+  | "local-alias"
+  | "server-label"
+  | "context-name";
+
+/** Precedence when two sources name the same DID. Higher wins.
+ *  Must stay in step with `NameSource::rank` in Rust. */
+const RANK: Record<NameSource, number> = {
+  "agent-name": 100,
+  "acl-label": 60,
+  "local-alias": 50,
+  "device-name": 45,
+  "server-label": 40,
+  "context-name": 30,
+  // Lowest by a wide margin: an unchecked claim must never displace the
+  // operator's own data.
+  "agent-name-unverified": 10,
+};
+
+/** Whether a name from this source may be shown without qualification. */
+export function isTrusted(source: NameSource): boolean {
+  return source !== "agent-name-unverified";
+}
+
+export interface DisplayName {
+  name: string;
+  source: NameSource;
+}
+
+/** Marker appended to an unverified name. Restyle it if you like; do not
+ *  drop it. */
+export const UNVERIFIED_SUFFIX = " [unverified]";
+
+export class NameBook {
+  private entries = new Map<string, DisplayName>();
+
+  /** Record a name, keeping whichever source ranks higher. Idempotent and
+   *  order-independent, so books can be merged from several responses in
+   *  whatever order they arrive. Blank names are dropped — an unset label
+   *  often arrives as `""`, and storing it would blank out the DID. */
+  insert(did: string, name: string | null | undefined, source: NameSource): void {
+    if (!name || !name.trim()) return;
+    const existing = this.entries.get(did);
+    if (existing && RANK[existing.source] >= RANK[source]) return;
+    this.entries.set(did, { name: name.trim(), source });
+  }
+
+  get(did: string): DisplayName | undefined {
+    return this.entries.get(did);
+  }
+
+  get size(): number {
+    return this.entries.size;
+  }
+
+  /** The name for `did`, tagged when unverified. `undefined` when unnamed,
+   *  so callers choose between a placeholder and the shortened DID. */
+  nameOf(did: string): string | undefined {
+    const entry = this.entries.get(did);
+    if (!entry) return undefined;
+    return isTrusted(entry.source) ? entry.name : `${entry.name}${UNVERIFIED_SUFFIX}`;
+  }
+
+  /** Whether any of `dids` has a name — drives whether a table gives up a
+   *  column to names at all. A column of dashes is worse than no column. */
+  namesAny(dids: Iterable<string>): boolean {
+    for (const did of dids) if (this.entries.has(did)) return true;
+    return false;
+  }
+
+  /** Name where we have one, shortened DID otherwise. For a cell that has no
+   *  room for both. */
+  nameOrDid(did: string): string {
+    return this.nameOf(did) ?? shortenDid(did);
+  }
+}
+
+// ── The shared book ─────────────────────────────────────────────────
+
+interface NamedMember {
+  did: string;
+  label: string | null;
+}
+
+interface NamedAclEntry {
+  subject: string;
+  label?: string | null;
+}
+
+const MEMBERS_TASK = "https://trusttasks.org/spec/vtc/members/list/0.1";
+const ACL_TASK = "https://trusttasks.org/spec/acl/list/0.1";
+
+/**
+ * The console-wide `NameBook`.
+ *
+ * Two requests — the member list and the ACL list — cover every principal
+ * this community knows by name. react-query shares one copy across every
+ * plugin that calls this, so a page rendering members, sessions and audit
+ * side by side still pays for it once.
+ *
+ * Failures are swallowed: naming is decoration, and an admin who can read
+ * sessions but not the ACL must still get their table. The book simply comes
+ * back smaller, and DIDs render bare.
+ */
+export function useNameBook(): NameBook {
+  const query = useQuery({
+    queryKey: ["name-book"],
+    queryFn: async () => {
+      const book = new NameBook();
+
+      const [members, acl] = await Promise.allSettled([
+        getJson<{ items: NamedMember[] }>("/v1/members?limit=500", {
+          trustTask: MEMBERS_TASK,
+        }),
+        getJson<{ entries: NamedAclEntry[] }>("/v1/acl", {
+          trustTask: ACL_TASK,
+        }),
+      ]);
+
+      if (members.status === "fulfilled") {
+        for (const m of members.value.items ?? []) {
+          book.insert(m.did, m.label, "acl-label");
+        }
+      }
+      if (acl.status === "fulfilled") {
+        for (const e of acl.value.entries ?? []) {
+          book.insert(e.subject, e.label, "acl-label");
+        }
+      }
+      return book;
+    },
+    // Labels change rarely and this is decoration on every other view;
+    // refetching it on each mount would triple the console's request count.
+    staleTime: 60_000,
+  });
+
+  return query.data ?? EMPTY_BOOK;
+}
+
+/** Shared empty book, so `useNameBook()` never returns a fresh object while
+ *  loading — a new identity each render would defeat memoisation downstream. */
+const EMPTY_BOOK = new NameBook();

--- a/vtc-service/admin-ui/src/plugins/audit.tsx
+++ b/vtc-service/admin-ui/src/plugins/audit.tsx
@@ -16,6 +16,8 @@ import { ClipboardList, RefreshCw } from "lucide-react";
 
 import { getJson } from "@/lib/api";
 import { formatIso } from "@/lib/format";
+import { useNameBook } from "@/lib/names";
+import { NamedDid } from "@/components/NamedDid";
 import { useToast } from "@/lib/toast";
 
 // Human-readable label per event kind. Falls through to the
@@ -310,6 +312,7 @@ export function Audit() {
 }
 
 function AuditRow({ env }: { env: AuditEntry }) {
+  const nameBook = useNameBook();
   const [open, setOpen] = useState(false);
   const kind = env.action;
   const description = EVENT_DESCRIPTIONS[kind];
@@ -332,9 +335,7 @@ function AuditRow({ env }: { env: AuditEntry }) {
         </td>
         <td>
           {env.actor ? (
-            <code className="truncate" title={env.actor}>
-              {env.actor}
-            </code>
+            <NamedDid book={nameBook} did={env.actor} />
           ) : (
             <span className="muted" title="Redacted by RTBF">
               redacted
@@ -343,9 +344,7 @@ function AuditRow({ env }: { env: AuditEntry }) {
         </td>
         <td>
           {env.target ? (
-            <code className="truncate" title={env.target}>
-              {env.target}
-            </code>
+            <NamedDid book={nameBook} did={env.target} />
           ) : env.ext?.vtc?.targetDidHash ? (
             <span className="muted" title="Redacted by RTBF">
               redacted

--- a/vtc-service/admin-ui/src/plugins/invitations.tsx
+++ b/vtc-service/admin-ui/src/plugins/invitations.tsx
@@ -19,6 +19,8 @@ import {
 } from "@/lib/api";
 import { CopyButton } from "@/components/CopyButton";
 import { useToast } from "@/lib/toast";
+import { useNameBook } from "@/lib/names";
+import { NamedDid } from "@/components/NamedDid";
 
 /// QR capacity ceiling: a version-40 QR at error-correction level L holds
 /// ~2,953 bytes. A signed VIC is typically ~1.5–2.5 KB, so it usually fits; we
@@ -27,6 +29,7 @@ import { useToast } from "@/lib/toast";
 const QR_MAX_CHARS = 2900;
 
 export function Invitations() {
+  const nameBook = useNameBook();
   const toast = useToast();
   const queryClient = useQueryClient();
   const [did, setDid] = useState("");
@@ -128,7 +131,7 @@ export function Invitations() {
 
       {result && (
         <section className="card">
-          <h3>Invitation for {result.subjectDid}</h3>
+          <h3>Invitation for {nameBook.nameOrDid(result.subjectDid)}</h3>
           {result.validUntil && (
             <p className="muted">
               Valid until <code>{result.validUntil}</code>
@@ -177,7 +180,7 @@ export function Invitations() {
               {invitations.data.map((inv: InvitationListItem) => (
                 <tr key={inv.id}>
                   <td>
-                    <code className="truncate">{inv.subjectDid}</code>
+                    <NamedDid book={nameBook} did={inv.subjectDid} />
                   </td>
                   <td>{inv.role ?? "member"}</td>
                   <td>{inv.issuedAt.slice(0, 10)}</td>

--- a/vtc-service/admin-ui/src/plugins/joinRequests.tsx
+++ b/vtc-service/admin-ui/src/plugins/joinRequests.tsx
@@ -17,6 +17,8 @@ import { ArrowLeft, ArrowRight, Inbox } from "lucide-react";
 import { getJson, postJson } from "@/lib/api";
 import { useConfirm } from "@/components/ConfirmDialog";
 import { formatIso as formatDate } from "@/lib/format";
+import { useNameBook } from "@/lib/names";
+import { NamedDid } from "@/components/NamedDid";
 
 const TRUST_TASK_SUBMIT =
   "https://trusttasks.org/spec/vtc/join-requests/list/0.1";
@@ -107,6 +109,7 @@ export function JoinRequests() {
 }
 
 function JoinRequestsList() {
+  const nameBook = useNameBook();
   const [status, setStatus] = useState<JoinStatus>("pending");
   const [cursor, setCursor] = useState<string | null>(null);
   const limit = 50;
@@ -185,9 +188,7 @@ function JoinRequestsList() {
               <tr key={r.id}>
                 <td>
                   <Link to={r.id}>
-                    <code className="truncate" title={r.applicantDid}>
-                      {r.applicantDid}
-                    </code>
+                    <NamedDid book={nameBook} did={r.applicantDid} />
                   </Link>
                 </td>
                 <td>{formatDate(r.submittedAt)}</td>

--- a/vtc-service/admin-ui/src/plugins/members.tsx
+++ b/vtc-service/admin-ui/src/plugins/members.tsx
@@ -24,7 +24,7 @@ import {
 
 import { deleteJson, getJson, postJson } from "@/lib/api";
 import { useConfirm } from "@/components/ConfirmDialog";
-import { formatIso as formatDate } from "@/lib/format";
+import { formatIso as formatDate, shortenDid } from "@/lib/format";
 import {
   decodePublicKeyOptions,
   serializeAssertion,
@@ -325,9 +325,13 @@ function MembersList() {
         <table className="data-table">
           <thead>
             <tr>
+              {/* Name leads: it is what an operator is looking for. The DID
+                  stays in its own column rather than being replaced by the
+                  name — a member you cannot check against an identifier is a
+                  member you cannot audit. */}
+              <th>Name</th>
               <th>DID</th>
               <th>Role</th>
-              <th>Label</th>
               <th>Joined</th>
               <th>Personhood</th>
             </tr>
@@ -357,9 +361,7 @@ function MembersList() {
             {query.data?.items.map((m) => (
               <tr key={m.did}>
                 <td>
-                  <Link to={encodeURIComponent(m.did)}>
-                    <code className="truncate">{m.did}</code>
-                  </Link>
+                  {m.label ?? <span className="muted">—</span>}
                   {m.joinedViaInvitation && (
                     <Ticket
                       size={14}
@@ -371,9 +373,15 @@ function MembersList() {
                   )}
                 </td>
                 <td>
+                  <Link to={encodeURIComponent(m.did)}>
+                    <code className="truncate" title={m.did}>
+                      {shortenDid(m.did)}
+                    </code>
+                  </Link>
+                </td>
+                <td>
                   <code>{m.role}</code>
                 </td>
-                <td>{m.label ?? "—"}</td>
                 <td>{formatDate(m.joinedAt)}</td>
                 <td>
                   {m.personhood ? (

--- a/vtc-service/admin-ui/src/plugins/relationshipsGraph.tsx
+++ b/vtc-service/admin-ui/src/plugins/relationshipsGraph.tsx
@@ -11,7 +11,8 @@ import { useQuery } from "@tanstack/react-query";
 import { Share2 } from "lucide-react";
 
 import { fetchRelationshipsGraph, type RelationshipsGraph } from "@/lib/api";
-import { shorten } from "@/lib/format";
+import { useNameBook } from "@/lib/names";
+import { NamedDid } from "@/components/NamedDid";
 
 const SIZE = 600;
 const C = SIZE / 2;
@@ -24,6 +25,7 @@ interface Placed {
 }
 
 export function Relationships() {
+  const nameBook = useNameBook();
   const [selected, setSelected] = useState<string | null>(null);
 
   const query = useQuery<RelationshipsGraph>({
@@ -157,7 +159,7 @@ export function Relationships() {
                     fontSize="10"
                     fill="var(--text-muted)"
                   >
-                    {shorten(p.did, 8, 4)}
+                    {nameBook.nameOrDid(p.did)}
                   </text>
                 </g>
               );
@@ -179,7 +181,7 @@ export function Relationships() {
             {selected && (
               <>
                 <p>
-                  <code className="truncate">{selected}</code>
+                  <NamedDid book={nameBook} did={selected} />
                 </p>
                 {selectedEdges.length === 0 ? (
                   <p className="muted">No relationships.</p>
@@ -190,12 +192,12 @@ export function Relationships() {
                         {e.issuerDid === selected ? (
                           <>
                             → vouched for{" "}
-                            <code>{shorten(e.subjectDid, 8, 4)}</code>
+                            <code>{nameBook.nameOrDid(e.subjectDid)}</code>
                           </>
                         ) : (
                           <>
                             ← vouched for by{" "}
-                            <code>{shorten(e.issuerDid, 8, 4)}</code>
+                            <code>{nameBook.nameOrDid(e.issuerDid)}</code>
                           </>
                         )}
                       </li>

--- a/vtc-service/admin-ui/src/plugins/sessions.tsx
+++ b/vtc-service/admin-ui/src/plugins/sessions.tsx
@@ -18,6 +18,8 @@ import { ArrowDown, ArrowUp, ArrowUpDown, Smartphone } from "lucide-react";
 import { deleteJson, getJson, WhoamiResponse } from "@/lib/api";
 import { useConfirm } from "@/components/ConfirmDialog";
 import { formatEpoch, shorten as shortId } from "@/lib/format";
+import { useNameBook } from "@/lib/names";
+import { NamedDid } from "@/components/NamedDid";
 import { useToast } from "@/lib/toast";
 
 type SortKey = "did" | "state" | "createdAt" | "refreshExpiresAt";
@@ -59,6 +61,7 @@ async function revokeAllForDid(did: string): Promise<void> {
 }
 
 export function Sessions() {
+  const nameBook = useNameBook();
   const qc = useQueryClient();
   const toast = useToast();
   const confirm = useConfirm();
@@ -262,9 +265,7 @@ export function Sessions() {
                 return (
                   <tr key={s.sessionId}>
                     <td>
-                      <code className="truncate" title={s.did}>
-                        {s.did}
-                      </code>
+                      <NamedDid book={nameBook} did={s.did} />
                       {s.did === myDid && (
                         <span className="chip accent" title="Your DID">
                           you

--- a/vtc-service/admin-ui/src/styles.css
+++ b/vtc-service/admin-ui/src/styles.css
@@ -1104,6 +1104,36 @@ select {
   vertical-align: bottom;
 }
 
+/* A DID shown as its display name. The name leads; the abbreviated
+   identifier follows in muted monospace so the operator can still audit what
+   they are looking at. Never style the identifier to `display: none` — see
+   the note in `components/NamedDid.tsx`. */
+.named-did {
+  display: inline-flex;
+  align-items: baseline;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+.named-did-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* An agent name that has not round-tripped: the DID claims it, but resolving
+   the name did not lead back to this DID. Shown, because the attempt is worth
+   seeing — but never as though it were established. */
+.named-did-name.unverified {
+  color: var(--warning);
+}
+
+.named-did-id {
+  color: var(--text-muted);
+  font-size: var(--text-sm);
+  white-space: nowrap;
+}
+
 .pagination {
   display: flex;
   gap: var(--space-3);

--- a/vtc-service/src/acl_cli.rs
+++ b/vtc-service/src/acl_cli.rs
@@ -12,6 +12,8 @@
 //! (ACL plugin) or the REST `/v1/acl` surface.
 
 use crate::store::keyspaces;
+use vta_sdk::display_name::{NameBook, NameSource, shorten_did};
+
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -44,31 +46,55 @@ pub async fn run_acl_list(config_path: Option<PathBuf>) -> CliResult {
     }
     entries.sort_by(|a, b| a.did.cmp(&b.did));
 
+    // Names come from the entries' own labels. Promote them to their own
+    // leading column — the label used to be tacked onto the end behind the
+    // contexts, which is the last place an operator scans.
+    let mut book = NameBook::new();
+    for e in &entries {
+        book.insert_opt(&e.did, e.label.as_deref(), NameSource::AclLabel);
+    }
+    let show_names = book.names_any(entries.iter().map(|e| e.did.as_str()));
+
     let now = now_epoch();
-    println!(
-        "   {:<48} {:<14} {:<12} LABEL / CONTEXTS",
-        "DID", "ROLE", "EXPIRES"
-    );
+    if show_names {
+        println!(
+            "   {:<24} {:<44} {:<14} {:<12} CONTEXTS",
+            "NAME", "DID", "ROLE", "EXPIRES"
+        );
+    } else {
+        println!("   {:<44} {:<14} {:<12} CONTEXTS", "DID", "ROLE", "EXPIRES");
+    }
     for e in &entries {
         let expires = match e.expires_at {
             None => "never".to_string(),
             Some(t) if t <= now => "EXPIRED".to_string(),
             Some(t) => format!("{}s", t - now),
         };
-        let mut detail = e.label.clone().unwrap_or_default();
-        if !e.allowed_contexts.is_empty() {
-            if !detail.is_empty() {
-                detail.push_str("  ");
-            }
-            detail.push_str(&format!("contexts=[{}]", e.allowed_contexts.join(",")));
+        let contexts = if e.allowed_contexts.is_empty() {
+            String::new()
+        } else {
+            format!("[{}]", e.allowed_contexts.join(","))
+        };
+        let did = shorten_did(&e.did);
+        if show_names {
+            let name = book.name_of(&e.did).unwrap_or_else(|| "\u{2014}".into());
+            println!(
+                "   {:<24} {:<44} {:<14} {:<12} {}",
+                name,
+                did,
+                e.role.to_string(),
+                expires,
+                contexts
+            );
+        } else {
+            println!(
+                "   {:<44} {:<14} {:<12} {}",
+                did,
+                e.role.to_string(),
+                expires,
+                contexts
+            );
         }
-        println!(
-            "   {:<48} {:<14} {:<12} {}",
-            e.did,
-            e.role.to_string(),
-            expires,
-            detail
-        );
     }
     println!(
         "\n{} entr{}.",

--- a/vtc-service/src/routes/members/update.rs
+++ b/vtc-service/src/routes/members/update.rs
@@ -20,7 +20,7 @@ use serde_json::Value as JsonValue;
 use vti_common::audit::{AuditEvent, FieldChange, MemberUpdatedData, RoleChangedData};
 
 use crate::acl::{VtcAclEntry, VtcRole, get_acl_entry};
-use crate::auth::AdminAuth;
+use crate::auth::{AdminAuth, session::now_epoch};
 use crate::error::AppError;
 use crate::members::{Disposition, Member, get_member, store_member};
 use crate::routes::members::read::MemberResponse;
@@ -33,6 +33,13 @@ use crate::server::AppState;
 #[derive(utoipa::ToSchema)]
 pub struct UpdateMemberRequest {
     pub role: Option<VtcRole>,
+    /// Human-readable name for this member, shown wherever their DID is
+    /// rendered (admin UI, `vtc acl list`).
+    ///
+    /// The label lives on the ACL row, so until now it was writable only via
+    /// `acl/grant` — a whole re-grant to correct a typo in a display name.
+    /// An empty string clears it; omitting the field leaves it unchanged.
+    pub label: Option<String>,
     pub publish_consent: Option<bool>,
     pub departure_preference: Option<Disposition>,
     pub extensions: Option<JsonValue>,
@@ -123,6 +130,31 @@ pub async fn update_member(
     }
     if !fields_changed.is_empty() {
         store_member(&state.members_ks, &member).await?;
+    }
+
+    // The label lives on the ACL row, not the member row. Written before any
+    // role change so the ceremony (which re-reads the ACL entry) picks it up
+    // rather than overwriting it from a stale copy.
+    if let Some(ref requested) = req.label {
+        let trimmed = requested.trim();
+        let new_label = if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        };
+        if new_label != acl.label {
+            changes.push(FieldChange {
+                field: "label".into(),
+                old: acl.label.clone().map(JsonValue::String),
+                new: new_label.clone().map(JsonValue::String),
+            });
+            let mut updated = acl.clone();
+            updated.label = new_label;
+            updated.updated_at = Some(now_epoch());
+            updated.updated_by = Some(auth.0.did.clone());
+            crate::acl::store_acl_entry(&state.acl_ks, &updated).await?;
+            fields_changed.push("label".into());
+        }
     }
 
     // Role change → the role-change ceremony.


### PR DESCRIPTION
Operators read DIDs constantly and cannot. Roughly ninety sites across the three
CLIs printed raw DIDs, and each abbreviated them its own way: a 29-**byte** slice
in `audit` (which would panic on a multi-byte character), 50- and 60-char
truncations in `services`, and a fourth strategy again in the VTC admin console.
Nothing anywhere mapped a DID to a human name at render time.

## The seam

New `vta_sdk::display_name`. A `NameBook` is a `DID → name` map a command fills
from a response it has **already fetched**, then queries while rendering — it is
not a resolver and performs no I/O. That shape is what makes naming free rather
than expensive: filling the book from an ACL listing also names the `Created By`
column, because a granting admin is nearly always another entry's subject. One
request, two columns named.

`shorten_did` replaces all four truncators. It abbreviates the opaque
`did:webvh` SCID and keeps the domain/path tail — the half that actually
identifies the agent — instead of clipping the end, which is what a trailing
ellipsis does. Ported from the admin console's `shortenDid`, with a vector table
pinning the two to identical output: an operator moving between a terminal and
the console should not have to re-identify the same DID.

## Rendering rules

- Tables gain a `Name` column **only when at least one row has one**. On a VTA
  where nothing has been labelled, a column of dashes is worse than no column.
- A DID is never *replaced* by a name. The name leads, the abbreviated
  identifier follows, and `--full-display` / `--json` still carry every DID in
  full. These are the screens where ACL grants get approved and members
  admitted; a name that cannot be cross-checked against an identifier is a name
  that cannot be audited.
- **`--json` output is unchanged.** No field renamed, removed, or reshaped, so
  scripts piping `pnm acl list --json` through `jq` are unaffected.

## Where names now appear

`pnm/cnm acl list|get`, `audit` (actor), `services didcomm drain list`,
`services report` (mediators + senders), the context-delete confirmation — both
the online path and the offline `vta contexts delete`, which is equally
destructive — `vtc acl list`, and the VTC console's members, ACL, sessions,
join-requests, invitations, audit and relationship-graph views.

## Agent names: wired, and deliberately inert

New optional `agent-names` feature on `vta-sdk` reads the names a DID's document
claims via `alsoKnownAs`.

**Those claims are self-asserted.** The agent-name specification's two-sided
binding protects the name→DID direction, not the reverse, so a hostile DID can
claim `mybank.com/@treasury` and a naive reader would render that as fact. Every
claim is therefore round-tripped — resolve the name forward, require it to lead
back to the same DID — before being shown unqualified. A claim that fails
surfaces as unverified, ranks below every local source, and never renders bare;
seeing that a DID *attempts* to present as the bank is useful, being told it *is*
would be a lie. There is a dedicated test for that case.

Nothing in this workspace publishes `alsoKnownAs` yet, so no agent name resolves
here today. This is the consumer half. No CLI `--resolve-agent-names` flag is
included, because it could only ever return nothing — that is one step once the
producer half (emitting `alsoKnownAs` from DID templates, publishing it through
`did:webvh`, serving the `domain/@name` redirect) lands in
`affinidi-webvh-service`.

Reference: `agent-names 0.1.3` + `affinidi-did-resolver-cache-sdk 0.8.19`, the
version this workspace already locks.

## One behavioural change

`PATCH /v1/members/{did}` accepts `label`. The VTC's only human name for a member
lives on the ACL row, so correcting a typo in a display name previously meant a
full `acl/grant` re-grant — which is why members were unnamed in practice, and
would have left the VTC display work inert.

## Breaking, internal

`vta_cli_common::commands::contexts::render_delete_context_preview` takes a
`&NameBook`. Both call sites are updated.

## Verification

- `cargo test --workspace` — green, exit 0 (re-run after rebasing onto #772).
- `cargo test -p vta-sdk --features agent-names` — 21 tests, including the spoof
  case above.
- `cargo fmt --check` clean; `cargo clippy --workspace --all-targets` reports
  nothing in any file this PR touches.
- Admin UI typechecks (`tsc -b --noEmit`) and bundles (`npm run build`).
- JSON compatibility: no `--json` serializer was touched.

Rebased onto `main` after #772, which refactored both ACL displays — the merge
was verified by build + full suite, not just by git reporting no conflict.

## Not covered

Left rendering bare DIDs, as low value: the `webvh` hosted-DID list,
`sealed_producer` banners, `vtc status` / `did_key`, and the console dashboard
(infrastructure DIDs with no name source).
