### PR TITLE
feat(vta-sdk): let a community advertise the registry authoritative for it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,54 @@
 
 ## Unreleased
 
+### vta-sdk 0.20.28 / vtc-service 0.11.46 — a community can advertise the registry authoritative for it
+
+TRQP v2.0 recommends a trust registry be machine-discoverable *"via the
+`authority_id`"* — from the DID document of the authority whose records it
+holds. A VTC **is** the `authority_id` in every tuple evaluated under it, so
+the pointer belongs in the community's own document. Nothing emitted one:
+`trql-client` gained `registry_referral` to *follow* a referral
+(affinidi/affinidi-trust-registry-rs#118) and returns `None` for every document
+in the wild because no producer existed. This is the producer.
+
+- **`vta-sdk`**: `vtc-host` gains an optional `#trust-registry` service entry
+  whose `serviceEndpoint` is `{uri: <registry DID>, profile: <TRQP profile
+  URI>}`. New `did_templates::referral_service` builds it, and owns
+  `TRUST_REGISTRY_SERVICE_TYPE` + `TRQP_PROFILE_URI` — the **single source of
+  truth** for both wire constants, matching `trust-registry`'s own values. The
+  entry rides as the `SERVICE_TRUST_REGISTRY` var through the template's
+  null-pruning slot, so a community with no registry renders byte-identically
+  to before. Built in Rust rather than written into the template JSON because
+  the format's only conditional is whole-array-element pruning, which requires
+  the caller to supply the whole element — the template cannot own a constant
+  it can also omit.
+- **`vtc-service`**: `vtc setup` prompts for the registry DID; `setup --from`
+  takes `registry_did`. Both refuse a non-DID before the first VTA round-trip
+  — a referral is distinguished from a registry advertising its own endpoint
+  by the `uri` carrying a `did:` prefix, so an https URL here would be read as
+  this community serving TRQP itself. Blank reads as "no registry", since
+  templated deploys emit empty strings for unset values.
+- **Docs**: `docs/02-vta/did-templates.md`, `docs/05-design-notes/vtc-mvp.md`
+  §4.4, and the shipped `vtc-setup.example.toml`.
+
+A consuming repo can then configure **one** DID — the community — and resolve
+one hop to its registry, instead of being handed both.
+
+Publishing a referral asserts nothing about authority: anyone may name any
+registry in their own document. Authority flows registry → subject, and
+closing that loop is the client's job (`TrqlClient::referred_by`,
+affinidi/affinidi-trust-registry-rs#122, which lands first for that reason).
+Emitting the entry establishes where to ask and nothing more.
+
+**Fixed at mint time.** A VTC serves a write-once `did.jsonl` and holds no
+update authority over its own log, so changing the referral later needs a
+VTA-side `pnm did-mgmt dids edit` plus redelivering the log by hand — a
+serverless DID's updated log is persisted only in the VTA's store and nothing
+pushes it. Existing communities therefore cannot gain a referral without
+re-provisioning. Automating that redelivery (a VTC-side pull against the VTA's
+public `GET /did/{did}/log`, plus a staleness check in `vtc status`) is the
+natural follow-up and is not included here.
+
 ### vta-backup 0.1.3 / vtc-service 0.11.45 / pnm-cli 0.11.16 / cnm-cli 0.11.13 / vta-sdk 0.20.27 — raise backup password minimum to 15 characters
 
 The export-side minimum password length is raised from 12 to 15 characters

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10271,7 +10271,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.20.27"
+version = "0.20.28"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10566,7 +10566,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-service"
-version = "0.11.45"
+version = "0.11.46"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/docs/02-vta/did-templates.md
+++ b/docs/02-vta/did-templates.md
@@ -188,6 +188,18 @@ template without explicit scope is **context → global → builtin**:
     `runtime-service-management.md`). Requires `URL`; optional
     `STATUS_LIST_PATH` (default `/v1/status-lists`). `URL` must not have a
     trailing slash.
+    Optionally advertises a `TrustRegistry` **referral** naming the registry
+    authoritative for this community by DID, so a client holding only the
+    community's DID resolves one hop to its registry rather than being
+    configured with both. Supply the whole entry as `SERVICE_TRUST_REGISTRY`,
+    built by `vta_sdk::did_templates::referral_service(registry_did)` — the
+    SDK owns the `TrustRegistry` type and the TRQP profile URI so the wire
+    constants have one source. Omit it and the element is pruned; a community
+    with no registry is unchanged. `vtc setup` surfaces this as a prompt and
+    as `registry_did` in the `--from` TOML.
+    Note the entry is fixed at mint time: a VTC serves a write-once
+    `did.jsonl` and cannot re-sign its own log, so changing the referral later
+    means a VTA-side `pnm did-mgmt dids edit` plus redelivering the log.
     The `did-host-*` names describe the DID-document shape the template
     mints — `http` = a `WebVHHosting` (HTTP resolution) endpoint,
     `didcomm` = a `DIDCommMessaging` endpoint, `tsp` = a `TSPTransport`

--- a/docs/03-vtc/examples/vtc-setup.example.toml
+++ b/docs/03-vtc/examples/vtc-setup.example.toml
@@ -35,6 +35,17 @@ setup_key_file = "/srv/vtc/setup-key.json"   # persisted + ACL-granted (see abov
 # ── Optional top-level ──────────────────────────────────────────────────
 context = "default"   # the VTA context this community provisions under
 
+# The trust registry authoritative for this community, if it has one.
+# Publishes a TrustRegistry referral in the VTC's DID document, so a client
+# holding only this community's DID resolves one hop to the registry instead
+# of being configured with both DIDs. Must be a DID, not a URL — the referral
+# names the registry by DID. Omit for a community with no registry.
+#
+# Fixed at mint time: the VTC serves a write-once did.jsonl and cannot
+# re-sign its own log, so changing this later means a VTA-side
+# `pnm did-mgmt dids edit` plus redelivering the log by hand.
+# registry_did = "did:webvh:abc:registry.example.com"
+
 # ── DID hosting (optional) ──────────────────────────────────────────────
 # Omit the whole [webvh] table for the serverless default: the VTC
 # self-hosts its did.jsonl at base_url with a server-assigned path.

--- a/docs/05-design-notes/vtc-mvp.md
+++ b/docs/05-design-notes/vtc-mvp.md
@@ -188,7 +188,8 @@ and is explicitly forbidden.
 
 Built-in template in `vta-sdk::did_templates::builtin`. Required
 var: `URL` (no trailing slash). Optional: `STATUS_LIST_PATH`
-(default `/v1/status-lists`).
+(default `/v1/status-lists`), `SERVICE_TRUST_REGISTRY` (default
+`null` — see the referral below).
 
 Mints two keys, following the workspace convention used by every
 other built-in template:
@@ -204,6 +205,41 @@ Service entries: `#vtc-rest` (`type: VTCRest`, endpoint = `{URL}`),
 `{URL}{STATUS_LIST_PATH}`). The status-list endpoint is gracefully
 present from day one so external verifiers can pre-cache resolution;
 the actual BitstringStatusList credentials are populated in Phase 2.
+
+Optionally a third: `#trust-registry` (`type: TrustRegistry`,
+endpoint = `{uri: <registry DID>, profile: <TRQP profile URI>}`) —
+the **referral** naming the registry authoritative for this
+community. TRQP v2.0 recommends a registry be discoverable "via the
+`authority_id`", and a VTC *is* the `authority_id` in every tuple
+evaluated under it, so the pointer belongs in the community's own
+document. A client given only the community's DID resolves one hop
+to the registry instead of being configured with both.
+
+The `uri` is a **DID, not a URL**. The same service type in a
+*registry's* document carries that registry's TRQP URL and means the
+opposite thing (an endpoint), so consumers disambiguate on the `did:`
+prefix — `trql_client::registry_referral` is the reference
+implementation.
+
+Publishing a referral asserts nothing about authority: anyone may
+name any registry in their own document. Authority flows registry →
+subject, so a client that follows the referral must confirm the
+registry answers *for* the community that referred it before
+believing the answer (`TrqlClient::referred_by`). Emitting the entry
+establishes where to ask and nothing more.
+
+The whole entry rides as the `SERVICE_TRUST_REGISTRY` var, built by
+`vta_sdk::did_templates::referral_service`. It is not spelled out in
+the template JSON because the template format's only conditional is
+whole-array-element `null` pruning, which requires the caller to
+supply the entire element — so the SDK owns the `TrustRegistry` type
+and profile URI to keep one source for both constants.
+
+The referral is fixed at mint time. A VTC serves a write-once
+`did.jsonl` and holds no update authority over its own log, so
+changing the referral later needs a VTA-side `pnm did-mgmt dids edit`
+followed by redelivering the log to the VTC by hand — there is no
+automated path for that today.
 
 DIDComm is not advertised by default — communities that need a
 mediator add it later via the existing runtime-service-management

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.20.27"
+version = "0.20.28"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/did_templates/mod.rs
+++ b/vta-sdk/src/did_templates/mod.rs
@@ -40,6 +40,7 @@
 
 mod builtin;
 mod render;
+mod trust_registry;
 mod validate;
 
 #[cfg(test)]
@@ -53,6 +54,9 @@ use serde_json::Value;
 use thiserror::Error;
 
 pub use builtin::{BUILTIN_NAMES, load_embedded};
+pub use trust_registry::{
+    TRQP_PROFILE_URI, TRUST_REGISTRY_SERVICE_TYPE, TRUST_REGISTRY_SERVICE_VAR, referral_service,
+};
 
 /// Minimum supported template `schemaVersion`.
 pub const SCHEMA_VERSION_MIN: u32 = 1;

--- a/vta-sdk/src/did_templates/tests.rs
+++ b/vta-sdk/src/did_templates/tests.rs
@@ -892,6 +892,68 @@ fn vtc_host_renders_with_minimal_vars() {
         out["service"][1]["serviceEndpoint"],
         "https://vtc.example.com/v1/status-lists",
     );
+    // Exactly two: the optional `SERVICE_TRUST_REGISTRY` slot defaults to
+    // `null` and is pruned, so a community with no registry is unchanged.
+    assert_eq!(out["service"].as_array().unwrap().len(), 2);
+}
+
+/// A community that names its registry gets a third entry: a `TrustRegistry`
+/// referral whose `uri` is the registry's DID.
+#[test]
+fn vtc_host_advertises_a_trust_registry_referral_when_given_one() {
+    let tpl = load_embedded("vtc-host").unwrap();
+    let mut vars = ambient_vars();
+    vars.insert_string("KA_KEY_MB", "z6LSKeyAgreement");
+    vars.insert_string("URL", "https://vtc.example.com");
+    vars.insert(
+        TRUST_REGISTRY_SERVICE_VAR,
+        referral_service("did:webvh:xyz:registry.example.com").unwrap(),
+    );
+
+    let out = tpl.render(&vars).unwrap();
+
+    let services = out["service"].as_array().unwrap();
+    assert_eq!(services.len(), 3, "appended, not replacing");
+    // Appended last, so the two pinned entries keep their indices.
+    assert_eq!(services[0]["type"], "VTCRest");
+    assert_eq!(services[1]["type"], "VTCStatusList");
+
+    let referral = &services[2];
+    assert_eq!(referral["type"], TRUST_REGISTRY_SERVICE_TYPE);
+    assert_eq!(
+        referral["serviceEndpoint"]["uri"], "did:webvh:xyz:registry.example.com",
+        "a referral names the registry by DID, never by URL"
+    );
+    assert_eq!(referral["serviceEndpoint"]["profile"], TRQP_PROFILE_URI);
+
+    // Caller-supplied variable values are not re-substituted by the renderer,
+    // so `{DID}` survives here rather than resolving to the ambient `DID`.
+    // That is deliberate: on the real mint path `DID` is itself the `{DID}`
+    // sentinel and `didwebvh-rs` resolves every leaf string once the SCID is
+    // known, so the entry lands with the community's own DID either way.
+    assert_eq!(referral["id"], "{DID}#trust-registry");
+}
+
+/// The registry a community trusts is not knowable at template-authoring
+/// time and many communities have none, so the entry has to be omissible —
+/// the null-pruning slot is what makes one template serve both shapes.
+#[test]
+fn vtc_host_omits_the_referral_when_no_registry_is_named() {
+    let tpl = load_embedded("vtc-host").unwrap();
+    let mut vars = ambient_vars();
+    vars.insert_string("KA_KEY_MB", "z6LSKeyAgreement");
+    vars.insert_string("URL", "https://vtc.example.com");
+
+    let out = tpl.render(&vars).unwrap();
+
+    let services = out["service"].as_array().unwrap();
+    assert_eq!(services.len(), 2);
+    assert!(
+        !services
+            .iter()
+            .any(|s| s["type"] == TRUST_REGISTRY_SERVICE_TYPE),
+        "no literal null and no half-built entry may survive"
+    );
 }
 
 #[test]

--- a/vta-sdk/src/did_templates/trust_registry.rs
+++ b/vta-sdk/src/did_templates/trust_registry.rs
@@ -1,0 +1,160 @@
+//! The `TrustRegistry` referral a community publishes in its DID document.
+//!
+//! TRQP v2.0 recommends that a trust registry be machine-discoverable *via the
+//! `authority_id`* — that is, from the DID document of the authority whose
+//! records it holds:
+//!
+//! > "It is RECOMMENDED that the TRQP service endpoint(s) for any authoritative
+//! > trust registry be machine-discoverable via the `authority_id`. An example
+//! > would be to publish either of the following in the DID document for the
+//! > `authority_id`: 1. The authoritative TRQP service endpoint URL(s).
+//! > 2. The DID(s) identifying authoritative trust registries."
+//!
+//! A VTC *is* the `authority_id` in every trust tuple evaluated under it, so
+//! this entry belongs in the VTC's document and names the registry by DID —
+//! form 2. A client that holds only the community's DID can then resolve one
+//! hop to the registry rather than being configured with both.
+//!
+//! ## Referral, not endpoint
+//!
+//! The same `TrustRegistry` service type means two different things depending
+//! on whose document carries it, and the endpoint's shape is what distinguishes
+//! them: in a *registry's own* document the `uri` is that registry's TRQP URL
+//! (an **endpoint**); in a *community's* document the `uri` is the registry's
+//! **DID** (a **referral**). Consumers test the `uri` for a `did:` prefix —
+//! `trql_client::registry_referral` is the reference implementation — so a
+//! referral whose `uri` is an https URL would be silently misread as this
+//! community claiming to serve TRQP itself. [`referral_service`] refuses a
+//! non-DID `uri` for that reason.
+//!
+//! ## A referral asserts nothing about authority
+//!
+//! Publishing this entry is a self-assertion: anyone may name any registry in
+//! their own document. Authority flows registry → subject, never the reverse,
+//! so a client that follows the referral must confirm the registry answers
+//! *for* the community that referred it before believing the answer. That
+//! check lives client-side (`TrqlClient::referred_by`), not here — emitting
+//! the entry establishes where to ask and nothing more.
+
+use serde_json::{Value, json};
+
+use super::TemplateError;
+
+/// DID-document service `type` for a Trust Registry, per the
+/// [ToIP Trust Registry Service Profile][profile].
+///
+/// TRQP v2.0 blesses the indirection but names no service type, so this one
+/// comes from the Service Profile spec instead. That spec is Pre-Draft 0.0.1
+/// and self-described as non-binding — the value is pinned here so the whole
+/// stack moves together if it changes.
+///
+/// [profile]: https://github.com/trustoverip/tswg-trust-registry-service-profile/blob/main/spec.md
+pub const TRUST_REGISTRY_SERVICE_TYPE: &str = "TrustRegistry";
+
+/// Profile URI stamped on the referral's service endpoint.
+///
+/// The ToIP Service Profile example says `.../profiles/trp/v2`, left over from
+/// when the protocol was still called TRP. Neither URI resolves today, so
+/// nothing depends on the choice; we name the protocol as it is now called,
+/// matching `trust-registry`'s own `TRQP_PROFILE_URI`. A consumer that starts
+/// matching on `profile` would need to accept both spellings.
+pub const TRQP_PROFILE_URI: &str = "https://trustoverip.org/profiles/trqp/v2";
+
+/// Template variable carrying the whole referral entry.
+///
+/// The `vtc-host` template declares this in `optionalVars` with a `null`
+/// default and places it as a bare array member, so a community provisioned
+/// without a registry simply has the element pruned (see the array arm of
+/// `render::substitute_value`). That null-pruning slot is the only conditional
+/// mechanism the template format has, and it is why the entry is built here in
+/// Rust rather than spelled out in the template JSON: the template cannot own
+/// a constant it can also omit.
+pub const TRUST_REGISTRY_SERVICE_VAR: &str = "SERVICE_TRUST_REGISTRY";
+
+/// Fragment appended to the community's DID to id the referral entry.
+const SERVICE_ID_FRAGMENT: &str = "#trust-registry";
+
+/// Build the `TrustRegistry` referral entry naming `registry_did` as the
+/// registry authoritative for this community.
+///
+/// Pass the result as [`TRUST_REGISTRY_SERVICE_VAR`] in a template's vars map.
+/// The `id` carries the literal `{DID}` sentinel: caller-supplied variable
+/// values are not re-substituted by the renderer, but `didwebvh-rs` resolves
+/// `{DID}` across every leaf string after the SCID is computed, so the entry
+/// lands with the community's minted DID.
+///
+/// # Errors
+///
+/// [`TemplateError::Invalid`] if `registry_did` is not a DID. An https URL
+/// here would render an entry that reads as an *endpoint* — this community
+/// advertising a TRQP surface it does not serve — rather than a referral.
+pub fn referral_service(registry_did: &str) -> Result<Value, TemplateError> {
+    let registry_did = registry_did.trim();
+    if !registry_did.starts_with("did:") {
+        return Err(TemplateError::Invalid(format!(
+            "trust-registry referral must name the registry by DID, got '{registry_did}'. \
+             A referral's `uri` is tested for a `did:` prefix by consumers; an https URL \
+             would be read as this community serving TRQP itself."
+        )));
+    }
+
+    Ok(json!({
+        "id": format!("{{DID}}{SERVICE_ID_FRAGMENT}"),
+        "type": TRUST_REGISTRY_SERVICE_TYPE,
+        "serviceEndpoint": {
+            "uri": registry_did,
+            "profile": TRQP_PROFILE_URI,
+        }
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+
+    use super::*;
+
+    #[test]
+    fn builds_the_referral_shape_the_profile_spec_defines() {
+        let entry = referral_service("did:webvh:abc:registry.example.com").unwrap();
+        assert_eq!(entry["id"], "{DID}#trust-registry");
+        assert_eq!(entry["type"], TRUST_REGISTRY_SERVICE_TYPE);
+        assert_eq!(
+            entry["serviceEndpoint"]["uri"],
+            "did:webvh:abc:registry.example.com"
+        );
+        assert_eq!(entry["serviceEndpoint"]["profile"], TRQP_PROFILE_URI);
+    }
+
+    /// The endpoint is a `{uri, profile}` struct, never a bare string — the
+    /// Service Profile spec's own text rules out an array of structs, and a
+    /// bare string would lose the profile.
+    #[test]
+    fn endpoint_is_a_struct_not_a_string() {
+        let entry = referral_service("did:key:z6Mk").unwrap();
+        assert!(entry["serviceEndpoint"].is_object());
+    }
+
+    #[test]
+    fn an_https_uri_is_refused_because_it_would_read_as_an_endpoint() {
+        let err = referral_service("https://registry.example.com").unwrap_err();
+        assert!(
+            matches!(err, TemplateError::Invalid(ref m) if m.contains("did:")),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn surrounding_whitespace_does_not_defeat_the_did_check() {
+        let entry = referral_service("  did:webvh:abc:registry.example.com  ").unwrap();
+        assert_eq!(
+            entry["serviceEndpoint"]["uri"], "did:webvh:abc:registry.example.com",
+            "the trimmed DID is what lands in the document"
+        );
+    }
+
+    #[test]
+    fn an_empty_registry_did_is_refused() {
+        assert!(referral_service("").is_err());
+    }
+}

--- a/vta-sdk/templates/vtc-host.json
+++ b/vta-sdk/templates/vtc-host.json
@@ -2,11 +2,12 @@
   "schemaVersion": 1,
   "name": "vtc-host",
   "kind": "vtc-host",
-  "description": "Verifiable Trust Community (VTC) service identity. Provisions the did:webvh that a vtc-service binary operates under. The document advertises the VTC's REST endpoint and the URL where its BitstringStatusList credentials will be hosted (populated in Phase 2 of the VTC MVP — the endpoint is gracefully present in the DID document from day one so external verifiers can pre-cache the resolution). DIDComm is not advertised here by default; communities that need a mediator add it later via the runtime-service-management flow (see docs/03-integrating/runtime-service-management.md). The URL variable must not end with a trailing slash to avoid double-slash artefacts in the status-list endpoint.",
+  "description": "Verifiable Trust Community (VTC) service identity. Provisions the did:webvh that a vtc-service binary operates under. The document advertises the VTC's REST endpoint and the URL where its BitstringStatusList credentials will be hosted (populated in Phase 2 of the VTC MVP — the endpoint is gracefully present in the DID document from day one so external verifiers can pre-cache the resolution). Optionally advertises a TrustRegistry referral naming the registry authoritative for this community by DID, so a client holding only the community's DID can resolve one hop to its registry (TRQP v2 §'machine-discoverable via the authority_id'); supply SERVICE_TRUST_REGISTRY, built by vta_sdk::did_templates::referral_service, and omit it for a community with no registry. DIDComm is not advertised here by default; communities that need a mediator add it later via the runtime-service-management flow (see docs/03-integrating/runtime-service-management.md). The URL variable must not end with a trailing slash to avoid double-slash artefacts in the status-list endpoint.",
   "methods": ["webvh", "web"],
   "requiredVars": ["URL"],
   "optionalVars": {
-    "STATUS_LIST_PATH": "/v1/status-lists"
+    "STATUS_LIST_PATH": "/v1/status-lists",
+    "SERVICE_TRUST_REGISTRY": null
   },
   "defaults": {
     "preRotationCount": 2,
@@ -46,7 +47,8 @@
         "id": "{DID}#vtc-status-list",
         "type": "VTCStatusList",
         "serviceEndpoint": "{URL}{STATUS_LIST_PATH}"
-      }
+      },
+      "{SERVICE_TRUST_REGISTRY}"
     ]
   }
 }

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.11.45"
+version = "0.11.46"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vtc-service/src/setup/from_toml.rs
+++ b/vtc-service/src/setup/from_toml.rs
@@ -37,7 +37,8 @@ use vti_common::error::AppError;
 use crate::config::{MessagingConfig, SecretsConfig};
 
 use super::wizard::{
-    SetupOutcome, WebvhTarget, WizardInputs, WizardPlan, apply, refuse_if_already_set_up,
+    SetupOutcome, WebvhTarget, WizardInputs, WizardPlan, apply, normalize_registry_did,
+    refuse_if_already_set_up,
 };
 
 /// TOML schema for `vtc setup --from <file>`.
@@ -70,6 +71,23 @@ pub(crate) struct VtcWizardInputs {
     /// to `default`.
     #[serde(default = "default_context")]
     pub context: String,
+
+    /// DID of the trust registry authoritative for this community, if it has
+    /// one (e.g. `did:webvh:abc:registry.example.com`). Publishes a
+    /// `TrustRegistry` referral in the VTC's DID document so a client holding
+    /// only the community's DID can resolve one hop to its registry rather
+    /// than being configured with both.
+    ///
+    /// Must be a DID, not a URL — a referral is distinguished from a registry
+    /// advertising its own endpoint by the `uri` carrying a `did:` prefix.
+    /// Omit (or leave blank) for a community with no registry; the service
+    /// entry is then pruned from the document.
+    ///
+    /// Fixed at mint time: the VTC serves a write-once `did.jsonl` and cannot
+    /// re-sign its own log, so changing this later needs a VTA-side
+    /// `pnm did-mgmt dids edit` plus redelivering the log by hand.
+    #[serde(default)]
+    pub registry_did: Option<String>,
 
     /// Where the VTC's `did:webvh` is published. All fields optional; an
     /// empty `[webvh]` table (or omitting it) reproduces the serverless
@@ -129,12 +147,17 @@ pub(crate) fn parse_from_toml(file_path: &Path) -> Result<WizardPlan, AppError> 
         ))
     })?;
 
+    // Already validated above; this trims and maps blank to "no registry" so
+    // both front-ends hand `apply` the same shape.
+    let registry_did = normalize_registry_did(inputs.registry_did.as_deref().unwrap_or(""))?;
+
     Ok(WizardPlan {
         config_path: inputs.config_path,
         inputs: WizardInputs {
             base_url: inputs.base_url.trim_end_matches('/').to_string(),
             vta_did: inputs.vta_did,
             context: inputs.context,
+            registry_did,
         },
         webvh: inputs.webvh,
         secrets: inputs.secrets,
@@ -176,6 +199,21 @@ fn validate(inputs: &VtcWizardInputs) -> Result<(), AppError> {
 
     if inputs.context.trim().is_empty() {
         errors.push("context must not be empty".into());
+    }
+
+    // A blank value is "no registry", same as omitting the key; a non-blank
+    // one has to be a DID. Caught here rather than at render time so the
+    // operator sees it alongside every other problem in the file, before the
+    // first VTA round-trip.
+    if let Some(registry_did) = inputs.registry_did.as_deref() {
+        let trimmed = registry_did.trim();
+        if !trimmed.is_empty() && !trimmed.starts_with("did:") {
+            errors.push(format!(
+                "registry_did must be a DID starting with `did:` (got {registry_did:?}) — the \
+                 referral names the registry by DID, not by URL. Omit it for a community with \
+                 no trust registry."
+            ));
+        }
     }
 
     if let Some(messaging) = inputs.messaging.as_ref()
@@ -410,6 +448,70 @@ keyring_service = "vtc-test"
         };
         assert!(err.contains("load setup key"), "{err}");
         assert!(err.contains("admin ACL"), "actionable hint present: {err}");
+    }
+
+    // ── trust-registry referral ─────────────────────────────────────
+
+    fn minimal_toml_with(extra: &str) -> String {
+        format!(
+            r#"
+config_path = "/srv/vtc/config.toml"
+base_url    = "https://vtc.example.com"
+vta_did     = "did:webvh:vta.example.com:abc"
+setup_key_file = "/secrets/vtc-setup-key.json"
+{extra}
+
+[secrets]
+keyring_service = "vtc"
+"#
+        )
+    }
+
+    #[test]
+    fn registry_did_parses_and_validates() {
+        let inputs: VtcWizardInputs = toml::from_str(&minimal_toml_with(
+            r#"registry_did = "did:webvh:xyz:registry""#,
+        ))
+        .expect("parse");
+        assert_eq!(
+            inputs.registry_did.as_deref(),
+            Some("did:webvh:xyz:registry")
+        );
+        validate(&inputs).expect("a DID-valued registry_did is valid");
+    }
+
+    /// Omitting the key is the no-registry case, and must stay valid — most
+    /// communities have no registry, and every setup file written before
+    /// this field existed omits it.
+    #[test]
+    fn registry_did_is_optional() {
+        let inputs: VtcWizardInputs = toml::from_str(&minimal_toml_with("")).expect("parse");
+        assert!(inputs.registry_did.is_none());
+        validate(&inputs).expect("no registry is a valid community");
+        assert!(normalize_registry_did("").unwrap().is_none());
+    }
+
+    /// A URL here would render an entry that reads as this community serving
+    /// TRQP itself rather than referring to a registry, so it is refused at
+    /// parse time rather than several VTA round-trips later.
+    #[test]
+    fn registry_did_rejects_a_url() {
+        let inputs: VtcWizardInputs = toml::from_str(&minimal_toml_with(
+            r#"registry_did = "https://registry.example.com""#,
+        ))
+        .expect("parse");
+        let err = validate(&inputs).expect_err("a URL is not a DID");
+        assert!(err.to_string().contains("registry_did"), "got: {err}");
+    }
+
+    /// A blank string reads as "no registry", the same as omitting the key —
+    /// templated deploys emit empty strings for unset values.
+    #[test]
+    fn blank_registry_did_reads_as_no_registry() {
+        let inputs: VtcWizardInputs =
+            toml::from_str(&minimal_toml_with(r#"registry_did = "   ""#)).expect("parse");
+        validate(&inputs).expect("blank is not an invalid DID, it is no registry");
+        assert!(normalize_registry_did("   ").unwrap().is_none());
     }
 
     /// The shipped example file must parse — keeps the docs honest.

--- a/vtc-service/src/setup/wizard.rs
+++ b/vtc-service/src/setup/wizard.rs
@@ -39,6 +39,7 @@ use serde_json::Value as JsonValue;
 use tokio::sync::mpsc;
 use tracing::warn;
 use vta_sdk::client::VtaClient;
+use vta_sdk::did_templates::{TRUST_REGISTRY_SERVICE_VAR, referral_service};
 use vta_sdk::provision_client::{
     EphemeralSetupKey, OperatorMessages, ProvisionAsk, ProvisionResult, ResolvedVta, VtaEvent,
     VtaIntent, VtaReply, resolve_vta, run_connection_test, run_provision_flight,
@@ -346,6 +347,16 @@ pub(crate) struct WizardInputs {
     pub(crate) base_url: String,
     pub(crate) vta_did: String,
     pub(crate) context: String,
+    /// DID of the trust registry authoritative for this community, when it
+    /// has one. Renders a `TrustRegistry` referral into the VTC's DID
+    /// document so a client holding only the community's DID can resolve one
+    /// hop to its registry instead of being configured with both.
+    ///
+    /// Optional: a community with no registry omits it and the service entry
+    /// is pruned. It is fixed at mint time — the VTC serves a write-once
+    /// `did.jsonl` and cannot re-sign its own log, so changing it later means
+    /// a VTA-side `dids edit` plus redelivering the log by hand.
+    pub(crate) registry_did: Option<String>,
 }
 
 /// A fully-resolved setup plan: every operator decision gathered, no
@@ -476,6 +487,24 @@ fn prompt_inputs() -> Result<WizardInputs, AppError> {
         .interact_text()
         .map_err(prompt_err)?;
 
+    println!();
+    println!("If this community has a trust registry, naming it here publishes a");
+    println!("TrustRegistry referral in the VTC's DID document, so a client that");
+    println!("holds only this community's DID can resolve one hop to the registry");
+    println!("rather than being configured with both DIDs.");
+    println!();
+    println!("This is fixed at mint time: the VTC serves a write-once did.jsonl and");
+    println!("cannot re-sign its own log, so changing it later needs a VTA-side");
+    println!("`pnm did-mgmt dids edit` and redelivering the log by hand. Leave blank");
+    println!("if the community has no registry, or if you don't know it yet.");
+    println!();
+    let registry_did: String = Input::new()
+        .with_prompt("Trust registry DID (blank for none)")
+        .allow_empty(true)
+        .interact_text()
+        .map_err(prompt_err)?;
+    let registry_did = normalize_registry_did(&registry_did)?;
+
     // The VTC DID's hosting target (did-hosting server, domain, path) is
     // collected later, in `select_webvh_target`, after the ACL grant — at
     // that point the ephemeral key can authenticate to the VTA and
@@ -486,7 +515,29 @@ fn prompt_inputs() -> Result<WizardInputs, AppError> {
         base_url,
         vta_did,
         context,
+        registry_did,
     })
+}
+
+/// Trim an operator-supplied registry DID, mapping blank to "no registry".
+///
+/// Rejects a non-DID early, at the prompt or at TOML-parse time, rather than
+/// letting it surface as a template-render failure several VTA round-trips
+/// later. A referral's `uri` is tested for a `did:` prefix by consumers, so an
+/// https URL here would render an entry that reads as this community serving
+/// TRQP itself.
+pub(crate) fn normalize_registry_did(raw: &str) -> Result<Option<String>, AppError> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+    if !trimmed.starts_with("did:") {
+        return Err(AppError::Config(format!(
+            "trust registry must be named by DID, got '{trimmed}'. The referral published in \
+             the VTC's DID document names the registry by DID, not by URL."
+        )));
+    }
+    Ok(Some(trimmed.to_string()))
 }
 
 /// Ask the operator which mediator the VTC should route DIDComm traffic
@@ -1140,6 +1191,20 @@ async fn run_provision_quietly(
         vars.insert(
             "WEBVH_PATH".to_string(),
             JsonValue::String(path.to_string()),
+        );
+    }
+    // The whole `TrustRegistry` service entry rides as one var. The template
+    // declares it in `optionalVars` with a `null` default and places it as a
+    // bare array member, so leaving it out prunes the element — that
+    // null-pruning slot is the only conditional the template format has, and
+    // it is why `referral_service` builds the entry here rather than the
+    // template spelling it out. Building it in the SDK keeps one owner for
+    // the `TrustRegistry` type and the TRQP profile URI.
+    if let Some(registry_did) = inputs.registry_did.as_deref() {
+        vars.insert(
+            TRUST_REGISTRY_SERVICE_VAR.to_string(),
+            referral_service(registry_did)
+                .map_err(|e| AppError::Config(format!("trust-registry referral: {e}")))?,
         );
     }
     let ask = ProvisionAsk::for_template("vtc-host", vars, inputs.context.clone())


### PR DESCRIPTION
The producer half of the VTC → registry referral. Pairs with affinidi/affinidi-trust-registry-rs#122 (the consumer half) and closes out affinidi/affinidi-trust-registry-rs#117.

TRQP v2.0 recommends a trust registry be machine-discoverable *"via the `authority_id`"* — from the DID document of the authority whose records it holds. A VTC **is** the `authority_id` in every tuple evaluated under it, so that pointer belongs in the community's own document.

Nothing emitted one. `trql-client` gained `registry_referral` in affinidi-trust-registry-rs#118 and returns `None` for every document in the wild, because no producer existed. This is the producer.

## What changes

`vtc-host` gains an optional third service entry:

```json
{
  "id": "<vtc-did>#trust-registry",
  "type": "TrustRegistry",
  "serviceEndpoint": {
    "uri": "did:webvh:…registry",
    "profile": "https://trustoverip.org/profiles/trqp/v2"
  }
}
```

A consuming repo then configures **one** DID — the community — and resolves one hop to its registry. That was the whole point of affinidi-trust-registry-rs#117: today `verifiable-git-infrastructure` needs both `VTC_DID` and `TRUST_REGISTRY_DID`.

Surfaced as a prompt in `vtc setup` and as `registry_did` in the `--from` TOML. Omit it and the element is pruned — **a community that names no registry renders byte-identically to before.**

## Why the entry is built in Rust, not written into the template JSON

The template format has exactly one conditional: whole-array-element `null` pruning (`render::substitute_value`). Most communities have no registry, so the entry must be omissible — which means it rides as a single var, and a caller-supplied var is one the caller would otherwise have to spell the `TrustRegistry` type and the profile URI into themselves.

`did_templates::referral_service` keeps one owner for both constants; the template just holds the slot. The alternative the format prescribes (`did_templates/mod.rs:9-11` — "templates that need branching ship as two templates") was rejected as the worse trade: two `vtc-host` documents to keep in step forever, against one constructor. Naming the cost honestly — the template no longer owns its own `profile` constant.

## Referral, not endpoint

The same service type means the **opposite** thing in a registry's own document, where `uri` is that registry's TRQP *URL*. Consumers disambiguate on the `did:` prefix (`trql_client::registry_referral`), so an https `uri` here would be read as this community advertising a TRQP surface it does not serve — silent, and wrong in the direction that matters.

`referral_service` refuses a non-DID, and both setup front-ends reject one earlier still: the wizard at the prompt, `--from` in `validate()` alongside every other field error, before the first VTA round-trip.

## This asserts nothing about authority

Publishing a referral is a self-assertion — anyone may name any registry in their own document. Authority flows registry → subject, so a client that follows the referral must confirm the registry answers *for* the community that referred it. That check is the client's (`TrqlClient::referred_by`, affinidi-trust-registry-rs#122), and landing it **first** is deliberate: emitting referrals before any client closes the loop is the "unverified redirect that looks like discovery" case affinidi-trust-registry-rs#117 warned about. Stated at every level here — module docs, template description, `vtc-mvp.md` §4.4 — so nobody reads the entry as proof of anything.

## Fixed at mint time — the real limitation

A VTC serves a write-once `did.jsonl` and holds no update authority over its own log (`tasks/vtc-mvp/vta-driven-keys.md`: *"for now the log is write-once at setup"*). Changing the referral later needs a VTA-side `pnm did-mgmt dids edit` **plus redelivering the log to the VTC by hand** — a serverless DID's updated log is persisted only in the VTA's store, and nothing pushes it.

Two consequences worth being explicit about:

- **Existing communities can't gain a referral from this change.** They'd need re-provisioning, which mints a new DID, or the manual file copy.
- Automating redelivery (a VTC-side pull against the VTA's existing public `GET /did/{did}/log`, plus a staleness check in `vtc status`) is the natural follow-up and is **not** in here.

Recorded in the prompt, the TOML field docs, the template description and `vtc-mvp.md` rather than left to be discovered.

## Compatibility

Appended **last**, so the two pinned `vtc-host` entries keep their indices and the positional assertions in `did_templates/tests.rs` still hold. (The existing `SERVICE_TSP` idiom in `didcomm-mediator.json` puts its optional slot first; that would have shifted both.) `registry_did` is `#[serde(default)]`, so every setup TOML written before this field existed parses unchanged. Nothing in the workspace reads a VTC document's `service[]` by index or type.

## Tests

`vta-sdk` 233 lib tests, `vtc-service` 697 — clippy and `cargo fmt` clean.

New: referral shape matches the Service Profile struct; endpoint is a `{uri, profile}` object not a bare string; an https `uri` is refused; whitespace doesn't defeat the DID check; empty is refused; `vtc-host` renders the referral when given one and prunes it when not (asserting no literal `null` and no half-built entry survive); the two pinned entries keep indices 0 and 1; `registry_did` parses, validates, is optional, rejects a URL, and treats blank as "no registry" (templated deploys emit empty strings). The existing minimal-render test now asserts `service.len() == 2` so the pruning is pinned from both sides.

One test documents a real asymmetry worth a reviewer's eye: caller-supplied var values are not re-substituted, so `{DID}` survives the renderer and is resolved later by `didwebvh-rs` once the SCID is known. The entry lands with the community's own DID either way, but the test harness and the mint path show different intermediate states.

## Pre-merge checklist

```
- [x] No new reqwest::Client::new() / bare fetch(); all clients have finite timeouts (R1.2) — no network code added
- [x] No lock held across a network await (R1.3) — no locks added
- [x] No local state committed before its remote effect, or the flow is resumable with an idempotency key (R2.1) — provisioning path unchanged; the entry rides the existing mint round-trip
- [x] Every retry is bounded + backed off; non-idempotent ops are not blind-retried (R1.4) — n/a
- [x] Accept/poll/listen loops survive transient errors (R1.5) — n/a
- [x] Acks/deletes happen only after durable handoff (R1.6) — n/a
- [x] New/changed wire types: camelCase, deny_unknown_fields where security-relevant, schema registered, all consumers (incl. JS) updated (R3.*) — new DID-document service entry, additive and optional; no consumer in any repo reads a VTC document's service[] by index or type (R3.6 sweep). The `TrustRegistry` type + TRQP profile URI match trust-registry's own constants
- [x] Config absence = most restrictive; fail-closed if enforcement can't start (R5.*) — no registry_did = no entry emitted, never a partial or null-valued one; a non-DID is refused rather than downgraded to an endpoint-shaped entry
```
