### PR TITLE
feat(sdk): make TSP a selectable transport, not just a probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,125 @@
 
 ## Unreleased
 
+### vta-sdk 0.20.0 — TSP is a selectable transport, not just a probe (BREAKING)
+
+TSP has worked on the wire since #749/#750, but nothing between "the wire works"
+and "a client can choose it" existed. A consumer could *ping* a TSP VTA and could
+*receive* pushes; it could not transact with one. Three gaps, closed together
+because each is useless without the others.
+
+**Discovery (#765).** `session::resolve_vta_endpoint` never read the `#tsp`
+service. It ran its own two-field extraction (`#vta-rest` + `DIDCommMessaging`)
+even though `protocol::matching::ServiceCapabilities::from_did_document` — which
+matches on service `type`, tolerates `type` as string-or-array, and had
+understood `TSPTransport` all along — was sitting beside it. That duplication
+*was* the bug, so discovery now routes through the shared matcher rather than
+gaining a third bespoke branch.
+
+Two consequences. A TSP-enabled VTA is no longer invisible: every SDK consumer
+can see it advertises TSP. And a **TSP-only** document no longer falls through
+both extractions to `url_from_did()`, which returned a REST URL synthesized from
+the DID's own domain — an endpoint that need not exist. This SDK ships
+`did-host-tsp` and `did-host-http-tsp` templates, so it could mint a node it
+could not then resolve.
+
+`ResolvedVta` gains `tsp_mediator_did` and `advertised()`, deliberately separate
+from "the transport we connected over" — a probe needs both, independently
+sourced. Conflating them is what rendered a TSP-advertising VTA as
+"DIDComm (in use) · only transport offered".
+
+**Selection (#766).** `TransportChoice` gains `Tsp` and `Didcomm`, and `Auto`
+now implements the documented precedence **TSP > DIDComm > REST** (it previously
+meant "DIDComm when advertised, else REST" — the precedence was documented
+everywhere and implemented nowhere). `Didcomm` did not exist even implicitly:
+forcing DIDComm was only available as "whatever `Auto` happens to pick".
+
+`Auto` **falls back loudly**: an advertised-but-unanswering TSP mediator logs a
+`WARN` naming the mediator and deadline, then tries DIDComm, then REST. Failing
+hard would make a dual-transport VTA *less* available than before, purely for
+having enabled TSP; falling back silently would make a permanently-broken TSP
+deployment invisible. `--transport tsp` never falls back, for operators who want
+the strict behaviour.
+
+TSP connects are bounded (`VTA_TSP_CONNECT_TIMEOUT_SECS`, 30s default) with
+their **own** ceiling rather than sharing the DIDComm one — the TSP websocket
+hits the same mediator behind the same reconnect/backoff loop, so without a
+deadline `Auto` preferring TSP would turn a working DIDComm fallback into an
+indefinite hang. Per R6.4, "TSP advertised but the mediator went silent" and "no
+TSP advertised at all" get distinct messages, the latter naming the transports
+the VTA *does* offer.
+
+**The client (#767).** `TspSession::request(vta_did, mediator_did, document,
+timeout)` — correlated request/response, which is what makes TSP a transport:
+
+- Replies match on `threadId` (fallback: echoed `nonce`), never "first frame
+  that parses". The mediator inbox is durable and flushes on connect, so an
+  uncorrelated read returns a reply from a *previous process run* — the fault
+  that made the #749 delivery bug look intermittent. The correlation logic was
+  written for `TspPingSession::ping` and welded there; it is now one shared
+  `correlates` helper both paths use.
+- Concurrent requests share one session. Whichever caller holds the socket
+  demultiplexes for all of them (leader/followers), so a slow request cannot
+  serialise a fast one and one request's read cannot consume another's reply.
+  `receive_next` previously took the socket lock for its entire timeout budget.
+- Frames matching no in-flight request are **parked** for `receive_next`, not
+  discarded — a pushed `task-consent/request` must not be eaten by a request
+  waiting on something unrelated.
+- Every wait has a finite deadline (R1.2).
+
+`VtaClient::connect_tsp` mirrors `connect_didcomm`, and `Transport::Tsp` plugs
+into `dispatch_trust_task` — the single funnel — so the **whole Trust-Task
+surface** works over TSP with no per-operation work. The older DIDComm
+*protocol-message* surface (`key-management/1.0/*`) has no TSP dispatcher behind
+it and returns `UnsupportedTransport` naming DIDComm, rather than sending a frame
+the VTA cannot dispatch.
+
+**Authentication, stated explicitly** (the issue asked for this in writing):
+there is no token dance and no holder proof on the TSP path. TSP `unpack` yields
+a cryptographically proven sender VID, which `tsp_inbound::dispatch_one` resolves
+straight to its ACL grant before dispatching on the shared spine — the same
+intrinsic-sender model as DIDComm authcrypt. The REST bearer-token flow has no
+TSP analogue; `set_token` is a no-op on this transport.
+
+New `VtaError::TspTransport`, distinct from `DidcommTransport`: the two fail for
+different reasons and have different recovery flags.
+
+**Breaking.** `VtaEndpoint` gains a `Tsp` variant. It was not `#[non_exhaustive]`
+(unlike `TransportChoice`), so an exhaustive downstream match no longer compiles;
+it is `#[non_exhaustive]` now, so this is the last time. Hence 0.19 → 0.20.
+`ResolvedVta` gains two fields. CLIs gain `--transport tsp` and
+`--transport didcomm`.
+
+A compile-time pin (`tsp_send_assertions`) asserts every `TspSession` future is
+`Send`. One `Box<dyn Error>` held across one `.await` makes the whole chain
+`!Send` — including `VtaClient::dispatch_trust_task`, which `vta-mcp` puts behind
+`#[tool]`. Because `vta-mcp` doesn't enable the `tsp` feature itself, that break
+only surfaces once Cargo's feature unification turns TSP on for a workspace-wide
+build, a long way from the edit that caused it. It bit during this change; the
+private helpers are now `String`-typed so it cannot recur silently.
+
+Closes #765, #766, #767.
+
+### Dependent crates — `vta-sdk` 0.20 pin bump only
+
+No behavioural change; each of these only re-pins `vta-sdk = "0.19"` → `"0.20"`,
+which the version guard counts as a source change. `pnm-cli` 0.11.10 and
+`cnm-cli` 0.11.7 additionally expose the new `--transport tsp` /
+`--transport didcomm` flags (documented above).
+
+- `vta-audit` 0.1.1
+- `vta-backup` 0.1.1
+- `vta-cli-common` 0.10.15
+- `vta-keys` 0.1.2
+- `vta-service` 0.12.39
+- `vta-support` 0.1.2
+- `vta-vault` 0.1.1
+- `vta-webvh` 0.1.1
+- `vtc-client` 0.1.5
+- `vtc-service` 0.11.26
+- `vti-common` 0.11.23
+- `vti-secrets` 0.1.8
+
 ### vta-service 0.12.38 — make the wizard's scripted prompts feature-proof, and actually run them in CI
 
 The setup wizard's two golden tests (`interactive_matches_equivalent_toml`,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -402,7 +402,7 @@ dependencies = [
  "trust-tasks-rs",
  "url",
  "uuid",
- "vta-sdk",
+ "vta-sdk 0.19.28",
 ]
 
 [[package]]
@@ -2488,7 +2488,7 @@ checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cnm-cli"
-version = "0.11.6"
+version = "0.11.7"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "clap",
@@ -2502,7 +2502,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk",
+ "vta-sdk 0.20.0",
 ]
 
 [[package]]
@@ -3303,7 +3303,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk",
+ "vta-sdk 0.20.0",
 ]
 
 [[package]]
@@ -6759,7 +6759,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "pnm-cli"
-version = "0.11.9"
+version = "0.11.10"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-resolver-cache-sdk",
@@ -6781,7 +6781,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk",
+ "vta-sdk 0.20.0",
 ]
 
 [[package]]
@@ -10079,17 +10079,17 @@ dependencies = [
 
 [[package]]
 name = "vta-audit"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "tracing",
  "uuid",
- "vta-sdk",
+ "vta-sdk 0.20.0",
  "vti-common",
 ]
 
 [[package]]
 name = "vta-backup"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -10109,7 +10109,7 @@ dependencies = [
  "vta-config",
  "vta-keys",
  "vta-keyspaces",
- "vta-sdk",
+ "vta-sdk 0.20.0",
  "vta-support",
  "vta-webvh",
  "vti-common",
@@ -10118,7 +10118,7 @@ dependencies = [
 
 [[package]]
 name = "vta-cli-common"
-version = "0.10.14"
+version = "0.10.15"
 dependencies = [
  "aes-gcm",
  "affinidi-crypto",
@@ -10136,7 +10136,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.19",
  "tokio",
- "vta-sdk",
+ "vta-sdk 0.20.0",
  "vti-common",
  "x25519-dalek",
 ]
@@ -10171,7 +10171,7 @@ dependencies = [
 
 [[package]]
 name = "vta-keys"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "aes-gcm",
  "affinidi-crypto",
@@ -10196,7 +10196,7 @@ dependencies = [
  "uuid",
  "vta-config",
  "vta-keyspaces",
- "vta-sdk",
+ "vta-sdk 0.20.0",
  "vti-common",
  "vti-secrets",
  "x25519-dalek",
@@ -10223,7 +10223,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk",
+ "vta-sdk 0.20.0",
 ]
 
 [[package]]
@@ -10246,7 +10246,7 @@ dependencies = [
  "tracing-subscriber",
  "trust-tasks-rs",
  "uniffi",
- "vta-sdk",
+ "vta-sdk 0.20.0",
 ]
 
 [[package]]
@@ -10270,6 +10270,39 @@ dependencies = [
 [[package]]
 name = "vta-sdk"
 version = "0.19.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e5c6b5be45c551ee4f7bfcd1165125c04fc7cbd7485b266e197eb6467bcaa17"
+dependencies = [
+ "affinidi-crypto",
+ "affinidi-did-resolver-cache-sdk",
+ "affinidi-messaging-core",
+ "affinidi-messaging-delivery",
+ "affinidi-messaging-didcomm",
+ "affinidi-openid4vci",
+ "affinidi-openid4vp",
+ "affinidi-tdk",
+ "base64 0.22.1",
+ "chrono",
+ "curve25519-dalek",
+ "didwebvh-rs",
+ "ed25519-dalek",
+ "futures-util",
+ "getrandom 0.4.3",
+ "multibase",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "thiserror 2.0.19",
+ "tokio",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "vta-sdk"
+version = "0.20.0"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10331,7 +10364,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.12.38"
+version = "0.12.39"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",
@@ -10413,7 +10446,7 @@ dependencies = [
  "vta-keys",
  "vta-keyspaces",
  "vta-policy",
- "vta-sdk",
+ "vta-sdk 0.20.0",
  "vta-service",
  "vta-support",
  "vta-sweepers",
@@ -10432,7 +10465,7 @@ dependencies = [
 
 [[package]]
 name = "vta-support"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "chrono",
  "ed25519-dalek",
@@ -10446,7 +10479,7 @@ dependencies = [
  "tracing",
  "vta-config",
  "vta-keyspaces",
- "vta-sdk",
+ "vta-sdk 0.20.0",
  "vti-common",
 ]
 
@@ -10501,7 +10534,7 @@ dependencies = [
 
 [[package]]
 name = "vta-vault"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10524,13 +10557,13 @@ dependencies = [
  "tracing",
  "uuid",
  "vta-keyspaces",
- "vta-sdk",
+ "vta-sdk 0.20.0",
  "vti-common",
 ]
 
 [[package]]
 name = "vta-webvh"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "affinidi-tdk",
  "chrono",
@@ -10543,7 +10576,7 @@ dependencies = [
  "tracing",
  "url",
  "vta-keyspaces",
- "vta-sdk",
+ "vta-sdk 0.20.0",
  "vti-common",
  "wiremock",
  "zeroize",
@@ -10551,7 +10584,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-client"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "chrono",
  "reqwest 0.13.4",
@@ -10559,12 +10592,12 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.19",
  "tokio",
- "vta-sdk",
+ "vta-sdk 0.20.0",
 ]
 
 [[package]]
 name = "vtc-service"
-version = "0.11.25"
+version = "0.11.26"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",
@@ -10633,7 +10666,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk",
+ "vta-sdk 0.20.0",
  "vtc-service",
  "vti-common",
  "vti-secrets",
@@ -10646,7 +10679,7 @@ dependencies = [
 
 [[package]]
 name = "vti-common"
-version = "0.11.22"
+version = "0.11.23"
 dependencies = [
  "aes-gcm",
  "affinidi-data-integrity",
@@ -10685,7 +10718,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk",
+ "vta-sdk 0.20.0",
  "webauthn-rs",
  "zeroize",
 ]
@@ -10712,14 +10745,14 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk",
+ "vta-sdk 0.20.0",
  "vta-service",
  "vti-common",
 ]
 
 [[package]]
 name = "vti-secrets"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "aws-config",
  "aws-sdk-secretsmanager",
@@ -10742,7 +10775,7 @@ dependencies = [
  "toml 1.1.3+spec-1.1.0",
  "tracing",
  "vaultrs",
- "vta-sdk",
+ "vta-sdk 0.20.0",
  "vti-common",
 ]
 

--- a/cnm-cli/Cargo.toml
+++ b/cnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cnm-cli"
 description = "CLI Tool for Verified Trust Agents operating in Verified Trust Communities"
-version = "0.11.6"
+version = "0.11.7"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -21,7 +21,7 @@ config-session = ["vta-sdk/config-session"]
 azure-secrets = ["vta-sdk/azure-secrets"]
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.19", features = ["session", "crypto-provider", "acl-setup"] }
+vta-sdk = { path = "../vta-sdk", version = "0.20", features = ["session", "crypto-provider", "acl-setup"] }
 # `agent-names` powers the global `--resolve-agent-names` flag; without it
 # the flag parses but can never resolve anything.
 vta-cli-common = { path = "../vta-cli-common", version = "0.10", features = [

--- a/cnm-cli/src/main.rs
+++ b/cnm-cli/src/main.rs
@@ -63,9 +63,10 @@ struct Cli {
     #[arg(long, global = true)]
     json: bool,
 
-    /// Force a transport instead of auto-selecting. `rest` skips DIDComm even
-    /// when the VTA advertises it — the recovery path when a mediator is
-    /// unreachable.
+    /// Force a transport instead of auto-selecting. Auto prefers TSP, then
+    /// DIDComm, then REST. `tsp` / `didcomm` pin a mediator transport and fail
+    /// rather than fall back; `rest` skips both — the recovery path when a
+    /// mediator is unreachable.
     #[arg(long, value_enum, default_value_t = TransportOpt::Auto, global = true)]
     transport: TransportOpt,
 
@@ -77,11 +78,19 @@ struct Cli {
 /// [`vta_sdk::session::TransportChoice`].
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, ValueEnum)]
 enum TransportOpt {
-    /// Prefer DIDComm when the VTA advertises it, else REST.
+    /// Prefer TSP when the VTA advertises it, else DIDComm, else REST.
+    /// Falls back loudly (a WARN naming the mediator) if an advertised TSP
+    /// endpoint doesn't answer.
     #[default]
     Auto,
-    /// Force REST even when DIDComm is advertised — recovers a VTA whose
-    /// mediator is unreachable.
+    /// Force TSP. Fails — rather than falling back — if the VTA advertises no
+    /// `#tsp` service or its TSP mediator doesn't answer.
+    Tsp,
+    /// Force DIDComm, ignoring an advertised `#tsp`. Recovers a VTA whose TSP
+    /// endpoint is broken but whose mediator is healthy.
+    Didcomm,
+    /// Force REST even when a mediator transport is advertised — recovers a VTA
+    /// whose mediator is unreachable.
     Rest,
 }
 
@@ -89,6 +98,8 @@ impl From<TransportOpt> for vta_sdk::session::TransportChoice {
     fn from(opt: TransportOpt) -> Self {
         match opt {
             TransportOpt::Auto => Self::Auto,
+            TransportOpt::Tsp => Self::Tsp,
+            TransportOpt::Didcomm => Self::Didcomm,
             TransportOpt::Rest => Self::Rest,
         }
     }

--- a/didcomm-test/Cargo.toml
+++ b/didcomm-test/Cargo.toml
@@ -13,7 +13,7 @@ name = "didcomm-test"
 path = "src/main.rs"
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.19", features = ["didcomm", "crypto-provider"] }
+vta-sdk = { path = "../vta-sdk", version = "0.20", features = ["didcomm", "crypto-provider"] }
 affinidi-tdk = { workspace = true }
 affinidi-did-resolver-cache-sdk = { workspace = true }
 tokio = { workspace = true }

--- a/docs/05-design-notes/tsp-enablement.md
+++ b/docs/05-design-notes/tsp-enablement.md
@@ -146,13 +146,23 @@ Two facts from the reference code:
 
 ## 3. Protocol matching — the load-bearing new logic (D4)
 
-Today's transport selection is **one-directional and shape-sniffing**:
-`vta-sdk/src/session.rs::resolve_vta_endpoint` walks a counterparty DID doc, and
-`integration/auth.rs::decide_transport` picks DIDComm-if-mediator-DID-else-REST.
+Transport selection **was** one-directional and shape-sniffing:
+`vta-sdk/src/session.rs::resolve_vta_endpoint` walked a counterparty DID doc, and
+`integration/auth.rs::decide_transport` picked DIDComm-if-mediator-DID-else-REST.
 The WakeHandle convention treats *a DID as DIDComm, a URL as REST*.
 
 That heuristic **breaks under TSP**: a TSP VID is also a DID, so "endpoint is a DID ⇒
 DIDComm" is ambiguous. The fix is structural.
+
+> **Status (vta-sdk 0.20, #765).** §3.1 has landed. `protocol::matching`
+> (`ServiceCapabilities` / `select_protocol`) is the workspace's one
+> implementation of service-`type` matching, and `resolve_vta_endpoint` now
+> routes through it rather than carrying its own extraction — which is what had
+> left `#tsp` unread on the client side while the matcher already understood it.
+> `VtaEndpoint::Tsp` and `ResolvedVta::tsp_mediator_did` surface the result;
+> `TransportChoice` (#766) selects on it and `TspSession::request` /
+> `VtaClient::connect_tsp` (#767) transact over it. The second resolution hop
+> below (mediator DID → delivery URL) stays inside the TSP stack.
 
 ### 3.1 Capability discovery (read from the DID document)
 

--- a/pnm-cli/Cargo.toml
+++ b/pnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pnm-cli"
 description = "CLI Tool for managing a personal Verifiable Trust Agent"
-version = "0.11.9"
+version = "0.11.10"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -28,7 +28,7 @@ azure-secrets = ["vta-sdk/azure-secrets"]
 tsp = ["vta-sdk/tsp"]
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.19", features = ["session", "sealed-transfer", "attest-verify", "provision-integration", "crypto-provider", "acl-setup"] }
+vta-sdk = { path = "../vta-sdk", version = "0.20", features = ["session", "sealed-transfer", "attest-verify", "provision-integration", "crypto-provider", "acl-setup"] }
 affinidi-crypto = { workspace = true }
 base64 = { workspace = true }
 reqwest = { workspace = true }

--- a/pnm-cli/src/cli.rs
+++ b/pnm-cli/src/cli.rs
@@ -11,11 +11,19 @@ use clap::{Parser, Subcommand, ValueEnum};
 /// Transport to use when connecting to the VTA.
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, ValueEnum)]
 pub(crate) enum TransportOpt {
-    /// Prefer DIDComm when the VTA advertises it, else REST.
+    /// Prefer TSP when the VTA advertises it, else DIDComm, else REST.
+    /// Falls back loudly (a WARN naming the mediator) if an advertised TSP
+    /// endpoint doesn't answer.
     #[default]
     Auto,
-    /// Force REST even when DIDComm is advertised — recovers a VTA whose
-    /// mediator is unreachable.
+    /// Force TSP. Fails — rather than falling back — if the VTA advertises no
+    /// `#tsp` service or its TSP mediator doesn't answer.
+    Tsp,
+    /// Force DIDComm, ignoring an advertised `#tsp`. Recovers a VTA whose TSP
+    /// endpoint is broken but whose mediator is healthy.
+    Didcomm,
+    /// Force REST even when a mediator transport is advertised — recovers a VTA
+    /// whose mediator is unreachable.
     Rest,
 }
 
@@ -23,6 +31,8 @@ impl From<TransportOpt> for vta_sdk::session::TransportChoice {
     fn from(opt: TransportOpt) -> Self {
         match opt {
             TransportOpt::Auto => Self::Auto,
+            TransportOpt::Tsp => Self::Tsp,
+            TransportOpt::Didcomm => Self::Didcomm,
             TransportOpt::Rest => Self::Rest,
         }
     }
@@ -67,9 +77,10 @@ pub(crate) struct Cli {
     #[arg(long, global = true)]
     pub(crate) json: bool,
 
-    /// Force a transport instead of auto-selecting. `rest` skips DIDComm even
-    /// when the VTA advertises it — the recovery path when a mediator is
-    /// unreachable.
+    /// Force a transport instead of auto-selecting. Auto prefers TSP, then
+    /// DIDComm, then REST. `tsp` / `didcomm` pin a mediator transport and fail
+    /// rather than fall back; `rest` skips both — the recovery path when a
+    /// mediator is unreachable.
     #[arg(long, value_enum, default_value_t = TransportOpt::Auto, global = true)]
     pub(crate) transport: TransportOpt,
 

--- a/vta-audit/Cargo.toml
+++ b/vta-audit/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-audit"
 description = "Structured audit logging for the VTA — the `audit!` tracing macro plus the audit-keyspace persistence helpers"
 readme = "README.md"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -12,6 +12,6 @@ repository.workspace = true
 
 [dependencies]
 vti-common = { path = "../vti-common", version = "0.11" }
-vta-sdk = { path = "../vta-sdk", version = "0.19" }
+vta-sdk = { path = "../vta-sdk", version = "0.20" }
 tracing = { workspace = true }
 uuid = { workspace = true }

--- a/vta-backup/Cargo.toml
+++ b/vta-backup/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-backup"
 description = "VTA backup/restore subsystem — encrypted full-state export/import, the sealed backup-bundle store, and its TTL sweeper"
 readme = "README.md"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -19,7 +19,7 @@ tee = ["vta-config/tee", "dep:async-trait"]
 
 [dependencies]
 vti-common = { path = "../vti-common", version = "0.11" }
-vta-sdk = { path = "../vta-sdk", version = "0.19" }
+vta-sdk = { path = "../vta-sdk", version = "0.20" }
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.1" }
 vta-keys = { path = "../vta-keys", version = "0.1" }
 vta-config = { path = "../vta-config", version = "0.1" }

--- a/vta-cli-common/Cargo.toml
+++ b/vta-cli-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-cli-common"
 description = "Shared CLI command handlers and rendering helpers for VTA CLIs"
 readme = "README.md"
-version = "0.10.14"
+version = "0.10.15"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -16,7 +16,7 @@ repository.workspace = true
 agent-names = ["vta-sdk/agent-names"]
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.19", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.20", features = [
   "client",
   "sealed-transfer",
   "provision-integration",

--- a/vta-keys/Cargo.toml
+++ b/vta-keys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-keys"
 description = "VTA key management — master-seed storage, BIP-32 key derivation, key wrapping, and the seed-store backend selection"
 readme = "README.md"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -29,7 +29,7 @@ vta-keyspaces = { path = "../vta-keyspaces", version = "0.1" }
 vta-config = { path = "../vta-config", version = "0.1" }
 vti-common = { path = "../vti-common", version = "0.11" }
 vti-secrets = { path = "../vti-secrets", version = "0.1" }
-vta-sdk = { path = "../vta-sdk", version = "0.19", features = ["sealed-transfer"] }
+vta-sdk = { path = "../vta-sdk", version = "0.20", features = ["sealed-transfer"] }
 affinidi-tdk = { workspace = true }
 affinidi-crypto = { workspace = true }
 ed25519-dalek = { workspace = true }

--- a/vta-mcp/Cargo.toml
+++ b/vta-mcp/Cargo.toml
@@ -10,7 +10,7 @@ repository.workspace = true
 publish = false
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.19", features = ["client", "session", "sealed-transfer", "didcomm", "vp", "crypto-provider"] }
+vta-sdk = { path = "../vta-sdk", version = "0.20", features = ["client", "session", "sealed-transfer", "didcomm", "vp", "crypto-provider"] }
 rmcp = { version = "1.7", features = ["server", "transport-io", "macros", "schemars"] }
 schemars = "1"
 tokio = { workspace = true }

--- a/vta-mobile-core/Cargo.toml
+++ b/vta-mobile-core/Cargo.toml
@@ -61,7 +61,7 @@ affinidi-messaging-didcomm = "0.15"
 # `vta-sdk::DIDCommSession` (connect + receive_next) so the mobile approver can
 # pull VTA-pushed step-up approve-requests off the mediator — reusing the SDK
 # the VTA uses rather than reimplementing the affinidi mediator protocol.
-vta-sdk = { path = "../vta-sdk", version = "0.19", features = ["session", "tsp"] }
+vta-sdk = { path = "../vta-sdk", version = "0.20", features = ["session", "tsp"] }
 # iOS has no native trust store that `rustls-native-certs` can read, so the
 # mediator WebSocket (tokio-tungstenite, via affinidi-messaging-sdk) fails with
 # "no native root CA certificates found". Declaring tokio-tungstenite here with

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.19.28"
+version = "0.20.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/client/backup_descriptors.rs
+++ b/vta-sdk/src/client/backup_descriptors.rs
@@ -192,6 +192,14 @@ impl VtaClient {
                 base_url,
                 auth,
             } => (client, base_url, auth),
+            #[cfg(feature = "tsp")]
+            Transport::Tsp { .. } => {
+                return Err(VtaError::Validation(
+                    "backup descriptor pattern is REST-only; \
+                     this client is on TSP transport"
+                        .into(),
+                ));
+            }
             #[cfg(feature = "session")]
             Transport::DIDComm { .. } => {
                 return Err(VtaError::Validation(
@@ -256,6 +264,10 @@ impl VtaClient {
                     "DIDComm transport has no REST client for blob download".into(),
                 )
             })?,
+            #[cfg(feature = "tsp")]
+            Transport::Tsp { rest_client, .. } => rest_client.as_ref().ok_or_else(|| {
+                VtaError::Validation("TSP transport has no REST client for blob download".into())
+            })?,
         };
         let resp = client
             .get(transport_url)
@@ -284,6 +296,10 @@ impl VtaClient {
             #[cfg(feature = "session")]
             Transport::DIDComm { rest_client, .. } => rest_client.as_ref().ok_or_else(|| {
                 VtaError::Validation("DIDComm transport has no REST client for blob upload".into())
+            })?,
+            #[cfg(feature = "tsp")]
+            Transport::Tsp { rest_client, .. } => rest_client.as_ref().ok_or_else(|| {
+                VtaError::Validation("TSP transport has no REST client for blob upload".into())
             })?,
         };
         let resp = client

--- a/vta-sdk/src/client/bootstrap.rs
+++ b/vta-sdk/src/client/bootstrap.rs
@@ -56,6 +56,16 @@ impl VtaClient {
                 )
                 .await
             }
+            // `provision_integration_didcomm` speaks the DIDComm
+            // `provision-integration/1.0` message, which has no TSP binding
+            // yet. Refuse plainly rather than send a frame the VTA cannot
+            // dispatch — the sealed bundle is too important to fail obscurely.
+            #[cfg(feature = "tsp")]
+            Transport::Tsp { .. } => Err(VtaError::UnsupportedTransport(
+                "provision-integration has no TSP binding yet; relay it over REST or \
+                 DIDComm:\n  <cli> --transport didcomm bootstrap provision-integration …"
+                    .into(),
+            )),
         }
     }
 }

--- a/vta-sdk/src/client/keys.rs
+++ b/vta-sdk/src/client/keys.rs
@@ -236,6 +236,10 @@ impl VtaClient {
             Transport::DIDComm { .. } => Err(VtaError::UnsupportedTransport(
                 "wrapping key not needed for DIDComm transport".into(),
             )),
+            #[cfg(feature = "tsp")]
+            Transport::Tsp { .. } => Err(VtaError::UnsupportedTransport(
+                "wrapping key not needed for TSP transport".into(),
+            )),
         }
     }
 

--- a/vta-sdk/src/client/mod.rs
+++ b/vta-sdk/src/client/mod.rs
@@ -48,6 +48,22 @@ pub(super) enum Transport {
         rest_client: Option<Client>,
         rest_url: Option<String>,
     },
+    /// TSP — the workspace's highest-preference transport.
+    ///
+    /// Carries the **Trust-Task** surface only ([`VtaClient::rpc_tt`]). The
+    /// VTA's TSP inbound dispatcher hands each unpacked payload straight to
+    /// `dispatch_trust_task_core`, so a trust task routes over TSP unchanged —
+    /// but the older DIDComm *protocol-message* surface ([`VtaClient::rpc`],
+    /// e.g. `key-management/1.0/sign-request`) has no TSP dispatcher behind it
+    /// and reports `UnsupportedTransport` naming DIDComm.
+    #[cfg(feature = "tsp")]
+    Tsp {
+        session: std::sync::Arc<crate::session::TspSession>,
+        vta_did: String,
+        mediator_did: String,
+        rest_client: Option<Client>,
+        rest_url: Option<String>,
+    },
 }
 
 /// HTTP/DIDComm client for the VTA service API.
@@ -133,6 +149,22 @@ pub(super) fn encode_path_segment(s: &str) -> String {
         .replace('#', "%23")
         .replace('?', "%3F")
         .replace('/', "%2F")
+}
+
+/// The error for a legacy DIDComm *protocol message* attempted over TSP.
+///
+/// TSP carries Trust Tasks; the VTA's TSP inbound dispatcher feeds every
+/// unpacked payload to `dispatch_trust_task_core` and has no handler for the
+/// older `key-management/1.0/*`-style protocol messages. Refusing here — rather
+/// than sending a frame the VTA would answer with an error, or silently doing
+/// nothing — names the transport that does serve the operation.
+#[cfg(feature = "tsp")]
+fn unsupported_over_tsp(msg_type: &str) -> VtaError {
+    VtaError::UnsupportedTransport(format!(
+        "'{msg_type}' is a DIDComm protocol message, which TSP does not carry \
+         (TSP carries Trust Tasks). Reach this operation over DIDComm:\n  \
+         <cli> --transport didcomm <command>"
+    ))
 }
 
 // ── REST helpers ────────────────────────────────────────────────────
@@ -265,6 +297,9 @@ impl VtaClient {
             Transport::Rest { auth, .. } => auth.lock().await.expires_at,
             #[cfg(feature = "session")]
             Transport::DIDComm { .. } => None,
+            // No token to expire: TSP authenticates by proven sender VID.
+            #[cfg(feature = "tsp")]
+            Transport::Tsp { .. } => None,
         }
     }
 
@@ -367,6 +402,70 @@ impl VtaClient {
         })
     }
 
+    /// Connect via **TSP** through a mediator — the transport-agnostic
+    /// counterpart to [`connect_didcomm`](Self::connect_didcomm), so consumers
+    /// switch transport by construction rather than by rewriting call sites.
+    ///
+    /// `mediator_did` is the VTA's `#tsp` (`TSPTransport`) service endpoint —
+    /// the mediator the VTA is a local account on. Get it from
+    /// [`resolve_vta_endpoint`](crate::session::resolve_vta_endpoint), which
+    /// reads it from that entry rather than assuming it matches the DIDComm
+    /// mediator.
+    ///
+    /// `rest_url` is an optional fallback for the REST-only operations
+    /// (`health()`, the descriptor uploads) exactly as on the DIDComm client.
+    ///
+    /// # What routes over TSP
+    ///
+    /// The **Trust-Task surface** — the VTA's TSP inbound dispatcher feeds each
+    /// unpacked payload to the same `dispatch_trust_task_core` spine REST and
+    /// DIDComm use, so those operations are byte-identical across transports.
+    /// The older DIDComm protocol-message surface (`key-management/1.0/*` and
+    /// friends) has no TSP dispatcher behind it and reports
+    /// [`VtaError::UnsupportedTransport`] naming DIDComm — deliberately, rather
+    /// than sending a frame the VTA would answer with an error.
+    ///
+    /// # Authentication
+    ///
+    /// None to perform. TSP `unpack` yields a cryptographically **proven**
+    /// sender VID, which the VTA resolves straight to its ACL grant — the same
+    /// intrinsic-sender model as DIDComm authcrypt. There is no challenge, no
+    /// bearer token, and no holder proof inside the document; the REST token
+    /// dance has no TSP analogue. [`set_token`](Self::set_token) is a no-op
+    /// here for that reason.
+    ///
+    /// # You MUST call [`shutdown`](Self::shutdown) when done
+    ///
+    /// The same live-session leak contract as
+    /// [`connect_didcomm`](Self::connect_didcomm): the mediator permits one
+    /// websocket per DID, so a leaked session makes the next connect for this
+    /// DID fight the old one.
+    #[cfg(feature = "tsp")]
+    pub async fn connect_tsp(
+        client_did: &str,
+        private_key_multibase: &str,
+        vta_did: &str,
+        mediator_did: &str,
+        rest_url: Option<String>,
+    ) -> Result<Self, VtaError> {
+        let session =
+            crate::session::TspSession::connect(client_did, private_key_multibase, mediator_did)
+                .await
+                .map_err(|e| VtaError::TspTransport(e.to_string()))?;
+
+        let rest_client = rest_url.as_ref().map(|_| crate::http::rest_client());
+
+        Ok(Self {
+            transport: Transport::Tsp {
+                session: std::sync::Arc::new(session),
+                vta_did: vta_did.to_string(),
+                mediator_did: mediator_did.to_string(),
+                rest_client,
+                rest_url: rest_url.map(|u| u.trim_end_matches('/').to_string()),
+            },
+        })
+    }
+
     /// Set the Bearer token for authenticated requests (REST only, no-op for DIDComm).
     ///
     /// Can be called from sync or async contexts. For async contexts, use
@@ -381,6 +480,9 @@ impl VtaClient {
             }
             #[cfg(feature = "session")]
             Transport::DIDComm { .. } => {}
+            // Intrinsic-sender auth — there is no bearer token on this path.
+            #[cfg(feature = "tsp")]
+            Transport::Tsp { .. } => {}
         }
     }
 
@@ -392,6 +494,8 @@ impl VtaClient {
             }
             #[cfg(feature = "session")]
             Transport::DIDComm { .. } => {}
+            #[cfg(feature = "tsp")]
+            Transport::Tsp { .. } => {}
         }
     }
 
@@ -411,6 +515,8 @@ impl VtaClient {
             Transport::Rest { base_url, .. } => Some(base_url),
             #[cfg(feature = "session")]
             Transport::DIDComm { rest_url, .. } => rest_url.as_deref(),
+            #[cfg(feature = "tsp")]
+            Transport::Tsp { rest_url, .. } => rest_url.as_deref(),
         }
     }
 
@@ -424,6 +530,8 @@ impl VtaClient {
             Transport::Rest { .. } => None,
             #[cfg(feature = "session")]
             Transport::DIDComm { session, .. } => Some(&session.vta_did),
+            #[cfg(feature = "tsp")]
+            Transport::Tsp { vta_did, .. } => Some(vta_did),
         }
     }
 
@@ -440,6 +548,10 @@ impl VtaClient {
             Transport::DIDComm {
                 session, rest_url, ..
             } => rest_url.as_deref().unwrap_or(&session.vta_did),
+            #[cfg(feature = "tsp")]
+            Transport::Tsp {
+                vta_did, rest_url, ..
+            } => rest_url.as_deref().unwrap_or(vta_did),
         }
     }
 
@@ -454,6 +566,12 @@ impl VtaClient {
     pub async fn shutdown(&self) {
         #[cfg(feature = "session")]
         if let Transport::DIDComm { session, .. } = &self.transport {
+            session.shutdown().await;
+        }
+        // Same one-websocket-per-DID contract as DIDComm: a leaked TSP session
+        // makes the next connect for this DID fight the old one.
+        #[cfg(feature = "tsp")]
+        if let Transport::Tsp { session, .. } = &self.transport {
             session.shutdown().await;
         }
     }
@@ -706,6 +824,8 @@ impl VtaClient {
                     .send_and_wait(msg_type, body, result_type, timeout)
                     .await
             }
+            #[cfg(feature = "tsp")]
+            Transport::Tsp { .. } => Err(unsupported_over_tsp(msg_type)),
         }
     }
 
@@ -736,6 +856,8 @@ impl VtaClient {
                     .await?;
                 Ok(())
             }
+            #[cfg(feature = "tsp")]
+            Transport::Tsp { .. } => Err(unsupported_over_tsp(msg_type)),
         }
     }
 
@@ -771,6 +893,15 @@ impl VtaClient {
                 serde_json::from_value(payload)
                     .map_err(|e| VtaError::Protocol(format!("trust-task response decode: {e}")))
             }
+            // Same trust-task path as DIDComm — `dispatch_trust_task` picks the
+            // transport, so this surface needed no per-operation work to reach
+            // TSP.
+            #[cfg(feature = "tsp")]
+            Transport::Tsp { .. } => {
+                let payload = self.dispatch_trust_task(tt_uri, payload, timeout).await?;
+                serde_json::from_value(payload)
+                    .map_err(|e| VtaError::Protocol(format!("trust-task response decode: {e}")))
+            }
         }
     }
 
@@ -796,6 +927,11 @@ impl VtaClient {
             }
             #[cfg(feature = "session")]
             Transport::DIDComm { .. } => {
+                let _ = self.dispatch_trust_task(tt_uri, payload, timeout).await?;
+                Ok(())
+            }
+            #[cfg(feature = "tsp")]
+            Transport::Tsp { .. } => {
                 let _ = self.dispatch_trust_task(tt_uri, payload, timeout).await?;
                 Ok(())
             }
@@ -848,6 +984,42 @@ impl VtaClient {
                     return Err(VtaError::from_http(status, body));
                 }
                 let response_doc: serde_json::Value = resp.json().await?;
+                Self::extract_trust_task_payload(response_doc)
+            }
+            // The whole typed VTA surface over TSP. The VTA's inbound
+            // dispatcher hands the unpacked payload straight to
+            // `dispatch_trust_task_core` — the same spine REST and DIDComm use
+            // — so the request and reply documents are byte-identical across
+            // all three transports. No envelope wrapper: TSP carries the
+            // Trust-Task bytes directly.
+            #[cfg(feature = "tsp")]
+            Transport::Tsp {
+                session,
+                vta_did,
+                mediator_did,
+                ..
+            } => {
+                // `issuer`/`recipient` are set here and not in the shared `doc`
+                // above because only a mediator transport knows both DIDs; the
+                // REST leg posts to an already-addressed endpoint.
+                let mut doc = doc;
+                doc["issuer"] = serde_json::Value::String(session.client_did().to_string());
+                doc["recipient"] = serde_json::Value::String(vta_did.clone());
+                let body = serde_json::to_vec(&doc)
+                    .map_err(|e| VtaError::Protocol(format!("trust-task encode: {e}")))?;
+
+                let reply = session
+                    .request(
+                        vta_did,
+                        mediator_did,
+                        &body,
+                        std::time::Duration::from_secs(timeout),
+                    )
+                    .await
+                    .map_err(|e| VtaError::TspTransport(e.to_string()))?;
+
+                let response_doc: serde_json::Value = serde_json::from_str(&reply)
+                    .map_err(|e| VtaError::Protocol(format!("trust-task reply decode: {e}")))?;
                 Self::extract_trust_task_payload(response_doc)
             }
             #[cfg(feature = "session")]
@@ -926,6 +1098,16 @@ impl VtaClient {
                  (REST clients hold no key material to authcrypt with)"
                     .into(),
             )),
+            // A TSP client *has* key material, but the seal is specifically a
+            // `didcomm-authcrypt` JWE — a wire format tied to the DIDComm
+            // stack, not to holding keys. Producing one here would need the
+            // DIDComm packer this transport deliberately does not carry.
+            #[cfg(feature = "tsp")]
+            Transport::Tsp { .. } => Err(VtaError::UnsupportedTransport(
+                "sealing a vault secret produces a didcomm-authcrypt JWE, which \
+                 requires the DIDComm transport:\n  <cli> --transport didcomm <command>"
+                    .into(),
+            )),
         }
     }
 
@@ -939,6 +1121,12 @@ impl VtaClient {
             Transport::DIDComm { session, .. } => session.open_from_vta(jwe).await,
             Transport::Rest { .. } => Err(VtaError::UnsupportedTransport(
                 "opening a sealed vault secret requires the DIDComm transport".into(),
+            )),
+            #[cfg(feature = "tsp")]
+            Transport::Tsp { .. } => Err(VtaError::UnsupportedTransport(
+                "opening a sealed vault secret unwraps a didcomm-authcrypt JWE, which \
+                 requires the DIDComm transport:\n  <cli> --transport didcomm <command>"
+                    .into(),
             )),
         }
     }
@@ -955,6 +1143,14 @@ impl VtaClient {
         match &self.transport {
             #[cfg(feature = "session")]
             Transport::DIDComm { session, .. } => session.receive_next(timeout_secs).await,
+            // TSP has a real receive path: `TspSession::receive_next` hands
+            // back frames that matched no in-flight `request` — i.e. exactly
+            // the unsolicited pushes this method is for.
+            #[cfg(feature = "tsp")]
+            Transport::Tsp { session, .. } => session
+                .receive_next(timeout_secs)
+                .await
+                .map_err(|e| VtaError::TspTransport(e.to_string())),
             Transport::Rest { .. } => Err(VtaError::UnsupportedTransport(
                 "receiving inbound messages requires the DIDComm transport".into(),
             )),
@@ -991,6 +1187,14 @@ impl VtaClient {
             Transport::Rest { .. } => Err(VtaError::UnsupportedTransport(
                 "one-way DIDComm send requires the DIDComm transport \
                  (REST clients hold no key material to authcrypt with)"
+                    .into(),
+            )),
+            // Named for the DIDComm wire format it emits. TSP's own
+            // fire-and-forget send is `TspSession::send_document`.
+            #[cfg(feature = "tsp")]
+            Transport::Tsp { .. } => Err(VtaError::UnsupportedTransport(
+                "one-way DIDComm send requires the DIDComm transport:\n  \
+                 <cli> --transport didcomm <command>"
                     .into(),
             )),
         }
@@ -1038,6 +1242,20 @@ impl VtaClient {
                     "health check not available via DIDComm (no REST URL)".into(),
                 )),
             },
+            #[cfg(feature = "tsp")]
+            Transport::Tsp {
+                rest_client,
+                rest_url,
+                ..
+            } => match (rest_client, rest_url) {
+                (Some(client), Some(url)) => {
+                    let resp = client.get(format!("{url}/health")).send().await?;
+                    Self::handle_response(resp).await
+                }
+                _ => Err(VtaError::UnsupportedTransport(
+                    "health check not available via TSP (no REST URL)".into(),
+                )),
+            },
         }
     }
 
@@ -1062,6 +1280,12 @@ impl VtaClient {
             #[cfg(feature = "session")]
             Transport::DIDComm { .. } => Err(VtaError::UnsupportedTransport(
                 "step-up policy read is REST-only in the SDK".into(),
+            )),
+            #[cfg(feature = "tsp")]
+            Transport::Tsp { .. } => Err(VtaError::UnsupportedTransport(
+                "step-up policy read is REST-only in the SDK; over TSP send the \
+                 `auth/step-up/policy/0.2` trust task instead"
+                    .into(),
             )),
         }
     }
@@ -1092,6 +1316,12 @@ impl VtaClient {
             Transport::DIDComm { .. } => Err(VtaError::UnsupportedTransport(
                 "step-up policy set is REST-only in the SDK; send the \
                  auth/step-up/policy/0.2 trust-task over DIDComm instead"
+                    .into(),
+            )),
+            #[cfg(feature = "tsp")]
+            Transport::Tsp { .. } => Err(VtaError::UnsupportedTransport(
+                "step-up policy set is REST-only in the SDK; send the \
+                 auth/step-up/policy/0.2 trust-task over TSP instead"
                     .into(),
             )),
         }
@@ -1140,6 +1370,10 @@ impl VtaClient {
                 // DIDComm sessions are always authenticated
                 Ok(true)
             }
+            // Same reasoning: the sender VID is proven by the TSP unpack, so
+            // there is no token that could be invalid or expired.
+            #[cfg(feature = "tsp")]
+            Transport::Tsp { .. } => Ok(true),
         }
     }
 }

--- a/vta-sdk/src/error.rs
+++ b/vta-sdk/src/error.rs
@@ -51,6 +51,14 @@ pub enum VtaError {
     #[error("didcomm transport error: {0}")]
     DidcommTransport(String),
 
+    /// TSP transport failure (seal/route/websocket). Network-ish — caller may
+    /// want to retry. Kept distinct from [`Self::DidcommTransport`] rather than
+    /// folded into it: the two transports fail for different reasons and have
+    /// different recovery flags, and one shared message is what R6.4 exists to
+    /// prevent.
+    #[error("tsp transport error: {0}")]
+    TspTransport(String),
+
     /// Remote endpoint returned a DIDComm problem-report whose `code`
     /// did not match any of the standard `e.p.msg.*` taxonomy variants
     /// (which map to the typed REST-aligned variants above). Inspect
@@ -348,6 +356,11 @@ impl VtaError {
             Self::DidcommTransport(_) => {
                 Some("Mediator or peer unreachable. Retry after checking mediator connectivity.")
             }
+            Self::TspTransport(_) => Some(
+                "The VTA's TSP mediator is unreachable or rejected the frame. Retry, or \
+                 reach the VTA over another transport: `--transport didcomm` / \
+                 `--transport rest`.",
+            ),
             #[cfg(feature = "client")]
             Self::Network(_) => Some(
                 "Network error reaching the VTA. Confirm the URL is correct and the \

--- a/vta-sdk/src/protocol/mod.rs
+++ b/vta-sdk/src/protocol/mod.rs
@@ -169,6 +169,10 @@ impl VtaClient {
             crate::client::Transport::DIDComm { .. } => Err(VtaError::UnsupportedTransport(
                 "enable_didcomm is REST-only".into(),
             )),
+            #[cfg(feature = "tsp")]
+            crate::client::Transport::Tsp { .. } => Err(VtaError::UnsupportedTransport(
+                "enable_didcomm is REST-only".into(),
+            )),
         }
     }
 
@@ -191,6 +195,10 @@ impl VtaClient {
             }
             #[cfg(feature = "session")]
             crate::client::Transport::DIDComm { .. } => Err(VtaError::UnsupportedTransport(
+                "didcomm status is REST-only in the SDK".into(),
+            )),
+            #[cfg(feature = "tsp")]
+            crate::client::Transport::Tsp { .. } => Err(VtaError::UnsupportedTransport(
                 "didcomm status is REST-only in the SDK".into(),
             )),
         }

--- a/vta-sdk/src/provision_client/resolve.rs
+++ b/vta-sdk/src/provision_client/resolve.rs
@@ -1,18 +1,48 @@
 //! Thin wrapper over [`crate::session::resolve_vta_endpoint`] that presents
-//! a flat result type and distinguishes "DIDComm only" / "REST only" /
-//! "both" for downstream consumers.
+//! a flat result type and distinguishes "TSP" / "DIDComm" / "REST" / several
+//! at once, for downstream consumers.
 
 use crate::session::{VtaEndpoint, resolve_vta_endpoint};
 
 use super::error::ProvisionError;
 
-#[derive(Clone, Debug)]
+/// Everything a VTA's DID document advertises, flattened.
+///
+/// Deliberately **not** "the transport we chose": every field is independently
+/// populated, so a *probe* can report what a VTA offers without that being what
+/// it connected over. A UI panel needs exactly this split — conflating the two
+/// is what made a TSP-enabled VTA render as "DIDComm · only transport offered".
+#[derive(Clone, Debug, Default)]
 pub struct ResolvedVta {
     pub vta_did: String,
+    /// TSP mediator DID advertised via the `#tsp` (`TSPTransport`) service, if
+    /// any. Read from that entry — *not* assumed to equal `mediator_did`, even
+    /// though a dual-transport VTA usually points both at one mediator.
+    pub tsp_mediator_did: Option<String>,
     /// DIDComm mediator DID advertised in the VTA document, if any.
     pub mediator_did: Option<String>,
     /// REST URL advertised via the `#vta-rest` service, if any.
     pub rest_url: Option<String>,
+}
+
+impl ResolvedVta {
+    /// Every transport this VTA advertises, in preference order — what a probe
+    /// prints as "transports offered".
+    #[must_use]
+    pub fn advertised(&self) -> Vec<crate::protocol::matching::Protocol> {
+        use crate::protocol::matching::Protocol;
+        let mut out = Vec::with_capacity(3);
+        if self.tsp_mediator_did.is_some() {
+            out.push(Protocol::Tsp);
+        }
+        if self.mediator_did.is_some() {
+            out.push(Protocol::Didcomm);
+        }
+        if self.rest_url.is_some() {
+            out.push(Protocol::Rest);
+        }
+        out
+    }
 }
 
 /// Resolve a VTA DID and extract its transport endpoints.
@@ -26,19 +56,83 @@ pub async fn resolve_vta(vta_did: &str) -> Result<ResolvedVta, ProvisionError> {
             vta_did: vta_did.to_string(),
             message: e.to_string(),
         })? {
+        VtaEndpoint::Tsp {
+            vta_did,
+            mediator_did,
+            didcomm_mediator_did,
+            rest_url,
+        } => Ok(ResolvedVta {
+            vta_did,
+            tsp_mediator_did: Some(mediator_did),
+            mediator_did: didcomm_mediator_did,
+            rest_url,
+        }),
         VtaEndpoint::DIDComm {
             vta_did,
             mediator_did,
             rest_url,
         } => Ok(ResolvedVta {
             vta_did,
+            tsp_mediator_did: None,
             mediator_did: Some(mediator_did),
             rest_url,
         }),
         VtaEndpoint::Rest { url } => Ok(ResolvedVta {
             vta_did: vta_did.to_string(),
+            tsp_mediator_did: None,
             mediator_did: None,
             rest_url: Some(url),
         }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::matching::Protocol;
+
+    fn resolved(tsp: Option<&str>, didcomm: Option<&str>, rest: Option<&str>) -> ResolvedVta {
+        ResolvedVta {
+            vta_did: "did:webvh:scid:vta.example".into(),
+            tsp_mediator_did: tsp.map(str::to_string),
+            mediator_did: didcomm.map(str::to_string),
+            rest_url: rest.map(str::to_string),
+        }
+    }
+
+    /// The split this type exists for: a probe reports *everything* a VTA
+    /// advertises, independently of which transport it would connect over.
+    /// Conflating the two is what rendered a TSP-enabled VTA as
+    /// "DIDComm · only transport offered".
+    #[test]
+    fn a_dual_transport_vta_reports_every_transport_it_offers() {
+        let r = resolved(
+            Some("did:webvh:scid:mediator.example"),
+            Some("did:webvh:scid:mediator.example"),
+            Some("https://vta.example"),
+        );
+        assert_eq!(
+            r.advertised(),
+            vec![Protocol::Tsp, Protocol::Didcomm, Protocol::Rest]
+        );
+    }
+
+    /// TSP is reported even when it is the *only* transport — the shape that
+    /// previously resolved to a REST URL guessed from the DID's own domain.
+    #[test]
+    fn a_tsp_only_vta_reports_tsp() {
+        let r = resolved(Some("did:webvh:scid:mediator.example"), None, None);
+        assert_eq!(r.advertised(), vec![Protocol::Tsp]);
+    }
+
+    #[test]
+    fn advertised_is_in_preference_order() {
+        let r = resolved(None, Some("did:webvh:scid:m"), Some("https://vta.example"));
+        assert_eq!(r.advertised(), vec![Protocol::Didcomm, Protocol::Rest]);
+    }
+
+    #[test]
+    fn a_vta_advertising_nothing_reports_nothing() {
+        assert!(resolved(None, None, None).advertised().is_empty());
     }
 }

--- a/vta-sdk/src/provision_client/runner.rs
+++ b/vta-sdk/src/provision_client/runner.rs
@@ -546,6 +546,7 @@ mod tests {
     fn resolved(mediator_did: Option<&str>, rest_url: Option<&str>) -> ResolvedVta {
         ResolvedVta {
             vta_did: "did:webvh:vta.test".into(),
+            tsp_mediator_did: None,
             mediator_did: mediator_did.map(str::to_string),
             rest_url: rest_url.map(str::to_string),
         }

--- a/vta-sdk/src/session.rs
+++ b/vta-sdk/src/session.rs
@@ -6,7 +6,7 @@ use affinidi_tdk::didcomm::Message;
 use affinidi_tdk::secrets_resolver::SecretsResolver;
 use serde::{Deserialize, Serialize};
 use serde_json;
-use tracing::debug;
+use tracing::{debug, warn};
 
 use crate::credentials::CredentialBundle;
 use crate::protocols::auth::{AuthenticateResponse, ChallengeRequest, ChallengeResponse};
@@ -560,7 +560,17 @@ impl SessionStore {
                 mediator_did,
                 rest_url,
             } => (vta_did, mediator_did, rest_url),
-            VtaEndpoint::Rest { .. } => {
+            // A TSP-advertising VTA may *also* advertise DIDComm. This function
+            // is explicitly the DIDComm path (its caller wants a
+            // `DIDCommSession`), so take the DIDComm mediator out of the TSP
+            // result rather than refusing a VTA that plainly offers one.
+            VtaEndpoint::Tsp {
+                vta_did,
+                didcomm_mediator_did: Some(mediator_did),
+                rest_url,
+                ..
+            } => (vta_did, mediator_did, rest_url),
+            VtaEndpoint::Tsp { .. } | VtaEndpoint::Rest { .. } => {
                 return Err(format!(
                     "VTA '{session_vta_did}' does not advertise a DIDComm service endpoint. \
                      Use SessionStore::ensure_authenticated for REST, or \
@@ -632,13 +642,25 @@ impl SessionStore {
 
     /// Like [`connect`](Self::connect) but with an explicit transport choice.
     ///
-    /// [`TransportChoice::Auto`] keeps the priority order documented on
-    /// [`connect`]. Its DIDComm connects are bounded (see
-    /// [`DIDCOMM_CONNECT_TIMEOUT_DEFAULT`]): an unreachable mediator errors out
-    /// pointing at `--transport rest` rather than hanging.
+    /// [`TransportChoice::Auto`] implements the workspace preference order —
+    /// **TSP > DIDComm > REST** — and falls back *loudly*; see the enum's docs
+    /// for why that policy and not a hard failure. Every mediator connect is
+    /// bounded ([`TSP_CONNECT_TIMEOUT_DEFAULT`],
+    /// [`DIDCOMM_CONNECT_TIMEOUT_DEFAULT`]) so an unreachable mediator errors
+    /// out naming a recovery flag rather than hanging — without that ceiling,
+    /// `Auto` preferring TSP would convert today's working DIDComm story into
+    /// an indefinite hang with no output.
+    ///
+    /// [`TransportChoice::Tsp`] forces TSP: errors if the VTA advertises no
+    /// `#tsp` service (naming what it *does* advertise), and errors rather than
+    /// falling back if the connect times out.
+    ///
+    /// [`TransportChoice::Didcomm`] forces DIDComm, ignoring an advertised
+    /// `#tsp` — the recovery path when TSP is broken but the DIDComm mediator
+    /// is healthy.
     ///
     /// [`TransportChoice::Rest`] forces REST — ignoring the mediator hint and
-    /// any advertised DIDComm — using `url_override`, else the `#vta-rest`
+    /// any advertised TSP/DIDComm — using `url_override`, else the `#vta-rest`
     /// service on the VTA's DID document. Errors if the VTA advertises neither
     /// and no `url_override` was given; unlike the auto path it will *not* fall
     /// back to a URL synthesized from the DID's domain, which for a hosted
@@ -680,8 +702,13 @@ impl SessionStore {
             return Ok(client);
         }
 
-        // Priority 1: Explicit mediator DID from config → DIDComm directly
-        if let Some(mediator_did) = mediator_did_hint {
+        // Priority 1: Explicit mediator DID from config → DIDComm directly.
+        // Skipped under `--transport tsp`: the hint names a *DIDComm* mediator,
+        // so honouring it would silently serve DIDComm to an operator who
+        // explicitly asked for TSP.
+        if let Some(mediator_did) = mediator_did_hint
+            && transport != TransportChoice::Tsp
+        {
             debug!(mediator_did, "connecting via DIDComm (config mediator_did)");
             let client = connect_didcomm_bounded(
                 &session.client_did,
@@ -696,11 +723,95 @@ impl SessionStore {
 
         // Priority 2: Resolve VTA DID for transport selection
         match resolve_vta_endpoint(&session_vta_did).await {
+            Ok(VtaEndpoint::Tsp {
+                vta_did,
+                mediator_did,
+                didcomm_mediator_did,
+                rest_url,
+            }) => {
+                // Forced DIDComm ignores the advertised `#tsp` entirely.
+                if transport == TransportChoice::Didcomm {
+                    let Some(didcomm_mediator_did) = didcomm_mediator_did else {
+                        return Err(no_didcomm_endpoint_error(
+                            &vta_did,
+                            true,
+                            rest_url.is_some(),
+                        ));
+                    };
+                    debug!("connecting via DIDComm (forced --transport didcomm)");
+                    let client = connect_didcomm_bounded(
+                        &session.client_did,
+                        &session.private_key,
+                        &vta_did,
+                        &didcomm_mediator_did,
+                        rest_url,
+                    )
+                    .await?;
+                    return Ok(client);
+                }
+
+                match connect_tsp_bounded(
+                    &session.client_did,
+                    &session.private_key,
+                    &vta_did,
+                    &mediator_did,
+                    rest_url.clone(),
+                )
+                .await
+                {
+                    Ok(client) => return Ok(client),
+                    // Forced TSP never falls back — that is the whole point of
+                    // asking for it by name.
+                    Err(e) if transport == TransportChoice::Tsp => return Err(e),
+                    Err(e) => {
+                        // `Auto` falls back, but never quietly: a TSP
+                        // deployment that never works must not look like one
+                        // that was never enabled. See `TransportChoice`.
+                        warn!(
+                            vta_did = %vta_did,
+                            tsp_mediator_did = %mediator_did,
+                            error = %e,
+                            "TSP is advertised but the connect failed; falling back \
+                             (use --transport tsp to make this fatal, or \
+                             --transport didcomm to stop trying TSP)"
+                        );
+                    }
+                }
+
+                if let Some(didcomm_mediator_did) = didcomm_mediator_did {
+                    debug!("connecting via DIDComm (fallback from TSP)");
+                    let client = connect_didcomm_bounded(
+                        &session.client_did,
+                        &session.private_key,
+                        &vta_did,
+                        &didcomm_mediator_did,
+                        rest_url,
+                    )
+                    .await?;
+                    return Ok(client);
+                }
+                if let Some(url) = rest_url {
+                    debug!(url = %url, "connecting via REST (fallback from TSP)");
+                    let token = self.ensure_authenticated(&url, key).await?;
+                    let client = crate::client::VtaClient::new(&url);
+                    client.set_token(token);
+                    return Ok(client);
+                }
+                // TSP-only VTA whose TSP is down: there is nothing to fall back
+                // to, so report the TSP failure rather than a generic one.
+                return Err(tsp_unreachable_error(&mediator_did, tsp_connect_timeout()).into());
+            }
             Ok(VtaEndpoint::DIDComm {
                 vta_did,
                 mediator_did,
                 rest_url,
             }) => {
+                // `--transport tsp` against a VTA that only speaks DIDComm is an
+                // error, not a silent downgrade — R6.4: name what it *does*
+                // advertise so the operator can pick.
+                if transport == TransportChoice::Tsp {
+                    return Err(no_tsp_endpoint_error(&vta_did, true, rest_url.is_some()));
+                }
                 debug!("connecting via DIDComm");
                 let client = connect_didcomm_bounded(
                     &session.client_did,
@@ -713,6 +824,12 @@ impl SessionStore {
                 return Ok(client);
             }
             Ok(VtaEndpoint::Rest { url }) => {
+                if transport == TransportChoice::Tsp {
+                    return Err(no_tsp_endpoint_error(&session_vta_did, false, true));
+                }
+                if transport == TransportChoice::Didcomm {
+                    return Err(no_didcomm_endpoint_error(&session_vta_did, false, true));
+                }
                 debug!(url = %url, "connecting via REST (from DID doc)");
                 let token = self.ensure_authenticated(&url, key).await?;
                 let client = crate::client::VtaClient::new(&url);
@@ -721,6 +838,23 @@ impl SessionStore {
             }
             Err(e) => {
                 debug!(error = %e, "DID resolution failed, trying URL-based fallback");
+                // A forced mediator transport cannot be served from a URL
+                // fallback — there is no mediator DID to route through — so
+                // stop here rather than silently continuing to the REST path.
+                if matches!(transport, TransportChoice::Tsp | TransportChoice::Didcomm) {
+                    return Err(format!(
+                        "--transport {}: could not resolve VTA DID '{session_vta_did}', so its \
+                         advertised transports are unknown: {e}\n\nRetry without forcing a \
+                         transport, or reach the VTA over REST:\n  \
+                         <cli> --transport rest --url https://vta.example.com <command>",
+                        if transport == TransportChoice::Tsp {
+                            "tsp"
+                        } else {
+                            "didcomm"
+                        }
+                    )
+                    .into());
+                }
             }
         }
 
@@ -1110,13 +1244,37 @@ pub async fn challenge_response(
 // ── DIDComm-preferred connection ─────────────────────────────────────
 
 /// Result of resolving a VTA DID's service endpoints.
+///
+/// Each variant names the transport the SDK would *connect over*, and carries
+/// the lower-preference endpoints alongside it so a caller that has to fall
+/// back does not re-resolve. Preference order is the workspace's:
+/// **TSP > DIDComm > REST**.
+///
+/// `#[non_exhaustive]`: this enum gained [`Tsp`](Self::Tsp) in 0.20 and may
+/// gain further transports. Match with a `_` arm.
+#[non_exhaustive]
 pub enum VtaEndpoint {
-    /// REST-only (no DIDCommMessaging service found).
+    /// No TSP or DIDComm service advertised.
     Rest { url: String },
-    /// DIDComm preferred, with optional REST fallback.
+    /// DIDComm advertised (but no TSP), with optional REST fallback.
     DIDComm {
         vta_did: String,
         mediator_did: String,
+        rest_url: Option<String>,
+    },
+    /// TSP advertised — the highest-preference transport.
+    ///
+    /// `mediator_did` is read from the `#tsp` (`TSPTransport`) entry, **not**
+    /// assumed to equal the DIDComm mediator. In a dual-transport deployment
+    /// they are usually the same mediator, but nothing requires that, and a
+    /// TSP-only node has no DIDComm entry to borrow from.
+    Tsp {
+        vta_did: String,
+        mediator_did: String,
+        /// The DIDComm mediator, when the VTA advertises that too — the
+        /// fallback [`TransportChoice::Auto`] drops to if the TSP connect
+        /// times out.
+        didcomm_mediator_did: Option<String>,
         rest_url: Option<String>,
     },
 }
@@ -1124,17 +1282,45 @@ pub enum VtaEndpoint {
 /// Operator transport selection for
 /// [`SessionStore::connect_with_transport`] (the `pnm`/`cnm` connect path).
 ///
-/// `#[non_exhaustive]`: TSP is the workspace's preferred transport
-/// (TSP > DIDComm > REST) and will land here as a variant, as may an
-/// explicit `Didcomm`. Match with a `_` arm.
+/// `#[non_exhaustive]`: further transports may land here. Match with a `_` arm.
+///
+/// # Auto's fallback policy
+///
+/// [`Auto`](Self::Auto) implements the workspace preference order
+/// **TSP > DIDComm > REST**, and **falls back loudly**: if the VTA advertises
+/// TSP but its mediator does not answer within
+/// [`TSP_CONNECT_TIMEOUT_DEFAULT`], `Auto` logs a `WARN` naming the mediator
+/// DID and the deadline, then tries DIDComm, then REST.
+///
+/// This is a deliberate choice between two bad options, recorded here because
+/// it is not recoverable from the code. Failing hard would make a
+/// dual-transport VTA *less* available than it is today — an operator whose
+/// TSP mediator broke would lose access to a VTA that still speaks DIDComm
+/// perfectly well, which is a regression caused purely by enabling TSP.
+/// Falling back *silently* is the other failure: a TSP deployment that never
+/// works would be invisible, and everyone would quietly run on DIDComm
+/// believing TSP was live. The `WARN` is what makes the fallback a diagnosis
+/// rather than a cover-up.
+///
+/// Operators who need the strict behaviour have it: [`Tsp`](Self::Tsp) never
+/// falls back.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum TransportChoice {
-    /// Prefer DIDComm when advertised, else REST. The default.
+    /// TSP when advertised, else DIDComm, else REST. The default.
     #[default]
     Auto,
-    /// Force REST, ignoring any advertised DIDComm. Recovery path when a VTA's
-    /// mediator is unreachable (auto would pick DIDComm and hang).
+    /// Force TSP. Errors — naming the transports the VTA *does* advertise — if
+    /// it advertises no `#tsp` service, and errors rather than falling back if
+    /// the TSP connect times out.
+    Tsp,
+    /// Force DIDComm, ignoring an advertised `#tsp`. The recovery path when a
+    /// VTA's TSP endpoint is broken but its DIDComm mediator is healthy;
+    /// previously this existed only by accident, as "whatever `Auto` picks".
+    Didcomm,
+    /// Force REST, ignoring any advertised TSP or DIDComm. Recovery path when a
+    /// VTA's mediator is unreachable (auto would pick a mediator transport and
+    /// hang).
     Rest,
 }
 
@@ -1152,18 +1338,41 @@ pub enum TransportChoice {
 const DIDCOMM_CONNECT_TIMEOUT_DEFAULT: Duration = Duration::from_secs(30);
 
 fn didcomm_connect_timeout() -> Duration {
-    parse_connect_timeout(std::env::var("VTA_DIDCOMM_CONNECT_TIMEOUT_SECS").ok())
+    parse_connect_timeout(
+        std::env::var("VTA_DIDCOMM_CONNECT_TIMEOUT_SECS").ok(),
+        DIDCOMM_CONNECT_TIMEOUT_DEFAULT,
+    )
 }
 
-/// Env-var parsing for [`didcomm_connect_timeout`], split out so it is
-/// testable without touching process environment. Garbage and `0` fall back to
-/// the default — a zero deadline would fail every connect instantly, which is
+/// How long a TSP connect may take before we give up.
+///
+/// The TSP websocket goes to the **same mediator** the DIDComm client does, and
+/// sits behind the same reconnect/backoff loop, so it needs the same ceiling
+/// for the same reason: without it, `Auto` preferring TSP would turn a working
+/// DIDComm-fallback story into an indefinite hang with no output — i.e.
+/// enabling TSP on a VTA would make it *less* reachable.
+///
+/// Its own env override rather than sharing the DIDComm one: an operator
+/// diagnosing a slow TSP mediator should be able to stretch that deadline
+/// without also loosening the DIDComm ceiling they rely on to fail fast.
+const TSP_CONNECT_TIMEOUT_DEFAULT: Duration = Duration::from_secs(30);
+
+fn tsp_connect_timeout() -> Duration {
+    parse_connect_timeout(
+        std::env::var("VTA_TSP_CONNECT_TIMEOUT_SECS").ok(),
+        TSP_CONNECT_TIMEOUT_DEFAULT,
+    )
+}
+
+/// Env-var parsing for the connect deadlines, split out so it is testable
+/// without touching process environment. Garbage and `0` fall back to
+/// `default` — a zero deadline would fail every connect instantly, which is
 /// worse than the hang it replaces.
-fn parse_connect_timeout(raw: Option<String>) -> Duration {
+fn parse_connect_timeout(raw: Option<String>, default: Duration) -> Duration {
     raw.and_then(|v| v.trim().parse::<u64>().ok())
         .filter(|secs| *secs > 0)
         .map(Duration::from_secs)
-        .unwrap_or(DIDCOMM_CONNECT_TIMEOUT_DEFAULT)
+        .unwrap_or(default)
 }
 
 /// [`crate::client::VtaClient::connect_didcomm`] under a deadline.
@@ -1224,16 +1433,150 @@ fn no_rest_endpoint_error(vta_did: &str) -> Box<dyn std::error::Error> {
     .into()
 }
 
+/// [`crate::client::VtaClient::connect_tsp`] under a deadline.
+///
+/// The TSP twin of [`connect_didcomm_bounded`]; see
+/// [`TSP_CONNECT_TIMEOUT_DEFAULT`] for why the ceiling is not optional.
+#[cfg_attr(not(feature = "tsp"), allow(unused_variables))]
+async fn connect_tsp_bounded(
+    client_did: &str,
+    private_key: &str,
+    vta_did: &str,
+    mediator_did: &str,
+    rest_url: Option<String>,
+) -> Result<crate::client::VtaClient, Box<dyn std::error::Error>> {
+    #[cfg(not(feature = "tsp"))]
+    {
+        // Reached only when this build can't speak TSP but the VTA advertises
+        // it. Say that plainly — the alternative is an operator staring at a
+        // VTA that offers TSP and a client that silently never picks it.
+        Err(format!(
+            "VTA '{vta_did}' advertises TSP, but this build of the SDK/CLI was compiled \
+             without the `tsp` feature, so it cannot connect over it.\n\n\
+             Rebuild with `--features tsp`, or select another transport:\n  \
+             <cli> --transport didcomm <command>\n  \
+             <cli> --transport rest <command>"
+        )
+        .into())
+    }
+    #[cfg(feature = "tsp")]
+    {
+        let timeout = tsp_connect_timeout();
+        match tokio::time::timeout(
+            timeout,
+            crate::client::VtaClient::connect_tsp(
+                client_did,
+                private_key,
+                vta_did,
+                mediator_did,
+                rest_url,
+            ),
+        )
+        .await
+        {
+            Ok(result) => Ok(result?),
+            Err(_) => Err(tsp_unreachable_error(mediator_did, timeout).into()),
+        }
+    }
+}
+
+/// The message an operator sees when a VTA advertises TSP but its mediator
+/// does not answer.
+///
+/// Distinct from [`mediator_unreachable_error`] on purpose (R6.4): "TSP is
+/// advertised and the mediator went silent" and "the VTA advertises no TSP at
+/// all" are different faults with different fixes, and one shared hint is
+/// exactly what that rule exists to prevent. Names the mediator DID so the
+/// operator knows *which* endpoint to go look at.
+fn tsp_unreachable_error(mediator_did: &str, timeout: Duration) -> String {
+    format!(
+        "Timed out after {}s connecting to the VTA's TSP mediator:\n  {mediator_did}\n\n\
+         The VTA advertises TSP (`#tsp`), but that mediator did not answer. Reach the \
+         VTA over another transport:\n  \
+         <cli> --transport didcomm <command>\n  \
+         <cli> --transport rest <command>\n\n\
+         Raise the deadline for a slow link with VTA_TSP_CONNECT_TIMEOUT_SECS.",
+        timeout.as_secs()
+    )
+}
+
+/// The message an operator sees when `--transport tsp` has no `#tsp` service to
+/// force. Lists what the VTA *does* advertise, so the next command is obvious
+/// rather than guessed (compare [`no_rest_endpoint_error`]).
+fn no_tsp_endpoint_error(
+    vta_did: &str,
+    has_didcomm: bool,
+    has_rest: bool,
+) -> Box<dyn std::error::Error> {
+    format!(
+        "--transport tsp: VTA '{vta_did}' does not advertise a TSP service (`#tsp`, \
+         type `TSPTransport`) in its DID document, so there is no TSP endpoint to \
+         force.\n\n{}\n\nTo start advertising TSP on the VTA itself:\n  \
+         pnm services tsp enable",
+        advertised_hint(has_didcomm, has_rest)
+    )
+    .into()
+}
+
+/// As [`no_tsp_endpoint_error`], for `--transport didcomm`.
+fn no_didcomm_endpoint_error(
+    vta_did: &str,
+    has_tsp: bool,
+    has_rest: bool,
+) -> Box<dyn std::error::Error> {
+    let offers = match (has_tsp, has_rest) {
+        (true, true) => {
+            "It advertises TSP and REST:\n  <cli> --transport tsp <command>\n  <cli> --transport rest <command>"
+        }
+        (true, false) => "It advertises TSP:\n  <cli> --transport tsp <command>",
+        (false, true) => "It advertises REST:\n  <cli> --transport rest <command>",
+        (false, false) => "It advertises no other transport this client can use.",
+    };
+    format!(
+        "--transport didcomm: VTA '{vta_did}' does not advertise a DIDComm service \
+         (`DIDCommMessaging`) in its DID document, so there is no mediator to \
+         force.\n\n{offers}"
+    )
+    .into()
+}
+
+/// "It advertises X" phrasing shared by the forced-transport errors.
+fn advertised_hint(has_didcomm: bool, has_rest: bool) -> &'static str {
+    match (has_didcomm, has_rest) {
+        (true, true) => {
+            "It advertises DIDComm and REST:\n  <cli> --transport didcomm <command>\n  <cli> --transport rest <command>"
+        }
+        (true, false) => "It advertises DIDComm:\n  <cli> --transport didcomm <command>",
+        (false, true) => "It advertises REST:\n  <cli> --transport rest <command>",
+        (false, false) => "It advertises no other transport this client can use.",
+    }
+}
+
 /// Resolve a VTA DID to discover available transport endpoints.
 ///
-/// Performs a single DID resolution and extracts:
-/// - `DIDCommMessaging` service → mediator DID (preferred transport)
-/// - `#vta-rest` service → REST URL (fallback)
+/// Performs a single DID resolution and reads every advertised transport via
+/// [`ServiceCapabilities::from_did_document`] — the workspace's one
+/// implementation of "which protocols does this party speak", which matches on
+/// service **`type`** (`TSPTransport` / `DIDCommMessaging` / `VTARest`), never
+/// on the `#id` fragment, and accepts `type` as either a string or an array.
 ///
-/// Returns `VtaEndpoint::DIDComm` if a mediator is found, otherwise `VtaEndpoint::Rest`.
+/// Returns the highest-preference transport advertised (**TSP > DIDComm >
+/// REST**), carrying the lower-preference endpoints with it so a caller that
+/// falls back does not resolve twice.
+///
+/// # The TSP-only case
+///
+/// A document with `TSPTransport` and no `DIDCommMessaging` resolves as
+/// [`VtaEndpoint::Tsp`]. It previously fell through both extractions and
+/// returned a REST URL *synthesized from the DID's own domain* — an endpoint
+/// that need not exist. That shape is not hypothetical: this crate ships
+/// `did-host-tsp` and `did-host-http-tsp` templates, so the SDK could mint a
+/// node it could not then resolve.
 pub async fn resolve_vta_endpoint(
     vta_did: &str,
 ) -> Result<VtaEndpoint, Box<dyn std::error::Error>> {
+    use crate::protocol::matching::ServiceCapabilities;
+
     debug!(vta_did, "resolving VTA DID for transport selection");
 
     let did_resolver = DIDCacheClient::new(crate::resolver::build_did_cache_config_from_env())
@@ -1250,24 +1593,46 @@ pub async fn resolve_vta_endpoint(
         }
     };
 
-    // Look for #vta-rest service endpoint
-    let rest_url = resolved
-        .doc
-        .find_service("vta-rest")
-        .and_then(|svc| svc.service_endpoint.get_uri())
+    // Round-trip the typed document through JSON so the shared matcher — which
+    // is defined over an already-resolved `serde_json::Value` — is the single
+    // place service types are interpreted. The alternative, a second bespoke
+    // extraction over the typed `doc.service` array, is exactly what left TSP
+    // invisible here while `matching.rs` had understood it all along.
+    let doc_json = serde_json::to_value(&resolved.doc)
+        .map_err(|e| format!("could not re-serialize resolved DID document: {e}"))?;
+    let caps = ServiceCapabilities::from_did_document(&doc_json);
+
+    let rest_url = caps
+        .rest
+        .as_deref()
         .map(|u| u.trim_matches('"').trim_end_matches('/').to_string());
 
-    // Look for DIDCommMessaging service with a DID-based endpoint (mediator)
-    let mediator_did = resolved
-        .doc
-        .service
-        .iter()
-        .filter(|svc| svc.type_.iter().any(|t| t == "DIDCommMessaging"))
-        .flat_map(|svc| svc.service_endpoint.get_uris())
-        .map(|u| u.trim_matches('"').to_string())
-        .find(|u| u.starts_with("did:"));
+    // TSP and DIDComm both advertise a *mediator DID*, not a transport URL —
+    // the real endpoint lives in the mediator's own document. Anything that
+    // isn't a DID is a misconfigured entry we cannot route through, so it is
+    // ignored rather than handed onward as a mediator.
+    let mediator_of = |endpoint: Option<&String>| -> Option<String> {
+        endpoint
+            .map(|u| u.trim_matches('"').to_string())
+            .filter(|u| u.starts_with("did:"))
+    };
+    let tsp_mediator_did = mediator_of(caps.tsp.as_ref());
+    let didcomm_mediator_did = mediator_of(caps.didcomm.as_ref());
 
-    if let Some(mediator_did) = mediator_did {
+    if let Some(mediator_did) = tsp_mediator_did {
+        debug!(
+            mediator_did = %mediator_did,
+            didcomm_mediator_did = ?didcomm_mediator_did,
+            rest_url = ?rest_url,
+            "TSP endpoint found (highest preference)"
+        );
+        Ok(VtaEndpoint::Tsp {
+            vta_did: vta_did.to_string(),
+            mediator_did,
+            didcomm_mediator_did,
+            rest_url,
+        })
+    } else if let Some(mediator_did) = didcomm_mediator_did {
         debug!(mediator_did = %mediator_did, rest_url = ?rest_url, "DIDComm endpoint found");
         Ok(VtaEndpoint::DIDComm {
             vta_did: vta_did.to_string(),
@@ -1717,12 +2082,10 @@ impl TspPingSession {
             // might not have answered at all. A stale frame must not be able to
             // turn a broken transport green.
             //
-            // Correlation is the Trust-Task `threadId`, which the responder sets
-            // to our request `id` (`doc.respond_with`); the echoed `nonce` is
-            // accepted as a fallback for a responder that replies with a fresh
-            // document instead of a threaded `#response`. Anything else is
-            // someone else's traffic or a leftover: skip it and keep waiting
-            // within the caller's budget.
+            // Correlation goes through [`correlates`] — the one implementation
+            // of "is this frame the reply to that request", shared with
+            // `TspSession::request`. Anything else is someone else's traffic or
+            // a leftover: skip it and keep waiting within the caller's budget.
             let Ok((payload, _sender)) = self.atm.tsp().unpack_bytes(&self.profile, &frame).await
             else {
                 continue; // not sealed to us / not TSP — not our business
@@ -1731,13 +2094,7 @@ impl TspPingSession {
                 continue; // not a Trust-Task document
             };
 
-            let threaded = doc.get("threadId").and_then(|v| v.as_str()) == Some(id.as_str());
-            let echoed_nonce = doc
-                .get("payload")
-                .and_then(|p| p.get("nonce"))
-                .and_then(|v| v.as_str())
-                == Some(nonce.as_str());
-            if threaded || echoed_nonce {
+            if correlates(&doc, &id, Some(&nonce)) {
                 return Ok(start.elapsed().as_millis());
             }
             tracing::debug!(
@@ -1814,6 +2171,58 @@ pub struct TspSession {
     ws: tokio::sync::Mutex<Option<affinidi_tdk::messaging::TspWebSocket>>,
     /// This client's DID — the `issuer` on an [`announce`](Self::announce) frame.
     client_did: String,
+    /// In-flight [`request`](Self::request) waiters, keyed by request document
+    /// `id`. Whichever task currently holds `ws` reads frames on behalf of
+    /// *all* of them and hands each reply to its own waiter.
+    pending: tokio::sync::Mutex<std::collections::HashMap<String, PendingRequest>>,
+    /// Inbound documents that matched no in-flight request — VTA-pushed
+    /// `task-consent/request`s and the like. Parked here rather than dropped,
+    /// so a request waiting on an unrelated reply cannot eat a push.
+    parked: tokio::sync::Mutex<std::collections::VecDeque<String>>,
+}
+
+/// One in-flight [`TspSession::request`]: how to recognise its reply, and where
+/// to deliver it.
+#[cfg(feature = "tsp")]
+struct PendingRequest {
+    /// Echoed-`nonce` fallback for a responder that replies with a fresh
+    /// document instead of a threaded `#response`.
+    nonce: Option<String>,
+    tx: tokio::sync::oneshot::Sender<String>,
+}
+
+/// Does `doc` correlate to the request identified by `request_id` (and
+/// optionally `nonce`)?
+///
+/// The single implementation of "is this frame the reply to that request",
+/// shared by [`TspPingSession::ping`] and [`TspSession::request`]. It was
+/// written for the ping path and welded there; every other caller would
+/// otherwise have re-derived `threadId` matching from the raw inner document.
+///
+/// Correlation is the Trust-Task `threadId`, which a responder sets to the
+/// request's `id` (`doc.respond_with`). The echoed `payload.nonce` is accepted
+/// as a fallback for a responder that replies with a fresh document rather than
+/// a threaded `#response`.
+///
+/// **Why this cannot be "the first frame that parses".** The client's mediator
+/// inbox is durable and flushes on connect, so every reply a previous process
+/// run never collected is queued and lands the moment we reconnect. Accepting
+/// the first frame therefore returns a *stale* reply — which is the exact fault
+/// that made the #749 delivery bug look intermittent.
+#[cfg(feature = "tsp")]
+fn correlates(doc: &serde_json::Value, request_id: &str, nonce: Option<&str>) -> bool {
+    if doc.get("threadId").and_then(|v| v.as_str()) == Some(request_id) {
+        return true;
+    }
+    match nonce {
+        Some(n) => {
+            doc.get("payload")
+                .and_then(|p| p.get("nonce"))
+                .and_then(|v| v.as_str())
+                == Some(n)
+        }
+        None => false,
+    }
 }
 
 #[cfg(feature = "tsp")]
@@ -1859,7 +2268,16 @@ impl TspSession {
             profile,
             ws: tokio::sync::Mutex::new(Some(ws)),
             client_did: client_did.to_string(),
+            pending: tokio::sync::Mutex::new(std::collections::HashMap::new()),
+            parked: tokio::sync::Mutex::new(std::collections::VecDeque::new()),
         })
+    }
+
+    /// This client's DID — the proven sender VID the VTA authorizes against,
+    /// and the `issuer` on documents sent through this session.
+    #[must_use]
+    pub fn client_did(&self) -> &str {
+        &self.client_did
     }
 
     /// Announce this client's TSP reachability to `vta_did` by sending a
@@ -1960,49 +2378,284 @@ impl TspSession {
     ) -> Result<Option<String>, Box<dyn std::error::Error>> {
         use std::time::{Duration, Instant};
 
-        let mut guard = self.ws.lock().await;
-        let ws = match guard.as_mut() {
-            Some(w) => w,
-            None => return Ok(None), // already shut down
-        };
-        let budget = Duration::from_secs(timeout_secs);
-        let start = Instant::now();
+        let deadline = Instant::now() + Duration::from_secs(timeout_secs);
         loop {
-            let remaining = match budget.checked_sub(start.elapsed()) {
-                Some(r) => r,
-                None => return Ok(None),
+            // A frame an in-flight `request` read off the socket but did not
+            // want is ours. Drain that before touching the socket, or a push
+            // that already arrived would sit unseen behind a fresh read.
+            if let Some(doc) = self.parked.lock().await.pop_front() {
+                return Ok(Some(doc));
+            }
+            if Instant::now() >= deadline {
+                return Ok(None);
+            }
+
+            let mut guard = self.ws.lock().await;
+            let Some(ws) = guard.as_mut() else {
+                return Ok(None); // already shut down
             };
+            // Bounded so the socket lock is released periodically even while
+            // idle — otherwise a long-polling `receive_next` would hold it for
+            // its whole budget and stall every concurrent `request`.
+            let slice = PUMP_SLICE.min(deadline.saturating_duration_since(Instant::now()));
+            // Bound before the `match` — see `await_reply`.
+            let outcome = self.pump_once(ws, slice).await?;
+            match outcome {
+                // Not addressed to any in-flight request → it is a push, and
+                // pushes are what this method is for.
+                PumpOutcome::Uncorrelated(doc) => return Ok(Some(doc)),
+                PumpOutcome::Delivered | PumpOutcome::Idle => {
+                    drop(guard);
+                    continue;
+                }
+            }
+        }
+    }
+
+    /// Send `document` to `vta_did` and wait for **its** reply.
+    ///
+    /// This is the piece that made TSP a transport rather than a probe: without
+    /// it a consumer could `send_document` and could `receive_next`, but could
+    /// not ask for *the reply to request X* — so nothing above the raw frame
+    /// level (trust tasks, credential flows, join ceremonies) could be routed
+    /// over TSP.
+    ///
+    /// Properties, each of which is load-bearing:
+    ///
+    /// - **Correlated, never "first frame that parses".** Replies are matched
+    ///   by [`correlates`] — `threadId`, falling back to an echoed `nonce`. The
+    ///   mediator inbox is durable and flushes on connect, so an uncorrelated
+    ///   read can hand back a reply from a *previous process run*.
+    /// - **Concurrent.** Several `request`s may be in flight on one session.
+    ///   Whichever one currently holds the socket reads on behalf of all of
+    ///   them and delivers each reply to its own waiter, so a slow request
+    ///   cannot serialise a fast one, and one request's read cannot consume
+    ///   another's reply.
+    /// - **Pushes survive.** A frame matching no in-flight request is parked
+    ///   for [`receive_next`](Self::receive_next), not discarded — a
+    ///   `task-consent/request` must not be eaten by a request waiting on
+    ///   something unrelated.
+    /// - **Finite.** Every wait is bounded by `timeout` (R1.2).
+    ///
+    /// # Authentication
+    ///
+    /// There is no token dance on this path and no holder proof in the
+    /// document. TSP `unpack` yields a **cryptographically proven sender VID**,
+    /// and the VTA's inbound dispatcher (`tsp_inbound::dispatch_one`) resolves
+    /// that VID straight to its ACL grant before dispatching on the shared
+    /// trust-task spine — the same intrinsic-sender model as DIDComm authcrypt,
+    /// and the reason the REST bearer-token flow has no TSP analogue. An
+    /// unknown or unauthorized sender gets a `permission_denied` trust-task
+    /// envelope back, not a drop.
+    pub async fn request(
+        &self,
+        vta_did: &str,
+        mediator_did: &str,
+        document: &[u8],
+        timeout: std::time::Duration,
+    ) -> Result<String, Box<dyn std::error::Error>> {
+        use std::time::Instant;
+
+        let parsed: serde_json::Value = serde_json::from_slice(document)
+            .map_err(|e| format!("TSP request document is not JSON: {e}"))?;
+        let request_id = parsed
+            .get("id")
+            .and_then(|v| v.as_str())
+            .ok_or("TSP request document has no `id` to correlate its reply on")?
+            .to_string();
+        let nonce = parsed
+            .get("payload")
+            .and_then(|p| p.get("nonce"))
+            .and_then(|v| v.as_str())
+            .map(str::to_string);
+
+        let (tx, mut rx) = tokio::sync::oneshot::channel();
+        self.pending.lock().await.insert(
+            request_id.clone(),
+            PendingRequest {
+                nonce: nonce.clone(),
+                tx,
+            },
+        );
+
+        // Registered *before* sending: a reply can land while `send_routed` is
+        // still returning, and a waiter registered afterwards would miss it.
+        //
+        // Both results are flattened to `String` **before** the deregistering
+        // `.await` below. A `Box<dyn Error>` is not `Send`, and holding one
+        // across an await makes this future `!Send` — and with it every caller,
+        // including `VtaClient::dispatch_trust_task`, whose future `vta-mcp`
+        // requires to be `Send`. Because `vta-mcp` doesn't enable the `tsp`
+        // feature itself, that break only appears once Cargo's feature
+        // unification turns TSP on for a workspace build, a long way from here.
+        // Pinned by `tsp_futures_are_send`.
+        let sent = self
+            .send_document(vta_did, mediator_did, document)
+            .await
+            .map_err(|e| e.to_string());
+        if sent.is_err() {
+            self.pending.lock().await.remove(&request_id);
+        }
+        sent?;
+
+        let deadline = Instant::now() + timeout;
+        let outcome = self
+            .await_reply(&request_id, &mut rx, deadline)
+            .await
+            .map_err(|e| e.to_string());
+        // Always deregister — a timed-out or failed request must not leave a
+        // waiter behind for the pump to deliver into.
+        self.pending.lock().await.remove(&request_id);
+        Ok(outcome?)
+    }
+
+    /// Wait for `request_id`'s reply, taking a turn at pumping the socket
+    /// whenever it is free.
+    ///
+    /// Leader/followers: whoever holds `ws` reads and demultiplexes for
+    /// everyone; the rest park on their oneshot. Contending for the lock in the
+    /// same `select!` as the oneshot is what lets a follower take over the
+    /// moment the leader finishes, with no background task to supervise and no
+    /// change to [`shutdown`](Self::shutdown) semantics.
+    ///
+    /// Returns `String` errors, not `Box<dyn Error>`: the latter is not `Send`,
+    /// and a `Box` living across any of the awaits in this loop would make the
+    /// whole call chain `!Send`. Keeping the internals `String`-typed makes
+    /// that mistake structurally impossible rather than merely tested for.
+    async fn await_reply(
+        &self,
+        request_id: &str,
+        rx: &mut tokio::sync::oneshot::Receiver<String>,
+        deadline: std::time::Instant,
+    ) -> Result<String, String> {
+        use std::time::Instant;
+
+        loop {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                return Err(format!(
+                    "timed out waiting for the TSP reply to request '{request_id}'"
+                ));
+            }
+
+            tokio::select! {
+                biased;
+
+                // Someone else's pump already delivered our reply.
+                delivered = &mut *rx => {
+                    return delivered.map_err(|_| {
+                        "TSP session shut down while waiting for a reply".to_string()
+                    });
+                }
+
+                // We are the leader for as long as we hold this.
+                mut guard = self.ws.lock() => {
+                    let Some(ws) = guard.as_mut() else {
+                        return Err("TSP session was shut down".to_string());
+                    };
+                    let slice = PUMP_SLICE.min(remaining);
+                    // Bound before the `match`: a scrutinee temporary lives for
+                    // the whole match body, which contains an `.await`.
+                    let outcome = self.pump_once(ws, slice).await?;
+                    match outcome {
+                        PumpOutcome::Uncorrelated(doc) => {
+                            // Not ours and not any other waiter's — park it for
+                            // the push consumer instead of dropping it.
+                            self.parked.lock().await.push_back(doc);
+                        }
+                        PumpOutcome::Delivered | PumpOutcome::Idle => {}
+                    }
+                    // Release before looping so a follower can take a turn.
+                    drop(guard);
+                }
+
+                () = tokio::time::sleep(remaining) => {
+                    return Err(format!(
+                        "timed out waiting for the TSP reply to request '{request_id}'"
+                    ));
+                }
+            }
+        }
+    }
+
+    /// Read at most one application frame off `ws` within `slice`, unpack it,
+    /// and route it: to the waiter it correlates with, or back to the caller as
+    /// [`PumpOutcome::Uncorrelated`].
+    ///
+    /// Frames that don't unpack are TSP control/relationship traffic and are
+    /// skipped within the slice rather than surfaced.
+    /// `String` errors for the same reason as [`await_reply`](Self::await_reply).
+    async fn pump_once(
+        &self,
+        ws: &mut affinidi_tdk::messaging::TspWebSocket,
+        slice: std::time::Duration,
+    ) -> Result<PumpOutcome, String> {
+        use std::time::Instant;
+
+        let until = Instant::now() + slice;
+        loop {
+            let remaining = until.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                return Ok(PumpOutcome::Idle);
+            }
             let frame = match tokio::time::timeout(remaining, ws.recv()).await {
                 Ok(Ok(Some(bytes))) => bytes,
-                // Closed socket is an ERROR, not `Ok(None)`.
+                // Closed socket is an ERROR, not "nothing arrived".
                 //
-                // `Ok(None)` means "nothing arrived, ask again" — the caller's
-                // normal idle path. A closed websocket is the opposite: asking
-                // again can never produce anything. Conflating them meant a
-                // dropped inbox was indistinguishable from a quiet one, so a
-                // polling loop would spin on `recv()` returning `None`
-                // immediately, forever — burning CPU and never reconnecting,
+                // "Nothing arrived, ask again" is the caller's normal idle
+                // path. A closed websocket is the opposite: asking again can
+                // never produce anything. Conflating them meant a dropped inbox
+                // was indistinguishable from a quiet one, so a polling loop
+                // would spin forever, burning CPU and never reconnecting,
                 // because nothing ever signalled that the connection had gone.
                 //
                 // Surfacing it as `Err` lets the supervisor do its job: the
                 // mobile listen loop already treats an error as a drop and
                 // reconnects with backoff.
-                Ok(Ok(None)) => {
-                    return Err("TSP websocket closed by the mediator".into());
-                }
-                Ok(Err(e)) => return Err(Box::new(e)),
-                Err(_) => return Ok(None), // timed out with nothing to hand back
+                Ok(Ok(None)) => return Err("TSP websocket closed by the mediator".to_string()),
+                Ok(Err(e)) => return Err(e.to_string()),
+                Err(_) => return Ok(PumpOutcome::Idle),
             };
-            // A frame sealed to us that unpacks to a UTF-8 body is an application
-            // message; hand its plaintext to the caller. Frames that don't unpack
-            // are TSP control/relationship traffic — skip and keep waiting.
-            match self.atm.tsp().unpack_bytes(&self.profile, &frame).await {
-                Ok((payload, _sender)) => {
-                    let json = String::from_utf8(payload)
-                        .map_err(|e| format!("TSP payload was not UTF-8: {e}"))?;
-                    return Ok(Some(json));
+
+            let Ok((payload, _sender)) = self.atm.tsp().unpack_bytes(&self.profile, &frame).await
+            else {
+                continue; // not sealed to us / TSP control traffic
+            };
+            let json = String::from_utf8(payload)
+                .map_err(|e| format!("TSP payload was not UTF-8: {e}"))?;
+
+            let Ok(doc) = serde_json::from_str::<serde_json::Value>(&json) else {
+                // Not a Trust-Task document, so it can correlate with nothing.
+                // Hand it up rather than drop it — the push consumer decides.
+                return Ok(PumpOutcome::Uncorrelated(json));
+            };
+
+            let mut pending = self.pending.lock().await;
+            let hit = pending
+                .iter()
+                .find(|(id, p)| correlates(&doc, id, p.nonce.as_deref()))
+                .map(|(id, _)| id.clone());
+            match hit {
+                Some(id) => {
+                    if let Some(p) = pending.remove(&id) {
+                        // A dropped receiver (the requester timed out and left)
+                        // is not an error — the frame is simply no longer
+                        // wanted by anyone.
+                        let _ = p.tx.send(json);
+                    }
+                    return Ok(PumpOutcome::Delivered);
                 }
-                Err(_) => continue,
+                None => {
+                    drop(pending);
+                    debug!(
+                        thread_id = doc
+                            .get("threadId")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("<none>"),
+                        "TSP frame matched no in-flight request (push, or a stale inbox entry)"
+                    );
+                    return Ok(PumpOutcome::Uncorrelated(json));
+                }
             }
         }
     }
@@ -2010,11 +2663,35 @@ impl TspSession {
     /// Close the TSP websocket and shut down the ATM connection. Takes `&self`
     /// (the session is shared across the FFI boundary).
     pub async fn shutdown(&self) {
+        // Drop every waiter first so an in-flight `request` fails fast with
+        // "session shut down" instead of blocking until its own deadline on a
+        // socket that is about to disappear.
+        self.pending.lock().await.clear();
         if let Some(ws) = self.ws.lock().await.take() {
             let _ = ws.close().await;
         }
         self.atm.graceful_shutdown().await;
     }
+}
+
+/// How long one turn at the socket lasts before the holder must release it.
+///
+/// Bounds lock hand-off latency: with several requests in flight, a follower
+/// waits at most this long to become leader after the current one goes idle.
+/// Short enough that concurrency feels immediate, long enough that an idle
+/// session is not spinning on the mutex.
+#[cfg(feature = "tsp")]
+const PUMP_SLICE: std::time::Duration = std::time::Duration::from_millis(250);
+
+/// What one turn at the socket produced.
+#[cfg(feature = "tsp")]
+enum PumpOutcome {
+    /// A frame arrived and went to the request that was waiting for it.
+    Delivered,
+    /// A frame arrived that no in-flight request wanted.
+    Uncorrelated(String),
+    /// The slice elapsed with no application frame.
+    Idle,
 }
 
 fn now_epoch() -> u64 {
@@ -2302,24 +2979,151 @@ mod tests {
 
     #[test]
     fn connect_timeout_defaults_when_unset_or_junk() {
-        assert_eq!(parse_connect_timeout(None), DIDCOMM_CONNECT_TIMEOUT_DEFAULT);
-        assert_eq!(
-            parse_connect_timeout(Some("not-a-number".into())),
-            DIDCOMM_CONNECT_TIMEOUT_DEFAULT
-        );
+        let d = DIDCOMM_CONNECT_TIMEOUT_DEFAULT;
+        assert_eq!(parse_connect_timeout(None, d), d);
+        assert_eq!(parse_connect_timeout(Some("not-a-number".into()), d), d);
         // Zero would fail every connect instantly — worse than the hang.
-        assert_eq!(
-            parse_connect_timeout(Some("0".into())),
-            DIDCOMM_CONNECT_TIMEOUT_DEFAULT
-        );
+        assert_eq!(parse_connect_timeout(Some("0".into()), d), d);
     }
 
     #[test]
     fn connect_timeout_honours_env_override() {
         assert_eq!(
-            parse_connect_timeout(Some(" 90 ".into())),
+            parse_connect_timeout(Some(" 90 ".into()), DIDCOMM_CONNECT_TIMEOUT_DEFAULT),
             Duration::from_secs(90)
         );
+    }
+
+    /// TSP carries its **own** deadline default, so an operator stretching the
+    /// TSP ceiling doesn't silently loosen the DIDComm one they rely on to fail
+    /// fast (and vice versa).
+    #[test]
+    fn tsp_connect_timeout_is_independent_of_the_didcomm_one() {
+        assert_eq!(
+            parse_connect_timeout(None, TSP_CONNECT_TIMEOUT_DEFAULT),
+            TSP_CONNECT_TIMEOUT_DEFAULT
+        );
+        assert_eq!(
+            parse_connect_timeout(Some("120".into()), TSP_CONNECT_TIMEOUT_DEFAULT),
+            Duration::from_secs(120)
+        );
+    }
+
+    /// R6.4: "TSP advertised but the mediator went silent" and "no TSP
+    /// advertised at all" are different faults with different fixes. One shared
+    /// hint for both is exactly what that rule exists to prevent.
+    #[test]
+    fn tsp_failure_modes_have_distinct_messages() {
+        let unreachable =
+            tsp_unreachable_error("did:web:mediator.example.com", Duration::from_secs(30));
+        assert!(
+            unreachable.contains("did:web:mediator.example.com"),
+            "must name the mediator that went silent: {unreachable}"
+        );
+        assert!(unreachable.contains("VTA_TSP_CONNECT_TIMEOUT_SECS"));
+
+        let not_advertised =
+            no_tsp_endpoint_error("did:webvh:x:vta.example", true, true).to_string();
+        assert!(
+            !not_advertised.contains("Timed out"),
+            "a VTA that never advertised TSP did not time out: {not_advertised}"
+        );
+        // Names what it *does* advertise, so the next command is obvious.
+        assert!(not_advertised.contains("--transport didcomm"));
+        assert!(not_advertised.contains("--transport rest"));
+    }
+
+    /// The advertised-transport hint must not offer a transport the VTA does
+    /// not have — that would send the operator into a second dead end.
+    #[test]
+    fn no_tsp_error_only_offers_transports_that_exist() {
+        let didcomm_only = no_tsp_endpoint_error("did:key:z6Mk", true, false).to_string();
+        assert!(didcomm_only.contains("--transport didcomm"));
+        assert!(!didcomm_only.contains("--transport rest"));
+
+        let rest_only = no_tsp_endpoint_error("did:key:z6Mk", false, true).to_string();
+        assert!(rest_only.contains("--transport rest"));
+        assert!(!rest_only.contains("--transport didcomm"));
+
+        let neither = no_tsp_endpoint_error("did:key:z6Mk", false, false).to_string();
+        assert!(neither.contains("no other transport"));
+    }
+
+    // ── TSP reply correlation ─────────────────────────────────────
+
+    /// The property that makes TSP request/response safe: a frame that is not
+    /// *this* request's reply must not be accepted as one.
+    ///
+    /// The mediator inbox is durable and flushes on connect, so every reply a
+    /// previous process run never collected lands the moment we reconnect.
+    /// "First frame that parses" would therefore return a stale reply — the
+    /// exact fault that made the #749 delivery bug look intermittent.
+    #[cfg(feature = "tsp")]
+    #[test]
+    fn a_stale_frame_is_not_mistaken_for_our_reply() {
+        let stale = serde_json::json!({
+            "id": "urn:uuid:reply-to-something-else",
+            "threadId": "urn:uuid:a-previous-run",
+            "payload": { "nonce": "some-other-nonce" },
+        });
+        assert!(!correlates(
+            &stale,
+            "urn:uuid:our-request",
+            Some("our-nonce")
+        ));
+    }
+
+    #[cfg(feature = "tsp")]
+    #[test]
+    fn thread_id_correlates() {
+        let reply = serde_json::json!({
+            "id": "urn:uuid:the-reply",
+            "threadId": "urn:uuid:our-request",
+            "payload": {},
+        });
+        assert!(correlates(&reply, "urn:uuid:our-request", None));
+    }
+
+    /// Fallback for a responder that answers with a fresh document rather than
+    /// a threaded `#response`.
+    #[cfg(feature = "tsp")]
+    #[test]
+    fn echoed_nonce_correlates_when_thread_id_is_absent() {
+        let reply = serde_json::json!({
+            "id": "urn:uuid:fresh-doc",
+            "payload": { "nonce": "our-nonce" },
+        });
+        assert!(correlates(
+            &reply,
+            "urn:uuid:our-request",
+            Some("our-nonce")
+        ));
+        // ...but only when we actually sent a nonce to echo.
+        assert!(!correlates(&reply, "urn:uuid:our-request", None));
+    }
+
+    /// A document with neither field correlates with nothing — it is a push,
+    /// and must be parked for the receive consumer rather than eaten.
+    #[cfg(feature = "tsp")]
+    #[test]
+    fn a_push_correlates_with_no_request() {
+        let push = serde_json::json!({
+            "id": "urn:uuid:pushed",
+            "type": "https://trusttasks.org/spec/task-consent/request/0.1",
+            "payload": { "taskId": "t1" },
+        });
+        assert!(!correlates(
+            &push,
+            "urn:uuid:our-request",
+            Some("our-nonce")
+        ));
+    }
+
+    #[test]
+    fn forced_didcomm_error_names_the_alternatives() {
+        let msg = no_didcomm_endpoint_error("did:webvh:x:vta.example", true, false).to_string();
+        assert!(msg.contains("--transport tsp"));
+        assert!(!msg.contains("--transport rest"));
     }
 
     /// The whole point of bounding the connect is that the operator learns the
@@ -2340,5 +3144,33 @@ mod tests {
         let msg = no_rest_endpoint_error("did:webvh:scid:host.example.com").to_string();
         assert!(msg.contains("--url"));
         assert!(msg.contains("did:webvh:scid:host.example.com"));
+    }
+}
+
+/// Every `TspSession` future must be `Send`.
+///
+/// Not a nicety: `VtaClient::dispatch_trust_task` awaits `request`, and
+/// `vta-mcp` puts that future behind `#[tool]`, which demands `Send`. A single
+/// `Box<dyn Error>` (not `Send`) held across one `.await` inside `request` is
+/// enough to make the whole chain `!Send` — and because `vta-mcp` does not
+/// enable the `tsp` feature itself, it only breaks once Cargo's feature
+/// unification turns TSP on for a workspace-wide build. That is a long way from
+/// the edit that caused it, so pin it here where the mistake is made.
+///
+/// A compile-time check: if these stop being `Send`, this module fails to
+/// build.
+#[cfg(all(test, feature = "tsp"))]
+mod tsp_send_assertions {
+    use std::time::Duration;
+
+    fn assert_send<T: Send>(_: T) {}
+
+    #[allow(dead_code)]
+    fn tsp_futures_are_send(s: &super::TspSession) {
+        assert_send(s.request("did:vta", "did:mediator", b"{}", Duration::from_secs(1)));
+        assert_send(s.receive_next(1));
+        assert_send(s.send_document("did:vta", "did:mediator", b"{}"));
+        assert_send(s.announce("did:vta", "did:mediator"));
+        assert_send(s.shutdown());
     }
 }

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.12.38"
+version = "0.12.39"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -127,7 +127,7 @@ vta-policy = { path = "../vta-policy", version = "0.1" }
 # extracted to its own crate and re-exported as crate::{webvh_store,
 # webvh_client, webvh_auth} behind this crate's `webvh` feature.
 vta-webvh = { path = "../vta-webvh", version = "0.1", optional = true }
-vta-sdk = { path = "../vta-sdk", version = "0.19", features = ["didcomm", "sealed-transfer", "provision-integration", "openapi", "crypto-provider", "acl-setup"] }
+vta-sdk = { path = "../vta-sdk", version = "0.20", features = ["didcomm", "sealed-transfer", "provision-integration", "openapi", "crypto-provider", "acl-setup"] }
 # DID-VM-resolved WebAuthn assertion verifier — drives the new
 # `vta/auth/passkey-login-{start,finish}/1.0` trust-task handlers.
 # Distinct from `webauthn-rs` (which drives the passkey *enrolment*
@@ -297,7 +297,7 @@ vta-service = { path = ".", features = ["test-support"] }
 # `provision_admin_rotated_via_rest` + DI-signed REST auth) the `MockVta`
 # bootstrap→provision e2e tests drive (issues #406, DI-auth follow-up). Kept out
 # of the production `vta-sdk` dep above so the server build stays lean.
-vta-sdk = { path = "../vta-sdk", version = "0.19", features = ["provision-client"] }
+vta-sdk = { path = "../vta-sdk", version = "0.20", features = ["provision-client"] }
 # Mock HTTP server for the did-hosting-daemon REST auth flow tests. Each
 # test spins up a real local server bound to a random port, validates
 # the JWS-signed request bodies the daemon would see, and serves

--- a/vta-support/Cargo.toml
+++ b/vta-support/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-support"
 description = "Shared mid-layer VTA services — trust-context storage, the sealed-transfer seal helper, and the sealed-bootstrap nonce store"
 readme = "README.md"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -14,7 +14,7 @@ repository.workspace = true
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.1" }
 vta-config = { path = "../vta-config", version = "0.1" }
 vti-common = { path = "../vti-common", version = "0.11" }
-vta-sdk = { path = "../vta-sdk", version = "0.19", features = ["sealed-transfer"] }
+vta-sdk = { path = "../vta-sdk", version = "0.20", features = ["sealed-transfer"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 chrono = { workspace = true }

--- a/vta-vault/Cargo.toml
+++ b/vta-vault/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-vault"
 description = "VTA holder credential vault — storage, query, receive/verify, present, and status refresh for credentials a holder stores on a VTA"
 readme = "README.md"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -25,7 +25,7 @@ webvh = ["dep:reqwest", "vta-sdk/client"]
 [dependencies]
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.1" }
 vti-common = { path = "../vti-common", version = "0.11", features = ["encryption"] }
-vta-sdk = { path = "../vta-sdk", version = "0.19", features = ["didcomm", "sealed-transfer"] }
+vta-sdk = { path = "../vta-sdk", version = "0.20", features = ["didcomm", "sealed-transfer"] }
 affinidi-crypto = { workspace = true }
 affinidi-secrets-resolver = { workspace = true }
 affinidi-data-integrity = { workspace = true }

--- a/vta-webvh/Cargo.toml
+++ b/vta-webvh/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-webvh"
 description = "WebVH hosting infrastructure for the VTA — the DID-record store, the HTTP client to a did:webvh hosting server, and its DID-auth handshake"
 readme = "README.md"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -13,7 +13,7 @@ repository.workspace = true
 [dependencies]
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.1" }
 vti-common = { path = "../vti-common", version = "0.11" }
-vta-sdk = { path = "../vta-sdk", version = "0.19" }
+vta-sdk = { path = "../vta-sdk", version = "0.20" }
 affinidi-tdk = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/vtc-client/Cargo.toml
+++ b/vtc-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vtc-client"
 description = "Client SDK for Verifiable Trust Communities (VTC) — auth, members, join, removal, policies"
-version = "0.1.4"
+version = "0.1.5"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -14,7 +14,7 @@ repository.workspace = true
 # Reuses the VTA SDK's challenge-response auth (audience-agnostic) and the
 # published join-request protocol types. `session` gates `auth_light` +
 # `protocols`.
-vta-sdk = { path = "../vta-sdk", version = "0.19", features = ["session"] }
+vta-sdk = { path = "../vta-sdk", version = "0.20", features = ["session"] }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.11.25"
+version = "0.11.26"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -102,7 +102,7 @@ vti-common = { path = "../vti-common", version = "0.11", features = [
 # factory + `*SecretStore` names are a thin facade over these). Per-backend
 # features are activated by this crate's matching features above.
 vti-secrets = { path = "../vti-secrets", version = "0.1" }
-vta-sdk = { path = "../vta-sdk", version = "0.19", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.20", features = [
   "didcomm",
   "session",
   "config-session",

--- a/vti-common/Cargo.toml
+++ b/vti-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-common"
 description = "Shared server-side infrastructure for VTA and VTC services"
 readme = "README.md"
-version = "0.11.22"
+version = "0.11.23"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -48,7 +48,7 @@ openapi = ["dep:utoipa", "dep:utoipa-axum"]
 # `default-features = false` skips the optional client transports
 # (didcomm, sealed-transfer, etc.); we only consume the type
 # definitions in the default feature set.
-vta-sdk = { path = "../vta-sdk", version = "0.19", default-features = false }
+vta-sdk = { path = "../vta-sdk", version = "0.20", default-features = false }
 async-trait = "0.1"
 # Durable OutboxStore backend (`outbox_store::VtiOutboxStore`) for the D1
 # delivery layer — the Guaranteed-send outbox, persisted via `store::Store`.

--- a/vti-secrets/Cargo.toml
+++ b/vti-secrets/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-secrets"
 description = "Pluggable secret-store backends + integration onboarding flow for Verifiable Trust Infrastructure"
 readme = "README.md"
-version = "0.1.7"
+version = "0.1.8"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -54,7 +54,7 @@ tracing = { workspace = true }
 tokio = { workspace = true }
 
 # Onboarding feature: the SDK session/auth state machine + local did:key mint.
-vta-sdk = { path = "../vta-sdk", version = "0.19", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.20", features = [
   "session",
 ], optional = true }
 ed25519-dalek = { workspace = true, optional = true }


### PR DESCRIPTION
Closes #765, closes #766, closes #767 — the three-leg TSP client-enablement set. Stacked in one PR because each leg is useless without the others: discovery with nothing to select, selection with nothing to speak, or a client nobody can choose.

TSP has worked on the wire since #749/#750. What was missing is everything between "the wire works" and "a client can choose it".

## #765 — Discovery

`resolve_vta_endpoint` never read the `#tsp` service. **The root cause is duplication, not a missing branch:** `protocol::matching::ServiceCapabilities::from_did_document` already matched on service `type`, already tolerated `type` as string-or-array, and already understood `TSPTransport` — it just sat beside a second, bespoke two-field extraction in `session.rs` that only knew `#vta-rest` and `DIDCommMessaging`.

So discovery now routes through the shared matcher rather than gaining a third hand-rolled branch. (Its existing tests — `matches_by_type_not_id`, `type_may_be_an_array` — are why that's the safe direction.)

Two consequences:

- A TSP-enabled VTA is no longer invisible to SDK consumers.
- A **TSP-only** document no longer falls through both extractions into `url_from_did()`, which returned a REST URL *synthesized from the DID's own domain* — an endpoint that need not exist. Not hypothetical: this SDK ships `did-host-tsp` and `did-host-http-tsp` templates, so it could mint a node it could not then resolve.

`ResolvedVta` gains `tsp_mediator_did` and `advertised()`, deliberately **separate from "the transport we connected over"** — a probe needs both, independently sourced. Conflating them is what rendered a TSP-advertising VTA as "DIDComm (in use) · only transport offered".

## #766 — Selection

`TransportChoice` gains `Tsp` and `Didcomm`. `Auto` now implements the precedence **TSP > DIDComm > REST** that was documented everywhere and implemented nowhere (it meant "DIDComm when advertised, else REST"). `Didcomm` didn't exist even implicitly — forcing DIDComm was only available as "whatever `Auto` happens to pick".

**Fallback policy — `Auto` falls back loudly** (WARN naming the mediator and deadline), then tries DIDComm, then REST. The issue asked for an explicit decision, so: failing hard would make a dual-transport VTA *less* available than today purely for having enabled TSP; falling back silently would make a permanently-broken TSP deployment invisible. The WARN is what makes it a diagnosis rather than a cover-up. `--transport tsp` never falls back, for operators who want strictness. Recorded on the enum, not just here.

TSP connects are bounded (`VTA_TSP_CONNECT_TIMEOUT_SECS`, 30s) with their **own** ceiling rather than sharing DIDComm's: same mediator, same reconnect/backoff loop, so without one `Auto` preferring TSP converts today's working fallback into an indefinite hang with no output. Separate env var so stretching one deadline doesn't silently loosen the other.

Per R6.4, the failure modes get distinct messages — "TSP advertised but the mediator went silent" names the mediator DID and the env var; "no TSP advertised" names the transports the VTA *does* offer, and only those (pinned by `no_tsp_error_only_offers_transports_that_exist`).

## #767 — The correlated client

`TspSession::request(vta_did, mediator_did, document, timeout)`:

- **Correlated, never "first frame that parses".** Matches `threadId`, falling back to echoed `nonce`. The mediator inbox is durable and flushes on connect, so an uncorrelated read returns a reply from a *previous process run* — the fault that made the #749 delivery bug look intermittent. The logic existed but was welded to `TspPingSession::ping`; it's now one shared `correlates` helper both paths use.
- **Concurrent.** Whichever caller holds the socket demultiplexes for all in-flight requests (leader/followers, no background task, so `shutdown` semantics are unchanged). `receive_next` previously took the socket lock for its entire timeout budget, so two requests serialised and the second's reply could be eaten by the first's read.
- **Pushes survive.** Frames matching no in-flight request are parked for `receive_next`, not dropped — a pushed `task-consent/request` must not be eaten by a request waiting on something unrelated.
- **Finite deadline on every wait** (R1.2).

`VtaClient::connect_tsp` mirrors `connect_didcomm`. `Transport::Tsp` plugs into `dispatch_trust_task` — the single funnel — so the **entire Trust-Task surface** reaches TSP with no per-operation work. The legacy DIDComm *protocol-message* surface (`key-management/1.0/*`) has no TSP dispatcher behind it and returns `UnsupportedTransport` naming DIDComm, rather than sending a frame the VTA would answer with an error.

### Authentication, written down

The issue asked for this explicitly. There is **no token dance and no holder proof** on the TSP path: `unpack` yields a cryptographically proven sender VID, which `tsp_inbound::dispatch_one` resolves straight to its ACL grant before dispatching on the shared spine — the same intrinsic-sender model as DIDComm authcrypt. The REST bearer-token flow has no TSP analogue; `set_token` is a no-op and `check_auth` is unconditionally true on this transport. Documented on `connect_tsp` and `request`, where consumers will read it.

## Breaking — 0.19 → 0.20

`VtaEndpoint` gains a `Tsp` variant and was **not** `#[non_exhaustive]`, so an exhaustive downstream match no longer compiles. It is `#[non_exhaustive]` now, so this is the last time. `ResolvedVta` gains two fields. Every internal `vta-sdk = "0.19"` pin moved to `"0.20"`, which cascades a patch bump into 14 dependent crates (all listed in the changelog as pin-only).

## A `Send` regression this introduced, and its pin

One `Box<dyn Error>` held across one `.await` in `request` made the whole chain `!Send` — including `VtaClient::dispatch_trust_task`, which `vta-mcp` puts behind `#[tool]`. Because `vta-mcp` doesn't enable the `tsp` feature itself, `cargo check -p vta-mcp` passed; it only broke once Cargo's feature unification turned TSP on for the workspace build. That's a long way from the edit that caused it, so:

- the private helpers (`await_reply`, `pump_once`) are `String`-typed, making the mistake structurally impossible in the hot loops;
- `tsp_send_assertions` is a compile-time pin asserting every `TspSession` future is `Send`.

## Verification

`cargo test --workspace` green (50 test binaries, 0 failures). `cargo clippy --workspace --all-targets` clean. `cargo fmt --check` clean. Both CI guards (`check-version-bumps.sh`, `check-changelogs.sh`) pass.

New tests cover the properties that matter: stale-frame rejection, `threadId` vs nonce-fallback correlation, a push correlating with nothing, TSP/DIDComm timeout independence, and the distinct-error-message rule. The `pnm services tsp enable` command named in the error hints was verified to exist.

Not verified: a live round-trip against a deployed TSP VTA. #765 asks for that (R3.6) and it needs a running deployment — worth doing before OpenVTC/openvtc#185 moves its trust-task surface across.

**Merge note:** bumps `vtc-service` to 0.11.26, the same version #796 uses. Whichever lands second needs a rebase to 0.11.27.
