### PR TITLE
fix(cli): retire the pre-Banyan shims, and fix the `init` aliases they hid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,58 @@
 
 ## Unreleased
 
+### vta-cli-common 0.10.14 / pnm-cli 0.11.9 / vta-service 0.12.36 — retire the pre-Banyan CLI shims, and fix the `init` aliases they hid
+
+Sunsets the compatibility shims left over from the `webvh` → `did-mgmt` and
+`did-hosting-*` → `did-host-*` renames (both pre-Banyan, May–June 2026), each of
+which documented itself as lasting "one release". Clearing them surfaced a real
+bug.
+
+* **`pnm did-templates init` was broken for seven of its nine aliases.** The
+  `did-hosting-*` → `did-host-*` rename updated `BUILTIN_NAMES` and
+  `load_embedded` but not the CLI's alias table, so `init control`, `daemon`,
+  `hosting`, `did-hosting`, `server`, `witness`, and `watcher` all resolved to
+  template names that no longer existed and failed with `builtin template
+  'did-hosting-…' not found`. Only `mediator` and `agent` worked. The role words
+  now map onto the canonical shape names — control →
+  `did-host-http-didcomm`, daemon/hosting → `did-host-http`,
+  witness/watcher/server → `did-host-didcomm`.
+
+  The resolution moved into a testable `resolve_builtin_kind`, with a test that
+  asserts **every** alias resolves to something `load_embedded` can actually
+  load. That is the check whose absence let the rename half-land; a future
+  rename that misses one side now fails in CI.
+
+* **Retired the legacy `webvh-*` template aliases** from `did-templates init`,
+  matching the builtin loader, which had already dropped them (its
+  `legacy_template_aliases_are_removed` test pins that). A stale name now fails
+  loudly instead of silently resolving.
+
+* **Retired `vta`'s hidden `webvh` command alias** and its deprecation warning.
+  `pnm`'s equivalent went in an earlier release; this finishes the pair.
+  `WebvhCommands` itself stays — it is now purely internal plumbing that
+  `did-mgmt` converts into, and renaming it touches every handler.
+
+* **Dropped `pnm`'s `LEGACY_SESSION_KEY`.** Documented as load-bearing for
+  operators upgrading from pre-0.4 `pnm`, it was in fact a dead constant behind
+  `#[allow(dead_code)]` — the migration that used it was already gone, and the
+  `#[allow]` was hiding that.
+
+* **Docs corrected where they described removed behaviour**: `CLAUDE.md` and
+  `docs/02-vta/{did-templates,provision-integration}.md` all still told
+  operators the legacy aliases resolved, and two of them listed
+  `did-hosting-control/daemon/server` as built-in template names. `CLAUDE.md`
+  now carries the real `BUILTIN_NAMES` list. (`did-hosting-*` remains valid as
+  an integration kind and as a service name — only the template names were
+  retired.)
+
+Deliberately **not** removed, since neither is migration code: the
+`#[serde(default)]`/`alias` wire fields (peer interop with older VTAs, mediators,
+and clients — including `ChallengeRequest`'s `alias = "did"`, which is on the
+authentication path), and `vta-keys`' `seed_hex` archive migration, whose read
+path is what keeps keys minted under a pre-P0.7b seed generation recoverable.
+
+
 ### vtc-service 0.11.25 / vta-service 0.12.35 — clear the workspace clippy warnings
 
 `cargo clippy --workspace --all-targets` emitted twelve warnings; it is now

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,9 +175,10 @@ just minted + caller-supplied variables. Built-ins ship with the service
 `did-host-http`, `did-host-didcomm`); operators can upload more. The
 `did-host-*` names describe the DID-document shape (`http` = WebVHHosting
 endpoint, `didcomm` = DIDCommMessaging endpoint), not the service. The
-previous `webvh-*` and `did-hosting-*` template names still resolve via
-the loader's alias table for one release — update operator configs to the
-canonical `did-host-*` names before the aliases are removed.
+previous `webvh-*` and `did-hosting-*` template names **no longer resolve** —
+their one-release alias window closed, in both the builtin loader and the
+`did-templates init` CLI. Operator configs must use the canonical `did-host-*`
+names; a stale name now fails rather than silently resolving.
 
 **Before inventing a new mint-a-DID path, reach for templates first.**
 
@@ -707,13 +708,20 @@ new flow, update both this section and the relevant `docs/*.md`.
 - **Offline**: `pnm did-templates init <kind>`, `validate`, `list-builtins`.
 - **Online**: `pnm did-templates list/show/create/update/delete` →
   REST `/did-templates` (global) or `/contexts/{id}/did-templates` (scoped).
-- **Built-ins**: `didcomm-mediator`, `vta-admin`, `did-hosting-control`,
-  `did-hosting-daemon`, `did-hosting-server` (shipped with the SDK,
-  always available). Three did-hosting templates by deployment role:
-  `did-hosting-control` (hosting + DIDComm), `did-hosting-daemon`
-  (hosting only), `did-hosting-server` (DIDComm only, for
-  witness/watcher). Legacy `webvh-*` names resolve via the loader's
-  alias table for one release.
+- **Built-ins** (`vta_sdk::did_templates::BUILTIN_NAMES`, shipped with
+  the SDK, always available): `ai-agent`, `ai-agent-peer`,
+  `did-host-didcomm`, `did-host-http`, `did-host-http-didcomm`,
+  `did-host-http-tsp`, `did-host-tsp`, `didcomm-mediator`,
+  `push-gateway`, `vta-admin`, `vtc-host`. The `did-host-*` names encode
+  the DID-document **shape** (`http` = WebVHHosting, `didcomm` =
+  DIDCommMessaging, `tsp` = TSPTransport), so a deployment role maps onto
+  a shape: control = `did-host-http-didcomm`, hosting daemon =
+  `did-host-http`, witness/watcher = `did-host-didcomm`. `pnm
+  did-templates init` accepts those role words as aliases. The earlier
+  `webvh-*` **and** `did-hosting-*` template names have been removed —
+  a stale name now fails instead of resolving. (`did-hosting-*` remains
+  valid as an *integration kind* and as a service/binary name; it is only
+  retired as a template name.)
 - **Code**: `vta-sdk/src/did_templates/`,
   `vta-service/src/routes/did_templates.rs`, `vta-service/src/operations/did_templates.rs`.
 - **Docs**: `docs/02-vta/did-templates.md`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6759,7 +6759,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "pnm-cli"
-version = "0.11.8"
+version = "0.11.9"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-resolver-cache-sdk",
@@ -10118,7 +10118,7 @@ dependencies = [
 
 [[package]]
 name = "vta-cli-common"
-version = "0.10.13"
+version = "0.10.14"
 dependencies = [
  "aes-gcm",
  "affinidi-crypto",
@@ -10331,7 +10331,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.12.35"
+version = "0.12.36"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/docs/02-vta/did-templates.md
+++ b/docs/02-vta/did-templates.md
@@ -212,11 +212,12 @@ template without explicit scope is **context → global → builtin**:
     endpoint or DIDComm. Use for a witness, watcher, or any service consumed
     over TSP only.
 
-  Legacy template names from two earlier generations still resolve to the
-  renamed templates for one release: `webvh-control` / `webvh-daemon` /
-  `webvh-server` and `did-hosting-control` / `did-hosting-daemon` /
-  `did-hosting-server` all map to the `did-host-*` canonical names. Update
-  operator configs to the canonical names before the aliases are removed.
+  Legacy template names from two earlier generations — `webvh-control` /
+  `webvh-daemon` / `webvh-server` and `did-hosting-control` /
+  `did-hosting-daemon` / `did-hosting-server` — **no longer resolve**. Their
+  one-release alias window has closed in both the builtin loader and
+  `did-templates init`. Use the canonical `did-host-*` names; a stale name now
+  fails with "unknown builtin kind" rather than silently resolving.
 - **Global** (`tpl:global:<name>`) — super-admin-managed. Visible across every
   context.
 - **Context** (`tpl:ctx:<id>:<name>`) — context-admin-managed (or super

--- a/docs/02-vta/provision-integration.md
+++ b/docs/02-vta/provision-integration.md
@@ -107,15 +107,15 @@ conditional logic in the renderer, so the template name is a
 | Template | DID-document services | Required vars (renderer) | Required at provision time | Use for |
 |---|---|---|---|---|
 | `didcomm-mediator` | `DIDCommMessaging` URL endpoint | `URL` | — | DIDComm v2 routing mediator |
-| `did-hosting-control` | `WebVHHosting` + `DIDCommMessaging` | `URL`, `MEDIATOR_DID` | `URL` or `WEBVH_SERVER` | Control-plane node — hosts DID logs **and** accepts DIDComm (admin RPC, witness coordination, control-plane traffic) |
-| `did-hosting-daemon` | `WebVHHosting` only | `URL` | `URL` or `WEBVH_SERVER` | Pure hosting daemon — publishes DID logs over HTTP, no DIDComm. If you also need DIDComm, use `did-hosting-control` |
-| `did-hosting-server` | `DIDCommMessaging` only | `MEDIATOR_DID` | `URL` or `WEBVH_SERVER` | Witness, watcher, or any service consumed via DIDComm only — no public HTTP endpoint |
+| `did-host-http-didcomm` | `WebVHHosting` + `DIDCommMessaging` | `URL`, `MEDIATOR_DID` | `URL` or `WEBVH_SERVER` | Control-plane node — hosts DID logs **and** accepts DIDComm (admin RPC, witness coordination, control-plane traffic) |
+| `did-host-http` | `WebVHHosting` only | `URL` | `URL` or `WEBVH_SERVER` | Pure hosting daemon — publishes DID logs over HTTP, no DIDComm. If you also need DIDComm, use `did-host-http-didcomm` |
+| `did-host-didcomm` | `DIDCommMessaging` only | `MEDIATOR_DID` | `URL` or `WEBVH_SERVER` | Witness, watcher, or any service consumed via DIDComm only — no public HTTP endpoint |
 | `vta-admin` | (none) | (none) | — | Long-term admin DID for `--admin-template` rollover |
 
-Legacy `webvh-control` / `webvh-daemon` / `webvh-server` names are still
-accepted at the wire level and resolve to the renamed templates for one
-release; update operator configs to the canonical `did-hosting-*` names
-before the alias is removed.
+Legacy `webvh-control` / `webvh-daemon` / `webvh-server` names are **no longer
+accepted** — their one-release alias window has closed. Use the canonical names
+in the table above; a stale name is now rejected rather than silently
+resolved.
 
 "Required at provision time" applies in addition to the renderer's
 `requiredVars`. Any webvh-method template needs to know where its

--- a/pnm-cli/Cargo.toml
+++ b/pnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pnm-cli"
 description = "CLI Tool for managing a personal Verifiable Trust Agent"
-version = "0.11.8"
+version = "0.11.9"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/pnm-cli/src/cli.rs
+++ b/pnm-cli/src/cli.rs
@@ -214,11 +214,10 @@ pub(crate) enum Commands {
     /// daemon-side hosting trust-tasks live under
     /// `spec/did-hosting/*` and are a separate concern.)
     ///
-    /// Replaces the earlier `pnm webvh …` surface. The retired
-    /// command path is still accepted (hidden) for one release —
-    /// operators get a stderr deprecation note on each invocation.
-    /// The DID method itself remains `did:webvh`; only the operator
-    /// UX category was renamed.
+    /// Replaced the earlier `pnm webvh …` surface, whose hidden alias
+    /// was retired after its one-release deprecation window. The DID
+    /// method itself remains `did:webvh`; only the operator UX
+    /// category was renamed.
     DidMgmt {
         #[command(subcommand)]
         command: DidMgmtCommands,
@@ -474,8 +473,8 @@ pub(crate) enum DidTemplateCommands {
     /// `kind` accepts either the full built-in name
     /// (`didcomm-mediator`, `did-hosting-control`, `did-hosting-daemon`, `did-hosting-server`) or a short alias
     /// (`mediator`, `control`, `did-hosting`, `hosting`, `daemon`, `witness`, `watcher`, `server`).
-    /// Legacy `webvh-control` / `webvh-daemon` / `webvh-server` names are
-    /// still accepted and resolve to the renamed templates for one release.
+    /// The legacy `webvh-*` names were retired after their one-release
+    /// deprecation window — use the canonical `did-host-*` names.
     Init {
         /// Built-in kind or alias to fork.
         kind: String,

--- a/pnm-cli/src/config.rs
+++ b/pnm-cli/src/config.rs
@@ -148,14 +148,6 @@ pub fn vta_keyring_key(slug: &str) -> String {
     format!("vta:{slug}")
 }
 
-/// Legacy keyring key (pre-multi-VTA). Used for migration detection.
-///
-/// `dead_code` allowed: referenced only by the migration path that runs at
-/// startup to transfer a single-VTA credential into the multi-VTA keyring
-/// layout. Deleting it would break operators upgrading from pre-0.4 pnm.
-#[allow(dead_code)]
-pub const LEGACY_SESSION_KEY: &str = "vta";
-
 /// Convert a name to a slug (lowercase, spaces → hyphens, non-alphanumeric removed).
 pub fn slugify(name: &str) -> String {
     name.to_lowercase()

--- a/vta-cli-common/Cargo.toml
+++ b/vta-cli-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-cli-common"
 description = "Shared CLI command handlers and rendering helpers for VTA CLIs"
 readme = "README.md"
-version = "0.10.13"
+version = "0.10.14"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-cli-common/src/commands/did_templates.rs
+++ b/vta-cli-common/src/commands/did_templates.rs
@@ -59,34 +59,45 @@ pub fn cmd_validate(path: PathBuf) -> Result<(), Box<dyn std::error::Error>> {
     }
 }
 
+/// Resolve an `init <kind>` argument to an exact [`BUILTIN_NAMES`] entry.
+///
+/// Accepts either the canonical name verbatim or a short role alias. Returns
+/// `None` for anything else.
+///
+/// Role aliases map onto the canonical *shape* names, where `http` = a
+/// WebVHHosting endpoint and `didcomm` = a DIDCommMessaging endpoint: a control
+/// node serves both, a daemon publishes DID logs only, and a witness/watcher is
+/// reached over DIDComm only.
+///
+/// The legacy `webvh-*` names were retired after their one-release deprecation
+/// window, matching the builtin loader — see
+/// `did_templates::builtin::legacy_template_aliases_are_removed`.
+fn resolve_builtin_kind(kind: &str) -> Option<&'static str> {
+    let name = match kind {
+        "mediator" => "didcomm-mediator",
+        "agent" => "ai-agent",
+        "did-hosting" | "hosting" | "daemon" => "did-host-http",
+        "control" => "did-host-http-didcomm",
+        "witness" | "watcher" | "server" => "did-host-didcomm",
+        other => *BUILTIN_NAMES.iter().find(|n| **n == other)?,
+    };
+    Some(name)
+}
+
 /// `pnm did-templates init <kind>` / `cnm did-templates init <kind>`.
 ///
 /// Emit a starter template on stdout by forking an embedded built-in. The
-/// operator can redirect to a file, edit, and upload. `kind` is a built-in
-/// name (`didcomm-mediator`, `did-hosting-control`, `did-hosting-daemon`,
-/// `did-hosting-server`).
+/// operator can redirect to a file, edit, and upload. `kind` is a canonical
+/// built-in name (`didcomm-mediator`, `did-host-http`, `did-host-http-didcomm`,
+/// `did-host-didcomm`, …) or a short role alias — see
+/// [`resolve_builtin_kind`].
 pub fn cmd_init(kind: String) -> Result<(), Box<dyn std::error::Error>> {
-    // Accept either the exact builtin name, a short alias, or a legacy
-    // webvh-* name (resolved via the builtin loader's alias table).
-    let builtin_name = match kind.as_str() {
-        "mediator" => "didcomm-mediator",
-        "agent" => "ai-agent",
-        "did-hosting" | "hosting" | "daemon" => "did-hosting-daemon",
-        "control" => "did-hosting-control",
-        "witness" | "watcher" | "server" => "did-hosting-server",
-        // Legacy aliases — silently resolve to the renamed templates.
-        "webvh-hosting" => "did-hosting-daemon",
-        "webvh-control" => "did-hosting-control",
-        "webvh-daemon" => "did-hosting-daemon",
-        "webvh-server" => "did-hosting-server",
-        other if BUILTIN_NAMES.contains(&other) => other,
-        other => {
-            eprintln!(
-                "{RED}\u{2717}{RESET} Unknown builtin kind '{other}'. Available: {}",
-                BUILTIN_NAMES.join(", ")
-            );
-            return Err("unknown builtin".into());
-        }
+    let Some(builtin_name) = resolve_builtin_kind(&kind) else {
+        eprintln!(
+            "{RED}\u{2717}{RESET} Unknown builtin kind '{kind}'. Available: {}",
+            BUILTIN_NAMES.join(", ")
+        );
+        return Err("unknown builtin".into());
     };
 
     // Load the builtin, re-serialize as pretty-printed JSON for editing.
@@ -504,4 +515,76 @@ pub fn cmd_list_builtins() -> Result<(), Box<dyn std::error::Error>> {
     let height = BUILTIN_NAMES.len() as u16 + 4;
     print_widget(table, height);
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// **Every** `init` alias must resolve to a builtin the loader actually
+    /// has. This is the check that was missing: the `did-hosting-*` →
+    /// `did-host-*` rename updated `BUILTIN_NAMES` and `load_embedded` but not
+    /// this alias table, so seven of the nine aliases resolved to names that no
+    /// longer existed and `init` failed with "builtin template not found".
+    ///
+    /// Asserting against `load_embedded` rather than a hardcoded list is the
+    /// point — a future rename that misses one side fails here.
+    #[test]
+    fn every_init_alias_resolves_to_a_loadable_builtin() {
+        for alias in [
+            "mediator",
+            "agent",
+            "did-hosting",
+            "hosting",
+            "daemon",
+            "control",
+            "witness",
+            "watcher",
+            "server",
+        ] {
+            let resolved = resolve_builtin_kind(alias)
+                .unwrap_or_else(|| panic!("alias '{alias}' resolved to nothing"));
+            assert!(
+                BUILTIN_NAMES.contains(&resolved),
+                "alias '{alias}' → '{resolved}', which is not in BUILTIN_NAMES"
+            );
+            assert!(
+                load_embedded(resolved).is_ok(),
+                "alias '{alias}' → '{resolved}', which the loader cannot load"
+            );
+        }
+    }
+
+    /// Every canonical name is accepted verbatim, not just via an alias.
+    #[test]
+    fn canonical_builtin_names_pass_through() {
+        for name in BUILTIN_NAMES {
+            assert_eq!(
+                resolve_builtin_kind(name),
+                Some(*name),
+                "canonical name '{name}' must pass through unchanged"
+            );
+        }
+    }
+
+    /// The retired `webvh-*` aliases must not come back. Their one-release
+    /// window closed; a stale name should fail loudly rather than resolve.
+    #[test]
+    fn retired_webvh_aliases_are_rejected() {
+        for old in [
+            "webvh-hosting",
+            "webvh-control",
+            "webvh-daemon",
+            "webvh-server",
+            "did-hosting-control",
+            "did-hosting-daemon",
+            "did-hosting-server",
+        ] {
+            assert_eq!(
+                resolve_builtin_kind(old),
+                None,
+                "retired alias '{old}' must no longer resolve"
+            );
+        }
+    }
 }

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.12.35"
+version = "0.12.36"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/main.rs
+++ b/vta-service/src/main.rs
@@ -247,26 +247,16 @@ enum Commands {
     /// controller's registered DID-hosting servers. `vta did-mgmt
     /// dids {…}` operates on the DIDs themselves.
     ///
-    /// Replaces the earlier `vta webvh …` surface. The retired
-    /// command path is still accepted (hidden) for one release —
-    /// operators get a stderr deprecation note on each invocation.
-    /// The DID method itself remains `did:webvh`; only the operator
-    /// UX category was renamed.
+    /// Replaced the earlier `vta webvh …` surface, whose hidden alias
+    /// was retired after its one-release deprecation window. The DID
+    /// method itself remains `did:webvh`; only the operator UX
+    /// category was renamed.
     #[cfg(feature = "webvh")]
     DidMgmt {
         #[command(subcommand)]
         command: DidMgmtCommands,
     },
 
-    /// DEPRECATED — renamed to `vta did-mgmt <subcommand>`. Still
-    /// dispatched for one release; switch your scripts before the
-    /// alias is removed in the next minor.
-    #[cfg(feature = "webvh")]
-    #[command(hide = true)]
-    Webvh {
-        #[command(subcommand)]
-        command: WebvhCommands,
-    },
     /// Sealed-transfer bootstrap — seal payloads for offline consumer
     /// provisioning (mediators, webvh servers, and other complex clients).
     Bootstrap {
@@ -1854,21 +1844,13 @@ async fn main() {
         }
         #[cfg(feature = "webvh")]
         Some(Commands::DidMgmt { command }) => {
-            // Funnel the new structure through the legacy enum so the
-            // existing dispatch / seal-check / handler chain stays the
-            // single source of business logic. Drop together with the
-            // legacy `Webvh` variant in the next minor release.
+            // Funnel the new structure through `WebvhCommands` so the existing
+            // dispatch / seal-check / handler chain stays the single source of
+            // business logic. That enum is now purely internal plumbing — the
+            // operator-facing `vta webvh …` alias it was named for is gone —
+            // so it should be renamed to the did-mgmt shape and the conversion
+            // inlined; tracked separately, since it touches every handler.
             run_webvh_dispatch(cli.config.clone(), command.into()).await;
-        }
-        #[cfg(feature = "webvh")]
-        Some(Commands::Webvh { command }) => {
-            eprintln!(
-                "\x1b[1;33mwarning:\x1b[0m `vta webvh …` has been renamed to \
-                 `vta did-mgmt {{servers,dids}} …`. The old name is accepted \
-                 for one release and will be removed in the next minor. \
-                 See `vta did-mgmt --help`."
-            );
-            run_webvh_dispatch(cli.config.clone(), command).await;
         }
         Some(Commands::Bootstrap { command }) => {
             let result = match command {


### PR DESCRIPTION
Sunsets the compatibility shims left over from two pre-Banyan renames — `webvh` → `did-mgmt` (2026-05-25) and `did-hosting-*` → `did-host-*` (2026-06-02) — each of which documented itself as lasting "one release". `Banyan` is 2026-06-22, so both windows closed a while ago.

Clearing them surfaced a bug that had been shipping unnoticed.

## `pnm did-templates init` was broken for 7 of its 9 aliases

The `did-hosting-*` → `did-host-*` rename updated `BUILTIN_NAMES` and `load_embedded` but **not** the CLI's alias table. So the table kept mapping role words onto template names that no longer existed:

```
$ pnm did-templates init control
✗ Error: builtin template 'did-hosting-control' not found
```

Measured before the fix — only `mediator` and `agent` worked:

| alias | before | after |
|---|---|---|
| `control` | ✗ not found | `did-host-http-didcomm` |
| `daemon` / `hosting` / `did-hosting` | ✗ not found | `did-host-http` |
| `server` / `witness` / `watcher` | ✗ not found | `did-host-didcomm` |
| `mediator` | ok | `didcomm-mediator` |
| `agent` | ok | `ai-agent` |

Role words now map onto the canonical **shape** names, where `http` = a WebVHHosting endpoint and `didcomm` = a DIDCommMessaging endpoint.

The resolution moved into a testable `resolve_builtin_kind`, with a test asserting **every** alias resolves to something `load_embedded` can actually load. That's the check whose absence let the rename half-land — a future rename that misses one side now fails in CI instead of in an operator's terminal.

## Also retired

- **Legacy `webvh-*` template aliases** from `did-templates init`. The builtin loader had already dropped them and pins it with `legacy_template_aliases_are_removed`; the CLI hadn't. A stale name now fails loudly.
- **`vta`'s hidden `webvh` command alias** + its deprecation warning. `pnm`'s equivalent went in an earlier release, so this finishes the pair.
- **`pnm`'s `LEGACY_SESSION_KEY`.** Its doc claimed deleting it would break operators upgrading from pre-0.4 `pnm` — but it was a dead constant behind `#[allow(dead_code)]`. The migration that used it was already gone, and the `#[allow]` was hiding that. Verified: one reference in the whole workspace, its own declaration.

`WebvhCommands` **stays**. It's no longer an operator-facing alias but internal plumbing that `did-mgmt` converts into; renaming it touches every handler, so it's tracked separately.

## Docs that described removed behaviour

`CLAUDE.md` and `docs/02-vta/{did-templates,provision-integration}.md` all still told operators the legacy aliases resolved, and two of them listed `did-hosting-control/daemon/server` as **built-in template names** — which they aren't. `CLAUDE.md` now carries the real `BUILTIN_NAMES` list.

`did-hosting-*` remains valid as an *integration kind* and as a *service/binary* name (`auth-architecture.md`, `seal-and-unseal.md`, the VTC setup docs). Only the template names were retired, so I left those references alone.

## Deliberately NOT removed

Neither is migration code, and a broader sweep would have caught both:

- **`#[serde(default)]` / `alias` wire fields** (`protocol/services.rs`, `did_management/*`, `provision_integration/http.rs`) — these are *peer* interop with older VTAs, mediators and clients, not migration. That includes `ChallengeRequest`'s `alias = "did"`, which sits on the **authentication** path: removing it would lock out any client still sending the pre-rename field. It has a test pinning it.
- **`vta-keys`' `seed_hex` archive migration** — `seed_hex` is the pre-P0.7b *plaintext* seed archive, migrated to `seed_enc` by `reconcile_archive`. Deleting the read path would permanently orphan keys minted under a retired seed generation. That's data loss, not cleanup.

## Verification

| | |
|---|---|
| `pnm-cli` | 51 passed |
| `vta-cli-common` (incl. 3 new alias tests) | 80 passed |
| `vta-service` bin `vta` | 53 passed |
| `vta-sdk` did-templates | 54 passed |
| `cargo clippy --workspace --all-targets` | clean |
| `cargo fmt --all --check` | clean |
| all 9 aliases exercised against the built binary | correct target each |

Versions bumped with a matching changelog entry: `vta-cli-common` 0.10.14, `pnm-cli` 0.11.9, `vta-service` 0.12.36.
