### PR TITLE
refactor(vtc): admin passkeys move to the canonical auth/passkey tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,50 @@
 
 ## Unreleased
 
+### vtc-service 0.11.31 — admin passkeys move to the canonical `auth/passkey/*` tasks
+
+The `/v1/admin/passkeys/*` surface leaves the retired `openvtc/vtc/` authority
+for the canonical tasks published in trust-tasks-tf#145 (`trust-tasks-rs`
+0.2.38 → 0.2.39). Three of the eight entries in `AWAITING_CANONICAL_FOLD` are
+gone; #710 and #709 shrink accordingly.
+
+**No wire change.** The canonical specs were written *from* this
+implementation, not the other way round, so request and response bodies are
+byte-identical. Only the `type` URIs moved.
+
+**One task per ceremony leg, where there used to be one per family.**
+`admin/passkeys/register/1.0` covered both `register/start` and
+`register/finish`; `revoke/1.0` likewise. A single schema spanning both legs
+had to permit the union of their members, so a `finish` arriving without its
+user-verification assertion still validated against the family task. Each leg
+now names its own task:
+
+| Endpoint | Task |
+|---|---|
+| `GET /v1/admin/passkeys` | `auth/passkey/list/0.1` |
+| `POST …/register/start` | `auth/passkey/enroll/start/0.2` |
+| `POST …/register/finish` | `auth/passkey/enroll/finish/0.2` |
+| `POST …/revoke/start` | `auth/passkey/revoke/start/0.1` |
+| `POST …/revoke/finish` | `auth/passkey/revoke/finish/0.1` |
+
+Because a mount split means every caller must be audited *per leg* rather than
+renamed in bulk, all four binding sites were walked individually — the router,
+`tests/admin_passkeys.rs` (19 call sites), `tests/install_flow.rs` (3), and the
+`myPasskeys` admin-UI plugin (4). The negative test that deliberately sends the
+wrong task to `register/start` still sends a wrong one.
+
+**The recorded blocker was wrong.** These three sat in
+`AWAITING_CANONICAL_FOLD` needing "a `confirm/1.0` gate". `confirm/request` is
+an *asynchronous* delegation whose response returns out of band on the
+approver's own transport — appropriate when the approver is a separate party,
+wrong here. This surface verifies the user *in-band, in the same request*, via
+WebAuthn, and always did. `enroll/*` moves to 0.2 because that is the version
+carrying the optional `uvOptions` / `uvCredential` members which describe the
+re-authentication half this code already performs.
+
+The superseded `admin/passkeys/{list,register,revoke}/1.0` are marked `retired`
+with `supersededBy` in `trust-tasks/` and `index.json`, per SPEC §5.3.
+
 ### vtc-service 0.11.30 — audit checkpoints honour their own signing key
 
 `verify_checkpoint_state` resolved every `verificationMethod` to the VTC's

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9585,9 +9585,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-rs"
-version = "0.2.38"
+version = "0.2.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15438a66c6f3e061554d8cd5a0e2c07c0828618f3e3ff3331be266347caccf25"
+checksum = "d7f80508c771f601bcd02b85d0a6d0890bdcee07b305d6afa9dff9d5c1f57f2c"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10564,7 +10564,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-service"
-version = "0.11.30"
+version = "0.11.31"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -212,7 +212,7 @@ aws-lc-rs = "1.16"
 # (camelCase wire enums + `/0.2` TYPE_URIs) alongside the retained
 # `v0_1` modules — the VTA dual-accepts both during the migration.
 # Bump in lockstep with affinidi-webvh-service when upstream publishes.
-trust-tasks-rs = { version = "0.2.38", default-features = false, features = ["validate"] }
+trust-tasks-rs = { version = "0.2.39", default-features = false, features = ["validate"] }
 trust-tasks-capability-client = "0.1"
 trust-tasks-https = { version = "0.2", default-features = false, features = ["server", "client", "jwt"] }
 trust-tasks-proof = { version = "0.2", default-features = false, features = ["affinidi"] }

--- a/trust-tasks/admin/passkeys/list/1.0/spec.md
+++ b/trust-tasks/admin/passkeys/list/1.0/spec.md
@@ -1,7 +1,8 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/admin/passkeys/list/1.0
 title: VTC Admin — List Passkeys
-status: draft
+status: retired
+supersededBy: https://trusttasks.org/spec/auth/passkey/list/0.1
 version: "1.0"
 authors:
   - did:webvh:openvtc.org
@@ -10,6 +11,15 @@ applies_to:
 ---
 
 # VTC Admin — List Passkeys
+
+> **Retired.** Folded onto the canonical `auth/passkey/*` tasks
+> (trust-tasks-tf#145); each ceremony leg now carries its own task,
+> where this one covered a whole family:
+>
+>   - `GET /v1/admin/passkeys` -> `https://trusttasks.org/spec/auth/passkey/list/0.1`
+>
+> No wire change — the canonical specs were written from this
+> implementation. Only the task URIs moved.
 
 Returns every passkey registered to the caller (admin) DID. Read-
 only — no step-up UV required (a stolen session leaks the

--- a/trust-tasks/admin/passkeys/register/1.0/spec.md
+++ b/trust-tasks/admin/passkeys/register/1.0/spec.md
@@ -1,7 +1,8 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/admin/passkeys/register/1.0
 title: VTC Admin — Register Passkey
-status: draft
+status: retired
+supersededBy: https://trusttasks.org/spec/auth/passkey/enroll/start/0.2
 version: "1.0"
 authors:
   - did:webvh:openvtc.org
@@ -11,6 +12,16 @@ applies_to:
 ---
 
 # VTC Admin — Register Passkey
+
+> **Retired.** Folded onto the canonical `auth/passkey/*` tasks
+> (trust-tasks-tf#145); each ceremony leg now carries its own task,
+> where this one covered a whole family:
+>
+>   - `POST /v1/admin/passkeys/register/start` -> `https://trusttasks.org/spec/auth/passkey/enroll/start/0.2`
+>   - `POST /v1/admin/passkeys/register/finish` -> `https://trusttasks.org/spec/auth/passkey/enroll/finish/0.2`
+>
+> No wire change — the canonical specs were written from this
+> implementation. Only the task URIs moved.
 
 Two-phase ceremony that enrols an additional WebAuthn passkey on
 the caller's admin DID. The spec (§4.3) requires a **fresh

--- a/trust-tasks/admin/passkeys/revoke/1.0/spec.md
+++ b/trust-tasks/admin/passkeys/revoke/1.0/spec.md
@@ -1,7 +1,8 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/admin/passkeys/revoke/1.0
 title: VTC Admin — Revoke Passkey
-status: draft
+status: retired
+supersededBy: https://trusttasks.org/spec/auth/passkey/revoke/start/0.1
 version: "1.0"
 authors:
   - did:webvh:openvtc.org
@@ -11,6 +12,16 @@ applies_to:
 ---
 
 # VTC Admin — Revoke Passkey
+
+> **Retired.** Folded onto the canonical `auth/passkey/*` tasks
+> (trust-tasks-tf#145); each ceremony leg now carries its own task,
+> where this one covered a whole family:
+>
+>   - `POST /v1/admin/passkeys/revoke/start` -> `https://trusttasks.org/spec/auth/passkey/revoke/start/0.1`
+>   - `POST /v1/admin/passkeys/revoke/finish` -> `https://trusttasks.org/spec/auth/passkey/revoke/finish/0.1`
+>
+> No wire change — the canonical specs were written from this
+> implementation. Only the task URIs moved.
 
 Two-phase ceremony that removes a registered WebAuthn passkey from
 the caller's admin DID. Spec §4.3:

--- a/trust-tasks/index.json
+++ b/trust-tasks/index.json
@@ -131,21 +131,24 @@
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/admin/passkeys/list/1.0",
-      "status": "draft",
+      "status": "retired",
       "path": "admin/passkeys/list/1.0",
-      "rest": "GET /v1/admin/passkeys"
+      "rest": "GET /v1/admin/passkeys",
+      "supersededBy": "https://trusttasks.org/spec/auth/passkey/list/0.1"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/admin/passkeys/register/1.0",
-      "status": "draft",
+      "status": "retired",
       "path": "admin/passkeys/register/1.0",
-      "rest": "POST /v1/admin/passkeys/register/{start,finish}"
+      "rest": "POST /v1/admin/passkeys/register/{start,finish}",
+      "supersededBy": "https://trusttasks.org/spec/auth/passkey/enroll/start/0.2"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/admin/passkeys/revoke/1.0",
-      "status": "draft",
+      "status": "retired",
       "path": "admin/passkeys/revoke/1.0",
-      "rest": "POST /v1/admin/passkeys/revoke/{start,finish}"
+      "rest": "POST /v1/admin/passkeys/revoke/{start,finish}",
+      "supersededBy": "https://trusttasks.org/spec/auth/passkey/revoke/start/0.1"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/admin/config/reload/1.0",

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.11.30"
+version = "0.11.31"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vtc-service/admin-ui/src/plugins/myPasskeys.tsx
+++ b/vtc-service/admin-ui/src/plugins/myPasskeys.tsx
@@ -23,12 +23,18 @@ import {
   type JsonPublicKeyOptions,
 } from "@/lib/webauthn";
 
-const TRUST_TASK_LIST =
-  "https://trusttasks.org/openvtc/vtc/admin/passkeys/list/1.0";
-const TRUST_TASK_REGISTER =
-  "https://trusttasks.org/openvtc/vtc/admin/passkeys/register/1.0";
-const TRUST_TASK_REVOKE =
-  "https://trusttasks.org/openvtc/vtc/admin/passkeys/revoke/1.0";
+// Canonical `auth/passkey/*` tasks (trust-tasks-tf#145). One task per
+// ceremony leg — the retired `admin/passkeys/{register,revoke}/1.0` pair
+// had start and finish sharing a URI.
+const TRUST_TASK_LIST = "https://trusttasks.org/spec/auth/passkey/list/0.1";
+const TRUST_TASK_ENROLL_START =
+  "https://trusttasks.org/spec/auth/passkey/enroll/start/0.2";
+const TRUST_TASK_ENROLL_FINISH =
+  "https://trusttasks.org/spec/auth/passkey/enroll/finish/0.2";
+const TRUST_TASK_REVOKE_START =
+  "https://trusttasks.org/spec/auth/passkey/revoke/start/0.1";
+const TRUST_TASK_REVOKE_FINISH =
+  "https://trusttasks.org/spec/auth/passkey/revoke/finish/0.1";
 
 
 interface RegisteredPasskey {
@@ -70,7 +76,7 @@ async function registerPasskey(args: {
   const start = await postJson<RegisterStartResponse>(
     "/v1/admin/passkeys/register/start",
     undefined,
-    { trustTask: TRUST_TASK_REGISTER },
+    { trustTask: TRUST_TASK_ENROLL_START },
   );
 
   const createPublicKey = decodePublicKeyOptions(
@@ -102,7 +108,7 @@ async function registerPasskey(args: {
       label: args.label,
       transports: [],
     },
-    { trustTask: TRUST_TASK_REGISTER },
+    { trustTask: TRUST_TASK_ENROLL_FINISH },
   );
 }
 
@@ -112,7 +118,7 @@ async function revokePasskey(args: {
   const start = await postJson<RevokeStartResponse>(
     "/v1/admin/passkeys/revoke/start",
     { credential_id: args.credentialId },
-    { trustTask: TRUST_TASK_REVOKE },
+    { trustTask: TRUST_TASK_REVOKE_START },
   );
 
   const uvPublicKey = decodePublicKeyOptions(
@@ -131,7 +137,7 @@ async function revokePasskey(args: {
       revocation_id: start.revocationId,
       uv_response: serializeAssertion(uvCred),
     },
-    { trustTask: TRUST_TASK_REVOKE },
+    { trustTask: TRUST_TASK_REVOKE_FINISH },
   );
 }
 

--- a/vtc-service/src/routes/mod.rs
+++ b/vtc-service/src/routes/mod.rs
@@ -479,30 +479,43 @@ fn build_api_chain(_routing: &RoutingConfig, trust_xff: bool) -> OpenApiRouter<A
             routes!(admin::bootstrap::bootstrap),
             "https://trusttasks.org/spec/vtc/admin/bootstrap/0.1",
         ))
-        // Admin passkey management (M0.6.3). Step-up UV is enforced
-        // via the two-phase ceremony: `register/start` and
-        // `revoke/start` issue a UV challenge bound to an existing
-        // passkey; `register/finish` and `revoke/finish` reject if
-        // the UV assertion doesn't verify.
+        // Admin passkey management (M0.6.3), on the canonical
+        // `auth/passkey/*` tasks (trust-tasks-tf#145).
+        //
+        // Each leg now carries its OWN task, where the retired
+        // `admin/passkeys/{register,revoke}/1.0` pair had start and
+        // finish sharing one URI. A shared URI could not describe
+        // either leg honestly: start takes no assertion and returns a
+        // challenge, finish takes the assertion and returns nothing
+        // like a challenge, so one schema covering both had to permit
+        // every member of each — which is how a finish missing its UV
+        // assertion validated cleanly.
+        //
+        // Step-up UV is unchanged in behaviour and is now *specified*:
+        // `enroll/start/0.2` returns `uvOptions` alongside the
+        // registration challenge and `enroll/finish/0.2` requires the
+        // matching `uvCredential`; revoke's two legs do the same. The
+        // canonical specs were written from this implementation, so
+        // the wire shape is what it always was.
         .routes(tt(
             routes!(admin::passkeys::list),
-            "https://trusttasks.org/openvtc/vtc/admin/passkeys/list/1.0",
+            "https://trusttasks.org/spec/auth/passkey/list/0.1",
         ))
         .routes(tt(
             routes!(admin::passkeys::register_start),
-            "https://trusttasks.org/openvtc/vtc/admin/passkeys/register/1.0",
+            "https://trusttasks.org/spec/auth/passkey/enroll/start/0.2",
         ))
         .routes(tt(
             routes!(admin::passkeys::register_finish),
-            "https://trusttasks.org/openvtc/vtc/admin/passkeys/register/1.0",
+            "https://trusttasks.org/spec/auth/passkey/enroll/finish/0.2",
         ))
         .routes(tt(
             routes!(admin::passkeys::revoke_start),
-            "https://trusttasks.org/openvtc/vtc/admin/passkeys/revoke/1.0",
+            "https://trusttasks.org/spec/auth/passkey/revoke/start/0.1",
         ))
         .routes(tt(
             routes!(admin::passkeys::revoke_finish),
-            "https://trusttasks.org/openvtc/vtc/admin/passkeys/revoke/1.0",
+            "https://trusttasks.org/spec/auth/passkey/revoke/finish/0.1",
         ))
         // Admin invites — REST mirror of `vtc admin invite`. GET +
         // POST share the same mount; DELETE on `/admin/invites/{jti}`

--- a/vtc-service/tests/admin_passkeys.rs
+++ b/vtc-service/tests/admin_passkeys.rs
@@ -34,9 +34,15 @@ use vtc_service::test_support::TestVtc;
 use common::webauthn_harness::SoftEd25519Authenticator;
 
 const RP_ORIGIN: &str = "https://vtc.example.com";
-const LIST_TASK: &str = "https://trusttasks.org/openvtc/vtc/admin/passkeys/list/1.0";
-const REGISTER_TASK: &str = "https://trusttasks.org/openvtc/vtc/admin/passkeys/register/1.0";
-const REVOKE_TASK: &str = "https://trusttasks.org/openvtc/vtc/admin/passkeys/revoke/1.0";
+// Canonical `auth/passkey/*` tasks (trust-tasks-tf#145). Each ceremony leg
+// carries its own task; the retired `admin/passkeys/{register,revoke}/1.0`
+// pair had start and finish sharing one URI, so a header naming the family
+// was accepted on either leg and could not distinguish them.
+const LIST_TASK: &str = "https://trusttasks.org/spec/auth/passkey/list/0.1";
+const ENROLL_START_TASK: &str = "https://trusttasks.org/spec/auth/passkey/enroll/start/0.2";
+const ENROLL_FINISH_TASK: &str = "https://trusttasks.org/spec/auth/passkey/enroll/finish/0.2";
+const REVOKE_START_TASK: &str = "https://trusttasks.org/spec/auth/passkey/revoke/start/0.1";
+const REVOKE_FINISH_TASK: &str = "https://trusttasks.org/spec/auth/passkey/revoke/finish/0.1";
 
 struct Fixture {
     state: AppState,
@@ -306,7 +312,7 @@ async fn register_succeeds_with_step_up_uv() {
         &fix.router,
         "POST",
         "/v1/admin/passkeys/register/start",
-        Some(REGISTER_TASK),
+        Some(ENROLL_START_TASK),
         Some(&token),
         Some(json!({})),
     )
@@ -327,7 +333,7 @@ async fn register_succeeds_with_step_up_uv() {
         &fix.router,
         "POST",
         "/v1/admin/passkeys/register/finish",
-        Some(REGISTER_TASK),
+        Some(ENROLL_FINISH_TASK),
         Some(&token),
         Some(json!({
             "registration_id": registration_id,
@@ -374,7 +380,7 @@ async fn register_finish_without_start_returns_401() {
         &fix.router,
         "POST",
         "/v1/admin/passkeys/register/finish",
-        Some(REGISTER_TASK),
+        Some(ENROLL_FINISH_TASK),
         Some(&token),
         Some(json!({
             "registration_id": Uuid::new_v4().to_string(),
@@ -397,7 +403,7 @@ async fn register_rejects_when_uv_signed_by_wrong_authenticator() {
         &fix.router,
         "POST",
         "/v1/admin/passkeys/register/start",
-        Some(REGISTER_TASK),
+        Some(ENROLL_START_TASK),
         Some(&token),
         Some(json!({})),
     )
@@ -465,7 +471,7 @@ async fn register_rejects_when_uv_signed_by_wrong_authenticator() {
         &fix.router,
         "POST",
         "/v1/admin/passkeys/register/finish",
-        Some(REGISTER_TASK),
+        Some(ENROLL_FINISH_TASK),
         Some(&token),
         Some(json!({
             "registration_id": registration_id,
@@ -500,7 +506,7 @@ async fn revoke_last_passkey_returns_409_last_passkey_protected() {
         &fix.router,
         "POST",
         "/v1/admin/passkeys/revoke/start",
-        Some(REVOKE_TASK),
+        Some(REVOKE_START_TASK),
         Some(&token),
         Some(json!({ "credential_id": cred_id })),
     )
@@ -516,7 +522,7 @@ async fn revoke_last_passkey_returns_409_last_passkey_protected() {
         &fix.router,
         "POST",
         "/v1/admin/passkeys/revoke/finish",
-        Some(REVOKE_TASK),
+        Some(REVOKE_FINISH_TASK),
         Some(&token),
         Some(json!({
             "revocation_id": revocation_id,
@@ -539,7 +545,7 @@ async fn revoke_after_register_succeeds_and_emits_audit_event() {
         &fix.router,
         "POST",
         "/v1/admin/passkeys/register/start",
-        Some(REGISTER_TASK),
+        Some(ENROLL_START_TASK),
         Some(&token),
         Some(json!({})),
     )
@@ -555,7 +561,7 @@ async fn revoke_after_register_succeeds_and_emits_audit_event() {
         &fix.router,
         "POST",
         "/v1/admin/passkeys/register/finish",
-        Some(REGISTER_TASK),
+        Some(ENROLL_FINISH_TASK),
         Some(&token),
         Some(json!({
             "registration_id": reg_id,
@@ -587,7 +593,7 @@ async fn revoke_after_register_succeeds_and_emits_audit_event() {
         &fix.router,
         "POST",
         "/v1/admin/passkeys/revoke/start",
-        Some(REVOKE_TASK),
+        Some(REVOKE_START_TASK),
         Some(&token),
         Some(json!({ "credential_id": bootstrap_id })),
     )
@@ -601,7 +607,7 @@ async fn revoke_after_register_succeeds_and_emits_audit_event() {
         &fix.router,
         "POST",
         "/v1/admin/passkeys/revoke/finish",
-        Some(REVOKE_TASK),
+        Some(REVOKE_FINISH_TASK),
         Some(&token),
         Some(json!({
             "revocation_id": revocation_id,
@@ -651,7 +657,7 @@ async fn revoke_rejects_unknown_credential_id() {
         &fix.router,
         "POST",
         "/v1/admin/passkeys/revoke/start",
-        Some(REVOKE_TASK),
+        Some(REVOKE_START_TASK),
         Some(&token),
         Some(json!({ "credential_id": "deadbeef" })),
     )
@@ -677,7 +683,7 @@ async fn revoke_finish_without_start_returns_401() {
         &fix.router,
         "POST",
         "/v1/admin/passkeys/revoke/finish",
-        Some(REVOKE_TASK),
+        Some(REVOKE_FINISH_TASK),
         Some(&token),
         Some(json!({
             "revocation_id": Uuid::new_v4().to_string(),
@@ -700,7 +706,7 @@ async fn register_start_returns_415_with_wrong_trust_task() {
         &fix.router,
         "POST",
         "/v1/admin/passkeys/register/start",
-        Some(REVOKE_TASK), // wrong task on register endpoint
+        Some(REVOKE_START_TASK), // wrong task on register endpoint
         Some(&token),
         Some(json!({})),
     )
@@ -716,7 +722,7 @@ async fn register_returns_503_when_audit_writer_missing() {
         &fix.router,
         "POST",
         "/v1/admin/passkeys/register/start",
-        Some(REGISTER_TASK),
+        Some(ENROLL_START_TASK),
         Some(&token),
         Some(json!({})),
     )
@@ -732,7 +738,7 @@ async fn register_returns_503_when_audit_writer_missing() {
         &fix.router,
         "POST",
         "/v1/admin/passkeys/register/finish",
-        Some(REGISTER_TASK),
+        Some(ENROLL_FINISH_TASK),
         Some(&token),
         Some(json!({
             "registration_id": registration_id,

--- a/vtc-service/tests/install_flow.rs
+++ b/vtc-service/tests/install_flow.rs
@@ -45,9 +45,9 @@ const RP_ORIGIN: &str = "https://vtc.example.com";
 const CLAIM_START_TASK: &str = "https://trusttasks.org/spec/vtc/install/claim/start/0.1";
 const CLAIM_FINISH_TASK: &str = "https://trusttasks.org/spec/vtc/install/claim/finish/0.1";
 const BOOTSTRAP_TASK: &str = "https://trusttasks.org/spec/vtc/admin/bootstrap/0.1";
-const PASSKEY_REGISTER_TASK: &str =
-    "https://trusttasks.org/openvtc/vtc/admin/passkeys/register/1.0";
-const PASSKEY_LIST_TASK: &str = "https://trusttasks.org/openvtc/vtc/admin/passkeys/list/1.0";
+const ENROLL_START_TASK: &str = "https://trusttasks.org/spec/auth/passkey/enroll/start/0.2";
+const ENROLL_FINISH_TASK: &str = "https://trusttasks.org/spec/auth/passkey/enroll/finish/0.2";
+const LIST_TASK: &str = "https://trusttasks.org/spec/auth/passkey/list/0.1";
 const COMMUNITY_PROFILE_TASK: &str = "https://trusttasks.org/spec/vtc/community/profile/show/0.1";
 const ADMIN_CONFIG_PATCH_TASK: &str = "https://trusttasks.org/spec/config/patch/0.1";
 const RESTART_TASK: &str = "https://trusttasks.org/spec/config/restart/0.1";
@@ -287,7 +287,7 @@ async fn end_to_end_install_flow_phase_0_gate() {
         &fix.router,
         "POST",
         "/v1/admin/passkeys/register/start",
-        PASSKEY_REGISTER_TASK,
+        ENROLL_START_TASK,
         Some(&admin_token),
         Some(json!({})),
     )
@@ -306,7 +306,7 @@ async fn end_to_end_install_flow_phase_0_gate() {
         &fix.router,
         "POST",
         "/v1/admin/passkeys/register/finish",
-        PASSKEY_REGISTER_TASK,
+        ENROLL_FINISH_TASK,
         Some(&admin_token),
         Some(json!({
             "registration_id": reg_id,
@@ -326,7 +326,7 @@ async fn end_to_end_install_flow_phase_0_gate() {
         &fix.router,
         "GET",
         "/v1/admin/passkeys",
-        PASSKEY_LIST_TASK,
+        LIST_TASK,
         Some(&admin_token),
         None,
     )

--- a/vtc-service/tests/trust_task_manifest.rs
+++ b/vtc-service/tests/trust_task_manifest.rs
@@ -335,18 +335,17 @@ const AWAITING_CANONICAL_FOLD: &[(&str, &str)] = &[
         "admin/config/import/1.0",
         "canonical config/import — blocked; communityProfileDiff is structural",
     ),
-    (
-        "admin/passkeys/list/1.0",
-        "canonical auth/passkey/list — blocked, spec not yet proposed upstream",
-    ),
-    (
-        "admin/passkeys/register/1.0",
-        "canonical auth/passkey/enroll/{start,finish} + confirm/1.0 gate",
-    ),
-    (
-        "admin/passkeys/revoke/1.0",
-        "canonical passkey-revoke + confirm/1.0 gate; needs the list spec first",
-    ),
+    // The three `admin/passkeys/*` entries are GONE, folded onto the
+    // canonical `auth/passkey/{list,enroll/*,revoke/*}` tasks authored in
+    // trust-tasks-tf#145.
+    //
+    // Their recorded blocker was wrong, which is why they sat here so long.
+    // The note said each needed a `confirm/1.0` gate; `confirm/request` is an
+    // ASYNCHRONOUS delegation whose response returns out of band on the
+    // approver's own transport. This surface never needed that — it verifies
+    // the user in-band, in the same request, via WebAuthn. The canonical specs
+    // were written from this implementation rather than the other way round,
+    // so the fold changed URIs and nothing else.
     (
         "auth/admin-login/1.0",
         "canonical auth/authenticate; the cookie side-effect moves to a binding/ext",


### PR DESCRIPTION
The VTI half of [trust-tasks-tf#145](https://github.com/trustoverip/dtgwg-trust-tasks-tf/pull/145). Moves `/v1/admin/passkeys/*` off the retired `openvtc/vtc/` authority onto the canonical tasks that PR published (`trust-tasks-rs` 0.2.38 → 0.2.39).

**Three of the eight entries in `AWAITING_CANONICAL_FOLD` are gone.** #710 and #709 shrink accordingly; five remain.

## No wire change

The canonical specs were written **from this implementation**, not the other way round. Request and response bodies are byte-identical — only the `type` URIs moved.

## One task per ceremony leg, where there used to be one per family

`admin/passkeys/register/1.0` covered *both* `register/start` and `register/finish`; `revoke/1.0` likewise. A single schema spanning both legs has to permit the union of their members — which means **a `finish` arriving without its user-verification assertion still validated against the family task**. Each leg now names its own:

| Endpoint | Task |
|---|---|
| `GET /v1/admin/passkeys` | `auth/passkey/list/0.1` |
| `POST …/register/start` | `auth/passkey/enroll/start/0.2` |
| `POST …/register/finish` | `auth/passkey/enroll/finish/0.2` |
| `POST …/revoke/start` | `auth/passkey/revoke/start/0.1` |
| `POST …/revoke/finish` | `auth/passkey/revoke/finish/0.1` |

## Every call site audited per leg, not renamed in bulk

A mount split means a bulk find-and-replace is exactly the wrong move — that's how splitting the VTC mounts earlier hid two admin-UI bugs. So all four binding sites were walked individually, each call site mapped to the endpoint it actually targets before being repointed:

- the router (5 mounts)
- `tests/admin_passkeys.rs` — **19 call sites**
- `tests/install_flow.rs` — 3
- `admin-ui/src/plugins/myPasskeys.tsx` — 4

The negative test that deliberately sends the wrong task to `register/start` still sends a wrong one.

## The recorded blocker was wrong

This is why these three sat unfolded so long. The note said each needed a **`confirm/1.0` gate**. Reading that spec: `confirm/request` is an **asynchronous** delegation whose response returns *out of band on the approver's own transport*. That is right when the approver is a separate party. It is wrong here — this surface verifies the user **in-band, in the same request**, via WebAuthn, and always did.

`enroll/*` moves to **0.2** because that is the version carrying the optional `uvOptions` / `uvCredential` members describing the re-authentication half this code already performs.

Worth noting for whoever picks up the rest: **`members/promote-to-admin` carries the same wrong blocker.** It is also a synchronous two-phase UV ceremony (`promote_start` / `promote_finish`). It is *not* a free fold though — its `finish` leg is fused, consuming the UV assertion *and* performing the role change, and `acl/change-role/0.1` requires `{subject, fromRole, toRole}` which the endpoint never carries. It needs either an API split or a new spec; both are judgement calls, not mechanical work.

## Retiring the superseded tasks

The manifest test refuses to publish a task no route binds, so `admin/passkeys/{list,register,revoke}/1.0` are marked `status: retired` + `supersededBy` in `trust-tasks/` and `index.json`, per SPEC §5.3 — the same treatment `admin/config/manage` got.

## Verification

- `cargo check --workspace --locked --all-targets` — clean
- `cargo test -p vtc-service` — full suite green
- `trust_task_manifest` 7/7 · `admin_passkeys` 12/12 · `install_flow` 1/1
- `cargo clippy --workspace --all-targets` — no warnings
- `cargo fmt --check`, version-bump guard, changelog guard, lockfile self-pin guard — all pass

Refs #710, #709.
