### PR TITLE
fix(sdk): TSP is a per-surface leg, not a whole-client transport (#803)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,68 @@
 
 ## Unreleased
 
+### vta-sdk 0.20.2 — TSP is a per-surface leg, not a whole-client transport
+
+A consumer holding a DIDComm session could not use TSP at all. The only way to
+a Trust-Task-over-TSP client was `connect_tsp`, which opens its **own**
+websocket — and the mediator permits one websocket per DID, so the second was
+rejected with `duplicate-channel` and the two reconnect loops duelled. On the
+reference deployment `#tsp` and `#vta-didcomm` resolve to the *same* mediator,
+so that was the normal case; a split-mediator topology would have worked, which
+is the worst shape available (correct on an unusual deployment, broken on the
+one everyone runs). This blocked OpenVTC/openvtc#185 item 2b.
+
+**The fix is the client-side mirror of one the VTA already shipped.**
+`vta-service` deleted its standalone TSP websocket for exactly this reason and
+now demuxes TSP off its single delivery-layer socket. The client can do the
+same, because neither half of TSP needs a socket of its own: send is an HTTP
+`POST /inbound` to the mediator, and receive already arrives on the DIDComm
+pickup socket, which `live_stream_next_frame` tags by protocol.
+
+- `DIDCommSession` gains a **TSP leg** — `send_tsp_document`, `request_tsp`,
+  `receive_next_tsp` — over its existing connection. **No second socket.** The
+  leg takes its own `subscribe()` receiver, so the TSP pump cannot eat a DIDComm
+  push and `receive_next` cannot eat a TSP reply.
+- `VtaClient::enable_tsp_trust_tasks` moves the Trust-Task surface
+  (`dispatch_trust_task`, `rpc_tt`, the `device/*` and `vault/*` methods) onto
+  it. **No I/O, cannot fail.** `attach_tsp_leg` covers the split-mediator
+  topology, and refuses a second session for a DID on the mediator it is already
+  connected to — the defect is now unrepresentable through the API.
+  `connect_didcomm_with_tsp` does both in one call.
+- `rpc` / `rpc_void` stay on DIDComm unconditionally. TSP carries Trust Tasks;
+  the VTA has no TSP dispatcher behind `key-management/1.0/*`,
+  `create_did_webvh` or `list_contexts`.
+
+**Fixes a live regression on the `pnm`/`cnm` connect path.** Since TSP became
+selectable, `TransportChoice::Auto` returned a **TSP-only** client whenever a
+VTA advertised `#tsp` — so on a TSP-enabled VTA every protocol-message command
+(`keys create`, `contexts list`, DID minting) failed with
+`UnsupportedTransport`. `Auto` now returns a **dual** client against a VTA
+advertising both: trust tasks over TSP, protocol messages over DIDComm, one
+socket. A VTA advertising `#tsp` alone still yields a TSP-only client, and
+`--transport tsp` is unchanged (TSP-only by request). If the DIDComm mediator is
+down, `Auto` still falls back to TSP-only — loudly, naming what that client
+cannot serve.
+
+New: `SurfaceTransport` + `VtaClient::{trust_task_transport,
+protocol_message_transport}`, because a client no longer has *one* transport and
+an operator display that renders a single value is wrong by construction.
+
+Also fixed: `DIDCommSession::receive_next` parsed every inbound frame as a
+DIDComm `Message`, so a TSP frame on the multiplexed socket became a hard error
+on the DIDComm inbox that received it. It now skips them. Latent until now,
+because nothing sent TSP to an SDK DIDComm session.
+
+Internals: reply correlation moved to a shared `tsp_demux` so `TspSession` and
+the new leg cannot drift on the rule that stops a *stale* inbox frame being
+returned as a reply (#749). Its parking queue is now bounded — previously
+unbounded, which a long-running process that only calls `request` would grow
+forever.
+
+Verified live against the deployed VTA (a trust task dispatched over the DIDComm
+session's socket, reply correlated back) and hermetically over the embedded
+`TestMediator` in `tests/e2e/tests/tsp_dual_leg.rs`.
+
 ### vtc-service 0.11.31 — admin passkeys move to the canonical `auth/passkey/*` tasks
 
 The `/v1/admin/passkeys/*` surface leaves the retired `openvtc/vtc/` authority

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,6 +145,27 @@ When designing any new inter-component flow *or its authentication*, reach for
 TSP first, then DIDComm. Do **not** default to "a REST endpoint plus a bespoke
 signature/DID-resolution scheme" — that is a recurring mistake.
 
+**TSP is selected per *surface*, not per client, and rides one socket per DID.**
+Two rules that bite anything adopting TSP (see
+`docs/05-design-notes/tsp-enablement.md` §3.3a):
+
+- TSP carries the **Trust-Task** surface. The older DIDComm protocol-message
+  surface (`key-management/1.0/*`, `create_did_webvh`, `list_contexts`) has no
+  TSP dispatcher behind it, so a client on a dual-transport VTA is on TSP for
+  trust tasks *and* DIDComm for protocol messages, simultaneously. Choosing one
+  transport client-wide breaks the other surface — that is how
+  `TransportChoice::Auto` silently broke every `rpc` call the moment a VTA
+  advertised `#tsp` (#803). Read `VtaClient::{trust_task_transport,
+  protocol_message_transport}`; never render a single "transport" for a client.
+- **The mediator permits one websocket per DID.** A node speaking both protocols
+  multiplexes them on that socket; a second is evicted as `duplicate-channel`
+  and the two reconnect loops duel. TSP send is an HTTP post and TSP receive
+  arrives on the existing pickup socket already tagged by protocol, so no second
+  socket is ever needed. `vta-service` works this way; client-side it is
+  `DIDCommSession`'s TSP leg via `VtaClient::enable_tsp_trust_tasks`. If you are
+  reaching for `TspSession::connect` on a DID that already holds a
+  `DIDCommSession`, use the leg instead.
+
 Why TSP over DIDComm: metadata-private routing (intermediaries don't learn the
 final recipient) at **bounded** message size (CESR + HPKE add roughly additive
 per-hop overhead, versus DIDComm-nested's multiplicative base64 blow-up), while

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10269,7 +10269,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",

--- a/docs/05-design-notes/tsp-enablement.md
+++ b/docs/05-design-notes/tsp-enablement.md
@@ -211,6 +211,51 @@ chosen  = first protocol in [Tsp, Didcomm, Rest] present in BOTH ours and theirs
   (`Auto` now = TSP→DIDComm→REST) and `decide_transport` / `TransportPlan` to a
   3-way plan with the new no-match terminal state.
 
+### 3.3a TSP is selected **per surface**, and rides one socket per DID (#803)
+
+Two constraints, discovered in implementation, that §3.2's "pick the highest
+protocol both parties advertise" does not by itself capture. Both are load-bearing
+for any consumer adopting TSP.
+
+**(a) TSP carries the Trust-Task surface only.** The VTA's TSP inbound dispatcher
+hands each unpacked payload to `dispatch_trust_task_core`; there is no TSP
+dispatcher behind the older DIDComm *protocol-message* surface
+(`key-management/1.0/*`, `create_did_webvh`, `list_contexts`, …), which reports
+`UnsupportedTransport` by design. So "chosen protocol" is **not** a single
+client-wide value: a client can legitimately be on TSP for trust tasks and DIDComm
+for protocol messages at the same moment, and that is the *correct* outcome against
+a VTA advertising both.
+
+Selecting TSP client-wide is a live defect, not a theoretical one — it broke every
+`rpc` operation on the `pnm`/`cnm` `TransportChoice::Auto` path the moment a VTA
+started advertising `#tsp`. `VtaClient::{trust_task_transport,
+protocol_message_transport}` exist so operator-facing displays cannot render the
+single value that is wrong by construction.
+
+**(b) The mediator permits one websocket per DID.** A node speaking both protocols
+**multiplexes them on that one socket** — it does not open a second. This is
+enforced upstream (`duplicate-channel`), and where the two protocols name the same
+mediator — which the reference deployment does — a second socket means eviction
+plus duelling reconnect loops.
+
+The mechanics that make one socket sufficient:
+
+| | Mechanism | Socket? |
+|---|---|---|
+| TSP send | `TspOps::send_raw` → HTTP `POST /inbound` on the mediator | none |
+| TSP receive | `live_stream_next_frame` on the DIDComm pickup socket, tagged `Inbound.message.protocol` | the DIDComm one |
+
+`vta-service` already works this way (its standalone TSP websocket was removed for
+exactly this reason). Client-side the same shape is `DIDCommSession`'s **TSP leg**
+(`send_tsp_document` / `request_tsp` / `receive_next_tsp`), turned on with
+`VtaClient::enable_tsp_trust_tasks` — free, no I/O, no new connection. A VTA
+advertising a *separate* TSP mediator is the one case that needs its own session
+(`attach_tsp_leg`); there the two mediators mean there is no conflict to have.
+
+**Rule for new code:** never open a second websocket for a DID that already has
+one. If you are reaching for `TspSession::connect` on a DID that holds a
+`DIDCommSession`, the answer is the leg.
+
 ### 3.4 The "No matching protocol" error (typed, both transports)
 
 Per CLAUDE.md's "operator errors should suggest the fix" + typed-`VtaError` discipline:

--- a/tests/e2e/tests/tsp_dual_leg.rs
+++ b/tests/e2e/tests/tsp_dual_leg.rs
@@ -1,0 +1,370 @@
+//! Regression guard: one DID, one websocket, **both** protocols (#803).
+//!
+//! ## Why this exists
+//!
+//! `vta-sdk` could only produce a Trust-Task-over-TSP client by opening its own
+//! websocket (`TspSession::connect`). The mediator permits **one websocket per
+//! DID**, so a consumer already holding a `DIDCommSession` on that DID got
+//! `duplicate-channel` and two duelling reconnect loops. On the reference
+//! deployment `#tsp` and `#vta-didcomm` resolve to the *same* mediator, so that
+//! was the normal case — and because a split-mediator deployment *would* have
+//! worked, the failure only showed up on the topology everyone actually runs.
+//!
+//! The fix is the client-side mirror of what the VTA already does on the server
+//! side: TSP rides the DIDComm session's existing socket. Send is an HTTP post
+//! to the mediator; receive arrives on the pickup socket already multiplexed
+//! (`live_stream_next_frame` tags each frame's protocol).
+//!
+//! ## What these tests pin
+//!
+//! 1. A TSP frame addressed to a DID whose only connection is a `DIDCommSession`
+//!    reaches that session — with **no** TSP socket of its own.
+//! 2. Both legs work on that one session: a DIDComm send and a TSP send from the
+//!    same connection.
+//! 3. `request_tsp` correlates its own reply, and an unrelated push is parked for
+//!    `receive_next_tsp` rather than eaten.
+//! 4. A `VtaClient` with the leg attached reports TSP for trust tasks and
+//!    DIDComm for protocol messages — the per-surface model, not a third
+//!    client-wide transport.
+//! 5. Attaching a *separate* TSP session for a DID on the mediator it is already
+//!    connected to is refused: the defect is unrepresentable through the API.
+//!
+//! Hermetic — `TestMediator`, no network, no deployed VTA — so these run in CI
+//! unignored.
+
+use std::time::Duration;
+
+use affinidi_messaging_test_mediator::TestMediator;
+use ed25519_dalek::SigningKey;
+use vta_sdk::client::{SurfaceTransport, VtaClient};
+use vta_sdk::did_key::ed25519_multibase_pubkey;
+use vta_sdk::didcomm_session::DIDCommSession;
+use vta_sdk::session::TspSession;
+
+mod common;
+
+/// Deterministic `did:key` + matching multibase private key from a seed byte.
+/// Mirrors `tsp_round_trip.rs` so both binaries build identities identically.
+fn did_key_from_seed(seed_byte: u8) -> (String, String) {
+    let seed = [seed_byte; 32];
+    let sk = SigningKey::from_bytes(&seed);
+    let pk = sk.verifying_key().to_bytes();
+    let did = format!("did:key:{}", ed25519_multibase_pubkey(&pk));
+    let mut buf = vec![0x80, 0x26];
+    buf.extend_from_slice(&seed);
+    let priv_mb = multibase::encode(multibase::Base::Base58Btc, &buf);
+    (did, priv_mb)
+}
+
+/// A minimal Trust-Task-shaped request. TSP carries these bytes directly (no
+/// DIDComm envelope), which is what the VTA's `tsp_inbound::dispatch_one`
+/// expects, so this matches the real wire shape.
+fn request_doc(id: &str) -> Vec<u8> {
+    serde_json::to_vec(&serde_json::json!({
+        "id": id,
+        "type": "https://trusttasks.org/spec/messaging/ping/0.1",
+        "payload": { "nonce": id },
+    }))
+    .expect("serialize request document")
+}
+
+/// The threaded `#response` a responder sends back — `threadId` is the request's
+/// `id`, which is what correlation matches on.
+fn response_doc(thread_id: &str) -> Vec<u8> {
+    serde_json::to_vec(&serde_json::json!({
+        "id": format!("{thread_id}-reply"),
+        "type": "https://trusttasks.org/spec/messaging/ping/0.1#response",
+        "threadId": thread_id,
+        "payload": { "pong": true },
+    }))
+    .expect("serialize response document")
+}
+
+/// Pull the `id` out of a received Trust-Task document.
+fn doc_id(json: &str) -> String {
+    serde_json::from_str::<serde_json::Value>(json)
+        .expect("received frame is JSON")
+        .get("id")
+        .and_then(|v| v.as_str())
+        .expect("received document has an id")
+        .to_string()
+}
+
+/// **The core case.** A DID whose only connection is a `DIDCommSession` still
+/// receives TSP.
+///
+/// Before the fix this required a second websocket for that DID, which the
+/// mediator rejects. Here the `DIDCommSession` is the *only* connection the
+/// recipient has: no `TspSession`, no second socket, and the frame still lands.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_didcomm_session_receives_tsp_on_its_own_socket() {
+    common::init_tracing();
+
+    let (recipient_did, recipient_priv) = did_key_from_seed(0x71);
+    let (sender_did, sender_priv) = did_key_from_seed(0x72);
+
+    let mediator = TestMediator::builder()
+        .local_did(recipient_did.clone())
+        .local_did(sender_did.clone())
+        .spawn()
+        .await
+        .expect("spawn test mediator");
+
+    // The recipient's ONLY connection — a DIDComm session. No TSP socket.
+    let recipient =
+        DIDCommSession::connect(&recipient_did, &recipient_priv, &sender_did, mediator.did())
+            .await
+            .expect("recipient DIDComm session connects");
+
+    let sender = TspSession::connect(&sender_did, &sender_priv, mediator.did())
+        .await
+        .expect("sender TSP session connects");
+    sender
+        .send_document(
+            &recipient_did,
+            mediator.did(),
+            &request_doc("urn:uuid:dual-1"),
+        )
+        .await
+        .expect("TSP send reports success");
+
+    // Generous budget: the failure mode is a drop, not slowness, so a short
+    // timeout would muddle "never delivered" with "still in flight".
+    let received = recipient
+        .receive_next_tsp(20)
+        .await
+        .expect("receive_next_tsp must not error");
+
+    sender.shutdown().await;
+    recipient.shutdown().await;
+    mediator.shutdown();
+    mediator.join().await.expect("mediator joins cleanly");
+
+    let frame = received.expect(
+        "a TSP frame addressed to a DID holding only a DIDComm session was never \
+         delivered — the multiplexed receive path is broken, and TSP is once again \
+         reachable only by opening a second socket for this DID (#803)",
+    );
+    assert_eq!(doc_id(&frame), "urn:uuid:dual-1");
+}
+
+/// Both legs, one session, one socket: a DIDComm send and a TSP send from the
+/// same connection.
+///
+/// This is the property that makes per-surface routing possible — `rpc` on
+/// DIDComm and `dispatch_trust_task` on TSP without the two fighting over the
+/// DID's single websocket slot.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn one_session_carries_both_protocols() {
+    common::init_tracing();
+
+    let (client_did, client_priv) = did_key_from_seed(0x73);
+    let (peer_did, peer_priv) = did_key_from_seed(0x74);
+
+    let mediator = TestMediator::builder()
+        .local_did(client_did.clone())
+        .local_did(peer_did.clone())
+        .spawn()
+        .await
+        .expect("spawn test mediator");
+
+    let session = DIDCommSession::connect(&client_did, &client_priv, &peer_did, mediator.did())
+        .await
+        .expect("DIDComm session connects");
+    // The peer only needs to be reachable; a TSP inbox proves the frame routed.
+    let peer = TspSession::connect(&peer_did, &peer_priv, mediator.did())
+        .await
+        .expect("peer TSP session connects");
+
+    session
+        .send_one_way(
+            &peer_did,
+            "https://trusttasks.org/binding/didcomm/0.1/envelope",
+            serde_json::json!({ "id": "urn:uuid:didcomm-leg" }),
+        )
+        .await
+        .expect("the DIDComm leg still works");
+
+    session
+        .send_tsp_document(&peer_did, &request_doc("urn:uuid:tsp-leg"))
+        .await
+        .expect("the TSP leg sends over the same session");
+
+    let delivered = peer
+        .receive_next(20)
+        .await
+        .expect("peer receive must not error");
+
+    session.shutdown().await;
+    peer.shutdown().await;
+    mediator.shutdown();
+    mediator.join().await.expect("mediator joins cleanly");
+
+    let frame = delivered.expect("the TSP frame sent from the DIDComm session never arrived");
+    assert_eq!(doc_id(&frame), "urn:uuid:tsp-leg");
+}
+
+/// The full request/response round trip over the multiplexed socket, plus the
+/// invariant that keeps it safe: an **unrelated** push must not be handed back
+/// as the reply.
+///
+/// The peer deliberately sends a push *first*, then the threaded `#response`.
+/// A "first frame that parses" implementation would return the push and report a
+/// successful round trip against a document nobody asked for — the exact fault
+/// class that made #749 look intermittent.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn request_tsp_correlates_its_reply_and_parks_the_push() {
+    common::init_tracing();
+
+    let (client_did, client_priv) = did_key_from_seed(0x75);
+    let (peer_did, peer_priv) = did_key_from_seed(0x76);
+
+    let mediator = TestMediator::builder()
+        .local_did(client_did.clone())
+        .local_did(peer_did.clone())
+        .spawn()
+        .await
+        .expect("spawn test mediator");
+
+    let session = DIDCommSession::connect(&client_did, &client_priv, &peer_did, mediator.did())
+        .await
+        .expect("DIDComm session connects");
+    let peer = TspSession::connect(&peer_did, &peer_priv, mediator.did())
+        .await
+        .expect("peer TSP session connects");
+
+    // The responder: wait for the request, send an unrelated push, then reply.
+    let peer_mediator = mediator.did().to_string();
+    let client_did_for_peer = client_did.clone();
+    let responder = tokio::spawn(async move {
+        let request = peer
+            .receive_next(20)
+            .await
+            .expect("peer receive must not error")
+            .expect("peer received the request");
+        let request_id = doc_id(&request);
+
+        peer.send_document(
+            &client_did_for_peer,
+            &peer_mediator,
+            &request_doc("urn:uuid:unrelated-push"),
+        )
+        .await
+        .expect("push send succeeds");
+        peer.send_document(
+            &client_did_for_peer,
+            &peer_mediator,
+            &response_doc(&request_id),
+        )
+        .await
+        .expect("reply send succeeds");
+        peer.shutdown().await;
+        request_id
+    });
+
+    let request_id = "urn:uuid:correlated-request";
+    let reply = session
+        .request_tsp(&peer_did, &request_doc(request_id), Duration::from_secs(25))
+        .await
+        .expect("request_tsp must return the correlated reply");
+
+    let received_request_id = responder.await.expect("responder task joins");
+
+    // The push must still be collectable — parked, not eaten by the request.
+    let parked = session
+        .receive_next_tsp(20)
+        .await
+        .expect("receive_next_tsp must not error");
+
+    session.shutdown().await;
+    mediator.shutdown();
+    mediator.join().await.expect("mediator joins cleanly");
+
+    assert_eq!(received_request_id, request_id, "the peer saw our request");
+
+    let reply_doc: serde_json::Value = serde_json::from_str(&reply).expect("reply is JSON");
+    assert_eq!(
+        reply_doc.get("threadId").and_then(|v| v.as_str()),
+        Some(request_id),
+        "request_tsp returned a document that is not the reply to our request \
+         (correlation is broken — a stale or unrelated frame can now be reported \
+         as a successful round trip): {reply}"
+    );
+
+    let push = parked.expect(
+        "the unrelated push was consumed by the in-flight request instead of being \
+         parked — a VTA-pushed task-consent request would be silently lost",
+    );
+    assert_eq!(doc_id(&push), "urn:uuid:unrelated-push");
+}
+
+/// The per-surface model at the `VtaClient` level: trust tasks on TSP, protocol
+/// messages on DIDComm, on one client.
+///
+/// A single "which transport is this client on" answer is wrong by construction
+/// — TSP carries Trust Tasks only, so selecting it client-wide would break
+/// `key-management/1.0/*`, `create_did_webvh` and `list_contexts`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_client_reports_tsp_for_trust_tasks_and_didcomm_for_protocol_messages() {
+    common::init_tracing();
+
+    let (client_did, client_priv) = did_key_from_seed(0x77);
+    let (vta_did, _) = did_key_from_seed(0x78);
+
+    let mediator = TestMediator::builder()
+        .local_did(client_did.clone())
+        .local_did(vta_did.clone())
+        .spawn()
+        .await
+        .expect("spawn test mediator");
+
+    let mut client =
+        VtaClient::connect_didcomm(&client_did, &client_priv, &vta_did, mediator.did(), None)
+            .await
+            .expect("DIDComm client connects");
+
+    assert_eq!(client.trust_task_transport(), SurfaceTransport::Didcomm);
+
+    // The VTA advertises the same mediator for `#tsp` — the reference topology.
+    // No I/O, no second socket.
+    client
+        .enable_tsp_trust_tasks(mediator.did())
+        .expect("enabling the TSP leg on the same mediator must not fail");
+
+    assert_eq!(
+        client.trust_task_transport(),
+        SurfaceTransport::Tsp,
+        "trust tasks must move to TSP"
+    );
+    assert_eq!(
+        client.protocol_message_transport(),
+        SurfaceTransport::Didcomm,
+        "protocol messages must stay on DIDComm — TSP has no dispatcher for them"
+    );
+
+    // Attaching a *separate* TSP session for this DID on the mediator it is
+    // already connected to is the #803 defect. The API refuses it rather than
+    // letting a caller reintroduce the duplicate socket.
+    let stray = std::sync::Arc::new(
+        TspSession::connect(&client_did, &client_priv, mediator.did())
+            .await
+            .expect("a raw TSP session can still be built directly"),
+    );
+    let refused = client.attach_tsp_leg(std::sync::Arc::clone(&stray), mediator.did());
+    // Refused, so the client will not shut it down for us — and a leaked TSP
+    // socket is the very thing under test.
+    stray.shutdown().await;
+    assert!(
+        refused.is_err(),
+        "attaching a second socket for this DID on its own mediator must be refused"
+    );
+    let msg = refused.unwrap_err().to_string();
+    assert!(
+        msg.contains("duplicate-channel") && msg.contains("enable_tsp_trust_tasks"),
+        "the refusal must name the failure and the fix: {msg}"
+    );
+
+    client.shutdown().await;
+    mediator.shutdown();
+    mediator.join().await.expect("mediator joins cleanly");
+}

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.20.1"
+version = "0.20.2"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/client/mod.rs
+++ b/vta-sdk/src/client/mod.rs
@@ -47,6 +47,17 @@ pub(super) enum Transport {
         session: crate::didcomm_session::DIDCommSession,
         rest_client: Option<Client>,
         rest_url: Option<String>,
+        /// The **Trust-Task surface**'s transport, when it has been moved to
+        /// TSP by [`VtaClient::enable_tsp_trust_tasks`]. `None` means every
+        /// surface uses DIDComm.
+        ///
+        /// TSP is selected *per surface*, not per client: it carries Trust
+        /// Tasks, and the older DIDComm protocol-message surface
+        /// ([`VtaClient::rpc`]) has no TSP dispatcher behind it. So a client
+        /// that wants both keeps its DIDComm leg and adds this one, rather than
+        /// choosing between them.
+        #[cfg(feature = "tsp")]
+        tsp: Option<TspLeg>,
     },
     /// TSP — the workspace's highest-preference transport.
     ///
@@ -64,6 +75,83 @@ pub(super) enum Transport {
         rest_client: Option<Client>,
         rest_url: Option<String>,
     },
+}
+
+/// How a DIDComm client reaches TSP for the Trust-Task surface.
+///
+/// The distinction exists because **the mediator permits one websocket per
+/// DID**. Which arm applies is decided by comparing the VTA's advertised `#tsp`
+/// endpoint against the mediator the DIDComm session is already on — see
+/// [`tsp_leg_for`].
+#[cfg(all(feature = "session", feature = "tsp"))]
+#[derive(Clone)]
+pub(super) enum TspLeg {
+    /// The VTA advertises the **same** mediator for `#tsp` and
+    /// `#vta-didcomm` — the reference topology. TSP rides the DIDComm session's
+    /// existing socket (`DIDCommSession::request_tsp`). No second connection, so
+    /// nothing to fail and nothing to shut down.
+    Multiplexed,
+    /// The VTA advertises a **different** TSP mediator. There is no
+    /// one-socket-per-DID conflict across two mediators, so this leg owns its
+    /// own [`TspSession`](crate::session::TspSession) — and, being ours, must be
+    /// shut down with the client.
+    Separate {
+        session: std::sync::Arc<crate::session::TspSession>,
+        mediator_did: String,
+    },
+}
+
+/// Which TSP leg a DIDComm session on `didcomm_mediator_did` should use to reach
+/// a VTA advertising `tsp_mediator_did`.
+///
+/// Pure so the rule is testable without a mediator: `None` here would mean
+/// silently keeping trust tasks on DIDComm, and `Separate` on the reference
+/// deployment would mean a second socket for one DID — `duplicate-channel` plus
+/// duelling reconnect loops (#803). Both failure modes are decided entirely by
+/// this comparison, so it is worth pinning on its own.
+#[cfg(all(feature = "session", feature = "tsp"))]
+pub(super) fn tsp_leg_kind(didcomm_mediator_did: &str, tsp_mediator_did: &str) -> TspLegKind {
+    if didcomm_mediator_did == tsp_mediator_did {
+        TspLegKind::Multiplexed
+    } else {
+        TspLegKind::Separate
+    }
+}
+
+/// The decision [`tsp_leg_kind`] makes, before any connecting happens.
+#[cfg(all(feature = "session", feature = "tsp"))]
+#[derive(Debug, PartialEq, Eq)]
+pub(super) enum TspLegKind {
+    Multiplexed,
+    Separate,
+}
+
+/// Which transport carries a given surface on this client.
+///
+/// A `VtaClient` no longer has *one* transport. TSP carries the Trust-Task
+/// surface only, so a client can legitimately be on DIDComm for protocol
+/// messages and TSP for trust tasks at the same time — an operator-facing
+/// display that renders a single value is therefore wrong by construction. Read
+/// both [`VtaClient::trust_task_transport`] and
+/// [`VtaClient::protocol_message_transport`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SurfaceTransport {
+    /// REST/HTTPS with a bearer token.
+    Rest,
+    /// DIDComm authcrypt via a mediator.
+    Didcomm,
+    /// TSP via a mediator.
+    Tsp,
+}
+
+impl std::fmt::Display for SurfaceTransport {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Rest => write!(f, "REST"),
+            Self::Didcomm => write!(f, "DIDComm"),
+            Self::Tsp => write!(f, "TSP"),
+        }
+    }
 }
 
 /// HTTP/DIDComm client for the VTA service API.
@@ -348,6 +436,8 @@ impl VtaClient {
                 session,
                 rest_client,
                 rest_url: rest_url.map(|u| u.trim_end_matches('/').to_string()),
+                #[cfg(feature = "tsp")]
+                tsp: None,
             },
         })
     }
@@ -398,6 +488,8 @@ impl VtaClient {
                 session,
                 rest_client,
                 rest_url: rest_url.map(|u| u.trim_end_matches('/').to_string()),
+                #[cfg(feature = "tsp")]
+                tsp: None,
             },
         })
     }
@@ -464,6 +556,215 @@ impl VtaClient {
                 rest_url: rest_url.map(|u| u.trim_end_matches('/').to_string()),
             },
         })
+    }
+
+    /// Move the **Trust-Task surface** of this DIDComm client onto TSP, keeping
+    /// the DIDComm leg for everything TSP does not carry.
+    ///
+    /// This is the seam for a consumer that already holds a DIDComm session and
+    /// wants TSP too (#803). Before it existed, the only way to a TSP-capable
+    /// client was [`connect_tsp`](Self::connect_tsp), which opens its **own**
+    /// websocket — and since the mediator permits one websocket per DID, and the
+    /// reference deployment advertises the *same* mediator for `#tsp` and
+    /// `#vta-didcomm`, that second socket is rejected with `duplicate-channel`
+    /// and the two reconnect loops duel.
+    ///
+    /// # What moves, and what does not
+    ///
+    /// - [`dispatch_trust_task`](Self::dispatch_trust_task) and everything built
+    ///   on it (`rpc_tt`, the `device/*` and `vault/*` methods, the generic
+    ///   trust-task escape hatch) routes over TSP.
+    /// - [`rpc`](Self::rpc) / `rpc_void` — the older DIDComm protocol-message
+    ///   surface (`key-management/1.0/*`, `create_did_webvh`, `list_contexts`)
+    ///   — stays on DIDComm **unconditionally**. It has no TSP dispatcher behind
+    ///   it, so moving it would break it; that is why TSP is a per-surface
+    ///   choice and not a client-wide one.
+    ///
+    /// # Cost
+    ///
+    /// **No I/O, and it cannot fail on the transport.** TSP send is an HTTP post
+    /// to the mediator and TSP receive already arrives on the existing socket,
+    /// so there is nothing to connect.
+    ///
+    /// Get `tsp_mediator_did` from
+    /// [`resolve_vta_endpoint`](crate::session::resolve_vta_endpoint) — it reads
+    /// the `#tsp` (`TSPTransport`) service entry, which is **not** assumed to
+    /// match the DIDComm mediator. When it doesn't match, this refuses and names
+    /// [`attach_tsp_leg`](Self::attach_tsp_leg): a different mediator genuinely
+    /// needs its own session, and that one needs key material a `DIDCommSession`
+    /// deliberately does not keep.
+    ///
+    /// Errors with [`VtaError::Validation`] on a non-DIDComm client: a REST
+    /// client has no session to ride, and a [`connect_tsp`](Self::connect_tsp)
+    /// client is already entirely on TSP.
+    #[cfg(all(feature = "session", feature = "tsp"))]
+    pub fn enable_tsp_trust_tasks(&mut self, tsp_mediator_did: &str) -> Result<(), VtaError> {
+        let Transport::DIDComm { session, tsp, .. } = &mut self.transport else {
+            return Err(VtaError::Validation(
+                "enable_tsp_trust_tasks needs a DIDComm client — TSP rides its mediator \
+                 session. Connect with `connect_didcomm` first, or use `connect_tsp` for a \
+                 TSP-only client."
+                    .into(),
+            ));
+        };
+
+        match tsp_leg_kind(session.mediator_did(), tsp_mediator_did) {
+            TspLegKind::Multiplexed => {
+                *tsp = Some(TspLeg::Multiplexed);
+                Ok(())
+            }
+            TspLegKind::Separate => Err(VtaError::Validation(format!(
+                "this VTA advertises its TSP mediator ({tsp_mediator_did}) separately from \
+                 its DIDComm mediator ({}), so TSP cannot ride the DIDComm session — build \
+                 a TspSession against the TSP mediator and pass it to `attach_tsp_leg`, or \
+                 use `connect_didcomm_with_tsp`, which does both.",
+                session.mediator_did()
+            ))),
+        }
+    }
+
+    /// Attach a **separately-connected** TSP session as this DIDComm client's
+    /// Trust-Task leg, for the split-mediator topology where the VTA's `#tsp`
+    /// endpoint names a different mediator from its `#vta-didcomm` one.
+    ///
+    /// The client takes ownership: [`shutdown`](Self::shutdown) closes this
+    /// session along with the DIDComm one.
+    ///
+    /// **Refuses when the two mediators are the same.** A second socket for one
+    /// DID on one mediator is `duplicate-channel` and duelling reconnect loops
+    /// (#803) — the very defect this whole surface exists to prevent — so that
+    /// case is not merely discouraged here, it is unrepresentable. Use
+    /// [`enable_tsp_trust_tasks`](Self::enable_tsp_trust_tasks), which is free.
+    #[cfg(all(feature = "session", feature = "tsp"))]
+    pub fn attach_tsp_leg(
+        &mut self,
+        tsp_session: std::sync::Arc<crate::session::TspSession>,
+        tsp_mediator_did: &str,
+    ) -> Result<(), VtaError> {
+        let Transport::DIDComm { session, tsp, .. } = &mut self.transport else {
+            return Err(VtaError::Validation(
+                "attach_tsp_leg needs a DIDComm client — the TSP leg is the Trust-Task half \
+                 of a two-transport client. Use `connect_tsp` for a TSP-only client."
+                    .into(),
+            ));
+        };
+        if tsp_leg_kind(session.mediator_did(), tsp_mediator_did) == TspLegKind::Multiplexed {
+            return Err(VtaError::Validation(format!(
+                "refusing to attach a second session for {} on mediator {tsp_mediator_did}: \
+                 the mediator permits one websocket per DID, so this would be evicted as \
+                 `duplicate-channel`. This VTA advertises the same mediator for TSP and \
+                 DIDComm — call `enable_tsp_trust_tasks` instead (no second socket needed).",
+                session.client_did()
+            )));
+        }
+        *tsp = Some(TspLeg::Separate {
+            session: tsp_session,
+            mediator_did: tsp_mediator_did.to_string(),
+        });
+        Ok(())
+    }
+
+    /// Connect via DIDComm and put the Trust-Task surface on TSP in one call,
+    /// picking the right leg for the VTA's topology: the DIDComm session's own
+    /// socket when both services name the same mediator, otherwise a TSP session
+    /// against the separate one.
+    ///
+    /// The same [`shutdown`](Self::shutdown) contract applies — and it closes
+    /// both legs.
+    #[cfg(all(feature = "session", feature = "tsp"))]
+    pub async fn connect_didcomm_with_tsp(
+        client_did: &str,
+        private_key_multibase: &str,
+        vta_did: &str,
+        mediator_did: &str,
+        tsp_mediator_did: &str,
+        rest_url: Option<String>,
+    ) -> Result<Self, VtaError> {
+        let mut client = Self::connect_didcomm(
+            client_did,
+            private_key_multibase,
+            vta_did,
+            mediator_did,
+            rest_url,
+        )
+        .await?;
+
+        let attached = match tsp_leg_kind(mediator_did, tsp_mediator_did) {
+            TspLegKind::Multiplexed => client.enable_tsp_trust_tasks(tsp_mediator_did),
+            TspLegKind::Separate => {
+                tracing::debug!(
+                    didcomm_mediator = %mediator_did,
+                    tsp_mediator = %tsp_mediator_did,
+                    "VTA advertises a separate TSP mediator; connecting a TSP session for it"
+                );
+                match crate::session::TspSession::connect(
+                    client_did,
+                    private_key_multibase,
+                    tsp_mediator_did,
+                )
+                .await
+                {
+                    Ok(s) => client.attach_tsp_leg(std::sync::Arc::new(s), tsp_mediator_did),
+                    Err(e) => Err(VtaError::TspTransport(e.to_string())),
+                }
+            }
+        };
+
+        // Shut the DIDComm session down rather than leaking it if the TSP leg
+        // can't be established — this constructor either returns a whole client
+        // or nothing.
+        if let Err(e) = attached {
+            client.shutdown().await;
+            return Err(e);
+        }
+        Ok(client)
+    }
+
+    /// Which transport carries the **Trust-Task** surface
+    /// ([`dispatch_trust_task`](Self::dispatch_trust_task), `rpc_tt`, the
+    /// `device/*` and `vault/*` methods).
+    ///
+    /// Pairs with [`protocol_message_transport`](Self::protocol_message_transport):
+    /// a client can be on TSP for one and DIDComm for the other, so rendering a
+    /// single "transport" for a `VtaClient` is wrong.
+    pub fn trust_task_transport(&self) -> SurfaceTransport {
+        match &self.transport {
+            Transport::Rest { .. } => SurfaceTransport::Rest,
+            #[cfg(feature = "tsp")]
+            Transport::Tsp { .. } => SurfaceTransport::Tsp,
+            #[cfg(feature = "session")]
+            Transport::DIDComm {
+                #[cfg(feature = "tsp")]
+                tsp,
+                ..
+            } => {
+                #[cfg(feature = "tsp")]
+                if tsp.is_some() {
+                    return SurfaceTransport::Tsp;
+                }
+                SurfaceTransport::Didcomm
+            }
+        }
+    }
+
+    /// Which transport carries the older DIDComm **protocol-message** surface
+    /// ([`rpc`](Self::rpc) / `rpc_void` — `key-management/1.0/*`,
+    /// `create_did_webvh`, `list_contexts`, …).
+    ///
+    /// Never TSP: the VTA has no TSP dispatcher for these, so they report
+    /// [`VtaError::UnsupportedTransport`] on a TSP-only client rather than being
+    /// silently routed somewhere that cannot serve them.
+    pub fn protocol_message_transport(&self) -> SurfaceTransport {
+        match &self.transport {
+            Transport::Rest { .. } => SurfaceTransport::Rest,
+            #[cfg(feature = "session")]
+            Transport::DIDComm { .. } => SurfaceTransport::Didcomm,
+            // A TSP-only client cannot serve this surface at all; naming DIDComm
+            // here would claim a leg it does not have, so report TSP and let the
+            // call itself fail with the message that names the fix.
+            #[cfg(feature = "tsp")]
+            Transport::Tsp { .. } => SurfaceTransport::Tsp,
+        }
     }
 
     /// Set the Bearer token for authenticated requests (REST only, no-op for DIDComm).
@@ -566,6 +867,17 @@ impl VtaClient {
     pub async fn shutdown(&self) {
         #[cfg(feature = "session")]
         if let Transport::DIDComm { session, .. } = &self.transport {
+            session.shutdown().await;
+        }
+        // A `Separate` TSP leg owns its own socket, so it leaks exactly like a
+        // DIDComm session would if nothing closed it. `Multiplexed` has nothing
+        // of its own — the DIDComm shutdown above already took its socket down.
+        #[cfg(all(feature = "session", feature = "tsp"))]
+        if let Transport::DIDComm {
+            tsp: Some(TspLeg::Separate { session, .. }),
+            ..
+        } = &self.transport
+        {
             session.shutdown().await;
         }
         // Same one-websocket-per-DID contract as DIDComm: a leaked TSP session
@@ -999,15 +1311,7 @@ impl VtaClient {
                 mediator_did,
                 ..
             } => {
-                // `issuer`/`recipient` are set here and not in the shared `doc`
-                // above because only a mediator transport knows both DIDs; the
-                // REST leg posts to an already-addressed endpoint.
-                let mut doc = doc;
-                doc["issuer"] = serde_json::Value::String(session.client_did().to_string());
-                doc["recipient"] = serde_json::Value::String(vta_did.clone());
-                let body = serde_json::to_vec(&doc)
-                    .map_err(|e| VtaError::Protocol(format!("trust-task encode: {e}")))?;
-
+                let body = Self::address_trust_task(doc, session.client_did(), vta_did)?;
                 let reply = session
                     .request(
                         vta_did,
@@ -1017,13 +1321,46 @@ impl VtaClient {
                     )
                     .await
                     .map_err(|e| VtaError::TspTransport(e.to_string()))?;
-
-                let response_doc: serde_json::Value = serde_json::from_str(&reply)
-                    .map_err(|e| VtaError::Protocol(format!("trust-task reply decode: {e}")))?;
-                Self::extract_trust_task_payload(response_doc)
+                Self::extract_trust_task_payload(Self::decode_trust_task_reply(&reply)?)
             }
             #[cfg(feature = "session")]
-            Transport::DIDComm { session, .. } => {
+            Transport::DIDComm {
+                session,
+                #[cfg(feature = "tsp")]
+                tsp,
+                ..
+            } => {
+                // Per-surface routing: with a TSP leg attached, trust tasks go
+                // over TSP while `rpc` keeps using this same session's DIDComm
+                // leg. The document is byte-identical either way — the VTA's TSP
+                // inbound dispatcher and its DIDComm envelope handler both feed
+                // `dispatch_trust_task_core`.
+                #[cfg(feature = "tsp")]
+                if let Some(leg) = tsp {
+                    let body =
+                        Self::address_trust_task(doc, session.client_did(), &session.vta_did)?;
+                    let timeout = std::time::Duration::from_secs(timeout);
+                    let reply = match leg {
+                        // Rides the DIDComm session's own socket — no second
+                        // websocket for this DID (#803).
+                        TspLeg::Multiplexed => {
+                            session
+                                .request_tsp(&session.vta_did, &body, timeout)
+                                .await?
+                        }
+                        TspLeg::Separate {
+                            session: tsp_session,
+                            mediator_did,
+                        } => tsp_session
+                            .request(&session.vta_did, mediator_did, &body, timeout)
+                            .await
+                            .map_err(|e| VtaError::TspTransport(e.to_string()))?,
+                    };
+                    return Self::extract_trust_task_payload(Self::decode_trust_task_reply(
+                        &reply,
+                    )?);
+                }
+
                 const TRUST_TASK_ENVELOPE_TYPE: &str =
                     "https://trusttasks.org/binding/didcomm/0.1/envelope";
                 let response_doc: serde_json::Value = session
@@ -1037,6 +1374,31 @@ impl VtaClient {
                 Self::extract_trust_task_payload(response_doc)
             }
         }
+    }
+
+    /// Address a trust-task document for a **mediator** transport and serialize
+    /// it.
+    ///
+    /// `issuer`/`recipient` are set here rather than at document construction
+    /// because only a mediator transport knows both DIDs — the REST leg posts to
+    /// an already-addressed endpoint. Shared by every TSP path so the wire shape
+    /// cannot drift between them.
+    #[cfg(feature = "tsp")]
+    fn address_trust_task(
+        mut doc: serde_json::Value,
+        issuer: &str,
+        recipient: &str,
+    ) -> Result<Vec<u8>, VtaError> {
+        doc["issuer"] = serde_json::Value::String(issuer.to_string());
+        doc["recipient"] = serde_json::Value::String(recipient.to_string());
+        serde_json::to_vec(&doc).map_err(|e| VtaError::Protocol(format!("trust-task encode: {e}")))
+    }
+
+    /// Parse a TSP reply frame back into a trust-task response document.
+    #[cfg(feature = "tsp")]
+    fn decode_trust_task_reply(reply: &str) -> Result<serde_json::Value, VtaError> {
+        serde_json::from_str(reply)
+            .map_err(|e| VtaError::Protocol(format!("trust-task reply decode: {e}")))
     }
 
     /// Pull `payload` out of a framework trust-task response document. A success
@@ -1681,5 +2043,50 @@ mod tests {
             VtaError::Protocol(msg) => assert!(msg.contains("not_found"), "got: {msg}"),
             other => panic!("expected Protocol error, got {other:?}"),
         }
+    }
+
+    // ── TSP leg selection (#803) ────────────────────────────────────
+
+    /// The reference topology: a VTA advertising the **same** mediator for
+    /// `#tsp` and `#vta-didcomm`. TSP must ride the DIDComm session's existing
+    /// socket — the mediator permits one websocket per DID, so a second one for
+    /// this DID is `duplicate-channel` and duelling reconnect loops.
+    #[cfg(all(feature = "session", feature = "tsp"))]
+    #[test]
+    fn same_mediator_multiplexes_rather_than_opening_a_second_socket() {
+        let mediator = "did:webvh:QmTS3a:webvh.storm.ws:mediator";
+        assert_eq!(tsp_leg_kind(mediator, mediator), TspLegKind::Multiplexed);
+    }
+
+    /// Split-mediator deployments are legitimate — `Transport::Tsp` explicitly
+    /// does not assume the two are equal — and there a second socket is fine,
+    /// because the one-websocket-per-DID rule is per mediator.
+    #[cfg(all(feature = "session", feature = "tsp"))]
+    #[test]
+    fn a_separate_tsp_mediator_gets_its_own_session() {
+        assert_eq!(
+            tsp_leg_kind(
+                "did:webvh:QmTS3a:webvh.storm.ws:mediator",
+                "did:web:tsp-mediator.example.com",
+            ),
+            TspLegKind::Separate
+        );
+    }
+
+    // ── Per-surface transport reporting ─────────────────────────────
+
+    /// A REST client is on REST for everything — no per-surface split to make.
+    #[test]
+    fn a_rest_client_reports_rest_for_both_surfaces() {
+        let client = VtaClient::new("https://vta.example.com");
+        assert_eq!(client.trust_task_transport(), SurfaceTransport::Rest);
+        assert_eq!(client.protocol_message_transport(), SurfaceTransport::Rest);
+    }
+
+    #[test]
+    fn surface_transport_renders_the_operator_facing_name() {
+        assert_eq!(SurfaceTransport::Tsp.to_string(), "TSP");
+        assert_eq!(SurfaceTransport::Didcomm.to_string(), "DIDComm");
+        assert_eq!(SurfaceTransport::Rest.to_string(), "REST");
     }
 }

--- a/vta-sdk/src/didcomm_session.rs
+++ b/vta-sdk/src/didcomm_session.rs
@@ -63,6 +63,16 @@ pub struct DIDCommSession {
     /// [`receive_next`]: Self::receive_next
     /// [`connect_with_secrets`]: Self::connect_with_secrets
     subscriber: Arc<tokio::sync::Mutex<BoxStream<'static, Inbound>>>,
+    /// The TSP leg riding this same session — see [`TspLeg`]. Always built (it
+    /// costs one extra `subscribe()` receiver) so a `VtaClient` can turn TSP on
+    /// for the Trust-Task surface without reconnecting.
+    #[cfg(feature = "tsp")]
+    tsp: Arc<TspLeg>,
+    /// The mediator this session is connected to. The TSP leg's route is
+    /// `[mediator_did, recipient]`, and a `VtaClient` compares it against the
+    /// VTA's advertised `#tsp` endpoint to decide whether TSP can ride this
+    /// socket or needs its own.
+    pub(crate) mediator_did: String,
     pub(crate) client_did: String,
     pub(crate) vta_did: String,
     /// Set by [`shutdown`](Self::shutdown). Shared across clones so calling
@@ -116,6 +126,68 @@ impl Drop for LeakGuard {
     }
 }
 
+/// The **TSP leg** of a [`DIDCommSession`] — Trust-Task traffic over TSP on the
+/// session's *existing* mediator connection.
+///
+/// # Why this lives on the DIDComm session
+///
+/// The mediator permits **one websocket per DID**. A consumer holding a DIDComm
+/// session cannot also open a [`TspSession`](crate::session::TspSession) on the
+/// same DID against the same mediator — the second socket is rejected with
+/// `duplicate-channel` and the two reconnect loops duel. On the reference
+/// deployment `#tsp` and `#vta-didcomm` resolve to the *same* mediator, so that
+/// is the normal case, not an edge case (#803).
+///
+/// It does not need a second socket, because neither half of TSP needs one here:
+///
+/// - **Send** is an HTTP `POST /inbound` to the mediator
+///   (`TspOps::send_raw`) — no socket at all.
+/// - **Receive** already arrives on the DIDComm socket. The delivery layer's
+///   `DidCommTransport` polls `live_stream_next_frame`, which yields **both**
+///   protocols off the one pickup socket and tags each `Inbound` with
+///   `message.protocol`. A TSP frame carries no DIDComm `thid`, so
+///   `MessagingService` routes it to `subscribe()`.
+///
+/// This mirrors what the VTA itself already does on the server side: it deleted
+/// its standalone TSP websocket for exactly this reason and now demuxes TSP off
+/// its single delivery-layer socket (`vta-service/src/messaging/service.rs`).
+///
+/// The leg takes its **own** `subscribe()` receiver. Subscribers are a
+/// broadcast, so each one sees every unsolicited frame and ignores what isn't
+/// its protocol — the TSP pump cannot eat a DIDComm push, and
+/// [`receive_next`](DIDCommSession::receive_next) cannot eat a TSP reply.
+#[cfg(feature = "tsp")]
+struct TspLeg {
+    /// Kept to reach `atm.tsp()` for the outbound seal + route.
+    atm: Arc<ATM>,
+    /// The profile the TSP keys and mediator endpoint are read from — the same
+    /// one the DIDComm transport is bound to.
+    profile: Arc<ATMProfile>,
+    /// In-flight `request_tsp` waiters + the parking lot for pushes. Shared
+    /// implementation with [`TspSession`](crate::session::TspSession).
+    demux: crate::tsp_demux::TspDemux,
+    /// This leg's own inbound stream. Behind a mutex so whichever task holds it
+    /// pumps on behalf of every waiter (leader/followers).
+    stream: tokio::sync::Mutex<BoxStream<'static, Inbound>>,
+}
+
+/// What one turn at the TSP leg's inbound stream produced.
+#[cfg(feature = "tsp")]
+enum TspPump {
+    /// A frame arrived and went to the request that was waiting for it.
+    Delivered,
+    /// A frame arrived that no in-flight request wanted.
+    Uncorrelated(String),
+    /// The slice elapsed with no TSP frame.
+    Idle,
+}
+
+/// How long one turn at the TSP leg's stream lasts before the holder must
+/// release it, bounding lock hand-off latency between concurrent requests.
+/// Mirrors `session::PUMP_SLICE`.
+#[cfg(feature = "tsp")]
+const TSP_PUMP_SLICE: Duration = Duration::from_millis(250);
+
 impl DIDCommSession {
     /// The session's local DID — the one used as the authcrypt
     /// sender on outbound messages. Surfaced so SDK helpers can
@@ -124,6 +196,17 @@ impl DIDCommSession {
     /// holder, for instance).
     pub fn client_did(&self) -> &str {
         &self.client_did
+    }
+
+    /// The mediator this session's websocket is connected to.
+    ///
+    /// Load-bearing for transport selection, not just diagnostics: because the
+    /// mediator permits **one websocket per DID**, whether TSP can ride this
+    /// session or needs its own connection is decided by comparing this against
+    /// the VTA's advertised `#tsp` endpoint. See
+    /// [`VtaClient::enable_tsp_trust_tasks`](crate::client::VtaClient::enable_tsp_trust_tasks).
+    pub fn mediator_did(&self) -> &str {
+        &self.mediator_did
     }
 
     /// Connect to a VTA via DIDComm through a mediator.
@@ -340,6 +423,18 @@ impl DIDCommSession {
         // would miss anything delivered before it started.
         let subscriber = Arc::new(tokio::sync::Mutex::new(service.subscribe()));
 
+        // The TSP leg rides this same socket — see `TspLeg`. Built here rather
+        // than on demand so enabling TSP for the Trust-Task surface later never
+        // has to reconnect (and so it can never be tempted to open a second
+        // socket for this DID). Its cost is one more broadcast receiver.
+        #[cfg(feature = "tsp")]
+        let tsp = Arc::new(TspLeg {
+            atm: Arc::clone(atm),
+            profile: Arc::clone(&profile),
+            demux: crate::tsp_demux::TspDemux::new(),
+            stream: tokio::sync::Mutex::new(service.subscribe()),
+        });
+
         debug!("DIDComm session connected via mediator {mediator_did} (delivery-layer mode)");
 
         let shutdown = Arc::new(AtomicBool::new(false));
@@ -352,6 +447,9 @@ impl DIDCommSession {
             service,
             atm: Arc::clone(atm),
             subscriber,
+            #[cfg(feature = "tsp")]
+            tsp,
+            mediator_did: mediator_did.to_string(),
             client_did: client_did.to_string(),
             vta_did: vta_did.to_string(),
             shutdown,
@@ -570,42 +668,63 @@ impl DIDCommSession {
         // reply to its `request` waiter, so this stream carries only unsolicited
         // inbound. The lock serialises concurrent `receive_next` calls on the
         // same session (each message goes to exactly one caller).
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(timeout_secs);
         let mut stream = self.subscriber.lock().await;
-        match tokio::time::timeout(Duration::from_secs(timeout_secs), stream.next()).await {
-            Ok(Some(inbound)) => {
-                // `payload` is the full plaintext DIDComm `Message` JSON;
-                // re-serialise it to preserve the `{ id, type, body, from, … }`
-                // shape callers (`InboundMessage::parse`) expect.
-                let msg: Message =
-                    serde_json::from_slice(&inbound.message.payload).map_err(VtaError::from)?;
-                debug!(msg_type = %msg.typ, "received inbound DIDComm message");
-                let json = serde_json::to_string(&msg).map_err(VtaError::from)?;
-                Ok(Some(json))
+        loop {
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            if remaining.is_zero() {
+                return Ok(None);
             }
-            // Stream ended — nothing more will EVER arrive on this session.
-            //
-            // Distinguish the two ways that happens, because they need opposite
-            // reactions from the caller:
-            //   * we called `shutdown()` — expected teardown, report idle;
-            //   * anything else (mediator dropped us, delivery layer died) — the
-            //     session is dead and must be rebuilt.
-            //
-            // Reporting the second as `Ok(None)` made a dead session look like a
-            // quiet one: a polling loop would treat "stream ended" as "nothing
-            // yet", call again, get the same answer instantly, and spin at full
-            // tilt forever without reconnecting. `Err` is what makes the
-            // supervisor reconnect instead.
-            Ok(None) => {
-                if self.shutdown.load(Ordering::Acquire) {
-                    Ok(None)
-                } else {
-                    Err(VtaError::DidcommTransport(
-                        "mediator inbound stream ended — session is no longer live".into(),
-                    ))
+            match tokio::time::timeout(remaining, stream.next()).await {
+                Ok(Some(inbound)) => {
+                    // The mediator multiplexes DIDComm and TSP onto one socket, so
+                    // this stream carries both. A TSP frame's payload is a bare
+                    // Trust-Task document, NOT a DIDComm `Message` — parsing it as
+                    // one is a hard error, which would turn an inbound TSP frame
+                    // into a failure of the DIDComm inbox that received it. Skip it
+                    // here; the TSP leg has its own subscriber and its own copy of
+                    // this frame (see `TspLeg`), so nothing is lost.
+                    #[cfg(feature = "tsp")]
+                    if inbound.message.protocol == affinidi_messaging_core::Protocol::TSP {
+                        debug!(
+                            "skipping an inbound TSP frame on the DIDComm inbox (the TSP leg has it)"
+                        );
+                        continue;
+                    }
+                    // `payload` is the full plaintext DIDComm `Message` JSON;
+                    // re-serialise it to preserve the `{ id, type, body, from, … }`
+                    // shape callers (`InboundMessage::parse`) expect.
+                    let msg: Message =
+                        serde_json::from_slice(&inbound.message.payload).map_err(VtaError::from)?;
+                    debug!(msg_type = %msg.typ, "received inbound DIDComm message");
+                    let json = serde_json::to_string(&msg).map_err(VtaError::from)?;
+                    return Ok(Some(json));
                 }
+                // Stream ended — nothing more will EVER arrive on this session.
+                //
+                // Distinguish the two ways that happens, because they need opposite
+                // reactions from the caller:
+                //   * we called `shutdown()` — expected teardown, report idle;
+                //   * anything else (mediator dropped us, delivery layer died) — the
+                //     session is dead and must be rebuilt.
+                //
+                // Reporting the second as `Ok(None)` made a dead session look like a
+                // quiet one: a polling loop would treat "stream ended" as "nothing
+                // yet", call again, get the same answer instantly, and spin at full
+                // tilt forever without reconnecting. `Err` is what makes the
+                // supervisor reconnect instead.
+                Ok(None) => {
+                    return if self.shutdown.load(Ordering::Acquire) {
+                        Ok(None)
+                    } else {
+                        Err(VtaError::DidcommTransport(
+                            "mediator inbound stream ended — session is no longer live".into(),
+                        ))
+                    };
+                }
+                // Poll window elapsed with nothing — the ordinary idle case.
+                Err(_) => return Ok(None),
             }
-            // Poll window elapsed with nothing — the ordinary idle case.
-            Err(_) => Ok(None),
         }
     }
 
@@ -615,7 +734,252 @@ impl DIDCommSession {
     /// connection. Idempotent and safe to call on any clone.
     pub async fn shutdown(&self) {
         self.shutdown.store(true, Ordering::Release);
+        // Drop every TSP waiter first so an in-flight `request_tsp` fails fast
+        // with "session shut down" rather than blocking until its own deadline
+        // on a connection that is about to disappear.
+        #[cfg(feature = "tsp")]
+        self.tsp.demux.clear().await;
         self.atm.graceful_shutdown().await;
+    }
+}
+
+// ── TSP leg ─────────────────────────────────────────────────────────
+//
+// Trust-Task traffic over TSP on this session's existing mediator connection.
+// See `TspLeg` for why it is here and not in a session of its own.
+
+#[cfg(feature = "tsp")]
+impl DIDCommSession {
+    /// Send an already-built Trust-Task document to `recipient_did` over TSP,
+    /// routed through this session's mediator. Fire-and-forget: any reply
+    /// arrives on [`receive_next_tsp`](Self::receive_next_tsp) (or is
+    /// correlated by [`request_tsp`](Self::request_tsp) if one is waiting).
+    ///
+    /// `body` is the serialized document itself — TSP carries the Trust-Task
+    /// bytes directly, with no DIDComm envelope around them (the VTA's
+    /// `tsp_inbound::dispatch_one` hands the payload straight to
+    /// `dispatch_trust_task_core`).
+    ///
+    /// **Opens no socket.** The send is an HTTP `POST /inbound` to the mediator,
+    /// so it never touches the websocket and is safe to call while a
+    /// `receive_next` / `receive_next_tsp` is blocked.
+    ///
+    /// The sender is proven by TSP itself, so the VTA derives authorization from
+    /// the sealed `sender_vid` (intrinsic-sender auth) — no bearer token and no
+    /// holder proof in the document.
+    pub async fn send_tsp_document(
+        &self,
+        recipient_did: &str,
+        body: &[u8],
+    ) -> Result<(), VtaError> {
+        self.tsp
+            .atm
+            .tsp()
+            .send_routed(
+                &self.tsp.profile,
+                &[self.mediator_did.clone(), recipient_did.to_string()],
+                body,
+            )
+            .await
+            .map_err(|e| VtaError::TspTransport(format!("TSP send failed: {e}")))
+    }
+
+    /// Send `document` to `recipient_did` over TSP and wait for **its** reply.
+    ///
+    /// The TSP counterpart of [`send_and_wait`](Self::send_and_wait), with the
+    /// same properties as [`TspSession::request`](crate::session::TspSession::request):
+    ///
+    /// - **Correlated, never "first frame that parses".** Replies are matched by
+    ///   `crate::tsp_demux::correlates` — `threadId`, falling back to an echoed
+    ///   `nonce`. The mediator inbox is durable and flushes on connect, so an
+    ///   uncorrelated read can hand back a reply from a *previous process run*.
+    /// - **Concurrent.** Several requests may be in flight; whichever holds the
+    ///   stream pumps for all of them.
+    /// - **Pushes survive.** A frame matching no in-flight request is parked for
+    ///   [`receive_next_tsp`](Self::receive_next_tsp), not discarded.
+    /// - **Finite.** Every wait is bounded by `timeout` (R1.2).
+    ///
+    /// Errors are `String`-flattened internally on purpose: a `Box<dyn Error>`
+    /// is not `Send`, and one held across an await would make this future — and
+    /// every caller of it, up to `VtaClient::dispatch_trust_task` — `!Send`.
+    pub async fn request_tsp(
+        &self,
+        recipient_did: &str,
+        document: &[u8],
+        timeout: Duration,
+    ) -> Result<String, VtaError> {
+        let (request_id, nonce) =
+            crate::tsp_demux::TspDemux::request_keys(document).map_err(VtaError::TspTransport)?;
+        let mut rx = self.tsp.demux.register(request_id.clone(), nonce).await;
+
+        // Registered *before* sending: a reply can land while the send is still
+        // returning, and a waiter registered afterwards would miss it.
+        let sent = self.send_tsp_document(recipient_did, document).await;
+        if sent.is_err() {
+            self.tsp.demux.deregister(&request_id).await;
+        }
+        sent?;
+
+        let deadline = tokio::time::Instant::now() + timeout;
+        let outcome = self.await_tsp_reply(&request_id, &mut rx, deadline).await;
+        // Always deregister — a timed-out or failed request must not leave a
+        // waiter behind for the pump to deliver into.
+        self.tsp.demux.deregister(&request_id).await;
+        outcome.map_err(VtaError::TspTransport)
+    }
+
+    /// Wait up to `timeout_secs` for the next **unsolicited** inbound TSP
+    /// document — a VTA-pushed `task-consent/request` and the like — returning
+    /// the unpacked Trust-Task document as a JSON string.
+    ///
+    /// The TSP counterpart of [`receive_next`](Self::receive_next). Same three
+    /// outcomes, and the same reason they are distinct: `Ok(Some(doc))` is an
+    /// application message, `Ok(None)` is idle (poll again), and `Err(_)` means
+    /// the connection is gone (reconnect — polling again cannot help).
+    pub async fn receive_next_tsp(&self, timeout_secs: u64) -> Result<Option<String>, VtaError> {
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(timeout_secs);
+        loop {
+            // A frame an in-flight `request_tsp` read but did not want is ours.
+            // Drain that before touching the stream, or a push that already
+            // arrived would sit unseen behind a fresh read.
+            if let Some(doc) = self.tsp.demux.take_parked().await {
+                return Ok(Some(doc));
+            }
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            if remaining.is_zero() {
+                return Ok(None);
+            }
+
+            let mut guard = self.tsp.stream.lock().await;
+            // Bounded so the lock is released periodically even while idle —
+            // otherwise a long-polling receive would hold it for its whole
+            // budget and stall every concurrent `request_tsp`.
+            let slice = TSP_PUMP_SLICE.min(remaining);
+            let outcome = self
+                .tsp_pump_once(&mut guard, slice)
+                .await
+                .map_err(VtaError::TspTransport)?;
+            match outcome {
+                // Not addressed to any in-flight request → it is a push, and
+                // pushes are what this method is for.
+                TspPump::Uncorrelated(doc) => return Ok(Some(doc)),
+                TspPump::Delivered | TspPump::Idle => {
+                    drop(guard);
+                    continue;
+                }
+            }
+        }
+    }
+
+    /// Wait for `request_id`'s reply, taking a turn at pumping the stream
+    /// whenever it is free.
+    ///
+    /// Leader/followers, exactly as in
+    /// [`TspSession::await_reply`](crate::session::TspSession): whoever holds
+    /// the stream reads and demultiplexes for everyone; the rest park on their
+    /// oneshot. Contending for the lock in the same `select!` as the oneshot is
+    /// what lets a follower take over the moment the leader finishes.
+    async fn await_tsp_reply(
+        &self,
+        request_id: &str,
+        rx: &mut tokio::sync::oneshot::Receiver<String>,
+        deadline: tokio::time::Instant,
+    ) -> Result<String, String> {
+        loop {
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            if remaining.is_zero() {
+                return Err(format!(
+                    "timed out waiting for the TSP reply to request '{request_id}'"
+                ));
+            }
+
+            tokio::select! {
+                biased;
+
+                // Someone else's pump already delivered our reply.
+                delivered = &mut *rx => {
+                    return delivered.map_err(|_| {
+                        "TSP session shut down while waiting for a reply".to_string()
+                    });
+                }
+
+                // We are the leader for as long as we hold this.
+                mut guard = self.tsp.stream.lock() => {
+                    let slice = TSP_PUMP_SLICE.min(remaining);
+                    // Bound before the `match`: a scrutinee temporary lives for
+                    // the whole match body, which contains an `.await`.
+                    let outcome = self.tsp_pump_once(&mut guard, slice).await?;
+                    match outcome {
+                        TspPump::Uncorrelated(doc) => {
+                            // Not ours and not any other waiter's — park it for
+                            // the push consumer instead of dropping it.
+                            self.tsp.demux.park(doc).await;
+                        }
+                        TspPump::Delivered | TspPump::Idle => {}
+                    }
+                    // Release before looping so a follower can take a turn.
+                    drop(guard);
+                }
+
+                () = tokio::time::sleep(remaining) => {
+                    return Err(format!(
+                        "timed out waiting for the TSP reply to request '{request_id}'"
+                    ));
+                }
+            }
+        }
+    }
+
+    /// Read at most one TSP frame off the leg's stream within `slice` and route
+    /// it: to the waiter it correlates with, or back to the caller as
+    /// [`TspPump::Uncorrelated`].
+    ///
+    /// DIDComm frames on this stream are **skipped, not consumed from anyone** —
+    /// this is the leg's own broadcast receiver, so
+    /// [`receive_next`](Self::receive_next) still has its own copy of every one
+    /// of them.
+    ///
+    /// `String` errors for the same `Send` reason as
+    /// [`request_tsp`](Self::request_tsp).
+    async fn tsp_pump_once(
+        &self,
+        stream: &mut BoxStream<'static, Inbound>,
+        slice: Duration,
+    ) -> Result<TspPump, String> {
+        let until = tokio::time::Instant::now() + slice;
+        loop {
+            let remaining = until.saturating_duration_since(tokio::time::Instant::now());
+            if remaining.is_zero() {
+                return Ok(TspPump::Idle);
+            }
+            let inbound = match tokio::time::timeout(remaining, stream.next()).await {
+                Ok(Some(inbound)) => inbound,
+                // Stream ended is an ERROR, not "nothing arrived" — asking again
+                // can never produce anything. Same reasoning as `receive_next`:
+                // conflating them makes a dead session look like a quiet one and
+                // a polling loop spins forever instead of reconnecting.
+                Ok(None) => {
+                    return Err(if self.shutdown.load(Ordering::Acquire) {
+                        "TSP leg closed: the session was shut down".to_string()
+                    } else {
+                        "mediator inbound stream ended — session is no longer live".to_string()
+                    });
+                }
+                Err(_) => return Ok(TspPump::Idle),
+            };
+
+            if inbound.message.protocol != affinidi_messaging_core::Protocol::TSP {
+                continue; // a DIDComm frame — `receive_next`'s business, not ours
+            }
+            let json = String::from_utf8(inbound.message.payload)
+                .map_err(|e| format!("TSP payload was not UTF-8: {e}"))?;
+
+            // One correlation rule for every TSP session — see `tsp_demux`.
+            return Ok(match self.tsp.demux.route(json).await {
+                crate::tsp_demux::Routed::Delivered => TspPump::Delivered,
+                crate::tsp_demux::Routed::Uncorrelated(doc) => TspPump::Uncorrelated(doc),
+            });
+        }
     }
 }
 
@@ -658,5 +1022,30 @@ mod tests {
             // Release builds compile out debug_assert; satisfy #[should_panic].
             panic!("dropped without shutdown() (release no-op shim)");
         }
+    }
+}
+
+/// Every TSP-leg future must be `Send`, for the same reason
+/// `session::tsp_send_assertions` exists: `VtaClient::dispatch_trust_task`
+/// awaits `request_tsp`, and `vta-mcp` puts that future behind `#[tool]`, which
+/// demands `Send`. One `Box<dyn Error>` (not `Send`) held across an `.await`
+/// inside the leg is enough to break the whole chain — and only once feature
+/// unification turns `tsp` on for a workspace build, a long way from the edit
+/// that caused it.
+///
+/// A compile-time check: if these stop being `Send`, this module fails to build.
+#[cfg(all(test, feature = "tsp"))]
+mod tsp_leg_send_assertions {
+    use std::time::Duration;
+
+    fn assert_send<T: Send>(_: T) {}
+
+    #[allow(dead_code)]
+    fn tsp_leg_futures_are_send(s: &super::DIDCommSession) {
+        assert_send(s.request_tsp("did:vta", b"{}", Duration::from_secs(1)));
+        assert_send(s.receive_next_tsp(1));
+        assert_send(s.send_tsp_document("did:vta", b"{}"));
+        assert_send(s.receive_next(1));
+        assert_send(s.shutdown());
     }
 }

--- a/vta-sdk/src/lib.rs
+++ b/vta-sdk/src/lib.rs
@@ -147,6 +147,10 @@ pub mod session;
 /// Canonical Trust-Task URLs for VTA operations. Mirrors
 /// `did-hosting-common::did_hosting_tasks` for the webvh-service side.
 pub mod trust_tasks;
+// Reply correlation for TSP, shared by `TspSession` and the `DIDCommSession`
+// TSP leg. Internal: consumers see the sessions, not the bookkeeping.
+#[cfg(all(feature = "session", feature = "tsp"))]
+mod tsp_demux;
 // DCQL credential selection + holder-bound OID4VP `vp_token` assembly. The
 // client-side counterpart to the `join-requests` / `credential-exchange`
 // protocol types: turns a verifier's `presentation_definition` + held

--- a/vta-sdk/src/session.rs
+++ b/vta-sdk/src/session.rs
@@ -651,9 +651,15 @@ impl SessionStore {
     /// `Auto` preferring TSP would convert today's working DIDComm story into
     /// an indefinite hang with no output.
     ///
-    /// [`TransportChoice::Tsp`] forces TSP: errors if the VTA advertises no
-    /// `#tsp` service (naming what it *does* advertise), and errors rather than
-    /// falling back if the connect times out.
+    /// Against a VTA advertising **both** TSP and DIDComm, `Auto` returns a
+    /// **dual** client: trust tasks over TSP, protocol messages over DIDComm,
+    /// on one mediator socket. TSP carries the Trust-Task surface only, so
+    /// there is no single client-wide transport choice that is correct.
+    ///
+    /// [`TransportChoice::Tsp`] forces a TSP-*only* client: errors if the VTA
+    /// advertises no `#tsp` service (naming what it *does* advertise), and
+    /// errors rather than falling back if the connect times out. Protocol-
+    /// message operations are unavailable on it by construction.
     ///
     /// [`TransportChoice::Didcomm`] forces DIDComm, ignoring an advertised
     /// `#tsp` — the recovery path when TSP is broken but the DIDComm mediator
@@ -748,6 +754,75 @@ impl SessionStore {
                     )
                     .await?;
                     return Ok(client);
+                }
+
+                // Both transports advertised, and the operator did not force
+                // one: build a **dual** client — DIDComm for the protocol-
+                // message surface, TSP for the Trust-Task surface.
+                //
+                // Not "TSP instead of DIDComm". TSP carries Trust Tasks only;
+                // the VTA has no TSP dispatcher behind `key-management/1.0/*`,
+                // `create_did_webvh`, `list_contexts` and friends. Returning a
+                // TSP-only client here — which is what this arm used to do —
+                // therefore broke every one of those operations with
+                // `UnsupportedTransport` the moment a VTA started advertising
+                // `#tsp`. TSP is selected per surface, not per client.
+                if let Some(didcomm) = didcomm_mediator_did.clone()
+                    && transport != TransportChoice::Tsp
+                {
+                    match connect_didcomm_bounded(
+                        &session.client_did,
+                        &session.private_key,
+                        &vta_did,
+                        &didcomm,
+                        rest_url.clone(),
+                    )
+                    .await
+                    {
+                        Ok(mut client) => {
+                            match attach_tsp_leg_bounded(
+                                &mut client,
+                                &session.client_did,
+                                &session.private_key,
+                                &didcomm,
+                                &mediator_did,
+                            )
+                            .await
+                            {
+                                Ok(()) => debug!(
+                                    tsp_mediator_did = %mediator_did,
+                                    "connected via DIDComm with trust tasks over TSP"
+                                ),
+                                // `Auto` falls back, but never quietly: a TSP
+                                // deployment that never works must not look like
+                                // one that was never enabled. See
+                                // `TransportChoice`.
+                                Err(e) => warn!(
+                                    vta_did = %vta_did,
+                                    tsp_mediator_did = %mediator_did,
+                                    error = %e,
+                                    "TSP is advertised but its leg could not be established; \
+                                     trust tasks stay on DIDComm (use --transport tsp to make \
+                                     this fatal, or --transport didcomm to stop trying TSP)"
+                                ),
+                            }
+                            return Ok(client);
+                        }
+                        Err(e) => {
+                            // DIDComm is down but TSP may not be. Drop to the
+                            // TSP-only client below rather than failing outright
+                            // — loudly, because that client cannot serve the
+                            // protocol-message surface at all.
+                            warn!(
+                                vta_did = %vta_did,
+                                didcomm_mediator_did = %didcomm,
+                                error = %e,
+                                "the DIDComm mediator did not answer; falling back to a \
+                                 TSP-only client — key management, context and DID-minting \
+                                 operations will report UnsupportedTransport"
+                            );
+                        }
+                    }
                 }
 
                 match connect_tsp_bounded(
@@ -1308,11 +1383,29 @@ pub enum VtaEndpoint {
 #[non_exhaustive]
 pub enum TransportChoice {
     /// TSP when advertised, else DIDComm, else REST. The default.
+    ///
+    /// **TSP is selected per surface, not per client.** Against a VTA
+    /// advertising both `#tsp` and `#vta-didcomm`, `Auto` returns a client whose
+    /// Trust-Task surface is on TSP and whose protocol-message surface
+    /// (`key-management/1.0/*`, `create_did_webvh`, `list_contexts`) is on
+    /// DIDComm — both legs live, one websocket. TSP carries Trust Tasks only, so
+    /// a TSP-*only* client would break every one of those operations; that is
+    /// what this used to return, and why it no longer does. See
+    /// [`VtaClient::trust_task_transport`](crate::client::VtaClient::trust_task_transport).
+    ///
+    /// A VTA advertising `#tsp` alone still yields a TSP-only client — there is
+    /// no DIDComm leg to have.
     #[default]
     Auto,
-    /// Force TSP. Errors — naming the transports the VTA *does* advertise — if
-    /// it advertises no `#tsp` service, and errors rather than falling back if
-    /// the TSP connect times out.
+    /// Force TSP — a **TSP-only** client, for exercising TSP on its own. Errors
+    /// — naming the transports the VTA *does* advertise — if it advertises no
+    /// `#tsp` service, and errors rather than falling back if the TSP connect
+    /// times out.
+    ///
+    /// Because it is TSP-only, protocol-message operations report
+    /// [`VtaError::UnsupportedTransport`](crate::error::VtaError::UnsupportedTransport)
+    /// naming `--transport didcomm`. Use [`Auto`](Self::Auto) for a client that
+    /// serves both surfaces.
     Tsp,
     /// Force DIDComm, ignoring an advertised `#tsp`. The recovery path when a
     /// VTA's TSP endpoint is broken but its DIDComm mediator is healthy;
@@ -1477,6 +1570,54 @@ async fn connect_tsp_bounded(
             Ok(result) => Ok(result?),
             Err(_) => Err(tsp_unreachable_error(mediator_did, timeout).into()),
         }
+    }
+}
+
+/// Put `client`'s Trust-Task surface on TSP, bounding any connect it needs.
+///
+/// The common case does no I/O at all: when the VTA advertises the **same**
+/// mediator for `#tsp` and `#vta-didcomm` — the reference topology — TSP rides
+/// the DIDComm session's existing socket, because the mediator permits one
+/// websocket per DID (#803). Only a VTA advertising a *separate* TSP mediator
+/// needs a connection, and there two mediators mean two sockets are legitimate.
+///
+/// A failure here is not fatal to the caller: `Auto` keeps the DIDComm client
+/// and reports the loss loudly. See [`TransportChoice`].
+#[cfg_attr(not(feature = "tsp"), allow(unused_variables))]
+async fn attach_tsp_leg_bounded(
+    client: &mut crate::client::VtaClient,
+    client_did: &str,
+    private_key: &str,
+    didcomm_mediator_did: &str,
+    tsp_mediator_did: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    #[cfg(not(feature = "tsp"))]
+    {
+        Err(format!(
+            "the VTA advertises TSP (`{tsp_mediator_did}`), but this build was compiled \
+             without the `tsp` feature. Rebuild with `--features tsp` to route trust tasks \
+             over it."
+        )
+        .into())
+    }
+    #[cfg(feature = "tsp")]
+    {
+        if didcomm_mediator_did == tsp_mediator_did {
+            client.enable_tsp_trust_tasks(tsp_mediator_did)?;
+            return Ok(());
+        }
+        let timeout = tsp_connect_timeout();
+        let tsp_session = match tokio::time::timeout(
+            timeout,
+            TspSession::connect(client_did, private_key, tsp_mediator_did),
+        )
+        .await
+        {
+            Ok(result) => result?,
+            Err(_) => return Err(tsp_unreachable_error(tsp_mediator_did, timeout).into()),
+        };
+        client.attach_tsp_leg(std::sync::Arc::new(tsp_session), tsp_mediator_did)?;
+        Ok(())
     }
 }
 
@@ -2094,7 +2235,7 @@ impl TspPingSession {
                 continue; // not a Trust-Task document
             };
 
-            if correlates(&doc, &id, Some(&nonce)) {
+            if crate::tsp_demux::correlates(&doc, &id, Some(&nonce)) {
                 return Ok(start.elapsed().as_millis());
             }
             tracing::debug!(
@@ -2171,58 +2312,14 @@ pub struct TspSession {
     ws: tokio::sync::Mutex<Option<affinidi_tdk::messaging::TspWebSocket>>,
     /// This client's DID — the `issuer` on an [`announce`](Self::announce) frame.
     client_did: String,
-    /// In-flight [`request`](Self::request) waiters, keyed by request document
-    /// `id`. Whichever task currently holds `ws` reads frames on behalf of
-    /// *all* of them and hands each reply to its own waiter.
-    pending: tokio::sync::Mutex<std::collections::HashMap<String, PendingRequest>>,
-    /// Inbound documents that matched no in-flight request — VTA-pushed
-    /// `task-consent/request`s and the like. Parked here rather than dropped,
-    /// so a request waiting on an unrelated reply cannot eat a push.
-    parked: tokio::sync::Mutex<std::collections::VecDeque<String>>,
-}
-
-/// One in-flight [`TspSession::request`]: how to recognise its reply, and where
-/// to deliver it.
-#[cfg(feature = "tsp")]
-struct PendingRequest {
-    /// Echoed-`nonce` fallback for a responder that replies with a fresh
-    /// document instead of a threaded `#response`.
-    nonce: Option<String>,
-    tx: tokio::sync::oneshot::Sender<String>,
-}
-
-/// Does `doc` correlate to the request identified by `request_id` (and
-/// optionally `nonce`)?
-///
-/// The single implementation of "is this frame the reply to that request",
-/// shared by [`TspPingSession::ping`] and [`TspSession::request`]. It was
-/// written for the ping path and welded there; every other caller would
-/// otherwise have re-derived `threadId` matching from the raw inner document.
-///
-/// Correlation is the Trust-Task `threadId`, which a responder sets to the
-/// request's `id` (`doc.respond_with`). The echoed `payload.nonce` is accepted
-/// as a fallback for a responder that replies with a fresh document rather than
-/// a threaded `#response`.
-///
-/// **Why this cannot be "the first frame that parses".** The client's mediator
-/// inbox is durable and flushes on connect, so every reply a previous process
-/// run never collected is queued and lands the moment we reconnect. Accepting
-/// the first frame therefore returns a *stale* reply — which is the exact fault
-/// that made the #749 delivery bug look intermittent.
-#[cfg(feature = "tsp")]
-fn correlates(doc: &serde_json::Value, request_id: &str, nonce: Option<&str>) -> bool {
-    if doc.get("threadId").and_then(|v| v.as_str()) == Some(request_id) {
-        return true;
-    }
-    match nonce {
-        Some(n) => {
-            doc.get("payload")
-                .and_then(|p| p.get("nonce"))
-                .and_then(|v| v.as_str())
-                == Some(n)
-        }
-        None => false,
-    }
+    /// In-flight [`request`](Self::request) waiters plus the parking lot for
+    /// frames none of them wanted. Whichever task currently holds `ws` reads
+    /// frames on behalf of *all* of them and hands each reply to its own
+    /// waiter. Shared with the [`DIDCommSession`] TSP leg so there is one
+    /// implementation of the correlation rule.
+    ///
+    /// [`DIDCommSession`]: crate::didcomm_session::DIDCommSession
+    demux: crate::tsp_demux::TspDemux,
 }
 
 #[cfg(feature = "tsp")]
@@ -2268,8 +2365,7 @@ impl TspSession {
             profile,
             ws: tokio::sync::Mutex::new(Some(ws)),
             client_did: client_did.to_string(),
-            pending: tokio::sync::Mutex::new(std::collections::HashMap::new()),
-            parked: tokio::sync::Mutex::new(std::collections::VecDeque::new()),
+            demux: crate::tsp_demux::TspDemux::new(),
         })
     }
 
@@ -2383,7 +2479,7 @@ impl TspSession {
             // A frame an in-flight `request` read off the socket but did not
             // want is ours. Drain that before touching the socket, or a push
             // that already arrived would sit unseen behind a fresh read.
-            if let Some(doc) = self.parked.lock().await.pop_front() {
+            if let Some(doc) = self.demux.take_parked().await {
                 return Ok(Some(doc));
             }
             if Instant::now() >= deadline {
@@ -2456,27 +2552,8 @@ impl TspSession {
     ) -> Result<String, Box<dyn std::error::Error>> {
         use std::time::Instant;
 
-        let parsed: serde_json::Value = serde_json::from_slice(document)
-            .map_err(|e| format!("TSP request document is not JSON: {e}"))?;
-        let request_id = parsed
-            .get("id")
-            .and_then(|v| v.as_str())
-            .ok_or("TSP request document has no `id` to correlate its reply on")?
-            .to_string();
-        let nonce = parsed
-            .get("payload")
-            .and_then(|p| p.get("nonce"))
-            .and_then(|v| v.as_str())
-            .map(str::to_string);
-
-        let (tx, mut rx) = tokio::sync::oneshot::channel();
-        self.pending.lock().await.insert(
-            request_id.clone(),
-            PendingRequest {
-                nonce: nonce.clone(),
-                tx,
-            },
-        );
+        let (request_id, nonce) = crate::tsp_demux::TspDemux::request_keys(document)?;
+        let mut rx = self.demux.register(request_id.clone(), nonce).await;
 
         // Registered *before* sending: a reply can land while `send_routed` is
         // still returning, and a waiter registered afterwards would miss it.
@@ -2494,7 +2571,7 @@ impl TspSession {
             .await
             .map_err(|e| e.to_string());
         if sent.is_err() {
-            self.pending.lock().await.remove(&request_id);
+            self.demux.deregister(&request_id).await;
         }
         sent?;
 
@@ -2505,7 +2582,7 @@ impl TspSession {
             .map_err(|e| e.to_string());
         // Always deregister — a timed-out or failed request must not leave a
         // waiter behind for the pump to deliver into.
-        self.pending.lock().await.remove(&request_id);
+        self.demux.deregister(&request_id).await;
         Ok(outcome?)
     }
 
@@ -2561,7 +2638,7 @@ impl TspSession {
                         PumpOutcome::Uncorrelated(doc) => {
                             // Not ours and not any other waiter's — park it for
                             // the push consumer instead of dropping it.
-                            self.parked.lock().await.push_back(doc);
+                            self.demux.park(doc).await;
                         }
                         PumpOutcome::Delivered | PumpOutcome::Idle => {}
                     }
@@ -2624,39 +2701,11 @@ impl TspSession {
             let json = String::from_utf8(payload)
                 .map_err(|e| format!("TSP payload was not UTF-8: {e}"))?;
 
-            let Ok(doc) = serde_json::from_str::<serde_json::Value>(&json) else {
-                // Not a Trust-Task document, so it can correlate with nothing.
-                // Hand it up rather than drop it — the push consumer decides.
-                return Ok(PumpOutcome::Uncorrelated(json));
-            };
-
-            let mut pending = self.pending.lock().await;
-            let hit = pending
-                .iter()
-                .find(|(id, p)| correlates(&doc, id, p.nonce.as_deref()))
-                .map(|(id, _)| id.clone());
-            match hit {
-                Some(id) => {
-                    if let Some(p) = pending.remove(&id) {
-                        // A dropped receiver (the requester timed out and left)
-                        // is not an error — the frame is simply no longer
-                        // wanted by anyone.
-                        let _ = p.tx.send(json);
-                    }
-                    return Ok(PumpOutcome::Delivered);
-                }
-                None => {
-                    drop(pending);
-                    debug!(
-                        thread_id = doc
-                            .get("threadId")
-                            .and_then(|v| v.as_str())
-                            .unwrap_or("<none>"),
-                        "TSP frame matched no in-flight request (push, or a stale inbox entry)"
-                    );
-                    return Ok(PumpOutcome::Uncorrelated(json));
-                }
-            }
+            // One correlation rule for every TSP session — see `tsp_demux`.
+            return Ok(match self.demux.route(json).await {
+                crate::tsp_demux::Routed::Delivered => PumpOutcome::Delivered,
+                crate::tsp_demux::Routed::Uncorrelated(doc) => PumpOutcome::Uncorrelated(doc),
+            });
         }
     }
 
@@ -2666,7 +2715,7 @@ impl TspSession {
         // Drop every waiter first so an in-flight `request` fails fast with
         // "session shut down" instead of blocking until its own deadline on a
         // socket that is about to disappear.
-        self.pending.lock().await.clear();
+        self.demux.clear().await;
         if let Some(ws) = self.ws.lock().await.take() {
             let _ = ws.close().await;
         }
@@ -3049,75 +3098,8 @@ mod tests {
         assert!(neither.contains("no other transport"));
     }
 
-    // ── TSP reply correlation ─────────────────────────────────────
-
-    /// The property that makes TSP request/response safe: a frame that is not
-    /// *this* request's reply must not be accepted as one.
-    ///
-    /// The mediator inbox is durable and flushes on connect, so every reply a
-    /// previous process run never collected lands the moment we reconnect.
-    /// "First frame that parses" would therefore return a stale reply — the
-    /// exact fault that made the #749 delivery bug look intermittent.
-    #[cfg(feature = "tsp")]
-    #[test]
-    fn a_stale_frame_is_not_mistaken_for_our_reply() {
-        let stale = serde_json::json!({
-            "id": "urn:uuid:reply-to-something-else",
-            "threadId": "urn:uuid:a-previous-run",
-            "payload": { "nonce": "some-other-nonce" },
-        });
-        assert!(!correlates(
-            &stale,
-            "urn:uuid:our-request",
-            Some("our-nonce")
-        ));
-    }
-
-    #[cfg(feature = "tsp")]
-    #[test]
-    fn thread_id_correlates() {
-        let reply = serde_json::json!({
-            "id": "urn:uuid:the-reply",
-            "threadId": "urn:uuid:our-request",
-            "payload": {},
-        });
-        assert!(correlates(&reply, "urn:uuid:our-request", None));
-    }
-
-    /// Fallback for a responder that answers with a fresh document rather than
-    /// a threaded `#response`.
-    #[cfg(feature = "tsp")]
-    #[test]
-    fn echoed_nonce_correlates_when_thread_id_is_absent() {
-        let reply = serde_json::json!({
-            "id": "urn:uuid:fresh-doc",
-            "payload": { "nonce": "our-nonce" },
-        });
-        assert!(correlates(
-            &reply,
-            "urn:uuid:our-request",
-            Some("our-nonce")
-        ));
-        // ...but only when we actually sent a nonce to echo.
-        assert!(!correlates(&reply, "urn:uuid:our-request", None));
-    }
-
-    /// A document with neither field correlates with nothing — it is a push,
-    /// and must be parked for the receive consumer rather than eaten.
-    #[cfg(feature = "tsp")]
-    #[test]
-    fn a_push_correlates_with_no_request() {
-        let push = serde_json::json!({
-            "id": "urn:uuid:pushed",
-            "type": "https://trusttasks.org/spec/task-consent/request/0.1",
-            "payload": { "taskId": "t1" },
-        });
-        assert!(!correlates(
-            &push,
-            "urn:uuid:our-request",
-            Some("our-nonce")
-        ));
-    }
+    // TSP reply correlation moved to `crate::tsp_demux` when the rule became
+    // shared with the `DIDCommSession` TSP leg; its tests moved with it.
 
     #[test]
     fn forced_didcomm_error_names_the_alternatives() {

--- a/vta-sdk/src/tsp_demux.rs
+++ b/vta-sdk/src/tsp_demux.rs
@@ -1,0 +1,400 @@
+//! Reply correlation for TSP, shared by every TSP-carrying session.
+//!
+//! TSP frames carry no transport-level thread id — correlation is explicitly the
+//! application's job. So any session that wants request/response over TSP needs
+//! the same three things: a registry of in-flight requests, one definition of
+//! "is this frame the reply to that request", and somewhere to put a frame that
+//! answers *no* so it isn't dropped.
+//!
+//! Both TSP-carrying sessions in this crate need exactly that:
+//!
+//! - [`crate::session::TspSession`] — its own raw-TSP websocket, frames read and
+//!   unpacked by hand.
+//! - [`crate::didcomm_session::DIDCommSession`]'s TSP leg — TSP frames arriving
+//!   already-unpacked on the **DIDComm** session's single multiplexed mediator
+//!   socket (see that module for why there is only ever one socket per DID).
+//!
+//! They differ only in where a document comes from, so the bookkeeping lives
+//! here and each session keeps its own pump loop. One implementation of
+//! [`correlates`] is the point: it is the guard against handing back a *stale*
+//! reply, and a second copy of that rule is how it would rot.
+
+use std::collections::{HashMap, VecDeque};
+
+use tokio::sync::{Mutex, oneshot};
+use tracing::{debug, warn};
+
+/// One in-flight request: how to recognise its reply, and where to deliver it.
+struct PendingRequest {
+    /// Echoed-`nonce` fallback for a responder that replies with a fresh
+    /// document instead of a threaded `#response`.
+    nonce: Option<String>,
+    tx: oneshot::Sender<String>,
+}
+
+/// What [`TspDemux::route`] did with a document.
+pub(crate) enum Routed {
+    /// It was the reply to an in-flight request and went to that waiter.
+    Delivered,
+    /// No in-flight request wanted it — a VTA-pushed document, or a stale inbox
+    /// entry. The caller decides: hand it to a push consumer, or
+    /// [`park`](TspDemux::park) it for one.
+    Uncorrelated(String),
+}
+
+/// How many uncorrelated documents may wait in [`TspDemux::park`] before the
+/// oldest is discarded.
+///
+/// The queue used to be unbounded, which was survivable for a short-lived CLI
+/// session but is not for a long-running process that only ever calls
+/// `request` — every unsolicited VTA push would accumulate for the life of the
+/// process with nothing ever draining it. Bounded + a `warn!` turns that into a
+/// visible symptom instead of a slow leak; 256 is far above any legitimate
+/// backlog for a consumer that polls its inbox at all.
+const PARKED_CAPACITY: usize = 256;
+
+/// In-flight TSP requests plus the parking lot for frames none of them wanted.
+pub(crate) struct TspDemux {
+    /// Waiters keyed by request document `id`. Whichever task currently holds
+    /// the frame source reads on behalf of *all* of them and hands each reply to
+    /// its own waiter.
+    pending: Mutex<HashMap<String, PendingRequest>>,
+    /// Documents that matched no in-flight request — VTA-pushed
+    /// `task-consent/request`s and the like. Parked rather than dropped, so a
+    /// request waiting on an unrelated reply cannot eat a push.
+    parked: Mutex<VecDeque<String>>,
+}
+
+impl TspDemux {
+    pub(crate) fn new() -> Self {
+        Self {
+            pending: Mutex::new(HashMap::new()),
+            parked: Mutex::new(VecDeque::new()),
+        }
+    }
+
+    /// Register a waiter for `request_id` and return its receiver.
+    ///
+    /// Register **before** sending: a reply can land while the send call is
+    /// still returning, and a waiter registered afterwards would miss it.
+    pub(crate) async fn register(
+        &self,
+        request_id: String,
+        nonce: Option<String>,
+    ) -> oneshot::Receiver<String> {
+        let (tx, rx) = oneshot::channel();
+        self.pending
+            .lock()
+            .await
+            .insert(request_id, PendingRequest { nonce, tx });
+        rx
+    }
+
+    /// Drop `request_id`'s waiter. Always call this once a request is finished —
+    /// a timed-out or failed request must not leave a waiter behind for the pump
+    /// to deliver into.
+    pub(crate) async fn deregister(&self, request_id: &str) {
+        self.pending.lock().await.remove(request_id);
+    }
+
+    /// Route one unpacked Trust-Task document (as JSON text) to the request it
+    /// answers, or hand it back as [`Routed::Uncorrelated`].
+    ///
+    /// A document that isn't JSON at all can correlate with nothing, so it comes
+    /// straight back uncorrelated rather than being discarded — the push
+    /// consumer decides what to do with it.
+    pub(crate) async fn route(&self, json: String) -> Routed {
+        let Ok(doc) = serde_json::from_str::<serde_json::Value>(&json) else {
+            return Routed::Uncorrelated(json);
+        };
+
+        let mut pending = self.pending.lock().await;
+        let hit = pending
+            .iter()
+            .find(|(id, p)| correlates(&doc, id, p.nonce.as_deref()))
+            .map(|(id, _)| id.clone());
+        match hit {
+            Some(id) => {
+                if let Some(p) = pending.remove(&id) {
+                    // A dropped receiver (the requester timed out and left) is
+                    // not an error — the frame is simply no longer wanted.
+                    let _ = p.tx.send(json);
+                }
+                Routed::Delivered
+            }
+            None => {
+                drop(pending);
+                debug!(
+                    thread_id = doc
+                        .get("threadId")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("<none>"),
+                    "TSP frame matched no in-flight request (push, or a stale inbox entry)"
+                );
+                Routed::Uncorrelated(json)
+            }
+        }
+    }
+
+    /// Hold an uncorrelated document for a push consumer to collect later.
+    /// Bounded by [`PARKED_CAPACITY`]; the oldest is discarded once full.
+    pub(crate) async fn park(&self, doc: String) {
+        let mut parked = self.parked.lock().await;
+        if parked.len() >= PARKED_CAPACITY {
+            parked.pop_front();
+            warn!(
+                capacity = PARKED_CAPACITY,
+                "TSP push queue is full — discarding the oldest parked document. \
+                 Nothing is draining inbound pushes on this session."
+            );
+        }
+        parked.push_back(doc);
+    }
+
+    /// Take the oldest parked document, if any. A push consumer must drain this
+    /// before reading the frame source, or a push that already arrived would sit
+    /// unseen behind a fresh read.
+    pub(crate) async fn take_parked(&self) -> Option<String> {
+        self.parked.lock().await.pop_front()
+    }
+
+    /// Drop every waiter, so an in-flight request fails fast with "session shut
+    /// down" instead of blocking until its own deadline on a frame source that
+    /// is about to disappear.
+    pub(crate) async fn clear(&self) {
+        self.pending.lock().await.clear();
+    }
+
+    /// Pull the correlation keys out of an outbound request document: its `id`
+    /// (what a threaded `#response` sets `threadId` to) and any
+    /// `payload.nonce` (the fallback an unthreaded responder echoes).
+    ///
+    /// Returns `String` errors, not `Box<dyn Error>` — see [`crate::session`]'s
+    /// `await_reply` note: a boxed error is not `Send`, and one living across an
+    /// await makes the whole call chain `!Send`.
+    pub(crate) fn request_keys(document: &[u8]) -> Result<(String, Option<String>), String> {
+        let parsed: serde_json::Value = serde_json::from_slice(document)
+            .map_err(|e| format!("TSP request document is not JSON: {e}"))?;
+        let request_id = parsed
+            .get("id")
+            .and_then(|v| v.as_str())
+            .ok_or("TSP request document has no `id` to correlate its reply on")?
+            .to_string();
+        let nonce = parsed
+            .get("payload")
+            .and_then(|p| p.get("nonce"))
+            .and_then(|v| v.as_str())
+            .map(str::to_string);
+        Ok((request_id, nonce))
+    }
+}
+
+/// Does `doc` correlate to the request identified by `request_id` (and
+/// optionally `nonce`)?
+///
+/// The single implementation of "is this frame the reply to that request",
+/// shared by every TSP session. It was written for the ping path and welded
+/// there; every other caller would otherwise have re-derived `threadId` matching
+/// from the raw inner document.
+///
+/// Correlation is the Trust-Task `threadId`, which a responder sets to the
+/// request's `id` (`doc.respond_with`). The echoed `payload.nonce` is accepted
+/// as a fallback for a responder that replies with a fresh document rather than
+/// a threaded `#response`.
+///
+/// **Why this cannot be "the first frame that parses".** The client's mediator
+/// inbox is durable and flushes on connect, so every reply a previous process
+/// run never collected is queued and lands the moment we reconnect. Accepting
+/// the first frame therefore returns a *stale* reply — which is the exact fault
+/// that made the #749 delivery bug look intermittent.
+pub(crate) fn correlates(doc: &serde_json::Value, request_id: &str, nonce: Option<&str>) -> bool {
+    if doc.get("threadId").and_then(|v| v.as_str()) == Some(request_id) {
+        return true;
+    }
+    match nonce {
+        Some(n) => {
+            doc.get("payload")
+                .and_then(|p| p.get("nonce"))
+                .and_then(|v| v.as_str())
+                == Some(n)
+        }
+        None => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn response(thread_id: &str) -> String {
+        json!({
+            "id": "urn:uuid:reply",
+            "type": "https://trusttasks.org/spec/messaging/ping/0.1#response",
+            "threadId": thread_id,
+            "payload": { "ok": true },
+        })
+        .to_string()
+    }
+
+    /// The property that makes TSP request/response safe: a frame that is not
+    /// *this* request's reply must not be accepted as one.
+    ///
+    /// The mediator inbox is durable and flushes on connect, so every reply a
+    /// previous process run never collected lands the moment we reconnect.
+    /// "First frame that parses" would therefore return a stale reply — the
+    /// exact fault that made the #749 delivery bug look intermittent.
+    #[test]
+    fn a_stale_frame_is_not_mistaken_for_our_reply() {
+        let stale = json!({
+            "id": "urn:uuid:reply-to-something-else",
+            "threadId": "urn:uuid:a-previous-run",
+            "payload": { "nonce": "some-other-nonce" },
+        });
+        assert!(!correlates(
+            &stale,
+            "urn:uuid:our-request",
+            Some("our-nonce")
+        ));
+    }
+
+    /// A document with neither field correlates with nothing — it is a push,
+    /// and must be parked for the receive consumer rather than eaten.
+    #[test]
+    fn a_push_correlates_with_no_request() {
+        let push = json!({
+            "id": "urn:uuid:pushed",
+            "type": "https://trusttasks.org/spec/task-consent/request/0.1",
+            "payload": { "taskId": "t1" },
+        });
+        assert!(!correlates(
+            &push,
+            "urn:uuid:our-request",
+            Some("our-nonce")
+        ));
+    }
+
+    #[test]
+    fn correlates_on_thread_id() {
+        let doc = json!({ "threadId": "urn:uuid:req-1" });
+        assert!(correlates(&doc, "urn:uuid:req-1", None));
+        assert!(!correlates(&doc, "urn:uuid:req-2", None));
+    }
+
+    /// A responder that replies with a fresh document rather than a threaded
+    /// `#response` still correlates, via the echoed nonce.
+    #[test]
+    fn correlates_on_echoed_nonce_when_unthreaded() {
+        let doc = json!({ "id": "urn:uuid:fresh", "payload": { "nonce": "n-1" } });
+        assert!(correlates(&doc, "urn:uuid:req-1", Some("n-1")));
+        assert!(!correlates(&doc, "urn:uuid:req-1", Some("n-2")));
+        // Without a nonce to fall back on there is nothing else to match.
+        assert!(!correlates(&doc, "urn:uuid:req-1", None));
+    }
+
+    #[tokio::test]
+    async fn a_reply_reaches_its_own_waiter() {
+        let demux = TspDemux::new();
+        let mut rx = demux.register("urn:uuid:req-1".into(), None).await;
+        assert!(matches!(
+            demux.route(response("urn:uuid:req-1")).await,
+            Routed::Delivered
+        ));
+        let got = rx.try_recv().expect("the waiter received its reply");
+        assert!(got.contains("urn:uuid:req-1"));
+    }
+
+    /// Two requests in flight: each reply goes to its own waiter, and neither
+    /// can consume the other's.
+    #[tokio::test]
+    async fn concurrent_waiters_do_not_steal_from_each_other() {
+        let demux = TspDemux::new();
+        let mut rx_a = demux.register("urn:uuid:a".into(), None).await;
+        let mut rx_b = demux.register("urn:uuid:b".into(), None).await;
+
+        demux.route(response("urn:uuid:b")).await;
+        assert!(
+            rx_a.try_recv().is_err(),
+            "A's waiter must not receive B's reply"
+        );
+        assert!(rx_b.try_recv().is_ok(), "B's waiter receives B's reply");
+
+        demux.route(response("urn:uuid:a")).await;
+        assert!(rx_a.try_recv().is_ok(), "A's waiter still receives its own");
+    }
+
+    /// The invariant that keeps a push from being eaten by an unrelated
+    /// request: an uncorrelated frame comes back to the caller, and parking it
+    /// makes it collectable.
+    #[tokio::test]
+    async fn an_uncorrelated_document_is_returned_and_can_be_parked() {
+        let demux = TspDemux::new();
+        let _rx = demux.register("urn:uuid:req-1".into(), None).await;
+
+        let push = json!({ "id": "urn:uuid:push", "type": "task-consent/request" }).to_string();
+        let Routed::Uncorrelated(doc) = demux.route(push.clone()).await else {
+            panic!("a push must not be delivered to an unrelated waiter");
+        };
+        assert_eq!(doc, push);
+
+        demux.park(doc).await;
+        assert_eq!(demux.take_parked().await.as_deref(), Some(push.as_str()));
+        assert!(demux.take_parked().await.is_none());
+    }
+
+    /// Non-JSON can correlate with nothing, so it must be handed up rather than
+    /// silently dropped.
+    #[tokio::test]
+    async fn a_non_json_frame_is_uncorrelated_not_dropped() {
+        let demux = TspDemux::new();
+        assert!(matches!(
+            demux.route("not json at all".into()).await,
+            Routed::Uncorrelated(_)
+        ));
+    }
+
+    /// `clear()` (what shutdown calls) drops every waiter, so an in-flight
+    /// request fails immediately instead of waiting out its deadline.
+    #[tokio::test]
+    async fn clear_wakes_waiters_with_a_closed_channel() {
+        let demux = TspDemux::new();
+        let mut rx = demux.register("urn:uuid:req-1".into(), None).await;
+        demux.clear().await;
+        assert!(
+            matches!(rx.try_recv(), Err(oneshot::error::TryRecvError::Closed)),
+            "a cleared waiter must observe the channel closed, not stay pending"
+        );
+    }
+
+    /// The parking lot is bounded: a session that never drains pushes drops the
+    /// oldest rather than growing without limit.
+    #[tokio::test]
+    async fn parking_is_bounded_and_drops_the_oldest() {
+        let demux = TspDemux::new();
+        for i in 0..PARKED_CAPACITY + 1 {
+            demux.park(format!("doc-{i}")).await;
+        }
+        assert_eq!(
+            demux.take_parked().await.as_deref(),
+            Some("doc-1"),
+            "doc-0 must have been discarded to make room"
+        );
+    }
+
+    #[test]
+    fn request_keys_reads_id_and_nonce() {
+        let doc = json!({ "id": "urn:uuid:req-1", "payload": { "nonce": "n-1" } });
+        let (id, nonce) = TspDemux::request_keys(&serde_json::to_vec(&doc).unwrap()).unwrap();
+        assert_eq!(id, "urn:uuid:req-1");
+        assert_eq!(nonce.as_deref(), Some("n-1"));
+    }
+
+    /// A document with no `id` has nothing to correlate a reply on, so it is
+    /// refused up front rather than sent and silently un-awaitable.
+    #[test]
+    fn request_keys_refuses_a_document_with_no_id() {
+        let doc = json!({ "payload": { "nonce": "n-1" } });
+        assert!(TspDemux::request_keys(&serde_json::to_vec(&doc).unwrap()).is_err());
+        assert!(TspDemux::request_keys(b"not json").is_err());
+    }
+}

--- a/vta-sdk/tests/tsp_dual_leg_live.rs
+++ b/vta-sdk/tests/tsp_dual_leg_live.rs
@@ -1,0 +1,211 @@
+//! Live dual-leg round trip against a **deployed** TSP-enabled VTA (#803).
+//!
+//! `tsp_discovery_live.rs` closes the discovery half and names what it cannot
+//! reach: *"the correlated round-trip (`connect_tsp` → `TspSession::request` →
+//! reply) … still wants a live exercise."* This is that exercise, for the shape
+//! the deployment actually forces — a client holding a DIDComm session that also
+//! needs TSP, on a VTA advertising **the same mediator** for both.
+//!
+//! What it proves that the hermetic tests cannot: the *deployed* VTA answers a
+//! trust task that arrived over TSP on a socket it shares with DIDComm. The
+//! hermetic suite (`tests/e2e/tests/tsp_dual_leg.rs`) uses a `TestMediator` and
+//! a scripted responder, so it pins the client's plumbing but not the VTA's.
+//!
+//! **`#[ignore]`d**: resolves a `did:webvh` and opens a mediator connection over
+//! the network. Run it deliberately:
+//!
+//! ```sh
+//! cargo test -p vta-sdk --features session,provision-client,tsp \
+//!     --test tsp_dual_leg_live -- --ignored --nocapture
+//! ```
+//!
+//! Point it at a different deployment with `VTA_LIVE_TSP_DID`.
+//!
+//! ## What counts as a pass, and why it needs no credential
+//!
+//! The question is **transport**, not authorization: did a document we sent over
+//! the multiplexed socket reach the VTA, and did *its* reply come back and
+//! correlate to that request? A `permissionDenied` trust-task response answers
+//! that with a yes — the VTA received the task, dispatched it, and routed a
+//! reply to the right waiter. Only a *transport* failure (timeout, TSP error)
+//! means the socket did not carry the exchange.
+//!
+//! So by default the test mints a throwaway `did:key` and asserts it got a
+//! correlated **reply of either kind**. Set `VTA_LIVE_CLIENT_DID` +
+//! `VTA_LIVE_CLIENT_KEY` to an ACL-granted identity and it tightens to
+//! demanding a successful payload. Each test prints which mode it ran in, so a
+//! green run never overstates what it checked.
+//!
+//! Every case is paired with a **DIDComm control over the same deployment**, so
+//! a failure is attributable to the TSP leg rather than to the VTA being down or
+//! the identity being rejected.
+
+#![cfg(all(feature = "session", feature = "provision-client", feature = "tsp"))]
+
+use vta_sdk::client::{SurfaceTransport, VtaClient};
+use vta_sdk::error::VtaError;
+use vta_sdk::provision_client::EphemeralSetupKey;
+use vta_sdk::session::{VtaEndpoint, resolve_vta_endpoint};
+
+/// The deployment named in #803. Overridable so this does not rot into a test
+/// that only ever proves one host was up.
+fn target_did() -> String {
+    std::env::var("VTA_LIVE_TSP_DID").unwrap_or_else(|_| {
+        "did:webvh:QmWoJD2kpP6AJknNtj7UFERUstEen258ywj3ruHoh1ZAqr:webvh.storm.ws:glenn-vta"
+            .to_string()
+    })
+}
+
+/// The identity to run as: an ACL-granted one from the environment when
+/// supplied, otherwise a freshly-minted throwaway.
+fn client_identity() -> (String, String, bool) {
+    match (
+        std::env::var("VTA_LIVE_CLIENT_DID"),
+        std::env::var("VTA_LIVE_CLIENT_KEY"),
+    ) {
+        (Ok(did), Ok(key)) if !did.is_empty() && !key.is_empty() => (did, key, true),
+        _ => {
+            let key = EphemeralSetupKey::generate().expect("mint an ephemeral did:key");
+            let mb = key.private_key_multibase().to_string();
+            (key.did, mb, false)
+        }
+    }
+}
+
+/// The VTA's `#tsp` + `#vta-didcomm` + `#vta-rest` advertisement, or a skip.
+async fn dual_endpoint() -> (String, String, String, Option<String>) {
+    let endpoint = resolve_vta_endpoint(&target_did())
+        .await
+        .expect("the target VTA's DID must resolve");
+    let VtaEndpoint::Tsp {
+        vta_did,
+        mediator_did: tsp_mediator_did,
+        didcomm_mediator_did,
+        rest_url,
+    } = endpoint
+    else {
+        panic!(
+            "this test needs a VTA advertising `#tsp`; {} advertises something else",
+            target_did()
+        );
+    };
+    let didcomm_mediator_did = didcomm_mediator_did.expect(
+        "this test needs a VTA advertising BOTH `#tsp` and `#vta-didcomm` — that pairing on \
+         one mediator is the collision #803 is about",
+    );
+    (vta_did, didcomm_mediator_did, tsp_mediator_did, rest_url)
+}
+
+/// Did the VTA *answer*? A denial is an answer; a transport error is not.
+///
+/// This is the whole distinction the test turns on. `dispatch_trust_task`
+/// surfaces a rejected task as [`VtaError::Protocol`] carrying the VTA's own
+/// response document — which can only exist if the request arrived, was
+/// dispatched, and its reply was routed back to this waiter. A
+/// [`VtaError::TspTransport`] or a timeout is the opposite: nothing came back.
+fn assert_vta_answered(result: Result<serde_json::Value, VtaError>, authorized: bool, over: &str) {
+    match result {
+        Ok(payload) => eprintln!("  ✅ {over}: authorized round trip — {payload}"),
+        Err(VtaError::Protocol(msg)) if !authorized => {
+            eprintln!("  ✅ {over}: the VTA answered (unauthorized identity) — {msg}");
+        }
+        Err(e) => panic!(
+            "{over}: no correlated reply came back from the deployed VTA — the exchange did \
+             not complete over the transport (set VTA_LIVE_CLIENT_DID/_KEY for an authorized \
+             run): {e}"
+        ),
+    }
+}
+
+/// A `messaging/ping` dispatched through `client`, with a fresh nonce.
+async fn ping(client: &VtaClient) -> Result<serde_json::Value, VtaError> {
+    client
+        .dispatch_trust_task(
+            vta_sdk::trust_tasks::TASK_MESSAGING_PING_0_1,
+            serde_json::json!({ "nonce": uuid::Uuid::new_v4().to_string() }),
+            30,
+        )
+        .await
+}
+
+/// **The core case.** One client, one socket, both surfaces — against the real
+/// deployment.
+///
+/// That deployment resolves `#tsp` and `#vta-didcomm` to the same mediator,
+/// which is precisely why `connect_tsp` alongside a DIDComm session could not
+/// work: the mediator permits one websocket per DID and evicts the second as
+/// `duplicate-channel`. Here the TSP leg rides the DIDComm session's socket, so
+/// there is only ever one — and the trust task still round-trips.
+#[tokio::test]
+#[ignore = "resolves a did:webvh and connects to a live mediator; run explicitly with --ignored"]
+async fn a_deployed_vta_answers_a_trust_task_over_the_didcomm_sessions_socket() {
+    let (vta_did, didcomm_mediator_did, tsp_mediator_did, rest_url) = dual_endpoint().await;
+    let (client_did, client_key, authorized) = client_identity();
+
+    eprintln!("  VTA:              {vta_did}");
+    eprintln!("  DIDComm mediator: {didcomm_mediator_did}");
+    eprintln!("  TSP mediator:     {tsp_mediator_did}");
+    eprintln!("  client:           {client_did}");
+    eprintln!(
+        "  mode:             {}",
+        if authorized {
+            "authorized (expecting a successful payload)"
+        } else {
+            "throwaway identity (expecting any correlated reply)"
+        }
+    );
+    assert_eq!(
+        didcomm_mediator_did, tsp_mediator_did,
+        "this deployment splits its TSP and DIDComm mediators, so it does not exercise the \
+         one-socket-per-DID collision #803 is about"
+    );
+
+    let client = VtaClient::connect_didcomm_with_tsp(
+        &client_did,
+        &client_key,
+        &vta_did,
+        &didcomm_mediator_did,
+        &tsp_mediator_did,
+        rest_url,
+    )
+    .await
+    .expect("connect DIDComm and put trust tasks on TSP");
+
+    assert_eq!(client.trust_task_transport(), SurfaceTransport::Tsp);
+    assert_eq!(
+        client.protocol_message_transport(),
+        SurfaceTransport::Didcomm
+    );
+
+    let result = ping(&client).await;
+    client.shutdown().await;
+
+    assert_vta_answered(result, authorized, "TSP on the DIDComm session's socket");
+}
+
+/// The same deployment over DIDComm alone, as a control. If the dual-leg test
+/// fails while this passes, the fault is TSP-specific rather than the deployment
+/// being down or the identity being rejected.
+#[tokio::test]
+#[ignore = "resolves a did:webvh and connects to a live mediator; run explicitly with --ignored"]
+async fn didcomm_control_against_the_same_deployment() {
+    let (vta_did, didcomm_mediator_did, _, rest_url) = dual_endpoint().await;
+    let (client_did, client_key, authorized) = client_identity();
+
+    let client = VtaClient::connect_didcomm(
+        &client_did,
+        &client_key,
+        &vta_did,
+        &didcomm_mediator_did,
+        rest_url,
+    )
+    .await
+    .expect("connect over DIDComm");
+
+    assert_eq!(client.trust_task_transport(), SurfaceTransport::Didcomm);
+
+    let result = ping(&client).await;
+    client.shutdown().await;
+
+    assert_vta_answered(result, authorized, "DIDComm");
+}


### PR DESCRIPTION
Closes #803. Unblocks OpenVTC/openvtc#185 item 2b.

## The problem

A consumer holding a DIDComm session could not use TSP at all. The only route to a
Trust-Task-over-TSP client was `connect_tsp`, which opens its **own** websocket — and
the mediator permits one websocket per DID, so the second was rejected with
`duplicate-channel` and the two reconnect loops duelled. On the reference deployment
`#tsp` and `#vta-didcomm` resolve to the *same* mediator, so this was the normal case.

## What decided the design

**The VTA already fixed this on the server side.** `vta-service/src/server.rs:1056-1062`
deleted its standalone TSP websocket because it "made the mediator evict a connection as
`duplicate-channel`, flapping the VTA"; it now demuxes TSP off its single delivery-layer
socket. This PR is the client-side mirror of a fix already in production.

**The plumbing was already there and unused.** `DidCommTransport::inbound` polls
`live_stream_next_frame`, which yields **both** protocols off the one pickup socket and
tags each `Inbound` with `message.protocol`. TSP *send* is an HTTP `POST /inbound` — no
socket at all. So a full TSP leg on an existing DIDComm session costs **zero new sockets**.

## Changes

- **`DIDCommSession` TSP leg** — `send_tsp_document` / `request_tsp` / `receive_next_tsp`
  over the existing connection. The leg takes its own `subscribe()` receiver (subscribers
  are a broadcast), so the TSP pump cannot eat a DIDComm push and `receive_next` cannot eat
  a TSP reply.
- **`VtaClient::enable_tsp_trust_tasks`** — the seam #803 asks for. Moves the Trust-Task
  surface (`dispatch_trust_task`, `rpc_tt`, the `device/*` and `vault/*` methods) onto TSP.
  No I/O, cannot fail. `attach_tsp_leg` covers the split-mediator topology and **refuses**
  a second session for a DID on the mediator it is already connected to — the defect is
  unrepresentable through the API. `connect_didcomm_with_tsp` does both in one call.
- `rpc` / `rpc_void` stay on DIDComm unconditionally — the VTA has no TSP dispatcher behind
  `key-management/1.0/*`, `create_did_webvh` or `list_contexts`.
- **`SurfaceTransport` + `trust_task_transport()` / `protocol_message_transport()`** — a
  client no longer has *one* transport, so an operator display rendering a single value is
  wrong by construction (openvtc#185 item 2a).

### Live regression fixed on the pnm/cnm path

`TransportChoice::Auto` returned a **TSP-only** client whenever a VTA advertised `#tsp`,
so on a TSP-enabled VTA every protocol-message command (`keys create`, `contexts list`,
DID minting) failed with `UnsupportedTransport`. Auto now returns a **dual** client against
a VTA advertising both — one socket — and still falls back to TSP-only, loudly, when the
DIDComm mediator is down. Forced `--transport tsp` is unchanged (TSP-only by request).

### Also fixed

`DIDCommSession::receive_next` parsed every inbound frame as a DIDComm `Message`, so a TSP
frame on the multiplexed socket became a hard error on the DIDComm inbox that received it.
Latent on `main` only because nothing sent TSP to an SDK DIDComm session.

Reply correlation moved to a shared `tsp_demux` so `TspSession` and the new leg cannot
drift on the rule that stops a *stale* inbox frame being returned as a reply (#749). Its
parking queue is now bounded (previously unbounded).

## Verification

**Live, against the deployed VTA** (`glenn-vta`, both services on one mediator) — a trust
task dispatched over the DIDComm session's socket reached the VTA and its reply came back
correlated:

```
  TSP mediator:     did:webvh:QmTS3a…:webvh.storm.ws:mediator
  DIDComm mediator: did:webvh:QmTS3a…:webvh.storm.ws:mediator
  ✅ TSP on the DIDComm session's socket: the VTA answered
  ✅ DIDComm (control): the VTA answered
```

`vta-sdk/tests/tsp_dual_leg_live.rs` (`#[ignore]`d, credential-free — a `permissionDenied`
trust-task *response* proves the transport; only a transport error fails it. Set
`VTA_LIVE_CLIENT_DID`/`_KEY` to tighten to a successful payload).

**Hermetic, in CI** — `tests/e2e/tests/tsp_dual_leg.rs` over the embedded `TestMediator`
(4 tests, all green): a TSP frame reaches a DID whose only connection is a `DIDCommSession`;
both legs work on that one session; `request_tsp` correlates its reply while an unrelated
push is parked, not eaten; and the API refuses the duplicate socket.

Plus unit coverage for the demux (correlation, nonce fallback, parking, concurrency,
bounded queue) and leg selection, `Send`-future assertions for the new call chain, `cargo
fmt`, and `cargo clippy --workspace --all-targets` clean.

`vta-sdk` 0.20.1 → 0.20.2 — additive only; a minor bump would break the workspace
`[patch.crates-io]` pin.