### PR TITLE
feat(webvh): the webvh DID mutations reach TSP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10113,7 +10113,7 @@ dependencies = [
 
 [[package]]
 name = "vta-cli-common"
-version = "0.10.21"
+version = "0.10.22"
 dependencies = [
  "aes-gcm",
  "affinidi-crypto",
@@ -10266,7 +10266,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.20.31"
+version = "0.20.32"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",

--- a/changelog.d/885-webvh-dids-trust-tasks.md
+++ b/changelog.d/885-webvh-dids-trust-tasks.md
@@ -1,0 +1,41 @@
+### vta-sdk 0.20.32 / vta-cli-common 0.10.22 — the webvh DID mutations reach TSP (#885)
+
+`VtaClient::rpc`'s TSP arm is an `UnsupportedTransport` error, so a client method
+still on the legacy DIDComm protocol message does not merely risk wire drift — it
+**does not exist over TSP**. #884 moved the ACL slice; this moves the two webvh
+DID mutations, which were the largest remaining pair.
+
+`update_did_webvh_by_did` and `rotate_did_webvh_keys_by_did` send canonical
+`webvh/dids/{update,rotate-keys}/1.0` on every transport, REST included (through
+the trust-task endpoint, leaving the dedicated routes mounted for other
+consumers). The maintainer has served both tasks all along — only the client
+never used them.
+
+**Why they were stranded:** the canonical tasks key on the **DID**, while the
+methods took `(context_id, scid)`. That is not a transport swap, so #861 left
+them behind. Callers already hold the DID — `pnm did-mgmt dids update` was
+fetching the DID record purely to translate it into the pair the method wanted,
+and now keeps that call only for the clean 404 it also provides.
+
+Both bodies flatten *beside* `did` rather than nesting under it, because the
+maintainer reads them back with `serde(flatten)`. A nested body would
+deserialize into an update that changes nothing — published, version-bumped and
+silently empty — so `flatten_with_did` refuses a body that is not a JSON object
+or that already carries a `did`.
+
+The `(context_id, scid)` methods are **deprecated, not removed**: they still work
+over REST and DIDComm, and deleting them would be a breaking change to a
+published crate for no gain. They have no TSP path and will not get one.
+
+## Still not on TSP, and why
+
+| method | blocker |
+|---|---|
+| `import_key`, `list_webvh_server_domains` | No published spec. The dispatcher's own guard (`every_served_uri_has_a_published_spec_or_is_tracked_debt`) refuses a newly-served URI the registry cannot resolve, and says so: author it upstream in `trustoverip/dtgwg-trust-tasks-tf` and bump `trust-tasks-rs` — growing the allowlist is the wrong fix. So these need an upstream spec PR first, not a binding here. |
+| `backup_export`, `backup_import` | Tasks already bound (`backup/{initiate,complete}-export`, `backup/{initiate,finalize}-import`) — but the **bytes** ride an HTTPS blob URL carried in the descriptor, deliberately, so a multi-megabyte envelope never enters a message envelope. A TSP-only client still needs an HTTP leg until the descriptor's already-declared `chunked-trust-task` algorithm exists. That is a design change, not a rewiring. |
+
+**Testing.** `tests/e2e/tests/client_didcomm.rs` pins both new calls as Trust
+Tasks — including that the body's members arrive un-nested, the assertion that
+would fail if `flatten` were dropped. `vta-sdk/tests/client_rest.rs` pins the
+REST leg on `/api/trust-tasks`; the two legacy-route tests remain, under
+`#[allow(deprecated)]`, so the deprecated path stays covered until it is removed.

--- a/tests/e2e/tests/client_didcomm.rs
+++ b/tests/e2e/tests/client_didcomm.rs
@@ -733,6 +733,89 @@ async fn swap_acl_via_didcomm_infers_the_sending_did() {
     shutdown_all(client, responder, mediator).await;
 }
 
+// ── WebVH DIDs ──────────────────────────────────────────────────────
+
+/// `webvh/dids/update/1.0` keys on the DID, which is why the `(context_id,
+/// scid)` method could never move off the legacy protocol message — and why
+/// that call had no TSP path at all. The body's members ride *beside* `did`:
+/// the maintainer reads them back with `serde(flatten)`, so a nested body
+/// deserializes into an update that changes nothing.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn update_did_webvh_by_did_via_didcomm() {
+    let (mediator, responder, client) = build_didcomm(|msg_type, body| {
+        if is_tt(msg_type, body, trust_tasks::TASK_WEBVH_DIDS_UPDATE_1_0) {
+            let p = &body["payload"];
+            assert_eq!(p["did"], "did:webvh:Qabc:host:slug", "{body}");
+            assert_eq!(p["document"]["id"], "did:webvh:Qabc:host:slug", "{body}");
+            assert_eq!(p["ttl"], 3600, "body members must not nest: {body}");
+            tt_ok(
+                trust_tasks::TASK_WEBVH_DIDS_UPDATE_1_0,
+                json!({
+                    "did": "did:webvh:Qabc:host:slug",
+                    "newVersionId": "2-z",
+                    "newScid": "Qabc",
+                    "newLogEntry": "{}",
+                    "updateKeysCount": 1,
+                    "preRotationKeyCount": 0,
+                }),
+            )
+        } else {
+            no_handler()
+        }
+    })
+    .await;
+
+    let body = vta_sdk::protocols::did_management::update::UpdateDidWebvhBody {
+        document: Some(json!({"id": "did:webvh:Qabc:host:slug"})),
+        ttl: Some(3600),
+        ..Default::default()
+    };
+    let r = client
+        .update_did_webvh_by_did("did:webvh:Qabc:host:slug", body)
+        .await
+        .unwrap();
+    assert_eq!(r.new_version_id, "2-z");
+
+    shutdown_all(client, responder, mediator).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn rotate_did_webvh_keys_by_did_via_didcomm() {
+    let (mediator, responder, client) = build_didcomm(|msg_type, body| {
+        if is_tt(msg_type, body, trust_tasks::TASK_WEBVH_DIDS_ROTATE_KEYS_1_0) {
+            let p = &body["payload"];
+            assert_eq!(p["did"], "did:webvh:Qabc:host:slug", "{body}");
+            assert_eq!(p["preRotationCount"], 2, "{body}");
+            tt_ok(
+                trust_tasks::TASK_WEBVH_DIDS_ROTATE_KEYS_1_0,
+                json!({
+                    "did": "did:webvh:Qabc:host:slug",
+                    "newVersionId": "3-z",
+                    "newScid": "Qabc",
+                    "newLogEntry": "{}",
+                    "updateKeysCount": 1,
+                    "preRotationKeyCount": 2,
+                }),
+            )
+        } else {
+            no_handler()
+        }
+    })
+    .await;
+
+    let body = vta_sdk::protocols::did_management::update::RotateDidWebvhKeysBody {
+        pre_rotation_count: Some(2),
+        ..Default::default()
+    };
+    let r = client
+        .rotate_did_webvh_keys_by_did("did:webvh:Qabc:host:slug", body)
+        .await
+        .unwrap();
+    assert_eq!(r.pre_rotation_key_count, 2);
+
+    shutdown_all(client, responder, mediator).await;
+}
+
 // ── WebVH servers ───────────────────────────────────────────────────
 
 /// Relabelling a registered server rides `webvh/servers/register/1.0` — the

--- a/vta-cli-common/Cargo.toml
+++ b/vta-cli-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-cli-common"
 description = "Shared CLI command handlers and rendering helpers for VTA CLIs"
 readme = "README.md"
-version = "0.10.21"
+version = "0.10.22"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-cli-common/src/commands/webvh.rs
+++ b/vta-cli-common/src/commands/webvh.rs
@@ -198,11 +198,11 @@ pub async fn cmd_webvh_did_edit(
         launch_editor, prompt_webvh_params,
     };
 
-    // Fetch the DID record (for context_id + scid) — this also
-    // surfaces a clean 404 if the DID isn't registered.
-    let record = client.get_did_webvh(did).await?;
-    let context_id = record.context_id.clone();
-    let scid = record.scid.clone();
+    // Confirm the DID is registered here before opening an editor on it — a
+    // clean 404 now beats a failed publish after the operator has typed a
+    // document. The record's `context_id`/`scid` are no longer needed: the
+    // canonical update task keys on the DID we already have.
+    let _ = client.get_did_webvh(did).await?;
 
     // Decide between interactive and non-interactive paths. The
     // non-interactive heuristic: any flag set → skip the editor
@@ -276,7 +276,7 @@ pub async fn cmd_webvh_did_edit(
 
     confirm_publish(&body, no_confirm)?;
 
-    let result = client.update_did_webvh(&context_id, &scid, body).await?;
+    let result = client.update_did_webvh_by_did(did, body).await?;
     println!("WebVH DID updated.");
     println!("  DID:             {}", result.did);
     println!("  New version ID:  {}", result.new_version_id);

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.20.31"
+version = "0.20.32"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/client/webvh.rs
+++ b/vta-sdk/src/client/webvh.rs
@@ -219,12 +219,66 @@ impl VtaClient {
         .await
     }
 
+    /// Apply a generic update to an existing webvh DID, identified by the DID
+    /// itself.
+    ///
+    /// Sends canonical `webvh/dids/update/1.0` on **every** transport, so this
+    /// is the only form of the call that works over TSP: TSP carries the
+    /// Trust-Task surface and nothing else, and the legacy protocol message
+    /// [`update_did_webvh`](Self::update_did_webvh) has no dispatcher behind it
+    /// there.
+    ///
+    /// The canonical task keys on the DID, not `(context_id, scid)` — which is
+    /// what kept this call on the legacy message after #861. Callers already
+    /// hold the DID; `pnm did-mgmt dids update` was fetching the record purely
+    /// to translate it into the pair this method no longer needs.
+    pub async fn update_did_webvh_by_did(
+        &self,
+        did: &str,
+        body: crate::protocols::did_management::update::UpdateDidWebvhBody,
+    ) -> Result<crate::protocols::did_management::update::UpdateDidWebvhResultBody, VtaError> {
+        let payload = flatten_with_did(did, &body)?;
+        let response = self
+            .dispatch_trust_task(crate::trust_tasks::TASK_WEBVH_DIDS_UPDATE_1_0, payload, 60)
+            .await?;
+        serde_json::from_value(response)
+            .map_err(|e| VtaError::Protocol(format!("webvh/dids/update response decode: {e}")))
+    }
+
+    /// Rotate every verificationMethod's keys on a webvh DID, identified by the
+    /// DID itself.
+    ///
+    /// The canonical `webvh/dids/rotate-keys/1.0` form of
+    /// [`rotate_did_webvh_keys`](Self::rotate_did_webvh_keys), and likewise the
+    /// only one that reaches a TSP client.
+    pub async fn rotate_did_webvh_keys_by_did(
+        &self,
+        did: &str,
+        body: crate::protocols::did_management::update::RotateDidWebvhKeysBody,
+    ) -> Result<crate::protocols::did_management::update::UpdateDidWebvhResultBody, VtaError> {
+        let payload = flatten_with_did(did, &body)?;
+        let response = self
+            .dispatch_trust_task(
+                crate::trust_tasks::TASK_WEBVH_DIDS_ROTATE_KEYS_1_0,
+                payload,
+                60,
+            )
+            .await?;
+        serde_json::from_value(response)
+            .map_err(|e| VtaError::Protocol(format!("webvh/dids/rotate-keys response decode: {e}")))
+    }
+
     /// Apply a generic update to an existing webvh DID.
     ///
     /// `ctx_id` is the context the DID lives in; `scid` is the
     /// stable component of the DID (e.g. the `Q...` segment of
     /// `did:webvh:Q...:host:slug`). REST path:
     /// `POST /contexts/{ctx_id}/dids/{scid}/update`.
+    #[deprecated(
+        since = "0.20.32",
+        note = "rides the legacy DIDComm protocol message, which has no TSP dispatcher — \
+                use `update_did_webvh_by_did`, the canonical `webvh/dids/update/1.0` form"
+    )]
     pub async fn update_did_webvh(
         &self,
         ctx_id: &str,
@@ -255,6 +309,12 @@ impl VtaClient {
     /// Rotate every verificationMethod's keys on a webvh DID. Auth
     /// keys + pre-rotation rotate as a consequence of the resulting
     /// document update.
+    #[deprecated(
+        since = "0.20.32",
+        note = "rides the legacy DIDComm protocol message, which has no TSP dispatcher — \
+                use `rotate_did_webvh_keys_by_did`, the canonical \
+                `webvh/dids/rotate-keys/1.0` form"
+    )]
     pub async fn rotate_did_webvh_keys(
         &self,
         ctx_id: &str,
@@ -420,4 +480,44 @@ impl VtaClient {
         serde_json::from_value(payload)
             .map_err(|e| VtaError::Protocol(format!("agent-name response decode: {e}")))
     }
+}
+
+/// Build a `webvh/dids/*` task payload: the body's own members at the top
+/// level, plus the `did` the task keys on.
+///
+/// The maintainer reads this back with `#[serde(flatten)]`, so `did` has to sit
+/// beside the body's members rather than nested under one. Anything that does
+/// not serialize to a JSON object — or that already carries a `did` — is a
+/// programming error here, and is refused rather than silently reshaped: a
+/// dropped member on an update body is a DID-document change the operator
+/// believes they published.
+fn flatten_with_did<T: serde::Serialize>(
+    did: &str,
+    body: &T,
+) -> Result<serde_json::Value, VtaError> {
+    let mut map = match serde_json::to_value(body)? {
+        serde_json::Value::Object(m) => m,
+        other => {
+            return Err(VtaError::Protocol(format!(
+                "webvh task body must serialize to an object, got {}",
+                match other {
+                    serde_json::Value::Null => "null",
+                    serde_json::Value::Bool(_) => "a boolean",
+                    serde_json::Value::Number(_) => "a number",
+                    serde_json::Value::String(_) => "a string",
+                    serde_json::Value::Array(_) => "an array",
+                    serde_json::Value::Object(_) => unreachable!(),
+                }
+            )));
+        }
+    };
+    if map.contains_key("did") {
+        return Err(VtaError::Protocol(
+            "webvh task body already carries a `did` member; refusing to overwrite it with the \
+             target DID"
+                .into(),
+        ));
+    }
+    map.insert("did".into(), serde_json::Value::String(did.to_string()));
+    Ok(serde_json::Value::Object(map))
 }

--- a/vta-sdk/tests/client_rest.rs
+++ b/vta-sdk/tests/client_rest.rs
@@ -1202,6 +1202,52 @@ async fn delete_did_webvh_returns_unit() {
     c.delete_did_webvh("did:webvh:abc").await.unwrap();
 }
 
+/// The canonical form keys on the DID and rides `/api/trust-tasks` on REST
+/// too, so one payload shape serves all three transports. The body's members
+/// sit *beside* `did` — the maintainer reads them back with `serde(flatten)`,
+/// and a nested body would arrive as an update that changes nothing.
+#[tokio::test]
+async fn update_did_webvh_by_did_sends_the_canonical_task() {
+    let server = MockServer::start().await;
+    let _g = Mock::given(method("POST"))
+        .and(path("/api/trust-tasks"))
+        .and(auth_match())
+        .and(wiremock::matchers::body_partial_json(json!({
+            "type": "https://trusttasks.org/spec/vta/webvh/dids/update/1.0",
+            "payload": {
+                "did": "did:webvh:Qabc:host:slug",
+                "document": {"id": "did:webvh:Qabc:host:slug"},
+            },
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": "urn:uuid:0000",
+            "type": "https://trusttasks.org/spec/vta/webvh/dids/update/1.0#response",
+            "payload": {
+                "did": "did:webvh:Qabc:host:slug",
+                "newVersionId": "2-z",
+                "newScid": "Qabc",
+                "newLogEntry": "{}",
+                "updateKeysCount": 1,
+                "preRotationKeyCount": 0
+            },
+        })))
+        .expect(1)
+        .mount_as_scoped(&server)
+        .await;
+
+    let c = client(&server).await;
+    let body = vta_sdk::protocols::did_management::update::UpdateDidWebvhBody {
+        document: Some(json!({"id": "did:webvh:Qabc:host:slug"})),
+        ..Default::default()
+    };
+    let r = c
+        .update_did_webvh_by_did("did:webvh:Qabc:host:slug", body)
+        .await
+        .unwrap();
+    assert_eq!(r.new_version_id, "2-z");
+}
+
+#[allow(deprecated)] // pins the legacy route until the method is removed
 #[tokio::test]
 async fn update_did_webvh_posts_to_context_path() {
     let server = MockServer::start().await;
@@ -1229,6 +1275,7 @@ async fn update_did_webvh_posts_to_context_path() {
     assert_eq!(r.new_version_id, "2-z");
 }
 
+#[allow(deprecated)] // pins the legacy route until the method is removed
 #[tokio::test]
 async fn rotate_did_webvh_keys_posts() {
     let server = MockServer::start().await;


### PR DESCRIPTION
`VtaClient::rpc`'s TSP arm is an `UnsupportedTransport` error, so a client method
still on the legacy DIDComm protocol message does not merely risk wire drift — it
**does not exist over TSP**. #884 moved the ACL slice; this moves the two webvh
DID mutations, which were the largest remaining pair.

## What moved

`update_did_webvh_by_did` and `rotate_did_webvh_keys_by_did` send canonical
`webvh/dids/{update,rotate-keys}/1.0` on every transport, REST included (through
the trust-task endpoint, leaving the dedicated routes mounted for other
consumers). **The maintainer has served both tasks all along** — only the client
never used them, so this is client-side rewiring with no server change.

**Why they were stranded.** The canonical tasks key on the **DID**; the methods
took `(context_id, scid)`. That is a signature change rather than a transport
swap, which is why #861 left them behind. Callers already hold the DID —
`pnm did-mgmt dids update` was fetching the DID record purely to translate it
into the pair the method wanted, and now keeps that call only for the clean 404
it also provides.

Both bodies flatten *beside* `did` rather than nesting under it, because the
maintainer reads them back with `serde(flatten)`. A nested body would deserialize
into an update that changes nothing — published, version-bumped and silently
empty — so `flatten_with_did` refuses a body that is not a JSON object or that
already carries a `did`.

The `(context_id, scid)` methods are **deprecated, not removed**. They still work
over REST and DIDComm; deleting them would break a published crate for no gain.
They have no TSP path and will not get one.

## Still not on TSP, and why

This is the rest of the coverage gap, and neither half is a rewiring job:

| method | blocker |
|---|---|
| `import_key`, `list_webvh_server_domains` | **No published spec.** The dispatcher's own guard (`every_served_uri_has_a_published_spec_or_is_tracked_debt`) refuses a newly-served URI the registry cannot resolve, and names the fix: author it upstream in `trustoverip/dtgwg-trust-tasks-tf` and bump `trust-tasks-rs` — "growing the allowlist is the wrong fix" (#854). So these need an upstream spec PR before any binding here. |
| `backup_export`, `backup_import` | Tasks already bound (`backup/{initiate,complete}-export`, `backup/{initiate,finalize}-import`) — but the **bytes** ride an HTTPS blob URL carried in the descriptor, deliberately, so a multi-megabyte envelope never enters a message envelope. A TSP-only client still needs an HTTP leg until the descriptor's already-declared `chunked-trust-task` algorithm exists. Design change, not rewiring. |

## Testing

- `tests/e2e/tests/client_didcomm.rs` pins both new calls as Trust Tasks,
  including that the body's members arrive un-nested — the assertion that fails
  if `flatten` is ever dropped. 47 passed.
- `vta-sdk/tests/client_rest.rs` pins the REST leg on `/api/trust-tasks`; the two
  legacy-route tests remain under `#[allow(deprecated)]` so the deprecated path
  stays covered until removal. 84 passed.
- `cargo test -p vta-sdk -p vta-cli-common`, clippy and fmt clean.
