### PR TITLE
test(vtc): close the unpublished Trust Task manifest backlog (#709)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 ## Unreleased
 
+### VTC Trust Tasks — the unpublished-manifest backlog is closed (#709)
+
+`vtc-service/tests/trust_task_manifest.rs` carried twenty `UNPUBLISHED_OK`
+exceptions: task URIs the router enforced that `trust-tasks/index.json` never
+published. The table is now empty — but **not** because twenty specs were
+authored into that manifest. Every one of those tasks was resolved by the #710
+migration (#806 / #809 / #811 / #812 and predecessors): they now bind canonical
+`https://trusttasks.org/spec/vtc/<slug>` URIs published by the upstream
+registry, verified against `trust_tasks_rs` by
+`every_bound_vtc_task_exists_in_the_registry`. Nothing in the workspace binds
+any of the twenty on the old authority any more.
+
+The table stays in place, empty, because the assertion behind it still is: a
+new `openvtc/vtc/` binding with no manifest row fails rather than silently
+reopening the backlog.
+
+**The manifest's own description was false and now says so.** It claimed to be
+the "source of truth for trusttasks.org publication" with "CI publishes Draft
+entries on every merge to main per spec §9.4". No CI job has ever read
+`trust-tasks/index.json` — that pipeline was never built. The description now
+records what the file actually is: a historical record of the retired
+`openvtc/vtc` authority, 60 entries retired and 6 awaiting a canonical fold.
+
 ### vta-sdk 0.20.4 / vta-service 0.12.41 — the signing oracle's authorization model is a documented guarantee (#805)
 
 The VTA signs the bytes it is handed without inspecting them, so *which keys a

--- a/trust-tasks/index.json
+++ b/trust-tasks/index.json
@@ -3,7 +3,7 @@
   "version": 1,
   "org": "openvtc",
   "domain": "vtc",
-  "description": "OpenVTC Verifiable Trust Community — Trust Task manifest. Source of truth for trusttasks.org publication; CI publishes Draft entries on every merge to main per spec §9.4.",
+  "description": "OpenVTC Verifiable Trust Community — Trust Task manifest for the retired openvtc/vtc authority. Historical record, not a publication pipeline: no CI job has ever read this file (an earlier description claimed one did, per spec §9.4 — it did not exist). The live VTC surface binds canonical https://trusttasks.org/spec/vtc/<slug> tasks published by the upstream registry; the entries here are retired, or awaiting a canonical fold. See docs/05-design-notes/vtc-trust-task-registry-migration.md.",
   "tasks": [
     {
       "id": "https://trusttasks.org/openvtc/vtc/auth/legacy/challenge/1.0",

--- a/vtc-service/tests/trust_task_manifest.rs
+++ b/vtc-service/tests/trust_task_manifest.rs
@@ -1,10 +1,12 @@
 //! Census: `trust-tasks/index.json` must agree with what the router
 //! actually enforces (#537 follow-up).
 //!
-//! The manifest is the publication source of truth for trusttasks.org.
-//! Nothing previously checked it against the code, so it drifted in both
-//! directions: entries for tasks no route binds, and live routes the
-//! manifest never published.
+//! The manifest describes the **retired** `openvtc/vtc` authority. Nothing
+//! previously checked it against the code, so it drifted in both directions:
+//! entries for tasks no route binds, and live routes the manifest never
+//! published. Publication now happens upstream, against canonical
+//! `spec/vtc/*` slugs — see [`every_bound_vtc_task_exists_in_the_registry`],
+//! which is the assertion that matters for anything shipping today.
 //!
 //! Task bindings are attached as tower layers (`tt` / `ttl` in
 //! `routes/mod.rs`), so a built `Router` cannot be enumerated for them.
@@ -56,40 +58,23 @@ const UNBOUND_OK: &[(&str, &str)] = &[
 
 /// Task URIs the code binds that the manifest does not publish.
 ///
-/// These are a real backlog, not a design choice: whole feature families
-/// shipped after the manifest was last reconciled. Publishing them needs
-/// a `spec.md` + `schema.json` per task, so it is tracked separately
-/// rather than fixed here. This table exists to stop the backlog growing.
-const UNPUBLISHED_OK: &[(&str, &str)] = &[
-    ("admin/invites/manage/1.0", "unpublished backlog"),
-    ("admin/invites/revoke/1.0", "unpublished backlog"),
-    ("auth/admin-session/1.0", "unpublished backlog"),
-    ("auth/recognise/challenge/1.0", "unpublished backlog"),
-    ("backup/export/1.0", "unpublished backlog"),
-    ("backup/import/1.0", "unpublished backlog"),
-    ("ceremonies/list/1.0", "unpublished backlog"),
-    ("directory/query/1.0", "unpublished backlog"),
-    ("invitations/issue/1.0", "unpublished backlog"),
-    ("invitations/revoke/1.0", "unpublished backlog"),
-    ("members/purge/1.0", "unpublished backlog"),
-    ("members/removed/1.0", "unpublished backlog"),
-    ("members/request-vmc/1.0", "unpublished backlog"),
-    ("members/self-remove-receipt/1.0", "unpublished backlog"),
-    ("recognition/check/1.0", "unpublished backlog"),
-    ("relationships/graph/1.0", "unpublished backlog"),
-    (
-        "spec/join-requests/submit-receipt/1.0",
-        "unpublished backlog",
-    ),
-    ("spec/members/request-vmc/1.0", "unpublished backlog"),
-    ("spec/members/vmc/1.0", "unpublished backlog"),
-    // Phase-0 mount collapse: the admin GET list reuses this slug, while
-    // the real wire task is `spec/join-requests/submit/1.0`.
-    (
-        "join-requests/submit/1.0",
-        "mount-collapse alias of spec/join-requests/submit/1.0",
-    ),
-];
+/// **Empty, and that is the finished state (#709).** This table once carried
+/// twenty entries — whole feature families that shipped after the manifest was
+/// last reconciled and were never published. None of them were resolved by
+/// authoring twenty specs into this manifest. They were resolved by the #710
+/// migration: every one of those tasks now binds a canonical
+/// `https://trusttasks.org/spec/vtc/<slug>` URI published by the upstream
+/// registry, which [`every_bound_vtc_task_exists_in_the_registry`] verifies
+/// against `trust_tasks_rs` rather than against anything local.
+///
+/// So the backlog did not get published here; the surface it described moved
+/// off this authority entirely. What is left on `openvtc/vtc/` is the four
+/// entries in [`AWAITING_CANONICAL_FOLD`], and all four *are* in the manifest.
+///
+/// The table stays (empty) because the assertion below is still load-bearing:
+/// a new `openvtc/vtc/` binding with no manifest row fails rather than
+/// silently reopening the backlog. Adding a row again is a deliberate act.
+const UNPUBLISHED_OK: &[(&str, &str)] = &[];
 
 fn workspace_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))


### PR DESCRIPTION
Closes #709.

## What #709 asked for

Twenty task URIs the VTC router enforced were absent from
`trust-tasks/index.json`, parked in the census test's `UNPUBLISHED_OK` table.
The issue's own completion criterion: *"As each family is published, delete its
row from `UNPUBLISHED_OK`. When the table is empty, this issue is done."*

## What actually resolved it

Not twenty specs authored into that manifest — the **#710 migration**. Every
one of the twenty now binds a canonical `https://trusttasks.org/spec/vtc/<slug>`
URI published by the upstream registry, verified against `trust_tasks_rs` by
`every_bound_vtc_task_exists_in_the_registry`. Measured across all four binding
sites (`vtc-service/src`, `vta-sdk/src`, `cnm-cli/src`,
`vtc-service/admin-ui/src`), **zero** of the twenty still touch the old
authority. The rows were dead exceptions holding a closed backlog open.

The table stays in place, empty. The assertion behind it is still load-bearing:
a new `openvtc/vtc/` binding with no manifest row fails rather than silently
reopening the backlog.

## The manifest's description was false

It claimed to be the *"source of truth for trusttasks.org publication"* with
*"CI publishes Draft entries on every merge to main per spec §9.4"*. No CI job
has ever read `trust-tasks/index.json` — that pipeline was never built, which
#709 itself flagged. The description now records what the file is: a historical
record of the retired `openvtc/vtc` authority, 60 entries retired and 6 awaiting
a canonical fold.

## The five `credential-exchange` directories

#709 also asked whether these were *"published or deleted"*, describing them as
in neither the manifest nor any binding. **That is no longer true and they
should not be deleted.** They carry conformant public-registry IDs
(`https://trusttasks.org/spec/credential-exchange/<verb>/1.0`) and are bound
live by `vta_sdk::protocols::credential_exchange`. They are absent from *this*
manifest correctly — it is scoped `org: openvtc, domain: vtc`, and these are
cross-domain canonical slugs that belong upstream. Follow-up filed separately;
nothing to change here.

## Verification

All 7 census tests pass:

```
test manifest_status_vocabulary_matches_spec ... ok
test every_manifest_entry_has_files_on_disk ... ok
test every_bound_vtc_task_exists_in_the_registry ... ok
test no_new_bindings_on_the_retired_authority ... ok
test every_bound_task_is_published_or_excepted ... ok
test retired_tasks_are_not_bound ... ok
test every_published_task_is_bound_or_excepted ... ok
```

No crate source changed (tests/ and workspace-root JSON only), so no version
bump — `check-version-bumps.sh` excludes `tests/` by convention.
