### PR TITLE
feat(audit): fold vta/audit/list-logs onto canonical audit/list/0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,82 @@
 
 ## Unreleased
 
+### vti-common 0.11.29 / vta-sdk 0.20.13 / vta-service 0.13.5 / vta-cli-common 0.10.19 / pnm-cli 0.11.13 — `vta/audit/list-logs` folds onto canonical `audit/list/0.1`
+
+The last item of #840 phase A, and the only one that was never a rename. The
+VTA now serves canonical `audit/list/0.1`; `spec/vta/audit/list-logs/1.0` is
+retired, taking the unpublished-canonical count for `spec/vta/` from 47 to
+**46**. Phase A is complete.
+
+**Offset paging → opaque cursor.** The old surface took a 1-based `page` and
+returned `total` / `totalPages`. An offset is only stable if nothing is
+appended while a consumer walks the pages — and the audit log is, by
+definition, appended to constantly, including by the very reads being paged.
+Page 2 of a log that grew by ten rows silently re-shows rows from page 1 and
+skips others. Paging is now by opaque continuation cursor over the storage key
+(`log:{timestamp}:{uuid}`), which is a stable position under concurrent
+appends. Responses carry `truncated` plus a `cursor` present iff truncated.
+
+`truncated` means "more *matching* entries remain", not "more rows remain": with
+a filter applied the tail may hold nothing that matches, and returning a cursor
+for an empty next page would read as results being withheld.
+
+**Cursors are signed and bound.** Canonical requires a cursor that cannot be
+forged into a position the filters did not authorize. The cursor's HMAC covers
+the filters *and the caller's DID* — so resuming under a changed filter set is
+refused rather than silently answered from another query's position, and a
+leaked cursor is not a cross-principal read. Signing uses a new
+`vti_common::pagination::CursorKey`: a random 32-byte key created once and
+persisted in the audit keyspace. Deliberately **not** seed-derived — a cursor
+carries no long-term secret, and a key that a backup+restore does not reproduce
+is the safer default, since a cursor minted against one database should not
+resolve to a position in another.
+
+**A context-scoped admin could read every context's audit entries.** Found
+while diffing against canonical, which states the gate directly: this is the
+tightest-gated read a maintainer offers, and a context-scoped admin does not
+qualify for the whole-log tail. The VTA's gate was `require_admin()`, which
+tests only the role and ignores `allowed_contexts` entirely — so an admin
+deliberately confined to one context could read the whole agent's activity,
+every other context included. Now an unrestricted admin reads anything, and a
+scoped admin must name a `contextId` within their own scope. Same defect class
+as #746 / #769 / #770, and fixed the same way: through `is_super_admin` /
+`has_context_access`, never by testing `allowed_contexts` directly.
+
+**Behaviour changes an operator will notice:**
+
+- `action` and `outcome` now match on **equality**, not substring. Asking for
+  `action=vault.delete` no longer also returns `vault.delete_force` — the old
+  behaviour quietly widened a query, so an operator could not tell which rows
+  they had actually asked for.
+- `to` is now **exclusive** (canonical), previously inclusive.
+- `from` / `to` are RFC 3339, not epoch seconds — on the wire and on the CLI.
+- Query params are camelCase (`pageSize`, `contextId`), per R3.1. They were
+  snake_case, which the canonical route binding would have dropped silently.
+- Max page size is 200 (the workspace-wide pagination cap), was 500.
+- `pnm audit list --page N` is replaced by `--cursor <token>`; the command
+  prints the continuation token when more entries remain.
+
+Entries are returned as the canonical camelCase `AuditEnvelope` (`eventId`,
+`recordedAt` as RFC 3339, `target`, `contextId`). The **stored** row shape is
+untouched — `AuditLogEntry` is the on-disk format for the audit keyspace, so
+renaming its fields would orphan every existing row; the envelope is built from
+it at the response boundary. The VTA's `channel` and free-text `reason`, which
+have no canonical envelope field, ride in `detail`.
+
+**An invalid cursor is now a caller fault on every transport.** REST already
+answered 400, but `AppError::InvalidCursor` sat in the catch-all arm of both the
+Trust-Task reject mapping (`internal_error`) and the DIDComm problem-report
+mapping (`e.p.msg.internal-error`). A consumer told "internal error" retries the
+same cursor; the correct response — and the one canonical asks for — is to
+restart from the first page. Both now map to malformed-request / bad-request.
+
+Two round-trip cases were added to `vta-service/tests/client_round_trip.rs`
+(the real client against the real router): one asserting the envelope arrives
+populated and the cursor actually advances past page one, one asserting a
+changed filter is refused. Both were mutation-verified — with the binding
+removed and with the resume position ignored, each fails for its own reason.
+
 ### vta-service 0.13.4 / vtc-service 0.11.42 — the last of the unregistered mediator sockets
 
 #846 fixed the two sites where the unregistered-profile defect actually leaked

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6759,7 +6759,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "pnm-cli"
-version = "0.11.12"
+version = "0.11.13"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-resolver-cache-sdk",
@@ -10118,7 +10118,7 @@ dependencies = [
 
 [[package]]
 name = "vta-cli-common"
-version = "0.10.18"
+version = "0.10.19"
 dependencies = [
  "aes-gcm",
  "affinidi-crypto",
@@ -10269,7 +10269,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.20.12"
+version = "0.20.13"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10331,7 +10331,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",
@@ -10646,7 +10646,7 @@ dependencies = [
 
 [[package]]
 name = "vti-common"
-version = "0.11.28"
+version = "0.11.29"
 dependencies = [
  "aes-gcm",
  "affinidi-data-integrity",

--- a/docs/05-design-notes/trust-task-uri-registry.md
+++ b/docs/05-design-notes/trust-task-uri-registry.md
@@ -145,7 +145,7 @@ URL was misleading). See `spec/vta/seeds/export-mnemonic/1.0`.
 
 | URI | Today's surface |
 |---|---|
-| `spec/vta/audit/list-logs/1.0` | `GET /audit/logs` + DIDComm `list-logs` |
+| `audit/list/0.1` (canonical) | `GET /audit/logs` + DIDComm `list-logs` |
 | `spec/vta/audit/get-retention/1.0` | DIDComm `get-retention` + REST |
 | `spec/vta/audit/update-retention/1.0` | DIDComm `update-retention` + REST |
 
@@ -430,11 +430,11 @@ REST:
   GET    /contexts/{id}                             → vta/contexts/get/1.0
   PATCH  /contexts/{id}                             → vta/contexts/update/1.0
   DELETE /contexts/{id}                             → vta/contexts/delete/1.0
-  GET    /acl                                       → vta/acl/list/1.0
-  POST   /acl                                       → vta/acl/create/1.0
-  PATCH  /acl/{did}                                 → vta/acl/update/1.0
-  DELETE /acl/{did}                                 → vta/acl/delete/1.0
-  GET    /audit/logs                                → vta/audit/list-logs/1.0
+  GET    /acl                                       → acl/list/0.1
+  POST   /acl                                       → acl/grant/0.1
+  PATCH  /acl/{did}                                 → acl/update/0.1
+  DELETE /acl/{did}                                 → acl/revoke/0.1
+  GET    /audit/logs                                → audit/list/0.1
   GET    /attestation/status                        → vta/attestation/status/1.0
   GET    /attestation/did-log                       → vta/attestation/did-log/1.0
   GET    /services                                  → vta/services/list/1.0

--- a/pnm-cli/Cargo.toml
+++ b/pnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pnm-cli"
 description = "CLI Tool for managing a personal Verifiable Trust Agent"
-version = "0.11.12"
+version = "0.11.13"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/pnm-cli/src/cli.rs
+++ b/pnm-cli/src/cli.rs
@@ -2170,30 +2170,31 @@ pub(crate) enum AuthCredentialCommands {
 pub(crate) enum AuditCommands {
     /// List audit log entries with optional filtering
     List {
-        /// Start time (unix epoch seconds)
+        /// Start time, RFC 3339 (e.g. 2026-07-01T00:00:00Z). Inclusive.
         #[arg(long)]
-        from: Option<u64>,
-        /// End time (unix epoch seconds)
+        from: Option<chrono::DateTime<chrono::Utc>>,
+        /// End time, RFC 3339. Exclusive.
         #[arg(long)]
-        to: Option<u64>,
-        /// Filter by action (e.g. "auth.challenge", "key.create")
+        to: Option<chrono::DateTime<chrono::Utc>>,
+        /// Filter by action — exact match (e.g. "auth.challenge", "key.create")
         #[arg(long)]
         action: Option<String>,
         /// Filter by actor DID
         #[arg(long)]
         actor: Option<String>,
-        /// Filter by outcome (e.g. "success", "denied")
+        /// Filter by outcome — exact match (e.g. "success", "denied")
         #[arg(long)]
         outcome: Option<String>,
-        /// Filter by context ID
+        /// Filter by context ID. Required unless you are an unrestricted admin.
         #[arg(long)]
         context_id: Option<String>,
-        /// Page number (default 1)
-        #[arg(long, default_value_t = 1)]
-        page: u64,
-        /// Page size (default 50, max 500)
-        #[arg(long, default_value_t = 50)]
-        page_size: u64,
+        /// Continuation cursor printed by the previous page. Pass it back
+        /// verbatim; do not change the filters when resuming.
+        #[arg(long)]
+        cursor: Option<String>,
+        /// Page size (default 50, max 200)
+        #[arg(long)]
+        page_size: Option<u64>,
     },
     /// Manage audit log retention
     Retention {

--- a/pnm-cli/src/commands/audit.rs
+++ b/pnm-cli/src/commands/audit.rs
@@ -17,7 +17,7 @@ pub(crate) async fn run(
             actor,
             outcome,
             context_id,
-            page,
+            cursor,
             page_size,
         } => {
             let params = vta_sdk::protocols::audit_management::list::ListAuditLogsBody {
@@ -27,7 +27,7 @@ pub(crate) async fn run(
                 actor,
                 outcome,
                 context_id,
-                page,
+                cursor,
                 page_size,
             };
             audit::cmd_list_audit_logs(client, &params).await

--- a/vta-cli-common/Cargo.toml
+++ b/vta-cli-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-cli-common"
 description = "Shared CLI command handlers and rendering helpers for VTA CLIs"
 readme = "README.md"
-version = "0.10.18"
+version = "0.10.19"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-cli-common/src/commands/audit.rs
+++ b/vta-cli-common/src/commands/audit.rs
@@ -3,6 +3,7 @@ use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::Span;
 use ratatui::widgets::{Cell, Row, Table};
 use vta_sdk::prelude::*;
+use vta_sdk::protocols::audit_management::list::{AuditEnvelope, ListAuditLogsResultBody};
 
 use crate::display::{NameBook, book_from_acl, named_did_cell};
 use crate::render::{is_full_display, print_full_entry_owned, print_full_list_title, print_widget};
@@ -29,42 +30,40 @@ pub async fn cmd_list_audit_logs(
     }
 
     if is_full_display() {
-        print_full_list_title(
-            &format!(
-                "Audit Log (page {}/{}, {} total)",
-                result.page, result.total_pages, result.total
-            ),
-            result.entries.len(),
-        );
+        print_full_list_title("Audit Log", result.entries.len());
         for entry in &result.entries {
-            let ts = crate::duration::format_local_time(entry.timestamp);
-            let resource = entry.resource.as_deref().unwrap_or("—");
-            let channel = entry.channel.as_deref().unwrap_or("—");
+            let ts = format_recorded_at(&entry.recorded_at);
+            let actor = entry.actor.as_deref().unwrap_or("—");
+            let target = entry.target.as_deref().unwrap_or("—");
+            let channel = detail_str(entry, "channel").unwrap_or_else(|| "—".to_string());
             let context = entry.context_id.as_deref().unwrap_or("—");
             let mut fields = vec![
-                ("ID", entry.id.clone()),
+                ("ID", entry.event_id.clone()),
                 ("Timestamp", ts),
                 ("Action", entry.action.clone()),
             ];
-            if let Some(name) = book.name_of(&entry.actor) {
+            if let Some(name) = book.name_of(actor) {
                 fields.push(("Actor", name));
             }
             // Actor DID stays in full — an audit trail is evidence.
-            fields.push(("Actor DID", entry.actor.clone()));
-            fields.push(("Resource", resource.to_string()));
-            fields.push(("Channel", channel.to_string()));
+            fields.push(("Actor DID", actor.to_string()));
+            fields.push(("Resource", target.to_string()));
+            fields.push(("Channel", channel));
             fields.push(("Context", context.to_string()));
-            fields.push(("Outcome", entry.outcome.clone()));
+            fields.push((
+                "Outcome",
+                entry.outcome.clone().unwrap_or_else(|| "—".to_string()),
+            ));
+            if let Some(reason) = detail_str(entry, "reason") {
+                fields.push(("Reason", reason));
+            }
             print_full_entry_owned(&fields);
         }
+        print_cursor_footer(&result);
         return Ok(());
     }
 
-    // Page info header
-    println!(
-        "\n  \x1b[1mAudit Log\x1b[0m  \x1b[2m(page {}/{}, {} total entries)\x1b[0m\n",
-        result.page, result.total_pages, result.total
-    );
+    println!("\n  \x1b[1mAudit Log\x1b[0m\n");
 
     // Build table rows
     let rows: Vec<Row> = result
@@ -72,12 +71,13 @@ pub async fn cmd_list_audit_logs(
         .iter()
         .map(|entry| {
             // Format timestamp in operator's local timezone.
-            let ts = crate::duration::format_local_time(entry.timestamp);
+            let ts = format_recorded_at(&entry.recorded_at);
+            let outcome = entry.outcome.as_deref().unwrap_or("—");
 
             // Color the outcome
-            let outcome_style = if entry.outcome == "success" {
+            let outcome_style = if outcome == "success" {
                 Style::default().fg(Color::Green)
-            } else if entry.outcome.starts_with("denied") {
+            } else if outcome.starts_with("denied") {
                 Style::default().fg(Color::Red).add_modifier(Modifier::BOLD)
             } else {
                 Style::default().fg(Color::Yellow)
@@ -99,14 +99,14 @@ pub async fn cmd_list_audit_logs(
             // Actor: the entry's name when we have one, else the shortened
             // DID. (The previous `&entry.actor[..29]` sliced on a byte
             // boundary and would panic on a multi-byte character.)
-            let resource_display = entry.resource.as_deref().unwrap_or("\u{2014}");
+            let resource_display = entry.target.as_deref().unwrap_or("\u{2014}");
 
             Row::new(vec![
                 Cell::from(Span::styled(ts, Style::default().fg(Color::DarkGray))),
                 Cell::from(Span::styled(entry.action.clone(), action_style)),
-                named_did_cell(&book, &entry.actor),
+                named_did_cell(&book, entry.actor.as_deref().unwrap_or("\u{2014}")),
                 Cell::from(resource_display.to_string()),
-                Cell::from(Span::styled(entry.outcome.clone(), outcome_style)),
+                Cell::from(Span::styled(outcome.to_string(), outcome_style)),
             ])
         })
         .collect();
@@ -166,15 +166,40 @@ pub async fn cmd_list_audit_logs(
     let height = row_count as u16 + 2; // rows + header + spacing
     print_widget(table, height);
 
-    // Footer with pagination info
-    if result.total_pages > 1 {
-        println!(
-            "\n  \x1b[2mPage {}/{} \u{2014} use --page N to navigate\x1b[0m",
-            result.page, result.total_pages
-        );
-    }
+    print_cursor_footer(&result);
 
     Ok(())
+}
+
+/// Render `recordedAt` (RFC 3339 on the wire) in the operator's local
+/// timezone, falling back to the raw string if it does not parse —
+/// an audit row must still be readable when its timestamp is odd.
+fn format_recorded_at(recorded_at: &str) -> String {
+    match chrono::DateTime::parse_from_rfc3339(recorded_at) {
+        Ok(dt) => crate::duration::format_local_datetime(dt.with_timezone(&chrono::Utc)),
+        Err(_) => recorded_at.to_string(),
+    }
+}
+
+/// Pull a string member out of the canonical `detail` object.
+fn detail_str(entry: &AuditEnvelope, key: &str) -> Option<String> {
+    entry
+        .detail
+        .get(key)
+        .and_then(|v| v.as_str())
+        .map(str::to_owned)
+}
+
+/// Print the continuation hint. Paging is by opaque cursor, so there
+/// is no page count to show — the only thing an operator can act on is
+/// whether another page exists and the token that fetches it.
+fn print_cursor_footer(result: &ListAuditLogsResultBody) {
+    if let Some(cursor) = &result.cursor {
+        println!(
+            "\n  \x1b[2mMore entries \u{2014} fetch the next page with --cursor {cursor}\x1b[0m"
+        );
+        println!("  \x1b[2m(keep the same filters; changing them invalidates the cursor)\x1b[0m");
+    }
 }
 
 /// Display the current audit retention period.

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.20.12"
+version = "0.20.13"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/client/audit.rs
+++ b/vta-sdk/src/client/audit.rs
@@ -3,6 +3,15 @@
 use super::VtaClient;
 use crate::error::VtaError;
 
+/// Percent-encode a query-parameter value.
+///
+/// Not optional for these params: an RFC 3339 timestamp ends in a `+`
+/// offset (`…+00:00`), which a query-string decoder reads as a space —
+/// so an unencoded `from`/`to` arrives as an unparseable datetime.
+fn enc(value: &str) -> String {
+    url::form_urlencoded::byte_serialize(value.as_bytes()).collect()
+}
+
 impl VtaClient {
     /// List audit logs with optional filtering and pagination.
     pub async fn list_audit_logs(
@@ -16,27 +25,33 @@ impl VtaClient {
             audit_management::LIST_LOGS_RESULT,
             30,
             |c, url| {
-                let mut qs = vec![
-                    format!("page={}", params.page),
-                    format!("page_size={}", params.page_size),
-                ];
+                // Query-param names are the canonical camelCase ones the
+                // route binds; a snake_case key here is silently dropped
+                // by serde and the filter never applies.
+                let mut qs: Vec<String> = Vec::new();
+                if let Some(page_size) = params.page_size {
+                    qs.push(format!("pageSize={page_size}"));
+                }
                 if let Some(from) = params.from {
-                    qs.push(format!("from={from}"));
+                    qs.push(format!("from={}", enc(&from.to_rfc3339())));
                 }
                 if let Some(to) = params.to {
-                    qs.push(format!("to={to}"));
+                    qs.push(format!("to={}", enc(&to.to_rfc3339())));
                 }
                 if let Some(ref action) = params.action {
-                    qs.push(format!("action={action}"));
+                    qs.push(format!("action={}", enc(action)));
                 }
                 if let Some(ref actor) = params.actor {
-                    qs.push(format!("actor={actor}"));
+                    qs.push(format!("actor={}", enc(actor)));
                 }
                 if let Some(ref outcome) = params.outcome {
-                    qs.push(format!("outcome={outcome}"));
+                    qs.push(format!("outcome={}", enc(outcome)));
                 }
                 if let Some(ref ctx) = params.context_id {
-                    qs.push(format!("context_id={ctx}"));
+                    qs.push(format!("contextId={}", enc(ctx)));
+                }
+                if let Some(ref cursor) = params.cursor {
+                    qs.push(format!("cursor={}", enc(cursor)));
                 }
                 c.get(format!("{url}/audit/logs?{}", qs.join("&")))
             },

--- a/vta-sdk/src/protocols/audit_management/list.rs
+++ b/vta-sdk/src/protocols/audit_management/list.rs
@@ -1,6 +1,28 @@
+//! Wire types for canonical `audit/list/0.1`.
+//!
+//! Two shapes live here and they are deliberately not the same one:
+//!
+//! - [`AuditLogEntry`] is the **stored row** — what `vta-audit` writes
+//!   into the audit keyspace. Its serde shape is a storage format, so
+//!   it is frozen: renaming a field here silently orphans every row
+//!   already on disk.
+//! - [`AuditEnvelope`] is the **wire form** canonical `audit/list`
+//!   returns. It is produced from a stored row at the response
+//!   boundary via `From<&AuditLogEntry>`.
+//!
+//! Keeping them separate is what lets the VTA adopt the canonical
+//! camelCase envelope without a storage migration.
+
+use chrono::{DateTime, TimeZone, Utc};
 use serde::{Deserialize, Serialize};
 
-/// A single audit log entry.
+/// A single audit log entry **as stored**. Not the wire form — see
+/// [`AuditEnvelope`].
+///
+/// The serde shape of this struct is the on-disk format for the audit
+/// keyspace. Do not add `rename_all`, and add new fields only with
+/// `#[serde(default)]` so rows written before the field existed still
+/// deserialize.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct AuditLogEntry {
@@ -22,51 +44,122 @@ pub struct AuditLogEntry {
     pub detail: Option<String>,
 }
 
-/// Request body for listing audit logs with filtering and pagination.
+/// Canonical `AuditEnvelope` — the wire form of one audit entry.
+///
+/// Field names and types follow
+/// `spec/audit/_shared/0.1/audit.schema.json`. The VTA populates the
+/// subset it tracks; `prevHash` / `entryHash` / `schemaVersion` are
+/// absent because this maintainer's log is flat and unchained (the
+/// canonical schema requires only `eventId` / `recordedAt` / `action`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct AuditEnvelope {
+    /// Stable identifier for this event — the stored row's `id`.
+    pub event_id: String,
+    /// RFC 3339 wall-clock time the entry was written.
+    pub recorded_at: String,
+    pub action: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub outcome: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub actor: Option<String>,
+    /// The stored row's `resource` — the principal or object acted upon.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_id: Option<String>,
+    /// Event-specific payload. Canonical types this as an object, so
+    /// the VTA's flat `detail` string and its `channel` (the transport
+    /// the action arrived over — a VTA-specific fact with no canonical
+    /// envelope field) are carried as members here rather than dropped.
+    #[serde(default, skip_serializing_if = "serde_json::Map::is_empty")]
+    pub detail: serde_json::Map<String, serde_json::Value>,
+}
+
+impl From<&AuditLogEntry> for AuditEnvelope {
+    fn from(row: &AuditLogEntry) -> Self {
+        let mut detail = serde_json::Map::new();
+        if let Some(reason) = &row.detail {
+            detail.insert("reason".into(), reason.clone().into());
+        }
+        if let Some(channel) = &row.channel {
+            detail.insert("channel".into(), channel.clone().into());
+        }
+
+        Self {
+            event_id: row.id.clone(),
+            // `timestamp` is unix seconds and always in range, but a
+            // corrupt row must not panic a list call — fall back to the
+            // epoch rather than unwrapping.
+            recorded_at: Utc
+                .timestamp_opt(row.timestamp as i64, 0)
+                .single()
+                .unwrap_or_else(|| DateTime::from_timestamp(0, 0).expect("epoch is valid"))
+                .to_rfc3339(),
+            action: row.action.clone(),
+            outcome: Some(row.outcome.clone()),
+            actor: Some(row.actor.clone()),
+            target: row.resource.clone(),
+            context_id: row.context_id.clone(),
+            detail,
+        }
+    }
+}
+
+/// Request payload for canonical `audit/list/0.1`.
+///
+/// Paging is by opaque continuation `cursor`, not offset: an offset
+/// silently skips or repeats rows when entries are appended while a
+/// consumer walks the pages, which on an audit log is a correctness
+/// bug rather than a cosmetic one.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema, utoipa::IntoParams))]
 #[cfg_attr(feature = "openapi", into_params(parameter_in = Query))]
 pub struct ListAuditLogsBody {
-    /// Start of time range (unix epoch seconds, inclusive).
+    /// Return only entries recorded at or after this time (inclusive).
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub from: Option<u64>,
-    /// End of time range (unix epoch seconds, inclusive).
+    pub from: Option<DateTime<Utc>>,
+    /// Return only entries recorded **strictly before** this time.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub to: Option<u64>,
-    /// Filter by action type (e.g. "auth.challenge", "key.create").
+    pub to: Option<DateTime<Utc>>,
+    /// Return only entries whose `action` **equals** this value.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub action: Option<String>,
-    /// Filter by actor DID.
+    /// Return only entries whose actor DID equals this value.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub actor: Option<String>,
-    /// Filter by outcome (e.g. "success", "denied").
+    /// Return only entries whose `outcome` equals this value.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub outcome: Option<String>,
-    /// Filter by application context ID.
+    /// Return only entries in this trust context.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub context_id: Option<String>,
-    /// Page number (1-based, default 1).
-    #[serde(default = "default_page")]
-    pub page: u64,
-    /// Page size (default 50, max 500).
-    #[serde(default = "default_page_size")]
-    pub page_size: u64,
+    /// Maximum entries to return in this page. Clamped to `1..=200`;
+    /// omitted means 50.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub page_size: Option<u64>,
+    /// Opaque continuation token from a previous response's `cursor`.
+    ///
+    /// The filters are bound into the cursor, so a consumer continuing
+    /// a page must not also change them — doing so is rejected as an
+    /// invalid cursor rather than silently answered from a position
+    /// that belonged to a different query.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cursor: Option<String>,
 }
 
-fn default_page() -> u64 {
-    1
-}
-fn default_page_size() -> u64 {
-    50
-}
-
-/// Response body for listing audit logs.
+/// Response payload for canonical `audit/list/0.1`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ListAuditLogsResultBody {
-    pub entries: Vec<AuditLogEntry>,
-    pub total: u64,
-    pub page: u64,
-    pub page_size: u64,
-    pub total_pages: u64,
+    /// The matching entries, newest first.
+    pub entries: Vec<AuditEnvelope>,
+    /// True when more entries **match** beyond this page.
+    pub truncated: bool,
+    /// Continuation token for the next page. Present iff `truncated`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cursor: Option<String>,
 }

--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -344,13 +344,15 @@ pub const TASK_SEEDS_ROTATE_1_0: &str = "https://trusttasks.org/spec/vta/seeds/r
 pub const TASK_SEEDS_EXPORT_MNEMONIC_1_0: &str =
     "https://trusttasks.org/spec/vta/seeds/export-mnemonic/1.0";
 
-// ─── Audit slice (spec/vta/audit/*) ──────────────────────────────────────
+// ─── Audit slice (canonical spec/audit/*, plus spec/vta/audit/*) ─────────
 
-/// `spec/vta/audit/list-logs/1.0` — list audit log entries (paginated,
-/// filterable). Payload:
+/// `audit/list/0.1` — page through the audit log, newest first, with
+/// optional filters and an opaque continuation cursor. Payload:
 /// [`crate::protocols::audit_management::list::ListAuditLogsBody`].
-/// Auth: Admin.
-pub const TASK_AUDIT_LIST_LOGS_1_0: &str = "https://trusttasks.org/spec/vta/audit/list-logs/1.0";
+///
+/// Auth: unrestricted admin for the whole-log tail; a context-scoped
+/// admin must supply `contextId` within their own scope.
+pub const TASK_AUDIT_LIST_LOGS_1_0: &str = "https://trusttasks.org/spec/audit/list/0.1";
 
 /// `spec/vta/audit/get-retention/1.0` — read the current retention
 /// period. Payload:
@@ -1577,6 +1579,10 @@ mod tests {
             // AI agent and whose subject is a platform/conversation pair — it
             // cannot express "approve this task payload".
             "https://trusttasks.org/spec/task-consent/",
+            // Canonical audit read — `audit/list`. The VTA's
+            // `vta/audit/list-logs` folded onto it in #840 phase A, trading
+            // offset pages for the canonical opaque cursor.
+            "https://trusttasks.org/spec/audit/",
         ];
         for uri in ALL_URIS {
             assert!(

--- a/vta-sdk/tests/client_rest.rs
+++ b/vta-sdk/tests/client_rest.rs
@@ -1195,28 +1195,67 @@ async fn list_audit_logs_paginates() {
     Mock::given(method("GET"))
         .and(path("/audit/logs"))
         .and(auth_match())
-        .and(wiremock::matchers::query_param("page", "2"))
-        .and(wiremock::matchers::query_param("page_size", "25"))
+        // camelCase, per canonical `audit/list/0.1`. A snake_case key
+        // here would be dropped by the route's serde binding and the
+        // filter would silently not apply.
+        .and(wiremock::matchers::query_param("pageSize", "25"))
         .and(wiremock::matchers::query_param("action", "key.create"))
+        .and(wiremock::matchers::query_param("cursor", "opaque-token"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "entries": [],
-            "total": 0,
-            "page": 2,
-            "page_size": 25,
-            "total_pages": 0
+            "entries": [{
+                "eventId": "e1",
+                "recordedAt": "2026-07-01T00:00:00+00:00",
+                "action": "key.create",
+                "outcome": "success",
+                "actor": "did:key:zActor",
+            }],
+            "truncated": true,
+            "cursor": "next-token"
         })))
         .expect(1)
         .mount(&server)
         .await;
     let c = client(&server).await;
     let params = vta_sdk::protocols::audit_management::list::ListAuditLogsBody {
-        page: 2,
-        page_size: 25,
+        page_size: Some(25),
         action: Some("key.create".into()),
+        cursor: Some("opaque-token".into()),
         ..Default::default()
     };
     let r = c.list_audit_logs(&params).await.unwrap();
-    assert_eq!(r.page, 2);
+    assert!(r.truncated);
+    assert_eq!(r.cursor.as_deref(), Some("next-token"));
+    assert_eq!(r.entries[0].event_id, "e1");
+    assert_eq!(r.entries[0].action, "key.create");
+}
+
+/// An RFC 3339 `from` ends in a `+00:00` offset. Unencoded, the `+`
+/// decodes as a space and the server sees an unparseable datetime, so
+/// the bound silently goes missing — the failure mode is "more rows
+/// than you asked for", which on an audit query reads as a full log.
+#[tokio::test]
+async fn audit_list_percent_encodes_rfc3339_bounds() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/audit/logs"))
+        .and(auth_match())
+        .and(wiremock::matchers::query_param(
+            "from",
+            "2026-07-01T00:00:00+00:00",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "entries": [], "truncated": false
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+    let c = client(&server).await;
+    let params = vta_sdk::protocols::audit_management::list::ListAuditLogsBody {
+        from: Some("2026-07-01T00:00:00Z".parse().unwrap()),
+        ..Default::default()
+    };
+    let r = c.list_audit_logs(&params).await.unwrap();
+    assert!(!r.truncated);
 }
 
 #[tokio::test]

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.13.4"
+version = "0.13.5"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/messaging/handlers.rs
+++ b/vta-service/src/messaging/handlers.rs
@@ -74,6 +74,11 @@ fn app_err_to_problem_report(e: &AppError) -> ProblemReport {
             escalate_to: None,
         },
         AppError::Validation(msg) => ProblemReport::bad_request(msg.clone()),
+        // A rejected pagination cursor is a caller fault — REST already
+        // answers 400. Collapsed into `internal-error` it reads as a
+        // server fault the caller should retry, when the correct
+        // response is to restart from the first page.
+        AppError::InvalidCursor => ProblemReport::bad_request(e.to_string()),
         _ => ProblemReport::internal_error(e.to_string()),
     }
 }
@@ -2022,6 +2027,17 @@ mod tests {
             assert_eq!(report.code, expected_code, "code for {err:?}");
             assert_eq!(report.comment, expected_comment, "comment for {err:?}");
         }
+    }
+
+    /// A rejected pagination cursor is a caller fault. REST answers 400;
+    /// this transport must not report it as an internal error, which
+    /// would tell the caller to retry the same cursor instead of
+    /// restarting from the first page.
+    #[test]
+    fn invalid_cursor_is_a_bad_request_not_an_internal_error() {
+        let report = app_err_to_problem_report(&AppError::InvalidCursor);
+        assert_eq!(report.code, codes::BAD_REQUEST);
+        assert_ne!(report.code, codes::INTERNAL);
     }
 
     /// Catch-all variants collapse to `internal-error` with the `Display`

--- a/vta-service/src/operations/audit.rs
+++ b/vta-service/src/operations/audit.rs
@@ -1,9 +1,10 @@
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use vta_sdk::protocols::audit_management::list::{
-    AuditLogEntry, ListAuditLogsBody, ListAuditLogsResultBody,
+    AuditEnvelope, AuditLogEntry, ListAuditLogsBody, ListAuditLogsResultBody,
 };
 use vta_sdk::protocols::audit_management::retention::RetentionResultBody;
+use vti_common::pagination::{Cursor, CursorKey, MAX_LIMIT};
 
 use crate::audit::{self, audit};
 use crate::auth::AuthClaims;
@@ -11,84 +12,216 @@ use crate::config::AppConfig;
 use crate::error::AppError;
 use crate::store::KeyspaceHandle;
 
-/// List audit logs with filtering and pagination.
+/// Page size used when the caller omits `pageSize`.
+const DEFAULT_PAGE_SIZE: u64 = 50;
+
+/// Does this stored row pass every supplied filter?
+///
+/// `action` and `outcome` match on **equality**, per canonical
+/// `audit/list`. They previously matched on substring, which quietly
+/// widened a query — asking for `action=vault.delete` also returned
+/// `vault.delete_force` — so an operator reading the result could not
+/// tell which rows they had actually asked for.
+fn matches(params: &ListAuditLogsBody, entry: &AuditLogEntry) -> bool {
+    if let Some(from) = params.from
+        && (entry.timestamp as i64) < from.timestamp()
+    {
+        return false;
+    }
+    // Canonical: `to` is exclusive.
+    if let Some(to) = params.to
+        && (entry.timestamp as i64) >= to.timestamp()
+    {
+        return false;
+    }
+    if let Some(action) = &params.action
+        && entry.action != *action
+    {
+        return false;
+    }
+    if let Some(actor) = &params.actor
+        && entry.actor != *actor
+    {
+        return false;
+    }
+    if let Some(outcome) = &params.outcome
+        && entry.outcome != *outcome
+    {
+        return false;
+    }
+    if let Some(ctx) = &params.context_id
+        && entry.context_id.as_deref() != Some(ctx.as_str())
+    {
+        return false;
+    }
+    true
+}
+
+/// The bytes a cursor is bound to.
+///
+/// Canonical forbids changing the filters while paging — they are part
+/// of the cursor's position — so they are folded into the cursor's
+/// HMAC, and resuming under a different filter set fails verification.
+/// The caller's DID is bound too, so a leaked cursor is not a
+/// cross-principal read (canonical §"Cursor as a capability").
+///
+/// Length-prefixed so that `action="a&actor=b"` cannot collide with
+/// `action="a", actor="b"`.
+fn cursor_binding(params: &ListAuditLogsBody, caller_did: &str) -> Vec<u8> {
+    let mut out = Vec::new();
+    let mut field = |v: Option<&str>| {
+        let bytes = v.unwrap_or("").as_bytes();
+        out.extend_from_slice(&(bytes.len() as u32).to_be_bytes());
+        out.extend_from_slice(bytes);
+    };
+    field(Some(caller_did));
+    field(params.from.map(|t| t.to_rfc3339()).as_deref());
+    field(params.to.map(|t| t.to_rfc3339()).as_deref());
+    field(params.action.as_deref());
+    field(params.actor.as_deref());
+    field(params.outcome.as_deref());
+    field(params.context_id.as_deref());
+    out
+}
+
+/// Authorize an audit read.
+///
+/// The audit log is the whole agent's tail: it holds actor DIDs and
+/// actions from **every** trust context. `require_admin` alone tests
+/// only the role, so a context-scoped admin — an admin deliberately
+/// confined to one context — could read every other context's
+/// activity. Canonical states the gate directly: this is the tightest-
+/// gated read a maintainer offers, and a context-scoped admin does not
+/// qualify for the whole-log tail.
+///
+/// So: a super-admin reads anything; a scoped admin must name a
+/// `contextId` inside their own scope, which the filter then confines
+/// the results to.
+///
+/// Note this deliberately goes through `is_super_admin` /
+/// `has_context_access` rather than testing `allowed_contexts`
+/// directly — an empty context list means *unrestricted* for an admin
+/// and *authorized nowhere* for every other role.
+fn authorize(auth: &AuthClaims, params: &ListAuditLogsBody) -> Result<(), AppError> {
+    auth.require_admin()?;
+
+    if auth.is_super_admin() {
+        return Ok(());
+    }
+
+    let Some(ctx) = params.context_id.as_deref() else {
+        return Err(AppError::Forbidden(
+            "reading the whole audit log requires an unrestricted admin; a context-scoped \
+             admin must pass contextId to read that context's entries"
+                .into(),
+        ));
+    };
+
+    if !auth.has_context_access(ctx) {
+        return Err(AppError::Forbidden(format!(
+            "not authorized to read audit entries for context {ctx}"
+        )));
+    }
+
+    Ok(())
+}
+
+/// List audit logs, newest first, with optional filters and opaque
+/// cursor pagination — canonical `audit/list/0.1`.
 pub async fn list_audit_logs(
     audit_ks: &KeyspaceHandle,
     auth: &AuthClaims,
     params: &ListAuditLogsBody,
     _channel: &str,
 ) -> Result<ListAuditLogsResultBody, AppError> {
-    // Any authenticated user can read audit logs (admin-level info)
-    auth.require_admin()?;
+    authorize(auth, params)?;
 
-    let page_size = params.page_size.clamp(1, 500);
-    let page = params.page.max(1);
+    let limit = params
+        .page_size
+        .unwrap_or(DEFAULT_PAGE_SIZE)
+        .clamp(1, MAX_LIMIT as u64) as usize;
 
-    // Scan all audit entries
-    let raw = audit_ks.prefix_iter_raw("log:").await?;
-    let mut entries: Vec<AuditLogEntry> = Vec::new();
+    let cursor_key = CursorKey::new(audit_ks.clone()).get().await?;
+    let binding = cursor_binding(params, &auth.did);
+    let resume_from = match &params.cursor {
+        Some(wire) => Some(Cursor::decode_bound(wire, &cursor_key, &binding)?),
+        None => None,
+    };
 
-    for (_key, value) in raw {
-        let entry: AuditLogEntry = match serde_json::from_slice(&value) {
-            Ok(e) => e,
-            Err(_) => continue,
-        };
+    // The storage key is `log:{timestamp:020}:{uuid}`, so a
+    // lexicographic walk is chronological and the key itself is a
+    // stable cursor position — stable under concurrent appends in a
+    // way an offset is not.
+    //
+    // This materialises the whole keyspace per page, as the offset
+    // implementation it replaces also did — retention caps how large
+    // that gets. The fix, when it is needed, is the cursor-aware
+    // `prefix_iter_after` sketched in `vti_common::pagination`'s module
+    // docs; it does not change the wire shape, because the cursor is
+    // already the storage key this would seek to.
+    let mut pairs = audit_ks.prefix_iter_raw("log:").await?;
+    pairs.sort_by(|(a, _), (b, _)| b.cmp(a)); // newest first
 
-        // Apply filters
-        if let Some(from) = params.from
-            && entry.timestamp < from
-        {
-            continue;
-        }
-        if let Some(to) = params.to
-            && entry.timestamp > to
-        {
-            continue;
-        }
-        if let Some(ref action) = params.action
-            && !entry.action.contains(action.as_str())
-        {
-            continue;
-        }
-        if let Some(ref actor) = params.actor
-            && entry.actor != *actor
-        {
-            continue;
-        }
-        if let Some(ref outcome) = params.outcome
-            && !entry.outcome.contains(outcome.as_str())
-        {
-            continue;
-        }
-        if let Some(ref ctx) = params.context_id
-            && entry.context_id.as_deref() != Some(ctx.as_str())
-        {
-            continue;
-        }
+    // Descending order means "the next page" is everything strictly
+    // less than the last key already returned.
+    let start = match &resume_from {
+        Some(c) => pairs
+            .iter()
+            .position(|(k, _)| k.as_slice() < c.last_key.as_slice())
+            .unwrap_or(pairs.len()),
+        None => 0,
+    };
 
-        entries.push(entry);
+    let mut entries: Vec<AuditEnvelope> = Vec::with_capacity(limit);
+    let mut last_seen_key: Option<Vec<u8>> = None;
+    let mut idx = start;
+    while entries.len() < limit && idx < pairs.len() {
+        let (key, value) = &pairs[idx];
+        match serde_json::from_slice::<AuditLogEntry>(value) {
+            Ok(row) => {
+                if matches(params, &row) {
+                    entries.push(AuditEnvelope::from(&row));
+                    last_seen_key = Some(key.clone());
+                }
+            }
+            Err(err) => {
+                tracing::warn!(
+                    error = %err,
+                    key = %String::from_utf8_lossy(key),
+                    "skipping unparseable audit row",
+                );
+            }
+        }
+        idx += 1;
     }
 
-    // Sort by timestamp descending (newest first)
-    entries.sort_by_key(|e| std::cmp::Reverse(e.timestamp));
+    // `truncated` must mean "more *matching* entries remain", not "more
+    // rows remain": under a filter the tail may hold nothing that
+    // matches, and handing back a cursor for an empty next page would
+    // read as results being withheld. Scan ahead only as far as the
+    // first further match.
+    let mut more_matches = false;
+    while idx < pairs.len() {
+        if let Ok(row) = serde_json::from_slice::<AuditLogEntry>(&pairs[idx].1)
+            && matches(params, &row)
+        {
+            more_matches = true;
+            break;
+        }
+        idx += 1;
+    }
 
-    let total = entries.len() as u64;
-    let total_pages = total.div_ceil(page_size);
-
-    // Apply pagination
-    let skip = ((page - 1) * page_size) as usize;
-    let page_entries: Vec<AuditLogEntry> = entries
-        .into_iter()
-        .skip(skip)
-        .take(page_size as usize)
-        .collect();
+    let cursor = if more_matches {
+        last_seen_key
+            .map(|k| Cursor::new(k, pairs.len() as u64).encode_bound(&cursor_key, &binding))
+    } else {
+        None
+    };
 
     Ok(ListAuditLogsResultBody {
-        entries: page_entries,
-        total,
-        page,
-        page_size,
-        total_pages,
+        entries,
+        truncated: cursor.is_some(),
+        cursor,
     })
 }
 

--- a/vta-service/src/trust_tasks/audit.rs
+++ b/vta-service/src/trust_tasks/audit.rs
@@ -1,7 +1,10 @@
 //! Audit slice trust-task handlers.
 //!
-//! Auth: Admin for list-logs and get-retention; Super-Admin for
-//! update-retention (enforced inside the operation function).
+//! Auth (all enforced inside the operation functions, so every
+//! transport gets the same gate): Admin for get-retention; Super-Admin
+//! for update-retention; and for `audit/list`, an unrestricted admin
+//! for the whole-log tail with a context-scoped admin confined to a
+//! `contextId` inside their own scope.
 
 use super::helpers::TrustTaskOutcome;
 use serde_json::Value;
@@ -15,7 +18,11 @@ use crate::server::AppState;
 
 use super::helpers::{TRANSPORT_TRUST_TASK, app_error_to_reject, parse_payload, success_response};
 
-/// Handler for `spec/vta/audit/list-logs/1.0`. Admin only.
+/// Handler for canonical `audit/list/0.1`.
+///
+/// Auth: unrestricted admin for the whole-log tail; a context-scoped
+/// admin must supply `contextId` within their own scope. The finer gate
+/// lives in the operation, so every transport gets it.
 pub(super) async fn handle_list_logs(
     state: &AppState,
     auth: &AuthClaims,
@@ -70,5 +77,82 @@ pub(super) async fn handle_update_retention(
     {
         Ok(body) => success_response(&doc, body),
         Err(e) => app_error_to_reject(&doc, e),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use trust_tasks_rs::specs::audit::list::v0_1 as canonical;
+    use vta_sdk::protocols::audit_management::list::{
+        AuditEnvelope, AuditLogEntry, ListAuditLogsResultBody,
+    };
+
+    /// The whole point of the fold: our wire shapes must be the
+    /// canonical ones, not merely bound to the canonical URI.
+    ///
+    /// The generated canonical types carry `deny_unknown_fields` and
+    /// the spec's required-field set, so deserializing our serialized
+    /// form into them is a conformance check — it catches a member we
+    /// named differently, one the spec forbids, and one the spec
+    /// requires that we omit. The dispatch spine validates *requests*
+    /// against the schema at runtime; nothing validates responses, so
+    /// this is the only place the response shape is checked at all.
+    #[test]
+    fn request_and_response_conform_to_the_canonical_schema() {
+        let req = ListAuditLogsBody {
+            from: Some("2026-07-01T00:00:00Z".parse().unwrap()),
+            to: Some("2026-07-28T00:00:00Z".parse().unwrap()),
+            action: Some("acl.create".into()),
+            actor: Some("did:key:z6MkActor".into()),
+            outcome: Some("success".into()),
+            context_id: Some("ctx1".into()),
+            page_size: Some(25),
+            cursor: Some("opaque".into()),
+        };
+        let json = serde_json::to_value(&req).expect("serialize request");
+        serde_json::from_value::<canonical::Payload>(json.clone())
+            .unwrap_or_else(|e| panic!("request is not canonical `audit/list/0.1`: {e}\n{json:#}"));
+
+        // An all-defaults request must also be valid — every filter is
+        // optional, and omitted members must be absent rather than null.
+        let empty = serde_json::to_value(ListAuditLogsBody::default()).expect("serialize");
+        assert_eq!(
+            empty,
+            serde_json::json!({}),
+            "omitted filters must not serialize"
+        );
+        serde_json::from_value::<canonical::Payload>(empty).expect("empty request is canonical");
+
+        let row = AuditLogEntry {
+            id: "e1".into(),
+            timestamp: 1_785_239_374,
+            action: "acl.create".into(),
+            actor: "did:key:z6MkActor".into(),
+            resource: Some("did:key:z6MkSubject".into()),
+            outcome: "success".into(),
+            channel: Some("rest".into()),
+            context_id: Some("ctx1".into()),
+            detail: Some("because".into()),
+        };
+        let resp = ListAuditLogsResultBody {
+            entries: vec![AuditEnvelope::from(&row)],
+            truncated: true,
+            cursor: Some("opaque".into()),
+        };
+        let json = serde_json::to_value(&resp).expect("serialize response");
+        serde_json::from_value::<canonical::Response>(json.clone()).unwrap_or_else(|e| {
+            panic!("response is not canonical `audit/list/0.1`: {e}\n{json:#}")
+        });
+
+        // Guard against a vacuous check: the canonical types must
+        // actually reject a shape the spec forbids, or the assertions
+        // above would pass for anything.
+        let mut drifted = json;
+        drifted["totalPages"] = serde_json::json!(3);
+        assert!(
+            serde_json::from_value::<canonical::Response>(drifted).is_err(),
+            "the canonical Response must reject members the spec does not define"
+        );
     }
 }

--- a/vta-service/src/trust_tasks/helpers.rs
+++ b/vta-service/src/trust_tasks/helpers.rs
@@ -85,7 +85,7 @@ pub(super) fn parse_payload<T: serde::de::DeserializeOwned>(
 /// code:
 ///
 /// - `Authentication` / `Unauthorized` / `Forbidden` → `permission_denied`
-/// - `Validation` / `TrustTaskMalformed` → `malformed_request`
+/// - `Validation` / `TrustTaskMalformed` / `InvalidCursor` → `malformed_request`
 /// - `NotFound` / `Conflict` → `task_failed`
 /// - everything else → `internal_error`
 pub(super) fn app_error_to_reject(doc: &TrustTask<Value>, err: AppError) -> TrustTaskOutcome {
@@ -94,7 +94,11 @@ pub(super) fn app_error_to_reject(doc: &TrustTask<Value>, err: AppError) -> Trus
         AppError::Authentication(_) | AppError::Unauthorized(_) | AppError::Forbidden(_) => {
             RejectReason::PermissionDenied { reason: message }
         }
-        AppError::Validation(_) | AppError::TrustTaskMalformed(_) => {
+        // A rejected pagination cursor is a caller fault, not a server
+        // one — REST already answers 400. Left in the `internal_error`
+        // fallback it would tell a consumer to retry the same cursor,
+        // when the correct response is to restart from the first page.
+        AppError::Validation(_) | AppError::TrustTaskMalformed(_) | AppError::InvalidCursor => {
             RejectReason::MalformedRequest { reason: message }
         }
         AppError::NotFound(_) | AppError::Conflict(_) => RejectReason::TaskFailed {

--- a/vta-service/tests/api_integration.rs
+++ b/vta-service/tests/api_integration.rs
@@ -1199,6 +1199,92 @@ async fn audit_list_requires_admin() {
     assert!(body["entries"].is_array());
 }
 
+/// The RFC 3339 time bounds must actually bind server-side.
+///
+/// This is the failure mode worth a test: a `from` the route cannot
+/// deserialize is not an error, it is an absent filter — so a query
+/// that should return nothing returns the entire log instead, and the
+/// caller reads that as "these are the entries in my window".
+#[tokio::test]
+async fn audit_time_bounds_are_parsed_and_applied() {
+    let (app, ctx) = TestApp::new().await;
+    let token = ctx.auth_token("did:key:z6MkAdmin", "admin", vec![]).await;
+
+    // Generate at least one auditable event.
+    app.request(post_auth(
+        "/keys",
+        &token,
+        json!({"key_type": "ed25519", "context_id": "ctx1"}),
+    ))
+    .await;
+
+    let (status, body) = app.request(get_auth("/audit/logs", &token)).await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(
+        !body["entries"].as_array().expect("entries").is_empty(),
+        "expected some audit entries to filter"
+    );
+
+    // A window that starts in the far future must exclude everything.
+    let (status, body) = app
+        .request(get_auth("/audit/logs?from=2999-01-01T00:00:00Z", &token))
+        .await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(
+        body["entries"].as_array().expect("entries").is_empty(),
+        "a far-future `from` must exclude every entry — got {}",
+        body["entries"]
+    );
+
+    // `to` is exclusive and also has to bind.
+    let (status, body) = app
+        .request(get_auth("/audit/logs?to=2000-01-01T00:00:00Z", &token))
+        .await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(
+        body["entries"].as_array().expect("entries").is_empty(),
+        "a far-past `to` must exclude every entry — got {}",
+        body["entries"]
+    );
+}
+
+/// The audit log is the whole agent's tail — every context's activity
+/// in one stream. An admin confined to one context must not be able to
+/// read the others' entries just by omitting the filter.
+#[tokio::test]
+async fn scoped_admin_cannot_read_the_whole_audit_log() {
+    let (app, ctx) = TestApp::new().await;
+    let token = ctx
+        .auth_token("did:key:z6MkScoped", "admin", vec!["ctx1".into()])
+        .await;
+
+    // No contextId → refused: this would be the whole-log tail.
+    let (status, _) = app.request(get_auth("/audit/logs", &token)).await;
+    assert_eq!(
+        status,
+        StatusCode::FORBIDDEN,
+        "a context-scoped admin must not read the unfiltered log"
+    );
+
+    // A context they do not hold → refused.
+    let (status, _) = app
+        .request(get_auth("/audit/logs?contextId=ctx2", &token))
+        .await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+
+    // Their own context → allowed.
+    let (status, body) = app
+        .request(get_auth("/audit/logs?contextId=ctx1", &token))
+        .await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(body["entries"].is_array());
+
+    // An unrestricted admin still reads everything.
+    let super_token = ctx.auth_token("did:key:z6MkAdmin", "admin", vec![]).await;
+    let (status, _) = app.request(get_auth("/audit/logs", &super_token)).await;
+    assert_eq!(status, StatusCode::OK);
+}
+
 // ── Context scoping ────────────────────────────────────────────────
 
 #[tokio::test]
@@ -1369,10 +1455,18 @@ async fn operations_create_audit_entries() {
         entries.len()
     );
 
-    // Verify audit entries have expected fields
+    // Verify entries carry the canonical `AuditEnvelope` shape —
+    // camelCase names, and `recordedAt` as RFC 3339 rather than an
+    // epoch number.
     let entry = &entries[0];
-    assert!(entry["id"].is_string());
-    assert!(entry["timestamp"].is_number());
+    assert!(entry["eventId"].is_string());
+    let recorded_at = entry["recordedAt"]
+        .as_str()
+        .expect("recordedAt is a string");
+    assert!(
+        chrono::DateTime::parse_from_rfc3339(recorded_at).is_ok(),
+        "recordedAt should be RFC 3339, got {recorded_at}"
+    );
     assert!(entry["action"].is_string());
     assert!(entry["actor"].is_string());
 }

--- a/vta-service/tests/client_round_trip.rs
+++ b/vta-service/tests/client_round_trip.rs
@@ -272,3 +272,134 @@ async fn config_registry_round_trips_and_identity_stays_read_only() {
          just the refusal"
     );
 }
+
+// ── Audit ───────────────────────────────────────────────────────────
+
+/// Audit list through the real client: the canonical envelope survives
+/// the trip, and cursor pagination actually advances.
+///
+/// The failure this catches is quiet in both directions. The stored row
+/// keeps its snake_case storage shape (`id`, `timestamp`) while the wire
+/// carries the canonical camelCase envelope (`eventId`, `recordedAt`),
+/// so a mapping that drops a field yields `None`, not an error — the
+/// client parses a row full of nulls and the CLI prints em-dashes. And
+/// a cursor the client fails to send back is not an error either; the
+/// server simply returns page one again, so a caller walking the log
+/// loops forever on the newest entries and never sees the tail.
+#[tokio::test]
+async fn audit_list_round_trips_through_the_real_client() {
+    let mock = MockVta::start().await;
+    let client = admin_client(&mock).await;
+
+    // Generate audit rows by doing auditable work through the client.
+    for i in 0..5 {
+        client
+            .create_acl(
+                CreateAclRequest::new(format!("did:key:z6MkAuditSubject{i}"), "application")
+                    .contexts(vec!["ctx1".into()]),
+            )
+            .await
+            .expect("grant round-trips");
+    }
+
+    let params = vta_sdk::protocols::audit_management::list::ListAuditLogsBody {
+        page_size: Some(2),
+        ..Default::default()
+    };
+    let first = client
+        .list_audit_logs(&params)
+        .await
+        .expect("audit/list round-trips");
+
+    assert_eq!(first.entries.len(), 2, "pageSize must be honoured");
+    assert!(
+        first.truncated && first.cursor.is_some(),
+        "more entries exist, so the page must be marked truncated with a cursor"
+    );
+
+    // The envelope arrives populated — not a shape-compatible row of
+    // nulls.
+    let entry = &first.entries[0];
+    assert!(
+        !entry.event_id.is_empty(),
+        "eventId must survive: {entry:?}"
+    );
+    assert!(
+        chrono::DateTime::parse_from_rfc3339(&entry.recorded_at).is_ok(),
+        "recordedAt must be RFC 3339, got {:?}",
+        entry.recorded_at
+    );
+    assert!(!entry.action.is_empty(), "action must survive: {entry:?}");
+    assert!(
+        entry.actor.is_some(),
+        "actor must survive — 'who did this' is the question a log answers: {entry:?}"
+    );
+
+    // Page two is *different* entries, not the same page again.
+    let next = client
+        .list_audit_logs(
+            &vta_sdk::protocols::audit_management::list::ListAuditLogsBody {
+                cursor: first.cursor.clone(),
+                ..params.clone()
+            },
+        )
+        .await
+        .expect("continuation round-trips");
+
+    let first_ids: Vec<&str> = first.entries.iter().map(|e| e.event_id.as_str()).collect();
+    for entry in &next.entries {
+        assert!(
+            !first_ids.contains(&entry.event_id.as_str()),
+            "the cursor must advance past page one, but {} repeated",
+            entry.event_id
+        );
+    }
+    assert!(!next.entries.is_empty(), "page two should hold entries");
+}
+
+/// The filters are bound into the cursor, so resuming a page under a
+/// different filter set is refused rather than silently answered from a
+/// position that belonged to another query.
+#[tokio::test]
+async fn audit_cursor_is_bound_to_its_filters() {
+    let mock = MockVta::start().await;
+    let client = admin_client(&mock).await;
+
+    for i in 0..5 {
+        client
+            .create_acl(
+                CreateAclRequest::new(format!("did:key:z6MkBoundSubject{i}"), "application")
+                    .contexts(vec!["ctx1".into()]),
+            )
+            .await
+            .expect("grant round-trips");
+    }
+
+    let first = client
+        .list_audit_logs(
+            &vta_sdk::protocols::audit_management::list::ListAuditLogsBody {
+                page_size: Some(1),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("audit/list round-trips");
+    let cursor = first.cursor.expect("more entries remain");
+
+    let err = client
+        .list_audit_logs(
+            &vta_sdk::protocols::audit_management::list::ListAuditLogsBody {
+                page_size: Some(1),
+                cursor: Some(cursor),
+                // A filter that was not in force when the cursor was minted.
+                action: Some("acl.create".into()),
+                ..Default::default()
+            },
+        )
+        .await;
+
+    assert!(
+        err.is_err(),
+        "changing the filters while resuming must be refused, got {err:?}"
+    );
+}

--- a/vtc-service/tests/trust_task_manifest.rs
+++ b/vtc-service/tests/trust_task_manifest.rs
@@ -437,11 +437,12 @@ const UNPUBLISHED_CANONICAL_OK: &[(&str, usize, &str)] = &[
     // 77.
     (
         "https://trusttasks.org/spec/vta/",
-        47,
+        46,
         "VTA Trust Task surface at 1.0 — predates the registry and was never reconciled with it. \
          Down from 55 via #840 phase A: config/{get,update} onto config/{show,patch}, \
-         provision-integration/request onto provision/integration/0.2, and acl/* onto the \
-         canonical acl/{grant,show,list,update,revoke} family",
+         provision-integration/request onto provision/integration/0.2, acl/* onto the \
+         canonical acl/{grant,show,list,update,revoke} family, and audit/list-logs onto \
+         audit/list/0.1. Phase A is complete at 46",
     ),
 ];
 

--- a/vti-common/Cargo.toml
+++ b/vti-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-common"
 description = "Shared server-side infrastructure for VTA and VTC services"
 readme = "README.md"
-version = "0.11.28"
+version = "0.11.29"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vti-common/src/pagination/mod.rs
+++ b/vti-common/src/pagination/mod.rs
@@ -20,10 +20,17 @@
 //! - **Opaque to consumers.** The cursor is a base64url-encoded
 //!   binary blob; clients pass it back verbatim. No public structure.
 //! - **Tamper-evident.** The cursor's payload is HMAC-SHA256-signed
-//!   under the per-community `audit_key`. A cursor minted for
-//!   community A can't be replayed against community B; a guessed
-//!   cursor can't iterate past the protocol boundary. See
-//!   [`Cursor::decode`] for the verification flow.
+//!   under a per-maintainer 32-byte key. A cursor minted by one
+//!   maintainer can't be replayed against another; a guessed cursor
+//!   can't iterate past the protocol boundary. See [`Cursor::decode`]
+//!   for the verification flow.
+//!
+//!   Where that key comes from depends on what the maintainer already
+//!   has. The VTC signs under the active `audit_key` from its
+//!   [`crate::audit::AuditKeyStore`]. A maintainer with no such store
+//!   — the VTA keeps a flat audit log with no hash chain — uses
+//!   [`CursorKey`], which persists a random key in a keyspace of the
+//!   caller's choosing and is used for nothing but cursor MACs.
 //! - **No structural feedback on failure.** A tampered, forged, or
 //!   malformed cursor returns [`AppError::InvalidCursor`] (400) with
 //!   no detail. The HMAC verification + payload deserialisation share
@@ -259,6 +266,81 @@ impl Cursor {
 }
 
 // ---------------------------------------------------------------------------
+// CursorKey — signing key for maintainers with no audit-key store
+// ---------------------------------------------------------------------------
+
+/// Storage key the [`CursorKey`] material lives under. Deliberately
+/// namespaced away from any `log:` / `audit_key:` prefix so a cursor
+/// key can share a keyspace with the rows it paginates.
+const CURSOR_KEY_STORAGE_KEY: &[u8] = b"pagination:cursor_key/v1";
+
+/// A keyspace-persisted 32-byte HMAC key for signing pagination
+/// cursors.
+///
+/// The VTC signs its cursors under the active `audit_key` from its
+/// [`crate::audit::AuditKeyStore`]. The VTA has no such store — it
+/// keeps a flat append-only log with no hash chain — but canonical
+/// `audit/list` still requires cursors that cannot be forged into a
+/// position the filters did not authorize. This is the minimum that
+/// buys: a random key, generated once and persisted, used for nothing
+/// but cursor MACs.
+///
+/// **Not** derived from the master seed. A cursor is ephemeral and
+/// carries no long-term secret, so seed derivation would only widen
+/// the seed's blast radius for no benefit; and a key that is *not*
+/// reproduced by a backup+restore is the safer default, since a
+/// cursor minted against one database should not silently resolve to
+/// a position in another.
+#[derive(Clone)]
+pub struct CursorKey {
+    ks: crate::store::KeyspaceHandle,
+}
+
+impl CursorKey {
+    /// Wrap a keyspace. The key is created lazily on first [`Self::get`].
+    pub fn new(ks: crate::store::KeyspaceHandle) -> Self {
+        Self { ks }
+    }
+
+    /// Read the signing key, generating and persisting one if this is
+    /// the first call against a fresh store.
+    ///
+    /// Creation is atomic via
+    /// [`crate::store::KeyspaceHandle::insert_raw_if_absent`]: a
+    /// concurrent creator loses the race and re-reads the winner's
+    /// key, so two requests arriving together never mint cursors under
+    /// different keys.
+    pub async fn get(&self) -> Result<[u8; 32], AppError> {
+        if let Some(existing) = self.read().await? {
+            return Ok(existing);
+        }
+
+        let mut fresh = [0u8; 32];
+        rand::fill(&mut fresh);
+        self.ks
+            .insert_raw_if_absent(CURSOR_KEY_STORAGE_KEY.to_vec(), fresh.to_vec())
+            .await?;
+
+        // Re-read unconditionally rather than trusting the bool: on a
+        // lost race the winner's key is the one every other request is
+        // already signing under.
+        self.read().await?.ok_or_else(|| {
+            AppError::Internal("cursor key vanished immediately after creation".into())
+        })
+    }
+
+    async fn read(&self) -> Result<Option<[u8; 32]>, AppError> {
+        let Some(raw) = self.ks.get_raw(CURSOR_KEY_STORAGE_KEY.to_vec()).await? else {
+            return Ok(None);
+        };
+        let key: [u8; 32] = raw.try_into().map_err(|_| {
+            AppError::Internal("stored cursor key is not 32 bytes; refusing to sign".into())
+        })?;
+        Ok(Some(key))
+    }
+}
+
+// ---------------------------------------------------------------------------
 // paginate helper
 // ---------------------------------------------------------------------------
 
@@ -342,6 +424,78 @@ mod tests {
 
     const KEY_A: [u8; 32] = [0xAA; 32];
     const KEY_B: [u8; 32] = [0xBB; 32];
+
+    fn temp_ks() -> (crate::store::KeyspaceHandle, tempfile::TempDir) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cfg = crate::config::StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        };
+        let store = crate::store::Store::open(&cfg).expect("store");
+        let ks = store.keyspace("cursor-key-test").expect("keyspace");
+        (ks, dir)
+    }
+
+    /// The key must be stable across calls — a key regenerated per
+    /// request would invalidate every cursor the moment it was handed
+    /// out, so pagination would never advance past page one.
+    #[tokio::test]
+    async fn cursor_key_is_created_once_and_reused() {
+        let (ks, _dir) = temp_ks();
+
+        let first = CursorKey::new(ks.clone()).get().await.expect("mint");
+        let second = CursorKey::new(ks.clone()).get().await.expect("reuse");
+        assert_eq!(first, second);
+        assert_ne!(first, [0u8; 32], "the key must be random, not zeroed");
+
+        // A cursor minted under it survives a round trip through a
+        // freshly-constructed handle over the same keyspace.
+        let c = Cursor::new(b"log:00000000000000000001:abc".to_vec(), 1);
+        let wire = c.encode_bound(&first, b"binding");
+        assert_eq!(Cursor::decode_bound(&wire, &second, b"binding").unwrap(), c);
+    }
+
+    /// The key must survive an **encrypted** keyspace.
+    ///
+    /// This is the deployment case, not an edge case: the VTA's audit
+    /// keyspace — where this key lives — is encrypted at rest. The key
+    /// is stored via the raw byte API and read back with a 32-byte
+    /// `try_into`, so if encrypt-on-write and decrypt-on-read were not
+    /// symmetric the read would see ciphertext of the wrong length and
+    /// every audit list call would fail. A plaintext-only test would
+    /// never show it.
+    #[cfg(feature = "encryption")]
+    #[tokio::test]
+    async fn cursor_key_round_trips_through_an_encrypted_keyspace() {
+        let (ks, _dir) = temp_ks();
+        let ks = ks.with_encryption([0x5A; 32]);
+        assert!(
+            ks.is_encrypted(),
+            "the test must exercise the encrypted path"
+        );
+
+        let first = CursorKey::new(ks.clone()).get().await.expect("mint");
+        let second = CursorKey::new(ks).get().await.expect("read back");
+        assert_eq!(first, second, "the key must survive the encryption layer");
+        assert_ne!(first, [0u8; 32]);
+    }
+
+    /// Two keyspaces are two independent keys, so a cursor cannot be
+    /// replayed from one store against another.
+    #[tokio::test]
+    async fn cursor_keys_are_per_keyspace() {
+        let (ks_a, _a) = temp_ks();
+        let (ks_b, _b) = temp_ks();
+
+        let key_a = CursorKey::new(ks_a).get().await.expect("a");
+        let key_b = CursorKey::new(ks_b).get().await.expect("b");
+        assert_ne!(key_a, key_b);
+
+        let wire = Cursor::new(b"log:1:x".to_vec(), 1).encode(&key_a);
+        assert!(matches!(
+            Cursor::decode(&wire, &key_b),
+            Err(AppError::InvalidCursor)
+        ));
+    }
 
     /// A bound cursor only decodes under the same binding. This is what
     /// stops a filtered listing from being resumed under different


### PR DESCRIPTION
Closes the last item of #840 phase A. `spec/vta/` unpublished-canonical count goes **47 → 46**; phase A is complete.

This is the one item in phase A that was never a rename. Canonical `audit/list/0.1` and the VTA's `vta/audit/list-logs/1.0` disagree on how paging works, on what the filters mean, and on who is allowed to read.

## Offset paging → opaque cursor

The old surface took a 1-based `page` and returned `total` / `totalPages`. An offset is only stable if nothing is appended while a consumer walks the pages — and an audit log is appended to constantly, including by the very reads being paged. Page 2 of a log that grew by ten rows silently re-shows rows from page 1 and skips others.

Paging is now by opaque continuation cursor over the storage key (`log:{timestamp}:{uuid}`), which is a stable position under concurrent appends. Responses carry `truncated` plus a `cursor` present iff truncated.

`truncated` means "more **matching** entries remain", not "more rows remain": with a filter applied the tail may hold nothing that matches, and returning a cursor for an empty next page would read as results being withheld.

## Cursors are signed and bound

Canonical requires a cursor that cannot be forged into a position the filters did not authorize, and says a maintainer SHOULD bind it to the caller. The HMAC here covers the filters **and the caller's DID** — so resuming under a changed filter set is refused rather than silently answered from another query's position, and a leaked cursor is not a cross-principal read.

The VTC already signs its cursors under the active `audit_key` from its `AuditKeyStore`. The VTA has no such store (flat log, no hash chain), so this adds `vti_common::pagination::CursorKey`: a random 32-byte key created once and persisted in the audit keyspace, used for nothing but cursor MACs. Creation is atomic via `insert_raw_if_absent`, so concurrent first-requests converge on one key.

Deliberately **not** seed-derived. A cursor carries no long-term secret, so seed derivation would only widen the seed's blast radius; and a key that a backup+restore does not reproduce is the safer default, since a cursor minted against one database should not resolve to a position in another.

## A context-scoped admin could read every context's audit entries

Found while diffing against canonical, which states the gate directly: *"This is the tightest-gated read a maintainer offers; a context-scoped admin does not qualify for the whole-log tail."*

The VTA's gate was `require_admin()`, which tests only `role == Admin` and ignores `allowed_contexts` entirely. So an admin deliberately confined to one context could read the whole agent's tail — every other context's actors and actions included.

Now an unrestricted admin reads anything, and a scoped admin must name a `contextId` within their own scope (which the filter then confines the results to). Resolved through `is_super_admin` / `has_context_access`, never by testing `allowed_contexts` directly — the same rule that #746, #769 and #770 each got wrong in a different place.

Gated on super-admin-vs-scoped-admin, so this is a confinement escape rather than a privilege escalation, and it required an already-admin credential.

## An invalid cursor was reported as a server fault on two of three transports

Introducing a rejectable cursor exposed a gap in the shared error mapping. `AppError::InvalidCursor` sat in the catch-all arm of both the Trust-Task reject mapping (`internal_error`) and the DIDComm problem-report mapping (`e.p.msg.internal-error`); only REST answered 400.

That inverts the caller's response: told "internal error", a consumer retries the same cursor, when the correct action — and the one canonical specifies for `invalidCursor` — is to restart from the first page. Both now map to malformed-request / bad-request, pinned by a case in the existing `app_error_maps_to_byte_identical_codes` contract test.

## Operator-visible behaviour changes

- `action` and `outcome` match on **equality**, not substring. `action=vault.delete` no longer also returns `vault.delete_force` — the old behaviour quietly widened a query, so an operator could not tell which rows they had actually asked for.
- `to` is now **exclusive** (canonical); was inclusive.
- `from` / `to` are RFC 3339, not epoch seconds — on the wire and on the CLI.
- Query params are camelCase (`pageSize`, `contextId`), per R3.1. They were snake_case.
- Max page size is 200 (the workspace-wide pagination cap); was 500.
- `pnm audit list --page N` → `--cursor <token>`. The command prints the continuation token when more entries remain.

## Storage shape is untouched

Entries now go out as the canonical camelCase `AuditEnvelope` (`eventId`, `recordedAt` as RFC 3339, `target`, `contextId`). `AuditLogEntry` — which is the **on-disk format** for the audit keyspace — keeps its shape; renaming its fields would orphan every row already written. The envelope is built from it at the response boundary. The VTA's `channel` and free-text `reason`, which have no canonical envelope field, ride in `detail` (canonical types it as an event-specific object).

## Testing

Requests are now schema-validated at the dispatch spine, which the old unpublished URI never was.

- **Canonical conformance** (`trust_tasks/audit.rs`) — the serialized request and response are deserialized into the *generated* `trust_tasks_rs` canonical types, which carry `deny_unknown_fields` and the spec's required set. Includes a guard assertion that a drifted response *is* rejected, so the check cannot pass vacuously.
- **Round-trip** (`client_round_trip.rs`, ×2) — real client against real router: the envelope arrives populated and the cursor advances past page one; a changed filter is refused.
- **Integration** (`api_integration.rs`, ×2) — the scope gate; and the RFC 3339 bounds actually binding server-side (a `from` the route cannot parse is not an error, it is an *absent filter*, so a query that should return nothing returns the whole log).
- **Unit** (`vti-common/pagination`, ×2) — the cursor key is created once and reused, and is per-keyspace.

Every new behavioural test was **mutation-verified**: with the filter binding removed, with the resume position ignored, and with the `from` bound dropped, each fails for its own distinct reason.

`cargo test --workspace` and `cargo clippy --workspace -- -D warnings` clean; both release guards pass.
