### PR TITLE
fix(task-consent): frame the granted notice as a Trust Task document (confirm/* retirement, VTI side)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+### vta-service 0.13.9 — `task-consent/granted` notice sent as a full Trust Task document
+
+The DIDComm granted notice (`push_granted`) sent a bare payload where the
+DIDComm binding deserialises bodies as complete Trust Task documents — the
+sibling request push already wrapped correctly. The notice is now enveloped
+(unsigned, per the spec's OPTIONAL proof; it is advisory and non-load-bearing —
+the grant lookup at re-submit remains the gate). Wire bytes change without a
+transition shim: no in-repo consumer parses the old bare shape, and the
+canonical shape is what `task-consent/granted/0.1` (new in the registry, PR
+trustoverip/dtgwg-trust-tasks-tf#156) specifies.
+
 ### vta-sdk 0.20.16 / vta-service 0.13.8 / vta-cli-common 0.10.20 / pnm-cli 0.11.14 — role changes split out of `acl/update` into `acl/change-role`
 
 Closes the known remainder of #840 phase A. The VTA's `acl/update` accepted a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10331,7 +10331,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.13.8"
+version = "0.13.9"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/trust_tasks/consent_request.rs
+++ b/vta-service/src/trust_tasks/consent_request.rs
@@ -283,11 +283,29 @@ pub(super) async fn push_granted(
 
     #[cfg(feature = "didcomm")]
     {
-        let body = serde_json::json!({
-            "status": "granted",
-            "payloadDigest": wire_digest,
-            "taskType": type_uri,
+        // A full Trust Task document, not a bare payload: the DIDComm binding
+        // deserialises the body as `TrustTask<P>`, and the request push above
+        // already sends complete documents. (The pre-spec shape was the bare
+        // `{status, payloadDigest, taskType}` object; the payload is unchanged,
+        // it just gained the envelope `task-consent/granted/0.1` requires.)
+        // Unsigned by design — the notice is non-load-bearing (the grant check
+        // at re-submit is the real gate) and the authcrypt sender is the only
+        // attribution the requester needs; the spec makes proof OPTIONAL.
+        let mut body = serde_json::json!({
+            "id": format!("urn:uuid:{}", uuid::Uuid::new_v4()),
+            "type": TASK_CONSENT_GRANTED_0_1,
+            "threadId": wire_digest,
+            "recipient": requester,
+            "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+            "payload": {
+                "status": "granted",
+                "payloadDigest": wire_digest,
+                "taskType": type_uri,
+            },
         });
+        if let Some(vta_did) = state.config.read().await.vta_did.clone() {
+            body["issuer"] = serde_json::json!(vta_did);
+        }
         // `webvh`, not `didcomm`: `AppState::mediator_registry` exists only under
         // `webvh`, while `PendingResponse`'s module needs only `didcomm`. The
         // enclosing block gates on the latter, so this line compiled in a


### PR DESCRIPTION
Closes #852

Implementation side of the confirm→task-consent consolidation (stream `s2-confirm-retire`). Spec PR: trustoverip/dtgwg-trust-tasks-tf#156 (specs `task-consent/granted/0.1`, adds the untrusted `note` to `task-consent/request/0.1`, retires `confirm/{request,response}/0.1`).

## What changed

**One fix: the `task-consent/granted/0.1` push now sends a Trust Task document.** `push_granted` sent a bare `{status, payloadDigest, taskType}` object as the DIDComm body. The DIDComm binding deserialises the body as a Trust Task document (`TrustTask<P>`), and the sibling `task-consent/request` push already sends complete documents — so a conforming consumer could never have parsed the granted notice. The payload is unchanged (the spec was authored from this exact shape); it just gained the required envelope (`id`, `type`, `threadId` = wire digest, `issuer`/`recipient`, `issuedAt`). Unsigned, per the spec's OPTIONAL proof: the notice is non-load-bearing (the single-use grant lookup at re-submit is the real gate) and the authcrypt sender is the attribution.

## What was verified, not changed

- **There is no confirm handler to remove.** Verified: no `confirm/request/0.1` or `confirm/response/0.1` URI appears anywhere in VTI source (dispatch table in `vta-service/src/trust_tasks/mod.rs`, SDK constants in `vta-sdk/src/trust_tasks.rs`). The only "confirm" hit is an unrelated comment about did-management's legacy confirm/offer DIDComm message pairs. Retiring the confirm specs removes nothing here, and per the clean-cutover policy there are no old URIs to dual-accept.
- **The granted wire shape matches the new spec** — the spec was derived from this code, and the decision handler (`task_consent.rs`) needed no change.
- **No `note` threading is possible.** The new `task-consent/request.note` field is requester-authored, but VTI's consent requests are minted by the policy gate from a rejected task submission, and task payload schemas are closed — there is no channel through which a requester supplies display text today. Nothing to thread; wiring one up (e.g. via a submission envelope member) would be a new feature, not part of this consolidation.

## Validation

- `cargo check -p vta-service` ✔ (didcomm is a default feature, so the changed path compiles)
- `cargo test -p vta-service --lib consent` — 19 passed, 0 failed ✔

## Coordination notes

- affinidi-webvh-service's dangling `confirm/request/0.1` reference is handled by the did-management stream (affinidi/affinidi-webvh-service#143).
- OpenVTC/vta-browser-plugin showed no trust-task URI references in source, but reviewers should confirm its approval UI doesn't render confirm prompts by other means.

## Reviewer checklist

- [ ] The granted envelope fields match `task-consent/granted/0.1` (spec PR above); payload untouched.
- [ ] Comfortable shipping the envelope fix without a transition shim — no in-repo consumer parses the old bare body, and the notice is explicitly non-load-bearing (worst case: one poll cycle).
- [ ] Agree no confirm handling exists to remove and no note-threading path exists today.
