### PR TITLE
fix(vtc): audit checkpoints honour their own signing key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 ## Unreleased
 
+### vtc-service 0.11.30 — audit checkpoints honour their own signing key
+
+`verify_checkpoint_state` resolved every `verificationMethod` to the VTC's
+*current* signing key (`|_vm| Some(current_key)`), which ignored the field
+entirely. Two consequences: a checkpoint naming some other key was silently
+checked against the live one, and the per-checkpoint `verificationMethod` that
+#708 persists specifically to survive rotation was decorative.
+
+The verifier now honours it. **The live signer is tried first, for its own
+method only**; anything else goes to the DID resolver. That ordering matters —
+resolving unconditionally would make a local integrity check depend on DID
+resolution being configured and the community's DID being reachable, which
+breaks verification outright on a deployment with no resolver. The common case
+(a checkpoint signed by the still-current key) stays entirely local, and
+resolution is reached only for a key the signer does not own — exactly the
+rotated-away case the old code could not handle.
+
+An unresolvable key is reported as **its own condition**, not as a bad
+signature. "The signing key is no longer published" is expected after a
+rotation; "this checkpoint was forged" is an incident, and the response must
+let an operator tell them apart.
+
+**Still not fixed, and now written down precisely:** verifying a checkpoint
+signed under a key since rotated away needs the DID document *as it stood at*
+`checkpointAt`. Neither `DIDCacheClient::resolve` nor `didwebvh-rs` offers
+version- or time-addressed resolution — `didwebvh-rs`'s `version_time` creates
+log entries rather than resolving history — so that is a resolver capability
+rather than something the audit verifier should take on by replaying
+`did.jsonl`. A deployment whose DID document retains prior verification methods
+alongside the current one already verifies across rotation today.
+
+Refs #708.
+
+
 ### vta-sdk 0.20.1 / vtc-service 0.11.29 / cnm-cli 0.11.9 / vti-common 0.11.25 — VTC Trust Tasks move to `spec/vtc/*`
 
 The registry now publishes every VTC task (`dtgwg-trust-tasks-tf` #144,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10564,7 +10564,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-service"
-version = "0.11.29"
+version = "0.11.30"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/docs/05-design-notes/vtc-audit-checkpoints.md
+++ b/docs/05-design-notes/vtc-audit-checkpoints.md
@@ -42,14 +42,40 @@ Everything in the Proposal section below, plus:
   keyspace, matching what `/audit/verify` already did. The checkpoint keyspace
   now makes an O(1) head pointer easy; it is a follow-up.
 
-### Known limitation
+### Key rotation — partly addressed, and where it stops
 
-`verify_checkpoint_state` resolves every `verificationMethod` to the VTC's
-*current* signing key. Correct until the community key rotates, at which point
-checkpoints signed under the retired key stop verifying. The fix is to resolve
-the DID document's key history — the per-checkpoint `verification_method` is
-already persisted for exactly that, so this is a verifier change with no data
-migration.
+The first implementation resolved every `verificationMethod` to the VTC's
+*current* signing key (`|_vm| Some(current_key)`), which ignored the field
+entirely. Two consequences: a checkpoint naming any other key was silently
+checked against the live one, and the field this design persists specifically
+to survive rotation was decorative.
+
+The verifier now honours it. The live signer is tried **first, for its own
+method only**, and anything else goes to the DID resolver. That ordering is
+deliberate: resolving unconditionally would make a local integrity check depend
+on DID resolution being configured and the community's DID being reachable,
+breaking verification outright on a deployment with no resolver — and the
+overwhelmingly common case, a checkpoint signed by the still-current key, stays
+entirely local. Resolution is reached only for a key the signer does not own,
+which is exactly the rotated-away case the old code could not handle at all.
+
+A key that will not resolve is reported as **its own condition**, not as a bad
+signature. "The signing key is no longer published" is expected maintenance;
+"this checkpoint was forged" is an incident, and an operator must be able to
+tell them apart from the response alone.
+
+**What is still not fixed.** Verifying a checkpoint signed under a key that has
+since been rotated *away* needs the DID document **as it stood at
+`checkpointAt`**. Neither `DIDCacheClient::resolve` nor `didwebvh-rs` exposes
+version- or time-addressed resolution today — `didwebvh-rs`'s `version_time` is
+for *creating* log entries, not resolving history. Closing this properly is a
+resolver capability, not something the audit verifier should take on by
+replaying `did.jsonl` itself. Until then such checkpoints report
+`chainBroken` with a detail naming the unresolvable key and the reason.
+
+A deployment whose DID document retains prior verification methods alongside
+the current one already verifies across rotation today, since the retired
+method still resolves from the current document.
 
 ---
 

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.11.29"
+version = "0.11.30"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vtc-service/src/routes/audit.rs
+++ b/vtc-service/src/routes/audit.rs
@@ -20,8 +20,10 @@ use axum::extract::{Query, State};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
+use std::collections::{BTreeMap, BTreeSet};
 use vti_common::audit::{AuditEnvelope, ChainBreak, ChainVerifier};
 use vti_common::error::AppError;
+
 use vti_common::pagination::{Cursor, MAX_LIMIT};
 
 use crate::auth::SuperAdminAuth;
@@ -431,7 +433,71 @@ async fn verify_checkpoint_state(state: &AppState) -> CheckpointReport {
     };
     let public = signer.public_bytes().to_vec();
 
-    let newest = match verify_checkpoints(&checkpoints, |_vm| Some(public.clone())) {
+    // Honour each checkpoint's OWN `verificationMethod` instead of assuming the
+    // community's current signing key.
+    //
+    // The previous implementation passed `|_vm| Some(current_signer_key)`,
+    // ignoring the field entirely — so the per-checkpoint `verificationMethod`
+    // that #708 deliberately persists was decorative, and a checkpoint naming
+    // some other key was silently checked against the live one.
+    //
+    // **The live signer is tried first, for its own method only.** Resolving
+    // unconditionally would make checkpoint verification depend on DID
+    // resolution being configured and the community's DID being reachable —
+    // turning a local integrity check into a network operation, and breaking
+    // verification outright on a deployment with no resolver. The overwhelmingly
+    // common case is a checkpoint signed by the key that is still current, and
+    // that case stays entirely local.
+    //
+    // Resolution is only reached for a method the current signer does not own —
+    // i.e. a key the community has rotated away from, or a second published
+    // key. That is exactly the case the old code could not handle at all.
+    //
+    // `verify_checkpoints` takes a synchronous callback and resolution is
+    // async, so distinct methods are resolved up front and the callback is a
+    // map lookup.
+    let resolver = crate::credentials::vm_resolver::DidVmResolver::new(state.did_resolver.clone());
+    let signer_vm = signer.assertion_method_id().to_string();
+    let mut keys: BTreeMap<String, Vec<u8>> = BTreeMap::new();
+    let mut unresolvable: Vec<String> = Vec::new();
+    for vm in checkpoints
+        .iter()
+        .map(|c| c.verification_method.clone())
+        .collect::<BTreeSet<_>>()
+    {
+        if vm == signer_vm {
+            keys.insert(vm, public.clone());
+            continue;
+        }
+        match resolver.resolve_ed25519(&vm).await {
+            Ok(bytes) => {
+                keys.insert(vm, bytes);
+            }
+            Err(e) => unresolvable.push(format!("{vm} ({e})")),
+        }
+    }
+
+    // A key that will not resolve is its own finding, not folded into "bad
+    // signature". After a rotation the retired key is absent from the
+    // community's *current* DID document, and "the signing key is no longer
+    // published" is a very different thing from "this checkpoint was forged":
+    // the first is expected maintenance, the second is an attack.
+    //
+    // Fully closing this needs the document *as it stood at `checkpointAt`*.
+    // Neither `DIDCacheClient` nor `didwebvh-rs` exposes version- or
+    // time-addressed resolution today, so that is a resolver capability rather
+    // than something to reimplement here by replaying `did.jsonl`.
+    if !unresolvable.is_empty() {
+        return broken(format!(
+            "these checkpoint signing keys could not be resolved: {}. A key retired by \
+             rotation is absent from the community's current DID document; verifying \
+             checkpoints signed under it needs resolution of the document as it stood at \
+             `checkpointAt`, which the DID resolver does not yet support.",
+            unresolvable.join("; ")
+        ));
+    }
+
+    let newest = match verify_checkpoints(&checkpoints, |vm| keys.get(vm).cloned()) {
         Ok(n) => n,
         Err(brk) => {
             let detail = match brk {

--- a/vtc-service/tests/audit_verify.rs
+++ b/vtc-service/tests/audit_verify.rs
@@ -455,3 +455,62 @@ async fn a_vtc_with_no_signing_key_cannot_claim_checkpoint_health() {
         "body: {body}"
     );
 }
+
+/// A checkpoint naming a `verificationMethod` the current signer does **not**
+/// own must not be waved through against the live key.
+///
+/// This is the bug the per-checkpoint `verificationMethod` existed to prevent
+/// and which the verifier previously had: it passed `|_vm| Some(current_key)`,
+/// so the field was decorative and *any* checkpoint was checked against
+/// whatever key happened to be live. A checkpoint claiming to be signed under
+/// some other key — a retired one, or one this community never held — was
+/// indistinguishable from one signed under the current key.
+///
+/// With no resolver configured the unknown method cannot be resolved, so the
+/// verifier reports that as its own condition rather than as a forgery. The
+/// distinction matters operationally: "the signing key is no longer published"
+/// is expected after a rotation, "this checkpoint was forged" is an incident.
+#[tokio::test]
+async fn a_checkpoint_naming_an_unknown_key_is_not_verified_against_the_live_one() {
+    let fix = build_signed().await;
+    let token = super_admin_token(&fix).await;
+    seed_audit_rows(&fix, &token, 2).await;
+
+    let signer = fix.state.credential_signer.as_ref().unwrap();
+    let key = signer.ed25519_signing_key().unwrap();
+
+    // Signed by the community's REAL key, so the signature is genuine — but it
+    // names a different verificationMethod. Under the old code this verified,
+    // because the named method was ignored entirely.
+    let cp = AuditCheckpoint::sign(
+        CheckpointClaim {
+            checkpoint_id: uuid::Uuid::new_v4(),
+            head: [0u8; 32],
+            entry_count: 0,
+            head_event_id: uuid::Uuid::nil(),
+            checkpoint_at: chrono::Utc::now(),
+            prev_checkpoint: None,
+            verification_method: "did:webvh:scid:vtc.example#key-retired".to_string(),
+        },
+        &key,
+    );
+    fix.state
+        .audit_checkpoint_ks
+        .insert(cp.storage_key(), &cp)
+        .await
+        .unwrap();
+
+    let (status, body) = verify(&fix, &token).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        body["checkpoints"]["status"], "chainBroken",
+        "a checkpoint naming a key the signer does not own must not verify \
+         against the live key: {body}"
+    );
+    let detail = body["checkpoints"]["detail"].as_str().unwrap_or_default();
+    assert!(
+        detail.contains("key-retired") && detail.contains("could not be resolved"),
+        "the finding must name the unresolvable key and say so, rather than \
+         reporting a forgery: {detail}"
+    );
+}


### PR DESCRIPTION
Closes the limitation recorded when signed audit checkpoints shipped in #708 — partly, and the PR is explicit about where it stops.

## The bug

`verify_checkpoint_state` resolved every `verificationMethod` to the VTC's current signing key:

```rust
verify_checkpoints(&checkpoints, |_vm| Some(public.clone()))
```

The `_vm` says it: the field was **ignored entirely**. Two consequences —

1. A checkpoint naming *some other* key was silently checked against the live one.
2. The per-checkpoint `verificationMethod` that #708 persists **specifically to survive rotation** was decorative.

## The fix, and why it isn't the obvious one

The verifier now honours the field. **The live signer is tried first, for its own method only**; anything else goes to the DID resolver.

That ordering is the whole design, and I got it wrong on the first attempt. Resolving unconditionally looks more correct and **broke every existing checkpoint test** — because it turns a local integrity check into a network operation, dependent on DID resolution being configured and the community's DID being reachable. A deployment with no resolver would have lost checkpoint verification outright. That's an availability regression, and the tests caught it.

Signer-first keeps the overwhelmingly common case — a checkpoint signed by the still-current key — entirely local, and reaches resolution only for a key the signer does not own. Which is exactly the rotated-away case the old code could not handle at all.

An unresolvable key is reported as **its own condition**, not as a bad signature. *"The signing key is no longer published"* is expected after a rotation; *"this checkpoint was forged"* is an incident. The response has to let an operator tell them apart.

## What is still not fixed

Verifying a checkpoint signed under a key **since rotated away** needs the DID document *as it stood at* `checkpointAt`.

Neither `DIDCacheClient::resolve` nor `didwebvh-rs` offers version- or time-addressed resolution — I checked; `didwebvh-rs`'s `version_time` *creates* log entries rather than resolving history. So closing this properly is a **resolver capability**, not something the audit verifier should take on by replaying `did.jsonl` itself. Such checkpoints report `chainBroken` with a detail naming the unresolvable key and the reason.

A deployment whose DID document retains prior verification methods alongside the current one already verifies across rotation today.

The design note's "Known limitation" section is rewritten to say all of this, rather than implying a fix that landed.

## Test

`a_checkpoint_naming_an_unknown_key_is_not_verified_against_the_live_one` — a checkpoint signed by the community's **real** key but naming a different `verificationMethod`. Under the old code it verified, because the named method was never consulted.

## Verification

Full `cargo test -p vtc-service` green (exit 0), 13 in `audit_verify` including the new one. `cargo check --workspace --locked --all-targets`, `cargo fmt --check`, clippy — all clean. Version-bump and changelog guards pass.

Refs #708.
