### PR TITLE
fix(acl): make delegated-any step-up ratification ancestry-aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## Unreleased
 
+### vti-common 0.11.18 — make delegated-any step-up ratification ancestry-aware
+
+* The admin path of `delegated_any_approver_covers` matched a subject's
+  contexts against the approver's with exact `contains`, while the
+  approve-scope path in the same function used ancestry-aware `covers`. So a
+  context admin of `acme` could **not** ratify a delegated AAL2 step-up for a
+  subject scoped to `acme/eng`, even though it administers that subtree — and
+  an equivalent explicit `ApproveScope` grant *could*.
+
+* That contradicted the stated ACL-gate rule — "any `allowed_contexts` entry
+  `is_ancestor_or_self` of the target" (`hierarchical-contexts.md`). The helper
+  landed (#257) five days before this function was written (#329) and was
+  simply not reached for. The admin path now uses the same `covers`, so admin
+  standing and explicit conferral agree.
+
+* Behaviour is identical while contexts are flat — the two readings diverge
+  only once sub-contexts exist, which is the case the hierarchy feature was
+  built for. Resolves one of the two conflations #772 left flagged.
+
 ### vta-service 0.12.23 — enforce credential custody on the credential-vault surface
 
 * **Security.** `StoredCredential.context_id` is documented as the **custody**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10409,7 +10409,7 @@ dependencies = [
 
 [[package]]
 name = "vti-common"
-version = "0.11.17"
+version = "0.11.18"
 dependencies = [
  "aes-gcm",
  "affinidi-data-integrity",

--- a/docs/05-design-notes/acl-scope-semantics.md
+++ b/docs/05-design-notes/acl-scope-semantics.md
@@ -106,29 +106,28 @@ surface to a context admin merely by being unrestricted.
 
 ## What this does *not* change
 
-Two conflations are preserved deliberately, because removing either is a
-change in authorization rather than in structure:
+One conflation is preserved deliberately, because removing it is a change in
+authorization rather than in structure:
 
-1. **`validate_acl_modification` still refuses an empty target to any
-   non-super-admin.** It receives `target_contexts` without a role, so it
-   cannot distinguish "grant nothing" (`None`) from "grant everything"
-   (`All`) — and refuses both. The consequence is that only a super-admin can
-   create a least-privilege approver, which is the very shape the CLI
-   recommends.
+- **`validate_acl_modification` still refuses an empty target to any
+  non-super-admin.** It receives `target_contexts` without a role, so it
+  cannot distinguish "grant nothing" (`None`) from "grant everything"
+  (`All`) — and refuses both. The consequence is that only a super-admin can
+  create a least-privilege approver, which is the very shape the CLI
+  recommends.
 
-2. **The admin path in `delegated_any_approver_covers` matches contexts with
-   exact membership, not `covers()`.** The approve-scope path in the same
-   function is ancestry-aware, so a context admin's conferral is narrower than
-   an equivalent explicit `ApproveScope` grant. Probably an oversight, but
-   widening it changes who may ratify a step-up.
+It is flagged where it occurs.
 
-Both are flagged where they occur.
+(The admin path in `delegated_any_approver_covers` used exact membership where
+the approve-scope path beside it used ancestry; that inconsistency has since
+been resolved — the admin path is ancestry-aware too, matching the ACL-gate
+rule in `hierarchical-contexts.md`.)
 
 ## Remaining work
 
-- **The two conflations above**, each as its own reviewed change. Note the
-  first one interacts with the read/manage split: a context admin still cannot
-  *create* the least-privilege approver that they can now *audit*.
+- **The remaining conflation above** (`validate_acl_modification`), as its own
+  reviewed change. It interacts with the read/manage split: a context admin
+  still cannot *create* the least-privilege approver that they can now *audit*.
 - **`reader + All`** ("may read every context, admin nowhere") is expressible
   in the type but unreachable through the decode table, since `All` requires
   `Role::Admin`. If it is ever wanted it needs a stored representation — i.e.

--- a/vti-common/Cargo.toml
+++ b/vti-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-common"
 description = "Shared server-side infrastructure for VTA and VTC services"
 readme = "README.md"
-version = "0.11.17"
+version = "0.11.18"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vti-common/src/acl/mod.rs
+++ b/vti-common/src/acl/mod.rs
@@ -793,12 +793,21 @@ pub fn delegated_any_approver_covers(approver: &AclEntry, subject: &AclEntry) ->
         ActScope::All => true,
         // Context admin: the subject must itself be context-scoped, and every
         // one of its contexts must fall within the approver's. A global subject
-        // needs a super-admin approver (handled above). Exact membership, not
-        // ancestry — preserved verbatim from the pre-`ActScope` code; widening
-        // it to `covers` would be a behaviour change, not a refactor.
-        ActScope::Contexts(approver_ctxs) => match subject.act_scope() {
+        // needs a super-admin approver (handled above).
+        //
+        // Ancestry-aware, via the same `covers` the approve-scope path above
+        // uses. This was an exact `contains` until now, which made a context
+        // admin's conferral *narrower* than an equivalent explicit
+        // `ApproveScope` grant and contradicted the stated ACL-gate rule —
+        // "any `allowed_contexts` entry `is_ancestor_or_self` of the target"
+        // (`docs/05-design-notes/hierarchical-contexts.md`). The helper landed
+        // five days before this function was written and simply was not reached
+        // for. While contexts stay flat the two are identical; they diverge
+        // only once sub-contexts exist, which is exactly the case the hierarchy
+        // work intended to cover.
+        approver_scope @ ActScope::Contexts(_) => match subject.act_scope() {
             ActScope::Contexts(subject_ctxs) => {
-                subject_ctxs.iter().all(|c| approver_ctxs.contains(c))
+                subject_ctxs.iter().all(|c| approver_scope.covers(c))
             }
             _ => false,
         },
@@ -891,6 +900,68 @@ mod delegated_any_tests {
     fn subject(role: Role, contexts: &[&str]) -> AclEntry {
         AclEntry::new("did:key:zSubject", role, "did:key:zCreator")
             .with_contexts(contexts.iter().map(|s| s.to_string()).collect())
+    }
+
+    /// A context admin of a *parent* may ratify for a subject scoped to its
+    /// subtree. This was refused until now — the admin path used exact
+    /// membership while the approve-scope path beside it used ancestry, making
+    /// admin standing narrower than an equivalent explicit `ApproveScope`
+    /// grant and contradicting the ACL-gate rule in
+    /// `docs/05-design-notes/hierarchical-contexts.md`.
+    #[test]
+    fn context_admin_covers_a_subject_in_its_subtree() {
+        let approver = admin(&["acme"]);
+        assert!(
+            delegated_any_approver_covers(&approver, &subject(Role::Reader, &["acme/eng"])),
+            "an admin of `acme` administers `acme/eng`, so it may ratify for it"
+        );
+        assert!(
+            delegated_any_approver_covers(
+                &approver,
+                &subject(Role::Reader, &["acme/eng", "acme/sales"])
+            ),
+            "…and for a subject scoped to several of its descendants"
+        );
+    }
+
+    /// The segment-aware guard still holds: a sibling with a shared string
+    /// prefix is not a descendant.
+    #[test]
+    fn context_admin_does_not_cover_a_prefix_sibling() {
+        let approver = admin(&["acme"]);
+        assert!(
+            !delegated_any_approver_covers(&approver, &subject(Role::Reader, &["acme-evil"])),
+            "`acme` must not cover `acme-evil` — segments, not string prefixes"
+        );
+    }
+
+    /// A subject holding *any* context outside the approver's subtree is still
+    /// refused — widening to ancestry must not become "covers if it covers one".
+    #[test]
+    fn context_admin_refuses_a_subject_partly_outside_its_subtree() {
+        let approver = admin(&["acme"]);
+        assert!(
+            !delegated_any_approver_covers(
+                &approver,
+                &subject(Role::Reader, &["acme/eng", "other"])
+            ),
+            "every subject context must fall within the approver's"
+        );
+    }
+
+    /// Flat contexts behave exactly as before, which is why this is safe to
+    /// change now: the two readings only diverge once sub-contexts exist.
+    #[test]
+    fn flat_contexts_are_unchanged_by_ancestry() {
+        let approver = admin(&["ctx-a"]);
+        assert!(delegated_any_approver_covers(
+            &approver,
+            &subject(Role::Reader, &["ctx-a"])
+        ));
+        assert!(!delegated_any_approver_covers(
+            &approver,
+            &subject(Role::Reader, &["ctx-b"])
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## The inconsistency

`delegated_any_approver_covers` decides whether one ACL entry may ratify a delegated AAL2 step-up for another. It has two paths, and they disagreed on how contexts match:

```rust
// approve-scope path — ancestry-aware
subject_ctxs.iter().all(|c| approver.approve_scope.covers(c))

// admin path — exact membership
subject_ctxs.iter().all(|c| approver_ctxs.contains(c))
```

So a context admin of `acme` could **not** ratify for a subject scoped to `acme/eng`, even though it administers that subtree — while an equivalent explicit `ApproveScope::Contexts(["acme"])` grant *could*. Admin standing was narrower than explicit conferral, for no reason.

## Why it's an oversight, not a decision

The stated ACL-gate rule (`docs/05-design-notes/hierarchical-contexts.md`) is:

> `has_context_access(target)`: super-admin, **or** any `allowed_contexts` entry `is_ancestor_or_self` of `target`.

No carve-out for step-up. I traced the history: `is_ancestor_or_self` landed in #257 (2026-06-04), and this function was written in #329 (2026-06-09) — five days later — reaching for a raw `contains`. The note calls the hierarchy feature "complete on the VTA", which it wasn't while this path used exact match.

The exact-match comment was mine, added in #772 to preserve behaviour through a pure refactor. This is the follow-up that comment pointed at.

## The change

The admin path uses the same `covers` as the approve-scope path beside it. Admin standing and explicit conferral now agree.

**Behaviour is identical while contexts are flat** — `covers` and `contains` diverge only once a context has a `/`-separated child, which is exactly the case the hierarchy work exists for. This is why it's safe to land now rather than needing a migration.

## Tests

- `context_admin_covers_a_subject_in_its_subtree` — the fix. **Verified load-bearing**: it fails against the old `contains`.
- `context_admin_does_not_cover_a_prefix_sibling` — `acme` must not cover `acme-evil`; guards the naive `starts_with` mistake.
- `context_admin_refuses_a_subject_partly_outside_its_subtree` — ancestry must not become "covers if it covers one".
- `flat_contexts_are_unchanged_by_ancestry` — the compatibility claim.

`cargo test -p vti-common`: **332 passed, 0 failed**. `step_up` handler tests (the one production caller) unaffected: 18 passed. Clippy and fmt clean.

Resolves one of the two conflations flagged in #772's design note. The other (`validate_acl_modification` refusing an empty target without a role) remains open — it interacts with the acts-nowhere-creation decision.