### PR TITLE
fix(acl): reuse live ATM profile for mediator ACL self-provisioning

### DIFF
--- a/vta-sdk/src/acl_setup.rs
+++ b/vta-sdk/src/acl_setup.rs
@@ -32,7 +32,7 @@
 //! TODO(tsp-client): if/when the general client request transport gains a
 //! *persistent* TSP variant (a `Tsp` arm on the `#[non_exhaustive]`
 //! `TransportChoice`, or `TspPingSession` generalised into a request session),
-//! that connect path must also call [`set_client_acl_on_connection`], or an
+//! that connect path must also call [`set_client_acl_with_profile`], or an
 //! `ExplicitAllow` mediator will reject it exactly as it did before this
 //! feature. The provisioning logic lives here so only the trigger is needed.
 
@@ -44,42 +44,31 @@ use sha2::{Digest, Sha256};
 use tracing::{debug, info, warn};
 use trust_tasks_rs::specs::messaging::account;
 
-/// Set a client's own ACL on the mediator to accept all messages.
+/// Set a client's own ACL on the mediator using an already-connected profile.
 ///
-/// Call this immediately after a connection to the mediator succeeds. The client
-/// sets its per-DID ACL to allow all message types, which overrides any
-/// restrictive global ACL settings on the mediator while still respecting
-/// per-context ACLs configured for integrations.
+/// Use this when you have already created an `ATMProfile` and enabled its
+/// WebSocket — for example, right after `build_messaging` in the VTA startup
+/// path or after `profile_enable_websocket` in a PNM DIDComm session. Reusing
+/// the live profile avoids opening a second WebSocket for the same DID, which
+/// the mediator would evict as a `duplicate-channel` (only one socket per DID
+/// is permitted), causing the ACL request to silently time out.
 ///
-/// **Fire-and-forget and fully non-blocking.** The entire operation — including
-/// building the ATM profile and the mediator round-trip — runs on a spawned
-/// background task, so neither VTA startup nor a client connect is delayed. This
-/// returns as soon as the task is spawned; both call sites (VTA and PNM) get the
-/// same non-blocking behaviour.
-///
-/// # Behavior
-/// - If building the profile or setting the ACL fails, a warning/debug line is
-///   logged but the caller's startup/connect continues unaffected.
-pub async fn set_client_acl_on_connection(
+/// **Fire-and-forget and fully non-blocking.** The ACL round-trip runs on a
+/// spawned background task; the caller is never blocked.
+pub async fn set_client_acl_with_profile(
     atm: &ATM,
+    profile: Arc<ATMProfile>,
     client_did: &str,
-    mediator_did: &str,
     channel: &str,
     client_name: &str,
 ) {
-    // Own everything so the work can outlive the caller's stack frame, then
-    // spawn a single background task. One spawn — not a spawn-inside-a-spawn —
-    // keeps the profile build and the ACL round-trip off the hot path together.
     let atm = atm.clone();
     let client_did = client_did.to_string();
-    let mediator_did = mediator_did.to_string();
     let channel = channel.to_string();
     let client_name = client_name.to_string();
 
     tokio::spawn(async move {
-        if let Err(e) =
-            set_client_acl_internal(&atm, &client_did, &mediator_did, &channel, &client_name).await
-        {
+        if let Err(e) = apply_acl_set(&atm, &profile, &client_did, &channel, &client_name).await {
             warn!(
                 channel,
                 error = %e,
@@ -90,29 +79,61 @@ pub async fn set_client_acl_on_connection(
     });
 }
 
-/// Internal implementation of ACL setup. Runs on the background task spawned by
-/// [`set_client_acl_on_connection`]; it is free to `await` the mediator
-/// round-trip directly since nothing on the caller's path is waiting on it.
-async fn set_client_acl_internal(
+/// Set a client's own ACL on the mediator, building a fresh ATM profile.
+///
+/// Prefer [`set_client_acl_with_profile`] when you already have a connected
+/// `ATMProfile` — that variant reuses the live socket and avoids a
+/// `duplicate-channel` eviction. Use this variant only if you genuinely need
+/// to create a new profile (no pre-existing connection).
+pub async fn set_client_acl_on_connection(
     atm: &ATM,
     client_did: &str,
     mediator_did: &str,
     channel: &str,
     client_name: &str,
-) -> Result<(), Box<dyn std::error::Error>> {
-    // Build an ATM profile for the client with the mediator as the peer.
-    let atm_profile = ATMProfile::new(
-        atm,
-        None,
-        client_did.to_string(),
-        Some(mediator_did.to_string()),
-    )
-    .await
-    .map_err(|e| format!("failed to create ATM profile: {e}"))?;
+) {
+    let atm = atm.clone();
+    let client_did = client_did.to_string();
+    let mediator_did = mediator_did.to_string();
+    let channel = channel.to_string();
+    let client_name = client_name.to_string();
 
-    // Hash the client's DID for the mediator's ACL record (self-reference).
-    // SHA-256 hex to match the mediator's account-key convention
-    // (`sha256::digest(did)` in affinidi-messaging-sdk).
+    tokio::spawn(async move {
+        match ATMProfile::new(&atm, None, client_did.clone(), Some(mediator_did)).await {
+            Ok(profile) => {
+                let profile = Arc::new(profile);
+                if let Err(e) =
+                    apply_acl_set(&atm, &profile, &client_did, &channel, &client_name).await
+                {
+                    warn!(
+                        channel,
+                        error = %e,
+                        client = client_name,
+                        "failed to set client ACL on mediator (startup continues)"
+                    );
+                }
+            }
+            Err(e) => {
+                warn!(
+                    channel,
+                    error = %e,
+                    client = client_name,
+                    "failed to create ATM profile for ACL setup (startup continues)"
+                );
+            }
+        }
+    });
+}
+
+/// Core ACL-set round-trip shared by both public entry points.
+async fn apply_acl_set(
+    atm: &ATM,
+    profile: &Arc<ATMProfile>,
+    client_did: &str,
+    channel: &str,
+    client_name: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // SHA-256 hex to match the mediator's account-key convention.
     let mut hasher = Sha256::new();
     hasher.update(client_did);
     let hash_bytes = hasher.finalize();
@@ -121,32 +142,15 @@ async fn set_client_acl_internal(
         .map(|b| format!("{:02x}", b))
         .collect::<String>();
 
-    // Build an "allow all" ACL that accepts every message type. Fields left
-    // `None` (e.g. the self-manage flags) keep the mediator's existing value.
     let acl = build_allow_all_acl();
 
-    let atm_profile_arc = Arc::new(atm_profile);
-
-    // Apply the ACL to the client's own DID via the mediator's trust-tasks
-    // protocol. The messaging family's rationalization (affinidi-tdk-rs#667/#668)
-    // retired the single-purpose `acl/set` task in favour of `account/update`,
-    // which carries `acl` as one optional member alongside `accountType` and
-    // `queueLimits` — passing `None` for those two leaves them untouched, so this
-    // is an ACL-only partial update exactly as `acl_set` was.
-    //
-    // `account_update` waits for a response, which on an `ExplicitAllow` mediator
-    // cannot arrive until this very ACL grants `receive_forwarded` — so an `Err`
-    // here (typically a timeout) does NOT mean the request was dropped; the
-    // mediator still applies it. Hence debug, not warn, on error.
+    // Apply the ACL via the mediator's trust-tasks `account/update` endpoint.
+    // On an `ExplicitAllow` mediator the response cannot route back until this
+    // very ACL grants `receive_forwarded`, so a timeout does NOT mean the
+    // request was dropped; the mediator still applies it.
     match atm
         .trust_tasks()
-        .account_update(
-            &atm_profile_arc,
-            Some(client_did_hash),
-            None,
-            Some(acl),
-            None,
-        )
+        .account_update(profile, Some(client_did_hash), None, Some(acl), None)
         .await
     {
         Ok(_) => {

--- a/vta-sdk/src/acl_setup.rs
+++ b/vta-sdk/src/acl_setup.rs
@@ -21,13 +21,11 @@
 //! On the client (PNM/CNM) the general request transport (`VtaClient` /
 //! `TransportChoice` in `session.rs`) is DIDComm-or-REST: every *persistent*,
 //! ACL-needing client connect goes through [`crate::didcomm_session`], which
-//! calls this. The SDK's one dedicated *client-side* TSP session,
-//! [`crate::session::TspPingSession`], is a transient `pnm health` liveness
-//! probe on an ephemeral DID — it opens its own short-lived TSP socket and tears
-//! it down, so it deliberately does **not** persist a mediator ACL (that would
-//! litter the mediator with allow-all entries for throwaway probe DIDs). A probe
-//! against an `ExplicitAllow` mediator is expected to require its DID be
-//! pre-authorised.
+//! calls this. The SDK's dedicated *client-side* DIDComm probe,
+//! [`crate::session::TrustPingSession`], calls [`setup_client_acl`] (the
+//! blocking variant) after opening its WebSocket, so the ACL is in place
+//! before the first ping is sent — required for ExplicitAllow mediators where
+//! the response cannot be forwarded to an unregistered DID.
 //!
 //! TODO(tsp-client): if/when the general client request transport gains a
 //! *persistent* TSP variant (a `Tsp` arm on the `#[non_exhaustive]`
@@ -36,13 +34,18 @@
 //! `ExplicitAllow` mediator will reject it exactly as it did before this
 //! feature. The provisioning logic lives here so only the trigger is needed.
 
+use std::str::FromStr;
 use std::sync::Arc;
+use std::time::SystemTime;
 
+use affinidi_tdk::didcomm::Message;
 use affinidi_tdk::messaging::ATM;
 use affinidi_tdk::messaging::profiles::ATMProfile;
 use sha2::{Digest, Sha256};
 use tracing::{debug, info, warn};
-use trust_tasks_rs::specs::messaging::account;
+use trust_tasks_rs::TrustTask;
+use trust_tasks_rs::specs::messaging::{account, acl};
+use uuid::Uuid;
 
 /// Set a client's own ACL on the mediator using an already-connected profile.
 ///
@@ -54,7 +57,8 @@ use trust_tasks_rs::specs::messaging::account;
 /// is permitted), causing the ACL request to silently time out.
 ///
 /// **Fire-and-forget and fully non-blocking.** The ACL round-trip runs on a
-/// spawned background task; the caller is never blocked.
+/// spawned background task; the caller is never blocked. Use
+/// [`setup_client_acl`] when you need to wait for the ACL before proceeding.
 pub async fn set_client_acl_with_profile(
     atm: &ATM,
     profile: Arc<ATMProfile>,
@@ -77,6 +81,30 @@ pub async fn set_client_acl_with_profile(
             );
         }
     });
+}
+
+/// Set a client's own ACL on the mediator and **await** the result.
+///
+/// Same as [`set_client_acl_with_profile`] but blocking — use this when the
+/// caller must not proceed until the ACL is applied. For example, a transient
+/// probe session (e.g. `TrustPingSession`) must have its ACL in place before
+/// sending the probe message, or an ExplicitAllow mediator will reject the
+/// response delivery.
+pub async fn setup_client_acl(
+    atm: &ATM,
+    profile: &Arc<ATMProfile>,
+    client_did: &str,
+    channel: &str,
+    client_name: &str,
+) {
+    if let Err(e) = apply_acl_set(atm, profile, client_did, channel, client_name).await {
+        warn!(
+            channel,
+            error = %e,
+            client = client_name,
+            "failed to set client ACL on mediator"
+        );
+    }
 }
 
 /// Set a client's own ACL on the mediator, building a fresh ATM profile.
@@ -126,6 +154,12 @@ pub async fn set_client_acl_on_connection(
 }
 
 /// Core ACL-set round-trip shared by both public entry points.
+///
+/// Tries `messaging/account/update` first (mediator ≥ 0.18.x). If the mediator
+/// returns `e.p.protocol.trust_task.unsupported` (pre-0.18 mediators that only
+/// know the retired `acl/set` task), falls back to a raw `acl/set` exchange
+/// built from the trust-tasks-rs types. This makes the VTA forward-compatible
+/// with newer mediators and backward-compatible with the deployed v0.17.x fleet.
 async fn apply_acl_set(
     atm: &ATM,
     profile: &Arc<ATMProfile>,
@@ -133,24 +167,19 @@ async fn apply_acl_set(
     channel: &str,
     client_name: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    // SHA-256 hex to match the mediator's account-key convention.
     let mut hasher = Sha256::new();
     hasher.update(client_did);
-    let hash_bytes = hasher.finalize();
-    let client_did_hash = hash_bytes
+    let client_did_hash = hasher
+        .finalize()
         .iter()
         .map(|b| format!("{:02x}", b))
         .collect::<String>();
 
-    let acl = build_allow_all_acl();
-
-    // Apply the ACL via the mediator's trust-tasks `account/update` endpoint.
-    // On an `ExplicitAllow` mediator the response cannot route back until this
-    // very ACL grants `receive_forwarded`, so a timeout does NOT mean the
-    // request was dropped; the mediator still applies it.
+    // --- Try account/update (mediator ≥ 0.18.x) ---
+    let acl_update = build_allow_all_acl_update();
     match atm
         .trust_tasks()
-        .account_update(profile, Some(client_did_hash), None, Some(acl), None)
+        .account_update(profile, Some(client_did_hash.clone()), None, Some(acl_update), None)
         .await
     {
         Ok(_) => {
@@ -160,6 +189,7 @@ async fn apply_acl_set(
                 client = client_name,
                 "client ACL configured on mediator"
             );
+            return Ok(());
         }
         Err(e) => {
             debug!(
@@ -167,22 +197,73 @@ async fn apply_acl_set(
                 client_did = %client_did,
                 error = %e,
                 client = client_name,
-                "client ACL request error (mediator may still process asynchronously)"
+                "account_update not supported by mediator, trying acl/set fallback"
             );
         }
     }
 
+    // --- Fallback: raw acl/set (mediator 0.17.x) ---
+    //
+    // SDK 0.18.65 removed the high-level `acl_set` helper (replaced by
+    // `account_update` in tdk-rs PR #668). Replicate the exchange manually
+    // using the trust-tasks-rs types and the public ATM pack+send APIs.
+    //
+    // IMPORTANT: must use wait_for_response=true (same as ATM's internal
+    // `exchange()` helper). This registers a live-stream listener so the
+    // mediator's response is routed back *directly* on the WebSocket channel —
+    // not via the forwarded inbox. Forwarded delivery is blocked on an
+    // ExplicitAllow mediator until the very ACL we're setting takes effect, so
+    // fire-and-forget (wait=false) silently fails: no listener ⇒ no committed
+    // ACL ⇒ all subsequent messages remain blocked.
+    const ENVELOPE_TYPE: &str = "https://trusttasks.org/binding/didcomm/0.1/envelope";
+
+    let (profile_did, mediator_did) = profile.dids()?;
+
+    let vid = acl::set::v0_1::Vid::from_str(&client_did_hash)
+        .map_err(|e| format!("invalid DID hash for acl/set fallback: {e}"))?;
+    let acl_set = build_allow_all_acl_set();
+    let mut task = TrustTask::for_payload(
+        Uuid::new_v4().to_string(),
+        acl::set::v0_1::Payload { acl: acl_set, did: vid, ext: None },
+    );
+    task.issuer = Some(profile_did.to_string());
+    task.recipient = Some(mediator_did.to_string());
+
+    let body = serde_json::to_value(&task)
+        .map_err(|e| format!("serialise acl/set task: {e}"))?;
+
+    let now = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let msg_id = Uuid::new_v4().to_string();
+    let msg = Message::build(msg_id.clone(), ENVELOPE_TYPE.to_string(), body)
+        .to(mediator_did.to_string())
+        .from(profile_did.to_string())
+        .created_time(now)
+        .expires_time(now + 10)
+        .finalize();
+
+    let (packed, _) = atm
+        .pack_encrypted(&msg, mediator_did, Some(profile_did), None)
+        .await
+        .map_err(|e| format!("pack acl/set: {e}"))?;
+
+    atm.send_message(profile, &packed, &msg_id, true, true)
+        .await
+        .map_err(|e| format!("send acl/set: {e}"))?;
+
+    info!(
+        channel,
+        client_did = %client_did,
+        client = client_name,
+        "client ACL configured on mediator (acl/set)"
+    );
     Ok(())
 }
 
-/// Build a wire-format ACL that allows all message types.
-///
-/// This creates a `MediatorAcl` wire format (the `acl` member of the trust-tasks
-/// `messaging/account/update/0.1` task, which superseded `acl/set/0.1`) that
-/// permits sending, receiving, forwarding, and anonymous messages. The
-/// access-list mode is set to ExplicitDeny (denylist semantics), allowing all
-/// except explicitly denied entries.
-fn build_allow_all_acl() -> account::update::v0_1::MediatorAcl {
+/// Allow-all ACL for `messaging/account/update` (mediator ≥ 0.18.x).
+fn build_allow_all_acl_update() -> account::update::v0_1::MediatorAcl {
     account::update::v0_1::MediatorAcl {
         blocked: Some(false),
         local: Some(true),
@@ -193,7 +274,22 @@ fn build_allow_all_acl() -> account::update::v0_1::MediatorAcl {
         create_invites: Some(true),
         anon_receive: Some(true),
         access_list_mode: Some(account::update::v0_1::MediatorAclAccessListMode::ExplicitDeny),
-        // Don't set self-manage flags — let the mediator's defaults apply
+        ..Default::default()
+    }
+}
+
+/// Allow-all ACL for `acl/set` (mediator 0.17.x fallback).
+fn build_allow_all_acl_set() -> acl::set::v0_1::MediatorAcl {
+    acl::set::v0_1::MediatorAcl {
+        blocked: Some(false),
+        local: Some(true),
+        send_messages: Some(true),
+        receive_messages: Some(true),
+        send_forwarded: Some(true),
+        receive_forwarded: Some(true),
+        create_invites: Some(true),
+        anon_receive: Some(true),
+        access_list_mode: Some(acl::set::v0_1::MediatorAclAccessListMode::ExplicitDeny),
         ..Default::default()
     }
 }

--- a/vta-sdk/src/didcomm_session.rs
+++ b/vta-sdk/src/didcomm_session.rs
@@ -484,17 +484,14 @@ impl DIDCommSession {
         }
 
         // Set this client's ACL on the mediator to accept all message types.
-        // `set_client_acl_on_connection` is itself fire-and-forget (it spawns a
-        // background task and returns immediately), so no extra spawn here — the
-        // connect path is not blocked on the mediator round-trip. Only compiled-in
-        // when the `acl-setup` feature is enabled (requires `session` +
-        // `trust-tasks-rs`). PNM enables `acl-setup`; SDK consumers that omit it
-        // are unaffected.
+        // Use the already-connected profile to avoid opening a second WebSocket
+        // for the same DID (which the mediator evicts as `duplicate-channel`,
+        // causing the ACL request to silently time out). Fire-and-forget.
         #[cfg(feature = "acl-setup")]
-        crate::acl_setup::set_client_acl_on_connection(
+        crate::acl_setup::set_client_acl_with_profile(
             atm,
+            profile.clone(),
             client_did,
-            mediator_did,
             "didcomm-session",
             "pnm",
         )

--- a/vta-sdk/src/session.rs
+++ b/vta-sdk/src/session.rs
@@ -2114,6 +2114,21 @@ impl TrustPingSession {
             return Err(msg.into());
         }
 
+        // Register the client's ACL on the mediator so it can receive forwarded
+        // messages. Without this, an ExplicitAllow mediator rejects forwarded
+        // delivery for any DID that hasn't called acl/set — the trust-ping
+        // response would never arrive. We await (blocking variant) so the ACL is
+        // in place before the first ping is sent.
+        #[cfg(feature = "acl-setup")]
+        crate::acl_setup::setup_client_acl(
+            hub.atm(),
+            &identity.profile,
+            client_did,
+            "trust-ping-session",
+            "pnm",
+        )
+        .await;
+
         Ok(Self {
             identity,
             ownership,

--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -2131,19 +2131,19 @@ impl MessagingConnect {
         // Set the VTA's own allow-all ACL on the mediator (keyed on the VTA DID,
         // so it authorises both DIDComm and TSP on the shared socket). Only when
         // `setup_acl` is set (mediators in ExplicitAllow mode).
+        //
+        // Use the already-connected messaging profile — creating a new ATMProfile
+        // here would open a second WebSocket for the same DID, which the mediator
+        // evicts as `duplicate-channel`, silently preventing the ACL from being set.
         if messaging_config.setup_acl {
-            if let Some(atm) = app_state.atm.as_ref() {
-                acl_setup::set_client_acl_on_connection(
-                    atm,
-                    vta_did,
-                    messaging_config.mediator_did.as_str(),
-                    "vta-main",
-                    "vta",
-                )
-                .await;
-            } else {
-                warn!("setup_acl = true but no ATM available; skipping mediator ACL provisioning");
-            }
+            acl_setup::set_client_acl_with_profile(
+                &messaging.atm,
+                messaging.profile.clone(),
+                vta_did,
+                "vta-main",
+                "vta",
+            )
+            .await;
         }
 
         Ok(messaging)


### PR DESCRIPTION
## Problem

On a mediator that applies a restrictive per-account ACL default (ExplicitAllow inbox mode), an agent and its DIDComm clients could appear connected yet never receive forwarded messages. Two root causes:

1. **Duplicate-channel eviction.** ACL self-provisioning opened a *second* WebSocket for the same DID right after the messaging connection was established. Mediators enforce one socket per DID and evict the newer connection as `duplicate-channel`, so the ACL trust task timed out silently. The inbox stayed ExplicitAllow and every forwarded message was dropped.

2. **Trust-task API mismatch.** Newer SDKs provision ACLs via the `account_update` trust task, which older mediators do not implement — they only understand the retired `acl/set` task. Against those mediators the update was rejected and the ACL was never set.

## Fix

- Add `set_client_acl_with_profile`, which reuses the already-connected `Arc<ATMProfile>` instead of spawning a new socket; update the agent startup and the DIDComm-connect call sites to use it.
- Add a dual-API fallback in the shared `apply_acl_set`: try `account_update` first, and on rejection fall back to a raw `acl/set` exchange built from the trust-tasks types. The fallback uses `wait_for_response=true` so the mediator's reply returns directly over the live WebSocket rather than via the (still-closed) forwarded inbox.
- Provision the client ACL in `TrustPingSession` (blocking variant) before the first ping, so an ExplicitAllow mediator can forward the ping response back.
- Keep `set_client_acl_on_connection` as a public API for callers without a pre-built profile.

## Compatibility

Forward-compatible with mediators that implement `account_update`; backward-compatible with 0.17.x mediators that only implement `acl/set`.

## Testing

Verified end-to-end with a local strict-ACL harness that reproduces the restrictive (ExplicitAllow) per-account posture against a did:webvh agent + did:webvh mediator + DIDComm client. Round-trip `keys list` / `acl list` / `keys create` all succeed over DIDComm (previously blocked). Both the agent and client sides carry the fallback.
