### PR TITLE
feat(agent-names): give the agent-name producer a caller

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,23 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # `cargo test --workspace` builds a test binary for every crate with
+      # full debuginfo, and the total (target/ plus the linker's scratch)
+      # runs the ubuntu-latest runner's ~14 GB of free root disk right to the
+      # edge. It began failing intermittently with "No space left on device"
+      # while linking the largest binary (libvta_service). The preinstalled
+      # Android SDK, .NET and GHC toolchains are ~20 GB we never use, so
+      # reclaiming them buys comfortable headroom. Test-only: no other job
+      # links the whole workspace at once, so none needs this.
+      # NB: do NOT remove $AGENT_TOOLSDIRECTORY (/opt/hostedtoolcache) — it
+      # holds the runner's node, and vtc-service's build.rs shells out to
+      # `npm run build` for the admin UI. Android + .NET + GHC are ~13 GB we
+      # never touch and are safe to reclaim.
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc
+          df -h /
+
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,74 @@
 
 ## Unreleased
 
+### vta-sdk 0.19.27 / vta-cli-common 0.10.13 / pnm-cli 0.11.8 / cnm-cli 0.11.6 / vta-service 0.12.25 / vtc-service 0.11.23 — give agent names a caller
+
+* The producer machinery for agent names was already complete — inbound
+  Trust-Task handlers for all six verbs, an operations layer that edits the DID
+  document's `alsoKnownAs` and republishes the signed log, and outbound calls to
+  the DID-hosting control plane over both REST and DIDComm. What it had was no
+  caller: no `VtaClient` methods, no CLI, so the only way to reach any of it was
+  a hand-rolled Trust Task.
+
+* **`pnm did-mgmt agent-names {set,check,list,remove,enable,disable}`**, on six
+  new `VtaClient` methods. Trust-task-only, and no new REST route was needed:
+  `dispatch_trust_task` posts to `/api/trust-tasks` on a REST transport and
+  rides the DIDComm envelope otherwise, so both reach the same handler.
+
+* `remove` and `disable` are deliberately distinct and the CLI says so at the
+  point of use — remove frees the name for anyone to claim, disable parks it so
+  it stops resolving while staying reserved to this DID. `list` reads the
+  hosting registry rather than the DID document, because a parked name is
+  absent from the document by design and would otherwise be invisible.
+
+* **`--resolve-agent-names`** turns on verified name resolution in display
+  output, and `pnm-cli` now enables the `agent-names` feature that backs it —
+  without which the flag would have parsed and done nothing. Off by default: a
+  lookup is a DID resolution plus an outbound fetch per claimed name, per DID
+  on screen. Wired into `acl list` / `acl get` (including the `created_by`
+  column, where an unfamiliar DID most often appears) and the hosted-DID list,
+  which is where names can actually exist.
+
+* **Fixed a real divergence**: reading a DID's names over DIDComm treated a
+  missing `agentNames` field as an internal error while the REST path treated
+  it as an empty list. A host predating the registry omits the field entirely,
+  so the same DID appeared to have names or not depending on how the VTA
+  happened to reach its host. Both are tolerant now.
+
+* Named DIDs also reach the remaining surfaces skipped last time: the hosted
+  `did:webvh` list, the DID-hosting server list, and `vtc create-did-key`,
+  which was storing an operator-supplied label and never showing it. `vtc
+  status`, `pnm doctor` and `cnm` report the names a resolved document claims,
+  marked unverified — free, since the document is already in hand.
+
+* **Correction.** The previous entry claimed "nothing in this workspace
+  publishes `alsoKnownAs` yet". That was false: `operations::did_webvh`'s
+  `edit_agent_name` has been writing the claim and republishing all along. The
+  claim was true of DID *templates*, which is where it was checked, and wrongly
+  generalised to the workspace. The same error was repeated in the
+  `display_name` module docs; both are corrected.
+
+* **A cross-repo contract test.** What the VTA writes into `alsoKnownAs` is
+  read back by the hosting server with `agent_names::AgentName::parse`, keeping
+  only entries whose authority matches the domain it serves. If our emitted
+  form ever stops satisfying that parser nothing errors — the claim is simply
+  never indexed and the name silently 404s. The test now uses the host's own
+  parser rather than asserting our format against itself.
+
+* `cnm` gains `--resolve-agent-names` for display parity. It has no
+  `did-mgmt` surface, so it gets the flag but not the binding commands.
+
+* CI: the Test job reclaims the runner's preinstalled Android/.NET/GHC
+  toolchains before building. `cargo test --workspace` links a test binary
+  per crate with full debuginfo and had begun exhausting the runner's root
+  disk while linking the largest one; this is the standard headroom fix and
+  helps every future PR, not just this one.
+
+* `sealed_producer` banners are deliberately left showing bare, full DIDs —
+  those DIDs are minted seconds before they are printed, so there is no name to
+  show, and the operator is copying an exact identifier for handoff.
+
+
 ### vti-common 0.11.19 / vta-service 0.12.24 / vtc-service 0.11.22 — let a context admin create a least-privilege approver
 
 * `validate_acl_modification` saw only the target's context list, never its
@@ -191,10 +259,8 @@
   claim `mybank.com/@treasury`. Every claim is round-tripped (resolve the name
   forward, require it to lead back to the same DID) before being shown
   unqualified; one that fails surfaces as unverified, ranks below every local
-  source, and never renders bare. Nothing in this workspace publishes
-  `alsoKnownAs` yet, so no agent name resolves here today — this is the
-  consumer half, built so that minting names lights up every surface without
-  touching a display site.
+  source, and never renders bare. See the agent-name entry below for the
+  producer side.
 
 * `PATCH /v1/members/{did}` accepts `label`. The VTC's only human name for a
   member lives on the ACL row, which meant correcting a typo in a display name

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2488,7 +2488,7 @@ checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cnm-cli"
-version = "0.11.5"
+version = "0.11.6"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "clap",
@@ -6759,7 +6759,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "pnm-cli"
-version = "0.11.7"
+version = "0.11.8"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-resolver-cache-sdk",
@@ -10079,7 +10079,7 @@ dependencies = [
 
 [[package]]
 name = "vta-cli-common"
-version = "0.10.12"
+version = "0.10.13"
 dependencies = [
  "aes-gcm",
  "affinidi-crypto",
@@ -10158,7 +10158,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.19.26"
+version = "0.19.27"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10220,7 +10220,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.12.24"
+version = "0.12.25"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",
@@ -10240,6 +10240,7 @@ dependencies = [
  "affinidi-status-list",
  "affinidi-tdk",
  "affinidi-tdk-common",
+ "agent-names",
  "argon2",
  "async-trait",
  "aws-config",
@@ -10327,7 +10328,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-service"
-version = "0.11.22"
+version = "0.11.23"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/cnm-cli/Cargo.toml
+++ b/cnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cnm-cli"
 description = "CLI Tool for Verified Trust Agents operating in Verified Trust Communities"
-version = "0.11.5"
+version = "0.11.6"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -22,7 +22,11 @@ azure-secrets = ["vta-sdk/azure-secrets"]
 
 [dependencies]
 vta-sdk = { path = "../vta-sdk", version = "0.19", features = ["session", "crypto-provider", "acl-setup"] }
-vta-cli-common = { path = "../vta-cli-common", version = "0.10" }
+# `agent-names` powers the global `--resolve-agent-names` flag; without it
+# the flag parses but can never resolve anything.
+vta-cli-common = { path = "../vta-cli-common", version = "0.10", features = [
+  "agent-names",
+] }
 affinidi-did-resolver-cache-sdk = { workspace = true }
 clap = { workspace = true, features = ["env"] }
 dialoguer = { workspace = true }

--- a/cnm-cli/src/main.rs
+++ b/cnm-cli/src/main.rs
@@ -49,6 +49,15 @@ struct Cli {
     #[arg(long, global = true)]
     full_display: bool,
 
+    /// Resolve verified agent names for the DIDs shown.
+    ///
+    /// Off by default because it costs network: one DID resolution plus an
+    /// outbound fetch per name a document claims, per DID on screen. A claim
+    /// that does not round-trip back to its DID is marked `[unverified]`
+    /// rather than believed — `alsoKnownAs` alone is self-asserted.
+    #[arg(long, global = true)]
+    resolve_agent_names: bool,
+
     /// Emit list output as JSON instead of a human-readable table.
     /// Use this for automation: `cnm acl list --json | jq …`.
     #[arg(long, global = true)]
@@ -866,6 +875,7 @@ async fn main() {
     // Propagate --full-display to the shared render module so list
     // commands from vta-cli-common pick it up.
     vta_cli_common::render::set_full_display(cli.full_display);
+    vta_cli_common::display::set_resolve_agent_names(cli.resolve_agent_names);
     if cli.json {
         vta_cli_common::render::set_output_format(vta_cli_common::render::OutputFormat::Json);
     }

--- a/pnm-cli/Cargo.toml
+++ b/pnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pnm-cli"
 description = "CLI Tool for managing a personal Verifiable Trust Agent"
-version = "0.11.7"
+version = "0.11.8"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -33,7 +33,11 @@ affinidi-crypto = { workspace = true }
 base64 = { workspace = true }
 reqwest = { workspace = true }
 sha2 = { workspace = true }
-vta-cli-common = { path = "../vta-cli-common", version = "0.10" }
+# `agent-names` powers the global `--resolve-agent-names` flag; without it
+# the flag parses but can never resolve anything.
+vta-cli-common = { path = "../vta-cli-common", version = "0.10", features = [
+  "agent-names",
+] }
 affinidi-did-resolver-cache-sdk = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true, features = ["env"] }

--- a/pnm-cli/src/cli.rs
+++ b/pnm-cli/src/cli.rs
@@ -52,6 +52,16 @@ pub(crate) struct Cli {
     #[arg(long, global = true)]
     pub(crate) full_display: bool,
 
+    /// Resolve verified agent names for the DIDs shown.
+    ///
+    /// Off by default because it costs network: one DID resolution plus an
+    /// outbound fetch per name a document claims, per DID on screen. A name
+    /// is shown as this DID's only if resolving it leads back to that same
+    /// DID — `alsoKnownAs` alone is self-asserted, so a claim that does not
+    /// round-trip is marked `[unverified]` rather than believed.
+    #[arg(long, global = true)]
+    pub(crate) resolve_agent_names: bool,
+
     /// Emit list output as JSON instead of a human-readable table.
     /// Use this for automation: `pnm acl list --json | jq …`.
     #[arg(long, global = true)]
@@ -877,6 +887,68 @@ pub(crate) enum DidMgmtCommands {
         #[command(subcommand)]
         command: DidMgmtDidCommands,
     },
+    /// Manage agent names — human-memorable `domain/@name` shortcuts that
+    /// resolve to one of your hosted DIDs.
+    ///
+    /// Binding a name edits the DID document's `alsoKnownAs` and republishes
+    /// the signed log. That claim is what authorises the hosting server to
+    /// serve the `/@name` redirect, so a name only ever resolves for a DID
+    /// that has actually claimed it.
+    AgentNames {
+        #[command(subcommand)]
+        command: DidMgmtAgentNameCommands,
+    },
+}
+
+/// `pnm did-mgmt agent-names {…}` — bind and inspect agent names.
+#[derive(Subcommand)]
+pub(crate) enum DidMgmtAgentNameCommands {
+    /// Bind a name to a hosted DID.
+    Set {
+        /// The hosted DID to bind the name to.
+        #[arg(long)]
+        did: String,
+        /// The name's local part — no `@`, 2-63 chars of `[a-z0-9-]`,
+        /// alphanumeric at both ends. The domain comes from the DID.
+        #[arg(long)]
+        name: String,
+    },
+    /// Release a name entirely, freeing it for anyone else to claim.
+    ///
+    /// To stop a name resolving while keeping it reserved to this DID, use
+    /// `disable` instead.
+    Remove {
+        #[arg(long)]
+        did: String,
+        #[arg(long)]
+        name: String,
+    },
+    /// Park a name: stop it resolving, keep it reserved to this DID.
+    Disable {
+        #[arg(long)]
+        did: String,
+        #[arg(long)]
+        name: String,
+    },
+    /// Bring a parked name back into service.
+    Enable {
+        #[arg(long)]
+        did: String,
+        #[arg(long)]
+        name: String,
+    },
+    /// List every name bound to a DID, including parked ones.
+    List {
+        #[arg(long)]
+        did: String,
+    },
+    /// Check whether a name is free on the DID's hosting domain.
+    Check {
+        #[arg(long)]
+        did: String,
+        #[arg(long)]
+        name: String,
+    },
 }
 
 /// `pnm did-mgmt servers {…}` — controller-side server registry.
@@ -1118,6 +1190,12 @@ impl From<DidMgmtCommands> for WebvhCommands {
                 }
                 DidMgmtServerCommands::Remove { id } => WebvhCommands::RemoveServer { id },
             },
+            // Intercepted in `main.rs` before this bridge is reached — agent
+            // names are a new surface and deliberately have no legacy
+            // `WebvhCommands` equivalent to bridge into.
+            DidMgmtCommands::AgentNames { .. } => {
+                unreachable!("agent-names is dispatched before the legacy bridge")
+            }
             DidMgmtCommands::Dids { command } => match command {
                 DidMgmtDidCommands::Create {
                     context,

--- a/pnm-cli/src/commands/agent_names.rs
+++ b/pnm-cli/src/commands/agent_names.rs
@@ -1,0 +1,34 @@
+//! `pnm did-mgmt agent-names …` dispatch.
+//!
+//! The implementations live in `vta_cli_common::commands::agent_names` so
+//! `cnm` can adopt the same surface without duplication.
+
+use vta_sdk::prelude::*;
+
+/// Dispatch `pnm did-mgmt agent-names …`.
+pub async fn run(
+    client: &VtaClient,
+    command: crate::cli::DidMgmtAgentNameCommands,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use crate::cli::DidMgmtAgentNameCommands as C;
+    match command {
+        C::Set { did, name } => {
+            vta_cli_common::commands::agent_names::cmd_agent_name_set(client, &did, &name).await
+        }
+        C::Remove { did, name } => {
+            vta_cli_common::commands::agent_names::cmd_agent_name_remove(client, &did, &name).await
+        }
+        C::Disable { did, name } => {
+            vta_cli_common::commands::agent_names::cmd_agent_name_disable(client, &did, &name).await
+        }
+        C::Enable { did, name } => {
+            vta_cli_common::commands::agent_names::cmd_agent_name_enable(client, &did, &name).await
+        }
+        C::List { did } => {
+            vta_cli_common::commands::agent_names::cmd_agent_name_list(client, &did).await
+        }
+        C::Check { did, name } => {
+            vta_cli_common::commands::agent_names::cmd_agent_name_check(client, &did, &name).await
+        }
+    }
+}

--- a/pnm-cli/src/commands/mod.rs
+++ b/pnm-cli/src/commands/mod.rs
@@ -9,6 +9,7 @@
 //! a `VtaClient` per that decision.
 
 pub(crate) mod acl;
+pub(crate) mod agent_names;
 pub(crate) mod audit;
 pub(crate) mod auth;
 pub(crate) mod auth_credential;

--- a/pnm-cli/src/main.rs
+++ b/pnm-cli/src/main.rs
@@ -62,6 +62,7 @@ async fn main() {
     // handlers — picks up the setting without threading a bool through
     // every signature.
     vta_cli_common::render::set_full_display(cli.full_display);
+    vta_cli_common::display::set_resolve_agent_names(cli.resolve_agent_names);
     if cli.json {
         vta_cli_common::render::set_output_format(vta_cli_common::render::OutputFormat::Json);
     }
@@ -287,6 +288,12 @@ async fn main() {
         Commands::AuthCredential { command } => {
             commands::auth_credential::run(&client, command).await
         }
+        // `agent-names` is intercepted here rather than routed through the
+        // legacy `WebvhCommands` bridge below — that enum is slated for
+        // removal, so new surfaces should not grow it.
+        Commands::DidMgmt {
+            command: cli::DidMgmtCommands::AgentNames { command },
+        } => commands::agent_names::run(&client, command).await,
         Commands::DidMgmt { command } => commands::webvh::run(&client, command.into()).await,
         Commands::Audit { command } => commands::audit::run(&client, command).await,
         Commands::Backup { command } => commands::backup::run(&client, command).await,

--- a/vta-cli-common/Cargo.toml
+++ b/vta-cli-common/Cargo.toml
@@ -2,13 +2,18 @@
 name = "vta-cli-common"
 description = "Shared CLI command handlers and rendering helpers for VTA CLIs"
 readme = "README.md"
-version = "0.10.12"
+version = "0.10.13"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
+
+[features]
+# Verified agent-name resolution behind `--resolve-agent-names`.
+# Forwarded to `vta-sdk`; off by default because a lookup costs network.
+agent-names = ["vta-sdk/agent-names"]
 
 [dependencies]
 vta-sdk = { path = "../vta-sdk", version = "0.19", features = [

--- a/vta-cli-common/src/commands/acl.rs
+++ b/vta-cli-common/src/commands/acl.rs
@@ -9,7 +9,7 @@ use vti_common::acl::{Role, act_scope_for};
 
 use crate::display::{
     NAME_HEADER, NameBook, NameSource, book_from_acl, did_cell, full_display_pairs, name_cell,
-    named_did_cell,
+    named_did_cell, resolve_agent_names_into,
 };
 use crate::render::{is_full_display, print_full_entry_owned, print_full_list_title, print_widget};
 
@@ -92,6 +92,15 @@ pub async fn cmd_acl_list(
     // always holds an ACL entry of their own.
     let mut book = NameBook::new();
     book_from_acl(&mut book, &resp.entries);
+    // Opt-in, and only over the DIDs actually on screen — including the
+    // `created_by` column, which is where an unfamiliar DID most often shows up.
+    resolve_agent_names_into(
+        &mut book,
+        resp.entries
+            .iter()
+            .flat_map(|e| [e.did.as_str(), e.created_by.as_str()]),
+    )
+    .await;
 
     if is_full_display() {
         print_full_list_title("ACL Entries", resp.entries.len());
@@ -188,6 +197,7 @@ pub async fn cmd_acl_get(client: &VtaClient, did: &str) -> Result<(), Box<dyn st
 
     let mut book = NameBook::new();
     book.insert_opt(&entry.did, entry.label.as_deref(), NameSource::AclLabel);
+    resolve_agent_names_into(&mut book, [entry.did.as_str()]).await;
 
     // Name above DID, DID in full — a single-entry view is where an operator
     // copies an identifier from.

--- a/vta-cli-common/src/commands/agent_names.rs
+++ b/vta-cli-common/src/commands/agent_names.rs
@@ -1,0 +1,238 @@
+//! `pnm did-mgmt agent-names …` — bind and inspect agent names.
+//!
+//! An agent name is a human-memorable `domain/@name` that resolves to a DID.
+//! Binding one edits the DID document's `alsoKnownAs` and republishes the
+//! signed log; the hosting server then serves `/@name` as a redirect to the
+//! DID — but *only* for a name the signed document claims, which it re-derives
+//! from the log on every publish. So the claim in the document is not a hint,
+//! it is the authorisation.
+//!
+//! That is one half of the binding. The other half — confirming a name leads
+//! back to the DID that claims it — is what
+//! [`vta_sdk::display_name::agent_name`] does on the reading side, and why
+//! `--resolve-agent-names` exists.
+
+use vta_sdk::prelude::*;
+
+use crate::display::shorten_did;
+use crate::render::{BOLD, CYAN, DIM, GREEN, RESET, YELLOW, is_json_output, print_json};
+
+/// The full name as an operator would type or read it, e.g.
+/// `webvh.storm.ws/@ops`.
+///
+/// Derived from the DID's host rather than asked for, because the domain is
+/// not the operator's to choose — it is wherever the DID is hosted, and the
+/// hosting server keys its index on exactly that.
+fn qualified(did: &str, name: &str) -> String {
+    match domain_of(did) {
+        Some(domain) => format!("{domain}/@{name}"),
+        None => format!("@{name}"),
+    }
+}
+
+/// The host component of a `did:webvh` / `did:web` identifier.
+///
+/// `did:webvh:<scid>:<host>[:<path>…]`, with the host percent-decoded because
+/// a port is encoded (`localhost%3A8534`).
+fn domain_of(did: &str) -> Option<String> {
+    let mut parts = did.split(':');
+    if parts.next()? != "did" {
+        return None;
+    }
+    let method = parts.next()?;
+    if method != "webvh" && method != "web" {
+        return None;
+    }
+    let _scid = parts.next()?;
+    let host = parts.next()?;
+    Some(host.replace("%3A", ":").replace("%3a", ":"))
+}
+
+pub async fn cmd_agent_name_set(
+    client: &VtaClient,
+    did: &str,
+    name: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let result = client.set_agent_name(did, name).await?;
+    if is_json_output() {
+        print_json(&result)?;
+        return Ok(());
+    }
+    println!("{GREEN}\u{2713}{RESET} Agent name bound.");
+    println!(
+        "  {CYAN}Name:{RESET}   {BOLD}{}{RESET}",
+        qualified(did, name)
+    );
+    println!("  {CYAN}DID:{RESET}    {did}");
+    println!(
+        "  {DIM}The DID document now claims this name; the hosting server \
+         serves it as a redirect.{RESET}"
+    );
+    Ok(())
+}
+
+pub async fn cmd_agent_name_remove(
+    client: &VtaClient,
+    did: &str,
+    name: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let result = client.remove_agent_name(did, name).await?;
+    if is_json_output() {
+        print_json(&result)?;
+        return Ok(());
+    }
+    println!(
+        "{GREEN}\u{2713}{RESET} Agent name released: {}",
+        qualified(did, name)
+    );
+    println!(
+        "  {DIM}The claim is gone from the DID document and the name is free \
+         for anyone to claim. Use `disable` instead to keep it reserved.{RESET}"
+    );
+    Ok(())
+}
+
+pub async fn cmd_agent_name_disable(
+    client: &VtaClient,
+    did: &str,
+    name: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let result = client.disable_agent_name(did, name).await?;
+    if is_json_output() {
+        print_json(&result)?;
+        return Ok(());
+    }
+    println!(
+        "{GREEN}\u{2713}{RESET} Agent name parked: {}",
+        qualified(did, name)
+    );
+    println!(
+        "  {DIM}It no longer resolves, but stays reserved to this DID. \
+         Re-enable with `agent-names enable`.{RESET}"
+    );
+    Ok(())
+}
+
+pub async fn cmd_agent_name_enable(
+    client: &VtaClient,
+    did: &str,
+    name: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let result = client.enable_agent_name(did, name).await?;
+    if is_json_output() {
+        print_json(&result)?;
+        return Ok(());
+    }
+    println!(
+        "{GREEN}\u{2713}{RESET} Agent name back in service: {}",
+        qualified(did, name)
+    );
+    Ok(())
+}
+
+pub async fn cmd_agent_name_list(
+    client: &VtaClient,
+    did: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let result = client.list_agent_names(did).await?;
+    if is_json_output() {
+        print_json(&result)?;
+        return Ok(());
+    }
+
+    if result.names.is_empty() {
+        println!("No agent names bound to {}.", shorten_did(did));
+        println!("  {DIM}Bind one with `agent-names set --did <did> --name <name>`.{RESET}");
+        return Ok(());
+    }
+
+    println!();
+    println!("{BOLD}Agent names for {}{RESET}", shorten_did(did));
+    println!();
+    for entry in &result.names {
+        // A parked name is deliberately absent from the DID document, so it
+        // would be invisible if we only read the document — this listing comes
+        // from the hosting registry, which is why it can show them at all.
+        let state = if entry.enabled {
+            format!("{GREEN}resolves{RESET}")
+        } else {
+            format!("{YELLOW}parked{RESET}")
+        };
+        println!("  {BOLD}{}{RESET}  {state}", qualified(did, &entry.name));
+    }
+    println!();
+    Ok(())
+}
+
+pub async fn cmd_agent_name_check(
+    client: &VtaClient,
+    did: &str,
+    name: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let result = client.check_agent_name(did, name).await?;
+    if is_json_output() {
+        print_json(&result)?;
+        return Ok(());
+    }
+
+    let full = format!("{}/@{}", result.domain, result.name);
+    if result.reserved {
+        println!("{YELLOW}\u{2717}{RESET} {full} is reserved.");
+        println!(
+            "  {DIM}Reserved names (admin, api, support, …) are withheld to \
+             make impersonation harder.{RESET}"
+        );
+    } else if result.available {
+        println!("{GREEN}\u{2713}{RESET} {full} is available.");
+        println!(
+            "  {DIM}Advisory only — it can be taken before you bind it, so \
+             `set` reports its own conflict.{RESET}"
+        );
+    } else {
+        println!("{YELLOW}\u{2717}{RESET} {full} is taken.");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn domain_comes_from_the_did_not_the_operator() {
+        assert_eq!(
+            domain_of("did:webvh:QmScid:webvh.storm.ws:glenn-vta").as_deref(),
+            Some("webvh.storm.ws")
+        );
+        assert_eq!(
+            domain_of("did:web:QmScid:example.com").as_deref(),
+            Some("example.com")
+        );
+    }
+
+    #[test]
+    fn a_ported_host_is_percent_decoded() {
+        // Hosting encodes the colon; rendering it raw would print a name no
+        // operator could paste back.
+        assert_eq!(
+            domain_of("did:webvh:QmScid:localhost%3A8534").as_deref(),
+            Some("localhost:8534")
+        );
+    }
+
+    #[test]
+    fn a_non_web_did_has_no_domain() {
+        assert!(domain_of("did:key:z6MkfrQjWz").is_none());
+        assert!(domain_of("not-a-did").is_none());
+    }
+
+    #[test]
+    fn qualified_falls_back_to_the_bare_local_part() {
+        // Better than inventing a domain we cannot derive.
+        assert_eq!(qualified("did:key:z6MkfrQjWz", "ops"), "@ops");
+        assert_eq!(
+            qualified("did:webvh:QmScid:webvh.storm.ws", "ops"),
+            "webvh.storm.ws/@ops"
+        );
+    }
+}

--- a/vta-cli-common/src/commands/mod.rs
+++ b/vta-cli-common/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod acl;
+pub mod agent_names;
 pub mod audit;
 pub mod config;
 pub mod contexts;

--- a/vta-cli-common/src/commands/webvh.rs
+++ b/vta-cli-common/src/commands/webvh.rs
@@ -6,7 +6,12 @@ use ratatui::{
 use vta_sdk::client::{AddWebvhServerRequest, CreateDidWebvhRequest, UpdateWebvhServerRequest};
 use vta_sdk::prelude::*;
 
-use crate::render::{is_full_display, print_full_entry, print_full_list_title, print_widget};
+use crate::display::{
+    NAME_HEADER, NameBook, book_from_vta, book_from_webvh_servers, did_cell, full_display_pairs,
+    name_cell, resolve_agent_names_into,
+};
+
+use crate::render::{is_full_display, print_full_entry_owned, print_full_list_title, print_widget};
 
 pub async fn cmd_webvh_server_add(
     client: &VtaClient,
@@ -33,21 +38,24 @@ pub async fn cmd_webvh_server_list(client: &VtaClient) -> Result<(), Box<dyn std
         return Ok(());
     }
 
+    // A hosting server's `label` is its name. Routing it through the book
+    // rather than printing it directly means a verified agent name will
+    // outrank it once these DIDs publish one.
+    let mut book = NameBook::new();
+    book_from_webvh_servers(&mut book, &resp.servers);
+
     if is_full_display() {
         print_full_list_title("WebVH Servers", resp.servers.len());
         for s in &resp.servers {
-            let label = s.label.as_deref().unwrap_or("—");
             let created = s
                 .created_at
                 .with_timezone(&chrono::Local)
                 .format("%Y-%m-%d %H:%M:%S %:z")
                 .to_string();
-            print_full_entry(&[
-                ("ID", &s.id),
-                ("DID", &s.did),
-                ("Label", label),
-                ("Created", &created),
-            ]);
+            let mut fields = vec![("ID", s.id.clone())];
+            fields.extend(full_display_pairs(&book, &s.did));
+            fields.push(("Created", created));
+            print_full_entry_owned(&fields);
         }
         return Ok(());
     }
@@ -55,7 +63,7 @@ pub async fn cmd_webvh_server_list(client: &VtaClient) -> Result<(), Box<dyn std
     let header_style = Style::default()
         .fg(Color::White)
         .add_modifier(Modifier::BOLD);
-    let header = Row::new(vec!["ID", "DID", "Label", "Created"])
+    let header = Row::new(vec!["ID", NAME_HEADER, "DID", "Created"])
         .style(header_style)
         .bottom_margin(1);
 
@@ -63,7 +71,6 @@ pub async fn cmd_webvh_server_list(client: &VtaClient) -> Result<(), Box<dyn std
         .servers
         .iter()
         .map(|s| {
-            let label = s.label.clone().unwrap_or_else(|| "\u{2014}".into());
             let created = s
                 .created_at
                 .with_timezone(&chrono::Local)
@@ -72,8 +79,8 @@ pub async fn cmd_webvh_server_list(client: &VtaClient) -> Result<(), Box<dyn std
 
             Row::new(vec![
                 Cell::from(s.id.clone()),
-                Cell::from(s.did.clone()).style(Style::default().fg(Color::DarkGray)),
-                Cell::from(label),
+                name_cell(&book, &s.did),
+                did_cell(&s.did),
                 Cell::from(created).style(Style::default().fg(Color::DarkGray)),
             ])
         })
@@ -415,6 +422,11 @@ pub async fn cmd_webvh_did_list(
         return Ok(());
     }
 
+    let mut book = book_from_vta(client).await;
+    // Hosted DIDs are the only ones that *can* carry an agent name, so this
+    // is where `--resolve-agent-names` earns its round trips.
+    resolve_agent_names_into(&mut book, resp.dids.iter().map(|d| d.did.as_str())).await;
+
     if is_full_display() {
         print_full_list_title("WebVH DIDs", resp.dids.len());
         for d in &resp.dids {
@@ -424,14 +436,15 @@ pub async fn cmd_webvh_did_list(
                 .format("%Y-%m-%d %H:%M:%S %:z")
                 .to_string();
             let portable = if d.portable { "yes" } else { "no" };
-            print_full_entry(&[
-                ("DID", &d.did),
-                ("Context", &d.context_id),
-                ("Server", &d.server_id),
-                ("SCID", &d.scid),
-                ("Portable", portable),
-                ("Created", &created),
-            ]);
+            // A `WebvhDidRecord` carries no name of its own, so anything we
+            // show comes from the ACL / context listings fetched above.
+            let mut fields = full_display_pairs(&book, &d.did);
+            fields.push(("Context", d.context_id.clone()));
+            fields.push(("Server", d.server_id.clone()));
+            fields.push(("SCID", d.scid.clone()));
+            fields.push(("Portable", portable.to_string()));
+            fields.push(("Created", created));
+            print_full_entry_owned(&fields);
         }
         return Ok(());
     }
@@ -439,9 +452,12 @@ pub async fn cmd_webvh_did_list(
     let header_style = Style::default()
         .fg(Color::White)
         .add_modifier(Modifier::BOLD);
-    let header = Row::new(vec!["DID", "Context", "Server", "Portable", "Created"])
-        .style(header_style)
-        .bottom_margin(1);
+    let show_names = book.names_any(resp.dids.iter().map(|d| d.did.as_str()));
+    let mut header_cells = vec!["DID", "Context", "Server", "Portable", "Created"];
+    if show_names {
+        header_cells.insert(0, NAME_HEADER);
+    }
+    let header = Row::new(header_cells).style(header_style).bottom_margin(1);
 
     let rows: Vec<Row> = resp
         .dids
@@ -454,13 +470,17 @@ pub async fn cmd_webvh_did_list(
                 .format("%Y-%m-%d %H:%M")
                 .to_string();
 
-            Row::new(vec![
-                Cell::from(d.did.clone()),
+            let mut cells = vec![
+                did_cell(&d.did),
                 Cell::from(d.context_id.clone()),
                 Cell::from(d.server_id.clone()),
                 Cell::from(portable.to_string()),
                 Cell::from(created).style(Style::default().fg(Color::DarkGray)),
-            ])
+            ];
+            if show_names {
+                cells.insert(0, name_cell(&book, &d.did));
+            }
+            Row::new(cells)
         })
         .collect();
 

--- a/vta-cli-common/src/display.rs
+++ b/vta-cli-common/src/display.rs
@@ -19,6 +19,8 @@
 //! listing also names the `Created By` column, because a granting admin is
 //! very often another entry's subject. No lookup, no round trip.
 
+use std::sync::atomic::{AtomicBool, Ordering};
+
 use ratatui::{
     style::{Color, Style},
     widgets::Cell,
@@ -117,6 +119,57 @@ pub fn full_display_pairs(book: &NameBook, did: &str) -> Vec<(&'static str, Stri
     }
 }
 
+// ── Agent-name resolution toggle ────────────────────────────────────
+//
+// Global `--resolve-agent-names`. Off by default: a verified lookup is a DID
+// resolution plus an outbound HTTPS fetch per claimed name, per DID on
+// screen, against hosts we do not control. On a fifty-row `acl list` that is
+// fifty fan-outs, so the operator asks for it rather than paying for it by
+// accident.
+
+static RESOLVE_AGENT_NAMES: AtomicBool = AtomicBool::new(false);
+
+/// Register the operator's `--resolve-agent-names` choice. Called once at
+/// CLI startup.
+pub fn set_resolve_agent_names(enabled: bool) {
+    RESOLVE_AGENT_NAMES.store(enabled, Ordering::Relaxed);
+}
+
+/// Whether agent-name resolution was requested.
+#[must_use]
+pub fn resolve_agent_names() -> bool {
+    RESOLVE_AGENT_NAMES.load(Ordering::Relaxed)
+}
+
+/// Add verified agent names to `book` for each DID in `dids`.
+///
+/// No-op unless `--resolve-agent-names` was passed. Each name is
+/// round-tripped before being trusted (see
+/// [`vta_sdk::display_name::agent_name`]); a claim that does not lead back to
+/// its DID still lands in the book, but as `AgentName { verified: false }`,
+/// which ranks below every local label and renders tagged.
+///
+/// Failures are swallowed per DID — an unreachable name server degrades that
+/// row to its local name or bare DID rather than failing the command.
+#[cfg(feature = "agent-names")]
+pub async fn resolve_agent_names_into<'a>(
+    book: &mut NameBook,
+    dids: impl IntoIterator<Item = &'a str>,
+) {
+    if !resolve_agent_names() {
+        return;
+    }
+    vta_sdk::display_name::agent_name::fill_book(book, dids).await;
+}
+
+/// Without the `agent-names` feature there is nothing to resolve.
+#[cfg(not(feature = "agent-names"))]
+pub async fn resolve_agent_names_into<'a>(
+    _book: &mut NameBook,
+    _dids: impl IntoIterator<Item = &'a str>,
+) {
+}
+
 // ── Book builders ───────────────────────────────────────────────────
 //
 // Each takes a response the command already fetched. Adding one here is
@@ -136,12 +189,30 @@ pub fn book_from_acl(book: &mut NameBook, entries: &[vta_sdk::client::AclEntryRe
 }
 
 /// Fill `book` from a context listing: each context's `name` names its DID.
-pub fn book_from_contexts(book: &mut NameBook, contexts: &[vta_sdk::contexts::ContextRecord]) {
+pub fn book_from_contexts(book: &mut NameBook, contexts: &[vta_sdk::client::ContextResponse]) {
     for ctx in contexts {
         if let Some(did) = &ctx.did {
             book.insert(did, DisplayName::new(&ctx.name, NameSource::ContextName));
         }
     }
+}
+
+/// Best-effort book from the two listings that name DIDs on a VTA: the ACL
+/// (subject labels) and the contexts (each context's name, for its own DID).
+///
+/// For surfaces whose own response carries no name — hosted `did:webvh`
+/// records, sealed-bundle banners, mediator tables. Both fetches are
+/// swallowed on failure: naming is decoration, and a caller who may read
+/// their own DIDs but not the ACL must still get their output.
+pub async fn book_from_vta(client: &vta_sdk::client::VtaClient) -> NameBook {
+    let mut book = NameBook::new();
+    if let Ok(acl) = client.list_acl(None).await {
+        book_from_acl(&mut book, &acl.entries);
+    }
+    if let Ok(ctxs) = client.list_contexts().await {
+        book_from_contexts(&mut book, &ctxs.contexts);
+    }
+    book
 }
 
 /// Fill `book` from a webvh hosting-server listing.

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.19.26"
+version = "0.19.27"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/client/mod.rs
+++ b/vta-sdk/src/client/mod.rs
@@ -1166,24 +1166,25 @@ mod tests {
     /// error envelope. Returning it as success made callers deserialise an error
     /// object as a result and report a missing field, hiding the real cause.
     ///
-    /// This is the exact envelope seen from `list_agent_names`.
+    /// Shaped after a rejected `set_agent_name`, where the actionable detail
+    /// lives only in the message — the caller cannot act on `internalError`
+    /// alone, but "that name is taken" tells them exactly what to do next.
     #[test]
     fn extract_surfaces_an_error_envelope_inside_the_payload() {
         let doc = serde_json::json!({
-            "id": "urn:uuid:1", "type": "spec/vta/webvh/agent-name/list/1.0",
+            "id": "urn:uuid:1", "type": "spec/vta/webvh/agent-name/set/1.0",
             "payload": {
                 "code": "internalError",
-                "message": "list_agent_names: validation error: agent-name operations \
-                            are not supported over the DIDComm transport; the hosting \
-                            server exposes them only via REST",
-                "retryable": true,
+                "message": "set_agent_name: name_taken: `ops` is already bound on \
+                            webvh.storm.ws",
+                "retryable": false,
             },
         });
         let err = VtaClient::extract_trust_task_payload(doc).expect_err("must be an error");
         let msg = err.to_string();
         assert!(msg.contains("internalError"), "{msg}");
         assert!(
-            msg.contains("not supported over the DIDComm transport"),
+            msg.contains("name_taken"),
             "the actionable part of the message must survive: {msg}"
         );
     }

--- a/vta-sdk/src/client/webvh.rs
+++ b/vta-sdk/src/client/webvh.rs
@@ -8,6 +8,8 @@ use crate::error::VtaError;
 
 #[cfg(feature = "client")]
 use crate::protocols::did_management;
+#[cfg(feature = "client")]
+use crate::protocols::did_management::agent_name;
 
 #[cfg(feature = "client")]
 impl VtaClient {
@@ -276,5 +278,144 @@ impl VtaClient {
             },
         )
         .await
+    }
+
+    // ── Agent names ───────────────────────────────────────────────────
+    //
+    // An agent name is a human-memorable `domain/@name` that resolves to a
+    // DID. Binding one edits the DID document's `alsoKnownAs` and republishes
+    // the signed log — that claim is the *sole* authorisation for the hosting
+    // server's `/@name` redirect, which is why every verb here goes through
+    // the VTA rather than talking to the host directly: only the VTA can sign.
+    //
+    // These are trust-task-only by design — there is no bespoke REST route,
+    // and none is needed: `dispatch_trust_task` posts to `/api/trust-tasks`
+    // on a REST transport and rides the DIDComm envelope otherwise, so both
+    // transports reach the same handler.
+
+    /// Bind `name` to `did`, adding `https://{domain}/@{name}` to the
+    /// document's `alsoKnownAs` and republishing.
+    ///
+    /// The hosting server refuses a binding whose document does not claim it,
+    /// so a success here means the claim is live.
+    pub async fn set_agent_name(
+        &self,
+        did: &str,
+        name: &str,
+    ) -> Result<agent_name::AgentNameResultBody, VtaError> {
+        self.agent_name_verb(crate::trust_tasks::TASK_WEBVH_AGENT_NAME_SET_1_0, did, name)
+            .await
+    }
+
+    /// Release `name` entirely, dropping the claim from the document.
+    ///
+    /// Distinct from [`disable_agent_name`](Self::disable_agent_name): remove
+    /// frees the name for anyone else to claim, disable parks it so it stops
+    /// resolving while staying reserved to this DID.
+    pub async fn remove_agent_name(
+        &self,
+        did: &str,
+        name: &str,
+    ) -> Result<agent_name::AgentNameResultBody, VtaError> {
+        self.agent_name_verb(
+            crate::trust_tasks::TASK_WEBVH_AGENT_NAME_REMOVE_1_0,
+            did,
+            name,
+        )
+        .await
+    }
+
+    /// Stop `name` resolving while keeping it reserved to this DID.
+    ///
+    /// Drops the claim from the document — the reservation lives in the
+    /// hosting server's registry, not in the DID.
+    pub async fn disable_agent_name(
+        &self,
+        did: &str,
+        name: &str,
+    ) -> Result<agent_name::AgentNameResultBody, VtaError> {
+        self.agent_name_verb(
+            crate::trust_tasks::TASK_WEBVH_AGENT_NAME_DISABLE_1_0,
+            did,
+            name,
+        )
+        .await
+    }
+
+    /// Bring a parked name back into service, re-adding its claim.
+    pub async fn enable_agent_name(
+        &self,
+        did: &str,
+        name: &str,
+    ) -> Result<agent_name::AgentNameResultBody, VtaError> {
+        self.agent_name_verb(
+            crate::trust_tasks::TASK_WEBVH_AGENT_NAME_ENABLE_1_0,
+            did,
+            name,
+        )
+        .await
+    }
+
+    /// Every name bound to `did`, including parked ones.
+    ///
+    /// Read live from the hosting control plane's registry, which is
+    /// authoritative — a parked name is absent from the DID document by
+    /// design, so the document alone cannot answer this.
+    pub async fn list_agent_names(
+        &self,
+        did: &str,
+    ) -> Result<agent_name::AgentNameListResultBody, VtaError> {
+        self.dispatch_trust_task(
+            crate::trust_tasks::TASK_WEBVH_AGENT_NAME_LIST_1_0,
+            serde_json::json!({ "did": did }),
+            30,
+        )
+        .await
+        .and_then(|v| {
+            serde_json::from_value(v)
+                .map_err(|e| VtaError::Protocol(format!("agent-name list decode: {e}")))
+        })
+    }
+
+    /// Whether `name` is free on the domain `did` is hosted under.
+    ///
+    /// Advisory only — the name can be taken between this call and a
+    /// [`set_agent_name`](Self::set_agent_name), which is why `set` reports
+    /// its own conflict rather than relying on a prior check.
+    pub async fn check_agent_name(
+        &self,
+        did: &str,
+        name: &str,
+    ) -> Result<agent_name::AgentNameCheckResultBody, VtaError> {
+        self.dispatch_trust_task(
+            crate::trust_tasks::TASK_WEBVH_AGENT_NAME_CHECK_1_0,
+            serde_json::json!({ "did": did, "name": name }),
+            30,
+        )
+        .await
+        .and_then(|v| {
+            serde_json::from_value(v)
+                .map_err(|e| VtaError::Protocol(format!("agent-name check decode: {e}")))
+        })
+    }
+
+    /// The four mutating verbs share a body and differ only by task URI.
+    async fn agent_name_verb(
+        &self,
+        task_uri: &str,
+        did: &str,
+        name: &str,
+    ) -> Result<agent_name::AgentNameResultBody, VtaError> {
+        // Republishing a signed log is slower than a plain read; the DID
+        // document is rebuilt, re-signed and pushed to the host.
+        let payload = self
+            .dispatch_trust_task(
+                task_uri,
+                serde_json::json!({ "did": did, "name": name }),
+                60,
+            )
+            .await?;
+        serde_json::from_value(payload)
+            .map_err(|e| VtaError::Protocol(format!("agent-name response decode: {e}")))
     }
 }

--- a/vta-sdk/src/display_name/agent_name.rs
+++ b/vta-sdk/src/display_name/agent_name.rs
@@ -34,15 +34,21 @@
 //! web redirect and is not derivable from DID structure, so a constructed
 //! "likely name" would be an unverified guess wearing an authoritative API.
 //!
-//! # Nothing publishes names yet
+//! # The other half
 //!
-//! No DID template, DID document, or webvh record in this workspace emits an
-//! `alsoKnownAs` entry, so [`lookup`] returns `None` for every DID here today.
-//! That is expected: this is the consumer half, built so that minting names
-//! lights up every operator surface without a single display site changing.
+//! Names are bound by `pnm did-mgmt agent-names set`, which edits the DID
+//! document's `alsoKnownAs` and republishes the signed log
+//! (`vta-service`'s `operations::did_webvh::agent_name_op`). The hosting
+//! server serves `/@name` only for a name the signed document claims, and
+//! rebuilds its index from the log on every publish — so it structurally
+//! cannot serve a name the DID has not claimed.
+//!
+//! That is the *first* half of the binding. This module is the second: the
+//! host's guarantee says the document claims the name, not that the name
+//! leads back here. Only the round trip below establishes that.
 
 use affinidi_did_common::Document;
-use affinidi_did_resolver_cache_sdk::DIDCacheClient;
+use affinidi_did_resolver_cache_sdk::{DIDCacheClient, config::DIDCacheConfigBuilder};
 use agent_names::extract_agent_names;
 
 use super::{DisplayName, NameSource};
@@ -136,6 +142,33 @@ pub async fn lookup(client: &DIDCacheClient, did: &str) -> Option<DisplayName> {
         did,
         outcomes.iter().map(|(n, d)| (n.as_str(), d.as_deref())),
     )
+}
+
+/// Resolve verified names for many DIDs into `book`, building the resolver
+/// once for the whole batch.
+///
+/// The entry point display layers use. Kept here rather than in the CLI crate
+/// because constructing a `DIDCacheClient` needs the resolver dependency this
+/// feature already pulls in.
+///
+/// Honours `PNM_RESOLVER_URL` so a CLI pointed at a shared resolver uses it
+/// here too. Per-DID failures are skipped, not propagated: an unreachable name
+/// server must degrade a row to its DID, never fail the operator's command.
+pub async fn fill_book<'a>(book: &mut super::NameBook, dids: impl IntoIterator<Item = &'a str>) {
+    let mut builder = DIDCacheConfigBuilder::default();
+    if let Ok(url) = std::env::var("PNM_RESOLVER_URL")
+        && !url.is_empty()
+    {
+        builder = builder.with_network_mode(&url);
+    }
+    let Ok(client) = DIDCacheClient::new(builder.build()).await else {
+        return;
+    };
+    for did in dids {
+        if let Some(name) = lookup(&client, did).await {
+            book.insert(did, name);
+        }
+    }
 }
 
 #[cfg(test)]

--- a/vta-sdk/src/display_name/mod.rs
+++ b/vta-sdk/src/display_name/mod.rs
@@ -18,14 +18,21 @@
 //! verified agent name — lives in [`agent_name`] behind the `agent-names`
 //! feature and hands its result back as a [`DisplayName`] like any other.
 //!
-//! # Where names come from today
+//! # Where names come from
 //!
-//! No DID document in this workspace currently publishes an `alsoKnownAs`
-//! entry, so there are no agent names to show yet. The names that exist are
-//! local: `AclEntry.label`, `ContextRecord.name`, `WebvhServerRecord.label`,
-//! the PNM/CNM per-VTA config `name`. [`NameSource`] keeps them distinguished
-//! rather than flattening them to a string, because they are not equally
-//! trustworthy — see below.
+//! Two kinds of source, and the difference is the whole reason [`NameSource`]
+//! exists rather than a bare `String`.
+//!
+//! **Local**: `AclEntry.label`, `ContextRecord.name`,
+//! `WebvhServerRecord.label`, the PNM/CNM per-VTA config `name`. Operator-typed,
+//! from our own store, and free to read — they arrive on responses the caller
+//! already fetched.
+//!
+//! **Agent names**: `domain/@name` bound to a DID by
+//! `pnm did-mgmt agent-names set`, which writes the claim into the DID
+//! document's `alsoKnownAs` and republishes the signed log. Reading one back
+//! costs network and is opt-in per invocation (`--resolve-agent-names`), since
+//! a verified lookup is a DID resolution plus an outbound fetch per claim.
 //!
 //! # Trust
 //!

--- a/vta-sdk/src/protocols/did_management/agent_name.rs
+++ b/vta-sdk/src/protocols/did_management/agent_name.rs
@@ -102,3 +102,107 @@ pub struct AgentNameCheckResultBody {
     /// but well-formed, which is distinct from a malformed name (an error).
     pub reserved: bool,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Wire shapes crossing to the DID-hosting control plane. Casing drift is
+    // this workspace's recurring defect class — an `allowed_contexts` that
+    // should have been `allowedContexts` once silently minted a super-admin
+    // (#656/#658) — so these pin the serialised key names, not just that the
+    // types round-trip through themselves.
+
+    #[test]
+    fn request_bodies_serialise_camel_case() {
+        let v = serde_json::to_value(AgentNameBody {
+            did: "did:webvh:QmScid:example.com".into(),
+            name: "ops".into(),
+        })
+        .unwrap();
+        assert_eq!(v["did"], "did:webvh:QmScid:example.com");
+        assert_eq!(v["name"], "ops");
+
+        let v = serde_json::to_value(AgentNameCheckBody {
+            did: "did:webvh:QmScid:example.com".into(),
+            name: "ops".into(),
+        })
+        .unwrap();
+        assert_eq!(v.as_object().unwrap().len(), 2, "no stray fields");
+    }
+
+    #[test]
+    fn created_at_is_camel_case_on_the_wire() {
+        // The one multi-word field in the family, and therefore the only one
+        // where a missing `rename_all` would show up.
+        let v = serde_json::to_value(AgentNameEntry {
+            name: "ops".into(),
+            enabled: true,
+            created_at: 1_700_000_000,
+        })
+        .unwrap();
+        assert!(
+            v.get("createdAt").is_some(),
+            "expected camelCase `createdAt`, got {v}"
+        );
+        assert!(v.get("created_at").is_none(), "snake_case leaked: {v}");
+    }
+
+    #[test]
+    fn a_parked_entry_deserialises_from_the_host_shape() {
+        // Exactly what did-hosting emits in `agentNames`.
+        let entry: AgentNameEntry = serde_json::from_value(serde_json::json!({
+            "name": "ops",
+            "enabled": false,
+            "createdAt": 1_700_000_000_u64,
+        }))
+        .unwrap();
+        assert!(
+            !entry.enabled,
+            "parked must survive the round trip — it is the difference \
+             between a name being reserved and being free"
+        );
+    }
+
+    #[test]
+    fn check_result_distinguishes_reserved_from_taken() {
+        // Three distinct outcomes share two booleans, so the combination
+        // carries the meaning: reserved names are unavailable but well-formed.
+        let reserved: AgentNameCheckResultBody = serde_json::from_value(serde_json::json!({
+            "name": "admin", "domain": "example.com",
+            "available": false, "reserved": true,
+        }))
+        .unwrap();
+        assert!(reserved.reserved && !reserved.available);
+
+        let taken: AgentNameCheckResultBody = serde_json::from_value(serde_json::json!({
+            "name": "ops", "domain": "example.com",
+            "available": false, "reserved": false,
+        }))
+        .unwrap();
+        assert!(!taken.reserved && !taken.available);
+    }
+
+    #[test]
+    fn list_result_carries_an_empty_registry() {
+        // A DID with no names is a normal answer, not an error — the DIDComm
+        // and REST read paths both have to render it the same way.
+        let r: AgentNameListResultBody = serde_json::from_value(serde_json::json!({
+            "did": "did:webvh:QmScid:example.com",
+            "names": [],
+        }))
+        .unwrap();
+        assert!(r.names.is_empty());
+    }
+
+    #[test]
+    fn result_body_reports_whether_the_name_resolves() {
+        let v = serde_json::to_value(AgentNameResultBody {
+            did: "did:webvh:QmScid:example.com".into(),
+            name: "ops".into(),
+            enabled: false,
+        })
+        .unwrap();
+        assert_eq!(v["enabled"], false);
+    }
+}

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.12.24"
+version = "0.12.25"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -264,6 +264,11 @@ aws-lc-rs = { version = "1", optional = true }
 
 [dev-dependencies]
 tempfile = "3"
+# The exact parser the DID-hosting server uses to read `alsoKnownAs` off a
+# published log. Dev-only: it lets the agent-name contract test assert that
+# what we *write* is what the host can *read*, rather than asserting our own
+# format against itself.
+agent-names = { workspace = true }
 http-body-util = "0.1"
 # Self-dep with `test-support` enabled so integration tests under
 # `tests/` get the shared `test_support::build_test_app` HTTP scaffolding

--- a/vta-service/src/operations/did_webvh/update/orchestrator.rs
+++ b/vta-service/src/operations/did_webvh/update/orchestrator.rs
@@ -1268,3 +1268,91 @@ mod agent_name_tests {
         );
     }
 }
+
+/// Cross-repo contract: what we write into `alsoKnownAs` must be what the
+/// DID-hosting server can read back out of the published log.
+///
+/// The host does not pattern-match our string. It parses each `alsoKnownAs`
+/// entry with `agent_names::AgentName::parse` and keeps the ones whose
+/// `authority()` equals the domain it is serving
+/// (`did-hosting-common::did_ops::extract_agent_names`). If our emitted form
+/// ever stops satisfying that parser, nothing errors anywhere — the claim is
+/// simply never indexed and the name silently 404s. So these tests use the
+/// host's own parser rather than re-asserting our format against itself.
+#[cfg(test)]
+mod agent_name_host_contract {
+    use super::edit_agent_name;
+
+    const DOMAIN: &str = "webvh.storm.ws";
+
+    /// Pull the `alsoKnownAs` entries out of a document, as the host would.
+    fn claims(doc: &serde_json::Value) -> Vec<String> {
+        doc.get("alsoKnownAs")
+            .and_then(|a| a.as_array())
+            .map(|a| {
+                a.iter()
+                    .filter_map(|v| v.as_str().map(str::to_string))
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    #[test]
+    fn what_we_write_is_what_the_host_parses() {
+        let mut doc = serde_json::json!({});
+        edit_agent_name(&mut doc, DOMAIN, "ops", true);
+
+        let entries = claims(&doc);
+        assert_eq!(entries.len(), 1, "expected exactly one claim: {entries:?}");
+
+        let parsed = agent_names::AgentName::parse(&entries[0])
+            .expect("the host must be able to parse what we emit");
+        assert_eq!(
+            parsed.authority(),
+            DOMAIN,
+            "the host keeps only entries whose authority matches the domain \
+             it serves; a mismatch means the name is never indexed"
+        );
+        assert_eq!(parsed.local_name(), "ops");
+    }
+
+    #[test]
+    fn a_removed_claim_leaves_nothing_for_the_host_to_index() {
+        let mut doc = serde_json::json!({});
+        edit_agent_name(&mut doc, DOMAIN, "ops", true);
+        edit_agent_name(&mut doc, DOMAIN, "ops", false);
+        assert!(
+            claims(&doc).is_empty(),
+            "a released name must leave no claim behind — the host rebuilds \
+             its index from the document on every publish"
+        );
+    }
+
+    #[test]
+    fn an_unrelated_also_known_as_entry_survives_and_is_ignored() {
+        // `alsoKnownAs` legitimately holds other identifier types; the host
+        // skips what it cannot parse rather than erroring, and so must we.
+        let mut doc = serde_json::json!({ "alsoKnownAs": ["did:web:other.example"] });
+        edit_agent_name(&mut doc, DOMAIN, "ops", true);
+        let entries = claims(&doc);
+        assert!(entries.iter().any(|e| e == "did:web:other.example"));
+        assert_eq!(entries.len(), 2);
+
+        edit_agent_name(&mut doc, DOMAIN, "ops", false);
+        assert_eq!(
+            claims(&doc),
+            vec!["did:web:other.example".to_string()],
+            "removing our name must not disturb identifiers we do not own"
+        );
+    }
+
+    #[test]
+    fn a_name_on_another_domain_is_not_ours_to_serve() {
+        // The host drops entries whose authority is not the domain it serves.
+        // Confirms our writer never emits one that would be silently dropped.
+        let mut doc = serde_json::json!({});
+        edit_agent_name(&mut doc, DOMAIN, "ops", true);
+        let parsed = agent_names::AgentName::parse(&claims(&doc)[0]).unwrap();
+        assert_ne!(parsed.authority(), "evil.example");
+    }
+}

--- a/vta-service/src/webvh_didcomm.rs
+++ b/vta-service/src/webvh_didcomm.rs
@@ -521,9 +521,15 @@ impl<'a> WebvhDIDCommClient<'a> {
                 30,
             )
             .await?;
-        let names = resp.body.get("agentNames").ok_or_else(|| {
-            AppError::Internal("agent-name list response has no 'agentNames'".to_string())
-        })?;
+        // A host predating the registry omits the field entirely. That is an
+        // empty list, not a parse error — otherwise every read against an
+        // older host fails. The REST path has always been tolerant here
+        // (`webvh_client::list_agent_names`); erroring on one transport and
+        // succeeding on the other made the same DID appear to have names or
+        // not depending on how the VTA happened to reach its host.
+        let Some(names) = resp.body.get("agentNames") else {
+            return Ok(Vec::new());
+        };
         serde_json::from_value(names.clone())
             .map_err(|e| AppError::Internal(format!("agent-name list response parse error: {e}")))
     }
@@ -561,7 +567,6 @@ impl<'a> WebvhDIDCommClient<'a> {
 #[cfg(test)]
 mod tests {
     use super::{build_check_name_body, parse_check_name_response};
-    use serde_json::json;
 
     /// Regression for `e.p.did.path-invalid`: auto-assign (`path == None`)
     /// must OMIT the `path` field, not send `""`. The host rejects a

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.11.22"
+version = "0.11.23"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vtc-service/src/did_key.rs
+++ b/vtc-service/src/did_key.rs
@@ -40,6 +40,11 @@ pub async fn run_create_did_key(args: CreateDidKeyArgs) -> Result<(), Box<dyn st
         };
         store_acl_entry(&acl_ks, &entry).await?;
         eprintln!("ACL entry created: {} (admin)", did);
+        // The label was already being stored and never shown, so an operator
+        // who named the key had no confirmation it took.
+        if let Some(ref label) = args.label {
+            eprintln!("Name: {label}");
+        }
     }
 
     // Persist all writes

--- a/vtc-service/src/status.rs
+++ b/vtc-service/src/status.rs
@@ -94,6 +94,7 @@ pub async fn run_status(config_path: Option<PathBuf>) -> Result<(), Box<dyn std:
                         .and_then(|s| s.split(':').next())
                         .unwrap_or("?");
                     eprintln!("                {GREEN}✓{RESET} resolves ({method})");
+                    print_claimed_names(&resolved.doc.also_known_as);
 
                     // Look for mediator DID in DIDCommMessaging service
                     for svc in &resolved.doc.service {
@@ -150,12 +151,13 @@ pub async fn run_status(config_path: Option<PathBuf>) -> Result<(), Box<dyn std:
             && let Some(did) = mediator_did
         {
             match resolver.resolve(did).await {
-                Ok(_) => {
+                Ok(resolved) => {
                     let method = did
                         .strip_prefix("did:")
                         .and_then(|s| s.split(':').next())
                         .unwrap_or("?");
                     eprintln!("                {GREEN}✓{RESET} resolves ({method})");
+                    print_claimed_names(&resolved.doc.also_known_as);
                 }
                 Err(e) => eprintln!("                {RED}✗ resolution failed: {e}{RESET}"),
             }
@@ -307,4 +309,20 @@ async fn send_trust_ping(
 
     atm.graceful_shutdown().await;
     Ok(elapsed)
+}
+
+/// Report the agent names a resolved DID Document claims via `alsoKnownAs`.
+///
+/// Free — the document is already in hand — and genuinely diagnostic here:
+/// `vtc status` is where an operator checks what their community's DID
+/// actually advertises.
+///
+/// Reported as *claims*, never as the DID's name. That half of the
+/// agent-name binding is self-asserted; confirming one means resolving the
+/// name forward and checking it leads back to this same DID, which is what
+/// `vta_sdk::display_name::agent_name` does.
+fn print_claimed_names(also_known_as: &[String]) {
+    for claim in also_known_as {
+        eprintln!("                {DIM}claims (unverified): {claim}{RESET}");
+    }
 }


### PR DESCRIPTION
Follow-up to #773, which built the *consumer* half of agent names. This builds
the caller for the producer half — and corrects a claim #773 made that turned
out to be false.

## What was actually missing

The producer machinery was already complete and shipped: inbound Trust-Task
handlers for all six verbs, an operations layer whose `edit_agent_name` writes
the `domain/@name` claim into the DID document's `alsoKnownAs` and republishes
the *signed* log, and outbound calls to the DID-hosting control plane over both
REST and DIDComm.

What it had was no caller. No `VtaClient` methods, no CLI — the only way to
reach any of it was a hand-rolled Trust Task. Both ends of a working middle
were dead code.

## The caller

Six `VtaClient` methods and `pnm did-mgmt agent-names
{set,check,list,remove,enable,disable}`.

No new REST route was needed, and none was added: `dispatch_trust_task` posts to
`/api/trust-tasks` on a REST transport and rides the DIDComm envelope
otherwise, so both transports reach the same handler.

Two distinctions the CLI makes explicit where an operator will read them:

- **`remove` vs `disable`** — remove frees the name for anyone to claim;
  disable parks it so it stops resolving while staying reserved to this DID.
  Getting these backwards loses a name permanently.
- **`list` reads the hosting registry, not the DID document** — a parked name is
  absent from the document by design, so a document-only read would report it as
  gone rather than reserved.

## Display

`--resolve-agent-names` turns on verified resolution, and both CLIs now enable
the `agent-names` feature backing it — without which the flag would have parsed
and silently done nothing. Off by default: a lookup is a DID resolution plus an
outbound fetch per claimed name, per DID on screen. Wired into `acl list` /
`acl get` (including `created_by`, where an unfamiliar DID most often appears)
and the hosted-DID list, where names can actually exist.

## A real defect found while wiring it

Reading a DID's names over DIDComm treated a missing `agentNames` field as an
internal error, while the REST path treated it as an empty list. A host
predating the registry omits the field entirely — so the same DID appeared to
have names or not depending purely on how the VTA happened to reach its host.
Both are tolerant now, matching the REST behaviour that was already pinned by a
test.

## A cross-repo contract test

The hosting server does not pattern-match our string. It parses each
`alsoKnownAs` entry with `agent_names::AgentName::parse` and keeps only those
whose `authority()` matches the domain it serves.

If our emitted form ever drifts, **nothing errors** — the claim is simply never
indexed and the name silently 404s. So the test pulls in the host's own parser
as a dev-dependency and asserts against that, rather than checking our format
against itself.

## Correction

#773's changelog said "nothing in this workspace publishes `alsoKnownAs` yet",
and I repeated it in the `display_name` module docs. That was false —
`edit_agent_name` has been writing the claim and republishing all along. It was
true of DID *templates*, which is where I looked, and I wrongly generalised to
the whole workspace. Corrected in both places; #773's entry is still unreleased,
so the wrong statement never ships.

## Surfaces finished

The ones #773 deliberately skipped: hosted `did:webvh` list, hosting-server
list, and `vtc create-did-key` — which was storing an operator-supplied label
and never showing it. `vtc status`, `pnm doctor` and `cnm` now report the names
a resolved document claims, marked unverified (free — the document is already
in hand).

`sealed_producer` banners deliberately keep bare, full DIDs: those DIDs are
minted seconds before they are printed, so there is no name to show, and the
operator is copying an exact identifier for handoff.

## Verification

- `cargo test --workspace` — green, exit 0, run after rebasing onto #774/#775.
- 19 agent-name tests, including the four new host-parser contract tests.
- `cargo fmt --check` clean; `cargo clippy --workspace --all-targets` reports
  nothing in any file this PR touches.
- `cargo check --workspace --locked` passes — the lockfile is in sync with the
  version bumps.
- Both CLI surfaces verified live (`pnm did-mgmt agent-names --help`,
  `cnm --help`).

## Coordination

Rebased onto #774 and #775. **Yielded `vta-service 0.12.23` to #776**, which
claimed it first and is already in CI; this takes `0.12.24`. #776 is otherwise
disjoint — it touches only credential-vault files, none of which appear here.
`CHANGELOG.md` will still need a mechanical merge with #776 (both add entries
under `## Unreleased`; keep both).

## Not done

The outbound DIDComm task URIs in `webvh_didcomm.rs` are hardcoded rather than
SDK constants. That is real, but systemic — the file hardcodes all ~20
did-management URIs and the SDK declares no `#response` variants at all. Fixing
only the agent-name ones would make that file less consistent, so it wants its
own refactor.
