### PR TITLE
fix(vta-service): enforce credential custody on the credential-vault surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,46 @@
 
 ## Unreleased
 
+### vta-service 0.12.23 — enforce credential custody on the credential-vault surface
+
+* **Security.** `StoredCredential.context_id` is documented as the **custody**
+  axis — "which context in *this* VTA owns the credential" — and no path
+  enforced it. Every credential-vault trust task gated on the caller's
+  *capability* and then read or mutated by id, so a caller scoped to one
+  context reached another's credentials. Verified with a repro before fixing:
+  a `ctx-a` caller received `{"credential":{"id":"cred-in-ctx-b"}}` from
+  `get`, and both contexts' rows from `query`.
+
+* Affected: `query` and `get` (read), `archive` / `unarchive` / `restore`
+  (mutate), and `delete` / `purge` (destroy). **`delete --force` was the
+  worst** — it hard-deleted by id without loading the record at all, so custody
+  could not be checked even in principle and a scoped caller could destroy
+  another context's credential outright.
+
+* One `caller_may_access_custody(&ActScope, Option<&str>)` predicate now backs
+  every path. In `search` it sits with the existing lifecycle and status
+  post-filters, where the full record is already loaded, so it costs nothing —
+  the descriptor returned to callers carries no `context_id`, making a
+  downstream filter impossible without re-reading every hit.
+
+* Inaccessible credentials conflate to **not-found**, matching how archived and
+  absent ones are already reported, so the gate is not an enumeration oracle.
+  An absent id stays idempotent-success on `delete --force`.
+
+* **Unscoped (`context_id: None`) credentials remain readable by any caller.**
+  That is how rows written before the field existed deserialize, and how a
+  multi-context or super-admin `receive` still stores today. Denying it would
+  retroactively hide legacy credentials from the scoped callers using them, so
+  it is a deliberate compatibility carve-out — tightening it needs a backfill
+  of `context_id` first.
+
+* The credential-**exchange** presentation path (`match_vault`) is deliberately
+  unchanged and passes `ActScope::All`: that is the holder presenting its own
+  store to a verifier, governed by the context-policy guardrail and consent, a
+  different question from "may this caller read this context's credentials".
+
+* Same defect class as #769, in the sibling file that fix did not cover.
+
 ### vtc-service 0.11.21 — decode ACL scope the same way the VTA does
 
 * The VTC's ACL surface read `allowed_contexts.is_empty()` by hand in three
@@ -173,7 +213,6 @@
 * One `acl_entry_can_act_in` predicate in `vti-common` now backs both call
   sites, so they cannot drift again.
 
-### vta-service 0.12.17 — fix a vault scope gate that ignored the caller's role
 ### vta-service 0.12.18 — fix a vault scope gate that ignored the caller's role
 
 * **Security.** `enforce_context_scope`, the gate on every vault trust task,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10220,7 +10220,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.12.22"
+version = "0.12.23"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.12.22"
+version = "0.12.23"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/operations/credential_exchange.rs
+++ b/vta-service/src/operations/credential_exchange.rs
@@ -51,6 +51,7 @@ use crate::vault::consent::{self, ConsentGrant};
 use crate::vault::model::{CredentialFormat, StoredCredential};
 use crate::vault::query::CredentialQuery as VaultQuery;
 use crate::vault::{self};
+use vti_common::acl::ActScope;
 
 /// Receive a credential delivered in a credential-exchange `issue` message into
 /// the holder's `vault`. Infers the credential format from the body, resolves
@@ -507,6 +508,16 @@ async fn gather_for_query(
                     // verifier (the include_* opt-ins are management-only).
                     ..Default::default()
                 },
+                // Unrestricted **deliberately**: this is the holder presenting
+                // its own store to a verifier, not an operator reading the
+                // credential-vault API. Disclosure here is governed by the
+                // context-policy guardrail in `present_query` (which verifier,
+                // which types) plus consent — a different question from "may
+                // this caller read this context's credentials". Narrowing it to
+                // the caller's scope would change which credentials are
+                // presentable, which is not this fix's business; `match_vault`
+                // would need `auth` threaded through first.
+                &ActScope::All,
             )
             .await?;
             for descriptor in descriptors {

--- a/vta-service/src/trust_tasks/cred_vault.rs
+++ b/vta-service/src/trust_tasks/cred_vault.rs
@@ -203,7 +203,11 @@ pub(super) async fn handle_query(
         Ok(q) => q,
         Err(resp) => return resp,
     };
-    match search(&state.vault_ks, &query).await {
+    // Custody gate: only credentials owned by a context the caller can act in
+    // (plus unscoped/legacy rows). Applied inside `search`, where the full
+    // record is in hand — the descriptor returned to the caller carries no
+    // `context_id` to filter on out here.
+    match search(&state.vault_ks, &query, &auth.act_scope()).await {
         Ok(credentials) => success_response(&doc, QueryResponse { credentials }),
         Err(e) => app_error_to_reject(&doc, e),
     }
@@ -260,10 +264,16 @@ pub(super) async fn handle_get(
         Err(resp) => return resp,
     };
     match storage::get(&state.vault_ks, &req.id).await {
-        // An archived / soft-deleted credential's body must not be handed out
-        // for presentation — conflate it with not-found (same enumeration
-        // stance as a genuinely absent id).
-        Ok(Some(stored)) if stored.is_active() => {
+        // Custody gate first: a credential owned by another context is
+        // conflated with not-found, exactly like an archived or absent one, so
+        // the caller cannot probe for ids outside their contexts.
+        Ok(Some(stored))
+            if stored.is_active()
+                && crate::vault::query::caller_may_access_custody(
+                    &auth.act_scope(),
+                    stored.context_id.as_deref(),
+                ) =>
+        {
             match serde_json::from_slice::<Value>(&stored.body) {
                 Ok(credential) => success_response(&doc, GetResponse { credential }),
                 Err(e) => reject_with(
@@ -409,6 +419,16 @@ async fn cred_transition(
         Ok(None) => return cred_not_found(&doc, verb, &req.id),
         Err(e) => return app_error_to_reject(&doc, e),
     };
+    // Custody gate, same as the read paths: a credential owned by another
+    // context is conflated with not-found. Mutating it would be worse than
+    // reading it — an operator scoped to one context could archive or delete
+    // another's credentials.
+    if !crate::vault::query::caller_may_access_custody(
+        &auth.act_scope(),
+        cred.context_id.as_deref(),
+    ) {
+        return cred_not_found(&doc, verb, &req.id);
+    }
     if let Err(e) = transition(&mut cred) {
         return cred_lifecycle_reject(&doc, verb, &req.id, e);
     }
@@ -436,7 +456,26 @@ pub(super) async fn handle_delete(
 
     // Forced hard delete bypasses the grace window entirely (and works even on
     // an absent id — idempotent, like the storage primitive).
+    //
+    // Custody must still be checked, which means loading the record first: this
+    // path previously deleted by id without reading anything, so a caller
+    // scoped to one context could destroy another context's credential outright.
+    // An absent id stays idempotent-success (nothing to own); a present but
+    // inaccessible one conflates to not-found, the same answer an absent id
+    // gives, so nothing is disclosed.
     if req.force {
+        match storage::get(&state.vault_ks, &req.id).await {
+            Ok(Some(cred))
+                if !crate::vault::query::caller_may_access_custody(
+                    &auth.act_scope(),
+                    cred.context_id.as_deref(),
+                ) =>
+            {
+                return cred_not_found(&doc, "delete", &req.id);
+            }
+            Err(e) => return app_error_to_reject(&doc, e),
+            _ => {}
+        }
         if let Err(e) = storage::delete(&state.vault_ks, &req.id).await {
             return app_error_to_reject(&doc, e);
         }
@@ -455,6 +494,12 @@ pub(super) async fn handle_delete(
         Ok(None) => return cred_not_found(&doc, "delete", &req.id),
         Err(e) => return app_error_to_reject(&doc, e),
     };
+    if !crate::vault::query::caller_may_access_custody(
+        &auth.act_scope(),
+        cred.context_id.as_deref(),
+    ) {
+        return cred_not_found(&doc, "delete", &req.id);
+    }
     let now = Utc::now();
     let grace_days = state.config.read().await.vault.grace_days;
     let grace_until = (now + chrono::Duration::days(grace_days as i64)).to_rfc3339();
@@ -484,7 +529,14 @@ pub(super) async fn handle_purge(
     // `storage::delete` is idempotent (absent id is a no-op); surface a
     // not_found only when there was genuinely nothing to purge.
     match storage::get(&state.vault_ks, &req.id).await {
-        Ok(Some(_)) => {}
+        Ok(Some(cred)) => {
+            if !crate::vault::query::caller_may_access_custody(
+                &auth.act_scope(),
+                cred.context_id.as_deref(),
+            ) {
+                return cred_not_found(&doc, "purge", &req.id);
+            }
+        }
         Ok(None) => return cred_not_found(&doc, "purge", &req.id),
         Err(e) => return app_error_to_reject(&doc, e),
     }
@@ -522,6 +574,212 @@ mod tests {
         assert!(
             generated.starts_with("urn:uuid:"),
             "fallback id is a urn:uuid: {generated}"
+        );
+    }
+
+    // ── custody-context enforcement on the read paths ───────────────
+
+    /// Store a credential owned by `context_id`, indexed so `search` can find
+    /// it by purpose.
+    async fn seed_credential(
+        vault_ks: &crate::store::KeyspaceHandle,
+        id: &str,
+        context_id: Option<&str>,
+    ) {
+        use crate::vault::model::{CredentialFormat, CredentialStatus, StoredCredential};
+        use vti_common::vault::VaultStatus;
+        let cred = StoredCredential {
+            id: id.into(),
+            format: CredentialFormat::EddsaJcs2022,
+            types: vec!["MembershipCredential".into()],
+            schema_id: None,
+            community_did: None,
+            context_id: context_id.map(str::to_string),
+            subject_did: None,
+            issuer_did: Some("did:key:zIssuer".into()),
+            purpose: None,
+            status: CredentialStatus::Unknown,
+            valid_from: None,
+            valid_until: None,
+            received_at: "2026-01-01T00:00:00Z".into(),
+            source: None,
+            tags: Default::default(),
+            body: serde_json::to_vec(&json!({"id": id})).unwrap(),
+            lifecycle: VaultStatus::Active,
+            archived_at: None,
+            deleted_at: None,
+            grace_until: None,
+        };
+        crate::vault::storage::put(vault_ks, &cred).await.unwrap();
+    }
+
+    fn get_doc(id: &str) -> TrustTask<Value> {
+        let uri: trust_tasks_rs::TypeUri = vta_sdk::trust_tasks::TASK_VAULT_CREDENTIALS_GET_0_1
+            .parse()
+            .expect("get uri");
+        TrustTask::new("urn:uuid:test-get", uri, json!({ "id": id }))
+    }
+
+    fn query_doc() -> TrustTask<Value> {
+        let uri: trust_tasks_rs::TypeUri = vta_sdk::trust_tasks::TASK_VAULT_CREDENTIALS_QUERY_0_1
+            .parse()
+            .expect("query uri");
+        TrustTask::new(
+            "urn:uuid:test-query",
+            uri,
+            json!({ "issuerDid": "did:key:zIssuer" }),
+        )
+    }
+
+    /// `context_id` is documented as the **custody** axis — "which context in
+    /// *this* VTA owns the credential" — and the owning context's policy is
+    /// meant to govern disclosure. A caller scoped to ctx-a must not be able to
+    /// fetch a credential owned by ctx-b.
+    #[tokio::test]
+    async fn get_refuses_a_credential_owned_by_another_context() {
+        let (state, _dir) = crate::test_support::build_signing_test_app_state().await;
+        seed_credential(&state.vault_ks, "cred-in-ctx-b", Some("ctx-b")).await;
+
+        let auth = auth_scoped(&["ctx-a"]);
+        let outcome = handle_get(&state, &auth, get_doc("cred-in-ctx-b")).await;
+        let body = String::from_utf8_lossy(&outcome.body).to_string();
+        assert!(
+            !body.contains("cred-in-ctx-b") || body.contains("not found"),
+            "a ctx-a caller must not receive a ctx-b credential body; got {body}"
+        );
+    }
+
+    /// The caller's own context still works — the gate must not deny everything.
+    #[tokio::test]
+    async fn get_allows_a_credential_owned_by_the_callers_context() {
+        let (state, _dir) = crate::test_support::build_signing_test_app_state().await;
+        seed_credential(&state.vault_ks, "cred-in-ctx-a", Some("ctx-a")).await;
+
+        let auth = auth_scoped(&["ctx-a"]);
+        let outcome = handle_get(&state, &auth, get_doc("cred-in-ctx-a")).await;
+        let body = String::from_utf8_lossy(&outcome.body).to_string();
+        assert!(
+            body.contains("cred-in-ctx-a"),
+            "the caller's own context must still be readable; got {body}"
+        );
+    }
+
+    /// The query path is the bulk equivalent: a filtered search must not return
+    /// another context's credentials.
+    #[tokio::test]
+    async fn query_excludes_credentials_owned_by_another_context() {
+        let (state, _dir) = crate::test_support::build_signing_test_app_state().await;
+        seed_credential(&state.vault_ks, "cred-in-ctx-a", Some("ctx-a")).await;
+        seed_credential(&state.vault_ks, "cred-in-ctx-b", Some("ctx-b")).await;
+
+        let auth = auth_scoped(&["ctx-a"]);
+        let outcome = handle_query(&state, &auth, query_doc()).await;
+        let body = String::from_utf8_lossy(&outcome.body).to_string();
+        assert!(
+            body.contains("cred-in-ctx-a"),
+            "own-context credential must be returned; got {body}"
+        );
+        assert!(
+            !body.contains("cred-in-ctx-b"),
+            "another context's credential must not be returned; got {body}"
+        );
+    }
+
+    /// A super-admin (no context restriction) still sees everything.
+    #[tokio::test]
+    async fn super_admin_still_reads_every_context() {
+        let (state, _dir) = crate::test_support::build_signing_test_app_state().await;
+        seed_credential(&state.vault_ks, "cred-anywhere", Some("ctx-b")).await;
+
+        let auth = auth_scoped(&[]);
+        let outcome = handle_get(&state, &auth, get_doc("cred-anywhere")).await;
+        let body = String::from_utf8_lossy(&outcome.body).to_string();
+        assert!(
+            body.contains("cred-anywhere"),
+            "super admin must still read any context; got {body}"
+        );
+    }
+
+    fn lifecycle_doc(task: &str, id: &str, force: bool) -> TrustTask<Value> {
+        let uri: trust_tasks_rs::TypeUri = task.parse().expect("uri");
+        TrustTask::new(
+            "urn:uuid:test-lifecycle",
+            uri,
+            json!({ "id": id, "force": force }),
+        )
+    }
+
+    /// Mutating another context's credential is worse than reading it. The
+    /// lifecycle verbs shared the read paths' missing gate.
+    #[tokio::test]
+    async fn archive_refuses_a_credential_owned_by_another_context() {
+        let (state, _dir) = crate::test_support::build_signing_test_app_state().await;
+        seed_credential(&state.vault_ks, "cred-in-ctx-b", Some("ctx-b")).await;
+
+        let auth = auth_scoped(&["ctx-a"]);
+        let doc = lifecycle_doc(
+            vta_sdk::trust_tasks::TASK_VAULT_CREDENTIALS_ARCHIVE_0_1,
+            "cred-in-ctx-b",
+            false,
+        );
+        let _ = handle_archive(&state, &auth, doc).await;
+
+        let after = crate::vault::storage::get(&state.vault_ks, "cred-in-ctx-b")
+            .await
+            .unwrap()
+            .expect("credential must survive");
+        assert!(
+            after.is_active(),
+            "a ctx-a caller must not archive a ctx-b credential"
+        );
+    }
+
+    /// `delete --force` hard-deletes by id and previously never loaded the
+    /// record, so custody could not be checked at all — a scoped caller could
+    /// destroy another context's credential outright.
+    #[tokio::test]
+    async fn force_delete_refuses_a_credential_owned_by_another_context() {
+        let (state, _dir) = crate::test_support::build_signing_test_app_state().await;
+        seed_credential(&state.vault_ks, "cred-in-ctx-b", Some("ctx-b")).await;
+
+        let auth = auth_scoped(&["ctx-a"]);
+        let doc = lifecycle_doc(
+            vta_sdk::trust_tasks::TASK_VAULT_CREDENTIALS_DELETE_0_1,
+            "cred-in-ctx-b",
+            true,
+        );
+        let _ = handle_delete(&state, &auth, doc).await;
+
+        assert!(
+            crate::vault::storage::get(&state.vault_ks, "cred-in-ctx-b")
+                .await
+                .unwrap()
+                .is_some(),
+            "a ctx-a caller must not hard-delete a ctx-b credential"
+        );
+    }
+
+    /// …and the caller's own context still works, so the gate is not a blanket
+    /// denial.
+    #[tokio::test]
+    async fn force_delete_allows_the_callers_own_context() {
+        let (state, _dir) = crate::test_support::build_signing_test_app_state().await;
+        seed_credential(&state.vault_ks, "cred-in-ctx-a", Some("ctx-a")).await;
+
+        let auth = auth_scoped(&["ctx-a"]);
+        let doc = lifecycle_doc(
+            vta_sdk::trust_tasks::TASK_VAULT_CREDENTIALS_DELETE_0_1,
+            "cred-in-ctx-a",
+            true,
+        );
+        let _ = handle_delete(&state, &auth, doc).await;
+
+        assert!(
+            crate::vault::storage::get(&state.vault_ks, "cred-in-ctx-a")
+                .await
+                .unwrap()
+                .is_none(),
+            "the caller's own credential must still be deletable"
         );
     }
 

--- a/vta-service/src/vault/query.rs
+++ b/vta-service/src/vault/query.rs
@@ -72,6 +72,7 @@
 //! `Unknown` → `Valid`/`Revoked` is the status task's job, run before a
 //! present.
 
+use vti_common::acl::ActScope;
 use vti_common::error::AppError;
 use vti_common::store::KeyspaceHandle;
 use vti_common::vault::{VaultStatus, default_active};
@@ -283,6 +284,7 @@ fn matches_constraint(cred: &StoredCredential, field: IndexField, value: &str) -
 pub async fn search(
     vault: &KeyspaceHandle,
     query: &CredentialQuery,
+    caller: &ActScope,
 ) -> Result<Vec<CredentialDescriptor>, AppError> {
     // No-enumeration gate: reject an unfiltered query outright, before any
     // store access. This is the load-bearing check — without an explicit
@@ -329,6 +331,14 @@ pub async fn search(
         if is_excluded_status(cred.status) {
             continue;
         }
+        // Custody gate: `context_id` records which context in *this* VTA owns
+        // the credential, and a caller must not read another context's. This
+        // sits with the other post-filters because the full record is already
+        // loaded here — the descriptor the caller receives does not carry
+        // `context_id`, so filtering downstream would mean re-reading every hit.
+        if !caller_may_access_custody(caller, cred.context_id.as_deref()) {
+            continue;
+        }
         // The anchor already matched via the index; re-check the remaining
         // constraints in memory. AND semantics: any miss drops the record.
         let all_match = constraints[1..]
@@ -339,6 +349,26 @@ pub async fn search(
         }
     }
     Ok(out)
+}
+
+/// Whether a caller holding `caller` may read a credential whose custody
+/// context is `context_id`.
+///
+/// - An unrestricted (super-admin) caller reads every context.
+/// - A scoped caller reads only the contexts its [`ActScope`] covers, honouring
+///   ancestry like every other context check.
+/// - **`None` (unscoped) is readable by any caller**, deliberately. It is how
+///   records written before the field existed deserialize, and how a
+///   multi-context or super-admin `receive` still stores today
+///   (`resolve_custody_context`). Denying it would retroactively hide legacy
+///   credentials from the scoped callers currently using them. That carve-out
+///   is a compatibility decision, not an oversight — tightening it needs a
+///   backfill of `context_id` on existing rows first.
+pub fn caller_may_access_custody(caller: &ActScope, context_id: Option<&str>) -> bool {
+    match context_id {
+        None => true,
+        Some(ctx) => caller.covers(ctx),
+    }
 }
 
 /// `true` for the **validity** states that must never appear in a search
@@ -414,7 +444,7 @@ mod tests {
             issuer_did: Some("did:web:issuer.example".into()),
             ..Default::default()
         };
-        let hits = search(&vault, &q).await.unwrap();
+        let hits = search(&vault, &q, &ActScope::All).await.unwrap();
         assert_eq!(hits.len(), 1);
         let d = &hits[0];
         assert_eq!(d.id, "cred-1");
@@ -442,7 +472,7 @@ mod tests {
                 r#type: Some(tag.into()),
                 ..Default::default()
             };
-            let hits = search(&vault, &q).await.unwrap();
+            let hits = search(&vault, &q, &ActScope::All).await.unwrap();
             assert_eq!(hits.len(), 1, "type tag {tag} must match");
             assert_eq!(hits[0].id, "cred-1");
         }
@@ -460,7 +490,7 @@ mod tests {
             community_did: Some("did:web:acme".into()),
             ..Default::default()
         };
-        let hits = search(&vault, &q).await.unwrap();
+        let hits = search(&vault, &q, &ActScope::All).await.unwrap();
         assert_eq!(hits.len(), 1);
 
         let json = serde_json::to_string(&hits[0]).unwrap();
@@ -491,7 +521,7 @@ mod tests {
         // ...but a no-filter query cannot retrieve any of them.
         let empty = CredentialQuery::default();
         assert!(empty.is_empty());
-        let err = search(&vault, &empty).await.unwrap_err();
+        let err = search(&vault, &empty, &ActScope::All).await.unwrap_err();
         assert!(
             matches!(err, AppError::Validation(_)),
             "an unfiltered (enumerate-all) query must be rejected, got {err:?}"
@@ -504,7 +534,7 @@ mod tests {
             issuer_did: Some("did:web:other".into()),
             ..Default::default()
         };
-        let hits = search(&vault, &q).await.unwrap();
+        let hits = search(&vault, &q, &ActScope::All).await.unwrap();
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].id, "cred-2");
     }
@@ -530,7 +560,7 @@ mod tests {
             community_did: Some("did:web:acme".into()),
             ..Default::default()
         };
-        let mut ids = search(&vault, &q)
+        let mut ids = search(&vault, &q, &ActScope::All)
             .await
             .unwrap()
             .into_iter()
@@ -545,7 +575,7 @@ mod tests {
             purpose: Some(CredentialPurpose::Membership),
             ..Default::default()
         };
-        let hits = search(&vault, &q).await.unwrap();
+        let hits = search(&vault, &q, &ActScope::All).await.unwrap();
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].id, "cred-a");
 
@@ -556,7 +586,7 @@ mod tests {
             issuer_did: Some("did:web:nobody".into()),
             ..Default::default()
         };
-        assert!(search(&vault, &q).await.unwrap().is_empty());
+        assert!(search(&vault, &q, &ActScope::All).await.unwrap().is_empty());
     }
 
     #[tokio::test]
@@ -570,7 +600,7 @@ mod tests {
             status: Some(CredentialStatus::Valid),
             ..Default::default()
         };
-        let hits = search(&vault, &q).await.unwrap();
+        let hits = search(&vault, &q, &ActScope::All).await.unwrap();
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].id, "cred-valid");
         assert_eq!(hits[0].status, CredentialStatus::Valid);
@@ -600,7 +630,7 @@ mod tests {
             community_did: Some("did:web:acme".into()),
             ..Default::default()
         };
-        let hits = search(&vault, &q).await.unwrap();
+        let hits = search(&vault, &q, &ActScope::All).await.unwrap();
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].id, "cred-valid");
 
@@ -610,7 +640,7 @@ mod tests {
             ..Default::default()
         };
         assert!(
-            search(&vault, &q).await.unwrap().is_empty(),
+            search(&vault, &q, &ActScope::All).await.unwrap().is_empty(),
             "there is no search surface that returns revoked credentials"
         );
 
@@ -619,7 +649,7 @@ mod tests {
             status: Some(CredentialStatus::Expired),
             ..Default::default()
         };
-        assert!(search(&vault, &q).await.unwrap().is_empty());
+        assert!(search(&vault, &q, &ActScope::All).await.unwrap().is_empty());
     }
 
     #[tokio::test]
@@ -631,7 +661,7 @@ mod tests {
             issuer_did: Some("did:web:nonexistent".into()),
             ..Default::default()
         };
-        assert!(search(&vault, &q).await.unwrap().is_empty());
+        assert!(search(&vault, &q, &ActScope::All).await.unwrap().is_empty());
     }
 
     /// By default an archived credential is hidden; `include_archived` opts it
@@ -652,7 +682,7 @@ mod tests {
             community_did: Some("did:web:acme".into()),
             ..Default::default()
         };
-        let hits = search(&vault, &base).await.unwrap();
+        let hits = search(&vault, &base, &ActScope::All).await.unwrap();
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].id, "cred-active");
         // The active descriptor omits the lifecycle key (defaults to active).
@@ -663,7 +693,7 @@ mod tests {
             include_archived: true,
             ..base.clone()
         };
-        let mut hits = search(&vault, &q).await.unwrap();
+        let mut hits = search(&vault, &q, &ActScope::All).await.unwrap();
         hits.sort_by(|a, b| a.id.cmp(&b.id));
         assert_eq!(hits.len(), 2);
         let arch = hits.iter().find(|d| d.id == "cred-archived").unwrap();
@@ -679,7 +709,7 @@ mod tests {
             include_deleted: true,
             ..base
         };
-        let hits = search(&vault, &q).await.unwrap();
+        let hits = search(&vault, &q, &ActScope::All).await.unwrap();
         assert_eq!(hits.len(), 1, "include_deleted must not surface archived");
         assert_eq!(hits[0].id, "cred-active");
     }
@@ -701,13 +731,18 @@ mod tests {
             purpose: Some(CredentialPurpose::Invite),
             ..Default::default()
         };
-        assert!(search(&vault, &base).await.unwrap().is_empty());
+        assert!(
+            search(&vault, &base, &ActScope::All)
+                .await
+                .unwrap()
+                .is_empty()
+        );
         let q = CredentialQuery {
             include_archived: true,
             ..base.clone()
         };
         assert!(
-            search(&vault, &q).await.unwrap().is_empty(),
+            search(&vault, &q, &ActScope::All).await.unwrap().is_empty(),
             "include_archived must not surface a tombstone"
         );
 
@@ -716,7 +751,7 @@ mod tests {
             include_deleted: true,
             ..base
         };
-        let hits = search(&vault, &q).await.unwrap();
+        let hits = search(&vault, &q, &ActScope::All).await.unwrap();
         assert_eq!(hits.len(), 1);
         let d = &hits[0];
         assert_eq!(d.lifecycle, VaultStatus::Deleted);
@@ -751,7 +786,7 @@ mod tests {
             },
         ] {
             assert!(q.is_empty(), "include flags must not count as a filter");
-            let err = search(&vault, &q).await.unwrap_err();
+            let err = search(&vault, &q, &ActScope::All).await.unwrap_err();
             assert!(
                 matches!(err, AppError::Validation(_)),
                 "an include-only query must still be refused as enumeration"
@@ -777,7 +812,7 @@ mod tests {
             ..Default::default()
         };
         assert!(
-            search(&vault, &q).await.unwrap().is_empty(),
+            search(&vault, &q, &ActScope::All).await.unwrap().is_empty(),
             "a revoked credential is never surfaced by search, even when archived \
              and explicitly included"
         );
@@ -795,7 +830,7 @@ mod tests {
             issuer_did: Some("did:web:issuer.example".into()),
             ..Default::default()
         };
-        let hits = search(&vault, &q).await.unwrap();
+        let hits = search(&vault, &q, &ActScope::All).await.unwrap();
         assert_eq!(hits.len(), 1);
         let json = serde_json::to_string(&hits[0]).unwrap();
         for key in ["lifecycle", "archivedAt", "deletedAt", "graceUntil"] {

--- a/vta-service/src/vault/status.rs
+++ b/vta-service/src/vault/status.rs
@@ -653,6 +653,7 @@ mod tests {
     use crate::vault::query::{CredentialQuery, search};
     use crate::vault::storage::put;
     use std::collections::BTreeMap;
+    use vti_common::acl::ActScope;
     use vti_common::config::StoreConfig;
     use vti_common::store::Store;
 
@@ -791,7 +792,7 @@ mod tests {
             issuer_did: Some("did:web:issuer.example".into()),
             ..Default::default()
         };
-        assert_eq!(search(&vault, &q).await.unwrap().len(), 1);
+        assert_eq!(search(&vault, &q, &ActScope::All).await.unwrap().len(), 1);
 
         let resolver = MockResolver::new(Some(42), StatusPurpose::Revocation);
         let outcome = refresh_status(&vault, "cred-revoked", &resolver)
@@ -812,7 +813,7 @@ mod tests {
         assert_eq!(stored.status, CredentialStatus::Revoked);
 
         // CRITICAL (§14 invariant 5): the revoked credential is EXCLUDED from search.
-        let hits = search(&vault, &q).await.unwrap();
+        let hits = search(&vault, &q, &ActScope::All).await.unwrap();
         assert!(
             hits.is_empty(),
             "a revoked credential must not be surfaced by search, got {hits:?}"
@@ -845,7 +846,7 @@ mod tests {
             issuer_did: Some("did:web:issuer.example".into()),
             ..Default::default()
         };
-        let hits = search(&vault, &q).await.unwrap();
+        let hits = search(&vault, &q, &ActScope::All).await.unwrap();
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].id, "cred-ok");
     }


### PR DESCRIPTION
## The defect

`StoredCredential.context_id` is documented as the **custody** axis:

> **Custody** axis: which context in *this* VTA owns the credential — distinct from `community_did` (provenance). The owning context's `ContextPolicy` governs disclosure of this credential.

No path enforced it. Every credential-vault trust task gated on the caller's *capability* and then read or mutated by id.

## Verified before fixing

Tests written against the unmodified code, and they fail:

```
get_refuses_a_credential_owned_by_another_context ... FAILED
  got {"payload":{"credential":{"id":"cred-in-ctx-b"}}}

query_excludes_credentials_owned_by_another_context ... FAILED
  got {"credentials":[{"id":"cred-in-ctx-a"...},{"id":"cred-in-ctx-b"...}]}
```

A caller scoped to `ctx-a` receives `ctx-b`'s credential body from `get`, and both contexts' rows from `query`.

## Scope — reads were only half of it

| verb | before |
|---|---|
| `query`, `get` | returns any context's credentials |
| `archive`, `unarchive`, `restore` | mutates any context's credential |
| `delete`, `purge` | destroys any context's credential |

**`delete --force` was the worst.** It hard-deleted by id *without loading the record at all* — "works even on an absent id — idempotent" — so custody could not be checked even in principle. A scoped caller could destroy another context's credential outright. It now loads first; an absent id stays idempotent-success, a present-but-inaccessible one conflates to not-found.

I widened past the two read paths deliberately: shipping a read fix while leaving cross-context *destruction* open would not have been defensible.

## The fix

One predicate, `caller_may_access_custody(&ActScope, Option<&str>)`, backs every path.

In `search` it sits with the existing lifecycle and status post-filters, where the full `StoredCredential` is already loaded — so it costs nothing. That placement is forced, not chosen: `CredentialDescriptor` carries no `context_id`, so filtering downstream would mean re-reading every hit.

Inaccessible credentials conflate to **not-found**, matching how archived and absent ones are already reported, so the gate is not an enumeration oracle.

## Two decisions worth reviewing

**1. Unscoped (`context_id: None`) credentials stay readable by any caller.** That is how rows written before the field existed deserialize, and how a multi-context or super-admin `receive` still stores today (`resolve_custody_context`). Denying it would retroactively hide legacy credentials from the scoped callers currently using them.

This is a compatibility carve-out, documented as such at the predicate. It is technically the same "empty means unrestricted" shape that caused #746/#769/#770, so it should be tightened — but that needs a `context_id` backfill on existing rows first, not a one-line change here.

**2. The credential-exchange presentation path is unchanged**, passing `ActScope::All` with an explicit comment. That is the holder presenting its own store to a verifier, governed by the context-policy guardrail in `present_query` plus consent — a different question from "may this caller read this context's credentials". Narrowing it would change which credentials are presentable and needs `auth` threaded through `match_vault` first.

## Tests

12 in `cred_vault`: cross-context refusal and own-context success for `get`, exclusion for `query`, super-admin unaffected, plus `archive` and `delete --force` refusing another context while the caller's own still works.

`cargo test -p vta-service`: **1239 passed, 0 failed**. Clippy and fmt clean.

## Also

Removes a duplicated `### vta-service 0.12.17` changelog heading left by an earlier rebase of #769 — `0.12.18` is what shipped. My error, fixed here since it is the same file.

Same defect class as #769, in the sibling file that fix did not cover.