### PR TITLE
feat(acl): let a context admin create a least-privilege approver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 ## Unreleased
 
+### vti-common 0.11.19 / vta-service 0.12.24 / vtc-service 0.11.22 — let a context admin create a least-privilege approver
+
+* `validate_acl_modification` saw only the target's context list, never its
+  role, so it could not tell an *acts-nowhere* entry (any non-admin role, no
+  contexts) from an *unrestricted* one (admin, no contexts) — and refused both
+  to a non-super-admin. That barred a context admin from creating the very
+  shape the CLI recommends: a reader that acts nowhere and confers a context it
+  administers via `approve_scope` (a least-privilege approver).
+
+* The function now takes the target role and decodes it into an `ActScope`.
+  `All` (unrestricted) stays super-admin-only; `None` (acts nowhere) grants no
+  authority to act, so any caller who may manage the ACL may create it. The
+  *conferral* half is unchanged — `validate_approve_scope_grant` still requires
+  the caller to administer every context an approver confers — so a context
+  admin can mint an approver for its own contexts and no others, and still
+  cannot mint a super-admin.
+
+* This is the last of the two conflations `ActScope` (#772) was introduced to
+  make resolvable. It is safe now, and was not before, because the "an
+  acts-nowhere entry grants nothing" premise it rests on is finally true on
+  every read path — the credential-vault custody gaps that violated it silently
+  were closed in #776. The two changes are related: this one should not have
+  landed ahead of that one.
+
+* Callers updated in all three services; behaviour is otherwise unchanged (the
+  scoped and unrestricted cases decide exactly as before). Verified
+  load-bearing: reverting the `None` arm to refuse fails both the unit test and
+  the end-to-end `create_acl` test.
+
 ### vti-common 0.11.18 — make delegated-any step-up ratification ancestry-aware
 
 * The admin path of `delegated_any_approver_covers` matched a subject's

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10220,7 +10220,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.12.23"
+version = "0.12.24"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",
@@ -10327,7 +10327,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-service"
-version = "0.11.21"
+version = "0.11.22"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",
@@ -10409,7 +10409,7 @@ dependencies = [
 
 [[package]]
 name = "vti-common"
-version = "0.11.18"
+version = "0.11.19"
 dependencies = [
  "aes-gcm",
  "affinidi-data-integrity",

--- a/docs/05-design-notes/acl-scope-semantics.md
+++ b/docs/05-design-notes/acl-scope-semantics.md
@@ -106,28 +106,26 @@ surface to a context admin merely by being unrestricted.
 
 ## What this does *not* change
 
-One conflation is preserved deliberately, because removing it is a change in
-authorization rather than in structure:
+Both conflations `ActScope` was introduced to make resolvable have since been
+resolved, each as its own reviewed change rather than folded into the refactor:
 
-- **`validate_acl_modification` still refuses an empty target to any
-  non-super-admin.** It receives `target_contexts` without a role, so it
-  cannot distinguish "grant nothing" (`None`) from "grant everything"
-  (`All`) — and refuses both. The consequence is that only a super-admin can
-  create a least-privilege approver, which is the very shape the CLI
-  recommends.
+- **`validate_acl_modification` now takes the target's role**, so it decodes
+  the target into an `ActScope` and distinguishes "grant nothing" (`None`) from
+  "grant everything" (`All`). `All` stays super-admin-only; `None` — an
+  acts-nowhere entry, which grants no authority to act — may be created by any
+  caller who may manage the ACL. That is how a context admin mints a
+  least-privilege approver for its own context; the *conferral* half is gated
+  independently by `validate_approve_scope_grant`, so it still cannot confer a
+  context it does not administer. Behaviour is otherwise unchanged: the scoped
+  and unrestricted cases decide exactly as before.
 
-It is flagged where it occurs.
-
-(The admin path in `delegated_any_approver_covers` used exact membership where
-the approve-scope path beside it used ancestry; that inconsistency has since
-been resolved — the admin path is ancestry-aware too, matching the ACL-gate
-rule in `hierarchical-contexts.md`.)
+- **The admin path in `delegated_any_approver_covers`** used exact membership
+  where the approve-scope path beside it used ancestry; the admin path is
+  ancestry-aware too now, matching the ACL-gate rule in
+  `hierarchical-contexts.md`.
 
 ## Remaining work
 
-- **The remaining conflation above** (`validate_acl_modification`), as its own
-  reviewed change. It interacts with the read/manage split: a context admin
-  still cannot *create* the least-privilege approver that they can now *audit*.
 - **`reader + All`** ("may read every context, admin nowhere") is expressible
   in the type but unreachable through the decode table, since `All` requires
   `Role::Admin`. If it is ever wanted it needs a stored representation — i.e.

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.12.23"
+version = "0.12.24"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/operations/acl.rs
+++ b/vta-service/src/operations/acl.rs
@@ -210,7 +210,7 @@ pub async fn create_acl(
 ) -> Result<CreateAclResultBody, AppError> {
     auth.require_manage()?;
     validate_role_assignment(auth, &role)?;
-    validate_acl_modification(auth, &allowed_contexts)?;
+    validate_acl_modification(auth, &role, &allowed_contexts)?;
     // Granting approve-authority is its own privilege check: `all` is
     // super-admin-only, a scoped grant requires the caller to hold each context.
     validate_approve_scope_grant(auth, &approve_scope)?;
@@ -371,12 +371,12 @@ pub async fn update_acl(
                 }
             }
         }
-        // Also keep the original full-shape check so the
-        // empty-`allowed_contexts` super-admin-only invariant is
-        // preserved on the *resulting* entry (a context admin can't
-        // produce an unrestricted entry by edit any more than by
-        // create).
-        validate_acl_modification(auth, &allowed_contexts)?;
+        // Also keep the full-shape check so the *resulting* entry is one
+        // the caller could have created directly: `entry.role` is the
+        // post-patch role, so an admin+empty result stays super-admin-only
+        // while a non-admin+empty (acts-nowhere) result is allowed — the same
+        // rule as create.
+        validate_acl_modification(auth, &entry.role, &allowed_contexts)?;
         // Validate only the *added* contexts. Removals are fine
         // (they only narrow scope); pre-existing contexts were
         // already validated at their original insertion point and
@@ -1281,6 +1281,97 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(body.allowed_contexts, vec!["ctx-real".to_string()]);
+    }
+
+    /// The acts-nowhere widening, end to end: a context admin can now mint a
+    /// least-privilege approver for its own context — a reader that acts
+    /// nowhere and confers `ctx-a` via `approve_scope`. Both privilege gates
+    /// pass: the act scope is `None` (grants nothing to act), and the approve
+    /// scope names only a context the caller administers.
+    #[tokio::test]
+    async fn context_admin_can_mint_a_least_privilege_approver() {
+        let (_store, acl_ks, audit_ks, contexts_ks, _dir) = fresh_store().await;
+        seed_contexts(&contexts_ks, &["ctx-a"]).await;
+
+        let caller = ctx_admin("did:key:zCtxAdminA", &["ctx-a"]);
+        let body = create_acl(
+            &acl_ks,
+            &audit_ks,
+            &contexts_ks,
+            &caller,
+            "did:key:zApprover",
+            Role::Reader,
+            None,
+            Vec::new(), // acts nowhere
+            None,
+            None,
+            None,
+            ApproveScope::Contexts(vec!["ctx-a".into()]),
+            "test",
+        )
+        .await
+        .expect("a context admin may create a least-privilege approver for its own context");
+        assert!(
+            body.allowed_contexts.is_empty(),
+            "the approver acts nowhere"
+        );
+        assert!(body.approve_contexts.contains(&"ctx-a".to_string()));
+    }
+
+    /// …but the conferral half is still gated: the same caller cannot mint an
+    /// approver for a context it does not administer.
+    #[tokio::test]
+    async fn context_admin_cannot_confer_a_foreign_context_via_the_approver() {
+        let (_store, acl_ks, audit_ks, contexts_ks, _dir) = fresh_store().await;
+        seed_contexts(&contexts_ks, &["ctx-a", "ctx-b"]).await;
+
+        let caller = ctx_admin("did:key:zCtxAdminA", &["ctx-a"]);
+        let err = create_acl(
+            &acl_ks,
+            &audit_ks,
+            &contexts_ks,
+            &caller,
+            "did:key:zApprover",
+            Role::Reader,
+            None,
+            Vec::new(),
+            None,
+            None,
+            None,
+            ApproveScope::Contexts(vec!["ctx-b".into()]),
+            "test",
+        )
+        .await
+        .expect_err("conferring ctx-b requires administering it");
+        assert!(matches!(err, AppError::Forbidden(_)), "got {err:?}");
+    }
+
+    /// …and the unrestricted case stays closed: a context admin still cannot
+    /// create an admin with no contexts (a super-admin).
+    #[tokio::test]
+    async fn context_admin_still_cannot_mint_a_super_admin() {
+        let (_store, acl_ks, audit_ks, contexts_ks, _dir) = fresh_store().await;
+        seed_contexts(&contexts_ks, &["ctx-a"]).await;
+
+        let caller = ctx_admin("did:key:zCtxAdminA", &["ctx-a"]);
+        let err = create_acl(
+            &acl_ks,
+            &audit_ks,
+            &contexts_ks,
+            &caller,
+            "did:key:zWouldBeSuper",
+            Role::Admin,
+            None,
+            Vec::new(), // admin + empty = super-admin
+            None,
+            None,
+            None,
+            ApproveScope::None,
+            "test",
+        )
+        .await
+        .expect_err("a context admin must not mint a super-admin");
+        assert!(matches!(err, AppError::Forbidden(_)), "got {err:?}");
     }
 
     /// Regression test: an Initiator whose `allowed_contexts` overlaps

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.11.21"
+version = "0.11.22"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vtc-service/src/routes/acl.rs
+++ b/vtc-service/src/routes/acl.rs
@@ -272,7 +272,7 @@ pub async fn create_acl(
     // Block non-admin callers from granting Admin — role + context
     // bound checks must run before we touch storage.
     validate_vtc_role_assignment(&auth.0, &req_entry.role)?;
-    validate_acl_modification(&auth.0, &req_entry.scopes)?;
+    validate_acl_modification(&auth.0, &as_vti_role(&req_entry.role), &req_entry.scopes)?;
 
     let acl = state.acl_ks.clone();
     let expires_at = req_entry.expires_at.map(|t| t.timestamp() as u64);

--- a/vti-common/Cargo.toml
+++ b/vti-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-common"
 description = "Shared server-side infrastructure for VTA and VTC services"
 readme = "README.md"
-version = "0.11.18"
+version = "0.11.19"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vti-common/src/acl/mod.rs
+++ b/vti-common/src/acl/mod.rs
@@ -721,6 +721,7 @@ pub fn validate_role_assignment(caller: &AuthClaims, target_role: &Role) -> Resu
 ///   they themselves have access to.
 pub fn validate_acl_modification(
     caller: &AuthClaims,
+    target_role: &Role,
     target_contexts: &[String],
 ) -> Result<(), AppError> {
     // Shape first, for every caller. `validate_context_path` existed all along
@@ -728,23 +729,41 @@ pub fn validate_acl_modification(
     // reachably `""`, which is what `--contexts ''` actually parses to — was
     // storable. Super admins reached it most easily, since their check below
     // returns before any per-context work happens. An empty id is not an
-    // identifier and matches nothing in `has_context_access`, so an entry
-    // holding one is inert while looking scoped.
+    // identifier and matches nothing in `covers`, so an entry holding one is
+    // inert while looking scoped.
     for ctx in target_contexts {
         crate::context_path::validate_context_path(ctx)?;
     }
     if caller.is_super_admin() {
         return Ok(());
     }
-    if target_contexts.is_empty() {
-        return Err(AppError::Forbidden(
-            "only super admin can create unrestricted accounts".into(),
-        ));
+    // The target's authority to *act*, decoded from its own role and contexts —
+    // which is why the role is required. Previously this function saw only the
+    // context list and refused *any* empty target, unable to tell an
+    // unrestricted grant from an acts-nowhere one. That barred a context admin
+    // from creating a least-privilege approver (acts nowhere, confers via
+    // `approve_scope`) — the very shape the CLI recommends — for no reason
+    // beyond the ambiguity.
+    match act_scope_for(target_role, target_contexts) {
+        // Unrestricted (admin + no contexts): a super-admin grant, and only a
+        // super-admin may confer it.
+        ActScope::All => Err(AppError::Forbidden(
+            "only super admin can create an unrestricted (super-admin) account".into(),
+        )),
+        // Acts nowhere (any other role + no contexts): grants no authority to
+        // act at all, so anyone who may manage the ACL may create it. Whatever
+        // *conferral* such an entry carries is a separate grant, gated
+        // independently by `validate_approve_scope_grant`, so a context admin
+        // still cannot confer a context it does not hold.
+        ActScope::None => Ok(()),
+        // Scoped: the caller must administer every named context.
+        ActScope::Contexts(cs) => {
+            for ctx in &cs {
+                caller.require_context(ctx)?;
+            }
+            Ok(())
+        }
     }
-    for ctx in target_contexts {
-        caller.require_context(ctx)?;
-    }
-    Ok(())
 }
 
 /// Authorization predicate for **`delegated-any`** step-up: may `approver`
@@ -1495,34 +1514,56 @@ mod tests {
     // ── validate_acl_modification ───────────────────────────────────
 
     #[test]
-    fn acl_modification_super_admin_can_create_unrestricted() {
-        validate_acl_modification(&super_admin_claims(), &[]).expect("super admin unrestricted");
-        validate_acl_modification(&super_admin_claims(), &["any-ctx".into()])
+    fn acl_modification_super_admin_can_create_anything() {
+        // admin + no contexts = super-admin (unrestricted)
+        validate_acl_modification(&super_admin_claims(), &Role::Admin, &[])
+            .expect("super admin unrestricted");
+        validate_acl_modification(&super_admin_claims(), &Role::Reader, &["any-ctx".into()])
             .expect("super admin any-context");
     }
 
     #[test]
     fn acl_modification_context_admin_cannot_create_unrestricted() {
-        // Empty allowed_contexts on a new entry = super admin. A scoped
-        // admin trying to create one would escape their scope.
-        let err = validate_acl_modification(&context_admin_claims(&["ctx1"]), &[])
-            .expect_err("context admin must not create unrestricted");
+        // admin + no contexts decodes to `All` — a super-admin grant — and
+        // only a super-admin may confer it.
+        let err = validate_acl_modification(&context_admin_claims(&["ctx1"]), &Role::Admin, &[])
+            .expect_err("context admin must not create an unrestricted entry");
         assert!(matches!(err, AppError::Forbidden(_)), "got {err:?}");
+    }
+
+    /// The widening: a *non-admin* with no contexts decodes to `None` — acts
+    /// nowhere, grants no authority to act — so a context admin may create it.
+    /// This is how a least-privilege approver is minted; its conferral is gated
+    /// separately by `validate_approve_scope_grant`.
+    #[test]
+    fn acl_modification_context_admin_can_create_acts_nowhere() {
+        for role in [
+            Role::Reader,
+            Role::Application,
+            Role::Initiator,
+            Role::Monitor,
+        ] {
+            validate_acl_modification(&context_admin_claims(&["ctx1"]), &role, &[]).unwrap_or_else(
+                |e| panic!("context admin must be able to create an acts-nowhere {role:?}: {e:?}"),
+            );
+        }
     }
 
     #[test]
     fn acl_modification_context_admin_confined_to_own_contexts() {
         let caller = context_admin_claims(&["ctx1", "ctx2"]);
-        validate_acl_modification(&caller, &["ctx1".into()]).expect("own context ok");
-        validate_acl_modification(&caller, &["ctx1".into(), "ctx2".into()])
+        validate_acl_modification(&caller, &Role::Reader, &["ctx1".into()])
+            .expect("own context ok");
+        validate_acl_modification(&caller, &Role::Reader, &["ctx1".into(), "ctx2".into()])
             .expect("all-own contexts ok");
 
-        let err = validate_acl_modification(&caller, &["ctx3".into()])
+        let err = validate_acl_modification(&caller, &Role::Reader, &["ctx3".into()])
             .expect_err("foreign context must be rejected");
         assert!(matches!(err, AppError::Forbidden(_)), "got {err:?}");
 
-        let err = validate_acl_modification(&caller, &["ctx1".into(), "ctx3".into()])
-            .expect_err("mixed own+foreign must be rejected");
+        let err =
+            validate_acl_modification(&caller, &Role::Reader, &["ctx1".into(), "ctx3".into()])
+                .expect_err("mixed own+foreign must be rejected");
         assert!(matches!(err, AppError::Forbidden(_)), "got {err:?}");
     }
 
@@ -1837,11 +1878,12 @@ mod tests {
         let blank = vec![String::new()];
 
         assert!(
-            validate_acl_modification(&super_admin_claims(), &blank).is_err(),
+            validate_acl_modification(&super_admin_claims(), &Role::Reader, &blank).is_err(),
             "a super admin must not store a context named empty-string"
         );
         assert!(
-            validate_acl_modification(&context_admin_claims(&["ctx-a"]), &blank).is_err(),
+            validate_acl_modification(&context_admin_claims(&["ctx-a"]), &Role::Reader, &blank)
+                .is_err(),
             "nor may a context admin"
         );
         assert!(
@@ -1857,16 +1899,21 @@ mod tests {
         // validates at all.
         for bad in ["/ctx", "ctx/", "a//b", "ev il"] {
             assert!(
-                validate_acl_modification(&super_admin_claims(), &[bad.to_string()]).is_err(),
+                validate_acl_modification(&super_admin_claims(), &Role::Reader, &[bad.to_string()])
+                    .is_err(),
                 "{bad} must be rejected"
             );
         }
 
         // The legitimate shapes still pass, including the empty *list* that
         // means super admin.
-        validate_acl_modification(&super_admin_claims(), &[])
-            .expect("an empty list is still how super admin is expressed");
-        validate_acl_modification(&super_admin_claims(), &["acme/eng".to_string()])
-            .expect("a well-formed nested path is still accepted");
+        validate_acl_modification(&super_admin_claims(), &Role::Admin, &[])
+            .expect("admin + empty list is still how super admin is expressed");
+        validate_acl_modification(
+            &super_admin_claims(),
+            &Role::Reader,
+            &["acme/eng".to_string()],
+        )
+        .expect("a well-formed nested path is still accepted");
     }
 }


### PR DESCRIPTION
## The restriction

`validate_acl_modification` saw only the target's context list, never its role:

```rust
if target_contexts.is_empty() {
    return Err(Forbidden("only super admin can create unrestricted accounts"));
}
```

So it could not distinguish an **acts-nowhere** entry (any non-admin role, no contexts) from an **unrestricted** one (admin, no contexts) — and refused both to a non-super-admin. That barred a context admin from creating the exact shape the CLI's own `--approve-all` help recommends: a reader that acts nowhere and confers a context it administers via `approve_scope` — a least-privilege approver.

An admin could *audit* one (#774) but not *create* one. This closes that gap.

## The change

The function takes the target role and decodes it into an `ActScope`:

| target | decode | rule |
|---|---|---|
| admin + no contexts | `All` | super-admin-only (unchanged) |
| any other role + no contexts | `None` | **any ACL manager may create it** |
| any + contexts | `Contexts` | caller must administer each (unchanged) |

`None` grants no authority to *act*. The **conferral** half is untouched — `validate_approve_scope_grant` still requires the caller to administer every context an approver confers — so a context admin can mint an approver for its own contexts and no others, and still cannot mint a super-admin.

## Why now, and why not before

This is the last of the two conflations `ActScope` (#772) was introduced to make resolvable. It rests on the premise that *an acts-nowhere entry grants nothing* — and that premise was **silently false** until recently: the credential-vault custody gaps (#776) let any `VaultRead`/`VaultWrite` holder, including an acts-nowhere reader, reach other contexts' credentials. This change should not have landed ahead of #776, and didn't. With both vault surfaces now enforcing context, the premise holds on every read path.

I raised that the premise had been violated twice before and asked whether to proceed; the go-ahead was given with that on the table.

## Tests

Unit (`vti-common`):
- `context_admin_can_create_acts_nowhere` — the widening, across every non-admin role
- `context_admin_cannot_create_unrestricted` — `All` stays closed
- confined-to-own-contexts and blank-id shape checks, updated to the 3-arg form

End-to-end (`vta-service`, through `create_acl`):
- `context_admin_can_mint_a_least_privilege_approver` — reader + no contexts + `approve_scope: Contexts([ctx-a])` succeeds for a ctx-a admin
- `context_admin_cannot_confer_a_foreign_context_via_the_approver` — conferring ctx-b still refused
- `context_admin_still_cannot_mint_a_super_admin` — admin + no contexts still refused

**Verified load-bearing**: reverting the `None` arm to refuse fails both the unit and the end-to-end test.

`cargo test -p vti-common -p vta-service -p vtc-service`: **2701 passed, 0 failed**. Clippy and fmt clean.

Completes the follow-ups from #772's design note. The note's "Remaining work" is now just the `reader + All` case, which needs a stored representation (a migration this design deliberately avoided).