### PR TITLE
feat(acl)!: fold the ACL surface onto canonical acl/* (#840 phase A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,62 @@
 
 ## Unreleased
 
+### vta-sdk 0.20.11 / vta-service 0.13.2 / vta-cli-common 0.10.18 / vtc-service 0.11.40 — the ACL surface folds onto canonical `acl/*` (#840 phase A)
+
+All five `vta/acl/*` tasks now bind the canonical family, with **no new specs
+authored** on the VTA side:
+
+| Was | Now |
+|---|---|
+| `vta/acl/create/1.0` | `acl/grant/0.1` |
+| `vta/acl/get/1.0` | `acl/show/0.1` |
+| `vta/acl/list/1.0` | `acl/list/0.1` |
+| `vta/acl/update/1.0` | `acl/update/0.1` |
+| `vta/acl/delete/1.0` | `acl/revoke/0.1` |
+
+The `spec/vta/` counted exception drops **52 → 47**. Two of these needed the
+canonical family extended first — `AclEntry.approve` (trust-tasks-tf#149) and
+`acl/update` plus `acl/list`'s `direction` (trust-tasks-tf#150) — because the
+approve-vs-act axis, a general entry amendment, and the subtree-vs-acting-in
+reading were genuine gaps rather than VTA quirks.
+
+**Breaking wire changes.** One `AclEntry` shape now serves every task:
+
+- `did` → `subject`, `allowedContexts` → `scopes`.
+- `expiresAt` is RFC 3339, not Unix epoch seconds.
+- The five loose step-up and approve members group under `stepUp{approver,
+  require}` and `approve{all, scopes}`.
+- The grant body nests the entry: `{entry: {...}, reason?}`.
+- `acl/list` responses carry `truncated` (and `cursor` when paging exists).
+- `acl/revoke` returns the entry rather than `{did, deleted}` — a boolean
+  cannot tell an auditor *what authority was lost*.
+
+**REST moved too, and that was the point.** `POST /acl` and `GET /acl/{did}`
+initially kept their flat REST-shaped bodies while the trust-task and DIDComm
+surfaces went canonical. That is exactly the split a fold is meant to remove —
+one operation with two payload shapes depending on how you reach it — so REST
+now takes the same body as everything else.
+
+**Scope reduction is refused, not approximated.** Canonical `acl/revoke` can
+withdraw named scopes and leave the entry standing; this maintainer implements
+full removal only. A request carrying `scopes` is rejected with an explicit
+error rather than treated as a full removal: quietly deleting an entire entry
+when the caller asked to withdraw one scope takes away far more authority than
+was requested, which is not a direction to guess in.
+
+**`truncated: false` is stated rather than implied.** This maintainer returns
+every matching entry in one response. Saying so explicitly is the whole point
+of the member — a caller must never infer completeness from page length, which
+is how a truncated revocation sweep reads as a finished one.
+
+**The stored shape is untouched.** `CreateAclResultBody` keeps epoch seconds
+and flat approve members; only the wire moved, so there is no migration. The
+canonical adapters in `operations::acl` are the single conversion boundary —
+REST, DIDComm and the trust-task dispatcher all reach the same operation, and
+three copies of "which member becomes which argument" would be three chances to
+disagree about, say, whether an absent `approve` confers nothing.
+
+
 ### vta-support 0.2.1 — declare the `vti-common` feature it actually uses
 
 `seal.rs` calls `KeyspaceHandle::with_encryption`, which is

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9585,9 +9585,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-rs"
-version = "0.2.42"
+version = "0.2.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e38e5179d94ec6ca22a396027beef33a3c27fde3b9edd03aab34ec4591551b1"
+checksum = "647c5ff5d054287bd42c34eaf8bc5ba8f3c3c063dcdc744acd45c9c6cf9bded3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -10118,7 +10118,7 @@ dependencies = [
 
 [[package]]
 name = "vta-cli-common"
-version = "0.10.17"
+version = "0.10.18"
 dependencies = [
  "aes-gcm",
  "affinidi-crypto",
@@ -10269,7 +10269,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.20.10"
+version = "0.20.11"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10331,7 +10331,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",
@@ -10564,7 +10564,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-service"
-version = "0.11.39"
+version = "0.11.40"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -212,7 +212,7 @@ aws-lc-rs = "1.16"
 # (camelCase wire enums + `/0.2` TYPE_URIs) alongside the retained
 # `v0_1` modules — the VTA dual-accepts both during the migration.
 # Bump in lockstep with affinidi-webvh-service when upstream publishes.
-trust-tasks-rs = { version = "0.2.42", default-features = false, features = ["validate"] }
+trust-tasks-rs = { version = "0.2.43", default-features = false, features = ["validate"] }
 trust-tasks-capability-client = "0.1"
 trust-tasks-https = { version = "0.2", default-features = false, features = ["server", "client", "jwt"] }
 trust-tasks-proof = { version = "0.2", default-features = false, features = ["affinidi"] }

--- a/tests/e2e/tests/client_didcomm.rs
+++ b/tests/e2e/tests/client_didcomm.rs
@@ -106,16 +106,22 @@ fn context_json(id: &str) -> Value {
     })
 }
 
+/// One entry in the canonical `acl/_shared/0.1/acl-entry` wire shape:
+/// `subject`/`scopes`, RFC 3339 timestamps.
 fn acl_entry_json(did: &str) -> Value {
     json!({
-        "did": did,
+        "subject": did,
         "role": "admin",
         "label": "ops",
-        "allowed_contexts": ["primary"],
-        "created_at": 1_700_000_000_u64,
-        "created_by": "did:web:vta",
-        "expires_at": null
+        "scopes": ["primary"],
+        "createdAt": "2023-11-14T22:13:20Z",
+        "createdBy": "did:web:vta",
     })
+}
+
+/// The `{ entry }` envelope canonical single-entry responses carry.
+fn acl_entry_envelope(did: &str) -> Value {
+    json!({ "entry": acl_entry_json(did) })
 }
 
 // ── Discovery / VTA management ──────────────────────────────────────
@@ -454,7 +460,7 @@ async fn list_acl_via_didcomm() {
         if msg_type == acl_management::LIST_ACL {
             ResponderReply::ok(
                 acl_management::LIST_ACL_RESULT,
-                json!({"entries": [acl_entry_json("did:key:zAdmin")]}),
+                json!({"entries": [acl_entry_json("did:key:zAdmin")], "truncated": false}),
             )
         } else {
             ResponderReply::problem_report("e.p.msg.not-found", "no handler")
@@ -474,7 +480,7 @@ async fn create_acl_via_didcomm() {
         if msg_type == acl_management::CREATE_ACL {
             ResponderReply::ok(
                 acl_management::CREATE_ACL_RESULT,
-                acl_entry_json("did:key:zAdmin"),
+                acl_entry_envelope("did:key:zAdmin"),
             )
         } else {
             ResponderReply::problem_report("e.p.msg.not-found", "no handler")
@@ -513,7 +519,7 @@ async fn update_acl_via_didcomm() {
         if msg_type == acl_management::UPDATE_ACL {
             ResponderReply::ok(
                 acl_management::UPDATE_ACL_RESULT,
-                acl_entry_json("did:key:zAdmin"),
+                acl_entry_envelope("did:key:zAdmin"),
             )
         } else {
             ResponderReply::problem_report("e.p.msg.not-found", "no handler")

--- a/vta-cli-common/Cargo.toml
+++ b/vta-cli-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-cli-common"
 description = "Shared CLI command handlers and rendering helpers for VTA CLIs"
 readme = "README.md"
-version = "0.10.17"
+version = "0.10.18"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-cli-common/src/commands/acl.rs
+++ b/vta-cli-common/src/commands/acl.rs
@@ -157,7 +157,8 @@ pub async fn cmd_acl_list(
         for entry in &resp.entries {
             let contexts = format_contexts(&entry.role, &entry.allowed_contexts);
             let role = format_role(&entry.role, &entry.allowed_contexts);
-            let approve = format_approve_scope(entry.approve_all_contexts, &entry.approve_contexts);
+            let approve =
+                format_approve_scope(entry.approve_all_contexts(), entry.approve_contexts());
 
             // Name + full DID. Full display exists so an operator can copy a
             // complete identifier, so the DID is never abbreviated here.
@@ -273,7 +274,9 @@ pub async fn cmd_acl_get(client: &VtaClient, did: &str) -> Result<(), Box<dyn st
         "Contexts:         {}",
         format_contexts(&entry.role, &entry.allowed_contexts)
     );
-    if let Some(scope) = format_approve_scope(entry.approve_all_contexts, &entry.approve_contexts) {
+    if let Some(scope) =
+        format_approve_scope(entry.approve_all_contexts(), entry.approve_contexts())
+    {
         println!("Approve:          {scope}");
     }
     println!("Created At:       {}", entry.created_at);
@@ -326,7 +329,9 @@ pub async fn cmd_acl_create(
         "  Contexts:   {}",
         format_contexts(&entry.role, &entry.allowed_contexts)
     );
-    if let Some(scope) = format_approve_scope(entry.approve_all_contexts, &entry.approve_contexts) {
+    if let Some(scope) =
+        format_approve_scope(entry.approve_all_contexts(), entry.approve_contexts())
+    {
         println!("  Approve:    {scope}");
     }
     if let Some(approver) = &step_up_approver {

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.20.10"
+version = "0.20.11"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/client/acl.rs
+++ b/vta-sdk/src/client/acl.rs
@@ -1,5 +1,6 @@
 //! ACL methods on [`VtaClient`].
 
+use super::types::AclEntryEnvelope;
 use super::{
     AclEntryResponse, AclListResponse, CreateAclRequest, SwapAclRequest, UpdateAclRequest,
     VtaClient, encode_path_segment,
@@ -72,25 +73,32 @@ impl VtaClient {
     }
 
     pub async fn get_acl(&self, did: &str) -> Result<AclEntryResponse, VtaError> {
-        self.rpc(
-            acl_management::GET_ACL,
-            serde_json::json!({ "did": did }),
-            acl_management::GET_ACL_RESULT,
-            30,
-            |c, url| c.get(format!("{url}/acl/{}", encode_path_segment(did))),
-        )
-        .await
+        // Canonical `acl/show/0.1` wraps the entry (alongside `redactedFields`);
+        // unwrap so callers keep working with the entry itself.
+        let wrapped: AclEntryEnvelope = self
+            .rpc(
+                acl_management::GET_ACL,
+                serde_json::json!({ "subject": did }),
+                acl_management::GET_ACL_RESULT,
+                30,
+                |c, url| c.get(format!("{url}/acl/{}", encode_path_segment(did))),
+            )
+            .await?;
+        Ok(wrapped.entry)
     }
 
     pub async fn create_acl(&self, req: CreateAclRequest) -> Result<AclEntryResponse, VtaError> {
-        self.rpc(
-            acl_management::CREATE_ACL,
-            serde_json::to_value(&req)?,
-            acl_management::CREATE_ACL_RESULT,
-            30,
-            |c, url| c.post(format!("{url}/acl")).json(&req),
-        )
-        .await
+        // Canonical `acl/grant/0.1` returns the realized entry under `entry`.
+        let wrapped: AclEntryEnvelope = self
+            .rpc(
+                acl_management::CREATE_ACL,
+                serde_json::to_value(&req)?,
+                acl_management::CREATE_ACL_RESULT,
+                30,
+                |c, url| c.post(format!("{url}/acl")).json(&req),
+            )
+            .await?;
+        Ok(wrapped.entry)
     }
 
     pub async fn update_acl(
@@ -98,28 +106,32 @@ impl VtaClient {
         did: &str,
         req: UpdateAclRequest,
     ) -> Result<AclEntryResponse, VtaError> {
-        self.rpc(
-            acl_management::UPDATE_ACL,
-            serde_json::json!({
-                "did": did,
-                "role": &req.role,
-                "label": &req.label,
-                "allowed_contexts": &req.allowed_contexts,
-            }),
-            acl_management::UPDATE_ACL_RESULT,
-            30,
-            |c, url| {
-                c.patch(format!("{url}/acl/{}", encode_path_segment(did)))
-                    .json(&req)
-            },
-        )
-        .await
+        // Canonical `acl/update/0.1` returns the realized entry under `entry`,
+        // like grant and show.
+        let wrapped: AclEntryEnvelope = self
+            .rpc(
+                acl_management::UPDATE_ACL,
+                serde_json::json!({
+                    "subject": did,
+                    "role": &req.role,
+                    "label": &req.label,
+                    "allowed_contexts": &req.allowed_contexts,
+                }),
+                acl_management::UPDATE_ACL_RESULT,
+                30,
+                |c, url| {
+                    c.patch(format!("{url}/acl/{}", encode_path_segment(did)))
+                        .json(&req)
+                },
+            )
+            .await?;
+        Ok(wrapped.entry)
     }
 
     pub async fn delete_acl(&self, did: &str) -> Result<(), VtaError> {
         self.rpc_void(
             acl_management::DELETE_ACL,
-            serde_json::json!({ "did": did }),
+            serde_json::json!({ "subject": did }),
             acl_management::DELETE_ACL_RESULT,
             30,
             |c, url| c.delete(format!("{url}/acl/{}", encode_path_segment(did))),

--- a/vta-sdk/src/client/mod.rs
+++ b/vta-sdk/src/client/mod.rs
@@ -1951,12 +1951,25 @@ mod tests {
             approve_contexts: vec![],
         };
         let json = serde_json::to_value(&req).unwrap();
-        assert_eq!(json["did"], "did:key:z6Mk123");
-        assert_eq!(json["role"], "admin");
-        // Omitted approver must not appear on the wire.
-        assert!(json.get("step_up_approver").is_none());
-        assert!(!json.as_object().unwrap().contains_key("label"));
-        assert_eq!(json["allowed_contexts"], serde_json::json!(["vta"]));
+        // The builder API is unchanged; only what it serialises moved. The wire
+        // is canonical `acl/grant/0.1`: the entry is nested and uses `subject`
+        // and `scopes`.
+        assert_eq!(json["entry"]["subject"], "did:key:z6Mk123");
+        assert_eq!(json["entry"]["role"], "admin");
+        assert_eq!(json["entry"]["scopes"][0], "vta");
+        assert!(
+            json.get("did").is_none(),
+            "pre-fold flat shape is gone: {json}"
+        );
+        // An omitted approver must not appear at all — an empty `stepUp` object
+        // would read as a configured-but-blank override rather than absence.
+        assert!(json["entry"].get("stepUp").is_none());
+        assert!(json["entry"].get("approve").is_none());
+        // An unset label is omitted rather than emitted as null.
+        assert!(!json["entry"].as_object().unwrap().contains_key("label"));
+        assert_eq!(json["entry"]["scopes"], serde_json::json!(["vta"]));
+        // And the pre-fold member name is not emitted alongside the new one.
+        assert!(json["entry"].get("allowedContexts").is_none(), "{json}");
     }
 
     #[test]
@@ -2007,12 +2020,16 @@ mod tests {
 
     #[test]
     fn test_acl_list_response_deserialization() {
-        let json = r#"{"entries":[{"did":"did:key:z6Mk1","role":"admin","label":null,"allowed_contexts":[],"created_at":1700000000,"created_by":"setup"}]}"#;
+        // Canonical wire: `subject`/`scopes`, RFC 3339 timestamps. The Rust
+        // field names stay historical so the CLI and the VTC's ACL routes did
+        // not have to move in the same change.
+        let json = r#"{"entries":[{"subject":"did:key:z6Mk1","role":"admin","label":null,"scopes":[],"createdAt":"2023-11-14T22:13:20Z","createdBy":"setup"}],"truncated":false}"#;
         let resp: AclListResponse = serde_json::from_str(json).unwrap();
         assert_eq!(resp.entries.len(), 1);
         assert_eq!(resp.entries[0].did, "did:key:z6Mk1");
         assert_eq!(resp.entries[0].role, "admin");
         assert!(resp.entries[0].allowed_contexts.is_empty());
+        assert_eq!(resp.entries[0].created_at, 1_700_000_000);
     }
 
     #[test]

--- a/vta-sdk/src/client/types.rs
+++ b/vta-sdk/src/client/types.rs
@@ -324,33 +324,135 @@ pub struct RotateSeedResponse {
 
 // ── ACL types ───────────────────────────────────────────────────────
 
+/// One ACL entry as the REST surface returns it.
+///
+/// The **wire** names are canonical (`acl/_shared/0.1/acl-entry`); the Rust
+/// field names are the maintainer's historical ones, kept so the CLI and the
+/// VTC's own ACL routes did not have to move in the same change. The mapping
+/// is `subject`↔`did` and `scopes`↔`allowed_contexts`, and the step-up and
+/// approve members are flattened back out of their canonical nesting.
 #[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct AclEntryResponse {
+    #[serde(rename = "subject")]
     pub did: String,
     pub role: String,
+    #[serde(default)]
     pub label: Option<String>,
+    #[serde(rename = "scopes", default)]
     pub allowed_contexts: Vec<String>,
+    #[serde(
+        default,
+        deserialize_with = "de_epoch_opt",
+        serialize_with = "ser_epoch"
+    )]
     pub created_at: u64,
+    #[serde(default)]
     pub created_by: String,
-    /// Unix-epoch seconds at which this entry expires. `None` = permanent.
-    /// Pre-Phase-2 entries on the wire never carried this field, so
-    /// defaults to `None` for backward compat.
-    #[serde(default)]
+    /// When the entry expires. Canonical sends RFC 3339; this is the epoch
+    /// seconds the rest of the code already speaks.
+    #[serde(
+        default,
+        deserialize_with = "de_epoch_opt_option",
+        serialize_with = "ser_epoch_opt"
+    )]
     pub expires_at: Option<u64>,
-    /// Per-entry step-up override (`"self"` | `"delegated"`) raising the system
-    /// floor for this subject. `None` = no override. `#[serde(default)]` for
-    /// pre-existing entries on the wire.
+    /// Flattened out of the canonical `stepUp` object.
+    #[serde(default, rename = "stepUp")]
+    step_up: Option<StepUpWire>,
+    /// Flattened out of the canonical `approve` object.
     #[serde(default)]
-    pub step_up_require: Option<String>,
-    /// Approve-authority over **any** context — may confer via approval while
-    /// acting nowhere. `#[serde(default)]` so entries from pre-approver servers
-    /// (which never send it) read as `false`.
+    approve: Option<ApproveWire>,
+}
+
+#[derive(Debug, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct StepUpWire {
     #[serde(default)]
-    pub approve_all_contexts: bool,
-    /// Approve-authority scoped to these contexts. Empty = confers nothing
-    /// (unless `approve_all_contexts`). `#[serde(default)]` for older servers.
+    approver: Option<String>,
     #[serde(default)]
-    pub approve_contexts: Vec<String>,
+    require: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ApproveWire {
+    #[serde(default)]
+    all: bool,
+    #[serde(default)]
+    scopes: Vec<String>,
+}
+
+impl AclEntryResponse {
+    /// Per-entry step-up mode override, if any.
+    pub fn step_up_require(&self) -> Option<&str> {
+        self.step_up.as_ref().and_then(|s| s.require.as_deref())
+    }
+
+    /// Delegated step-up approver, if any.
+    pub fn step_up_approver(&self) -> Option<&str> {
+        self.step_up.as_ref().and_then(|s| s.approver.as_deref())
+    }
+
+    /// True when the entry may confer **any** scope via approval.
+    pub fn approve_all_contexts(&self) -> bool {
+        self.approve.as_ref().is_some_and(|a| a.all)
+    }
+
+    /// Scopes the entry may confer. Empty confers nothing.
+    pub fn approve_contexts(&self) -> &[String] {
+        self.approve.as_ref().map_or(&[], |a| a.scopes.as_slice())
+    }
+}
+
+/// Epoch seconds → RFC 3339, so a re-serialised entry stays canonical.
+fn ser_epoch<S: serde::Serializer>(v: &u64, s: S) -> Result<S::Ok, S::Error> {
+    ser_epoch_opt(&Some(*v), s)
+}
+
+/// Epoch seconds → RFC 3339, preserving absence.
+fn ser_epoch_opt<S: serde::Serializer>(v: &Option<u64>, s: S) -> Result<S::Ok, S::Error> {
+    use chrono::{TimeZone, Utc};
+    match v.and_then(|e| {
+        i64::try_from(e)
+            .ok()
+            .and_then(|x| Utc.timestamp_opt(x, 0).single())
+    }) {
+        Some(t) => s.serialize_str(&t.to_rfc3339()),
+        None => s.serialize_none(),
+    }
+}
+
+/// RFC 3339 → epoch seconds, defaulting to 0 when absent.
+fn de_epoch_opt<'de, D>(d: D) -> Result<u64, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Ok(de_epoch_opt_option(d)?.unwrap_or(0))
+}
+
+/// RFC 3339 → epoch seconds. A pre-epoch instant clamps to 0, which for an
+/// expiry reads as "already expired" — the safe direction for a timestamp that
+/// gates authority.
+fn de_epoch_opt_option<'de, D>(d: D) -> Result<Option<u64>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let raw = Option::<String>::deserialize(d)?;
+    Ok(raw.and_then(|s| {
+        chrono::DateTime::parse_from_rfc3339(&s)
+            .ok()
+            .map(|t| u64::try_from(t.timestamp()).unwrap_or(0))
+    }))
+}
+
+/// The `{ entry }` envelope canonical `acl/*` responses carry.
+///
+/// Internal: the client unwraps it so callers keep receiving the entry itself
+/// rather than having to know the envelope exists.
+#[derive(Debug, Deserialize)]
+pub(crate) struct AclEntryEnvelope {
+    pub entry: AclEntryResponse,
 }
 
 #[derive(Debug, Deserialize)]
@@ -358,34 +460,70 @@ pub struct AclListResponse {
     pub entries: Vec<AclEntryResponse>,
 }
 
-#[derive(Debug, Serialize)]
+/// Builder for `acl/grant/0.1`.
+///
+/// The builder API is unchanged by the canonical fold; only what it serialises
+/// moved. Callers keep writing `CreateAclRequest::new(did, role).contexts(..)`
+/// and the wire carries `{entry: {subject, role, scopes, ...}}`.
+#[derive(Debug)]
 #[must_use]
 pub struct CreateAclRequest {
     pub did: String,
     pub role: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub label: Option<String>,
     pub allowed_contexts: Vec<String>,
     /// Unix-epoch seconds at which this entry auto-expires. `None` = permanent.
     /// Useful for setup ACLs where the temp did:key should stop authenticating
     /// if the admin never claims it via `pnm setup` + rotation.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub expires_at: Option<u64>,
-    /// VID authorized to ratify a **delegated** AAL2 step-up for this subject
-    /// (the subject's `stepUp.approver`). Omit for no delegated approver.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    /// VID authorized to ratify a **delegated** AAL2 step-up for this subject.
     pub step_up_approver: Option<String>,
-    /// Per-entry step-up override (`"self"` | `"delegated"`) raising the system
-    /// floor for this subject. Omit for none.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    /// Per-entry step-up override (`"self"` | `"delegated"`).
     pub step_up_require: Option<String>,
     /// Approve-authority over any context (confer via approval, act nowhere).
-    /// Super-admin-only to grant. Takes precedence over `approve_contexts`.
-    #[serde(skip_serializing_if = "std::ops::Not::not")]
     pub approve_all_contexts: bool,
-    /// Approve-authority scoped to these contexts. Empty = confers nothing.
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    /// Approve-authority scoped to these contexts.
     pub approve_contexts: Vec<String>,
+}
+
+impl serde::Serialize for CreateAclRequest {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        use crate::protocols::acl_management::create::CreateAclBody;
+        use crate::protocols::acl_management::entry::{AclEntry, Approve, StepUp};
+        use chrono::{TimeZone, Utc};
+
+        let step_up = StepUp {
+            approver: self.step_up_approver.clone(),
+            require: self.step_up_require.clone(),
+        };
+        let approve = Approve {
+            all: self.approve_all_contexts,
+            scopes: self.approve_contexts.clone(),
+        };
+        let has_step_up = step_up.approver.is_some() || step_up.require.is_some();
+        let has_approve = approve.all || !approve.scopes.is_empty();
+        let body = CreateAclBody {
+            entry: AclEntry {
+                subject: self.did.clone(),
+                role: self.role.clone(),
+                scopes: self.allowed_contexts.clone(),
+                label: self.label.clone(),
+                created_at: None,
+                created_by: None,
+                updated_at: None,
+                updated_by: None,
+                expires_at: self.expires_at.and_then(|e| {
+                    i64::try_from(e)
+                        .ok()
+                        .and_then(|s| Utc.timestamp_opt(s, 0).single())
+                }),
+                step_up: has_step_up.then_some(step_up),
+                approve: has_approve.then_some(approve),
+            },
+            reason: None,
+        };
+        body.serialize(s)
+    }
 }
 
 impl CreateAclRequest {

--- a/vta-sdk/src/protocols/acl_management/create.rs
+++ b/vta-sdk/src/protocols/acl_management/create.rs
@@ -1,71 +1,46 @@
+//! `acl/grant/0.1` — add a subject to the ACL.
+
 use serde::{Deserialize, Serialize};
 
-/// Payload for the `spec/vta/acl/create/1.0` Trust Task.
+use super::entry::AclEntry;
+
+/// `acl/grant/0.1` request.
 ///
-/// **Wire casing is camelCase** (the published Trust-Task spec convention,
-/// matching the sibling `acl/swap-key` body). Snake_case is still accepted on
-/// input via per-field aliases so existing/legacy senders keep working, and
-/// `deny_unknown_fields` makes a misspelled or unrecognized field a *loud*
-/// rejection rather than a silent drop.
+/// The entry is **nested** rather than flattened because canonical `acl/*`
+/// carries one `AclEntry` shape across every task — grant, show, list, revoke
+/// — so a consumer comparing entries between them cannot end up looking at two
+/// different spellings of the same thing.
 ///
-/// This matters for authorization safety: a silently-dropped `allowedContexts`
-/// defaults to an empty vec, and an empty `allowed_contexts` on an `Admin`
-/// entry is a **super-admin** (`AclEntry::is_super_admin`). Before camelCase
-/// was accepted, a spec-conventional caller intending a scoped, expiring grant
-/// could have both `allowedContexts` and `expiresAt` dropped and end up
-/// minting a permanent, unrestricted admin.
+/// Note what grant deliberately cannot do. **Changing an existing subject's
+/// role** belongs to `acl/change-role`, which takes the current role as a
+/// compare-and-swap; **narrowing scopes** belongs to `acl/revoke`. Both are
+/// refused here rather than silently applied, so that a reduction in authority
+/// always passes through the task that is named and audited as one.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct CreateAclBody {
-    pub did: String,
-    pub role: String,
+    /// The entry the caller wants the maintainer to hold.
+    pub entry: AclEntry,
+    /// Optional human-readable rationale, recorded with the grant.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub label: Option<String>,
-    #[serde(default, alias = "allowed_contexts")]
-    pub allowed_contexts: Vec<String>,
-    /// Unix-epoch seconds at which the entry auto-expires. `None` = permanent.
-    #[serde(default, skip_serializing_if = "Option::is_none", alias = "expires_at")]
-    pub expires_at: Option<u64>,
-    /// VID authorized to ratify a delegated AAL2 step-up for this subject —
-    /// the `recipient` an `auth/step-up/approve-request/0.1` is addressed to
-    /// (the holder's mobile/browser approver). Stored on the ACL entry as
-    /// `step_up_approver`. `None` = no delegated approver configured.
-    #[serde(
-        default,
-        skip_serializing_if = "Option::is_none",
-        alias = "step_up_approver"
-    )]
-    pub step_up_approver: Option<String>,
-    /// Per-entry step-up override (`"self"` | `"delegated"`) raising the system
-    /// floor for this subject. Stored as `step_up_require`. `None` = no override.
-    #[serde(
-        default,
-        skip_serializing_if = "Option::is_none",
-        alias = "step_up_require"
-    )]
-    pub step_up_require: Option<String>,
-    /// Approve-authority: this DID may **confer** access via an approval
-    /// (task-consent delegation / step-up ratification) over any context,
-    /// **without** any authority to act. Granting this is super-admin-only.
-    /// Takes precedence over `approve_contexts`. Stored as `approve_scope`.
-    #[serde(
-        default,
-        skip_serializing_if = "std::ops::Not::not",
-        alias = "approve_all_contexts"
-    )]
-    pub approve_all_contexts: bool,
-    /// Approve-authority scoped to these contexts (and their subtrees): the DID
-    /// may confer them via approval but cannot act in them. Ignored when
-    /// `approve_all_contexts` is set. Empty = confers nothing (the default).
-    #[serde(
-        default,
-        skip_serializing_if = "Vec::is_empty",
-        alias = "approve_contexts"
-    )]
-    pub approve_contexts: Vec<String>,
+    pub reason: Option<String>,
 }
 
+/// `acl/grant/0.1` response — the realized entry the maintainer now holds.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct CreateAclResponseBody {
+    pub entry: AclEntry,
+}
+
+/// The maintainer's internal view of a stored entry.
+///
+/// **Not a wire type any more.** It is what `operations::acl` returns, and the
+/// handlers convert it to an [`AclEntry`] on the way out
+/// ([`AclEntry::from_result`]). Kept in its stored form — epoch seconds, flat
+/// approve members — so the storage layer is unaffected by the canonical fold.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct CreateAclResultBody {
@@ -101,107 +76,50 @@ pub struct CreateAclResultBody {
 mod tests {
     use super::*;
 
-    /// The regression: a spec-conventional **camelCase** `acl/create` payload
-    /// must populate `allowed_contexts`/`expires_at`, not silently drop them.
-    /// A dropped `allowedContexts` on an Admin role is a permanent super-admin.
+    /// The regression the pre-fold body existed to prevent, restated against
+    /// the canonical shape: a scoped, expiring grant must not lose its scope.
+    ///
+    /// A dropped `scopes` on an admin entry is a **permanent super-admin**,
+    /// because an empty scope list means "unrestricted" for that role. Nesting
+    /// changes where the member lives, not how badly losing it fails.
     #[test]
-    fn camelcase_payload_populates_scope_and_expiry() {
+    fn scoped_expiring_grant_keeps_its_scope_and_expiry() {
         let json = serde_json::json!({
-            "did": "did:key:z6MkSubject",
-            "role": "admin",
-            "allowedContexts": ["ctx-a", "ctx-b"],
-            "expiresAt": 1_800_000_000u64,
-            "stepUpApprover": "did:key:z6MkApprover",
-            "stepUpRequire": "delegated",
+            "entry": {
+                "subject": "did:key:z6MkSubject",
+                "role": "admin",
+                "scopes": ["ctx-a", "ctx-b"],
+                "expiresAt": "2027-01-15T08:00:00Z",
+                "stepUp": { "approver": "did:key:z6MkApprover", "require": "delegated" }
+            }
         });
         let body: CreateAclBody = serde_json::from_value(json).unwrap();
-        assert_eq!(body.allowed_contexts, vec!["ctx-a", "ctx-b"]);
-        assert_eq!(body.expires_at, Some(1_800_000_000));
+        assert_eq!(body.entry.scopes, vec!["ctx-a", "ctx-b"]);
+        assert!(body.entry.expires_at.is_some());
         assert_eq!(
-            body.step_up_approver.as_deref(),
+            body.entry.step_up_approver().as_deref(),
             Some("did:key:z6MkApprover")
         );
-        assert_eq!(body.step_up_require.as_deref(), Some("delegated"));
+        assert_eq!(body.entry.step_up_require().as_deref(), Some("delegated"));
     }
 
-    /// Back-compat: legacy/REST snake_case senders still deserialize via aliases.
+    /// A misspelled member is a loud rejection, never a silent drop that would
+    /// default the entry to unrestricted scope.
     #[test]
-    fn snakecase_payload_still_accepted_via_alias() {
+    fn unknown_member_is_rejected() {
         let json = serde_json::json!({
-            "did": "did:key:z6MkSubject",
-            "role": "admin",
-            "allowed_contexts": ["ctx-a"],
-            "expires_at": 1_800_000_000u64,
-            "step_up_approver": "did:key:z6MkApprover",
-        });
-        let body: CreateAclBody = serde_json::from_value(json).unwrap();
-        assert_eq!(body.allowed_contexts, vec!["ctx-a"]);
-        assert_eq!(body.expires_at, Some(1_800_000_000));
-        assert_eq!(
-            body.step_up_approver.as_deref(),
-            Some("did:key:z6MkApprover")
-        );
-    }
-
-    /// A misspelled/unknown scope field is a loud rejection, never a silent
-    /// drop that would default the entry to unrestricted super-admin scope.
-    #[test]
-    fn unknown_field_is_rejected() {
-        let json = serde_json::json!({
-            "did": "did:key:z6MkSubject",
-            "role": "admin",
-            "allowedContext": ["ctx-a"], // note: singular typo
+            "entry": { "subject": "did:key:zA", "role": "admin", "scope": ["ctx-a"] }
         });
         assert!(serde_json::from_value::<CreateAclBody>(json).is_err());
     }
 
-    /// Serialization emits the canonical camelCase wire form.
+    /// The pre-fold flat body must not deserialize — it would arrive with no
+    /// scopes at all, which for an admin role is a super-admin.
     #[test]
-    fn serializes_as_camelcase() {
-        let body = CreateAclBody {
-            did: "did:key:z6MkSubject".into(),
-            role: "admin".into(),
-            label: None,
-            allowed_contexts: vec!["ctx-a".into()],
-            expires_at: Some(1_800_000_000),
-            step_up_approver: None,
-            step_up_require: None,
-            approve_all_contexts: false,
-            approve_contexts: vec![],
-        };
-        let v = serde_json::to_value(&body).unwrap();
-        assert!(v.get("allowedContexts").is_some());
-        assert!(v.get("expiresAt").is_some());
-        assert!(v.get("allowed_contexts").is_none());
-    }
-
-    /// Approve-authority fields round-trip via camelCase, and snake_case aliases
-    /// are still accepted; the boolean/list default to off so an omitted scope
-    /// confers nothing.
-    #[test]
-    fn approve_scope_fields_round_trip_and_default_off() {
+    fn pre_fold_flat_body_is_rejected() {
         let json = serde_json::json!({
-            "did": "did:key:z6MkApprover",
-            "role": "reader",
-            "approveAllContexts": true,
+            "did": "did:key:zA", "role": "admin", "allowedContexts": ["ctx-a"]
         });
-        let body: CreateAclBody = serde_json::from_value(json).unwrap();
-        assert!(body.approve_all_contexts);
-        assert!(body.approve_contexts.is_empty());
-
-        let json = serde_json::json!({
-            "did": "did:key:z6MkApprover",
-            "role": "reader",
-            "approve_contexts": ["openvtc"],
-        });
-        let body: CreateAclBody = serde_json::from_value(json).unwrap();
-        assert!(!body.approve_all_contexts);
-        assert_eq!(body.approve_contexts, vec!["openvtc"]);
-
-        // Absent ⇒ confers nothing.
-        let json = serde_json::json!({ "did": "did:key:zX", "role": "reader" });
-        let body: CreateAclBody = serde_json::from_value(json).unwrap();
-        assert!(!body.approve_all_contexts);
-        assert!(body.approve_contexts.is_empty());
+        assert!(serde_json::from_value::<CreateAclBody>(json).is_err());
     }
 }

--- a/vta-sdk/src/protocols/acl_management/delete.rs
+++ b/vta-sdk/src/protocols/acl_management/delete.rs
@@ -1,14 +1,42 @@
+//! `acl/revoke/0.1` — remove a subject, or withdraw some of its scopes.
+
 use serde::{Deserialize, Serialize};
 
+use super::entry::AclEntry;
+
+/// `acl/revoke/0.1` request.
+///
+/// Canonical revoke has two modes: **full removal** (omit `scopes`) and
+/// **scope reduction** (list the scopes to withdraw; the entry survives with
+/// the rest).
+///
+/// This maintainer implements full removal only. A request carrying `scopes`
+/// is **refused**, not silently treated as a full removal — quietly removing
+/// an entire entry when the caller asked to withdraw one scope would take away
+/// far more authority than was requested, which is the wrong direction for an
+/// operation to guess in.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct DeleteAclBody {
-    pub did: String,
+    /// VID of the subject being revoked. Was `did` before the canonical fold.
+    pub subject: String,
+    /// Scopes to withdraw instead of removing the entry. Unsupported here.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scopes: Option<Vec<String>>,
+    /// Optional human-readable rationale, recorded with the revocation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
 }
 
+/// `acl/revoke/0.1` response — the entry as it stood when revoked.
+///
+/// Returning it rather than a bare `{ deleted: true }` means the audit record
+/// and the caller both retain what was actually withdrawn, which a boolean
+/// cannot express.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct DeleteAclResultBody {
-    pub did: String,
-    pub deleted: bool,
+    pub entry: AclEntry,
 }

--- a/vta-sdk/src/protocols/acl_management/entry.rs
+++ b/vta-sdk/src/protocols/acl_management/entry.rs
@@ -1,0 +1,289 @@
+//! The canonical `AclEntry` — `acl/_shared/0.1/acl-entry`.
+//!
+//! Every `acl/*` task carries this one shape, which is what let the VTA's
+//! private `vta/acl/*` family fold onto the canonical one (#840 phase A).
+//!
+//! Three things differ from the pre-fold VTA wire form, and each is the
+//! canonical spelling rather than a rename for its own sake:
+//!
+//! - `did` → `subject`, `allowedContexts` → `scopes`. The canonical vocabulary
+//!   is deliberately generic: a scope is an opaque identifier, which is what
+//!   lets one ACL family serve a VTA's contexts, a hosting service's domains,
+//!   and anything else with a containment relation.
+//! - `expiresAt` is **RFC 3339**, not Unix epoch seconds. A timestamp that a
+//!   human can read in a signed document is worth the conversion; the internal
+//!   store keeps epoch seconds.
+//! - `stepUpApprover` / `stepUpRequire` and the approve-authority pair are
+//!   nested under [`StepUp`] and [`Approve`], grouping each per-entry
+//!   sub-concern instead of flattening five loosely-related members.
+
+use chrono::{DateTime, TimeZone, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::acl::ApproveScope;
+
+use super::create::CreateAclResultBody;
+
+/// Per-entry step-up configuration — canonical `AclEntry.stepUp`.
+///
+/// **Additive only.** A per-entry setting may raise the assurance required of
+/// this subject above the maintainer's system-wide floor; it must never lower
+/// it. The effective requirement is the strictest of (floor, entry).
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct StepUp {
+    /// VID that ratifies step-up for this subject. Absent → the subject is its
+    /// own approver, when it holds a usable authenticator.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub approver: Option<String>,
+    /// Minimum step-up mode: `self` or `delegated`. Absent → the system floor
+    /// applies unchanged.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub require: Option<String>,
+}
+
+impl StepUp {
+    fn is_empty(&self) -> bool {
+        self.approver.is_none() && self.require.is_none()
+    }
+}
+
+/// Approve-authority — canonical `AclEntry.approve`.
+///
+/// What the subject may **confer on others** by ratifying an approval, as
+/// distinct from `scopes`, which is what it may **exercise itself**. The two
+/// are independent, which is what expresses a least-privilege approver: a party
+/// that can authorize an operation in a scope it has no authority to perform.
+///
+/// Omission confers nothing — absent, `all: false` and an empty `scopes` all
+/// mean "may ratify nothing", so a consumer that ignores this member grants
+/// *less* than intended.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct Approve {
+    /// May confer any scope. Takes precedence over `scopes`.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub all: bool,
+    /// Scopes the subject may confer. Empty confers nothing; not a wildcard.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub scopes: Vec<String>,
+}
+
+impl Approve {
+    fn is_empty(&self) -> bool {
+        !self.all && self.scopes.is_empty()
+    }
+
+    /// The internal [`ApproveScope`] this wire form denotes.
+    pub fn to_scope(&self) -> ApproveScope {
+        if self.all {
+            ApproveScope::All
+        } else if self.scopes.is_empty() {
+            ApproveScope::None
+        } else {
+            ApproveScope::Contexts(self.scopes.clone())
+        }
+    }
+
+    /// The wire form of an internal [`ApproveScope`].
+    pub fn from_scope(scope: &ApproveScope) -> Self {
+        match scope {
+            ApproveScope::None => Self::default(),
+            ApproveScope::All => Self {
+                all: true,
+                scopes: Vec::new(),
+            },
+            ApproveScope::Contexts(cs) => Self {
+                all: false,
+                scopes: cs.clone(),
+            },
+        }
+    }
+}
+
+/// One access-control entry — canonical `acl/_shared/0.1/acl-entry#AclEntry`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct AclEntry {
+    /// VID of the party in the ACL.
+    pub subject: String,
+    /// Role identifier, interpreted by the maintainer.
+    pub role: String,
+    /// Opaque scope identifiers. For a VTA these are trust contexts.
+    ///
+    /// **Never read emptiness as "unrestricted".** An empty list means
+    /// unrestricted only for an admin role and *authorized nowhere* for every
+    /// other, so a check that ignores the role gets one of the two backwards.
+    /// Resolve through the role, as `AclEntry::act_scope` does.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub scopes: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<DateTime<Utc>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub created_by: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<DateTime<Utc>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub updated_by: Option<String>,
+    /// When the entry stops being effective. RFC 3339 on the wire.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<DateTime<Utc>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub step_up: Option<StepUp>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub approve: Option<Approve>,
+}
+
+/// Unix epoch seconds → RFC 3339, for the wire.
+fn to_rfc3339(epoch: u64) -> Option<DateTime<Utc>> {
+    i64::try_from(epoch)
+        .ok()
+        .and_then(|s| Utc.timestamp_opt(s, 0).single())
+}
+
+/// RFC 3339 → Unix epoch seconds, for the store. Pre-epoch instants clamp to
+/// 0 rather than wrapping, which for an `expiresAt` reads as "already expired"
+/// — the safe direction for a timestamp that gates authority.
+pub fn to_epoch(ts: DateTime<Utc>) -> u64 {
+    u64::try_from(ts.timestamp()).unwrap_or(0)
+}
+
+impl AclEntry {
+    /// Build the wire form from the internal result body.
+    pub fn from_result(r: &CreateAclResultBody) -> Self {
+        let step_up = StepUp {
+            approver: r.step_up_approver.clone(),
+            require: r.step_up_require.clone(),
+        };
+        let approve = Approve {
+            all: r.approve_all_contexts,
+            scopes: r.approve_contexts.clone(),
+        };
+        Self {
+            subject: r.did.clone(),
+            role: r.role.clone(),
+            scopes: r.allowed_contexts.clone(),
+            label: r.label.clone(),
+            created_at: to_rfc3339(r.created_at),
+            created_by: Some(r.created_by.clone()),
+            updated_at: None,
+            updated_by: None,
+            expires_at: r.expires_at.and_then(to_rfc3339),
+            step_up: (!step_up.is_empty()).then_some(step_up),
+            approve: (!approve.is_empty()).then_some(approve),
+        }
+    }
+
+    /// The step-up approver this entry names, if any.
+    pub fn step_up_approver(&self) -> Option<String> {
+        self.step_up.as_ref().and_then(|s| s.approver.clone())
+    }
+
+    /// The per-entry step-up mode override, if any.
+    pub fn step_up_require(&self) -> Option<String> {
+        self.step_up.as_ref().and_then(|s| s.require.clone())
+    }
+
+    /// The approve-authority this entry carries. Absent → confers nothing.
+    pub fn approve_scope(&self) -> ApproveScope {
+        self.approve
+            .as_ref()
+            .map(Approve::to_scope)
+            .unwrap_or_default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_approve_and_step_up_are_omitted_not_emitted() {
+        let e = AclEntry {
+            subject: "did:key:z6MkA".into(),
+            role: "reader".into(),
+            scopes: vec![],
+            label: None,
+            created_at: None,
+            created_by: None,
+            updated_at: None,
+            updated_by: None,
+            expires_at: None,
+            step_up: None,
+            approve: None,
+        };
+        let v = serde_json::to_value(&e).unwrap();
+        assert!(v.get("approve").is_none(), "{v}");
+        assert!(v.get("stepUp").is_none(), "{v}");
+        assert!(v.get("scopes").is_none(), "empty scopes are omitted: {v}");
+    }
+
+    /// Omission and "confers nothing" must agree, so a consumer that drops the
+    /// member grants less rather than more.
+    #[test]
+    fn absent_approve_confers_nothing() {
+        let e: AclEntry =
+            serde_json::from_value(serde_json::json!({"subject": "did:key:zA", "role": "admin"}))
+                .unwrap();
+        assert_eq!(e.approve_scope(), ApproveScope::None);
+    }
+
+    #[test]
+    fn approve_all_takes_precedence_over_scopes() {
+        let a = Approve {
+            all: true,
+            scopes: vec!["ctx-a".into()],
+        };
+        assert_eq!(a.to_scope(), ApproveScope::All);
+    }
+
+    #[test]
+    fn approve_scope_round_trips() {
+        for s in [
+            ApproveScope::None,
+            ApproveScope::All,
+            ApproveScope::Contexts(vec!["a".into(), "b".into()]),
+        ] {
+            assert_eq!(Approve::from_scope(&s).to_scope(), s);
+        }
+    }
+
+    #[test]
+    fn expiry_round_trips_through_rfc3339() {
+        let epoch = 1_800_000_000u64;
+        let ts = to_rfc3339(epoch).expect("representable");
+        assert_eq!(to_epoch(ts), epoch);
+        assert_eq!(ts.to_rfc3339(), "2027-01-15T08:00:00+00:00");
+    }
+
+    /// The wire form is camelCase; the pre-fold snake_case names are gone.
+    #[test]
+    fn wire_form_is_camel_case() {
+        let e = AclEntry {
+            subject: "did:key:zA".into(),
+            role: "admin".into(),
+            scopes: vec!["ctx".into()],
+            label: None,
+            created_at: None,
+            created_by: None,
+            updated_at: None,
+            updated_by: None,
+            expires_at: to_rfc3339(1_800_000_000),
+            step_up: Some(StepUp {
+                approver: Some("did:key:zB".into()),
+                require: Some("delegated".into()),
+            }),
+            approve: None,
+        };
+        let v = serde_json::to_value(&e).unwrap();
+        assert!(v.get("expiresAt").is_some(), "{v}");
+        assert!(v.get("stepUp").is_some(), "{v}");
+        assert!(v.get("allowed_contexts").is_none(), "{v}");
+        assert!(v.get("did").is_none(), "subject, not did: {v}");
+    }
+}

--- a/vta-sdk/src/protocols/acl_management/get.rs
+++ b/vta-sdk/src/protocols/acl_management/get.rs
@@ -1,11 +1,29 @@
+//! `acl/show/0.1` — read one ACL entry.
+
 use serde::{Deserialize, Serialize};
 
-use super::create::CreateAclResultBody;
+use super::entry::AclEntry;
 
+/// `acl/show/0.1` request.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct GetAclBody {
-    pub did: String,
+    /// VID of the entry to read. Was `did` before the canonical fold.
+    pub subject: String,
 }
 
-pub type GetAclResultBody = CreateAclResultBody;
+/// `acl/show/0.1` response.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct GetAclResultBody {
+    pub entry: AclEntry,
+    /// Entry members the maintainer withheld. Empty when nothing was redacted.
+    ///
+    /// Reported rather than silently omitted so a caller can tell "this entry
+    /// has no label" from "you may not see its label" — which are different
+    /// answers, and only one of them means the data is absent.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub redacted_fields: Vec<String>,
+}

--- a/vta-sdk/src/protocols/acl_management/list.rs
+++ b/vta-sdk/src/protocols/acl_management/list.rs
@@ -1,24 +1,54 @@
+//! `acl/list/0.1` — enumerate ACL entries.
+
 use serde::{Deserialize, Serialize};
 
-use super::create::CreateAclResultBody;
+use super::entry::AclEntry;
 use crate::acl::ContextDirection;
 
+/// `acl/list/0.1` request. Every member is an optional filter.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ListAclBody {
+    /// Only entries with this role.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub context: Option<String>,
-    /// Which way [`context`](Self::context) reads along the hierarchy —
-    /// `acting-in` (default, entries that may act *in* it), `subtree` (entries
-    /// granted at or *beneath* it), or `any`. Absent = `acting-in`, i.e. the
-    /// pre-#822 behaviour exactly. Meaningless without `context`, and refused
-    /// rather than ignored in that case.
+    pub role: Option<String>,
+    /// Only entries whose scopes relate to this one, per `direction`. Was
+    /// `context` before the canonical fold.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scope: Option<String>,
+    /// How to read `scope`. Omitted means `acting-in`.
+    ///
+    /// The axis exists because a scope identifier names a subtree, so it asks
+    /// two questions: who may act *in* it, and what is granted *beneath* it.
+    /// A revocation sweep wants `subtree`; asking `acting-in` returns the
+    /// ancestors that keep their authority and omits every leaf grant — short
+    /// rather than empty, so it reads as complete.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub direction: Option<ContextDirection>,
+    /// Only entries whose subject VID starts with this prefix.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subject_prefix: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub page_size: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cursor: Option<String>,
 }
 
+/// `acl/list/0.1` response.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ListAclResultBody {
-    pub entries: Vec<CreateAclResultBody>,
+    pub entries: Vec<AclEntry>,
+    /// True when more entries match beyond this page.
+    ///
+    /// Required by the canonical response precisely so that a short page is
+    /// never mistaken for the end of the list — the failure that makes a
+    /// revocation sweep look complete when it is not.
+    pub truncated: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cursor: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub redacted_fields: Vec<String>,
 }

--- a/vta-sdk/src/protocols/acl_management/mod.rs
+++ b/vta-sdk/src/protocols/acl_management/mod.rs
@@ -1,5 +1,6 @@
 pub mod create;
 pub mod delete;
+pub mod entry;
 pub mod get;
 pub mod list;
 pub mod swap;

--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -197,30 +197,30 @@ pub const TASK_DEVICE_SET_WAKE_0_1: &str = "https://trusttasks.org/spec/device/s
 /// values changed; the bump is the canonical-version alignment.
 pub const TASK_DEVICE_SET_WAKE_0_2: &str = "https://trusttasks.org/spec/device/set-wake/0.2";
 
-// ─── ACL slice (spec/vta/acl/*) ──────────────────────────────────────────
+// ─── ACL slice (canonical spec/acl/*) ────────────────────────────────────
 
-/// `spec/vta/acl/list/1.0` — list ACL entries, optionally filtered by
+/// `acl/list/0.1` — list ACL entries, optionally filtered by
 /// context. Payload: [`crate::protocols::acl_management::list::ListAclBody`].
-pub const TASK_ACL_LIST_1_0: &str = "https://trusttasks.org/spec/vta/acl/list/1.0";
+pub const TASK_ACL_LIST_1_0: &str = "https://trusttasks.org/spec/acl/list/0.1";
 
-/// `spec/vta/acl/create/1.0` — add an ACL entry. Payload:
+/// `acl/grant/0.1` — add an ACL entry. Payload:
 /// [`crate::protocols::acl_management::create::CreateAclBody`].
 /// Auth: Admin or Initiator.
-pub const TASK_ACL_CREATE_1_0: &str = "https://trusttasks.org/spec/vta/acl/create/1.0";
+pub const TASK_ACL_CREATE_1_0: &str = "https://trusttasks.org/spec/acl/grant/0.1";
 
-/// `spec/vta/acl/get/1.0` — retrieve a single entry. Payload:
+/// `acl/show/0.1` — retrieve a single entry. Payload:
 /// [`crate::protocols::acl_management::get::GetAclBody`].
-pub const TASK_ACL_GET_1_0: &str = "https://trusttasks.org/spec/vta/acl/get/1.0";
+pub const TASK_ACL_GET_1_0: &str = "https://trusttasks.org/spec/acl/show/0.1";
 
-/// `spec/vta/acl/update/1.0` — patch role, label, or allowed contexts.
+/// `acl/update/0.1` — patch role, label, or allowed contexts.
 /// Payload: [`crate::protocols::acl_management::update::UpdateAclBody`].
 /// Auth: Admin only.
-pub const TASK_ACL_UPDATE_1_0: &str = "https://trusttasks.org/spec/vta/acl/update/1.0";
+pub const TASK_ACL_UPDATE_1_0: &str = "https://trusttasks.org/spec/acl/update/0.1";
 
-/// `spec/vta/acl/delete/1.0` — remove an entry. Payload:
+/// `acl/revoke/0.1` — remove an entry. Payload:
 /// [`crate::protocols::acl_management::delete::DeleteAclBody`].
 /// Auth: Admin or Initiator.
-pub const TASK_ACL_DELETE_1_0: &str = "https://trusttasks.org/spec/vta/acl/delete/1.0";
+pub const TASK_ACL_DELETE_1_0: &str = "https://trusttasks.org/spec/acl/revoke/0.1";
 
 /// `spec/acl/swap-key/0.1` — self-service rotation of the caller's own ACL
 /// entry onto a new subject DID, proven by a `link_proof` VP-JWT. Payload:

--- a/vta-sdk/tests/client_rest.rs
+++ b/vta-sdk/tests/client_rest.rs
@@ -584,16 +584,22 @@ async fn rotate_seed_with_mnemonic() {
 
 // ── ACL ─────────────────────────────────────────────────────────────
 
+/// One entry in the canonical `acl/_shared/0.1/acl-entry` wire shape:
+/// `subject`/`scopes`, RFC 3339 timestamps, nested `stepUp`/`approve`.
 fn acl_entry_json(did: &str) -> Value {
     json!({
-        "did": did,
+        "subject": did,
         "role": "admin",
         "label": "ops",
-        "allowed_contexts": ["ctx-a"],
-        "created_at": 1_700_000_000_u64,
-        "created_by": "did:web:vta",
-        "expires_at": null
+        "scopes": ["ctx-a"],
+        "createdAt": "2023-11-14T22:13:20Z",
+        "createdBy": "did:web:vta",
     })
+}
+
+/// The `{ entry }` envelope canonical single-entry responses carry.
+fn acl_entry_envelope(did: &str) -> Value {
+    json!({ "entry": acl_entry_json(did) })
 }
 
 #[tokio::test]
@@ -604,7 +610,7 @@ async fn list_acl_no_filter() {
         "GET",
         "/acl",
         200,
-        json!({"entries": [acl_entry_json("did:key:zAdmin")]}),
+        json!({"entries": [acl_entry_json("did:key:zAdmin")], "truncated": false}),
     )
     .await;
     let c = client(&server).await;
@@ -674,7 +680,7 @@ async fn get_acl_path_encodes_did() {
         "GET",
         "/acl/did:web:example.com",
         200,
-        acl_entry_json("did:web:example.com"),
+        acl_entry_envelope("did:web:example.com"),
     )
     .await;
     let c = client(&server).await;
@@ -690,7 +696,7 @@ async fn create_acl_posts() {
         "POST",
         "/acl",
         200,
-        acl_entry_json("did:key:zAdmin"),
+        acl_entry_envelope("did:key:zAdmin"),
     )
     .await;
     let c = client(&server).await;
@@ -720,7 +726,7 @@ async fn update_acl_patches() {
         "PATCH",
         "/acl/did:key:zAdmin",
         200,
-        acl_entry_json("did:key:zAdmin"),
+        acl_entry_envelope("did:key:zAdmin"),
     )
     .await;
     let c = client(&server).await;

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.13.1"
+version = "0.13.2"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/messaging/handlers.rs
+++ b/vta-service/src/messaging/handlers.rs
@@ -581,23 +581,12 @@ didcomm_handler!(
     acl_management::CREATE_ACL_RESULT,
     acl_management::create::CreateAclBody,
     |s, auth, body| {
-        let role = Role::parse(&body.role)?;
-        operations::acl::create_acl(
+        operations::acl::grant_from_entry(
             &s.acl_ks,
             &s.audit_ks,
             &s.contexts_ks,
             &auth,
-            &body.did,
-            role,
-            body.label,
-            body.allowed_contexts,
-            body.expires_at,
-            body.step_up_approver,
-            body.step_up_require,
-            operations::acl::approve_scope_from_wire(
-                body.approve_all_contexts,
-                body.approve_contexts,
-            ),
+            body.entry,
             "didcomm",
         )
         .await
@@ -716,7 +705,7 @@ didcomm_handler!(
     Gate::Manage,
     acl_management::GET_ACL_RESULT,
     acl_management::get::GetAclBody,
-    |s, auth, body| operations::acl::get_acl(&s.acl_ks, &auth, &body.did, "didcomm").await
+    |s, auth, body| operations::acl::get_acl(&s.acl_ks, &auth, &body.subject, "didcomm").await
 );
 
 didcomm_handler!(
@@ -727,7 +716,7 @@ didcomm_handler!(
     |s, auth, body| operations::acl::list_acl(
         &s.acl_ks,
         &auth,
-        body.context.as_deref(),
+        body.scope.as_deref(),
         body.direction.unwrap_or_default(),
         "didcomm"
     )
@@ -744,7 +733,7 @@ didcomm_handler!(
             Some(r) => Some(Role::parse(&r)?),
             None => None,
         };
-        operations::acl::update_acl(
+        operations::acl::update_from_params(
             &s.acl_ks,
             &s.audit_ks,
             &s.contexts_ks,
@@ -769,11 +758,12 @@ didcomm_handler!(
     Gate::Manage,
     acl_management::DELETE_ACL_RESULT,
     acl_management::delete::DeleteAclBody,
-    |s, auth, body| operations::acl::delete_acl(
+    |s, auth, body| operations::acl::revoke_by_subject(
         &s.acl_ks,
         &s.audit_ks,
         &auth,
-        &body.did,
+        &body.subject,
+        body.scopes,
         "didcomm"
     )
     .await

--- a/vta-service/src/operations/acl.rs
+++ b/vta-service/src/operations/acl.rs
@@ -3,7 +3,10 @@ use tracing::info;
 
 use crate::audit::{self, audit};
 use vta_sdk::protocols::acl_management::{
-    create::CreateAclResultBody, delete::DeleteAclResultBody, list::ListAclResultBody,
+    create::{CreateAclResponseBody, CreateAclResultBody},
+    delete::DeleteAclResultBody,
+    get::GetAclResultBody,
+    list::ListAclResultBody,
     swap::AclSwapPresentation,
 };
 
@@ -291,7 +294,7 @@ pub async fn list_acl(
     context_filter: Option<&str>,
     direction: ContextDirection,
     channel: &str,
-) -> Result<ListAclResultBody, AppError> {
+) -> Result<Vec<CreateAclResultBody>, AppError> {
     auth.require_manage()?;
 
     if context_filter.is_none() && direction != ContextDirection::default() {
@@ -329,7 +332,7 @@ pub async fn list_acl(
         count = entries.len(),
         "ACL listed"
     );
-    Ok(ListAclResultBody { entries })
+    Ok(entries)
 }
 
 pub async fn update_acl(
@@ -463,7 +466,7 @@ pub async fn delete_acl(
     auth: &AuthClaims,
     did: &str,
     channel: &str,
-) -> Result<DeleteAclResultBody, AppError> {
+) -> Result<(), AppError> {
     auth.require_manage()?;
 
     if auth.did == did {
@@ -508,10 +511,7 @@ pub async fn delete_acl(
         None,
     )
     .await;
-    Ok(DeleteAclResultBody {
-        did: did.to_string(),
-        deleted: true,
-    })
+    Ok(())
 }
 
 /// Atomic self-service key rotation. The authenticated caller (`auth.did` =
@@ -767,9 +767,7 @@ mod tests {
             .await
             .unwrap();
         assert!(
-            body.entries
-                .iter()
-                .any(|e| e.did == "did:key:zApproverList"),
+            body.iter().any(|e| e.did == "did:key:zApproverList"),
             "an approve-all holder must be auditable by every context admin"
         );
     }
@@ -795,7 +793,7 @@ mod tests {
         let body = list_acl(acl_ks, caller, Some(ctx), direction, "test")
             .await
             .unwrap();
-        let mut dids: Vec<String> = body.entries.into_iter().map(|e| e.did).collect();
+        let mut dids: Vec<String> = body.into_iter().map(|e| e.did).collect();
         dids.sort();
         dids
     }
@@ -1552,11 +1550,19 @@ mod tests {
         seed_target(&acl_ks, admin_target, &["ctx-shared"]).await;
 
         let caller = ctx_admin("did:key:zCallerAdmin", &["ctx-shared"]);
-        let body = delete_acl(&acl_ks, &audit_ks, &caller, admin_target, "test")
+        // `delete_acl` is the internal removal; the canonical response body is
+        // built by `revoke_by_subject`, which reads the entry first so the
+        // caller learns what was withdrawn.
+        delete_acl(&acl_ks, &audit_ks, &caller, admin_target, "test")
             .await
             .expect("admin-on-admin delete succeeds");
-        assert_eq!(body.did, admin_target);
-        assert!(body.deleted);
+        assert!(
+            get_acl_entry(&acl_ks, admin_target)
+                .await
+                .unwrap()
+                .is_none(),
+            "the entry is gone after a delete"
+        );
     }
 
     /// Updating an ACL entry to add a context that doesn't exist
@@ -1601,4 +1607,151 @@ mod tests {
         .unwrap_err();
         assert!(matches!(err, AppError::NotFound(_)), "got {err:?}");
     }
+}
+
+// ---------------------------------------------------------------------------
+// Canonical `acl/*` adapters (#840 phase A)
+// ---------------------------------------------------------------------------
+//
+// The functions above take the maintainer's internal argument shape and are
+// unchanged by the fold; these adapt the canonical wire types onto them.
+//
+// Keeping the mapping in one place rather than in each transport's handler is
+// deliberate: REST, DIDComm and the trust-task dispatcher all reach the same
+// operation, and three copies of "which wire member becomes which argument" is
+// three chances for them to disagree about, say, whether an absent `approve`
+// confers nothing.
+
+// Aliased: `AclEntry` is already the *stored* type in this module. The wire
+// form and the stored form are deliberately different shapes, so keeping both
+// names visible stops one being mistaken for the other.
+use vta_sdk::protocols::acl_management::entry::{AclEntry as WireAclEntry, to_epoch};
+
+/// `acl/grant/0.1` → [`create_acl`].
+pub async fn grant_from_entry(
+    acl_ks: &KeyspaceHandle,
+    audit_ks: &KeyspaceHandle,
+    contexts_ks: &KeyspaceHandle,
+    auth: &AuthClaims,
+    entry: WireAclEntry,
+    channel: &str,
+) -> Result<CreateAclResponseBody, AppError> {
+    let role = Role::parse(&entry.role)
+        .map_err(|_| AppError::Validation(format!("invalid role: {}", entry.role)))?;
+    let stored = create_acl(
+        acl_ks,
+        audit_ks,
+        contexts_ks,
+        auth,
+        &entry.subject,
+        role,
+        entry.label.clone(),
+        entry.scopes.clone(),
+        entry.expires_at.map(to_epoch),
+        entry.step_up_approver(),
+        entry.step_up_require(),
+        entry.approve_scope(),
+        channel,
+    )
+    .await?;
+    Ok(CreateAclResponseBody {
+        entry: WireAclEntry::from_result(&stored),
+    })
+}
+
+/// `acl/show/0.1` → [`get_acl`].
+pub async fn show_by_subject(
+    acl_ks: &KeyspaceHandle,
+    auth: &AuthClaims,
+    subject: &str,
+    channel: &str,
+) -> Result<GetAclResultBody, AppError> {
+    let stored = get_acl(acl_ks, auth, subject, channel).await?;
+    Ok(GetAclResultBody {
+        entry: WireAclEntry::from_result(&stored),
+        // Nothing is withheld from a caller already authorized to read the
+        // entry, so the list is empty rather than absent — an explicit "we
+        // redacted nothing" beats leaving the caller to infer it.
+        redacted_fields: Vec::new(),
+    })
+}
+
+/// `acl/list/0.1` → [`list_acl`].
+pub async fn list_entries(
+    acl_ks: &KeyspaceHandle,
+    auth: &AuthClaims,
+    scope: Option<&str>,
+    direction: ContextDirection,
+    channel: &str,
+) -> Result<ListAclResultBody, AppError> {
+    let stored = list_acl(acl_ks, auth, scope, direction, channel).await?;
+    Ok(ListAclResultBody {
+        entries: stored.iter().map(WireAclEntry::from_result).collect(),
+        // This maintainer returns every matching entry in one response, so the
+        // page is never partial. Saying so explicitly is the point of the
+        // member: a caller must never have to infer completeness from length,
+        // which is how a truncated revocation sweep reads as a finished one.
+        truncated: false,
+        cursor: None,
+        redacted_fields: Vec::new(),
+    })
+}
+
+/// `acl/update/0.1` → [`update_acl`].
+pub async fn update_from_params(
+    acl_ks: &KeyspaceHandle,
+    audit_ks: &KeyspaceHandle,
+    contexts_ks: &KeyspaceHandle,
+    auth: &AuthClaims,
+    subject: &str,
+    params: UpdateAclParams,
+    channel: &str,
+) -> Result<CreateAclResponseBody, AppError> {
+    let stored = update_acl(
+        acl_ks,
+        audit_ks,
+        contexts_ks,
+        auth,
+        subject,
+        params,
+        channel,
+    )
+    .await?;
+    Ok(CreateAclResponseBody {
+        entry: WireAclEntry::from_result(&stored),
+    })
+}
+
+/// `acl/revoke/0.1` → [`delete_acl`].
+///
+/// Canonical revoke has a scope-reduction mode (`scopes` lists what to
+/// withdraw, the entry survives). This maintainer implements full removal
+/// only, and **refuses** a scoped request rather than treating it as a full
+/// removal — silently taking the whole entry when the caller asked to withdraw
+/// one scope removes far more authority than was requested, which is not a
+/// direction to guess in.
+pub async fn revoke_by_subject(
+    acl_ks: &KeyspaceHandle,
+    audit_ks: &KeyspaceHandle,
+    auth: &AuthClaims,
+    subject: &str,
+    scopes: Option<Vec<String>>,
+    channel: &str,
+) -> Result<DeleteAclResultBody, AppError> {
+    if let Some(scopes) = scopes.filter(|s| !s.is_empty()) {
+        return Err(AppError::Validation(format!(
+            "scope reduction is not supported by this maintainer — `scopes` named {} entr{}, \
+             but only full revocation is implemented. Omit `scopes` to remove the entry.",
+            scopes.len(),
+            if scopes.len() == 1 { "y" } else { "ies" }
+        )));
+    }
+    // Read before removing so the response carries what was actually
+    // withdrawn. Canonical revoke returns the entry, not a boolean: a bare
+    // `deleted: true` cannot tell an auditor what authority was lost.
+    let stored = get_acl(acl_ks, auth, subject, channel).await?;
+    delete_acl(acl_ks, audit_ks, auth, subject, channel).await?;
+    Ok(DeleteAclResultBody {
+        entry: WireAclEntry::from_result(&stored),
+    })
 }

--- a/vta-service/src/routes/acl.rs
+++ b/vta-service/src/routes/acl.rs
@@ -3,7 +3,11 @@ use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use serde::Deserialize;
 
-use vta_sdk::protocols::acl_management::{create::CreateAclResultBody, list::ListAclResultBody};
+use vta_sdk::protocols::acl_management::{
+    create::{CreateAclResponseBody, CreateAclResultBody},
+    get::GetAclResultBody,
+    list::ListAclResultBody,
+};
 
 use crate::acl::{ApproveScope, ContextDirection, Role};
 use crate::auth::{AdminAuth, AuthClaims, ManageAuth};
@@ -45,7 +49,7 @@ pub async fn list_acl(
     Query(query): Query<ListAclQuery>,
 ) -> Result<Json<ListAclResultBody>, AppError> {
     let direction = parse_direction(query.direction.as_deref())?;
-    let result = operations::acl::list_acl(
+    let result = operations::acl::list_entries(
         &state.acl_ks,
         &auth.0,
         query.context.as_deref(),
@@ -67,33 +71,10 @@ fn parse_direction(raw: Option<&str>) -> Result<ContextDirection, AppError> {
     }
 }
 
-#[derive(Debug, Deserialize, utoipa::ToSchema)]
-pub struct CreateAclRequest {
-    pub did: String,
-    pub role: Role,
-    pub label: Option<String>,
-    #[serde(default)]
-    pub allowed_contexts: Vec<String>,
-    /// Unix-epoch seconds at which this entry auto-expires. Omit or set to
-    /// `null` for a permanent entry.
-    #[serde(default)]
-    pub expires_at: Option<u64>,
-    /// VID authorized to ratify a delegated AAL2 step-up for this subject
-    /// (the approve-request `recipient`). Omit for no delegated approver.
-    #[serde(default)]
-    pub step_up_approver: Option<String>,
-    /// Per-entry step-up override (`"self"` | `"delegated"`) raising the system
-    /// floor for this subject. Omit for none.
-    #[serde(default)]
-    pub step_up_require: Option<String>,
-    /// Approve-authority over any context (confer via approval, act nowhere).
-    /// Super-admin-only to grant. Takes precedence over `approve_contexts`.
-    #[serde(default)]
-    pub approve_all_contexts: bool,
-    /// Approve-authority scoped to these contexts. Empty = confers nothing.
-    #[serde(default)]
-    pub approve_contexts: Vec<String>,
-}
+/// REST body for `POST /acl`, identical to the canonical `acl/grant/0.1`
+/// payload — the same interface the DIDComm and trust-task transports carry,
+/// rather than a REST-shaped variant of it.
+pub type CreateAclRequest = vta_sdk::protocols::acl_management::create::CreateAclBody;
 
 /// POST /acl — create a new ACL entry for a DID. Auth: Admin or Initiator.
 #[utoipa::path(
@@ -101,7 +82,7 @@ pub struct CreateAclRequest {
     security(("bearer_jwt" = [])),
     request_body = CreateAclRequest,
     responses(
-        (status = 201, description = "ACL entry created", body = CreateAclResultBody),
+        (status = 201, description = "ACL entry created", body = CreateAclResponseBody),
         (status = 401, description = "Missing or invalid bearer token"),
         (status = 403, description = "Caller cannot manage ACL entries"),
     ),
@@ -114,20 +95,13 @@ pub async fn create_acl(
     _step_up: RequireStepUp<AclGrantOp>,
     State(state): State<AppState>,
     Json(req): Json<CreateAclRequest>,
-) -> Result<(StatusCode, Json<CreateAclResultBody>), AppError> {
-    let result = operations::acl::create_acl(
+) -> Result<(StatusCode, Json<CreateAclResponseBody>), AppError> {
+    let result = operations::acl::grant_from_entry(
         &state.acl_ks,
         &state.audit_ks,
         &state.contexts_ks,
         &auth.0,
-        &req.did,
-        req.role,
-        req.label,
-        req.allowed_contexts,
-        req.expires_at,
-        req.step_up_approver,
-        req.step_up_require,
-        operations::acl::approve_scope_from_wire(req.approve_all_contexts, req.approve_contexts),
+        req.entry,
         "rest",
     )
     .await?;
@@ -140,7 +114,7 @@ pub async fn create_acl(
     security(("bearer_jwt" = [])),
     params(("did" = String, Path, description = "Subject DID")),
     responses(
-        (status = 200, description = "ACL entry", body = CreateAclResultBody),
+        (status = 200, description = "ACL entry", body = GetAclResultBody),
         (status = 401, description = "Missing or invalid bearer token"),
         (status = 403, description = "Caller cannot manage ACL entries"),
         (status = 404, description = "ACL entry not found"),
@@ -150,8 +124,8 @@ pub async fn get_acl(
     auth: ManageAuth,
     State(state): State<AppState>,
     Path(did): Path<String>,
-) -> Result<Json<CreateAclResultBody>, AppError> {
-    let result = operations::acl::get_acl(&state.acl_ks, &auth.0, &did, "rest").await?;
+) -> Result<Json<GetAclResultBody>, AppError> {
+    let result = operations::acl::show_by_subject(&state.acl_ks, &auth.0, &did, "rest").await?;
     Ok(Json(result))
 }
 
@@ -187,7 +161,7 @@ pub struct UpdateAclRequest {
     params(("did" = String, Path, description = "Subject DID")),
     request_body = UpdateAclRequest,
     responses(
-        (status = 200, description = "ACL entry updated", body = CreateAclResultBody),
+        (status = 200, description = "ACL entry updated", body = CreateAclResponseBody),
         (status = 401, description = "Missing or invalid bearer token"),
         (status = 403, description = "Caller is not an admin"),
         (status = 404, description = "ACL entry not found"),
@@ -199,8 +173,8 @@ pub async fn update_acl(
     State(state): State<AppState>,
     Path(did): Path<String>,
     Json(req): Json<UpdateAclRequest>,
-) -> Result<Json<CreateAclResultBody>, AppError> {
-    let result = operations::acl::update_acl(
+) -> Result<Json<CreateAclResponseBody>, AppError> {
+    let result = operations::acl::update_from_params(
         &state.acl_ks,
         &state.audit_ks,
         &state.contexts_ks,

--- a/vta-service/src/trust_tasks/acl.rs
+++ b/vta-service/src/trust_tasks/acl.rs
@@ -24,7 +24,7 @@ use super::helpers::{
     TRANSPORT_TRUST_TASK, app_error_to_reject, parse_payload, reject_with, success_response,
 };
 
-/// Handler for `spec/vta/acl/list/1.0`.
+/// Handler for `acl/list/0.1`.
 pub(super) async fn handle_list(
     state: &AppState,
     auth: &AuthClaims,
@@ -40,7 +40,7 @@ pub(super) async fn handle_list(
     match operations::acl::list_acl(
         &state.acl_ks,
         auth,
-        req.context.as_deref(),
+        req.scope.as_deref(),
         req.direction.unwrap_or_default(),
         TRANSPORT_TRUST_TASK,
     )
@@ -51,7 +51,7 @@ pub(super) async fn handle_list(
     }
 }
 
-/// Handler for `spec/vta/acl/create/1.0`.
+/// Handler for `acl/grant/0.1`.
 pub(super) async fn handle_create(
     state: &AppState,
     auth: &AuthClaims,
@@ -65,30 +65,12 @@ pub(super) async fn handle_create(
         Ok(r) => r,
         Err(resp) => return resp,
     };
-    let role = match Role::parse(&req.role) {
-        Ok(r) => r,
-        Err(_) => {
-            return reject_with(
-                &doc,
-                RejectReason::MalformedRequest {
-                    reason: format!("invalid role: {}", req.role),
-                },
-            );
-        }
-    };
-    match operations::acl::create_acl(
+    match operations::acl::grant_from_entry(
         &state.acl_ks,
         &state.audit_ks,
         &state.contexts_ks,
         auth,
-        &req.did,
-        role,
-        req.label,
-        req.allowed_contexts,
-        req.expires_at,
-        req.step_up_approver,
-        req.step_up_require,
-        operations::acl::approve_scope_from_wire(req.approve_all_contexts, req.approve_contexts),
+        req.entry,
         TRANSPORT_TRUST_TASK,
     )
     .await
@@ -98,7 +80,7 @@ pub(super) async fn handle_create(
     }
 }
 
-/// Handler for `spec/vta/acl/get/1.0`.
+/// Handler for `acl/show/0.1`.
 pub(super) async fn handle_get(
     state: &AppState,
     auth: &AuthClaims,
@@ -111,13 +93,13 @@ pub(super) async fn handle_get(
         Ok(r) => r,
         Err(resp) => return resp,
     };
-    match operations::acl::get_acl(&state.acl_ks, auth, &req.did, TRANSPORT_TRUST_TASK).await {
+    match operations::acl::get_acl(&state.acl_ks, auth, &req.subject, TRANSPORT_TRUST_TASK).await {
         Ok(body) => success_response(&doc, body),
         Err(e) => app_error_to_reject(&doc, e),
     }
 }
 
-/// Handler for `spec/vta/acl/update/1.0`. Admin-only — matches the
+/// Handler for `acl/update/0.1`. Admin-only — matches the
 /// legacy REST `PATCH /acl/{did}` policy.
 pub(super) async fn handle_update(
     state: &AppState,
@@ -146,7 +128,7 @@ pub(super) async fn handle_update(
         },
         None => None,
     };
-    match operations::acl::update_acl(
+    match operations::acl::update_from_params(
         &state.acl_ks,
         &state.audit_ks,
         &state.contexts_ks,
@@ -169,7 +151,7 @@ pub(super) async fn handle_update(
     }
 }
 
-/// Handler for `spec/vta/acl/delete/1.0`.
+/// Handler for `acl/revoke/0.1`.
 pub(super) async fn handle_delete(
     state: &AppState,
     auth: &AuthClaims,
@@ -183,11 +165,12 @@ pub(super) async fn handle_delete(
         Ok(r) => r,
         Err(resp) => return resp,
     };
-    match operations::acl::delete_acl(
+    match operations::acl::revoke_by_subject(
         &state.acl_ks,
         &state.audit_ks,
         auth,
-        &req.did,
+        &req.subject,
+        req.scopes,
         TRANSPORT_TRUST_TASK,
     )
     .await

--- a/vta-service/tests/api_integration.rs
+++ b/vta-service/tests/api_integration.rs
@@ -568,10 +568,12 @@ async fn acl_create_and_list() {
             "/acl",
             &token,
             json!({
-                "did": "did:key:z6MkNew",
-                "role": "application",
-                "label": "test app",
-                "allowed_contexts": ["ctx1"]
+                "entry": {
+                    "subject": "did:key:z6MkNew",
+                    "role": "application",
+                    "label": "test app",
+                    "scopes": ["ctx1"]
+                }
             }),
         ))
         .await;
@@ -582,7 +584,7 @@ async fn acl_create_and_list() {
     assert_eq!(status, StatusCode::OK);
     let entries = body["entries"].as_array().expect("entries array");
     assert!(
-        entries.iter().any(|e| e["did"] == "did:key:z6MkNew"),
+        entries.iter().any(|e| e["subject"] == "did:key:z6MkNew"),
         "new entry should be in list"
     );
 }
@@ -624,9 +626,11 @@ async fn acl_list_filters_a_context_in_both_directions() {
                 "/acl",
                 &token,
                 json!({
-                    "did": did,
-                    "role": "application",
-                    "allowed_contexts": [context],
+                    "entry": {
+                        "subject": did,
+                        "role": "application",
+                        "scopes": [context],
+                    }
                 }),
             ))
             .await;
@@ -638,7 +642,7 @@ async fn acl_list_filters_a_context_in_both_directions() {
             .as_array()
             .expect("entries array")
             .iter()
-            .map(|e| e["did"].as_str().unwrap().to_string())
+            .map(|e| e["subject"].as_str().unwrap().to_string())
             .collect();
         v.sort();
         v
@@ -710,10 +714,12 @@ async fn acl_mutation_requires_step_up() {
             "/acl",
             &token,
             json!({
-                "did": "did:key:z6MkNew",
-                "role": "application",
-                "label": "test app",
-                "allowed_contexts": ["ctx1"]
+                "entry": {
+                    "subject": "did:key:z6MkNew",
+                    "role": "application",
+                    "label": "test app",
+                    "scopes": ["ctx1"]
+                }
             }),
         ))
         .await;
@@ -755,10 +761,12 @@ async fn step_up_floor_is_per_operation_class() {
             "/acl",
             &token,
             json!({
-                "did": "did:key:z6MkUngated",
-                "role": "application",
-                "label": "ungated app",
-                "allowed_contexts": ["ctx1"]
+                "entry": {
+                    "subject": "did:key:z6MkUngated",
+                    "role": "application",
+                    "label": "ungated app",
+                    "scopes": ["ctx1"]
+                }
             }),
         ))
         .await;
@@ -838,7 +846,7 @@ async fn acl_update_sets_step_up_approver() {
         .request(post_auth(
             "/acl",
             &token,
-            json!({ "did": "did:key:z6MkGrantee2", "role": "application", "allowed_contexts": ["ctx1"] }),
+            json!({ "entry": { "subject": "did:key:z6MkGrantee2", "role": "application", "scopes": ["ctx1"] } }),
         ))
         .await;
     assert!(status.is_success());
@@ -856,7 +864,7 @@ async fn acl_update_sets_step_up_approver() {
         "update should succeed: {status} {body}"
     );
     assert_eq!(
-        body["step_up_approver"], "did:key:z6MkApprover",
+        body["entry"]["stepUp"]["approver"], "did:key:z6MkApprover",
         "update must set + reflect the step-up approver: {body}"
     );
 }
@@ -872,10 +880,12 @@ async fn acl_grant_persists_step_up_approver() {
             "/acl",
             &token,
             json!({
-                "did": "did:key:z6MkGrantee",
-                "role": "application",
-                "allowed_contexts": ["ctx1"],
-                "step_up_approver": "did:key:z6MkApprover"
+                "entry": {
+                    "subject": "did:key:z6MkGrantee",
+                    "role": "application",
+                    "scopes": ["ctx1"],
+                    "stepUp": { "approver": "did:key:z6MkApprover" }
+                }
             }),
         ))
         .await;
@@ -883,7 +893,7 @@ async fn acl_grant_persists_step_up_approver() {
     assert!(status.is_success(), "grant should succeed: {status} {body}");
     // The configured approver round-trips through the create result.
     assert_eq!(
-        body["step_up_approver"], "did:key:z6MkApprover",
+        body["entry"]["stepUp"]["approver"], "did:key:z6MkApprover",
         "grant must persist + reflect the step-up approver: {body}"
     );
 }
@@ -915,7 +925,7 @@ async fn delegated_step_up_routes_to_configured_approver() {
         .request(post_auth(
             "/acl",
             &token,
-            json!({ "did": "did:key:z6MkNew", "role": "application", "allowed_contexts": ["ctx1"] }),
+            json!({ "entry": { "subject": "did:key:z6MkNew", "role": "application", "scopes": ["ctx1"] } }),
         ))
         .await;
 
@@ -950,7 +960,7 @@ async fn delegated_step_up_without_approver_fails_closed() {
         .request(post_auth(
             "/acl",
             &token,
-            json!({ "did": "did:key:z6MkNew2", "role": "application", "allowed_contexts": ["ctx1"] }),
+            json!({ "entry": { "subject": "did:key:z6MkNew2", "role": "application", "scopes": ["ctx1"] } }),
         ))
         .await;
 
@@ -1437,10 +1447,12 @@ async fn acl_get_update_delete_lifecycle() {
         "/acl",
         &token,
         json!({
-            "did": "did:key:z6MkTarget",
-            "role": "application",
-            "label": "test",
-            "allowed_contexts": ["ctx1"]
+            "entry": {
+                "subject": "did:key:z6MkTarget",
+                "role": "application",
+                "label": "test",
+                "scopes": ["ctx1"]
+            }
         }),
     ))
     .await;
@@ -1450,7 +1462,7 @@ async fn acl_get_update_delete_lifecycle() {
         .request(get_auth("/acl/did:key:z6MkTarget", &token))
         .await;
     assert_eq!(status, StatusCode::OK);
-    assert_eq!(body["role"], "application");
+    assert_eq!(body["entry"]["role"], "application", "{body}");
 
     // Update
     let (status, body) = app
@@ -1461,7 +1473,7 @@ async fn acl_get_update_delete_lifecycle() {
         ))
         .await;
     assert!(status.is_success(), "update: {status} {body}");
-    assert_eq!(body["role"], "initiator");
+    assert_eq!(body["entry"]["role"], "initiator", "{body}");
 
     // Delete
     let (status, _) = app

--- a/vta-service/tests/step_up_approve_response.rs
+++ b/vta-service/tests/step_up_approve_response.rs
@@ -335,13 +335,15 @@ async fn trust_task_acl_mutation_requires_step_up() {
     // before payload parsing, so the body need only route + pass the role check.
     let doc = json!({
         "id": "acl-create-itest-1",
-        "type": "https://trusttasks.org/spec/vta/acl/create/1.0",
+        "type": "https://trusttasks.org/spec/acl/grant/0.1",
         "issuer": did,
         "recipient": "did:key:z6MkTestVTA",
         "payload": {
-            "did": "did:key:z6MkSomeNewEntry",
-            "role": "application",
-            "allowed_contexts": ["ctx1"]
+            "entry": {
+                "subject": "did:key:z6MkSomeNewEntry",
+                "role": "application",
+                "scopes": ["ctx1"]
+            }
         },
     });
     let req = Request::builder()

--- a/vta-service/tests/step_up_policy.rs
+++ b/vta-service/tests/step_up_policy.rs
@@ -155,9 +155,11 @@ async fn enabling_delegated_floor_with_an_approver_succeeds() {
     // Register an ACL entry that carries a delegated approver (allowed at AAL1
     // while the policy is still disabled). Now a delegated floor is satisfiable.
     let create = json!({
-        "did": "did:key:z6MkSomeUser",
-        "role": "application",
-        "step_up_approver": "did:key:z6MkApproverPhone"
+        "entry": {
+            "subject": "did:key:z6MkSomeUser",
+            "role": "application",
+            "stepUp": { "approver": "did:key:z6MkApproverPhone" }
+        }
     });
     let req = Request::builder()
         .method("POST")

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.11.39"
+version = "0.11.40"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vtc-service/tests/trust_task_manifest.rs
+++ b/vtc-service/tests/trust_task_manifest.rs
@@ -437,10 +437,11 @@ const UNPUBLISHED_CANONICAL_OK: &[(&str, usize, &str)] = &[
     // 77.
     (
         "https://trusttasks.org/spec/vta/",
-        52,
+        47,
         "VTA Trust Task surface at 1.0 — predates the registry and was never reconciled with it. \
-         Down from 55: #840 phase A folded config/{get,update} onto canonical config/{show,patch} \
-         and provision-integration/request onto provision/integration/0.2",
+         Down from 55 via #840 phase A: config/{get,update} onto config/{show,patch}, \
+         provision-integration/request onto provision/integration/0.2, and acl/* onto the \
+         canonical acl/{grant,show,list,update,revoke} family",
     ),
 ];
 


### PR DESCRIPTION
Completes the ACL half of #840 phase A. All five `vta/acl/*` tasks now bind the canonical family, with **no new specs authored on the VTA side**:

| Was | Now |
|---|---|
| `vta/acl/create/1.0` | `acl/grant/0.1` |
| `vta/acl/get/1.0` | `acl/show/0.1` |
| `vta/acl/list/1.0` | `acl/list/0.1` |
| `vta/acl/update/1.0` | `acl/update/0.1` |
| `vta/acl/delete/1.0` | `acl/revoke/0.1` |

The `spec/vta/` counted exception drops **52 → 47**.

Two of the five needed the canonical family extended first — `AclEntry.approve` ([trust-tasks-tf#149](https://github.com/trustoverip/dtgwg-trust-tasks-tf/pull/149)) and `acl/update` plus `acl/list`'s `direction` ([#150](https://github.com/trustoverip/dtgwg-trust-tasks-tf/pull/150)). The approve-vs-act axis, a general entry amendment, and the subtree-vs-acting-in reading were genuine gaps in the canonical family, not VTA quirks, so they benefit every consumer of `acl/*`.

## Scoping this as "repoint five constants" was wrong

One reshaped wire type had **six consumers across four crates**: SDK protocol bodies, service operations, the REST/DIDComm/trust-task handlers, and the SDK client and CLI.

The client layer was a latent **runtime** break rather than a compile error. It carried its own `AclEntryResponse` with `did`/`allowed_contexts`, so once the server began returning `{entry: {subject, scopes}}`, the CLI would have failed while every test passed — because the client's tests mock the server.

Resolved as a **compatibility layer**, not a rename: the client keeps its historical Rust field names, with serde mapping them to the canonical wire (`subject`↔`did`, `scopes`↔`allowed_contexts`, RFC 3339↔epoch). That left 40 CLI call sites and `vtc-service`'s ACL routes untouched. The builder API is unchanged too — callers still write `CreateAclRequest::new(did, role).contexts(..)`; only what it serialises moved.

## Wire changes

One `AclEntry` now serves every task: `did`→`subject`, `allowedContexts`→`scopes`, `expiresAt` as RFC 3339 rather than epoch seconds, and the five loose step-up/approve members grouped under `stepUp{approver, require}` and `approve{all, scopes}`. Grant nests the entry; `acl/list` responses carry `truncated`; `acl/revoke` returns the entry rather than `{did, deleted}`.

**REST moved with everything else.** It initially kept its flat bodies while the message transports went canonical — exactly the split a fold exists to remove: one operation with two payload shapes depending on how it's reached.

Three deliberate choices:

- **Scope reduction is refused, not approximated.** Canonical revoke can withdraw named scopes and leave the entry standing; this maintainer implements full removal only, and rejects a `scopes`-bearing request rather than treating it as full removal. Quietly deleting a whole entry when the caller asked to withdraw one scope removes far more authority than was requested.
- **`truncated: false` is stated, not implied.** This maintainer returns every match in one response, and saying so is the point of the member — a caller must never infer completeness from page length, which is how a truncated revocation sweep reads as a finished one.
- **The stored shape is untouched**, so there's no migration. The adapters in `operations::acl` are the single conversion boundary: three transports reach one operation, and three copies of the mapping would be three chances to disagree about whether an absent `approve` confers nothing.

## Known remainder — worth a reviewer's attention

**`vta/acl/update` maps to two canonical tasks, not one.** Its *response* is now canonical, but its *request* still merges `acl/update` with `acl/change-role`: the VTA's update accepts role changes, while canonical `acl/update` refuses them because `change-role` owns that transition with a `fromRole` compare-and-swap.

I've deliberately not folded that in. Splitting it is a behavioural change deserving its own tests — particularly because the compare-and-swap is what prevents a lost update on the one attribute where losing an update is a *privilege change* rather than a cosmetic one.

**No test exercises the client against the real router.** Every layer's tests mock the layer below, so this wire change surfaced as a sequence of individually-small failures across eleven fix-and-rerun cycles rather than one clear signal. A single round-trip test would have caught the client mismatch immediately, and I'd prioritise it over the remaining phase-A items.

## Breaking changes

Every `acl/*` payload and response changed shape — `subject` for `did`, `scopes` for `allowedContexts`, RFC 3339 expiry, nested `stepUp`/`approve`, and an `{entry}` envelope on grant/show/update/revoke responses.

## Verification

- `cargo fmt --check` clean
- `cargo clippy --workspace` clean
- `cargo test -p vta-sdk -p vta-service -p vta-cli-common -p pnm-cli -p cnm-cli -p vtc-service`: **88 test binaries, exit 0**
- The census resolves all five new URIs against published `trust_tasks_rs` 0.2.43

Note: the `client` module is feature-gated, so `-p vta-sdk --lib` alone compiles it out — the combined invocation above is what actually covers it.

`vta-sdk` 0.20.11, `vta-service` 0.13.2, `vtc-service` 0.11.40.
