### PR TITLE
feat(acl): let an ACL listing say which direction its context filter reads (#822)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,64 @@
 
 ## Unreleased
 
+### vta-sdk 0.20.5 / vti-common 0.11.27 / vta-service 0.12.42 / vta-cli-common 0.10.16 / pnm-cli 0.11.11 / cnm-cli 0.11.10 — ACL listings can be asked which direction a context filter reads (#822)
+
+`GET /acl?context=X` answers "who may act **in** X" — entries scoped to X or to
+an ancestor of it. That is correct, and it is one of two questions a context id
+raises, because a context id names a subtree. The other — "what is granted
+**beneath** X" — had no way to be asked, and asking it with the act-in filter
+returns precisely the entries that are *not* the answer: the ancestors keeping
+their authority, with every leaf-scoped grant omitted. Short, not empty, so it
+reads as complete.
+
+That bites on revocation. Once sub-contexts exist the least-privilege layout is
+a leaf per purpose (`<tenant>/<unit>/<purpose>` — partly because, absent a
+per-key actor grant (#818), a context of its own is the only way to scope a
+caller to one key), and a sweep of `<tenant>/<unit>` then misses *every*
+principal under it. Cierge's kill switch hit exactly this
+(affinidi/cierge#49): a gateway grant at `<domain>/attestation` survived the
+cut and could keep signing as the killed domain while the report said success.
+
+**An explicit direction on the filter**, defaulting to today's behaviour:
+
+| direction | question | predicate |
+|---|---|---|
+| `acting-in` (default) | who may act **in** X? | entry scope `is_ancestor_or_self` of X |
+| `subtree` | what is granted **beneath** X? | X `is_ancestor_or_self` of the entry scope |
+| `any` | whose authority **touches** X's subtree? | either |
+
+One enum rather than a `subtree=true` flag, because "either direction" is the
+third question an auditor actually asks and a boolean cannot spell it.
+
+Surfaces: `GET /acl?context=…&direction=…`, a `direction` member on the
+`spec/vta/acl/list/1.0` payload (and the DIDComm `list-acl` body),
+`pnm|cnm acl list --direction`, the offline `vta acl list --direction`, and
+`VtaClient::list_acl_in_direction`. `VtaClient::list_acl` is unchanged and
+stays `acting-in`; the client omits the parameter entirely at the default, so
+requests that mean what an older VTA already does still reach it.
+
+Two edges, both deliberate and tested: an **unrestricted (super-admin) entry is
+not in the `subtree` answer** — it names no context, so it is not a grant *of*
+the branch, and returning it would hand a caller revoking a compromised branch
+its own super-admin to delete (`acting-in` and `any` report it); an entry naming
+contexts inside *and* outside the branch **is** in it, because it does hold a
+grant inside and omitting it would under-report.
+
+Fail-closed: absent parameter is byte-for-byte the previous behaviour, pinned at
+the scope, entry, and operation layers. An unparseable direction is refused with
+the valid set rather than defaulted, and a direction with no context is refused
+rather than silently answered with the whole ACL — guessing which of two
+opposite questions the caller meant is the defect, one level up. The CLI prints
+the question it asked beside the count, including on an empty result.
+
+The VTC's equivalent filter deliberately did **not** follow: its listing is
+bound to the canonical `acl/list/0.1` Trust Task, whose payload is
+`additionalProperties: false`, so a `direction` member is an openvtc spec change
+(or an `ext` member), not a local one. Recorded as a follow-up in
+`docs/05-design-notes/acl-scope-semantics.md` — with the note that the VTC list
+is paginated, so `direction` must also join the cursor binding or a resumed
+sweep changes question mid-listing.
+
 ### VTC Trust Tasks — the unpublished-manifest backlog is closed (#709)
 
 `vtc-service/tests/trust_task_manifest.rs` carried twenty `UNPUBLISHED_OK`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2488,7 +2488,7 @@ checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cnm-cli"
-version = "0.11.9"
+version = "0.11.10"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "clap",
@@ -6759,7 +6759,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "pnm-cli"
-version = "0.11.10"
+version = "0.11.11"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-resolver-cache-sdk",
@@ -10118,7 +10118,7 @@ dependencies = [
 
 [[package]]
 name = "vta-cli-common"
-version = "0.10.15"
+version = "0.10.16"
 dependencies = [
  "aes-gcm",
  "affinidi-crypto",
@@ -10269,7 +10269,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.20.4"
+version = "0.20.5"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10331,7 +10331,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.12.41"
+version = "0.12.42"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",
@@ -10646,7 +10646,7 @@ dependencies = [
 
 [[package]]
 name = "vti-common"
-version = "0.11.26"
+version = "0.11.27"
 dependencies = [
  "aes-gcm",
  "affinidi-data-integrity",

--- a/cnm-cli/Cargo.toml
+++ b/cnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cnm-cli"
 description = "CLI Tool for Verified Trust Agents operating in Verified Trust Communities"
-version = "0.11.9"
+version = "0.11.10"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/cnm-cli/src/main.rs
+++ b/cnm-cli/src/main.rs
@@ -527,10 +527,18 @@ enum ContextCommands {
 enum AclCommands {
     /// List ACL entries
     List {
-        /// FILTER: only show entries whose `allowed_contexts` include this
-        /// context. Omit to see every entry visible to you.
+        /// FILTER: narrow the listing to one context. Omit to see every entry
+        /// visible to you. See --direction for which way this reads.
         #[arg(long)]
         context: Option<String>,
+        /// Which way --context reads along the context hierarchy:
+        /// `acting-in` (default) — who may act IN the context: entries scoped
+        /// to it or to an ancestor of it;
+        /// `subtree` — what is granted BENEATH it: entries scoped to it or to
+        /// a descendant, i.e. the grants a revocation sweep must cut;
+        /// `any` — both.
+        #[arg(long, requires = "context")]
+        direction: Option<String>,
     },
     /// Get an ACL entry by DID
     Get {
@@ -1149,7 +1157,9 @@ async fn main() {
             },
         },
         Commands::Acl { command } => match command {
-            AclCommands::List { context } => acl::cmd_acl_list(&client, context.as_deref()).await,
+            AclCommands::List { context, direction } => {
+                acl::cmd_acl_list(&client, context.as_deref(), direction.as_deref()).await
+            }
             AclCommands::Get { did } => acl::cmd_acl_get(&client, &did).await,
             AclCommands::Create {
                 did,
@@ -1801,7 +1811,10 @@ mod tests {
     #[test]
     fn test_requires_auth_acl_true() {
         let cmd = Commands::Acl {
-            command: AclCommands::List { context: None },
+            command: AclCommands::List {
+                context: None,
+                direction: None,
+            },
         };
         assert!(requires_auth(&cmd));
     }

--- a/docs/02-vta/cold-start.md
+++ b/docs/02-vta/cold-start.md
@@ -286,7 +286,7 @@ vta status
 vta import-did --did <did> --role admin [--label <text>] [--context <id>]...
 
 # List / update / delete ACL entries
-vta acl list [--context <id>] [--role <role>]
+vta acl list [--context <id>] [--direction acting-in|subtree|any] [--role <role>]
 vta acl get <did>
 vta acl update <did> [--role <role>] [--label <text>] [--contexts <id,...>]
 vta acl delete <did>

--- a/docs/05-design-notes/acl-scope-semantics.md
+++ b/docs/05-design-notes/acl-scope-semantics.md
@@ -72,6 +72,82 @@ been a bug:
 Go through `act_scope()` — or `has_context_access` / `can_act_in` /
 `is_super_admin`, which are built on it — and match on the result.
 
+## The third axis: which *direction* a context filter reads
+
+A context id names a subtree, so "the ACL entries relevant to context X" is two
+questions, not one — and until #822 only the first was askable:
+
+| direction | question | predicate |
+|---|---|---|
+| `acting-in` (default) | who may act **in** X? | entry scope `is_ancestor_or_self` of X |
+| `subtree` | what is granted **beneath** X? | X `is_ancestor_or_self` of the entry scope |
+| `any` | whose authority **touches** X's subtree? | either |
+
+Both are pure segment comparisons over data already in the entry; `subtree` is
+`acting-in`'s predicate with its arguments swapped
+(`ActScope::acts_within` beside `ActScope::covers`).
+
+**Why the gap mattered.** `?context=X` answered only the first, correctly — but
+a caller sweeping a subtree to *revoke* it needs the second, and asking it with
+the first's filter returns precisely the entries that are **not** being revoked
+(the ancestors keeping their authority) while omitting every leaf-scoped grant
+the sweep exists to cut. The wrong answer is short, not empty, so it looks
+complete. Once sub-contexts exist the natural least-privilege layout is a leaf
+per purpose (`<tenant>/<unit>/<purpose>` — partly because, without a per-key
+actor grant (#818), a context of its own is the only way to scope a caller to
+one key), which is exactly the layout that makes the omission total: every
+principal's grant is a leaf. Cierge's kill switch hit this
+(affinidi/cierge#49) — a gateway grant at `<domain>/attestation` survived a
+sweep of `<domain>` and could keep signing while the kill report read
+"succeeded".
+
+This is the same lesson as `allowed_contexts.is_empty()` one level up: an
+answer that is only meaningful paired with the question, and a call site that
+could not say which question it meant.
+
+### Two edges, both deliberate
+
+- **An unrestricted (super-admin) entry is not in the `subtree` answer.** It
+  names no context, so it is not a grant *of* the branch; it is authority
+  everywhere, which `acting-in` already reports. Including it would hand a
+  caller revoking a compromised branch its own super-admin to delete. `any` is
+  where an auditor asks for it.
+- **An entry naming contexts inside *and* outside the branch is in the
+  `subtree` answer.** It does hold a grant inside, so omitting it would
+  under-report — the failure mode being fixed. Whether to delete the entry or
+  narrow its scope is then a decision made with the entry in hand.
+
+### Fail-closed shape
+
+Absent parameter = `acting-in`, byte for byte the pre-#822 behaviour (pinned by
+tests at the scope, entry, and operation layers). An unparseable direction is
+**refused with the valid set**, never defaulted — guessing which of two
+opposite questions an operator meant is how a confidently-wrong answer gets
+served. A direction with no context is refused too: it is inert, and silently
+listing the whole ACL to a caller that asked to sweep a branch is the same
+defect one level up.
+
+Surfaces: `GET /acl?context=…&direction=…`, the `direction` member on the
+`spec/vta/acl/list/1.0` payload (also the DIDComm `list-acl` body),
+`pnm|cnm acl list --context … --direction …`, the offline `vta acl list`, and
+`VtaClient::list_acl_in_direction` (`list_acl` stays `acting-in` exactly). The
+CLI prints the question it asked next to the count, because two directions over
+one `--context` produce two legitimate, differently-shaped lists.
+
+### Why the VTC did not follow
+
+The VTC has the same one-directional filter (`GET /acl?scope=…`, ancestry-aware
+since the hierarchical-contexts work), but its listing is bound to the
+**canonical** `acl/list/0.1` Trust Task, whose payload is
+`additionalProperties: false` over `{cursor, ext, pageSize, role, scope,
+subjectPrefix}`. A `direction` member there is an openvtc spec change (or an
+`ext` member), not a local one, so adding it unilaterally would be exactly the
+canonical-conformance drift the VTC migration exists to remove. Left as a
+follow-up with the shape already decided here. Note for whoever picks it up:
+the VTC list is **paginated**, and `direction` must join
+`ListAclQuery::cursor_binding` — a cursor minted under one direction must not
+resume under another, or a resumed sweep silently changes question mid-listing.
+
 ## Reading is not managing
 
 Two predicates, deliberately separate:

--- a/docs/05-design-notes/hierarchical-contexts.md
+++ b/docs/05-design-notes/hierarchical-contexts.md
@@ -75,6 +75,13 @@ derivation (unchanged contract; just deeper).
    caller is admin of it, allocates the nested BIP-32 base, enforces depth.
 3. **Subtree operations** — delete (cascade / refuse-non-empty), list-subtree,
    and admin-of-parent authority over descendant ACL / keys.
+
+   The **ACL** half of "list-subtree" landed with #822: `GET /acl` (and every
+   other ACL listing surface) takes an explicit `direction`, because
+   `?context=X` reads *up* the tree by design and a subtree sweep needs it to
+   read *down*. See the direction axis in `acl-scope-semantics.md` — including
+   why an unrestricted entry is not in the subtree answer, and why the VTC's
+   canonical `acl/list/0.1` filter cannot follow without a spec change.
 4. **VTC** — mirror the relevant parts to the community/context surface.
 
    **Finding (on investigation):** the VTC is **not** the key authority — it

--- a/pnm-cli/Cargo.toml
+++ b/pnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pnm-cli"
 description = "CLI Tool for managing a personal Verifiable Trust Agent"
-version = "0.11.10"
+version = "0.11.11"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/pnm-cli/src/cli.rs
+++ b/pnm-cli/src/cli.rs
@@ -1742,10 +1742,18 @@ pub(crate) enum ContextCommands {
 pub(crate) enum AclCommands {
     /// List ACL entries
     List {
-        /// FILTER: only show ACL entries whose `allowed_contexts` include
-        /// this context. Omit to see every entry visible to you.
+        /// FILTER: narrow the listing to one context. Omit to see every entry
+        /// visible to you. See --direction for which way this reads.
         #[arg(long)]
         context: Option<String>,
+        /// Which way --context reads along the context hierarchy:
+        /// `acting-in` (default) — who may act IN the context: entries scoped
+        /// to it or to an ancestor of it;
+        /// `subtree` — what is granted BENEATH it: entries scoped to it or to
+        /// a descendant, i.e. the grants a revocation sweep must cut;
+        /// `any` — both.
+        #[arg(long, requires = "context")]
+        direction: Option<String>,
     },
     /// Get an ACL entry by DID
     Get {

--- a/pnm-cli/src/commands/acl.rs
+++ b/pnm-cli/src/commands/acl.rs
@@ -10,7 +10,9 @@ pub(crate) async fn run(
     command: AclCommands,
 ) -> Result<(), Box<dyn std::error::Error>> {
     match command {
-        AclCommands::List { context } => acl::cmd_acl_list(client, context.as_deref()).await,
+        AclCommands::List { context, direction } => {
+            acl::cmd_acl_list(client, context.as_deref(), direction.as_deref()).await
+        }
         AclCommands::Get { did } => acl::cmd_acl_get(client, &did).await,
         AclCommands::Create {
             did,

--- a/pnm-cli/src/main.rs
+++ b/pnm-cli/src/main.rs
@@ -630,7 +630,10 @@ mod tests {
     #[test]
     fn test_requires_auth_acl_true() {
         let cmd = Commands::Acl {
-            command: AclCommands::List { context: None },
+            command: AclCommands::List {
+                context: None,
+                direction: None,
+            },
         };
         assert!(requires_auth(&cmd));
     }

--- a/vta-cli-common/Cargo.toml
+++ b/vta-cli-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-cli-common"
 description = "Shared CLI command handlers and rendering helpers for VTA CLIs"
 readme = "README.md"
-version = "0.10.15"
+version = "0.10.16"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-cli-common/src/commands/acl.rs
+++ b/vta-cli-common/src/commands/acl.rs
@@ -3,7 +3,7 @@ use ratatui::{
     style::{Color, Modifier, Style},
     widgets::{Block, Cell, Row, Table},
 };
-use vta_sdk::acl::ApproveScope;
+use vta_sdk::acl::{ApproveScope, ContextDirection};
 use vta_sdk::prelude::*;
 use vti_common::acl::{Role, act_scope_for};
 
@@ -67,11 +67,46 @@ pub fn validate_role(role: &str) -> Result<(), Box<dyn std::error::Error>> {
     }
 }
 
+/// Parse the operator's `--direction` value, defaulting to the historical
+/// "who may act in this context" reading and refusing anything else with the
+/// valid set — the same table the wire uses, so flag and payload cannot drift.
+pub fn parse_direction(
+    direction: Option<&str>,
+) -> Result<ContextDirection, Box<dyn std::error::Error>> {
+    match direction {
+        None => Ok(ContextDirection::default()),
+        Some(d) => Ok(d.parse::<ContextDirection>()?),
+    }
+}
+
+/// The question a `--context` + `--direction` pair actually asked, in words.
+///
+/// On screen because the two directions are equally plausible readings of the
+/// same flag and produce different lists: a subtree sweep that quietly ran as
+/// an act-in query returns the ancestors it is not revoking and looks like a
+/// complete answer (#822).
+pub fn describe_filter(context: &str, direction: ContextDirection) -> String {
+    match direction {
+        ContextDirection::ActingIn => format!("able to act in {context}"),
+        ContextDirection::Subtree => format!("granted at or beneath {context}"),
+        ContextDirection::Any => format!("with authority touching {context}"),
+    }
+}
+
 pub async fn cmd_acl_list(
     client: &VtaClient,
     context: Option<&str>,
+    direction: Option<&str>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let resp = client.list_acl(context).await?;
+    let direction = parse_direction(direction)?;
+    if context.is_none() && direction != ContextDirection::default() {
+        return Err(format!(
+            "--direction {direction} says how to read --context, and no --context was given.\n\
+             Try: pnm acl list --context <id> --direction {direction}"
+        )
+        .into());
+    }
+    let resp = client.list_acl_in_direction(context, direction).await?;
 
     // `--json` short-circuits all rendering and emits a single JSON
     // document. Empty result returns an empty array, NOT a printed
@@ -83,7 +118,13 @@ pub async fn cmd_acl_list(
     }
 
     if resp.entries.is_empty() {
-        println!("No ACL entries found.");
+        // An empty subtree sweep is the answer that most needs qualifying:
+        // it can equally mean "nothing is granted beneath this context" and
+        // "you asked the other direction". Name the question that was asked.
+        match context {
+            Some(ctx) => println!("No ACL entries found {}.", describe_filter(ctx, direction)),
+            None => println!("No ACL entries found."),
+        }
         return Ok(());
     }
 
@@ -102,8 +143,17 @@ pub async fn cmd_acl_list(
     )
     .await;
 
+    // Name the question on screen whenever a context filter narrowed the
+    // answer. Two opposite readings of the same `--context` produce two
+    // legitimate, differently-shaped lists, and an operator who cannot see
+    // which one they got cannot tell a short list from a wrong one.
+    let heading = match context {
+        Some(ctx) => format!("ACL Entries — {}", describe_filter(ctx, direction)),
+        None => "ACL Entries".to_string(),
+    };
+
     if is_full_display() {
-        print_full_list_title("ACL Entries", resp.entries.len());
+        print_full_list_title(&heading, resp.entries.len());
         for entry in &resp.entries {
             let contexts = format_contexts(&entry.role, &entry.allowed_contexts);
             let role = format_role(&entry.role, &entry.allowed_contexts);
@@ -162,7 +212,7 @@ pub async fn cmd_acl_list(
         })
         .collect();
 
-    let title = format!(" ACL Entries ({}) ", resp.entries.len());
+    let title = format!(" {heading} ({}) ", resp.entries.len());
 
     // DIDs are abbreviated by `shorten_did` (SCID squeezed, domain tail kept),
     // which frees the width the name column needs. `--full-display` and

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.20.4"
+version = "0.20.5"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/acl.rs
+++ b/vta-sdk/src/acl.rs
@@ -66,6 +66,51 @@ impl ActScope {
         }
     }
 
+    /// Whether this scope names a context **at or beneath** `context_id` — the
+    /// mirror of [`covers`](ActScope::covers), with the ancestry test's
+    /// arguments swapped.
+    ///
+    /// [`covers`](ActScope::covers) answers "may this entry act *in* the
+    /// context?"; this answers "does this entry hold a grant *inside* the
+    /// context's subtree?". They are different questions and a caller sweeping
+    /// a subtree — to revoke it, or to audit it — wants this one: a grant at
+    /// `acme/eng/team-a` is invisible to `covers("acme/eng")` because it holds
+    /// no authority over `acme/eng`, yet it is precisely what the sweep exists
+    /// to find.
+    ///
+    /// Two deliberate edges:
+    ///
+    /// - [`All`](ActScope::All) is **not** a match. An unrestricted entry names
+    ///   no context, so it is not a grant *of* this subtree — it is authority
+    ///   everywhere, which [`covers`](ActScope::covers) already reports. A
+    ///   subtree sweep that returned it would invite a caller revoking a
+    ///   compromised branch to delete its own super-admin. Ask
+    ///   [`ContextDirection::Any`] for "everyone whose authority touches this
+    ///   subtree", which includes it.
+    /// - A [`Contexts`](ActScope::Contexts) scope matches if **any** named
+    ///   context is inside the subtree, even when it also names contexts
+    ///   outside it. Such an entry does hold a grant in the subtree, so
+    ///   omitting it would under-report; whether to delete the entry or narrow
+    ///   its scope is then the caller's decision, made with the entry in hand.
+    pub fn acts_within(&self, context_id: &str) -> bool {
+        match self {
+            ActScope::None | ActScope::All => false,
+            ActScope::Contexts(cs) => cs
+                .iter()
+                .any(|c| crate::context_path::is_ancestor_or_self(context_id, c)),
+        }
+    }
+
+    /// Whether this scope matches `context_id` when read in `direction` — the
+    /// single predicate behind every context-filtered ACL listing.
+    pub fn matches_context(&self, context_id: &str, direction: ContextDirection) -> bool {
+        match direction {
+            ContextDirection::ActingIn => self.covers(context_id),
+            ContextDirection::Subtree => self.acts_within(context_id),
+            ContextDirection::Any => self.covers(context_id) || self.acts_within(context_id),
+        }
+    }
+
     /// Whether this scope authorizes every context (the super-admin condition
     /// when paired with the admin role).
     pub fn is_unrestricted(&self) -> bool {
@@ -85,6 +130,87 @@ impl ActScope {
             ActScope::Contexts(cs) => cs,
             _ => &[],
         }
+    }
+}
+
+/// Which way a context filter reads along the context hierarchy.
+///
+/// A context id names a subtree, so "entries relevant to context X" is two
+/// questions, not one, and an answer is only meaningful paired with the
+/// direction being asked:
+///
+/// | direction | question | predicate |
+/// |---|---|---|
+/// | [`ActingIn`](ContextDirection::ActingIn) | who may act **in** X? | scope is X or an ancestor of it |
+/// | [`Subtree`](ContextDirection::Subtree) | who holds a grant **beneath** X? | scope is X or a descendant of it |
+/// | [`Any`](ContextDirection::Any) | whose authority **touches** X's subtree? | either of the above |
+///
+/// Only [`ActingIn`](ContextDirection::ActingIn) existed until now, and a
+/// caller sweeping a subtree to revoke it got back exactly the entries it was
+/// *not* revoking (the ancestors keeping their authority) while every
+/// leaf-scoped grant it existed to cut was silently absent — an incomplete
+/// answer that looks like a complete one (#822).
+///
+/// [`ActingIn`](ContextDirection::ActingIn) is the default, so an omitted
+/// parameter is today's behaviour exactly. An unparseable value is refused
+/// rather than defaulted: guessing which question an operator meant is how the
+/// silent-wrong-answer failure returns.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "kebab-case")]
+pub enum ContextDirection {
+    /// Entries that may act **in** the context: scoped to it or to an ancestor
+    /// of it. The historical (and default) behaviour of `?context=`.
+    #[default]
+    ActingIn,
+    /// Entries holding a grant **at or beneath** the context. The revocation-
+    /// sweep and delegation-audit direction.
+    Subtree,
+    /// The union — every entry whose act authority touches the context's
+    /// subtree in either direction. The auditor's question.
+    Any,
+}
+
+impl ContextDirection {
+    /// Every direction, in the order the operator-facing help lists them.
+    pub const ALL: [ContextDirection; 3] = [
+        ContextDirection::ActingIn,
+        ContextDirection::Subtree,
+        ContextDirection::Any,
+    ];
+
+    /// The wire spelling — identical to the serde representation, so the CLI,
+    /// the query string, and the Trust Task payload cannot drift apart.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ContextDirection::ActingIn => "acting-in",
+            ContextDirection::Subtree => "subtree",
+            ContextDirection::Any => "any",
+        }
+    }
+}
+
+impl std::fmt::Display for ContextDirection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl std::str::FromStr for ContextDirection {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::ALL
+            .into_iter()
+            .find(|d| d.as_str() == s)
+            .ok_or_else(|| {
+                let valid = Self::ALL
+                    .iter()
+                    .map(|d| d.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                format!("invalid context direction '{s}', expected one of: {valid}")
+            })
     }
 }
 
@@ -241,5 +367,144 @@ mod tests {
 
         assert!(ApproveScope::All.covers("anything"));
         assert!(!ApproveScope::None.covers("anything"));
+    }
+
+    // ── ContextDirection ────────────────────────────────────────────
+
+    /// The two directions are mirror images: `covers` walks up from the
+    /// queried context, `acts_within` walks down. The defect was having only
+    /// the first, so the descendant column here was unaskable.
+    #[test]
+    fn the_two_directions_are_mirrors() {
+        let ancestor = ActScope::Contexts(vec!["acme".into()]);
+        let exact = ActScope::Contexts(vec!["acme/eng".into()]);
+        let descendant = ActScope::Contexts(vec!["acme/eng/team-a".into()]);
+        let sibling = ActScope::Contexts(vec!["acme/ops".into()]);
+        let q = "acme/eng";
+
+        // covers: ancestor-or-self of the queried context.
+        assert!(ancestor.covers(q));
+        assert!(exact.covers(q));
+        assert!(!descendant.covers(q), "a leaf holds no authority over q");
+        assert!(!sibling.covers(q));
+
+        // acts_within: at-or-beneath the queried context.
+        assert!(!ancestor.acts_within(q), "a parent grant is not inside q");
+        assert!(exact.acts_within(q), "self is inside its own subtree");
+        assert!(descendant.acts_within(q), "the sweep's whole point");
+        assert!(!sibling.acts_within(q));
+    }
+
+    /// Segment-awareness must hold in the new direction too, or `acme/eng`
+    /// would "contain" `acme/engineering` and a sweep would revoke a
+    /// bystander.
+    #[test]
+    fn acts_within_is_segment_aware() {
+        let scope = ActScope::Contexts(vec!["acme/engineering".into()]);
+        assert!(!scope.acts_within("acme/eng"));
+        assert!(scope.acts_within("acme"));
+    }
+
+    /// An unrestricted entry is authority *everywhere*, not a grant *of* this
+    /// subtree. Surfacing it under `subtree` would put the caller's own
+    /// super-admin on a revocation list; `any` is where it belongs.
+    #[test]
+    fn unrestricted_is_reported_by_acting_in_and_any_but_not_subtree() {
+        let all = ActScope::All;
+        assert!(all.matches_context("acme/eng", ContextDirection::ActingIn));
+        assert!(!all.matches_context("acme/eng", ContextDirection::Subtree));
+        assert!(all.matches_context("acme/eng", ContextDirection::Any));
+    }
+
+    /// Acts-nowhere matches in no direction — the fail-closed edge.
+    #[test]
+    fn acts_nowhere_matches_no_direction() {
+        for d in ContextDirection::ALL {
+            assert!(
+                !ActScope::None.matches_context("acme", d),
+                "acts-nowhere matched {d}"
+            );
+        }
+    }
+
+    /// A scope naming several contexts matches the sweep if *any* of them is
+    /// inside it — under-reporting is the failure mode being fixed.
+    #[test]
+    fn a_partially_inside_scope_is_surfaced() {
+        let scope = ActScope::Contexts(vec!["acme/eng/team-a".into(), "other".into()]);
+        assert!(scope.acts_within("acme/eng"));
+    }
+
+    /// `Any` is exactly the union, and never narrower than either leg.
+    #[test]
+    fn any_is_the_union_of_both_legs() {
+        let scopes = [
+            ActScope::None,
+            ActScope::All,
+            ActScope::Contexts(vec!["acme".into()]),
+            ActScope::Contexts(vec!["acme/eng".into()]),
+            ActScope::Contexts(vec!["acme/eng/team-a".into()]),
+            ActScope::Contexts(vec!["other".into()]),
+        ];
+        for scope in scopes {
+            let acting_in = scope.matches_context("acme/eng", ContextDirection::ActingIn);
+            let subtree = scope.matches_context("acme/eng", ContextDirection::Subtree);
+            assert_eq!(
+                scope.matches_context("acme/eng", ContextDirection::Any),
+                acting_in || subtree,
+                "union broken for {scope:?}"
+            );
+        }
+    }
+
+    /// Omitting the parameter must be today's behaviour, byte for byte.
+    #[test]
+    fn default_direction_is_the_historical_one() {
+        assert_eq!(ContextDirection::default(), ContextDirection::ActingIn);
+        let scope = ActScope::Contexts(vec!["acme".into()]);
+        for ctx in ["acme", "acme/eng", "acme-corp", "other"] {
+            assert_eq!(
+                scope.matches_context(ctx, ContextDirection::default()),
+                scope.covers(ctx),
+                "default direction diverged from `covers` at {ctx}"
+            );
+        }
+    }
+
+    /// One spelling across the query string, the Trust Task payload, and the
+    /// CLI flag — parsed and rendered through the same table.
+    #[test]
+    fn wire_spelling_is_pinned_and_round_trips() {
+        let cases = [
+            (ContextDirection::ActingIn, "acting-in"),
+            (ContextDirection::Subtree, "subtree"),
+            (ContextDirection::Any, "any"),
+        ];
+        for (direction, wire) in cases {
+            assert_eq!(direction.as_str(), wire);
+            assert_eq!(direction.to_string(), wire);
+            assert_eq!(
+                serde_json::to_string(&direction).unwrap(),
+                format!("\"{wire}\"")
+            );
+            assert_eq!(
+                serde_json::from_str::<ContextDirection>(&format!("\"{wire}\"")).unwrap(),
+                direction
+            );
+            assert_eq!(wire.parse::<ContextDirection>().unwrap(), direction);
+        }
+    }
+
+    /// An unknown value is refused, and the error names the valid ones — the
+    /// operator-errors-suggest-the-fix rule. Silently defaulting would
+    /// reintroduce "wrong question, confident answer".
+    #[test]
+    fn an_unknown_direction_is_refused_with_the_valid_set() {
+        let err = "descendants".parse::<ContextDirection>().unwrap_err();
+        assert!(err.contains("descendants"), "{err}");
+        for d in ContextDirection::ALL {
+            assert!(err.contains(d.as_str()), "{err} omits {d}");
+        }
+        assert!(serde_json::from_str::<ContextDirection>("\"ActingIn\"").is_err());
     }
 }

--- a/vta-sdk/src/client/acl.rs
+++ b/vta-sdk/src/client/acl.rs
@@ -4,6 +4,7 @@ use super::{
     AclEntryResponse, AclListResponse, CreateAclRequest, SwapAclRequest, UpdateAclRequest,
     VtaClient, encode_path_segment,
 };
+use crate::acl::ContextDirection;
 use crate::error::VtaError;
 
 #[cfg(feature = "client")]
@@ -11,16 +12,58 @@ use crate::protocols::acl_management;
 
 #[cfg(feature = "client")]
 impl VtaClient {
+    /// List ACL entries, optionally filtered to the entries that may act **in**
+    /// `context`.
+    ///
+    /// For the other direction — what is granted *beneath* a context, which is
+    /// what a revocation sweep or a delegation audit needs — call
+    /// [`list_acl_in_direction`](Self::list_acl_in_direction). This method is
+    /// exactly `ContextDirection::ActingIn` and stays that way.
     pub async fn list_acl(&self, context: Option<&str>) -> Result<AclListResponse, VtaError> {
+        self.list_acl_in_direction(context, ContextDirection::ActingIn)
+            .await
+    }
+
+    /// List ACL entries, filtering `context` in an explicit
+    /// [`ContextDirection`].
+    ///
+    /// A context id names a subtree, so `?context=X` is two questions:
+    /// [`ActingIn`](ContextDirection::ActingIn) (who holds authority over X)
+    /// and [`Subtree`](ContextDirection::Subtree) (what is granted inside X).
+    /// Sweeping a subtree with the first returns precisely the entries the
+    /// sweep is *not* revoking, so a caller cutting a branch must ask for the
+    /// second (#822). [`Any`](ContextDirection::Any) is the auditor's union.
+    ///
+    /// The direction is inert without a context and the VTA refuses that
+    /// combination rather than silently listing everything.
+    pub async fn list_acl_in_direction(
+        &self,
+        context: Option<&str>,
+        direction: ContextDirection,
+    ) -> Result<AclListResponse, VtaError> {
+        // Omitted when it is the default, so an old VTA — which would reject
+        // the unknown field — keeps serving the calls that mean what it
+        // already does.
+        let direction_field = (direction != ContextDirection::default())
+            .then(|| serde_json::Value::String(direction.to_string()));
         self.rpc(
             acl_management::LIST_ACL,
-            serde_json::json!({ "context": context }),
+            serde_json::json!({ "context": context, "direction": direction_field }),
             acl_management::LIST_ACL_RESULT,
             30,
             |c, url| {
+                // Both parameters are appended independently — a direction
+                // without a context is a caller error, and the VTA says so;
+                // dropping it here would make REST answer a question DIDComm
+                // refuses.
                 let mut u = format!("{url}/acl");
+                let mut sep = '?';
                 if let Some(ctx) = context {
-                    u.push_str(&format!("?context={ctx}"));
+                    u.push_str(&format!("{sep}context={ctx}"));
+                    sep = '&';
+                }
+                if direction != ContextDirection::default() {
+                    u.push_str(&format!("{sep}direction={direction}"));
                 }
                 c.get(u)
             },

--- a/vta-sdk/src/protocols/acl_management/list.rs
+++ b/vta-sdk/src/protocols/acl_management/list.rs
@@ -1,12 +1,20 @@
 use serde::{Deserialize, Serialize};
 
 use super::create::CreateAclResultBody;
+use crate::acl::ContextDirection;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ListAclBody {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub context: Option<String>,
+    /// Which way [`context`](Self::context) reads along the hierarchy —
+    /// `acting-in` (default, entries that may act *in* it), `subtree` (entries
+    /// granted at or *beneath* it), or `any`. Absent = `acting-in`, i.e. the
+    /// pre-#822 behaviour exactly. Meaningless without `context`, and refused
+    /// rather than ignored in that case.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub direction: Option<ContextDirection>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/vta-sdk/tests/client_rest.rs
+++ b/vta-sdk/tests/client_rest.rs
@@ -578,6 +578,44 @@ async fn list_acl_with_context_query() {
     assert!(resp.entries.is_empty());
 }
 
+/// A non-default direction rides the query string; `list_acl` and an explicit
+/// `acting-in` must stay byte-identical to the historical request, so an older
+/// VTA keeps answering them.
+#[tokio::test]
+async fn list_acl_sends_the_direction_only_when_it_is_not_the_default() {
+    use vta_sdk::acl::ContextDirection;
+
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/acl"))
+        .and(auth_match())
+        .and(wiremock::matchers::query_param("context", "acme/eng"))
+        .and(wiremock::matchers::query_param("direction", "subtree"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"entries": []})))
+        .expect(1)
+        .mount(&server)
+        .await;
+    let c = client(&server).await;
+    c.list_acl_in_direction(Some("acme/eng"), ContextDirection::Subtree)
+        .await
+        .unwrap();
+    server.reset().await;
+
+    Mock::given(method("GET"))
+        .and(path("/acl"))
+        .and(auth_match())
+        .and(wiremock::matchers::query_param("context", "acme/eng"))
+        .and(wiremock::matchers::query_param_is_missing("direction"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"entries": []})))
+        .expect(2)
+        .mount(&server)
+        .await;
+    c.list_acl(Some("acme/eng")).await.unwrap();
+    c.list_acl_in_direction(Some("acme/eng"), ContextDirection::ActingIn)
+        .await
+        .unwrap();
+}
+
 #[tokio::test]
 async fn get_acl_path_encodes_did() {
     let server = MockServer::start().await;

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.12.41"
+version = "0.12.42"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/acl_cli.rs
+++ b/vta-service/src/acl_cli.rs
@@ -1,6 +1,6 @@
 use crate::acl::{
-    AclEntry, ApproveScope, Role, acl_entry_can_act_in, delete_acl_entry, get_acl_entry,
-    list_acl_entries, store_acl_entry,
+    AclEntry, ApproveScope, ContextDirection, Role, acl_entry_matches_context, delete_acl_entry,
+    get_acl_entry, list_acl_entries, store_acl_entry,
 };
 use crate::config::AppConfig;
 use crate::store::Store;
@@ -120,8 +120,21 @@ pub async fn run_acl_list(
     config_path: Option<PathBuf>,
     context: Option<String>,
     role: Option<String>,
+    direction: Option<String>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let role_filter = role.map(|r| Role::parse(&r)).transpose()?;
+    let direction: ContextDirection = match direction {
+        Some(d) => d.parse()?,
+        None => ContextDirection::default(),
+    };
+    // Inert without a context, and saying so beats listing the whole ACL to an
+    // operator who believes they asked for a subtree.
+    if context.is_none() && direction != ContextDirection::default() {
+        return Err(format!(
+            "--direction {direction} filters a context and --context was not given"
+        )
+        .into());
+    }
 
     let config = AppConfig::load(config_path)?;
     let store = Store::open(&config.store)?;
@@ -135,9 +148,10 @@ pub async fn run_acl_list(
     }
     if let Some(ref ctx) = context {
         // Shared with the online `list_acl` so the two surfaces cannot answer
-        // the same question differently. The previous `is_empty() ||
-        // contains()` matched an *acts-nowhere* entry under every context.
-        entries.retain(|e| acl_entry_can_act_in(e, ctx));
+        // the same question differently — including which *direction* the
+        // context filter reads. The previous `is_empty() || contains()`
+        // matched an *acts-nowhere* entry under every context.
+        entries.retain(|e| acl_entry_matches_context(e, ctx, direction));
     }
 
     if entries.is_empty() {

--- a/vta-service/src/main.rs
+++ b/vta-service/src/main.rs
@@ -1240,6 +1240,13 @@ enum AclCommands {
         /// Filter by role (admin, initiator, application, reader)
         #[arg(long)]
         role: Option<String>,
+        /// Which way --context reads along the hierarchy:
+        /// `acting-in` (default — who may act IN the context: entries scoped
+        /// to it or to an ancestor), `subtree` (what is granted BENEATH it:
+        /// entries scoped to it or to a descendant — the revocation-sweep
+        /// direction), or `any` (both).
+        #[arg(long, requires = "context")]
+        direction: Option<String>,
     },
     /// Show details of a single ACL entry
     Get {
@@ -1779,9 +1786,11 @@ async fn main() {
                 }
             }
             let result = match command {
-                AclCommands::List { context, role } => {
-                    acl_cli::run_acl_list(cli.config, context, role).await
-                }
+                AclCommands::List {
+                    context,
+                    role,
+                    direction,
+                } => acl_cli::run_acl_list(cli.config, context, role, direction).await,
                 AclCommands::Get { did } => acl_cli::run_acl_get(cli.config, did).await,
                 AclCommands::Create {
                     did,

--- a/vta-service/src/messaging/handlers.rs
+++ b/vta-service/src/messaging/handlers.rs
@@ -724,8 +724,14 @@ didcomm_handler!(
     Gate::Manage,
     acl_management::LIST_ACL_RESULT,
     acl_management::list::ListAclBody,
-    |s, auth, body| operations::acl::list_acl(&s.acl_ks, &auth, body.context.as_deref(), "didcomm")
-        .await
+    |s, auth, body| operations::acl::list_acl(
+        &s.acl_ks,
+        &auth,
+        body.context.as_deref(),
+        body.direction.unwrap_or_default(),
+        "didcomm"
+    )
+    .await
 );
 
 didcomm_handler!(

--- a/vta-service/src/operations/acl.rs
+++ b/vta-service/src/operations/acl.rs
@@ -8,8 +8,8 @@ use vta_sdk::protocols::acl_management::{
 };
 
 use crate::acl::{
-    AclEntry, ApproveScope, Role, acl_entry_can_act_in, delete_acl_entry, get_acl_entry,
-    is_acl_entry_auditable, is_acl_entry_visible, list_acl_entries, store_acl_entry,
+    AclEntry, ApproveScope, ContextDirection, Role, acl_entry_matches_context, delete_acl_entry,
+    get_acl_entry, is_acl_entry_auditable, is_acl_entry_visible, list_acl_entries, store_acl_entry,
     validate_acl_modification, validate_approve_scope_grant, validate_role_assignment,
 };
 use crate::auth::AuthClaims;
@@ -278,13 +278,28 @@ pub async fn get_acl(
     Ok(to_result_body(&entry))
 }
 
+/// List the ACL entries the caller may audit, optionally filtered to one
+/// context.
+///
+/// `direction` says which way `context_filter` reads along the hierarchy;
+/// it is inert without a context, and supplying one there is an error rather
+/// than a silent no-op — a caller that asked for a subtree sweep and got the
+/// unfiltered ACL back would believe it had swept.
 pub async fn list_acl(
     acl_ks: &KeyspaceHandle,
     auth: &AuthClaims,
     context_filter: Option<&str>,
+    direction: ContextDirection,
     channel: &str,
 ) -> Result<ListAclResultBody, AppError> {
     auth.require_manage()?;
+
+    if context_filter.is_none() && direction != ContextDirection::default() {
+        return Err(AppError::Validation(format!(
+            "`direction={direction}` filters a context and there is no context to filter — \
+             pass a context as well, or drop the direction to list every visible entry"
+        )));
+    }
 
     let all_entries = list_acl_entries(acl_ks).await?;
     let entries: Vec<CreateAclResultBody> = all_entries
@@ -295,13 +310,25 @@ pub async fn list_acl(
         // omitted super-admin entries, which do hold every context — an
         // operator auditing "who can reach context X" never saw them — and
         // missed entries scoped to an ancestor of X.
+        //
+        // The direction is what makes the question answerable at all: the
+        // ancestor-or-self reading cannot express "what is granted beneath
+        // this context", and a sweep asking that with this filter got back the
+        // entries it was *not* revoking (#822).
         .filter(|e| match context_filter {
-            Some(ctx) => acl_entry_can_act_in(e, ctx),
+            Some(ctx) => acl_entry_matches_context(e, ctx, direction),
             None => true,
         })
         .map(to_result_body)
         .collect();
-    info!(channel, caller = %auth.did, count = entries.len(), "ACL listed");
+    info!(
+        channel,
+        caller = %auth.did,
+        context = context_filter.unwrap_or("-"),
+        direction = %direction,
+        count = entries.len(),
+        "ACL listed"
+    );
     Ok(ListAclResultBody { entries })
 }
 
@@ -736,13 +763,121 @@ mod tests {
         .unwrap();
 
         let caller = ctx_admin("did:key:zCtxAdminA", &["ctx-a"]);
-        let body = list_acl(&acl_ks, &caller, None, "test").await.unwrap();
+        let body = list_acl(&acl_ks, &caller, None, ContextDirection::default(), "test")
+            .await
+            .unwrap();
         assert!(
             body.entries
                 .iter()
                 .any(|e| e.did == "did:key:zApproverList"),
             "an approve-all holder must be auditable by every context admin"
         );
+    }
+
+    // ── context-filter direction (#822) ─────────────────────────────
+
+    /// Seed the layout the issue describes: a tenant unit with a
+    /// per-purpose leaf per principal, plus a unit-wide admin above them.
+    async fn seed_tenant_subtree(acl_ks: &KeyspaceHandle) {
+        seed_target(acl_ks, "did:key:zUnitAdmin", &["acme/eng"]).await;
+        seed_target(acl_ks, "did:key:zTenantAdmin", &["acme"]).await;
+        seed_target(acl_ks, "did:key:zGateway", &["acme/eng/attestation"]).await;
+        seed_target(acl_ks, "did:key:zSigner", &["acme/eng/signing"]).await;
+        seed_target(acl_ks, "did:key:zOps", &["acme/ops/keys"]).await;
+    }
+
+    async fn dids_for(
+        acl_ks: &KeyspaceHandle,
+        caller: &AuthClaims,
+        ctx: &str,
+        direction: ContextDirection,
+    ) -> Vec<String> {
+        let body = list_acl(acl_ks, caller, Some(ctx), direction, "test")
+            .await
+            .unwrap();
+        let mut dids: Vec<String> = body.entries.into_iter().map(|e| e.did).collect();
+        dids.sort();
+        dids
+    }
+
+    /// The bug: sweeping `acme/eng` to revoke it returned the ancestors that
+    /// keep their authority and none of the leaf grants the sweep exists to
+    /// cut. Both directions are now askable, and they answer differently.
+    #[tokio::test]
+    async fn a_subtree_listing_returns_the_leaves_an_act_in_listing_omits() {
+        let (_store, acl_ks, _audit_ks, _contexts_ks, _dir) = fresh_store().await;
+        seed_tenant_subtree(&acl_ks).await;
+        let caller = super_admin("did:key:zRoot");
+
+        assert_eq!(
+            dids_for(&acl_ks, &caller, "acme/eng", ContextDirection::ActingIn).await,
+            ["did:key:zTenantAdmin", "did:key:zUnitAdmin"],
+            "act-in: authority over the unit, which is not what a sweep revokes"
+        );
+        assert_eq!(
+            dids_for(&acl_ks, &caller, "acme/eng", ContextDirection::Subtree).await,
+            ["did:key:zGateway", "did:key:zSigner", "did:key:zUnitAdmin"],
+            "subtree: every grant inside the unit, and nothing from acme/ops"
+        );
+        assert_eq!(
+            dids_for(&acl_ks, &caller, "acme/eng", ContextDirection::Any).await,
+            [
+                "did:key:zGateway",
+                "did:key:zSigner",
+                "did:key:zTenantAdmin",
+                "did:key:zUnitAdmin"
+            ],
+            "any: the union — the auditor's question"
+        );
+    }
+
+    /// Absent parameter ⇒ pre-#822 behaviour, entry for entry.
+    #[tokio::test]
+    async fn the_default_direction_is_the_historical_filter() {
+        let (_store, acl_ks, _audit_ks, _contexts_ks, _dir) = fresh_store().await;
+        seed_tenant_subtree(&acl_ks).await;
+        let caller = super_admin("did:key:zRoot");
+        assert_eq!(
+            dids_for(&acl_ks, &caller, "acme/eng", ContextDirection::default()).await,
+            dids_for(&acl_ks, &caller, "acme/eng", ContextDirection::ActingIn).await,
+        );
+    }
+
+    /// Visibility is applied before the filter in every direction — the new
+    /// direction must not become a way to enumerate entries a context admin
+    /// could not otherwise see.
+    #[tokio::test]
+    async fn a_subtree_listing_does_not_widen_what_a_context_admin_can_see() {
+        let (_store, acl_ks, _audit_ks, _contexts_ks, _dir) = fresh_store().await;
+        seed_tenant_subtree(&acl_ks).await;
+        // Admin of a sibling unit only.
+        let caller = ctx_admin("did:key:zOpsAdmin", &["acme/ops"]);
+        for direction in ContextDirection::ALL {
+            let dids = dids_for(&acl_ks, &caller, "acme/eng", direction).await;
+            assert!(
+                dids.is_empty(),
+                "{direction} leaked acme/eng entries to an acme/ops admin: {dids:?}"
+            );
+        }
+    }
+
+    /// A direction with nothing to point at is refused rather than ignored:
+    /// silently listing the whole ACL to a caller that asked to sweep a
+    /// branch is the failure this issue is about, one level up.
+    #[tokio::test]
+    async fn a_direction_without_a_context_is_refused() {
+        let (_store, acl_ks, _audit_ks, _contexts_ks, _dir) = fresh_store().await;
+        seed_tenant_subtree(&acl_ks).await;
+        let caller = super_admin("did:key:zRoot");
+
+        let err = list_acl(&acl_ks, &caller, None, ContextDirection::Subtree, "test")
+            .await
+            .expect_err("a direction needs a context");
+        assert!(matches!(err, AppError::Validation(_)), "got {err:?}");
+
+        list_acl(&acl_ks, &caller, None, ContextDirection::default(), "test")
+            .await
+            .expect("the default direction with no context is just an unfiltered list");
     }
 
     /// The escalation the split exists to prevent: reading an entry that

--- a/vta-service/src/routes/acl.rs
+++ b/vta-service/src/routes/acl.rs
@@ -5,7 +5,7 @@ use serde::Deserialize;
 
 use vta_sdk::protocols::acl_management::{create::CreateAclResultBody, list::ListAclResultBody};
 
-use crate::acl::{ApproveScope, Role};
+use crate::acl::{ApproveScope, ContextDirection, Role};
 use crate::auth::{AdminAuth, AuthClaims, ManageAuth};
 use crate::error::AppError;
 use crate::operations;
@@ -16,6 +16,15 @@ use crate::trust_tasks::{AclChangeRoleOp, AclGrantOp, AclRevokeOp, AclSwapKeyOp,
 #[into_params(parameter_in = Query)]
 pub struct ListAclQuery {
     pub context: Option<String>,
+    /// Which way `context` reads along the hierarchy: `acting-in` (default —
+    /// entries that may act *in* the context, i.e. scoped to it or an
+    /// ancestor), `subtree` (entries granted at or *beneath* it — the
+    /// revocation-sweep direction), or `any` (the union).
+    ///
+    /// Taken as a string and parsed here rather than deserialized straight
+    /// into the enum so a typo answers with the valid set instead of serde's
+    /// "unknown variant" — the operator-errors-suggest-the-fix rule.
+    pub direction: Option<String>,
 }
 
 /// GET /acl — list all ACL entries, optionally filtered by context. Auth: Admin or Initiator.
@@ -25,6 +34,7 @@ pub struct ListAclQuery {
     params(ListAclQuery),
     responses(
         (status = 200, description = "ACL entries", body = ListAclResultBody),
+        (status = 400, description = "Unparseable `direction`, or a direction without a context"),
         (status = 401, description = "Missing or invalid bearer token"),
         (status = 403, description = "Caller cannot manage ACL entries"),
     ),
@@ -34,9 +44,27 @@ pub async fn list_acl(
     State(state): State<AppState>,
     Query(query): Query<ListAclQuery>,
 ) -> Result<Json<ListAclResultBody>, AppError> {
-    let result =
-        operations::acl::list_acl(&state.acl_ks, &auth.0, query.context.as_deref(), "rest").await?;
+    let direction = parse_direction(query.direction.as_deref())?;
+    let result = operations::acl::list_acl(
+        &state.acl_ks,
+        &auth.0,
+        query.context.as_deref(),
+        direction,
+        "rest",
+    )
+    .await?;
     Ok(Json(result))
+}
+
+/// Parse the `direction` query parameter, defaulting to the historical
+/// ancestor-or-self reading when it is absent and **refusing** anything it
+/// cannot parse. Guessing which of the two opposite questions an operator
+/// meant is how a confidently-wrong answer gets served.
+fn parse_direction(raw: Option<&str>) -> Result<ContextDirection, AppError> {
+    match raw {
+        None => Ok(ContextDirection::default()),
+        Some(s) => s.parse().map_err(AppError::Validation),
+    }
 }
 
 #[derive(Debug, Deserialize, utoipa::ToSchema)]

--- a/vta-service/src/trust_tasks/acl.rs
+++ b/vta-service/src/trust_tasks/acl.rs
@@ -41,6 +41,7 @@ pub(super) async fn handle_list(
         &state.acl_ks,
         auth,
         req.context.as_deref(),
+        req.direction.unwrap_or_default(),
         TRANSPORT_TRUST_TASK,
     )
     .await

--- a/vta-service/tests/api_integration.rs
+++ b/vta-service/tests/api_integration.rs
@@ -526,6 +526,112 @@ async fn acl_create_and_list() {
     );
 }
 
+/// The `?direction=` filter over the wire (#822): the same `?context=` reads
+/// two opposite ways, and a caller sweeping a subtree to revoke it must be
+/// able to ask for the second.
+#[tokio::test]
+async fn acl_list_filters_a_context_in_both_directions() {
+    let (app, ctx) = TestApp::new().await;
+    let token = ctx
+        .auth_token_aal2("did:key:z6MkAdmin", "admin", vec![])
+        .await;
+
+    // The layout the issue describes: a tenant, two units, a purpose leaf
+    // under each. Sub-contexts are created leaf-segment + `parent`.
+    for (id, parent) in [
+        ("acme", None),
+        ("eng", Some("acme")),
+        ("attestation", Some("acme/eng")),
+        ("ops", Some("acme")),
+        ("keys", Some("acme/ops")),
+    ] {
+        let mut req = json!({"id": id, "name": id});
+        if let Some(p) = parent {
+            req["parent"] = json!(p);
+        }
+        let (status, body) = app.request(post_auth("/contexts", &token, req)).await;
+        assert!(status.is_success(), "create context {id}: {body}");
+    }
+
+    for (did, context) in [
+        ("did:key:z6MkUnitAdmin", "acme/eng"),
+        ("did:key:z6MkGateway", "acme/eng/attestation"),
+        ("did:key:z6MkOps", "acme/ops/keys"),
+    ] {
+        let (status, body) = app
+            .request(post_auth(
+                "/acl",
+                &token,
+                json!({
+                    "did": did,
+                    "role": "application",
+                    "allowed_contexts": [context],
+                }),
+            ))
+            .await;
+        assert!(status.is_success(), "create {did}: {body}");
+    }
+
+    let dids = |body: &serde_json::Value| -> Vec<String> {
+        let mut v: Vec<String> = body["entries"]
+            .as_array()
+            .expect("entries array")
+            .iter()
+            .map(|e| e["did"].as_str().unwrap().to_string())
+            .collect();
+        v.sort();
+        v
+    };
+
+    // Default (absent) == acting-in: the unit's own admin, not the leaf under it.
+    let (status, body) = app.request(get_auth("/acl?context=acme/eng", &token)).await;
+    assert_eq!(status, StatusCode::OK);
+    let default_dids = dids(&body);
+    assert!(default_dids.contains(&"did:key:z6MkUnitAdmin".to_string()));
+    assert!(!default_dids.contains(&"did:key:z6MkGateway".to_string()));
+
+    let (status, body) = app
+        .request(get_auth(
+            "/acl?context=acme/eng&direction=acting-in",
+            &token,
+        ))
+        .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(dids(&body), default_dids, "explicit acting-in == absent");
+
+    // subtree: the leaf grant a revocation sweep must cut, and nothing from
+    // the sibling unit.
+    let (status, body) = app
+        .request(get_auth("/acl?context=acme/eng&direction=subtree", &token))
+        .await;
+    assert_eq!(status, StatusCode::OK);
+    let subtree = dids(&body);
+    assert!(subtree.contains(&"did:key:z6MkGateway".to_string()));
+    assert!(subtree.contains(&"did:key:z6MkUnitAdmin".to_string()));
+    assert!(!subtree.contains(&"did:key:z6MkOps".to_string()));
+
+    // A typo is refused with the valid set, not answered with the other
+    // question.
+    let (status, body) = app
+        .request(get_auth(
+            "/acl?context=acme/eng&direction=descendants",
+            &token,
+        ))
+        .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{body}");
+    let rendered = body.to_string();
+    for valid in ["acting-in", "subtree", "any"] {
+        assert!(rendered.contains(valid), "error omits {valid}: {rendered}");
+    }
+
+    // A direction with nothing to point at is refused rather than silently
+    // returning the whole ACL.
+    let (status, body) = app
+        .request(get_auth("/acl?direction=subtree", &token))
+        .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{body}");
+}
+
 /// An AAL1 admin hitting an AAL2-gated mutation is rejected with the step-up
 /// `403` that *carries the approve-request* — not a bare 403. The caller has
 /// the right role (so this isn't a permission failure); it just hasn't stepped

--- a/vti-common/Cargo.toml
+++ b/vti-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-common"
 description = "Shared server-side infrastructure for VTA and VTC services"
 readme = "README.md"
-version = "0.11.26"
+version = "0.11.27"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vti-common/src/acl/mod.rs
+++ b/vti-common/src/acl/mod.rs
@@ -268,7 +268,7 @@ impl DeviceBinding {
 /// server crates. Only the *shape* is shared — every authorization rule over
 /// it ([`validate_approve_scope_grant`] below) stays here. Same arrangement as
 /// [`crate::context_path`].
-pub use vta_sdk::acl::{ActScope, ApproveScope};
+pub use vta_sdk::acl::{ActScope, ApproveScope, ContextDirection};
 
 /// Decode the stored `(role, allowed_contexts)` pair into an explicit
 /// [`ActScope`].
@@ -853,6 +853,33 @@ pub fn delegated_any_approver_covers(approver: &AclEntry, subject: &AclEntry) ->
 /// with `contains`, so neither surfaced it.
 pub fn acl_entry_can_act_in(entry: &AclEntry, context_id: &str) -> bool {
     entry.act_scope().covers(context_id)
+}
+
+/// Whether `entry` holds a grant **at or beneath** `context_id` — the
+/// complement of [`acl_entry_can_act_in`], and the predicate a subtree sweep
+/// (revoke everything under this branch) needs.
+///
+/// See [`ActScope::acts_within`] for the two edges: an unrestricted entry is
+/// deliberately *not* a match, and a multi-context entry matches if any one of
+/// its contexts is inside the subtree.
+pub fn acl_entry_acts_within(entry: &AclEntry, context_id: &str) -> bool {
+    entry.act_scope().acts_within(context_id)
+}
+
+/// Whether `entry` matches `context_id` read in `direction` — the one filter
+/// every context-scoped ACL listing goes through, online and offline.
+///
+/// The direction is explicit at the call site because the answer is only
+/// meaningful paired with the question: `?context=X` alone cannot express
+/// whether the caller means "who may act in X" or "what is granted beneath X",
+/// and the second, asked with the first's filter, returns exactly the entries
+/// that are *not* the ones the caller is looking for (#822).
+pub fn acl_entry_matches_context(
+    entry: &AclEntry,
+    context_id: &str,
+    direction: ContextDirection,
+) -> bool {
+    entry.act_scope().matches_context(context_id, direction)
 }
 
 /// Whether an ACL entry is within the caller's authority to **manage**.
@@ -1624,6 +1651,99 @@ mod tests {
             &sample_entry("did:key:zB", Role::Reader),
             ctx
         ));
+    }
+
+    // ── acl_entry_acts_within / acl_entry_matches_context ───────────
+
+    /// The revocation sweep the old filter could not express: under a
+    /// per-purpose leaf layout, `?context=<tenant>/<unit>` returned the
+    /// ancestors keeping their authority and omitted every leaf grant the
+    /// sweep existed to cut (#822).
+    #[test]
+    fn a_subtree_sweep_finds_the_leaves_the_act_filter_omits() {
+        let leaf = scoped_entry(
+            "did:key:zGateway",
+            Role::Application,
+            &["acme/eng/attestation"],
+        );
+        let unit = "acme/eng";
+
+        assert!(
+            !acl_entry_can_act_in(&leaf, unit),
+            "correct for the act question, and the reason the sweep missed it"
+        );
+        assert!(acl_entry_acts_within(&leaf, unit), "the sweep must see it");
+        assert!(acl_entry_matches_context(
+            &leaf,
+            unit,
+            ContextDirection::Any
+        ));
+    }
+
+    /// The sweep must not reach outside its branch — a sibling unit and a
+    /// string-prefix lookalike both stay out.
+    #[test]
+    fn a_subtree_sweep_stops_at_the_branch() {
+        let sibling = scoped_entry("did:key:zOps", Role::Reader, &["acme/ops/keys"]);
+        let lookalike = scoped_entry("did:key:zLook", Role::Reader, &["acme/engineering"]);
+        assert!(!acl_entry_acts_within(&sibling, "acme/eng"));
+        assert!(!acl_entry_acts_within(&lookalike, "acme/eng"));
+        assert!(
+            acl_entry_acts_within(&lookalike, "acme"),
+            "still under acme"
+        );
+    }
+
+    /// A super-admin can act beneath any context, but it is not a grant *of*
+    /// the branch. Returning it from a sweep would hand a caller revoking a
+    /// compromised branch its own super-admin to delete; `any` is where an
+    /// auditor asks for it.
+    #[test]
+    fn a_subtree_sweep_does_not_offer_up_the_super_admin() {
+        let super_admin = sample_entry("did:key:zSuper", Role::Admin);
+        assert!(!acl_entry_acts_within(&super_admin, "acme/eng"));
+        assert!(acl_entry_matches_context(
+            &super_admin,
+            "acme/eng",
+            ContextDirection::ActingIn
+        ));
+        assert!(acl_entry_matches_context(
+            &super_admin,
+            "acme/eng",
+            ContextDirection::Any
+        ));
+    }
+
+    /// An acts-nowhere entry is in no direction's answer.
+    #[test]
+    fn acts_nowhere_is_in_no_direction() {
+        let nowhere = sample_entry("did:key:zNowhere", Role::Reader);
+        for d in ContextDirection::ALL {
+            assert!(
+                !acl_entry_matches_context(&nowhere, "acme", d),
+                "acts-nowhere surfaced under {d}"
+            );
+        }
+    }
+
+    /// The default direction is the pre-#822 filter, entry for entry.
+    #[test]
+    fn the_default_direction_reproduces_the_old_filter() {
+        let entries = [
+            sample_entry("did:key:zSuper", Role::Admin),
+            sample_entry("did:key:zNowhere", Role::Reader),
+            scoped_entry("did:key:zParent", Role::Reader, &["acme"]),
+            scoped_entry("did:key:zSelf", Role::Reader, &["acme/eng"]),
+            scoped_entry("did:key:zLeaf", Role::Reader, &["acme/eng/team-a"]),
+        ];
+        for entry in &entries {
+            assert_eq!(
+                acl_entry_matches_context(entry, "acme/eng", ContextDirection::default()),
+                acl_entry_can_act_in(entry, "acme/eng"),
+                "default direction diverged for {}",
+                entry.did
+            );
+        }
     }
 
     // ── is_acl_entry_auditable ──────────────────────────────────────


### PR DESCRIPTION
Closes #822.

`GET /acl?context=X` answers "who may act **in** X" — entries scoped to X or to an ancestor of it. That is correct, and it is one of *two* questions a context id raises, because a context id names a subtree. The other — "what is granted **beneath** X" — had no way to be asked, and asking it with the act-in filter returns precisely the entries that are **not** the answer: the ancestors keeping their authority, with every leaf-scoped grant omitted. Short, not empty, so it reads as complete.

That bites on revocation. Once sub-contexts exist the least-privilege layout is a leaf per purpose (`<tenant>/<unit>/<purpose>` — partly because, absent a per-key actor grant (#818), a context of its own is the only way to scope a caller to one key), and a sweep of `<tenant>/<unit>` then misses *every* principal under it. Cierge's kill switch hit exactly this (affinidi/cierge#49): a gateway grant at `<domain>/attestation` survived the cut and could keep signing as the killed domain while the report said success.

## The shape

An explicit direction on the filter, defaulting to today's behaviour:

| direction | question | predicate |
|---|---|---|
| `acting-in` (default) | who may act **in** X? | entry scope `is_ancestor_or_self` of X |
| `subtree` | what is granted **beneath** X? | X `is_ancestor_or_self` of the entry scope |
| `any` | whose authority **touches** X's subtree? | either |

One enum rather than a `subtree=true` flag — the issue's own open question. "Either direction" is the third question an auditor actually asks and a boolean cannot spell it. The predicate is the existing one with its arguments swapped (`ActScope::acts_within` beside `covers`), so both directions stay the same pure, store-free segment comparison.

Surfaces: `GET /acl?context=…&direction=…`, a `direction` member on the `spec/vta/acl/list/1.0` payload (and the DIDComm `list-acl` body), `pnm|cnm acl list --direction`, the offline `vta acl list --direction`, and `VtaClient::list_acl_in_direction`. `VtaClient::list_acl` is unchanged and stays `acting-in`; the client omits the parameter entirely at the default, so a request meaning what an older VTA already does still reaches it.

## Two edges, both deliberate and tested

- **An unrestricted (super-admin) entry is *not* in the `subtree` answer.** It names no context, so it is not a grant *of* the branch — it is authority everywhere, which `acting-in` already reports. Returning it would hand a caller revoking a compromised branch its own super-admin to delete. `any` is where an auditor asks for it.
- **An entry naming contexts inside *and* outside the branch *is* in it.** It does hold a grant inside, so omitting it would under-report — the failure mode being fixed. Whether to delete the entry or narrow its scope is then a decision made with the entry in hand.

## Fail-closed

Absent parameter is byte-for-byte the previous behaviour, pinned at the scope, entry, and operation layers. An unparseable direction is refused **with the valid set** rather than defaulted, and a direction with no context is refused rather than silently answered with the whole ACL — guessing which of two opposite questions the caller meant is the defect, one level up. Visibility (`is_acl_entry_auditable`) is still applied before the filter in every direction, pinned by a test that a sibling-unit admin sees nothing under `acme/eng` in any of the three. The CLI prints the question it asked beside the count, including on an empty result — otherwise an empty sweep and a wrong-direction sweep look identical.

## The VTC question, answered rather than done

Its equivalent filter deliberately did **not** follow. The VTC listing is bound to the canonical `acl/list/0.1` Trust Task, whose payload is `additionalProperties: false` over `{cursor, ext, pageSize, role, scope, subjectPrefix}`, so a `direction` member there is an openvtc spec change (or an `ext` member), not a local one — adding it unilaterally would be exactly the canonical-conformance drift the VTC migration exists to remove. Recorded as a follow-up in `docs/05-design-notes/acl-scope-semantics.md`, with the trap for whoever picks it up: the VTC list is **paginated**, so `direction` must also join `ListAclQuery::cursor_binding`, or a resumed sweep silently changes question mid-listing.

## Testing

- `vta-sdk`: mirror/segment-awareness/union/default-equivalence/wire-spelling + refusal of an unknown value on `ContextDirection` and `ActScope::acts_within`.
- `vti-common`: the sweep finds the leaves the act filter omits, stops at the branch (sibling + `acme/engineering` lookalike), does not offer up the super-admin, acts-nowhere is in no direction, default reproduces the old filter entry for entry.
- `vta-service` operations: all three directions over the tenant/unit/purpose layout, visibility not widened, direction-without-context refused.
- `vta-service` REST integration: `?direction=` end to end incl. `acting-in` == absent, a typo answered with the valid set (400), and `?direction=` alone refused.
- `vta-sdk` REST client: the parameter rides the query only when it is not the default.

`cargo fmt` / `clippy --workspace --all-targets` clean; full `vta-service`, `vta-sdk`, `vti-common`, `vta-cli-common`, `pnm-cli`, `cnm-cli` suites green. All three release guards (`check-changelogs.sh`, `check-version-bumps.sh`, `check-lockfile-self-pins.sh`) pass against `origin/main`.

Version bumps: vta-sdk 0.20.5, vti-common 0.11.27, vta-service 0.12.42, vta-cli-common 0.10.16, pnm-cli 0.11.11, cnm-cli 0.11.10.