### PR TITLE
feat(parity): reverse registry-parity harness, per-URI drift triage, and the vta-sdk constant rename pass (#854 phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 ## Unreleased
 
+### vta-sdk 0.20.17 / vta-service 0.13.10 — reverse registry-parity harness + the `_1_0` constant rename pass (#854 phase 1)
+
+The dispatcher's parity harness has always asserted every `vta-sdk` URI is
+served; nothing asserted the opposite, so a URI could be served for months with
+no published spec behind it. `vta-service` now carries the reverse check:
+`every_served_uri_has_a_published_spec_or_is_tracked_debt` requires every URI
+the service serves — dispatched, REST-routed, feature-gated, or `wire_v0_2`
+edge-transformed — to resolve in the published registry via the generated
+`trust_tasks_rs::schema_index`. The 56 known-unspecced URIs are acknowledged
+per-URI in `UNSPECCED_DISPATCHED_URIS`; the harness fails on new drift, on an
+entry whose spec has since been published (the list only shrinks), and on an
+entry no longer served. Dispositions for all 56 — plus the version-straddle
+list (`auth/step-up/approve-request` 0.2, `device/wipe/0.2`,
+`policy/evaluate`) — are recorded in
+`docs/05-design-notes/registry-drift-triage.md`.
+
+`vta-sdk` gets the long-pending rename pass: ten `TASK_*` constants whose
+greppable name lied about the wire (`TASK_ACL_LIST_1_0` naming `acl/list/0.1`)
+now carry the canonical verb stem and version suffix
+(`TASK_ACL_{LIST,GRANT,SHOW,UPDATE,REVOKE,SWAP_KEY}_0_1`,
+`TASK_AUDIT_LIST_0_1`, `TASK_CONFIG_{SHOW,PATCH}_0_1`,
+`TASK_PROVISION_INTEGRATION_0_2`). A source-scanning guard
+(`constant_suffix_matches_uri_version`) keeps every literal-assigned constant's
+suffix equal to its URI version from now on. Constant renames only — no wire
+URI changed.
+
 ### vta-service 0.13.9 — `task-consent/granted` notice sent as a full Trust Task document
 
 The DIDComm granted notice (`push_granted`) sent a bare payload where the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10269,7 +10269,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.20.16"
+version = "0.20.17"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10331,7 +10331,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.13.9"
+version = "0.13.10"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/docs/05-design-notes/registry-drift-triage.md
+++ b/docs/05-design-notes/registry-drift-triage.md
@@ -1,0 +1,171 @@
+# Registry↔implementation drift — the per-URI triage (#854, phase 1)
+
+**Status:** phase 1 shipped (reverse parity harness + constant rename pass);
+dispositions below are the input to the next registry PRs.
+**Tracking issue:** OpenVTC/verifiable-trust-infrastructure#854.
+**Programme:** this slots into `canonical-task-reduction.md` — section references
+(§A–§F) below are to that document's disposition classes. Where the two
+disagree, this document is newer and reflects the pre-production policy:
+**everything on defined trust tasks with defined specs, aligned and as minimal
+as possible.** Nothing here has external consumers yet, so the preferred verbs
+are *fold* and *delete*, not *alias*.
+
+**Sibling streams (do not duplicate):**
+
+- `task-consent/granted/0.1` is being specced upstream right now — it is
+  excluded from this triage as in-flight. (It is an outbound producer URI in
+  `vta-service/src/trust_tasks/consent_request.rs`, not a dispatched one, so it
+  is also outside the harness's scope.)
+- #856 — `acl/update`'s non-canonical body — is being fixed by another stream.
+- #857 — the payload-conformance sweep (the *third* parity direction: served
+  URIs whose published schema the handler's actual payload type does not
+  satisfy) — is being implemented by another stream.
+
+---
+
+## What phase 1 shipped
+
+1. **The reverse parity harness.** The dispatcher's test module
+   (`vta-service/src/trust_tasks/mod.rs`) has always asserted every vta-sdk URI
+   is served. It now also asserts the opposite:
+   `every_served_uri_has_a_published_spec_or_is_tracked_debt` requires every
+   URI this service serves — dispatched, REST-routed, feature-gated, or
+   `wire_v0_2` edge-transformed — to resolve in the published registry via
+   `trust_tasks_rs::schema_index` (the registry's index, vendored through the
+   pinned `trust-tasks-rs` crate; the `trust-tasks/index.json` manifest in this
+   repo is the *retired* `openvtc/vtc` authority and is not usable for this).
+   The 56 known-unspecced URIs sit in `UNSPECCED_DISPATCHED_URIS`, per-URI and
+   annotated; the harness fails on any NEW unspecced URI, on any entry whose
+   spec has since been published (the list only shrinks), and on any entry no
+   longer served. This complements — not replaces — the workspace-wide census
+   in `vtc-service/tests/trust_task_manifest.rs` (#821), which scans source
+   literals in four trees and counts per *family*; the new check is per *URI*,
+   scoped to what the VTA dispatcher actually serves, and lives next to the
+   forward harness so the two directions cannot drift apart.
+
+2. **The `_1_0` constant rename pass** (previously "pending" in
+   `vta-sdk/src/trust_tasks.rs`). Ten constants whose greppable name lied about
+   the wire were renamed so suffix = URI version and verb stem = canonical
+   slug: `TASK_ACL_{LIST,GRANT,SHOW,UPDATE,REVOKE,SWAP_KEY}_0_1`,
+   `TASK_AUDIT_LIST_0_1`, `TASK_CONFIG_{SHOW,PATCH}_0_1`,
+   `TASK_PROVISION_INTEGRATION_0_2`. A source-scanning guard test
+   (`constant_suffix_matches_uri_version`) keeps every literal-assigned
+   constant honest from now on.
+
+3. Regenerating `trust-task-uri-registry.md` from the constants is **deferred
+   to tranche 2** — see the last section.
+
+## Corrections to the issue's enumeration (re-derived from main)
+
+The issue's "~45" list was written against an older main. Re-derivation found
+**56** unspecced *served* URIs (the census's counted exceptions agree: 44
+`vta/` + 12 `vault/`), and four rows of the issue's list are not drift at all:
+
+| Issue row | Reality | Action |
+|---|---|---|
+| `consent/approve-request/0.1` | No such URI anywhere. The real family is `task-consent/{request,granted}`; `request/0.1` **is published**. | None (enumeration error). |
+| `vtc/auth/login/0.1` | Bound by no route. It survives only as a test-fixture/doc-example string in `vti-common/src/trust_task/{openapi,mod,router}.rs` (a tree the #821 census does not scan). | **Delete**: repoint the fixture strings at published tasks. |
+| `vtc/install/claim/0.1\|0.2` | The monolithic shape exists only in the same `vti-common` fixtures/doc examples. `vtc-service` binds the published `vtc/install/claim/{start,finish}/0.1`. | Shape decision is already made by reality: **start/finish wins**. Scrub the stale monolithic fixture strings (same edit as the row above). |
+| `task-consent/granted/0.1` | Real, outbound-only, spec in flight upstream. | Excluded — sibling stream. |
+
+## The 56, with dispositions
+
+Recommendation vocabulary: **spec** (author upstream, URI stays),
+**fold** (repoint onto an existing/extended canonical task, then delete the
+`vta/` URI — no alias window; pre-production), **delete** (remove the surface).
+
+### `vta/contexts/*` — 7 × spec (§E)
+
+| URI | Recommendation |
+|---|---|
+| `vta/contexts/{list,create,get,update,update-did,preview-delete,delete}/1.0` | **spec** under `vta/` — the BIP-32 context tree is genuinely VTA-shaped. One caveat: `get` vs `list` and `preview-delete` stay separate per the registry's read-one/read-many convention; do **not** collapse. |
+
+### `vta/keys/*` — 8 × fold-to-new-canonical (§D)
+
+| URI | Recommendation |
+|---|---|
+| `vta/keys/{list,create,get,rename,revoke,sign,derive-and-sign,derive-and-sign-document}/1.0` | **spec as top-level `keys/*` 0.1**, repoint, delete the `vta/` URIs. The signing-oracle surface is generic to any key-holding agent; publishing it under `vta/` would strand the next consumer. |
+
+### `vta/seeds/*` — 3 × spec (§E)
+
+| URI | Recommendation |
+|---|---|
+| `vta/seeds/{list,rotate,export-mnemonic}/1.0` | **spec** under `vta/` — meaningless to an agent that is not the key authority. `export-mnemonic` is the registry's first `discloses: secret` VTA task; write the Security section accordingly. |
+
+### `vta/audit/*-retention` — 2 × fold-to-new-canonical
+
+| URI | Recommendation |
+|---|---|
+| `vta/audit/{get,update}-retention/1.0` | **spec as `audit/retention/{show,update}/0.1`** extending the published `audit/` family, delete the `vta/` forms. Retention is not VTA-specific (VTC has the same knob ahead of it). |
+
+### Singletons — diff first, then fold or delete
+
+| URI | Recommendation |
+|---|---|
+| `vta/discovery/capabilities/1.0` | Diff against the published `trust-task-discovery/*` family. Expected outcome: **fold** (the discovery family exists precisely for "what can you do"); keep only if the VTA's services/hosts inventory genuinely exceeds it — then spec the *delta*, not a parallel task. |
+| `vta/management/reload-services/1.0` | Diff against published `config/reload/0.1`. The VTA already folded `vta/config/*` onto `config/{show,patch}` (#840 phase A); reload is the same shape of thing. Expected outcome: **fold onto `config/reload/0.1`, delete**. |
+
+### `vta/backup/*` — 5 × fold-to-new-canonical (§D)
+
+| URI | Recommendation |
+|---|---|
+| `vta/backup/{initiate-export,complete-export,initiate-import,finalize-import,abort}/1.0` | **spec as top-level `backup/*` 0.1** (two-phase descriptor flow), repoint, delete `vta/` URIs. `vtc/backup/{export,import}` folds onto it in a later phase — design the family so that fold is possible (the descriptor pattern already is). |
+
+### `vta/attestation/*` — 2 × spec (§E)
+
+| URI | Recommendation |
+|---|---|
+| `vta/attestation/{status,report}/1.0` | **spec** under `vta/`. REST-routed and unauthenticated by design (attestation is what you check *before* trusting the VTA), which the spec must state — it is the registry's odd one out and undocumentable drift until published. |
+
+### `vta/webvh/**` — 15, split by the two-ends-of-one-wire test (§B)
+
+| URI | Recommendation |
+|---|---|
+| `vta/webvh/agent-name/{set,remove,disable,enable}/1.0` | Payload-diff against published `did-management/agent-name/{set,remove,disable,enable}/0.1`. Expected: **fold — one task dispatched twice** (operator→VTA and VTA→host are the same document). Delete the `vta/` forms. |
+| `vta/webvh/agent-name/check/1.0` | Diff against `did-management/did/check-name/0.1`; expected **fold**. |
+| `vta/webvh/agent-name/list/1.0` | No canonical counterpart (parked names are invisible in the DID doc). **spec** under `vta/`. |
+| `vta/webvh/dids/{list,get,delete}/1.0` | Diff against `did-management/did/{list,info,delete}/0.1`; expected **fold** for list/delete; `get` vs `info` needs the diff before calling it. |
+| `vta/webvh/dids/{create,rotate-keys,register-with-server}/1.0` | Genuinely VTA-side (local key material involved): **spec** under `vta/`. `dids/update` is already published — these join it. |
+| `vta/webvh/servers/{list,register,remove}/1.0` | **spec** under `vta/` — the VTA's own registry of known hosts. `did-management/server/register` is the *host* registering itself: different subject, not a fold. |
+
+### `vault/*` archival + credential store — 12 → 4 new specs (§C)
+
+| URI | Recommendation |
+|---|---|
+| `vault/{archive,unarchive,restore,purge}/0.1` | **spec once, upstream, with a store discriminator** (`store: passwordVault \| credentialStore`, default `passwordVault` so existing callers keep their meaning). |
+| `vault/credentials/{archive,unarchive,restore,purge}/0.1` | **fold** onto the four above via the discriminator; delete. |
+| `vault/credentials/{get,query,receive,delete}/0.1` | **fold** onto published `vault/{get,list,upsert,delete}` at a new 0.3 carrying the discriminator; delete. |
+| *(authorization caveat)* | The discriminator must not let a `VaultWrite` holder reach the credential store (#540 split `CredentialWrite` deliberately). The spec's Security section must bind the store value to the capability check; the PDP class stays per-store. |
+
+**Net effect if every expected fold survives its payload diff:** 56 served
+URIs → **~38 new specs** (7 contexts + 8 keys + 3 seeds + 2 audit-retention +
+5 backup + 2 attestation + 3 webvh-servers + 3 webvh-dids + 1 agent-name-list
++ 4 vault-archival), the other ~18 folding onto tasks the registry already
+publishes (or new versions of them) and their `vta/`/`vault/credentials/` URIs
+deleted. That is consistent with `canonical-task-reduction.md`'s 67→~42
+estimate — this census is the dispatcher-served subset of that one. The
+`UNSPECCED_DISPATCHED_URIS` length is the progress metric; every registry PR
+lowers it and the harness enforces the bookkeeping.
+
+## Version straddles
+
+| Straddle | State on main | Recommendation |
+|---|---|---|
+| `auth/step-up/approve-request` 0.1 vs 0.2 | Registry publishes both. The VTA *emits* 0.1 (`step_up.rs`, outbound push to the approver device) while `approve-response` dual-accepts 0.1\|0.2 in a single match arm. | Emit 0.2; keep accepting both responses through the existing arm until the mobile engine confirms, then drop 0.1. Pre-production: do it in one move with the mobile-core update. |
+| `device/wipe/0.2` | Published; the only device 0.2 absent from `wire_v0_2::WIRE_V0_2_URIS` (register/heartbeat/list/set-wake are all there). | Add the `wire_v0_2` entry — it is the same enum-casing-only family the adapter exists for. One table row + one `WIRE_V0_2_URIS` line. Note the adapter stops growing once trustoverip/dtgwg-trust-tasks-tf#151 lands. |
+| `policy/evaluate` 0.1/0.2/0.3, `policy/delete/0.1` | Published, referenced nowhere in VTI (comments only). | Registry-side housekeeping, not VTI work: retire 0.1/0.2 with `supersededBy` 0.3. Whether the VTA's PDP should *serve* `policy/evaluate/0.3` as its dry-run surface is a real question — take it as its own issue rather than speccing around it. |
+
+## Tranche 2 (deliberately out of this PR)
+
+- **Generate the URI doc from the constants.** `trust-task-uri-registry.md` is
+  a 663-line Phase-0.2 design catalogue whose tables predate the canonical-URI
+  migration — it hand-mirrors constants that no longer exist. Regenerating it
+  mechanically means replacing its catalogue sections with a table derived from
+  `vta_sdk::trust_tasks::ALL_URIS` / `REST_ROUTED_URIS` (+ the per-URI doc
+  comments) and demoting the rest to a historical appendix. That is a doc
+  rewrite, not a mechanical pass — scoped out of phase 1. The
+  `constant_suffix_matches_uri_version` guard removes the worst hand-mirroring
+  hazard in the meantime.
+- The registry PRs implementing the dispositions above, in the
+  `canonical-task-reduction.md` sequencing (folds first, new canonical families
+  second, `vta/`-specific third, vault discriminator fourth, webvh last).

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.20.16"
+version = "0.20.17"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -57,10 +57,12 @@
 // ─── Auth slice — canonical cross-cutting specs ──────────────────────────
 //
 // These point at the framework's `spec/auth/*/0.1` canonical specs in the
-// trusttasks-tf registry. VTA was the first implementer; the constant names
-// keep their `_1_0` suffix for cargo-grep continuity but the URIs are now
-// the canonical 0.1 specs. When the canonical specs cure to candidate /
-// standard the constants will follow with a `_0_1` rename pass.
+// trusttasks-tf registry. VTA was the first implementer. The long-pending
+// `_1_0` → actual-version rename pass landed with #854: every constant's
+// suffix now matches its URI's version, and the constant's verb stem matches
+// the canonical slug (`TASK_ACL_GRANT_0_1` for `acl/grant/0.1`, not the old
+// `TASK_ACL_CREATE_1_0`). A `tests::constant_suffix_matches_uri_version`
+// guard keeps it that way.
 
 /// `spec/auth/challenge/0.1` — request a one-time nonce for a subject DID.
 pub const TASK_AUTH_CHALLENGE_0_1: &str = "https://trusttasks.org/spec/auth/challenge/0.1";
@@ -201,16 +203,16 @@ pub const TASK_DEVICE_SET_WAKE_0_2: &str = "https://trusttasks.org/spec/device/s
 
 /// `acl/list/0.1` — list ACL entries, optionally filtered by
 /// context. Payload: [`crate::protocols::acl_management::list::ListAclBody`].
-pub const TASK_ACL_LIST_1_0: &str = "https://trusttasks.org/spec/acl/list/0.1";
+pub const TASK_ACL_LIST_0_1: &str = "https://trusttasks.org/spec/acl/list/0.1";
 
 /// `acl/grant/0.1` — add an ACL entry. Payload:
 /// [`crate::protocols::acl_management::create::CreateAclBody`].
 /// Auth: Admin or Initiator.
-pub const TASK_ACL_CREATE_1_0: &str = "https://trusttasks.org/spec/acl/grant/0.1";
+pub const TASK_ACL_GRANT_0_1: &str = "https://trusttasks.org/spec/acl/grant/0.1";
 
 /// `acl/show/0.1` — retrieve a single entry. Payload:
 /// [`crate::protocols::acl_management::get::GetAclBody`].
-pub const TASK_ACL_GET_1_0: &str = "https://trusttasks.org/spec/acl/show/0.1";
+pub const TASK_ACL_SHOW_0_1: &str = "https://trusttasks.org/spec/acl/show/0.1";
 
 /// `acl/update/0.1` — patch label, scopes, expiry, step-up or approve
 /// authority on an existing entry. Payload:
@@ -221,14 +223,14 @@ pub const TASK_ACL_GET_1_0: &str = "https://trusttasks.org/spec/acl/show/0.1";
 /// task so it can carry a compare-and-swap — see
 /// [`TASK_ACL_CHANGE_ROLE_0_1`]. A request naming a role here is
 /// refused rather than applied.
-pub const TASK_ACL_UPDATE_1_0: &str = "https://trusttasks.org/spec/acl/update/0.1";
+pub const TASK_ACL_UPDATE_0_1: &str = "https://trusttasks.org/spec/acl/update/0.1";
 
 /// `acl/change-role/0.1` — transition a subject's role, guarded by a
 /// compare-and-swap on their current one. Payload:
 /// [`crate::protocols::acl_management::change_role::ChangeRoleBody`].
 /// Auth: Admin only.
 ///
-/// Separate from [`TASK_ACL_UPDATE_1_0`] because role is the one
+/// Separate from [`TASK_ACL_UPDATE_0_1`] because role is the one
 /// attribute where losing an update is a privilege change: two admins
 /// editing concurrently could otherwise silently overwrite each other,
 /// and the loser's intent — say a demotion — would vanish with no
@@ -239,7 +241,7 @@ pub const TASK_ACL_CHANGE_ROLE_0_1: &str = "https://trusttasks.org/spec/acl/chan
 /// `acl/revoke/0.1` — remove an entry. Payload:
 /// [`crate::protocols::acl_management::delete::DeleteAclBody`].
 /// Auth: Admin or Initiator.
-pub const TASK_ACL_DELETE_1_0: &str = "https://trusttasks.org/spec/acl/revoke/0.1";
+pub const TASK_ACL_REVOKE_0_1: &str = "https://trusttasks.org/spec/acl/revoke/0.1";
 
 /// `spec/acl/swap-key/0.1` — self-service rotation of the caller's own ACL
 /// entry onto a new subject DID, proven by a `link_proof` VP-JWT. Payload:
@@ -249,7 +251,7 @@ pub const TASK_ACL_DELETE_1_0: &str = "https://trusttasks.org/spec/acl/revoke/0.
 /// Registry alias of [`crate::protocols::acl_management::ACL_SWAP_KEY`] so the
 /// dispatcher can route it through the shared spine (previously it was bespoke
 /// on both REST `/acl/swap` and the DIDComm router).
-pub const TASK_ACL_SWAP_KEY_1_0: &str = crate::protocols::acl_management::ACL_SWAP_KEY;
+pub const TASK_ACL_SWAP_KEY_0_1: &str = crate::protocols::acl_management::ACL_SWAP_KEY;
 
 // ─── Contexts slice (spec/vta/contexts/*) ────────────────────────────────
 
@@ -371,7 +373,7 @@ pub const TASK_SEEDS_EXPORT_MNEMONIC_1_0: &str =
 ///
 /// Auth: unrestricted admin for the whole-log tail; a context-scoped
 /// admin must supply `contextId` within their own scope.
-pub const TASK_AUDIT_LIST_LOGS_1_0: &str = "https://trusttasks.org/spec/audit/list/0.1";
+pub const TASK_AUDIT_LIST_0_1: &str = "https://trusttasks.org/spec/audit/list/0.1";
 
 /// `spec/vta/audit/get-retention/1.0` — read the current retention
 /// period. Payload:
@@ -780,12 +782,12 @@ pub const TASK_DID_MANAGEMENT_REGISTRY_DEREGISTER_0_1: &str =
 /// (VTA DID, name, public URL).
 /// Payload: [`crate::protocols::vta_management::get_config::GetConfigBody`]
 /// (empty). Auth: any authenticated user.
-pub const TASK_CONFIG_GET_1_0: &str = "https://trusttasks.org/spec/config/show/0.1";
+pub const TASK_CONFIG_SHOW_0_1: &str = "https://trusttasks.org/spec/config/show/0.1";
 
 /// `spec/vta/config/update/1.0` — patch VTA DID, name, or public URL.
 /// Payload: [`crate::protocols::vta_management::update_config::UpdateConfigBody`].
 /// Auth: Super Admin only.
-pub const TASK_CONFIG_UPDATE_1_0: &str = "https://trusttasks.org/spec/config/patch/0.1";
+pub const TASK_CONFIG_PATCH_0_1: &str = "https://trusttasks.org/spec/config/patch/0.1";
 
 // ─── Management slice (spec/vta/management/*) ────────────────────────────
 
@@ -856,7 +858,7 @@ pub const TASK_PASSKEY_VMS_REVOKE_0_1: &str =
 /// [`crate::provision_integration::http::ProvisionIntegrationRequest`].
 /// Auth: Admin role on the target context (super-admin to use
 /// `create_context: true`).
-pub const TASK_PROVISION_INTEGRATION_REQUEST_1_0: &str =
+pub const TASK_PROVISION_INTEGRATION_0_2: &str =
     "https://trusttasks.org/spec/provision/integration/0.2";
 
 // ─── WebVH-DID-lifecycle slice (spec/vta/webvh/*) ────────────────────────
@@ -1330,13 +1332,13 @@ pub const ALL_URIS: &[&str] = &[
     // Messaging slice
     TASK_MESSAGING_PING_0_1,
     // ACL slice
-    TASK_ACL_LIST_1_0,
-    TASK_ACL_CREATE_1_0,
-    TASK_ACL_GET_1_0,
-    TASK_ACL_UPDATE_1_0,
+    TASK_ACL_LIST_0_1,
+    TASK_ACL_GRANT_0_1,
+    TASK_ACL_SHOW_0_1,
+    TASK_ACL_UPDATE_0_1,
     TASK_ACL_CHANGE_ROLE_0_1,
-    TASK_ACL_DELETE_1_0,
-    TASK_ACL_SWAP_KEY_1_0,
+    TASK_ACL_REVOKE_0_1,
+    TASK_ACL_SWAP_KEY_0_1,
     // Contexts slice
     TASK_CONTEXTS_LIST_1_0,
     TASK_CONTEXTS_CREATE_1_0,
@@ -1359,7 +1361,7 @@ pub const ALL_URIS: &[&str] = &[
     TASK_SEEDS_ROTATE_1_0,
     TASK_SEEDS_EXPORT_MNEMONIC_1_0,
     // Audit slice
-    TASK_AUDIT_LIST_LOGS_1_0,
+    TASK_AUDIT_LIST_0_1,
     TASK_AUDIT_GET_RETENTION_1_0,
     TASK_AUDIT_UPDATE_RETENTION_1_0,
     // Discovery
@@ -1408,8 +1410,8 @@ pub const ALL_URIS: &[&str] = &[
     TASK_DID_MANAGEMENT_REGISTRY_ADMIN_REGISTER_0_1,
     TASK_DID_MANAGEMENT_REGISTRY_DEREGISTER_0_1,
     // Config slice
-    TASK_CONFIG_GET_1_0,
-    TASK_CONFIG_UPDATE_1_0,
+    TASK_CONFIG_SHOW_0_1,
+    TASK_CONFIG_PATCH_0_1,
     // Management slice
     TASK_MANAGEMENT_RELOAD_SERVICES_1_0,
     // Passkey-VMs slice (feature-gated: webvh + didcomm). Dual-accept
@@ -1419,7 +1421,7 @@ pub const ALL_URIS: &[&str] = &[
     TASK_PASSKEY_VMS_LIST_0_1,
     TASK_PASSKEY_VMS_REVOKE_0_1,
     // Provision-integration (feature-gated: webvh)
-    TASK_PROVISION_INTEGRATION_REQUEST_1_0,
+    TASK_PROVISION_INTEGRATION_0_2,
     // WebVH-DID-lifecycle slice (feature-gated: webvh)
     TASK_WEBVH_SERVERS_LIST_1_0,
     TASK_WEBVH_SERVERS_REGISTER_1_0,
@@ -1587,7 +1589,7 @@ mod tests {
             // was a constant change.
             "https://trusttasks.org/spec/provision/",
             // Framework ACL protocol — the `acl/swap-key` self-service key
-            // rotation task (`TASK_ACL_SWAP_KEY_1_0`), now dispatcher-routed.
+            // rotation task (`TASK_ACL_SWAP_KEY_0_1`), now dispatcher-routed.
             "https://trusttasks.org/spec/acl/",
             // ToIP messaging protocol — the transport-agnostic `messaging/ping`
             // liveness/capability probe (`TASK_MESSAGING_PING_0_1`).
@@ -1622,6 +1624,61 @@ mod tests {
                 "version components must be digits: {uri}"
             );
         }
+    }
+
+    /// The #854 rename-pass guard: every literal-assigned `TASK_*` constant's
+    /// `_MAJ_MIN` suffix must match the version segment of the URI it names.
+    /// `TASK_ACL_LIST_1_0 = ".../acl/list/0.1"` was exactly the drift this
+    /// module carried for months — greppable names that lied about the wire.
+    ///
+    /// Scans this file's own source text (the same technique as
+    /// `vtc-service/tests/trust_task_manifest.rs`) because consts have no
+    /// runtime name. Alias-assigned constants (no string literal on the
+    /// declaration) are asserted individually below.
+    #[test]
+    fn constant_suffix_matches_uri_version() {
+        let src: String = include_str!("trust_tasks.rs")
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ");
+        let mut checked = 0usize;
+        for decl in src.split("pub const TASK_").skip(1) {
+            let Some(name_end) = decl.find(':') else {
+                continue;
+            };
+            let name = format!("TASK_{}", &decl[..name_end]);
+            // Only literal assignments: `: &str = "https://..."`. Alias
+            // assignments (`= crate::protocols::…`) and stray occurrences of
+            // the split pattern in other string literals fail the prefix
+            // check and are skipped.
+            let Some(rest) = decl[name_end..].strip_prefix(": &str = \"") else {
+                continue;
+            };
+            let Some(lit_end) = rest.find('"') else {
+                continue;
+            };
+            let uri = &rest[..lit_end];
+            let version = uri.rsplit('/').next().unwrap();
+            let expected_suffix = format!("_{}", version.replace('.', "_"));
+            assert!(
+                name.ends_with(&expected_suffix),
+                "constant `{name}` names `{uri}` but its suffix does not match \
+                 the URI version `{version}` — rename the constant (the #854 \
+                 convention: suffix always mirrors the wire version)"
+            );
+            checked += 1;
+        }
+        assert!(
+            checked > 100,
+            "scanned only {checked} constants — the source scan is broken, not the code"
+        );
+        // The one alias-assigned constant: `TASK_ACL_SWAP_KEY_0_1` points at
+        // `protocols::acl_management::ACL_SWAP_KEY`, which the scan above
+        // cannot see through.
+        assert!(
+            TASK_ACL_SWAP_KEY_0_1.ends_with("/0.1"),
+            "acl/swap-key alias drifted from its 0.1 suffix"
+        );
     }
 
     #[test]

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.13.9"
+version = "0.13.10"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -137,7 +137,7 @@ const KNOWN_FEATURE_GATED_URIS: &[&str] = &[
     vta_sdk::trust_tasks::TASK_PASSKEY_VMS_LIST_0_1,
     vta_sdk::trust_tasks::TASK_PASSKEY_VMS_REVOKE_0_1,
     // Provision-integration — requires `webvh`.
-    vta_sdk::trust_tasks::TASK_PROVISION_INTEGRATION_REQUEST_1_0,
+    vta_sdk::trust_tasks::TASK_PROVISION_INTEGRATION_0_2,
     // WebVH-DID-lifecycle slice — requires `webvh`. The `dispatch_table!`
     // entries list the same URIs and are tracked by the parity harness when
     // `webvh` is on; this allowlist covers builds where `webvh` is off.
@@ -192,6 +192,97 @@ const KNOWN_FEATURE_GATED_URIS: &[&str] = &[
     vta_sdk::trust_tasks::TASK_DID_MANAGEMENT_SERVER_STATS_SYNC_0_1,
     vta_sdk::trust_tasks::TASK_DID_MANAGEMENT_REGISTRY_ADMIN_REGISTER_0_1,
     vta_sdk::trust_tasks::TASK_DID_MANAGEMENT_REGISTRY_DEREGISTER_0_1,
+];
+
+/// URIs this dispatcher serves that the published Trust-Tasks registry does
+/// NOT yet spec — the implementation→registry drift tracked by issue #854.
+///
+/// The forward parity harness below asserts every vta-sdk URI is served; the
+/// reverse harness (`every_served_uri_has_a_published_spec_or_is_tracked_debt`)
+/// asserts every *served* URI resolves in the published registry, using the
+/// generated `trust_tasks_rs::schema_index` as the registry's vendored index
+/// (the same source `validate_payload` consults at dispatch time, and the same
+/// one the workspace-wide census in `vtc-service/tests/trust_task_manifest.rs`
+/// checks against — that census counts per *family*; this list is per *URI*,
+/// scoped to what this dispatcher actually serves).
+///
+/// Every entry is acknowledged debt with a disposition recorded in
+/// `docs/05-design-notes/registry-drift-triage.md` (and the programme doc
+/// `canonical-task-reduction.md`). The harness enforces monotonicity in both
+/// directions: serving a NEW unspecced URI fails (add the spec upstream — do
+/// not grow this list), and once a spec is published upstream the entry MUST
+/// be removed (a stale entry also fails).
+///
+/// Tracking issue: OpenVTC/verifiable-trust-infrastructure#854.
+#[allow(dead_code)] // consumed by the dispatcher's test-only parity harness
+const UNSPECCED_DISPATCHED_URIS: &[&str] = &[
+    // ─ vta/contexts/* — keep-and-spec under `vta/` (reduction plan §E).
+    "https://trusttasks.org/spec/vta/contexts/list/1.0",
+    "https://trusttasks.org/spec/vta/contexts/create/1.0",
+    "https://trusttasks.org/spec/vta/contexts/get/1.0",
+    "https://trusttasks.org/spec/vta/contexts/update/1.0",
+    "https://trusttasks.org/spec/vta/contexts/update-did/1.0",
+    "https://trusttasks.org/spec/vta/contexts/preview-delete/1.0",
+    "https://trusttasks.org/spec/vta/contexts/delete/1.0",
+    // ─ vta/keys/* — author top-level `keys/*` (reduction plan §D).
+    "https://trusttasks.org/spec/vta/keys/list/1.0",
+    "https://trusttasks.org/spec/vta/keys/create/1.0",
+    "https://trusttasks.org/spec/vta/keys/get/1.0",
+    "https://trusttasks.org/spec/vta/keys/rename/1.0",
+    "https://trusttasks.org/spec/vta/keys/revoke/1.0",
+    "https://trusttasks.org/spec/vta/keys/sign/1.0",
+    "https://trusttasks.org/spec/vta/keys/derive-and-sign/1.0",
+    "https://trusttasks.org/spec/vta/keys/derive-and-sign-document/1.0",
+    // ─ vta/seeds/* — keep-and-spec under `vta/` (reduction plan §E).
+    "https://trusttasks.org/spec/vta/seeds/list/1.0",
+    "https://trusttasks.org/spec/vta/seeds/rotate/1.0",
+    "https://trusttasks.org/spec/vta/seeds/export-mnemonic/1.0",
+    // ─ vta/audit retention pair — candidate `audit/retention/{show,update}`.
+    "https://trusttasks.org/spec/vta/audit/get-retention/1.0",
+    "https://trusttasks.org/spec/vta/audit/update-retention/1.0",
+    // ─ Discovery / management singletons — diff against canonical first.
+    "https://trusttasks.org/spec/vta/discovery/capabilities/1.0",
+    "https://trusttasks.org/spec/vta/management/reload-services/1.0",
+    // ─ vta/backup/* — author top-level `backup/*` (reduction plan §D).
+    "https://trusttasks.org/spec/vta/backup/initiate-export/1.0",
+    "https://trusttasks.org/spec/vta/backup/complete-export/1.0",
+    "https://trusttasks.org/spec/vta/backup/initiate-import/1.0",
+    "https://trusttasks.org/spec/vta/backup/finalize-import/1.0",
+    "https://trusttasks.org/spec/vta/backup/abort/1.0",
+    // ─ vta/attestation/* (REST-routed, unauthenticated) — keep-and-spec.
+    "https://trusttasks.org/spec/vta/attestation/status/1.0",
+    "https://trusttasks.org/spec/vta/attestation/report/1.0",
+    // ─ vta/webvh/** — two-ends-of-one-wire decision pending (plan §B).
+    //   `dids/update` is published; the rest are not.
+    "https://trusttasks.org/spec/vta/webvh/servers/list/1.0",
+    "https://trusttasks.org/spec/vta/webvh/servers/register/1.0",
+    "https://trusttasks.org/spec/vta/webvh/servers/remove/1.0",
+    "https://trusttasks.org/spec/vta/webvh/dids/list/1.0",
+    "https://trusttasks.org/spec/vta/webvh/dids/create/1.0",
+    "https://trusttasks.org/spec/vta/webvh/dids/get/1.0",
+    "https://trusttasks.org/spec/vta/webvh/dids/delete/1.0",
+    "https://trusttasks.org/spec/vta/webvh/dids/rotate-keys/1.0",
+    "https://trusttasks.org/spec/vta/webvh/dids/register-with-server/1.0",
+    "https://trusttasks.org/spec/vta/webvh/agent-name/list/1.0",
+    "https://trusttasks.org/spec/vta/webvh/agent-name/check/1.0",
+    "https://trusttasks.org/spec/vta/webvh/agent-name/set/1.0",
+    "https://trusttasks.org/spec/vta/webvh/agent-name/remove/1.0",
+    "https://trusttasks.org/spec/vta/webvh/agent-name/disable/1.0",
+    "https://trusttasks.org/spec/vta/webvh/agent-name/enable/1.0",
+    // ─ Vault archival lifecycle (#540) — generalise with a store
+    //   discriminator instead of publishing twelve (reduction plan §C).
+    "https://trusttasks.org/spec/vault/archive/0.1",
+    "https://trusttasks.org/spec/vault/unarchive/0.1",
+    "https://trusttasks.org/spec/vault/restore/0.1",
+    "https://trusttasks.org/spec/vault/purge/0.1",
+    "https://trusttasks.org/spec/vault/credentials/receive/0.1",
+    "https://trusttasks.org/spec/vault/credentials/query/0.1",
+    "https://trusttasks.org/spec/vault/credentials/get/0.1",
+    "https://trusttasks.org/spec/vault/credentials/archive/0.1",
+    "https://trusttasks.org/spec/vault/credentials/unarchive/0.1",
+    "https://trusttasks.org/spec/vault/credentials/delete/0.1",
+    "https://trusttasks.org/spec/vault/credentials/restore/0.1",
+    "https://trusttasks.org/spec/vault/credentials/purge/0.1",
 ];
 
 /// Declarative Trust-Task dispatch table.
@@ -674,19 +765,19 @@ dispatch_table! {
     vta_sdk::trust_tasks::TASK_TASK_CONSENT_DECISION_0_1 => task_consent::handle_decision
         [ Mutating None false ],
     // ─── ACL slice ────────────────────────────────────────────────
-    vta_sdk::trust_tasks::TASK_ACL_LIST_1_0 => acl::handle_list
+    vta_sdk::trust_tasks::TASK_ACL_LIST_0_1 => acl::handle_list
         [ None Metadata false ],
-    vta_sdk::trust_tasks::TASK_ACL_CREATE_1_0 => acl::handle_create
+    vta_sdk::trust_tasks::TASK_ACL_GRANT_0_1 => acl::handle_create
         [ Mutating None false ],
-    vta_sdk::trust_tasks::TASK_ACL_GET_1_0 => acl::handle_get
+    vta_sdk::trust_tasks::TASK_ACL_SHOW_0_1 => acl::handle_get
         [ None Metadata false ],
-    vta_sdk::trust_tasks::TASK_ACL_UPDATE_1_0 => acl::handle_update
+    vta_sdk::trust_tasks::TASK_ACL_UPDATE_0_1 => acl::handle_update
         [ Mutating None false ],
     vta_sdk::trust_tasks::TASK_ACL_CHANGE_ROLE_0_1 => acl::handle_change_role
         [ Mutating None false ],
-    vta_sdk::trust_tasks::TASK_ACL_DELETE_1_0 => acl::handle_delete
+    vta_sdk::trust_tasks::TASK_ACL_REVOKE_0_1 => acl::handle_delete
         [ Mutating None false ],
-    vta_sdk::trust_tasks::TASK_ACL_SWAP_KEY_1_0 => acl::handle_swap_key
+    vta_sdk::trust_tasks::TASK_ACL_SWAP_KEY_0_1 => acl::handle_swap_key
         [ Destructive None false ],
     // ─── Device slice ─────────────────────────────────────────────
     vta_sdk::trust_tasks::TASK_DEVICE_REGISTER_0_1 => device::handle_register
@@ -744,7 +835,7 @@ dispatch_table! {
     vta_sdk::trust_tasks::TASK_SEEDS_EXPORT_MNEMONIC_1_0 => seeds::handle_export_mnemonic
         [ None Secret false ],
     // ─── Audit slice ─────────────────────────────────────────────
-    vta_sdk::trust_tasks::TASK_AUDIT_LIST_LOGS_1_0 => audit::handle_list_logs
+    vta_sdk::trust_tasks::TASK_AUDIT_LIST_0_1 => audit::handle_list_logs
         [ None Metadata false ],
     vta_sdk::trust_tasks::TASK_AUDIT_GET_RETENTION_1_0 => audit::handle_get_retention
         [ None Metadata false ],
@@ -828,9 +919,9 @@ dispatch_table! {
     vta_sdk::trust_tasks::TASK_VTA_MEMORY_DELETE_0_1 => memory::handle_delete
         [ Mutating None false ],
     // ─── Config slice ────────────────────────────────────────────
-    vta_sdk::trust_tasks::TASK_CONFIG_GET_1_0 => config::handle_get
+    vta_sdk::trust_tasks::TASK_CONFIG_SHOW_0_1 => config::handle_get
         [ None Metadata false ],
-    vta_sdk::trust_tasks::TASK_CONFIG_UPDATE_1_0 => config::handle_update
+    vta_sdk::trust_tasks::TASK_CONFIG_PATCH_0_1 => config::handle_update
         [ Mutating None false ],
     // ─── Management slice ────────────────────────────────────────
     vta_sdk::trust_tasks::TASK_MANAGEMENT_RELOAD_SERVICES_1_0 => management::handle_reload_services
@@ -895,7 +986,7 @@ dispatch_table! {
         [ Destructive None false ],
     // ─── Provision-integration (feature-gated: webvh) ────────────
     #[cfg(feature = "webvh")]
-    vta_sdk::trust_tasks::TASK_PROVISION_INTEGRATION_REQUEST_1_0
+    vta_sdk::trust_tasks::TASK_PROVISION_INTEGRATION_0_2
         => provision_integration::handle_request
         [ Mutating Secret false ],
     // ─── WebVH-DID-lifecycle slice (feature-gated: webvh) ────────
@@ -1130,6 +1221,67 @@ mod tests {
                  (b) add it to `REST_ROUTED` if it lives on a dedicated REST route, \
                  (c) add it to `KNOWN_FEATURE_GATED_URIS` with a comment explaining the gating, or \
                  (d) register it in `wire_v0_2::WIRE_V0_2_URIS` if it's an edge-transformed 0.2 URI"
+            );
+        }
+    }
+
+    /// Reverse parity harness (#854) — the opposite direction of
+    /// [`dispatcher_handles_every_vta_sdk_uri`]. Every URI this service
+    /// *serves* — dispatched, REST-routed, feature-gated, or accepted via the
+    /// `wire_v0_2` edge transform — must resolve to a published spec in the
+    /// Trust-Tasks registry, as vendored by the generated
+    /// `trust_tasks_rs::schema_index` this build validates payloads against.
+    ///
+    /// A URI with no published spec is a live wire contract with no schema,
+    /// no registry page, no generated bindings, and no discovery entry. The
+    /// known ones are acknowledged per-URI in [`UNSPECCED_DISPATCHED_URIS`]
+    /// with their disposition recorded in
+    /// `docs/05-design-notes/registry-drift-triage.md`; anything else fails
+    /// here, so NEW drift cannot land silently.
+    ///
+    /// The allowlist is also checked for staleness in both directions: an
+    /// entry whose spec has since been published upstream must be removed
+    /// (the debt shrinks monotonically), and an entry no longer served is
+    /// dead and must be removed too.
+    #[test]
+    fn every_served_uri_has_a_published_spec_or_is_tracked_debt() {
+        let mut served: std::collections::BTreeSet<&str> = dispatched_uris().into_iter().collect();
+        served.extend(REST_ROUTED);
+        served.extend(KNOWN_FEATURE_GATED_URIS);
+        served.extend(wire_v0_2::WIRE_V0_2_URIS);
+
+        let unspecced: Vec<&&str> = served
+            .iter()
+            .filter(|uri| {
+                trust_tasks_rs::schema_index::schema_for(uri).is_none()
+                    && !UNSPECCED_DISPATCHED_URIS.contains(uri)
+            })
+            .collect();
+        assert!(
+            unspecced.is_empty(),
+            "this service serves URIs the published registry (trust-tasks-rs) \
+             has no spec for, and they are not acknowledged in \
+             UNSPECCED_DISPATCHED_URIS:\n  {}\n\n\
+             Author the spec upstream in trustoverip/dtgwg-trust-tasks-tf and \
+             bump trust-tasks-rs — growing the allowlist is the wrong fix \
+             (see issue #854 and docs/05-design-notes/registry-drift-triage.md).",
+            unspecced
+                .iter()
+                .map(|u| u.to_string())
+                .collect::<Vec<_>>()
+                .join("\n  ")
+        );
+
+        for uri in UNSPECCED_DISPATCHED_URIS {
+            assert!(
+                trust_tasks_rs::schema_index::schema_for(uri).is_none(),
+                "`{uri}` is now published in the registry — remove it from \
+                 UNSPECCED_DISPATCHED_URIS so the debt shrinks monotonically"
+            );
+            assert!(
+                served.contains(uri),
+                "`{uri}` is in UNSPECCED_DISPATCHED_URIS but this service no \
+                 longer serves it — remove the stale entry"
             );
         }
     }

--- a/vta-service/src/trust_tasks/policy_gate.rs
+++ b/vta-service/src/trust_tasks/policy_gate.rs
@@ -72,9 +72,9 @@ fn op_class_for(type_uri: &str) -> Option<&'static str> {
     use super::step_up::op;
     use vta_sdk::trust_tasks as t;
     match type_uri {
-        t::TASK_ACL_CREATE_1_0 => Some(op::ACL_GRANT),
-        t::TASK_ACL_UPDATE_1_0 => Some(op::ACL_CHANGE_ROLE),
-        t::TASK_ACL_DELETE_1_0 => Some(op::ACL_REVOKE),
+        t::TASK_ACL_GRANT_0_1 => Some(op::ACL_GRANT),
+        t::TASK_ACL_UPDATE_0_1 => Some(op::ACL_CHANGE_ROLE),
+        t::TASK_ACL_REVOKE_0_1 => Some(op::ACL_REVOKE),
         t::TASK_CONTEXTS_DELETE_1_0 => Some(op::CONTEXT_DELETE),
         t::TASK_KEYS_REVOKE_1_0 => Some(op::KEY_REVOKE),
         t::TASK_VAULT_RELEASE_0_1 => Some(op::VAULT_RELEASE),


### PR DESCRIPTION
Closes https://github.com/OpenVTC/verifiable-trust-infrastructure/issues/854 (phase 1 — triage + guard; the registry PRs implementing the dispositions are follow-on tranches).

## What changed

**1. Reverse parity harness** (`vta-service/src/trust_tasks/mod.rs`). The existing harness asserts every `vta-sdk` URI is served; nothing asserted the opposite. `every_served_uri_has_a_published_spec_or_is_tracked_debt` now requires every URI the VTA serves — dispatched, REST-routed, feature-gated, or `wire_v0_2` edge-transformed — to resolve in the published registry via the generated `trust_tasks_rs::schema_index` (the registry index vendored through the pinned crate; the in-repo `trust-tasks/index.json` is the retired `openvtc/vtc` authority and was not usable for this). The 56 known-unspecced URIs sit in `UNSPECCED_DISPATCHED_URIS`, per-URI, annotated with the tracking issue. The harness fails on: any NEW unspecced served URI, any allowlist entry whose spec has since been published upstream (the list only shrinks), and any entry no longer served. Complements — does not replace — the workspace census in `vtc-service/tests/trust_task_manifest.rs` (#821), which is source-literal + per-family-count based.

**2. Triage doc** — `docs/05-design-notes/registry-drift-triage.md`. Tabulates all 56 implemented-but-unspecced URIs with a keep-and-spec / fold / delete disposition each (aggressive, per the pre-production policy), the version-straddle list (`auth/step-up/approve-request` 0.2, `device/wipe/0.2` missing from `wire_v0_2`, `policy/evaluate`/`policy/delete` unreferenced), and corrections to the issue's enumeration re-derived from latest main:
- `consent/approve-request/0.1` does not exist (the real family is `task-consent/*`; `request/0.1` is published);
- `vtc/auth/login/0.1` and monolithic `vtc/install/claim/0.1|0.2` are bound by **no route** — they survive only as `vti-common` test-fixture/doc-example strings; the start/finish claim shape already won;
- `task-consent/granted/0.1` excluded as in-flight (sibling stream).
Slotted into the `canonical-task-reduction.md` programme (§A–§F references); sibling streams #856 (acl/update body) and #857 (payload-conformance sweep) are referenced, not duplicated.

**3. The `_1_0` rename pass** (`vta-sdk/src/trust_tasks.rs` + 2 consumer files). Ten constants whose greppable name lied about the wire (`TASK_ACL_LIST_1_0` naming `acl/list/0.1`) renamed to canonical verb stem + true version suffix: `TASK_ACL_{LIST,GRANT,SHOW,UPDATE,REVOKE,SWAP_KEY}_0_1`, `TASK_AUDIT_LIST_0_1`, `TASK_CONFIG_{SHOW,PATCH}_0_1`, `TASK_PROVISION_INTEGRATION_0_2`. A new source-scanning guard (`constant_suffix_matches_uri_version`) pins suffix = URI version for every literal-assigned constant. **Constant renames only — no wire URI changed.** Regenerating `trust-task-uri-registry.md` from the constants is scoped to tranche 2 in the triage doc (it is a doc rewrite, not a mechanical pass).

Release housekeeping: vta-sdk 0.20.16 → 0.20.17, vta-service 0.13.8 → 0.13.9, root `CHANGELOG.md` entry, `Cargo.lock` refreshed. Version bumps may be rebased by the orchestrator as sibling consolidation PRs merge.

## Evidence

```
cargo test -p vta-sdk --lib      → 220 passed; 0 failed
cargo test -p vta-service --lib  → 719 passed; 0 failed
cargo check -p vta-sdk -p vta-service -p vta-mcp -p vtc-service → clean
cargo clippy -p vta-sdk -p vta-service --all-targets → no warnings
scripts/check-version-bumps.sh / check-changelogs.sh → ok
```

The new harness passes on this branch and fails loudly if a URI is served without a spec or an allowlist entry goes stale in either direction.

## Reviewer checklist

- [ ] `UNSPECCED_DISPATCHED_URIS` (56 entries) matches your expectation of the served-but-unspecced surface — the harness itself verifies both directions, so a wrong entry cannot pass silently.
- [ ] Dispositions in `docs/05-design-notes/registry-drift-triage.md` — especially the aggressive fold/delete calls (keys/backup as top-level canonical families; vault store-discriminator; webvh one-task-dispatched-twice) — read as the right phase-2 inputs.
- [ ] The ten constant renames carry no behaviour change (`git grep` for the old names returns nothing).
- [ ] Version bumps + changelog entry look right for a source-touching change to two publishable crates.