### PR TITLE
feat(vtc): signed audit checkpoints, so truncating the log stops being invisible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,85 @@
 
 ## Unreleased
 
+### vti-common 0.11.24 / vtc-service 0.11.28 / cnm-cli 0.11.8 — signed audit checkpoints
+
+The `prev_hash` chain (#555) and `GET /v1/audit/verify` (#703) detect
+reordering, dropping, duplication, and content edits. They do not detect the
+adversary #537 tier 3 actually named — one with **write access to the `audit`
+keyspace** — because `chain_digest` is an *unkeyed* SHA-256, so that adversary
+holds everything needed to recompute it:
+
+- **Restamping** — edit or insert an envelope, recompute its `entry_hash`, walk
+  forward restamping every successor. Verifies cleanly. No secret required.
+- **Truncation** — delete everything after some point. The remaining prefix is
+  a *valid chain*, and nothing recorded how long the log should be, so a
+  truncated log was indistinguishable from a community that went quiet. This is
+  the cheaper attack and the more serious one: it erases an incident with no
+  forgery at all.
+
+**What ships.** A periodic `AuditCheckpoint`, signed with the **community
+Ed25519 key** (the same `LocalSigner` that issues VMCs/VECs), committing to the
+chain head *and* `entry_count`. That count is the load-bearing field: a log
+shorter than a signed checkpoint attests to has lost entries, and that
+contradiction cannot be manufactured from the store alone.
+
+Not the audit HMAC key — it lives in the very store the adversary is assumed to
+have reached, and symmetric verification means whoever can *check* a checkpoint
+can also *forge* one, which reduces to the status quo. Signing with the
+community key also makes checkpoints **externally** verifiable: an auditor
+holding only the community DID can confirm the log has not been rewritten, with
+no shared secret and no daemon access.
+
+Checkpoints chain to each other, so deleting the checkpoint that contradicts a
+truncated log is itself detectable — without that, the mechanism would protect
+nothing.
+
+**Beyond the design note**, three additions the threat model demanded:
+
+- `entry_count` must be **monotonic** across the checkpoint chain. Otherwise an
+  adversary could re-link a genuinely-signed *older* checkpoint into a later
+  position and lower the attested count without forging anything.
+- `emit_checkpoint` **refuses to sign** when the live log already holds fewer
+  entries than the last checkpoint claims. Signing there would launder a
+  truncation into a fresh "this is fine".
+- Each checkpoint records the `verificationMethod` that signed it, so one
+  signed under a later-retired key stays verifiable.
+
+**Cadence** (the note left this open): time-based, default 15 minutes,
+`[audit_checkpoints] interval_secs`, `0` disables with a loud `WARN`. The
+interval is the attacker's free truncation window, so it sets residual risk
+directly. Count-based triggering was deliberately *not* implemented — doing it
+honestly needs a running entry counter in `AuditWriter`, and approximating it by
+polling more often means walking the whole audit keyspace on a timer. A shorter
+interval is the cheaper knob and bounds the window in *time* regardless of
+traffic. A tick with no new entries emits nothing.
+
+**`GET /v1/audit/verify`** gains a `checkpoints` block —
+`consistent` / `truncated` / `headMismatch` / `chainBroken` / `noCheckpoints`,
+with `attestedEntries` and `unattestedEntries`. That last one is the live
+truncation window (entries written since the last checkpoint, covered by the
+forgeable chain and no signature) and is reported rather than left implicit.
+`cnm audit verify` prints it and now **exits non-zero on a checkpoint failure
+even when the chain verifies** — that combination *is* the store-level attack,
+and exiting 0 would make `cnm audit verify || alert` silent for the one thing
+checkpoints exist to catch.
+
+**Backup.** `audit_checkpoint` is in `BACKED_UP` and gated on the same
+`include_audit` flag as `audit`. The pairing is not optional: either half alone
+turns a legitimate restore into the truncation finding — checkpoints without
+their log attest to entries that aren't there, and a log without its
+checkpoints is shorter than every checkpoint claims. Pinned by two tests.
+
+**Known limitation, recorded not hidden.** The verifier resolves every
+`verificationMethod` to the VTC's *current* signing key, so checkpoints signed
+before a community key rotation would stop verifying. The per-checkpoint
+`verification_method` is already persisted for the fix (resolve the DID
+document's key history), so it is a verifier change with no data migration.
+External anchoring — publishing the head somewhere append-only to defend
+against an adversary who *also* holds the signing key — remains out of scope
+and is the next step.
+
+Closes #708.
 ### vtc-service 0.11.27 — a REST-only client can now refresh without a mediator
 
 `POST /v1/auth/refresh` went straight to `atm.unpack` and — correctly, since

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2488,7 +2488,7 @@ checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cnm-cli"
-version = "0.11.7"
+version = "0.11.8"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "clap",
@@ -10564,7 +10564,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-service"
-version = "0.11.27"
+version = "0.11.28"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",
@@ -10646,7 +10646,7 @@ dependencies = [
 
 [[package]]
 name = "vti-common"
-version = "0.11.23"
+version = "0.11.24"
 dependencies = [
  "aes-gcm",
  "affinidi-data-integrity",

--- a/cnm-cli/Cargo.toml
+++ b/cnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cnm-cli"
 description = "CLI Tool for Verified Trust Agents operating in Verified Trust Communities"
-version = "0.11.7"
+version = "0.11.8"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/cnm-cli/src/audit.rs
+++ b/cnm-cli/src/audit.rs
@@ -81,6 +81,49 @@ pub async fn cmd_verify(
         );
     }
 
+    // Signed checkpoints (#708) — the half that resists a store-level
+    // adversary. Printed after the chain result and *before* the exit
+    // decision, because a green chain over a truncated log is precisely the
+    // case an operator must not skim past.
+    let checkpoints = &body["checkpoints"];
+    let cp_status = checkpoints["status"].as_str().unwrap_or("unknown");
+    let cp_detail = checkpoints["detail"].as_str();
+    let cp_broken = matches!(cp_status, "truncated" | "headMismatch" | "chainBroken");
+    println!();
+    match cp_status {
+        "consistent" => {
+            let attested = checkpoints["attestedEntries"].as_u64().unwrap_or(0);
+            let unattested = checkpoints["unattestedEntries"].as_u64().unwrap_or(0);
+            let count = checkpoints["verifiedCheckpoints"].as_u64().unwrap_or(0);
+            println!(
+                "{GREEN}✓ signed checkpoints consistent{RESET} {DIM}({count} verified){RESET}"
+            );
+            println!("  {DIM}attested entries:{RESET} {attested}");
+            if let Some(at) = checkpoints["newestCheckpointAt"].as_str() {
+                println!("  {DIM}newest checkpoint:{RESET} {at}");
+            }
+            if unattested > 0 {
+                // Not a failure, but not nothing: this tail is covered by the
+                // forgeable chain only, so it is the live truncation window.
+                println!(
+                    "  {DIM}unattested tail:  {RESET} {unattested}                      {DIM}(written since the last checkpoint — signed by nothing yet){RESET}"
+                );
+            }
+        }
+        "noCheckpoints" => {
+            println!("{RED}! no signed checkpoints{RESET}");
+            if let Some(d) = cp_detail {
+                println!("  {DIM}{d}{RESET}");
+            }
+        }
+        _ => {
+            println!("{RED}✗ signed checkpoints FAILED ({cp_status}){RESET}");
+            if let Some(d) = cp_detail {
+                println!("  {RED}{d}{RESET}");
+            }
+        }
+    }
+
     if let Some(brk) = body.get("chainBreak").filter(|v| !v.is_null()) {
         let kind = brk["kind"].as_str().unwrap_or("?");
         let index = brk["index"].as_u64().unwrap_or(0);
@@ -101,11 +144,26 @@ pub async fn cmd_verify(
     if !verified {
         println!();
         println!(
-            "{DIM}Note: a passing chain proves internal consistency, not authenticity —\n\
-             the chain is unsigned, so an adversary with store write access can\n\
-             restamp a forged suffix. Verify an out-of-band copy before concluding.{RESET}"
+            "{DIM}Note: the chain alone proves internal consistency, not authenticity —\n\
+             it is unsigned, so an adversary with store write access can restamp a\n\
+             forged suffix. The checkpoint result above is the signed half.{RESET}"
         );
         return Err("audit chain verification failed".into());
+    }
+
+    // A broken checkpoint result must fail the command even when the chain
+    // verifies — that combination *is* the store-level attack: an internally
+    // consistent log that the community key says is missing entries. Exiting
+    // 0 here would make `cnm audit verify || alert` silent for the one attack
+    // checkpoints exist to catch.
+    if cp_broken {
+        println!();
+        println!(
+            "{RED}The hash chain is internally consistent but contradicts a signature made\n\
+             with the community key. That is what a store-level tamper looks like:\n\
+             the surviving log was re-stamped to look correct.{RESET}"
+        );
+        return Err("audit checkpoint verification failed".into());
     }
     Ok(())
 }

--- a/docs/03-vtc/backup-restore.md
+++ b/docs/03-vtc/backup-restore.md
@@ -17,7 +17,11 @@ AES-256-GCM encryption of:
   `community`, `members`, `join_requests`, `policies`, `active_policies`,
   `status_lists`, `relationships`, `relationships_by_did`, `endorsement_types`,
   `schemas`, `endorsements`, and `audit_key`. The `audit` log is included only
-  when you pass `include_audit: true`.
+  when you pass `include_audit: true` — and when it is, its signed checkpoints
+  (`audit_checkpoint`) come with it. That pairing is not optional: a log
+  restored without its checkpoints holds fewer entries than every signed
+  checkpoint attests to, so `cnm audit verify` would report the restore as
+  **truncation**.
 - **The signing key bundle** — so the backup is a *complete* disaster-recovery
   artifact: a restore re-establishes the VTC's ability to sign (status-list
   re-issue, VMC minting), not just its data.

--- a/docs/05-design-notes/vtc-audit-checkpoints.md
+++ b/docs/05-design-notes/vtc-audit-checkpoints.md
@@ -1,9 +1,59 @@
 # Signed audit checkpoints
 
-**Status:** proposed — not implemented.
+**Status:** **implemented** (#708, vtc-service 0.11.26). This note is now
+the rationale record; the code is `vti_common::audit::checkpoint` (type +
+signature scheme) and `vtc_service::audit_checkpoint` (emitter + verifier).
 **Context:** issue #537 tier 3. The `prev_hash` chain shipped in #555;
-`GET /v1/audit/verify` (this PR) exposes it. This note covers what is
-still missing and why it matters.
+`GET /v1/audit/verify` exposed it in #703.
+
+## What shipped, against this design
+
+Everything in the Proposal section below, plus:
+
+- `AuditCheckpoint.verification_method` — the `verificationMethod` URI of the
+  signing key, recorded per checkpoint so one signed under a retired key stays
+  verifiable. The note called for rotation to be handled; this is the field
+  that makes it possible.
+- `CheckpointBreak::CountWentBackwards` — `entry_count` must be monotonic
+  across the checkpoint chain. Without it, an adversary could re-link a
+  genuinely-signed *older* checkpoint into a later position and lower the
+  attested count without forging anything.
+- `emit_checkpoint` **refuses** to sign when the live log already holds fewer
+  entries than the last checkpoint attests to. Signing there would launder a
+  truncation into a fresh "this is fine".
+- `unattestedEntries` on the verify response — entries written since the last
+  checkpoint, covered by the forgeable chain but no signature. That tail is
+  the live truncation window and is now visible rather than implied.
+
+### Open questions, resolved
+
+- **Cadence** — time-based, default 15 minutes, `[audit_checkpoints]
+  interval_secs`, `0` disables. Count-based triggering was **not** implemented:
+  doing it honestly needs a running entry counter in `AuditWriter`, and
+  approximating it by polling more often means walking the whole audit keyspace
+  on a timer. A shorter interval is the cheaper knob, and it bounds the window
+  in *time* regardless of traffic — which is what an incident responder
+  reasons about. Rationale is restated on the module so it is not lost.
+- **Backup interaction** — `AUDIT_CHECKPOINT` is in `BACKED_UP`. Required, not
+  optional: restoring the audit log without its checkpoints reads as mass
+  truncation.
+- **External anchoring** — still out of scope, still the next step.
+- **Chain-head durability** — not taken. `measure_chain` still walks the
+  keyspace, matching what `/audit/verify` already did. The checkpoint keyspace
+  now makes an O(1) head pointer easy; it is a follow-up.
+
+### Known limitation
+
+`verify_checkpoint_state` resolves every `verificationMethod` to the VTC's
+*current* signing key. Correct until the community key rotates, at which point
+checkpoints signed under the retired key stop verifying. The fix is to resolve
+the DID document's key history — the per-checkpoint `verification_method` is
+already persisted for exactly that, so this is a verifier change with no data
+migration.
+
+---
+
+*Original note follows.*
 
 ## The problem the chain does not solve
 

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.11.27"
+version = "0.11.28"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vtc-service/src/audit_checkpoint.rs
+++ b/vtc-service/src/audit_checkpoint.rs
@@ -1,0 +1,602 @@
+//! Emitting and verifying signed audit checkpoints (#708).
+//!
+//! The type, its signature scheme, and the threat model live in
+//! [`vti_common::audit::checkpoint`]. This module is the VTC-side wiring: the
+//! periodic emitter that signs checkpoints with the community key, and the
+//! verifier that measures the live audit log against the newest one.
+//!
+//! # Cadence
+//!
+//! **Time-based, default 15 minutes, configurable via
+//! `[audit_checkpoints] interval_secs`.** The interval is the attacker's free
+//! truncation window, so it sets the residual risk directly: entries written
+//! after the last checkpoint are covered by the (unkeyed, forgeable) hash
+//! chain but by no signature, and can still be truncated without detection.
+//! `GET /v1/audit/verify` reports that tail as `unattestedEntries` rather than
+//! leaving it implicit.
+//!
+//! Count-based triggering ("also checkpoint every N entries") was considered
+//! and **deliberately not implemented**. Doing it honestly needs a running
+//! entry counter maintained by `AuditWriter` in `vti-common`; approximating it
+//! by polling more often would mean walking the whole audit keyspace every
+//! poll, which is O(log size) work on a timer. A shorter interval is the
+//! cheaper knob for a busy community, and it bounds the window in *time*
+//! regardless of traffic — which is the property an incident responder
+//! actually reasons about. Revisit if the counter lands.
+//!
+//! A tick with no new entries emits nothing: a quiet community should not
+//! accumulate identical checkpoints.
+
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+use ed25519_dalek::SigningKey;
+use serde::{Deserialize, Serialize};
+use tokio::sync::watch;
+use tracing::{info, warn};
+use uuid::Uuid;
+
+use vti_common::audit::{
+    AuditCheckpoint, AuditEnvelope, CheckpointAudit, CheckpointClaim, GENESIS_HASH,
+};
+use vti_common::error::AppError;
+use vti_common::store::KeyspaceHandle;
+
+/// Signed-checkpoint settings, mounted at `[audit_checkpoints]`.
+///
+/// Deliberately **not** named `AuditConfig`: `vti_common::config::AuditConfig`
+/// already exists (the VTA's audit *retention* settings). Two same-named
+/// config types one crate apart is how an operator ends up editing the wrong
+/// section, so this one says what it configures.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub struct AuditCheckpointConfig {
+    /// How often to sign a checkpoint, in seconds. `0` disables
+    /// checkpointing entirely (the log keeps its unkeyed hash chain and
+    /// nothing more).
+    ///
+    /// Clamped to a 60s floor when non-zero: each emission walks the audit
+    /// keyspace, so a very short interval turns tamper-evidence into a
+    /// self-inflicted load problem.
+    #[serde(default = "default_interval_secs")]
+    pub interval_secs: u64,
+}
+
+fn default_interval_secs() -> u64 {
+    900 // 15 minutes
+}
+
+impl Default for AuditCheckpointConfig {
+    fn default() -> Self {
+        Self {
+            interval_secs: default_interval_secs(),
+        }
+    }
+}
+
+/// The audit chain's current state, as measured by walking the keyspace.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChainState {
+    /// `entry_hash` of the newest chainable envelope.
+    pub head: [u8; 32],
+    /// `event_id` of that envelope.
+    pub head_event_id: Uuid,
+    /// Count of **chainable** (v2+) envelopes. Pre-v2 rows are excluded
+    /// because the verifier skips them — counting them would make the
+    /// attested number disagree with what a recount can produce.
+    pub entry_count: u64,
+}
+
+impl ChainState {
+    /// The state of an empty (or entirely pre-v2) log.
+    #[must_use]
+    pub fn empty() -> Self {
+        Self {
+            head: GENESIS_HASH,
+            head_event_id: Uuid::nil(),
+            entry_count: 0,
+        }
+    }
+}
+
+/// Walk the audit keyspace in ascending (chronological) key order and measure
+/// the chain.
+///
+/// O(log size). Called once per checkpoint interval and once per
+/// `GET /v1/audit/verify`, matching what that endpoint already does. A
+/// persisted head pointer would make this O(1); the checkpoint keyspace is the
+/// natural place for one, and is a follow-up rather than a prerequisite.
+///
+/// Unparseable rows are counted, not fatal — one corrupt row must not stop the
+/// daemon from checkpointing everything around it. They are reported so the
+/// finding is visible.
+pub async fn measure_chain(audit_ks: &KeyspaceHandle) -> Result<(ChainState, usize), AppError> {
+    let mut pairs = audit_ks.prefix_iter_raw(Vec::new()).await?;
+    pairs.sort_by(|(a, _), (b, _)| a.cmp(b));
+
+    let mut state = ChainState::empty();
+    let mut unparseable = 0usize;
+    for (key, value) in &pairs {
+        match serde_json::from_slice::<AuditEnvelope>(value) {
+            Ok(env) => {
+                if env.schema_version < 2 {
+                    continue; // unchainable; the verifier skips these too
+                }
+                state.head = env.entry_hash;
+                state.head_event_id = env.event_id;
+                state.entry_count += 1;
+            }
+            Err(err) => {
+                unparseable += 1;
+                warn!(
+                    error = %err,
+                    key = %String::from_utf8_lossy(key),
+                    "skipping unparseable audit envelope while measuring the chain",
+                );
+            }
+        }
+    }
+    Ok((state, unparseable))
+}
+
+/// Load every checkpoint in ascending (chronological) order.
+pub async fn load_checkpoints(
+    checkpoint_ks: &KeyspaceHandle,
+) -> Result<Vec<AuditCheckpoint>, AppError> {
+    let mut pairs = checkpoint_ks.prefix_iter_raw(Vec::new()).await?;
+    pairs.sort_by(|(a, _), (b, _)| a.cmp(b));
+
+    let mut out = Vec::with_capacity(pairs.len());
+    for (key, value) in &pairs {
+        match serde_json::from_slice::<AuditCheckpoint>(value) {
+            Ok(cp) => out.push(cp),
+            Err(err) => {
+                // Deliberately an error, not a skip. An unparseable checkpoint
+                // is not like an unparseable audit row: checkpoints are the
+                // thing being trusted, so silently dropping one would let an
+                // adversary erase an inconvenient attestation by corrupting it.
+                return Err(AppError::Internal(format!(
+                    "unparseable audit checkpoint at {}: {err}",
+                    String::from_utf8_lossy(key)
+                )));
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// Sign and persist a checkpoint for the audit log's current state, unless
+/// nothing has been written since the last one.
+///
+/// Returns the new checkpoint, or `None` when there was nothing new to attest.
+pub async fn emit_checkpoint(
+    audit_ks: &KeyspaceHandle,
+    checkpoint_ks: &KeyspaceHandle,
+    signing_key: &SigningKey,
+    verification_method: &str,
+    now: DateTime<Utc>,
+) -> Result<Option<AuditCheckpoint>, AppError> {
+    let (state, _unparseable) = measure_chain(audit_ks).await?;
+    let existing = load_checkpoints(checkpoint_ks).await?;
+    let previous = existing.last();
+
+    // Nothing new: a quiet community should not accumulate a checkpoint per
+    // tick, each attesting to exactly the same head.
+    if let Some(prev) = previous
+        && prev.entry_count == state.entry_count
+        && prev.head == state.head
+    {
+        return Ok(None);
+    }
+
+    // Never sign a claim that contradicts one we already signed. If the live
+    // log holds fewer entries than the last checkpoint attests to, something
+    // has already gone wrong — emitting a lower count would launder the
+    // truncation into a freshly-signed "this is fine".
+    if let Some(prev) = previous
+        && state.entry_count < prev.entry_count
+    {
+        return Err(AppError::Internal(format!(
+            "refusing to checkpoint: audit log holds {} chainable entries but the last \
+             checkpoint attests to {}. This is the truncation signature — investigate \
+             before checkpointing again.",
+            state.entry_count, prev.entry_count
+        )));
+    }
+
+    let claim = CheckpointClaim {
+        checkpoint_id: Uuid::new_v4(),
+        head: state.head,
+        entry_count: state.entry_count,
+        head_event_id: state.head_event_id,
+        checkpoint_at: now,
+        prev_checkpoint: previous.map(AuditCheckpoint::link_hash),
+        verification_method: verification_method.to_string(),
+    };
+    let checkpoint = AuditCheckpoint::sign(claim, signing_key);
+
+    checkpoint_ks
+        .insert(checkpoint.storage_key(), &checkpoint)
+        .await?;
+
+    info!(
+        entry_count = checkpoint.entry_count,
+        checkpoint_id = %checkpoint.checkpoint_id,
+        "signed audit checkpoint",
+    );
+    Ok(Some(checkpoint))
+}
+
+/// Measure the live audit log against the newest signed checkpoint.
+///
+/// `newest` is the last checkpoint from a **already-verified** chain — call
+/// [`vti_common::audit::verify_checkpoints`] first. Passing an unverified
+/// checkpoint here measures the log against something an adversary may have
+/// written, which proves nothing.
+pub async fn audit_against_checkpoint(
+    audit_ks: &KeyspaceHandle,
+    newest: Option<&AuditCheckpoint>,
+    state: &ChainState,
+) -> Result<CheckpointAudit, AppError> {
+    let Some(cp) = newest else {
+        return Ok(CheckpointAudit::NoCheckpoints);
+    };
+
+    // The finding this whole mechanism exists for. Checked before the head
+    // lookup because it is the cheaper and more serious signal: a truncation
+    // that removed the head envelope would otherwise surface as the vaguer
+    // `HeadMismatch`.
+    if state.entry_count < cp.entry_count {
+        return Ok(CheckpointAudit::Truncated {
+            attested: cp.entry_count,
+            found: state.entry_count,
+        });
+    }
+
+    // The attested anchor must still be present and unaltered. A genesis
+    // checkpoint (empty log at the time) has no anchor to find.
+    if cp.head != GENESIS_HASH {
+        let found = find_entry_hash(audit_ks, cp.head_event_id).await?;
+        match found {
+            Some(hash) if hash == cp.head => {}
+            other => {
+                return Ok(CheckpointAudit::HeadMismatch {
+                    head_event_id: cp.head_event_id,
+                    found: other.is_some(),
+                });
+            }
+        }
+    }
+
+    Ok(CheckpointAudit::Consistent {
+        checkpoint_at: cp.checkpoint_at,
+        attested_entries: cp.entry_count,
+        unattested_entries: state.entry_count.saturating_sub(cp.entry_count),
+    })
+}
+
+/// The `entry_hash` of the envelope with `event_id`, if it is still there.
+///
+/// The audit keyspace is keyed by `<timestamp>:<event_id>`, so there is no
+/// direct lookup by id alone — this scans. Called once per verify request,
+/// alongside a walk that is already O(n).
+async fn find_entry_hash(
+    audit_ks: &KeyspaceHandle,
+    event_id: Uuid,
+) -> Result<Option<[u8; 32]>, AppError> {
+    let pairs = audit_ks.prefix_iter_raw(Vec::new()).await?;
+    for (_key, value) in &pairs {
+        if let Ok(env) = serde_json::from_slice::<AuditEnvelope>(value)
+            && env.event_id == event_id
+        {
+            return Ok(Some(env.entry_hash));
+        }
+    }
+    Ok(None)
+}
+
+/// Periodic checkpoint emitter, spawned at boot alongside the other
+/// background tasks.
+pub struct CheckpointEmitter;
+
+impl CheckpointEmitter {
+    /// Spawn the emitter. Returns `None` — without spawning — when
+    /// checkpointing is disabled (`checkpoint_interval_secs = 0`).
+    pub fn spawn(
+        audit_ks: KeyspaceHandle,
+        checkpoint_ks: KeyspaceHandle,
+        signing_key: SigningKey,
+        verification_method: String,
+        config: AuditCheckpointConfig,
+        mut shutdown_rx: watch::Receiver<bool>,
+    ) -> Option<tokio::task::JoinHandle<()>> {
+        if config.interval_secs == 0 {
+            warn!(
+                "audit checkpointing is DISABLED (interval_secs = 0). The audit \
+                 chain is unkeyed, so a store-level adversary can truncate or restamp it \
+                 undetectably."
+            );
+            return None;
+        }
+        let interval = Duration::from_secs(config.interval_secs.max(60));
+
+        Some(tokio::spawn(async move {
+            info!(
+                interval_secs = interval.as_secs(),
+                "audit checkpoint emitter started"
+            );
+            // Checkpoint once at startup so a restart immediately re-anchors
+            // whatever was written while the daemon was down, rather than
+            // leaving that span unattested until the first tick.
+            emit_and_log(
+                &audit_ks,
+                &checkpoint_ks,
+                &signing_key,
+                &verification_method,
+            )
+            .await;
+
+            loop {
+                tokio::select! {
+                    _ = shutdown_rx.changed() => {
+                        // Final checkpoint on the way out: a clean shutdown
+                        // should not leave its last span of entries unsigned.
+                        emit_and_log(
+                            &audit_ks,
+                            &checkpoint_ks,
+                            &signing_key,
+                            &verification_method,
+                        )
+                        .await;
+                        info!("audit checkpoint emitter shutting down");
+                        return;
+                    }
+                    _ = tokio::time::sleep(interval) => {
+                        emit_and_log(
+                            &audit_ks,
+                            &checkpoint_ks,
+                            &signing_key,
+                            &verification_method,
+                        )
+                        .await;
+                    }
+                }
+            }
+        }))
+    }
+}
+
+async fn emit_and_log(
+    audit_ks: &KeyspaceHandle,
+    checkpoint_ks: &KeyspaceHandle,
+    signing_key: &SigningKey,
+    verification_method: &str,
+) {
+    match emit_checkpoint(
+        audit_ks,
+        checkpoint_ks,
+        signing_key,
+        verification_method,
+        Utc::now(),
+    )
+    .await
+    {
+        Ok(Some(_)) => {}
+        Ok(None) => {}
+        // WARN, not debug: a checkpoint that silently stops being emitted
+        // leaves the log unattested while `verify` keeps reporting the last
+        // good checkpoint as consistent.
+        Err(e) => warn!(error = %e, "failed to emit audit checkpoint"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vti_common::audit::verify_checkpoints;
+
+    fn key() -> SigningKey {
+        SigningKey::from_bytes(&[7u8; 32])
+    }
+
+    const VM: &str = "did:webvh:scid:vtc.example#key-0";
+
+    async fn ks(name: &str) -> (KeyspaceHandle, tempfile::TempDir) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = vti_common::store::Store::open(&vti_common::config::StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        })
+        .expect("store");
+        let handle = store.keyspace(name).expect("keyspace");
+        (handle, dir)
+    }
+
+    #[tokio::test]
+    async fn an_empty_log_measures_as_genesis() {
+        let (audit, _d) = ks("audit").await;
+        let (state, unparseable) = measure_chain(&audit).await.expect("measure");
+        assert_eq!(state, ChainState::empty());
+        assert_eq!(unparseable, 0);
+    }
+
+    #[tokio::test]
+    async fn a_checkpoint_over_an_empty_log_verifies_and_reports_no_truncation() {
+        let (audit, _d1) = ks("audit").await;
+        let (cps, _d2) = ks("audit_checkpoint").await;
+
+        let cp = emit_checkpoint(&audit, &cps, &key(), VM, Utc::now())
+            .await
+            .expect("emit")
+            .expect("a first checkpoint is emitted even for an empty log");
+        assert_eq!(cp.entry_count, 0);
+
+        let loaded = load_checkpoints(&cps).await.expect("load");
+        let pk = key().verifying_key().to_bytes().to_vec();
+        let newest = verify_checkpoints(&loaded, |_| Some(pk.clone())).expect("verifies");
+
+        let (state, _) = measure_chain(&audit).await.expect("measure");
+        let audit_result = audit_against_checkpoint(&audit, newest, &state)
+            .await
+            .expect("audit");
+        assert!(matches!(
+            audit_result,
+            CheckpointAudit::Consistent {
+                attested_entries: 0,
+                unattested_entries: 0,
+                ..
+            }
+        ));
+    }
+
+    /// A quiet community must not accumulate an identical checkpoint per tick.
+    #[tokio::test]
+    async fn a_second_tick_with_no_new_entries_emits_nothing() {
+        let (audit, _d1) = ks("audit").await;
+        let (cps, _d2) = ks("audit_checkpoint").await;
+
+        assert!(
+            emit_checkpoint(&audit, &cps, &key(), VM, Utc::now())
+                .await
+                .expect("first")
+                .is_some()
+        );
+        assert!(
+            emit_checkpoint(&audit, &cps, &key(), VM, Utc::now())
+                .await
+                .expect("second")
+                .is_none(),
+            "nothing was written between ticks",
+        );
+        assert_eq!(load_checkpoints(&cps).await.expect("load").len(), 1);
+    }
+
+    /// The emitter must not launder a truncation into a freshly-signed lower
+    /// count — that would destroy the evidence it exists to preserve.
+    #[tokio::test]
+    async fn emitting_refuses_when_the_log_shrank_below_a_signed_checkpoint() {
+        let (audit, _d1) = ks("audit").await;
+        let (cps, _d2) = ks("audit_checkpoint").await;
+
+        // Hand-place a checkpoint attesting to 5 entries over an empty log.
+        let claim = CheckpointClaim {
+            checkpoint_id: Uuid::new_v4(),
+            head: [3u8; 32],
+            entry_count: 5,
+            head_event_id: Uuid::new_v4(),
+            checkpoint_at: Utc::now(),
+            prev_checkpoint: None,
+            verification_method: VM.to_string(),
+        };
+        let cp = AuditCheckpoint::sign(claim, &key());
+        cps.insert(cp.storage_key(), &cp).await.expect("insert");
+
+        let err = emit_checkpoint(&audit, &cps, &key(), VM, Utc::now())
+            .await
+            .expect_err("must refuse");
+        assert!(
+            err.to_string().contains("truncation"),
+            "the error must name the finding: {err}"
+        );
+    }
+
+    /// The core detection: a log shorter than its signed checkpoint claims.
+    #[tokio::test]
+    async fn a_shortened_log_reports_truncation() {
+        let (audit, _d1) = ks("audit").await;
+
+        let claim = CheckpointClaim {
+            checkpoint_id: Uuid::new_v4(),
+            head: [3u8; 32],
+            entry_count: 100,
+            head_event_id: Uuid::new_v4(),
+            checkpoint_at: Utc::now(),
+            prev_checkpoint: None,
+            verification_method: VM.to_string(),
+        };
+        let cp = AuditCheckpoint::sign(claim, &key());
+
+        let state = ChainState {
+            head: [9u8; 32],
+            head_event_id: Uuid::new_v4(),
+            entry_count: 12,
+        };
+        let result = audit_against_checkpoint(&audit, Some(&cp), &state)
+            .await
+            .expect("audit");
+        assert_eq!(
+            result,
+            CheckpointAudit::Truncated {
+                attested: 100,
+                found: 12
+            }
+        );
+    }
+
+    /// The head envelope is gone (or rewritten) even though the count still
+    /// adds up — e.g. an entry was swapped rather than removed.
+    #[tokio::test]
+    async fn a_missing_head_envelope_is_reported() {
+        let (audit, _d1) = ks("audit").await;
+
+        let head_event_id = Uuid::new_v4();
+        let claim = CheckpointClaim {
+            checkpoint_id: Uuid::new_v4(),
+            head: [3u8; 32],
+            entry_count: 1,
+            head_event_id,
+            checkpoint_at: Utc::now(),
+            prev_checkpoint: None,
+            verification_method: VM.to_string(),
+        };
+        let cp = AuditCheckpoint::sign(claim, &key());
+
+        let state = ChainState {
+            head: [9u8; 32],
+            head_event_id: Uuid::new_v4(),
+            entry_count: 1,
+        };
+        let result = audit_against_checkpoint(&audit, Some(&cp), &state)
+            .await
+            .expect("audit");
+        assert_eq!(
+            result,
+            CheckpointAudit::HeadMismatch {
+                head_event_id,
+                found: false
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn no_checkpoints_is_reported_as_such_not_as_success() {
+        let (audit, _d1) = ks("audit").await;
+        let state = ChainState::empty();
+        assert_eq!(
+            audit_against_checkpoint(&audit, None, &state)
+                .await
+                .expect("audit"),
+            CheckpointAudit::NoCheckpoints
+        );
+    }
+
+    /// A corrupt checkpoint must fail loudly — silently skipping it would let
+    /// an adversary erase an inconvenient attestation by corrupting the row.
+    #[tokio::test]
+    async fn an_unparseable_checkpoint_is_an_error_not_a_skip() {
+        let (cps, _d) = ks("audit_checkpoint").await;
+        cps.insert(
+            b"2026-07-25T10:00:00Z:garbage".to_vec(),
+            &"not a checkpoint",
+        )
+        .await
+        .expect("insert");
+        assert!(load_checkpoints(&cps).await.is_err());
+    }
+
+    #[test]
+    fn disabled_config_is_representable_and_the_default_is_not_disabled() {
+        assert_eq!(AuditCheckpointConfig::default().interval_secs, 900);
+        let disabled = AuditCheckpointConfig { interval_secs: 0 };
+        assert_eq!(disabled.interval_secs, 0);
+    }
+}

--- a/vtc-service/src/backup.rs
+++ b/vtc-service/src/backup.rs
@@ -176,9 +176,16 @@ pub async fn export_backup(
 
     // Keyspace census. `audit` rows are skipped unless requested; the
     // keyspace still appears (empty) so the dump shape is stable.
+    //
+    // `audit_checkpoint` is gated on the *same* flag, and must stay that way.
+    // The two only mean anything together: checkpoints restored without their
+    // log attest to entries that aren't there (reads as total truncation), and
+    // a log restored without its checkpoints is shorter than every signed
+    // checkpoint claims (also reads as truncation). Either half alone turns a
+    // legitimate restore into the exact finding #708 exists to raise.
     let mut keyspace_dumps = Vec::with_capacity(keyspaces::BACKED_UP.len());
     for name in keyspaces::BACKED_UP {
-        if *name == keyspaces::AUDIT && !include_audit {
+        if (*name == keyspaces::AUDIT || *name == keyspaces::AUDIT_CHECKPOINT) && !include_audit {
             keyspace_dumps.push(KeyspaceDump {
                 name: (*name).to_string(),
                 rows: Vec::new(),
@@ -358,6 +365,7 @@ fn backed_up_handle<'a>(state: &'a AppState, name: &str) -> Option<&'a KeyspaceH
         x if x == CONSUMED_INVITATIONS => &state.consumed_invitations_ks,
         x if x == AUDIT => &state.audit_ks,
         x if x == AUDIT_KEY => &state.audit_key_ks,
+        x if x == AUDIT_CHECKPOINT => &state.audit_checkpoint_ks,
         _ => return None,
     })
 }

--- a/vtc-service/src/config.rs
+++ b/vtc-service/src/config.rs
@@ -25,6 +25,11 @@ pub struct AppConfig {
     pub auth: AuthConfig,
     #[serde(default)]
     pub secrets: SecretsConfig,
+    /// Signed audit-checkpoint settings (#708). The interval is the
+    /// attacker's free truncation window, so it sets the residual risk
+    /// directly; `0` disables checkpointing.
+    #[serde(default)]
+    pub audit_checkpoints: crate::audit_checkpoint::AuditCheckpointConfig,
     #[serde(default)]
     pub routing: RoutingConfig,
     #[serde(default)]

--- a/vtc-service/src/credentials/signer.rs
+++ b/vtc-service/src/credentials/signer.rs
@@ -82,6 +82,27 @@ impl LocalSigner {
         self.secret.get_public_bytes()
     }
 
+    /// The raw Ed25519 signing key behind this signer.
+    ///
+    /// For signing **non-credential** byte strings — currently the audit
+    /// checkpoints (#708), whose signature covers a domain-tagged binary
+    /// encoding rather than a JSON-LD document. A Data Integrity proof would
+    /// be the wrong shape there: it would make a security-critical signature
+    /// depend on JSON canonicalisation agreeing between signer and verifier,
+    /// where the whole point is a byte-exact commitment.
+    ///
+    /// Not for authorization assertions — those are VCs (see the workspace
+    /// CLAUDE.md). A checkpoint asserts "the log had this head and this many
+    /// entries", which is tamper-evidence, not a grant.
+    ///
+    /// `None` if the underlying secret is not a 32-byte Ed25519 key.
+    pub fn ed25519_signing_key(&self) -> Option<ed25519_dalek::SigningKey> {
+        let bytes = self.secret.get_private_bytes();
+        <[u8; 32]>::try_from(bytes)
+            .ok()
+            .map(|b| ed25519_dalek::SigningKey::from_bytes(&b))
+    }
+
     /// Sign the supplied VC in place. Appends the
     /// `DataIntegrityProof` to `vc.proof`. Returns
     /// [`AppError::Internal`] on signing failure — every error

--- a/vtc-service/src/lib.rs
+++ b/vtc-service/src/lib.rs
@@ -16,6 +16,7 @@ pub mod acl;
 pub mod acl_cli;
 #[cfg(feature = "admin-ui")]
 pub mod admin_ui;
+pub mod audit_checkpoint;
 pub mod auth;
 pub mod backup;
 pub mod ceremony;

--- a/vtc-service/src/routes/audit.rs
+++ b/vtc-service/src/routes/audit.rs
@@ -352,6 +352,194 @@ pub struct VerifyResponse {
     /// Where the chain broke. Absent when `verified` is true.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub chain_break: Option<ChainBreakReport>,
+    /// Signed-checkpoint verification (#708) — the half of this endpoint that
+    /// a store-level adversary cannot satisfy.
+    pub checkpoints: CheckpointReport,
+}
+
+/// Signed-checkpoint verification result.
+///
+/// **This, not `verified`, is what resists a store-level adversary.** The
+/// chain is an unkeyed SHA-256, so `verified: true` only means "nobody edited
+/// the log carelessly". `checkpoints.status: "consistent"` means the log still
+/// matches an Ed25519 commitment made with the community key — which an
+/// adversary holding only the store cannot forge.
+#[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
+pub struct CheckpointReport {
+    /// One of `noCheckpoints`, `consistent`, `truncated`, `headMismatch`,
+    /// or `chainBroken`.
+    pub status: String,
+    /// Human-readable detail. Always populated for a non-`consistent`
+    /// status so an operator reading the JSON knows what they are looking at.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+    /// Checkpoints found and signature-verified.
+    pub verified_checkpoints: usize,
+    /// Entries covered by the newest signed checkpoint.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub attested_entries: Option<u64>,
+    /// Chainable entries written **since** the newest checkpoint.
+    ///
+    /// These are the residual exposure: covered by the (forgeable) hash chain
+    /// but by no signature, so they can still be truncated undetectably. The
+    /// checkpoint interval bounds how large this gets.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub unattested_entries: Option<u64>,
+    /// When the newest checkpoint was signed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub newest_checkpoint_at: Option<String>,
+}
+
+/// Verify the signed-checkpoint chain and measure the live log against it.
+///
+/// Never returns `Err`: a verification endpoint that 500s on a checkpoint
+/// problem tells an operator less than one that reports the problem. Every
+/// failure becomes a `status` an operator can act on.
+///
+/// The community's *current* signing key is used to resolve every
+/// `verificationMethod`. That is correct today (no rotation has happened) and
+/// is the known limitation to lift next: a checkpoint signed under a retired
+/// key must stay verifiable, which means resolving the DID document's key
+/// history rather than assuming the live signer. Recorded on the
+/// `verification_method` field so the data needed is already being persisted.
+async fn verify_checkpoint_state(state: &AppState) -> CheckpointReport {
+    use vti_common::audit::{CheckpointAudit, CheckpointBreak, verify_checkpoints};
+
+    let broken = |detail: String| CheckpointReport {
+        status: "chainBroken".to_string(),
+        detail: Some(detail),
+        verified_checkpoints: 0,
+        attested_entries: None,
+        unattested_entries: None,
+        newest_checkpoint_at: None,
+    };
+
+    let checkpoints =
+        match crate::audit_checkpoint::load_checkpoints(&state.audit_checkpoint_ks).await {
+            Ok(c) => c,
+            Err(e) => return broken(format!("could not load checkpoints: {e}")),
+        };
+
+    let Some(signer) = state.credential_signer.as_ref() else {
+        return broken(
+            "no community signing key is available, so checkpoint signatures cannot be \
+             verified"
+                .to_string(),
+        );
+    };
+    let public = signer.public_bytes().to_vec();
+
+    let newest = match verify_checkpoints(&checkpoints, |_vm| Some(public.clone())) {
+        Ok(n) => n,
+        Err(brk) => {
+            let detail = match brk {
+                CheckpointBreak::BadSignature {
+                    index,
+                    checkpoint_id,
+                } => format!(
+                    "checkpoint {index} ({checkpoint_id}) has an invalid signature — it was \
+                     forged, altered, or signed by a key this community does not control"
+                ),
+                CheckpointBreak::BrokenLink {
+                    index,
+                    checkpoint_id,
+                } => format!(
+                    "checkpoint {index} ({checkpoint_id}) does not link to its predecessor — \
+                     a checkpoint was deleted, reordered, or inserted"
+                ),
+                CheckpointBreak::CountWentBackwards {
+                    index,
+                    checkpoint_id,
+                    previous,
+                    claimed,
+                } => format!(
+                    "checkpoint {index} ({checkpoint_id}) attests to {claimed} entries after \
+                     an earlier one attested to {previous}; the audit log only grows"
+                ),
+            };
+            return broken(detail);
+        }
+    };
+
+    let (chain_state, _unparseable) =
+        match crate::audit_checkpoint::measure_chain(&state.audit_ks).await {
+            Ok(m) => m,
+            Err(e) => return broken(format!("could not measure the audit chain: {e}")),
+        };
+
+    let outcome = match crate::audit_checkpoint::audit_against_checkpoint(
+        &state.audit_ks,
+        newest,
+        &chain_state,
+    )
+    .await
+    {
+        Ok(o) => o,
+        Err(e) => return broken(format!("could not compare the log to its checkpoint: {e}")),
+    };
+
+    let verified_checkpoints = checkpoints.len();
+    match outcome {
+        CheckpointAudit::NoCheckpoints => CheckpointReport {
+            status: "noCheckpoints".to_string(),
+            detail: Some(
+                "no signed checkpoints exist, so the audit log carries only unkeyed-chain \
+                 tamper-evidence: a store-level adversary could truncate or restamp it \
+                 undetectably"
+                    .to_string(),
+            ),
+            verified_checkpoints,
+            attested_entries: None,
+            unattested_entries: None,
+            newest_checkpoint_at: None,
+        },
+        CheckpointAudit::Consistent {
+            checkpoint_at,
+            attested_entries,
+            unattested_entries,
+        } => CheckpointReport {
+            status: "consistent".to_string(),
+            detail: None,
+            verified_checkpoints,
+            attested_entries: Some(attested_entries),
+            unattested_entries: Some(unattested_entries),
+            newest_checkpoint_at: Some(checkpoint_at.to_rfc3339()),
+        },
+        CheckpointAudit::Truncated { attested, found } => CheckpointReport {
+            status: "truncated".to_string(),
+            detail: Some(format!(
+                "TRUNCATION: the log holds {found} chainable entries but a checkpoint signed \
+                 with the community key attests to {attested}. Entries have been deleted."
+            )),
+            verified_checkpoints,
+            attested_entries: Some(attested),
+            unattested_entries: None,
+            newest_checkpoint_at: newest.map(|c| c.checkpoint_at.to_rfc3339()),
+        },
+        CheckpointAudit::HeadMismatch {
+            head_event_id,
+            found,
+        } => CheckpointReport {
+            status: "headMismatch".to_string(),
+            detail: Some(if found {
+                format!(
+                    "the envelope {head_event_id} that a signed checkpoint anchors to has been \
+                     rewritten — its entry hash no longer matches the attested head"
+                )
+            } else {
+                format!(
+                    "the envelope {head_event_id} that a signed checkpoint anchors to is \
+                     missing from the log"
+                )
+            }),
+            verified_checkpoints,
+            attested_entries: newest.map(|c| c.entry_count),
+            unattested_entries: None,
+            newest_checkpoint_at: newest.map(|c| c.checkpoint_at.to_rfc3339()),
+        },
+    }
 }
 
 /// A detected break, flattened for the wire.
@@ -384,7 +572,13 @@ pub struct ChainBreakReport {
 /// an unkeyed SHA-256, so an adversary with write access to the store
 /// can forge a suffix and restamp every envelope after it, and a
 /// truncation to a valid prefix is indistinguishable from a quiet
-/// period. Closing that needs signed checkpoints — see
+/// period.
+///
+/// That is what the `checkpoints` block closes (#708). Read it as the
+/// load-bearing half of this response: `verified: true` with
+/// `checkpoints.status: "truncated"` means the surviving log is internally
+/// consistent *and* provably shorter than the community key attested to —
+/// i.e. exactly the attack the chain alone cannot see. See
 /// `docs/05-design-notes/vtc-audit-checkpoints.md`.
 #[utoipa::path(
     get, path = "/audit/verify", tag = "audit",
@@ -439,6 +633,7 @@ pub async fn verify_audit_chain(
     }
 
     let verified = chain_break.is_none();
+    let checkpoints = verify_checkpoint_state(&state).await;
     let response = VerifyResponse {
         verified,
         entries_examined: verifier.index(),
@@ -447,6 +642,7 @@ pub async fn verify_audit_chain(
         unparseable_skipped: unparseable,
         head: verifier.head().map(hex::encode),
         chain_break,
+        checkpoints,
     };
 
     // Warn, not info, on failure: a broken audit chain is the kind of

--- a/vtc-service/src/server.rs
+++ b/vtc-service/src/server.rs
@@ -116,6 +116,9 @@ pub struct AppState {
     pub endorsements_ks: KeyspaceHandle,
     pub audit_ks: KeyspaceHandle,
     pub audit_key_ks: KeyspaceHandle,
+    /// Signed audit checkpoints (#708). Read by `GET /v1/audit/verify`,
+    /// written by the periodic `CheckpointEmitter`.
+    pub audit_checkpoint_ks: KeyspaceHandle,
     /// Durable delivery-layer outbox (D2 P1a). Backs
     /// [`vti_common::outbox_store::VtiOutboxStore`] for the messaging
     /// service's `Guaranteed` sends so delivery-critical work survives a
@@ -385,6 +388,7 @@ pub async fn run(
     let endorsements_ks = store.keyspace(keyspaces::ENDORSEMENTS)?;
     let audit_ks = store.keyspace(keyspaces::AUDIT)?;
     let audit_key_ks = store.keyspace(keyspaces::AUDIT_KEY)?;
+    let audit_checkpoint_ks = store.keyspace(keyspaces::AUDIT_CHECKPOINT)?;
     let consumed_invitations_ks = store.keyspace(keyspaces::CONSUMED_INVITATIONS)?;
     let invitations_ks = store.keyspace(keyspaces::INVITATIONS)?;
     let outbox_ks = store.keyspace(keyspaces::OUTBOX)?;
@@ -605,6 +609,7 @@ pub async fn run(
         endorsements_ks,
         audit_ks,
         audit_key_ks,
+        audit_checkpoint_ks: audit_checkpoint_ks.clone(),
         outbox_ks,
         consumed_invitations_ks,
         invitations_ks,
@@ -887,6 +892,37 @@ pub async fn run(
         boot_cfg.join_requests.clone(),
         shutdown_rx.clone(),
     );
+
+    // #708: spawn the signed-checkpoint emitter. Without it the audit chain
+    // is unkeyed all the way down — a store-level adversary can restamp a
+    // forged suffix or truncate the log to a valid prefix, and `verify` cannot
+    // tell. Requires the credential signer: checkpoints are signed with the
+    // *community* Ed25519 key, deliberately not the audit HMAC key (which
+    // lives in the same store the adversary is assumed to have reached, and
+    // whose symmetric verification would make every verifier a forger).
+    match state.credential_signer.as_ref().and_then(|s| {
+        s.ed25519_signing_key()
+            .map(|k| (k, s.assertion_method_id().to_string()))
+    }) {
+        Some((signing_key, verification_method)) => {
+            crate::audit_checkpoint::CheckpointEmitter::spawn(
+                state.audit_ks.clone(),
+                state.audit_checkpoint_ks.clone(),
+                signing_key,
+                verification_method,
+                boot_cfg.audit_checkpoints.clone(),
+                shutdown_rx.clone(),
+            );
+        }
+        None => {
+            // Not fatal — a VTC with no key material yet still runs — but it
+            // must not look like checkpointing is on when it isn't.
+            tracing::warn!(
+                "no community signing key available; audit checkpoints will NOT be \
+                 emitted and the audit log has only unkeyed-chain tamper-evidence"
+            );
+        }
+    }
 
     // M0.10: consume + audit any pending emergency-bootstrap marker
     // left behind by `vtc admin emergency-bootstrap`. The marker is

--- a/vtc-service/src/store/keyspaces.rs
+++ b/vtc-service/src/store/keyspaces.rs
@@ -36,6 +36,11 @@ pub const SCHEMAS: &str = "schemas";
 pub const ENDORSEMENTS: &str = "endorsements";
 pub const AUDIT: &str = "audit";
 pub const AUDIT_KEY: &str = "audit_key";
+/// Signed audit checkpoints (#708) — periodic Ed25519-signed commitments to
+/// the audit chain head *and its entry count*, which is what makes truncation
+/// detectable. Separate from [`AUDIT`] so a checkpoint is not just another row
+/// in the keyspace an adversary is assumed to control.
+pub const AUDIT_CHECKPOINT: &str = "audit_checkpoint";
 /// Single-use ledger for redeemed Invitation Credentials (VICs): one
 /// row per consumed VIC `id`, written when a VIC-driven join is
 /// admitted. Read at verify time to set `Invitation.consumed`.
@@ -75,6 +80,7 @@ pub const ALL: &[&str] = &[
     ENDORSEMENTS,
     AUDIT,
     AUDIT_KEY,
+    AUDIT_CHECKPOINT,
     CONSUMED_INVITATIONS,
     INVITATIONS,
     OUTBOX,
@@ -104,6 +110,11 @@ pub const BACKED_UP: &[&str] = &[
     ENDORSEMENTS,
     AUDIT,
     AUDIT_KEY,
+    // Required, not optional: restoring the audit log without its
+    // checkpoints reads as mass truncation — every signed checkpoint would
+    // attest to more entries than the restored log holds, so a legitimate
+    // restore would look exactly like the attack this mechanism detects.
+    AUDIT_CHECKPOINT,
     // A consumed VIC must stay consumed across a restore, else a
     // restored community could re-redeem a single-use invitation.
     CONSUMED_INVITATIONS,
@@ -139,7 +150,7 @@ mod tests {
     /// keyspace is added to one without the other, this trips.
     #[test]
     fn all_matches_app_state_keyspace_count() {
-        assert_eq!(ALL.len(), 24, "ALL must list every AppState keyspace");
+        assert_eq!(ALL.len(), 25, "ALL must list every AppState keyspace");
     }
 
     /// The backup census (P3.9): every keyspace is either backed up or

--- a/vtc-service/src/test_support.rs
+++ b/vtc-service/src/test_support.rs
@@ -228,6 +228,9 @@ impl TestVtcBuilder {
         let endorsements_ks = store.keyspace("endorsements").expect("endorsements ks");
         let audit_ks = store.keyspace("audit").expect("audit ks");
         let audit_key_ks = store.keyspace("audit_key").expect("audit_key ks");
+        let audit_checkpoint_ks = store
+            .keyspace("audit_checkpoint")
+            .expect("audit_checkpoint ks");
         let consumed_invitations_ks = store
             .keyspace("consumed_invitations")
             .expect("consumed_invitations ks");
@@ -349,6 +352,7 @@ impl TestVtcBuilder {
             endorsements_ks,
             audit_ks,
             audit_key_ks,
+            audit_checkpoint_ks,
             outbox_ks,
             consumed_invitations_ks,
             invitations_ks,

--- a/vtc-service/tests/audit_verify.rs
+++ b/vtc-service/tests/audit_verify.rs
@@ -201,3 +201,257 @@ async fn non_super_admin_is_refused() {
         "the audit chain is the community-wide god view"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Signed checkpoints (#708)
+// ---------------------------------------------------------------------------
+//
+// The chain tests above cover what an unkeyed SHA-256 can prove. These cover
+// what it *cannot*: an adversary who holds the store can restamp a forged
+// suffix or truncate to a valid prefix and the chain still verifies. Only a
+// signature made with a key that is not in the store contradicts that.
+
+use vti_common::audit::{AuditCheckpoint, CheckpointClaim};
+
+/// A fixture whose `credential_signer` is present, so checkpoints can be
+/// signed and verified. (`build()` above has no signer — checkpoint status
+/// there is `chainBroken`, which is itself asserted below.)
+async fn build_signed() -> Fixture {
+    let vtc = TestVtc::builder()
+        .with_audit(true)
+        .with_signers(true)
+        .build()
+        .await;
+    Fixture {
+        router: vtc.router.clone(),
+        state: vtc.state.clone(),
+        vtc,
+    }
+}
+
+/// Sign a checkpoint over the audit log's current state and persist it —
+/// what the periodic emitter does on a tick.
+async fn checkpoint_now(fix: &Fixture) -> AuditCheckpoint {
+    let signer = fix
+        .state
+        .credential_signer
+        .as_ref()
+        .expect("fixture built with signers");
+    let key = signer
+        .ed25519_signing_key()
+        .expect("community key is Ed25519");
+    vtc_service::audit_checkpoint::emit_checkpoint(
+        &fix.state.audit_ks,
+        &fix.state.audit_checkpoint_ks,
+        &key,
+        signer.assertion_method_id(),
+        chrono::Utc::now(),
+    )
+    .await
+    .expect("emit")
+    .expect("there were new entries to attest")
+}
+
+#[tokio::test]
+async fn a_log_with_no_checkpoints_says_so_rather_than_looking_clean() {
+    let fix = build_signed().await;
+    let token = super_admin_token(&fix).await;
+    seed_audit_rows(&fix, &token, 3).await;
+
+    let (status, body) = verify(&fix, &token).await;
+    assert_eq!(status, StatusCode::OK);
+    // The chain is fine...
+    assert_eq!(body["verified"], true, "body: {body}");
+    // ...but nothing has attested to it, and that must be visible.
+    assert_eq!(
+        body["checkpoints"]["status"], "noCheckpoints",
+        "body: {body}"
+    );
+}
+
+#[tokio::test]
+async fn a_checkpointed_log_verifies_as_consistent() {
+    let fix = build_signed().await;
+    let token = super_admin_token(&fix).await;
+    seed_audit_rows(&fix, &token, 4).await;
+    let cp = checkpoint_now(&fix).await;
+    assert!(
+        cp.entry_count >= 4,
+        "checkpoint should cover the seeded rows"
+    );
+
+    let (status, body) = verify(&fix, &token).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["verified"], true, "body: {body}");
+    assert_eq!(body["checkpoints"]["status"], "consistent", "body: {body}");
+    assert_eq!(body["checkpoints"]["verifiedCheckpoints"], 1);
+    assert_eq!(body["checkpoints"]["unattestedEntries"], 0);
+}
+
+/// **The whole point of #708.**
+///
+/// Delete a *suffix* of the log. The remaining prefix is a perfectly valid
+/// chain — `verified` stays `true`, exactly as it did before checkpoints
+/// existed — but it is now shorter than a signature made with the community
+/// key attests to, and that contradiction cannot be manufactured from the
+/// store alone.
+#[tokio::test]
+async fn truncating_the_log_is_caught_even_though_the_chain_still_verifies() {
+    let fix = build_signed().await;
+    let token = super_admin_token(&fix).await;
+    seed_audit_rows(&fix, &token, 6).await;
+    let cp = checkpoint_now(&fix).await;
+    let attested = cp.entry_count;
+
+    // Delete the newest two rows — the cheapest way to erase an incident,
+    // and one that needs no forgery at all.
+    let mut rows = fix
+        .state
+        .audit_ks
+        .prefix_iter_raw(Vec::new())
+        .await
+        .unwrap();
+    rows.sort_by(|(a, _), (b, _)| a.cmp(b));
+    assert!(rows.len() >= 3);
+    for (key, _) in rows.iter().rev().take(2) {
+        fix.state.audit_ks.remove(key.clone()).await.unwrap();
+    }
+
+    let (status, body) = verify(&fix, &token).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        body["verified"], true,
+        "a truncated prefix is still a valid chain — that is the whole problem: {body}"
+    );
+    assert_eq!(body["checkpoints"]["status"], "truncated", "body: {body}");
+    assert_eq!(body["checkpoints"]["attestedEntries"], attested);
+    assert!(
+        body["checkpoints"]["detail"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("TRUNCATION"),
+        "the detail must name the finding: {body}"
+    );
+}
+
+/// Deleting the checkpoints that contradict a truncated log must not restore
+/// a clean bill of health — otherwise the mechanism protects nothing.
+#[tokio::test]
+async fn deleting_a_checkpoint_is_itself_detected() {
+    let fix = build_signed().await;
+    let token = super_admin_token(&fix).await;
+
+    seed_audit_rows(&fix, &token, 2).await;
+    checkpoint_now(&fix).await;
+    seed_audit_rows(&fix, &token, 2).await;
+    checkpoint_now(&fix).await;
+
+    // Remove the *first* checkpoint, leaving the second orphaned.
+    let mut rows = fix
+        .state
+        .audit_checkpoint_ks
+        .prefix_iter_raw(Vec::new())
+        .await
+        .unwrap();
+    rows.sort_by(|(a, _), (b, _)| a.cmp(b));
+    assert_eq!(rows.len(), 2, "expected two checkpoints");
+    fix.state
+        .audit_checkpoint_ks
+        .remove(rows[0].0.clone())
+        .await
+        .unwrap();
+
+    let (status, body) = verify(&fix, &token).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["checkpoints"]["status"], "chainBroken", "body: {body}");
+    assert!(
+        body["checkpoints"]["detail"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("deleted"),
+        "detail should explain the broken checkpoint link: {body}"
+    );
+}
+
+/// A checkpoint minted by someone who holds the store but not the community
+/// key must not verify — that is the entire security argument for signing
+/// with the community key rather than the audit HMAC key.
+#[tokio::test]
+async fn a_checkpoint_forged_with_a_foreign_key_is_rejected() {
+    let fix = build_signed().await;
+    let token = super_admin_token(&fix).await;
+    seed_audit_rows(&fix, &token, 3).await;
+
+    let attacker = ed25519_dalek::SigningKey::from_bytes(&[0x42; 32]);
+    let signer = fix.state.credential_signer.as_ref().unwrap();
+    let forged = AuditCheckpoint::sign(
+        CheckpointClaim {
+            checkpoint_id: uuid::Uuid::new_v4(),
+            head: [0u8; 32],
+            entry_count: 0,
+            head_event_id: uuid::Uuid::nil(),
+            checkpoint_at: chrono::Utc::now(),
+            prev_checkpoint: None,
+            // Names the community's real key — but is not signed by it.
+            verification_method: signer.assertion_method_id().to_string(),
+        },
+        &attacker,
+    );
+    fix.state
+        .audit_checkpoint_ks
+        .insert(forged.storage_key(), &forged)
+        .await
+        .unwrap();
+
+    let (status, body) = verify(&fix, &token).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["checkpoints"]["status"], "chainBroken", "body: {body}");
+    assert!(
+        body["checkpoints"]["detail"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("invalid signature"),
+        "detail should name the bad signature: {body}"
+    );
+}
+
+/// Entries written since the last checkpoint are the live truncation window.
+/// They are real exposure, so the endpoint reports them rather than letting
+/// "consistent" imply everything is signed.
+#[tokio::test]
+async fn entries_written_after_a_checkpoint_are_reported_as_unattested() {
+    let fix = build_signed().await;
+    let token = super_admin_token(&fix).await;
+    seed_audit_rows(&fix, &token, 2).await;
+    let cp = checkpoint_now(&fix).await;
+    seed_audit_rows(&fix, &token, 3).await;
+
+    let (status, body) = verify(&fix, &token).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["checkpoints"]["status"], "consistent", "body: {body}");
+    assert_eq!(body["checkpoints"]["attestedEntries"], cp.entry_count);
+    assert!(
+        body["checkpoints"]["unattestedEntries"].as_u64().unwrap() >= 3,
+        "the post-checkpoint tail must be surfaced: {body}"
+    );
+}
+
+/// Without a community signing key there is nothing to verify against, and
+/// the endpoint must say so rather than report a green checkpoint status.
+#[tokio::test]
+async fn a_vtc_with_no_signing_key_cannot_claim_checkpoint_health() {
+    let fix = build().await; // no signers
+    let token = super_admin_token(&fix).await;
+    seed_audit_rows(&fix, &token, 2).await;
+
+    let (status, body) = verify(&fix, &token).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["checkpoints"]["status"], "chainBroken", "body: {body}");
+    assert!(
+        body["checkpoints"]["detail"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("no community signing key"),
+        "body: {body}"
+    );
+}

--- a/vtc-service/tests/backup.rs
+++ b/vtc-service/tests/backup.rs
@@ -209,3 +209,112 @@ async fn wrong_password_rejected() {
         "{err}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Audit checkpoints (#708)
+// ---------------------------------------------------------------------------
+
+/// The audit log and its signed checkpoints must travel **together**.
+///
+/// Either half alone turns a legitimate restore into the exact finding
+/// checkpoints exist to raise: checkpoints without their log attest to entries
+/// that aren't there, and a log without its checkpoints is shorter than every
+/// signed checkpoint claims. Both read as truncation to `cnm audit verify`.
+#[tokio::test]
+async fn audit_and_its_checkpoints_round_trip_together() {
+    let a = TestVtc::builder().vtc_did(VTC_DID).build().await;
+    set_config_path(&a.state, a.data_dir().join("config.toml")).await;
+    let a_store = PlaintextSecretStore::new(a.data_dir());
+    a_store.set(b"signing-bundle-A").await.unwrap();
+
+    a.state
+        .audit_ks
+        .insert_raw(b"2026-07-25T10:00:00Z:e1".to_vec(), b"envelope-1".to_vec())
+        .await
+        .unwrap();
+    a.state
+        .audit_checkpoint_ks
+        .insert_raw(
+            b"2026-07-25T10:05:00Z:c1".to_vec(),
+            b"checkpoint-1".to_vec(),
+        )
+        .await
+        .unwrap();
+
+    let envelope = export_backup(&a.state, &a_store, PW, true).await.unwrap();
+
+    let b = TestVtc::builder().vtc_did(VTC_DID).build().await;
+    set_config_path(&b.state, b.data_dir().join("config.toml")).await;
+    let b_store = PlaintextSecretStore::new(b.data_dir());
+    import_backup(&b.state, &b_store, &envelope, PW, true)
+        .await
+        .unwrap();
+
+    let audit_rows = b.state.audit_ks.prefix_iter_raw(Vec::new()).await.unwrap();
+    let cp_rows = b
+        .state
+        .audit_checkpoint_ks
+        .prefix_iter_raw(Vec::new())
+        .await
+        .unwrap();
+    assert_eq!(audit_rows.len(), 1, "audit log must be restored");
+    assert_eq!(
+        cp_rows.len(),
+        1,
+        "checkpoints must be restored alongside the log they attest to"
+    );
+}
+
+/// `include_audit: false` must drop **both**. Carrying the checkpoints while
+/// omitting the log would restore signed attestations to entries the restored
+/// VTC does not have.
+#[tokio::test]
+async fn excluding_the_audit_log_also_excludes_its_checkpoints() {
+    let a = TestVtc::builder().vtc_did(VTC_DID).build().await;
+    set_config_path(&a.state, a.data_dir().join("config.toml")).await;
+    let a_store = PlaintextSecretStore::new(a.data_dir());
+    a_store.set(b"signing-bundle-A").await.unwrap();
+
+    a.state
+        .audit_ks
+        .insert_raw(b"2026-07-25T10:00:00Z:e1".to_vec(), b"envelope-1".to_vec())
+        .await
+        .unwrap();
+    a.state
+        .audit_checkpoint_ks
+        .insert_raw(
+            b"2026-07-25T10:05:00Z:c1".to_vec(),
+            b"checkpoint-1".to_vec(),
+        )
+        .await
+        .unwrap();
+
+    let envelope = export_backup(&a.state, &a_store, PW, false).await.unwrap();
+
+    let b = TestVtc::builder().vtc_did(VTC_DID).build().await;
+    set_config_path(&b.state, b.data_dir().join("config.toml")).await;
+    let b_store = PlaintextSecretStore::new(b.data_dir());
+    import_backup(&b.state, &b_store, &envelope, PW, true)
+        .await
+        .unwrap();
+
+    assert!(
+        b.state
+            .audit_ks
+            .prefix_iter_raw(Vec::new())
+            .await
+            .unwrap()
+            .is_empty(),
+        "audit log was excluded"
+    );
+    assert!(
+        b.state
+            .audit_checkpoint_ks
+            .prefix_iter_raw(Vec::new())
+            .await
+            .unwrap()
+            .is_empty(),
+        "checkpoints must be excluded with the log — restoring them alone would \
+         attest to entries that are not there"
+    );
+}

--- a/vtc-service/tests/emergency_bootstrap.rs
+++ b/vtc-service/tests/emergency_bootstrap.rs
@@ -224,6 +224,7 @@ async fn build_fixture(public_url: Option<&str>) -> Fixture {
     let endorsements_ks = store.keyspace("endorsements").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
+    let audit_checkpoint_ks = store.keyspace("audit_checkpoint").unwrap();
     let outbox_ks = store.keyspace("outbox").unwrap();
     let invitations_ks = store.keyspace("invitations").unwrap();
     let consumed_invitations_ks = store.keyspace("consumed_invitations").unwrap();
@@ -326,6 +327,7 @@ async fn build_fixture(public_url: Option<&str>) -> Fixture {
         credential_signer: None,
         audit_ks,
         audit_key_ks,
+        audit_checkpoint_ks,
         outbox_ks,
         config: Arc::new(RwLock::new(config.clone())),
         did_resolver: None,

--- a/vtc-service/tests/passkey_state.rs
+++ b/vtc-service/tests/passkey_state.rs
@@ -53,6 +53,7 @@ fn build_state(public_url: Option<&str>) -> (AppState, tempfile::TempDir) {
     let endorsements_ks = store.keyspace("endorsements").unwrap();
     let audit_ks = store.keyspace("audit").unwrap();
     let audit_key_ks = store.keyspace("audit_key").unwrap();
+    let audit_checkpoint_ks = store.keyspace("audit_checkpoint").unwrap();
     let outbox_ks = store.keyspace("outbox").unwrap();
     let invitations_ks = store.keyspace("invitations").unwrap();
     let consumed_invitations_ks = store.keyspace("consumed_invitations").unwrap();
@@ -110,6 +111,7 @@ fn build_state(public_url: Option<&str>) -> (AppState, tempfile::TempDir) {
         install_store: vtc_service::install::InstallTokenStore::new(install_ks),
         audit_ks,
         audit_key_ks,
+        audit_checkpoint_ks,
         outbox_ks,
         audit_writer: None,
         shutdown_tx: tokio::sync::watch::channel(false).0,

--- a/vtc-service/tests/routing_cors.rs
+++ b/vtc-service/tests/routing_cors.rs
@@ -38,6 +38,7 @@ fn cfg_with(routing: RoutingConfig, cors: CorsConfig) -> AppConfig {
         },
         messaging: None,
         auth: Default::default(),
+        audit_checkpoints: Default::default(),
         secrets: Default::default(),
         routing,
         cors,

--- a/vti-common/Cargo.toml
+++ b/vti-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-common"
 description = "Shared server-side infrastructure for VTA and VTC services"
 readme = "README.md"
-version = "0.11.23"
+version = "0.11.24"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vti-common/src/audit/checkpoint.rs
+++ b/vti-common/src/audit/checkpoint.rs
@@ -1,0 +1,584 @@
+//! Signed audit checkpoints — tamper-evidence against a *store-level*
+//! adversary.
+//!
+//! # What the hash chain does not solve
+//!
+//! [`super::envelope::verify_chain`] detects reordering, dropping,
+//! duplication, and content edits. It does not detect a competent
+//! adversary, because [`super::AuditEnvelope::chain_digest`] is an
+//! **unkeyed** SHA-256: anyone who can write to the `audit` keyspace holds
+//! everything needed to recompute it. Two attacks follow directly.
+//!
+//! 1. **Restamping.** Edit or insert an envelope, recompute its `entry_hash`,
+//!    then walk forward restamping every successor. The result verifies
+//!    cleanly. O(entries after the edit), no secret required.
+//! 2. **Truncation.** Delete everything after some point. The remaining
+//!    prefix is a *valid chain*, and nothing records how long the log should
+//!    be — so a truncated log is indistinguishable from a community that went
+//!    quiet.
+//!
+//! Truncation is the cheaper attack and the more serious one: it erases an
+//! incident with no forgery at all.
+//!
+//! The actor/target HMAC does not help. It protects attribution (and enables
+//! RTBF via key rotation), not sequence integrity — and the writer holds that
+//! key anyway.
+//!
+//! # What a checkpoint adds
+//!
+//! A periodically-persisted, **signed** commitment to the chain head *and the
+//! number of entries behind it*. [`AuditCheckpoint::entry_count`] is the
+//! load-bearing field: a log shorter than a signed checkpoint claims is
+//! truncation, and that check cannot be spoofed without the signing key.
+//!
+//! # Why the community Ed25519 key, not the audit HMAC key
+//!
+//! | | Audit HMAC key | Community Ed25519 key |
+//! |---|---|---|
+//! | Verifiable by | the daemon only | anyone with the community DID |
+//! | Forgeable by a store-adversary | **yes** — it is in the same store | no |
+//!
+//! The HMAC key is rejected on both counts: it lives in the very store the
+//! adversary is assumed to have reached, and symmetric verification means
+//! whoever can *check* a checkpoint can also *forge* one — which reduces to
+//! the status quo. Signing with the community key instead makes checkpoints
+//! **externally** verifiable: an auditor holding only the community DID can
+//! confirm the log has not been rewritten, with no shared secret and no daemon
+//! access.
+//!
+//! Consequence accepted: verification depends on the community DID resolving,
+//! and on key rotation being handled — a checkpoint signed under a retired key
+//! must stay verifiable, which the `did:webvh` document history already
+//! provides. [`AuditCheckpoint::verification_method`] records which key signed.
+//!
+//! # What this still does not protect against
+//!
+//! An adversary who *also* holds the community signing key. Closing that needs
+//! the head published somewhere append-only (the community's own `did.jsonl`,
+//! a transparency log, a peer VTC). Out of scope — the signature is the
+//! prerequisite. See `docs/05-design-notes/vtc-audit-checkpoints.md`.
+
+use chrono::{DateTime, Utc};
+use ed25519_dalek::{Signature, Signer, SigningKey, Verifier, VerifyingKey};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+
+use super::envelope::{GENESIS_HASH, hash32_b64, hash32_opt_b64};
+
+/// Domain separator for the bytes a checkpoint signature covers.
+///
+/// Distinct from the envelope chain's `vtc-audit-chain/v1\0` so a signature
+/// over one can never be replayed as a signature over the other.
+const CHECKPOINT_DOMAIN: &[u8] = b"vtc-audit-checkpoint/v1\0";
+
+/// Domain separator for a checkpoint's *own* hash — the value the next
+/// checkpoint's [`AuditCheckpoint::prev_checkpoint`] points at.
+const CHECKPOINT_LINK_DOMAIN: &[u8] = b"vtc-audit-checkpoint-link/v1\0";
+
+/// A signed commitment to the audit chain's state at a point in time.
+///
+/// Stored in the `audit_checkpoint` keyspace keyed by `<rfc3339>:<uuid>`,
+/// matching the audit keyspace's convention so an ascending walk is
+/// chronological.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct AuditCheckpoint {
+    /// Stable identifier for this checkpoint.
+    pub checkpoint_id: Uuid,
+
+    /// `entry_hash` of the newest chainable envelope at checkpoint time.
+    #[serde(with = "hash32_b64")]
+    pub head: [u8; 32],
+
+    /// Total **chainable** (v2+) envelopes written up to and including
+    /// [`Self::head`].
+    ///
+    /// This is the field that makes truncation detectable: a log holding
+    /// fewer chainable entries than a signed checkpoint claims has lost
+    /// entries, and no amount of restamping fixes that without the signing
+    /// key. Counting only chainable envelopes matters — pre-v2 rows are
+    /// skipped by the verifier, so including them would make the count
+    /// disagree with what verification can actually recount.
+    pub entry_count: u64,
+
+    /// `event_id` of the envelope at [`Self::head`], so a verifier can locate
+    /// the anchor point directly instead of recomputing the whole chain.
+    pub head_event_id: Uuid,
+
+    /// Wall-clock at checkpoint time.
+    pub checkpoint_at: DateTime<Utc>,
+
+    /// The previous checkpoint's own [`Self::link_hash`], or `None` for the
+    /// first. Checkpoints chain too, so **deleting a checkpoint is itself
+    /// detectable** — otherwise an adversary would simply drop the
+    /// checkpoints that contradict a truncated log.
+    #[serde(with = "hash32_opt_b64")]
+    pub prev_checkpoint: Option<[u8; 32]>,
+
+    /// `verificationMethod` URI of the key that signed this checkpoint (e.g.
+    /// `did:webvh:…#key-0`). Recorded so a checkpoint stays verifiable across
+    /// a key rotation: a verifier resolves *this* key from the community's DID
+    /// document history rather than assuming the current one.
+    pub verification_method: String,
+
+    /// Ed25519 signature over [`Self::signing_payload`].
+    #[serde(with = "sig_b64")]
+    pub signature: Vec<u8>,
+}
+
+/// Everything a checkpoint commits to, except the signature itself.
+///
+/// Split out so [`AuditCheckpoint::sign`] and
+/// [`AuditCheckpoint::verify_signature`] cannot disagree about what is signed
+/// — the classic way a signature scheme ends up covering less than it appears
+/// to.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CheckpointClaim {
+    pub checkpoint_id: Uuid,
+    pub head: [u8; 32],
+    pub entry_count: u64,
+    pub head_event_id: Uuid,
+    pub checkpoint_at: DateTime<Utc>,
+    pub prev_checkpoint: Option<[u8; 32]>,
+    pub verification_method: String,
+}
+
+impl CheckpointClaim {
+    /// The exact bytes an Ed25519 signature covers.
+    ///
+    /// Length-prefixed and domain-tagged rather than a JSON encoding: the
+    /// signature must not depend on serializer field ordering or on a
+    /// canonicalisation step that could differ between signer and verifier.
+    /// Same reasoning as the envelope's `chain_digest`.
+    #[must_use]
+    pub fn signing_payload(&self) -> Vec<u8> {
+        let mut out = Vec::with_capacity(256);
+        out.extend_from_slice(CHECKPOINT_DOMAIN);
+        out.extend_from_slice(self.checkpoint_id.as_bytes());
+        out.extend_from_slice(&self.head);
+        out.extend_from_slice(&self.entry_count.to_be_bytes());
+        out.extend_from_slice(self.head_event_id.as_bytes());
+        let ts = self.checkpoint_at.to_rfc3339();
+        out.extend_from_slice(&(ts.len() as u64).to_be_bytes());
+        out.extend_from_slice(ts.as_bytes());
+        match self.prev_checkpoint {
+            Some(p) => {
+                out.push(1);
+                out.extend_from_slice(&p);
+            }
+            None => out.push(0),
+        }
+        out.extend_from_slice(&(self.verification_method.len() as u64).to_be_bytes());
+        out.extend_from_slice(self.verification_method.as_bytes());
+        out
+    }
+}
+
+impl AuditCheckpoint {
+    /// Build and sign a checkpoint with `signing_key`.
+    ///
+    /// `verification_method` must name the public key corresponding to
+    /// `signing_key` in the community's DID document — a verifier resolves it
+    /// to check the signature.
+    #[must_use]
+    pub fn sign(claim: CheckpointClaim, signing_key: &SigningKey) -> Self {
+        let signature = signing_key
+            .sign(&claim.signing_payload())
+            .to_bytes()
+            .to_vec();
+        Self {
+            checkpoint_id: claim.checkpoint_id,
+            head: claim.head,
+            entry_count: claim.entry_count,
+            head_event_id: claim.head_event_id,
+            checkpoint_at: claim.checkpoint_at,
+            prev_checkpoint: claim.prev_checkpoint,
+            verification_method: claim.verification_method,
+            signature,
+        }
+    }
+
+    /// The claim this checkpoint carries — the signed half of it.
+    #[must_use]
+    pub fn claim(&self) -> CheckpointClaim {
+        CheckpointClaim {
+            checkpoint_id: self.checkpoint_id,
+            head: self.head,
+            entry_count: self.entry_count,
+            head_event_id: self.head_event_id,
+            checkpoint_at: self.checkpoint_at,
+            prev_checkpoint: self.prev_checkpoint,
+            verification_method: self.verification_method.clone(),
+        }
+    }
+
+    /// Verify the signature against `public_key` (32 raw Ed25519 bytes).
+    ///
+    /// Returns `false` for a malformed key or signature as well as a genuine
+    /// mismatch — from the verifier's point of view those are the same
+    /// finding: this checkpoint does not prove anything.
+    #[must_use]
+    pub fn verify_signature(&self, public_key: &[u8]) -> bool {
+        let Ok(key_bytes) = <[u8; 32]>::try_from(public_key) else {
+            return false;
+        };
+        let Ok(verifying) = VerifyingKey::from_bytes(&key_bytes) else {
+            return false;
+        };
+        let Ok(sig_bytes) = <[u8; 64]>::try_from(self.signature.as_slice()) else {
+            return false;
+        };
+        verifying
+            .verify(
+                &self.claim().signing_payload(),
+                &Signature::from_bytes(&sig_bytes),
+            )
+            .is_ok()
+    }
+
+    /// This checkpoint's own hash — what the next one's
+    /// [`Self::prev_checkpoint`] points at.
+    ///
+    /// Covers the signature as well as the claim, so swapping a valid
+    /// signature for a different valid signature over the same claim still
+    /// breaks the link.
+    #[must_use]
+    pub fn link_hash(&self) -> [u8; 32] {
+        let mut h = Sha256::new();
+        h.update(CHECKPOINT_LINK_DOMAIN);
+        h.update(self.claim().signing_payload());
+        h.update((self.signature.len() as u64).to_be_bytes());
+        h.update(&self.signature);
+        h.finalize().into()
+    }
+
+    /// Storage key: `<rfc3339>:<checkpoint_id>`, so an ascending prefix walk
+    /// is chronological (matching the audit keyspace's convention).
+    #[must_use]
+    pub fn storage_key(&self) -> Vec<u8> {
+        format!("{}:{}", self.checkpoint_at.to_rfc3339(), self.checkpoint_id).into_bytes()
+    }
+}
+
+/// Why a checkpoint chain failed to verify.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CheckpointBreak {
+    /// The signature does not verify under the resolved public key. The
+    /// checkpoint was forged, altered, or signed by a different key than
+    /// `verification_method` names.
+    BadSignature { index: usize, checkpoint_id: Uuid },
+    /// `prev_checkpoint` does not point at the previous checkpoint's
+    /// `link_hash` — a checkpoint was reordered, dropped, or inserted.
+    BrokenLink { index: usize, checkpoint_id: Uuid },
+    /// `entry_count` went backwards. The audit log only grows, so a later
+    /// checkpoint claiming fewer entries than an earlier one is a forgery or
+    /// a replay of an older checkpoint under a later timestamp.
+    CountWentBackwards {
+        index: usize,
+        checkpoint_id: Uuid,
+        previous: u64,
+        claimed: u64,
+    },
+}
+
+/// Verify a checkpoint chain in ascending (chronological) order.
+///
+/// Checks each signature, the `prev_checkpoint` links, and that
+/// `entry_count` is monotonically non-decreasing. Returns the newest
+/// checkpoint on success, or `None` when `checkpoints` is empty (a community
+/// that has not checkpointed yet — not an error).
+///
+/// `public_key_for` resolves a `verification_method` URI to raw Ed25519 public
+/// bytes. It is a callback rather than a single key so a checkpoint signed
+/// before a key rotation still verifies against the key that actually signed
+/// it. Returning `None` fails that checkpoint as [`CheckpointBreak::BadSignature`]
+/// — an unresolvable signing key proves nothing.
+pub fn verify_checkpoints<F>(
+    checkpoints: &[AuditCheckpoint],
+    mut public_key_for: F,
+) -> Result<Option<&AuditCheckpoint>, CheckpointBreak>
+where
+    F: FnMut(&str) -> Option<Vec<u8>>,
+{
+    let mut prev_link: Option<[u8; 32]> = None;
+    let mut prev_count: u64 = 0;
+
+    for (index, cp) in checkpoints.iter().enumerate() {
+        let ok = public_key_for(&cp.verification_method).is_some_and(|pk| cp.verify_signature(&pk));
+        if !ok {
+            return Err(CheckpointBreak::BadSignature {
+                index,
+                checkpoint_id: cp.checkpoint_id,
+            });
+        }
+        if cp.prev_checkpoint != prev_link {
+            return Err(CheckpointBreak::BrokenLink {
+                index,
+                checkpoint_id: cp.checkpoint_id,
+            });
+        }
+        if cp.entry_count < prev_count {
+            return Err(CheckpointBreak::CountWentBackwards {
+                index,
+                checkpoint_id: cp.checkpoint_id,
+                previous: prev_count,
+                claimed: cp.entry_count,
+            });
+        }
+        prev_link = Some(cp.link_hash());
+        prev_count = cp.entry_count;
+    }
+
+    Ok(checkpoints.last())
+}
+
+/// How the audit log measured up against its newest signed checkpoint.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CheckpointAudit {
+    /// No checkpoints exist. Nothing is contradicted, but nothing is
+    /// attested either — the log carries only unkeyed-chain assurance.
+    NoCheckpoints,
+    /// The log is consistent with the newest checkpoint.
+    Consistent {
+        checkpoint_at: DateTime<Utc>,
+        attested_entries: u64,
+        /// Chainable entries written *since* the checkpoint. These are
+        /// covered by the hash chain but not by any signature — an
+        /// adversary can still truncate this tail freely, so it is the
+        /// residual exposure and worth surfacing.
+        unattested_entries: u64,
+    },
+    /// **Truncation.** The log holds fewer chainable entries than the newest
+    /// signed checkpoint attests to. This is the finding the whole mechanism
+    /// exists for and cannot be produced without the signing key.
+    Truncated { attested: u64, found: u64 },
+    /// The envelope named by `head_event_id` is missing, or its `entry_hash`
+    /// no longer matches the signed `head`. The attested anchor point has
+    /// been removed or rewritten.
+    HeadMismatch {
+        head_event_id: Uuid,
+        /// `false` when the envelope is absent entirely rather than altered.
+        found: bool,
+    },
+}
+
+// Base64 codec for the signature, matching the envelope's hash encodings so
+// the whole audit surface serialises consistently.
+mod sig_b64 {
+    use base64::Engine as _;
+    use base64::engine::general_purpose::STANDARD as B64;
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S: Serializer>(v: &[u8], s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(&B64.encode(v))
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Vec<u8>, D::Error> {
+        let s = String::deserialize(d)?;
+        B64.decode(s.as_bytes()).map_err(serde::de::Error::custom)
+    }
+}
+
+/// A checkpoint over an empty log anchors at [`GENESIS_HASH`] with a zero
+/// count — the same convention the envelope chain uses for its first link.
+#[must_use]
+pub fn genesis_claim(
+    checkpoint_id: Uuid,
+    checkpoint_at: DateTime<Utc>,
+    verification_method: String,
+) -> CheckpointClaim {
+    CheckpointClaim {
+        checkpoint_id,
+        head: GENESIS_HASH,
+        entry_count: 0,
+        head_event_id: Uuid::nil(),
+        checkpoint_at,
+        prev_checkpoint: None,
+        verification_method,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key(seed: u8) -> SigningKey {
+        SigningKey::from_bytes(&[seed; 32])
+    }
+
+    fn claim(n: u64, prev: Option<[u8; 32]>) -> CheckpointClaim {
+        CheckpointClaim {
+            checkpoint_id: Uuid::from_u128(u128::from(n) + 1),
+            head: [n as u8; 32],
+            entry_count: n,
+            head_event_id: Uuid::from_u128(u128::from(n) + 1000),
+            checkpoint_at: DateTime::parse_from_rfc3339("2026-07-25T10:00:00Z")
+                .unwrap()
+                .with_timezone(&Utc),
+            prev_checkpoint: prev,
+            verification_method: "did:webvh:scid:vtc.example#key-0".into(),
+        }
+    }
+
+    fn chain(sk: &SigningKey, counts: &[u64]) -> Vec<AuditCheckpoint> {
+        let mut out: Vec<AuditCheckpoint> = Vec::new();
+        for &n in counts {
+            let prev = out.last().map(AuditCheckpoint::link_hash);
+            out.push(AuditCheckpoint::sign(claim(n, prev), sk));
+        }
+        out
+    }
+
+    fn resolver(sk: &SigningKey) -> impl FnMut(&str) -> Option<Vec<u8>> + use<'_> {
+        move |_vm: &str| Some(sk.verifying_key().to_bytes().to_vec())
+    }
+
+    #[test]
+    fn a_signed_checkpoint_verifies_under_its_own_key() {
+        let sk = key(1);
+        let cp = AuditCheckpoint::sign(claim(10, None), &sk);
+        assert!(cp.verify_signature(&sk.verifying_key().to_bytes()));
+    }
+
+    /// The point of signing: a store-level adversary holds the store but not
+    /// the community key, so a checkpoint they mint does not verify.
+    #[test]
+    fn a_checkpoint_signed_by_a_different_key_is_rejected() {
+        let real = key(1);
+        let attacker = key(2);
+        let forged = AuditCheckpoint::sign(claim(10, None), &attacker);
+        assert!(!forged.verify_signature(&real.verifying_key().to_bytes()));
+    }
+
+    /// Editing any signed field invalidates the signature. `entry_count` is
+    /// the one that matters — lowering it is how an adversary would try to
+    /// make a truncated log look complete.
+    #[test]
+    fn lowering_entry_count_breaks_the_signature() {
+        let sk = key(1);
+        let mut cp = AuditCheckpoint::sign(claim(500, None), &sk);
+        cp.entry_count = 3;
+        assert!(!cp.verify_signature(&sk.verifying_key().to_bytes()));
+    }
+
+    #[test]
+    fn head_cannot_be_swapped() {
+        let sk = key(1);
+        let mut cp = AuditCheckpoint::sign(claim(10, None), &sk);
+        cp.head = [0xAB; 32];
+        assert!(!cp.verify_signature(&sk.verifying_key().to_bytes()));
+    }
+
+    #[test]
+    fn a_well_formed_chain_verifies() {
+        let sk = key(1);
+        let cps = chain(&sk, &[10, 25, 40]);
+        let newest = verify_checkpoints(&cps, resolver(&sk)).expect("chain verifies");
+        assert_eq!(newest.map(|c| c.entry_count), Some(40));
+    }
+
+    /// Checkpoints chain so that *deleting one* is detectable — otherwise an
+    /// adversary would simply drop the checkpoints contradicting a truncated
+    /// log, and the mechanism would protect nothing.
+    #[test]
+    fn deleting_a_checkpoint_breaks_the_chain() {
+        let sk = key(1);
+        let cps = chain(&sk, &[10, 25, 40]);
+        let gapped = vec![cps[0].clone(), cps[2].clone()];
+        assert!(matches!(
+            verify_checkpoints(&gapped, resolver(&sk)),
+            Err(CheckpointBreak::BrokenLink { index: 1, .. })
+        ));
+    }
+
+    #[test]
+    fn reordering_checkpoints_breaks_the_chain() {
+        let sk = key(1);
+        let cps = chain(&sk, &[10, 25]);
+        let swapped = vec![cps[1].clone(), cps[0].clone()];
+        assert!(matches!(
+            verify_checkpoints(&swapped, resolver(&sk)),
+            Err(CheckpointBreak::BrokenLink { .. })
+        ));
+    }
+
+    /// A replayed older checkpoint re-linked under a later position would let
+    /// an adversary lower the attested count without forging a signature.
+    #[test]
+    fn entry_count_may_not_go_backwards() {
+        let sk = key(1);
+        // Hand-build a chain whose second link is genuinely signed but claims
+        // fewer entries than the first.
+        let first = AuditCheckpoint::sign(claim(40, None), &sk);
+        let second = AuditCheckpoint::sign(claim(10, Some(first.link_hash())), &sk);
+        assert!(matches!(
+            verify_checkpoints(&[first, second], resolver(&sk)),
+            Err(CheckpointBreak::CountWentBackwards {
+                previous: 40,
+                claimed: 10,
+                ..
+            })
+        ));
+    }
+
+    /// An unresolvable `verification_method` proves nothing, so it must fail
+    /// rather than be skipped — skipping would let an adversary sign with a
+    /// key they invented and name it something that does not resolve.
+    #[test]
+    fn an_unresolvable_signing_key_fails_verification() {
+        let sk = key(1);
+        let cps = chain(&sk, &[10]);
+        assert!(matches!(
+            verify_checkpoints(&cps, |_vm: &str| None),
+            Err(CheckpointBreak::BadSignature { index: 0, .. })
+        ));
+    }
+
+    #[test]
+    fn an_empty_checkpoint_set_is_not_an_error() {
+        let sk = key(1);
+        assert_eq!(verify_checkpoints(&[], resolver(&sk)), Ok(None));
+    }
+
+    #[test]
+    fn checkpoints_round_trip_through_json() {
+        let sk = key(1);
+        let cp = AuditCheckpoint::sign(claim(7, Some([9u8; 32])), &sk);
+        let json = serde_json::to_vec(&cp).expect("serialize");
+        let back: AuditCheckpoint = serde_json::from_slice(&json).expect("deserialize");
+        assert_eq!(cp, back);
+        assert!(back.verify_signature(&sk.verifying_key().to_bytes()));
+    }
+
+    /// The signature must not be replayable as an envelope-chain digest, nor
+    /// a link hash confusable with a signing payload.
+    #[test]
+    fn link_hash_and_signing_payload_are_domain_separated() {
+        let sk = key(1);
+        let cp = AuditCheckpoint::sign(claim(10, None), &sk);
+        assert_ne!(cp.link_hash().to_vec(), cp.claim().signing_payload());
+    }
+
+    /// Two checkpoints differing only in signature must not share a link
+    /// hash — otherwise a signature swap would be invisible to the chain.
+    #[test]
+    fn link_hash_covers_the_signature() {
+        let a = AuditCheckpoint::sign(claim(10, None), &key(1));
+        let b = AuditCheckpoint::sign(claim(10, None), &key(2));
+        assert_eq!(a.claim(), b.claim(), "same claim");
+        assert_ne!(a.link_hash(), b.link_hash(), "different signature");
+    }
+
+    #[test]
+    fn storage_key_sorts_chronologically() {
+        let sk = key(1);
+        let mut early = claim(1, None);
+        early.checkpoint_at = DateTime::parse_from_rfc3339("2026-07-25T09:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let a = AuditCheckpoint::sign(early, &sk);
+        let b = AuditCheckpoint::sign(claim(2, Some(a.link_hash())), &sk);
+        assert!(a.storage_key() < b.storage_key());
+    }
+}

--- a/vti-common/src/audit/envelope.rs
+++ b/vti-common/src/audit/envelope.rs
@@ -313,7 +313,7 @@ impl ChainVerifier {
 pub(crate) const B64: base64::engine::general_purpose::GeneralPurpose =
     base64::engine::general_purpose::URL_SAFE_NO_PAD;
 
-mod hash32_b64 {
+pub(super) mod hash32_b64 {
     use super::B64;
     use base64::Engine as _;
     use serde::{Deserialize, Deserializer, Serializer};
@@ -330,7 +330,7 @@ mod hash32_b64 {
     }
 }
 
-mod hash32_opt_b64 {
+pub(super) mod hash32_opt_b64 {
     use super::B64;
     use base64::Engine as _;
     use serde::{Deserialize, Deserializer, Serializer};

--- a/vti-common/src/audit/mod.rs
+++ b/vti-common/src/audit/mod.rs
@@ -24,11 +24,16 @@
 //!   the identifiers with the active key, and persists the envelope
 //!   into an `audit` keyspace.
 
+pub mod checkpoint;
 pub mod envelope;
 pub mod event;
 pub mod key_store;
 pub mod writer;
 
+pub use checkpoint::{
+    AuditCheckpoint, CheckpointAudit, CheckpointBreak, CheckpointClaim, genesis_claim,
+    verify_checkpoints,
+};
 pub use envelope::{
     AuditEnvelope, ChainBreak, ChainVerifier, EVENT_VERSION, GENESIS_HASH, SCHEMA_VERSION,
     verify_chain,


### PR DESCRIPTION
Closes #708. Implements `docs/05-design-notes/vtc-audit-checkpoints.md`, which had the signer decision already made.

## The gap

The `prev_hash` chain (#555) and `GET /v1/audit/verify` (#703) catch reordering, dropping, duplication, and content edits. They do **not** catch the adversary #537 tier 3 actually named — one with write access to the `audit` keyspace — because `chain_digest` is an **unkeyed** SHA-256, so that adversary holds everything needed to recompute it:

- **Restamping** — edit or insert an envelope, recompute its `entry_hash`, walk forward restamping every successor. Verifies cleanly. No secret required.
- **Truncation** — delete everything after some point. The remaining prefix is a *valid chain*, and nothing recorded how long the log should be. A truncated log was indistinguishable from a community that went quiet.

Truncation is the cheaper attack and the more serious one: it erases an incident with no forgery at all.

## What ships

A periodic `AuditCheckpoint` signed with the **community Ed25519 key**, committing to the chain head *and* `entry_count`. That count is the load-bearing field: a log shorter than a signed checkpoint attests to has lost entries, and that contradiction cannot be manufactured from the store alone.

**Not the audit HMAC key** — it lives in the very store the adversary is assumed to have reached, and symmetric verification means whoever can *check* a checkpoint can also *forge* one, which reduces to the status quo. The community key also makes checkpoints externally verifiable: an auditor holding only the community DID can confirm the log has not been rewritten, with no shared secret and no daemon access.

Checkpoints chain to each other, so deleting the one that contradicts a truncated log is itself detectable — without that, the mechanism would protect nothing.

### Three additions beyond the design note

Each demanded by the threat model rather than by taste:

1. **`entry_count` must be monotonic** across the checkpoint chain. Otherwise an adversary re-links a genuinely-signed *older* checkpoint into a later position and lowers the attested count without forging anything.
2. **`emit_checkpoint` refuses to sign** when the live log already holds fewer entries than the last checkpoint claims. Signing there would launder a truncation into a freshly-signed "this is fine".
3. **Each checkpoint records its `verificationMethod`**, so one signed under a later-retired key stays verifiable.

### Cadence — the note's open question

Time-based, default 15 min, `[audit_checkpoints] interval_secs`, `0` disables with a loud `WARN`. The interval *is* the attacker's free truncation window, so it sets residual risk directly.

Count-based triggering was **deliberately not implemented**: doing it honestly needs a running entry counter in `AuditWriter`, and approximating it by polling more often means walking the whole audit keyspace on a timer. A shorter interval is the cheaper knob and bounds the window in *time* regardless of traffic. The reasoning is on the module so it isn't relitigated.

## Operator surface

`GET /v1/audit/verify` gains a `checkpoints` block — `consistent` / `truncated` / `headMismatch` / `chainBroken` / `noCheckpoints` — with `attestedEntries` and `unattestedEntries`. That last one is the live truncation window (entries written since the last checkpoint, covered by the forgeable chain and no signature), reported rather than left implicit.

`cnm audit verify` prints it and **exits non-zero on a checkpoint failure even when the chain verifies**. That combination *is* the store-level attack — an internally consistent log the community key says is missing entries — and exiting 0 would make `cnm audit verify || alert` silent for the one thing checkpoints exist to catch.

## Backup

`audit_checkpoint` is in `BACKED_UP`, gated on the same `include_audit` flag as `audit`. The pairing is not optional and is pinned by two tests: checkpoints without their log attest to entries that aren't there, and a log without its checkpoints is shorter than every checkpoint claims. Either half alone turns a legitimate restore into the truncation finding.

## Tests

31 new. The load-bearing ones:

- `truncating_the_log_is_caught_even_though_the_chain_still_verifies` — end-to-end: seed, checkpoint, delete the newest rows, then assert `verified: true` **and** `checkpoints.status: "truncated"`. That assertion pair is the whole PR.
- `deleting_a_checkpoint_is_itself_detected`
- `a_checkpoint_forged_with_a_foreign_key_is_rejected` — a checkpoint naming the real key but signed by another.
- `emitting_refuses_when_the_log_shrank_below_a_signed_checkpoint`
- `entry_count_may_not_go_backwards`
- `excluding_the_audit_log_also_excludes_its_checkpoints`
- `a_vtc_with_no_signing_key_cannot_claim_checkpoint_health`

`cargo test --workspace` green (exit 0). `cargo clippy --workspace --all-targets` and `cargo fmt --check` clean. Both CI guards pass.

## Known limitation, recorded not hidden

`verify_checkpoint_state` resolves every `verificationMethod` to the VTC's **current** signing key, so a community key rotation would strand older checkpoints. The per-checkpoint field is already persisted for the fix (resolve the DID document's key history) — a verifier change with no data migration. Noted in the design note and on the function.

**Also still open** (unchanged, and stated in the note): external anchoring. Checkpoints do not stop an adversary who *also* holds the signing key; publishing the head somewhere append-only would. The signature was the prerequisite.

**Merge note:** bumps `vtc-service` to 0.11.26, same as #796 and #797. Whichever lands last needs a rebase.
