### PR TITLE
feat(acl): allowedKeys — scope a caller to specific signing-oracle keys (#818)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,57 @@
 
 ## Unreleased
 
+### vti-common 0.11.30 / vta-sdk 0.20.22 / vta-service 0.13.13 / vta-cli-common 0.10.21 / pnm-cli 0.11.15 / cnm-cli 0.11.12 — ACL grants can scope a caller to specific signing keys (`allowedKeys`, #818)
+
+The **resource** dimension of an ACL grant was expressible only as a context:
+`Capability::Sign` is unparameterized, so "this caller may invoke the signing
+oracle on exactly key K" could not be said — the only spelling was giving K a
+context of its own, forcing context topology to encode per-key authorization.
+`ContextPolicy.signable_keys` is not the answer: it is resource-bound by
+design (it constrains the key's context for *every* actor, super-admin
+included). This adds the actor-scoped half.
+
+**The member.** `AclEntry.allowed_keys: Option<BTreeSet<String>>` — key ids
+the entry may invoke the signing oracle on, mirroring the canonical
+`acl/_shared/0.1/acl-entry#allowedKeys` (trust-tasks 0.2.45). It
+**intersects** with `allowed_contexts`, never widens: an entry naming a key
+outside its contexts still cannot use it. `None` = every key in scope
+(byte-identical for every existing row); **`Some(∅)` = authorized on no
+keys**. The decode lives in one place — `KeyScope` +
+`AclEntry::key_scope()` — the same shape `ActScope` gave the context axis,
+so the empty-vs-absent distinction cannot be got backwards and no call site
+tests emptiness (`acl-scope-semantics.md`; the #746/#769/#770 defect class).
+
+**The gate.** `operations::keys::sign_payload` gains gate 4, strictly after
+`auth.require_context(ctx)` (a caller can never reach a key outside its
+contexts by naming it here) and before the policy quota (a refused call burns
+no daily sign budget). One enforcement point covers all three transports
+(REST, DIDComm `sign-request`, `keys/sign` Trust Task). The gate reads the
+**stored ACL row**, not the JWT — so narrowing an entry's filter binds the
+subject's next sign request with no session revocation and no token-TTL
+window. Unscoped (super-admin-only) keys are gated too: the filter only ever
+narrows.
+
+**Wire + surfaces.** Canonical `AclEntry` carries `allowedKeys`
+(`Option<Vec<String>>`, skip-if-**none** so `[]` survives the wire);
+`acl/update` carries the three-intention replacement (omitted = leave, `null`
+= clear — a privilege increase, empty array = no keys) as a double-`Option`
+pinned to the `allowedKeys` spelling with round-trip tests (the #656/#658
+casing-drift lesson). Wired through REST `POST /acl` / `PATCH /acl/{did}`,
+DIDComm and Trust Task `acl/grant` + `acl/update`, `CreateAclRequest
+::allowed_keys(..)` / `UpdateAclRequest.allowed_keys`, and
+`pnm|cnm acl create|update --allowed-keys <ids>` (update also takes
+`--allowed-keys-unrestricted` to remove the filter — its own flag, because an
+empty `--allowed-keys` cannot mean both "no keys" and "no filter"). Displays
+render the empty filter as "no keys", never blank. Docs: integration-guide
+§"What authorizes a sign request" is now four gates.
+
+**Revocation semantics (issue trap 3).** Nothing to add to
+`is_privilege_reduction`: that path is VTC-only, the VTC runs no signing
+oracle and `VtcAclEntry` has no `allowed_keys`; on the VTA the live
+store-read above already makes narrowing immediate, which is strictly
+stronger than session revocation.
+
 ### vtc-service 0.11.43 / vta-sdk 0.20.20 — join-request decide, accept folded into members/vmc, endorsement-types per-method tasks
 
 Implements OpenVTC/verifiable-trust-infrastructure#853 (clean cutover — the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2488,7 +2488,7 @@ checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cnm-cli"
-version = "0.11.11"
+version = "0.11.12"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "clap",
@@ -6759,7 +6759,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "pnm-cli"
-version = "0.11.14"
+version = "0.11.15"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-resolver-cache-sdk",
@@ -10118,7 +10118,7 @@ dependencies = [
 
 [[package]]
 name = "vta-cli-common"
-version = "0.10.20"
+version = "0.10.21"
 dependencies = [
  "aes-gcm",
  "affinidi-crypto",
@@ -10269,7 +10269,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.20.20"
+version = "0.20.22"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10331,7 +10331,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.13.11"
+version = "0.13.13"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",
@@ -10646,7 +10646,7 @@ dependencies = [
 
 [[package]]
 name = "vti-common"
-version = "0.11.29"
+version = "0.11.30"
 dependencies = [
  "aes-gcm",
  "affinidi-data-integrity",

--- a/cnm-cli/Cargo.toml
+++ b/cnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cnm-cli"
 description = "CLI Tool for Verified Trust Agents operating in Verified Trust Communities"
-version = "0.11.11"
+version = "0.11.12"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/cnm-cli/src/main.rs
+++ b/cnm-cli/src/main.rs
@@ -564,6 +564,11 @@ enum AclCommands {
         /// Without this flag the entry is permanent.
         #[arg(long)]
         expires: Option<String>,
+        /// Restrict this DID to invoking the signing oracle on exactly these
+        /// key ids (comma-separated). Intersects with `--contexts` — it can
+        /// only narrow, never widen. Omit for no filter.
+        #[arg(long, value_delimiter = ',')]
+        allowed_keys: Option<Vec<String>>,
     },
     /// Update an ACL entry
     Update {
@@ -578,6 +583,19 @@ enum AclCommands {
         /// New comma-separated context IDs
         #[arg(long, value_delimiter = ',')]
         contexts: Option<Vec<String>>,
+        /// Replace the signing-oracle key filter with exactly these key ids
+        /// (comma-separated). The narrowing binds the subject's next sign
+        /// request. Omit to leave the filter unchanged.
+        #[arg(
+            long,
+            value_delimiter = ',',
+            conflicts_with = "allowed_keys_unrestricted"
+        )]
+        allowed_keys: Option<Vec<String>>,
+        /// Remove the signing-oracle key filter entirely (a privilege
+        /// increase — the subject may again use every key in its contexts).
+        #[arg(long)]
+        allowed_keys_unrestricted: bool,
     },
     /// Delete an ACL entry
     Delete {
@@ -1160,6 +1178,7 @@ async fn main() {
                 label,
                 contexts,
                 expires,
+                allowed_keys,
             } => match expires
                 .as_deref()
                 .map(vta_cli_common::duration::duration_to_expires_at)
@@ -1178,6 +1197,7 @@ async fn main() {
                         None,
                         false,
                         Vec::new(),
+                        allowed_keys,
                     )
                     .await
                 }
@@ -1188,10 +1208,25 @@ async fn main() {
                 role,
                 label,
                 contexts,
+                allowed_keys,
+                allowed_keys_unrestricted,
             } => {
                 // cnm exposes no approve-scope flags; pass `None` so the
                 // scope is left unchanged rather than silently cleared.
-                acl::cmd_acl_update(&client, &did, role, label, contexts, None, None, None).await
+                let allowed_keys =
+                    acl::allowed_keys_from_flags(allowed_keys, allowed_keys_unrestricted);
+                acl::cmd_acl_update(
+                    &client,
+                    &did,
+                    role,
+                    label,
+                    contexts,
+                    None,
+                    None,
+                    None,
+                    allowed_keys,
+                )
+                .await
             }
             AclCommands::Delete { did } => acl::cmd_acl_delete(&client, &did).await,
         },

--- a/docs/02-vta/integration-guide.md
+++ b/docs/02-vta/integration-guide.md
@@ -245,7 +245,7 @@ Authorization: Bearer <token>
 The VTA **does not inspect what it signs** — `POST /keys/{key_id}/sign` signs
 the bytes you hand it. What stops a caller signing as something it isn't is
 therefore entirely *which keys it may name*, and that is enforced. A sign
-request passes three gates, in order:
+request passes four gates, in order:
 
 1. **The caller's context scope.** If the key carries a `context_id`, the
    caller must be authorized in that context (or an ancestor of it). A caller
@@ -258,23 +258,39 @@ request passes three gates, in order:
 3. **Unscoped keys are super-admin only.** A key with no `context_id` has no
    context and therefore no policy to constrain it, so the role floor is the
    only guardrail — non-super-admin callers are refused.
+4. **The caller's own key filter** (`allowedKeys` on its ACL entry, #818).
+   Where gate 2 is resource-bound, this is *actor-scoped*: it names the key
+   ids **this caller** may invoke the oracle on, and it only ever
+   **intersects** with the context scope — a key named in the filter but
+   outside the caller's contexts is still refused by gate 1, which runs
+   first. Absent means every key the caller's contexts reach (every
+   pre-existing entry behaves exactly as before); **present-but-empty means
+   no keys at all** — emptiness is never a wildcard. The gate reads the
+   stored ACL row on every request, so an operator narrowing a filter binds
+   the subject's *next* sign call — no session revocation, no waiting out a
+   token TTL.
 
-The same three gates apply on **every** transport: REST, the DIDComm
+The same four gates apply on **every** transport: REST, the DIDComm
 `key-management/1.0/sign-request` protocol, and the `keys/sign` Trust Task all
 funnel through one enforcement point (`operations::keys::sign_payload`).
 
-> **Granularity: per context, not per key id.** Gate 1 authorizes a caller for
-> *every* key in a context they hold. If one credential signs for several
-> domains, give **each domain its own context** — putting several domains' keys
-> in one context and scoping the caller to it authorizes all of them. Gate 2
-> (`signable_keys`) gives per-key narrowing, but it is opt-in policy an operator
-> must write; it is not the default.
+> **Granularity: per context by default, per key id on request.** Gate 1
+> authorizes a caller for *every* key in a context it holds. If one credential
+> signs for several domains, give **each domain its own context** — putting
+> several domains' keys in one context and scoping the caller to it authorizes
+> all of them. For a caller that legitimately needs *one key out of a shared
+> context*, grant it `--allowed-keys <key-id>` (gate 4) instead of carving a
+> context per key; and use gate 2 (`signable_keys`) when the restriction
+> should bind every actor uniformly. Both narrowings are opt-in; neither is
+> the default.
 
 This is the property that makes a multi-tenant signer safe without the VTA
 understanding the payload. Pinned by
 `sign_payload_refuses_a_key_outside_the_callers_contexts`,
-`sign_payload_restricts_unscoped_keys_to_super_admin`, and
-`sign_payload_honours_context_policy_signable_keys`.
+`sign_payload_restricts_unscoped_keys_to_super_admin`,
+`sign_payload_honours_context_policy_signable_keys`,
+`sign_payload_honours_acl_allowed_keys`, and
+`sign_payload_allowed_keys_only_narrows_never_widens`.
 
 ### Context Operations
 

--- a/pnm-cli/Cargo.toml
+++ b/pnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pnm-cli"
 description = "CLI Tool for managing a personal Verifiable Trust Agent"
-version = "0.11.14"
+version = "0.11.15"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/pnm-cli/src/cli.rs
+++ b/pnm-cli/src/cli.rs
@@ -1807,6 +1807,13 @@ pub(crate) enum AclCommands {
         /// `--approve-all` is set.
         #[arg(long, value_delimiter = ',')]
         approve_contexts: Vec<String>,
+        /// Restrict this DID to invoking the signing oracle on exactly these
+        /// key ids (comma-separated). Intersects with `--contexts` — it can
+        /// only narrow, never widen. Omit the flag for no filter (every key
+        /// the contexts reach). Do not pass `--allowed-keys ''`: an empty
+        /// string is not an id and is rejected.
+        #[arg(long, value_delimiter = ',')]
+        allowed_keys: Option<Vec<String>>,
     },
     /// Update an ACL entry
     /// Change a subject's role, guarded by a compare-and-swap.
@@ -1867,6 +1874,22 @@ pub(crate) enum AclCommands {
         /// leaves the scope unchanged.
         #[arg(long)]
         approve_none: bool,
+        /// Replace the signing-oracle key filter with exactly these key ids
+        /// (comma-separated). Intersects with the entry's contexts — it can
+        /// only narrow. Narrowing binds the subject's next sign request.
+        /// Omit to leave the filter unchanged.
+        #[arg(
+            long,
+            value_delimiter = ',',
+            conflicts_with = "allowed_keys_unrestricted"
+        )]
+        allowed_keys: Option<Vec<String>>,
+        /// Remove the signing-oracle key filter entirely — the subject may
+        /// again use every key its contexts reach. A privilege increase, and
+        /// its own flag because an empty `--allowed-keys` cannot mean both
+        /// "no keys at all" and "no filter".
+        #[arg(long)]
+        allowed_keys_unrestricted: bool,
     },
     /// Delete an ACL entry
     Delete {

--- a/pnm-cli/src/commands/acl.rs
+++ b/pnm-cli/src/commands/acl.rs
@@ -24,6 +24,7 @@ pub(crate) async fn run(
             step_up_require,
             approve_all,
             approve_contexts,
+            allowed_keys,
         } => match resolve_expires_at(expires.as_deref()) {
             Ok(expires_at) => {
                 acl::cmd_acl_create(
@@ -37,6 +38,7 @@ pub(crate) async fn run(
                     step_up_require,
                     approve_all,
                     approve_contexts,
+                    allowed_keys,
                 )
                 .await
             }
@@ -52,9 +54,13 @@ pub(crate) async fn run(
             approve_all,
             approve_contexts,
             approve_none,
+            allowed_keys,
+            allowed_keys_unrestricted,
         } => {
             let approve_scope =
                 acl::approve_scope_from_flags(approve_all, approve_contexts, approve_none);
+            let allowed_keys =
+                acl::allowed_keys_from_flags(allowed_keys, allowed_keys_unrestricted);
             acl::cmd_acl_update(
                 client,
                 &did,
@@ -64,6 +70,7 @@ pub(crate) async fn run(
                 step_up_approver,
                 step_up_require,
                 approve_scope,
+                allowed_keys,
             )
             .await
         }

--- a/tests/e2e/tests/client_didcomm.rs
+++ b/tests/e2e/tests/client_didcomm.rs
@@ -533,6 +533,7 @@ async fn update_acl_via_didcomm() {
         step_up_approver: None,
         step_up_require: None,
         approve_scope: None,
+        allowed_keys: None,
     };
     client.update_acl("did:key:zAdmin", req).await.unwrap();
 

--- a/vta-cli-common/Cargo.toml
+++ b/vta-cli-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-cli-common"
 description = "Shared CLI command handlers and rendering helpers for VTA CLIs"
 readme = "README.md"
-version = "0.10.20"
+version = "0.10.21"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-cli-common/src/commands/acl.rs
+++ b/vta-cli-common/src/commands/acl.rs
@@ -58,6 +58,35 @@ pub fn format_approve_scope(approve_all: bool, approve_contexts: &[String]) -> O
     }
 }
 
+/// Human-readable signing-key filter (#818). `None` (no filter) omits the
+/// line entirely; the empty filter is the state that must never be
+/// misrendered — "no keys" and "no filter" are opposite grants, so the empty
+/// set is spelled out rather than shown as a blank list.
+pub fn format_allowed_keys(allowed_keys: Option<&[String]>) -> Option<String> {
+    match allowed_keys {
+        None => None,
+        Some([]) => Some("(none — may invoke the signing oracle on no keys)".to_string()),
+        Some(keys) => Some(format!("keys [{}]", keys.join(", "))),
+    }
+}
+
+/// Resolve the two mutually-exclusive allowed-keys flags into the wire value.
+///
+/// `None` means "leave unchanged"; `Some(None)` clears the filter
+/// (`--allowed-keys-unrestricted`); `Some(Some(keys))` replaces it. Clearing
+/// needs its own flag for the same reason `--approve-none` does: an empty
+/// `--allowed-keys` cannot mean both "no keys at all" and "no filter".
+pub fn allowed_keys_from_flags(
+    allowed_keys: Option<Vec<String>>,
+    allowed_keys_unrestricted: bool,
+) -> Option<Option<Vec<String>>> {
+    if allowed_keys_unrestricted {
+        Some(None)
+    } else {
+        allowed_keys.map(Some)
+    }
+}
+
 pub fn validate_role(role: &str) -> Result<(), Box<dyn std::error::Error>> {
     match role {
         "admin" | "initiator" | "application" | "reader" => Ok(()),
@@ -173,6 +202,9 @@ pub async fn cmd_acl_list(
                 fields.push(("Label", label.to_string()));
             }
             fields.push(("Contexts", contexts));
+            if let Some(k) = format_allowed_keys(entry.allowed_keys.as_deref()) {
+                fields.push(("Allowed Keys", k));
+            }
             if let Some(a) = approve {
                 fields.push(("Approve", a));
             }
@@ -275,6 +307,9 @@ pub async fn cmd_acl_get(client: &VtaClient, did: &str) -> Result<(), Box<dyn st
         "Contexts:         {}",
         format_contexts(&entry.role, &entry.allowed_contexts)
     );
+    if let Some(keys) = format_allowed_keys(entry.allowed_keys.as_deref()) {
+        println!("Allowed keys:     {keys}");
+    }
     if let Some(scope) =
         format_approve_scope(entry.approve_all_contexts(), entry.approve_contexts())
     {
@@ -285,6 +320,7 @@ pub async fn cmd_acl_get(client: &VtaClient, did: &str) -> Result<(), Box<dyn st
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn cmd_acl_create(
     client: &VtaClient,
     did: String,
@@ -296,9 +332,13 @@ pub async fn cmd_acl_create(
     step_up_require: Option<String>,
     approve_all: bool,
     approve_contexts: Vec<String>,
+    allowed_keys: Option<Vec<String>>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     validate_role(&role)?;
     let mut req = CreateAclRequest::new(did, role).contexts(contexts);
+    if let Some(keys) = allowed_keys {
+        req = req.allowed_keys(keys);
+    }
     if let Some(l) = label {
         req = req.label(l);
     }
@@ -330,6 +370,9 @@ pub async fn cmd_acl_create(
         "  Contexts:   {}",
         format_contexts(&entry.role, &entry.allowed_contexts)
     );
+    if let Some(keys) = format_allowed_keys(entry.allowed_keys.as_deref()) {
+        println!("  Allowed keys: {keys}");
+    }
     if let Some(scope) =
         format_approve_scope(entry.approve_all_contexts(), entry.approve_contexts())
     {
@@ -414,6 +457,7 @@ pub async fn cmd_acl_update(
     step_up_approver: Option<String>,
     step_up_require: Option<String>,
     approve_scope: Option<ApproveScope>,
+    allowed_keys: Option<Option<Vec<String>>>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     // Role transitions moved to `acl change-role`, which carries the
     // compare-and-swap that makes a concurrent edit an error instead of a
@@ -436,12 +480,14 @@ pub async fn cmd_acl_update(
         .into());
     }
     let approve_scope_echo = approve_scope.clone();
+    let allowed_keys_echo = allowed_keys.clone();
     let req = UpdateAclRequest {
         label,
         allowed_contexts: contexts,
         step_up_approver: step_up_approver.clone(),
         step_up_require: step_up_require.clone(),
         approve_scope,
+        allowed_keys,
     };
     let entry = client.update_acl(did, req).await?;
     println!("ACL entry updated:");
@@ -470,6 +516,17 @@ pub async fn cmd_acl_update(
         } else {
             println!("  Step-up require:  {require}");
         }
+    }
+    // Echo the filter only when this call set it — and spell out the two
+    // extremes, since "(cleared — every key in scope)" and "no keys at all"
+    // are the grants an operator most needs to see they just made.
+    if let Some(replacement) = &allowed_keys_echo {
+        let rendered = match replacement.as_deref() {
+            None => "(cleared — every key within the entry's contexts)".to_string(),
+            Some([]) => "(none — may invoke the signing oracle on no keys)".to_string(),
+            Some(keys) => format!("keys [{}]", keys.join(", ")),
+        };
+        println!("  Allowed keys: {rendered}");
     }
     // Echo the scope only when this call set it, so "unchanged" is visibly
     // different from "set to confer nothing".
@@ -559,6 +616,37 @@ mod tests {
     fn test_format_contexts_multiple() {
         let ctx = vec!["vta".to_string(), "payments".to_string()];
         assert_eq!(format_contexts("reader", &ctx), "vta, payments");
+    }
+
+    // ── format_allowed_keys (#818) ─────────────────────────────────
+
+    /// "No filter" and "no keys" are opposite grants; the display must never
+    /// blur them (the same lesson as #746 one axis over).
+    #[test]
+    fn test_format_allowed_keys_distinguishes_absent_from_empty() {
+        assert_eq!(format_allowed_keys(None), None, "no filter → no line");
+        assert_eq!(
+            format_allowed_keys(Some(&[])).as_deref(),
+            Some("(none — may invoke the signing oracle on no keys)")
+        );
+        assert_eq!(
+            format_allowed_keys(Some(&["k1".to_string(), "k2".to_string()])).as_deref(),
+            Some("keys [k1, k2]")
+        );
+    }
+
+    #[test]
+    fn test_allowed_keys_from_flags() {
+        // Neither flag → leave unchanged.
+        assert_eq!(allowed_keys_from_flags(None, false), None);
+        // Replace with exactly these ids.
+        assert_eq!(
+            allowed_keys_from_flags(Some(vec!["k1".into()]), false),
+            Some(Some(vec!["k1".to_string()]))
+        );
+        // Clear the filter — its own flag, because an empty `--allowed-keys`
+        // cannot mean both "no keys at all" and "no filter".
+        assert_eq!(allowed_keys_from_flags(None, true), Some(None));
     }
 
     // ── format_role ────────────────────────────────────────────────

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.20.20"
+version = "0.20.22"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/client/mod.rs
+++ b/vta-sdk/src/client/mod.rs
@@ -2045,6 +2045,7 @@ mod tests {
             step_up_require: None,
             approve_all_contexts: false,
             approve_contexts: vec![],
+            allowed_keys: None,
         };
         let json = serde_json::to_value(&req).unwrap();
         // The builder API is unchanged; only what it serialises moved. The wire
@@ -2076,10 +2077,54 @@ mod tests {
             step_up_approver: None,
             step_up_require: None,
             approve_scope: None,
+            allowed_keys: None,
         };
         let json = serde_json::to_value(&req).unwrap();
         let obj = json.as_object().unwrap();
         assert!(obj.is_empty(), "all-None request should serialize to {{}}");
+    }
+
+    /// The `allowedKeys` member of the update request keeps the three-way
+    /// distinction on the wire (#818): leave-alone emits nothing, clear emits
+    /// an explicit `null`, and the empty list — "no keys at all" — emits `[]`.
+    #[test]
+    fn test_update_acl_request_allowed_keys_three_intentions() {
+        let base = || UpdateAclRequest {
+            label: None,
+            allowed_contexts: None,
+            step_up_approver: None,
+            step_up_require: None,
+            approve_scope: None,
+            allowed_keys: None,
+        };
+
+        let set = UpdateAclRequest {
+            allowed_keys: Some(Some(vec!["key-1".into()])),
+            ..base()
+        };
+        let json = serde_json::to_value(&set).unwrap();
+        assert_eq!(json["allowedKeys"], serde_json::json!(["key-1"]));
+
+        let clear = UpdateAclRequest {
+            allowed_keys: Some(None),
+            ..base()
+        };
+        let json = serde_json::to_value(&clear).unwrap();
+        assert!(
+            json["allowedKeys"].is_null(),
+            "clear is explicit null: {json}"
+        );
+
+        let none_at_all = UpdateAclRequest {
+            allowed_keys: Some(Some(vec![])),
+            ..base()
+        };
+        let json = serde_json::to_value(&none_at_all).unwrap();
+        assert_eq!(
+            json["allowedKeys"],
+            serde_json::json!([]),
+            "the empty list must be emitted, not skipped: {json}"
+        );
     }
 
     #[test]

--- a/vta-sdk/src/client/types.rs
+++ b/vta-sdk/src/client/types.rs
@@ -357,6 +357,14 @@ pub struct AclEntryResponse {
         serialize_with = "ser_epoch_opt"
     )]
     pub expires_at: Option<u64>,
+    /// Signing-oracle key filter (#818). `None` = no filter; `Some([])` =
+    /// authorized on no keys — keep the distinction when rendering.
+    #[serde(
+        default,
+        rename = "allowedKeys",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub allowed_keys: Option<Vec<String>>,
     /// Flattened out of the canonical `stepUp` object.
     #[serde(default, rename = "stepUp")]
     step_up: Option<StepUpWire>,
@@ -484,6 +492,10 @@ pub struct CreateAclRequest {
     pub approve_all_contexts: bool,
     /// Approve-authority scoped to these contexts.
     pub approve_contexts: Vec<String>,
+    /// Signing-oracle key filter (#818). `None` = no filter (every key in the
+    /// entry's contexts); `Some(∅)` = **no** keys at all — the two are
+    /// opposite grants and are serialized distinctly.
+    pub allowed_keys: Option<Vec<String>>,
 }
 
 impl serde::Serialize for CreateAclRequest {
@@ -507,6 +519,7 @@ impl serde::Serialize for CreateAclRequest {
                 subject: self.did.clone(),
                 role: self.role.clone(),
                 scopes: self.allowed_contexts.clone(),
+                allowed_keys: self.allowed_keys.clone(),
                 label: self.label.clone(),
                 created_at: None,
                 created_by: None,
@@ -538,6 +551,7 @@ impl CreateAclRequest {
             step_up_require: None,
             approve_all_contexts: false,
             approve_contexts: Vec::new(),
+            allowed_keys: None,
         }
     }
     pub fn label(mut self, label: impl Into<String>) -> Self {
@@ -572,6 +586,14 @@ impl CreateAclRequest {
     /// Grant approve-authority scoped to these contexts.
     pub fn approve_contexts(mut self, contexts: Vec<String>) -> Self {
         self.approve_contexts = contexts;
+        self
+    }
+    /// Restrict the subject to invoking the signing oracle on exactly these
+    /// key ids (#818). Intersects with — never widens — the context scope.
+    /// An empty vec means **no keys at all**; not calling this leaves the
+    /// subject unfiltered (every key its contexts reach).
+    pub fn allowed_keys(mut self, keys: Vec<String>) -> Self {
+        self.allowed_keys = Some(keys);
         self
     }
 }
@@ -612,6 +634,13 @@ pub struct UpdateAclRequest {
     /// empty list cannot mean both "confer nothing" and "leave alone".
     #[serde(skip_serializing_if = "Option::is_none")]
     pub approve_scope: Option<crate::acl::ApproveScope>,
+    /// Replace the signing-oracle key filter (#818): `None` leaves it
+    /// unchanged, `Some(None)` clears it (serialized as explicit `null` — a
+    /// privilege increase), `Some(Some(keys))` sets it to exactly those ids
+    /// (**the empty vec is "no keys at all"**, never a wildcard). Wire name
+    /// pinned to the canonical `allowedKeys`.
+    #[serde(rename = "allowedKeys", skip_serializing_if = "Option::is_none")]
+    pub allowed_keys: Option<Option<Vec<String>>>,
 }
 
 // ── WebVH server types ──────────────────────────────────────────────

--- a/vta-sdk/src/protocols/acl_management/create.rs
+++ b/vta-sdk/src/protocols/acl_management/create.rs
@@ -70,6 +70,13 @@ pub struct CreateAclResultBody {
     /// `approve_scope`). Empty = confers nothing, unless `approve_all_contexts`.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub approve_contexts: Vec<String>,
+    /// The signing-oracle key filter the maintainer now holds for this
+    /// subject (#818), echoing the stored `allowed_keys`. `None` = no filter
+    /// (every key in the entry's contexts); **`Some([])` = no keys at all** —
+    /// the skip is deliberately `Option::is_none`, never emptiness, so the
+    /// two cannot collapse.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub allowed_keys: Option<Vec<String>>,
 }
 
 #[cfg(test)]

--- a/vta-sdk/src/protocols/acl_management/entry.rs
+++ b/vta-sdk/src/protocols/acl_management/entry.rs
@@ -120,6 +120,17 @@ pub struct AclEntry {
     /// Resolve through the role, as `AclEntry::act_scope` does.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub scopes: Vec<String>,
+    /// Key ids the subject may invoke the signing oracle on (#818).
+    /// Intersects with — never widens — `scopes`.
+    ///
+    /// **`None` and `Some(∅)` are opposite grants.** Absent = every key the
+    /// entry's scopes reach (entries that pre-date the member); present-but-
+    /// empty = authorized on **no** keys. That is why the skip is
+    /// `Option::is_none`, *not* `Vec::is_empty`: `Some([])` must survive the
+    /// wire as `"allowedKeys": []` or the narrowest grant silently becomes
+    /// the widest. Mirrors `acl/_shared/0.1/acl-entry#allowedKeys`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub allowed_keys: Option<Vec<String>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub label: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -168,6 +179,7 @@ impl AclEntry {
             subject: r.did.clone(),
             role: r.role.clone(),
             scopes: r.allowed_contexts.clone(),
+            allowed_keys: r.allowed_keys.clone(),
             label: r.label.clone(),
             created_at: to_rfc3339(r.created_at),
             created_by: Some(r.created_by.clone()),
@@ -208,6 +220,7 @@ mod tests {
             subject: "did:key:z6MkA".into(),
             role: "reader".into(),
             scopes: vec![],
+            allowed_keys: None,
             label: None,
             created_at: None,
             created_by: None,
@@ -261,6 +274,39 @@ mod tests {
         assert_eq!(ts.to_rfc3339(), "2027-01-15T08:00:00+00:00");
     }
 
+    /// `allowedKeys` (#818): absent and empty are opposite grants and both
+    /// must survive the wire. `Some([])` emits `"allowedKeys": []`; `None`
+    /// emits nothing — collapsing them would turn "may sign with no keys"
+    /// into "may sign with every key in scope".
+    #[test]
+    fn allowed_keys_empty_and_absent_both_survive_the_wire() {
+        let mut e: AclEntry =
+            serde_json::from_value(serde_json::json!({"subject": "did:key:zA", "role": "reader"}))
+                .unwrap();
+        assert_eq!(e.allowed_keys, None, "absent decodes to None (no filter)");
+        let v = serde_json::to_value(&e).unwrap();
+        assert!(
+            v.get("allowedKeys").is_none(),
+            "no filter emits nothing: {v}"
+        );
+
+        e.allowed_keys = Some(vec![]);
+        let v = serde_json::to_value(&e).unwrap();
+        assert_eq!(
+            v.get("allowedKeys"),
+            Some(&serde_json::json!([])),
+            "the empty filter must be emitted, not skipped: {v}"
+        );
+        let back: AclEntry = serde_json::from_value(v).unwrap();
+        assert_eq!(back.allowed_keys, Some(vec![]));
+
+        // And the wire casing is the canonical camelCase, pinned (#656/#658).
+        e.allowed_keys = Some(vec!["key-1".into()]);
+        let v = serde_json::to_value(&e).unwrap();
+        assert!(v.get("allowedKeys").is_some(), "{v}");
+        assert!(v.get("allowed_keys").is_none(), "{v}");
+    }
+
     /// The wire form is camelCase; the pre-fold snake_case names are gone.
     #[test]
     fn wire_form_is_camel_case() {
@@ -268,6 +314,7 @@ mod tests {
             subject: "did:key:zA".into(),
             role: "admin".into(),
             scopes: vec!["ctx".into()],
+            allowed_keys: None,
             label: None,
             created_at: None,
             created_by: None,

--- a/vta-sdk/src/protocols/acl_management/update.rs
+++ b/vta-sdk/src/protocols/acl_management/update.rs
@@ -42,6 +42,128 @@ pub struct UpdateAclBody {
     /// Clear is `Some(ApproveScope::None)` — an explicit value, not absence.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub approve_scope: Option<ApproveScope>,
+    /// Replace the signing-oracle key filter (#818). Three intentions, three
+    /// spellings, exactly as `acl/update/0.1` specifies:
+    ///
+    /// - **omitted** → `None` — leave the filter unchanged;
+    /// - **explicit `null`** → `Some(None)` — clear the filter (the subject
+    ///   may again reach every key in its contexts — a privilege *increase*);
+    /// - **an array** → `Some(Some(keys))` — set the filter to exactly these
+    ///   ids; **the empty array is "no keys at all"**, never a wildcard.
+    ///
+    /// Replacement, not merge; a narrowing replacement is a privilege
+    /// reduction (enforcement reads the stored row live in `sign_payload`
+    /// gate 4, so it binds the subject's next sign request).
+    ///
+    /// The wire name is pinned to the canonical `allowedKeys` (the rest of
+    /// this body is snake_case pending the #856 rename): casing drift on this
+    /// exact struct family once let an empty `allowed_contexts` mint a
+    /// super-admin (#656/#658), so the round-trip test below pins it.
+    #[serde(
+        rename = "allowedKeys",
+        default,
+        deserialize_with = "double_option",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub allowed_keys: Option<Option<Vec<String>>>,
+}
+
+/// Deserialize a member where **absent** and **explicit `null`** mean
+/// different things: absent → `None` (field default), `null` → `Some(None)`,
+/// a value → `Some(Some(v))`. Plain `Option<Option<T>>` cannot make the
+/// distinction — serde folds `null` into the outer `None`.
+fn double_option<'de, T, D>(de: D) -> Result<Option<Option<T>>, D::Error>
+where
+    T: Deserialize<'de>,
+    D: serde::Deserializer<'de>,
+{
+    Deserialize::deserialize(de).map(Some)
 }
 
 pub type UpdateAclResultBody = CreateAclResultBody;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn body(json: serde_json::Value) -> UpdateAclBody {
+        serde_json::from_value(json).unwrap()
+    }
+
+    /// Trap 2 (#818): pin the wire casing. `CreateAclBody` is the struct
+    /// family where a camelCase/snake_case mismatch once let an empty
+    /// `allowed_contexts` silently mint a super-admin (#656/#658) — the new
+    /// member must round-trip under exactly one spelling.
+    #[test]
+    fn allowed_keys_round_trips_as_camel_case() {
+        let b = UpdateAclBody {
+            did: "did:key:zA".into(),
+            label: None,
+            allowed_contexts: None,
+            step_up_approver: None,
+            step_up_require: None,
+            approve_scope: None,
+            allowed_keys: Some(Some(vec!["key-1".into(), "key-2".into()])),
+        };
+        let v = serde_json::to_value(&b).unwrap();
+        assert!(v.get("allowedKeys").is_some(), "{v}");
+        assert!(v.get("allowed_keys").is_none(), "one spelling only: {v}");
+        let back: UpdateAclBody = serde_json::from_value(v).unwrap();
+        assert_eq!(
+            back.allowed_keys,
+            Some(Some(vec!["key-1".to_string(), "key-2".to_string()]))
+        );
+        // The snake_case spelling is NOT accepted — a misspelled member must
+        // not silently read as "leave unchanged" under the pinned name while
+        // the caller believes they narrowed the filter. (This body does not
+        // deny unknown fields, matching its siblings, so the member is
+        // ignored — the test documents that the pinned name is the only one
+        // that takes effect.)
+        let b = body(serde_json::json!({
+            "did": "did:key:zA", "allowed_keys": ["key-1"]
+        }));
+        assert_eq!(b.allowed_keys, None);
+    }
+
+    /// The three intentions decode to three different values: omitted =
+    /// leave alone, explicit null = clear the filter, empty array = no keys.
+    #[test]
+    fn allowed_keys_distinguishes_absent_null_and_empty() {
+        let absent = body(serde_json::json!({ "did": "did:key:zA" }));
+        assert_eq!(absent.allowed_keys, None, "omitted = leave unchanged");
+
+        let null = body(serde_json::json!({ "did": "did:key:zA", "allowedKeys": null }));
+        assert_eq!(null.allowed_keys, Some(None), "null = clear the filter");
+
+        let empty = body(serde_json::json!({ "did": "did:key:zA", "allowedKeys": [] }));
+        assert_eq!(
+            empty.allowed_keys,
+            Some(Some(vec![])),
+            "empty array = authorized on NO keys — not a wildcard, not a clear"
+        );
+    }
+
+    /// Serialization keeps the same three-way distinction (the SDK client
+    /// sends this body): `Some(None)` must emit an explicit null.
+    #[test]
+    fn allowed_keys_clear_serializes_as_explicit_null() {
+        let b = UpdateAclBody {
+            did: "did:key:zA".into(),
+            label: None,
+            allowed_contexts: None,
+            step_up_approver: None,
+            step_up_require: None,
+            approve_scope: None,
+            allowed_keys: Some(None),
+        };
+        let v = serde_json::to_value(&b).unwrap();
+        assert!(v.get("allowedKeys").is_some_and(|k| k.is_null()), "{v}");
+
+        let untouched = UpdateAclBody {
+            allowed_keys: None,
+            ..b
+        };
+        let v = serde_json::to_value(&untouched).unwrap();
+        assert!(v.get("allowedKeys").is_none(), "omitted stays omitted: {v}");
+    }
+}

--- a/vta-sdk/tests/client_rest.rs
+++ b/vta-sdk/tests/client_rest.rs
@@ -736,6 +736,7 @@ async fn update_acl_patches() {
         step_up_approver: None,
         step_up_require: None,
         approve_scope: None,
+        allowed_keys: None,
     };
     let resp = c.update_acl("did:key:zAdmin", req).await.unwrap();
     assert_eq!(resp.did, "did:key:zAdmin");

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.13.11"
+version = "0.13.13"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/messaging/handlers.rs
+++ b/vta-service/src/messaging/handlers.rs
@@ -428,6 +428,7 @@ didcomm_handler!(
             &s.keys_ks,
             &s.imported_ks,
             &s.contexts_ks,
+            &s.acl_ks,
             &s.seed_store,
             &auth,
             &body.key_id,
@@ -770,6 +771,9 @@ didcomm_handler!(
                 step_up_approver: body.step_up_approver,
                 step_up_require: body.step_up_require,
                 approve_scope: body.approve_scope,
+                allowed_keys: body
+                    .allowed_keys
+                    .map(|r| r.map(|keys| keys.into_iter().collect())),
             },
             "didcomm",
         )

--- a/vta-service/src/operations/acl.rs
+++ b/vta-service/src/operations/acl.rs
@@ -43,6 +43,16 @@ pub struct UpdateAclParams {
     /// approver's authority" from "don't touch it", and revoking is the case
     /// that matters most.
     pub approve_scope: Option<ApproveScope>,
+    /// Replace the signing-oracle key filter (#818). `None` leaves it
+    /// unchanged; `Some(None)` clears it (back to every key in the entry's
+    /// contexts — a privilege *increase*); `Some(Some(keys))` sets it to
+    /// exactly those ids, **the empty set meaning no keys at all**.
+    ///
+    /// A narrowing replacement is a privilege reduction. No session
+    /// revocation is needed to make it bind: `sign_payload` gate 4 reads the
+    /// stored entry on every request, so the narrowed set applies to the
+    /// subject's next sign call even while its access token stays valid.
+    pub allowed_keys: Option<Option<std::collections::BTreeSet<String>>>,
 }
 
 /// Parse a wire `stepUp.require` value into a [`StepUpMode`]. Only `self` and
@@ -193,7 +203,34 @@ fn to_result_body(e: &AclEntry) -> CreateAclResultBody {
         step_up_require: step_up_require_to_wire(e.step_up_require),
         approve_all_contexts,
         approve_contexts,
+        // `Some(∅)` must echo as an empty list, never collapse to `None` —
+        // the two are opposite grants (see `KeyScope`).
+        allowed_keys: e
+            .allowed_keys
+            .as_ref()
+            .map(|keys| keys.iter().cloned().collect()),
     }
+}
+
+/// Shape-check a signing-key filter before storing it: every id must be
+/// non-empty after trimming. The `--contexts ''` lesson one axis over — an
+/// empty id is not an identifier, matches no key, and an entry holding one
+/// looks filtered while being inert (or, worse, looks narrower than it is).
+fn validate_allowed_keys(
+    allowed_keys: Option<&std::collections::BTreeSet<String>>,
+) -> Result<(), AppError> {
+    if let Some(keys) = allowed_keys {
+        for key in keys {
+            if key.trim().is_empty() {
+                return Err(AppError::Validation(
+                    "allowedKeys must not contain an empty key id — pass an empty \
+                     list to authorize no keys, or omit the member for no filter"
+                        .into(),
+                ));
+            }
+        }
+    }
+    Ok(())
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -210,11 +247,16 @@ pub async fn create_acl(
     step_up_approver: Option<String>,
     step_up_require: Option<String>,
     approve_scope: ApproveScope,
+    allowed_keys: Option<std::collections::BTreeSet<String>>,
     channel: &str,
 ) -> Result<CreateAclResultBody, AppError> {
     auth.require_manage()?;
     validate_role_assignment(auth, &role)?;
     validate_acl_modification(auth, &role, &allowed_contexts)?;
+    // The key filter can only narrow (it intersects with the context scope in
+    // `sign_payload` gate 4), so granting it needs no privilege check beyond
+    // the ones above — only a shape check.
+    validate_allowed_keys(allowed_keys.as_ref())?;
     // Granting approve-authority is its own privilege check: `all` is
     // super-admin-only, a scoped grant requires the caller to hold each context.
     validate_approve_scope_grant(auth, &approve_scope)?;
@@ -236,7 +278,8 @@ pub async fn create_acl(
         .with_expires_at(expires_at)
         .with_step_up_approver(step_up_approver)
         .with_step_up_require(step_up_require)
-        .with_approve_scope(approve_scope);
+        .with_approve_scope(approve_scope)
+        .with_allowed_keys(allowed_keys);
 
     store_acl_entry(acl_ks, &entry).await?;
 
@@ -422,6 +465,19 @@ pub async fn update_acl(
             .collect();
         require_contexts_exist(contexts_ks, &added).await?;
         entry.allowed_contexts = allowed_contexts;
+    }
+
+    if let Some(replacement) = params.allowed_keys {
+        // Replacement, not merge, per `acl/update/0.1`: the stored filter
+        // becomes exactly this value. `Some(None)` clears it (privilege
+        // increase — admin-gated like everything on this path); `Some(∅)`
+        // is "no keys at all", never a wildcard. A narrowing replacement is
+        // a privilege reduction, and it binds without any session revocation
+        // because `sign_payload` gate 4 reads this row live on every sign
+        // request — the narrowed set applies to the subject's next call even
+        // while its access token stays valid.
+        validate_allowed_keys(replacement.as_ref())?;
+        entry.allowed_keys = replacement;
     }
 
     if let Some(scope) = params.approve_scope {
@@ -764,6 +820,10 @@ pub async fn grant_from_entry(
         entry.step_up_approver(),
         entry.step_up_require(),
         entry.approve_scope(),
+        entry
+            .allowed_keys
+            .clone()
+            .map(|keys| keys.into_iter().collect()),
         channel,
     )
     .await?;
@@ -1302,6 +1362,7 @@ mod tests {
 
         let admin = super_admin("did:key:zRoot");
         let set = |scope| UpdateAclParams {
+            allowed_keys: None,
             role: None,
             label: None,
             allowed_contexts: None,
@@ -1374,6 +1435,120 @@ mod tests {
         );
     }
 
+    /// The `allowedKeys` replacement carries three intentions (#818): omitted
+    /// leaves the filter, `Some(Some(keys))` replaces it (the empty set is
+    /// "no keys at all"), `Some(None)` clears it. Each must land distinctly.
+    #[tokio::test]
+    async fn update_acl_sets_empties_and_clears_the_key_filter() {
+        use std::collections::BTreeSet;
+
+        let (_store, acl_ks, audit_ks, contexts_ks, _dir) = fresh_store().await;
+        seed_contexts(&contexts_ks, &["ctx-a"]).await;
+        let target = "did:key:zSigner";
+        seed_target(&acl_ks, target, &["ctx-a"]).await;
+        let admin = super_admin("did:key:zRoot");
+
+        let set = |replacement| UpdateAclParams {
+            role: None,
+            label: None,
+            allowed_contexts: None,
+            step_up_approver: None,
+            step_up_require: None,
+            approve_scope: None,
+            allowed_keys: replacement,
+        };
+        let stored_filter = |acl_ks: &KeyspaceHandle| {
+            let acl_ks = acl_ks.clone();
+            async move {
+                get_acl_entry(&acl_ks, target)
+                    .await
+                    .unwrap()
+                    .unwrap()
+                    .allowed_keys
+            }
+        };
+
+        // Replace: exactly this set.
+        let keys: BTreeSet<String> = ["key-1".to_string()].into_iter().collect();
+        update_acl(
+            &acl_ks,
+            &audit_ks,
+            &contexts_ks,
+            &admin,
+            target,
+            set(Some(Some(keys.clone()))),
+            "test",
+        )
+        .await
+        .expect("setting the filter");
+        assert_eq!(stored_filter(&acl_ks).await, Some(keys.clone()));
+
+        // Omitted: a label-only edit must not disturb the filter.
+        update_acl(
+            &acl_ks,
+            &audit_ks,
+            &contexts_ks,
+            &admin,
+            target,
+            UpdateAclParams {
+                label: Some("relabelled".into()),
+                ..set(None)
+            },
+            "test",
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            stored_filter(&acl_ks).await,
+            Some(keys),
+            "omitting allowedKeys must leave the filter unchanged"
+        );
+
+        // Empty set: authorized on NO keys — stored as Some(∅), never
+        // collapsed into "no filter".
+        update_acl(
+            &acl_ks,
+            &audit_ks,
+            &contexts_ks,
+            &admin,
+            target,
+            set(Some(Some(BTreeSet::new()))),
+            "test",
+        )
+        .await
+        .expect("narrowing to no keys");
+        assert_eq!(stored_filter(&acl_ks).await, Some(BTreeSet::new()));
+
+        // Clear: back to every key in scope — Some(None), an explicit value.
+        update_acl(
+            &acl_ks,
+            &audit_ks,
+            &contexts_ks,
+            &admin,
+            target,
+            set(Some(None)),
+            "test",
+        )
+        .await
+        .expect("clearing the filter");
+        assert_eq!(stored_filter(&acl_ks).await, None);
+
+        // Shape guard: an empty-string key id is not an identifier (the
+        // `--contexts ''` lesson one axis over).
+        let err = update_acl(
+            &acl_ks,
+            &audit_ks,
+            &contexts_ks,
+            &admin,
+            target,
+            set(Some(Some(["".to_string()].into_iter().collect()))),
+            "test",
+        )
+        .await
+        .expect_err("an empty key id must be refused");
+        assert!(matches!(err, AppError::Validation(_)), "got {err:?}");
+    }
+
     /// Omitting the field leaves the existing scope alone — the distinction
     /// that made a flat bool/list pair unusable for this.
     #[tokio::test]
@@ -1391,6 +1566,7 @@ mod tests {
             &admin,
             target,
             UpdateAclParams {
+                allowed_keys: None,
                 role: None,
                 label: None,
                 allowed_contexts: None,
@@ -1411,6 +1587,7 @@ mod tests {
             &admin,
             target,
             UpdateAclParams {
+                allowed_keys: None,
                 role: None,
                 label: Some("renamed".into()),
                 allowed_contexts: None,
@@ -1449,6 +1626,7 @@ mod tests {
             &ctx_admin_a,
             target,
             UpdateAclParams {
+                allowed_keys: None,
                 role: None,
                 label: None,
                 allowed_contexts: None,
@@ -1472,6 +1650,7 @@ mod tests {
             &ctx_admin_a,
             target,
             UpdateAclParams {
+                allowed_keys: None,
                 role: None,
                 label: None,
                 allowed_contexts: None,
@@ -1504,6 +1683,7 @@ mod tests {
             &caller,
             target,
             UpdateAclParams {
+                allowed_keys: None,
                 role: None,
                 label: None,
                 step_up_approver: None,
@@ -1540,6 +1720,7 @@ mod tests {
             &caller,
             target,
             UpdateAclParams {
+                allowed_keys: None,
                 role: None,
                 label: None,
                 step_up_approver: None,
@@ -1573,6 +1754,7 @@ mod tests {
             &caller,
             target,
             UpdateAclParams {
+                allowed_keys: None,
                 role: None,
                 label: None,
                 step_up_approver: None,
@@ -1621,6 +1803,7 @@ mod tests {
             None,
             None,
             ApproveScope::None,
+            None,
             "test",
         )
         .await
@@ -1656,6 +1839,7 @@ mod tests {
             None,
             None,
             ApproveScope::None,
+            None,
             "test",
         )
         .await
@@ -1687,6 +1871,7 @@ mod tests {
             None,
             None,
             ApproveScope::Contexts(vec!["ctx-a".into()]),
+            None,
             "test",
         )
         .await
@@ -1719,6 +1904,7 @@ mod tests {
             None,
             None,
             ApproveScope::Contexts(vec!["ctx-b".into()]),
+            None,
             "test",
         )
         .await
@@ -1747,6 +1933,7 @@ mod tests {
             None,
             None,
             ApproveScope::None,
+            None,
             "test",
         )
         .await
@@ -1841,6 +2028,7 @@ mod tests {
             &caller,
             target,
             UpdateAclParams {
+                allowed_keys: None,
                 role: None,
                 label: None,
                 step_up_approver: None,

--- a/vta-service/src/operations/keys.rs
+++ b/vta-service/src/operations/keys.rs
@@ -808,6 +808,48 @@ pub async fn get_key_secret_internal(
     })
 }
 
+/// Gate 4 of [`sign_payload`] (#818): the **actor-scoped** key filter.
+///
+/// Loads the caller's stored ACL row and asks its [`KeyScope`] whether
+/// `key_id` is within the entry's `allowed_keys`. Complements the
+/// resource-bound `ContextPolicy.signable_keys` (which binds every actor,
+/// super-admin included); this one binds *this caller*, and only ever
+/// narrows what the context gates already allowed.
+///
+/// Reads the store rather than the JWT deliberately: an operator narrowing
+/// an entry's `allowed_keys` is a privilege reduction, and reading the row
+/// live means the reduction binds the subject's **next** sign request — no
+/// session revocation, no waiting out an access-token TTL (the trap the
+/// VTC's `is_privilege_reduction` path exists to close for claims-borne
+/// authority).
+///
+/// A caller with **no ACL row** passes: the only callers that reach here
+/// without one are process-local synthesized identities (the offline CLI's
+/// `cli:<channel>` sentinel), whose trust boundary is the OS, and a row
+/// deleted mid-session — for whom this preserves today's behaviour exactly
+/// (`None` on every existing row is byte-identical, and absence of a row
+/// carries no `allowed_keys` to enforce). The decode goes through
+/// [`AclEntry::key_scope`], never a bare emptiness test: `Some(∅)` means
+/// authorized on **no** keys, the opposite of `None`.
+///
+/// [`KeyScope`]: vti_common::acl::KeyScope
+/// [`AclEntry::key_scope`]: vti_common::acl::AclEntry::key_scope
+async fn require_key_in_caller_scope(
+    acl_ks: &KeyspaceHandle,
+    auth: &AuthClaims,
+    key_id: &str,
+) -> Result<(), AppError> {
+    let Some(entry) = vti_common::acl::get_acl_entry(acl_ks, &auth.did).await? else {
+        return Ok(());
+    };
+    if entry.key_scope().allows(key_id) {
+        return Ok(());
+    }
+    Err(AppError::Forbidden(format!(
+        "signing key {key_id} is not in the caller's allowed keys"
+    )))
+}
+
 /// Sign a payload using a VTA-managed key.
 ///
 /// For derived keys, re-derives from BIP-32 seed. For imported keys,
@@ -818,6 +860,7 @@ pub async fn sign_payload(
     keys_ks: &KeyspaceHandle,
     imported_ks: &KeyspaceHandle,
     contexts_ks: &KeyspaceHandle,
+    acl_ks: &KeyspaceHandle,
     seed_store: &Arc<dyn SeedStore>,
     auth: &AuthClaims,
     key_id: &str,
@@ -838,6 +881,13 @@ pub async fn sign_payload(
 
     if let Some(ref ctx) = record.context_id {
         auth.require_context(ctx)?;
+        // Gate 4 (#818) — the caller's own ACL row may narrow which key ids
+        // it can invoke the oracle on. Runs strictly AFTER `require_context`,
+        // so a caller can never reach (or learn about) a key outside its
+        // contexts by naming it here — the filter intersects with the context
+        // scope, never widens it. Placed BEFORE the policy quota so a refused
+        // call burns none of the context's daily sign budget.
+        require_key_in_caller_scope(acl_ks, auth, key_id).await?;
         // Context policy is a resource-bound guardrail: it constrains the key's
         // context regardless of the actor — even the super-admin. This is what
         // lets a higher authority (e.g. a VTC/fleet-pushed policy) or the
@@ -855,10 +905,16 @@ pub async fn sign_payload(
         if let Some(limit) = policy.quota_for("sign") {
             crate::contexts::enforce_daily_quota(contexts_ks, ctx, "sign", limit).await?;
         }
-    } else if !auth.is_super_admin() {
-        return Err(AppError::Forbidden(
-            "only super admin can use unscoped keys".into(),
-        ));
+    } else {
+        if !auth.is_super_admin() {
+            return Err(AppError::Forbidden(
+                "only super admin can use unscoped keys".into(),
+            ));
+        }
+        // Gate 4 applies to unscoped keys too: the filter can only ever
+        // *narrow* whatever the context dimension allowed, and a super-admin
+        // whose entry names specific keys asked to be bound to them.
+        require_key_in_caller_scope(acl_ks, auth, key_id).await?;
     }
 
     let signature_bytes = match record.origin {
@@ -1158,6 +1214,7 @@ mod tests {
         contexts_ks: KeyspaceHandle,
         audit_ks: KeyspaceHandle,
         imported_ks: KeyspaceHandle,
+        acl_ks: KeyspaceHandle,
         seed_store: Arc<dyn SeedStore>,
         _dir: tempfile::TempDir,
     }
@@ -1174,6 +1231,7 @@ mod tests {
             let contexts_ks = store.keyspace(crate::keyspaces::CONTEXTS).unwrap();
             let audit_ks = store.keyspace(crate::keyspaces::AUDIT).unwrap();
             let imported_ks = store.keyspace(crate::keyspaces::IMPORTED_SECRETS).unwrap();
+            let acl_ks = store.keyspace(crate::keyspaces::ACL).unwrap();
 
             // 32-byte seed; will be expanded to 64 bytes by BIP-32 internally
             let seed_store: Arc<dyn SeedStore> =
@@ -1189,6 +1247,7 @@ mod tests {
                 contexts_ks,
                 audit_ks,
                 imported_ks,
+                acl_ks,
                 seed_store,
                 _dir: dir,
             }
@@ -1520,6 +1579,7 @@ mod tests {
             &h.keys_ks,
             &h.imported_ks,
             &h.contexts_ks,
+            &h.acl_ks,
             &h.seed_store,
             &auth,
             &key.key_id,
@@ -1761,6 +1821,7 @@ mod tests {
             &h.keys_ks,
             &h.imported_ks,
             &h.contexts_ks,
+            &h.acl_ks,
             &h.seed_store,
             &scoped,
             &key.key_id,
@@ -1780,6 +1841,7 @@ mod tests {
             &h.keys_ks,
             &h.imported_ks,
             &h.contexts_ks,
+            &h.acl_ks,
             &h.seed_store,
             &admin,
             &key.key_id,
@@ -1816,6 +1878,7 @@ mod tests {
             &h.keys_ks,
             &h.imported_ks,
             &h.contexts_ks,
+            &h.acl_ks,
             &h.seed_store,
             &scoped,
             &allowed.key_id,
@@ -1825,6 +1888,248 @@ mod tests {
         )
         .await
         .expect("policy permits allowed-key");
+    }
+
+    /// Gate 4 (#818): the caller's own ACL row may narrow which key ids it
+    /// can invoke the oracle on — the actor-scoped complement of the
+    /// resource-bound `signable_keys` policy pinned above.
+    #[tokio::test]
+    async fn sign_payload_honours_acl_allowed_keys() {
+        use vti_common::acl::{AclEntry, store_acl_entry};
+
+        let h = TestHarness::new().await;
+        let admin = h.super_admin_auth();
+
+        // Two keys in the same context — the split gate 4 exists to express.
+        for id in ["tenant-key-a", "tenant-key-b"] {
+            create_key(
+                &h.keys_ks,
+                &h.contexts_ks,
+                &h.seed_store,
+                &h.audit_ks,
+                &admin,
+                CreateKeyParams {
+                    key_type: KeyType::Ed25519,
+                    derivation_path: None,
+                    key_id: Some(id.into()),
+                    mnemonic: None,
+                    label: None,
+                    context_id: Some("test-ctx".into()),
+                },
+                "test",
+            )
+            .await
+            .expect("create key");
+        }
+
+        let caller_did = "did:key:z6MkFilteredSigner";
+        let claims = AuthClaims {
+            did: caller_did.to_string(),
+            role: Role::Application,
+            allowed_contexts: vec!["test-ctx".to_string()],
+            session_id: "test-session".into(),
+            access_expires_at: 0,
+            amr: Vec::new(),
+            acr: String::new(),
+        };
+        let sign = |key_id: &'static str| {
+            let claims = claims.clone();
+            let h = &h;
+            async move {
+                sign_payload(
+                    &h.keys_ks,
+                    &h.imported_ks,
+                    &h.contexts_ks,
+                    &h.acl_ks,
+                    &h.seed_store,
+                    &claims,
+                    key_id,
+                    b"payload",
+                    &SignAlgorithm::EdDSA,
+                    "test",
+                )
+                .await
+            }
+        };
+
+        // No ACL filter (`allowed_keys: None`): every key in scope — the
+        // pre-#818 behaviour, byte-identical.
+        let entry = AclEntry::new(caller_did, Role::Application, "did:key:zSetup")
+            .with_contexts(vec!["test-ctx".into()]);
+        store_acl_entry(&h.acl_ks, &entry).await.unwrap();
+        sign("tenant-key-a").await.expect("no filter: key-a signs");
+        sign("tenant-key-b").await.expect("no filter: key-b signs");
+
+        // A filter naming exactly key-a: key-b is refused, key-a still signs.
+        // The narrowing bound the very next request — same claims, same live
+        // "session", no revocation step in between (the gate reads the row).
+        store_acl_entry(
+            &h.acl_ks,
+            &entry
+                .clone()
+                .with_allowed_keys(Some(["tenant-key-a".to_string()].into_iter().collect())),
+        )
+        .await
+        .unwrap();
+        sign("tenant-key-a").await.expect("filter names key-a");
+        let denied = sign("tenant-key-b").await;
+        assert!(
+            matches!(denied, Err(crate::error::AppError::Forbidden(_))),
+            "a key outside the caller's allowed_keys must be Forbidden, got {denied:?}"
+        );
+
+        // Trap 1: PRESENT-BUT-EMPTY is authorized on NO keys — the narrowest
+        // grant, never a wildcard. If a bare `is_empty()` ever sneaks into
+        // the gate, this is the assertion that catches it.
+        store_acl_entry(
+            &h.acl_ks,
+            &entry.clone().with_allowed_keys(Some(Default::default())),
+        )
+        .await
+        .unwrap();
+        for key in ["tenant-key-a", "tenant-key-b"] {
+            let denied = sign(key).await;
+            assert!(
+                matches!(denied, Err(crate::error::AppError::Forbidden(_))),
+                "an EMPTY allowed_keys must refuse every key (got {denied:?} for {key})"
+            );
+        }
+    }
+
+    /// Gate 4 intersects — it never widens. A filter naming a key outside the
+    /// caller's contexts does not grant it: the context gate still runs
+    /// first, so the caller is refused before its key filter is even asked.
+    /// And the filter binds the unscoped-key path too: a super-admin whose
+    /// entry names specific keys asked to be bound to them.
+    #[tokio::test]
+    async fn sign_payload_allowed_keys_only_narrows_never_widens() {
+        use crate::contexts::{ContextRecord, store_context};
+        use vta_sdk::context_policy::ContextPolicy;
+        use vti_common::acl::{AclEntry, store_acl_entry};
+
+        let h = TestHarness::new().await;
+        let admin = h.super_admin_auth();
+
+        // A key in a context the caller does NOT hold.
+        let now = chrono::Utc::now();
+        store_context(
+            &h.contexts_ks,
+            &ContextRecord {
+                id: "other-ctx".into(),
+                name: "other".into(),
+                did: None,
+                description: None,
+                parent: None,
+                base_path: "m/26'/2'/31'".into(),
+                index: 31,
+                created_at: now,
+                updated_at: now,
+                context_policy: Some(ContextPolicy::unrestricted()),
+            },
+        )
+        .await
+        .unwrap();
+        let foreign = create_key(
+            &h.keys_ks,
+            &h.contexts_ks,
+            &h.seed_store,
+            &h.audit_ks,
+            &admin,
+            CreateKeyParams {
+                key_type: KeyType::Ed25519,
+                derivation_path: None,
+                key_id: Some("foreign-key".into()),
+                mnemonic: None,
+                label: None,
+                context_id: Some("other-ctx".into()),
+            },
+            "test",
+        )
+        .await
+        .unwrap();
+
+        // The caller's entry NAMES the foreign key — and must still be
+        // refused, because the filter intersects with the context scope.
+        let caller_did = "did:key:z6MkOverreach";
+        store_acl_entry(
+            &h.acl_ks,
+            &AclEntry::new(caller_did, Role::Application, "did:key:zSetup")
+                .with_contexts(vec!["test-ctx".into()])
+                .with_allowed_keys(Some(["foreign-key".to_string()].into_iter().collect())),
+        )
+        .await
+        .unwrap();
+        let claims = AuthClaims {
+            did: caller_did.to_string(),
+            role: Role::Application,
+            allowed_contexts: vec!["test-ctx".to_string()],
+            session_id: "test-session".into(),
+            access_expires_at: 0,
+            amr: Vec::new(),
+            acr: String::new(),
+        };
+        let denied = sign_payload(
+            &h.keys_ks,
+            &h.imported_ks,
+            &h.contexts_ks,
+            &h.acl_ks,
+            &h.seed_store,
+            &claims,
+            &foreign.key_id,
+            b"payload",
+            &SignAlgorithm::EdDSA,
+            "test",
+        )
+        .await;
+        assert!(
+            matches!(denied, Err(crate::error::AppError::Forbidden(_))),
+            "naming a key in allowed_keys must not reach past the context scope, got {denied:?}"
+        );
+
+        // Unscoped keys are gated too: a super-admin whose own row carries a
+        // filter is bound by it even where no context policy exists.
+        let unscoped = create_key(
+            &h.keys_ks,
+            &h.contexts_ks,
+            &h.seed_store,
+            &h.audit_ks,
+            &admin,
+            CreateKeyParams {
+                key_type: KeyType::Ed25519,
+                derivation_path: Some("m/26'/2'/77'/0'".into()),
+                key_id: Some("unscoped-key".into()),
+                mnemonic: None,
+                label: None,
+                context_id: None,
+            },
+            "test",
+        )
+        .await
+        .unwrap();
+        store_acl_entry(
+            &h.acl_ks,
+            &AclEntry::new(&admin.did, Role::Admin, "did:key:zSetup")
+                .with_allowed_keys(Some(["some-other-key".to_string()].into_iter().collect())),
+        )
+        .await
+        .unwrap();
+        let denied = sign_payload(
+            &h.keys_ks,
+            &h.imported_ks,
+            &h.contexts_ks,
+            &h.acl_ks,
+            &h.seed_store,
+            &admin,
+            &unscoped.key_id,
+            b"payload",
+            &SignAlgorithm::EdDSA,
+            "test",
+        )
+        .await;
+        assert!(
+            matches!(denied, Err(crate::error::AppError::Forbidden(_))),
+            "a filtered super-admin is bound on unscoped keys too, got {denied:?}"
+        );
     }
 
     /// A caller authorized in one context cannot sign with another context's
@@ -1838,9 +2143,11 @@ mod tests {
     /// could name — and nothing about the request would look wrong.
     ///
     /// Note the granularity being pinned: **per context, not per key id**. A
-    /// caller scoped to a context may sign with *every* key in it. Per-key
-    /// narrowing exists (`signable_keys`, covered above) but is opt-in policy;
-    /// separation between domains comes from giving each its own context.
+    /// caller scoped to a context may sign with *every* key in it by default.
+    /// Per-key narrowing exists in two opt-in forms — the resource-bound
+    /// `signable_keys` policy and the actor-scoped `allowed_keys` ACL filter
+    /// (#818), each covered above; separation between domains still comes
+    /// from giving each its own context.
     #[tokio::test]
     async fn sign_payload_refuses_a_key_outside_the_callers_contexts() {
         use crate::contexts::{ContextRecord, store_context};
@@ -1907,6 +2214,7 @@ mod tests {
             &h.keys_ks,
             &h.imported_ks,
             &h.contexts_ks,
+            &h.acl_ks,
             &h.seed_store,
             &other_tenant,
             &key.key_id,
@@ -1944,6 +2252,7 @@ mod tests {
             &h.keys_ks,
             &h.imported_ks,
             &h.contexts_ks,
+            &h.acl_ks,
             &h.seed_store,
             &other_tenant,
             &own.key_id,
@@ -2005,6 +2314,7 @@ mod tests {
             &h.keys_ks,
             &h.imported_ks,
             &h.contexts_ks,
+            &h.acl_ks,
             &h.seed_store,
             &scoped,
             &key.key_id,
@@ -2022,6 +2332,7 @@ mod tests {
             &h.keys_ks,
             &h.imported_ks,
             &h.contexts_ks,
+            &h.acl_ks,
             &h.seed_store,
             &admin,
             &key.key_id,

--- a/vta-service/src/operations/provision_integration/mod.rs
+++ b/vta-service/src/operations/provision_integration/mod.rs
@@ -631,6 +631,7 @@ pub async fn provision_integration(
         None,
         None,
         crate::acl::ApproveScope::None,
+        None,
         "provision-integration",
     )
     .await
@@ -902,6 +903,7 @@ async fn provision_admin_rotation(
         None,
         None,
         crate::acl::ApproveScope::None,
+        None,
         "provision-integration",
     )
     .await

--- a/vta-service/src/routes/acl.rs
+++ b/vta-service/src/routes/acl.rs
@@ -150,6 +150,25 @@ pub struct UpdateAclRequest {
     /// "leave it alone", and revoking is the case that matters most.
     #[serde(default)]
     pub approve_scope: Option<ApproveScope>,
+    /// Replace the signing-oracle key filter (#818). Omitted leaves it
+    /// unchanged; explicit `null` clears it (privilege increase); an array
+    /// sets it to exactly those ids — **the empty array means no keys at
+    /// all**, never a wildcard. Wire name pinned to the canonical
+    /// `allowedKeys` (the SDK's `UpdateAclRequest` serializes the same).
+    #[serde(rename = "allowedKeys", default, deserialize_with = "double_option")]
+    pub allowed_keys: Option<Option<Vec<String>>>,
+}
+
+/// Absent vs explicit-null, distinguishably: absent → `None` (leave alone),
+/// `null` → `Some(None)` (clear), value → `Some(Some(v))`. A plain
+/// `Option<Option<T>>` folds `null` into the outer `None` and loses the
+/// clearing intent.
+fn double_option<'de, T, D>(de: D) -> Result<Option<Option<T>>, D::Error>
+where
+    T: serde::Deserialize<'de>,
+    D: serde::Deserializer<'de>,
+{
+    serde::Deserialize::deserialize(de).map(Some)
 }
 
 /// PATCH /acl/{did} — update label, contexts, step-up or approve authority on
@@ -203,6 +222,9 @@ pub async fn update_acl(
             step_up_approver: req.step_up_approver,
             step_up_require: req.step_up_require,
             approve_scope: req.approve_scope,
+            allowed_keys: req
+                .allowed_keys
+                .map(|r| r.map(|keys| keys.into_iter().collect())),
         },
         "rest",
     )

--- a/vta-service/src/routes/keys.rs
+++ b/vta-service/src/routes/keys.rs
@@ -315,6 +315,7 @@ pub async fn sign_with_key(
         &state.keys_ks,
         &state.imported_ks,
         &state.contexts_ks,
+        &state.acl_ks,
         &state.seed_store,
         &auth,
         &key_id,

--- a/vta-service/src/trust_tasks/acl.rs
+++ b/vta-service/src/trust_tasks/acl.rs
@@ -129,6 +129,9 @@ pub(super) async fn handle_update(
             step_up_approver: req.step_up_approver,
             step_up_require: req.step_up_require,
             approve_scope: req.approve_scope,
+            allowed_keys: req
+                .allowed_keys
+                .map(|r| r.map(|keys| keys.into_iter().collect())),
         },
         TRANSPORT_TRUST_TASK,
     )
@@ -344,6 +347,7 @@ mod tests {
             step_up_approver: None,
             step_up_require: None,
             approve_scope: None,
+            allowed_keys: None,
         })
         .expect("serialize");
         assert!(

--- a/vta-service/src/trust_tasks/keys.rs
+++ b/vta-service/src/trust_tasks/keys.rs
@@ -200,6 +200,7 @@ pub(super) async fn handle_sign(
         &state.keys_ks,
         &state.imported_ks,
         &state.contexts_ks,
+        &state.acl_ks,
         &state.seed_store,
         auth,
         &req.key_id,

--- a/vta-service/tests/client_round_trip.rs
+++ b/vta-service/tests/client_round_trip.rs
@@ -116,6 +116,7 @@ async fn acl_lifecycle_round_trips_through_the_real_client() {
                 step_up_approver: None,
                 step_up_require: None,
                 approve_scope: None,
+                allowed_keys: None,
             },
         )
         .await
@@ -677,6 +678,7 @@ async fn acl_change_role_compare_and_swaps() {
                 step_up_approver: None,
                 step_up_require: None,
                 approve_scope: None,
+                allowed_keys: None,
             },
         )
         .await

--- a/vti-common/Cargo.toml
+++ b/vti-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-common"
 description = "Shared server-side infrastructure for VTA and VTC services"
 readme = "README.md"
-version = "0.11.29"
+version = "0.11.30"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vti-common/src/acl/mod.rs
+++ b/vti-common/src/acl/mod.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::fmt;
 
 use serde::{Deserialize, Serialize};
@@ -296,6 +297,67 @@ pub fn act_scope_for(role: &Role, allowed_contexts: &[String]) -> ActScope {
     }
 }
 
+/// An entry's authority over **signing-oracle key ids** — the effective
+/// decision decoded from the stored `allowed_keys` member (#818).
+///
+/// This is the actor-scoped complement of `ContextPolicy.signable_keys`
+/// (which is resource-bound and constrains every actor uniformly): it narrows
+/// which keys *this caller* may invoke the signing oracle on, and it only
+/// ever **intersects** with the context scope — a key named in the filter
+/// that lies outside the entry's contexts stays unreachable.
+///
+/// Exists for the same reason [`ActScope`] does: `Option<BTreeSet<String>>`
+/// has an empty-vs-absent distinction that a bare `is_empty()` gets
+/// backwards (see `docs/05-design-notes/acl-scope-semantics.md`). Decode once
+/// through [`key_scope_for`] / [`AclEntry::key_scope`], then ask
+/// [`KeyScope::allows`] — never test emptiness at a call site.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KeyScope {
+    /// No per-key filter: every key the entry's context scope reaches.
+    /// This is the decode of an **absent** (`None`) `allowed_keys` — the
+    /// behaviour of every entry that pre-dates the member.
+    AllInScope,
+    /// Exactly these key ids (still intersected with the context scope).
+    /// The decode of a **present** `allowed_keys`, *including the empty
+    /// set*: `Some([])` authorizes **no** keys — the narrowest grant, the
+    /// opposite of absent, and deliberately not a wildcard.
+    Keys(BTreeSet<String>),
+}
+
+impl KeyScope {
+    /// May this scope invoke the signing oracle on `key_id`?
+    ///
+    /// `AllInScope` defers entirely to the context gates that ran before it;
+    /// `Keys` is exact membership. `Keys(∅)` therefore allows nothing, which
+    /// is the point — the empty filter can never read as unrestricted.
+    pub fn allows(&self, key_id: &str) -> bool {
+        match self {
+            KeyScope::AllInScope => true,
+            KeyScope::Keys(keys) => keys.contains(key_id),
+        }
+    }
+}
+
+/// Decode a stored `allowed_keys` member into an explicit [`KeyScope`].
+///
+/// This is the one and only interpretation of the member:
+///
+/// | `allowed_keys` | scope |
+/// |---|---|
+/// | `None` | [`KeyScope::AllInScope`] — every key in the entry's contexts |
+/// | `Some(keys)` (even empty) | [`KeyScope::Keys`] — exactly those ids |
+///
+/// **Call this (or [`AclEntry::key_scope`]) instead of testing
+/// `allowed_keys` emptiness.** `Some(∅)` means *authorized on no keys*, not
+/// "unrestricted"; a call site that collapses the two re-creates the
+/// empty-means-unrestricted defect class (#746, #769, #770).
+pub fn key_scope_for(allowed_keys: Option<&BTreeSet<String>>) -> KeyScope {
+    match allowed_keys {
+        None => KeyScope::AllInScope,
+        Some(keys) => KeyScope::Keys(keys.clone()),
+    }
+}
+
 /// Validate that `caller` may grant `scope` on an ACL entry.
 ///
 /// Mirrors [`validate_acl_modification`]'s context rule: `All` is a
@@ -408,6 +470,16 @@ pub struct AclEntry {
     /// ⇒ pre-existing rows deserialise as [`ApproveScope::None`].
     #[serde(default)]
     pub approve_scope: ApproveScope,
+    /// Key ids this entry may invoke the signing oracle on (#818). `None` =
+    /// every key in `allowed_contexts` (today's behaviour; pre-existing rows
+    /// deserialise here). **`Some(∅)` = authorized on no keys** — the
+    /// narrowest grant, never a wildcard. Intersects with the context scope;
+    /// it can only narrow, never widen, so an entry naming a key outside its
+    /// contexts still cannot use it. Read through [`AclEntry::key_scope`],
+    /// never by testing emptiness — see [`KeyScope`]. Mirrors the canonical
+    /// `acl/_shared/0.1/acl-entry#allowedKeys`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub allowed_keys: Option<BTreeSet<String>>,
 }
 
 impl AclEntry {
@@ -435,6 +507,7 @@ impl AclEntry {
             step_up_approver: None,
             step_up_require: None,
             approve_scope: ApproveScope::None,
+            allowed_keys: None,
         }
     }
 
@@ -498,6 +571,21 @@ impl AclEntry {
     pub fn with_approve_scope(mut self, approve_scope: ApproveScope) -> Self {
         self.approve_scope = approve_scope;
         self
+    }
+
+    /// Set the signing-oracle key filter. `None` = no filter (every key in
+    /// the entry's contexts); `Some(∅)` = **no** keys at all.
+    pub fn with_allowed_keys(mut self, allowed_keys: Option<BTreeSet<String>>) -> Self {
+        self.allowed_keys = allowed_keys;
+        self
+    }
+
+    /// This entry's authority over signing-oracle key ids, decoded from
+    /// `allowed_keys`. Use this rather than reading the `Option` directly —
+    /// see [`KeyScope`] for why (`Some(∅)` and `None` are opposite grants,
+    /// and a bare emptiness test collapses them).
+    pub fn key_scope(&self) -> KeyScope {
+        key_scope_for(self.allowed_keys.as_ref())
     }
 
     /// Whether this entry is an admin (`Role::Admin`).
@@ -1317,6 +1405,75 @@ mod tests {
             let s = format!("{role}");
             assert_eq!(Role::parse(&s).unwrap(), role, "display->parse cycle");
         }
+    }
+
+    // ── KeyScope (#818): allowed_keys decode ────────────────────────
+
+    /// The trap the `ActScope` precedent exists for, restated on the key
+    /// axis: `None` and `Some(∅)` are opposite grants and must decode to
+    /// different scopes.
+    #[test]
+    fn key_scope_none_is_unrestricted_and_empty_set_allows_nothing() {
+        let unfiltered = sample_entry("did:key:zA", Role::Application);
+        assert_eq!(unfiltered.key_scope(), KeyScope::AllInScope);
+        assert!(unfiltered.key_scope().allows("any-key"));
+
+        let no_keys =
+            sample_entry("did:key:zB", Role::Application).with_allowed_keys(Some(BTreeSet::new()));
+        assert_eq!(no_keys.key_scope(), KeyScope::Keys(BTreeSet::new()));
+        assert!(
+            !no_keys.key_scope().allows("any-key"),
+            "an empty filter authorizes NO keys — it is never a wildcard"
+        );
+    }
+
+    #[test]
+    fn key_scope_filters_by_exact_key_id() {
+        let entry = sample_entry("did:key:zA", Role::Application)
+            .with_allowed_keys(Some(["key-1".to_string()].into_iter().collect()));
+        assert!(entry.key_scope().allows("key-1"));
+        assert!(!entry.key_scope().allows("key-2"));
+        assert!(
+            !entry.key_scope().allows("key-1x"),
+            "exact match, not prefix"
+        );
+    }
+
+    /// A row serialized before `allowed_keys` existed must deserialise as
+    /// `None` (no filter), preserving behaviour byte-identically — the same
+    /// contract every other additive ACL member honours.
+    #[test]
+    fn legacy_row_without_allowed_keys_deserialises_to_none() {
+        let legacy = serde_json::json!({
+            "did": "did:key:zOld",
+            "role": "application",
+            "label": null,
+            "allowed_contexts": ["ctx-a"],
+            "created_at": 0,
+            "created_by": "did:key:zSetup"
+        });
+        let entry: AclEntry = serde_json::from_value(legacy).unwrap();
+        assert!(entry.allowed_keys.is_none());
+        assert_eq!(entry.key_scope(), KeyScope::AllInScope);
+    }
+
+    /// `Some(∅)` must survive a store round-trip as `Some(∅)` — if
+    /// serialization dropped the empty set, the narrowest grant would come
+    /// back as the widest.
+    #[test]
+    fn empty_allowed_keys_survives_serde_round_trip() {
+        let entry =
+            sample_entry("did:key:zA", Role::Application).with_allowed_keys(Some(BTreeSet::new()));
+        let json = serde_json::to_string(&entry).unwrap();
+        assert!(json.contains("\"allowed_keys\":[]"), "{json}");
+        let back: AclEntry = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.allowed_keys, Some(BTreeSet::new()));
+        assert!(!back.key_scope().allows("k"));
+
+        // And absence stays absent: no filter is not serialized at all.
+        let unfiltered = sample_entry("did:key:zB", Role::Application);
+        let json = serde_json::to_string(&unfiltered).unwrap();
+        assert!(!json.contains("allowed_keys"), "{json}");
     }
 
     // ── Expiration ──────────────────────────────────────────────────


### PR DESCRIPTION
Closes #818

Spec sibling: trustoverip/dtgwg-trust-tasks-tf#164 (`AclEntry.allowedKeys` on the canonical `acl/_shared/0.1/acl-entry` component + `acl/update/0.1` prose).

## The gap

The **resource** dimension of an ACL grant was expressible only as a *context*. `Capability::Sign` is unparameterized, so "this caller may invoke the signing oracle on exactly key K" could not be said — the only spelling was giving K a context of its own, forcing context topology to encode per-key authorization. `ContextPolicy.signable_keys` is not the answer: it is **resource-bound by design** (it constrains the key's context for *every* actor, super-admin included — the property that lets a VTC- or fleet-pushed policy bind every signer). This adds the actor-scoped half; the two are complementary.

## The field (`vti-common`)

```rust
pub allowed_keys: Option<BTreeSet<String>>,   // #[serde(default, skip_serializing_if = "Option::is_none")]
```

The effective decision is **never** read off the raw `Option`. It decodes once through `key_scope_for` / `AclEntry::key_scope()` into

```rust
enum KeyScope { AllInScope, Keys(BTreeSet<String>) }   // ask KeyScope::allows(key_id)
```

— the same shape `ActScope` gave the context axis. `None` → `AllInScope` (every key the entry's contexts reach); `Some(set)` → `Keys(set)` **including the empty set**, which authorizes no keys. That is issue trap 1: `docs/05-design-notes/acl-scope-semantics.md` records three defects (#746, #770, #769) from testing `allowed_contexts.is_empty()` at a call site, and this member has the same empty-vs-absent hazard. There is no `is_empty()` on the key axis anywhere in the diff.

Additive and fail-closed: `#[serde(default)]` means every existing row deserialises to `None` and behaves byte-identically.

## The gate (`vta-service`)

Gate 4 in `operations::keys::sign_payload`, placed deliberately:

- **After `auth.require_context(ctx)`** — as the issue specifies. The filter intersects with the context scope and can only narrow, so a caller naming a key outside its contexts is refused by gate 1 before its own filter is even consulted. Pinned by `sign_payload_allowed_keys_only_narrows_never_widens`.
- **Before the policy quota** — a refused call burns none of the context's daily sign budget.
- **On the unscoped-key path too** — a super-admin whose row carries a filter asked to be bound by it.

All three transports (REST, DIDComm `key-management/1.0/sign-request`, `keys/sign` Trust Task) funnel through this one function, so this is one edit, not three. `sign_payload` gains an `acl_ks` parameter; the three call sites are updated.

The gate reads the **stored ACL row**, not the JWT. That is deliberate and is also the answer to **trap 3** (see below): narrowing an entry's filter binds the subject's *next* sign request, with no session revocation and no access-token-TTL window.

## Wire plumbing (`vta-sdk` + handlers) — trap 2

`CreateAclBody` is the exact struct family where a camelCase/snake_case mismatch once let an empty `allowed_contexts` silently mint a super-admin (#656/#658), so the spelling is pinned by tests at every layer:

- canonical wire `AclEntry.allowedKeys: Option<Vec<String>>`, skipped on **`is_none`, never `is_empty`** — `"allowedKeys": []` must survive the wire or the narrowest grant becomes the widest (`allowed_keys_empty_and_absent_both_survive_the_wire`);
- `UpdateAclBody.allowed_keys: Option<Option<Vec<String>>>` with a `double_option` deserializer and `rename = "allowedKeys"`, so **omitted / explicit `null` / array** stay three distinct intentions (`allowed_keys_round_trips_as_camel_case`, `allowed_keys_distinguishes_absent_null_and_empty`, `allowed_keys_clear_serializes_as_explicit_null`);
- same three-way shape on the REST `PATCH /acl/{did}` body and on `vta_sdk::client::UpdateAclRequest` (`test_update_acl_request_allowed_keys_three_intentions`).

Wired through REST `POST /acl` + `PATCH /acl/{did}`, DIDComm `create-acl`/`update-acl`, the `acl/grant` + `acl/update` Trust Tasks, `CreateAclRequest::allowed_keys(..)`, and every grant/show/list/update echo. Empty-string key ids are refused at create and update (the `--contexts ''` lesson one axis over).

## CLI + docs

- `pnm|cnm acl create --allowed-keys <ids>`;
- `pnm|cnm acl update --allowed-keys <ids>` or `--allowed-keys-unrestricted` to remove the filter. Clearing gets its own flag for the same reason `--approve-none` does: an empty `--allowed-keys` cannot mean both "no keys at all" and "no filter".
- Displays render the empty filter as `(none — may invoke the signing oracle on no keys)`, never blank and never "unrestricted" — the #746 lesson.
- `docs/02-vta/integration-guide.md` §"What authorizes a sign request" is now **four** gates, and the per-context granularity callout points at `--allowed-keys` for the one-key-out-of-a-shared-context case.

## Trap 3 — revocation semantics (a finding, not a code change)

`is_privilege_reduction` does **not** need to account for `allowedKeys`:

- it lives in `vtc-service/src/routes/acl.rs` and is VTC-only; the VTC runs no signing oracle and `VtcAclEntry` has no `allowed_keys` to narrow;
- its purpose is to revoke sessions when authority that rides in the **JWT claims** (role, contexts) shrinks. `allowed_keys` never enters the claims — gate 4 reads the stored row on every request, so a narrowing is effective immediately. That is strictly stronger than session revocation, and it avoids logging every subject out over a per-key tweak.

Worth a reviewer's confirmation, since the alternative (mirroring the field into claims and revoking on narrowing) is defensible but buys nothing here.

## Validation

```
cargo test -p vta-service      → 719 + 120 + 64 + … all suites ok, 0 failed
cargo test -p vti-common       → ok (incl. 4 new KeyScope / serde tests)
cargo test -p vta-sdk          → 376 + 359 + … ok (incl. 4 new wire tests)
cargo test -p vta-cli-common   → ok (incl. 2 new display/flag tests)
cargo clippy -p vti-common -p vta-sdk -p vta-service -p vta-cli-common -p pnm-cli -p cnm-cli --all-targets → 0 errors, 0 warnings
cargo check --workspace --all-targets → clean
cargo fmt --all → clean
```

New tests: `sign_payload_honours_acl_allowed_keys`, `sign_payload_allowed_keys_only_narrows_never_widens`, `update_acl_sets_empties_and_clears_the_key_filter`, `key_scope_*`, `legacy_row_without_allowed_keys_deserialises_to_none`, `empty_allowed_keys_survives_serde_round_trip`, plus the wire/casing tests listed above.

## Release housekeeping

`vti-common` 0.11.30, `vta-sdk` 0.20.17, **`vta-service` 0.13.10** (0.13.9 is claimed by the in-flight #858), `vta-cli-common` 0.10.21, `pnm-cli` 0.11.15, `cnm-cli` 0.11.12, with a root `CHANGELOG.md` entry under Unreleased.

## Coordination

A sibling stream is fixing **#856** (`UpdateAclBody` canonical field renames) in these same `acl_management` files. This branch is based on `origin/main` as-is and its diff is deliberately additive — **a small rebase against the #856 fix is expected**. The one member this PR adds is already spelled canonically (`allowedKeys`), so it should survive that rename untouched.

## Reviewer checklist

- [ ] Gate 4 sits after `require_context` and cannot widen — confirm `sign_payload_allowed_keys_only_narrows_never_widens` pins what you'd expect.
- [ ] No bare `is_empty()` on the key axis; `Some(∅)` really does refuse every key (`sign_payload_honours_acl_allowed_keys`, final block).
- [ ] The three-way update semantics (omitted / `null` / `[]`) are right for a maintainer's mental model, and the wire casing is pinned everywhere it is carried.
- [ ] The trap-3 finding — leaving `is_privilege_reduction` alone because the gate reads the live row — is the call you'd make.
- [ ] Reading the ACL row on every sign request is acceptable overhead (one keyspace get, same store already hit for the key record).
