### PR TITLE
ci: catch a `[patch.crates-io]` entry that has stopped applying

### DIFF
--- a/scripts/check-lockfile-self-pins.sh
+++ b/scripts/check-lockfile-self-pins.sh
@@ -53,6 +53,32 @@
 # patch entry. Without it, the first sign would be a dependent published against
 # stale source.
 #
+# ── The second failure mode: the patch itself stops applying ──────────────────
+#
+# Everything above treats a stale pin as REFRESHABLE — publish the new version,
+# run `cargo update --precise`, done. That holds for a PATCH bump (0.19.11 ->
+# 0.19.12): a dependent requiring `^0.19` accepts the new version, so the patch
+# keeps applying and the pin can be moved.
+#
+# It does NOT hold for a MINOR bump. Under 0.x semver `^0.19` excludes 0.20, so
+# the moment a patched crate goes 0.19 -> 0.20, an external dependent pinning
+# `^0.19` can no longer be satisfied by the patched path copy — cargo silently
+# stops applying the patch and reinstates the registry node the patch existed to
+# delete. No local `cargo update` can fix that; it needs the DEPENDENT's
+# requirement bumped and re-released upstream.
+#
+# The published-or-not test above cannot distinguish the two. At PR time the new
+# version is unpublished either way, so both take the "bump in flight" branch and
+# pass. That is exactly how vta-sdk 0.20.0 (#797) merged 12/12 and broke main
+# ~52s later, when the publish workflow closed the escape hatch.
+#
+# So ask the question that IS answerable locally, with no network and no
+# dependence on publish state: **is each `[patch.crates-io]` entry still
+# applying?** A patched crate must have NO registry-sourced node in Cargo.lock —
+# deleting that node is the entire point of the patch. If one is present, the
+# patch has broken. That check runs before the version comparison below and
+# fails hard, because there is no in-flight state where it is legitimately true.
+#
 # Usage: scripts/check-lockfile-self-pins.sh
 # Portable to macOS bash 3.2 / BSD userland.
 set -euo pipefail
@@ -111,14 +137,63 @@ locked=$(awk '
     next }
 ' Cargo.lock)
 
+# Crate names listed under `[patch.crates-io]` in the root manifest. Reads the
+# section between that header and the next `[`, taking the key from each
+# `name = ...` line. Table-syntax entries (`[patch.crates-io.foo]`) are matched
+# too, since a bare `[` would otherwise end the section at one.
+patched=$(awk '
+  /^\[patch\.crates-io\.[A-Za-z0-9_-]+\]/ {
+    line=$0; sub(/^\[patch\.crates-io\./, "", line); sub(/\]$/, "", line);
+    print line; next }
+  /^\[patch\.crates-io\]/ { inpatch=1; next }
+  /^\[/ { inpatch=0 }
+  inpatch && /^[A-Za-z0-9_-]+ *=/ { sub(/ *=.*$/, ""); print }
+' Cargo.toml)
+
 echo "${CYAN}=== Lockfile self-pin guard ===${NC}"
 echo ""
 
 fail=0
 found=0
 bumping=0
+
+# ── 1. Is every `[patch.crates-io]` entry still applying? ─────────────────────
+#
+# Checked first: a broken patch makes the version comparison below report the
+# right crate for the wrong reason, and suggest a `cargo update` that cannot
+# work. No crates.io call — the answer is in the lockfile.
+for p in $patched; do
+  [ -z "$p" ] && continue
+  pinned=$(printf '%s\n' "$locked" | awk -F'\t' -v n="$p" '$1 == n { print $2 }' | head -1)
+  [ -z "$pinned" ] && continue   # no registry node: the patch is applying
+
+  workspace_version=$(printf '%s\n' "$members" \
+    | awk -F'\t' -v n="$p" '$1 == n { print $2 }' | head -1)
+
+  echo "  ${RED}PATCH BROKEN${NC} $p: patched to the workspace copy${workspace_version:+ ($workspace_version)}, but Cargo.lock still carries a registry copy at $pinned"
+  echo "         An external dependent's semver requirement excludes the workspace"
+  echo "         version, so \`[patch.crates-io] $p\` no longer applies and the"
+  echo "         registry node it exists to delete is back."
+  echo ""
+  echo "         ${CYAN}cargo update cannot fix this${NC} — no published version satisfies both"
+  echo "         sides. Find the dependent still requiring the old range:"
+  echo "           cargo tree -i '$p@$pinned'"
+  echo "         then bump ITS requirement upstream, release it, and move that pin"
+  echo "         here first (the dependent's own lock entry constrains the update):"
+  echo "           cargo update -p <dependent> --precise <new-version>"
+  fail=1
+  found=1
+done
+
+# ── 2. Where a self-pin legitimately exists, does it match the workspace? ─────
 while IFS=$'\t' read -r name version; do
   [ -z "$name" ] && continue
+  # Already reported by the patch check above. Reporting it twice would offer
+  # a `cargo update --precise` that cannot work, which is the advice that sent
+  # the 0.20 incident down a dead end.
+  if printf '%s\n' "$patched" | grep -qx -- "$name"; then
+    continue
+  fi
   # Is this workspace crate also present as a registry package?
   pinned=$(printf '%s\n' "$locked" | awk -F'\t' -v n="$name" '$1 == n { print $2 }' | head -1)
   [ -z "$pinned" ] && continue
@@ -170,10 +245,14 @@ if [ "$fail" -eq 0 ]; then
     echo "${GREEN}All self-pins match the workspace versions.${NC}"
   fi
 else
-  echo "${RED}Cargo.lock pins a stale crates.io copy of a workspace crate.${NC}"
+  echo "${RED}Cargo.lock carries a crates.io copy of a workspace crate.${NC}"
   echo "\`cargo publish --locked\` verifies dependent crates against that pinned copy,"
   echo "so a dependent will be built against the OLD source and fail to compile —"
   echo "silently, since the workspace's own path-dep build stays green."
-  echo "Run the cargo update shown above and commit the Cargo.lock change."
+  echo ""
+  echo "For a ${CYAN}STALE${NC} pin: run the cargo update shown above and commit Cargo.lock."
+  echo "For a ${CYAN}PATCH BROKEN${NC} entry: the fix is upstream, not here — bump the"
+  echo "dependent's requirement, release it, then move its pin. See the note at the"
+  echo "top of this script for why no local update can resolve it."
   exit 1
 fi


### PR DESCRIPTION
Follow-up to the #797 incident. One-file change to `scripts/check-lockfile-self-pins.sh`; no crate source touched, so no version bumps.

## The blind spot

The guard decides on one question — *"is the workspace version published yet?"* — and that conflates two situations that need opposite treatment.

**Refreshable** (what it was built for). A **patch** bump, 0.19.11 → 0.19.12. The registry node is stale but becomes refreshable once published, because a dependent requiring `^0.19` accepts the new version. The "bump in flight" branch is right: wait for publish, then `cargo update --precise`.

**Unrefreshable.** A **minor** bump, 0.19 → 0.20. Under 0.x semver `^0.19` excludes 0.20, so an external dependent pinning `^0.19` can no longer be satisfied by the patched path copy. Cargo silently stops applying the patch and reinstates the very registry node the patch exists to delete. Publishing never makes that refreshable — it needs the *dependent's* requirement bumped and re-released upstream.

At PR time both look identical: version unpublished → "bump in flight" → pass. So the second is **invisible until after merge**. That is exactly how vta-sdk 0.20.0 (#797) passed 12/12 and broke `main` ~52 seconds later, when the publish workflow closed the escape hatch. The guard then reported `STALE` and suggested a `cargo update --precise` that could not work, sending the fix down a dead end.

## The change

Ask the question that *is* answerable locally, with **no network call and no dependence on publish state**:

> Is each `[patch.crates-io]` entry still applying?

A patched crate must have **no** registry-sourced node in `Cargo.lock` — deleting that node is the entire point of the patch. If one is present, the patch has broken.

- Runs **before** the version comparison, and **fails hard** — there is no in-flight state where a broken patch is legitimately true, so no escape hatch is warranted.
- Patched crates are then **skipped** by the comparison loop, so the same crate is never reported twice with contradictory advice.
- The remedy it prints points **upstream** (`cargo tree -i` to find the blocking dependent, then bump *its* requirement), rather than at a local update that cannot work.

It also **fixes the misleading hint without a separate change**: once the broken patch is diagnosed separately, the `STALE` branch only ever sees the refreshable case, where its `--precise` command genuinely works. The bad advice was a symptom of the conflation, not an independent bug.

## Verification

Reproduced the actual incident rather than reasoning about it:

```
$ cargo update -p affinidi-messaging-mediator --precise 0.17.7
   Downgrading affinidi-messaging-mediator v0.17.10 -> v0.17.7
      Adding vta-sdk v0.19.28          # ← the #797 state, exactly

$ bash scripts/check-lockfile-self-pins.sh
  PATCH BROKEN vta-sdk: patched to the workspace copy (0.20.0), but Cargo.lock
                        still carries a registry copy at 0.19.28
         ...
         cargo update cannot fix this — no published version satisfies both
         sides. Find the dependent still requiring the old range:
           cargo tree -i 'vta-sdk@0.19.28'
exit=1
```

Note there is **no crates.io line in that output** — the failing path never queries publish state, which is what makes it fire at PR time.

Also verified:

- Passes unchanged on current `main` ("nothing to check", exit 0).
- The new `[patch.crates-io]` parser handles inline-table form (`vta-sdk = { path = … }`), table form (`[patch.crates-io.vta-sdk]`), a manifest with **no** patch section, and the real one — and correctly stops at the next section rather than swallowing `[workspace.dependencies]`.
- `bash -n` clean; bash 3.2 / BSD-compatible, matching the script's stated portability.

## What this does not address

The **coupling** remains: a minor bump of `vta-sdk` still requires a coordinated TDK release. This makes that a pre-merge failure with actionable advice instead of a post-merge surprise.

Removing the coupling entirely means breaking the dev-dependency cycle that creates the self-pin in the first place — `vti-e2e-tests → affinidi-messaging-test-mediator → affinidi-messaging-mediator → vta-sdk`. A test harness dragging a circular dependency on the crate under test is the root cause; killing it would let us delete both the `[patch]` and this guard. Bigger piece of work, deliberately out of scope here.
