### PR TITLE
feat(acl): split role changes out of acl/update into acl/change-role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,65 @@
 
 ## Unreleased
 
+### vta-sdk 0.20.16 / vta-service 0.13.8 / vta-cli-common 0.10.20 / pnm-cli 0.11.14 — role changes split out of `acl/update` into `acl/change-role`
+
+Closes the known remainder of #840 phase A. The VTA's `acl/update` accepted a
+`role`, but canonical `acl/update/0.1` defines no such member: the transition
+belongs to `acl/change-role/0.1`, which carries a **compare-and-swap** on the
+subject's current role. Both URIs are already published, so the
+unpublished-canonical count is unchanged at 44 — this is a correctness fix, not
+a reduction.
+
+**Why role is the one attribute that needs the check.** Everywhere else a lost
+update is an inconvenience; here it is a privilege change. Two admins acting on
+the same stale read — one demoting to `reader`, one promoting to `admin` —
+both succeed under a blind write, and whichever lands second silently wins. The
+loser's intent vanishes with no error anywhere, and when the loser was the
+*demotion*, someone stays an admin who was meant to be removed. Declaring
+`fromRole` turns that race into a refusal naming the role actually found.
+
+The check is backed by a versioned write (`update_acl_entry_versioned`), because
+comparing the role and then storing is still read-then-write on its own; the
+version guard closes the window between them.
+
+Two authorization guards run after the swap. `validate_role_assignment` decides
+whether the caller may confer the target role at all. `validate_acl_modification`
+— the same check `create` applies — decides whether the *resulting* entry is one
+the caller could have created directly, which is what stops promotion being an
+escalation route: an entry with an empty scope list is authorized **nowhere**
+while its role is non-admin, but flipping that same entry to `admin` makes it
+**unrestricted**.
+
+**Surfaces:**
+
+- New Trust Task `acl/change-role/0.1`, REST `POST /acl/{did}/change-role`,
+  DIDComm `change-role`, and `VtaClient::change_acl_role`.
+- New `pnm acl change-role --did <did> --from <role> --to <role> [--reason]`.
+- `acl/update` and `PATCH /acl/{did}` now **refuse** a role rather than ignoring
+  it — silently dropping it would report success while leaving the subject's
+  privileges exactly as they were.
+- `pnm acl update --role` is kept only so it can name its replacement: it looks
+  up the role the subject actually holds and prints the full corrected command,
+  since `--from` is the one argument an operator cannot guess.
+- An unrecognized role is a 400, not the 500 that `Role::parse` returns by
+  default.
+
+**Separately found, not fixed here.** `acl/update`'s *request* body is not
+canonical: it emits `did`/`allowedContexts` where the schema requires
+`subject`/`scopes`, and has no nested `stepUp`/`approve`. #842 made the response
+canonical and repointed the URI but left the request shape alone. Because that
+URI is published, the dispatch spine validates against the canonical schema, so
+`acl/update` over the **Trust Task** transport is rejected today (REST and the
+legacy DIDComm message use their own bodies and are unaffected). Pinned by a
+comment in the conformance test rather than asserted, so it cannot be mistaken
+for conformant; the fix is its own change.
+
+Covered by a round-trip case driving the real client against the real router:
+the valid transition, a stale `fromRole` refused with the entry left untouched,
+an unrecognized role refused, and `update` leaving the role alone.
+Mutation-verified — with the compare-and-swap removed, the stale request
+promotes the subject to `admin`.
+
 ### vta-sdk 0.20.15 / vta-service 0.13.7 — `webvh/servers/{add,update}` fold into `webvh/servers/register`
 
 Second reduction of the `spec/vta/webvh/*` family (#840 phase B). Takes the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6759,7 +6759,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "pnm-cli"
-version = "0.11.13"
+version = "0.11.14"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-resolver-cache-sdk",
@@ -10118,7 +10118,7 @@ dependencies = [
 
 [[package]]
 name = "vta-cli-common"
-version = "0.10.19"
+version = "0.10.20"
 dependencies = [
  "aes-gcm",
  "affinidi-crypto",
@@ -10269,7 +10269,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.20.15"
+version = "0.20.16"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10331,7 +10331,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.13.7"
+version = "0.13.8"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/pnm-cli/Cargo.toml
+++ b/pnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pnm-cli"
 description = "CLI Tool for managing a personal Verifiable Trust Agent"
-version = "0.11.13"
+version = "0.11.14"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/pnm-cli/src/cli.rs
+++ b/pnm-cli/src/cli.rs
@@ -1809,10 +1809,33 @@ pub(crate) enum AclCommands {
         approve_contexts: Vec<String>,
     },
     /// Update an ACL entry
+    /// Change a subject's role, guarded by a compare-and-swap.
+    ///
+    /// `--from` is the role you believe they hold. If another admin has
+    /// moved them since you looked, the change is refused rather than
+    /// silently overwriting theirs — re-read with `pnm acl get` and retry.
+    ChangeRole {
+        /// DID of the entry whose role is changing
+        #[arg(long)]
+        did: String,
+        /// The role the subject currently holds
+        #[arg(long = "from")]
+        from_role: String,
+        /// The role to move them to
+        #[arg(long = "to")]
+        to_role: String,
+        /// Optional rationale, recorded in the audit log
+        #[arg(long)]
+        reason: Option<String>,
+    },
     Update {
         /// DID of the entry to update
         did: String,
-        /// New role
+        /// New role.
+        ///
+        /// Refused — role changes need `pnm acl change-role`, which carries
+        /// the compare-and-swap. Kept here so the error can name the exact
+        /// replacement command rather than reading as an unknown flag.
         #[arg(long)]
         role: Option<String>,
         /// New label

--- a/pnm-cli/src/commands/acl.rs
+++ b/pnm-cli/src/commands/acl.rs
@@ -67,6 +67,12 @@ pub(crate) async fn run(
             )
             .await
         }
+        AclCommands::ChangeRole {
+            did,
+            from_role,
+            to_role,
+            reason,
+        } => acl::cmd_acl_change_role(client, &did, &from_role, &to_role, reason).await,
         AclCommands::Delete { did } => acl::cmd_acl_delete(client, &did).await,
     }
 }

--- a/tests/e2e/tests/client_didcomm.rs
+++ b/tests/e2e/tests/client_didcomm.rs
@@ -528,7 +528,6 @@ async fn update_acl_via_didcomm() {
     .await;
 
     let req = UpdateAclRequest {
-        role: Some("reader".into()),
         label: None,
         allowed_contexts: None,
         step_up_approver: None,
@@ -536,6 +535,44 @@ async fn update_acl_via_didcomm() {
         approve_scope: None,
     };
     client.update_acl("did:key:zAdmin", req).await.unwrap();
+
+    shutdown_all(client, responder, mediator).await;
+}
+
+/// The client must send `change-role` over a message type the router
+/// actually handles. Adding the client method without registering the
+/// DIDComm arm compiles cleanly and fails only at runtime with
+/// "unsupported message type" — which is precisely what happened while
+/// this task was being split out.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn change_acl_role_via_didcomm() {
+    let (mediator, responder, client) = build_didcomm(|msg_type, body| {
+        if msg_type == acl_management::CHANGE_ROLE {
+            // The compare-and-swap has to reach the maintainer, or the
+            // check it exists for cannot run.
+            assert_eq!(body["fromRole"], "reader", "fromRole must be sent: {body}");
+            assert_eq!(body["toRole"], "application", "toRole must be sent: {body}");
+            ResponderReply::ok(
+                acl_management::CHANGE_ROLE_RESULT,
+                acl_entry_envelope("did:key:zAdmin"),
+            )
+        } else {
+            ResponderReply::problem_report("e.p.msg.not-found", "no handler")
+        }
+    })
+    .await;
+
+    client
+        .change_acl_role(
+            "did:key:zAdmin",
+            vta_sdk::client::ChangeAclRoleRequest {
+                from_role: "reader".into(),
+                to_role: "application".into(),
+                reason: None,
+            },
+        )
+        .await
+        .unwrap();
 
     shutdown_all(client, responder, mediator).await;
 }

--- a/vta-cli-common/Cargo.toml
+++ b/vta-cli-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-cli-common"
 description = "Shared CLI command handlers and rendering helpers for VTA CLIs"
 readme = "README.md"
-version = "0.10.19"
+version = "0.10.20"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-cli-common/src/commands/acl.rs
+++ b/vta-cli-common/src/commands/acl.rs
@@ -4,6 +4,7 @@ use ratatui::{
     widgets::{Block, Cell, Row, Table},
 };
 use vta_sdk::acl::{ApproveScope, ContextDirection};
+use vta_sdk::client::ChangeAclRoleRequest;
 use vta_sdk::prelude::*;
 use vti_common::acl::{Role, act_scope_for};
 
@@ -370,6 +371,39 @@ pub fn approve_scope_from_flags(
     }
 }
 
+/// `pnm acl change-role` — transition a subject's role with a
+/// compare-and-swap on the role they currently hold.
+pub async fn cmd_acl_change_role(
+    client: &VtaClient,
+    did: &str,
+    from_role: &str,
+    to_role: &str,
+    reason: Option<String>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    validate_role(from_role)?;
+    validate_role(to_role)?;
+
+    let entry = client
+        .change_acl_role(
+            did,
+            ChangeAclRoleRequest {
+                from_role: from_role.to_string(),
+                to_role: to_role.to_string(),
+                reason,
+            },
+        )
+        .await?;
+
+    println!("ACL role changed:");
+    println!("  DID:  {}", entry.did);
+    println!(
+        "  Role: {} \u{2192} {}",
+        from_role,
+        format_role(&entry.role, &entry.allowed_contexts)
+    );
+    Ok(())
+}
+
 #[allow(clippy::too_many_arguments)]
 pub async fn cmd_acl_update(
     client: &VtaClient,
@@ -381,12 +415,28 @@ pub async fn cmd_acl_update(
     step_up_require: Option<String>,
     approve_scope: Option<ApproveScope>,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    // Role transitions moved to `acl change-role`, which carries the
+    // compare-and-swap that makes a concurrent edit an error instead of a
+    // silent overwrite. Rather than just refusing, look up the role the
+    // subject actually holds so the operator can copy the fixed command —
+    // `--from` is the one argument they cannot guess.
     if let Some(ref r) = role {
         validate_role(r)?;
+        let current = client
+            .get_acl(did)
+            .await
+            .ok()
+            .map(|e| e.role)
+            .unwrap_or_else(|| "<current-role>".to_string());
+        return Err(format!(
+            "role changes are not part of `acl update` — they need the compare-and-swap that \
+             `acl change-role` carries.\n\n  Run: pnm acl change-role --did {did} --from \
+             {current} --to {r}"
+        )
+        .into());
     }
     let approve_scope_echo = approve_scope.clone();
     let req = UpdateAclRequest {
-        role,
         label,
         allowed_contexts: contexts,
         step_up_approver: step_up_approver.clone(),

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.20.15"
+version = "0.20.16"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/client/acl.rs
+++ b/vta-sdk/src/client/acl.rs
@@ -2,8 +2,8 @@
 
 use super::types::AclEntryEnvelope;
 use super::{
-    AclEntryResponse, AclListResponse, CreateAclRequest, SwapAclRequest, UpdateAclRequest,
-    VtaClient, encode_path_segment,
+    AclEntryResponse, AclListResponse, ChangeAclRoleRequest, CreateAclRequest, SwapAclRequest,
+    UpdateAclRequest, VtaClient, encode_path_segment,
 };
 use crate::acl::ContextDirection;
 use crate::error::VtaError;
@@ -113,7 +113,6 @@ impl VtaClient {
                 acl_management::UPDATE_ACL,
                 serde_json::json!({
                     "subject": did,
-                    "role": &req.role,
                     "label": &req.label,
                     "allowed_contexts": &req.allowed_contexts,
                 }),
@@ -122,6 +121,41 @@ impl VtaClient {
                 |c, url| {
                     c.patch(format!("{url}/acl/{}", encode_path_segment(did)))
                         .json(&req)
+                },
+            )
+            .await?;
+        Ok(wrapped.entry)
+    }
+
+    /// Transition a subject's role, compare-and-swapped against the role
+    /// they currently hold.
+    ///
+    /// Separate from [`Self::update_acl`] because role is the one ACL
+    /// attribute where a lost update is a privilege change. If another
+    /// admin has moved the subject since you read them, this fails
+    /// rather than overwriting their change — re-read and retry.
+    pub async fn change_acl_role(
+        &self,
+        did: &str,
+        req: ChangeAclRoleRequest,
+    ) -> Result<AclEntryResponse, VtaError> {
+        let wrapped: AclEntryEnvelope = self
+            .rpc(
+                acl_management::CHANGE_ROLE,
+                serde_json::json!({
+                    "subject": did,
+                    "fromRole": &req.from_role,
+                    "toRole": &req.to_role,
+                    "reason": &req.reason,
+                }),
+                acl_management::CHANGE_ROLE_RESULT,
+                30,
+                |c, url| {
+                    c.post(format!(
+                        "{url}/acl/{}/change-role",
+                        encode_path_segment(did)
+                    ))
+                    .json(&req)
                 },
             )
             .await?;

--- a/vta-sdk/src/client/mod.rs
+++ b/vta-sdk/src/client/mod.rs
@@ -2105,7 +2105,6 @@ mod tests {
     #[test]
     fn test_update_acl_request_all_none() {
         let req = UpdateAclRequest {
-            role: None,
             label: None,
             allowed_contexts: None,
             step_up_approver: None,

--- a/vta-sdk/src/client/types.rs
+++ b/vta-sdk/src/client/types.rs
@@ -596,8 +596,6 @@ impl SwapAclRequest {
 #[derive(Debug, Serialize)]
 pub struct UpdateAclRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub role: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub label: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub allowed_contexts: Option<Vec<String>>,
@@ -689,6 +687,21 @@ pub struct CreateDidWebvhRequest {
     /// `CONTEXT_ID`, `CONTEXT_DID`, `NOW`) are injected automatically.
     #[serde(default, skip_serializing_if = "std::collections::HashMap::is_empty")]
     pub template_vars: std::collections::HashMap<String, serde_json::Value>,
+}
+
+/// Request for `VtaClient::change_acl_role`.
+///
+/// `from_role` is the compare-and-swap: the role the caller believes the
+/// subject holds. The VTA refuses the transition if its stored role differs,
+/// so a race against another admin surfaces as an error rather than one
+/// change silently overwriting the other.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ChangeAclRoleRequest {
+    pub from_role: String,
+    pub to_role: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
 }
 
 // ── WebVH DID log types ──────────────────────────────────────────────

--- a/vta-sdk/src/protocols/acl_management/change_role.rs
+++ b/vta-sdk/src/protocols/acl_management/change_role.rs
@@ -1,0 +1,38 @@
+//! Wire types for canonical `acl/change-role/0.1`.
+
+use serde::{Deserialize, Serialize};
+
+use super::create::CreateAclResultBody;
+
+/// Request payload for `acl/change-role/0.1`.
+///
+/// Role is the one ACL attribute where a lost update is a privilege
+/// change, so the transition is **state-checked** rather than applied
+/// blind: the producer declares the role it believes the subject holds,
+/// and a maintainer whose stored role differs rejects the change
+/// instead of overwriting.
+///
+/// Concretely, without this two admins acting on the same stale read —
+/// one demoting to `reader`, one promoting to `admin` — would both
+/// "succeed", and whichever landed second would silently win. The
+/// demotion would disappear with no error anywhere.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct ChangeRoleBody {
+    /// VID of the party whose role is changing.
+    pub subject: String,
+    /// The role the producer believes the subject currently holds. A
+    /// mismatch against the stored role is refused.
+    pub from_role: String,
+    /// The role to transition the subject to.
+    pub to_role: String,
+    /// Optional human-readable rationale, recorded with the change.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+/// Response payload — the entry as it stands after the transition.
+/// Same shape as `acl/update`'s, so a caller that already handles one
+/// handles the other.
+pub type ChangeRoleResultBody = CreateAclResultBody;

--- a/vta-sdk/src/protocols/acl_management/mod.rs
+++ b/vta-sdk/src/protocols/acl_management/mod.rs
@@ -1,3 +1,4 @@
+pub mod change_role;
 pub mod create;
 pub mod delete;
 pub mod entry;
@@ -23,6 +24,11 @@ pub const LIST_ACL_RESULT: &str =
 pub const UPDATE_ACL: &str = "https://firstperson.network/protocols/acl-management/1.0/update-acl";
 pub const UPDATE_ACL_RESULT: &str =
     "https://firstperson.network/protocols/acl-management/1.0/update-acl-result";
+
+pub const CHANGE_ROLE: &str =
+    "https://firstperson.network/protocols/acl-management/1.0/change-role";
+pub const CHANGE_ROLE_RESULT: &str =
+    "https://firstperson.network/protocols/acl-management/1.0/change-role-result";
 
 pub const DELETE_ACL: &str = "https://firstperson.network/protocols/acl-management/1.0/delete-acl";
 pub const DELETE_ACL_RESULT: &str =

--- a/vta-sdk/src/protocols/acl_management/update.rs
+++ b/vta-sdk/src/protocols/acl_management/update.rs
@@ -4,12 +4,17 @@ use crate::acl::ApproveScope;
 
 use super::create::CreateAclResultBody;
 
+/// Request payload for canonical `acl/update/0.1`.
+///
+/// Carries no `role`: canonical gives the role transition its own
+/// task (`acl/change-role/0.1`) so it can be compare-and-swapped
+/// against the subject's current role, which is what stops two admins
+/// on a stale read from silently overwriting one another on the one
+/// attribute where that is a privilege change.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct UpdateAclBody {
     pub did: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub role: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub label: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -212,10 +212,29 @@ pub const TASK_ACL_CREATE_1_0: &str = "https://trusttasks.org/spec/acl/grant/0.1
 /// [`crate::protocols::acl_management::get::GetAclBody`].
 pub const TASK_ACL_GET_1_0: &str = "https://trusttasks.org/spec/acl/show/0.1";
 
-/// `acl/update/0.1` — patch role, label, or allowed contexts.
-/// Payload: [`crate::protocols::acl_management::update::UpdateAclBody`].
+/// `acl/update/0.1` — patch label, scopes, expiry, step-up or approve
+/// authority on an existing entry. Payload:
+/// [`crate::protocols::acl_management::update::UpdateAclBody`].
 /// Auth: Admin only.
+///
+/// **Does not change roles.** Canonical gives that transition its own
+/// task so it can carry a compare-and-swap — see
+/// [`TASK_ACL_CHANGE_ROLE_0_1`]. A request naming a role here is
+/// refused rather than applied.
 pub const TASK_ACL_UPDATE_1_0: &str = "https://trusttasks.org/spec/acl/update/0.1";
+
+/// `acl/change-role/0.1` — transition a subject's role, guarded by a
+/// compare-and-swap on their current one. Payload:
+/// [`crate::protocols::acl_management::change_role::ChangeRoleBody`].
+/// Auth: Admin only.
+///
+/// Separate from [`TASK_ACL_UPDATE_1_0`] because role is the one
+/// attribute where losing an update is a privilege change: two admins
+/// editing concurrently could otherwise silently overwrite each other,
+/// and the loser's intent — say a demotion — would vanish with no
+/// error. The producer declares `fromRole`; a mismatch against the
+/// stored role is rejected instead of applied.
+pub const TASK_ACL_CHANGE_ROLE_0_1: &str = "https://trusttasks.org/spec/acl/change-role/0.1";
 
 /// `acl/revoke/0.1` — remove an entry. Payload:
 /// [`crate::protocols::acl_management::delete::DeleteAclBody`].
@@ -1315,6 +1334,7 @@ pub const ALL_URIS: &[&str] = &[
     TASK_ACL_CREATE_1_0,
     TASK_ACL_GET_1_0,
     TASK_ACL_UPDATE_1_0,
+    TASK_ACL_CHANGE_ROLE_0_1,
     TASK_ACL_DELETE_1_0,
     TASK_ACL_SWAP_KEY_1_0,
     // Contexts slice

--- a/vta-sdk/tests/client_rest.rs
+++ b/vta-sdk/tests/client_rest.rs
@@ -731,7 +731,6 @@ async fn update_acl_patches() {
     .await;
     let c = client(&server).await;
     let req = UpdateAclRequest {
-        role: Some("reader".into()),
         label: None,
         allowed_contexts: Some(vec!["ctx-b".into()]),
         step_up_approver: None,

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.13.7"
+version = "0.13.8"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/messaging/handlers.rs
+++ b/vta-service/src/messaging/handlers.rs
@@ -729,15 +729,34 @@ didcomm_handler!(
 );
 
 didcomm_handler!(
+    handle_change_acl_role,
+    // Admin-only, like the other role-bearing paths; the operation
+    // re-checks and also compare-and-swaps against `fromRole`.
+    Gate::Admin,
+    acl_management::CHANGE_ROLE_RESULT,
+    acl_management::change_role::ChangeRoleBody,
+    |s, auth, body| operations::acl::change_role(
+        &s.acl_ks,
+        &s.audit_ks,
+        &auth,
+        &body.subject,
+        &body.from_role,
+        &body.to_role,
+        body.reason.as_deref(),
+        "didcomm",
+    )
+    .await
+);
+
+didcomm_handler!(
     handle_update_acl,
     Gate::Manage,
     acl_management::UPDATE_ACL_RESULT,
     acl_management::update::UpdateAclBody,
     |s, auth, body| {
-        let role = match body.role {
-            Some(r) => Some(Role::parse(&r)?),
-            None => None,
-        };
+        // No `role` here: role transitions are `acl/change-role`, which
+        // carries the compare-and-swap this path cannot express.
+        let role = None;
         operations::acl::update_from_params(
             &s.acl_ks,
             &s.audit_ks,

--- a/vta-service/src/messaging/router.rs
+++ b/vta-service/src/messaging/router.rs
@@ -360,6 +360,9 @@ pub async fn dispatch(
     if t == acl_management::LIST_ACL {
         return finish(handlers::handle_list_acl(ctx, msg, Extension(vta_state)).await);
     }
+    if t == acl_management::CHANGE_ROLE {
+        return finish(handlers::handle_change_acl_role(ctx, msg, Extension(vta_state)).await);
+    }
     if t == acl_management::UPDATE_ACL {
         return finish(handlers::handle_update_acl(ctx, msg, Extension(vta_state)).await);
     }

--- a/vta-service/src/operations/acl.rs
+++ b/vta-service/src/operations/acl.rs
@@ -13,7 +13,8 @@ use vta_sdk::protocols::acl_management::{
 use crate::acl::{
     AclEntry, ApproveScope, ContextDirection, Role, acl_entry_matches_context, delete_acl_entry,
     get_acl_entry, is_acl_entry_auditable, is_acl_entry_visible, list_acl_entries, store_acl_entry,
-    validate_acl_modification, validate_approve_scope_grant, validate_role_assignment,
+    update_acl_entry_versioned, validate_acl_modification, validate_approve_scope_grant,
+    validate_role_assignment,
 };
 use crate::auth::AuthClaims;
 use crate::auth::session::now_epoch;
@@ -455,6 +456,105 @@ pub async fn update_acl(
         "success",
         Some(channel),
         None,
+    )
+    .await;
+    Ok(to_result_body(&entry))
+}
+
+/// `acl/change-role/0.1` — transition a subject's role, compare-and-swapped
+/// against the role the caller believes they hold.
+///
+/// Split out of [`update_acl`] because role is the one ACL attribute where a
+/// lost update is a privilege change. Two admins acting on the same stale read
+/// — one demoting to `reader`, one promoting to `admin` — would both succeed
+/// under a blind write, and whichever landed second would silently win. The
+/// demotion would vanish with no error anywhere. Declaring `from_role` turns
+/// that race into a refusal.
+///
+/// Two guards run *after* the compare-and-swap, and both matter:
+///
+/// - [`validate_role_assignment`] — may this caller hand out the target role
+///   at all (only an admin may confer admin).
+/// - [`validate_acl_modification`] — is the *resulting* entry one the caller
+///   could have created directly. This is what stops promotion being an
+///   escalation route: an entry with an empty `allowed_contexts` is authorized
+///   *nowhere* while its role is non-admin, but flipping that same entry to
+///   `admin` makes it **unrestricted** — a super-admin. Only a caller who is
+///   already unrestricted may do that.
+#[allow(clippy::too_many_arguments)]
+pub async fn change_role(
+    acl_ks: &KeyspaceHandle,
+    audit_ks: &KeyspaceHandle,
+    auth: &AuthClaims,
+    subject: &str,
+    from_role: &str,
+    to_role: &str,
+    reason: Option<&str>,
+    channel: &str,
+) -> Result<CreateAclResultBody, AppError> {
+    auth.require_admin()?;
+
+    let mut entry = get_acl_entry(acl_ks, subject)
+        .await?
+        .ok_or_else(|| AppError::NotFound(format!("ACL entry not found for DID: {subject}")))?;
+
+    if !is_acl_entry_visible(auth, &entry) {
+        return Err(not_manageable(auth, &entry, subject, "change-role"));
+    }
+
+    // `Role::parse` owns the vocabulary, but maps an unknown value to
+    // `Internal` — a 500 for what is a caller mistake. Re-map it: an
+    // unrecognized role is a bad request, which is also what canonical's
+    // `role_not_recognized` describes.
+    let parse = |raw: &str| -> Result<Role, AppError> {
+        Role::parse(raw).map_err(|_| {
+            AppError::Validation(format!(
+                "role not recognized: {raw}; expected one of admin, initiator, \
+                 application, reader, monitor"
+            ))
+        })
+    };
+    let from = parse(from_role)?;
+    let to = parse(to_role)?;
+
+    // The compare-and-swap. Report what was actually found — an operator
+    // racing another admin needs to see the role they lost to, not just
+    // that they lost.
+    if entry.role != from {
+        return Err(AppError::Conflict(format!(
+            "role of {subject} is {}, not {from} — the change was based on stale state. \
+             Re-read the entry and retry with the current role",
+            entry.role,
+        )));
+    }
+
+    validate_role_assignment(auth, &to)?;
+    validate_acl_modification(auth, &to, &entry.allowed_contexts)?;
+
+    let expected_version = entry.version;
+    entry.role = to;
+
+    // Versioned write rather than a plain store: the role check above is
+    // read-then-compare, so on its own it still leaves a window for another
+    // writer to land between the two. The version guard closes it.
+    update_acl_entry_versioned(acl_ks, entry.clone(), expected_version).await?;
+
+    info!(channel, did = %subject, from = %from_role, to = %to_role, "ACL role changed");
+    audit!(
+        "acl.change_role",
+        actor = &auth.did,
+        resource = subject,
+        outcome = "success"
+    );
+    let _ = audit::record_with_detail(
+        audit_ks,
+        "acl.change_role",
+        &auth.did,
+        Some(subject),
+        "success",
+        Some(channel),
+        None,
+        reason,
     )
     .await;
     Ok(to_result_body(&entry))

--- a/vta-service/src/routes/acl.rs
+++ b/vta-service/src/routes/acl.rs
@@ -152,9 +152,14 @@ pub struct UpdateAclRequest {
     pub approve_scope: Option<ApproveScope>,
 }
 
-/// PATCH /acl/{did} — update role, label, or allowed contexts for an ACL entry.
-/// Auth: Admin only (the operation layer also enforces this; gating at the
-/// extractor fails earlier with a clearer error).
+/// PATCH /acl/{did} — update label, contexts, step-up or approve authority on
+/// an ACL entry. Auth: Admin only (the operation layer also enforces this;
+/// gating at the extractor fails earlier with a clearer error).
+///
+/// **Role changes are refused here.** They belong to
+/// `POST /acl/{did}/change-role`, which carries the `fromRole`
+/// compare-and-swap; applying one without that check is how a concurrent
+/// demotion gets silently overwritten.
 #[utoipa::path(
     patch, path = "/acl/{did}", tag = "acl",
     security(("bearer_jwt" = [])),
@@ -174,6 +179,17 @@ pub async fn update_acl(
     Path(did): Path<String>,
     Json(req): Json<UpdateAclRequest>,
 ) -> Result<Json<CreateAclResponseBody>, AppError> {
+    // Refuse rather than ignore. Silently dropping a role from a patch
+    // would report success while leaving the subject's privileges exactly
+    // as they were — the caller believes they demoted someone who is still
+    // an admin.
+    if let Some(role) = &req.role {
+        return Err(AppError::Validation(format!(
+            "role changes are not part of `acl/update`; they need the compare-and-swap that \
+             `acl/change-role` carries. Run: pnm acl change-role --did {did} --from \
+             <current-role> --to {role}"
+        )));
+    }
     let result = operations::acl::update_from_params(
         &state.acl_ks,
         &state.audit_ks,
@@ -181,7 +197,7 @@ pub async fn update_acl(
         &auth.0,
         &did,
         operations::acl::UpdateAclParams {
-            role: req.role,
+            role: None,
             label: req.label,
             allowed_contexts: req.allowed_contexts,
             step_up_approver: req.step_up_approver,
@@ -192,6 +208,62 @@ pub async fn update_acl(
     )
     .await?;
     Ok(Json(result))
+}
+
+/// Request body for `POST /acl/{did}/change-role`.
+#[derive(Debug, Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ChangeRoleRequest {
+    /// The role the caller believes the subject currently holds. A
+    /// mismatch against the stored role is refused rather than applied.
+    pub from_role: String,
+    pub to_role: String,
+    #[serde(default)]
+    pub reason: Option<String>,
+}
+
+/// POST /acl/{did}/change-role — transition a subject's role, guarded by a
+/// compare-and-swap on `fromRole`. Auth: Admin only.
+///
+/// Split from `PATCH /acl/{did}` because role is the one attribute where a
+/// lost update is a privilege change: without the check, two admins on the
+/// same stale read silently overwrite one another and the loser's intent —
+/// a demotion, say — disappears with no error.
+#[utoipa::path(
+    post, path = "/acl/{did}/change-role", tag = "acl",
+    security(("bearer_jwt" = [])),
+    params(("did" = String, Path, description = "Subject DID")),
+    request_body = ChangeRoleRequest,
+    responses(
+        (status = 200, description = "Role changed", body = CreateAclResponseBody),
+        (status = 400, description = "Role not recognized"),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller may not confer the target role"),
+        (status = 404, description = "ACL entry not found"),
+        (status = 409, description = "Stored role does not match fromRole"),
+    ),
+)]
+pub async fn change_role(
+    auth: AdminAuth,
+    _step_up: RequireStepUp<AclChangeRoleOp>,
+    State(state): State<AppState>,
+    Path(did): Path<String>,
+    Json(req): Json<ChangeRoleRequest>,
+) -> Result<Json<CreateAclResponseBody>, AppError> {
+    let stored = operations::acl::change_role(
+        &state.acl_ks,
+        &state.audit_ks,
+        &auth.0,
+        &did,
+        &req.from_role,
+        &req.to_role,
+        req.reason.as_deref(),
+        "rest",
+    )
+    .await?;
+    Ok(Json(CreateAclResponseBody {
+        entry: vta_sdk::protocols::acl_management::entry::AclEntry::from_result(&stored),
+    }))
 }
 
 /// DELETE /acl/{did} — remove an ACL entry. Auth: Admin or Initiator.

--- a/vta-service/src/routes/mod.rs
+++ b/vta-service/src/routes/mod.rs
@@ -432,6 +432,7 @@ fn build_api_router(trust_xff: bool) -> OpenApiRouter<AppState> {
         // as a DID. Self-service key rotation (any authenticated caller).
         .routes(routes!(acl::swap_acl))
         .routes(routes!(acl::get_acl, acl::update_acl, acl::delete_acl))
+        .routes(routes!(acl::change_role))
         // Audit log routes
         .routes(routes!(audit::list_audit_logs))
         .routes(routes!(audit::get_retention, audit::update_retention))

--- a/vta-service/src/trust_tasks/acl.rs
+++ b/vta-service/src/trust_tasks/acl.rs
@@ -6,6 +6,7 @@
 use super::helpers::TrustTaskOutcome;
 use serde_json::{Value, json};
 use trust_tasks_rs::{RejectReason, TrustTask};
+use vta_sdk::protocols::acl_management::change_role::ChangeRoleBody;
 use vta_sdk::protocols::acl_management::create::CreateAclBody;
 use vta_sdk::protocols::acl_management::delete::DeleteAclBody;
 use vta_sdk::protocols::acl_management::get::GetAclBody;
@@ -13,7 +14,6 @@ use vta_sdk::protocols::acl_management::list::ListAclBody;
 use vta_sdk::protocols::acl_management::swap::SwapKeyBody;
 use vta_sdk::protocols::acl_management::update::UpdateAclBody;
 
-use crate::acl::Role;
 use crate::auth::AuthClaims;
 use crate::error::AppError;
 use crate::operations;
@@ -114,20 +114,8 @@ pub(super) async fn handle_update(
         Ok(r) => r,
         Err(resp) => return resp,
     };
-    let role = match req.role.as_deref() {
-        Some(r) => match Role::parse(r) {
-            Ok(parsed) => Some(parsed),
-            Err(_) => {
-                return reject_with(
-                    &doc,
-                    RejectReason::MalformedRequest {
-                        reason: format!("invalid role: {r}"),
-                    },
-                );
-            }
-        },
-        None => None,
-    };
+    // Role transitions live in `acl/change-role`, not here.
+    let role = None;
     match operations::acl::update_from_params(
         &state.acl_ks,
         &state.audit_ks,
@@ -142,6 +130,40 @@ pub(super) async fn handle_update(
             step_up_require: req.step_up_require,
             approve_scope: req.approve_scope,
         },
+        TRANSPORT_TRUST_TASK,
+    )
+    .await
+    {
+        Ok(body) => success_response(&doc, body),
+        Err(e) => app_error_to_reject(&doc, e),
+    }
+}
+
+/// Handler for `acl/change-role/0.1`. Admin-only.
+///
+/// Separate task from `acl/update` because the transition is
+/// compare-and-swapped against `fromRole` — see
+/// [`operations::acl::change_role`].
+pub(super) async fn handle_change_role(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    if let Err(e) = auth.require_admin() {
+        return app_error_to_reject(&doc, e);
+    }
+    let req: ChangeRoleBody = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    match operations::acl::change_role(
+        &state.acl_ks,
+        &state.audit_ks,
+        auth,
+        &req.subject,
+        &req.from_role,
+        &req.to_role,
+        req.reason.as_deref(),
         TRANSPORT_TRUST_TASK,
     )
     .await
@@ -288,5 +310,56 @@ pub(super) async fn handle_swap_key(
             success_response(&doc, result)
         }
         Err(e) => app_error_to_reject(&doc, e),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use trust_tasks_rs::specs::acl::change_role::v0_1 as canonical_change_role;
+
+    /// Our wire shapes must be the canonical ones, not merely bound to
+    /// the canonical URIs. The generated types carry
+    /// `deny_unknown_fields` and the spec's required set, so round-
+    /// tripping our serialized form through them catches a member we
+    /// named differently or one the spec forbids.
+    #[test]
+    fn change_role_conforms_and_update_carries_no_role() {
+        let change = ChangeRoleBody {
+            subject: "did:key:z6MkSubject".into(),
+            from_role: "reader".into(),
+            to_role: "application".into(),
+            reason: Some("promoted".into()),
+        };
+        let json = serde_json::to_value(&change).expect("serialize");
+        serde_json::from_value::<canonical_change_role::Payload>(json.clone())
+            .unwrap_or_else(|e| panic!("not canonical `acl/change-role/0.1`: {e}\n{json:#}"));
+
+        // What this PR establishes: `acl/update` carries no role, so the
+        // only way to move one is the checked path above.
+        let base = serde_json::to_value(UpdateAclBody {
+            did: "did:key:z6MkSubject".into(),
+            label: None,
+            allowed_contexts: None,
+            step_up_approver: None,
+            step_up_require: None,
+            approve_scope: None,
+        })
+        .expect("serialize");
+        assert!(
+            base.get("role").is_none(),
+            "acl/update must not carry a role: {base:#}"
+        );
+
+        // KNOWN GAP, deliberately not asserted as conformant: this body is
+        // not yet canonical — it emits `did`/`allowedContexts` where
+        // `acl/update/0.1` requires `subject`/`scopes`, and it has no
+        // nested `stepUp`/`approve`. #842 made the *response* canonical
+        // and repointed the URI but left the request shape alone. Because
+        // the URI is published, the dispatch spine validates against the
+        // canonical schema, so `acl/update` over the Trust Task transport
+        // is rejected today. Tracked separately from this role split;
+        // asserting conformance here would fail for that unrelated reason
+        // and mask what this test is actually for.
     }
 }

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -682,6 +682,8 @@ dispatch_table! {
         [ None Metadata false ],
     vta_sdk::trust_tasks::TASK_ACL_UPDATE_1_0 => acl::handle_update
         [ Mutating None false ],
+    vta_sdk::trust_tasks::TASK_ACL_CHANGE_ROLE_0_1 => acl::handle_change_role
+        [ Mutating None false ],
     vta_sdk::trust_tasks::TASK_ACL_DELETE_1_0 => acl::handle_delete
         [ Mutating None false ],
     vta_sdk::trust_tasks::TASK_ACL_SWAP_KEY_1_0 => acl::handle_swap_key

--- a/vta-service/tests/api_integration.rs
+++ b/vta-service/tests/api_integration.rs
@@ -1558,16 +1558,59 @@ async fn acl_get_update_delete_lifecycle() {
     assert_eq!(status, StatusCode::OK);
     assert_eq!(body["entry"]["role"], "application", "{body}");
 
-    // Update
+    // Update — label only. `acl/update` no longer carries a role.
     let (status, body) = app
         .request(patch_auth(
             "/acl/did:key:z6MkTarget",
             &token,
-            json!({"role": "initiator", "label": "updated"}),
+            json!({"label": "updated"}),
         ))
         .await;
     assert!(status.is_success(), "update: {status} {body}");
+    assert_eq!(
+        body["entry"]["role"], "application",
+        "update must leave the role alone: {body}"
+    );
+
+    // A role on the patch is refused, not ignored — and the error names
+    // the command that does work.
+    let (status, body) = app
+        .request(patch_auth(
+            "/acl/did:key:z6MkTarget",
+            &token,
+            json!({"role": "initiator"}),
+        ))
+        .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{body}");
+    assert!(
+        body["error"].as_str().unwrap_or("").contains("change-role"),
+        "the refusal must point at the replacement: {body}"
+    );
+
+    // The transition goes through the compare-and-swapped endpoint.
+    let (status, body) = app
+        .request(post_auth(
+            "/acl/did:key:z6MkTarget/change-role",
+            &token,
+            json!({"fromRole": "application", "toRole": "initiator"}),
+        ))
+        .await;
+    assert!(status.is_success(), "change-role: {status} {body}");
     assert_eq!(body["entry"]["role"], "initiator", "{body}");
+
+    // A stale `fromRole` is refused — they are `initiator` now.
+    let (status, body) = app
+        .request(post_auth(
+            "/acl/did:key:z6MkTarget/change-role",
+            &token,
+            json!({"fromRole": "application", "toRole": "admin"}),
+        ))
+        .await;
+    assert_eq!(
+        status,
+        StatusCode::CONFLICT,
+        "a stale fromRole must conflict: {body}"
+    );
 
     // Delete
     let (status, _) = app

--- a/vta-service/tests/client_round_trip.rs
+++ b/vta-service/tests/client_round_trip.rs
@@ -111,7 +111,6 @@ async fn acl_lifecycle_round_trips_through_the_real_client() {
         .update_acl(
             subject,
             UpdateAclRequest {
-                role: None,
                 label: Some("renamed".into()),
                 allowed_contexts: None,
                 step_up_approver: None,
@@ -587,5 +586,103 @@ async fn webvh_server_register_upserts_but_refuses_a_repoint() {
     assert!(
         missing.is_err(),
         "patching an unregistered server must fail, got {missing:?}"
+    );
+}
+
+// ── ACL change-role ─────────────────────────────────────────────────
+
+/// The role transition is compare-and-swapped, through the real client.
+///
+/// The defect this exists to prevent: two admins acting on the same
+/// stale read — one demoting, one promoting — both "succeed" under a
+/// blind write, and whichever lands second silently wins. The loser's
+/// intent disappears with no error anywhere, which on a *demotion*
+/// means someone stays an admin who was meant to be removed.
+#[tokio::test]
+async fn acl_change_role_compare_and_swaps() {
+    use vta_sdk::client::ChangeAclRoleRequest;
+
+    let mock = MockVta::start().await;
+    let client = admin_client(&mock).await;
+    let subject = "did:key:z6MkChangeRoleSubject";
+
+    client
+        .create_acl(CreateAclRequest::new(subject, "reader").contexts(vec!["ctx1".into()]))
+        .await
+        .expect("grant round-trips");
+
+    // A transition from the role they actually hold succeeds.
+    let changed = client
+        .change_acl_role(
+            subject,
+            ChangeAclRoleRequest {
+                from_role: "reader".into(),
+                to_role: "application".into(),
+                reason: Some("promoted for the integration".into()),
+            },
+        )
+        .await
+        .expect("change-role round-trips");
+    assert_eq!(
+        changed.role, "application",
+        "the new role must come back on the entry: {changed:?}"
+    );
+
+    // A transition declaring a stale `from` is refused — this is the
+    // whole point of the split.
+    let stale = client
+        .change_acl_role(
+            subject,
+            ChangeAclRoleRequest {
+                // They are `application` now, not `reader`.
+                from_role: "reader".into(),
+                to_role: "admin".into(),
+                reason: None,
+            },
+        )
+        .await;
+    assert!(
+        stale.is_err(),
+        "a stale fromRole must be refused, got {stale:?}"
+    );
+
+    // …and the refusal left the entry alone.
+    let after = client.get_acl(subject).await.expect("show round-trips");
+    assert_eq!(
+        after.role, "application",
+        "a refused change must not modify the entry"
+    );
+
+    // An unrecognized role is a caller error, not a 500.
+    let bogus = client
+        .change_acl_role(
+            subject,
+            ChangeAclRoleRequest {
+                from_role: "application".into(),
+                to_role: "superuser".into(),
+                reason: None,
+            },
+        )
+        .await;
+    assert!(bogus.is_err(), "an unknown role must be refused");
+
+    // `acl/update` no longer carries a role at all, so the only way to
+    // move one is through the checked path above.
+    let updated = client
+        .update_acl(
+            subject,
+            vta_sdk::client::UpdateAclRequest {
+                label: Some("still an application".into()),
+                allowed_contexts: None,
+                step_up_approver: None,
+                step_up_require: None,
+                approve_scope: None,
+            },
+        )
+        .await
+        .expect("update round-trips");
+    assert_eq!(
+        updated.role, "application",
+        "update must leave the role untouched"
     );
 }


### PR DESCRIPTION
Closes the known remainder of #840 phase A. The VTA's `acl/update` accepted a `role`, but canonical `acl/update/0.1` defines no such member — the transition belongs to `acl/change-role/0.1`, which carries a **compare-and-swap** on the subject's current role.

Both URIs are already published, so the unpublished-canonical count is unchanged at **44**. This buys correctness, not a reduction.

## Why role is the one attribute that needs the check

Everywhere else a lost update is an inconvenience. Here it is a privilege change.

Two admins acting on the same stale read — one demoting to `reader`, one promoting to `admin` — both succeed under a blind write, and whichever lands second silently wins. The loser's intent vanishes with no error anywhere. When the loser was the *demotion*, someone stays an admin who was meant to be removed.

Declaring `fromRole` turns that race into a refusal that names the role actually found. It is backed by a versioned write (`update_acl_entry_versioned`), because comparing the role and then storing is still read-then-write on its own; the version guard closes the window between them.

**The mutation test shows this is an escalation, not just a lost write.** With the compare-and-swap removed, the stale request promoted the subject to `admin` — the entry ended up more privileged than *either* admin intended.

## Authorization

Two guards run after the swap:

- `validate_role_assignment` — may this caller confer the target role at all.
- `validate_acl_modification` — the same check `create` applies: is the *resulting* entry one the caller could have created directly. This is what stops promotion being an escalation route. An entry with an empty scope list is authorized **nowhere** while its role is non-admin, but flipping that same entry to `admin` makes it **unrestricted**.

## Surfaces

- Trust Task `acl/change-role/0.1`, REST `POST /acl/{did}/change-role`, DIDComm `change-role`, `VtaClient::change_acl_role`.
- `pnm acl change-role --did <did> --from <role> --to <role> [--reason]`.
- `acl/update` and `PATCH /acl/{did}` **refuse** a role rather than ignoring it — silently dropping it would report success while leaving the subject's privileges exactly as they were.
- `pnm acl update --role` is kept *only* so it can name its replacement: it looks up the role the subject actually holds and prints the full corrected command, since `--from` is the one argument an operator cannot guess.
- An unrecognized role is a 400, not the 500 `Role::parse` returns by default.

## Two gaps caught late, both runtime-only

Recording these because each compiles cleanly and would have shipped:

1. **The DIDComm transport had no `change-role` handler.** The protocol constants and client method compiled fine; a DIDComm caller would have received `unsupported message type`. Now handled and routed, with an e2e case that asserts `fromRole`/`toRole` actually reach the maintainer — if the CAS values don't cross the wire, the check cannot run.
2. **`acl_get_update_delete_lifecycle` encoded the old behaviour** (PATCH with a role, asserting success). Rewritten into REST-layer coverage of the split rather than having the assertion deleted: label-only patch leaves the role alone, a role on the patch is a 400 naming the fix, the transition succeeds through the new endpoint, and a stale `fromRole` is a 409.

## Separately found, deliberately not fixed here

**`acl/update`'s request body is not canonical.** It emits `did`/`allowedContexts` where the schema requires `subject`/`scopes`, and has no nested `stepUp`/`approve`:

```
unknown field `did`, expected one of `approve`, `expiresAt`, `ext`,
`label`, `reason`, `scopes`, `stepUp`, `subject`
```

Because that URI *is* published, the dispatch spine validates against the canonical schema — so `acl/update` over the **Trust Task** transport is rejected today. REST and the legacy DIDComm message use their own bodies, which is why nothing caught it. #842 made the response canonical and repointed the URI but left the request shape alone.

Fixing it needs the `subject`/`scopes` renames plus nested `stepUp`/`approve` — the compatibility-layer work #842 did for responses — and bundling that here would obscure the role split. It is pinned by a comment in the conformance test rather than asserted, so it cannot be mistaken for conformant.

Worth flagging for the wider programme: I found this only because an assertion I had written was passing for the *wrong* reason. That means the ACL fold shipped without request-side conformance coverage, and the same may be true elsewhere. A sweep asserting every canonically-bound request body deserializes into its generated `trust_tasks_rs` type would either clear the programme or find the rest of this class in one pass.

## Testing

`cargo test --workspace`: **138 suites, 0 failures**. Clippy `-D warnings` clean; both release guards pass.
