### PR TITLE
fix(setup): make the wizard's scripted prompts feature-proof, and run them in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,6 +248,18 @@ jobs:
       - name: vta-sdk client + sealed-transfer + provision-integration
         run: cargo check -p vta-sdk --features client,sealed-transfer,provision-integration
 
+      # Every step above only *compiles*. The setup wizard's scripted-prompt
+      # tests are the one place where a feature flag changes behaviour rather
+      # than just what compiles: each secrets backend adds an option to the
+      # backend menu, which shifts the answer script. `cargo check` cannot see
+      # that, so these two tests sat broken under `config-seed` — the only combo
+      # that both adds a backend and is cheap to build — until someone ran it by
+      # hand. Run them, don't just build them.
+      - name: vta-service setup wizard under extra secrets backends
+        run: |
+          cargo test -p vta-service --bin vta --features config-seed setup::interactive
+          cargo test -p vta-service --bin vta --features config-seed,vault-secrets,k8s-secrets setup::interactive
+
   enclave:
     # The Nitro enclave binary uses a TEE-only feature combo that the
     # default `check` job never touches. Linux-only because vsock-store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,46 @@
 
 ## Unreleased
 
+### vta-service 0.12.37 — make the wizard's scripted prompts feature-proof, and actually run them in CI
+
+The setup wizard's two golden tests (`interactive_matches_equivalent_toml`,
+`advanced_existing_keys_mode_maps_through`) failed under `--features config-seed`
+and had been failing since that feature landed. CI never noticed because the
+`Feature combos` job only runs `cargo check`, so nothing in CI *executed* a
+wizard test under any non-default backend set.
+
+**Cause.** `ScriptedPrompter` replayed answers **positionally**, ignoring the
+prompt and its option list. The secrets-backend menu is assembled feature by
+feature (`aws-secrets`, `config-seed`, `keyring`, …), so `Answer::Index(0)` meant
+"OS keyring" by default but "Config file" once `config-seed` was on. That picked
+the wrong backend, which meant the wizard never asked for a keyring service name,
+which meant the *next* scripted answer was eaten by the wrong prompt — surfacing
+as a bogus `expected Index answer for prompt: VTA DID` several prompts downstream.
+A positional script cannot survive a menu whose length is a build-time property.
+
+**Fix.** New `Answer::Label(&str)` picks a `select` option by its label, resolved
+against the `items` the harness already received and previously discarded. The two
+backend answers now say `Answer::Label("OS keyring")`. This is immune to options
+being added, removed, or reordered, and when a label genuinely disappears it fails
+at the *right* prompt with the available options listed, instead of derailing the
+script.
+
+Verified across seven feature sets — default, `config-seed`,
+`config-seed,keyring`, `aws-secrets,keyring`, `vault-secrets,keyring`,
+`k8s-secrets,keyring`, and `config-seed,vault-secrets,k8s-secrets,keyring` — all
+green. Previously only the default set passed.
+
+**CI.** `Feature combos` gained a step that *runs* these tests under
+`config-seed` and under `config-seed,vault-secrets,k8s-secrets`. Every other step
+in that job only compiles; the wizard is the one place a feature flag changes
+behaviour rather than just what builds, so compiling it was never going to catch
+this.
+
+Pre-existing `Answer::Index` uses for fixed menus (log format, messaging kind,
+VTA DID kind, advanced mode) are unchanged — those option lists don't vary by
+feature.
+
+
 ### vta-cli-common 0.10.14 / pnm-cli 0.11.9 / vta-service 0.12.36 — retire the pre-Banyan CLI shims, and fix the `init` aliases they hid
 
 Sunsets the compatibility shims left over from the `webvh` → `did-mgmt` and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10331,7 +10331,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.12.36"
+version = "0.12.37"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.12.36"
+version = "0.12.37"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/setup/interactive.rs
+++ b/vta-service/src/setup/interactive.rs
@@ -1048,6 +1048,20 @@ mod tests {
         Bool(bool),
         Index(usize),
         Indices(Vec<usize>),
+        /// Pick a `select` option by its **label** rather than its position.
+        ///
+        /// Prefer this over [`Answer::Index`] whenever the option list depends
+        /// on which features are compiled. The secrets-backend menu is the
+        /// motivating case: it is built up feature by feature (`aws-secrets`,
+        /// `config-seed`, `keyring`, …), so `Index(0)` means "OS keyring" in the
+        /// default build and "Config file" once `config-seed` is on. That
+        /// silently picked the wrong backend, which skipped the keyring-service
+        /// prompt, which shifted every later answer by one — surfacing as a
+        /// bogus "expected Index answer for prompt: VTA DID" far downstream.
+        ///
+        /// Matching on the label is immune to options being added, removed, or
+        /// reordered, and fails at the *right* prompt when a label disappears.
+        Label(&'static str),
     }
 
     /// Head-less [`Prompter`] that replays a fixed script of answers. Panics on
@@ -1096,10 +1110,17 @@ mod tests {
                 _ => panic!("expected Bool answer for prompt: {prompt}"),
             }
         }
-        fn select(&self, prompt: &str, _items: &[&str], _default: usize) -> Result<usize, DynErr> {
+        fn select(&self, prompt: &str, items: &[&str], _default: usize) -> Result<usize, DynErr> {
             match self.next(prompt) {
                 Answer::Index(i) => Ok(i),
-                _ => panic!("expected Index answer for prompt: {prompt}"),
+                Answer::Label(want) => items.iter().position(|it| *it == want).ok_or_else(|| {
+                    format!(
+                        "scripted label {want:?} is not an option for prompt {prompt:?}; \
+                         available: {items:?}"
+                    )
+                    .into()
+                }),
+                _ => panic!("expected Index or Label answer for prompt: {prompt}"),
             }
         }
         fn multiselect(
@@ -1125,9 +1146,13 @@ mod tests {
     /// advanced server options — exercises the divergence-prone mappings.
     #[tokio::test]
     async fn interactive_matches_equivalent_toml() {
-        // Scripted answers, in the exact order the prompts fire. Backend Select
-        // is index 0 = "OS keyring" (the only cloud-free backend in the default
-        // feature set besides plaintext).
+        // Scripted answers, in the exact order the prompts fire.
+        //
+        // Selects whose option list varies with the compiled feature set use
+        // `Answer::Label` rather than `Answer::Index` — see [`Answer::Label`].
+        // The secrets-backend menu is the one that bites: it is assembled
+        // feature by feature, so a positional answer picks a different backend
+        // under `config-seed`/`aws-secrets`/… than it does by default.
         let answers = vec![
             text("/tmp/vta-golden/config.toml"), // config path (doesn't exist)
             text("golden-vta"),                  // vta name
@@ -1144,13 +1169,14 @@ mod tests {
             // unifies `tee` onto this binary via vta-enclave).
             #[cfg(feature = "tee")]
             text(""), // TEE-only: remote DID resolver URL (skip)
-            text("90"),                                // audit retention
-            text("/tmp/vta-golden/data"),              // data dir (doesn't exist)
-            Answer::Bool(true),                        // configure advanced server opts?
-            text("https://app.example.com"),           // cors origins
-            Answer::Bool(true),                        // trust_xff
-            Answer::Bool(true),                        // webauthn
-            Answer::Index(0),                          // secrets backend = keyring
+            text("90"),                      // audit retention
+            text("/tmp/vta-golden/data"),    // data dir (doesn't exist)
+            Answer::Bool(true),              // configure advanced server opts?
+            text("https://app.example.com"), // cors origins
+            Answer::Bool(true),              // trust_xff
+            Answer::Bool(true),              // webauthn
+            // Label, not index: the backend menu grows with features (config-seed etc.).
+            Answer::Label("OS keyring"),
             text("golden-keyring"),                    // keyring service
             Answer::Index(1),                          // messaging = create mediator
             text("mediator"),                          // mediator context
@@ -1238,8 +1264,9 @@ mod tests {
             text("28"),                    // audit retention
             text("/tmp/vta-golden2/data"), // data dir
             Answer::Bool(false),           // advanced server opts? no
-            Answer::Index(0),              // secrets backend = keyring
-            text("vta"),                   // keyring service
+            // Label, not index: the backend menu grows with features (config-seed etc.).
+            Answer::Label("OS keyring"),
+            text("vta"), // keyring service
             // messaging skipped (REST only)
             Answer::Index(0),                       // VTA DID = create_webvh
             text("https://t.example.com/dids/vta"), // webvh url


### PR DESCRIPTION
Fixes the `config-seed` failure surfaced while cleaning up #793. The setup wizard's two golden tests — `interactive_matches_equivalent_toml` and `advanced_existing_keys_mode_maps_through` — failed under `--features config-seed`, and had been failing since that feature landed.

```
$ cargo test -p vta-service --bin vta --features config-seed setup::interactive
panicked at interactive.rs:1102: expected Index answer for prompt: VTA DID
panicked at interactive.rs:1102: expected Index answer for prompt: DIDComm messaging
test result: FAILED. 0 passed; 2 failed
```

**CI never noticed** because the `Feature combos` job only runs `cargo check` — nothing in CI ever *executed* a wizard test under a non-default secrets-backend set.

## Cause

`ScriptedPrompter` replayed answers **positionally**, ignoring both the prompt and the option list it was handed. The secrets-backend menu is assembled feature by feature (`aws-secrets`, `config-seed`, `keyring`, …), so:

| build | menu | `Answer::Index(0)` selects |
|---|---|---|
| default | `["OS keyring", "Plaintext"]` | OS keyring ✓ |
| `+config-seed` | `["Config file", "OS keyring", "Plaintext"]` | **Config file** ✗ |

Picking the wrong backend meant the wizard never asked for a keyring service name, so the next scripted answer (`text("golden-keyring")`) was eaten by the wrong prompt — and the panic surfaced several prompts *downstream* of the actual mistake, which is why it read as unrelated.

A positional script cannot survive a menu whose length is a build-time property. There was already a `#[cfg(feature = "tee")]` answer in the script working around the same class by hand.

## Fix

New `Answer::Label(&'static str)` picks a `select` option by label, resolved against the `items` the harness already received and previously discarded:

```rust
Answer::Label(want) => items.iter().position(|it| *it == want).ok_or_else(|| …)
```

The two backend answers now say `Answer::Label("OS keyring")` instead of guessing its position. This is immune to options being added, removed, or reordered — and when a label genuinely disappears, it fails at the *right* prompt with the available options listed, rather than derailing the script.

Existing `Answer::Index` uses for fixed menus (log format, messaging kind, VTA DID kind, advanced mode) are left alone — those lists don't vary by feature.

## Verified across seven feature sets

All green; previously **only the default set passed**:

| feature set | before | after |
|---|---|---|
| *(default)* | ok | ok |
| `config-seed` | **FAILED** | ok |
| `config-seed,keyring` | **FAILED** | ok |
| `aws-secrets,keyring` | **FAILED** | ok |
| `vault-secrets,keyring` | **FAILED** | ok |
| `k8s-secrets,keyring` | **FAILED** | ok |
| `config-seed,vault-secrets,k8s-secrets,keyring` | **FAILED** | ok |

Plus the full suites unchanged: `vta-service` lib 690 passed, bin `vta` 53 passed, clippy and fmt clean.

## CI

`Feature combos` gained a step that **runs** these tests under `config-seed` and under `config-seed,vault-secrets,k8s-secrets`. The first is the exact command that reproduced the original failure.

Every other step in that job only compiles. The wizard is the one place a feature flag changes *behaviour* rather than just what builds, so `cargo check` was never going to catch this — which is precisely how it stayed broken.
