### PR TITLE
feat(vtc-client)!: submit_join signs its own document and needs no token

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10553,7 +10553,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-client"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "chrono",
  "reqwest 0.13.4",
@@ -10561,6 +10561,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.19",
  "tokio",
+ "trust-tasks-rs",
  "vta-sdk",
 ]
 

--- a/changelog.d/882-vtc-client-submit-join.md
+++ b/changelog.d/882-vtc-client-submit-join.md
@@ -1,0 +1,43 @@
+### vtc-client 0.3.0 — `submit_join` works: signs its own document, needs no token (#882)
+
+`VtcClient::submit_join` posted the VP-framed body to `POST /join-requests`, a
+route that is **no longer mounted**. The holder-facing join verbs
+(`submit`/`request`, `manifest`, `status`) were folded into the single Trust-Task
+document endpoint `POST /trust-tasks`, routed by document `type`, with the
+holder's `eddsa-jcs-2022` proof as the authentication. #880 stopped it silently
+404ing by returning a typed error naming the replacement; this implements it.
+
+That fold moved the applicant's authentication from "a signature somewhere inside
+the body" to "a proof over the whole document" — which is why the signature grew
+the key:
+
+```rust
+submit_join(&body, applicant_did, private_key_multibase) -> VerdictResponse
+```
+
+**Breaking.** The two extra parameters, and the return type: the server answers a
+Trust-Task request with a `#response` document carrying a `VerdictResponse`
+(`allow` with the VMC + role VEC inline on auto-admit, `refer` when queued for an
+admin, `deny`, `requestMore`), which is not the old `DecideResult`.
+
+- **New `VtcClient::anonymous(base_url, vtc_did)`.** `submit_join` authenticates
+  with the document's own proof, so an applicant — by definition not yet a member,
+  with no token to get — needs a client with no token. Every other method returns
+  `NotAuthenticated`, which beats a 401 from the server.
+- `applicant_did` must be a `did:key` (the server's proof resolver accepts no
+  other method) and is the DID that becomes the member on admission — *not*
+  whatever identity the client may hold a token for. A fleet manager submitting on
+  behalf of a VTA signs with that VTA's key.
+- The document is addressed to the client's `vtc_did`. The VTC enforces
+  `recipient == its own DID`, so a submit signed for one community cannot be
+  replayed into another.
+
+Built on `vta_sdk::trust_task_sign` (#881) rather than a fourth copy of the
+signing logic.
+
+**Testing.** `vtc-service/tests/vtc_client_live.rs` drives the real client
+against a live `MockVtc` through all three server-side gates, each of which was a
+way to get this wrong: the proof verifies under the `did:key` resolver, the
+document `issuer` equals the proven signer (a document signed by one key while
+claiming another as issuer is refused), and the submitted request lands in the
+admin queue attributed to the *signing* DID rather than anything the body claimed.

--- a/vtc-client/Cargo.toml
+++ b/vtc-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vtc-client"
 description = "Client SDK for Verifiable Trust Communities (VTC) — auth, members, join, removal, policies"
-version = "0.2.0"
+version = "0.3.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -15,6 +15,10 @@ repository.workspace = true
 # published join-request protocol types. `session` gates `auth_light` +
 # `protocols`.
 vta-sdk = { path = "../vta-sdk", version = "0.20", features = ["session"] }
+# `TrustTask` — the join-submit document this client signs, and the `#response`
+# envelope the VTC answers it with. Same crate `vta-sdk` builds the document
+# from, so one shape crosses the boundary.
+trust-tasks-rs = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/vtc-client/src/lib.rs
+++ b/vtc-client/src/lib.rs
@@ -31,9 +31,10 @@
 //!
 //! ## Scope
 //!
-//! Authentication, the member roster, the admin join queue, removal, and
-//! policy. Join *submission* (the applicant side) is not here — see
-//! [`VtcClient::submit_join`] for where it moved.
+//! Authentication, the member roster, the admin join queue, removal, policy,
+//! and the applicant side of the join ceremony
+//! ([`VtcClient::submit_join`], which signs its own document and needs no
+//! token).
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -86,6 +87,10 @@ pub enum VtcError {
     /// replacement for it. Carries what to use instead.
     #[error("unsupported by this client: {0}")]
     Unsupported(&'static str),
+    /// Building or signing a holder Trust Task failed — e.g. a non-`did:key`
+    /// applicant, or an undecodable private key.
+    #[error("could not sign the request document: {0}")]
+    Signing(String),
 }
 
 /// A single member of the community, as returned by `GET /members`. Mirrors the
@@ -219,6 +224,26 @@ impl VtcClient {
             base_url: base_url.trim_end_matches('/').to_string(),
             vtc_did: vtc_did.to_string(),
             token: Some(token.into()),
+        }
+    }
+
+    /// Construct a client with **no** bearer token, for the applicant side of
+    /// the join ceremony.
+    ///
+    /// [`submit_join`](Self::submit_join) authenticates with the document's own
+    /// holder proof, so an applicant — who is by definition not yet a member and
+    /// has no token to get — needs exactly this. Every other method returns
+    /// [`VtcError::NotAuthenticated`], which is the honest answer rather than a
+    /// 401 from the server.
+    ///
+    /// `vtc_did` still matters: it is the audience the submitted document is
+    /// addressed to, and the VTC rejects a document addressed elsewhere.
+    pub fn anonymous(base_url: &str, vtc_did: &str) -> Self {
+        Self {
+            http: vta_sdk::http::rest_client(),
+            base_url: base_url.trim_end_matches('/').to_string(),
+            vtc_did: vtc_did.to_string(),
+            token: None,
         }
     }
 
@@ -427,34 +452,86 @@ impl VtcClient {
         Ok(())
     }
 
-    /// Submit a join request (the applicant side).
+    /// Submit a join request (the applicant side): sign a
+    /// `join-requests/submit/0.1` Trust Task with the applicant's holder key and
+    /// post it to the document endpoint. Returns the community's verdict —
+    /// auto-admit carries the issued VMC + role VEC inline, otherwise the
+    /// request is queued for an admin.
     ///
-    /// # Unimplemented against the current VTC
+    /// **No bearer token.** The document's `eddsa-jcs-2022` proof *is* the
+    /// authentication: the VTC takes the proof's `verificationMethod` DID as the
+    /// applicant and requires the document `issuer` to match it
+    /// (`vtc-service/src/trust_tasks/mod.rs::resolve_holder`). So this is the
+    /// one method that works on a client built with neither
+    /// [`connect`](Self::connect) nor [`with_token`](Self::with_token) — an
+    /// applicant is by definition not yet a member.
     ///
-    /// This posted the VP-framed body to `POST /join-requests`. That route no
-    /// longer exists: the holder-facing join verbs (`submit`/`request`,
+    /// `applicant_did` must be a `did:key` (the server's proof resolver accepts
+    /// no other method) whose seed is `private_key_multibase`. It is the DID
+    /// that becomes the member on admission, *not* whatever identity this client
+    /// may hold a token for — a fleet manager submitting on behalf of a VTA
+    /// signs with that VTA's key.
+    ///
+    /// The document is addressed to [`vtc_did`](Self::vtc_did) (SPEC §4.8.2
+    /// audience binding), so a signed submit captured from one community cannot
+    /// be replayed into another.
+    ///
+    /// ## Why the key, and not just a body
+    ///
+    /// This used to POST the VP-framed body to `POST /join-requests`, a route
+    /// that no longer exists — the holder-facing join verbs (`submit`/`request`,
     /// `manifest`, `status`) were folded into the single Trust-Task document
-    /// endpoint `POST /trust-tasks`, routed by document `type`, with the
-    /// holder's `eddsa-jcs-2022` proof as the authentication
-    /// (`vtc-service/src/routes/mod.rs`, `trust_tasks::dispatch`). The handler
-    /// this used to reach is now unrouted code.
-    ///
-    /// Submitting therefore means building and signing a
-    /// `join-requests/submit` Trust Task, which needs the applicant's holder
-    /// key — a different shape from this method's `body`-only signature, and
-    /// not something to fake by changing the URL. Rather than keep issuing a
-    /// silent 404, this returns a typed error naming the replacement. The
-    /// applicant side is driven today by the join ceremony in
-    /// `vta-cli-common` / `vta-mobile-core`, which speak that endpoint.
+    /// endpoint, routed by document `type`. That fold moved the applicant's
+    /// authentication from "a signature somewhere inside the body" to "a proof
+    /// over the whole document", which is why this signature grew the key.
     pub async fn submit_join(
         &self,
-        _body: &join_requests::JoinRequestSubmitBody,
-    ) -> Result<DecideResult, VtcError> {
-        Err(VtcError::Unsupported(
-            "join submission moved to the Trust-Task document endpoint (POST /trust-tasks, \
-             type join-requests/submit) and needs the applicant's holder key to sign the \
-             document; POST /join-requests is no longer routed",
-        ))
+        body: &join_requests::JoinRequestSubmitBody,
+        applicant_did: &str,
+        private_key_multibase: &str,
+    ) -> Result<join_requests::VerdictResponse, VtcError> {
+        let payload = serde_json::to_value(body)
+            .map_err(|e| VtcError::Url(format!("serialise submit payload: {e}")))?;
+        let doc = vta_sdk::trust_task_sign::build_signed(
+            join_requests::JOIN_REQUEST_SUBMIT_TYPE,
+            payload,
+            applicant_did,
+            private_key_multibase,
+            &self.vtc_did,
+        )
+        .await
+        .map_err(|e| VtcError::Signing(e.to_string()))?;
+
+        // The document endpoint takes no `Trust-Task` header — the document's
+        // own `type` is the identity, which is exactly why one mount can serve
+        // every holder verb.
+        let resp = self
+            .http
+            .post(format!("{}/trust-tasks", self.base_url))
+            .header("content-type", "application/json")
+            .body(doc)
+            .send()
+            .await?;
+        if !resp.status().is_success() {
+            let status = resp.status().as_u16();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(VtcError::Http { status, body });
+        }
+
+        // A Trust-Task request is answered with a `#response` document whose
+        // payload is the verdict.
+        let text = resp.text().await?;
+        let response_doc: trust_tasks_rs::TrustTask<serde_json::Value> =
+            serde_json::from_str(&text).map_err(|e| VtcError::Http {
+                status: 200,
+                body: format!(
+                    "unexpected submit response (not a Trust Task document): {e}: {text}"
+                ),
+            })?;
+        serde_json::from_value(response_doc.payload).map_err(|e| VtcError::Http {
+            status: 200,
+            body: format!("submit response payload is not a VerdictResponse: {e}"),
+        })
     }
 
     /// List the community's policies (opaque JSON descriptors). Admin token.

--- a/vtc-service/tests/vtc_client_live.rs
+++ b/vtc-service/tests/vtc_client_live.rs
@@ -34,6 +34,17 @@ fn admin_entry(did: &str) -> VtcAclEntry {
     }
 }
 
+/// Seed the join ceremony the way `server::run` does at boot: the default
+/// policy set, so `join.rego` evaluates instead of the ceremony failing closed
+/// with "no active join policy". A bare `MockVtc` has no policies — the join
+/// tests that predate this file seed the same way.
+async fn seed_join_policies(mock: &MockVtc) {
+    let state = &mock.vtc.state;
+    vtc_service::policy::default::install_defaults(&state.policies_ks, &state.active_policies_ks)
+        .await
+        .expect("install default policies");
+}
+
 /// A deterministic `did:key` + its multibase private key.
 fn did_key_from_seed(seed_byte: u8) -> (String, String) {
     let seed = [seed_byte; 32];
@@ -142,25 +153,146 @@ async fn join_queue_reads_and_decide_reaches_the_handler() {
     mock.shutdown().await;
 }
 
-/// Join submission is refused with a typed error naming its replacement,
-/// instead of silently 404ing against an unrouted path.
+/// The applicant side, end to end: `submit_join` signs a
+/// `join-requests/submit/0.1` document with the applicant's holder key, posts it
+/// to the document endpoint with **no bearer token**, and gets the community's
+/// verdict back.
+///
+/// This is the method that could not work at all before — it posted to
+/// `POST /join-requests`, a route that is no longer mounted. Three separate
+/// server-side gates have to be satisfied for this to pass, and each was a way
+/// to get it wrong: the document's proof must verify under the `did:key`
+/// resolver, its `issuer` must equal the proven signer, and its `recipient` must
+/// equal *this* VTC's configured DID (the replay defence — a submit signed for
+/// one community cannot be posted to another).
 #[tokio::test]
-async fn submit_join_reports_where_it_moved() {
-    let (did, private_key_multibase) = did_key_from_seed(0x93);
-    let _ = private_key_multibase;
-    let client = VtcClient::with_token("https://vtc.invalid/v1", &did, "unused-token");
+async fn submit_join_signs_and_gets_a_verdict() {
+    let mock = MockVtc::start().await;
+    let base = format!("{}/v1", mock.base_url());
 
-    // Contents are irrelevant — the call is refused before any transport.
-    let body =
-        serde_json::from_value(serde_json::json!({ "vp": {} })).expect("minimal submit body");
+    seed_join_policies(&mock).await;
+    let (applicant_did, applicant_key) = did_key_from_seed(0x94);
 
-    match client.submit_join(&body).await {
-        Err(vtc_client::VtcError::Unsupported(msg)) => {
-            assert!(
-                msg.contains("/trust-tasks"),
-                "the error must name the endpoint that replaced it: {msg}"
-            );
-        }
-        other => panic!("expected Unsupported, got {other:?}"),
-    }
+    // No token: an applicant is by definition not yet a member. The client is
+    // built with the VTC's real DID because the document is addressed to it.
+    let client = VtcClient::anonymous(&base, vtc_service::test_support::TEST_VTC_DID);
+
+    let body = vtc_client::join_requests::JoinRequestSubmitBody {
+        vp: serde_json::json!({
+            "type": "VerifiablePresentation",
+            "holder": applicant_did,
+        }),
+        registry_consent: false,
+        extensions: serde_json::json!({}),
+    };
+
+    let verdict = client
+        .submit_join(&body, &applicant_did, &applicant_key)
+        .await
+        .expect("a signed submit must be accepted");
+
+    // The default policy refers the request to an admin rather than
+    // auto-admitting — the point here is that the ceremony *ran*.
+    assert_eq!(
+        verdict.verdict.effect,
+        vtc_client::join_requests::VerdictEffect::Refer,
+        "default policy refers to an admin; got {:?}",
+        verdict.verdict.effect
+    );
+
+    mock.shutdown().await;
+}
+
+/// The submitted request lands in the admin queue under the applicant's DID —
+/// i.e. the server took the *proof's* signer as the applicant, not anything the
+/// body claimed.
+#[tokio::test]
+async fn submitted_request_is_attributed_to_the_signing_did() {
+    let mock = MockVtc::start().await;
+    let base = format!("{}/v1", mock.base_url());
+
+    seed_join_policies(&mock).await;
+    let (applicant_did, applicant_key) = did_key_from_seed(0x95);
+    let (admin_did, admin_key) = did_key_from_seed(0x96);
+    store_acl_entry(&mock.vtc.state.acl_ks, &admin_entry(&admin_did))
+        .await
+        .expect("seed admin acl row");
+
+    let applicant = VtcClient::anonymous(&base, vtc_service::test_support::TEST_VTC_DID);
+    let body = vtc_client::join_requests::JoinRequestSubmitBody {
+        vp: serde_json::json!({
+            "type": "VerifiablePresentation",
+            "holder": applicant_did,
+        }),
+        registry_consent: false,
+        extensions: serde_json::json!({}),
+    };
+    applicant
+        .submit_join(&body, &applicant_did, &applicant_key)
+        .await
+        .expect("submit");
+
+    let admin = VtcClient::connect(
+        &base,
+        vtc_service::test_support::TEST_VTC_DID,
+        &admin_did,
+        &admin_key,
+    )
+    .await
+    .expect("admin connect");
+    let queue = admin
+        .list_join_requests(Some("pending"))
+        .await
+        .expect("list join requests");
+
+    assert_eq!(queue.len(), 1, "one pending request, got {queue:?}");
+    assert_eq!(
+        queue[0].applicant_did, applicant_did,
+        "the request must be attributed to the DID that signed the document"
+    );
+
+    mock.shutdown().await;
+}
+
+/// A signature by a key other than the claimed `issuer` is refused — the
+/// issuer↔signer cross-check, not just "some valid proof is present".
+#[tokio::test]
+async fn submit_with_mismatched_issuer_is_refused() {
+    let mock = MockVtc::start().await;
+    let base = format!("{}/v1", mock.base_url());
+
+    let (victim_did, _) = did_key_from_seed(0x97);
+    let (attacker_did, attacker_key) = did_key_from_seed(0x98);
+
+    // Sign with the attacker's key but claim the victim as issuer.
+    let payload = serde_json::json!({
+        "vp": { "type": "VerifiablePresentation", "holder": victim_did },
+        "registryConsent": false,
+        "extensions": {},
+    });
+    let mut doc = vta_sdk::trust_task_sign::build_unsigned(
+        vtc_client::join_requests::JOIN_REQUEST_SUBMIT_TYPE,
+        payload,
+        &victim_did,
+        vtc_service::test_support::TEST_VTC_DID,
+    )
+    .expect("build");
+    vta_sdk::trust_task_sign::sign_in_place(&mut doc, &attacker_did, &attacker_key)
+        .await
+        .expect("sign with the attacker key");
+
+    let resp = reqwest::Client::new()
+        .post(format!("{base}/trust-tasks"))
+        .header("content-type", "application/json")
+        .body(serde_json::to_string(&doc).unwrap())
+        .send()
+        .await
+        .expect("POST /trust-tasks");
+
+    assert!(
+        !resp.status().is_success(),
+        "a document whose issuer is not the signer must be refused"
+    );
+
+    mock.shutdown().await;
 }


### PR DESCRIPTION
**Layer 2 of 2** — stacked on #881, which adds the signing primitive this uses. Review #881 first; this diff is only the client change.

## Why

`VtcClient::submit_join` posted the VP-framed body to `POST /join-requests`, a route that is **no longer mounted**. The holder-facing join verbs (`submit`/`request`, `manifest`, `status`) were folded into the single Trust-Task document endpoint `POST /trust-tasks`, routed by document `type`, with the holder's `eddsa-jcs-2022` proof as the authentication. #880 stopped it silently 404ing by returning a typed error naming the replacement; this implements it.

That fold moved the applicant's authentication from "a signature somewhere inside the body" to "a proof over the whole document" — which is why the signature grew the key rather than just changing the URL.

## What

```rust
submit_join(&body, applicant_did, private_key_multibase) -> VerdictResponse
```

**Breaking** on both counts: the two extra parameters, and the return type. The server answers a Trust-Task request with a `#response` document carrying a `VerdictResponse` (`allow` with the VMC + role VEC inline on auto-admit, `refer` when queued for an admin, `deny`, `requestMore`) — not the old `DecideResult`.

- **New `VtcClient::anonymous(base_url, vtc_did)`.** `submit_join` authenticates with the document's own proof, so an applicant — by definition not yet a member, with no token to get — needs a client with no token. Every other method on it returns `NotAuthenticated`, which is more honest than a 401 from the server.
- `applicant_did` must be a `did:key` (the server's proof resolver accepts no other method) and is the DID that becomes the member on admission — *not* whatever identity the client may hold a token for. A fleet manager submitting on behalf of a VTA signs with that VTA's key.
- The document is addressed to the client's `vtc_did`. The VTC enforces `recipient == its own DID`, so a submit signed for one community cannot be replayed into another.

## Testing

`vtc-service/tests/vtc_client_live.rs` drives the real client against a live `MockVtc` through all three server-side gates, each of which was a way to get this wrong:

1. the proof verifies under the `did:key` resolver and the ceremony runs to a verdict;
2. a document signed by one key while claiming another as `issuer` is refused (the issuer↔signer cross-check, not merely "a valid proof is present");
3. the submitted request lands in the admin queue attributed to the **signing** DID, not to anything the body claimed.

An intermediate run was useful evidence: before the test seeded the default policies, the submit failed with `500: no active join policy` — i.e. the document had already been authenticated and reached the ceremony, which is precisely the part that could not happen before.

## Pre-merge checklist

- [x] No new reqwest::Client::new() / bare fetch(); all clients have finite timeouts (R1.2) — reuses the client's existing `vta_sdk::http::rest_client`
- [x] No lock held across a network await (R1.3) — n/a
- [x] No local state committed before its remote effect (R2.1) — n/a; submit is a single request whose response is the whole result
- [x] Every retry is bounded + backed off (R1.4) — no retry added; a submit is non-idempotent and must not be blind-retried
- [x] Accept/poll/listen loops survive transient errors (R1.5) — n/a
- [x] Acks/deletes happen only after durable handoff (R1.6) — n/a
- [x] New/changed wire types: camelCase, deny_unknown_fields where security-relevant, schema registered, all consumers updated (R3.*) — no new types; the body is the existing `JoinRequestSubmitBody` and the reply the existing `VerdictResponse`, both already registered
- [x] Config absence = most restrictive (R5.*) — a client with no token can do exactly one thing, the one that needs none
- [x] Logs/status claim only what was verified (R6.*) — the returned verdict is the server's, not inferred from a 2xx
- [x] "Process dies on the next line" answered for every mutation touched (R2.1) — the only mutation is server-side; a lost response leaves a queued request the applicant can observe via the status verb
- [x] Deviations flagged with rule numbers — none
