### PR TITLE
fix(vtc-service): fix the broken #771 test and bump to republish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+### vtc-service 0.11.24 — fix a broken test from #771 and republish
+
+* **Fixes the red `Test` job on main.** #771 ("fix: auth check") added
+  `tests/auth_forged_plaintext.rs`, whose `VtcAclEntry { … }` construction omits
+  the `updated_at` / `updated_by` fields the struct carries — so
+  `cargo test --workspace` fails to compile it
+  (`E0063: missing fields updated_at and updated_by`). CI Test has been red on
+  main since #771 merged; a genuine merge-integration miss, not a registry
+  staleness. The two `None` fields are now set, matching every other
+  `VtcAclEntry` test construction.
+
+* Bumps the crate so the fix — and #771's earlier `routes/auth.rs` security fix,
+  which #771 never bumped for — reaches crates.io. The published `0.11.23` still
+  holds pre-#771 source; `0.11.24` republishes the current source.
+
 ### vti-common 0.11.20 — publish the auth-check fix that #771 left unreleased
 
 * #771 ("fix: auth check") added `vti_common::auth::AuthcryptError` (and the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10412,7 +10412,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-service"
-version = "0.11.23"
+version = "0.11.24"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.11.23"
+version = "0.11.24"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vtc-service/tests/auth_forged_plaintext.rs
+++ b/vtc-service/tests/auth_forged_plaintext.rs
@@ -31,6 +31,8 @@ fn admin_entry(did: &str) -> VtcAclEntry {
         allowed_contexts: vec![],
         created_at: 1,
         created_by: "did:key:vtc-install".into(),
+        updated_at: None,
+        updated_by: None,
         expires_at: None,
     }
 }


### PR DESCRIPTION
## Corrects my earlier diagnosis

I initially guessed the red `Test` job was a stale registry self-pin. **It isn't** — there's no registry copy of `vtc-service` in `Cargo.lock` (the lockfile-self-pin guard confirms "nothing pulled back from crates.io"). It's a genuine, pre-existing **test compile bug from #771**.

## The bug

#771 ("fix: auth check") added `vtc-service/tests/auth_forged_plaintext.rs`, whose `VtcAclEntry { … }` construction **omits the `updated_at` / `updated_by` fields** the struct carries:

```
error[E0063]: missing fields `updated_at` and `updated_by` in initializer of `VtcAclEntry`
  --> vtc-service/tests/auth_forged_plaintext.rs:27
```

So `cargo test --workspace` fails to compile that test target. **CI `Test` has been red on `main` since #771 merged** — a merge-integration miss (the fields existed on the struct; the new test didn't set them). It didn't show in `cargo build -p vtc-service` because that skips test targets.

## The fix

- Add `updated_at: None` / `updated_by: None` to the construction, matching every other `VtcAclEntry` test construction (`renewal.rs`, `cookie_session.rs`, …). `Test` compiles and passes.
- Bump `vtc-service 0.11.23 → 0.11.24` so this fix — and #771's earlier `routes/auth.rs` **security fix**, which #771 also never bumped for — reach crates.io (the published `0.11.23` still holds pre-#771 source).

## Verification

`cargo build -p vtc-service --tests`: 0 errors. `cargo test -p vtc-service --test auth_forged_plaintext`: 2 passed. Version-bump + changelog guards pass.

## Note on the guard gap

#771 changed three crates' source, bumped none, **and** merged with a red `Test`. That's two process gaps — the version-bump guard didn't fire, and a red required `Test` didn't block the merge. Both worth a separate look, but out of scope here.