### PR TITLE
fix(messaging): clear the last unregistered mediator sockets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,44 @@
 
 ## Unreleased
 
+### vta-service 0.13.4 / vtc-service 0.11.42 — the last of the unregistered mediator sockets
+
+#846 fixed the two sites where the unregistered-profile defect actually leaked
+per operation. This clears the rest of the class, so `profile_enable_websocket`
+has no remaining caller in the workspace whose socket outlives its teardown.
+
+Nothing here leaks in production today — every site is either a one-shot CLI
+that exits immediately or test-only. They are fixed because the *shape* is the
+trap: a profile that opens a websocket without being registered with the ATM is
+invisible to `ATM::graceful_shutdown`, which stops sockets by iterating the
+profile map, and the transport task cannot be stopped any other way (it
+transitively owns the only `Sender` for its own command channel).
+
+- **`vta status` / `vtc status` trust-ping probes.** Two defects, not one: the
+  profile was unregistered *and* the `?` on `profile_enable_websocket` /
+  `send_ping` returned past `graceful_shutdown` entirely. Both probes now
+  register the profile and run the fallible body so a single path tears the ATM
+  down on success and failure alike.
+- **`didcomm-test`.** Its `graceful_shutdown` was a no-op for the same reason.
+  This tool exists to debug DIDComm connectivity, so a ghost socket outliving
+  the run is more misleading here than anywhere.
+- **e2e helpers** (`test_vta_responder`'s two constructors, `tsp_round_trip`'s
+  pickup socket) — each test left a socket reconnect-looping against a
+  shut-down mediator for the rest of the binary.
+
+Also: `vta-service/src/operations/acl.rs` moves the canonical `acl/*` adapter
+block above `mod tests`, clearing the `items_after_test_module` warning left by
+#842. A pure move — 147 lines out, 147 lines in — no behaviour change. The
+workspace now builds clippy-clean with no warnings.
+
+Assessed and deliberately unchanged: `vta_sdk::session::challenge_response`
+builds a TDK + ATM per login purely to pack one message. It has no profile and
+no socket, and #844 already made it shut that ATM down on every path, so there
+is nothing left to leak. Moving it onto `didcomm_light`'s packer would drop the
+ATM entirely but swaps authcrypt for anoncrypt — a wire and sender-authentication
+change, not a cleanup. REST-only consumers should keep using
+`auth_light::challenge_response_light`, which needs no ATM at all.
+
 ### vta-service 0.13.3 / vtc-service 0.11.41 — the mediator handshakes stop leaking websockets
 
 The defect #830 fixed in `vta-sdk` was also present, unfixed, in the services'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10331,7 +10331,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",
@@ -10564,7 +10564,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-service"
-version = "0.11.41"
+version = "0.11.42"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/didcomm-test/src/main.rs
+++ b/didcomm-test/src/main.rs
@@ -189,7 +189,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let profile = ATMProfile::new(&atm, None, did.clone(), Some(args.mediator_did.clone()))
         .await
         .map_err(|e| format!("ATM profile: {e}"))?;
-    let profile = Arc::new(profile);
+    // Registered so the `graceful_shutdown` at the end of the run actually
+    // stops this socket. This tool exists to debug DIDComm connectivity, so a
+    // ghost socket outliving the run is worse here than anywhere (vta-sdk #830).
+    let profile = atm
+        .profile_add(&profile, false)
+        .await
+        .map_err(|e| format!("register profile: {e}"))?;
 
     // Enable WebSocket (triggers auth + live streaming)
     atm.profile_enable_websocket(&profile)

--- a/tests/e2e/tests/common/test_vta_responder.rs
+++ b/tests/e2e/tests/common/test_vta_responder.rs
@@ -154,7 +154,14 @@ impl TestVtaResponder {
         let profile = ATMProfile::new(&atm, None, did.clone(), Some(mediator_did.to_string()))
             .await
             .map_err(|e| ResponderError::Profile(e.to_string()))?;
-        let profile = Arc::new(profile);
+        // Registered so the dispatch loop's `graceful_shutdown` can actually
+        // stop this socket — it stops websockets by iterating the ATM's profile
+        // map, so an unregistered one outlives every teardown and keeps
+        // reconnecting for the rest of the test binary (vta-sdk #830).
+        let profile = atm
+            .profile_add(&profile, false)
+            .await
+            .map_err(|e| ResponderError::Profile(e.to_string()))?;
 
         // 3. Open inbound WebSocket so live_stream_next has a channel.
         atm.profile_enable_websocket(&profile)
@@ -258,7 +265,14 @@ impl TestVtaResponder {
         let profile = ATMProfile::new(&atm, None, did.clone(), Some(mediator_did.to_string()))
             .await
             .map_err(|e| ResponderError::Profile(e.to_string()))?;
-        let profile = Arc::new(profile);
+        // Registered so the dispatch loop's `graceful_shutdown` can actually
+        // stop this socket — it stops websockets by iterating the ATM's profile
+        // map, so an unregistered one outlives every teardown and keeps
+        // reconnecting for the rest of the test binary (vta-sdk #830).
+        let profile = atm
+            .profile_add(&profile, false)
+            .await
+            .map_err(|e| ResponderError::Profile(e.to_string()))?;
 
         atm.profile_enable_websocket(&profile)
             .await

--- a/tests/e2e/tests/tsp_round_trip.rs
+++ b/tests/e2e/tests/tsp_round_trip.rs
@@ -275,6 +275,12 @@ async fn tsp_frame_arrives_on_the_pickup_socket() {
         .await
         .expect("profile"),
     );
+    // Registered so `graceful_shutdown` below can stop it; an unregistered
+    // profile's socket survives every teardown (vta-sdk #830).
+    let profile = atm
+        .profile_add(&profile, false)
+        .await
+        .expect("register pickup profile");
     atm.profile_enable_websocket(&profile)
         .await
         .expect("enable pickup websocket");

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.13.3"
+version = "0.13.4"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/operations/acl.rs
+++ b/vta-service/src/operations/acl.rs
@@ -622,6 +622,153 @@ pub async fn swap_acl(
     Ok(to_result_body(&entry))
 }
 
+// ---------------------------------------------------------------------------
+// Canonical `acl/*` adapters (#840 phase A)
+// ---------------------------------------------------------------------------
+//
+// The functions above take the maintainer's internal argument shape and are
+// unchanged by the fold; these adapt the canonical wire types onto them.
+//
+// Keeping the mapping in one place rather than in each transport's handler is
+// deliberate: REST, DIDComm and the trust-task dispatcher all reach the same
+// operation, and three copies of "which wire member becomes which argument" is
+// three chances for them to disagree about, say, whether an absent `approve`
+// confers nothing.
+
+// Aliased: `AclEntry` is already the *stored* type in this module. The wire
+// form and the stored form are deliberately different shapes, so keeping both
+// names visible stops one being mistaken for the other.
+use vta_sdk::protocols::acl_management::entry::{AclEntry as WireAclEntry, to_epoch};
+
+/// `acl/grant/0.1` → [`create_acl`].
+pub async fn grant_from_entry(
+    acl_ks: &KeyspaceHandle,
+    audit_ks: &KeyspaceHandle,
+    contexts_ks: &KeyspaceHandle,
+    auth: &AuthClaims,
+    entry: WireAclEntry,
+    channel: &str,
+) -> Result<CreateAclResponseBody, AppError> {
+    let role = Role::parse(&entry.role)
+        .map_err(|_| AppError::Validation(format!("invalid role: {}", entry.role)))?;
+    let stored = create_acl(
+        acl_ks,
+        audit_ks,
+        contexts_ks,
+        auth,
+        &entry.subject,
+        role,
+        entry.label.clone(),
+        entry.scopes.clone(),
+        entry.expires_at.map(to_epoch),
+        entry.step_up_approver(),
+        entry.step_up_require(),
+        entry.approve_scope(),
+        channel,
+    )
+    .await?;
+    Ok(CreateAclResponseBody {
+        entry: WireAclEntry::from_result(&stored),
+    })
+}
+
+/// `acl/show/0.1` → [`get_acl`].
+pub async fn show_by_subject(
+    acl_ks: &KeyspaceHandle,
+    auth: &AuthClaims,
+    subject: &str,
+    channel: &str,
+) -> Result<GetAclResultBody, AppError> {
+    let stored = get_acl(acl_ks, auth, subject, channel).await?;
+    Ok(GetAclResultBody {
+        entry: WireAclEntry::from_result(&stored),
+        // Nothing is withheld from a caller already authorized to read the
+        // entry, so the list is empty rather than absent — an explicit "we
+        // redacted nothing" beats leaving the caller to infer it.
+        redacted_fields: Vec::new(),
+    })
+}
+
+/// `acl/list/0.1` → [`list_acl`].
+pub async fn list_entries(
+    acl_ks: &KeyspaceHandle,
+    auth: &AuthClaims,
+    scope: Option<&str>,
+    direction: ContextDirection,
+    channel: &str,
+) -> Result<ListAclResultBody, AppError> {
+    let stored = list_acl(acl_ks, auth, scope, direction, channel).await?;
+    Ok(ListAclResultBody {
+        entries: stored.iter().map(WireAclEntry::from_result).collect(),
+        // This maintainer returns every matching entry in one response, so the
+        // page is never partial. Saying so explicitly is the point of the
+        // member: a caller must never have to infer completeness from length,
+        // which is how a truncated revocation sweep reads as a finished one.
+        truncated: false,
+        cursor: None,
+        redacted_fields: Vec::new(),
+    })
+}
+
+/// `acl/update/0.1` → [`update_acl`].
+pub async fn update_from_params(
+    acl_ks: &KeyspaceHandle,
+    audit_ks: &KeyspaceHandle,
+    contexts_ks: &KeyspaceHandle,
+    auth: &AuthClaims,
+    subject: &str,
+    params: UpdateAclParams,
+    channel: &str,
+) -> Result<CreateAclResponseBody, AppError> {
+    let stored = update_acl(
+        acl_ks,
+        audit_ks,
+        contexts_ks,
+        auth,
+        subject,
+        params,
+        channel,
+    )
+    .await?;
+    Ok(CreateAclResponseBody {
+        entry: WireAclEntry::from_result(&stored),
+    })
+}
+
+/// `acl/revoke/0.1` → [`delete_acl`].
+///
+/// Canonical revoke has a scope-reduction mode (`scopes` lists what to
+/// withdraw, the entry survives). This maintainer implements full removal
+/// only, and **refuses** a scoped request rather than treating it as a full
+/// removal — silently taking the whole entry when the caller asked to withdraw
+/// one scope removes far more authority than was requested, which is not a
+/// direction to guess in.
+pub async fn revoke_by_subject(
+    acl_ks: &KeyspaceHandle,
+    audit_ks: &KeyspaceHandle,
+    auth: &AuthClaims,
+    subject: &str,
+    scopes: Option<Vec<String>>,
+    channel: &str,
+) -> Result<DeleteAclResultBody, AppError> {
+    if let Some(scopes) = scopes.filter(|s| !s.is_empty()) {
+        return Err(AppError::Validation(format!(
+            "scope reduction is not supported by this maintainer — `scopes` named {} entr{}, \
+             but only full revocation is implemented. Omit `scopes` to remove the entry.",
+            scopes.len(),
+            if scopes.len() == 1 { "y" } else { "ies" }
+        )));
+    }
+    // Read before removing so the response carries what was actually
+    // withdrawn. Canonical revoke returns the entry, not a boolean: a bare
+    // `deleted: true` cannot tell an auditor what authority was lost.
+    let stored = get_acl(acl_ks, auth, subject, channel).await?;
+    delete_acl(acl_ks, audit_ks, auth, subject, channel).await?;
+    Ok(DeleteAclResultBody {
+        entry: WireAclEntry::from_result(&stored),
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1607,151 +1754,4 @@ mod tests {
         .unwrap_err();
         assert!(matches!(err, AppError::NotFound(_)), "got {err:?}");
     }
-}
-
-// ---------------------------------------------------------------------------
-// Canonical `acl/*` adapters (#840 phase A)
-// ---------------------------------------------------------------------------
-//
-// The functions above take the maintainer's internal argument shape and are
-// unchanged by the fold; these adapt the canonical wire types onto them.
-//
-// Keeping the mapping in one place rather than in each transport's handler is
-// deliberate: REST, DIDComm and the trust-task dispatcher all reach the same
-// operation, and three copies of "which wire member becomes which argument" is
-// three chances for them to disagree about, say, whether an absent `approve`
-// confers nothing.
-
-// Aliased: `AclEntry` is already the *stored* type in this module. The wire
-// form and the stored form are deliberately different shapes, so keeping both
-// names visible stops one being mistaken for the other.
-use vta_sdk::protocols::acl_management::entry::{AclEntry as WireAclEntry, to_epoch};
-
-/// `acl/grant/0.1` → [`create_acl`].
-pub async fn grant_from_entry(
-    acl_ks: &KeyspaceHandle,
-    audit_ks: &KeyspaceHandle,
-    contexts_ks: &KeyspaceHandle,
-    auth: &AuthClaims,
-    entry: WireAclEntry,
-    channel: &str,
-) -> Result<CreateAclResponseBody, AppError> {
-    let role = Role::parse(&entry.role)
-        .map_err(|_| AppError::Validation(format!("invalid role: {}", entry.role)))?;
-    let stored = create_acl(
-        acl_ks,
-        audit_ks,
-        contexts_ks,
-        auth,
-        &entry.subject,
-        role,
-        entry.label.clone(),
-        entry.scopes.clone(),
-        entry.expires_at.map(to_epoch),
-        entry.step_up_approver(),
-        entry.step_up_require(),
-        entry.approve_scope(),
-        channel,
-    )
-    .await?;
-    Ok(CreateAclResponseBody {
-        entry: WireAclEntry::from_result(&stored),
-    })
-}
-
-/// `acl/show/0.1` → [`get_acl`].
-pub async fn show_by_subject(
-    acl_ks: &KeyspaceHandle,
-    auth: &AuthClaims,
-    subject: &str,
-    channel: &str,
-) -> Result<GetAclResultBody, AppError> {
-    let stored = get_acl(acl_ks, auth, subject, channel).await?;
-    Ok(GetAclResultBody {
-        entry: WireAclEntry::from_result(&stored),
-        // Nothing is withheld from a caller already authorized to read the
-        // entry, so the list is empty rather than absent — an explicit "we
-        // redacted nothing" beats leaving the caller to infer it.
-        redacted_fields: Vec::new(),
-    })
-}
-
-/// `acl/list/0.1` → [`list_acl`].
-pub async fn list_entries(
-    acl_ks: &KeyspaceHandle,
-    auth: &AuthClaims,
-    scope: Option<&str>,
-    direction: ContextDirection,
-    channel: &str,
-) -> Result<ListAclResultBody, AppError> {
-    let stored = list_acl(acl_ks, auth, scope, direction, channel).await?;
-    Ok(ListAclResultBody {
-        entries: stored.iter().map(WireAclEntry::from_result).collect(),
-        // This maintainer returns every matching entry in one response, so the
-        // page is never partial. Saying so explicitly is the point of the
-        // member: a caller must never have to infer completeness from length,
-        // which is how a truncated revocation sweep reads as a finished one.
-        truncated: false,
-        cursor: None,
-        redacted_fields: Vec::new(),
-    })
-}
-
-/// `acl/update/0.1` → [`update_acl`].
-pub async fn update_from_params(
-    acl_ks: &KeyspaceHandle,
-    audit_ks: &KeyspaceHandle,
-    contexts_ks: &KeyspaceHandle,
-    auth: &AuthClaims,
-    subject: &str,
-    params: UpdateAclParams,
-    channel: &str,
-) -> Result<CreateAclResponseBody, AppError> {
-    let stored = update_acl(
-        acl_ks,
-        audit_ks,
-        contexts_ks,
-        auth,
-        subject,
-        params,
-        channel,
-    )
-    .await?;
-    Ok(CreateAclResponseBody {
-        entry: WireAclEntry::from_result(&stored),
-    })
-}
-
-/// `acl/revoke/0.1` → [`delete_acl`].
-///
-/// Canonical revoke has a scope-reduction mode (`scopes` lists what to
-/// withdraw, the entry survives). This maintainer implements full removal
-/// only, and **refuses** a scoped request rather than treating it as a full
-/// removal — silently taking the whole entry when the caller asked to withdraw
-/// one scope removes far more authority than was requested, which is not a
-/// direction to guess in.
-pub async fn revoke_by_subject(
-    acl_ks: &KeyspaceHandle,
-    audit_ks: &KeyspaceHandle,
-    auth: &AuthClaims,
-    subject: &str,
-    scopes: Option<Vec<String>>,
-    channel: &str,
-) -> Result<DeleteAclResultBody, AppError> {
-    if let Some(scopes) = scopes.filter(|s| !s.is_empty()) {
-        return Err(AppError::Validation(format!(
-            "scope reduction is not supported by this maintainer — `scopes` named {} entr{}, \
-             but only full revocation is implemented. Omit `scopes` to remove the entry.",
-            scopes.len(),
-            if scopes.len() == 1 { "y" } else { "ies" }
-        )));
-    }
-    // Read before removing so the response carries what was actually
-    // withdrawn. Canonical revoke returns the entry, not a boolean: a bare
-    // `deleted: true` cannot tell an auditor what authority was lost.
-    let stored = get_acl(acl_ks, auth, subject, channel).await?;
-    delete_acl(acl_ks, audit_ks, auth, subject, channel).await?;
-    Ok(DeleteAclResultBody {
-        entry: WireAclEntry::from_result(&stored),
-    })
 }

--- a/vta-service/src/status.rs
+++ b/vta-service/src/status.rs
@@ -381,26 +381,38 @@ async fn send_trust_ping(
         tdk.secrets_resolver().insert(ka_secret).await;
     }
 
-    let atm = ATM::new(ATMConfig::builder().build()?, Arc::new(tdk)).await?;
+    let atm = Arc::new(ATM::new(ATMConfig::builder().build()?, Arc::new(tdk)).await?);
 
-    let profile = ATMProfile::new(
-        &atm,
-        None,
-        vta_did.to_string(),
-        Some(mediator_did.to_string()),
-    )
-    .await?;
-    let profile = Arc::new(profile);
-
-    // The mediator may only expose a wss:// endpoint (no REST/https).
-    atm.profile_enable_websocket(&profile).await?;
-
-    let start = Instant::now();
-    TrustPing::default()
-        .send_ping(&atm, &profile, mediator_did, true, true, true)
+    // Everything past the ATM runs inside the block so ONE path tears it down.
+    // Both `?`s below used to return past `graceful_shutdown` entirely, and that
+    // shutdown could not have stopped the socket anyway — it stops websockets by
+    // iterating the ATM's profile map, and this profile was never registered
+    // (vta-sdk #830). `vta status` exits straight after, so nothing was harmed;
+    // the shape is the trap. Stringified before the teardown await: a boxed
+    // error is not `Send`.
+    let outcome = async {
+        let profile = ATMProfile::new(
+            &atm,
+            None,
+            vta_did.to_string(),
+            Some(mediator_did.to_string()),
+        )
         .await?;
-    let elapsed = start.elapsed().as_millis();
+        // Registered, so the teardown below can actually reach the socket.
+        let profile = atm.profile_add(&profile, false).await?;
+
+        // The mediator may only expose a wss:// endpoint (no REST/https).
+        atm.profile_enable_websocket(&profile).await?;
+
+        let start = Instant::now();
+        TrustPing::default()
+            .send_ping(&atm, &profile, mediator_did, true, true, true)
+            .await?;
+        Ok::<u128, Box<dyn std::error::Error>>(start.elapsed().as_millis())
+    }
+    .await
+    .map_err(|e| e.to_string());
 
     atm.graceful_shutdown().await;
-    Ok(elapsed)
+    outcome.map_err(Into::into)
 }

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.11.41"
+version = "0.11.42"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vtc-service/src/status.rs
+++ b/vtc-service/src/status.rs
@@ -287,28 +287,37 @@ async fn send_trust_ping(
     ka_secret.id = format!("{vtc_did}#key-1");
     tdk.secrets_resolver().insert(ka_secret).await;
 
-    let atm = ATM::new(ATMConfig::builder().build()?, Arc::new(tdk)).await?;
+    let atm = Arc::new(ATM::new(ATMConfig::builder().build()?, Arc::new(tdk)).await?);
 
-    let profile = ATMProfile::new(
-        &atm,
-        None,
-        vtc_did.to_string(),
-        Some(mediator_did.to_string()),
-    )
-    .await?;
-    let profile = Arc::new(profile);
-
-    // The mediator may only expose a wss:// endpoint (no REST/https).
-    atm.profile_enable_websocket(&profile).await?;
-
-    let start = Instant::now();
-    TrustPing::default()
-        .send_ping(&atm, &profile, mediator_did, true, true, true)
+    // Mirrors `vta-service::status`: everything past the ATM runs inside the
+    // block so ONE path tears it down (both `?`s below used to return past the
+    // shutdown), and the profile is registered so that shutdown can reach the
+    // websocket at all — it stops sockets by iterating the ATM's profile map
+    // (vta-sdk #830). Stringified first: a boxed error is not `Send`.
+    let outcome = async {
+        let profile = ATMProfile::new(
+            &atm,
+            None,
+            vtc_did.to_string(),
+            Some(mediator_did.to_string()),
+        )
         .await?;
-    let elapsed = start.elapsed().as_millis();
+        let profile = atm.profile_add(&profile, false).await?;
+
+        // The mediator may only expose a wss:// endpoint (no REST/https).
+        atm.profile_enable_websocket(&profile).await?;
+
+        let start = Instant::now();
+        TrustPing::default()
+            .send_ping(&atm, &profile, mediator_did, true, true, true)
+            .await?;
+        Ok::<u128, Box<dyn std::error::Error>>(start.elapsed().as_millis())
+    }
+    .await
+    .map_err(|e| e.to_string());
 
     atm.graceful_shutdown().await;
-    Ok(elapsed)
+    outcome.map_err(Into::into)
 }
 
 /// Report the agent names a resolved DID Document claims via `alsoKnownAs`.


### PR DESCRIPTION
Follow-up to #846, closing out the flagged remainder. #846 fixed the two sites that leaked **per operation**; this clears the rest of the class, so `profile_enable_websocket` has no remaining caller in the workspace whose socket outlives its teardown.

## Nothing here leaks in production

Every site is a one-shot CLI that exits immediately, or test-only. They are fixed because the *shape* is the trap: a profile that opens a websocket without being registered with the ATM is invisible to `ATM::graceful_shutdown` (which stops sockets by iterating the profile map), and nothing else can stop the transport task — it transitively owns the only `Sender` for its own command channel. Left in place, these are four working examples of the pattern for the next person to copy.

- **`vta status` / `vtc status` trust-ping probes** — two defects, not one. The profile was unregistered *and* the `?` on `profile_enable_websocket` / `send_ping` returned past `graceful_shutdown` entirely, so a failing probe never even reached its teardown. Both now register the profile and run the fallible body so one path tears the ATM down on success and failure alike.
- **`didcomm-test`** — its `graceful_shutdown` was a no-op for the same reason. This tool exists to debug DIDComm connectivity, so a ghost socket outliving the run is more misleading here than anywhere.
- **e2e helpers** — `test_vta_responder`'s two constructors and `tsp_round_trip`'s pickup socket. Each test left one reconnect-looping against a shut-down mediator for the rest of the binary.

## The clippy warning

`vta-service/src/operations/acl.rs` moves the canonical `acl/*` adapter block above `mod tests`, clearing the `items_after_test_module` warning #842 left behind. A pure move — 147 lines out, 147 lines in, no behaviour change — so the diff reads large but says nothing. **The workspace now builds clippy-clean with no warnings at all.**

## Assessed and deliberately unchanged

`vta_sdk::session::challenge_response` builds a TDK + ATM per login purely to pack one message. I flagged it earlier, but on inspection there is nothing left to fix: it has no profile and no socket, and #844 already made it shut that ATM down on every path including the error return. What remains is cost, not a leak.

Moving it onto `didcomm_light`'s packer would drop the ATM entirely — but that packer is **anoncrypt** (`pack_anoncrypt`), where this path is **authcrypt** (`pack_encrypted(.., Some(client_did), ..)`). That is a change to how the VTA authenticates the sender, not a cleanup, so it does not belong in a follow-up PR. REST-only consumers should keep using `auth_light::challenge_response_light`, which needs no ATM at all.

## Checks

Workspace `cargo check --all-targets` and `clippy --all-targets` clean (zero warnings). `cargo fmt --check` clean. Full e2e suite green (161 tests / 10 binaries), `vta-service` green (713 lib + integration binaries), `vtc-service` lib green (685, `admin_ui` skipped per `VTC_SKIP_ADMIN_UI_BUILD`). All three repo guards pass.