### PR TITLE
feat(did-templates): consolidate onto the merged six-task 2.0 family

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 ## Unreleased
 
+### vta-sdk 0.20.21 / vta-service 0.13.12 — did-templates consolidated onto the merged 2.0 family
+
+Implements OpenVTC/verifiable-trust-infrastructure#851. The twelve-URI pair of
+trust-task families `vta/did-templates/*/1.0` (global) and
+`vta/contexts/did-templates/*/1.0` (context-scoped) collapses onto the merged
+six-task `vta/did-templates/{list,get,create,update,delete,render}/2.0` family:
+one URI per operation, with the payload's **optional `contextId`** selecting the
+scope — absent = global (super-admin gated for writes), present = that context
+(context-admin gated for writes, context access for reads). `render/2.0`
+additionally injects the ambient `CONTEXT_ID` / `CONTEXT_DID` variables when
+scoped, exactly as the former context render did.
+
+**Clean cutover — removed wire URIs.** Per the pre-production consolidation
+policy the twelve 1.0 URIs are dropped outright rather than dual-accepted; a
+document carrying any of them now gets `UnsupportedType`:
+
+- `https://trusttasks.org/spec/vta/did-templates/{list,create,get,update,delete,render}/1.0`
+- `https://trusttasks.org/spec/vta/contexts/did-templates/{list,create,get,update,delete,render}/1.0`
+
+**Surfaces:**
+
+- `vta-sdk`: six `TASK_DID_TEMPLATES_*_2_0` constants replace the twelve 1.0
+  constants; the `did_template_management` wire bodies collapse to one body per
+  op with `context_id: Option<String>` (the `*Context*Body` variants are gone);
+  `VtaClient` template methods keep their signatures but dispatch the 2.0 URIs.
+- `vta-service`: the did-templates trust-task slice is six scope-branching
+  handlers dispatching into the unchanged `operations::did_templates`
+  global/context functions; per-scope auth still enforced at the op layer.
+  REST routes are untouched.
+
 ### vtc-service 0.11.43 / vta-sdk 0.20.20 — join-request decide, accept folded into members/vmc, endorsement-types per-method tasks
 
 Implements OpenVTC/verifiable-trust-infrastructure#853 (clean cutover — the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10269,7 +10269,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.20.20"
+version = "0.20.21"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10331,7 +10331,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.13.11"
+version = "0.13.12"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/docs/05-design-notes/registry-drift-triage.md
+++ b/docs/05-design-notes/registry-drift-triage.md
@@ -16,6 +16,12 @@ are *fold* and *delete*, not *alias*.
   excluded from this triage as in-flight. (It is an outbound producer URI in
   `vta-service/src/trust_tasks/consent_request.rs`, not a dispatched one, so it
   is also outside the harness's scope.)
+- #851 — the did-templates global+context merge — shipped as
+  `vta/did-templates/*/2.0` (specced upstream in
+  trustoverip/dtgwg-trust-tasks-tf#162). The six 2.0 URIs sit in
+  `UNSPECCED_DISPATCHED_URIS` as **publish-lag entries only** until the pinned
+  `trust-tasks-rs` is bumped to ≥0.2.49; the staleness check then forces their
+  removal. Not missing-spec debt — do not fold into this triage.
 - #856 — `acl/update`'s non-canonical body — is being fixed by another stream.
 - #857 — the payload-conformance sweep (the *third* parity direction: served
   URIs whose published schema the handler's actual payload type does not

--- a/tests/e2e/tests/client_didcomm.rs
+++ b/tests/e2e/tests/client_didcomm.rs
@@ -679,7 +679,7 @@ fn template_record_json(name: &str) -> Value {
 }
 
 /// DIDComm template management is dispatched as a Trust Task: the SDK sends the
-/// binding-envelope type carrying `{type: vta/did-templates/list/1.0, payload}`,
+/// binding-envelope type carrying `{type: vta/did-templates/list/2.0, payload}`,
 /// and the VTA replies with a trust-task document whose `payload` is the result.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn list_did_templates_via_didcomm() {
@@ -687,13 +687,13 @@ async fn list_did_templates_via_didcomm() {
     let (mediator, responder, client) = build_didcomm(|msg_type, body| {
         if msg_type == TT_ENVELOPE
             && body.get("type").and_then(|v| v.as_str())
-                == Some(trust_tasks::TASK_DID_TEMPLATES_LIST_1_0)
+                == Some(trust_tasks::TASK_DID_TEMPLATES_LIST_2_0)
         {
             ResponderReply::ok(
                 TT_ENVELOPE,
                 json!({
                     "id": "urn:uuid:resp-1",
-                    "type": format!("{}#response", trust_tasks::TASK_DID_TEMPLATES_LIST_1_0),
+                    "type": format!("{}#response", trust_tasks::TASK_DID_TEMPLATES_LIST_2_0),
                     "payload": {"templates": [template_record_json("custom-1")]}
                 }),
             )

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.20.20"
+version = "0.20.21"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/client/did_templates.rs
+++ b/vta-sdk/src/client/did_templates.rs
@@ -4,9 +4,10 @@
 //! `/did-templates` (and `/contexts/{id}/did-templates`) routes. On the
 //! DIDComm transport there is no raw protocol surface — the VTA exposes
 //! template management only through its Trust-Task dispatcher, so the DIDComm
-//! leg dispatches the `trusttasks.org/spec/vta/did-templates/*` (and
-//! `.../contexts/did-templates/*`) Trust Tasks via the binding envelope. Both
-//! legs are wired through [`VtaClient::rpc_tt`] / [`VtaClient::rpc_tt_void`].
+//! leg dispatches the `trusttasks.org/spec/vta/did-templates/*/2.0` Trust
+//! Tasks via the binding envelope. One URI per operation; the payload's
+//! optional `contextId` selects global vs context scope. Both legs are wired
+//! through [`VtaClient::rpc_tt`] / [`VtaClient::rpc_tt_void`].
 
 use std::collections::HashMap;
 
@@ -23,12 +24,13 @@ impl VtaClient {
 
     /// List all global templates.
     ///
-    /// REST: `GET /did-templates`. DIDComm: `vta/did-templates/list/1.0`.
+    /// REST: `GET /did-templates`. DIDComm: `vta/did-templates/list/2.0`
+    /// without `contextId`.
     pub async fn list_did_templates(&self) -> Result<Vec<DidTemplateRecord>, VtaError> {
         let resp: proto::list::ListDidTemplatesResultBody = self
             .rpc_tt(
-                trust_tasks::TASK_DID_TEMPLATES_LIST_1_0,
-                serde_json::to_value(proto::list::ListDidTemplatesBody::default())?,
+                trust_tasks::TASK_DID_TEMPLATES_LIST_2_0,
+                serde_json::to_value(proto::list::ListDidTemplatesBody { context_id: None })?,
                 30,
                 |c, url| c.get(format!("{url}/did-templates")),
             )
@@ -38,11 +40,13 @@ impl VtaClient {
 
     /// Fetch one global template by name.
     ///
-    /// REST: `GET /did-templates/{name}`. DIDComm: `vta/did-templates/get/1.0`.
+    /// REST: `GET /did-templates/{name}`. DIDComm:
+    /// `vta/did-templates/get/2.0` without `contextId`.
     pub async fn get_did_template(&self, name: &str) -> Result<DidTemplateRecord, VtaError> {
         self.rpc_tt(
-            trust_tasks::TASK_DID_TEMPLATES_GET_1_0,
+            trust_tasks::TASK_DID_TEMPLATES_GET_2_0,
             serde_json::to_value(proto::get::GetDidTemplateBody {
+                context_id: None,
                 name: name.to_string(),
             })?,
             30,
@@ -53,16 +57,18 @@ impl VtaClient {
 
     /// Create a global template. Super admin only.
     ///
-    /// REST: `POST /did-templates`. DIDComm: `vta/did-templates/create/1.0`.
+    /// REST: `POST /did-templates`. DIDComm:
+    /// `vta/did-templates/create/2.0` without `contextId`.
     pub async fn create_did_template(
         &self,
         template: DidTemplate,
     ) -> Result<DidTemplateRecord, VtaError> {
         let payload = serde_json::to_value(proto::create::CreateDidTemplateBody {
+            context_id: None,
             template: template.clone(),
         })?;
         self.rpc_tt(
-            trust_tasks::TASK_DID_TEMPLATES_CREATE_1_0,
+            trust_tasks::TASK_DID_TEMPLATES_CREATE_2_0,
             payload,
             30,
             |c, url| c.post(format!("{url}/did-templates")).json(&template),
@@ -72,18 +78,20 @@ impl VtaClient {
 
     /// Replace a global template. Super admin only.
     ///
-    /// REST: `PUT /did-templates/{name}`. DIDComm: `vta/did-templates/update/1.0`.
+    /// REST: `PUT /did-templates/{name}`. DIDComm:
+    /// `vta/did-templates/update/2.0` without `contextId`.
     pub async fn update_did_template(
         &self,
         name: &str,
         template: DidTemplate,
     ) -> Result<DidTemplateRecord, VtaError> {
         let payload = serde_json::to_value(proto::update::UpdateDidTemplateBody {
+            context_id: None,
             name: name.to_string(),
             template: template.clone(),
         })?;
         self.rpc_tt(
-            trust_tasks::TASK_DID_TEMPLATES_UPDATE_1_0,
+            trust_tasks::TASK_DID_TEMPLATES_UPDATE_2_0,
             payload,
             30,
             |c, url| {
@@ -96,11 +104,13 @@ impl VtaClient {
 
     /// Delete a global template. Super admin only.
     ///
-    /// REST: `DELETE /did-templates/{name}`. DIDComm: `vta/did-templates/delete/1.0`.
+    /// REST: `DELETE /did-templates/{name}`. DIDComm:
+    /// `vta/did-templates/delete/2.0` without `contextId`.
     pub async fn delete_did_template(&self, name: &str) -> Result<(), VtaError> {
         self.rpc_tt_void(
-            trust_tasks::TASK_DID_TEMPLATES_DELETE_1_0,
+            trust_tasks::TASK_DID_TEMPLATES_DELETE_2_0,
             serde_json::to_value(proto::delete::DeleteDidTemplateBody {
+                context_id: None,
                 name: name.to_string(),
             })?,
             30,
@@ -115,19 +125,20 @@ impl VtaClient {
     /// `vars` provides everything else.
     ///
     /// REST: `POST /did-templates/{name}/render`. DIDComm:
-    /// `vta/did-templates/render/1.0`.
+    /// `vta/did-templates/render/2.0` without `contextId`.
     pub async fn render_did_template(
         &self,
         name: &str,
         vars: HashMap<String, Value>,
     ) -> Result<Value, VtaError> {
         let payload = serde_json::to_value(proto::render::RenderDidTemplateBody {
+            context_id: None,
             name: name.to_string(),
             vars: vars.clone(),
         })?;
         let resp: proto::render::RenderDidTemplateResultBody = self
             .rpc_tt(
-                trust_tasks::TASK_DID_TEMPLATES_RENDER_1_0,
+                trust_tasks::TASK_DID_TEMPLATES_RENDER_2_0,
                 payload,
                 30,
                 |c, url| {
@@ -147,16 +158,16 @@ impl VtaClient {
     /// List context-scoped templates.
     ///
     /// REST: `GET /contexts/{id}/did-templates`. DIDComm:
-    /// `vta/contexts/did-templates/list/1.0`.
+    /// `vta/did-templates/list/2.0` with `contextId` set.
     pub async fn list_context_did_templates(
         &self,
         context_id: &str,
     ) -> Result<Vec<DidTemplateRecord>, VtaError> {
         let resp: proto::list::ListDidTemplatesResultBody = self
             .rpc_tt(
-                trust_tasks::TASK_CONTEXTS_DID_TEMPLATES_LIST_1_0,
-                serde_json::to_value(proto::list::ListContextDidTemplatesBody {
-                    context_id: context_id.to_string(),
+                trust_tasks::TASK_DID_TEMPLATES_LIST_2_0,
+                serde_json::to_value(proto::list::ListDidTemplatesBody {
+                    context_id: Some(context_id.to_string()),
                 })?,
                 30,
                 |c, url| {
@@ -173,16 +184,16 @@ impl VtaClient {
     /// Fetch one context-scoped template.
     ///
     /// REST: `GET /contexts/{id}/did-templates/{name}`. DIDComm:
-    /// `vta/contexts/did-templates/get/1.0`.
+    /// `vta/did-templates/get/2.0` with `contextId` set.
     pub async fn get_context_did_template(
         &self,
         context_id: &str,
         name: &str,
     ) -> Result<DidTemplateRecord, VtaError> {
         self.rpc_tt(
-            trust_tasks::TASK_CONTEXTS_DID_TEMPLATES_GET_1_0,
-            serde_json::to_value(proto::get::GetContextDidTemplateBody {
-                context_id: context_id.to_string(),
+            trust_tasks::TASK_DID_TEMPLATES_GET_2_0,
+            serde_json::to_value(proto::get::GetDidTemplateBody {
+                context_id: Some(context_id.to_string()),
                 name: name.to_string(),
             })?,
             30,
@@ -200,18 +211,18 @@ impl VtaClient {
     /// Create a context-scoped template. Context admin or super admin.
     ///
     /// REST: `POST /contexts/{id}/did-templates`. DIDComm:
-    /// `vta/contexts/did-templates/create/1.0`.
+    /// `vta/did-templates/create/2.0` with `contextId` set.
     pub async fn create_context_did_template(
         &self,
         context_id: &str,
         template: DidTemplate,
     ) -> Result<DidTemplateRecord, VtaError> {
-        let payload = serde_json::to_value(proto::create::CreateContextDidTemplateBody {
-            context_id: context_id.to_string(),
+        let payload = serde_json::to_value(proto::create::CreateDidTemplateBody {
+            context_id: Some(context_id.to_string()),
             template: template.clone(),
         })?;
         self.rpc_tt(
-            trust_tasks::TASK_CONTEXTS_DID_TEMPLATES_CREATE_1_0,
+            trust_tasks::TASK_DID_TEMPLATES_CREATE_2_0,
             payload,
             30,
             |c, url| {
@@ -228,20 +239,20 @@ impl VtaClient {
     /// Replace a context-scoped template.
     ///
     /// REST: `PUT /contexts/{id}/did-templates/{name}`. DIDComm:
-    /// `vta/contexts/did-templates/update/1.0`.
+    /// `vta/did-templates/update/2.0` with `contextId` set.
     pub async fn update_context_did_template(
         &self,
         context_id: &str,
         name: &str,
         template: DidTemplate,
     ) -> Result<DidTemplateRecord, VtaError> {
-        let payload = serde_json::to_value(proto::update::UpdateContextDidTemplateBody {
-            context_id: context_id.to_string(),
+        let payload = serde_json::to_value(proto::update::UpdateDidTemplateBody {
+            context_id: Some(context_id.to_string()),
             name: name.to_string(),
             template: template.clone(),
         })?;
         self.rpc_tt(
-            trust_tasks::TASK_CONTEXTS_DID_TEMPLATES_UPDATE_1_0,
+            trust_tasks::TASK_DID_TEMPLATES_UPDATE_2_0,
             payload,
             30,
             |c, url| {
@@ -259,16 +270,16 @@ impl VtaClient {
     /// Delete a context-scoped template.
     ///
     /// REST: `DELETE /contexts/{id}/did-templates/{name}`. DIDComm:
-    /// `vta/contexts/did-templates/delete/1.0`.
+    /// `vta/did-templates/delete/2.0` with `contextId` set.
     pub async fn delete_context_did_template(
         &self,
         context_id: &str,
         name: &str,
     ) -> Result<(), VtaError> {
         self.rpc_tt_void(
-            trust_tasks::TASK_CONTEXTS_DID_TEMPLATES_DELETE_1_0,
-            serde_json::to_value(proto::delete::DeleteContextDidTemplateBody {
-                context_id: context_id.to_string(),
+            trust_tasks::TASK_DID_TEMPLATES_DELETE_2_0,
+            serde_json::to_value(proto::delete::DeleteDidTemplateBody {
+                context_id: Some(context_id.to_string()),
                 name: name.to_string(),
             })?,
             30,
@@ -289,21 +300,21 @@ impl VtaClient {
     /// `CONTEXT_ID`, and (if set on the context) `CONTEXT_DID`.
     ///
     /// REST: `POST /contexts/{id}/did-templates/{name}/render`. DIDComm:
-    /// `vta/contexts/did-templates/render/1.0`.
+    /// `vta/did-templates/render/2.0` with `contextId` set.
     pub async fn render_context_did_template(
         &self,
         context_id: &str,
         name: &str,
         vars: HashMap<String, Value>,
     ) -> Result<Value, VtaError> {
-        let payload = serde_json::to_value(proto::render::RenderContextDidTemplateBody {
-            context_id: context_id.to_string(),
+        let payload = serde_json::to_value(proto::render::RenderDidTemplateBody {
+            context_id: Some(context_id.to_string()),
             name: name.to_string(),
             vars: vars.clone(),
         })?;
         let resp: proto::render::RenderDidTemplateResultBody = self
             .rpc_tt(
-                trust_tasks::TASK_CONTEXTS_DID_TEMPLATES_RENDER_1_0,
+                trust_tasks::TASK_DID_TEMPLATES_RENDER_2_0,
                 payload,
                 30,
                 |c, url| {

--- a/vta-sdk/src/protocols/did_template_management/create.rs
+++ b/vta-sdk/src/protocols/did_template_management/create.rs
@@ -1,28 +1,27 @@
-//! Wire bodies for the `create` op (both scopes).
+//! Wire bodies for the `create` op.
 //!
-//! The result body for both URIs is the persisted
-//! [`DidTemplateRecord`] — same shape as `GET /did-templates/{name}`.
+//! The result body is the persisted [`DidTemplateRecord`] — same
+//! shape as `GET /did-templates/{name}`.
+//!
+//! [`DidTemplateRecord`]: crate::did_templates::DidTemplateRecord
 
 use serde::{Deserialize, Serialize};
 
 use crate::did_templates::DidTemplate;
 
-/// `spec/vta/did-templates/create/1.0` payload — create a global
-/// template. Auth: super-admin.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-pub struct CreateDidTemplateBody {
-    /// Full template document. The template's `name` field is the
-    /// resource id; the VTA refuses duplicates.
-    pub template: DidTemplate,
-}
-
-/// `spec/vta/contexts/did-templates/create/1.0` payload — create a
-/// context-scoped template. Auth: super-admin OR admin-with-context.
+/// `spec/vta/did-templates/create/2.0` payload — create a template
+/// in one scope. `context_id` absent: the global scope (super-admin
+/// gated). `context_id` present: that context's scope (context admin
+/// OR super-admin).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase")]
-pub struct CreateContextDidTemplateBody {
-    pub context_id: String,
+pub struct CreateDidTemplateBody {
+    /// Scope selector. `None` = global scope; `Some` = that context.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_id: Option<String>,
+    /// Full template document. The template's `name` field is the
+    /// resource id within the selected scope; the VTA refuses
+    /// duplicates.
     pub template: DidTemplate,
 }

--- a/vta-sdk/src/protocols/did_template_management/delete.rs
+++ b/vta-sdk/src/protocols/did_template_management/delete.rs
@@ -1,29 +1,23 @@
-//! Wire bodies for the `delete` op (both scopes).
+//! Wire bodies for the `delete` op.
 
 use serde::{Deserialize, Serialize};
 
-/// `spec/vta/did-templates/delete/1.0` payload — remove a global
-/// template by name. Auth: super-admin.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-pub struct DeleteDidTemplateBody {
-    pub name: String,
-}
-
-/// `spec/vta/contexts/did-templates/delete/1.0` payload — remove a
-/// context-scoped template. Auth: super-admin OR
-/// admin-with-context.
+/// `spec/vta/did-templates/delete/2.0` payload — remove a template
+/// by name from one scope. `context_id` absent: the global scope
+/// (super-admin gated). `context_id` present: that context's scope
+/// (context admin OR super-admin).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase")]
-pub struct DeleteContextDidTemplateBody {
-    pub context_id: String,
+pub struct DeleteDidTemplateBody {
+    /// Scope selector. `None` = global scope; `Some` = that context.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_id: Option<String>,
     pub name: String,
 }
 
-/// Shared result body. Echoes the resource id back so callers can
-/// log the deletion in audit pipelines that key on the wire
-/// payload.
+/// Result body. Echoes the resource id back so callers can log the
+/// deletion in audit pipelines that key on the wire payload.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct DeleteDidTemplateResultBody {

--- a/vta-sdk/src/protocols/did_template_management/get.rs
+++ b/vta-sdk/src/protocols/did_template_management/get.rs
@@ -1,25 +1,21 @@
-//! Wire bodies for the `get` op (both scopes).
+//! Wire bodies for the `get` op.
 //!
-//! The result body for both URIs is the persisted
-//! [`DidTemplateRecord`].
+//! The result body is the persisted [`DidTemplateRecord`].
+//!
+//! [`DidTemplateRecord`]: crate::did_templates::DidTemplateRecord
 
 use serde::{Deserialize, Serialize};
 
-/// `spec/vta/did-templates/get/1.0` payload — fetch one global
-/// template by name. Auth: any authed.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-pub struct GetDidTemplateBody {
-    pub name: String,
-}
-
-/// `spec/vta/contexts/did-templates/get/1.0` payload — fetch one
-/// context-scoped template by name. Auth: any authed with access to
-/// the context.
+/// `spec/vta/did-templates/get/2.0` payload — fetch one template by
+/// name from one scope. `context_id` absent: the global scope (any
+/// authed caller). `context_id` present: that context's scope
+/// (requires context access).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase")]
-pub struct GetContextDidTemplateBody {
-    pub context_id: String,
+pub struct GetDidTemplateBody {
+    /// Scope selector. `None` = global scope; `Some` = that context.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_id: Option<String>,
     pub name: String,
 }

--- a/vta-sdk/src/protocols/did_template_management/list.rs
+++ b/vta-sdk/src/protocols/did_template_management/list.rs
@@ -1,27 +1,25 @@
-//! Wire bodies for the `list` op (both scopes).
+//! Wire bodies for the `list` op.
 
 use serde::{Deserialize, Serialize};
 
 use crate::did_templates::DidTemplateRecord;
 
-/// `spec/vta/did-templates/list/1.0` payload — list global
-/// templates. Empty body; the request has no parameters.
+/// `spec/vta/did-templates/list/2.0` payload — list the templates in
+/// one scope. `context_id` absent: the global templates (any authed
+/// caller). `context_id` present: the templates scoped to that
+/// context (requires context access).
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-pub struct ListDidTemplatesBody {}
-
-/// `spec/vta/contexts/did-templates/list/1.0` payload — list
-/// templates scoped to a specific context.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase")]
-pub struct ListContextDidTemplatesBody {
-    pub context_id: String,
+pub struct ListDidTemplatesBody {
+    /// Scope selector. `None` = global scope; `Some` = that context.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_id: Option<String>,
 }
 
-/// Shared result body for both list URIs. Returns the matching
-/// templates (global ones for the global URI, context-scoped ones
-/// for the context URI).
+/// Result body. Returns the templates of the selected scope (global
+/// ones when the request carried no `contextId`, that context's
+/// otherwise).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ListDidTemplatesResultBody {

--- a/vta-sdk/src/protocols/did_template_management/mod.rs
+++ b/vta-sdk/src/protocols/did_template_management/mod.rs
@@ -2,27 +2,25 @@
 //! for DID-template management.
 //!
 //! Each operation lives in its own submodule (`list`, `create`,
-//! `get`, `update`, `delete`, `render`). Each module defines two
-//! body types when relevant: a **global**-scope variant
-//! (`*DidTemplateBody`) and a **context**-scope variant
-//! (`*ContextDidTemplateBody`). The context-scope variant carries
-//! a required `context_id` field (serialized as `contextId` on the
-//! wire, lowerCamelCase per the Trust Task framework); the global
-//! variant doesn't.
+//! `get`, `update`, `delete`, `render`) and defines one body type
+//! per operation. Scope is selected by the body's **optional
+//! `context_id`** field (serialized as `contextId` on the wire,
+//! lowerCamelCase per the Trust Task framework): absent = the
+//! global scope (super-admin gated for writes), present = that
+//! context's scope (context-admin gated for writes, context access
+//! for reads).
 //!
-//! The split is deliberate. Global and context templates are not
-//! the same resource filtered differently — they have different
-//! owners (super-admin vs context-admin), different lifecycles, and
-//! different visibility scopes. Modelling them as distinct wire
-//! types makes the auth contract self-documenting from the
-//! payload, mirrors the URI hierarchy
-//! (`spec/vta/did-templates/*` vs `spec/vta/contexts/did-templates/*`),
-//! and removes the need for slice handlers to branch on
-//! `Option<String>`.
+//! This is the 2.0 shape of the family
+//! (`spec/vta/did-templates/*/2.0`, trust-tasks registry issue
+//! OpenVTC/verifiable-trust-infrastructure#851), which merged the
+//! former global (`spec/vta/did-templates/*/1.0`) and context
+//! (`spec/vta/contexts/did-templates/*/1.0`) URI hierarchies — the
+//! per-scope ACL moved from the slug structure into the `contextId`
+//! field plus party gating. The twelve 1.0 URIs are retired and no
+//! longer accepted.
 //!
 //! Trust-task URIs are declared in
-//! [`crate::trust_tasks`] under the `TASK_DID_TEMPLATES_*` and
-//! `TASK_CONTEXTS_DID_TEMPLATES_*` prefixes.
+//! [`crate::trust_tasks`] under the `TASK_DID_TEMPLATES_*` prefix.
 //!
 //! Template management over DIDComm ships as a **Trust Task**: the
 //! `VtaClient` dispatches the

--- a/vta-sdk/src/protocols/did_template_management/render.rs
+++ b/vta-sdk/src/protocols/did_template_management/render.rs
@@ -1,39 +1,35 @@
-//! Wire bodies for the `render` op (both scopes).
+//! Wire bodies for the `render` op.
 //!
 //! Render takes a template name + caller-supplied variables and
 //! returns the rendered DID document. The VTA injects ambient
-//! variables (`VTA_DID`, `NOW`, etc.) server-side before
-//! substitution.
+//! variables server-side before substitution: `VTA_DID`, `VTA_URL`,
+//! `NOW` always; `CONTEXT_ID` and (if set on the context)
+//! `CONTEXT_DID` when the request carries a `contextId`.
 
 use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-/// `spec/vta/did-templates/render/1.0` payload — render a global
-/// template with caller vars. Auth: any authed.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-pub struct RenderDidTemplateBody {
-    pub name: String,
-    #[serde(default)]
-    pub vars: HashMap<String, Value>,
-}
-
-/// `spec/vta/contexts/did-templates/render/1.0` payload — render a
-/// context-scoped template (or fall through to global). Auth: any
-/// authed with access to the context.
+/// `spec/vta/did-templates/render/2.0` payload — render a template
+/// from one scope with caller vars. `context_id` absent: the global
+/// scope (any authed caller). `context_id` present: that context's
+/// scope, with fall-through to a global template of the same name
+/// per the op layer's scope-fallback rule (requires context access).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase")]
-pub struct RenderContextDidTemplateBody {
-    pub context_id: String,
+pub struct RenderDidTemplateBody {
+    /// Scope selector. `None` = global scope; `Some` = that context
+    /// (adds ambient `CONTEXT_ID` / `CONTEXT_DID` variables).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_id: Option<String>,
     pub name: String,
     #[serde(default)]
     pub vars: HashMap<String, Value>,
 }
 
-/// Shared result body. `document` is the rendered DID document.
+/// Result body. `document` is the rendered DID document.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct RenderDidTemplateResultBody {

--- a/vta-sdk/src/protocols/did_template_management/update.rs
+++ b/vta-sdk/src/protocols/did_template_management/update.rs
@@ -1,35 +1,30 @@
-//! Wire bodies for the `update` op (both scopes).
+//! Wire bodies for the `update` op.
 //!
 //! "Update" replaces the template at `name` with the new
 //! [`DidTemplate`]; the template's own `name` field must match the
 //! resource id (legacy REST: `PATCH /did-templates/{name}`).
 //!
-//! The result body for both URIs is the new persisted
-//! [`DidTemplateRecord`].
+//! The result body is the new persisted [`DidTemplateRecord`].
+//!
+//! [`DidTemplateRecord`]: crate::did_templates::DidTemplateRecord
 
 use serde::{Deserialize, Serialize};
 
 use crate::did_templates::DidTemplate;
 
-/// `spec/vta/did-templates/update/1.0` payload — replace a global
-/// template. Auth: super-admin.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-pub struct UpdateDidTemplateBody {
-    /// Resource id (the template's name). The op layer rejects with
-    /// `Validation` if `template.name != name`.
-    pub name: String,
-    pub template: DidTemplate,
-}
-
-/// `spec/vta/contexts/did-templates/update/1.0` payload — replace
-/// a context-scoped template. Auth: super-admin OR
-/// admin-with-context.
+/// `spec/vta/did-templates/update/2.0` payload — replace a template
+/// in one scope. `context_id` absent: the global scope (super-admin
+/// gated). `context_id` present: that context's scope (context admin
+/// OR super-admin).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase")]
-pub struct UpdateContextDidTemplateBody {
-    pub context_id: String,
+pub struct UpdateDidTemplateBody {
+    /// Scope selector. `None` = global scope; `Some` = that context.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_id: Option<String>,
+    /// Resource id (the template's name). The op layer rejects with
+    /// `Validation` if `template.name != name`.
     pub name: String,
     pub template: DidTemplate,
 }

--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -1057,102 +1057,62 @@ pub const TASK_WEBVH_AGENT_NAME_ENABLE_1_0: &str =
 
 // ─── DID-templates slice (spec/vta/did-templates/*) ──────────────────────
 //
-// Global-scope template CRUD + render. Mirrored under
-// `spec/vta/contexts/did-templates/*` below for the context-scoped
-// resource. The two URI hierarchies are intentionally separate —
-// global templates and context templates have different owners and
-// lifecycles (super-admin vs context-admin), and the URI carries
-// that distinction directly so the auth contract is self-evident
-// from the wire `type` field.
+// Template CRUD + render across both scopes, one URI per operation.
+// The 2.0 family (trust-tasks registry, issue #851) merges the former
+// `spec/vta/did-templates/*/1.0` (global) and
+// `spec/vta/contexts/did-templates/*/1.0` (context-scoped) pairs
+// behind an optional `contextId` payload field: absent = global scope
+// (super-admin gated for writes), present = that context
+// (context-admin gated for writes, context access for reads). The
+// retired 1.0 URIs are no longer accepted — clean cutover, both
+// hierarchies dropped in the same change that introduced 2.0.
 
-/// `spec/vta/did-templates/list/1.0` — list all global templates.
-/// Payload:
-/// [`crate::protocols::did_template_management::list::ListDidTemplatesBody`]
-/// (empty). Auth: any authenticated user.
-pub const TASK_DID_TEMPLATES_LIST_1_0: &str =
-    "https://trusttasks.org/spec/vta/did-templates/list/1.0";
+/// `spec/vta/did-templates/list/2.0` — list the templates in one
+/// scope: global when `contextId` is absent, that context's when
+/// present. Payload:
+/// [`crate::protocols::did_template_management::list::ListDidTemplatesBody`].
+/// Auth: any authenticated user; context access when scoped.
+pub const TASK_DID_TEMPLATES_LIST_2_0: &str =
+    "https://trusttasks.org/spec/vta/did-templates/list/2.0";
 
-/// `spec/vta/did-templates/create/1.0` — create a new global
-/// template. Payload:
+/// `spec/vta/did-templates/create/2.0` — create a template in one
+/// scope. Payload:
 /// [`crate::protocols::did_template_management::create::CreateDidTemplateBody`].
-/// Auth: Super Admin only.
-pub const TASK_DID_TEMPLATES_CREATE_1_0: &str =
-    "https://trusttasks.org/spec/vta/did-templates/create/1.0";
+/// Auth: Super Admin (global) OR Admin-with-context (`contextId` set).
+pub const TASK_DID_TEMPLATES_CREATE_2_0: &str =
+    "https://trusttasks.org/spec/vta/did-templates/create/2.0";
 
-/// `spec/vta/did-templates/get/1.0` — fetch one global template by
-/// name. Payload:
+/// `spec/vta/did-templates/get/2.0` — fetch one template by name from
+/// one scope. Payload:
 /// [`crate::protocols::did_template_management::get::GetDidTemplateBody`].
-/// Auth: any authenticated user.
-pub const TASK_DID_TEMPLATES_GET_1_0: &str =
-    "https://trusttasks.org/spec/vta/did-templates/get/1.0";
+/// Auth: any authenticated user; context access when scoped.
+pub const TASK_DID_TEMPLATES_GET_2_0: &str =
+    "https://trusttasks.org/spec/vta/did-templates/get/2.0";
 
-/// `spec/vta/did-templates/update/1.0` — replace a global template.
-/// Payload:
+/// `spec/vta/did-templates/update/2.0` — replace a template in one
+/// scope. Payload:
 /// [`crate::protocols::did_template_management::update::UpdateDidTemplateBody`].
-/// Auth: Super Admin only.
-pub const TASK_DID_TEMPLATES_UPDATE_1_0: &str =
-    "https://trusttasks.org/spec/vta/did-templates/update/1.0";
+/// Auth: Super Admin (global) OR Admin-with-context (`contextId` set).
+pub const TASK_DID_TEMPLATES_UPDATE_2_0: &str =
+    "https://trusttasks.org/spec/vta/did-templates/update/2.0";
 
-/// `spec/vta/did-templates/delete/1.0` — delete a global template.
-/// Payload:
+/// `spec/vta/did-templates/delete/2.0` — delete a template from one
+/// scope. Payload:
 /// [`crate::protocols::did_template_management::delete::DeleteDidTemplateBody`].
-/// Auth: Super Admin only.
-pub const TASK_DID_TEMPLATES_DELETE_1_0: &str =
-    "https://trusttasks.org/spec/vta/did-templates/delete/1.0";
+/// Auth: Super Admin (global) OR Admin-with-context (`contextId` set).
+pub const TASK_DID_TEMPLATES_DELETE_2_0: &str =
+    "https://trusttasks.org/spec/vta/did-templates/delete/2.0";
 
-/// `spec/vta/did-templates/render/1.0` — render a global template
-/// with caller-supplied variables. Server injects ambient vars
-/// (`VTA_DID`, `NOW`, …). Payload:
+/// `spec/vta/did-templates/render/2.0` — render a template from one
+/// scope with caller-supplied variables. Server injects ambient vars
+/// (`VTA_DID`, `VTA_URL`, `NOW`; plus `CONTEXT_ID` / `CONTEXT_DID`
+/// when `contextId` is present). Context renders may fall through to
+/// a global template of the same name, per the op layer's
+/// scope-fallback rule. Payload:
 /// [`crate::protocols::did_template_management::render::RenderDidTemplateBody`].
-/// Auth: any authenticated user.
-pub const TASK_DID_TEMPLATES_RENDER_1_0: &str =
-    "https://trusttasks.org/spec/vta/did-templates/render/1.0";
-
-// ─── Context-scoped DID-templates (spec/vta/contexts/did-templates/*) ────
-
-/// `spec/vta/contexts/did-templates/list/1.0` — list templates
-/// scoped to a specific context. Payload:
-/// [`crate::protocols::did_template_management::list::ListContextDidTemplatesBody`].
-/// Auth: any authenticated user with access to the context.
-pub const TASK_CONTEXTS_DID_TEMPLATES_LIST_1_0: &str =
-    "https://trusttasks.org/spec/vta/contexts/did-templates/list/1.0";
-
-/// `spec/vta/contexts/did-templates/create/1.0` — create a
-/// context-scoped template. Payload:
-/// [`crate::protocols::did_template_management::create::CreateContextDidTemplateBody`].
-/// Auth: Super Admin OR Admin-with-context.
-pub const TASK_CONTEXTS_DID_TEMPLATES_CREATE_1_0: &str =
-    "https://trusttasks.org/spec/vta/contexts/did-templates/create/1.0";
-
-/// `spec/vta/contexts/did-templates/get/1.0` — fetch one
-/// context-scoped template. Payload:
-/// [`crate::protocols::did_template_management::get::GetContextDidTemplateBody`].
-/// Auth: any authenticated user with access to the context.
-pub const TASK_CONTEXTS_DID_TEMPLATES_GET_1_0: &str =
-    "https://trusttasks.org/spec/vta/contexts/did-templates/get/1.0";
-
-/// `spec/vta/contexts/did-templates/update/1.0` — replace a
-/// context-scoped template. Payload:
-/// [`crate::protocols::did_template_management::update::UpdateContextDidTemplateBody`].
-/// Auth: Super Admin OR Admin-with-context.
-pub const TASK_CONTEXTS_DID_TEMPLATES_UPDATE_1_0: &str =
-    "https://trusttasks.org/spec/vta/contexts/did-templates/update/1.0";
-
-/// `spec/vta/contexts/did-templates/delete/1.0` — delete a
-/// context-scoped template. Payload:
-/// [`crate::protocols::did_template_management::delete::DeleteContextDidTemplateBody`].
-/// Auth: Super Admin OR Admin-with-context.
-pub const TASK_CONTEXTS_DID_TEMPLATES_DELETE_1_0: &str =
-    "https://trusttasks.org/spec/vta/contexts/did-templates/delete/1.0";
-
-/// `spec/vta/contexts/did-templates/render/1.0` — render a
-/// context-scoped template (or fall through to a global template
-/// of the same name, per the op layer's scope-fallback rule).
-/// Payload:
-/// [`crate::protocols::did_template_management::render::RenderContextDidTemplateBody`].
-/// Auth: any authenticated user with access to the context.
-pub const TASK_CONTEXTS_DID_TEMPLATES_RENDER_1_0: &str =
-    "https://trusttasks.org/spec/vta/contexts/did-templates/render/1.0";
+/// Auth: any authenticated user; context access when scoped.
+pub const TASK_DID_TEMPLATES_RENDER_2_0: &str =
+    "https://trusttasks.org/spec/vta/did-templates/render/2.0";
 
 // ─── Backup slice (spec/vta/backup/*) ────────────────────────────────────
 //
@@ -1439,20 +1399,14 @@ pub const ALL_URIS: &[&str] = &[
     TASK_WEBVH_AGENT_NAME_REMOVE_1_0,
     TASK_WEBVH_AGENT_NAME_DISABLE_1_0,
     TASK_WEBVH_AGENT_NAME_ENABLE_1_0,
-    // DID-templates slice (global)
-    TASK_DID_TEMPLATES_LIST_1_0,
-    TASK_DID_TEMPLATES_CREATE_1_0,
-    TASK_DID_TEMPLATES_GET_1_0,
-    TASK_DID_TEMPLATES_UPDATE_1_0,
-    TASK_DID_TEMPLATES_DELETE_1_0,
-    TASK_DID_TEMPLATES_RENDER_1_0,
-    // DID-templates slice (context-scoped)
-    TASK_CONTEXTS_DID_TEMPLATES_LIST_1_0,
-    TASK_CONTEXTS_DID_TEMPLATES_CREATE_1_0,
-    TASK_CONTEXTS_DID_TEMPLATES_GET_1_0,
-    TASK_CONTEXTS_DID_TEMPLATES_UPDATE_1_0,
-    TASK_CONTEXTS_DID_TEMPLATES_DELETE_1_0,
-    TASK_CONTEXTS_DID_TEMPLATES_RENDER_1_0,
+    // DID-templates slice (2.0 — one URI per op, optional contextId
+    // selects global vs context scope; the twelve 1.0 URIs are retired)
+    TASK_DID_TEMPLATES_LIST_2_0,
+    TASK_DID_TEMPLATES_CREATE_2_0,
+    TASK_DID_TEMPLATES_GET_2_0,
+    TASK_DID_TEMPLATES_UPDATE_2_0,
+    TASK_DID_TEMPLATES_DELETE_2_0,
+    TASK_DID_TEMPLATES_RENDER_2_0,
     // Backup slice (descriptor pattern). URIs land in ALL_URIS now
     // that the trust-task slice is wired in vta-service.
     TASK_BACKUP_INITIATE_EXPORT_1_0,

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.13.11"
+version = "0.13.12"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/trust_tasks/did_templates.rs
+++ b/vta-service/src/trust_tasks/did_templates.rs
@@ -1,19 +1,21 @@
-//! DID-templates slice trust-task handlers (global + context scope).
+//! DID-templates slice trust-task handlers.
 //!
-//! Twelve handlers — six per scope, mirroring the legacy REST surface.
-//! Auth contracts:
+//! Six handlers — one per operation, serving the merged
+//! `spec/vta/did-templates/*/2.0` family. Scope is selected by the
+//! payload's optional `contextId` (absent = global, present = that
+//! context); each handler branches to the matching global/context
+//! operation function. Auth contracts:
 //!
-//! | URI                                                       | Auth                              |
-//! |-----------------------------------------------------------|-----------------------------------|
-//! | `did-templates/{list,get,render}/1.0`                     | any authed                        |
-//! | `did-templates/{create,update,delete}/1.0`                | super-admin                       |
-//! | `contexts/did-templates/{list,get,render}/1.0`            | any authed with context access    |
-//! | `contexts/did-templates/{create,update,delete}/1.0`       | super-admin OR admin-with-context |
+//! | URI                                     | `contextId` absent | `contextId` present               |
+//! |------------------------------------------|--------------------|-----------------------------------|
+//! | `did-templates/{list,get,render}/2.0`    | any authed         | any authed with context access    |
+//! | `did-templates/{create,update,delete}/2.0` | super-admin      | super-admin OR admin-with-context |
 //!
 //! Auth enforcement lives in the operation functions (`require_super_admin`
 //! for global writes, `require_context_write` / `require_context_read`
 //! for context ops). The slice handlers don't gate themselves — they
-//! deserialize the payload, call the op, and serialize back.
+//! deserialize the payload, branch on scope, call the op, and serialize
+//! back.
 
 use std::collections::HashMap;
 
@@ -22,12 +24,12 @@ use serde_json::Value;
 use trust_tasks_rs::TrustTask;
 use vta_sdk::did_templates::TemplateVars;
 use vta_sdk::protocols::did_template_management::{
-    create::{CreateContextDidTemplateBody, CreateDidTemplateBody},
-    delete::{DeleteContextDidTemplateBody, DeleteDidTemplateBody, DeleteDidTemplateResultBody},
-    get::{GetContextDidTemplateBody, GetDidTemplateBody},
-    list::{ListContextDidTemplatesBody, ListDidTemplatesBody, ListDidTemplatesResultBody},
-    render::{RenderContextDidTemplateBody, RenderDidTemplateBody, RenderDidTemplateResultBody},
-    update::{UpdateContextDidTemplateBody, UpdateDidTemplateBody},
+    create::CreateDidTemplateBody,
+    delete::{DeleteDidTemplateBody, DeleteDidTemplateResultBody},
+    get::GetDidTemplateBody,
+    list::{ListDidTemplatesBody, ListDidTemplatesResultBody},
+    render::{RenderDidTemplateBody, RenderDidTemplateResultBody},
+    update::UpdateDidTemplateBody,
 };
 
 use crate::auth::AuthClaims;
@@ -36,31 +38,42 @@ use crate::server::AppState;
 
 use super::helpers::{TRANSPORT_TRUST_TASK, app_error_to_reject, parse_payload, success_response};
 
-// ─── Global scope ──────────────────────────────────────────────────────
-
-/// `did-templates/list/1.0` — list all global templates. Any authed.
+/// `did-templates/list/2.0` — list the templates in one scope.
 pub(super) async fn handle_list(
     state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
 ) -> TrustTaskOutcome {
-    let _: ListDidTemplatesBody = match parse_payload(&doc) {
+    let req: ListDidTemplatesBody = match parse_payload(&doc) {
         Ok(r) => r,
         Err(resp) => return resp,
     };
-    match operations::did_templates::list_global(
-        &state.did_templates_ks,
-        auth,
-        TRANSPORT_TRUST_TASK,
-    )
-    .await
-    {
+    let result = match req.context_id {
+        Some(context_id) => {
+            operations::did_templates::list_context(
+                &state.did_templates_ks,
+                auth,
+                &context_id,
+                TRANSPORT_TRUST_TASK,
+            )
+            .await
+        }
+        None => {
+            operations::did_templates::list_global(
+                &state.did_templates_ks,
+                auth,
+                TRANSPORT_TRUST_TASK,
+            )
+            .await
+        }
+    };
+    match result {
         Ok(templates) => success_response(&doc, ListDidTemplatesResultBody { templates }),
         Err(e) => app_error_to_reject(&doc, e),
     }
 }
 
-/// `did-templates/create/1.0` — create a global template. Super-admin.
+/// `did-templates/create/2.0` — create a template in one scope.
 pub(super) async fn handle_create(
     state: &AppState,
     auth: &AuthClaims,
@@ -70,21 +83,37 @@ pub(super) async fn handle_create(
         Ok(r) => r,
         Err(resp) => return resp,
     };
-    match operations::did_templates::create_global(
-        &state.did_templates_ks,
-        &state.audit_ks,
-        auth,
-        req.template,
-        TRANSPORT_TRUST_TASK,
-    )
-    .await
-    {
+    let result = match req.context_id {
+        Some(context_id) => {
+            operations::did_templates::create_context(
+                &state.did_templates_ks,
+                &state.contexts_ks,
+                &state.audit_ks,
+                auth,
+                &context_id,
+                req.template,
+                TRANSPORT_TRUST_TASK,
+            )
+            .await
+        }
+        None => {
+            operations::did_templates::create_global(
+                &state.did_templates_ks,
+                &state.audit_ks,
+                auth,
+                req.template,
+                TRANSPORT_TRUST_TASK,
+            )
+            .await
+        }
+    };
+    match result {
         Ok(record) => success_response(&doc, record),
         Err(e) => app_error_to_reject(&doc, e),
     }
 }
 
-/// `did-templates/get/1.0` — fetch one global template. Any authed.
+/// `did-templates/get/2.0` — fetch one template from one scope.
 pub(super) async fn handle_get(
     state: &AppState,
     auth: &AuthClaims,
@@ -94,20 +123,34 @@ pub(super) async fn handle_get(
         Ok(r) => r,
         Err(resp) => return resp,
     };
-    match operations::did_templates::get_global(
-        &state.did_templates_ks,
-        auth,
-        &req.name,
-        TRANSPORT_TRUST_TASK,
-    )
-    .await
-    {
+    let result = match req.context_id {
+        Some(context_id) => {
+            operations::did_templates::get_context(
+                &state.did_templates_ks,
+                auth,
+                &context_id,
+                &req.name,
+                TRANSPORT_TRUST_TASK,
+            )
+            .await
+        }
+        None => {
+            operations::did_templates::get_global(
+                &state.did_templates_ks,
+                auth,
+                &req.name,
+                TRANSPORT_TRUST_TASK,
+            )
+            .await
+        }
+    };
+    match result {
         Ok(record) => success_response(&doc, record),
         Err(e) => app_error_to_reject(&doc, e),
     }
 }
 
-/// `did-templates/update/1.0` — replace a global template. Super-admin.
+/// `did-templates/update/2.0` — replace a template in one scope.
 pub(super) async fn handle_update(
     state: &AppState,
     auth: &AuthClaims,
@@ -117,22 +160,38 @@ pub(super) async fn handle_update(
         Ok(r) => r,
         Err(resp) => return resp,
     };
-    match operations::did_templates::update_global(
-        &state.did_templates_ks,
-        &state.audit_ks,
-        auth,
-        &req.name,
-        req.template,
-        TRANSPORT_TRUST_TASK,
-    )
-    .await
-    {
+    let result = match req.context_id {
+        Some(context_id) => {
+            operations::did_templates::update_context(
+                &state.did_templates_ks,
+                &state.audit_ks,
+                auth,
+                &context_id,
+                &req.name,
+                req.template,
+                TRANSPORT_TRUST_TASK,
+            )
+            .await
+        }
+        None => {
+            operations::did_templates::update_global(
+                &state.did_templates_ks,
+                &state.audit_ks,
+                auth,
+                &req.name,
+                req.template,
+                TRANSPORT_TRUST_TASK,
+            )
+            .await
+        }
+    };
+    match result {
         Ok(record) => success_response(&doc, record),
         Err(e) => app_error_to_reject(&doc, e),
     }
 }
 
-/// `did-templates/delete/1.0` — delete a global template. Super-admin.
+/// `did-templates/delete/2.0` — delete a template from one scope.
 pub(super) async fn handle_delete(
     state: &AppState,
     auth: &AuthClaims,
@@ -142,15 +201,30 @@ pub(super) async fn handle_delete(
         Ok(r) => r,
         Err(resp) => return resp,
     };
-    match operations::did_templates::delete_global(
-        &state.did_templates_ks,
-        &state.audit_ks,
-        auth,
-        &req.name,
-        TRANSPORT_TRUST_TASK,
-    )
-    .await
-    {
+    let result = match &req.context_id {
+        Some(context_id) => {
+            operations::did_templates::delete_context(
+                &state.did_templates_ks,
+                &state.audit_ks,
+                auth,
+                context_id,
+                &req.name,
+                TRANSPORT_TRUST_TASK,
+            )
+            .await
+        }
+        None => {
+            operations::did_templates::delete_global(
+                &state.did_templates_ks,
+                &state.audit_ks,
+                auth,
+                &req.name,
+                TRANSPORT_TRUST_TASK,
+            )
+            .await
+        }
+    };
+    match result {
         Ok(()) => success_response(
             &doc,
             DeleteDidTemplateResultBody {
@@ -162,8 +236,9 @@ pub(super) async fn handle_delete(
     }
 }
 
-/// `did-templates/render/1.0` — render a global template with caller
-/// vars. Any authed.
+/// `did-templates/render/2.0` — render a template from one scope with
+/// caller vars. Context scope additionally injects ambient
+/// `CONTEXT_ID` / `CONTEXT_DID`.
 pub(super) async fn handle_render(
     state: &AppState,
     auth: &AuthClaims,
@@ -175,182 +250,33 @@ pub(super) async fn handle_render(
     };
     let caller_vars = vars_from_hashmap(req.vars);
     let config_guard = state.config.read().await;
-    match operations::did_templates::render_global(
-        &state.did_templates_ks,
-        &config_guard,
-        auth,
-        &req.name,
-        caller_vars,
-        TRANSPORT_TRUST_TASK,
-    )
-    .await
-    {
-        Ok(document) => success_response(&doc, RenderDidTemplateResultBody { document }),
-        Err(e) => app_error_to_reject(&doc, e),
-    }
-}
-
-// ─── Context scope ─────────────────────────────────────────────────────
-
-/// `contexts/did-templates/list/1.0` — list templates in a context.
-pub(super) async fn handle_context_list(
-    state: &AppState,
-    auth: &AuthClaims,
-    doc: TrustTask<Value>,
-) -> TrustTaskOutcome {
-    let req: ListContextDidTemplatesBody = match parse_payload(&doc) {
-        Ok(r) => r,
-        Err(resp) => return resp,
+    let result = match req.context_id {
+        Some(context_id) => {
+            operations::did_templates::render_context(
+                &state.did_templates_ks,
+                &state.contexts_ks,
+                &config_guard,
+                auth,
+                &context_id,
+                &req.name,
+                caller_vars,
+                TRANSPORT_TRUST_TASK,
+            )
+            .await
+        }
+        None => {
+            operations::did_templates::render_global(
+                &state.did_templates_ks,
+                &config_guard,
+                auth,
+                &req.name,
+                caller_vars,
+                TRANSPORT_TRUST_TASK,
+            )
+            .await
+        }
     };
-    match operations::did_templates::list_context(
-        &state.did_templates_ks,
-        auth,
-        &req.context_id,
-        TRANSPORT_TRUST_TASK,
-    )
-    .await
-    {
-        Ok(templates) => success_response(&doc, ListDidTemplatesResultBody { templates }),
-        Err(e) => app_error_to_reject(&doc, e),
-    }
-}
-
-/// `contexts/did-templates/create/1.0` — create a context-scoped
-/// template. Super-admin OR admin-with-context.
-pub(super) async fn handle_context_create(
-    state: &AppState,
-    auth: &AuthClaims,
-    doc: TrustTask<Value>,
-) -> TrustTaskOutcome {
-    let req: CreateContextDidTemplateBody = match parse_payload(&doc) {
-        Ok(r) => r,
-        Err(resp) => return resp,
-    };
-    match operations::did_templates::create_context(
-        &state.did_templates_ks,
-        &state.contexts_ks,
-        &state.audit_ks,
-        auth,
-        &req.context_id,
-        req.template,
-        TRANSPORT_TRUST_TASK,
-    )
-    .await
-    {
-        Ok(record) => success_response(&doc, record),
-        Err(e) => app_error_to_reject(&doc, e),
-    }
-}
-
-/// `contexts/did-templates/get/1.0` — fetch one context-scoped
-/// template.
-pub(super) async fn handle_context_get(
-    state: &AppState,
-    auth: &AuthClaims,
-    doc: TrustTask<Value>,
-) -> TrustTaskOutcome {
-    let req: GetContextDidTemplateBody = match parse_payload(&doc) {
-        Ok(r) => r,
-        Err(resp) => return resp,
-    };
-    match operations::did_templates::get_context(
-        &state.did_templates_ks,
-        auth,
-        &req.context_id,
-        &req.name,
-        TRANSPORT_TRUST_TASK,
-    )
-    .await
-    {
-        Ok(record) => success_response(&doc, record),
-        Err(e) => app_error_to_reject(&doc, e),
-    }
-}
-
-/// `contexts/did-templates/update/1.0` — replace a context-scoped
-/// template. Super-admin OR admin-with-context.
-pub(super) async fn handle_context_update(
-    state: &AppState,
-    auth: &AuthClaims,
-    doc: TrustTask<Value>,
-) -> TrustTaskOutcome {
-    let req: UpdateContextDidTemplateBody = match parse_payload(&doc) {
-        Ok(r) => r,
-        Err(resp) => return resp,
-    };
-    match operations::did_templates::update_context(
-        &state.did_templates_ks,
-        &state.audit_ks,
-        auth,
-        &req.context_id,
-        &req.name,
-        req.template,
-        TRANSPORT_TRUST_TASK,
-    )
-    .await
-    {
-        Ok(record) => success_response(&doc, record),
-        Err(e) => app_error_to_reject(&doc, e),
-    }
-}
-
-/// `contexts/did-templates/delete/1.0` — delete a context-scoped
-/// template. Super-admin OR admin-with-context.
-pub(super) async fn handle_context_delete(
-    state: &AppState,
-    auth: &AuthClaims,
-    doc: TrustTask<Value>,
-) -> TrustTaskOutcome {
-    let req: DeleteContextDidTemplateBody = match parse_payload(&doc) {
-        Ok(r) => r,
-        Err(resp) => return resp,
-    };
-    match operations::did_templates::delete_context(
-        &state.did_templates_ks,
-        &state.audit_ks,
-        auth,
-        &req.context_id,
-        &req.name,
-        TRANSPORT_TRUST_TASK,
-    )
-    .await
-    {
-        Ok(()) => success_response(
-            &doc,
-            DeleteDidTemplateResultBody {
-                name: req.name,
-                deleted: true,
-            },
-        ),
-        Err(e) => app_error_to_reject(&doc, e),
-    }
-}
-
-/// `contexts/did-templates/render/1.0` — render a context-scoped
-/// template with caller vars. Any authed with context access.
-pub(super) async fn handle_context_render(
-    state: &AppState,
-    auth: &AuthClaims,
-    doc: TrustTask<Value>,
-) -> TrustTaskOutcome {
-    let req: RenderContextDidTemplateBody = match parse_payload(&doc) {
-        Ok(r) => r,
-        Err(resp) => return resp,
-    };
-    let caller_vars = vars_from_hashmap(req.vars);
-    let config_guard = state.config.read().await;
-    match operations::did_templates::render_context(
-        &state.did_templates_ks,
-        &state.contexts_ks,
-        &config_guard,
-        auth,
-        &req.context_id,
-        &req.name,
-        caller_vars,
-        TRANSPORT_TRUST_TASK,
-    )
-    .await
-    {
+    match result {
         Ok(document) => success_response(&doc, RenderDidTemplateResultBody { document }),
         Err(e) => app_error_to_reject(&doc, e),
     }

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -216,6 +216,18 @@ const KNOWN_FEATURE_GATED_URIS: &[&str] = &[
 /// Tracking issue: OpenVTC/verifiable-trust-infrastructure#854.
 #[allow(dead_code)] // consumed by the dispatcher's test-only parity harness
 const UNSPECCED_DISPATCHED_URIS: &[&str] = &[
+    // ─ vta/did-templates/*/2.0 — spec AUTHORED upstream
+    //   (trustoverip/dtgwg-trust-tasks-tf#162, lands in trust-tasks-rs
+    //   0.2.49); these entries are publish-lag only, not missing-spec
+    //   debt. The staleness check below forces their removal the moment
+    //   the pinned trust-tasks-rs is bumped to a version that indexes
+    //   the 2.0 family. (#851 — merged global+context family.)
+    "https://trusttasks.org/spec/vta/did-templates/list/2.0",
+    "https://trusttasks.org/spec/vta/did-templates/create/2.0",
+    "https://trusttasks.org/spec/vta/did-templates/get/2.0",
+    "https://trusttasks.org/spec/vta/did-templates/update/2.0",
+    "https://trusttasks.org/spec/vta/did-templates/delete/2.0",
+    "https://trusttasks.org/spec/vta/did-templates/render/2.0",
     // ─ vta/contexts/* — keep-and-spec under `vta/` (reduction plan §E).
     "https://trusttasks.org/spec/vta/contexts/list/1.0",
     "https://trusttasks.org/spec/vta/contexts/create/1.0",
@@ -937,35 +949,19 @@ dispatch_table! {
         [ Destructive None false ],
     vta_sdk::trust_tasks::TASK_BACKUP_ABORT_1_0 => backup::handle_abort
         [ Mutating None false ],
-    // ─── DID-templates slice (global) ────────────────────────────
-    vta_sdk::trust_tasks::TASK_DID_TEMPLATES_LIST_1_0 => did_templates::handle_list
+    // ─── DID-templates slice (2.0 — optional contextId selects the
+    // scope; the twelve retired 1.0 URIs now get UnsupportedType) ──
+    vta_sdk::trust_tasks::TASK_DID_TEMPLATES_LIST_2_0 => did_templates::handle_list
         [ None Metadata false ],
-    vta_sdk::trust_tasks::TASK_DID_TEMPLATES_CREATE_1_0 => did_templates::handle_create
+    vta_sdk::trust_tasks::TASK_DID_TEMPLATES_CREATE_2_0 => did_templates::handle_create
         [ Mutating None false ],
-    vta_sdk::trust_tasks::TASK_DID_TEMPLATES_GET_1_0 => did_templates::handle_get
+    vta_sdk::trust_tasks::TASK_DID_TEMPLATES_GET_2_0 => did_templates::handle_get
         [ None Metadata false ],
-    vta_sdk::trust_tasks::TASK_DID_TEMPLATES_UPDATE_1_0 => did_templates::handle_update
+    vta_sdk::trust_tasks::TASK_DID_TEMPLATES_UPDATE_2_0 => did_templates::handle_update
         [ Mutating None false ],
-    vta_sdk::trust_tasks::TASK_DID_TEMPLATES_DELETE_1_0 => did_templates::handle_delete
+    vta_sdk::trust_tasks::TASK_DID_TEMPLATES_DELETE_2_0 => did_templates::handle_delete
         [ Mutating None false ],
-    vta_sdk::trust_tasks::TASK_DID_TEMPLATES_RENDER_1_0 => did_templates::handle_render
-        [ None Metadata false ],
-    // ─── DID-templates slice (context-scoped) ────────────────────
-    vta_sdk::trust_tasks::TASK_CONTEXTS_DID_TEMPLATES_LIST_1_0 => did_templates::handle_context_list
-        [ None Metadata false ],
-    vta_sdk::trust_tasks::TASK_CONTEXTS_DID_TEMPLATES_CREATE_1_0
-        => did_templates::handle_context_create
-        [ Mutating None false ],
-    vta_sdk::trust_tasks::TASK_CONTEXTS_DID_TEMPLATES_GET_1_0 => did_templates::handle_context_get
-        [ None Metadata false ],
-    vta_sdk::trust_tasks::TASK_CONTEXTS_DID_TEMPLATES_UPDATE_1_0
-        => did_templates::handle_context_update
-        [ Mutating None false ],
-    vta_sdk::trust_tasks::TASK_CONTEXTS_DID_TEMPLATES_DELETE_1_0
-        => did_templates::handle_context_delete
-        [ Mutating None false ],
-    vta_sdk::trust_tasks::TASK_CONTEXTS_DID_TEMPLATES_RENDER_1_0
-        => did_templates::handle_context_render
+    vta_sdk::trust_tasks::TASK_DID_TEMPLATES_RENDER_2_0 => did_templates::handle_render
         [ None Metadata false ],
     // ─── Passkey-VMs slice (feature-gated: webvh + didcomm) ─────
     //

--- a/vtc-service/tests/trust_task_manifest.rs
+++ b/vtc-service/tests/trust_task_manifest.rs
@@ -447,14 +447,17 @@ const UNPUBLISHED_CANONICAL_OK: &[(&str, usize, &str)] = &[
     // 77.
     (
         "https://trusttasks.org/spec/vta/",
-        44,
+        50,
         "VTA Trust Task surface at 1.0 — predates the registry and was never reconciled with it. \
          Down from 55 via #840 phase A: config/{get,update} onto config/{show,patch}, \
          provision-integration/request onto provision/integration/0.2, acl/* onto the \
          canonical acl/{grant,show,list,update,revoke} family, and audit/list-logs onto \
          audit/list/0.1. Phase A complete at 46; phase B folded \
          webvh/dids/get-log into webvh/dids/get, and webvh/servers/{add,update} \
-         into webvh/servers/register",
+         into webvh/servers/register. The last +6 are publish-lag, not debt: the \
+         vta/did-templates/*/2.0 family (#851, trust-tasks-tf#162) is published in \
+         trust-tasks-rs 0.2.49 while the workspace still pins 0.2.43, so this returns \
+         to 44 on the dependency bump without anything being authored",
     ),
 ];
 


### PR DESCRIPTION
Closes #851.

Companion spec PR (must merge and publish first): trustoverip/dtgwg-trust-tasks-tf#162 (`vta/did-templates/*/2.0`, trust-tasks-rs 0.2.49 slot).

## Summary

Implements the did-templates consolidation: the global (`vta/did-templates/*/1.0`) and context-scoped (`vta/contexts/did-templates/*/1.0`) trust-task families merge into six `vta/did-templates/*/2.0` URIs. Scope is selected by the payload's **optional `contextId`**: absent = global (super-admin gated for writes, any authed for reads), present = that context (context-admin gated for writes, context access for reads). `render/2.0` injects the ambient `CONTEXT_ID` / `CONTEXT_DID` variables when scoped, exactly as the former context render did.

- **vta-sdk**: six `TASK_DID_TEMPLATES_*_2_0` constants replace the twelve 1.0 constants (`ALL_URIS` updated); the `did_template_management` wire bodies collapse to one per op with `context_id: Option<String>` (the `*Context*Body` variants are removed); `VtaClient` methods keep their signatures — global methods send `contextId: None`, `*_context_*` methods send `Some` — so SDK consumers are source-compatible.
- **vta-service**: the did-templates trust-task slice is now six scope-branching handlers over the **unchanged** `operations::did_templates` global/context functions (auth still enforced at the op layer: `require_super_admin` / `require_context_write` / `require_context_read`); dispatch table 12 arms → 6. REST routes untouched.
- **Registry parity harness**: the six 2.0 URIs are acknowledged in `UNSPECCED_DISPATCHED_URIS` as *publish-lag* entries (spec authored in dtgwg-trust-tasks-tf#162, not yet in the pinned trust-tasks-rs 0.2.43). The harness's staleness check forces their removal as soon as the `trust-tasks-rs` dep is bumped to a version that indexes the 2.0 family (≥0.2.49). Disposition noted in `docs/05-design-notes/registry-drift-triage.md`.
- **Release guards**: vta-sdk 0.20.19 → 0.20.20, vta-service 0.13.11 → 0.13.12, root `CHANGELOG.md` Unreleased entry, `Cargo.lock` refreshed.

## ⚠️ Clean cutover — removed wire URIs

Per the pre-production consolidation policy these twelve URIs are **removed outright** (a document carrying them now gets `UnsupportedType`), not dual-accepted. Sweep any consumers:

- `https://trusttasks.org/spec/vta/did-templates/{list,create,get,update,delete,render}/1.0`
- `https://trusttasks.org/spec/vta/contexts/did-templates/{list,create,get,update,delete,render}/1.0`

(Workspace grep found no remaining producers of these URIs outside the updated SDK client and one e2e fixture, which was updated.)

## Validation

- `cargo check -p vta-sdk` / `cargo check -p vta-service` / `cargo check -p vta-mcp` / `cargo check -p vti-e2e-tests --all-targets` — clean.
- `cargo test -p vta-sdk` — all suites pass.
- `cargo test -p vta-service` — all suites pass, `--lib` 720 passed / 0 failed after rebase onto latest main (includes the dispatcher parity harnesses and the new reverse registry-parity test).
- `cargo fmt --all` applied.

## Reviewer checklist

- [ ] Scope branch in each of the six handlers routes to the correct global/context op (auth unchanged at the op layer).
- [ ] `ALL_URIS` / dispatch-table parity: 1.0 constants fully gone, six 2.0 arms present, harness tests green.
- [ ] `UNSPECCED_DISPATCHED_URIS` publish-lag entries acceptable as transitional (self-removing via the staleness check once the dep bump lands).
- [ ] Removed-URI list above matches the CHANGELOG entry.
- [ ] Version bumps satisfy the release guards (vta-sdk 0.20.20, vta-service 0.13.12).
