### PR TITLE
fix(vta-sdk): select_initial_transport consults tsp_mediator_did, and TSP provisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,69 @@ renders is signed by its issuer.
 - `issuedAt` added to the minted document (framework SHOULD; the signed
   evidence gets a timestamp).
 
+### vta-sdk 0.20.26 — TSP is a provisioning transport, not an invisible one
+
+`provision_client::select_initial_transport` decided the provisioning wire from
+two of the three endpoints its own resolver produces. `ResolvedVta` carries
+`tsp_mediator_did`, `mediator_did` and `rest_url`, and even exposes an
+`advertised()` helper that reports all three — but the selector matched only on
+`(mediator_did, rest_url)`. A VTA advertising **only** `#tsp` therefore fell
+through to `InitialChoice::Neither` and failed with `"resolved (no endpoints)"`,
+about a document from which the resolver had just parsed a perfectly good
+endpoint. 0.19 masked this by synthesising a REST URL from the VTA DID's own
+domain; 0.20 correctly stopped guessing, which removed the accidental fallback
+and exposed the gap (#869).
+
+TSP now provisions. The VTA's TSP inbound dispatcher already feeds
+`dispatch_trust_task_core` — the same spine REST and DIDComm use — and both
+operations this flow needs (`spec/vta/webvh/servers/list/1.0`,
+`spec/provision/integration/0.2`) are registered on it, so the request and reply
+documents are byte-identical across all three transports. This is wiring, not
+new protocol surface.
+
+- **`InitialChoice` now has one variant per cell of the 2×2×2 advertise
+  matrix** — `TspOnly`, `TspAndDIDComm`, `TspAndRest`, `TspDIDCommAndRest`
+  alongside the existing four. Adding variants is a breaking match for any
+  external consumer that matches exhaustively; the alternative was a choice that
+  keeps losing the endpoint it was asked about. `starts_with_tsp()` /
+  `has_didcomm()` / `has_rest()` keep the match sites small, and a test asserts
+  the predicates agree with the resolved document (the runner's degrade path
+  `expect`s on them).
+- **Ranking is TSP > DIDComm > REST**, matching `ResolvedVta::advertised()` and
+  `vta-service`'s own inbound ranking. **This changes the default wire for a VTA
+  advertising both `#tsp` and `#vta-didcomm`** — the reference topology. Pass
+  `force_transport: Some(Protocol::DidComm)` to pin the old behaviour.
+- **Degradation is pre-auth only.** An auto-picked TSP leg that fails before the
+  VTA accepts anything (no `tsp` feature compiled in, mediator unreachable) is
+  reported and the run continues on DIDComm/REST when the document advertises
+  one. A post-auth failure stays terminal, exactly as the existing
+  `AttemptOutcome` split already dictated for DIDComm. A **forced** transport
+  never degrades.
+- **`Protocol` gains `Tsp`** (also the `force_transport` vocabulary) and
+  `DiagCheck` gains `AuthenticateTSP`, listed first so a consumer rendering
+  `DiagCheck::all()` shows the rows in the order the runner tries them. Both are
+  breaking for exhaustive matches. `AttemptLog` and the headless
+  `HeadlessVtaError` gain a `tsp` slot.
+- **New `provision_client::runner_tsp`**, gated on `tsp`: `run_tsp_attempt` plus
+  one-shot `provision_via_tsp` / `provision_admin_rotation_via_tsp`. A build
+  without the feature keeps compiling and fails with a message naming the
+  *cargo feature*, in the shape `session::connect_tsp_bounded` already uses —
+  never "no endpoints", which is what sent people hunting a DID-document error
+  that did not exist.
+- **`select_initial_transport` stays feature-independent.** A `tsp`-less build
+  still *selects* `TspOnly` for a TSP-only VTA and then explains itself, rather
+  than the selection matrix quietly changing shape with the feature flags.
+
+Known gap, deliberate: the TSP `FullSetup` leg runs the webvh catalogue lookup
+and the provision round-trip back-to-back on one socket instead of splitting
+into `PreflightOk` → `run_provision_flight`. The split exists to let an
+interactive consumer close its session while a picker dialog is up, and the
+picker is driven off `VtaEvent::PreflightDone`, whose `mediator_did` is a DIDComm
+mediator by construction — carrying a TSP mediator there needs a public
+event-shape change. Explicit `WEBVH_SERVER` in the ask wins, 0/1 catalogue
+entries auto-pick, and 2+ with no explicit choice is refused by name rather than
+guessed.
+
 ### vta-sdk 0.20.25 / vta-service 0.13.16 / vtc-service 0.11.44 — trust-tasks-rs 0.2.51, messaging SDK 0.18.65, `acl_set` → `account_update`
 
 Picks up the consolidation programme's published registry output and sweeps the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10271,7 +10271,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.20.25"
+version = "0.20.26"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.20.25"
+version = "0.20.26"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/provision_client/diagnostics.rs
+++ b/vta-sdk/src/provision_client/diagnostics.rs
@@ -9,6 +9,13 @@ use super::intent::VtaReply;
 pub enum DiagCheck {
     ResolveDid,
     EnumerateServices,
+    /// TSP-leg of the auth check. Emitted when the VTA advertises a
+    /// `#tsp` (`TSPTransport`) service — TSP is the highest-preference
+    /// transport (TSP > DIDComm > REST), so this row runs first. Stays
+    /// `Skipped` when no `#tsp` service is advertised, or when the SDK
+    /// was built without the `tsp` feature and another transport is
+    /// available to fall back to.
+    AuthenticateTSP,
     /// DIDComm-leg of the auth check. The runner emits `Running` /
     /// `Ok` / `Failed` on this row when the configured transport is
     /// DIDComm. When DIDComm isn't advertised by the VTA, this row
@@ -31,6 +38,7 @@ impl DiagCheck {
         match self {
             Self::ResolveDid => "Resolve VTA DID",
             Self::EnumerateServices => "Enumerate service endpoints",
+            Self::AuthenticateTSP => "Authenticate via TSP",
             Self::AuthenticateDIDComm => "Authenticate via DIDComm",
             Self::AuthenticateREST => "Authenticate via REST",
             Self::ListWebvhServers => "List webvh hosting servers",
@@ -43,6 +51,7 @@ impl DiagCheck {
         &[
             Self::ResolveDid,
             Self::EnumerateServices,
+            Self::AuthenticateTSP,
             Self::AuthenticateDIDComm,
             Self::AuthenticateREST,
             Self::ListWebvhServers,
@@ -67,8 +76,15 @@ pub struct DiagEntry {
 }
 
 /// Which authentication path the runner actually completed with.
+///
+/// Also the `force_transport` vocabulary for
+/// [`run_connection_test`](super::run_connection_test) — forcing a transport
+/// pins the runner to that leg with no fallback.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Protocol {
+    /// Trust Spanning Protocol, routed through the mediator named by the VTA's
+    /// `#tsp` (`TSPTransport`) service. Highest preference.
+    Tsp,
     DidComm,
     Rest,
 }
@@ -76,6 +92,7 @@ pub enum Protocol {
 impl Protocol {
     pub fn label(&self) -> &'static str {
         match self {
+            Self::Tsp => "TSP",
             Self::DidComm => "DIDComm",
             Self::Rest => "REST",
         }
@@ -91,8 +108,9 @@ pub struct ConnectedInfo {
     /// REST URL advertised by the VTA DID document, for runtime-side
     /// fallback. The provisioning workflow itself does not use it.
     pub rest_url: Option<String>,
-    /// DIDComm mediator DID advertised by the VTA. Always `Some` when
-    /// `protocol == DidComm`.
+    /// Mediator DID the round-trip was routed through. Always `Some` when
+    /// `protocol == DidComm` (the `#DIDCommMessaging` mediator) or
+    /// `protocol == Tsp` (the `#tsp` mediator).
     pub mediator_did: Option<String>,
     /// Unified reply — see [`VtaReply`] for the variants.
     pub reply: VtaReply,
@@ -146,6 +164,9 @@ mod tests {
         assert!(matches!(resolved.status, DiagStatus::Ok(_)));
     }
 
+    /// The authenticate rows are listed in the runner's own preference order —
+    /// TSP > DIDComm > REST — so a consumer rendering `all()` top-to-bottom
+    /// shows them in the order the runner will actually try them.
     #[test]
     fn all_lists_split_authenticate_rows_in_order() {
         let all = DiagCheck::all();
@@ -154,6 +175,7 @@ mod tests {
             &[
                 DiagCheck::ResolveDid,
                 DiagCheck::EnumerateServices,
+                DiagCheck::AuthenticateTSP,
                 DiagCheck::AuthenticateDIDComm,
                 DiagCheck::AuthenticateREST,
                 DiagCheck::ListWebvhServers,
@@ -164,11 +186,21 @@ mod tests {
 
     #[test]
     fn authenticate_rows_have_distinct_labels() {
+        assert_eq!(DiagCheck::AuthenticateTSP.label(), "Authenticate via TSP");
         assert_eq!(
             DiagCheck::AuthenticateDIDComm.label(),
             "Authenticate via DIDComm"
         );
         assert_eq!(DiagCheck::AuthenticateREST.label(), "Authenticate via REST");
+    }
+
+    /// Every transport the runner can complete over has a distinct operator-
+    /// facing label — `Connected via {label}` is rendered verbatim.
+    #[test]
+    fn protocol_labels_are_distinct() {
+        assert_eq!(Protocol::Tsp.label(), "TSP");
+        assert_eq!(Protocol::DidComm.label(), "DIDComm");
+        assert_eq!(Protocol::Rest.label(), "REST");
     }
 
     #[test]

--- a/vta-sdk/src/provision_client/driver.rs
+++ b/vta-sdk/src/provision_client/driver.rs
@@ -38,8 +38,9 @@ use super::{ProvisionAsk, run_provision};
 /// can pick a fixed exit code without re-parsing the error string.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HeadlessFailureKind {
-    /// VTA advertises neither DIDComm nor REST, OR every advertised
-    /// transport's auth attempt failed pre-auth.
+    /// VTA advertises no usable transport (no `#tsp`, no DIDComm mediator,
+    /// no REST endpoint), OR every advertised transport's auth attempt
+    /// failed pre-auth.
     NoTransport,
     /// VTA accepted the auth handshake but rejected the request body
     /// afterwards (template render error, validation, etc.). A
@@ -52,6 +53,10 @@ pub enum HeadlessFailureKind {
 /// `Display` is stable and grep-friendly for CI logs.
 #[derive(Debug)]
 pub struct HeadlessVtaError {
+    /// Failure reported by the TSP leg, if it ran. Populated when the VTA
+    /// advertises a `#tsp` service — including the "built without the
+    /// `tsp` feature" case, which is a TSP-leg pre-auth failure.
+    pub tsp: Option<String>,
     pub didcomm: Option<String>,
     pub rest: Option<String>,
     pub kind: HeadlessFailureKind,
@@ -60,13 +65,16 @@ pub struct HeadlessVtaError {
 impl fmt::Display for HeadlessVtaError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "Headless VTA setup failed.")?;
+        if let Some(reason) = &self.tsp {
+            writeln!(f, "  TSP: {reason}")?;
+        }
         if let Some(reason) = &self.didcomm {
             writeln!(f, "  DIDComm: {reason}")?;
         }
         if let Some(reason) = &self.rest {
             writeln!(f, "  REST: {reason}")?;
         }
-        if self.didcomm.is_none() && self.rest.is_none() {
+        if self.tsp.is_none() && self.didcomm.is_none() && self.rest.is_none() {
             writeln!(f, "  No transport advertised by the VTA's DID document.")?;
         }
         writeln!(f)?;
@@ -172,6 +180,7 @@ pub async fn run_phase2_connect(
     force_transport: Option<Protocol>,
 ) -> Result<(), HeadlessVtaError> {
     let key = EphemeralSetupKey::load_from(key_path).map_err(|e| HeadlessVtaError {
+        tsp: None,
         didcomm: Some(format!("could not load setup key: {e}")),
         rest: None,
         kind: HeadlessFailureKind::NoTransport,
@@ -206,6 +215,7 @@ pub async fn run_phase2_connect(
 
     let mut connected = false;
     let mut last_failure: Option<String> = None;
+    let mut tsp_failure: Option<String> = None;
     let mut didcomm_failure: Option<String> = None;
     let mut rest_failure: Option<String> = None;
     let mut last_attempt: Option<(Protocol, AttemptResultKind)> = None;
@@ -236,6 +246,7 @@ pub async fn run_phase2_connect(
                 | AttemptResultKind::PostAuthFailure(reason) = &outcome
                 {
                     match protocol {
+                        Protocol::Tsp => tsp_failure = Some(reason.clone()),
                         Protocol::DidComm => didcomm_failure = Some(reason.clone()),
                         Protocol::Rest => rest_failure = Some(reason.clone()),
                     }
@@ -258,11 +269,13 @@ pub async fn run_phase2_connect(
         _ => HeadlessFailureKind::NoTransport,
     };
 
-    if didcomm_failure.is_none()
+    if tsp_failure.is_none()
+        && didcomm_failure.is_none()
         && rest_failure.is_none()
         && let Some(reason) = last_failure
     {
         return Err(HeadlessVtaError {
+            tsp: None,
             didcomm: Some(reason),
             rest: None,
             kind,
@@ -270,6 +283,7 @@ pub async fn run_phase2_connect(
     }
 
     Err(HeadlessVtaError {
+        tsp: tsp_failure,
         didcomm: didcomm_failure,
         rest: rest_failure,
         kind,
@@ -292,27 +306,47 @@ mod tests {
     use crate::provision_client::messages::MediatorMessages;
 
     #[test]
-    fn headless_error_display_names_both_protocols() {
+    fn headless_error_display_names_every_protocol() {
         let err = HeadlessVtaError {
+            tsp: Some("TSP mediator unreachable".into()),
             didcomm: Some("ACL not found".into()),
             rest: Some("REST 401".into()),
             kind: HeadlessFailureKind::NoTransport,
         };
         let s = err.to_string();
+        assert!(s.contains("TSP: TSP mediator unreachable"));
         assert!(s.contains("DIDComm: ACL not found"));
         assert!(s.contains("REST: REST 401"));
         assert!(s.contains("sealed-handoff"));
     }
 
+    /// A TSP-only VTA whose TSP leg failed reports the TSP reason — not the
+    /// "no transport advertised" line, which is reserved for a document that
+    /// really advertised nothing (#869).
+    #[test]
+    fn headless_error_with_only_a_tsp_failure_does_not_claim_nothing_was_advertised() {
+        let s = HeadlessVtaError {
+            tsp: Some("built without the `tsp` feature".into()),
+            didcomm: None,
+            rest: None,
+            kind: HeadlessFailureKind::NoTransport,
+        }
+        .to_string();
+        assert!(s.contains("TSP: built without the `tsp` feature"));
+        assert!(!s.contains("No transport advertised"));
+    }
+
     #[test]
     fn headless_error_display_no_transport_message_differs_from_post_auth() {
         let no_transport = HeadlessVtaError {
+            tsp: None,
             didcomm: Some("network".into()),
             rest: None,
             kind: HeadlessFailureKind::NoTransport,
         }
         .to_string();
         let post_auth = HeadlessVtaError {
+            tsp: None,
             didcomm: Some("template error".into()),
             rest: None,
             kind: HeadlessFailureKind::PostAuthFailed,

--- a/vta-sdk/src/provision_client/event.rs
+++ b/vta-sdk/src/provision_client/event.rs
@@ -59,10 +59,13 @@ pub enum VtaEvent {
         protocol: Protocol,
         /// REST URL advertised in the VTA DID doc, retained for the
         /// integration's runtime credential so it has a URL fallback
-        /// at startup. Always `None` when the VTA is DIDComm-only.
+        /// at startup. Always `None` when the VTA advertises no
+        /// `#vta-rest` service.
         rest_url: Option<String>,
-        /// DIDComm mediator DID from the VTA DID doc. Always `Some`
-        /// when `protocol == DidComm`.
+        /// Mediator DID from the VTA DID doc that carried the round-trip:
+        /// the `#DIDCommMessaging` mediator when `protocol == DidComm`,
+        /// the `#tsp` mediator when `protocol == Tsp`. Always `Some` for
+        /// both; `None` on the REST path.
         mediator_did: Option<String>,
         /// Unified reply — see [`VtaReply`] for the variants.
         reply: VtaReply,
@@ -91,10 +94,11 @@ pub struct AttemptResult {
     pub at: Instant,
 }
 
-/// Per-transport history of attempts on this run. Both fields are
+/// Per-transport history of attempts on this run. Every field is
 /// `None` until the corresponding transport runs at least once.
 #[derive(Clone, Debug, Default)]
 pub struct AttemptLog {
+    pub tsp: Option<AttemptResult>,
     pub didcomm: Option<AttemptResult>,
     pub rest: Option<AttemptResult>,
 }

--- a/vta-sdk/src/provision_client/mod.rs
+++ b/vta-sdk/src/provision_client/mod.rs
@@ -55,6 +55,7 @@ pub mod result;
 pub mod runner;
 pub mod runner_didcomm;
 pub(crate) mod runner_rest;
+pub mod runner_tsp;
 pub mod setup_key;
 
 /// Test fixtures available to downstream integration tests.
@@ -69,6 +70,13 @@ pub use runner::{
 pub use runner_didcomm::{
     provision_admin_rotation_via_didcomm, provision_via_didcomm, run_provision_flight,
 };
+/// One-shot TSP round-trips — the TSP siblings of
+/// [`provision_via_didcomm`] / [`provision_via_rest`]. Gated on the `tsp`
+/// feature: without it the SDK has no TSP stack to send over, and the
+/// orchestrated [`run_provision`] path reports that by name rather than
+/// silently degrading.
+#[cfg(feature = "tsp")]
+pub use runner_tsp::{provision_admin_rotation_via_tsp, provision_via_tsp};
 
 pub use ask::{
     BUILTIN_DID_HOST_DIDCOMM_TEMPLATE, BUILTIN_DID_HOST_HTTP_DIDCOMM_TEMPLATE,

--- a/vta-sdk/src/provision_client/runner.rs
+++ b/vta-sdk/src/provision_client/runner.rs
@@ -1,11 +1,13 @@
 //! Background orchestration: pick a transport, run the diagnostic
 //! checklist, dispatch to the appropriate runner.
 //!
-//! [`select_initial_transport`] is a pure function that picks DIDComm or
-//! REST based on the VTA's advertised endpoints.
+//! [`select_initial_transport`] is a pure function that picks TSP,
+//! DIDComm or REST based on the VTA's advertised endpoints, in that
+//! preference order.
 //!
 //! [`run_connection_test`] is the event-driven entry point. Resolves the
-//! VTA DID, enumerates services, then dispatches to either
+//! VTA DID, enumerates services, then dispatches to
+//! [`super::runner_tsp::run_tsp_attempt`],
 //! [`super::runner_didcomm::run_didcomm_attempt`] or one of the
 //! [`super::runner_rest`] entry points depending on the chosen transport
 //! and the [`super::intent::VtaIntent`].
@@ -34,29 +36,101 @@ use super::runner_didcomm::{run_didcomm_attempt, run_provision_flight};
 use super::runner_rest::{
     run_rest_attempt_admin_only, run_rest_attempt_admin_rotated, run_rest_attempt_full_setup,
 };
+use super::runner_tsp::run_tsp_attempt;
 
 /// Which transport(s) the VTA advertises and how the orchestrator should
 /// treat them on this run.
+///
+/// One variant per cell of the 2×2×2 advertise matrix
+/// (`#tsp` × `#DIDCommMessaging` × `#vta-rest`), so the choice never loses
+/// information the runner needs for fallback. [`ResolvedVta`] carries all
+/// three endpoints; before #869 this enum only looked at two of them, and a
+/// VTA advertising nothing but `#tsp` therefore resolved to
+/// [`Neither`](InitialChoice::Neither) — "no endpoints" — with an endpoint
+/// sitting right there in the resolved document.
+///
+/// Preference order is TSP > DIDComm > REST, matching
+/// [`ResolvedVta::advertised`] and the VTA's own inbound ranking
+/// (`vta-service`'s `tsp_inbound`). The runner starts on the highest-ranked
+/// transport advertised and degrades to a lower one only on a **pre-auth**
+/// failure — see [`run_connection_test`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum InitialChoice {
-    /// Both DIDComm and REST endpoints advertised. Start with DIDComm.
+    /// Only `#tsp` advertised. Provisioning runs over TSP; there is nothing
+    /// to fall back to, so a build without the `tsp` feature fails here
+    /// (naming that as the reason).
+    TspOnly,
+    /// `#tsp` + `#DIDCommMessaging`. Start with TSP, fall back to DIDComm.
+    /// This is the reference deployment's shape.
+    TspAndDIDComm,
+    /// `#tsp` + `vta-rest`. Start with TSP, fall back to REST.
+    TspAndRest,
+    /// All three advertised. Start with TSP, fall back to DIDComm.
+    TspDIDCommAndRest,
+    /// Both DIDComm and REST endpoints advertised, no `#tsp`. Start with
+    /// DIDComm.
     BothAvailable,
     /// Only `#DIDCommMessaging` advertised.
     DIDCommOnly,
     /// Only `vta-rest` advertised.
     RestOnly,
-    /// Neither transport is advertised — workflow cannot proceed online.
+    /// No transport is advertised — workflow cannot proceed online.
     Neither,
+}
+
+impl InitialChoice {
+    /// Does the run start on the TSP leg?
+    #[must_use]
+    pub fn starts_with_tsp(self) -> bool {
+        matches!(
+            self,
+            Self::TspOnly | Self::TspAndDIDComm | Self::TspAndRest | Self::TspDIDCommAndRest
+        )
+    }
+
+    /// Is a DIDComm mediator available on this run — as the primary leg or as
+    /// the TSP leg's fallback?
+    #[must_use]
+    pub fn has_didcomm(self) -> bool {
+        matches!(
+            self,
+            Self::TspAndDIDComm | Self::TspDIDCommAndRest | Self::BothAvailable | Self::DIDCommOnly
+        )
+    }
+
+    /// Is a REST endpoint available on this run — as the primary leg or as a
+    /// fallback?
+    #[must_use]
+    pub fn has_rest(self) -> bool {
+        matches!(
+            self,
+            Self::TspAndRest | Self::TspDIDCommAndRest | Self::BothAvailable | Self::RestOnly
+        )
+    }
 }
 
 /// Decide the initial transport based on what the VTA's DID document
 /// advertises. Pure function — no I/O.
+///
+/// Consults **all three** of [`ResolvedVta`]'s endpoints. The result is
+/// deliberately independent of which cargo features this build has: a
+/// TSP-only VTA selects [`InitialChoice::TspOnly`] whether or not `tsp` is
+/// compiled in, so the failure a `tsp`-less build produces names the missing
+/// feature rather than pretending the DID document was empty.
 pub fn select_initial_transport(resolved: &ResolvedVta) -> InitialChoice {
-    match (resolved.mediator_did.is_some(), resolved.rest_url.is_some()) {
-        (true, true) => InitialChoice::BothAvailable,
-        (true, false) => InitialChoice::DIDCommOnly,
-        (false, true) => InitialChoice::RestOnly,
-        (false, false) => InitialChoice::Neither,
+    match (
+        resolved.tsp_mediator_did.is_some(),
+        resolved.mediator_did.is_some(),
+        resolved.rest_url.is_some(),
+    ) {
+        (true, true, true) => InitialChoice::TspDIDCommAndRest,
+        (true, true, false) => InitialChoice::TspAndDIDComm,
+        (true, false, true) => InitialChoice::TspAndRest,
+        (true, false, false) => InitialChoice::TspOnly,
+        (false, true, true) => InitialChoice::BothAvailable,
+        (false, true, false) => InitialChoice::DIDCommOnly,
+        (false, false, true) => InitialChoice::RestOnly,
+        (false, false, false) => InitialChoice::Neither,
     }
 }
 
@@ -66,11 +140,25 @@ pub fn select_initial_transport(resolved: &ResolvedVta) -> InitialChoice {
 /// events carry enough detail for the consumer's UI to surface an
 /// actionable error without having to dig into logs.
 ///
-/// `force_transport`: `Some(Protocol::Rest)` forces REST; `Some(Protocol::DidComm)`
-/// forces DIDComm; `None` lets [`select_initial_transport`] auto-pick.
+/// `force_transport`: `Some(Protocol::Tsp)` forces TSP;
+/// `Some(Protocol::Rest)` forces REST; `Some(Protocol::DidComm)` forces
+/// DIDComm; `None` lets [`select_initial_transport`] auto-pick.
 /// The forced choice is honoured only when the requested transport is
 /// actually advertised; otherwise the runner quietly falls back to
-/// auto-pick.
+/// auto-pick. Forcing pins the run to that one leg — the auto-picked TSP
+/// path degrades to DIDComm/REST on a pre-auth failure, a forced one does
+/// not.
+///
+/// # Transport ranking and degradation
+///
+/// TSP > DIDComm > REST, per [`InitialChoice`]. When the auto-picked TSP
+/// leg fails **before** auth (no `tsp` feature compiled in, mediator
+/// unreachable, socket refused) and the VTA also advertises DIDComm or
+/// REST, the runner reports the TSP attempt and continues on the next
+/// transport rather than failing the run — the same reasoning the
+/// pre-auth/post-auth split already encodes (`AttemptOutcome`). A
+/// **post**-auth TSP failure is terminal: the VTA accepted us and another
+/// wire reproduces the rejection.
 pub async fn run_connection_test(
     intent: VtaIntent,
     vta_did: String,
@@ -84,10 +172,15 @@ pub async fn run_connection_test(
     let _ = tx.send(VtaEvent::CheckStart(DiagCheck::ResolveDid));
     let resolved = match resolve_vta(&vta_did).await {
         Ok(r) => {
-            let detail = match (&r.mediator_did, &r.rest_url) {
-                (Some(m), _) => format!("mediator DID: {m}"),
-                (None, Some(u)) => format!("REST: {u}"),
-                (None, None) => "resolved (no endpoints)".into(),
+            // Report the endpoint the runner will actually start on, in
+            // preference order. `tsp_mediator_did` used to be missing from
+            // this match, so a TSP-only VTA reported "resolved (no
+            // endpoints)" about a document that had just yielded one (#869).
+            let detail = match (&r.tsp_mediator_did, &r.mediator_did, &r.rest_url) {
+                (Some(t), _, _) => format!("TSP mediator DID: {t}"),
+                (None, Some(m), _) => format!("mediator DID: {m}"),
+                (None, None, Some(u)) => format!("REST: {u}"),
+                (None, None, None) => "resolved (no endpoints)".into(),
             };
             let _ = tx.send(VtaEvent::CheckDone(
                 DiagCheck::ResolveDid,
@@ -113,20 +206,23 @@ pub async fn run_connection_test(
     let _ = tx.send(VtaEvent::CheckStart(DiagCheck::EnumerateServices));
     let rest_url = resolved.rest_url.clone();
     let mediator_did_opt = resolved.mediator_did.clone();
+    let tsp_mediator_did_opt = resolved.tsp_mediator_did.clone();
+    let yes_no = |present: bool| if present { "yes" } else { "no" };
     let enum_detail = format!(
-        "REST: {}, DIDCommMessaging: {}",
-        if rest_url.is_some() { "yes" } else { "no" },
-        if mediator_did_opt.is_some() {
-            "yes"
-        } else {
-            "no"
-        },
+        "TSP: {}, REST: {}, DIDCommMessaging: {}",
+        yes_no(tsp_mediator_did_opt.is_some()),
+        yes_no(rest_url.is_some()),
+        yes_no(mediator_did_opt.is_some()),
     );
     let auto_choice = select_initial_transport(&resolved);
 
+    // A forced transport pins the run to that single leg — hence the
+    // `*Only` variants, which carry no fallback. Honoured only when the
+    // requested transport is actually advertised.
     let choice = match force_transport {
-        Some(Protocol::Rest) if resolved.rest_url.is_some() => InitialChoice::RestOnly,
-        Some(Protocol::DidComm) if resolved.mediator_did.is_some() => InitialChoice::DIDCommOnly,
+        Some(Protocol::Tsp) if tsp_mediator_did_opt.is_some() => InitialChoice::TspOnly,
+        Some(Protocol::Rest) if rest_url.is_some() => InitialChoice::RestOnly,
+        Some(Protocol::DidComm) if mediator_did_opt.is_some() => InitialChoice::DIDCommOnly,
         _ => auto_choice,
     };
 
@@ -134,6 +230,10 @@ pub async fn run_connection_test(
         let _ = tx.send(VtaEvent::CheckDone(
             DiagCheck::EnumerateServices,
             DiagStatus::Failed(enum_detail),
+        ));
+        let _ = tx.send(VtaEvent::CheckDone(
+            DiagCheck::AuthenticateTSP,
+            DiagStatus::Skipped("no TSP endpoint".into()),
         ));
         let _ = tx.send(VtaEvent::CheckDone(
             DiagCheck::AuthenticateDIDComm,
@@ -152,8 +252,9 @@ pub async fn run_connection_test(
             DiagStatus::Skipped("no transport".into()),
         ));
         let _ = tx.send(VtaEvent::Failed(
-            "VTA DID document advertises neither a DIDComm mediator endpoint \
-             nor a REST endpoint. Use the offline sealed-handoff flow."
+            "VTA DID document advertises no usable transport — no `#tsp` \
+             service, no DIDComm mediator endpoint, and no REST endpoint. \
+             Use the offline sealed-handoff flow."
                 .into(),
         ));
         return;
@@ -164,6 +265,67 @@ pub async fn run_connection_test(
     ));
 
     // ── 3. Dispatch by transport choice ───────────────────────────────
+    if choice.starts_with_tsp() {
+        let tsp_mediator_did = tsp_mediator_did_opt.expect("TSP path requires tsp_mediator_did");
+        let outcome = run_tsp_attempt(
+            intent,
+            vta_did.clone(),
+            tsp_mediator_did.clone(),
+            rest_url.clone(),
+            setup_did.clone(),
+            setup_privkey_mb.clone(),
+            ask.clone(),
+            &tx,
+        )
+        .await;
+
+        // Degrade only on a pre-auth failure, and only when the document
+        // actually advertises somewhere else to go. Everything else is
+        // terminal on this leg.
+        if let AttemptOutcome::PreAuthFailure(reason) = &outcome
+            && (choice.has_didcomm() || choice.has_rest())
+        {
+            let _ = tx.send(VtaEvent::AttemptCompleted {
+                protocol: Protocol::Tsp,
+                outcome: AttemptResultKind::PreAuthFailure(reason.clone()),
+            });
+            if choice.has_didcomm() {
+                let mediator_did =
+                    mediator_did_opt.expect("has_didcomm() implies an advertised mediator");
+                dispatch_didcomm_leg(
+                    intent,
+                    vta_did,
+                    mediator_did,
+                    rest_url,
+                    setup_did,
+                    setup_privkey_mb,
+                    ask,
+                    "TSP leg unavailable — continuing on DIDComm",
+                    &tx,
+                )
+                .await;
+            } else {
+                let rest_url_str = rest_url.clone().expect("has_rest() implies a REST URL");
+                dispatch_rest_leg(
+                    intent,
+                    vta_did,
+                    rest_url_str,
+                    rest_url,
+                    setup_did,
+                    setup_privkey_mb,
+                    ask,
+                    "TSP leg unavailable — continuing on REST",
+                    &tx,
+                )
+                .await;
+            }
+            return;
+        }
+
+        emit_mediator_outcome(Protocol::Tsp, outcome, rest_url, tsp_mediator_did, &tx);
+        return;
+    }
+
     match choice {
         InitialChoice::BothAvailable | InitialChoice::DIDCommOnly => {
             let mediator_did = mediator_did_opt.expect("DIDComm path requires mediator_did");
@@ -172,144 +334,216 @@ pub async fn run_connection_test(
             } else {
                 "DIDComm-only VTA"
             };
-            let _ = tx.send(VtaEvent::CheckDone(
-                DiagCheck::AuthenticateREST,
-                DiagStatus::Skipped(rest_skip_msg.into()),
-            ));
-
-            let outcome = run_didcomm_attempt(
+            dispatch_didcomm_leg(
                 intent,
                 vta_did,
-                mediator_did.clone(),
-                rest_url.clone(),
+                mediator_did,
+                rest_url,
                 setup_did,
                 setup_privkey_mb,
-                ask.clone(),
+                ask,
+                rest_skip_msg,
                 &tx,
             )
             .await;
-
-            match outcome {
-                AttemptOutcome::Connected(reply) => {
-                    let _ = tx.send(VtaEvent::AttemptCompleted {
-                        protocol: Protocol::DidComm,
-                        outcome: AttemptResultKind::Connected,
-                    });
-                    let _ = tx.send(VtaEvent::Connected {
-                        protocol: Protocol::DidComm,
-                        rest_url,
-                        mediator_did: Some(mediator_did),
-                        reply,
-                    });
-                }
-                AttemptOutcome::PreflightOk {
-                    rest_url,
-                    mediator_did,
-                    servers,
-                } => {
-                    // Mid-attempt — the run_provision_flight follow-up
-                    // emits its own terminal event.
-                    let _ = tx.send(VtaEvent::PreflightDone {
-                        rest_url,
-                        mediator_did,
-                        servers,
-                    });
-                }
-                AttemptOutcome::PreAuthFailure(reason) => {
-                    let _ = tx.send(VtaEvent::AttemptCompleted {
-                        protocol: Protocol::DidComm,
-                        outcome: AttemptResultKind::PreAuthFailure(reason.clone()),
-                    });
-                    let _ = tx.send(VtaEvent::Failed(reason));
-                }
-                AttemptOutcome::PostAuthFailure(reason) => {
-                    let _ = tx.send(VtaEvent::AttemptCompleted {
-                        protocol: Protocol::DidComm,
-                        outcome: AttemptResultKind::PostAuthFailure(reason.clone()),
-                    });
-                    let _ = tx.send(VtaEvent::Failed(reason));
-                }
-            }
         }
         InitialChoice::RestOnly => {
             let rest_url_str = rest_url.clone().expect("REST path requires rest_url");
-            let _ = tx.send(VtaEvent::CheckDone(
-                DiagCheck::AuthenticateDIDComm,
-                DiagStatus::Skipped("REST-only VTA".into()),
-            ));
-
-            let outcome = match intent {
-                VtaIntent::AdminOnly => {
-                    run_rest_attempt_admin_only(
-                        &rest_url_str,
-                        &vta_did,
-                        setup_did,
-                        setup_privkey_mb,
-                        &tx,
-                    )
-                    .await
-                }
-                VtaIntent::FullSetup => {
-                    run_rest_attempt_full_setup(
-                        &rest_url_str,
-                        &vta_did,
-                        setup_did,
-                        setup_privkey_mb,
-                        ask,
-                        &tx,
-                    )
-                    .await
-                }
-                VtaIntent::AdminRotated => {
-                    run_rest_attempt_admin_rotated(
-                        &rest_url_str,
-                        &vta_did,
-                        setup_did,
-                        setup_privkey_mb,
-                        ask,
-                        &tx,
-                    )
-                    .await
-                }
-            };
-
-            match outcome {
-                AttemptOutcome::Connected(reply) => {
-                    let _ = tx.send(VtaEvent::AttemptCompleted {
-                        protocol: Protocol::Rest,
-                        outcome: AttemptResultKind::Connected,
-                    });
-                    let _ = tx.send(VtaEvent::Connected {
-                        protocol: Protocol::Rest,
-                        rest_url,
-                        mediator_did: None,
-                        reply,
-                    });
-                }
-                AttemptOutcome::PreflightOk { .. } => {
-                    let _ = tx.send(VtaEvent::Failed(
-                        "REST attempt produced an unexpected PreflightOk outcome — \
-                         wiring bug; please report."
-                            .into(),
-                    ));
-                }
-                AttemptOutcome::PreAuthFailure(reason) => {
-                    let _ = tx.send(VtaEvent::AttemptCompleted {
-                        protocol: Protocol::Rest,
-                        outcome: AttemptResultKind::PreAuthFailure(reason.clone()),
-                    });
-                    let _ = tx.send(VtaEvent::Failed(reason));
-                }
-                AttemptOutcome::PostAuthFailure(reason) => {
-                    let _ = tx.send(VtaEvent::AttemptCompleted {
-                        protocol: Protocol::Rest,
-                        outcome: AttemptResultKind::PostAuthFailure(reason.clone()),
-                    });
-                    let _ = tx.send(VtaEvent::Failed(reason));
-                }
-            }
+            dispatch_rest_leg(
+                intent,
+                vta_did,
+                rest_url_str,
+                rest_url,
+                setup_did,
+                setup_privkey_mb,
+                ask,
+                "REST-only VTA",
+                &tx,
+            )
+            .await;
         }
         InitialChoice::Neither => unreachable!("handled above"),
+        InitialChoice::TspOnly
+        | InitialChoice::TspAndDIDComm
+        | InitialChoice::TspAndRest
+        | InitialChoice::TspDIDCommAndRest => {
+            unreachable!("handled by the starts_with_tsp() branch above")
+        }
+    }
+}
+
+/// Translate a mediator-transport attempt (TSP or DIDComm) into the
+/// terminal [`VtaEvent`]s. Shared so the two legs cannot drift in what
+/// they report; `protocol` and `mediator_did` are what differ.
+fn emit_mediator_outcome(
+    protocol: Protocol,
+    outcome: AttemptOutcome,
+    rest_url: Option<String>,
+    mediator_did: String,
+    tx: &UnboundedSender<VtaEvent>,
+) {
+    match outcome {
+        AttemptOutcome::Connected(reply) => {
+            let _ = tx.send(VtaEvent::AttemptCompleted {
+                protocol,
+                outcome: AttemptResultKind::Connected,
+            });
+            let _ = tx.send(VtaEvent::Connected {
+                protocol,
+                rest_url,
+                mediator_did: Some(mediator_did),
+                reply,
+            });
+        }
+        AttemptOutcome::PreflightOk {
+            rest_url,
+            mediator_did,
+            servers,
+        } => {
+            // Mid-attempt — the run_provision_flight follow-up
+            // emits its own terminal event.
+            let _ = tx.send(VtaEvent::PreflightDone {
+                rest_url,
+                mediator_did,
+                servers,
+            });
+        }
+        AttemptOutcome::PreAuthFailure(reason) => {
+            let _ = tx.send(VtaEvent::AttemptCompleted {
+                protocol,
+                outcome: AttemptResultKind::PreAuthFailure(reason.clone()),
+            });
+            let _ = tx.send(VtaEvent::Failed(reason));
+        }
+        AttemptOutcome::PostAuthFailure(reason) => {
+            let _ = tx.send(VtaEvent::AttemptCompleted {
+                protocol,
+                outcome: AttemptResultKind::PostAuthFailure(reason.clone()),
+            });
+            let _ = tx.send(VtaEvent::Failed(reason));
+        }
+    }
+}
+
+/// Run the DIDComm leg and emit its terminal events.
+///
+/// Extracted from [`run_connection_test`]'s match so the TSP leg can reuse
+/// it verbatim as its pre-auth fallback rather than growing a second copy.
+#[allow(clippy::too_many_arguments)]
+async fn dispatch_didcomm_leg(
+    intent: VtaIntent,
+    vta_did: String,
+    mediator_did: String,
+    rest_url: Option<String>,
+    setup_did: String,
+    setup_privkey_mb: String,
+    ask: ProvisionAsk,
+    rest_skip_msg: &str,
+    tx: &UnboundedSender<VtaEvent>,
+) {
+    let _ = tx.send(VtaEvent::CheckDone(
+        DiagCheck::AuthenticateREST,
+        DiagStatus::Skipped(rest_skip_msg.to_string()),
+    ));
+
+    let outcome = run_didcomm_attempt(
+        intent,
+        vta_did,
+        mediator_did.clone(),
+        rest_url.clone(),
+        setup_did,
+        setup_privkey_mb,
+        ask,
+        tx,
+    )
+    .await;
+
+    emit_mediator_outcome(Protocol::DidComm, outcome, rest_url, mediator_did, tx);
+}
+
+/// Run the REST leg and emit its terminal events. The counterpart to
+/// [`dispatch_didcomm_leg`], reused as the TSP leg's fallback when the VTA
+/// advertises REST but no DIDComm mediator.
+#[allow(clippy::too_many_arguments)]
+async fn dispatch_rest_leg(
+    intent: VtaIntent,
+    vta_did: String,
+    rest_url_str: String,
+    rest_url: Option<String>,
+    setup_did: String,
+    setup_privkey_mb: String,
+    ask: ProvisionAsk,
+    didcomm_skip_msg: &str,
+    tx: &UnboundedSender<VtaEvent>,
+) {
+    let _ = tx.send(VtaEvent::CheckDone(
+        DiagCheck::AuthenticateDIDComm,
+        DiagStatus::Skipped(didcomm_skip_msg.to_string()),
+    ));
+
+    let outcome = match intent {
+        VtaIntent::AdminOnly => {
+            run_rest_attempt_admin_only(&rest_url_str, &vta_did, setup_did, setup_privkey_mb, tx)
+                .await
+        }
+        VtaIntent::FullSetup => {
+            run_rest_attempt_full_setup(
+                &rest_url_str,
+                &vta_did,
+                setup_did,
+                setup_privkey_mb,
+                ask,
+                tx,
+            )
+            .await
+        }
+        VtaIntent::AdminRotated => {
+            run_rest_attempt_admin_rotated(
+                &rest_url_str,
+                &vta_did,
+                setup_did,
+                setup_privkey_mb,
+                ask,
+                tx,
+            )
+            .await
+        }
+    };
+
+    match outcome {
+        AttemptOutcome::Connected(reply) => {
+            let _ = tx.send(VtaEvent::AttemptCompleted {
+                protocol: Protocol::Rest,
+                outcome: AttemptResultKind::Connected,
+            });
+            let _ = tx.send(VtaEvent::Connected {
+                protocol: Protocol::Rest,
+                rest_url,
+                mediator_did: None,
+                reply,
+            });
+        }
+        AttemptOutcome::PreflightOk { .. } => {
+            let _ = tx.send(VtaEvent::Failed(
+                "REST attempt produced an unexpected PreflightOk outcome — \
+                 wiring bug; please report."
+                    .into(),
+            ));
+        }
+        AttemptOutcome::PreAuthFailure(reason) => {
+            let _ = tx.send(VtaEvent::AttemptCompleted {
+                protocol: Protocol::Rest,
+                outcome: AttemptResultKind::PreAuthFailure(reason.clone()),
+            });
+            let _ = tx.send(VtaEvent::Failed(reason));
+        }
+        AttemptOutcome::PostAuthFailure(reason) => {
+            let _ = tx.send(VtaEvent::AttemptCompleted {
+                protocol: Protocol::Rest,
+                outcome: AttemptResultKind::PostAuthFailure(reason.clone()),
+            });
+            let _ = tx.send(VtaEvent::Failed(reason));
+        }
     }
 }
 
@@ -543,36 +777,179 @@ pub async fn provision_admin_rotated_via_rest(
 mod tests {
     use super::*;
 
-    fn resolved(mediator_did: Option<&str>, rest_url: Option<&str>) -> ResolvedVta {
+    const TSP_MEDIATOR: &str = "did:webvh:tsp-mediator.test";
+    const MEDIATOR: &str = "did:webvh:mediator.test";
+    const REST: &str = "https://vta.test";
+
+    /// Full three-endpoint fixture. `tsp` is deliberately a *separate*
+    /// argument from `mediator_did` — the resolver reads the `#tsp` entry on
+    /// its own and never assumes it equals the DIDComm mediator, so the
+    /// selection matrix must be exercised with them independent.
+    fn resolved(
+        tsp: Option<&str>,
+        mediator_did: Option<&str>,
+        rest_url: Option<&str>,
+    ) -> ResolvedVta {
         ResolvedVta {
             vta_did: "did:webvh:vta.test".into(),
-            tsp_mediator_did: None,
+            tsp_mediator_did: tsp.map(str::to_string),
             mediator_did: mediator_did.map(str::to_string),
             rest_url: rest_url.map(str::to_string),
         }
     }
 
+    // ── The 2×2×2 selection matrix ────────────────────────────────────
+    //
+    // Eight advertise combinations, eight variants, one test each. The
+    // matrix is pinned exhaustively because #869 was precisely a cell that
+    // nothing covered: `select_initial_transport` matched on two of the
+    // three endpoints `ResolvedVta` carries, so every TSP-advertising row
+    // below collapsed onto its non-TSP neighbour and the TSP-only row
+    // reported `Neither`.
+
+    #[test]
+    fn select_returns_tsp_only_when_only_tsp_advertised() {
+        let r = resolved(Some(TSP_MEDIATOR), None, None);
+        assert_eq!(
+            select_initial_transport(&r),
+            InitialChoice::TspOnly,
+            "a TSP-only VTA must not resolve to `Neither` — #869"
+        );
+    }
+
+    #[test]
+    fn select_returns_tsp_and_didcomm_when_both_mediator_transports_advertised() {
+        let r = resolved(Some(TSP_MEDIATOR), Some(MEDIATOR), None);
+        assert_eq!(select_initial_transport(&r), InitialChoice::TspAndDIDComm);
+    }
+
+    #[test]
+    fn select_returns_tsp_and_rest_when_tsp_and_rest_advertised() {
+        let r = resolved(Some(TSP_MEDIATOR), None, Some(REST));
+        assert_eq!(select_initial_transport(&r), InitialChoice::TspAndRest);
+    }
+
+    #[test]
+    fn select_returns_all_three_when_all_three_advertised() {
+        let r = resolved(Some(TSP_MEDIATOR), Some(MEDIATOR), Some(REST));
+        assert_eq!(
+            select_initial_transport(&r),
+            InitialChoice::TspDIDCommAndRest
+        );
+    }
+
     #[test]
     fn select_returns_both_when_both_advertised() {
-        let r = resolved(Some("did:webvh:mediator.test"), Some("https://vta.test"));
+        let r = resolved(None, Some(MEDIATOR), Some(REST));
         assert_eq!(select_initial_transport(&r), InitialChoice::BothAvailable);
     }
 
     #[test]
     fn select_returns_didcomm_only_when_only_didcomm_advertised() {
-        let r = resolved(Some("did:webvh:mediator.test"), None);
+        let r = resolved(None, Some(MEDIATOR), None);
         assert_eq!(select_initial_transport(&r), InitialChoice::DIDCommOnly);
     }
 
     #[test]
     fn select_returns_rest_only_when_only_rest_advertised() {
-        let r = resolved(None, Some("https://vta.test"));
+        let r = resolved(None, None, Some(REST));
         assert_eq!(select_initial_transport(&r), InitialChoice::RestOnly);
     }
 
     #[test]
     fn select_returns_neither_when_no_transport_advertised() {
-        let r = resolved(None, None);
+        let r = resolved(None, None, None);
         assert_eq!(select_initial_transport(&r), InitialChoice::Neither);
+    }
+
+    /// `Neither` means exactly one thing: the document advertises nothing.
+    /// Any advertised endpoint — including a `#tsp` the SDK may or may not
+    /// have been compiled to speak — must select something else, because
+    /// `Neither` is what makes the runner print "advertises no usable
+    /// transport" and send the operator hunting a DID-document error.
+    #[test]
+    fn neither_is_reserved_for_a_document_that_advertises_nothing() {
+        for (tsp, didcomm, rest) in [
+            (Some(TSP_MEDIATOR), None, None),
+            (None, Some(MEDIATOR), None),
+            (None, None, Some(REST)),
+            (Some(TSP_MEDIATOR), Some(MEDIATOR), Some(REST)),
+        ] {
+            let r = resolved(tsp, didcomm, rest);
+            assert_ne!(
+                select_initial_transport(&r),
+                InitialChoice::Neither,
+                "{:?} advertises something",
+                r.advertised()
+            );
+        }
+    }
+
+    /// Selection is feature-independent by construction: this assertion
+    /// holds in a `tsp` build and a non-`tsp` build alike. A build that
+    /// cannot speak TSP still *selects* TSP and then fails naming the
+    /// missing cargo feature — see `runner_tsp`.
+    #[test]
+    fn tsp_selection_does_not_depend_on_the_tsp_feature() {
+        let r = resolved(Some(TSP_MEDIATOR), None, None);
+        assert_eq!(select_initial_transport(&r), InitialChoice::TspOnly);
+    }
+
+    // ── Ranking helpers: TSP > DIDComm > REST ─────────────────────────
+
+    /// Every TSP-advertising cell starts on TSP; no other cell does.
+    #[test]
+    fn starts_with_tsp_covers_exactly_the_tsp_variants() {
+        for choice in [
+            InitialChoice::TspOnly,
+            InitialChoice::TspAndDIDComm,
+            InitialChoice::TspAndRest,
+            InitialChoice::TspDIDCommAndRest,
+        ] {
+            assert!(choice.starts_with_tsp(), "{choice:?}");
+        }
+        for choice in [
+            InitialChoice::BothAvailable,
+            InitialChoice::DIDCommOnly,
+            InitialChoice::RestOnly,
+            InitialChoice::Neither,
+        ] {
+            assert!(!choice.starts_with_tsp(), "{choice:?}");
+        }
+    }
+
+    /// The fallback predicates must agree with what the resolved document
+    /// actually carried, or the runner's `expect`s in the degrade path are
+    /// live panics.
+    #[test]
+    fn fallback_predicates_match_the_resolved_endpoints() {
+        for (tsp, didcomm, rest) in [
+            (None, None, None),
+            (None, None, Some(REST)),
+            (None, Some(MEDIATOR), None),
+            (None, Some(MEDIATOR), Some(REST)),
+            (Some(TSP_MEDIATOR), None, None),
+            (Some(TSP_MEDIATOR), None, Some(REST)),
+            (Some(TSP_MEDIATOR), Some(MEDIATOR), None),
+            (Some(TSP_MEDIATOR), Some(MEDIATOR), Some(REST)),
+        ] {
+            let r = resolved(tsp, didcomm, rest);
+            let choice = select_initial_transport(&r);
+            assert_eq!(
+                choice.starts_with_tsp(),
+                r.tsp_mediator_did.is_some(),
+                "{choice:?}"
+            );
+            assert_eq!(choice.has_didcomm(), r.mediator_did.is_some(), "{choice:?}");
+            assert_eq!(choice.has_rest(), r.rest_url.is_some(), "{choice:?}");
+        }
+    }
+
+    /// TSP-only is the one cell with nowhere to degrade to — the runner
+    /// must surface the TSP failure rather than silently trying nothing.
+    #[test]
+    fn tsp_only_has_no_fallback() {
+        assert!(!InitialChoice::TspOnly.has_didcomm());
+        assert!(!InitialChoice::TspOnly.has_rest());
     }
 }

--- a/vta-sdk/src/provision_client/runner_tsp.rs
+++ b/vta-sdk/src/provision_client/runner_tsp.rs
@@ -1,0 +1,590 @@
+//! TSP transport for the online provisioning attempt fns, plus the
+//! one-shot [`provision_via_tsp`] entry point that doesn't go through the
+//! runner orchestration at all.
+//!
+//! Sibling to [`super::runner_didcomm`] and [`super::runner_rest`]. All
+//! three return the shared [`super::event::AttemptOutcome`] so the
+//! orchestrator's outcome → event translation is uniform regardless of
+//! which wire delivered the credential.
+//!
+//! # Why provisioning rides TSP without new protocol surface
+//!
+//! The VTA's TSP inbound dispatcher (`vta-service`'s
+//! `messaging::tsp_inbound::dispatch_one`) hands every unpacked frame
+//! straight to `dispatch_trust_task_core` — the *same* spine REST and the
+//! DIDComm trust-task envelope feed. Both operations this flow needs are
+//! registered on that spine:
+//!
+//! - `spec/vta/webvh/servers/list/1.0`
+//!   ([`TASK_WEBVH_SERVERS_LIST_1_0`]) — the webvh-host catalogue.
+//! - `spec/provision/integration/0.2`
+//!   ([`TASK_PROVISION_INTEGRATION_0_2`]) — the VP-framed bootstrap
+//!   request and its sealed reply.
+//!
+//! So the request and reply documents are byte-identical to the ones the
+//! other two transports carry, and this module is wiring rather than
+//! protocol design. Note the **0.2** URI: the DIDComm leg addresses
+//! `provision/integration/0.1` as a DIDComm *protocol message* (routed by
+//! `messaging::handlers_protocol`, not by the trust-task spine), and only
+//! 0.2 is on the spine. The signed VP inside is byte-identical either way
+//! — `spec_version` selects the casing of the *options* around it.
+//!
+//! # What TSP does not share with DIDComm
+//!
+//! - **No handshake, no envelope.** TSP carries the Trust-Task bytes
+//!   directly and `unpack` yields a cryptographically *proven* sender VID,
+//!   which the VTA resolves straight to its ACL grant. There is no
+//!   authcrypt envelope, no challenge, and no bearer token.
+//! - **No mediator-side ACL step.** `DIDCommSession::connect` sets the
+//!   client's mediator ACL and flushes its inbox; the TSP socket does
+//!   neither.
+//! - **Correlation is the application's job.** TSP frames carry no
+//!   transport thread-id, so replies are matched on the response
+//!   document's `threadId` (see `tsp_demux`). That is already implemented
+//!   under [`VtaClient::dispatch_trust_task`], which this module drives
+//!   rather than re-deriving.
+//!
+//! What it *does* share is the shape of the checklist: the socket open is
+//! the [`DiagCheck::AuthenticateTSP`] proxy exactly as the mediator
+//! connect is the [`DiagCheck::AuthenticateDIDComm`] proxy on the DIDComm
+//! leg — neither transport performs a VTA round-trip at connect time. The
+//! first *authorized* round-trip is the real ACL proof, and on the
+//! FullSetup path that is the very next step.
+//!
+//! # Feature gate
+//!
+//! `provision-client` does not imply `tsp`, so every entry point here has
+//! a `#[cfg(not(feature = "tsp"))]` twin that fails with the same message
+//! shape `session::connect_tsp_bounded` uses: name the missing feature,
+//! don't pretend the DID document was at fault.
+//!
+//! [`TASK_WEBVH_SERVERS_LIST_1_0`]: crate::trust_tasks::TASK_WEBVH_SERVERS_LIST_1_0
+//! [`TASK_PROVISION_INTEGRATION_0_2`]: crate::trust_tasks::TASK_PROVISION_INTEGRATION_0_2
+//! [`VtaClient::dispatch_trust_task`]: crate::client::VtaClient::dispatch_trust_task
+//! [`DiagCheck::AuthenticateTSP`]: super::diagnostics::DiagCheck::AuthenticateTSP
+//! [`DiagCheck::AuthenticateDIDComm`]: super::diagnostics::DiagCheck::AuthenticateDIDComm
+
+use tokio::sync::mpsc::UnboundedSender;
+
+use super::ask::ProvisionAsk;
+use super::event::{AttemptOutcome, VtaEvent};
+use super::intent::VtaIntent;
+
+/// Round-trip budget for the `provision-integration` call over TSP.
+/// Matches the DIDComm leg's `DEFAULT_TIMEOUT_SECS` — the VTA mints keys,
+/// renders templates, builds the webvh log and seals the bundle
+/// synchronously before replying, and none of that is transport-dependent.
+#[cfg(feature = "tsp")]
+const PROVISION_TIMEOUT_SECS: u64 = 60;
+
+/// Round-trip budget for the webvh-server catalogue lookup, matching the
+/// DIDComm leg's `send_and_wait(..., 30)`.
+#[cfg(feature = "tsp")]
+const LIST_SERVERS_TIMEOUT_SECS: u64 = 30;
+
+/// The message an operator sees when the VTA advertises `#tsp` but this
+/// build cannot speak it. Mirrors `session::connect_tsp_bounded`'s wording
+/// so the two paths read the same in a log.
+#[cfg(not(feature = "tsp"))]
+fn tsp_feature_missing(vta_did: &str, tsp_mediator_did: &str) -> String {
+    format!(
+        "VTA '{vta_did}' advertises a TSP service (`#tsp` → {tsp_mediator_did}), but this \
+         build of the SDK was compiled without the `tsp` feature, so it cannot provision \
+         over TSP.\n\n\
+         Rebuild the setup tool with `--features tsp`, or point provisioning at a VTA \
+         that also advertises a DIDComm mediator or a `#vta-rest` endpoint."
+    )
+}
+
+/// Run the TSP leg of the auth check.
+///
+/// Emits diagnostic rows ([`super::diagnostics::DiagCheck::AuthenticateTSP`],
+/// [`super::diagnostics::DiagCheck::ListWebvhServers`],
+/// [`super::diagnostics::DiagCheck::ProvisionIntegration`]) through `tx`
+/// and returns the shared [`AttemptOutcome`], exactly like
+/// [`super::runner_didcomm::run_didcomm_attempt`].
+///
+/// Pre-auth boundary: anything up to and including the TSP socket opening
+/// is pre-auth — a failure there is worth retrying on another transport,
+/// and the orchestrator does so when the VTA advertises one. Once a
+/// trust-task round-trip has been accepted by the VTA the failure is
+/// post-auth and terminal.
+///
+/// # FullSetup and the webvh-server picker
+///
+/// Unlike the DIDComm leg this arm does **not** split into a preflight +
+/// [`super::runner_didcomm::run_provision_flight`] pair. The split exists so an
+/// interactive consumer can close its session while a picker dialog is on
+/// screen; the picker itself is driven by the consumer off
+/// [`VtaEvent::PreflightDone`], whose `mediator_did` field is a DIDComm
+/// mediator by construction. Rather than overload that field with a TSP
+/// mediator (the resolver deliberately keeps the two apart — see
+/// [`super::resolve::ResolvedVta`]), the TSP leg runs the catalogue lookup
+/// and the provision round-trip back-to-back on one socket and resolves
+/// the server choice the way [`super::run_provision`] does:
+///
+/// - an explicit `WEBVH_SERVER` already in the ask's
+///   `integration_template_vars` wins (this is what `vtc-service`'s wizard
+///   does to bypass auto-pick);
+/// - otherwise 0 or 1 catalogue entries auto-pick;
+/// - 2+ entries with no explicit choice is refused rather than guessed,
+///   naming `WEBVH_SERVER` as the fix.
+///
+/// A TSP-carried `PreflightDone` needs a public event-shape change; it is
+/// deliberately out of scope here and is tracked as follow-up work.
+#[cfg(feature = "tsp")]
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn run_tsp_attempt(
+    intent: VtaIntent,
+    vta_did: String,
+    tsp_mediator_did: String,
+    rest_url: Option<String>,
+    setup_did: String,
+    setup_privkey_mb: String,
+    ask: ProvisionAsk,
+    tx: &UnboundedSender<VtaEvent>,
+) -> AttemptOutcome {
+    use super::diagnostics::{DiagCheck, DiagStatus};
+    use crate::client::VtaClient;
+
+    let _ = tx.send(VtaEvent::CheckStart(DiagCheck::AuthenticateTSP));
+
+    // The socket open is this leg's auth proxy — see the module docs for
+    // why that is the same proxy the DIDComm leg uses.
+    let client = match VtaClient::connect_tsp(
+        &setup_did,
+        &setup_privkey_mb,
+        &vta_did,
+        &tsp_mediator_did,
+        rest_url.clone(),
+    )
+    .await
+    {
+        Ok(c) => {
+            let _ = tx.send(VtaEvent::CheckDone(
+                DiagCheck::AuthenticateTSP,
+                DiagStatus::Ok(format!("TSP session as {setup_did} via {tsp_mediator_did}")),
+            ));
+            c
+        }
+        Err(e) => {
+            let msg = e.to_string();
+            let _ = tx.send(VtaEvent::CheckDone(
+                DiagCheck::AuthenticateTSP,
+                DiagStatus::Failed(msg.clone()),
+            ));
+            let _ = tx.send(VtaEvent::CheckDone(
+                DiagCheck::ListWebvhServers,
+                DiagStatus::Skipped("TSP session did not open".into()),
+            ));
+            let _ = tx.send(VtaEvent::CheckDone(
+                DiagCheck::ProvisionIntegration,
+                DiagStatus::Skipped("TSP session did not open".into()),
+            ));
+            return AttemptOutcome::PreAuthFailure(format!(
+                "Could not open a TSP session to the VTA's `#tsp` mediator \
+                 ({tsp_mediator_did}). Confirm the mediator is reachable and that the \
+                 `pnm acl create` command ran successfully for setup DID {setup_did}. \
+                 ({msg})"
+            ));
+        }
+    };
+
+    // Everything past the connect lives in its own fn so the session is
+    // shut down on EVERY path out of it — the mediator permits one
+    // websocket per DID, so a leaked session makes the next connect for
+    // this DID fight the old one. Same contract as the DIDComm leg's
+    // `session.shutdown()`, and the reason the body cannot just `?`.
+    let outcome = tsp_attempt_body(&client, intent, &setup_did, &setup_privkey_mb, ask, tx).await;
+    client.shutdown().await;
+    outcome
+}
+
+/// The post-connect body of [`run_tsp_attempt`], split out so its caller
+/// has exactly one place to shut the session down.
+#[cfg(feature = "tsp")]
+async fn tsp_attempt_body(
+    client: &crate::client::VtaClient,
+    intent: VtaIntent,
+    setup_did: &str,
+    setup_privkey_mb: &str,
+    ask: ProvisionAsk,
+    tx: &UnboundedSender<VtaEvent>,
+) -> AttemptOutcome {
+    use super::diagnostics::{DiagCheck, DiagStatus};
+    use super::intent::VtaReply;
+
+    match intent {
+        VtaIntent::AdminOnly => {
+            // AdminOnly: the setup DID *is* the long-term admin DID. The
+            // session open is the proof the operator's `pnm acl create`
+            // landed — same contract as the DIDComm leg's AdminOnly arm.
+            let _ = tx.send(VtaEvent::CheckDone(
+                DiagCheck::ListWebvhServers,
+                DiagStatus::Skipped("AdminOnly — no VTA-minted DID so no webvh host needed".into()),
+            ));
+            let _ = tx.send(VtaEvent::CheckDone(
+                DiagCheck::ProvisionIntegration,
+                DiagStatus::Skipped(
+                    "AdminOnly — setup did:key is the long-term admin credential; \
+                     no template render, no rollover"
+                        .into(),
+                ),
+            ));
+            AttemptOutcome::Connected(VtaReply::AdminOnly(super::intent::AdminCredentialReply {
+                admin_did: setup_did.to_string(),
+                admin_private_key_mb: setup_privkey_mb.to_string(),
+            }))
+        }
+        VtaIntent::AdminRotated => {
+            // No integration DID is minted, so no webvh host is needed —
+            // straight to the provision round-trip.
+            let _ = tx.send(VtaEvent::CheckDone(
+                DiagCheck::ListWebvhServers,
+                DiagStatus::Skipped(
+                    "AdminRotated — no integration DID minted so no webvh host needed".into(),
+                ),
+            ));
+            let _ = tx.send(VtaEvent::CheckStart(DiagCheck::ProvisionIntegration));
+
+            match provision_admin_rotation_over(client, setup_did, setup_privkey_mb, &ask).await {
+                Ok(reply) => {
+                    let _ = tx.send(VtaEvent::CheckDone(
+                        DiagCheck::ProvisionIntegration,
+                        DiagStatus::Ok(format!(
+                            "admin DID rotated: {} (via {})",
+                            reply.admin_did,
+                            ask.admin_template
+                                .as_deref()
+                                .unwrap_or(super::ask::BUILTIN_VTA_ADMIN_TEMPLATE),
+                        )),
+                    ));
+                    AttemptOutcome::Connected(VtaReply::AdminOnly(reply))
+                }
+                Err(err) => {
+                    let msg = err.to_string();
+                    let _ = tx.send(VtaEvent::CheckDone(
+                        DiagCheck::ProvisionIntegration,
+                        DiagStatus::Failed(msg.clone()),
+                    ));
+                    AttemptOutcome::PostAuthFailure(format!(
+                        "AdminRotation provisioning failed after auth. ({msg})"
+                    ))
+                }
+            }
+        }
+        VtaIntent::FullSetup => tsp_full_setup(client, setup_did, setup_privkey_mb, ask, tx).await,
+    }
+}
+
+/// FullSetup over TSP: catalogue lookup, server choice, provision
+/// round-trip — all on the one already-open session.
+#[cfg(feature = "tsp")]
+async fn tsp_full_setup(
+    client: &crate::client::VtaClient,
+    setup_did: &str,
+    setup_privkey_mb: &str,
+    ask: ProvisionAsk,
+    tx: &UnboundedSender<VtaEvent>,
+) -> AttemptOutcome {
+    use super::diagnostics::{DiagCheck, DiagStatus};
+    use super::intent::VtaReply;
+    use super::runner_didcomm::inject_webvh_vars;
+    use crate::protocols::did_management::servers::ListWebvhServersResultBody;
+
+    // Webvh-server catalogue lookup. Failure here is non-fatal — the
+    // serverless path still works — but we surface the attempt in the
+    // checklist, exactly as the DIDComm leg does.
+    let _ = tx.send(VtaEvent::CheckStart(DiagCheck::ListWebvhServers));
+    let servers = match client
+        .dispatch_trust_task(
+            crate::trust_tasks::TASK_WEBVH_SERVERS_LIST_1_0,
+            serde_json::json!({}),
+            LIST_SERVERS_TIMEOUT_SECS,
+        )
+        .await
+        .map_err(|e| e.to_string())
+        .and_then(|payload| {
+            serde_json::from_value::<ListWebvhServersResultBody>(payload)
+                .map_err(|e| format!("webvh-server catalogue decode: {e}"))
+        }) {
+        Ok(body) => {
+            let detail = match body.servers.len() {
+                0 => "no registered servers — serverless path".into(),
+                1 => format!("1 registered server ({})", body.servers[0].id),
+                n => format!("{n} registered servers"),
+            };
+            let _ = tx.send(VtaEvent::CheckDone(
+                DiagCheck::ListWebvhServers,
+                DiagStatus::Ok(detail),
+            ));
+            body.servers
+        }
+        Err(msg) => {
+            let _ = tx.send(VtaEvent::CheckDone(
+                DiagCheck::ListWebvhServers,
+                DiagStatus::Failed(format!("could not list — continuing serverless ({msg})")),
+            ));
+            Vec::new()
+        }
+    };
+
+    let mut ask = ask;
+    // An explicit operator choice already in the ask wins outright; only
+    // fill one in when there isn't one. Same precedence `run_provision`'s
+    // `PreflightDone` handler applies via `inject_webvh_vars`.
+    if !ask.integration_template_vars.contains_key("WEBVH_SERVER") {
+        match servers.len() {
+            0 => {}
+            1 => inject_webvh_vars(&mut ask, Some(&servers[0].id), None),
+            n => {
+                let msg = format!(
+                    "VTA has {n} registered webvh servers and the provisioning ask names \
+                     none, so the choice is ambiguous. Set `WEBVH_SERVER` in the ask's \
+                     integration_template_vars to the id you want. (The interactive \
+                     picker is driven off VtaEvent::PreflightDone, which the TSP leg \
+                     does not emit.)"
+                );
+                let _ = tx.send(VtaEvent::CheckDone(
+                    DiagCheck::ProvisionIntegration,
+                    DiagStatus::Failed(msg.clone()),
+                ));
+                return AttemptOutcome::PostAuthFailure(msg);
+            }
+        }
+    }
+    let webvh_note = match ask.integration_template_vars.get("WEBVH_SERVER") {
+        Some(serde_json::Value::String(id)) => format!(", webvh server: {id}"),
+        _ => ", webvh: serverless".to_string(),
+    };
+
+    let _ = tx.send(VtaEvent::CheckStart(DiagCheck::ProvisionIntegration));
+    match provision_over(client, setup_did, setup_privkey_mb, &ask).await {
+        Ok(result) => {
+            let _ = tx.send(VtaEvent::CheckDone(
+                DiagCheck::ProvisionIntegration,
+                DiagStatus::Ok(format!(
+                    "admin DID: {} (rolled: {}), integration DID: {}{webvh_note}",
+                    result.admin_did(),
+                    result.summary.admin_rolled_over,
+                    result.integration_did().unwrap_or("(none)"),
+                )),
+            ));
+            AttemptOutcome::Connected(VtaReply::Full(Box::new(result)))
+        }
+        Err(err) => {
+            let msg = err.to_string();
+            let _ = tx.send(VtaEvent::CheckDone(
+                DiagCheck::ProvisionIntegration,
+                DiagStatus::Failed(msg.clone()),
+            ));
+            AttemptOutcome::PostAuthFailure(format!("Provisioning failed after auth. ({msg})"))
+        }
+    }
+}
+
+/// Send the VP-framed bootstrap request as a `provision/integration/0.2`
+/// trust task over `client`'s transport and open the sealed reply.
+///
+/// The VP is signed with the setup key and the bundle is sealed to it, so
+/// the returned material is only openable here — identical to the DIDComm
+/// and REST legs, which is the whole point of the wire being
+/// transport-neutral.
+#[cfg(feature = "tsp")]
+async fn provision_over(
+    client: &crate::client::VtaClient,
+    setup_did: &str,
+    setup_privkey_mb: &str,
+    ask: &ProvisionAsk,
+) -> Result<super::result::ProvisionResult, super::error::ProvisionError> {
+    use super::error::ProvisionError;
+    use super::result::{decode_nonce_b64url, response_to_result};
+
+    let seed = crate::did_key::decode_private_key_multibase(setup_privkey_mb)
+        .map_err(|e| ProvisionError::SetupKeyMalformed(e.to_string()))?;
+    let vp = ask.to_builder().sign_with(&seed, setup_did).await?;
+    let nonce = decode_nonce_b64url(&vp.nonce).map_err(ProvisionError::Armor)?;
+    let response = dispatch_provision_integration(client, vp, ask).await?;
+    response_to_result(&seed, nonce, response)
+}
+
+/// [`provision_over`] for the `AdminRotation` ask — same round-trip,
+/// different sealed-payload variant on the way out.
+#[cfg(feature = "tsp")]
+async fn provision_admin_rotation_over(
+    client: &crate::client::VtaClient,
+    setup_did: &str,
+    setup_privkey_mb: &str,
+    ask: &ProvisionAsk,
+) -> Result<super::intent::AdminCredentialReply, super::error::ProvisionError> {
+    use super::error::ProvisionError;
+    use super::result::{admin_rotation_response_to_reply, decode_nonce_b64url};
+
+    let seed = crate::did_key::decode_private_key_multibase(setup_privkey_mb)
+        .map_err(|e| ProvisionError::SetupKeyMalformed(e.to_string()))?;
+    let vp = ask.to_builder().sign_with(&seed, setup_did).await?;
+    let nonce = decode_nonce_b64url(&vp.nonce).map_err(ProvisionError::Armor)?;
+    let response = dispatch_provision_integration(client, vp, ask).await?;
+    admin_rotation_response_to_reply(&seed, nonce, response)
+}
+
+/// The one place the `provision/integration/0.2` trust task is built and
+/// dispatched, so the two callers above cannot disagree about the wire
+/// shape. `0.2` because that is the version registered on the VTA's shared
+/// trust-task spine — the only surface the TSP inbound dispatcher feeds.
+#[cfg(feature = "tsp")]
+async fn dispatch_provision_integration(
+    client: &crate::client::VtaClient,
+    request: crate::provision_integration::BootstrapRequest,
+    ask: &ProvisionAsk,
+) -> Result<
+    crate::provision_integration::http::ProvisionIntegrationResponse,
+    super::error::ProvisionError,
+> {
+    use super::error::ProvisionError;
+    use crate::protocols::provision_integration_management::{
+        ProvisionSpecVersion, request_body_for_version,
+    };
+
+    let body_struct = crate::provision_integration::http::ProvisionIntegrationRequest {
+        request,
+        context: Some(ask.context.clone()),
+        assertion: None,
+        vc_validity_seconds: None,
+        create_context: false,
+    };
+    let request_uri = ProvisionSpecVersion::V0_2.request_uri();
+    let payload = request_body_for_version(&body_struct, request_uri)
+        .map_err(ProvisionError::Serialization)?;
+
+    let reply = client
+        .dispatch_trust_task(request_uri, payload, PROVISION_TIMEOUT_SECS)
+        .await
+        .map_err(ProvisionError::Rpc)?;
+
+    serde_json::from_value(reply).map_err(ProvisionError::Serialization)
+}
+
+/// Drive a one-shot `provision-integration` round-trip over TSP.
+///
+/// The TSP sibling of
+/// [`provision_via_didcomm`](super::runner_didcomm::provision_via_didcomm)
+/// and [`provision_via_rest`](super::runner::provision_via_rest).
+/// Stand-alone — does not emit [`VtaEvent`]s; consumers that want
+/// diagnostics drive [`super::run_provision`] instead.
+///
+/// - `setup_did` / `setup_private_key_mb`: the ephemeral key the operator
+///   enrolled on the VTA via `pnm acl create`. TSP proves it as the sender
+///   VID; the VP inside is signed with it and the returned bundle is
+///   sealed to it.
+/// - `tsp_mediator_did`: the mediator named by the VTA's `#tsp`
+///   (`TSPTransport`) service — read it off
+///   [`ResolvedVta::tsp_mediator_did`](super::resolve::ResolvedVta), not
+///   off the DIDComm mediator entry, which the resolver deliberately keeps
+///   separate.
+#[cfg(feature = "tsp")]
+pub async fn provision_via_tsp(
+    setup_did: &str,
+    setup_private_key_mb: &str,
+    vta_did: &str,
+    tsp_mediator_did: &str,
+    ask: &ProvisionAsk,
+) -> Result<super::result::ProvisionResult, super::error::ProvisionError> {
+    use super::error::ProvisionError;
+
+    let client = crate::client::VtaClient::connect_tsp(
+        setup_did,
+        setup_private_key_mb,
+        vta_did,
+        tsp_mediator_did,
+        None,
+    )
+    .await
+    .map_err(|e| ProvisionError::SessionOpen(e.to_string()))?;
+
+    let result = provision_over(&client, setup_did, setup_private_key_mb, ask).await;
+    client.shutdown().await;
+    result
+}
+
+/// [`provision_via_tsp`] for the **admin-rotation** ask. Mirrors
+/// [`provision_admin_rotation_via_didcomm`](super::runner_didcomm::provision_admin_rotation_via_didcomm).
+#[cfg(feature = "tsp")]
+pub async fn provision_admin_rotation_via_tsp(
+    setup_did: &str,
+    setup_private_key_mb: &str,
+    vta_did: &str,
+    tsp_mediator_did: &str,
+    ask: &ProvisionAsk,
+) -> Result<super::intent::AdminCredentialReply, super::error::ProvisionError> {
+    use super::error::ProvisionError;
+
+    let client = crate::client::VtaClient::connect_tsp(
+        setup_did,
+        setup_private_key_mb,
+        vta_did,
+        tsp_mediator_did,
+        None,
+    )
+    .await
+    .map_err(|e| ProvisionError::SessionOpen(e.to_string()))?;
+
+    let result = provision_admin_rotation_over(&client, setup_did, setup_private_key_mb, ask).await;
+    client.shutdown().await;
+    result
+}
+
+/// `tsp`-less build: the VTA advertises `#tsp` and this binary cannot
+/// speak it. Reported as a **pre-auth** failure so the orchestrator
+/// degrades to DIDComm/REST when the VTA advertises one, and surfaces the
+/// missing feature when it does not.
+#[cfg(not(feature = "tsp"))]
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn run_tsp_attempt(
+    _intent: VtaIntent,
+    vta_did: String,
+    tsp_mediator_did: String,
+    _rest_url: Option<String>,
+    _setup_did: String,
+    _setup_privkey_mb: String,
+    _ask: ProvisionAsk,
+    tx: &UnboundedSender<VtaEvent>,
+) -> AttemptOutcome {
+    use super::diagnostics::{DiagCheck, DiagStatus};
+
+    let msg = tsp_feature_missing(&vta_did, &tsp_mediator_did);
+    let _ = tx.send(VtaEvent::CheckDone(
+        DiagCheck::AuthenticateTSP,
+        DiagStatus::Skipped("built without the `tsp` feature".into()),
+    ));
+    let _ = tx.send(VtaEvent::CheckDone(
+        DiagCheck::ListWebvhServers,
+        DiagStatus::Skipped("no TSP session".into()),
+    ));
+    let _ = tx.send(VtaEvent::CheckDone(
+        DiagCheck::ProvisionIntegration,
+        DiagStatus::Skipped("no TSP session".into()),
+    ));
+    AttemptOutcome::PreAuthFailure(msg)
+}
+
+#[cfg(all(test, not(feature = "tsp")))]
+mod tests {
+    use super::*;
+
+    /// The whole point of #869's honest-diagnostic half: a build that
+    /// cannot speak TSP must say *that*, not "no endpoints". Anyone who
+    /// reads this message must be sent to the cargo feature, not to the
+    /// DID document.
+    #[test]
+    fn feature_missing_message_names_the_feature_not_the_document() {
+        let msg = tsp_feature_missing("did:webvh:vta.test", "did:webvh:mediator.test");
+        assert!(msg.contains("`tsp` feature"), "{msg}");
+        assert!(msg.contains("--features tsp"), "{msg}");
+        assert!(msg.contains("did:webvh:mediator.test"), "{msg}");
+        assert!(
+            !msg.contains("no endpoints"),
+            "must not blame the DID document: {msg}"
+        );
+    }
+}


### PR DESCRIPTION
Closes https://github.com/OpenVTC/verifiable-trust-infrastructure/issues/869

## The bug, re-verified against current `origin/main` (433f9131)

`vta-sdk/src/provision_client/runner.rs::select_initial_transport` decided the
provisioning wire from **two of the three** endpoints its own resolver produces:

```rust
match (resolved.mediator_did.is_some(), resolved.rest_url.is_some()) { … }
```

`ResolvedVta` (`provision_client/resolve.rs`) carries `tsp_mediator_did`,
`mediator_did` and `rest_url`, and even exposes `advertised()` — which *does*
report `Protocol::Tsp` and has four tests pinning it. The selector never
consulted it. A VTA advertising only `#tsp` therefore fell through to
`InitialChoice::Neither` and failed with `"resolved (no endpoints)"` about a
document the resolver had just parsed a real endpoint out of. Everything the
issue describes is still true at 433f9131; nothing had moved.

## Decision: option (A) — TSP is a provisioning transport

Per the directive. The investigation says this is **wiring, not new protocol
surface**, and here is the evidence that decided it:

1. **`vta-service/src/messaging/tsp_inbound.rs::dispatch_one`** hands every
   unpacked TSP frame straight to `crate::trust_tasks::dispatch_trust_task_core`
   — *the same spine* REST (`POST /api/trust-tasks`) and the DIDComm trust-task
   envelope feed. Its own module doc says so, and states the ranking this PR
   adopts: "TSP is the highest-preference transport (TSP > DIDComm > REST)".
2. **Both operations the provisioning flow needs are already on that spine**
   (`vta-service/src/trust_tasks/mod.rs`): `TASK_PROVISION_INTEGRATION_0_2` →
   `provision_integration::handle_request`, and `TASK_WEBVH_SERVERS_LIST_1_0` →
   `webvh::handle_servers_list`. The handler takes a `ProvisionIntegrationRequest`
   payload and returns a `ProvisionIntegrationResponse` — the exact types the
   DIDComm and REST legs already exchange. There is **no transport gating**
   anywhere in the spine.
3. **The SDK already has the client half.** `VtaClient::connect_tsp` +
   `dispatch_trust_task` route a trust task over `TspSession::request`, which
   correlates replies by `threadId` (`tsp_demux::correlates`) against the
   `respond_with(...)` documents `trust_tasks/helpers.rs::success_response`
   emits. Auth is intrinsic-sender: TSP `unpack` yields a **proven** sender VID
   that `auth_from_did` resolves straight to the ACL grant `pnm acl create`
   wrote — the same model as DIDComm authcrypt, no challenge and no token.

So this PR drives the existing surface rather than inventing a parallel one.

### Where TSP genuinely is *not* symmetric with DIDComm — modelled, not assumed

- **No handshake.** `DIDCommSession::connect` flushes the mediator inbox, enables
  the websocket and sets the client's mediator ACL. The TSP socket does none of
  that. Neither transport performs a VTA round-trip at connect time, so the
  socket open is the `AuthenticateTSP` proxy exactly as the mediator connect is
  the `AuthenticateDIDComm` proxy today. Documented as such in `runner_tsp`.
- **No envelope.** TSP carries the Trust-Task bytes directly; the DIDComm leg
  wraps them (or, for provisioning, uses a DIDComm *protocol message*).
- **Version.** The DIDComm leg addresses `provision/integration/0.1` as a
  DIDComm protocol message routed by `messaging::handlers_protocol`. Only **0.2**
  is registered on the trust-task spine, so the TSP leg uses `0.2`. The signed VP
  inside is byte-identical either way — `spec_version` only selects the casing of
  the options *around* it (`request_body_for_version`, identity for 0.2).
- **Correlation is the application's job** — already solved by `tsp_demux`.

## What changed

- **`InitialChoice` now has one variant per cell of the 2×2×2 advertise matrix**
  — `TspOnly`, `TspAndDIDComm`, `TspAndRest`, `TspDIDCommAndRest` beside the
  existing four — so the choice never discards the endpoint the runner needs for
  fallback. `starts_with_tsp()` / `has_didcomm()` / `has_rest()` keep match sites
  small, and a test asserts they agree with the resolved document (the degrade
  path `expect`s on them).
- **`select_initial_transport` consults `tsp_mediator_did`**, and is
  **feature-independent by construction**: a `tsp`-less build still selects
  `TspOnly` for a TSP-only VTA and then fails naming the cargo feature. The
  selection matrix does not change shape with the feature flags.
- **`force_transport` honours `Some(Protocol::Tsp)`**, collapsing to `TspOnly`
  — the same "forced means no fallback" precedent the REST/DIDComm arms already
  set.
- **New `vta-sdk/src/provision_client/runner_tsp.rs`** (gated on `tsp`):
  `run_tsp_attempt` mirroring `run_didcomm_attempt` for all three
  `VtaIntent`s, plus one-shot `provision_via_tsp` /
  `provision_admin_rotation_via_tsp` siblings of the DIDComm/REST entry points.
  The `#[cfg(not(feature = "tsp"))]` twin compiles and reports a **pre-auth**
  failure naming the missing feature, in the shape
  `session::connect_tsp_bounded` already uses.
- **Dispatch restructured, not duplicated.** The DIDComm and REST arms of
  `run_connection_test` were extracted into `dispatch_didcomm_leg` /
  `dispatch_rest_leg` so the TSP leg reuses them verbatim as its fallback, and
  `emit_mediator_outcome` is shared by the TSP and DIDComm legs so their event
  translation cannot drift.
- **`Protocol` gains `Tsp`**, **`DiagCheck` gains `AuthenticateTSP`** (listed
  first, so `DiagCheck::all()` renders in the order the runner tries them),
  `AttemptLog` and `HeadlessVtaError` gain a `tsp` slot, and the "advertises
  neither" terminal message became "advertises no usable transport" naming all
  three.

### Ranking — stated explicitly, because it changes a default

**TSP > DIDComm > REST.** Precedent: `ResolvedVta::advertised()` documents that
order ("in preference order", with a test named
`advertised_is_in_preference_order`), `tsp_inbound.rs` states it, and
`session.rs`'s `TransportChoice::Auto` prefers TSP for the runtime client.

**This changes the default wire for a VTA advertising both `#tsp` and
`#vta-didcomm`** — the reference topology, and `vtc-service`'s setup wizard
drives `run_connection_test` with `force_transport: None`. Two things bound the
blast radius:

- Degradation is **pre-auth only**. A TSP leg that fails before the VTA accepts
  anything — including "this build has no `tsp` feature" — is reported as an
  `AttemptCompleted` and the run continues on DIDComm/REST. A post-auth failure
  stays terminal, exactly as the existing `AttemptOutcome` split already
  dictated for DIDComm ("a different transport may succeed" / "a different wire
  will reproduce the rejection").
- `force_transport: Some(Protocol::DidComm)` pins the old behaviour.

### Selection matrix (now pinned, one test per cell)

| `#tsp` | `#DIDCommMessaging` | `#vta-rest` | `InitialChoice` | leg | fallback |
|---|---|---|---|---|---|
| ✓ | ✓ | ✓ | `TspDIDCommAndRest` | TSP | DIDComm |
| ✓ | ✓ | – | `TspAndDIDComm` | TSP | DIDComm |
| ✓ | – | ✓ | `TspAndRest` | TSP | REST |
| ✓ | – | – | `TspOnly` | TSP | none |
| – | ✓ | ✓ | `BothAvailable` | DIDComm | (consumer) |
| – | ✓ | – | `DIDCommOnly` | DIDComm | none |
| – | – | ✓ | `RestOnly` | REST | none |
| – | – | – | `Neither` | — | — |

Plus: `neither_is_reserved_for_a_document_that_advertises_nothing`,
`tsp_selection_does_not_depend_on_the_tsp_feature`,
`starts_with_tsp_covers_exactly_the_tsp_variants`,
`fallback_predicates_match_the_resolved_endpoints` (all eight rows),
`tsp_only_has_no_fallback`.

## `InitialChoice` / `Protocol` match-site sweep

Swept the whole workspace for `InitialChoice`, `provision_client`'s `Protocol`,
`ResolvedVta::advertised()`, `AttemptLog`, `HeadlessVtaError` and every
`run_provision` / `run_connection_test` consumer:

- `InitialChoice` is matched **only inside `vta-sdk`** (`runner.rs`, re-exported
  via `provision_client::mod` and `prelude`). No daemon or CLI matches it.
- `provision_client::Protocol` is matched in `driver.rs:238` — updated with a
  `Protocol::Tsp` arm.
- `pnm-cli/src/commands/health.rs` matches `Protocol::{Tsp,Didcomm,Rest}` — that
  is `protocol::matching::Protocol`, a **different** enum that already had `Tsp`.
  Untouched.
- `vtc-service` (`setup/wizard.rs`, `emergency.rs`) consumes `VtaEvent` and
  destructures `PreflightDone { .. }` with a rest pattern; it compiles unchanged
  and handles the TSP leg's terminal `Connected` on its existing arm.
- Out-of-workspace: adding enum variants is a breaking match for an external
  consumer that matches exhaustively (`affinidi-webvh-service` is the known one).
  Unavoidable — the issue asks for a new variant, and the alternative is a
  transport choice that keeps discarding the endpoint it was asked about.

## Deliberate gap, scoped

The TSP `FullSetup` leg runs the webvh catalogue lookup and the provision
round-trip back-to-back on one socket rather than splitting into `PreflightOk` →
`run_provision_flight`. That split exists so an interactive consumer can close
its session while a picker dialog is on screen, and the picker is driven off
`VtaEvent::PreflightDone`, whose `mediator_did: String` is a DIDComm mediator by
construction. Carrying a TSP mediator there means either overloading that field
(the resolver deliberately keeps the two apart) or a public event-shape change
— out of scope here. Meanwhile the TSP leg resolves the server choice the way
`run_provision` does: explicit `WEBVH_SERVER` in the ask wins (what
`vtc-service`'s wizard does), 0/1 catalogue entries auto-pick, and 2+ with no
explicit choice is refused **by name** rather than guessed.

## Needs a live TSP-only VTA to confirm

Everything below is reasoned from the sources and compiles + unit-tests, but no
TSP-only VTA was available to exercise the wire:

1. **The full round-trip**: `provision/integration/0.2` over TSP against a VTA
   advertising only `#tsp`, end to end into an opened sealed bundle.
2. **Sealed-bundle size over a TSP frame.** The provisioning reply carries an
   armored bundle (keys + `did.jsonl` + VC + trust bundle) — far larger than the
   `task-consent/request` pushes TSP carries today. If the mediator or the TSP
   stack has a frame ceiling, this is where it shows up first.
3. **`PROVISION_TIMEOUT_SECS = 60`** is copied from the DIDComm leg; TSP's
   `request` correlation loop pumps in 250 ms slices, so a slow VTA mint should
   behave the same, but that is untested under load.
4. **Whether the mediator's one-socket-per-DID ceiling** interacts badly if a
   setup DID somehow already holds a session (it should not — the setup key is
   freshly minted per run).

## Verification

```
cargo test -p vta-sdk --lib                                   224 passed; 0 failed
cargo test -p vta-sdk --lib --features provision-client,tsp   512 passed; 0 failed
cargo test -p vta-sdk --lib --features provision-client       499 passed; 0 failed   (non-tsp build)
cargo check  --workspace --all-targets                        Finished
cargo clippy --workspace --all-targets -- -D warnings         Finished
cargo fmt --all -- --check                                    clean
cargo check -p vta-sdk --no-default-features --features provision-client   Finished
cargo check -p vta-sdk --all-features                                      Finished
```

Both feature configurations are exercised: the `tsp` build compiles and tests the
real leg, the non-`tsp` build compiles and tests the honest-diagnostic twin.
`tests/e2e` already enables `vta-sdk` with both `tsp` and `provision-client`, so
the workspace clippy run covers the TSP leg.

**Pre-existing, not introduced here:** `cargo clippy -p vta-sdk --all-features
--all-targets` fails in `vta-sdk/tests/session_store.rs:622` (`E0004`, missing
`_` arm on the `#[non_exhaustive]` `VtaEndpoint` once `tsp` adds a variant).
Reproduced on a clean `origin/main` checkout with my changes stashed. CI runs
`cargo clippy --workspace -- -D warnings`, which is green. Left alone — no
drive-by fixes.

## Release guards

- `vta-sdk` 0.20.25 → **0.20.26** (next free patch; checked `main`, not assumed).
- Root `CHANGELOG.md` entry under `## Unreleased`.
- `Cargo.lock` refreshed.

## Reviewer checklist

- [ ] Ranking: TSP-first for a `#tsp` + `#vta-didcomm` VTA is the intended
      default change, and pre-auth-only degradation is the right guard rail.
- [ ] `InitialChoice`'s 8 variants vs. a `Tsp { didcomm_fallback, rest_fallback }`
      struct variant — flat was chosen to match the existing style and to make
      the test matrix one assertion per cell.
- [ ] `provision/integration/**0.2**` on the TSP leg (the spine registers only
      0.2) while the DIDComm leg still sends 0.1 as a protocol message.
- [ ] The socket-open-as-`AuthenticateTSP` proxy — same proxy the DIDComm leg
      uses, but worth an explicit nod.
- [ ] The deferred TSP `PreflightDone`/picker path and its `WEBVH_SERVER`
      workaround.
- [ ] Breaking-for-external-consumers enum additions (`InitialChoice`,
      `Protocol`, `DiagCheck`) on a patch bump.

Version bumps may be rebased by the orchestrator as sibling consolidation PRs
merge.
