### PR TITLE
feat(vta-sdk): one ATM per process, and a shutdown that stops the socket (#830)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@ REST, DIDComm and the trust-task dispatcher all reach the same operation, and
 three copies of "which member becomes which argument" would be three chances to
 disagree about, say, whether an absent `approve` confers nothing.
 
-### vta-sdk 0.20.11 — one ATM per process, and `shutdown()` that actually stops the socket (#830)
+### vta-sdk 0.20.12 — one ATM per process, and `shutdown()` that actually stops the socket (#830)
 
 Every session constructor in the SDK built its own `TDKSharedState` **and** its
 own `ATM`, then attached exactly one identity to it. A process authenticating as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,51 @@ REST, DIDComm and the trust-task dispatcher all reach the same operation, and
 three copies of "which member becomes which argument" would be three chances to
 disagree about, say, whether an absent `approve` confers nothing.
 
+### vta-sdk 0.20.11 — one ATM per process, and `shutdown()` that actually stops the socket (#830)
+
+Every session constructor in the SDK built its own `TDKSharedState` **and** its
+own `ATM`, then attached exactly one identity to it. A process authenticating as
+N DIDs held N ATMs, N secrets resolvers, N deletion handlers, and N sets of
+background tasks — none of which the transport requires. `ATM` already models
+many identities (`Profiles` keyed by alias, `profile_add` giving each one its
+own websocket), and the mediator's real ceiling is *one socket per DID*, which N
+profiles on one ATM satisfies exactly as well as N ATMs do.
+
+New `vta_sdk::session_hub::SessionHub` holds one TDK + one ATM; identities
+attach to it. Every existing constructor is unchanged and now builds a private
+hub for its one identity; `*_on` variants take a caller-owned one —
+`DIDCommSession::{connect_on, connect_with_secrets_on}`,
+`TspSession::connect_on`, `TrustPingSession::new_on`, `TspPingSession::new_on`,
+`VtaClient::{connect_didcomm_on, connect_didcomm_bundle_on, connect_tsp_on}`.
+
+**A live defect fell out of it.** No session in this SDK ever called
+`atm.profile_add`, and `ATM::graceful_shutdown` stops websockets by iterating
+the ATM's profile map — which was therefore empty. So `shutdown()` stopped the
+deletion handler and left the socket **running**, and nothing else could stop
+it: the websocket task transitively owns the only `Sender` for its own command
+channel, so that channel never closes on its own (`stop_websocket` had zero
+callers anywhere in this workspace). Every "cleanly shut down" session left an
+orphaned, auto-reconnecting socket holding the mediator's one-socket-per-DID
+slot for the life of the process.
+
+Teardown is now `SessionHub::detach` — `profile_remove` (which sends the
+transport its `Stop`) plus eviction of that identity's secrets from the shared
+resolver — and only an *exclusive* hub is torn down with its session, so a
+sibling identity's socket survives. `tests/e2e/tests/session_hub.rs` pins all
+three claims against a live mediator, and its shutdown test fails when the
+pre-#830 shape is restored.
+
+Also fixed alongside: `session::challenge_response` built an ATM purely to pack
+one message and never shut it down, leaking a deletion-handler task per login
+and per re-authentication (REST-only consumers should still prefer
+`auth_light::challenge_response_light`, which needs no ATM at all), and
+`session::send_trust_ping`'s teardown had the same unregistered-profile hole.
+
+New: `DIDCommSession::is_connected()` — a live, re-falsifiable view of the
+session's socket (R6.2), and how a caller confirms `shutdown()` really stopped
+it.
+
+Design note: `docs/05-design-notes/sdk-session-hub.md`.
 
 ### vta-support 0.2.1 — declare the `vti-common` feature it actually uses
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10269,7 +10269,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.20.11"
+version = "0.20.12"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",

--- a/docs/05-design-notes/sdk-session-hub.md
+++ b/docs/05-design-notes/sdk-session-hub.md
@@ -1,0 +1,125 @@
+# One ATM per process, not per identity
+
+**Status:** implemented (vta-sdk 0.20.11). Closes #830.
+**Related:** `multi-tenant-signing.md` (R1b, R4), `tsp-enablement.md` §3.3a
+(one socket per DID).
+
+## The problem
+
+Every session constructor in `vta-sdk` built its own `TDKSharedState` **and**
+its own `ATM`, then attached exactly one identity to it —
+`DIDCommSession::connect_with_secrets`, `TrustPingSession::new`,
+`TspPingSession::new`, `TspSession::connect`, and the free function
+`send_trust_ping`. A process authenticating as N DIDs therefore held N ATMs, N
+secrets resolvers, N deletion handlers, and N sets of background tasks.
+
+The transport never required that shape. `ATM` already models many identities:
+`Profiles` is a map keyed by alias with `find_by_did`, and
+`profile_add(profile, live_stream)` attaches each one with **its own** websocket.
+The mediator's real ceiling is *one websocket per DID*, which N profiles on one
+ATM satisfies exactly as well as N ATMs do — each DID still gets one socket.
+What N ATMs bought was duplicated per-process machinery.
+
+## What was actually broken
+
+Chasing this surfaced a live defect. **No session in the SDK ever called
+`atm.profile_add`** — each built an `ATMProfile` and went straight to
+`profile_enable_websocket`. But `ATM::graceful_shutdown` stops websockets by
+iterating the ATM's profile map, and that map was empty. So `shutdown()` stopped
+the deletion handler and **left the socket running**.
+
+Nothing else could stop it either. The websocket task transitively owns the only
+`Sender` for its own command channel (task → `Arc<ATMProfile>` → `Mediator
+.ws_channel_tx`), so the channel never closes on its own; upstream's
+`cleanup_failed_websocket` documents that exact Arc cycle. `stop_websocket` had
+zero callers anywhere in this workspace.
+
+Net: every "cleanly shut down" client session left an orphaned,
+auto-reconnecting socket holding the mediator's one-socket-per-DID slot for the
+life of the process. That is demonstrated, not inferred —
+`tests/e2e/tests/session_hub.rs::shutdown_stops_the_mediator_websocket` fails
+when the pre-#830 shape is restored.
+
+## The shape
+
+`vta_sdk::session_hub::SessionHub` holds one TDK + one ATM. Identities attach to
+it; each gets a registered `ATMProfile` and its own socket.
+
+```rust
+let hub = SessionHub::new().await?;
+let finance = VtaClient::connect_didcomm_on(&hub, fin_did, key, vta, med, rest).await?;
+let legal   = VtaClient::connect_didcomm_on(&hub, leg_did, key, vta, med, rest).await?;
+// ...
+finance.shutdown().await;   // detaches this identity only
+legal.shutdown().await;
+hub.shutdown().await;       // tears the shared ATM down
+```
+
+| Shared across identities | Per identity |
+|---|---|
+| `TDKSharedState` (DID resolver cache, secrets resolver) | `ATMProfile` |
+| `ATM` + its deletion handler | mediator websocket |
+| `ATMConfig` | delivery-layer `MessagingService` + subscribers |
+
+Every legacy constructor still works unchanged — it now builds a **private**
+hub for its one identity. `*_on` variants take a caller-owned hub:
+`DIDCommSession::{connect_on, connect_with_secrets_on}`,
+`TspSession::connect_on`, `TrustPingSession::new_on`, `TspPingSession::new_on`,
+`VtaClient::{connect_didcomm_on, connect_didcomm_bundle_on, connect_tsp_on}`.
+
+### Ownership is explicit
+
+`HubOwnership::{Exclusive, Shared}` decides what `shutdown()` does:
+
+- **Exclusive** (legacy constructors): detach the identity, then shut the hub
+  down. Nothing else is on it.
+- **Shared** (`*_on`): detach the identity and leave the hub running. A
+  sibling's socket must survive — sharing an ATM must not mean sharing a
+  failure domain, and the e2e suite pins that.
+
+### Detach is the teardown
+
+`SessionHub::detach` is `profile_remove` (which sends the transport its `Stop`)
+plus eviction of that identity's secrets from the shared resolver. Both halves
+matter: the first is what actually ends the socket, the second is what stops a
+torn-down tenant's keys from staying reachable to whatever else runs on the hub.
+It is idempotent, so `shutdown()` remains safe on any session clone.
+
+### One DID, one attachment
+
+Attaching a DID that already has a session on the hub is **refused**
+(`HubError::AlreadyAttached`). The mediator would evict the older socket as
+`duplicate-channel` and the two reconnect loops would duel, so failing the
+second connect is strictly better than letting both exist. The claim is taken in
+one locked step and released on detach (and on a failed attach), so a
+reconnecting identity is never locked out. The lock is *not* held across the
+mediator resolution — that would serialise every unrelated identity's attach
+behind one DID-document fetch (R1.3).
+
+## The TSP question
+
+#830 asked whether the TSP legs want the same treatment. They already have it,
+in the sense that matters: `TspLeg::Multiplexed` exists so a DID that holds a
+DIDComm session never opens a second socket for TSP (#803), and that is
+unchanged here — the leg rides the same profile the hub attached. `TspSession`
+and `TspPingSession` are hub-hosted like everything else, so a process that is
+TSP-only across N identities pays one ATM rather than N.
+
+The standing rule is unchanged and is a *mediator* rule, not an ATM one: **a DID
+that already holds a `DIDCommSession` must use that session's TSP leg**
+(`request_tsp`), not a `TspSession` beside it. Same hub or not, the mediator is
+what permits only one socket per DID.
+
+## What this does not change
+
+The architectural rule is still **one principal per process**
+(`multi-tenant-signing.md` R4). A hub makes holding N identities *cheap*; it
+does not make it *safe*. It exists for the front door that legitimately
+terminates requests for N tenants and has not yet split into a process per
+tenant (R1b) — the cost of that intermediate step should not be N of everything.
+
+A REST-only consumer should still prefer `auth_light::challenge_response_light`,
+which needs no ATM at all. (`session::challenge_response` built an ATM purely to
+pack one message and never shut it down — one leaked deletion-handler task per
+login and per re-authentication. That is fixed here too, but the light path
+remains the right one.)

--- a/tests/e2e/tests/session_hub.rs
+++ b/tests/e2e/tests/session_hub.rs
@@ -1,0 +1,196 @@
+//! Coverage for `vta_sdk::session_hub::SessionHub` against a live
+//! `TestMediator` — the parts of #830 that only a real socket can show.
+//!
+//! Two claims are under test here, and both need the mediator:
+//!
+//! 1. **`shutdown()` actually stops the websocket.** Before #830 no session in
+//!    the SDK registered its `ATMProfile` with the ATM, and
+//!    `ATM::graceful_shutdown` stops websockets by iterating that profile map —
+//!    so `shutdown()` stopped the deletion handler and left a live,
+//!    auto-reconnecting socket behind for the life of the process. Nothing else
+//!    could ever stop it: the transport task transitively owns the only `Sender`
+//!    for its own command channel, so the channel never closes on its own.
+//! 2. **Identities on one hub are independent.** Tearing one down must leave its
+//!    siblings connected — otherwise sharing an ATM would trade N ATMs for a
+//!    shared failure domain, which is not a trade worth making.
+
+use affinidi_messaging_test_mediator::TestMediator;
+use ed25519_dalek::SigningKey;
+use vta_sdk::did_key::ed25519_multibase_pubkey;
+use vta_sdk::didcomm_session::DIDCommSession;
+use vta_sdk::session_hub::SessionHub;
+
+mod common;
+
+/// Build a deterministic `did:key` + matching multibase private-key string.
+/// Same helper as `didcomm_session.rs`; each test binary is self-contained.
+fn did_key_from_seed(seed_byte: u8) -> (String, String) {
+    let seed = [seed_byte; 32];
+    let sk = SigningKey::from_bytes(&seed);
+    let pk = sk.verifying_key().to_bytes();
+    let did = format!("did:key:{}", ed25519_multibase_pubkey(&pk));
+    let mut buf = vec![0x80, 0x26];
+    buf.extend_from_slice(&seed);
+    let priv_mb = multibase::encode(multibase::Base::Base58Btc, &buf);
+    (did, priv_mb)
+}
+
+/// The regression test for the defect #830 surfaced: a session that has been
+/// shut down must not still hold a live mediator socket.
+///
+/// `is_connected()` reads the transport's own `ConnState` watch, and reports
+/// `false` once the transport is gone — so this fails if `shutdown()` ever stops
+/// detaching the identity (which is what sends the transport its `Stop`).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn shutdown_stops_the_mediator_websocket() {
+    common::init_tracing();
+
+    let (client_did, client_priv) = did_key_from_seed(0x31);
+    let (vta_did, _) = did_key_from_seed(0x32);
+
+    let mediator = TestMediator::builder()
+        .local_did(client_did.clone())
+        .spawn()
+        .await
+        .expect("spawn test mediator");
+
+    let session = DIDCommSession::connect(&client_did, &client_priv, &vta_did, mediator.did())
+        .await
+        .expect("session connects");
+
+    assert!(
+        session.is_connected().await,
+        "a freshly connected session must report a live socket"
+    );
+
+    session.shutdown().await;
+
+    assert!(
+        !session.is_connected().await,
+        "after shutdown() the websocket transport must be gone — a session that \
+         reports connected here is the orphaned, auto-reconnecting socket #830 \
+         is about"
+    );
+
+    mediator.shutdown();
+    mediator.join().await.expect("mediator joins cleanly");
+}
+
+/// Two identities, one hub: each gets its own socket, and shutting one down
+/// leaves the other alone. This is the shape a multi-tenant front door needs.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn two_identities_share_one_hub_and_shut_down_independently() {
+    common::init_tracing();
+
+    let (alice_did, alice_priv) = did_key_from_seed(0x33);
+    let (bob_did, bob_priv) = did_key_from_seed(0x34);
+    let (vta_did, _) = did_key_from_seed(0x35);
+
+    // Both DIDs must be local accounts on the mediator for the websocket
+    // upgrade to succeed.
+    let mediator = TestMediator::builder()
+        .local_did(alice_did.clone())
+        .local_did(bob_did.clone())
+        .spawn()
+        .await
+        .expect("spawn test mediator");
+
+    let hub = SessionHub::new().await.expect("build hub");
+
+    let alice = DIDCommSession::connect_on(&hub, &alice_did, &alice_priv, &vta_did, mediator.did())
+        .await
+        .expect("alice connects on the hub");
+    let bob = DIDCommSession::connect_on(&hub, &bob_did, &bob_priv, &vta_did, mediator.did())
+        .await
+        .expect("bob connects on the same hub");
+
+    let mut identities = hub.identities().await;
+    identities.sort();
+    let mut expected = vec![alice_did.clone(), bob_did.clone()];
+    expected.sort();
+    assert_eq!(identities, expected, "both identities are on the one hub");
+
+    assert!(alice.is_connected().await, "alice has her own live socket");
+    assert!(bob.is_connected().await, "bob has his own live socket");
+
+    // Tearing one identity down must not disturb the other.
+    alice.shutdown().await;
+
+    assert!(!alice.is_connected().await, "alice's socket is stopped");
+    assert!(
+        bob.is_connected().await,
+        "bob's socket must survive alice's shutdown — sharing an ATM must not \
+         mean sharing a failure domain"
+    );
+    assert_eq!(
+        hub.identities().await,
+        vec![bob_did.clone()],
+        "only bob remains attached"
+    );
+
+    bob.shutdown().await;
+    assert!(!bob.is_connected().await);
+    assert!(hub.identities().await.is_empty());
+
+    hub.shutdown().await;
+
+    mediator.shutdown();
+    mediator.join().await.expect("mediator joins cleanly");
+}
+
+/// A second session for a DID that already has one on the same hub is refused,
+/// and the refusal must not disturb the live session.
+///
+/// This is the one-socket-per-DID rule expressed where a consumer will actually
+/// hit it: the mediator would evict the older socket as `duplicate-channel` and
+/// the two reconnect loops would duel, so failing the *second* connect is
+/// strictly better than letting both exist.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_second_session_for_the_same_did_is_refused() {
+    common::init_tracing();
+
+    let (client_did, client_priv) = did_key_from_seed(0x36);
+    let (vta_did, _) = did_key_from_seed(0x37);
+
+    let mediator = TestMediator::builder()
+        .local_did(client_did.clone())
+        .spawn()
+        .await
+        .expect("spawn test mediator");
+
+    let hub = SessionHub::new().await.expect("build hub");
+
+    let first =
+        DIDCommSession::connect_on(&hub, &client_did, &client_priv, &vta_did, mediator.did())
+            .await
+            .expect("first session connects");
+
+    // Not `expect_err`: an unexpected `Ok` would drop a live session, and a
+    // dropped-without-shutdown session trips the SDK's leak `debug_assert`,
+    // masking this assertion's message with an unrelated panic.
+    let msg =
+        match DIDCommSession::connect_on(&hub, &client_did, &client_priv, &vta_did, mediator.did())
+            .await
+        {
+            Err(e) => e.to_string(),
+            Ok(second) => {
+                second.shutdown().await;
+                panic!("a second session for the same DID must be refused");
+            }
+        };
+    assert!(
+        msg.contains("one websocket per DID"),
+        "the error must say why, not just that it failed: {msg}"
+    );
+
+    assert!(
+        first.is_connected().await,
+        "the refused second connect must leave the first session untouched"
+    );
+
+    first.shutdown().await;
+    hub.shutdown().await;
+
+    mediator.shutdown();
+    mediator.join().await.expect("mediator joins cleanly");
+}

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.20.11"
+version = "0.20.12"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/client/mod.rs
+++ b/vta-sdk/src/client/mod.rs
@@ -429,9 +429,19 @@ impl VtaClient {
         .await
         .map_err(|e| VtaError::DidcommTransport(e.to_string()))?;
 
-        let rest_client = rest_url.as_ref().map(|_| crate::http::rest_client());
+        Ok(Self::didcomm_transport(session, rest_url))
+    }
 
-        Ok(Self {
+    /// Wrap a connected [`DIDCommSession`](crate::didcomm_session::DIDCommSession)
+    /// in a client. One place to build the transport, so a new `connect_*_on`
+    /// variant cannot forget the REST fallback or the TSP-leg default.
+    #[cfg(feature = "session")]
+    fn didcomm_transport(
+        session: crate::didcomm_session::DIDCommSession,
+        rest_url: Option<String>,
+    ) -> Self {
+        let rest_client = rest_url.as_ref().map(|_| crate::http::rest_client());
+        Self {
             transport: Transport::DIDComm {
                 session,
                 rest_client,
@@ -439,7 +449,56 @@ impl VtaClient {
                 #[cfg(feature = "tsp")]
                 tsp: None,
             },
-        })
+        }
+    }
+
+    /// Connect via DIDComm as one identity **on a shared
+    /// [`SessionHub`](crate::session_hub::SessionHub)** — the multi-identity
+    /// counterpart to [`connect_didcomm`](Self::connect_didcomm).
+    ///
+    /// This is the constructor for a front door that terminates requests for N
+    /// tenants and has to *act as* each of them: build one hub, then one client
+    /// per tenant DID on it. Each client still gets its own profile and its own
+    /// mediator websocket (the mediator's ceiling is one socket per DID); what
+    /// they share is the TDK, the ATM, the secrets resolver, and the background
+    /// tasks — the N-of-everything this replaces (#830).
+    ///
+    /// # You MUST still call [`shutdown`](Self::shutdown)
+    ///
+    /// Same contract as [`connect_didcomm`](Self::connect_didcomm), with one
+    /// difference: `shutdown()` detaches **this** identity and leaves the hub —
+    /// and every sibling client on it — running. Shut the hub down yourself once
+    /// the last client on it is done.
+    ///
+    /// ```ignore
+    /// let hub = SessionHub::new().await?;
+    /// let finance = VtaClient::connect_didcomm_on(&hub, fin_did, key, vta, med, rest).await?;
+    /// let legal   = VtaClient::connect_didcomm_on(&hub, leg_did, key, vta, med, rest).await?;
+    /// // ...
+    /// finance.shutdown().await;
+    /// legal.shutdown().await;
+    /// hub.shutdown().await;
+    /// ```
+    #[cfg(feature = "session")]
+    pub async fn connect_didcomm_on(
+        hub: &std::sync::Arc<crate::session_hub::SessionHub>,
+        client_did: &str,
+        private_key_multibase: &str,
+        vta_did: &str,
+        mediator_did: &str,
+        rest_url: Option<String>,
+    ) -> Result<Self, VtaError> {
+        let session = crate::didcomm_session::DIDCommSession::connect_on(
+            hub,
+            client_did,
+            private_key_multibase,
+            vta_did,
+            mediator_did,
+        )
+        .await
+        .map_err(|e| VtaError::DidcommTransport(e.to_string()))?;
+
+        Ok(Self::didcomm_transport(session, rest_url))
     }
 
     /// Connect via DIDComm through a mediator using a hosted-DID secrets
@@ -481,17 +540,37 @@ impl VtaClient {
         .await
         .map_err(|e| VtaError::DidcommTransport(e.to_string()))?;
 
-        let rest_client = rest_url.as_ref().map(|_| crate::http::rest_client());
+        Ok(Self::didcomm_transport(session, rest_url))
+    }
 
-        Ok(Self {
-            transport: Transport::DIDComm {
-                session,
-                rest_client,
-                rest_url: rest_url.map(|u| u.trim_end_matches('/').to_string()),
-                #[cfg(feature = "tsp")]
-                tsp: None,
-            },
-        })
+    /// Connect from a hosted-DID secrets bundle as one identity **on a shared
+    /// [`SessionHub`](crate::session_hub::SessionHub)** — the bundle
+    /// counterpart to [`connect_didcomm_on`](Self::connect_didcomm_on).
+    ///
+    /// The same hub / per-identity split and the same `shutdown()` contract
+    /// apply; see [`connect_didcomm_on`](Self::connect_didcomm_on).
+    #[cfg(feature = "session")]
+    pub async fn connect_didcomm_bundle_on(
+        hub: &std::sync::Arc<crate::session_hub::SessionHub>,
+        bundle: &crate::did_secrets::DidSecretsBundle,
+        vta_did: &str,
+        mediator_did: &str,
+        rest_url: Option<String>,
+    ) -> Result<Self, VtaError> {
+        let secrets = crate::did_key::secrets_from_bundle(bundle)
+            .map_err(|e| VtaError::DidcommTransport(e.to_string()))?;
+
+        let session = crate::didcomm_session::DIDCommSession::connect_with_secrets_on(
+            hub,
+            &bundle.did,
+            secrets,
+            vta_did,
+            mediator_did,
+        )
+        .await
+        .map_err(|e| VtaError::DidcommTransport(e.to_string()))?;
+
+        Ok(Self::didcomm_transport(session, rest_url))
     }
 
     /// Connect via **TSP** through a mediator — the transport-agnostic
@@ -545,9 +624,60 @@ impl VtaClient {
                 .await
                 .map_err(|e| VtaError::TspTransport(e.to_string()))?;
 
-        let rest_client = rest_url.as_ref().map(|_| crate::http::rest_client());
+        Ok(Self::tsp_transport(
+            session,
+            vta_did,
+            mediator_did,
+            rest_url,
+        ))
+    }
 
-        Ok(Self {
+    /// Connect via **TSP** as one identity **on a shared
+    /// [`SessionHub`](crate::session_hub::SessionHub)** — the multi-identity
+    /// counterpart to [`connect_tsp`](Self::connect_tsp).
+    ///
+    /// Each identity still opens its own TSP websocket to the mediator; the hub
+    /// shares everything above the socket. The same `shutdown()` contract as
+    /// [`connect_didcomm_on`](Self::connect_didcomm_on) applies — the client
+    /// detaches its identity and the hub keeps running for its siblings.
+    #[cfg(all(feature = "session", feature = "tsp"))]
+    pub async fn connect_tsp_on(
+        hub: &std::sync::Arc<crate::session_hub::SessionHub>,
+        client_did: &str,
+        private_key_multibase: &str,
+        vta_did: &str,
+        mediator_did: &str,
+        rest_url: Option<String>,
+    ) -> Result<Self, VtaError> {
+        let session = crate::session::TspSession::connect_on(
+            hub,
+            client_did,
+            private_key_multibase,
+            mediator_did,
+        )
+        .await
+        .map_err(|e| VtaError::TspTransport(e.to_string()))?;
+
+        Ok(Self::tsp_transport(
+            session,
+            vta_did,
+            mediator_did,
+            rest_url,
+        ))
+    }
+
+    /// Wrap a connected [`TspSession`](crate::session::TspSession) in a client —
+    /// the TSP counterpart of
+    /// [`didcomm_transport`](Self::didcomm_transport).
+    #[cfg(all(feature = "session", feature = "tsp"))]
+    fn tsp_transport(
+        session: crate::session::TspSession,
+        vta_did: &str,
+        mediator_did: &str,
+        rest_url: Option<String>,
+    ) -> Self {
+        let rest_client = rest_url.as_ref().map(|_| crate::http::rest_client());
+        Self {
             transport: Transport::Tsp {
                 session: std::sync::Arc::new(session),
                 vta_did: vta_did.to_string(),
@@ -555,7 +685,7 @@ impl VtaClient {
                 rest_client,
                 rest_url: rest_url.map(|u| u.trim_end_matches('/').to_string()),
             },
-        })
+        }
     }
 
     /// Move the **Trust-Task surface** of this DIDComm client onto TSP, keeping

--- a/vta-sdk/src/didcomm_session.rs
+++ b/vta-sdk/src/didcomm_session.rs
@@ -4,19 +4,17 @@ use std::time::Duration;
 
 use affinidi_messaging_core::{Inbound, MessageTransport};
 use affinidi_messaging_delivery::{Delivery, InMemoryOutboxStore, MessagingService, OutboxStore};
-use affinidi_tdk::common::TDKSharedState;
-use affinidi_tdk::common::config::TDKConfig;
 use affinidi_tdk::didcomm::Message;
-use affinidi_tdk::messaging::config::ATMConfig;
+#[cfg(feature = "tsp")]
 use affinidi_tdk::messaging::profiles::ATMProfile;
 use affinidi_tdk::messaging::{ATM, DidCommTransport};
-use affinidi_tdk::secrets_resolver::SecretsResolver;
 use futures_util::StreamExt;
 use futures_util::stream::BoxStream;
 use tracing::{debug, info, warn};
 
 use crate::error::VtaError;
 use crate::protocols::PROBLEM_REPORT_TYPE;
+use crate::session_hub::{AttachedIdentity, HubOwnership, SessionHub};
 
 // Per-step ceiling for mediator round-trips during session setup. The
 // upstream calls below are otherwise unbounded — when the mediator is
@@ -52,8 +50,18 @@ pub struct DIDCommSession {
     /// [`subscribe`]: affinidi_messaging_delivery::MessagingService::subscribe
     service: Arc<MessagingService>,
     /// Kept solely to `pack_encrypted` outbound messages (the delivery layer
-    /// takes already-packed bytes) and to seal/open vault JWEs.
+    /// takes already-packed bytes) and to seal/open vault JWEs. Shared with
+    /// every other identity on the same [`SessionHub`] — this is the ATM the
+    /// hub owns, not one per session.
     atm: Arc<ATM>,
+    /// This session's identity on its hub: the profile, plus what
+    /// [`shutdown`](Self::shutdown) needs to detach it again (`profile_remove`
+    /// + secrets eviction). Shared across clones so the detach happens once.
+    identity: Arc<AttachedIdentity>,
+    /// Whether this session built its own hub (legacy single-identity
+    /// constructors) or was handed one. Decides whether `shutdown()` also tears
+    /// the shared ATM down.
+    ownership: HubOwnership,
     /// The one persistent [`subscribe`] stream feeding [`receive_next`]. Each
     /// subscriber is independent + buffered, so this must be created once (in
     /// [`connect_with_secrets`]) and shared across clones — a fresh `subscribe()`
@@ -241,6 +249,42 @@ impl DIDCommSession {
         .await
     }
 
+    /// Connect as one identity **on a shared [`SessionHub`]** — the
+    /// multi-identity counterpart to [`connect`](Self::connect).
+    ///
+    /// Same transport behaviour and the same
+    /// [`shutdown`](Self::shutdown) contract; the difference is what the session
+    /// owns. This one gets its own `ATMProfile` and its own mediator websocket
+    /// (the mediator's ceiling is one socket per DID, and that is still
+    /// honoured) while sharing the hub's TDK, ATM, secrets resolver, and
+    /// background tasks with every sibling identity. `shutdown()` detaches just
+    /// this identity and leaves the hub running.
+    ///
+    /// Fails with [`HubError::AlreadyAttached`] if `client_did` already has a
+    /// session on this hub — a second socket for one DID is a duelling socket,
+    /// not extra capacity.
+    ///
+    /// [`HubError::AlreadyAttached`]: crate::session_hub::HubError::AlreadyAttached
+    pub async fn connect_on(
+        hub: &Arc<SessionHub>,
+        client_did: &str,
+        private_key_multibase: &str,
+        vta_did: &str,
+        mediator_did: &str,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        let seed = crate::did_key::decode_private_key_multibase(private_key_multibase)?;
+        let secrets = crate::did_key::secrets_from_did_key(client_did, &seed)?;
+
+        Self::connect_with_secrets_on(
+            hub,
+            client_did,
+            vec![secrets.signing, secrets.key_agreement],
+            vta_did,
+            mediator_did,
+        )
+        .await
+    }
+
     /// Connect to a VTA via DIDComm using **pre-built** DIDComm secrets.
     ///
     /// Same transport behaviour as [`connect`](Self::connect) — a persistent,
@@ -265,70 +309,123 @@ impl DIDCommSession {
         vta_did: &str,
         mediator_did: &str,
     ) -> Result<Self, Box<dyn std::error::Error>> {
-        // Create TDK shared state and insert secrets
-        let tdk = TDKSharedState::new(TDKConfig::builder().build()?).await?;
-        for secret in secrets {
-            tdk.secrets_resolver().insert(secret).await;
+        // A private hub for this one identity — the shape this constructor has
+        // always had, now expressed in terms of the shared machinery. Its
+        // `shutdown()` tears the whole hub down, because nothing else uses it.
+        let hub = SessionHub::new().await?;
+        // Stringify before the shutdown await: a `Box<dyn Error>` is not `Send`,
+        // and one held across an await makes this whole future non-`Send` —
+        // which breaks every caller that `tokio::spawn`s a connect.
+        let outcome = Self::attach(
+            &hub,
+            HubOwnership::Exclusive,
+            client_did,
+            secrets,
+            vta_did,
+            mediator_did,
+        )
+        .await
+        .map_err(|e| e.to_string());
+
+        match outcome {
+            Ok(session) => Ok(session),
+            Err(msg) => {
+                // The hub owns live background tasks from the moment it exists;
+                // a failed connect must not leave them running.
+                hub.shutdown().await;
+                Err(msg.into())
+            }
         }
+    }
 
-        // Build ATM — inbound is driven by the delivery layer's DidCommTransport,
-        // not by direct ATM polling (see the `MessagingService` wiring below).
-        let atm_config = ATMConfig::builder().build()?;
-        let atm = Arc::new(ATM::new(atm_config, Arc::new(tdk)).await?);
+    /// Connect with pre-built secrets as one identity **on a shared
+    /// [`SessionHub`]** — the bundle-friendly counterpart to
+    /// [`connect_on`](Self::connect_on), and the multi-identity counterpart to
+    /// [`connect_with_secrets`](Self::connect_with_secrets).
+    ///
+    /// This is the constructor a multi-tenant front door wants: one hub, one
+    /// `connect_with_secrets_on` per tenant DID, one socket each.
+    pub async fn connect_with_secrets_on(
+        hub: &Arc<SessionHub>,
+        client_did: &str,
+        secrets: Vec<affinidi_tdk::secrets_resolver::secrets::Secret>,
+        vta_did: &str,
+        mediator_did: &str,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        Self::attach(
+            hub,
+            HubOwnership::Shared,
+            client_did,
+            secrets,
+            vta_did,
+            mediator_did,
+        )
+        .await
+    }
 
-        // Past this point we own live background tasks: the ATM's deletion
-        // handler, and shortly a websocket transport that reconnects on its own
-        // timer. Dropping the handles does NOT stop them. An abandoned transport
-        // keeps holding — and fighting other sessions for — the mediator's
-        // one-socket-per-DID slot for `client_did`, for the life of the process.
-        //
-        // So every fallible step runs inside `finish_connect`, and a failure
-        // tears the ATM down here. One place to get right, rather than one per
-        // `?` (a timeout arm that forgot this is exactly how a service that
-        // reconnects on a schedule accumulates duelling ghost sockets).
-        // `map_err` to a `String` before the match: the boxed error is not
-        // `Send`, so holding it across the `graceful_shutdown().await` below
-        // would make this whole future non-`Send` and break callers that
-        // `tokio::spawn` a connect.
-        let outcome = Self::finish_connect(&atm, client_did, vta_did, mediator_did)
+    /// Attach `client_did` to `hub` and build the session on it.
+    ///
+    /// Past the attach we own live background tasks: the hub's deletion handler
+    /// (shared) and this identity's websocket transport, which reconnects on its
+    /// own timer. Dropping the handles does NOT stop them. An abandoned
+    /// transport keeps holding — and fighting other sessions for — the
+    /// mediator's one-socket-per-DID slot for `client_did`, for the life of the
+    /// process.
+    ///
+    /// So every fallible step past the attach runs inside `finish_connect`, and
+    /// a failure detaches the identity here. One place to get right, rather than
+    /// one per `?` (a timeout arm that forgot this is exactly how a service that
+    /// reconnects on a schedule accumulates duelling ghost sockets). `map_err`
+    /// to a `String` before the match: the boxed error is not `Send`, so holding
+    /// it across the `detach().await` below would make this whole future
+    /// non-`Send` and break callers that `tokio::spawn` a connect.
+    async fn attach(
+        hub: &Arc<SessionHub>,
+        ownership: HubOwnership,
+        client_did: &str,
+        secrets: Vec<affinidi_tdk::secrets_resolver::secrets::Secret>,
+        vta_did: &str,
+        mediator_did: &str,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        let identity = Arc::new(hub.attach(client_did, secrets, mediator_did).await?);
+
+        let outcome = Self::finish_connect(hub, &identity, ownership, vta_did)
             .await
             .map_err(|e| e.to_string());
 
         match outcome {
             Ok(session) => Ok(session),
             Err(msg) => {
-                atm.graceful_shutdown().await;
+                identity.detach().await;
                 Err(msg.into())
             }
         }
     }
 
-    /// Fallible tail of [`connect_with_secrets`]: everything that needs a live
-    /// ATM. Split out so a single error path can shut that ATM down — see the
-    /// call site.
+    /// Fallible tail of the connect path: everything that needs an attached
+    /// identity. Split out so a single error path can detach it — see
+    /// [`attach`](Self::attach).
     async fn finish_connect(
-        atm: &Arc<ATM>,
-        client_did: &str,
+        hub: &Arc<SessionHub>,
+        identity: &Arc<AttachedIdentity>,
+        ownership: HubOwnership,
         vta_did: &str,
-        mediator_did: &str,
     ) -> Result<Self, Box<dyn std::error::Error>> {
-        // Create profile with mediator
-        let profile = Arc::new(
-            ATMProfile::new(
-                atm,
-                None,
-                client_did.to_string(),
-                Some(mediator_did.to_string()),
-            )
-            .await?,
-        );
+        let atm = hub.atm();
+        let profile = &identity.profile;
+        let client_did = identity.did.as_str();
+        let mediator_did = profile
+            .dids()
+            .map(|(_, mediator)| mediator.to_string())
+            .map_err(|e| format!("attached profile has no mediator: {e}"))?;
+        let mediator_did = mediator_did.as_str();
 
         // Flush stale messages from the inbox (accumulated between CLI runs)
         {
             use affinidi_tdk::messaging::messages::Folder;
             match tokio::time::timeout(
                 MEDIATOR_OP_TIMEOUT,
-                atm.list_messages(&profile, Folder::Inbox),
+                atm.list_messages(profile, Folder::Inbox),
             )
             .await
             {
@@ -343,7 +440,7 @@ impl DIDCommSession {
                     };
                     match tokio::time::timeout(
                         MEDIATOR_OP_TIMEOUT,
-                        atm.delete_messages_direct(&profile, &delete_req),
+                        atm.delete_messages_direct(profile, &delete_req),
                     )
                     .await
                     {
@@ -373,8 +470,7 @@ impl DIDCommSession {
         // Enable WebSocket for streaming message delivery from mediator.
         // Without this, the ATM can only poll via REST and may miss responses
         // that arrive after the initial send_message call returns.
-        match tokio::time::timeout(MEDIATOR_OP_TIMEOUT, atm.profile_enable_websocket(&profile))
-            .await
+        match tokio::time::timeout(MEDIATOR_OP_TIMEOUT, atm.profile_enable_websocket(profile)).await
         {
             Ok(res) => res?,
             Err(_) => {
@@ -430,7 +526,7 @@ impl DIDCommSession {
         #[cfg(feature = "tsp")]
         let tsp = Arc::new(TspLeg {
             atm: Arc::clone(atm),
-            profile: Arc::clone(&profile),
+            profile: Arc::clone(profile),
             demux: crate::tsp_demux::TspDemux::new(),
             stream: tokio::sync::Mutex::new(service.subscribe()),
         });
@@ -446,6 +542,8 @@ impl DIDCommSession {
         Ok(Self {
             service,
             atm: Arc::clone(atm),
+            identity: Arc::clone(identity),
+            ownership,
             subscriber,
             #[cfg(feature = "tsp")]
             tsp,
@@ -740,6 +838,20 @@ impl DIDCommSession {
     /// session (see the type-level docs). Marks the session closed (so the
     /// drop-time leak check stays quiet) and tears down the mediator
     /// connection. Idempotent and safe to call on any clone.
+    ///
+    /// # What actually stops the socket
+    ///
+    /// Detaching the identity from the hub is what ends the websocket transport
+    /// task: `profile_remove` sends it `Stop`. Nothing else can — the task
+    /// transitively owns the only `Sender` for its own command channel, so the
+    /// channel never closes on its own, and `ATM::graceful_shutdown` only
+    /// reaches profiles that were *registered* with the ATM. Before #830 no
+    /// session in this SDK registered one, so `shutdown()` stopped the deletion
+    /// handler and left a reconnecting socket behind for the life of the
+    /// process.
+    ///
+    /// On a shared hub the detach is the whole teardown: siblings keep running.
+    /// On a hub this session built for itself, the hub is torn down too.
     pub async fn shutdown(&self) {
         self.shutdown.store(true, Ordering::Release);
         // Drop every TSP waiter first so an in-flight `request_tsp` fails fast
@@ -747,7 +859,47 @@ impl DIDCommSession {
         // on a connection that is about to disappear.
         #[cfg(feature = "tsp")]
         self.tsp.demux.clear().await;
-        self.atm.graceful_shutdown().await;
+
+        // Stop *this* identity's socket and evict its keys. Idempotent, so
+        // calling `shutdown()` on several clones is safe.
+        self.identity.detach().await;
+
+        if self.ownership == HubOwnership::Exclusive {
+            // Nobody else is on this hub — stop its background tasks too.
+            self.identity.hub.shutdown().await;
+        }
+    }
+
+    /// Whether this session's mediator websocket is up **right now**.
+    ///
+    /// A live signal, not a boot-time latch (R6.2): it reads the transport's
+    /// `ConnState` watch, which flips to `Disconnected` on every socket drop and
+    /// back on every reconnect, and reports `false` once the transport is gone
+    /// (after [`shutdown`](Self::shutdown), or if it was never started).
+    ///
+    /// Being `false` here does not mean the session is dead — the transport
+    /// reconnects on its own timer — so treat it as a health signal, not a
+    /// reason to rebuild the session. `false` *after* `shutdown()` is the
+    /// contract: it is how a caller can confirm the socket really stopped.
+    pub async fn is_connected(&self) -> bool {
+        match self.identity.profile.connection_state().await {
+            Some(state) => *state.borrow() == affinidi_messaging_core::ConnState::Connected,
+            // No transport at all — never started, or stopped by `shutdown()`.
+            None => false,
+        }
+    }
+
+    /// The hub this session runs on.
+    ///
+    /// Useful for a consumer that took a session from a helper and wants to add
+    /// a second identity beside it rather than build a second ATM. Note the
+    /// ownership contract: if this session created the hub
+    /// ([`connect`](Self::connect) and friends), its `shutdown()` takes the hub
+    /// down with it, so anything else attached there dies too. Sessions meant to
+    /// be siblings should all be built with the `*_on` constructors from a hub
+    /// the caller owns.
+    pub fn hub(&self) -> &Arc<SessionHub> {
+        &self.identity.hub
     }
 }
 

--- a/vta-sdk/src/lib.rs
+++ b/vta-sdk/src/lib.rs
@@ -144,6 +144,11 @@ pub mod provision_integration;
 pub mod sealed_transfer;
 #[cfg(feature = "session")]
 pub mod session;
+// One TDK + one ATM per process, with a session per identity on it. Every
+// session type in this SDK runs on a hub; the legacy constructors just build a
+// private one (#830).
+#[cfg(feature = "session")]
+pub mod session_hub;
 /// Canonical Trust-Task URLs for VTA operations. Mirrors
 /// `did-hosting-common::did_hosting_tasks` for the webvh-service side.
 pub mod trust_tasks;

--- a/vta-sdk/src/session.rs
+++ b/vta-sdk/src/session.rs
@@ -1268,11 +1268,22 @@ pub async fn challenge_response(
     .to(vta_did.to_string())
     .finalize();
 
-    // Pack the message (encrypted)
-    let (packed, _metadata) = atm
+    // Pack the message (encrypted), then shut the ATM down. It is used only to
+    // pack — there is no profile and no socket — but `ATM::new` still starts a
+    // deletion-handler task, and this function is called on every login and
+    // every re-authentication. Returning early through `?` used to leak one of
+    // those tasks per call. Stringify first: the boxed error is not `Send` and
+    // must not be held across the shutdown await.
+    //
+    // A REST-only consumer should prefer `auth_light::challenge_response_light`,
+    // which needs no ATM at all.
+    let packed = atm
         .pack_encrypted(&msg, vta_did, Some(client_did), None)
         .await
-        .map_err(|e| format!("DIDComm pack failed: {e}"))?;
+        .map(|(packed, _metadata)| packed)
+        .map_err(|e| format!("DIDComm pack failed: {e}"));
+    atm.graceful_shutdown().await;
+    let packed = packed?;
 
     debug!(packed_len = packed.len(), "message packed");
 
@@ -1911,50 +1922,44 @@ pub async fn send_trust_ping(
     mediator_did: &str,
     target_did: Option<&str>,
 ) -> Result<u128, Box<dyn std::error::Error>> {
-    use std::sync::Arc;
     use std::time::Instant;
 
-    use affinidi_tdk::common::TDKSharedState;
-    use affinidi_tdk::common::config::TDKConfig;
-    use affinidi_tdk::messaging::ATM;
-    use affinidi_tdk::messaging::config::ATMConfig;
-    use affinidi_tdk::messaging::profiles::ATMProfile;
     use affinidi_tdk::messaging::protocols::trust_ping::TrustPing;
 
     let seed = crate::did_key::decode_private_key_multibase(private_key_multibase)?;
     let secrets = crate::did_key::secrets_from_did_key(client_did, &seed)?;
 
-    let tdk = TDKSharedState::new(TDKConfig::builder().build()?).await?;
-    tdk.secrets_resolver().insert(secrets.signing).await;
-    tdk.secrets_resolver().insert(secrets.key_agreement).await;
+    // A private hub for the duration of the probe. Registering the identity with
+    // the ATM is what makes the teardown below real: an unregistered profile's
+    // websocket survives `graceful_shutdown` and keeps reconnecting for the life
+    // of the process (#830).
+    let hub = crate::session_hub::SessionHub::new().await?;
 
-    let atm = ATM::new(ATMConfig::builder().build()?, Arc::new(tdk)).await?;
-
-    // Run the probe to completion, then shut down on EVERY path. An early `?`
+    // Run the probe to completion, then tear down on EVERY path. An early `?`
     // here used to return while the ATM's websocket transport kept running and
-    // auto-reconnecting for the life of the process — a failed probe must not
-    // leave a ghost socket contending for this DID's slot on the mediator.
+    // auto-reconnecting — a failed probe must not leave a ghost socket
+    // contending for this DID's slot on the mediator.
     //
     // The outcome is stringified before the shutdown await: the boxed error is
     // not `Send`, and holding it across an await would make this future non-Send.
     let outcome = async {
-        let profile = Arc::new(
-            ATMProfile::new(
-                &atm,
-                None,
-                client_did.to_string(),
-                Some(mediator_did.to_string()),
+        let identity = hub
+            .attach(
+                client_did,
+                vec![secrets.signing, secrets.key_agreement],
+                mediator_did,
             )
-            .await?,
-        );
+            .await?;
 
-        atm.profile_enable_websocket(&profile).await?;
+        hub.atm()
+            .profile_enable_websocket(&identity.profile)
+            .await?;
 
         let start = Instant::now();
         TrustPing::default()
             .send_ping(
-                &atm,
-                &profile,
+                hub.atm(),
+                &identity.profile,
                 target_did.unwrap_or(mediator_did),
                 true,
                 true,
@@ -1967,7 +1972,7 @@ pub async fn send_trust_ping(
     .await
     .map_err(|e| e.to_string());
 
-    atm.graceful_shutdown().await;
+    hub.shutdown().await;
     outcome.map_err(Into::into)
 }
 
@@ -2014,65 +2019,98 @@ pub async fn resolve_mediator_did_with_resolver(
 /// Eliminates per-ping overhead of TDK init, ATM creation, profile setup,
 /// and WebSocket handshake (~4 seconds saved per additional ping).
 pub struct TrustPingSession {
-    atm: affinidi_tdk::messaging::ATM,
-    profile: std::sync::Arc<affinidi_tdk::messaging::profiles::ATMProfile>,
+    identity: crate::session_hub::AttachedIdentity,
+    ownership: crate::session_hub::HubOwnership,
     mediator_did: String,
 }
 
 impl TrustPingSession {
-    /// Create a new session connected to the mediator via WebSocket.
+    /// Create a new session connected to the mediator via WebSocket, on a
+    /// private [`SessionHub`](crate::session_hub::SessionHub) of its own.
     pub async fn new(
         client_did: &str,
         private_key_multibase: &str,
         mediator_did: &str,
     ) -> Result<Self, Box<dyn std::error::Error>> {
-        use affinidi_tdk::common::TDKSharedState;
-        use affinidi_tdk::common::config::TDKConfig;
-        use affinidi_tdk::messaging::ATM;
-        use affinidi_tdk::messaging::config::ATMConfig;
-        use affinidi_tdk::messaging::profiles::ATMProfile;
-        use std::sync::Arc;
-
-        let seed = crate::did_key::decode_private_key_multibase(private_key_multibase)?;
-        let secrets = crate::did_key::secrets_from_did_key(client_did, &seed)?;
-
-        let tdk = TDKSharedState::new(TDKConfig::builder().build()?).await?;
-        tdk.secrets_resolver().insert(secrets.signing).await;
-        tdk.secrets_resolver().insert(secrets.key_agreement).await;
-
-        let atm = ATM::new(ATMConfig::builder().build()?, Arc::new(tdk)).await?;
-
-        // Build the profile + socket behind a single fallible step so a failure
-        // can tear the ATM down. Without this, a session that fails to connect
-        // still leaves an auto-reconnecting websocket task running — see
-        // `ping_over_didcomm` above.
-        let prepared = async {
-            let profile = Arc::new(
-                ATMProfile::new(
-                    &atm,
-                    None,
-                    client_did.to_string(),
-                    Some(mediator_did.to_string()),
-                )
-                .await?,
-            );
-            atm.profile_enable_websocket(&profile).await?;
-            Ok::<_, Box<dyn std::error::Error>>(profile)
-        }
+        let hub = crate::session_hub::SessionHub::new().await?;
+        // Stringify before the shutdown await: a `Box<dyn Error>` is not `Send`,
+        // and one held across an await would make this future non-`Send`.
+        let outcome = Self::attach(
+            &hub,
+            crate::session_hub::HubOwnership::Exclusive,
+            client_did,
+            private_key_multibase,
+            mediator_did,
+        )
         .await
         .map_err(|e| e.to_string());
 
-        let profile = match prepared {
-            Ok(profile) => profile,
+        match outcome {
+            Ok(session) => Ok(session),
             Err(msg) => {
-                atm.graceful_shutdown().await;
-                return Err(msg.into());
+                hub.shutdown().await;
+                Err(msg.into())
             }
-        };
+        }
+    }
+
+    /// Create a session as one identity **on a shared hub** — same probe, but
+    /// the TDK, ATM, and background tasks come from `hub` instead of being built
+    /// fresh. [`shutdown`](Self::shutdown) then detaches only this identity.
+    pub async fn new_on(
+        hub: &std::sync::Arc<crate::session_hub::SessionHub>,
+        client_did: &str,
+        private_key_multibase: &str,
+        mediator_did: &str,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        Self::attach(
+            hub,
+            crate::session_hub::HubOwnership::Shared,
+            client_did,
+            private_key_multibase,
+            mediator_did,
+        )
+        .await
+    }
+
+    /// Attach the identity and open its websocket.
+    ///
+    /// The socket comes up behind a single fallible step so a failure can detach
+    /// again. Without that, a session that fails to connect still leaves an
+    /// auto-reconnecting websocket task running — see `ping_over_didcomm` above.
+    async fn attach(
+        hub: &std::sync::Arc<crate::session_hub::SessionHub>,
+        ownership: crate::session_hub::HubOwnership,
+        client_did: &str,
+        private_key_multibase: &str,
+        mediator_did: &str,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        let seed = crate::did_key::decode_private_key_multibase(private_key_multibase)?;
+        let secrets = crate::did_key::secrets_from_did_key(client_did, &seed)?;
+
+        let identity = hub
+            .attach(
+                client_did,
+                vec![secrets.signing, secrets.key_agreement],
+                mediator_did,
+            )
+            .await?;
+
+        // Stringified before the detach await: a boxed error is not `Send`.
+        let prepared = hub
+            .atm()
+            .profile_enable_websocket(&identity.profile)
+            .await
+            .map_err(|e| e.to_string());
+
+        if let Err(msg) = prepared {
+            identity.detach().await;
+            return Err(msg.into());
+        }
 
         Ok(Self {
-            atm,
-            profile,
+            identity,
+            ownership,
             mediator_did: mediator_did.to_string(),
         })
     }
@@ -2086,14 +2124,25 @@ impl TrustPingSession {
         let target = target_did.unwrap_or(&self.mediator_did);
         let start = Instant::now();
         TrustPing::default()
-            .send_ping(&self.atm, &self.profile, target, true, true, true)
+            .send_ping(
+                self.identity.hub.atm(),
+                &self.identity.profile,
+                target,
+                true,
+                true,
+                true,
+            )
             .await?;
         Ok(start.elapsed().as_millis())
     }
 
-    /// Gracefully shut down the ATM connection.
+    /// Detach this identity — which is what stops its websocket — and, if this
+    /// session owns its hub, shut the hub down too.
     pub async fn shutdown(self) {
-        self.atm.graceful_shutdown().await;
+        self.identity.detach().await;
+        if self.ownership == crate::session_hub::HubOwnership::Exclusive {
+            self.identity.hub.shutdown().await;
+        }
     }
 }
 
@@ -2114,8 +2163,8 @@ impl TrustPingSession {
 /// the same client DID must shut it down before opening this.
 #[cfg(feature = "tsp")]
 pub struct TspPingSession {
-    atm: affinidi_tdk::messaging::ATM,
-    profile: std::sync::Arc<affinidi_tdk::messaging::profiles::ATMProfile>,
+    identity: crate::session_hub::AttachedIdentity,
+    ownership: crate::session_hub::HubOwnership,
     ws: affinidi_tdk::messaging::TspWebSocket,
     client_did: String,
     mediator_did: String,
@@ -2124,57 +2173,93 @@ pub struct TspPingSession {
 #[cfg(feature = "tsp")]
 impl TspPingSession {
     /// Connect the client's TSP websocket to `mediator_did` (the VTA's `#tsp`
-    /// service endpoint — the same mediator the VTA is a local account on).
+    /// service endpoint — the same mediator the VTA is a local account on), on a
+    /// private [`SessionHub`](crate::session_hub::SessionHub) of its own.
     pub async fn new(
         client_did: &str,
         private_key_multibase: &str,
         mediator_did: &str,
     ) -> Result<Self, Box<dyn std::error::Error>> {
-        use affinidi_tdk::common::TDKSharedState;
-        use affinidi_tdk::common::config::TDKConfig;
-        use affinidi_tdk::messaging::ATM;
-        use affinidi_tdk::messaging::config::ATMConfig;
-        use affinidi_tdk::messaging::profiles::ATMProfile;
-        use std::sync::Arc;
-
-        let seed = crate::did_key::decode_private_key_multibase(private_key_multibase)?;
-        let secrets = crate::did_key::secrets_from_did_key(client_did, &seed)?;
-
-        let tdk = TDKSharedState::new(TDKConfig::builder().build()?).await?;
-        tdk.secrets_resolver().insert(secrets.signing).await;
-        tdk.secrets_resolver().insert(secrets.key_agreement).await;
-
-        let atm = ATM::new(ATMConfig::builder().build()?, Arc::new(tdk)).await?;
-
-        // As in `TrustPingSession::connect`: any failure past `ATM::new` must
-        // shut the ATM down rather than abandon its background tasks.
-        let prepared = async {
-            let profile = Arc::new(
-                ATMProfile::new(
-                    &atm,
-                    None,
-                    client_did.to_string(),
-                    Some(mediator_did.to_string()),
-                )
-                .await?,
-            );
-            let ws = atm.tsp().connect_websocket(&profile).await?;
-            Ok::<_, Box<dyn std::error::Error>>((profile, ws))
-        }
+        let hub = crate::session_hub::SessionHub::new().await?;
+        // Stringify before the shutdown await: a `Box<dyn Error>` is not `Send`,
+        // and one held across an await would make this future non-`Send`.
+        let outcome = Self::attach(
+            &hub,
+            crate::session_hub::HubOwnership::Exclusive,
+            client_did,
+            private_key_multibase,
+            mediator_did,
+        )
         .await
         .map_err(|e| e.to_string());
 
-        let (profile, ws) = match prepared {
-            Ok(pair) => pair,
+        match outcome {
+            Ok(session) => Ok(session),
             Err(msg) => {
-                atm.graceful_shutdown().await;
+                hub.shutdown().await;
+                Err(msg.into())
+            }
+        }
+    }
+
+    /// Connect as one identity **on a shared hub** — the multi-identity
+    /// counterpart to [`new`](Self::new).
+    pub async fn new_on(
+        hub: &std::sync::Arc<crate::session_hub::SessionHub>,
+        client_did: &str,
+        private_key_multibase: &str,
+        mediator_did: &str,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        Self::attach(
+            hub,
+            crate::session_hub::HubOwnership::Shared,
+            client_did,
+            private_key_multibase,
+            mediator_did,
+        )
+        .await
+    }
+
+    /// Attach the identity and open its TSP websocket. As in
+    /// [`TrustPingSession::attach`]: any failure past the attach must detach
+    /// again rather than abandon a live socket.
+    async fn attach(
+        hub: &std::sync::Arc<crate::session_hub::SessionHub>,
+        ownership: crate::session_hub::HubOwnership,
+        client_did: &str,
+        private_key_multibase: &str,
+        mediator_did: &str,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        let seed = crate::did_key::decode_private_key_multibase(private_key_multibase)?;
+        let secrets = crate::did_key::secrets_from_did_key(client_did, &seed)?;
+
+        let identity = hub
+            .attach(
+                client_did,
+                vec![secrets.signing, secrets.key_agreement],
+                mediator_did,
+            )
+            .await?;
+
+        // Stringified before the detach await: a boxed error is not `Send`.
+        let prepared = hub
+            .atm()
+            .tsp()
+            .connect_websocket(&identity.profile)
+            .await
+            .map_err(|e| e.to_string());
+
+        let ws = match prepared {
+            Ok(ws) => ws,
+            Err(msg) => {
+                identity.detach().await;
                 return Err(msg.into());
             }
         };
 
         Ok(Self {
-            atm,
-            profile,
+            identity,
+            ownership,
             ws,
             client_did: client_did.to_string(),
             mediator_did: mediator_did.to_string(),
@@ -2213,10 +2298,12 @@ impl TspPingSession {
         let start = Instant::now();
         // Route through our mediator to the VTA (a local account on it):
         // inner sealed end-to-end to the VTA, outer sealed to the mediator.
-        self.atm
+        self.identity
+            .hub
+            .atm()
             .tsp()
             .send_routed(
-                &self.profile,
+                &self.identity.profile,
                 &[self.mediator_did.clone(), vta_did.to_string()],
                 &body,
             )
@@ -2248,7 +2335,13 @@ impl TspPingSession {
             // of "is this frame the reply to that request", shared with
             // `TspSession::request`. Anything else is someone else's traffic or
             // a leftover: skip it and keep waiting within the caller's budget.
-            let Ok((payload, _sender)) = self.atm.tsp().unpack_bytes(&self.profile, &frame).await
+            let Ok((payload, _sender)) = self
+                .identity
+                .hub
+                .atm()
+                .tsp()
+                .unpack_bytes(&self.identity.profile, &frame)
+                .await
             else {
                 continue; // not sealed to us / not TSP — not our business
             };
@@ -2293,10 +2386,12 @@ impl TspPingSession {
         doc.recipient = Some(vta_did.to_string());
         let body = serde_json::to_vec(&doc)?;
 
-        self.atm
+        self.identity
+            .hub
+            .atm()
             .tsp()
             .send_routed(
-                &self.profile,
+                &self.identity.profile,
                 &[self.mediator_did.clone(), vta_did.to_string()],
                 &body,
             )
@@ -2304,10 +2399,14 @@ impl TspPingSession {
         Ok(())
     }
 
-    /// Close the TSP websocket and shut down the ATM connection.
+    /// Close the TSP websocket, detach this identity from its hub, and — if the
+    /// session owns the hub — shut the hub down too.
     pub async fn shutdown(self) {
         let _ = self.ws.close().await;
-        self.atm.graceful_shutdown().await;
+        self.identity.detach().await;
+        if self.ownership == crate::session_hub::HubOwnership::Exclusive {
+            self.identity.hub.shutdown().await;
+        }
     }
 }
 
@@ -2325,8 +2424,12 @@ impl TspPingSession {
 /// boundary, mirroring `DIDCommSession::receive_next`.
 #[cfg(feature = "tsp")]
 pub struct TspSession {
-    atm: affinidi_tdk::messaging::ATM,
-    profile: std::sync::Arc<affinidi_tdk::messaging::profiles::ATMProfile>,
+    /// This session's identity on its hub — the profile plus the teardown it
+    /// needs. One TDK + one ATM are shared with every sibling identity; the TSP
+    /// websocket below is this identity's own.
+    identity: crate::session_hub::AttachedIdentity,
+    /// Whether the hub was built for this session or handed to it.
+    ownership: crate::session_hub::HubOwnership,
     // `Option` so `shutdown` can `take()` the socket out to `close()` it —
     // `TspWebSocket::close` consumes `self`, which a `MutexGuard` can't yield.
     // `None` means already shut down; receive then no-ops.
@@ -2354,36 +2457,96 @@ impl TspSession {
         private_key_multibase: &str,
         mediator_did: &str,
     ) -> Result<Self, Box<dyn std::error::Error>> {
-        use affinidi_tdk::common::TDKSharedState;
-        use affinidi_tdk::common::config::TDKConfig;
-        use affinidi_tdk::messaging::ATM;
-        use affinidi_tdk::messaging::config::ATMConfig;
-        use affinidi_tdk::messaging::profiles::ATMProfile;
-        use std::sync::Arc;
+        let hub = crate::session_hub::SessionHub::new().await?;
+        // Stringify before the shutdown await: a `Box<dyn Error>` is not `Send`,
+        // and one held across an await would make this future non-`Send`.
+        let outcome = Self::attach(
+            &hub,
+            crate::session_hub::HubOwnership::Exclusive,
+            client_did,
+            private_key_multibase,
+            mediator_did,
+        )
+        .await
+        .map_err(|e| e.to_string());
 
+        match outcome {
+            Ok(session) => Ok(session),
+            Err(msg) => {
+                hub.shutdown().await;
+                Err(msg.into())
+            }
+        }
+    }
+
+    /// Connect as one identity **on a shared
+    /// [`SessionHub`](crate::session_hub::SessionHub)** — the multi-identity
+    /// counterpart to [`connect`](Self::connect).
+    ///
+    /// This identity gets its own TSP websocket (the mediator's one-socket-per-
+    /// DID ceiling is per DID, and still honoured) and shares the hub's TDK,
+    /// ATM, and background tasks with its siblings.
+    ///
+    /// Note the standing rule from [`TspPingSession`]: a DID that already holds
+    /// a `DIDCommSession` must use that session's TSP leg
+    /// (`DIDCommSession::request_tsp`) rather than open a `TspSession` beside
+    /// it — same hub or not, the *mediator* is what permits only one socket per
+    /// DID. Attaching the same DID twice to one hub is refused outright.
+    pub async fn connect_on(
+        hub: &std::sync::Arc<crate::session_hub::SessionHub>,
+        client_did: &str,
+        private_key_multibase: &str,
+        mediator_did: &str,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        Self::attach(
+            hub,
+            crate::session_hub::HubOwnership::Shared,
+            client_did,
+            private_key_multibase,
+            mediator_did,
+        )
+        .await
+    }
+
+    /// Attach the identity and open its TSP websocket, detaching again on any
+    /// failure past the attach so no live socket is abandoned.
+    async fn attach(
+        hub: &std::sync::Arc<crate::session_hub::SessionHub>,
+        ownership: crate::session_hub::HubOwnership,
+        client_did: &str,
+        private_key_multibase: &str,
+        mediator_did: &str,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
         let seed = crate::did_key::decode_private_key_multibase(private_key_multibase)?;
         let secrets = crate::did_key::secrets_from_did_key(client_did, &seed)?;
 
-        let tdk = TDKSharedState::new(TDKConfig::builder().build()?).await?;
-        tdk.secrets_resolver().insert(secrets.signing).await;
-        tdk.secrets_resolver().insert(secrets.key_agreement).await;
+        let identity = hub
+            .attach(
+                client_did,
+                vec![secrets.signing, secrets.key_agreement],
+                mediator_did,
+            )
+            .await?;
 
-        let atm = ATM::new(ATMConfig::builder().build()?, Arc::new(tdk)).await?;
+        // Stringified before the detach await: a boxed error is not `Send`.
+        let prepared = hub
+            .atm()
+            .tsp()
+            .connect_websocket(&identity.profile)
+            .await
+            .map_err(|e| e.to_string());
 
-        let profile = ATMProfile::new(
-            &atm,
-            None,
-            client_did.to_string(),
-            Some(mediator_did.to_string()),
-        )
-        .await?;
-        let profile = Arc::new(profile);
-
-        let ws = atm.tsp().connect_websocket(&profile).await?;
+        let ws = match prepared {
+            Ok(ws) => ws,
+            Err(msg) => {
+                identity.detach().await;
+                return Err(msg.into());
+            }
+        };
 
         Ok(Self {
-            atm,
-            profile,
+            identity,
+            ownership,
             ws: tokio::sync::Mutex::new(Some(ws)),
             client_did: client_did.to_string(),
             demux: crate::tsp_demux::TspDemux::new(),
@@ -2457,10 +2620,12 @@ impl TspSession {
         mediator_did: &str,
         body: &[u8],
     ) -> Result<(), Box<dyn std::error::Error>> {
-        self.atm
+        self.identity
+            .hub
+            .atm()
             .tsp()
             .send_routed(
-                &self.profile,
+                &self.identity.profile,
                 &[mediator_did.to_string(), vta_did.to_string()],
                 body,
             )
@@ -2715,7 +2880,13 @@ impl TspSession {
                 Err(_) => return Ok(PumpOutcome::Idle),
             };
 
-            let Ok((payload, _sender)) = self.atm.tsp().unpack_bytes(&self.profile, &frame).await
+            let Ok((payload, _sender)) = self
+                .identity
+                .hub
+                .atm()
+                .tsp()
+                .unpack_bytes(&self.identity.profile, &frame)
+                .await
             else {
                 continue; // not sealed to us / TSP control traffic
             };
@@ -2730,8 +2901,9 @@ impl TspSession {
         }
     }
 
-    /// Close the TSP websocket and shut down the ATM connection. Takes `&self`
-    /// (the session is shared across the FFI boundary).
+    /// Close the TSP websocket and detach this identity from its hub (shutting
+    /// the hub down as well when this session owns it). Takes `&self` (the
+    /// session is shared across the FFI boundary).
     pub async fn shutdown(&self) {
         // Drop every waiter first so an in-flight `request` fails fast with
         // "session shut down" instead of blocking until its own deadline on a
@@ -2740,7 +2912,10 @@ impl TspSession {
         if let Some(ws) = self.ws.lock().await.take() {
             let _ = ws.close().await;
         }
-        self.atm.graceful_shutdown().await;
+        self.identity.detach().await;
+        if self.ownership == crate::session_hub::HubOwnership::Exclusive {
+            self.identity.hub.shutdown().await;
+        }
     }
 }
 

--- a/vta-sdk/src/session_hub.rs
+++ b/vta-sdk/src/session_hub.rs
@@ -1,0 +1,522 @@
+//! One TDK + one ATM per **process**, with a session per **identity** on it.
+//!
+//! # Why this exists
+//!
+//! Every session constructor in this SDK used to build its own
+//! [`TDKSharedState`] *and* its own [`ATM`], then attach exactly one identity to
+//! it. A process authenticating as N DIDs therefore held N ATMs, N secrets
+//! resolvers, N deletion handlers, and N sets of background tasks — none of
+//! which the transport requires (#830).
+//!
+//! `ATM` already models many identities: `Profiles` is a map keyed by alias with
+//! `find_by_did`, and `profile_add` attaches each one with **its own**
+//! websocket. The mediator's real ceiling is *one websocket per DID*, which N
+//! profiles on one ATM satisfies exactly as well as N ATMs do — each DID still
+//! gets one socket. What N ATMs buy is duplicated per-process machinery.
+//!
+//! ```ignore
+//! let hub = SessionHub::new().await?;                       // one TDK + one ATM
+//! let finance = DIDCommSession::connect_on(&hub, fin_did, fin_key, vta, med).await?;
+//! let legal   = DIDCommSession::connect_on(&hub, leg_did, leg_key, vta, med).await?;
+//! // ... one profile and one socket each, everything else shared ...
+//! finance.shutdown().await;   // detaches just this identity
+//! legal.shutdown().await;
+//! hub.shutdown().await;       // tears the shared ATM down
+//! ```
+//!
+//! # What is shared, and what is not
+//!
+//! | Shared across identities | Per identity |
+//! |---|---|
+//! | `TDKSharedState` (DID resolver cache, secrets resolver) | `ATMProfile` |
+//! | `ATM` + its deletion handler | mediator websocket |
+//! | `ATMConfig` | delivery-layer `MessagingService` + subscribers |
+//!
+//! Sharing the secrets resolver is what makes one ATM able to act as several
+//! DIDs: every `Secret`'s id is a verification-method id of its own DID
+//! (`{did}#key-0`), so lookups stay unambiguous. It also means a torn-down
+//! identity's keys must not linger — `SessionHub::detach` evicts them.
+//!
+//! # This is not a licence to be multi-tenant
+//!
+//! The architectural rule is still **one principal per process**
+//! (`docs/05-design-notes/multi-tenant-signing.md`, R4). A hub makes holding N
+//! identities *cheap*; it does not make it *safe*. It exists for the front door
+//! that legitimately terminates requests for N tenants and has not yet split
+//! into a process per tenant (R1b) — the cost of that intermediate step should
+//! not be N of everything.
+//!
+//! # Every session still owns its teardown
+//!
+//! A session built on a hub detaches **itself** on `shutdown()`
+//! (`detach` → `profile_remove` → the websocket task is
+//! actually told to stop), and leaves the hub running for its siblings. A
+//! session built by a legacy constructor owns a private hub and shuts the whole
+//! thing down. Neither path may skip the detach: an abandoned websocket
+//! transport keeps reconnecting and keeps fighting for the mediator's
+//! one-socket-per-DID slot for the life of the process.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use affinidi_tdk::common::TDKSharedState;
+use affinidi_tdk::common::config::TDKConfig;
+use affinidi_tdk::messaging::ATM;
+use affinidi_tdk::messaging::config::ATMConfig;
+use affinidi_tdk::messaging::profiles::ATMProfile;
+use affinidi_tdk::secrets_resolver::SecretsResolver;
+use affinidi_tdk::secrets_resolver::secrets::Secret;
+use tokio::sync::Mutex;
+use tracing::{debug, warn};
+
+/// A shared TDK + ATM that any number of identities attach to.
+///
+/// Construct one per process with [`new`](Self::new), hand it to the `*_on`
+/// constructors ([`DIDCommSession::connect_on`], `TspSession::connect_on`, …),
+/// and [`shutdown`](Self::shutdown) it once every session on it is done. See the
+/// module docs for what is and is not shared.
+///
+/// [`DIDCommSession::connect_on`]: crate::didcomm_session::DIDCommSession::connect_on
+pub struct SessionHub {
+    /// Shared DID-resolution cache + secrets resolver. Held so
+    /// [`attach`](Self::attach) can insert an identity's secrets and
+    /// [`detach`](Self::detach) can evict them.
+    tdk: Arc<TDKSharedState>,
+    /// The one ATM every identity on this hub rides.
+    atm: Arc<ATM>,
+    /// DIDs currently attached. The ATM's own profile map is the real registry;
+    /// this exists so "is this DID already attached?" and "attach it" are one
+    /// atomic step. Without that, two concurrent `attach` calls for the same DID
+    /// both pass the check and the second silently *replaces* the first in the
+    /// ATM's map — leaving the first session's socket orphaned and its
+    /// `profile_remove` a no-op.
+    attached: Mutex<HashSet<String>>,
+}
+
+/// Why attaching an identity to a [`SessionHub`] could not proceed.
+#[derive(Debug)]
+pub enum HubError {
+    /// This DID already has a session on this hub. The mediator permits one
+    /// websocket per DID, so a second session for the same DID is a duelling
+    /// socket, not extra capacity — shut the first one down first (or, if the
+    /// two need different mediators, use a second hub).
+    AlreadyAttached(String),
+    /// The ATM refused the profile (bad mediator DID, unresolvable mediator …).
+    Attach(String),
+}
+
+impl std::fmt::Display for HubError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::AlreadyAttached(did) => write!(
+                f,
+                "`{did}` already has a session on this hub — the mediator permits one \
+                 websocket per DID, so shut that session down before opening another"
+            ),
+            Self::Attach(msg) => write!(f, "could not attach the identity: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for HubError {}
+
+impl SessionHub {
+    /// Build a hub with the default TDK + ATM configuration.
+    pub async fn new() -> Result<Arc<Self>, Box<dyn std::error::Error>> {
+        Self::with_configs(TDKConfig::builder().build()?, ATMConfig::builder().build()?).await
+    }
+
+    /// Build a hub with explicit configuration — for consumers that need custom
+    /// SSL roots (a self-signed mediator) or fetch-cache tuning.
+    ///
+    /// Both configs are process-wide once shared, which is the trade the hub
+    /// makes: identities that need *different* ATM configuration need different
+    /// hubs.
+    pub async fn with_configs(
+        tdk_config: TDKConfig,
+        atm_config: ATMConfig,
+    ) -> Result<Arc<Self>, Box<dyn std::error::Error>> {
+        let tdk = Arc::new(TDKSharedState::new(tdk_config).await?);
+        let atm = Arc::new(ATM::new(atm_config, Arc::clone(&tdk)).await?);
+        debug!("session hub initialised (one TDK + one ATM)");
+        Ok(Arc::new(Self {
+            tdk,
+            atm,
+            attached: Mutex::new(HashSet::new()),
+        }))
+    }
+
+    /// The shared ATM. Sessions pack/unpack and open their own transports
+    /// through it.
+    pub(crate) fn atm(&self) -> &Arc<ATM> {
+        &self.atm
+    }
+
+    /// The shared TDK state — the DID-resolution cache and the secrets resolver
+    /// every identity on this hub reads through.
+    pub(crate) fn tdk(&self) -> &Arc<TDKSharedState> {
+        &self.tdk
+    }
+
+    /// The DIDs currently holding a session on this hub.
+    pub async fn identities(&self) -> Vec<String> {
+        let mut dids: Vec<String> = self.attached.lock().await.iter().cloned().collect();
+        dids.sort();
+        dids
+    }
+
+    /// Attach `did` to the hub: insert its secrets into the shared resolver and
+    /// register an [`ATMProfile`] with the ATM.
+    ///
+    /// Returns the profile. The caller then opens whichever transport it needs
+    /// on it — `profile_enable_websocket` for DIDComm, `atm.tsp()
+    /// .connect_websocket` for TSP — because that choice is the session's, not
+    /// the hub's. `live_stream` is deliberately `false` here for the same
+    /// reason.
+    ///
+    /// **The registration is the load-bearing part.** A profile that is never
+    /// `profile_add`ed is invisible to `ATM::graceful_shutdown`, which stops
+    /// websockets by iterating the profile map — so its socket survives every
+    /// shutdown path and reconnects forever (the websocket task transitively
+    /// owns the only `Sender` for its own command channel, so nothing else can
+    /// ever close it). That was the state of every session in this SDK before
+    /// #830.
+    ///
+    /// On any failure the secrets are evicted again, so a failed attach leaves
+    /// no key material in the shared resolver.
+    pub(crate) async fn attach(
+        self: &Arc<Self>,
+        did: &str,
+        secrets: Vec<Secret>,
+        mediator_did: &str,
+    ) -> Result<AttachedIdentity, HubError> {
+        let secret_ids: Vec<String> = secrets.iter().map(|s| s.id.clone()).collect();
+
+        // Claim the DID *first*, in one locked step, then release the lock for
+        // the slow part. `insert` returning false means someone else holds the
+        // claim. Holding the lock across the mediator resolution below instead
+        // would serialise every unrelated identity's attach behind one DID
+        // document fetch (R1.3 — never hold a lock across an await).
+        if !self.attached.lock().await.insert(did.to_string()) {
+            return Err(HubError::AlreadyAttached(did.to_string()));
+        }
+
+        for secret in secrets {
+            self.tdk().secrets_resolver().insert(secret).await;
+        }
+
+        let profile = match self.register_profile(did, mediator_did).await {
+            Ok(profile) => profile,
+            Err(e) => {
+                // Nothing is attached, so nothing of this identity may remain —
+                // release the claim as well, or the DID is unusable until the
+                // process restarts.
+                self.attached.lock().await.remove(did);
+                self.evict_secrets(&secret_ids).await;
+                return Err(e);
+            }
+        };
+
+        Ok(AttachedIdentity {
+            hub: Arc::clone(self),
+            profile,
+            did: did.to_string(),
+            secret_ids,
+        })
+    }
+
+    /// Build the profile and register it with the ATM. Split out so
+    /// [`attach`](Self::attach) has one error path to clean up behind.
+    async fn register_profile(
+        &self,
+        did: &str,
+        mediator_did: &str,
+    ) -> Result<Arc<ATMProfile>, HubError> {
+        // Alias == DID. `profile_remove` takes an alias, and every lookup we do
+        // is by DID, so keeping them identical means there is one key.
+        let profile = ATMProfile::new(
+            self.atm.as_ref(),
+            None,
+            did.to_string(),
+            Some(mediator_did.to_string()),
+        )
+        .await
+        .map_err(|e| HubError::Attach(format!("build profile for `{did}`: {e}")))?;
+
+        // `live_stream: false` — the session opens the transport it needs.
+        self.atm
+            .profile_add(&profile, false)
+            .await
+            .map_err(|e| HubError::Attach(format!("register profile for `{did}`: {e}")))
+    }
+
+    /// Detach an identity: stop its websocket (via `profile_remove`) and evict
+    /// its secrets from the shared resolver.
+    ///
+    /// Idempotent — a second call for the same DID is a no-op, which is what
+    /// lets a session's `shutdown()` be safe to call on any clone.
+    pub(crate) async fn detach(&self, did: &str, secret_ids: &[String]) {
+        let was_attached = self.attached.lock().await.remove(did);
+        if !was_attached {
+            return;
+        }
+
+        // `profile_remove` sends `Stop` to the websocket transport task and
+        // drops it out of the ATM's map. This is the only thing that ends that
+        // task: it owns a `Sender` for its own command channel, so the channel
+        // never closes on its own.
+        match self.atm.profile_remove(did).await {
+            Ok(true) => debug!(did, "identity detached from the hub"),
+            // Registered by `attach`, so absent here means someone removed it
+            // behind our back — worth a word, since a socket may be orphaned.
+            Ok(false) => warn!(did, "identity was not registered with the ATM at detach"),
+            Err(e) => warn!(did, "could not detach identity cleanly: {e}"),
+        }
+
+        self.evict_secrets(secret_ids).await;
+    }
+
+    /// Remove `secret_ids` from the shared resolver. A hub outlives the
+    /// identities on it, so a detached identity's keys must not stay reachable
+    /// to whatever is still running on the hub.
+    async fn evict_secrets(&self, secret_ids: &[String]) {
+        for id in secret_ids {
+            self.tdk().secrets_resolver().remove_secret(id).await;
+        }
+    }
+
+    /// Shut the hub down: stop every remaining identity's websocket and stop the
+    /// ATM's background tasks.
+    ///
+    /// Sessions should be shut down first — they own their own teardown, and
+    /// only they can drain in-flight waiters. This is the backstop for whatever
+    /// is left, and it is bounded (see `ATM::graceful_shutdown`).
+    pub async fn shutdown(&self) {
+        let remaining = self.attached.lock().await.len();
+        if remaining > 0 {
+            debug!(
+                remaining,
+                "hub shutdown with identities still attached — stopping their transports"
+            );
+        }
+        self.atm.graceful_shutdown().await;
+        self.attached.lock().await.clear();
+    }
+}
+
+/// One identity's attachment to a [`SessionHub`] — the profile plus everything
+/// needed to detach it again.
+///
+/// Sessions hold this instead of a bare `Arc<ATMProfile>` so that "tear this
+/// identity down" is a single call that cannot forget the secrets eviction or
+/// the profile removal.
+pub(crate) struct AttachedIdentity {
+    pub(crate) hub: Arc<SessionHub>,
+    pub(crate) profile: Arc<ATMProfile>,
+    pub(crate) did: String,
+    /// Ids of the secrets this identity inserted into the shared resolver.
+    pub(crate) secret_ids: Vec<String>,
+}
+
+impl std::fmt::Debug for AttachedIdentity {
+    /// Manual: neither the hub nor the ATM behind it is `Debug`, and this is
+    /// key-adjacent — print what identifies the attachment, never the material.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AttachedIdentity")
+            .field("did", &self.did)
+            .field("secrets", &self.secret_ids.len())
+            .finish()
+    }
+}
+
+impl AttachedIdentity {
+    /// Detach this identity from its hub. Idempotent.
+    pub(crate) async fn detach(&self) {
+        self.hub.detach(&self.did, &self.secret_ids).await;
+    }
+}
+
+/// How a session relates to the hub it runs on — the difference between "I was
+/// handed this hub" and "I built it for myself".
+///
+/// A session that built its own hub is the legacy single-identity shape
+/// (`DIDCommSession::connect`, `TspSession::connect`, …): its `shutdown()` must
+/// tear the whole ATM down, because nothing else will. A session handed a hub
+/// must **not** — its siblings are still using it.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum HubOwnership {
+    /// The session created the hub and is its only user.
+    Exclusive,
+    /// The hub was supplied by the caller and outlives this session.
+    Shared,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A deterministic `did:key` + its DIDComm secrets, for attaching identities
+    /// without a network.
+    fn identity(seed_byte: u8) -> (String, Vec<Secret>) {
+        let seed = [seed_byte; 32];
+        let sk = ed25519_dalek::SigningKey::from_bytes(&seed);
+        let did = format!(
+            "did:key:{}",
+            crate::did_key::ed25519_multibase_pubkey(&sk.verifying_key().to_bytes())
+        );
+        let secrets = crate::did_key::secrets_from_did_key(&did, &seed).expect("build secrets");
+        (did, vec![secrets.signing, secrets.key_agreement])
+    }
+
+    /// A `did:key` used where a mediator DID is wanted. It resolves (it is a
+    /// `did:key`) but advertises no messaging service, so `ATMProfile::new`
+    /// records `mediator: None` and no socket is ever opened — which is exactly
+    /// what these tests want: hub bookkeeping, no I/O.
+    fn mediator_placeholder() -> String {
+        identity(0xEE).0
+    }
+
+    #[tokio::test]
+    async fn attaching_registers_the_identity_and_its_secrets() {
+        let hub = SessionHub::new().await.expect("build hub");
+        let (did, secrets) = identity(0x01);
+        let secret_ids: Vec<String> = secrets.iter().map(|s| s.id.clone()).collect();
+
+        let attached = hub
+            .attach(&did, secrets, &mediator_placeholder())
+            .await
+            .expect("attach");
+
+        assert_eq!(hub.identities().await, vec![did.clone()]);
+        // Registered with the ATM — this is what makes teardown reach the
+        // websocket at all (#830).
+        assert!(
+            hub.atm().find_profile(&did).await.is_some(),
+            "the ATM must know about the profile, not just the session"
+        );
+        for id in &secret_ids {
+            assert!(
+                hub.tdk().secrets_resolver().get_secret(id).await.is_some(),
+                "secret {id} must be resolvable while the identity is attached"
+            );
+        }
+
+        attached.detach().await;
+
+        assert!(hub.identities().await.is_empty());
+        assert!(
+            hub.atm().find_profile(&did).await.is_none(),
+            "detach must remove the profile from the ATM"
+        );
+        for id in &secret_ids {
+            assert!(
+                hub.tdk().secrets_resolver().get_secret(id).await.is_none(),
+                "detach must evict {id} — a torn-down identity's keys must not \
+                 stay reachable to whatever else runs on the hub"
+            );
+        }
+
+        hub.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn a_second_session_for_the_same_did_is_refused() {
+        let hub = SessionHub::new().await.expect("build hub");
+        let mediator = mediator_placeholder();
+        let (did, secrets) = identity(0x02);
+        let first = hub.attach(&did, secrets, &mediator).await.expect("attach");
+
+        let (_, again) = identity(0x02);
+        let err = hub
+            .attach(&did, again, &mediator)
+            .await
+            .expect_err("the same DID must not attach twice");
+        assert!(matches!(err, HubError::AlreadyAttached(ref d) if *d == did));
+
+        // The refusal must not have disturbed the live identity.
+        assert_eq!(hub.identities().await, vec![did.clone()]);
+        assert!(hub.atm().find_profile(&did).await.is_some());
+
+        first.detach().await;
+        hub.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn identities_are_independent_and_detach_is_idempotent() {
+        let hub = SessionHub::new().await.expect("build hub");
+        let mediator = mediator_placeholder();
+        let (alice, alice_secrets) = identity(0x03);
+        let (bob, bob_secrets) = identity(0x04);
+        let bob_secret_ids: Vec<String> = bob_secrets.iter().map(|s| s.id.clone()).collect();
+
+        let alice_id = hub
+            .attach(&alice, alice_secrets, &mediator)
+            .await
+            .expect("attach alice");
+        let bob_id = hub
+            .attach(&bob, bob_secrets, &mediator)
+            .await
+            .expect("attach bob");
+        assert_eq!(hub.identities().await.len(), 2);
+
+        // Tearing one identity down must leave its sibling untouched — this is
+        // the whole point of a shared hub.
+        bob_id.detach().await;
+        assert_eq!(hub.identities().await, vec![alice.clone()]);
+        assert!(hub.atm().find_profile(&alice).await.is_some());
+
+        // A session's `shutdown()` may be called on several clones.
+        bob_id.detach().await;
+        assert_eq!(hub.identities().await, vec![alice.clone()]);
+        for id in &bob_secret_ids {
+            assert!(hub.tdk().secrets_resolver().get_secret(id).await.is_none());
+        }
+
+        alice_id.detach().await;
+        hub.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn a_detached_did_can_attach_again() {
+        // The claim is released on detach, so a consumer that reconnects an
+        // identity (token refresh, socket rebuild) is not locked out.
+        let hub = SessionHub::new().await.expect("build hub");
+        let mediator = mediator_placeholder();
+        let (did, secrets) = identity(0x05);
+
+        hub.attach(&did, secrets, &mediator)
+            .await
+            .expect("first attach")
+            .detach()
+            .await;
+
+        let (_, secrets) = identity(0x05);
+        let second = hub
+            .attach(&did, secrets, &mediator)
+            .await
+            .expect("re-attach after detach");
+        assert_eq!(hub.identities().await, vec![did]);
+
+        second.detach().await;
+        hub.shutdown().await;
+    }
+
+    #[test]
+    fn already_attached_names_the_did_and_the_fix() {
+        let msg = HubError::AlreadyAttached("did:key:zAlice".into()).to_string();
+        assert!(
+            msg.contains("did:key:zAlice"),
+            "names the offending DID: {msg}"
+        );
+        assert!(
+            msg.contains("one websocket per DID"),
+            "explains why a second session is not extra capacity: {msg}"
+        );
+    }
+
+    #[test]
+    fn ownership_distinguishes_a_borrowed_hub_from_an_owned_one() {
+        // The whole point of the enum: a shared hub must survive its sessions.
+        assert_ne!(HubOwnership::Exclusive, HubOwnership::Shared);
+    }
+}


### PR DESCRIPTION
Closes #830.

## What the issue asked for

Every session constructor in the SDK built its own `TDKSharedState` **and** its own `ATM`, then attached exactly one identity to it. A process authenticating as N DIDs held N ATMs, N secrets resolvers, N deletion handlers, and N sets of background tasks.

`ATM` already models many identities — `Profiles` is keyed by alias with `find_by_did`, and `profile_add` attaches each one with its own websocket. The mediator's real ceiling is *one socket per DID*, which N profiles on one ATM satisfies exactly as well as N ATMs do.

New `vta_sdk::session_hub::SessionHub` holds one TDK + one ATM; identities attach to it:

```rust
let hub = SessionHub::new().await?;
let finance = VtaClient::connect_didcomm_on(&hub, fin_did, key, vta, med, rest).await?;
let legal   = VtaClient::connect_didcomm_on(&hub, leg_did, key, vta, med, rest).await?;
finance.shutdown().await;   // detaches this identity only
legal.shutdown().await;
hub.shutdown().await;
```

Every existing constructor keeps its signature and now builds a **private** hub for its one identity, so no caller changes. `*_on` variants take a caller-owned hub: `DIDCommSession::{connect_on, connect_with_secrets_on}`, `TspSession::connect_on`, `TrustPingSession::new_on`, `TspPingSession::new_on`, `VtaClient::{connect_didcomm_on, connect_didcomm_bundle_on, connect_tsp_on}`.

## A live defect fell out of it

**No session in this SDK ever called `atm.profile_add`.** `ATM::graceful_shutdown` stops websockets by iterating the ATM's profile map — which was therefore empty. So `shutdown()` stopped the deletion handler and left the socket **running**. Nothing else could stop it: the websocket task transitively owns the only `Sender` for its own command channel (task → `Arc<ATMProfile>` → `Mediator.ws_channel_tx`), so the channel never closes on its own — upstream's `cleanup_failed_websocket` documents that Arc cycle. `stop_websocket` had zero callers anywhere in this workspace.

Net: every "cleanly shut down" client session left an orphaned, auto-reconnecting socket holding the mediator's one-socket-per-DID slot for the life of the process.

This is demonstrated, not inferred: restoring the pre-#830 shape (skip `profile_add`, skip `profile_remove`) makes `shutdown_stops_the_mediator_websocket` fail with the session still reporting a live socket after `shutdown()`.

Teardown is now `SessionHub::detach` — `profile_remove` (which sends the transport its `Stop`) plus eviction of that identity's secrets from the shared resolver — and only an *exclusive* hub is torn down alongside its session, so a sibling identity's socket survives.

## Also fixed alongside

- `session::challenge_response` built an ATM purely to pack one message and **never shut it down** — one leaked deletion-handler task per login and per re-authentication. (REST-only consumers should still prefer `auth_light::challenge_response_light`, which needs no ATM at all.)
- `session::send_trust_ping` had the same unregistered-profile hole in its teardown.
- New `DIDCommSession::is_connected()` — a live, re-falsifiable view of the socket (R6.2), and how a caller confirms `shutdown()` really stopped it.

## Scope

All five ATM construction sites in the SDK, per the issue's "worth deciding alongside": `didcomm_session.rs` (incl. its TSP leg), and `session.rs`'s `TrustPingSession`, `TspPingSession`, `TspSession`, plus the two free functions. The one-socket-per-DID rule is unchanged and is a *mediator* rule, not an ATM one — a DID that already holds a `DIDCommSession` still uses that session's TSP leg rather than a `TspSession` beside it (#803).

The architectural rule is still one principal per process (`multi-tenant-signing.md` R4). A hub makes holding N identities *cheap*, not *safe* — it is for the front door that has not yet split into a process per tenant (R1b).

## Tests

- `vta-sdk` unit tests (6, offline): attach registers the profile with the ATM and resolves its secrets; detach removes both; a duplicate DID is refused without disturbing the live identity; identities are independent; detach is idempotent; a detached DID can re-attach.
- `tests/e2e/tests/session_hub.rs` (3, live `TestMediator`): shutdown stops the websocket; two identities share one hub and shut down independently; a second session for the same DID is refused with an error that says why.
- Full `vta-sdk` suite and the whole e2e suite (including the TSP binaries that exercise the rewritten sessions) are green; `cargo fmt`, workspace clippy, and the three repo guards (version bump, changelog, lockfile self-pins) pass. Rustdoc warning count is unchanged from baseline.

Design note: `docs/05-design-notes/sdk-session-hub.md`.