### PR TITLE
feat(vta-sdk): sign() reaches TSP via the Trust-Task bridge — and every twinned rpc method moves with it (#829)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,44 @@
 
 ## Unreleased
 
+### vta-sdk 0.20.18 — every client method with a Trust-Task twin now rides the Trust-Task bridge (#829)
+
+`VtaClient::sign()` was the odd one out among the three signing entry points:
+it rode the legacy `rpc` path, whose TSP arm is `unsupported_over_tsp`, so the
+one VTA call a signing consumer (e.g. Cierge's gateway) builds on was the one
+that didn't port DIDComm → TSP. It now routes through
+`rpc_tt(TASK_KEYS_SIGN_1_0, …)` — same REST leg, same
+`operations::keys::sign_payload` spine, and the DIDComm/TSP legs dispatch the
+`spec/vta/keys/sign/1.0` Trust Task exactly like `derive_and_sign` beside it.
+
+The audit the issue asked for happened, and acted: **every** remaining
+`rpc`/`rpc_void`-routed client method whose Trust-Task twin exists in the
+dispatcher and whose request/response wire shapes already match moved in the
+same sweep — the keys slice (list/create/get/rename/revoke/sign,
+`get_key_secret` via `vta/seeds/export-mnemonic`), seeds (list/rotate), ACL
+grant + revoke, audit (list + retention get/update), contexts (all seven),
+config show/patch, `restart` (via `vta/management/reload-services`),
+`capabilities`, and the WebVH servers/DIDs methods (register/list/remove,
+create/list/get/get-log/delete/register-with-server). All of them keep their
+dedicated REST routes; only the DIDComm leg changes envelope, and TSP support
+falls out for free.
+
+Deliberately **not** moved (wire shapes differ — the gap is the conformance
+stream's, not this PR's to paper over): `list_acl`/`get_acl`/`change_acl_role`
+(trust-task responses are the flat stored form, not the canonical `{entry}` /
+`{entries}` envelopes), `update_acl` (request shape is non-canonical and the
+dispatch spine schema-rejects it today), `swap_acl` (canonical `acl/swap-key`
+needs `currentSubject`/`newSubject` the client API doesn't carry),
+`update_webvh_server` (its twin is register-or-update, a different contract),
+`update_did_webvh`/`rotate_did_webvh_keys` (trust task addresses by `did`, the
+client by `context_id`+`scid`). No twin at all: `import_key`,
+`get_wrapping_key`, `list_webvh_server_domains`, and the one-shot
+`backup_export`/`backup_import` pair (the trust-task backup slice is the
+five-step descriptor protocol).
+
+`rpc_void` lost its last caller and is gone; `rpc` stays for the surfaces
+listed above.
+
 ### vta-sdk 0.20.17 / vta-service 0.13.10 — reverse registry-parity harness + the `_1_0` constant rename pass (#854 phase 1)
 
 The dispatcher's parity harness has always asserted every `vta-sdk` URI is

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10269,7 +10269,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.20.17"
+version = "0.20.18"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.20.17"
+version = "0.20.18"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/client/acl.rs
+++ b/vta-sdk/src/client/acl.rs
@@ -89,11 +89,13 @@ impl VtaClient {
 
     pub async fn create_acl(&self, req: CreateAclRequest) -> Result<AclEntryResponse, VtaError> {
         // Canonical `acl/grant/0.1` returns the realized entry under `entry`.
+        // `CreateAclRequest` serializes to the canonical `{ entry, … }`
+        // request, so the same body serves the REST route and the trust-task
+        // dispatcher (which schema-validates it against the published spec).
         let wrapped: AclEntryEnvelope = self
-            .rpc(
-                acl_management::CREATE_ACL,
+            .rpc_tt(
+                crate::trust_tasks::TASK_ACL_GRANT_0_1,
                 serde_json::to_value(&req)?,
-                acl_management::CREATE_ACL_RESULT,
                 30,
                 |c, url| c.post(format!("{url}/acl")).json(&req),
             )
@@ -163,10 +165,9 @@ impl VtaClient {
     }
 
     pub async fn delete_acl(&self, did: &str) -> Result<(), VtaError> {
-        self.rpc_void(
-            acl_management::DELETE_ACL,
+        self.rpc_tt_void(
+            crate::trust_tasks::TASK_ACL_REVOKE_0_1,
             serde_json::json!({ "subject": did }),
-            acl_management::DELETE_ACL_RESULT,
             30,
             |c, url| c.delete(format!("{url}/acl/{}", encode_path_segment(did))),
         )

--- a/vta-sdk/src/client/audit.rs
+++ b/vta-sdk/src/client/audit.rs
@@ -18,11 +18,12 @@ impl VtaClient {
         &self,
         params: &crate::protocols::audit_management::list::ListAuditLogsBody,
     ) -> Result<crate::protocols::audit_management::list::ListAuditLogsResultBody, VtaError> {
-        use crate::protocols::audit_management;
-        self.rpc(
-            audit_management::LIST_LOGS,
+        // `ListAuditLogsBody` serializes to the canonical `audit/list/0.1`
+        // payload (omitted filters are absent, not null) — conformance is
+        // asserted server-side in `trust_tasks::audit::tests`.
+        self.rpc_tt(
+            crate::trust_tasks::TASK_AUDIT_LIST_0_1,
             serde_json::to_value(params)?,
-            audit_management::LIST_LOGS_RESULT,
             30,
             |c, url| {
                 // Query-param names are the canonical camelCase ones the
@@ -63,11 +64,9 @@ impl VtaClient {
     pub async fn get_audit_retention(
         &self,
     ) -> Result<crate::protocols::audit_management::retention::RetentionResultBody, VtaError> {
-        use crate::protocols::audit_management;
-        self.rpc(
-            audit_management::GET_RETENTION,
+        self.rpc_tt(
+            crate::trust_tasks::TASK_AUDIT_GET_RETENTION_1_0,
             serde_json::json!({}),
-            audit_management::GET_RETENTION_RESULT,
             30,
             |c, url| c.get(format!("{url}/audit/retention")),
         )
@@ -81,10 +80,9 @@ impl VtaClient {
     ) -> Result<crate::protocols::audit_management::retention::RetentionResultBody, VtaError> {
         use crate::protocols::audit_management;
         let body = audit_management::retention::UpdateRetentionBody { retention_days };
-        self.rpc(
-            audit_management::UPDATE_RETENTION,
+        self.rpc_tt(
+            crate::trust_tasks::TASK_AUDIT_UPDATE_RETENTION_1_0,
             serde_json::to_value(&body)?,
-            audit_management::UPDATE_RETENTION_RESULT,
             30,
             |c, url| c.patch(format!("{url}/audit/retention")).json(&body),
         )

--- a/vta-sdk/src/client/contexts.rs
+++ b/vta-sdk/src/client/contexts.rs
@@ -12,10 +12,9 @@ use crate::protocols::context_management;
 #[cfg(feature = "client")]
 impl VtaClient {
     pub async fn list_contexts(&self) -> Result<ContextListResponse, VtaError> {
-        self.rpc(
-            context_management::LIST_CONTEXTS,
+        self.rpc_tt(
+            crate::trust_tasks::TASK_CONTEXTS_LIST_1_0,
             serde_json::json!({}),
-            context_management::LIST_CONTEXTS_RESULT,
             30,
             |c, url| c.get(format!("{url}/contexts")),
         )
@@ -23,10 +22,9 @@ impl VtaClient {
     }
 
     pub async fn get_context(&self, id: &str) -> Result<ContextResponse, VtaError> {
-        self.rpc(
-            context_management::GET_CONTEXT,
+        self.rpc_tt(
+            crate::trust_tasks::TASK_CONTEXTS_GET_1_0,
             serde_json::json!({ "id": id }),
-            context_management::GET_CONTEXT_RESULT,
             30,
             |c, url| c.get(format!("{url}/contexts/{}", encode_path_segment(id))),
         )
@@ -37,10 +35,9 @@ impl VtaClient {
         &self,
         req: CreateContextRequest,
     ) -> Result<ContextResponse, VtaError> {
-        self.rpc(
-            context_management::CREATE_CONTEXT,
+        self.rpc_tt(
+            crate::trust_tasks::TASK_CONTEXTS_CREATE_1_0,
             serde_json::to_value(&req)?,
-            context_management::CREATE_CONTEXT_RESULT,
             30,
             |c, url| c.post(format!("{url}/contexts")).json(&req),
         )
@@ -52,15 +49,14 @@ impl VtaClient {
         id: &str,
         req: UpdateContextRequest,
     ) -> Result<ContextResponse, VtaError> {
-        self.rpc(
-            context_management::UPDATE_CONTEXT,
+        self.rpc_tt(
+            crate::trust_tasks::TASK_CONTEXTS_UPDATE_1_0,
             serde_json::json!({
                 "id": id,
                 "name": &req.name,
                 "did": &req.did,
                 "description": &req.description,
             }),
-            context_management::UPDATE_CONTEXT_RESULT,
             30,
             |c, url| {
                 c.patch(format!("{url}/contexts/{}", encode_path_segment(id)))
@@ -77,10 +73,9 @@ impl VtaClient {
         did: impl Into<String>,
     ) -> Result<ContextResponse, VtaError> {
         let did = did.into();
-        self.rpc(
-            context_management::UPDATE_CONTEXT_DID,
+        self.rpc_tt(
+            crate::trust_tasks::TASK_CONTEXTS_UPDATE_DID_1_0,
             serde_json::json!({ "id": id, "did": &did }),
-            context_management::UPDATE_CONTEXT_DID_RESULT,
             30,
             |c, url| {
                 c.put(format!("{url}/contexts/{}/did", encode_path_segment(id)))
@@ -94,10 +89,9 @@ impl VtaClient {
         &self,
         id: &str,
     ) -> Result<context_management::delete::DeleteContextPreviewResultBody, VtaError> {
-        self.rpc(
-            context_management::PREVIEW_DELETE_CONTEXT,
+        self.rpc_tt(
+            crate::trust_tasks::TASK_CONTEXTS_PREVIEW_DELETE_1_0,
             serde_json::json!({ "id": id }),
-            context_management::PREVIEW_DELETE_CONTEXT_RESULT,
             30,
             |c, url| {
                 c.get(format!(
@@ -110,10 +104,9 @@ impl VtaClient {
     }
 
     pub async fn delete_context(&self, id: &str, force: bool) -> Result<(), VtaError> {
-        self.rpc_void(
-            context_management::DELETE_CONTEXT,
+        self.rpc_tt_void(
+            crate::trust_tasks::TASK_CONTEXTS_DELETE_1_0,
             serde_json::json!({ "id": id, "force": force }),
-            context_management::DELETE_CONTEXT_RESULT,
             30,
             |c, url| {
                 let mut url = format!("{url}/contexts/{}", encode_path_segment(id));

--- a/vta-sdk/src/client/keys.rs
+++ b/vta-sdk/src/client/keys.rs
@@ -14,15 +14,21 @@ use crate::protocols::key_management::sign::SignAlgorithm;
 use crate::trust_tasks;
 
 #[cfg(feature = "client")]
-use crate::protocols::{key_management, seed_management};
+use crate::protocols::key_management;
 
 #[cfg(feature = "client")]
 impl VtaClient {
     // ── Key methods ─────────────────────────────────────────────────
 
+    /// Create a key.
+    ///
+    /// Trust-task leg note: `spec/vta/keys/create/1.0` auto-generates the
+    /// key id from the derivation path, so an explicit `req.key_id` only
+    /// takes effect on the REST leg — exactly as it did on the legacy
+    /// DIDComm message, which never carried `key_id` either.
     pub async fn create_key(&self, req: CreateKeyRequest) -> Result<CreateKeyResponse, VtaError> {
-        self.rpc(
-            key_management::CREATE_KEY,
+        self.rpc_tt(
+            trust_tasks::TASK_KEYS_CREATE_1_0,
             serde_json::json!({
                 "key_type": serde_json::to_value(&req.key_type)?,
                 "derivation_path": req.derivation_path.as_deref().unwrap_or_default(),
@@ -30,7 +36,6 @@ impl VtaClient {
                 "label": req.label.as_deref(),
                 "context_id": req.context_id.as_deref(),
             }),
-            key_management::CREATE_KEY_RESULT,
             30,
             |c, url| c.post(format!("{url}/keys")).json(&req),
         )
@@ -44,15 +49,14 @@ impl VtaClient {
         status: Option<&str>,
         context_id: Option<&str>,
     ) -> Result<ListKeysResponse, VtaError> {
-        self.rpc(
-            key_management::LIST_KEYS,
+        self.rpc_tt(
+            trust_tasks::TASK_KEYS_LIST_1_0,
             serde_json::json!({
                 "offset": offset,
                 "limit": limit,
                 "status": status,
                 "context_id": context_id,
             }),
-            key_management::LIST_KEYS_RESULT,
             30,
             |c, url| {
                 let mut u = format!("{url}/keys?offset={offset}&limit={limit}");
@@ -69,21 +73,23 @@ impl VtaClient {
     }
 
     pub async fn get_key(&self, key_id: &str) -> Result<KeyRecord, VtaError> {
-        self.rpc(
-            key_management::GET_KEY,
+        self.rpc_tt(
+            trust_tasks::TASK_KEYS_GET_1_0,
             serde_json::json!({ "key_id": key_id }),
-            key_management::GET_KEY_RESULT,
             30,
             |c, url| c.get(format!("{url}/keys/{}", encode_path_segment(key_id))),
         )
         .await
     }
 
+    /// Export a key's secret material. The trust-task twin lives in the
+    /// seeds slice (`spec/vta/seeds/export-mnemonic/1.0`) — same
+    /// `{ key_id }` request and the same
+    /// `operations::keys::get_key_secret` spine as the legacy message.
     pub async fn get_key_secret(&self, key_id: &str) -> Result<GetKeySecretResponse, VtaError> {
-        self.rpc(
-            key_management::GET_KEY_SECRET,
+        self.rpc_tt(
+            trust_tasks::TASK_SEEDS_EXPORT_MNEMONIC_1_0,
             serde_json::json!({ "key_id": key_id }),
-            key_management::GET_KEY_SECRET_RESULT,
             30,
             |c, url| c.get(format!("{url}/keys/{}/secret", encode_path_segment(key_id))),
         )
@@ -102,14 +108,13 @@ impl VtaClient {
     ) -> Result<SignResponse, VtaError> {
         use base64::Engine;
         let payload_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(payload);
-        self.rpc(
-            key_management::SIGN_REQUEST,
+        self.rpc_tt(
+            trust_tasks::TASK_KEYS_SIGN_1_0,
             serde_json::json!({
                 "key_id": key_id,
                 "payload": payload_b64,
                 "algorithm": algorithm,
             }),
-            key_management::SIGN_RESULT,
             30,
             |c, url| {
                 c.post(format!("{url}/keys/{}/sign", encode_path_segment(key_id)))
@@ -186,10 +191,9 @@ impl VtaClient {
     }
 
     pub async fn invalidate_key(&self, key_id: &str) -> Result<InvalidateKeyResponse, VtaError> {
-        self.rpc(
-            key_management::REVOKE_KEY,
+        self.rpc_tt(
+            trust_tasks::TASK_KEYS_REVOKE_1_0,
             serde_json::json!({ "key_id": key_id }),
-            key_management::REVOKE_KEY_RESULT,
             30,
             |c, url| c.delete(format!("{url}/keys/{}", encode_path_segment(key_id))),
         )
@@ -201,10 +205,9 @@ impl VtaClient {
         key_id: &str,
         new_key_id: &str,
     ) -> Result<RenameKeyResponse, VtaError> {
-        self.rpc(
-            key_management::RENAME_KEY,
+        self.rpc_tt(
+            trust_tasks::TASK_KEYS_RENAME_1_0,
             serde_json::json!({ "key_id": key_id, "new_key_id": new_key_id }),
-            key_management::RENAME_KEY_RESULT,
             30,
             |c, url| {
                 c.patch(format!("{url}/keys/{}", encode_path_segment(key_id)))
@@ -258,10 +261,9 @@ impl VtaClient {
     // ── Seed methods ────────────────────────────────────────────────
 
     pub async fn list_seeds(&self) -> Result<ListSeedsResponse, VtaError> {
-        self.rpc(
-            seed_management::LIST_SEEDS,
+        self.rpc_tt(
+            trust_tasks::TASK_SEEDS_LIST_1_0,
             serde_json::json!({}),
-            seed_management::LIST_SEEDS_RESULT,
             30,
             |c, url| c.get(format!("{url}/keys/seeds")),
         )
@@ -275,10 +277,9 @@ impl VtaClient {
         let body = RotateSeedRequest {
             mnemonic: mnemonic.clone(),
         };
-        self.rpc(
-            seed_management::ROTATE_SEED,
+        self.rpc_tt(
+            trust_tasks::TASK_SEEDS_ROTATE_1_0,
             serde_json::json!({ "mnemonic": mnemonic }),
-            seed_management::ROTATE_SEED_RESULT,
             30,
             |c, url| c.post(format!("{url}/keys/seeds/rotate")).json(&body),
         )

--- a/vta-sdk/src/client/mod.rs
+++ b/vta-sdk/src/client/mod.rs
@@ -6,7 +6,7 @@
 //! `audit.rs`, `did_templates.rs`, `bootstrap.rs`, `backup.rs`,
 //! `vta_management.rs`, `secrets.rs`). This file holds the struct
 //! definition, transport plumbing, the constructor / connection
-//! surface, and the shared `rpc` / `rpc_void` dispatch helpers used
+//! surface, and the shared `rpc` / `rpc_tt` dispatch helpers used
 //! by every per-domain method.
 
 use crate::error::VtaError;
@@ -704,8 +704,8 @@ impl VtaClient {
     /// - [`dispatch_trust_task`](Self::dispatch_trust_task) and everything built
     ///   on it (`rpc_tt`, the `device/*` and `vault/*` methods, the generic
     ///   trust-task escape hatch) routes over TSP.
-    /// - [`rpc`](Self::rpc) / `rpc_void` — the older DIDComm protocol-message
-    ///   surface (`key-management/1.0/*`, `create_did_webvh`, `list_contexts`)
+    /// - [`rpc`](Self::rpc) — the older DIDComm protocol-message surface
+    ///   (`import_key`, `update_webvh_server`, the legacy `backup/*` pair, …)
     ///   — stays on DIDComm **unconditionally**. It has no TSP dispatcher behind
     ///   it, so moving it would break it; that is why TSP is a per-surface
     ///   choice and not a client-wide one.
@@ -878,8 +878,8 @@ impl VtaClient {
     }
 
     /// Which transport carries the older DIDComm **protocol-message** surface
-    /// ([`rpc`](Self::rpc) / `rpc_void` — `key-management/1.0/*`,
-    /// `create_did_webvh`, `list_contexts`, …).
+    /// ([`rpc`](Self::rpc) — `import_key`, `update_webvh_server`, the legacy
+    /// `backup/*` pair, …).
     ///
     /// Never TSP: the VTA has no TSP dispatcher for these, so they report
     /// [`VtaError::UnsupportedTransport`] on a TSP-only client rather than being
@@ -1265,38 +1265,6 @@ impl VtaClient {
                 session
                     .send_and_wait(msg_type, body, result_type, timeout)
                     .await
-            }
-            #[cfg(feature = "tsp")]
-            Transport::Tsp { .. } => Err(unsupported_over_tsp(msg_type)),
-        }
-    }
-
-    /// Like [`rpc`](Self::rpc) but for operations that return `()` (e.g. DELETE).
-    #[allow(unused_variables)]
-    pub(super) async fn rpc_void(
-        &self,
-        msg_type: &str,
-        body: serde_json::Value,
-        result_type: &str,
-        timeout: u64,
-        build_rest: impl FnOnce(&Client, &str) -> RequestBuilder,
-    ) -> Result<(), VtaError> {
-        match &self.transport {
-            Transport::Rest {
-                client,
-                base_url,
-                auth,
-            } => {
-                let req = build_rest(client, base_url);
-                let resp = Self::send_authed(client, base_url, auth, req).await?;
-                Self::handle_delete_response(resp).await
-            }
-            #[cfg(feature = "session")]
-            Transport::DIDComm { session, .. } => {
-                let _: serde_json::Value = session
-                    .send_and_wait(msg_type, body, result_type, timeout)
-                    .await?;
-                Ok(())
             }
             #[cfg(feature = "tsp")]
             Transport::Tsp { .. } => Err(unsupported_over_tsp(msg_type)),
@@ -1829,11 +1797,9 @@ impl VtaClient {
     pub async fn capabilities(
         &self,
     ) -> Result<crate::protocols::discovery::CapabilitiesResponse, VtaError> {
-        use crate::protocols::discovery;
-        self.rpc(
-            discovery::DISCOVER_CAPABILITIES,
+        self.rpc_tt(
+            crate::trust_tasks::TASK_DISCOVERY_CAPABILITIES_1_0,
             serde_json::json!({}),
-            discovery::DISCOVER_CAPABILITIES_RESULT,
             30,
             |c, url| c.get(format!("{url}/capabilities")),
         )

--- a/vta-sdk/src/client/vta_management.rs
+++ b/vta-sdk/src/client/vta_management.rs
@@ -10,10 +10,9 @@ use crate::protocols::vta_management;
 impl VtaClient {
     /// Trigger a soft restart of the VTA.
     pub async fn restart(&self) -> Result<vta_management::restart::RestartResult, VtaError> {
-        self.rpc(
-            vta_management::RESTART,
+        self.rpc_tt(
+            crate::trust_tasks::TASK_MANAGEMENT_RELOAD_SERVICES_1_0,
             serde_json::json!({}),
-            vta_management::RESTART_RESULT,
             30,
             |c, url| {
                 c.post(format!("{url}/vta/restart"))
@@ -24,10 +23,9 @@ impl VtaClient {
     }
 
     pub async fn get_config(&self) -> Result<ConfigResponse, VtaError> {
-        self.rpc(
-            vta_management::GET_CONFIG,
+        self.rpc_tt(
+            crate::trust_tasks::TASK_CONFIG_SHOW_0_1,
             serde_json::json!({}),
-            vta_management::GET_CONFIG_RESULT,
             30,
             |c, url| c.get(format!("{url}/config")),
         )
@@ -39,10 +37,11 @@ impl VtaClient {
         req: UpdateConfigRequest,
     ) -> Result<crate::protocols::vta_management::update_config::UpdateConfigResultBody, VtaError>
     {
-        self.rpc(
-            vta_management::UPDATE_CONFIG,
+        // `UpdateConfigRequest` flattens `UpdateConfigBody`, so the serialized
+        // form is the canonical `config/patch/0.1` `{ overrides }` payload.
+        self.rpc_tt(
+            crate::trust_tasks::TASK_CONFIG_PATCH_0_1,
             serde_json::to_value(&req)?,
-            vta_management::UPDATE_CONFIG_RESULT,
             30,
             |c, url| c.patch(format!("{url}/config")).json(&req),
         )

--- a/vta-sdk/src/client/webvh.rs
+++ b/vta-sdk/src/client/webvh.rs
@@ -19,10 +19,9 @@ impl VtaClient {
         &self,
         req: AddWebvhServerRequest,
     ) -> Result<crate::webvh::WebvhServerRecord, VtaError> {
-        self.rpc(
-            did_management::ADD_WEBVH_SERVER,
+        self.rpc_tt(
+            crate::trust_tasks::TASK_WEBVH_SERVERS_REGISTER_1_0,
             serde_json::to_value(&req)?,
-            did_management::ADD_WEBVH_SERVER_RESULT,
             30,
             |c, url| c.post(format!("{url}/webvh/servers")).json(&req),
         )
@@ -33,10 +32,9 @@ impl VtaClient {
         &self,
     ) -> Result<crate::protocols::did_management::servers::ListWebvhServersResultBody, VtaError>
     {
-        self.rpc(
-            did_management::LIST_WEBVH_SERVERS,
+        self.rpc_tt(
+            crate::trust_tasks::TASK_WEBVH_SERVERS_LIST_1_0,
             serde_json::json!({}),
-            did_management::LIST_WEBVH_SERVERS_RESULT,
             30,
             |c, url| c.get(format!("{url}/webvh/servers")),
         )
@@ -88,10 +86,9 @@ impl VtaClient {
     }
 
     pub async fn remove_webvh_server(&self, id: &str) -> Result<(), VtaError> {
-        self.rpc_void(
-            did_management::REMOVE_WEBVH_SERVER,
+        self.rpc_tt_void(
+            crate::trust_tasks::TASK_WEBVH_SERVERS_REMOVE_1_0,
             serde_json::json!({ "id": id }),
-            did_management::REMOVE_WEBVH_SERVER_RESULT,
             30,
             |c, url| c.delete(format!("{url}/webvh/servers/{}", encode_path_segment(id))),
         )
@@ -123,10 +120,9 @@ impl VtaClient {
             force,
             domain: domain.map(|d| d.to_string()),
         };
-        self.rpc(
-            did_management::REGISTER_DID_WITH_SERVER,
+        self.rpc_tt(
+            crate::trust_tasks::TASK_WEBVH_DIDS_REGISTER_WITH_SERVER_1_0,
             serde_json::to_value(&body)?,
-            did_management::REGISTER_DID_WITH_SERVER_RESULT,
             60,
             |c, url| {
                 c.post(format!(
@@ -145,10 +141,9 @@ impl VtaClient {
         &self,
         req: CreateDidWebvhRequest,
     ) -> Result<crate::protocols::did_management::create::CreateDidWebvhResultBody, VtaError> {
-        self.rpc(
-            did_management::CREATE_DID_WEBVH,
+        self.rpc_tt(
+            crate::trust_tasks::TASK_WEBVH_DIDS_CREATE_1_0,
             serde_json::to_value(&req)?,
-            did_management::CREATE_DID_WEBVH_RESULT,
             60,
             |c, url| c.post(format!("{url}/webvh/dids")).json(&req),
         )
@@ -160,13 +155,12 @@ impl VtaClient {
         context_id: Option<&str>,
         server_id: Option<&str>,
     ) -> Result<crate::protocols::did_management::list::ListDidsWebvhResultBody, VtaError> {
-        self.rpc(
-            did_management::LIST_DIDS_WEBVH,
+        self.rpc_tt(
+            crate::trust_tasks::TASK_WEBVH_DIDS_LIST_1_0,
             serde_json::json!({
                 "context_id": context_id,
                 "server_id": server_id,
             }),
-            did_management::LIST_DIDS_WEBVH_RESULT,
             30,
             |c, url| {
                 let mut u = format!("{url}/webvh/dids");
@@ -185,10 +179,12 @@ impl VtaClient {
     }
 
     pub async fn get_did_webvh(&self, did: &str) -> Result<crate::webvh::WebvhDidRecord, VtaError> {
-        self.rpc(
-            did_management::GET_DID_WEBVH,
+        // `spec/vta/webvh/dids/get/1.0` returns the record flattened (a
+        // strict superset of the bare `WebvhDidRecord`), so the same decode
+        // serves both legs.
+        self.rpc_tt(
+            crate::trust_tasks::TASK_WEBVH_DIDS_GET_1_0,
             serde_json::json!({ "did": did }),
-            did_management::GET_DID_WEBVH_RESULT,
             30,
             |c, url| c.get(format!("{url}/webvh/dids/{}", encode_path_segment(did))),
         )
@@ -196,10 +192,12 @@ impl VtaClient {
     }
 
     pub async fn get_did_webvh_log(&self, did: &str) -> Result<GetDidLogResponse, VtaError> {
-        self.rpc(
-            did_management::GET_DID_WEBVH_LOG,
-            serde_json::json!({ "did": did }),
-            did_management::GET_DID_WEBVH_LOG_RESULT,
+        // The dedicated get-log task folded into `dids/get` + `includeLog`
+        // (see `GetDidWebvhBody`); the flattened response is a superset of
+        // `GetDidLogResponse`, so the decode is unchanged.
+        self.rpc_tt(
+            crate::trust_tasks::TASK_WEBVH_DIDS_GET_1_0,
+            serde_json::json!({ "did": did, "includeLog": true }),
             30,
             |c, url| c.get(format!("{url}/webvh/dids/{}/log", encode_path_segment(did))),
         )
@@ -207,10 +205,9 @@ impl VtaClient {
     }
 
     pub async fn delete_did_webvh(&self, did: &str) -> Result<(), VtaError> {
-        self.rpc_void(
-            did_management::DELETE_DID_WEBVH,
+        self.rpc_tt_void(
+            crate::trust_tasks::TASK_WEBVH_DIDS_DELETE_1_0,
             serde_json::json!({ "did": did }),
-            did_management::DELETE_DID_WEBVH_RESULT,
             60,
             |c, url| c.delete(format!("{url}/webvh/dids/{}", encode_path_segment(did))),
         )


### PR DESCRIPTION
Closes https://github.com/OpenVTC/verifiable-trust-infrastructure/issues/829

## What

`VtaClient::sign()` was the only signing entry point that could not reach TSP — it rode the legacy `rpc` path whose TSP arm is `Err(unsupported_over_tsp(..))`. It now routes through `rpc_tt(TASK_KEYS_SIGN_1_0, …)`, keeping `POST /keys/{key_id}/sign` as the REST leg — exactly the shape `derive_and_sign` beside it already has.

The issue's last paragraph asked which other `rpc`/`rpc_void`-routed methods with an existing Trust Task twin should move at the same time. This PR audits **all 42** remaining `rpc`/`rpc_void` call sites against the current dispatcher (`vta-service/src/trust_tasks/mod.rs`) and moves **every method whose request AND response wire shapes already match its twin** — the sweeping form the issue gestures at, on pre-production code. Nothing server-side changes: legacy DIDComm message handlers remain, so existing clients keep working (nothing to dual-accept — the dispatcher already served all of these URIs).

Note (re. the issue text vs. current main): the issue named the keys/seeds/ACL slices as having twins. Latest main has grown twins for contexts, audit, config, management, discovery, and webvh as well; the audit below covers all of them.

## Audit table: method → task URI → moved?

| Client method | Trust Task URI | Moved? |
|---|---|---|
| `sign` | `vta/keys/sign/1.0` | **moved** (the headline fix) |
| `list_keys` / `create_key` / `get_key` / `rename_key` / `invalidate_key` | `vta/keys/{list,create,get,rename,revoke}/1.0` | moved |
| `get_key_secret` | `vta/seeds/export-mnemonic/1.0` | moved — same `{key_id}` body, same `operations::keys::get_key_secret` spine |
| `list_seeds` / `rotate_seed` | `vta/seeds/{list,rotate}/1.0` | moved |
| `create_acl` | `acl/grant/0.1` | moved — `CreateAclRequest` already serializes the canonical `{entry}` body |
| `delete_acl` | `acl/revoke/0.1` | moved (`rpc_tt_void`) |
| `list_audit_logs` | `audit/list/0.1` | moved — request conformance is asserted in `trust_tasks::audit::tests` |
| `get_audit_retention` / `update_audit_retention` | `vta/audit/{get,update}-retention/1.0` | moved |
| `list_contexts` / `get_context` / `create_context` / `update_context` / `update_context_did` / `preview_delete_context` / `delete_context` | `vta/contexts/*/1.0` | moved |
| `get_config` / `update_config` | `config/show/0.1` / `config/patch/0.1` | moved — `UpdateConfigRequest` flattens to the canonical `{overrides}` |
| `restart` | `vta/management/reload-services/1.0` | moved (registry doc's mapping for `POST /vta/restart`) |
| `capabilities` | `vta/discovery/capabilities/1.0` | moved |
| `add_webvh_server` / `list_webvh_servers` / `remove_webvh_server` | `vta/webvh/servers/{register,list,remove}/1.0` | moved |
| `create_did_webvh` / `list_dids_webvh` / `get_did_webvh` / `delete_did_webvh` / `register_did_with_server` | `vta/webvh/dids/*/1.0` | moved |
| `get_did_webvh_log` | `vta/webvh/dids/get/1.0` + `includeLog: true` | moved — the get-log task folded into `dids/get`; the flattened response is a strict superset of `GetDidLogResponse` |
| `list_acl` / `list_acl_in_direction` | `acl/list/0.1` | **not moved** — the twin's response is a bare array of the flat stored form, not the canonical `{entries, truncated, …}` the client (and REST leg) decode; request also renames `context`→`scope`. → #857 |
| `get_acl` | `acl/show/0.1` | **not moved** — twin returns flat `CreateAclResultBody`, not the canonical `{entry}` envelope the client decodes (`handle_get` calls `operations::acl::get_acl` instead of `show_by_subject`). → #857 |
| `change_acl_role` | `acl/change-role/0.1` | **not moved** — same flat-response drift (`handle_change_role` → `change_role`, not a wrapped op). → #857 |
| `update_acl` | `acl/update/0.1` | **not moved** — request shape is non-canonical (`did`/`allowed_contexts` vs required `subject`/`scopes`) and the dispatch spine schema-rejects it today; documented in `trust_tasks/acl.rs` tests. → #857 |
| `swap_acl` | `acl/swap-key/0.1` | **not moved** — canonical body needs `currentSubject`/`newSubject`; the client API carries only the VP-JWT. Needs a (breaking) client-API change first. → #857 |
| `update_webvh_server` | (`vta/webvh/servers/register/1.0` absorbs update) | **not moved** — twin is register-or-update: a typo'd id would silently create a server instead of 404ing. Behavioural change, flagged rather than papered over. → #857 |
| `update_did_webvh` / `rotate_did_webvh_keys` | `vta/webvh/dids/{update,rotate-keys}/1.0` | **not moved** — twins address the DID by `did` (flattened body); the client addresses by `context_id`+`scid`. `dids/update` is additionally schema-validated. → #857 |
| `import_key` | — | no twin (`keys/import` not dispatched) → drift input for #854 |
| `get_wrapping_key` | — | no twin; REST-only by design (wrapping key exists only for REST import) → #854 triage can confirm |
| `list_webvh_server_domains` | — | no twin → #854 |
| `backup_export` / `backup_import` | — | no *direct* twin — the trust-task backup slice is the five-step descriptor protocol (`initiate/complete-export`, `initiate/finalize-import`, `abort`), a different wire contract → #854/#857 |

## Observable wire-behaviour notes (beyond the transport envelope)

- DIDComm/TSP legs of moved methods now pass through the trust-task dispatch spine: PDP policy gate, replay guard, and payload-schema validation for the published URIs (`acl/grant`, `acl/revoke`, `audit/list`, `config/show`, `config/patch`). All moved payloads were verified against those schemas (no nulls where the schema types a string; `additionalProperties: false` respected). The `vta/*` URIs in this sweep have no published schema and dispatch unvalidated.
- `create_key` over trust task auto-generates the key id (`handle_create` pins `key_id: None`) — identical to the legacy DIDComm message, which never carried `key_id`; explicit ids remain a REST-leg feature.
- Errors on the DIDComm leg now surface as trust-task rejections (`VtaError::Protocol`/task-rejection mapping) rather than legacy problem-reports — same as the already-migrated `derive_and_sign`/`did_templates` surfaces.
- `rpc_void` lost its last caller and is removed from the SDK (internal, `pub(super)`).

## Validation

- `cargo check -p vta-sdk -p vta-service --all-features` — clean (no warnings).
- `cargo test -p vta-sdk --all-features --lib` — **540 passed, 0 failed**.
- `cargo test -p vta-service --all-features --lib` — **729 passed, 0 failed** (includes the trust-task dispatch/schema-gate suites).
- Release guards: `vta-sdk` bumped 0.20.16 → 0.20.17 with a root `CHANGELOG.md` entry under Unreleased. (`vta-service` untouched. Expect a trivial CHANGELOG rebase if #858 merges first.)

## Reviewer checklist

- [ ] Each moved method's TT handler parses the same protocol body the client sends (spot-check `keys::handle_sign`, `seeds::handle_export_mnemonic`, `webvh::handle_dids_get`).
- [ ] Agree the not-moved rows are #857/#854 material rather than blockers here.
- [ ] `get_did_webvh_log` via `dids/get` + `includeLog`: flattened superset decodes as `GetDidLogResponse` (fields `did`, `log`).
- [ ] Removal of `rpc_void` is acceptable (internal helper, zero callers).
