### PR TITLE
docs(security-model): re-ground the TEE security model against current code

### DIFF
--- a/docs/01-concepts/security-model.md
+++ b/docs/01-concepts/security-model.md
@@ -3,9 +3,10 @@
 ## Overview
 
 The VTA implements a defense-in-depth security model with eight layers of
-protection when deployed in TEE mode. Non-TEE deployments use layers 4-8;
-TEE deployments add hardware isolation, KMS-backed secrets, and encrypted
-storage.
+protection when deployed in TEE mode. Non-TEE deployments use the
+identity/access, seal, and audit layers (5, 6, 8); TEE deployments add
+hardware isolation, KMS-backed secrets, encrypted storage, config locking,
+and the vsock network controls (layers 1-4, 7).
 
 For TEE implementation details (KMS bootstrap code, encrypted store layer,
 config changes), see [TEE Enclave Security Design](tee-architecture.md).
@@ -35,7 +36,7 @@ config changes), see [TEE Enclave Security Design](tee-architecture.md).
 - Storage key derived from master seed via HKDF-SHA256
 - Deterministic derivation -- same seed produces same key across restarts
 - Keys stored in plaintext for prefix scans; values always encrypted
-- Each value: `[12-byte random nonce][ciphertext][16-byte auth tag]`
+- Each value: `[4-byte magic "VAE1"][12-byte random nonce][ciphertext + 16-byte GCM tag]`, AEAD-bound (AAD) to its `(keyspace, key)` location
 
 ### Layer 4: Configuration Locking
 - When KMS bootstrap is active, environment variable overrides are blocked
@@ -53,7 +54,7 @@ config changes), see [TEE Enclave Security Design](tee-architecture.md).
   - **Admin**: full key/DID/audit management within contexts
   - **Monitor**: infrastructure-only (metrics, health)
 - Context scoping restricts access to assigned application contexts
-- DID method whitelist blocks unsafe `did:web` in TEE mode
+- Optional DID-method allowlist (`tee.allowed_did_methods`, TEE-only, off by default) can restrict which DID methods may authenticate
 - Session state machine prevents challenge replay
 
 ### Layer 6: VTA Seal
@@ -240,7 +241,7 @@ Client                          VTA (in enclave)
 │     Semi-Trusted Zone            │
 │  (Parent EC2 instance)           │
 │  - enclave-proxy                 │
-│  - EBS volumes (ciphertext only) │
+│  - EBS (fjall, ciphertext only)  │
 │  - IAM role (limited)            │
 └──────────────┬───────────────────┘
                │ vsock (no network)
@@ -249,7 +250,7 @@ Client                          VTA (in enclave)
 │  (Nitro Enclave)                 │
 │  - VTA service                   │
 │  - Plaintext secrets (memory)    │
-│  - Encrypted storage (fjall)     │
+│  - Storage encryption key (mem)  │
 │  - /dev/nsm (attestation)        │
 └──────────────────────────────────┘
 ```
@@ -276,7 +277,7 @@ Client                          VTA (in enclave)
   seed / data-key plaintext even by MITM'ing the vsock or TLS path to KMS
 - Anti-rollback anchor: an external monotonic counter (DynamoDB, attestation-gated
   writer) detects EBS snapshot rollback / state replay when configured (`tee.kms.anchor`)
-- DID method whitelist blocks `did:web` through untrusted resolver
+- Optional DID-method allowlist (`tee.allowed_did_methods`) restricts which DID methods may authenticate, enforced at auth time (off unless configured)
 
 #### A3: Supply Chain Attacker
 **Capabilities:** Modify the enclave image or signing certificate.
@@ -320,7 +321,8 @@ Steal master seed
 │   │   └── Brute-force Ed25519 → computationally infeasible
 │   └── Bypass time window → entropy zeroed after window
 └── Intercept during KMS Decrypt
-    ├── MITM vsock proxy → TLS to KMS (webpki-roots)
+    ├── MITM vsock proxy → end-to-end TLS enclave↔KMS (CONNECT tunnel,
+    │   not terminated by the parent; system CA bundle in-enclave)
     └── Read KMS response → attestation-encrypted to enclave
         (CiphertextForRecipient, RSAES-OAEP to in-enclave RSA-2048)
 ```
@@ -377,6 +379,7 @@ Escalate privileges
 | ECDSA P-384 | EIF signing (Nitro) | 384-bit | FIPS 186-4 |
 | COSE_Sign1 | Attestation reports (Nitro) | ES384 | RFC 8152 |
 | RSAES-OAEP-SHA256 | KMS attested `Recipient` (data-key unwrap) | RSA-2048 (ephemeral) | PKCS#1 v2.2 |
+| AES-256-CBC | KMS `CiphertextForRecipient` CMS content encryption | 256-bit | RFC 5652 / NIST SP 800-38A |
 
 ## Deployment Security Checklist
 

--- a/docs/01-concepts/security-model.md
+++ b/docs/01-concepts/security-model.md
@@ -24,6 +24,11 @@ config changes), see [TEE Enclave Security Design](tee-architecture.md).
 - KMS key policy requires PCR0 (image hash) + PCR8 (signing cert)
 - Only the exact enclave image + signing cert can decrypt secrets
 - JWT signing key also KMS-encrypted with fingerprint verification
+- KMS calls are **attestation-gated**: `GenerateDataKey` and `Decrypt` pass a
+  `Recipient` carrying an NSM attestation document, and KMS returns
+  `CiphertextForRecipient` wrapped (RSAES-OAEP-SHA256) to an ephemeral RSA-2048
+  key generated inside the enclave. The seed / data-key plaintext is therefore
+  never exposed to the parent, even on the vsock + TLS path to KMS.
 
 ### Layer 3: Encrypted Storage
 - All fjall keyspace values encrypted with AES-256-GCM
@@ -64,10 +69,15 @@ the unseal dance) lives in
 [`02-vta/seal-and-unseal.md`](../02-vta/seal-and-unseal.md).
 
 ### Layer 7: Network Controls
-- Three vsock channels with strict purpose separation:
+- Seven vsock channels with strict purpose separation (all network I/O is
+  brokered by the parent-side proxy -- the enclave has no direct network):
   - Inbound REST (port 5100): client requests to VTA
   - Outbound mediator (port 5200): DIDComm messaging with TLS
-  - Outbound HTTPS (port 5300): allowlisted destinations only
+  - Outbound HTTPS (port 5300): allowlisted destinations only (KMS, etc.)
+  - IMDS credential proxy (port 5400): IMDSv2, hop-limited
+  - Storage proxy (port 5500): fjall keyspace I/O -- ciphertext only
+  - DID resolver bridge (port 5600): resolver sidecar on the parent
+  - Log forwarding (port 5700): enclave logs forwarded to parent stdout
 - HTTPS CONNECT proxy validates every request against allowlist
 - Non-CONNECT requests rejected with 405 Method Not Allowed
 - Connection limits prevent resource exhaustion
@@ -97,6 +107,7 @@ graph LR
     VTA -->|vsock :5400| Proxy --> IMDS
     VTA -->|vsock :5500| Proxy --> Store
     VTA -->|vsock :5600| Proxy --> Resolver
+    VTA -->|vsock :5700| Proxy --> Logs[Parent stdout]
 ```
 
 ### Layer 8: Audit & Observability
@@ -167,6 +178,16 @@ graph LR
    │   envelope (Argon2id + AES-256-GCM)      │
    └─────────────────────────────────────────┘
 ```
+
+**Boot with a KMS decrypt failure (fail-closed).** On a subsequent boot, if
+`KMS Decrypt` of the stored `seed.enc` / `jwt.enc` fails, the VTA does **not**
+blindly regenerate its identity. Only an `AccessDenied` result -- the expected
+signal after an image rebuild changes PCR0 -- or an explicit
+`tee.kms.allow_kms_reinit = true` clears the bootstrap keyspace and mints a
+fresh identity. Every other error class (KMS internal, network, invalid
+ciphertext, unknown) is treated as a transient outage or possible tampering:
+the VTA refuses to start rather than silently reset its DID and keys. Resetting
+a live identity is thus always a deliberate, logged action.
 
 ## Authentication Flow
 
@@ -243,13 +264,18 @@ Client                          VTA (in enclave)
 - HTTPS CONNECT proxy with allowlist (outbound)
 
 #### A2: Compromised Parent Instance
-**Capabilities:** Root access to the EC2 host. Can read EBS, modify proxy, inject env vars.
+**Capabilities:** Root access to the EC2 host. Can read or roll back EBS, modify the proxy, inject env vars.
 **Mitigations:**
 - Nitro Enclave memory isolation (hypervisor-enforced)
 - KMS key policy with PCR pinning (PCR0 + PCR8)
 - Environment variable locking when KMS bootstrap active
 - Storage encrypted with AES-256-GCM (key only in enclave memory)
 - Attestation reports prove enclave identity to clients
+- KMS `Decrypt` / `GenerateDataKey` responses are attestation-encrypted
+  (`Recipient` -> `CiphertextForRecipient`), so a root parent cannot read the
+  seed / data-key plaintext even by MITM'ing the vsock or TLS path to KMS
+- Anti-rollback anchor: an external monotonic counter (DynamoDB, attestation-gated
+  writer) detects EBS snapshot rollback / state replay when configured (`tee.kms.anchor`)
 - DID method whitelist blocks `did:web` through untrusted resolver
 
 #### A3: Supply Chain Attacker
@@ -295,7 +321,8 @@ Steal master seed
 │   └── Bypass time window → entropy zeroed after window
 └── Intercept during KMS Decrypt
     ├── MITM vsock proxy → TLS to KMS (webpki-roots)
-    └── Read KMS response → TLS encrypted (TODO: Recipient param)
+    └── Read KMS response → attestation-encrypted to enclave
+        (CiphertextForRecipient, RSAES-OAEP to in-enclave RSA-2048)
 ```
 
 #### AT2: Impersonate VTA
@@ -320,6 +347,8 @@ Escalate privileges
 │   └── Ed25519 signing key only in enclave memory
 ├── Replay auth challenge
 │   └── Nonce stored in session KS, state machine prevents replay
+├── Roll back EBS to pre-revocation state
+│   └── Anti-rollback anchor (monotonic counter) detects stale state
 └── Create admin via API
     └── Requires existing admin/initiator JWT with Manage role
 ```
@@ -328,7 +357,8 @@ Escalate privileges
 
 | Risk | Severity | Status | Notes |
 |------|----------|--------|-------|
-| KMS Recipient parameter not implemented | Medium | TODO | Parent could theoretically intercept KMS Decrypt response; mitigated by TLS + key policy |
+| KMS Recipient parameter | n/a | Implemented | `GenerateDataKey`/`Decrypt` use an attestation-bound `Recipient`; KMS returns `CiphertextForRecipient` (RSAES-OAEP-SHA256) to an ephemeral in-enclave RSA-2048 key, so the parent never sees plaintext |
+| EBS snapshot rollback / state replay | Medium | Mitigated (config-gated) | Anti-rollback anchor (external monotonic counter, DynamoDB, attestation-gated writer) detects replayed state when `tee.kms.anchor` is set; manifest-only if unset |
 | No per-IP rate limiting in VTA | Low | Mitigated | Deploy behind reverse proxy with rate limiting |
 | Health endpoint information disclosure | Low | Fixed | Split into minimal (public) and detailed (auth required) |
 | DID resolver through parent | Low | Mitigated | Whitelist blocks `did:web`; `did:key` and `did:webvh` are self-certifying |
@@ -346,14 +376,17 @@ Escalate privileges
 | SHA-256 | JWT fingerprint, nonce hashing | 256-bit | FIPS 180-4 |
 | ECDSA P-384 | EIF signing (Nitro) | 384-bit | FIPS 186-4 |
 | COSE_Sign1 | Attestation reports (Nitro) | ES384 | RFC 8152 |
+| RSAES-OAEP-SHA256 | KMS attested `Recipient` (data-key unwrap) | RSA-2048 (ephemeral) | PKCS#1 v2.2 |
 
 ## Deployment Security Checklist
 
 - [ ] TEE mode set to `required` (not `optional` or `simulated`)
+- [ ] Parent instance is enclave-eligible (Graviton `.large`+ / x86 `.xlarge`+; T-family is not enclave-capable)
 - [ ] KMS key policy pinned to PCR0 + PCR8
 - [ ] EIF signed with offline P-384 key
 - [ ] IAM role limited to `kms:GenerateDataKey` + `kms:Decrypt` (both attestation-gated)
 - [ ] KMS admin requires MFA for policy changes
+- [ ] Anti-rollback anchor configured (`tee.kms.anchor`) if rollback protection is required
 - [ ] DID method whitelist: `["did:key", "did:webvh"]`
 - [ ] Reverse proxy with TLS, rate limiting, CORS policy
 - [ ] Mnemonic exported and stored securely offline


### PR DESCRIPTION
## Summary

Re-grounds `docs/01-concepts/security-model.md` against the current TEE
implementation. The document had drifted from the code in several places; this
corrects the inaccurate/stale claims and fills gaps, verified against the
implementation.

## Corrections

**Pass 1 — stale/incomplete claims:**
- **KMS attestation (Recipient):** `GenerateDataKey`/`Decrypt` now pass an
  NSM-attested `Recipient`; KMS returns `CiphertextForRecipient` wrapped
  (RSAES-OAEP-SHA256) to an ephemeral in-enclave RSA-2048 key. Updated the
  residual-risk row (was "TODO/not implemented"), the AT1 tree, added a Layer 2
  bullet + A2 mitigation and a crypto-inventory row.
- **vsock channels:** Layer 7 said "three"; the proxy actually brokers seven
  (REST, mediator, HTTPS, IMDS, storage, resolver, logs). Enumerated all and added
  the log channel to the enclave↔proxy diagram.
- **Fail-closed boot:** documented that a KMS decrypt failure only re-mints
  identity on `AccessDenied` (post-rebuild PCR0 change) or explicit
  `allow_kms_reinit`; all other error classes refuse to start.
- **Anti-rollback anchor:** added the EBS rollback / state-replay threat and its
  mitigation (external monotonic counter, config-gated) to the A2 adversary, AT3
  tree, and residual-risk table.
- **Deployment checklist:** enclave-eligible instance floor + optional
  anti-rollback anchor configuration.

**Pass 2 — six code-grounding fixes:**
- Overview: non-TEE deployments use layers 5, 6, 8 (not "4–8") — Layer 4 (config
  locking) is KMS-gated and Layer 7 (vsock) is TEE-only.
- Layer 3: storage value format is `[4-byte magic "VAE1"][12-byte nonce][ciphertext
  + 16-byte GCM tag]`, AAD-bound to its `(keyspace, key)` location.
- Layer 5 / A2: the DID-method restriction is an optional allowlist (TEE-only, off
  by default) enforced at auth time — it does not unconditionally block `did:web`.
- Trust Boundaries: fjall storage physically lives on the parent EBS (semi-trusted);
  the enclave holds only the storage-encryption key in memory.
- Attack tree: KMS `Decrypt` uses end-to-end TLS enclave↔KMS over a CONNECT tunnel
  not terminated by the parent; `webpki-roots` is the proxy's mediator/resolver
  trust store, not the KMS path.
- Crypto inventory: add AES-256-CBC (KMS `CiphertextForRecipient` CMS content
  encryption).

Docs-only; no crate sources or versions touched.
