### PR TITLE
chore(deps)!: move the workspace to curve25519-dalek 5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,6 +38,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "aead"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
+dependencies = [
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
+]
+
+[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -65,7 +75,7 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
 dependencies = [
- "aead",
+ "aead 0.5.2",
  "aes 0.8.4",
  "cipher 0.4.4",
  "ctr",
@@ -111,7 +121,7 @@ dependencies = [
  "base58",
  "base64 0.22.1",
  "cbc 0.1.2",
- "ed25519-dalek",
+ "ed25519-dalek 2.2.0",
  "getrandom 0.2.17",
  "hmac 0.12.1",
  "k256",
@@ -125,7 +135,7 @@ dependencies = [
  "sha2 0.10.9",
  "subtle",
  "thiserror 2.0.19",
- "x25519-dalek",
+ "x25519-dalek 2.0.1",
  "zeroize",
 ]
 
@@ -143,7 +153,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "ciborium",
- "ed25519-dalek",
+ "ed25519-dalek 2.2.0",
  "hmac 0.12.1",
  "multibase",
  "serde",
@@ -191,7 +201,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.19",
  "url",
- "x25519-dalek",
+ "x25519-dalek 2.0.1",
  "zeroize",
 ]
 
@@ -328,7 +338,7 @@ checksum = "6ace13f99837427a4854d476a58ef51f695c5f8abbc1e15937725cdc1b3cc444"
 dependencies = [
  "affinidi-crypto",
  "base64ct",
- "ed25519-dalek",
+ "ed25519-dalek 2.2.0",
  "k256",
  "p256",
  "rand_core 0.6.4",
@@ -402,7 +412,7 @@ dependencies = [
  "trust-tasks-rs",
  "url",
  "uuid",
- "vta-sdk",
+ "vta-sdk 0.20.32",
 ]
 
 [[package]]
@@ -527,7 +537,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "419d638be45a2b839e503aa89fd870c2f470f1e83f1b05d5e941bd94c95c56a6"
 dependencies = [
  "base64 0.22.1",
- "ed25519-dalek",
+ "ed25519-dalek 2.2.0",
  "p256",
  "rand_core 0.6.4",
  "serde",
@@ -638,7 +648,7 @@ dependencies = [
  "tokio",
  "tracing",
  "unsigned-varint 0.8.0",
- "x25519-dalek",
+ "x25519-dalek 2.0.1",
  "zeroize",
 ]
 
@@ -737,8 +747,8 @@ dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-encoding",
  "blake2",
- "chacha20poly1305",
- "ed25519-dalek",
+ "chacha20poly1305 0.10.1",
+ "ed25519-dalek 2.2.0",
  "hex",
  "hkdf 0.12.4",
  "rand_core 0.6.4",
@@ -748,7 +758,7 @@ dependencies = [
  "thiserror 2.0.19",
  "tokio",
  "url",
- "x25519-dalek",
+ "x25519-dalek 2.0.1",
  "zeroize",
 ]
 
@@ -2068,6 +2078,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
  "hybrid-array",
+ "zeroize",
 ]
 
 [[package]]
@@ -2336,6 +2347,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
+ "cipher 0.5.2",
  "cpufeatures 0.3.0",
  "rand_core 0.10.1",
 ]
@@ -2346,11 +2358,23 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
- "aead",
+ "aead 0.5.2",
  "chacha20 0.9.1",
  "cipher 0.4.4",
- "poly1305",
+ "poly1305 0.8.0",
  "zeroize",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b89e1c441e926b9c82a8d023f6e1b7ae0adcfaa7d621814e4d60789bac751cb"
+dependencies = [
+ "aead 0.6.1",
+ "chacha20 0.10.1",
+ "cipher 0.5.2",
+ "poly1305 0.9.1",
 ]
 
 [[package]]
@@ -2421,6 +2445,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
+ "block-buffer 0.12.1",
  "crypto-common 0.2.2",
  "inout 0.2.2",
 ]
@@ -2505,7 +2530,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk",
+ "vta-sdk 0.21.0",
 ]
 
 [[package]]
@@ -2813,6 +2838,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2874,7 +2900,23 @@ dependencies = [
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest 0.10.7",
- "fiat-crypto",
+ "fiat-crypto 0.2.9",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "curve25519-dalek-derive",
+ "digest 0.11.3",
+ "fiat-crypto 0.3.0",
  "rustc_version",
  "subtle",
  "zeroize",
@@ -3289,7 +3331,7 @@ dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-tdk",
  "clap",
- "ed25519-dalek",
+ "ed25519-dalek 3.0.0",
  "ed25519-dalek-bip32",
  "hex",
  "multibase",
@@ -3297,7 +3339,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk",
+ "vta-sdk 0.21.0",
 ]
 
 [[package]]
@@ -3358,6 +3400,7 @@ dependencies = [
  "const-oid 0.10.2",
  "crypto-common 0.2.2",
  "ctutils",
+ "zeroize",
 ]
 
 [[package]]
@@ -3438,7 +3481,7 @@ dependencies = [
  "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
- "signature",
+ "signature 2.2.0",
  "spki",
 ]
 
@@ -3449,7 +3492,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
  "pkcs8",
- "signature",
+ "signature 2.2.0",
+]
+
+[[package]]
+name = "ed25519"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a"
+dependencies = [
+ "signature 3.0.0",
 ]
 
 [[package]]
@@ -3458,11 +3510,24 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
- "curve25519-dalek",
- "ed25519",
+ "curve25519-dalek 4.1.3",
+ "ed25519 2.2.3",
  "rand_core 0.6.4",
  "serde",
  "sha2 0.10.9",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ebaa1a2bf1290ab3bfe5a7b771d050ebffab2711c19a81691c683a5144a25de"
+dependencies = [
+ "curve25519-dalek 5.0.0",
+ "ed25519 3.0.0",
+ "sha2 0.11.0",
  "subtle",
  "zeroize",
 ]
@@ -3474,7 +3539,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b49a684b133c4980d7ee783936af771516011c8cd15f429dbda77245e282f03"
 dependencies = [
  "derivation-path",
- "ed25519-dalek",
+ "ed25519-dalek 2.2.0",
  "hmac 0.12.1",
  "sha2 0.10.9",
 ]
@@ -3719,6 +3784,12 @@ name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "filedescriptor"
@@ -4541,22 +4612,24 @@ dependencies = [
 
 [[package]]
 name = "hpke"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f65d16b699dd1a1fa2d851c970b0c971b388eeeb40f744252b8de48860980c8f"
+checksum = "dd5130e119706b4d8c2180da6126f7e60b6c38c2d340d539219f57051f0a7af7"
 dependencies = [
- "aead",
- "aes-gcm",
- "chacha20poly1305",
- "digest 0.10.7",
- "generic-array",
- "hkdf 0.12.4",
- "hmac 0.12.1",
- "p256",
- "rand_core 0.9.5",
- "sha2 0.10.9",
+ "aead 0.6.1",
+ "chacha20poly1305 0.11.0",
+ "getrandom 0.4.3",
+ "hkdf 0.13.0",
+ "hybrid-array",
+ "ml-kem",
+ "rand_core 0.10.1",
+ "sha2 0.11.0",
+ "sha3 0.12.0",
+ "shake",
  "subtle",
- "x25519-dalek",
+ "turboshake",
+ "x-wing",
+ "x25519-dalek 3.0.0",
  "zeroize",
 ]
 
@@ -4639,7 +4712,9 @@ version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
+ "ctutils",
  "typenum",
+ "zeroize",
 ]
 
 [[package]]
@@ -5408,7 +5483,7 @@ dependencies = [
  "pem",
  "serde",
  "serde_json",
- "signature",
+ "signature 2.2.0",
  "simple_asn1 0.6.4",
  "zeroize",
 ]
@@ -5424,7 +5499,7 @@ dependencies = [
  "elliptic-curve",
  "once_cell",
  "sha2 0.10.9",
- "signature",
+ "signature 2.2.0",
 ]
 
 [[package]]
@@ -5451,6 +5526,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "keccak"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
 name = "keccak-hash"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5458,6 +5543,16 @@ checksum = "ae0386ec98c26dd721aaa3412bf3a817156ff3ee7cb6959503f8d1095f4ccc51"
 dependencies = [
  "primitive-types",
  "tiny-keccak",
+]
+
+[[package]]
+name = "kem"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01737161ba802849cfd486b5bd209d38ba4943494c249a8126005170c7621edd"
+dependencies = [
+ "crypto-common 0.2.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -5971,6 +6066,32 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "ml-kem"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e15f3e5b957493873e396a66914e83e616b6afe335cdef7efe5c6e1216aba66"
+dependencies = [
+ "hybrid-array",
+ "kem",
+ "module-lattice",
+ "rand_core 0.10.1",
+ "sha3 0.11.0",
+ "zeroize",
+]
+
+[[package]]
+name = "module-lattice"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c61b87c9683ab7cb1c6871d261ad5479b6b10ceb52c4352aaca3b5d35a8febe"
+dependencies = [
+ "ctutils",
+ "hybrid-array",
+ "num-traits",
+ "zeroize",
 ]
 
 [[package]]
@@ -6762,7 +6883,7 @@ dependencies = [
  "clap",
  "dialoguer",
  "dirs",
- "ed25519-dalek",
+ "ed25519-dalek 3.0.0",
  "hex",
  "multibase",
  "rand 0.10.2",
@@ -6775,7 +6896,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk",
+ "vta-sdk 0.21.0",
 ]
 
 [[package]]
@@ -6786,7 +6907,17 @@ checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
  "cpufeatures 0.2.17",
  "opaque-debug",
- "universal-hash",
+ "universal-hash 0.5.1",
+]
+
+[[package]]
+name = "poly1305"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2d0073b297041425c7c3df6eb4792d598a15323fe63346852b092eca02904c"
+dependencies = [
+ "cpufeatures 0.3.0",
+ "universal-hash 0.6.1",
 ]
 
 [[package]]
@@ -6798,7 +6929,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "opaque-debug",
- "universal-hash",
+ "universal-hash 0.5.1",
 ]
 
 [[package]]
@@ -8294,6 +8425,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha3"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
+dependencies = [
+ "digest 0.11.3",
+ "keccak",
+]
+
+[[package]]
+name = "sha3"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc9bad02c26382724b2d2692c6f179285e4b54eeecd7968f52a50059c3c11759"
+dependencies = [
+ "digest 0.11.3",
+ "keccak",
+ "sponge-cursor",
+]
+
+[[package]]
+name = "shake"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09057cb2149ad4cbd2da1e26b351f9a4c354219421229c69c3063e6f61947c4a"
+dependencies = [
+ "digest 0.11.3",
+ "keccak",
+ "sponge-cursor",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8354,6 +8517,12 @@ dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "signature"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
 
 [[package]]
 name = "simd-adler32"
@@ -8509,6 +8678,15 @@ checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
+]
+
+[[package]]
+name = "sponge-cursor"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a0219bd7d979d58245a4f41f695e1ac9f8befdffadd7f61f1bae9e39abc6620"
+dependencies = [
+ "zeroize",
 ]
 
 [[package]]
@@ -9619,6 +9797,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "turboshake"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f892c6904b0bd5a9241eac848347abcbbbd2b9f3892bad23ac3e6efab8d6f06a"
+dependencies = [
+ "digest 0.11.3",
+ "keccak",
+ "sponge-cursor",
+]
+
+[[package]]
 name = "twox-hash"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9885,6 +10074,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "universal-hash"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
+dependencies = [
+ "crypto-common 0.2.2",
+ "ctutils",
+]
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10078,7 +10277,7 @@ version = "0.1.1"
 dependencies = [
  "tracing",
  "uuid",
- "vta-sdk",
+ "vta-sdk 0.21.0",
  "vti-common",
 ]
 
@@ -10104,7 +10303,7 @@ dependencies = [
  "vta-config",
  "vta-keys",
  "vta-keyspaces",
- "vta-sdk",
+ "vta-sdk 0.21.0",
  "vta-support",
  "vta-webvh",
  "vti-common",
@@ -10120,7 +10319,7 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "dialoguer",
- "ed25519-dalek",
+ "ed25519-dalek 3.0.0",
  "hkdf 0.13.0",
  "multibase",
  "rand 0.10.2",
@@ -10131,9 +10330,9 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.19",
  "tokio",
- "vta-sdk",
+ "vta-sdk 0.21.0",
  "vti-common",
- "x25519-dalek",
+ "x25519-dalek 3.0.0",
 ]
 
 [[package]]
@@ -10166,7 +10365,7 @@ dependencies = [
 
 [[package]]
 name = "vta-keys"
-version = "0.1.4"
+version = "0.2.0"
 dependencies = [
  "aes-gcm",
  "affinidi-crypto",
@@ -10174,7 +10373,7 @@ dependencies = [
  "base64 0.22.1",
  "bip39",
  "chrono",
- "ed25519-dalek",
+ "ed25519-dalek 3.0.0",
  "ed25519-dalek-bip32",
  "hex",
  "hkdf 0.13.0",
@@ -10191,10 +10390,10 @@ dependencies = [
  "uuid",
  "vta-config",
  "vta-keyspaces",
- "vta-sdk",
+ "vta-sdk 0.21.0",
  "vti-common",
  "vti-secrets",
- "x25519-dalek",
+ "x25519-dalek 3.0.0",
  "zeroize",
 ]
 
@@ -10218,7 +10417,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk",
+ "vta-sdk 0.21.0",
 ]
 
 [[package]]
@@ -10232,7 +10431,7 @@ dependencies = [
  "affinidi-secrets-resolver",
  "base64 0.22.1",
  "chrono",
- "ed25519-dalek",
+ "ed25519-dalek 3.0.0",
  "multibase",
  "serde",
  "serde_json",
@@ -10243,7 +10442,7 @@ dependencies = [
  "trust-tasks-proof",
  "trust-tasks-rs",
  "uniffi",
- "vta-sdk",
+ "vta-sdk 0.21.0",
 ]
 
 [[package]]
@@ -10267,6 +10466,42 @@ dependencies = [
 [[package]]
 name = "vta-sdk"
 version = "0.20.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "948774795d04846e6e4d70e18069dfb12294c2213e7195ad0938e685c837866a"
+dependencies = [
+ "affinidi-crypto",
+ "affinidi-data-integrity",
+ "affinidi-did-resolver-cache-sdk",
+ "affinidi-messaging-core",
+ "affinidi-messaging-delivery",
+ "affinidi-messaging-didcomm",
+ "affinidi-openid4vci",
+ "affinidi-openid4vp",
+ "affinidi-secrets-resolver",
+ "affinidi-tdk",
+ "base64 0.22.1",
+ "chrono",
+ "curve25519-dalek 4.1.3",
+ "didwebvh-rs",
+ "ed25519-dalek 2.2.0",
+ "futures-util",
+ "getrandom 0.4.3",
+ "multibase",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "thiserror 2.0.19",
+ "tokio",
+ "tracing",
+ "trust-tasks-rs",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "vta-sdk"
+version = "0.21.0"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10294,10 +10529,10 @@ dependencies = [
  "chrono",
  "ciborium",
  "coset 0.4.2",
- "curve25519-dalek",
+ "curve25519-dalek 5.0.0",
  "dbus-secret-service-keyring-store",
  "didwebvh-rs",
- "ed25519-dalek",
+ "ed25519-dalek 3.0.0",
  "futures-util",
  "getrandom 0.4.3",
  "hpke",
@@ -10321,14 +10556,14 @@ dependencies = [
  "uuid",
  "windows-native-keyring-store",
  "wiremock",
- "x25519-dalek",
+ "x25519-dalek 3.0.0",
  "x509-parser 0.18.1",
  "zeroize",
 ]
 
 [[package]]
 name = "vta-service"
-version = "0.13.22"
+version = "0.14.0"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",
@@ -10361,7 +10596,7 @@ dependencies = [
  "dialoguer",
  "didwebvh-rs",
  "dirs",
- "ed25519-dalek",
+ "ed25519-dalek 3.0.0",
  "ed25519-dalek-bip32",
  "fjall",
  "futures-util",
@@ -10410,7 +10645,7 @@ dependencies = [
  "vta-keys",
  "vta-keyspaces",
  "vta-policy",
- "vta-sdk",
+ "vta-sdk 0.21.0",
  "vta-service",
  "vta-support",
  "vta-sweepers",
@@ -10423,7 +10658,7 @@ dependencies = [
  "webauthn-rs",
  "webauthn-rs-proto",
  "wiremock",
- "x25519-dalek",
+ "x25519-dalek 3.0.0",
  "zeroize",
 ]
 
@@ -10432,7 +10667,7 @@ name = "vta-support"
 version = "0.2.2"
 dependencies = [
  "chrono",
- "ed25519-dalek",
+ "ed25519-dalek 3.0.0",
  "hex",
  "multibase",
  "rand 0.10.2",
@@ -10443,7 +10678,7 @@ dependencies = [
  "tracing",
  "vta-config",
  "vta-keyspaces",
- "vta-sdk",
+ "vta-sdk 0.21.0",
  "vti-common",
 ]
 
@@ -10511,7 +10746,7 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "chrono",
- "ed25519-dalek",
+ "ed25519-dalek 3.0.0",
  "multibase",
  "reqwest 0.13.4",
  "serde",
@@ -10521,7 +10756,7 @@ dependencies = [
  "tracing",
  "uuid",
  "vta-keyspaces",
- "vta-sdk",
+ "vta-sdk 0.21.0",
  "vti-common",
 ]
 
@@ -10531,7 +10766,7 @@ version = "0.1.2"
 dependencies = [
  "affinidi-tdk",
  "chrono",
- "ed25519-dalek",
+ "ed25519-dalek 3.0.0",
  "reqwest 0.13.4",
  "serde",
  "serde_json",
@@ -10540,7 +10775,7 @@ dependencies = [
  "tracing",
  "url",
  "vta-keyspaces",
- "vta-sdk",
+ "vta-sdk 0.21.0",
  "vti-common",
  "wiremock",
  "zeroize",
@@ -10557,7 +10792,7 @@ dependencies = [
  "thiserror 2.0.19",
  "tokio",
  "trust-tasks-rs",
- "vta-sdk",
+ "vta-sdk 0.21.0",
 ]
 
 [[package]]
@@ -10592,7 +10827,7 @@ dependencies = [
  "dialoguer",
  "didwebvh-rs",
  "dtg-credentials",
- "ed25519-dalek",
+ "ed25519-dalek 3.0.0",
  "fjall",
  "flate2",
  "futures-util",
@@ -10631,7 +10866,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk",
+ "vta-sdk 0.21.0",
  "vtc-client",
  "vtc-service",
  "vti-common",
@@ -10639,7 +10874,7 @@ dependencies = [
  "webauthn-rs",
  "webauthn-rs-proto",
  "wiremock",
- "x25519-dalek",
+ "x25519-dalek 3.0.0",
  "zeroize",
 ]
 
@@ -10659,7 +10894,7 @@ dependencies = [
  "bytes",
  "chrono",
  "dialoguer",
- "ed25519-dalek",
+ "ed25519-dalek 3.0.0",
  "fjall",
  "hex",
  "hkdf 0.13.0",
@@ -10684,7 +10919,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk",
+ "vta-sdk 0.21.0",
  "webauthn-rs",
  "zeroize",
 ]
@@ -10700,7 +10935,7 @@ dependencies = [
  "affinidi-secrets-resolver",
  "affinidi-tdk",
  "chrono",
- "ed25519-dalek",
+ "ed25519-dalek 3.0.0",
  "multibase",
  "reqwest 0.13.4",
  "serde_json",
@@ -10711,7 +10946,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk",
+ "vta-sdk 0.21.0",
  "vta-service",
  "vti-common",
 ]
@@ -10725,7 +10960,7 @@ dependencies = [
  "azure_identity",
  "azure_security_keyvault_secrets",
  "bytes",
- "ed25519-dalek",
+ "ed25519-dalek 3.0.0",
  "futures-util",
  "google-cloud-auth",
  "google-cloud-secretmanager-v1",
@@ -10741,7 +10976,7 @@ dependencies = [
  "toml 1.1.4+spec-1.1.0",
  "tracing",
  "vaultrs",
- "vta-sdk",
+ "vta-sdk 0.21.0",
  "vti-common",
 ]
 
@@ -11404,14 +11639,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "x-wing"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b51507b887016c3925c84591108dadb8c099f776eb04fec6a60ae3519fee856f"
+dependencies = [
+ "kem",
+ "ml-kem",
+ "sha3 0.12.0",
+ "shake",
+ "x25519-dalek 3.0.0",
+]
+
+[[package]]
 name = "x25519-dalek"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
 dependencies = [
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "rand_core 0.6.4",
  "serde",
+ "zeroize",
+]
+
+[[package]]
+name = "x25519-dalek"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7e8131a03190127fb2263afc72b322ecadae46b6ff8c6f399ff5d02f5559af6"
+dependencies = [
+ "curve25519-dalek 5.0.0",
+ "rand_core 0.10.1",
  "zeroize",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2516,7 +2516,7 @@ checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cnm-cli"
-version = "0.11.13"
+version = "0.11.14"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "clap",
@@ -6874,7 +6874,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "pnm-cli"
-version = "0.11.16"
+version = "0.11.17"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-resolver-cache-sdk",
@@ -10273,7 +10273,7 @@ dependencies = [
 
 [[package]]
 name = "vta-audit"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "tracing",
  "uuid",
@@ -10283,7 +10283,7 @@ dependencies = [
 
 [[package]]
 name = "vta-backup"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -10312,7 +10312,7 @@ dependencies = [
 
 [[package]]
 name = "vta-cli-common"
-version = "0.10.22"
+version = "0.10.23"
 dependencies = [
  "aes-gcm",
  "affinidi-crypto",
@@ -10664,7 +10664,7 @@ dependencies = [
 
 [[package]]
 name = "vta-support"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "chrono",
  "ed25519-dalek 3.0.0",
@@ -10700,7 +10700,7 @@ dependencies = [
 
 [[package]]
 name = "vta-tee"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "aes 0.9.2",
  "aes-gcm",
@@ -10733,7 +10733,7 @@ dependencies = [
 
 [[package]]
 name = "vta-vault"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10762,7 +10762,7 @@ dependencies = [
 
 [[package]]
 name = "vta-webvh"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "affinidi-tdk",
  "chrono",
@@ -10783,7 +10783,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-client"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "chrono",
  "reqwest 0.13.4",
@@ -10797,7 +10797,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-service"
-version = "0.11.49"
+version = "0.11.50"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",
@@ -10880,7 +10880,7 @@ dependencies = [
 
 [[package]]
 name = "vti-common"
-version = "0.11.31"
+version = "0.11.32"
 dependencies = [
  "aes-gcm",
  "affinidi-data-integrity",
@@ -10953,7 +10953,7 @@ dependencies = [
 
 [[package]]
 name = "vti-secrets"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "aws-config",
  "aws-sdk-secretsmanager",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -176,13 +176,13 @@ didwebvh-rs = "0.6"
 url = "2"
 
 # Cryptography
-ed25519-dalek = "2"
+ed25519-dalek = "3"
 sha2 = "0.11"
 # Constant-time byte equality. Used wherever we compare a
 # server-stored hash against a caller-supplied value (e.g.
 # backup-bundle bearer tokens). Already used by vtc-service.
 subtle = "2.6"
-x25519-dalek = { version = "2", features = ["static_secrets"] }
+x25519-dalek = { version = "3", features = ["static_secrets"] }
 multibase = "0.9"
 
 # JWT

--- a/changelog.d/887-curve25519-dalek-5.md
+++ b/changelog.d/887-curve25519-dalek-5.md
@@ -35,6 +35,15 @@ tree, so it never reaches TDK consumers. Removing it means reimplementing
 SLIP-0010 ed25519 derivation — security-sensitive, and tracked separately
 rather than folded into a dependency bump.
 
+**Version-pin fan-out.** `vta-sdk`'s minor bump moves the `version = "0.20"`
+requirement every dependent carries, and a changed requirement has to publish or
+the registry keeps resolving the old one. Those crates are otherwise untouched —
+their own APIs do not change — so they take patch bumps: **cnm-cli 0.11.14**,
+**pnm-cli 0.11.17**, **vta-audit 0.1.2**, **vta-backup 0.1.5**,
+**vta-cli-common 0.10.23**, **vta-support 0.2.3**, **vta-tee 0.1.5**,
+**vta-vault 0.1.2**, **vta-webvh 0.1.3**, **vtc-client 0.3.1**,
+**vtc-service 0.11.50**, **vti-common 0.11.32**, **vti-secrets 0.1.9**.
+
 **Sequencing for consuming repos.** `curve25519-dalek` 4 does not fully leave
 this workspace on merge. The `affinidi-*` crates are the other dalek-2 source
 inside `vta-sdk`'s own tree, so the order is: affinidi-tdk-rs publishes its leaf

--- a/changelog.d/887-curve25519-dalek-5.md
+++ b/changelog.d/887-curve25519-dalek-5.md
@@ -1,0 +1,47 @@
+### vta-sdk 0.21.0 / vta-keys 0.2.0 / vta-service 0.14.0 — the workspace moves to curve25519-dalek 5 (#887)
+
+`ed25519-dalek` 2 → 3, `x25519-dalek` 2 → 3, `curve25519-dalek` 4 → 5 and `hpke`
+0.13 → 0.14. These shipped together on 2026-07-06 (hpke on 07-09) and bring the
+next-generation RustCrypto stack with them: rand_core 0.10, signature 3,
+ed25519 3, aead 0.6.
+
+`vta-sdk` was the single reason `curve25519-dalek` 4 could not leave the
+affinidi-tdk-rs graph. It pinned `curve25519-dalek = "4"` directly, plus
+ed25519-dalek 2, x25519-dalek 2 and hpke 0.13, and every TDK consumer inherits
+that through the mediator.
+
+- **`vta-sdk`**: **breaking.** Dalek types sit in public signatures —
+  `protocols::acl_management::swap::build_swap_presentation` takes
+  `&ed25519_dalek::SigningKey` — so callers must move to ed25519-dalek 3 in
+  step. `sealed_transfer::hpke` loses its hand-rolled `OsCsprng` adapter, which
+  existed only to bridge `getrandom` onto hpke 0.13's rand_core 0.9 traits;
+  hpke 0.14 ships OS-CSPRNG variants of `single_shot_seal` / `gen_keypair`
+  backed by `UnwrapErr(SysRng)`, the same panic-on-CSPRNG-failure posture the
+  adapter documented. **The sealed-transfer wire format is unchanged** and the
+  randomness posture is unchanged.
+- **`vta-keys`**: ephemeral X25519 wrapping-key generation moves to
+  `rand::rng()`. rand 0.10 renamed `OsRng` → `SysRng` *and* made it fallible
+  (`TryRng<Error = SysError>`), so it no longer satisfies dalek's `CryptoRng`
+  bound; `rand_core` 0.10 has no `OsRng` at all.
+- **`vta-service`**: two sites passed an `ed25519-dalek-bip32` `SigningKey`
+  straight into a workspace slot. That crate (0.3, last released 2023-08) still
+  pins ed25519-dalek 2 and has no v3, so its `SigningKey` is now a *different
+  type* — they cross the boundary as raw bytes, which is what every other
+  derivation site here already did.
+
+**`ed25519-dalek-bip32` keeps a dalek-2 subtree** in vta-service, vta-keys and
+didcomm-test. It is contained: the crate is absent from `vta-sdk`'s dependency
+tree, so it never reaches TDK consumers. Removing it means reimplementing
+SLIP-0010 ed25519 derivation — security-sensitive, and tracked separately
+rather than folded into a dependency bump.
+
+**Sequencing for consuming repos.** `curve25519-dalek` 4 does not fully leave
+this workspace on merge. The `affinidi-*` crates are the other dalek-2 source
+inside `vta-sdk`'s own tree, so the order is: affinidi-tdk-rs publishes its leaf
+crypto crates on dalek 3 (with `affinidi-crypto` going to 0.3.0 — a public
+break, since `PrivateKeyAgreement::X25519` holds an `x25519_dalek::StaticSecret`)
+→ `vta-sdk` 0.21.0 publishes → `affinidi-messaging-mediator` moves its
+`vta-sdk ^0.20.0` requirement to `^0.21` and publishes → the lockfile here drops
+the registry `vta-sdk` node, and dalek 4 with it. Until that third step lands,
+`[patch.crates-io] vta-sdk` no longer applies (mediator 0.18.0 requires
+`^0.20.0`) and the registry copy stays in `Cargo.lock`.

--- a/cnm-cli/Cargo.toml
+++ b/cnm-cli/Cargo.toml
@@ -21,7 +21,7 @@ config-session = ["vta-sdk/config-session"]
 azure-secrets = ["vta-sdk/azure-secrets"]
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.20", features = ["session", "crypto-provider", "acl-setup"] }
+vta-sdk = { path = "../vta-sdk", version = "0.21", features = ["session", "crypto-provider", "acl-setup"] }
 # `agent-names` powers the global `--resolve-agent-names` flag; without it
 # the flag parses but can never resolve anything.
 vta-cli-common = { path = "../vta-cli-common", version = "0.10", features = [

--- a/cnm-cli/Cargo.toml
+++ b/cnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cnm-cli"
 description = "CLI Tool for Verified Trust Agents operating in Verified Trust Communities"
-version = "0.11.13"
+version = "0.11.14"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/didcomm-test/Cargo.toml
+++ b/didcomm-test/Cargo.toml
@@ -13,7 +13,7 @@ name = "didcomm-test"
 path = "src/main.rs"
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.20", features = ["didcomm", "crypto-provider"] }
+vta-sdk = { path = "../vta-sdk", version = "0.21", features = ["didcomm", "crypto-provider"] }
 affinidi-tdk = { workspace = true }
 affinidi-did-resolver-cache-sdk = { workspace = true }
 tokio = { workspace = true }

--- a/pnm-cli/Cargo.toml
+++ b/pnm-cli/Cargo.toml
@@ -28,7 +28,7 @@ azure-secrets = ["vta-sdk/azure-secrets"]
 tsp = ["vta-sdk/tsp"]
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.20", features = ["session", "sealed-transfer", "attest-verify", "provision-integration", "crypto-provider", "acl-setup"] }
+vta-sdk = { path = "../vta-sdk", version = "0.21", features = ["session", "sealed-transfer", "attest-verify", "provision-integration", "crypto-provider", "acl-setup"] }
 affinidi-crypto = { workspace = true }
 base64 = { workspace = true }
 reqwest = { workspace = true }

--- a/pnm-cli/Cargo.toml
+++ b/pnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pnm-cli"
 description = "CLI Tool for managing a personal Verifiable Trust Agent"
-version = "0.11.16"
+version = "0.11.17"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-audit/Cargo.toml
+++ b/vta-audit/Cargo.toml
@@ -12,6 +12,6 @@ repository.workspace = true
 
 [dependencies]
 vti-common = { path = "../vti-common", version = "0.11" }
-vta-sdk = { path = "../vta-sdk", version = "0.20" }
+vta-sdk = { path = "../vta-sdk", version = "0.21" }
 tracing = { workspace = true }
 uuid = { workspace = true }

--- a/vta-audit/Cargo.toml
+++ b/vta-audit/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-audit"
 description = "Structured audit logging for the VTA — the `audit!` tracing macro plus the audit-keyspace persistence helpers"
 readme = "README.md"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-backup/Cargo.toml
+++ b/vta-backup/Cargo.toml
@@ -19,9 +19,9 @@ tee = ["vta-config/tee", "dep:async-trait"]
 
 [dependencies]
 vti-common = { path = "../vti-common", version = "0.11" }
-vta-sdk = { path = "../vta-sdk", version = "0.20" }
+vta-sdk = { path = "../vta-sdk", version = "0.21" }
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.1" }
-vta-keys = { path = "../vta-keys", version = "0.1" }
+vta-keys = { path = "../vta-keys", version = "0.2" }
 vta-config = { path = "../vta-config", version = "0.3" }
 vta-support = { path = "../vta-support", version = "0.2" }
 tokio = { workspace = true }

--- a/vta-backup/Cargo.toml
+++ b/vta-backup/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-backup"
 description = "VTA backup/restore subsystem — encrypted full-state export/import, the sealed backup-bundle store, and its TTL sweeper"
 readme = "README.md"
-version = "0.1.4"
+version = "0.1.5"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-cli-common/Cargo.toml
+++ b/vta-cli-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-cli-common"
 description = "Shared CLI command handlers and rendering helpers for VTA CLIs"
 readme = "README.md"
-version = "0.10.22"
+version = "0.10.23"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-cli-common/Cargo.toml
+++ b/vta-cli-common/Cargo.toml
@@ -16,7 +16,7 @@ repository.workspace = true
 agent-names = ["vta-sdk/agent-names"]
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.20", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.21", features = [
   "client",
   "sealed-transfer",
   "provision-integration",

--- a/vta-enclave/Cargo.toml
+++ b/vta-enclave/Cargo.toml
@@ -30,7 +30,7 @@ vsock-store = ["vta-service/vsock-store"]
 vsock-log = ["dep:tokio-vsock"]
 
 [dependencies]
-vta-service = { path = "../vta-service", version = "0.13", default-features = false, features = ["tee"] }
+vta-service = { path = "../vta-service", version = "0.14", default-features = false, features = ["tee"] }
 vti-common = { path = "../vti-common", version = "0.11", features = ["encryption"] }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/vta-keys/Cargo.toml
+++ b/vta-keys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-keys"
 description = "VTA key management — master-seed storage, BIP-32 key derivation, key wrapping, and the seed-store backend selection"
 readme = "README.md"
-version = "0.1.4"
+version = "0.2.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -29,7 +29,7 @@ vta-keyspaces = { path = "../vta-keyspaces", version = "0.1" }
 vta-config = { path = "../vta-config", version = "0.3" }
 vti-common = { path = "../vti-common", version = "0.11" }
 vti-secrets = { path = "../vti-secrets", version = "0.1" }
-vta-sdk = { path = "../vta-sdk", version = "0.20", features = ["sealed-transfer"] }
+vta-sdk = { path = "../vta-sdk", version = "0.21", features = ["sealed-transfer"] }
 affinidi-tdk = { workspace = true }
 affinidi-crypto = { workspace = true }
 ed25519-dalek = { workspace = true }

--- a/vta-keys/src/wrapping.rs
+++ b/vta-keys/src/wrapping.rs
@@ -66,7 +66,7 @@ impl WrappingKeyCache {
     pub async fn generate(&self) -> (String, String) {
         let kid = Uuid::new_v4().to_string();
         // Use StaticSecret so we can store it (EphemeralSecret is consumed on DH)
-        let secret = StaticSecret::random_from_rng(aes_gcm::aead::OsRng);
+        let secret = StaticSecret::random_from_rng(&mut rand::rng());
         let public = PublicKey::from(&secret);
 
         let public_b64 = BASE64.encode(public.as_bytes());
@@ -273,7 +273,7 @@ mod tests {
     /// Client-side wrapping helper for tests.
     fn wrap_for_test(vta_pub_bytes: &[u8; 32], kid: &str, plaintext: &[u8]) -> String {
         let vta_pub = PublicKey::from(*vta_pub_bytes);
-        let client_secret = StaticSecret::random_from_rng(aes_gcm::aead::OsRng);
+        let client_secret = StaticSecret::random_from_rng(&mut rand::rng());
         let client_pub = PublicKey::from(&client_secret);
 
         let shared = client_secret.diffie_hellman(&vta_pub);

--- a/vta-mcp/Cargo.toml
+++ b/vta-mcp/Cargo.toml
@@ -10,7 +10,7 @@ repository.workspace = true
 publish = false
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.20", features = ["client", "session", "sealed-transfer", "didcomm", "vp", "crypto-provider"] }
+vta-sdk = { path = "../vta-sdk", version = "0.21", features = ["client", "session", "sealed-transfer", "didcomm", "vp", "crypto-provider"] }
 rmcp = { version = "1.7", features = ["server", "transport-io", "macros", "schemars"] }
 schemars = "1"
 tokio = { workspace = true }

--- a/vta-mobile-core/Cargo.toml
+++ b/vta-mobile-core/Cargo.toml
@@ -69,7 +69,7 @@ affinidi-messaging-didcomm = "0.15"
 # lookup the approval sheets render through. Costs a DID resolution plus an
 # outbound fetch per claimed name, which is why the app resolves lazily and
 # caches; see `crate::display_name`.
-vta-sdk = { path = "../vta-sdk", version = "0.20", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.21", features = [
   "session",
   "tsp",
   "agent-names",

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.20.32"
+version = "0.21.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -252,7 +252,7 @@ ed25519-dalek = { workspace = true, optional = true }
 # client/didcomm-light path now goes through `affinidi-messaging-didcomm`'s
 # `PublicKeyAgreement` and doesn't take this dependency directly.
 x25519-dalek = { workspace = true, optional = true }
-curve25519-dalek = { version = "4", optional = true }
+curve25519-dalek = { version = "5", optional = true }
 sha2 = { workspace = true, optional = true }
 # Used by `client` (didcomm_light::pack_anoncrypt) to produce JWEs the
 # workspace's pinned DIDComm decrypt path will accept (ECDH-ES+A256KW +
@@ -262,7 +262,7 @@ affinidi-messaging-didcomm = { version = "0.15", optional = true }
 # `did:webvh:` VTAs without pulling in the heavyweight TDK runtime. Same
 # workspace-pinned version as `vta-service`.
 didwebvh-rs = { workspace = true, optional = true }
-hpke = { version = "0.13", optional = true }
+hpke = { version = "0.14", optional = true }
 affinidi-crypto = { workspace = true, optional = true }
 affinidi-vc = { workspace = true, optional = true }
 affinidi-data-integrity = { workspace = true, optional = true }
@@ -273,8 +273,9 @@ affinidi-secrets-resolver = { workspace = true, optional = true }
 # a dev-dependency for the always-on conformance tests below.
 trust-tasks-rs = { workspace = true, optional = true }
 ciborium = { version = "0.2", optional = true }
-# Used only by sealed-transfer to feed an OS-backed CSPRNG into hpke's
-# rand_core 0.9 trait surface (rand 0.10 + rand_core 0.10 are incompatible).
+# Direct OS-CSPRNG access for seed/nonce/bundle-id generation. (hpke 0.14
+# sources its own randomness internally, so this is no longer the bridge
+# into hpke's rand_core trait surface that it was under 0.13.)
 getrandom = { version = "0.4", optional = true }
 # Local AWS Nitro attestation decode + verify (`attest-verify`). Same crates
 # and versions the upstream `nitro_attest` verifier uses internally — we depend

--- a/vta-sdk/src/sealed_transfer/hpke.rs
+++ b/vta-sdk/src/sealed_transfer/hpke.rs
@@ -9,12 +9,8 @@
 //! bound as AEAD AAD by the caller.
 
 use hpke::{
-    Deserializable, Kem as KemTrait, OpModeR, OpModeS, Serializable,
-    aead::ChaCha20Poly1305,
-    kdf::HkdfSha256,
-    kem::X25519HkdfSha256,
-    rand_core::{CryptoRng, RngCore},
-    single_shot_open, single_shot_seal,
+    Deserializable, Kem as KemTrait, OpModeR, OpModeS, Serializable, aead::ChaCha20Poly1305,
+    kdf::HkdfSha256, kem::X25519HkdfSha256, single_shot_open, single_shot_seal,
 };
 use serde::{Deserialize, Serialize};
 use zeroize::Zeroizing;
@@ -25,36 +21,19 @@ use super::error::SealedTransferError;
 /// purpose cannot be replayed against another.
 const HPKE_INFO: &[u8] = b"vta-sealed-transfer/v1";
 
-/// Adapter from `getrandom` to the rand_core trait version that `hpke` 0.13
-/// re-exports. We can't use the `rand` crate directly because rand 0.10 /
-/// rand_core 0.10 are not compatible with hpke's rand_core 0.9 traits.
-///
-/// **On CSPRNG failure we panic.** `rand_core::RngCore` is infallible by
-/// design — the only alternatives on `getrandom::fill` error are (a) return
-/// zeros (catastrophic: attacker-predictable HPKE keys) or (b) silently
-/// degrade to a weaker source (worse). A panic propagates the failure to
-/// the handler, which bubbles up as a 500. In practice OS CSPRNG only
-/// fails pre-init on broken platforms; in a TEE with proper boot it
-/// cannot fail after startup.
-struct OsCsprng;
-
-impl RngCore for OsCsprng {
-    fn next_u32(&mut self) -> u32 {
-        let mut buf = [0u8; 4];
-        getrandom::fill(&mut buf).expect("OS CSPRNG failed — see OsCsprng docs");
-        u32::from_le_bytes(buf)
-    }
-    fn next_u64(&mut self) -> u64 {
-        let mut buf = [0u8; 8];
-        getrandom::fill(&mut buf).expect("OS CSPRNG failed — see OsCsprng docs");
-        u64::from_le_bytes(buf)
-    }
-    fn fill_bytes(&mut self, dest: &mut [u8]) {
-        getrandom::fill(dest).expect("OS CSPRNG failed — see OsCsprng docs");
-    }
-}
-
-impl CryptoRng for OsCsprng {}
+// Randomness note: the `single_shot_seal` / `gen_keypair` calls below are
+// `hpke`'s OS-CSPRNG variants — internally `UnwrapErr(getrandom::SysRng)`.
+//
+// **On CSPRNG failure they panic**, which is the behaviour we want and the
+// same posture the hand-rolled `OsCsprng` adapter had before hpke 0.14. The
+// only alternatives on a `getrandom` error are (a) return zeros
+// (catastrophic: attacker-predictable HPKE keys) or (b) silently degrade to
+// a weaker source (worse). A panic propagates to the handler and bubbles up
+// as a 500. In practice the OS CSPRNG only fails pre-init on broken
+// platforms; in a TEE with proper boot it cannot fail after startup.
+//
+// hpke 0.14 moved to rand_core 0.10, so the adapter that used to bridge
+// `getrandom` to hpke's rand_core 0.9 traits is no longer needed.
 
 type Aead = ChaCha20Poly1305;
 type Kdf = HkdfSha256;
@@ -79,16 +58,9 @@ pub fn seal(
 ) -> Result<HpkeSealed, SealedTransferError> {
     let pk = <Kem as KemTrait>::PublicKey::from_bytes(recipient_pubkey)
         .map_err(SealedTransferError::hpke)?;
-    let mut rng = OsCsprng;
-    let (encap, ciphertext) = single_shot_seal::<Aead, Kdf, Kem, _>(
-        &OpModeS::Base,
-        &pk,
-        HPKE_INFO,
-        plaintext,
-        aad,
-        &mut rng,
-    )
-    .map_err(SealedTransferError::hpke)?;
+    let (encap, ciphertext) =
+        single_shot_seal::<Aead, Kdf, Kem>(&OpModeS::Base, &pk, HPKE_INFO, plaintext, aad)
+            .map_err(SealedTransferError::hpke)?;
     let encap_bytes = encap.to_bytes();
     let kem_encap: [u8; 32] = encap_bytes
         .as_slice()
@@ -130,8 +102,7 @@ pub fn open(
 /// so call sites that pass `&[u8; 32]` (e.g. to [`open`] / [`crate::sealed_transfer::open_bundle`])
 /// keep working unchanged via auto-deref.
 pub fn generate_keypair() -> (Zeroizing<[u8; 32]>, [u8; 32]) {
-    let mut rng = OsCsprng;
-    let (sk, pk) = <Kem as KemTrait>::gen_keypair(&mut rng);
+    let (sk, pk) = <Kem as KemTrait>::gen_keypair();
     let sk_bytes: [u8; 32] = sk
         .to_bytes()
         .as_slice()

--- a/vta-sdk/src/sealed_transfer/mod.rs
+++ b/vta-sdk/src/sealed_transfer/mod.rs
@@ -51,7 +51,8 @@ use zeroize::Zeroizing;
 /// same identity can later be used for signing without regenerating.
 pub fn generate_ed25519_keypair() -> (Zeroizing<[u8; 32]>, [u8; 32]) {
     let mut seed = [0u8; 32];
-    getrandom::fill(&mut seed).expect("OS CSPRNG failed — see hpke::OsCsprng docs");
+    getrandom::fill(&mut seed)
+        .expect("OS CSPRNG failed — see the randomness note in sealed_transfer::hpke");
     let signing = ed25519_dalek::SigningKey::from_bytes(&seed);
     let pubkey = signing.verifying_key().to_bytes();
     (Zeroizing::new(seed), pubkey)

--- a/vta-sdk/tests/session_store.rs
+++ b/vta-sdk/tests/session_store.rs
@@ -621,7 +621,9 @@ async fn resolve_vta_endpoint_falls_back_to_rest_for_did_web() {
         .unwrap();
     match endpoint {
         VtaEndpoint::Rest { url } => assert_eq!(url, "https://vta.example.invalid"),
-        VtaEndpoint::DIDComm { .. } => panic!("expected Rest fallback, got DIDComm"),
+        // `VtaEndpoint` is `#[non_exhaustive]`; any non-Rest transport is a
+        // failure here, so catch the rest in one arm.
+        _ => panic!("expected Rest fallback, got a non-Rest transport"),
     }
 }
 

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.13.22"
+version = "0.14.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -104,7 +104,7 @@ vta-config = { path = "../vta-config", version = "0.3" }
 vta-support = { path = "../vta-support", version = "0.2" }
 # Key management (seed store, BIP-32 derivation, wrapping), extracted and
 # re-exported as `crate::keys`. Backend features chain to `vta-keys/*`.
-vta-keys = { path = "../vta-keys", version = "0.1" }
+vta-keys = { path = "../vta-keys", version = "0.2" }
 # Holder credential vault (storage/query/receive/present/status), extracted to
 # its own crate and re-exported as `crate::vault`. Feature edges: this crate's
 # `bbs` / `webvh` features enable `vta-vault/bbs` / `vta-vault/webvh`.
@@ -127,7 +127,7 @@ vta-policy = { path = "../vta-policy", version = "0.1" }
 # extracted to its own crate and re-exported as crate::{webvh_store,
 # webvh_client, webvh_auth} behind this crate's `webvh` feature.
 vta-webvh = { path = "../vta-webvh", version = "0.1", optional = true }
-vta-sdk = { path = "../vta-sdk", version = "0.20", features = ["didcomm", "sealed-transfer", "provision-integration", "openapi", "crypto-provider", "acl-setup"] }
+vta-sdk = { path = "../vta-sdk", version = "0.21", features = ["didcomm", "sealed-transfer", "provision-integration", "openapi", "crypto-provider", "acl-setup"] }
 # DID-VM-resolved WebAuthn assertion verifier — drives the new
 # `vta/auth/passkey-login-{start,finish}/1.0` trust-task handlers.
 # Distinct from `webauthn-rs` (which drives the passkey *enrolment*
@@ -297,7 +297,7 @@ vta-service = { path = ".", features = ["test-support"] }
 # `provision_admin_rotated_via_rest` + DI-signed REST auth) the `MockVta`
 # bootstrap→provision e2e tests drive (issues #406, DI-auth follow-up). Kept out
 # of the production `vta-sdk` dep above so the server build stays lean.
-vta-sdk = { path = "../vta-sdk", version = "0.20", features = ["provision-client"] }
+vta-sdk = { path = "../vta-sdk", version = "0.21", features = ["provision-client"] }
 # Mock HTTP server for the did-hosting-daemon REST auth flow tests. Each
 # test spins up a real local server bound to a random port, validates
 # the JWS-signed request bodies the daemon would see, and serves

--- a/vta-service/src/operations/credential_exchange.rs
+++ b/vta-service/src/operations/credential_exchange.rs
@@ -2419,8 +2419,11 @@ mod tests {
             .unwrap()
             .derive(&"m/26'/2'/0'/0'".parse::<DerivationPath>().unwrap())
             .unwrap();
-        derived
-            .signing_key
+        // `ed25519-dalek-bip32` still pins ed25519-dalek 2, so re-make the key
+        // as a workspace (v3) `SigningKey` via raw bytes before verifying —
+        // `sig` above is a v3 `Signature` and the two versions are distinct
+        // types.
+        ed25519_dalek::SigningKey::from_bytes(derived.signing_key.as_bytes())
             .verifying_key()
             .verify(signing_input.as_bytes(), &sig)
             .expect("key-binding proof signature verifies under the holder key");

--- a/vta-service/src/operations/holder_keys.rs
+++ b/vta-service/src/operations/holder_keys.rs
@@ -144,7 +144,11 @@ pub async fn resolve_holder_keys(
     let derived = bip32
         .derive(&path)
         .map_err(|e| AppError::Internal(format!("derive: {e}")))?;
-    let signing_key = derived.signing_key;
+    // `ed25519-dalek-bip32` is pinned to ed25519-dalek 2 upstream, so its
+    // `SigningKey` is a *different type* from the workspace's ed25519-dalek 3
+    // one. Cross the boundary as raw bytes, the same way every other
+    // derivation site here does.
+    let signing_key = ed25519_dalek::SigningKey::from_bytes(derived.signing_key.as_bytes());
 
     let signer = HolderSdJwtSigner {
         key: signing_key.clone(),

--- a/vta-support/Cargo.toml
+++ b/vta-support/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-support"
 description = "Shared mid-layer VTA services — trust-context storage, the sealed-transfer seal helper, and the sealed-bootstrap nonce store"
 readme = "README.md"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-support/Cargo.toml
+++ b/vta-support/Cargo.toml
@@ -21,7 +21,7 @@ vta-config = { path = "../vta-config", version = "0.3" }
 # does not exist and the tarball fails to compile. That is what broke the
 # publish run for 0.2.0.
 vti-common = { path = "../vti-common", version = "0.11", features = ["encryption"] }
-vta-sdk = { path = "../vta-sdk", version = "0.20", features = ["sealed-transfer"] }
+vta-sdk = { path = "../vta-sdk", version = "0.21", features = ["sealed-transfer"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 chrono = { workspace = true }

--- a/vta-tee/Cargo.toml
+++ b/vta-tee/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-tee"
 description = "VTA TEE bootstrap — Nitro/SEV-SNP attestation providers, KMS attest/decrypt + storage-key derivation, the anchor MAC, and first-boot DID autogen"
 readme = "README.md"
-version = "0.1.4"
+version = "0.1.5"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-tee/Cargo.toml
+++ b/vta-tee/Cargo.toml
@@ -14,7 +14,7 @@ repository.workspace = true
 vti-common = { path = "../vti-common", version = "0.11", features = ["encryption", "openapi"] }
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.1" }
 vta-config = { path = "../vta-config", version = "0.3", features = ["tee"] }
-vta-keys = { path = "../vta-keys", version = "0.1" }
+vta-keys = { path = "../vta-keys", version = "0.2" }
 vta-support = { path = "../vta-support", version = "0.2" }
 aes-gcm = { workspace = true }
 utoipa = { workspace = true }

--- a/vta-vault/Cargo.toml
+++ b/vta-vault/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-vault"
 description = "VTA holder credential vault — storage, query, receive/verify, present, and status refresh for credentials a holder stores on a VTA"
 readme = "README.md"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-vault/Cargo.toml
+++ b/vta-vault/Cargo.toml
@@ -25,7 +25,7 @@ webvh = ["dep:reqwest", "vta-sdk/client"]
 [dependencies]
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.1" }
 vti-common = { path = "../vti-common", version = "0.11", features = ["encryption"] }
-vta-sdk = { path = "../vta-sdk", version = "0.20", features = ["didcomm", "sealed-transfer"] }
+vta-sdk = { path = "../vta-sdk", version = "0.21", features = ["didcomm", "sealed-transfer"] }
 affinidi-crypto = { workspace = true }
 affinidi-secrets-resolver = { workspace = true }
 affinidi-data-integrity = { workspace = true }

--- a/vta-webvh/Cargo.toml
+++ b/vta-webvh/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-webvh"
 description = "WebVH hosting infrastructure for the VTA — the DID-record store, the HTTP client to a did:webvh hosting server, and its DID-auth handshake"
 readme = "README.md"
-version = "0.1.2"
+version = "0.1.3"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-webvh/Cargo.toml
+++ b/vta-webvh/Cargo.toml
@@ -13,7 +13,7 @@ repository.workspace = true
 [dependencies]
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.1" }
 vti-common = { path = "../vti-common", version = "0.11" }
-vta-sdk = { path = "../vta-sdk", version = "0.20" }
+vta-sdk = { path = "../vta-sdk", version = "0.21" }
 affinidi-tdk = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/vtc-client/Cargo.toml
+++ b/vtc-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vtc-client"
 description = "Client SDK for Verifiable Trust Communities (VTC) — auth, members, join, removal, policies"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vtc-client/Cargo.toml
+++ b/vtc-client/Cargo.toml
@@ -14,7 +14,7 @@ repository.workspace = true
 # Reuses the VTA SDK's challenge-response auth (audience-agnostic) and the
 # published join-request protocol types. `session` gates `auth_light` +
 # `protocols`.
-vta-sdk = { path = "../vta-sdk", version = "0.20", features = ["session"] }
+vta-sdk = { path = "../vta-sdk", version = "0.21", features = ["session"] }
 # `TrustTask` — the join-submit document this client signs, and the `#response`
 # envelope the VTC answers it with. Same crate `vta-sdk` builds the document
 # from, so one shape crosses the boundary.

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.11.49"
+version = "0.11.50"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -109,7 +109,7 @@ vti-common = { path = "../vti-common", version = "0.11", features = [
 # factory + `*SecretStore` names are a thin facade over these). Per-backend
 # features are activated by this crate's matching features above.
 vti-secrets = { path = "../vti-secrets", version = "0.1" }
-vta-sdk = { path = "../vta-sdk", version = "0.20", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.21", features = [
   "didcomm",
   "session",
   "config-session",

--- a/vti-common/Cargo.toml
+++ b/vti-common/Cargo.toml
@@ -48,7 +48,7 @@ openapi = ["dep:utoipa", "dep:utoipa-axum"]
 # `default-features = false` skips the optional client transports
 # (didcomm, sealed-transfer, etc.); we only consume the type
 # definitions in the default feature set.
-vta-sdk = { path = "../vta-sdk", version = "0.20", default-features = false }
+vta-sdk = { path = "../vta-sdk", version = "0.21", default-features = false }
 async-trait = "0.1"
 # Durable OutboxStore backend (`outbox_store::VtiOutboxStore`) for the D1
 # delivery layer — the Guaranteed-send outbox, persisted via `store::Store`.

--- a/vti-common/Cargo.toml
+++ b/vti-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-common"
 description = "Shared server-side infrastructure for VTA and VTC services"
 readme = "README.md"
-version = "0.11.31"
+version = "0.11.32"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vti-secrets/Cargo.toml
+++ b/vti-secrets/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-secrets"
 description = "Pluggable secret-store backends + integration onboarding flow for Verifiable Trust Infrastructure"
 readme = "README.md"
-version = "0.1.8"
+version = "0.1.9"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vti-secrets/Cargo.toml
+++ b/vti-secrets/Cargo.toml
@@ -54,7 +54,7 @@ tracing = { workspace = true }
 tokio = { workspace = true }
 
 # Onboarding feature: the SDK session/auth state machine + local did:key mint.
-vta-sdk = { path = "../vta-sdk", version = "0.20", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.21", features = [
   "session",
 ], optional = true }
 ed25519-dalek = { workspace = true, optional = true }


### PR DESCRIPTION
Takes `ed25519-dalek` 2 → 3, `x25519-dalek` 2 → 3, `curve25519-dalek` 4 → 5 and
`hpke` 0.13 → 0.14. These shipped together on 2026-07-06 (hpke on 07-09) and drag
the next-generation RustCrypto stack with them: rand_core 0.10, signature 3,
ed25519 3, aead 0.6.

## Why

`vta-sdk` is the single reason `curve25519-dalek` 4 cannot leave the
affinidi-tdk-rs graph. It pinned `curve25519-dalek = "4"` directly plus
ed25519-dalek 2, x25519-dalek 2 and hpke 0.13, and every TDK consumer inherits
that through the mediator.

## Notable pieces

- **`sealed_transfer::hpke` loses the hand-rolled `OsCsprng` adapter.** It
  existed only to bridge `getrandom` onto hpke 0.13's rand_core 0.9 traits.
  hpke 0.14 is on rand_core 0.10 and ships OS-CSPRNG variants of
  `single_shot_seal` / `gen_keypair` backed by `UnwrapErr(SysRng)` — the same
  panic-on-CSPRNG-failure posture the adapter documented. Security behaviour is
  unchanged and the wire format is untouched.
- **rand 0.10 renamed `OsRng` → `SysRng` and made it *fallible***
  (`TryRng<Error = SysError>`), so it no longer satisfies dalek's `CryptoRng`
  bound. Key-generation sites move to `rand::rng()`.
- **`ed25519-dalek-bip32` 0.3 (last released 2023-08) still pins ed25519-dalek 2**
  and has no v3 release, so it keeps its own dalek-2 subtree inside
  vta-service / vta-keys / didcomm-test. That is contained: the crate is absent
  from `vta-sdk`'s dependency tree, so it never reaches TDK consumers. Two places
  passed a bip32 `SigningKey` straight into a workspace (v3) slot — they now
  cross the boundary as raw bytes, which is what every other derivation site here
  already did. Replacing that crate means reimplementing SLIP-0010 ed25519
  derivation; security-sensitive, so it is deliberately **not** in this PR.

## BREAKING

Dalek types appear in public signatures —
`vta_sdk::protocols::acl_management::swap::build_swap_presentation` takes
`&ed25519_dalek::SigningKey` — so callers must move to ed25519-dalek 3 in step.
Versions: `vta-sdk` 0.21.0, `vta-keys` 0.2.0, `vta-service` 0.14.0.

## ⚠️ This cannot merge on its own — 4-step cross-repo sequence

`curve25519-dalek` 4 does **not** leave this workspace until the `affinidi-*`
crates publish on dalek 3; they are the other source inside `vta-sdk`'s own tree.

1. **affinidi-tdk-rs** publishes the leaf crypto crates on dalek 3
   (affinidi-crypto, -secrets-resolver, -did-common, -data-integrity,
   -messaging-didcomm, -tsp, -oid4vc-core, -mdoc). `affinidi-crypto` breaks
   publicly (`PrivateKeyAgreement::X25519` holds an `x25519_dalek::StaticSecret`)
   so it must go **0.3.0**, not 0.2.6 — which this repo's `affinidi-crypto = "0.2"`
   pin excludes, so those pins move too.
2. **This PR** → publish `vta-sdk` 0.21.0.
3. **affinidi-tdk-rs** `affinidi-messaging-mediator` bumps its `vta-sdk ^0.20.0`
   requirement to `^0.21` and publishes.
4. **Here** `cargo update -p affinidi-messaging-mediator --precise <new>` — only
   then does the registry `vta-sdk` node, and with it dalek 4, leave the graph.

Steps 3–4 exist because bumping to 0.21 makes `[patch.crates-io] vta-sdk` stop
applying (mediator 0.18.0 requires `^0.20.0`), so the registry copy at 0.20.32
returns and brings dalek 4 back. `scripts/check-lockfile-self-pins.sh` catches
this and is **not** PR-only, so **`lockfile-self-pins` will be red until step 3
lands.** That is expected, not a defect in this branch.

## Verification

- `cargo check --workspace --all-features --all-targets` clean
- `cargo fmt --all --check` clean; clippy clean (the one `type_complexity`
  warning is pre-existing in `vta-vault/src/bbs.rs`, untouched here)
- **4191 tests pass.** 16 fail, and all 16 reproduce identically on a clean
  `origin/main` worktree — 8 in vta-sdk (`provision_client_e2e` ×3,
  `session_store` ×5) and 8 `vtc-service keys::seed_store::tests::*`
  (`--all-features` artifacts: they assert an error when a feature is *not*
  compiled). Zero regressions from this change.

## Also in this PR

A separate first commit fixes `vta-sdk/tests/session_store.rs`, which **does not
compile on `main` today**: `resolve_vta_endpoint_falls_back_to_rest_for_did_web`
matched only `Rest`/`DIDComm`, but `VtaEndpoint` is `#[non_exhaustive]` and gained
`Tsp` in 0.20 — its own doc comment says "Match with a `_` arm". It took the whole
`session_store` target, and therefore any `--all-targets` run of the crate, with
it. The fix is independent of the upgrade and is split out accordingly.