### PR TITLE
feat(vta-service): sign the step-up approve-request (spec: proof REQUIRED)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## Unreleased
 
+### vta-service 0.13.17 — the step-up approve-request is signed (spec: proof REQUIRED)
+
+Part of the ecosystem-wide "signed request legs" push
+(affinidi/affinidi-webvh-service#147): every approval request leg an approver
+renders is signed by its issuer.
+
+- `mint_pending_step_up` signs the complete `auth/step-up/approve-request/0.1`
+  document (`eddsa-jcs-2022`, `assertionMethod`) with the `{vta_did}#key-0`
+  issuer secret — the same pattern task-consent requests already use, so
+  issuer DID == proof `verificationMethod` DID by construction. All three gate
+  surfaces (trust-task `require_step_up`, policy `initiate_self_step_up`, the
+  REST `RequireStepUp` extractor) load the secret.
+- **Fail-closed behavior change:** a VTA with no loadable `{vta_did}#key-0`
+  (or unset `vta_did`) now returns internal-error instead of emitting an
+  unsigned approve-request. Operators with unusual key setups take note.
+- `issuedAt` added to the minted document (framework SHOULD; the signed
+  evidence gets a timestamp).
+
 ### vta-sdk 0.20.25 / vta-service 0.13.16 / vtc-service 0.11.44 — trust-tasks-rs 0.2.51, messaging SDK 0.18.65, `acl_set` → `account_update`
 
 Picks up the consolidation programme's published registry output and sweeps the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10331,7 +10331,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.13.16"
+version = "0.13.17"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.13.16"
+version = "0.13.17"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/trust_tasks/consent_request.rs
+++ b/vta-service/src/trust_tasks/consent_request.rs
@@ -6,10 +6,12 @@
 //! the prose the human reads — including the relying party whose task is being
 //! approved — while every downstream signature still verified.
 //!
-//! Note the contrast with step-up, whose `approveRequest` is deliberately
-//! unsigned: there the challenge is the binding and the approver signs the
-//! *response*, and nothing in the request is load-bearing for the decision.
-//! Here the request *is* the decision's basis, so it has to be attributable.
+//! Step-up's `approveRequest` is signed the same way (see
+//! `super::step_up::mint_pending_step_up`): both request legs put prose in
+//! front of a human, so both must be attributable to their issuer, and the
+//! signed request doubles as retainable evidence of exactly what was asked.
+//! The challenge binding still carries each decision's freshness — the
+//! signature authenticates the ask, the challenge scopes the approval.
 
 // Only the DIDComm delivery paths below bound their sends.
 #[cfg(feature = "didcomm")]

--- a/vta-service/src/trust_tasks/step_up.rs
+++ b/vta-service/src/trust_tasks/step_up.rs
@@ -14,11 +14,23 @@
 //! This module is the did-signed verifier; the handler that consumes the
 //! pending step-up, dispatches on `evidence.kind`, and elevates the session
 //! lands alongside it.
+//!
+//! The *request* leg (`auth/step-up/approve-request/0.1`, minted by
+//! [`mint_pending_step_up`]) is **signed by this VTA** — `eddsa-jcs-2022`,
+//! `assertionMethod`, issuer DID == the proof's `verificationMethod` DID —
+//! the same shape as `task-consent` ([`super::consent_request`]) and the
+//! spec's REQUIRED proof. Both request legs put prose (`reason`) in front of
+//! a human, so the request must be attributable to its issuer, and the signed
+//! document doubles as retainable evidence of exactly what was asked. The
+//! challenge binding still carries the decision's freshness — the signature
+//! authenticates the ask, the challenge scopes the approval.
 
 // Only the DIDComm send below bounds its delivery window.
 #[cfg(feature = "didcomm")]
 use std::time::Duration;
 
+use affinidi_data_integrity::{DataIntegrityProof, SignOptions, crypto_suites::CryptoSuite};
+use affinidi_secrets_resolver::secrets::Secret;
 use axum::extract::FromRequestParts;
 use axum::http::StatusCode;
 use axum::http::request::Parts;
@@ -489,16 +501,6 @@ const STEP_UP_TTL_SECS: u64 = 300;
 /// long enough while keeping the standing grant short.
 const STEP_UP_ELEVATION_TTL_SECS: u64 = 900; // 15m
 
-/// Mint a pending step-up and build the `auth/step-up/approve-request/0.1`
-/// document the AAL1 caller hands to its approver (wallet / VTA).
-///
-/// A fresh challenge is bound server-side to the caller's
-/// `{session_id, subject, targetAcr=aal2, acceptableEvidence}` via the
-/// pending-step-up store; the approver's `approve-response` is later consumed by
-/// [`handle_approve_response`]. Shared by both gate surfaces — the REST `403`
-/// ([`issue_step_up_challenge`]) and the trust-task reject ([`require_step_up`]).
-/// Returns the approve-request document, or `Err(())` if the pending step-up
-/// could not be persisted (the caller maps that to a 5xx / internal-error reject).
 /// The default step-up reason when the gated request carries no structured
 /// authorization context (or one without a `summary`).
 const DEFAULT_STEP_UP_REASON: &str = "this operation requires a stepped-up (AAL2) session";
@@ -522,9 +524,43 @@ fn reason_and_context(payload: &Value) -> (&str, Option<&Value>) {
     (reason, ctx)
 }
 
+/// Load the VTA's `{vta_did}#key-0` issuer key for signing a step-up
+/// approve-request. Thin wrapper over
+/// [`crate::operations::credentials::load_vta_issuer_secret`] (the same key
+/// task-consent requests are signed with) that logs the failure and flattens
+/// the error to `Err(())` for the gate surfaces' internal-error mapping.
+async fn load_step_up_signing_secret(state: &AppState, vta_did: &str) -> Result<Secret, ()> {
+    crate::operations::credentials::load_vta_issuer_secret(state, vta_did, "step-up")
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, "failed to load VTA issuer key for step-up approve-request");
+        })
+}
+
+/// Mint a pending step-up and build the **signed**
+/// `auth/step-up/approve-request/0.1` document the AAL1 caller hands to its
+/// approver (wallet / VTA).
+///
+/// A fresh challenge is bound server-side to the caller's
+/// `{session_id, subject, targetAcr=aal2, acceptableEvidence}` via the
+/// pending-step-up store; the approver's `approve-response` is later consumed by
+/// [`handle_approve_response`]. Shared by both gate surfaces — the REST `403`
+/// ([`issue_step_up_challenge`]) and the trust-task reject ([`require_step_up`]).
+///
+/// The document carries the spec's REQUIRED Data-Integrity proof
+/// (`eddsa-jcs-2022`, `assertionMethod`), signed with `secret` — the VTA's
+/// `{vta_did}#key-0` issuer key — so the `reason` a human reads is attributable
+/// to this VTA and the request is retainable evidence of what was asked (see
+/// the module doc). Signing happens *last*, over the complete document
+/// (including `recipient` and `payload.ext`).
+///
+/// Returns the approve-request document, or `Err(())` if the pending step-up
+/// could not be persisted or the document could not be signed (the caller maps
+/// that to a 5xx / internal-error reject).
 async fn mint_pending_step_up(
     sessions_ks: &KeyspaceHandle,
     vta_did: &str,
+    secret: &Secret,
     subject: &str,
     recipient: &str,
     approver_any: bool,
@@ -570,6 +606,7 @@ async fn mint_pending_step_up(
         "id": format!("urn:uuid:{}", Uuid::new_v4()),
         "type": "https://trusttasks.org/spec/auth/step-up/approve-request/0.1",
         "issuer": vta_did,
+        "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         "payload": {
             "subject": subject,
             "sessionId": session_id,
@@ -593,6 +630,31 @@ async fn mint_pending_step_up(
     if let Some(ctx) = authorization_context {
         doc["payload"]["ext"] = json!({ EXT_KEY_AUTHZ_CONTEXT: ctx });
     }
+    // Sign the complete document (spec: proof REQUIRED) — same pattern as
+    // `consent_request::mint_signed_requests`. The proof's verificationMethod
+    // resolves under the VTA DID, so issuer DID == proof VM DID.
+    let proof = match DataIntegrityProof::sign(
+        &doc,
+        secret,
+        SignOptions::new()
+            .with_proof_purpose("assertionMethod")
+            .with_cryptosuite(CryptoSuite::EddsaJcs2022),
+    )
+    .await
+    {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::error!(error = %e, "failed to sign step-up approve-request");
+            return Err(());
+        }
+    };
+    match serde_json::to_value(&proof) {
+        Ok(p) => doc["proof"] = p,
+        Err(e) => {
+            tracing::error!(error = %e, "failed to serialize step-up approve-request proof");
+            return Err(());
+        }
+    }
     Ok(doc)
 }
 
@@ -605,6 +667,7 @@ async fn mint_pending_step_up(
 pub(crate) async fn issue_step_up_challenge(
     sessions_ks: &KeyspaceHandle,
     vta_did: &str,
+    secret: &Secret,
     subject: &str,
     recipient: &str,
     approver_any: bool,
@@ -615,6 +678,7 @@ pub(crate) async fn issue_step_up_challenge(
     let approve_request = match mint_pending_step_up(
         sessions_ks,
         vta_did,
+        secret,
         subject,
         recipient,
         approver_any,
@@ -989,9 +1053,21 @@ pub(super) async fn require_step_up(
     // `summary` as the `reason` so a context-unaware renderer still shows
     // something meaningful.
     let (reason, authorization_context) = reason_and_context(&doc.payload);
+    let secret = match load_step_up_signing_secret(state, &vta_did).await {
+        Ok(s) => s,
+        Err(()) => {
+            return Some(reject_with(
+                doc,
+                RejectReason::InternalError {
+                    reason: "failed to initiate step-up".to_string(),
+                },
+            ));
+        }
+    };
     let reject = match mint_pending_step_up(
         &state.sessions_ks,
         &vta_did,
+        &secret,
         &auth.did,
         &recipient,
         approver_any,
@@ -1046,9 +1122,21 @@ pub(super) async fn initiate_self_step_up(
         .clone()
         .unwrap_or_default();
     let (reason, authorization_context) = reason_and_context(&doc.payload);
+    let secret = match load_step_up_signing_secret(state, &vta_did).await {
+        Ok(s) => s,
+        Err(()) => {
+            return reject_with(
+                doc,
+                RejectReason::InternalError {
+                    reason: "failed to initiate step-up".to_string(),
+                },
+            );
+        }
+    };
     let reject = match mint_pending_step_up(
         &state.sessions_ks,
         &vta_did,
+        &secret,
         &auth.did,
         &auth.did, // self-approve: the subject is its own approver
         false,
@@ -1170,9 +1258,21 @@ impl<O: StepUpOp> FromRequestParts<AppState> for RequireStepUp<O> {
             .vta_did
             .clone()
             .unwrap_or_default();
+        let secret = match load_step_up_signing_secret(state, &vta_did).await {
+            Ok(s) => s,
+            Err(()) => {
+                return Err((
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    [(axum::http::header::CONTENT_TYPE, "application/json")],
+                    br#"{"error":"internal_error"}"#.to_vec(),
+                )
+                    .into_response());
+            }
+        };
         Err(issue_step_up_challenge(
             &state.sessions_ks,
             &vta_did,
+            &secret,
             &claims.did,
             &recipient,
             approver_any,
@@ -1265,9 +1365,16 @@ mod tests {
         .unwrap();
         let ks = store.keyspace(crate::keyspaces::SESSIONS).unwrap();
 
+        // A did:key issuer so the minted proof can be verified end-to-end with
+        // the same shared verifier the gates use (did:key resolves locally).
+        let sk = SigningKey::from_bytes(&[42u8; 32]);
+        let (vta_did, mb) = did_key(&sk);
+        let secret = issuer_secret(&sk, &format!("{vta_did}#{mb}"));
+
         let resp = issue_step_up_challenge(
             &ks,
-            "did:web:vta.example",
+            &vta_did,
+            &secret,
             "did:key:zHolder",
             // self-approval: recipient == subject
             "did:key:zHolder",
@@ -1287,7 +1394,7 @@ mod tests {
             v["approveRequest"]["type"],
             "https://trusttasks.org/spec/auth/step-up/approve-request/0.1"
         );
-        assert_eq!(v["approveRequest"]["issuer"], "did:web:vta.example");
+        assert_eq!(v["approveRequest"]["issuer"], vta_did);
         assert_eq!(v["approveRequest"]["recipient"], "did:key:zHolder");
         assert_eq!(v["approveRequest"]["payload"]["sessionId"], "sess-9");
         assert_eq!(v["approveRequest"]["payload"]["targetAcr"], "aal2");
@@ -1295,6 +1402,22 @@ mod tests {
         let challenge = v["approveRequest"]["payload"]["challenge"]
             .as_str()
             .expect("challenge string");
+
+        // The approve-request is signed (spec: proof REQUIRED) — an
+        // eddsa-jcs-2022 assertionMethod proof whose verificationMethod DID is
+        // the issuer, and the signature verifies over the served document.
+        let proof = &v["approveRequest"]["proof"];
+        assert_eq!(proof["type"], "DataIntegrityProof", "{v}");
+        assert_eq!(proof["cryptosuite"], "eddsa-jcs-2022", "{v}");
+        assert_eq!(proof["proofPurpose"], "assertionMethod", "{v}");
+        let task: TrustTask<Value> = serde_json::from_value(v["approveRequest"].clone()).unwrap();
+        let signer = crate::auth::di_proof::verify_trust_task_proof(&task)
+            .await
+            .expect("approve-request proof verifies");
+        assert_eq!(
+            signer, vta_did,
+            "issuer DID == proof verificationMethod DID"
+        );
 
         // The pending step-up was minted + bound to the caller, ready for the
         // matching approve-response to consume.
@@ -1354,9 +1477,14 @@ mod tests {
             "risk": "high",
             "action": { "kind": "share", "from": "finance", "to": "travel", "ttlSeconds": 3600 },
         });
+        let sk = SigningKey::from_bytes(&[43u8; 32]);
+        let (vta_did, mb) = did_key(&sk);
+        let secret = issuer_secret(&sk, &format!("{vta_did}#{mb}"));
+
         let resp = issue_step_up_challenge(
             &ks,
-            "did:web:vta.example",
+            &vta_did,
+            &secret,
             "did:key:zHolder",
             "did:key:zHolder",
             false,
@@ -1369,6 +1497,14 @@ mod tests {
 
         let bytes = resp.into_body().collect().await.unwrap().to_bytes();
         let v: Value = serde_json::from_slice(&bytes).unwrap();
+        // The `ext` context rides *inside* the signed surface — the proof
+        // covers it (SPEC: "The optional `ext` extension is part of the signed
+        // surface").
+        let task: TrustTask<Value> = serde_json::from_value(v["approveRequest"].clone()).unwrap();
+        let signer = crate::auth::di_proof::verify_trust_task_proof(&task)
+            .await
+            .expect("approve-request proof verifies over ext");
+        assert_eq!(signer, vta_did);
         let payload = &v["approveRequest"]["payload"];
         // The structured context rode into the approve-request under the
         // reverse-DNS `ext` key (spec-valid for deny_unknown_fields consumers)…
@@ -1391,6 +1527,12 @@ mod tests {
         mc.extend_from_slice(pk.as_bytes());
         let mb = multibase::encode(Base::Base58Btc, mc);
         (format!("did:key:{mb}"), mb)
+    }
+
+    /// A signing `Secret` for `sk` with verification-method `id` — the shape
+    /// `load_vta_issuer_secret` hands the production mint path.
+    fn issuer_secret(sk: &SigningKey, id: &str) -> Secret {
+        Secret::generate_ed25519(Some(id), Some(sk.as_bytes()))
     }
 
     /// Build an approve-response-shaped TrustTask and attach a did-signed

--- a/vta-service/tests/api_integration.rs
+++ b/vta-service/tests/api_integration.rs
@@ -17,7 +17,7 @@ use vti_common::auth::jwt::JwtKeys;
 use vti_common::auth::session::{Session, SessionState, store_session};
 
 use vta_service::store::KeyspaceHandle;
-use vta_service::test_support::{TestAppContext, build_test_app};
+use vta_service::test_support::{TestAppContext, build_provisionable_test_app, build_test_app};
 
 // ── Test harness — thin wrapper over the workspace's `test_support`
 // `build_test_app` helper. The substantial AppState wiring (every
@@ -33,6 +33,16 @@ struct TestApp {
 impl TestApp {
     async fn new() -> (Self, TestContext) {
         let (router, ctx) = build_test_app().await;
+        (Self { router }, TestContext { inner: ctx })
+    }
+
+    /// Like [`TestApp::new`] but with a real, self-resolving VTA signing
+    /// identity (`{vta_did}#key-0` provisioned). Needed by tests that drive a
+    /// path which **mints a VTA-signed document** — e.g. the step-up gate,
+    /// whose approve-request now carries the spec-REQUIRED proof — since the
+    /// cheap sentinel-DID app has no issuer key to sign with.
+    async fn new_signing() -> (Self, TestContext) {
+        let (router, ctx) = build_provisionable_test_app().await;
         (Self { router }, TestContext { inner: ctx })
     }
 
@@ -703,7 +713,8 @@ async fn acl_list_filters_a_context_in_both_directions() {
 /// up. Mirrors the operator policy: all ACL changes require AAL2.
 #[tokio::test]
 async fn acl_mutation_requires_step_up() {
-    let (app, ctx) = TestApp::new().await;
+    // Signing app: the approve-request carries the spec-REQUIRED VTA proof.
+    let (app, ctx) = TestApp::new_signing().await;
     // Opt into step-up enforcement (shipping default is disabled).
     ctx.enable_step_up_all().await;
     // A normal (AAL1) admin session: correct role, but not stepped up.
@@ -741,6 +752,11 @@ async fn acl_mutation_requires_step_up() {
             .is_some_and(|c| c.len() >= 16),
         "approve-request must carry a ≥16-char challenge"
     );
+    // The approve-request is signed by the VTA (spec: proof REQUIRED) so the
+    // reason the approver renders is attributable to this relying party.
+    assert_eq!(ar["proof"]["type"], "DataIntegrityProof", "{body}");
+    assert_eq!(ar["proof"]["cryptosuite"], "eddsa-jcs-2022", "{body}");
+    assert_eq!(ar["proof"]["proofPurpose"], "assertionMethod", "{body}");
 }
 
 #[tokio::test]
@@ -811,7 +827,8 @@ async fn swap_key_carve_out_admits_aal1_when_configured() {
 #[tokio::test]
 async fn swap_key_gated_without_carve_out() {
     use vti_common::auth::step_up::{StepUpFloor, StepUpMode};
-    let (app, ctx) = TestApp::new().await;
+    // Signing app: the gate mints a signed approve-request (spec: proof REQUIRED).
+    let (app, ctx) = TestApp::new_signing().await;
     // Same AAL2 floor but WITHOUT the carve-out → swap-key is gated.
     ctx.set_step_up_floors(vec![StepUpFloor {
         operation: "acl/swap-key".into(),
@@ -902,7 +919,8 @@ async fn acl_grant_persists_step_up_approver() {
 async fn delegated_step_up_routes_to_configured_approver() {
     use vti_common::acl::{AclEntry, Role, store_acl_entry};
     use vti_common::auth::step_up::{StepUpFloor, StepUpMode};
-    let (app, ctx) = TestApp::new().await;
+    // Signing app: the approve-request carries the spec-REQUIRED VTA proof.
+    let (app, ctx) = TestApp::new_signing().await;
     let caller = "did:key:z6MkAdmin";
     let approver = "did:key:z6MkApprover";
     // The caller's ACL entry names its delegated approver.

--- a/vta-service/tests/step_up_approve_response.rs
+++ b/vta-service/tests/step_up_approve_response.rs
@@ -18,7 +18,7 @@ use ed25519_dalek::{Signer, SigningKey};
 use multibase::Base;
 use trust_tasks_rs::{Proof, TrustTask};
 
-use vta_service::test_support::build_test_app;
+use vta_service::test_support::{build_provisionable_test_app, build_test_app};
 use vti_common::auth::session::{Session, SessionState, get_session, now_epoch, store_session};
 use vti_common::auth::step_up::{new_pending_step_up, store_pending_step_up};
 
@@ -284,7 +284,9 @@ async fn did_signed_approve_response_0_2_elevates_session_to_aal2() {
 /// gate firing — not a permission denial — and it fires before payload parsing.
 #[tokio::test]
 async fn trust_task_acl_mutation_requires_step_up() {
-    let (router, ctx) = build_test_app().await;
+    // Signing app (real `{vta_did}#key-0`): the minted approve-request carries
+    // the spec-REQUIRED VTA proof, which the sentinel-DID app cannot sign.
+    let (router, ctx) = build_provisionable_test_app().await;
 
     // Opt into step-up enforcement (shipping default is disabled): a `*`
     // floor at AAL2 so the AAL1 trust-task mutation below is gated.
@@ -337,7 +339,7 @@ async fn trust_task_acl_mutation_requires_step_up() {
         "id": "acl-create-itest-1",
         "type": "https://trusttasks.org/spec/acl/grant/0.1",
         "issuer": did,
-        "recipient": "did:key:z6MkTestVTA",
+        "recipient": ctx.vta_did,
         "payload": {
             "entry": {
                 "subject": "did:key:z6MkSomeNewEntry",
@@ -377,6 +379,17 @@ async fn trust_task_acl_mutation_requires_step_up() {
     assert_eq!(details["approveRequest"]["recipient"], did, "{v}");
     assert_eq!(
         details["approveRequest"]["payload"]["targetAcr"], "aal2",
+        "{v}"
+    );
+    // The carried approve-request is signed by the VTA (spec: proof REQUIRED),
+    // and the issuer is the signing VTA itself.
+    assert_eq!(details["approveRequest"]["issuer"], ctx.vta_did, "{v}");
+    assert_eq!(
+        details["approveRequest"]["proof"]["cryptosuite"], "eddsa-jcs-2022",
+        "approve-request must carry the VTA's proof: {v}"
+    );
+    assert_eq!(
+        details["approveRequest"]["proof"]["proofPurpose"], "assertionMethod",
         "{v}"
     );
 }


### PR DESCRIPTION
## What

Part of the cross-repo "signed request legs" programme (affinidi/affinidi-webvh-service#147, trustoverip/dtgwg-trust-tasks-tf#166): the `auth/step-up/approve-request` spec marks the request proof REQUIRED, and this repo deliberately minted it unsigned. That decision is reversed — the reason prose the human reads must be attributable, and the signed request is retainable evidence; the challenge binding still carries the decision's freshness.

- `mint_pending_step_up` signs the complete document (`eddsa-jcs-2022`, `assertionMethod`) with the `{vta_did}#key-0` issuer secret via `load_vta_issuer_secret(state, vta_did, "step-up")` — the exact `consent_request.rs` pattern, so issuer DID == proof `verificationMethod` DID by construction. Sign failure → internal-error reject: **it never emits unsigned** (fail closed).
- All three gate surfaces load the secret: trust-task `require_step_up`, policy-driven `initiate_self_step_up`, and the REST `RequireStepUp` extractor.
- `issuedAt` added to the minted doc (framework SHOULD; the signed evidence gets a timestamp).
- Module docs rewritten in both `step_up.rs` and `consent_request.rs` — the latter's "contrast with step-up, whose approveRequest is deliberately unsigned" paragraph is gone; both request legs are signed now.

## Behavior change

A VTA with no loadable `{vta_did}#key-0` (or unset `vta_did`) now returns internal-error instead of an unsigned approve-request. Correct per spec; release-note-worthy for unusual key setups.

## Tests

- `cargo test -p vta-service --no-fail-fast` all green: 726 lib + every integration target (`api_integration` 120, `step_up_approve_response` 5, `step_up_policy` 7, `setup` 64); 4 pre-existing ignored
- Unit tests sign with a did:key issuer and cryptographically verify the proof end-to-end (`di_proof::verify_trust_task_proof`), asserting signer == issuer and that the proof covers `payload.ext`
- Gate-path integration tests moved to the provisionable signing app and assert the carried `approveRequest.proof`
- fmt + clippy clean

## Merge notes

- Receivers tolerate the added `proof` (mobile's `parse_step_up_request` ignores unknown members) — safe to merge/deploy before the approver-side enforcement PRs (vta-mobile-core, browser plugin), which must come after.
- Type stays `approve-request/0.1`; the 0.1→0.2 migration is a separate coordinated pass (inbound canonical-URI router + mobile's typed parse move together).
