### PR TITLE
refactor(vtc): decode ACL scope the same way the VTA does

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 ## Unreleased
 
+### vtc-service 0.11.21 — decode ACL scope the same way the VTA does
+
+* The VTC's ACL surface read `allowed_contexts.is_empty()` by hand in three
+  places, the same idiom that produced three separate bugs on the VTA side
+  (#746, #769, #770). `VtcAclEntry::act_scope()` now maps the community role
+  through `as_vti_role` and calls the shared `act_scope_for`, so the two
+  services cannot disagree about what an empty scope set means.
+
+* **Revoking every scope** now says which case it refused. Emptying an *admin*
+  entry's scopes silently promotes it to community-wide authority; emptying any
+  other role's leaves it inert. Both are refused, as before, but the message no
+  longer describes every entry as community-wide.
+
+* **`caller_covers_admin_target`** distinguishes an unrestricted target from an
+  acts-nowhere one rather than having both fall out of a single `is_empty()`.
+
+* **The offline `vtc acl` listing** always renders the scope. Printing nothing
+  for an empty list left "community-wide" and "acts nowhere" looking identical
+  on an operator display.
+
+* No behaviour change beyond the two clarified messages; `as_vti_role` moves
+  from the route layer to `acl::role` so the offline CLI can reach it.
+
+### vti-common 0.11.17 / vta-service 0.12.21 — let a context admin audit who may confer in their context
 ### vti-common 0.11.17 / vta-service 0.12.22 — let a context admin audit who may confer in their context
 
 * **A least-privilege approver was invisible to the admins whose contexts it

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10327,7 +10327,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-service"
-version = "0.11.20"
+version = "0.11.21"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/docs/05-design-notes/acl-scope-semantics.md
+++ b/docs/05-design-notes/acl-scope-semantics.md
@@ -1,7 +1,6 @@
 # ACL scope semantics — the two axes
 
-**Status:** implemented for the VTA. The VTC's parallel ACL surface still
-decodes by hand — see [Remaining work](#remaining-work).
+**Status:** implemented (VTA + VTC).
 
 An ACL entry answers two independent questions, and they must never be
 conflated:
@@ -42,6 +41,10 @@ That decode is `vti_common::acl::act_scope_for`, reached in practice via
 `AclEntry::act_scope()` / `AuthClaims::act_scope()`. Storage, JWT claims, and
 every wire body are unchanged — this is a read-path abstraction, not a
 migration.
+
+The VTC shares the same decode: `VtcAclEntry::act_scope()` maps its own role
+enum through `as_vti_role` and calls the same `act_scope_for`, so the two
+services cannot disagree about what an empty scope set means.
 
 The type and its `covers()` predicate live in `vta-sdk` beside `ApproveScope`,
 so the two axes read as one model. The *decode* stays in `vti-common` because
@@ -126,11 +129,6 @@ Both are flagged where they occur.
 - **The two conflations above**, each as its own reviewed change. Note the
   first one interacts with the read/manage split: a context admin still cannot
   *create* the least-privilege approver that they can now *audit*.
-- **The VTC.** `vtc-service` has a parallel ACL surface with the same idiom
-  (`routes/acl.rs`, `acl_cli.rs`). It needs its own `act_scope()` accessor
-  because `VtcAclEntry` is a distinct type with its own role enum, mapped via
-  `as_vti_role`. Until then the two services can still drift on what an empty
-  scope set means.
 - **`reader + All`** ("may read every context, admin nowhere") is expressible
   in the type but unreachable through the decode table, since `All` requires
   `Role::Admin`. If it is ever wanted it needs a stored representation — i.e.

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.11.20"
+version = "0.11.21"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vtc-service/src/acl/entry.rs
+++ b/vtc-service/src/acl/entry.rs
@@ -62,6 +62,26 @@ pub struct VtcAclEntry {
 }
 
 impl VtcAclEntry {
+    /// This entry's authority to **act**, decoded from `(role,
+    /// allowed_contexts)` through the shared rule.
+    ///
+    /// Use this rather than reading `allowed_contexts` directly: an empty list
+    /// means *unrestricted* for an admin and *nothing at all* for every other
+    /// role, so a bare `is_empty()` gets one of the two backwards. See
+    /// [`vti_common::acl::ActScope`] and
+    /// `docs/05-design-notes/acl-scope-semantics.md`.
+    pub fn act_scope(&self) -> vti_common::acl::ActScope {
+        vti_common::acl::act_scope_for(&crate::acl::as_vti_role(&self.role), &self.allowed_contexts)
+    }
+
+    /// Whether this entry is a **super-admin**: an admin whose scope is
+    /// unrestricted (community-wide).
+    pub fn is_super_admin(&self) -> bool {
+        self.act_scope().is_unrestricted()
+    }
+}
+
+impl VtcAclEntry {
     /// Returns `true` once this entry has passed its
     /// `expires_at`. Permanent entries (`None`) never expire.
     pub fn is_expired(&self, now_unix: u64) -> bool {
@@ -164,6 +184,42 @@ mod tests {
         let parsed = decode(&bytes).unwrap();
         assert_eq!(parsed.role, VtcRole::Custom("editor".into()));
         assert_eq!(parsed, entry);
+    }
+
+    /// The VTA and the VTC must decode an empty scope set identically, or the
+    /// two services disagree on what an entry means. Admin + empty is
+    /// community-wide; every other role + empty acts nowhere.
+    #[test]
+    fn act_scope_decodes_empty_scopes_by_role() {
+        let mut admin = sample_entry(None);
+        admin.role = VtcRole::Admin;
+        assert_eq!(admin.act_scope(), vti_common::acl::ActScope::All);
+        assert!(admin.is_super_admin());
+        assert!(admin.act_scope().covers("anything"));
+
+        for role in [VtcRole::Member, VtcRole::Custom("editor".into())] {
+            let mut e = sample_entry(None);
+            e.role = role.clone();
+            assert_eq!(
+                e.act_scope(),
+                vti_common::acl::ActScope::None,
+                "{role:?} with no scopes acts nowhere"
+            );
+            assert!(!e.is_super_admin());
+            assert!(!e.act_scope().covers("anything"));
+        }
+    }
+
+    /// A scoped entry covers its subtree, matching the VTA and the VTC's own
+    /// hierarchy-aware `acl/list` filter.
+    #[test]
+    fn act_scope_is_subtree_aware() {
+        let mut e = sample_entry(None);
+        e.allowed_contexts = vec!["parent".into()];
+        assert!(e.act_scope().covers("parent"));
+        assert!(e.act_scope().covers("parent/child"));
+        assert!(!e.act_scope().covers("parentless"));
+        assert!(!e.is_super_admin(), "a scoped entry is never a super-admin");
     }
 
     fn sample_entry(expires_at: Option<u64>) -> VtcAclEntry {

--- a/vtc-service/src/acl/mod.rs
+++ b/vtc-service/src/acl/mod.rs
@@ -4,12 +4,12 @@ pub mod role;
 pub mod storage;
 
 pub use entry::VtcAclEntry;
-pub use role::VtcRole;
+pub use role::{VtcRole, as_vti_role};
 pub use storage::{
     delete_acl_entry, get_acl_entry, list_acl_entries, list_acl_entries_paginated,
     map_vtc_role_to_auth_role, resolve_auth_role, store_acl_entry, validate_vtc_role_assignment,
 };
 pub use vti_common::acl::{
-    Role, check_acl, check_acl_full, is_acl_entry_visible, validate_acl_modification,
+    ActScope, Role, check_acl, check_acl_full, is_acl_entry_visible, validate_acl_modification,
     validate_role_assignment,
 };

--- a/vtc-service/src/acl/role.rs
+++ b/vtc-service/src/acl/role.rs
@@ -279,3 +279,17 @@ mod tests {
         assert_eq!(role, VtcRole::Admin);
     }
 }
+
+/// Map a [`VtcRole`] onto the shared [`vti_common::acl::Role`] that the common
+/// ACL predicates reason over. Only `Admin` is privilege-bearing in those
+/// predicates; every other community role collapses to `Reader`.
+///
+/// Lives here rather than in the route layer because the offline break-glass
+/// CLI needs it too, and both surfaces must decode an entry's scope the same
+/// way.
+pub fn as_vti_role(role: &VtcRole) -> vti_common::acl::Role {
+    match role {
+        VtcRole::Admin => vti_common::acl::Role::Admin,
+        _ => vti_common::acl::Role::Reader,
+    }
+}

--- a/vtc-service/src/acl_cli.rs
+++ b/vtc-service/src/acl_cli.rs
@@ -19,7 +19,8 @@ use std::str::FromStr;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::acl::{
-    VtcAclEntry, VtcRole, delete_acl_entry, get_acl_entry, list_acl_entries, store_acl_entry,
+    ActScope, VtcAclEntry, VtcRole, delete_acl_entry, get_acl_entry, list_acl_entries,
+    store_acl_entry,
 };
 use crate::config::AppConfig;
 use crate::store::Store;
@@ -70,10 +71,14 @@ pub async fn run_acl_list(config_path: Option<PathBuf>) -> CliResult {
             Some(t) if t <= now => "EXPIRED".to_string(),
             Some(t) => format!("{}s", t - now),
         };
-        let contexts = if e.allowed_contexts.is_empty() {
-            String::new()
-        } else {
-            format!("[{}]", e.allowed_contexts.join(","))
+        // Decode through `ActScope` rather than testing the list: an empty
+        // scope set means community-wide for an admin and *nothing at all* for
+        // every other role, and rendering both as blank left the two looking
+        // identical on an operator display. Scoped entries keep the bracketed
+        // form.
+        let contexts = match e.act_scope() {
+            ActScope::Contexts(cs) => format!("[{}]", cs.join(",")),
+            other => other.to_string(),
         };
         let did = shorten_did(&e.did);
         if show_names {

--- a/vtc-service/src/routes/acl.rs
+++ b/vtc-service/src/routes/acl.rs
@@ -7,8 +7,9 @@ use serde::{Deserialize, Serialize};
 use tracing::info;
 
 use crate::acl::{
-    VtcAclEntry, VtcRole, delete_acl_entry, get_acl_entry, is_acl_entry_visible, list_acl_entries,
-    store_acl_entry, validate_acl_modification, validate_vtc_role_assignment,
+    ActScope, VtcAclEntry, VtcRole, as_vti_role, delete_acl_entry, get_acl_entry,
+    is_acl_entry_visible, list_acl_entries, store_acl_entry, validate_acl_modification,
+    validate_vtc_role_assignment,
 };
 use crate::auth::{AdminAuth, AuthClaims, ManageAuth, session::now_epoch};
 use crate::error::AppError;
@@ -602,14 +603,26 @@ pub async fn delete_acl(
                 "none of the requested scopes are held by {did}"
             )));
         }
-        // Emptying an entry's scopes would silently promote it to
-        // community-wide authority (an empty scope set is how a
-        // super-admin is spelled), which is the opposite of revoking.
-        if entry.allowed_contexts.is_empty() {
-            return Err(AppError::Conflict(format!(
-                "revoking every scope of {did} would leave an unscoped \
-                 (community-wide) entry; omit `scopes` to remove it instead"
-            )));
+        // Emptying an entry's scopes leaves it in one of two states, and
+        // neither is what "revoke these scopes" asked for: an *admin* is
+        // silently promoted to community-wide authority (an empty scope set is
+        // how a super-admin is spelled), and any other role is left inert.
+        // Decode through `ActScope` so the message can say which happened
+        // instead of describing every entry as community-wide.
+        match entry.act_scope() {
+            ActScope::All => {
+                return Err(AppError::Conflict(format!(
+                    "revoking every scope of {did} would leave an unscoped \
+                     (community-wide) entry; omit `scopes` to remove it instead"
+                )));
+            }
+            ActScope::None => {
+                return Err(AppError::Conflict(format!(
+                    "revoking every scope of {did} would leave an entry that \
+                     can act nowhere; omit `scopes` to remove it instead"
+                )));
+            }
+            ActScope::Contexts(_) => {}
         }
         entry.updated_at = Some(now_epoch());
         entry.updated_by = Some(auth.0.did.clone());
@@ -677,11 +690,7 @@ pub async fn delete_acl(
 /// match), which is fine because these helpers ignore the role
 /// field entirely.
 pub(crate) fn as_vti_acl_entry(e: &VtcAclEntry) -> vti_common::acl::AclEntry {
-    let role = match e.role {
-        VtcRole::Admin => vti_common::acl::Role::Admin,
-        _ => vti_common::acl::Role::Reader,
-    };
-    vti_common::acl::AclEntry::new(e.did.clone(), role, e.created_by.clone())
+    vti_common::acl::AclEntry::new(e.did.clone(), as_vti_role(&e.role), e.created_by.clone())
         .with_label(e.label.clone())
         .with_contexts(e.allowed_contexts.clone())
         .with_created_at(e.created_at)
@@ -700,11 +709,15 @@ fn caller_covers_admin_target(caller: &AuthClaims, target: &VtcAclEntry) -> bool
     if caller.is_super_admin() {
         return true;
     }
-    !target.allowed_contexts.is_empty()
-        && target
-            .allowed_contexts
-            .iter()
-            .all(|ctx| caller.has_context_access(ctx))
+    // Only a context-scoped target is coverable by a context admin. An
+    // unrestricted target is itself a super-admin (super-admin caller only,
+    // handled above); an acts-nowhere target names no context to check
+    // against. `ActScope` makes those two distinguishable rather than both
+    // falling out of one `is_empty()`.
+    match target.act_scope() {
+        ActScope::Contexts(cs) => cs.iter().all(|ctx| caller.has_context_access(ctx)),
+        ActScope::All | ActScope::None => false,
+    }
 }
 
 /// Did an ACL update reduce the subject's authorization?


### PR DESCRIPTION
> Stacked on #774 — review that first. Base retargets to `main` when it merges.

## Why

The VTC's ACL surface read `allowed_contexts.is_empty()` by hand in three places — the same idiom that produced three separate bugs on the VTA side (#746 display, #769 vault escalation, #770 filter divergence). Until this lands the two services can disagree about what an empty scope set means.

`VtcAclEntry::act_scope()` maps the community role through `as_vti_role` and calls the shared `act_scope_for`, so both services decode identically.

## The three sites

1. **Revoking every scope** now says which case it refused. Emptying an *admin* entry's scopes silently promotes it to community-wide authority; emptying any other role's leaves it inert. Both are refused, as before, but the message no longer describes every entry as community-wide.

2. **`caller_covers_admin_target`** distinguishes an unrestricted target from an acts-nowhere one, rather than having both fall out of one `is_empty()`.

3. **The offline `vtc acl` listing** always renders the scope. Printing nothing for an empty list left "community-wide" and "acts nowhere" looking identical on an operator display.

`as_vti_role` moves from the route layer to `acl::role` so the offline CLI can reach it.

## Worth noting

The listing in (3) was **rewritten by #773 after `ActScope` landed**, and the rewrite reintroduced the same blank-for-both rendering:

```rust
let contexts = if e.allowed_contexts.is_empty() { String::new() } else { ... };
```

That is the argument for this PR: the idiom reproduces itself in new code because nothing makes the wrong version awkward to write. The accessor added here does. I adapted the fix onto #773's new structure rather than reverting it — scoped entries keep its bracketed `[a,b]` form.

## Tests

Two decode tests on `VtcAclEntry` covering the role-dependent empty case and subtree coverage, so the VTC's decode is pinned independently of the VTA's.

`cargo test -p vtc-service -p vti-common -p vta-service`: **1127 passed, 0 failed**. Clippy and fmt clean.

## Result

Zero live `allowed_contexts.is_empty()` scope decodes remain anywhere in the workspace — the seven textual matches left are test assertions and doc comments quoting the rule.

Completes the remaining VTC item from #772's design note.