### PR TITLE
feat(vtc)!: repoint config export/import, retiring the last openvtc/vtc bindings (#710)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,53 @@
 
 ## Unreleased
 
+### vtc-service 0.11.35 — the retired Trust Task authority has no bindings left (#710)
+
+`admin/config/{export,import}` move to canonical
+`spec/vtc/config/{export,import}/0.1`. They were the last two bindings on
+`https://trusttasks.org/openvtc/vtc/`, and **that authority is now unbound
+across the whole workspace** — router, `vta-sdk` constants, admin SPA and
+`cnm-cli` alike. All 66 entries in `trust-tasks/index.json` are `retired` with
+a `supersededBy`, which turns that file from a manifest into a redirect table.
+Both census tables in `vtc-service/tests/trust_task_manifest.rs` are empty;
+`no_new_bindings_on_the_retired_authority` is what stops it regressing one
+literal at a time.
+
+These two were the only entries whose recorded blocker was *real*: no canonical
+counterpart existed — `specs/config/` published `show`, `patch`, `reload`,
+`restart` and nothing to migrate to. They are now authored upstream
+(trust-tasks-tf#147, `trust-tasks-rs` 0.2.40, pinned here).
+
+**Not promoted into the generic `config/*` family.** The recorded plan was to
+push `communityProfile` into `ext` and make these generic. Dropped: the profile
+and its diff are roughly half the import's payload, so the "generic" task would
+have been a hollow shell in its only real use. They are `vtc/`-slugged, on the
+`vtc/backup/{export,import}` precedent.
+
+**Breaking wire changes** — the repoint is not a rename:
+
+- **`confirm` moves from the query string into the payload.** A Trust Task is
+  one interface over REST, DIDComm and TSP, and only REST has a query string to
+  carry a flag in. A stale client still sending `?confirm=true` now **previews**
+  instead of applying — the recoverable direction, and pinned by a test.
+- **Export wraps its result**: `{ "document": { … } }` rather than the bare
+  document. The registry response convention needs `additionalProperties: false`
+  plus an `ext` extension point, and neither attaches to a bare `$ref`.
+- **Import's response is one shape with a discriminant.** `confirmed: bool` →
+  `status: "preview" | "imported"`; `communityProfileDiff` → `profileChanges`;
+  `configOverridesDiff` → `overrideChanges`. The `communityProfileApplied` /
+  `configOverridesApplied` lists are **gone**: on `imported` the change arrays
+  carry what was actually written, so a key that failed to persist is in
+  `rejected` and not reported as applied.
+- **`pendingRestart` is new, and is reported on the preview too** — an operator
+  learns that confirming implies downtime while they are still deciding.
+- Absent-vs-null is now preserved on the wire. `oldValue` / `newValue` are
+  omitted when unset rather than emitted as `null`, so "leave this field alone"
+  stays distinguishable from an explicit "clear it".
+
+No SPA or CLI consumer existed for either endpoint, so the blast radius is
+external callers only.
+
 ### vta-sdk 0.20.7 — `receive_next`'s poll loop no longer trips `never_loop` without the `tsp` feature
 
 `DIDCommSession::receive_next` polls in a `loop`, but its only `continue` — the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9585,9 +9585,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-rs"
-version = "0.2.39"
+version = "0.2.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7f80508c771f601bcd02b85d0a6d0890bdcee07b305d6afa9dff9d5c1f57f2c"
+checksum = "0df173f3b418d2740c8c0609ee0ba55ea5dc4c09308fcc42892b37e8337a865e"
 dependencies = [
  "async-trait",
  "chrono",
@@ -10564,7 +10564,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-service"
-version = "0.11.34"
+version = "0.11.35"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -212,7 +212,7 @@ aws-lc-rs = "1.16"
 # (camelCase wire enums + `/0.2` TYPE_URIs) alongside the retained
 # `v0_1` modules — the VTA dual-accepts both during the migration.
 # Bump in lockstep with affinidi-webvh-service when upstream publishes.
-trust-tasks-rs = { version = "0.2.39", default-features = false, features = ["validate"] }
+trust-tasks-rs = { version = "0.2.40", default-features = false, features = ["validate"] }
 trust-tasks-capability-client = "0.1"
 trust-tasks-https = { version = "0.2", default-features = false, features = ["server", "client", "jwt"] }
 trust-tasks-proof = { version = "0.2", default-features = false, features = ["affinidi"] }

--- a/docs/05-design-notes/vtc-mvp.md
+++ b/docs/05-design-notes/vtc-mvp.md
@@ -1305,8 +1305,11 @@ to point TLS at `/etc/shadow` or to relocate storage transparently).
 
 **Config import audit.** `POST /v1/admin/config/import` runs a
 diff-and-confirm flow: the response surfaces every changed field
-with a pre-apply preview; a second call with `confirm=true` applies.
-Per-field audit events emitted on apply.
+with a pre-apply preview; a second call with `confirm: true` **in the
+request body** applies. (`confirm` was a `?confirm=` query parameter
+until the move to canonical `spec/vtc/config/import/0.1` — a Trust
+Task is one interface over REST, DIDComm and TSP, and only REST has
+a query string.) Per-field audit events emitted on apply.
 
 **Config-mutation audit (P1.2).** Every config-mutation door audits
 to the calling admin's real DID — there is no longer a

--- a/docs/05-design-notes/vtc-trust-task-registry-migration.md
+++ b/docs/05-design-notes/vtc-trust-task-registry-migration.md
@@ -1,11 +1,31 @@
 # Consolidating VTC's Trust Task surface onto the registry
 
-**Status:** **partly implemented — the residual is much smaller than this
-note assumes.** See "Where this actually stands" immediately below before
-reading anything else; the reduction analysis further down is still sound,
-but its headline numbers are stale. That section was itself corrected on
-2026-07-26 (a router-only scan had undercounted the residual and wrongly
-reported #709 as partly unblocked).
+**Status: COMPLETE (2026-07-27).** Nothing in this workspace binds
+`https://trusttasks.org/openvtc/vtc/…` any more. All 66 entries in
+`trust-tasks/index.json` are `retired`, each carrying a `supersededBy`, so
+that file is now a redirect table rather than a live manifest.
+`AWAITING_CANONICAL_FOLD` and `UNBOUND_OK` in
+`vtc-service/tests/trust_task_manifest.rs` are both empty, and
+`no_new_bindings_on_the_retired_authority` is what keeps it that way.
+
+The last two — `admin/config/{export,import}` — were repointed to
+`spec/vtc/config/{export,import}/0.1` once those were authored upstream
+(trust-tasks-tf#147, `trust-tasks-rs` 0.2.40).
+
+**Read the rest of this note as history, not as a plan.** The analysis below
+was written against a 64-task surface and its headline numbers are stale; more
+importantly, several dispositions it records were *wrong* and are annotated
+inline where they were corrected on execution. The one durable lesson:
+
+> Most of the recorded blockers did not survive contact. Three assumed a
+> `confirm/1.0` gate that could not apply (it is asynchronous; those flows
+> verify in-band), one named a target task that would have reintroduced a
+> policy bypass, one assumed an endpoint had to survive when nothing called
+> it, and one cited a duplicate relationship that did not exist. Only
+> `admin/config/{export,import}` had a blocker that held — and even there the
+> *fix* it proposed (push `communityProfile` into `ext`) was wrong. **Verify a
+> blocker before planning work on it.**
+
 **Context:** issue #710. The manifest census (PR #711) pinned VTC's Trust
 Task surface in place; this note covers reducing and relocating it.
 
@@ -421,7 +441,7 @@ effort this work exists to eliminate. Ranked by readiness:
 | 2 | `config/reload`, `config/restart` | Near as-is. Rename the `VTC_SUPERVISED` env var; supervisor detection is deployment-generic. |
 | 3 | `audit/list` | Must reconcile paging: VTC uses opaque HMAC-signed cursor + limit, VTA's existing `ListAuditLogsBody` uses offset (`page`/`page_size`). That reconciliation *is* the value. Consider folding in VTA's `retention` get/update, which VTC lacks. |
 | 4 | `config/manage` | **Done (Phase 2c).** Split into canonical `config/show` + `config/patch`. The "pending per-method selectors" caveat was **mistaken**: `task_routes` layers the *method* router and axum merges same-path method routers per method, so each verb already enforces its own Trust Task — proven by `vti_common::trust_task::openapi::per_method_tasks_on_one_path_are_enforced_independently`. The same applies to any other merged-method mount (e.g. `acl/legacy/entry`). Open the `source` enum — `env > db > toml > default` is a VTC implementation choice. |
-| 5 | `config/export`, `config/import` | ~~Blocked until `communityProfile` moves to `ext`~~ — **not promoted after all.** The blocker was read as a sequencing problem; it is a signal that these are not generics. `communityProfileDiff` / `communityProfileApplied` are structural (roughly half the import response) and the community-DID mismatch `409` routes through `CommunityProfileUpdate::apply`, so a "generic" task with all of that in `ext` would be a hollow shell in its only real use. `vtc/backup/{export,import}/0.1` is the precedent for the alternative: VTC-slugged, `confirm` in the payload not the query string, fields first-class. Target `spec/vtc/config/{export,import}/0.1`, authored upstream. **These two are the last bindings on the retired `openvtc/vtc/` authority.** |
+| 5 | `config/export`, `config/import` | ~~Blocked until `communityProfile` moves to `ext`~~ — **not promoted; VTC-slugged instead. DONE.** The blocker was read as a sequencing problem; it was a signal that these are not generics. `communityProfileDiff` / `communityProfileApplied` are structural (roughly half the import response) and the community-DID mismatch `409` routes through `CommunityProfileUpdate::apply`, so a "generic" task with all of that in `ext` would be a hollow shell in its only real use. `vtc/backup/{export,import}/0.1` was the precedent for the alternative. Authored upstream as `spec/vtc/config/{export,import}/0.1` (trust-tasks-tf#147, `trust-tasks-rs` 0.2.40) and repointed here — **these were the last bindings on the retired `openvtc/vtc/` authority, and it now has none.** |
 
 **`health/diagnostics` is explicitly *not* promoted.** It is not a health
 task — it is trust-registry reconciler telemetry (`rtbf_batched_count`,

--- a/trust-tasks/index.json
+++ b/trust-tasks/index.json
@@ -3,7 +3,7 @@
   "version": 1,
   "org": "openvtc",
   "domain": "vtc",
-  "description": "OpenVTC Verifiable Trust Community — Trust Task manifest for the retired openvtc/vtc authority. Historical record, not a publication pipeline: no CI job has ever read this file (an earlier description claimed one did, per spec §9.4 — it did not exist). The live VTC surface binds canonical https://trusttasks.org/spec/vtc/<slug> tasks published by the upstream registry; 64 of the 66 entries here are retired, and the 2 that are not (admin/config/export, admin/config/import) are the only bindings left on this authority — blocked on spec/vtc/config/{export,import}/0.1 being authored upstream. See docs/05-design-notes/vtc-trust-task-registry-migration.md.",
+  "description": "OpenVTC Verifiable Trust Community — Trust Task manifest for the retired openvtc/vtc authority. Historical record, not a publication pipeline: no CI job has ever read this file (an earlier description claimed one did, per spec §9.4 — it did not exist). The live VTC surface binds canonical https://trusttasks.org/spec/vtc/<slug> tasks published by the upstream registry; All 66 entries are retired and nothing in this workspace binds this authority any more — the migration is complete. Each entry carries a supersededBy naming the canonical task that replaced it, so this file is now a redirect table for anyone holding an old URI. See docs/05-design-notes/vtc-trust-task-registry-migration.md.",
   "tasks": [
     {
       "id": "https://trusttasks.org/openvtc/vtc/auth/legacy/challenge/1.0",
@@ -168,15 +168,17 @@
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/admin/config/export/1.0",
-      "status": "draft",
+      "status": "retired",
       "path": "admin/config/export/1.0",
-      "rest": "POST /v1/admin/config/export"
+      "rest": "POST /v1/admin/config/export",
+      "supersededBy": "https://trusttasks.org/spec/vtc/config/export/0.1"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/admin/config/import/1.0",
-      "status": "draft",
+      "status": "retired",
       "path": "admin/config/import/1.0",
-      "rest": "POST /v1/admin/config/import"
+      "rest": "POST /v1/admin/config/import",
+      "supersededBy": "https://trusttasks.org/spec/vtc/config/import/0.1"
     },
     {
       "id": "https://trusttasks.org/openvtc/vtc/members/list/1.0",

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.11.34"
+version = "0.11.35"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vtc-service/src/routes/admin/config.rs
+++ b/vtc-service/src/routes/admin/config.rs
@@ -20,7 +20,7 @@
 use std::collections::HashMap;
 
 use axum::Json;
-use axum::extract::{Query, State};
+use axum::extract::State;
 use axum::http::StatusCode;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -439,27 +439,49 @@ fn apply_to_live(cfg: &mut crate::config::AppConfig, key: &str, value: &Value) -
 /// exports cleanly. Phase 0 ships v1.
 pub const EXPORT_SCHEMA_VERSION: u32 = 1;
 
-/// Wire payload for `POST /v1/admin/config/{export,import}`.
+/// The portable configuration document — canonical
+/// `vtc/_shared/0.1/config-portability#ConfigExportDocument`.
 ///
 /// `community_profile` is `None` when the community hasn't been
-/// initialised yet (pre-bootstrap). `config_overrides` carries
-/// *only* the db-layer keys — env-layer and toml-layer values stay
-/// per-host and aren't portable.
+/// initialised yet (pre-bootstrap); the member is omitted rather
+/// than emitted as `null`, because an import cannot distinguish a
+/// synthesised empty profile from a real blank one.
+/// `config_overrides` carries *only* the db-layer keys — env-layer
+/// and toml-layer values stay per-host and aren't portable.
+///
+/// `schema_version` is not redundant with the `0.1` in the Trust
+/// Task URI. The URI versions the *envelope*; the moment an operator
+/// writes this document to a file the envelope is gone and it is
+/// bare JSON, so `schemaVersion` is the only thing a later reader has
+/// to check it against.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[derive(utoipa::ToSchema)]
-pub struct ConfigExport {
+pub struct ConfigExportDocument {
     pub schema_version: u32,
     pub exported_at: DateTime<Utc>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub community_profile: Option<CommunityProfile>,
     pub config_overrides: HashMap<String, Value>,
+}
+
+/// `POST /v1/admin/config/export` response — canonical
+/// `vtc/config/export/0.1#response`. The document is returned under a
+/// named member rather than as the bare body: the registry response
+/// convention requires `additionalProperties: false` plus an `ext`
+/// extension point, and neither attaches to a bare `$ref`.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
+pub struct ExportResponse {
+    pub document: ConfigExportDocument,
 }
 
 #[utoipa::path(
     post, path = "/admin/config/export", tag = "admin",
     security(("bearer_jwt" = [])),
     responses(
-        (status = 200, description = "Portable config + community-profile export", body = ConfigExport),
+        (status = 200, description = "Portable config + community-profile export", body = ExportResponse),
         (status = 401, description = "Missing or invalid bearer token"),
         (status = 403, description = "Caller is not an admin"),
     ),
@@ -467,16 +489,18 @@ pub struct ConfigExport {
 pub async fn export_config(
     _admin: AdminAuth,
     State(state): State<AppState>,
-) -> Result<Json<ConfigExport>, AppError> {
+) -> Result<Json<ExportResponse>, AppError> {
     let community_profile = load_profile(&state.community_ks).await?;
     let store = ConfigStore::new(state.config_ks.clone());
     let config_overrides = store.snapshot().await?;
 
-    Ok(Json(ConfigExport {
-        schema_version: EXPORT_SCHEMA_VERSION,
-        exported_at: Utc::now(),
-        community_profile,
-        config_overrides,
+    Ok(Json(ExportResponse {
+        document: ConfigExportDocument {
+            schema_version: EXPORT_SCHEMA_VERSION,
+            exported_at: Utc::now(),
+            community_profile,
+            config_overrides,
+        },
     }))
 }
 
@@ -484,75 +508,109 @@ pub async fn export_config(
 // Import (diff-and-confirm)
 // ---------------------------------------------------------------------------
 
-/// Query string for `POST /v1/admin/config/import`. Default is
-/// `confirm=false` (dry-run / diff). The operator UX shows the diff,
-/// then re-submits with `?confirm=true` to apply.
+/// `POST /v1/admin/config/import` request — canonical
+/// `vtc/config/import/0.1`.
+///
+/// `confirm` rides in the **payload**, not a query string: a Trust
+/// Task is the same interface over REST, DIDComm and TSP, and only
+/// one of those three has a query string to put it in.
+///
+/// It defaults to `false` because the safe direction of a default is
+/// the one whose mistake is recoverable — a caller who meant to apply
+/// and previewed loses a round-trip, where the reverse has already
+/// overwritten a live community's configuration.
 #[derive(Debug, Deserialize, utoipa::ToSchema)]
-pub struct ImportQuery {
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ImportRequest {
+    pub document: ConfigExportDocument,
     #[serde(default)]
     pub confirm: bool,
 }
 
-/// A single field's worth of import diff. `oldValue` is `None`
-/// when the key isn't currently set (either no profile yet, or no
-/// db-layer override). `newValue` is `None` when the import omits
-/// the field — which `import` interprets as "leave the live value
-/// alone", not "clear it".
+/// A single field an import would change, or did — canonical
+/// `vtc/_shared/0.1/config-portability#ConfigFieldChange`.
+///
+/// `oldValue` is omitted when the key isn't currently set (no profile
+/// yet, or no db-layer override). `newValue` is omitted when the
+/// document leaves the field out, which means "leave the live value
+/// alone" — distinct from an explicit `null`, which means "clear it".
+/// Both are serialised as *absent* rather than `null` so that
+/// distinction survives on the wire.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[derive(utoipa::ToSchema)]
 pub struct FieldDiff {
     pub key: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub old_value: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub new_value: Option<Value>,
 }
 
-/// `POST /v1/admin/config/import` response. The shape is the same
-/// regardless of `confirm`: `applied` is empty on dry-run; on
-/// confirm it lists the keys that actually persisted.
+/// `POST /v1/admin/config/import` response — canonical
+/// `vtc/config/import/0.1#response`.
+///
+/// One shape for both paths. On a preview the change arrays are what
+/// *would* be written; on an apply they are what *was*. That is why
+/// there are no separate `*Applied` lists: a caller reads `status` to
+/// know which it is holding.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[derive(utoipa::ToSchema)]
 pub struct ImportResponse {
-    /// Was the request a dry-run? Mirrors the inbound `?confirm`
-    /// flag so an admin UX caching the response can render the
-    /// banner correctly.
-    pub confirmed: bool,
-    /// Profile-field-level diffs against the current profile.
-    /// Empty when import omits `communityProfile` or when no
-    /// fields differ.
-    pub community_profile_diff: Vec<FieldDiff>,
-    /// Config-override-level diffs. One entry per registry key
-    /// that the import would change.
-    pub config_overrides_diff: Vec<FieldDiff>,
-    /// On apply: the profile fields that were written. Empty on
-    /// dry-run or when no change.
-    pub community_profile_applied: Vec<String>,
-    /// On apply: the override keys that were written. Empty on
-    /// dry-run.
-    pub config_overrides_applied: Vec<String>,
+    /// `preview` when `confirm` was not set; `imported` after the
+    /// document was applied.
+    pub status: ImportStatus,
+    /// Community-profile members that differ from what is in force.
+    /// Empty when the document omits `communityProfile`, or when
+    /// nothing differs.
+    pub profile_changes: Vec<FieldDiff>,
+    /// Configuration-override keys that differ from what is in force.
+    /// Rejected keys are not listed here — they appear under
+    /// `rejected`.
+    pub override_changes: Vec<FieldDiff>,
+    /// Applied keys whose new value takes effect only after a
+    /// restart. Reported on a preview too, so an operator learns that
+    /// the import implies downtime *before* confirming it.
+    pub pending_restart: Vec<String>,
     /// Keys rejected by validation (unknown registry key, type
     /// mismatch, value-out-of-range, oversized extensions blob).
+    /// Populated identically on preview and apply, so a preview
+    /// surfaces every rejection before anything is written.
     pub rejected: Vec<RejectedKey>,
+}
+
+/// Whether an import response describes a dry run or a completed apply.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
+pub enum ImportStatus {
+    Preview,
+    Imported,
 }
 
 #[utoipa::path(
     post, path = "/admin/config/import", tag = "admin",
     security(("bearer_jwt" = [])),
-    params(("confirm" = Option<bool>, Query, description = "Apply the import (true) or dry-run diff (false, default)")),
-    request_body = ConfigExport,
+    request_body = ImportRequest,
     responses(
-        (status = 200, description = "Import diff (dry-run) or applied keys", body = ImportResponse),
+        (status = 200, description = "Import diff (preview) or applied changes", body = ImportResponse),
+        (status = 400, description = "Document carries an unsupported schemaVersion"),
         (status = 401, description = "Missing or invalid bearer token"),
         (status = 403, description = "Caller is not an admin"),
+        (status = 409, description = "Document was taken from a different community"),
     ),
 )]
 pub async fn import_config(
     admin: AdminAuth,
     State(state): State<AppState>,
-    Query(query): Query<ImportQuery>,
-    Json(req): Json<ConfigExport>,
+    Json(body): Json<ImportRequest>,
 ) -> Result<(StatusCode, Json<ImportResponse>), AppError> {
+    let ImportRequest { document, confirm } = body;
+    let req = document;
+
+    // Version first: a document whose shape we cannot vouch for must not be
+    // diffed, because the diff would be against members we may be misreading.
     if req.schema_version != EXPORT_SCHEMA_VERSION {
         return Err(AppError::Validation(format!(
             "unsupported export schemaVersion: got {}, expected {EXPORT_SCHEMA_VERSION}",
@@ -621,16 +679,22 @@ pub async fn import_config(
         }
     }
 
-    // --- dry-run? -----------------------------------------------------
-    if !query.confirm {
+    // --- preview? -----------------------------------------------------
+    // `pendingRestart` is reported here too: an operator should learn that
+    // confirming implies downtime while they are still deciding, not after.
+    if !confirm {
+        let pending_restart = overrides_diff
+            .iter()
+            .filter(|d| matches!(lookup(&d.key), Some(def) if def.requires_restart))
+            .map(|d| d.key.clone())
+            .collect();
         return Ok((
             StatusCode::OK,
             Json(ImportResponse {
-                confirmed: false,
-                community_profile_diff: profile_diff,
-                config_overrides_diff: overrides_diff,
-                community_profile_applied: Vec::new(),
-                config_overrides_applied: Vec::new(),
+                status: ImportStatus::Preview,
+                profile_changes: profile_diff,
+                override_changes: overrides_diff,
+                pending_restart,
                 rejected,
             }),
         ));
@@ -650,6 +714,7 @@ pub async fn import_config(
     };
 
     let mut config_overrides_applied: Vec<String> = Vec::new();
+    let mut pending_restart: Vec<String> = Vec::new();
     let mut audit_changes: Vec<ConfigChange> = Vec::new();
     let mut requires_restart = false;
     for FieldDiff {
@@ -685,6 +750,7 @@ pub async fn import_config(
         audit_changes.push(change);
         if def.requires_restart {
             requires_restart = true;
+            pending_restart.push(key.clone());
         }
     }
 
@@ -729,14 +795,27 @@ pub async fn import_config(
         "config imported"
     );
 
+    // On `imported` the change arrays carry what was actually written, not
+    // what was proposed. A key that made it into `overrides_diff` but then
+    // failed to persist has already been pushed to `rejected` above; leaving
+    // it in `overrideChanges` would report it as applied.
+    let profile_changes: Vec<FieldDiff> = profile_diff
+        .iter()
+        .filter(|d| community_profile_applied.contains(&d.key))
+        .cloned()
+        .collect();
+    let override_changes: Vec<FieldDiff> = overrides_diff
+        .into_iter()
+        .filter(|d| config_overrides_applied.contains(&d.key))
+        .collect();
+
     Ok((
         StatusCode::OK,
         Json(ImportResponse {
-            confirmed: true,
-            community_profile_diff: profile_diff,
-            config_overrides_diff: overrides_diff,
-            community_profile_applied,
-            config_overrides_applied,
+            status: ImportStatus::Imported,
+            profile_changes,
+            override_changes,
+            pending_restart,
             rejected,
         }),
     ))

--- a/vtc-service/src/routes/mod.rs
+++ b/vtc-service/src/routes/mod.rs
@@ -457,16 +457,19 @@ fn build_api_chain(_routing: &RoutingConfig, trust_xff: bool) -> OpenApiRouter<A
             routes!(admin::config::restart_config),
             "https://trusttasks.org/spec/config/restart/0.1",
         ))
-        // Export / import (M0.8.4). Export returns the portable
-        // (db-layer overrides + community profile) JSON; import runs
-        // diff-and-confirm via `?confirm=true|false`.
+        // Export / import (M0.8.4), on the canonical `vtc/config/*` tasks
+        // (trust-tasks-tf#147). Export returns the portable document
+        // (db-layer overrides + community profile); import runs
+        // diff-and-confirm via `confirm` **in the payload** — a Trust Task
+        // is one interface over REST, DIDComm and TSP, and only REST has a
+        // query string to carry a flag in.
         .routes(tt(
             routes!(admin::config::export_config),
-            "https://trusttasks.org/openvtc/vtc/admin/config/export/1.0",
+            "https://trusttasks.org/spec/vtc/config/export/0.1",
         ))
         .routes(tt(
             routes!(admin::config::import_config),
-            "https://trusttasks.org/openvtc/vtc/admin/config/import/1.0",
+            "https://trusttasks.org/spec/vtc/config/import/0.1",
         ))
         // Install claim endpoints (`/install/claim/start` and
         // `/install/claim/finish`) are unauthenticated and live in

--- a/vtc-service/tests/admin_config.rs
+++ b/vtc-service/tests/admin_config.rs
@@ -672,8 +672,8 @@ async fn restart_wrong_trust_task_returns_415() {
 
 // ──────────────────────── Export / Import ────────────────────────
 
-const EXPORT_TASK: &str = "https://trusttasks.org/openvtc/vtc/admin/config/export/1.0";
-const IMPORT_TASK: &str = "https://trusttasks.org/openvtc/vtc/admin/config/import/1.0";
+const EXPORT_TASK: &str = "https://trusttasks.org/spec/vtc/config/export/0.1";
+const IMPORT_TASK: &str = "https://trusttasks.org/spec/vtc/config/import/0.1";
 
 async fn export_post(fix: &Fixture, token: &str) -> (StatusCode, Value) {
     let req = Request::builder()
@@ -684,23 +684,29 @@ async fn export_post(fix: &Fixture, token: &str) -> (StatusCode, Value) {
         .body(Body::empty())
         .unwrap();
     let resp = fix.router.clone().oneshot(req).await.unwrap();
-    body_value(resp).await
+    let (status, body) = body_value(resp).await;
+    // Canonical `vtc/config/export/0.1#response` wraps the portable document
+    // under `document`; these tests assert on the document itself.
+    let doc = if body.get("document").is_some() {
+        body["document"].clone()
+    } else {
+        body
+    };
+    (status, doc)
 }
 
+/// `confirm` rides in the payload, not the query string — one interface over
+/// every transport, and only REST has a query string to carry a flag in.
 async fn import_post(
     fix: &Fixture,
     token: &str,
     confirm: bool,
-    body: Value,
+    document: Value,
 ) -> (StatusCode, Value) {
-    let uri = if confirm {
-        "/v1/admin/config/import?confirm=true"
-    } else {
-        "/v1/admin/config/import"
-    };
+    let body = json!({ "document": document, "confirm": confirm });
     let req = Request::builder()
         .method("POST")
-        .uri(uri)
+        .uri("/v1/admin/config/import")
         .header("Trust-Task", IMPORT_TASK)
         .header("Authorization", format!("Bearer {token}"))
         .header("Content-Type", "application/json")
@@ -789,17 +795,17 @@ async fn import_dry_run_returns_diff_without_persisting() {
     });
     let (status, body) = import_post(&fix, &token, false, payload).await;
     assert_eq!(status, StatusCode::OK);
-    assert_eq!(body["confirmed"], false);
+    assert_eq!(body["status"], "preview");
 
     // Diff lists the changed name + the new db-layer override.
-    let profile_keys: Vec<_> = body["communityProfileDiff"]
+    let profile_keys: Vec<_> = body["profileChanges"]
         .as_array()
         .unwrap()
         .iter()
         .map(|d| d["key"].as_str().unwrap().to_string())
         .collect();
     assert!(profile_keys.contains(&"name".to_string()));
-    let overrides_keys: Vec<_> = body["configOverridesDiff"]
+    let overrides_keys: Vec<_> = body["overrideChanges"]
         .as_array()
         .unwrap()
         .iter()
@@ -807,9 +813,8 @@ async fn import_dry_run_returns_diff_without_persisting() {
         .collect();
     assert_eq!(overrides_keys, vec!["log.level"]);
 
-    // Nothing applied.
-    assert_eq!(body["communityProfileApplied"], json!([]));
-    assert_eq!(body["configOverridesApplied"], json!([]));
+    // `log.level` is hot-reloadable, so a preview of it implies no downtime.
+    assert_eq!(body["pendingRestart"], json!([]));
 
     // Live profile unchanged.
     let live = vtc_service::community::load_profile(&fix.state.community_ks)
@@ -843,17 +848,25 @@ async fn import_confirm_applies_profile_and_overrides() {
     });
     let (status, body) = import_post(&fix, &token, true, payload).await;
     assert_eq!(status, StatusCode::OK, "{body}");
-    assert_eq!(body["confirmed"], true);
+    assert_eq!(body["status"], "imported");
 
-    let applied: Vec<_> = body["communityProfileApplied"]
+    // On `imported` the change arrays carry what was actually written, so the
+    // applied fields are read off them rather than a separate list.
+    let applied: Vec<_> = body["profileChanges"]
         .as_array()
         .unwrap()
         .iter()
-        .map(|v| v.as_str().unwrap().to_string())
+        .map(|d| d["key"].as_str().unwrap().to_string())
         .collect();
     assert!(applied.contains(&"name".to_string()));
     assert!(applied.contains(&"language".to_string()));
-    assert_eq!(body["configOverridesApplied"], json!(["log.level"]));
+    let overrides_applied: Vec<_> = body["overrideChanges"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|d| d["key"].as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(overrides_applied, vec!["log.level"]);
 
     // Live profile reflects the import.
     let live = vtc_service::community::load_profile(&fix.state.community_ks)
@@ -1048,5 +1061,101 @@ async fn import_dry_run_works_without_audit_writer() {
     });
     let (status, body) = import_post(&fix, &token, false, payload).await;
     assert_eq!(status, StatusCode::OK);
-    assert_eq!(body["confirmed"], false);
+    assert_eq!(body["status"], "preview");
+}
+
+/// A restart-gated key is reported as `pendingRestart` on the **preview**, not
+/// only after applying. An operator should learn that confirming implies
+/// downtime while they are still deciding whether to confirm.
+#[tokio::test]
+async fn import_preview_reports_pending_restart_before_confirming() {
+    let fix = build_with(true, None).await;
+    let token = token_for(&fix, "admin").await;
+    let payload = json!({
+        "schemaVersion": 1,
+        "exportedAt": "2026-05-12T03:42:00Z",
+        "configOverrides": { "server.port": 9100 }
+    });
+
+    let (status, body) = import_post(&fix, &token, false, payload.clone()).await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert_eq!(body["status"], "preview");
+    assert_eq!(body["pendingRestart"], json!(["server.port"]), "{body}");
+
+    // Nothing was written — the preview said so, and the store agrees.
+    let store = vtc_service::config_store::ConfigStore::new(fix.state.config_ks.clone());
+    assert_eq!(store.get("server.port").await.unwrap(), None);
+
+    // …and confirming reports the same key, now actually applied.
+    let (status, body) = import_post(&fix, &token, true, payload).await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert_eq!(body["status"], "imported");
+    assert_eq!(body["pendingRestart"], json!(["server.port"]), "{body}");
+    assert_eq!(store.get("server.port").await.unwrap(), Some(json!(9100)));
+}
+
+/// `confirm` moved from the query string into the payload. A stale client
+/// still sending `?confirm=true` must not apply — and does not, because
+/// nothing reads the query string any more. The failure direction matters:
+/// the stale call previews instead of writing, which is the recoverable one.
+#[tokio::test]
+async fn import_ignores_the_pre_migration_confirm_query_param() {
+    let fix = build_with(true, None).await;
+    let token = token_for(&fix, "admin").await;
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/admin/config/import?confirm=true")
+        .header("Trust-Task", IMPORT_TASK)
+        .header("Authorization", format!("Bearer {token}"))
+        .header("Content-Type", "application/json")
+        .body(Body::from(
+            json!({
+                "document": {
+                    "schemaVersion": 1,
+                    "exportedAt": "2026-05-12T03:42:00Z",
+                    "configOverrides": { "log.level": "debug" }
+                }
+            })
+            .to_string(),
+        ))
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    let (status, body) = body_value(resp).await;
+
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert_eq!(
+        body["status"], "preview",
+        "a query-string confirm must not apply: {body}"
+    );
+    let store = vtc_service::config_store::ConfigStore::new(fix.state.config_ks.clone());
+    assert_eq!(store.get("log.level").await.unwrap(), None);
+}
+
+/// The document is the request's own member, so an unknown top-level member is
+/// rejected rather than silently dropped — the canonical payload is
+/// `additionalProperties: false`.
+#[tokio::test]
+async fn import_rejects_an_unknown_top_level_member() {
+    let fix = build_with(true, None).await;
+    let token = token_for(&fix, "admin").await;
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/admin/config/import")
+        .header("Trust-Task", IMPORT_TASK)
+        .header("Authorization", format!("Bearer {token}"))
+        .header("Content-Type", "application/json")
+        .body(Body::from(
+            json!({
+                "document": {
+                    "schemaVersion": 1,
+                    "exportedAt": "2026-05-12T03:42:00Z",
+                    "configOverrides": {}
+                },
+                "__notARealMember__": true
+            })
+            .to_string(),
+        ))
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
 }

--- a/vtc-service/tests/trust_task_manifest.rs
+++ b/vtc-service/tests/trust_task_manifest.rs
@@ -284,25 +284,45 @@ fn every_manifest_entry_has_files_on_disk() {
 
 /// The `openvtc/vtc/*` URIs still awaiting a canonical disposition.
 ///
-/// This list only ever shrinks. Each entry is a task the #710 design note
-/// folds onto a canonical spec rather than republishing under `spec/vtc/*`,
-/// so it cannot simply be repointed. Both survivors need an upstream registry
-/// spec that does not exist yet: `specs/config/` publishes `show`, `patch`,
-/// `reload` and `restart`, and no `export` / `import` counterpart. They are
-/// blocked on `vtc/config/{export,import}/0.1` being authored upstream, not on
-/// anything in this repo.
+/// **Empty — the migration is done (#710).** Nothing in this workspace binds
+/// the `https://trusttasks.org/openvtc/vtc/` authority any more. The list only
+/// ever shrank: every entry was either folded onto a canonical spec, deleted
+/// outright, or — for the last two — repointed once the canonical spec it
+/// needed was authored upstream.
 ///
-/// A new `openvtc/vtc/` URI appearing anywhere fails the test below, which is
-/// the point: the authority is retired, and nothing should be added to it.
+/// Worth keeping the shape of what was learned emptying it: of the ten
+/// dispositions recorded here over the migration, **most of the recorded
+/// blockers were wrong**, and each was wrong in a way that had kept real work
+/// parked. Three assumed a `confirm/1.0` gate that could not apply, one named
+/// a target task that would have reintroduced a policy bypass, one assumed an
+/// endpoint had to survive when nothing called it, and one cited a duplicate
+/// relationship that did not exist. Only `admin/config/{export,import}` had a
+/// blocker that held up — and even there, the *fix* it proposed was wrong.
+/// Verify a blocker before planning work on it.
+///
+/// The table stays because the assertion below is still load-bearing: a new
+/// `openvtc/vtc/` URI appearing anywhere fails, which is the point — the
+/// authority is retired, and nothing should be added to it.
 const AWAITING_CANONICAL_FOLD: &[(&str, &str)] = &[
-    (
-        "admin/config/export/1.0",
-        "canonical config/export — blocked on communityProfile moving to ext",
-    ),
-    (
-        "admin/config/import/1.0",
-        "canonical config/import — blocked; communityProfileDiff is structural",
-    ),
+    // `admin/config/{export,import}/1.0` are GONE — repointed to the canonical
+    // `spec/vtc/config/{export,import}/0.1` authored in trust-tasks-tf#147.
+    //
+    // These were the last two, and the only ones whose recorded blocker was
+    // *real*: no canonical counterpart existed. `specs/config/` published
+    // `show`, `patch`, `reload` and `restart` and nothing to migrate to.
+    //
+    // The blocker's proposed fix — promote them into the generic `config/*`
+    // family with `communityProfile` pushed into `ext` — was dropped. The
+    // profile and its diff are roughly half the import's payload, so the
+    // "generic" task would have been a hollow shell in its only real use.
+    // They are `vtc/`-slugged instead, following `vtc/backup/{export,import}`.
+    //
+    // The repoint was not a rename: `confirm` moved from a query string into
+    // the payload (a Trust Task is one interface over REST, DIDComm and TSP,
+    // and only REST has a query string), the `*Applied` lists folded into the
+    // change arrays behind a `status` discriminant, and `pendingRestart` is
+    // now reported on the preview as well as the apply.
+    //
     // The three `admin/passkeys/*` entries are GONE, folded onto the
     // canonical `auth/passkey/{list,enroll/*,revoke/*}` tasks authored in
     // trust-tasks-tf#145.


### PR DESCRIPTION
Closes #710.

`admin/config/{export,import}` move to the canonical `spec/vtc/config/{export,import}/0.1` authored upstream in [trust-tasks-tf#147](https://github.com/trustoverip/dtgwg-trust-tasks-tf/pull/147) (`trust-tasks-rs` 0.2.40, pinned here).

They were the last two bindings on `https://trusttasks.org/openvtc/vtc/`. **That authority is now unbound across the whole workspace** — router, `vta-sdk` constants, admin SPA and `cnm-cli` alike:

```
$ grep -rhoE '"https://trusttasks\.org/openvtc/vtc/[^"]+"' \
    vtc-service/src vta-sdk/src cnm-cli/src vtc-service/admin-ui/src | wc -l
0
```

All 66 entries in `trust-tasks/index.json` are `retired` with a `supersededBy`, which turns that file from a manifest into a redirect table for anyone still holding an old URI. Both census tables in `vtc-service/tests/trust_task_manifest.rs` — `AWAITING_CANONICAL_FOLD` and `UNBOUND_OK` — are now empty, and `no_new_bindings_on_the_retired_authority` is what stops it regressing one literal at a time.

## Why these two took the longest

They were the only entries in the whole migration whose recorded blocker was **real**: no canonical counterpart existed. `specs/config/` published `show`, `patch`, `reload`, `restart` and nothing to migrate to.

But the fix that blocker proposed — push `communityProfile` into `ext` and promote these into the generic `config/*` family — was still wrong. `communityProfile` and its diff are roughly half the import's payload, so the "generic" task would have been a hollow shell in its only real use. They are `vtc/`-slugged instead, on the `vtc/backup/{export,import}` precedent.

That is the pattern across #710 as a whole, and it is recorded in the design note and the now-empty fold table so it isn't relearned: of the ten dispositions on file, most of the blockers did not survive contact. Three assumed a `confirm/1.0` gate that could not apply (it is asynchronous; those flows verify in-band via WebAuthn), one named a target task that would have reintroduced a policy bypass, one assumed an endpoint had to survive when nothing called it, and one cited a duplicate relationship that did not exist. **Verify a blocker before planning work on it.**

## Breaking wire changes

The repoint is not a rename:

- **`confirm` moves from the query string into the payload.** A Trust Task is one interface over REST, DIDComm and TSP, and only REST has a query string to carry a flag in. A stale client still sending `?confirm=true` now **previews** instead of applying — the recoverable direction. Pinned by `import_ignores_the_pre_migration_confirm_query_param`.
- **Export wraps its result**: `{ "document": { … } }` rather than the bare document. The registry response convention needs `additionalProperties: false` plus an `ext` extension point, and neither attaches to a bare `$ref`.
- **Import returns one shape with a discriminant.** `confirmed: bool` → `status: "preview" | "imported"`; `communityProfileDiff` → `profileChanges`; `configOverridesDiff` → `overrideChanges`. The `communityProfileApplied` / `configOverridesApplied` lists are **gone** — on `imported` the change arrays carry what was actually written, so a key that failed to persist lands in `rejected` rather than being reported as applied.
- **`pendingRestart` is new, and is reported on the preview too** — an operator learns that confirming implies downtime while they are still deciding whether to confirm. Pinned by `import_preview_reports_pending_restart_before_confirming`.
- **Absent-vs-null is preserved on the wire.** `oldValue` / `newValue` are omitted when unset rather than emitted as `null`, so "leave this field alone" stays distinguishable from an explicit "clear it". Conflating those turns every partial document into a destructive one.

No SPA or CLI consumer existed for either endpoint, so the blast radius is external callers only.

## Verification

- `cargo fmt --check` clean
- `cargo clippy --workspace` clean (as CI runs it)
- Full `cargo test -p vtc-service -p vti-common`: 52 test binaries, exit 0, zero failures (built with the admin UI, not `VTC_SKIP_ADMIN_UI_BUILD`)
- `every_bound_vtc_task_exists_in_the_registry` resolves both new URIs against the published `trust_tasks_rs` 0.2.40 rather than a hand-maintained list, so a typo or an unauthored slug would fail here rather than at runtime

`vtc-service` 0.11.35.
