### PR TITLE
chore(mobile): vta-mobile-core 0.6.17 — version label for the verify-request-proofs release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,15 @@ control plane accepts both approve-response minors
   signed approve-response completes the 0.2-minted step-up, with the ack
   echoing the approver's 0.1 family.
 
+### vta-mobile-core 0.6.17 — release cut for on-device request-proof verification
+
+Version label for the already-merged #871 (`mobile/verify-request-proofs`):
+async `parse_task_consent_request` / `parse_step_up_request` with a
+`trustedIssuers` allowlist, on-device eddsa-jcs-2022 proof verification
+before any prompt, and the new `UntrustedIssuer` error. Cut so the
+`vta-mobile-core-v0.6.17` iOS xcframework release can be published for
+OpenVTC/vta-mobile-agent-ios#25, whose vendored bindings need the new ABI.
+
 ### vta-service 0.13.17 — the step-up approve-request is signed (spec: proof REQUIRED)
 
 Part of the ecosystem-wide "signed request legs" push

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10228,7 +10228,7 @@ dependencies = [
 
 [[package]]
 name = "vta-mobile-core"
-version = "0.6.16"
+version = "0.6.17"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",

--- a/vta-mobile-core/Cargo.toml
+++ b/vta-mobile-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vta-mobile-core"
-version = "0.6.16"
+version = "0.6.17"
 description = "UniFFI engine for the VTA mobile agent (Android/iOS): DIDComm, Trust Tasks, AAL step-up."
 edition.workspace = true
 # Not a crates.io library — the published artifacts are the Android AAR


### PR DESCRIPTION
Pure version bump + CHANGELOG label for the already-merged #871, so the `vta-mobile-core-v0.6.17` tag (and its iOS xcframework release via release-mobile-ios.yml) sits on a commit whose crate version matches. Unblocks OpenVTC/vta-mobile-agent-ios#25, whose vendored uniffi bindings need the post-#871 ABI — its CI fails against the v0.6.16 binary. No source changes. After merge: push tag `vta-mobile-core-v0.6.17` on the merge commit; the release workflow publishes the xcframework + checksum + `VtaMobileCore.swift`; then #25 gets its `engineTag`/`engineChecksum` bump.