### PR TITLE
fix: re-export resolve_vta_with_resolver alongside resolve_vta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## Unreleased
 
+### vta-sdk 0.20.6 — re-export `resolve_vta_with_resolver` alongside `resolve_vta`
+
+`provision_client` re-exports a curated list, and #813 added
+`resolve_vta_with_resolver` to `resolve.rs` without adding it there. So the
+function existed and was `pub`, but not at the path its sibling lives at:
+`provision_client::resolve_vta` worked while
+`provision_client::resolve_vta_with_resolver` did not, and a consumer had to
+reach through `provision_client::resolve::` to find it.
+
+OpenVTC hit exactly that wiring its TSP discovery tests
+(OpenVTC/openvtc#198) and worked around it with the deeper path. An
+asymmetric export on a pair of functions that differ only by "and here is
+the resolver" is the kind of thing every future caller stubs a toe on.
+
+Additive — the deeper path keeps working, so nothing that already compiles
+breaks.
+
 ### vta-sdk 0.20.5 / vti-common 0.11.27 / vta-service 0.12.42 / vta-cli-common 0.10.16 / pnm-cli 0.11.11 / cnm-cli 0.11.10 — ACL listings can be asked which direction a context filter reads (#822)
 
 `GET /acl?context=X` answers "who may act **in** X" — entries scoped to X or to

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10269,7 +10269,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.20.5"
+version = "0.20.6"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.20.5"
+version = "0.20.6"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/provision_client/mod.rs
+++ b/vta-sdk/src/provision_client/mod.rs
@@ -87,6 +87,6 @@ pub use error::ProvisionError;
 pub use event::{AttemptLog, AttemptResult, AttemptResultKind, VtaEvent};
 pub use intent::{AdminCredentialReply, VtaIntent, VtaReply};
 pub use messages::{MediatorMessages, OperatorMessages, WebvhServerMessages};
-pub use resolve::{ResolvedVta, resolve_vta};
+pub use resolve::{ResolvedVta, resolve_vta, resolve_vta_with_resolver};
 pub use result::{ProvisionResult, admin_rotation_response_to_reply, response_to_result};
 pub use setup_key::EphemeralSetupKey;

--- a/vta-sdk/src/provision_client/resolve.rs
+++ b/vta-sdk/src/provision_client/resolve.rs
@@ -124,7 +124,22 @@ fn flatten(vta_did: &str, endpoint: VtaEndpoint) -> Result<ResolvedVta, Provisio
 #[cfg(test)]
 mod tests {
     use super::*;
+
     use crate::protocol::matching::Protocol;
+    /// Both discovery entry points must be exported from `provision_client`
+    /// itself, not just from this module.
+    ///
+    /// #813 added `resolve_vta_with_resolver` to this file but not to
+    /// `provision_client`'s curated `pub use` list, so it was reachable only via
+    /// `provision_client::resolve::`. This import fails to compile if that
+    /// happens again — which is exactly how it was introduced.
+    ///
+    /// Deliberately a unit test rather than a `tests/` file: an integration test
+    /// is a separate binary, and in a workspace this size each one links hundreds
+    /// of rlibs. The first version of this guard was a `tests/reexport_check.rs`
+    /// and the CI Test job ran the runner out of disk.
+    #[allow(unused_imports)]
+    use crate::provision_client::{resolve_vta, resolve_vta_with_resolver};
 
     fn resolved(tsp: Option<&str>, didcomm: Option<&str>, rest: Option<&str>) -> ResolvedVta {
         ResolvedVta {

--- a/vta-sdk/tests/reexport_check.rs
+++ b/vta-sdk/tests/reexport_check.rs
@@ -1,9 +1,0 @@
-//! Compile-only proof that both discovery entry points live at the same path.
-//! `resolve_vta_with_resolver` was added in #813 but omitted from
-//! `provision_client`'s re-export list, so it was reachable only through
-//! `provision_client::resolve::`. This fails to compile if that regresses.
-#[allow(unused_imports)]
-use vta_sdk::provision_client::{resolve_vta, resolve_vta_with_resolver};
-
-#[test]
-fn both_entry_points_are_exported_from_provision_client() {}

--- a/vta-sdk/tests/reexport_check.rs
+++ b/vta-sdk/tests/reexport_check.rs
@@ -1,0 +1,9 @@
+//! Compile-only proof that both discovery entry points live at the same path.
+//! `resolve_vta_with_resolver` was added in #813 but omitted from
+//! `provision_client`'s re-export list, so it was reachable only through
+//! `provision_client::resolve::`. This fails to compile if that regresses.
+#[allow(unused_imports)]
+use vta_sdk::provision_client::{resolve_vta, resolve_vta_with_resolver};
+
+#[test]
+fn both_entry_points_are_exported_from_provision_client() {}


### PR DESCRIPTION
Mine to fix — I added the function in #813 and missed the re-export list.

## The gap

`provision_client` re-exports a **curated** list:

```rust
pub use resolve::{ResolvedVta, resolve_vta};
```

#813 added `resolve_vta_with_resolver` to `resolve.rs` without adding it there. The function exists and is `pub`, but not at the path its sibling lives at — `provision_client::resolve_vta` works, `provision_client::resolve_vta_with_resolver` doesn't, and a consumer has to reach through `provision_client::resolve::` instead.

OpenVTC hit exactly that wiring its TSP discovery tests (OpenVTC/openvtc#198) and worked around it with the deeper path. An asymmetric export on a pair of functions differing only by *"and here is the resolver"* is the kind of thing every future caller stubs a toe on.

## The change

One line, plus a compile-only test that imports **both** names from `provision_client` and fails to build if either is pruned from the list again — which is precisely how this was introduced. That felt more useful than a comment asking the next editor to remember.

Additive: the deeper path keeps working, so nothing that already compiles breaks.

## Verification

- `cargo test -p vta-sdk --features session,client,didcomm,provision-client` — 462 + 16 + 78 + … all green, 0 failed
- `cargo clippy --workspace -- -D warnings` (CI's invocation) — clean
- `cargo fmt --all --check` — clean
- `scripts/check-version-bumps.sh` — `ok vta-sdk: 0.20.4 -> 0.20.5`
- `scripts/check-changelogs.sh` — `ok vta-sdk: 0.20.4 -> 0.20.5 (documented)`

Incidentally this also exercised #815 for real: the worktree is under `/tmp`, and both guards reported correctly rather than the vacuous "nothing to check" they'd have given before that fix.

## Follow-on

Once 0.20.5 publishes, OpenVTC can drop its `provision_client::resolve::` workaround and the note explaining it.
