### PR TITLE
fix(vta-service): Nitro enclave attestation + did:webvh persistence

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,9 @@ docs/
 *.md
 !README.md
 .claude/
+# Keep enclave signing keys and Nitro runtime state out of the build context.
+# The Nitro build uses selective per-crate COPYs, but excluding these avoids
+# shipping private keys / large EIF artifacts to the Docker daemon.
+signing/
+.deploy-nitro/
+*.txt

--- a/Dockerfile.nitro
+++ b/Dockerfile.nitro
@@ -10,13 +10,15 @@
 #   nitro-cli build-enclave --docker-uri vta-nitro --output-file vta.eif
 #
 # Networking: Nitro Enclaves have NO direct network access. The entrypoint
-# starts socat-based vsock proxies inside the enclave to bridge TCP↔vsock.
-# The parent EC2 instance runs parent-proxy.sh to bridge vsock↔internet.
+# starts socat-based vsock proxies inside the enclave to bridge TCP<->vsock.
+# The parent EC2 instance runs parent-proxy.sh to bridge vsock<->internet.
 #
-# Architecture:
-#   Client → parent TCP:8443 → vsock:5100 → enclave socat → VTA :8100
-#   VTA DIDComm → localhost:4443 → enclave socat → vsock:5200 → parent → mediator
-#   VTA HTTPS   → localhost:4444 → enclave socat → vsock:5300 → parent → internet
+# CACHING NOTE: config.toml is copied ONLY in Stage 2 (runtime), so editing
+# deploy/nitro/config.toml re-layers just the tiny Alpine stage and does NOT
+# invalidate the Rust build. Stage 1 copies the workspace crates explicitly
+# (never `COPY . .`) so deploy/ never enters the compile layer, and the
+# manifest list below covers ALL workspace members so the dependency-cache
+# warm-up build actually succeeds.
 # =============================================================================
 
 # ---------------------------------------------------------------------------
@@ -31,30 +33,59 @@ RUN apt-get update && \
 
 WORKDIR /build
 
-# Cache dependency builds: copy manifests first, create dummy sources, build deps
+# Cache dependency builds: copy manifests first, create dummy sources, build deps.
+# This must list EVERY workspace member from the root Cargo.toml [workspace].members
+# or `cargo build` fails workspace resolution (and the `|| true` below silently
+# swallows it, giving you a full-from-scratch dep rebuild every time).
 COPY Cargo.toml Cargo.lock ./
+COPY cnm-cli/Cargo.toml cnm-cli/Cargo.toml
+COPY didcomm-test/Cargo.toml didcomm-test/Cargo.toml
+COPY pnm-cli/Cargo.toml pnm-cli/Cargo.toml
+COPY tests/e2e/Cargo.toml tests/e2e/Cargo.toml
+COPY vta-cli-common/Cargo.toml vta-cli-common/Cargo.toml
+COPY vta-mcp/Cargo.toml vta-mcp/Cargo.toml
+COPY vta-mobile-core/Cargo.toml vta-mobile-core/Cargo.toml
 COPY vta-sdk/Cargo.toml vta-sdk/Cargo.toml
 COPY vta-service/Cargo.toml vta-service/Cargo.toml
 COPY vta-enclave/Cargo.toml vta-enclave/Cargo.toml
-COPY vta-cli-common/Cargo.toml vta-cli-common/Cargo.toml
+COPY vtc-client/Cargo.toml vtc-client/Cargo.toml
 COPY vtc-service/Cargo.toml vtc-service/Cargo.toml
 COPY vti-common/Cargo.toml vti-common/Cargo.toml
-COPY cnm-cli/Cargo.toml cnm-cli/Cargo.toml
-COPY pnm-cli/Cargo.toml pnm-cli/Cargo.toml
-COPY didcomm-test/Cargo.toml didcomm-test/Cargo.toml
+COPY vti-secrets/Cargo.toml vti-secrets/Cargo.toml
+COPY vti-webauthn/Cargo.toml vti-webauthn/Cargo.toml
 
-# Create dummy source files so cargo can resolve the workspace
-RUN mkdir -p vta-sdk/src vta-service/src vta-enclave/src vta-cli-common/src vtc-service/src vti-common/src cnm-cli/src pnm-cli/src didcomm-test/src && \
-    echo "pub fn dummy() {}" > vta-sdk/src/lib.rs && \
-    echo "pub fn dummy() {}" > vta-service/src/lib.rs && \
-    echo "fn main() {}" > vta-service/src/main.rs && \
-    echo "fn main() {}" > vta-enclave/src/main.rs && \
-    echo "pub fn dummy() {}" > vta-cli-common/src/lib.rs && \
-    echo "fn main() {}" > vtc-service/src/main.rs && \
-    echo "pub fn dummy() {}" > vti-common/src/lib.rs && \
-    echo "fn main() {}" > cnm-cli/src/main.rs && \
-    echo "fn main() {}" > pnm-cli/src/main.rs && \
-    echo "fn main() {}" > didcomm-test/src/main.rs
+# Create dummy source files so cargo can resolve + dep-build the workspace.
+# Target kind (bin vs lib) must match each crate's manifest:
+#   bins  (src/main.rs):  cnm-cli, didcomm-test, pnm-cli, vta-mcp, vta-enclave
+#   libs  (src/lib.rs):   vta-cli-common, vta-sdk, vtc-client, vti-common,
+#                         vti-secrets, vti-webauthn
+#   both:                 vta-service, vtc-service
+#   lib + custom bin:     vta-mobile-core (uniffi-bindgen)
+#   no targets:           tests/e2e (autobins=false, integration tests only)
+RUN mkdir -p \
+      cnm-cli/src didcomm-test/src pnm-cli/src \
+      vta-cli-common/src vta-mcp/src \
+      vta-mobile-core/src vta-mobile-core/src/bin \
+      vta-sdk/src vta-service/src vta-enclave/src \
+      vtc-client/src vtc-service/src \
+      vti-common/src vti-secrets/src vti-webauthn/src && \
+    echo "fn main() {}"       > cnm-cli/src/main.rs && \
+    echo "fn main() {}"       > didcomm-test/src/main.rs && \
+    echo "fn main() {}"       > pnm-cli/src/main.rs && \
+    echo "fn main() {}"       > vta-mcp/src/main.rs && \
+    echo "fn main() {}"       > vta-enclave/src/main.rs && \
+    echo "pub fn dummy() {}"  > vta-cli-common/src/lib.rs && \
+    echo "pub fn dummy() {}"  > vta-sdk/src/lib.rs && \
+    echo "pub fn dummy() {}"  > vtc-client/src/lib.rs && \
+    echo "pub fn dummy() {}"  > vti-common/src/lib.rs && \
+    echo "pub fn dummy() {}"  > vti-secrets/src/lib.rs && \
+    echo "pub fn dummy() {}"  > vti-webauthn/src/lib.rs && \
+    echo "pub fn dummy() {}"  > vta-service/src/lib.rs && \
+    echo "fn main() {}"       > vta-service/src/main.rs && \
+    echo "pub fn dummy() {}"  > vtc-service/src/lib.rs && \
+    echo "fn main() {}"       > vtc-service/src/main.rs && \
+    echo "pub fn dummy() {}"  > vta-mobile-core/src/lib.rs && \
+    echo "fn main() {}"       > vta-mobile-core/src/bin/uniffi-bindgen.rs
 
 # Feature flags for the VTA enclave build.
 # Override with: docker build --build-arg FEATURES="didcomm,vsock-store" ...
@@ -65,28 +96,39 @@ RUN mkdir -p vta-sdk/src vta-service/src vta-enclave/src vta-cli-common/src vtc-
 #   REST only:                rest,vsock-store,vsock-log
 #
 # TEE support is built into vta-enclave by default (no need to specify tee).
-# KMS bootstrap handles seed and JWT key — no need for config-seed, keyring,
-# or aws-secrets features.
 ARG FEATURES="rest,didcomm,vsock-store,vsock-log"
 
-# Build dependencies only (cached unless Cargo.toml or features change)
+# Build dependencies only (cached unless Cargo.toml, Cargo.lock or features change)
 RUN cargo build --release --package vta-enclave \
     --no-default-features --features ${FEATURES} \
     2>/dev/null || true
 
-# Copy actual source code
+# Copy actual source code — every workspace member EXCEPT deploy/ (whose
+# config.toml is baked later in Stage 2). Never use `COPY . .` here: that would
+# pull deploy/nitro/config.toml into this layer and make every config edit
+# trigger a full Rust recompile.
+COPY cnm-cli/ cnm-cli/
+COPY didcomm-test/ didcomm-test/
+COPY pnm-cli/ pnm-cli/
+COPY tests/ tests/
+COPY vta-cli-common/ vta-cli-common/
+COPY vta-mcp/ vta-mcp/
+COPY vta-mobile-core/ vta-mobile-core/
 COPY vta-sdk/ vta-sdk/
 COPY vta-service/ vta-service/
 COPY vta-enclave/ vta-enclave/
-COPY vta-cli-common/ vta-cli-common/
+COPY vtc-client/ vtc-client/
 COPY vtc-service/ vtc-service/
 COPY vti-common/ vti-common/
-COPY cnm-cli/ cnm-cli/
-COPY pnm-cli/ pnm-cli/
-COPY didcomm-test/ didcomm-test/
+COPY vti-secrets/ vti-secrets/
+COPY vti-webauthn/ vti-webauthn/
 
-# Touch source files to invalidate the dummy build cache
-RUN find vta-sdk/src vta-service/src vta-enclave/src vta-cli-common/src vti-common/src -name '*.rs' -exec touch {} +
+# Touch source files to invalidate the dummy build cache so the real crates
+# (not the dummy stubs) get compiled.
+RUN find cnm-cli didcomm-test pnm-cli vta-cli-common vta-mcp vta-mobile-core \
+        vta-sdk vta-service vta-enclave vtc-client vtc-service \
+        vti-common vti-secrets vti-webauthn \
+        -name '*.rs' -exec touch {} +
 
 # Build the VTA enclave binary with selected feature flags
 RUN cargo build --release --package vta-enclave \
@@ -119,7 +161,9 @@ COPY --from=builder /build/target/release/vta-enclave /usr/local/bin/vta-enclave
 COPY --from=builder /tmp/libresolv_compat.so /usr/lib/libresolv_compat.so
 ENV LD_PRELOAD=/usr/lib/libresolv_compat.so
 
-# Copy the entrypoint script and config
+# Copy the entrypoint script and config.
+# config.toml is baked HERE (Stage 2) on purpose: editing it re-layers only
+# this tiny Alpine stage, never the Rust build in Stage 1.
 COPY deploy/nitro/enclave-entrypoint.sh /usr/local/bin/enclave-entrypoint.sh
 RUN chmod +x /usr/local/bin/enclave-entrypoint.sh
 COPY deploy/nitro/config.toml /etc/vta/config.toml

--- a/vta-service/src/routes/protocol.rs
+++ b/vta-service/src/routes/protocol.rs
@@ -1355,6 +1355,7 @@ async fn try_run_first_enable_handshake(
     use crate::messaging::transient_handshake::{
         TransientHandshakeContext, run_transient_handshake,
     };
+    use affinidi_tdk::common::config::TDKConfig;
     use affinidi_tdk::secrets_resolver::SecretsResolver;
 
     let Some(secrets_resolver) = state.secrets_resolver.as_ref() else {
@@ -1385,11 +1386,36 @@ async fn try_run_first_enable_handshake(
         return Ok(());
     }
 
+    // The mediator handshake proves control of the VTA's OWN did:webvh by
+    // resolving it. For a serverless did:webvh the sidecar cannot fetch the
+    // document (it is not hosted anywhere), so resolution succeeds only from
+    // the resolver's local cache. That cache is seeded at boot but webvh is a
+    // mutable method and the entry expires after the cache TTL. Re-seed it now
+    // so enable works regardless of how long the VTA has been running.
+    #[cfg(feature = "webvh")]
+    {
+        let mut reseed = resolver.clone();
+        crate::server::preload_self_did_document(&mut reseed, &vta_did, Some(&state.webvh_ks))
+            .await;
+    }
+
+    // The transient handshake spins up its own TDK/ATM to trust-ping the new
+    // mediator. It MUST resolve DIDs through the VTA's own (network-mode)
+    // resolver: in a TEE that resolver is bridged to a parent-side sidecar,
+    // whereas a default TDK resolver resolves locally and has no enclave
+    // egress — so resolving the mediator DID would fail with a network error.
+    // Mirrors the resolver wiring in `messaging::service` and the auth ATM.
+    let tdk_config = TDKConfig::builder()
+        .with_did_resolver(resolver.clone())
+        .with_load_environment(false)
+        .build()
+        .ok();
+
     run_transient_handshake(
         TransientHandshakeContext {
             vta_did,
             secrets,
-            tdk_config: None,
+            tdk_config,
         },
         resolver,
         &state.telemetry,

--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -1819,7 +1819,7 @@ async fn init_auth(
 /// Best-effort and fail-safe: if local state is missing or malformed we warn and
 /// keep the last-known-good cache entry (never evict, never poison), falling back
 /// to normal resolver behaviour where none exists.
-async fn preload_self_did_document(
+pub(crate) async fn preload_self_did_document(
     did_resolver: &mut DIDCacheClient,
     vta_did: &str,
     webvh_ks: Option<&KeyspaceHandle>,

--- a/vta-service/src/tee/did_autogen.rs
+++ b/vta-service/src/tee/did_autogen.rs
@@ -26,6 +26,36 @@ use crate::store::{KeyspaceHandle, Store};
 /// Well-known store key for the auto-generated VTA DID.
 const VTA_DID_STORE_KEY: &str = "tee:vta_did";
 
+/// Build the `WebvhDidRecord` for the auto-generated serverless VTA DID.
+///
+/// `webvh_store` keys the record (`did:{did}`) and the log (`log:{did}`)
+/// separately. `list_services` (and did update/rotate ops) require the record
+/// via `webvh_store::get_did`; without it `GET /services` 500s with
+/// `VtaDidRecordMissing` even though the log resolves and
+/// `/.well-known/did.jsonl` serves fine. Mirrors the production
+/// `create_did_webvh` (final mode) builder: defensive defaults for the
+/// key-count fields — the next rotate/update re-scans the log and persists the
+/// corrected values. The SCID is the third colon-segment of a
+/// `did:webvh:{SCID}:{host}` identifier.
+#[cfg(feature = "webvh")]
+fn build_vta_webvh_record(did: &str) -> vta_sdk::webvh::WebvhDidRecord {
+    let scid = did.split(':').nth(2).unwrap_or_default().to_string();
+    let now = chrono::Utc::now();
+    vta_sdk::webvh::WebvhDidRecord {
+        did: did.to_string(),
+        server_id: "serverless".to_string(),
+        mnemonic: String::new(),
+        scid,
+        context_id: "vta".to_string(),
+        portable: true,
+        log_entry_count: 1,
+        pre_rotation_count: 0,
+        next_fragment_id: 1,
+        created_at: now,
+        updated_at: now,
+    }
+}
+
 /// Check for an existing DID in the store, or auto-generate one from the template.
 ///
 /// Sets `config.vta_did` on success (either from store or newly generated).
@@ -64,6 +94,23 @@ pub async fn maybe_generate_vta_did(
         let did = String::from_utf8(did_bytes)
             .map_err(|e| AppError::Internal(format!("corrupt stored VTA DID: {e}")))?;
         info!(did = %did, "restored VTA identity from encrypted store");
+
+        // Backfill the webvh DID *record* if an earlier build persisted only
+        // the log (`log:{did}`) but not the record (`did:{did}`). Idempotent:
+        // only writes when the record is absent, so a rebuild+reboot repairs
+        // `list_services` for an already-generated DID without wiping state
+        // (which would rotate the DID). See `build_vta_webvh_record`.
+        #[cfg(feature = "webvh")]
+        {
+            let webvh_ks = apply_enc(store.keyspace(crate::keyspaces::WEBVH)?);
+            if crate::webvh_store::get_did(&webvh_ks, &did).await?.is_none() {
+                let record = build_vta_webvh_record(&did);
+                crate::webvh_store::store_did(&webvh_ks, &record).await?;
+                store.persist().await?;
+                info!(did = %did, "backfilled missing webvh DID record on restore");
+            }
+        }
+
         config.vta_did = Some(did);
         return Ok(());
     }
@@ -240,6 +287,12 @@ pub async fn maybe_generate_vta_did(
     {
         let webvh_ks = apply_enc(store.keyspace(crate::keyspaces::WEBVH)?);
         crate::webvh_store::store_did_log(&webvh_ks, &final_did, &log_content).await?;
+
+        // Store the DID *record* alongside the log so `list_services` and did
+        // update/rotate ops can find it via `webvh_store::get_did`. See
+        // `build_vta_webvh_record`.
+        let did_record = build_vta_webvh_record(&final_did);
+        crate::webvh_store::store_did(&webvh_ks, &did_record).await?;
     }
 
     // Also store in bootstrap keyspace (no encryption) so the parent proxy

--- a/vta-service/src/tee/did_autogen.rs
+++ b/vta-service/src/tee/did_autogen.rs
@@ -230,6 +230,18 @@ pub async fn maybe_generate_vta_did(
         .insert_raw("tee:did_log", log_content.as_bytes().to_vec())
         .await?;
 
+    // Also store the did.jsonl in the WEBVH keyspace keyed by the DID. Both
+    // the public `/.well-known/did.jsonl` route (`serve_canonical`) and the
+    // internal self-DID resolver preload read via `webvh_store::get_did_log`,
+    // keyed by the DID — without this write the VTA's own did:webvh is
+    // unresolvable (well-known 404s, preload WARN fires) so no client can
+    // authcrypt to it. Feature-gated to match `webvh_store`.
+    #[cfg(feature = "webvh")]
+    {
+        let webvh_ks = apply_enc(store.keyspace(crate::keyspaces::WEBVH)?);
+        crate::webvh_store::store_did_log(&webvh_ks, &final_did, &log_content).await?;
+    }
+
     // Also store in bootstrap keyspace (no encryption) so the parent proxy
     // can read it and write did.jsonl to disk for the operator.
     let bootstrap_ks = store.keyspace(crate::keyspaces::BOOTSTRAP)?;

--- a/vta-service/src/tee/nitro.rs
+++ b/vta-service/src/tee/nitro.rs
@@ -213,10 +213,15 @@ fn nsm_ioctl(fd: std::os::unix::io::RawFd, request: &[u8]) -> Result<Vec<u8>, Ap
         response: NsmIoBuffer,
     }
 
+    // Mirrors the kernel `struct nsm_iovec { __u64 addr; __u64 len; }`.
+    // `len` MUST be u64: a u32 here leaves 4 bytes of uninitialized padding
+    // under #[repr(C)], which the kernel reads as the high bits of the 64-bit
+    // length — inflating it to a garbage value and failing the ioctl with
+    // EMSGSIZE (os error 90).
     #[repr(C)]
     struct NsmIoBuffer {
         addr: u64,
-        len: u32,
+        len: u64,
     }
 
     // NSM_IOCTL_REQUEST: _IOWR(0x0A, 0, struct nsm_message)
@@ -228,11 +233,11 @@ fn nsm_ioctl(fd: std::os::unix::io::RawFd, request: &[u8]) -> Result<Vec<u8>, Ap
     let mut msg = NsmMessage {
         request: NsmIoBuffer {
             addr: request.as_ptr() as u64,
-            len: request.len() as u32,
+            len: request.len() as u64,
         },
         response: NsmIoBuffer {
             addr: response_buf.as_mut_ptr() as u64,
-            len: response_buf.len() as u32,
+            len: response_buf.len() as u64,
         },
     };
 


### PR DESCRIPTION
## Summary

Fixes required to run the VTA signing service inside an AWS Nitro Enclave, plus
`did:webvh` log-persistence correctness fixes so a service keeps its identity
across restarts.

## Changes

**Enclave attestation**
- Fix the NSM ioctl request encoding: the length field passed to the Nitro
  Security Module ioctl must be a `u64`, not a `u32`. The wrong width corrupted
  the request struct on aarch64 and caused attestation calls to fail.

**did:webvh persistence**
- Persist the auto-generated `did:webvh` log to the webvh keyspace so the DID
  document history survives restarts.
- Persist the auto-generated `did:webvh` record and backfill it on restore, so a
  restored instance keeps its identity.
- Resolve the service's own DID via the network-mode resolver during the first
  enable handshake, instead of a resolver path that isn't available at that point.

**Deploy / build**
- Exclude signing keys and enclave runtime state from the Docker build context.
- Restore per-crate `COPY` layering + the full workspace manifest list for better
  build-cache reuse.

## Testing

Built and run inside the enclave: attestation succeeds and the DID persists
across restarts.

---
Opened as a **draft** for review/visibility.
