### PR TITLE
feat(mobile): DID→name display seam for the mobile agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,43 @@ against an adversary who *also* holds the signing key — remains out of scope
 and is the next step.
 
 Closes #708.
+
+### vta-mobile-core 0.6.16 — give the phone the DID→name seam every other surface already has
+
+The mobile agent shows DIDs where it has no choice: who is asking for a step-up,
+who delivered a task-consent request, which VTA and mediator it is bound to. A
+`did:webvh` in a phone caption is unreadable, and on an approval sheet
+unreadable is not cosmetic — it is the operator approving something they cannot
+identify.
+
+New `vta_mobile_core::display_name`, a thin FFI skin over `vta_sdk::display_name`
+— the same seam the PNM/CNM CLIs, the VTC CLI and the admin console render
+through. Two exports:
+
+* `resolve_agent_name(did) -> Option<AgentName { name, verified }>` — the
+  round-tripped lookup, `display_name::agent_name::lookup` verbatim. Infallible
+  by design: an unreachable name server must degrade to showing the DID, never
+  fail the operator's approval.
+* `shorten_did(did) -> String` — the pure abbreviation, exported rather than
+  ported so the phone cannot drift from the CLIs and the console. An operator
+  moves between all three looking at the same community.
+
+**Why a skin and not an implementation.** A name is only safe to show because it
+round-tripped: the DID's document claimed it *and* resolving that name led back
+to the same DID. `alsoKnownAs` alone is self-asserted, so a hostile DID can claim
+`mybank.com/@treasury`, and a display layer printing that bare has told the
+operator they are looking at their bank — on the one screen where they are about
+to approve something. That defence is already written and tested in `vta-sdk`;
+re-deriving it in the engine, or across the FFI in Swift, would mean two
+implementations of a spoofing check that must agree forever. So the *verdict*
+crosses the boundary instead — `verified` is `vta-sdk`'s conclusion, and the
+app's job is to not discard it.
+
+Enables `vta-sdk/agent-names` for the mobile crate. Nothing in this workspace
+publishes an `alsoKnownAs` entry yet, so `resolve_agent_name` returns `None` for
+every DID today — the surfaces are wired so that minting names lights them up
+without another mobile release.
+
 ### vtc-service 0.11.27 — a REST-only client can now refresh without a mediator
 
 `POST /v1/auth/refresh` went straight to `atm.unpack` and — correctly, since

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10228,7 +10228,7 @@ dependencies = [
 
 [[package]]
 name = "vta-mobile-core"
-version = "0.6.15"
+version = "0.6.16"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",

--- a/vta-mobile-core/Cargo.toml
+++ b/vta-mobile-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vta-mobile-core"
-version = "0.6.15"
+version = "0.6.16"
 description = "UniFFI engine for the VTA mobile agent (Android/iOS): DIDComm, Trust Tasks, AAL step-up."
 edition.workspace = true
 # Not a crates.io library — the published artifacts are the Android AAR
@@ -61,7 +61,15 @@ affinidi-messaging-didcomm = "0.15"
 # `vta-sdk::DIDCommSession` (connect + receive_next) so the mobile approver can
 # pull VTA-pushed step-up approve-requests off the mediator — reusing the SDK
 # the VTA uses rather than reimplementing the affinidi mediator protocol.
-vta-sdk = { path = "../vta-sdk", version = "0.20", features = ["session", "tsp"] }
+# `agent-names` enables `display_name::agent_name` — the round-tripped DID→name
+# lookup the approval sheets render through. Costs a DID resolution plus an
+# outbound fetch per claimed name, which is why the app resolves lazily and
+# caches; see `crate::display_name`.
+vta-sdk = { path = "../vta-sdk", version = "0.20", features = [
+  "session",
+  "tsp",
+  "agent-names",
+] }
 # iOS has no native trust store that `rustls-native-certs` can read, so the
 # mediator WebSocket (tokio-tungstenite, via affinidi-messaging-sdk) fails with
 # "no native root CA certificates found". Declaring tokio-tungstenite here with

--- a/vta-mobile-core/src/display_name.rs
+++ b/vta-mobile-core/src/display_name.rs
@@ -1,0 +1,139 @@
+//! DID → human-readable name, for the mobile agent's display surfaces.
+//!
+//! The phone shows DIDs where it has no choice: *who* is asking for a step-up,
+//! *who* delivered a task-consent request, which VTA and mediator it is bound
+//! to. A `did:webvh` in a caption is unreadable, and on an approval sheet
+//! unreadable is not a cosmetic problem — it is the operator approving something
+//! they cannot identify.
+//!
+//! This module is a thin FFI skin over [`vta_sdk::display_name`], which every
+//! other operator surface in the workspace already renders through (the PNM/CNM
+//! CLIs, the VTC CLI, the admin console). Two exports:
+//!
+//! - [`resolve_agent_name`] — the network lookup, [`agent_name::lookup`] verbatim.
+//! - [`shorten_did`] — the pure abbreviation, [`display_name::shorten_did`]
+//!   verbatim.
+//!
+//! # Why this is a skin and not an implementation
+//!
+//! An agent name is only safe to show because it was **round-tripped**: the
+//! DID's document claimed the name *and* resolving that name led back to the
+//! same DID. `alsoKnownAs` on its own is self-asserted, so a hostile DID can
+//! claim `mybank.com/@treasury` and a display layer that prints the claim bare
+//! has told the operator, in an authoritative voice, that they are looking at
+//! their bank — on the one screen where they are about to approve something.
+//!
+//! That check is security-critical and already written, audited and tested in
+//! `vta-sdk`. Re-deriving it in the engine (or worse, in Swift on the other side
+//! of the FFI) would mean two implementations of a spoofing defence that must
+//! agree forever. So the verdict crosses the boundary instead: `verified` is
+//! [`vta_sdk`]'s conclusion, and the app's job is to not discard it.
+//!
+//! # Nothing publishes names yet
+//!
+//! No DID in this workspace writes an `alsoKnownAs` entry today, so
+//! [`resolve_agent_name`] returns `None` for every DID it is asked about. That
+//! is the intended state: the surfaces are wired so that minting names lights
+//! them up without another mobile release.
+
+use vta_sdk::display_name::{self, NameSource, agent_name};
+
+/// A name to show for a DID, plus the provenance the UI must not throw away.
+///
+/// `verified == false` is a bare self-assertion. It is still returned — a DID
+/// *attempting* to present as somebody else is something the operator should
+/// see — but the app must qualify it (see `DisplayName.rendered` on the Swift
+/// side, which appends `[unverified]`). Never render `name` alone.
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct AgentName {
+    /// The claimed name, e.g. `example.com/@treasury`.
+    pub name: String,
+    /// Whether the claim round-tripped back to this DID.
+    pub verified: bool,
+}
+
+/// The agent name a DID's document claims, if any, with the round trip already
+/// performed.
+///
+/// Returns `None` when the DID does not resolve, claims no agent name, or the
+/// lookup fails. **Infallible on purpose**: this is a display helper, and an
+/// unreachable name server must degrade to showing the DID, never fail the
+/// operator's approval. That mirrors [`agent_name::lookup`], which swallows its
+/// own errors for the same reason.
+///
+/// Costs one DID resolution plus up to
+/// [`agent_name::MAX_CLAIMS_CHECKED`] outbound fetches, so the app resolves
+/// lazily — per DID actually on screen — and caches the result rather than
+/// calling this on every render.
+#[uniffi::export(async_runtime = "tokio")]
+pub async fn resolve_agent_name(did: String) -> Option<AgentName> {
+    let client = crate::resolver::client().await.ok()?;
+    let name = agent_name::lookup(client, &did).await?;
+    Some(AgentName {
+        name: name.name,
+        // `lookup` only ever returns an `AgentName` source, but match rather
+        // than assume: if the SDK ever routes another source through here,
+        // defaulting to unverified fails safe.
+        verified: matches!(name.source, NameSource::AgentName { verified: true }),
+    })
+}
+
+/// Abbreviate a DID for a narrow phone caption, keeping the part that
+/// identifies it.
+///
+/// Exported rather than ported so the phone, the CLIs and the admin console
+/// cannot drift: an operator moves between all three looking at the same
+/// community, and a DID abbreviated two ways is one they must re-identify on
+/// every switch. See [`display_name::shorten_did`] for the rule and the shared
+/// vector table that is its authority.
+#[uniffi::export]
+#[must_use]
+pub fn shorten_did(did: String) -> String {
+    display_name::shorten_did(&did)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The same vectors `vta_sdk`'s `shorten_did_matches_shared_vectors`
+    /// asserts, re-asserted through the FFI signature the app actually calls —
+    /// so a `String`-by-value wrapper that mangled its input could not pass.
+    #[test]
+    fn shorten_did_matches_the_shared_vectors() {
+        for (input, expected) in [
+            ("alice", "alice"),
+            (
+                "did:webvh:QmXkAbCdEfGhIjKlMnOp:webvh.storm.ws:glenn-vta",
+                "did:webvh:QmXkAbCdEf…:webvh.storm.ws:glenn-vta",
+            ),
+            (
+                "did:key:z6MkfrQjWzPQrTuVwXyZaBcDeFgHiJkLmNoPqRsTuVwXyZ4rT",
+                "did:key:z6MkfrQjWz…XyZ4rT",
+            ),
+            ("did:webvh:Qm123:example.com", "did:webvh:Qm123:example.com"),
+        ] {
+            assert_eq!(shorten_did(input.to_string()), expected, "input: {input}");
+        }
+    }
+
+    /// A DID claiming nothing must yield no name rather than a guess. There is
+    /// deliberately no path from a DID's domain to a "likely" name.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_did_key_claims_no_agent_name() {
+        // `did:key` resolves offline and its document has no `alsoKnownAs`, so
+        // this exercises the whole export without touching the network.
+        let did = "did:key:z6MkiToqovww7vYtxm1xNM15u9JzqzUFZ1k7s7MazYJUyAxv";
+        assert!(
+            resolve_agent_name(did.to_string()).await.is_none(),
+            "a document claiming nothing must not produce a name"
+        );
+    }
+
+    /// A DID that does not resolve must degrade to `None`, not propagate an
+    /// error: an approval sheet has to render regardless.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn an_unresolvable_did_degrades_to_no_name() {
+        assert!(resolve_agent_name("not-a-did".to_string()).await.is_none());
+    }
+}

--- a/vta-mobile-core/src/lib.rs
+++ b/vta-mobile-core/src/lib.rs
@@ -42,6 +42,7 @@ mod proof;
 // so the crate layout matches the mapped design from day one.
 pub mod consent;
 pub mod didcomm;
+pub mod display_name;
 pub mod keys;
 pub mod mediator;
 pub mod push;

--- a/vta-mobile-core/src/resolver.rs
+++ b/vta-mobile-core/src/resolver.rs
@@ -19,7 +19,10 @@ use vta_sdk::protocol::matching::{DIDCOMM_SERVICE_TYPE, REST_SERVICE_TYPES};
 /// lookups stay cheap.
 static CLIENT: OnceCell<DIDCacheClient> = OnceCell::const_new();
 
-async fn client() -> Result<&'static DIDCacheClient, FfiError> {
+/// Shared with [`crate::display_name`], which needs the same cache: an agent-name
+/// lookup resolves the DID and then each claimed name, and those resolutions
+/// overlap heavily with the ones the app has already done.
+pub(crate) async fn client() -> Result<&'static DIDCacheClient, FfiError> {
     CLIENT
         .get_or_try_init(|| async {
             DIDCacheClient::new(DIDCacheConfigBuilder::default().build())


### PR DESCRIPTION
The mobile agent shows DIDs where it has no choice — who is asking for a step-up, who delivered a task-consent request, which VTA and mediator it is bound to. A `did:webvh` in a phone caption is unreadable, and on an approval sheet unreadable is not cosmetic: it is the operator approving something they cannot identify.

## What this adds

`vta_mobile_core::display_name`, a thin FFI skin over `vta_sdk::display_name` — the seam the PNM/CNM CLIs, the VTC CLI and the admin console already render through. Two exports:

- **`resolve_agent_name(did) -> Option<AgentName { name, verified }>`** — `display_name::agent_name::lookup` verbatim. Infallible on purpose, mirroring `lookup`: an unreachable name server must degrade to showing the DID, never fail the operator's approval.
- **`shorten_did(did) -> String`** — `display_name::shorten_did` verbatim.

Enables `vta-sdk/agent-names` for the mobile crate and shares `resolver::client()` with the new module, since an agent-name lookup resolves the DID and then each claimed name — resolutions that overlap heavily with ones the app has already done.

## Why a skin, and not an implementation

An agent name is only safe to show because it **round-tripped**: the DID's document claimed the name *and* resolving that name forward led back to the same DID. `alsoKnownAs` on its own is self-asserted, so a hostile DID can claim `mybank.com/@treasury`, and a display layer printing that claim bare has told the operator — in an authoritative voice, on the one screen where they are about to approve something — that they are looking at their bank.

That defence is already written, tested and reviewed in `vta-sdk`. Re-deriving it here, or across the FFI in Swift, would mean two implementations of a spoofing check that must agree forever. So only the *verdict* crosses the boundary: `verified` is `vta-sdk`'s conclusion, and the app's job is to not discard it. The `matches!` on `NameSource` rather than a bare `is_trusted()` is deliberate — if the SDK ever routes another source through `lookup`, defaulting to unverified fails safe.

`shorten_did` is exported rather than ported for the same anti-drift reason: an operator moves between the phone, a terminal and the console looking at the same community, and a DID abbreviated three ways is one they must re-identify on every switch. The consuming app re-asserts the shared vector table against this export, so a change to the Rust table fails the iOS build.

## Nothing publishes names yet

No DID in this workspace writes an `alsoKnownAs` entry today, so `resolve_agent_name` returns `None` for every DID and every mobile surface shows a shortened DID. That is the intended state — same as every other surface wired for `agent-names`. The seam exists so that minting names lights up the phone without another mobile release.

## Verification

- `cargo test -p vta-mobile-core --lib` — 48 passed, 4 ignored (network), including 3 new: the shared `shorten_did` vectors asserted through the FFI signature, a `did:key` (resolves offline, claims nothing) yielding no name, and an unresolvable DID degrading to `None` rather than erroring.
- `cargo clippy -p vta-mobile-core --all-targets` — clean.
- **iOS cross-compile validated**: dispatched `release-mobile-ios.yml` on this branch ([run 30159754623](https://github.com/OpenVTC/verifiable-trust-infrastructure/actions/runs/30159754623)) — the xcframework assembles for `aarch64-apple-ios`, `aarch64-apple-ios-sim` and `x86_64-apple-ios` with `agent-names` enabled. Worth checking explicitly, since the feature pulls `agent-names` + `affinidi-did-common` into a target that has no native trust store and a fussy `aws-lc-sys` build.

Crate bumped to 0.6.16; the consuming `vta-mobile-agent-ios` change needs a `vta-mobile-core-v0.6.16` release to pin against.