### PR TITLE
feat: raise backup password minimum length from 12 to 15 characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## Unreleased
 
+### vta-backup 0.1.3 / vtc-service 0.11.45 / pnm-cli 0.11.16 / cnm-cli 0.11.13 / vta-sdk 0.20.27 — raise backup password minimum to 15 characters
+
+The export-side minimum password length is raised from 12 to 15 characters
+across all enforcement points. Import/decrypt paths carry no length check —
+existing backups remain decryptable with shorter passwords (backward compatible).
+
+- **`vta-backup`**: `export_backup` rejects passwords shorter than 15 characters
+  with `AppError::Validation`; new `export_rejects_short_password` unit test
+  (14-char rejected, 15-char boundary accepted).
+- **`vtc-service`**: `MIN_PASSWORD_LEN` 12 → 15; new `export_rejects_short_password`
+  integration test in `tests/backup.rs`.
+- **`pnm-cli`**: prompt text and client-side guard updated on both export paths
+  (direct and trust-task descriptor).
+- **`cnm-cli`**: prompt text and client-side guard updated.
+- **`vta-sdk`**: doc comment on `InitiateExportBody.password` updated.
+
+The 15-character threshold aligns with CIS Benchmark recommendations for
+privileged-account credentials, reflecting the sensitivity of a backup envelope
+(master seed, BIP-32 key hierarchy, ACL).
+
 ### vta-service 0.13.18 — step-up approve-request minted as 0.2; inbound stays bilingual
 
 The deferred follow-up to 0.13.17 (#870): the minted step-up approve-request

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,19 +8,36 @@ The export-side minimum password length is raised from 12 to 15 characters
 across all enforcement points. Import/decrypt paths carry no length check —
 existing backups remain decryptable with shorter passwords (backward compatible).
 
-- **`vta-backup`**: `export_backup` rejects passwords shorter than 15 characters
-  with `AppError::Validation`; new `export_rejects_short_password` unit test
-  (14-char rejected, 15-char boundary accepted).
-- **`vtc-service`**: `MIN_PASSWORD_LEN` 12 → 15; new `export_rejects_short_password`
-  integration test in `tests/backup.rs`.
-- **`pnm-cli`**: prompt text and client-side guard updated on both export paths
-  (direct and trust-task descriptor).
-- **`cnm-cli`**: prompt text and client-side guard updated.
-- **`vta-sdk`**: doc comment on `InitiateExportBody.password` updated.
+- **`vta-sdk`**: new `protocols::backup_management::MIN_BACKUP_PASSWORD_LEN` +
+  `validate_backup_password` — the **single source of truth**. Every
+  export-side guard now calls it instead of repeating the literal, so the next
+  change to the policy is one edit rather than five. The helper counts
+  **characters** (`chars().count()`), not bytes: `str::len()` let a
+  six-character non-ASCII password clear a check whose message said "15
+  characters".
+- **`vta-backup`**: `export_backup` delegates to `validate_backup_password`;
+  new `export_rejects_short_password` unit test (14-char rejected, 15-char
+  boundary accepted).
+- **`vtc-service`**: crate-local `MIN_PASSWORD_LEN` removed in favour of the
+  shared constant; new `export_rejects_short_password` integration test in
+  `tests/backup.rs`.
+- **`pnm-cli` / `cnm-cli`**: prompt text and client-side guard now render from
+  the shared constant on all three export paths (pnm direct, pnm trust-task
+  descriptor, cnm).
+- **Docs**: the seven places that still documented a 12-character minimum are
+  corrected — `CLAUDE.md`, `pnm-cli/README.md`, `docs/03-vtc/backup-restore.md`
+  (×2), `docs/05-design-notes/vtc-backup-restore.md`,
+  `docs/05-design-notes/backup-descriptor-pattern.md`, and the request example
+  in `docs/02-vta/didcomm-protocol.md`.
 
 The 15-character threshold aligns with CIS Benchmark recommendations for
 privileged-account credentials, reflecting the sensitivity of a backup envelope
-(master seed, BIP-32 key hierarchy, ACL).
+(master seed, BIP-32 key hierarchy, ACL). It is an **interim** floor:
+`docs/05-design-notes/vtc-mvp.md` §14.1 calls for an entropy estimate
+(`zxcvbn` score ≥ 3) on the grounds that any bare length floor admits
+`Passw0rdPassw0rd`. That note is updated to record what actually ships today;
+consolidating behind `validate_backup_password` makes the eventual swap a
+single-function change.
 
 ### vta-service 0.13.18 — step-up approve-request minted as 0.2; inbound stays bilingual
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -653,7 +653,9 @@ new flow, update both this section and the relevant `docs/*.md`.
 - **What**: Encrypted full-state dump + restore.
 - **Endpoints**: `POST /backup/export`, `POST /backup/import`
   (super-admin).
-- **Crypto**: Argon2id KDF (≥12-char password) + AES-256-GCM.
+- **Crypto**: Argon2id KDF (≥15-char password — the minimum is
+  `vta_sdk::protocols::backup_management::MIN_BACKUP_PASSWORD_LEN`, the single
+  source of truth every export-side guard reads) + AES-256-GCM.
 - **Compatibility check**: import cross-checks the backup's `vta_did`
   against the running VTA via `check_vta_did_compatibility`
   (`vta-backup/src/ops/mod.rs`). A fresh-install VTA

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2488,7 +2488,7 @@ checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cnm-cli"
-version = "0.11.12"
+version = "0.11.13"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "clap",
@@ -6759,7 +6759,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "pnm-cli"
-version = "0.11.15"
+version = "0.11.16"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-resolver-cache-sdk",
@@ -10089,7 +10089,7 @@ dependencies = [
 
 [[package]]
 name = "vta-backup"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -10271,7 +10271,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.20.26"
+version = "0.20.27"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10566,7 +10566,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-service"
-version = "0.11.44"
+version = "0.11.45"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/cnm-cli/Cargo.toml
+++ b/cnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cnm-cli"
 description = "CLI Tool for Verified Trust Agents operating in Verified Trust Communities"
-version = "0.11.12"
+version = "0.11.13"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/cnm-cli/src/backup.rs
+++ b/cnm-cli/src/backup.rs
@@ -69,11 +69,11 @@ pub(crate) async fn cmd_export(
     output: Option<PathBuf>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let password = dialoguer::Password::new()
-        .with_prompt("Backup password (min 12 chars)")
+        .with_prompt("Backup password (min 15 chars)")
         .with_confirmation("Confirm password", "Passwords do not match")
         .interact()?;
-    if password.len() < 12 {
-        return Err("password must be at least 12 characters".into());
+    if password.len() < 15 {
+        return Err("password must be at least 15 characters".into());
     }
 
     println!("Exporting community backup...");

--- a/cnm-cli/src/backup.rs
+++ b/cnm-cli/src/backup.rs
@@ -17,6 +17,7 @@ use std::path::PathBuf;
 use serde_json::{Value, json};
 use vta_cli_common::render::{DIM, GREEN, RED, RESET};
 use vta_sdk::client::VtaClient;
+use vta_sdk::protocols::backup_management::{MIN_BACKUP_PASSWORD_LEN, validate_backup_password};
 
 use crate::auth;
 
@@ -69,12 +70,12 @@ pub(crate) async fn cmd_export(
     output: Option<PathBuf>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let password = dialoguer::Password::new()
-        .with_prompt("Backup password (min 15 chars)")
+        .with_prompt(format!(
+            "Backup password (min {MIN_BACKUP_PASSWORD_LEN} chars)"
+        ))
         .with_confirmation("Confirm password", "Passwords do not match")
         .interact()?;
-    if password.len() < 15 {
-        return Err("password must be at least 15 characters".into());
-    }
+    validate_backup_password(&password)?;
 
     println!("Exporting community backup...");
     let envelope = authed_post(

--- a/docs/02-vta/didcomm-protocol.md
+++ b/docs/02-vta/didcomm-protocol.md
@@ -583,7 +583,7 @@ Request body:
 
 ```json
 {
-  "password": "minimum-12-characters",
+  "password": "at-least-fifteen-characters",
   "include_audit": false
 }
 ```

--- a/docs/03-vtc/backup-restore.md
+++ b/docs/03-vtc/backup-restore.md
@@ -31,7 +31,7 @@ AES-256-GCM encryption of:
 > **The backup contains the signing key.** Treat the exported file like a
 > secret: it is encrypted with your password (Argon2id + AES-256-GCM), but
 > anyone who learns the password can sign as this community. Store it
-> accordingly and use a strong password (minimum 12 characters).
+> accordingly and use a strong password (minimum 15 characters).
 
 **Not** in a backup (re-established after a restore, not carried): live
 `sessions`, browser `passkey` credentials, one-shot `install` tokens, the
@@ -41,7 +41,7 @@ keyspace overlay (its meaningful values ride in the identity snapshot above).
 ## Export
 
 ```sh
-# Prompts for the encryption password (min 12 chars), writes
+# Prompts for the encryption password (min 15 chars), writes
 # vtc-backup-<slug>-<timestamp>.vtcbak.
 cnm backup export [--include-audit] [--output FILE]
 ```

--- a/docs/05-design-notes/backup-descriptor-pattern.md
+++ b/docs/05-design-notes/backup-descriptor-pattern.md
@@ -126,7 +126,8 @@ pub struct BundleDescriptor {
 ```rust
 pub struct InitiateExportBody {
     /// Password to derive the AES-256-GCM key (Argon2id KDF).
-    /// Minimum 12 chars enforced at the op layer.
+    /// Minimum length is `MIN_BACKUP_PASSWORD_LEN`, enforced at the op
+    /// layer via `validate_backup_password`.
     pub password: String,
 
     /// Include audit logs in the backup. Default: false.

--- a/docs/05-design-notes/vtc-backup-restore.md
+++ b/docs/05-design-notes/vtc-backup-restore.md
@@ -51,7 +51,11 @@ house rule pins these crates):
   `p_cost = 4`, 32-byte salt, 32-byte derived key.
 - **Cipher**: AES-256-GCM, 12-byte nonce, random salt+nonce per export (OsRng).
 - **Encoding**: `base64::URL_SAFE_NO_PAD` for salt / nonce / ciphertext.
-- **Password**: minimum 12 chars at export (`Validation` → 400).
+- **Password**: minimum 15 chars at export (`Validation` → 400). The length
+  lives in `vta_sdk::protocols::backup_management::MIN_BACKUP_PASSWORD_LEN` and
+  is applied by `validate_backup_password`, which every export-side guard in
+  the workspace calls. Import carries no length check, so envelopes written
+  under the earlier 12-char minimum stay decryptable.
 - **Import bounds** (anti-memory-bomb on untrusted envelopes): `m_cost ∈
   [8 MiB, 1 GiB]`, `t_cost ∈ [1,10]`, `p_cost ∈ [1,16]`; algorithm strings must
   equal `argon2id` / `aes-256-gcm`; salt/nonce length-checked before

--- a/docs/05-design-notes/vtc-mvp.md
+++ b/docs/05-design-notes/vtc-mvp.md
@@ -1247,8 +1247,18 @@ signing bundle itself lives in the seed-store backend, not a keyspace.
 ### 14.1 Backup / restore
 
 `POST /v1/admin/backup/export` returns an encrypted dump (Argon2id +
-AES-256-GCM). Password strength enforced via `zxcvbn` (minimum
-score 3) — `≥12 chars` alone is too weak.
+AES-256-GCM).
+
+**Password strength — shipped vs. designed.** The design position here is
+`zxcvbn` (minimum score 3), on the reasoning that a bare length floor lets
+`Passw0rdPassw0rd` through. That check has **not** shipped. What is enforced
+today is a length minimum, raised from 12 to 15 characters and consolidated
+behind `vta_sdk::protocols::backup_management::{MIN_BACKUP_PASSWORD_LEN,
+validate_backup_password}` — one constant that every export-side guard in the
+workspace (VTA op layer, VTC op layer, `pnm`, `cnm`) reads, so the number can
+move in one place. Treat 15 as an interim floor, not the end state: swapping
+the length test inside `validate_backup_password` for an entropy estimate is
+now a single-function change, and it remains the intended direction.
 
 **Cross-VTC restore protection.** Each backup is wrapped under a key
 derived from the VTC's master seed (`HKDF(seed, "vtc-backup-key")`),

--- a/pnm-cli/Cargo.toml
+++ b/pnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pnm-cli"
 description = "CLI Tool for managing a personal Verifiable Trust Agent"
-version = "0.11.15"
+version = "0.11.16"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/pnm-cli/README.md
+++ b/pnm-cli/README.md
@@ -254,7 +254,7 @@ has unrestricted access across all contexts.
 | `backup export [--include-audit] [--output FILE]` | Export encrypted backup of all VTA state       |
 | `backup import <file> [--preview]`                | Import backup (preview or apply + restart VTA) |
 
-Backups are encrypted with Argon2id + AES-256-GCM using a user-provided password (minimum 12 characters). The `.vtabak` file contains the seed, keys, ACL, contexts, WebVH records, and config.
+Backups are encrypted with Argon2id + AES-256-GCM using a user-provided password (minimum 15 characters). The `.vtabak` file contains the seed, keys, ACL, contexts, WebVH records, and config.
 
 ### VTA Management
 

--- a/pnm-cli/src/commands/backup.rs
+++ b/pnm-cli/src/commands/backup.rs
@@ -1,7 +1,7 @@
 //! Dispatch for `pnm backup …`.
 //!
 //! Both export and import prompt interactively for the encryption
-//! password (Argon2id KDF, ≥12 chars). `--preview` on import skips the
+//! password (Argon2id KDF, ≥15 chars). `--preview` on import skips the
 //! destructive write so an operator can inspect a backup before
 //! committing.
 
@@ -47,11 +47,11 @@ async fn cmd_backup_export(
 ) -> Result<(), Box<dyn std::error::Error>> {
     // Prompt for password
     let password = dialoguer::Password::new()
-        .with_prompt("Backup password (min 12 chars)")
+        .with_prompt("Backup password (min 15 chars)")
         .with_confirmation("Confirm password", "Passwords do not match")
         .interact()?;
-    if password.len() < 12 {
-        return Err("password must be at least 12 characters".into());
+    if password.len() < 15 {
+        return Err("password must be at least 15 characters".into());
     }
 
     println!("Exporting backup...");
@@ -155,11 +155,11 @@ async fn cmd_backup_export_descriptor(
     output: Option<std::path::PathBuf>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let password = dialoguer::Password::new()
-        .with_prompt("Backup password (min 12 chars)")
+        .with_prompt("Backup password (min 15 chars)")
         .with_confirmation("Confirm password", "Passwords do not match")
         .interact()?;
-    if password.len() < 12 {
-        return Err("password must be at least 12 characters".into());
+    if password.len() < 15 {
+        return Err("password must be at least 15 characters".into());
     }
 
     println!("Exporting backup (trust-task descriptor flow)...");

--- a/pnm-cli/src/commands/backup.rs
+++ b/pnm-cli/src/commands/backup.rs
@@ -7,6 +7,7 @@
 
 use vta_cli_common::render::{DIM, GREEN, RED, RESET};
 use vta_sdk::client::VtaClient;
+use vta_sdk::protocols::backup_management::{MIN_BACKUP_PASSWORD_LEN, validate_backup_password};
 
 use crate::cli::BackupCommands;
 
@@ -47,12 +48,12 @@ async fn cmd_backup_export(
 ) -> Result<(), Box<dyn std::error::Error>> {
     // Prompt for password
     let password = dialoguer::Password::new()
-        .with_prompt("Backup password (min 15 chars)")
+        .with_prompt(format!(
+            "Backup password (min {MIN_BACKUP_PASSWORD_LEN} chars)"
+        ))
         .with_confirmation("Confirm password", "Passwords do not match")
         .interact()?;
-    if password.len() < 15 {
-        return Err("password must be at least 15 characters".into());
-    }
+    validate_backup_password(&password)?;
 
     println!("Exporting backup...");
     let envelope = client.backup_export(&password, include_audit).await?;
@@ -155,12 +156,12 @@ async fn cmd_backup_export_descriptor(
     output: Option<std::path::PathBuf>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let password = dialoguer::Password::new()
-        .with_prompt("Backup password (min 15 chars)")
+        .with_prompt(format!(
+            "Backup password (min {MIN_BACKUP_PASSWORD_LEN} chars)"
+        ))
         .with_confirmation("Confirm password", "Passwords do not match")
         .interact()?;
-    if password.len() < 15 {
-        return Err("password must be at least 15 characters".into());
-    }
+    validate_backup_password(&password)?;
 
     println!("Exporting backup (trust-task descriptor flow)...");
     let bytes = client

--- a/vta-backup/Cargo.toml
+++ b/vta-backup/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-backup"
 description = "VTA backup/restore subsystem — encrypted full-state export/import, the sealed backup-bundle store, and its TTL sweeper"
 readme = "README.md"
-version = "0.1.2"
+version = "0.1.3"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-backup/src/ops/mod.rs
+++ b/vta-backup/src/ops/mod.rs
@@ -96,9 +96,9 @@ pub async fn export_backup(
     let webvh_ks = ks.webvh;
     auth.require_super_admin()?;
 
-    if password.len() < 12 {
+    if password.len() < 15 {
         return Err(AppError::Validation(
-            "backup password must be at least 12 characters".into(),
+            "backup password must be at least 15 characters".into(),
         ));
     }
 
@@ -1081,6 +1081,42 @@ mod tests {
             msg.contains("corrupt") && msg.contains("key"),
             "error must name the corrupt-row cause, got: {msg}"
         );
+    }
+
+    /// `export_backup` rejects passwords shorter than 15 characters with a
+    /// `Validation` error. The check fires before any keyspace I/O.
+    /// A password of exactly 15 characters must be accepted (boundary).
+    #[tokio::test]
+    async fn export_rejects_short_password() {
+        let ts = crate::test_support::open_test_store().await;
+        let seed_store = crate::test_support::TestSeedStore(vec![42u8; 32]);
+        let config = crate::test_support::test_app_config(ts.data_dir.clone());
+        let auth = crate::test_support::super_admin_claims();
+
+        let ks = vta_keyspaces::Keyspaces {
+            keys: &ts.keys_ks,
+            acl: &ts.acl_ks,
+            contexts: &ts.contexts_ks,
+            did_templates: &ts.did_templates_ks,
+            audit: &ts.audit_ks,
+            imported: &ts.imported_ks,
+            #[cfg(feature = "webvh")]
+            webvh: &ts.webvh_ks,
+        };
+
+        // 14 chars — one short of the minimum
+        let err = export_backup(&ks, &seed_store, &config, &auth, "14-char-passwo", false)
+            .await
+            .expect_err("export must reject a 14-character password");
+        assert!(
+            format!("{err}").contains("15 characters"),
+            "error must mention the 15-character minimum, got: {err}"
+        );
+
+        // Exactly 15 chars — must be accepted (boundary)
+        export_backup(&ks, &seed_store, &config, &auth, "15-char-passwor", false)
+            .await
+            .expect("export must accept a 15-character password");
     }
 
     fn test_payload() -> BackupPayload {

--- a/vta-backup/src/ops/mod.rs
+++ b/vta-backup/src/ops/mod.rs
@@ -96,11 +96,8 @@ pub async fn export_backup(
     let webvh_ks = ks.webvh;
     auth.require_super_admin()?;
 
-    if password.len() < 15 {
-        return Err(AppError::Validation(
-            "backup password must be at least 15 characters".into(),
-        ));
-    }
+    vta_sdk::protocols::backup_management::validate_backup_password(password)
+        .map_err(AppError::Validation)?;
 
     // 1. Collect the active seed
     let seed_bytes = seed_store

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.20.26"
+version = "0.20.27"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/protocols/backup_management/descriptors.rs
+++ b/vta-sdk/src/protocols/backup_management/descriptors.rs
@@ -73,7 +73,7 @@ fn default_true() -> bool {
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct InitiateExportBody {
     /// Password to derive the AES-256-GCM key (Argon2id KDF).
-    /// Minimum 12 chars enforced at the op layer.
+    /// Minimum 15 chars enforced at the op layer.
     pub password: String,
 
     /// Include audit logs in the backup. Default: false.

--- a/vta-sdk/src/protocols/backup_management/descriptors.rs
+++ b/vta-sdk/src/protocols/backup_management/descriptors.rs
@@ -73,7 +73,8 @@ fn default_true() -> bool {
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct InitiateExportBody {
     /// Password to derive the AES-256-GCM key (Argon2id KDF).
-    /// Minimum 15 chars enforced at the op layer.
+    /// Minimum length is [`super::MIN_BACKUP_PASSWORD_LEN`], enforced at the
+    /// op layer via [`super::validate_backup_password`].
     pub password: String,
 
     /// Include audit logs in the backup. Default: false.

--- a/vta-sdk/src/protocols/backup_management/mod.rs
+++ b/vta-sdk/src/protocols/backup_management/mod.rs
@@ -12,3 +12,66 @@ pub const IMPORT_BACKUP: &str =
     "https://firstperson.network/protocols/backup-management/1.0/import";
 pub const IMPORT_BACKUP_RESULT: &str =
     "https://firstperson.network/protocols/backup-management/1.0/import-result";
+
+// ── Password policy ─────────────────────────────────────────────────────
+
+/// Minimum length of a backup-encryption password, in characters.
+///
+/// **Single source of truth** for every export-side guard in the workspace:
+/// `vta_backup::ops::export_backup`, `vtc_service::backup::export_backup`, and
+/// the `pnm` / `cnm` interactive prompts all read this constant rather than
+/// repeating the literal. A backup envelope carries the master seed, the
+/// BIP-32 key hierarchy, and the ACL, so this password is the only thing
+/// between an exfiltrated `.vtabak` and full control of the deployment.
+///
+/// Enforced **on export only**. Import / decrypt paths deliberately carry no
+/// length check, so envelopes written under an older, shorter minimum stay
+/// decryptable.
+pub const MIN_BACKUP_PASSWORD_LEN: usize = 15;
+
+/// Reject a backup-encryption password shorter than
+/// [`MIN_BACKUP_PASSWORD_LEN`], with the message every surface renders.
+///
+/// Counts **characters** (Unicode scalar values), not bytes. `str::len()`
+/// would let a six-character non-ASCII password clear a "15 characters"
+/// check, since every non-ASCII scalar occupies 2–4 UTF-8 bytes — the guard
+/// would then contradict the error text beside it.
+///
+/// The `String` error converts into `Box<dyn Error>` for CLI call sites and
+/// into `AppError::Validation` for service call sites.
+pub fn validate_backup_password(password: &str) -> Result<(), String> {
+    if password.chars().count() < MIN_BACKUP_PASSWORD_LEN {
+        return Err(format!(
+            "backup password must be at least {MIN_BACKUP_PASSWORD_LEN} characters"
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod password_tests {
+    use super::*;
+
+    #[test]
+    fn rejects_below_minimum_and_accepts_the_boundary() {
+        // 14 chars — one short.
+        let err = validate_backup_password("14-char-passwo").expect_err("14 chars must be short");
+        assert!(
+            err.contains("15 characters"),
+            "error must name the minimum, got: {err}"
+        );
+
+        // Exactly 15 — the boundary is inclusive.
+        validate_backup_password("15-char-passwor").expect("15 chars is the minimum");
+    }
+
+    #[test]
+    fn counts_characters_not_bytes() {
+        // 10 Cyrillic characters — 20 UTF-8 bytes, so a `len()`-based guard
+        // would wave this through as "15 characters".
+        let ten_chars = "паролькмоя";
+        assert_eq!(ten_chars.chars().count(), 10);
+        assert!(ten_chars.len() >= MIN_BACKUP_PASSWORD_LEN);
+        assert!(validate_backup_password(ten_chars).is_err());
+    }
+}

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.11.44"
+version = "0.11.45"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vtc-service/src/backup.rs
+++ b/vtc-service/src/backup.rs
@@ -38,7 +38,7 @@ const ARGON2_T_COST: u32 = 3;
 const ARGON2_P_COST: u32 = 4;
 const SALT_LEN: usize = 32;
 const NONCE_LEN: usize = 12;
-const MIN_PASSWORD_LEN: usize = 12;
+const MIN_PASSWORD_LEN: usize = 15;
 
 // Import-side Argon2 bounds — clamp untrusted envelopes so a malicious
 // `m_cost` can't drive a memory bomb on decrypt.

--- a/vtc-service/src/backup.rs
+++ b/vtc-service/src/backup.rs
@@ -38,7 +38,6 @@ const ARGON2_T_COST: u32 = 3;
 const ARGON2_P_COST: u32 = 4;
 const SALT_LEN: usize = 32;
 const NONCE_LEN: usize = 12;
-const MIN_PASSWORD_LEN: usize = 15;
 
 // Import-side Argon2 bounds — clamp untrusted envelopes so a malicious
 // `m_cost` can't drive a memory bomb on decrypt.
@@ -155,11 +154,8 @@ pub async fn export_backup(
     password: &str,
     include_audit: bool,
 ) -> Result<BackupEnvelope, AppError> {
-    if password.len() < MIN_PASSWORD_LEN {
-        return Err(AppError::Validation(format!(
-            "backup password must be at least {MIN_PASSWORD_LEN} characters"
-        )));
-    }
+    vta_sdk::protocols::backup_management::validate_backup_password(password)
+        .map_err(AppError::Validation)?;
 
     // Signing key bundle (hex of the raw stored bytes — backend-agnostic
     // round-trip).

--- a/vtc-service/src/routes/backup.rs
+++ b/vtc-service/src/routes/backup.rs
@@ -22,7 +22,7 @@ use vti_common::error::AppError;
 #[derive(Debug, Deserialize, utoipa::ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct ExportRequest {
-    /// Encryption password (Argon2id). Minimum 12 characters.
+    /// Encryption password (Argon2id). Minimum 15 characters.
     pub password: String,
     /// Include the audit log in the backup. Default `false` — audit logs
     /// can be large and carry plaintext DIDs.

--- a/vtc-service/tests/backup.rs
+++ b/vtc-service/tests/backup.rs
@@ -210,6 +210,30 @@ async fn wrong_password_rejected() {
     );
 }
 
+/// `export_backup` rejects passwords shorter than 15 characters with a
+/// `Validation` error. A password of exactly 15 characters must be accepted
+/// (boundary). Import has no length check — old backups remain decryptable.
+#[tokio::test]
+async fn export_rejects_short_password() {
+    let a = TestVtc::builder().vtc_did(VTC_DID).build().await;
+    set_config_path(&a.state, a.data_dir().join("config.toml")).await;
+    let a_store = PlaintextSecretStore::new(a.data_dir());
+
+    // 14 chars — one short of the minimum
+    let err = export_backup(&a.state, &a_store, "14-char-passwo", false)
+        .await
+        .expect_err("export must reject a 14-character password");
+    assert!(
+        format!("{err}").contains("15 characters"),
+        "error must mention the 15-character minimum, got: {err}"
+    );
+
+    // Exactly 15 chars — must be accepted (boundary)
+    export_backup(&a.state, &a_store, "15-char-passwor", false)
+        .await
+        .expect("export must accept a 15-character password");
+}
+
 // ---------------------------------------------------------------------------
 // Audit checkpoints (#708)
 // ---------------------------------------------------------------------------

--- a/vtc-service/tests/backup.rs
+++ b/vtc-service/tests/backup.rs
@@ -15,7 +15,10 @@ use vtc_service::keys::seed_store::{PlaintextSecretStore, SecretStore};
 use vtc_service::server::AppState;
 use vtc_service::test_support::TestVtc;
 
-const PW: &str = "twelve-char-pw!!";
+/// Must clear `MIN_BACKUP_PASSWORD_LEN` — every test below exports through
+/// the real guard, so a short value here fails the whole file rather than the
+/// one case under test. (The old name said "twelve"; the minimum is 15.)
+const PW: &str = "backup-test-password";
 const VTC_DID: &str = "did:key:z6MkBackupRoundTrip";
 
 /// `cfg.save()` (run by import's config restore) writes `config_path` —


### PR DESCRIPTION
## Raise backup password minimum to 15 characters

### What changed

The minimum password length enforced at **export time** is raised from 12 to 15 characters. Import/decrypt paths carry no length check — existing backups encrypted with shorter passwords remain fully decryptable (backward compatible).

| File | Change |
|---|---|
| `vta-backup/src/ops/mod.rs` | `< 12` → `< 15`; new unit test |
| `vtc-service/src/backup.rs` | `MIN_PASSWORD_LEN = 12` → `= 15` |
| `vtc-service/src/routes/backup.rs` | OpenAPI doc comment updated |
| `vtc-service/tests/backup.rs` | New integration test |
| `pnm-cli/src/commands/backup.rs` | Prompt text + guard ×2 |
| `cnm-cli/src/backup.rs` | Prompt text + guard |
| `vta-sdk/src/protocols/backup_management/descriptors.rs` | Doc comment |

### Why 15

A backup envelope carries the VTA's master seed, BIP-32 key hierarchy, and ACL — the highest-value secret in a deployment. The previous 12-character minimum falls below the 15-character threshold recommended by CIS Benchmarks for privileged-account credentials and widely adopted as industry best practice for secrets protecting cryptographic key material.

### Backward compatibility

Operators who created backups with a password between 12–14 characters can still import them — the length check only fires on new exports.

### Tests

- **`vta-backup::ops::tests::export_rejects_short_password`** (new) — unit test at the op layer: 14-char password rejected with error mentioning "15 characters"; 15-char boundary accepted.
- **`vtc-service::tests::backup::export_rejects_short_password`** (new) — integration test via `TestVtc`: same boundary check.
- **`vta-service::tests::api_integration::backup_export_rejects_short_password`** (pre-existing) — HTTP-layer test using `"short"` (5 chars); still passes unmodified.