### PR TITLE
feat(acl): let a context admin audit who may confer in their context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 ## Unreleased
 
+### vti-common 0.11.17 / vta-service 0.12.22 — let a context admin audit who may confer in their context
+
+* **A least-privilege approver was invisible to the admins whose contexts it
+  could confer.** It acts nowhere by design, so it names no context on the act
+  axis, so it never overlapped a context admin's scope in
+  `is_acl_entry_visible` — and an operator asking "who can authorize a change
+  in my context?" could not see the answer. Conferral is authority, and
+  authority in your context should be auditable by its admin.
+
+* The fix is a **second predicate, not a wider first one**:
+
+  | predicate | includes | gates |
+  |---|---|---|
+  | `is_acl_entry_visible` | act-scope overlap | update, delete |
+  | `is_acl_entry_auditable` | that, plus approve-scope reaching the caller | list, get |
+
+  Separate because `is_acl_entry_visible` gates *mutations* too. An entry can
+  administer someone else's context while conferring into yours; folding
+  conferral into one predicate would have made that entry deletable by you —
+  `delete_acl`'s only other guard is `validate_role_assignment`, which a
+  context admin passes — turning a read widening into privilege escalation.
+  Pinned at both the predicate and operation layers, and verified by merging
+  the two and watching those tests fail.
+
+* A mutation refused on an entry the caller can nonetheless read now returns
+  `Forbidden` explaining the split rather than `NotFound`: there is nothing
+  left to conceal about a row they can already list. Entries the caller cannot
+  read at all still conflate to `NotFound`, so the enumeration guard is intact.
+
+* The act axis is unchanged — an unrestricted (super-admin) entry still does
+  not surface to a context admin merely by being unrestricted.
 ### vta-sdk 0.19.26 / vta-cli-common 0.10.12 / pnm-cli 0.11.7 / cnm-cli 0.11.5 / vta-service 0.12.21 / vtc-service 0.11.20 — show names where we used to show DIDs
 
 * Operators read DIDs constantly and cannot. Roughly ninety sites across the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10220,7 +10220,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.12.21"
+version = "0.12.22"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",
@@ -10409,7 +10409,7 @@ dependencies = [
 
 [[package]]
 name = "vti-common"
-version = "0.11.16"
+version = "0.11.17"
 dependencies = [
  "aes-gcm",
  "affinidi-data-integrity",

--- a/docs/05-design-notes/acl-scope-semantics.md
+++ b/docs/05-design-notes/acl-scope-semantics.md
@@ -69,6 +69,38 @@ been a bug:
 Go through `act_scope()` — or `has_context_access` / `can_act_in` /
 `is_super_admin`, which are built on it — and match on the result.
 
+## Reading is not managing
+
+Two predicates, deliberately separate:
+
+| predicate | includes | gates |
+|---|---|---|
+| `is_acl_entry_visible` | act-scope overlap | update, delete |
+| `is_acl_entry_auditable` | that, **plus** approve-scope reaching the caller | list, get |
+
+A least-privilege approver names no context on the act axis, so it never
+overlapped a context admin's scope — meaning an admin could not see who was
+able to authorize a change in their own context. Conferral is authority, and
+authority in your context should be auditable by its admin.
+
+**Keeping them separate is load-bearing, not tidiness.** An entry can
+administer *someone else's* context while conferring into yours. Folding
+conferral into the single visibility predicate would have made that entry
+deletable by you — `delete_acl`'s only other guard is
+`validate_role_assignment`, which a context admin passes — turning a read
+widening into privilege escalation. Pinned at both layers by
+`auditable_does_not_confer_manage_authority` and
+`delete_acl_refuses_an_entry_that_acts_outside_callers_contexts`.
+
+A mutation refused on an entry the caller can nonetheless read returns
+`Forbidden` explaining the split, rather than the usual `NotFound`: there is
+nothing left to conceal about a row they can already list, and "not found"
+would be a lie. Entries the caller cannot read at all still conflate to
+`NotFound`, so the enumeration guard is intact.
+
+The act axis is unchanged — an unrestricted (super-admin) entry still does not
+surface to a context admin merely by being unrestricted.
+
 ## What this does *not* change
 
 Two conflations are preserved deliberately, because removing either is a
@@ -91,15 +123,9 @@ Both are flagged where they occur.
 
 ## Remaining work
 
-- **The two widenings above**, each as its own reviewed change.
-- **A read/manage split.** `is_acl_entry_visible` gates *both* the list/get
-  reads and the update/delete mutations. Because it follows only the act axis,
-  a least-privilege approver is invisible to the very context admins whose
-  contexts it can confer — an admin cannot audit who may authorize a change in
-  their own context. The fix is a second, read-only predicate that also follows
-  the approve axis; it must **not** be a wider `is_acl_entry_visible`, because
-  an entry can administer someone else's context while conferring into yours,
-  and folding the two would make that entry deletable by you.
+- **The two conflations above**, each as its own reviewed change. Note the
+  first one interacts with the read/manage split: a context admin still cannot
+  *create* the least-privilege approver that they can now *audit*.
 - **The VTC.** `vtc-service` has a parallel ACL surface with the same idiom
   (`routes/acl.rs`, `acl_cli.rs`). It needs its own `act_scope()` accessor
   because `VtcAclEntry` is a distinct type with its own role enum, mapped via

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.12.21"
+version = "0.12.22"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/operations/acl.rs
+++ b/vta-service/src/operations/acl.rs
@@ -9,8 +9,8 @@ use vta_sdk::protocols::acl_management::{
 
 use crate::acl::{
     AclEntry, ApproveScope, Role, acl_entry_can_act_in, delete_acl_entry, get_acl_entry,
-    is_acl_entry_visible, list_acl_entries, store_acl_entry, validate_acl_modification,
-    validate_approve_scope_grant, validate_role_assignment,
+    is_acl_entry_auditable, is_acl_entry_visible, list_acl_entries, store_acl_entry,
+    validate_acl_modification, validate_approve_scope_grant, validate_role_assignment,
 };
 use crate::auth::AuthClaims;
 use crate::auth::session::now_epoch;
@@ -150,6 +150,27 @@ async fn require_contexts_exist(
     Ok(())
 }
 
+/// Error for a mutation the caller may not perform on `entry`.
+///
+/// Conflates to `NotFound` in the normal case — a caller who cannot see an
+/// entry must not learn it exists by watching the error change. But an entry
+/// that is *auditable* (it confers into a context the caller administers) is
+/// already readable by this caller through `acl get` / `acl list`, so there is
+/// nothing left to conceal, and "not found" would be a lie about a row they
+/// can list. Those get a `Forbidden` naming why managing it is a different
+/// question from seeing it.
+fn not_manageable(auth: &AuthClaims, entry: &AclEntry, did: &str, verb: &str) -> AppError {
+    if is_acl_entry_auditable(auth, entry) {
+        AppError::Forbidden(format!(
+            "{did} is visible to you because it may confer in a context you administer, \
+             but it acts outside your contexts — only an admin of the contexts it acts in \
+             can {verb} it"
+        ))
+    } else {
+        AppError::NotFound(format!("ACL entry not found for DID: {did}"))
+    }
+}
+
 fn to_result_body(e: &AclEntry) -> CreateAclResultBody {
     let (approve_all_contexts, approve_contexts) = match &e.approve_scope {
         ApproveScope::All => (true, Vec::new()),
@@ -246,7 +267,9 @@ pub async fn get_acl(
     let entry = get_acl_entry(acl_ks, did)
         .await?
         .ok_or_else(|| AppError::NotFound(format!("ACL entry not found for DID: {did}")))?;
-    if !is_acl_entry_visible(auth, &entry) {
+    // Read path: an entry that can *confer* into a context the caller
+    // administers is authority in that context, so its admin can audit it.
+    if !is_acl_entry_auditable(auth, &entry) {
         return Err(AppError::NotFound(format!(
             "ACL entry not found for DID: {did}"
         )));
@@ -266,7 +289,7 @@ pub async fn list_acl(
     let all_entries = list_acl_entries(acl_ks).await?;
     let entries: Vec<CreateAclResultBody> = all_entries
         .iter()
-        .filter(|e| is_acl_entry_visible(auth, e))
+        .filter(|e| is_acl_entry_auditable(auth, e))
         // Shared with the offline `vta acl list` so the two surfaces cannot
         // answer the same question differently. The previous `contains()`
         // omitted super-admin entries, which do hold every context — an
@@ -302,9 +325,7 @@ pub async fn update_acl(
         .ok_or_else(|| AppError::NotFound(format!("ACL entry not found for DID: {did}")))?;
 
     if !is_acl_entry_visible(auth, &entry) {
-        return Err(AppError::NotFound(format!(
-            "ACL entry not found for DID: {did}"
-        )));
+        return Err(not_manageable(auth, &entry, did, "update"));
     }
 
     if let Some(ref role) = params.role {
@@ -428,9 +449,7 @@ pub async fn delete_acl(
         .await?
         .ok_or_else(|| AppError::NotFound(format!("ACL entry not found for DID: {did}")))?;
     if !is_acl_entry_visible(auth, &entry) {
-        return Err(AppError::NotFound(format!(
-            "ACL entry not found for DID: {did}"
-        )));
+        return Err(not_manageable(auth, &entry, did, "delete"));
     }
 
     // Caller must be at least as privileged as the entry they are
@@ -655,6 +674,119 @@ mod tests {
         )
         .await
         .unwrap();
+    }
+
+    // ── read/manage split ───────────────────────────────────────────
+
+    /// Seed the escalation-shaped entry: it *administers* ctx-b while
+    /// *conferring* into ctx-a. A ctx-a admin must be able to read it and must
+    /// not be able to mutate it.
+    async fn seed_foreign_admin_conferring_into(
+        acl_ks: &KeyspaceHandle,
+        did: &str,
+        admins: &[&str],
+        confers: &[&str],
+    ) {
+        store_acl_entry(
+            acl_ks,
+            &AclEntry::new(did, Role::Admin, "seed")
+                .with_contexts(admins.iter().map(|s| s.to_string()).collect())
+                .with_approve_scope(ApproveScope::Contexts(
+                    confers.iter().map(|s| s.to_string()).collect(),
+                )),
+        )
+        .await
+        .unwrap();
+    }
+
+    /// The audit gap: a least-privilege approver conferring into the caller's
+    /// context is now readable by that context's admin.
+    #[tokio::test]
+    async fn get_acl_surfaces_an_approver_conferring_into_callers_context() {
+        let (_store, acl_ks, audit_ks, contexts_ks, _dir) = fresh_store().await;
+        seed_contexts(&contexts_ks, &["ctx-a"]).await;
+        let target = "did:key:zApproverRead";
+        store_acl_entry(
+            &acl_ks,
+            &AclEntry::new(target, Role::Reader, "seed")
+                .with_approve_scope(ApproveScope::Contexts(vec!["ctx-a".into()])),
+        )
+        .await
+        .unwrap();
+
+        let caller = ctx_admin("did:key:zCtxAdminA", &["ctx-a"]);
+        let body = get_acl(&acl_ks, &caller, target, "test")
+            .await
+            .expect("an approver in my context must be auditable");
+        assert_eq!(body.did, target);
+        let _ = (audit_ks, contexts_ks);
+    }
+
+    /// …and appears in the listing, which is where an operator actually audits.
+    #[tokio::test]
+    async fn list_acl_includes_an_approver_conferring_into_callers_context() {
+        let (_store, acl_ks, _audit_ks, contexts_ks, _dir) = fresh_store().await;
+        seed_contexts(&contexts_ks, &["ctx-a"]).await;
+        store_acl_entry(
+            &acl_ks,
+            &AclEntry::new("did:key:zApproverList", Role::Reader, "seed")
+                .with_approve_scope(ApproveScope::All),
+        )
+        .await
+        .unwrap();
+
+        let caller = ctx_admin("did:key:zCtxAdminA", &["ctx-a"]);
+        let body = list_acl(&acl_ks, &caller, None, "test").await.unwrap();
+        assert!(
+            body.entries
+                .iter()
+                .any(|e| e.did == "did:key:zApproverList"),
+            "an approve-all holder must be auditable by every context admin"
+        );
+    }
+
+    /// The escalation the split exists to prevent: reading an entry that
+    /// confers into your context must not let you delete it when it
+    /// administers someone else's.
+    #[tokio::test]
+    async fn delete_acl_refuses_an_entry_that_acts_outside_callers_contexts() {
+        let (_store, acl_ks, audit_ks, contexts_ks, _dir) = fresh_store().await;
+        seed_contexts(&contexts_ks, &["ctx-a", "ctx-b"]).await;
+        let target = "did:key:zForeignAdmin";
+        seed_foreign_admin_conferring_into(&acl_ks, target, &["ctx-b"], &["ctx-a"]).await;
+
+        let caller = ctx_admin("did:key:zCtxAdminA", &["ctx-a"]);
+        // Readable…
+        get_acl(&acl_ks, &caller, target, "test")
+            .await
+            .expect("confers into ctx-a, so ctx-a's admin may read it");
+        // …but not deletable, and the error says why rather than lying.
+        let err = delete_acl(&acl_ks, &audit_ks, &caller, target, "test")
+            .await
+            .expect_err("ctx-a admin must not delete an entry that administers ctx-b");
+        assert!(
+            matches!(err, AppError::Forbidden(_)),
+            "expected Forbidden (the row is already readable), got {err:?}"
+        );
+    }
+
+    /// An entry the caller cannot read at all still conflates to `NotFound` —
+    /// the split must not turn the enumeration guard into an oracle.
+    #[tokio::test]
+    async fn delete_acl_still_conflates_a_wholly_invisible_entry_to_not_found() {
+        let (_store, acl_ks, audit_ks, contexts_ks, _dir) = fresh_store().await;
+        seed_contexts(&contexts_ks, &["ctx-a", "ctx-b"]).await;
+        let target = "did:key:zInvisible";
+        seed_target(&acl_ks, target, &["ctx-b"]).await;
+
+        let caller = ctx_admin("did:key:zCtxAdminA", &["ctx-a"]);
+        let err = delete_acl(&acl_ks, &audit_ks, &caller, target, "test")
+            .await
+            .expect_err("not visible, not auditable");
+        assert!(
+            matches!(err, AppError::NotFound(_)),
+            "expected NotFound so existence is not disclosed, got {err:?}"
+        );
     }
 
     #[test]

--- a/vti-common/Cargo.toml
+++ b/vti-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-common"
 description = "Shared server-side infrastructure for VTA and VTC services"
 readme = "README.md"
-version = "0.11.16"
+version = "0.11.17"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vti-common/src/acl/mod.rs
+++ b/vti-common/src/acl/mod.rs
@@ -827,10 +827,18 @@ pub fn acl_entry_can_act_in(entry: &AclEntry, context_id: &str) -> bool {
     entry.act_scope().covers(context_id)
 }
 
-/// Check whether an ACL entry is visible to the caller.
+/// Whether an ACL entry is within the caller's authority to **manage**.
 ///
-/// Super admins see all entries. Context admins only see entries whose
-/// `allowed_contexts` overlap with their own.
+/// Super admins may manage any entry. A context admin may manage an entry only
+/// if the entry *acts* in a context the caller holds — so neither an
+/// unrestricted ([`ActScope::All`]) nor an acts-nowhere ([`ActScope::None`])
+/// entry is manageable by a context admin, neither naming a context to overlap.
+///
+/// This is the predicate the **mutation** paths gate on (update, delete). It
+/// deliberately ignores [`ApproveScope`]: an entry may confer into your context
+/// while acting entirely inside someone else's, and being able to *see* such an
+/// entry must not become authority to delete it. For the read paths, see
+/// [`is_acl_entry_auditable`].
 pub fn is_acl_entry_visible(caller: &AuthClaims, entry: &AclEntry) -> bool {
     if caller.is_super_admin() {
         return true;
@@ -840,6 +848,36 @@ pub fn is_acl_entry_visible(caller: &AuthClaims, entry: &AclEntry) -> bool {
         .named_contexts()
         .iter()
         .any(|ctx| caller.has_context_access(ctx))
+}
+
+/// Whether an ACL entry should be **readable** by the caller — the superset of
+/// [`is_acl_entry_visible`] used by `acl list` / `acl get`.
+///
+/// Adds entries holding *conferral* authority over a context the caller
+/// administers. A least-privilege approver acts nowhere, so it names no context
+/// on the act axis and was invisible to the very admins whose contexts it can
+/// confer: an operator asking "who can authorize a change in my context?" could
+/// not see the answer. Conferral is authority, and authority in your context
+/// should be auditable by its admin.
+///
+/// **Read-only by construction.** Widening what an admin may see is not
+/// widening what they may do, and keeping this separate from
+/// [`is_acl_entry_visible`] is what stops it from becoming that — an entry can
+/// administer someone else's context while conferring into yours, and a single
+/// merged predicate would have made that entry deletable by you.
+///
+/// The act axis is unchanged: an unrestricted (super-admin) entry still does
+/// not surface to a context admin merely by being unrestricted.
+pub fn is_acl_entry_auditable(caller: &AuthClaims, entry: &AclEntry) -> bool {
+    if is_acl_entry_visible(caller, entry) {
+        return true;
+    }
+    match &entry.approve_scope {
+        // Confers everywhere, therefore into the caller's contexts too.
+        ApproveScope::All => true,
+        ApproveScope::Contexts(cs) => cs.iter().any(|ctx| caller.has_context_access(ctx)),
+        ApproveScope::None => false,
+    }
 }
 
 #[cfg(test)]
@@ -1474,6 +1512,107 @@ mod tests {
             &sample_entry("did:key:zB", Role::Reader),
             ctx
         ));
+    }
+
+    // ── is_acl_entry_auditable ──────────────────────────────────────
+
+    /// The audit gap this closes: a least-privilege approver acts nowhere, so
+    /// it names no context on the act axis and never overlapped a context
+    /// admin's scope — leaving that admin unable to see who could authorize a
+    /// change in their own context.
+    #[test]
+    fn auditable_surfaces_an_approver_scoped_to_the_callers_context() {
+        let caller = context_admin_claims(&["ctx1"]);
+        let approver = AclEntry::new("did:key:zApprover", Role::Reader, "did:key:zSetup")
+            .with_approve_scope(ApproveScope::Contexts(vec!["ctx1".into()]));
+
+        assert!(
+            !is_acl_entry_visible(&caller, &approver),
+            "acts nowhere, so it is not the caller's to manage"
+        );
+        assert!(
+            is_acl_entry_auditable(&caller, &approver),
+            "but it confers in ctx1, so ctx1's admin must be able to see it"
+        );
+    }
+
+    /// An `All` approver confers into every context, the caller's included.
+    #[test]
+    fn auditable_surfaces_an_approve_all_holder() {
+        let caller = context_admin_claims(&["ctx1"]);
+        let approver = AclEntry::new("did:key:zGlobal", Role::Reader, "did:key:zSetup")
+            .with_approve_scope(ApproveScope::All);
+        assert!(is_acl_entry_auditable(&caller, &approver));
+    }
+
+    /// Conferral is subtree-aware, matching `ApproveScope::covers`.
+    #[test]
+    fn auditable_follows_context_ancestry() {
+        let caller = context_admin_claims(&["parent"]);
+        let approver = AclEntry::new("did:key:zChild", Role::Reader, "did:key:zSetup")
+            .with_approve_scope(ApproveScope::Contexts(vec!["parent/child".into()]));
+        assert!(
+            is_acl_entry_auditable(&caller, &approver),
+            "an admin of the parent context administers the subtree it confers in"
+        );
+    }
+
+    /// An approver for someone else's context stays hidden — the widening is
+    /// scoped to conferral that actually reaches the caller.
+    #[test]
+    fn auditable_hides_an_approver_for_a_foreign_context() {
+        let caller = context_admin_claims(&["ctx1"]);
+        let approver = AclEntry::new("did:key:zOther", Role::Reader, "did:key:zSetup")
+            .with_approve_scope(ApproveScope::Contexts(vec!["ctx2".into()]));
+        assert!(!is_acl_entry_auditable(&caller, &approver));
+    }
+
+    /// **Read-only by construction.** The mutation predicate must not follow
+    /// the approve axis, or seeing an entry would become authority to delete
+    /// it. An entry that admins someone else's context while conferring into
+    /// ours is exactly the case that would be an escalation.
+    #[test]
+    fn auditable_does_not_confer_manage_authority() {
+        let caller = context_admin_claims(&["ctx1"]);
+        let foreign_admin = scoped_entry("did:key:zForeignAdmin", Role::Admin, &["ctx2"])
+            .with_approve_scope(ApproveScope::Contexts(vec!["ctx1".into()]));
+
+        assert!(
+            is_acl_entry_auditable(&caller, &foreign_admin),
+            "confers into ctx1, so ctx1's admin can see it"
+        );
+        assert!(
+            !is_acl_entry_visible(&caller, &foreign_admin),
+            "but it admins ctx2 — ctx1's admin must not be able to update or delete it"
+        );
+    }
+
+    /// Entries carrying no conferral are unaffected: `auditable` collapses to
+    /// `visible`, so this widens nothing for the ordinary case.
+    #[test]
+    fn auditable_matches_visible_when_nothing_is_conferred() {
+        let caller = context_admin_claims(&["ctx1"]);
+        for entry in [
+            scoped_entry("did:key:zA", Role::Reader, &["ctx1"]),
+            scoped_entry("did:key:zB", Role::Reader, &["ctx2"]),
+            sample_entry("did:key:zC", Role::Admin),
+            sample_entry("did:key:zD", Role::Reader),
+        ] {
+            assert_eq!(
+                is_acl_entry_auditable(&caller, &entry),
+                is_acl_entry_visible(&caller, &entry),
+                "{} must be unaffected by the approve axis",
+                entry.did
+            );
+        }
+    }
+
+    /// A super-admin caller sees everything either way.
+    #[test]
+    fn auditable_is_total_for_a_super_admin() {
+        let caller = super_admin_claims();
+        let entry = scoped_entry("did:key:zAny", Role::Reader, &["whatever"]);
+        assert!(is_acl_entry_auditable(&caller, &entry));
     }
 
     // ── is_acl_entry_visible ────────────────────────────────────────


### PR DESCRIPTION
## The gap

A least-privilege approver acts nowhere by design — that is the point of the shape. So it names no context on the act axis, so it never overlapped a context admin's scope in `is_acl_entry_visible`, so an operator asking *"who can authorize a change in my context?"* could not see the answer.

Conferral is authority. Authority in your context should be auditable by its admin.

## The fix is a second predicate, not a wider first one

| predicate | includes | gates |
|---|---|---|
| `is_acl_entry_visible` | act-scope overlap (unchanged) | update, delete |
| `is_acl_entry_auditable` | that, **plus** approve-scope reaching the caller | list, get |

**This separation is load-bearing, not tidiness.** `is_acl_entry_visible` is not a display filter — it gates mutations. Consider:

```rust
AclEntry { role: Admin, allowed_contexts: ["ctx-b"], approve_scope: Contexts(["ctx-a"]) }
```

It administers ctx-b while conferring into ctx-a. Folding conferral into the single visibility predicate would let a **ctx-a** admin delete it, because `delete_acl`'s only other guard is `validate_role_assignment`, which a context admin passes. A read fix would have become privilege escalation.

Pinned at both layers:

- `auditable_does_not_confer_manage_authority` — the predicate
- `delete_acl_refuses_an_entry_that_acts_outside_callers_contexts` — the actual operation

Verified load-bearing by merging the two predicates and watching both fail (plus `auditable_surfaces_an_approver_scoped_to_the_callers_context`).

## Error semantics

A mutation refused on an entry the caller can nonetheless *read* now returns `Forbidden` naming the split, rather than the usual `NotFound` — there is nothing left to conceal about a row they can already list, and "not found" would be a lie about it.

Entries the caller cannot read at all still conflate to `NotFound`, so the enumeration guard is intact. Pinned by `delete_acl_still_conflates_a_wholly_invisible_entry_to_not_found`.

## Scope of the widening

Deliberately narrow:

- Only the **approve** axis is added, and only where it reaches a context the caller administers. An approver for someone else's context stays hidden.
- Ancestry-aware, matching `ApproveScope::covers` — an admin of `parent` can audit an approver conferring in `parent/child`.
- Entries carrying no conferral are completely unaffected: `auditable` collapses to `visible`. Pinned by `auditable_matches_visible_when_nothing_is_conferred`.
- The **act** axis is unchanged — an unrestricted (super-admin) entry still does not surface to a context admin merely by being unrestricted. Whether it should is a separate question, left in the design note.

## Tests

7 predicate tests + 4 operation tests (`get_acl` and `list_acl` surface the approver; `delete_acl` refuses with `Forbidden`; a wholly-invisible entry still yields `NotFound`).

`cargo test -p vti-common -p vta-service`: **1594 passed, 0 failed**. Clippy and fmt clean.

Follow-up to #772, which introduced `ActScope` and listed this as remaining work.