### PR TITLE
refactor(vta-sdk): one holder-signing primitive for Trust Task documents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10271,7 +10271,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.20.29"
+version = "0.20.30"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",

--- a/changelog.d/881-trust-task-sign.md
+++ b/changelog.d/881-trust-task-sign.md
@@ -1,0 +1,30 @@
+### vta-sdk 0.20.30 — one holder-signing primitive for Trust Task documents (#881)
+
+Both VTI services authenticate a holder-submitted Trust Task the same way: verify
+its `eddsa-jcs-2022` Data-Integrity proof with a **`did:key`-only** resolver
+(`vti_common::auth::di_proof`) and take the proof's `verificationMethod` DID as
+the proven signer. That is the whole authentication for the VTC's `POST
+/trust-tasks` holder surface (join submit / manifest / status) and for both
+services' canonical REST login.
+
+The *signing* side had been written three times — `auth_di`, the
+provision-client's VP signer, and `vta-mobile-core` — each handling JCS
+presence-sensitivity slightly differently. That is a bad thing to have three of:
+a mistake in it produces a signature that verifies nowhere, and the failure is
+opaque at every call site.
+
+**New `vta_sdk::trust_task_sign`** (feature `client`): `build_unsigned`,
+`sign_in_place`, `build_signed`. It enforces by construction the two invariants
+that are easy to get wrong —
+
+- **Sign the proof-less document.** `eddsa-jcs-2022` canonicalises via JCS, which
+  is presence-sensitive, and the verifier strips `proof` before checking.
+- **Set `recipient`.** SPEC §4.8.2 audience binding rejects a signed document
+  with no in-band recipient; it is also the replay defence that stops a document
+  signed for one community being posted to another.
+
+`auth_di` now builds on it and keeps its public API unchanged, except that its
+signing-failure variants collapse into `AuthDiError::Sign(TrustTaskSignError)` —
+`NotDidKey` / `BadPrivateKey` / `TypeUri` move to the shared error, which renders
+the same text. No behaviour change; the auth suites are unmodified apart from the
+two tests that were purely about the signing primitive and now live beside it.

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.20.29"
+version = "0.20.30"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/auth_di.rs
+++ b/vta-sdk/src/auth_di.rs
@@ -28,16 +28,13 @@
 //! [`crate::provision_client::auth_rest`] build their documents here so the two
 //! can't drift.
 
-use affinidi_data_integrity::{DataIntegrityProof, SignOptions};
-use affinidi_secrets_resolver::secrets::Secret;
-use chrono::Utc;
 use serde_json::Value;
+use trust_tasks_rs::TrustTask;
 use trust_tasks_rs::specs::auth::authenticate::v0_1 as authenticate;
 use trust_tasks_rs::specs::auth::refresh::v0_1 as refresh;
-use trust_tasks_rs::{Proof, TrustTask};
 
-use crate::did_key::decode_private_key_multibase;
 use crate::protocols::auth::AuthenticateResponse;
+use crate::trust_task_sign::{self, TrustTaskSignError};
 use crate::trust_tasks::{TASK_AUTH_AUTHENTICATE_0_1, TASK_AUTH_REFRESH_0_1};
 
 /// Why building or reading a DI-signed auth document failed.
@@ -46,49 +43,34 @@ use crate::trust_tasks::{TASK_AUTH_AUTHENTICATE_0_1, TASK_AUTH_REFRESH_0_1};
 /// HTTP client and its error type.
 #[derive(Debug)]
 pub enum AuthDiError {
-    /// The holder DID is not a `did:key`. The server verifies the proof with a
-    /// `did:key`-only resolver, so no other method can authenticate this way.
-    NotDidKey(String),
-    /// The holder's private key could not be decoded from its multibase form.
-    BadPrivateKey(String),
     /// A payload field failed the spec type's own validation (e.g. an empty
     /// challenge or refresh token) — caught here rather than by the server.
     Payload(String),
-    /// Signing the document failed.
-    Sign(String),
-    /// The Trust Task type URI failed to parse. Unreachable in practice — the
-    /// URIs are `const`s from [`crate::trust_tasks`] — but not worth an
-    /// `unwrap` on a client's auth path.
-    TypeUri(String),
+    /// Building or signing the document failed — see
+    /// [`TrustTaskSignError`] (non-`did:key` holder, bad key, bad type URI).
+    Sign(TrustTaskSignError),
     /// The VTA's response was neither a flat `AuthenticateResponse` nor a
     /// Trust-Task `#response` document wrapping one.
     Response(String),
 }
 
+impl From<TrustTaskSignError> for AuthDiError {
+    fn from(e: TrustTaskSignError) -> Self {
+        Self::Sign(e)
+    }
+}
+
 impl std::fmt::Display for AuthDiError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::NotDidKey(did) => write!(
-                f,
-                "DI-signed REST authentication requires a did:key holder; got {did}"
-            ),
-            Self::BadPrivateKey(e) => write!(f, "decode holder private key: {e}"),
             Self::Payload(e) => write!(f, "invalid auth payload: {e}"),
-            Self::Sign(e) => write!(f, "sign authenticate Trust Task: {e}"),
-            Self::TypeUri(e) => write!(f, "Trust Task type URI parse: {e}"),
+            Self::Sign(e) => write!(f, "{e}"),
             Self::Response(e) => write!(f, "unexpected auth response from VTA: {e}"),
         }
     }
 }
 
 impl std::error::Error for AuthDiError {}
-
-/// The `did:key:zXxx#zXxx` verification-method id the Data-Integrity resolver
-/// recognises for a `did:key` holder.
-fn did_key_to_vm(did: &str) -> Option<String> {
-    let mb = did.strip_prefix("did:key:")?;
-    Some(format!("{did}#{mb}"))
-}
 
 /// Build and sign an `auth/authenticate/0.1` Trust Task, returning the JSON
 /// body to POST to `/auth/`.
@@ -118,42 +100,14 @@ pub async fn sign_authenticate_doc(
         scope: Vec::new(),
         ext: None,
     };
-    let mut doc = new_doc(
+    Ok(trust_task_sign::build_signed(
         TASK_AUTH_AUTHENTICATE_0_1,
         serde_json::to_value(&payload).map_err(|e| AuthDiError::Payload(e.to_string()))?,
         client_did,
+        private_key_multibase,
         vta_did,
-    )?;
-
-    let vm_id =
-        did_key_to_vm(client_did).ok_or_else(|| AuthDiError::NotDidKey(client_did.into()))?;
-    let seed = decode_private_key_multibase(private_key_multibase)
-        .map_err(|e| AuthDiError::BadPrivateKey(e.to_string()))?;
-    let mut signer = Secret::generate_ed25519(Some(&vm_id), Some(&seed));
-    signer.id = vm_id;
-
-    let mut signing_doc =
-        serde_json::to_value(&doc).map_err(|e| AuthDiError::Sign(e.to_string()))?;
-    if let Some(obj) = signing_doc.as_object_mut() {
-        obj.remove("proof");
-    }
-    let di_proof = DataIntegrityProof::sign(
-        &signing_doc,
-        &signer,
-        SignOptions::new()
-            .with_proof_purpose("assertionMethod")
-            .with_created(Utc::now()),
     )
-    .await
-    .map_err(|e| AuthDiError::Sign(e.to_string()))?;
-    let proof_json =
-        serde_json::to_value(&di_proof).map_err(|e| AuthDiError::Sign(e.to_string()))?;
-    doc.proof = Some(
-        serde_json::from_value::<Proof>(proof_json)
-            .map_err(|e| AuthDiError::Sign(e.to_string()))?,
-    );
-
-    serde_json::to_string(&doc).map_err(|e| AuthDiError::Sign(e.to_string()))
+    .await?)
 }
 
 /// Build an `auth/refresh/0.1` Trust Task, returning the JSON body to POST to
@@ -178,13 +132,13 @@ pub fn build_refresh_doc(
         scope: Vec::new(),
         ext: None,
     };
-    let doc = new_doc(
+    let doc = trust_task_sign::build_unsigned(
         TASK_AUTH_REFRESH_0_1,
         serde_json::to_value(&payload).map_err(|e| AuthDiError::Payload(e.to_string()))?,
         client_did,
         vta_did,
     )?;
-    serde_json::to_string(&doc).map_err(|e| AuthDiError::Sign(e.to_string()))
+    serde_json::to_string(&doc).map_err(|e| AuthDiError::Payload(e.to_string()))
 }
 
 /// Parse an `/auth/` or `/auth/refresh` response body.
@@ -200,30 +154,6 @@ pub fn parse_auth_response(body: &str) -> Result<AuthenticateResponse, AuthDiErr
         .map_err(|e| AuthDiError::Response(format!("{e} (is this a VTA?)")))?;
     serde_json::from_value(doc.payload)
         .map_err(|e| AuthDiError::Response(format!("payload is not an AuthenticateResponse: {e}")))
-}
-
-/// A Trust Task addressed from the holder to the VTA, with a fresh id.
-///
-/// `recipient` is always set: SPEC §4.8.2 audience binding rejects a *signed*
-/// document with no in-band recipient, and it costs nothing on the unsigned
-/// refresh document.
-fn new_doc(
-    type_uri: &str,
-    payload: Value,
-    client_did: &str,
-    vta_did: &str,
-) -> Result<TrustTask<Value>, AuthDiError> {
-    let mut doc: TrustTask<Value> = TrustTask::new(
-        format!("urn:uuid:{}", uuid::Uuid::new_v4()),
-        type_uri
-            .parse()
-            .map_err(|e| AuthDiError::TypeUri(format!("{e}")))?,
-        payload,
-    );
-    doc.issuer = Some(client_did.to_string());
-    doc.recipient = Some(vta_did.to_string());
-    doc.issued_at = Some(Utc::now());
-    Ok(doc)
 }
 
 #[cfg(test)]
@@ -278,59 +208,10 @@ mod tests {
         );
     }
 
-    /// The proof verifies under the same `did:key` resolver the VTA uses
-    /// (`vti-common/src/auth/di_proof.rs`) — i.e. the document the client
-    /// emits is one the server actually accepts.
-    #[tokio::test]
-    async fn signed_doc_verifies_under_did_key_resolver() {
-        use affinidi_data_integrity::{DidKeyResolver, VerifyOptions};
-
-        let (did, pk) = did_key_from_seed(0x22);
-        let body = sign_authenticate_doc(&did, &pk, "did:key:z6MkVta", CHALLENGE, "sess-1")
-            .await
-            .expect("sign");
-        let doc: TrustTask<Value> = serde_json::from_str(&body).unwrap();
-
-        let proof: DataIntegrityProof =
-            serde_json::from_value(serde_json::to_value(doc.proof.as_ref().unwrap()).unwrap())
-                .expect("proof round-trips into a DataIntegrityProof");
-        let mut unsigned = doc.clone();
-        unsigned.proof = None;
-        proof
-            .verify(&unsigned, &DidKeyResolver, VerifyOptions::new())
-            .await
-            .expect("server-side verification must succeed");
-    }
-
-    /// Tampering with the payload after signing invalidates the proof — the
-    /// signature covers the document, not just its presence.
-    #[tokio::test]
-    async fn tampered_payload_fails_verification() {
-        use affinidi_data_integrity::{DidKeyResolver, VerifyOptions};
-
-        let (did, pk) = did_key_from_seed(0x33);
-        let body = sign_authenticate_doc(&did, &pk, "did:key:z6MkVta", CHALLENGE, "sess-1")
-            .await
-            .expect("sign");
-        let mut doc: TrustTask<Value> = serde_json::from_str(&body).unwrap();
-        doc.payload = json!({ "challenge": "attacker-nonce-0000000000", "sessionId": "sess-1" });
-
-        let proof: DataIntegrityProof =
-            serde_json::from_value(serde_json::to_value(doc.proof.as_ref().unwrap()).unwrap())
-                .unwrap();
-        let mut unsigned = doc.clone();
-        unsigned.proof = None;
-        assert!(
-            proof
-                .verify(&unsigned, &DidKeyResolver, VerifyOptions::new())
-                .await
-                .is_err(),
-            "a tampered challenge must not verify"
-        );
-    }
-
     /// A non-`did:key` holder is refused locally rather than after a round trip
-    /// the VTA's `did:key`-only verifier would reject anyway.
+    /// the VTA's `did:key`-only verifier would reject anyway. The refusal comes
+    /// from the shared signer and must survive being wrapped by this layer —
+    /// the auth entry point is where a caller actually meets it.
     #[tokio::test]
     async fn non_did_key_holder_is_refused() {
         let (_, pk) = did_key_from_seed(0x44);
@@ -343,7 +224,17 @@ mod tests {
         )
         .await
         .expect_err("did:web holder must be refused");
-        assert!(matches!(err, AuthDiError::NotDidKey(_)), "got {err:?}");
+        assert!(
+            matches!(
+                err,
+                AuthDiError::Sign(crate::trust_task_sign::TrustTaskSignError::NotDidKey(_))
+            ),
+            "got {err:?}"
+        );
+        assert!(
+            err.to_string().contains("did:web:example.com"),
+            "the rendered error must name the offending DID: {err}"
+        );
     }
 
     /// Refresh carries the token in a camelCase payload and no proof.

--- a/vta-sdk/src/lib.rs
+++ b/vta-sdk/src/lib.rs
@@ -151,6 +151,10 @@ pub mod session;
 // private one (#830).
 #[cfg(feature = "session")]
 pub mod session_hub;
+/// Holder-signing for Trust Task documents — the shared `eddsa-jcs-2022`
+/// primitive both services' holder surfaces verify against.
+#[cfg(feature = "client")]
+pub mod trust_task_sign;
 /// Canonical Trust-Task URLs for VTA operations. Mirrors
 /// `did-hosting-common::did_hosting_tasks` for the webvh-service side.
 pub mod trust_tasks;

--- a/vta-sdk/src/trust_task_sign.rs
+++ b/vta-sdk/src/trust_task_sign.rs
@@ -1,0 +1,252 @@
+//! Build and holder-sign a Trust Task document — the one client-side
+//! implementation of "an `eddsa-jcs-2022` proof by a `did:key` holder, over the
+//! proof-less document".
+//!
+//! Both VTI services authenticate holder-submitted Trust Tasks the same way:
+//! verify the document's Data-Integrity proof with a **`did:key`-only** resolver
+//! (`vti_common::auth::di_proof`) and take the proof's `verificationMethod` DID
+//! as the proven signer, cross-checked against the document `issuer` where one
+//! is present. That is the whole authentication for the VTC's `POST
+//! /trust-tasks` holder surface (join submit / manifest / status) and for both
+//! services' canonical REST login.
+//!
+//! Signing had already been written three times — [`crate::auth_di`], the
+//! provision-client's VP signer, and `vta-mobile-core` — with the JCS
+//! presence-sensitivity handled slightly differently each time. This is the
+//! shared primitive; [`crate::auth_di`] builds on it, and so does anything that
+//! needs to speak a holder-signed Trust Task.
+//!
+//! Two invariants that are easy to get wrong and expensive to debug, because a
+//! mistake in either yields a signature that verifies nowhere:
+//!
+//! - **Sign the proof-less document.** `eddsa-jcs-2022` canonicalises via JCS,
+//!   which is presence-sensitive, and the verifier strips `proof` before
+//!   checking. Signing a document that already carries a `proof` key — even an
+//!   empty one — produces a signature over different bytes.
+//! - **Set `recipient`.** SPEC §4.8.2 audience binding rejects a *signed*
+//!   document with no in-band recipient unless its specification is a bearer
+//!   spec. [`build_signed`] always sets it, so the caller cannot forget.
+
+use affinidi_data_integrity::{DataIntegrityProof, SignOptions};
+use affinidi_secrets_resolver::secrets::Secret;
+use chrono::Utc;
+use serde_json::Value;
+use trust_tasks_rs::{Proof, TrustTask};
+
+use crate::did_key::decode_private_key_multibase;
+
+/// Why building or signing a Trust Task document failed.
+#[derive(Debug)]
+pub enum TrustTaskSignError {
+    /// The holder DID is not a `did:key`. Both services verify the proof with a
+    /// `did:key`-only resolver, so no other method can sign a document they
+    /// will accept — refused here rather than after a round trip.
+    NotDidKey(String),
+    /// The holder's private key could not be decoded from its multibase form.
+    BadPrivateKey(String),
+    /// The Trust Task type URI failed to parse.
+    TypeUri(String),
+    /// Serialising the document, or signing it, failed.
+    Sign(String),
+}
+
+impl std::fmt::Display for TrustTaskSignError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotDidKey(did) => write!(
+                f,
+                "signing a Trust Task requires a did:key holder; got {did}"
+            ),
+            Self::BadPrivateKey(e) => write!(f, "decode holder private key: {e}"),
+            Self::TypeUri(e) => write!(f, "Trust Task type URI parse: {e}"),
+            Self::Sign(e) => write!(f, "sign Trust Task: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for TrustTaskSignError {}
+
+/// The `did:key:zXxx#zXxx` verification-method id the Data-Integrity resolver
+/// recognises for a `did:key` holder.
+pub fn did_key_to_vm(did: &str) -> Option<String> {
+    let mb = did.strip_prefix("did:key:")?;
+    Some(format!("{did}#{mb}"))
+}
+
+/// An unsigned Trust Task addressed from `issuer` to `recipient`, with a fresh
+/// `urn:uuid:` id and `issuedAt` stamped now.
+///
+/// Split out from [`build_signed`] because the unsigned form is a legitimate
+/// wire shape for bearer specifications — `auth/refresh/0.1` carries no proof,
+/// its opaque token being the credential.
+pub fn build_unsigned(
+    type_uri: &str,
+    payload: Value,
+    issuer: &str,
+    recipient: &str,
+) -> Result<TrustTask<Value>, TrustTaskSignError> {
+    let mut doc: TrustTask<Value> = TrustTask::new(
+        format!("urn:uuid:{}", uuid::Uuid::new_v4()),
+        type_uri
+            .parse()
+            .map_err(|e| TrustTaskSignError::TypeUri(format!("{e}")))?,
+        payload,
+    );
+    doc.issuer = Some(issuer.to_string());
+    doc.recipient = Some(recipient.to_string());
+    doc.issued_at = Some(Utc::now());
+    Ok(doc)
+}
+
+/// Attach the holder's `eddsa-jcs-2022` Data-Integrity proof to `doc` in place.
+///
+/// `holder_did` must be a `did:key` whose seed is `private_key_multibase`. The
+/// proof is computed over the document with `proof` removed — see the module
+/// docs for why that matters.
+pub async fn sign_in_place(
+    doc: &mut TrustTask<Value>,
+    holder_did: &str,
+    private_key_multibase: &str,
+) -> Result<(), TrustTaskSignError> {
+    let vm_id = did_key_to_vm(holder_did)
+        .ok_or_else(|| TrustTaskSignError::NotDidKey(holder_did.to_string()))?;
+    let seed = decode_private_key_multibase(private_key_multibase)
+        .map_err(|e| TrustTaskSignError::BadPrivateKey(e.to_string()))?;
+    let mut signer = Secret::generate_ed25519(Some(&vm_id), Some(&seed));
+    signer.id = vm_id;
+
+    let mut signing_doc =
+        serde_json::to_value(&*doc).map_err(|e| TrustTaskSignError::Sign(e.to_string()))?;
+    if let Some(obj) = signing_doc.as_object_mut() {
+        obj.remove("proof");
+    }
+    let di_proof = DataIntegrityProof::sign(
+        &signing_doc,
+        &signer,
+        SignOptions::new()
+            .with_proof_purpose("assertionMethod")
+            .with_created(Utc::now()),
+    )
+    .await
+    .map_err(|e| TrustTaskSignError::Sign(e.to_string()))?;
+    let proof_json =
+        serde_json::to_value(&di_proof).map_err(|e| TrustTaskSignError::Sign(e.to_string()))?;
+    doc.proof = Some(
+        serde_json::from_value::<Proof>(proof_json)
+            .map_err(|e| TrustTaskSignError::Sign(e.to_string()))?,
+    );
+    Ok(())
+}
+
+/// Build a holder-signed Trust Task and return it as the JSON body to POST.
+///
+/// The one call a client needs: `issuer` is the holder (and the proven signer),
+/// `recipient` is the service the document is addressed to (audience binding).
+pub async fn build_signed(
+    type_uri: &str,
+    payload: Value,
+    holder_did: &str,
+    private_key_multibase: &str,
+    recipient: &str,
+) -> Result<String, TrustTaskSignError> {
+    let mut doc = build_unsigned(type_uri, payload, holder_did, recipient)?;
+    sign_in_place(&mut doc, holder_did, private_key_multibase).await?;
+    serde_json::to_string(&doc).map_err(|e| TrustTaskSignError::Sign(e.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn did_key_from_seed(seed_byte: u8) -> (String, String) {
+        let seed = [seed_byte; 32];
+        let sk = ed25519_dalek::SigningKey::from_bytes(&seed);
+        let did = format!(
+            "did:key:{}",
+            crate::did_key::ed25519_multibase_pubkey(&sk.verifying_key().to_bytes())
+        );
+        let mut buf = vec![0x80, 0x26];
+        buf.extend_from_slice(&seed);
+        (did, multibase::encode(multibase::Base::Base58Btc, &buf))
+    }
+
+    const TYPE: &str = "https://trusttasks.org/spec/vtc/join-requests/submit/0.1";
+
+    /// The signed document verifies under the same `did:key` resolver both
+    /// services use, and carries issuer + recipient.
+    #[tokio::test]
+    async fn signed_document_verifies_server_side() {
+        use affinidi_data_integrity::{DidKeyResolver, VerifyOptions};
+
+        let (did, pk) = did_key_from_seed(0xa1);
+        let body = build_signed(TYPE, json!({"vp": {}}), &did, &pk, "did:key:z6MkVtc")
+            .await
+            .expect("sign");
+        let doc: TrustTask<Value> = serde_json::from_str(&body).unwrap();
+
+        assert_eq!(doc.issuer.as_deref(), Some(did.as_str()));
+        assert_eq!(doc.recipient.as_deref(), Some("did:key:z6MkVtc"));
+
+        let proof: DataIntegrityProof =
+            serde_json::from_value(serde_json::to_value(doc.proof.as_ref().unwrap()).unwrap())
+                .unwrap();
+        let mut unsigned = doc.clone();
+        unsigned.proof = None;
+        proof
+            .verify(&unsigned, &DidKeyResolver, VerifyOptions::new())
+            .await
+            .expect("must verify under the server's resolver");
+    }
+
+    /// The proof covers the payload — a post-signature edit does not verify.
+    #[tokio::test]
+    async fn tampered_payload_fails() {
+        use affinidi_data_integrity::{DidKeyResolver, VerifyOptions};
+
+        let (did, pk) = did_key_from_seed(0xa2);
+        let body = build_signed(TYPE, json!({"vp": {}}), &did, &pk, "did:key:z6MkVtc")
+            .await
+            .unwrap();
+        let mut doc: TrustTask<Value> = serde_json::from_str(&body).unwrap();
+        doc.payload = json!({"vp": {"forged": true}});
+
+        let proof: DataIntegrityProof =
+            serde_json::from_value(serde_json::to_value(doc.proof.as_ref().unwrap()).unwrap())
+                .unwrap();
+        let mut unsigned = doc.clone();
+        unsigned.proof = None;
+        assert!(
+            proof
+                .verify(&unsigned, &DidKeyResolver, VerifyOptions::new())
+                .await
+                .is_err()
+        );
+    }
+
+    /// A non-`did:key` holder is refused locally.
+    #[tokio::test]
+    async fn non_did_key_holder_refused() {
+        let (_, pk) = did_key_from_seed(0xa3);
+        let err = build_signed(
+            TYPE,
+            json!({}),
+            "did:web:example.com",
+            &pk,
+            "did:key:z6MkVtc",
+        )
+        .await
+        .expect_err("did:web must be refused");
+        assert!(matches!(err, TrustTaskSignError::NotDidKey(_)), "{err:?}");
+    }
+
+    /// The unsigned builder always sets `recipient` — a signed document without
+    /// one is rejected by SPEC §4.8.2 audience binding.
+    #[test]
+    fn unsigned_sets_issuer_and_recipient() {
+        let doc = build_unsigned(TYPE, json!({}), "did:key:z6MkA", "did:key:z6MkB").unwrap();
+        assert_eq!(doc.issuer.as_deref(), Some("did:key:z6MkA"));
+        assert_eq!(doc.recipient.as_deref(), Some("did:key:z6MkB"));
+        assert!(doc.proof.is_none());
+    }
+}


### PR DESCRIPTION
**Layer 1 of 2** — base for #882, which needs this primitive. No behaviour change; reviewable on its own.

## Why

Both VTI services authenticate a holder-submitted Trust Task identically: verify its `eddsa-jcs-2022` Data-Integrity proof with a **`did:key`-only** resolver (`vti_common::auth::di_proof`) and take the proof's `verificationMethod` DID as the proven signer. That is the whole authentication for the VTC's `POST /trust-tasks` holder surface (join submit / manifest / status) and for both services' canonical REST login.

The *signing* side had been written three times — `auth_di`, the provision-client's VP signer, and `vta-mobile-core` — each handling JCS presence-sensitivity a little differently. That is a bad thing to have three of: a mistake in it produces a signature that verifies nowhere, and the failure is opaque at every call site.

## What

New `vta_sdk::trust_task_sign` (feature `client`): `build_unsigned`, `sign_in_place`, `build_signed`. It makes structural the two invariants that are easy to miss:

- **Sign the proof-less document.** `eddsa-jcs-2022` canonicalises via JCS, which is presence-sensitive, and the verifier strips `proof` before checking. Signing a document that already carries a `proof` key signs different bytes.
- **Always set `recipient`.** SPEC §4.8.2 audience binding rejects a signed document with no in-band recipient — and it is the replay defence that stops a document signed for one community being posted to another.

`auth_di` now builds on it, with its public API unchanged except that the signing-failure variants collapse into `AuthDiError::Sign(TrustTaskSignError)` (`NotDidKey` / `BadPrivateKey` / `TypeUri` move to the shared error and render the same text).

## Testing

The new suite asserts the emitted document verifies under the *same* `DidKeyResolver` + `VerifyOptions` the servers use — not just that a proof is present — plus tamper detection and the non-`did:key` refusal. The two `auth_di` tests that were purely about the signing primitive move to sit beside it; the rest of the auth suites are untouched and pass unmodified, which is the evidence that this is a no-op refactor.

## Pre-merge checklist

- [x] No new reqwest::Client::new() / bare fetch(); all clients have finite timeouts (R1.2) — no HTTP added
- [x] No lock held across a network await (R1.3) — n/a
- [x] No local state committed before its remote effect (R2.1) — n/a
- [x] Every retry is bounded + backed off (R1.4) — n/a
- [x] Accept/poll/listen loops survive transient errors (R1.5) — n/a
- [x] Acks/deletes happen only after durable handoff (R1.6) — n/a
- [x] New/changed wire types: camelCase, deny_unknown_fields where security-relevant, schema registered, all consumers updated (R3.*) — no wire-type change; this is the signing path for existing documents
- [x] Config absence = most restrictive (R5.*) — n/a
- [x] Logs/status claim only what was verified (R6.*) — n/a
- [x] "Process dies on the next line" answered for every mutation touched (R2.1) — n/a
- [x] Deviations flagged with rule numbers — none
