### PR TITLE
chore(tee): one home for the TEE store keys, and a changelog guard that can fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,57 @@ spec change.
 
 Unblocks the member-side half of OpenVTC/openvtc#185.
 
+### vta-tee 0.1.2 / vta-service 0.12.46 — the TEE store keys get one home, and the changelog guard stops passing vacuously
+
+Three small cross-cutting fixes that kept surfacing while reviewing the TEE and
+Nitro PRs (#819, #824, #826, #827, #832). None of them belongs to any one of
+those changes.
+
+**`tee:did_log` and `tee:vta_did` are now exported constants.** The DID log key
+was spelled as a bare string literal in four places: written twice in
+`vta_tee::did_autogen` (to the `KEYS` and `BOOTSTRAP` keyspaces), read by
+`vta_service::routes::attestation::did_log` to serve `GET
+/attestation/did-log`, re-declared a fifth time by `vta_service::tee_webvh`
+(#827), and read twice more by the parent-side `deploy/nitro/enclave-proxy`.
+Renaming it would have broken the readers silently. `did_autogen` now exports
+`DID_LOG_STORE_KEY` and `VTA_DID_STORE_KEY` and every in-workspace reader takes
+the constant. (`tee_webvh`'s copy was justified as avoiding a `vta-tee`
+dependency, but that module is `cfg(tee)` and `crate::tee` is already
+`pub use vta_tee` under the same feature — there was no dependency to avoid.) `enclave-proxy` is a separate
+cargo project on the parent that deliberately does not link enclave code, so it
+keeps the literal — now with a comment naming the canonical definition.
+
+**`deploy/nitro/parent-proxy.sh` bound the DID resolver to the IMDS port.** It
+defaulted `VSOCK_RESOLVER_PORT` to 5400, but 5400 is the IMDS credential proxy
+on the enclave side and the resolver is 5600 (`enclave-entrypoint.sh`,
+`enclave-proxy/src/main.rs`). The script is also socat-only and serves four of
+the seven vsock channels — no storage (5500) and no log forwarding (5700) — so
+its header now says that outright and points at `enclave-proxy` as the
+canonical parent implementation.
+
+**`scripts/check-changelogs.sh` matched the version string anywhere in the
+file, not a `<crate> <version>` entry.** With a dozen subsystem crates sharing
+the 0.1.x range, patch numbers collide constantly: `vta-tee` 0.1.0 -> 0.1.1
+(#819) passed the guard with no `vta-tee` entry at all, because `0.1.1` already
+appeared for `vta-audit`, `vta-backup`, `vta-vault` and `vta-webvh`. The match
+now requires the crate name immediately before the version, accepting both
+heading shapes in use here (`### vta-service 0.12.43 — …`, `### vti-secrets
+0.1.7 / vta-config 0.1.1 — …`, and backticked list items), and keeps the
+right-hand token boundary so a `0.1.30` entry cannot satisfy a bump to `0.1.3`.
+Replayed over the last 25 commits of `main`: 16 commits carrying version bumps
+still pass, and the only thing the tightened guard newly catches is #819 — the
+bug that motivated it.
+
+### vta-tee 0.1.1 — NSM ioctl `len` must be u64 (#819)
+
+Backfilled: this shipped without an entry, which is what the guard change above
+exists to prevent. The NSM ioctl request/response descriptors mirror the kernel's
+`struct nsm_iovec { __u64 addr; __u64 len; }`. `len` was declared `u32`, leaving
+four bytes of uninitialised `#[repr(C)]` padding that the kernel read as the high
+half of the 64-bit length — inflating it to a garbage value and failing
+attestation with `EMSGSIZE`. The same field is read back after the call to size
+the response, so the truncated read was a second latent defect.
+
 ### vtc-service 0.11.36 — the VTC accepts Trust Tasks over TSP
 
 TSP frames already reached the VTC: the delivery-layer `DidCommTransport` owns the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10331,7 +10331,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.12.45"
+version = "0.12.46"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",
@@ -10468,7 +10468,7 @@ dependencies = [
 
 [[package]]
 name = "vta-tee"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",

--- a/deploy/nitro/enclave-proxy/src/storage.rs
+++ b/deploy/nitro/enclave-proxy/src/storage.rs
@@ -40,6 +40,10 @@ pub async fn run_storage(vsock_port: u32, data_dir: PathBuf) {
 
     // On startup, check if a DID log was previously stored and write it to disk.
     // This ensures the file is always available even after proxy restarts.
+    //
+    // The key is spelled out rather than imported: this proxy runs on the
+    // *parent* and deliberately does not link enclave code. Canonical
+    // definition is `vta_tee::did_autogen::DID_LOG_STORE_KEY` — keep in sync.
     if let Ok(ks) = db.keyspace("bootstrap", KeyspaceCreateOptions::default) {
         if let Ok(Some(value)) = ks.get("tee:did_log") {
             write_did_log_file(&data_dir, &value);
@@ -212,7 +216,9 @@ async fn handle_insert(state: &StorageState, data: &[u8]) -> Vec<u8> {
         Ok(()) => {
             // When the VTA writes its auto-generated DID log to the bootstrap
             // keyspace, also write it to disk so the operator can retrieve it
-            // without needing REST enabled.
+            // without needing REST enabled. Key mirrors
+            // `vta_tee::did_autogen::DID_LOG_STORE_KEY` (see the startup read
+            // above for why it is not imported).
             if ks_name == "bootstrap" && key == b"tee:did_log" {
                 write_did_log_file(&state.data_dir, &value);
             }

--- a/deploy/nitro/parent-proxy.sh
+++ b/deploy/nitro/parent-proxy.sh
@@ -4,12 +4,20 @@
 # =============================================================================
 #
 # This script runs on the PARENT EC2 instance (not inside the enclave).
-# It manages all networking for the enclave:
 #
-#   1. INBOUND:   External clients → TCP:8443 → vsock → Enclave VTA
-#   2. MEDIATOR:  Enclave DIDComm → vsock → TLS → mediator
-#   3. RESOLVER:  Enclave DID resolution → vsock → local DID resolver
-#   4. HTTPS:     Enclave general HTTPS → vsock → allowlisted endpoints
+# PARTIAL — socat only, four of the seven vsock channels. The canonical parent
+# implementation is the Rust `deploy/nitro/enclave-proxy`, which additionally
+# serves the IMDS credential proxy (5400), the storage proxy (5500) and log
+# forwarding (5700). A VTA deployed with only this script has no persistent
+# store and no enclave logs on the parent. Use it for bring-up and debugging;
+# use enclave-proxy for anything real.
+#
+# It manages the following channels for the enclave:
+#
+#   1. INBOUND:   External clients → TCP:8443 → vsock:5100 → Enclave VTA
+#   2. MEDIATOR:  Enclave DIDComm → vsock:5200 → TLS → mediator
+#   3. RESOLVER:  Enclave DID resolution → vsock:5600 → local DID resolver
+#   4. HTTPS:     Enclave general HTTPS → vsock:5300 → allowlisted endpoints
 #
 # Configuration is auto-read from deploy/nitro/config.toml (the same config
 # baked into the EIF). Override any value with environment variables.
@@ -82,10 +90,14 @@ EXTRA_HOSTS=("$@")
 # ---------------------------------------------------------------------------
 # Port assignments (must match enclave-entrypoint.sh)
 # ---------------------------------------------------------------------------
+# Enclave-side vsock ports. These MUST match the enclave: see
+# `enclave-entrypoint.sh` and `enclave-proxy/src/main.rs`, which are the
+# authority. 5400 is the IMDS credential proxy and 5500 / 5700 are the storage
+# and log channels — this script serves none of those, so it must not bind them.
 VSOCK_INBOUND_PORT="${VSOCK_INBOUND_PORT:-5100}"      # Inbound REST
 VSOCK_MEDIATOR_PORT="${VSOCK_MEDIATOR_PORT:-5200}"     # Outbound mediator
 VSOCK_HTTPS_PORT="${VSOCK_HTTPS_PORT:-5300}"            # Outbound HTTPS
-VSOCK_RESOLVER_PORT="${VSOCK_RESOLVER_PORT:-5400}"      # Outbound DID resolver
+VSOCK_RESOLVER_PORT="${VSOCK_RESOLVER_PORT:-5600}"      # Outbound DID resolver
 
 LISTEN_PORT="${LISTEN_PORT:-8443}"                      # External REST API port
 MEDIATOR_PORT="${MEDIATOR_PORT:-443}"                   # Mediator WSS port

--- a/scripts/check-changelogs.sh
+++ b/scripts/check-changelogs.sh
@@ -105,13 +105,27 @@ while IFS="$(printf '\t')" read -r name dir; do
   [ "$old_version" != "$new_version" ] || continue
 
   found=1
-  # Match the version as a whole token: a plain substring search would let
-  # `0.1.30`'s entry satisfy a bump to `0.1.3`.
+  # Match the crate NAME immediately followed by the version, as whole tokens.
+  #
+  # Version-alone was not enough. The workspace carries a dozen subsystem crates
+  # all sitting in the 0.1.x range, so a patch number is routinely shared: a
+  # `vta-tee` 0.1.0 -> 0.1.1 bump passed this guard with no `vta-tee` entry at
+  # all, because `0.1.1` already appeared for `vta-audit`, `vta-backup`,
+  # `vta-vault` and `vta-webvh` (PR #819). A guard that green-lights an
+  # undocumented release is worse than no guard, because it is trusted.
+  #
+  # Both heading shapes in CHANGELOG.md are accepted, backticks optional:
+  #   ### vta-service 0.12.43 — summary
+  #   ### vti-secrets 0.1.7 / vta-config 0.1.1 — summary
+  #   - `vta-audit` 0.1.1
+  # The version stays token-boundaried on the right so a `0.1.30` entry cannot
+  # satisfy a bump to `0.1.3`.
   escaped=$(printf '%s' "$new_version" | sed 's/\./\\./g')
-  if grep -qE "(^|[^0-9.])$escaped([^0-9.]|\$)" "$CHANGELOG"; then
+  escaped_name=$(printf '%s' "$name" | sed 's/[.[\*^$]/\\&/g')
+  if grep -qE "(^|[^A-Za-z0-9_-])\`?$escaped_name\`?[[:space:]]+$escaped([^0-9.]|\$)" "$CHANGELOG"; then
     echo "  ${GREEN}ok${NC}   $name: ${old_version:-<new>} -> $new_version (documented)"
   else
-    echo "  ${RED}MISSING${NC} $name: ${old_version:-<new>} -> $new_version, but $new_version does not appear in $CHANGELOG"
+    echo "  ${RED}MISSING${NC} $name: ${old_version:-<new>} -> $new_version, but no \"$name $new_version\" entry appears in $CHANGELOG"
     fail=1
   fi
 done <<EOF

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.12.45"
+version = "0.12.46"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/routes/attestation.rs
+++ b/vta-service/src/routes/attestation.rs
@@ -89,13 +89,17 @@ pub async fn cached_report(
     ),
 )]
 pub async fn did_log(State(state): State<AppState>) -> Result<Response, AppError> {
-    let log_bytes = state.keys_ks.get_raw("tee:did_log").await?.ok_or_else(|| {
-        AppError::NotFound(
-            "no auto-generated DID log found — the VTA may not have \
+    let log_bytes = state
+        .keys_ks
+        .get_raw(crate::tee::did_autogen::DID_LOG_STORE_KEY)
+        .await?
+        .ok_or_else(|| {
+            AppError::NotFound(
+                "no auto-generated DID log found — the VTA may not have \
                  been configured with a vta_did_template"
-                .into(),
-        )
-    })?;
+                    .into(),
+            )
+        })?;
 
     let log = String::from_utf8(log_bytes)
         .map_err(|e| AppError::Internal(format!("DID log is not valid UTF-8: {e}")))?;

--- a/vta-service/src/tee_webvh.rs
+++ b/vta-service/src/tee_webvh.rs
@@ -26,9 +26,12 @@ use crate::store::{KeyspaceHandle, Store};
 use crate::webvh_store;
 
 /// The `KEYS`-keyspace key that `vta_tee::did_autogen` writes the encrypted
-/// did.jsonl log under. Mirrored here (rather than imported) so this bridge
-/// doesn't pull `vta-tee` into `vta-service`'s dependency graph.
-const TEE_DID_LOG_STORE_KEY: &str = "tee:did_log";
+/// did.jsonl log under.
+///
+/// Taken from the writer rather than re-typed: this module is `cfg(tee)` and
+/// `crate::tee` is already `pub use vta_tee`, so there is no dependency to
+/// avoid — only a literal to keep in sync, which is the failure mode.
+use crate::tee::did_autogen::DID_LOG_STORE_KEY as TEE_DID_LOG_STORE_KEY;
 
 /// Idempotently persist the serverless VTA did:webvh record + log into the
 /// `webvh` keyspace.

--- a/vta-tee/Cargo.toml
+++ b/vta-tee/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-tee"
 description = "VTA TEE bootstrap — Nitro/SEV-SNP attestation providers, KMS attest/decrypt + storage-key derivation, the anchor MAC, and first-boot DID autogen"
 readme = "README.md"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-tee/src/did_autogen.rs
+++ b/vta-tee/src/did_autogen.rs
@@ -24,7 +24,27 @@ use vti_common::error::AppError;
 use vti_common::store::{KeyspaceHandle, Store};
 
 /// Well-known store key for the auto-generated VTA DID.
-const VTA_DID_STORE_KEY: &str = "tee:vta_did";
+///
+/// Public because the DID this module mints is read back outside `vta-tee` —
+/// see [`DID_LOG_STORE_KEY`] for why these names are exported rather than
+/// re-typed at each call site.
+pub const VTA_DID_STORE_KEY: &str = "tee:vta_did";
+
+/// Well-known store key for the auto-generated `did.jsonl` log.
+///
+/// Written here under **both** the `KEYS` keyspace (encrypted, read by the
+/// service) and the `BOOTSTRAP` keyspace (unencrypted, read by the parent-side
+/// proxy so it can write `did.jsonl` to disk for the operator).
+///
+/// Exported because the readers live in other crates —
+/// `vta_service::routes::attestation::did_log` serves it over
+/// `GET /attestation/did-log`. Renaming this key silently breaks those readers
+/// if each one spells the string itself, so they take the constant instead.
+///
+/// One reader deliberately cannot: `deploy/nitro/enclave-proxy` is a separate
+/// cargo project on the *parent* side and does not link enclave code, so it
+/// repeats the literal with a comment pointing back here.
+pub const DID_LOG_STORE_KEY: &str = "tee:did_log";
 
 /// Check for an existing DID in the store, or auto-generate one from the template.
 ///
@@ -221,14 +241,14 @@ pub async fn maybe_generate_vta_did(
 
     // Store did.jsonl in encrypted keyspace for REST API access
     keys_ks
-        .insert_raw("tee:did_log", log_content.as_bytes().to_vec())
+        .insert_raw(DID_LOG_STORE_KEY, log_content.as_bytes().to_vec())
         .await?;
 
     // Also store in bootstrap keyspace (no encryption) so the parent proxy
     // can read it and write did.jsonl to disk for the operator.
     let bootstrap_ks = store.keyspace(vta_keyspaces::BOOTSTRAP)?;
     bootstrap_ks
-        .insert_raw("tee:did_log", log_content.as_bytes().to_vec())
+        .insert_raw(DID_LOG_STORE_KEY, log_content.as_bytes().to_vec())
         .await?;
 
     // Flush the store to ensure durability
@@ -237,8 +257,9 @@ pub async fn maybe_generate_vta_did(
     info!(
         did = %final_did,
         scid = %scid,
+        store_key = DID_LOG_STORE_KEY,
         "VTA did:webvh identity auto-generated — retrieve did.jsonl via: \
-         GET /attestation/did-log or from the bootstrap keyspace key 'tee:did_log'"
+         GET /attestation/did-log or from the bootstrap keyspace key in `store_key`"
     );
 
     config.vta_did = Some(final_did);


### PR DESCRIPTION
Three small cross-cutting fixes that surfaced while reviewing the TEE / Nitro batch (#819, #824, #826, #827, #832). None of them belongs to any one of those PRs, so they are collected here rather than bolted onto whichever happened to touch the file.

Independent of each other and of the PRs that surfaced them — mergeable in any order.

## 1. `tee:did_log` / `tee:vta_did` get one home

The DID-log store key was a bare string literal in **four** places across three crates:

| Site | Role |
|---|---|
| `vta-tee/src/did_autogen.rs` (×2) | writes it to the `KEYS` (encrypted) and `BOOTSTRAP` (plain) keyspaces |
| `vta-service/src/routes/attestation.rs` | reads it to serve `GET /attestation/did-log` |
| `deploy/nitro/enclave-proxy/src/storage.rs` (×2) | parent-side reader that writes `did.jsonl` to disk |

Renaming the key would have broken the attestation route silently — nothing links the writer to the reader.

`vta_tee::did_autogen` now exports `DID_LOG_STORE_KEY` and `VTA_DID_STORE_KEY`, and every in-workspace reader takes the constant. `enclave-proxy` deliberately **cannot**: it is a separate cargo project running on the *parent* and does not link enclave code. It keeps the literal, now with a comment naming the canonical definition — an honest cross-reference rather than a fake abstraction.

Note for #827: `vta-service/src/tee_webvh.rs` introduces a fifth copy, with a doc comment justifying it as "so this bridge doesn't pull `vta-tee` into `vta-service`'s dependency graph". That rationale doesn't hold — the module is `#[cfg(feature = "tee")]` and `lib.rs` already does `pub use vta_tee as tee;` under the same feature. Whichever of these lands second should use the constant.

## 2. `parent-proxy.sh` bound the DID resolver to the IMDS port

It defaulted `VSOCK_RESOLVER_PORT` to **5400**. On the enclave side 5400 is the IMDS credential proxy and the resolver is **5600** — see `enclave-entrypoint.sh:39-40` and `enclave-proxy/src/main.rs:54,62`. A VTA brought up with this script would have had its resolver leg wired into the credential channel.

The script is also socat-only and covers four of the seven vsock channels — no storage proxy (5500), no log forwarding (5700) — so a VTA deployed with it has no persistent store and no enclave logs on the parent. The header now says that plainly and points at the Rust `enclave-proxy` as the canonical parent implementation, so nobody reaches for the socat path for a real deployment.

Surfaced by #832, which documents all seven channels correctly.

## 3. `check-changelogs.sh` could not fail the case it was written for

The guard matched the version **string anywhere in the file**, not a `<crate> <version>` entry. With a dozen subsystem crates all sitting in the 0.1.x range, patch numbers collide constantly — so `vta-tee` 0.1.0 → 0.1.1 (#819) **passed with no `vta-tee` entry at all**, because `0.1.1` already appeared for `vta-audit`, `vta-backup`, `vta-vault` and `vta-webvh`. It is now on `main` as an undocumented published version; this PR backfills the entry.

A release guard that green-lights an undocumented release is worse than no guard, because it is trusted.

The match now requires the crate name immediately before the version, accepting both heading shapes actually in use:

```
### vta-service 0.12.43 — summary
### vti-secrets 0.1.7 / vta-config 0.1.1 — summary
- `vta-audit` 0.1.1
```

The right-hand token boundary is unchanged, so a `0.1.30` entry still cannot satisfy a bump to `0.1.3`.

**Validation** — replayed the tightened guard over the last 25 commits of `main`, running it at each commit with `BASE=<commit>^`:

- **16** commits carrying version bumps still pass — no false positives.
- **1** new catch: `63539989` (#819), `MISSING vta-tee: 0.1.0 -> 0.1.1`. That is the bug, not a regression.

## Verification

- `cargo check -p vta-service --no-default-features --features tee,rest,didcomm` — clean
- `cargo check` in `deploy/nitro/enclave-proxy` — clean
- `cargo fmt --all --check` — clean
- both release guards pass against `origin/main`

## Versions

`vta-tee` 0.1.1 → **0.1.2**, `vta-service` 0.12.42 → **0.12.45**. The gap is deliberate: #824 claims 0.12.43 and #827 claims 0.12.44, so this stays out of their way regardless of merge order.
