### PR TITLE
fix: REST auth signs again — DI-signed Trust Task across VTA, VTC, and the clients

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10333,7 +10333,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.13.20"
+version = "0.13.21"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",
@@ -10553,7 +10553,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-client"
-version = "0.1.5"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "reqwest 0.13.4",
@@ -10566,7 +10566,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-service"
-version = "0.11.47"
+version = "0.11.48"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",
@@ -10636,6 +10636,7 @@ dependencies = [
  "utoipa-axum",
  "uuid",
  "vta-sdk",
+ "vtc-client",
  "vtc-service",
  "vti-common",
  "vti-secrets",
@@ -10648,7 +10649,7 @@ dependencies = [
 
 [[package]]
 name = "vti-common"
-version = "0.11.30"
+version = "0.11.31"
 dependencies = [
  "aes-gcm",
  "affinidi-data-integrity",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10271,7 +10271,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.20.28"
+version = "0.20.29"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",

--- a/changelog.d/880-auth-light-di-signed.md
+++ b/changelog.d/880-auth-light-di-signed.md
@@ -1,0 +1,63 @@
+### vta-sdk 0.20.29 / vtc-client 0.1.6 — REST auth signs again: `auth_light` moves to the DI-signed Trust Task (#880)
+
+Every REST client authenticating through the SDK's lightweight tier was failing
+with `authentication failed: {"error":"authentication error: authenticate
+message must be an authenticated (authcrypt) DIDComm envelope"}`. Most visibly
+the VTC setup wizard, which degraded to "Could not reach the VTA to list
+did-hosting servers … the VTA will auto-select one (or self-host)" and skipped
+the server/domain picker entirely — so the operator silently lost control of
+where the community DID gets published.
+
+`auth_light` packed its `auth/authenticate/0.1` message as an **anoncrypt**
+DIDComm envelope (`didcomm_light::pack_auth_message`) and discarded the caller's
+private key: the sender was merely *asserted* in a plaintext `from` header. VTI
+#771 correctly closed that hole by requiring an authenticated (authcrypt)
+envelope on `/auth/` and `/auth/refresh` — which rejects every anoncrypt message,
+so the whole tier had been dead since. It surfaced now because the VTC wizard is
+the one caller with no fallback; `integration::auth::try_rest` had been quietly
+absorbing it by dropping to the heavyweight ATM path.
+
+The fix is the transport the VTA already prefers and tries **first**: a
+`auth/authenticate/0.1` Trust Task carrying the holder's `eddsa-jcs-2022`
+Data-Integrity proof, where the signature *is* the authentication. No mediator,
+no ATM, works against a REST-only VTA, and the key the caller already holds now
+proves the sender instead of a header claiming it.
+
+- **New `vta_sdk::auth_di`** (feature `client`): `sign_authenticate_doc`,
+  `build_refresh_doc`, `parse_auth_response`. `provision_client::auth_rest`,
+  which had the only working copy of this logic, now builds its documents here
+  too — the two transports can't drift apart again.
+- `challenge_response_light` and `refresh_token_light` keep their signatures;
+  callers (`VtaClient` re-auth + auto-refresh, `vtc-client`, the VTC setup
+  wizard, `integration::auth::try_rest`) need no change.
+- `refresh_token_light` posts an *unsigned* `auth/refresh/0.1` Trust Task: the
+  opaque refresh token is the bearer credential (RFC 6749 §10.4), which is what
+  the VTA's refresh path verifies.
+- Both now accept either response shape — the Trust-Task `#response` document
+  the server returns to a Trust-Task request, or flat JSON.
+- The VTA resolves the proof's verification method with a `did:key`-only
+  resolver, so **`challenge_response_light` now requires a `did:key` holder** and
+  returns `VtaError::Validation` for any other method (refused locally, before a
+  round trip). Callers holding another DID method need
+  `session::challenge_response` over DIDComm authcrypt — the fallback
+  `integration::auth::try_rest` already takes.
+- Conversely the VTA's DID is no longer resolved by the client at all — it is
+  just the document's `recipient` — so the `did:webvh` log fetch that preceded
+  every login is gone.
+- `didcomm_light` is documented as unusable for `/auth/*` and left in place for
+  any consumer packing anoncrypt on a non-auth surface.
+
+**Known gap, unchanged by this PR (`vtc-client` 0.1.6, docs only).** The VTC's
+`POST /auth/` accepts a VTA-wallet SIOP envelope or an authcrypt DIDComm
+envelope, and has no Trust-Task login path — only its `/auth/refresh` does. So
+`VtcClient::connect`, which borrows the VTA SDK's flow, still cannot authenticate
+against a live VTC; it has been unable to since #771 rejected the anoncrypt
+envelope it used to send, and this change only alters which error comes back.
+Documented on the crate root, with `with_token` as the interim route. Giving the
+VTC the same DI-signed login path as the VTA is the fix and is not attempted
+here.
+
+Regression cover: `vta-service/tests/auth_flow.rs` drives the real `/auth/` route
+with the SDK's own document (login succeeds; a challenge swapped after signing is
+rejected 401), so a client-side builder that drifts from what the route accepts
+fails the build rather than the operator's setup run.

--- a/changelog.d/880-auth-light-di-signed.md
+++ b/changelog.d/880-auth-light-di-signed.md
@@ -92,6 +92,11 @@ faults that each hid behind the others:
   from this method's signature and is driven today by `vta-cli-common` /
   `vta-mobile-core`.
 
+  Its HTTP client also had no timeouts (R1.2) — a blackholed VTC hung the caller
+  forever. It now uses `vta_sdk::http::rest_client`, which is promoted from
+  `pub(crate)` to `pub` so sibling client crates share that one chokepoint
+  instead of each reaching for `reqwest::Client::new()`.
+
 **Regression cover.** The gap that let all of this accumulate was that no test
 ever ran a client and its server together — client tests stubbed the server,
 server tests hand-wrote the request. Three suites now close that:

--- a/changelog.d/880-auth-light-di-signed.md
+++ b/changelog.d/880-auth-light-di-signed.md
@@ -36,9 +36,12 @@ proves the sender instead of a header claiming it.
   `refresh::Payload`) rather than hand-written JSON, so wire casing can't drift
   (R3.1) and the spec's own validation runs client-side — a short challenge is
   now a clear local error instead of a 401.
-- Both paths **send the `Trust-Task` URL header**. The VTA ignores it; the VTC
-  gates every route on it and answers 400 without it, so its absence made this
-  client VTC-incompatible at the transport layer regardless of the body.
+- **All three REST auth paths now send the `Trust-Task` URL header** —
+  `auth_light`, `provision_client::auth_rest`, and `session::challenge_response`
+  (the authcrypt-DIDComm-over-REST path `cnm`'s VTC backup authenticates
+  through). The VTA ignores it; the VTC gates every route on it and answers 400
+  without it, so its absence made these clients VTC-incompatible at the
+  transport layer regardless of the body.
 - `refresh_token_light` posts an *unsigned* `auth/refresh/0.1` Trust Task: the
   opaque refresh token is the bearer credential (RFC 6749 §10.4).
 - Both accept either response shape — the Trust-Task `#response` document or

--- a/changelog.d/880-auth-light-di-signed.md
+++ b/changelog.d/880-auth-light-di-signed.md
@@ -1,4 +1,4 @@
-### vta-sdk 0.20.29 / vtc-client 0.1.6 — REST auth signs again: `auth_light` moves to the DI-signed Trust Task (#880)
+### vta-sdk 0.20.29 / vti-common 0.11.31 / vta-service 0.13.21 / vtc-service 0.11.48 / vtc-client 0.2.0 — REST auth signs again, and the VTC accepts it (#880)
 
 Every REST client authenticating through the SDK's lightweight tier was failing
 with `authentication failed: {"error":"authentication error: authenticate
@@ -23,6 +23,8 @@ Data-Integrity proof, where the signature *is* the authentication. No mediator,
 no ATM, works against a REST-only VTA, and the key the caller already holds now
 proves the sender instead of a header claiming it.
 
+**vta-sdk**
+
 - **New `vta_sdk::auth_di`** (feature `client`): `sign_authenticate_doc`,
   `build_refresh_doc`, `parse_auth_response`. `provision_client::auth_rest`,
   which had the only working copy of this logic, now builds its documents here
@@ -30,34 +32,70 @@ proves the sender instead of a header claiming it.
 - `challenge_response_light` and `refresh_token_light` keep their signatures;
   callers (`VtaClient` re-auth + auto-refresh, `vtc-client`, the VTC setup
   wizard, `integration::auth::try_rest`) need no change.
+- Payloads are built from the **generated spec types** (`authenticate::Payload`,
+  `refresh::Payload`) rather than hand-written JSON, so wire casing can't drift
+  (R3.1) and the spec's own validation runs client-side — a short challenge is
+  now a clear local error instead of a 401.
+- Both paths **send the `Trust-Task` URL header**. The VTA ignores it; the VTC
+  gates every route on it and answers 400 without it, so its absence made this
+  client VTC-incompatible at the transport layer regardless of the body.
 - `refresh_token_light` posts an *unsigned* `auth/refresh/0.1` Trust Task: the
-  opaque refresh token is the bearer credential (RFC 6749 §10.4), which is what
-  the VTA's refresh path verifies.
-- Both now accept either response shape — the Trust-Task `#response` document
-  the server returns to a Trust-Task request, or flat JSON.
-- The VTA resolves the proof's verification method with a `did:key`-only
-  resolver, so **`challenge_response_light` now requires a `did:key` holder** and
-  returns `VtaError::Validation` for any other method (refused locally, before a
-  round trip). Callers holding another DID method need
-  `session::challenge_response` over DIDComm authcrypt — the fallback
-  `integration::auth::try_rest` already takes.
+  opaque refresh token is the bearer credential (RFC 6749 §10.4).
+- Both accept either response shape — the Trust-Task `#response` document or
+  flat JSON.
+- The server resolves the proof's verification method with a `did:key`-only
+  resolver, so **`challenge_response_light` now requires a `did:key` holder**
+  and returns `VtaError::Validation` for any other method, refused locally
+  before a round trip. Other methods need `session::challenge_response` over
+  DIDComm authcrypt — the fallback `integration::auth::try_rest` already takes.
 - Conversely the VTA's DID is no longer resolved by the client at all — it is
   just the document's `recipient` — so the `did:webvh` log fetch that preceded
   every login is gone.
 - `didcomm_light` is documented as unusable for `/auth/*` and left in place for
   any consumer packing anoncrypt on a non-auth surface.
 
-**Known gap, unchanged by this PR (`vtc-client` 0.1.6, docs only).** The VTC's
-`POST /auth/` accepts a VTA-wallet SIOP envelope or an authcrypt DIDComm
-envelope, and has no Trust-Task login path — only its `/auth/refresh` does. So
-`VtcClient::connect`, which borrows the VTA SDK's flow, still cannot authenticate
-against a live VTC; it has been unable to since #771 rejected the anoncrypt
-envelope it used to send, and this change only alters which error comes back.
-Documented on the crate root, with `with_token` as the interim route. Giving the
-VTC the same DI-signed login path as the VTA is the fix and is not attempted
-here.
+**vti-common / vta-service** — the Trust-Task DI-proof verifier moves to
+`vti_common::auth::di_proof`. It had already drifted into two copies inside the
+VTA and a third when the VTC ported it; both services verify the same holder
+proof over the same wire shape, so a divergence between them is a divergence in
+what a signature *means*. `vta_service::auth::di_proof` is re-exported at its
+original path — no VTA call site changes.
 
-Regression cover: `vta-service/tests/auth_flow.rs` drives the real `/auth/` route
-with the SDK's own document (login succeeds; a challenge swapped after signing is
-rejected 401), so a client-side builder that drifts from what the route accepts
-fails the build rather than the operator's setup run.
+**vtc-service** — `POST /auth/` gains the DI-signed Trust-Task login path,
+tried after SIOP and before the DIDComm envelope. A body is claimed only when it
+parses as a Trust Task, carries the authenticate Type URI, **and** has a `proof`
+— the proof requirement is what keeps it from shadowing the SIOP envelope, which
+shares that URI. `/auth/refresh` had grown this path already; login had not,
+which left a client able to *rotate* a token it had no way to obtain.
+
+**vtc-client 0.2.0** — was broken on **every** route, by three independent
+faults that each hid behind the others:
+
+1. `connect` sent the anoncrypt envelope above (fixed by the SDK + the VTC's new
+   login path).
+2. Nothing sent the mandatory `Trust-Task` header, so every call 400'd before
+   reaching a handler. All requests now go through one `tt(...)` helper, with the
+   per-route URLs collected in a `task` module that can be read against the
+   server's router in one pass.
+3. `approve_join` / `reject_join` posted to `/approve` + `/reject` mounts that
+   were replaced by a single `/decide` endpoint carrying the decision in the
+   body, and `submit_join` posted to a route that is **no longer mounted at all**
+   — the holder-facing join verbs moved to the Trust-Task document endpoint.
+
+  Breaking: `reject_join` takes an optional `reason` (the `/decide` body carries
+  it). `submit_join` now returns a typed `VtcError::Unsupported` naming the
+  endpoint that replaced it, rather than issuing a silent 404 — submitting needs
+  the applicant's holder key to sign a Trust Task, which is a different shape
+  from this method's signature and is driven today by `vta-cli-common` /
+  `vta-mobile-core`.
+
+**Regression cover.** The gap that let all of this accumulate was that no test
+ever ran a client and its server together — client tests stubbed the server,
+server tests hand-wrote the request. Three suites now close that:
+`vta-service/tests/auth_flow.rs` and `vtc-service/tests/auth_di_trust_task.rs`
+drive each service's real `/auth/` route with the SDK's own document (login
+succeeds; a challenge swapped in after signing is refused 401; an unsigned
+document falls through rather than being claimed), and
+`vtc-service/tests/vtc_client_live.rs` drives `vtc-client` against a live
+`MockVtc`. A builder that drifts from what the route accepts now fails the
+build rather than an operator's setup run.

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.20.28"
+version = "0.20.29"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -70,6 +70,13 @@ client = [
   "dep:uuid",
   "dep:affinidi-tdk",
   "dep:affinidi-messaging-didcomm",
+  # `auth_di` — the canonical REST auth transport. The VTA requires an
+  # *authenticated* sender on `/auth/*` (VTI #771), so the client signs an
+  # `auth/authenticate/0.1` Trust Task with the holder key: the DI suite
+  # signs, `Secret` carries the key, `trust-tasks-rs` is the document shape.
+  "dep:affinidi-data-integrity",
+  "dep:affinidi-secrets-resolver",
+  "dep:trust-tasks-rs",
   # didcomm 0.15 moved `PublicKeyAgreement` out of
   # `affinidi_messaging_didcomm::crypto` into `affinidi_crypto::jose`.
   # `didcomm_light::pack_anoncrypt` (gated on `client`) names that type,

--- a/vta-sdk/src/auth_di.rs
+++ b/vta-sdk/src/auth_di.rs
@@ -19,7 +19,8 @@
 //! instead of a header asserting it.
 //!
 //! Server-side the proof is verified with a **`did:key` resolver**
-//! (`vta-service/src/auth/di_proof.rs`), so [`sign_authenticate_doc`] refuses
+//! (`vti-common/src/auth/di_proof.rs`, shared by the VTA and the VTC), so
+//! [`sign_authenticate_doc`] refuses
 //! any other DID method up front rather than letting the VTA reject it after a
 //! round trip.
 //!
@@ -30,7 +31,9 @@
 use affinidi_data_integrity::{DataIntegrityProof, SignOptions};
 use affinidi_secrets_resolver::secrets::Secret;
 use chrono::Utc;
-use serde_json::{Value, json};
+use serde_json::Value;
+use trust_tasks_rs::specs::auth::authenticate::v0_1 as authenticate;
+use trust_tasks_rs::specs::auth::refresh::v0_1 as refresh;
 use trust_tasks_rs::{Proof, TrustTask};
 
 use crate::did_key::decode_private_key_multibase;
@@ -48,6 +51,9 @@ pub enum AuthDiError {
     NotDidKey(String),
     /// The holder's private key could not be decoded from its multibase form.
     BadPrivateKey(String),
+    /// A payload field failed the spec type's own validation (e.g. an empty
+    /// challenge or refresh token) — caught here rather than by the server.
+    Payload(String),
     /// Signing the document failed.
     Sign(String),
     /// The Trust Task type URI failed to parse. Unreachable in practice — the
@@ -67,6 +73,7 @@ impl std::fmt::Display for AuthDiError {
                 "DI-signed REST authentication requires a did:key holder; got {did}"
             ),
             Self::BadPrivateKey(e) => write!(f, "decode holder private key: {e}"),
+            Self::Payload(e) => write!(f, "invalid auth payload: {e}"),
             Self::Sign(e) => write!(f, "sign authenticate Trust Task: {e}"),
             Self::TypeUri(e) => write!(f, "Trust Task type URI parse: {e}"),
             Self::Response(e) => write!(f, "unexpected auth response from VTA: {e}"),
@@ -86,9 +93,12 @@ fn did_key_to_vm(did: &str) -> Option<String> {
 /// Build and sign an `auth/authenticate/0.1` Trust Task, returning the JSON
 /// body to POST to `/auth/`.
 ///
-/// `challenge` / `session_id` come from `/auth/challenge`. The payload is
-/// camelCase (`sessionId`) to match the spec `authenticate::Payload` the server
-/// deserializes *after* verifying the proof.
+/// `challenge` / `session_id` come from `/auth/challenge`. The payload is built
+/// from the **generated spec type** (`authenticate::Payload`) rather than
+/// hand-written JSON, so its wire casing (`sessionId`) is whatever the spec says
+/// and cannot drift: the server deserializes into that same type with
+/// `deny_unknown_fields`, and R3.1 casing drift is the recurring class that
+/// silently breaks these bodies. It is also the shape `vta-mobile-core` emits.
 ///
 /// The proof is attached over the **proof-less** document: `eddsa-jcs-2022`
 /// canonicalises with JCS, which is presence-sensitive, and the server verifies
@@ -100,9 +110,17 @@ pub async fn sign_authenticate_doc(
     challenge: &str,
     session_id: &str,
 ) -> Result<String, AuthDiError> {
+    let payload = authenticate::Payload {
+        challenge: authenticate::PayloadChallenge::try_from(challenge.to_string())
+            .map_err(|e| AuthDiError::Payload(format!("challenge: {e}")))?,
+        session_id: authenticate::PayloadSessionId::try_from(session_id.to_string())
+            .map_err(|e| AuthDiError::Payload(format!("sessionId: {e}")))?,
+        scope: Vec::new(),
+        ext: None,
+    };
     let mut doc = new_doc(
         TASK_AUTH_AUTHENTICATE_0_1,
-        json!({ "challenge": challenge, "sessionId": session_id }),
+        serde_json::to_value(&payload).map_err(|e| AuthDiError::Payload(e.to_string()))?,
         client_did,
         vta_did,
     )?;
@@ -146,14 +164,23 @@ pub async fn sign_authenticate_doc(
 /// refresh path passes `signer_did: None` and verifies no proof. That also
 /// means refresh works for a holder of any DID method, unlike
 /// [`sign_authenticate_doc`].
+///
+/// Payload built from the generated `refresh::Payload` for the same
+/// casing-can't-drift reason as [`sign_authenticate_doc`].
 pub fn build_refresh_doc(
     client_did: &str,
     vta_did: &str,
     refresh_token: &str,
 ) -> Result<String, AuthDiError> {
+    let payload = refresh::Payload {
+        refresh_token: refresh::PayloadRefreshToken::try_from(refresh_token.to_string())
+            .map_err(|e| AuthDiError::Payload(format!("refreshToken: {e}")))?,
+        scope: Vec::new(),
+        ext: None,
+    };
     let doc = new_doc(
         TASK_AUTH_REFRESH_0_1,
-        json!({ "refreshToken": refresh_token }),
+        serde_json::to_value(&payload).map_err(|e| AuthDiError::Payload(e.to_string()))?,
         client_did,
         vta_did,
     )?;
@@ -202,6 +229,12 @@ fn new_doc(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
+
+    /// A challenge shaped like the real thing — the canonical handler issues
+    /// hex-encoded 32 random bytes, and the spec type enforces `minLength: 16`,
+    /// so a toy `"c"` is not a valid fixture.
+    const CHALLENGE: &str = "a3f1c09b7e2d4856a3f1c09b7e2d4856";
 
     /// A deterministic `did:key` + its multibase private key.
     fn did_key_from_seed(seed_byte: u8) -> (String, String) {
@@ -222,13 +255,13 @@ mod tests {
     #[tokio::test]
     async fn authenticate_doc_is_signed_and_camel_cased() {
         let (did, pk) = did_key_from_seed(0x11);
-        let body = sign_authenticate_doc(&did, &pk, "did:key:z6MkVta", "c-nonce", "sess-1")
+        let body = sign_authenticate_doc(&did, &pk, "did:key:z6MkVta", CHALLENGE, "sess-1")
             .await
             .expect("sign");
         let v: Value = serde_json::from_str(&body).unwrap();
 
         assert_eq!(v["type"], TASK_AUTH_AUTHENTICATE_0_1);
-        assert_eq!(v["payload"]["challenge"], "c-nonce");
+        assert_eq!(v["payload"]["challenge"], CHALLENGE);
         assert_eq!(v["payload"]["sessionId"], "sess-1");
         assert_eq!(v["issuer"], did);
         assert_eq!(v["recipient"], "did:key:z6MkVta");
@@ -246,14 +279,14 @@ mod tests {
     }
 
     /// The proof verifies under the same `did:key` resolver the VTA uses
-    /// (`vta-service/src/auth/di_proof.rs`) — i.e. the document the client
+    /// (`vti-common/src/auth/di_proof.rs`) — i.e. the document the client
     /// emits is one the server actually accepts.
     #[tokio::test]
     async fn signed_doc_verifies_under_did_key_resolver() {
         use affinidi_data_integrity::{DidKeyResolver, VerifyOptions};
 
         let (did, pk) = did_key_from_seed(0x22);
-        let body = sign_authenticate_doc(&did, &pk, "did:key:z6MkVta", "c", "s")
+        let body = sign_authenticate_doc(&did, &pk, "did:key:z6MkVta", CHALLENGE, "sess-1")
             .await
             .expect("sign");
         let doc: TrustTask<Value> = serde_json::from_str(&body).unwrap();
@@ -276,11 +309,11 @@ mod tests {
         use affinidi_data_integrity::{DidKeyResolver, VerifyOptions};
 
         let (did, pk) = did_key_from_seed(0x33);
-        let body = sign_authenticate_doc(&did, &pk, "did:key:z6MkVta", "c", "s")
+        let body = sign_authenticate_doc(&did, &pk, "did:key:z6MkVta", CHALLENGE, "sess-1")
             .await
             .expect("sign");
         let mut doc: TrustTask<Value> = serde_json::from_str(&body).unwrap();
-        doc.payload = json!({ "challenge": "attacker-nonce", "sessionId": "s" });
+        doc.payload = json!({ "challenge": "attacker-nonce-0000000000", "sessionId": "sess-1" });
 
         let proof: DataIntegrityProof =
             serde_json::from_value(serde_json::to_value(doc.proof.as_ref().unwrap()).unwrap())
@@ -301,9 +334,15 @@ mod tests {
     #[tokio::test]
     async fn non_did_key_holder_is_refused() {
         let (_, pk) = did_key_from_seed(0x44);
-        let err = sign_authenticate_doc("did:web:example.com", &pk, "did:key:z6MkVta", "c", "s")
-            .await
-            .expect_err("did:web holder must be refused");
+        let err = sign_authenticate_doc(
+            "did:web:example.com",
+            &pk,
+            "did:key:z6MkVta",
+            CHALLENGE,
+            "sess-1",
+        )
+        .await
+        .expect_err("did:web holder must be refused");
         assert!(matches!(err, AuthDiError::NotDidKey(_)), "got {err:?}");
     }
 

--- a/vta-sdk/src/auth_di.rs
+++ b/vta-sdk/src/auth_di.rs
@@ -1,0 +1,358 @@
+//! Shared building blocks for the **canonical REST auth transport**: a
+//! `auth/authenticate/0.1` Trust Task whose holder `eddsa-jcs-2022`
+//! Data-Integrity proof *is* the authentication, and its unsigned
+//! `auth/refresh/0.1` counterpart.
+//!
+//! Why this exists rather than a DIDComm envelope: the VTA's `/auth/` and
+//! `/auth/refresh` routes try the Trust-Task document **before** the
+//! DIDComm-envelope path (`vta-service/src/routes/auth.rs::
+//! try_authenticate_trust_task`), so this transport works against a REST-only
+//! VTA (no mediator / ATM) as well as a DIDComm-enabled one — and it *signs*,
+//! which the envelope path now requires of everyone.
+//!
+//! The historical alternative — `didcomm_light`'s **anoncrypt** envelope —
+//! carried an unauthenticated plaintext `from`. The VTA hardened `/auth/*` to
+//! require authcrypt (`vti_common::auth::bind_authcrypt_sender`, VTI #771), so
+//! an anoncrypt envelope is now rejected outright with "authenticate message
+//! must be an authenticated (authcrypt) DIDComm envelope". Signing with the
+//! holder key is the fix — the key the caller already holds proves the sender
+//! instead of a header asserting it.
+//!
+//! Server-side the proof is verified with a **`did:key` resolver**
+//! (`vta-service/src/auth/di_proof.rs`), so [`sign_authenticate_doc`] refuses
+//! any other DID method up front rather than letting the VTA reject it after a
+//! round trip.
+//!
+//! Both [`crate::auth_light`] (the REST client tier) and
+//! [`crate::provision_client::auth_rest`] build their documents here so the two
+//! can't drift.
+
+use affinidi_data_integrity::{DataIntegrityProof, SignOptions};
+use affinidi_secrets_resolver::secrets::Secret;
+use chrono::Utc;
+use serde_json::{Value, json};
+use trust_tasks_rs::{Proof, TrustTask};
+
+use crate::did_key::decode_private_key_multibase;
+use crate::protocols::auth::AuthenticateResponse;
+use crate::trust_tasks::{TASK_AUTH_AUTHENTICATE_0_1, TASK_AUTH_REFRESH_0_1};
+
+/// Why building or reading a DI-signed auth document failed.
+///
+/// Deliberately narrow: transport errors belong to the caller, which owns the
+/// HTTP client and its error type.
+#[derive(Debug)]
+pub enum AuthDiError {
+    /// The holder DID is not a `did:key`. The server verifies the proof with a
+    /// `did:key`-only resolver, so no other method can authenticate this way.
+    NotDidKey(String),
+    /// The holder's private key could not be decoded from its multibase form.
+    BadPrivateKey(String),
+    /// Signing the document failed.
+    Sign(String),
+    /// The Trust Task type URI failed to parse. Unreachable in practice — the
+    /// URIs are `const`s from [`crate::trust_tasks`] — but not worth an
+    /// `unwrap` on a client's auth path.
+    TypeUri(String),
+    /// The VTA's response was neither a flat `AuthenticateResponse` nor a
+    /// Trust-Task `#response` document wrapping one.
+    Response(String),
+}
+
+impl std::fmt::Display for AuthDiError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotDidKey(did) => write!(
+                f,
+                "DI-signed REST authentication requires a did:key holder; got {did}"
+            ),
+            Self::BadPrivateKey(e) => write!(f, "decode holder private key: {e}"),
+            Self::Sign(e) => write!(f, "sign authenticate Trust Task: {e}"),
+            Self::TypeUri(e) => write!(f, "Trust Task type URI parse: {e}"),
+            Self::Response(e) => write!(f, "unexpected auth response from VTA: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for AuthDiError {}
+
+/// The `did:key:zXxx#zXxx` verification-method id the Data-Integrity resolver
+/// recognises for a `did:key` holder.
+fn did_key_to_vm(did: &str) -> Option<String> {
+    let mb = did.strip_prefix("did:key:")?;
+    Some(format!("{did}#{mb}"))
+}
+
+/// Build and sign an `auth/authenticate/0.1` Trust Task, returning the JSON
+/// body to POST to `/auth/`.
+///
+/// `challenge` / `session_id` come from `/auth/challenge`. The payload is
+/// camelCase (`sessionId`) to match the spec `authenticate::Payload` the server
+/// deserializes *after* verifying the proof.
+///
+/// The proof is attached over the **proof-less** document: `eddsa-jcs-2022`
+/// canonicalises with JCS, which is presence-sensitive, and the server verifies
+/// against the same shape with `proof` stripped.
+pub async fn sign_authenticate_doc(
+    client_did: &str,
+    private_key_multibase: &str,
+    vta_did: &str,
+    challenge: &str,
+    session_id: &str,
+) -> Result<String, AuthDiError> {
+    let mut doc = new_doc(
+        TASK_AUTH_AUTHENTICATE_0_1,
+        json!({ "challenge": challenge, "sessionId": session_id }),
+        client_did,
+        vta_did,
+    )?;
+
+    let vm_id =
+        did_key_to_vm(client_did).ok_or_else(|| AuthDiError::NotDidKey(client_did.into()))?;
+    let seed = decode_private_key_multibase(private_key_multibase)
+        .map_err(|e| AuthDiError::BadPrivateKey(e.to_string()))?;
+    let mut signer = Secret::generate_ed25519(Some(&vm_id), Some(&seed));
+    signer.id = vm_id;
+
+    let mut signing_doc =
+        serde_json::to_value(&doc).map_err(|e| AuthDiError::Sign(e.to_string()))?;
+    if let Some(obj) = signing_doc.as_object_mut() {
+        obj.remove("proof");
+    }
+    let di_proof = DataIntegrityProof::sign(
+        &signing_doc,
+        &signer,
+        SignOptions::new()
+            .with_proof_purpose("assertionMethod")
+            .with_created(Utc::now()),
+    )
+    .await
+    .map_err(|e| AuthDiError::Sign(e.to_string()))?;
+    let proof_json =
+        serde_json::to_value(&di_proof).map_err(|e| AuthDiError::Sign(e.to_string()))?;
+    doc.proof = Some(
+        serde_json::from_value::<Proof>(proof_json)
+            .map_err(|e| AuthDiError::Sign(e.to_string()))?,
+    );
+
+    serde_json::to_string(&doc).map_err(|e| AuthDiError::Sign(e.to_string()))
+}
+
+/// Build an `auth/refresh/0.1` Trust Task, returning the JSON body to POST to
+/// `/auth/refresh`.
+///
+/// **Unsigned by design.** The opaque refresh token in the payload *is* the
+/// bearer credential (RFC 6749 §10.4 rotation), so the server's Trust-Task
+/// refresh path passes `signer_did: None` and verifies no proof. That also
+/// means refresh works for a holder of any DID method, unlike
+/// [`sign_authenticate_doc`].
+pub fn build_refresh_doc(
+    client_did: &str,
+    vta_did: &str,
+    refresh_token: &str,
+) -> Result<String, AuthDiError> {
+    let doc = new_doc(
+        TASK_AUTH_REFRESH_0_1,
+        json!({ "refreshToken": refresh_token }),
+        client_did,
+        vta_did,
+    )?;
+    serde_json::to_string(&doc).map_err(|e| AuthDiError::Sign(e.to_string()))
+}
+
+/// Parse an `/auth/` or `/auth/refresh` response body.
+///
+/// A Trust-Task request yields a Trust-Task `#response` document whose payload
+/// is the `{ session, tokens }` body; flat JSON is still what the older
+/// DIDComm-envelope path returns, and some mocks emit it. Accept either.
+pub fn parse_auth_response(body: &str) -> Result<AuthenticateResponse, AuthDiError> {
+    if let Ok(flat) = serde_json::from_str::<AuthenticateResponse>(body) {
+        return Ok(flat);
+    }
+    let doc: TrustTask<Value> = serde_json::from_str(body)
+        .map_err(|e| AuthDiError::Response(format!("{e} (is this a VTA?)")))?;
+    serde_json::from_value(doc.payload)
+        .map_err(|e| AuthDiError::Response(format!("payload is not an AuthenticateResponse: {e}")))
+}
+
+/// A Trust Task addressed from the holder to the VTA, with a fresh id.
+///
+/// `recipient` is always set: SPEC §4.8.2 audience binding rejects a *signed*
+/// document with no in-band recipient, and it costs nothing on the unsigned
+/// refresh document.
+fn new_doc(
+    type_uri: &str,
+    payload: Value,
+    client_did: &str,
+    vta_did: &str,
+) -> Result<TrustTask<Value>, AuthDiError> {
+    let mut doc: TrustTask<Value> = TrustTask::new(
+        format!("urn:uuid:{}", uuid::Uuid::new_v4()),
+        type_uri
+            .parse()
+            .map_err(|e| AuthDiError::TypeUri(format!("{e}")))?,
+        payload,
+    );
+    doc.issuer = Some(client_did.to_string());
+    doc.recipient = Some(vta_did.to_string());
+    doc.issued_at = Some(Utc::now());
+    Ok(doc)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A deterministic `did:key` + its multibase private key.
+    fn did_key_from_seed(seed_byte: u8) -> (String, String) {
+        let seed = [seed_byte; 32];
+        let sk = ed25519_dalek::SigningKey::from_bytes(&seed);
+        let did = format!(
+            "did:key:{}",
+            crate::did_key::ed25519_multibase_pubkey(&sk.verifying_key().to_bytes())
+        );
+        let mut buf = vec![0x80, 0x26];
+        buf.extend_from_slice(&seed);
+        (did, multibase::encode(multibase::Base::Base58Btc, &buf))
+    }
+
+    /// The signed document carries the camelCase payload the server's typed
+    /// `authenticate::Payload` expects, and an `eddsa-jcs-2022` proof whose
+    /// verification method is the holder's `did:key` VM id.
+    #[tokio::test]
+    async fn authenticate_doc_is_signed_and_camel_cased() {
+        let (did, pk) = did_key_from_seed(0x11);
+        let body = sign_authenticate_doc(&did, &pk, "did:key:z6MkVta", "c-nonce", "sess-1")
+            .await
+            .expect("sign");
+        let v: Value = serde_json::from_str(&body).unwrap();
+
+        assert_eq!(v["type"], TASK_AUTH_AUTHENTICATE_0_1);
+        assert_eq!(v["payload"]["challenge"], "c-nonce");
+        assert_eq!(v["payload"]["sessionId"], "sess-1");
+        assert_eq!(v["issuer"], did);
+        assert_eq!(v["recipient"], "did:key:z6MkVta");
+        assert_eq!(v["proof"]["cryptosuite"], "eddsa-jcs-2022");
+        assert_eq!(
+            v["proof"]["verificationMethod"],
+            format!("{did}#{}", did.strip_prefix("did:key:").unwrap())
+        );
+        assert!(
+            v["proof"]["proofValue"]
+                .as_str()
+                .is_some_and(|s| !s.is_empty()),
+            "proof carries no proofValue"
+        );
+    }
+
+    /// The proof verifies under the same `did:key` resolver the VTA uses
+    /// (`vta-service/src/auth/di_proof.rs`) — i.e. the document the client
+    /// emits is one the server actually accepts.
+    #[tokio::test]
+    async fn signed_doc_verifies_under_did_key_resolver() {
+        use affinidi_data_integrity::{DidKeyResolver, VerifyOptions};
+
+        let (did, pk) = did_key_from_seed(0x22);
+        let body = sign_authenticate_doc(&did, &pk, "did:key:z6MkVta", "c", "s")
+            .await
+            .expect("sign");
+        let doc: TrustTask<Value> = serde_json::from_str(&body).unwrap();
+
+        let proof: DataIntegrityProof =
+            serde_json::from_value(serde_json::to_value(doc.proof.as_ref().unwrap()).unwrap())
+                .expect("proof round-trips into a DataIntegrityProof");
+        let mut unsigned = doc.clone();
+        unsigned.proof = None;
+        proof
+            .verify(&unsigned, &DidKeyResolver, VerifyOptions::new())
+            .await
+            .expect("server-side verification must succeed");
+    }
+
+    /// Tampering with the payload after signing invalidates the proof — the
+    /// signature covers the document, not just its presence.
+    #[tokio::test]
+    async fn tampered_payload_fails_verification() {
+        use affinidi_data_integrity::{DidKeyResolver, VerifyOptions};
+
+        let (did, pk) = did_key_from_seed(0x33);
+        let body = sign_authenticate_doc(&did, &pk, "did:key:z6MkVta", "c", "s")
+            .await
+            .expect("sign");
+        let mut doc: TrustTask<Value> = serde_json::from_str(&body).unwrap();
+        doc.payload = json!({ "challenge": "attacker-nonce", "sessionId": "s" });
+
+        let proof: DataIntegrityProof =
+            serde_json::from_value(serde_json::to_value(doc.proof.as_ref().unwrap()).unwrap())
+                .unwrap();
+        let mut unsigned = doc.clone();
+        unsigned.proof = None;
+        assert!(
+            proof
+                .verify(&unsigned, &DidKeyResolver, VerifyOptions::new())
+                .await
+                .is_err(),
+            "a tampered challenge must not verify"
+        );
+    }
+
+    /// A non-`did:key` holder is refused locally rather than after a round trip
+    /// the VTA's `did:key`-only verifier would reject anyway.
+    #[tokio::test]
+    async fn non_did_key_holder_is_refused() {
+        let (_, pk) = did_key_from_seed(0x44);
+        let err = sign_authenticate_doc("did:web:example.com", &pk, "did:key:z6MkVta", "c", "s")
+            .await
+            .expect_err("did:web holder must be refused");
+        assert!(matches!(err, AuthDiError::NotDidKey(_)), "got {err:?}");
+    }
+
+    /// Refresh carries the token in a camelCase payload and no proof.
+    #[test]
+    fn refresh_doc_is_unsigned_and_camel_cased() {
+        let body = build_refresh_doc("did:key:z6MkHolder", "did:key:z6MkVta", "tok-1").unwrap();
+        let v: Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(v["type"], TASK_AUTH_REFRESH_0_1);
+        assert_eq!(v["payload"]["refreshToken"], "tok-1");
+        assert!(
+            v.get("proof").is_none_or(Value::is_null),
+            "refresh must not be signed"
+        );
+    }
+
+    /// Both response shapes parse: the Trust-Task `#response` envelope the
+    /// server returns to a Trust-Task request, and flat JSON.
+    #[test]
+    fn parses_flat_and_trust_task_responses() {
+        let tokens = json!({
+            "session": {
+                "id": "sess", "subject": "did:key:z6MkHolder",
+                "issuedAt": "1970-01-01T00:00:00Z", "expiresAt": "2099-12-31T23:59:59Z",
+                "amr": ["did"], "acr": "aal1"
+            },
+            "tokens": {
+                "accessToken": "acc", "tokenType": "Bearer", "expiresIn": 900_u64
+            }
+        });
+
+        let flat = parse_auth_response(&tokens.to_string()).expect("flat");
+        assert_eq!(flat.tokens.access_token, "acc");
+
+        let wrapped = json!({
+            "id": "urn:uuid:1",
+            "type": "https://trusttasks.org/spec/auth/authenticate/0.1#response",
+            "payload": tokens,
+        });
+        let unwrapped = parse_auth_response(&wrapped.to_string()).expect("trust-task");
+        assert_eq!(unwrapped.tokens.access_token, "acc");
+    }
+
+    /// Anything else is a typed error, not a panic or a silent default.
+    #[test]
+    fn rejects_unrecognisable_response() {
+        assert!(matches!(
+            parse_auth_response("<html>not a VTA</html>"),
+            Err(AuthDiError::Response(_))
+        ));
+    }
+}

--- a/vta-sdk/src/auth_light.rs
+++ b/vta-sdk/src/auth_light.rs
@@ -29,6 +29,19 @@ use crate::error::VtaError;
 use crate::protocols::auth::{ChallengeRequest, ChallengeResponse};
 use reqwest::Client;
 
+/// The per-request Trust-Task URL header.
+///
+/// The **VTC gates every route on it** (`vtc-service/src/routes/mod.rs`, the
+/// `tt(...)` wrapper) and answers 400 without it; the VTA does not read it. So
+/// omitting it made this client VTC-incompatible at the *transport* layer,
+/// independently of the body — `vtc-client::connect` could not even reach the
+/// authenticate handler. Sending it on every call is what lets one auth client
+/// speak to both services.
+///
+/// Not sent on the VTC's `/wallet/auth/*` aliases, which are deliberately
+/// header-exempt for the browser extension; those aren't this client's paths.
+const TRUST_TASK_HEADER: &str = "Trust-Task";
+
 /// Result of a successful authentication.
 #[derive(Debug, Clone)]
 pub struct AuthResult {
@@ -56,6 +69,10 @@ pub async fn challenge_response_light(
     let challenge_url = format!("{base_url}/auth/challenge");
     let challenge_resp = http
         .post(&challenge_url)
+        .header(
+            TRUST_TASK_HEADER,
+            crate::trust_tasks::TASK_AUTH_CHALLENGE_0_1,
+        )
         .json(&ChallengeRequest {
             did: client_did.to_string(),
         })
@@ -88,6 +105,10 @@ pub async fn challenge_response_light(
     let auth_resp = http
         .post(&auth_url)
         .header("content-type", "application/json")
+        .header(
+            TRUST_TASK_HEADER,
+            crate::trust_tasks::TASK_AUTH_AUTHENTICATE_0_1,
+        )
         .body(body)
         .send()
         .await?;
@@ -145,6 +166,7 @@ pub async fn refresh_token_light(
     let resp = http
         .post(&refresh_url)
         .header("content-type", "application/json")
+        .header(TRUST_TASK_HEADER, crate::trust_tasks::TASK_AUTH_REFRESH_0_1)
         .body(body)
         .send()
         .await?;

--- a/vta-sdk/src/auth_light.rs
+++ b/vta-sdk/src/auth_light.rs
@@ -1,16 +1,32 @@
 //! Lightweight challenge-response authentication for VTA REST clients.
 //!
-//! This module provides the same DIDComm challenge-response flow as
-//! `session::challenge_response()` but without requiring ATM/TDK runtime
-//! initialization. It uses the lightweight DIDComm packer from
-//! `didcomm_light` to build encrypted auth messages.
+//! Same challenge-response flow as `session::challenge_response()`, but with no
+//! ATM/TDK runtime and no mediator: the request is a DI-signed
+//! `auth/authenticate/0.1` Trust Task (see [`crate::auth_di`]), the canonical
+//! REST transport the VTA tries before its DIDComm-envelope path.
+//!
+//! **This module used to pack an anoncrypt DIDComm envelope** via
+//! `didcomm_light` and throw the caller's private key away — the sender was
+//! merely *asserted* in a plaintext `from` header. VTI #771 hardened `/auth/*`
+//! to require an authenticated (authcrypt) envelope, which rejected every
+//! anoncrypt message outright ("authenticate message must be an authenticated
+//! (authcrypt) DIDComm envelope") and broke this whole tier: the VTC setup
+//! wizard's did-hosting picker, `VtaClient`'s REST re-auth and refresh, and
+//! `vtc-client`. Signing with the holder key both fixes that and is what the
+//! server actually prefers.
+//!
+//! Consequence of the switch: the VTA verifies the proof with a `did:key`-only
+//! resolver, so [`challenge_response_light`] requires a `did:key` holder and
+//! returns [`VtaError::Validation`] for anything else. Callers holding another
+//! DID method need `session::challenge_response` (DIDComm authcrypt), which
+//! `integration::auth::try_rest` already falls back to.
 //!
 //! Feature gate: `client` (not `session`).
 
+use crate::auth_di;
 use crate::credentials::CredentialBundle;
-use crate::didcomm_light;
 use crate::error::VtaError;
-use crate::protocols::auth::{AuthenticateResponse, ChallengeRequest, ChallengeResponse};
+use crate::protocols::auth::{ChallengeRequest, ChallengeResponse};
 use reqwest::Client;
 
 /// Result of a successful authentication.
@@ -22,10 +38,13 @@ pub struct AuthResult {
     pub refresh_expires_at: Option<u64>,
 }
 
-/// Perform DIDComm challenge-response authentication without ATM/TDK runtime.
+/// Perform challenge-response authentication without ATM/TDK runtime.
 ///
-/// This is the lightweight equivalent of `session::challenge_response()`.
-/// It uses the `didcomm_light` packer to build the encrypted message.
+/// The lightweight equivalent of `session::challenge_response()`: the
+/// challenge is answered with a DI-signed `auth/authenticate/0.1` Trust Task,
+/// so the holder key proves the sender and no mediator is involved.
+///
+/// `client_did` must be a `did:key` — see the module docs.
 pub async fn challenge_response_light(
     http: &Client,
     base_url: &str,
@@ -33,9 +52,6 @@ pub async fn challenge_response_light(
     private_key_multibase: &str,
     vta_did: &str,
 ) -> Result<AuthResult, crate::error::VtaError> {
-    let _ = private_key_multibase; // Sender identity is in the plaintext `from` field;
-    // anoncrypt doesn't use sender's private key for encryption.
-
     // Step 1: Request challenge
     let challenge_url = format!("{base_url}/auth/challenge");
     let challenge_resp = http
@@ -54,27 +70,25 @@ pub async fn challenge_response_light(
 
     let challenge: ChallengeResponse = challenge_resp.json().await?;
 
-    // Step 2: Pack encrypted authenticate message. `pack_auth_message`
-    // is async because `did:webvh` VTAs require an HTTP fetch + chain
-    // verification; for `did:key:` VTAs the future resolves without I/O.
-    let packed = didcomm_light::pack_auth_message(
-        crate::trust_tasks::TASK_AUTH_AUTHENTICATE_0_1,
-        serde_json::json!({
-            "challenge": challenge.challenge,
-            "session_id": challenge.session_id,
-        }),
+    // Step 2: Build + sign the authenticate Trust Task. Signing is local
+    // (no DID resolution, no I/O): the holder's key is right here, and the
+    // VTA resolves the proof's `did:key` verification method itself.
+    let body = auth_di::sign_authenticate_doc(
         client_did,
+        private_key_multibase,
         vta_did,
+        &challenge.challenge,
+        &challenge.session_id,
     )
     .await
-    .map_err(|e| VtaError::Validation(format!("pack auth message: {e}")))?;
+    .map_err(|e| VtaError::Validation(e.to_string()))?;
 
-    // Step 3: Send packed message
+    // Step 3: Send the signed document
     let auth_url = format!("{base_url}/auth/");
     let auth_resp = http
         .post(&auth_url)
-        .header("content-type", "text/plain")
-        .body(packed)
+        .header("content-type", "application/json")
+        .body(body)
         .send()
         .await?;
 
@@ -84,7 +98,8 @@ pub async fn challenge_response_light(
         return Err(VtaError::from_http(status, body));
     }
 
-    let auth_data: AuthenticateResponse = auth_resp.json().await?;
+    let auth_data = auth_di::parse_auth_response(&auth_resp.text().await?)
+        .map_err(|e| VtaError::Validation(e.to_string()))?;
 
     let access_expires_at = auth_data.access_expires_at_epoch().ok_or_else(|| {
         VtaError::Validation(format!(
@@ -111,6 +126,11 @@ pub async fn challenge_response_light(
 /// token after a successful refresh fails with `Auth("refresh token not
 /// found")`. The `VtaClient` handles this automatically (see
 /// `client.rs::ensure_token_valid`).
+///
+/// Unlike [`challenge_response_light`] this carries no proof and works for a
+/// holder of any DID method: the opaque refresh token *is* the credential
+/// (RFC 6749 §10.4), so the VTA's Trust-Task refresh path verifies the token,
+/// not a signer.
 pub async fn refresh_token_light(
     http: &Client,
     base_url: &str,
@@ -118,22 +138,14 @@ pub async fn refresh_token_light(
     vta_did: &str,
     refresh_token: &str,
 ) -> Result<AuthResult, crate::error::VtaError> {
-    let packed = didcomm_light::pack_auth_message(
-        crate::trust_tasks::TASK_AUTH_REFRESH_0_1,
-        serde_json::json!({
-            "refresh_token": refresh_token,
-        }),
-        client_did,
-        vta_did,
-    )
-    .await
-    .map_err(|e| VtaError::Validation(format!("pack refresh message: {e}")))?;
+    let body = auth_di::build_refresh_doc(client_did, vta_did, refresh_token)
+        .map_err(|e| VtaError::Validation(e.to_string()))?;
 
     let refresh_url = format!("{base_url}/auth/refresh");
     let resp = http
         .post(&refresh_url)
-        .header("content-type", "text/plain")
-        .body(packed)
+        .header("content-type", "application/json")
+        .body(body)
         .send()
         .await?;
 
@@ -143,7 +155,8 @@ pub async fn refresh_token_light(
         return Err(VtaError::from_http(status, body));
     }
 
-    let auth_data: AuthenticateResponse = resp.json().await?;
+    let auth_data = auth_di::parse_auth_response(&resp.text().await?)
+        .map_err(|e| VtaError::Validation(e.to_string()))?;
 
     let access_expires_at = auth_data.access_expires_at_epoch().ok_or_else(|| {
         VtaError::Validation(format!(

--- a/vta-sdk/src/didcomm_light.rs
+++ b/vta-sdk/src/didcomm_light.rs
@@ -8,6 +8,15 @@
 //! only needs the recipient's X25519 public key (derived from their
 //! `did:key`).
 //!
+//! **Not usable for `/auth/*`.** Anoncrypt carries an *unauthenticated*
+//! plaintext `from`, and the VTA now requires an authenticated (authcrypt)
+//! envelope on `/auth/` and `/auth/refresh`
+//! (`vti_common::auth::bind_authcrypt_sender`, VTI #771) — an anoncrypt message
+//! is rejected with "authenticate message must be an authenticated (authcrypt)
+//! DIDComm envelope". [`crate::auth_light`] used to pack its auth messages here
+//! and moved to the DI-signed Trust Task transport ([`crate::auth_di`]) for
+//! exactly that reason. Do not route authentication back through this module.
+//!
 //! Algorithm: ECDH-ES+A256KW (key agreement) + A256CBC-HS512 (content
 //! encryption) — the algorithm pair the workspace's pinned
 //! `affinidi-messaging-didcomm-0.15` actually decrypts. An earlier
@@ -256,6 +265,11 @@ fn resolve_vm_reference(
 /// `did:webvh:` (fetches + verifies the log) VTAs; for other DID
 /// methods, errors out so the caller can fall back to the heavyweight
 /// `session::challenge_response` path.
+///
+/// **Superseded for authentication** — see the module docs. The VTA rejects
+/// anoncrypt on `/auth/*`; use [`crate::auth_light::challenge_response_light`]
+/// (DI-signed Trust Task) instead. Retained for any consumer that packs
+/// anoncrypt for a non-auth surface.
 pub async fn pack_auth_message(
     msg_type: &str,
     body: serde_json::Value,

--- a/vta-sdk/src/http.rs
+++ b/vta-sdk/src/http.rs
@@ -23,7 +23,12 @@ const DEFAULT_REST_CONNECT_TIMEOUT_SECS: u64 = 10;
 /// Panics only if the TLS backend cannot initialize — the same condition under
 /// which `reqwest::Client::new()` already panics, so this is not a new failure
 /// mode.
-pub(crate) fn rest_client() -> reqwest::Client {
+///
+/// Public so sibling client crates (`vtc-client`) share this one chokepoint
+/// rather than each reaching for the untimed `reqwest::Client::new()` — R1.2
+/// allows no exceptions, and a client crate is exactly where an unbounded hang
+/// reaches an operator.
+pub fn rest_client() -> reqwest::Client {
     reqwest::Client::builder()
         .timeout(env_secs("VTA_REST_TIMEOUT_SECS", DEFAULT_REST_TIMEOUT_SECS))
         .connect_timeout(env_secs(

--- a/vta-sdk/src/lib.rs
+++ b/vta-sdk/src/lib.rs
@@ -95,6 +95,8 @@ pub mod agent_session;
 #[cfg(feature = "attest-verify")]
 pub mod attestation;
 #[cfg(feature = "client")]
+pub mod auth_di;
+#[cfg(feature = "client")]
 pub mod auth_light;
 #[cfg(feature = "client")]
 pub mod client;

--- a/vta-sdk/src/provision_client/auth_rest.rs
+++ b/vta-sdk/src/provision_client/auth_rest.rs
@@ -27,6 +27,7 @@
 use crate::auth_di;
 use crate::protocols::auth::{ChallengeRequest, ChallengeResponse};
 use crate::session::TokenResult;
+use crate::trust_tasks::TASK_AUTH_AUTHENTICATE_0_1;
 
 /// Authenticate over plain REST using a DI-signed `auth/authenticate/0.1`
 /// Trust Task, returning the same [`TokenResult`] as
@@ -53,6 +54,9 @@ pub async fn challenge_response_di(
     let challenge_url = format!("{base_url}/auth/challenge");
     let challenge_resp = http
         .post(&challenge_url)
+        // Trust-Task URL header: required by the VTC, ignored by the VTA. See
+        // `crate::auth_light::TRUST_TASK_HEADER`.
+        .header("Trust-Task", crate::trust_tasks::TASK_AUTH_CHALLENGE_0_1)
         .json(&ChallengeRequest {
             did: client_did.to_string(),
         })
@@ -87,6 +91,7 @@ pub async fn challenge_response_di(
     let auth_resp = http
         .post(&auth_url)
         .header("content-type", "application/json")
+        .header("Trust-Task", TASK_AUTH_AUTHENTICATE_0_1)
         .body(body)
         .send()
         .await

--- a/vta-sdk/src/provision_client/auth_rest.rs
+++ b/vta-sdk/src/provision_client/auth_rest.rs
@@ -17,24 +17,16 @@
 //!
 //! It works against *any* VTA — REST-only or DIDComm-enabled — because the
 //! server attempts the DI path before the DIDComm-envelope path.
+//!
+//! The document building / signing / response parsing lives in
+//! [`crate::auth_di`], shared with [`crate::auth_light`] (the REST client tier,
+//! which moved onto this same transport once the VTA started requiring an
+//! authenticated sender on `/auth/*`). This module is the provision-client's
+//! entry point onto it.
 
-use affinidi_data_integrity::{DataIntegrityProof, SignOptions};
-use affinidi_secrets_resolver::secrets::Secret;
-use chrono::Utc;
-use serde_json::{Value, json};
-use trust_tasks_rs::{Proof, TrustTask};
-
-use crate::did_key::decode_private_key_multibase;
-use crate::protocols::auth::{AuthenticateResponse, ChallengeRequest, ChallengeResponse};
+use crate::auth_di;
+use crate::protocols::auth::{ChallengeRequest, ChallengeResponse};
 use crate::session::TokenResult;
-use crate::trust_tasks::TASK_AUTH_AUTHENTICATE_0_1;
-
-/// The `did:key:zXxx#zXxx` verification-method id the Data-Integrity resolver
-/// recognises for a `did:key` holder.
-fn did_key_to_vm(did: &str) -> Option<String> {
-    let mb = did.strip_prefix("did:key:")?;
-    Some(format!("{did}#{mb}"))
-}
 
 /// Authenticate over plain REST using a DI-signed `auth/authenticate/0.1`
 /// Trust Task, returning the same [`TokenResult`] as
@@ -76,59 +68,22 @@ pub async fn challenge_response_di(
         format!("unexpected challenge response from VTA at {challenge_url} (is this a VTA?): {e}")
     })?;
 
-    // Step 2 — build the `auth/authenticate/0.1` Trust Task. The payload is a
-    // `Value` matching the spec `authenticate::Payload` shape
-    // (`{ challenge, sessionId }`); the server deserializes it into the typed
-    // payload after verifying the proof.
-    let type_uri = TASK_AUTH_AUTHENTICATE_0_1
-        .parse()
-        .map_err(|e| format!("authenticate type URI parse: {e}"))?;
-    let mut doc: TrustTask<Value> = TrustTask::new(
-        format!("urn:uuid:{}", uuid::Uuid::new_v4()),
-        type_uri,
-        json!({
-            "challenge": challenge.challenge,
-            "sessionId": challenge.session_id,
-        }),
-    );
-    doc.issuer = Some(client_did.to_string());
-    doc.recipient = Some(vta_did.to_string());
-    doc.issued_at = Some(Utc::now());
+    // Step 2 — build + sign the `auth/authenticate/0.1` Trust Task with the
+    // holder key (payload `{ challenge, sessionId }`, `eddsa-jcs-2022` proof
+    // over the proof-less document).
+    let body = auth_di::sign_authenticate_doc(
+        client_did,
+        private_key_multibase,
+        vta_did,
+        &challenge.challenge,
+        &challenge.session_id,
+    )
+    .await?;
 
-    // Step 3 — attach the holder's `eddsa-jcs-2022` Data-Integrity proof. Build
-    // a `Secret` whose id is the `did:key:zXxx#zXxx` verification method, sign
-    // the proof-less document (JCS is presence-sensitive — the server verifies
-    // against the same shape with `proof` stripped), then graft the proof on.
-    let vm_id = did_key_to_vm(client_did).ok_or_else(|| {
-        format!("the DI-signed auth path requires a did:key holder; got {client_did}")
-    })?;
-    let seed = decode_private_key_multibase(private_key_multibase)?;
-    let mut signer = Secret::generate_ed25519(Some(&vm_id), Some(&seed));
-    signer.id = vm_id.clone();
-
-    let sign_options = SignOptions::new()
-        .with_proof_purpose("assertionMethod")
-        .with_created(Utc::now());
-
-    let mut signing_doc =
-        serde_json::to_value(&doc).map_err(|e| format!("serialize authenticate document: {e}"))?;
-    if let Some(obj) = signing_doc.as_object_mut() {
-        obj.remove("proof");
-    }
-    let di_proof = DataIntegrityProof::sign(&signing_doc, &signer, sign_options)
-        .await
-        .map_err(|e| format!("sign authenticate Trust Task: {e}"))?;
-    let proof_json =
-        serde_json::to_value(&di_proof).map_err(|e| format!("serialize proof: {e}"))?;
-    doc.proof =
-        Some(serde_json::from_value::<Proof>(proof_json).map_err(|e| format!("proof shape: {e}"))?);
-
-    // Step 4 — POST the signed document. A Trust Task request yields a TT
+    // Step 3 — POST the signed document. A Trust Task request yields a TT
     // `#response` document whose payload is the `{ session, tokens }`
     // `AuthenticateResponse`.
     let auth_url = format!("{base_url}/auth/");
-    let body =
-        serde_json::to_string(&doc).map_err(|e| format!("serialize signed document: {e}"))?;
     let auth_resp = http
         .post(&auth_url)
         .header("content-type", "application/json")
@@ -147,17 +102,8 @@ pub async fn challenge_response_di(
         .map_err(|e| format!("failed to read auth response from VTA: {e}"))?;
     // A Trust-Task request yields a TT `#response` document whose payload is the
     // `{ session, tokens }` body; some clients/mocks return that body flat.
-    // Accept either: try flat first, then unwrap the Trust-Task envelope.
-    let auth_data: AuthenticateResponse = match serde_json::from_str(&auth_text) {
-        Ok(flat) => flat,
-        Err(_) => {
-            let response_doc: TrustTask<Value> = serde_json::from_str(&auth_text).map_err(|e| {
-                format!("unexpected auth response from VTA at {auth_url} (is this a VTA?): {e}")
-            })?;
-            serde_json::from_value(response_doc.payload)
-                .map_err(|e| format!("auth response payload is not an AuthenticateResponse: {e}"))?
-        }
-    };
+    let auth_data =
+        auth_di::parse_auth_response(&auth_text).map_err(|e| format!("{e} (VTA at {auth_url})"))?;
     let access_expires_at = auth_data.access_expires_at_epoch().ok_or_else(|| {
         format!(
             "VTA returned unparseable session.issuedAt: '{}'",

--- a/vta-sdk/src/provision_client/runner_rest.rs
+++ b/vta-sdk/src/provision_client/runner_rest.rs
@@ -386,6 +386,12 @@ pub(crate) async fn run_rest_attempt_admin_rotated(
 
 #[cfg(test)]
 mod tests {
+    /// A challenge that satisfies the spec payload's `minLength: 16` (the
+    /// canonical handler issues hex-encoded 32 random bytes). The old
+    /// `"test-challenge"` fixture was 14 chars — accepted only while the client
+    /// hand-wrote its payload JSON instead of building the typed spec type.
+    const TEST_CHALLENGE: &str = "test-challenge-0123456789abcdef";
+
     use super::*;
     use crate::provision_client::setup_key::EphemeralSetupKey;
     use serde_json::json;
@@ -412,7 +418,7 @@ mod tests {
         Mock::given(method("POST"))
             .and(path("/auth/challenge"))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-                "challenge": "test-challenge",
+                "challenge": TEST_CHALLENGE,
                 "sessionId": "test-session",
                 "expiresAt": "2026-12-31T23:59:59Z"
             })))
@@ -586,7 +592,7 @@ mod tests {
         Mock::given(method("POST"))
             .and(path("/auth/challenge"))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-                "challenge": "test-challenge",
+                "challenge": TEST_CHALLENGE,
                 "sessionId": "test-session",
                 "expiresAt": "2026-12-31T23:59:59Z"
             })))

--- a/vta-sdk/src/session.rs
+++ b/vta-sdk/src/session.rs
@@ -1191,6 +1191,11 @@ pub async fn challenge_response(
     debug!(url = %challenge_url, did = client_did, "requesting challenge");
     let challenge_resp = http
         .post(&challenge_url)
+        // Trust-Task URL header: the VTC gates every route on it (400 without);
+        // the VTA ignores it. `cnm`'s VTC backup authenticates through this
+        // function, so omitting it made that login a 400 before any handler ran.
+        // Same header the `auth_light` / `auth_rest` REST paths send.
+        .header("Trust-Task", crate::trust_tasks::TASK_AUTH_CHALLENGE_0_1)
         .json(&ChallengeRequest {
             did: client_did.to_string(),
         })
@@ -1293,6 +1298,7 @@ pub async fn challenge_response(
     let auth_resp = http
         .post(&auth_url)
         .header("content-type", "text/plain")
+        .header("Trust-Task", crate::trust_tasks::TASK_AUTH_AUTHENTICATE_0_1)
         .body(packed)
         .send()
         .await

--- a/vta-sdk/tests/auth_light_rest.rs
+++ b/vta-sdk/tests/auth_light_rest.rs
@@ -26,6 +26,12 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 
 // ── Test fixtures ───────────────────────────────────────────────────
 
+/// A challenge shaped like the real thing. The canonical handler issues
+/// hex-encoded 32 random bytes and the spec payload type enforces
+/// `minLength: 16`, so a short toy nonce is not a valid fixture — the typed
+/// builder in `auth_di` rejects it before it reaches the wire.
+const CHALLENGE: &str = "a3f1c09b7e2d4856a3f1c09b7e2d4856";
+
 /// Build a deterministic `did:key` + matching multibase private-key
 /// string from a seed byte. The client DID must be a valid `did:key`
 /// (the server's DI-proof resolver accepts nothing else); the VTA DID is
@@ -54,7 +60,7 @@ async fn mount_challenge(server: &MockServer) {
     Mock::given(method("POST"))
         .and(path("/auth/challenge"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "challenge": "c-nonce-123",
+            "challenge": CHALLENGE,
             "sessionId": "sess-test",
             "expiresAt": "2026-12-31T23:59:59Z"
         })))
@@ -170,7 +176,7 @@ async fn authenticate_endpoint_401_maps_to_auth() {
 }
 
 /// The VTA verifies the holder's DI proof with a `did:key`-only resolver
-/// (`vta-service/src/auth/di_proof.rs`), so a non-`did:key` holder is refused
+/// (`vti-common/src/auth/di_proof.rs`), so a non-`did:key` holder is refused
 /// locally as `Validation` rather than after a round trip.
 #[tokio::test]
 async fn non_did_key_holder_maps_to_validation() {
@@ -243,7 +249,7 @@ async fn authenticate_body_is_a_signed_trust_task() {
         body["type"], "https://trusttasks.org/spec/auth/authenticate/0.1",
         "body must be an authenticate Trust Task"
     );
-    assert_eq!(body["payload"]["challenge"], "c-nonce-123");
+    assert_eq!(body["payload"]["challenge"], CHALLENGE);
     assert_eq!(body["payload"]["sessionId"], "sess-test");
     assert_eq!(body["issuer"], client_did);
     assert_eq!(body["proof"]["cryptosuite"], "eddsa-jcs-2022");
@@ -573,7 +579,7 @@ async fn ensure_token_valid_full_reauth_when_refresh_expired() {
     Mock::given(method("POST"))
         .and(path("/auth/challenge"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "challenge": "c",
+            "challenge": CHALLENGE,
             "sessionId": "sess",
             "expiresAt": "2099-12-31T23:59:59Z"
         })))
@@ -660,7 +666,7 @@ async fn ensure_token_valid_falls_through_when_refresh_fails() {
     Mock::given(method("POST"))
         .and(path("/auth/challenge"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "challenge": "c",
+            "challenge": CHALLENGE,
             "sessionId": "sess",
             "expiresAt": "2099-12-31T23:59:59Z"
         })))

--- a/vta-sdk/tests/auth_light_rest.rs
+++ b/vta-sdk/tests/auth_light_rest.rs
@@ -2,10 +2,11 @@
 //! paths in `vta_sdk::client::VtaClient` (`from_credential`,
 //! `ensure_token_valid` refresh-on-expiry, full re-auth fallback).
 //!
-//! All tests run against a `wiremock` server. Where a real `did:key` is
-//! required for DIDComm anoncrypt packing, we derive one from a fixed
-//! seed via `ed25519_dalek` + the SDK's own multibase helpers — no
-//! private key material leaves the test process.
+//! All tests run against a `wiremock` server. The holder `did:key` +
+//! private key are derived from a fixed seed via `ed25519_dalek` + the
+//! SDK's own multibase helpers — no private key material leaves the test
+//! process. The holder must be a real key pair because the auth request
+//! is now a DI-signed Trust Task (`auth_di`), not an anoncrypt envelope.
 
 #![cfg(feature = "client")]
 
@@ -26,9 +27,9 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 // ── Test fixtures ───────────────────────────────────────────────────
 
 /// Build a deterministic `did:key` + matching multibase private-key
-/// string from a seed byte. Both client and VTA DIDs need to be valid
-/// `did:key`s because `auth_light` calls `pack_auth_message`, which
-/// derives X25519 keys from the embedded Ed25519 multibase.
+/// string from a seed byte. The client DID must be a valid `did:key`
+/// (the server's DI-proof resolver accepts nothing else); the VTA DID is
+/// only an addressee, so tests may use any method for it.
 fn did_key_from_seed(seed_byte: u8) -> (String, String) {
     let seed = [seed_byte; 32];
     let sk = SigningKey::from_bytes(&seed);
@@ -168,17 +169,40 @@ async fn authenticate_endpoint_401_maps_to_auth() {
     assert!(matches!(err, VtaError::Auth(_)), "got {err:?}");
 }
 
+/// The VTA verifies the holder's DI proof with a `did:key`-only resolver
+/// (`vta-service/src/auth/di_proof.rs`), so a non-`did:key` holder is refused
+/// locally as `Validation` rather than after a round trip.
 #[tokio::test]
-async fn pack_failure_with_invalid_vta_did_maps_to_validation() {
-    // `pack_auth_message` resolves the VTA's keyAgreement via
-    // `resolve_vta_keyagreement`, which supports `did:key` and
-    // `did:webvh` only. A `did:web` VTA produces an "unsupported DID
-    // method" error that `auth_light` wraps into `VtaError::Validation`.
+async fn non_did_key_holder_maps_to_validation() {
     let server = MockServer::start().await;
     mount_challenge(&server).await;
-    let (client_did, client_priv) = did_key_from_seed(0x11);
+    let (_, client_priv) = did_key_from_seed(0x11);
+    let (vta_did, _) = did_key_from_seed(0x22);
     let http = reqwest::Client::new();
     let err = challenge_response_light(
+        &http,
+        &server.uri(),
+        "did:web:example.com",
+        &client_priv,
+        &vta_did,
+    )
+    .await
+    .unwrap_err();
+    assert!(matches!(err, VtaError::Validation(_)), "got {err:?}");
+}
+
+/// The VTA's DID is only an addressee on the signed document, never resolved
+/// by the client — so a DID method the old anoncrypt packer couldn't resolve
+/// (it needed the VTA's `keyAgreement` key) now authenticates fine.
+#[tokio::test]
+async fn non_key_vta_did_still_authenticates() {
+    let server = MockServer::start().await;
+    mount_challenge(&server).await;
+    mount_authenticate(&server, 1_700_001_000).await;
+
+    let (client_did, client_priv) = did_key_from_seed(0x11);
+    let http = reqwest::Client::new();
+    let result = challenge_response_light(
         &http,
         &server.uri(),
         &client_did,
@@ -186,8 +210,88 @@ async fn pack_failure_with_invalid_vta_did_maps_to_validation() {
         "did:web:not-a-key",
     )
     .await
-    .unwrap_err();
-    assert!(matches!(err, VtaError::Validation(_)), "got {err:?}");
+    .expect("the VTA DID is not resolved on this path");
+    assert_eq!(result.access_token, "access-jwt");
+}
+
+/// The request body must be a DI-signed `auth/authenticate/0.1` Trust Task —
+/// **not** an anoncrypt DIDComm envelope, which the VTA rejects outright since
+/// it began requiring an authenticated sender (VTI #771).
+#[tokio::test]
+async fn authenticate_body_is_a_signed_trust_task() {
+    let server = MockServer::start().await;
+    mount_challenge(&server).await;
+    mount_authenticate(&server, 1_700_001_000).await;
+
+    let (client_did, client_priv) = did_key_from_seed(0x11);
+    let (vta_did, _) = did_key_from_seed(0x22);
+    let http = reqwest::Client::new();
+    challenge_response_light(&http, &server.uri(), &client_did, &client_priv, &vta_did)
+        .await
+        .unwrap();
+
+    let req = server
+        .received_requests()
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|r| r.url.path() == "/auth/")
+        .expect("an /auth/ request was made");
+    let body: serde_json::Value = serde_json::from_slice(&req.body).expect("body is JSON");
+
+    assert_eq!(
+        body["type"], "https://trusttasks.org/spec/auth/authenticate/0.1",
+        "body must be an authenticate Trust Task"
+    );
+    assert_eq!(body["payload"]["challenge"], "c-nonce-123");
+    assert_eq!(body["payload"]["sessionId"], "sess-test");
+    assert_eq!(body["issuer"], client_did);
+    assert_eq!(body["proof"]["cryptosuite"], "eddsa-jcs-2022");
+    assert!(body.get("protected").is_none(), "must not be a JWE");
+}
+
+/// The VTA answers a Trust-Task request with a Trust-Task `#response`
+/// document; the client must unwrap it, not just handle flat JSON.
+#[tokio::test]
+async fn trust_task_wrapped_response_is_unwrapped() {
+    let server = MockServer::start().await;
+    mount_challenge(&server).await;
+    Mock::given(method("POST"))
+        .and(path("/auth/"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": "urn:uuid:resp-1",
+            "type": "https://trusttasks.org/spec/auth/authenticate/0.1#response",
+            "threadId": "urn:uuid:req-1",
+            "payload": {
+                "session": {
+                    "id": "sess-test",
+                    "subject": "did:example:caller",
+                    "issuedAt": "1970-01-01T00:00:00Z",
+                    "expiresAt": "2099-12-31T23:59:59Z",
+                    "amr": ["did"],
+                    "acr": "aal1"
+                },
+                "tokens": {
+                    "accessToken": "wrapped-access",
+                    "tokenType": "Bearer",
+                    "expiresIn": 1_700_001_000_u64,
+                    "refreshToken": "wrapped-refresh",
+                    "refreshExpiresIn": 1_700_004_600_u64
+                }
+            }
+        })))
+        .mount(&server)
+        .await;
+
+    let (client_did, client_priv) = did_key_from_seed(0x11);
+    let (vta_did, _) = did_key_from_seed(0x22);
+    let http = reqwest::Client::new();
+    let result =
+        challenge_response_light(&http, &server.uri(), &client_did, &client_priv, &vta_did)
+            .await
+            .unwrap();
+    assert_eq!(result.access_token, "wrapped-access");
+    assert_eq!(result.refresh_token.as_deref(), Some("wrapped-refresh"));
 }
 
 // ── refresh_token_light ─────────────────────────────────────────────
@@ -244,21 +348,56 @@ async fn refresh_token_401_maps_to_auth() {
     assert!(matches!(err, VtaError::Auth(_)));
 }
 
+/// Refresh posts an **unsigned** `auth/refresh/0.1` Trust Task: the opaque
+/// token is the credential (RFC 6749 §10.4), so the VTA verifies the token
+/// rather than a signer — and neither DID is resolved.
 #[tokio::test]
-async fn refresh_token_pack_failure_with_invalid_did() {
+async fn refresh_body_is_an_unsigned_trust_task() {
     let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/auth/refresh"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "session": {
+                "id": "sess-test",
+                "subject": "did:example:caller",
+                "issuedAt": "1970-01-01T00:00:00Z",
+                "expiresAt": "2099-12-31T23:59:59Z",
+                "amr": ["did"],
+                "acr": "aal1"
+            },
+            "tokens": {
+                "accessToken": "a",
+                "tokenType": "Bearer",
+                "expiresIn": 2_000_000_000_u64
+            }
+        })))
+        .mount(&server)
+        .await;
+
     let (client_did, _) = did_key_from_seed(0x11);
     let http = reqwest::Client::new();
-    let err = refresh_token_light(
+    // A `did:web` VTA is fine here — nothing resolves it.
+    refresh_token_light(
         &http,
         &server.uri(),
         &client_did,
         "did:web:not-a-key",
-        "old",
+        "old-refresh",
     )
     .await
-    .unwrap_err();
-    assert!(matches!(err, VtaError::Validation(_)), "got {err:?}");
+    .expect("refresh needs no DID resolution");
+
+    let req = server
+        .received_requests()
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|r| r.url.path() == "/auth/refresh")
+        .expect("a refresh request was made");
+    let body: serde_json::Value = serde_json::from_slice(&req.body).expect("body is JSON");
+    assert_eq!(body["type"], "https://trusttasks.org/spec/auth/refresh/0.1");
+    assert_eq!(body["payload"]["refreshToken"], "old-refresh");
+    assert!(body.get("proof").is_none(), "refresh must not be signed");
 }
 
 // ── authenticate_with_credential ────────────────────────────────────

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.13.20"
+version = "0.13.21"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/auth/mod.rs
+++ b/vta-service/src/auth/mod.rs
@@ -1,8 +1,12 @@
 pub mod backend;
 pub mod credentials;
-pub mod di_proof;
 
 pub use backend::VtaAuthBackend;
+/// The shared Trust-Task DI-proof verifier, now owned by `vti-common` so the
+/// VTA and the VTC verify a holder proof identically. Re-exported at its
+/// original path — `crate::auth::di_proof::verify_trust_task_proof` still
+/// resolves for the step-up gate, task consent, and the REST auth route.
+pub use vti_common::auth::di_proof;
 pub use vti_common::auth::extractor::{
     AdminAuth, AuthClaims, AuthState, ManageAuth, SuperAdminAuth,
 };

--- a/vta-service/tests/auth_flow.rs
+++ b/vta-service/tests/auth_flow.rs
@@ -16,10 +16,13 @@
 //! - `TestAppContext` exposes the keyspaces auth tests need —
 //!   surface check so future contributors don't have to grep.
 //!
+//! - The full challenge → DI-signed Trust Task → tokens round trip over
+//!   plain REST, driven by the *SDK's own* document builder. `did:key`
+//!   resolution is local, so no network resolver is needed.
+//!
 //! What's NOT covered (intentional — needs real DID resolver):
-//! - Full sign-then-verify against the challenge in `POST /auth/`.
-//!   That round-trip lives in the e2e suite where a real signing
-//!   admin DID + DID resolver are available.
+//! - The same round trip over a DIDComm envelope, which needs a real
+//!   mediator-backed ATM. That lives in the e2e suite.
 
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
@@ -112,6 +115,137 @@ async fn challenge_endpoint_issues_session_and_persists_it() {
     assert_eq!(
         session.challenge, challenge,
         "persisted challenge must match the one returned to the client (so `/auth/` can verify the signature against the same nonce the client signed)"
+    );
+}
+
+/// A deterministic `did:key` + its multibase private key, as the SDK's
+/// client-side helpers expect them.
+fn did_key_from_seed(seed_byte: u8) -> (String, String) {
+    let seed = [seed_byte; 32];
+    let sk = ed25519_dalek::SigningKey::from_bytes(&seed);
+    let did = format!(
+        "did:key:{}",
+        vta_sdk::did_key::ed25519_multibase_pubkey(&sk.verifying_key().to_bytes())
+    );
+    // Multicodec Ed25519 private-key prefix (0x1300 → varint 0x80 0x26).
+    let mut buf = vec![0x80, 0x26];
+    buf.extend_from_slice(&seed);
+    (did, multibase::encode(multibase::Base::Base58Btc, &buf))
+}
+
+/// The canonical REST login, end to end: `/auth/challenge` → a Trust Task
+/// signed by the SDK's own builder → tokens. No mediator, no ATM.
+///
+/// This is the pin for the regression that broke every REST client: the SDK's
+/// `auth_light` tier packed an **anoncrypt** DIDComm envelope, and once
+/// `/auth/` began requiring an authenticated sender (VTI #771) the server
+/// answered "authenticate message must be an authenticated (authcrypt) DIDComm
+/// envelope" to every one of them. Driving the server with the *client's* own
+/// document — rather than a hand-rolled fixture — is what makes this test able
+/// to catch that class: a builder that drifts out of what the route accepts
+/// fails here.
+#[tokio::test]
+async fn di_signed_trust_task_authenticates_over_rest() {
+    let (router, ctx) = build_test_app().await;
+
+    let (did, private_key_multibase) = did_key_from_seed(0x5a);
+    let entry = vti_common::acl::AclEntry::new(&did, vti_common::acl::Role::Admin, "test")
+        .with_created_at(1);
+    vti_common::acl::store_acl_entry(&ctx.acl_ks, &entry)
+        .await
+        .expect("seed admin ACL");
+
+    let (status, challenge_body) =
+        request(&router, post_json("/auth/challenge", json!({"did": did}))).await;
+    assert_eq!(status, StatusCode::OK, "challenge: {challenge_body}");
+    let challenge = challenge_body["challenge"].as_str().unwrap();
+    let session_id = challenge_body["sessionId"].as_str().unwrap();
+
+    // The exact bytes `vta_sdk::auth_light::challenge_response_light` puts on
+    // the wire.
+    let doc = vta_sdk::auth_di::sign_authenticate_doc(
+        &did,
+        &private_key_multibase,
+        "did:key:z6MkTestVta",
+        challenge,
+        session_id,
+    )
+    .await
+    .expect("sign authenticate document");
+
+    let req = Request::builder()
+        .method("POST")
+        .uri("/auth/")
+        .header("content-type", "application/json")
+        .header("x-forwarded-for", "203.0.113.1")
+        .body(Body::from(doc))
+        .unwrap();
+    let (status, body) = request(&router, req).await;
+
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "a DI-signed Trust Task must authenticate over plain REST; got: {body}"
+    );
+    // The response is a Trust-Task `#response` document wrapping the tokens —
+    // the shape the SDK unwraps in `auth_di::parse_auth_response`.
+    let payload = &body["payload"];
+    assert!(
+        payload["tokens"]["accessToken"]
+            .as_str()
+            .is_some_and(|t| !t.is_empty()),
+        "response must carry an access token: {body}"
+    );
+    assert_eq!(
+        payload["session"]["subject"], did,
+        "the session must be bound to the proven signer: {body}"
+    );
+}
+
+/// The proof is not decoration: the same document with a challenge the holder
+/// never signed is rejected. Guards against a future "parse the payload, skip
+/// the proof" shortcut on the REST path.
+#[tokio::test]
+async fn di_signed_trust_task_with_tampered_challenge_is_rejected() {
+    let (router, ctx) = build_test_app().await;
+
+    let (did, private_key_multibase) = did_key_from_seed(0x5b);
+    let entry = vti_common::acl::AclEntry::new(&did, vti_common::acl::Role::Admin, "test")
+        .with_created_at(1);
+    vti_common::acl::store_acl_entry(&ctx.acl_ks, &entry)
+        .await
+        .expect("seed admin ACL");
+
+    let (_, challenge_body) =
+        request(&router, post_json("/auth/challenge", json!({"did": did}))).await;
+    let session_id = challenge_body["sessionId"].as_str().unwrap();
+
+    let doc = vta_sdk::auth_di::sign_authenticate_doc(
+        &did,
+        &private_key_multibase,
+        "did:key:z6MkTestVta",
+        "the-real-challenge",
+        session_id,
+    )
+    .await
+    .expect("sign");
+    // Swap the challenge *after* signing — the proof no longer covers it.
+    let mut tampered: Value = serde_json::from_str(&doc).unwrap();
+    tampered["payload"]["challenge"] = json!(challenge_body["challenge"].as_str().unwrap());
+
+    let req = Request::builder()
+        .method("POST")
+        .uri("/auth/")
+        .header("content-type", "application/json")
+        .header("x-forwarded-for", "203.0.113.1")
+        .body(Body::from(tampered.to_string()))
+        .unwrap();
+    let (status, body) = request(&router, req).await;
+
+    assert_eq!(
+        status,
+        StatusCode::UNAUTHORIZED,
+        "a post-signature edit must not authenticate; got: {body}"
     );
 }
 

--- a/vtc-client/Cargo.toml
+++ b/vtc-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vtc-client"
 description = "Client SDK for Verifiable Trust Communities (VTC) — auth, members, join, removal, policies"
-version = "0.1.5"
+version = "0.1.6"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vtc-client/Cargo.toml
+++ b/vtc-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vtc-client"
 description = "Client SDK for Verifiable Trust Communities (VTC) — auth, members, join, removal, policies"
-version = "0.1.6"
+version = "0.2.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vtc-client/src/lib.rs
+++ b/vtc-client/src/lib.rs
@@ -19,27 +19,45 @@
 //! **full** API base to [`VtcClient::connect`] / [`VtcClient::with_token`] —
 //! e.g. `https://vtc.example.com/v1` — so both `/auth/*` and `/members` resolve.
 //!
-//! ## Status
+//! ## The `Trust-Task` header is mandatory
 //!
-//! First cut: authentication + member listing. Join / removal / policy methods
-//! are layered on next (the auth + transport plumbing here is what they build
-//! on).
+//! The VTC gates **every** route on a per-route `Trust-Task` URL header
+//! (`vtc-service/src/routes/mod.rs`, the `tt(...)` wrapper) and answers `400`
+//! without it — only `/health` and the browser wallet's `/wallet/auth/*`
+//! aliases are exempt. This client sent it on nothing, so every method failed
+//! at the transport layer regardless of its body. [`task`] holds the URL for
+//! each route and `VtcClient::tt` attaches it; a new method must go through
+//! that helper, not a bare `self.http.get(...)`.
 //!
-//! **[`VtcClient::connect`] does not currently authenticate against a live
-//! VTC.** The challenge-response flow is audience-agnostic in shape but not in
-//! *transport*: `challenge_response_light` posts a DI-signed
-//! `auth/authenticate/0.1` Trust Task, and the VTC's `POST /auth/` accepts only
-//! a VTA-wallet SIOP envelope or an authcrypt DIDComm envelope
-//! (`vtc-service/src/routes/auth.rs::authenticate_and_mint`) — it has no
-//! Trust-Task path on login, unlike its own `/auth/refresh` and unlike the VTA.
-//! This has been broken since the VTC began requiring an authenticated sender
-//! (VTI #771) rejected the anoncrypt envelope this used to send; the SDK's move
-//! to a signed document fixed the VTA side and changes only *which* error the
-//! VTC returns. Until the VTC grows the Trust-Task login path, obtain a token
-//! out of band and use [`VtcClient::with_token`].
+//! ## Scope
+//!
+//! Authentication, the member roster, the admin join queue, removal, and
+//! policy. Join *submission* (the applicant side) is not here — see
+//! [`VtcClient::submit_join`] for where it moved.
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+
+/// The `Trust-Task` URL each route this client calls is gated on, as declared
+/// in `vtc-service/src/routes/mod.rs`.
+///
+/// Kept as one block so the mapping is auditable against the server's router in
+/// a single read, rather than scattered as string literals down the file. A URL
+/// that drifts from the server's is a 400 at runtime, so this list is part of
+/// the client's contract, not decoration.
+pub mod task {
+    pub const MEMBERS_LIST: &str = "https://trusttasks.org/spec/vtc/members/list/0.1";
+    pub const MEMBERS_UPDATE: &str = "https://trusttasks.org/spec/vtc/members/update/0.1";
+    pub const MEMBERS_ADMIN_REMOVE: &str =
+        "https://trusttasks.org/spec/vtc/members/admin-remove/0.1";
+    pub const JOIN_REQUESTS_LIST: &str = "https://trusttasks.org/spec/vtc/join-requests/list/0.1";
+    pub const JOIN_REQUESTS_DECIDE: &str =
+        "https://trusttasks.org/spec/vtc/join-requests/decide/0.1";
+    pub const POLICY_LIST: &str = "https://trusttasks.org/spec/policy/list/0.2";
+    pub const POLICY_GET: &str = "https://trusttasks.org/spec/policy/get/0.1";
+    pub const POLICY_UPSERT: &str = "https://trusttasks.org/spec/policy/upsert/0.2";
+    pub const POLICY_ACTIVATE: &str = "https://trusttasks.org/spec/policy/activate/0.1";
+}
 
 /// Re-export of the published join-request protocol wire types, so a consumer
 /// driving the join ceremony depends on one crate.
@@ -64,6 +82,10 @@ pub enum VtcError {
     /// Challenge-response authentication failed.
     #[error("authentication failed: {0}")]
     Auth(#[from] vta_sdk::error::VtaError),
+    /// The operation's route no longer exists on the VTC and this client has no
+    /// replacement for it. Carries what to use instead.
+    #[error("unsupported by this client: {0}")]
+    Unsupported(&'static str),
 }
 
 /// A single member of the community, as returned by `GET /members`. Mirrors the
@@ -203,11 +225,31 @@ impl VtcClient {
         &self.vtc_did
     }
 
+    /// Start a request carrying the route's `Trust-Task` URL header and the
+    /// bearer token.
+    ///
+    /// Every authenticated call goes through here. The VTC rejects a request
+    /// with no `Trust-Task` header (400) before any handler sees it, so a
+    /// method that builds its request by hand is broken on arrival — which is
+    /// how every method in this client came to be.
+    fn tt(
+        &self,
+        method: reqwest::Method,
+        url: impl reqwest::IntoUrl,
+        task: &str,
+    ) -> Result<reqwest::RequestBuilder, VtcError> {
+        let token = self.token()?;
+        Ok(self
+            .http
+            .request(method, url)
+            .header("Trust-Task", task)
+            .bearer_auth(token))
+    }
+
     /// List every community member, optionally filtered by `role`, following the
     /// cursor to completion. Requires an admin token. This is the fleet roster
     /// when the community's members are managed VTAs.
     pub async fn list_members(&self, role: Option<&str>) -> Result<Vec<MemberRecord>, VtcError> {
-        let token = self.token.as_deref().ok_or(VtcError::NotAuthenticated)?;
         let mut out: Vec<MemberRecord> = Vec::new();
         let mut cursor: Option<String> = None;
 
@@ -223,7 +265,10 @@ impl VtcClient {
                 reqwest::Url::parse_with_params(&format!("{}/members", self.base_url), &params)
                     .map_err(|e| VtcError::Url(e.to_string()))?;
 
-            let resp = self.http.get(url).bearer_auth(token).send().await?;
+            let resp = self
+                .tt(reqwest::Method::GET, url, task::MEMBERS_LIST)?
+                .send()
+                .await?;
             if !resp.status().is_success() {
                 let status = resp.status().as_u16();
                 let body = resp.text().await.unwrap_or_default();
@@ -247,7 +292,6 @@ impl VtcClient {
         &self,
         status: Option<&str>,
     ) -> Result<Vec<JoinRequestSummary>, VtcError> {
-        let token = self.token()?;
         let mut out: Vec<JoinRequestSummary> = Vec::new();
         let mut cursor: Option<String> = None;
         loop {
@@ -264,7 +308,10 @@ impl VtcClient {
             )
             .map_err(|e| VtcError::Url(e.to_string()))?;
 
-            let resp = self.http.get(url).bearer_auth(token).send().await?;
+            let resp = self
+                .tt(reqwest::Method::GET, url, task::JOIN_REQUESTS_LIST)?
+                .send()
+                .await?;
             if !resp.status().is_success() {
                 let status = resp.status().as_u16();
                 let body = resp.text().await.unwrap_or_default();
@@ -284,18 +331,43 @@ impl VtcClient {
     /// credential (VMC). Requires an admin token. For a fleet, this enrolls a
     /// VTA that has applied to join.
     pub async fn approve_join(&self, request_id: &str) -> Result<DecideResult, VtcError> {
-        self.decide(request_id, "approve").await
+        self.decide(request_id, "approved", None).await
     }
 
-    /// Reject a join request. Requires an admin token.
-    pub async fn reject_join(&self, request_id: &str) -> Result<DecideResult, VtcError> {
-        self.decide(request_id, "reject").await
+    /// Reject a join request, optionally recording an operator rationale in the
+    /// audit trail. Requires an admin token.
+    pub async fn reject_join(
+        &self,
+        request_id: &str,
+        reason: Option<&str>,
+    ) -> Result<DecideResult, VtcError> {
+        self.decide(request_id, "rejected", reason).await
     }
 
-    async fn decide(&self, request_id: &str, verb: &str) -> Result<DecideResult, VtcError> {
-        let token = self.token()?;
-        let url = format!("{}/join-requests/{request_id}/{verb}", self.base_url);
-        let resp = self.http.post(url).bearer_auth(token).send().await?;
+    /// `POST /join-requests/{id}/decide` with `{ decision, reason? }`.
+    ///
+    /// The VTC previously exposed a `/approve` + `/reject` mount pair; both were
+    /// retired in favour of this single endpoint carrying the decision in the
+    /// body, and the old mounts are **gone** — this client was still posting to
+    /// them, so approve and reject were 404s independent of the missing header.
+    /// `decision` is the server's `Decision` enum on the wire (`approved` /
+    /// `rejected`), not the imperative verb the old paths used.
+    async fn decide(
+        &self,
+        request_id: &str,
+        decision: &str,
+        reason: Option<&str>,
+    ) -> Result<DecideResult, VtcError> {
+        let url = format!("{}/join-requests/{request_id}/decide", self.base_url);
+        let mut body = serde_json::json!({ "decision": decision });
+        if let Some(reason) = reason {
+            body["reason"] = serde_json::json!(reason);
+        }
+        let resp = self
+            .tt(reqwest::Method::POST, url, task::JOIN_REQUESTS_DECIDE)?
+            .json(&body)
+            .send()
+            .await?;
         if !resp.status().is_success() {
             let status = resp.status().as_u16();
             let body = resp.text().await.unwrap_or_default();
@@ -313,9 +385,8 @@ impl VtcClient {
         did: &str,
         reason: Option<&str>,
     ) -> Result<RemoveResult, VtcError> {
-        let token = self.token()?;
         let url = format!("{}/members/{did}", self.base_url);
-        let mut req = self.http.delete(url).bearer_auth(token);
+        let mut req = self.tt(reqwest::Method::DELETE, url, task::MEMBERS_ADMIN_REMOVE)?;
         if let Some(reason) = reason {
             req = req.json(&serde_json::json!({ "reason": reason }));
         }
@@ -337,11 +408,12 @@ impl VtcClient {
         did: &str,
         extensions: serde_json::Value,
     ) -> Result<(), VtcError> {
-        let token = self.token()?;
         let resp = self
-            .http
-            .patch(format!("{}/members/{did}", self.base_url))
-            .bearer_auth(token)
+            .tt(
+                reqwest::Method::PATCH,
+                format!("{}/members/{did}", self.base_url),
+                task::MEMBERS_UPDATE,
+            )?
             .json(&serde_json::json!({ "extensions": extensions }))
             .send()
             .await?;
@@ -353,31 +425,38 @@ impl VtcClient {
         Ok(())
     }
 
-    /// Submit a join request (the applicant side): POST the VP-framed
-    /// `body` to `/join-requests`. The VP's holder-binding proof authenticates
-    /// the applicant, so this does not require a bearer token. Returns the
-    /// verdict (auto-admit issues the VMC inline; otherwise it's queued).
+    /// Submit a join request (the applicant side).
+    ///
+    /// # Unimplemented against the current VTC
+    ///
+    /// This posted the VP-framed body to `POST /join-requests`. That route no
+    /// longer exists: the holder-facing join verbs (`submit`/`request`,
+    /// `manifest`, `status`) were folded into the single Trust-Task document
+    /// endpoint `POST /trust-tasks`, routed by document `type`, with the
+    /// holder's `eddsa-jcs-2022` proof as the authentication
+    /// (`vtc-service/src/routes/mod.rs`, `trust_tasks::dispatch`). The handler
+    /// this used to reach is now unrouted code.
+    ///
+    /// Submitting therefore means building and signing a
+    /// `join-requests/submit` Trust Task, which needs the applicant's holder
+    /// key — a different shape from this method's `body`-only signature, and
+    /// not something to fake by changing the URL. Rather than keep issuing a
+    /// silent 404, this returns a typed error naming the replacement. The
+    /// applicant side is driven today by the join ceremony in
+    /// `vta-cli-common` / `vta-mobile-core`, which speak that endpoint.
     pub async fn submit_join(
         &self,
-        body: &join_requests::JoinRequestSubmitBody,
+        _body: &join_requests::JoinRequestSubmitBody,
     ) -> Result<DecideResult, VtcError> {
-        let resp = self
-            .http
-            .post(format!("{}/join-requests", self.base_url))
-            .json(body)
-            .send()
-            .await?;
-        if !resp.status().is_success() {
-            let status = resp.status().as_u16();
-            let body = resp.text().await.unwrap_or_default();
-            return Err(VtcError::Http { status, body });
-        }
-        Ok(resp.json().await?)
+        Err(VtcError::Unsupported(
+            "join submission moved to the Trust-Task document endpoint (POST /trust-tasks, \
+             type join-requests/submit) and needs the applicant's holder key to sign the \
+             document; POST /join-requests is no longer routed",
+        ))
     }
 
     /// List the community's policies (opaque JSON descriptors). Admin token.
     pub async fn list_policies(&self) -> Result<Vec<serde_json::Value>, VtcError> {
-        let token = self.token()?;
         let mut out = Vec::new();
         let mut cursor: Option<String> = None;
         loop {
@@ -388,7 +467,10 @@ impl VtcClient {
             let url =
                 reqwest::Url::parse_with_params(&format!("{}/policies", self.base_url), &params)
                     .map_err(|e| VtcError::Url(e.to_string()))?;
-            let resp = self.http.get(url).bearer_auth(token).send().await?;
+            let resp = self
+                .tt(reqwest::Method::GET, url, task::POLICY_LIST)?
+                .send()
+                .await?;
             if !resp.status().is_success() {
                 let status = resp.status().as_u16();
                 let body = resp.text().await.unwrap_or_default();
@@ -406,7 +488,8 @@ impl VtcClient {
 
     /// Fetch one policy by id (opaque JSON, incl. the Rego source). Admin token.
     pub async fn get_policy(&self, id: &str) -> Result<serde_json::Value, VtcError> {
-        self.get_json(&format!("policies/{id}")).await
+        self.get_json(&format!("policies/{id}"), task::POLICY_GET)
+            .await
     }
 
     /// Upload a new Rego policy bundle for `purpose` (`"join"`, `"removal"`,
@@ -419,6 +502,7 @@ impl VtcClient {
     ) -> Result<serde_json::Value, VtcError> {
         self.post_json(
             "policies",
+            task::POLICY_UPSERT,
             &serde_json::json!({ "purpose": purpose, "regoSource": rego_source }),
         )
         .await
@@ -427,17 +511,22 @@ impl VtcClient {
     /// Activate a previously-uploaded policy (make it live for decisions of its
     /// purpose). Admin token.
     pub async fn activate_policy(&self, id: &str) -> Result<serde_json::Value, VtcError> {
-        self.post_json(&format!("policies/{id}/activate"), &serde_json::json!({}))
-            .await
+        self.post_json(
+            &format!("policies/{id}/activate"),
+            task::POLICY_ACTIVATE,
+            &serde_json::json!({}),
+        )
+        .await
     }
 
-    /// Authenticated GET returning JSON.
-    async fn get_json(&self, path: &str) -> Result<serde_json::Value, VtcError> {
-        let token = self.token()?;
+    /// Authenticated GET returning JSON, carrying `task` as the Trust-Task URL.
+    async fn get_json(&self, path: &str, task: &str) -> Result<serde_json::Value, VtcError> {
         let resp = self
-            .http
-            .get(format!("{}/{path}", self.base_url))
-            .bearer_auth(token)
+            .tt(
+                reqwest::Method::GET,
+                format!("{}/{path}", self.base_url),
+                task,
+            )?
             .send()
             .await?;
         if !resp.status().is_success() {
@@ -448,17 +537,20 @@ impl VtcClient {
         Ok(resp.json().await?)
     }
 
-    /// Authenticated POST of a JSON body returning JSON.
+    /// Authenticated POST of a JSON body returning JSON, carrying `task` as the
+    /// Trust-Task URL.
     async fn post_json(
         &self,
         path: &str,
+        task: &str,
         body: &serde_json::Value,
     ) -> Result<serde_json::Value, VtcError> {
-        let token = self.token()?;
         let resp = self
-            .http
-            .post(format!("{}/{path}", self.base_url))
-            .bearer_auth(token)
+            .tt(
+                reqwest::Method::POST,
+                format!("{}/{path}", self.base_url),
+                task,
+            )?
             .json(body)
             .send()
             .await?;

--- a/vtc-client/src/lib.rs
+++ b/vtc-client/src/lib.rs
@@ -24,6 +24,19 @@
 //! First cut: authentication + member listing. Join / removal / policy methods
 //! are layered on next (the auth + transport plumbing here is what they build
 //! on).
+//!
+//! **[`VtcClient::connect`] does not currently authenticate against a live
+//! VTC.** The challenge-response flow is audience-agnostic in shape but not in
+//! *transport*: `challenge_response_light` posts a DI-signed
+//! `auth/authenticate/0.1` Trust Task, and the VTC's `POST /auth/` accepts only
+//! a VTA-wallet SIOP envelope or an authcrypt DIDComm envelope
+//! (`vtc-service/src/routes/auth.rs::authenticate_and_mint`) — it has no
+//! Trust-Task path on login, unlike its own `/auth/refresh` and unlike the VTA.
+//! This has been broken since the VTC began requiring an authenticated sender
+//! (VTI #771) rejected the anoncrypt envelope this used to send; the SDK's move
+//! to a signed document fixed the VTA side and changes only *which* error the
+//! VTC returns. Until the VTC grows the Trust-Task login path, obtain a token
+//! out of band and use [`VtcClient::with_token`].
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};

--- a/vtc-client/src/lib.rs
+++ b/vtc-client/src/lib.rs
@@ -191,7 +191,9 @@ impl VtcClient {
         client_did: &str,
         private_key_multibase: &str,
     ) -> Result<Self, VtcError> {
-        let http = reqwest::Client::new();
+        // Finite request + connect timeouts (R1.2) — `reqwest::Client::new()`
+        // has neither, so a blackholed VTC would hang an operator forever.
+        let http = vta_sdk::http::rest_client();
         let base_url = base_url.trim_end_matches('/').to_string();
         let auth = vta_sdk::auth_light::challenge_response_light(
             &http,
@@ -213,7 +215,7 @@ impl VtcClient {
     /// minted out of band, or for testing). `base_url` includes the mount.
     pub fn with_token(base_url: &str, vtc_did: &str, token: impl Into<String>) -> Self {
         Self {
-            http: reqwest::Client::new(),
+            http: vta_sdk::http::rest_client(),
             base_url: base_url.trim_end_matches('/').to_string(),
             vtc_did: vtc_did.to_string(),
             token: Some(token.into()),

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.11.47"
+version = "0.11.48"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -271,6 +271,13 @@ tempfile = { version = "3", optional = true }
 # Self-dep with `test-support` enabled so integration tests under
 # `tests/` can import `vtc_service::test_support` (`TestVtc`, `MockVtc`).
 vtc-service = { path = ".", features = ["test-support", "didcomm-harness"] }
+# The VTC's own client SDK, driven against `MockVtc` in
+# `tests/vtc_client_live.rs`. Testing it here (rather than in `vtc-client`,
+# which cannot see `MockVtc`) is what makes client/server drift a build
+# failure: the client was silently broken on every route because nothing ever
+# ran the pair together. Dev-only, and `vtc-client` does not depend on
+# `vtc-service`, so there is no cycle.
+vtc-client = { path = "../vtc-client" }
 tempfile = "3"
 # Integration tests under `tests/` exercise the route stack via
 # `Router::oneshot` — same pattern as `vta-service/tests/api_integration.rs`.

--- a/vtc-service/src/routes/auth.rs
+++ b/vtc-service/src/routes/auth.rs
@@ -122,9 +122,7 @@ async fn authenticate_siop(
     let Ok(env) = serde_json::from_str::<SiopAuthEnvelope>(body) else {
         return Ok(None);
     };
-    if env.typ.as_str() != "https://trusttasks.org/spec/auth/authenticate/0.1"
-        || env.payload.id_token.is_empty()
-    {
+    if env.typ.as_str() != AUTHENTICATE_TASK_URI || env.payload.id_token.is_empty() {
         return Ok(None);
     }
 
@@ -231,6 +229,12 @@ async fn authenticate_and_mint(
         return Ok(resp);
     }
 
+    // Canonical REST login: a DI-signed `auth/authenticate/0.1` Trust Task,
+    // the same document the VTA accepts. Returns `None` for any other body.
+    if let Some(resp) = authenticate_trust_task(state, body).await? {
+        return Ok(resp);
+    }
+
     let atm = state
         .atm
         .as_ref()
@@ -246,7 +250,7 @@ async fn authenticate_and_mint(
 
     // Canonical Trust-Task URI only; the legacy `affinidi.com/atm/1.0`
     // alias was removed (all VTC clients emit the canonical type).
-    if msg.typ.as_str() != "https://trusttasks.org/spec/auth/authenticate/0.1" {
+    if msg.typ.as_str() != AUTHENTICATE_TASK_URI {
         return Err(AppError::Authentication(format!(
             "unexpected message type: {}",
             msg.typ
@@ -277,6 +281,78 @@ async fn authenticate_and_mint(
         },
     )
     .await
+}
+
+/// The canonical `auth/authenticate/0.1` Type URI, shared by all three request
+/// shapes — the DIDComm envelope's `msg.typ`, the SIOP envelope's `type`, and
+/// the REST Trust Task's `type`.
+const AUTHENTICATE_TASK_URI: &str = "https://trusttasks.org/spec/auth/authenticate/0.1";
+
+/// Try to authenticate from a DI-signed `auth/authenticate/0.1` Trust Task —
+/// the canonical REST login, and the VTC counterpart of the VTA's
+/// `try_authenticate_trust_task`.
+///
+/// **Why this exists.** The VTC accepted two login shapes: a VTA-wallet SIOP
+/// envelope, and an authcrypt DIDComm envelope. A REST client holding a plain
+/// `did:key` — no wallet to self-issue an `id_token`, no mediator to authcrypt
+/// through — could satisfy neither, so `vtc-client::connect` could not log in
+/// at all. `/auth/refresh` had already grown the Trust-Task path for exactly
+/// this reason; login had not, which left a client able to *rotate* a token it
+/// had no way to obtain.
+///
+/// The document is byte-identical to the one the VTA accepts (built by
+/// `vta_sdk::auth_di::sign_authenticate_doc`), so one client builder logs in to
+/// both services. The holder's `eddsa-jcs-2022` proof *is* the authentication:
+/// the proven `verificationMethod` DID is the signer, and the canonical handler
+/// binds it to the session's DID.
+///
+/// **Discrimination.** A body is claimed only when it parses as a Trust Task,
+/// carries the authenticate Type URI, *and* has a `proof`. The proof
+/// requirement is what keeps this from shadowing [`authenticate_siop`], whose
+/// envelope shares the Type URI — and it means an unsigned document falls
+/// through to the other paths rather than being claimed and rejected.
+///
+/// Returns `Ok(None)` when the body isn't such a document; `Err` when it *is*
+/// one but is invalid (bad proof, malformed payload, challenge mismatch).
+async fn authenticate_trust_task(
+    state: &AppState,
+    body: &str,
+) -> Result<Option<AuthenticateResponse>, AppError> {
+    use trust_tasks_rs::specs::auth::authenticate::v0_1 as authenticate;
+
+    let doc: TrustTask<serde_json::Value> = match serde_json::from_str(body) {
+        Ok(doc) => doc,
+        Err(_) => return Ok(None), // not a Trust Task document
+    };
+    if doc.type_uri.to_string() != AUTHENTICATE_TASK_URI || doc.proof.is_none() {
+        return Ok(None);
+    }
+
+    // From here the caller's intent is unambiguous; failures are real.
+    let signer_did = vti_common::auth::di_proof::verify_trust_task_proof(&doc)
+        .await
+        .map_err(|e| AppError::Authentication(e.to_string()))?;
+    let payload: authenticate::Payload = serde_json::from_value(doc.payload.clone())
+        .map_err(|e| AppError::Authentication(format!("invalid authenticate payload: {e}")))?;
+
+    let backend = crate::auth::VtcAuthBackend::from_state(state).await?;
+    let resp = vti_common::auth::handlers::handle_authenticate(
+        &backend,
+        vti_common::auth::AuthenticateInput {
+            session_id: payload.session_id.to_string(),
+            challenge: payload.challenge.to_string(),
+            // Proven by the DI proof, not claimed by a header.
+            signer_did,
+            // No DIDComm `created_time`; the single-use, TTL'd challenge bound
+            // to the session is the freshness/replay anchor (the canonical
+            // handler reads `None` as a no-op freshness check, same as the SIOP
+            // path above).
+            created_time: None,
+            session_pubkey_b58btc: None,
+        },
+    )
+    .await?;
+    Ok(Some(resp))
 }
 
 // ---------- POST /auth/admin-session ----------

--- a/vtc-service/src/trust_tasks/helpers.rs
+++ b/vtc-service/src/trust_tasks/helpers.rs
@@ -15,9 +15,9 @@
 //! - `body_parse_error_response` — unrouted reject for a body that is not a
 //!   Trust Task document at all.
 //! - `verify_trust_task_proof` — the holder's `eddsa-jcs-2022` DI proof
-//!   verifier for the REST path (ported from the VTA's `auth::di_proof`).
+//!   verifier for the REST path (an adapter over the shared
+//!   `vti_common::auth::di_proof`, which both services now use).
 
-use affinidi_data_integrity::{DataIntegrityProof, DidKeyResolver, VerifyOptions};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use serde::Serialize;
@@ -181,44 +181,20 @@ pub(crate) fn body_parse_error_response(reason: &str) -> TrustTaskOutcome {
 
 /// Verify the holder's `eddsa-jcs-2022` Data-Integrity proof on `doc` and
 /// return the proven signer DID — the base DID (before `#`) of the proof's
-/// `verificationMethod`. Ported from `vta-service::auth::di_proof`.
+/// `verificationMethod`.
+///
+/// Thin adapter over [`vti_common::auth::di_proof::verify_trust_task_proof`],
+/// the single implementation both services share. This used to be a *port* of
+/// the VTA's copy; a proof means the same thing at both ends of the mesh, so a
+/// second implementation was only ever a chance for the two to disagree. Only
+/// the error mapping is local — the join dispatcher renders `AppError`.
 ///
 /// The signature is verified over the document with its `proof` removed
 /// (`eddsa-jcs-2022` canonicalises the proofless document via JCS). The
 /// returned DID is *proven*, not merely claimed — binding it to an expected
 /// identity is the caller's job. `did:key` resolution is local (no network).
 pub(crate) async fn verify_trust_task_proof(doc: &TrustTask<Value>) -> Result<String, AppError> {
-    let proof = doc
-        .proof
-        .as_ref()
-        .ok_or_else(|| AppError::Unauthorized("Trust Task document has no proof".into()))?;
-
-    let di: DataIntegrityProof = serde_json::to_value(proof)
-        .ok()
-        .and_then(|v| serde_json::from_value(v).ok())
-        .ok_or_else(|| {
-            AppError::Unauthorized("Trust Task proof is not a Data Integrity proof".into())
-        })?;
-
-    let signer_did = di
-        .verification_method
-        .split('#')
-        .next()
-        .unwrap_or_default()
-        .to_string();
-    if signer_did.is_empty() {
-        return Err(AppError::Unauthorized(
-            "Trust Task proof verificationMethod carries no DID".into(),
-        ));
-    }
-
-    let mut unsigned = doc.clone();
-    unsigned.proof = None;
-    di.verify(&unsigned, &DidKeyResolver, VerifyOptions::new())
+    vti_common::auth::di_proof::verify_trust_task_proof(doc)
         .await
-        .map_err(|e| {
-            AppError::Unauthorized(format!("Trust Task proof verification failed: {e}"))
-        })?;
-
-    Ok(signer_did)
+        .map_err(|e| AppError::Unauthorized(format!("Trust Task {e}")))
 }

--- a/vtc-service/tests/auth_di_trust_task.rs
+++ b/vtc-service/tests/auth_di_trust_task.rs
@@ -1,0 +1,299 @@
+//! The VTC's canonical REST login: a DI-signed `auth/authenticate/0.1` Trust
+//! Task, driven by the *client's own* builder (`vta_sdk::auth_di`).
+//!
+//! **Why this exists.** The VTC accepted two login shapes — a VTA-wallet SIOP
+//! envelope, and an authcrypt DIDComm envelope. A REST client holding a plain
+//! `did:key` (no wallet to self-issue an `id_token`, no mediator to authcrypt
+//! through) could satisfy neither, so `vtc-client::connect` could not log in at
+//! all. `/auth/refresh` had already grown the Trust-Task path; login had not,
+//! which left a client able to *rotate* a token it had no way to obtain.
+//!
+//! Every test here posts bytes produced by the real SDK builder rather than a
+//! hand-written fixture, so a client/server drift — the defect class that made
+//! this necessary — fails the build instead of an operator's setup run.
+
+use reqwest::StatusCode;
+use serde_json::{Value, json};
+
+use vtc_service::acl::{VtcAclEntry, VtcRole, store_acl_entry};
+use vtc_service::test_support::MockVtc;
+
+const CHALLENGE_TASK: &str = "https://trusttasks.org/spec/auth/challenge/0.1";
+const AUTHENTICATE_TASK: &str = "https://trusttasks.org/spec/auth/authenticate/0.1";
+const REFRESH_TASK: &str = "https://trusttasks.org/spec/auth/refresh/0.1";
+
+fn admin_entry(did: &str) -> VtcAclEntry {
+    VtcAclEntry {
+        did: did.into(),
+        role: VtcRole::Admin,
+        label: None,
+        allowed_contexts: vec![],
+        created_at: 1,
+        created_by: "did:key:vtc-install".into(),
+        updated_at: None,
+        updated_by: None,
+        expires_at: None,
+    }
+}
+
+/// A deterministic `did:key` + its multibase private key, in the shape the
+/// SDK's client helpers take.
+fn did_key_from_seed(seed_byte: u8) -> (String, String) {
+    let seed = [seed_byte; 32];
+    let sk = ed25519_dalek::SigningKey::from_bytes(&seed);
+    let did = format!(
+        "did:key:{}",
+        vta_sdk::did_key::ed25519_multibase_pubkey(&sk.verifying_key().to_bytes())
+    );
+    // Multicodec Ed25519 private-key prefix (0x1300 → varint 0x80 0x26).
+    let mut buf = vec![0x80, 0x26];
+    buf.extend_from_slice(&seed);
+    (did, multibase::encode(multibase::Base::Base58Btc, &buf))
+}
+
+/// Fetch a challenge for `did` from a running VTC.
+async fn get_challenge(client: &reqwest::Client, base: &str, did: &str) -> (String, String) {
+    let resp = client
+        .post(format!("{base}/v1/auth/challenge"))
+        .header("Trust-Task", CHALLENGE_TASK)
+        .json(&json!({ "did": did }))
+        .send()
+        .await
+        .expect("POST /v1/auth/challenge");
+    assert_eq!(resp.status(), StatusCode::OK, "challenge issuance");
+    let body: Value = resp.json().await.expect("challenge json");
+    (
+        body["challenge"].as_str().expect("challenge").to_string(),
+        body["sessionId"].as_str().expect("sessionId").to_string(),
+    )
+}
+
+/// The whole login: challenge → SDK-signed Trust Task → tokens. No mediator,
+/// no ATM, no wallet — the holder key is the only credential involved.
+#[tokio::test]
+async fn di_signed_trust_task_authenticates_over_rest() {
+    let mock = MockVtc::start().await;
+    let base = mock.base_url().to_string();
+    let client = reqwest::Client::new();
+
+    let (did, private_key_multibase) = did_key_from_seed(0x7a);
+    store_acl_entry(&mock.vtc.state.acl_ks, &admin_entry(&did))
+        .await
+        .expect("seed admin acl row");
+
+    let (challenge, session_id) = get_challenge(&client, &base, &did).await;
+
+    let doc = vta_sdk::auth_di::sign_authenticate_doc(
+        &did,
+        &private_key_multibase,
+        "did:key:z6MkVtcUnderTest",
+        &challenge,
+        &session_id,
+    )
+    .await
+    .expect("sign authenticate document");
+
+    let resp = client
+        .post(format!("{base}/v1/auth/"))
+        .header("Trust-Task", AUTHENTICATE_TASK)
+        .header("content-type", "application/json")
+        .body(doc)
+        .send()
+        .await
+        .expect("POST /v1/auth/");
+
+    let status = resp.status();
+    let body: Value = resp.json().await.unwrap_or_else(|_| json!({}));
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "a DI-signed Trust Task must authenticate against the VTC; got: {body}"
+    );
+    assert!(
+        body["tokens"]["accessToken"]
+            .as_str()
+            .is_some_and(|t| !t.is_empty()),
+        "response must carry an access token: {body}"
+    );
+    assert_eq!(
+        body["session"]["subject"], did,
+        "the session must be bound to the proven signer: {body}"
+    );
+
+    mock.shutdown().await;
+}
+
+/// The token the DI login mints is usable, and the refresh token it carries
+/// rotates through the Trust-Task refresh path — the two halves of the flow
+/// that were previously unreachable together (refresh existed; login did not).
+#[tokio::test]
+async fn di_login_then_trust_task_refresh_round_trips() {
+    let mock = MockVtc::start().await;
+    let base = mock.base_url().to_string();
+    let client = reqwest::Client::new();
+
+    let (did, private_key_multibase) = did_key_from_seed(0x7b);
+    store_acl_entry(&mock.vtc.state.acl_ks, &admin_entry(&did))
+        .await
+        .expect("seed admin acl row");
+
+    let (challenge, session_id) = get_challenge(&client, &base, &did).await;
+    let doc = vta_sdk::auth_di::sign_authenticate_doc(
+        &did,
+        &private_key_multibase,
+        "did:key:z6MkVtcUnderTest",
+        &challenge,
+        &session_id,
+    )
+    .await
+    .expect("sign");
+    let body: Value = client
+        .post(format!("{base}/v1/auth/"))
+        .header("Trust-Task", AUTHENTICATE_TASK)
+        .header("content-type", "application/json")
+        .body(doc)
+        .send()
+        .await
+        .expect("login")
+        .json()
+        .await
+        .expect("login json");
+
+    let refresh_token = body["tokens"]["refreshToken"]
+        .as_str()
+        .expect("login must issue a refresh token")
+        .to_string();
+
+    let refresh_doc =
+        vta_sdk::auth_di::build_refresh_doc(&did, "did:key:z6MkVtcUnderTest", &refresh_token)
+            .expect("build refresh document");
+    let resp = client
+        .post(format!("{base}/v1/auth/refresh"))
+        .header("Trust-Task", REFRESH_TASK)
+        .header("content-type", "application/json")
+        .body(refresh_doc)
+        .send()
+        .await
+        .expect("POST /v1/auth/refresh");
+
+    let status = resp.status();
+    let refreshed: Value = resp.json().await.unwrap_or_else(|_| json!({}));
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "the refresh token from a DI login must rotate: {refreshed}"
+    );
+    assert!(
+        refreshed["tokens"]["accessToken"]
+            .as_str()
+            .is_some_and(|t| !t.is_empty()),
+        "rotation must return a fresh access token: {refreshed}"
+    );
+
+    mock.shutdown().await;
+}
+
+/// The proof is load-bearing: editing the challenge after signing must not
+/// authenticate. Guards against a future "parse the payload, skip the proof"
+/// shortcut on the VTC's REST path.
+#[tokio::test]
+async fn tampered_challenge_is_rejected() {
+    let mock = MockVtc::start().await;
+    let base = mock.base_url().to_string();
+    let client = reqwest::Client::new();
+
+    let (did, private_key_multibase) = did_key_from_seed(0x7c);
+    store_acl_entry(&mock.vtc.state.acl_ks, &admin_entry(&did))
+        .await
+        .expect("seed admin acl row");
+
+    let (challenge, session_id) = get_challenge(&client, &base, &did).await;
+    let doc = vta_sdk::auth_di::sign_authenticate_doc(
+        &did,
+        &private_key_multibase,
+        "did:key:z6MkVtcUnderTest",
+        // Sign over a *different* challenge, then swap the real one in.
+        "0000000000000000000000000000000000000000",
+        &session_id,
+    )
+    .await
+    .expect("sign");
+    let mut tampered: Value = serde_json::from_str(&doc).expect("signed doc is JSON");
+    tampered["payload"]["challenge"] = json!(challenge);
+
+    let resp = client
+        .post(format!("{base}/v1/auth/"))
+        .header("Trust-Task", AUTHENTICATE_TASK)
+        .header("content-type", "application/json")
+        .body(tampered.to_string())
+        .send()
+        .await
+        .expect("POST /v1/auth/");
+
+    let status = resp.status();
+    let body: Value = resp.json().await.unwrap_or_else(|_| json!({}));
+    assert_eq!(
+        status,
+        StatusCode::UNAUTHORIZED,
+        "a post-signature edit must not authenticate: {body}"
+    );
+    assert!(
+        body.get("tokens").is_none(),
+        "no token may be issued for a tampered document: {body}"
+    );
+
+    mock.shutdown().await;
+}
+
+/// An **unsigned** authenticate document must not be claimed by the DI path.
+///
+/// This is the discrimination rule that keeps the new path from shadowing the
+/// SIOP envelope, which shares the Type URI: a body is only claimed when it
+/// carries a `proof`. Without the rule, a SIOP login that happened to parse as
+/// a Trust Task would be claimed here and rejected for a missing proof instead
+/// of being verified as a SIOP token. An unsigned document therefore falls
+/// through — and, finding no other path that accepts it, is refused.
+#[tokio::test]
+async fn unsigned_authenticate_document_is_not_claimed_by_the_di_path() {
+    let mock = MockVtc::start().await;
+    let base = mock.base_url().to_string();
+    let client = reqwest::Client::new();
+
+    let (did, _) = did_key_from_seed(0x7d);
+    store_acl_entry(&mock.vtc.state.acl_ks, &admin_entry(&did))
+        .await
+        .expect("seed admin acl row");
+
+    let (challenge, session_id) = get_challenge(&client, &base, &did).await;
+    let unsigned = json!({
+        "id": "urn:uuid:unsigned-1",
+        "type": AUTHENTICATE_TASK,
+        "issuer": did,
+        "payload": { "challenge": challenge, "sessionId": session_id },
+    });
+
+    let resp = client
+        .post(format!("{base}/v1/auth/"))
+        .header("Trust-Task", AUTHENTICATE_TASK)
+        .header("content-type", "application/json")
+        .body(unsigned.to_string())
+        .send()
+        .await
+        .expect("POST /v1/auth/");
+
+    let status = resp.status();
+    let body: Value = resp.json().await.unwrap_or_else(|_| json!({}));
+    assert_eq!(
+        status,
+        StatusCode::UNAUTHORIZED,
+        "an unsigned document must not mint tokens: {body}"
+    );
+    // Specifically NOT a DI-proof error — the DI path declined to claim it.
+    let err = body["error"].as_str().unwrap_or_default();
+    assert!(
+        !err.contains("proof verification failed"),
+        "the unsigned body must fall through, not be claimed and proof-rejected: {body}"
+    );
+
+    mock.shutdown().await;
+}

--- a/vtc-service/tests/vtc_client_live.rs
+++ b/vtc-service/tests/vtc_client_live.rs
@@ -1,0 +1,166 @@
+//! `vtc-client` driven against a live `MockVtc` — the pair, in one test.
+//!
+//! **Why this file exists.** `vtc-client` was broken on *every* route and
+//! nothing noticed, because its own tests only exercised serde shapes and the
+//! VTC's tests only exercised hand-written requests. Three independent faults
+//! had accumulated:
+//!
+//! 1. `connect` posted an anoncrypt DIDComm envelope, which the VTC stopped
+//!    accepting when `/auth/*` began requiring an authenticated sender (#771).
+//! 2. Nothing sent the `Trust-Task` URL header the VTC gates every route on, so
+//!    every call was a 400 before reaching a handler.
+//! 3. `approve_join` / `reject_join` posted to `/approve` + `/reject` mounts
+//!    that had been replaced by a single `/decide` endpoint, and `submit_join`
+//!    posted to a route that is no longer mounted at all.
+//!
+//! Each is invisible to a test that stubs the other side. So these run the real
+//! client against the real router: a regression in either direction fails here.
+
+use vtc_client::VtcClient;
+use vtc_service::acl::{VtcAclEntry, VtcRole, store_acl_entry};
+use vtc_service::test_support::MockVtc;
+
+fn admin_entry(did: &str) -> VtcAclEntry {
+    VtcAclEntry {
+        did: did.into(),
+        role: VtcRole::Admin,
+        label: None,
+        allowed_contexts: vec![],
+        created_at: 1,
+        created_by: "did:key:vtc-install".into(),
+        updated_at: None,
+        updated_by: None,
+        expires_at: None,
+    }
+}
+
+/// A deterministic `did:key` + its multibase private key.
+fn did_key_from_seed(seed_byte: u8) -> (String, String) {
+    let seed = [seed_byte; 32];
+    let sk = ed25519_dalek::SigningKey::from_bytes(&seed);
+    let did = format!(
+        "did:key:{}",
+        vta_sdk::did_key::ed25519_multibase_pubkey(&sk.verifying_key().to_bytes())
+    );
+    let mut buf = vec![0x80, 0x26];
+    buf.extend_from_slice(&seed);
+    (did, multibase::encode(multibase::Base::Base58Btc, &buf))
+}
+
+/// `VtcClient::connect` authenticates against a real VTC, and the token it
+/// returns drives an authenticated call.
+///
+/// This is the end-to-end pin for all three faults above: the login body must
+/// be what the VTC accepts, and both the login and the follow-up call must
+/// carry the Trust-Task header.
+#[tokio::test]
+async fn connect_then_list_members_round_trips() {
+    let mock = MockVtc::start().await;
+    let base = format!("{}/v1", mock.base_url());
+
+    let (did, private_key_multibase) = did_key_from_seed(0x91);
+    store_acl_entry(&mock.vtc.state.acl_ks, &admin_entry(&did))
+        .await
+        .expect("seed admin acl row");
+
+    let client = VtcClient::connect(
+        &base,
+        "did:key:z6MkVtcUnderTest",
+        &did,
+        &private_key_multibase,
+    )
+    .await
+    .expect("connect must authenticate against a live VTC");
+
+    // An authenticated admin read. A fresh community has no members; the point
+    // is that the call is *accepted* — a missing Trust-Task header would be a
+    // 400 and a stale token a 401.
+    let members = client
+        .list_members(None)
+        .await
+        .expect("list_members must be accepted by a live VTC");
+    assert!(
+        members.is_empty(),
+        "a fresh community has no members, got {members:?}"
+    );
+
+    mock.shutdown().await;
+}
+
+/// The admin join queue is readable, and a decision on a non-existent request
+/// reaches the handler rather than being refused at the router.
+///
+/// A 404/400-from-the-handler is the *success* condition for the decide half:
+/// it proves the request got past the Trust-Task gate and hit the `/decide`
+/// endpoint. The old client posted to `/approve`, which is unrouted — that is
+/// indistinguishable from this at the status-code level, so the assertion is on
+/// the error *not* being the router's Trust-Task rejection.
+#[tokio::test]
+async fn join_queue_reads_and_decide_reaches_the_handler() {
+    let mock = MockVtc::start().await;
+    let base = format!("{}/v1", mock.base_url());
+
+    let (did, private_key_multibase) = did_key_from_seed(0x92);
+    store_acl_entry(&mock.vtc.state.acl_ks, &admin_entry(&did))
+        .await
+        .expect("seed admin acl row");
+
+    let client = VtcClient::connect(
+        &base,
+        "did:key:z6MkVtcUnderTest",
+        &did,
+        &private_key_multibase,
+    )
+    .await
+    .expect("connect");
+
+    let queue = client
+        .list_join_requests(Some("pending"))
+        .await
+        .expect("list_join_requests must be accepted");
+    assert!(queue.is_empty(), "fresh community, got {queue:?}");
+
+    let err = client
+        .approve_join("00000000-0000-0000-0000-000000000000")
+        .await
+        .expect_err("no such join request");
+    match err {
+        vtc_client::VtcError::Http { status, body } => {
+            assert_ne!(
+                status, 400,
+                "a 400 here means the router refused the request (bad/missing \
+                 Trust-Task URL), not that the handler ran: {body}"
+            );
+            assert!(
+                !body.contains("Trust-Task"),
+                "the failure must come from the handler, not the Trust-Task gate: {body}"
+            );
+        }
+        other => panic!("expected an HTTP error from the decide handler, got {other:?}"),
+    }
+
+    mock.shutdown().await;
+}
+
+/// Join submission is refused with a typed error naming its replacement,
+/// instead of silently 404ing against an unrouted path.
+#[tokio::test]
+async fn submit_join_reports_where_it_moved() {
+    let (did, private_key_multibase) = did_key_from_seed(0x93);
+    let _ = private_key_multibase;
+    let client = VtcClient::with_token("https://vtc.invalid/v1", &did, "unused-token");
+
+    // Contents are irrelevant — the call is refused before any transport.
+    let body =
+        serde_json::from_value(serde_json::json!({ "vp": {} })).expect("minimal submit body");
+
+    match client.submit_join(&body).await {
+        Err(vtc_client::VtcError::Unsupported(msg)) => {
+            assert!(
+                msg.contains("/trust-tasks"),
+                "the error must name the endpoint that replaced it: {msg}"
+            );
+        }
+        other => panic!("expected Unsupported, got {other:?}"),
+    }
+}

--- a/vti-common/Cargo.toml
+++ b/vti-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-common"
 description = "Shared server-side infrastructure for VTA and VTC services"
 readme = "README.md"
-version = "0.11.30"
+version = "0.11.31"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vti-common/src/auth/di_proof.rs
+++ b/vti-common/src/auth/di_proof.rs
@@ -1,17 +1,24 @@
 //! Single `eddsa-jcs-2022` Data-Integrity proof verifier for Trust Task
 //! documents (P1.4).
 //!
-//! Two `/auth/*` paths need to verify a holder's DI proof on a Trust Task and
-//! recover the cryptographically-proven signer DID: the canonical REST
-//! authenticate path (`routes/auth.rs::verify_authenticate_proof`, signer
-//! unknown a priori) and the did-signed step-up gate
-//! (`routes/trust_tasks/step_up.rs::verify_did_signed_gate`, signer checked
-//! against the document issuer). They had drifted into two copies of the same
-//! extract → round-trip → verify-proofless-doc logic; this is the one
-//! implementation both delegate to.
+//! Every place that verifies a holder's DI proof on a Trust Task and recovers
+//! the cryptographically-proven signer DID delegates here. In the **VTA**: the
+//! canonical REST authenticate path (`routes/auth.rs::
+//! verify_authenticate_proof`, signer unknown a priori) and the did-signed
+//! step-up gate (`trust_tasks/step_up.rs::verify_did_signed_gate`, signer
+//! checked against the document issuer). In the **VTC**: the same REST
+//! authenticate path, and the join-request dispatcher's holder-binding check
+//! (`trust_tasks/helpers.rs::verify_trust_task_proof`).
+//!
+//! It started as one implementation in the VTA that had already drifted into
+//! two copies there, then a third when the VTC ported it. It lives in
+//! `vti-common` because *both services verify the same holder proof over the
+//! same wire shape* — a divergence between them is a divergence in what a
+//! signature means, which is not a thing to let happen twice.
 //!
 //! `did:key` resolution is local (no network I/O) — the mobile holder key is
-//! always a `did:key`, matching the engine's signing side.
+//! always a `did:key`, matching the engine's signing side, and it keeps proof
+//! verification off the network on an unauthenticated route.
 
 use affinidi_data_integrity::{DataIntegrityProof, DidKeyResolver, VerifyOptions};
 use serde_json::Value;

--- a/vti-common/src/auth/mod.rs
+++ b/vti-common/src/auth/mod.rs
@@ -1,4 +1,5 @@
 pub mod backend;
+pub mod di_proof;
 pub mod didcomm;
 pub mod extractor;
 pub mod handlers;
@@ -13,6 +14,7 @@ pub use backend::{
     AttestationOutcome, AuthAuditEvent, AuthBackend, AuthError, AuthenticateInput, ChallengeInput,
     RefreshInput, RoleResolution, SessionStore,
 };
+pub use di_proof::{DiProofError, verify_trust_task_proof};
 pub use didcomm::{AuthcryptError, bind_authcrypt_sender};
 pub use extractor::{
     AdminAuth, AuthClaims, AuthState, ManageAuth, StepUpAuth, SuperAdminAuth, WriteAuth,


### PR DESCRIPTION
## The symptom

VTC setup printed this and skipped the DID-hosting picker entirely, leaving the
community DID's publication target to be auto-selected:

```
Could not reach the VTA to list did-hosting servers (internal error: VTA REST
authentication failed: authentication failed: {"error":"authentication error:
authenticate message must be an authenticated (authcrypt) DIDComm envelope"})
```

## Root cause

`vta_sdk::auth_light` packed its `auth/authenticate/0.1` message as an
**anoncrypt** DIDComm envelope and discarded the caller's private key — the
sender was merely *asserted*, in a plaintext `from` header. #771 correctly
closed that forged-sender hole by requiring an authenticated (authcrypt)
envelope on `/auth/` and `/auth/refresh`, which rejects every anoncrypt message.
The SDK's whole lightweight REST auth tier has been dead since; the VTC wizard is
just the one caller with no fallback (`integration::auth::try_rest` had been
quietly absorbing it by dropping to the heavyweight ATM path).

The fix is the transport the VTA already prefers and tries **first**: an
`auth/authenticate/0.1` Trust Task carrying the holder's `eddsa-jcs-2022` proof,
where the signature *is* the authentication. No mediator, no ATM, works against a
REST-only service, and the key the caller already holds now proves the sender.

## The defect class, and three more instances of it

The real fault is structural: **a client builder and a server parser that no
single test ever runs together.** Client tests stub the server, server tests
hand-write the request, and the pair rots unnoticed. Auditing for it found:

2. **The VTC had no Trust-Task login path.** `/auth/` took a wallet SIOP
   envelope or an authcrypt DIDComm envelope. `/auth/refresh` had grown the
   Trust-Task path; login had not — leaving a REST client able to *rotate* a
   token it had no way to obtain. Added, tried after SIOP; a body is claimed only
   when it parses as a Trust Task, carries the authenticate Type URI, **and** has
   a `proof`. That last condition is what stops it shadowing the SIOP envelope,
   which shares the URI.

3. **The VTC gates every route on a `Trust-Task` URL header** (400 without it;
   the VTA ignores it) and **none** of the SDK's three REST auth paths sent one —
   so they were VTC-incompatible at the transport layer regardless of body. All
   three now do, including `session::challenge_response`, which is what `cnm`'s
   VTC backup authenticates through.

4. **`vtc-client` was broken on every route**, by three faults each hiding behind
   the others: the anoncrypt login, the missing header, and methods posting to
   mounts that no longer exist — `/approve` + `/reject` were replaced by one
   `/decide` carrying the decision in the body, and `POST /join-requests` is not
   routed at all since the holder-facing join verbs moved to the Trust-Task
   document endpoint.

## Also in here

- **The DI-proof verifier existed three times** — two copies in the VTA, a port
  in the VTC. Both services verify the same holder proof over the same wire
  shape, so a divergence between them is a divergence in what a signature
  *means*. Now `vti_common::auth::di_proof`, re-exported at the VTA's old path
  (no call site changes; the VTC adapter's error strings stay byte-identical).
- **Auth payloads are built from the generated spec types** instead of
  hand-written JSON, so casing can't drift (R3.1) and the spec's own validation
  runs client-side. This immediately caught three test fixtures using challenges
  below the spec's 16-char minimum — which the hand-written JSON had been happily
  putting on the wire.
- **`vtc-client` had no HTTP timeouts** (R1.2). Now uses
  `vta_sdk::http::rest_client`, promoted `pub(crate)` → `pub` so sibling client
  crates share the one chokepoint.

## Behaviour changes worth review

- `challenge_response_light` now **requires a `did:key` holder** — the servers
  resolve the proof's verification method with a `did:key`-only resolver, so
  anything else is refused locally (`VtaError::Validation`) instead of after a
  round trip. Other DID methods need `session::challenge_response` over DIDComm
  authcrypt, which `integration::auth::try_rest` already falls back to.
- The VTA's DID is no longer resolved by the client at all — it is just the
  document's `recipient` — so the `did:webvh` log fetch that preceded every login
  is gone.
- **vtc-client 0.2.0 is breaking**: `reject_join` gains an optional `reason` (the
  `/decide` body carries it), and `submit_join` returns a typed
  `VtcError::Unsupported` naming its replacement rather than issuing a silent
  404. Submitting needs the applicant's holder key to sign a Trust Task — a
  different shape from that method's signature, and driven today by
  `vta-cli-common` / `vta-mobile-core`.

## Testing

The gap that let all of this accumulate was that nothing ran a client against its
own server. Three suites now close it, all driving real bytes from the real
builder against the real router:

- `vta-service/tests/auth_flow.rs` — login succeeds; a challenge swapped in after
  signing is refused 401.
- `vtc-service/tests/auth_di_trust_task.rs` — login, login→refresh round trip,
  tampered challenge refused, unsigned document falls through rather than being
  claimed.
- `vtc-service/tests/vtc_client_live.rs` — `vtc-client` against a live `MockVtc`.

Full workspace `cargo check --all-targets` clean, `cargo fmt --check` clean,
clippy clean on touched crates. vta-sdk 13 suites green; the pre-existing
forged-plaintext security pins on both services still pass (the new DI path opens
no hole).

## Pre-merge checklist

- [x] No new reqwest::Client::new() / bare fetch(); all clients have finite timeouts (R1.2) — *and one pre-existing offender in `vtc-client` fixed*
- [x] No lock held across a network await (R1.3) — n/a, none touched
- [x] No local state committed before its remote effect, or the flow is resumable with an idempotency key (R2.1) — n/a, no new mutations
- [x] Every retry is bounded + backed off; non-idempotent ops are not blind-retried (R1.4) — n/a
- [x] Accept/poll/listen loops survive transient errors (R1.5) — n/a
- [x] Acks/deletes happen only after durable handoff (R1.6) — n/a
- [x] New/changed wire types: camelCase, deny_unknown_fields where security-relevant, schema registered, all consumers (incl. JS) updated (R3.*) — no new types; payloads now built from the generated spec types so casing is enforced by construction; `vtc-client` updated
- [x] Config absence = most restrictive; fail-closed if enforcement can't start (R5.*) — n/a
- [x] Logs/status claim only what was verified; background-job failures are surfaced (R6.*) — n/a
- [x] "Process dies on the next line" answered for every mutation touched (R2.1) — n/a
- [x] Deviations from this guide flagged explicitly with rule numbers — none

## Versions

vta-sdk 0.20.29 · vti-common 0.11.31 · vta-service 0.13.21 · vtc-service 0.11.48 · vtc-client **0.2.0** (breaking)
