### PR TITLE
chore: changelog fragments, so concurrent PRs stop conflicting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -830,6 +830,33 @@ unwrap (drops RUSTSEC-2023-0071 exposure); don't reintroduce `rsa`.
 - Don't bypass hooks (`--no-verify`), don't skip signatures, don't amend
   published commits.
 
+## Changelog: write a fragment, never edit `CHANGELOG.md`
+
+**A feature PR must not touch `CHANGELOG.md`.** Add
+`changelog.d/<PR-number>-<slug>.md` containing the `###` block you would
+otherwise have pasted in. Every PR used to insert at the same anchor (the first
+line under `## Unreleased`), so any two concurrent PRs conflicted — structurally,
+every time, with the same mechanical "keep both" resolution. Two PRs adding two
+different files never conflict.
+
+- **Heading**: `### <crate> <version> [/ <crate> <version> …] — <summary> (#PR)`.
+  Name every crate you bumped, with its **new** version — `check-changelogs.sh`
+  matches `<crate> <version>` as whole tokens and fails a bump with no entry.
+- **At release**: `scripts/collate-changelog.sh` folds the fragments into
+  `## Unreleased` (newest PR first, verbatim) and deletes them. One commit, one
+  author, nothing to conflict with. `--check` for a dry run.
+- **Full convention**: `changelog.d/README.md`.
+
+Editing `CHANGELOG.md` directly still *passes* the guard — the collated file is a
+legitimate place for an entry to live — so nothing stops you mechanically. Don't:
+it recreates the conflict for every other open PR.
+
+Note this does **not** solve version-number collisions. Two open PRs both bumping
+the same crate still conflict in `Cargo.toml`, and whichever merges second ships a
+version whose changelog claims both changes. Versions are still claimed at
+authoring time, so when a queue builds up, give the next number to whichever PR is
+closest to merge and rebase the others.
+
 ## General
 
 Before creating new crates or clients, search the workspace and crates.io to

--- a/changelog.d/878-changelog-fragments.md
+++ b/changelog.d/878-changelog-fragments.md
@@ -1,0 +1,18 @@
+### Release process — changelog fragments replace direct `CHANGELOG.md` edits (#878)
+
+Feature PRs now add `changelog.d/<PR-number>-<slug>.md` instead of editing
+`CHANGELOG.md`. Every PR previously inserted at the same anchor — the first line
+under `## Unreleased` — so any two concurrent PRs conflicted, structurally and
+every time. Two PRs adding two different files never conflict.
+
+`scripts/collate-changelog.sh` folds the fragments into `## Unreleased` at release
+time (newest PR first, verbatim) and deletes them, as one commit by one author.
+`scripts/check-changelogs.sh` keeps its contract — a bumped publishable crate must
+be named with its new version — and now searches both locations, so only the file
+the entry lives in moved.
+
+Also fixes two latent bugs in that guard: a `cut -f3` against two-column data,
+which made the anti-vacuous-pass check unable to ever fire, and a glob passed to
+`grep` that would have read stdin and hung CI on an empty fragment directory.
+
+No crate versions change; this is release tooling and convention only.

--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -1,0 +1,59 @@
+# Changelog fragments
+
+**One file per PR. Never edit `CHANGELOG.md` in a feature PR.**
+
+Two PRs that both insert a section at the top of `## Unreleased` conflict every
+time — same anchor, different text, and git has no way to order them. That is
+structural, not bad luck: it hit every pair of concurrent PRs, and the cost grew
+with the amount of parallel work. Adding two *different files* never conflicts,
+so the conflict is designed out rather than resolved over and over.
+
+## Writing one
+
+Create `changelog.d/<PR-number>-<short-slug>.md` containing exactly the block you
+would previously have pasted into `CHANGELOG.md`:
+
+```markdown
+### vta-sdk 0.20.28 / vtc-service 0.11.46 — communities advertise their authoritative registry (#877)
+
+Prose explaining what changed and why, in the same voice as the rest of
+`CHANGELOG.md`. Bullets per crate when several are involved.
+```
+
+Rules:
+
+- **Filename**: `<PR-number>-<slug>.md`. The PR number keeps it unique, which is
+  the whole point; the slug is for humans skimming the directory. Validated by
+  `scripts/check-changelogs.sh`.
+
+  You won't know the number until the PR exists, so the order is: push the
+  branch, open the PR, then add the fragment in a second commit. The guard only
+  runs on the PR, so it will be satisfied by the time it matters.
+- **Heading**: `### <crate> <version> [/ <crate> <version> …] — <summary> (#PR)`.
+  The version-bump guard matches on `<crate> <version>` as whole tokens, so name
+  every crate you bumped, with its **new** version.
+- **Content is final.** Fragments are concatenated verbatim at release time, not
+  reformatted. Write it as it should appear.
+
+If your PR bumps no publishable crate version, a fragment is optional — but add
+one anyway for anything a consumer or operator would want to know about
+(release-process changes, CI contracts, docs restructures). Several of those have
+shipped unrecorded precisely because nothing forced the entry.
+
+## What happens at release
+
+`scripts/collate-changelog.sh` folds every fragment into `## Unreleased` in
+`CHANGELOG.md`, newest PR first, and deletes the fragments. It runs once when a
+release is cut — one commit, one author, so there is nothing to conflict with.
+
+```sh
+scripts/collate-changelog.sh          # rewrite CHANGELOG.md, remove fragments
+scripts/collate-changelog.sh --check  # dry run; prints what would be folded in
+```
+
+## Why the guard still passes
+
+`scripts/check-changelogs.sh` requires every bumped publishable crate to be named
+with its new version in a changelog entry. It now searches `CHANGELOG.md` **and**
+`changelog.d/*.md`, so the contract is unchanged — only the file you write it in
+moved. A bump with no entry in either place still fails.

--- a/scripts/check-changelogs.sh
+++ b/scripts/check-changelogs.sh
@@ -12,8 +12,16 @@
 # pin these crates loosely, so a behavioural change is breaking for them even
 # when no signature changes, and CHANGELOG.md is where they find out.
 #
-# The rule: if a publishable crate's VERSION changed in this PR, the root
-# CHANGELOG.md must MENTION THE NEW VERSION.
+# The rule: if a publishable crate's VERSION changed in this PR, a changelog
+# entry must MENTION THE NEW VERSION — in the root CHANGELOG.md, or in a
+# fragment under changelog.d/.
+#
+# Fragments exist because a shared CHANGELOG.md conflicted on every pair of
+# concurrent PRs: each one inserts a section at the same anchor (the top of
+# `## Unreleased`), which git cannot order. One file per PR never conflicts.
+# `scripts/collate-changelog.sh` folds them in at release time. See
+# changelog.d/README.md. Both locations are accepted here so the rule is about
+# the record existing, not about which file it currently lives in.
 #
 # Deliberately not the weaker "the changelog was touched": a PR that edits the
 # changelog for one reason and bumps a version for another would satisfy that
@@ -48,6 +56,7 @@ if ! git rev-parse --verify --quiet "$BASE" >/dev/null; then
 fi
 
 CHANGELOG="CHANGELOG.md"
+FRAGMENT_DIR="changelog.d"
 
 echo "=== Changelog guard (base: $BASE) ==="
 echo
@@ -63,6 +72,49 @@ if [ ! -f "$CHANGELOG" ]; then
   exit 2
 fi
 
+# Every place an entry may live. Fragments are searched alongside CHANGELOG.md so
+# a PR satisfies the rule by writing a fragment, and a release that has already
+# collated its fragments still satisfies it from CHANGELOG.md.
+#
+# Built as an array rather than a glob expanded at grep time: with `nullglob`
+# unset an empty changelog.d/ would pass the literal string `changelog.d/*.md` to
+# grep, which then reads *stdin* and hangs the CI job.
+set -- "$CHANGELOG"
+if [ -d "$FRAGMENT_DIR" ]; then
+  for frag in "$FRAGMENT_DIR"/*.md; do
+    [ -f "$frag" ] || continue
+    case "$(basename "$frag")" in
+      README.md) continue ;;
+    esac
+    set -- "$@" "$frag"
+  done
+fi
+ENTRY_FILES="$*"
+
+# Fragment filenames carry the PR number, which is what makes them collision-free.
+# A fragment named otherwise still *works* here (it is just a file to grep), but it
+# defeats the convention, so reject it while the author is still looking.
+bad_names=0
+if [ -d "$FRAGMENT_DIR" ]; then
+  for frag in "$FRAGMENT_DIR"/*.md; do
+    [ -f "$frag" ] || continue
+    base_name="$(basename "$frag")"
+    case "$base_name" in
+      README.md) continue ;;
+    esac
+    if ! printf '%s' "$base_name" | grep -qE '^[0-9]+-[a-z0-9][a-z0-9-]*\.md$'; then
+      echo "  ${RED}BAD NAME${NC} $FRAGMENT_DIR/$base_name — expected <PR-number>-<slug>.md"
+      bad_names=1
+    fi
+  done
+fi
+if [ "$bad_names" -ne 0 ]; then
+  echo
+  echo "${RED}Fragment filenames must be <PR-number>-<slug>.md${NC} (lowercase slug)."
+  echo "The PR number is what guarantees two concurrent PRs cannot collide."
+  exit 1
+fi
+
 # Publishable crates as  name<TAB>relative-crate-dir. Non-publishable crates are
 # irrelevant: nothing reaches a consumer, so there is no contract to record.
 crates=$(cargo metadata --format-version 1 --no-deps 2>/dev/null \
@@ -76,10 +128,15 @@ crates=$(cargo metadata --format-version 1 --no-deps 2>/dev/null \
 # this script reports "nothing to check" and exits 0 — passing vacuously on a PR it
 # should have failed. That is the worst outcome available to a release guard, so it
 # fails loudly instead of silently.
-if printf '%s\n' "$crates" | cut -f3 | grep -q '^/'; then
+# `cut -f2` — the crate dir. This read `-f3` and so inspected a field that does
+# not exist in this script's two-column data (check-version-bumps.sh emits three).
+# Every line was empty, nothing ever matched `^/`, and the check that exists to
+# stop a vacuous pass could not fire. It is the one check that must not be
+# decorative.
+if printf '%s\n' "$crates" | cut -f2 | grep -q '^/'; then
   echo "${RED}error:${NC} crate paths did not resolve relative to $ROOT." >&2
   echo "Cannot attribute changed files; refusing to pass without checking." >&2
-  printf '%s\n' "$crates" | cut -f3 | grep '^/' | head -3 | sed 's/^/  /' >&2
+  printf '%s\n' "$crates" | cut -f2 | grep '^/' | head -3 | sed 's/^/  /' >&2
   exit 2
 fi
 
@@ -122,10 +179,14 @@ while IFS="$(printf '\t')" read -r name dir; do
   # satisfy a bump to `0.1.3`.
   escaped=$(printf '%s' "$new_version" | sed 's/\./\\./g')
   escaped_name=$(printf '%s' "$name" | sed 's/[.[\*^$]/\\&/g')
-  if grep -qE "(^|[^A-Za-z0-9_-])\`?$escaped_name\`?[[:space:]]+$escaped([^0-9.]|\$)" "$CHANGELOG"; then
+  # $ENTRY_FILES is intentionally unquoted: it is a whitespace-joined file list,
+  # and every path in this repo is space-free (enforced by the fragment filename
+  # check above and by CHANGELOG.md being a fixed name).
+  # shellcheck disable=SC2086
+  if grep -qE "(^|[^A-Za-z0-9_-])\`?$escaped_name\`?[[:space:]]+$escaped([^0-9.]|\$)" $ENTRY_FILES; then
     echo "  ${GREEN}ok${NC}   $name: ${old_version:-<new>} -> $new_version (documented)"
   else
-    echo "  ${RED}MISSING${NC} $name: ${old_version:-<new>} -> $new_version, but no \"$name $new_version\" entry appears in $CHANGELOG"
+    echo "  ${RED}MISSING${NC} $name: ${old_version:-<new>} -> $new_version, but no \"$name $new_version\" entry appears in $CHANGELOG or $FRAGMENT_DIR/"
     fail=1
   fi
 done <<EOF
@@ -141,8 +202,16 @@ fi
 if [ "$fail" -ne 0 ]; then
   echo "${RED}A crate is being published with no record of what changed.${NC}"
   echo "Sibling repos pin these crates loosely, so a behavioural change is breaking"
-  echo "for them even when no signature changes — ${CYAN}$CHANGELOG${NC} is where they find out."
-  echo "Add an entry naming the new version, e.g. '### $name <version> — <summary>'."
+  echo "for them even when no signature changes — the changelog is where they find out."
+  echo
+  echo "Add a fragment (${CYAN}not${NC} an edit to $CHANGELOG — that conflicts with every"
+  echo "other open PR). Create ${CYAN}$FRAGMENT_DIR/<PR-number>-<slug>.md${NC} containing:"
+  echo
+  echo "  ### $name <version> — <summary> (#<PR-number>)"
+  echo
+  echo "  <what changed and why>"
+  echo
+  echo "See ${CYAN}$FRAGMENT_DIR/README.md${NC}."
   exit 1
 fi
 

--- a/scripts/collate-changelog.sh
+++ b/scripts/collate-changelog.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# Fold changelog.d/ fragments into CHANGELOG.md under `## Unreleased`.
+#
+# Feature PRs never touch CHANGELOG.md — they add one fragment each, because two
+# PRs inserting a section at the same anchor conflict every time and git has no
+# way to order them (see changelog.d/README.md). This script is the other half:
+# run once when a release is cut, as one commit by one author, so there is
+# nothing to conflict with.
+#
+# Fragments are concatenated VERBATIM, newest PR number first, matching the
+# newest-at-top order CHANGELOG.md already uses. Nothing is reformatted — what
+# the author wrote is what ships.
+#
+# Usage:
+#   scripts/collate-changelog.sh            # rewrite CHANGELOG.md, delete fragments
+#   scripts/collate-changelog.sh --check    # dry run: print the plan, change nothing
+#
+# Portable to macOS bash 3.2 / BSD userland.
+set -euo pipefail
+
+CHECK_ONLY=0
+case "${1:-}" in
+  --check) CHECK_ONLY=1 ;;
+  "") ;;
+  *) echo "usage: $(basename "$0") [--check]" >&2; exit 2 ;;
+esac
+
+# `pwd -P` for the same reason as the sibling guards: a worktree reached through a
+# symlink (/tmp on macOS) otherwise disagrees with resolved paths.
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+cd "$ROOT"
+
+if [ -t 1 ]; then
+  RED=$'\033[0;31m'; GREEN=$'\033[0;32m'; CYAN=$'\033[0;36m'; NC=$'\033[0m'
+else
+  RED=''; GREEN=''; CYAN=''; NC=''
+fi
+
+CHANGELOG="CHANGELOG.md"
+FRAGMENT_DIR="changelog.d"
+UNRELEASED_HEADING="## Unreleased"
+
+[ -f "$CHANGELOG" ] || { echo "${RED}error:${NC} $CHANGELOG not found at $ROOT" >&2; exit 2; }
+
+if ! grep -qx "$UNRELEASED_HEADING" "$CHANGELOG"; then
+  echo "${RED}error:${NC} no '$UNRELEASED_HEADING' heading in $CHANGELOG — don't know where to insert." >&2
+  exit 2
+fi
+
+# Collect fragments, sorted by leading PR number DESCENDING so the newest lands at
+# the top of the section. `sort -t- -k1,1nr` on the basename: numeric on the first
+# dash-delimited field, reversed.
+list_fragments() {
+  [ -d "$FRAGMENT_DIR" ] || return 0
+  for frag in "$FRAGMENT_DIR"/*.md; do
+    [ -f "$frag" ] || continue
+    base_name="$(basename "$frag")"
+    if [ "$base_name" = "README.md" ]; then
+      continue
+    fi
+    echo "$base_name"
+  done
+}
+fragments=$(list_fragments | sort -t- -k1,1nr | sed "s|^|$FRAGMENT_DIR/|")
+
+if [ -z "$fragments" ]; then
+  echo "${GREEN}No fragments in $FRAGMENT_DIR/ — $CHANGELOG is already current.${NC}"
+  exit 0
+fi
+
+count=$(printf '%s\n' "$fragments" | wc -l | tr -d ' ')
+echo "=== Collating $count fragment(s) into $UNRELEASED_HEADING ==="
+echo
+printf '%s\n' "$fragments" | sed 's/^/  /'
+echo
+
+if [ "$CHECK_ONLY" -eq 1 ]; then
+  echo "${CYAN}--check: nothing written.${NC}"
+  exit 0
+fi
+
+tmp="$(mktemp "${TMPDIR:-/tmp}/collate-changelog.XXXXXX")"
+trap 'rm -f "$tmp"' EXIT
+
+{
+  # Head: everything through the `## Unreleased` line.
+  awk -v h="$UNRELEASED_HEADING" '{ print } $0 == h { exit }' "$CHANGELOG"
+  echo
+
+  # Fragments, verbatim, each followed by exactly one blank line. `sed '$d'`-free:
+  # awk strips trailing blank lines per fragment so the spacing is uniform whether
+  # or not the author left a trailing newline.
+  while IFS= read -r frag; do
+    [ -n "$frag" ] || continue
+    awk 'BEGIN { blanks = 0 }
+         /^[[:space:]]*$/ { blanks++; next }
+         { while (blanks-- > 0) print ""; blanks = 0; print }' "$frag"
+    echo
+  done <<EOF
+$fragments
+EOF
+
+  # Tail: everything after the `## Unreleased` line, with its leading blank lines
+  # dropped so we don't accumulate a growing gap on each release.
+  awk -v h="$UNRELEASED_HEADING" '
+    seen && started { print; next }
+    seen && !/^[[:space:]]*$/ { started = 1; print; next }
+    $0 == h { seen = 1 }
+  ' "$CHANGELOG"
+} >"$tmp"
+
+mv "$tmp" "$CHANGELOG"
+trap - EXIT
+
+# Remove the fragments. `git rm` when tracked so the deletion is staged with the
+# rewrite; plain rm otherwise (a fragment added but not yet committed).
+while IFS= read -r frag; do
+  [ -n "$frag" ] || continue
+  if git ls-files --error-unmatch "$frag" >/dev/null 2>&1; then
+    git rm -q "$frag"
+  else
+    rm -f "$frag"
+  fi
+done <<EOF
+$fragments
+EOF
+
+echo "${GREEN}Folded $count fragment(s) into $CHANGELOG and removed them.${NC}"
+echo "Review the diff, then commit — one commit, one author, no conflicts."


### PR DESCRIPTION
## Problem

Every PR inserts its entry at the same anchor — the first line under `## Unreleased` in `CHANGELOG.md`. Two PRs inserting different text at the same line is an unresolvable conflict, so **every pair of concurrent PRs conflicts**, the resolution is always the same mechanical "keep both", and the cost grows with parallel work.

#877 hit it against #876 even though the two share no crates: `Cargo.lock` auto-merged, only `CHANGELOG.md` conflicted.

## Change

Feature PRs add `changelog.d/<PR-number>-<slug>.md` instead of editing `CHANGELOG.md`. Two PRs adding two *different* files never conflict — the problem is designed out rather than resolved repeatedly.

- **`changelog.d/`** + `README.md` documenting the convention. Fragment content is the same `###` block you write today, verbatim.
- **`scripts/collate-changelog.sh`** folds fragments into `## Unreleased` at release time — newest PR first, matching the existing newest-at-top order, nothing reformatted — and deletes them. One commit, one author, nothing to conflict with. `--check` for a dry run.
- **`scripts/check-changelogs.sh`** keeps its contract exactly (a bumped publishable crate must be named with its new version) and now searches `CHANGELOG.md` **and** `changelog.d/*.md`. Only the file you write the entry in moved. Its failure message now tells you to write a fragment rather than edit `CHANGELOG.md`, because doing the latter is what recreates the problem.
- Fragment filenames are validated as `<PR-number>-<slug>.md`, since the PR number is the thing that makes them collision-free.

Editing `CHANGELOG.md` directly still passes the guard — the collated file is a legitimate home for an entry, and a release commit has to write there. The convention is enforced by review and `CLAUDE.md`, not by a hard block.

## Two bugs fixed in the guard while I was in it

- **`cut -f3` on two-column data.** The "guard the guard" check exists to prevent a *vacuous pass* — if crate paths don't resolve relative to `$ROOT`, every changed file fails attribution and the script would exit 0 on a PR it should fail. It read field 3, which this script never emits (its sibling `check-version-bumps.sh` has three columns; this one has two). Every line was empty, nothing ever matched `^/`, so the one check whose whole job is to stop a silent pass could never fire. Now `cut -f2`.
- **Glob-into-grep hang.** The entry-file list is built as an array rather than a glob expanded at grep time. With `nullglob` unset, an empty `changelog.d/` would have passed the literal string `changelog.d/*.md` to `grep`, which then reads **stdin** — hanging the CI job rather than failing it.

## Testing

Verified by driving the guard with synthetic commits on this branch, then dropping them:

| Case | Expected | Result |
|---|---|---|
| Crate bumped, no entry anywhere | `MISSING`, exit 1 | pass |
| Bump satisfied by a fragment alone, `CHANGELOG.md` untouched | `ok`, exit 0 | pass |
| Fragment named `Synthetic_Entry.md` | `BAD NAME`, exit 1 | pass |
| Empty `changelog.d/` | completes, no hang | pass |

`collate-changelog.sh` verified end-to-end with two fragments (`900-alpha`, `1001-beta`): descending PR order, single blank lines throughout, existing `## Unreleased` content preserved, fragments deleted, `README.md` kept. `--check` leaves `CHANGELOG.md` byte-identical.

## What this does not fix

Version-number collisions. Two open PRs both bumping the same crate still conflict in `Cargo.toml`, and whichever merges second publishes a version whose changelog claims both changes. Versions are still claimed at authoring time; the real fix is bumping at merge time, which is a separate change.

## Follow-up for #877

Once this lands, #877's conflict is resolved by *moving* its `CHANGELOG.md` edit into `changelog.d/877-*.md` — its changelog diff becomes empty, so there is nothing left to conflict.