### PR TITLE
docs(changelog): say which transports reach the member document form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,18 @@ spec change.
 - The proven member comes from `resolve_holder`, so the authenticated identity
   is the transport's (DIDComm authcrypt sender / TSP sender VID) or the document
   proof signer — never a self-asserted `issuer`.
-- The bare-body DIDComm handlers stay. Existing senders keep working, and both
-  forms return the same receipt payload, so a client migrating to the document
-  form sees no behaviour change. Accept before send: a member-side change can
-  only follow this, never precede it.
+- The bare-body DIDComm handlers stay, and **DIDComm keeps routing these two
+  types to them** — `route()` matches on `msg.typ`, so `members/self-remove` and
+  `members/vmc` still reach `member_self_remove_handler` / `member_vmc_handler`,
+  which parse a bare body. The document form is therefore reachable over **TSP
+  and REST**, not over DIDComm. Existing senders keep working unchanged; a
+  sender that switches to the document form must switch transport with it, or
+  the bare-body handler will reject the document as malformed. (Contrast
+  `join-requests/*`, whose DIDComm handlers forward to the dispatcher via
+  `inbound_doc_bytes` and so accept the document on every transport.)
+- Both forms return the same receipt payload, so the response contract does not
+  depend on which one a caller used. Accept before send: a member-side change
+  can only follow this, never precede it.
 - `DISPATCHED_URIS` now documents what it has quietly become — the set reachable
   over TSP — and its coverage test extends to the member verbs.
 


### PR DESCRIPTION
## What

Corrects one claim in the `vtc-service 0.11.37` entry from #838.

It said *"a client migrating to the document form sees no behaviour change."* That holds over **TSP and REST** and is **false over DIDComm** — which is the reading most likely to be acted on, since DIDComm is what OpenVTC sends these two verbs over today.

## Why it's wrong

`route()` matches on `msg.typ`, so `members/self-remove` and `members/vmc` still reach `member_self_remove_handler` / `member_vmc_handler`, which parse a **bare body**. #838 added the document handlers to `dispatch_trust_task_core`, which DIDComm does not consult for these two types. A sender that switched to the document form without also switching transport would have its document rejected as a malformed bare body.

`join-requests/*` does not have this property — its DIDComm handlers forward to the dispatcher via `inbound_doc_bytes`, so they accept the document on every transport. That asymmetry is exactly what makes the original wording easy to misread.

## The change

- States the reachable transports outright, and names the contrast with `join-requests/*` so the asymmetry is visible.
- Splits the receipt-payload claim — which *does* hold on every transport — into its own bullet, so the two are not read as a single guarantee.

Changelog text only: no code, no version bump. `check-version-bumps.sh` excludes `CHANGELOG*` from the bump requirement; both guards re-run clean.

Refs #838, OpenVTC/openvtc#185
