### PR TITLE
fix(webvh): stop sending Trust-Task URIs did-hosting retired in 0.8.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10333,7 +10333,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.13.19"
+version = "0.13.20"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",
@@ -10532,7 +10532,7 @@ dependencies = [
 
 [[package]]
 name = "vta-webvh"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "affinidi-tdk",
  "chrono",
@@ -10566,7 +10566,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-service"
-version = "0.11.46"
+version = "0.11.47"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/changelog.d/879-retired-didhosting-tasks.md
+++ b/changelog.d/879-retired-didhosting-tasks.md
@@ -1,0 +1,34 @@
+### vta-service 0.13.20 / vta-webvh 0.1.2 / vtc-service 0.11.47 — stop sending Trust-Task URIs did-hosting retired in 0.8.3 (#879)
+
+VTC setup against a current VTA failed with `bad gateway: failed to send message:
+transport error: request timed out after 30s`, and the error text sent operators
+to check an ACL that was never the problem. The VTA was sending
+`did-management/did/publish/0.1`, which did-hosting 0.8.3 retired in favour of
+`did/register/0.1` (spec `supersededBy`). The host's DIDComm router has no arm
+for the retired task and its fallback drops an unrouted type *without replying*,
+so every server-managed publish burned the full 30s `send_and_wait` timeout — on
+DIDComm, which is the preferred transport whenever a host advertises both. REST
+was unaffected: `PUT /api/dids/{mnemonic}` kept its handler and was only
+re-identified.
+
+- **vta-service**: the DIDComm `publish_did` now sends `did/register/0.1` with
+  the reserved slot's mnemonic as `path` and `force: false`. On the host, an
+  owner re-registering their own slot is a publish — content replaced in-batch,
+  `version_count` bumped, `created_at` preserved, agent-name registry
+  reconciled. `force` stays false deliberately: forcing is how a *different*
+  owner takes a slot, so a forced publish would turn a real ownership conflict
+  into a silent takeover.
+- **vta-service / vta-webvh**: the agent-name `set` / `enable` / `disable` trio
+  was folded into one declarative `update` carrying `state: active | parked` by
+  the same upstream release, so the VTA's three outbound verbs were hanging 30s
+  on DIDComm and 404ing on REST. Both transports now map onto the host's two
+  remaining tasks through `AgentNameVerb::{host_endpoint,host_state}`. The VTA's
+  own inbound four-verb surface is unchanged — the collapse is a property of the
+  host wire, and an operator parking a name still reads `disable`.
+- **vtc-service**: the setup wizard's failure hint no longer suggests an ACL
+  grant for a transport failure. A hint that names the wrong layer costs more
+  than no hint; unrecognised failures keep the ACL wording, which is usually
+  right.
+
+Operators who cannot yet upgrade can point the VTA's webvh server record at the
+REST transport, or roll the DID-hosting daemon back to 0.8.2.

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.13.19"
+version = "0.13.20"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/operations/did_webvh/mod.rs
+++ b/vta-service/src/operations/did_webvh/mod.rs
@@ -1754,31 +1754,31 @@ impl<'a> WebvhTransport<'a> {
                 bridge, server_did, ..
             } => {
                 let client = WebvhDIDCommClient::new(bridge, server_did);
-                return match verb {
-                    update::AgentNameVerb::Set => {
-                        client.set_agent_name(mnemonic, name, did_log, domain).await
+                // `host_state()` is `Some` for exactly the three verbs the
+                // host serves via `update` and `None` for `remove`, so this
+                // match is the verb→task mapping — no second place for the
+                // two transports to disagree about which task a verb is.
+                return match verb.host_state() {
+                    Some(state) => {
+                        client
+                            .update_agent_name(mnemonic, name, state, did_log, domain)
+                            .await
                     }
-                    update::AgentNameVerb::Remove => {
+                    None => {
                         client
                             .remove_agent_name(mnemonic, name, did_log, domain)
-                            .await
-                    }
-                    update::AgentNameVerb::Enable => {
-                        client
-                            .enable_agent_name(mnemonic, name, did_log, domain)
-                            .await
-                    }
-                    update::AgentNameVerb::Disable => {
-                        client
-                            .disable_agent_name(mnemonic, name, did_log, domain)
                             .await
                     }
                 };
             }
             Self::Rest(c) => c,
         };
-        let op = verb.endpoint();
-        match c.agent_name_op(op, mnemonic, name, did_log, domain).await {
+        let op = verb.host_endpoint();
+        let state = verb.host_state();
+        match c
+            .agent_name_op(op, mnemonic, name, state, did_log, domain)
+            .await
+        {
             Ok(()) => Ok(()),
             Err(AppError::Unauthorized(_)) => {
                 info!(
@@ -1788,7 +1788,8 @@ impl<'a> WebvhTransport<'a> {
                 );
                 auth_cache::invalidate_cached_token(auth_ctx.webvh_ks, &server.id).await?;
                 auth_cache::ensure_fresh_access_token(auth_ctx, server, c).await?;
-                c.agent_name_op(op, mnemonic, name, did_log, domain).await
+                c.agent_name_op(op, mnemonic, name, state, did_log, domain)
+                    .await
             }
             Err(e) => Err(e),
         }

--- a/vta-service/src/operations/did_webvh/update/orchestrator.rs
+++ b/vta-service/src/operations/did_webvh/update/orchestrator.rs
@@ -120,13 +120,51 @@ pub enum AgentNameVerb {
 }
 
 impl AgentNameVerb {
-    /// The host endpoint segment — `POST /api/agent-names/{op}`.
-    pub fn endpoint(self) -> &'static str {
+    /// The verb's own name — operator-facing labels, logs, and the
+    /// `agent-name/{verb}/0.1` Trust Task the VTA *serves* to its clients.
+    ///
+    /// Deliberately not the host wire name: did-hosting collapsed
+    /// set/enable/disable into one declarative task (see [`Self::host_endpoint`]),
+    /// but the VTA's own inbound surface still has four verbs, and an operator
+    /// asking to park a name should see "disable", not "update".
+    pub fn as_str(self) -> &'static str {
         match self {
             Self::Set => "set",
             Self::Remove => "remove",
             Self::Enable => "enable",
             Self::Disable => "disable",
+        }
+    }
+
+    /// The host's endpoint segment / task verb — `POST /api/agent-names/{op}`
+    /// and `did-management/agent-name/{op}/0.1`.
+    ///
+    /// did-hosting 0.8.3 retired the `set` / `enable` / `disable` trio in
+    /// favour of one declarative `update` carrying [`Self::host_state`]
+    /// (affinidi-webvh-service#144). Three of our four verbs are therefore the
+    /// same host operation distinguished only by the desired state; `remove`
+    /// stays its own destructive task. Sending the retired names cost the
+    /// caller a silent 30s timeout on DIDComm and a 404 on REST, because the
+    /// host's DIDComm fallback drops an unrouted type without replying.
+    pub fn host_endpoint(self) -> &'static str {
+        match self {
+            Self::Set | Self::Enable | Self::Disable => "update",
+            Self::Remove => "remove",
+        }
+    }
+
+    /// The `state` field on `agent-name/update/0.1` — `None` for `remove`,
+    /// which carries no state.
+    ///
+    /// `active` and `parked` are the two values of did-hosting's
+    /// `AgentNameState`; they align with [`Self::claims_name`] by
+    /// construction, since a name is served exactly when the document claims
+    /// it.
+    pub fn host_state(self) -> Option<&'static str> {
+        match self {
+            Self::Set | Self::Enable => Some("active"),
+            Self::Disable => Some("parked"),
+            Self::Remove => None,
         }
     }
 
@@ -302,7 +340,7 @@ pub async fn agent_name_op(
 
     let opts = UpdateDidWebvhOptions {
         document: Some(document),
-        label: Some(format!("agent-name/{}", verb.endpoint())),
+        label: Some(format!("agent-name/{}", verb.as_str())),
         ..Default::default()
     };
 
@@ -1106,15 +1144,66 @@ mod agent_name_tests {
     use super::{AgentNameVerb, domain_from_webvh_did, edit_agent_name, is_agent_name};
     use serde_json::{Value, json};
 
-    /// Each verb maps to its own host endpoint. A transposition here would
-    /// send `remove` to `disable` — releasing a name the caller meant to
-    /// park, or the reverse — and nothing downstream could detect it.
+    /// Each verb keeps its own operator-facing name. These are what an
+    /// operator reads on a label and what the VTA's own inbound
+    /// `agent-name/{verb}/0.1` tasks are called — they did NOT collapse when
+    /// the host wire did.
     #[test]
-    fn verbs_map_to_distinct_endpoints() {
-        assert_eq!(AgentNameVerb::Set.endpoint(), "set");
-        assert_eq!(AgentNameVerb::Remove.endpoint(), "remove");
-        assert_eq!(AgentNameVerb::Enable.endpoint(), "enable");
-        assert_eq!(AgentNameVerb::Disable.endpoint(), "disable");
+    fn verbs_keep_distinct_operator_facing_names() {
+        assert_eq!(AgentNameVerb::Set.as_str(), "set");
+        assert_eq!(AgentNameVerb::Remove.as_str(), "remove");
+        assert_eq!(AgentNameVerb::Enable.as_str(), "enable");
+        assert_eq!(AgentNameVerb::Disable.as_str(), "disable");
+    }
+
+    /// The host wire mapping. did-hosting 0.8.3 serves only `update` (with a
+    /// declarative `state`) and `remove`; `set` / `enable` / `disable` are
+    /// retired and answer 404 on REST and *nothing at all* on DIDComm, where
+    /// an unrouted type is dropped without a reply — so a regression here
+    /// costs a 30s timeout, not an error. Pinned per-verb rather than by
+    /// counting, so re-adding a retired name fails here.
+    #[test]
+    fn verbs_map_onto_the_hosts_two_tasks() {
+        assert_eq!(AgentNameVerb::Set.host_endpoint(), "update");
+        assert_eq!(AgentNameVerb::Enable.host_endpoint(), "update");
+        assert_eq!(AgentNameVerb::Disable.host_endpoint(), "update");
+        assert_eq!(AgentNameVerb::Remove.host_endpoint(), "remove");
+
+        assert_eq!(AgentNameVerb::Set.host_state(), Some("active"));
+        assert_eq!(AgentNameVerb::Enable.host_state(), Some("active"));
+        assert_eq!(AgentNameVerb::Disable.host_state(), Some("parked"));
+        // `remove` carries no state — the field must be absent, not `null`.
+        assert_eq!(AgentNameVerb::Remove.host_state(), None);
+    }
+
+    /// The requested state and the document direction are the same fact told
+    /// twice, so they must agree: `active` iff the document claims the name.
+    /// This is the assertion that catches a transposition — mapping `Disable`
+    /// to `active` would ask the host to serve a name while handing it a
+    /// document that dropped the claim, and the host would reject it with
+    /// `also_known_as_mismatch` at runtime instead of here.
+    #[test]
+    fn host_state_agrees_with_the_claim_direction() {
+        for verb in [
+            AgentNameVerb::Set,
+            AgentNameVerb::Remove,
+            AgentNameVerb::Enable,
+            AgentNameVerb::Disable,
+        ] {
+            match verb.host_state() {
+                Some("active") => assert!(
+                    verb.claims_name(),
+                    "{} asks for `active` so its document must claim the name",
+                    verb.as_str()
+                ),
+                Some("parked") | None => assert!(
+                    !verb.claims_name(),
+                    "{} takes the name out of service so its document must not claim it",
+                    verb.as_str()
+                ),
+                other => panic!("{} has an unknown host state {other:?}", verb.as_str()),
+            }
+        }
     }
 
     /// The document direction per verb, which must match did-hosting's
@@ -1152,7 +1241,7 @@ mod agent_name_tests {
                 claimed,
                 verb.claims_name(),
                 "{} must leave the document {} the name",
-                verb.endpoint(),
+                verb.as_str(),
                 if verb.claims_name() {
                     "claiming"
                 } else {
@@ -1167,7 +1256,7 @@ mod agent_name_tests {
                 .get("alsoKnownAs")
                 .and_then(|v| v.as_array())
                 .is_some_and(|l| l.iter().any(|v| is_agent_name(v, "example.com", "alice")));
-            assert_eq!(claimed, verb.claims_name(), "{}", verb.endpoint());
+            assert_eq!(claimed, verb.claims_name(), "{}", verb.as_str());
         }
     }
 

--- a/vta-service/src/webvh_didcomm.rs
+++ b/vta-service/src/webvh_didcomm.rs
@@ -61,9 +61,14 @@ use crate::webvh_client::RequestUriResponse;
 const TASK_DID_CHECK_NAME: &str = "https://trusttasks.org/spec/did-management/did/check-name/0.1";
 const TASK_DID_CHECK_NAME_RESPONSE: &str =
     "https://trusttasks.org/spec/did-management/did/check-name/0.1#response";
-const TASK_DID_PUBLISH: &str = "https://trusttasks.org/spec/did-management/did/publish/0.1";
-const TASK_DID_PUBLISH_RESPONSE: &str =
-    "https://trusttasks.org/spec/did-management/did/publish/0.1#response";
+// `did/publish/0.1` is NOT sent. did-hosting 0.8.3 retired it — spec
+// `supersededBy: did/register` — so the host's DIDComm router has no arm for
+// it and its fallback drops the message without replying, which cost every
+// server-managed publish a 30s `send_and_wait` timeout surfaced as a 500
+// (affinidi-webvh-service#144). `publish_did` below sends `did/register/0.1`
+// instead: on the host, an owner re-registering their own slot IS a publish —
+// same content replace, version bump, `created_at` preservation and
+// agent-name reconcile, in one batch.
 const TASK_DID_REGISTER: &str = "https://trusttasks.org/spec/did-management/did/register/0.1";
 const TASK_DID_REGISTER_RESPONSE: &str =
     "https://trusttasks.org/spec/did-management/did/register/0.1#response";
@@ -79,21 +84,20 @@ const TASK_DID_PROBLEM_REPORT: &str =
 // `spec/did-management/...` family as the verbs above; the server answers
 // them from the same `did_ops` functions its REST routes use, so the two
 // transports return identical payloads.
-const TASK_AGENT_NAME_SET: &str = "https://trusttasks.org/spec/did-management/agent-name/set/0.1";
-const TASK_AGENT_NAME_SET_RESPONSE: &str =
-    "https://trusttasks.org/spec/did-management/agent-name/set/0.1#response";
+// One declarative `update` carrying `state: active | parked` replaced the
+// `set` / `enable` / `disable` trio in did-hosting 0.8.3, alongside the
+// `did/publish` retirement above and for the same reason — those three URIs
+// now hit the host's silent fallback. `remove` stays a separate destructive
+// task. The VTA's own *inbound* four-verb surface is unchanged; the collapse
+// is a property of the host wire only (see `AgentNameVerb::host_endpoint`).
+const TASK_AGENT_NAME_UPDATE: &str =
+    "https://trusttasks.org/spec/did-management/agent-name/update/0.1";
+const TASK_AGENT_NAME_UPDATE_RESPONSE: &str =
+    "https://trusttasks.org/spec/did-management/agent-name/update/0.1#response";
 const TASK_AGENT_NAME_REMOVE: &str =
     "https://trusttasks.org/spec/did-management/agent-name/remove/0.1";
 const TASK_AGENT_NAME_REMOVE_RESPONSE: &str =
     "https://trusttasks.org/spec/did-management/agent-name/remove/0.1#response";
-const TASK_AGENT_NAME_ENABLE: &str =
-    "https://trusttasks.org/spec/did-management/agent-name/enable/0.1";
-const TASK_AGENT_NAME_ENABLE_RESPONSE: &str =
-    "https://trusttasks.org/spec/did-management/agent-name/enable/0.1#response";
-const TASK_AGENT_NAME_DISABLE: &str =
-    "https://trusttasks.org/spec/did-management/agent-name/disable/0.1";
-const TASK_AGENT_NAME_DISABLE_RESPONSE: &str =
-    "https://trusttasks.org/spec/did-management/agent-name/disable/0.1#response";
 const TASK_AGENT_NAME_LIST: &str = "https://trusttasks.org/spec/did-management/agent-name/list/0.1";
 const TASK_AGENT_NAME_LIST_RESPONSE: &str =
     "https://trusttasks.org/spec/did-management/agent-name/list/0.1#response";
@@ -119,6 +123,49 @@ fn build_check_name_body(
         body.insert("path".to_string(), serde_json::Value::String(p.to_string()));
     }
     body.insert("reserve".to_string(), serde_json::Value::Bool(true));
+    if let Some(d) = domain {
+        body.insert(
+            "domain".to_string(),
+            serde_json::Value::String(d.to_string()),
+        );
+    }
+    body
+}
+
+/// Build the `did/register/0.1` body.
+///
+/// Serves both callers of the register task: the atomic claim-and-publish and
+/// — since did-hosting retired `did/publish/0.1` in favour of it — the plain
+/// "publish the log for a slot I own" path, where `path` is the reserved
+/// slot's mnemonic and `force` is false.
+///
+/// Extracted so the body is assertable without a live bridge; the publish
+/// regression this pins was a silent 30s timeout, which no unit test built on
+/// `send_and_wait` would have caught.
+fn build_register_body(
+    path: &str,
+    did_log: &str,
+    force: bool,
+    domain: Option<&str>,
+) -> serde_json::Map<String, serde_json::Value> {
+    let mut body = serde_json::Map::new();
+    body.insert(
+        "path".to_string(),
+        serde_json::Value::String(path.to_string()),
+    );
+    body.insert(
+        "method".to_string(),
+        serde_json::Value::String("webvh".to_string()),
+    );
+    // v0.1 spec names this field `didData`; the legacy
+    // did-hosting-control alias map normalises legacy `did_log`
+    // → `didData` server-side, so passing the canonical name
+    // works on both old and new hosts.
+    body.insert(
+        "didData".to_string(),
+        serde_json::Value::String(did_log.to_string()),
+    );
+    body.insert("force".to_string(), serde_json::Value::Bool(force));
     if let Some(d) = domain {
         body.insert(
             "domain".to_string(),
@@ -245,37 +292,12 @@ impl<'a> WebvhDIDCommClient<'a> {
         force: bool,
         domain: Option<&str>,
     ) -> Result<RequestUriResponse, AppError> {
-        let mut body = serde_json::Map::new();
-        body.insert(
-            "path".to_string(),
-            serde_json::Value::String(path.to_string()),
-        );
-        body.insert(
-            "method".to_string(),
-            serde_json::Value::String("webvh".to_string()),
-        );
-        // v0.1 spec names this field `didData`; the legacy
-        // did-hosting-control alias map normalises legacy `did_log`
-        // → `didData` server-side, so passing the canonical name
-        // works on both old and new hosts.
-        body.insert(
-            "didData".to_string(),
-            serde_json::Value::String(did_log.to_string()),
-        );
-        body.insert("force".to_string(), serde_json::Value::Bool(force));
-        if let Some(d) = domain {
-            body.insert(
-                "domain".to_string(),
-                serde_json::Value::String(d.to_string()),
-            );
-        }
-
         let response = self
             .bridge
             .send_and_wait(
                 self.server_did,
                 TASK_DID_REGISTER,
-                serde_json::Value::Object(body),
+                serde_json::Value::Object(build_register_body(path, did_log, force, domain)),
                 TASK_DID_REGISTER_RESPONSE,
                 TASK_DID_PROBLEM_REPORT,
                 30,
@@ -309,48 +331,34 @@ impl<'a> WebvhDIDCommClient<'a> {
         Ok(RequestUriResponse { mnemonic, did_url })
     }
 
-    /// Publish a DID log to the remote (v0.1
-    /// `did-management/did/publish/0.1`). The `domain` argument is
-    /// accepted for disambiguation when the remote runs per-domain
-    /// mnemonic namespaces; consumers that haven't enabled per-domain
-    /// namespacing treat it as a no-op on the lookup.
+    /// Publish a DID log to the remote as an owner re-register (v0.1
+    /// `did-management/did/register/0.1`).
+    ///
+    /// Carries the slot's `mnemonic` as the register `path` — the host keys
+    /// the slot on that path either way, and re-registering a slot you already
+    /// own is idempotent: content is replaced in-batch (never a half-updated
+    /// slot from a resolver's view), `version_count` bumps, `created_at` is
+    /// preserved, and the agent-name registry is reconciled against the new
+    /// document. That is the retired publish verb's behaviour exactly, which is
+    /// why the spec supersedes one with the other.
+    ///
+    /// `force` is always false: this call means "publish the log for a slot I
+    /// own", and forcing is how you'd take a slot from *another* owner. A
+    /// genuine ownership conflict must surface as a conflict, not be papered
+    /// over by a publish.
+    ///
+    /// The `domain` argument is accepted for disambiguation when the remote
+    /// runs per-domain mnemonic namespaces; consumers that haven't enabled
+    /// per-domain namespacing treat it as a no-op on the lookup.
     pub async fn publish_did(
         &self,
         mnemonic: &str,
         log_content: &str,
         domain: Option<&str>,
     ) -> Result<(), AppError> {
-        let mut body = serde_json::Map::new();
-        body.insert(
-            "mnemonic".to_string(),
-            serde_json::Value::String(mnemonic.to_string()),
-        );
-        body.insert(
-            "method".to_string(),
-            serde_json::Value::String("webvh".to_string()),
-        );
-        body.insert(
-            "didData".to_string(),
-            serde_json::Value::String(log_content.to_string()),
-        );
-        if let Some(d) = domain {
-            body.insert(
-                "domain".to_string(),
-                serde_json::Value::String(d.to_string()),
-            );
-        }
-
-        self.bridge
-            .send_and_wait(
-                self.server_did,
-                TASK_DID_PUBLISH,
-                serde_json::Value::Object(body),
-                TASK_DID_PUBLISH_RESPONSE,
-                TASK_DID_PROBLEM_REPORT,
-                30,
-            )
-            .await?;
-        Ok(())
+        self.register_did_atomic(mnemonic, log_content, false, domain)
+            .await
+            .map(|_| ())
     }
 
     /// Soft-delete a DID on the remote (v0.1
@@ -383,11 +391,15 @@ impl<'a> WebvhDIDCommClient<'a> {
 
     // ── Agent names ────────────────────────────────────────────────────
     //
-    // The four mutating verbs share a body and a `{record}` response, so they
+    // Both mutating tasks share a body and a `{record}` response, so they
     // share one submit. `didLog` carries the newly signed document: the server
-    // requires `set`/`enable` to claim the name in `alsoKnownAs` and
-    // `remove`/`disable` not to, which is what makes the registry and the
-    // document agree.
+    // requires `state: active` to claim the name in `alsoKnownAs` and
+    // `remove`/`state: parked` not to, which is what makes the registry and
+    // the document agree.
+    //
+    // `didLog` — not the spec's `didData` — is deliberate: it is the canonical
+    // field name on `remove` and an accepted alias on `update`, so one
+    // spelling satisfies both tasks.
 
     async fn agent_name_verb(
         &self,
@@ -395,6 +407,7 @@ impl<'a> WebvhDIDCommClient<'a> {
         response_task: &str,
         mnemonic: &str,
         name: &str,
+        state: Option<&str>,
         did_log: &str,
         domain: Option<&str>,
     ) -> Result<(), AppError> {
@@ -402,6 +415,9 @@ impl<'a> WebvhDIDCommClient<'a> {
         body.insert("mnemonic".to_string(), serde_json::json!(mnemonic));
         body.insert("name".to_string(), serde_json::json!(name));
         body.insert("didLog".to_string(), serde_json::json!(did_log));
+        if let Some(s) = state {
+            body.insert("state".to_string(), serde_json::json!(s));
+        }
         if let Some(d) = domain {
             body.insert("domain".to_string(), serde_json::json!(d));
         }
@@ -418,19 +434,28 @@ impl<'a> WebvhDIDCommClient<'a> {
         Ok(())
     }
 
-    /// Bind or refresh `name` on `mnemonic`.
-    pub async fn set_agent_name(
+    /// Set `name`'s binding state on `mnemonic` — `active` to bind, refresh,
+    /// or resume it; `parked` to stop it resolving while keeping it reserved
+    /// to this DID.
+    ///
+    /// One call for what used to be `set`, `enable`, and `disable`: the host
+    /// takes the desired end state and the document that must agree with it,
+    /// so "bind" and "resume" are the same request and idempotent by
+    /// construction.
+    pub async fn update_agent_name(
         &self,
         mnemonic: &str,
         name: &str,
+        state: &str,
         did_log: &str,
         domain: Option<&str>,
     ) -> Result<(), AppError> {
         self.agent_name_verb(
-            TASK_AGENT_NAME_SET,
-            TASK_AGENT_NAME_SET_RESPONSE,
+            TASK_AGENT_NAME_UPDATE,
+            TASK_AGENT_NAME_UPDATE_RESPONSE,
             mnemonic,
             name,
+            Some(state),
             did_log,
             domain,
         )
@@ -450,44 +475,7 @@ impl<'a> WebvhDIDCommClient<'a> {
             TASK_AGENT_NAME_REMOVE_RESPONSE,
             mnemonic,
             name,
-            did_log,
-            domain,
-        )
-        .await
-    }
-
-    /// Resume serving a parked `name`.
-    pub async fn enable_agent_name(
-        &self,
-        mnemonic: &str,
-        name: &str,
-        did_log: &str,
-        domain: Option<&str>,
-    ) -> Result<(), AppError> {
-        self.agent_name_verb(
-            TASK_AGENT_NAME_ENABLE,
-            TASK_AGENT_NAME_ENABLE_RESPONSE,
-            mnemonic,
-            name,
-            did_log,
-            domain,
-        )
-        .await
-    }
-
-    /// Park `name` — it stops resolving but stays reserved to this DID.
-    pub async fn disable_agent_name(
-        &self,
-        mnemonic: &str,
-        name: &str,
-        did_log: &str,
-        domain: Option<&str>,
-    ) -> Result<(), AppError> {
-        self.agent_name_verb(
-            TASK_AGENT_NAME_DISABLE,
-            TASK_AGENT_NAME_DISABLE_RESPONSE,
-            mnemonic,
-            name,
+            None,
             did_log,
             domain,
         )
@@ -566,7 +554,78 @@ impl<'a> WebvhDIDCommClient<'a> {
 
 #[cfg(test)]
 mod tests {
-    use super::{build_check_name_body, parse_check_name_response};
+    use super::{
+        TASK_AGENT_NAME_LIST, TASK_AGENT_NAME_REMOVE, TASK_AGENT_NAME_UPDATE, TASK_DID_CHECK_NAME,
+        TASK_DID_DELETE, TASK_DID_REGISTER, build_check_name_body, build_register_body,
+        parse_check_name_response,
+    };
+
+    /// None of the tasks this client sends may be one did-hosting retired in
+    /// 0.8.3 (`did/publish`, `agent-name/{set,enable,disable}`). Those URIs
+    /// have no route on the host, and its DIDComm fallback drops an unrouted
+    /// type **without replying** — so the failure mode is a 30s `send_and_wait`
+    /// timeout surfaced as a 500, not an error naming the task. That is what
+    /// broke every server-managed publish, and what made it hard to see.
+    ///
+    /// Asserted over the constants rather than per-call-site: adding a retired
+    /// URI back is the regression, and it can only enter through one of these.
+    #[test]
+    fn no_task_constant_names_a_retired_verb() {
+        const RETIRED: &[&str] = &[
+            "did/publish/",
+            "agent-name/set/",
+            "agent-name/enable/",
+            "agent-name/disable/",
+        ];
+        for task in [
+            TASK_DID_CHECK_NAME,
+            TASK_DID_REGISTER,
+            TASK_DID_DELETE,
+            TASK_AGENT_NAME_UPDATE,
+            TASK_AGENT_NAME_REMOVE,
+            TASK_AGENT_NAME_LIST,
+        ] {
+            for retired in RETIRED {
+                assert!(
+                    !task.contains(retired),
+                    "{task} names `{retired}`, retired by did-hosting 0.8.3 — \
+                     the host will drop it silently and the caller will hang 30s"
+                );
+            }
+        }
+    }
+
+    /// A publish is a register of the slot we already own: the mnemonic
+    /// travels as `path`, the log as `didData`, and `force` is false.
+    ///
+    /// `force: false` is the load-bearing part. Forcing is how a *different*
+    /// owner takes a slot, so a forced publish would convert a genuine
+    /// ownership conflict into a silent takeover — the opposite of what a
+    /// publish means.
+    #[test]
+    fn publish_registers_the_owned_slot_without_forcing() {
+        let body = build_register_body("brave-otter", "<jsonl>", false, None);
+        assert_eq!(body.get("path"), Some(&serde_json::json!("brave-otter")));
+        assert_eq!(body.get("didData"), Some(&serde_json::json!("<jsonl>")));
+        assert_eq!(body.get("force"), Some(&serde_json::json!(false)));
+        assert_eq!(body.get("method"), Some(&serde_json::json!("webvh")));
+        assert!(!body.contains_key("domain"));
+        // The retired verb's field name must not leak into the register body:
+        // the host keys the slot on `path`, and a `mnemonic` key would be
+        // silently ignored, publishing nothing while appearing to succeed.
+        assert!(!body.contains_key("mnemonic"));
+    }
+
+    /// `domain` rides along on register exactly as it does on check-name.
+    #[test]
+    fn register_body_includes_domain_when_present() {
+        let body = build_register_body("brave-otter", "<jsonl>", true, Some("acme.example.com"));
+        assert_eq!(
+            body.get("domain"),
+            Some(&serde_json::json!("acme.example.com"))
+        );
+        assert_eq!(body.get("force"), Some(&serde_json::json!(true)));
+    }
 
     /// Regression for `e.p.did.path-invalid`: auto-assign (`path == None`)
     /// must OMIT the `path` field, not send `""`. The host rejects a

--- a/vta-webvh/Cargo.toml
+++ b/vta-webvh/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-webvh"
 description = "WebVH hosting infrastructure for the VTA — the DID-record store, the HTTP client to a did:webvh hosting server, and its DID-auth handshake"
 readme = "README.md"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-webvh/src/webvh_client.rs
+++ b/vta-webvh/src/webvh_client.rs
@@ -618,23 +618,30 @@ impl WebvhClient {
         Ok(())
     }
 
-    /// POST /api/agent-names/{op} — bind (`set`), release (`remove`), park
-    /// (`disable`) or resume (`enable`) an agent name via a signed new DID
-    /// version.
+    /// POST /api/agent-names/{op} — set an agent name's binding state
+    /// (`update`, with `state: active | parked`) or release it (`remove`), via
+    /// a signed new DID version.
     ///
     /// `did_log` is the full new signed `did.jsonl` whose `alsoKnownAs` claims
-    /// (`set`/`enable`) or no longer claims (`remove`/`disable`) the name; the
-    /// host verifies that direction matches the verb, republishes the log as a
-    /// new version, and applies the registry change in one commit.
+    /// (`state: active`) or no longer claims (`remove` / `state: parked`) the
+    /// name; the host verifies that direction matches the request, republishes
+    /// the log as a new version, and applies the registry change in one commit.
     ///
-    /// One generic call rather than four wrappers: the request body is
-    /// identical for every verb, so the only thing a wrapper would add is a
-    /// place for the endpoint and the document direction to disagree.
+    /// `state` is `None` for `remove`, which carries no state, and omitted from
+    /// the body in that case — `remove`'s handler rejects unknown fields'
+    /// siblings, and a `null` state on a task that has none is a wire lie.
+    ///
+    /// One generic call rather than a wrapper per verb: the body differs only
+    /// by `state`, so the only thing wrappers would add is a place for the
+    /// endpoint and the document direction to disagree. `/api/agent-names/`
+    /// `{set,enable,disable}` no longer exist on the host — they were folded
+    /// into `update` in did-hosting 0.8.3 and now 404.
     pub async fn agent_name_op(
         &self,
         op: &str,
         mnemonic: &str,
         name: &str,
+        state: Option<&str>,
         did_log: &str,
         domain: Option<&str>,
     ) -> Result<(), AppError> {
@@ -653,6 +660,12 @@ impl WebvhClient {
             "didLog".to_string(),
             serde_json::Value::String(did_log.to_string()),
         );
+        if let Some(s) = state {
+            body.insert(
+                "state".to_string(),
+                serde_json::Value::String(s.to_string()),
+            );
+        }
         if let Some(d) = domain {
             body.insert(
                 "domain".to_string(),
@@ -1432,12 +1445,23 @@ mod tests {
         );
     }
 
+    /// Parking a name posts `update` with `state: parked` — NOT the retired
+    /// `/api/agent-names/disable`, which 404s on any host from did-hosting
+    /// 0.8.3 onward. The mock only answers `update`, so a regression back to
+    /// the old endpoint fails here rather than in the field.
     #[tokio::test]
-    async fn agent_name_disable_posts_bearer_authed_body() {
+    async fn agent_name_park_posts_update_with_parked_state() {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
-            .and(path("/api/agent-names/disable"))
+            .and(path("/api/agent-names/update"))
             .and(header("Authorization", "Bearer tok-1"))
+            .and(body_json(json!({
+                "mnemonic": "alice",
+                "name": "alice",
+                "didLog": "<jsonl>",
+                "state": "parked",
+                "domain": "example.com",
+            })))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "record": {} })))
             .expect(1)
             .mount(&server)
@@ -1446,16 +1470,23 @@ mod tests {
         let mut client = WebvhClient::new(&server.uri(), "did:web:daemon-mock.example").unwrap();
         client.set_access_token("tok-1".to_string());
         client
-            .agent_name_op("disable", "alice", "alice", "<jsonl>", Some("example.com"))
+            .agent_name_op(
+                "update",
+                "alice",
+                "alice",
+                Some("parked"),
+                "<jsonl>",
+                Some("example.com"),
+            )
             .await
-            .expect("disable should POST and succeed");
+            .expect("park should POST update and succeed");
     }
 
     #[tokio::test]
-    async fn agent_name_enable_maps_403_to_forbidden() {
+    async fn agent_name_update_maps_403_to_forbidden() {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
-            .and(path("/api/agent-names/enable"))
+            .and(path("/api/agent-names/update"))
             .respond_with(ResponseTemplate::new(403).set_body_string("not the owner"))
             .expect(1)
             .mount(&server)
@@ -1464,7 +1495,7 @@ mod tests {
         let mut client = WebvhClient::new(&server.uri(), "did:web:daemon-mock.example").unwrap();
         client.set_access_token("tok-1".to_string());
         let err = client
-            .agent_name_op("enable", "alice", "alice", "<jsonl>", None)
+            .agent_name_op("update", "alice", "alice", Some("active"), "<jsonl>", None)
             .await
             .unwrap_err();
         assert!(
@@ -1473,22 +1504,35 @@ mod tests {
         );
     }
 
-    /// Every verb hits its own endpoint and carries the same body. The name
-    /// is what the caller passes, not a fixed `alice` — a wrapper that
-    /// transposed arguments would still pass a same-value test.
+    /// Each host task hits its own endpoint and carries the state it was
+    /// given. The name is what the caller passes, not a fixed `alice` — a
+    /// wrapper that transposed arguments would still pass a same-value test.
+    ///
+    /// `remove` carries no `state` **key at all**: the field is absent, not
+    /// `null`. The host's remove body has no such field, and asserting the
+    /// exact body is what pins that — `body_json` is an equality check, so a
+    /// stray `"state": null` fails this.
     #[tokio::test]
-    async fn agent_name_op_routes_each_verb_to_its_endpoint() {
-        for verb in ["set", "remove", "enable", "disable"] {
+    async fn agent_name_op_routes_each_host_task_with_its_state() {
+        for (op, state) in [
+            ("update", Some("active")),
+            ("update", Some("parked")),
+            ("remove", None),
+        ] {
             let server = MockServer::start().await;
+            let mut expected = json!({
+                "mnemonic": "slot-one",
+                "name": "bob",
+                "didLog": "<jsonl>",
+                "domain": "example.com",
+            });
+            if let Some(s) = state {
+                expected["state"] = json!(s);
+            }
             Mock::given(method("POST"))
-                .and(path(format!("/api/agent-names/{verb}")))
+                .and(path(format!("/api/agent-names/{op}")))
                 .and(header("Authorization", "Bearer tok-1"))
-                .and(body_json(json!({
-                    "mnemonic": "slot-one",
-                    "name": "bob",
-                    "didLog": "<jsonl>",
-                    "domain": "example.com",
-                })))
+                .and(body_json(expected))
                 .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "record": {} })))
                 .expect(1)
                 .mount(&server)
@@ -1498,9 +1542,9 @@ mod tests {
                 WebvhClient::new(&server.uri(), "did:web:daemon-mock.example").unwrap();
             client.set_access_token("tok-1".to_string());
             client
-                .agent_name_op(verb, "slot-one", "bob", "<jsonl>", Some("example.com"))
+                .agent_name_op(op, "slot-one", "bob", state, "<jsonl>", Some("example.com"))
                 .await
-                .unwrap_or_else(|e| panic!("{verb} should POST and succeed: {e:?}"));
+                .unwrap_or_else(|e| panic!("{op}/{state:?} should POST and succeed: {e:?}"));
         }
     }
 
@@ -1595,10 +1639,10 @@ mod tests {
     /// error, not a generic failure — the client has to render "pick another
     /// name" differently from "you don't control this DID".
     #[tokio::test]
-    async fn agent_name_set_surfaces_a_taken_name() {
+    async fn agent_name_bind_surfaces_a_taken_name() {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
-            .and(path("/api/agent-names/set"))
+            .and(path("/api/agent-names/update"))
             .respond_with(ResponseTemplate::new(409).set_body_json(json!({
                 "code": "did-management:name_taken",
                 "message": "agent name is already taken",
@@ -1610,7 +1654,14 @@ mod tests {
         let mut client = WebvhClient::new(&server.uri(), "did:web:daemon-mock.example").unwrap();
         client.set_access_token("tok-1".to_string());
         let err = client
-            .agent_name_op("set", "slot-one", "alice", "<jsonl>", None)
+            .agent_name_op(
+                "update",
+                "slot-one",
+                "alice",
+                Some("active"),
+                "<jsonl>",
+                None,
+            )
             .await
             .unwrap_err();
         let rendered = format!("{err:?}");

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.11.46"
+version = "0.11.47"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vtc-service/src/setup/wizard.rs
+++ b/vtc-service/src/setup/wizard.rs
@@ -1299,15 +1299,88 @@ async fn drive_provision(
     ))
 }
 
-/// Wrap a terminal failure string with the actionable hint the wizard has
-/// always printed — the most common cause is a missing or expired ACL
-/// grant on the setup DID.
+/// Wrap a terminal failure string with an actionable hint.
+///
+/// The ACL hint is the right guess for most failures — a missing or expired
+/// grant on the setup DID is the common cause — but it is **wrong for a
+/// transport failure**, and confidently wrong at that: a VTA that timed out
+/// talking to its DID-hosting host reported "authorize the ephemeral DID",
+/// sending operators to re-check an ACL that was never the problem while the
+/// real fault was two hops away. A hint that names the wrong layer costs more
+/// than no hint.
+///
+/// The classification is a heuristic over the rendered message because
+/// [`VtaEvent::Failed`] carries a string, not a typed error. Threading a typed
+/// variant through the event would let this switch on the cause instead of its
+/// spelling; until then, match only unambiguous transport markers and fall
+/// through to the ACL hint, so a message we don't recognise keeps the advice
+/// that is usually right.
 fn provision_failed(msg: &str) -> AppError {
-    AppError::Internal(format!(
-        "VTA provisioning failed: {msg}. Double-check the VTA URL/DID and that the ephemeral \
-         DID was authorized via `pnm contexts create` (or `pnm acl create` if the context \
-         already exists)."
-    ))
+    const TRANSPORT_MARKERS: &[&str] = &[
+        "timed out",
+        "request timed out",
+        "bad gateway",
+        "transport error",
+        "failed to send message",
+    ];
+    let lower = msg.to_ascii_lowercase();
+    let hint = if TRANSPORT_MARKERS.iter().any(|m| lower.contains(m)) {
+        "The VTA accepted the request but could not complete it — this is a transport failure \
+         between the VTA and one of its peers (its DID-hosting server or mediator), not an \
+         authorization problem. Check the VTA's own logs for the operation that stalled, and \
+         that its DID-hosting server and mediator are reachable and version-compatible."
+    } else {
+        "Double-check the VTA URL/DID and that the ephemeral DID was authorized via \
+         `pnm contexts create` (or `pnm acl create` if the context already exists)."
+    };
+    AppError::Internal(format!("VTA provisioning failed: {msg}. {hint}"))
+}
+
+#[cfg(test)]
+mod provision_failed_tests {
+    use super::provision_failed;
+
+    /// The exact message that shipped the misleading hint: a 30s DIDComm
+    /// timeout between the VTA and its DID-hosting host. It must NOT tell the
+    /// operator to go fix an ACL.
+    #[test]
+    fn transport_timeout_does_not_blame_the_acl() {
+        let err = provision_failed(
+            "Provisioning failed. Details: provision-integration call failed: server error \
+             (500): bad gateway: failed to send message: transport error: request timed out \
+             after 30s",
+        );
+        let rendered = format!("{err:?}");
+        assert!(
+            !rendered.contains("pnm contexts create"),
+            "a transport failure must not suggest an ACL grant: {rendered}"
+        );
+        assert!(
+            rendered.contains("transport failure"),
+            "a transport failure must be named as one: {rendered}"
+        );
+    }
+
+    /// An unrecognised failure keeps the ACL hint — it is the common cause, and
+    /// dropping it would make the usual case harder to diagnose.
+    #[test]
+    fn unclassified_failure_keeps_the_acl_hint() {
+        let err = provision_failed("provisioning ended without a terminal event");
+        let rendered = format!("{err:?}");
+        assert!(
+            rendered.contains("pnm contexts create"),
+            "the default hint must survive: {rendered}"
+        );
+    }
+
+    /// A genuine permission failure keeps the ACL hint too — "forbidden" is
+    /// not a transport marker, so it must not be swallowed by the new branch.
+    #[test]
+    fn forbidden_keeps_the_acl_hint() {
+        let err = provision_failed("provision-integration call failed: forbidden");
+        let rendered = format!("{err:?}");
+        assert!(rendered.contains("pnm acl create"), "{rendered}");
+    }
 }
 
 /// `OperatorMessages` impl for the vtc-host integration kind.


### PR DESCRIPTION
## The failure

VTC setup against a current VTA dies with:

```
Setup failed: internal error: VTA provisioning failed: Provisioning failed. Details:
provision-integration call failed: server error (500): bad gateway: failed to send
message: transport error: request timed out after 30s (thid 91d8ff75-…).
Double-check the VTA URL/DID and that the ephemeral DID was authorized via
`pnm contexts create` …
```

The hint is wrong. Authorization was fine — the ephemeral `did:key` authenticated and `list-webvh-servers` answered in 326µs. From the DID-hosting daemon's log:

| Time | Event |
|---|---|
| 07:40:47.687 | `did-management/did/check-name/0.1` → slot `myagent-vtc` reserved ✅ |
| 07:40:47.696 | `did-management/did/publish/0.1` → **`unhandled message type — ignoring`** |
| 07:41:17.696 | VTA's `send_and_wait` gives up after 30s → 500 |

## Root cause

affinidi-webvh-service#144 — *"clean cutover to consolidated state-enum tasks, retire publish, canonical URIs everywhere"*, did-hosting 0.8.2 → **0.8.3**, 29 Jul 2026, shipped in `VTI-Cypress-RC-0` — retired `did/publish/0.1` in favour of `did/register/0.1`:

```rust
// did-hosting-control/src/messaging.rs:48
// `did/publish` is retired (spec supersededBy: `did/register`) —
// the register arm's owner-update rule carries the reserved-slot
// completion the two-step flow used to finish with a publish.
```

This repo was never moved off it. Two things turned a clean deprecation into a mystery timeout:

1. The host's DIDComm fallback returns `Ok(None)` — an unrouted type is dropped **without a reply**, so the caller learns nothing for 30s. (Being fixed separately in `affinidi-webvh-service`: the fallback should emit a `did/problem-report/0.1`.)
2. DIDComm is the *preferred* transport when a host advertises both, so this hits the default path. REST was never affected — `PUT /api/dids/{mnemonic}` kept its handler and was only re-identified as `did/register/0.1`.

## Also broken by the same commit, not yet reported

That commit also folded agent-name `set` / `enable` / `disable` into one declarative `update` carrying `state: active | parked`. This repo still sent all three:

- **DIDComm** — same silent 30s hang; the host routes only `update`/`remove`/`list`/`check`.
- **REST** — `/api/agent-names/{set,enable,disable}` are gone → 404.

## Changes

- **`publish_did` (DIDComm) → `did/register/0.1`**, mnemonic as `path`, `force: false`. On the host an owner re-registering their own slot *is* a publish: content replaced in-batch (never a half-updated slot from a resolver's view), `version_count` bumped, `created_at` preserved, agent-name registry reconciled — verified against `did_ops::register_did_atomic` and its `owner_re_register_is_idempotent` test. `force` stays false deliberately: forcing is how a *different* owner takes a slot, so a forced publish would convert a genuine ownership conflict into a silent takeover.
- **Agent names → the host's two remaining tasks** on both transports, via new `AgentNameVerb::{host_endpoint,host_state}`. One mapping, not two that can disagree. The VTA's own inbound four-verb surface is unchanged — the collapse is a property of the host wire, and an operator parking a name should still read `disable`, not `update`.
- **The VTC wizard's hint no longer blames the ACL for a transport failure.** Unrecognised failures keep the ACL hint (usually right); transport markers get one naming the actual layer. Heuristic over the rendered string because `VtaEvent::Failed` carries no typed error — noted in the doc comment as the thing to fix if that changes.

## Tests

A DIDComm timeout yields no error to assert on, so coverage targets what *is* assertable:

- `build_register_body` extracted → publish's body asserted directly (`path`, `force: false`, no stray `mnemonic` key that would publish nothing while appearing to succeed).
- `no_task_constant_names_a_retired_verb` — rejects any retired verb reappearing in a task URI.
- `host_state_agrees_with_the_claim_direction` — cross-checks state against `claims_name`, so mapping `Disable` → `active` fails here instead of as a runtime `also_known_as_mismatch`.
- REST tests rewritten to the new contract; `remove` asserted to carry **no `state` key** (absent, not `null`).

`cargo fmt --check`, `clippy --all-targets`, and `check --workspace --all-targets` clean. 751 vta-service + 48 vta-webvh lib tests pass; 3 new vtc-service tests pass.

## Operator workaround until this ships

Point the VTA's webvh server record at the REST transport, or roll the daemon back to 0.8.2.

## Versions

vta-service 0.13.19 → 0.13.20, vta-webvh 0.1.1 → 0.1.2, vtc-service 0.11.46 → 0.11.47.