### PR TITLE
feat(vtc): move VTC Trust Tasks onto the spec/vtc registry authority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,80 @@
 
 ## Unreleased
 
+### vta-sdk 0.20.1 / vtc-service 0.11.29 / cnm-cli 0.11.9 / vti-common 0.11.25 — VTC Trust Tasks move to `spec/vtc/*`
+
+The registry now publishes every VTC task (`dtgwg-trust-tasks-tf` #144,
+`trust-tasks-rs` 0.2.38), so the bindings move off the non-conformant
+`trusttasks.org/openvtc/vtc/...` authority they were never entitled to use.
+This repoints **20 old URIs onto the 22 authored `spec/vtc/<slug>/0.1`
+slugs** — 22 because two collapsed mounts split.
+
+**All four binding sites**, in one change, because they cannot lag each
+other: `routes/mod.rs`, the `vta-sdk` DIDComm constants, the admin SPA's
+TypeScript `Trust-Task` headers, and `cnm-cli`. The SPA is compiled into the
+binary by `build.rs`, so a partial migration would ship a UI calling URIs the
+router no longer binds.
+
+**Two mounts split per method.** `admin/invites/manage` served list *and*
+create; `invitations/issue` served issue *and* list. One URI cannot state two
+contracts, and the exposure differs sharply — issuing returns a bearer
+credential, listing must never re-disclose one. `task_routes` layers the
+method router and axum merges same-path method routers per method, so each
+verb enforces its own task (pinned by
+`per_method_tasks_on_one_path_are_enforced_independently`). The SPA's
+`listInvitations` even carried the comment "Reuses the issue Trust Task";
+it now has its own.
+
+**The reciprocal-VMC exchange became three tasks.** `members/request-vmc`
+(admin → VTC) and `spec/members/request-vmc` (VTC → member) would have
+collided on one slug once the parsing-artifact `spec/` segment was dropped.
+They are now `vtc/members/solicit-vmc`, `vtc/members/request-vmc`, and
+`vtc/members/vmc`.
+
+**BREAKING (wire): the VTC backup payloads are now camelCase.**
+`ExportRequest`, `ImportRequest`, `BackupEnvelope`, `KdfParams`,
+`EncryptionParams` and `ImportResult` carried no `serde(rename_all)` and were
+snake_case on the wire, against R3.1 and against every other VTC payload.
+`cnm-cli` is updated on both sides — it was sending `include_audit` and
+reading `source_did` / `includes_audit` / `created_at`, all of which would
+have silently returned `None` against the new server. **The VTA's backup wire
+is untouched**: `vta-sdk::client::backup` targets a different service and
+stays snake_case.
+
+**De-listed, not migrated:** `website/deploy` and `website/files/show` are
+raw-byte operations — a JSON Trust-Task payload cannot carry file bytes — so
+the registry deliberately has no spec for them. They are removed from the
+manifest rather than retired, because `supersededBy` is mandatory on a
+retired entry and nothing supersedes them.
+
+**The census test now reads every binding site**, not just the router. A
+router-only scan is what produced the wrong residual count corrected in #802:
+four tasks are `vta-sdk` DIDComm constants with no REST mount. Two new
+guards:
+- `no_new_bindings_on_the_retired_authority` — nothing may bind
+  `openvtc/vtc/` outside a shrinking, reasoned allowlist of the 10 tasks
+  still awaiting a canonical fold.
+- `every_bound_vtc_task_exists_in_the_registry` — every bound `spec/vtc/`
+  URI must resolve through `trust_tasks_rs::schema_index::schema_for`, so a
+  typo or a slug that was never authored fails here rather than at runtime.
+
+**Downstream:** `openvtc` consumes the changed `vta-sdk` constants and has a
+DIDComm regex allowlist that will *reject* the new URIs until it upgrades. It
+must land in the same release.
+
+Deferred to a follow-up (tracked in `AWAITING_CANONICAL_FOLD`): the 8 tasks
+that fold onto canonical specs rather than `spec/vtc/*`. Three of those are
+blocked on upstream registry work, and three need the delegated `confirm/1.0`
+gate.
+
+Also updates `vti-common`'s Trust-Task doc examples and test fixtures off the
+retired authority. They are not bindings — the census deliberately excludes
+them — but a doc comment demonstrating `openvtc/vtc/...` teaches the shape we
+just spent this change removing.
+
+Refs #710, refs #709.
+
+
 ### vti-common 0.11.24 / vtc-service 0.11.28 / cnm-cli 0.11.8 — signed audit checkpoints
 
 The `prev_hash` chain (#555) and `GET /v1/audit/verify` (#703) detect

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2488,7 +2488,7 @@ checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cnm-cli"
-version = "0.11.8"
+version = "0.11.9"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "clap",
@@ -9585,9 +9585,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-rs"
-version = "0.2.18"
+version = "0.2.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b54d12f633f9ed89d4531879b01d90b8138f4e59e67a77f0489e9466507f4fb1"
+checksum = "15438a66c6f3e061554d8cd5a0e2c07c0828618f3e3ff3331be266347caccf25"
 dependencies = [
  "async-trait",
  "chrono",
@@ -10269,7 +10269,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10564,7 +10564,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-service"
-version = "0.11.28"
+version = "0.11.29"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",
@@ -10646,7 +10646,7 @@ dependencies = [
 
 [[package]]
 name = "vti-common"
-version = "0.11.24"
+version = "0.11.25"
 dependencies = [
  "aes-gcm",
  "affinidi-data-integrity",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -212,7 +212,7 @@ aws-lc-rs = "1.16"
 # (camelCase wire enums + `/0.2` TYPE_URIs) alongside the retained
 # `v0_1` modules — the VTA dual-accepts both during the migration.
 # Bump in lockstep with affinidi-webvh-service when upstream publishes.
-trust-tasks-rs = { version = "0.2.16", default-features = false, features = ["validate"] }
+trust-tasks-rs = { version = "0.2.38", default-features = false, features = ["validate"] }
 trust-tasks-capability-client = "0.1"
 trust-tasks-https = { version = "0.2", default-features = false, features = ["server", "client", "jwt"] }
 trust-tasks-proof = { version = "0.2", default-features = false, features = ["affinidi"] }

--- a/cnm-cli/Cargo.toml
+++ b/cnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cnm-cli"
 description = "CLI Tool for Verified Trust Agents operating in Verified Trust Communities"
-version = "0.11.8"
+version = "0.11.9"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/cnm-cli/src/backup.rs
+++ b/cnm-cli/src/backup.rs
@@ -23,8 +23,8 @@ use crate::auth;
 /// Canonical HTTP header carrying the Trust-Task URL (mirrors
 /// `vti_common::trust_task::HEADER_NAME`).
 const TRUST_TASK_HEADER: &str = "Trust-Task";
-const EXPORT_TASK: &str = "https://trusttasks.org/openvtc/vtc/backup/export/1.0";
-const IMPORT_TASK: &str = "https://trusttasks.org/openvtc/vtc/backup/import/1.0";
+const EXPORT_TASK: &str = "https://trusttasks.org/spec/vtc/backup/export/0.1";
+const IMPORT_TASK: &str = "https://trusttasks.org/spec/vtc/backup/import/0.1";
 
 /// Authenticated REST POST to a VTC `/v1/backup/*` route. `client.rest_url()`
 /// already carries the `/v1` mount, so the path here is relative to it.
@@ -82,11 +82,11 @@ pub(crate) async fn cmd_export(
         keyring_key,
         "/backup/export",
         EXPORT_TASK,
-        json!({ "password": password, "include_audit": include_audit }),
+        json!({ "password": password, "includeAudit": include_audit }),
     )
     .await?;
 
-    let source_did = envelope.get("source_did").and_then(Value::as_str);
+    let source_did = envelope.get("sourceDid").and_then(Value::as_str);
     let path = output.unwrap_or_else(|| {
         let slug = source_did
             .and_then(|d| d.rsplit(':').next())
@@ -106,7 +106,7 @@ pub(crate) async fn cmd_export(
     println!(
         "  Includes audit: {}",
         envelope
-            .get("includes_audit")
+            .get("includesAudit")
             .and_then(Value::as_bool)
             .unwrap_or(false)
     );
@@ -129,13 +129,13 @@ pub(crate) async fn cmd_import(
         .map_err(|e| format!("{} is not a valid backup file: {e}", file.display()))?;
 
     println!("Backup file: {}", file.display());
-    println!("  Source DID:  {}", str_field(&envelope, "source_did"));
-    println!("  Created:     {}", str_field(&envelope, "created_at"));
+    println!("  Source DID:  {}", str_field(&envelope, "sourceDid"));
+    println!("  Created:     {}", str_field(&envelope, "createdAt"));
     println!("  Format:      {}", str_field(&envelope, "format"));
     println!(
         "  Audit:       {}",
         envelope
-            .get("includes_audit")
+            .get("includesAudit")
             .and_then(Value::as_bool)
             .unwrap_or(false)
     );
@@ -214,7 +214,7 @@ fn print_counts(result: &Value) {
 /// digits of its ISO-8601 timestamp), avoiding a `chrono` dependency.
 fn file_stamp(envelope: &Value) -> String {
     let created = envelope
-        .get("created_at")
+        .get("createdAt")
         .and_then(Value::as_str)
         .unwrap_or("");
     let digits: String = created
@@ -235,7 +235,7 @@ mod tests {
 
     #[test]
     fn file_stamp_uses_created_at_digits() {
-        let env = json!({ "created_at": "2026-06-15T14:30:05Z" });
+        let env = json!({ "createdAt": "2026-06-15T14:30:05Z" });
         assert_eq!(file_stamp(&env), "20260615143005");
     }
 

--- a/trust-tasks/index.json
+++ b/trust-tasks/index.json
@@ -3,7 +3,7 @@
   "version": 1,
   "org": "openvtc",
   "domain": "vtc",
-  "description": "OpenVTC Verifiable Trust Community — Trust Task manifest. Source of truth for trusttasks.org publication; CI publishes Draft entries on every merge to main per spec §9.4.",
+  "description": "OpenVTC Verifiable Trust Community \u2014 Trust Task manifest. Source of truth for trusttasks.org publication; CI publishes Draft entries on every merge to main per spec \u00a79.4.",
   "tasks": [
     {
       "id": "https://trusttasks.org/openvtc/vtc/auth/legacy/challenge/1.0",
@@ -291,9 +291,10 @@
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/policies/test/1.0",
-      "status": "draft",
+      "status": "retired",
       "path": "policies/test/1.0",
-      "rest": "POST /v1/policies/{id}/test"
+      "rest": "POST /v1/policies/{id}/test",
+      "supersededBy": "https://trusttasks.org/spec/vtc/policies/test/0.1"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/policies/list/1.0",
@@ -441,28 +442,10 @@
       "supersededBy": "https://trusttasks.org/spec/vtc/website/files/list/0.1"
     },
     {
-      "id": "https://trusttasks.org/openvtc/vtc/website/files/show/1.0",
-      "status": "draft",
-      "path": "website/files/show/1.0",
-      "rest": "GET /v1/website/files/{*path}"
-    },
-    {
-      "id": "https://trusttasks.org/openvtc/vtc/website/files/write/1.0",
-      "status": "draft",
-      "path": "website/files/write/1.0",
-      "rest": "PUT /v1/website/files/{*path}"
-    },
-    {
       "id": "https://trusttasks.org/openvtc/vtc/website/files/delete/1.0",
       "status": "draft",
       "path": "website/files/delete/1.0",
       "rest": "DELETE /v1/website/files/{*path}"
-    },
-    {
-      "id": "https://trusttasks.org/openvtc/vtc/website/deploy/1.0",
-      "status": "draft",
-      "path": "website/deploy/1.0",
-      "rest": "POST /v1/website/deploy"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/website/generations/list/1.0",

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.20.0"
+version = "0.20.1"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/protocols/join_requests.rs
+++ b/vta-sdk/src/protocols/join_requests.rs
@@ -61,7 +61,7 @@ pub const JOIN_REQUEST_SUBMIT_RESPONSE_TYPE: &str =
 /// Inventing `spec/vtc/join-requests/submit-receipt` here would mean
 /// emitting a URI that resolves to nothing in the registry.
 pub const JOIN_REQUEST_SUBMIT_RECEIPT_TYPE: &str =
-    "https://trusttasks.org/openvtc/vtc/spec/join-requests/submit-receipt/1.0";
+    "https://trusttasks.org/spec/vtc/join-requests/submit-receipt/0.1";
 
 /// Body of the credential-exchange join receipt (see
 /// [`JOIN_REQUEST_SUBMIT_RECEIPT_TYPE`]).
@@ -349,7 +349,7 @@ pub const MEMBER_SELF_REMOVE_TYPE: &str = "https://trusttasks.org/spec/vtc/membe
 /// for the same reason as [`JOIN_REQUEST_SUBMIT_RECEIPT_TYPE`] — no
 /// canonical receipt task exists.
 pub const MEMBER_SELF_REMOVE_RECEIPT_TYPE: &str =
-    "https://trusttasks.org/openvtc/vtc/members/self-remove-receipt/1.0";
+    "https://trusttasks.org/spec/vtc/members/self-remove-receipt/0.1";
 
 /// Body of the self-remove message. `did` comes from the DIDComm
 /// `from` field — the caller's authcrypt sender authenticates

--- a/vta-sdk/src/protocols/members.rs
+++ b/vta-sdk/src/protocols/members.rs
@@ -33,17 +33,16 @@ use serde_json::Value;
 pub const VERIFIABLE_MEMBERSHIP_CREDENTIAL_TYPE: &str = "MembershipCredential";
 
 /// VTC → member: request that the member issue and send their reciprocal VMC.
-pub const MEMBER_REQUEST_VMC_TYPE: &str =
-    "https://trusttasks.org/openvtc/vtc/spec/members/request-vmc/1.0";
+pub const MEMBER_REQUEST_VMC_TYPE: &str = "https://trusttasks.org/spec/vtc/members/request-vmc/0.1";
 
 /// Member → VTC: a member-issued [`VERIFIABLE_MEMBERSHIP_CREDENTIAL_TYPE`] VMC,
 /// the member → community half of the membership pair.
-pub const MEMBER_VMC_TYPE: &str = "https://trusttasks.org/openvtc/vtc/spec/members/vmc/1.0";
+pub const MEMBER_VMC_TYPE: &str = "https://trusttasks.org/spec/vtc/members/vmc/0.1";
 
 /// VTC → member: receipt acknowledging a stored member VMC. The `#response`
 /// variant of [`MEMBER_VMC_TYPE`].
 pub const MEMBER_VMC_RESPONSE_TYPE: &str =
-    "https://trusttasks.org/openvtc/vtc/spec/members/vmc/1.0#response";
+    "https://trusttasks.org/spec/vtc/members/vmc/0.1#response";
 
 /// Body of a [`MEMBER_REQUEST_VMC_TYPE`] request. The member should issue a VMC
 /// whose `credentialSubject.id` is `community_did` and send it back as a

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.11.28"
+version = "0.11.29"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vtc-service/admin-ui/src/lib/api.ts
+++ b/vtc-service/admin-ui/src/lib/api.ts
@@ -238,7 +238,9 @@ export const signOut = (): Promise<void> =>
 // ---------------------------------------------------------------------------
 
 const ISSUE_INVITATION_TASK =
-  "https://trusttasks.org/openvtc/vtc/invitations/issue/1.0";
+  "https://trusttasks.org/spec/vtc/invitations/issue/0.1";
+const LIST_INVITATIONS_TASK =
+  "https://trusttasks.org/spec/vtc/invitations/list/0.1";
 
 export interface IssueInvitationResponse {
   subjectDid: string;
@@ -263,7 +265,7 @@ export const issueInvitation = (
 };
 
 const REVOKE_INVITATION_TASK =
-  "https://trusttasks.org/openvtc/vtc/invitations/revoke/1.0";
+  "https://trusttasks.org/spec/vtc/invitations/revoke/0.1";
 
 export interface InvitationListItem {
   id: string;
@@ -275,11 +277,12 @@ export interface InvitationListItem {
   revokedAt?: string;
 }
 
-/** List issued invitations (newest first). Reuses the issue Trust Task (GET +
- * POST share the /invitations mount). */
+/** List issued invitations (newest first). Its own Trust Task: listing the
+ * registry and minting a bearer credential are different contracts, even
+ * though GET and POST share the /invitations path. */
 export const listInvitations = (): Promise<{ invitations: InvitationListItem[] }> =>
   getJson<{ invitations: InvitationListItem[] }>("/v1/invitations", {
-    trustTask: ISSUE_INVITATION_TASK,
+    trustTask: LIST_INVITATIONS_TASK,
   });
 
 /** Revoke an outstanding invitation by VIC id (flips its revocation bit). */
@@ -292,7 +295,7 @@ export const revokeInvitation = (
   );
 
 const RELATIONSHIPS_GRAPH_TASK =
-  "https://trusttasks.org/openvtc/vtc/relationships/graph/1.0";
+  "https://trusttasks.org/spec/vtc/relationships/graph/0.1";
 
 export interface GraphNode {
   did: string;
@@ -316,7 +319,7 @@ export const fetchRelationshipsGraph = (): Promise<RelationshipsGraph> =>
   });
 
 const RECOGNITION_CHECK_TASK =
-  "https://trusttasks.org/openvtc/vtc/recognition/check/1.0";
+  "https://trusttasks.org/spec/vtc/recognition/check/0.1";
 
 export interface RecognitionCheck {
   did: string;

--- a/vtc-service/admin-ui/src/lib/ceremony-manifest.ts
+++ b/vtc-service/admin-ui/src/lib/ceremony-manifest.ts
@@ -61,7 +61,7 @@ export const natureColor: Record<Nature, string> = {
 };
 
 const TRUST_TASK_CEREMONIES =
-  "https://trusttasks.org/openvtc/vtc/ceremonies/list/1.0";
+  "https://trusttasks.org/spec/vtc/ceremonies/list/0.1";
 
 export async function fetchCeremonies(): Promise<CeremonyManifest[]> {
   return getJson<CeremonyManifest[]>("/v1/ceremonies", {

--- a/vtc-service/admin-ui/src/pages/Login.tsx
+++ b/vtc-service/admin-ui/src/pages/Login.tsx
@@ -34,7 +34,7 @@ const TRUST_TASK_START =
 const TRUST_TASK_FINISH =
   "https://trusttasks.org/spec/auth/passkey/login/finish/0.1";
 const TRUST_TASK_ADMIN_SESSION =
-  "https://trusttasks.org/openvtc/vtc/auth/admin-session/1.0";
+  "https://trusttasks.org/spec/vtc/auth/admin-session/0.1";
 
 type Phase =
   | { kind: "idle" }

--- a/vtc-service/admin-ui/src/plugins/acl.tsx
+++ b/vtc-service/admin-ui/src/plugins/acl.tsx
@@ -25,10 +25,12 @@ import { useToast } from "@/lib/toast";
 const TRUST_TASK_LIST = "https://trusttasks.org/spec/acl/list/0.1";
 const TRUST_TASK_GRANT = "https://trusttasks.org/spec/acl/grant/0.1";
 const TRUST_TASK_REVOKE = "https://trusttasks.org/spec/acl/revoke/0.1";
-const TRUST_TASK_INVITES_MANAGE =
-  "https://trusttasks.org/openvtc/vtc/admin/invites/manage/1.0";
+const TRUST_TASK_INVITES_LIST =
+  "https://trusttasks.org/spec/vtc/admin/invites/list/0.1";
+const TRUST_TASK_INVITES_CREATE =
+  "https://trusttasks.org/spec/vtc/admin/invites/create/0.1";
 const TRUST_TASK_INVITES_REVOKE =
-  "https://trusttasks.org/openvtc/vtc/admin/invites/revoke/1.0";
+  "https://trusttasks.org/spec/vtc/admin/invites/revoke/0.1";
 
 // Canonical `acl/_shared` AclEntry. `did` -> `subject`,
 // `allowed_contexts` -> `scopes`, and every timestamp is now an
@@ -147,7 +149,7 @@ interface CreateInviteResponse {
 
 async function fetchInvites(): Promise<InvitesListResponse> {
   return getJson<InvitesListResponse>("/v1/admin/invites", {
-    trustTask: TRUST_TASK_INVITES_MANAGE,
+    trustTask: TRUST_TASK_INVITES_LIST,
   });
 }
 
@@ -155,7 +157,7 @@ async function createInvite(
   req: CreateInviteRequest,
 ): Promise<CreateInviteResponse> {
   return postJson<CreateInviteResponse>("/v1/admin/invites", req, {
-    trustTask: TRUST_TASK_INVITES_MANAGE,
+    trustTask: TRUST_TASK_INVITES_CREATE,
   });
 }
 

--- a/vtc-service/admin-ui/src/plugins/ceremonies.tsx
+++ b/vtc-service/admin-ui/src/plugins/ceremonies.tsx
@@ -51,7 +51,7 @@ import {
   natureColor,
 } from "@/lib/ceremony-manifest";
 
-const TRUST_TASK_TEST = "https://trusttasks.org/openvtc/vtc/policies/test/1.0";
+const TRUST_TASK_TEST = "https://trusttasks.org/spec/vtc/policies/test/0.1";
 const TRUST_TASK_JOIN_REQUESTS =
   "https://trusttasks.org/spec/vtc/join-requests/list/0.1";
 

--- a/vtc-service/admin-ui/src/plugins/members.tsx
+++ b/vtc-service/admin-ui/src/plugins/members.tsx
@@ -46,11 +46,11 @@ const TRUST_TASK_ADMIN_REMOVE =
 const TRUST_TASK_PROMOTE =
   "https://trusttasks.org/openvtc/vtc/members/promote-to-admin/1.0";
 const TRUST_TASK_REMOVED =
-  "https://trusttasks.org/openvtc/vtc/members/removed/1.0";
+  "https://trusttasks.org/spec/vtc/members/removed/0.1";
 const TRUST_TASK_PURGE =
-  "https://trusttasks.org/openvtc/vtc/members/purge/1.0";
+  "https://trusttasks.org/spec/vtc/members/purge/0.1";
 const TRUST_TASK_REQUEST_VMC =
-  "https://trusttasks.org/openvtc/vtc/members/request-vmc/1.0";
+  "https://trusttasks.org/spec/vtc/members/solicit-vmc/0.1";
 
 interface MemberRow {
   did: string;

--- a/vtc-service/src/backup.rs
+++ b/vtc-service/src/backup.rs
@@ -60,6 +60,7 @@ const IMPORT_IN_PROGRESS_KEY: &[u8] = b"backup:import_in_progress";
 /// Outer envelope: unencrypted metadata + the encrypted payload. Crypto
 /// fields mirror the VTA's `vta-backup-v1`.
 #[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct BackupEnvelope {
     pub version: u32,
     pub format: String,
@@ -75,6 +76,7 @@ pub struct BackupEnvelope {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct KdfParams {
     pub algorithm: String, // "argon2id"
     pub salt: String,      // base64url, 32 bytes
@@ -84,6 +86,7 @@ pub struct KdfParams {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct EncryptionParams {
     pub algorithm: String, // "aes-256-gcm"
     pub nonce: String,     // base64url, 12 bytes
@@ -130,6 +133,7 @@ pub struct BackupConfig {
 
 /// Result of an import (or, with `confirm = false`, a preview).
 #[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct ImportResult {
     pub status: String, // "imported" | "preview"
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/vtc-service/src/routes/backup.rs
+++ b/vtc-service/src/routes/backup.rs
@@ -20,6 +20,7 @@ use vti_common::error::AppError;
 
 /// `POST /v1/backup/export` body.
 #[derive(Debug, Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct ExportRequest {
     /// Encryption password (Argon2id). Minimum 12 characters.
     pub password: String,
@@ -31,6 +32,7 @@ pub struct ExportRequest {
 
 /// `POST /v1/backup/import` body.
 #[derive(Debug, Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct ImportRequest {
     /// The encrypted backup envelope produced by `export`.
     pub backup: BackupEnvelope,

--- a/vtc-service/src/routes/mod.rs
+++ b/vtc-service/src/routes/mod.rs
@@ -508,25 +508,37 @@ fn build_api_chain(_routing: &RoutingConfig, trust_xff: bool) -> OpenApiRouter<A
         // POST share the same mount; DELETE on `/admin/invites/{jti}`
         // revokes outstanding (Issued) invites. Consumed rows are
         // immutable (audit history) — DELETE on those returns 409.
+        // Split per method (was one `admin/invites/manage` task over both
+        // verbs). "Enumerate the invites" and "mint a credential-bearing
+        // install URL" are different contracts with different exposure, so
+        // they get different Trust Tasks. Same path, different methods —
+        // `task_routes` layers the *method* router and axum merges same-path
+        // method routers per method, so each verb enforces its own task
+        // (pinned by `vti_common::trust_task::openapi::
+        // per_method_tasks_on_one_path_are_enforced_independently`).
         .routes(tt(
-            routes!(admin::invites::list_invites, admin::invites::create_invite),
-            "https://trusttasks.org/openvtc/vtc/admin/invites/manage/1.0",
+            routes!(admin::invites::list_invites),
+            "https://trusttasks.org/spec/vtc/admin/invites/list/0.1",
+        ))
+        .routes(tt(
+            routes!(admin::invites::create_invite),
+            "https://trusttasks.org/spec/vtc/admin/invites/create/0.1",
         ))
         .routes(tt(
             routes!(admin::invites::revoke_invite),
-            "https://trusttasks.org/openvtc/vtc/admin/invites/revoke/1.0",
+            "https://trusttasks.org/spec/vtc/admin/invites/revoke/0.1",
         ))
         // Directory ceremony (read-only field projection via the
         // ceremony decision pipeline).
         .routes(tt(
             routes!(directory::query),
-            "https://trusttasks.org/openvtc/vtc/directory/query/1.0",
+            "https://trusttasks.org/spec/vtc/directory/query/0.1",
         ))
         // Ceremony registry — the admin-UI renders its flow + simulator
         // from these manifests (purpose / fields / facts template).
         .routes(tt(
             routes!(ceremonies::list),
-            "https://trusttasks.org/openvtc/vtc/ceremonies/list/1.0",
+            "https://trusttasks.org/spec/vtc/ceremonies/list/0.1",
         ))
         // Members (Phase 1 M1.4–M1.6).
         .routes(tt(
@@ -538,11 +550,11 @@ fn build_api_chain(_routing: &RoutingConfig, trust_xff: bool) -> OpenApiRouter<A
         // path-trie doesn't route "removed" as a DID (same reason as `/me`).
         .routes(tt(
             routes!(members::read::list_removed),
-            "https://trusttasks.org/openvtc/vtc/members/removed/1.0",
+            "https://trusttasks.org/spec/vtc/members/removed/0.1",
         ))
         .routes(tt(
             routes!(members::remove::purge),
-            "https://trusttasks.org/openvtc/vtc/members/purge/1.0",
+            "https://trusttasks.org/spec/vtc/members/purge/0.1",
         ))
         // `/v1/members/me` for self-remove (M1.11.1). Must be
         // declared BEFORE the `/v1/members/{did}` mount otherwise
@@ -575,7 +587,7 @@ fn build_api_chain(_routing: &RoutingConfig, trust_xff: bool) -> OpenApiRouter<A
         // asynchronously over the `members/vmc/1.0` DIDComm surface.
         .routes(tt(
             routes!(members::request_vmc::request_vmc),
-            "https://trusttasks.org/openvtc/vtc/members/request-vmc/1.0",
+            "https://trusttasks.org/spec/vtc/members/solicit-vmc/0.1",
         ))
         // Phase 4 M4.3 + M4.4 — personhood lifecycle. Three
         // mounts on the same path prefix; declared BEFORE
@@ -606,7 +618,7 @@ fn build_api_chain(_routing: &RoutingConfig, trust_xff: bool) -> OpenApiRouter<A
         // Admin connections-graph view — the member-relationship (VRC) graph.
         .routes(tt(
             routes!(relationships::graph),
-            "https://trusttasks.org/openvtc/vtc/relationships/graph/1.0",
+            "https://trusttasks.org/spec/vtc/relationships/graph/0.1",
         ))
         .routes(tt(
             routes!(relationships::publish),
@@ -656,19 +668,26 @@ fn build_api_chain(_routing: &RoutingConfig, trust_xff: bool) -> OpenApiRouter<A
         // the VIC auto-join ceremony. Admin / Moderator / Issuer. POST + GET on
         // /invitations share the `issue/1.0` mount; the standalone `list/1.0`
         // task is declared on disk for the soft-gate surface.
+        // Split per method, as with admin/invites above: issuance returns a
+        // bearer credential, listing must never re-disclose one. The old
+        // shared `issue/1.0` mount could not state both contracts.
         .routes(tt(
-            routes!(invitations::issue, invitations::list),
-            "https://trusttasks.org/openvtc/vtc/invitations/issue/1.0",
+            routes!(invitations::issue),
+            "https://trusttasks.org/spec/vtc/invitations/issue/0.1",
+        ))
+        .routes(tt(
+            routes!(invitations::list),
+            "https://trusttasks.org/spec/vtc/invitations/list/0.1",
         ))
         // Revoke an outstanding invitation (flips its revocation bit).
         .routes(tt(
             routes!(invitations::revoke),
-            "https://trusttasks.org/openvtc/vtc/invitations/revoke/1.0",
+            "https://trusttasks.org/spec/vtc/invitations/revoke/0.1",
         ))
         // Recognition (trust-graph) lookup — admin window into TRQP recognise.
         .routes(tt(
             routes!(recognition_admin::check),
-            "https://trusttasks.org/openvtc/vtc/recognition/check/1.0",
+            "https://trusttasks.org/spec/vtc/recognition/check/0.1",
         ))
         .routes(tt(
             routes!(endorsements::show),
@@ -766,7 +785,7 @@ fn build_api_chain(_routing: &RoutingConfig, trust_xff: bool) -> OpenApiRouter<A
         ))
         .routes(tt(
             routes!(policies::admin::test),
-            "https://trusttasks.org/openvtc/vtc/policies/test/1.0",
+            "https://trusttasks.org/spec/vtc/policies/test/0.1",
         ));
 
     // Phase 5 M5.5 — public-website management routes. The
@@ -844,14 +863,14 @@ fn build_api_chain(_routing: &RoutingConfig, trust_xff: bool) -> OpenApiRouter<A
             "/backup/export",
             ttl(
                 post(backup::export),
-                "https://trusttasks.org/openvtc/vtc/backup/export/1.0",
+                "https://trusttasks.org/spec/vtc/backup/export/0.1",
             ),
         )
         .route(
             "/backup/import",
             ttl(
                 post(backup::import).layer(DefaultBodyLimit::max(BACKUP_IMPORT_CAP)),
-                "https://trusttasks.org/openvtc/vtc/backup/import/1.0",
+                "https://trusttasks.org/spec/vtc/backup/import/0.1",
             ),
         );
 
@@ -968,7 +987,7 @@ fn build_unauth_routes(trust_xff: bool) -> OpenApiRouter<AppState> {
         ))
         .routes(tt(
             routes!(auth::admin_session),
-            "https://trusttasks.org/openvtc/vtc/auth/admin-session/1.0",
+            "https://trusttasks.org/spec/vtc/auth/admin-session/0.1",
         ))
         .routes(tt(
             routes!(auth::passkey_login_start),
@@ -988,7 +1007,7 @@ fn build_unauth_routes(trust_xff: bool) -> OpenApiRouter<AppState> {
         ))
         .routes(tt(
             routes!(recognise::recognise_challenge),
-            "https://trusttasks.org/openvtc/vtc/auth/recognise/challenge/1.0",
+            "https://trusttasks.org/spec/vtc/auth/recognise/challenge/0.1",
         ))
         .routes(tt(
             routes!(recognise::recognise),

--- a/vtc-service/tests/directory.rs
+++ b/vtc-service/tests/directory.rs
@@ -30,7 +30,7 @@ use vtc_service::policy::default::install_defaults;
 use vtc_service::test_support::TestVtc;
 
 const RP_ORIGIN: &str = "https://vtc.example.com";
-const DIRECTORY_TASK: &str = "https://trusttasks.org/openvtc/vtc/directory/query/1.0";
+const DIRECTORY_TASK: &str = "https://trusttasks.org/spec/vtc/directory/query/0.1";
 const ADMIN_DID: &str = "did:key:zAdmin1";
 
 struct Fixture {

--- a/vtc-service/tests/invitations.rs
+++ b/vtc-service/tests/invitations.rs
@@ -22,9 +22,9 @@ use vtc_service::status_list;
 use vtc_service::test_support::TestVtc;
 
 const PUBLIC_URL: &str = "https://vtc.example.com";
-const ISSUE_TASK: &str = "https://trusttasks.org/openvtc/vtc/invitations/issue/1.0";
-const LIST_TASK: &str = "https://trusttasks.org/openvtc/vtc/invitations/issue/1.0";
-const REVOKE_TASK: &str = "https://trusttasks.org/openvtc/vtc/invitations/revoke/1.0";
+const ISSUE_TASK: &str = "https://trusttasks.org/spec/vtc/invitations/issue/0.1";
+const LIST_TASK: &str = "https://trusttasks.org/spec/vtc/invitations/list/0.1";
+const REVOKE_TASK: &str = "https://trusttasks.org/spec/vtc/invitations/revoke/0.1";
 const ADMIN_DID: &str = "did:key:zInvAdmin";
 const MEMBER_DID: &str = "did:key:zInvMember";
 const INVITEE_DID: &str = "did:key:zInvitee";

--- a/vtc-service/tests/members_crud.rs
+++ b/vtc-service/tests/members_crud.rs
@@ -21,8 +21,8 @@ use vtc_service::test_support::TestVtc;
 
 const RP_ORIGIN: &str = "https://vtc.example.com";
 const LIST_TASK: &str = "https://trusttasks.org/spec/vtc/members/list/0.1";
-const REMOVED_TASK: &str = "https://trusttasks.org/openvtc/vtc/members/removed/1.0";
-const PURGE_TASK: &str = "https://trusttasks.org/openvtc/vtc/members/purge/1.0";
+const REMOVED_TASK: &str = "https://trusttasks.org/spec/vtc/members/removed/0.1";
+const PURGE_TASK: &str = "https://trusttasks.org/spec/vtc/members/purge/0.1";
 const SHOW_TASK: &str = "https://trusttasks.org/spec/vtc/members/show/0.1";
 const UPDATE_TASK: &str = "https://trusttasks.org/spec/vtc/members/update/0.1";
 const PROMOTE_TASK: &str = "https://trusttasks.org/openvtc/vtc/members/promote-to-admin/1.0";

--- a/vtc-service/tests/policies.rs
+++ b/vtc-service/tests/policies.rs
@@ -25,7 +25,7 @@ use vtc_service::test_support::TestVtc;
 
 const UPLOAD_TASK: &str = "https://trusttasks.org/spec/policy/upsert/0.2";
 const ACTIVATE_TASK: &str = "https://trusttasks.org/spec/policy/activate/0.1";
-const TEST_TASK: &str = "https://trusttasks.org/openvtc/vtc/policies/test/1.0";
+const TEST_TASK: &str = "https://trusttasks.org/spec/vtc/policies/test/0.1";
 /// `/v1/policies` (list) + `/v1/policies/{id}` (show) share their
 /// HTTP mounts with the upload + activate POSTs respectively —
 /// TrustTaskRouter doesn't yet support per-method selectors, so

--- a/vtc-service/tests/recognise.rs
+++ b/vtc-service/tests/recognise.rs
@@ -296,7 +296,7 @@ mod holder_binding {
 
     const VTC_DID: &str = "did:key:z6MkTestVTC";
     const RECOGNISE_TASK: &str = "https://trusttasks.org/spec/vtc/auth/recognise/0.1";
-    const CHALLENGE_TASK: &str = "https://trusttasks.org/openvtc/vtc/auth/recognise/challenge/1.0";
+    const CHALLENGE_TASK: &str = "https://trusttasks.org/spec/vtc/auth/recognise/challenge/0.1";
 
     async fn test_vtc() -> TestVtc {
         // `with_did_resolver` so the route's VP holder/issuer `did:key`

--- a/vtc-service/tests/trust_task_manifest.rs
+++ b/vtc-service/tests/trust_task_manifest.rs
@@ -97,6 +97,16 @@ const UNPUBLISHED_OK: &[(&str, &str)] = &[
         "join-requests/submit/1.0",
         "mount-collapse alias of spec/join-requests/submit/1.0",
     ),
+    // Raw-byte operations, de-listed rather than retired: a JSON Trust-Task
+    // payload cannot carry file bytes, so there is no spec to supersede them
+    // with — and `supersededBy` is mandatory on a retired entry. The registry
+    // deliberately publishes only the four website tasks that genuinely are
+    // Trust Tasks (files/list, files/delete, generations/list, rollback).
+    ("website/deploy/1.0", "raw-byte upload — not a Trust Task"),
+    (
+        "website/files/show/1.0",
+        "raw-byte download — not a Trust Task",
+    ),
 ];
 
 fn workspace_root() -> PathBuf {
@@ -137,18 +147,37 @@ fn manifest() -> BTreeMap<String, Task> {
 fn bound_task_uris() -> BTreeSet<String> {
     let root = workspace_root();
     let mut found = BTreeSet::new();
-    for crate_src in ["vtc-service/src", "vta-sdk/src"] {
+    for crate_src in BINDING_SITES {
         collect_from_dir(&root.join(crate_src), &mut found);
     }
     found
 }
+
+/// Every place a Trust-Task URI is bound, dispatched, or sent as a header.
+///
+/// **All four, not just the router.** A router-only scan is what produced the
+/// wrong residual count in #799: four tasks are `vta-sdk` DIDComm constants
+/// with no REST mount, so nothing in `routes/mod.rs` mentions them. The admin
+/// SPA is worse — it sends `Trust-Task` headers as TypeScript string literals
+/// with no type-system backstop, so a missed one fails at runtime in the UI
+/// and nothing in the Rust build notices. It is compiled into the binary by
+/// `build.rs`, so it cannot lag the daemon by even one release.
+const BINDING_SITES: &[&str] = &[
+    "vtc-service/src",
+    "vta-sdk/src",
+    "cnm-cli/src",
+    "vtc-service/admin-ui/src",
+];
 
 fn collect_from_dir(dir: &Path, out: &mut BTreeSet<String>) {
     for entry in std::fs::read_dir(dir).expect("read source dir") {
         let path = entry.expect("dir entry").path();
         if path.is_dir() {
             collect_from_dir(&path, out);
-        } else if path.extension().is_some_and(|e| e == "rs") {
+        } else if path
+            .extension()
+            .is_some_and(|e| e == "rs" || e == "ts" || e == "tsx")
+        {
             let text = std::fs::read_to_string(&path).expect("read source file");
             for (idx, _) in text.match_indices(PREFIX) {
                 // Only string literals count. Doc comments carry `{verb}`-style
@@ -282,4 +311,144 @@ fn every_manifest_entry_has_files_on_disk() {
         "manifest entries missing files:\n  {}",
         missing.join("\n  ")
     );
+}
+
+// ---------------------------------------------------------------------------
+// Migration guards (#710)
+// ---------------------------------------------------------------------------
+
+/// The `openvtc/vtc/*` URIs still awaiting a canonical disposition.
+///
+/// This list only ever shrinks. Each entry is a task the #710 design note
+/// folds onto a canonical spec rather than republishing under `spec/vtc/*`,
+/// so it cannot simply be repointed — three of them additionally need an
+/// upstream registry spec that does not exist yet.
+///
+/// A new `openvtc/vtc/` URI appearing anywhere fails the test below, which is
+/// the point: the authority is retired, and nothing should be added to it.
+const AWAITING_CANONICAL_FOLD: &[(&str, &str)] = &[
+    (
+        "admin/config/export/1.0",
+        "canonical config/export — blocked on communityProfile moving to ext",
+    ),
+    (
+        "admin/config/import/1.0",
+        "canonical config/import — blocked; communityProfileDiff is structural",
+    ),
+    (
+        "admin/passkeys/list/1.0",
+        "canonical auth/passkey/list — blocked, spec not yet proposed upstream",
+    ),
+    (
+        "admin/passkeys/register/1.0",
+        "canonical auth/passkey/enroll/{start,finish} + confirm/1.0 gate",
+    ),
+    (
+        "admin/passkeys/revoke/1.0",
+        "canonical passkey-revoke + confirm/1.0 gate; needs the list spec first",
+    ),
+    (
+        "auth/admin-login/1.0",
+        "canonical auth/authenticate; the cookie side-effect moves to a binding/ext",
+    ),
+    (
+        "config/legacy/manage/1.0",
+        "delete — strict duplicate of admin/config/manage, which shipped",
+    ),
+    (
+        "members/promote-to-admin/1.0",
+        "canonical acl/change-role + confirm/1.0 gate",
+    ),
+    // Not Trust Tasks at all: a JSON payload cannot carry file bytes. These
+    // are de-listed rather than folded, and the registry deliberately has no
+    // spec for them (see specs/vtc/website/, which holds only the four that
+    // are genuinely tasks).
+    (
+        "website/deploy/1.0",
+        "raw-byte upload — de-listed, not a Trust Task",
+    ),
+    (
+        "website/files/show/1.0",
+        "raw-byte download — de-listed, not a Trust Task",
+    ),
+];
+
+/// No `openvtc/vtc/` URI may appear outside the shrinking fold list.
+///
+/// The authority is retired. This is what stops the migration regressing one
+/// literal at a time — a new binding on the old authority fails here rather
+/// than being discovered by a downstream consumer.
+#[test]
+fn no_new_bindings_on_the_retired_authority() {
+    let bound = bound_task_uris();
+    let allowed = exceptions(AWAITING_CANONICAL_FOLD);
+    let unexpected: BTreeSet<_> = bound.difference(&allowed).cloned().collect();
+    assert!(
+        unexpected.is_empty(),
+        "these bind the retired `openvtc/vtc/` authority and are not in \
+         AWAITING_CANONICAL_FOLD:\n  {}\n\nRepoint them to \
+         https://trusttasks.org/spec/vtc/<slug>/<ver>, or — if the task is \
+         genuinely awaiting a canonical fold — add it to the list with a reason.",
+        unexpected.iter().cloned().collect::<Vec<_>>().join("\n  ")
+    );
+}
+
+/// Every `spec/vtc/` URI the code binds must be one the registry actually
+/// publishes.
+///
+/// Cross-checked against the generated `trust_tasks_rs` schema index rather
+/// than a hand-maintained list, so it tracks the published registry: a typo, a
+/// stale slug, or a task repointed to a spec that was never authored all fail
+/// here instead of at runtime. `schema_for` returning `None` means this build
+/// of the registry crate knows no such task.
+#[test]
+fn every_bound_vtc_task_exists_in_the_registry() {
+    const SPEC_PREFIX: &str = "https://trusttasks.org/spec/vtc/";
+    let root = workspace_root();
+    let mut bound = BTreeSet::new();
+    for crate_src in BINDING_SITES {
+        collect_prefixed(&root.join(crate_src), SPEC_PREFIX, &mut bound);
+    }
+    assert!(
+        !bound.is_empty(),
+        "found no spec/vtc/ bindings at all — the scan is broken, not the code"
+    );
+
+    let unknown: Vec<_> = bound
+        .iter()
+        .filter(|uri| trust_tasks_rs::schema_index::schema_for(uri).is_none())
+        .cloned()
+        .collect();
+    assert!(
+        unknown.is_empty(),
+        "these spec/vtc/ URIs are bound but the registry (trust-tasks-rs \
+         {}) publishes no such task:\n  {}\n\nEither the slug is wrong or the \
+         spec was never authored upstream.",
+        env!("CARGO_PKG_VERSION"),
+        unknown.join("\n  ")
+    );
+}
+
+/// As [`collect_from_dir`], for an arbitrary URI prefix.
+fn collect_prefixed(dir: &Path, prefix: &str, out: &mut BTreeSet<String>) {
+    for entry in std::fs::read_dir(dir).expect("read source dir") {
+        let path = entry.expect("dir entry").path();
+        if path.is_dir() {
+            collect_prefixed(&path, prefix, out);
+        } else if path
+            .extension()
+            .is_some_and(|e| e == "rs" || e == "ts" || e == "tsx")
+        {
+            let text = std::fs::read_to_string(&path).expect("read source file");
+            for (idx, _) in text.match_indices(prefix) {
+                if idx == 0 || !text[..idx].ends_with('"') {
+                    continue;
+                }
+                let rest = &text[idx..];
+                let Some(end) = rest.find('"') else { continue };
+                let uri = rest[..end].split('#').next().expect("head").to_owned();
+                out.insert(uri);
+            }
+        }
+    }
 }

--- a/vtc-service/tests/wallet_login_siop.rs
+++ b/vtc-service/tests/wallet_login_siop.rs
@@ -275,7 +275,7 @@ async fn wallet_login_rejects_nonce_not_matching_challenge() {
 
 // ─── Phase 3: bearer → cookie bridge (`/v1/auth/admin-session`) ───
 
-const ADMIN_SESSION_TASK: &str = "https://trusttasks.org/openvtc/vtc/auth/admin-session/1.0";
+const ADMIN_SESSION_TASK: &str = "https://trusttasks.org/spec/vtc/auth/admin-session/0.1";
 const WHOAMI_TASK: &str = "https://trusttasks.org/spec/auth/whoami/0.1";
 
 /// Run a full wallet login and return the minted bearer access token.

--- a/vti-common/Cargo.toml
+++ b/vti-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-common"
 description = "Shared server-side infrastructure for VTA and VTC services"
 readme = "README.md"
-version = "0.11.24"
+version = "0.11.25"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vti-common/src/trust_task/mod.rs
+++ b/vti-common/src/trust_task/mod.rs
@@ -99,10 +99,10 @@ mod tests {
 
     #[test]
     fn accepts_well_formed_https_url() {
-        let t = TrustTask::new("https://trusttasks.org/openvtc/vtc/install/claim/1.0").unwrap();
+        let t = TrustTask::new("https://trusttasks.org/spec/vtc/install/claim/0.1").unwrap();
         assert_eq!(
             t.as_str(),
-            "https://trusttasks.org/openvtc/vtc/install/claim/1.0"
+            "https://trusttasks.org/spec/vtc/install/claim/0.1"
         );
     }
 
@@ -115,9 +115,9 @@ mod tests {
     #[test]
     fn rejects_non_https() {
         for s in [
-            "http://trusttasks.org/openvtc/vtc/install/claim/1.0",
+            "http://trusttasks.org/spec/vtc/install/claim/0.1",
             "urn:openvtc:vtc:install:claim:1.0",
-            "trusttasks.org/openvtc/vtc/install/claim/1.0",
+            "trusttasks.org/spec/vtc/install/claim/0.1",
         ] {
             let err = TrustTask::new(s).expect_err("non-https");
             assert!(

--- a/vti-common/src/trust_task/openapi.rs
+++ b/vti-common/src/trust_task/openapi.rs
@@ -76,7 +76,7 @@ mod tests {
     }
 
     fn task() -> TrustTask {
-        TrustTask::new("https://trusttasks.org/openvtc/vtc/install/claim/1.0").unwrap()
+        TrustTask::new("https://trusttasks.org/spec/vtc/install/claim/0.1").unwrap()
     }
 
     #[test]
@@ -194,7 +194,7 @@ mod tests {
                     .uri("/v1/install/claim")
                     .header(
                         HEADER_NAME,
-                        "https://trusttasks.org/openvtc/vtc/install/claim/1.0",
+                        "https://trusttasks.org/spec/vtc/install/claim/0.1",
                     )
                     .body(Body::empty())
                     .unwrap(),
@@ -224,7 +224,7 @@ mod tests {
                     .uri("/v1/install/claim")
                     .header(
                         HEADER_NAME,
-                        "https://trusttasks.org/openvtc/vtc/auth/login/1.0",
+                        "https://trusttasks.org/spec/vtc/auth/login/0.1",
                     )
                     .body(Body::empty())
                     .unwrap(),

--- a/vti-common/src/trust_task/router.rs
+++ b/vti-common/src/trust_task/router.rs
@@ -15,7 +15,7 @@
 //! use vti_common::trust_task::{TrustTask, TrustTaskRouter};
 //! use axum::routing::{get, post};
 //!
-//! let install_claim = TrustTask::new("https://trusttasks.org/openvtc/vtc/install/claim/start/1.0")?;
+//! let install_claim = TrustTask::new("https://trusttasks.org/spec/vtc/install/claim/start/0.1")?;
 //!
 //! let router = TrustTaskRouter::new()
 //!     .route_with_task("/v1/install/claim/start", post(claim_start), install_claim)
@@ -123,7 +123,7 @@ mod tests {
     }
 
     fn make_router() -> Router {
-        let claim = TrustTask::new("https://trusttasks.org/openvtc/vtc/install/claim/1.0").unwrap();
+        let claim = TrustTask::new("https://trusttasks.org/spec/vtc/install/claim/0.1").unwrap();
         TrustTaskRouter::new()
             .route_with_task("/v1/install/claim", post(ok), claim)
             .route_exempt("/health", get(ok))
@@ -140,7 +140,7 @@ mod tests {
                     .uri("/v1/install/claim")
                     .header(
                         HEADER_NAME,
-                        "https://trusttasks.org/openvtc/vtc/install/claim/1.0",
+                        "https://trusttasks.org/spec/vtc/install/claim/0.1",
                     )
                     .body(Body::empty())
                     .unwrap(),
@@ -180,7 +180,7 @@ mod tests {
                     .uri("/v1/install/claim")
                     .header(
                         HEADER_NAME,
-                        "https://trusttasks.org/openvtc/vtc/auth/login/1.0",
+                        "https://trusttasks.org/spec/vtc/auth/login/0.1",
                     )
                     .body(Body::empty())
                     .unwrap(),
@@ -194,11 +194,11 @@ mod tests {
         assert_eq!(body["error"], "TrustTaskMismatch");
         assert_eq!(
             body["expected"],
-            "https://trusttasks.org/openvtc/vtc/install/claim/1.0"
+            "https://trusttasks.org/spec/vtc/install/claim/0.1"
         );
         assert_eq!(
             body["received"],
-            "https://trusttasks.org/openvtc/vtc/auth/login/1.0"
+            "https://trusttasks.org/spec/vtc/auth/login/0.1"
         );
     }
 
@@ -213,7 +213,7 @@ mod tests {
                     .uri("/v1/install/claim")
                     .header(
                         HEADER_NAME,
-                        "https://trusttasks.org/openvtc/vtc/install/claim/1.1",
+                        "https://trusttasks.org/spec/vtc/install/claim/0.2",
                     )
                     .body(Body::empty())
                     .unwrap(),


### PR DESCRIPTION
The registry now publishes every VTC task ([dtgwg-trust-tasks-tf#144](https://github.com/trustoverip/dtgwg-trust-tasks-tf/pull/144), `trust-tasks-rs` 0.2.38), so the bindings move off the non-conformant `trusttasks.org/openvtc/vtc/...` authority they were never entitled to use (SPEC 6.1 / 6.5).

**20 old URIs → 22 authored `spec/vtc/<slug>/0.1` slugs.** 22 because two collapsed mounts split.

## All four binding sites, in one change

They cannot lag each other:

| Site | What |
|---|---|
| `vtc-service/src/routes/mod.rs` | the mounts |
| `vta-sdk/src/protocols/` | 4 DIDComm constants with no REST mount |
| `vtc-service/admin-ui/src/` | TypeScript `Trust-Task` header literals |
| `cnm-cli/src/` | CLI |

The SPA is compiled into the binary by `build.rs`, so a partial migration would ship a UI calling URIs the router no longer binds.

## Two mounts split per method

`admin/invites/manage` served **list and create**; `invitations/issue` served **issue and list**. One URI cannot state two contracts, and the exposure differs sharply — issuing returns a bearer credential, listing must never re-disclose one. `task_routes` layers the method router and axum merges same-path method routers per method, so each verb enforces its own task (pinned by `per_method_tasks_on_one_path_are_enforced_independently`).

The SPA's `listInvitations` literally carried the comment *"Reuses the issue Trust Task"*. It has its own now. The test file had `ISSUE_TASK` and `LIST_TASK` set to the same string; they differ now.

## The reciprocal-VMC exchange became three tasks

`members/request-vmc` (admin → VTC) and `spec/members/request-vmc` (VTC → member) would have **collided on one slug** once the parsing-artefact `spec/` segment was dropped. Now `vtc/members/solicit-vmc`, `vtc/members/request-vmc`, `vtc/members/vmc`.

## BREAKING (wire): VTC backup payloads are camelCase

Six types — `ExportRequest`, `ImportRequest`, `BackupEnvelope`, `KdfParams`, `EncryptionParams`, `ImportResult` — carried **no `serde(rename_all)`** and were snake_case, against R3.1 and against every other VTC payload.

`cnm-cli` is fixed on **both** sides: it was sending `include_audit` *and* reading `source_did` / `includes_audit` / `created_at`, all of which would have silently returned `None` against the new server rather than erroring.

**The VTA's backup wire is untouched** — `vta-sdk::client::backup` targets a different service ("Export VTA state") and stays snake_case. Worth checking on review; the two look identical at a glance.

## De-listed, not migrated

`website/deploy` and `website/files/show` are raw-byte operations — a JSON Trust-Task payload cannot carry file bytes — so the registry deliberately has no spec for them. **Removed** from the manifest rather than retired, because `supersededBy` is mandatory on a retired entry and nothing supersedes them. Recorded in `UNPUBLISHED_OK` with that reason.

## The census now reads every binding site

A router-only scan is exactly what produced the wrong residual count corrected in #802 — four tasks are `vta-sdk` DIDComm constants the router never mentions. Two new guards:

- **`no_new_bindings_on_the_retired_authority`** — nothing may bind `openvtc/vtc/` outside a shrinking, reasoned allowlist of the 10 tasks still awaiting a canonical fold. The authority is retired; this stops the migration regressing one literal at a time.
- **`every_bound_vtc_task_exists_in_the_registry`** — every bound `spec/vtc/` URI must resolve through `trust_tasks_rs::schema_index::schema_for`. Cross-checked against the *published registry crate* rather than a hand-maintained list, so a typo or an unauthored slug fails here instead of at runtime.

Also updates `vti-common`'s Trust-Task doc examples and test fixtures off the retired authority. Not bindings — the census deliberately excludes them — but a doc comment demonstrating `openvtc/vtc/...` teaches the shape this change removes.

## ⚠️ Downstream: openvtc must land in the same release

`openvtc` consumes the changed `vta-sdk` constants **and** has a DIDComm regex allowlist that will actively **reject** the new URIs until it upgrades. This is not a soft break.

## Deferred

The 8 tasks that fold onto *canonical* specs rather than `spec/vtc/*`, tracked in `AWAITING_CANONICAL_FOLD` with a reason each. Three are blocked on upstream registry work (`auth/passkey/list`, `config/{export,import}`); three need the delegated `confirm/1.0` gate.

## Verification

`cargo test --workspace` exit 0. `cargo check --workspace --locked --all-targets` clean — the lockfile is in the same commit as the version bumps this time, which is the check that failed on #796. `cargo fmt --check` and clippy clean. All four repo guards pass: version-bumps, changelogs, lockfile self-pins, and the 7-test census.

Refs #710, refs #709.
