### PR TITLE
feat: let a caller supply the resolver for VTA transport discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 ## Unreleased
 
+### vta-sdk 0.20.3 — transport discovery is testable without a live VTA
+
+`resolve_vta_endpoint` built its `DIDCacheClient` from the environment, so a
+consumer had no way to point discovery at a fixture: seeding a document into its
+own cache did nothing, because the function never saw that cache. The practical
+effect was that "does this VTA advertise `#tsp`" — the question #765 and #810
+made answerable — could still only be *asserted* against a live deployment.
+OpenVTC hit this trying to cover its TSP-enablement path (OpenVTC/openvtc#185)
+and had to leave the assertion unmade.
+
+- `resolve_vta_endpoint_with_resolver(vta_did, &DIDCacheClient)` and
+  `provision_client::resolve_vta_with_resolver(...)` run the same discovery over
+  a caller-supplied resolver. The env-configured entry points delegate to them,
+  so behaviour is unchanged and no caller has to move.
+- Follows the pattern `resolve_mediator_did_with_resolver` already set in the
+  same module, for the same two reasons: reuse (no second cache per resolve) and
+  testability.
+- `provision_client`'s two entry points now share one `flatten`, so they cannot
+  disagree about what an endpoint shape means.
+
+Additive. Four new tests seed a document and assert what discovery makes of it,
+in-process with no network: a dual `#tsp` + `#vta-didcomm` VTA (the reference
+deployment's shape) reports both in preference order; a DIDComm-only VTA reports
+no TSP; a TSP-only VTA does not fall back to a REST URL synthesized from its own
+domain; and a `#tsp` entry carrying a URL instead of a mediator DID is ignored
+rather than routed through.
+
 ### vtc-service 0.11.33 — the raw-byte website endpoints stop pretending to be Trust Tasks
 
 Three endpoints on the website management surface move **file bytes**:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10269,7 +10269,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.20.2"
+version = "0.20.3"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.20.2"
+version = "0.20.3"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/provision_client/resolve.rs
+++ b/vta-sdk/src/provision_client/resolve.rs
@@ -50,12 +50,47 @@ impl ResolvedVta {
 /// Returns an error if the DID cannot be resolved and no fallback URL can
 /// be inferred from the DID string.
 pub async fn resolve_vta(vta_did: &str) -> Result<ResolvedVta, ProvisionError> {
-    match resolve_vta_endpoint(vta_did)
-        .await
-        .map_err(|e| ProvisionError::Resolve {
-            vta_did: vta_did.to_string(),
-            message: e.to_string(),
-        })? {
+    flatten(
+        vta_did,
+        resolve_vta_endpoint(vta_did)
+            .await
+            .map_err(|e| ProvisionError::Resolve {
+                vta_did: vta_did.to_string(),
+                message: e.to_string(),
+            })?,
+    )
+}
+
+/// [`resolve_vta`] over an **existing** resolver.
+///
+/// The probing counterpart of
+/// [`resolve_vta_endpoint_with_resolver`](crate::session::resolve_vta_endpoint_with_resolver):
+/// same flattened `ResolvedVta`, but discovery runs against a resolver the
+/// caller supplies. A consumer testing "does the panel report `#tsp` when the
+/// VTA advertises it" seeds a document and calls this; against the
+/// env-configured entry point that assertion needs a live deployment.
+pub async fn resolve_vta_with_resolver(
+    vta_did: &str,
+    resolver: &affinidi_did_resolver_cache_sdk::DIDCacheClient,
+) -> Result<ResolvedVta, ProvisionError> {
+    flatten(
+        vta_did,
+        crate::session::resolve_vta_endpoint_with_resolver(vta_did, resolver)
+            .await
+            .map_err(|e| ProvisionError::Resolve {
+                vta_did: vta_did.to_string(),
+                message: e.to_string(),
+            })?,
+    )
+}
+
+/// Flatten a [`VtaEndpoint`] into the independently-populated [`ResolvedVta`].
+///
+/// Shared so the two entry points cannot disagree about what a given endpoint
+/// shape means — the split that keeps "what is advertised" separate from "what
+/// we connected over".
+fn flatten(vta_did: &str, endpoint: VtaEndpoint) -> Result<ResolvedVta, ProvisionError> {
+    match endpoint {
         VtaEndpoint::Tsp {
             vta_did,
             mediator_did,
@@ -134,5 +169,129 @@ mod tests {
     #[test]
     fn a_vta_advertising_nothing_reports_nothing() {
         assert!(resolved(None, None, None).advertised().is_empty());
+    }
+}
+
+/// Discovery against a **seeded** resolver — the assertions that were previously
+/// only provable against a live deployment.
+///
+/// `resolve_vta` builds its resolver from the environment, so before
+/// [`resolve_vta_with_resolver`] a consumer could not point discovery at a
+/// fixture: seeding a document into its own cache did nothing, because the
+/// function never saw that cache. These run in-process with no network.
+#[cfg(test)]
+mod seeded_discovery_tests {
+    use super::*;
+    use crate::protocol::matching::Protocol;
+    use affinidi_did_resolver_cache_sdk::{DIDCacheClient, config::DIDCacheConfigBuilder};
+    use serde_json::json;
+
+    const VTA: &str = "did:web:vta.example";
+    const MEDIATOR: &str = "did:web:mediator.example";
+    const REST: &str = "https://vta.example/api";
+
+    /// A resolver holding exactly `doc` for [`VTA`], resolving offline.
+    async fn resolver_serving(doc: serde_json::Value) -> DIDCacheClient {
+        let mut client = DIDCacheClient::new(DIDCacheConfigBuilder::default().build())
+            .await
+            .expect("local DID cache");
+        client
+            .add_did_document(
+                VTA,
+                serde_json::from_value(doc).expect("fixture document deserializes"),
+            )
+            .await;
+        client
+    }
+
+    fn document(services: serde_json::Value) -> serde_json::Value {
+        json!({
+            "@context": ["https://www.w3.org/ns/did/v1"],
+            "id": VTA,
+            "service": services,
+        })
+    }
+
+    /// The shape the reference deployment actually has: `#tsp` and
+    /// `#vta-didcomm` pointing at the **same** mediator. This is what a consumer
+    /// needs to be able to assert without a live VTA.
+    #[tokio::test]
+    async fn a_tsp_advertising_vta_is_discovered_as_tsp() {
+        let resolver = resolver_serving(document(json!([
+            { "id": format!("{VTA}#tsp"), "type": "TSPTransport", "serviceEndpoint": MEDIATOR },
+            { "id": format!("{VTA}#vta-didcomm"), "type": "DIDCommMessaging", "serviceEndpoint": MEDIATOR },
+        ])))
+        .await;
+
+        let resolved = resolve_vta_with_resolver(VTA, &resolver)
+            .await
+            .expect("the seeded document resolves");
+
+        assert_eq!(resolved.tsp_mediator_did.as_deref(), Some(MEDIATOR));
+        assert_eq!(resolved.mediator_did.as_deref(), Some(MEDIATOR));
+        assert_eq!(
+            resolved.advertised(),
+            vec![Protocol::Tsp, Protocol::Didcomm],
+            "both transports are reported, in preference order"
+        );
+    }
+
+    /// A VTA advertising no `#tsp` must not report one — the other direction,
+    /// and the one a panel would misreport if discovery guessed.
+    #[tokio::test]
+    async fn a_didcomm_only_vta_advertises_no_tsp() {
+        let resolver = resolver_serving(document(json!([
+            { "id": format!("{VTA}#vta-didcomm"), "type": "DIDCommMessaging", "serviceEndpoint": MEDIATOR },
+            { "id": format!("{VTA}#vta-rest"), "type": "VTARest", "serviceEndpoint": REST },
+        ])))
+        .await;
+
+        let resolved = resolve_vta_with_resolver(VTA, &resolver)
+            .await
+            .expect("the seeded document resolves");
+
+        assert_eq!(resolved.tsp_mediator_did, None);
+        assert_eq!(
+            resolved.advertised(),
+            vec![Protocol::Didcomm, Protocol::Rest]
+        );
+    }
+
+    /// A TSP-only node — the shape this crate ships `did-host-tsp` templates for.
+    /// It must not fall through to a REST URL synthesized from the DID's domain,
+    /// which is the bug the endpoint doc calls out.
+    #[tokio::test]
+    async fn a_tsp_only_vta_does_not_fall_back_to_a_guessed_rest_url() {
+        let resolver = resolver_serving(document(json!([
+            { "id": format!("{VTA}#tsp"), "type": "TSPTransport", "serviceEndpoint": MEDIATOR },
+        ])))
+        .await;
+
+        let resolved = resolve_vta_with_resolver(VTA, &resolver)
+            .await
+            .expect("the seeded document resolves");
+
+        assert_eq!(resolved.tsp_mediator_did.as_deref(), Some(MEDIATOR));
+        assert_eq!(resolved.rest_url, None, "no URL was invented");
+        assert_eq!(resolved.advertised(), vec![Protocol::Tsp]);
+    }
+
+    /// A `#tsp` entry whose endpoint is a URL rather than a mediator DID is a
+    /// misconfiguration, not a routable TSP endpoint, and must be ignored rather
+    /// than handed onward.
+    #[tokio::test]
+    async fn a_non_did_tsp_endpoint_is_not_treated_as_a_mediator() {
+        let resolver = resolver_serving(document(json!([
+            { "id": format!("{VTA}#tsp"), "type": "TSPTransport", "serviceEndpoint": "https://not-a-did.example" },
+            { "id": format!("{VTA}#vta-didcomm"), "type": "DIDCommMessaging", "serviceEndpoint": MEDIATOR },
+        ])))
+        .await;
+
+        let resolved = resolve_vta_with_resolver(VTA, &resolver)
+            .await
+            .expect("the seeded document resolves");
+
+        assert_eq!(resolved.tsp_mediator_did, None);
+        assert_eq!(resolved.mediator_did.as_deref(), Some(MEDIATOR));
     }
 }

--- a/vta-sdk/src/session.rs
+++ b/vta-sdk/src/session.rs
@@ -1716,13 +1716,34 @@ fn advertised_hint(has_didcomm: bool, has_rest: bool) -> &'static str {
 pub async fn resolve_vta_endpoint(
     vta_did: &str,
 ) -> Result<VtaEndpoint, Box<dyn std::error::Error>> {
-    use crate::protocol::matching::ServiceCapabilities;
-
-    debug!(vta_did, "resolving VTA DID for transport selection");
-
     let did_resolver = DIDCacheClient::new(crate::resolver::build_did_cache_config_from_env())
         .await
         .map_err(|e| format!("DID resolver init failed: {e}"))?;
+    resolve_vta_endpoint_with_resolver(vta_did, &did_resolver).await
+}
+
+/// [`resolve_vta_endpoint`] over an **existing** resolver.
+///
+/// Two reasons to reach for this rather than the env-configured entry point:
+///
+/// - **Reuse.** A caller that already holds a `DIDCacheClient` avoids building a
+///   second one (and a second cache) per resolve — the same reason
+///   [`resolve_mediator_did_with_resolver`] exists.
+/// - **Testability, which is why this was added.** `resolve_vta_endpoint` builds
+///   its resolver from the environment, so a consumer had no way to point
+///   discovery at a fixture: seeding a document into *its own* cache did nothing,
+///   because the function never saw that cache. Transport discovery — including
+///   whether a VTA advertises `#tsp` — was therefore only provable against a live
+///   deployment. With a resolver parameter a test seeds a document via
+///   `DIDCacheClient::add_did_document` and asserts what discovery makes of it,
+///   in-process and with no network.
+pub async fn resolve_vta_endpoint_with_resolver(
+    vta_did: &str,
+    did_resolver: &DIDCacheClient,
+) -> Result<VtaEndpoint, Box<dyn std::error::Error>> {
+    use crate::protocol::matching::ServiceCapabilities;
+
+    debug!(vta_did, "resolving VTA DID for transport selection");
 
     let resolved = match did_resolver.resolve(vta_did).await {
         Ok(r) => r,


### PR DESCRIPTION
Closes the testability half of what OpenVTC/openvtc#185 needed. Additive; no signature changes.

## The problem

`resolve_vta_endpoint` builds its `DIDCacheClient` from the environment, so a consumer has **no way to point discovery at a fixture**: seeding a document into its own cache does nothing, because the function never sees that cache.

The practical effect is that *"does this VTA advertise `#tsp`"* — the question #765 and #810 made answerable — can still only be **asserted** against a live deployment. OpenVTC hit this covering its TSP-enablement path and had to leave the assertion unmade, with the wiring verified by construction rather than execution.

## This started as a MockVta fixture, which was the wrong layer

The obvious fix looked like "give `MockVta` a TSP-advertising variant". It cannot work: `preseed_did_docs` seeds the **VTA's own** resolver, and an external consumer resolves through its own. No fixture on the VTA side can reach a consumer's discovery call while that call constructs its resolver internally.

The blocker was never the fixture. It was the missing seam.

## The change

- **`resolve_vta_endpoint_with_resolver(vta_did, &DIDCacheClient)`** and **`provision_client::resolve_vta_with_resolver(...)`** run the same discovery over a caller-supplied resolver. The env-configured entry points delegate to them, so behaviour is unchanged and no caller has to move.
- Follows the pattern **`resolve_mediator_did_with_resolver` already set in the same module**, for the same two reasons: reuse (no second cache per resolve) and testability.
- `provision_client`'s two entry points now share one `flatten`, so they cannot disagree about what an endpoint shape means — the split that keeps "what is advertised" separate from "what we connected over".

## Tests — the assertions that were previously impossible

Four, seeding a document and asserting what discovery makes of it, in-process with no network:

- a dual `#tsp` + `#vta-didcomm` VTA (**the reference deployment's shape**) reports both, in preference order
- a DIDComm-only VTA reports no TSP
- a TSP-only VTA does **not** fall back to a REST URL synthesized from its own domain — the bug `resolve_vta_endpoint`'s own doc calls out, now covered
- a `#tsp` entry carrying a URL instead of a mediator DID is ignored rather than routed through

## Verification

- `cargo test -p vta-sdk --features session,client,didcomm,provision-client` — 462 + 16 + 78 + … all green, 0 failed
- `cargo clippy --workspace -- -D warnings` (CI's invocation) — clean
- `cargo fmt --all --check` — clean
- `scripts/check-version-bumps.sh` — `ok vta-sdk: 0.20.2 -> 0.20.3`
- `scripts/check-changelogs.sh` — `ok vta-sdk: 0.20.2 -> 0.20.3 (documented)`

## Two things flagged, not fixed

**Pre-existing clippy errors.** `cargo clippy -p vta-sdk --features session,client,didcomm,provision-client --all-targets` reports 3 errors (`didcomm_session.rs:673` "this loop never actually loops", and two others). **Same count on a clean `origin/main`**, none in files this change touches, and CI's own invocation is clean — so unrelated to this PR, but worth someone's attention since that feature combination is what consumers build with.

**A guard blind spot.** Both release guards resolve `$ROOT` via `pwd`, while `cargo metadata` reports the symlink-resolved path. On macOS, running from a worktree under `/tmp` (→ `/private/tmp`) makes the paths mismatch, every crate fails attribution, and both guards **pass vacuously** with "nothing to check". They behave correctly from the canonical path, and CI checks out normally so it is unaffected — but a guard that silently passes when it cannot attribute anything is worth hardening, given these exist precisely to catch what authors forget.
