### PR TITLE
chore(vti-common): bump to 0.11.20 to publish the #771 auth-check fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Unreleased
 
+### vti-common 0.11.20 — publish the auth-check fix that #771 left unreleased
+
+* #771 ("fix: auth check") added `vti_common::auth::AuthcryptError` (and the
+  `bind_authcrypt_sender` binding in `auth/didcomm.rs`) and used it from
+  `vta-service`, but did **not** bump `vti-common`. crates.io therefore still
+  held the pre-#771 `0.11.19` source, so publishing `vta-service 0.12.28`
+  failed its verify build — `cannot find AuthcryptError in vti_common::auth` —
+  because it resolved the stale registry copy. This bump republishes the
+  crate with the symbol, unblocking the `vta-service` release. No source change
+  here beyond the version.
+
+  (The version-bump guard is meant to catch a source change with no bump; #771
+  slipped through it — a guard gap worth a separate look. `vtc-service` was
+  also touched by #771 without a bump; its published copy is likewise missing
+  the fix, tracked separately.)
+
 ### vta-keys 0.1.0 / vta-service 0.12.28 — extract key management into its own crate
 
 Third decomposition step (after `vta-keyspaces`+`vta-vault` in #780 and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10494,7 +10494,7 @@ dependencies = [
 
 [[package]]
 name = "vti-common"
-version = "0.11.19"
+version = "0.11.20"
 dependencies = [
  "aes-gcm",
  "affinidi-data-integrity",

--- a/vti-common/Cargo.toml
+++ b/vti-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-common"
 description = "Shared server-side infrastructure for VTA and VTC services"
 readme = "README.md"
-version = "0.11.19"
+version = "0.11.20"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true


### PR DESCRIPTION
## The problem

The publish pipeline that ran on #782's merge **failed to publish `vta-service 0.12.28`** — the release is currently blocked (crates.io still serves `vta-service 0.12.27`; downstream pinning `"0.12"` is stuck there).

Root cause is **not** the decomposition work. It's **#771 ("fix: auth check")**:

- #771 added `vti_common::auth::AuthcryptError` + `bind_authcrypt_sender` (`auth/didcomm.rs`) and used them from `vta-service` (`operations/vault/upsert.rs`), but **did not bump `vti-common`**.
- `vti-common` is `0.11.19` on both main and crates.io — but crates.io's `0.11.19` is the *pre-#771* source, with no `AuthcryptError`.
- Publishing `vta-service 0.12.28` verifies against the registry copy of its deps, resolves the stale `vti-common 0.11.19`, and fails:
  ```
  error[E0433]: cannot find `AuthcryptError` in `auth`
      vti_common::auth::AuthcryptError::NoFrom
  ```

## The fix

Bump `vti-common 0.11.19 → 0.11.20`. Source is unchanged beyond the version. Merging this:
1. publishes `vti-common 0.11.20` (which contains `AuthcryptError`), then
2. the pipeline's idempotent retry publishes `vta-service 0.12.28` — its `vti_common = "0.11"` pin now resolves `0.11.20`, so the verify build compiles.

## Two follow-ups (out of scope here, flagged)

1. **`vtc-service` is stale the same way.** #771 also changed `vtc-service/src/routes/auth.rs` without a bump, so the published `vtc-service 0.11.23` is missing #771's fix. It's *inert for the release* (nothing verifies against `vtc-service`), but since #771 is a **security fix**, the published `vtc-service` currently lacks it — worth a bump to republish. Happy to do that next.
2. **The version-bump guard missed #771.** It's meant to fail a PR that changes a publishable crate's source without bumping it. #771 changed three crates' source and bumped none, yet merged. The guard has a gap worth investigating separately.

## Verification

`check-version-bumps` + `check-changelogs` guards pass. `cargo test -p vti-common`: 325 passed, 0 failed.