### PR TITLE
fix(messaging): stop the mediator handshakes leaking websockets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,48 @@
 
 ## Unreleased
 
+### vta-service 0.13.3 / vtc-service 0.11.41 — the mediator handshakes stop leaking websockets
+
+The defect #830 fixed in `vta-sdk` was also present, unfixed, in the services'
+own mediator plumbing. Same shape every time: a profile that opens a websocket
+but is never registered with the ATM, so `ATM::graceful_shutdown` — which stops
+websockets by iterating the profile map — walks straight past it, and nothing
+else can stop it either (the transport task transitively owns the only `Sender`
+for its own command channel, so no handle going out of scope ends it).
+
+**`messaging/transient_handshake.rs` — leaked one socket per first-enable.** Its
+teardown was a comment: *"dropping `service`/`atm` on return closes the transient
+websocket."* It does not. Every `services didcomm enable` left a socket
+reconnecting to that mediator, for the VTA's own DID, for the life of the
+process. The profile is now registered, and the ATM is torn down explicitly
+(`profile_remove` + `graceful_shutdown`) on every exit path — success, ping
+failure, and each early return in the build sequence.
+
+**`messaging/live_prover.rs` — leaked one socket per failed `services didcomm
+update`.** The failure path called `remove_transport`, which unbinds the
+transport from the delivery layer and does nothing to the socket. Repeated
+attempts against the same candidate stacked up live sockets for the same DID on
+the same mediator, which then duelled over the mediator's one-per-DID slot. The
+candidate profile is now registered and its socket stopped with `profile_remove`
+on failure — **not** `graceful_shutdown`, which would take the VTA's own live
+listener down with it, since this ATM is shared.
+
+**The long-lived listeners** (`vta-service::messaging::service::build_messaging`,
+`vtc-service::messaging::build_messaging`) now register their profiles too. Both
+run once per process, so nothing is reclaimed today; the point is that a listener
+whose socket cannot be stopped short of `exit()` is a trap for whoever adds a
+shutdown path next.
+
+**`vtc-service`'s DIDComm test harness** (`test_support::MockVtcDidcomm`) now
+shuts the applicant client down. Each test previously left a socket
+reconnect-looping against a dead mediator for the rest of the test binary.
+
+Regression test: `tests/e2e/tests/transient_handshake.rs::
+transient_handshake_leaves_no_socket_behind` runs the handshake twice against a
+mediator capped at one websocket per DID — which *refuses* the second connection
+rather than evicting the first, so the second handshake can only succeed if the
+first one's socket is really gone. It fails on the pre-fix code.
+
 ### vta-sdk 0.20.11 / vta-service 0.13.2 / vta-cli-common 0.10.18 / vtc-service 0.11.40 — the ACL surface folds onto canonical `acl/*` (#840 phase A)
 
 All five `vta/acl/*` tasks now bind the canonical family, with **no new specs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10331,7 +10331,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",
@@ -10564,7 +10564,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-service"
-version = "0.11.40"
+version = "0.11.41"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/tests/e2e/tests/transient_handshake.rs
+++ b/tests/e2e/tests/transient_handshake.rs
@@ -70,6 +70,61 @@ async fn transient_handshake_against_live_mediator_succeeds() {
     mediator.join().await.expect("mediator joins cleanly");
 }
 
+/// The handshake must leave **no live websocket** behind.
+///
+/// Observing that from outside needs a lever, and the mediator has one: a
+/// per-DID connection cap that *refuses* the new connection (POLICY close,
+/// "per-DID connection limit reached") rather than evicting the old one. So with
+/// the cap at 1, a second handshake for the same DID can only succeed if the
+/// first one's socket is really gone.
+///
+/// Before the fix it was not. `transient_prove` never registered its profile
+/// with the ATM, and its teardown was a comment claiming that dropping the
+/// service and ATM closes the socket — which it does not: the transport task
+/// transitively owns the only `Sender` for its own command channel, so nothing
+/// going out of scope can end it. Every first-enable handshake leaked one
+/// reconnecting socket for the VTA's own DID. This test fails (at Connect) on
+/// that code.
+#[tokio::test]
+async fn transient_handshake_leaves_no_socket_behind() {
+    common::init_tracing();
+
+    let vta = TestVta::spawn().await.expect("spawn test VTA");
+    let mediator = TestMediator::builder()
+        .local_did(vta.did.clone())
+        // One at a time: a second concurrent socket for this DID is refused,
+        // which is what turns "the first one leaked" into a test failure.
+        .max_websocket_connections_per_did(1)
+        .spawn()
+        .await
+        .expect("spawn test mediator");
+
+    let opts = HandshakeOptions {
+        timeout: Duration::from_secs(10),
+        force: false,
+    };
+
+    vta.run_transient_handshake(mediator.did(), opts.clone())
+        .await
+        .expect("first handshake succeeds");
+
+    // The teardown is asynchronous at the mediator end (it decrements its count
+    // when the connection handler returns), so give it a moment to settle. This
+    // cannot mask the defect it guards: a leaked socket is still there after any
+    // sleep — it reconnects on its own timer and never goes away.
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    vta.run_transient_handshake(mediator.did(), opts)
+        .await
+        .expect(
+            "second handshake for the same DID must succeed — if it fails at Connect, \
+             the first handshake's websocket is still holding the mediator's per-DID slot",
+        );
+
+    mediator.shutdown();
+    mediator.join().await.expect("mediator joins cleanly");
+}
+
 #[tokio::test]
 async fn transient_handshake_unresolvable_did_fails_at_resolve_stage() {
     common::init_tracing();

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.13.2"
+version = "0.13.3"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/messaging/live_prover.rs
+++ b/vta-service/src/messaging/live_prover.rs
@@ -21,7 +21,9 @@
 //! 4. On success the candidate transport is left installed for the caller
 //!    (`update_didcomm`) to `promote`; on any-stage failure it is
 //!    `remove_transport`-ed so the registry doesn't promote a mediator the VTA
-//!    can't reach.
+//!    can't reach, **and its websocket is stopped** via `profile_remove` —
+//!    unbinding the transport does not close the socket, so a failed handshake
+//!    used to leave one reconnecting to the rejected mediator forever.
 //!
 //! Behind the `didcomm` feature gate so non-DIDComm builds don't pull in the
 //! delivery-layer surface.
@@ -99,7 +101,7 @@ impl ListenerProver for DIDCommServiceProver {
         )
         .await
         {
-            Ok(p) => Arc::new(p),
+            Ok(p) => p,
             Err(e) => {
                 return Err(ProverFailure {
                     stage: HandshakeStage::Connect,
@@ -107,40 +109,93 @@ impl ListenerProver for DIDCommServiceProver {
                 });
             }
         };
-        match tokio::time::timeout(timeout, atm.profile_enable_websocket(&profile)).await {
-            Ok(Ok(())) => {}
-            Ok(Err(e)) => {
+
+        // Register the candidate with the ATM before opening its socket
+        // (`live_stream: false` — the websocket is enabled explicitly, bounded,
+        // below). Registration is what lets the failure path actually stop that
+        // socket: `profile_remove` sends the transport its `Stop`, and nothing
+        // else can, because the transport task transitively owns the only
+        // `Sender` for its own command channel. Before this, a failed handshake
+        // left a live socket reconnecting to the *rejected* mediator for the
+        // VTA's own DID — and repeated attempts against the same candidate
+        // stacked up sockets that then duelled with each other over the
+        // mediator's one-per-DID slot. Same defect and same fix as vta-sdk #830.
+        let profile = match atm.profile_add(&profile, false).await {
+            Ok(p) => p,
+            Err(e) => {
                 return Err(ProverFailure {
                     stage: HandshakeStage::Connect,
-                    cause: format!("enable candidate websocket: {e}"),
+                    cause: format!("register candidate profile: {e}"),
                 });
             }
+        };
+
+        let outcome = self
+            .connect_and_ping(&atm, &service, &profile, &candidate_id, vta_did, timeout)
+            .await;
+
+        if let Err(failure) = outcome {
+            // Best-effort cleanup so the registry doesn't promote an
+            // unreachable mediator — and so its socket does not outlive the
+            // attempt.
+            service.remove_transport(&candidate_id);
+            drop_candidate_socket(&atm, &candidate_id).await;
+            return Err(failure);
+        }
+
+        // The candidate transport stays installed — the caller (`update_didcomm`)
+        // will `promote` it in the registry + delivery service on success. Its
+        // profile stays registered with the ATM for the same reason.
+        Ok(())
+    }
+}
+
+impl DIDCommServiceProver {
+    /// Steps 2–5 with the candidate profile already registered: open its
+    /// websocket, bind + install the transport, and trust-ping the VTA through
+    /// it. Split out so [`prove`](ListenerProver::prove) has one failure path to
+    /// clean up behind, rather than one per early return.
+    async fn connect_and_ping(
+        &self,
+        atm: &affinidi_tdk::messaging::ATM,
+        service: &Arc<affinidi_messaging_delivery::MessagingService>,
+        profile: &Arc<ATMProfile>,
+        candidate_id: &str,
+        vta_did: &str,
+        timeout: Duration,
+    ) -> Result<(), ProverFailure> {
+        let connect_fail = |cause: String| ProverFailure {
+            stage: HandshakeStage::Connect,
+            cause,
+        };
+
+        match tokio::time::timeout(timeout, atm.profile_enable_websocket(profile)).await {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => return Err(connect_fail(format!("enable candidate websocket: {e}"))),
             Err(_) => {
-                return Err(ProverFailure {
-                    stage: HandshakeStage::Connect,
-                    cause: "timeout enabling candidate mediator websocket".to_string(),
-                });
+                return Err(connect_fail(
+                    "timeout enabling candidate mediator websocket".to_string(),
+                ));
             }
         }
+
         let transport: Arc<dyn MessageTransport> =
             match DidCommTransport::new(atm.clone(), profile.clone()).await {
                 Ok(t) => Arc::new(t),
                 Err(e) => {
-                    return Err(ProverFailure {
-                        stage: HandshakeStage::Connect,
-                        cause: format!("bind candidate DidComm transport: {e}"),
-                    });
+                    return Err(connect_fail(format!(
+                        "bind candidate DidComm transport: {e}"
+                    )));
                 }
             };
-        service.add_transport(candidate_id.clone(), transport);
+        service.add_transport(candidate_id.to_string(), transport);
 
         // Steps 4-5: trust-ping the VTA via the candidate transport; the main
         // inbound loop answers the self-ping and the pong routes back through the
         // merged dispatcher, demuxed to this waiter by thread id.
-        let result = self
-            .bridge
+        self.bridge
             .send_and_wait_via(
-                &candidate_id,
+                candidate_id,
                 vta_did, // recipient = self; the mediator forwards it back
                 TRUST_PING_TYPE,
                 json!({ "response_requested": true }),
@@ -148,21 +203,29 @@ impl ListenerProver for DIDCommServiceProver {
                 PROBLEM_REPORT_TYPE,
                 timeout.as_secs(),
             )
-            .await;
-
-        if let Err(e) = result {
-            // Best-effort cleanup so the registry doesn't promote an
-            // unreachable mediator.
-            service.remove_transport(&candidate_id);
-            return Err(ProverFailure {
+            .await
+            .map_err(|e| ProverFailure {
                 stage: HandshakeStage::TrustPing,
                 cause: format!("trust-ping round-trip failed: {e}"),
-            });
-        }
+            })?;
 
-        // The candidate transport stays installed — the caller (`update_didcomm`)
-        // will `promote` it in the registry + delivery service on success.
         Ok(())
+    }
+}
+
+/// Stop a rejected candidate's websocket.
+///
+/// **`profile_remove` only — never `graceful_shutdown` here.** This ATM is the
+/// VTA's live one, shared with the running listener; shutting it down would take
+/// the VTA's own mediator connection with it. Removing the candidate's profile
+/// stops exactly its transport and leaves everything else alone.
+async fn drop_candidate_socket(atm: &affinidi_tdk::messaging::ATM, candidate_id: &str) {
+    if let Err(e) = atm.profile_remove(candidate_id).await {
+        tracing::warn!(
+            candidate = %candidate_id,
+            error = %e,
+            "could not stop the rejected candidate's websocket"
+        );
     }
 }
 

--- a/vta-service/src/messaging/service.rs
+++ b/vta-service/src/messaging/service.rs
@@ -99,16 +99,27 @@ pub async fn build_messaging(
     .await
     .map_err(|e| format!("create ATM: {e}"))?;
 
-    let profile = Arc::new(
-        ATMProfile::new(
-            &atm,
-            None,
-            vta_did.to_string(),
-            Some(mediator_did.to_string()),
-        )
+    let profile = ATMProfile::new(
+        &atm,
+        None,
+        vta_did.to_string(),
+        Some(mediator_did.to_string()),
+    )
+    .await
+    .map_err(|e| format!("create ATM profile: {e}"))?;
+
+    // Register with the ATM (`live_stream: false` — the websocket is enabled
+    // explicitly, bounded, just below). The VTA's listener lives for the whole
+    // process, so this is not about reclaiming anything today; it is what makes
+    // stopping the socket *possible at all*. `ATM::graceful_shutdown` stops
+    // websockets by iterating the profile map, so an unregistered profile's
+    // transport survives every shutdown path there is (vta-sdk #830). A listener
+    // whose socket cannot be stopped short of `exit()` is a trap for the next
+    // person who adds a shutdown path here.
+    let profile = atm
+        .profile_add(&profile, false)
         .await
-        .map_err(|e| format!("create ATM profile: {e}"))?,
-    );
+        .map_err(|e| format!("register ATM profile: {e}"))?;
 
     // Bounded — a `did:webvh` mediator websocket connect can hang.
     match tokio::time::timeout(

--- a/vta-service/src/messaging/transient_handshake.rs
+++ b/vta-service/src/messaging/transient_handshake.rs
@@ -8,16 +8,19 @@
 //! reused. This module spins up a **transient** delivery-layer service just for
 //! the handshake round-trip:
 //!
-//! 1. Build an ATM (seeded with the VTA's secrets) + a bounded-websocket
-//!    [`ATMProfile`] against the new mediator, wrap it in a [`DidCommTransport`],
-//!    and drive it with a single-transport [`MessagingService`] over an
-//!    in-memory outbox.
+//! 1. Build an ATM (seeded with the VTA's secrets) + a **registered**,
+//!    bounded-websocket [`ATMProfile`] against the new mediator, wrap it in a
+//!    [`DidCommTransport`], and drive it with a single-transport
+//!    [`MessagingService`] over an in-memory outbox.
 //! 2. Spawn a minimal trust-ping answerer on `subscribe()` (there is no full
 //!    handler set at first-enable) so the self-ping gets a pong.
 //! 3. Trust-ping the VTA's own DID via the new mediator and await the pong.
-//! 4. Cancel the answerer + drop the service so the websocket tears down.
+//! 4. Cancel the answerer, then `profile_remove` + `graceful_shutdown` the ATM.
 //!
 //! On success or failure the transient service is torn down before returning.
+//! Step 4 is an explicit teardown because **dropping the service and ATM does
+//! not close the websocket** — see [`transient_prove`] for why, and why the
+//! profile must be registered for the teardown to reach it.
 //! The caller (`enable_didcomm`) then publishes the LogEntry and persists
 //! `services.didcomm = true`; the next restart starts the real
 //! [`crate::messaging::service`] path, which re-connects to the now-active
@@ -117,6 +120,22 @@ pub async fn run_transient_handshake(
 
 /// Build a transient single-transport delivery service against `mediator_did`,
 /// prove it with a self trust-ping, then tear it down.
+///
+/// # Teardown is explicit, because dropping does nothing
+///
+/// This used to end with "dropping `service`/`atm` on return closes the
+/// transient websocket". It does not. The websocket transport runs on a spawned
+/// task that transitively owns the only `Sender` for its own command channel
+/// (task → `Arc<ATMProfile>` → `Mediator.ws_channel_tx`), so no handle going out
+/// of scope can end it — it keeps reconnecting for the life of the process,
+/// holding the mediator's one-socket-per-DID slot for the VTA's own DID. Every
+/// first-enable handshake leaked one.
+///
+/// `ATM::graceful_shutdown` is the thing that stops it, but only for profiles
+/// **registered** with the ATM — it stops websockets by iterating the profile
+/// map — and this profile never was. So the fix is both halves: register with
+/// `profile_add`, and tear down on every exit path. Same defect and same fix as
+/// vta-sdk #830.
 async fn transient_prove(
     ctx: &TransientHandshakeContext,
     mediator_did: &str,
@@ -139,25 +158,60 @@ async fn transient_prove(
     for secret in &ctx.secrets {
         tdk.secrets_resolver().insert(secret.clone()).await;
     }
-    let atm = ATM::new(
-        ATMConfig::builder()
-            .build()
-            .map_err(|e| connect_fail(format!("build ATM config: {e}")))?,
-        Arc::new(tdk),
-    )
-    .await
-    .map_err(|e| connect_fail(format!("create ATM: {e}")))?;
-
-    let profile = Arc::new(
-        ATMProfile::new(
-            &atm,
-            Some(mediator_did.to_string()),
-            ctx.vta_did.clone(),
-            Some(mediator_did.to_string()),
+    let atm = Arc::new(
+        ATM::new(
+            ATMConfig::builder()
+                .build()
+                .map_err(|e| connect_fail(format!("build ATM config: {e}")))?,
+            Arc::new(tdk),
         )
         .await
-        .map_err(|e| connect_fail(format!("create transient profile: {e}")))?,
+        .map_err(|e| connect_fail(format!("create ATM: {e}")))?,
     );
+
+    // Past this point the ATM owns a live background task (its deletion
+    // handler), and `prove_on` is about to open a socket. Everything fallible
+    // runs inside it so a single path here can tear both down — one place to get
+    // right, rather than one per `?`.
+    let outcome = prove_on(&atm, ctx, mediator_did, timeout).await;
+
+    // Unconditional: success, ping failure, and every early return inside
+    // `prove_on` land here.
+    teardown_transient(&atm, mediator_did).await;
+    outcome
+}
+
+/// The fallible body of [`transient_prove`], with the transient ATM already
+/// built. Split out so its every exit path is covered by one teardown.
+async fn prove_on(
+    atm: &Arc<ATM>,
+    ctx: &TransientHandshakeContext,
+    mediator_did: &str,
+    timeout: Duration,
+) -> Result<(), ProverFailure> {
+    let connect_fail = |cause: String| ProverFailure {
+        stage: HandshakeStage::Connect,
+        cause,
+    };
+
+    let profile = ATMProfile::new(
+        atm,
+        Some(mediator_did.to_string()),
+        ctx.vta_did.clone(),
+        Some(mediator_did.to_string()),
+    )
+    .await
+    .map_err(|e| connect_fail(format!("create transient profile: {e}")))?;
+
+    // Register BEFORE the socket exists. `live_stream: false` — the websocket is
+    // enabled explicitly (bounded) just below. Registration is what makes the
+    // teardown reach the transport at all; without it `graceful_shutdown` walks
+    // an empty map and the socket outlives the handshake.
+    let profile = atm
+        .profile_add(&profile, false)
+        .await
+        .map_err(|e| connect_fail(format!("register transient profile: {e}")))?;
+
     match tokio::time::timeout(timeout, atm.profile_enable_websocket(&profile)).await {
         Ok(Ok(())) => {}
         Ok(Err(e)) => return Err(connect_fail(format!("enable transient websocket: {e}"))),
@@ -168,9 +222,8 @@ async fn transient_prove(
         }
     }
 
-    let atm = Arc::new(atm);
     let transport: Arc<dyn MessageTransport> = Arc::new(
-        DidCommTransport::new((*atm).clone(), profile.clone())
+        DidCommTransport::new((**atm).clone(), profile.clone())
             .await
             .map_err(|e| connect_fail(format!("bind transient transport: {e}")))?,
     );
@@ -187,13 +240,27 @@ async fn transient_prove(
         answerer_shutdown.clone(),
     );
 
-    let result = ping_self(&service, &atm, &ctx.vta_did, timeout).await;
+    let result = ping_self(&service, atm, &ctx.vta_did, timeout).await;
 
-    // Tear down the answerer; dropping `service`/`atm` on return closes the
-    // transient websocket.
+    // Stop the answerer; the socket itself is stopped by `teardown_transient`.
     answerer_shutdown.cancel();
     tokio::time::sleep(Duration::from_millis(50)).await;
     result
+}
+
+/// Stop the transient ATM's websocket and background tasks.
+///
+/// `profile_remove` is what sends the transport its `Stop` (the alias is the
+/// mediator DID — see the `ATMProfile::new` call above). `graceful_shutdown`
+/// then stops the deletion handler; it would also stop the socket now that the
+/// profile is registered, but removing explicitly keeps the intent legible and
+/// survives a future refactor that shares the ATM. Both are idempotent, and
+/// neither can hang (`graceful_shutdown` is internally bounded).
+async fn teardown_transient(atm: &Arc<ATM>, mediator_did: &str) {
+    if let Err(e) = atm.profile_remove(mediator_did).await {
+        warn!(mediator = %mediator_did, error = %e, "could not remove the transient profile");
+    }
+    atm.graceful_shutdown().await;
 }
 
 /// Trust-ping the VTA's own DID over the transient service and await the pong.

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.11.40"
+version = "0.11.41"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vtc-service/src/messaging.rs
+++ b/vtc-service/src/messaging.rs
@@ -177,16 +177,25 @@ async fn build_messaging(
     .await
     .map_err(|e| format!("create ATM: {e}"))?;
 
-    let profile = Arc::new(
-        ATMProfile::new(
-            &atm,
-            None,
-            vtc_did.to_string(),
-            Some(mediator_did.to_string()),
-        )
+    let profile = ATMProfile::new(
+        &atm,
+        None,
+        vtc_did.to_string(),
+        Some(mediator_did.to_string()),
+    )
+    .await
+    .map_err(|e| format!("create ATM profile: {e}"))?;
+
+    // Register with the ATM (`live_stream: false` — the websocket is enabled
+    // explicitly, bounded, just below). Mirrors `vta-service`'s
+    // `build_messaging`: the listener lives for the whole process, so this is
+    // not about reclaiming anything today, but `ATM::graceful_shutdown` stops
+    // websockets by iterating the profile map — an unregistered profile's
+    // transport survives every shutdown path there is (vta-sdk #830).
+    let profile = atm
+        .profile_add(&profile, false)
         .await
-        .map_err(|e| format!("create ATM profile: {e}"))?,
-    );
+        .map_err(|e| format!("register ATM profile: {e}"))?;
 
     // Bounded — a `did:webvh` mediator websocket connect can hang.
     match tokio::time::timeout(

--- a/vtc-service/src/test_support.rs
+++ b/vtc-service/src/test_support.rs
@@ -780,11 +780,15 @@ mod didcomm_harness {
             holder_secret: Secret,
         ) -> Self {
             let atm = build_atm(transport_secrets).await;
-            let profile = Arc::new(
-                ATMProfile::new(&atm, None, did.clone(), Some(mediator_did.clone()))
-                    .await
-                    .expect("applicant ATM profile"),
-            );
+            let profile = ATMProfile::new(&atm, None, did.clone(), Some(mediator_did.clone()))
+                .await
+                .expect("applicant ATM profile");
+            // Registered so `shutdown` can actually stop the socket — an
+            // unregistered profile's transport outlives every teardown there is.
+            let profile = atm
+                .profile_add(&profile, false)
+                .await
+                .expect("register applicant profile");
             atm.profile_enable_websocket(&profile)
                 .await
                 .expect("applicant websocket");
@@ -803,6 +807,16 @@ mod didcomm_harness {
         /// the VTC sees as the join applicant.
         pub fn did(&self) -> &str {
             &self.did
+        }
+
+        /// Stop this applicant's mediator websocket and the ATM behind it.
+        ///
+        /// Called by [`MockVtcDidcomm::shutdown`]; dropping the client instead
+        /// does nothing, because the websocket transport task owns the only
+        /// `Sender` for its own command channel. `graceful_shutdown` reaches it
+        /// only because `connect` registered the profile with the ATM.
+        pub async fn shutdown(&self) {
+            self.atm.graceful_shutdown().await;
         }
 
         /// A holder signing key (`did:key`) for assembling a `vp_token` from a
@@ -1097,8 +1111,17 @@ mod didcomm_harness {
             self.mediator.did()
         }
 
-        /// Stop the dispatch loop + mediator and wait for a clean wind-down.
+        /// Stop the applicant's socket, the dispatch loop, and the mediator, and
+        /// wait for a clean wind-down.
+        ///
+        /// The applicant goes first, and it is not optional: its websocket
+        /// transport runs on a task that nothing can stop by going out of scope
+        /// (it transitively owns the only `Sender` for its own command channel),
+        /// so a harness that skipped this left one reconnect-looping against a
+        /// dead mediator for the rest of the test binary — every test adding
+        /// another. See `TestJoinClient::shutdown` and vta-sdk #830.
         pub async fn shutdown(mut self) {
+            self.client.shutdown().await;
             if let Some(tx) = self.shutdown_tx.take() {
                 let _ = tx.send(true);
             }


### PR DESCRIPTION
Follow-up to #844 (#830). Reviewing the rest of the workspace for the same defect found it in the services' own mediator plumbing, in two places that **accumulate**.

## The shape, every time

A profile that opens a websocket but is never registered with the ATM. `ATM::graceful_shutdown` stops websockets by *iterating the profile map*, so it walks straight past an unregistered one — and nothing else can stop it either, because the transport task transitively owns the only `Sender` for its own command channel (task → `Arc<ATMProfile>` → `Mediator.ws_channel_tx`). No handle going out of scope ends it.

## What leaks, and how often

**`vta-service/src/messaging/transient_handshake.rs` — one socket per first-enable.** Its teardown was a comment:

> *"Tear down the answerer; dropping `service`/`atm` on return closes the transient websocket."*

It does not. I reproduced the exact construction against a live test mediator, dropped the ATM, and the socket was still up. So every `services didcomm enable` left a socket reconnecting to that mediator, for the VTA's own DID, for the life of the process.

Now: the profile is registered (`profile_add`), and the ATM is torn down explicitly (`profile_remove` + `graceful_shutdown`) on **every** exit path — success, ping failure, and each early return in the build sequence. The fallible body moved into `prove_on` so there is one teardown rather than one per `?`.

**`vta-service/src/messaging/live_prover.rs` — one socket per failed `services didcomm update`.** The failure path called `service.remove_transport(&candidate_id)`, which unbinds the transport from the delivery layer and does nothing to the socket. Repeated attempts against the same candidate stacked up live sockets for the same DID on the same mediator, which then duelled over its one-per-DID slot — the churn signature from the mediator storm.

Now: the candidate is registered and its socket stopped with `profile_remove` on failure. Deliberately **not** `graceful_shutdown` — that ATM is the VTA's live one, and shutting it down would take the running listener with it. There's a comment saying so, because it is exactly the kind of thing a later edit gets wrong.

## Also registered (low severity, deliberate)

`vta-service::messaging::service::build_messaging` and `vtc-service::messaging::build_messaging` now register their profiles. Both run once per process, so nothing is reclaimed today — the point is that a listener whose socket cannot be stopped short of `exit()` is a trap for whoever adds a shutdown path next.

`vtc-service`'s `test_support::MockVtcDidcomm::shutdown` now shuts the applicant client down. Each test previously left a socket reconnect-looping against a dead mediator for the rest of the test binary. Applicant DIDs are per-harness, so this was noise rather than a same-DID duel — but it is noise under exactly the timing the DIDComm tests are sensitive to.

## Not affected (checked)

The three `server.rs` sites (TSP profile, inbox drain, outbox flush) all use `profile_add(_, false)` with no socket. `vta-sdk/src/acl_setup.rs` builds a profile with no websocket. Both `status.rs` probes are one-shot CLI paths that exit immediately.

## The regression test

`tests/e2e/tests/transient_handshake.rs::transient_handshake_leaves_no_socket_behind` needed a lever to observe "no socket left", and the mediator has one: a per-DID connection cap that **refuses** the new connection (POLICY close, "per-DID connection limit reached") rather than evicting the old. With the cap at 1, a second handshake for the same DID can only succeed if the first one's socket is really gone.

Verified in both directions — it passes with the fix, and on the pre-fix shape it fails with:

```
Failed { stage: TrustPing, cause: "trust-ping round-trip failed: ...
  WebSocket message not transmitted: websocket is not connected" }
```

## Checks

Workspace `cargo check --all-targets` and `clippy` clean (the one warning, `vta-service/src/operations/acl.rs:626` "items after a test module", is pre-existing on main from #842 and untouched here). `cargo fmt --check` clean. Full e2e suite green (161 tests across 10 binaries), `vta-service` green (713 + 293 across its binaries), `vtc-service` green (685 + integration binaries, `admin_ui` skipped per `VTC_SKIP_ADMIN_UI_BUILD`). All three repo guards pass.