### PR TITLE
feat(mobile): device Trust Task submission with no REST, decomposition docs, clippy clean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,55 @@
 
 ## Unreleased
 
+### vta-mobile-core 0.6.15 / vta-sdk 0.19.28 / vta-service 0.12.35 — a device can submit Trust Tasks with no REST API
+
+Completes the mobile no-REST loop: a device could already *receive* over both
+DIDComm and TSP, but had no way to submit a signed document back, so every reply
+path still needed the VTA's REST surface.
+
+* **`vta-mobile-core`: `MediatorSession::send_trust_task`** (+ a
+  `send_trust_task_one_way` counterpart) — submits an already-signed Trust Task
+  document as the body of a `binding/didcomm/0.1/envelope` message and awaits its
+  `#response`, demuxed by `thid`. No bearer token: the message is
+  authcrypt-packed, so the VTA proves the sender DID and derives authorization
+  from it (intrinsic-sender auth). Safe to call while a `receive_next` loop runs.
+
+* **`vta-mobile-core`: `TspMediatorSession::send_trust_task`** — the TSP
+  counterpart, making the TSP session bidirectional. Deliberately
+  fire-and-forget: TSP has no `thid` demux, so the VTA's reply arrives as an
+  ordinary inbound frame and the caller correlates it off the inbox on
+  `threadId`. Sending takes no socket lock, so it is safe to call while
+  `receive_next` holds one; an in-place wait would deadlock.
+
+* **`vta-sdk`: a dead DIDComm session no longer looks like an idle one.**
+  `DIDCommSession::receive_next` returned `Ok(None)` both when the poll window
+  elapsed *and* when the inbound stream ended. A supervisor polling for work
+  therefore treated "stream ended" as "nothing yet", called again, got the same
+  answer instantly, and spun at full tilt forever without reconnecting. Now
+  reports `Ok(None)` only for an expected teardown (`shutdown()` was called) and
+  `Err(DidcommTransport)` otherwise, which is what makes a supervisor reconnect.
+
+* **`vta-service`: inbound messaging is concurrent, bounded at 32 in flight.**
+  `run_inbound_loop` awaited each `handle_inbound` inline, so the VTA processed
+  exactly one inbound frame at a time — across *both* protocols, since one
+  mediator websocket carries DIDComm and TSP together. A single slow handler
+  stalled every other caller's traffic and a hanging one wedged inbound messaging
+  entirely. Handlers now spawn under a semaphore; at the cap the loop waits for a
+  permit, degrading to the old serialised behaviour under extreme load rather
+  than growing tasks unboundedly. Safe because the dispatch spine was already
+  concurrent — the REST route runs `dispatch_trust_task_core` under axum with no
+  such serialisation.
+
+* **Regression test: hermetic TSP routing** (`tests/e2e/tests/tsp_round_trip.rs`).
+  Pins that a TSP frame routes between two local mediator accounts and is
+  readable on **both** socket modes — the raw-TSP socket the device reads and the
+  store-and-pickup socket the VTA's inbound loop reads — each paired with a
+  DIDComm control over the same fixture, plus a 10-round burst case because the
+  original failure was intermittent. Guards the silent-drop bug fixed upstream in
+  `affinidi-messaging-mediator` 0.17.7 (tdk #646); the VTA drives a different
+  crate (`affinidi-messaging-delivery`), so a recurrence would not be caught by
+  the upstream test. No network, no deployed VTA — runs unignored in CI.
+
 ### vta-tee 0.1.0 / vta-policy 0.1.0 / vta-keys 0.1.1 / vti-common 0.11.21 / vta-service 0.12.34 — extract the TEE and policy subsystems
 
 Ninth decomposition step — two subsystem extractions in one PR, each unblocked

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## Unreleased
 
+### vtc-service 0.11.25 / vta-service 0.12.35 — clear the workspace clippy warnings
+
+`cargo clippy --workspace --all-targets` emitted twelve warnings; it is now
+silent. No behaviour change.
+
+* Test-module imports in `did_peer.rs` / `did_webvh.rs` now carry the
+  `config-seed` gate their only consumer already had, instead of reading as
+  unused whenever that feature is off.
+* `edit_did_document` and `vtc-service`'s `as_vti_role` moved above their file's
+  `mod tests` ("items after a test module"), so tests stay last.
+* Two `.err().expect(..)` calls in `provision_integration/preconditions.rs`
+  became `.expect_err(..)`.
+* Dropped two unused `SHOW_TASK` constants from the `vtc-service` endorsement and
+  removal tests, left behind by the spec/vtc Trust Task migration.
+
+Known unrelated gap, not fixed here: `setup::interactive`'s two scripted-wizard
+tests fail under `--features config-seed`, because the wizard skips its "Seed
+storage backend" select when only one backend is compiled and a second one shifts
+every scripted answer. CI never builds that combo.
+
 ### vta-mobile-core 0.6.15 / vta-sdk 0.19.28 / vta-service 0.12.35 — a device can submit Trust Tasks with no REST API
 
 Completes the mobile no-REST loop: a device could already *receive* over both

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,14 +11,42 @@ strictly downward — no cycles. There are two leaf crates with no internal
 workspace deps (`vti-common`, `vta-sdk`); everything else depends on one
 or both of them, plus optionally on `vta-cli-common`.
 
+`vta-service` has been **decomposed into subsystem crates** (#780–#791, nine
+steps, ~114k → ~87k lines). Each subsystem is re-exported from `vta-service`, so
+`crate::policy::…`, `vta_service::tee::…`, and `crate::operations::backup::…`
+still resolve — **but new code should depend on the subsystem crate directly**,
+not reach through the facade. Before proposing a further extraction, read
+`docs/05-design-notes/vta-service-decomposition.md`, which records the technique
+and — importantly — where the program stops.
+
 ```
-Leaf crates:
+Layer 0 (leaves):
   vti-common   (no internal deps)
   vta-sdk      (no internal deps)
-
   vti-secrets     → vti-common (+ vta-sdk under the `onboarding` feature)
+
+Layer 1 (VTA foundations):
+  vta-keyspaces   → vti-common
+  vta-config      → vti-common, vti-secrets
+  vta-audit       → vta-sdk, vti-common
+
+Layer 2 (VTA subsystems):
+  vta-support     → vta-config, vta-keyspaces, vta-sdk, vti-common
+  vta-keys        → vta-config, vta-keyspaces, vta-sdk, vti-common, vti-secrets
+  vta-vault       → vta-keyspaces, vta-sdk, vti-common
+  vta-webvh       → vta-keyspaces, vta-sdk, vti-common
+  vta-policy      → vta-config, vta-keyspaces, vti-common
+
+Layer 3 (composed subsystems):
+  vta-tee         → vta-config, vta-keys, vta-keyspaces, vta-support, vti-common
+  vta-backup      → vta-config, vta-keys, vta-keyspaces, vta-sdk, vta-support,
+                    vta-webvh, vti-common
+  vta-sweepers    → vta-audit, vta-keyspaces, vta-vault, vti-common
+
+Layer 4 (the spine + consumers):
   vta-cli-common  → vta-sdk, vti-common
-  vta-service     → vti-common, vti-secrets, vta-sdk, vta-cli-common
+  vta-service     → every vta-* subsystem above, + vti-common, vti-secrets,
+                    vta-sdk, vta-cli-common
   vtc-service     → vti-common, vti-secrets, vta-sdk
   pnm-cli         → vta-sdk, vta-cli-common
   cnm-cli         → vta-sdk, vta-cli-common
@@ -28,10 +56,21 @@ Leaf crates:
 
 | Crate | Role |
 |---|---|
-| `vti-common` | Shared foundation: JWT auth, ACL, `Store`/`KeyspaceHandle` enum (local fjall + vsock), `AppError`, config types, identifier validation (`identifier.rs`), `secure_file` (owner-only file hardening), pluggable telemetry sink (`telemetry::TelemetrySink`, default ring buffer), the `SeedStore` trait |
+| `vti-common` | Shared foundation: JWT auth, ACL, `Store`/`KeyspaceHandle` enum (local fjall + vsock), `AppError`, config types, identifier validation (`identifier.rs`), `secure_file` (owner-only file hardening), pluggable telemetry sink (`telemetry::TelemetrySink`, default ring buffer), the `SeedStore` trait, `guards` (executor preconditions) |
 | `vta-sdk` | Public SDK: types, REST + DIDComm client, `sealed_transfer`, `did_templates`, `provision_integration`, attestation verification, `protocol` (DIDComm protocol-management types) |
-| `vti-secrets` | Shared secret-store backends (AWS / GCP / Azure / Vault / Kubernetes / keyring / config-seed / TEE-KMS / plaintext) + the `create_seed_store(&secrets, &data_dir)` factory + `SecretsConfig`, all behind the same feature flags. Plus (feature `onboarding`) `IntegrationOnboarding` — the ephemeral-`did:key` → ACL-grant → auto-rotate cold-start helper. Lets external VTI integrations onboard + store secrets exactly like first-party ones without depending on `vta-service`. The backend implementations are shared by **both** the VTA (`vta-service::keys::seed_store`) and the VTC (`vtc-service::keys::seed_store`, which keeps its own factory for VTC-specific storage locations / `*SecretStore` naming) |
-| `vta-service` | VTA logic (library) + local/dev binary. Routes, operations (provision-integration, did-webvh, contexts, backup, **protocol management**), setup wizards (interactive + `--from <toml>`), DIDComm bridge + `messaging::*` (registry, drain store/sweeper, handshake, live prover, transient handshake) |
+| `vti-secrets` | Shared secret-store backends (AWS / GCP / Azure / Vault / Kubernetes / keyring / config-seed / TEE-KMS / plaintext) + the `create_seed_store(&secrets, &data_dir)` factory + `SecretsConfig`, all behind the same feature flags. Plus (feature `onboarding`) `IntegrationOnboarding` — the ephemeral-`did:key` → ACL-grant → auto-rotate cold-start helper. Lets external VTI integrations onboard + store secrets exactly like first-party ones without depending on `vta-service`. The backend implementations are shared by **both** the VTA (`vta-keys::seed_store`) and the VTC (`vtc-service::keys::seed_store`, which keeps its own factory for VTC-specific storage locations / `*SecretStore` naming) |
+| `vta-keyspaces` | Keyspace-name registry — the `const` names every `store.keyspace(..)` call uses, plus the backup partition (`ALL` / `BACKED_UP` / `EXCLUDED_FROM_BACKUP`, pinned by a census test). Dependency-free leaf |
+| `vta-config` | `AppConfig` TOML shape + sub-configs (`PolicyConfig`; under `tee`, `TeeConfig` / `TeeKmsConfig` / `TeeMode`), composed over `vti-common`'s shared config types |
+| `vta-audit` | Structured audit logging for security-relevant operations, so any subsystem can emit audit events without depending on the whole service. `AuditLogEntry.detail` carries the operator `reason` |
+| `vta-support` | Shared mid-layer services — trust-context storage (the BIP-32 key-hierarchy roots) and the other clean glue subsystems need |
+| `vta-keys` | **Key management**: master-seed storage, BIP-32 hierarchical derivation, key wrapping (AES-GCM), imported-key handling, `create_seed_store` backend selection, `derive_pre_rotation_keys` |
+| `vta-vault` | **Holder credential vault**: storage, query, receive/verify, present, status refresh, and the archival lifecycle (`VaultStatus {Active,Archived,Deleted}`) |
+| `vta-webvh` | WebVH hosting infrastructure for the `did:webvh` lifecycle and its other consumers |
+| `vta-policy` | Policy subsystem: the regorus (Rego) engine + default bundle, the DTTE consent model, decision evaluators, policy storage |
+| `vta-tee` | TEE bootstrap: attestation providers (Nitro / SEV-SNP / simulated), KMS attest/decrypt, storage-key derivation, CMS unwrap, the DynamoDB anti-rollback anchor MAC, Mode-B admin bootstrap + carve-out, the mnemonic-export guard. Behind the `tee` feature — keeps the AWS SDK stack out of the default build graph |
+| `vta-backup` | Encrypted full-state export/import (Argon2id + AES-256-GCM), the `vta_did` compatibility check, the two-phase descriptor flow, the sealed bundle store + its TTL sweeper. TEE re-encryption is injected via the `BootstrapReEncryptor` trait |
+| `vta-sweepers` | Background TTL sweepers for the core keyspaces (acl / consent / vault) |
+| `vta-service` | The VTA **spine** (library) + local/dev binary — what remains after the subsystem extractions: `routes/` (HTTP surface), `trust_tasks/` (dispatch spine), `messaging/*` (DIDComm + TSP bridge: registry, drain store/sweeper, handshake, live prover, transient handshake), `operations/` (orchestration: provision-integration, did-webvh, contexts, protocol management), `setup/` (wizards, interactive + `--from <toml>`), and the offline CLI surfaces. Re-exports every subsystem crate above |
 | `vta-enclave` | Nitro Enclave front-end. Depends on `vta-service` as a library, adds TEE bootstrap (KMS, vsock-store, attestation). `publish = false` |
 | `vtc-service` | Verifiable Trust Community service (community lifecycle, separate JWT audience) |
 | `vta-cli-common` | Shared CLI command implementations — both CLIs are thin wrappers |
@@ -41,20 +80,21 @@ Leaf crates:
 | `didcomm-test` | Standalone DIDComm connectivity harness (test tool, `publish = false`) |
 
 Hot spots to know about (file size in source lines, sorted descending):
-- `vta-service/src/operations/provision_integration/mod.rs` (~1.8k lines)
+- `vta-service/src/operations/provision_integration/mod.rs` (~2.4k lines)
   — orchestrates template render → key mint → ACL wire-up → VC issue
   → seal. Split into a module directory; the seal helper extracted to
   `seal.rs` is the canonical place for new payload variants.
-- `vta-service/src/tee/kms_bootstrap.rs` (~1.65k lines) — KMS attest/
+- `vta-service/src/operations/did_webvh/mod.rs` (~2.05k lines) —
+  WebVH DID lifecycle + `did.jsonl` publication, used by every
+  protocol-management operation that mutates the VTA's own DID.
+- `vta-tee/src/kms_bootstrap.rs` (~1.8k lines) — KMS attest/
   decrypt, JWT fingerprint check, storage-key derivation, MODE_B_LOCK
-  carve-out gating.
+  carve-out gating. **Moved out of `vta-service` in #791**; still
+  reachable as `vta_service::tee::…` via the re-export facade.
 - `vta-service/src/messaging/registry.rs` (~1.3k lines) — the
   `MediatorListenerRegistry`: active-mediator membership, drain
   windows, sticky outbound routing, telemetry emission. Load-bearing
   for the protocol-management surface.
-- `vta-service/src/operations/did_webvh/mod.rs` (~1.15k lines) —
-  WebVH DID lifecycle + `did.jsonl` publication, used by every
-  protocol-management operation that mutates the VTA's own DID.
 - `vta-sdk/src/sealed_transfer/` — HPKE seal/open, armor, assertions
   (`DidSigned`, `Attested`, `PinnedOnly`).
 - `vta-service/src/messaging/{drain_store,drain_sweeper,handshake,live_prover,transient_handshake}.rs`
@@ -347,7 +387,7 @@ new flow, update both this section and the relevant `docs/*.md`.
   Ed25519 pubkey + bundle_id + producer's Ed25519 pubkey via SHA-256.
 - **Carve-out**: Single-use. `BOOTSTRAP_CARVEOUT_CLOSED_KEY` flips on
   first success; subsequent calls return 410.
-- **Code**: `vta-service/src/routes/bootstrap.rs`, `vta-service/src/tee/`.
+- **Code**: `vta-service/src/routes/bootstrap.rs`, `vta-tee/src/`.
 - **Docs**: `sealed-bootstrap.md`, `docs/02-vta/tee-architecture.md`.
 
 ### DIDComm challenge-response auth
@@ -580,8 +620,8 @@ new flow, update both this section and the relevant `docs/*.md`.
   consumer use paths (enumeration resistance).
 - **Code**: `vti-common/src/vault/mod.rs` (`VaultStatus`, lifecycle
   methods, `LifecycleError`), `vta-service/src/trust_tasks/{vault,
-  cred_vault,mod}.rs`, `vta-service/src/vault/{model,status,query,
-  present}.rs`, `vta-service/src/vault_sweeper.rs`,
+  cred_vault,mod}.rs`, `vta-vault/src/{model,status,query,
+  present}.rs`, `vta-sweepers/src/vault_sweeper.rs`,
   `vta_sdk::client::vault`, `vta_cli_common::commands::{vault,cred_vault}`
   (`pnm vault {archive,unarchive,restore,purge}`, `delete --force`,
   `list --status`; `pnm cred-vault {receive,query,get,archive,unarchive,
@@ -594,10 +634,10 @@ new flow, update both this section and the relevant `docs/*.md`.
 - **Crypto**: Argon2id KDF (≥12-char password) + AES-256-GCM.
 - **Compatibility check**: import cross-checks the backup's `vta_did`
   against the running VTA via `check_vta_did_compatibility`
-  (`vta-service/src/operations/backup.rs:286-307`). A fresh-install VTA
+  (`vta-backup/src/ops/mod.rs`). A fresh-install VTA
   accepts any backup; a configured VTA rejects backups whose `vta_did`
   doesn't match. Tested at `backup.rs:867-911`.
-- **Code**: `vta-service/src/operations/backup.rs`.
+- **Code**: `vta-backup/src/ops/`, `vta-backup/src/backup_bundle_store.rs`.
 - **VTC counterpart** (P3.9): same shape for the VTC — `POST
   /backup/{export,import}` (super-admin, preview/confirm), Argon2id +
   AES-256-GCM, `check_vtc_did_compatibility` (mismatch → 409). Backs up
@@ -654,7 +694,7 @@ new flow, update both this section and the relevant `docs/*.md`.
   Use this to find legitimate `--domain` values for the same
   server before the first create / register.
 - **Code**: `vta-service/src/webvh_didcomm.rs`,
-  `vta-service/src/webvh_client.rs`,
+  `vta-webvh/src/webvh_client.rs`,
   `vta-service/src/operations/did_webvh/{mod,servers,auth_cache,register_server}.rs`,
   `vta-service/src/routes/did_webvh.rs::list_server_domains_handler`,
   `vta_sdk::client::VtaClient::list_webvh_server_domains`,
@@ -703,7 +743,7 @@ These are load-bearing — know they exist before adjusting nearby code.
   are rejected. Don't add a "shared" audience.
 - **Mnemonic export window** (`MnemonicExportGuard`) — one-shot, timed,
   zeroized on drop. Don't cache the plaintext anywhere.
-- **JWT key fingerprint** on TEE boot (`vta-service/src/tee/kms_bootstrap.rs`)
+- **JWT key fingerprint** on TEE boot (`vta-tee/src/kms_bootstrap.rs`)
   detects KMS ciphertext tampering or key rotation. Do not widen the
   "first boot after upgrade" silent-store path.
 - **Carve-out** (`BOOTSTRAP_CARVEOUT_CLOSED_KEY`) on `/bootstrap/request`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10228,7 +10228,7 @@ dependencies = [
 
 [[package]]
 name = "vta-mobile-core"
-version = "0.6.14"
+version = "0.6.15"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -10269,7 +10269,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.19.27"
+version = "0.19.28"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10331,7 +10331,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.12.34"
+version = "0.12.35"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10564,7 +10564,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-service"
-version = "0.11.24"
+version = "0.11.25"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/docs/05-design-notes/vta-service-decomposition.md
+++ b/docs/05-design-notes/vta-service-decomposition.md
@@ -1,0 +1,176 @@
+# vta-service decomposition — extracting subsystems from the monolith
+
+**Status:** in progress. Nine steps landed (#780–#791); the subsystem phase is
+close to done. See [Where this stops](#where-this-stops) before proposing a
+tenth.
+
+`vta-service` was a single ~114k-line crate holding every VTA concern: key
+management, the credential vault, WebVH hosting, policy evaluation, TEE
+bootstrap, backup/restore, audit, TTL sweepers — plus the service's own HTTP
+routes, Trust-Task dispatch, messaging bridge, and orchestration. Everything
+recompiled when anything changed, no subsystem could be tested without standing
+up the whole service, and the AWS KMS dependency stack sat in the default build
+graph for every developer who would never run a TEE.
+
+This note records what has been extracted, the technique, and — most
+importantly — the rule for when to stop.
+
+## Where it stands
+
+| | `vta-service/src` |
+|---|---|
+| Before (#777) | 113,949 |
+| After nine steps (#791) | **87,404** |
+| Change | **−26,545 (−23%)** |
+
+Extracted into eleven crates totalling 27,050 lines. The move is close to 1:1 —
+26.5k left, 27.0k arrived — which is the signal that these were *moves*, not
+rewrites.
+
+## What LOC is and isn't measuring
+
+Net workspace LOC went slightly **up** (~500 lines of new `Cargo.toml`,
+`lib.rs`, and re-export boilerplate). Shrinking `vta-service` is a proxy, not
+the goal. The goals it stands in for:
+
+- **Compile-unit granularity.** Touching `vta-vault` no longer recompiles 87k
+  lines of unrelated code.
+- **Independent testability.** `vta-policy`'s 37 tests and `vta-tee`'s 32 run
+  without constructing an `AppState` or standing up a service.
+- **Narrow dependency surfaces.** The concrete win: `aws-sdk-kms`,
+  `aws-sdk-dynamodb`, `aws-config`, `aes`, and `cbc` left the default build
+  graph with `vta-tee`. A dev VTA no longer builds the AWS SDK.
+
+If a proposed extraction moves lines without advancing one of those three, it is
+not worth doing.
+
+## The layering that emerged
+
+Dependencies flow strictly downward, as everywhere else in the workspace.
+
+```
+Layer 0  vti-common      vta-sdk      vti-secrets        (pre-existing leaves)
+             │              │              │
+Layer 1  vta-keyspaces  vta-config   vta-audit
+             │              │              │
+Layer 2  vta-support   vta-keys   vta-vault   vta-webvh   vta-policy
+             │              │              │
+Layer 3  vta-tee       vta-backup   vta-sweepers
+             │
+Layer 4  vta-service                                      (the spine)
+```
+
+| Crate | Lines | Role |
+|---|---|---|
+| `vta-keyspaces` | 225 | Keyspace-name registry + the backup partition (`ALL` / `BACKED_UP` / `EXCLUDED_FROM_BACKUP`). Dependency-free leaf. |
+| `vta-audit` | 217 | Structured audit logging, so any subsystem can emit events without depending on the service. |
+| `vta-config` | 1,011 | `AppConfig` TOML shape and sub-configs, composed over `vti-common`'s shared types. |
+| `vta-support` | 1,069 | Shared mid-layer services (trust-context storage, and the rest of the clean glue the subsystems need). |
+| `vta-keys` | 2,885 | Master-seed storage, BIP-32 derivation, key wrapping, imported keys, `create_seed_store`. |
+| `vta-policy` | 2,292 | Regorus (Rego) engine, default bundle, DTTE consent model, decision evaluators, policy storage. |
+| `vta-webvh` | 2,373 | WebVH hosting infrastructure for the `did:webvh` lifecycle and its other consumers. |
+| `vta-vault` | 8,668 | Holder credential vault — storage, query, receive/verify, present, status refresh. |
+| `vta-backup` | 3,891 | Encrypted export/import (Argon2id + AES-256-GCM), compatibility check, two-phase descriptor flow, sealed bundle store. |
+| `vta-tee` | 3,970 | TEE bootstrap: attestation providers, KMS attest/decrypt, storage-key derivation, anti-rollback anchor, Mode-B carve-out. |
+| `vta-sweepers` | 449 | Background TTL sweepers for the core keyspaces. |
+
+## Technique
+
+Four patterns, in descending order of preference.
+
+**1. Pure move behind a re-export facade.** The default. Code moves to the new
+crate; `vta-service` keeps a `pub use` so `crate::policy::…`,
+`vta_service::tee::…`, `crate::operations::backup::…` all still resolve. No call
+site churns, so the diff is legible as a move and `vta-enclave` needs no change.
+Do not take this as licence to keep the facade forever — but do not churn
+hundreds of call sites in the same PR as the extraction, or the review becomes
+impossible.
+
+**2. Enabling move.** A small preparatory relocation that removes the single
+coupling blocking a clean extraction. `derive_pre_rotation_keys` (a pure BIP-32
+operation) moved from `operations::did_webvh` to `vta-keys` because it was
+`vta-tee`'s only reach back into `vta-service`. The `Guards` /
+`WebvhPathCounter` executor-precondition types moved to `vti_common::guards`
+because they were the trust-task planner's only shared type with the consent
+model. Both were a few dozen lines that unblocked thousands.
+
+**3. Dependency inversion.** When the glue is genuinely service-specific, invert
+through a trait rather than dragging `AppState` down a layer. The TEE KMS
+re-encryption step of a backup import is injected via
+`vta_backup::BootstrapReEncryptor`, whose sole implementation lives in
+`vta-service`. Use this when a pure move would require the lower crate to know
+about the higher one.
+
+**4. Tests move with the code.** Each crate runs its own suite. This is what
+makes "independent testability" real rather than nominal, and it is why the
+extractions needed slim local fixtures (`vta-backup` has its own, so it needs no
+dependency on `vta-service`).
+
+Every step asserted **no behaviour change**: the full `vta-service` lib suite,
+the new crate's suite, all feature combinations, the enclave build, and the
+workspace build green before merge.
+
+## Where this stops
+
+This is the part to read before opening a tenth extraction PR.
+
+**A subsystem is extractable. The service's own spine is not.** What remains in
+`vta-service` is what makes it the service:
+
+| Module | Lines | Why it stays |
+|---|---|---|
+| `operations/` | 38,686 | Orchestration. Depends on every subsystem; nothing depends on it. |
+| `trust_tasks/` | 14,258 | The dispatch spine — the thing that routes to everything else. |
+| `routes/` | 9,235 | The HTTP surface. Terminal by definition. |
+| `messaging/` | 7,736 | The DIDComm/TSP bridge — the other terminal surface. |
+| `setup/` | 3,790 | First-boot wizards. Consumes subsystems, is consumed by nothing. |
+| `main.rs`, `server.rs`, `*_cli.rs` | ~13,000 | The binary, plus the offline-CLI entry points. |
+
+Extracting `operations/` into a `vta-operations` crate would move 38k lines and
+narrow **no** dependency surface: the new crate would still need every subsystem
+below it, and `vta-service` would still need all of it. That is renaming, not
+decoupling — it fails the test in
+[What LOC is and isn't measuring](#what-loc-is-and-isnt-measuring).
+
+So: **the subsystem phase is nearly complete, and completing it is the natural
+end of the program.** Do not chase the LOC number further by carving up the
+spine.
+
+### The remaining legitimate candidates
+
+Small, genuinely separable, and each worth doing only if someone can name the
+build-time or testability win first:
+
+- **`setup/` (3,790)** — a leaf-ward consumer: it uses subsystems and nothing
+  uses it. The cleanest remaining extraction, and the least valuable, since the
+  wizards are not on any hot compile path.
+- **The offline CLI surface (~3k)** — `bootstrap_cli`, `services_cli`,
+  `webvh_cli`, `vault_cli`, `acl_cli` form a distinct entry point (direct fjall
+  access, no auth ceremony, not for TEE deployments). A `vta-offline-cli` crate
+  would make that boundary explicit rather than conventional.
+- **`test_support.rs` (1,427)** — a dev-only crate would keep test fixtures out
+  of the release build graph.
+
+### What is probably worth more than another extraction
+
+- **In-file test modules are 22,622 of the remaining 87,404 lines (26%).** The
+  non-test figure is 64,782. Any future LOC discussion should quote both numbers,
+  because "87k" overstates the implementation by a quarter.
+- **Measure compile time, not lines.** The program's actual justification is
+  build latency and testability. Nobody has published a before/after on either.
+  A recorded `cargo build --timings` delta across #780→#791 would tell us
+  whether the 23% was worth nine PRs — and would settle the stopping question
+  with evidence instead of judgement.
+
+## Invariants to preserve
+
+- **Dependencies flow strictly downward. No cycles.** The layering above is the
+  contract; a new crate must slot into it, not straddle it.
+- **Re-export facades keep call sites resolving.** Breaking `crate::x::y` paths
+  and extracting in the same PR makes the change unreviewable.
+- **Tests move with the code they cover.** A subsystem crate whose tests stayed
+  behind has not really been extracted.
+- **Extraction is behaviour-neutral.** If a step needs a behaviour change, land
+  the behaviour change separately, before or after — never inside the move.
+- **Feature gates travel with their subsystem.** `vta-tee` is behind `tee`;
+  extracting it must not put the AWS stack back in the default graph.

--- a/docs/README.md
+++ b/docs/README.md
@@ -146,6 +146,10 @@ How to operate and integrate against a VTC.
 In-flight or historical design documents kept for context. These
 are implementer-facing rather than operator-facing.
 
+- **[vta-service decomposition](05-design-notes/vta-service-decomposition.md)** —
+  how the ~114k-line VTA crate was split into subsystem crates, the
+  extraction technique, and the rule for where the program stops.
+  **Read this before proposing a further extraction.**
 - **[VTC MVP spec](05-design-notes/vtc-mvp.md)** — full
   specification for the VTC's Phase 0–5 build (the source of truth
   the implementation tracks).

--- a/tests/e2e/tests/tsp_round_trip.rs
+++ b/tests/e2e/tests/tsp_round_trip.rs
@@ -1,0 +1,331 @@
+//! Regression guard: a TSP frame must be delivered between two local accounts
+//! on a mediator, and be readable on **both** socket modes.
+//!
+//! ## Why this exists
+//!
+//! TSP submissions against a deployed VTA used to round-trip intermittently —
+//! the send reported success and the reply never arrived, in multi-minute
+//! bursts, while DIDComm over the same mediator stayed reliable throughout.
+//! Client-side probing could not separate the candidate causes, because the
+//! good/bad windows moved underneath every A/B.
+//!
+//! The root cause was below the VTA: the mediator never marked raw-TSP sockets
+//! `Live`, so frames were accepted and then silently dropped rather than routed.
+//! Fixed upstream in `affinidi-messaging-mediator` 0.17.7 (tdk #646), with the
+//! SDK-side reply correlation in #750. The same shape had bitten the DIDComm
+//! service earlier (#595/#618), which is why it is worth pinning here: the VTA
+//! drives a *different* crate (`affinidi-messaging-delivery`), so a recurrence
+//! would not be caught by the upstream test.
+//!
+//! ## What this tests, and what it deliberately does not
+//!
+//! The narrowest useful question: **can the mediator route a TSP frame from one
+//! local account to another, and can the recipient read it?** No VTA, no Trust
+//! Task dispatch, no ACL — just the transport. A failure here means the fault is
+//! below everything the VTA or the device does.
+//!
+//! Each TSP case is paired with a **DIDComm control over the same mediator**, so
+//! a failure is attributable to TSP rather than to harness or fixture noise.
+//!
+//! These are hermetic — `TestMediator`, no network, no deployed VTA — so they
+//! run in CI unignored.
+
+use std::time::Duration;
+
+use affinidi_messaging_test_mediator::TestMediator;
+use ed25519_dalek::SigningKey;
+use vta_sdk::did_key::ed25519_multibase_pubkey;
+use vta_sdk::didcomm_session::DIDCommSession;
+use vta_sdk::session::TspSession;
+
+mod common;
+
+/// Deterministic `did:key` + matching multibase private key from a seed byte.
+/// Mirrors `didcomm_session.rs` so both binaries build identities identically.
+fn did_key_from_seed(seed_byte: u8) -> (String, String) {
+    let seed = [seed_byte; 32];
+    let sk = SigningKey::from_bytes(&seed);
+    let pk = sk.verifying_key().to_bytes();
+    let did = format!("did:key:{}", ed25519_multibase_pubkey(&pk));
+    let mut buf = vec![0x80, 0x26];
+    buf.extend_from_slice(&seed);
+    let priv_mb = multibase::encode(multibase::Base::Base58Btc, &buf);
+    (did, priv_mb)
+}
+
+/// A minimal Trust-Task-shaped document. TSP carries these bytes directly (no
+/// DIDComm envelope), which is what the VTA's `tsp_inbound::dispatch_one`
+/// expects, so this matches the real wire shape.
+fn doc(id: &str) -> Vec<u8> {
+    serde_json::to_vec(&serde_json::json!({
+        "id": id,
+        "type": "https://trusttasks.org/spec/messaging/ping/0.1",
+        "payload": { "nonce": id },
+    }))
+    .expect("serialize probe document")
+}
+
+/// **The core case.** Two local accounts, one mediator, one TSP frame.
+///
+/// `send_document` routes `[mediator, recipient]` — exactly what the device and
+/// the VTA both do — and the recipient polls its own inbox on the raw-TSP
+/// socket. This is the exact path that silently dropped frames before mediator
+/// 0.17.7; a failure here is that regression returning.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn tsp_frame_routes_between_two_local_accounts() {
+    common::init_tracing();
+
+    let (sender_did, sender_priv) = did_key_from_seed(0x31);
+    let (recipient_did, recipient_priv) = did_key_from_seed(0x32);
+
+    // BOTH DIDs must be local accounts: the sender needs the websocket upgrade,
+    // and the recipient needs the mediator willing to hold a frame for it.
+    let mediator = TestMediator::builder()
+        .local_did(sender_did.clone())
+        .local_did(recipient_did.clone())
+        .spawn()
+        .await
+        .expect("spawn test mediator");
+
+    let recipient = TspSession::connect(&recipient_did, &recipient_priv, mediator.did())
+        .await
+        .expect("recipient TSP inbox connects");
+    let sender = TspSession::connect(&sender_did, &sender_priv, mediator.did())
+        .await
+        .expect("sender TSP session connects");
+
+    let body = doc("urn:uuid:tsp-local-probe");
+    sender
+        .send_document(&recipient_did, mediator.did(), &body)
+        .await
+        .expect("send_document reports success");
+
+    // Generous budget: the remote failure is a silent drop, not slowness, so a
+    // short timeout would muddle "dropped" with "still in flight".
+    let received = recipient
+        .receive_next(20)
+        .await
+        .expect("receive_next must not error");
+
+    sender.shutdown().await;
+    recipient.shutdown().await;
+    mediator.shutdown();
+    mediator.join().await.expect("mediator joins cleanly");
+
+    let frame = received.expect(
+        "TSP frame was sent successfully but never delivered — the pre-0.17.7 \
+         silent-drop regression is back on the raw-TSP socket",
+    );
+    assert!(
+        frame.contains("urn:uuid:tsp-local-probe"),
+        "delivered frame was not the document we sent: {frame}"
+    );
+}
+
+/// Control for the test above, over the *same* mediator fixture. If TSP fails
+/// while this passes, the fault is TSP-specific rather than the harness.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn didcomm_control_over_the_same_mediator() {
+    common::init_tracing();
+
+    let (sender_did, sender_priv) = did_key_from_seed(0x41);
+    let (recipient_did, _) = did_key_from_seed(0x42);
+
+    let mediator = TestMediator::builder()
+        .local_did(sender_did.clone())
+        .local_did(recipient_did.clone())
+        .spawn()
+        .await
+        .expect("spawn test mediator");
+
+    let session =
+        DIDCommSession::connect(&sender_did, &sender_priv, &recipient_did, mediator.did())
+            .await
+            .expect("DIDComm session connects");
+    session
+        .send_one_way(
+            &recipient_did,
+            "https://trusttasks.org/binding/didcomm/0.1/envelope",
+            serde_json::json!({ "id": "urn:uuid:didcomm-control" }),
+        )
+        .await
+        .expect("DIDComm one-way send succeeds over the same mediator");
+
+    session.shutdown().await;
+    mediator.shutdown();
+    mediator.join().await.expect("mediator joins cleanly");
+}
+
+/// Repetition, because the original failure was *bursty*: a single green run
+/// proves little. Reports a count rather than asserting on the first failure, so
+/// a regression's output distinguishes "never works" from "works 7 times in 10"
+/// — the latter being exactly how this bug presented.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn tsp_round_trip_is_not_intermittent() {
+    common::init_tracing();
+
+    const ROUNDS: usize = 10;
+    let (sender_did, sender_priv) = did_key_from_seed(0x51);
+    let (recipient_did, recipient_priv) = did_key_from_seed(0x52);
+
+    let mediator = TestMediator::builder()
+        .local_did(sender_did.clone())
+        .local_did(recipient_did.clone())
+        .spawn()
+        .await
+        .expect("spawn test mediator");
+
+    let recipient = TspSession::connect(&recipient_did, &recipient_priv, mediator.did())
+        .await
+        .expect("recipient inbox connects");
+    let sender = TspSession::connect(&sender_did, &sender_priv, mediator.did())
+        .await
+        .expect("sender connects");
+
+    let mut delivered = 0usize;
+    for round in 0..ROUNDS {
+        let id = format!("urn:uuid:burst-{round}");
+        sender
+            .send_document(&recipient_did, mediator.did(), &doc(&id))
+            .await
+            .expect("send reports success");
+
+        match recipient.receive_next(10).await {
+            Ok(Some(f)) if f.contains(&id) => delivered += 1,
+            Ok(Some(f)) => eprintln!("  round {round}: got an unexpected frame: {f}"),
+            Ok(None) => eprintln!("  round {round}: ❌ silent drop (send reported success)"),
+            Err(e) => eprintln!("  round {round}: ❌ receive error: {e}"),
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    sender.shutdown().await;
+    recipient.shutdown().await;
+    mediator.shutdown();
+    mediator.join().await.expect("mediator joins cleanly");
+
+    eprintln!("\n=== TSP local round trip: {delivered}/{ROUNDS} delivered ===");
+    assert_eq!(
+        delivered,
+        ROUNDS,
+        "TSP dropped {} of {ROUNDS} frames locally — the remote intermittency reproduces here",
+        ROUNDS - delivered
+    );
+}
+
+/// **The other socket mode.** Same send as
+/// [`tsp_frame_routes_between_two_local_accounts`], but the recipient listens on
+/// the **message-pickup** socket (`profile_enable_websocket` +
+/// `live_stream_next_frame`) instead of the raw-TSP socket that
+/// `TspSession::connect` opens.
+///
+/// The mediator *stores* an inbound TSP frame for a local recipient (see its
+/// "TSP/bridged message stored for local recipient" log), and stored messages
+/// are drained by message pickup. Both modes must deliver, because the workspace
+/// uses both: the VTA's inbound loop reads pickup, while the device's
+/// `TspMediatorSession` reads raw TSP.
+///
+/// Keeping both pinned is what makes a future failure *attributable*. When only
+/// the raw-TSP socket was broken (pre-0.17.7), the two tests disagreed, and that
+/// disagreement was the diagnosis.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn tsp_frame_arrives_on_the_pickup_socket() {
+    use affinidi_tdk::common::TDKSharedState;
+    use affinidi_tdk::common::config::TDKConfig;
+    // `insert` lives on the SecretsResolver trait — must be in scope.
+    use affinidi_tdk::messaging::ATM;
+    use affinidi_tdk::messaging::config::ATMConfig;
+    use affinidi_tdk::messaging::profiles::ATMProfile;
+    use affinidi_tdk::secrets_resolver::SecretsResolver;
+    use std::sync::Arc;
+
+    common::init_tracing();
+
+    let (sender_did, sender_priv) = did_key_from_seed(0x61);
+    let (recipient_did, recipient_priv) = did_key_from_seed(0x62);
+
+    let mediator = TestMediator::builder()
+        .local_did(sender_did.clone())
+        .local_did(recipient_did.clone())
+        .spawn()
+        .await
+        .expect("spawn test mediator");
+
+    // Recipient on the PICKUP socket (the path the VTA uses), not raw TSP.
+    let seed = vta_sdk::did_key::decode_private_key_multibase(&recipient_priv).expect("seed");
+    let secrets = vta_sdk::did_key::secrets_from_did_key(&recipient_did, &seed).expect("secrets");
+    let tdk = TDKSharedState::new(TDKConfig::builder().build().expect("tdk cfg"))
+        .await
+        .expect("tdk");
+    tdk.secrets_resolver().insert(secrets.signing).await;
+    tdk.secrets_resolver().insert(secrets.key_agreement).await;
+    let atm = ATM::new(
+        ATMConfig::builder().build().expect("atm cfg"),
+        Arc::new(tdk),
+    )
+    .await
+    .expect("atm");
+    let profile = Arc::new(
+        ATMProfile::new(
+            &atm,
+            None,
+            recipient_did.clone(),
+            Some(mediator.did().to_string()),
+        )
+        .await
+        .expect("profile"),
+    );
+    atm.profile_enable_websocket(&profile)
+        .await
+        .expect("enable pickup websocket");
+
+    let sender = TspSession::connect(&sender_did, &sender_priv, mediator.did())
+        .await
+        .expect("sender connects");
+    sender
+        .send_document(
+            &recipient_did,
+            mediator.did(),
+            &doc("urn:uuid:pickup-probe"),
+        )
+        .await
+        .expect("send succeeds");
+
+    // Enabling live delivery immediately yields a `messagepickup/3.0/status`
+    // DIDComm frame; the TSP frame follows. Keep pulling until a `Tsp` variant
+    // appears (or we run out of budget) rather than judging on the first frame.
+    let mut tsp_frame: Option<String> = None;
+    for _ in 0..6 {
+        match atm
+            .message_pickup()
+            .live_stream_next_frame(&profile, Some(Duration::from_secs(5)), true)
+            .await
+            .expect("live_stream_next_frame must not error")
+        {
+            Some(affinidi_tdk::messaging::protocols::message_pickup::InboundFrame::Tsp(raw)) => {
+                tsp_frame = Some(*raw);
+                break;
+            }
+            Some(other) => eprintln!(
+                "  (skipping non-TSP frame: {:?})",
+                std::mem::discriminant(&other)
+            ),
+            None => {}
+        }
+    }
+
+    sender.shutdown().await;
+    mediator.shutdown();
+    mediator.join().await.expect("mediator joins");
+
+    match tsp_frame {
+        Some(f) => eprintln!(
+            "\n=== ✅ pickup socket received the TSP frame ({} bytes) ===",
+            f.len()
+        ),
+        None => panic!(
+            "pickup socket received no TSP frame — TSP delivery to the store-and-pickup \
+             path is broken (this is the path the VTA's inbound loop reads)"
+        ),
+    }
+}

--- a/vta-mobile-core/Cargo.toml
+++ b/vta-mobile-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vta-mobile-core"
-version = "0.6.14"
+version = "0.6.15"
 description = "UniFFI engine for the VTA mobile agent (Android/iOS): DIDComm, Trust Tasks, AAL step-up."
 edition.workspace = true
 # Not a crates.io library — the published artifacts are the Android AAR

--- a/vta-mobile-core/src/mediator.rs
+++ b/vta-mobile-core/src/mediator.rs
@@ -17,10 +17,20 @@ use vta_sdk::didcomm_session::DIDCommSession;
 
 use crate::error::FfiError;
 
+/// The DIDComm message type that carries a Trust Task document to the VTA.
+/// Its `handle_trust_task` handler unwraps the body and runs it through the
+/// same `dispatch_trust_task_core` that backs `POST /api/trust-tasks`, so a
+/// document submitted this way takes an identical path to the REST one.
+const TRUST_TASK_ENVELOPE_TYPE: &str = "https://trusttasks.org/binding/didcomm/0.1/envelope";
+
 /// A live DIDComm session to a mediator, scoped to one holder identity.
 #[derive(uniffi::Object)]
 pub struct MediatorSession {
     inner: DIDCommSession,
+    /// The peer this session converses with. `DIDCommSession` knows it too, but
+    /// only `pub(crate)` to `vta-sdk`; `send_one_way` needs it as an explicit
+    /// recipient, so keep the copy the constructor already has in hand.
+    vta_did: String,
 }
 
 #[uniffi::export(async_runtime = "tokio")]
@@ -47,7 +57,7 @@ impl MediatorSession {
             .map_err(|e| FfiError::Transport {
                 reason: e.to_string(),
             })?;
-        Ok(Arc::new(Self { inner }))
+        Ok(Arc::new(Self { inner, vta_did }))
     }
 
     /// Wait up to `timeout_secs` for the next inbound DIDComm message from the
@@ -58,6 +68,71 @@ impl MediatorSession {
     pub async fn receive_next(&self, timeout_secs: u64) -> Result<Option<String>, FfiError> {
         self.inner
             .receive_next(timeout_secs)
+            .await
+            .map_err(|e| FfiError::Transport {
+                reason: e.to_string(),
+            })
+    }
+
+    /// Submit a Trust Task document to the VTA over this mediator session and
+    /// wait up to `timeout_secs` for its `#response`. Returns the framework
+    /// response document as JSON — the same bytes `POST /api/trust-tasks`
+    /// returns over REST, so callers parse it identically.
+    ///
+    /// `doc_json` is a complete, already-signed Trust Task document (e.g. what
+    /// `build_approve_response_did_signed` produces). It rides as the body of a
+    /// [`TRUST_TASK_ENVELOPE_TYPE`] DIDComm message; the VTA's
+    /// `messaging::handlers::handle_trust_task` unwraps it into the same
+    /// `dispatch_trust_task_core` the REST route calls.
+    ///
+    /// **No bearer token.** The message is authcrypt-packed, so the VTA proves
+    /// the sender DID cryptographically and derives authorization from it
+    /// (intrinsic-sender auth) — this is what lets a device operate with no VTA
+    /// REST API at all.
+    ///
+    /// Safe to call while a [`receive_next`](Self::receive_next) loop is
+    /// running: the reply is demuxed to this caller by `thid`, so it can't be
+    /// stolen by (or steal from) the unsolicited inbound stream.
+    pub async fn send_trust_task(
+        &self,
+        doc_json: String,
+        timeout_secs: u64,
+    ) -> Result<String, FfiError> {
+        let doc: serde_json::Value =
+            serde_json::from_str(&doc_json).map_err(|e| FfiError::Transport {
+                reason: format!("trust task document is not valid JSON: {e}"),
+            })?;
+
+        let response: serde_json::Value = self
+            .inner
+            .send_and_wait(
+                TRUST_TASK_ENVELOPE_TYPE,
+                doc,
+                TRUST_TASK_ENVELOPE_TYPE,
+                timeout_secs,
+            )
+            .await
+            .map_err(|e| FfiError::Transport {
+                reason: e.to_string(),
+            })?;
+
+        serde_json::to_string(&response).map_err(|e| FfiError::Transport {
+            reason: format!("could not re-serialize the VTA response: {e}"),
+        })
+    }
+
+    /// Send a Trust Task document without awaiting a response — the
+    /// fire-and-forget counterpart to
+    /// [`send_trust_task`](Self::send_trust_task), for documents whose outcome
+    /// the caller doesn't need (or will pick up off the inbox itself).
+    pub async fn send_trust_task_one_way(&self, doc_json: String) -> Result<(), FfiError> {
+        let doc: serde_json::Value =
+            serde_json::from_str(&doc_json).map_err(|e| FfiError::Transport {
+                reason: format!("trust task document is not valid JSON: {e}"),
+            })?;
+
+        self.inner
+            .send_one_way(&self.vta_did, TRUST_TASK_ENVELOPE_TYPE, doc)
             .await
             .map_err(|e| FfiError::Transport {
                 reason: e.to_string(),
@@ -114,5 +189,95 @@ mod tests {
             .expect("receive_next should not error");
         eprintln!("receive_next → {got:?}");
         session.shutdown().await;
+    }
+
+    /// Live: the whole no-REST loop against a real VTA — connect the mediator,
+    /// submit a holder-signed `whoami` Trust Task over DIDComm, and read the
+    /// `#response`. This is exactly what the iOS app's post-connect handshake
+    /// does, minus Swift.
+    ///
+    /// Proves in one shot: the mediator round-trips, `send_trust_task`'s `thid`
+    /// correlation works, and the VTA authorizes purely from the authcrypt
+    /// sender DID (intrinsic-sender auth) with no bearer token anywhere.
+    ///
+    /// Ignored by default (network + a real VTA). Run:
+    /// `cargo test -p vta-mobile-core -- --ignored whoami_over_didcomm --nocapture`
+    /// Override with `VTA_TEST_DID` / `VTA_TEST_MEDIATOR` / `VTA_TEST_SEED`.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    #[ignore = "network: submits a whoami to a live VTA over its mediator"]
+    async fn whoami_over_didcomm_without_rest() {
+        use crate::keys::Signer;
+        use ed25519_dalek::{Signer as _, SigningKey};
+        use multibase::Base;
+
+        let seed_byte: u8 = std::env::var("VTA_TEST_SEED")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(11);
+        let seed = [seed_byte; 32];
+        let sk = SigningKey::from_bytes(&seed);
+        let mut mc = vec![0xed, 0x01];
+        mc.extend_from_slice(sk.verifying_key().as_bytes());
+        let holder_did = format!("did:key:{}", multibase::encode(Base::Base58Btc, &mc));
+
+        let vta_did = std::env::var("VTA_TEST_DID").unwrap_or_else(|_| {
+            "did:webvh:QmWoJD2kpP6AJknNtj7UFERUstEen258ywj3ruHoh1ZAqr:webvh.storm.ws:glenn-vta"
+                .to_string()
+        });
+        let mediator = std::env::var("VTA_TEST_MEDIATOR").unwrap_or_else(|_| {
+            "did:webvh:QmTS3a3H9Dk4ZMPAZ8jNWGeyPbuKrPbrPZcSbg8CJ6yynD:webvh.storm.ws:mediator"
+                .to_string()
+        });
+
+        eprintln!("holder   = {holder_did}");
+        eprintln!("vta      = {vta_did}");
+        eprintln!("mediator = {mediator}");
+        eprintln!("\n(enrol this holder first: pnm acl create --did {holder_did})\n");
+
+        struct Stub {
+            sk: SigningKey,
+            did: String,
+        }
+        impl Signer for Stub {
+            fn did(&self) -> String {
+                self.did.clone()
+            }
+            fn sign(&self, payload: Vec<u8>) -> Result<Vec<u8>, FfiError> {
+                Ok(self.sk.sign(&payload).to_bytes().to_vec())
+            }
+        }
+
+        let session =
+            MediatorSession::connect(holder_did.clone(), seed.to_vec(), vta_did.clone(), mediator)
+                .await
+                .expect("connect to the mediator");
+        eprintln!("✅ mediator connected");
+
+        let env = crate::session::AuthEnvelope {
+            id: format!(
+                "urn:uuid:test-whoami-{seed_byte}-{}",
+                chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default()
+            ),
+            holder_did: holder_did.clone(),
+            vta_did: vta_did.clone(),
+            issued_at: chrono::Utc::now().to_rfc3339(),
+        };
+        let doc = crate::session::build_whoami(
+            env,
+            Box::new(Stub {
+                sk,
+                did: holder_did.clone(),
+            }),
+        )
+        .expect("build a signed whoami document");
+        eprintln!("→ submitting whoami ({} bytes)", doc.len());
+
+        let result = session.send_trust_task(doc, 30).await;
+        session.shutdown().await;
+
+        match result {
+            Ok(response) => eprintln!("\n✅ VTA replied over DIDComm, no REST:\n{response}"),
+            Err(e) => panic!("send_trust_task failed: {e}"),
+        }
     }
 }

--- a/vta-mobile-core/src/tsp.rs
+++ b/vta-mobile-core/src/tsp.rs
@@ -8,10 +8,15 @@
 //! client the VTA and `pnm health` use, rather than reimplementing TSP framing
 //! in the host language.
 //!
-//! Receive-only for now: TSP inbound is the missing half of "the VTA should use
-//! TSP when it can" for device push. The reply path (a TSP `confirm/decision`
-//! back to the VTA) still rides the existing REST/DIDComm sender; a TSP send
-//! FFI lands with the VTA's outbound TSP work.
+//! Bidirectional: [`TspMediatorSession::receive_next`] pulls VTA-pushed
+//! requests, and [`TspMediatorSession::send_trust_task`] submits the signed
+//! decision back the same way. Because TSP proves the sender, the VTA
+//! authorizes on the sealed `sender_vid` alone (intrinsic-sender auth) — so a
+//! device can run this loop with no VTA REST API and no bearer token.
+//!
+//! The asymmetry worth knowing: sends are fire-and-forget. TSP has no `thid`
+//! demux, so the VTA's reply comes back as an ordinary inbound frame and the
+//! caller correlates it off the inbox. See `send_trust_task`.
 
 use std::sync::Arc;
 
@@ -86,8 +91,198 @@ impl TspMediatorSession {
             })
     }
 
+    /// Submit an already-signed Trust Task document to `vta_did`, routed through
+    /// `mediator_did`. TSP carries the document bytes directly — no DIDComm
+    /// envelope — so the VTA's `tsp_inbound::dispatch_one` hands the payload
+    /// straight to the same `dispatch_trust_task_core` that backs
+    /// `POST /api/trust-tasks`.
+    ///
+    /// **No bearer token.** TSP proves the sender, and the VTA derives
+    /// authorization from that sealed `sender_vid` (intrinsic-sender auth).
+    ///
+    /// **Fire-and-forget, unlike the DIDComm
+    /// [`send_trust_task`](crate::mediator::MediatorSession::send_trust_task).**
+    /// The VTA seals its reply and routes it back over TSP, so the response
+    /// document arrives on [`receive_next`](Self::receive_next) like any other
+    /// frame — a caller that needs the outcome must match it off the inbox (on
+    /// the document's `id`/`type`) rather than awaiting it here. TSP has no
+    /// `thid` demux, and `receive_next` holds the socket lock for its whole
+    /// budget, so an in-place wait would deadlock against a running inbox loop.
+    ///
+    /// Sending itself takes no socket lock, so this *is* safe to call while
+    /// that loop is blocked in `receive_next`.
+    pub async fn send_trust_task(
+        &self,
+        vta_did: String,
+        mediator_did: String,
+        doc_json: String,
+    ) -> Result<(), FfiError> {
+        self.inner
+            .send_document(&vta_did, &mediator_did, doc_json.as_bytes())
+            .await
+            .map_err(|e| FfiError::Transport {
+                reason: e.to_string(),
+            })
+    }
+
     /// Gracefully close the mediator connection (the TSP websocket).
     pub async fn shutdown(&self) {
         self.inner.shutdown().await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Live: the no-REST loop over **TSP** — connect the inbox, announce, submit
+    /// a holder-signed `whoami`, then read the reply back off the inbox.
+    ///
+    /// This is the TSP counterpart of
+    /// `mediator::tests::whoami_over_didcomm_without_rest`, and it exists to
+    /// validate the one assumption the Swift `TspReplyRouter` is built on:
+    /// **that the VTA's TSP reply carries `threadId` echoing our request `id`**.
+    /// TSP has no `thid` demux, so if that echo isn't there, correlation on the
+    /// device is impossible and the router design is wrong. The polling loop
+    /// below is deliberately the same rule the router implements.
+    ///
+    /// Ignored by default (network + a real VTA). Run:
+    /// `cargo test -p vta-mobile-core -- --ignored whoami_over_tsp --nocapture`
+    /// Override with `VTA_TEST_DID` / `VTA_TEST_MEDIATOR` / `VTA_TEST_SEED`.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    #[ignore = "network: submits a whoami to a live VTA over TSP"]
+    async fn whoami_over_tsp_without_rest() {
+        use crate::keys::Signer;
+        use ed25519_dalek::{Signer as _, SigningKey};
+        use multibase::Base;
+
+        let seed_byte: u8 = std::env::var("VTA_TEST_SEED")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(11);
+        let seed = [seed_byte; 32];
+        let sk = SigningKey::from_bytes(&seed);
+        let mut mc = vec![0xed, 0x01];
+        mc.extend_from_slice(sk.verifying_key().as_bytes());
+        let holder_did = format!("did:key:{}", multibase::encode(Base::Base58Btc, &mc));
+
+        let vta_did = std::env::var("VTA_TEST_DID").unwrap_or_else(|_| {
+            "did:webvh:QmWoJD2kpP6AJknNtj7UFERUstEen258ywj3ruHoh1ZAqr:webvh.storm.ws:glenn-vta"
+                .to_string()
+        });
+        let mediator = std::env::var("VTA_TEST_MEDIATOR").unwrap_or_else(|_| {
+            "did:webvh:QmTS3a3H9Dk4ZMPAZ8jNWGeyPbuKrPbrPZcSbg8CJ6yynD:webvh.storm.ws:mediator"
+                .to_string()
+        });
+
+        eprintln!("holder   = {holder_did}");
+        eprintln!("vta      = {vta_did}");
+        eprintln!("mediator = {mediator}");
+        eprintln!("\n(enrol this holder first: pnm acl create --did {holder_did})\n");
+
+        struct Stub {
+            sk: SigningKey,
+            did: String,
+        }
+        impl Signer for Stub {
+            fn did(&self) -> String {
+                self.did.clone()
+            }
+            fn sign(&self, payload: Vec<u8>) -> Result<Vec<u8>, FfiError> {
+                Ok(self.sk.sign(&payload).to_bytes().to_vec())
+            }
+        }
+
+        let session =
+            TspMediatorSession::connect(holder_did.clone(), seed.to_vec(), mediator.clone())
+                .await
+                .expect("connect the TSP inbox");
+        eprintln!("✅ TSP inbox connected");
+
+        // Learn-from-inbound: makes the VTA record us as TSP-reachable. Also the
+        // cheapest proof that outbound TSP works at all, before we send the real
+        // document.
+        session
+            .announce(vta_did.clone(), mediator.clone())
+            .await
+            .expect("announce TSP reachability");
+        eprintln!("✅ announced reachability");
+
+        // Drain the announce's pong FIRST, so the channel is proven live at the
+        // moment we submit. Without this, a failure can't distinguish "the
+        // whoami broke the channel" from "the channel was never working".
+        match session.receive_next(15).await {
+            Ok(Some(f)) => eprintln!("✅ channel proven live (pong: {})", &f[..f.len().min(90)]),
+            Ok(None) => eprintln!("⚠️  no pong before submit — channel may be dead already"),
+            Err(e) => eprintln!("⚠️  pong read error: {e}"),
+        }
+
+        // Unique per run: once the DID is enrolled the replay guard
+        // (`check_and_record(auth.did, doc.id)`) is reachable, so a fixed id would
+        // pass once and then be rejected as a replay on every rerun.
+        let request_id = format!(
+            "urn:uuid:test-tsp-whoami-{seed_byte}-{}",
+            chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default()
+        );
+        let env = crate::session::AuthEnvelope {
+            id: request_id.clone(),
+            holder_did: holder_did.clone(),
+            vta_did: vta_did.clone(),
+            issued_at: chrono::Utc::now().to_rfc3339(),
+        };
+        let doc = crate::session::build_whoami(
+            env,
+            Box::new(Stub {
+                sk,
+                did: holder_did.clone(),
+            }),
+        )
+        .expect("build a signed whoami document");
+
+        eprintln!(
+            "→ submitting whoami over TSP ({} bytes), id={request_id}",
+            doc.len()
+        );
+        session
+            .send_trust_task(vta_did.clone(), mediator.clone(), doc)
+            .await
+            .expect("send the whoami over TSP");
+        eprintln!("✅ sent (fire-and-forget); polling the inbox for the reply…\n");
+
+        // The router's rule, in miniature: match a frame whose `threadId` equals
+        // the id we sent. Anything else is unsolicited traffic (e.g. the pong
+        // from `announce`) and is skipped.
+        let mut correlated: Option<String> = None;
+        for attempt in 1..=6 {
+            match session.receive_next(10).await {
+                Ok(Some(frame)) => {
+                    let thread = serde_json::from_str::<serde_json::Value>(&frame)
+                        .ok()
+                        .and_then(|v| v.get("threadId").and_then(|t| t.as_str()).map(String::from));
+                    eprintln!("  [{attempt}] frame threadId={thread:?}\n      {frame}");
+                    if thread.as_deref() == Some(request_id.as_str()) {
+                        correlated = Some(frame);
+                        break;
+                    }
+                    eprintln!("      (not ours — skipping, as the router would)");
+                }
+                Ok(None) => eprintln!("  [{attempt}] nothing within 10s"),
+                Err(e) => {
+                    eprintln!("  [{attempt}] receive error: {e}");
+                    break;
+                }
+            }
+        }
+        session.shutdown().await;
+
+        match correlated {
+            Some(reply) => {
+                eprintln!("\n✅ correlated TSP reply by threadId, no REST:\n{reply}");
+            }
+            None => panic!(
+                "no TSP frame carried threadId={request_id}. The Swift TspReplyRouter \
+                 correlates on exactly this echo, so it would never resolve a submit."
+            ),
+        }
     }
 }

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.19.27"
+version = "0.19.28"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/didcomm_session.rs
+++ b/vta-sdk/src/didcomm_session.rs
@@ -582,9 +582,29 @@ impl DIDCommSession {
                 let json = serde_json::to_string(&msg).map_err(VtaError::from)?;
                 Ok(Some(json))
             }
-            // Stream ended (service shut down) — nothing more to receive.
-            Ok(None) => Ok(None),
-            // Poll window elapsed with nothing.
+            // Stream ended — nothing more will EVER arrive on this session.
+            //
+            // Distinguish the two ways that happens, because they need opposite
+            // reactions from the caller:
+            //   * we called `shutdown()` — expected teardown, report idle;
+            //   * anything else (mediator dropped us, delivery layer died) — the
+            //     session is dead and must be rebuilt.
+            //
+            // Reporting the second as `Ok(None)` made a dead session look like a
+            // quiet one: a polling loop would treat "stream ended" as "nothing
+            // yet", call again, get the same answer instantly, and spin at full
+            // tilt forever without reconnecting. `Err` is what makes the
+            // supervisor reconnect instead.
+            Ok(None) => {
+                if self.shutdown.load(Ordering::Acquire) {
+                    Ok(None)
+                } else {
+                    Err(VtaError::DidcommTransport(
+                        "mediator inbound stream ended — session is no longer live".into(),
+                    ))
+                }
+            }
+            // Poll window elapsed with nothing — the ordinary idle case.
             Err(_) => Ok(None),
         }
     }

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.12.34"
+version = "0.12.35"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/did_peer.rs
+++ b/vta-service/src/did_peer.rs
@@ -189,8 +189,10 @@ fn websocket_service_uri(service_uri: &str) -> Result<String, Box<dyn std::error
 #[cfg(test)]
 mod tests {
     use super::*;
+    // Only the `config-seed`-gated test below reads an ACL entry back; `Role`
+    // already arrives via `use super::*`.
+    #[cfg(feature = "config-seed")]
     use crate::acl::get_acl_entry;
-    use vti_common::acl::Role;
 
     /// `vta create-did-peer --context <ctx> --mediator-url <uri> --admin
     /// --export-secrets` must run fully non-interactive and, in one shot:

--- a/vta-service/src/did_webvh.rs
+++ b/vta-service/src/did_webvh.rs
@@ -351,7 +351,55 @@ pub async fn run_create_did_webvh(
     Ok(())
 }
 
-#[cfg(test)]
+fn edit_did_document(
+    doc: serde_json::Value,
+) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
+    use std::io::Write;
+    use std::process::Command;
+
+    let json = serde_json::to_string_pretty(&doc)?;
+
+    // Write to a named temp file with .json extension for editor syntax highlighting
+    let mut tmp = tempfile::Builder::new().suffix(".json").tempfile()?;
+    tmp.write_all(json.as_bytes())?;
+    tmp.flush()?;
+    let path = tmp.path().to_path_buf();
+
+    // Resolve editor: $VISUAL > $EDITOR > fallback
+    let editor = std::env::var("VISUAL")
+        .or_else(|_| std::env::var("EDITOR"))
+        .unwrap_or_else(|_| "vi".to_string());
+
+    // Open editor and wait
+    let status = Command::new(&editor)
+        .arg(&path)
+        .status()
+        .map_err(|e| format!("failed to launch editor '{editor}': {e}"))?;
+
+    if !status.success() {
+        return Err(format!("editor exited with {status}").into());
+    }
+
+    // Read back and parse
+    let edited = std::fs::read_to_string(&path)?;
+    let new_doc: serde_json::Value =
+        serde_json::from_str(&edited).map_err(|e| format!("invalid JSON from editor: {e}"))?;
+
+    // Basic validation: must be an object with "id" field
+    if !new_doc.is_object() || !new_doc.get("id").is_some_and(|v| v.is_string()) {
+        return Err("DID document must be a JSON object with an \"id\" field".into());
+    }
+
+    // Show the updated document
+    eprintln!(
+        "\x1b[2mUpdated DID Document:\n{}\x1b[0m",
+        serde_json::to_string_pretty(&new_doc)?
+    );
+
+    Ok(new_doc)
+}
+
+#[cfg(all(test, feature = "config-seed"))]
 mod tests {
     use super::*;
     use crate::acl::get_acl_entry;
@@ -370,7 +418,6 @@ mod tests {
     /// Gated on `config-seed` so the seed store is the in-config backend (no
     /// OS keyring), making the test hermetic. Run with:
     /// `cargo test -p vta-service --bin vta --features config-seed`.
-    #[cfg(feature = "config-seed")]
     #[tokio::test]
     async fn create_did_webvh_url_admin_export_is_noninteractive_and_grants_admin() {
         let dir = tempfile::TempDir::new().expect("tempdir");
@@ -465,52 +512,4 @@ mod tests {
         assert_eq!(entry.role, Role::Admin);
         assert_eq!(entry.allowed_contexts, vec!["agents".to_string()]);
     }
-}
-
-fn edit_did_document(
-    doc: serde_json::Value,
-) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
-    use std::io::Write;
-    use std::process::Command;
-
-    let json = serde_json::to_string_pretty(&doc)?;
-
-    // Write to a named temp file with .json extension for editor syntax highlighting
-    let mut tmp = tempfile::Builder::new().suffix(".json").tempfile()?;
-    tmp.write_all(json.as_bytes())?;
-    tmp.flush()?;
-    let path = tmp.path().to_path_buf();
-
-    // Resolve editor: $VISUAL > $EDITOR > fallback
-    let editor = std::env::var("VISUAL")
-        .or_else(|_| std::env::var("EDITOR"))
-        .unwrap_or_else(|_| "vi".to_string());
-
-    // Open editor and wait
-    let status = Command::new(&editor)
-        .arg(&path)
-        .status()
-        .map_err(|e| format!("failed to launch editor '{editor}': {e}"))?;
-
-    if !status.success() {
-        return Err(format!("editor exited with {status}").into());
-    }
-
-    // Read back and parse
-    let edited = std::fs::read_to_string(&path)?;
-    let new_doc: serde_json::Value =
-        serde_json::from_str(&edited).map_err(|e| format!("invalid JSON from editor: {e}"))?;
-
-    // Basic validation: must be an object with "id" field
-    if !new_doc.is_object() || !new_doc.get("id").is_some_and(|v| v.is_string()) {
-        return Err("DID document must be a JSON object with an \"id\" field".into());
-    }
-
-    // Show the updated document
-    eprintln!(
-        "\x1b[2mUpdated DID Document:\n{}\x1b[0m",
-        serde_json::to_string_pretty(&new_doc)?
-    );
-
-    Ok(new_doc)
 }

--- a/vta-service/src/messaging/service.rs
+++ b/vta-service/src/messaging/service.rs
@@ -184,6 +184,25 @@ pub async fn run_inbound_loop(
     let mut stream = messaging.service.subscribe();
     info!("VTA messaging connected to mediator — inbound messages will be processed");
 
+    // Handlers run concurrently, bounded by a semaphore.
+    //
+    // This loop used to `await` `handle_inbound` inline, so the VTA processed
+    // exactly one inbound frame at a time — across BOTH protocols, since one
+    // mediator websocket carries DIDComm and TSP together (one socket per DID).
+    // A single slow handler therefore stalled every other caller's traffic, and
+    // a hanging one wedged inbound messaging entirely.
+    //
+    // Spawning is safe because the dispatch spine is already concurrent: the
+    // REST route runs `dispatch_trust_task_core` under axum with no such
+    // serialisation, so handlers cannot have been relying on it.
+    //
+    // Bounded rather than unbounded: an unbounded spawn turns a burst (or a
+    // hostile sender) into unbounded task and memory growth. At the cap, the
+    // loop waits for a permit — degrading to the old serialised behaviour under
+    // extreme load instead of falling over.
+    const MAX_INFLIGHT_INBOUND: usize = 32;
+    let inflight = Arc::new(tokio::sync::Semaphore::new(MAX_INFLIGHT_INBOUND));
+
     loop {
         tokio::select! {
             maybe = stream.next() => {
@@ -191,15 +210,34 @@ pub async fn run_inbound_loop(
                     warn!("VTA inbound stream ended — messaging dispatcher stopping");
                     break;
                 };
-                handle_inbound(
-                    inbound,
-                    &messaging,
-                    &app_state,
-                    &vta_state,
-                    &vta_did,
-                    &mediator_did,
-                )
-                .await;
+
+                // Acquire before spawning so the cap actually bounds in-flight
+                // work; the permit is released when the handler task ends.
+                let permit = match Arc::clone(&inflight).acquire_owned().await {
+                    Ok(p) => p,
+                    Err(_) => {
+                        warn!("inbound concurrency semaphore closed — stopping");
+                        break;
+                    }
+                };
+
+                let messaging = Arc::clone(&messaging);
+                let app_state = app_state.clone();
+                let vta_state = Arc::clone(&vta_state);
+                let vta_did = vta_did.clone();
+                let mediator_did = mediator_did.clone();
+                tokio::spawn(async move {
+                    let _permit = permit;
+                    handle_inbound(
+                        inbound,
+                        &messaging,
+                        &app_state,
+                        &vta_state,
+                        &vta_did,
+                        &mediator_did,
+                    )
+                    .await;
+                });
             }
             _ = shutdown.cancelled() => {
                 info!("VTA messaging stopping (shutdown signalled)");

--- a/vta-service/src/operations/provision_integration/preconditions.rs
+++ b/vta-service/src/operations/provision_integration/preconditions.rs
@@ -520,8 +520,7 @@ mod tests {
 
         let err = resolve_target_context(&a, &ks, None, false)
             .await
-            .err()
-            .expect("ambiguous");
+            .expect_err("ambiguous");
         match err {
             ResolveContextError::Ambiguous(amb) => {
                 assert_eq!(
@@ -541,8 +540,7 @@ mod tests {
 
         let err = resolve_target_context(&a, &ks, Some("ctx-absent".into()), false)
             .await
-            .err()
-            .expect("not found");
+            .expect_err("not found");
         assert!(
             matches!(err, ResolveContextError::Op(AppError::NotFound(_))),
             "expected Op(NotFound)",

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.11.24"
+version = "0.11.25"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vtc-service/src/acl/role.rs
+++ b/vtc-service/src/acl/role.rs
@@ -176,6 +176,20 @@ fn is_valid_name_char(c: char) -> bool {
     matches!(c, 'a'..='z' | '0'..='9' | '-' | '_')
 }
 
+/// Map a [`VtcRole`] onto the shared [`vti_common::acl::Role`] that the common
+/// ACL predicates reason over. Only `Admin` is privilege-bearing in those
+/// predicates; every other community role collapses to `Reader`.
+///
+/// Lives here rather than in the route layer because the offline break-glass
+/// CLI needs it too, and both surfaces must decode an entry's scope the same
+/// way.
+pub fn as_vti_role(role: &VtcRole) -> vti_common::acl::Role {
+    match role {
+        VtcRole::Admin => vti_common::acl::Role::Admin,
+        _ => vti_common::acl::Role::Reader,
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -277,19 +291,5 @@ mod tests {
         // re-serialisation. This pins that path.
         let role = VtcRole::from_str("admin").unwrap();
         assert_eq!(role, VtcRole::Admin);
-    }
-}
-
-/// Map a [`VtcRole`] onto the shared [`vti_common::acl::Role`] that the common
-/// ACL predicates reason over. Only `Admin` is privilege-bearing in those
-/// predicates; every other community role collapses to `Reader`.
-///
-/// Lives here rather than in the route layer because the offline break-glass
-/// CLI needs it too, and both surfaces must decode an entry's scope the same
-/// way.
-pub fn as_vti_role(role: &VtcRole) -> vti_common::acl::Role {
-    match role {
-        VtcRole::Admin => vti_common::acl::Role::Admin,
-        _ => vti_common::acl::Role::Reader,
     }
 }

--- a/vtc-service/tests/endorsements.rs
+++ b/vtc-service/tests/endorsements.rs
@@ -31,7 +31,6 @@ const PUBLIC_URL: &str = "https://vtc.example.com";
 const REGISTER_TASK: &str = "https://trusttasks.org/spec/vtc/endorsement-types/register/0.1";
 const DELETE_TYPE_TASK: &str = "https://trusttasks.org/spec/vtc/endorsement-types/delete/0.1";
 const ISSUE_TASK: &str = "https://trusttasks.org/spec/vtc/endorsements/issue/0.1";
-const SHOW_TASK: &str = "https://trusttasks.org/spec/vtc/endorsements/show/0.1";
 const REVOKE_TASK: &str = "https://trusttasks.org/spec/vtc/endorsements/revoke/0.1";
 const ADMIN_DID: &str = "did:key:zEndAdmin";
 const ISSUER_DID: &str = "did:key:zEndIssuer";

--- a/vtc-service/tests/removal.rs
+++ b/vtc-service/tests/removal.rs
@@ -24,7 +24,6 @@ use vtc_service::test_support::TestVtc;
 
 const RP_ORIGIN: &str = "https://vtc.example.com";
 const SELF_REMOVE_TASK: &str = "https://trusttasks.org/spec/vtc/members/self-remove/0.1";
-const SHOW_TASK: &str = "https://trusttasks.org/spec/vtc/members/show/0.1";
 const ADMIN_REMOVE_TASK: &str = "https://trusttasks.org/spec/vtc/members/admin-remove/0.1";
 const POLICY_UPLOAD_TASK: &str = "https://trusttasks.org/spec/policy/upsert/0.2";
 const POLICY_ACTIVATE_TASK: &str = "https://trusttasks.org/spec/policy/activate/0.1";


### PR DESCRIPTION
Three related pieces of cleanup, each in its own commit.

## 1. `feat(mobile)` — a device can submit Trust Tasks with no REST API

A device could already *receive* over both DIDComm and TSP but had no way to submit a signed document back, so every reply path still needed the VTA's REST surface.

- **`MediatorSession::send_trust_task`** (+ `send_trust_task_one_way`) — submits an already-signed document as the body of a `binding/didcomm/0.1/envelope` message and awaits its `#response`, demuxed by `thid`. No bearer token: authcrypt-packed, so the VTA proves the sender DID and authorizes from it.
- **`TspMediatorSession::send_trust_task`** — the TSP counterpart, making that session bidirectional. Deliberately **fire-and-forget**: TSP has no `thid` demux, so the reply arrives as an ordinary inbound frame and the caller correlates on `threadId`. Sending takes no socket lock, so it is safe to call while `receive_next` holds one — an in-place wait would deadlock.

Two transport bugs this surfaced:

- **`DIDCommSession::receive_next` reported a dead session as an idle one.** It returned `Ok(None)` both when the poll window elapsed *and* when the inbound stream ended. `AgentSession::run` therefore treated "stream ended" as "nothing yet", called again, got the same answer instantly, and spun at full tilt forever without reconnecting. Now `Ok(None)` only for an expected teardown, `Err` otherwise — which is what `run` already breaks on. **This is a fix to an R1.5 violation, not a new risk.**
- **Inbound messaging was fully serialised.** `run_inbound_loop` awaited each `handle_inbound` inline, so the VTA processed one frame at a time across *both* protocols (one mediator websocket carries DIDComm and TSP together). A slow handler stalled every other caller; a hanging one wedged inbound messaging entirely. Handlers now spawn under a 32-permit semaphore. Safe because the dispatch spine is already concurrent — the REST route runs `dispatch_trust_task_core` under axum with no such serialisation.

Adds a **hermetic** regression test (`tests/e2e/tests/tsp_round_trip.rs`, `TestMediator`, no network) pinning that a TSP frame routes between two local accounts and is readable on **both** socket modes — raw-TSP (device) and store-and-pickup (VTA inbound loop) — each with a DIDComm control, plus a 10-round burst case. Guards the silent-drop bug fixed in `affinidi-messaging-mediator` 0.17.7 (tdk #646); the VTA drives `affinidi-messaging-delivery`, so the upstream test cannot catch a recurrence for us.

> Note: the incoming version of this file documented the bug as **open** and printed `"the raw-TSP socket did NOT"`. All 13 tests now pass, including 10/10 on the raw-TSP socket, so that narrative was stale and has been rewritten as a regression guard. Four obsolete diagnostic probes (~340 lines) that chased the now-closed intermittency were dropped.

## 2. `docs` — record the decomposition, refresh the crate map

Nine extraction steps (#780–#791) moved eleven subsystem crates out of `vta-service` (~114k → 87k lines) but left no workspace-level record: eleven READMEs and a changelog entry, no layering contract, no stopping rule. `CLAUDE.md` still described the pre-decomposition layout — the file loaded into every session was missing all eleven crates and pointed at five moved paths.

Adds `docs/05-design-notes/vta-service-decomposition.md`. Its point is the **stopping rule**: *a subsystem is extractable; the service's own spine is not.* What remains — `operations/` (38.7k), `trust_tasks/` (14.3k), `routes/` (9.2k), `messaging/` (7.7k) — depends on every subsystem and is depended on by nothing, so extracting it would move lines without narrowing any dependency surface. That is renaming, not decoupling.

It also records two things worth having on the record:
- LOC is a proxy. Net workspace lines went slightly **up**; the real wins are compile-unit granularity, independent testability, and the AWS SDK stack leaving the default build graph with `vta-tee`.
- **22,622 of the remaining 87,404 lines are in-file `#[cfg(test)]` modules** (non-test: 64,782), and nobody has measured the build-time delta the program is justified by.

## 3. `fix` — clear the workspace clippy warnings

`cargo clippy --workspace --all-targets` emitted twelve warnings; now silent. Feature-gate corrections on test-module imports, two `items after a test module` reorderings, `.err().expect()` → `.expect_err()`, and two unused `SHOW_TASK` constants removed. No behaviour change.

## Verification

| | |
|---|---|
| `vta-service` lib | 690 passed |
| `vta-service` bin `vta` | 53 passed |
| `vtc-service` lib + all integration suites | 683 + 89 passed |
| `vta-sdk` lib | 296 passed |
| `tsp_round_trip` (new) | 13 passed, incl. 10/10 burst |
| `vta-policy` / `vta-tee` | 37 / 32 passed |
| `cargo clippy --workspace --all-targets` | clean, with and without `config-seed` |
| `cargo fmt --all --check` | clean |

Versions bumped with matching changelog entries: `vta-sdk` 0.19.28, `vta-service` 0.12.35, `vta-mobile-core` 0.6.15, `vtc-service` 0.11.25.

## Known pre-existing failure, deliberately not fixed here

`setup::interactive`'s two scripted-wizard tests fail under `--features config-seed`. The wizard **skips** its "Seed storage backend" select when only one backend is compiled, so enabling a second shifts every scripted answer by one. **CI never builds that combo, so this has been silently red.** The fix is to make the scripted-answer harness feature-aware rather than assume a single-backend build — a separate change, and arguably CI should cover the combo too. Happy to open an issue.

## Pre-merge checklist (`vti-stack-development-guide.md` §9)

- [x] No new `reqwest::Client::new()` / bare `fetch()`; all clients have finite timeouts (R1.2) — no HTTP clients added
- [x] No lock held across a network await (R1.3) — **actively relevant**: `TspMediatorSession::send_trust_task` deliberately takes no socket lock, since `receive_next` holds it for its whole budget; documented on both
- [x] No local state committed before its remote effect (R2.1) — no mutations reordered
- [x] Every retry is bounded + backed off (R1.4) — no retries added; the `receive_next` fix is what lets a supervisor reconnect rather than spin
- [x] Accept/poll/listen loops survive transient errors (R1.5) — **this PR fixes a violation**: the inbound poll loop could not distinguish a dead stream from an idle one and busy-spun forever
- [x] Acks/deletes happen only after durable handoff (R1.6) — n/a
- [x] New/changed wire types (R3.*) — none; `TRUST_TASK_ENVELOPE_TYPE` is an existing URI and Trust Task documents pass through as opaque JSON
- [x] Config absence = most restrictive (R5.*) — no new config; the concurrency cap is a compile-time `const`
- [x] Logs/status claim only what was verified (R6.*) — the TSP send is documented as fire-and-forget and never claims delivery, per R1.1
- [x] "Process dies on the next line" answered for every mutation touched (R2.1) — **one honest deviation, called out below**
- [x] Deviations flagged explicitly with rule numbers

**R2.1 deviation (accepted):** with 32 handlers in flight, a crash now loses up to 32 inbound frames instead of 1. The mediator is an at-least-once bus so those frames are redeliverable, and the serialised version had the same exposure at N=1 with far worse head-of-line blocking. Flagging rather than hiding it — if that trade is unwanted, the cap is a one-line change.
