### PR TITLE
fix(ci): stop the release guards passing vacuously from a symlinked path

### DIFF
--- a/scripts/check-changelogs.sh
+++ b/scripts/check-changelogs.sh
@@ -29,7 +29,11 @@ set -euo pipefail
 
 BASE="${1:-origin/main}"
 
-ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# `pwd -P` (physical path), not `pwd`: `cargo metadata` reports symlink-resolved
+# manifest paths, and ROOT is used to strip that prefix. On macOS a worktree
+# under /tmp (a symlink to /private/tmp) made the two disagree, so the prefix
+# never matched, every file failed attribution, and the guard passed vacuously.
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 cd "$ROOT"
 
 if [ -t 1 ]; then
@@ -66,6 +70,18 @@ crates=$(cargo metadata --format-version 1 --no-deps 2>/dev/null \
       | select(.publish == null or .publish == ["crates.io"])
       | "\(.name)\t\(.manifest_path)"' \
   | sed "s|\t$ROOT/|\t|; s|/Cargo.toml\$||")
+
+# Guard the guard. Every dir above must now be workspace-relative; an absolute one
+# means the ROOT prefix did not strip, so every changed file fails attribution and
+# this script reports "nothing to check" and exits 0 — passing vacuously on a PR it
+# should have failed. That is the worst outcome available to a release guard, so it
+# fails loudly instead of silently.
+if printf '%s\n' "$crates" | cut -f3 | grep -q '^/'; then
+  echo "${RED}error:${NC} crate paths did not resolve relative to $ROOT." >&2
+  echo "Cannot attribute changed files; refusing to pass without checking." >&2
+  printf '%s\n' "$crates" | cut -f3 | grep '^/' | head -3 | sed 's/^/  /' >&2
+  exit 2
+fi
 
 version_of() {
   awk '/^\[/{ in_pkg = ($0 == "[package]") } in_pkg && /^version = / { gsub(/^version = "|"$/, ""); print; exit }'

--- a/scripts/check-lockfile-self-pins.sh
+++ b/scripts/check-lockfile-self-pins.sh
@@ -83,7 +83,11 @@
 # Portable to macOS bash 3.2 / BSD userland.
 set -euo pipefail
 
-ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# `pwd -P` (physical path), not `pwd`: `cargo metadata` reports symlink-resolved
+# manifest paths, and ROOT is used to strip that prefix. On macOS a worktree
+# under /tmp (a symlink to /private/tmp) made the two disagree, so the prefix
+# never matched, every file failed attribution, and the guard passed vacuously.
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 cd "$ROOT"
 
 if [ -t 1 ]; then

--- a/scripts/check-version-bumps.sh
+++ b/scripts/check-version-bumps.sh
@@ -32,7 +32,11 @@ set -euo pipefail
 
 BASE="${1:-origin/main}"
 
-ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# `pwd -P` (physical path), not `pwd`: `cargo metadata` reports symlink-resolved
+# manifest paths, and ROOT is used to strip that prefix. On macOS a worktree
+# under /tmp (a symlink to /private/tmp) made the two disagree, so the prefix
+# never matched, every file failed attribution, and the guard passed vacuously.
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 cd "$ROOT"
 
 if [ -t 1 ]; then
@@ -70,6 +74,18 @@ crates=$(cargo metadata --format-version 1 --no-deps 2>/dev/null \
   | awk -F'\t' '{ print length($3)"\t"$0 }' \
   | sort -rn \
   | cut -f2-)
+
+# Guard the guard. Every dir above must now be workspace-relative; an absolute one
+# means the ROOT prefix did not strip, so every changed file fails attribution and
+# this script reports "nothing to check" and exits 0 — passing vacuously on a PR it
+# should have failed. That is the worst outcome available to a release guard, so it
+# fails loudly instead of silently.
+if printf '%s\n' "$crates" | cut -f3 | grep -q '^/'; then
+  echo "${RED}error:${NC} crate paths did not resolve relative to $ROOT." >&2
+  echo "Cannot attribute changed files; refusing to pass without checking." >&2
+  printf '%s\n' "$crates" | cut -f3 | grep '^/' | head -3 | sed 's/^/  /' >&2
+  exit 2
+fi
 
 # classify a path (relative to a crate dir) as source-or-not
 is_source() {


### PR DESCRIPTION
Found while working on #813, where both guards told me "nothing to check" on a PR that definitely changed crate source.

## The bug

`check-version-bumps.sh` and `check-changelogs.sh` strip `$ROOT/` from the manifest paths `cargo metadata` reports, to attribute each changed file to its crate. `ROOT` came from `pwd`, which **preserves** symlinks; `cargo metadata` reports the **physical** path.

On macOS a git worktree under `/tmp` (a symlink to `/private/tmp`) makes the two disagree. The prefix never matches, every crate dir stays absolute, every changed file fails attribution, and the script reports *"No publishable-crate source changed — nothing to check"* and **exits 0**.

Reproduced on `64497b5b` — an unbumped edit to `vta-sdk/src/vp.rs`:

```
/private/tmp/vti-guard-fix -> exit 1   ← correctly fails
/tmp/vti-guard-fix         -> exit 0   ← silently passes
```

Same commit, same guard, opposite answers.

**CI is not affected** — it checks out a normal path. But anyone using a `/tmp` worktree gets a green guard that checked nothing, which is worse than no guard, because it reads as confirmation.

## The fix

- **`pwd -P`** so `ROOT` is the physical path `cargo metadata` reports. Applied to `check-lockfile-self-pins.sh` too: it doesn't strip paths today so it was unaffected, but it derives `ROOT` the same way and shouldn't acquire the bug later.

- **A guard-the-guard** in both attributing scripts: if any crate dir is still absolute after the strip, exit 2 rather than continue. `pwd -P` closes the cause known today; this closes the *class*. The failure mode being fixed is **silence**, so the fix should not depend on having anticipated every way the prefix can mismatch.

## Verification

- From the previously-broken `/tmp` path, the version-bump guard now **exits 1** on an unbumped source change (was 0). Both paths agree.
- All three guards still **exit 0 on a clean tree** from both paths — no false positives.
- The assertion was exercised directly against crafted input: fires on absolute dirs, passes relative ones. An untested error path is how you get a guard that doesn't guard.
- This PR touches only `scripts/`, so the guards correctly report "nothing to check" — and since a *vacuous* pass would now exit 2, exit 0 confirms it's a genuine one. The fix validates itself.

No shell linter in CI and `shellcheck` isn't available locally, so the scripts were checked with `bash -n` only.
