### PR TITLE
fix(vta-service): self-readiness gate + persistent mediator reconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,26 +2,53 @@
 
 ## Unreleased
 
-### vta-service 0.13.19 / vta-config 0.2.1 / vta-backup 0.1.4 — mediator cold-start self-readiness gate + persistent reconnect (#876)
+### vta-service 0.13.19 / vta-config 0.3.0 / vta-backup 0.1.4 / vta-support 0.2.2 / vta-keys 0.1.4 / vta-policy 0.1.2 / vta-tee 0.1.4 — mediator readiness gate + connection supervisor (#876)
 
 Fixes a cold-start race where a freshly deployed VTA could fail to establish its
-mediator connection and stay disconnected. On startup, before the first connect
-attempt, the mediator DID and the VTA's own DID may not yet be resolvable
-(propagation / caching), so the initial DIDComm handshake is rejected and the
-service never retries.
+mediator connection and stay disconnected until an operator restarted it. The
+mediator authenticates a VTA by resolving that VTA's DID itself; on a cold start
+the DID document often isn't published yet, so the handshake is rejected — and
+the mediator's resolver negative-caches the failure, so the VTA's short retry
+burst fails too. It then gave up permanently.
 
-- **`vta-service`**: new `messaging::readiness` gate. Before connecting, the
-  service confirms its own DID resolves over the network; until it does, the
-  connect is deferred rather than attempted-and-failed. A `MessagingConnect`
-  supervisor then owns the mediator connection for the process lifetime,
-  reconnecting with capped exponential backoff and full jitter instead of
-  giving up after the first failure. Self-resolution honours the configured
-  remote resolver when one is set, matching how the rest of the service
-  resolves DIDs.
-- **`vta-config`**: `MediatorReadinessConfig` gains reconnect controls —
-  `reconnect` (enable/disable), `reconnect_backoff_cap_secs`, and
-  `reconnect_max_elapsed_secs`.
-- **`vta-backup`**: test-support constructor updated for the new config field.
+- **`vta-service`**: new `messaging::readiness` gate. Before connecting, the VTA
+  waits until its own DID **fully resolves over the network**, through the
+  configured resolver — the same operation the mediator performs, so a pass means
+  the mediator can authenticate us. Only `did:webvh` / `did:web` are gated;
+  `did:key` resolves without a network fetch and skips the wait.
+- **`vta-service`**: a `MessagingConnect` supervisor owns the mediator lifecycle
+  — gate, connect, and reconnect — with capped exponential backoff and full
+  jitter, re-confirming self-resolution before each attempt. It recovers both a
+  failed initial connect (once the mediator's negative cache expires) and an
+  established session whose inbound loop ended, where the VTA previously went
+  silently deaf for the rest of the process. Sessions shorter than 60s don't
+  reset the backoff, so a flapping mediator escalates rather than being retried
+  at full rate.
+- **`vta-service`**: the whole gate + reconnect runs in a background task.
+  Nothing blocks the startup path, so `/health` is live throughout and a
+  `SIGTERM` mid-gate is honoured immediately.
+- **`vta-service`**: `build_messaging` now tears the ATM down
+  (`graceful_shutdown`) on every error path after the profile is registered.
+  There is no `Drop` impl on `ATM`, so an abandoned socket keeps auto-reconnecting
+  while holding the mediator's one-socket-per-DID slot — without this a retrying
+  connect loop would leak one duelling socket per attempt. The 30s websocket
+  timeout is the sharp edge: it drops the future mid-flight, so the SDK's own
+  cleanup never runs.
+- **`vta-service`**: `DIDCommBridge` wiring is republishable rather than
+  set-once, so a reconnect actually re-points outbound sends at the new session
+  instead of silently leaving them on the dead one.
+- **`vta-config`** (breaking): `AppConfig` gains a `mediator_readiness` field,
+  and `MediatorReadinessConfig` / `ReadinessTimeoutPolicy` are new — `enabled`,
+  `retry_secs`, `backoff_cap_secs`, `max_wait_secs`, `on_timeout`, `reconnect`,
+  `reconnect_backoff_cap_secs`, `reconnect_max_elapsed_secs`. All default; the
+  defaults suit a normal LB/Kubernetes deployment. Minor bump because
+  `AppConfig` is not `#[non_exhaustive]`, so the new field breaks struct-literal
+  construction.
+- **`vta-backup`** / **`vta-support`** / **`vta-keys`** / **`vta-policy`** /
+  **`vta-tee`**: `vta-config` requirement moved to `0.3`; `vta-backup`'s
+  test-support constructor updated for the new field.
+- **Docs**: new `docs/02-vta/mediator-connection.md` (operator guide to the gate,
+  the supervisor, and every `[mediator_readiness]` setting).
 
 ### vta-backup 0.1.3 / vtc-service 0.11.45 / pnm-cli 0.11.16 / cnm-cli 0.11.13 / vta-sdk 0.20.27 — raise backup password minimum to 15 characters
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ## Unreleased
 
+### vta-service 0.13.19 / vta-config 0.2.1 / vta-backup 0.1.4 — mediator cold-start self-readiness gate + persistent reconnect (#876)
+
+Fixes a cold-start race where a freshly deployed VTA could fail to establish its
+mediator connection and stay disconnected. On startup, before the first connect
+attempt, the mediator DID and the VTA's own DID may not yet be resolvable
+(propagation / caching), so the initial DIDComm handshake is rejected and the
+service never retries.
+
+- **`vta-service`**: new `messaging::readiness` gate. Before connecting, the
+  service confirms its own DID resolves over the network; until it does, the
+  connect is deferred rather than attempted-and-failed. A `MessagingConnect`
+  supervisor then owns the mediator connection for the process lifetime,
+  reconnecting with capped exponential backoff and full jitter instead of
+  giving up after the first failure. Self-resolution honours the configured
+  remote resolver when one is set, matching how the rest of the service
+  resolves DIDs.
+- **`vta-config`**: `MediatorReadinessConfig` gains reconnect controls —
+  `reconnect` (enable/disable), `reconnect_backoff_cap_secs`, and
+  `reconnect_max_elapsed_secs`.
+- **`vta-backup`**: test-support constructor updated for the new config field.
+
 ### vta-backup 0.1.3 / vtc-service 0.11.45 / pnm-cli 0.11.16 / cnm-cli 0.11.13 / vta-sdk 0.20.27 — raise backup password minimum to 15 characters
 
 The export-side minimum password length is raised from 12 to 15 characters

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -349,6 +349,36 @@ new flow, update both this section and the relevant `docs/*.md`.
   backend (OS keyring by default; AWS/GCP/Azure via feature flags).
 - **Docs**: `docs/02-vta/cold-start.md`, `docs/02-vta/non-interactive-setup.md`.
 
+### Mediator connection (readiness gate + reconnect)
+- **What**: How the VTA establishes and *keeps* its outbound mediator DIDComm
+  connection. One background supervisor (`MessagingConnect`) owns the whole
+  lifecycle: gate → connect-with-retry → supervise session → reconnect.
+- **Gate**: waits until the VTA's own DID **fully resolves over the network**
+  before the first connect, because the mediator authenticates us by resolving
+  that DID itself. Resolution through the configured resolver is the whole check
+  — do **not** re-add an HTTP probe of the `did.jsonl` URL: a 200 doesn't imply
+  resolvability, and it tests the VTA's own egress to the DID host, which is the
+  wrong path (and unreachable) when egress is restricted to a resolver sidecar.
+  Only `did:webvh` / `did:web` are gated; `did:key` skips.
+- **Reconnect**: capped exponential backoff + full jitter, re-confirming
+  self-resolution before every attempt. Covers both a failed initial connect
+  (the mediator's own resolver negative-caching us, which clears on its own
+  timer) and an established session whose inbound loop ended.
+- **Invariants to preserve**: (1) nothing here may run on the startup path —
+  `server::run` must reach its shutdown select for a signal to be honoured;
+  (2) every `build_messaging` error path after `profile_add` must
+  `graceful_shutdown` the ATM — there is no `Drop` impl, and an abandoned socket
+  keeps auto-reconnecting while holding the mediator's one-socket-per-DID slot,
+  so a retry loop without teardown leaks one duelling socket per attempt;
+  (3) a session must last `MIN_HEALTHY_SESSION` before it resets the backoff,
+  else a flapping mediator gets retried at full rate.
+- **Code**: `vta-service/src/messaging/readiness.rs`,
+  `vta-service/src/server.rs` (`MessagingConnect`),
+  `vta-service/src/messaging/service.rs` (`build_messaging`,
+  `connect_transport`), `vta-config/src/lib.rs`
+  (`MediatorReadinessConfig`).
+- **Docs**: `docs/02-vta/mediator-connection.md`.
+
 ### VTC first-boot setup (VTA-provisioned)
 - **What**: Stands up a VTC by provisioning its DID + keys from a running
   VTA via the `vtc-host` DID template, then writing `config.toml`, the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10143,7 +10143,7 @@ dependencies = [
 
 [[package]]
 name = "vta-config"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "serde",
  "serde_ignored",
@@ -10171,7 +10171,7 @@ dependencies = [
 
 [[package]]
 name = "vta-keys"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "aes-gcm",
  "affinidi-crypto",
@@ -10253,7 +10253,7 @@ dependencies = [
 
 [[package]]
 name = "vta-policy"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "hex",
  "regorus",
@@ -10434,7 +10434,7 @@ dependencies = [
 
 [[package]]
 name = "vta-support"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "chrono",
  "ed25519-dalek",
@@ -10470,7 +10470,7 @@ dependencies = [
 
 [[package]]
 name = "vta-tee"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10089,7 +10089,7 @@ dependencies = [
 
 [[package]]
 name = "vta-backup"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -10143,7 +10143,7 @@ dependencies = [
 
 [[package]]
 name = "vta-config"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "serde",
  "serde_ignored",
@@ -10333,7 +10333,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.13.18"
+version = "0.13.19"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/docs/02-vta/mediator-connection.md
+++ b/docs/02-vta/mediator-connection.md
@@ -1,0 +1,139 @@
+# Mediator connection: readiness gate and reconnect
+
+How a VTA establishes and keeps its outbound DIDComm connection to its mediator,
+and the `[mediator_readiness]` settings that tune it.
+
+Audience: operators deploying a VTA behind a load balancer, in Kubernetes, or
+anywhere the VTA's DID document becomes resolvable *after* the process starts.
+
+## The problem this solves
+
+The mediator authenticates a VTA by **resolving the VTA's DID itself** — it
+fetches the DID document to get the key that decrypts the authcrypt handshake.
+That creates a cold-start ordering hazard:
+
+1. The VTA boots and publishes its `did:webvh`.
+2. The VTA immediately opens the mediator websocket.
+3. The mediator tries to resolve the VTA's DID — but the document isn't served
+   yet (the DID host hasn't published it, or the LB target fronting it isn't
+   healthy).
+4. The resolution fails, the mediator rejects the handshake with a 403, and —
+   worse — the mediator's resolver **negative-caches** the failure, so the next
+   several attempts fail even after the document goes live.
+
+Before the readiness gate, the VTA burned a short retry burst against that and
+then gave up until an operator restarted it.
+
+## What the VTA does now
+
+A single background supervisor owns the whole mediator lifecycle. Nothing below
+runs on the startup path, so `/health` is live throughout and a `SIGTERM` is
+honoured immediately — including mid-gate.
+
+### 1. Self-readiness gate
+
+Before the first connect, the VTA waits until **its own DID fully resolves over
+the network**, through the configured resolver (`resolver_url` when set, local
+resolution otherwise). A pass means the mediator can do the same lookup and
+authenticate us.
+
+Resolution — not an HTTP probe of the `did.jsonl` URL — is deliberately the whole
+check:
+
+- A bare `200` on `did.jsonl` doesn't imply resolvability; a `200` serving a
+  partial or malformed log still fails resolution.
+- A direct HTTP probe would test *the VTA's own egress to the DID host*, which is
+  the wrong path when egress is restricted to a resolver sidecar — there the VTA
+  cannot reach the DID host directly at all, so the probe could never succeed.
+
+Only network-resolved methods are gated (`did:webvh`, `did:web`). A `did:key` VTA
+resolves from its own identifier with no network fetch, so it skips the wait
+entirely. An unrecognised method is also not gated — DIDComm is not withheld on
+the strength of a probe we can't reason about.
+
+The gate retries with capped exponential backoff and full jitter up to
+`max_wait_secs`, then applies `on_timeout`.
+
+### 2. Connect, with retry
+
+The connect itself retries on the same backoff scheme. The classic failure here
+is the mediator's *own* negative cache from step 4 above: it clears on its own
+timer, so retrying means the VTA **self-heals with no restart**.
+
+Every attempt re-confirms self-resolution first, so a VTA that can't resolve
+itself never storms the mediator with unauthenticatable handshakes.
+
+### 3. Session supervision
+
+Once connected, the supervisor watches the session. If the inbound loop ends, it
+tears the session down — unpublishing the outbound wiring, then stopping the
+websocket — and reconnects. Without this the VTA would go silently deaf for the
+rest of the process while still looking healthy.
+
+The teardown is not optional: the mediator permits **one socket per DID**, so
+reconnecting while the old socket is still auto-reconnecting would have the two
+duel over the slot (each evicting the other as `duplicate-channel`).
+
+A session must stay up for at least 60s to count as healthy and reset the
+backoff. A connect that succeeds and instantly drops is treated as a failed
+attempt, so a flapping mediator escalates the backoff instead of being retried at
+full rate.
+
+## Configuration
+
+All optional, under `[mediator_readiness]` in the VTA's `config.toml`. The
+defaults are intended to be correct for a normal LB/Kubernetes deployment —
+most operators need none of this.
+
+```toml
+[mediator_readiness]
+enabled                     = true   # run the gate at all
+retry_secs                  = 5      # base backoff interval
+backoff_cap_secs            = 30     # cap on the gate's backoff
+max_wait_secs               = 300    # how long the gate waits
+on_timeout                  = "skip" # skip | proceed | fail
+reconnect                   = true   # retry the connect, and reconnect dropped sessions
+reconnect_backoff_cap_secs  = 60     # cap on the reconnect backoff
+reconnect_max_elapsed_secs  = 0      # 0 = retry forever
+```
+
+| Setting | Default | Meaning |
+|---|---|---|
+| `enabled` | `true` | Run the self-readiness gate. `false` connects immediately — only sensible where the DID is known-published before boot. |
+| `retry_secs` | `5` | Base interval. Attempt `n` sleeps a uniform random duration in `[0, min(cap, retry_secs * 2^n)]` (full jitter), so a fleet coming up together doesn't probe in lock-step. |
+| `backoff_cap_secs` | `30` | Upper bound on the gate's per-attempt interval. |
+| `max_wait_secs` | `300` | How long the gate waits before applying `on_timeout`. Cancellable — a shutdown signal abandons the wait immediately. |
+| `on_timeout` | `"skip"` | See below. |
+| `reconnect` | `true` | Retry a failed connect, and reconnect a dropped session. `false` restores the legacy single-shot behaviour. |
+| `reconnect_backoff_cap_secs` | `60` | Upper bound on the reconnect interval. Larger than `backoff_cap_secs` because it must outlast a resolver negative-cache TTL. |
+| `reconnect_max_elapsed_secs` | `0` | Give up after this many seconds of *continuous* failure; `0` never gives up. Measured from the start of the current failure run and reset by any healthy session — a VTA that ran for a week then dropped gets the full budget. |
+
+### `on_timeout` policies
+
+| Value | Behaviour |
+|---|---|
+| `"skip"` (default) | Don't start DIDComm this boot. REST stays fully live, so the LB target turns healthy and the DID can finish publishing; a later restart reconnects. |
+| `"proceed"` | Connect anyway, best-effort, accepting that the handshake may be rejected. The reconnect loop still applies. |
+| `"fail"` | Treat it as fatal and shut the process down. Use where an orchestrator should recreate the pod rather than run it without DIDComm. |
+
+## Operating notes
+
+- **`/health` is never gated.** The REST listener starts before the supervisor,
+  so a VTA waiting on its DID is healthy from the LB's point of view — which is
+  what lets the DID become resolvable in the first place.
+- **A gate timeout under `skip` is not an error state.** The VTA runs
+  REST-only. If that is unacceptable for your deployment, use `fail`.
+- **`did:key` VTAs are unaffected** by every setting here.
+- **What to check when the gate times out.** The log names the DID and, for
+  `did:webvh`, where its document is expected to be published. Fetch that URL and
+  confirm it returns a complete log; if the VTA uses a resolver sidecar, check the
+  sidecar can reach the DID host.
+
+## Code
+
+- `vta-service/src/messaging/readiness.rs` — the gate, the resolution probe, and
+  the shared backoff/jitter helpers.
+- `vta-service/src/server.rs` — `MessagingConnect`, the supervisor.
+- `vta-service/src/messaging/service.rs` — `build_messaging` /
+  `connect_transport`, including the socket teardown every error path takes.
+- `vta-config/src/lib.rs` — `MediatorReadinessConfig`, `ReadinessTimeoutPolicy`.

--- a/vta-backup/Cargo.toml
+++ b/vta-backup/Cargo.toml
@@ -22,7 +22,7 @@ vti-common = { path = "../vti-common", version = "0.11" }
 vta-sdk = { path = "../vta-sdk", version = "0.20" }
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.1" }
 vta-keys = { path = "../vta-keys", version = "0.1" }
-vta-config = { path = "../vta-config", version = "0.2" }
+vta-config = { path = "../vta-config", version = "0.3" }
 vta-support = { path = "../vta-support", version = "0.2" }
 tokio = { workspace = true }
 serde = { workspace = true }

--- a/vta-backup/Cargo.toml
+++ b/vta-backup/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-backup"
 description = "VTA backup/restore subsystem — encrypted full-state export/import, the sealed backup-bundle store, and its TTL sweeper"
 readme = "README.md"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-backup/src/test_support.rs
+++ b/vta-backup/src/test_support.rs
@@ -72,6 +72,7 @@ pub fn test_app_config(data_dir: PathBuf) -> AppConfig {
         log: Default::default(),
         store: StoreConfig { data_dir },
         messaging: None,
+        mediator_readiness: Default::default(),
         services: Default::default(),
         auth: Default::default(),
         audit: Default::default(),

--- a/vta-config/Cargo.toml
+++ b/vta-config/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-config"
 description = "VTA configuration types — the `AppConfig` TOML shape and its sub-configs, composing the vti-common and vti-secrets config types"
 readme = "README.md"
-version = "0.2.1"
+version = "0.3.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-config/Cargo.toml
+++ b/vta-config/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-config"
 description = "VTA configuration types — the `AppConfig` TOML shape and its sub-configs, composing the vti-common and vti-secrets config types"
 readme = "README.md"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-config/src/lib.rs
+++ b/vta-config/src/lib.rs
@@ -103,9 +103,10 @@ pub struct AppConfig {
     #[serde(default = "default_store_config")]
     pub store: StoreConfig,
     pub messaging: Option<MessagingConfig>,
-    /// Startup readiness gate for the mediator DIDComm connection:
-    /// wait until the VTA's own public DID document is externally reachable
-    /// before initiating the outbound mediator handshake.
+    /// Startup readiness gate + reconnect policy for the mediator DIDComm
+    /// connection: wait until the VTA's own DID resolves over the network before
+    /// initiating the outbound mediator handshake, then keep the connection up.
+    /// See `docs/02-vta/mediator-connection.md`.
     #[serde(default)]
     pub mediator_readiness: MediatorReadinessConfig,
     #[serde(default)]
@@ -167,23 +168,26 @@ pub enum ReadinessTimeoutPolicy {
     /// the target healthy; a later restart reconnects. Default.
     #[default]
     Skip,
-    /// Connect to the mediator anyway (best-effort), accepting the initial
-    /// 503→403 risk.
+    /// Connect to the mediator anyway (best-effort), accepting that the
+    /// handshake may be rejected because the mediator can't resolve us yet.
     Proceed,
-    /// Treat an un-ready endpoint as a fatal startup error.
+    /// Treat a DID that won't resolve as fatal and shut the process down.
     Fail,
 }
 
 /// Startup readiness gate for the mediator DIDComm connection.
 ///
 /// On cold start a VTA can initiate its outbound mediator handshake before its
-/// own public DID document is externally reachable (the LB target isn't
-/// healthy yet). The mediator then can't fetch the VTA's `did.jsonl` to decrypt
-/// the authcrypt handshake, yielding a 503→403 retry storm and an LB 5XX
-/// burst. This gate makes the VTA poll its own public DID endpoint until it
-/// returns 200 before connecting. Only network-resolved DID methods
-/// (`did:webvh`) are gated; a `did:key` VTA has no external endpoint and skips
-/// the wait.
+/// own DID document is resolvable — the DID host hasn't published it, or the
+/// load-balancer target fronting it isn't healthy yet. The mediator
+/// authenticates the VTA by resolving that DID itself, so it can't get the key
+/// to decrypt the authcrypt handshake and rejects it, producing a burst of 403s.
+///
+/// This gate makes the VTA wait until its own DID **fully resolves over the
+/// network** — through the configured resolver, so it exercises the same path
+/// the mediator takes — before connecting. Only network-resolved methods
+/// (`did:webvh`, `did:web`) are gated; a `did:key` VTA resolves from its own
+/// identifier with no network fetch and skips the wait.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct MediatorReadinessConfig {
     /// Enable the gate. Default `true`.
@@ -191,9 +195,8 @@ pub struct MediatorReadinessConfig {
     pub enabled: bool,
     /// Base (initial) seconds between probe attempts. The actual wait uses
     /// capped exponential backoff with full jitter — attempt `n` sleeps a
-    /// random duration in `[0, min(backoff_cap_secs, retry_secs * 2^n)]` — so
-    /// the VTA doesn't hammer its own (still-unhealthy) LB target while it
-    /// waits, keeping self-probe 5XX volume down. Default 5.
+    /// random duration in `[0, min(backoff_cap_secs, retry_secs * 2^n)]` — so a
+    /// fleet of VTAs coming up together doesn't probe in lock-step. Default 5.
     #[serde(default = "default_readiness_retry_secs")]
     pub retry_secs: u64,
     /// Upper bound on the per-attempt backoff interval (the "cap" in the
@@ -201,35 +204,48 @@ pub struct MediatorReadinessConfig {
     /// this. Default 30.
     #[serde(default = "default_readiness_backoff_cap_secs")]
     pub backoff_cap_secs: u64,
-    /// Maximum seconds to wait before applying `on_timeout`. Default 300.
+    /// Maximum seconds the gate waits before applying `on_timeout`. The wait is
+    /// cancellable: a shutdown signal abandons it immediately rather than
+    /// holding the process open for the remainder. Default 300.
     #[serde(default = "default_readiness_max_wait_secs")]
     pub max_wait_secs: u64,
     /// What to do when the gate times out. Default `skip`.
     #[serde(default)]
     pub on_timeout: ReadinessTimeoutPolicy,
-    /// Persistent reconnect supervisor. After the self-readiness
-    /// gate passes, the initial mediator connect can still fail — most commonly
-    /// because the mediator's *own* DNS resolver holds a negative-cache entry
-    /// for the VTA host and can't fetch our `did.jsonl` to complete the
-    /// authcrypt handshake (a `NetworkError{status_code:None}` → 403). That
-    /// clears itself once the mediator's negative cache expires, so rather than
-    /// give up until the next restart, keep retrying the connect with capped
-    /// exponential backoff + full jitter. Each attempt first re-confirms the
-    /// VTA can resolve its own DID over the network, so the mediator is never
-    /// touched while the VTA is unresolvable. Default `true`.
+    /// Persistent reconnect supervisor. After the self-readiness gate passes,
+    /// the mediator connect can still fail — most commonly because the
+    /// mediator's *own* resolver holds a negative-cache entry for the VTA host
+    /// and can't fetch our DID document to complete the authcrypt handshake
+    /// (a `NetworkError{status_code:None}` → 403). That clears itself once the
+    /// mediator's negative cache expires, so rather than give up until the next
+    /// restart, keep retrying with capped exponential backoff + full jitter.
+    /// Each attempt first re-confirms the VTA can resolve its own DID, so the
+    /// mediator is never touched while the VTA is unresolvable.
+    ///
+    /// This also covers an *established* session whose inbound loop ends: the
+    /// supervisor tears the session down and reconnects, instead of leaving the
+    /// VTA silently deaf until an operator restarts it. Setting this `false`
+    /// restores the legacy single-shot behaviour (one attempt, then nothing
+    /// until the next restart). Default `true`.
     #[serde(default = "default_true")]
     pub reconnect: bool,
     /// Upper bound on the reconnect backoff interval (seconds) — the "cap" for
     /// the persistent-reconnect scheme. The jittered retry wait never exceeds
-    /// this. Larger than `backoff_cap_secs` (the self-probe cap) because the
-    /// reconnect horizon must comfortably outlast a DNS negative-cache TTL,
+    /// this. Larger than `backoff_cap_secs` (the gate's cap) because the
+    /// reconnect horizon must comfortably outlast a resolver negative-cache TTL,
     /// which can be many minutes. Default 60.
     #[serde(default = "default_reconnect_backoff_cap_secs")]
     pub reconnect_backoff_cap_secs: u64,
-    /// Give up reconnecting after this many seconds. `0` = never give up (retry
-    /// forever at the capped, jittered interval). A bounded retry rate is safe
-    /// to run indefinitely and lets the VTA self-heal once the mediator's
-    /// negative cache expires without any operator restart. Default 0.
+    /// Give up reconnecting after this many seconds of *continuous* failure.
+    /// `0` = never give up (retry forever at the capped, jittered interval).
+    /// A bounded retry rate is safe to run indefinitely and lets the VTA
+    /// self-heal without any operator restart.
+    ///
+    /// The clock is measured from the start of the current run of failures, not
+    /// from process start, and resets after any session that stayed up long
+    /// enough to count as healthy — so a VTA that ran for a week and then
+    /// dropped gets the full budget rather than one it exhausted days ago.
+    /// Default 0.
     #[serde(default)]
     pub reconnect_max_elapsed_secs: u64,
 }

--- a/vta-config/src/lib.rs
+++ b/vta-config/src/lib.rs
@@ -103,6 +103,11 @@ pub struct AppConfig {
     #[serde(default = "default_store_config")]
     pub store: StoreConfig,
     pub messaging: Option<MessagingConfig>,
+    /// Startup readiness gate for the mediator DIDComm connection:
+    /// wait until the VTA's own public DID document is externally reachable
+    /// before initiating the outbound mediator handshake.
+    #[serde(default)]
+    pub mediator_readiness: MediatorReadinessConfig,
     #[serde(default)]
     pub services: ServicesConfig,
     #[serde(default)]
@@ -151,6 +156,113 @@ pub struct AppConfig {
     /// that boots fine today must keep booting (P0.9b).
     #[serde(skip)]
     pub unknown_keys: Vec<String>,
+}
+
+/// How the mediator self-readiness gate behaves when it times out.
+/// See [`MediatorReadinessConfig`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum ReadinessTimeoutPolicy {
+    /// Skip DIDComm startup this boot. `/health` stays live so the LB can turn
+    /// the target healthy; a later restart reconnects. Default.
+    #[default]
+    Skip,
+    /// Connect to the mediator anyway (best-effort), accepting the initial
+    /// 503→403 risk.
+    Proceed,
+    /// Treat an un-ready endpoint as a fatal startup error.
+    Fail,
+}
+
+/// Startup readiness gate for the mediator DIDComm connection.
+///
+/// On cold start a VTA can initiate its outbound mediator handshake before its
+/// own public DID document is externally reachable (the LB target isn't
+/// healthy yet). The mediator then can't fetch the VTA's `did.jsonl` to decrypt
+/// the authcrypt handshake, yielding a 503→403 retry storm and an LB 5XX
+/// burst. This gate makes the VTA poll its own public DID endpoint until it
+/// returns 200 before connecting. Only network-resolved DID methods
+/// (`did:webvh`) are gated; a `did:key` VTA has no external endpoint and skips
+/// the wait.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct MediatorReadinessConfig {
+    /// Enable the gate. Default `true`.
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    /// Base (initial) seconds between probe attempts. The actual wait uses
+    /// capped exponential backoff with full jitter — attempt `n` sleeps a
+    /// random duration in `[0, min(backoff_cap_secs, retry_secs * 2^n)]` — so
+    /// the VTA doesn't hammer its own (still-unhealthy) LB target while it
+    /// waits, keeping self-probe 5XX volume down. Default 5.
+    #[serde(default = "default_readiness_retry_secs")]
+    pub retry_secs: u64,
+    /// Upper bound on the per-attempt backoff interval (the "cap" in the
+    /// exponential-backoff-with-jitter scheme). The jittered wait never exceeds
+    /// this. Default 30.
+    #[serde(default = "default_readiness_backoff_cap_secs")]
+    pub backoff_cap_secs: u64,
+    /// Maximum seconds to wait before applying `on_timeout`. Default 300.
+    #[serde(default = "default_readiness_max_wait_secs")]
+    pub max_wait_secs: u64,
+    /// What to do when the gate times out. Default `skip`.
+    #[serde(default)]
+    pub on_timeout: ReadinessTimeoutPolicy,
+    /// Persistent reconnect supervisor. After the self-readiness
+    /// gate passes, the initial mediator connect can still fail — most commonly
+    /// because the mediator's *own* DNS resolver holds a negative-cache entry
+    /// for the VTA host and can't fetch our `did.jsonl` to complete the
+    /// authcrypt handshake (a `NetworkError{status_code:None}` → 403). That
+    /// clears itself once the mediator's negative cache expires, so rather than
+    /// give up until the next restart, keep retrying the connect with capped
+    /// exponential backoff + full jitter. Each attempt first re-confirms the
+    /// VTA can resolve its own DID over the network, so the mediator is never
+    /// touched while the VTA is unresolvable. Default `true`.
+    #[serde(default = "default_true")]
+    pub reconnect: bool,
+    /// Upper bound on the reconnect backoff interval (seconds) — the "cap" for
+    /// the persistent-reconnect scheme. The jittered retry wait never exceeds
+    /// this. Larger than `backoff_cap_secs` (the self-probe cap) because the
+    /// reconnect horizon must comfortably outlast a DNS negative-cache TTL,
+    /// which can be many minutes. Default 60.
+    #[serde(default = "default_reconnect_backoff_cap_secs")]
+    pub reconnect_backoff_cap_secs: u64,
+    /// Give up reconnecting after this many seconds. `0` = never give up (retry
+    /// forever at the capped, jittered interval). A bounded retry rate is safe
+    /// to run indefinitely and lets the VTA self-heal once the mediator's
+    /// negative cache expires without any operator restart. Default 0.
+    #[serde(default)]
+    pub reconnect_max_elapsed_secs: u64,
+}
+
+fn default_readiness_retry_secs() -> u64 {
+    5
+}
+
+fn default_reconnect_backoff_cap_secs() -> u64 {
+    60
+}
+
+fn default_readiness_backoff_cap_secs() -> u64 {
+    30
+}
+
+fn default_readiness_max_wait_secs() -> u64 {
+    300
+}
+
+impl Default for MediatorReadinessConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            retry_secs: default_readiness_retry_secs(),
+            backoff_cap_secs: default_readiness_backoff_cap_secs(),
+            max_wait_secs: default_readiness_max_wait_secs(),
+            on_timeout: ReadinessTimeoutPolicy::Skip,
+            reconnect: true,
+            reconnect_backoff_cap_secs: default_reconnect_backoff_cap_secs(),
+            reconnect_max_elapsed_secs: 0,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/vta-keys/Cargo.toml
+++ b/vta-keys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-keys"
 description = "VTA key management — master-seed storage, BIP-32 key derivation, key wrapping, and the seed-store backend selection"
 readme = "README.md"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -26,7 +26,7 @@ tee = ["vti-secrets/tee"]
 
 [dependencies]
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.1" }
-vta-config = { path = "../vta-config", version = "0.2" }
+vta-config = { path = "../vta-config", version = "0.3" }
 vti-common = { path = "../vti-common", version = "0.11" }
 vti-secrets = { path = "../vti-secrets", version = "0.1" }
 vta-sdk = { path = "../vta-sdk", version = "0.20", features = ["sealed-transfer"] }

--- a/vta-policy/Cargo.toml
+++ b/vta-policy/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-policy"
 description = "VTA policy subsystem — the regorus (Rego) engine, the default policy bundle, consent model, and decision evaluators"
 readme = "README.md"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -12,7 +12,7 @@ repository.workspace = true
 
 [dependencies]
 vti-common = { path = "../vti-common", version = "0.11" }
-vta-config = { path = "../vta-config", version = "0.2" }
+vta-config = { path = "../vta-config", version = "0.3" }
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.1" }
 regorus = { workspace = true }
 serde = { workspace = true }

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -98,7 +98,7 @@ vta-keyspaces = { path = "../vta-keyspaces", version = "0.1" }
 vta-audit = { path = "../vta-audit", version = "0.1" }
 # VTA configuration types (AppConfig + sub-configs), extracted and re-exported
 # as `crate::config`. The `tee` feature enables `vta-config/tee`.
-vta-config = { path = "../vta-config", version = "0.2" }
+vta-config = { path = "../vta-config", version = "0.3" }
 # Shared mid-layer services (contexts, seal, sealed_nonce_store), re-exported
 # as crate::{contexts,seal,sealed_nonce_store}.
 vta-support = { path = "../vta-support", version = "0.2" }

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.13.18"
+version = "0.13.19"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/didcomm_bridge.rs
+++ b/vta-service/src/didcomm_bridge.rs
@@ -1,10 +1,10 @@
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
 use affinidi_messaging_delivery::{Delivery, MessagingService, MessagingStatus};
 use affinidi_tdk::didcomm::Message;
 use affinidi_tdk::messaging::ATM;
-use tokio::sync::OnceCell;
+use tracing::debug;
 
 use crate::error::{AppError, bad_gateway_error};
 use vta_sdk::protocols::{PROBLEM_REPORT_TYPE, extract_problem_report};
@@ -46,8 +46,8 @@ fn problem_report_to_app_error(code: &str, comment: &str) -> AppError {
     }
 }
 
-/// The live delivery-layer wiring the bridge sends through, published once the
-/// [`MessagingService`] is built in `server::run`.
+/// The live delivery-layer wiring the bridge sends through, published each time
+/// `server::MessagingConnect` establishes a mediator session.
 struct BridgeInner {
     /// The one delivery-layer service over the VTA's mediator websocket(s).
     /// Outbound `send`/`request` route through its current **primary**;
@@ -76,9 +76,23 @@ struct BridgeInner {
 /// The public method surface is unchanged so the ~25 WebVH / provision / CLI /
 /// test call-sites that thread `Arc<DIDCommBridge>` compile untouched;
 /// [`placeholder`](Self::placeholder) stays free (offline CLI + tests never
-/// send). The live wiring is published once via [`set_messaging`](Self::set_messaging).
+/// send). The live wiring is published via [`set_messaging`](Self::set_messaging)
+/// on every (re)connect and dropped via
+/// [`clear_messaging`](Self::clear_messaging) when a session ends.
 pub struct DIDCommBridge {
-    inner: OnceCell<BridgeInner>,
+    /// The current wiring, or `None` before the first successful mediator
+    /// connect.
+    ///
+    /// **Republishable, not set-once.** `server::MessagingConnect` reconnects
+    /// after a dropped session, and each reconnect builds a *new*
+    /// `MessagingService`/ATM over a new socket. A set-once cell silently
+    /// discarded the republish, leaving every outbound send pointed at the
+    /// previous session's dead socket — so the bridge has to be able to swap.
+    ///
+    /// Accessors clone the `Arc` out and drop the guard before any `.await`
+    /// (R1.3: never hold a lock across an await), which is also why this is a
+    /// `std` lock rather than a `tokio` one.
+    inner: RwLock<Option<Arc<BridgeInner>>>,
     /// The primary transport id (e.g. `"vta-main"`). Retained for parity with
     /// the old listener id; outbound always routes through the service's
     /// current primary regardless.
@@ -91,7 +105,7 @@ impl DIDCommBridge {
     /// the delivery-layer `MessagingService` starts to enable outbound sends.
     pub fn new(listener_id: impl Into<String>) -> Self {
         Self {
-            inner: OnceCell::new(),
+            inner: RwLock::new(None),
             listener_id: listener_id.into(),
         }
     }
@@ -102,14 +116,36 @@ impl DIDCommBridge {
         Self::new("")
     }
 
-    /// Publish the live delivery-layer wiring. Called once from `server::run`
-    /// after the `MessagingService` is built over the mediator websocket.
+    /// Publish the live delivery-layer wiring, replacing any previous session's.
+    /// Called from `server::MessagingConnect` after each successful mediator
+    /// connect.
     pub fn set_messaging(&self, service: Arc<MessagingService>, atm: ATM, vta_did: String) {
-        let _ = self.inner.set(BridgeInner {
-            service,
-            atm,
-            vta_did,
-        });
+        let replacing = {
+            let mut guard = self.write_inner();
+            guard
+                .replace(Arc::new(BridgeInner {
+                    service,
+                    atm,
+                    vta_did,
+                }))
+                .is_some()
+        };
+        if replacing {
+            debug!("DIDComm bridge wiring replaced (mediator reconnect)");
+        }
+    }
+
+    /// Drop the published wiring — outbound sends fail with "not initialized"
+    /// until the next [`set_messaging`](Self::set_messaging).
+    ///
+    /// Called by the reconnect supervisor once a session's inbound loop has
+    /// ended: the old `MessagingService` is finished at that point, and leaving
+    /// it published would have callers queue sends onto a dead socket that can
+    /// only fail. Failing fast is the honest signal.
+    pub fn clear_messaging(&self) {
+        if self.write_inner().take().is_some() {
+            debug!("DIDComm bridge wiring cleared (mediator session ended)");
+        }
     }
 
     /// The live [`MessagingService`] handle, or `None` before
@@ -117,18 +153,18 @@ impl DIDCommBridge {
     /// handshake prover, which drives `add_transport`/`request_via`/`promote`
     /// against it.
     pub fn messaging_handle(&self) -> Option<Arc<MessagingService>> {
-        self.inner.get().map(|i| i.service.clone())
+        self.snapshot().map(|i| i.service.clone())
     }
 
     /// The ATM (for building a candidate transport's profile + packing during
     /// the mediator handshake), or `None` before the service is published.
     pub fn atm(&self) -> Option<ATM> {
-        self.inner.get().map(|i| i.atm.clone())
+        self.snapshot().map(|i| i.atm.clone())
     }
 
     /// The VTA's own DID, or `None` before the service is published.
     pub fn vta_did(&self) -> Option<String> {
-        self.inner.get().map(|i| i.vta_did.clone())
+        self.snapshot().map(|i| i.vta_did.clone())
     }
 
     /// The live, **non-latched** messaging status (R6.2), or `None` before the
@@ -136,7 +172,7 @@ impl DIDCommBridge {
     /// which reflects each transport's live connection signal and can go false
     /// again after boot.
     pub fn messaging_status_str(&self) -> Option<String> {
-        self.inner.get().map(|i| {
+        self.snapshot().map(|i| {
             match i.service.status() {
                 MessagingStatus::Connected => "connected",
                 MessagingStatus::Degraded => "degraded",
@@ -148,9 +184,26 @@ impl DIDCommBridge {
         })
     }
 
-    fn inner(&self) -> Result<&BridgeInner, AppError> {
+    /// Clone the current wiring out from under the read lock. Every accessor
+    /// goes through this so no guard is ever alive across an `.await`.
+    fn snapshot(&self) -> Option<Arc<BridgeInner>> {
+        match self.inner.read() {
+            Ok(guard) => guard.clone(),
+            // A poisoned lock means a writer panicked mid-swap. The wiring is
+            // just three cloneable handles, so recover rather than propagate a
+            // panic into every send path.
+            Err(poisoned) => poisoned.into_inner().clone(),
+        }
+    }
+
+    fn write_inner(&self) -> std::sync::RwLockWriteGuard<'_, Option<Arc<BridgeInner>>> {
         self.inner
-            .get()
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    fn inner(&self) -> Result<Arc<BridgeInner>, AppError> {
+        self.snapshot()
             .ok_or_else(|| AppError::Internal("DIDComm messaging not initialized".into()))
     }
 
@@ -216,7 +269,7 @@ impl DIDCommBridge {
         // request's own `expiresAt` — a shorter message expiry could make the
         // mediator drop it before an offline device reconnects. (This preserves
         // the prior `send_oneway` behaviour, which set no expiry.)
-        let (_msg_id, packed) = Self::pack(inner, recipient_did, msg_type, body, None).await?;
+        let (_msg_id, packed) = Self::pack(&inner, recipient_did, msg_type, body, None).await?;
         inner
             .service
             .send(
@@ -247,7 +300,7 @@ impl DIDCommBridge {
     ) -> Result<Message, AppError> {
         let inner = self.inner()?;
         let (msg_id, packed) =
-            Self::pack(inner, server_did, msg_type, body, Some(timeout_secs)).await?;
+            Self::pack(&inner, server_did, msg_type, body, Some(timeout_secs)).await?;
         // The outbound message id IS the correlation thread id: the reply
         // threads to it (`thid == request.id`), and the delivery dispatcher
         // demuxes the reply to this waiter by that thread id.
@@ -281,7 +334,7 @@ impl DIDCommBridge {
     ) -> Result<Message, AppError> {
         let inner = self.inner()?;
         let (msg_id, packed) =
-            Self::pack(inner, recipient_did, msg_type, body, Some(timeout_secs)).await?;
+            Self::pack(&inner, recipient_did, msg_type, body, Some(timeout_secs)).await?;
         let received = inner
             .service
             .request_via(

--- a/vta-service/src/messaging/mod.rs
+++ b/vta-service/src/messaging/mod.rs
@@ -7,6 +7,9 @@ pub mod handlers_protocol;
 pub mod handshake;
 #[cfg(feature = "didcomm")]
 pub mod live_prover;
+/// Startup self-readiness gate for the mediator DIDComm connection.
+#[cfg(feature = "didcomm")]
+pub mod readiness;
 pub mod registry;
 pub mod router;
 /// Delivery-layer construction + protocol-routed inbound loop (D2 P2a).

--- a/vta-service/src/messaging/readiness.rs
+++ b/vta-service/src/messaging/readiness.rs
@@ -1,32 +1,56 @@
 //! Startup self-readiness gate for the mediator DIDComm connection.
 //!
 //! During cold start a VTA can fire its outbound mediator handshake before its
-//! own public DID document is externally reachable — the LB target isn't
-//! healthy yet, so a fetch of the VTA's `did.jsonl` returns 503. The mediator
-//! then can't get the VTA's key to decrypt the authcrypt auth message and
-//! returns 403; the VTA burns its short retry burst and (today) gives up. The
-//! visible blast radius is an LB 5XX burst and mediator auth/resolve failures.
+//! own DID document is externally resolvable — the DID host hasn't published
+//! it, or the load-balancer target fronting it isn't healthy yet. The mediator
+//! authenticates us by resolving our DID itself, so it can't get the key to
+//! decrypt the authcrypt auth message and returns 403; the VTA burns its short
+//! retry burst and (before this gate) gave up until the next restart.
 //!
-//! This gate makes the VTA wait until its own public DID is fully resolvable
-//! over the network — an HTTP 200 on its `did.jsonl` *and* a complete
-//! `did:webvh` resolution (the same path the mediator takes) — before
-//! initiating the mediator connection. Only network-resolved DID methods
-//! (`did:webvh`) are gated; a `did:key` VTA publishes no external endpoint, so
-//! it skips the wait (AC #2).
+//! This gate makes the VTA wait until its own DID **fully resolves over the
+//! network** before initiating the mediator connection — the same operation the
+//! mediator performs to fetch our sender key, so a pass here means the mediator
+//! can authenticate us. Only network-resolved methods (`did:webvh`, `did:web`)
+//! are gated; a `did:key` VTA resolves from its own identifier with no network
+//! fetch at all, so it skips the wait.
+//!
+//! Resolution — not an HTTP probe of the `did.jsonl` URL — is deliberately the
+//! whole check:
+//!
+//! - A bare 200 on `did.jsonl` doesn't imply resolvability (a 200 serving a
+//!   partial or malformed log still fails resolution), so the HTTP probe was
+//!   never sufficient on its own.
+//! - More importantly, a direct HTTP probe tests *the VTA's own egress to the
+//!   DID host*, which is the wrong path in exactly the deployment that needs
+//!   this gate most: when egress is restricted to a resolver sidecar
+//!   (`resolver_url`), the VTA cannot reach the DID host directly at all, so
+//!   the probe could never return 200 and the gate would always time out.
+//!   Resolving through the configured resolver exercises the real path.
 //!
 //! The gate is bounded: it retries with capped exponential backoff and full
 //! jitter (the AWS "Exponential Backoff And Jitter" scheme) up to a maximum
 //! wait, then applies a configured timeout policy (skip / proceed / fail). The
-//! jitter keeps the VTA from hammering its own still-unhealthy LB target in
-//! lock-step while it waits. See [`vta_config::MediatorReadinessConfig`].
+//! jitter keeps a fleet of VTAs from probing in lock-step. It is also
+//! cancellable — a shutdown signal mid-wait abandons the gate immediately
+//! rather than holding the process open for the rest of the horizon. See
+//! [`vta_config::MediatorReadinessConfig`].
 
 use std::time::Duration;
 
 use affinidi_did_resolver_cache_sdk::DIDCacheClient;
 use affinidi_did_resolver_cache_sdk::config::DIDCacheConfigBuilder;
 use rand::RngExt;
+use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 use vta_config::{MediatorReadinessConfig, ReadinessTimeoutPolicy};
+
+/// DID method prefixes whose resolution requires a network fetch, and whose
+/// document therefore has to be published before a mediator can authenticate
+/// us. Anything else (`did:key`, `did:peer`, `did:jwk`, or a method we don't
+/// recognise) is not gated — `did:key` and friends resolve straight from the
+/// identifier, and an unrecognised method must not have DIDComm withheld from
+/// it on the strength of a probe we can't reason about.
+const NETWORK_RESOLVED_METHODS: &[&str] = &["did:webvh:", "did:web:"];
 
 /// What the caller should do after the gate runs.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -42,7 +66,11 @@ pub enum GateDecision {
 /// [`ReadinessTimeoutPolicy::Fail`].
 #[derive(Debug, Clone)]
 pub struct ReadinessTimeout {
-    pub url: String,
+    /// The DID that would not resolve.
+    pub vta_did: String,
+    /// Where its document is expected to be published, when we can derive it —
+    /// the single most useful thing for an operator to go check.
+    pub endpoint: Option<String>,
     pub waited_secs: u64,
 }
 
@@ -50,126 +78,43 @@ impl std::fmt::Display for ReadinessTimeout {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "own public DID endpoint {} not reachable after {}s",
-            self.url, self.waited_secs
-        )
+            "own DID {} did not resolve over the network after {}s",
+            self.vta_did, self.waited_secs
+        )?;
+        if let Some(endpoint) = &self.endpoint {
+            write!(f, " (expected its document at {endpoint})")?;
+        }
+        Ok(())
     }
 }
 
 impl std::error::Error for ReadinessTimeout {}
 
-/// Run the self-readiness gate for `vta_did` and return the caller's decision.
-///
-/// Returns `Ok(Proceed)` when the endpoint became reachable, when the method
-/// needs no external endpoint (e.g. `did:key`), or when the gate is disabled.
-/// Returns `Ok(Skip)` on timeout under the `skip` policy. Returns
-/// `Err(ReadinessTimeout)` only on timeout under the `fail` policy.
-pub async fn run_gate(
-    vta_did: &str,
-    cfg: &MediatorReadinessConfig,
-    resolver_url: Option<&str>,
-) -> Result<GateDecision, ReadinessTimeout> {
-    if !cfg.enabled {
-        info!("mediator self-readiness gate disabled; connecting without waiting");
-        return Ok(GateDecision::Proceed);
-    }
-
-    let Some(url) = self_did_jsonl_url(vta_did) else {
-        // did:key (or a method we can't derive a URL for): nothing external to
-        // wait for — the mediator resolves it without a network fetch.
-        info!(
-            vta_did,
-            "self-readiness gate skipped: DID method needs no reachable public endpoint"
-        );
-        return Ok(GateDecision::Proceed);
-    };
-
-    let base = Duration::from_secs(cfg.retry_secs.max(1));
-    // Cap can never be below the base, else backoff couldn't grow.
-    let cap = Duration::from_secs(cfg.backoff_cap_secs.max(cfg.retry_secs.max(1)));
-    let max_wait = Duration::from_secs(cfg.max_wait_secs);
-    let url_str = url.to_string();
-    info!(
-        url = %url_str,
-        base_secs = base.as_secs(),
-        backoff_cap_secs = cap.as_secs(),
-        max_wait_secs = cfg.max_wait_secs,
-        "waiting for own public DID endpoint to become reachable before mediator connect \
-         (exponential backoff + full jitter)"
-    );
-
-    let client = build_probe_client(base);
-    let vta_did_owned = vta_did.to_string();
-    let resolver_url_owned = resolver_url.map(str::to_string);
-    let became_ready = run_readiness_loop(base, cap, max_wait, move || {
-        let client = client.clone();
-        let url = url.clone();
-        let did = vta_did_owned.clone();
-        let resolver_url = resolver_url_owned.clone();
-        async move { probe_self_ready(&client, url, &did, resolver_url.as_deref()).await }
-    })
-    .await;
-
-    if became_ready {
-        info!(url = %url_str, "own public DID endpoint reachable (200); proceeding to mediator connect");
-        return Ok(GateDecision::Proceed);
-    }
-
-    apply_timeout_policy(cfg.on_timeout, &url_str, cfg.max_wait_secs)
+/// `true` when `vta_did`'s method needs a network fetch to resolve, so the
+/// document must be published before the mediator can authenticate us.
+pub fn needs_network_probe(vta_did: &str) -> bool {
+    NETWORK_RESOLVED_METHODS
+        .iter()
+        .any(|prefix| vta_did.starts_with(prefix))
 }
 
-/// Map a timed-out gate to the caller decision per the configured policy.
-/// Extracted so the policy mapping is unit-testable without any network I/O.
-fn apply_timeout_policy(
-    policy: ReadinessTimeoutPolicy,
-    url: &str,
-    waited_secs: u64,
-) -> Result<GateDecision, ReadinessTimeout> {
-    match policy {
-        ReadinessTimeoutPolicy::Proceed => {
-            warn!(
-                url,
-                waited_secs,
-                "self-readiness gate timed out; connecting to mediator anyway (best-effort)"
-            );
-            Ok(GateDecision::Proceed)
-        }
-        ReadinessTimeoutPolicy::Skip => {
-            warn!(
-                url,
-                waited_secs,
-                "self-readiness gate timed out; skipping DIDComm startup this boot \
-                 (/health stays live; a later restart reconnects)"
-            );
-            Ok(GateDecision::Skip)
-        }
-        ReadinessTimeoutPolicy::Fail => Err(ReadinessTimeout {
-            url: url.to_string(),
-            waited_secs,
-        }),
-    }
-}
-
-/// The public `did.jsonl` URL for `vta_did`, or `None` when the method needs no
-/// reachable public endpoint (`did:key`) or a URL can't be derived (unknown
-/// method, or built without the `webvh` feature).
-pub fn self_did_jsonl_url(vta_did: &str) -> Option<reqwest::Url> {
-    if vta_did.starts_with("did:key:") {
-        return None;
-    }
-
+/// Where `vta_did`'s document is expected to be published, for **operator
+/// diagnostics only** — never fetched. `None` when we can't derive it (a
+/// non-`webvh` method, an unparseable DID, or a build without the `webvh`
+/// feature).
+pub fn self_did_endpoint_hint(vta_did: &str) -> Option<String> {
     #[cfg(feature = "webvh")]
     if vta_did.starts_with("did:webvh:") {
         return match didwebvh_rs::url::WebVHURL::parse_did_url(vta_did) {
             Ok(webvh) => match webvh.get_http_url(None) {
-                Ok(url) => reqwest::Url::parse(url.as_str()).ok(),
+                Ok(url) => Some(url.to_string()),
                 Err(e) => {
-                    warn!(vta_did, error = %e, "self-readiness: cannot derive did.jsonl URL from DID");
+                    debug!(vta_did, error = %e, "self-readiness: cannot derive did.jsonl URL");
                     None
                 }
             },
             Err(e) => {
-                warn!(vta_did, error = %e, "self-readiness: cannot parse did:webvh DID");
+                debug!(vta_did, error = %e, "self-readiness: cannot parse did:webvh DID");
                 None
             }
         };
@@ -179,67 +124,118 @@ pub fn self_did_jsonl_url(vta_did: &str) -> Option<reqwest::Url> {
     None
 }
 
-/// Build the probe HTTP client with a bounded per-attempt timeout so a hung
-/// connect can't stall the retry cadence.
-fn build_probe_client(retry: Duration) -> reqwest::Client {
-    let per_attempt = retry
-        .min(Duration::from_secs(10))
-        .max(Duration::from_secs(1));
-    reqwest::Client::builder()
-        .timeout(per_attempt)
-        .user_agent("vta-self-readiness-gate")
-        .build()
-        .expect("static reqwest client config (timeout + user agent) is always valid")
-}
-
-/// One readiness probe used by the gate loop: `true` iff the VTA's own public
-/// DID is fully resolvable over the network — the same path the mediator takes
-/// to fetch the authcrypt sender key. This is the "don't touch the
-/// mediator until the VTA has resolved *itself*" gate upgrade: a bare HTTP 200
-/// on `did.jsonl` isn't enough (a 200 with malformed/partial content still
-/// fails mediator resolution), so after the cheap HTTP check we run a full
-/// `did:webvh` resolution through a throwaway resolver.
-async fn probe_self_ready(
-    client: &reqwest::Client,
-    url: reqwest::Url,
-    vta_did: &str,
-    resolver_url: Option<&str>,
-) -> bool {
-    // Fast path: the mediator fetches `did.jsonl` over HTTP first. While that
-    // isn't 200 yet there's no point paying for a full resolution.
-    if !probe_endpoint_200(client, url).await {
-        return false;
-    }
-    resolve_self_did(vta_did, resolver_url).await
-}
-
-/// `true` iff the endpoint answers HTTP 200.
-async fn probe_endpoint_200(client: &reqwest::Client, url: reqwest::Url) -> bool {
-    match client.get(url).send().await {
-        Ok(resp) => {
-            let status = resp.status();
-            if status == reqwest::StatusCode::OK {
-                true
-            } else {
-                debug!(%status, "self-readiness probe: endpoint not ready (non-200)");
-                false
-            }
-        }
-        Err(e) => {
-            debug!(error = %e, "self-readiness probe: request failed");
-            false
-        }
-    }
-}
-
-/// `true` iff the VTA's own DID fully resolves over the network right now.
+/// Run the self-readiness gate for `vta_did` and return the caller's decision.
 ///
-/// Builds a **throwaway** [`DIDCacheClient`] per call — network mode against the
-/// configured `resolver_url` when set, local mode otherwise — so it resolves
-/// the VTA the same way the mediator does, while a preloaded self-DID entry
-/// (see `server::preload_self_did_document`) or a stale negative entry in the
+/// Returns `Ok(Proceed)` when the DID resolved, when its method needs no
+/// network fetch (e.g. `did:key`), or when the gate is disabled. Returns
+/// `Ok(Skip)` on timeout under the `skip` policy, and on cancellation. Returns
+/// `Err(ReadinessTimeout)` only on timeout under the `fail` policy.
+pub async fn run_gate(
+    vta_did: &str,
+    cfg: &MediatorReadinessConfig,
+    resolver_url: Option<&str>,
+    shutdown: &CancellationToken,
+) -> Result<GateDecision, ReadinessTimeout> {
+    if !cfg.enabled {
+        info!("mediator self-readiness gate disabled; connecting without waiting");
+        return Ok(GateDecision::Proceed);
+    }
+
+    if !needs_network_probe(vta_did) {
+        info!(
+            vta_did,
+            "self-readiness gate skipped: DID method resolves without a network fetch"
+        );
+        return Ok(GateDecision::Proceed);
+    }
+
+    let base = Duration::from_secs(cfg.retry_secs.max(1));
+    // Cap can never be below the base, else backoff couldn't grow.
+    let cap = Duration::from_secs(cfg.backoff_cap_secs.max(cfg.retry_secs.max(1)));
+    let max_wait = Duration::from_secs(cfg.max_wait_secs);
+    let endpoint = self_did_endpoint_hint(vta_did);
+    info!(
+        vta_did,
+        endpoint = endpoint.as_deref().unwrap_or("<unknown>"),
+        base_secs = base.as_secs(),
+        backoff_cap_secs = cap.as_secs(),
+        max_wait_secs = cfg.max_wait_secs,
+        "waiting for own DID to resolve over the network before mediator connect \
+         (exponential backoff + full jitter)"
+    );
+
+    let did = vta_did.to_string();
+    let resolver_url = resolver_url.map(str::to_string);
+    let outcome = run_readiness_loop(base, cap, max_wait, shutdown, move || {
+        let did = did.clone();
+        let resolver_url = resolver_url.clone();
+        async move { self_did_resolves(&did, resolver_url.as_deref()).await }
+    })
+    .await;
+
+    match outcome {
+        LoopOutcome::Ready => {
+            info!(
+                vta_did,
+                "own DID resolves over the network; proceeding to mediator connect"
+            );
+            Ok(GateDecision::Proceed)
+        }
+        LoopOutcome::Cancelled => {
+            info!("shutdown during self-readiness wait; not starting DIDComm");
+            Ok(GateDecision::Skip)
+        }
+        LoopOutcome::TimedOut => apply_timeout_policy(
+            cfg.on_timeout,
+            vta_did,
+            endpoint.as_deref(),
+            cfg.max_wait_secs,
+        ),
+    }
+}
+
+/// Map a timed-out gate to the caller decision per the configured policy.
+/// Extracted so the policy mapping is unit-testable without any network I/O.
+fn apply_timeout_policy(
+    policy: ReadinessTimeoutPolicy,
+    vta_did: &str,
+    endpoint: Option<&str>,
+    waited_secs: u64,
+) -> Result<GateDecision, ReadinessTimeout> {
+    match policy {
+        ReadinessTimeoutPolicy::Proceed => {
+            warn!(
+                vta_did,
+                waited_secs,
+                "self-readiness gate timed out; connecting to mediator anyway (best-effort)"
+            );
+            Ok(GateDecision::Proceed)
+        }
+        ReadinessTimeoutPolicy::Skip => {
+            warn!(
+                vta_did,
+                waited_secs,
+                "self-readiness gate timed out; skipping DIDComm startup this boot \
+                 (/health stays live; a later restart reconnects)"
+            );
+            Ok(GateDecision::Skip)
+        }
+        ReadinessTimeoutPolicy::Fail => Err(ReadinessTimeout {
+            vta_did: vta_did.to_string(),
+            endpoint: endpoint.map(str::to_string),
+            waited_secs,
+        }),
+    }
+}
+
+/// `true` iff `vta_did` fully resolves over the network right now.
+///
+/// Builds a **throwaway** [`DIDCacheClient`] per call — network mode against
+/// the configured `resolver_url` when set, local mode otherwise — so it
+/// resolves the VTA the same way the mediator does, while a preloaded self-DID
+/// entry (see `server::preload_self_did_document`) or a stale entry in the
 /// long-lived resolver can't mask the real state.
-async fn resolve_self_did(vta_did: &str, resolver_url: Option<&str>) -> bool {
+async fn self_did_resolves(vta_did: &str, resolver_url: Option<&str>) -> bool {
     let mut builder = DIDCacheConfigBuilder::default();
     if let Some(url) = resolver_url {
         builder = builder.with_network_mode(url);
@@ -251,10 +247,22 @@ async fn resolve_self_did(vta_did: &str, resolver_url: Option<&str>) -> bool {
             return false;
         }
     };
-    match resolver.resolve(vta_did).await {
+
+    let resolved = resolver.resolve(vta_did).await;
+
+    // MUST stop before dropping. In network mode `DIDCacheClient::new` spawns a
+    // supervised task holding a websocket to the resolver sidecar that
+    // reconnects on its own timer, and the SDK has no `Drop` impl — dropping the
+    // client abandons the task rather than ending it. Since this probe runs
+    // before *every* connect attempt and the reconnect horizon is unbounded by
+    // default, skipping this leaks one task + one reconnecting socket per
+    // attempt for the life of the process.
+    resolver.stop();
+
+    match resolved {
         Ok(_) => true,
         Err(e) => {
-            debug!(error = %e, "self-readiness: full self-DID resolution not yet succeeding");
+            debug!(error = %e, "self-readiness: self-DID resolution not yet succeeding");
             false
         }
     }
@@ -262,32 +270,42 @@ async fn resolve_self_did(vta_did: &str, resolver_url: Option<&str>) -> bool {
 
 /// Single-shot: can the VTA resolve its own DID over the network right now?
 ///
-/// The persistent-reconnect supervisor calls this before every
-/// mediator connect attempt, so a cold VTA never storms the mediator with
-/// unresolvable-sender auth attempts while it can't even resolve itself.
-/// Endpoint-less methods (`did:key`) have nothing external to resolve and are
-/// always considered ready.
+/// The persistent-reconnect supervisor calls this before every mediator connect
+/// attempt, so a cold VTA never storms the mediator with unresolvable-sender
+/// auth attempts while it can't even resolve itself. Methods that resolve
+/// without a network fetch (`did:key`) are always considered ready.
 pub async fn self_did_network_resolvable(vta_did: &str, resolver_url: Option<&str>) -> bool {
-    let Some(url) = self_did_jsonl_url(vta_did) else {
+    if !needs_network_probe(vta_did) {
         return true;
-    };
-    let client = build_probe_client(Duration::from_secs(5));
-    probe_self_ready(&client, url, vta_did, resolver_url).await
+    }
+    self_did_resolves(vta_did, resolver_url).await
 }
 
-/// Poll `probe` until it returns `true` or `max_wait` elapses. Between attempts
-/// it waits a capped-exponential-backoff-with-full-jitter interval: attempt `n`
-/// (0-based) sleeps a uniform random duration in
+/// Why [`run_readiness_loop`] stopped.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LoopOutcome {
+    /// The probe returned `true`.
+    Ready,
+    /// `max_wait` elapsed with the probe still returning `false`.
+    TimedOut,
+    /// Shutdown was signalled while waiting.
+    Cancelled,
+}
+
+/// Poll `probe` until it returns `true`, `max_wait` elapses, or `shutdown` is
+/// cancelled. Between attempts it waits a capped-exponential-backoff-with-full-
+/// jitter interval: attempt `n` (0-based) sleeps a uniform random duration in
 /// `[0, min(cap, base * 2^n)]`, always clamped so it never overshoots the
-/// deadline. Returns `true` if it became ready, `false` on timeout. At least
-/// one probe attempt always runs (even with `max_wait == 0`). Pure of any
-/// concrete I/O so it can be driven by an injected probe in tests.
+/// deadline. At least one probe attempt always runs (even with
+/// `max_wait == 0`). Pure of any concrete I/O so it can be driven by an
+/// injected probe in tests.
 async fn run_readiness_loop<F, Fut>(
     base: Duration,
     cap: Duration,
     max_wait: Duration,
+    shutdown: &CancellationToken,
     mut probe: F,
-) -> bool
+) -> LoopOutcome
 where
     F: FnMut() -> Fut,
     Fut: std::future::Future<Output = bool>,
@@ -296,11 +314,14 @@ where
     let mut attempt: u32 = 0;
     loop {
         if probe().await {
-            return true;
+            return LoopOutcome::Ready;
+        }
+        if shutdown.is_cancelled() {
+            return LoopOutcome::Cancelled;
         }
         let now = tokio::time::Instant::now();
         if now >= deadline {
-            return false;
+            return LoopOutcome::TimedOut;
         }
         let ceiling = backoff_ceiling(base, cap, attempt);
         // Full jitter, then clamp to the remaining time so we don't overshoot.
@@ -309,16 +330,94 @@ where
             attempt = attempt + 1,
             ceiling_secs = ceiling.as_secs_f64(),
             sleep_secs = sleep_for.as_secs_f64(),
-            "self-readiness endpoint not ready; backing off before retry"
+            "self-readiness probe not ready; backing off before retry"
         );
-        tokio::time::sleep(sleep_for).await;
+        // Cancellable: a SIGTERM during the wait must not hold the process open
+        // for the remainder of the (up to `max_wait_secs`) horizon.
+        tokio::select! {
+            _ = shutdown.cancelled() => return LoopOutcome::Cancelled,
+            _ = tokio::time::sleep(sleep_for) => {}
+        }
         attempt = attempt.saturating_add(1);
+    }
+}
+
+/// A mediator session must last at least this long before it counts as
+/// "healthy" and resets the reconnect backoff.
+///
+/// Without this floor, a connect that succeeds and then immediately drops resets
+/// the backoff to its base every time, turning a flapping mediator into a
+/// reconnect storm at full rate — which is how the SDK's own
+/// reset-backoff-on-connect produced the dual-websocket churn storm this
+/// workspace already had to chase down. A session shorter than the floor is
+/// treated as a failed attempt and keeps escalating the backoff.
+pub(crate) const MIN_HEALTHY_SESSION: Duration = Duration::from_secs(60);
+
+/// Retry policy for the mediator connect/reconnect loop.
+///
+/// Extracted from `server::MessagingConnect` so the decisions — keep trying or
+/// give up, and how long to wait — are unit-testable without a mediator, an
+/// `AppState`, or any I/O. The supervisor owns the effects; this owns the
+/// arithmetic.
+#[derive(Debug, Clone)]
+pub(crate) struct ReconnectPolicy {
+    base: Duration,
+    cap: Duration,
+    /// `None` = never give up.
+    horizon: Option<Duration>,
+    reconnect: bool,
+}
+
+impl ReconnectPolicy {
+    pub(crate) fn from_config(cfg: &MediatorReadinessConfig) -> Self {
+        let base_secs = cfg.retry_secs.max(1);
+        Self {
+            base: Duration::from_secs(base_secs),
+            // Cap can never be below the base, else backoff couldn't grow.
+            cap: Duration::from_secs(cfg.reconnect_backoff_cap_secs.max(base_secs)),
+            // 0 = never give up (retry forever at the capped, jittered interval).
+            horizon: (cfg.reconnect_max_elapsed_secs > 0)
+                .then(|| Duration::from_secs(cfg.reconnect_max_elapsed_secs)),
+            reconnect: cfg.reconnect,
+        }
+    }
+
+    /// How long to wait before retry number `attempt` (0-based), or `None` to
+    /// stop retrying — because reconnect is disabled, or `failing_for` has
+    /// exhausted the configured horizon.
+    ///
+    /// `failing_for` is the length of the *current run of failures*, not the
+    /// process lifetime: the supervisor resets it after any healthy session.
+    pub(crate) fn next_backoff(&self, attempt: u32, failing_for: Duration) -> Option<Duration> {
+        if !self.reconnect {
+            return None;
+        }
+        if let Some(horizon) = self.horizon
+            && failing_for >= horizon
+        {
+            return None;
+        }
+        Some(jittered_backoff(backoff_ceiling(
+            self.base, self.cap, attempt,
+        )))
+    }
+
+    /// The un-jittered upper bound this policy would use for `attempt`. Exposed
+    /// for logging so an operator sees the schedule, not just the sampled wait.
+    pub(crate) fn ceiling_for(&self, attempt: u32) -> Duration {
+        backoff_ceiling(self.base, self.cap, attempt)
+    }
+
+    /// Whether a session that lasted `session` counts as healthy — long enough
+    /// to reset both the backoff escalation and the horizon window.
+    pub(crate) fn session_was_healthy(&self, session: Duration) -> bool {
+        session >= MIN_HEALTHY_SESSION
     }
 }
 
 /// Upper bound on the backoff interval for a 0-based `attempt`:
 /// `min(cap, base * 2^attempt)`. Saturating — never panics on overflow.
-pub(crate) fn backoff_ceiling(base: Duration, cap: Duration, attempt: u32) -> Duration {
+fn backoff_ceiling(base: Duration, cap: Duration, attempt: u32) -> Duration {
     let factor = 1u64.checked_shl(attempt).unwrap_or(u64::MAX); // 2^attempt, saturating
     let ceil_ms = base
         .as_millis()
@@ -328,7 +427,7 @@ pub(crate) fn backoff_ceiling(base: Duration, cap: Duration, attempt: u32) -> Du
 }
 
 /// Full jitter (AWS blog): a uniform random duration in `[0, ceiling]`.
-pub(crate) fn jittered_backoff(ceiling: Duration) -> Duration {
+fn jittered_backoff(ceiling: Duration) -> Duration {
     let max_ms = ceiling.as_millis().min(u128::from(u64::MAX)) as u64;
     if max_ms == 0 {
         return Duration::ZERO;
@@ -342,66 +441,94 @@ mod tests {
     use std::cell::Cell;
 
     #[test]
-    fn did_key_has_no_public_endpoint() {
-        assert!(self_did_jsonl_url("did:key:z6MkExampleKeyValue").is_none());
+    fn did_key_needs_no_network_probe() {
+        assert!(!needs_network_probe("did:key:z6MkExampleKeyValue"));
+    }
+
+    #[test]
+    fn webvh_and_web_need_a_network_probe() {
+        assert!(needs_network_probe("did:webvh:QmScid:example.com:agent"));
+        assert!(needs_network_probe("did:web:example.com:agent"));
+    }
+
+    #[test]
+    fn unknown_method_is_not_gated() {
+        // An unrecognised method must not have DIDComm withheld from it on the
+        // strength of a probe we can't reason about.
+        assert!(!needs_network_probe("did:peer:2zSomething"));
+        assert!(!needs_network_probe("did:example:whatever"));
     }
 
     #[cfg(feature = "webvh")]
     #[test]
-    fn did_webvh_derives_public_jsonl_url() {
+    fn webvh_endpoint_hint_is_derived_for_diagnostics() {
         let did = "did:webvh:QmExampleScid:example.com:budget-engine";
-        let url = self_did_jsonl_url(did).expect("did:webvh yields a public URL");
-        assert_eq!(url.as_str(), "https://example.com/budget-engine/did.jsonl");
+        assert_eq!(
+            self_did_endpoint_hint(did).as_deref(),
+            Some("https://example.com/budget-engine/did.jsonl")
+        );
     }
 
     #[test]
-    fn unknown_method_is_not_probed() {
-        assert!(self_did_jsonl_url("did:peer:2zSomething").is_none());
+    fn no_endpoint_hint_for_did_key() {
+        assert!(self_did_endpoint_hint("did:key:z6MkExampleKeyValue").is_none());
     }
 
     #[test]
     fn timeout_policy_maps_to_decision() {
+        let did = "did:webvh:QmScid:example.com:agent";
         assert_eq!(
-            apply_timeout_policy(ReadinessTimeoutPolicy::Skip, "https://x/did.jsonl", 30).unwrap(),
+            apply_timeout_policy(ReadinessTimeoutPolicy::Skip, did, None, 30).unwrap(),
             GateDecision::Skip
         );
         assert_eq!(
-            apply_timeout_policy(ReadinessTimeoutPolicy::Proceed, "https://x/did.jsonl", 30)
-                .unwrap(),
+            apply_timeout_policy(ReadinessTimeoutPolicy::Proceed, did, None, 30).unwrap(),
             GateDecision::Proceed
         );
-        assert!(
-            apply_timeout_policy(ReadinessTimeoutPolicy::Fail, "https://x/did.jsonl", 30).is_err()
-        );
+        assert!(apply_timeout_policy(ReadinessTimeoutPolicy::Fail, did, None, 30).is_err());
+    }
+
+    #[test]
+    fn timeout_error_names_the_endpoint_when_known() {
+        let err = apply_timeout_policy(
+            ReadinessTimeoutPolicy::Fail,
+            "did:webvh:QmScid:example.com:agent",
+            Some("https://example.com/agent/did.jsonl"),
+            300,
+        )
+        .expect_err("fail policy errors");
+        let msg = err.to_string();
+        assert!(msg.contains("did:webvh:QmScid:example.com:agent"), "{msg}");
+        assert!(msg.contains("https://example.com/agent/did.jsonl"), "{msg}");
+        assert!(msg.contains("300s"), "{msg}");
     }
 
     #[tokio::test]
     async fn loop_times_out_when_never_ready() {
         let calls = Cell::new(0u64);
-        let ready = run_readiness_loop(
+        let outcome = run_readiness_loop(
             Duration::from_millis(2),
             Duration::from_millis(8),
             Duration::from_millis(20),
+            &CancellationToken::new(),
             || {
                 calls.set(calls.get() + 1);
                 async { false }
             },
         )
         .await;
-        assert!(
-            !ready,
-            "should time out when the endpoint never becomes ready"
-        );
+        assert_eq!(outcome, LoopOutcome::TimedOut);
         assert!(calls.get() >= 1, "at least one probe attempt must run");
     }
 
     #[tokio::test]
     async fn loop_succeeds_after_a_few_attempts() {
         let calls = Cell::new(0u64);
-        let ready = run_readiness_loop(
+        let outcome = run_readiness_loop(
             Duration::from_millis(1),
             Duration::from_millis(4),
             Duration::from_secs(5),
+            &CancellationToken::new(),
             || {
                 let n = calls.get() + 1;
                 calls.set(n);
@@ -409,8 +536,36 @@ mod tests {
             },
         )
         .await;
-        assert!(ready);
+        assert_eq!(outcome, LoopOutcome::Ready);
         assert_eq!(calls.get(), 3, "should stop probing once ready");
+    }
+
+    #[tokio::test]
+    async fn loop_abandons_the_wait_on_shutdown() {
+        // A cancelled token must cut the wait short rather than burn the whole
+        // (here: 60s) horizon — otherwise a SIGTERM mid-gate holds the process
+        // open with no listener.
+        let shutdown = CancellationToken::new();
+        shutdown.cancel();
+        let calls = Cell::new(0u64);
+        let started = tokio::time::Instant::now();
+        let outcome = run_readiness_loop(
+            Duration::from_secs(5),
+            Duration::from_secs(30),
+            Duration::from_secs(60),
+            &shutdown,
+            || {
+                calls.set(calls.get() + 1);
+                async { false }
+            },
+        )
+        .await;
+        assert_eq!(outcome, LoopOutcome::Cancelled);
+        assert_eq!(calls.get(), 1, "one probe runs, then cancellation wins");
+        assert!(
+            started.elapsed() < Duration::from_secs(1),
+            "cancellation must not wait out the horizon"
+        );
     }
 
     #[test]
@@ -438,6 +593,91 @@ mod tests {
         assert_eq!(jittered_backoff(Duration::ZERO), Duration::ZERO);
     }
 
+    // ── ReconnectPolicy: the supervisor's give-up / keep-trying decisions ────
+
+    #[test]
+    fn policy_retries_forever_by_default() {
+        let policy = ReconnectPolicy::from_config(&MediatorReadinessConfig::default());
+        // Default `reconnect_max_elapsed_secs = 0` means no horizon at all, so
+        // even an absurd failure run still yields a wait rather than giving up.
+        assert!(policy.next_backoff(0, Duration::from_secs(0)).is_some());
+        assert!(
+            policy
+                .next_backoff(99, Duration::from_secs(86_400 * 365))
+                .is_some(),
+            "0 horizon must mean never give up"
+        );
+    }
+
+    #[test]
+    fn policy_with_reconnect_disabled_never_retries() {
+        let policy = ReconnectPolicy::from_config(&MediatorReadinessConfig {
+            reconnect: false,
+            ..Default::default()
+        });
+        assert!(
+            policy.next_backoff(0, Duration::ZERO).is_none(),
+            "reconnect = false must preserve legacy single-shot behaviour"
+        );
+    }
+
+    #[test]
+    fn policy_gives_up_once_the_horizon_is_exhausted() {
+        let policy = ReconnectPolicy::from_config(&MediatorReadinessConfig {
+            reconnect_max_elapsed_secs: 120,
+            ..Default::default()
+        });
+        assert!(policy.next_backoff(3, Duration::from_secs(119)).is_some());
+        assert!(
+            policy.next_backoff(3, Duration::from_secs(120)).is_none(),
+            "at the horizon exactly, stop"
+        );
+        assert!(policy.next_backoff(3, Duration::from_secs(600)).is_none());
+    }
+
+    #[test]
+    fn policy_backoff_is_bounded_by_the_reconnect_cap() {
+        let policy = ReconnectPolicy::from_config(&MediatorReadinessConfig {
+            retry_secs: 5,
+            reconnect_backoff_cap_secs: 60,
+            ..Default::default()
+        });
+        assert_eq!(policy.ceiling_for(0), Duration::from_secs(5));
+        assert_eq!(policy.ceiling_for(4), Duration::from_secs(60)); // 80 -> cap
+        for attempt in 0..40 {
+            let waited = policy
+                .next_backoff(attempt, Duration::ZERO)
+                .expect("no horizon set");
+            assert!(
+                waited <= Duration::from_secs(60),
+                "attempt {attempt} slept {waited:?}, past the cap"
+            );
+        }
+    }
+
+    #[test]
+    fn policy_cap_below_base_still_grows() {
+        // A misconfigured cap under the base would otherwise pin the backoff at
+        // the (smaller) cap and defeat the escalation entirely.
+        let policy = ReconnectPolicy::from_config(&MediatorReadinessConfig {
+            retry_secs: 30,
+            reconnect_backoff_cap_secs: 5,
+            ..Default::default()
+        });
+        assert_eq!(policy.ceiling_for(0), Duration::from_secs(30));
+    }
+
+    #[test]
+    fn only_a_long_enough_session_counts_as_healthy() {
+        let policy = ReconnectPolicy::from_config(&MediatorReadinessConfig::default());
+        // A connect that succeeds and instantly drops must NOT reset the
+        // backoff — that is what turns a flapping mediator into a storm.
+        assert!(!policy.session_was_healthy(Duration::from_secs(1)));
+        assert!(!policy.session_was_healthy(MIN_HEALTHY_SESSION - Duration::from_secs(1)));
+        assert!(policy.session_was_healthy(MIN_HEALTHY_SESSION));
+        assert!(policy.session_was_healthy(Duration::from_secs(3600)));
+    }
+
     #[tokio::test]
     async fn disabled_gate_proceeds_without_probing() {
         let cfg = MediatorReadinessConfig {
@@ -445,9 +685,14 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(
-            run_gate("did:webvh:QmScid:example.com:agent", &cfg, None)
-                .await
-                .unwrap(),
+            run_gate(
+                "did:webvh:QmScid:example.com:agent",
+                &cfg,
+                None,
+                &CancellationToken::new()
+            )
+            .await
+            .unwrap(),
             GateDecision::Proceed
         );
     }
@@ -456,9 +701,14 @@ mod tests {
     async fn did_key_skips_gate_and_proceeds() {
         let cfg = MediatorReadinessConfig::default();
         assert_eq!(
-            run_gate("did:key:z6MkExampleKeyValue", &cfg, None)
-                .await
-                .unwrap(),
+            run_gate(
+                "did:key:z6MkExampleKeyValue",
+                &cfg,
+                None,
+                &CancellationToken::new()
+            )
+            .await
+            .unwrap(),
             GateDecision::Proceed
         );
     }

--- a/vta-service/src/messaging/readiness.rs
+++ b/vta-service/src/messaging/readiness.rs
@@ -1,0 +1,465 @@
+//! Startup self-readiness gate for the mediator DIDComm connection.
+//!
+//! During cold start a VTA can fire its outbound mediator handshake before its
+//! own public DID document is externally reachable — the LB target isn't
+//! healthy yet, so a fetch of the VTA's `did.jsonl` returns 503. The mediator
+//! then can't get the VTA's key to decrypt the authcrypt auth message and
+//! returns 403; the VTA burns its short retry burst and (today) gives up. The
+//! visible blast radius is an LB 5XX burst and mediator auth/resolve failures.
+//!
+//! This gate makes the VTA wait until its own public DID is fully resolvable
+//! over the network — an HTTP 200 on its `did.jsonl` *and* a complete
+//! `did:webvh` resolution (the same path the mediator takes) — before
+//! initiating the mediator connection. Only network-resolved DID methods
+//! (`did:webvh`) are gated; a `did:key` VTA publishes no external endpoint, so
+//! it skips the wait (AC #2).
+//!
+//! The gate is bounded: it retries with capped exponential backoff and full
+//! jitter (the AWS "Exponential Backoff And Jitter" scheme) up to a maximum
+//! wait, then applies a configured timeout policy (skip / proceed / fail). The
+//! jitter keeps the VTA from hammering its own still-unhealthy LB target in
+//! lock-step while it waits. See [`vta_config::MediatorReadinessConfig`].
+
+use std::time::Duration;
+
+use affinidi_did_resolver_cache_sdk::DIDCacheClient;
+use affinidi_did_resolver_cache_sdk::config::DIDCacheConfigBuilder;
+use rand::RngExt;
+use tracing::{debug, info, warn};
+use vta_config::{MediatorReadinessConfig, ReadinessTimeoutPolicy};
+
+/// What the caller should do after the gate runs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GateDecision {
+    /// Go ahead and establish the mediator DIDComm connection.
+    Proceed,
+    /// Do not start DIDComm this boot. `/health` stays live so the LB can turn
+    /// the target healthy; a later restart reconnects.
+    Skip,
+}
+
+/// Returned only when the gate times out **and** the configured policy is
+/// [`ReadinessTimeoutPolicy::Fail`].
+#[derive(Debug, Clone)]
+pub struct ReadinessTimeout {
+    pub url: String,
+    pub waited_secs: u64,
+}
+
+impl std::fmt::Display for ReadinessTimeout {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "own public DID endpoint {} not reachable after {}s",
+            self.url, self.waited_secs
+        )
+    }
+}
+
+impl std::error::Error for ReadinessTimeout {}
+
+/// Run the self-readiness gate for `vta_did` and return the caller's decision.
+///
+/// Returns `Ok(Proceed)` when the endpoint became reachable, when the method
+/// needs no external endpoint (e.g. `did:key`), or when the gate is disabled.
+/// Returns `Ok(Skip)` on timeout under the `skip` policy. Returns
+/// `Err(ReadinessTimeout)` only on timeout under the `fail` policy.
+pub async fn run_gate(
+    vta_did: &str,
+    cfg: &MediatorReadinessConfig,
+    resolver_url: Option<&str>,
+) -> Result<GateDecision, ReadinessTimeout> {
+    if !cfg.enabled {
+        info!("mediator self-readiness gate disabled; connecting without waiting");
+        return Ok(GateDecision::Proceed);
+    }
+
+    let Some(url) = self_did_jsonl_url(vta_did) else {
+        // did:key (or a method we can't derive a URL for): nothing external to
+        // wait for — the mediator resolves it without a network fetch.
+        info!(
+            vta_did,
+            "self-readiness gate skipped: DID method needs no reachable public endpoint"
+        );
+        return Ok(GateDecision::Proceed);
+    };
+
+    let base = Duration::from_secs(cfg.retry_secs.max(1));
+    // Cap can never be below the base, else backoff couldn't grow.
+    let cap = Duration::from_secs(cfg.backoff_cap_secs.max(cfg.retry_secs.max(1)));
+    let max_wait = Duration::from_secs(cfg.max_wait_secs);
+    let url_str = url.to_string();
+    info!(
+        url = %url_str,
+        base_secs = base.as_secs(),
+        backoff_cap_secs = cap.as_secs(),
+        max_wait_secs = cfg.max_wait_secs,
+        "waiting for own public DID endpoint to become reachable before mediator connect \
+         (exponential backoff + full jitter)"
+    );
+
+    let client = build_probe_client(base);
+    let vta_did_owned = vta_did.to_string();
+    let resolver_url_owned = resolver_url.map(str::to_string);
+    let became_ready = run_readiness_loop(base, cap, max_wait, move || {
+        let client = client.clone();
+        let url = url.clone();
+        let did = vta_did_owned.clone();
+        let resolver_url = resolver_url_owned.clone();
+        async move { probe_self_ready(&client, url, &did, resolver_url.as_deref()).await }
+    })
+    .await;
+
+    if became_ready {
+        info!(url = %url_str, "own public DID endpoint reachable (200); proceeding to mediator connect");
+        return Ok(GateDecision::Proceed);
+    }
+
+    apply_timeout_policy(cfg.on_timeout, &url_str, cfg.max_wait_secs)
+}
+
+/// Map a timed-out gate to the caller decision per the configured policy.
+/// Extracted so the policy mapping is unit-testable without any network I/O.
+fn apply_timeout_policy(
+    policy: ReadinessTimeoutPolicy,
+    url: &str,
+    waited_secs: u64,
+) -> Result<GateDecision, ReadinessTimeout> {
+    match policy {
+        ReadinessTimeoutPolicy::Proceed => {
+            warn!(
+                url,
+                waited_secs,
+                "self-readiness gate timed out; connecting to mediator anyway (best-effort)"
+            );
+            Ok(GateDecision::Proceed)
+        }
+        ReadinessTimeoutPolicy::Skip => {
+            warn!(
+                url,
+                waited_secs,
+                "self-readiness gate timed out; skipping DIDComm startup this boot \
+                 (/health stays live; a later restart reconnects)"
+            );
+            Ok(GateDecision::Skip)
+        }
+        ReadinessTimeoutPolicy::Fail => Err(ReadinessTimeout {
+            url: url.to_string(),
+            waited_secs,
+        }),
+    }
+}
+
+/// The public `did.jsonl` URL for `vta_did`, or `None` when the method needs no
+/// reachable public endpoint (`did:key`) or a URL can't be derived (unknown
+/// method, or built without the `webvh` feature).
+pub fn self_did_jsonl_url(vta_did: &str) -> Option<reqwest::Url> {
+    if vta_did.starts_with("did:key:") {
+        return None;
+    }
+
+    #[cfg(feature = "webvh")]
+    if vta_did.starts_with("did:webvh:") {
+        return match didwebvh_rs::url::WebVHURL::parse_did_url(vta_did) {
+            Ok(webvh) => match webvh.get_http_url(None) {
+                Ok(url) => reqwest::Url::parse(url.as_str()).ok(),
+                Err(e) => {
+                    warn!(vta_did, error = %e, "self-readiness: cannot derive did.jsonl URL from DID");
+                    None
+                }
+            },
+            Err(e) => {
+                warn!(vta_did, error = %e, "self-readiness: cannot parse did:webvh DID");
+                None
+            }
+        };
+    }
+
+    let _ = vta_did;
+    None
+}
+
+/// Build the probe HTTP client with a bounded per-attempt timeout so a hung
+/// connect can't stall the retry cadence.
+fn build_probe_client(retry: Duration) -> reqwest::Client {
+    let per_attempt = retry
+        .min(Duration::from_secs(10))
+        .max(Duration::from_secs(1));
+    reqwest::Client::builder()
+        .timeout(per_attempt)
+        .user_agent("vta-self-readiness-gate")
+        .build()
+        .expect("static reqwest client config (timeout + user agent) is always valid")
+}
+
+/// One readiness probe used by the gate loop: `true` iff the VTA's own public
+/// DID is fully resolvable over the network — the same path the mediator takes
+/// to fetch the authcrypt sender key. This is the "don't touch the
+/// mediator until the VTA has resolved *itself*" gate upgrade: a bare HTTP 200
+/// on `did.jsonl` isn't enough (a 200 with malformed/partial content still
+/// fails mediator resolution), so after the cheap HTTP check we run a full
+/// `did:webvh` resolution through a throwaway resolver.
+async fn probe_self_ready(
+    client: &reqwest::Client,
+    url: reqwest::Url,
+    vta_did: &str,
+    resolver_url: Option<&str>,
+) -> bool {
+    // Fast path: the mediator fetches `did.jsonl` over HTTP first. While that
+    // isn't 200 yet there's no point paying for a full resolution.
+    if !probe_endpoint_200(client, url).await {
+        return false;
+    }
+    resolve_self_did(vta_did, resolver_url).await
+}
+
+/// `true` iff the endpoint answers HTTP 200.
+async fn probe_endpoint_200(client: &reqwest::Client, url: reqwest::Url) -> bool {
+    match client.get(url).send().await {
+        Ok(resp) => {
+            let status = resp.status();
+            if status == reqwest::StatusCode::OK {
+                true
+            } else {
+                debug!(%status, "self-readiness probe: endpoint not ready (non-200)");
+                false
+            }
+        }
+        Err(e) => {
+            debug!(error = %e, "self-readiness probe: request failed");
+            false
+        }
+    }
+}
+
+/// `true` iff the VTA's own DID fully resolves over the network right now.
+///
+/// Builds a **throwaway** [`DIDCacheClient`] per call — network mode against the
+/// configured `resolver_url` when set, local mode otherwise — so it resolves
+/// the VTA the same way the mediator does, while a preloaded self-DID entry
+/// (see `server::preload_self_did_document`) or a stale negative entry in the
+/// long-lived resolver can't mask the real state.
+async fn resolve_self_did(vta_did: &str, resolver_url: Option<&str>) -> bool {
+    let mut builder = DIDCacheConfigBuilder::default();
+    if let Some(url) = resolver_url {
+        builder = builder.with_network_mode(url);
+    }
+    let resolver = match DIDCacheClient::new(builder.build()).await {
+        Ok(r) => r,
+        Err(e) => {
+            debug!(error = %e, "self-readiness: could not build resolver for self-resolution probe");
+            return false;
+        }
+    };
+    match resolver.resolve(vta_did).await {
+        Ok(_) => true,
+        Err(e) => {
+            debug!(error = %e, "self-readiness: full self-DID resolution not yet succeeding");
+            false
+        }
+    }
+}
+
+/// Single-shot: can the VTA resolve its own DID over the network right now?
+///
+/// The persistent-reconnect supervisor calls this before every
+/// mediator connect attempt, so a cold VTA never storms the mediator with
+/// unresolvable-sender auth attempts while it can't even resolve itself.
+/// Endpoint-less methods (`did:key`) have nothing external to resolve and are
+/// always considered ready.
+pub async fn self_did_network_resolvable(vta_did: &str, resolver_url: Option<&str>) -> bool {
+    let Some(url) = self_did_jsonl_url(vta_did) else {
+        return true;
+    };
+    let client = build_probe_client(Duration::from_secs(5));
+    probe_self_ready(&client, url, vta_did, resolver_url).await
+}
+
+/// Poll `probe` until it returns `true` or `max_wait` elapses. Between attempts
+/// it waits a capped-exponential-backoff-with-full-jitter interval: attempt `n`
+/// (0-based) sleeps a uniform random duration in
+/// `[0, min(cap, base * 2^n)]`, always clamped so it never overshoots the
+/// deadline. Returns `true` if it became ready, `false` on timeout. At least
+/// one probe attempt always runs (even with `max_wait == 0`). Pure of any
+/// concrete I/O so it can be driven by an injected probe in tests.
+async fn run_readiness_loop<F, Fut>(
+    base: Duration,
+    cap: Duration,
+    max_wait: Duration,
+    mut probe: F,
+) -> bool
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = bool>,
+{
+    let deadline = tokio::time::Instant::now() + max_wait;
+    let mut attempt: u32 = 0;
+    loop {
+        if probe().await {
+            return true;
+        }
+        let now = tokio::time::Instant::now();
+        if now >= deadline {
+            return false;
+        }
+        let ceiling = backoff_ceiling(base, cap, attempt);
+        // Full jitter, then clamp to the remaining time so we don't overshoot.
+        let sleep_for = jittered_backoff(ceiling).min(deadline - now);
+        debug!(
+            attempt = attempt + 1,
+            ceiling_secs = ceiling.as_secs_f64(),
+            sleep_secs = sleep_for.as_secs_f64(),
+            "self-readiness endpoint not ready; backing off before retry"
+        );
+        tokio::time::sleep(sleep_for).await;
+        attempt = attempt.saturating_add(1);
+    }
+}
+
+/// Upper bound on the backoff interval for a 0-based `attempt`:
+/// `min(cap, base * 2^attempt)`. Saturating — never panics on overflow.
+pub(crate) fn backoff_ceiling(base: Duration, cap: Duration, attempt: u32) -> Duration {
+    let factor = 1u64.checked_shl(attempt).unwrap_or(u64::MAX); // 2^attempt, saturating
+    let ceil_ms = base
+        .as_millis()
+        .saturating_mul(factor as u128)
+        .min(cap.as_millis());
+    Duration::from_millis(ceil_ms as u64)
+}
+
+/// Full jitter (AWS blog): a uniform random duration in `[0, ceiling]`.
+pub(crate) fn jittered_backoff(ceiling: Duration) -> Duration {
+    let max_ms = ceiling.as_millis().min(u128::from(u64::MAX)) as u64;
+    if max_ms == 0 {
+        return Duration::ZERO;
+    }
+    Duration::from_millis(rand::rng().random_range(0..=max_ms))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::Cell;
+
+    #[test]
+    fn did_key_has_no_public_endpoint() {
+        assert!(self_did_jsonl_url("did:key:z6MkExampleKeyValue").is_none());
+    }
+
+    #[cfg(feature = "webvh")]
+    #[test]
+    fn did_webvh_derives_public_jsonl_url() {
+        let did = "did:webvh:QmExampleScid:example.com:budget-engine";
+        let url = self_did_jsonl_url(did).expect("did:webvh yields a public URL");
+        assert_eq!(url.as_str(), "https://example.com/budget-engine/did.jsonl");
+    }
+
+    #[test]
+    fn unknown_method_is_not_probed() {
+        assert!(self_did_jsonl_url("did:peer:2zSomething").is_none());
+    }
+
+    #[test]
+    fn timeout_policy_maps_to_decision() {
+        assert_eq!(
+            apply_timeout_policy(ReadinessTimeoutPolicy::Skip, "https://x/did.jsonl", 30).unwrap(),
+            GateDecision::Skip
+        );
+        assert_eq!(
+            apply_timeout_policy(ReadinessTimeoutPolicy::Proceed, "https://x/did.jsonl", 30)
+                .unwrap(),
+            GateDecision::Proceed
+        );
+        assert!(
+            apply_timeout_policy(ReadinessTimeoutPolicy::Fail, "https://x/did.jsonl", 30).is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn loop_times_out_when_never_ready() {
+        let calls = Cell::new(0u64);
+        let ready = run_readiness_loop(
+            Duration::from_millis(2),
+            Duration::from_millis(8),
+            Duration::from_millis(20),
+            || {
+                calls.set(calls.get() + 1);
+                async { false }
+            },
+        )
+        .await;
+        assert!(
+            !ready,
+            "should time out when the endpoint never becomes ready"
+        );
+        assert!(calls.get() >= 1, "at least one probe attempt must run");
+    }
+
+    #[tokio::test]
+    async fn loop_succeeds_after_a_few_attempts() {
+        let calls = Cell::new(0u64);
+        let ready = run_readiness_loop(
+            Duration::from_millis(1),
+            Duration::from_millis(4),
+            Duration::from_secs(5),
+            || {
+                let n = calls.get() + 1;
+                calls.set(n);
+                async move { n >= 3 }
+            },
+        )
+        .await;
+        assert!(ready);
+        assert_eq!(calls.get(), 3, "should stop probing once ready");
+    }
+
+    #[test]
+    fn backoff_ceiling_doubles_then_caps() {
+        let base = Duration::from_secs(5);
+        let cap = Duration::from_secs(30);
+        assert_eq!(backoff_ceiling(base, cap, 0), Duration::from_secs(5)); // 5 * 1
+        assert_eq!(backoff_ceiling(base, cap, 1), Duration::from_secs(10)); // 5 * 2
+        assert_eq!(backoff_ceiling(base, cap, 2), Duration::from_secs(20)); // 5 * 4
+        assert_eq!(backoff_ceiling(base, cap, 3), Duration::from_secs(30)); // 40 -> cap 30
+        assert_eq!(backoff_ceiling(base, cap, 10), Duration::from_secs(30)); // capped
+        // Must not panic on a huge attempt count (saturating shift).
+        assert_eq!(
+            backoff_ceiling(base, cap, u32::MAX),
+            Duration::from_secs(30)
+        );
+    }
+
+    #[test]
+    fn jitter_stays_within_ceiling() {
+        let ceiling = Duration::from_secs(30);
+        for _ in 0..1000 {
+            assert!(jittered_backoff(ceiling) <= ceiling);
+        }
+        assert_eq!(jittered_backoff(Duration::ZERO), Duration::ZERO);
+    }
+
+    #[tokio::test]
+    async fn disabled_gate_proceeds_without_probing() {
+        let cfg = MediatorReadinessConfig {
+            enabled: false,
+            ..Default::default()
+        };
+        assert_eq!(
+            run_gate("did:webvh:QmScid:example.com:agent", &cfg, None)
+                .await
+                .unwrap(),
+            GateDecision::Proceed
+        );
+    }
+
+    #[tokio::test]
+    async fn did_key_skips_gate_and_proceeds() {
+        let cfg = MediatorReadinessConfig::default();
+        assert_eq!(
+            run_gate("did:key:z6MkExampleKeyValue", &cfg, None)
+                .await
+                .unwrap(),
+            GateDecision::Proceed
+        );
+    }
+}

--- a/vta-service/src/messaging/service.rs
+++ b/vta-service/src/messaging/service.rs
@@ -90,14 +90,16 @@ pub async fn build_messaging(
         tdk.secrets_resolver().insert(secret).await;
     }
 
-    let atm = ATM::new(
-        ATMConfig::builder()
-            .build()
-            .map_err(|e| format!("build ATM config: {e}"))?,
-        Arc::new(tdk),
-    )
-    .await
-    .map_err(|e| format!("create ATM: {e}"))?;
+    let atm = Arc::new(
+        ATM::new(
+            ATMConfig::builder()
+                .build()
+                .map_err(|e| format!("build ATM config: {e}"))?,
+            Arc::new(tdk),
+        )
+        .await
+        .map_err(|e| format!("create ATM: {e}"))?,
+    );
 
     let profile = ATMProfile::new(
         &atm,
@@ -121,28 +123,25 @@ pub async fn build_messaging(
         .await
         .map_err(|e| format!("register ATM profile: {e}"))?;
 
-    // Bounded — a `did:webvh` mediator websocket connect can hang.
-    match tokio::time::timeout(
-        Duration::from_secs(30),
-        atm.profile_enable_websocket(&profile),
-    )
-    .await
-    {
-        Ok(res) => res.map_err(|e| format!("enable websocket: {e}"))?,
-        Err(_) => {
-            return Err(
-                "timeout enabling websocket to mediator after 30s — mediator may be unreachable"
-                    .to_string(),
-            );
+    // ── Past this point the ATM owns a registered profile and a live (or
+    // half-open) mediator websocket, so every error path MUST tear it down. ──
+    //
+    // There is no `Drop` impl on `ATM`: dropping it *abandons* the websocket
+    // task rather than ending it, and an abandoned socket keeps auto-reconnecting
+    // on its own timer while holding the mediator's one-socket-per-DID slot — so
+    // the next attempt gets evicted as `duplicate-channel` and the two reconnect
+    // loops duel. `graceful_shutdown` is what actually stops it (it iterates the
+    // profile map calling `stop_websocket`). This matters far more now that a
+    // failed connect is *retried* by `server::MessagingConnect`: without the
+    // teardown, that loop would leak one duelling socket per attempt.
+    let transport = match connect_transport(&atm, &profile).await {
+        Ok(transport) => transport,
+        Err(e) => {
+            atm.graceful_shutdown().await;
+            return Err(e);
         }
-    }
+    };
 
-    let atm = Arc::new(atm);
-    let transport: Arc<dyn MessageTransport> = Arc::new(
-        DidCommTransport::new((*atm).clone(), profile.clone())
-            .await
-            .map_err(|e| format!("bind DidComm transport: {e}"))?,
-    );
     let outbox: Arc<dyn OutboxStore> = Arc::new(VtiOutboxStore::new(outbox_ks));
     // P2a uses `new` (not `with_receipts`) — no layer-receipt *emit* yet (P2b);
     // the consume half is always active, so the VTA settles its own sends.
@@ -173,6 +172,45 @@ pub async fn build_messaging(
         atm,
         profile,
     })
+}
+
+/// Enable the mediator websocket (bounded) and bind the [`DidCommTransport`]
+/// over it.
+///
+/// Split out of [`build_messaging`] so the two fallible steps that leave a live
+/// socket behind have a *single* error chokepoint the caller can tear down from
+/// — see the comment at the call site.
+async fn connect_transport(
+    atm: &Arc<ATM>,
+    profile: &Arc<ATMProfile>,
+) -> Result<Arc<dyn MessageTransport>, String> {
+    // Bounded — a `did:webvh` mediator websocket connect can hang.
+    //
+    // NB: when this timeout fires, the `profile_enable_websocket` future is
+    // dropped mid-flight, so the SDK's own `cleanup_failed_websocket` (which its
+    // internal error path relies on) never runs. The caller's
+    // `graceful_shutdown` is what compensates — do not "simplify" this to a bare
+    // `?` that skips it.
+    match tokio::time::timeout(
+        Duration::from_secs(30),
+        atm.profile_enable_websocket(profile),
+    )
+    .await
+    {
+        Ok(res) => res.map_err(|e| format!("enable websocket: {e}"))?,
+        Err(_) => {
+            return Err(
+                "timeout enabling websocket to mediator after 30s — mediator may be unreachable"
+                    .to_string(),
+            );
+        }
+    }
+
+    Ok(Arc::new(
+        DidCommTransport::new((**atm).clone(), profile.clone())
+            .await
+            .map_err(|e| format!("bind DidComm transport: {e}"))?,
+    ))
 }
 
 /// Drive inbound dispatch off [`MessagingService::subscribe`] until shutdown.

--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -36,8 +36,6 @@ use tracing::{debug, error, info, warn};
 // `affinidi-messaging-didcomm-service` framework. `MessagingService` (built in
 // `messaging::service`) drives inbound + outbound over a `DidCommTransport`.
 #[cfg(feature = "didcomm")]
-use affinidi_messaging_delivery::MessagingService;
-#[cfg(feature = "didcomm")]
 use tokio_util::sync::CancellationToken;
 // Only the DIDComm listener wires the client ACL on connect.
 #[cfg(feature = "didcomm")]
@@ -888,174 +886,78 @@ pub async fn run(
         // per DID — a second would be evicted as `duplicate-channel`), so TSP
         // receive is always on when compiled with `tsp`; `config.services.tsp`
         // governs advertisement only.
+        //
+        // Self-readiness gate + persistent reconnect.
+        //
+        // The self-readiness gate (below) blocks *this* boot's mediator connect
+        // until the VTA's own public DID is fully resolvable over the network —
+        // so the mediator can fetch our did.jsonl and decrypt the authcrypt
+        // handshake instead of 503→403 storming on a cold start. `/health` is
+        // already live (REST thread spawned above), so the gate delays only the
+        // mediator connect, not liveness.
+        //
+        // Once the gate passes, the connect + wiring + persistent-reconnect loop
+        // runs in a spawned supervisor (`MessagingConnect`). If the *initial*
+        // connect fails — classically because the mediator's own DNS resolver
+        // still negative-caches the VTA host and can't resolve us yet
+        // (NetworkError → authcrypt 403) — the supervisor keeps retrying with
+        // capped exponential backoff + full jitter (re-confirming self-
+        // resolution each attempt) on a horizon that outlasts the negative
+        // cache, so the VTA self-heals with no operator restart. The live
+        // `MessagingService` handle is published into `app_state.didcomm_bridge`
+        // on first success; the drain-teardown consumer + status read it there.
+        // Backgrounding the retry keeps the (possibly long) reconnect horizon
+        // off the startup path so shutdown/restart stays responsive.
         #[cfg(feature = "didcomm")]
-        let messaging_service: Option<Arc<MessagingService>> = if config.services.didcomm {
+        if config.services.didcomm {
             match (
                 &app_state.secrets_resolver,
                 &config.vta_did,
                 &config.messaging,
             ) {
-                (Some(sr), Some(vta_did), Some(messaging_config)) => {
-                    // Collect secrets using the VM IDs from init_auth (correct for both
-                    // did:key and did:webvh — avoids hardcoding #key-0/#key-1 fragments).
-                    let mut secrets = Vec::new();
-                    if let Some(ref signing_id) = app_state.signing_vm_id
-                        && let Some(s) = sr.get_secret(signing_id).await
-                    {
-                        secrets.push(s);
-                    }
-                    if let Some(ref ka_id) = app_state.ka_vm_id
-                        && let Some(s) = sr.get_secret(ka_id).await
-                    {
-                        secrets.push(s);
-                    }
-
-                    // Recovery: optionally clear this DID's mediator inbox over
-                    // REST *before* enabling live delivery, so a poison /
-                    // undeliverable backlog can't stall the pickup handshake and
-                    // wedge the (shared DIDComm+TSP) socket. Best-effort, and off
-                    // unless `messaging.drain_inbox_on_start` is set.
-                    if messaging_config.drain_inbox_on_start || flush_queues {
-                        match app_state.atm.as_ref() {
-                            Some(atm) => {
-                                let cleared = drain_mediator_inbox(
-                                    atm,
-                                    &messaging_config.mediator_did,
-                                    vta_did,
-                                )
-                                .await;
-                                info!(
-                                    count = cleared,
-                                    mediator = %messaging_config.mediator_did,
-                                    "cleared queued mediator inbox before going live"
-                                );
-                            }
-                            None => {
-                                warn!("inbox drain requested but no ATM is available; skipping")
-                            }
-                        }
-                    }
-
-                    // `--flush-queues` additionally clears the OUTBOUND (sender)
-                    // queue — messages this DID sent that are still queued at the
-                    // mediator awaiting delivery. A message loop can fill that
-                    // queue (`limits.queue.sender`), after which the mediator
-                    // rejects every new send until it drains. The inbox drain
-                    // above cannot touch it; this does.
-                    if flush_queues {
-                        match app_state.atm.as_ref() {
-                            Some(atm) => {
-                                let cleared = flush_mediator_outbox(
-                                    atm,
-                                    &messaging_config.mediator_did,
-                                    vta_did,
-                                )
-                                .await;
-                                info!(
-                                    count = cleared,
-                                    mediator = %messaging_config.mediator_did,
-                                    "flush_queues: cleared outbound sender queue before going live"
-                                );
-                            }
-                            None => warn!(
-                                "--flush-queues set but no ATM is available; skipping outbox flush"
-                            ),
-                        }
-                    }
-
-                    let outbox_ks = apply_encryption(store.keyspace(crate::keyspaces::OUTBOX)?);
-                    match crate::messaging::service::build_messaging(
-                        secrets,
+                (Some(_), Some(vta_did), Some(messaging_config)) => {
+                    let gate_decision = match crate::messaging::readiness::run_gate(
                         vta_did,
-                        &messaging_config.mediator_did,
-                        outbox_ks,
-                        app_state.did_resolver.as_ref(),
+                        &config.mediator_readiness,
                         config.resolver_url.as_deref(),
                     )
                     .await
                     {
-                        Ok(messaging) => {
-                            let service = messaging.service.clone();
-                            // Publish the outbound wiring so every REST/DIDComm
-                            // component can send to a peer over this one
-                            // connection (`DIDCommBridge` → `MessagingService`).
-                            app_state.didcomm_bridge.set_messaging(
-                                service.clone(),
-                                (*messaging.atm).clone(),
-                                vta_did.clone(),
-                            );
-
-                            // Register the config-loaded mediator in the listener
-                            // registry so the delegated step-up push (which buffers
-                            // outbound through the registry) can reach approvers on
-                            // this mediator. The runtime `services didcomm enable`
-                            // path calls `record_activate`; a mediator loaded from
-                            // config at boot did not, so `buffer_outbound` failed
-                            // with `NotRegistered` and the delegated push never
-                            // reached the device.
-                            #[cfg(feature = "webvh")]
-                            app_state
-                                .mediator_registry
-                                .record_activate(crate::messaging::registry::MediatorBinding {
-                                    mediator_did: messaging_config.mediator_did.clone(),
-                                    endpoint: messaging_config.mediator_url.clone(),
-                                })
-                                .await;
-
-                            // Set the VTA's own ACL on the mediator to accept all messages.
-                            // The ACL is keyed on the VTA's DID, so it authorises the account
-                            // for both DIDComm *and* TSP, which share this one mediator socket.
-                            // Only runs when `setup_acl = true` in the messaging config
-                            // (set during VTA setup for mediators using ExplicitAllow mode).
-                            if messaging_config.setup_acl {
-                                if let Some(atm) = app_state.atm.as_ref() {
-                                    acl_setup::set_client_acl_on_connection(
-                                        atm,
-                                        vta_did,
-                                        messaging_config.mediator_did.as_str(),
-                                        "vta-main",
-                                        "vta",
-                                    )
-                                    .await;
-                                } else {
-                                    warn!(
-                                        "setup_acl = true but no ATM available; \
-                                         skipping mediator ACL provisioning"
-                                    );
-                                }
-                            }
-
-                            // Spawn the protocol-routed inbound loop. It runs until
-                            // `didcomm_shutdown` is cancelled (Ctrl-C or soft
-                            // restart), dispatching DIDComm frames to the handler
-                            // set and TSP frames to the trust-task spine.
-                            tokio::spawn(crate::messaging::service::run_inbound_loop(
-                                Arc::new(messaging),
-                                app_state.clone(),
-                                vta_did.clone(),
-                                messaging_config.mediator_did.clone(),
-                                didcomm_shutdown.clone(),
-                            ));
-
-                            info!("DIDComm messaging started");
-                            Some(service)
-                        }
+                        Ok(decision) => decision,
                         Err(e) => {
-                            warn!("failed to start DIDComm messaging: {e}");
-                            None
+                            return Err(AppError::Internal(format!(
+                                "mediator self-readiness gate failed: {e}"
+                            )));
                         }
+                    };
+                    if gate_decision == crate::messaging::readiness::GateDecision::Skip {
+                        info!(
+                            "DIDComm messaging not started this boot \
+                             (mediator self-readiness gate: skip)"
+                        );
+                    } else {
+                        // Compute the outbox keyspace here (it needs `?`), then
+                        // hand the connect + persistent-reconnect loop to a
+                        // background supervisor.
+                        let outbox_ks = apply_encryption(store.keyspace(crate::keyspaces::OUTBOX)?);
+                        let supervisor = MessagingConnect {
+                            app_state: app_state.clone(),
+                            vta_did: vta_did.clone(),
+                            messaging_config: messaging_config.clone(),
+                            readiness: config.mediator_readiness.clone(),
+                            resolver_url: config.resolver_url.clone(),
+                            outbox_ks,
+                            flush_queues,
+                            shutdown: didcomm_shutdown.clone(),
+                        };
+                        tokio::spawn(supervisor.run());
                     }
                 }
                 _ => {
                     info!("DIDComm not configured — service not started");
-                    None
                 }
             }
-        } else {
-            None
-        };
-        #[cfg(not(feature = "didcomm"))]
-        let messaging_service: Option<()> = None;
+        }
 
         // TSP inbound is no longer a standalone websocket. The delivery-layer
         // `DidCommTransport` built above multiplexes TSP frames off its single
@@ -1074,7 +976,13 @@ pub async fn run(
         // keyspace level by the sweeper.
         #[cfg(all(feature = "webvh", feature = "didcomm"))]
         let _teardown_handle = {
-            let messaging_service_ref = messaging_service.clone();
+            // Source the live `MessagingService` from the bridge at recv time
+            // rather than a captured handle: the connect now happens in the
+            // background `MessagingConnect` supervisor, so the service may not be
+            // published yet when this consumer is spawned (and it self-heals /
+            // (re)connects later). `messaging_handle()` returns the current
+            // handle once the supervisor's first successful connect sets it.
+            let teardown_app_state = app_state.clone();
             let mut teardown_rx = teardown_rx;
             let mut shutdown_rx_for_teardown = shutdown_rx.clone();
             tokio::spawn(async move {
@@ -1095,7 +1003,9 @@ pub async fn run(
                                     // via the merged dispatcher) after promote; its
                                     // fjall drain-entry TTL has now expired, so drop
                                     // it from the delivery-layer service.
-                                    if let Some(ref svc) = messaging_service_ref {
+                                    if let Some(svc) =
+                                        teardown_app_state.didcomm_bridge.messaging_handle()
+                                    {
                                         svc.remove_transport(&mediator_did);
                                         info!(
                                             mediator = %mediator_did,
@@ -1104,7 +1014,7 @@ pub async fn run(
                                     } else {
                                         debug!(
                                             mediator = %mediator_did,
-                                            "drain teardown: DIDComm not running, skipping remove_transport"
+                                            "drain teardown: DIDComm not connected, skipping remove_transport"
                                         );
                                     }
                                 }
@@ -1179,18 +1089,16 @@ pub async fn run(
             }
         }
 
-        // Stop DIDComm messaging: cancel the inbound loop's shutdown token.
-        // The delivery-layer background tasks (dispatcher, transport forwarder,
-        // outbox drain loops) are detached — as in the VTC pilot — and wind down
-        // as their `Arc<MessagingService>`/transport handles drop.
+        // Stop DIDComm messaging: cancel the inbound loop's shutdown token
+        // (also stops the `MessagingConnect` reconnect supervisor between
+        // attempts). The delivery-layer background tasks (dispatcher, transport
+        // forwarder, outbox drain loops) are detached — as in the VTC pilot —
+        // and wind down as their `Arc<MessagingService>`/transport handles drop.
         #[cfg(feature = "didcomm")]
         {
             didcomm_shutdown.cancel();
-            let _ = &messaging_service;
             info!("DIDComm messaging stopped");
         }
-        #[cfg(not(feature = "didcomm"))]
-        let _ = messaging_service;
 
         if any_panic {
             let _ = shutdown_tx.send(true);
@@ -1930,6 +1838,241 @@ fn decode_jwt_key(b64: &str) -> Result<JwtKeys, AppError> {
     let keys = JwtKeys::from_ed25519_bytes(&key_bytes, "VTA")?;
     debug!("JWT signing key decoded successfully");
     Ok(keys)
+}
+
+/// Persistent mediator-connect supervisor.
+///
+/// Owns the mediator connect + wiring that used to run inline once during
+/// startup, and — crucially — retries it. The classic failure this fixes: the
+/// self-readiness gate passes (our own DID resolves) but the *mediator's* own
+/// DNS resolver still holds a negative-cache entry for the VTA host, so it
+/// can't fetch our `did.jsonl` to complete the authcrypt handshake and returns
+/// 403 (`NetworkError{status_code:None}`). That clears itself when the
+/// mediator's negative cache expires, so rather than give up until the next
+/// restart the supervisor keeps retrying with capped exponential backoff + full
+/// jitter on a horizon that outlasts the negative cache.
+///
+/// Runs as a spawned task so the (possibly long / unbounded) reconnect horizon
+/// never blocks startup or shutdown. On the first successful connect it wires
+/// the `DIDCommBridge`, mediator registry, and ACL, spawns the inbound loop,
+/// and returns.
+#[cfg(feature = "didcomm")]
+struct MessagingConnect {
+    app_state: AppState,
+    vta_did: String,
+    messaging_config: crate::config::MessagingConfig,
+    readiness: crate::config::MediatorReadinessConfig,
+    resolver_url: Option<String>,
+    outbox_ks: KeyspaceHandle,
+    flush_queues: bool,
+    shutdown: CancellationToken,
+}
+
+#[cfg(feature = "didcomm")]
+impl MessagingConnect {
+    /// Drive the connect + persistent-reconnect loop until it succeeds, the
+    /// horizon elapses, or shutdown is signalled.
+    async fn run(self) {
+        let cfg = &self.readiness;
+        let base = Duration::from_secs(cfg.retry_secs.max(1));
+        // Cap can never be below the base, else backoff couldn't grow.
+        let cap = Duration::from_secs(cfg.reconnect_backoff_cap_secs.max(cfg.retry_secs.max(1)));
+        // 0 = never give up (retry forever at the capped, jittered interval).
+        let horizon = (cfg.reconnect_max_elapsed_secs > 0)
+            .then(|| Duration::from_secs(cfg.reconnect_max_elapsed_secs));
+        let started = tokio::time::Instant::now();
+        let mut attempt: u32 = 0;
+
+        loop {
+            // Never touch the mediator unless the VTA can resolve its own DID
+            // over the network (the same path the mediator takes). A cold VTA
+            // that can't resolve itself would only storm the mediator with
+            // unresolvable-sender auth attempts.
+            if crate::messaging::readiness::self_did_network_resolvable(
+                &self.vta_did,
+                self.resolver_url.as_deref(),
+            )
+            .await
+            {
+                match self.try_connect_once().await {
+                    Ok(()) => {
+                        info!("DIDComm messaging started");
+                        return;
+                    }
+                    Err(e) => warn!("failed to start DIDComm messaging: {e}"),
+                }
+            } else {
+                warn!(
+                    vta_did = %self.vta_did,
+                    "VTA not yet self-resolvable over the network; deferring mediator connect"
+                );
+            }
+
+            // Reconnect disabled → preserve the legacy single-shot behaviour:
+            // give up until the next restart.
+            if !cfg.reconnect {
+                return;
+            }
+            if let Some(h) = horizon
+                && started.elapsed() >= h
+            {
+                warn!(
+                    waited_secs = started.elapsed().as_secs(),
+                    "mediator reconnect gave up after the configured horizon; \
+                     a later restart will retry"
+                );
+                return;
+            }
+
+            let ceiling = crate::messaging::readiness::backoff_ceiling(base, cap, attempt);
+            let sleep_for = crate::messaging::readiness::jittered_backoff(ceiling);
+            debug!(
+                attempt = attempt + 1,
+                ceiling_secs = ceiling.as_secs_f64(),
+                sleep_secs = sleep_for.as_secs_f64(),
+                "mediator connection not established; backing off before retry \
+                 (exponential backoff + full jitter)"
+            );
+            tokio::select! {
+                _ = self.shutdown.cancelled() => {
+                    info!("shutdown during mediator reconnect backoff; stopping supervisor");
+                    return;
+                }
+                _ = tokio::time::sleep(sleep_for) => {}
+            }
+            attempt = attempt.saturating_add(1);
+        }
+    }
+
+    /// One connect attempt: build the messaging service and, on success, wire
+    /// the bridge/registry/ACL and spawn the inbound loop. Returns `Err` (to be
+    /// retried) if the connect fails.
+    async fn try_connect_once(&self) -> Result<(), String> {
+        let app_state = &self.app_state;
+        let messaging_config = &self.messaging_config;
+        let vta_did = self.vta_did.as_str();
+
+        let sr = app_state
+            .secrets_resolver
+            .as_ref()
+            .ok_or_else(|| "no secrets resolver available".to_string())?;
+
+        // Collect secrets using the VM IDs from init_auth (correct for both
+        // did:key and did:webvh — avoids hardcoding #key-0/#key-1 fragments).
+        let mut secrets = Vec::new();
+        if let Some(ref signing_id) = app_state.signing_vm_id
+            && let Some(s) = sr.get_secret(signing_id).await
+        {
+            secrets.push(s);
+        }
+        if let Some(ref ka_id) = app_state.ka_vm_id
+            && let Some(s) = sr.get_secret(ka_id).await
+        {
+            secrets.push(s);
+        }
+
+        // Recovery: optionally clear this DID's mediator inbox over REST *before*
+        // enabling live delivery, so a poison / undeliverable backlog can't stall
+        // the pickup handshake and wedge the (shared DIDComm+TSP) socket.
+        // Best-effort, and off unless `messaging.drain_inbox_on_start` is set.
+        if messaging_config.drain_inbox_on_start || self.flush_queues {
+            match app_state.atm.as_ref() {
+                Some(atm) => {
+                    let cleared =
+                        drain_mediator_inbox(atm, &messaging_config.mediator_did, vta_did).await;
+                    info!(
+                        count = cleared,
+                        mediator = %messaging_config.mediator_did,
+                        "cleared queued mediator inbox before going live"
+                    );
+                }
+                None => warn!("inbox drain requested but no ATM is available; skipping"),
+            }
+        }
+
+        // `--flush-queues` additionally clears the OUTBOUND (sender) queue —
+        // messages this DID sent that are still queued at the mediator. A message
+        // loop can fill that queue, after which the mediator rejects every new
+        // send until it drains; the inbox drain above cannot touch it, this does.
+        if self.flush_queues {
+            match app_state.atm.as_ref() {
+                Some(atm) => {
+                    let cleared =
+                        flush_mediator_outbox(atm, &messaging_config.mediator_did, vta_did).await;
+                    info!(
+                        count = cleared,
+                        mediator = %messaging_config.mediator_did,
+                        "flush_queues: cleared outbound sender queue before going live"
+                    );
+                }
+                None => {
+                    warn!("--flush-queues set but no ATM is available; skipping outbox flush")
+                }
+            }
+        }
+
+        let messaging = crate::messaging::service::build_messaging(
+            secrets,
+            vta_did,
+            &messaging_config.mediator_did,
+            self.outbox_ks.clone(),
+            app_state.did_resolver.as_ref(),
+            self.resolver_url.as_deref(),
+        )
+        .await?;
+
+        let service = messaging.service.clone();
+        // Publish the outbound wiring so every REST/DIDComm component can send to
+        // a peer over this one connection (`DIDCommBridge` → `MessagingService`).
+        app_state.didcomm_bridge.set_messaging(
+            service,
+            (*messaging.atm).clone(),
+            vta_did.to_string(),
+        );
+
+        // Register the config-loaded mediator in the listener registry so the
+        // delegated step-up push (buffered through the registry) can reach
+        // approvers on this mediator.
+        #[cfg(feature = "webvh")]
+        app_state
+            .mediator_registry
+            .record_activate(crate::messaging::registry::MediatorBinding {
+                mediator_did: messaging_config.mediator_did.clone(),
+                endpoint: messaging_config.mediator_url.clone(),
+            })
+            .await;
+
+        // Set the VTA's own allow-all ACL on the mediator (keyed on the VTA DID,
+        // so it authorises both DIDComm and TSP on the shared socket). Only when
+        // `setup_acl` is set (mediators in ExplicitAllow mode).
+        if messaging_config.setup_acl {
+            if let Some(atm) = app_state.atm.as_ref() {
+                acl_setup::set_client_acl_on_connection(
+                    atm,
+                    vta_did,
+                    messaging_config.mediator_did.as_str(),
+                    "vta-main",
+                    "vta",
+                )
+                .await;
+            } else {
+                warn!("setup_acl = true but no ATM available; skipping mediator ACL provisioning");
+            }
+        }
+
+        // Spawn the protocol-routed inbound loop. It runs until `shutdown` is
+        // cancelled (Ctrl-C or soft restart), dispatching DIDComm frames to the
+        // handler set and TSP frames to the trust-task spine.
+        tokio::spawn(crate::messaging::service::run_inbound_loop(
+            Arc::new(messaging),
+            app_state.clone(),
+            vta_did.to_string(),
+            messaging_config.mediator_did.clone(),
+            self.shutdown.clone(),
+        ));
+
+        Ok(())
+    }
 }
 
 /// Best-effort REST drain of this DID's mediator inbox, run at startup when

--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -887,27 +887,37 @@ pub async fn run(
         // receive is always on when compiled with `tsp`; `config.services.tsp`
         // governs advertisement only.
         //
-        // Self-readiness gate + persistent reconnect.
+        // Self-readiness gate + persistent reconnect, both owned by the spawned
+        // `MessagingConnect` supervisor.
         //
-        // The self-readiness gate (below) blocks *this* boot's mediator connect
-        // until the VTA's own public DID is fully resolvable over the network —
-        // so the mediator can fetch our did.jsonl and decrypt the authcrypt
-        // handshake instead of 503→403 storming on a cold start. `/health` is
-        // already live (REST thread spawned above), so the gate delays only the
-        // mediator connect, not liveness.
+        // The supervisor first runs the self-readiness gate: it waits until the
+        // VTA's own DID resolves over the network — the same operation the
+        // mediator performs to fetch our sender key — so the mediator can
+        // authenticate us instead of 403-storming on a cold start. It then
+        // connects, and keeps reconnecting: the classic initial failure is the
+        // mediator's *own* resolver still negative-caching the VTA host, which
+        // clears itself on its own timer, so the VTA self-heals with no operator
+        // restart. It also re-connects if an established session's inbound loop
+        // ends, rather than going silently deaf for the rest of the process.
         //
-        // Once the gate passes, the connect + wiring + persistent-reconnect loop
-        // runs in a spawned supervisor (`MessagingConnect`). If the *initial*
-        // connect fails — classically because the mediator's own DNS resolver
-        // still negative-caches the VTA host and can't resolve us yet
-        // (NetworkError → authcrypt 403) — the supervisor keeps retrying with
-        // capped exponential backoff + full jitter (re-confirming self-
-        // resolution each attempt) on a horizon that outlasts the negative
-        // cache, so the VTA self-heals with no operator restart. The live
-        // `MessagingService` handle is published into `app_state.didcomm_bridge`
-        // on first success; the drain-teardown consumer + status read it there.
-        // Backgrounding the retry keeps the (possibly long) reconnect horizon
-        // off the startup path so shutdown/restart stays responsive.
+        // Everything — gate included — runs in the spawned task, never on the
+        // startup path. `run()` must reach the shutdown/restart select below for
+        // a SIGTERM to be honoured, so awaiting a gate here (up to
+        // `max_wait_secs`, default 300s) would hold the process open with no
+        // listener after the REST thread had already exited.
+        //
+        // The live `MessagingService` handle is published into
+        // `app_state.didcomm_bridge` on each successful connect; the
+        // drain-teardown consumer + status read it there.
+        //
+        // `on_timeout = "fail"` has to fail the *process*, and the gate no longer
+        // runs on this path, so it can't do that by returning `Err` from here.
+        // The supervisor sets this flag and signals shutdown; `run` converts it
+        // back into an `Err` after the threads are joined, so the exit status
+        // still says "failed" for a systemd `Restart=on-failure` or anything else
+        // that reads it.
+        #[cfg(feature = "didcomm")]
+        let readiness_fatal = Arc::new(std::sync::atomic::AtomicBool::new(false));
         #[cfg(feature = "didcomm")]
         if config.services.didcomm {
             match (
@@ -916,42 +926,23 @@ pub async fn run(
                 &config.messaging,
             ) {
                 (Some(_), Some(vta_did), Some(messaging_config)) => {
-                    let gate_decision = match crate::messaging::readiness::run_gate(
-                        vta_did,
-                        &config.mediator_readiness,
-                        config.resolver_url.as_deref(),
-                    )
-                    .await
-                    {
-                        Ok(decision) => decision,
-                        Err(e) => {
-                            return Err(AppError::Internal(format!(
-                                "mediator self-readiness gate failed: {e}"
-                            )));
-                        }
+                    // Compute the outbox keyspace here (it needs `?`), then hand
+                    // the whole gate + connect + reconnect loop to the background
+                    // supervisor.
+                    let outbox_ks = apply_encryption(store.keyspace(crate::keyspaces::OUTBOX)?);
+                    let supervisor = MessagingConnect {
+                        app_state: app_state.clone(),
+                        vta_did: vta_did.clone(),
+                        messaging_config: messaging_config.clone(),
+                        readiness: config.mediator_readiness.clone(),
+                        resolver_url: config.resolver_url.clone(),
+                        outbox_ks,
+                        flush_queues,
+                        shutdown: didcomm_shutdown.clone(),
+                        fatal_shutdown: shutdown_tx.clone(),
+                        fatal_flag: readiness_fatal.clone(),
                     };
-                    if gate_decision == crate::messaging::readiness::GateDecision::Skip {
-                        info!(
-                            "DIDComm messaging not started this boot \
-                             (mediator self-readiness gate: skip)"
-                        );
-                    } else {
-                        // Compute the outbox keyspace here (it needs `?`), then
-                        // hand the connect + persistent-reconnect loop to a
-                        // background supervisor.
-                        let outbox_ks = apply_encryption(store.keyspace(crate::keyspaces::OUTBOX)?);
-                        let supervisor = MessagingConnect {
-                            app_state: app_state.clone(),
-                            vta_did: vta_did.clone(),
-                            messaging_config: messaging_config.clone(),
-                            readiness: config.mediator_readiness.clone(),
-                            resolver_url: config.resolver_url.clone(),
-                            outbox_ks,
-                            flush_queues,
-                            shutdown: didcomm_shutdown.clone(),
-                        };
-                        tokio::spawn(supervisor.run());
-                    }
+                    tokio::spawn(supervisor.run());
                 }
                 _ => {
                     info!("DIDComm not configured — service not started");
@@ -1115,6 +1106,15 @@ pub async fn run(
 
         if any_panic {
             return Err(AppError::Internal("one or more threads panicked".into()));
+        }
+
+        // Surface a `fail`-policy readiness timeout as a non-zero exit, now that
+        // the threads are joined and the store is flushed.
+        #[cfg(feature = "didcomm")]
+        if readiness_fatal.load(std::sync::atomic::Ordering::Relaxed) {
+            return Err(AppError::Internal(
+                "mediator self-readiness gate timed out with on_timeout = \"fail\"".into(),
+            ));
         }
 
         if !is_restart {
@@ -1840,22 +1840,25 @@ fn decode_jwt_key(b64: &str) -> Result<JwtKeys, AppError> {
     Ok(keys)
 }
 
-/// Persistent mediator-connect supervisor.
+/// Mediator-connect supervisor: readiness gate, connect, and reconnect.
 ///
-/// Owns the mediator connect + wiring that used to run inline once during
-/// startup, and — crucially — retries it. The classic failure this fixes: the
-/// self-readiness gate passes (our own DID resolves) but the *mediator's* own
-/// DNS resolver still holds a negative-cache entry for the VTA host, so it
-/// can't fetch our `did.jsonl` to complete the authcrypt handshake and returns
-/// 403 (`NetworkError{status_code:None}`). That clears itself when the
-/// mediator's negative cache expires, so rather than give up until the next
-/// restart the supervisor keeps retrying with capped exponential backoff + full
-/// jitter on a horizon that outlasts the negative cache.
+/// Owns the whole mediator lifecycle that used to run inline once during
+/// startup:
 ///
-/// Runs as a spawned task so the (possibly long / unbounded) reconnect horizon
-/// never blocks startup or shutdown. On the first successful connect it wires
-/// the `DIDCommBridge`, mediator registry, and ACL, spawns the inbound loop,
-/// and returns.
+/// 1. **Self-readiness gate** — wait until the VTA's own DID resolves over the
+///    network, so the mediator (which authenticates us by resolving that DID)
+///    can actually fetch our sender key instead of 403-ing the handshake.
+/// 2. **Connect**, with capped exponential backoff + full jitter. The classic
+///    initial failure is the mediator's *own* resolver still negative-caching
+///    the VTA host: it clears on its own timer, so retrying self-heals with no
+///    operator restart where the previous one-shot connect needed one.
+/// 3. **Supervise the session** — the inbound loop is awaited here rather than
+///    detached, so when it ends the supervisor tears the session down and
+///    reconnects instead of leaving the VTA silently deaf for the rest of the
+///    process.
+///
+/// All of it runs in a spawned task: nothing here may block `server::run`, which
+/// has to reach its shutdown/restart select for a signal to be honoured.
 #[cfg(feature = "didcomm")]
 struct MessagingConnect {
     app_state: AppState,
@@ -1866,24 +1869,72 @@ struct MessagingConnect {
     outbox_ks: KeyspaceHandle,
     flush_queues: bool,
     shutdown: CancellationToken,
+    /// Brings the whole process down when the readiness gate's `fail` policy
+    /// trips. The gate runs off the startup path (so a SIGTERM mid-gate is
+    /// honoured), which means it can no longer surface a fatal by returning
+    /// `Err` from `run` — it signals here instead.
+    fatal_shutdown: watch::Sender<bool>,
+    /// Set alongside `fatal_shutdown` so `run` can turn the same condition into
+    /// a non-zero exit status once the threads are joined.
+    fatal_flag: Arc<std::sync::atomic::AtomicBool>,
 }
 
 #[cfg(feature = "didcomm")]
 impl MessagingConnect {
-    /// Drive the connect + persistent-reconnect loop until it succeeds, the
-    /// horizon elapses, or shutdown is signalled.
+    /// Gate, then run the connect/supervise/reconnect loop until shutdown, the
+    /// configured horizon, or a `reconnect = false` single-shot failure.
     async fn run(self) {
-        let cfg = &self.readiness;
-        let base = Duration::from_secs(cfg.retry_secs.max(1));
-        // Cap can never be below the base, else backoff couldn't grow.
-        let cap = Duration::from_secs(cfg.reconnect_backoff_cap_secs.max(cfg.retry_secs.max(1)));
-        // 0 = never give up (retry forever at the capped, jittered interval).
-        let horizon = (cfg.reconnect_max_elapsed_secs > 0)
-            .then(|| Duration::from_secs(cfg.reconnect_max_elapsed_secs));
-        let started = tokio::time::Instant::now();
+        match crate::messaging::readiness::run_gate(
+            &self.vta_did,
+            &self.readiness,
+            self.resolver_url.as_deref(),
+            &self.shutdown,
+        )
+        .await
+        {
+            Ok(crate::messaging::readiness::GateDecision::Proceed) => {}
+            Ok(crate::messaging::readiness::GateDecision::Skip) => {
+                info!(
+                    "DIDComm messaging not started this boot \
+                     (mediator self-readiness gate: skip)"
+                );
+                return;
+            }
+            Err(e) => {
+                error!("mediator self-readiness gate failed, shutting down: {e}");
+                self.fatal_flag
+                    .store(true, std::sync::atomic::Ordering::Relaxed);
+                let _ = self.fatal_shutdown.send(true);
+                return;
+            }
+        }
+
+        // One-shot, *before* the first connect attempt and never repeated. Both
+        // of these delete queued messages at the mediator, so re-running them on
+        // every retry would keep destroying traffic that arrived between
+        // attempts.
+        self.run_startup_recovery().await;
+
+        self.supervise().await;
+    }
+
+    /// The connect → supervise-session → reconnect loop.
+    async fn supervise(&self) {
+        // The give-up / how-long-to-wait arithmetic lives in `ReconnectPolicy`
+        // so it is unit-testable without a mediator; this loop owns the effects.
+        let policy = crate::messaging::readiness::ReconnectPolicy::from_config(&self.readiness);
+        // `failing_for` is measured from the start of the current run of
+        // failures, not from process start — a VTA that ran healthily for a week
+        // and then dropped gets the full horizon to reconnect, rather than
+        // blowing a 1-hour budget it exhausted six days ago.
+        let mut window_started = tokio::time::Instant::now();
         let mut attempt: u32 = 0;
 
         loop {
+            if self.shutdown.is_cancelled() {
+                return;
+            }
+
             // Never touch the mediator unless the VTA can resolve its own DID
             // over the network (the same path the mediator takes). A cold VTA
             // that can't resolve itself would only storm the mediator with
@@ -1894,10 +1945,43 @@ impl MessagingConnect {
             )
             .await
             {
-                match self.try_connect_once().await {
-                    Ok(()) => {
+                match self.connect_once().await {
+                    Ok(messaging) => {
                         info!("DIDComm messaging started");
-                        return;
+                        let session_started = tokio::time::Instant::now();
+
+                        // Await the inbound loop rather than detaching it: its
+                        // return is the only signal that this session is over.
+                        crate::messaging::service::run_inbound_loop(
+                            messaging.clone(),
+                            self.app_state.clone(),
+                            self.vta_did.clone(),
+                            self.messaging_config.mediator_did.clone(),
+                            self.shutdown.clone(),
+                        )
+                        .await;
+
+                        // Session over. Unpublish before tearing down so no
+                        // caller packs onto a socket we're about to stop, then
+                        // stop it — the mediator allows one socket per DID, so a
+                        // reconnect while the old socket still auto-reconnects
+                        // would have the two duel over the slot.
+                        self.app_state.didcomm_bridge.clear_messaging();
+                        messaging.atm.graceful_shutdown().await;
+
+                        if self.shutdown.is_cancelled() {
+                            return;
+                        }
+
+                        let lasted = session_started.elapsed();
+                        warn!(
+                            session_secs = lasted.as_secs(),
+                            "mediator session ended unexpectedly; reconnecting"
+                        );
+                        if policy.session_was_healthy(lasted) {
+                            attempt = 0;
+                            window_started = tokio::time::Instant::now();
+                        }
                     }
                     Err(e) => warn!("failed to start DIDComm messaging: {e}"),
                 }
@@ -1908,27 +1992,21 @@ impl MessagingConnect {
                 );
             }
 
-            // Reconnect disabled → preserve the legacy single-shot behaviour:
-            // give up until the next restart.
-            if !cfg.reconnect {
+            // `None` = stop: either reconnect is disabled (legacy single-shot:
+            // give up until the next restart) or the horizon is exhausted.
+            let Some(sleep_for) = policy.next_backoff(attempt, window_started.elapsed()) else {
+                if self.readiness.reconnect {
+                    warn!(
+                        waited_secs = window_started.elapsed().as_secs(),
+                        "mediator reconnect gave up after the configured horizon; \
+                         a later restart will retry"
+                    );
+                }
                 return;
-            }
-            if let Some(h) = horizon
-                && started.elapsed() >= h
-            {
-                warn!(
-                    waited_secs = started.elapsed().as_secs(),
-                    "mediator reconnect gave up after the configured horizon; \
-                     a later restart will retry"
-                );
-                return;
-            }
-
-            let ceiling = crate::messaging::readiness::backoff_ceiling(base, cap, attempt);
-            let sleep_for = crate::messaging::readiness::jittered_backoff(ceiling);
+            };
             debug!(
                 attempt = attempt + 1,
-                ceiling_secs = ceiling.as_secs_f64(),
+                ceiling_secs = policy.ceiling_for(attempt).as_secs_f64(),
                 sleep_secs = sleep_for.as_secs_f64(),
                 "mediator connection not established; backing off before retry \
                  (exponential backoff + full jitter)"
@@ -1944,10 +2022,56 @@ impl MessagingConnect {
         }
     }
 
+    /// Best-effort, destructive queue recovery that runs **once** per process,
+    /// before the first connect attempt.
+    ///
+    /// Clearing this DID's mediator inbox stops a poison / undeliverable backlog
+    /// stalling the pickup handshake and wedging the (shared DIDComm+TSP)
+    /// socket. `--flush-queues` additionally clears the OUTBOUND (sender) queue:
+    /// a message loop can fill it, after which the mediator rejects every new
+    /// send until it drains, and the inbox drain cannot touch it.
+    async fn run_startup_recovery(&self) {
+        let messaging_config = &self.messaging_config;
+        let vta_did = self.vta_did.as_str();
+
+        if messaging_config.drain_inbox_on_start || self.flush_queues {
+            match self.app_state.atm.as_ref() {
+                Some(atm) => {
+                    let cleared =
+                        drain_mediator_inbox(atm, &messaging_config.mediator_did, vta_did).await;
+                    info!(
+                        count = cleared,
+                        mediator = %messaging_config.mediator_did,
+                        "cleared queued mediator inbox before going live"
+                    );
+                }
+                None => warn!("inbox drain requested but no ATM is available; skipping"),
+            }
+        }
+
+        if self.flush_queues {
+            match self.app_state.atm.as_ref() {
+                Some(atm) => {
+                    let cleared =
+                        flush_mediator_outbox(atm, &messaging_config.mediator_did, vta_did).await;
+                    info!(
+                        count = cleared,
+                        mediator = %messaging_config.mediator_did,
+                        "flush_queues: cleared outbound sender queue before going live"
+                    );
+                }
+                None => {
+                    warn!("--flush-queues set but no ATM is available; skipping outbox flush")
+                }
+            }
+        }
+    }
+
     /// One connect attempt: build the messaging service and, on success, wire
-    /// the bridge/registry/ACL and spawn the inbound loop. Returns `Err` (to be
-    /// retried) if the connect fails.
-    async fn try_connect_once(&self) -> Result<(), String> {
+    /// the bridge/registry/ACL and hand the live session back to the caller,
+    /// which owns its inbound loop. Returns `Err` (to be retried) if the connect
+    /// fails; `build_messaging` tears its own socket down on every error path.
+    async fn connect_once(&self) -> Result<Arc<crate::messaging::service::VtaMessaging>, String> {
         let app_state = &self.app_state;
         let messaging_config = &self.messaging_config;
         let vta_did = self.vta_did.as_str();
@@ -1971,61 +2095,23 @@ impl MessagingConnect {
             secrets.push(s);
         }
 
-        // Recovery: optionally clear this DID's mediator inbox over REST *before*
-        // enabling live delivery, so a poison / undeliverable backlog can't stall
-        // the pickup handshake and wedge the (shared DIDComm+TSP) socket.
-        // Best-effort, and off unless `messaging.drain_inbox_on_start` is set.
-        if messaging_config.drain_inbox_on_start || self.flush_queues {
-            match app_state.atm.as_ref() {
-                Some(atm) => {
-                    let cleared =
-                        drain_mediator_inbox(atm, &messaging_config.mediator_did, vta_did).await;
-                    info!(
-                        count = cleared,
-                        mediator = %messaging_config.mediator_did,
-                        "cleared queued mediator inbox before going live"
-                    );
-                }
-                None => warn!("inbox drain requested but no ATM is available; skipping"),
-            }
-        }
+        let messaging = Arc::new(
+            crate::messaging::service::build_messaging(
+                secrets,
+                vta_did,
+                &messaging_config.mediator_did,
+                self.outbox_ks.clone(),
+                app_state.did_resolver.as_ref(),
+                self.resolver_url.as_deref(),
+            )
+            .await?,
+        );
 
-        // `--flush-queues` additionally clears the OUTBOUND (sender) queue —
-        // messages this DID sent that are still queued at the mediator. A message
-        // loop can fill that queue, after which the mediator rejects every new
-        // send until it drains; the inbox drain above cannot touch it, this does.
-        if self.flush_queues {
-            match app_state.atm.as_ref() {
-                Some(atm) => {
-                    let cleared =
-                        flush_mediator_outbox(atm, &messaging_config.mediator_did, vta_did).await;
-                    info!(
-                        count = cleared,
-                        mediator = %messaging_config.mediator_did,
-                        "flush_queues: cleared outbound sender queue before going live"
-                    );
-                }
-                None => {
-                    warn!("--flush-queues set but no ATM is available; skipping outbox flush")
-                }
-            }
-        }
-
-        let messaging = crate::messaging::service::build_messaging(
-            secrets,
-            vta_did,
-            &messaging_config.mediator_did,
-            self.outbox_ks.clone(),
-            app_state.did_resolver.as_ref(),
-            self.resolver_url.as_deref(),
-        )
-        .await?;
-
-        let service = messaging.service.clone();
         // Publish the outbound wiring so every REST/DIDComm component can send to
         // a peer over this one connection (`DIDCommBridge` → `MessagingService`).
+        // Replaces any previous session's wiring on a reconnect.
         app_state.didcomm_bridge.set_messaging(
-            service,
+            messaging.service.clone(),
             (*messaging.atm).clone(),
             vta_did.to_string(),
         );
@@ -2060,18 +2146,7 @@ impl MessagingConnect {
             }
         }
 
-        // Spawn the protocol-routed inbound loop. It runs until `shutdown` is
-        // cancelled (Ctrl-C or soft restart), dispatching DIDComm frames to the
-        // handler set and TSP frames to the trust-task spine.
-        tokio::spawn(crate::messaging::service::run_inbound_loop(
-            Arc::new(messaging),
-            app_state.clone(),
-            vta_did.to_string(),
-            messaging_config.mediator_did.clone(),
-            self.shutdown.clone(),
-        ));
-
-        Ok(())
+        Ok(messaging)
     }
 }
 

--- a/vta-service/src/setup/from_toml.rs
+++ b/vta-service/src/setup/from_toml.rs
@@ -989,6 +989,7 @@ pub async fn apply_inputs(
         },
         services: inputs.services.clone(),
         messaging: messaging.clone(),
+        mediator_readiness: Default::default(),
         auth: AuthConfig {
             jwt_signing_key,
             ..AuthConfig::default()
@@ -1475,6 +1476,7 @@ fn scratch_config_for_seed_store(
         store: StoreConfig { data_dir },
         services: ServicesConfig::default(),
         messaging: None,
+        mediator_readiness: Default::default(),
         auth: AuthConfig::default(),
         audit: Default::default(),
         vault: Default::default(),

--- a/vta-service/src/test_support.rs
+++ b/vta-service/src/test_support.rs
@@ -129,6 +129,7 @@ pub fn test_app_config(data_dir: PathBuf) -> AppConfig {
         log: Default::default(),
         store: StoreConfig { data_dir },
         messaging: None,
+        mediator_readiness: Default::default(),
         services: Default::default(),
         auth: Default::default(),
         audit: Default::default(),

--- a/vta-support/Cargo.toml
+++ b/vta-support/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-support"
 description = "Shared mid-layer VTA services — trust-context storage, the sealed-transfer seal helper, and the sealed-bootstrap nonce store"
 readme = "README.md"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -12,7 +12,7 @@ repository.workspace = true
 
 [dependencies]
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.1" }
-vta-config = { path = "../vta-config", version = "0.2" }
+vta-config = { path = "../vta-config", version = "0.3" }
 # `encryption` is REQUIRED, not optional: `seal.rs` calls
 # `KeyspaceHandle::with_encryption`, which is `#[cfg(feature = "encryption")]`.
 # Omitting it still built here — another workspace member enables the feature

--- a/vta-tee/Cargo.toml
+++ b/vta-tee/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-tee"
 description = "VTA TEE bootstrap — Nitro/SEV-SNP attestation providers, KMS attest/decrypt + storage-key derivation, the anchor MAC, and first-boot DID autogen"
 readme = "README.md"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -13,7 +13,7 @@ repository.workspace = true
 [dependencies]
 vti-common = { path = "../vti-common", version = "0.11", features = ["encryption", "openapi"] }
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.1" }
-vta-config = { path = "../vta-config", version = "0.2", features = ["tee"] }
+vta-config = { path = "../vta-config", version = "0.3", features = ["tee"] }
 vta-keys = { path = "../vta-keys", version = "0.1" }
 vta-support = { path = "../vta-support", version = "0.2" }
 aes-gcm = { workspace = true }


### PR DESCRIPTION
## Problem

On a cold start the VTA publishes its `did:webvh` and immediately opens the mediator DIDComm session. The mediator authenticates the VTA by resolving that DID itself; if it resolves before the VTA's DID document is externally reachable, the lookup fails and is negative-cached, producing a burst of authcrypt 403s. The previous one-shot connect then gave up permanently instead of recovering once the negative cache expired.

## Changes

- **Self-readiness gate** — waits until the VTA's own DID fully resolves over the network before initiating the mediator handshake, using a throwaway resolver so it exercises the same path the mediator takes. It honours the configured resolver (network vs local mode), so it also works where egress is restricted to a resolver sidecar. Endpoint-less methods (`did:key`) short-circuit.
- **Persistent reconnect supervisor** — replaces the one-shot connect: capped exponential backoff with full jitter, re-checking self-resolution before every attempt so a cold VTA never storms the mediator with unresolvable-sender auth. Configurable via `MediatorReadinessConfig` (`reconnect`, `reconnect_backoff_cap_secs`, `reconnect_max_elapsed_secs`; default retries indefinitely at a capped, jittered interval). The VTA recovers once the negative cache expires, without a restart.

## Testing

- `cargo test -p vta-service` (readiness unit tests) pass.
- Reproduced the cold-start race on a local DNS harness: without the fix the VTA 403-storms and never reconnects; with the fix it self-heals once the negative cache expires (no restart).
