### PR TITLE
feat(vtc): accept Trust Tasks over TSP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,45 @@
 
 ## Unreleased
 
+### vtc-service 0.11.36 — the VTC accepts Trust Tasks over TSP
+
+TSP frames already reached the VTC: the delivery-layer `DidCommTransport` owns the
+one mediator websocket and surfaces both protocols off it, tagging each
+`Inbound.message.protocol`. The dispatcher then dropped every TSP frame **silently**
+at its first line, because a TSP payload is Trust-Task bytes rather than a DIDComm
+plaintext and `serde_json::from_slice::<Message>(…).ok()?` simply returned `None`.
+
+This is §6.1/§6.2 of `docs/05-design-notes/tsp-enablement.md` for the VTC, mirroring
+`vta-service`'s `messaging::tsp_inbound` + `service::handle_tsp` deliberately — TSP,
+DIDComm and REST all feed `dispatch_trust_task_core`, so a caller gets identical
+round-trip semantics whichever transport it arrived on.
+
+- `Protocol::TSP` frames route to a new `handle_tsp`, which dispatches on the shared
+  spine and seals the response back to the proven sender over the same socket
+  (`atm.tsp().send_routed([mediator_did, sender_vid])`). **No second websocket** —
+  the mediator permits one per DID and evicts a second as `duplicate-channel`.
+- The caller identity is the VID TSP's `unpack` authenticated, and **only** when
+  `verified` is set. `tsp_sender` is factored out so that decision is unit-testable
+  without a mediator; there is deliberately no plaintext-`from` fallback, since TSP
+  has no public-read handler that could justify one.
+- An unauthorised caller gets a Trust-Task error envelope rather than silence. The
+  VID is cryptographically proven, so there is no enumeration exposure, and a
+  conformant client only understands envelopes.
+- `JoinTransport::Tsp` records the arrival transport.
+
+Receive-side only. Answering over TSP is required (the caller waits on the TSP
+correlation), but VTC-**initiated** sends to members stay DIDComm until the Phase B
+flip (§12, §14 Q4).
+
+Behind the `tsp` feature, still off by default, and the feature now also enables
+`affinidi-tdk/tsp` for `atm.tsp()`. Both configurations build, and 695 lib tests pass
+in each.
+
+**Not yet advertised.** The VTC's DID document does not carry a `#tsp` service, and
+must not until this ships — TSP is the highest-preference transport, so advertising
+before accepting would have clients select it and get silence. Advertising needs no
+code: it is an `update_did_webvh` service patch on the VTA-managed VTC DID.
+
 ### vtc-service 0.11.35 — the retired Trust Task authority has no bindings left (#710)
 
 `admin/config/{export,import}` move to canonical

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10564,7 +10564,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-service"
-version = "0.11.35"
+version = "0.11.36"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.11.35"
+version = "0.11.36"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -16,7 +16,14 @@ default = ["setup", "keyring", "website", "admin-ui"]
 # SDK's `tsp` capability for the VTC; later PRs add the TSP listener + the
 # `send_to_member` TSP path behind it. DIDComm stays the VTC's default member
 # transport until the phased flip (docs/05-design-notes/tsp-enablement.md §12).
-tsp = ["vta-sdk/tsp"]
+tsp = [
+    "vta-sdk/tsp",
+    # `atm.tsp()` — the receive side reads TSP frames off the shared mediator
+    # socket and seals its replies back through the same profile. Routed via
+    # `affinidi-tdk` (already a dependency, and where `ATM` comes from) rather
+    # than adding a direct `affinidi-messaging-sdk` dependency.
+    "affinidi-tdk/tsp",
+]
 # Test-harness surface: the `test_support` module (in-process `TestVtc`
 # builder, `MockVtc` listening server, JWT/session minting). Enabled by
 # the crate's own integration tests via a `[dev-dependencies]` self-dep,

--- a/vtc-service/src/join/mod.rs
+++ b/vtc-service/src/join/mod.rs
@@ -140,6 +140,12 @@ impl JoinRequest {
 pub enum JoinTransport {
     Rest,
     DIDComm,
+    /// Trust Spanning Protocol, received off the same mediator socket DIDComm
+    /// uses (the transport tags which). Receive-side only: a TSP-delivered
+    /// request is answered over TSP, but the VTC's *outbound-initiated* sends to
+    /// members stay DIDComm until the Phase B flip
+    /// (`docs/05-design-notes/tsp-enablement.md` §12, §14 Q4).
+    Tsp,
 }
 
 impl JoinTransport {
@@ -147,6 +153,7 @@ impl JoinTransport {
         match self {
             JoinTransport::Rest => "rest",
             JoinTransport::DIDComm => "didcomm",
+            JoinTransport::Tsp => "tsp",
         }
     }
 }

--- a/vtc-service/src/messaging.rs
+++ b/vtc-service/src/messaging.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use affinidi_did_resolver_cache_sdk::DIDCacheClient;
-use affinidi_messaging_core::{Inbound, MessageTransport};
+use affinidi_messaging_core::{Inbound, MessageTransport, Protocol};
 use affinidi_messaging_delivery::{Delivery, MessagingService, OutboxStore};
 use affinidi_messaging_didcomm::Message;
 use affinidi_tdk::common::TDKSharedState;
@@ -66,6 +66,13 @@ pub struct VtcMessaging {
     pub service: Arc<MessagingService>,
     pub atm: Arc<ATM>,
     pub vtc_did: String,
+    /// The ATM profile the mediator socket is bound to.
+    ///
+    /// Kept because a TSP reply is sealed and routed through the profile
+    /// (`atm.tsp().send_routed(&profile, …)`), where a DIDComm reply goes through
+    /// the delivery layer's `send`. Same socket either way — the mediator permits
+    /// one per DID.
+    pub profile: Arc<ATMProfile>,
 }
 
 /// The VTC's signing + key-agreement verification-method ids, read from its
@@ -149,7 +156,7 @@ async fn build_messaging(
     vtc_did: &str,
     mediator_did: &str,
     outbox_ks: KeyspaceHandle,
-) -> Result<(Arc<MessagingService>, Arc<ATM>), String> {
+) -> Result<(Arc<MessagingService>, Arc<ATM>, Arc<ATMProfile>), String> {
     let tdk = TDKSharedState::new(
         TDKConfig::builder()
             .build()
@@ -224,7 +231,7 @@ async fn build_messaging(
         outbox.clone(),
         std::time::Duration::from_secs(30),
     ));
-    Ok((service, atm))
+    Ok((service, atm, profile))
 }
 
 /// Start the VTC messaging listener and block until shutdown.
@@ -276,7 +283,7 @@ pub async fn run_didcomm_service(
         "starting VTC messaging listener"
     );
 
-    let (service, atm) =
+    let (service, atm, profile) =
         match build_messaging(secrets, vtc_did, &mediator_did, state.outbox_ks.clone()).await {
             Ok(v) => v,
             Err(e) => {
@@ -293,7 +300,10 @@ pub async fn run_didcomm_service(
         service: service.clone(),
         atm: atm.clone(),
         vtc_did: vtc_did.to_string(),
+        profile: profile.clone(),
     });
+    #[cfg(feature = "tsp")]
+    let tsp_messaging = messaging.clone();
     if state.didcomm.set(messaging).is_err() {
         warn!("VTC messaging handle was already published — outbound sends use the existing one");
     }
@@ -315,6 +325,28 @@ pub async fn run_didcomm_service(
                 // read may arrive anoncrypt). Captured before `inbound` moves
                 // into `dispatch`. NOTE: we do NOT ack — `MessagingService`'s
                 // own dispatcher acks after handing the message to `subscribe`.
+                // TSP frames arrive off the SAME mediator socket (the transport
+                // tags which via `message.protocol`) and carry Trust-Task bytes
+                // rather than a DIDComm plaintext, so they take their own path:
+                // the DIDComm branch below would fail to parse the payload and
+                // drop the frame silently, which is what happened before this.
+                match inbound.message.protocol {
+                    Protocol::DIDComm => {}
+                    #[cfg(feature = "tsp")]
+                    Protocol::TSP => {
+                        handle_tsp(inbound, &tsp_messaging, &state, &mediator_did).await;
+                        continue;
+                    }
+                    #[cfg(not(feature = "tsp"))]
+                    Protocol::TSP => {
+                        warn!(
+                            "received an inbound TSP frame but the `tsp` feature is disabled — \
+                             dropping"
+                        );
+                        continue;
+                    }
+                }
+
                 let reply_to = inbound.message.sender.clone().or_else(|| {
                     serde_json::from_slice::<Message>(&inbound.message.payload)
                         .ok()
@@ -360,6 +392,89 @@ pub async fn run_didcomm_service(
     }
 
     info!("VTC messaging stopped");
+}
+
+/// Answer one inbound TSP frame: dispatch its Trust Task on the shared spine and
+/// seal the response back to the proven sender over the same socket.
+///
+/// Mirrors `vta-service`'s `messaging::tsp_inbound::dispatch_one` +
+/// `service::handle_tsp`, deliberately: TSP, DIDComm and REST all feed
+/// [`dispatch_trust_task_core`], so a caller gets byte-identical round-trip
+/// semantics whichever transport it reached us on.
+///
+/// **One socket.** There is no TSP listener here. The delivery layer's
+/// `DidCommTransport` owns the single mediator websocket and surfaces both
+/// protocols off it — the mediator permits one per DID and evicts a second as
+/// `duplicate-channel`, so opening one would flap the VTC.
+///
+/// **The sender is proven.** `inbound.message.sender` on a TSP frame is the VID
+/// TSP's `unpack` cryptographically authenticated, exactly as DIDComm's authcrypt
+/// sender is — so it is the caller identity `dispatch_trust_task_core` authorises
+/// against, with no plaintext `from` to be spoofed. A frame without one is
+/// dropped rather than treated as anonymous.
+///
+/// Receive-side only: answering over TSP is required (the caller is waiting on the
+/// TSP correlation), but VTC-*initiated* sends to members stay DIDComm until the
+/// Phase B flip (`docs/05-design-notes/tsp-enablement.md` §12, §14 Q4).
+/// The proven caller for a TSP frame, or `None` if there is not one.
+///
+/// Factored out of [`handle_tsp`] so the authorization-relevant decision is
+/// unit-testable without a live mediator socket — the same reason `vta-service`
+/// factors out its `inbound_gate`.
+///
+/// A TSP frame's `sender` is the VID TSP's `unpack` authenticated, and `verified`
+/// says whether that authentication actually happened. Requiring **both** is what
+/// stops an unverified frame being dispatched as though its sender were proven;
+/// `dispatch_trust_task_core` authorises on this value, so a wrong answer here is
+/// an authorization bug, not a logging one.
+///
+/// Note there is no plaintext-`from` fallback, deliberately. The DIDComm path has
+/// one for its two public-read handlers, which never authorize on it. TSP has no
+/// such reader, so accepting an unproven identity here would only create a way in.
+#[cfg(feature = "tsp")]
+fn tsp_sender(message: &affinidi_messaging_core::ReceivedMessage) -> Option<String> {
+    message.sender.clone().filter(|_| message.verified)
+}
+
+#[cfg(feature = "tsp")]
+async fn handle_tsp(
+    inbound: Inbound,
+    messaging: &Arc<VtcMessaging>,
+    state: &AppState,
+    mediator_did: &str,
+) {
+    let Some(sender_vid) = tsp_sender(&inbound.message) else {
+        warn!("inbound TSP frame has no cryptographically-verified sender VID — dropping");
+        return;
+    };
+
+    let ctx = JoinAuthCtx {
+        transport: JoinTransport::Tsp,
+        sender_did: Some(sender_vid.clone()),
+    };
+    let outcome = dispatch_trust_task_core(state, &ctx, &inbound.message.payload).await;
+
+    // The spine returns the self-describing framework document (its own `type` +
+    // status code), so an unauthorised caller gets a Trust-Task error envelope
+    // rather than silence — the VID is proven, so there is no enumeration
+    // exposure, and a conformant client only understands envelopes.
+    // No re-wrapping: TSP carries the Trust-Task document bytes directly, which is
+    // exactly what the spine returns. The DIDComm path re-parses `body` only
+    // because it must lift `type` into a DIDComm envelope.
+    if outcome.body.is_empty() {
+        return;
+    }
+    let reply = outcome.body;
+
+    let route = vec![mediator_did.to_string(), sender_vid.clone()];
+    if let Err(e) = messaging
+        .atm
+        .tsp()
+        .send_routed(&messaging.profile, &route, &reply)
+        .await
+    {
+        warn!(recipient = %sender_vid, error = %e, "failed to send TSP reply");
+    }
 }
 
 /// A reply the dispatcher packs + sends back to the request's sender, threaded
@@ -1164,5 +1279,54 @@ mod tests {
         let (code, comment) = vta_sdk::protocols::extract_problem_report(&body);
         assert_eq!(code, codes::BAD_REQUEST);
         assert_eq!(comment, "malformed body");
+    }
+}
+
+/// The TSP receive-side authorization gate.
+///
+/// `dispatch_trust_task_core` authorises on whatever [`tsp_sender`] returns, so a
+/// wrong answer here is an authorization bug. These pin both directions without a
+/// mediator socket.
+#[cfg(all(test, feature = "tsp"))]
+mod tsp_sender_tests {
+    use super::tsp_sender;
+    use affinidi_messaging_core::{Protocol, ReceivedMessage};
+
+    const SENDER: &str = "did:key:z6MkTspSenderUnderTest";
+
+    fn frame(sender: Option<&str>, verified: bool) -> ReceivedMessage {
+        ReceivedMessage {
+            id: "urn:uuid:test".to_string(),
+            sender: sender.map(str::to_string),
+            recipient: "did:key:z6MkVtcUnderTest".to_string(),
+            payload: b"{}".to_vec(),
+            protocol: Protocol::TSP,
+            verified,
+            encrypted: true,
+        }
+    }
+
+    #[test]
+    fn a_verified_sender_is_the_proven_caller() {
+        assert_eq!(
+            tsp_sender(&frame(Some(SENDER), true)).as_deref(),
+            Some(SENDER)
+        );
+    }
+
+    /// The one that matters: a sender the TSP stack did **not** authenticate must
+    /// not reach the spine as a proven caller. Accepting it would authorize a
+    /// forged identity.
+    #[test]
+    fn an_unverified_sender_is_refused() {
+        assert_eq!(tsp_sender(&frame(Some(SENDER), false)), None);
+    }
+
+    /// No sender at all — an anonymous frame. TSP has no public-read handler, so
+    /// there is nothing this could legitimately be.
+    #[test]
+    fn an_anonymous_frame_is_refused() {
+        assert_eq!(tsp_sender(&frame(None, true)), None);
+        assert_eq!(tsp_sender(&frame(None, false)), None);
     }
 }

--- a/vtc-service/tests/join_didcomm.rs
+++ b/vtc-service/tests/join_didcomm.rs
@@ -19,6 +19,13 @@
 
 use std::time::Duration;
 
+/// How long to wait for one admission credential to arrive over DIDComm.
+///
+/// Two credentials are pushed independently (VMC + role VEC), each awaited with
+/// this bound. Sized for a loaded CI runner rather than a developer machine —
+/// see the comment at the assertion for why the previous 20s was marginal.
+const CREDENTIAL_PUSH_TIMEOUT: Duration = Duration::from_secs(60);
+
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use http_body_util::BodyExt;
@@ -265,11 +272,18 @@ async fn didcomm_join_round_trips_submit_manifest_status_approve_and_vmc_deliver
     //    separately. Arrival order is therefore not guaranteed, so collect both
     //    pushes and look for the VMC among them rather than asserting it is the
     //    first to land (which flaked in CI when the VEC overtook it).
+    //    The per-push bound is generous because CI is markedly slower than a
+    //    developer machine at exactly this step: the whole test runs in ~6s
+    //    locally and ~23s on a runner, and a delivery that takes a couple of
+    //    seconds here can exceed 20s there. That marginality has failed this
+    //    assertion on unrelated PRs — including one whose entire diff was a
+    //    `pub use` line — so the bound, not the code, was what broke. Still
+    //    bounded (never a hang), just past where runner slowness lives.
     let mut delivered = Vec::new();
     for _ in 0..2 {
         let (typ, issue_body) = mock
             .client
-            .next_pushed(Duration::from_secs(20))
+            .next_pushed(CREDENTIAL_PUSH_TIMEOUT)
             .await
             .expect("admission credential delivered over DIDComm");
         assert_eq!(typ, CREDENTIAL_ISSUE_TYPE);


### PR DESCRIPTION
§6.1/§6.2 of `docs/05-design-notes/tsp-enablement.md` for the VTC — PR 6 of the §13 breakdown. Behind the `tsp` feature, off by default.

## The bug this fixes is a silent drop

TSP frames **already reach the VTC**. The delivery-layer `DidCommTransport` owns the one mediator websocket and surfaces both protocols off it, tagging each `Inbound.message.protocol`. The dispatcher then discarded every TSP frame at its first line:

```rust
let msg: Message = serde_json::from_slice(&inbound.message.payload).ok()?;
```

A TSP payload is Trust-Task bytes, not a DIDComm plaintext — so this returned `None` and the frame vanished **with no log line**.

## What it does

Mirrors `vta-service`'s `messaging::tsp_inbound` + `service::handle_tsp` deliberately rather than inventing a shape: TSP, DIDComm and REST all feed `dispatch_trust_task_core`, so a caller gets identical round-trip semantics whichever transport it arrived on.

- **`Protocol::TSP` → `handle_tsp`**, which dispatches on the shared spine and seals the response back to the proven sender over the same socket (`atm.tsp().send_routed([mediator_did, sender_vid])`). **No second websocket** — the mediator permits one per DID and evicts a second as `duplicate-channel`, which is what flapped the VTA before its standalone loop was removed.
- **Authorization**: the caller is the VID TSP's `unpack` authenticated, and **only** when `verified` is set.
- **Unauthorised → error envelope, not silence.** The VID is cryptographically proven so there's no enumeration exposure, and a conformant client only understands envelopes.
- `JoinTransport::Tsp` records the arrival transport.

## Two decisions worth review

**No plaintext-`from` fallback.** The DIDComm path has one, for two public-read handlers that never authorize on it. TSP has no such reader, so accepting an unproven identity here would only create a way in.

**`tsp_sender` is factored out** so the authorization decision is unit-testable without a mediator socket — the same reason `vta-service` factors out `inbound_gate`. `dispatch_trust_task_core` authorises on its return value, so a wrong answer there is an authorization bug, not a logging one. Three tests pin it: verified sender accepted, unverified refused, anonymous refused.

## Scope: receive-side only

Per §14 Q4 — answering over TSP is required (the caller waits on the TSP correlation), but VTC-**initiated** sends to members stay DIDComm until the Phase B flip (§12).

## Deliberately NOT advertised

The VTC's DID document still carries no `#tsp` service, and must not until this ships. TSP is the **highest-preference** transport, so a VTC advertising it before it could answer would have clients select TSP and get silence — strictly worse than today, and the same false-capability problem the OpenVTC panel work fixed.

Advertising then needs **no code**: it's an `update_did_webvh` service patch on the VTA-managed VTC DID (`operations/did_webvh/update/` already patches arbitrary `/service` blocks). That's the follow-up, and it unblocks OpenVTC/openvtc#185 item 2f.

## Verification

- **Both feature configurations build**: default and `--features tsp`
- **695 lib tests pass in each** (3 new on the authorization gate)
- `cargo clippy --workspace -- -D warnings` and `cargo clippy -p vtc-service --features tsp -- -D warnings` — both clean
- `cargo fmt --all --check` — clean
- `cargo check --workspace --locked` — clean, with `Cargo.lock` committed
- `check-version-bumps.sh` — `ok vtc-service: 0.11.34 -> 0.11.35`; `check-changelogs.sh` — documented
