### PR TITLE
fix(acl): the ACL slice speaks Trust Tasks on every transport

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,15 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # Same reclaim as the Test job, and for the same reason: this job
+      # also links the whole workspace. It ran out of disk mid-`cargo
+      # check` on #884 — an infrastructure failure that reads exactly like
+      # a real MSRV break. Do NOT remove $AGENT_TOOLSDIRECTORY (see Test).
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc
+          df -h /
+
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
 
@@ -144,9 +153,12 @@ jobs:
             ~/.cargo/git
             target
           key: ${{ runner.os }}-cargo-msrv-${{ steps.msrv.outputs.msrv }}-${{ hashFiles('**/Cargo.lock') }}
+          # Deliberately NO `${{ runner.os }}-cargo-` fallback. This job runs a
+          # different toolchain, so another job's `target/` is unusable to it —
+          # the shared key only ever restored gigabytes it could not link
+          # against, onto a disk that then had to hold this job's own build too.
           restore-keys: |
             ${{ runner.os }}-cargo-msrv-${{ steps.msrv.outputs.msrv }}-
-            ${{ runner.os }}-cargo-
 
       - run: cargo check --workspace --locked
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,9 +50,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
+checksum = "f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58"
 dependencies = [
  "cipher 0.5.2",
  "cpubits",
@@ -131,9 +131,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-data-integrity"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab562d8232a2837c8fd23c06688ac5dc3ed2f8fdf5b503344b50677d3ef2a38"
+checksum = "bf2bf693c0bb26ea6c0a0d04ea1391500d694cda95d98c7918354e29292e566d"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -197,9 +197,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-did-resolver-cache-sdk"
-version = "0.8.19"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad166a17f2222def03193ffd8d601a85e6e04f2214e9494db6a6156efaba48b"
+checksum = "7c6fd1d099f394056d9eaf853211421b97dffb04c4f00de242ebf23cce812a6b"
 dependencies = [
  "affinidi-did-common",
  "affinidi-did-resolver-traits",
@@ -215,7 +215,7 @@ dependencies = [
  "highway",
  "moka",
  "rand 0.10.2",
- "rustls 0.23.42",
+ "rustls 0.23.43",
  "rustls-platform-verifier",
  "serde",
  "serde-wasm-bindgen",
@@ -306,9 +306,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-delivery"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb92150efbc0d18868510c2163ab0e314b34e71a16a032688c6f3033eb1f4e14"
+checksum = "d6ea99eb78ae37cf0092d7669a1e2b76ad6e4a5fe71099ca2144bd89653ec01f"
 dependencies = [
  "affinidi-messaging-core",
  "async-trait",
@@ -342,9 +342,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-mediator"
-version = "0.17.13"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3a4dbf5d8151ba18bd96ff4b684252ac57dc4569c0b7725d97b51297a6ffa5"
+checksum = "3cdd9b715dda0d25b9fa5afce0ea96540e5e5fc4067503357c08126ab40d3f59"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-common",
@@ -372,7 +372,7 @@ dependencies = [
  "futures-util",
  "governor",
  "hostname",
- "http 1.4.2",
+ "http 1.5.0",
  "humantime",
  "itertools",
  "jsonwebtoken",
@@ -384,7 +384,7 @@ dependencies = [
  "regex",
  "reqwest 0.13.4",
  "ring",
- "rustls 0.23.42",
+ "rustls 0.23.43",
  "semver",
  "serde",
  "serde_json",
@@ -394,7 +394,7 @@ dependencies = [
  "tokio-stream",
  "tokio-tungstenite",
  "tokio-util",
- "toml 1.1.3+spec-1.1.0",
+ "toml 1.1.4+spec-1.1.0",
  "tower",
  "tower-http",
  "tracing",
@@ -451,7 +451,7 @@ dependencies = [
  "affinidi-messaging-mediator-common",
  "serde",
  "thiserror 2.0.19",
- "toml 1.1.3+spec-1.1.0",
+ "toml 1.1.4+spec-1.1.0",
  "tracing",
 ]
 
@@ -480,7 +480,7 @@ dependencies = [
  "rand 0.10.2",
  "regex",
  "reqwest 0.13.4",
- "rustls 0.23.42",
+ "rustls 0.23.43",
  "rustls-pemfile 2.2.0",
  "serde",
  "serde_json",
@@ -495,9 +495,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-test-mediator"
-version = "0.2.43"
+version = "0.2.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d86ac1886e4569e190523d5b549fd0f89733ca3fa9729933c750ad74b55ff0f6"
+checksum = "000d5bb24597fe363a376cf6d845e7c842e27aa46f1c13a49974d829cc574d8d"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-didcomm",
@@ -509,7 +509,7 @@ dependencies = [
  "async-trait",
  "jsonwebtoken",
  "ring",
- "rustls 0.23.42",
+ "rustls 0.23.43",
  "serde_json",
  "sha256",
  "thiserror 2.0.19",
@@ -573,7 +573,7 @@ checksum = "894d604fc9b9d10eaf5c48b1f063a263048a7d4f13e648c9580c32de1f90d5fe"
 dependencies = [
  "axum",
  "governor",
- "http 1.4.2",
+ "http 1.5.0",
  "tokio",
  "tokio-util",
  "tower",
@@ -689,7 +689,7 @@ dependencies = [
  "affinidi-tdk-common",
  "affinidi-tsp",
  "clap",
- "rustls 0.23.42",
+ "rustls 0.23.43",
  "serde",
  "serde_json",
  "tokio",
@@ -699,9 +699,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-tdk-common"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94ff6b46621c148d7dc175f2f5aefa955b5dfbc1c8d5ea92a0e4def55cb69463"
+checksum = "28b84deea82515fc558c7c663986060b227b7604612e48fe31ce8cde688fc3ed"
 dependencies = [
  "affinidi-data-integrity",
  "affinidi-did-authentication",
@@ -715,7 +715,7 @@ dependencies = [
  "keyring-core",
  "moka",
  "reqwest 0.13.4",
- "rustls 0.23.42",
+ "rustls 0.23.43",
  "rustls-pemfile 2.2.0",
  "rustls-platform-verifier",
  "serde",
@@ -1094,9 +1094,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.42"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+checksum = "3976abdc8fe7d1133d43d304afd42abdf5bc3e1319d263d223bde07b5efc4be8"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -1132,7 +1132,7 @@ checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.0",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1158,9 +1158,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-config"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47712fde1909402600ccfbb26e47d482d2e58bb9e9e603d9f17e67cc435a6319"
+checksum = "1b180a3c8b55960db3426d8964b8745e652466a1a49fe1a2eda828046d30b5e4"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1178,7 +1178,7 @@ dependencies = [
  "bytes",
  "fastrand",
  "hex",
- "http 1.4.2",
+ "http 1.5.0",
  "sha1",
  "time",
  "tokio",
@@ -1251,9 +1251,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.8.1"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7816e98ee912159f45d307e5ee6bfea4a335a55aee15f7f3e32f81a6f3000f1d"
+checksum = "c9007227e10b5fed2f3e0a2beff489211e2b5604c400b7a9d5d81ca9d64c24bb"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -1266,7 +1266,7 @@ dependencies = [
  "bytes",
  "bytes-utils",
  "fastrand",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "percent-encoding",
  "pin-project-lite",
@@ -1276,9 +1276,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-dynamodb"
-version = "1.117.0"
+version = "1.119.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f2b4adcf6592e06ebb2c78235ae09cee178263a5b7fc20ae5ea07ca67067bb6"
+checksum = "b0176c1927f2e065f43cecde84602f769959b34ab53a317da92a64022ba09345"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -1295,16 +1295,16 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.5.0",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sdk-kms"
-version = "1.112.0"
+version = "1.114.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12409cfb265576c245cf86640c4090634959459f2537a428174ca6aba5ec9456"
+checksum = "c0b7d906608ee41e7ddea9983577ba82200435644d567d63dc34e822e088b453"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -1321,16 +1321,16 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.5.0",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sdk-secretsmanager"
-version = "1.109.0"
+version = "1.111.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "661ce910a6ed895c6bde66aa78040272628b127714fe0e9bb799f07ab4db407b"
+checksum = "d77f840fd8a79900661ca05e9af1f4e2b3c74386e9fc1b4a9dd58745faf689f0"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -1347,16 +1347,16 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.5.0",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.103.0"
+version = "1.105.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0469f435f645ad2162cfb463b15bde37115966ee3acf2d87fb4871ee309b8401"
+checksum = "6ffd0fbe7873cb548a7aa60f9573c268fff94155397fd4f14dc9f1ecaaab8516"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -1373,16 +1373,16 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.5.0",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.105.0"
+version = "1.107.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "085faefb253f770655e162b9304321e62a1e71adf7f019ee1f4454228a377b3a"
+checksum = "175763eb222a46377df7aa257a3bca980ab3e96703fefc8f4d0b8da6ad2e254c"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -1399,16 +1399,16 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.5.0",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.108.0"
+version = "1.110.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c72b08911d8128dd360fe1b22a9fec0fa8b552dde8ec828dcf20ef5ec974e9f"
+checksum = "dd8b14781dfbff48984017d57167b6ea0b6471c6920ec52b44a2677c7feb3c13"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -1426,7 +1426,7 @@ dependencies = [
  "aws-types",
  "fastrand",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.5.0",
  "regex-lite",
  "tracing",
 ]
@@ -1446,7 +1446,7 @@ dependencies = [
  "hex",
  "hmac 0.13.0",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.5.0",
  "percent-encoding",
  "sha2 0.11.0",
  "time",
@@ -1476,7 +1476,7 @@ dependencies = [
  "bytes-utils",
  "futures-core",
  "futures-util",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
  "percent-encoding",
@@ -1497,16 +1497,16 @@ dependencies = [
  "h2 0.3.27",
  "h2 0.4.15",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 0.4.6",
  "hyper 0.14.32",
- "hyper 1.10.1",
+ "hyper 1.11.0",
  "hyper-rustls 0.24.2",
  "hyper-rustls 0.27.9",
  "hyper-util",
  "pin-project-lite",
  "rustls 0.21.12",
- "rustls 0.23.42",
+ "rustls 0.23.43",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
@@ -1537,19 +1537,22 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-query"
-version = "0.61.1"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd22a6ba36e3f113cb8d5b3d1fe0ed31c76ee608ef63322d753bb8d2c9479e77"
+checksum = "512346c7212ab7436df2d77a16d976a468ae44a418835511d2a69269810aaf62"
 dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
+ "aws-smithy-xml",
  "urlencoding",
 ]
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bea94a9ff8464016338c851e24b472d7131c388c88898a502e781815b2ee6045"
+checksum = "07505b34e8f4b3591a4fa69e9792b52289b95488dbbc68c3c0075b7bedb245e1"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -1561,7 +1564,7 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 0.4.6",
  "http-body 1.1.0",
  "http-body-util",
@@ -1573,16 +1576,16 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.13.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ed1ebe6e0a95ea84570225f5a8208dec4b8f77e61a9b0d6f51773fcb4612f0"
+checksum = "3b98f2e1fd67ec06618f9c291e5e495a468e60519e44c9c1979cd0521f3affdb"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api-macros",
  "aws-smithy-types",
  "bytes",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.5.0",
  "pin-project-lite",
  "tokio",
  "tracing",
@@ -1608,7 +1611,7 @@ checksum = "7d56e0a4e53127a632224e43633b0fe045fa9e1e3cfc68b9830f1115e103f910"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "http 1.4.2",
+ "http 1.5.0",
 ]
 
 [[package]]
@@ -1622,7 +1625,7 @@ dependencies = [
  "bytes-utils",
  "futures-core",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 0.4.6",
  "http-body 1.1.0",
  "http-body-util",
@@ -1639,9 +1642,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-xml"
-version = "0.61.1"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea3f68eec3607f02acd24067969ce2abc6ba16aa7d5ce59ca450ed2fb5f78957"
+checksum = "ce84f71c72fee2cbbadde6e7d082f5fb466e3a84733855295fa7aafd1b31b7d8"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-schema",
@@ -1651,9 +1654,9 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e957a6c6dbce82b7a91f44231c09273159703769f447cbe85e854dfe9cf67f86"
+checksum = "eec1cd5469f328c782dc3e33d4153cf118a54e33cbb3356d60d16f89883e1f94"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
@@ -1675,10 +1678,10 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
- "hyper 1.10.1",
+ "hyper 1.11.0",
  "hyper-util",
  "itoa",
  "matchit",
@@ -1708,7 +1711,7 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
  "mime",
@@ -1731,7 +1734,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "headers",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
  "mime",
@@ -1751,12 +1754,12 @@ dependencies = [
  "bytes",
  "either",
  "fs-err 3.3.1",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
- "hyper 1.10.1",
+ "hyper 1.11.0",
  "hyper-util",
  "pin-project-lite",
- "rustls 0.23.42",
+ "rustls 0.23.43",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.4",
@@ -2182,9 +2185,9 @@ checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytemuck"
-version = "1.25.1"
+version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6aedf8ae72766347502cf3cb4f41cf5e9cc37d28bee90f1fdaaae15f9cf9424"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 
 [[package]]
 name = "byteorder"
@@ -2219,15 +2222,15 @@ dependencies = [
 
 [[package]]
 name = "byteview"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c53ba0f290bfc610084c05582d9c5d421662128fc69f4bf236707af6fd321b9"
+checksum = "0d74937895e761d5984206f82ca8ff7725d0fd8021921011921894b41ab1b9f7"
 
 [[package]]
 name = "camino"
-version = "1.2.4"
+version = "1.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f2d30e4173c4026932d51d31d6b0613b1fd3014bf3f9f8943d4ba139c437ba0"
+checksum = "bb1307f12aa967b5a58416e87b3653360e0fd614a016b6e970db08fecbb1b80d"
 dependencies = [
  "serde_core",
 ]
@@ -2284,9 +2287,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -2424,9 +2427,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.2"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd059f9da4f5c36b3787f65d38ccaab1cc315f07b01f89abc8359ee6a8205011"
+checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -2446,14 +2449,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2498,7 +2501,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "toml 1.1.3+spec-1.1.0",
+ "toml 1.1.4+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
@@ -2576,15 +2579,6 @@ name = "compression-core"
 version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
-
-[[package]]
-name = "concurrent-queue"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
-]
 
 [[package]]
 name = "console"
@@ -3389,13 +3383,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3503,7 +3497,7 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4bd92664bf78c4d3dba9b7cdafce6fa15b13ed3ed16175218196942e99168a8"
 dependencies = [
- "enum-ordinalize 4.4.1",
+ "enum-ordinalize 4.4.2",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -3511,9 +3505,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "elliptic-curve"
@@ -3590,9 +3584,9 @@ dependencies = [
 
 [[package]]
 name = "enum-ordinalize"
-version = "4.4.1"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07f808d588c10e464ea6f7d3eaed500049eff30aaac103460f61828c2d65b3eb"
+checksum = "89dd01549b09589510cf0647475075d12071456586d70f5c75c98ae2a5537677"
 dependencies = [
  "enum-ordinalize-derive",
 ]
@@ -3647,11 +3641,10 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]
@@ -3706,9 +3699,9 @@ checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "ff"
@@ -4092,9 +4085,9 @@ dependencies = [
 
 [[package]]
 name = "glob"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "globset"
@@ -4121,9 +4114,9 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-auth"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3494870d06f3cbbb3561ada6f234982549e3a2fb31e719ef258e6eadb9ae09a"
+checksum = "f54aab44c16b8463ae11b165a87c3d484780231f157bb1ed65843d591beb5abd"
 dependencies = [
  "async-trait",
  "aws-lc-rs",
@@ -4133,11 +4126,11 @@ dependencies = [
  "google-cloud-gax",
  "hex",
  "hmac 0.13.0",
- "http 1.4.2",
+ "http 1.5.0",
  "jsonwebtoken",
  "reqwest 0.13.4",
  "rustc_version",
- "rustls 0.23.42",
+ "rustls 0.23.43",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -4150,15 +4143,15 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-gax"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3103a4a9013f1aed573ca56e19a9680b0211643a99ea85caf524b397d6be8be3"
+checksum = "b9a46dd0fd026bbc4a5d84e6ab0c941cee6e3b057976a0bb107fdb5238ce598f"
 dependencies = [
  "bytes",
  "futures",
  "google-cloud-rpc",
  "google-cloud-wkt",
- "http 1.4.2",
+ "http 1.5.0",
  "pin-project",
  "rand 0.10.2",
  "serde",
@@ -4169,18 +4162,18 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-gax-internal"
-version = "0.7.15"
+version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0df265fba091ed7e00ecd0755009423310163f8b52820f007b6b4d97f4c6617"
+checksum = "fb04c54317ace06d489213f761797240b3046142a9b7ce6b9a82a9d134e193d1"
 dependencies = [
  "bytes",
  "futures",
  "google-cloud-auth",
  "google-cloud-gax",
  "google-cloud-rpc",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body-util",
- "hyper 1.10.1",
+ "hyper 1.11.0",
  "lazy_static",
  "opentelemetry",
  "opentelemetry-semantic-conventions",
@@ -4248,9 +4241,9 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-secretmanager-v1"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35ba4c0675ebad84016a3c31f754512fd9e311800cfa53ec28b7459d6cbb55bd"
+checksum = "5c698b2c961dd595c5f4daacdedb23321089ca8d85353f505ad53a54caa7d63e"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4258,6 +4251,7 @@ dependencies = [
  "google-cloud-gax-internal",
  "google-cloud-iam-v1",
  "google-cloud-location",
+ "google-cloud-rpc",
  "google-cloud-wkt",
  "serde",
  "serde_json",
@@ -4280,9 +4274,9 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-wkt"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46df1fcc3ab69164af3f4199ed21f45b5dbc56d9f03211eb4fa20116d442364b"
+checksum = "7fccf98cfd5481a5f5a285181ab0c62123d7d47cd2bb7299448440649349e4e7"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -4358,7 +4352,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.2",
+ "http 1.5.0",
  "indexmap 2.14.0",
  "slab",
  "tokio",
@@ -4444,7 +4438,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "headers-core",
- "http 1.4.2",
+ "http 1.5.0",
  "httpdate",
  "mime",
  "sha1",
@@ -4456,7 +4450,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
 dependencies = [
- "http 1.4.2",
+ "http 1.5.0",
 ]
 
 [[package]]
@@ -4579,9 +4573,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -4605,7 +4599,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
- "http 1.4.2",
+ "http 1.5.0",
 ]
 
 [[package]]
@@ -4616,7 +4610,7 @@ checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "pin-project-lite",
 ]
@@ -4641,9 +4635,9 @@ checksum = "15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
  "typenum",
 ]
@@ -4674,16 +4668,16 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
  "futures-channel",
  "futures-core",
  "h2 0.4.15",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "httparse",
  "httpdate",
@@ -4715,11 +4709,11 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http 1.4.2",
- "hyper 1.10.1",
+ "http 1.5.0",
+ "hyper 1.11.0",
  "hyper-util",
  "log",
- "rustls 0.23.42",
+ "rustls 0.23.43",
  "rustls-native-certs",
  "tokio",
  "tokio-rustls 0.26.4",
@@ -4732,7 +4726,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper 1.10.1",
+ "hyper 1.11.0",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -4762,9 +4756,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
- "hyper 1.10.1",
+ "hyper 1.11.0",
  "ipnet",
  "libc",
  "percent-encoding",
@@ -5068,9 +5062,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.33"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc43d6fb25860892c78ef7ce2ffed572087a6853ecb60f587f499329717ed7da"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
 dependencies = [
  "defmt",
  "jiff-core",
@@ -5092,9 +5086,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.33"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96fb828bff41eeb269a9665f950cb359e8018f7288b8f34db24937ff54ed8fc5"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
 dependencies = [
  "jiff-core",
  "proc-macro2",
@@ -5352,9 +5346,9 @@ dependencies = [
 
 [[package]]
 name = "jsonpath-rust"
-version = "1.0.5"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4222e00941bfe18bf81b79fa23ad933e233bfa18f3ee27254c5dd9b1543b5d5f"
+checksum = "f62a190c17bf3c6e3a2a676b522edf09d3ba94046e3cdb85fb9d6f09234fdc82"
 dependencies = [
  "pest",
  "pest_derive",
@@ -5385,7 +5379,7 @@ dependencies = [
  "referencing",
  "regex",
  "reqwest 0.13.4",
- "rustls 0.23.42",
+ "rustls 0.23.43",
  "serde",
  "serde_json",
  "unicode-general-category",
@@ -5496,10 +5490,10 @@ dependencies = [
  "bytes",
  "either",
  "futures",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
- "hyper 1.10.1",
+ "hyper 1.11.0",
  "hyper-rustls 0.27.9",
  "hyper-timeout",
  "hyper-util",
@@ -5508,7 +5502,7 @@ dependencies = [
  "k8s-openapi",
  "kube-core",
  "pem",
- "rustls 0.23.42",
+ "rustls 0.23.43",
  "secrecy",
  "serde",
  "serde_json",
@@ -5529,7 +5523,7 @@ checksum = "f126d2db7a8b532ec1d839ece2a71e2485dc3bbca6cc3c3f929becaa810e719e"
 dependencies = [
  "derive_more",
  "form_urlencoded",
- "http 1.4.2",
+ "http 1.5.0",
  "jiff",
  "k8s-openapi",
  "serde",
@@ -5639,9 +5633,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libdbus-sys"
@@ -5898,7 +5892,7 @@ dependencies = [
  "base64 0.22.1",
  "evmap",
  "http-body-util",
- "hyper 1.10.1",
+ "hyper 1.11.0",
  "hyper-rustls 0.27.9",
  "hyper-util",
  "indexmap 2.14.0",
@@ -5906,7 +5900,7 @@ dependencies = [
  "metrics",
  "metrics-util",
  "quanta",
- "rustls 0.23.42",
+ "rustls 0.23.43",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
@@ -6593,9 +6587,9 @@ checksum = "b687ff7b5da449d39e418ad391e5e08da53ec334903ddbb921db208908fc372c"
 
 [[package]]
 name = "pest"
-version = "2.8.7"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47627dd7305c6a2d6c8c6bcd24c5a4c17dbbf425f4f9c5313e724b38fc9782e9"
+checksum = "7df728be843c7070fab6ab7c328c4e9e9d78e23bf749c0669c86ee7ebfa050a2"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -6603,9 +6597,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.7"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b4254325ecad416ab689e27ba51da03ba01a9632bc6e108f5fe7c3c4ad29d58"
+checksum = "9e2dd6fc3b26b3462ee188aac870f5a41d398f1cd5e2408d16531bd71c9591fd"
 dependencies = [
  "pest",
  "pest_generator",
@@ -6613,9 +6607,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.7"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c4c0e91ead7a8f7acecbca6f003fc2e8282b1dbe2dd9c9d2f16aba42995e0a7"
+checksum = "6a7a9205cfb6f596a9e8b689c0a15f9ceb7a1aafae7aaf788150ac65b29975b6"
 dependencies = [
  "pest",
  "pest_meta",
@@ -6626,9 +6620,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.8.7"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9744bc48116fee06334924bb5f2bad41eed5e89bd26e29b0b799f9a3f82c210"
+checksum = "85abd351c0de1e8384fc791a0737111a350394937e92b956b743dac12429f57c"
 dependencies = [
  "pest",
 ]
@@ -6777,7 +6771,7 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "tokio",
- "toml 1.1.3+spec-1.1.0",
+ "toml 1.1.4+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
@@ -6956,7 +6950,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.42",
+ "rustls 0.23.43",
  "socket2 0.6.5",
  "thiserror 2.0.19",
  "tokio",
@@ -6978,7 +6972,7 @@ dependencies = [
  "rand_pcg",
  "ring",
  "rustc-hash",
- "rustls 0.23.42",
+ "rustls 0.23.43",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.19",
@@ -7295,9 +7289,9 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0b9503711b03773e43b31668c7b5bd279ee7cd9b7d18cff7c23a42cc1d08e5a"
+checksum = "3257df217f7eab0044627a268c9cc6cdb60c0c421c88f83ac41c4e31520b6b84"
 dependencies = [
  "ahash 0.8.12",
  "arc-swap",
@@ -7313,7 +7307,7 @@ dependencies = [
  "num-bigint",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.23.42",
+ "rustls 0.23.43",
  "rustls-native-certs",
  "ryu",
  "sha1_smol",
@@ -7362,7 +7356,7 @@ checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.0",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -7519,10 +7513,10 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2 0.4.15",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
- "hyper 1.10.1",
+ "hyper 1.11.0",
  "hyper-rustls 0.27.9",
  "hyper-util",
  "js-sys",
@@ -7531,7 +7525,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.42",
+ "rustls 0.23.43",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "serde",
@@ -7599,7 +7593,7 @@ dependencies = [
  "pastey 0.2.3",
  "pin-project-lite",
  "rmcp-macros",
- "schemars 1.2.1",
+ "schemars 1.2.2",
  "serde",
  "serde_json",
  "thiserror 2.0.19",
@@ -7654,7 +7648,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bytes",
- "http 1.4.2",
+ "http 1.5.0",
  "reqwest 0.13.4",
  "rustify_derive",
  "serde",
@@ -7706,9 +7700,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.42"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -7751,9 +7745,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "web-time",
  "zeroize",
@@ -7770,7 +7764,7 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.42",
+ "rustls 0.23.43",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki 0.103.13",
@@ -7870,9 +7864,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
 dependencies = [
  "chrono",
  "dyn-clone",
@@ -7884,14 +7878,14 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+checksum = "d98c67716b46af2f0b8cf752abc930f6f9aecfbf671ecfb531db8a31dbe4e2ba"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -8077,18 +8071,18 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.0",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "serde_derive_internals"
-version = "0.29.1"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -8114,9 +8108,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -8181,7 +8175,7 @@ dependencies = [
  "indexmap 1.9.3",
  "indexmap 2.14.0",
  "schemars 0.9.0",
- "schemars 1.2.1",
+ "schemars 1.2.2",
  "serde_core",
  "serde_json",
  "serde_with_macros",
@@ -8852,9 +8846,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.0"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2fac314a64dc9a36e61a9eb4261a5e9bbfbc922b27e518af97bc32b926cf967"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9099,7 +9093,7 @@ checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.0",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -9113,9 +9107,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.53"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
+checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
 dependencies = [
  "deranged",
  "js-sys",
@@ -9136,9 +9130,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -9180,9 +9174,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.53.0"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d988bcd52dbe076d3d46903332f58c912b87a2c49b1428419a5845154762ffee"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -9197,13 +9191,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -9232,15 +9226,15 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.42",
+ "rustls 0.23.43",
  "tokio",
 ]
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -9255,7 +9249,7 @@ checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
 dependencies = [
  "futures-util",
  "log",
- "rustls 0.23.42",
+ "rustls 0.23.43",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
@@ -9266,14 +9260,15 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
  "futures-util",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
@@ -9302,9 +9297,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.3+spec-1.1.0"
+version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
  "indexmap 2.14.0",
  "serde_core",
@@ -9326,9 +9321,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow",
 ]
@@ -9350,10 +9345,10 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "h2 0.4.15",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
- "hyper 1.10.1",
+ "hyper 1.11.0",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
@@ -9401,7 +9396,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
  "mime",
@@ -9436,7 +9431,7 @@ dependencies = [
  "axum",
  "forwarded-header-value",
  "governor",
- "http 1.4.2",
+ "http 1.5.0",
  "pin-project",
  "thiserror 2.0.19",
  "tonic",
@@ -9568,9 +9563,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-proof"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0138696d9a4d052ee0c7d780a7ba28d469c41dc3157312ae222c9e54d484fe9"
+checksum = "88908c703a80ae8716603fba04fdbe5ef91dae66c433ce07267bf589b616bd6a"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -9613,11 +9608,11 @@ checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
 dependencies = [
  "bytes",
  "data-encoding",
- "http 1.4.2",
+ "http 1.5.0",
  "httparse",
  "log",
  "rand 0.9.5",
- "rustls 0.23.42",
+ "rustls 0.23.43",
  "rustls-pki-types",
  "sha1",
  "thiserror 2.0.19",
@@ -10038,7 +10033,7 @@ checksum = "30ffcc0e81025065dda612ec1e26a3d81bb16ef3062354873d17a35965d68522"
 dependencies = [
  "async-trait",
  "derive_builder",
- "http 1.4.2",
+ "http 1.5.0",
  "reqwest 0.13.4",
  "rustify",
  "rustify_derive",
@@ -10103,7 +10098,7 @@ dependencies = [
  "subtle",
  "tempfile",
  "tokio",
- "toml 1.1.3+spec-1.1.0",
+ "toml 1.1.4+spec-1.1.0",
  "tracing",
  "uuid",
  "vta-config",
@@ -10148,7 +10143,7 @@ dependencies = [
  "serde",
  "serde_ignored",
  "tempfile",
- "toml 1.1.3+spec-1.1.0",
+ "toml 1.1.4+spec-1.1.0",
  "tracing",
  "vti-common",
  "vti-secrets",
@@ -10217,7 +10212,7 @@ dependencies = [
  "anyhow",
  "clap",
  "rmcp",
- "schemars 1.2.1",
+ "schemars 1.2.2",
  "serde",
  "serde_json",
  "tokio",
@@ -10311,7 +10306,7 @@ dependencies = [
  "nitro_attest",
  "reqwest 0.13.4",
  "ring",
- "rustls 0.23.42",
+ "rustls 0.23.43",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -10394,7 +10389,7 @@ dependencies = [
  "thiserror 2.0.19",
  "tokio",
  "tokio-util",
- "toml 1.1.3+spec-1.1.0",
+ "toml 1.1.4+spec-1.1.0",
  "tower",
  "tower-http",
  "tower_governor",
@@ -10472,7 +10467,7 @@ dependencies = [
 name = "vta-tee"
 version = "0.1.4"
 dependencies = [
- "aes 0.9.1",
+ "aes 0.9.2",
  "aes-gcm",
  "aws-config",
  "aws-lc-rs",
@@ -10623,7 +10618,7 @@ dependencies = [
  "thiserror 2.0.19",
  "tokio",
  "tokio-util",
- "toml 1.1.3+spec-1.1.0",
+ "toml 1.1.4+spec-1.1.0",
  "tower",
  "tower-http",
  "tower_governor",
@@ -10743,7 +10738,7 @@ dependencies = [
  "serde",
  "tempfile",
  "tokio",
- "toml 1.1.3+spec-1.1.0",
+ "toml 1.1.4+spec-1.1.0",
  "tracing",
  "vaultrs",
  "vta-sdk",
@@ -11374,9 +11369,9 @@ dependencies = [
  "base64 0.22.1",
  "deadpool",
  "futures",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body-util",
- "hyper 1.10.1",
+ "hyper 1.11.0",
  "hyper-util",
  "log",
  "once_cell",
@@ -11511,9 +11506,9 @@ dependencies = [
 
 [[package]]
 name = "xxhash-rust"
-version = "0.8.17"
+version = "0.8.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "985eec839aaf2a1270af8f4ebcf63cf9401cfd90f0902f97c28d9f104ffbde72"
+checksum = "aee1b19627c7c60102ab80d3a9cbe18de90bfe03bfa6c3715447681f0e8c8af6"
 
 [[package]]
 name = "yasna"
@@ -11549,18 +11544,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.54"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.54"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10562,7 +10562,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-service"
-version = "0.11.48"
+version = "0.11.49"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10271,7 +10271,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.20.30"
+version = "0.20.31"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10333,7 +10333,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.13.21"
+version = "0.13.22"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/changelog.d/883-acl-didcomm-trust-tasks.md
+++ b/changelog.d/883-acl-didcomm-trust-tasks.md
@@ -1,0 +1,59 @@
+### vta-sdk 0.20.31 / vta-service 0.13.22 — the ACL slice speaks Trust Tasks on every transport (#883)
+
+`pnm acl get <did>` against a DIDComm-connected VTA failed with
+
+```
+✗ Error: serialization error: missing field `entry`
+```
+
+while the VTA logged `ACL entry retrieved … status="ok(response)"`. Both were
+right: the maintainer answered, and the client could not read the answer.
+
+**Root cause.** Folding the ACL surface onto canonical `acl/*` (#842, #855) moved
+the REST routes and the Trust Task spine onto the canonical bodies — `{ entry }`,
+`{ entries, truncated, … }` over the shared camelCase `AclEntry` — and moved the
+SDK client with them. The legacy `acl-management/1.0/*` DIDComm handlers were
+folded only partway: `create`, `update` and `revoke` moved, while `get-acl`,
+`list-acl` and `change-role` kept calling the maintainer's **stored** shape
+(`CreateAclResultBody`: flat, snake_case, `did`/`allowed_contexts`). The SDK
+deserializes both transports with the same type, so the same call worked over
+REST and failed over DIDComm. Nothing caught it — each side of that wire is
+tested against its own hand-written fixture.
+
+Three ACL calls were affected over DIDComm, in two directions:
+
+| call | failure |
+|---|---|
+| `acl get` | response `missing field 'entry'` |
+| `acl list` | request rejected (`ListAclBody` is `deny_unknown_fields` and the client sent the pre-fold `context`), response a bare array |
+| `acl change-role` | response `missing field 'entry'` |
+
+**The client now sends Trust Tasks for the whole ACL slice** — `acl/show/0.1`,
+`acl/list/0.1`, `acl/update/0.1`, `acl/change-role/0.1`, joining the `grant` and
+`revoke` that #861 had already moved. The REST leg of each call is byte-identical
+to before; only the DIDComm leg changes shape, and TSP — which carries the
+Trust-Task surface and nothing else — reaches these four calls for the first
+time.
+
+`update_acl` gained back what the legacy leg dropped. It hand-built three members
+of its DIDComm body (`subject`, `label`, `scopes`), so an operator narrowing a
+step-up approver, an approve scope, an expiry or an `allowedKeys` filter over
+DIDComm silently changed none of them and got a healthy-looking entry back. The
+task payload is now the full canonical `UpdateAclBody`.
+
+**Why it cannot drift back.** The stored-shape operations
+(`operations::acl::{get_acl, list_acl, update_acl, change_role}`) are private to
+`operations::acl`. Transports reach them only through the canonical wrappers —
+`show_by_subject`, `list_entries`, `update_from_params`, and the new
+`change_role_by_subject`, which replaces the identical hand-wrapping REST and the
+Trust Task spine each did. A handler that returns the internal shape no longer
+compiles.
+
+The DIDComm handlers keep answering the legacy type URIs with the canonical
+bodies, so an already-installed `pnm` gets working `acl get` and `acl change-role`
+from a VTA upgrade alone; `acl list` needs the rebuilt client, since its old
+request is refused at the maintainer.
+
+**Testing.** `tests/e2e/tests/client_didcomm.rs` pins each of the four as a Trust
+Task, including the members `update` used to drop and the canonical `scope`
+filter name that replaced `context`.

--- a/changelog.d/884-acl-didcomm-trust-tasks.md
+++ b/changelog.d/884-acl-didcomm-trust-tasks.md
@@ -54,6 +54,52 @@ bodies, so an already-installed `pnm` gets working `acl get` and `acl change-rol
 from a VTA upgrade alone; `acl list` needs the rebuilt client, since its old
 request is refused at the maintainer.
 
-**Testing.** `tests/e2e/tests/client_didcomm.rs` pins each of the four as a Trust
-Task, including the members `update` used to drop and the canonical `scope`
-filter name that replaced `context`.
+## `swap_acl` works again, on all three transports
+
+Self-service key rotation was broken the same way, but everywhere at once: the
+client parsed the canonical entry (`subject`/`scopes`) while REST `/acl/swap` and
+legacy DIDComm both answered the flat stored row and the Trust Task spine
+answered `{ entry, previousSubject }`. Three shapes, one parser, no working
+caller — `missing field 'subject'` on every transport.
+
+It now sends canonical `acl/swap-key/0.1` **everywhere**, over REST through the
+trust-task endpoint rather than the legacy route (which stays mounted, unchanged,
+for the non-Rust consumers reading it). `newSubject` is read from the
+presentation's own `iss` via the new `swap::peek_presentation_holder` — which
+`AclSwapPresentation::peek_holder` now delegates to, so producer and verifier
+cannot disagree about what a proof says. `currentSubject` comes from the DID the
+client sends as (new `VtaClient::caller_did`). Both are declarations the
+maintainer cross-checks against the proof and the authenticated caller.
+
+A REST client has a bearer token, not a DID, so it has nothing to infer the
+swapped-out VID from: `swap_acl` there fails before the request leaves the
+process, naming the additive `swap_acl_for(current_subject, req)` that takes it.
+
+Server-side, the bare-DIDComm `acl/swap-key/0.1` route answered the flat row too,
+so the same canonical URI had two shapes depending on which envelope carried it.
+It now answers `{ entry, previousSubject }` like the spine. The legacy
+`swap-acl` type keeps the flat row — that is its documented contract.
+
+## Sweep of the remaining legacy `rpc` surfaces
+
+`rpc`'s TSP arm is an `UnsupportedTransport` error, so **every method still on it
+is unavailable over TSP** — which is what made this worth auditing rather than
+just fixing the reported call. Findings for the eight that remained:
+
+| method | DIDComm shape | disposition |
+|---|---|---|
+| `swap_acl` | broken (above) | → canonical task, all transports |
+| `update_webvh_server` | agrees | → `webvh/servers/register/1.0`, whose payload is byte-identical to what it already sent (#850 folded add + update into it) |
+| `update_did_webvh`, `rotate_did_webvh_keys` | agree | left: their canonical twins key on `did`, while these take `(context_id, scid)` — moving them is a signature change plus a CLI lookup, not a transport swap |
+| `import_key`, `backup_export`, `backup_import`, `list_webvh_server_domains` | agree | left: no canonical twin exists, and minting task URIs is spec work (VTI #856/#857), not something to do inside a bug fix |
+
+The four left behind are shape-correct over REST and DIDComm and dead over TSP.
+None of them is the defect class this PR fixes; all of them are on the TSP gap
+list.
+
+**Testing.** `tests/e2e/tests/client_didcomm.rs` pins each moved call as a Trust
+Task — including the members `update` used to drop, the canonical `scope` filter
+name that replaced `context`, and a `swap_acl` whose `currentSubject` is the
+session's own DID and whose `newSubject` is read out of an SDK-built
+presentation. `vta-sdk/tests/client_rest.rs` pins swap's REST leg on
+`/api/trust-tasks` and the error that names `swap_acl_for`.

--- a/changelog.d/884-acl-didcomm-trust-tasks.md
+++ b/changelog.d/884-acl-didcomm-trust-tasks.md
@@ -1,4 +1,4 @@
-### vta-sdk 0.20.31 / vta-service 0.13.22 — the ACL slice speaks Trust Tasks on every transport (#884)
+### vta-sdk 0.20.31 / vta-service 0.13.22 / vtc-service 0.11.49 — the ACL slice speaks Trust Tasks on every transport (#884)
 
 `pnm acl get <did>` against a DIDComm-connected VTA failed with
 
@@ -101,7 +101,9 @@ list.
 
 `cargo update` (69 crates) and `npm update` in `vtc-service/admin-ui` — both
 within the existing requirement ranges, so no `Cargo.toml` or `package.json`
-changed. Two open advisories close as a side effect: `rustls-webpki` 0.103.13
+changed. `vtc-service` is version-bumped because the admin UI is **embedded in
+its binary**: the npm move changes what that crate publishes even though no Rust
+line differs. Two open advisories close as a side effect: `rustls-webpki` 0.103.13
 (high) and `postcss` 8.5.23 plus `react-router` 7.18.2 (high + three medium).
 
 Still open afterwards, and **not** fixable by an in-range update:

--- a/changelog.d/884-acl-didcomm-trust-tasks.md
+++ b/changelog.d/884-acl-didcomm-trust-tasks.md
@@ -1,4 +1,4 @@
-### vta-sdk 0.20.31 / vta-service 0.13.22 — the ACL slice speaks Trust Tasks on every transport (#883)
+### vta-sdk 0.20.31 / vta-service 0.13.22 — the ACL slice speaks Trust Tasks on every transport (#884)
 
 `pnm acl get <did>` against a DIDComm-connected VTA failed with
 

--- a/changelog.d/884-acl-didcomm-trust-tasks.md
+++ b/changelog.d/884-acl-didcomm-trust-tasks.md
@@ -97,6 +97,24 @@ The four left behind are shape-correct over REST and DIDComm and dead over TSP.
 None of them is the defect class this PR fixes; all of them are on the TSP gap
 list.
 
+## Dependency refresh
+
+`cargo update` (69 crates) and `npm update` in `vtc-service/admin-ui` — both
+within the existing requirement ranges, so no `Cargo.toml` or `package.json`
+changed. Two open advisories close as a side effect: `rustls-webpki` 0.103.13
+(high) and `postcss` 8.5.23 plus `react-router` 7.18.2 (high + three medium).
+
+Still open afterwards, and **not** fixable by an in-range update:
+`rustls-webpki` 0.101.7, which arrives through the AWS SDK's legacy `rustls`
+0.21 and needs an `aws-config` feature change rather than a lockfile move.
+
+Twenty direct dependencies remain a major behind, including the crypto core
+(`ed25519-dalek` 3, `curve25519-dalek` 5, `x25519-dalek` 3, `hpke` 0.14,
+`aes-gcm` 0.11, `p256` 0.14, `jsonwebtoken` 11) and `kube` 4 / `rmcp` 3 /
+`uniffi` 0.32 / `azure_*` 1.0. Each needs an API migration through code this PR
+does not otherwise touch — sealed-transfer, DI proofs and auth for the crypto
+set — so they are left for their own changes.
+
 **Testing.** `tests/e2e/tests/client_didcomm.rs` pins each moved call as a Trust
 Task — including the members `update` used to drop, the canonical `scope` filter
 name that replaced `context`, and a `swap_acl` whose `currentSubject` is the

--- a/tests/e2e/tests/client_didcomm.rs
+++ b/tests/e2e/tests/client_didcomm.rs
@@ -682,6 +682,103 @@ async fn change_acl_role_via_didcomm() {
     shutdown_all(client, responder, mediator).await;
 }
 
+/// `swap_acl` declares `currentSubject`, and a DIDComm client already proves
+/// that DID by sending — so it fills it in rather than making the caller repeat
+/// it. `newSubject` comes from the presentation's own `iss`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn swap_acl_via_didcomm_infers_the_sending_did() {
+    // The presentation is built by the SDK's own producer, so the `iss` the
+    // client reads back is the one a real rotation would carry.
+    let new_key = SigningKey::from_bytes(&[0x22; 32]);
+    let new_did = format!(
+        "did:key:{}",
+        ed25519_multibase_pubkey(&new_key.verifying_key().to_bytes())
+    );
+    let (sender_did, _) = did_key_from_seed(0x11);
+
+    let (expect_sender, expect_new) = (sender_did.clone(), new_did.clone());
+    let (mediator, responder, client) = build_didcomm(move |msg_type, body| {
+        if is_tt(msg_type, body, trust_tasks::TASK_ACL_SWAP_KEY_0_1) {
+            let p = &body["payload"];
+            assert_eq!(p["currentSubject"], expect_sender.as_str(), "{body}");
+            assert_eq!(p["newSubject"], expect_new.as_str(), "{body}");
+            assert!(p["linkProof"].is_string(), "{body}");
+            tt_ok(
+                trust_tasks::TASK_ACL_SWAP_KEY_0_1,
+                json!({
+                    "entry": acl_entry_json(&expect_new),
+                    "previousSubject": expect_sender.as_str(),
+                }),
+            )
+        } else {
+            no_handler()
+        }
+    })
+    .await;
+
+    let presentation = vta_sdk::protocols::acl_management::swap::build_swap_presentation(
+        &new_key,
+        &new_did,
+        responder.did(),
+        1_000,
+        300,
+        None,
+    );
+    let entry = client
+        .swap_acl(SwapAclRequest::new(presentation))
+        .await
+        .unwrap();
+    assert_eq!(entry.did, new_did);
+
+    shutdown_all(client, responder, mediator).await;
+}
+
+// ── WebVH servers ───────────────────────────────────────────────────
+
+/// Relabelling a registered server rides `webvh/servers/register/1.0` — the
+/// canonical task #850 folded add + update into. A payload with no `did` is the
+/// label-only patch; the maintainer refuses to create a registration from one.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn update_webvh_server_via_didcomm() {
+    let (mediator, responder, client) = build_didcomm(|msg_type, body| {
+        if is_tt(msg_type, body, trust_tasks::TASK_WEBVH_SERVERS_REGISTER_1_0) {
+            let p = &body["payload"];
+            assert_eq!(p["id"], "s1", "{body}");
+            assert_eq!(p["label"], "primary", "{body}");
+            assert!(
+                p.get("did").is_none_or(Value::is_null),
+                "a label-only patch must not claim a did: {body}"
+            );
+            tt_ok(
+                trust_tasks::TASK_WEBVH_SERVERS_REGISTER_1_0,
+                json!({
+                    "id": "s1",
+                    "did": "did:web:host.example",
+                    "label": "primary",
+                    "created_at": "2026-01-01T00:00:00Z",
+                    "updated_at": "2026-01-02T00:00:00Z",
+                }),
+            )
+        } else {
+            no_handler()
+        }
+    })
+    .await;
+
+    let record = client
+        .update_webvh_server(
+            "s1",
+            UpdateWebvhServerRequest {
+                label: Some("primary".into()),
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(record.label.as_deref(), Some("primary"));
+
+    shutdown_all(client, responder, mediator).await;
+}
+
 // ── Contexts ────────────────────────────────────────────────────────
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/tests/e2e/tests/client_didcomm.rs
+++ b/tests/e2e/tests/client_didcomm.rs
@@ -20,7 +20,7 @@
 //! - **Legacy protocol message**: the surfaces still on `rpc` (`import_key`,
 //!   `backup_export`/`backup_import`, the webvh server/DID updates) dispatch
 //!   on the `*_management` message-type constant. The ACL reads and updates
-//!   left behind by #861 moved to Trust Tasks in #883 — they were the ones
+//!   left behind by #861 moved to Trust Tasks in #884 — they were the ones
 //!   where the maintainer had already folded and the client had not.
 
 use ed25519_dalek::SigningKey;
@@ -508,7 +508,7 @@ async fn rotate_seed_via_didcomm() {
 
 // ── ACL ─────────────────────────────────────────────────────────────
 
-/// The whole ACL slice rides Trust Tasks as of #883 — the last four methods
+/// The whole ACL slice rides Trust Tasks as of #884 — the last four methods
 /// (`list`, `show`, `update`, `change-role`) that #861 left on the legacy
 /// `acl-management/1.0/*` messages. The legacy surface is where client and
 /// maintainer drifted apart unnoticed: `get-acl` answered the flat stored row
@@ -604,7 +604,7 @@ async fn delete_acl_via_didcomm_returns_unit() {
     shutdown_all(client, responder, mediator).await;
 }
 
-/// Every member the caller set has to reach the maintainer. The pre-#883
+/// Every member the caller set has to reach the maintainer. The pre-#884
 /// DIDComm leg hand-built three of them (`subject`, `label`, `scopes`) and
 /// dropped the rest, so an operator narrowing an approver or a key filter over
 /// DIDComm silently changed nothing — the response still echoed a fine-looking

--- a/tests/e2e/tests/client_didcomm.rs
+++ b/tests/e2e/tests/client_didcomm.rs
@@ -17,10 +17,11 @@
 //!   `{ id, type, payload }`, so the responder must dispatch on the *inner*
 //!   `type` URI (a `vta_sdk::trust_tasks::TASK_*` constant) — see [`is_tt`]
 //!   / [`tt_ok`].
-//! - **Legacy protocol message**: the surfaces #861 deliberately left on
-//!   `rpc` (`import_key`, the flat-response ACL reads/updates,
-//!   `backup_export`, …) still dispatch on the `*_management` message-type
-//!   constant.
+//! - **Legacy protocol message**: the surfaces still on `rpc` (`import_key`,
+//!   `backup_export`/`backup_import`, the webvh server/DID updates) dispatch
+//!   on the `*_management` message-type constant. The ACL reads and updates
+//!   left behind by #861 moved to Trust Tasks in #883 — they were the ones
+//!   where the maintainer had already folded and the client had not.
 
 use ed25519_dalek::SigningKey;
 use serde_json::{Value, json};
@@ -29,7 +30,7 @@ use vta_sdk::did_key::ed25519_multibase_pubkey;
 use vta_sdk::error::VtaError;
 use vta_sdk::keys::{KeyOrigin, KeyStatus, KeyType};
 use vta_sdk::protocols::key_management::sign::SignAlgorithm;
-use vta_sdk::protocols::{acl_management, backup_management, key_management};
+use vta_sdk::protocols::{backup_management, key_management};
 use vta_sdk::trust_tasks;
 
 mod common;
@@ -507,14 +508,28 @@ async fn rotate_seed_via_didcomm() {
 
 // ── ACL ─────────────────────────────────────────────────────────────
 
-/// `list_acl` stayed on the legacy message (#861 left the ACL reads behind:
-/// their twins answer with the flat stored form, not `{ entries }`).
+/// The whole ACL slice rides Trust Tasks as of #883 — the last four methods
+/// (`list`, `show`, `update`, `change-role`) that #861 left on the legacy
+/// `acl-management/1.0/*` messages. The legacy surface is where client and
+/// maintainer drifted apart unnoticed: `get-acl` answered the flat stored row
+/// while the client parsed `{ entry }`, so `pnm acl get` over DIDComm failed
+/// with `missing field 'entry'` against a VTA whose REST route was correct.
+///
+/// The canonical filter member is `scope`, not `context`. Sending the old
+/// name is not a soft mismatch: `ListAclBody` is `deny_unknown_fields`, so the
+/// maintainer refuses the whole request.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn list_acl_via_didcomm() {
-    let (mediator, responder, client) = build_didcomm(|msg_type, _body| {
-        if msg_type == acl_management::LIST_ACL {
-            ResponderReply::ok(
-                acl_management::LIST_ACL_RESULT,
+    let (mediator, responder, client) = build_didcomm(|msg_type, body| {
+        if is_tt(msg_type, body, trust_tasks::TASK_ACL_LIST_0_1) {
+            let payload = &body["payload"];
+            assert_eq!(payload["scope"], "ctx-a", "canonical filter member: {body}");
+            assert!(
+                payload.get("context").is_none(),
+                "pre-fold `context` must not be sent: {body}"
+            );
+            tt_ok(
+                trust_tasks::TASK_ACL_LIST_0_1,
                 json!({"entries": [acl_entry_json("did:key:zAdmin")], "truncated": false}),
             )
         } else {
@@ -523,8 +538,29 @@ async fn list_acl_via_didcomm() {
     })
     .await;
 
-    let r = client.list_acl(None).await.unwrap();
+    let r = client.list_acl(Some("ctx-a")).await.unwrap();
     assert_eq!(r.entries.len(), 1);
+
+    shutdown_all(client, responder, mediator).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn get_acl_via_didcomm() {
+    let (mediator, responder, client) = build_didcomm(|msg_type, body| {
+        if is_tt(msg_type, body, trust_tasks::TASK_ACL_SHOW_0_1) {
+            assert_eq!(body["payload"]["subject"], "did:key:zAdmin", "{body}");
+            tt_ok(
+                trust_tasks::TASK_ACL_SHOW_0_1,
+                acl_entry_envelope("did:key:zAdmin"),
+            )
+        } else {
+            no_handler()
+        }
+    })
+    .await;
+
+    let entry = client.get_acl("did:key:zAdmin").await.unwrap();
+    assert_eq!(entry.did, "did:key:zAdmin");
 
     shutdown_all(client, responder, mediator).await;
 }
@@ -568,14 +604,24 @@ async fn delete_acl_via_didcomm_returns_unit() {
     shutdown_all(client, responder, mediator).await;
 }
 
-/// `update_acl` stayed on the legacy message: its request is non-canonical
-/// and the dispatch spine's schema check rejects it (#861).
+/// Every member the caller set has to reach the maintainer. The pre-#883
+/// DIDComm leg hand-built three of them (`subject`, `label`, `scopes`) and
+/// dropped the rest, so an operator narrowing an approver or a key filter over
+/// DIDComm silently changed nothing — the response still echoed a fine-looking
+/// entry.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn update_acl_via_didcomm() {
-    let (mediator, responder, client) = build_didcomm(|msg_type, _body| {
-        if msg_type == acl_management::UPDATE_ACL {
-            ResponderReply::ok(
-                acl_management::UPDATE_ACL_RESULT,
+async fn update_acl_via_didcomm_carries_every_member() {
+    let (mediator, responder, client) = build_didcomm(|msg_type, body| {
+        if is_tt(msg_type, body, trust_tasks::TASK_ACL_UPDATE_0_1) {
+            let p = &body["payload"];
+            assert_eq!(p["subject"], "did:key:zAdmin", "{body}");
+            assert_eq!(p["scopes"], json!(["ctx-a"]), "{body}");
+            assert_eq!(p["stepUp"]["approver"], "did:key:zApprover", "{body}");
+            assert_eq!(p["stepUp"]["require"], "delegated", "{body}");
+            assert_eq!(p["approve"]["scopes"], json!(["ctx-b"]), "{body}");
+            assert_eq!(p["allowedKeys"], json!(["tenant-key-a"]), "{body}");
+            tt_ok(
+                trust_tasks::TASK_ACL_UPDATE_0_1,
                 acl_entry_envelope("did:key:zAdmin"),
             )
         } else {
@@ -586,11 +632,11 @@ async fn update_acl_via_didcomm() {
 
     let req = UpdateAclRequest {
         label: None,
-        allowed_contexts: None,
-        step_up_approver: None,
-        step_up_require: None,
-        approve_scope: None,
-        allowed_keys: None,
+        allowed_contexts: Some(vec!["ctx-a".into()]),
+        step_up_approver: Some("did:key:zApprover".into()),
+        step_up_require: Some("delegated".into()),
+        approve_scope: Some(vta_sdk::acl::ApproveScope::Contexts(vec!["ctx-b".into()])),
+        allowed_keys: Some(Some(vec!["tenant-key-a".into()])),
     };
     client.update_acl("did:key:zAdmin", req).await.unwrap();
 
@@ -605,13 +651,14 @@ async fn update_acl_via_didcomm() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn change_acl_role_via_didcomm() {
     let (mediator, responder, client) = build_didcomm(|msg_type, body| {
-        if msg_type == acl_management::CHANGE_ROLE {
+        if is_tt(msg_type, body, trust_tasks::TASK_ACL_CHANGE_ROLE_0_1) {
             // The compare-and-swap has to reach the maintainer, or the
             // check it exists for cannot run.
-            assert_eq!(body["fromRole"], "reader", "fromRole must be sent: {body}");
-            assert_eq!(body["toRole"], "application", "toRole must be sent: {body}");
-            ResponderReply::ok(
-                acl_management::CHANGE_ROLE_RESULT,
+            let p = &body["payload"];
+            assert_eq!(p["fromRole"], "reader", "fromRole must be sent: {body}");
+            assert_eq!(p["toRole"], "application", "toRole must be sent: {body}");
+            tt_ok(
+                trust_tasks::TASK_ACL_CHANGE_ROLE_0_1,
                 acl_entry_envelope("did:key:zAdmin"),
             )
         } else {

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.20.30"
+version = "0.20.31"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/client/acl.rs
+++ b/vta-sdk/src/client/acl.rs
@@ -199,14 +199,60 @@ impl VtaClient {
 
     /// Atomic self-service key rotation: move the caller's own ACL entry onto
     /// the DID proven by `req.presentation` (a VP-JWT). Returns the new entry.
+    ///
+    /// Sends canonical `acl/swap-key/0.1` on **every** transport — over REST
+    /// through the trust-task endpoint rather than the legacy `POST /acl/swap`
+    /// route, which is the one surface that still answers with the maintainer's
+    /// flat stored row. That mismatch is what left this method returning
+    /// `missing field 'subject'` for every caller on every transport after the
+    /// canonical fold (#842); the legacy route stays mounted, untouched, for
+    /// the non-Rust consumers that read it.
+    ///
+    /// `newSubject` is read from the presentation's `iss`, and `currentSubject`
+    /// from the DID this client sends as. Both are declarations the maintainer
+    /// cross-checks against the proof and the authenticated caller — a wrong
+    /// one is refused, never applied.
+    ///
+    /// **A REST client has a bearer token, not a DID**, so there is nothing to
+    /// infer the swapped-out VID from; use [`swap_acl_for`](Self::swap_acl_for)
+    /// there.
     pub async fn swap_acl(&self, req: SwapAclRequest) -> Result<AclEntryResponse, VtaError> {
-        self.rpc(
-            acl_management::SWAP_ACL,
-            serde_json::to_value(&req)?,
-            acl_management::SWAP_ACL_RESULT,
-            30,
-            |c, url| c.post(format!("{url}/acl/swap")).json(&req),
-        )
-        .await
+        let current_subject = self.caller_did().map(str::to_string).ok_or_else(|| {
+            VtaError::Validation(
+                "acl/swap-key declares the VID being swapped out, and a REST client has no DID \
+                 to infer it from — call `swap_acl_for(<did>, req)` instead"
+                    .into(),
+            )
+        })?;
+        self.swap_acl_for(&current_subject, req).await
+    }
+
+    /// [`swap_acl`](Self::swap_acl) with the swapped-out VID stated outright —
+    /// the REST-transport form, since a bearer token does not name a DID.
+    ///
+    /// The maintainer refuses a `currentSubject` that is not the authenticated
+    /// caller, so naming someone else's VID here rotates nothing.
+    pub async fn swap_acl_for(
+        &self,
+        current_subject: &str,
+        req: SwapAclRequest,
+    ) -> Result<AclEntryResponse, VtaError> {
+        let new_subject = acl_management::swap::peek_presentation_holder(&req.presentation)
+            .map_err(|e| VtaError::Validation(format!("swap presentation is unreadable: {e}")))?;
+
+        // `AclEntryEnvelope` ignores the response's `previousSubject`; the
+        // caller asked for the entry, and the VID that lost the grant is the
+        // one they just sent.
+        let payload = serde_json::json!({
+            "currentSubject": current_subject,
+            "newSubject": new_subject,
+            "linkProof": &req.presentation,
+        });
+        let response = self
+            .dispatch_trust_task(crate::trust_tasks::TASK_ACL_SWAP_KEY_0_1, payload, 30)
+            .await?;
+        let wrapped: AclEntryEnvelope = serde_json::from_value(response)
+            .map_err(|e| VtaError::Protocol(format!("acl/swap-key response decode: {e}")))?;
+        Ok(wrapped.entry)
     }
 }

--- a/vta-sdk/src/client/acl.rs
+++ b/vta-sdk/src/client/acl.rs
@@ -117,7 +117,7 @@ impl VtaClient {
         // like grant and show.
         //
         // The task payload is the full canonical body. Hand-rolling three of
-        // its members here — as this did before #883 — silently dropped the
+        // its members here — as this did before #884 — silently dropped the
         // step-up, approve-authority, expiry, `allowedKeys` and `reason` the
         // caller asked for the moment the client was on DIDComm rather than
         // REST: a narrowing the operator believed they had applied.

--- a/vta-sdk/src/client/acl.rs
+++ b/vta-sdk/src/client/acl.rs
@@ -47,10 +47,16 @@ impl VtaClient {
         // already does.
         let direction_field = (direction != ContextDirection::default())
             .then(|| serde_json::Value::String(direction.to_string()));
-        self.rpc(
-            acl_management::LIST_ACL,
-            serde_json::json!({ "context": context, "direction": direction_field }),
-            acl_management::LIST_ACL_RESULT,
+        let mut payload = serde_json::Map::new();
+        if let Some(ctx) = context {
+            payload.insert("scope".into(), serde_json::Value::String(ctx.to_string()));
+        }
+        if let Some(d) = direction_field {
+            payload.insert("direction".into(), d);
+        }
+        self.rpc_tt(
+            crate::trust_tasks::TASK_ACL_LIST_0_1,
+            serde_json::Value::Object(payload),
             30,
             |c, url| {
                 // Both parameters are appended independently — a direction
@@ -76,10 +82,9 @@ impl VtaClient {
         // Canonical `acl/show/0.1` wraps the entry (alongside `redactedFields`);
         // unwrap so callers keep working with the entry itself.
         let wrapped: AclEntryEnvelope = self
-            .rpc(
-                acl_management::GET_ACL,
+            .rpc_tt(
+                crate::trust_tasks::TASK_ACL_SHOW_0_1,
                 serde_json::json!({ "subject": did }),
-                acl_management::GET_ACL_RESULT,
                 30,
                 |c, url| c.get(format!("{url}/acl/{}", encode_path_segment(did))),
             )
@@ -109,17 +114,35 @@ impl VtaClient {
         req: UpdateAclRequest,
     ) -> Result<AclEntryResponse, VtaError> {
         // Canonical `acl/update/0.1` returns the realized entry under `entry`,
-        // like grant and show. The DIDComm body is the canonical wire shape
-        // (`subject`/`scopes` — #856), same as the Trust Task transport.
+        // like grant and show.
+        //
+        // The task payload is the full canonical body. Hand-rolling three of
+        // its members here — as this did before #883 — silently dropped the
+        // step-up, approve-authority, expiry, `allowedKeys` and `reason` the
+        // caller asked for the moment the client was on DIDComm rather than
+        // REST: a narrowing the operator believed they had applied.
+        let body = acl_management::update::UpdateAclBody {
+            did: did.to_string(),
+            label: req.label.clone(),
+            allowed_contexts: req.allowed_contexts.clone(),
+            expires_at: None,
+            reason: None,
+            step_up: (req.step_up_approver.is_some() || req.step_up_require.is_some()).then(|| {
+                acl_management::entry::StepUp {
+                    approver: req.step_up_approver.clone(),
+                    require: req.step_up_require.clone(),
+                }
+            }),
+            approve: req
+                .approve_scope
+                .as_ref()
+                .map(acl_management::entry::Approve::from_scope),
+            allowed_keys: req.allowed_keys.clone(),
+        };
         let wrapped: AclEntryEnvelope = self
-            .rpc(
-                acl_management::UPDATE_ACL,
-                serde_json::json!({
-                    "subject": did,
-                    "label": &req.label,
-                    "scopes": &req.allowed_contexts,
-                }),
-                acl_management::UPDATE_ACL_RESULT,
+            .rpc_tt(
+                crate::trust_tasks::TASK_ACL_UPDATE_0_1,
+                serde_json::to_value(&body)?,
                 30,
                 |c, url| {
                     c.patch(format!("{url}/acl/{}", encode_path_segment(did)))
@@ -143,15 +166,14 @@ impl VtaClient {
         req: ChangeAclRoleRequest,
     ) -> Result<AclEntryResponse, VtaError> {
         let wrapped: AclEntryEnvelope = self
-            .rpc(
-                acl_management::CHANGE_ROLE,
+            .rpc_tt(
+                crate::trust_tasks::TASK_ACL_CHANGE_ROLE_0_1,
                 serde_json::json!({
                     "subject": did,
                     "fromRole": &req.from_role,
                     "toRole": &req.to_role,
                     "reason": &req.reason,
                 }),
-                acl_management::CHANGE_ROLE_RESULT,
                 30,
                 |c, url| {
                     c.post(format!(

--- a/vta-sdk/src/client/mod.rs
+++ b/vta-sdk/src/client/mod.rs
@@ -1242,6 +1242,21 @@ impl VtaClient {
     /// Dispatch an RPC call via REST (using `build_rest`) or DIDComm (using
     /// `msg_type`/`body`/`result_type`), returning a deserialized response.
     #[allow(unused_variables)]
+    /// The DID this client sends as, when the transport has one.
+    ///
+    /// `None` over REST: a REST client authenticates with a bearer token, and
+    /// the token's subject is the VTA's business, not something to be inferred
+    /// here. Callers that need the DID on REST take it from the operator.
+    pub fn caller_did(&self) -> Option<&str> {
+        match &self.transport {
+            Transport::Rest { .. } => None,
+            #[cfg(feature = "session")]
+            Transport::DIDComm { session, .. } => Some(session.client_did()),
+            #[cfg(feature = "tsp")]
+            Transport::Tsp { session, .. } => Some(session.client_did()),
+        }
+    }
+
     pub(crate) async fn rpc<T: serde::de::DeserializeOwned>(
         &self,
         msg_type: &str,

--- a/vta-sdk/src/client/webvh.rs
+++ b/vta-sdk/src/client/webvh.rs
@@ -72,10 +72,15 @@ impl VtaClient {
         id: &str,
         req: UpdateWebvhServerRequest,
     ) -> Result<crate::webvh::WebvhServerRecord, VtaError> {
-        self.rpc(
-            did_management::UPDATE_WEBVH_SERVER,
+        // `webvh/servers/register/1.0` is the canonical twin: #850 folded
+        // add + update into it, and a payload with no `did` is exactly the
+        // label-only patch this method performs (the maintainer refuses to
+        // create a registration from one). Same body, so the move costs
+        // nothing and buys the TSP leg, which the legacy message has no
+        // dispatcher for.
+        self.rpc_tt(
+            crate::trust_tasks::TASK_WEBVH_SERVERS_REGISTER_1_0,
             serde_json::json!({ "id": id, "label": &req.label }),
-            did_management::UPDATE_WEBVH_SERVER_RESULT,
             30,
             |c, url| {
                 c.patch(format!("{url}/webvh/servers/{}", encode_path_segment(id)))

--- a/vta-sdk/src/protocols/acl_management/swap.rs
+++ b/vta-sdk/src/protocols/acl_management/swap.rs
@@ -73,6 +73,61 @@ pub struct SwapKeyResultBody {
     pub previous_subject: String,
 }
 
+/// Read the **unverified** holder (`iss`) out of a swap presentation.
+///
+/// The canonical `acl/swap-key/0.1` request declares `newSubject` alongside the
+/// proof, and the maintainer refuses the pair when they disagree. A producer
+/// holding only the presentation therefore needs to read the DID it claims —
+/// this does that, and nothing more: no signature check, no expiry check, no
+/// audience check. The value is a *claim to be cross-checked*, never a
+/// conclusion. To conclude anything from a presentation, use
+/// [`AclSwapPresentation::verify`] (which peeks through this same function, so
+/// the two can never disagree about what the proof says).
+pub fn peek_presentation_holder(jws: &str) -> Result<String, String> {
+    use base64::Engine;
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD as B64URL;
+
+    let payload = jws
+        .split('.')
+        .nth(1)
+        .ok_or_else(|| "not a compact JWS (no payload segment)".to_string())?;
+    let bytes = B64URL
+        .decode(payload.as_bytes())
+        .map_err(|e| format!("payload b64: {e}"))?;
+    let claims: serde_json::Value =
+        serde_json::from_slice(&bytes).map_err(|e| format!("payload json: {e}"))?;
+    claims
+        .get("iss")
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+        .ok_or_else(|| "presentation has no `iss`".to_string())
+}
+
+#[cfg(test)]
+mod peek_tests {
+    /// The producer's own presentation must be readable by the producer: this
+    /// is where `newSubject` comes from, and a request that names the wrong one
+    /// is refused by the maintainer.
+    #[cfg(feature = "client")]
+    #[test]
+    fn reads_the_holder_the_builder_signed_for() {
+        use ed25519_dalek::SigningKey;
+        let sk = SigningKey::from_bytes(&[3u8; 32]);
+        let mb = crate::did_key::ed25519_multibase_pubkey(&sk.verifying_key().to_bytes());
+        let did = format!("did:key:{mb}");
+        let jws = super::build_swap_presentation(&sk, &did, "did:web:vta", 1_000, 300, None);
+        assert_eq!(super::peek_presentation_holder(&jws).unwrap(), did);
+    }
+
+    /// Garbage in is an error, never a silent empty subject — an empty
+    /// `newSubject` would be a request to move the entry nowhere.
+    #[test]
+    fn refuses_what_is_not_a_compact_jws() {
+        assert!(super::peek_presentation_holder("not-a-jws").is_err());
+        assert!(super::peek_presentation_holder("aaa.bbb.ccc").is_err());
+    }
+}
+
 /// Build the compact Ed25519 VP-JWT (`presentation` / `link_proof`) that
 /// proves control of `holder_did` for an `acl/swap-key` request.
 ///
@@ -195,7 +250,7 @@ mod verify_impl {
         /// needs it to resolve the DID document `verify` checks against. The
         /// returned DID is **unverified** until [`Self::verify`].
         pub fn peek_holder(&self) -> Result<String, AclSwapError> {
-            Ok(self.decode()?.1.iss)
+            super::peek_presentation_holder(&self.jws).map_err(AclSwapError::Parse)
         }
 
         fn decode(&self) -> Result<(JwsHeader, SwapClaims, Vec<u8>, Vec<u8>), AclSwapError> {

--- a/vta-sdk/tests/client_rest.rs
+++ b/vta-sdk/tests/client_rest.rs
@@ -672,6 +672,78 @@ async fn list_acl_sends_the_direction_only_when_it_is_not_the_default() {
         .unwrap();
 }
 
+/// Self-service key rotation is the one ACL verb whose REST route answers the
+/// maintainer's flat stored row, so the client sends the canonical Trust Task
+/// on REST too — through `/api/trust-tasks`, not `POST /acl/swap`. Parsing the
+/// legacy route's reply is what left this method failing with
+/// `missing field 'subject'` on every transport after the canonical fold.
+#[tokio::test]
+async fn swap_acl_sends_the_canonical_task_over_rest() {
+    let server = MockServer::start().await;
+    let _g = Mock::given(method("POST"))
+        .and(path("/api/trust-tasks"))
+        .and(auth_match())
+        .and(wiremock::matchers::body_partial_json(json!({
+            "type": "https://trusttasks.org/spec/acl/swap-key/0.1",
+            "payload": {
+                "currentSubject": "did:key:zOld",
+                // Read out of the presentation rather than taken on trust
+                // from the caller — the maintainer refuses the pair when the
+                // proof says something else.
+                "newSubject": "did:key:zNew",
+            },
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": "urn:uuid:0000",
+            "type": "https://trusttasks.org/spec/acl/swap-key/0.1#response",
+            "payload": {
+                "entry": acl_entry_json("did:key:zNew"),
+                "previousSubject": "did:key:zOld",
+            },
+        })))
+        .expect(1)
+        .mount_as_scoped(&server)
+        .await;
+
+    let c = client(&server).await;
+    let entry = c
+        .swap_acl_for(
+            "did:key:zOld",
+            SwapAclRequest::new(swap_presentation("did:key:zNew")),
+        )
+        .await
+        .unwrap();
+    assert_eq!(entry.did, "did:key:zNew");
+}
+
+/// A REST client has a token, not a DID, so it cannot infer which VID is being
+/// swapped out. Failing here — naming the method that takes it — beats sending
+/// a request the VTA can only refuse.
+#[tokio::test]
+async fn swap_acl_over_rest_says_which_method_takes_the_subject() {
+    let c = VtaClient::new("https://vta.example.com");
+    let err = c
+        .swap_acl(SwapAclRequest::new(swap_presentation("did:key:zNew")))
+        .await
+        .unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("swap_acl_for"), "unhelpful error: {msg}");
+}
+
+/// A compact JWS whose payload carries `iss` — the shape `swap_acl` reads
+/// `newSubject` out of. Unsigned: nothing client-side verifies it, and the
+/// maintainer checks the real signature.
+fn swap_presentation(iss: &str) -> String {
+    use base64::Engine;
+    let b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    format!(
+        "{}.{}.{}",
+        b64.encode(br#"{"alg":"EdDSA","typ":"JWT"}"#),
+        b64.encode(serde_json::to_vec(&json!({ "iss": iss })).unwrap()),
+        b64.encode([0u8; 64]),
+    )
+}
+
 #[tokio::test]
 async fn get_acl_path_encodes_did() {
     let server = MockServer::start().await;

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.13.21"
+version = "0.13.22"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/messaging/handlers.rs
+++ b/vta-service/src/messaging/handlers.rs
@@ -708,7 +708,7 @@ pub async fn handle_swap_acl(
 
 // The three ACL reads below answer the canonical bodies (`{ entry }` /
 // `{ entries }`), same as REST and the Trust Task spine. They returned the
-// maintainer's flat stored shape until #883, which no client could parse —
+// maintainer's flat stored shape until #884, which no client could parse —
 // `pnm acl get` over DIDComm failed with `missing field 'entry'` while the
 // same call over REST worked. The stored-shape operations are now private to
 // `operations::acl`, so this cannot drift back.

--- a/vta-service/src/messaging/handlers.rs
+++ b/vta-service/src/messaging/handlers.rs
@@ -706,12 +706,19 @@ pub async fn handle_swap_acl(
     response(response_type, &result)
 }
 
+// The three ACL reads below answer the canonical bodies (`{ entry }` /
+// `{ entries }`), same as REST and the Trust Task spine. They returned the
+// maintainer's flat stored shape until #883, which no client could parse —
+// `pnm acl get` over DIDComm failed with `missing field 'entry'` while the
+// same call over REST worked. The stored-shape operations are now private to
+// `operations::acl`, so this cannot drift back.
 didcomm_handler!(
     handle_get_acl,
     Gate::Manage,
     acl_management::GET_ACL_RESULT,
     acl_management::get::GetAclBody,
-    |s, auth, body| operations::acl::get_acl(&s.acl_ks, &auth, &body.subject, "didcomm").await
+    |s, auth, body| operations::acl::show_by_subject(&s.acl_ks, &auth, &body.subject, "didcomm")
+        .await
 );
 
 didcomm_handler!(
@@ -719,7 +726,7 @@ didcomm_handler!(
     Gate::Manage,
     acl_management::LIST_ACL_RESULT,
     acl_management::list::ListAclBody,
-    |s, auth, body| operations::acl::list_acl(
+    |s, auth, body| operations::acl::list_entries(
         &s.acl_ks,
         &auth,
         body.scope.as_deref(),
@@ -736,7 +743,7 @@ didcomm_handler!(
     Gate::Admin,
     acl_management::CHANGE_ROLE_RESULT,
     acl_management::change_role::ChangeRoleBody,
-    |s, auth, body| operations::acl::change_role(
+    |s, auth, body| operations::acl::change_role_by_subject(
         &s.acl_ks,
         &s.audit_ks,
         &auth,

--- a/vta-service/src/messaging/handlers.rs
+++ b/vta-service/src/messaging/handlers.rs
@@ -614,7 +614,7 @@ pub async fn handle_swap_acl(
     // No require_manage(): self-service rotation of the caller's own entry.
     let auth = app_try!(auth_from_message(&message, &state.acl_ks, &state.sessions_ks).await);
 
-    let (presentation, claimed_new_subject) = if is_canonical {
+    let (presentation, claimed_new_subject, previous_subject) = if is_canonical {
         let body: vta_sdk::protocols::acl_management::swap::SwapKeyBody =
             serde_json::from_value(message.body).map_err(handler_err)?;
         // Cross-check: the DIDComm sender (authenticated) must equal the
@@ -626,11 +626,15 @@ pub async fn handle_swap_acl(
                 body.current_subject, auth.did
             )));
         }
-        (body.link_proof, Some(body.new_subject))
+        (
+            body.link_proof,
+            Some(body.new_subject),
+            Some(body.current_subject),
+        )
     } else {
         let body: vta_sdk::protocols::acl_management::swap::SwapAclBody =
             serde_json::from_value(message.body).map_err(handler_err)?;
-        (body.presentation, None)
+        (body.presentation, None, None)
     };
 
     // Honour any operator-configured step-up floor for `acl/swap-key` on the
@@ -698,12 +702,22 @@ pub async fn handle_swap_acl(
         )));
     }
 
-    let response_type = if is_canonical {
-        acl_management::ACL_SWAP_KEY_RESPONSE
-    } else {
-        acl_management::SWAP_ACL_RESULT
-    };
-    response(response_type, &result)
+    // Canonical `acl/swap-key/0.1` answers `{ entry, previousSubject }` — the
+    // shape the Trust Task spine returns for the same URI and the published
+    // spec pins (#857). This route used to answer the flat stored row under
+    // both type URIs, so the one task had two shapes depending on which
+    // envelope carried it. The legacy `swap-acl` type keeps the flat row, which
+    // is its documented contract.
+    match previous_subject {
+        Some(previous_subject) => response(
+            acl_management::ACL_SWAP_KEY_RESPONSE,
+            &vta_sdk::protocols::acl_management::swap::SwapKeyResultBody {
+                entry: vta_sdk::protocols::acl_management::entry::AclEntry::from_result(&result),
+                previous_subject,
+            },
+        ),
+        None => response(acl_management::SWAP_ACL_RESULT, &result),
+    }
 }
 
 // The three ACL reads below answer the canonical bodies (`{ entry }` /

--- a/vta-service/src/operations/acl.rs
+++ b/vta-service/src/operations/acl.rs
@@ -308,7 +308,14 @@ pub async fn create_acl(
     Ok(to_result_body(&entry))
 }
 
-pub async fn get_acl(
+/// Read one entry in the maintainer's **stored** shape.
+///
+/// Deliberately not `pub`: [`CreateAclResultBody`] is the internal view, and a
+/// transport handler that returns it emits the pre-fold flat JSON while every
+/// other surface — and the SDK client — speaks canonical `{ entry }`. That is
+/// exactly how `acl-management/1.0/get-acl` came to answer a shape no client
+/// could parse (#883). Transports go through [`show_by_subject`].
+async fn get_acl(
     acl_ks: &KeyspaceHandle,
     auth: &AuthClaims,
     did: &str,
@@ -337,7 +344,10 @@ pub async fn get_acl(
 /// it is inert without a context, and supplying one there is an error rather
 /// than a silent no-op — a caller that asked for a subtree sweep and got the
 /// unfiltered ACL back would believe it had swept.
-pub async fn list_acl(
+///
+/// Stored shape, so not `pub` — see [`get_acl`]. Transports go through
+/// [`list_entries`].
+async fn list_acl(
     acl_ks: &KeyspaceHandle,
     auth: &AuthClaims,
     context_filter: Option<&str>,
@@ -384,7 +394,9 @@ pub async fn list_acl(
     Ok(entries)
 }
 
-pub async fn update_acl(
+/// Stored shape, so not `pub` — see [`get_acl`]. Transports go through
+/// [`update_from_params`].
+async fn update_acl(
     acl_ks: &KeyspaceHandle,
     audit_ks: &KeyspaceHandle,
     contexts_ks: &KeyspaceHandle,
@@ -547,8 +559,11 @@ pub async fn update_acl(
 ///   *nowhere* while its role is non-admin, but flipping that same entry to
 ///   `admin` makes it **unrestricted** — a super-admin. Only a caller who is
 ///   already unrestricted may do that.
+///
+/// Stored shape, so not `pub` — see [`get_acl`]. Transports go through
+/// [`change_role_by_subject`].
 #[allow(clippy::too_many_arguments)]
-pub async fn change_role(
+async fn change_role(
     acl_ks: &KeyspaceHandle,
     audit_ks: &KeyspaceHandle,
     auth: &AuthClaims,
@@ -877,6 +892,32 @@ pub async fn list_entries(
         truncated: false,
         cursor: None,
         redacted_fields: Vec::new(),
+    })
+}
+
+/// `acl/change-role/0.1` → [`change_role`].
+///
+/// Every transport reads the transition through this wrapper so the realized
+/// entry comes back under `entry`, like grant/show/update. REST and the Trust
+/// Task spine each used to wrap the stored body themselves, which left the
+/// DIDComm handler free to return it unwrapped — and it did (#883).
+#[allow(clippy::too_many_arguments)]
+pub async fn change_role_by_subject(
+    acl_ks: &KeyspaceHandle,
+    audit_ks: &KeyspaceHandle,
+    auth: &AuthClaims,
+    subject: &str,
+    from_role: &str,
+    to_role: &str,
+    reason: Option<&str>,
+    channel: &str,
+) -> Result<CreateAclResponseBody, AppError> {
+    let stored = change_role(
+        acl_ks, audit_ks, auth, subject, from_role, to_role, reason, channel,
+    )
+    .await?;
+    Ok(CreateAclResponseBody {
+        entry: WireAclEntry::from_result(&stored),
     })
 }
 

--- a/vta-service/src/operations/acl.rs
+++ b/vta-service/src/operations/acl.rs
@@ -314,7 +314,7 @@ pub async fn create_acl(
 /// transport handler that returns it emits the pre-fold flat JSON while every
 /// other surface — and the SDK client — speaks canonical `{ entry }`. That is
 /// exactly how `acl-management/1.0/get-acl` came to answer a shape no client
-/// could parse (#883). Transports go through [`show_by_subject`].
+/// could parse (#884). Transports go through [`show_by_subject`].
 async fn get_acl(
     acl_ks: &KeyspaceHandle,
     auth: &AuthClaims,
@@ -900,7 +900,7 @@ pub async fn list_entries(
 /// Every transport reads the transition through this wrapper so the realized
 /// entry comes back under `entry`, like grant/show/update. REST and the Trust
 /// Task spine each used to wrap the stored body themselves, which left the
-/// DIDComm handler free to return it unwrapped — and it did (#883).
+/// DIDComm handler free to return it unwrapped — and it did (#884).
 #[allow(clippy::too_many_arguments)]
 pub async fn change_role_by_subject(
     acl_ks: &KeyspaceHandle,

--- a/vta-service/src/routes/acl.rs
+++ b/vta-service/src/routes/acl.rs
@@ -276,7 +276,7 @@ pub async fn change_role(
     Path(did): Path<String>,
     Json(req): Json<ChangeRoleRequest>,
 ) -> Result<Json<CreateAclResponseBody>, AppError> {
-    let stored = operations::acl::change_role(
+    let result = operations::acl::change_role_by_subject(
         &state.acl_ks,
         &state.audit_ks,
         &auth.0,
@@ -287,9 +287,7 @@ pub async fn change_role(
         "rest",
     )
     .await?;
-    Ok(Json(CreateAclResponseBody {
-        entry: vta_sdk::protocols::acl_management::entry::AclEntry::from_result(&stored),
-    }))
+    Ok(Json(result))
 }
 
 /// DELETE /acl/{did} — remove an ACL entry. Auth: Admin or Initiator.

--- a/vta-service/src/trust_tasks/acl.rs
+++ b/vta-service/src/trust_tasks/acl.rs
@@ -171,7 +171,7 @@ pub(super) async fn handle_change_role(
         Ok(r) => r,
         Err(resp) => return resp,
     };
-    match operations::acl::change_role(
+    match operations::acl::change_role_by_subject(
         &state.acl_ks,
         &state.audit_ks,
         auth,
@@ -185,12 +185,7 @@ pub(super) async fn handle_change_role(
     {
         // Canonical `acl/change-role/0.1` responds with the realized entry
         // under `entry`, like the rest of the family (#857).
-        Ok(body) => success_response(
-            &doc,
-            vta_sdk::protocols::acl_management::create::CreateAclResponseBody {
-                entry: vta_sdk::protocols::acl_management::entry::AclEntry::from_result(&body),
-            },
-        ),
+        Ok(body) => success_response(&doc, body),
         Err(e) => app_error_to_reject(&doc, e),
     }
 }

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.11.48"
+version = "0.11.49"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vtc-service/admin-ui/package-lock.json
+++ b/vtc-service/admin-ui/package-lock.json
@@ -29,21 +29,21 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "version": "2.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-2.0.0-alpha.3.tgz",
+      "integrity": "sha512-AZypUeJ/yByuxyS7BlSNRDOMLMlROYtjYdIAuBmJssVz1UJDSeYxLrdizhXCFYhedC5bqd/ASy8EuNXbVVXp9g==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
+        "@emnapi/wasi-threads": "2.0.1",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "version": "2.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-2.0.0-alpha.3.tgz",
+      "integrity": "sha512-hFPAhMUjJD9BSyCANEISPOogeXC9Zo9ZQl7L6vKnaVsMkCtzznaW/naYypeyl0Gv5rYfWYsZbpixTMpjDJzQeA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -52,9 +52,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-2.0.1.tgz",
+      "integrity": "sha512-9DsSk+o5NBX0CCJT8s0EROGSGxjR/tKu6aBTaVyq+SjAEQH4XcdcRxPBRzsBLizTTJ49MJjF+jgu3qnO9GLQcQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -63,55 +63,58 @@
       }
     },
     "node_modules/@fontsource-variable/fraunces": {
-      "version": "5.2.9",
-      "resolved": "https://registry.npmjs.org/@fontsource-variable/fraunces/-/fraunces-5.2.9.tgz",
-      "integrity": "sha512-Y6IjunlN9Ni723np+GIgAaKzCDBrPRrqNi01TZxHs5wtHYROWFM9W6yiT+/gGwSjWIRD18oX17kD/BRWekc/Lw==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/fraunces/-/fraunces-5.3.0.tgz",
+      "integrity": "sha512-9BYGySn4AHEJdgp9Z28tQ3X+laJMEOITXkQarZXeloWQZDq5oOvXJ3kDA8c7MGIfpogIaZfjrQBqmda8POOCKA==",
       "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@fontsource/ibm-plex-mono": {
-      "version": "5.2.7",
-      "resolved": "https://registry.npmjs.org/@fontsource/ibm-plex-mono/-/ibm-plex-mono-5.2.7.tgz",
-      "integrity": "sha512-MKAb8qV+CaiMQn2B0dIi1OV3565NYzp3WN5b4oT6LTkk+F0jR6j0ZN+5BKJiIhffDC3rtBULsYZE65+0018z9w==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource/ibm-plex-mono/-/ibm-plex-mono-5.3.0.tgz",
+      "integrity": "sha512-eTgnZjZEGk1QtD3ZstF+Vclo2HLAni8YMy34/DxllwZvyz1lR/1RF/xTiAquOBO7MvqBx8D2Ig2WCPMVfdZu7Q==",
       "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@fontsource/ibm-plex-sans": {
-      "version": "5.2.8",
-      "resolved": "https://registry.npmjs.org/@fontsource/ibm-plex-sans/-/ibm-plex-sans-5.2.8.tgz",
-      "integrity": "sha512-eztSXjDhPhcpxNIiGTgMebdLP9qS4rWkysuE1V7c+DjOR0qiezaiDaTwQE7bTnG5HxAY/8M43XKDvs3cYq6ZYQ==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource/ibm-plex-sans/-/ibm-plex-sans-5.3.0.tgz",
+      "integrity": "sha512-CbE4CbbEEZJX860XyUiRpsksXIQR8Rp2XDva2VO53NJox9tVNtusrysd2x5YkUEY3ErQ66W1IiiQL8/wihhw5w==",
       "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
-      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.2.tgz",
+      "integrity": "sha512-JfB4kuJQjaoHuCTseIINHtHWeJnvgEcxjwA5t/Y00ZgaOO1Crz3fjT/p8kT28zA/Caz7oiUMn3d6H2yOVCVwuw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@tybys/wasm-util": "^0.10.2"
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Brooooooklyn"
       },
       "peerDependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1"
+        "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.3",
+        "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.3"
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
-      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
+      "version": "0.142.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.142.0.tgz",
+      "integrity": "sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -119,9 +122,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
-      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.1.tgz",
+      "integrity": "sha512-02hOeOSryYxVrOIphmLAsqnCJWxwlzFk+pEt/N/i6OgT3lShHO7xGCU5cpgchRDHboAEbSjzgGh+O/u1GswQmA==",
       "cpu": [
         "arm64"
       ],
@@ -136,9 +139,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
-      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.1.tgz",
+      "integrity": "sha512-fMsTOnN0OjFm3CyppWPitKnc8UlliVARUULW6cfU6AIqjdtgmSFWSk9vecHzZduv/yMWIHDlRhM1e8Iff9uAfA==",
       "cpu": [
         "arm64"
       ],
@@ -153,9 +156,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
-      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.1.tgz",
+      "integrity": "sha512-1wjKdz/XLGKHaTNHjQveQ/B23TKx4ItAqm1JbyVuvNPc4Ze0Fb48s49TAd/2zcplPl8okE/UbTgmlVfwT7eFeQ==",
       "cpu": [
         "x64"
       ],
@@ -170,9 +173,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
-      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.1.tgz",
+      "integrity": "sha512-Fa0jHR07E7YBN4vOEsbVf2briYNsuOowfLJaXULZM0ldMlaCaj2LJgLMbMe4iacRyZmvR8efFhgR9wKuGclQUg==",
       "cpu": [
         "x64"
       ],
@@ -187,9 +190,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
-      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.1.tgz",
+      "integrity": "sha512-pzkgu1SSHGgRRyRZ4fbmSgmajbVt+epaLP99NDjFft69v/ypfTi6swBMiVdh2EkQ0OSnHE1lZDM7DRGkyAzUpA==",
       "cpu": [
         "arm"
       ],
@@ -204,9 +207,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
-      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.1.tgz",
+      "integrity": "sha512-QI5SEDY8cbiYWHx0VO4vIc3UlS6a32vXHjU8Qy/17adEmZIPuByJg13UEvo9c/UCiUkdcVWY83C+b+JrwnNyUg==",
       "cpu": [
         "arm64"
       ],
@@ -224,9 +227,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
-      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.1.tgz",
+      "integrity": "sha512-Sm41FyCeXqmYcERoYOCbGIL5hNfd8w9LQ7Y61Bev48HkcjaJqV/iiVOaiDxjVTRMS+QKrZmD8cfPt4uMVnvM+A==",
       "cpu": [
         "arm64"
       ],
@@ -244,9 +247,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
-      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.1.tgz",
+      "integrity": "sha512-2x+WhXTGl9yJYPbltW/BSEPTVz9OIWQyER4N+gJEDWkkn904eRcBzELqh/Hf7K0w/ubGbKNMv0ZC+94QK/IFEg==",
       "cpu": [
         "ppc64"
       ],
@@ -264,9 +267,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
-      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.1.tgz",
+      "integrity": "sha512-eEjmQpuRQayHPWWnywaWHkFT3ToPbP3RYy42VVd/B9aBGDA+Ol25EIWHxKQST3IiWJjikCWUF7KtbfqwZrzVwQ==",
       "cpu": [
         "s390x"
       ],
@@ -284,9 +287,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
-      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.1.tgz",
+      "integrity": "sha512-/Orga1fZYkLc/56jBICcHrKchl8Z2UKdDSr3LG9ToWO1lQ6a4Livk9Xz+9WN91zsz5QR3XQz2NNoSDEvP6qadw==",
       "cpu": [
         "x64"
       ],
@@ -304,9 +307,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
-      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.1.tgz",
+      "integrity": "sha512-xxBJRL+0q0Kce7orznGWLuylHDY65vuARXZRpX+hPdv+DqK2c3NlCsVA98tlWzWNEE7yPqA/1NQ5nnCrj49Y5A==",
       "cpu": [
         "x64"
       ],
@@ -324,9 +327,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
-      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.1.tgz",
+      "integrity": "sha512-M6AdXIXw3s+/8XpKMzdGDEXGS1S7kwUsy+rcTIUIOx5Ge4nXKCtAFHFV9YKkXvGcC5WMoTjAteLzlsQROVI0Yw==",
       "cpu": [
         "arm64"
       ],
@@ -341,28 +344,25 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
-      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
-      "cpu": [
-        "wasm32"
-      ],
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.2.1.tgz",
+      "integrity": "sha512-/TX0SoRGojHzSAHpfVBbavRVSazg5U3h3Y3VXfcc0cdugq6kxdqw8LPGFiPr+/7gE/60zRcsOY2Vi9b9eT0jww==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "1.10.0",
-        "@emnapi/runtime": "1.10.0",
-        "@napi-rs/wasm-runtime": "^1.1.4"
+        "@emnapi/core": "2.0.0-alpha.3",
+        "@emnapi/runtime": "2.0.0-alpha.3",
+        "@napi-rs/wasm-runtime": "^1.2.0"
       },
       "engines": {
-        "node": "^20.19.0 || >=22.12.0"
+        "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
-      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.1.tgz",
+      "integrity": "sha512-EvRrivJieyHG+AO9lleZWgq+g0+S7oV2C51yuqlcyU/R9net+sI4Pj0F+lUoP2bEr6TWX3SqFaaS0SzfLxSzkw==",
       "cpu": [
         "arm64"
       ],
@@ -377,9 +377,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
-      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.1.tgz",
+      "integrity": "sha512-Z4eCmn5QJ/5+azF9knpLWKfVd9aidn0mAe9TpJgvBLId9Ax3t0+JVxBmT25Bv7NBbVW1TZyKjQjQReouMeH5UQ==",
       "cpu": [
         "x64"
       ],
@@ -401,9 +401,9 @@
       "license": "MIT"
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.101.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.0.tgz",
-      "integrity": "sha512-cQetA74EB+seWySv1TTKr828TnP0u39m6LykwDXIo84SNortpDkp30TMEjkqtYCNP9c40uT/iwl6MLiufEt0Ow==",
+      "version": "5.101.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.4.tgz",
+      "integrity": "sha512-gNwcvOJcRbLWPOLG/2OBm+zM+Yv+MKsXKEOWC57USuZDEsI71hEErQsiEGx5wX9rzWWkfwM0fVSPoiIFSsxfiw==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -411,12 +411,12 @@
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "5.101.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.101.0.tgz",
-      "integrity": "sha512-rLlJXSpkqfizLWgkR5+eLeIk0MvTx/meEIR7LRjxic+qxiQP8zVjq7BqQkiCMNLQBlLfuOLqqr6KO5GtrDlmSg==",
+      "version": "5.101.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.101.4.tgz",
+      "integrity": "sha512-yRg2pfOCxIs4ZJW3XYYHU/WgtD04FHSnfHlpRT7h7pR77hwkdRG4wxbKe4aq6P0RvXUTBSQpQeadS1SUYUe+KA==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/query-core": "5.101.0"
+        "@tanstack/query-core": "5.101.4"
       },
       "funding": {
         "type": "github",
@@ -427,9 +427,9 @@
       }
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
-      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -438,13 +438,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "25.9.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
-      "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
+      "version": "26.1.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": ">=7.24.0 <7.24.7"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/@types/qrcode": {
@@ -458,9 +458,9 @@
       }
     },
     "node_modules/@types/react": {
-      "version": "19.2.17",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
-      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "version": "19.2.18",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
+      "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -468,9 +468,9 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
-      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -478,13 +478,13 @@
       }
     },
     "node_modules/@vitejs/plugin-react": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.2.tgz",
-      "integrity": "sha512-DlSMqo4WhThw4vB8Mpn0Woe9J+Jfq1geJ61AKW0QEgLzGMNwtIMdxbDUzLxcun8W7NbJO0e2Jg/Nxm3cCSVzzg==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.5.tgz",
+      "integrity": "sha512-BOVzne/NL162sMdResB25mUv+vWMF5NoAjNf09TeGlE7ZpszZWSD3winycicLJw72yeVsoCn/2kOhEuCvEShMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@rolldown/pluginutils": "^1.0.0"
+        "@rolldown/pluginutils": "^1.0.1"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
@@ -681,9 +681,9 @@
       }
     },
     "node_modules/lightningcss": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
-      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
@@ -697,23 +697,23 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "lightningcss-android-arm64": "1.32.0",
-        "lightningcss-darwin-arm64": "1.32.0",
-        "lightningcss-darwin-x64": "1.32.0",
-        "lightningcss-freebsd-x64": "1.32.0",
-        "lightningcss-linux-arm-gnueabihf": "1.32.0",
-        "lightningcss-linux-arm64-gnu": "1.32.0",
-        "lightningcss-linux-arm64-musl": "1.32.0",
-        "lightningcss-linux-x64-gnu": "1.32.0",
-        "lightningcss-linux-x64-musl": "1.32.0",
-        "lightningcss-win32-arm64-msvc": "1.32.0",
-        "lightningcss-win32-x64-msvc": "1.32.0"
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
       }
     },
     "node_modules/lightningcss-android-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
-      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
       "cpu": [
         "arm64"
       ],
@@ -732,9 +732,9 @@
       }
     },
     "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
-      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
       "cpu": [
         "arm64"
       ],
@@ -753,9 +753,9 @@
       }
     },
     "node_modules/lightningcss-darwin-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
-      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
       "cpu": [
         "x64"
       ],
@@ -774,9 +774,9 @@
       }
     },
     "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
-      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
       "cpu": [
         "x64"
       ],
@@ -795,9 +795,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
-      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
       "cpu": [
         "arm"
       ],
@@ -816,9 +816,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
-      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
       "cpu": [
         "arm64"
       ],
@@ -840,9 +840,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
-      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
       "cpu": [
         "arm64"
       ],
@@ -864,9 +864,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
-      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
       "cpu": [
         "x64"
       ],
@@ -888,9 +888,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
-      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
       "cpu": [
         "x64"
       ],
@@ -912,9 +912,9 @@
       }
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
-      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
       "cpu": [
         "arm64"
       ],
@@ -933,9 +933,9 @@
       }
     },
     "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
-      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
       "cpu": [
         "x64"
       ],
@@ -975,9 +975,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -1046,9 +1046,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1068,9 +1068,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -1088,7 +1088,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -1114,30 +1114,30 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
-      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
-      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.7"
+        "react": "^19.2.8"
       }
     },
     "node_modules/react-router": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.17.0.tgz",
-      "integrity": "sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
+      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -1157,12 +1157,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.17.0.tgz",
-      "integrity": "sha512-fyU2yjGups/hE6Xz0I5ZYbVL8Gx29eCjgpHaRaTaVU+OOAdfRX05KsvyRm0GO8YQwOkhpU3MurW1jyMUJn+zSw==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.2.tgz",
+      "integrity": "sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.17.0"
+        "react-router": "7.18.2"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -1188,13 +1188,13 @@
       "license": "ISC"
     },
     "node_modules/rolldown": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
-      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.1.tgz",
+      "integrity": "sha512-4FKJhg8d3OiyQOA6Q1Q0hoFFpW9/OoX+VsHzpECsdsIZoOArrAK90gl59YK/Z+gnDel45bgJZK03ozH/9bCqEw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.133.0",
+        "@oxc-project/types": "=0.142.0",
         "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
@@ -1204,21 +1204,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.3",
-        "@rolldown/binding-darwin-arm64": "1.0.3",
-        "@rolldown/binding-darwin-x64": "1.0.3",
-        "@rolldown/binding-freebsd-x64": "1.0.3",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
-        "@rolldown/binding-linux-arm64-musl": "1.0.3",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
-        "@rolldown/binding-linux-x64-gnu": "1.0.3",
-        "@rolldown/binding-linux-x64-musl": "1.0.3",
-        "@rolldown/binding-openharmony-arm64": "1.0.3",
-        "@rolldown/binding-wasm32-wasi": "1.0.3",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
-        "@rolldown/binding-win32-x64-msvc": "1.0.3"
+        "@rolldown/binding-android-arm64": "1.2.1",
+        "@rolldown/binding-darwin-arm64": "1.2.1",
+        "@rolldown/binding-darwin-x64": "1.2.1",
+        "@rolldown/binding-freebsd-x64": "1.2.1",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.1",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.1",
+        "@rolldown/binding-linux-arm64-musl": "1.2.1",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.1",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.1",
+        "@rolldown/binding-linux-x64-gnu": "1.2.1",
+        "@rolldown/binding-linux-x64-musl": "1.2.1",
+        "@rolldown/binding-openharmony-arm64": "1.2.1",
+        "@rolldown/binding-wasm32-wasi": "1.2.1",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.1",
+        "@rolldown/binding-win32-x64-msvc": "1.2.1"
       }
     },
     "node_modules/scheduler": {
@@ -1315,23 +1315,23 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
-      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "8.0.16",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
-      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.0.tgz",
+      "integrity": "sha512-pn+CFpM0lwDeKwmOq1ZaBK/9sjorZcgqxki6MbY/jPEVd9vichIlmlD4HmQ5wdP5EgqQCFRaACBxMC7uEGc6lQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "lightningcss": "^1.32.0",
-        "picomatch": "^4.0.4",
-        "postcss": "^8.5.15",
-        "rolldown": "1.0.3",
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.23",
+        "rolldown": "~1.2.0",
         "tinyglobby": "^0.2.17"
       },
       "bin": {
@@ -1348,7 +1348,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.18",
+        "@vitejs/devtools": "^0.4.0",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",


### PR DESCRIPTION
`pnm acl get <did>` against a DIDComm-connected VTA fails with

```
✗ Error: serialization error: missing field `entry`
```

while the VTA logs the read as `ACL entry retrieved … status="ok(response)"`.
Both are right: the maintainer answered, and the client cannot read the answer.

## Root cause

Folding the ACL surface onto canonical `acl/*` (#842, #855) moved the REST
routes and the Trust Task spine onto the canonical bodies — `{ entry }`,
`{ entries, truncated, … }` over the shared camelCase `AclEntry` — and moved the
SDK client with them. The legacy `acl-management/1.0/*` DIDComm handlers were
folded only partway: `create`, `update` and `revoke` moved, while `get-acl`,
`list-acl` and `change-role` kept calling the maintainer's **stored** shape
(`CreateAclResultBody`: flat, snake_case, `did`/`allowed_contexts`).

The SDK deserializes both transports with the same type, so the same call worked
over REST and failed over DIDComm. Nothing caught it — each side of that wire is
tested against its own hand-written fixture, which is the gap
`vta-service/tests/client_round_trip.rs` was written for, on the one transport it
does not cover.

| call | failure over DIDComm |
|---|---|
| `acl get` | response `missing field 'entry'` |
| `acl list` | request rejected (`ListAclBody` is `deny_unknown_fields` and the client sent the pre-fold `context`), response a bare array |
| `acl change-role` | response `missing field 'entry'` |
| `acl swap` | broken on **every** transport — see below |

## The ACL slice now speaks Trust Tasks

`acl/show/0.1`, `acl/list/0.1`, `acl/update/0.1`, `acl/change-role/0.1` join the
`grant` and `revoke` that #861 had already moved. Each call's REST leg is
byte-identical to before; only the DIDComm leg changes shape, and TSP — which
carries the Trust-Task surface and nothing else — reaches these calls for the
first time.

**`update_acl` gained back what the legacy leg dropped.** It hand-built three
members of its DIDComm body (`subject`, `label`, `scopes`), so an operator
narrowing a step-up approver, an approve scope, an expiry or an `allowedKeys`
filter over DIDComm silently changed none of them and got a healthy-looking entry
back. The task payload is now the full canonical `UpdateAclBody`.

**It cannot drift back.** `operations::acl::{get_acl, list_acl, update_acl,
change_role}` are private to their module; transports reach them only through
`show_by_subject` / `list_entries` / `update_from_params` / the new
`change_role_by_subject`, which replaces the identical hand-wrapping REST and the
Trust Task spine each did. A handler returning the internal shape no longer
compiles.

## `swap_acl` works again

Same fold, broken everywhere at once: the client parsed the canonical entry while
REST `/acl/swap` and legacy DIDComm answered the flat stored row and the spine
answered `{ entry, previousSubject }`. Three shapes, one parser, so there is no
working caller to break.

It now sends canonical `acl/swap-key/0.1` on all three transports — over REST
through the trust-task endpoint, leaving the legacy route mounted and unchanged
for the non-Rust consumers that read it. `newSubject` comes from the
presentation's own `iss` (new `swap::peek_presentation_holder`, which
`AclSwapPresentation::peek_holder` now delegates to, so producer and verifier
cannot disagree about what a proof says); `currentSubject` from the DID the
client sends as (new `VtaClient::caller_did`). Both are declarations the
maintainer cross-checks against the proof and the authenticated caller.

A REST client has a token, not a DID, so `swap_acl` there fails before the
request leaves the process, naming the additive `swap_acl_for(current_subject,
req)`. Server-side, the bare-DIDComm `acl/swap-key/0.1` route answered the flat
row too — one canonical URI with two shapes depending on the envelope — and now
answers like the spine.

## Sweep of the remaining legacy `rpc` surfaces

`rpc`'s TSP arm is an `UnsupportedTransport` error, so **every method still on it
is unavailable over TSP**. Audited, not assumed:

| method | DIDComm shape | disposition |
|---|---|---|
| `swap_acl` | broken | → canonical task, all transports |
| `update_webvh_server` | agrees | → `webvh/servers/register/1.0`, whose payload is byte-identical to what it already sent (#850 folded add + update into it) |
| `update_did_webvh`, `rotate_did_webvh_keys` | agree | left: canonical twins key on `did`, these take `(context_id, scid)` — a signature change plus a CLI lookup, not a transport swap |
| `import_key`, `backup_export`, `backup_import`, `list_webvh_server_domains` | agree | left: no canonical twin exists, and minting task URIs is spec work (VTI #856/#857) |

The four left behind work over REST and DIDComm and are dead over TSP.

## Upgrade path

The DIDComm handlers keep answering the legacy type URIs with the canonical
bodies, so an **already-installed `pnm` gets working `acl get` and
`acl change-role` from a VTA upgrade alone**. `acl list` needs the rebuilt
client, since its old request never reaches a handler.

## Testing

- `tests/e2e/tests/client_didcomm.rs` pins every moved call as a Trust Task —
  including the members `update` used to drop, the canonical `scope` filter name,
  a `swap_acl` whose `currentSubject` is the session's own DID and whose
  `newSubject` is read out of an SDK-built presentation, and the label-only
  server patch that must not claim a `did`. Adds the `get_acl` case the file
  never had.
- `vta-sdk/tests/client_rest.rs` pins swap's REST leg on `/api/trust-tasks` and
  the error that names `swap_acl_for`; `swap.rs` unit-tests the `iss` peek
  against the SDK's own builder.
- `cargo test -p vta-sdk -p vta-service` (37 suites), `cargo test -p
  vti-e2e-tests --test client_didcomm` (45), `cargo check --workspace
  --all-targets`, clippy and fmt clean.


## Dependency refresh (separate commit — droppable)

`cargo update` (69 crates) and `npm update` in `vtc-service/admin-ui`, both
within the existing requirement ranges: no `Cargo.toml`, no `package.json`, the
two lockfiles are the whole diff. `vtc-service` is version-bumped because the
admin UI is embedded in its binary, so an npm-only move still changes what the
crate publishes.

Two open advisories close as a side effect:

- `rustls-webpki` 0.103.13 — **high** (`< 0.103.13`);
- `postcss` 8.5.23 and `react-router` 7.18.2 — one high, three medium.

`rustls-webpki` 0.101.7 survives and still matches the low advisory: it arrives
through the AWS SDK's legacy `rustls` 0.21, so no lockfile move reaches it —
that one needs an `aws-config` feature change.

Twenty direct dependencies remain a major behind and are deliberately left: the
crypto core (`ed25519-dalek` 3, `curve25519-dalek` 5, `x25519-dalek` 3, `hpke`
0.14, `aes-gcm` 0.11, `p256` 0.14, `jsonwebtoken` 11) plus `kube` 4, `rmcp` 3,
`uniffi` 0.32 and the `azure_*` 1.0 line. Each is an API migration through
sealed-transfer, DI proofs, auth or a whole secrets backend — its own change,
its own review, not a ride-along on a lockfile refresh. Tracked as follow-ups.

Full workspace suite on the new lockfile: **4120 passed, 0 failed, 49 ignored**.
The admin UI builds clean.
