### PR TITLE
feat(push): cut push/* emitters over to 0.2 wire (gateway cutover sweep)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## Unreleased
 
+### vta-sdk 0.20.19 / vta-service 0.13.11 — push/* emitters cut over to 0.2
+
+The vti-push-gateway's clean cutover to `push/*` 0.2
+(OpenVTC/vti-push-gateway#21) rejects 0.1 documents, so the VTA-side emitters
+move with it: `device/set-wake` provisioning now sends
+`push/provision/0.2` (vta-service `device.rs`) and the step-up wake trigger
+sends `push/wake/0.2` (vta-service `step_up.rs`). Request payloads are
+field-identical across 0.1→0.2; the only wire-visible change is the wake
+response status enum `token-unregistered` → `tokenUnregistered`, which the
+wake trigger now parses (via the generated `push::wake::v0_2` types) and logs
+— a `tokenUnregistered` reply means the platform token is dead and the handle
+was dropped, so the mediator-queue fallback applies. The vta-sdk
+`agent_session` inbound-wake test fixture moves to the 0.2 URI.
+`vta-mobile-core` was already on `push/register/0.2` and parses no wake
+status — unchanged. Clean cutover, no dual-emit; must merge before the
+gateway cutover deploys against these services.
+
 ### vta-sdk 0.20.18 — every client method with a Trust-Task twin now rides the Trust-Task bridge (#829)
 
 `VtaClient::sign()` was the odd one out among the three signing entry points:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10269,7 +10269,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.20.18"
+version = "0.20.19"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10331,7 +10331,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.13.10"
+version = "0.13.11"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.20.18"
+version = "0.20.19"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/agent_session.rs
+++ b/vta-sdk/src/agent_session.rs
@@ -340,13 +340,13 @@ mod tests {
     fn inbound_message_parses_didcomm_envelope() {
         let json = r#"{
             "id": "urn:uuid:abc",
-            "type": "https://trusttasks.org/spec/push/wake/0.1",
+            "type": "https://trusttasks.org/spec/push/wake/0.2",
             "from": "did:key:zVta",
             "body": { "reason": "work-available" }
         }"#;
         let msg = InboundMessage::parse(json).unwrap();
         assert_eq!(msg.id, "urn:uuid:abc");
-        assert_eq!(msg.typ, "https://trusttasks.org/spec/push/wake/0.1");
+        assert_eq!(msg.typ, "https://trusttasks.org/spec/push/wake/0.2");
         assert_eq!(msg.from.as_deref(), Some("did:key:zVta"));
         assert_eq!(msg.body["reason"], "work-available");
     }

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.13.10"
+version = "0.13.11"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/trust_tasks/device.rs
+++ b/vta-service/src/trust_tasks/device.rs
@@ -216,7 +216,7 @@ fn provision_gateway(
     };
     let provision = serde_json::json!({
         "id": format!("urn:uuid:{}", uuid::Uuid::new_v4()),
-        "type": "https://trusttasks.org/spec/push/provision/0.1",
+        "type": "https://trusttasks.org/spec/push/provision/0.2",
         "issuer": vta_did,
         "recipient": gateway,
         "payload": { "handle": handle, "policy": { "allowedTriggers": triggers } },

--- a/vta-service/src/trust_tasks/step_up.rs
+++ b/vta-service/src/trust_tasks/step_up.rs
@@ -27,6 +27,8 @@ use base64::Engine as _;
 use base64::engine::general_purpose;
 use serde_json::{Value, json};
 use trust_tasks_rs::specs::auth::step_up::approve_response::v0_1 as approve_response;
+#[cfg(feature = "didcomm")]
+use trust_tasks_rs::specs::push::wake::v0_2 as push_wake;
 use trust_tasks_rs::{RejectReason, TrustTask};
 use uuid::Uuid;
 
@@ -874,7 +876,7 @@ pub(super) async fn trigger_gateway_wake(
     let vta_did = state.config.read().await.vta_did.clone();
     let wake_doc = json!({
         "id": format!("urn:uuid:{}", uuid::Uuid::new_v4()),
-        "type": "https://trusttasks.org/spec/push/wake/0.1",
+        "type": "https://trusttasks.org/spec/push/wake/0.2",
         "issuer": vta_did,
         "recipient": wake.gateway,
         "payload": {
@@ -899,15 +901,38 @@ pub(super) async fn trigger_gateway_wake(
             )
             .await
         {
-            Ok(_) => {
-                tracing::info!(gateway = %gateway, approver = %approver, "push/wake sent to gateway")
-            }
+            Ok(reply) => match wake_reply_status(&reply.body) {
+                Some(push_wake::ResponseStatus::TokenUnregistered) => tracing::warn!(
+                    gateway = %gateway, approver = %approver,
+                    "push/wake: gateway reports tokenUnregistered — dead platform token, \
+                     handle dropped; mediator queue + pickup fallback applies"
+                ),
+                Some(push_wake::ResponseStatus::Delivered) => {
+                    tracing::info!(gateway = %gateway, approver = %approver, "push/wake delivered by gateway")
+                }
+                None => tracing::info!(
+                    gateway = %gateway, approver = %approver,
+                    "push/wake sent to gateway (no recognizable 0.2 response status)"
+                ),
+            },
             Err(e) => tracing::warn!(
                 error = %e, gateway = %gateway, approver = %approver,
                 "push/wake to gateway failed (best-effort)"
             ),
         }
     });
+}
+
+/// Extract the `push/wake/0.2#response` status from the gateway's reply — the
+/// DIDComm envelope body is the Trust Task response document, so the status
+/// lives at `payload.status`. Returns `None` when the reply carries no
+/// recognizable 0.2 status; that includes the retired 0.1 kebab-case
+/// `token-unregistered`, which the 0.2 clean cutover no longer accepts.
+#[cfg(feature = "didcomm")]
+fn wake_reply_status(envelope_body: &Value) -> Option<push_wake::ResponseStatus> {
+    envelope_body
+        .pointer("/payload/status")
+        .and_then(|s| serde_json::from_value(s.clone()).ok())
 }
 
 /// Trust-task analogue of [`issue_step_up_challenge`]: enforce a stepped-up
@@ -1170,6 +1195,45 @@ mod tests {
     use http_body_util::BodyExt;
     use multibase::Base;
     use serde_json::json;
+
+    #[cfg(feature = "didcomm")]
+    #[test]
+    fn wake_reply_status_parses_camel_case_token_unregistered() {
+        // push/wake/0.2 renamed the status value `token-unregistered` →
+        // `tokenUnregistered` (the only wire-visible 0.1→0.2 change).
+        let reply = json!({
+            "type": "https://trusttasks.org/spec/push/wake/0.2#response",
+            "payload": { "status": "tokenUnregistered" },
+        });
+        assert_eq!(
+            wake_reply_status(&reply),
+            Some(push_wake::ResponseStatus::TokenUnregistered)
+        );
+    }
+
+    #[cfg(feature = "didcomm")]
+    #[test]
+    fn wake_reply_status_parses_delivered() {
+        let reply = json!({
+            "type": "https://trusttasks.org/spec/push/wake/0.2#response",
+            "payload": { "status": "delivered" },
+        });
+        assert_eq!(
+            wake_reply_status(&reply),
+            Some(push_wake::ResponseStatus::Delivered)
+        );
+    }
+
+    #[cfg(feature = "didcomm")]
+    #[test]
+    fn wake_reply_status_rejects_retired_kebab_case_and_junk() {
+        // Clean cutover: the 0.1 kebab-case value is NOT accepted.
+        let legacy = json!({ "payload": { "status": "token-unregistered" } });
+        assert_eq!(wake_reply_status(&legacy), None);
+        // Missing / malformed payloads degrade to None (best-effort logging).
+        assert_eq!(wake_reply_status(&json!({})), None);
+        assert_eq!(wake_reply_status(&json!({ "payload": {} })), None);
+    }
 
     #[test]
     fn approver_mediator_routes_did_key_to_configured_mediator() {


### PR DESCRIPTION
Addresses OpenVTC/vti-push-gateway#21 consumer sweep.

**Merge-order note: this must merge (and deploy) before the gateway 0.2 cutover (OpenVTC/vti-push-gateway#21) deploys against these services** — the gateway now rejects push/* 0.1 documents.

## What changed

Clean cutover of all VTI push/* emitters to the 0.2 URIs — no dual-emit. Request payloads are field-identical 0.1→0.2; the only wire-visible change is the push/wake response status enum `token-unregistered` → `tokenUnregistered`.

- **vta-service `trust_tasks/device.rs`** — set-wake gateway provisioning now emits `push/provision/0.2`.
- **vta-service `trust_tasks/step_up.rs`** — the step-up wake trigger now emits `push/wake/0.2`, and now **parses the gateway's response status** (previously discarded) via the generated `trust_tasks_rs::specs::push::wake::v0_2::ResponseStatus`: `tokenUnregistered` (dead platform token; handle dropped) logs a warning — mediator-queue fallback applies; `delivered` logs info. The retired kebab-case `token-unregistered` is deliberately NOT accepted (clean cutover).
- **vta-sdk `agent_session.rs`** — inbound-wake test fixture moved to the 0.2 URI.
- **vta-mobile-core `push.rs`** — verified already on `push/register/0.2`; it parses no wake status anywhere. Unchanged.
- Release guards: vta-service 0.13.8 → **0.13.9**, vta-sdk 0.20.16 → **0.20.17**, root `CHANGELOG.md` entry under Unreleased, `Cargo.lock` refreshed.

## Discrepancies vs. the gateway PR's consumer list

- `vta-sdk/src/agent_session.rs` does **not** emit push/wake — it only *parses* an inbound wake envelope (type string is opaque to the parser; only a test fixture cited the 0.1 URI), and it never inspects the wake response status. Fixture updated; no behavior change.
- No code in VTI parsed the wake response status at all before this PR; the `tokenUnregistered` handling in `step_up.rs` is new (and is where the renamed enum value becomes wire-visible to VTI).

## Version-bump caveat

vta-service 0.13.9 assumes #858 (which also bumps vta-service) has not merged yet — if it lands first, this PR takes 0.13.10 and a small CHANGELOG rebase (orchestrator-coordinated).

## Test evidence

```
cargo check -p vta-service -p vta-sdk                       → Finished dev profile
cargo test -p vta-service --lib step_up                     → 21 passed; 0 failed
cargo test -p vta-service --lib wake_reply_status           → 3 passed; 0 failed (new)
cargo test -p vta-sdk --features session --lib agent_session → 5 passed; 0 failed
cargo test -p vta-mobile-core --lib push                    → 7 passed; 0 failed
cargo fmt -p vta-service -p vta-sdk --check                 → clean
```

## Reviewer checklist

- [ ] Confirm clean cutover is intended (no dual-emit window on the VTA side) and that this merges/deploys before the gateway cutover.
- [ ] `wake_reply_status` returning `None` for the legacy kebab-case value only affects a log line (best-effort path) — confirm that's acceptable vs. hard-failing.
- [ ] Version bumps: vta-service 0.13.9 / vta-sdk 0.20.17 vs. #858 ordering.