### PR TITLE
feat(config)!: fold config and provisioning onto canonical, and stop the VTA rewriting its own DID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,66 @@
 
 ## Unreleased
 
+### vta-sdk 0.20.10 / vta-service 0.13.1 / vta-cli-common 0.10.17 / pnm-cli 0.11.12 / cnm-cli 0.11.11 / vtc-service 0.11.39 — config and provisioning fold onto canonical, and the VTA can no longer rewrite its own identity (#840 phase A)
+
+Three of the 67 unpublished canonical URIs are gone, folded onto tasks the
+registry already publishes — **no new specs authored**:
+
+| Was | Now |
+|---|---|
+| `vta/config/get/1.0` | `config/show/0.1` |
+| `vta/config/update/1.0` | `config/patch/0.1` |
+| `vta/provision-integration/request/1.0` | `provision/integration/0.2` |
+
+The `spec/vta/` counted exception in `trust_task_manifest.rs` drops 55 → 52.
+
+`provision-integration` was nearly free: its payload already cited the
+canonical spec and already dual-accepted the 0.2 camelCase wire form (#517), so
+the fold was a constant change.
+
+### The VTA could rewrite its own DID at runtime. It can't now.
+
+`config/update` wrote `vta_did` straight into `config.toml` with **no guard at
+all**, and the write survived a restart. One mistaken call re-pointed the
+agent's own identity — orphaning every credential it had issued, every ACL
+grant naming it, and its DID-document linkage.
+
+It was super-admin gated, so this was a bricking footgun rather than a
+privilege escalation. Same class as the defect VTC fixed in its P1.1 hardening,
+and the rationale ports verbatim: a mistaken patch must not strand the daemon
+auth-dead or re-point the recovery authority.
+
+Folding onto canonical `config/patch` **required** deciding which keys are
+patchable, so the fix rides the fold rather than being bolted on. `vta_did` is
+now a registry key marked immutable: `config/show` returns it, and a patch
+naming it comes back under `rejected` with a reason.
+
+Modelling it as *immutable* rather than *absent from the registry* — VTC's
+choice — keeps the read path (nothing else exposes the VTA's DID) and gives a
+better answer: "identity is set at setup" instead of "unknown key".
+
+Enforcement lives in the registry table, not an `if` in a handler. There is one
+place saying what may change and every write path consults it, so a new
+mutation surface cannot forget the check. `--community-vta-did` is gone from
+both CLIs: there is no longer a flag to attempt it with.
+
+### Config is a key registry now, not three named fields
+
+That reshape is what made the fold possible — canonical `config/*` speaks
+`{key, value, source, requiresRestart}`, and the VTA's three typed fields
+could not fold without it. Two things fall out:
+
+- `public_url` is honestly marked `requiresRestart: true`. It is read at boot
+  to build the advertised origin, so before this a patch silently diverged the
+  running services from the stored value until someone called
+  `management/reload-services`.
+- `config/patch` reports `applied` / `pendingRestart` / `rejected` per key
+  instead of echoing the whole config, so a caller learns which of its changes
+  actually took effect.
+
+`ConfigResponse` keeps `vta_did()`, `vta_name()` and `public_url()` accessors
+so call sites read the same as before.
+
 ### vta-config 0.2.0 — `HardenedConfig` added to `AppConfig`
 
 New public struct `HardenedConfig` and a corresponding `hardened:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 ## Unreleased
 
+### vta-support 0.2.1 — declare the `vti-common` feature it actually uses
+
+`seal.rs` calls `KeyspaceHandle::with_encryption`, which is
+`#[cfg(feature = "encryption")]` in `vti-common`. `vta-support` depended on
+`vti-common` with **no features at all**.
+
+It built anyway, which is exactly why this went unnoticed: another workspace
+member enables `vti-common/encryption`, and cargo's feature unification turns
+it on for the shared build. `cargo publish` verifies each crate **in
+isolation**, where nothing else is present to enable it — so the method
+genuinely is not compiled in and the tarball fails with `E0599`.
+
+**This is what broke the publish run for 0.2.0**, and it would have failed on
+every subsequent run: the published `vti-common` 0.11.28 *does* carry the
+method, it was simply never compiled into `vta-support`'s isolated build. A
+version bump would not have helped.
+
+0.2.0 is skipped rather than reused — it exists only as a failed publish
+attempt and never reached crates.io.
+
+The generalisable point: **a workspace build cannot detect a missing feature
+dependency**, because unification supplies it from a sibling. Only an isolated
+build can, and `cargo package` is the only thing in the pipeline that does one
+— which is why `Feature combos` passed throughout.
+
+
 ### vta-sdk 0.20.10 / vta-service 0.13.1 / vta-cli-common 0.10.17 / pnm-cli 0.11.12 / cnm-cli 0.11.11 / vtc-service 0.11.39 — config and provisioning fold onto canonical, and the VTA can no longer rewrite its own identity (#840 phase A)
 
 Three of the 67 unpublished canonical URIs are gone, folded onto tasks the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10432,7 +10432,7 @@ dependencies = [
 
 [[package]]
 name = "vta-support"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "chrono",
  "ed25519-dalek",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2488,7 +2488,7 @@ checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cnm-cli"
-version = "0.11.10"
+version = "0.11.11"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "clap",
@@ -6759,7 +6759,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "pnm-cli"
-version = "0.11.11"
+version = "0.11.12"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-resolver-cache-sdk",
@@ -9585,9 +9585,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-rs"
-version = "0.2.41"
+version = "0.2.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0922fbd2ff5bf3813d119288e420c94c10a33dbe46e5bd2beb04b24d7cc927d0"
+checksum = "2e38e5179d94ec6ca22a396027beef33a3c27fde3b9edd03aab34ec4591551b1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -10118,7 +10118,7 @@ dependencies = [
 
 [[package]]
 name = "vta-cli-common"
-version = "0.10.16"
+version = "0.10.17"
 dependencies = [
  "aes-gcm",
  "affinidi-crypto",
@@ -10269,7 +10269,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.20.9"
+version = "0.20.10"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10331,7 +10331,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",
@@ -10564,7 +10564,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-service"
-version = "0.11.38"
+version = "0.11.39"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -212,7 +212,7 @@ aws-lc-rs = "1.16"
 # (camelCase wire enums + `/0.2` TYPE_URIs) alongside the retained
 # `v0_1` modules — the VTA dual-accepts both during the migration.
 # Bump in lockstep with affinidi-webvh-service when upstream publishes.
-trust-tasks-rs = { version = "0.2.41", default-features = false, features = ["validate"] }
+trust-tasks-rs = { version = "0.2.42", default-features = false, features = ["validate"] }
 trust-tasks-capability-client = "0.1"
 trust-tasks-https = { version = "0.2", default-features = false, features = ["server", "client", "jwt"] }
 trust-tasks-proof = { version = "0.2", default-features = false, features = ["affinidi"] }

--- a/cnm-cli/Cargo.toml
+++ b/cnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cnm-cli"
 description = "CLI Tool for Verified Trust Agents operating in Verified Trust Communities"
-version = "0.11.10"
+version = "0.11.11"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/cnm-cli/src/main.rs
+++ b/cnm-cli/src/main.rs
@@ -412,9 +412,9 @@ enum ConfigCommands {
     Get,
     /// Update configuration
     Update {
-        /// VTA DID
-        #[arg(long)]
-        community_vta_did: Option<String>,
+        // `--community-vta-did` is deliberately absent: the VTA's own identity
+        // is set at setup and immutable at runtime (canonical config/patch
+        // reports it under `rejected`). There is no flag to attempt it with.
         /// VTA name
         #[arg(long)]
         community_vta_name: Option<String>,
@@ -1073,18 +1073,11 @@ async fn main() {
         Commands::Config { command } => match command {
             ConfigCommands::Get => config_cmd::cmd_config_get(&client, "Community ").await,
             ConfigCommands::Update {
-                community_vta_did,
                 community_vta_name,
                 public_url,
             } => {
-                config_cmd::cmd_config_update(
-                    &client,
-                    "Community ",
-                    community_vta_did,
-                    community_vta_name,
-                    public_url,
-                )
-                .await
+                config_cmd::cmd_config_update(&client, "Community ", community_vta_name, public_url)
+                    .await
             }
         },
         Commands::Contexts { command } => match command {

--- a/pnm-cli/Cargo.toml
+++ b/pnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pnm-cli"
 description = "CLI Tool for managing a personal Verifiable Trust Agent"
-version = "0.11.11"
+version = "0.11.12"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/pnm-cli/src/cli.rs
+++ b/pnm-cli/src/cli.rs
@@ -1325,9 +1325,9 @@ pub(crate) enum ConfigCommands {
     Get,
     /// Update configuration
     Update {
-        /// VTA DID
-        #[arg(long)]
-        community_vta_did: Option<String>,
+        // `--community-vta-did` is deliberately absent: the VTA's own identity
+        // is set at setup and immutable at runtime (canonical config/patch
+        // reports it under `rejected`). There is no flag to attempt it with.
         /// VTA name
         #[arg(long)]
         community_vta_name: Option<String>,

--- a/pnm-cli/src/commands/config.rs
+++ b/pnm-cli/src/commands/config.rs
@@ -13,19 +13,9 @@ pub(crate) async fn run(
     match command {
         ConfigCommands::Get => config_cmd::cmd_config_get(client, "").await,
         ConfigCommands::Update {
-            community_vta_did,
             community_vta_name,
             public_url,
-        } => {
-            config_cmd::cmd_config_update(
-                client,
-                "",
-                community_vta_did,
-                community_vta_name,
-                public_url,
-            )
-            .await
-        }
+        } => config_cmd::cmd_config_update(client, "", community_vta_name, public_url).await,
         ConfigCommands::ResolverUrl { .. } => {
             // Handled in the pre-auth dispatcher (see `main.rs`) — local
             // config mutation, no VTA round-trip. Reaching here means

--- a/tests/e2e/tests/client_didcomm.rs
+++ b/tests/e2e/tests/client_didcomm.rs
@@ -173,9 +173,14 @@ async fn get_config_via_didcomm() {
             ResponderReply::ok(
                 vta_management::GET_CONFIG_RESULT,
                 json!({
-                    "vta_did": "did:web:vta.example.com",
-                    "vta_name": "primary",
-                    "public_url": "https://vta.example.com"
+                    "fields": [
+                        { "key": "vta_did", "value": "did:web:vta.example.com",
+                          "source": "setup", "requiresRestart": false },
+                        { "key": "vta_name", "value": "primary",
+                          "source": "toml", "requiresRestart": false },
+                        { "key": "public_url", "value": "https://vta.example.com",
+                          "source": "toml", "requiresRestart": true }
+                    ]
                 }),
             )
         } else {
@@ -185,7 +190,8 @@ async fn get_config_via_didcomm() {
     .await;
 
     let cfg = client.get_config().await.unwrap();
-    assert_eq!(cfg.community_vta_name.as_deref(), Some("primary"));
+    assert_eq!(cfg.vta_name(), Some("primary"));
+    assert_eq!(cfg.vta_did(), Some("did:web:vta.example.com"));
 
     shutdown_all(client, responder, mediator).await;
 }

--- a/vta-cli-common/Cargo.toml
+++ b/vta-cli-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-cli-common"
 description = "Shared CLI command handlers and rendering helpers for VTA CLIs"
 readme = "README.md"
-version = "0.10.16"
+version = "0.10.17"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-cli-common/src/commands/config.rs
+++ b/vta-cli-common/src/commands/config.rs
@@ -1,50 +1,87 @@
-use vta_sdk::prelude::*;
+use std::collections::HashMap;
 
+use vta_sdk::prelude::*;
+use vta_sdk::protocols::vta_management::update_config::UpdateConfigBody;
+
+/// Print the configuration registry as canonical `config/show/0.1` returns it.
+///
+/// Boot-stable keys are marked, so an operator can see before patching that a
+/// change will not take effect until a restart.
 pub async fn cmd_config_get(
     client: &VtaClient,
     label_prefix: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let resp = client.get_config().await?;
-    println!(
-        "{label_prefix}VTA DID:    {}",
-        resp.community_vta_did.as_deref().unwrap_or("(not set)")
-    );
-    println!(
-        "{label_prefix}VTA Name:   {}",
-        resp.community_vta_name.as_deref().unwrap_or("(not set)")
-    );
-    println!(
-        "{label_prefix}Public URL: {}",
-        resp.public_url.as_deref().unwrap_or("(not set)")
-    );
+    for field in &resp.config.fields {
+        let value = match &field.value {
+            serde_json::Value::Null => "(not set)".to_string(),
+            serde_json::Value::String(s) => s.clone(),
+            other => other.to_string(),
+        };
+        let restart = if field.requires_restart {
+            "  (requires restart)"
+        } else {
+            ""
+        };
+        println!(
+            "{label_prefix}{:<12} {value}  [{}]{restart}",
+            format!("{}:", field.key),
+            field.source
+        );
+    }
     Ok(())
 }
 
+/// Patch configuration keys.
+///
+/// `vta_did` is deliberately **not** a parameter: the VTA's own identity is
+/// set at setup and is immutable at runtime, so there is no flag to attempt
+/// it with. A caller that names it anyway (over the wire) is answered with a
+/// rejection, which this command prints — the operator learns the rule rather
+/// than silently re-pointing the agent's identity, which is what the
+/// pre-canonical surface did.
 pub async fn cmd_config_update(
     client: &VtaClient,
     label_prefix: &str,
-    vta_did: Option<String>,
     vta_name: Option<String>,
     public_url: Option<String>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let req = UpdateConfigRequest {
-        vta_did,
-        vta_name,
-        public_url,
-    };
-    let resp = client.update_config(req).await?;
-    println!("Configuration updated:");
-    println!(
-        "  {label_prefix}VTA DID:    {}",
-        resp.community_vta_did.as_deref().unwrap_or("(not set)")
-    );
-    println!(
-        "  {label_prefix}VTA Name:   {}",
-        resp.community_vta_name.as_deref().unwrap_or("(not set)")
-    );
-    println!(
-        "  {label_prefix}Public URL: {}",
-        resp.public_url.as_deref().unwrap_or("(not set)")
-    );
+    let mut overrides = HashMap::new();
+    if let Some(v) = vta_name {
+        overrides.insert("vta_name".to_string(), serde_json::Value::String(v));
+    }
+    if let Some(v) = public_url {
+        overrides.insert("public_url".to_string(), serde_json::Value::String(v));
+    }
+    if overrides.is_empty() {
+        println!("Nothing to update — pass at least one of --vta-name or --public-url.");
+        return Ok(());
+    }
+
+    let resp = client
+        .update_config(UpdateConfigRequest {
+            patch: UpdateConfigBody { overrides },
+        })
+        .await?;
+
+    if !resp.applied.is_empty() {
+        println!(
+            "{label_prefix}Applied:          {}",
+            resp.applied.join(", ")
+        );
+    }
+    if !resp.pending_restart.is_empty() {
+        println!(
+            "{label_prefix}Pending restart:  {}",
+            resp.pending_restart.join(", ")
+        );
+        println!("{label_prefix}  Stored, but not in effect until the VTA restarts.");
+    }
+    for rejected in &resp.rejected {
+        println!(
+            "{label_prefix}Rejected {}: {}",
+            rejected.key, rejected.reason
+        );
+    }
     Ok(())
 }

--- a/vta-cli-common/src/commands/contexts.rs
+++ b/vta-cli-common/src/commands/contexts.rs
@@ -48,10 +48,10 @@ pub async fn cmd_context_bootstrap(
     // Fetch VTA config so the minted CredentialBundle carries VTA DID/URL.
     let config = client.get_config().await?;
     let vta_did = config
-        .community_vta_did
-        .clone()
+        .vta_did()
+        .map(str::to_string)
         .ok_or("VTA DID not configured — cannot mint admin credential")?;
-    let vta_url = config.public_url.clone();
+    let vta_url = config.public_url().map(str::to_string);
 
     // Mint admin did:key locally + register ACL. The VTA never sees the
     // private half; the full bundle reaches the recipient via sealed transfer.
@@ -514,10 +514,10 @@ pub async fn cmd_context_provision(
     // 2. Fetch VTA config for URL/DID (needed to build the admin credential).
     let config = client.get_config().await?;
     let vta_did = config
-        .community_vta_did
-        .clone()
+        .vta_did()
+        .map(str::to_string)
         .ok_or("VTA DID not configured — cannot mint admin credential")?;
-    let vta_url = config.public_url.clone();
+    let vta_url = config.public_url().map(str::to_string);
 
     // 3. Generate admin did:key locally (private key never crosses the wire)
     //    and register it with the VTA via POST /acl. This replaces the
@@ -598,8 +598,8 @@ pub async fn cmd_context_provision(
     let bundle = ContextProvisionBundle {
         context_id: id.to_string(),
         context_name: name.to_string(),
-        vta_url: config.public_url,
-        vta_did: config.community_vta_did,
+        vta_url: config.public_url().map(str::to_string),
+        vta_did: config.vta_did().map(str::to_string),
         credential: admin_credential,
         admin_did,
         did: provisioned_did,
@@ -639,16 +639,13 @@ pub async fn cmd_context_reprovision(
 
     // 2. Fetch VTA config for URL/DID
     let config = client.get_config().await?;
-    let vta_did = config
-        .community_vta_did
-        .as_deref()
-        .ok_or("VTA DID not configured")?;
+    let vta_did = config.vta_did().ok_or("VTA DID not configured")?;
 
     // 3. Resolve admin credential
     let (admin_credential, admin_did) = if let Some(ref kid) = key_id {
         // Direct key ID specified
         eprintln!("Using key '{kid}'...");
-        credential_from_key(client, kid, vta_did, config.public_url.as_deref()).await?
+        credential_from_key(client, kid, vta_did, config.public_url()).await?
     } else {
         // Interactive: list existing Ed25519 keys and let user choose
         let keys_resp = client.list_keys(0, 10000, Some("active"), Some(id)).await?;
@@ -701,23 +698,11 @@ pub async fn cmd_context_reprovision(
                     context_id: Some(id.to_string()),
                 })
                 .await?;
-            credential_from_key(
-                client,
-                &key_resp.key_id,
-                vta_did,
-                config.public_url.as_deref(),
-            )
-            .await?
+            credential_from_key(client, &key_resp.key_id, vta_did, config.public_url()).await?
         } else if choice >= 1 && choice <= ed25519_keys.len() {
             let selected = &ed25519_keys[choice - 1];
             eprintln!("Using key '{}'...", selected.key_id);
-            credential_from_key(
-                client,
-                &selected.key_id,
-                vta_did,
-                config.public_url.as_deref(),
-            )
-            .await?
+            credential_from_key(client, &selected.key_id, vta_did, config.public_url()).await?
         } else {
             return Err(format!("Invalid choice: {choice}").into());
         }
@@ -766,8 +751,8 @@ pub async fn cmd_context_reprovision(
     let bundle = ContextProvisionBundle {
         context_id: id.to_string(),
         context_name: ctx.name.clone(),
-        vta_url: config.public_url,
-        vta_did: config.community_vta_did,
+        vta_url: config.public_url().map(str::to_string),
+        vta_did: config.vta_did().map(str::to_string),
         credential: admin_credential,
         admin_did,
         did: provisioned_did,

--- a/vta-cli-common/src/commands/credentials.rs
+++ b/vta-cli-common/src/commands/credentials.rs
@@ -17,10 +17,10 @@ pub async fn cmd_auth_credential_create(
     // Fetch VTA metadata for the credential bundle.
     let config = client.get_config().await?;
     let vta_did = config
-        .community_vta_did
-        .clone()
+        .vta_did()
+        .map(str::to_string)
         .ok_or("VTA DID not configured — cannot mint credential")?;
-    let vta_url = config.public_url.clone();
+    let vta_url = config.public_url().map(str::to_string);
 
     // Mint locally, then register the did:key via POST /acl. The private key
     // never crosses the wire — it reaches the recipient only via the sealed

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.20.9"
+version = "0.20.10"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/client/mod.rs
+++ b/vta-sdk/src/client/mod.rs
@@ -1892,17 +1892,31 @@ mod tests {
 
     // ── Request/Response serialization ──────────────────────────────
 
+    /// The patch carries only the keys the caller named — it is a map, so an
+    /// unmentioned key is simply absent rather than an explicit null that a
+    /// consumer might read as "clear this".
     #[test]
-    fn test_update_config_skips_none_fields() {
+    fn test_update_config_sends_only_named_keys() {
+        use crate::protocols::vta_management::update_config::UpdateConfigBody;
+        let mut overrides = std::collections::HashMap::new();
+        overrides.insert("vta_name".to_string(), serde_json::json!("Test"));
         let req = UpdateConfigRequest {
-            vta_did: None,
-            vta_name: Some("Test".into()),
-            public_url: None,
+            patch: UpdateConfigBody { overrides },
         };
         let json = serde_json::to_value(&req).unwrap();
-        assert!(!json.as_object().unwrap().contains_key("vta_did"));
-        assert_eq!(json["vta_name"], "Test");
-        assert!(!json.as_object().unwrap().contains_key("public_url"));
+        assert_eq!(json["overrides"]["vta_name"], "Test");
+        assert!(
+            !json["overrides"]
+                .as_object()
+                .unwrap()
+                .contains_key("public_url")
+        );
+        assert!(
+            !json["overrides"]
+                .as_object()
+                .unwrap()
+                .contains_key("vta_did")
+        );
     }
 
     #[test]

--- a/vta-sdk/src/client/types.rs
+++ b/vta-sdk/src/client/types.rs
@@ -25,21 +25,41 @@ pub struct HealthResponse {
 
 #[derive(Debug, Deserialize)]
 pub struct ConfigResponse {
-    #[serde(rename = "vta_did")]
-    pub community_vta_did: Option<String>,
-    #[serde(rename = "vta_name")]
-    pub community_vta_name: Option<String>,
-    pub public_url: Option<String>,
+    /// The registry, as canonical `config/show/0.1` returns it. Read a single
+    /// key with [`GetConfigResultBody::get`], or the common one with
+    /// [`GetConfigResultBody::vta_did`].
+    ///
+    /// [`GetConfigResultBody::get`]: crate::protocols::vta_management::get_config::GetConfigResultBody::get
+    /// [`GetConfigResultBody::vta_did`]: crate::protocols::vta_management::get_config::GetConfigResultBody::vta_did
+    #[serde(flatten)]
+    pub config: crate::protocols::vta_management::get_config::GetConfigResultBody,
+}
+
+impl ConfigResponse {
+    /// The VTA's own DID, if set. Read-only — see
+    /// [`UpdateConfigBody`](crate::protocols::vta_management::update_config::UpdateConfigBody)
+    /// for why it cannot be patched.
+    pub fn vta_did(&self) -> Option<&str> {
+        self.config.vta_did()
+    }
+
+    /// The VTA's advertised public URL, if set.
+    pub fn public_url(&self) -> Option<&str> {
+        self.config.get("public_url").and_then(|v| v.as_str())
+    }
+
+    /// The VTA's operator-facing name, if set.
+    pub fn vta_name(&self) -> Option<&str> {
+        self.config.get("vta_name").and_then(|v| v.as_str())
+    }
 }
 
 #[derive(Debug, Serialize)]
 pub struct UpdateConfigRequest {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub vta_did: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub vta_name: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub public_url: Option<String>,
+    /// `key → value`. Keys outside the registry, and keys immutable at
+    /// runtime (`vta_did`), come back under `rejected` rather than applying.
+    #[serde(flatten)]
+    pub patch: crate::protocols::vta_management::update_config::UpdateConfigBody,
 }
 
 #[derive(Debug, Serialize)]

--- a/vta-sdk/src/client/vta_management.rs
+++ b/vta-sdk/src/client/vta_management.rs
@@ -37,7 +37,8 @@ impl VtaClient {
     pub async fn update_config(
         &self,
         req: UpdateConfigRequest,
-    ) -> Result<ConfigResponse, VtaError> {
+    ) -> Result<crate::protocols::vta_management::update_config::UpdateConfigResultBody, VtaError>
+    {
         self.rpc(
             vta_management::UPDATE_CONFIG,
             serde_json::to_value(&req)?,

--- a/vta-sdk/src/protocols/vta_management/get_config.rs
+++ b/vta-sdk/src/protocols/vta_management/get_config.rs
@@ -1,14 +1,66 @@
+//! `config/show/0.1` — read the VTA's runtime configuration.
+//!
+//! Folded onto the canonical `config/*` family (#840 phase A). The VTA
+//! previously exposed three named, typed fields (`vta_did`, `vta_name`,
+//! `public_url`); canonical `config/show` returns a **registry** of keys, each
+//! carrying where its effective value came from and whether a restart is
+//! needed for a change to take effect. Same information, one shape shared with
+//! every other agent.
+
 use serde::{Deserialize, Serialize};
 
+/// `config/show/0.1` request. `keys` narrows the result; omitted returns every
+/// registered key.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-pub struct GetConfigBody {}
+pub struct GetConfigBody {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub keys: Option<Vec<String>>,
+}
 
+/// One configuration key as the operator currently sees it — canonical
+/// `config/_shared/0.1/config#ConfigField`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct ConfigField {
+    /// The configuration key, e.g. `vta_name`.
+    pub key: String,
+    /// The effective value. `null` when the key is unset.
+    #[cfg_attr(feature = "openapi", schema(value_type = Object))]
+    pub value: serde_json::Value,
+    /// Which layer supplied the effective value — `setup`, `toml`, `default`.
+    pub source: String,
+    /// True when a change to this key takes effect only after a restart.
+    pub requires_restart: bool,
+}
+
+/// `config/show/0.1` response.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct GetConfigResultBody {
-    pub vta_did: Option<String>,
-    pub vta_name: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub public_url: Option<String>,
+    pub fields: Vec<ConfigField>,
+}
+
+impl GetConfigResultBody {
+    /// Value of `key`, if the registry carries it and it is set.
+    ///
+    /// Convenience for callers that want one key out of the registry — most
+    /// commonly `vta_did`, which is read far more often than the rest and used
+    /// to have a named field of its own.
+    pub fn get(&self, key: &str) -> Option<&serde_json::Value> {
+        self.fields
+            .iter()
+            .find(|f| f.key == key)
+            .map(|f| &f.value)
+            .filter(|v| !v.is_null())
+    }
+
+    /// `vta_did` as a string, if set. The VTA's own identity is read-only —
+    /// see `update_config` for why it cannot be patched.
+    pub fn vta_did(&self) -> Option<&str> {
+        self.get("vta_did").and_then(|v| v.as_str())
+    }
 }

--- a/vta-sdk/src/protocols/vta_management/update_config.rs
+++ b/vta-sdk/src/protocols/vta_management/update_config.rs
@@ -1,16 +1,69 @@
+//! `config/patch/0.1` — change the VTA's runtime configuration.
+//!
+//! Folded onto the canonical `config/*` family (#840 phase A). The request is
+//! a key/value map rather than named typed fields, and the response reports
+//! per-key what happened: applied now, stored but pending a restart, or
+//! rejected with a reason.
+//!
+//! # Identity is not patchable
+//!
+//! `vta_did` is a **readable but immutable** registry key: `config/show`
+//! returns it, and a patch naming it lands in `rejected`. This is a change —
+//! the pre-fold `config/update` wrote `vta_did` straight into `config.toml`
+//! with no guard, so a single mistaken call could re-point the agent's own
+//! identity and survive a restart. Every credential the VTA had issued, every
+//! ACL grant naming it, and its DID-document linkage would then refer to an
+//! identity it no longer claimed.
+//!
+//! It was super-admin gated, so this was a bricking footgun rather than a
+//! privilege escalation — the same class of defect VTC fixed in its P1.1
+//! hardening, and for the same reason: a mistaken patch must not strand the
+//! daemon auth-dead or re-point the recovery authority.
+//!
+//! Modelling it as *immutable* rather than *absent from the registry* (VTC's
+//! choice) keeps the read path and yields a better error — "identity is set at
+//! setup" instead of "unknown key".
+
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 use super::get_config::GetConfigResultBody;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// `config/patch/0.1` request: `key → value`. Keys outside the registry, and
+/// keys that are immutable at runtime, come back under `rejected` rather than
+/// being silently dropped.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct UpdateConfigBody {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub vta_did: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub vta_name: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub public_url: Option<String>,
+    #[cfg_attr(feature = "openapi", schema(value_type = Object))]
+    pub overrides: HashMap<String, serde_json::Value>,
 }
 
-pub type UpdateConfigResultBody = GetConfigResultBody;
+/// A key the patch declined to apply, and why — canonical
+/// `config/_shared/0.1/config#RejectedKey`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct RejectedKey {
+    pub key: String,
+    /// Why it was rejected — unknown key, immutable at runtime, wrong type.
+    pub reason: String,
+}
+
+/// `config/patch/0.1` response.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct UpdateConfigResultBody {
+    /// Keys whose new value is in effect now.
+    pub applied: Vec<String>,
+    /// Keys stored but needing a restart to take effect.
+    pub pending_restart: Vec<String>,
+    /// Keys not applied, each with a reason.
+    pub rejected: Vec<RejectedKey>,
+}
+
+/// Retained so callers that want the post-patch view can ask for it without a
+/// second round trip shape change; `config/show` is the canonical way to read.
+pub type ConfigView = GetConfigResultBody;

--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -759,12 +759,12 @@ pub const TASK_DID_MANAGEMENT_REGISTRY_DEREGISTER_0_1: &str =
 /// (VTA DID, name, public URL).
 /// Payload: [`crate::protocols::vta_management::get_config::GetConfigBody`]
 /// (empty). Auth: any authenticated user.
-pub const TASK_CONFIG_GET_1_0: &str = "https://trusttasks.org/spec/vta/config/get/1.0";
+pub const TASK_CONFIG_GET_1_0: &str = "https://trusttasks.org/spec/config/show/0.1";
 
 /// `spec/vta/config/update/1.0` — patch VTA DID, name, or public URL.
 /// Payload: [`crate::protocols::vta_management::update_config::UpdateConfigBody`].
 /// Auth: Super Admin only.
-pub const TASK_CONFIG_UPDATE_1_0: &str = "https://trusttasks.org/spec/vta/config/update/1.0";
+pub const TASK_CONFIG_UPDATE_1_0: &str = "https://trusttasks.org/spec/config/patch/0.1";
 
 // ─── Management slice (spec/vta/management/*) ────────────────────────────
 
@@ -829,14 +829,14 @@ pub const TASK_PASSKEY_VMS_REVOKE_0_1: &str =
 // carries the same request/response shapes the SDK already exports
 // under `vta_sdk::provision_integration::http`.
 
-/// `spec/vta/provision-integration/request/1.0` — submit a VP-framed
+/// `provision/integration/0.2` — submit a VP-framed
 /// `BootstrapRequest` plus provisioning options to the VTA; receive a
 /// sealed `TemplateBootstrap` bundle back. Payload:
 /// [`crate::provision_integration::http::ProvisionIntegrationRequest`].
 /// Auth: Admin role on the target context (super-admin to use
 /// `create_context: true`).
 pub const TASK_PROVISION_INTEGRATION_REQUEST_1_0: &str =
-    "https://trusttasks.org/spec/vta/provision-integration/request/1.0";
+    "https://trusttasks.org/spec/provision/integration/0.2";
 
 // ─── WebVH-DID-lifecycle slice (spec/vta/webvh/*) ────────────────────────
 //
@@ -1556,6 +1556,16 @@ mod tests {
             // proof's signer against a policy-named approver set, not a bridge
             // enrolment), different lifetime (single-use grant, not standing).
             "https://trusttasks.org/spec/task-consent/",
+            // Canonical runtime configuration — `config/{show,patch}`. The VTA
+            // folded its `vta/config/*` pair onto these in #840 phase A; its
+            // configuration is a key registry, which is the shape the
+            // canonical family already speaks.
+            "https://trusttasks.org/spec/config/",
+            // Canonical integration provisioning — `provision/integration`.
+            // The VTA's `vta/provision-integration/request` carried the same
+            // payload and already dual-accepted the 0.2 wire form, so the fold
+            // was a constant change.
+            "https://trusttasks.org/spec/provision/",
             // Framework ACL protocol — the `acl/swap-key` self-service key
             // rotation task (`TASK_ACL_SWAP_KEY_1_0`), now dispatcher-routed.
             "https://trusttasks.org/spec/acl/",

--- a/vta-sdk/tests/auth_light_rest.rs
+++ b/vta-sdk/tests/auth_light_rest.rs
@@ -406,7 +406,7 @@ async fn ensure_token_valid_refreshes_expired_access_token() {
             "Bearer fresh-access",
         ))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "vta_did": null, "vta_name": null, "public_url": null
+            "fields": []
         })))
         .expect(1)
         .mount(&server)
@@ -499,7 +499,7 @@ async fn ensure_token_valid_full_reauth_when_refresh_expired() {
             "Bearer reauth-access",
         ))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "vta_did": null, "vta_name": null, "public_url": null
+            "fields": []
         })))
         .expect(1)
         .mount(&server)
@@ -591,7 +591,7 @@ async fn ensure_token_valid_falls_through_when_refresh_fails() {
             "Bearer fallback-access",
         ))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "vta_did": null, "vta_name": null, "public_url": null
+            "fields": []
         })))
         .expect(1)
         .mount(&server)

--- a/vta-sdk/tests/client_rest.rs
+++ b/vta-sdk/tests/client_rest.rs
@@ -175,7 +175,7 @@ async fn restart_returns_status() {
 }
 
 #[tokio::test]
-async fn get_config_returns_fields() {
+async fn get_config_returns_the_registry() {
     let server = MockServer::start().await;
     let _g = mount_json(
         &server,
@@ -183,23 +183,67 @@ async fn get_config_returns_fields() {
         "/config",
         200,
         json!({
-            "vta_did": "did:web:vta.example.com",
-            "vta_name": "primary",
-            "public_url": "https://vta.example.com"
+            "fields": [
+                { "key": "vta_did", "value": "did:web:vta.example.com",
+                  "source": "setup", "requiresRestart": false },
+                { "key": "vta_name", "value": "primary",
+                  "source": "toml", "requiresRestart": false },
+                { "key": "public_url", "value": "https://vta.example.com",
+                  "source": "toml", "requiresRestart": true }
+            ]
         }),
     )
     .await;
     let c = client(&server).await;
     let cfg = c.get_config().await.unwrap();
+    assert_eq!(cfg.config.vta_did(), Some("did:web:vta.example.com"));
     assert_eq!(
-        cfg.community_vta_did.as_deref(),
-        Some("did:web:vta.example.com")
+        cfg.config.get("vta_name").and_then(|v| v.as_str()),
+        Some("primary")
     );
-    assert_eq!(cfg.community_vta_name.as_deref(), Some("primary"));
+    // `public_url` is boot-stable, and the registry says so rather than
+    // leaving a caller to discover it by restarting.
+    assert!(
+        cfg.config
+            .fields
+            .iter()
+            .find(|f| f.key == "public_url")
+            .expect("public_url registered")
+            .requires_restart
+    );
 }
 
 #[tokio::test]
-async fn update_config_sends_patch_body() {
+async fn update_config_sends_the_overrides_map() {
+    let server = MockServer::start().await;
+    let _g = mount_json(
+        &server,
+        "PATCH",
+        "/config",
+        200,
+        json!({ "applied": ["vta_name"], "pendingRestart": [], "rejected": [] }),
+    )
+    .await;
+    let c = client(&server).await;
+    let mut overrides = std::collections::HashMap::new();
+    overrides.insert("vta_name".to_string(), json!("new"));
+    let res = c
+        .update_config(UpdateConfigRequest {
+            patch: vta_sdk::protocols::vta_management::update_config::UpdateConfigBody {
+                overrides,
+            },
+        })
+        .await
+        .unwrap();
+    assert_eq!(res.applied, vec!["vta_name"]);
+    assert!(res.rejected.is_empty());
+}
+
+/// Identity is readable but not patchable: naming `vta_did` comes back under
+/// `rejected`, never applied. Before the fold onto canonical `config/patch`,
+/// the VTA wrote it straight to `config.toml` with no guard.
+#[tokio::test]
+async fn update_config_reports_identity_as_rejected() {
     let server = MockServer::start().await;
     let _g = mount_json(
         &server,
@@ -207,20 +251,26 @@ async fn update_config_sends_patch_body() {
         "/config",
         200,
         json!({
-            "vta_did": "did:web:new",
-            "vta_name": "new",
-            "public_url": null
+            "applied": [],
+            "pendingRestart": [],
+            "rejected": [{ "key": "vta_did", "reason": "the VTA's own identity is set at setup" }]
         }),
     )
     .await;
     let c = client(&server).await;
-    let req = UpdateConfigRequest {
-        vta_did: Some("did:web:new".into()),
-        vta_name: Some("new".into()),
-        public_url: None,
-    };
-    let cfg = c.update_config(req).await.unwrap();
-    assert_eq!(cfg.community_vta_name.as_deref(), Some("new"));
+    let mut overrides = std::collections::HashMap::new();
+    overrides.insert("vta_did".to_string(), json!("did:web:attacker"));
+    let res = c
+        .update_config(UpdateConfigRequest {
+            patch: vta_sdk::protocols::vta_management::update_config::UpdateConfigBody {
+                overrides,
+            },
+        })
+        .await
+        .unwrap();
+    assert!(res.applied.is_empty(), "identity must never be applied");
+    assert_eq!(res.rejected.len(), 1);
+    assert_eq!(res.rejected[0].key, "vta_did");
 }
 
 // ── Backup ──────────────────────────────────────────────────────────

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.13.0"
+version = "0.13.1"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/messaging/handlers.rs
+++ b/vta-service/src/messaging/handlers.rs
@@ -821,7 +821,7 @@ didcomm_handler!(
     handle_get_config,
     Gate::None,
     vta_management::GET_CONFIG_RESULT,
-    |s, auth| operations::config::get_config(&s.config, &auth, "didcomm").await
+    |s, auth| operations::config::get_config(&s.config, &auth, None, "didcomm").await
 );
 
 didcomm_handler!(
@@ -829,17 +829,8 @@ didcomm_handler!(
     Gate::SuperAdmin,
     vta_management::UPDATE_CONFIG_RESULT,
     vta_management::update_config::UpdateConfigBody,
-    |s, auth, body| operations::config::update_config(
-        &s.config,
-        &auth,
-        operations::config::UpdateConfigParams {
-            vta_did: body.vta_did,
-            vta_name: body.vta_name,
-            public_url: body.public_url,
-        },
-        "didcomm",
-    )
-    .await
+    |s, auth, body| operations::config::update_config(&s.config, &auth, body.overrides, "didcomm",)
+        .await
 );
 
 // ---------------------------------------------------------------------------

--- a/vta-service/src/operations/config.rs
+++ b/vta-service/src/operations/config.rs
@@ -1,69 +1,274 @@
+//! Runtime configuration, on the canonical `config/{show,patch}/0.1` tasks.
+//!
+//! The VTA's configuration is exposed as a **registry** of keys rather than
+//! named typed fields, which is what let it fold onto the canonical family
+//! (#840 phase A) instead of carrying a `vta/config/*` pair of its own.
+//!
+//! # Identity is immutable at runtime
+//!
+//! [`REGISTRY`] marks `vta_did` `mutable: false`. It is readable through
+//! `config/show`, and a `config/patch` naming it is **rejected** — reported
+//! back under `rejected` with a reason, never written.
+//!
+//! Before the fold, `update_config` wrote `vta_did` straight into
+//! `config.toml` with no guard at all. A single mistaken super-admin call
+//! could re-point the agent's own identity, persist it, and survive a restart:
+//! every credential the VTA had issued, every ACL grant naming it, and its
+//! DID-document linkage would then refer to an identity it no longer claimed.
+//! Super-admin gating made that a bricking footgun rather than a privilege
+//! escalation — the same class of defect VTC fixed in its P1.1 hardening.
+//!
+//! Enforcing it through the registry rather than an `if` in the handler is
+//! deliberate: there is one table saying what may change, and every write path
+//! consults it. A new mutation surface cannot forget the check.
+
+use std::collections::HashMap;
 use std::sync::Arc;
 
+use serde_json::Value;
 use tokio::sync::RwLock;
 use tracing::info;
 
-use vta_sdk::protocols::vta_management::get_config::GetConfigResultBody;
+use vta_sdk::protocols::vta_management::get_config::{ConfigField, GetConfigResultBody};
+use vta_sdk::protocols::vta_management::update_config::{RejectedKey, UpdateConfigResultBody};
 
 use crate::auth::AuthClaims;
 use crate::config::AppConfig;
 use crate::error::AppError;
 
-pub struct UpdateConfigParams {
-    pub vta_did: Option<String>,
-    pub vta_name: Option<String>,
-    pub public_url: Option<String>,
+/// One registered configuration key.
+struct KeyDef {
+    key: &'static str,
+    /// False → readable but refused by `config/patch`.
+    mutable: bool,
+    /// True → a change is stored but only takes effect on restart.
+    requires_restart: bool,
+    /// Why an immutable key is immutable. Surfaced verbatim as the rejection
+    /// reason, so an operator learns the rule rather than just the refusal.
+    immutable_reason: &'static str,
 }
 
+/// Every configuration key this VTA exposes. **The single source of truth for
+/// what may change at runtime** — `patch` consults it, so a new write path
+/// cannot bypass it.
+const REGISTRY: &[KeyDef] = &[
+    KeyDef {
+        key: "vta_did",
+        mutable: false,
+        requires_restart: false,
+        immutable_reason: "the VTA's own identity is set at setup and cannot be changed at \
+                           runtime; re-pointing it would orphan every credential this agent \
+                           issued and every ACL grant naming it",
+    },
+    KeyDef {
+        key: "vta_name",
+        mutable: true,
+        requires_restart: false,
+        immutable_reason: "",
+    },
+    KeyDef {
+        key: "public_url",
+        mutable: true,
+        // The advertised origin is read at boot; changing it while running
+        // would diverge the live services from the stored value.
+        requires_restart: true,
+        immutable_reason: "",
+    },
+];
+
+fn lookup(key: &str) -> Option<&'static KeyDef> {
+    REGISTRY.iter().find(|d| d.key == key)
+}
+
+fn value_of(config: &AppConfig, key: &str) -> Value {
+    let v = match key {
+        "vta_did" => config.vta_did.clone(),
+        "vta_name" => config.vta_name.clone(),
+        "public_url" => config.public_url.clone(),
+        _ => None,
+    };
+    v.map(Value::String).unwrap_or(Value::Null)
+}
+
+fn source_of(config: &AppConfig, key: &str) -> &'static str {
+    if value_of(config, key).is_null() {
+        "default"
+    } else if key == "vta_did" {
+        "setup"
+    } else {
+        "toml"
+    }
+}
+
+/// `config/show/0.1`. Auth: any authenticated caller.
 pub async fn get_config(
     config: &Arc<RwLock<AppConfig>>,
     auth: &AuthClaims,
+    keys: Option<Vec<String>>,
     channel: &str,
 ) -> Result<GetConfigResultBody, AppError> {
     let config = config.read().await;
+    let fields = REGISTRY
+        .iter()
+        .filter(|d| keys.as_ref().is_none_or(|ks| ks.iter().any(|k| k == d.key)))
+        .map(|d| ConfigField {
+            key: d.key.to_string(),
+            value: value_of(&config, d.key),
+            source: source_of(&config, d.key).to_string(),
+            requires_restart: d.requires_restart,
+        })
+        .collect();
     info!(channel, caller = %auth.did, "config retrieved");
-    Ok(GetConfigResultBody {
-        vta_did: config.vta_did.clone(),
-        vta_name: config.vta_name.clone(),
-        public_url: config.public_url.clone(),
-    })
+    Ok(GetConfigResultBody { fields })
 }
 
+/// `config/patch/0.1`. Auth: super-admin.
+///
+/// Unknown and immutable keys are reported under `rejected`; everything else
+/// is applied. A patch that rejects every key writes nothing.
 pub async fn update_config(
     config: &Arc<RwLock<AppConfig>>,
     auth: &AuthClaims,
-    params: UpdateConfigParams,
+    overrides: HashMap<String, Value>,
     channel: &str,
-) -> Result<GetConfigResultBody, AppError> {
+) -> Result<UpdateConfigResultBody, AppError> {
     auth.require_super_admin()?;
 
-    let (result, contents, path) = {
-        let mut config = config.write().await;
+    let mut applied = Vec::new();
+    let mut pending_restart = Vec::new();
+    let mut rejected = Vec::new();
 
-        if let Some(vta_did) = params.vta_did {
-            config.vta_did = Some(vta_did);
-        }
-        if let Some(vta_name) = params.vta_name {
-            config.vta_name = Some(vta_name);
-        }
-        if let Some(public_url) = params.public_url {
-            config.public_url = Some(public_url);
-        }
-
-        let result = GetConfigResultBody {
-            vta_did: config.vta_did.clone(),
-            vta_name: config.vta_name.clone(),
-            public_url: config.public_url.clone(),
+    // Partition before taking the write lock: validation needs no lock, and a
+    // patch that changes nothing must not rewrite config.toml.
+    let mut writes: Vec<(&'static KeyDef, String)> = Vec::new();
+    for (key, value) in &overrides {
+        let Some(def) = lookup(key) else {
+            rejected.push(RejectedKey {
+                key: key.clone(),
+                reason: "unknown config key (not in the registry)".into(),
+            });
+            continue;
         };
+        if !def.mutable {
+            rejected.push(RejectedKey {
+                key: key.clone(),
+                reason: def.immutable_reason.to_string(),
+            });
+            continue;
+        }
+        let Some(s) = value.as_str() else {
+            rejected.push(RejectedKey {
+                key: key.clone(),
+                reason: "expected a string value".into(),
+            });
+            continue;
+        };
+        writes.push((def, s.to_string()));
+    }
+
+    if writes.is_empty() {
+        info!(channel, caller = %auth.did, rejected = rejected.len(), "config patch applied nothing");
+        return Ok(UpdateConfigResultBody {
+            applied,
+            pending_restart,
+            rejected,
+        });
+    }
+
+    let (contents, path) = {
+        let mut config = config.write().await;
+        for (def, value) in &writes {
+            match def.key {
+                "vta_name" => config.vta_name = Some(value.clone()),
+                "public_url" => config.public_url = Some(value.clone()),
+                // Unreachable: `writes` only ever holds mutable registry keys.
+                other => unreachable!("non-mutable key {other} reached the write path"),
+            }
+            if def.requires_restart {
+                pending_restart.push(def.key.to_string());
+            } else {
+                applied.push(def.key.to_string());
+            }
+        }
         let contents = toml::to_string_pretty(&*config)
             .map_err(|e| AppError::Config(format!("failed to serialize config: {e}")))?;
-        let path = config.config_path.clone();
-
-        (result, contents, path)
+        (contents, config.config_path.clone())
     };
 
     std::fs::write(&path, contents).map_err(AppError::Io)?;
 
-    info!(channel, caller = %auth.did, "config updated");
-    Ok(result)
+    info!(
+        channel,
+        caller = %auth.did,
+        applied = applied.len(),
+        pending_restart = pending_restart.len(),
+        rejected = rejected.len(),
+        "config updated"
+    );
+    Ok(UpdateConfigResultBody {
+        applied,
+        pending_restart,
+        rejected,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The registry is the authorization boundary, so the properties that
+    /// matter are properties *of the table* — asserting them here means a new
+    /// key cannot quietly become mutable, and no write path can disagree.
+    #[test]
+    fn identity_is_registered_but_immutable() {
+        let did = lookup("vta_did").expect("vta_did is readable through config/show");
+        assert!(
+            !did.mutable,
+            "the VTA's own identity must never be patchable at runtime — \
+             re-pointing it orphans every credential this agent issued"
+        );
+        assert!(
+            !did.immutable_reason.is_empty(),
+            "an immutable key must carry a reason; it is surfaced to the operator verbatim"
+        );
+    }
+
+    /// Readable *and* immutable, not absent. VTC solved the same problem by
+    /// leaving its DID out of the registry entirely, which loses the read path
+    /// and answers "unknown key" to a question that deserves a better answer.
+    #[test]
+    fn identity_is_readable() {
+        assert!(
+            REGISTRY.iter().any(|d| d.key == "vta_did"),
+            "config/show must still return the VTA DID"
+        );
+    }
+
+    /// Every immutable key states why, and every mutable one does not pretend
+    /// to. Guards against a key being marked immutable with an empty reason,
+    /// which would surface as a blank rejection.
+    #[test]
+    fn reasons_track_mutability() {
+        for d in REGISTRY {
+            assert_eq!(
+                d.mutable,
+                d.immutable_reason.is_empty(),
+                "{}: an immutable key needs a reason and a mutable one must not carry one",
+                d.key
+            );
+        }
+    }
+
+    /// `public_url` is boot-stable: it is read once at startup to build the
+    /// advertised origin, so a patch stores it but must report it as pending.
+    /// Silently applying it would diverge the running services from the value
+    /// an operator just read back.
+    #[test]
+    fn boot_stable_keys_are_marked_restart_required() {
+        assert!(
+            lookup("public_url").expect("registered").requires_restart,
+            "public_url is read at boot; a change cannot take effect in place"
+        );
+        assert!(!lookup("vta_name").expect("registered").requires_restart);
+    }
 }

--- a/vta-service/src/routes/config.rs
+++ b/vta-service/src/routes/config.rs
@@ -1,20 +1,18 @@
 use axum::Json;
 use axum::extract::State;
-use serde::Deserialize;
 
 use vta_sdk::protocols::vta_management::get_config::GetConfigResultBody;
+use vta_sdk::protocols::vta_management::update_config::{UpdateConfigBody, UpdateConfigResultBody};
 
 use crate::auth::{AuthClaims, SuperAdminAuth};
 use crate::error::AppError;
 use crate::operations;
 use crate::server::AppState;
 
-#[derive(Debug, Deserialize, utoipa::ToSchema)]
-pub struct UpdateConfigRequest {
-    pub vta_did: Option<String>,
-    pub vta_name: Option<String>,
-    pub public_url: Option<String>,
-}
+/// REST body for `PATCH /config`, identical to the canonical
+/// `config/patch/0.1` payload — the same interface the DIDComm and TSP
+/// transports carry, rather than a REST-shaped variant of it.
+pub type UpdateConfigRequest = UpdateConfigBody;
 
 /// GET /config — retrieve the current VTA configuration. Auth: any authenticated user.
 #[utoipa::path(
@@ -29,17 +27,21 @@ pub async fn get_config(
     auth: AuthClaims,
     State(state): State<AppState>,
 ) -> Result<Json<GetConfigResultBody>, AppError> {
-    let result = operations::config::get_config(&state.config, &auth, "rest").await?;
+    let result = operations::config::get_config(&state.config, &auth, None, "rest").await?;
     Ok(Json(result))
 }
 
-/// PATCH /config — update VTA name, DID, or public URL. Auth: Super Admin only.
+/// PATCH /config — patch registered configuration keys. Auth: Super Admin only.
+///
+/// `vta_did` is readable but **not** patchable: it is a registry key marked
+/// immutable, so naming it comes back under `rejected` rather than being
+/// written. See `operations::config` for why.
 #[utoipa::path(
     patch, path = "/config", tag = "config",
     security(("bearer_jwt" = [])),
     request_body = UpdateConfigRequest,
     responses(
-        (status = 200, description = "Updated VTA configuration", body = GetConfigResultBody),
+        (status = 200, description = "Applied / pending-restart / rejected keys", body = UpdateConfigResultBody),
         (status = 401, description = "Missing or invalid bearer token"),
         (status = 403, description = "Caller is not a super-admin"),
     ),
@@ -48,17 +50,8 @@ pub async fn update_config(
     auth: SuperAdminAuth,
     State(state): State<AppState>,
     Json(req): Json<UpdateConfigRequest>,
-) -> Result<Json<GetConfigResultBody>, AppError> {
-    let result = operations::config::update_config(
-        &state.config,
-        &auth.0,
-        operations::config::UpdateConfigParams {
-            vta_did: req.vta_did,
-            vta_name: req.vta_name,
-            public_url: req.public_url,
-        },
-        "rest",
-    )
-    .await?;
+) -> Result<Json<UpdateConfigResultBody>, AppError> {
+    let result =
+        operations::config::update_config(&state.config, &auth.0, req.overrides, "rest").await?;
     Ok(Json(result))
 }

--- a/vta-service/src/trust_tasks/config.rs
+++ b/vta-service/src/trust_tasks/config.rs
@@ -15,23 +15,24 @@ use crate::server::AppState;
 
 use super::helpers::{TRANSPORT_TRUST_TASK, app_error_to_reject, parse_payload, success_response};
 
-/// Handler for `spec/vta/config/get/1.0`.
+/// Handler for canonical `config/show/0.1`.
 pub(super) async fn handle_get(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
 ) -> TrustTaskOutcome {
-    let _req: GetConfigBody = match parse_payload(&doc) {
+    let req: GetConfigBody = match parse_payload(&doc) {
         Ok(r) => r,
         Err(resp) => return resp,
     };
-    match operations::config::get_config(&state.config, auth, TRANSPORT_TRUST_TASK).await {
+    match operations::config::get_config(&state.config, auth, req.keys, TRANSPORT_TRUST_TASK).await
+    {
         Ok(body) => success_response(&doc, body),
         Err(e) => app_error_to_reject(&doc, e),
     }
 }
 
-/// Handler for `spec/vta/config/update/1.0`. Super-admin only.
+/// Handler for canonical `config/patch/0.1`. Super-admin only.
 pub(super) async fn handle_update(
     state: &AppState,
     auth: &AuthClaims,
@@ -44,11 +45,7 @@ pub(super) async fn handle_update(
     match operations::config::update_config(
         &state.config,
         auth,
-        operations::config::UpdateConfigParams {
-            vta_did: req.vta_did,
-            vta_name: req.vta_name,
-            public_url: req.public_url,
-        },
+        req.overrides,
         TRANSPORT_TRUST_TASK,
     )
     .await

--- a/vta-service/src/trust_tasks/provision_integration.rs
+++ b/vta-service/src/trust_tasks/provision_integration.rs
@@ -35,7 +35,7 @@ use crate::server::AppState;
 
 use super::helpers::{app_error_to_reject, parse_payload, reject_with, success_response};
 
-/// Handler for `spec/vta/provision-integration/request/1.0`. Admin
+/// Handler for canonical `provision/integration/0.2`. Admin
 /// role on the target context required; super-admin required if the
 /// request asks to create the context inline.
 pub(super) async fn handle_request(

--- a/vta-service/tests/api_integration.rs
+++ b/vta-service/tests/api_integration.rs
@@ -460,7 +460,14 @@ async fn admin_can_read_config() {
     let token = ctx.auth_token("did:key:z6MkAdmin", "admin", vec![]).await;
     let (status, body) = app.request(get_auth("/config", &token)).await;
     assert_eq!(status, StatusCode::OK);
-    assert_eq!(body["vta_did"], "did:key:z6MkTestVTA");
+    let did = body["fields"]
+        .as_array()
+        .expect("registry")
+        .iter()
+        .find(|f| f["key"] == "vta_did")
+        .expect("vta_did is registered and readable");
+    assert_eq!(did["value"], "did:key:z6MkTestVTA");
+    assert_eq!(did["source"], "setup");
 }
 
 #[tokio::test]
@@ -471,11 +478,61 @@ async fn super_admin_can_update_config() {
         .request(patch_auth(
             "/config",
             &token,
-            json!({"vta_name": "Updated Name"}),
+            json!({"overrides": {"vta_name": "Updated Name"}}),
         ))
         .await;
     assert!(status.is_success(), "update config: {status} {body}");
-    assert_eq!(body["vta_name"], "Updated Name");
+    assert_eq!(body["applied"], json!(["vta_name"]));
+    assert_eq!(body["rejected"], json!([]));
+}
+
+/// Identity is readable but not writable, end to end through the real router.
+///
+/// Before the fold onto canonical `config/patch`, this call rewrote `vta_did`
+/// in `config.toml` and survived a restart — orphaning every credential the
+/// VTA had issued and every ACL grant naming it. Super-admin gated, so a
+/// bricking footgun rather than an escalation, but there was no guard at all.
+#[tokio::test]
+async fn super_admin_cannot_rewrite_the_vta_identity() {
+    let (app, ctx) = TestApp::new().await;
+    let token = ctx.auth_token("did:key:z6MkAdmin", "admin", vec![]).await;
+
+    let (status, body) = app
+        .request(patch_auth(
+            "/config",
+            &token,
+            json!({"overrides": {"vta_did": "did:key:z6MkAttacker"}}),
+        ))
+        .await;
+
+    // Not an error — a reported rejection, so the operator learns the rule.
+    assert!(status.is_success(), "{status} {body}");
+    assert_eq!(
+        body["applied"],
+        json!([]),
+        "identity must never apply: {body}"
+    );
+    let rejected = body["rejected"].as_array().expect("rejected array");
+    assert_eq!(rejected.len(), 1, "{body}");
+    assert_eq!(rejected[0]["key"], "vta_did");
+    assert!(
+        !rejected[0]["reason"]
+            .as_str()
+            .unwrap_or_default()
+            .is_empty(),
+        "the rejection must say why: {body}"
+    );
+
+    // And the live identity is untouched.
+    let (status, body) = app.request(get_auth("/config", &token)).await;
+    assert_eq!(status, StatusCode::OK);
+    let did = body["fields"]
+        .as_array()
+        .expect("registry")
+        .iter()
+        .find(|f| f["key"] == "vta_did")
+        .expect("vta_did registered");
+    assert_eq!(did["value"], "did:key:z6MkTestVTA", "{body}");
 }
 
 #[tokio::test]
@@ -486,7 +543,11 @@ async fn scoped_admin_cannot_update_config() {
         .auth_token("did:key:z6MkScoped", "admin", vec!["ctx1".into()])
         .await;
     let (status, _) = app
-        .request(patch_auth("/config", &token, json!({"vta_name": "nope"})))
+        .request(patch_auth(
+            "/config",
+            &token,
+            json!({"overrides": {"vta_name": "nope"}}),
+        ))
         .await;
     assert_eq!(status, StatusCode::FORBIDDEN);
 }

--- a/vta-support/Cargo.toml
+++ b/vta-support/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-support"
 description = "Shared mid-layer VTA services — trust-context storage, the sealed-transfer seal helper, and the sealed-bootstrap nonce store"
 readme = "README.md"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -13,7 +13,14 @@ repository.workspace = true
 [dependencies]
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.1" }
 vta-config = { path = "../vta-config", version = "0.2" }
-vti-common = { path = "../vti-common", version = "0.11" }
+# `encryption` is REQUIRED, not optional: `seal.rs` calls
+# `KeyspaceHandle::with_encryption`, which is `#[cfg(feature = "encryption")]`.
+# Omitting it still built here — another workspace member enables the feature
+# and unification turns it on for the shared build — but `cargo publish`
+# verifies each crate in isolation, where nothing enables it, so the method
+# does not exist and the tarball fails to compile. That is what broke the
+# publish run for 0.2.0.
+vti-common = { path = "../vti-common", version = "0.11", features = ["encryption"] }
 vta-sdk = { path = "../vta-sdk", version = "0.20", features = ["sealed-transfer"] }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.11.38"
+version = "0.11.39"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vtc-service/tests/trust_task_manifest.rs
+++ b/vtc-service/tests/trust_task_manifest.rs
@@ -437,8 +437,10 @@ const UNPUBLISHED_CANONICAL_OK: &[(&str, usize, &str)] = &[
     // 77.
     (
         "https://trusttasks.org/spec/vta/",
-        55,
-        "VTA Trust Task surface at 1.0 — predates the registry and was never reconciled with it",
+        52,
+        "VTA Trust Task surface at 1.0 — predates the registry and was never reconciled with it. \
+         Down from 55: #840 phase A folded config/{get,update} onto canonical config/{show,patch} \
+         and provision-integration/request onto provision/integration/0.2",
     ),
 ];
 


### PR DESCRIPTION
First execution step of #840 phase A. Three of the 67 unpublished canonical URIs are gone — folded onto tasks the registry **already publishes**, with **no new specs authored**:

| Was | Now |
|---|---|
| `vta/config/get/1.0` | `config/show/0.1` |
| `vta/config/update/1.0` | `config/patch/0.1` |
| `vta/provision-integration/request/1.0` | `provision/integration/0.2` |

The `spec/vta/` counted exception in `trust_task_manifest.rs` drops **55 → 52**.

`provision-integration` was nearly free: its payload already cited the canonical spec in a doc comment and already dual-accepted the 0.2 camelCase wire form from #517, so the fold was a constant change.

## The VTA could rewrite its own DID at runtime

Found while diffing the payloads, and worth reading on its own.

`config/update` wrote `vta_did` straight into `config.toml` with **no guard at all**, and the write survived a restart. One mistaken call re-pointed the agent's own identity — orphaning every credential it had issued, every ACL grant naming it, and its DID-document linkage.

To be precise about severity: it was super-admin gated (`auth.require_super_admin()`), so this is a **bricking footgun, not a privilege escalation**. Same class as the defect VTC fixed in its P1.1 hardening, where the rationale ports verbatim — a mistaken patch must not strand the daemon auth-dead or re-point the recovery authority.

**The fix rides the fold rather than being bolted on**, because folding onto canonical `config/patch` *required* deciding which keys are patchable. `vta_did` is now a registry key marked immutable: `config/show` returns it, and a patch naming it comes back under `rejected` with a reason.

Two deliberate choices:

- **Immutable rather than absent.** VTC solved its equivalent by leaving `vtc_did` out of the registry entirely. Keeping it *in* and marking it immutable preserves the read path — nothing else exposes the VTA's DID — and answers "identity is set at setup" rather than "unknown key".
- **Enforcement in the registry table, not an `if` in a handler.** One place says what may change and every write path consults it, so a new mutation surface cannot forget the check. `--community-vta-did` is removed from both CLIs: there is no longer a flag to attempt it with.

Pinned by `super_admin_cannot_rewrite_the_vta_identity` end-to-end through the real router, plus four unit tests asserting properties *of the registry table* so a new key cannot quietly become mutable.

## Config is a key registry now, not three named fields

That reshape is what made the fold possible — canonical `config/*` speaks `{key, value, source, requiresRestart}`, and three typed fields could not fold without it. Two things fall out:

- **`public_url` is honestly marked `requiresRestart: true`.** It is read at boot to build the advertised origin, so before this a patch silently diverged the running services from the stored value until someone called `management/reload-services`. Pre-existing; the canonical shape simply has a field for saying so.
- **`config/patch` reports `applied` / `pendingRestart` / `rejected` per key** instead of echoing the whole config, so a caller learns which of its changes actually took effect.

`ConfigResponse` keeps `vta_did()`, `vta_name()` and `public_url()` accessors, so most call sites read as they did before.

## Breaking changes

`GET/PATCH /config` change shape — response is a key registry, patch body is `{overrides: {key: value}}`. `vta_did` is no longer writable through any surface, and `--community-vta-did` is removed from `pnm config update` and `cnm config update`.

## Verification

- `cargo fmt --check` clean
- `cargo clippy --workspace` clean (as CI runs it)
- `cargo test -p vta-sdk -p vta-service -p vta-cli-common -p pnm-cli -p cnm-cli -p vtc-service`: **88 test binaries, exit 0**, zero failures
- The widened census resolves both new canonical URIs against published `trust_tasks_rs` 0.2.42

`vta-sdk` 0.20.9, `vta-service` 0.12.48, `vta-cli-common` 0.10.17, `pnm-cli` 0.11.12, `cnm-cli` 0.11.11, `vtc-service` 0.11.39.

## Next in phase A

`vta/acl/*` ×5 onto canonical `acl/*` (unblocked by trustoverip/dtgwg-trust-tasks-tf#149, which added the approve-vs-act axis), then `audit/list-logs` — which is behavioural, not a rename: canonical uses opaque cursor paging where the VTA uses 1-based offsets.
