### PR TITLE
refactor(webvh): fold servers/{add,update} into servers/register

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,43 @@
 
 ## Unreleased
 
+### vta-sdk 0.20.15 / vta-service 0.13.7 — `webvh/servers/{add,update}` fold into `webvh/servers/register`
+
+Second reduction of the `spec/vta/webvh/*` family (#840 phase B). Takes the
+unpublished-canonical count for `spec/vta/` from 45 to **44**.
+
+`servers/update`'s body was `servers/add`'s minus `did`, and both returned the
+same `WebvhServerRecord`. They now share one task, with the `id` deciding what
+happens rather than a mode flag: an unregistered `id` requires `did` and
+validates it before storing; a registered one updates the label.
+
+**A different `did` for an existing `id` is refused.** This is why the merge is
+not a blind upsert. Without the guard the update branch — which only ever
+touched `label` — would silently *ignore* the new DID and report success, so a
+caller would believe they had re-pointed a registration when nothing had
+changed. Re-pointing for real also needs coordinated teardown on the old host,
+since every DID resolving through that registration follows it. Same reasoning
+that makes `dids/register-with-server` refuse an already-server-managed DID.
+
+**Operator surfaces are unchanged.** Both REST routes (`POST /webvh/servers`,
+`PATCH /webvh/servers/{id}`), both CLI verbs, and both legacy DIDComm protocol
+messages are kept, all now backed by the one operation — one task, reused
+several times. `PATCH` keeps its 404 for an unknown id, because "no stored
+record and no `did` to create one with" resolves to `NotFound` rather than a
+validation error. It also still needs no DID resolver: the resolver is now
+`Option`, required only on the create path, so a relabel cannot fail on a VTA
+that has none.
+
+One behaviour change: `POST /webvh/servers` for an already-registered `id` with
+the *same* `did` now succeeds idempotently (updating the label) instead of
+returning 409. A colliding `id` with a *different* `did` is still refused.
+
+Covered by a round-trip case in `vta-service/tests/client_round_trip.rs` driving
+the real client against the real router across every path — relabel, idempotent
+re-register, refused re-point (asserting the stored record is untouched
+afterwards), and patch-unknown-id. Mutation-verified: with the guard removed,
+the re-point silently succeeds.
+
 ### vta-sdk 0.20.14 / vta-service 0.13.6 — `webvh/dids/get-log` folds into `webvh/dids/get`
 
 First reduction of the `spec/vta/webvh/*` family (#840 phase B). Takes the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10269,7 +10269,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.20.14"
+version = "0.20.15"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10331,7 +10331,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.13.6"
+version = "0.13.7"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/docs/05-design-notes/trust-task-uri-registry.md
+++ b/docs/05-design-notes/trust-task-uri-registry.md
@@ -191,8 +191,7 @@ dispatcher's `KNOWN_FEATURE_GATED_URIS` allowlist for builds where
 | URI | Today's surface | Status |
 |---|---|---|
 | `spec/vta/webvh/servers/list/1.0` | webvh server CRUD on VTA side | implemented |
-| `spec/vta/webvh/servers/add/1.0` | (REST `POST /webvh/servers`) | implemented |
-| `spec/vta/webvh/servers/update/1.0` | | implemented |
+| `spec/vta/webvh/servers/register/1.0` | (REST `POST /webvh/servers`, `PATCH /webvh/servers/{id}`) | implemented — **absorbed `servers/add` + `servers/update`**: update's body was add's minus `did`, both returned the same record. A `did` that differs from the stored one is refused, not treated as a re-point |
 | `spec/vta/webvh/servers/remove/1.0` | | implemented |
 | `spec/vta/webvh/dids/list/1.0` | DIDs hosted/known to this VTA | implemented |
 | `spec/vta/webvh/dids/create/1.0` | Mint new DID via template + register with host | implemented |
@@ -385,7 +384,7 @@ Both services touch WebVH DIDs. Disambiguation:
 
 Concrete examples:
 - VTA wants to rotate a key on a DID it controls → `spec/vta/webvh/dids/rotate-keys/1.0` to the VTA, which then sends `spec/webvh/did/sync-update/1.0` to the host. Two different URIs, two different actions, on two different services.
-- Operator wants to add a host to their VTA's known-hosts list → `spec/vta/webvh/servers/add/1.0`. Adding a controller authorisation to the host itself → `spec/did-hosting/acl/create/1.0`.
+- Operator wants to add a host to their VTA's known-hosts list → `spec/vta/webvh/servers/register/1.0`. Adding a controller authorisation to the host itself → `spec/did-hosting/acl/create/1.0`.
 
 ## Excluded from migration
 
@@ -449,7 +448,7 @@ REST:
   GET    /services/didcomm/drain                    → vta/services/didcomm/drain/list/1.0
   POST   /services/didcomm/drain/cancel             → vta/services/didcomm/drain/cancel/1.0
   GET    /mediators/report                          → vta/services/mediators/report/1.0
-  POST   /webvh/servers                             → vta/webvh/servers/add/1.0
+  POST   /webvh/servers                             → vta/webvh/servers/register/1.0
   GET    /webvh/servers                             → vta/webvh/servers/list/1.0
   …(see WebVH-DID-lifecycle slice for the rest)…
   GET    /did-templates                             → vta/did-templates/list/1.0

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.20.14"
+version = "0.20.15"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/protocols/did_management/servers.rs
+++ b/vta-sdk/src/protocols/did_management/servers.rs
@@ -2,16 +2,38 @@ use serde::{Deserialize, Serialize};
 
 use crate::webvh::WebvhServerRecord;
 
+/// Request for `spec/vta/webvh/servers/register/1.0`.
+///
+/// Absorbs the former `servers/update/1.0`, whose body was this one
+/// minus `did` and which returned the same `WebvhServerRecord`.
+///
+/// Which operation runs is decided by whether `id` is already
+/// registered, not by a mode flag:
+///
+/// - **new `id`** — `did` is required, gets validated (it must resolve
+///   and advertise a WebVH service), and the registration is created.
+/// - **existing `id`** — the label is updated. `did` may be omitted, or
+///   repeated identically for an idempotent re-register; supplying a
+///   *different* `did` is refused.
+///
+/// That last rule is the point of not making this a blind upsert.
+/// Re-pointing a registration at another host would silently redirect
+/// every DID that resolves through it, and doing so safely needs
+/// coordinated teardown on the old host — the same reasoning that makes
+/// `dids/register-with-server` refuse an already-server-managed DID.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-pub struct AddWebvhServerBody {
+pub struct RegisterWebvhServerBody {
     pub id: String,
-    pub did: String,
+    /// Required when registering a new `id`; on an existing one it may
+    /// be omitted or repeated identically, but never changed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub did: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub label: Option<String>,
 }
 
-pub type AddWebvhServerResultBody = WebvhServerRecord;
+pub type RegisterWebvhServerResultBody = WebvhServerRecord;
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
@@ -57,16 +79,6 @@ pub struct WebvhServerDomainEntry {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub label: Option<String>,
 }
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-pub struct UpdateWebvhServerBody {
-    pub id: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub label: Option<String>,
-}
-
-pub type UpdateWebvhServerResultBody = WebvhServerRecord;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]

--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -868,19 +868,19 @@ pub const TASK_PROVISION_INTEGRATION_REQUEST_1_0: &str =
 pub const TASK_WEBVH_SERVERS_LIST_1_0: &str =
     "https://trusttasks.org/spec/vta/webvh/servers/list/1.0";
 
-/// `spec/vta/webvh/servers/add/1.0` — register a new webvh host.
-/// Payload:
-/// [`crate::protocols::did_management::servers::AddWebvhServerBody`].
+/// `spec/vta/webvh/servers/register/1.0` — register a webvh host, or
+/// update the label of one already registered. Payload:
+/// [`crate::protocols::did_management::servers::RegisterWebvhServerBody`].
 /// Auth: Super Admin.
-pub const TASK_WEBVH_SERVERS_ADD_1_0: &str =
-    "https://trusttasks.org/spec/vta/webvh/servers/add/1.0";
-
-/// `spec/vta/webvh/servers/update/1.0` — patch a registered webvh
-/// host's label. Payload:
-/// [`crate::protocols::did_management::servers::UpdateWebvhServerBody`].
-/// Auth: Super Admin.
-pub const TASK_WEBVH_SERVERS_UPDATE_1_0: &str =
-    "https://trusttasks.org/spec/vta/webvh/servers/update/1.0";
+///
+/// Absorbs the retired `servers/add/1.0` and `servers/update/1.0`:
+/// update's body was add's minus `did`, and both returned the same
+/// `WebvhServerRecord`. Which runs is decided by whether `id` is
+/// already registered — see the payload docs, including why supplying
+/// a *different* `did` for an existing `id` is refused rather than
+/// treated as a re-point.
+pub const TASK_WEBVH_SERVERS_REGISTER_1_0: &str =
+    "https://trusttasks.org/spec/vta/webvh/servers/register/1.0";
 
 /// `spec/vta/webvh/servers/remove/1.0` — deregister a webvh host.
 /// Payload:
@@ -1402,8 +1402,7 @@ pub const ALL_URIS: &[&str] = &[
     TASK_PROVISION_INTEGRATION_REQUEST_1_0,
     // WebVH-DID-lifecycle slice (feature-gated: webvh)
     TASK_WEBVH_SERVERS_LIST_1_0,
-    TASK_WEBVH_SERVERS_ADD_1_0,
-    TASK_WEBVH_SERVERS_UPDATE_1_0,
+    TASK_WEBVH_SERVERS_REGISTER_1_0,
     TASK_WEBVH_SERVERS_REMOVE_1_0,
     TASK_WEBVH_DIDS_LIST_1_0,
     TASK_WEBVH_DIDS_CREATE_1_0,

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.13.6"
+version = "0.13.7"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/messaging/handlers.rs
+++ b/vta-service/src/messaging/handlers.rs
@@ -910,14 +910,16 @@ didcomm_handler!(
 #[cfg(feature = "webvh")]
 didcomm_handler!(
     resolver handle_add_webvh_server, Gate::None, did_management::ADD_WEBVH_SERVER_RESULT,
-    did_management::servers::AddWebvhServerBody,
-    |s, auth, body, did_resolver| operations::did_webvh::add_webvh_server(
+    did_management::servers::RegisterWebvhServerBody,
+    // Trust Task folded into `servers/register`; this legacy DIDComm
+    // message stays for wire compatibility, backed by the merged op.
+    |s, auth, body, did_resolver| operations::did_webvh::register_webvh_server(
         &s.webvh_ks,
         &auth,
         &body.id,
-        &body.did,
+        body.did.as_deref(),
         body.label,
-        did_resolver,
+        Some(did_resolver),
         "didcomm",
     )
     .await
@@ -963,15 +965,19 @@ didcomm_handler!(
 
 #[cfg(feature = "webvh")]
 didcomm_handler!(
-    handle_update_webvh_server,
-    Gate::None,
+    resolver handle_update_webvh_server, Gate::None,
     did_management::UPDATE_WEBVH_SERVER_RESULT,
-    did_management::servers::UpdateWebvhServerBody,
-    |s, auth, body| operations::did_webvh::update_webvh_server(
+    did_management::servers::RegisterWebvhServerBody,
+    // As above: kept for wire compatibility, backed by the merged op.
+    // A `did` that differs from the stored one is refused there rather
+    // than silently re-pointing the registration.
+    |s, auth, body, did_resolver| operations::did_webvh::register_webvh_server(
         &s.webvh_ks,
         &auth,
         &body.id,
+        body.did.as_deref(),
         body.label,
+        Some(did_resolver),
         "didcomm",
     )
     .await

--- a/vta-service/src/operations/did_webvh/mod.rs
+++ b/vta-service/src/operations/did_webvh/mod.rs
@@ -32,8 +32,7 @@ pub use register_server::{
     register_did_with_server,
 };
 pub use servers::{
-    add_webvh_server, list_webvh_server_domains, list_webvh_servers, remove_webvh_server,
-    update_webvh_server,
+    list_webvh_server_domains, list_webvh_servers, register_webvh_server, remove_webvh_server,
 };
 pub use update::{
     AgentNameVerb, RotateDidWebvhKeysOptions, UpdateDidWebvhError, UpdateDidWebvhOptions,

--- a/vta-service/src/operations/did_webvh/servers.rs
+++ b/vta-service/src/operations/did_webvh/servers.rs
@@ -16,29 +16,68 @@ use crate::error::AppError;
 use crate::store::KeyspaceHandle;
 use crate::webvh_store;
 use vta_sdk::protocols::did_management::servers::{
-    AddWebvhServerResultBody, ListWebvhServersResultBody, RemoveWebvhServerResultBody,
-    UpdateWebvhServerResultBody,
+    ListWebvhServersResultBody, RegisterWebvhServerResultBody, RemoveWebvhServerResultBody,
 };
 use vta_sdk::webvh::WebvhServerRecord;
 
-pub async fn add_webvh_server(
+/// Register a webvh host, or update the label of one already
+/// registered — `spec/vta/webvh/servers/register/1.0`.
+///
+/// The `id` decides which happens; there is no mode flag. A new `id`
+/// requires `did` and validates it over the network before storing. An
+/// existing `id` updates the label only, and a `did` that differs from
+/// the stored one is **refused**: re-pointing a registration silently
+/// redirects every DID resolving through it, and unwinding that needs
+/// coordinated teardown on the old host.
+pub async fn register_webvh_server(
     webvh_ks: &KeyspaceHandle,
     auth: &AuthClaims,
     id: &str,
-    server_did: &str,
+    server_did: Option<&str>,
     label: Option<String>,
-    did_resolver: &DIDCacheClient,
+    // Only needed to create a registration — the label-only path never
+    // resolves anything, so a caller that is just relabelling may pass
+    // `None` rather than having to construct a resolver.
+    did_resolver: Option<&DIDCacheClient>,
     channel: &str,
-) -> Result<AddWebvhServerResultBody, AppError> {
+) -> Result<RegisterWebvhServerResultBody, AppError> {
     auth.require_super_admin()?;
 
-    if webvh_store::get_server(webvh_ks, id).await?.is_some() {
-        return Err(AppError::Conflict(format!(
-            "webvh server already exists: {id}"
-        )));
+    if let Some(mut record) = webvh_store::get_server(webvh_ks, id).await? {
+        // Re-registering the same host is idempotent; pointing the same
+        // id at a different host is not something this op will do.
+        if let Some(did) = server_did
+            && did != record.did
+        {
+            return Err(AppError::Conflict(format!(
+                "webvh server {id} is registered to {}; re-pointing it at {did} would redirect                  every DID resolving through it. Remove the registration and add it again,                  after migrating those DIDs off the old host",
+                record.did
+            )));
+        }
+
+        if let Some(lbl) = label {
+            record.label = if lbl.is_empty() { None } else { Some(lbl) };
+        }
+        record.updated_at = Utc::now();
+        webvh_store::store_server(webvh_ks, &record).await?;
+
+        info!(channel, id = %id, "webvh server updated");
+        return Ok(record);
     }
 
-    // Validate the DID resolves and has a supported WebVH service
+    // No stored record and no `did` to create one with: the caller was
+    // updating something that does not exist. NotFound (404), not a
+    // validation error — this is what preserves `PATCH
+    // /webvh/servers/{id}`'s contract now that it shares this op.
+    let server_did = server_did.ok_or_else(|| {
+        AppError::NotFound(format!(
+            "webvh server not found: {id}; supply `did` to register it"
+        ))
+    })?;
+
+    // Validate the DID resolves and has a supported WebVH service.
+    let did_resolver =
+        did_resolver.ok_or_else(|| AppError::Internal("DID resolver not available".into()))?;
     validate_server_did(did_resolver, server_did).await?;
 
     let now = Utc::now();
@@ -156,30 +195,6 @@ pub async fn list_webvh_server_domains(
         "webvh server hosting domains listed"
     );
     Ok(entries)
-}
-
-pub async fn update_webvh_server(
-    webvh_ks: &KeyspaceHandle,
-    auth: &AuthClaims,
-    id: &str,
-    label: Option<String>,
-    channel: &str,
-) -> Result<UpdateWebvhServerResultBody, AppError> {
-    auth.require_super_admin()?;
-
-    let mut record = webvh_store::get_server(webvh_ks, id)
-        .await?
-        .ok_or_else(|| AppError::NotFound(format!("webvh server not found: {id}")))?;
-
-    if let Some(lbl) = label {
-        record.label = if lbl.is_empty() { None } else { Some(lbl) };
-    }
-    record.updated_at = Utc::now();
-
-    webvh_store::store_server(webvh_ks, &record).await?;
-
-    info!(channel, id = %id, "webvh server updated");
-    Ok(record)
 }
 
 pub async fn remove_webvh_server(

--- a/vta-service/src/routes/did_webvh.rs
+++ b/vta-service/src/routes/did_webvh.rs
@@ -8,8 +8,8 @@ use vta_sdk::protocols::did_management::{
     get::GetDidWebvhResultBody,
     list::ListDidsWebvhResultBody,
     servers::{
-        AddWebvhServerResultBody, ListWebvhServersResultBody, RegisterDidWithServerBody,
-        RegisterDidWithServerResultBody, UpdateWebvhServerResultBody,
+        ListWebvhServersResultBody, RegisterDidWithServerBody, RegisterDidWithServerResultBody,
+        RegisterWebvhServerResultBody,
     },
 };
 
@@ -44,7 +44,7 @@ pub struct ListDidsQuery {
     security(("bearer_jwt" = [])),
     request_body = AddServerRequest,
     responses(
-        (status = 201, description = "Server registered", body = AddWebvhServerResultBody),
+        (status = 201, description = "Server registered", body = RegisterWebvhServerResultBody),
         (status = 401, description = "Missing or invalid bearer token"),
         (status = 403, description = "Caller is not a super-admin"),
     ),
@@ -53,18 +53,18 @@ pub async fn add_server_handler(
     auth: SuperAdminAuth,
     State(state): State<AppState>,
     Json(req): Json<AddServerRequest>,
-) -> Result<(StatusCode, Json<AddWebvhServerResultBody>), AppError> {
+) -> Result<(StatusCode, Json<RegisterWebvhServerResultBody>), AppError> {
     let did_resolver = state
         .did_resolver
         .as_ref()
         .ok_or_else(|| AppError::Internal("DID resolver not available".into()))?;
-    let result = operations::did_webvh::add_webvh_server(
+    let result = operations::did_webvh::register_webvh_server(
         &state.webvh_ks,
         &auth.0,
         &req.id,
-        &req.did,
+        Some(&req.did),
         req.label,
-        did_resolver,
+        Some(did_resolver),
         "rest",
     )
     .await?;
@@ -139,7 +139,7 @@ pub struct UpdateServerRequest {
     params(("id" = String, Path, description = "Server identifier")),
     request_body = UpdateServerRequest,
     responses(
-        (status = 200, description = "Server updated", body = UpdateWebvhServerResultBody),
+        (status = 200, description = "Server updated", body = RegisterWebvhServerResultBody),
         (status = 401, description = "Missing or invalid bearer token"),
         (status = 403, description = "Caller is not a super-admin"),
         (status = 404, description = "Server not found"),
@@ -150,12 +150,18 @@ pub async fn update_server_handler(
     State(state): State<AppState>,
     Path(id): Path<String>,
     Json(req): Json<UpdateServerRequest>,
-) -> Result<Json<UpdateWebvhServerResultBody>, AppError> {
-    let result = operations::did_webvh::update_webvh_server(
+) -> Result<Json<RegisterWebvhServerResultBody>, AppError> {
+    // `did: None` keeps this a label-only patch: the merged op returns
+    // NotFound for an unknown id rather than creating one, so PATCH's
+    // 404 contract is unchanged — and it needs no resolver, exactly as
+    // before the merge.
+    let result = operations::did_webvh::register_webvh_server(
         &state.webvh_ks,
         &auth.0,
         &id,
+        None,
         req.label,
+        None,
         "rest",
     )
     .await?;

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -142,8 +142,7 @@ const KNOWN_FEATURE_GATED_URIS: &[&str] = &[
     // entries list the same URIs and are tracked by the parity harness when
     // `webvh` is on; this allowlist covers builds where `webvh` is off.
     vta_sdk::trust_tasks::TASK_WEBVH_SERVERS_LIST_1_0,
-    vta_sdk::trust_tasks::TASK_WEBVH_SERVERS_ADD_1_0,
-    vta_sdk::trust_tasks::TASK_WEBVH_SERVERS_UPDATE_1_0,
+    vta_sdk::trust_tasks::TASK_WEBVH_SERVERS_REGISTER_1_0,
     vta_sdk::trust_tasks::TASK_WEBVH_SERVERS_REMOVE_1_0,
     vta_sdk::trust_tasks::TASK_WEBVH_DIDS_LIST_1_0,
     vta_sdk::trust_tasks::TASK_WEBVH_DIDS_CREATE_1_0,
@@ -902,10 +901,7 @@ dispatch_table! {
     vta_sdk::trust_tasks::TASK_WEBVH_SERVERS_LIST_1_0 => webvh::handle_servers_list
         [ None Metadata false ],
     #[cfg(feature = "webvh")]
-    vta_sdk::trust_tasks::TASK_WEBVH_SERVERS_ADD_1_0 => webvh::handle_servers_add
-        [ Mutating None false ],
-    #[cfg(feature = "webvh")]
-    vta_sdk::trust_tasks::TASK_WEBVH_SERVERS_UPDATE_1_0 => webvh::handle_servers_update
+    vta_sdk::trust_tasks::TASK_WEBVH_SERVERS_REGISTER_1_0 => webvh::handle_servers_register
         [ Mutating None false ],
     #[cfg(feature = "webvh")]
     vta_sdk::trust_tasks::TASK_WEBVH_SERVERS_REMOVE_1_0 => webvh::handle_servers_remove

--- a/vta-service/src/trust_tasks/webvh.rs
+++ b/vta-service/src/trust_tasks/webvh.rs
@@ -46,8 +46,8 @@ use vta_sdk::protocols::did_management::{
     get::GetDidWebvhBody,
     list::ListDidsWebvhBody,
     servers::{
-        AddWebvhServerBody, ListWebvhServersBody, RegisterDidWithServerBody,
-        RegisterDidWithServerResultBody, RemoveWebvhServerBody, UpdateWebvhServerBody,
+        ListWebvhServersBody, RegisterDidWithServerBody, RegisterDidWithServerResultBody,
+        RegisterWebvhServerBody, RemoveWebvhServerBody,
     },
     update::{RotateDidWebvhKeysBody, UpdateDidWebvhBody},
 };
@@ -85,8 +85,11 @@ pub(super) async fn handle_servers_list(
     }
 }
 
-/// `webvh/servers/add/1.0` — register a new webvh host. Super-admin.
-pub(super) async fn handle_servers_add(
+/// `webvh/servers/register/1.0` — register a webvh host, or update the
+/// label of one already registered. Super-admin.
+///
+/// Absorbs the retired `servers/add/1.0` and `servers/update/1.0`.
+pub(super) async fn handle_servers_register(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
@@ -94,7 +97,7 @@ pub(super) async fn handle_servers_add(
     if let Err(e) = auth.require_super_admin() {
         return app_error_to_reject(&doc, e);
     }
-    let req: AddWebvhServerBody = match parse_payload(&doc) {
+    let req: RegisterWebvhServerBody = match parse_payload(&doc) {
         Ok(r) => r,
         Err(resp) => return resp,
     };
@@ -107,40 +110,13 @@ pub(super) async fn handle_servers_add(
             );
         }
     };
-    match operations::did_webvh::add_webvh_server(
+    match operations::did_webvh::register_webvh_server(
         &state.webvh_ks,
         auth,
         &req.id,
-        &req.did,
+        req.did.as_deref(),
         req.label,
-        did_resolver,
-        TRANSPORT_TRUST_TASK,
-    )
-    .await
-    {
-        Ok(body) => success_response(&doc, body),
-        Err(e) => app_error_to_reject(&doc, e),
-    }
-}
-
-/// `webvh/servers/update/1.0` — patch a webvh host's label. Super-admin.
-pub(super) async fn handle_servers_update(
-    state: &AppState,
-    auth: &AuthClaims,
-    doc: TrustTask<Value>,
-) -> TrustTaskOutcome {
-    if let Err(e) = auth.require_super_admin() {
-        return app_error_to_reject(&doc, e);
-    }
-    let req: UpdateWebvhServerBody = match parse_payload(&doc) {
-        Ok(r) => r,
-        Err(resp) => return resp,
-    };
-    match operations::did_webvh::update_webvh_server(
-        &state.webvh_ks,
-        auth,
-        &req.id,
-        req.label,
+        Some(did_resolver),
         TRANSPORT_TRUST_TASK,
     )
     .await

--- a/vta-service/src/webvh_cli.rs
+++ b/vta-service/src/webvh_cli.rs
@@ -43,13 +43,13 @@ pub async fn run_add_server(
     let did_resolver = DIDCacheClient::new(DIDCacheConfigBuilder::default().build()).await?;
 
     let auth = cli_super_admin();
-    let result = operations::did_webvh::add_webvh_server(
+    let result = operations::did_webvh::register_webvh_server(
         &webvh_ks,
         &auth,
         &id,
-        &did,
+        Some(&did),
         label,
-        &did_resolver,
+        Some(&did_resolver),
         "cli",
     )
     .await?;
@@ -102,8 +102,12 @@ pub async fn run_update_server(
     let webvh_ks = cs.keyspace(crate::keyspaces::WEBVH)?;
 
     let auth = cli_super_admin();
-    let result =
-        operations::did_webvh::update_webvh_server(&webvh_ks, &auth, &id, label, "cli").await?;
+    // `did: None` — label-only, so an unknown id is NotFound rather
+    // than a silent registration, and no resolver is needed.
+    let result = operations::did_webvh::register_webvh_server(
+        &webvh_ks, &auth, &id, None, label, None, "cli",
+    )
+    .await?;
     cs.persist().await?;
 
     eprintln!("WebVH server updated:");

--- a/vta-service/tests/client_round_trip.rs
+++ b/vta-service/tests/client_round_trip.rs
@@ -503,3 +503,89 @@ async fn webvh_get_did_round_trips_after_the_get_log_fold() {
         "the log must survive the merge into the flattened record"
     );
 }
+
+// ── WebVH server registration ───────────────────────────────────────
+
+/// The merged `servers/register` behaves correctly on every path the
+/// two tasks it replaces used to cover, through the real client.
+///
+/// The one that matters is the last: an upsert keyed only on `id`
+/// would happily re-point an existing registration at a different
+/// host. That silently redirects every DID resolving through it, and
+/// unwinding it needs coordinated teardown on the old host — so the
+/// merge has to refuse it rather than treat it as an update.
+#[tokio::test]
+async fn webvh_server_register_upserts_but_refuses_a_repoint() {
+    use vta_sdk::client::{AddWebvhServerRequest, UpdateWebvhServerRequest};
+
+    let mock = MockVta::start().await;
+    let client = admin_client(&mock).await;
+
+    let host_did = "did:web:host-one.example";
+    mock.seed_webvh_server("host1", host_did).await;
+
+    // Label-only update, the path that was `servers/update`.
+    let updated = client
+        .update_webvh_server(
+            "host1",
+            UpdateWebvhServerRequest {
+                label: Some("renamed".into()),
+            },
+        )
+        .await
+        .expect("relabel round-trips");
+    assert_eq!(updated.label.as_deref(), Some("renamed"));
+    assert_eq!(updated.did, host_did, "a relabel must not touch the DID");
+
+    // Re-registering the same host is idempotent rather than a conflict.
+    let again = client
+        .add_webvh_server(AddWebvhServerRequest {
+            id: "host1".into(),
+            did: host_did.into(),
+            label: Some("same host".into()),
+        })
+        .await
+        .expect("re-registering an identical host is idempotent");
+    assert_eq!(again.did, host_did);
+    assert_eq!(again.label.as_deref(), Some("same host"));
+
+    // Re-pointing at a different host is refused.
+    let repoint = client
+        .add_webvh_server(AddWebvhServerRequest {
+            id: "host1".into(),
+            did: "did:web:host-two.example".into(),
+            label: None,
+        })
+        .await;
+    assert!(
+        repoint.is_err(),
+        "re-pointing a registration at a different DID must be refused, got {repoint:?}"
+    );
+
+    // …and the stored record is untouched by the refused attempt.
+    let servers = client.list_webvh_servers().await.expect("list round-trips");
+    let host1 = servers
+        .servers
+        .iter()
+        .find(|s| s.id == "host1")
+        .expect("host1 still registered");
+    assert_eq!(
+        host1.did, host_did,
+        "a refused re-point must leave the registration alone"
+    );
+
+    // A label-only patch against an unknown id is still NotFound, not a
+    // silent registration.
+    let missing = client
+        .update_webvh_server(
+            "nope",
+            UpdateWebvhServerRequest {
+                label: Some("x".into()),
+            },
+        )
+        .await;
+    assert!(
+        missing.is_err(),
+        "patching an unregistered server must fail, got {missing:?}"
+    );
+}

--- a/vtc-service/tests/trust_task_manifest.rs
+++ b/vtc-service/tests/trust_task_manifest.rs
@@ -437,13 +437,14 @@ const UNPUBLISHED_CANONICAL_OK: &[(&str, usize, &str)] = &[
     // 77.
     (
         "https://trusttasks.org/spec/vta/",
-        45,
+        44,
         "VTA Trust Task surface at 1.0 — predates the registry and was never reconciled with it. \
          Down from 55 via #840 phase A: config/{get,update} onto config/{show,patch}, \
          provision-integration/request onto provision/integration/0.2, acl/* onto the \
          canonical acl/{grant,show,list,update,revoke} family, and audit/list-logs onto \
-         audit/list/0.1. Phase A complete at 46; phase B then folded \
-         webvh/dids/get-log into webvh/dids/get",
+         audit/list/0.1. Phase A complete at 46; phase B folded \
+         webvh/dids/get-log into webvh/dids/get, and webvh/servers/{add,update} \
+         into webvh/servers/register",
     ),
 ];
 


### PR DESCRIPTION
Second reduction of the `spec/vta/webvh/*` family (#840 phase B). Takes the unpublished-canonical count for `spec/vta/` from 45 to **44**.

## The fold

`servers/update`'s body was `servers/add`'s minus `did`, and both returned the same `WebvhServerRecord`. They become one task, with the `id` deciding what happens rather than a mode flag:

- **unregistered `id`** — `did` required, validated over the network (it must resolve and advertise a WebVH service), registration created.
- **registered `id`** — label updated.

## Why it is not a blind upsert

**A `did` that differs from the stored one is refused.** Without that guard the update branch — which only ever touched `label` — would silently *ignore* the new DID and return success, so a caller would believe they had re-pointed a registration when nothing had changed. Re-pointing for real also needs coordinated teardown on the old host, since every DID resolving through the registration follows it. This is the same call `dids/register-with-server` already makes when it refuses an already-server-managed DID.

## A caveat worth stating

This pair is a **weaker** merge candidate than `dids/{get,get-log}` in #849, and I'd rather say so than oversell it. Those two were one read under two names. These two differ in more than payload: `add` does a network DID validation with its own failure mode, `update` is a local write. The payload diff alone doesn't show that — it only surfaced on reading the operation bodies.

What makes it defensible is the precedent already set in this programme: canonical `acl/grant` is an upsert, adopted in #842. This applies the same shape.

## Operator surfaces are unchanged

Both REST routes, both CLI verbs, and both legacy DIDComm protocol messages (which are not Trust Task URIs, so they don't affect the count) are kept, all backed by the one operation — one task, reused several times.

Two details that keep `PATCH /webvh/servers/{id}` exactly as it was:

- Its **404** survives, because "no stored record and no `did` to create one with" resolves to `NotFound` rather than a validation error.
- It still needs **no DID resolver**. The resolver parameter is now `Option`, required only on the create path, so a relabel cannot start failing on a VTA configured without one. Threading a required resolver through the patch path would have been a quiet regression.

One deliberate behaviour change: `POST /webvh/servers` for an already-registered `id` with the *same* `did` now succeeds idempotently (updating the label) instead of returning 409. A colliding `id` with a *different* `did` is still refused.

## Testing

A round-trip case in `vta-service/tests/client_round_trip.rs` drives the **real client against the real router** across every path the two tasks used to cover: relabel, idempotent re-register, refused re-point — asserting the stored record is untouched after the refusal — and patch-unknown-id.

**Mutation-verified**: with the guard removed, the re-point silently succeeds and returns a record whose DID never changed.

`cargo test --workspace` and `cargo clippy --workspace -- -D warnings` clean; both release guards pass.

## Where this leaves phase B

18 URIs → **16**, which is the realistic ceiling rather than the ~14 originally estimated. The remaining candidate was the four `agent-name` verbs — identical request *and* response types, so tempting — but `disable` parks a name while `remove` releases it for anyone to reclaim. Collapsing them would put materially different blast radii behind one authorization decision and one audit action. The contract is already shared (one `AgentNameBody` reused four times), which is the reuse that matters; the URIs stay split.
