### PR TITLE
fix(setup): stop treating a pre-created data directory as a conflict, and make the secrets backend explicit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,35 @@ path still needed the VTA's REST surface.
   crate (`affinidi-messaging-delivery`), so a recurrence would not be caught by
   the upstream test. No network, no deployed VTA — runs unignored in CI.
 
+### vti-secrets 0.1.7 / vta-config 0.1.1 — `[secrets] backend` selects the seed store explicitly
+
+Choosing "Plaintext file" in the setup wizard silently produced a
+**keyring-backed** VTA. `create_seed_store` inferred the backend from whichever
+selector field was populated, and plaintext has no field of its own —
+`allow_plaintext` is a *permission* to fall back, not a request. With `keyring`
+compiled in (the default) the keyring arm matched unconditionally, so the
+plaintext arm below it was unreachable. The same shadowing hid any backend
+sitting under a configured one.
+
+* **New `secrets.backend`** (`keyring` | `config_seed` | `aws` | `gcp` |
+  `azure` | `vault` | `kubernetes` | `plaintext`). When set it wins outright:
+  that backend is built and its required fields are validated. Mirrors
+  `vtc_service::config::SecretBackend`, so the VTA and VTC now share one
+  vocabulary.
+
+* **Fail closed.** A backend named on a binary built without its Cargo feature
+  is a hard config error rather than a silent fall-through to keyring or
+  plaintext — the same P0.8 stance the VTC already took.
+
+* **The setup wizard always writes it**, so every generated `config.toml`
+  states its backend instead of leaving it to inference. Plaintext now needs
+  both keys: `backend = "plaintext"` (which backend) and
+  `allow_plaintext = true` (accepting a cleartext master seed).
+
+* **Backward compatible.** Omitting `secrets.backend` keeps the legacy implicit
+  priority chain exactly as it was, and the field is skipped on serialize when
+  unset, so existing configs neither change behaviour nor grow a key.
+
 ### vta-tee 0.1.0 / vta-policy 0.1.0 / vta-keys 0.1.1 / vti-common 0.11.21 / vta-service 0.12.34 — extract the TEE and policy subsystems
 
 Ninth decomposition step — two subsystem extractions in one PR, each unblocked

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,46 @@
 
 ## Unreleased
 
+### vti-common 0.11.22 / vta-service 0.12.37 — setup no longer treats a pre-created data directory as a conflict
+
+`vta setup` refused to run against any `data_dir` that already existed, offering
+only "delete everything" or "cancel". That made containerized first-boot
+impossible: Docker volumes, bind mounts, and Kubernetes PVCs all create the
+mount path *before* the container starts, so a completely fresh install always
+hit the prompt — and answering "yes" then failed too, because
+`remove_dir_all` removes the directory itself and `rmdir` on a mount point
+returns `EBUSY` however empty it is. Reported against `/app/vta-data`.
+
+* **The gate is store presence, not directory presence.** New
+  `vti_common::store::local_store_exists` probes for fjall's own `version`
+  marker — the same file `fjall::Database` uses to decide "recover" versus
+  "create new", so the two cannot drift. An existing-but-storeless `data_dir`
+  is initialized into silently, with no prompt.
+
+* **`data_dir_exists = "delete"` clears the directory's contents, not the
+  directory.** Same destruction, but it succeeds on a mount point.
+
+* **New `data_dir_exists = "reuse"`** plus a matching third option in the
+  interactive prompt, which is now a three-way choice (cancel / keep contents /
+  wipe) instead of a yes-no with no survivable answer.
+
+* **Setup fails closed over an initialized VTA.** Re-running setup mints a
+  fresh master seed as generation 0; on top of an existing seed that orphans
+  every key derived from the original. All policies — including `reuse` — now
+  refuse when generation 0 is already present.
+
+* **The wizard no longer deletes `config.toml` while it is still asking
+  questions.** It used to remove the file at the config-path prompt, so an
+  operator who backed out at the data-directory question a dozen prompts later
+  was left with no config and a VTA that would not start. Intent is now carried
+  as `overwrite_config` (new `WizardInputs` field, `--from <toml>`-settable,
+  default `false`) and the file is written only once everything else has
+  succeeded. `--from` callers that relied on the previous "delete it first"
+  behaviour are unaffected; those that want in-place re-runs can set
+  `overwrite_config = true` instead of `rm`-ing the file.
+
+* The data-directory and config-path answers are trimmed, so a pasted path with
+  stray whitespace no longer becomes a subtly different path.
 ### vta-cli-common 0.10.14 / pnm-cli 0.11.9 / vta-service 0.12.36 — retire the pre-Banyan CLI shims, and fix the `init` aliases they hid
 
 Sunsets the compatibility shims left over from the `webvh` → `did-mgmt` and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10331,7 +10331,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.12.36"
+version = "0.12.37"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",
@@ -10646,7 +10646,7 @@ dependencies = [
 
 [[package]]
 name = "vti-common"
-version = "0.11.21"
+version = "0.11.22"
 dependencies = [
  "aes-gcm",
  "affinidi-data-integrity",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10143,7 +10143,7 @@ dependencies = [
 
 [[package]]
 name = "vta-config"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "serde",
  "serde_ignored",
@@ -10719,7 +10719,7 @@ dependencies = [
 
 [[package]]
 name = "vti-secrets"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "aws-config",
  "aws-sdk-secretsmanager",
@@ -10739,6 +10739,7 @@ dependencies = [
  "serde",
  "tempfile",
  "tokio",
+ "toml 1.1.3+spec-1.1.0",
  "tracing",
  "vaultrs",
  "vta-sdk",

--- a/docs/02-vta/examples/vta-setup.example.toml
+++ b/docs/02-vta/examples/vta-setup.example.toml
@@ -119,7 +119,11 @@ service = "vta-prod"   # default "vta"; use a unique name per VTA on the same ho
 # [secrets]
 # backend = "config_seed"
 
-# Plaintext file under `data_dir`. Dev only.
+# Plaintext file under `data_dir`. Dev only. The wizard writes BOTH
+# `backend = "plaintext"` (which backend) and `allow_plaintext = true`
+# (yes, a cleartext master seed is acceptable) into the generated
+# config.toml — plaintext needs both, and is otherwise unreachable on a
+# build with the `keyring` feature compiled in.
 # [secrets]
 # backend = "plaintext"
 

--- a/docs/02-vta/examples/vta-setup.example.toml
+++ b/docs/02-vta/examples/vta-setup.example.toml
@@ -35,10 +35,20 @@ vta_name    = "trust-prod-1"
 # DIDComm-only or private-network deployments.
 public_url  = "https://trust.example.com"
 
-# What to do if `data_dir` already exists.
+# What to do if `data_dir` already holds a store. Only consulted when a
+# store is actually present — an existing-but-empty directory (a mounted
+# Docker volume, a Kubernetes PVC, a path you created yourself) is
+# initialized into without complaint.
 #   "error"  (default) — refuse and exit
-#   "delete" — recursively wipe and re-init (CI re-run pattern)
+#   "delete" — wipe the directory's *contents* and re-init (CI re-run
+#              pattern; keeps the directory itself, so it works on a
+#              mount point)
+#   "reuse"  — initialize into it, keeping whatever is already there
 data_dir_exists = "error"
+
+# Permit overwriting an existing `config_path`. The file is only written
+# once setup has otherwise succeeded, so a failed run leaves it intact.
+overwrite_config = false
 
 # Seed an initial super-admin and seal the VTA atomically with the rest of
 # setup. Equivalent to running `vta bootstrap-admin --did <X>` after

--- a/docs/02-vta/non-interactive-setup.md
+++ b/docs/02-vta/non-interactive-setup.md
@@ -147,11 +147,12 @@ summary.
 
 | Field | Required | Default | Notes |
 |---|---|---|---|
-| `config_path` | yes | — | Where to write `config.toml`. Refuses to overwrite an existing file. |
+| `config_path` | yes | — | Where to write `config.toml`. Refuses to overwrite an existing file unless `overwrite_config` is set. |
+| `overwrite_config` | no | `false` | Permit overwriting an existing `config_path`. The file is written only after everything else succeeds, so a failed run never destroys it. |
 | `data_dir` | yes | — | On-disk fjall store location. |
 | `vta_name` | no | `null` | Human-readable name. |
 | `public_url` | no | `null` | Used as the `VTARest` service endpoint when minting a DID. |
-| `data_dir_exists` | no | `"error"` | What to do if `data_dir` already exists. `"delete"` for CI re-runs. |
+| `data_dir_exists` | no | `"error"` | What to do if `data_dir` already holds a **store**. `"delete"` wipes the directory's contents (not the directory — so it works on a mount point) for CI re-runs; `"reuse"` initializes into it as-is. An existing-but-empty `data_dir` is never a conflict: see [Mounted data directories](#mounted-data-directories). |
 | `admin_did` | no | `null` | If set, seeds a super-admin and seals the VTA atomically. Must start with `did:`. See [`seal-and-unseal.md`](seal-and-unseal.md) for the consequences of sealing at setup time and the recommended seal-last alternative. |
 | `admin_label` | no | `null` | Label on the seeded admin's ACL row. |
 | `staff` | no | `[]` | Array of `[[staff]]` entries — each creates a context, applies its `context_policy`, and seeds a context-scoped ACL row (the bounded *user*). See [Enterprise: owner + bounded staff](#enterprise-owner--bounded-staff). |
@@ -259,10 +260,11 @@ the VTA's persistent state.
 For pipelines that re-run setup against a clean state each time:
 
 ```toml
-config_path     = "/srv/vta/config.toml"
-data_dir        = "/srv/vta/data"
-data_dir_exists = "delete"     # wipe on re-run
-admin_did       = "did:key:..."
+config_path      = "/srv/vta/config.toml"
+overwrite_config = true        # replace the previous run's config
+data_dir         = "/srv/vta/data"
+data_dir_exists  = "delete"    # wipe on re-run
+admin_did        = "did:key:..."
 
 [secrets]
 backend = "aws"
@@ -272,13 +274,32 @@ secret_name = "vta/ci/seed"
 Then in your pipeline:
 
 ```bash
-rm -f /srv/vta/config.toml             # config_path overwrite is also blocked
 vta setup --from setup.toml
 vta --config /srv/vta/config.toml &    # ready to serve
 ```
 
 The seed is generated fresh on each run, so the AWS secret value
 changes each time — fine for CI, not what you want in production.
+
+## Mounted data directories
+
+`data_dir` is routinely a Docker volume, a bind mount, or a Kubernetes
+PVC — and the container runtime creates that path *before* the container
+starts. Setup accounts for this:
+
+- **The existence check is store presence, not directory presence.** An
+  empty `/app/vta-data` is a normal first-boot state and is initialized
+  into silently. `data_dir_exists` is consulted only when the directory
+  actually holds a fjall store.
+- **`"delete"` clears the directory's contents, not the directory.**
+  `rmdir` on a mount point fails with `EBUSY` on Linux (and a sharing
+  violation on Windows) however empty it is, so removing the mount point
+  itself is never attempted.
+- **Setup refuses to run over an initialized VTA.** If the store already
+  carries master seed generation 0, setup stops rather than minting a
+  second master seed on top of the first, which would orphan every key
+  derived from the original. Choose `"delete"` if you genuinely want to
+  start over.
 
 ## Validation and errors
 

--- a/docs/02-vta/secret-backends.md
+++ b/docs/02-vta/secret-backends.md
@@ -29,9 +29,31 @@ backends and the factory live in the shared **`vti-secrets`** crate
 VTI integration can reuse them without depending on `vta-service`.
 `vta-service` re-exports them from `keys::seed_store` and keeps a thin
 `create_seed_store(&config)` wrapper, so first-party call sites are
-unchanged. At startup that wrapper walks the configured backends in
-priority order and returns the first one whose feature is compiled in
-**and** whose config is populated:
+unchanged.
+
+### Selecting a backend explicitly (recommended)
+
+Set `secrets.backend` and the named backend is built, with its required
+fields validated:
+
+```toml
+[secrets]
+backend = "vault"          # keyring | config_seed | aws | gcp | azure | vault | kubernetes | plaintext
+addr        = "https://vault.example.com:8200"
+secret_path = "vta/master-seed"
+```
+
+An explicit selector **wins outright** — a missing required field, or a
+backend whose Cargo feature isn't compiled into this binary, is a hard
+config error, never a silent substitution of a different backend. The
+setup wizard always writes this key, so every generated `config.toml`
+states its backend.
+
+### Implicit resolution (legacy)
+
+Omit `secrets.backend` and the wrapper walks the backends in priority
+order, returning the first whose feature is compiled in **and** whose
+selector field is populated:
 
 | Priority | Backend | Cargo feature | Activates when… |
 |---|---|---|---|
@@ -43,6 +65,14 @@ priority order and returns the first one whose feature is compiled in
 | 6 | Config-seed | `config-seed` | `secrets.seed` is set |
 | 7 | OS keyring | `keyring` | always (the default) |
 | 8 | Plaintext file | always available | unconditional fallback |
+
+Note what this chain **cannot** express: plaintext has no selector field
+of its own and the keyring arm matches unconditionally, so on any build
+with `keyring` compiled in (the default) implicit resolution can never
+reach plaintext. `secrets.allow_plaintext` is a *permission* to fall
+back, not a request — `backend = "plaintext"` is how you ask for it.
+The same shadowing applies to any backend sitting below a configured
+one; prefer the explicit selector.
 
 If no secure-backend feature is compiled and no config is set, the
 service falls back to a plaintext file in the data directory and
@@ -460,17 +490,23 @@ the seed sits on disk in plaintext.
 If you find yourself reaching for this in production, use Vault or a
 cloud secret manager instead.
 
-### Plaintext file (fallback only)
+### Plaintext file
 
 File: `vti-secrets/src/seed_store/plaintext.rs`
 
 Always available, no Cargo feature required. Stores the seed as a
-hex string in `<data_dir>/seed.hex`. The service emits a `WARN` log
-line at startup when this backend is selected:
+hex string in `<data_dir>/seed.plaintext`. It takes **two** keys — one
+to select it, one to accept the consequence:
 
+```toml
+[secrets]
+backend         = "plaintext"   # which backend
+allow_plaintext = true          # yes, I accept a cleartext master seed
 ```
-WARN no secure seed store backend available — falling back to plaintext file storage
-```
+
+Without `backend = "plaintext"` it is unreachable on a keyring build;
+without `allow_plaintext = true` it is a hard config error. The service
+emits a `WARN` log line at startup when this backend is selected.
 
 Use only when first-boot-bringing-up a VTA in a sandbox where you
 plan to migrate to a real backend before any production traffic hits

--- a/local-dev/vta-pathful-webvh-setup.toml
+++ b/local-dev/vta-pathful-webvh-setup.toml
@@ -16,7 +16,8 @@
 config_path     = "/tmp/vta-dev-path/config.toml"
 data_dir        = "/tmp/vta-dev-path/data"
 public_url      = "http://localhost:3000"
-data_dir_exists = "delete"   # re-run friendly; wipes and re-inits on each setup call
+data_dir_exists  = "delete"  # re-run friendly; wipes the data dir contents on each setup call
+overwrite_config = true      # …and replaces the previous run's config.toml
 
 [server]
 host = "0.0.0.0"

--- a/local-dev/vta-root-webvh-setup.toml
+++ b/local-dev/vta-root-webvh-setup.toml
@@ -15,7 +15,8 @@
 config_path     = "/tmp/vta-dev-root/config.toml"
 data_dir        = "/tmp/vta-dev-root/data"
 public_url      = "http://localhost:3000"
-data_dir_exists = "delete"   # re-run friendly; wipes and re-inits on each setup call
+data_dir_exists  = "delete"  # re-run friendly; wipes the data dir contents on each setup call
+overwrite_config = true      # …and replaces the previous run's config.toml
 
 [server]
 host = "0.0.0.0"

--- a/vta-config/Cargo.toml
+++ b/vta-config/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-config"
 description = "VTA configuration types — the `AppConfig` TOML shape and its sub-configs, composing the vti-common and vti-secrets config types"
 readme = "README.md"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-config/src/lib.rs
+++ b/vta-config/src/lib.rs
@@ -9,7 +9,7 @@ pub use vti_common::config::{
 // The `[secrets]` config shape + its seed-store backends live in the shared
 // `vti-secrets` crate (issue #501). Re-exported here so `AppConfig.secrets`
 // and every `crate::config::SecretsConfig` reference are unchanged.
-pub use vti_secrets::SecretsConfig;
+pub use vti_secrets::{SecretBackend, SecretsConfig};
 
 /// Policy Decision Point configuration.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.12.36"
+version = "0.12.37"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/setup/from_toml.rs
+++ b/vta-service/src/setup/from_toml.rs
@@ -41,7 +41,7 @@ use crate::config::{
 };
 use crate::contexts::store_context;
 use crate::keys::seed_store::{SeedStore, create_seed_store};
-use crate::keys::seeds::{SeedRecord, save_seed_record, set_active_seed_id};
+use crate::keys::seeds::{SeedRecord, get_seed_record, save_seed_record, set_active_seed_id};
 use crate::operations;
 use crate::operations::did_webvh::CreateDidWebvhParams;
 use crate::store::{KeyspaceHandle, Store};
@@ -59,8 +59,16 @@ use super::{SetupUi, SilentUi, create_seed_context, generate_mnemonic_silent};
 #[serde(deny_unknown_fields)]
 pub struct WizardInputs {
     /// Output path for the generated `config.toml`. The setup wizard refuses
-    /// to overwrite an existing file; delete it first if you want to re-run.
+    /// to overwrite an existing file unless `overwrite_config` is set.
     pub config_path: PathBuf,
+
+    /// Permit overwriting an existing `config_path`.
+    ///
+    /// The file is not touched until the engine writes the finished config at
+    /// the very end, so a setup run that fails — or that the operator
+    /// cancels — leaves the existing config intact.
+    #[serde(default)]
+    pub overwrite_config: bool,
 
     /// Optional human-readable name for this VTA. Surfaced in `vta config
     /// show` and `pnm setup`.
@@ -184,14 +192,51 @@ fn default_services() -> ServicesConfig {
     }
 }
 
+/// What to do when `data_dir` already holds a store.
+///
+/// Only consulted when [`vti_common::store::local_store_exists`] reports a
+/// store — an existing-but-storeless directory (a mounted volume, a PVC, an
+/// operator's `mkdir`) is initialized into without asking, because it carries
+/// nothing to lose.
 #[derive(Debug, Deserialize, Serialize, Default, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum ExistingDataDirPolicy {
-    /// Refuse to proceed if `data_dir` already exists.
+    /// Refuse to proceed if `data_dir` already holds a store.
     #[default]
     Error,
-    /// Recursively delete `data_dir` before initializing the store.
+    /// Delete the *contents* of `data_dir` before initializing the store.
+    ///
+    /// The directory itself is kept: `data_dir` is routinely a mount point
+    /// (Docker volume, K8s PVC), and `rmdir` on a mount point fails with
+    /// `EBUSY` no matter how empty it is.
     Delete,
+    /// Initialize into `data_dir` as-is, keeping whatever is already there.
+    ///
+    /// Setup still refuses to run over a store that already holds an
+    /// initialized VTA — that would mint a fresh master seed on top of the
+    /// existing one and orphan every key derived from it.
+    Reuse,
+}
+
+/// Delete everything *inside* `dir`, leaving `dir` itself in place.
+///
+/// `remove_dir_all` is wrong here: it removes the directory too, and
+/// `data_dir` is commonly a mount point, where the final `rmdir` fails with
+/// `EBUSY` (Linux) or a sharing violation (Windows) — after the contents are
+/// already gone. Clearing entry-by-entry is destructive in exactly the same
+/// way but succeeds on a mounted target.
+fn clear_dir_contents(dir: &Path) -> std::io::Result<()> {
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        // `DirEntry::file_type` does not follow symlinks, so a symlinked
+        // directory is unlinked (remove_file) rather than recursed into.
+        if entry.file_type()?.is_dir() {
+            std::fs::remove_dir_all(entry.path())?;
+        } else {
+            std::fs::remove_file(entry.path())?;
+        }
+    }
+    Ok(())
 }
 
 /// Per-backend seed-store config. The `backend` discriminator selects the
@@ -531,12 +576,13 @@ pub async fn apply_inputs(
     inputs: WizardInputs,
     ui: &dyn SetupUi,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    // 1. Refuse to overwrite an existing config — same stance as the
-    //    interactive wizard. Operators who want a re-run can delete the
-    //    file first.
-    if inputs.config_path.exists() {
+    // 1. Refuse to overwrite an existing config unless the operator asked
+    //    for it. Note this only *checks* — the file is not written (and so
+    //    not destroyed) until step 13, so a failure or a cancel anywhere in
+    //    between leaves the operator's existing install untouched.
+    if inputs.config_path.exists() && !inputs.overwrite_config {
         return Err(format!(
-            "config file {} already exists — delete it first to re-run setup",
+            "config file {} already exists — set overwrite_config = true (or delete it) to re-run setup",
             inputs.config_path.display()
         )
         .into());
@@ -546,20 +592,28 @@ pub async fn apply_inputs(
     //    needs `services.didcomm = true`, and so on.
     validate_inputs(&inputs)?;
 
-    // 3. Handle data_dir conflict per policy.
-    if inputs.data_dir.exists() {
+    // 3. Handle data_dir conflict per policy. The gate is "does this
+    //    directory hold a *store*", not "does this directory exist" — a
+    //    Docker volume, a K8s PVC, and an operator's `mkdir` all pre-create
+    //    an empty data_dir, and refusing those makes containerized
+    //    first-boot impossible.
+    if vti_common::store::local_store_exists(&inputs.data_dir) {
         match inputs.data_dir_exists {
             ExistingDataDirPolicy::Error => {
                 return Err(format!(
-                    "data directory {} already exists — set data_dir_exists = \"delete\" to wipe and re-init",
+                    "data directory {} already holds a store — set data_dir_exists = \"delete\" \
+                     to wipe it, or \"reuse\" to initialize into it",
                     inputs.data_dir.display()
                 )
                 .into());
             }
             ExistingDataDirPolicy::Delete => {
-                std::fs::remove_dir_all(&inputs.data_dir)
-                    .map_err(|e| format!("delete {}: {e}", inputs.data_dir.display()))?;
-                eprintln!("  Deleted existing data directory.");
+                clear_dir_contents(&inputs.data_dir)
+                    .map_err(|e| format!("clear {}: {e}", inputs.data_dir.display()))?;
+                eprintln!("  Deleted existing data directory contents.");
+            }
+            ExistingDataDirPolicy::Reuse => {
+                eprintln!("  Reusing existing data directory.");
             }
         }
     }
@@ -569,6 +623,23 @@ pub async fn apply_inputs(
         data_dir: inputs.data_dir.clone(),
     })?;
     let keys_ks = store.keyspace(crate::keyspaces::KEYS)?;
+
+    // 4a. Fail closed if the store already holds an initialized VTA. Setup
+    //     mints a fresh master seed and writes it as generation 0 (step 8),
+    //     which on top of an existing seed silently orphans every key
+    //     derived from it. Reachable via `reuse`, and as a backstop for a
+    //     `delete` that did not actually clear (an odd mount, a partial
+    //     failure) — so the check guards every policy, not just `reuse`.
+    if get_seed_record(&keys_ks, 0).await?.is_some() {
+        return Err(format!(
+            "data directory {} already holds an initialized VTA (master seed generation 0) — \
+             refusing to re-run setup over it, which would mint a new master seed and orphan \
+             every existing key. Use the existing install, or set data_dir_exists = \"delete\" \
+             to start over.",
+            inputs.data_dir.display()
+        )
+        .into());
+    }
     let imported_ks = store.keyspace(crate::keyspaces::IMPORTED_SECRETS)?;
     let contexts_ks = store.keyspace(crate::keyspaces::CONTEXTS)?;
     let webvh_ks = store.keyspace(crate::keyspaces::WEBVH)?;
@@ -1703,6 +1774,294 @@ mod tests {
         assert!(
             toml_out.contains("allow_plaintext = true"),
             "generated config must carry the flag, got:\n{toml_out}"
+        );
+    }
+
+    /// Register an in-memory keyring so the seed-store step works without an
+    /// OS credential store. `set_default_store` is process-global, so it is
+    /// installed exactly once for the whole test binary.
+    ///
+    /// The plaintext backend can't stand in here: with the `keyring` feature
+    /// compiled in (the default), `create_seed_store` returns a keyring store
+    /// before it ever reaches the plaintext arm.
+    #[cfg(feature = "keyring")]
+    fn install_mock_keyring() {
+        static ONCE: std::sync::Once = std::sync::Once::new();
+        ONCE.call_once(|| {
+            let store = keyring_core::mock::Store::new().expect("build mock keyring store");
+            keyring_core::set_default_store(store);
+        });
+    }
+
+    /// The smallest `WizardInputs` that drives `apply_inputs` end-to-end with
+    /// no network and no operator interaction: no services, no mediator, no
+    /// DID. Each caller gets a distinct keyring service name so concurrent
+    /// tests don't share a seed entry.
+    #[cfg(feature = "keyring")]
+    fn offline_inputs(root: &Path, keyring_service: &str) -> WizardInputs {
+        install_mock_keyring();
+        WizardInputs {
+            config_path: root.join("config.toml"),
+            overwrite_config: false,
+            vta_name: None,
+            public_url: None,
+            data_dir: root.join("data"),
+            data_dir_exists: ExistingDataDirPolicy::default(),
+            services: ServicesConfig {
+                rest: false,
+                didcomm: false,
+                webauthn: false,
+                tsp: false,
+            },
+            server: ServerConfig::default(),
+            log: LogConfig::default(),
+            secrets: SecretsBackendInput::Keyring {
+                service: keyring_service.to_string(),
+            },
+            messaging: MessagingInput::Skip,
+            vta_did: VtaDidInput::Skip,
+            admin_did: None,
+            admin_label: None,
+            resolver_url: None,
+            audit: AuditConfig::default(),
+            staff: Vec::new(),
+        }
+    }
+
+    /// The master seed as the store on disk sees it — the seed *record* for
+    /// generation 0. Used to prove a wipe produced fresh key material and
+    /// that a refusal left the existing material alone.
+    #[cfg(feature = "keyring")]
+    async fn seed_record_created_at(data_dir: &Path) -> chrono::DateTime<Utc> {
+        let store = Store::open(&StoreConfig {
+            data_dir: data_dir.to_path_buf(),
+        })
+        .expect("open store");
+        let keys_ks = store
+            .keyspace(crate::keyspaces::KEYS)
+            .expect("keys keyspace");
+        get_seed_record(&keys_ks, 0)
+            .await
+            .expect("read seed record")
+            .expect("generation 0 must exist after setup")
+            .created_at
+    }
+
+    #[cfg(feature = "keyring")]
+    #[tokio::test]
+    async fn a_pre_created_empty_data_dir_is_not_a_conflict() {
+        // The reported failure: a Docker volume / K8s PVC / hand-created
+        // `mkdir` makes data_dir exist before setup ever runs, and the old
+        // `data_dir.exists()` gate turned that into "delete everything or
+        // abort" — with no third answer. An empty directory carries nothing
+        // to lose, so the default (fail-closed) policy must sail past it.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let inputs = offline_inputs(dir.path(), "vta-test-precreated");
+        std::fs::create_dir_all(&inputs.data_dir).expect("pre-create the mount point");
+
+        apply_inputs(inputs, &SilentUi)
+            .await
+            .expect("setup must initialize into a pre-created empty data directory");
+
+        assert!(
+            vti_common::store::local_store_exists(&dir.path().join("data")),
+            "the store must have been created in the pre-existing directory"
+        );
+        assert!(dir.path().join("config.toml").is_file(), "config written");
+    }
+
+    #[cfg(feature = "keyring")]
+    #[tokio::test]
+    async fn setup_refuses_to_run_over_an_initialized_vta() {
+        // `reuse` must not become a foot-gun: re-running setup mints a fresh
+        // master seed as generation 0, which on top of an existing seed
+        // orphans every key derived from the original.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let data_dir = dir.path().join("data");
+        apply_inputs(
+            offline_inputs(dir.path(), "vta-test-initialized"),
+            &SilentUi,
+        )
+        .await
+        .expect("first setup succeeds");
+        let seed_before = seed_record_created_at(&data_dir).await;
+
+        let mut again = offline_inputs(dir.path(), "vta-test-initialized");
+        again.data_dir_exists = ExistingDataDirPolicy::Reuse;
+        again.overwrite_config = true;
+        let err = apply_inputs(again, &SilentUi)
+            .await
+            .expect_err("re-running setup over an initialized VTA must fail");
+        assert!(
+            err.to_string().contains("already holds an initialized VTA"),
+            "got: {err}"
+        );
+
+        assert_eq!(
+            seed_record_created_at(&data_dir).await,
+            seed_before,
+            "the refusal must leave the existing master seed generation untouched"
+        );
+    }
+
+    #[cfg(feature = "keyring")]
+    #[tokio::test]
+    async fn a_failed_run_leaves_the_existing_config_intact() {
+        // The config file is only written once everything else has
+        // succeeded (step 13), so a run that dies mid-flight — or an
+        // operator who backs out — never destroys a working install.
+        let dir = tempfile::tempdir().expect("tempdir");
+        apply_inputs(
+            offline_inputs(dir.path(), "vta-test-config-intact"),
+            &SilentUi,
+        )
+        .await
+        .expect("first setup succeeds");
+
+        let config_path = dir.path().join("config.toml");
+        let config_before = std::fs::read_to_string(&config_path).expect("config written");
+
+        let mut again = offline_inputs(dir.path(), "vta-test-config-intact");
+        again.overwrite_config = true; // permitted to overwrite …
+        again.data_dir_exists = ExistingDataDirPolicy::Error; // … but this aborts first
+        let err = apply_inputs(again, &SilentUi)
+            .await
+            .expect_err("`error` policy over an existing store must fail");
+        assert!(
+            err.to_string().contains("already holds a store"),
+            "got: {err}"
+        );
+
+        assert_eq!(
+            std::fs::read_to_string(&config_path).unwrap(),
+            config_before,
+            "a failed run must not have touched the existing config"
+        );
+    }
+
+    #[cfg(feature = "keyring")]
+    #[tokio::test]
+    async fn delete_policy_wipes_a_store_without_removing_the_directory() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let data_dir = dir.path().join("data");
+        apply_inputs(offline_inputs(dir.path(), "vta-test-delete"), &SilentUi)
+            .await
+            .expect("first setup succeeds");
+        let seed_before = seed_record_created_at(&data_dir).await;
+
+        // Record the directory's creation stamp so we can prove it was
+        // cleared in place rather than removed and recreated — the
+        // difference between working and failing with EBUSY on a mount point.
+        let created_before = std::fs::metadata(&data_dir)
+            .expect("metadata")
+            .created()
+            .ok();
+
+        let mut again = offline_inputs(dir.path(), "vta-test-delete");
+        again.data_dir_exists = ExistingDataDirPolicy::Delete;
+        again.overwrite_config = true;
+        apply_inputs(again, &SilentUi)
+            .await
+            .expect("`delete` policy must wipe and re-init");
+
+        assert_ne!(
+            seed_record_created_at(&data_dir).await,
+            seed_before,
+            "a wipe must produce a fresh master seed generation"
+        );
+        if let (Some(before), Ok(after)) = (created_before, std::fs::metadata(&data_dir)) {
+            assert_eq!(
+                Some(before),
+                after.created().ok(),
+                "the data directory must be cleared in place, not recreated"
+            );
+        }
+    }
+
+    #[test]
+    fn data_dir_policy_defaults_to_error_and_parses_every_variant() {
+        let base = |extra: &str| {
+            format!(
+                r#"
+                config_path = "/tmp/vta-test/config.toml"
+                data_dir    = "/tmp/vta-test/data"
+                {extra}
+
+                [secrets]
+                backend = "keyring"
+                "#
+            )
+        };
+
+        assert_eq!(
+            parse(&base("")).unwrap().data_dir_exists,
+            ExistingDataDirPolicy::Error,
+            "omitting the policy must stay fail-closed"
+        );
+        assert_eq!(
+            parse(&base(r#"data_dir_exists = "delete""#))
+                .unwrap()
+                .data_dir_exists,
+            ExistingDataDirPolicy::Delete
+        );
+        assert_eq!(
+            parse(&base(r#"data_dir_exists = "reuse""#))
+                .unwrap()
+                .data_dir_exists,
+            ExistingDataDirPolicy::Reuse,
+            "`reuse` is what lets an operator point setup at existing state"
+        );
+    }
+
+    #[test]
+    fn overwrite_config_defaults_to_false_and_round_trips() {
+        let base = |extra: &str| {
+            format!(
+                r#"
+                config_path = "/tmp/vta-test/config.toml"
+                data_dir    = "/tmp/vta-test/data"
+                {extra}
+
+                [secrets]
+                backend = "keyring"
+                "#
+            )
+        };
+
+        assert!(
+            !parse(&base("")).unwrap().overwrite_config,
+            "clobbering an operator's config must be opt-in"
+        );
+        assert!(
+            parse(&base("overwrite_config = true"))
+                .unwrap()
+                .overwrite_config
+        );
+    }
+
+    #[test]
+    fn clear_dir_contents_empties_the_dir_but_keeps_it() {
+        // The distinction that makes a mounted data_dir work: `rmdir` on a
+        // mount point fails with EBUSY no matter how empty it is, so the
+        // directory itself must survive the wipe.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+
+        std::fs::write(root.join("version"), b"fjall").expect("file");
+        std::fs::create_dir_all(root.join("keyspaces/0/segments")).expect("nested dirs");
+        std::fs::write(root.join("keyspaces/0/segments/1.sst"), b"data").expect("nested file");
+
+        clear_dir_contents(root).expect("clearing contents should succeed");
+
+        assert!(root.is_dir(), "the directory itself must survive");
+        assert_eq!(
+            std::fs::read_dir(root).unwrap().count(),
+            0,
+            "every entry must be gone"
+        );
+        assert!(
+            !vti_common::store::local_store_exists(root),
+            "a cleared directory must no longer look like a store"
         );
     }
 

--- a/vta-service/src/setup/from_toml.rs
+++ b/vta-service/src/setup/from_toml.rs
@@ -36,8 +36,8 @@ use url::Url;
 use affinidi_did_resolver_cache_sdk::{DIDCacheClient, config::DIDCacheConfigBuilder};
 
 use crate::config::{
-    AppConfig, AuditConfig, AuthConfig, LogConfig, MessagingConfig, SecretsConfig, ServerConfig,
-    ServicesConfig, StoreConfig,
+    AppConfig, AuditConfig, AuthConfig, LogConfig, MessagingConfig, SecretBackend, SecretsConfig,
+    ServerConfig, ServicesConfig, StoreConfig,
 };
 use crate::contexts::store_context;
 use crate::keys::seed_store::{SeedStore, create_seed_store};
@@ -1145,10 +1145,30 @@ fn validate_inputs(inputs: &WizardInputs) -> Result<(), Box<dyn std::error::Erro
     }
 }
 
+/// The explicit `[secrets] backend` selector matching an operator's wizard
+/// choice. Every generated config states its backend outright rather than
+/// leaving `create_seed_store` to infer one from which fields are populated
+/// — inference cannot express "plaintext" at all on a build with `keyring`
+/// compiled in, so the wizard's plaintext option used to silently produce a
+/// keyring-backed VTA.
+fn backend_selector(input: &SecretsBackendInput) -> SecretBackend {
+    match input {
+        SecretsBackendInput::Keyring { .. } => SecretBackend::Keyring,
+        SecretsBackendInput::ConfigSeed => SecretBackend::ConfigSeed,
+        SecretsBackendInput::Aws { .. } => SecretBackend::Aws,
+        SecretsBackendInput::Gcp { .. } => SecretBackend::Gcp,
+        SecretsBackendInput::Azure { .. } => SecretBackend::Azure,
+        SecretsBackendInput::Vault { .. } => SecretBackend::Vault,
+        SecretsBackendInput::Kubernetes { .. } => SecretBackend::Kubernetes,
+        SecretsBackendInput::Plaintext => SecretBackend::Plaintext,
+    }
+}
+
 fn secrets_config_from_input(
     input: &SecretsBackendInput,
 ) -> Result<SecretsConfig, Box<dyn std::error::Error>> {
-    Ok(match input {
+    let selector = backend_selector(input);
+    let mut config = match input {
         SecretsBackendInput::Keyring { service } => {
             #[cfg(not(feature = "keyring"))]
             {
@@ -1341,12 +1361,17 @@ fn secrets_config_from_input(
             // the seed store can be created during setup *and* the booted VTA
             // can re-open it. The flag is serialized into `[secrets]` in the
             // generated config.toml, so plaintext deployments stay runnable.
+            //
+            // `allow_plaintext` is only the *permission*; `backend` below is
+            // what actually selects plaintext over the compiled-in keyring.
             SecretsConfig {
                 allow_plaintext: true,
                 ..SecretsConfig::default()
             }
         }
-    })
+    };
+    config.backend = Some(selector);
+    Ok(config)
 }
 
 fn scratch_config_for_seed_store(
@@ -1757,7 +1782,7 @@ mod tests {
     }
 
     #[test]
-    fn plaintext_backend_sets_allow_plaintext() {
+    fn plaintext_backend_sets_allow_plaintext_and_selects_itself() {
         // Selecting the plaintext backend must opt in to the plaintext
         // seed-store fallback (P0.9). Otherwise `create_seed_store` errors
         // during setup and the booted VTA can't re-open the seed. The flag
@@ -1768,13 +1793,47 @@ mod tests {
             secrets.allow_plaintext,
             "plaintext backend must set allow_plaintext = true"
         );
+        // …and `allow_plaintext` alone is not enough. It is a *permission*
+        // to fall back, not a request: with `keyring` compiled in (the
+        // default) the implicit chain hits the keyring arm first, so an
+        // operator who chose "Plaintext file" in the wizard used to get a
+        // keyring-backed VTA. The explicit selector is what makes it stick.
+        assert_eq!(
+            secrets.backend,
+            Some(SecretBackend::Plaintext),
+            "the wizard must state the backend it was asked for"
+        );
 
-        // And it round-trips into the written config as `allow_plaintext = true`.
+        // Both round-trip into the written config.
         let toml_out = toml::to_string(&secrets).expect("secrets config serializes");
         assert!(
             toml_out.contains("allow_plaintext = true"),
             "generated config must carry the flag, got:\n{toml_out}"
         );
+        assert!(
+            toml_out.contains("backend = \"plaintext\""),
+            "generated config must carry the selector, got:\n{toml_out}"
+        );
+    }
+
+    #[test]
+    fn every_wizard_backend_choice_states_its_selector() {
+        // No wizard choice may lean on implicit resolution — that is how
+        // plaintext silently became keyring.
+        let cases: Vec<(SecretsBackendInput, SecretBackend)> = vec![
+            #[cfg(feature = "keyring")]
+            (
+                SecretsBackendInput::Keyring {
+                    service: "vta".into(),
+                },
+                SecretBackend::Keyring,
+            ),
+            (SecretsBackendInput::Plaintext, SecretBackend::Plaintext),
+        ];
+        for (input, expected) in cases {
+            let secrets = secrets_config_from_input(&input).expect("converts");
+            assert_eq!(secrets.backend, Some(expected), "for {input:?}");
+        }
     }
 
     /// Register an in-memory keyring so the seed-store step works without an

--- a/vta-service/src/setup/interactive.rs
+++ b/vta-service/src/setup/interactive.rs
@@ -790,21 +790,25 @@ async fn gather_inputs(
         .unwrap_or_else(|| {
             std::env::var("VTA_CONFIG_PATH").unwrap_or_else(|_| "config.toml".into())
         });
-    let config_path =
-        PathBuf::from(p.text("Config file path", Some(&default_path), false, None)?);
+    let config_path = PathBuf::from(
+        p.text("Config file path", Some(&default_path), false, None)?
+            .trim(),
+    );
+    // Record the operator's intent; do *not* delete the file here. Gathering
+    // is a further dozen prompts, any of which can cancel — deleting now
+    // would leave an operator who backs out at the data-directory question
+    // with no config and a VTA that no longer starts. The engine overwrites
+    // it at the end, once everything else has succeeded.
+    let mut overwrite_config = false;
     if config_path.exists() {
-        let overwrite = p.confirm(
+        if !p.confirm(
             &format!("{} already exists. Overwrite?", config_path.display()),
             false,
-        )?;
-        if !overwrite {
+        )? {
             eprintln!("Setup cancelled.");
             return Ok(None);
         }
-        // The engine refuses to overwrite; the operator just confirmed they
-        // want to, so clear the way.
-        std::fs::remove_file(&config_path)
-            .map_err(|e| format!("could not remove {}: {e}", config_path.display()))?;
+        overwrite_config = true;
     }
 
     // 2. VTA name.
@@ -918,22 +922,40 @@ async fn gather_inputs(
         .expect("validated above");
     let audit = AuditConfig { retention_days };
 
-    // 8. Data directory + existing-dir policy.
-    let data_dir = PathBuf::from(p.text("Data directory", Some("data/vta"), false, None)?);
+    // 8. Data directory + existing-store policy. Trimmed because operators
+    //    paste paths, and a stray trailing space silently becomes part of
+    //    the path on Unix (and a different path again on Windows).
+    let data_dir = PathBuf::from(
+        p.text("Data directory", Some("data/vta"), false, None)?
+            .trim(),
+    );
     let mut data_dir_exists = ExistingDataDirPolicy::default();
-    if data_dir.exists() {
-        let delete = p.confirm(
-            &format!(
-                "Data directory \"{}\" already exists. Delete and start fresh?",
-                data_dir.display()
-            ),
-            false,
+    // Ask only when the directory holds an actual store. An empty
+    // directory — the normal state of a freshly-mounted Docker volume or a
+    // path the operator just created — is initialized into silently.
+    if vti_common::store::local_store_exists(&data_dir) {
+        eprintln!();
+        eprintln!(
+            "  Data directory \"{}\" already contains a VTA store.",
+            data_dir.display()
+        );
+        eprintln!();
+        let choice = p.select(
+            "How should setup proceed?",
+            &[
+                "Cancel setup (leave the existing data untouched)",
+                "Keep the existing contents and initialize into it",
+                "Delete everything in it and start fresh",
+            ],
+            0,
         )?;
-        if delete {
-            data_dir_exists = ExistingDataDirPolicy::Delete;
-        } else {
-            eprintln!("Setup cancelled.");
-            return Ok(None);
+        match choice {
+            1 => data_dir_exists = ExistingDataDirPolicy::Reuse,
+            2 => data_dir_exists = ExistingDataDirPolicy::Delete,
+            _ => {
+                eprintln!("Setup cancelled.");
+                return Ok(None);
+            }
         }
     }
 
@@ -981,6 +1003,7 @@ async fn gather_inputs(
 
     Ok(Some(WizardInputs {
         config_path,
+        overwrite_config,
         vta_name,
         public_url,
         data_dir,
@@ -1216,6 +1239,134 @@ mod tests {
             "interactive-gathered inputs must equal the equivalent --from TOML\n\
              interactive = {a:#}\n--from = {b:#}"
         );
+    }
+
+    /// A `data_dir` that exists but holds no store is *not* a conflict, so
+    /// the wizard must not ask about it at all. This is the reported
+    /// failure: a Docker volume / K8s PVC / hand-created directory is
+    /// always there before setup runs, and the old `exists()` gate offered
+    /// only "delete everything" or "cancel".
+    ///
+    /// The scripted prompter panics on an unexpected prompt kind or a
+    /// short script, so a spurious question fails the test loudly.
+    #[tokio::test]
+    async fn a_pre_created_empty_data_dir_is_never_asked_about() {
+        let dir = tempfile::tempdir().unwrap();
+        let data_dir = dir.path().join("vta-data");
+        std::fs::create_dir_all(&data_dir).expect("pre-create the mount point");
+
+        let answers = vec![
+            text(dir.path().join("config.toml").to_str().unwrap()), // doesn't exist
+            text(""),                                               // vta name (skip)
+            Answer::Indices(vec![0]),                               // services: REST only
+            text("0.0.0.0"),                                        // host
+            text("8100"),                                           // port
+            text("https://t.example.com"),                          // REST URL
+            text("info"),                                           // log level
+            Answer::Index(0),                                       // log format
+            #[cfg(feature = "tee")]
+            text(""),            // TEE-only: remote DID resolver URL (skip)
+            text("28"),                                             // audit retention
+            text(data_dir.to_str().unwrap()),                       // data dir — exists, but empty
+            Answer::Bool(false),                                    // advanced server opts? no
+            Answer::Index(0),                                       // secrets backend = keyring
+            text("vta"),                                            // keyring service
+            Answer::Index(1),                                       // VTA DID = did:key
+        ];
+        let gathered = gather_inputs(&ScriptedPrompter::new(answers), None)
+            .await
+            .expect("gather should succeed")
+            .expect("an empty data directory must not cancel setup");
+
+        assert_eq!(
+            gathered.data_dir_exists,
+            ExistingDataDirPolicy::Error,
+            "with nothing to lose the policy stays at its fail-closed default"
+        );
+        assert!(!gathered.overwrite_config);
+    }
+
+    /// Backing out at the data-directory question must leave the operator's
+    /// existing `config.toml` exactly where it was. The wizard used to
+    /// delete it up-front, so an operator who answered "no" here was left
+    /// with no config and a VTA that no longer started.
+    #[tokio::test]
+    async fn cancelling_at_the_data_dir_prompt_leaves_the_config_intact() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("config.toml");
+        const ORIGINAL: &str = "vta_did = \"did:key:zExistingInstall\"\n";
+        std::fs::write(&config_path, ORIGINAL).unwrap();
+
+        // A directory that looks like a store: fjall's version marker is
+        // exactly what `local_store_exists` (and fjall itself) keys on.
+        let data_dir = dir.path().join("vta-data");
+        std::fs::create_dir_all(&data_dir).unwrap();
+        std::fs::write(data_dir.join("version"), b"fjall").unwrap();
+
+        let answers = vec![
+            text(config_path.to_str().unwrap()), // config path — exists
+            Answer::Bool(true),                  // overwrite? yes
+            text(""),                            // vta name (skip)
+            Answer::Indices(vec![1]),            // services: DIDComm only (no URL prompts)
+            text("info"),                        // log level
+            Answer::Index(0),                    // log format
+            #[cfg(feature = "tee")]
+            text(""), // TEE-only: remote DID resolver URL (skip)
+            text("28"),                          // audit retention
+            text(data_dir.to_str().unwrap()),    // data dir — holds a store
+            Answer::Index(0),                    // → cancel
+        ];
+        let gathered = gather_inputs(&ScriptedPrompter::new(answers), None)
+            .await
+            .expect("cancelling is not an error");
+
+        assert!(gathered.is_none(), "cancelling must abort setup");
+        assert_eq!(
+            std::fs::read_to_string(&config_path).unwrap(),
+            ORIGINAL,
+            "cancelling must not have touched the operator's config"
+        );
+        assert!(
+            data_dir.join("version").is_file(),
+            "cancelling must not have touched the operator's data"
+        );
+    }
+
+    /// The other two answers to the same question map to the policies that
+    /// let setup proceed.
+    #[tokio::test]
+    async fn existing_store_offers_reuse_and_delete() {
+        for (choice, expected) in [
+            (1, ExistingDataDirPolicy::Reuse),
+            (2, ExistingDataDirPolicy::Delete),
+        ] {
+            let dir = tempfile::tempdir().unwrap();
+            let data_dir = dir.path().join("vta-data");
+            std::fs::create_dir_all(&data_dir).unwrap();
+            std::fs::write(data_dir.join("version"), b"fjall").unwrap();
+
+            let answers = vec![
+                text(dir.path().join("config.toml").to_str().unwrap()),
+                text(""),                 // vta name (skip)
+                Answer::Indices(vec![1]), // services: DIDComm only
+                text("info"),             // log level
+                Answer::Index(0),         // log format
+                #[cfg(feature = "tee")]
+                text(""), // TEE-only: remote DID resolver URL (skip)
+                text("28"),               // audit retention
+                text(data_dir.to_str().unwrap()), // data dir — holds a store
+                Answer::Index(choice),    // reuse / delete
+                Answer::Index(0),         // secrets backend = keyring
+                text("vta"),              // keyring service
+                Answer::Index(2),         // messaging = skip
+                Answer::Index(1),         // VTA DID = did:key
+            ];
+            let gathered = gather_inputs(&ScriptedPrompter::new(answers), None)
+                .await
+                .expect("gather should succeed")
+                .expect("choosing reuse/delete must not cancel");
+            assert_eq!(gathered.data_dir_exists, expected, "choice {choice}");
+        }
     }
 
     /// The advanced webvh "use existing keys" mode maps to the right

--- a/vti-common/Cargo.toml
+++ b/vti-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-common"
 description = "Shared server-side infrastructure for VTA and VTC services"
 readme = "README.md"
-version = "0.11.21"
+version = "0.11.22"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vti-common/src/store/mod.rs
+++ b/vti-common/src/store/mod.rs
@@ -39,6 +39,24 @@ where
 /// A key-value pair of raw bytes from a prefix scan.
 pub type RawKvPair = (Vec<u8>, Vec<u8>);
 
+/// fjall's on-disk "this directory is a database root" marker
+/// (`fjall::file::VERSION_MARKER`, which the crate does not re-export).
+const FJALL_VERSION_MARKER: &str = "version";
+
+/// Does `data_dir` already hold a local (fjall) database?
+///
+/// Probes for fjall's own version marker — the same file
+/// [`fjall::Database`] consults to decide "recover" versus "create new" —
+/// so this cannot drift from what actually opening the store would do.
+///
+/// Deliberately **not** `data_dir.exists()`. A Docker bind mount, a
+/// Kubernetes PVC, and an operator's `mkdir` all produce an
+/// existing-but-storeless directory, which is a perfectly good target for
+/// a fresh store. Only the marker means "there is state here".
+pub fn local_store_exists(data_dir: &std::path::Path) -> bool {
+    data_dir.join(FJALL_VERSION_MARKER).is_file()
+}
+
 // ===========================================================================
 // Store — dispatches to local (fjall) or vsock backend
 // ===========================================================================
@@ -791,6 +809,39 @@ mod tests {
         };
         let store = Store::open(&config).expect("failed to open store");
         (store, dir)
+    }
+
+    #[test]
+    fn local_store_exists_ignores_a_bare_directory() {
+        // The case that motivated this probe: a Docker volume / PVC /
+        // hand-created directory exists before setup ever runs. That is
+        // not "there is a store here", and setup must not treat it as a
+        // conflict.
+        let dir = tempfile::tempdir().expect("tempdir");
+        assert!(
+            !local_store_exists(dir.path()),
+            "an empty directory holds no store"
+        );
+
+        std::fs::write(dir.path().join("did.jsonl"), b"{}").expect("write stray file");
+        assert!(
+            !local_store_exists(dir.path()),
+            "a non-empty directory without fjall's marker still holds no store"
+        );
+
+        assert!(
+            !local_store_exists(&dir.path().join("does-not-exist")),
+            "an absent directory holds no store"
+        );
+    }
+
+    #[test]
+    fn local_store_exists_sees_an_opened_store() {
+        let (_store, dir) = temp_store();
+        assert!(
+            local_store_exists(dir.path()),
+            "opening a store must make the probe report it"
+        );
     }
 
     #[tokio::test]

--- a/vti-secrets/Cargo.toml
+++ b/vti-secrets/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-secrets"
 description = "Pluggable secret-store backends + integration onboarding flow for Verifiable Trust Infrastructure"
 readme = "README.md"
-version = "0.1.6"
+version = "0.1.7"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -89,6 +89,7 @@ keyring-core = { workspace = true, optional = true }
 [dev-dependencies]
 tempfile = "3"
 tokio = { workspace = true }
+toml = { workspace = true }
 
 [lints]
 workspace = true

--- a/vti-secrets/src/config.rs
+++ b/vti-secrets/src/config.rs
@@ -8,8 +8,46 @@
 
 use serde::{Deserialize, Serialize};
 
+/// Which seed-store backend to build, stated explicitly.
+///
+/// Mirrors `vtc_service::config::SecretBackend` and the wizard's
+/// `SecretsBackendInput` discriminator, so operators meet one vocabulary
+/// across the setup TOML, the generated `config.toml`, and the VTC.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SecretBackend {
+    /// OS keyring (libsecret / Keychain / Credential Manager).
+    Keyring,
+    /// Hex-encoded seed inlined in `[secrets] seed` (config-seed feature).
+    ConfigSeed,
+    /// AWS Secrets Manager.
+    Aws,
+    /// GCP Secret Manager.
+    Gcp,
+    /// Azure Key Vault.
+    Azure,
+    /// HashiCorp Vault (KV v2).
+    Vault,
+    /// Kubernetes `Secret`.
+    Kubernetes,
+    /// Plaintext file under the data dir — NOT secure, dev/test only.
+    Plaintext,
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct SecretsConfig {
+    /// Explicit backend selector. When set it wins outright:
+    /// [`create_seed_store`](crate::create_seed_store) builds exactly this
+    /// backend and validates its required fields, rather than inferring the
+    /// backend from whichever selector field happens to be populated.
+    ///
+    /// Omit to keep the legacy implicit priority chain. Setting it is the
+    /// only way to reach a backend that sits *below* a compiled-in one in
+    /// that chain — `plaintext` in particular is unreachable implicitly on
+    /// any build with `keyring` compiled in (the default), because the
+    /// keyring arm matches unconditionally.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub backend: Option<SecretBackend>,
     /// Hex-encoded BIP-32 seed (config-seed feature)
     pub seed: Option<String>,
     /// AWS Secrets Manager secret name (aws-secrets feature)
@@ -131,6 +169,7 @@ fn default_vault_approle_mount() -> String {
 impl Default for SecretsConfig {
     fn default() -> Self {
         Self {
+            backend: None,
             seed: None,
             aws_secret_name: None,
             aws_region: None,

--- a/vti-secrets/src/lib.rs
+++ b/vti-secrets/src/lib.rs
@@ -36,5 +36,5 @@ pub mod seed_store;
 #[cfg(feature = "onboarding")]
 pub mod onboarding;
 
-pub use config::SecretsConfig;
+pub use config::{SecretBackend, SecretsConfig};
 pub use seed_store::{SeedStore, create_seed_store};

--- a/vti-secrets/src/seed_store/mod.rs
+++ b/vti-secrets/src/seed_store/mod.rs
@@ -43,7 +43,7 @@ use std::pin::Pin;
 
 use std::path::Path;
 
-use crate::config::SecretsConfig;
+use crate::config::{SecretBackend, SecretsConfig};
 use vti_common::error::AppError;
 
 pub use vti_common::seed_store::SeedStore;
@@ -58,9 +58,14 @@ pub(crate) type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 ///
 /// `secrets` is the resolved [`SecretsConfig`] (which backend + its
 /// connection parameters); `data_dir` is only consulted by the plaintext
-/// fallback for the `seed.plaintext` location.
+/// backend for the `seed.plaintext` location.
 ///
-/// Priority:
+/// **Selection.** If [`SecretsConfig::backend`] is set it wins outright — the
+/// named backend is built and its required fields are validated. A mismatch
+/// is a hard [`AppError::Config`], never a silent pick of a different
+/// backend. If it is unset, resolution falls back to the legacy implicit
+/// priority chain, keyed on which selector field is populated:
+///
 /// 1. AWS Secrets Manager (if `aws-secrets` compiled + `aws_secret_name` set)
 /// 2. GCP Secret Manager (if `gcp-secrets` compiled + `gcp_secret_name` set)
 /// 3. Azure Key Vault (if `azure-secrets` compiled + `azure_vault_url` set)
@@ -68,7 +73,16 @@ pub(crate) type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 /// 5. Kubernetes Secret (if `k8s-secrets` compiled + `k8s_secret_name` set)
 /// 6. Config file seed (if `config-seed` compiled + `seed` set)
 /// 7. OS keyring (if `keyring` compiled — the default)
-/// 8. Plaintext file (always available — NOT secure)
+/// 8. Plaintext file (NOT secure)
+///
+/// Note what the implicit chain cannot express: plaintext has no selector
+/// field of its own, and the keyring arm matches unconditionally, so on any
+/// build with `keyring` compiled in (the default) implicit resolution can
+/// never reach plaintext. `allow_plaintext` is a *permission* to fall back,
+/// not a request — `backend = "plaintext"` is how you ask for it.
+///
+/// A backend requested on a binary built without its feature is a hard
+/// `Config` error — never a silent fall-through to keyring or plaintext.
 ///
 /// `unused_variables` allowed: `secrets` / `data_dir` are only read under
 /// specific feature flags; a build with none of the cloud/keyring/config-seed
@@ -80,29 +94,53 @@ pub fn create_seed_store(
     secrets: &SecretsConfig,
     data_dir: &Path,
 ) -> Result<Box<dyn SeedStore>, AppError> {
+    let explicit = secrets.backend;
+
+    // Is backend `b` the one to build? An explicit selector wins outright;
+    // otherwise fall back to "its selector field is set" implicit
+    // resolution. Used for the cloud / config-seed backends — keyring and
+    // plaintext are the tail arms and are handled separately below.
+    let wants = |b: SecretBackend, field_set: bool| match explicit {
+        Some(sel) => sel == b,
+        None => field_set,
+    };
+
     #[cfg(feature = "aws-secrets")]
-    if secrets.aws_secret_name.is_some() {
-        let store = AwsSeedStore::new(
-            secrets.aws_secret_name.clone().unwrap(),
-            secrets.aws_region.clone(),
-        );
+    if wants(SecretBackend::Aws, secrets.aws_secret_name.is_some()) {
+        let name = secrets.aws_secret_name.clone().ok_or_else(|| {
+            AppError::Config("secrets.backend = aws requires secrets.aws_secret_name".into())
+        })?;
+        let store = AwsSeedStore::new(name, secrets.aws_region.clone());
         return Ok(Box::new(store));
+    }
+    #[cfg(not(feature = "aws-secrets"))]
+    if wants(SecretBackend::Aws, secrets.aws_secret_name.is_some()) {
+        return Err(uncompiled("aws", "aws-secrets"));
     }
 
     #[cfg(feature = "gcp-secrets")]
-    if secrets.gcp_secret_name.is_some() {
+    if wants(SecretBackend::Gcp, secrets.gcp_secret_name.is_some()) {
+        let name = secrets.gcp_secret_name.clone().ok_or_else(|| {
+            AppError::Config("secrets.backend = gcp requires secrets.gcp_secret_name".into())
+        })?;
         let project = secrets.gcp_project.clone().ok_or_else(|| {
             AppError::Config(
                 "secrets.gcp_project is required when secrets.gcp_secret_name is set".into(),
             )
         })?;
-        let store = GcpSeedStore::new(project, secrets.gcp_secret_name.clone().unwrap());
+        let store = GcpSeedStore::new(project, name);
         return Ok(Box::new(store));
+    }
+    #[cfg(not(feature = "gcp-secrets"))]
+    if wants(SecretBackend::Gcp, secrets.gcp_secret_name.is_some()) {
+        return Err(uncompiled("gcp", "gcp-secrets"));
     }
 
     #[cfg(feature = "azure-secrets")]
-    if secrets.azure_vault_url.is_some() {
-        let vault_url = secrets.azure_vault_url.clone().unwrap();
+    if wants(SecretBackend::Azure, secrets.azure_vault_url.is_some()) {
+        let vault_url = secrets.azure_vault_url.clone().ok_or_else(|| {
+            AppError::Config("secrets.backend = azure requires secrets.azure_vault_url".into())
+        })?;
         let secret_name = secrets
             .azure_secret_name
             .clone()
@@ -110,27 +148,64 @@ pub fn create_seed_store(
         let store = AzureSeedStore::new(vault_url, secret_name);
         return Ok(Box::new(store));
     }
+    #[cfg(not(feature = "azure-secrets"))]
+    if wants(SecretBackend::Azure, secrets.azure_vault_url.is_some()) {
+        return Err(uncompiled("azure", "azure-secrets"));
+    }
 
     #[cfg(feature = "vault-secrets")]
-    if secrets.vault_addr.is_some() {
+    if wants(SecretBackend::Vault, secrets.vault_addr.is_some()) {
+        if secrets.vault_addr.is_none() {
+            return Err(AppError::Config(
+                "secrets.backend = vault requires secrets.vault_addr".into(),
+            ));
+        }
         let store = vault::from_config(secrets)?;
         return Ok(Box::new(store));
     }
+    #[cfg(not(feature = "vault-secrets"))]
+    if wants(SecretBackend::Vault, secrets.vault_addr.is_some()) {
+        return Err(uncompiled("vault", "vault-secrets"));
+    }
 
     #[cfg(feature = "k8s-secrets")]
-    if secrets.k8s_secret_name.is_some() {
+    if wants(SecretBackend::Kubernetes, secrets.k8s_secret_name.is_some()) {
+        if secrets.k8s_secret_name.is_none() {
+            return Err(AppError::Config(
+                "secrets.backend = kubernetes requires secrets.k8s_secret_name".into(),
+            ));
+        }
         let store = k8s::from_config(secrets)?;
         return Ok(Box::new(store));
     }
-
-    #[cfg(feature = "config-seed")]
-    if secrets.seed.is_some() {
-        let store = ConfigSeedStore::new(secrets.seed.clone().unwrap());
-        return Ok(Box::new(store));
+    #[cfg(not(feature = "k8s-secrets"))]
+    if wants(SecretBackend::Kubernetes, secrets.k8s_secret_name.is_some()) {
+        return Err(uncompiled("kubernetes", "k8s-secrets"));
     }
 
+    #[cfg(feature = "config-seed")]
+    if wants(SecretBackend::ConfigSeed, secrets.seed.is_some()) {
+        let seed = secrets.seed.clone().ok_or_else(|| {
+            AppError::Config("secrets.backend = config_seed requires secrets.seed".into())
+        })?;
+        let store = ConfigSeedStore::new(seed);
+        return Ok(Box::new(store));
+    }
+    #[cfg(not(feature = "config-seed"))]
+    if wants(SecretBackend::ConfigSeed, secrets.seed.is_some()) {
+        return Err(uncompiled("config_seed", "config-seed"));
+    }
+
+    // Keyring — the implicit default when nothing is selected, or an
+    // explicit `backend = "keyring"`. An explicit keyring selection on a
+    // binary built without the feature is a hard error (mirrors the arms
+    // above); the implicit path just falls through to plaintext.
+    #[cfg(not(feature = "keyring"))]
+    if matches!(explicit, Some(SecretBackend::Keyring)) {
+        return Err(uncompiled("keyring", "keyring"));
+    }
     #[cfg(feature = "keyring")]
-    {
+    if explicit.is_none() || matches!(explicit, Some(SecretBackend::Keyring)) {
         let store = KeyringSeedStore::new(&secrets.keyring_service, "master_seed");
         return Ok(Box::new(store));
     }
@@ -142,24 +217,179 @@ pub fn create_seed_store(
     // only when `keyring` is the selected feature.
     #[allow(unreachable_code)]
     {
-        // No secure backend was compiled-in AND configured. Writing the
+        // Plaintext — either explicitly requested, or the last resort when
+        // no secure backend was compiled-in AND configured. Writing the
         // BIP-32 master seed to a plaintext file is a real footgun (one
-        // wrong/missing TOML key would silently do it), so require an
-        // explicit opt-in rather than falling through silently (P0.9).
+        // wrong/missing TOML key would silently do it), so it still takes
+        // the `allow_plaintext` opt-in either way (P0.9).
         if !secrets.allow_plaintext {
             return Err(AppError::Config(
-                "no secure seed-store backend is available (keyring/cloud/Vault/config-seed \
-                 not compiled-in or not configured), and the plaintext file fallback is \
-                 disabled. Configure a secure backend, or set `secrets.allow_plaintext = true` \
-                 to explicitly accept storing the master seed in a cleartext file (dev/test only)."
+                "the plaintext seed-store fallback is disabled. Configure a secure backend, \
+                 or set `secrets.allow_plaintext = true` to explicitly accept storing the \
+                 master seed in a cleartext file (dev/test only)."
                     .into(),
             ));
         }
         tracing::warn!(
-            "secrets.allow_plaintext = true — storing the BIP-32 master seed in a PLAINTEXT \
-             file. This is NOT secure; use a keyring or cloud/Vault backend in production."
+            "storing the BIP-32 master seed in a PLAINTEXT file. This is NOT secure; use a \
+             keyring or cloud/Vault backend in production."
         );
         let store = PlaintextSeedStore::new(data_dir);
         Ok(Box::new(store))
+    }
+}
+
+/// A backend was requested (explicitly, or implicitly by setting its
+/// selector field) on a binary built without its feature. Fail closed —
+/// pre-P0.8 the arm was `#[cfg]`'d away, so a production config pointing at
+/// AWS on a keyring-only binary booted against an empty keyring.
+#[allow(dead_code)]
+fn uncompiled(backend: &str, feature: &str) -> AppError {
+    AppError::Config(format!(
+        "secrets backend '{backend}' selected but this binary was built without the \
+         '{feature}' feature"
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base() -> SecretsConfig {
+        SecretsConfig::default()
+    }
+
+    fn data_dir() -> std::path::PathBuf {
+        std::env::temp_dir()
+    }
+
+    // `Box<dyn SeedStore>` is not `Debug`, so `expect_err` won't compile;
+    // pattern-match the result instead.
+    fn expect_config_err(secrets: &SecretsConfig, needle: &str) {
+        match create_seed_store(secrets, &data_dir()) {
+            Err(AppError::Config(msg)) => assert!(
+                msg.contains(needle),
+                "error should mention {needle:?}, got: {msg}"
+            ),
+            Err(other) => panic!("expected a Config error, got {other:?}"),
+            Ok(_) => panic!("expected a Config error, got a store"),
+        }
+    }
+
+    #[test]
+    fn plaintext_is_unreachable_implicitly_but_selectable_explicitly() {
+        // The reported bug: with `keyring` compiled in (the default), the
+        // keyring arm matches unconditionally, so `allow_plaintext` alone
+        // never reaches the plaintext backend — the wizard's "Plaintext
+        // file" choice silently produced a keyring-backed VTA. The explicit
+        // selector is what makes the request expressible.
+        let mut secrets = base();
+        secrets.allow_plaintext = true;
+
+        // Implicit: allow_plaintext is a permission, not a request.
+        #[cfg(feature = "keyring")]
+        assert!(
+            create_seed_store(&secrets, &data_dir()).is_ok(),
+            "implicit resolution still picks keyring"
+        );
+
+        // Explicit: plaintext is built, and the file lands where the
+        // plaintext backend puts it.
+        secrets.backend = Some(SecretBackend::Plaintext);
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = create_seed_store(&secrets, dir.path()).expect("plaintext store builds");
+        futures_executor_block_on(store.set(&[7u8; 64]));
+        assert!(
+            dir.path().join("seed.plaintext").is_file(),
+            "an explicit plaintext selection must write the plaintext seed file"
+        );
+    }
+
+    /// Minimal block-on so the test doesn't pull a runtime into this crate's
+    /// non-async surface. `PlaintextSeedStore::set` never yields — it is a
+    /// synchronous `std::fs` write behind an async signature.
+    fn futures_executor_block_on(fut: impl std::future::Future<Output = Result<(), AppError>>) {
+        let waker = std::task::Waker::noop();
+        let mut cx = std::task::Context::from_waker(waker);
+        let mut fut = Box::pin(fut);
+        match fut.as_mut().poll(&mut cx) {
+            std::task::Poll::Ready(r) => r.expect("plaintext write succeeds"),
+            std::task::Poll::Pending => panic!("plaintext set must complete without yielding"),
+        }
+    }
+
+    #[test]
+    fn explicit_plaintext_still_needs_the_allow_optin() {
+        // Selecting plaintext says *which* backend; `allow_plaintext` still
+        // says you accept a cleartext master seed (P0.9). Both are required.
+        let mut secrets = base();
+        secrets.backend = Some(SecretBackend::Plaintext);
+        expect_config_err(&secrets, "allow_plaintext");
+    }
+
+    #[test]
+    fn an_explicit_uncompiled_backend_is_a_hard_error() {
+        // Fail closed: never silently substitute keyring (or plaintext) for
+        // the backend the operator named.
+        let mut secrets = base();
+        for (sel, needle) in [
+            (SecretBackend::Aws, "aws"),
+            (SecretBackend::Gcp, "gcp"),
+            (SecretBackend::Azure, "azure"),
+            (SecretBackend::Vault, "vault"),
+            (SecretBackend::Kubernetes, "kubernetes"),
+        ] {
+            secrets.backend = Some(sel);
+            // Only assert for backends this build genuinely lacks; the
+            // workspace test build compiles none of them.
+            if cfg!(not(any(
+                feature = "aws-secrets",
+                feature = "gcp-secrets",
+                feature = "azure-secrets",
+                feature = "vault-secrets",
+                feature = "k8s-secrets"
+            ))) {
+                expect_config_err(&secrets, needle);
+            }
+        }
+    }
+
+    #[test]
+    fn an_explicit_selector_overrides_a_stray_implicit_field() {
+        // A leftover `aws_secret_name` must not drag a keyring-selected
+        // deployment onto AWS — the named backend wins outright.
+        let mut secrets = base();
+        secrets.aws_secret_name = Some("vta/prod/seed".into());
+        secrets.backend = Some(SecretBackend::Keyring);
+        #[cfg(feature = "keyring")]
+        assert!(
+            create_seed_store(&secrets, &data_dir()).is_ok(),
+            "the explicit keyring selection must win over the stray AWS field"
+        );
+    }
+
+    #[test]
+    fn no_selector_keeps_the_legacy_implicit_chain() {
+        // Existing configs must resolve exactly as before.
+        let secrets = base();
+        assert!(secrets.backend.is_none(), "unset by default");
+        #[cfg(feature = "keyring")]
+        assert!(
+            create_seed_store(&secrets, &data_dir()).is_ok(),
+            "an all-default config still lands on keyring"
+        );
+    }
+
+    #[test]
+    fn the_selector_round_trips_through_toml_in_wizard_spelling() {
+        let parsed: SecretsConfig =
+            toml::from_str("backend = \"config_seed\"\nseed = \"aa\"").expect("parses");
+        assert_eq!(parsed.backend, Some(SecretBackend::ConfigSeed));
+
+        let out = toml::to_string(&base()).expect("serializes");
+        assert!(
+            !out.contains("backend"),
+            "an unset selector must not be written into config.toml, got:\n{out}"
+        );
     }
 }


### PR DESCRIPTION
Two setup defects found while chasing an operator report that `vta setup`
failed "no matter if you say yes or no" at the existing-data-directory
prompt. Reported against `/app/vta-data` from a PowerShell host, but neither
bug is Windows-specific — there is no platform-conditional code anywhere in
this path.

```
Data directory: /app/vta-data
Data directory "/app/vta-data" already exists. Delete and start fresh? no
Setup cancelled.
```

## 1. A pre-created data directory is not a conflict

The gate was `data_dir.exists()`, and `ExistingDataDirPolicy` had exactly two
variants: `Error` and `Delete`. Neither the wizard nor `--from <toml>` could
point setup at a directory that already existed. Docker volumes, bind mounts,
and Kubernetes PVCs all create the mount path *before* the container starts,
so containerized first-boot hit the prompt 100% of the time — and neither
answer worked:

- **"no"** → `Setup cancelled.` The only non-destructive answer, and a dead end.
- **"yes"** → `remove_dir_all` removes the directory *itself*, and `rmdir` on a
  mount point returns `EBUSY` however empty it is — after the contents are
  already gone. Destructive *and* failing.

Fixes:

- **Gate on store presence, not directory presence.** New
  `vti_common::store::local_store_exists` probes fjall's own `version` marker
  — the same file `fjall::Database` uses to decide recover-vs-create, so the
  two cannot drift. An existing-but-storeless `data_dir` is initialized into
  silently, with no prompt at all.
- **`data_dir_exists = "delete"` clears the directory's *contents*.** Same
  destruction, but it succeeds on a mount point.
- **New `data_dir_exists = "reuse"`**, plus a third option in the interactive
  prompt — now cancel / keep / wipe rather than a yes-no with no survivable
  answer.
- **Fail closed over an initialized VTA.** Re-running setup mints a fresh
  master seed as generation 0; on top of an existing seed that orphans every
  key derived from the original. All policies — including `reuse` — refuse
  when generation 0 is already present.

## 2. The wizard deleted `config.toml` while still asking questions

Separate, platform-independent, and probably why "no" read as a hard failure.
`gather_inputs` removed the config file at the *config-path* prompt, a dozen
prompts before the data-directory question. Backing out there left the
operator with no config and a VTA that would not start.

Intent is now carried as `overwrite_config` (new `WizardInputs` field,
`--from`-settable, default `false`) and the file is written only at step 13,
once everything else has succeeded. An `--from` caller that wants in-place
re-runs sets `overwrite_config = true` instead of `rm`-ing the file first.

Also trims the data-directory and config-path answers, so a pasted path with
stray whitespace no longer becomes a subtly different path.

## 3. Choosing "Plaintext file" silently gave you a keyring

Found while writing the tests for the above. `create_seed_store` inferred the
backend from whichever selector field was populated, and plaintext has no
field of its own — `allow_plaintext` is a *permission* to fall back, not a
request. With `keyring` compiled in (the default) the keyring arm matched
unconditionally, so the plaintext arm below it was unreachable. The same
shadowing hid any backend sitting under a configured one.

- **New `secrets.backend`** (`keyring` | `config_seed` | `aws` | `gcp` |
  `azure` | `vault` | `kubernetes` | `plaintext`). When set it wins outright:
  that backend is built and its required fields validated. Mirrors
  `vtc_service::config::SecretBackend`, so the VTA and VTC share one
  vocabulary rather than solving this twice, differently.
- **Fail closed** — a backend named on a binary built without its Cargo
  feature is a hard config error, never a silent substitution. Same P0.8
  stance the VTC already took.
- **The wizard writes the selector for every choice**, so a generated
  `config.toml` states its backend. Plaintext takes both keys now:
  `backend = "plaintext"` (which) and `allow_plaintext = true` (accepting a
  cleartext master seed).

## Compatibility

- Omitting `secrets.backend` keeps the legacy implicit priority chain exactly
  as it was; the field is skipped on serialize when unset, so existing configs
  neither change behaviour nor grow a key. **No silent backend downgrade on
  upgrade** — `allow_plaintext` keeps its documented meaning.
- `overwrite_config` defaults to `false`, matching the previous refuse-to-
  overwrite behaviour.
- `data_dir_exists` still defaults to `"error"`. The only behaviour change for
  an existing config is that an *empty* `data_dir` no longer trips it, which
  is the bug.

## Verification

- `cargo test --workspace` — 131 suites, all `ok`, zero failures.
- `cargo clippy --workspace -- -D warnings` — clean (CI's own bar).
- `cargo fmt --all --check` — clean.
- `vti-secrets` compiles under every backend feature individually and all
  together; the four `vta-service` feature combos CI checks all pass.

New tests: 4 end-to-end `apply_inputs` tests (pre-created dir is not a
conflict; refusal over an initialized VTA leaves the seed alone; a failed run
leaves the config byte-identical; delete clears in place, asserted via the
directory's creation stamp), 3 interactive-wizard tests (empty dir is never
asked about; cancelling preserves config *and* data; reuse/delete map
through), 3 in `vti-common`, and 6 in `vti-secrets` covering the selector,
the uncompiled-backend refusal, and the implicit chain's preserved behaviour.

## Note

The `remove_dir_all` → `EBUSY` diagnosis for the "yes" path is inferred from
the code and the reported `/app/vta-data` path; I do not have the operator's
"Y" error text. The fix addresses the cause either way, but confirming that
error would close the loop.
