### PR TITLE
chore(deps): trust-tasks-rs 0.2.51, messaging SDK 0.18.65 + mediator 0.17.13, acl_set → account_update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,106 @@
 
 ## Unreleased
 
+### vta-sdk 0.20.25 / vta-service 0.13.16 / vtc-service 0.11.44 — trust-tasks-rs 0.2.51, messaging SDK 0.18.65, `acl_set` → `account_update`
+
+Picks up the consolidation programme's published registry output and sweeps the
+consumer breaks it forces. The four bumps are one chain, not four choices
+(#854):
+
+- **`trust-tasks-rs` 0.2.43 → 0.2.51** (workspace `Cargo.toml`) — every spec
+  change from this programme, including `vtc/join-requests/decide/0.1`, the
+  merged `vta/did-templates/*/2.0` family, the rationalized `messaging/*`
+  family, and (at 0.2.51 specifically) `allowedKeys` on
+  `acl/_shared/0.1/acl-entry` + `acl/update/0.1`. **0.2.50 was the intended
+  target and is not sufficient** — registry PR #164 published `allowedKeys`
+  one release later, and 0.2.50 → 0.2.51 changes nothing else in the
+  workspace's view: identical URI index, identical module set, three
+  `allowed_keys: None` additions in the crate's own fixtures.
+- **`affinidi-messaging-sdk` 0.18.62 → 0.18.65** — forced, not optional.
+  0.18.62 does **not** compile against 0.2.50: it builds
+  `messaging::account::list::v0_1::Payload` and
+  `messaging::access_list::list::v0_1::Payload` with struct-literal syntax, and
+  both payloads gained optional filter members. Additive to the JSON Schema and
+  wire-compatible, but **source-breaking for struct literals** — a generated
+  `struct` with no `#[non_exhaustive]` and no builder makes every new optional
+  field a compile error in any crate that constructs it positionally. Worth
+  knowing when judging what a "patch" bump of the generated bindings can do:
+  schema-additive is not source-additive for downstream literal constructors
+  (`..Default::default()` at the construction site is the cheap immunisation).
+- **`vta-sdk/src/acl_setup.rs` migrated off `acl_set`** — the messaging family's
+  clean cutover (affinidi/affinidi-tdk-rs#668) removed
+  `TrustTasksOps::acl_set` outright. The replacement is
+  `account_update(profile, did_hash, account_type, acl, queue_limits)` on
+  `messaging/account/update/0.1`, which carries `acl` as one optional member
+  beside `accountType`/`queueLimits`; passing `None` for the other two makes it
+  the same ACL-only partial update. `build_allow_all_acl` now returns
+  `account::update::v0_1::MediatorAcl` (identical field set). Behaviour,
+  fire-and-forget semantics and the deliberate debug-not-warn on timeout are
+  unchanged. No other retired-URI call site exists in the workspace.
+- **`affinidi-messaging-mediator` 0.17.10 → 0.17.13 and
+  `affinidi-messaging-test-mediator` 0.2.40 → 0.2.43** — the fourth link, and
+  the one that is easy to miss because it is a *dev*-dependency. The messaging
+  cutover is clean on **both** ends: 0.17.10 serves `messaging/acl/set` and
+  answers `messaging/account/update/0.1` with `501 Not Implemented`
+  (`unsupported Trust Task type`), so the moment the SDK moves the client side,
+  the embedded test mediator can no longer provision an ACL at all — the client
+  never gets `receive_forwarded` and every forwarded round-trip is refused. The
+  server half of the cutover ships in mediator 0.17.13. Worth stating plainly
+  for deployments: **a mediator older than 0.17.13 cannot serve a VTA built on
+  messaging SDK 0.18.65.** There is no dual-accept window on either side.
+
+Publish-lag debt flushed by the bump — the shrink-only exception assertions
+fail until it is, which is the harness working as designed:
+
+- `vta-service/src/trust_tasks/mod.rs`: the six `vta/did-templates/*/2.0`
+  entries leave `UNSPECCED_DISPATCHED_URIS` (#851 authored them upstream as
+  trust-tasks-tf#162; 0.2.49 indexed them), putting the list back at 56.
+- `vtc-service/tests/trust_task_manifest.rs`: the `vtc/join-requests/decide/`
+  entry leaves `UNPUBLISHED_CANONICAL_OK` (the spec it was waiting on ships in
+  0.2.47). The `spec/vta/` count of 44 and the remaining 56 unspecced URIs are
+  unaffected — the bump publishes nothing else that would shrink them, so those
+  remain genuine unspecced surface rather than lag.
+- `docs/05-design-notes/registry-drift-triage.md` gains the rule that produced
+  this sweep: a publish-lag entry is debt with an expiry date, so every
+  `trust-tasks-rs` bump is also an exception-list sweep.
+
+**Reconciliation with the conformance sweep (#866).** Indexing the six
+`vta/did-templates/*/2.0` URIs puts them back inside the sweep's *derived*
+census, and its coverage assertion then demands a witness for each — exactly
+the hand-off #866 left in a comment where the twelve 1.0 witnesses used to be.
+All six are now `checked!` entries built from the slice's real wire types
+(`vta_sdk::protocols::did_template_management`), and all six conform on the
+first run — no `KnownDrift` was needed:
+
+- `list` / `create` / `get` / `update` / `delete` / `render`, each carrying the
+  **context** form of the request (the richer of the two scopes) and the
+  response the handler actually emits — `DidTemplateRecord` for `create`,
+  `get` and `update`, `{templates}` / `{name, deleted}` / `{document}` for the
+  rest.
+- The family's whole point is that scope moved out of the slug hierarchy into
+  one **optional** `contextId` (#851), and a witness can only carry one of the
+  two scopes. So the global form of all six requests is asserted alongside the
+  table: `contextId` omitted must still parse as the published `Payload`.
+  Otherwise "optional" would be the one thing about this family the sweep
+  never checks.
+
+**`allowedKeys` (#818) enters the witnesses.** #866 left it absent in three
+places — `conformance::acl_entry()`, the `acl/update` conformance sample, and
+`trust_tasks::acl::tests::update_body()` — each with a comment saying the
+member was not in the published schema and would join "at the `trust-tasks-rs`
+bump that publishes it". This is that bump, so all three now carry
+`Some(["tenant-key-a"])` / `Some(Some(["tenant-key-a"]))` and the comments are
+gone. Populated rather than left `None` deliberately: `None` and `Some(∅)` are
+opposite grants on this member, and only a *present* value proves it survives
+the wire under its canonical `allowedKeys` spelling.
+
+That third item is worth separating from the other two: unlike the exception
+lists, **nothing asserted it**. A comment claiming a member is unpublished
+cannot fail when it stops being true, and this one was stale by one patch
+release. `registry-drift-triage.md` records the resulting rule — a bump's
+exception-list sweep must also grep the pinned crate for the members that
+comments claim are missing.
+
 ### vta-sdk 0.20.24 / vta-service 0.13.15 — schema-conformance sweep, and every published task made canonical
 
 Closes #856 and #857. A conformance sweep now asserts, for **every** task the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,9 +342,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-mediator"
-version = "0.17.10"
+version = "0.17.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5888cf7493766b85257206459a0ae691570ca134a6926cf5fb8bbdd8ebb3dec"
+checksum = "3c3a4dbf5d8151ba18bd96ff4b684252ac57dc4569c0b7725d97b51297a6ffa5"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-common",
@@ -407,9 +407,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-mediator-common"
-version = "0.15.30"
+version = "0.15.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80f271a25216dfff7ec10e30c9d73b78f705f6319d1bd1544dc221a9dee331cc"
+checksum = "e8740756329af4040d2c488f2d2e5c27a62b91c4cdde04e9f8d3876cb583ce9a"
 dependencies = [
  "aes-gcm",
  "ahash 0.8.12",
@@ -457,9 +457,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-sdk"
-version = "0.18.62"
+version = "0.18.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f14872999e626152a24f87dcfc611f78a41f1f53c1f38895ad400e2165b62d0"
+checksum = "3b4901696220a28519f77af11ec6c38ebfde678ce7c59f6748f0a65d7166d688"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-authentication",
@@ -495,9 +495,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-test-mediator"
-version = "0.2.40"
+version = "0.2.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "288c2bda86e2c0e3689d03af8a1ea40cb8100974a71d49446fdf75e0bb148e1f"
+checksum = "d86ac1886e4569e190523d5b549fd0f89733ca3fa9729933c750ad74b55ff0f6"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-didcomm",
@@ -9585,9 +9585,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-rs"
-version = "0.2.43"
+version = "0.2.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "647c5ff5d054287bd42c34eaf8bc5ba8f3c3c063dcdc744acd45c9c6cf9bded3"
+checksum = "2e0b56c949946c8b79072036414e3d18fc0b87f5edd309311282d17e9a780510"
 dependencies = [
  "async-trait",
  "chrono",
@@ -10269,7 +10269,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.20.24"
+version = "0.20.25"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10331,7 +10331,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.13.15"
+version = "0.13.16"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",
@@ -10564,7 +10564,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-service"
-version = "0.11.43"
+version = "0.11.44"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -212,7 +212,7 @@ aws-lc-rs = "1.16"
 # (camelCase wire enums + `/0.2` TYPE_URIs) alongside the retained
 # `v0_1` modules — the VTA dual-accepts both during the migration.
 # Bump in lockstep with affinidi-webvh-service when upstream publishes.
-trust-tasks-rs = { version = "0.2.43", default-features = false, features = ["validate"] }
+trust-tasks-rs = { version = "0.2.51", default-features = false, features = ["validate"] }
 trust-tasks-capability-client = "0.1"
 trust-tasks-https = { version = "0.2", default-features = false, features = ["server", "client", "jwt"] }
 trust-tasks-proof = { version = "0.2", default-features = false, features = ["affinidi"] }

--- a/docs/05-design-notes/registry-drift-triage.md
+++ b/docs/05-design-notes/registry-drift-triage.md
@@ -18,10 +18,12 @@ are *fold* and *delete*, not *alias*.
   is also outside the harness's scope.)
 - #851 — the did-templates global+context merge — shipped as
   `vta/did-templates/*/2.0` (specced upstream in
-  trustoverip/dtgwg-trust-tasks-tf#162). The six 2.0 URIs sit in
-  `UNSPECCED_DISPATCHED_URIS` as **publish-lag entries only** until the pinned
-  `trust-tasks-rs` is bumped to ≥0.2.49; the staleness check then forces their
-  removal. Not missing-spec debt — do not fold into this triage.
+  trustoverip/dtgwg-trust-tasks-tf#162). The six 2.0 URIs sat in
+  `UNSPECCED_DISPATCHED_URIS` as **publish-lag entries only**; the
+  0.2.43 → 0.2.51 bump indexed them and the staleness check forced their
+  removal, as designed. Never missing-spec debt — not part of this triage.
+  The same bump put the six URIs back inside the conformance sweep's
+  derived census (#866), which then required a witness for each.
 - #856 — `acl/update`'s non-canonical body — is being fixed by another stream.
 - #857 — the payload-conformance sweep (the *third* parity direction: served
   URIs whose published schema the handler's actual payload type does not
@@ -48,6 +50,30 @@ are *fold* and *delete*, not *alias*.
    literals in four trees and counts per *family*; the new check is per *URI*,
    scoped to what the VTA dispatcher actually serves, and lives next to the
    forward harness so the two directions cannot drift apart.
+
+   **Publish-lag entries are debt with an expiry date.** Both exception lists
+   (`UNSPECCED_DISPATCHED_URIS` here, `UNPUBLISHED_CANONICAL_OK` in the census)
+   sometimes carry a URI whose spec is *already authored upstream* but not yet
+   in the pinned `trust-tasks-rs`. Those entries are not dispositions — they are
+   waiting on a dependency bump, and the shrink-only assertions turn the bump
+   into a hard failure until they are removed. So **every `trust-tasks-rs` bump
+   is also an exception-list sweep**: run
+   `cargo test -p vta-service --lib` and
+   `cargo test -p vtc-service --test trust_task_manifest`, and delete whatever
+   they flag. The 0.2.43 → 0.2.51 bump flushed seven such entries — the six
+   `vta/did-templates/*/2.0` URIs (#851) and `vtc/join-requests/decide/0.1`
+   (#853) — leaving the list back at its 56. Those 56 are unaffected by the
+   bump: they are genuine unspecced surface, not lag.
+
+   **Publish lag also shows up in prose, where nothing asserts.** The same
+   bump had a third kind of lag to flush, and it had no failing test behind
+   it: #866's conformance witnesses left `allowedKeys` (#818) absent with a
+   comment saying the member was not in the published
+   `acl/_shared/0.1/acl-entry` / `acl/update/0.1` schemas — true at 0.2.43,
+   and 0.2.51 is where it stopped being true (0.2.50 does **not** carry it;
+   registry PR #164 landed one release later). A comment cannot fail, so
+   sweeping the two exception lists is not enough — grep the pinned crate for
+   the member a comment claims is missing. Both witnesses now carry it.
 
 2. **The `_1_0` constant rename pass** (previously "pending" in
    `vta-sdk/src/trust_tasks.rs`). Ten constants whose greppable name lied about

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.20.24"
+version = "0.20.25"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/acl_setup.rs
+++ b/vta-sdk/src/acl_setup.rs
@@ -42,7 +42,7 @@ use affinidi_tdk::messaging::ATM;
 use affinidi_tdk::messaging::profiles::ATMProfile;
 use sha2::{Digest, Sha256};
 use tracing::{debug, info, warn};
-use trust_tasks_rs::specs::messaging::acl;
+use trust_tasks_rs::specs::messaging::account;
 
 /// Set a client's own ACL on the mediator to accept all messages.
 ///
@@ -128,13 +128,25 @@ async fn set_client_acl_internal(
     let atm_profile_arc = Arc::new(atm_profile);
 
     // Apply the ACL to the client's own DID via the mediator's trust-tasks
-    // protocol. `acl_set` waits for a response, which on an `ExplicitAllow`
-    // mediator cannot arrive until this very ACL grants `receive_forwarded` —
-    // so an `Err` here (typically a timeout) does NOT mean the request was
-    // dropped; the mediator still applies it. Hence debug, not warn, on error.
+    // protocol. The messaging family's rationalization (affinidi-tdk-rs#667/#668)
+    // retired the single-purpose `acl/set` task in favour of `account/update`,
+    // which carries `acl` as one optional member alongside `accountType` and
+    // `queueLimits` — passing `None` for those two leaves them untouched, so this
+    // is an ACL-only partial update exactly as `acl_set` was.
+    //
+    // `account_update` waits for a response, which on an `ExplicitAllow` mediator
+    // cannot arrive until this very ACL grants `receive_forwarded` — so an `Err`
+    // here (typically a timeout) does NOT mean the request was dropped; the
+    // mediator still applies it. Hence debug, not warn, on error.
     match atm
         .trust_tasks()
-        .acl_set(&atm_profile_arc, client_did_hash, acl)
+        .account_update(
+            &atm_profile_arc,
+            Some(client_did_hash),
+            None,
+            Some(acl),
+            None,
+        )
         .await
     {
         Ok(_) => {
@@ -161,12 +173,13 @@ async fn set_client_acl_internal(
 
 /// Build a wire-format ACL that allows all message types.
 ///
-/// This creates a `MediatorAcl` wire format (compatible with the trust-tasks
-/// `acl/set/0.1` endpoint) that permits sending, receiving, forwarding, and
-/// anonymous messages. The access-list mode is set to ExplicitDeny (denylist
-/// semantics), allowing all except explicitly denied entries.
-fn build_allow_all_acl() -> acl::set::v0_1::MediatorAcl {
-    acl::set::v0_1::MediatorAcl {
+/// This creates a `MediatorAcl` wire format (the `acl` member of the trust-tasks
+/// `messaging/account/update/0.1` task, which superseded `acl/set/0.1`) that
+/// permits sending, receiving, forwarding, and anonymous messages. The
+/// access-list mode is set to ExplicitDeny (denylist semantics), allowing all
+/// except explicitly denied entries.
+fn build_allow_all_acl() -> account::update::v0_1::MediatorAcl {
+    account::update::v0_1::MediatorAcl {
         blocked: Some(false),
         local: Some(true),
         send_messages: Some(true),
@@ -175,7 +188,7 @@ fn build_allow_all_acl() -> acl::set::v0_1::MediatorAcl {
         receive_forwarded: Some(true),
         create_invites: Some(true),
         anon_receive: Some(true),
-        access_list_mode: Some(acl::set::v0_1::MediatorAclAccessListMode::ExplicitDeny),
+        access_list_mode: Some(account::update::v0_1::MediatorAclAccessListMode::ExplicitDeny),
         // Don't set self-manage flags — let the mediator's defaults apply
         ..Default::default()
     }

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.13.15"
+version = "0.13.16"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/trust_tasks/acl.rs
+++ b/vta-service/src/trust_tasks/acl.rs
@@ -401,14 +401,12 @@ mod tests {
                 all: false,
                 scopes: vec!["ctx-a".into()],
             }),
-            // `allowedKeys` (#818) is deliberately left absent: the member is
-            // not in the *published* `acl/update/0.1` schema yet (the registry
-            // side of #818 is still in flight), and the canonical Payload is
-            // `deny_unknown_fields`. Populating it here would assert a wire
-            // form the published spec rejects. It joins this sample — and the
-            // conformance sweep — at the `trust-tasks-rs` bump that publishes
-            // `acl/_shared/0.1/acl-entry#allowedKeys`.
-            allowed_keys: None,
+            // `allowedKeys` (#818) is published in `acl/update/0.1` as of
+            // `trust-tasks-rs` 0.2.51, so the fully-populated sample carries
+            // it. `Some(Some(..))` is the arm that emits an array; the
+            // clear (`Some(None)` → explicit `null`) and leave-unchanged
+            // (`None` → omitted) arms are pinned in `update.rs`'s own tests.
+            allowed_keys: Some(Some(vec!["tenant-key-a".into()])),
         }
     }
 

--- a/vta-service/src/trust_tasks/conformance.rs
+++ b/vta-service/src/trust_tasks/conformance.rs
@@ -45,10 +45,16 @@
 //! directions matter — a witness for a URI nothing dispatches any more is as
 //! much drift as a dispatched URI with no witness, and only the first tells
 //! you a fold landed.
+//!
+//! And then the other direction fired for the same family: the
+//! `trust-tasks-rs` 0.2.43 → 0.2.51 bump indexed the six 2.0 specs, the
+//! derived census picked them straight back up, and the missing-witness
+//! assertion asked for all six. Neither half was hand-listed — a fold
+//! upstream and a dependency bump each moved the census on their own.
 
 use serde::de::DeserializeOwned;
 use serde_json::{Value, json};
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashMap};
 
 use trust_tasks_rs::specs;
 use vta_sdk::trust_tasks as uris;
@@ -167,11 +173,13 @@ fn acl_entry() -> AclEntry {
             all: false,
             scopes: vec!["ctx-a".into()],
         }),
-        // Absent on purpose — `allowedKeys` (#818) is not in the published
-        // `acl/_shared/0.1/acl-entry` component yet and every response type
-        // that embeds this entry is `deny_unknown_fields`. It joins the
-        // witness at the `trust-tasks-rs` bump that publishes the member.
-        allowed_keys: None,
+        // `allowedKeys` (#818) reached the published
+        // `acl/_shared/0.1/acl-entry` component in `trust-tasks-rs` 0.2.51,
+        // so the entry every ACL response embeds now carries it. Populated
+        // rather than `None` deliberately: `None` and `Some(∅)` are opposite
+        // grants and only a present value proves the member survives the
+        // wire under its canonical `allowedKeys` spelling.
+        allowed_keys: Some(vec!["tenant-key-a".into()]),
     }
 }
 
@@ -523,11 +531,13 @@ fn table() -> Vec<(&'static str, Conformance)> {
                         all: false,
                         scopes: vec!["ctx-a".into()],
                     }),
-                    // Absent on purpose — `allowedKeys` (#818) is not in the
-                    // published `acl/update/0.1` schema yet, and the Payload
-                    // is `deny_unknown_fields`. It enters this sample at the
-                    // `trust-tasks-rs` bump that publishes the member.
-                    allowed_keys: None,
+                    // `allowedKeys` (#818) is in the published
+                    // `acl/update/0.1` schema as of `trust-tasks-rs` 0.2.51.
+                    // `Some(Some(..))` is the narrowing replacement — the
+                    // arm that actually emits an array; `Some(None)` emits
+                    // an explicit `null` (clear) and `None` emits nothing,
+                    // and `update.rs`'s own tests pin all three.
+                    allowed_keys: Some(Some(vec!["tenant-key-a".into()])),
                 }),
                 to_v(CreateAclResponseBody { entry: acl_entry() })
             ),
@@ -975,18 +985,232 @@ fn table() -> Vec<(&'static str, Conformance)> {
                 })
             ),
         ),
-        // ─── vta/did-templates ───────────────────────────────────
-        //
-        // No witnesses, and that is correct right now. #864 folded the twelve
-        // `vta/{contexts/,}did-templates/*/1.0` URIs onto the merged six-task
-        // `vta/did-templates/*/2.0` family, and the 2.0 specs are published
-        // upstream but not yet in the pinned `trust-tasks-rs` (the publish-lag
-        // `vtc-service/tests/trust_task_manifest.rs` also records). So
-        // `schema_for` resolves none of them and the derived census excludes
-        // them. The next `trust-tasks-rs` bump puts all six back in scope and
-        // the coverage assertion will ask for their witnesses — which is the
-        // sweep working, not breaking.
     ];
+
+    // ─── vta/did-templates ────────────────────────────────────────
+    //
+    // The merged 2.0 family (#851, bound by #864, published into the pinned
+    // `trust-tasks-rs` by this bump). Its whole point is that scope moved out
+    // of the slug hierarchy and into ONE optional `contextId` member: absent
+    // = the global scope, present = that context's. A witness can only carry
+    // one of the two, so each witness carries the context form (the richer)
+    // and the global form is asserted alongside — otherwise "optional" would
+    // be the one thing about this family the sweep never checks.
+    {
+        use vta_sdk::did_templates::{DidTemplate, DidTemplateRecord, Scope};
+        use vta_sdk::protocols::did_template_management as tpl;
+
+        const TPL_NAME: &str = "didcomm-mediator";
+        const CTX: &str = "ctx-a";
+        // UTC unix-epoch seconds, the record's own time unit (not `TS`).
+        const EPOCH: u64 = 1_785_369_600;
+
+        /// The authored template body `create`/`update` carry and every
+        /// record embeds.
+        fn template() -> DidTemplate {
+            DidTemplate {
+                schema_version: 1,
+                name: TPL_NAME.into(),
+                kind: "mediator".into(),
+                description: Some("DIDComm mediator".into()),
+                methods: vec!["webvh".into()],
+                required_vars: vec!["SERVICE_ENDPOINT".into()],
+                optional_vars: [("LABEL".to_string(), json!("mediator"))]
+                    .into_iter()
+                    .collect(),
+                defaults: [("preRotationCount".to_string(), json!(2))]
+                    .into_iter()
+                    .collect(),
+                document: json!({
+                    "id": "{DID}",
+                    "service": [{
+                        "id": "{DID}#didcomm",
+                        "type": "DIDCommMessaging",
+                        "serviceEndpoint": "{SERVICE_ENDPOINT}",
+                    }],
+                }),
+            }
+        }
+
+        /// The persisted record `create`/`get`/`update` return — the
+        /// authored template flattened under the resolved scope and
+        /// provenance metadata.
+        fn record() -> DidTemplateRecord {
+            DidTemplateRecord {
+                template: template(),
+                scope: Scope::Context {
+                    context_id: CTX.into(),
+                },
+                created_at: EPOCH,
+                updated_at: EPOCH,
+                created_by: "did:key:z6MkAdmin".into(),
+            }
+        }
+
+        fn rendered() -> Value {
+            json!({
+                "id": "did:webvh:scid:vta.example",
+                "service": [{
+                    "id": "did:webvh:scid:vta.example#didcomm",
+                    "type": "DIDCommMessaging",
+                    "serviceEndpoint": "https://mediator.example",
+                }],
+            })
+        }
+
+        // The global form of each request — same bodies with `contextId`
+        // dropped — must parse too. `contextId` is the family's only scope
+        // selector; if the published schema ever made it required, the
+        // global half of all six ops would break with no other signal.
+        for (what, parse, global) in [
+            (
+                "list",
+                parses::<specs::vta::did_templates::list::v2_0::Payload> as ParseFn,
+                to_v(tpl::list::ListDidTemplatesBody { context_id: None }),
+            ),
+            (
+                "create",
+                parses::<specs::vta::did_templates::create::v2_0::Payload> as ParseFn,
+                to_v(tpl::create::CreateDidTemplateBody {
+                    context_id: None,
+                    template: template(),
+                }),
+            ),
+            (
+                "get",
+                parses::<specs::vta::did_templates::get::v2_0::Payload> as ParseFn,
+                to_v(tpl::get::GetDidTemplateBody {
+                    context_id: None,
+                    name: TPL_NAME.into(),
+                }),
+            ),
+            (
+                "update",
+                parses::<specs::vta::did_templates::update::v2_0::Payload> as ParseFn,
+                to_v(tpl::update::UpdateDidTemplateBody {
+                    context_id: None,
+                    name: TPL_NAME.into(),
+                    template: template(),
+                }),
+            ),
+            (
+                "delete",
+                parses::<specs::vta::did_templates::delete::v2_0::Payload> as ParseFn,
+                to_v(tpl::delete::DeleteDidTemplateBody {
+                    context_id: None,
+                    name: TPL_NAME.into(),
+                }),
+            ),
+            (
+                "render",
+                parses::<specs::vta::did_templates::render::v2_0::Payload> as ParseFn,
+                to_v(tpl::render::RenderDidTemplateBody {
+                    context_id: None,
+                    name: TPL_NAME.into(),
+                    vars: HashMap::new(),
+                }),
+            ),
+        ] {
+            assert!(
+                global.get("contextId").is_none(),
+                "did-templates/{what}: the global fixture must omit contextId"
+            );
+            parse(global.clone()).unwrap_or_else(|e| {
+                panic!(
+                    "did-templates/{what}: global-scope request is not canonical: {e}\n{global:#}"
+                )
+            });
+        }
+
+        t.extend([
+            (
+                uris::TASK_DID_TEMPLATES_LIST_2_0,
+                checked!(
+                    specs::vta::did_templates::list::v2_0::Payload,
+                    specs::vta::did_templates::list::v2_0::Response,
+                    to_v(tpl::list::ListDidTemplatesBody {
+                        context_id: Some(CTX.into()),
+                    }),
+                    to_v(tpl::list::ListDidTemplatesResultBody {
+                        templates: vec![record()],
+                    })
+                ),
+            ),
+            (
+                uris::TASK_DID_TEMPLATES_CREATE_2_0,
+                checked!(
+                    specs::vta::did_templates::create::v2_0::Payload,
+                    specs::vta::did_templates::create::v2_0::Response,
+                    to_v(tpl::create::CreateDidTemplateBody {
+                        context_id: Some(CTX.into()),
+                        template: template(),
+                    }),
+                    // `handle_create` returns the persisted record itself.
+                    to_v(record())
+                ),
+            ),
+            (
+                uris::TASK_DID_TEMPLATES_GET_2_0,
+                checked!(
+                    specs::vta::did_templates::get::v2_0::Payload,
+                    specs::vta::did_templates::get::v2_0::Response,
+                    to_v(tpl::get::GetDidTemplateBody {
+                        context_id: Some(CTX.into()),
+                        name: TPL_NAME.into(),
+                    }),
+                    to_v(record())
+                ),
+            ),
+            (
+                uris::TASK_DID_TEMPLATES_UPDATE_2_0,
+                checked!(
+                    specs::vta::did_templates::update::v2_0::Payload,
+                    specs::vta::did_templates::update::v2_0::Response,
+                    to_v(tpl::update::UpdateDidTemplateBody {
+                        context_id: Some(CTX.into()),
+                        name: TPL_NAME.into(),
+                        template: template(),
+                    }),
+                    to_v(record())
+                ),
+            ),
+            (
+                uris::TASK_DID_TEMPLATES_DELETE_2_0,
+                checked!(
+                    specs::vta::did_templates::delete::v2_0::Payload,
+                    specs::vta::did_templates::delete::v2_0::Response,
+                    to_v(tpl::delete::DeleteDidTemplateBody {
+                        context_id: Some(CTX.into()),
+                        name: TPL_NAME.into(),
+                    }),
+                    to_v(tpl::delete::DeleteDidTemplateResultBody {
+                        name: TPL_NAME.into(),
+                        deleted: true,
+                    })
+                ),
+            ),
+            (
+                uris::TASK_DID_TEMPLATES_RENDER_2_0,
+                checked!(
+                    specs::vta::did_templates::render::v2_0::Payload,
+                    specs::vta::did_templates::render::v2_0::Response,
+                    to_v(tpl::render::RenderDidTemplateBody {
+                        context_id: Some(CTX.into()),
+                        name: TPL_NAME.into(),
+                        vars: [(
+                            "SERVICE_ENDPOINT".to_string(),
+                            json!("https://mediator.example")
+                        )]
+                        .into_iter()
+                        .collect(),
+                    }),
+                    to_v(tpl::render::RenderDidTemplateResultBody {
+                        document: rendered(),
+                    })
+                ),
+            ),
+        ]);
+    }
 
     // ─── passkey-vms (feature-gated like their dispatch arms) ─────
     #[cfg(all(feature = "webvh", feature = "didcomm"))]

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -218,18 +218,6 @@ const KNOWN_FEATURE_GATED_URIS: &[&str] = &[
 /// Tracking issue: OpenVTC/verifiable-trust-infrastructure#854.
 #[allow(dead_code)] // consumed by the dispatcher's test-only parity harness
 const UNSPECCED_DISPATCHED_URIS: &[&str] = &[
-    // ─ vta/did-templates/*/2.0 — spec AUTHORED upstream
-    //   (trustoverip/dtgwg-trust-tasks-tf#162, lands in trust-tasks-rs
-    //   0.2.49); these entries are publish-lag only, not missing-spec
-    //   debt. The staleness check below forces their removal the moment
-    //   the pinned trust-tasks-rs is bumped to a version that indexes
-    //   the 2.0 family. (#851 — merged global+context family.)
-    "https://trusttasks.org/spec/vta/did-templates/list/2.0",
-    "https://trusttasks.org/spec/vta/did-templates/create/2.0",
-    "https://trusttasks.org/spec/vta/did-templates/get/2.0",
-    "https://trusttasks.org/spec/vta/did-templates/update/2.0",
-    "https://trusttasks.org/spec/vta/did-templates/delete/2.0",
-    "https://trusttasks.org/spec/vta/did-templates/render/2.0",
     // ─ vta/contexts/* — keep-and-spec under `vta/` (reduction plan §E).
     "https://trusttasks.org/spec/vta/contexts/list/1.0",
     "https://trusttasks.org/spec/vta/contexts/create/1.0",

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.11.43"
+version = "0.11.44"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vtc-service/tests/trust_task_manifest.rs
+++ b/vtc-service/tests/trust_task_manifest.rs
@@ -410,16 +410,6 @@ fn no_new_bindings_on_the_retired_authority() {
 /// (#821) is what produced this list. **None of it was previously checked by
 /// anything.**
 const UNPUBLISHED_CANONICAL_OK: &[(&str, usize, &str)] = &[
-    // Authored upstream in trust-tasks-tf alongside this change (#853,
-    // trust-tasks-tf#160): `vtc/join-requests/decide/0.1` supersedes the
-    // retired approve/reject pair. Ships in trust-tasks-rs 0.2.47; the
-    // workspace pins 0.2.43. Drop this entry when the trust-tasks-rs
-    // dependency bumps to >= 0.2.47.
-    (
-        "https://trusttasks.org/spec/vtc/join-requests/decide/",
-        1,
-        "vtc/join-requests/decide/0.1 — authored upstream with #853 (trust-tasks-tf#160), ships in trust-tasks-rs 0.2.47; remove on dependency bump",
-    ),
     // Not a dispatchable task: the framework's error envelope is a *response*
     // type, deliberately absent from the task index, so `schema_for` will never
     // resolve it. This entry is permanent — the others are debt.
@@ -447,17 +437,14 @@ const UNPUBLISHED_CANONICAL_OK: &[(&str, usize, &str)] = &[
     // 77.
     (
         "https://trusttasks.org/spec/vta/",
-        50,
+        44,
         "VTA Trust Task surface at 1.0 — predates the registry and was never reconciled with it. \
          Down from 55 via #840 phase A: config/{get,update} onto config/{show,patch}, \
          provision-integration/request onto provision/integration/0.2, acl/* onto the \
          canonical acl/{grant,show,list,update,revoke} family, and audit/list-logs onto \
          audit/list/0.1. Phase A complete at 46; phase B folded \
          webvh/dids/get-log into webvh/dids/get, and webvh/servers/{add,update} \
-         into webvh/servers/register. The last +6 are publish-lag, not debt: the \
-         vta/did-templates/*/2.0 family (#851, trust-tasks-tf#162) is published in \
-         trust-tasks-rs 0.2.49 while the workspace still pins 0.2.43, so this returns \
-         to 44 on the dependency bump without anything being authored",
+         into webvh/servers/register",
     ),
 ];
 


### PR DESCRIPTION
Refs OpenVTC/verifiable-trust-infrastructure#854.

Bumps VTI's pinned `trust-tasks-rs` to the consolidation programme's published
output and sweeps every consumer break that follows. What the issue scoped as
one bump plus two list edits turned out to be a **four-link chain**, two links of
which only surfaced under CI.

## The chain

**1. `trust-tasks-rs` 0.2.43 → 0.2.51.** The issue targeted 0.2.50. That is
**not sufficient**, and the failure is silent at compile time — the whole
workspace builds clean at 0.2.50. It fails in #866's new conformance sweep:

```
https://trusttasks.org/spec/acl/list/0.1: response is not canonical:
  unknown field `allowedKeys`, expected one of `approve`, `createdAt`, ...
```

#865 added `allowedKeys` to VTI's ACL entry; the registry published it on
`acl/_shared/0.1/acl-entry` + `acl/update/0.1` one release later, at 0.2.51.
Both those PRs landed while this branch was in flight. 0.2.50 → 0.2.51 changes
nothing else in the workspace's view (identical URI index and module set).

**2. `affinidi-messaging-sdk` 0.18.62 → 0.18.65 — forced, not chosen.** 0.18.62
does not compile against the bumped registry: it constructs
`messaging::account::list::v0_1::Payload` and
`messaging::access_list::list::v0_1::Payload` with struct-literal syntax, and both
gained optional filter members.

> **Schema-additive is not source-additive.** A new *optional* field is additive to
> the JSON Schema and fully wire-compatible — old producers keep validating, old
> consumers keep parsing. But the generated Rust `struct` carries no
> `#[non_exhaustive]` and no builder, so every downstream crate that constructs the
> payload with a **struct literal** stops compiling: `missing field ...`. The break
> is invisible in the spec diff, invisible on the wire, and surfaces only as a
> downstream build failure one publish-cycle later, in a different repo.

The cheap immunisation is at the *construction* site: end every generated-payload
literal with `..Default::default()` (as `build_allow_all_acl` here does). Whether
the codegen should emit `#[non_exhaustive]` on payload structs — making the
property enforced rather than conventional, at the cost of banning literals — is
worth a decision by the codegen owners. Flagging, not proposing.

**3. `affinidi-messaging-mediator` 0.17.10 → 0.17.13 / `-test-mediator` 0.2.40 →
0.2.43 — the link that only CI could find.** It is a *dev*-dependency, so nothing
in a local `cargo check` touches it. The messaging cutover is clean on **both**
ends: 0.17.10 serves `messaging/acl/set` and answers `account/update/0.1` with

```
WARN  unsupported Trust Task type: https://trusttasks.org/spec/messaging/account/update/0.1
ERROR response failed classification=Status code: 501 Not Implemented
```

So the moment the SDK moves the client side, the embedded test mediator can no
longer provision an ACL at all — the client never gets `receive_forwarded`, and
every forwarded round-trip is refused. The server half ships in 0.17.13.

Stated plainly for deployments: **a mediator older than 0.17.13 cannot serve a VTA
built on messaging SDK 0.18.65.** There is no dual-accept window on either side.

**4. `vta-sdk/src/acl_setup.rs` migrated off the removed `acl_set`.**
affinidi/affinidi-tdk-rs#668 removed `TrustTasksOps::acl_set` outright. Replacement:

```rust
account_update(profile, did_hash, account_type, acl, queue_limits)
```

on `messaging/account/update/0.1`, which carries `acl` as one optional member
alongside `accountType` / `queueLimits`; `None` for the other two makes it the same
ACL-only partial update. `build_allow_all_acl` now returns
`account::update::v0_1::MediatorAcl` (identical field set). Fire-and-forget
semantics and the deliberate `debug!`-not-`warn!` on timeout are unchanged.

Swept the workspace for the other retired URIs (`account/{change-type,
change-queue-limits}`, `acl/set`, `admin/{add,strip,list,audit-log,config}`,
`access-list/{add,remove,clear,get}`): **no other call site**.

## Publish-lag debt flushed

The shrink-only staleness assertions turn a dependency bump into a forcing
function — these fail CI until removed, which is the harness working as designed:

- **`vta-service/src/trust_tasks/mod.rs`** — the six `vta/did-templates/*/2.0`
  entries leave `UNSPECCED_DISPATCHED_URIS` (#851/#864 authored them upstream;
  0.2.49 indexed them). List back to **56**.
- **`vtc-service/tests/trust_task_manifest.rs`** — `vtc/join-requests/decide/`
  leaves `UNPUBLISHED_CANONICAL_OK`, and `spec/vta/` goes **50 → 44** with the
  publish-lag sentence trimmed from its reason string.
- **`docs/05-design-notes/registry-drift-triage.md`** — records the rule this
  produced: *a publish-lag entry is debt with an expiry date, so every
  `trust-tasks-rs` bump is also an exception-list sweep.*

## Reconciliation the bump forces on #866

Indexing the six did-templates 2.0 URIs puts them back inside the conformance
sweep's **derived** census, whose coverage assertion then demands a witness for
each — exactly the hand-off #866 left in a comment. All six are now `checked!`
entries built from the slice's real wire types, and all six conform on the first
run (no `KnownDrift` needed). Each witness carries the **context** form; the
**global** form (`contextId` omitted) is asserted alongside, since the family's
whole point is that scope moved into one optional member — otherwise "optional"
would be the one thing about it the sweep never checks.

`allowedKeys` also enters the three witnesses whose comments promised it would "at
the bump that publishes the member". Worth separating from the exception lists:
**nothing asserted those comments.** A comment claiming a member is unpublished
cannot fail when it stops being true, and this one was stale by one patch release.
The design note records the corollary — a bump's sweep must also grep the pinned
crate for members that comments claim are missing.

## Test evidence

```
cargo test -p vtc-service --test trust_task_manifest   7 passed;   0 failed
cargo test -p vta-service --lib                      726 passed;   0 failed
cargo test -p vta-sdk --lib                          224 passed;   0 failed
cargo check --workspace --all-targets                Finished, no errors
cargo test -p vti-e2e-tests --test client_didcomm      42 passed;   0 failed
cargo fmt --all -- --check                           clean
cargo clippy -p vta-sdk -p vta-service -p vtc-service --all-targets   clean
scripts/check-changelogs.sh / check-version-bumps.sh  both pass
```

The e2e suite is included deliberately: it is the only one that exercises a real
mediator, and it is what proved link 3. It was **21 passed / 21 failed** before —
red on unmodified `main` since #861, independently of this branch, and fixed by
#868. This branch is rebased on #868 and the suite is fully green.

## Releases

`vta-sdk 0.20.25` / `vta-service 0.13.16` / `vtc-service 0.11.44`, root CHANGELOG
entry under `## Unreleased`. Version bumps may be rebased by the orchestrator as
sibling consolidation PRs merge — these slots were consumed out from under this
branch three times already (#864, #865, #866).

## Reviewer checklist

- [ ] `account_update(profile, Some(did_hash), None, Some(acl), None)` is the right
      translation of `acl_set(profile, did_hash, acl)` — confirm `None` for
      `account_type` / `queue_limits` means *unchanged* mediator-side. Note one real
      semantic difference found while reading 0.17.13: `account_update` requires the
      account to exist (`account_get` → 404 otherwise), where `acl_set` upserted via
      `get_did_acl(..).unwrap_or_default()`. The e2e suite covers the connect path
      and is green, but this is the sharpest edge in the migration.
- [ ] `account::update::v0_1::MediatorAcl` field set matches the old
      `acl::set::v0_1::MediatorAcl` — no capability silently dropped from the
      allow-all ACL.
- [ ] The mediator floor (≥ 0.17.13) is acceptable for every deployment target, and
      wants saying somewhere operator-facing beyond the CHANGELOG.
- [ ] The six new did-templates witnesses assert the response the handler *actually*
      emits, not the one the spec suggests.
- [ ] `spec/vta/` = 44 and `UNSPECCED_DISPATCHED_URIS` = 56 are the correct
      post-bump resting state (assertions pass, but the *numbers* are the artifact).
