### PR TITLE
feat(vtc): REST-only auth refresh, so a mediator-less client can complete its login loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 ## Unreleased
 
+### vtc-service 0.11.27 — a REST-only client can now refresh without a mediator
+
+`POST /v1/auth/refresh` went straight to `atm.unpack` and — correctly, since
+0.11.20 — required an authcrypt DIDComm envelope. That left the VTC's auth
+surface asymmetric: a wallet could **log in** over plain REST via the SIOP
+`id_token` path, but to spend the refresh token it was handed on the way out it
+needed a mediator/DIDComm stack it otherwise never touched. In practice such a
+client re-ran the whole SIOP round-trip on every access-token expiry instead of
+refreshing. The VTA has had both halves of this loop since 0.12.x; the VTC only
+had the first.
+
+**Fix.** `refresh` now tries a canonical `auth/refresh/0.1` Trust Task document
+before falling through to `atm.unpack`, mirroring the VTA's
+`try_refresh_trust_task`. Refresh carries no proof — the opaque refresh token
+*is* the bearer credential (RFC 6749 §10.4), verified by the canonical handler's
+single-use rotating reverse index — so the REST path passes `signer_did: None`,
+exactly as the VTA does. A VTC running with no `atm` at all can now serve
+refresh.
+
+The payload is `payload.refreshToken` (camelCase, per the generated spec type
+and R3.1), byte-identical to the VTA's, so one document builder serves both
+services. The DIDComm envelope path is untouched and still gated by
+`bind_authcrypt_sender` — pinned by the existing
+`plaintext_didcomm_refresh_is_rejected` regression, which still passes because a
+plaintext DIDComm message has no `payload` member and so cannot be mistaken for
+a Trust Task.
+
+Also adds the header-exempt `POST /v1/wallet/auth/refresh` alias beside the
+existing `/v1/wallet/auth/{challenge,}` pair. The browser wallet extension posts
+with **no** `Trust-Task` header, so without this its loop was still incomplete:
+it could log in header-free but not refresh. Same handler, op `type` in the body.
+
+Closes #783.
 ### vta-sdk 0.20.0 — TSP is a selectable transport, not just a probe (BREAKING)
 
 TSP has worked on the wire since #749/#750, but nothing between "the wire works"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10597,7 +10597,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-service"
-version = "0.11.26"
+version = "0.11.27"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,9 +342,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-mediator"
-version = "0.17.7"
+version = "0.17.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cac110108e4019d850ad9a75c65e5598ab8406a1f6868137165c2512c73b6c04"
+checksum = "a5888cf7493766b85257206459a0ae691570ca134a6926cf5fb8bbdd8ebb3dec"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-common",
@@ -402,7 +402,7 @@ dependencies = [
  "trust-tasks-rs",
  "url",
  "uuid",
- "vta-sdk 0.19.28",
+ "vta-sdk",
 ]
 
 [[package]]
@@ -2502,7 +2502,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.20.0",
+ "vta-sdk",
 ]
 
 [[package]]
@@ -3303,7 +3303,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.20.0",
+ "vta-sdk",
 ]
 
 [[package]]
@@ -6781,7 +6781,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.20.0",
+ "vta-sdk",
 ]
 
 [[package]]
@@ -10083,7 +10083,7 @@ version = "0.1.1"
 dependencies = [
  "tracing",
  "uuid",
- "vta-sdk 0.20.0",
+ "vta-sdk",
  "vti-common",
 ]
 
@@ -10109,7 +10109,7 @@ dependencies = [
  "vta-config",
  "vta-keys",
  "vta-keyspaces",
- "vta-sdk 0.20.0",
+ "vta-sdk",
  "vta-support",
  "vta-webvh",
  "vti-common",
@@ -10136,7 +10136,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.19",
  "tokio",
- "vta-sdk 0.20.0",
+ "vta-sdk",
  "vti-common",
  "x25519-dalek",
 ]
@@ -10196,7 +10196,7 @@ dependencies = [
  "uuid",
  "vta-config",
  "vta-keyspaces",
- "vta-sdk 0.20.0",
+ "vta-sdk",
  "vti-common",
  "vti-secrets",
  "x25519-dalek",
@@ -10223,7 +10223,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.20.0",
+ "vta-sdk",
 ]
 
 [[package]]
@@ -10246,7 +10246,7 @@ dependencies = [
  "tracing-subscriber",
  "trust-tasks-rs",
  "uniffi",
- "vta-sdk 0.20.0",
+ "vta-sdk",
 ]
 
 [[package]]
@@ -10265,39 +10265,6 @@ dependencies = [
  "vta-config",
  "vta-keyspaces",
  "vti-common",
-]
-
-[[package]]
-name = "vta-sdk"
-version = "0.19.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e5c6b5be45c551ee4f7bfcd1165125c04fc7cbd7485b266e197eb6467bcaa17"
-dependencies = [
- "affinidi-crypto",
- "affinidi-did-resolver-cache-sdk",
- "affinidi-messaging-core",
- "affinidi-messaging-delivery",
- "affinidi-messaging-didcomm",
- "affinidi-openid4vci",
- "affinidi-openid4vp",
- "affinidi-tdk",
- "base64 0.22.1",
- "chrono",
- "curve25519-dalek",
- "didwebvh-rs",
- "ed25519-dalek",
- "futures-util",
- "getrandom 0.4.3",
- "multibase",
- "reqwest 0.13.4",
- "serde",
- "serde_json",
- "sha2 0.11.0",
- "thiserror 2.0.19",
- "tokio",
- "tracing",
- "url",
- "uuid",
 ]
 
 [[package]]
@@ -10446,7 +10413,7 @@ dependencies = [
  "vta-keys",
  "vta-keyspaces",
  "vta-policy",
- "vta-sdk 0.20.0",
+ "vta-sdk",
  "vta-service",
  "vta-support",
  "vta-sweepers",
@@ -10479,7 +10446,7 @@ dependencies = [
  "tracing",
  "vta-config",
  "vta-keyspaces",
- "vta-sdk 0.20.0",
+ "vta-sdk",
  "vti-common",
 ]
 
@@ -10557,7 +10524,7 @@ dependencies = [
  "tracing",
  "uuid",
  "vta-keyspaces",
- "vta-sdk 0.20.0",
+ "vta-sdk",
  "vti-common",
 ]
 
@@ -10576,7 +10543,7 @@ dependencies = [
  "tracing",
  "url",
  "vta-keyspaces",
- "vta-sdk 0.20.0",
+ "vta-sdk",
  "vti-common",
  "wiremock",
  "zeroize",
@@ -10592,7 +10559,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.19",
  "tokio",
- "vta-sdk 0.20.0",
+ "vta-sdk",
 ]
 
 [[package]]
@@ -10666,7 +10633,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.20.0",
+ "vta-sdk",
  "vtc-service",
  "vti-common",
  "vti-secrets",
@@ -10718,7 +10685,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.20.0",
+ "vta-sdk",
  "webauthn-rs",
  "zeroize",
 ]
@@ -10745,7 +10712,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.20.0",
+ "vta-sdk",
  "vta-service",
  "vti-common",
 ]
@@ -10775,7 +10742,7 @@ dependencies = [
  "toml 1.1.3+spec-1.1.0",
  "tracing",
  "vaultrs",
- "vta-sdk 0.20.0",
+ "vta-sdk",
  "vti-common",
 ]
 

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.11.26"
+version = "0.11.27"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vtc-service/src/routes/auth.rs
+++ b/vtc-service/src/routes/auth.rs
@@ -3,6 +3,8 @@ use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use serde::{Deserialize, Serialize};
+use trust_tasks_rs::TrustTask;
+use trust_tasks_rs::specs::auth::refresh::v0_1 as refresh;
 use uuid::Uuid;
 
 use vta_sdk::protocols::auth::{
@@ -740,6 +742,11 @@ mod cookie_format_tests {
 
 // ---------- POST /auth/refresh ----------
 
+/// The canonical `auth/refresh/0.1` Type URI, shared by both request shapes —
+/// the DIDComm envelope's `msg.typ` and the REST Trust Task's `type`. The
+/// legacy `affinidi.com/atm/1.0/authenticate/refresh` alias was removed.
+const REFRESH_TASK_URI: &str = <refresh::Payload as trust_tasks_rs::Payload>::TYPE_URI;
+
 /// `POST /v1/auth/refresh` — exchange the presented refresh
 /// token for a new access + refresh pair.
 ///
@@ -749,6 +756,13 @@ mod cookie_format_tests {
 /// claim, refresh-expiry check, ACL re-look-up, AAL preservation
 /// across rotation, RFC 6749 §10.4 rotation semantics — lives in
 /// the canonical handler in vti-common.
+///
+/// Two request shapes, tried in order:
+///
+/// 1. **Trust-Task `auth/refresh/0.1` document** (canonical REST) — no
+///    mediator, no DIDComm stack. See [`try_refresh_trust_task`].
+/// 2. **DIDComm authcrypt envelope** — for clients already on a mediator.
+///    Unchanged, and still gated by `bind_authcrypt_sender`.
 #[utoipa::path(
     post, path = "/auth/refresh", tag = "auth",
     request_body(content = String, description = "DIDComm envelope or Trust-Task refresh document"),
@@ -761,6 +775,13 @@ pub async fn refresh(
     State(state): State<AppState>,
     body: String,
 ) -> Result<Json<AuthenticateResponse>, AppError> {
+    // Canonical REST path, tried first so a VTC reached by a client with no
+    // DIDComm stack — and a VTC running with no `atm` at all — can still
+    // refresh. Falls through for any body that isn't such a document.
+    if let Some(resp) = try_refresh_trust_task(&state, &body).await? {
+        return Ok(Json(resp));
+    }
+
     let atm = state
         .atm
         .as_ref()
@@ -776,9 +797,8 @@ pub async fn refresh(
     let sender_base = vti_common::auth::bind_authcrypt_sender(&msg, &metadata)
         .map_err(|e| AppError::Authentication(e.message("refresh message")))?;
 
-    // Canonical Trust-Task URI only; the legacy
-    // `affinidi.com/atm/1.0/authenticate/refresh` alias was removed.
-    if msg.typ.as_str() != "https://trusttasks.org/spec/auth/refresh/0.1" {
+    // Canonical Trust-Task URI only — see [`REFRESH_TASK_URI`].
+    if msg.typ.as_str() != REFRESH_TASK_URI {
         return Err(AppError::Authentication(format!(
             "unexpected message type: {}",
             msg.typ
@@ -800,6 +820,62 @@ pub async fn refresh(
     )
     .await?;
     Ok(Json(resp))
+}
+
+/// Try to refresh from an `auth/refresh/0.1` Trust Task document — the
+/// canonical REST transport, and the VTC counterpart of the VTA's
+/// `try_refresh_trust_task`.
+///
+/// **Why this exists.** `POST /v1/auth/` already has a mediator-less path
+/// ([`authenticate_siop`]), so a wallet can *log in* to a VTC over plain
+/// REST. Without this, exercising the refresh token it was just handed
+/// required posting an authcrypt DIDComm envelope — a mediator stack the
+/// client otherwise never touched — so a genuinely REST-only client had to
+/// re-run the whole SIOP round-trip on every access-token expiry.
+///
+/// **Why there is no proof here.** Refresh carries none: the opaque refresh
+/// token in the payload *is* the bearer credential (RFC 6749 §10.4 rotation),
+/// verified server-side by the canonical handler's single-use rotating
+/// reverse-index. `signer_did` is therefore `None` — there is no proven signer
+/// to bind, and the handler reads `None` as "skip the optional signer-DID
+/// check". That is the same posture the DIDComm path ends up in: its
+/// `bind_authcrypt_sender` gate proves *who sent the envelope*, but the token
+/// is what actually authorizes the rotation. A stolen refresh token is
+/// therefore exactly as usable over REST as the token itself is — which is
+/// why rotation is single-use and a replay surfaces as "not found".
+///
+/// The wire shape is the canonical Trust Task, byte-identical to the VTA's
+/// (`payload.refreshToken`, camelCase per R3.1) rather than the DIDComm
+/// path's snake_case `refresh_token` body — so one REST client speaks to both
+/// services with one document builder.
+///
+/// Returns `Ok(None)` when the body isn't an `auth/refresh/0.1` Trust Task (→
+/// fall through to the DIDComm path); `Err` when it *is* one but is invalid.
+async fn try_refresh_trust_task(
+    state: &AppState,
+    body: &str,
+) -> Result<Option<AuthenticateResponse>, AppError> {
+    let doc: TrustTask<serde_json::Value> = match serde_json::from_str(body) {
+        Ok(doc) => doc,
+        Err(_) => return Ok(None), // not a Trust Task document → DIDComm path
+    };
+    if doc.type_uri.to_string() != REFRESH_TASK_URI {
+        return Ok(None);
+    }
+
+    let payload: refresh::Payload = serde_json::from_value(doc.payload)
+        .map_err(|e| AppError::Authentication(format!("invalid refresh payload: {e}")))?;
+
+    let backend = crate::auth::VtcAuthBackend::from_state(state).await?;
+    let resp = vti_common::auth::handlers::handle_refresh(
+        &backend,
+        vti_common::auth::RefreshInput {
+            refresh_token: payload.refresh_token.to_string(),
+            signer_did: None,
+        },
+    )
+    .await?;
+    Ok(Some(resp))
 }
 
 // ---------- GET /auth/sessions ----------

--- a/vtc-service/src/routes/mod.rs
+++ b/vtc-service/src/routes/mod.rs
@@ -951,6 +951,13 @@ fn build_unauth_routes(trust_xff: bool) -> OpenApiRouter<AppState> {
         // CLI clients. Mirrors did-hosting-control's header-less auth.
         .route("/wallet/auth/challenge", post(auth::challenge))
         .route("/wallet/auth/", post(auth::authenticate))
+        // Completes the wallet's loop. Without this alias the extension could
+        // log in header-free above but had to send a `Trust-Task` header (or,
+        // before the REST fast-path, an authcrypt DIDComm envelope) to spend
+        // the refresh token it was just handed — so it re-ran the whole SIOP
+        // round-trip on every access-token expiry instead. Same handler; the
+        // op `type` rides in the body exactly as it does on `/wallet/auth/`.
+        .route("/wallet/auth/refresh", post(auth::refresh))
         .routes(tt(
             routes!(auth::refresh),
             "https://trusttasks.org/spec/auth/refresh/0.1",

--- a/vtc-service/tests/wallet_login_siop.rs
+++ b/vtc-service/tests/wallet_login_siop.rs
@@ -412,3 +412,221 @@ async fn wallet_login_rejects_iss_not_matching_session() {
     .await;
     assert_eq!(status, StatusCode::UNAUTHORIZED);
 }
+
+// ---------------------------------------------------------------------------
+// Mediator-less refresh (#783)
+// ---------------------------------------------------------------------------
+//
+// The fixture above is built with **no ATM** (`TestVtc` defaults `atm: None`),
+// which is what makes these tests load-bearing: before the REST fast-path,
+// `POST /v1/auth/refresh` went straight to `atm.unpack` and every request here
+// died on "ATM not configured". A REST-only wallet could log in without a
+// mediator but could not spend the refresh token it was handed — so it re-ran
+// the whole SIOP round-trip on each access-token expiry.
+
+const REFRESH_TYPE: &str = "https://trusttasks.org/spec/auth/refresh/0.1";
+
+/// A canonical `auth/refresh/0.1` Trust Task document. `refreshToken` is
+/// camelCase per the generated spec payload (R3.1) — deliberately *not* the
+/// DIDComm body's snake_case `refresh_token`, so one document builder serves
+/// both the VTA and the VTC over REST.
+fn refresh_doc(refresh_token: &str) -> Value {
+    json!({
+        "id": "urn:uuid:11111111-2222-3333-4444-555555555555",
+        "type": REFRESH_TYPE,
+        "payload": { "refreshToken": refresh_token },
+    })
+}
+
+/// POST with an explicit `Trust-Task` header — the header-gated `/v1/auth/*`
+/// surface used by CLI/SDK clients (the `/v1/wallet/*` aliases are exempt).
+async fn post_with_task_header(
+    router: &axum::Router,
+    path: &str,
+    task: &str,
+    body: Value,
+) -> (StatusCode, Value) {
+    let res = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(path)
+                .header("content-type", "application/json")
+                .header("Trust-Task", task)
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .expect("oneshot");
+    let status = res.status();
+    let bytes = res.into_body().collect().await.unwrap().to_bytes();
+    let json = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
+    (status, json)
+}
+
+/// Run a full wallet login and return the whole `{ session, tokens }` body.
+async fn wallet_login_tokens(fix: &Fixture, sk: &SigningKey, holder: &str, kid: &str) -> Value {
+    let (session_id, challenge) = get_challenge(&fix.router, holder).await;
+    let now = now_epoch();
+    let id_token = sign_id_token(sk, kid, holder, holder, VTC_DID, &challenge, now, now + 300);
+    let (status, body) = post_json(
+        &fix.router,
+        "/v1/wallet/auth/",
+        json!({ "type": AUTH_TYPE, "payload": { "id_token": id_token, "session_id": session_id } }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "login failed: {body}");
+    body
+}
+
+#[tokio::test]
+async fn rest_only_login_then_refresh_needs_no_didcomm() {
+    let (sk, holder, kid) = holder_identity(20);
+    let fix = build_fixture(&holder).await;
+
+    // Leg 1 — SIOP login over plain REST.
+    let login = wallet_login_tokens(&fix, &sk, &holder, &kid).await;
+    let refresh_token = login["tokens"]["refreshToken"]
+        .as_str()
+        .expect("login must issue a refresh token")
+        .to_string();
+    let first_access = login["tokens"]["accessToken"].as_str().unwrap().to_string();
+
+    // Leg 2 — spend it on the header-exempt wallet alias. No mediator, no
+    // DIDComm envelope, no `Trust-Task` header.
+    let (status, body) = post_json(
+        &fix.router,
+        "/v1/wallet/auth/refresh",
+        refresh_doc(&refresh_token),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "REST refresh failed: {body}");
+    let new_access = body["tokens"]["accessToken"]
+        .as_str()
+        .expect("refresh must mint an access token");
+    assert!(!new_access.is_empty());
+    assert_ne!(
+        new_access, first_access,
+        "refresh must mint a *new* access token, not echo the old one"
+    );
+    // The session survives rotation and still names the same subject.
+    assert_eq!(body["session"]["subject"].as_str(), Some(holder.as_str()));
+}
+
+#[tokio::test]
+async fn rest_refresh_rotates_and_the_old_token_is_dead() {
+    // RFC 6749 §10.4: every successful refresh mints a new refresh token and
+    // retires the presented one. A replayed token must read as "not found" —
+    // the same shape a revoked token gives, so a leak is not distinguishable
+    // from a revocation by probing.
+    let (sk, holder, kid) = holder_identity(21);
+    let fix = build_fixture(&holder).await;
+
+    let login = wallet_login_tokens(&fix, &sk, &holder, &kid).await;
+    let first = login["tokens"]["refreshToken"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let (status, body) =
+        post_json(&fix.router, "/v1/wallet/auth/refresh", refresh_doc(&first)).await;
+    assert_eq!(status, StatusCode::OK, "first refresh failed: {body}");
+    let second = body["tokens"]["refreshToken"]
+        .as_str()
+        .expect("rotation must return a new refresh token");
+    assert_ne!(second, first, "refresh token must rotate");
+
+    // Replay the spent token.
+    let (status, body) =
+        post_json(&fix.router, "/v1/wallet/auth/refresh", refresh_doc(&first)).await;
+    assert_eq!(
+        status,
+        StatusCode::UNAUTHORIZED,
+        "a spent refresh token must not work twice: {body}"
+    );
+}
+
+#[tokio::test]
+async fn rest_refresh_also_works_on_the_header_gated_route() {
+    // The CLI/SDK surface. Same handler, same document — it just arrives on
+    // `/v1/auth/refresh` behind the `Trust-Task` gate instead of the
+    // header-exempt wallet alias.
+    let (sk, holder, kid) = holder_identity(22);
+    let fix = build_fixture(&holder).await;
+
+    let login = wallet_login_tokens(&fix, &sk, &holder, &kid).await;
+    let refresh_token = login["tokens"]["refreshToken"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let (status, body) = post_with_task_header(
+        &fix.router,
+        "/v1/auth/refresh",
+        REFRESH_TYPE,
+        refresh_doc(&refresh_token),
+    )
+    .await;
+
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "header-gated REST refresh failed: {body}"
+    );
+    assert!(
+        body["tokens"]["accessToken"]
+            .as_str()
+            .is_some_and(|t| !t.is_empty()),
+        "expected rotated tokens, got {body}"
+    );
+}
+
+#[tokio::test]
+async fn rest_refresh_rejects_an_unknown_token() {
+    let (_sk, holder, _kid) = holder_identity(23);
+    let fix = build_fixture(&holder).await;
+
+    let (status, body) = post_json(
+        &fix.router,
+        "/v1/wallet/auth/refresh",
+        refresh_doc("rt_never-issued-by-this-vtc"),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::UNAUTHORIZED,
+        "an unissued refresh token must be rejected: {body}"
+    );
+}
+
+#[tokio::test]
+async fn rest_refresh_rejects_a_malformed_payload() {
+    // The document *is* an `auth/refresh/0.1` Trust Task, so the fast-path
+    // owns it and must fail loudly rather than fall through to the DIDComm
+    // path and report the misleading "ATM not configured" / "failed to unpack".
+    // `refresh::Payload` is `deny_unknown_fields`, so the snake_case spelling
+    // is a hard error, not a silently-missing token.
+    let (_sk, holder, _kid) = holder_identity(24);
+    let fix = build_fixture(&holder).await;
+
+    let (status, body) = post_json(
+        &fix.router,
+        "/v1/wallet/auth/refresh",
+        json!({
+            "id": "urn:uuid:99999999-9999-9999-9999-999999999999",
+            "type": REFRESH_TYPE,
+            "payload": { "refresh_token": "wrong-casing" },
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED, "got {body}");
+    assert!(
+        body["error"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("invalid refresh payload"),
+        "the error must name the payload as the problem, got: {body}"
+    );
+}


### PR DESCRIPTION
## Problem

`POST /v1/auth/refresh` went straight to `atm.unpack` and — correctly, since #771 — required an authcrypt DIDComm envelope. That left the VTC's auth surface asymmetric:

| Endpoint | REST-only fast-path (mediator-less) |
|---|---|
| VTA `POST /auth/` | ✅ DI-signed Trust Task |
| VTA `POST /auth/refresh` | ✅ Trust Task |
| VTC `POST /v1/auth/` | ✅ SIOP `id_token` |
| **VTC `POST /v1/auth/refresh`** | ❌ `atm.unpack` only |

A wallet could **log in** to a VTC over plain REST, but to spend the refresh token it was handed on the way out it needed a mediator/DIDComm stack it otherwise never touched. In practice such a client re-ran the whole SIOP round-trip on every access-token expiry.

## Root cause

Ordering, not the gate. #771's `bind_authcrypt_sender` check is correct — it was just the *only* path. The fix is to try the REST document first, exactly as the VTA does, and fall through for anything else.

## Change

`refresh` now tries a canonical `auth/refresh/0.1` Trust Task before `atm.unpack`, mirroring the VTA's `try_refresh_trust_task`.

Refresh carries **no proof** — the opaque refresh token *is* the bearer credential (RFC 6749 §10.4), verified by the canonical handler's single-use rotating reverse index — so the REST path passes `signer_did: None`, exactly as the VTA does. A VTC running with **no `atm` at all** can now serve refresh.

The payload is `payload.refreshToken` (camelCase, per the generated spec type and R3.1), byte-identical to the VTA's, so one document builder serves both services.

### The wallet alias

Also adds the header-exempt `POST /v1/wallet/auth/refresh` beside the existing `/v1/wallet/auth/{challenge,}` pair. The browser wallet extension posts with **no** `Trust-Task` header — that's why those aliases exist — so without this its loop was still incomplete: header-free login, header-gated refresh. Same handler; the op `type` rides in the body.

The header-gated `/v1/auth/refresh` is unchanged for CLI/SDK clients and now serves both document shapes.

## Why the DIDComm gate is safe

A plaintext DIDComm message carries `body`, not `payload`, so it fails `TrustTask` deserialization and falls through to `atm.unpack` — the authcrypt guard still runs first on that path. The existing `plaintext_didcomm_refresh_is_rejected` regression passes unchanged, untouched by this PR.

## Tests

Five new tests, all on the `TestVtc` fixture built with **no ATM** — which is what makes them load-bearing: every one died on `"ATM not configured"` before this change.

- `rest_only_login_then_refresh_needs_no_didcomm` — the acceptance criterion: SIOP login → REST refresh, no mediator, new access token.
- `rest_refresh_rotates_and_the_old_token_is_dead` — §10.4 rotation; a replayed token 401s.
- `rest_refresh_also_works_on_the_header_gated_route` — the CLI/SDK surface.
- `rest_refresh_rejects_an_unknown_token`
- `rest_refresh_rejects_a_malformed_payload` — the fast-path owns an `auth/refresh/0.1` document and must fail loudly rather than fall through and report a misleading "failed to unpack".

Full `cargo test -p vtc-service` green (683 lib + all integration, admin UI built). `cargo fmt --check` and `cargo clippy --all-targets` clean. Both CI guards (`check-version-bumps.sh`, `check-changelogs.sh`) pass.

Closes #783.
