### PR TITLE
docs(vta): make the signing oracle's authorization model a guarantee (#805)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,47 @@
 
 ## Unreleased
 
+### vta-sdk 0.20.4 / vta-service 0.12.41 — the signing oracle's authorization model is a documented guarantee (#805)
+
+The VTA signs the bytes it is handed without inspecting them, so *which keys a
+caller may name* is the whole of the authorization story. A companion proposal
+was declined partly on the reasoning that per-key scoping already delivers the
+identity property — but that reasoning was read off an SDK field comment
+("must be an active key the caller has access to") rather than observed in the
+service, and a multi-domain signer now depends on it.
+
+**Confirmed: the service enforces it**, in three layers, in
+`operations::keys::sign_payload` — and more strictly than the field comment
+implies:
+
+1. **Caller's context scope** — `require_context` on the key's `context_id`,
+   via `ActScope`.
+2. **The key's context policy** — `signable_keys` is *resource-bound*: it
+   constrains the key's context **regardless of the actor, including a
+   super-admin**. That is what lets a fleet- or VTC-pushed policy bind every
+   signer; the owner relaxes it via policy CRUD, not by holding a bigger role.
+3. **Unscoped keys are super-admin only** — no context means no policy, so the
+   role floor is the only guardrail left.
+
+All three transports (REST, DIDComm `key-management/1.0/sign-request`, and the
+`keys/sign` Trust Task) funnel through that one function, so there is a single
+enforcement point rather than three.
+
+**Documented, with the caveat that matters.** Enforcement is **per context, not
+per key id**: holding a context authorizes every key in it. A signer acting for
+several identities therefore needs a context *each* — putting several
+identities' keys in one context and scoping the caller to it authorizes all of
+them. `signable_keys` gives per-key narrowing but is opt-in policy an operator
+must write. New §"What authorizes a sign request" in
+`docs/02-vta/integration-guide.md`; the SDK field comment now states the
+guarantee and points there instead of implying it.
+
+**Two of the three layers had no regression test** — the two the declined
+proposal actually rests on. Added
+`sign_payload_refuses_a_key_outside_the_callers_contexts` and
+`sign_payload_restricts_unscoped_keys_to_super_admin`; both verified to fail
+when their check is removed.
+
 ### vta-sdk 0.20.3 — transport discovery is testable without a live VTA
 
 `resolve_vta_endpoint` built its `DIDCacheClient` from the environment, so a
@@ -28,6 +69,7 @@ deployment's shape) reports both in preference order; a DIDComm-only VTA reports
 no TSP; a TSP-only VTA does not fall back to a REST URL synthesized from its own
 domain; and a `#tsp` entry carrying a URL instead of a mediator DID is ignored
 rather than routed through.
+
 
 ### vtc-service 0.11.33 — the raw-byte website endpoints stop pretending to be Trust Tasks
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10269,7 +10269,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.20.3"
+version = "0.20.4"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10331,7 +10331,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.12.40"
+version = "0.12.41"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/docs/02-vta/integration-guide.md
+++ b/docs/02-vta/integration-guide.md
@@ -240,6 +240,42 @@ GET /keys/<key_id>/secret
 Authorization: Bearer <token>
 ```
 
+### What authorizes a sign request
+
+The VTA **does not inspect what it signs** — `POST /keys/{key_id}/sign` signs
+the bytes you hand it. What stops a caller signing as something it isn't is
+therefore entirely *which keys it may name*, and that is enforced. A sign
+request passes three gates, in order:
+
+1. **The caller's context scope.** If the key carries a `context_id`, the
+   caller must be authorized in that context (or an ancestor of it). A caller
+   scoped to `domain-b` naming a key in `domain-a` is refused `403`.
+2. **The key's context policy.** `signable_keys` on the context restricts which
+   key ids may be used for signing at all. This is *resource-bound*: it
+   constrains the key's context **regardless of the actor, including a
+   super-admin**. An operator relaxes it through policy CRUD, never by holding
+   a bigger role. `quota_for("sign")` applies a daily cap the same way.
+3. **Unscoped keys are super-admin only.** A key with no `context_id` has no
+   context and therefore no policy to constrain it, so the role floor is the
+   only guardrail — non-super-admin callers are refused.
+
+The same three gates apply on **every** transport: REST, the DIDComm
+`key-management/1.0/sign-request` protocol, and the `keys/sign` Trust Task all
+funnel through one enforcement point (`operations::keys::sign_payload`).
+
+> **Granularity: per context, not per key id.** Gate 1 authorizes a caller for
+> *every* key in a context they hold. If one credential signs for several
+> domains, give **each domain its own context** — putting several domains' keys
+> in one context and scoping the caller to it authorizes all of them. Gate 2
+> (`signable_keys`) gives per-key narrowing, but it is opt-in policy an operator
+> must write; it is not the default.
+
+This is the property that makes a multi-tenant signer safe without the VTA
+understanding the payload. Pinned by
+`sign_payload_refuses_a_key_outside_the_callers_contexts`,
+`sign_payload_restricts_unscoped_keys_to_super_admin`, and
+`sign_payload_honours_context_policy_signable_keys`.
+
 ### Context Operations
 
 ```
@@ -270,7 +306,9 @@ complete API reference.
    - **Reader** — for services that only need to read keys and config
    - **Application** — for services that need to sign or write to cache
    - **Admin** — only for services that manage keys and DIDs
-   Avoid sharing admin credentials across services.
+   Avoid sharing admin credentials across services. For a signer that acts for
+   several identities, the context boundary *is* the security boundary — see
+   [What authorizes a sign request](#what-authorizes-a-sign-request).
 
 4. **Prefer server-side signing** — Use `POST /keys/{id}/sign` instead of
    exporting private keys when possible. This keeps keys inside the VTA's

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.20.3"
+version = "0.20.4"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/protocols/key_management/sign.rs
+++ b/vta-sdk/src/protocols/key_management/sign.rs
@@ -15,7 +15,21 @@ pub enum SignAlgorithm {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct SignRequestBody {
-    /// Key ID to sign with (must be an active key the caller has access to).
+    /// Key ID to sign with. Must be **active**, and the consumer enforces the
+    /// caller's authority over it — this is not merely a caller-side
+    /// precondition.
+    ///
+    /// Because the VTA signs the bytes it is given without inspecting them,
+    /// *which keys a caller may name* is the whole of the authorization story,
+    /// so callers reasoning about identity separation depend on it. The
+    /// guarantee, in order: the caller must be authorized in the key's context;
+    /// the context's `signable_keys` policy must permit the key (binding even a
+    /// super-admin); and a key with no context is super-admin-only.
+    ///
+    /// **Scoped per context, not per key id** — holding a context authorizes
+    /// every key in it, so a signer acting for several identities needs a
+    /// context each. See `docs/02-vta/integration-guide.md` §"What authorizes a
+    /// sign request".
     pub key_id: String,
     /// Base64url-encoded payload bytes to sign.
     pub payload: String,

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.12.40"
+version = "0.12.41"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/operations/keys.rs
+++ b/vta-service/src/operations/keys.rs
@@ -1827,6 +1827,212 @@ mod tests {
         .expect("policy permits allowed-key");
     }
 
+    /// A caller authorized in one context cannot sign with another context's
+    /// key (#805).
+    ///
+    /// This is the property a declined proposal rests on. The VTA does not
+    /// inspect what it signs, so "a multi-domain signer cannot sign as a domain
+    /// it does not hold" is true *only* because the caller's context scope is
+    /// checked against the key's. If this regressed, a compromised gateway
+    /// holding one domain's session could sign as any domain whose key id it
+    /// could name — and nothing about the request would look wrong.
+    ///
+    /// Note the granularity being pinned: **per context, not per key id**. A
+    /// caller scoped to a context may sign with *every* key in it. Per-key
+    /// narrowing exists (`signable_keys`, covered above) but is opt-in policy;
+    /// separation between domains comes from giving each its own context.
+    #[tokio::test]
+    async fn sign_payload_refuses_a_key_outside_the_callers_contexts() {
+        use crate::contexts::{ContextRecord, store_context};
+        use vta_sdk::context_policy::ContextPolicy;
+
+        let h = TestHarness::new().await;
+        let admin = h.super_admin_auth();
+
+        // Two tenant contexts, both with an unrestricted policy — so the only
+        // thing that can refuse below is the caller's context scope, not the
+        // `signable_keys` guardrail (which has its own test above).
+        let now = chrono::Utc::now();
+        for (idx, id) in [(21u32, "domain-a"), (22, "domain-b")] {
+            store_context(
+                &h.contexts_ks,
+                &ContextRecord {
+                    id: id.into(),
+                    name: id.into(),
+                    did: None,
+                    description: None,
+                    parent: None,
+                    base_path: format!("m/26'/2'/{idx}'"),
+                    index: idx,
+                    created_at: now,
+                    updated_at: now,
+                    context_policy: Some(ContextPolicy::unrestricted()),
+                },
+            )
+            .await
+            .unwrap_or_else(|e| panic!("store {id}: {e:?}"));
+        }
+
+        let key = create_key(
+            &h.keys_ks,
+            &h.contexts_ks,
+            &h.seed_store,
+            &h.audit_ks,
+            &admin,
+            CreateKeyParams {
+                key_type: KeyType::Ed25519,
+                derivation_path: None,
+                key_id: Some("domain-a-key".into()),
+                mnemonic: None,
+                label: None,
+                context_id: Some("domain-a".into()),
+            },
+            "test",
+        )
+        .await
+        .expect("create domain-a-key");
+
+        // Authorized in `domain-b` only — a different tenant of the same VTA.
+        let other_tenant = AuthClaims {
+            did: "did:key:z6MkDomainB".to_string(),
+            role: Role::Admin,
+            allowed_contexts: vec!["domain-b".to_string()],
+            session_id: "test-session".into(),
+            access_expires_at: 0,
+            amr: Vec::new(),
+            acr: String::new(),
+        };
+
+        let denied = sign_payload(
+            &h.keys_ks,
+            &h.imported_ks,
+            &h.contexts_ks,
+            &h.seed_store,
+            &other_tenant,
+            &key.key_id,
+            b"payload",
+            &SignAlgorithm::EdDSA,
+            "test",
+        )
+        .await;
+        assert!(
+            matches!(denied, Err(crate::error::AppError::Forbidden(_))),
+            "signing another context's key must be Forbidden, got {denied:?}"
+        );
+
+        // ...and the same caller signs fine once the key is in *their* context,
+        // so the refusal above is the scope check and not an unrelated failure.
+        let own = create_key(
+            &h.keys_ks,
+            &h.contexts_ks,
+            &h.seed_store,
+            &h.audit_ks,
+            &admin,
+            CreateKeyParams {
+                key_type: KeyType::Ed25519,
+                derivation_path: None,
+                key_id: Some("domain-b-key".into()),
+                mnemonic: None,
+                label: None,
+                context_id: Some("domain-b".into()),
+            },
+            "test",
+        )
+        .await
+        .expect("create domain-b-key");
+        sign_payload(
+            &h.keys_ks,
+            &h.imported_ks,
+            &h.contexts_ks,
+            &h.seed_store,
+            &other_tenant,
+            &own.key_id,
+            b"payload",
+            &SignAlgorithm::EdDSA,
+            "test",
+        )
+        .await
+        .expect("a caller signs with a key in their own context");
+    }
+
+    /// An **unscoped** key (no `context_id`) is super-admin-only (#805).
+    ///
+    /// Such a key has no context, so it has no context policy to constrain it —
+    /// the resource-bound guardrail that binds even a super-admin simply does
+    /// not apply. That makes the role floor the only thing standing between a
+    /// scoped caller and an unconstrained signer, which is why it is asserted
+    /// rather than assumed.
+    #[tokio::test]
+    async fn sign_payload_restricts_unscoped_keys_to_super_admin() {
+        let h = TestHarness::new().await;
+        let admin = h.super_admin_auth();
+
+        let key = create_key(
+            &h.keys_ks,
+            &h.contexts_ks,
+            &h.seed_store,
+            &h.audit_ks,
+            &admin,
+            CreateKeyParams {
+                key_type: KeyType::Ed25519,
+                derivation_path: Some("m/26'/2'/99'/0'".into()),
+                key_id: Some("unscoped-key".into()),
+                mnemonic: None,
+                label: None,
+                // No context — hence the explicit path (a context would
+                // otherwise supply its own base path).
+                context_id: None,
+            },
+            "test",
+        )
+        .await
+        .expect("create unscoped-key");
+
+        // A context-scoped admin is *not* a super-admin (its list is non-empty),
+        // so it is refused — the `ActScope` distinction, not a role comparison.
+        let scoped = AuthClaims {
+            did: "did:key:z6MkScopedStaff".to_string(),
+            role: Role::Admin,
+            allowed_contexts: vec!["some-ctx".to_string()],
+            session_id: "test-session".into(),
+            access_expires_at: 0,
+            amr: Vec::new(),
+            acr: String::new(),
+        };
+        assert!(!scoped.is_super_admin());
+
+        let denied = sign_payload(
+            &h.keys_ks,
+            &h.imported_ks,
+            &h.contexts_ks,
+            &h.seed_store,
+            &scoped,
+            &key.key_id,
+            b"payload",
+            &SignAlgorithm::EdDSA,
+            "test",
+        )
+        .await;
+        assert!(
+            matches!(denied, Err(crate::error::AppError::Forbidden(_))),
+            "a scoped caller must not sign with an unscoped key, got {denied:?}"
+        );
+
+        sign_payload(
+            &h.keys_ks,
+            &h.imported_ks,
+            &h.contexts_ks,
+            &h.seed_store,
+            &admin,
+            &key.key_id,
+            b"payload",
+            &SignAlgorithm::EdDSA,
+            "test",
+        )
+        .await
+        .expect("super-admin may use an unscoped key");
+    }
+
     /// Regression test for the missing role floor on `get_key` /
     /// `list_keys`. A Monitor-role caller (intended for metrics +
     /// health endpoints only) must not be able to read key records,


### PR DESCRIPTION
Answers #805.

## The question

`SignRequestBody.key_id` was documented as *"must be an active key the caller has access to"*. A companion proposal (have the VTA issue attestations rather than blind-sign supplied bytes) was **declined** partly because per-key scoping was thought to already deliver the identity property. But that was read off the SDK's API contract, not observed in the service — and Cierge's gateway now signs as multiple domains through one VTA session, which is exactly where it matters.

## The answer: yes, enforced — and more strictly than the comment implied

`operations::keys::sign_payload` (`vta-service/src/operations/keys.rs:839-861`) applies three gates:

1. **The caller's context scope** — `auth.require_context(ctx)?` on the key's `context_id`, routed through `ActScope` (the guard `CLAUDE.md` flags as the one people get backwards, so it is the right mechanism rather than an ad-hoc `is_empty()` check).
2. **The key's context policy** — `signable_keys` is *resource-bound*: it constrains the key's context **regardless of the actor, including a super-admin**. That is what lets a fleet- or VTC-pushed policy bind every signer; the owner relaxes it via policy CRUD, never by holding a bigger role.
3. **Unscoped keys are super-admin only** — a key with no `context_id` has no context and therefore no policy to constrain it, so the role floor is the only guardrail left.

All three transports — REST `POST /keys/{key_id}/sign`, DIDComm `key-management/1.0/sign-request`, and the `keys/sign` Trust Task — funnel through that single function. One enforcement point, not three.

**So the reasoning that declined V1 holds.** Scope a multi-domain caller to specific keys and it cannot sign as a domain it does not hold.

## The caveat worth knowing (issue ask #2)

**Enforcement is per *context*, not per *key id*.** Holding a context authorizes **every** key in it.

A signer acting for several identities therefore needs **a context each**. Putting several domains' keys in one context and scoping the caller to that context authorizes all of them — and nothing about the resulting sign request would look wrong. `signable_keys` (gate 2) does give per-key narrowing, but it is opt-in policy an operator must write; it is not the default.

That distinction was stated nowhere, and it is precisely the misconfiguration that would silently void the guarantee. It is now documented.

## What changed

- **`docs/02-vta/integration-guide.md`** — new §"What authorizes a sign request": the three gates, the all-transports note, and the per-context caveat called out as a block quote. Best-practice item 3 links to it.
- **`vta-sdk/src/protocols/key_management/sign.rs`** — the field comment now states the guarantee and points at the doc, instead of implying it in passing.
- **Two regression tests**, because two of the three layers had none — and they were the two the declined proposal actually rests on:
  - `sign_payload_refuses_a_key_outside_the_callers_contexts` (gate 1)
  - `sign_payload_restricts_unscoped_keys_to_super_admin` (gate 3)

  Gate 2 was already covered by `sign_payload_honours_context_policy_signable_keys`.

## On the tests being real

Both new tests were verified by removing the check they pin and confirming they fail.

Worth recording: **my first attempt at that verification was wrong.** `auth.require_context(ctx)?;` appears seven times in the file, so a `replace(..., 1)` mutation hit a different function entirely — the check under test was untouched and the test passed, which I nearly read as "defence in depth" rather than "bad mutation". Redoing it by line number showed the test does fail. Anyone re-verifying should mutate by line, not by string.

## Verification

- `vta-service` lib: 685 tests pass, 0 fail.
- `cargo clippy --workspace -- -D warnings` (CI's exact command) clean; `cargo fmt --check` clean.
- `vta-sdk` patch bump 0.20.2 → 0.20.3 keeps the `[patch.crates-io]` self-pin valid (a *minor* bump is what breaks it).

## Residual, unaddressed

The declined V1 also covered timestamp and claim-shape control (backdating, TTL extension). Per-key scoping does not address that, and this PR does not change it — that residual stands.
