### PR TITLE
feat(keys)!: fold the keys surface onto canonical keys/*

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2530,7 +2530,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.21.0",
+ "vta-sdk 0.21.1",
 ]
 
 [[package]]
@@ -3339,7 +3339,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.21.0",
+ "vta-sdk 0.21.1",
 ]
 
 [[package]]
@@ -6896,7 +6896,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.21.0",
+ "vta-sdk 0.21.1",
 ]
 
 [[package]]
@@ -9758,9 +9758,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-rs"
-version = "0.2.51"
+version = "0.2.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e0b56c949946c8b79072036414e3d18fc0b87f5edd309311282d17e9a780510"
+checksum = "ac070d1bc7b9d1c570b3975abac38eb8411d8b7b4898cebaf3d162d0654c94d1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -10277,7 +10277,7 @@ version = "0.1.2"
 dependencies = [
  "tracing",
  "uuid",
- "vta-sdk 0.21.0",
+ "vta-sdk 0.21.1",
  "vti-common",
 ]
 
@@ -10303,7 +10303,7 @@ dependencies = [
  "vta-config",
  "vta-keys",
  "vta-keyspaces",
- "vta-sdk 0.21.0",
+ "vta-sdk 0.21.1",
  "vta-support",
  "vta-webvh",
  "vti-common",
@@ -10330,7 +10330,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.19",
  "tokio",
- "vta-sdk 0.21.0",
+ "vta-sdk 0.21.1",
  "vti-common",
  "x25519-dalek 3.0.0",
 ]
@@ -10390,7 +10390,7 @@ dependencies = [
  "uuid",
  "vta-config",
  "vta-keyspaces",
- "vta-sdk 0.21.0",
+ "vta-sdk 0.21.1",
  "vti-common",
  "vti-secrets",
  "x25519-dalek 3.0.0",
@@ -10417,7 +10417,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.21.0",
+ "vta-sdk 0.21.1",
 ]
 
 [[package]]
@@ -10442,7 +10442,7 @@ dependencies = [
  "trust-tasks-proof",
  "trust-tasks-rs",
  "uniffi",
- "vta-sdk 0.21.0",
+ "vta-sdk 0.21.1",
 ]
 
 [[package]]
@@ -10501,7 +10501,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10563,7 +10563,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",
@@ -10645,7 +10645,7 @@ dependencies = [
  "vta-keys",
  "vta-keyspaces",
  "vta-policy",
- "vta-sdk 0.21.0",
+ "vta-sdk 0.21.1",
  "vta-service",
  "vta-support",
  "vta-sweepers",
@@ -10678,7 +10678,7 @@ dependencies = [
  "tracing",
  "vta-config",
  "vta-keyspaces",
- "vta-sdk 0.21.0",
+ "vta-sdk 0.21.1",
  "vti-common",
 ]
 
@@ -10756,7 +10756,7 @@ dependencies = [
  "tracing",
  "uuid",
  "vta-keyspaces",
- "vta-sdk 0.21.0",
+ "vta-sdk 0.21.1",
  "vti-common",
 ]
 
@@ -10775,7 +10775,7 @@ dependencies = [
  "tracing",
  "url",
  "vta-keyspaces",
- "vta-sdk 0.21.0",
+ "vta-sdk 0.21.1",
  "vti-common",
  "wiremock",
  "zeroize",
@@ -10792,7 +10792,7 @@ dependencies = [
  "thiserror 2.0.19",
  "tokio",
  "trust-tasks-rs",
- "vta-sdk 0.21.0",
+ "vta-sdk 0.21.1",
 ]
 
 [[package]]
@@ -10866,7 +10866,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.21.0",
+ "vta-sdk 0.21.1",
  "vtc-client",
  "vtc-service",
  "vti-common",
@@ -10919,7 +10919,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.21.0",
+ "vta-sdk 0.21.1",
  "webauthn-rs",
  "zeroize",
 ]
@@ -10946,7 +10946,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.21.0",
+ "vta-sdk 0.21.1",
  "vta-service",
  "vti-common",
 ]
@@ -10976,7 +10976,7 @@ dependencies = [
  "toml 1.1.4+spec-1.1.0",
  "tracing",
  "vaultrs",
- "vta-sdk 0.21.0",
+ "vta-sdk 0.21.1",
  "vti-common",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -352,9 +352,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-mediator"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cdd9b715dda0d25b9fa5afce0ea96540e5e5fc4067503357c08126ab40d3f59"
+checksum = "f332431a1186288f0f121974e37a96dc7130adf2b5c141f36267f681dbab56a0"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-common",
@@ -412,7 +412,7 @@ dependencies = [
  "trust-tasks-rs",
  "url",
  "uuid",
- "vta-sdk 0.20.32",
+ "vta-sdk",
 ]
 
 [[package]]
@@ -2530,7 +2530,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.21.1",
+ "vta-sdk",
 ]
 
 [[package]]
@@ -3339,7 +3339,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.21.1",
+ "vta-sdk",
 ]
 
 [[package]]
@@ -6896,7 +6896,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
- "vta-sdk 0.21.1",
+ "vta-sdk",
 ]
 
 [[package]]
@@ -10277,7 +10277,7 @@ version = "0.1.2"
 dependencies = [
  "tracing",
  "uuid",
- "vta-sdk 0.21.1",
+ "vta-sdk",
  "vti-common",
 ]
 
@@ -10303,7 +10303,7 @@ dependencies = [
  "vta-config",
  "vta-keys",
  "vta-keyspaces",
- "vta-sdk 0.21.1",
+ "vta-sdk",
  "vta-support",
  "vta-webvh",
  "vti-common",
@@ -10330,7 +10330,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.19",
  "tokio",
- "vta-sdk 0.21.1",
+ "vta-sdk",
  "vti-common",
  "x25519-dalek 3.0.0",
 ]
@@ -10390,7 +10390,7 @@ dependencies = [
  "uuid",
  "vta-config",
  "vta-keyspaces",
- "vta-sdk 0.21.1",
+ "vta-sdk",
  "vti-common",
  "vti-secrets",
  "x25519-dalek 3.0.0",
@@ -10417,7 +10417,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.21.1",
+ "vta-sdk",
 ]
 
 [[package]]
@@ -10442,7 +10442,7 @@ dependencies = [
  "trust-tasks-proof",
  "trust-tasks-rs",
  "uniffi",
- "vta-sdk 0.21.1",
+ "vta-sdk",
 ]
 
 [[package]]
@@ -10461,42 +10461,6 @@ dependencies = [
  "vta-config",
  "vta-keyspaces",
  "vti-common",
-]
-
-[[package]]
-name = "vta-sdk"
-version = "0.20.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "948774795d04846e6e4d70e18069dfb12294c2213e7195ad0938e685c837866a"
-dependencies = [
- "affinidi-crypto",
- "affinidi-data-integrity",
- "affinidi-did-resolver-cache-sdk",
- "affinidi-messaging-core",
- "affinidi-messaging-delivery",
- "affinidi-messaging-didcomm",
- "affinidi-openid4vci",
- "affinidi-openid4vp",
- "affinidi-secrets-resolver",
- "affinidi-tdk",
- "base64 0.22.1",
- "chrono",
- "curve25519-dalek 4.1.3",
- "didwebvh-rs",
- "ed25519-dalek 2.2.0",
- "futures-util",
- "getrandom 0.4.3",
- "multibase",
- "reqwest 0.13.4",
- "serde",
- "serde_json",
- "sha2 0.11.0",
- "thiserror 2.0.19",
- "tokio",
- "tracing",
- "trust-tasks-rs",
- "url",
- "uuid",
 ]
 
 [[package]]
@@ -10645,7 +10609,7 @@ dependencies = [
  "vta-keys",
  "vta-keyspaces",
  "vta-policy",
- "vta-sdk 0.21.1",
+ "vta-sdk",
  "vta-service",
  "vta-support",
  "vta-sweepers",
@@ -10678,7 +10642,7 @@ dependencies = [
  "tracing",
  "vta-config",
  "vta-keyspaces",
- "vta-sdk 0.21.1",
+ "vta-sdk",
  "vti-common",
 ]
 
@@ -10756,7 +10720,7 @@ dependencies = [
  "tracing",
  "uuid",
  "vta-keyspaces",
- "vta-sdk 0.21.1",
+ "vta-sdk",
  "vti-common",
 ]
 
@@ -10775,7 +10739,7 @@ dependencies = [
  "tracing",
  "url",
  "vta-keyspaces",
- "vta-sdk 0.21.1",
+ "vta-sdk",
  "vti-common",
  "wiremock",
  "zeroize",
@@ -10792,7 +10756,7 @@ dependencies = [
  "thiserror 2.0.19",
  "tokio",
  "trust-tasks-rs",
- "vta-sdk 0.21.1",
+ "vta-sdk",
 ]
 
 [[package]]
@@ -10866,7 +10830,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.21.1",
+ "vta-sdk",
  "vtc-client",
  "vtc-service",
  "vti-common",
@@ -10919,7 +10883,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.21.1",
+ "vta-sdk",
  "webauthn-rs",
  "zeroize",
 ]
@@ -10946,7 +10910,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.21.1",
+ "vta-sdk",
  "vta-service",
  "vti-common",
 ]
@@ -10976,7 +10940,7 @@ dependencies = [
  "toml 1.1.4+spec-1.1.0",
  "tracing",
  "vaultrs",
- "vta-sdk 0.21.1",
+ "vta-sdk",
  "vti-common",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -212,7 +212,7 @@ aws-lc-rs = "1.16"
 # (camelCase wire enums + `/0.2` TYPE_URIs) alongside the retained
 # `v0_1` modules — the VTA dual-accepts both during the migration.
 # Bump in lockstep with affinidi-webvh-service when upstream publishes.
-trust-tasks-rs = { version = "0.2.51", default-features = false, features = ["validate"] }
+trust-tasks-rs = { version = "0.2.53", default-features = false, features = ["validate"] }
 trust-tasks-capability-client = "0.1"
 trust-tasks-https = { version = "0.2", default-features = false, features = ["server", "client", "jwt"] }
 trust-tasks-proof = { version = "0.2", default-features = false, features = ["affinidi"] }

--- a/changelog.d/888-keys-canonical-fold.md
+++ b/changelog.d/888-keys-canonical-fold.md
@@ -1,0 +1,63 @@
+### vta-sdk 0.21.1 / vta-service 0.14.1 — the keys surface folds onto canonical `keys/*` (#888)
+
+**Breaking.** The VTA now emits the canonical key shapes on **every** transport:
+camelCase members, and the single-record responses (`create`, `show`, `import`)
+wrapped as `{ key }`. Snake_case is still accepted on *intake* via serde aliases,
+so a producer written against the old spelling keeps working — but a consumer
+reading responses must be rebuilt. `pnm` needs a rebuild for `keys` commands.
+
+This is phase D of the canonical-task reduction. The specs were authored upstream
+first (`trustoverip/dtgwg-trust-tasks-tf` #167, #169) and published as
+`trust-tasks-rs` 0.2.53; this binds them.
+
+## What moved
+
+| Was | Now |
+|---|---|
+| `vta/keys/{list,create,get,rename,revoke,sign,derive-and-sign,derive-and-sign-document}/1.0` | `keys/{list,create,show,rename,revoke,sign,derive-and-sign,derive-and-sign-document}/0.1` |
+| *(no task)* | `keys/import/0.1` — new binding |
+
+Nine entries leave `UNSPECCED_DISPATCHED_URIS`, which is the metric that
+programme tracks. `SignAlgorithm` moves to the IANA JOSE spellings (`EdDSA`,
+`ES256`) with the lowercase forms accepted on intake.
+
+## `keys/import` refuses the cleartext carrier
+
+The new task accepts `privateKeySealed` and `privateKeyJwe` and **refuses
+`privateKeyMultibase` outright**. One dispatcher serves the trust-task surface
+over REST, DIDComm *and* TSP, so a handler there cannot tell whether the request
+travelled end to end — and cleartext is admissible only where it did. Refusing is
+the only reading that cannot leak a key.
+
+The client forks on the same line: a sealed or JWE carrier rides the canonical
+task (so it reaches TSP); a raw multibase key stays on the legacy DIDComm
+message, where authcrypt has already established the guarantee. No capability is
+lost, and none moves to a transport that cannot carry it safely.
+
+## What conformance caught
+
+The round-trip harness rejected the first cut of the spec:
+
+```
+keys/create/0.1: request is not canonical: unknown field `mnemonic`
+```
+
+`create_key` has always been able to derive from a caller-supplied BIP-39 phrase,
+and the published schema had no member for it. Binding the task as it stood would
+have compiled cleanly and **silently dropped the capability** — create-from-a-phrase
+would have kept "working" while deriving from the wrong seed. Fixed at the source
+(#169), which is why the dependency is 0.2.53 rather than 0.2.52.
+
+That is the second time in this programme that a hand-rolled client payload has
+been the defect (after `update_acl` in #884), so `create_key`, `list_keys` and
+`import_key` now build their task payloads from the canonical Rust bodies rather
+than a `json!` map. A member that exists in the type but not in the map is a
+compile error; a member that exists in neither is a schema failure. Neither is
+silence.
+
+**Testing.** Nine conformance witnesses — every task in the family round-trips
+through its generated `Payload`/`Response` types. `tests/e2e/tests/client_didcomm.rs`
+pins the canonical envelope and the sealed-vs-multibase import fork, including
+the assertion that the cleartext carrier never rides the canonical task.
+`vta-sdk/tests/client_rest.rs` moves its fixtures to the canonical shape; the
+imported-key fixture carries `origin: "imported"` so a broken mapping cannot pass.

--- a/ci-test.log
+++ b/ci-test.log
@@ -1,0 +1,5496 @@
+﻿2026-08-01T02:30:12.9871088Z Current runner version: '2.336.0'
+2026-08-01T02:30:12.9897261Z ##[group]Runner Image Provisioner
+2026-08-01T02:30:12.9898241Z Hosted Compute Agent
+2026-08-01T02:30:12.9898862Z Version: 20260707.563
+2026-08-01T02:30:12.9899492Z Commit: 02667638d2b423fbc733a8e32a88b44996a3ba6e
+2026-08-01T02:30:12.9900273Z Build Date: 2026-07-07T19:33:50Z
+2026-08-01T02:30:12.9900995Z Worker ID: {149fa032-7a03-4842-a088-23ce1fa83323}
+2026-08-01T02:30:12.9901700Z Azure Region: northcentralus
+2026-08-01T02:30:12.9902655Z ##[endgroup]
+2026-08-01T02:30:12.9904059Z ##[group]Operating System
+2026-08-01T02:30:12.9904762Z Ubuntu
+2026-08-01T02:30:12.9905359Z 24.04.4
+2026-08-01T02:30:12.9905885Z LTS
+2026-08-01T02:30:12.9906468Z ##[endgroup]
+2026-08-01T02:30:12.9907031Z ##[group]Runner Image
+2026-08-01T02:30:12.9907634Z Image: ubuntu-24.04
+2026-08-01T02:30:12.9908317Z Version: 20260720.247.2
+2026-08-01T02:30:12.9909588Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20260720.247/images/ubuntu/Ubuntu2404-Readme.md
+2026-08-01T02:30:12.9911182Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20260720.247
+2026-08-01T02:30:12.9912341Z ##[endgroup]
+2026-08-01T02:30:12.9915528Z ##[group]GITHUB_TOKEN Permissions
+2026-08-01T02:30:12.9917691Z Actions: write
+2026-08-01T02:30:12.9918593Z ArtifactMetadata: write
+2026-08-01T02:30:12.9919225Z Attestations: write
+2026-08-01T02:30:12.9919890Z Checks: write
+2026-08-01T02:30:12.9920483Z CodeQuality: write
+2026-08-01T02:30:12.9921070Z Contents: write
+2026-08-01T02:30:12.9921702Z CopilotRequests: write
+2026-08-01T02:30:12.9922552Z Deployments: write
+2026-08-01T02:30:12.9923105Z Discussions: write
+2026-08-01T02:30:12.9923775Z Drives: write
+2026-08-01T02:30:12.9924324Z Issues: write
+2026-08-01T02:30:12.9924901Z Metadata: read
+2026-08-01T02:30:12.9925601Z Models: read
+2026-08-01T02:30:12.9926166Z Packages: write
+2026-08-01T02:30:12.9926793Z Pages: write
+2026-08-01T02:30:12.9927374Z PullRequests: write
+2026-08-01T02:30:12.9928014Z RepositoryProjects: write
+2026-08-01T02:30:12.9928665Z SecurityEvents: write
+2026-08-01T02:30:12.9929286Z Statuses: write
+2026-08-01T02:30:12.9929901Z VulnerabilityAlerts: read
+2026-08-01T02:30:12.9930519Z ##[endgroup]
+2026-08-01T02:30:12.9933316Z Secret source: Actions
+2026-08-01T02:30:12.9934482Z Prepare workflow directory
+2026-08-01T02:30:13.0463205Z Prepare all required actions
+2026-08-01T02:30:13.0530561Z Getting action download info
+2026-08-01T02:30:13.2819333Z Download action repository 'actions/checkout@v6' (SHA:d23441a48e516b6c34aea4fa41551a30e30af803)
+2026-08-01T02:30:13.6589470Z Download action repository 'dtolnay/rust-toolchain@stable' (SHA:4cda84d5c5c54efe2404f9d843567869ab1699d4)
+2026-08-01T02:30:13.7849911Z Download action repository 'actions/cache@v5' (SHA:caa296126883cff596d87d8935842f9db880ef25)
+2026-08-01T02:30:14.0891364Z Complete job name: Test
+2026-08-01T02:30:14.1673528Z ##[group]Run actions/checkout@v6
+2026-08-01T02:30:14.1674485Z with:
+2026-08-01T02:30:14.1675032Z   repository: OpenVTC/verifiable-trust-infrastructure
+2026-08-01T02:30:14.1679415Z   token: ***
+2026-08-01T02:30:14.1679876Z   ssh-strict: true
+2026-08-01T02:30:14.1680347Z   ssh-user: git
+2026-08-01T02:30:14.1680813Z   persist-credentials: true
+2026-08-01T02:30:14.1681350Z   clean: true
+2026-08-01T02:30:14.1681821Z   sparse-checkout-cone-mode: true
+2026-08-01T02:30:14.1682517Z   fetch-depth: 1
+2026-08-01T02:30:14.1682973Z   fetch-tags: false
+2026-08-01T02:30:14.1683431Z   show-progress: true
+2026-08-01T02:30:14.1683898Z   lfs: false
+2026-08-01T02:30:14.1684336Z   submodules: false
+2026-08-01T02:30:14.1684816Z   set-safe-directory: true
+2026-08-01T02:30:14.1685344Z   allow-unsafe-pr-checkout: false
+2026-08-01T02:30:14.1686075Z env:
+2026-08-01T02:30:14.1686504Z   CARGO_TERM_COLOR: always
+2026-08-01T02:30:14.1687002Z ##[endgroup]
+2026-08-01T02:30:14.2722678Z Syncing repository: OpenVTC/verifiable-trust-infrastructure
+2026-08-01T02:30:14.2725102Z ##[group]Getting Git version info
+2026-08-01T02:30:14.2726231Z Working directory is '/home/runner/work/verifiable-trust-infrastructure/verifiable-trust-infrastructure'
+2026-08-01T02:30:14.2728247Z [command]/usr/bin/git version
+2026-08-01T02:30:14.2753497Z git version 2.54.0
+2026-08-01T02:30:14.2784031Z ##[endgroup]
+2026-08-01T02:30:14.2794545Z Temporarily overriding HOME='/home/runner/work/_temp/dc0e77a7-e164-44cf-8691-f2a5f6bf92cd' before making global git config changes
+2026-08-01T02:30:14.2797120Z Adding repository directory to the temporary git global config as a safe directory
+2026-08-01T02:30:14.2802035Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/verifiable-trust-infrastructure/verifiable-trust-infrastructure
+2026-08-01T02:30:14.2849250Z Deleting the contents of '/home/runner/work/verifiable-trust-infrastructure/verifiable-trust-infrastructure'
+2026-08-01T02:30:14.2853564Z ##[group]Determining repository object format
+2026-08-01T02:30:14.2856158Z ##[endgroup]
+2026-08-01T02:30:14.2857065Z ##[group]Initializing the repository
+2026-08-01T02:30:14.2861033Z [command]/usr/bin/git init /home/runner/work/verifiable-trust-infrastructure/verifiable-trust-infrastructure
+2026-08-01T02:30:14.2947437Z hint: Using 'master' as the name for the initial branch. This default branch name
+2026-08-01T02:30:14.2949745Z hint: will change to "main" in Git 3.0. To configure the initial branch name
+2026-08-01T02:30:14.2951616Z hint: to use in all of your new repositories, which will suppress this warning,
+2026-08-01T02:30:14.2953484Z hint: call:
+2026-08-01T02:30:14.2954711Z hint:
+2026-08-01T02:30:14.2955701Z hint: 	git config --global init.defaultBranch <name>
+2026-08-01T02:30:14.2956792Z hint:
+2026-08-01T02:30:14.2957821Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+2026-08-01T02:30:14.2959464Z hint: 'development'. The just-created branch can be renamed via this command:
+2026-08-01T02:30:14.2960737Z hint:
+2026-08-01T02:30:14.2961522Z hint: 	git branch -m <name>
+2026-08-01T02:30:14.2962631Z hint:
+2026-08-01T02:30:14.2963768Z hint: Disable this message with "git config set advice.defaultBranchName false"
+2026-08-01T02:30:14.2966126Z Initialized empty Git repository in /home/runner/work/verifiable-trust-infrastructure/verifiable-trust-infrastructure/.git/
+2026-08-01T02:30:14.2969783Z [command]/usr/bin/git remote add origin https://github.com/OpenVTC/verifiable-trust-infrastructure
+2026-08-01T02:30:14.3008233Z ##[endgroup]
+2026-08-01T02:30:14.3009535Z ##[group]Disabling automatic garbage collection
+2026-08-01T02:30:14.3013178Z [command]/usr/bin/git config --local gc.auto 0
+2026-08-01T02:30:14.3048218Z ##[endgroup]
+2026-08-01T02:30:14.3049517Z ##[group]Setting up auth
+2026-08-01T02:30:14.3050438Z Removing SSH command configuration
+2026-08-01T02:30:14.3056989Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+2026-08-01T02:30:14.3097304Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+2026-08-01T02:30:14.3439797Z Removing HTTP extra header
+2026-08-01T02:30:14.3446910Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+2026-08-01T02:30:14.3483454Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+2026-08-01T02:30:14.3724626Z Removing includeIf entries pointing to credentials config files
+2026-08-01T02:30:14.3726497Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+2026-08-01T02:30:14.3761250Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+2026-08-01T02:30:14.4006401Z [command]/usr/bin/git config --file /home/runner/work/_temp/git-credentials-08490eff-5acd-4870-9e07-5f18f662d4df.config http.https://github.com/.extraheader AUTHORIZATION: basic ***
+2026-08-01T02:30:14.4049212Z [command]/usr/bin/git config --local includeIf.gitdir:/home/runner/work/verifiable-trust-infrastructure/verifiable-trust-infrastructure/.git.path /home/runner/work/_temp/git-credentials-08490eff-5acd-4870-9e07-5f18f662d4df.config
+2026-08-01T02:30:14.4083791Z [command]/usr/bin/git config --local includeIf.gitdir:/home/runner/work/verifiable-trust-infrastructure/verifiable-trust-infrastructure/.git/worktrees/*.path /home/runner/work/_temp/git-credentials-08490eff-5acd-4870-9e07-5f18f662d4df.config
+2026-08-01T02:30:14.4125233Z [command]/usr/bin/git config --local includeIf.gitdir:/github/workspace/.git.path /github/runner_temp/git-credentials-08490eff-5acd-4870-9e07-5f18f662d4df.config
+2026-08-01T02:30:14.4159626Z [command]/usr/bin/git config --local includeIf.gitdir:/github/workspace/.git/worktrees/*.path /github/runner_temp/git-credentials-08490eff-5acd-4870-9e07-5f18f662d4df.config
+2026-08-01T02:30:14.4189557Z ##[endgroup]
+2026-08-01T02:30:14.4190824Z ##[group]Fetching the repository
+2026-08-01T02:30:14.4200414Z [command]/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +6d9861dae893237058e55f5eeb45089701bded53:refs/remotes/pull/888/merge
+2026-08-01T02:30:15.5040006Z From https://github.com/OpenVTC/verifiable-trust-infrastructure
+2026-08-01T02:30:15.5043188Z  * [new ref]         6d9861dae893237058e55f5eeb45089701bded53 -> pull/888/merge
+2026-08-01T02:30:15.5075375Z ##[endgroup]
+2026-08-01T02:30:15.5076873Z ##[group]Determining the checkout info
+2026-08-01T02:30:15.5078492Z ##[endgroup]
+2026-08-01T02:30:15.5081778Z [command]/usr/bin/git sparse-checkout disable
+2026-08-01T02:30:15.5127332Z [command]/usr/bin/git config --local --unset-all extensions.worktreeConfig
+2026-08-01T02:30:15.5158071Z ##[group]Checking out the ref
+2026-08-01T02:30:15.5161201Z [command]/usr/bin/git checkout --progress --force refs/remotes/pull/888/merge
+2026-08-01T02:30:15.6483333Z Note: switching to 'refs/remotes/pull/888/merge'.
+2026-08-01T02:30:15.6485413Z 
+2026-08-01T02:30:15.6486982Z You are in 'detached HEAD' state. You can look around, make experimental
+2026-08-01T02:30:15.6490787Z changes and commit them, and you can discard any commits you make in this
+2026-08-01T02:30:15.6494811Z state without impacting any branches by switching back to a branch.
+2026-08-01T02:30:15.6497555Z 
+2026-08-01T02:30:15.6499107Z If you want to create a new branch to retain commits you create, you may
+2026-08-01T02:30:15.6502257Z do so (now or later) by using -c with the switch command. Example:
+2026-08-01T02:30:15.6503919Z 
+2026-08-01T02:30:15.6504664Z   git switch -c <new-branch-name>
+2026-08-01T02:30:15.6505983Z 
+2026-08-01T02:30:15.6506504Z Or undo this operation with:
+2026-08-01T02:30:15.6507291Z 
+2026-08-01T02:30:15.6507779Z   git switch -
+2026-08-01T02:30:15.6509230Z 
+2026-08-01T02:30:15.6510641Z Turn off this advice by setting config variable advice.detachedHead to false
+2026-08-01T02:30:15.6512313Z 
+2026-08-01T02:30:15.6513936Z HEAD is now at 6d9861d Merge 24355f8fc8267aa91c3826a88329d3f431fe3481 into 39a1bda2bd6e084f79c6b62ca212721a89e7a79f
+2026-08-01T02:30:15.6519667Z ##[endgroup]
+2026-08-01T02:30:15.6543930Z [command]/usr/bin/git log -1 --format=%H
+2026-08-01T02:30:15.6571005Z 6d9861dae893237058e55f5eeb45089701bded53
+2026-08-01T02:30:15.6839990Z ##[group]Run sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc
+2026-08-01T02:30:15.6842397Z [36;1msudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc[0m
+2026-08-01T02:30:15.6844007Z [36;1mdf -h /[0m
+2026-08-01T02:30:15.6898767Z shell: /usr/bin/bash -e {0}
+2026-08-01T02:30:15.6899905Z env:
+2026-08-01T02:30:15.6900808Z   CARGO_TERM_COLOR: always
+2026-08-01T02:30:15.6901879Z ##[endgroup]
+2026-08-01T02:31:13.8248162Z Filesystem      Size  Used Avail Use% Mounted on
+2026-08-01T02:31:13.8248781Z /dev/root       145G   42G  103G  29% /
+2026-08-01T02:31:13.8290160Z ##[group]Run sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
+2026-08-01T02:31:13.8290778Z [36;1msudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config[0m
+2026-08-01T02:31:13.8336583Z shell: /usr/bin/bash -e {0}
+2026-08-01T02:31:13.8336852Z env:
+2026-08-01T02:31:13.8337061Z   CARGO_TERM_COLOR: always
+2026-08-01T02:31:13.8337301Z ##[endgroup]
+2026-08-01T02:31:13.9773751Z Get:1 file:/etc/apt/apt-mirrors.txt Mirrorlist [144 B]
+2026-08-01T02:31:14.0179582Z Hit:6 https://packages.microsoft.com/repos/azure-cli noble InRelease
+2026-08-01T02:31:14.0180840Z Hit:2 http://azure.archive.ubuntu.com/ubuntu noble InRelease
+2026-08-01T02:31:14.0181899Z Get:7 https://packages.microsoft.com/ubuntu/24.04/prod noble InRelease [3600 B]
+2026-08-01T02:31:14.0243527Z Get:3 http://azure.archive.ubuntu.com/ubuntu noble-updates InRelease [126 kB]
+2026-08-01T02:31:14.0259594Z Get:8 https://dl.google.com/linux/chrome-stable/deb stable InRelease [2548 B]
+2026-08-01T02:31:14.0331812Z Get:4 http://azure.archive.ubuntu.com/ubuntu noble-backports InRelease [126 kB]
+2026-08-01T02:31:14.0344740Z Get:5 http://azure.archive.ubuntu.com/ubuntu noble-security InRelease [126 kB]
+2026-08-01T02:31:14.2614486Z Get:9 https://packages.microsoft.com/ubuntu/24.04/prod noble/main arm64 Packages [227 kB]
+2026-08-01T02:31:14.2837260Z Get:10 https://packages.microsoft.com/ubuntu/24.04/prod noble/main armhf Packages [11.7 kB]
+2026-08-01T02:31:14.2864860Z Get:11 https://packages.microsoft.com/ubuntu/24.04/prod noble/main amd64 Packages [261 kB]
+2026-08-01T02:31:14.3413193Z Get:12 https://dl.google.com/linux/chrome-stable/deb stable/main amd64 Packages [1409 B]
+2026-08-01T02:31:14.3764460Z Get:13 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 Packages [1154 kB]
+2026-08-01T02:31:14.3849806Z Get:14 http://azure.archive.ubuntu.com/ubuntu noble-updates/main Translation-en [278 kB]
+2026-08-01T02:31:14.3861023Z Get:15 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 Components [181 kB]
+2026-08-01T02:31:14.3923294Z Get:16 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 Packages [1681 kB]
+2026-08-01T02:31:14.4006015Z Get:17 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe Translation-en [334 kB]
+2026-08-01T02:31:14.4014527Z Get:18 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 Components [388 kB]
+2026-08-01T02:31:14.4047286Z Get:19 http://azure.archive.ubuntu.com/ubuntu noble-updates/restricted amd64 Packages [1367 kB]
+2026-08-01T02:31:14.4124612Z Get:20 http://azure.archive.ubuntu.com/ubuntu noble-updates/restricted Translation-en [308 kB]
+2026-08-01T02:31:14.4167629Z Get:21 http://azure.archive.ubuntu.com/ubuntu noble-updates/multiverse amd64 Packages [45.4 kB]
+2026-08-01T02:31:14.4184593Z Get:22 http://azure.archive.ubuntu.com/ubuntu noble-updates/multiverse Translation-en [12.3 kB]
+2026-08-01T02:31:14.4638947Z Get:23 http://azure.archive.ubuntu.com/ubuntu noble-updates/multiverse amd64 Components [940 B]
+2026-08-01T02:31:14.4650257Z Get:24 http://azure.archive.ubuntu.com/ubuntu noble-backports/main amd64 Components [5744 B]
+2026-08-01T02:31:14.4661466Z Get:25 http://azure.archive.ubuntu.com/ubuntu noble-backports/universe amd64 Packages [32.5 kB]
+2026-08-01T02:31:14.4674067Z Get:26 http://azure.archive.ubuntu.com/ubuntu noble-backports/universe amd64 Components [12.6 kB]
+2026-08-01T02:31:14.5112898Z Get:27 http://azure.archive.ubuntu.com/ubuntu noble-security/main amd64 Packages [897 kB]
+2026-08-01T02:31:14.5188471Z Get:28 http://azure.archive.ubuntu.com/ubuntu noble-security/main Translation-en [198 kB]
+2026-08-01T02:31:14.5207405Z Get:29 http://azure.archive.ubuntu.com/ubuntu noble-security/main amd64 Components [46.4 kB]
+2026-08-01T02:31:14.5220438Z Get:30 http://azure.archive.ubuntu.com/ubuntu noble-security/universe amd64 Packages [1199 kB]
+2026-08-01T02:31:14.5283608Z Get:31 http://azure.archive.ubuntu.com/ubuntu noble-security/universe Translation-en [239 kB]
+2026-08-01T02:31:14.5304653Z Get:32 http://azure.archive.ubuntu.com/ubuntu noble-security/universe amd64 Components [76.3 kB]
+2026-08-01T02:31:14.5320632Z Get:33 http://azure.archive.ubuntu.com/ubuntu noble-security/restricted amd64 Packages [1273 kB]
+2026-08-01T02:31:14.5416211Z Get:34 http://azure.archive.ubuntu.com/ubuntu noble-security/restricted Translation-en [290 kB]
+2026-08-01T02:31:14.5439104Z Get:35 http://azure.archive.ubuntu.com/ubuntu noble-security/multiverse amd64 Packages [40.3 kB]
+2026-08-01T02:31:14.5452180Z Get:36 http://azure.archive.ubuntu.com/ubuntu noble-security/multiverse Translation-en [10.6 kB]
+2026-08-01T02:31:21.9488134Z Fetched 11.0 MB in 2s (7114 kB/s)
+2026-08-01T02:31:22.6876526Z Reading package lists...
+2026-08-01T02:31:22.7208585Z Reading package lists...
+2026-08-01T02:31:22.9304868Z Building dependency tree...
+2026-08-01T02:31:22.9312289Z Reading state information...
+2026-08-01T02:31:23.1508821Z pkg-config is already the newest version (1.8.1-2build1).
+2026-08-01T02:31:23.1509922Z The following NEW packages will be installed:
+2026-08-01T02:31:23.1517326Z   libdbus-1-dev
+2026-08-01T02:31:23.1726462Z 0 upgraded, 1 newly installed, 0 to remove and 79 not upgraded.
+2026-08-01T02:31:23.1727073Z Need to get 190 kB of archives.
+2026-08-01T02:31:23.1727612Z After this operation, 1007 kB of additional disk space will be used.
+2026-08-01T02:31:23.1728332Z Get:1 file:/etc/apt/apt-mirrors.txt Mirrorlist [144 B]
+2026-08-01T02:31:23.2246188Z Get:2 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libdbus-1-dev amd64 1.14.10-4ubuntu4.1 [190 kB]
+2026-08-01T02:31:23.4989414Z Fetched 190 kB in 0s (2881 kB/s)
+2026-08-01T02:31:23.5456904Z Selecting previously unselected package libdbus-1-dev:amd64.
+2026-08-01T02:31:23.6271739Z (Reading database ... 
+2026-08-01T02:31:23.6272315Z (Reading database ... 5%
+2026-08-01T02:31:23.6272584Z (Reading database ... 10%
+2026-08-01T02:31:23.6272826Z (Reading database ... 15%
+2026-08-01T02:31:23.6273053Z (Reading database ... 20%
+2026-08-01T02:31:23.6273270Z (Reading database ... 25%
+2026-08-01T02:31:23.6273535Z (Reading database ... 30%
+2026-08-01T02:31:23.6273801Z (Reading database ... 35%
+2026-08-01T02:31:23.6274101Z (Reading database ... 40%
+2026-08-01T02:31:23.6274381Z (Reading database ... 45%
+2026-08-01T02:31:23.6274848Z (Reading database ... 50%
+2026-08-01T02:31:23.6610144Z (Reading database ... 55%
+2026-08-01T02:31:24.0384449Z (Reading database ... 60%
+2026-08-01T02:31:24.3509356Z (Reading database ... 65%
+2026-08-01T02:31:24.6476441Z (Reading database ... 70%
+2026-08-01T02:31:24.8929468Z (Reading database ... 75%
+2026-08-01T02:31:25.3960327Z (Reading database ... 80%
+2026-08-01T02:31:26.1000076Z (Reading database ... 85%
+2026-08-01T02:31:26.5290126Z (Reading database ... 90%
+2026-08-01T02:31:27.2175073Z (Reading database ... 95%
+2026-08-01T02:31:27.2175402Z (Reading database ... 100%
+2026-08-01T02:31:27.2175770Z (Reading database ... 202954 files and directories currently installed.)
+2026-08-01T02:31:27.2224291Z Preparing to unpack .../libdbus-1-dev_1.14.10-4ubuntu4.1_amd64.deb ...
+2026-08-01T02:31:27.2247756Z Unpacking libdbus-1-dev:amd64 (1.14.10-4ubuntu4.1) ...
+2026-08-01T02:31:27.2949647Z Setting up libdbus-1-dev:amd64 (1.14.10-4ubuntu4.1) ...
+2026-08-01T02:31:27.4533831Z Processing triggers for sgml-base (1.31) ...
+2026-08-01T02:31:28.5261698Z 
+2026-08-01T02:31:28.5262590Z Running kernel seems to be up-to-date.
+2026-08-01T02:31:28.5262850Z 
+2026-08-01T02:31:28.5262966Z No services need to be restarted.
+2026-08-01T02:31:28.5263147Z 
+2026-08-01T02:31:28.5263251Z No containers need to be restarted.
+2026-08-01T02:31:28.5263423Z 
+2026-08-01T02:31:28.5263550Z No user sessions are running outdated binaries.
+2026-08-01T02:31:28.5263755Z 
+2026-08-01T02:31:28.5263958Z No VM guests are running outdated hypervisor (qemu) binaries on this host.
+2026-08-01T02:31:29.6654094Z ##[group]Run dtolnay/rust-toolchain@stable
+2026-08-01T02:31:29.6654411Z with:
+2026-08-01T02:31:29.6654612Z   toolchain: stable
+2026-08-01T02:31:29.6654818Z env:
+2026-08-01T02:31:29.6655009Z   CARGO_TERM_COLOR: always
+2026-08-01T02:31:29.6655236Z ##[endgroup]
+2026-08-01T02:31:29.6746381Z ##[start-action display=Run : parse toolchain version;id=__dtolnay_rust-toolchain.parse]
+2026-08-01T02:31:29.6773352Z ##[group]Run : parse toolchain version
+2026-08-01T02:31:29.6773704Z [36;1m: parse toolchain version[0m
+2026-08-01T02:31:29.6774175Z [36;1mif [[ -z $toolchain ]]; then[0m
+2026-08-01T02:31:29.6774720Z [36;1m  # GitHub does not enforce `required: true` inputs itself. https://github.com/actions/runner/issues/1070[0m
+2026-08-01T02:31:29.6775297Z [36;1m  echo "'toolchain' is a required input" >&2[0m
+2026-08-01T02:31:29.6775598Z [36;1m  exit 1[0m
+2026-08-01T02:31:29.6775936Z [36;1melif [[ $toolchain =~ ^stable' '[0-9]+' '(year|month|week|day)s?' 'ago$ ]]; then[0m
+2026-08-01T02:31:29.6776407Z [36;1m  if [[ Linux == macOS ]]; then[0m
+2026-08-01T02:31:29.6776948Z [36;1m    echo "toolchain=1.$((($(date -v-$(sed 's/stable \([0-9]*\) \(.\).*/\1\2/' <<< $toolchain) +%s)/60/60/24-16569)/7/6))" >> $GITHUB_OUTPUT[0m
+2026-08-01T02:31:29.6777443Z [36;1m  else[0m
+2026-08-01T02:31:29.6777845Z [36;1m    echo "toolchain=1.$((($(date --date "${toolchain#stable }" +%s)/60/60/24-16569)/7/6))" >> $GITHUB_OUTPUT[0m
+2026-08-01T02:31:29.6778286Z [36;1m  fi[0m
+2026-08-01T02:31:29.6778585Z [36;1melif [[ $toolchain =~ ^stable' 'minus' '[0-9]+' 'releases?$ ]]; then[0m
+2026-08-01T02:31:29.6779110Z [36;1m  echo "toolchain=1.$((($(date +%s)/60/60/24-16569)/7/6-${toolchain//[^0-9]/}))" >> $GITHUB_OUTPUT[0m
+2026-08-01T02:31:29.6779557Z [36;1melif [[ $toolchain =~ ^1\.[0-9]+$ ]]; then[0m
+2026-08-01T02:31:29.6780063Z [36;1m  echo "toolchain=1.$((i=${toolchain#1.}, c=($(date +%s)/60/60/24-16569)/7/6, i+9*i*(10*i<=c)+90*i*(100*i<=c)))" >> $GITHUB_OUTPUT[0m
+2026-08-01T02:31:29.6780543Z [36;1melse[0m
+2026-08-01T02:31:29.6780790Z [36;1m  echo "toolchain=$toolchain" >> $GITHUB_OUTPUT[0m
+2026-08-01T02:31:29.6781087Z [36;1mfi[0m
+2026-08-01T02:31:29.6827023Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-08-01T02:31:29.6827370Z env:
+2026-08-01T02:31:29.6827575Z   CARGO_TERM_COLOR: always
+2026-08-01T02:31:29.6827821Z   toolchain: stable
+2026-08-01T02:31:29.6828031Z ##[endgroup]
+2026-08-01T02:31:29.6924945Z ##[end-action id=__dtolnay_rust-toolchain.parse;outcome=success;conclusion=success;duration_ms=17]
+2026-08-01T02:31:29.6947677Z ##[start-action display=Run : construct rustup command line;id=__dtolnay_rust-toolchain.flags]
+2026-08-01T02:31:29.6965867Z ##[group]Run : construct rustup command line
+2026-08-01T02:31:29.6966702Z [36;1m: construct rustup command line[0m
+2026-08-01T02:31:29.6967882Z [36;1mecho "targets=$(for t in ${targets//,/ }; do echo -n ' --target' $t; done)" >> $GITHUB_OUTPUT[0m
+2026-08-01T02:31:29.6968566Z [36;1mecho "components=$(for c in ${components//,/ }; do echo -n ' --component' $c; done)" >> $GITHUB_OUTPUT[0m
+2026-08-01T02:31:29.6969703Z [36;1mecho "downgrade=" >> $GITHUB_OUTPUT[0m
+2026-08-01T02:31:29.7014070Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-08-01T02:31:29.7014402Z env:
+2026-08-01T02:31:29.7014609Z   CARGO_TERM_COLOR: always
+2026-08-01T02:31:29.7014842Z   targets: 
+2026-08-01T02:31:29.7015037Z   components: 
+2026-08-01T02:31:29.7015239Z ##[endgroup]
+2026-08-01T02:31:29.7099411Z ##[end-action id=__dtolnay_rust-toolchain.flags;outcome=success;conclusion=success;duration_ms=15]
+2026-08-01T02:31:29.7103622Z ##[start-action display=Run : set $CARGO_HOME;id=__dtolnay_rust-toolchain.__run]
+2026-08-01T02:31:29.7147552Z ##[group]Run : set $CARGO_HOME
+2026-08-01T02:31:29.7147834Z [36;1m: set $CARGO_HOME[0m
+2026-08-01T02:31:29.7148163Z [36;1mecho CARGO_HOME=${CARGO_HOME:-"$HOME/.cargo"} >> $GITHUB_ENV[0m
+2026-08-01T02:31:29.7192253Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-08-01T02:31:29.7192620Z env:
+2026-08-01T02:31:29.7193069Z   CARGO_TERM_COLOR: always
+2026-08-01T02:31:29.7193305Z ##[endgroup]
+2026-08-01T02:31:29.7267437Z ##[end-action id=__dtolnay_rust-toolchain.__run;outcome=success;conclusion=success;duration_ms=16]
+2026-08-01T02:31:29.7269773Z ##[start-action display=Run : install rustup if needed;id=__dtolnay_rust-toolchain.__run_2]
+2026-08-01T02:31:29.7294340Z ##[group]Run : install rustup if needed
+2026-08-01T02:31:29.7294671Z [36;1m: install rustup if needed[0m
+2026-08-01T02:31:29.7294975Z [36;1mif ! command -v rustup &>/dev/null; then[0m
+2026-08-01T02:31:29.7295898Z [36;1m  curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused --location --silent --show-error --fail https://sh.rustup.rs | sh -s -- --default-toolchain none -y[0m
+2026-08-01T02:31:29.7296593Z [36;1m  echo "$CARGO_HOME/bin" >> $GITHUB_PATH[0m
+2026-08-01T02:31:29.7296873Z [36;1mfi[0m
+2026-08-01T02:31:29.7338696Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-08-01T02:31:29.7339032Z env:
+2026-08-01T02:31:29.7339251Z   CARGO_TERM_COLOR: always
+2026-08-01T02:31:29.7339494Z   CARGO_HOME: /home/runner/.cargo
+2026-08-01T02:31:29.7339786Z ##[endgroup]
+2026-08-01T02:31:29.7410833Z ##[end-action id=__dtolnay_rust-toolchain.__run_2;outcome=success;conclusion=success;duration_ms=13]
+2026-08-01T02:31:29.7415442Z ##[start-action display=Run : install rustup if needed on windows;id=__dtolnay_rust-toolchain.__run_3]
+2026-08-01T02:31:29.7423329Z ##[end-action id=__dtolnay_rust-toolchain.__run_3;outcome=skipped;conclusion=skipped;duration_ms=0]
+2026-08-01T02:31:29.7426670Z ##[start-action display=rustup toolchain install stable;id=__dtolnay_rust-toolchain.__run_4]
+2026-08-01T02:31:29.7443934Z ##[group]Run rustup toolchain install stable --profile minimal --no-self-update
+2026-08-01T02:31:29.7444490Z [36;1mrustup toolchain install stable --profile minimal --no-self-update[0m
+2026-08-01T02:31:29.7487062Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-08-01T02:31:29.7487398Z env:
+2026-08-01T02:31:29.7487609Z   CARGO_TERM_COLOR: always
+2026-08-01T02:31:29.7487857Z   CARGO_HOME: /home/runner/.cargo
+2026-08-01T02:31:29.7488116Z   RUSTUP_PERMIT_COPY_RENAME: 1
+2026-08-01T02:31:29.7488357Z ##[endgroup]
+2026-08-01T02:31:30.4290608Z info: syncing channel updates for stable-x86_64-unknown-linux-gnu
+2026-08-01T02:31:30.6648829Z 
+2026-08-01T02:31:30.6741526Z   stable-x86_64-unknown-linux-gnu unchanged - rustc 1.97.1 (8bab26f4f 2026-07-14)
+2026-08-01T02:31:30.6741961Z 
+2026-08-01T02:31:30.6822233Z ##[end-action id=__dtolnay_rust-toolchain.__run_4;outcome=success;conclusion=success;duration_ms=939]
+2026-08-01T02:31:30.6828025Z ##[start-action display=Run rustup default stable;id=__dtolnay_rust-toolchain.__run_5]
+2026-08-01T02:31:30.6845985Z ##[group]Run rustup default stable
+2026-08-01T02:31:30.6846303Z [36;1mrustup default stable[0m
+2026-08-01T02:31:30.6891016Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-08-01T02:31:30.6891351Z env:
+2026-08-01T02:31:30.6891554Z   CARGO_TERM_COLOR: always
+2026-08-01T02:31:30.6891811Z   CARGO_HOME: /home/runner/.cargo
+2026-08-01T02:31:30.6892226Z ##[endgroup]
+2026-08-01T02:31:30.7014268Z info: using existing install for stable-x86_64-unknown-linux-gnu
+2026-08-01T02:31:30.7018378Z info: default toolchain set to stable-x86_64-unknown-linux-gnu
+2026-08-01T02:31:30.7018914Z 
+2026-08-01T02:31:30.7109035Z   stable-x86_64-unknown-linux-gnu unchanged - rustc 1.97.1 (8bab26f4f 2026-07-14)
+2026-08-01T02:31:30.7109390Z 
+2026-08-01T02:31:30.7128655Z ##[end-action id=__dtolnay_rust-toolchain.__run_5;outcome=success;conclusion=success;duration_ms=29]
+2026-08-01T02:31:30.7133654Z ##[start-action display=Run : create cachekey;id=__dtolnay_rust-toolchain.rustc-version]
+2026-08-01T02:31:30.7151774Z ##[group]Run : create cachekey
+2026-08-01T02:31:30.7152293Z [36;1m: create cachekey[0m
+2026-08-01T02:31:30.7152814Z [36;1mDATE=$(rustc +stable --version --verbose | sed -ne 's/^commit-date: \(20[0-9][0-9]\)-\([01][0-9]\)-\([0-3][0-9]\)$/\1\2\3/p')[0m
+2026-08-01T02:31:30.7153682Z [36;1mHASH=$(rustc +stable --version --verbose | sed -ne 's/^commit-hash: //p')[0m
+2026-08-01T02:31:30.7154182Z [36;1mecho "cachekey=$(echo $DATE$HASH | head -c12)" >> $GITHUB_OUTPUT[0m
+2026-08-01T02:31:30.7198636Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-08-01T02:31:30.7198971Z env:
+2026-08-01T02:31:30.7199177Z   CARGO_TERM_COLOR: always
+2026-08-01T02:31:30.7199431Z   CARGO_HOME: /home/runner/.cargo
+2026-08-01T02:31:30.7199680Z ##[endgroup]
+2026-08-01T02:31:30.7853860Z ##[end-action id=__dtolnay_rust-toolchain.rustc-version;outcome=success;conclusion=success;duration_ms=71]
+2026-08-01T02:31:30.7856894Z ##[start-action display=Run : disable incremental compilation;id=__dtolnay_rust-toolchain.__run_6]
+2026-08-01T02:31:30.7874432Z ##[group]Run : disable incremental compilation
+2026-08-01T02:31:30.7874791Z [36;1m: disable incremental compilation[0m
+2026-08-01T02:31:30.7875113Z [36;1mif [ -z "${CARGO_INCREMENTAL+set}" ]; then[0m
+2026-08-01T02:31:30.7875462Z [36;1m  echo CARGO_INCREMENTAL=0 >> $GITHUB_ENV[0m
+2026-08-01T02:31:30.7875745Z [36;1mfi[0m
+2026-08-01T02:31:30.7920213Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-08-01T02:31:30.7920555Z env:
+2026-08-01T02:31:30.7920758Z   CARGO_TERM_COLOR: always
+2026-08-01T02:31:30.7921000Z   CARGO_HOME: /home/runner/.cargo
+2026-08-01T02:31:30.7921249Z ##[endgroup]
+2026-08-01T02:31:30.7990672Z ##[end-action id=__dtolnay_rust-toolchain.__run_6;outcome=success;conclusion=success;duration_ms=13]
+2026-08-01T02:31:30.7993110Z ##[start-action display=Run : enable colors in Cargo output;id=__dtolnay_rust-toolchain.__run_7]
+2026-08-01T02:31:30.8008972Z ##[group]Run : enable colors in Cargo output
+2026-08-01T02:31:30.8009309Z [36;1m: enable colors in Cargo output[0m
+2026-08-01T02:31:30.8009624Z [36;1mif [ -z "${CARGO_TERM_COLOR+set}" ]; then[0m
+2026-08-01T02:31:30.8009962Z [36;1m  echo CARGO_TERM_COLOR=always >> $GITHUB_ENV[0m
+2026-08-01T02:31:30.8010254Z [36;1mfi[0m
+2026-08-01T02:31:30.8051233Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-08-01T02:31:30.8051567Z env:
+2026-08-01T02:31:30.8051768Z   CARGO_TERM_COLOR: always
+2026-08-01T02:31:30.8052010Z   CARGO_HOME: /home/runner/.cargo
+2026-08-01T02:31:30.8052435Z   CARGO_INCREMENTAL: 0
+2026-08-01T02:31:30.8052653Z ##[endgroup]
+2026-08-01T02:31:30.8119135Z ##[end-action id=__dtolnay_rust-toolchain.__run_7;outcome=success;conclusion=success;duration_ms=12]
+2026-08-01T02:31:30.8123943Z ##[start-action display=Run : enable Cargo sparse registry;id=__dtolnay_rust-toolchain.__run_8]
+2026-08-01T02:31:30.8140681Z ##[group]Run : enable Cargo sparse registry
+2026-08-01T02:31:30.8141024Z [36;1m: enable Cargo sparse registry[0m
+2026-08-01T02:31:30.8141387Z [36;1m# implemented in 1.66, stabilized in 1.68, made default in 1.70[0m
+2026-08-01T02:31:30.8142347Z [36;1mif [ -z "${CARGO_REGISTRIES_CRATES_IO_PROTOCOL+set}" -o -f "/home/runner/work/_temp"/.implicit_cargo_registries_crates_io_protocol ]; then[0m
+2026-08-01T02:31:30.8143079Z [36;1m  if rustc +stable --version --verbose | grep -q '^release: 1\.6[89]\.'; then[0m
+2026-08-01T02:31:30.8143649Z [36;1m    touch "/home/runner/work/_temp"/.implicit_cargo_registries_crates_io_protocol || true[0m
+2026-08-01T02:31:30.8144169Z [36;1m    echo CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse >> $GITHUB_ENV[0m
+2026-08-01T02:31:30.8144652Z [36;1m  elif rustc +stable --version --verbose | grep -q '^release: 1\.6[67]\.'; then[0m
+2026-08-01T02:31:30.8145191Z [36;1m    touch "/home/runner/work/_temp"/.implicit_cargo_registries_crates_io_protocol || true[0m
+2026-08-01T02:31:30.8145696Z [36;1m    echo CARGO_REGISTRIES_CRATES_IO_PROTOCOL=git >> $GITHUB_ENV[0m
+2026-08-01T02:31:30.8146039Z [36;1m  fi[0m
+2026-08-01T02:31:30.8146231Z [36;1mfi[0m
+2026-08-01T02:31:30.8186125Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-08-01T02:31:30.8186469Z env:
+2026-08-01T02:31:30.8186672Z   CARGO_TERM_COLOR: always
+2026-08-01T02:31:30.8186920Z   CARGO_HOME: /home/runner/.cargo
+2026-08-01T02:31:30.8187169Z   CARGO_INCREMENTAL: 0
+2026-08-01T02:31:30.8187559Z ##[endgroup]
+2026-08-01T02:31:30.8571548Z ##[end-action id=__dtolnay_rust-toolchain.__run_8;outcome=success;conclusion=success;duration_ms=44]
+2026-08-01T02:31:30.8579025Z ##[start-action display=Run : work around spurious network errors in curl 8.0;id=__dtolnay_rust-toolchain.__run_9]
+2026-08-01T02:31:30.8627365Z ##[group]Run : work around spurious network errors in curl 8.0
+2026-08-01T02:31:30.8628813Z [36;1m: work around spurious network errors in curl 8.0[0m
+2026-08-01T02:31:30.8629729Z [36;1m# https://rust-lang.zulipchat.com/#narrow/stream/246057-t-cargo/topic/timeout.20investigation[0m
+2026-08-01T02:31:30.8631016Z [36;1mif rustc +stable --version --verbose | grep -q '^release: 1\.7[01]\.'; then[0m
+2026-08-01T02:31:30.8631739Z [36;1m  echo CARGO_HTTP_MULTIPLEXING=false >> $GITHUB_ENV[0m
+2026-08-01T02:31:30.8632527Z [36;1mfi[0m
+2026-08-01T02:31:30.8696175Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-08-01T02:31:30.8696545Z env:
+2026-08-01T02:31:30.8696772Z   CARGO_TERM_COLOR: always
+2026-08-01T02:31:30.8697039Z   CARGO_HOME: /home/runner/.cargo
+2026-08-01T02:31:30.8697298Z   CARGO_INCREMENTAL: 0
+2026-08-01T02:31:30.8697520Z ##[endgroup]
+2026-08-01T02:31:30.8929037Z ##[end-action id=__dtolnay_rust-toolchain.__run_9;outcome=success;conclusion=success;duration_ms=34]
+2026-08-01T02:31:30.8935772Z ##[start-action display=Run rustc +stable --version --verbose;id=__dtolnay_rust-toolchain.__run_10]
+2026-08-01T02:31:30.8962769Z ##[group]Run rustc +stable --version --verbose
+2026-08-01T02:31:30.8963360Z [36;1mrustc +stable --version --verbose[0m
+2026-08-01T02:31:30.9028333Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-08-01T02:31:30.9028894Z env:
+2026-08-01T02:31:30.9029212Z   CARGO_TERM_COLOR: always
+2026-08-01T02:31:30.9029614Z   CARGO_HOME: /home/runner/.cargo
+2026-08-01T02:31:30.9030025Z   CARGO_INCREMENTAL: 0
+2026-08-01T02:31:30.9030372Z ##[endgroup]
+2026-08-01T02:31:30.9249449Z rustc 1.97.1 (8bab26f4f 2026-07-14)
+2026-08-01T02:31:30.9250328Z binary: rustc
+2026-08-01T02:31:30.9251155Z commit-hash: 8bab26f4f68e0e26f0bb7960be334d5b520ea452
+2026-08-01T02:31:30.9251657Z commit-date: 2026-07-14
+2026-08-01T02:31:30.9252002Z host: x86_64-unknown-linux-gnu
+2026-08-01T02:31:30.9252522Z release: 1.97.1
+2026-08-01T02:31:30.9252824Z LLVM version: 22.1.6
+2026-08-01T02:31:30.9279343Z ##[end-action id=__dtolnay_rust-toolchain.__run_10;outcome=success;conclusion=success;duration_ms=34]
+2026-08-01T02:31:31.1426334Z ##[group]Run actions/cache@v5
+2026-08-01T02:31:31.1426617Z with:
+2026-08-01T02:31:31.1426883Z   path: ~/.cargo/registry
+~/.cargo/git
+target
+
+2026-08-01T02:31:31.1427371Z   key: Linux-cargo-test-5c19bc72aeda89682075276d1220635a4e4c797e69d34866a228da908deb23fe
+2026-08-01T02:31:31.1427871Z   restore-keys: Linux-cargo-test-
+Linux-cargo-
+
+2026-08-01T02:31:31.1428188Z   enableCrossOsArchive: false
+2026-08-01T02:31:31.1428442Z   fail-on-cache-miss: false
+2026-08-01T02:31:31.1428680Z   lookup-only: false
+2026-08-01T02:31:31.1428892Z   save-always: false
+2026-08-01T02:31:31.1429090Z env:
+2026-08-01T02:31:31.1429286Z   CARGO_TERM_COLOR: always
+2026-08-01T02:31:31.1429525Z   CARGO_HOME: /home/runner/.cargo
+2026-08-01T02:31:31.1429777Z   CARGO_INCREMENTAL: 0
+2026-08-01T02:31:31.1429990Z ##[endgroup]
+2026-08-01T02:31:31.3762921Z Cache hit for restore-key: Linux-cargo-enclave-5c19bc72aeda89682075276d1220635a4e4c797e69d34866a228da908deb23fe
+2026-08-01T02:31:32.5101786Z Received 142606336 of 528779196 (27.0%), 135.7 MBs/sec
+2026-08-01T02:31:33.5106971Z Received 402653184 of 528779196 (76.1%), 191.7 MBs/sec
+2026-08-01T02:31:33.9532363Z Received 528779196 of 528779196 (100.0%), 206.3 MBs/sec
+2026-08-01T02:31:33.9534241Z Cache Size: ~504 MB (528779196 B)
+2026-08-01T02:31:33.9571432Z [command]/usr/bin/tar -xf /home/runner/work/_temp/8337b9eb-5b4d-4d43-bdeb-911943abf96b/cache.tzst -P -C /home/runner/work/verifiable-trust-infrastructure/verifiable-trust-infrastructure --use-compress-program unzstd
+2026-08-01T02:31:38.2393140Z Cache restored successfully
+2026-08-01T02:31:38.5124931Z Cache restored from key: Linux-cargo-enclave-5c19bc72aeda89682075276d1220635a4e4c797e69d34866a228da908deb23fe
+2026-08-01T02:31:38.5318391Z ##[group]Run cargo test --workspace
+2026-08-01T02:31:38.5318717Z [36;1mcargo test --workspace[0m
+2026-08-01T02:31:38.5365073Z shell: /usr/bin/bash -e {0}
+2026-08-01T02:31:38.5365330Z env:
+2026-08-01T02:31:38.5365533Z   CARGO_TERM_COLOR: always
+2026-08-01T02:31:38.5365790Z   CARGO_HOME: /home/runner/.cargo
+2026-08-01T02:31:38.5366062Z   CARGO_INCREMENTAL: 0
+2026-08-01T02:31:38.5366482Z ##[endgroup]
+2026-08-01T02:31:42.3525456Z [1m[92m Downloading[0m crates ...
+2026-08-01T02:31:42.5092011Z [1m[92m  Downloaded[0m affinidi-cesr v0.1.3
+2026-08-01T02:31:42.5162581Z [1m[92m  Downloaded[0m affinidi-messaging-mediator-config v0.2.0
+2026-08-01T02:31:42.5176054Z [1m[92m  Downloaded[0m affinidi-messaging-test-mediator v0.2.44
+2026-08-01T02:31:42.5215338Z [1m[92m  Downloaded[0m affinidi-rate-limit v0.1.0
+2026-08-01T02:31:42.5224610Z [1m[92m  Downloaded[0m funty v2.0.0
+2026-08-01T02:31:42.5232536Z [1m[92m  Downloaded[0m affinidi-bbs v0.3.2
+2026-08-01T02:31:42.5259300Z [1m[92m  Downloaded[0m gethostname v1.1.0
+2026-08-01T02:31:42.5269917Z [1m[92m  Downloaded[0m async-convert v1.0.0
+2026-08-01T02:31:42.5282779Z [1m[92m  Downloaded[0m deadpool-runtime v0.1.4
+2026-08-01T02:31:42.5291328Z [1m[92m  Downloaded[0m include_dir v0.7.4
+2026-08-01T02:31:42.5301888Z [1m[92m  Downloaded[0m askama_escape v0.10.3
+2026-08-01T02:31:42.5311454Z [1m[92m  Downloaded[0m hostname v0.4.2
+2026-08-01T02:31:42.5328725Z [1m[92m  Downloaded[0m chacha20 v0.9.1
+2026-08-01T02:31:42.5347348Z [1m[92m  Downloaded[0m include_dir_macros v0.7.4
+2026-08-01T02:31:42.5354490Z [1m[92m  Downloaded[0m assert-json-diff v2.0.2
+2026-08-01T02:31:42.5368575Z [1m[92m  Downloaded[0m asn1-rs-derive v0.6.0
+2026-08-01T02:31:42.5379330Z [1m[92m  Downloaded[0m num_cpus v1.17.0
+2026-08-01T02:31:42.5410380Z [1m[92m  Downloaded[0m pairing v0.23.0
+2026-08-01T02:31:42.5421835Z [1m[92m  Downloaded[0m bincode v1.3.3
+2026-08-01T02:31:42.5444029Z [1m[92m  Downloaded[0m cargo_metadata v0.15.4
+2026-08-01T02:31:42.5460117Z [1m[92m  Downloaded[0m fs-err v2.11.0
+2026-08-01T02:31:42.5478591Z [1m[92m  Downloaded[0m glob v0.3.4
+2026-08-01T02:31:42.5493798Z [1m[92m  Downloaded[0m cargo-platform v0.1.9
+2026-08-01T02:31:42.5505720Z [1m[92m  Downloaded[0m askama v0.12.1
+2026-08-01T02:31:42.5518975Z [1m[92m  Downloaded[0m askama_parser v0.2.1
+2026-08-01T02:31:42.5533057Z [1m[92m  Downloaded[0m async-compat v0.2.5
+2026-08-01T02:31:42.5547066Z [1m[92m  Downloaded[0m filetime v0.2.29
+2026-08-01T02:31:42.5563800Z [1m[92m  Downloaded[0m humantime v2.4.0
+2026-08-01T02:31:42.5580051Z [1m[92m  Downloaded[0m fs-err v3.3.1
+2026-08-01T02:31:42.5599685Z [1m[92m  Downloaded[0m mime_guess v2.0.5
+2026-08-01T02:31:42.5616983Z [1m[92m  Downloaded[0m oid-registry v0.8.1
+2026-08-01T02:31:42.5629625Z [1m[92m  Downloaded[0m pastey v0.2.3
+2026-08-01T02:31:42.5642368Z [1m[92m  Downloaded[0m agent-names v0.1.3
+2026-08-01T02:31:42.5658409Z [1m[92m  Downloaded[0m aws-nitro-enclaves-nsm-api v0.4.0
+2026-08-01T02:31:42.5680960Z [1m[92m  Downloaded[0m axum-server v0.8.0
+2026-08-01T02:31:42.5713591Z [1m[92m  Downloaded[0m backon v1.6.0
+2026-08-01T02:31:42.5741620Z [1m[92m  Downloaded[0m camino v1.2.5
+2026-08-01T02:31:42.5758423Z [1m[92m  Downloaded[0m arcstr v1.2.0
+2026-08-01T02:31:42.5772501Z [1m[92m  Downloaded[0m askama_derive v0.12.5
+2026-08-01T02:31:42.5789811Z [1m[92m  Downloaded[0m deadpool v0.12.3
+2026-08-01T02:31:42.5820062Z [1m[92m  Downloaded[0m plain v0.2.3
+2026-08-01T02:31:42.5831083Z [1m[92m  Downloaded[0m aws-nitro-enclaves-nsm-api v0.5.2
+2026-08-01T02:31:42.5854712Z [1m[92m  Downloaded[0m dtg-credentials v0.1.3
+2026-08-01T02:31:42.5870982Z [1m[92m  Downloaded[0m half v1.8.3
+2026-08-01T02:31:42.5892976Z [1m[92m  Downloaded[0m nitro_attest v0.2.0
+2026-08-01T02:31:42.5920347Z [1m[92m  Downloaded[0m num-format v0.4.4
+2026-08-01T02:31:42.5956192Z [1m[92m  Downloaded[0m chacha20poly1305 v0.10.1
+2026-08-01T02:31:42.5972957Z [1m[92m  Downloaded[0m basic-toml v0.1.10
+2026-08-01T02:31:42.6081777Z [1m[92m  Downloaded[0m coset v0.4.2
+2026-08-01T02:31:42.6123362Z [1m[92m  Downloaded[0m coset v0.3.8
+2026-08-01T02:31:42.6163236Z [1m[92m  Downloaded[0m der-parser v10.0.0
+2026-08-01T02:31:42.6197487Z [1m[92m  Downloaded[0m radium v0.7.0
+2026-08-01T02:31:42.6207841Z [1m[92m  Downloaded[0m affinidi-tsp v0.1.13
+2026-08-01T02:31:42.6236532Z [1m[92m  Downloaded[0m asn1-rs v0.7.2
+2026-08-01T02:31:42.6305685Z [1m[92m  Downloaded[0m poly1305 v0.8.0
+2026-08-01T02:31:42.6330139Z [1m[92m  Downloaded[0m combine v4.6.7
+2026-08-01T02:31:42.6385905Z [1m[92m  Downloaded[0m goblin v0.8.2
+2026-08-01T02:31:42.6443720Z [1m[92m  Downloaded[0m bitvec v1.1.1
+2026-08-01T02:31:42.6611158Z [1m[92m  Downloaded[0m affinidi-messaging-mediator v0.18.1
+2026-08-01T02:31:42.6728271Z [1m[92m  Downloaded[0m bls12_381_plus v0.8.18
+2026-08-01T02:31:42.6782598Z [1m[92m  Downloaded[0m rcgen v0.13.2
+2026-08-01T02:31:42.6810517Z [1m[92m  Downloaded[0m rmcp-macros v1.8.0
+2026-08-01T02:31:42.6824415Z [1m[92m  Downloaded[0m rmcp v1.8.0
+2026-08-01T02:31:42.6961418Z [1m[92m  Downloaded[0m redis v1.5.0
+2026-08-01T02:31:42.7097691Z [1m[92m  Downloaded[0m serde_cbor v0.11.2
+2026-08-01T02:31:42.7126587Z [1m[92m  Downloaded[0m scroll v0.12.0
+2026-08-01T02:31:42.7140738Z [1m[92m  Downloaded[0m serde_bytes v0.11.19
+2026-08-01T02:31:42.7156848Z [1m[92m  Downloaded[0m schemars_derive v1.2.2
+2026-08-01T02:31:42.7176153Z [1m[92m  Downloaded[0m scroll_derive v0.12.1
+2026-08-01T02:31:42.7183556Z [1m[92m  Downloaded[0m serde_derive_internals v0.30.0
+2026-08-01T02:31:42.7198688Z [1m[92m  Downloaded[0m sha1_smol v1.0.1
+2026-08-01T02:31:42.7211901Z [1m[92m  Downloaded[0m siphasher v0.3.11
+2026-08-01T02:31:42.7224023Z [1m[92m  Downloaded[0m smawk v0.3.3
+2026-08-01T02:31:42.7240728Z [1m[92m  Downloaded[0m tap v1.0.1
+2026-08-01T02:31:42.7250119Z [1m[92m  Downloaded[0m tar v0.4.46
+2026-08-01T02:31:42.7278859Z [1m[92m  Downloaded[0m textwrap v0.16.2
+2026-08-01T02:31:42.7303586Z [1m[92m  Downloaded[0m toml v0.5.11
+2026-08-01T02:31:42.7325852Z [1m[92m  Downloaded[0m uniffi v0.28.3
+2026-08-01T02:31:42.7339432Z [1m[92m  Downloaded[0m unicase v2.9.0
+2026-08-01T02:31:42.7353656Z [1m[92m  Downloaded[0m uniffi_checksum_derive v0.28.3
+2026-08-01T02:31:42.7360008Z [1m[92m  Downloaded[0m uniffi_core v0.28.3
+2026-08-01T02:31:42.7382282Z [1m[92m  Downloaded[0m uniffi_meta v0.28.3
+2026-08-01T02:31:42.7392601Z [1m[92m  Downloaded[0m uniffi_testing v0.28.3
+2026-08-01T02:31:42.7398882Z [1m[92m  Downloaded[0m uniffi_macros v0.28.3
+2026-08-01T02:31:42.7419925Z [1m[92m  Downloaded[0m uniffi_udl v0.28.3
+2026-08-01T02:31:42.7434091Z [1m[92m  Downloaded[0m uniffi_bindgen v0.28.3
+2026-08-01T02:31:42.7579122Z [1m[92m  Downloaded[0m webpki-roots v0.26.11
+2026-08-01T02:31:42.7591551Z [1m[92m  Downloaded[0m weedle2 v5.0.0
+2026-08-01T02:31:42.7607805Z [1m[92m  Downloaded[0m webpki-roots v1.0.9
+2026-08-01T02:31:42.7639570Z [1m[92m  Downloaded[0m wiremock v0.6.5
+2026-08-01T02:31:42.7670066Z [1m[92m  Downloaded[0m wyz v0.5.1
+2026-08-01T02:31:42.7682459Z [1m[92m  Downloaded[0m xattr v1.6.1
+2026-08-01T02:31:42.7701075Z [1m[92m  Downloaded[0m x509-parser v0.18.1
+2026-08-01T02:31:42.7757126Z [1m[92m  Downloaded[0m yasna v0.5.2
+2026-08-01T02:31:42.7778553Z [1m[92m  Downloaded[0m x509-parser v0.17.0
+2026-08-01T02:31:42.7833500Z [1m[92m  Downloaded[0m zopfli v0.8.3
+2026-08-01T02:31:42.7856817Z [1m[92m  Downloaded[0m zip v2.4.2
+2026-08-01T02:31:43.5489594Z [1m[92m   Compiling[0m unicode-ident v1.0.24
+2026-08-01T02:31:43.5545387Z [1m[92m   Compiling[0m cfg-if v1.0.4
+2026-08-01T02:31:43.5550659Z [1m[92m   Compiling[0m libc v0.2.189
+2026-08-01T02:31:43.5579437Z [1m[92m   Compiling[0m memchr v2.8.3
+2026-08-01T02:31:45.1792786Z [1m[92m   Compiling[0m serde_core v1.0.229
+2026-08-01T02:31:46.2384016Z [1m[92m   Compiling[0m proc-macro2 v1.0.107
+2026-08-01T02:31:46.6293834Z [1m[92m   Compiling[0m typenum v1.20.1
+2026-08-01T02:31:46.6894609Z [1m[92m   Compiling[0m itoa v1.0.18
+2026-08-01T02:31:46.8214281Z [1m[92m   Compiling[0m quote v1.0.47
+2026-08-01T02:31:47.0264355Z [1m[92m   Compiling[0m syn v2.0.119
+2026-08-01T02:31:47.0373646Z [1m[92m   Compiling[0m syn v3.0.3
+2026-08-01T02:31:47.5153633Z [1m[92m   Compiling[0m once_cell v1.21.4
+2026-08-01T02:31:47.7134275Z [1m[92m   Compiling[0m smallvec v1.15.2
+2026-08-01T02:31:47.8783363Z [1m[92m   Compiling[0m getrandom v0.2.17
+2026-08-01T02:31:47.9394350Z [1m[92m   Compiling[0m log v0.4.33
+2026-08-01T02:31:48.0423740Z [1m[92m   Compiling[0m pin-project-lite v0.2.17
+2026-08-01T02:31:48.0927348Z [1m[92m   Compiling[0m subtle v2.6.1
+2026-08-01T02:31:48.1293723Z [1m[92m   Compiling[0m rand_core v0.6.4
+2026-08-01T02:31:48.2214356Z [1m[92m   Compiling[0m slab v0.4.12
+2026-08-01T02:31:48.3123817Z [1m[92m   Compiling[0m num-traits v0.2.19
+2026-08-01T02:31:48.3543760Z [1m[92m   Compiling[0m bytes v1.12.1
+2026-08-01T02:31:49.0497633Z [1m[92m   Compiling[0m cpufeatures v0.2.17
+2026-08-01T02:31:49.0569640Z [1m[92m   Compiling[0m futures-core v0.3.33
+2026-08-01T02:31:49.0993702Z [1m[92m   Compiling[0m scopeguard v1.2.0
+2026-08-01T02:31:49.1646646Z [1m[92m   Compiling[0m lock_api v0.4.14
+2026-08-01T02:31:49.1736078Z [1m[92m   Compiling[0m parking_lot_core v0.9.12
+2026-08-01T02:31:49.3724304Z [1m[92m   Compiling[0m futures-io v0.3.33
+2026-08-01T02:31:49.3873972Z [1m[92m   Compiling[0m equivalent v1.0.2
+2026-08-01T02:31:49.4354346Z [1m[92m   Compiling[0m jobserver v0.1.35
+2026-08-01T02:31:49.4734248Z [1m[92m   Compiling[0m futures-sink v0.3.33
+2026-08-01T02:31:49.5353808Z [1m[92m   Compiling[0m futures-channel v0.3.33
+2026-08-01T02:31:49.7103504Z [1m[92m   Compiling[0m cc v1.4.0
+2026-08-01T02:31:49.7463783Z [1m[92m   Compiling[0m parking_lot v0.12.5
+2026-08-01T02:31:50.1583616Z [1m[92m   Compiling[0m errno v0.3.14
+2026-08-01T02:31:50.2723919Z [1m[92m   Compiling[0m futures-task v0.3.33
+2026-08-01T02:31:50.4323707Z [1m[92m   Compiling[0m signal-hook-registry v1.4.8
+2026-08-01T02:31:50.6963699Z [1m[92m   Compiling[0m mio v1.2.2
+2026-08-01T02:31:50.9499304Z [1m[92m   Compiling[0m serde_derive v1.0.229
+2026-08-01T02:31:51.2023767Z [1m[92m   Compiling[0m zmij v1.0.23
+2026-08-01T02:31:51.2884818Z [1m[92m   Compiling[0m foldhash v0.2.0
+2026-08-01T02:31:51.3983817Z [1m[92m   Compiling[0m allocator-api2 v0.2.21
+2026-08-01T02:31:51.6877877Z [1m[92m   Compiling[0m serde_json v1.0.151
+2026-08-01T02:31:51.7709001Z [1m[92m   Compiling[0m tokio-macros v2.7.2
+2026-08-01T02:31:51.9665316Z [1m[92m   Compiling[0m zeroize_derive v1.5.0
+2026-08-01T02:31:53.5254771Z [1m[92m   Compiling[0m futures-macro v0.3.33
+2026-08-01T02:31:53.5327933Z [1m[92m   Compiling[0m zeroize v1.9.0
+2026-08-01T02:31:53.5393577Z [1m[92m   Compiling[0m zerocopy-derive v0.8.55
+2026-08-01T02:31:53.5453453Z [1m[92m   Compiling[0m serde v1.0.229
+2026-08-01T02:31:53.6765316Z [1m[92m   Compiling[0m generic-array v0.14.7
+2026-08-01T02:31:54.1883766Z [1m[92m   Compiling[0m futures-util v0.3.33
+2026-08-01T02:31:54.2113849Z [1m[92m   Compiling[0m crypto-common v0.1.7
+2026-08-01T02:31:54.2894615Z [1m[92m   Compiling[0m thiserror-impl v2.0.19
+2026-08-01T02:31:55.0303766Z [1m[92m   Compiling[0m zerocopy v0.8.55
+2026-08-01T02:31:55.3961168Z [1m[92m   Compiling[0m socket2 v0.6.5
+2026-08-01T02:31:55.8643752Z [1m[92m   Compiling[0m const-oid v0.9.6
+2026-08-01T02:31:55.9303997Z [1m[92m   Compiling[0m tokio v1.53.1
+2026-08-01T02:31:55.9953793Z [1m[92m   Compiling[0m thiserror v2.0.19
+2026-08-01T02:31:56.0454089Z [1m[92m   Compiling[0m block-buffer v0.10.4
+2026-08-01T02:31:56.1300507Z [1m[92m   Compiling[0m digest v0.10.7
+2026-08-01T02:31:56.2983745Z [1m[92m   Compiling[0m tracing-core v0.1.36
+2026-08-01T02:31:56.8823615Z [1m[92m   Compiling[0m tracing-attributes v0.1.31
+2026-08-01T02:31:56.9764652Z [1m[92m   Compiling[0m hashbrown v0.17.1
+2026-08-01T02:31:57.6143901Z [1m[92m   Compiling[0m synstructure v0.13.2
+2026-08-01T02:31:58.0624127Z [1m[92m   Compiling[0m tracing v0.1.44
+2026-08-01T02:31:58.1263830Z [1m[92m   Compiling[0m num-integer v0.1.46
+2026-08-01T02:31:58.2993894Z [1m[92m   Compiling[0m base64 v0.22.1
+2026-08-01T02:31:58.4873541Z [1m[92m   Compiling[0m percent-encoding v2.3.2
+2026-08-01T02:31:58.5923681Z [1m[92m   Compiling[0m indexmap v2.14.0
+2026-08-01T02:31:58.6453725Z [1m[92m   Compiling[0m displaydoc v0.2.7
+2026-08-01T02:31:58.9136050Z [1m[92m   Compiling[0m minimal-lexical v0.2.1
+2026-08-01T02:31:59.1453949Z [1m[92m   Compiling[0m cmov v0.5.4
+2026-08-01T02:31:59.2634303Z [1m[92m   Compiling[0m nom v7.1.3
+2026-08-01T02:31:59.3353918Z [1m[92m   Compiling[0m rand_core v0.10.1
+2026-08-01T02:31:59.3543752Z [1m[92m   Compiling[0m ctutils v0.4.2
+2026-08-01T02:31:59.4503770Z [1m[92m   Compiling[0m getrandom v0.3.4
+2026-08-01T02:31:59.5464288Z [1m[92m   Compiling[0m hybrid-array v0.4.14
+2026-08-01T02:31:59.6063709Z [1m[92m   Compiling[0m http v1.5.0
+2026-08-01T02:32:00.5014324Z [1m[92m   Compiling[0m tokio-util v0.7.19
+2026-08-01T02:32:00.7093770Z [1m[92m   Compiling[0m crypto-common v0.2.2
+2026-08-01T02:32:00.8552392Z [1m[92m   Compiling[0m form_urlencoded v1.2.2
+2026-08-01T02:32:00.9933572Z [1m[92m   Compiling[0m thiserror-impl v1.0.69
+2026-08-01T02:32:01.8113709Z [1m[92m   Compiling[0m fnv v1.0.7
+2026-08-01T02:32:01.8444053Z [1m[92m   Compiling[0m ryu v1.0.23
+2026-08-01T02:32:01.8693838Z [1m[92m   Compiling[0m untrusted v0.9.0
+2026-08-01T02:32:01.9393827Z [1m[92m   Compiling[0m block-buffer v0.12.1
+2026-08-01T02:32:01.9963607Z [1m[92m   Compiling[0m zerofrom-derive v0.1.7
+2026-08-01T02:32:02.0592528Z [1m[92m   Compiling[0m data-encoding v2.11.0
+2026-08-01T02:32:02.0723697Z [1m[92m   Compiling[0m thiserror v1.0.69
+2026-08-01T02:32:02.1296815Z [1m[92m   Compiling[0m http-body v1.1.0
+2026-08-01T02:32:02.2393721Z [1m[92m   Compiling[0m yoke-derive v0.8.2
+2026-08-01T02:32:02.9913770Z [1m[92m   Compiling[0m cmake v0.1.58
+2026-08-01T02:32:03.1143879Z [1m[92m   Compiling[0m zerofrom v0.1.8
+2026-08-01T02:32:03.2143751Z [1m[92m   Compiling[0m stable_deref_trait v1.2.1
+2026-08-01T02:32:03.2473675Z [1m[92m   Compiling[0m base64ct v1.8.3
+2026-08-01T02:32:03.2578703Z [1m[92m   Compiling[0m yoke v0.8.3
+2026-08-01T02:32:03.3193818Z [1m[92m   Compiling[0m aws-lc-sys v0.43.0
+2026-08-01T02:32:03.4175590Z [1m[92m   Compiling[0m sha2 v0.10.9
+2026-08-01T02:32:03.4845939Z [1m[92m   Compiling[0m zerovec-derive v0.11.3
+2026-08-01T02:32:03.6693822Z [1m[92m   Compiling[0m hmac v0.12.1
+2026-08-01T02:32:03.7646681Z [1m[92m   Compiling[0m radium v0.7.0
+2026-08-01T02:32:03.8897724Z [1m[92m   Compiling[0m half v2.7.1
+2026-08-01T02:32:03.9426425Z [1m[92m   Compiling[0m rustls-pki-types v1.15.1
+2026-08-01T02:32:04.1774667Z [1m[92m   Compiling[0m tap v1.0.1
+2026-08-01T02:32:04.2463739Z [1m[92m   Compiling[0m untrusted v0.7.1
+2026-08-01T02:32:04.3175300Z [1m[92m   Compiling[0m wyz v0.5.1
+2026-08-01T02:32:04.4936883Z [1m[92m   Compiling[0m zerovec v0.11.6
+2026-08-01T02:32:04.5033680Z [1m[92m   Compiling[0m hkdf v0.12.4
+2026-08-01T02:32:04.5851056Z [1m[92m   Compiling[0m pem-rfc7468 v0.7.0
+2026-08-01T02:32:04.6159384Z [1m[92m   Compiling[0m http-body-util v0.1.4
+2026-08-01T02:32:04.8325241Z [1m[92m   Compiling[0m num-bigint v0.4.8
+2026-08-01T02:32:04.8733963Z [1m[92m   Compiling[0m funty v2.0.0
+2026-08-01T02:32:04.9463824Z [1m[92m   Compiling[0m tinystr v0.8.3
+2026-08-01T02:32:05.0884657Z [1m[92m   Compiling[0m writeable v0.6.3
+2026-08-01T02:32:05.2035385Z [1m[92m   Compiling[0m litemap v0.8.2
+2026-08-01T02:32:05.3166696Z [1m[92m   Compiling[0m icu_locale_core v2.2.0
+2026-08-01T02:32:05.6398926Z [1m[92m   Compiling[0m bitvec v1.1.1
+2026-08-01T02:32:06.3513046Z [1m[92m   Compiling[0m potential_utf v0.1.5
+2026-08-01T02:32:06.3775475Z [1m[92m   Compiling[0m der v0.7.10
+2026-08-01T02:32:06.9755276Z [1m[92m   Compiling[0m zerotrie v0.2.4
+2026-08-01T02:32:07.1813918Z [1m[92m   Compiling[0m ppv-lite86 v0.2.21
+2026-08-01T02:32:07.2140796Z [1m[92m   Compiling[0m num-conv v0.2.2
+2026-08-01T02:32:07.3209146Z [1m[92m   Compiling[0m time-core v0.1.9
+2026-08-01T02:32:07.4650633Z [1m[92m   Compiling[0m utf8_iter v1.0.4
+2026-08-01T02:32:07.4823571Z [1m[92m   Compiling[0m time-macros v0.2.32
+2026-08-01T02:32:07.5508872Z [1m[92m   Compiling[0m icu_collections v2.2.0
+2026-08-01T02:32:07.7164372Z [1m[92m   Compiling[0m spki v0.7.3
+2026-08-01T02:32:07.8653831Z [1m[92m   Compiling[0m icu_provider v2.2.0
+2026-08-01T02:32:08.0223724Z [1m[92m   Compiling[0m ff v0.13.1
+2026-08-01T02:32:08.1143838Z [1m[92m   Compiling[0m powerfmt v0.2.0
+2026-08-01T02:32:08.1558014Z [1m[92m   Compiling[0m cpufeatures v0.3.0
+2026-08-01T02:32:08.1966461Z [1m[92m   Compiling[0m mime v0.3.17
+2026-08-01T02:32:08.2513336Z [1m[92m   Compiling[0m deranged v0.5.8
+2026-08-01T02:32:08.3941520Z [1m[92m   Compiling[0m ciborium-io v0.2.2
+2026-08-01T02:32:08.4424158Z [1m[92m   Compiling[0m base16ct v0.2.0
+2026-08-01T02:32:08.5523876Z [1m[92m   Compiling[0m serdect v0.2.0
+2026-08-01T02:32:08.5597647Z [1m[92m   Compiling[0m ciborium-ll v0.2.2
+2026-08-01T02:32:08.6634419Z [1m[92m   Compiling[0m group v0.13.0
+2026-08-01T02:32:08.6944933Z [1m[92m   Compiling[0m pkcs8 v0.10.2
+2026-08-01T02:32:08.7700505Z [1m[92m   Compiling[0m icu_properties_data v2.2.0
+2026-08-01T02:32:08.8543753Z [1m[92m   Compiling[0m icu_normalizer_data v2.2.0
+2026-08-01T02:32:08.8991258Z [1m[92m   Compiling[0m signature v2.2.0
+2026-08-01T02:32:08.9157108Z [1m[92m   Compiling[0m lazy_static v1.5.0
+2026-08-01T02:32:08.9691000Z [1m[92m   Compiling[0m bitflags v2.13.1
+2026-08-01T02:32:08.9845669Z [1m[92m   Compiling[0m icu_normalizer v2.2.0
+2026-08-01T02:32:09.1480065Z [1m[92m   Compiling[0m icu_properties v2.2.0
+2026-08-01T02:32:09.1582425Z [1m[92m   Compiling[0m sec1 v0.7.3
+2026-08-01T02:32:09.4107490Z [1m[92m   Compiling[0m httparse v1.10.1
+2026-08-01T02:32:09.5773902Z [1m[92m   Compiling[0m crypto-bigint v0.5.5
+2026-08-01T02:32:09.6830929Z [1m[92m   Compiling[0m tower-service v0.3.3
+2026-08-01T02:32:09.7335376Z [1m[92m   Compiling[0m httpdate v1.0.3
+2026-08-01T02:32:09.9409354Z [1m[92m   Compiling[0m try-lock v0.2.5
+2026-08-01T02:32:09.9929680Z [1m[92m   Compiling[0m want v0.3.1
+2026-08-01T02:32:10.1076265Z [1m[92m   Compiling[0m idna_adapter v1.2.2
+2026-08-01T02:32:10.1847415Z [1m[92m   Compiling[0m idna v1.1.0
+2026-08-01T02:32:10.3425874Z [1m[92m   Compiling[0m syn v1.0.109
+2026-08-01T02:32:10.8424310Z [1m[92m   Compiling[0m elliptic-curve v0.13.8
+2026-08-01T02:32:10.8533633Z [1m[92m   Compiling[0m url v2.5.8
+2026-08-01T02:32:11.3790629Z [1m[92m   Compiling[0m iana-time-zone v0.1.65
+2026-08-01T02:32:11.5614046Z [1m[92m   Compiling[0m hex v0.4.3
+2026-08-01T02:32:11.7035011Z [1m[92m   Compiling[0m atomic-waker v1.1.2
+2026-08-01T02:32:11.7706401Z [1m[92m   Compiling[0m h2 v0.4.15
+2026-08-01T02:32:11.7803535Z [1m[92m   Compiling[0m chrono v0.4.45
+2026-08-01T02:32:13.5867163Z [1m[92m   Compiling[0m proc-macro-error-attr v1.0.4
+2026-08-01T02:32:13.5867831Z [1m[92m   Compiling[0m rfc6979 v0.4.0
+2026-08-01T02:32:13.6633614Z [1m[92m   Compiling[0m ecdsa v0.16.9
+2026-08-01T02:32:13.8219801Z [1m[92m   Compiling[0m proc-macro-error v1.0.4
+2026-08-01T02:32:14.0436117Z [1m[92m   Compiling[0m block-padding v0.4.2
+2026-08-01T02:32:14.1071510Z [1m[92m   Compiling[0m cc-traits v2.0.0
+2026-08-01T02:32:14.1323660Z [1m[92m   Compiling[0m num_threads v0.1.7
+2026-08-01T02:32:14.2147741Z [1m[92m   Compiling[0m openssl-probe v0.2.1
+2026-08-01T02:32:14.2460894Z [1m[92m   Compiling[0m ipnet v2.12.0
+2026-08-01T02:32:14.3443764Z [1m[92m   Compiling[0m rustls-native-certs v0.8.4
+2026-08-01T02:32:14.5963648Z [1m[92m   Compiling[0m btree-slab v0.6.1
+2026-08-01T02:32:14.7703596Z [1m[92m   Compiling[0m time v0.3.54
+2026-08-01T02:32:14.9853995Z [1m[92m   Compiling[0m inout v0.2.2
+2026-08-01T02:32:15.2413763Z [1m[92m   Compiling[0m hyper v1.11.0
+2026-08-01T02:32:16.7934094Z [1m[92m   Compiling[0m hyper-util v0.1.20
+2026-08-01T02:32:17.1185498Z [1m[92m   Compiling[0m abnf-core v0.5.0
+2026-08-01T02:32:17.1433652Z [1m[92m   Compiling[0m async-trait v0.1.91
+2026-08-01T02:32:17.2243970Z [1m[92m   Compiling[0m btree-range-map v0.7.2
+2026-08-01T02:32:17.5174080Z [1m[92m   Compiling[0m abnf v0.13.0
+2026-08-01T02:32:18.0113767Z [1m[92m   Compiling[0m ahash v0.8.12
+2026-08-01T02:32:18.1847054Z [1m[92m   Compiling[0m ciborium v0.2.2
+2026-08-01T02:32:18.1994755Z [1m[92m   Compiling[0m utf8-decode v1.0.1
+2026-08-01T02:32:18.2622430Z [1m[92m   Compiling[0m getrandom v0.4.3
+2026-08-01T02:32:18.4303751Z [1m[92m   Compiling[0m cipher v0.5.2
+2026-08-01T02:32:18.6606508Z [1m[92m   Compiling[0m sync_wrapper v1.0.2
+2026-08-01T02:32:18.7164178Z [1m[92m   Compiling[0m tower-layer v0.3.3
+2026-08-01T02:32:18.7513682Z [1m[92m   Compiling[0m pct-str v2.0.0
+2026-08-01T02:32:18.7579333Z [1m[92m   Compiling[0m static-regular-grammar v2.0.2
+2026-08-01T02:32:18.8523690Z [1m[92m   Compiling[0m num-rational v0.4.2
+2026-08-01T02:32:18.9213970Z [1m[92m   Compiling[0m tower v0.5.3
+2026-08-01T02:32:19.4902751Z [1m[92m   Compiling[0m primeorder v0.13.6
+2026-08-01T02:32:19.6843585Z [1m[92m   Compiling[0m rand_core v0.9.5
+2026-08-01T02:32:19.9755605Z [1m[92m   Compiling[0m const-oid v0.10.2
+2026-08-01T02:32:20.0959821Z [1m[92m   Compiling[0m lexical-util v1.0.7
+2026-08-01T02:32:20.1228469Z [1m[92m   Compiling[0m digest v0.11.3
+2026-08-01T02:32:20.7713727Z [1m[92m   Compiling[0m chacha20 v0.10.1
+2026-08-01T02:32:21.0355443Z [1m[92m   Compiling[0m rand_chacha v0.9.0
+2026-08-01T02:32:21.4220071Z [1m[92m   Compiling[0m rand v0.9.5
+2026-08-01T02:32:21.8427628Z [1m[92m   Compiling[0m lexical-write-integer v1.0.6
+2026-08-01T02:32:22.0437195Z [1m[92m   Compiling[0m lexical-parse-integer v1.0.6
+2026-08-01T02:32:22.0660236Z [1m[92m   Compiling[0m iref-core v3.2.2
+2026-08-01T02:32:22.1028223Z [1m[92m   Compiling[0m p256 v0.13.2
+2026-08-01T02:32:22.2083546Z [1m[92m   Compiling[0m static_assertions v1.1.0
+2026-08-01T02:32:22.2452683Z [1m[92m   Compiling[0m lexical-parse-float v1.0.6
+2026-08-01T02:32:22.4883828Z [1m[92m   Compiling[0m lexical-write-float v1.0.6
+2026-08-01T02:32:22.7243604Z [1m[92m   Compiling[0m rand v0.10.2
+2026-08-01T02:32:23.4633642Z [1m[92m   Compiling[0m data-encoding-macro-internal v0.1.18
+2026-08-01T02:32:23.7693714Z [1m[92m   Compiling[0m iref v3.2.2
+2026-08-01T02:32:23.8100444Z [1m[92m   Compiling[0m match-lookup v0.1.2
+2026-08-01T02:32:24.0379804Z [1m[92m   Compiling[0m const-str v0.4.3
+2026-08-01T02:32:24.3163657Z [1m[92m   Compiling[0m base256emoji v1.0.2
+2026-08-01T02:32:24.3892674Z [1m[92m   Compiling[0m static-iref v3.0.0
+2026-08-01T02:32:24.4776248Z [1m[92m   Compiling[0m data-encoding-macro v0.1.20
+2026-08-01T02:32:24.5103880Z [1m[92m   Compiling[0m lexical-core v1.0.6
+2026-08-01T02:32:24.6014262Z [1m[92m   Compiling[0m ahash v0.7.8
+2026-08-01T02:32:24.6173839Z [1m[92m   Compiling[0m block-padding v0.3.3
+2026-08-01T02:32:24.7026417Z [1m[92m   Compiling[0m curve25519-dalek-derive v0.1.1
+2026-08-01T02:32:24.7563684Z [1m[92m   Compiling[0m enum-ordinalize-derive v4.4.1
+2026-08-01T02:32:25.1306777Z [1m[92m   Compiling[0m base45 v3.2.0
+2026-08-01T02:32:25.1924492Z [1m[92m   Compiling[0m base-x v0.2.11
+2026-08-01T02:32:25.2709169Z [1m[92m   Compiling[0m ryu-js v0.2.2
+2026-08-01T02:32:25.2954055Z [1m[92m   Compiling[0m multibase v0.9.3
+2026-08-01T02:32:25.3964139Z [1m[92m   Compiling[0m enum-ordinalize v4.4.2
+2026-08-01T02:32:25.4163690Z [1m[92m   Compiling[0m hashbrown v0.12.3
+2026-08-01T02:32:25.4413681Z [1m[92m   Compiling[0m inout v0.1.4
+2026-08-01T02:32:25.4583713Z [1m[92m   Compiling[0m lexical v7.0.5
+2026-08-01T02:32:25.5188502Z [1m[92m   Compiling[0m k256 v0.13.4
+2026-08-01T02:32:25.5392390Z [1m[92m   Compiling[0m contextual v0.1.6
+2026-08-01T02:32:25.5837502Z [1m[92m   Compiling[0m outref v0.5.2
+2026-08-01T02:32:25.6244270Z [1m[92m   Compiling[0m opaque-debug v0.3.1
+2026-08-01T02:32:25.6533448Z [1m[92m   Compiling[0m vsimd v0.8.0
+2026-08-01T02:32:25.9025169Z [1m[92m   Compiling[0m indexmap v1.9.3
+2026-08-01T02:32:26.0793534Z [1m[92m   Compiling[0m cipher v0.4.4
+2026-08-01T02:32:26.2439873Z [1m[92m   Compiling[0m json-number v0.4.10
+2026-08-01T02:32:26.2624737Z [1m[92m   Compiling[0m educe v0.5.11
+2026-08-01T02:32:26.3170670Z [1m[92m   Compiling[0m ryu_floating_decimal v0.1.0
+2026-08-01T02:32:26.4103768Z [1m[92m   Compiling[0m langtag v0.4.0
+2026-08-01T02:32:26.8684255Z [1m[92m   Compiling[0m enum-ordinalize v3.1.15
+2026-08-01T02:32:27.1821959Z [1m[92m   Compiling[0m locspan-derive v0.6.0
+2026-08-01T02:32:27.1914606Z [1m[92m   Compiling[0m locspan v0.8.2
+2026-08-01T02:32:27.4103655Z [1m[92m   Compiling[0m smallstr v0.3.1
+2026-08-01T02:32:27.5411349Z [1m[92m   Compiling[0m bitmaps v2.1.0
+2026-08-01T02:32:28.0017643Z [1m[92m   Compiling[0m raw-btree v0.3.3
+2026-08-01T02:32:28.1333745Z [1m[92m   Compiling[0m replace_with v0.1.8
+2026-08-01T02:32:28.1913944Z [1m[92m   Compiling[0m regex-syntax v0.8.11
+2026-08-01T02:32:28.2783141Z [1m[92m   Compiling[0m decoded-char v0.1.1
+2026-08-01T02:32:28.3564291Z [1m[92m   Compiling[0m json-syntax v0.12.5
+2026-08-01T02:32:28.5693927Z [1m[92m   Compiling[0m rdf-types v0.22.5
+2026-08-01T02:32:29.8634822Z [1m[92m   Compiling[0m sized-chunks v0.6.5
+2026-08-01T02:32:30.0553622Z [1m[92m   Compiling[0m educe v0.4.23
+2026-08-01T02:32:30.3703705Z [1m[92m   Compiling[0m pretty_dtoa v0.3.0
+2026-08-01T02:32:30.5585838Z [1m[92m   Compiling[0m ordered-float v3.9.2
+2026-08-01T02:32:30.8702338Z [1m[92m   Compiling[0m rand_xoshiro v0.6.0
+2026-08-01T02:32:31.1737474Z [1m[92m   Compiling[0m strsim v0.11.1
+2026-08-01T02:32:31.2133701Z [1m[92m   Compiling[0m im v15.1.0
+2026-08-01T02:32:31.5433670Z [1m[92m   Compiling[0m xsd-types v0.9.6
+2026-08-01T02:32:31.7673771Z [1m[92m   Compiling[0m linked-data-derive v0.1.0
+2026-08-01T02:32:32.4048735Z [1m[92m   Compiling[0m futures-executor v0.3.33
+2026-08-01T02:32:32.6553815Z [1m[92m   Compiling[0m futures v0.3.33
+2026-08-01T02:32:32.6989239Z [1m[92m   Compiling[0m uuid v1.24.0
+2026-08-01T02:32:32.8843761Z [1m[92m   Compiling[0m curve25519-dalek v4.1.3
+2026-08-01T02:32:33.1493603Z [1m[92m   Compiling[0m crunchy v0.2.4
+2026-08-01T02:32:33.1964030Z [1m[92m   Compiling[0m hashbrown v0.13.2
+2026-08-01T02:32:33.6642550Z [1m[92m   Compiling[0m darling_core v0.23.0
+2026-08-01T02:32:34.2713735Z [1m[92m   Compiling[0m linked-data v0.1.2
+2026-08-01T02:32:34.8431609Z [1m[92m   Compiling[0m json-ld-syntax v0.21.4
+2026-08-01T02:32:35.6153641Z [1m[92m   Compiling[0m crossbeam-utils v0.8.22
+2026-08-01T02:32:36.0634218Z [1m[92m   Compiling[0m aes v0.8.4
+2026-08-01T02:32:36.2602588Z [1m[92m   Compiling[0m sha2 v0.11.0
+2026-08-01T02:32:36.2952942Z [1m[92m   Compiling[0m ed25519 v2.2.3
+2026-08-01T02:32:36.4479590Z [1m[92m   Compiling[0m pin-project-internal v1.1.13
+2026-08-01T02:32:36.6210956Z [1m[92m   Compiling[0m hashbrown v0.16.1
+2026-08-01T02:32:37.1213675Z [1m[92m   Compiling[0m ring v0.17.14
+2026-08-01T02:32:37.2216919Z [1m[92m   Compiling[0m permutohedron v0.2.4
+2026-08-01T02:32:37.3083786Z [1m[92m   Compiling[0m unsigned-varint v0.8.0
+2026-08-01T02:32:37.3853725Z [1m[92m   Compiling[0m byteorder v1.5.0
+2026-08-01T02:32:37.4253481Z [1m[92m   Compiling[0m pin-project v1.1.13
+2026-08-01T02:32:37.4777680Z [1m[92m   Compiling[0m json-ld-core v0.21.4
+2026-08-01T02:32:37.5363720Z [1m[92m   Compiling[0m uint v0.9.5
+2026-08-01T02:32:37.6235463Z [1m[92m   Compiling[0m ed25519-dalek v2.2.0
+2026-08-01T02:32:37.8478526Z [1m[92m   Compiling[0m darling_macro v0.23.0
+2026-08-01T02:32:38.0659414Z [1m[92m   Compiling[0m fixed-hash v0.7.0
+2026-08-01T02:32:38.1056708Z [1m[92m   Compiling[0m digest v0.9.0
+2026-08-01T02:32:38.1784039Z [1m[92m   Compiling[0m block-buffer v0.9.0
+2026-08-01T02:32:38.2534689Z [1m[92m   Compiling[0m aho-corasick v1.1.4
+2026-08-01T02:32:38.9317785Z [1m[92m   Compiling[0m primitive-types v0.9.1
+2026-08-01T02:32:40.2319614Z [1m[92m   Compiling[0m regex-automata v0.4.16
+2026-08-01T02:32:40.3714528Z [1m[92m   Compiling[0m darling v0.23.0
+2026-08-01T02:32:40.4250602Z [1m[92m   Compiling[0m tiny-keccak v2.0.2
+2026-08-01T02:32:40.5886805Z [1m[92m   Compiling[0m rand_chacha v0.3.1
+2026-08-01T02:32:40.9843855Z [1m[92m   Compiling[0m arrayref v0.3.9
+2026-08-01T02:32:41.0233379Z [1m[92m   Compiling[0m mown v0.2.2
+2026-08-01T02:32:41.0925382Z [1m[92m   Compiling[0m json-ld-context-processing v0.21.4
+2026-08-01T02:32:41.4821612Z [1m[92m   Compiling[0m rand v0.8.7
+2026-08-01T02:32:42.1120199Z [1m[92m   Compiling[0m keccak-hash v0.7.0
+2026-08-01T02:32:42.1723830Z [1m[92m   Compiling[0m sha2 v0.9.9
+2026-08-01T02:32:42.5690888Z [1m[92m   Compiling[0m cbc v0.1.2
+2026-08-01T02:32:42.6429969Z [1m[92m   Compiling[0m serde_urlencoded v0.7.1
+2026-08-01T02:32:42.7900812Z [1m[92m   Compiling[0m sha1 v0.10.7
+2026-08-01T02:32:42.9253399Z [1m[92m   Compiling[0m bs58 v0.4.0
+2026-08-01T02:32:43.0743912Z [1m[92m   Compiling[0m json-ld-expansion v0.21.4
+2026-08-01T02:32:43.4715836Z [1m[92m   Compiling[0m ripemd160 v0.9.1
+2026-08-01T02:32:43.7554381Z [1m[92m   Compiling[0m tower-http v0.6.11
+2026-08-01T02:32:44.7358901Z [1m[92m   Compiling[0m csv-core v0.1.13
+2026-08-01T02:32:44.8948354Z [1m[92m   Compiling[0m encoding_rs v0.8.35
+2026-08-01T02:32:45.2266697Z [1m[92m   Compiling[0m bs58 v0.5.1
+2026-08-01T02:32:45.3448852Z [1m[92m   Compiling[0m fastrand v2.5.0
+2026-08-01T02:32:45.4736392Z [1m[92m   Compiling[0m affinidi-encoding v0.1.5
+2026-08-01T02:32:45.6169304Z [1m[92m   Compiling[0m csv v1.4.0
+2026-08-01T02:32:46.0411068Z [1m[92m   Compiling[0m ssi-crypto v0.2.1
+2026-08-01T02:32:46.4144550Z [1m[92m   Compiling[0m json-ld-compaction v0.21.4
+2026-08-01T02:32:46.4752982Z [1m[92m   Compiling[0m json-ld-serialization v0.21.4
+2026-08-01T02:32:46.6348654Z [1m[92m   Compiling[0m x25519-dalek v2.0.1
+2026-08-01T02:32:46.6994423Z [1m[92m   Compiling[0m p384 v0.13.1
+2026-08-01T02:32:46.8484763Z [1m[92m   Compiling[0m p521 v0.13.3
+2026-08-01T02:32:47.2186862Z [1m[92m   Compiling[0m combination v0.1.5
+2026-08-01T02:32:47.3214376Z [1m[92m   Compiling[0m base58 v0.2.0
+2026-08-01T02:32:47.4295553Z [1m[92m   Compiling[0m ssi-rdf v0.1.1
+2026-08-01T02:32:47.8895037Z [1m[92m   Compiling[0m affinidi-crypto v0.2.5
+2026-08-01T02:32:48.0460369Z [1m[92m   Compiling[0m json-ld v0.21.4
+2026-08-01T02:32:48.3175218Z [1m[92m   Compiling[0m ssi-multicodec v0.2.0
+2026-08-01T02:32:48.4784489Z [1m[92m   Compiling[0m serde_jcs v0.1.0
+2026-08-01T02:32:48.5761850Z [1m[92m   Compiling[0m rusticata-macros v4.1.0
+2026-08-01T02:32:48.6993165Z [1m[92m   Compiling[0m asn1-rs-impl v0.2.0
+2026-08-01T02:32:48.8773974Z [1m[92m   Compiling[0m ssi-contexts v0.1.10
+2026-08-01T02:32:48.9246384Z [1m[92m   Compiling[0m ssi-json-ld v0.3.3
+2026-08-01T02:32:49.0683716Z [1m[92m   Compiling[0m ssi-eip712 v0.1.1
+2026-08-01T02:32:49.7323735Z [1m[92m   Compiling[0m regex v1.13.1
+2026-08-01T02:32:50.1474051Z [1m[92m   Compiling[0m ssi-core v0.2.3
+2026-08-01T02:32:50.2384068Z [1m[92m   Compiling[0m ryu-js v1.0.3
+2026-08-01T02:32:50.3947775Z [1m[92m   Compiling[0m arrayvec v0.5.2
+2026-08-01T02:32:50.4180170Z [1m[92m   Compiling[0m constant_time_eq v0.1.5
+2026-08-01T02:32:50.4623046Z [1m[92m   Compiling[0m unsigned-varint v0.7.2
+2026-08-01T02:32:50.5884932Z [1m[92m   Compiling[0m blake2b_simd v0.5.11
+2026-08-01T02:32:50.6941657Z [1m[92m   Compiling[0m ssi-claims-core v0.1.3
+2026-08-01T02:32:50.8723537Z [1m[92m   Compiling[0m serde_json_canonicalizer v0.3.2
+2026-08-01T02:32:51.1693898Z [1m[92m   Compiling[0m num-derive v0.3.3
+2026-08-01T02:32:51.5863949Z [1m[92m   Compiling[0m simple_asn1 v0.5.4
+2026-08-01T02:32:51.7463618Z [1m[92m   Compiling[0m clear_on_drop v0.2.5
+2026-08-01T02:32:51.9765693Z [1m[92m   Compiling[0m ssi-jwk v0.3.2
+2026-08-01T02:32:52.0404477Z [1m[92m   Compiling[0m affinidi-did-common v0.4.0
+2026-08-01T02:32:52.8439420Z [1m[92m   Compiling[0m crossbeam-epoch v0.9.20
+2026-08-01T02:32:53.1566747Z [1m[92m   Compiling[0m wasm-bindgen-shared v0.2.126
+2026-08-01T02:32:53.4665098Z [1m[92m   Compiling[0m serde_with_macros v3.21.0
+2026-08-01T02:32:53.5520213Z [1m[92m   Compiling[0m pairing v0.23.0
+2026-08-01T02:32:53.6177225Z [1m[92m   Compiling[0m num-iter v0.1.46
+2026-08-01T02:32:53.7023776Z [1m[92m   Compiling[0m num-complex v0.4.6
+2026-08-01T02:32:54.1257171Z [1m[92m   Compiling[0m hashbrown v0.14.5
+2026-08-01T02:32:54.1511061Z [1m[92m   Compiling[0m num v0.4.3
+2026-08-01T02:32:54.1924871Z [1m[92m   Compiling[0m bls12_381_plus v0.8.18
+2026-08-01T02:32:54.3504148Z [1m[92m   Compiling[0m serde_with v3.21.0
+2026-08-01T02:32:54.6835320Z [1m[92m   Compiling[0m dashmap v6.2.1
+2026-08-01T02:32:55.0817186Z [1m[92m   Compiling[0m wasm-bindgen-macro-support v0.2.126
+2026-08-01T02:32:55.8344142Z [1m[92m   Compiling[0m ssi-jws v0.3.1
+2026-08-01T02:32:56.0903830Z [1m[92m   Compiling[0m webpki-roots v1.0.9
+2026-08-01T02:32:56.1685736Z [1m[92m   Compiling[0m ref-cast-impl v1.0.26
+2026-08-01T02:32:56.4833995Z [1m[92m   Compiling[0m parking v2.2.1
+2026-08-01T02:32:56.5813637Z [1m[92m   Compiling[0m event-listener v5.4.2
+2026-08-01T02:32:56.6249152Z [1m[92m   Compiling[0m ref-cast v1.0.26
+2026-08-01T02:32:56.6793869Z [1m[92m   Compiling[0m ssi-verification-methods-core v0.1.2
+2026-08-01T02:32:56.8085160Z [1m[92m   Compiling[0m webpki-roots v0.26.11
+2026-08-01T02:32:56.8505543Z [1m[92m   Compiling[0m affinidi-bbs v0.3.2
+2026-08-01T02:32:57.3683630Z [1m[92m   Compiling[0m portable-atomic v1.14.0
+2026-08-01T02:32:57.6394253Z [1m[92m   Compiling[0m affinidi-secrets-resolver v0.5.8
+2026-08-01T02:32:57.9933888Z [1m[92m   Compiling[0m affinidi-rdf-encoding v0.1.6
+2026-08-01T02:32:58.6847837Z [1m[92m   Compiling[0m asn1-rs-derive v0.6.0
+2026-08-01T02:32:58.7471870Z [1m[92m   Compiling[0m wasm-bindgen-macro v0.2.126
+2026-08-01T02:32:58.9677293Z [1m[92m   Compiling[0m heck v0.5.0
+2026-08-01T02:32:59.1414148Z [1m[92m   Compiling[0m wasm-bindgen v0.2.126
+2026-08-01T02:32:59.2975300Z [1m[92m   Compiling[0m affinidi-data-integrity v0.7.8
+2026-08-01T02:32:59.5814415Z [1m[92m   Compiling[0m ssi-dids-core v0.1.3
+2026-08-01T02:33:00.4649288Z [1m[92m   Compiling[0m event-listener-strategy v0.5.4
+2026-08-01T02:33:00.5533542Z [1m[92m   Compiling[0m axum-core v0.5.6
+2026-08-01T02:33:01.4753600Z [1m[92m   Compiling[0m serde_path_to_error v0.1.20
+2026-08-01T02:33:01.7853731Z [1m[92m   Compiling[0m matchit v0.8.4
+2026-08-01T02:33:01.8345194Z [1m[92m   Compiling[0m async-lock v3.4.2
+2026-08-01T02:33:02.0400361Z [1m[92m   Compiling[0m js-sys v0.3.103
+2026-08-01T02:33:02.1304310Z [1m[92m   Compiling[0m ssi-caips v0.2.2
+2026-08-01T02:33:02.3646536Z [1m[92m   Compiling[0m hmac v0.13.0
+2026-08-01T02:33:02.4010830Z [1m[92m   Compiling[0m universal-hash v0.5.1
+2026-08-01T02:33:02.4713729Z [1m[92m   Compiling[0m semver v1.0.28
+2026-08-01T02:33:02.4850805Z [1m[92m   Compiling[0m bit-vec v0.8.0
+2026-08-01T02:33:02.6453826Z [1m[92m   Compiling[0m borrow-or-share v0.2.4
+2026-08-01T02:33:02.6838226Z [1m[92m   Compiling[0m fluent-uri v0.4.1
+2026-08-01T02:33:02.7873797Z [1m[92m   Compiling[0m bit-set v0.8.0
+2026-08-01T02:33:02.9013797Z [1m[92m   Compiling[0m crossbeam-channel v0.5.16
+2026-08-01T02:33:03.3863514Z [1m[92m   Compiling[0m oid-registry v0.8.1
+2026-08-01T02:33:03.4709372Z [1m[92m   Compiling[0m tagptr v0.2.0
+2026-08-01T02:33:03.5599380Z [1m[92m   Compiling[0m bech32 v0.8.1
+2026-08-01T02:33:03.6023742Z [1m[92m   Compiling[0m micromap v0.3.0
+2026-08-01T02:33:03.7763451Z [1m[92m   Compiling[0m did-pkh v0.3.2
+2026-08-01T02:33:03.8508453Z [1m[92m   Compiling[0m referencing v0.46.10
+2026-08-01T02:33:04.1510768Z [1m[92m   Compiling[0m moka v0.12.15
+2026-08-01T02:33:05.4043785Z [1m[92m   Compiling[0m fancy-regex v0.18.0
+2026-08-01T02:33:05.4278642Z [1m[92m   Compiling[0m unicode-general-category v1.1.0
+2026-08-01T02:33:05.8915104Z [1m[92m   Compiling[0m did-ethr v0.3.2
+2026-08-01T02:33:06.2583905Z [1m[92m   Compiling[0m affinidi-task-utils v0.1.0
+2026-08-01T02:33:06.6113764Z [1m[92m   Compiling[0m fraction v0.15.4
+2026-08-01T02:33:06.8716105Z [1m[92m   Compiling[0m affinidi-did-resolver-traits v0.1.3
+2026-08-01T02:33:07.0053887Z [1m[92m   Compiling[0m web-socket v0.7.0
+2026-08-01T02:33:07.1334883Z [1m[92m   Compiling[0m jsonschema-regex v0.46.10
+2026-08-01T02:33:07.1440896Z [1m[92m   Compiling[0m uuid-simd v0.8.0
+2026-08-01T02:33:07.2700358Z [1m[92m   Compiling[0m email_address v0.2.9
+2026-08-01T02:33:07.4241081Z [1m[92m   Compiling[0m arrayvec v0.7.8
+2026-08-01T02:33:07.5315211Z [1m[92m   Compiling[0m bytecount v0.6.9
+2026-08-01T02:33:07.5853721Z [1m[92m   Compiling[0m highway v1.3.0
+2026-08-01T02:33:07.6541761Z [1m[92m   Compiling[0m num-cmp v0.1.0
+2026-08-01T02:33:07.8943442Z [1m[92m   Compiling[0m libdbus-sys v0.2.7
+2026-08-01T02:33:07.9495037Z [1m[92m   Compiling[0m rapidhash v4.5.1
+2026-08-01T02:33:07.9820221Z [1m[92m   Compiling[0m serde-wasm-bindgen v0.6.5
+2026-08-01T02:33:08.1853787Z [1m[92m   Compiling[0m wasm-bindgen-futures v0.4.76
+2026-08-01T02:33:08.2343675Z [1m[92m   Compiling[0m aead v0.5.2
+2026-08-01T02:33:08.3193343Z [1m[92m   Compiling[0m keccak v0.2.0
+2026-08-01T02:33:08.3593390Z [1m[92m   Compiling[0m metrics v0.24.6
+2026-08-01T02:33:08.4264199Z [1m[92m   Compiling[0m dbus v0.9.12
+2026-08-01T02:33:08.8283772Z [1m[92m   Compiling[0m polyval v0.6.2
+2026-08-01T02:33:08.9921588Z [1m[92m   Compiling[0m regress v0.11.1
+2026-08-01T02:33:09.0504287Z [1m[92m   Compiling[0m tokio-stream v0.1.19
+2026-08-01T02:33:09.4844164Z [1m[92m   Compiling[0m blake2 v0.10.6
+2026-08-01T02:33:09.9114084Z [1m[92m   Compiling[0m utf8parse v0.2.2
+2026-08-01T02:33:09.9707169Z [1m[92m   Compiling[0m anstyle-parse v1.0.0
+2026-08-01T02:33:10.1038410Z [1m[92m   Compiling[0m ghash v0.5.1
+2026-08-01T02:33:10.1767449Z [1m[92m   Compiling[0m asn1-rs v0.7.2
+2026-08-01T02:33:11.5244147Z [1m[92m   Compiling[0m dbus-secret-service v4.1.0
+2026-08-01T02:33:12.7969165Z [1m[92m   Compiling[0m affinidi-messaging-didcomm v0.15.5
+2026-08-01T02:33:12.8104319Z [1m[92m   Compiling[0m ctr v0.9.2
+2026-08-01T02:33:12.9287519Z [1m[92m   Compiling[0m password-hash v0.5.0
+2026-08-01T02:33:13.2964973Z [1m[92m   Compiling[0m sponge-cursor v0.1.0
+2026-08-01T02:33:13.3648617Z [1m[92m   Compiling[0m keyring-core v1.0.0
+2026-08-01T02:33:13.7393711Z [1m[92m   Compiling[0m colorchoice v1.0.5
+2026-08-01T02:33:13.7994758Z [1m[92m   Compiling[0m is_terminal_polyfill v1.70.2
+2026-08-01T02:33:13.8513774Z [1m[92m   Compiling[0m anstyle-query v1.1.5
+2026-08-01T02:33:13.9007109Z [1m[92m   Compiling[0m anstyle v1.0.14
+2026-08-01T02:33:14.0453693Z [1m[92m   Compiling[0m anstream v1.0.0
+2026-08-01T02:33:14.3254205Z [1m[92m   Compiling[0m dbus-secret-service-keyring-store v1.0.0
+2026-08-01T02:33:14.6640622Z [1m[92m   Compiling[0m argon2 v0.5.3
+2026-08-01T02:33:15.1395505Z [1m[92m   Compiling[0m aes-gcm v0.10.3
+2026-08-01T02:33:15.1473641Z [1m[92m   Compiling[0m curve25519-dalek v5.0.0
+2026-08-01T02:33:15.2623569Z [1m[92m   Compiling[0m num-format v0.4.4
+2026-08-01T02:33:15.9033912Z [1m[92m   Compiling[0m poly1305 v0.8.0
+2026-08-01T02:33:16.3343853Z [1m[92m   Compiling[0m chacha20 v0.9.1
+2026-08-01T02:33:16.5163769Z [1m[92m   Compiling[0m sha256 v1.6.0
+2026-08-01T02:33:16.6533826Z [1m[92m   Compiling[0m rustls-pemfile v2.2.0
+2026-08-01T02:33:16.7393849Z [1m[92m   Compiling[0m humantime v2.4.0
+2026-08-01T02:33:16.8053513Z [1m[92m   Compiling[0m half v1.8.3
+2026-08-01T02:33:16.9739789Z [1m[92m   Compiling[0m clap_lex v1.1.0
+2026-08-01T02:33:17.0492696Z [1m[92m   Compiling[0m serde_cbor v0.11.2
+2026-08-01T02:33:17.1723773Z [1m[92m   Compiling[0m clap_builder v4.6.2
+2026-08-01T02:33:17.7233605Z [1m[92m   Compiling[0m chacha20poly1305 v0.10.1
+2026-08-01T02:33:18.1344054Z [1m[92m   Compiling[0m der-parser v10.0.0
+2026-08-01T02:33:18.1584379Z [1m[92m   Compiling[0m sha3 v0.11.0
+2026-08-01T02:33:18.5593755Z [1m[92m   Compiling[0m clap_derive v4.6.4
+2026-08-01T02:33:18.7233837Z [1m[92m   Compiling[0m aws-lc-rs v1.17.3
+2026-08-01T02:33:18.8611137Z [1m[92m   Compiling[0m rustls v0.23.43
+2026-08-01T02:33:18.8803833Z [1m[92m   Compiling[0m affinidi-messaging-core v0.1.5
+2026-08-01T02:33:19.0613675Z [1m[92m   Compiling[0m affinidi-cesr v0.1.3
+2026-08-01T02:33:19.4326305Z [1m[92m   Compiling[0m universal-hash v0.6.1
+2026-08-01T02:33:19.5103639Z [1m[92m   Compiling[0m kem v0.3.0
+2026-08-01T02:33:19.5754878Z [1m[92m   Compiling[0m module-lattice v0.2.3
+2026-08-01T02:33:19.7844175Z [1m[92m   Compiling[0m serde_bytes v0.11.19
+2026-08-01T02:33:19.9743777Z [1m[92m   Compiling[0m ml-kem v0.3.2
+2026-08-01T02:33:20.3093740Z [1m[92m   Compiling[0m clap v4.6.4
+2026-08-01T02:33:20.3575133Z [1m[92m   Compiling[0m utoipa-gen v5.5.0
+2026-08-01T02:33:21.1449681Z [1m[92m   Compiling[0m rustls-webpki v0.103.13
+2026-08-01T02:33:21.2064100Z [1m[92m   Compiling[0m poly1305 v0.9.1
+2026-08-01T02:33:21.5993816Z [1m[92m   Compiling[0m x25519-dalek v3.0.0
+2026-08-01T02:33:21.6843773Z [1m[92m   Compiling[0m sha3 v0.12.0
+2026-08-01T02:33:21.9863833Z [1m[92m   Compiling[0m shake v0.1.0
+2026-08-01T02:33:22.0611686Z [1m[92m   Compiling[0m matchers v0.2.0
+2026-08-01T02:33:22.1464209Z [1m[92m   Compiling[0m affinidi-oid4vc-core v0.1.5
+2026-08-01T02:33:22.3683816Z [1m[92m   Compiling[0m affinidi-sd-jwt v0.1.4
+2026-08-01T02:33:22.9943556Z [1m[92m   Compiling[0m aead v0.6.1
+2026-08-01T02:33:23.0783783Z [1m[92m   Compiling[0m sharded-slab v0.1.7
+2026-08-01T02:33:23.3303691Z [1m[92m   Compiling[0m tracing-serde v0.2.0
+2026-08-01T02:33:23.4464025Z [1m[92m   Compiling[0m tracing-log v0.2.0
+2026-08-01T02:33:23.5743992Z [1m[92m   Compiling[0m thread_local v1.1.10
+2026-08-01T02:33:23.6254245Z [1m[92m   Compiling[0m signature v3.0.0
+2026-08-01T02:33:23.6953387Z [1m[92m   Compiling[0m nu-ansi-term v0.50.3
+2026-08-01T02:33:23.7643739Z [1m[92m   Compiling[0m ed25519 v3.0.0
+2026-08-01T02:33:23.8894359Z [1m[92m   Compiling[0m tracing-subscriber v0.3.23
+2026-08-01T02:33:23.9713464Z [1m[92m   Compiling[0m chacha20poly1305 v0.11.0
+2026-08-01T02:33:24.0492678Z [1m[92m   Compiling[0m affinidi-vc v0.2.1
+2026-08-01T02:33:24.5034056Z [1m[92m   Compiling[0m x-wing v0.1.0
+2026-08-01T02:33:25.5392411Z [1m[92m   Compiling[0m tokio-rustls v0.26.4
+2026-08-01T02:33:25.7703788Z [1m[92m   Compiling[0m hyper-rustls v0.27.9
+2026-08-01T02:33:26.0443968Z [1m[92m   Compiling[0m rustls-platform-verifier v0.7.0
+2026-08-01T02:33:26.2243672Z [1m[92m   Compiling[0m reqwest v0.13.4
+2026-08-01T02:33:26.5793735Z [1m[92m   Compiling[0m tungstenite v0.29.0
+2026-08-01T02:33:26.7533648Z [1m[92m   Compiling[0m utoipa v5.5.0
+2026-08-01T02:33:27.8924000Z [1m[92m   Compiling[0m tokio-tungstenite v0.29.0
+2026-08-01T02:33:28.1953760Z [1m[92m   Compiling[0m axum v0.8.9
+2026-08-01T02:33:29.3864704Z [1m[92m   Compiling[0m didwebvh-rs v0.6.0
+2026-08-01T02:33:30.8543991Z [1m[92m   Compiling[0m jsonschema v0.46.10
+2026-08-01T02:33:32.6043633Z [1m[92m   Compiling[0m agent-names v0.1.3
+2026-08-01T02:33:33.0483724Z [1m[92m   Compiling[0m affinidi-did-web v0.1.3
+2026-08-01T02:33:33.6708324Z [1m[92m   Compiling[0m trust-tasks-rs v0.2.53
+2026-08-01T02:33:33.9465859Z [1m[92m   Compiling[0m did-scid v0.1.12
+2026-08-01T02:33:34.1083837Z [1m[92m   Compiling[0m affinidi-messaging-mediator-common v0.15.32
+2026-08-01T02:33:35.7843968Z [1m[92m   Compiling[0m affinidi-did-resolver-cache-sdk v0.8.21
+2026-08-01T02:33:37.7514117Z [1m[92m   Compiling[0m turboshake v0.7.1
+2026-08-01T02:33:37.8263999Z [1m[92m   Compiling[0m hkdf v0.13.0
+2026-08-01T02:33:37.9093861Z [1m[92m   Compiling[0m hpke v0.14.0
+2026-08-01T02:33:39.6784314Z [1m[92m   Compiling[0m ed25519-dalek v3.0.0
+2026-08-01T02:33:39.8874334Z [1m[92m   Compiling[0m affinidi-openid4vp v0.1.3
+2026-08-01T02:33:40.3954520Z [1m[92m   Compiling[0m affinidi-openid4vci v0.2.1
+2026-08-01T02:33:40.9044014Z [1m[92m   Compiling[0m affinidi-did-authentication v0.3.10
+2026-08-01T02:33:41.4883681Z [1m[92m   Compiling[0m affinidi-tsp v0.1.13
+2026-08-01T02:33:41.6964191Z [1m[92m   Compiling[0m affinidi-tdk-common v0.6.7
+2026-08-01T02:33:41.8663740Z [1m[92m   Compiling[0m aws-nitro-enclaves-nsm-api v0.5.2
+2026-08-01T02:33:42.9393800Z [1m[92m   Compiling[0m affinidi-messaging-delivery v0.1.12
+2026-08-01T02:33:42.9693674Z [1m[92m   Compiling[0m x509-parser v0.18.1
+2026-08-01T02:33:45.1734406Z [1m[92m   Compiling[0m affinidi-meeting-place v0.4.4
+2026-08-01T02:33:45.6403636Z [1m[92m   Compiling[0m coset v0.4.2
+2026-08-01T02:33:45.8773619Z [1m[92m   Compiling[0m rustix v1.1.4
+2026-08-01T02:33:46.2164138Z [1m[92m   Compiling[0m linux-raw-sys v0.12.1
+2026-08-01T02:33:47.2504199Z [1m[92m   Compiling[0m pem v3.0.6
+2026-08-01T02:33:47.5803544Z [1m[92m   Compiling[0m openssl-sys v0.9.117
+2026-08-01T02:33:48.0463827Z [1m[92m   Compiling[0m unicode-width v0.2.2
+2026-08-01T02:33:48.2453563Z [1m[92m   Compiling[0m asn1-rs-derive v0.5.1
+2026-08-01T02:33:48.7776704Z [1m[92m   Compiling[0m tempfile v3.27.0
+2026-08-01T02:33:48.7886296Z [1m[92m   Compiling[0m xxhash-rust v0.8.18
+2026-08-01T02:33:48.9970517Z [1m[92m   Compiling[0m asn1-rs v0.6.2
+2026-08-01T02:33:49.0236050Z [1m[92m   Compiling[0m foreign-types-shared v0.1.1
+2026-08-01T02:33:49.0733924Z [1m[92m   Compiling[0m base64 v0.21.7
+2026-08-01T02:33:49.2163811Z [1m[92m   Compiling[0m openssl v0.10.81
+2026-08-01T02:33:49.2333665Z [1m[92m   Compiling[0m foreign-types v0.3.2
+2026-08-01T02:33:49.3783840Z [1m[92m   Compiling[0m base64urlsafedata v0.5.5
+2026-08-01T02:33:49.5174358Z [1m[92m   Compiling[0m simple_asn1 v0.6.4
+2026-08-01T02:33:49.7033963Z [1m[92m   Compiling[0m headers-core v0.3.0
+2026-08-01T02:33:49.7673815Z [1m[92m   Compiling[0m openssl-macros v0.1.1
+2026-08-01T02:33:49.9894255Z [1m[92m   Compiling[0m webauthn-attestation-ca v0.5.5
+2026-08-01T02:33:50.6403883Z [1m[92m   Compiling[0m der-parser v9.0.0
+2026-08-01T02:33:50.6974427Z [1m[92m   Compiling[0m oid-registry v0.7.1
+2026-08-01T02:33:51.0504334Z [1m[92m   Compiling[0m jsonwebtoken v10.4.0
+2026-08-01T02:33:51.3303785Z [1m[92m   Compiling[0m headers v0.4.1
+2026-08-01T02:33:52.3093821Z [1m[92m   Compiling[0m byteorder-lite v0.1.0
+2026-08-01T02:33:52.5639799Z [1m[92m   Compiling[0m compare v0.0.6
+2026-08-01T02:33:52.6613773Z [1m[92m   Compiling[0m twox-hash v2.1.3
+2026-08-01T02:33:52.7583747Z [1m[92m   Compiling[0m lz4_flex v0.13.1
+2026-08-01T02:33:52.8453746Z [1m[92m   Compiling[0m webauthn-rs-core v0.5.5
+2026-08-01T02:33:52.8583495Z [1m[92m   Compiling[0m interval-heap v0.0.5
+2026-08-01T02:33:52.9663963Z [1m[92m   Compiling[0m sfa v1.0.0
+2026-08-01T02:33:53.1903777Z [1m[92m   Compiling[0m axum-extra v0.12.6
+2026-08-01T02:33:53.5499184Z [1m[92m   Compiling[0m x509-parser v0.16.0
+2026-08-01T02:33:53.9511163Z [1m[92m   Compiling[0m webauthn-rs-proto v0.5.5
+2026-08-01T02:33:54.2043598Z [1m[92m   Compiling[0m crossbeam-skiplist v0.1.3
+2026-08-01T02:33:54.4703743Z [1m[92m   Compiling[0m quick_cache v0.6.24
+2026-08-01T02:33:54.8783725Z [1m[92m   Compiling[0m serde_cbor_2 v0.13.0
+2026-08-01T02:33:54.9064019Z [1m[92m   Compiling[0m enum_dispatch v0.3.13
+2026-08-01T02:33:55.5583711Z [1m[92m   Compiling[0m spin v0.9.9
+2026-08-01T02:33:55.6794099Z [1m[92m   Compiling[0m byteview v0.10.2
+2026-08-01T02:33:55.7464549Z [1m[92m   Compiling[0m self_cell v1.3.0
+2026-08-01T02:33:55.8244169Z [1m[92m   Compiling[0m rustc-hash v2.1.3
+2026-08-01T02:33:55.9014224Z [1m[92m   Compiling[0m varint-rs v2.2.1
+2026-08-01T02:33:55.9093498Z [1m[92m   Compiling[0m flume v0.12.0
+2026-08-01T02:33:55.9994039Z [1m[92m   Compiling[0m lsm-tree v3.1.8
+2026-08-01T02:33:56.2149821Z [1m[92m   Compiling[0m console v0.16.4
+2026-08-01T02:33:56.8993744Z [1m[92m   Compiling[0m shell-words v1.1.1
+2026-08-01T02:33:57.0114537Z [1m[92m   Compiling[0m dialoguer v0.12.0
+2026-08-01T02:33:57.8384944Z [1m[92m   Compiling[0m utoipa-axum v0.2.0
+2026-08-01T02:33:58.0353612Z [1m[92m   Compiling[0m either v1.17.0
+2026-08-01T02:33:58.2223702Z [1m[92m   Compiling[0m webauthn-rs v0.5.5
+2026-08-01T02:33:58.6563664Z [1m[92m   Compiling[0m fjall v3.1.8
+2026-08-01T02:34:00.3233576Z [1m[92m   Compiling[0m adler2 v2.0.1
+2026-08-01T02:34:00.4083859Z [1m[92m   Compiling[0m crc32fast v1.5.0
+2026-08-01T02:34:00.5433469Z [1m[92m   Compiling[0m winnow v1.0.4
+2026-08-01T02:34:00.9003855Z [1m[92m   Compiling[0m toml_parser v1.1.3+spec-1.1.0
+2026-08-01T02:34:01.7063751Z [1m[92m   Compiling[0m toml_datetime v1.1.1+spec-1.1.0
+2026-08-01T02:34:01.8763725Z [1m[92m   Compiling[0m serde_spanned v1.1.1
+2026-08-01T02:34:01.9586073Z [1m[92m   Compiling[0m toml_writer v1.1.2+spec-1.1.0
+2026-08-01T02:34:01.9713562Z [1m[92m   Compiling[0m anyhow v1.0.104
+2026-08-01T02:34:02.1238295Z [1m[92m   Compiling[0m toml v1.1.4+spec-1.1.0
+2026-08-01T02:34:02.3223858Z [1m[92m   Compiling[0m lru v0.18.1
+2026-08-01T02:34:02.4543689Z [1m[92m   Compiling[0m itertools v0.14.0
+2026-08-01T02:34:02.5593929Z [1m[92m   Compiling[0m arc-swap v1.9.2
+2026-08-01T02:34:02.8033928Z [1m[92m   Compiling[0m tinyvec_macros v0.1.1
+2026-08-01T02:34:02.8463686Z [1m[92m   Compiling[0m tinyvec v1.12.0
+2026-08-01T02:34:03.2043811Z [1m[92m   Compiling[0m hex-conservative v0.2.2
+2026-08-01T02:34:03.4173784Z [1m[92m   Compiling[0m bitcoin_hashes v0.14.101
+2026-08-01T02:34:03.8920126Z [1m[92m   Compiling[0m unicode-normalization v0.1.25
+2026-08-01T02:34:03.9463976Z [1m[92m   Compiling[0m simd-adler32 v0.3.10
+2026-08-01T02:34:04.1073556Z [1m[92m   Compiling[0m miniz_oxide v0.8.9
+2026-08-01T02:34:04.3233707Z [1m[92m   Compiling[0m bip39 v2.2.2
+2026-08-01T02:34:04.5793716Z [1m[92m   Compiling[0m raw-cpuid v11.6.0
+2026-08-01T02:34:04.8109857Z [1m[92m   Compiling[0m flate2 v1.1.9
+2026-08-01T02:34:04.8503723Z [1m[92m   Compiling[0m siphasher v1.0.3
+2026-08-01T02:34:05.0163896Z [1m[92m   Compiling[0m phf_shared v0.12.1
+2026-08-01T02:34:05.1503830Z [1m[92m   Compiling[0m affinidi-status-list v0.1.4
+2026-08-01T02:34:05.2233563Z [1m[92m   Compiling[0m phf v0.12.1
+2026-08-01T02:34:05.3343704Z [1m[92m   Compiling[0m regorus v0.10.1
+2026-08-01T02:34:05.5329236Z [1m[92m   Compiling[0m cobs v0.3.0
+2026-08-01T02:34:05.6067152Z [1m[92m   Compiling[0m spinning_top v0.3.0
+2026-08-01T02:34:05.6772435Z [1m[92m   Compiling[0m bstr v1.13.0
+2026-08-01T02:34:05.6883550Z [1m[92m   Compiling[0m web-time v1.1.0
+2026-08-01T02:34:05.7403790Z [1m[92m   Compiling[0m nonzero_ext v0.3.0
+2026-08-01T02:34:05.8283745Z [1m[92m   Compiling[0m futures-timer v3.0.4
+2026-08-01T02:34:06.2009021Z [1m[92m   Compiling[0m unsafe-libyaml v0.2.11
+2026-08-01T02:34:06.2103637Z [1m[92m   Compiling[0m globset v0.4.19
+2026-08-01T02:34:06.9033816Z [1m[92m   Compiling[0m quanta v0.12.6
+2026-08-01T02:34:07.0403684Z [1m[92m   Compiling[0m serde_yaml v0.9.34+deprecated
+2026-08-01T02:34:07.0770446Z [1m[92m   Compiling[0m governor v0.10.4
+2026-08-01T02:34:07.2394445Z [1m[92m   Compiling[0m postcard v1.1.3
+2026-08-01T02:34:07.4183518Z [1m[92m   Compiling[0m chrono-tz v0.10.4
+2026-08-01T02:34:07.5561116Z [1m[92m   Compiling[0m msvc_spectre_libs v0.1.3
+2026-08-01T02:34:07.6133785Z [1m[92m   Compiling[0m left-right v0.11.8
+2026-08-01T02:34:07.7522774Z [1m[92m   Compiling[0m rand_xoshiro v0.7.0
+2026-08-01T02:34:08.0113722Z [1m[92m   Compiling[0m num_cpus v1.17.0
+2026-08-01T02:34:08.3535914Z [1m[92m   Compiling[0m hashbag v0.1.13
+2026-08-01T02:34:08.4823617Z [1m[92m   Compiling[0m sketches-ddsketch v0.3.1
+2026-08-01T02:34:08.6853700Z [1m[92m   Compiling[0m spin v0.10.1
+2026-08-01T02:34:08.7633699Z [1m[92m   Compiling[0m deadpool-runtime v0.1.4
+2026-08-01T02:34:08.8441755Z [1m[92m   Compiling[0m metrics-exporter-prometheus v0.18.3
+2026-08-01T02:34:08.9743892Z [1m[92m   Compiling[0m deadpool v0.12.3
+2026-08-01T02:34:08.9918535Z [1m[92m   Compiling[0m metrics-util v0.20.4
+2026-08-01T02:34:09.2453137Z [1m[92m   Compiling[0m evmap v11.0.0
+2026-08-01T02:34:09.5133744Z [1m[92m   Compiling[0m assert-json-diff v2.0.2
+2026-08-01T02:34:09.9493737Z [1m[92m   Compiling[0m wiremock v0.6.5
+2026-08-01T02:34:10.9434812Z [1m[92m   Compiling[0m hyper-timeout v0.5.2
+2026-08-01T02:34:11.1254020Z [1m[92m   Compiling[0m nonempty v0.7.0
+2026-08-01T02:34:11.2394519Z [1m[92m   Compiling[0m forwarded-header-value v0.1.1
+2026-08-01T02:34:11.4913640Z [1m[92m   Compiling[0m tonic v0.14.6
+2026-08-01T02:34:16.0693543Z [1m[92m   Compiling[0m tower_governor v0.8.0
+2026-08-01T02:34:16.3283851Z [1m[92m   Compiling[0m fs-err v3.3.1
+2026-08-01T02:34:16.4135181Z [1m[92m   Compiling[0m backon v1.6.0
+2026-08-01T02:34:16.6063482Z [1m[92m   Compiling[0m combine v4.6.7
+2026-08-01T02:34:16.9093500Z [1m[92m   Compiling[0m sha1_smol v1.0.1
+2026-08-01T02:34:17.0783624Z [1m[92m   Compiling[0m arcstr v1.2.0
+2026-08-01T02:34:17.3243775Z [1m[92m   Compiling[0m axum-server v0.8.0
+2026-08-01T02:34:17.9533717Z [1m[92m   Compiling[0m affinidi-rate-limit v0.1.0
+2026-08-01T02:34:18.5914622Z [1m[92m   Compiling[0m affinidi-messaging-mediator-config v0.2.0
+2026-08-01T02:34:20.5759813Z [1m[92m   Compiling[0m async-convert v1.0.0
+2026-08-01T02:34:20.6413673Z [1m[92m   Compiling[0m http v0.2.12
+2026-08-01T02:34:20.7863728Z [1m[92m   Compiling[0m redis v1.5.0
+2026-08-01T02:34:21.7135670Z [1m[92m   Compiling[0m hostname v0.4.2
+2026-08-01T02:34:21.8454157Z [1m[92m   Compiling[0m unicase v2.9.0
+2026-08-01T02:34:22.0029031Z [1m[92m   Compiling[0m mime_guess v2.0.5
+2026-08-01T02:34:22.4173820Z [1m[92m   Compiling[0m http-body v0.4.6
+2026-08-01T02:34:23.0723984Z [1m[92m   Compiling[0m bytes-utils v0.1.4
+2026-08-01T02:34:23.2879122Z [1m[92m   Compiling[0m base64-simd v0.8.0
+2026-08-01T02:34:23.6833573Z [1m[92m   Compiling[0m pin-utils v0.1.0
+2026-08-01T02:34:23.7230705Z [1m[92m   Compiling[0m aws-smithy-types v1.6.1
+2026-08-01T02:34:25.5493549Z [1m[92m   Compiling[0m aws-smithy-async v1.3.0
+2026-08-01T02:34:25.7699485Z [1m[92m   Compiling[0m aws-smithy-runtime-api-macros v1.1.0
+2026-08-01T02:34:26.0183732Z [1m[92m   Compiling[0m aws-smithy-runtime-api v1.14.0
+2026-08-01T02:34:28.1103627Z [1m[92m   Compiling[0m affinidi-sd-jwt-vc v0.2.0
+2026-08-01T02:34:28.1611025Z [1m[92m   Compiling[0m serde_ignored v0.1.14
+2026-08-01T02:34:28.3173789Z [1m[92m   Compiling[0m affinidi-messaging-sdk v0.18.65
+2026-08-01T02:34:30.2143799Z [1m[92m   Compiling[0m trust-tasks-capability-client v0.1.0
+2026-08-01T02:34:30.7494253Z [1m[92m   Compiling[0m trust-tasks-https v0.2.2
+2026-08-01T02:34:32.1573496Z [1m[92m   Compiling[0m xattr v1.6.1
+2026-08-01T02:34:32.4433795Z [1m[92m   Compiling[0m include_dir_macros v0.7.4
+2026-08-01T02:34:32.7183715Z [1m[92m   Compiling[0m filetime v0.2.29
+2026-08-01T02:34:32.8832490Z [1m[92m   Compiling[0m vtc-service v0.11.50 (/home/runner/work/verifiable-trust-infrastructure/verifiable-trust-infrastructure/vtc-service)
+2026-08-01T02:34:33.0794038Z [1m[92m   Compiling[0m rustls v0.21.12
+2026-08-01T02:34:33.1059470Z [1m[92m   Compiling[0m tar v0.4.46
+2026-08-01T02:34:34.0704076Z [1m[92m   Compiling[0m include_dir v0.7.4
+2026-08-01T02:34:34.1795569Z [1m[92m   Compiling[0m aws-smithy-schema v0.2.0
+2026-08-01T02:34:34.1883986Z [1m[92m   Compiling[0m gethostname v1.1.0
+2026-08-01T02:34:34.2713677Z [1m[92m   Compiling[0m dtg-credentials v0.1.3
+2026-08-01T02:34:34.8893794Z [1m[92m   Compiling[0m rustls-webpki v0.101.7
+2026-08-01T02:34:34.9901019Z [1m[92m   Compiling[0m sct v0.7.1
+2026-08-01T02:34:35.1194026Z [1m[92m   Compiling[0m unicode-segmentation v1.13.3
+2026-08-01T02:34:35.5469563Z [1m[92m   Compiling[0m affinidi-tdk v0.8.4
+2026-08-01T02:34:36.0993162Z [1m[92m   Compiling[0m vta-sdk v0.21.1 (/home/runner/work/verifiable-trust-infrastructure/verifiable-trust-infrastructure/vta-sdk)
+2026-08-01T02:34:38.6336300Z [1m[92m   Compiling[0m h2 v0.3.27
+2026-08-01T02:34:40.4664066Z [1m[92m   Compiling[0m socket2 v0.5.10
+2026-08-01T02:34:41.0254163Z [1m[92m   Compiling[0m tokio-rustls v0.24.1
+2026-08-01T02:34:41.2524119Z [1m[92m   Compiling[0m aws-credential-types v1.3.0
+2026-08-01T02:34:41.6663513Z [1m[92m   Compiling[0m aws-smithy-http v0.64.0
+2026-08-01T02:34:42.0393868Z [1m[92m   Compiling[0m aws-smithy-observability v0.3.0
+2026-08-01T02:34:42.2863641Z [1m[92m   Compiling[0m strum_macros v0.28.0
+2026-08-01T02:34:44.3258835Z [1m[92m   Compiling[0m hyper v0.14.32
+2026-08-01T02:34:44.8534122Z [1m[92m   Compiling[0m castaway v0.2.4
+2026-08-01T02:34:44.9193866Z [1m[92m   Compiling[0m derivation-path v0.2.0
+2026-08-01T02:34:45.1073849Z [1m[92m   Compiling[0m ed25519-dalek-bip32 v0.3.0
+2026-08-01T02:34:45.2643723Z [1m[92m   Compiling[0m compact_str v0.9.1
+2026-08-01T02:34:45.9164677Z [1m[92m   Compiling[0m strum v0.28.0
+2026-08-01T02:34:46.0139598Z [1m[92m   Compiling[0m aws-types v1.5.0
+2026-08-01T02:34:46.6263632Z [1m[92m   Compiling[0m aws-sigv4 v1.5.1
+2026-08-01T02:34:47.6220253Z [1m[92m   Compiling[0m convert_case v0.10.0
+2026-08-01T02:34:47.9388768Z [1m[92m   Compiling[0m unicode-truncate v2.0.1
+2026-08-01T02:34:48.0742298Z [1m[92m   Compiling[0m kasuari v0.4.12
+2026-08-01T02:34:48.7963862Z [1m[92m   Compiling[0m hyper-rustls v0.24.2
+2026-08-01T02:34:48.8463669Z [1m[92m   Compiling[0m critical-section v1.2.0
+2026-08-01T02:34:48.9103666Z [1m[92m   Compiling[0m ratatui-core v0.1.2
+2026-08-01T02:34:49.0064711Z [1m[92m   Compiling[0m aws-smithy-http-client v1.2.0
+2026-08-01T02:34:49.8433789Z [1m[92m   Compiling[0m derive_more-impl v2.1.1
+2026-08-01T02:34:50.4474071Z [1m[92m   Compiling[0m signal-hook v0.3.18
+2026-08-01T02:34:50.7133734Z [1m[92m   Compiling[0m instability v0.3.12
+2026-08-01T02:34:50.9866519Z [1m[92m   Compiling[0m aws-smithy-runtime v1.12.1
+2026-08-01T02:34:51.1804181Z [1m[92m   Compiling[0m aws-smithy-json v0.63.0
+2026-08-01T02:34:52.1294386Z [1m[92m   Compiling[0m vti-common v0.11.32 (/home/runner/work/verifiable-trust-infrastructure/verifiable-trust-infrastructure/vti-common)
+2026-08-01T02:34:56.4243969Z [1m[92m   Compiling[0m affinidi-messaging-mediator v0.18.1
+2026-08-01T02:34:58.4244671Z [1m[92m   Compiling[0m vtc-client v0.3.1 (/home/runner/work/verifiable-trust-infrastructure/verifiable-trust-infrastructure/vtc-client)
+2026-08-01T02:34:59.1293904Z [1m[92m   Compiling[0m aws-runtime v1.9.1
+2026-08-01T02:35:01.6553619Z [1m[92m   Compiling[0m regex-lite v0.1.9
+2026-08-01T02:35:02.7864720Z [1m[92m   Compiling[0m vti-secrets v0.1.9 (/home/runner/work/verifiable-trust-infrastructure/verifiable-trust-infrastructure/vti-secrets)
+2026-08-01T02:35:03.6934262Z [1m[92m   Compiling[0m vta-keyspaces v0.1.1 (/home/runner/work/verifiable-trust-infrastructure/verifiable-trust-infrastructure/vta-keyspaces)
+2026-08-01T02:35:03.7563817Z [1m[92m   Compiling[0m vta-config v0.3.0 (/home/runner/work/verifiable-trust-infrastructure/verifiable-trust-infrastructure/vta-config)
+2026-08-01T02:35:03.8233918Z [1m[92m   Compiling[0m signal-hook-mio v0.2.5
+2026-08-01T02:35:03.8943723Z [1m[92m   Compiling[0m derive_more v2.1.1
+2026-08-01T02:35:03.9404164Z [1m[92m   Compiling[0m line-clipping v0.3.7
+2026-08-01T02:35:04.1234105Z [1m[92m   Compiling[0m ratatui-widgets v0.3.2
+2026-08-01T02:35:06.1624919Z [1m[92m   Compiling[0m vta-support v0.2.3 (/home/runner/work/verifiable-trust-infrastructure/verifiable-trust-infrastructure/vta-support)
+2026-08-01T02:35:07.4274775Z [1m[92m   Compiling[0m vta-keys v0.2.0 (/home/runner/work/verifiable-trust-infrastructure/verifiable-trust-infrastructure/vta-keys)
+2026-08-01T02:35:08.7676145Z [1m[92m   Compiling[0m crossterm v0.29.0
+2026-08-01T02:35:09.8354262Z [1m[92m   Compiling[0m xmlparser v0.13.6
+2026-08-01T02:35:09.9563916Z [1m[92m   Compiling[0m ratatui-crossterm v0.1.2
+2026-08-01T02:35:10.1033674Z [1m[92m   Compiling[0m aws-smithy-xml v0.62.0
+2026-08-01T02:35:10.2233729Z [1m[92m   Compiling[0m ratatui-macros v0.7.2
+2026-08-01T02:35:10.2794891Z [1m[92m   Compiling[0m urlencoding v2.1.3
+2026-08-01T02:35:10.4173816Z [1m[92m   Compiling[0m affinidi-messaging-test-mediator v0.2.44
+2026-08-01T02:35:10.6287706Z [1m[92m   Compiling[0m aws-smithy-query v0.62.0
+2026-08-01T02:35:10.8833703Z [1m[92m   Compiling[0m ratatui v0.30.2
+2026-08-01T02:35:11.1423520Z [1m[92m   Compiling[0m aws-sdk-sts v1.110.0
+2026-08-01T02:35:11.2695045Z [1m[92m   Compiling[0m vta-vault v0.1.2 (/home/runner/work/verifiable-trust-infrastructure/verifiable-trust-infrastructure/vta-vault)
+2026-08-01T02:35:14.9214261Z [1m[92m   Compiling[0m vta-audit v0.1.2 (/home/runner/work/verifiable-trust-infrastructure/verifiable-trust-infrastructure/vta-audit)
+2026-08-01T02:35:15.6723734Z [1m[92m   Compiling[0m aws-sdk-sso v1.105.0
+2026-08-01T02:35:16.5473564Z [1m[92m   Compiling[0m aws-sdk-ssooidc v1.107.0
+2026-08-01T02:35:19.2927019Z [1m[92m   Compiling[0m trust-tasks-proof v0.2.2
+2026-08-01T02:35:20.3063692Z [1m[92m   Compiling[0m cpubits v0.1.1
+2026-08-01T02:35:20.3573726Z [1m[92m   Compiling[0m option-ext v0.2.0
+2026-08-01T02:35:20.4103592Z [1m[92m   Compiling[0m dirs-sys v0.5.0
+2026-08-01T02:35:20.6793593Z [1m[92m   Compiling[0m aes v0.9.2
+2026-08-01T02:35:21.0563695Z [1m[92m   Compiling[0m aws-config v1.10.1
+2026-08-01T02:35:22.4174428Z [1m[92m   Compiling[0m vta-cli-common v0.10.23 (/home/runner/work/verifiable-trust-infrastructure/verifiable-trust-infrastructure/vta-cli-common)
+2026-08-01T02:35:26.9184347Z [1m[92m   Compiling[0m vta-webvh v0.1.3 (/home/runner/work/verifiable-trust-infrastructure/verifiable-trust-infrastructure/vta-webvh)
+2026-08-01T02:35:28.7384177Z [1m[92m   Compiling[0m aws-sdk-dynamodb v1.119.0
+2026-08-01T02:35:29.7003601Z [1m[92m   Compiling[0m aws-sdk-kms v1.114.0
+2026-08-01T02:35:31.0428394Z [1m[92m   Compiling[0m cbc v0.2.1
+2026-08-01T02:35:31.1273734Z [1m[92m   Compiling[0m dirs v6.0.0
+2026-08-01T02:35:31.1949066Z [1m[92m   Compiling[0m vti-webauthn v0.1.0 (/home/runner/work/verifiable-trust-infrastructure/verifiable-trust-infrastructure/vti-webauthn)
+2026-08-01T02:35:31.7574525Z [1m[92m   Compiling[0m vta-sweepers v0.1.0 (/home/runner/work/verifiable-trust-infrastructure/verifiable-trust-infrastructure/vta-sweepers)
+2026-08-01T02:35:32.4494312Z [1m[92m   Compiling[0m vta-backup v0.1.5 (/home/runner/work/verifiable-trust-infrastructure/verifiable-trust-infrastructure/vta-backup)
+2026-08-01T02:35:36.8564804Z [1m[92m   Compiling[0m vta-policy v0.1.2 (/home/runner/work/verifiable-trust-infrastructure/verifiable-trust-infrastructure/vta-policy)
+2026-08-01T02:35:41.1801749Z [1m[92m   Compiling[0m vta-tee v0.1.5 (/home/runner/work/verifiable-trust-infrastructure/verifiable-trust-infrastructure/vta-tee)
+2026-08-01T02:35:44.3774413Z [1m[92m   Compiling[0m vta-service v0.14.1 (/home/runner/work/verifiable-trust-infrastructure/verifiable-trust-infrastructure/vta-service)
+2026-08-01T02:35:54.1983894Z [1m[92m   Compiling[0m zip v2.4.2
+2026-08-01T02:35:55.0203885Z [1m[92m   Compiling[0m zopfli v0.8.3
+2026-08-01T02:35:56.3255276Z [1m[92m   Compiling[0m x509-parser v0.17.0
+2026-08-01T02:35:58.7953694Z [1m[92m   Compiling[0m yasna v0.5.2
+2026-08-01T02:35:59.2953760Z [1m[92m   Compiling[0m nitro_attest v0.2.0
+2026-08-01T02:35:59.6067033Z [1m[92m   Compiling[0m rcgen v0.13.2
+2026-08-01T02:35:59.6344134Z [1m[92m   Compiling[0m aws-nitro-enclaves-nsm-api v0.4.0
+2026-08-01T02:36:00.9496425Z [1m[92m   Compiling[0m coset v0.3.8
+2026-08-01T02:36:03.1683535Z [1m[92m   Compiling[0m fs-err v2.11.0
+2026-08-01T02:36:03.2890775Z [1m[92m   Compiling[0m camino v1.2.5
+2026-08-01T02:36:03.7544163Z [1m[92m   Compiling[0m cargo-platform v0.1.9
+2026-08-01T02:36:03.9054300Z [1m[92m   Compiling[0m uniffi_checksum_derive v0.28.3
+2026-08-01T02:36:03.9653647Z [1m[92m   Compiling[0m siphasher v0.3.11
+2026-08-01T02:36:04.1154197Z [1m[92m   Compiling[0m cargo_metadata v0.15.4
+2026-08-01T02:36:04.1853883Z [1m[92m   Compiling[0m uniffi_meta v0.28.3
+2026-08-01T02:36:05.2764160Z [1m[92m   Compiling[0m basic-toml v0.1.10
+2026-08-01T02:36:05.8883531Z [1m[92m   Compiling[0m askama_parser v0.2.1
+2026-08-01T02:36:05.9463871Z [1m[92m   Compiling[0m scroll_derive v0.12.1
+2026-08-01T02:36:06.4733623Z [1m[92m   Compiling[0m smawk v0.3.3
+2026-08-01T02:36:06.7633655Z [1m[92m   Compiling[0m textwrap v0.16.2
+2026-08-01T02:36:07.2233644Z [1m[92m   Compiling[0m scroll v0.12.0
+2026-08-01T02:36:07.4353690Z [1m[92m   Compiling[0m uniffi_testing v0.28.3
+2026-08-01T02:36:07.7986183Z [1m[92m   Compiling[0m askama_derive v0.12.5
+2026-08-01T02:36:08.3964090Z [1m[92m   Compiling[0m weedle2 v5.0.0
+2026-08-01T02:36:09.3930649Z [1m[92m   Compiling[0m plain v0.2.3
+2026-08-01T02:36:09.4573694Z [1m[92m   Compiling[0m askama_escape v0.10.3
+2026-08-01T02:36:09.5203910Z [1m[92m   Compiling[0m askama v0.12.1
+2026-08-01T02:36:09.6483466Z [1m[92m   Compiling[0m goblin v0.8.2
+2026-08-01T02:36:11.1633507Z [1m[92m   Compiling[0m uniffi_udl v0.28.3
+2026-08-01T02:36:12.4964027Z [1m[92m   Compiling[0m bincode v1.3.3
+2026-08-01T02:36:12.8543542Z [1m[92m   Compiling[0m toml v0.5.11
+2026-08-01T02:36:14.4883924Z [1m[92m   Compiling[0m async-compat v0.2.5
+2026-08-01T02:36:14.7223528Z [1m[92m   Compiling[0m glob v0.3.4
+2026-08-01T02:36:15.1223542Z [1m[92m   Compiling[0m uniffi_core v0.28.3
+2026-08-01T02:36:15.4784119Z [1m[92m   Compiling[0m uniffi_bindgen v0.28.3
+2026-08-01T02:36:16.2533614Z [1m[92m   Compiling[0m uniffi_macros v0.28.3
+2026-08-01T02:36:19.3979753Z [1m[92m   Compiling[0m serde_derive_internals v0.30.0
+2026-08-01T02:36:20.2574264Z [1m[92m   Compiling[0m schemars_derive v1.2.2
+2026-08-01T02:36:21.6873954Z [1m[92m   Compiling[0m dyn-clone v1.0.20
+2026-08-01T02:36:21.7717729Z [1m[92m   Compiling[0m rmcp v1.8.0
+2026-08-01T02:36:21.9423727Z [1m[92m   Compiling[0m schemars v1.2.2
+2026-08-01T02:36:22.6264300Z [1m[92m   Compiling[0m rmcp-macros v1.8.0
+2026-08-01T02:36:23.6003549Z [1m[92m   Compiling[0m pastey v0.2.3
+2026-08-01T02:36:23.9827811Z [1m[92m   Compiling[0m uniffi v0.28.3
+2026-08-01T02:36:30.7686073Z [1m[92m   Compiling[0m vta-mobile-core v0.6.17 (/home/runner/work/verifiable-trust-infrastructure/verifiable-trust-infrastructure/vta-mobile-core)
+2026-08-01T02:36:37.3345005Z [1m[92m   Compiling[0m vta-mcp v0.1.5 (/home/runner/work/verifiable-trust-infrastructure/verifiable-trust-infrastructure/vta-mcp)
+2026-08-01T02:37:25.0306369Z [1m[92m   Compiling[0m vta-enclave v0.7.7 (/home/runner/work/verifiable-trust-infrastructure/verifiable-trust-infrastructure/vta-enclave)
+2026-08-01T02:37:28.9284895Z [1m[92m   Compiling[0m vti-e2e-tests v0.6.0 (/home/runner/work/verifiable-trust-infrastructure/verifiable-trust-infrastructure/tests/e2e)
+2026-08-01T02:41:13.6222196Z [1m[92m   Compiling[0m pnm-cli v0.11.17 (/home/runner/work/verifiable-trust-infrastructure/verifiable-trust-infrastructure/pnm-cli)
+2026-08-01T02:41:20.0025480Z [1m[92m   Compiling[0m cnm-cli v0.11.14 (/home/runner/work/verifiable-trust-infrastructure/verifiable-trust-infrastructure/cnm-cli)
+2026-08-01T02:42:02.5126391Z [1m[92m   Compiling[0m didcomm-test v0.6.8 (/home/runner/work/verifiable-trust-infrastructure/verifiable-trust-infrastructure/didcomm-test)
+2026-08-01T02:42:23.8793949Z [1m[92m    Finished[0m `test` profile [unoptimized + debuginfo] target(s) in 10m 42s
+2026-08-01T02:42:25.7030112Z [1m[92m     Running[0m unittests src/main.rs (target/debug/deps/cnm-d31ca76096630a83)
+2026-08-01T02:42:25.7057265Z 
+2026-08-01T02:42:25.7060572Z running 26 tests
+2026-08-01T02:42:25.7162593Z test backup::tests::file_stamp_falls_back_without_timestamp ... ok
+2026-08-01T02:42:25.7173472Z test backup::tests::file_stamp_uses_created_at_digits ... ok
+2026-08-01T02:42:25.7180318Z test backup::tests::print_counts_tolerates_missing_or_empty ... ok
+2026-08-01T02:42:25.7186763Z test config::tests::test_community_keyring_key ... ok
+2026-08-01T02:42:25.7190076Z test config::tests::test_config_default_is_empty ... ok
+2026-08-01T02:42:25.7195863Z test config::tests::test_config_deserialize_empty_toml ... ok
+2026-08-01T02:42:25.7203903Z test config::tests::test_config_round_trip ... ok
+2026-08-01T02:42:25.7209434Z test config::tests::test_resolve_community_no_default_no_override_fails ... ok
+2026-08-01T02:42:25.7212020Z test config::tests::test_resolve_community_slug_not_found_fails ... ok
+2026-08-01T02:42:25.7215014Z test config::tests::test_legacy_url_is_silently_dropped ... ok
+2026-08-01T02:42:25.7217791Z test config::tests::test_resolve_community_with_override ... ok
+2026-08-01T02:42:25.7223857Z test config::tests::test_resolve_community_with_default ... ok
+2026-08-01T02:42:25.7227158Z test setup::tests::test_slugify_already_slug ... ok
+2026-08-01T02:42:25.7229324Z test setup::tests::test_slugify_basic ... ok
+2026-08-01T02:42:25.7231375Z test setup::tests::test_slugify_multiple_spaces ... ok
+2026-08-01T02:42:25.7232569Z test setup::tests::test_slugify_numbers ... ok
+2026-08-01T02:42:25.7234602Z test setup::tests::test_slugify_special_chars ... ok
+2026-08-01T02:42:25.7236745Z test setup::tests::test_slugify_uppercase ... ok
+2026-08-01T02:42:25.7238750Z test tests::test_requires_auth_acl_true ... ok
+2026-08-01T02:42:25.7239408Z test tests::test_requires_auth_config_true ... ok
+2026-08-01T02:42:25.7241529Z test tests::test_requires_auth_auth_login_false ... ok
+2026-08-01T02:42:25.7243634Z test tests::test_requires_auth_community_false ... ok
+2026-08-01T02:42:25.7245608Z test tests::test_requires_auth_contexts_true ... ok
+2026-08-01T02:42:25.7248536Z test tests::test_requires_auth_health_false ... ok
+2026-08-01T02:42:25.7267830Z test tests::test_requires_auth_setup_false ... ok
+2026-08-01T02:42:25.7275100Z test tests::test_requires_auth_keys_true ... ok
+2026-08-01T02:42:25.7282465Z 
+2026-08-01T02:42:25.7287809Z test result: ok. 26 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+2026-08-01T02:42:25.7290959Z 
+2026-08-01T02:42:25.7300936Z [1m[92m     Running[0m unittests src/main.rs (target/debug/deps/didcomm_test-517b19f13583e1fe)
+2026-08-01T02:42:25.7308437Z [1m[92m     Running[0m unittests src/main.rs (target/debug/deps/pnm-eb3a82becf865033)
+2026-08-01T02:42:25.7311688Z 
+2026-08-01T02:42:25.7314341Z running 0 tests
+2026-08-01T02:42:25.7319232Z 
+2026-08-01T02:42:25.7324010Z test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+2026-08-01T02:42:25.7326098Z 
+2026-08-01T02:42:25.7326103Z 
+2026-08-01T02:42:25.7330065Z running 51 tests
+2026-08-01T02:42:25.7335635Z test bootstrap::tests::parse_var_empty_key_errors ... ok
+2026-08-01T02:42:25.7340405Z test bootstrap::tests::parse_var_json_types_round_trip ... ok
+2026-08-01T02:42:25.7342589Z test bootstrap::tests::parse_var_missing_equals_errors ... ok
+2026-08-01T02:42:25.7344479Z test bootstrap::tests::parse_var_plain_string ... ok
+2026-08-01T02:42:25.7352340Z test bootstrap::tests::parse_var_value_may_contain_equals ... ok
+2026-08-01T02:42:25.7356811Z test auth::sign_challenge_tests::signature_is_64_bytes_hex ... ok
+2026-08-01T02:42:25.7358700Z test bootstrap::tests::written_credential_omits_absent_vta_url ... ok
+2026-08-01T02:42:25.7363747Z test bootstrap::tests::written_credential_is_owner_only ... ok
+2026-08-01T02:42:25.7373950Z test bootstrap::tests::written_credential_uses_wire_field_names ... ok
+2026-08-01T02:42:25.7391781Z test bootstrap::tests::written_credential_truncates_existing_file ... ok
+2026-08-01T02:42:25.7397142Z test cli::transport_flag_tests::transport_defaults_to_auto ... ok
+2026-08-01T02:42:25.7399502Z test cli::transport_flag_tests::transport_rest_parses ... ok
+2026-08-01T02:42:25.7402393Z test config::tests::test_config_default_is_empty ... ok
+2026-08-01T02:42:25.7405175Z test config::tests::test_config_deserialize_empty_toml ... ok
+2026-08-01T02:42:25.7413414Z test config::tests::test_config_round_trip ... ok
+2026-08-01T02:42:25.7420620Z test cli::transport_flag_tests::transport_rejects_unknown_value ... ok
+2026-08-01T02:42:25.7430447Z test config::tests::test_legacy_config_deserialize ... ok
+2026-08-01T02:42:25.7438142Z test config::tests::test_legacy_per_vta_url_is_preserved ... ok
+2026-08-01T02:42:25.7445819Z test config::tests::test_resolve_vta_no_default_fails ... ok
+2026-08-01T02:42:25.7450956Z test config::tests::test_resolve_vta_slug_not_found_fails ... ok
+2026-08-01T02:42:25.7455199Z test config::tests::test_resolve_vta_with_default ... ok
+2026-08-01T02:42:25.7458555Z test config::tests::test_resolve_vta_with_override ... ok
+2026-08-01T02:42:25.7462973Z test config::tests::test_slugify ... ok
+2026-08-01T02:42:25.7468745Z test config::tests::test_vta_keyring_key ... ok
+2026-08-01T02:42:25.7471196Z test setup::tests::detect_existing_state_absent_for_missing_slug ... ok
+2026-08-01T02:42:25.7473750Z test setup::tests::detect_existing_state_complete ... ok
+2026-08-01T02:42:25.7474527Z test setup::tests::emit_json_shape_matches_spec ... ok
+2026-08-01T02:42:25.7480105Z test setup::tests::require_pending_rejects_complete_slug ... ok
+2026-08-01T02:42:25.7487553Z test setup::tests::require_pending_rejects_unknown_slug ... ok
+2026-08-01T02:42:25.7495033Z test tests::disable_clears_a_pinned_mediator_hint ... ok
+2026-08-01T02:42:25.7505373Z test tests::enable_repoints_a_pinned_mediator_hint ... ok
+2026-08-01T02:42:25.7512648Z test tests::read_only_commands_leave_the_hint_alone ... ok
+2026-08-01T02:42:25.7522644Z test setup::tests::emit_json_states_match_spec ... ok
+2026-08-01T02:42:25.7534487Z test tests::setup_continue_parses_interactive ... ok
+2026-08-01T02:42:25.7544770Z test auth::sign_challenge_tests::wrong_seed_fails_verify ... ok
+2026-08-01T02:42:25.7553733Z test tests::setup_bare_parses_all_none ... ok
+2026-08-01T02:42:25.7567728Z test auth::sign_challenge_tests::sign_then_verify_round_trip ... ok
+2026-08-01T02:42:25.7573787Z test tests::setup_continue_parses_non_interactive ... ok
+2026-08-01T02:42:25.7581352Z test tests::test_requires_auth_acl_true ... ok
+2026-08-01T02:42:25.7587589Z test tests::test_requires_auth_auth_status_false ... ok
+2026-08-01T02:42:25.7596049Z test tests::test_requires_auth_config_true ... ok
+2026-08-01T02:42:25.7603770Z test tests::test_requires_auth_contexts_true ... ok
+2026-08-01T02:42:25.7617906Z [1m[92m     Running[0m unittests src/lib.rs (target/debug/deps/vta_audit-262b69b5716b97bb)
+2026-08-01T02:42:25.7632415Z [1m[92m     Running[0m unittests src/lib.rs (target/debug/deps/vta_backup-9258399ce8e141a6)
+2026-08-01T02:42:25.7635577Z test tests::test_requires_auth_health_false ... ok
+2026-08-01T02:42:25.7639178Z test tests::setup_name_with_continue_subcommand_parses ... ok
+2026-08-01T02:42:25.7640193Z test tests::test_requires_auth_keys_true ... ok
+2026-08-01T02:42:25.7646335Z test tests::test_requires_auth_setup_false ... ok
+2026-08-01T02:42:25.7653277Z test tests::test_requires_auth_vta_false ... ok
+2026-08-01T02:42:25.7659615Z test tests::unpinned_vta_never_gains_a_hint ... ok
+2026-08-01T02:42:25.7662979Z test tests::update_repoints_a_pinned_mediator_hint ... ok
+2026-08-01T02:42:25.7665580Z test tests::setup_with_name_parses_as_non_interactive_phase1 ... ok
+2026-08-01T02:42:25.7670387Z test tests::setup_with_name_and_overwrite_parses ... ok
+2026-08-01T02:42:25.7672819Z 
+2026-08-01T02:42:25.7675057Z test result: ok. 51 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s
+2026-08-01T02:42:25.7678367Z 
+2026-08-01T02:42:25.7678374Z 
+2026-08-01T02:42:25.7681664Z running 0 tests
+2026-08-01T02:42:25.7681958Z 
+2026-08-01T02:42:25.7684378Z test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+2026-08-01T02:42:25.7686602Z 
+2026-08-01T02:42:25.7686609Z 
+2026-08-01T02:42:25.7686848Z running 60 tests
+2026-08-01T02:42:25.7690420Z test backup_bundle_store::tests::bundle_token_debug_redacts_secret ... ok
+2026-08-01T02:42:25.7700661Z test backup_bundle_store::tests::hash_is_deterministic_across_calls ... ok
+2026-08-01T02:42:25.7716294Z test backup_bundle_store::tests::is_terminal_pins_the_state_machine_taxonomy ... ok
+2026-08-01T02:42:25.7730029Z test backup_bundle_store::tests::mint_token_emits_url_safe_base64 ... ok
+2026-08-01T02:42:25.7738896Z test backup_bundle_store::tests::mint_token_paired_hash_matches_re_hashed_token ... ok
+2026-08-01T02:42:25.7748893Z test backup_bundle_store::tests::mint_token_produces_distinct_tokens_per_call ... ok
+2026-08-01T02:42:25.7754530Z test backup_bundle_store::tests::verify_token_accepts_matching_token ... ok
+2026-08-01T02:42:25.7763812Z test backup_bundle_store::tests::verify_token_rejects_empty_string ... ok
+2026-08-01T02:42:25.7772667Z test backup_bundle_store::tests::verify_token_rejects_mismatched_token ... ok
+2026-08-01T02:42:25.7781110Z test backup_bundle_store::tests::verify_token_rejects_token_with_one_byte_flipped ... ok
+2026-08-01T02:42:25.7791617Z test backup_bundle_store::tests::bundle_round_trips_through_keyspace ... ok
+2026-08-01T02:42:25.7802554Z test backup_bundle_store::tests::list_returns_all_bundles_via_prefix_scan ... ok
+2026-08-01T02:42:25.7810732Z test backup_bundle_sweeper::tests::retention_pass_deletes_terminal_records_past_cutoff ... ok
+2026-08-01T02:42:25.7823868Z test backup_bundle_store::tests::delete_removes_record ... ok
+2026-08-01T02:42:25.7831431Z test backup_bundle_sweeper::tests::ttl_pass_expires_non_terminal_records_past_deadline ... ok
+2026-08-01T02:42:25.7843788Z test backup_bundle_sweeper::tests::retention_pass_removes_orphan_blob_alongside_record ... ok
+2026-08-01T02:42:25.7853971Z test backup_bundle_sweeper::tests::retention_pass_keeps_fresh_terminal_records ... ok
+2026-08-01T02:42:25.7862343Z test ops::descriptors::tests::build_blob_url_strips_trailing_slash ... ok
+2026-08-01T02:42:25.7875702Z test ops::descriptors::tests::context_admin_is_not_super_admin ... ok
+2026-08-01T02:42:25.7881861Z test ops::descriptors::tests::enforce_kind_rejects_wrong_kind_as_not_found ... ok
+2026-08-01T02:42:25.7894927Z test backup_bundle_sweeper::tests::sweep_combines_ttl_and_retention_in_one_pass ... ok
+2026-08-01T02:42:25.7902672Z test backup_bundle_sweeper::tests::ttl_pass_ignores_already_terminal_records ... ok
+2026-08-01T02:42:25.7909272Z test backup_bundle_sweeper::tests::ttl_pass_ignores_records_still_within_ttl ... ok
+2026-08-01T02:42:25.7921106Z test ops::descriptors::tests::enforce_open_bundle_cap_allows_under_limit ... ok
+2026-08-01T02:42:25.7929191Z test ops::descriptors::tests::enforce_open_bundle_cap_ignores_terminal_states ... ok
+2026-08-01T02:42:25.7934846Z test ops::descriptors::tests::parse_bundle_id_rejects_malformed ... ok
+2026-08-01T02:42:25.8027958Z test ops::descriptors::tests::enforce_open_bundle_cap_scopes_to_did ... ok
+2026-08-01T02:42:25.8036659Z test ops::descriptors::tests::enforce_open_bundle_cap_rejects_at_limit ... ok
+2026-08-01T02:42:25.8046007Z test ops::descriptors::tests::initiate_import_then_abort_round_trip ... ok
+2026-08-01T02:42:25.8056246Z test ops::descriptors::tests::validate_algorithm_accepts_stream_only ... ok
+2026-08-01T02:42:25.8070586Z test ops::descriptors::tests::require_owned_404_for_unknown_bundle ... ok
+2026-08-01T02:42:25.8202714Z test ops::descriptors::tests::require_owned_returns_record_for_owner ... ok
+2026-08-01T02:42:25.8211850Z test ops::descriptors::tests::require_owned_treats_cross_did_as_not_found ... ok
+2026-08-01T02:42:25.8738465Z test ops::tests::export_aborts_on_corrupt_key_row ... ok
+2026-08-01T02:42:30.3886240Z test ops::tests::export_rejects_short_password ... ok
+2026-08-01T02:42:30.4522988Z test ops::tests::import_recomputes_path_counter_for_legacy_backup ... ok
+2026-08-01T02:42:30.4983100Z test ops::tests::import_restores_full_acl_entry_fields ... ok
+2026-08-01T02:42:30.5444923Z test ops::tests::import_restores_path_counter_preventing_key_reuse ... ok
+2026-08-01T02:42:30.5922889Z test ops::tests::import_sentinel_survives_keyspace_clear ... ok
+2026-08-01T02:42:34.7517839Z test ops::tests::envelope_serialization_roundtrip ... ok
+2026-08-01T02:42:34.7872574Z test ops::tests::encrypt_decrypt_roundtrip ... ok
+2026-08-01T02:42:34.9971166Z test ops::tests::different_passwords_produce_different_ciphertexts ... ok
+2026-08-01T02:42:35.1008996Z test ops::tests::kdf_m_cost_above_max_rejected ... ok
+2026-08-01T02:42:39.4642714Z test ops::tests::kdf_t_cost_zero_rejected ... ok
+2026-08-01T02:42:40.3207511Z test ops::tests::kdf_p_cost_above_max_rejected ... ok
+2026-08-01T02:42:40.3225782Z test ops::tests::recompute_path_counters_skips_imported_keys_and_takes_max ... ok
+2026-08-01T02:42:40.3546019Z test ops::tests::restore_clears_pre_existing_webvh_auth_cache ... ok
+2026-08-01T02:42:40.6582595Z test ops::tests::kdf_m_cost_below_min_rejected ... ok
+2026-08-01T02:42:40.7396317Z test ops::tests::successful_import_leaves_no_in_progress_sentinel ... ok
+2026-08-01T02:42:40.7824285Z test ops::tests::kdf_unknown_algorithm_rejected ... ok
+2026-08-01T02:42:44.6792543Z test ops::tests::nonce_wrong_length_rejected_without_panic ... ok
+2026-08-01T02:42:45.9596430Z test ops::tests::unsupported_format_rejected ... ok
+2026-08-01T02:42:45.9626204Z test ops::tests::vta_did_guard_backup_missing_did_rejected_when_running_has_did ... ok
+2026-08-01T02:42:45.9645581Z test ops::tests::vta_did_guard_fresh_install_accepts_any_backup ... ok
+2026-08-01T02:42:45.9665069Z test ops::tests::vta_did_guard_matching_dids_accepted ... ok
+2026-08-01T02:42:45.9695291Z test ops::tests::vta_did_guard_mismatch_rejected ... ok
+2026-08-01T02:42:46.0795682Z test ops::tests::salt_wrong_length_rejected_without_panic ... ok
+2026-08-01T02:42:48.9809598Z test ops::tests::unsupported_version_rejected ... ok
+2026-08-01T02:42:51.1246626Z test ops::tests::tampered_ciphertext_detected ... ok
+2026-08-01T02:42:53.3265168Z test ops::tests::wrong_password_fails ... ok
+2026-08-01T02:42:53.3266796Z 
+2026-08-01T02:42:53.3269661Z test result: ok. 60 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 27.59s
+2026-08-01T02:42:53.3272793Z 
+2026-08-01T02:42:53.3273593Z [1m[92m     Running[0m unittests src/lib.rs (target/debug/deps/vta_cli_common-dd26c2ee931198c5)
+2026-08-01T02:42:53.3289244Z 
+2026-08-01T02:42:53.3291389Z running 82 tests
+2026-08-01T02:42:53.3305211Z test commands::acl::tests::test_allowed_keys_from_flags ... ok
+2026-08-01T02:42:53.3311665Z test commands::acl::tests::test_format_contexts_empty_is_role_dependent ... ok
+2026-08-01T02:42:53.3324889Z test commands::acl::tests::test_format_contexts_multiple ... ok
+2026-08-01T02:42:53.3344415Z test commands::acl::tests::test_format_allowed_keys_distinguishes_absent_from_empty ... ok
+2026-08-01T02:42:53.3352822Z test commands::acl::tests::test_format_role_admin_no_contexts_is_super_admin ... ok
+2026-08-01T02:42:53.3369416Z test commands::acl::tests::test_format_approve_scope ... ok
+2026-08-01T02:42:53.3376423Z test commands::acl::tests::test_format_role_application_unchanged ... ok
+2026-08-01T02:42:53.3381638Z test commands::acl::tests::test_format_contexts_single ... ok
+2026-08-01T02:42:53.3387070Z test commands::acl::tests::test_format_role_admin_with_contexts_stays_admin ... ok
+2026-08-01T02:42:53.3392979Z test commands::acl::tests::test_least_privilege_approver_does_not_read_as_unrestricted ... ok
+2026-08-01T02:42:53.3397991Z test commands::acl::tests::test_format_role_initiator_unchanged ... ok
+2026-08-01T02:42:53.3403942Z test commands::acl::tests::test_validate_role_admin_ok ... ok
+2026-08-01T02:42:53.3408046Z test commands::acl::tests::test_validate_role_empty_fails ... ok
+2026-08-01T02:42:53.3409115Z test commands::acl::tests::test_validate_role_application_ok ... ok
+2026-08-01T02:42:53.3411587Z test commands::acl::tests::test_validate_role_unknown_fails ... ok
+2026-08-01T02:42:53.3414130Z test commands::acl::tests::test_validate_role_reader_ok ... ok
+2026-08-01T02:42:53.3418059Z test commands::acl::tests::test_validate_role_initiator_ok ... ok
+2026-08-01T02:42:53.3420444Z test commands::agent_names::tests::a_non_web_did_has_no_domain ... ok
+2026-08-01T02:42:53.3425916Z test commands::agent_names::tests::domain_comes_from_the_did_not_the_operator ... ok
+2026-08-01T02:42:53.3432370Z test commands::agent_names::tests::a_ported_host_is_percent_decoded ... ok
+2026-08-01T02:42:53.3438731Z test commands::agent_names::tests::qualified_falls_back_to_the_bare_local_part ... ok
+2026-08-01T02:42:53.3444782Z test commands::did_templates::tests::canonical_builtin_names_pass_through ... ok
+2026-08-01T02:42:53.3452719Z test commands::webvh_edit::tests::assert_did_id_unchanged_rejects_id_mutation ... ok
+2026-08-01T02:42:53.3459790Z test commands::webvh_edit::tests::assert_did_id_unchanged_passes_when_id_matches ... ok
+2026-08-01T02:42:53.3464744Z test commands::did_templates::tests::retired_webvh_aliases_are_rejected ... ok
+2026-08-01T02:42:53.3468386Z test commands::webvh_edit::tests::build_options_from_flags_loads_document_from_file ... ok
+2026-08-01T02:42:53.3473264Z test commands::webvh_edit::tests::build_options_from_flags_no_flags_produces_empty_body ... ok
+2026-08-01T02:42:53.3478825Z test commands::webvh_edit::tests::build_options_from_flags_no_watchers_clears_set ... ok
+2026-08-01T02:42:53.3489814Z test commands::did_templates::tests::every_init_alias_resolves_to_a_loadable_builtin ... ok
+2026-08-01T02:42:53.3497849Z test commands::webvh_edit::tests::diff_summary_describes_added_changed_removed ... ok
+2026-08-01T02:42:53.3506508Z test commands::webvh_edit::tests::build_options_from_flags_propagates_pre_rotation_ttl_label ... ok
+2026-08-01T02:42:53.3513141Z test commands::webvh_edit::tests::diff_summary_handles_no_changes ... ok
+2026-08-01T02:42:53.3522901Z test commands::webvh_edit::tests::build_options_from_flags_watchers_replace_set ... ok
+2026-08-01T02:42:53.3528550Z test commands::webvh_edit::tests::extract_current_document_rejects_empty_log ... ok
+2026-08-01T02:42:53.3536991Z test commands::webvh_edit::tests::extract_current_document_rejects_unparseable_line ... ok
+2026-08-01T02:42:53.3544574Z test commands::webvh_edit::tests::extract_current_document_returns_state_of_last_line ... ok
+2026-08-01T02:42:53.3549100Z test commands::webvh_edit::tests::extract_current_document_skips_trailing_blank_lines ... ok
+2026-08-01T02:42:53.3555507Z test commands::webvh_edit::tests::extract_latest_version_id_errors_on_empty_log ... ok
+2026-08-01T02:42:53.3563916Z test commands::webvh_edit::tests::extract_latest_version_id_returns_last_entrys_version_id ... ok
+2026-08-01T02:42:53.3571950Z test commands::webvh_edit::tests::extract_latest_version_id_skips_trailing_blank_lines ... ok
+2026-08-01T02:42:53.3580554Z test commands::webvh_edit::tests::extract_pre_rotation_status_returns_never_set_when_no_entry_mentions_it ... ok
+2026-08-01T02:42:53.3586860Z test commands::webvh_edit::tests::extract_pre_rotation_status_recognises_explicit_disable ... ok
+2026-08-01T02:42:53.3595222Z test commands::webvh_edit::tests::extract_pre_rotation_status_walks_back_through_deltas ... ok
+2026-08-01T02:42:53.3599993Z test display::tests::full_display_keeps_the_did_whole ... ok
+2026-08-01T02:42:53.3603969Z test display::tests::inline_marks_an_unverified_claim ... ok
+2026-08-01T02:42:53.3606316Z test display::tests::unnamed_entries_get_no_name_line ... ok
+2026-08-01T02:42:53.4071570Z test duration::tests::expiry_is_in_the_future ... ok
+2026-08-01T02:42:53.4072728Z test display::tests::inline_falls_back_to_the_shortened_did ... ok
+2026-08-01T02:42:53.4073462Z test duration::tests::humanize_picks_the_right_unit_pair ... ok
+2026-08-01T02:42:53.4074221Z test duration::tests::format_remaining_handles_future_and_past ... ok
+2026-08-01T02:42:53.4074904Z test duration::tests::parses_each_unit ... ok
+2026-08-01T02:42:53.4075425Z test duration::tests::rejects_garbage ... ok
+2026-08-01T02:42:53.4076009Z test duration::tests::format_local_time_is_nonempty ... ok
+2026-08-01T02:42:53.4076645Z test local_keygen::tests::generated_did_is_did_key ... ok
+2026-08-01T02:42:53.4077257Z test local_keygen::tests::generated_dids_are_unique ... ok
+2026-08-01T02:42:53.4077980Z test local_keygen::tests::private_key_multibase_roundtrips_to_seed ... ok
+2026-08-01T02:42:53.4078715Z test local_keygen::tests::derived_did_matches_seed ... ok
+2026-08-01T02:42:53.4079382Z test local_keygen::tests::unbound_did_key_has_valid_shape ... ok
+2026-08-01T02:42:53.4080068Z test local_keygen::tests::unbound_seed_round_trips_to_did ... ok
+2026-08-01T02:42:53.4080760Z test render::tests::falls_back_to_error_field_when_no_message ... ok
+2026-08-01T02:42:53.4081486Z test render::tests::falls_back_to_raw_text_for_non_json ... ok
+2026-08-01T02:42:53.4083673Z test render::tests::falls_back_to_raw_text_when_fields_missing ... ok
+2026-08-01T02:42:53.4084892Z test local_keygen::tests::unbound_dids_are_unique ... ok
+2026-08-01T02:42:53.4085948Z test render::tests::prefers_message_field ... ok
+2026-08-01T02:42:53.4086907Z test sealed_consumer::tests::extract_accepts_context_provision ... ok
+2026-08-01T02:42:53.4087678Z test sealed_consumer::tests::create_request_persists_secret ... ok
+2026-08-01T02:42:53.4089193Z test sealed_consumer::tests::extract_rejects_did_secrets ... ok
+2026-08-01T02:42:53.4090398Z test sealed_consumer::tests::open_rejects_missing_digest_without_opt_out ... ok
+2026-08-01T02:42:53.4092606Z [1m[92m     Running[0m unittests src/lib.rs (target/debug/deps/vta_config-ea02c29d0569d3bb)
+2026-08-01T02:42:53.4093725Z [1m[92m     Running[0m unittests src/main.rs (target/debug/deps/vta_enclave-e6957de3af74b557)
+2026-08-01T02:42:53.4094807Z [1m[92m     Running[0m unittests src/lib.rs (target/debug/deps/vta_keys-3b237e8c3fa04485)
+2026-08-01T02:42:53.4095781Z test sealed_consumer::tests::secrets_dir_creates_when_missing ... ok
+2026-08-01T02:42:53.4096630Z test sealed_consumer::tests::create_provision_request_seed_file_is_owner_only ... ok
+2026-08-01T02:42:53.4097453Z test sealed_consumer::tests::zero_overwrite_handles_empty_file ... ok
+2026-08-01T02:42:53.4098249Z test sealed_consumer::tests::zero_overwrite_errors_on_missing_file ... ok
+2026-08-01T02:42:53.4099111Z test sealed_consumer::tests::zero_overwrite_removes_file_and_scrubs_bytes ... ok
+2026-08-01T02:42:53.4099892Z test sealed_producer::tests::decode_hex_rejects_non_hex ... ok
+2026-08-01T02:42:53.4100574Z test sealed_producer::tests::decode_hex_rejects_odd_length ... ok
+2026-08-01T02:42:53.4101255Z test sealed_producer::tests::hex_roundtrip_16_bytes ... ok
+2026-08-01T02:42:53.4102014Z test sealed_producer::tests::recipient_from_json_rejects_unknown_version ... ok
+2026-08-01T02:42:53.4104018Z test sealed_producer::tests::recipient_from_inline_validates_sizes ... ok
+2026-08-01T02:42:53.4104947Z test sealed_consumer::tests::request_seal_open_round_trip ... ok
+2026-08-01T02:42:53.4105708Z test sealed_producer::tests::seal_recipient_from_json_round_trip ... ok
+2026-08-01T02:42:53.4106439Z test sealed_producer::tests::seal_round_trips_via_armor ... ok
+2026-08-01T02:42:53.4107237Z test sealed_consumer::tests::create_provision_request_persists_seed_and_signs ... ok
+2026-08-01T02:42:53.4107809Z 
+2026-08-01T02:42:53.4108222Z test result: ok. 82 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.03s
+2026-08-01T02:42:53.4108828Z 
+2026-08-01T02:42:53.4108834Z 
+2026-08-01T02:42:53.4108968Z running 7 tests
+2026-08-01T02:42:53.4109379Z test validate_tests::default_config_validates ... ok
+2026-08-01T02:42:53.4110047Z test validate_tests::present_but_empty_resolver_url_is_rejected ... ok
+2026-08-01T02:42:53.4110832Z test validate_tests::present_but_empty_public_url_is_rejected ... ok
+2026-08-01T02:42:53.4111643Z test validate_tests::rest_without_public_url_only_warns_does_not_fail ... ok
+2026-08-01T02:42:53.4112578Z test validate_tests::known_keys_and_aliases_are_not_flagged ... ok
+2026-08-01T02:42:53.4113233Z test validate_tests::zero_retention_days_is_rejected ... ok
+2026-08-01T02:42:53.4113908Z test validate_tests::unknown_keys_are_collected_not_rejected ... ok
+2026-08-01T02:42:53.4114373Z 
+2026-08-01T02:42:53.4114783Z test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+2026-08-01T02:42:53.4115364Z 
+2026-08-01T02:42:53.4115369Z 
+2026-08-01T02:42:53.4115506Z running 0 tests
+2026-08-01T02:42:53.4115694Z 
+2026-08-01T02:42:53.4116084Z test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+2026-08-01T02:42:53.4116621Z 
+2026-08-01T02:42:53.4116626Z 
+2026-08-01T02:42:53.4116745Z running 36 tests
+2026-08-01T02:42:53.4117181Z test derivation::tests::test_bip39_invalid_mnemonic ... ok
+2026-08-01T02:42:53.4117884Z test derivation::tests::test_derive_ed25519_different_paths ... ok
+2026-08-01T02:42:53.4118907Z test derivation::tests::test_derive_ed25519_deterministic ... ok
+2026-08-01T02:42:53.4119598Z test derivation::tests::test_derive_p256_different_paths ... ok
+2026-08-01T02:42:53.4120253Z test derivation::tests::test_derive_p256_invalid_path ... ok
+2026-08-01T02:42:53.4120923Z test derivation::tests::test_derive_p256_deterministic ... ok
+2026-08-01T02:42:53.4121598Z test derivation::tests::test_derive_x25519_deterministic ... ok
+2026-08-01T02:42:53.4122637Z test derivation::tests::test_derive_x25519_differs_from_ed25519 ... ok
+2026-08-01T02:42:53.4123398Z test derivation::tests::test_ed25519_creation_matches_recovery ... ok
+2026-08-01T02:42:53.4124054Z test derivation::tests::test_invalid_path ... ok
+2026-08-01T02:42:53.4124665Z test derivation::tests::test_ka_priv_reconstructs_x25519 ... ok
+2026-08-01T02:42:53.4125307Z test derivation::tests::test_derive_p256_sign_verify ... ok
+2026-08-01T02:42:53.4126041Z test derivation::tests::test_signing_pub_matches_did_document_format ... ok
+2026-08-01T02:42:53.4233594Z test derivation::tests::test_x25519_creation_matches_recovery ... ok
+2026-08-01T02:42:53.4245531Z test derivation::tests::test_multiple_restarts_produce_identical_keys ... ok
+2026-08-01T02:42:53.4392500Z test imported::tests::get_or_create_salt_converges_on_one_salt_under_concurrency ... ok
+2026-08-01T02:42:53.4438585Z test imported::tests::test_delete_secret_removes_value ... ok
+2026-08-01T02:42:53.4440884Z test derivation::tests::test_bip39_seed_to_keys_deterministic ... ok
+2026-08-01T02:42:53.4623659Z test imported::tests::test_reencrypt_all ... ok
+2026-08-01T02:42:53.4635478Z test imported::tests::test_store_and_load_secret ... ok
+2026-08-01T02:42:53.4640585Z test seeds::tests::archive_crypto_round_trips_and_binds_id ... ok
+2026-08-01T02:42:53.4655094Z test derivation::tests::test_bip39_seed_deterministic ... ok
+2026-08-01T02:42:53.4655737Z test imported::tests::test_wrong_aad_fails ... ok
+2026-08-01T02:42:53.4802673Z test seeds::tests::load_active_generation_falls_back_when_archive_undecryptable ... ok
+2026-08-01T02:42:53.4834937Z test seeds::tests::load_retired_generation_errors_when_archive_stale ... ok
+2026-08-01T02:42:53.4844421Z test seeds::tests::reconcile_migrates_legacy_plaintext_archive ... ok
+2026-08-01T02:42:53.4993778Z test seeds::tests::reconcile_repairs_archive_under_a_predecessor ... ok
+2026-08-01T02:42:53.5006149Z test seeds::tests::rotation_archives_ciphertext_and_recovers_all_generations ... ok
+2026-08-01T02:42:53.5061951Z test tests::test_hex_seed_roundtrip ... ok
+2026-08-01T02:42:53.5157793Z test paths::tests::allocate_path_is_collision_free_under_concurrency ... ok
+2026-08-01T02:42:53.5178848Z test wrapping::tests::test_generate_and_unwrap ... ok
+2026-08-01T02:42:53.5216914Z test wrapping::tests::test_single_use ... ok
+2026-08-01T02:42:53.5264091Z test tests::test_create_store_recover_cycle ... ok
+2026-08-01T02:42:53.5266718Z test wrapping::tests::test_unwrap_sealed_round_trip ... ok
+2026-08-01T02:42:53.5314000Z test tests::test_key_records_survive_store_reopen ... ok
+2026-08-01T02:42:53.5315165Z test tests::test_path_allocation_produces_unique_keys ... ok
+2026-08-01T02:42:53.5315784Z 
+2026-08-01T02:42:53.5316065Z test result: ok. 36 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.17s
+2026-08-01T02:42:53.5316500Z 
+2026-08-01T02:42:53.5325740Z [1m[92m     Running[0m unittests src/lib.rs (target/debug/deps/vta_keyspaces-9854a995b7b3bd4b)
+2026-08-01T02:42:53.5338811Z 
+2026-08-01T02:42:53.5338979Z running 1 test
+2026-08-01T02:42:53.5341799Z test tests::backup_partition_is_total ... ok
+2026-08-01T02:42:53.5342307Z 
+2026-08-01T02:42:53.5342601Z test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+2026-08-01T02:42:53.5342940Z 
+2026-08-01T02:42:53.5349160Z [1m[92m     Running[0m unittests src/main.rs (target/debug/deps/vta_mcp-6c40f5fb7e59741e)
+2026-08-01T02:42:53.5451644Z 
+2026-08-01T02:42:53.5451919Z running 6 tests
+2026-08-01T02:42:53.5458349Z test tests::didkey_didcomm_params_none_set_returns_none ... ok
+2026-08-01T02:42:53.5466140Z test tests::didkey_didcomm_params_all_set_returns_some ... ok
+2026-08-01T02:42:53.5467794Z test tests::didkey_didcomm_params_partial_is_error ... ok
+2026-08-01T02:42:53.5496505Z test tests::load_agent_bundle_parses_inline_json ... ok
+2026-08-01T02:42:53.5496892Z test tests::load_agent_bundle_reads_file_path ... ok
+2026-08-01T02:42:53.5537987Z test server::tests::tool_router_exposes_the_expected_tools ... ok
+2026-08-01T02:42:53.5538857Z 
+2026-08-01T02:42:53.5539159Z test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
+2026-08-01T02:42:53.5539504Z 
+2026-08-01T02:42:53.5551323Z [1m[92m     Running[0m unittests src/lib.rs (target/debug/deps/vta_mobile_core-3c8b71e70bceca20)
+2026-08-01T02:42:53.5662862Z 
+2026-08-01T02:42:53.5663130Z running 60 tests
+2026-08-01T02:42:53.5823589Z test consent::tests::builds_a_signed_approval_that_echoes_the_binding_and_carries_a_proof ... ok
+2026-08-01T02:42:53.5824586Z test consent::tests::builds_a_signed_denial_with_a_reason ... ok
+2026-08-01T02:42:53.5852965Z test consent::tests::refuses_a_request_without_a_proof ... ok
+2026-08-01T02:42:53.5853911Z test consent::tests::refuses_a_valid_proof_from_a_non_enrolled_did ... ok
+2026-08-01T02:42:53.5859204Z test consent::tests::rejects_a_non_request_document ... ok
+2026-08-01T02:42:53.5878670Z test consent::tests::refuses_an_issuer_verification_method_mismatch ... ok
+2026-08-01T02:42:53.5932883Z test didcomm::tests::anoncrypt_round_trip_is_not_sender_authenticated ... ok
+2026-08-01T02:42:53.5961295Z test didcomm::tests::authcrypt_round_trip_between_two_sessions ... ok
+2026-08-01T02:42:53.6031167Z test didcomm::tests::authcrypt_with_route_wraps_in_forward_for_the_mediator ... ok
+2026-08-01T02:42:53.6069607Z test didcomm::tests::derived_holders_authcrypt_round_trip ... ok
+2026-08-01T02:42:53.6076232Z test didcomm::tests::didcomm_holder_keys_match_the_did_key_key_agreement ... ok
+2026-08-01T02:42:53.6079158Z test didcomm::tests::rejects_bad_holder_key_length ... ok
+2026-08-01T02:42:53.7162629Z test display_name::tests::a_did_key_claims_no_agent_name ... ok
+2026-08-01T02:42:53.7169009Z test display_name::tests::an_unresolvable_did_degrades_to_no_name ... ok
+2026-08-01T02:42:53.7188841Z test display_name::tests::shorten_did_matches_the_shared_vectors ... ok
+2026-08-01T02:42:53.7201157Z test mediator::tests::connects_to_mediator_as_fresh_did_key ... ignored, network: connects to a live mediator as a fresh did:key
+2026-08-01T02:42:53.7204140Z test mediator::tests::whoami_over_didcomm_without_rest ... ignored, network: submits a whoami to a live VTA over its mediator
+2026-08-01T02:42:53.7205442Z test push::tests::device_set_wake_clear_omits_handle_and_optional_fields ... ok
+2026-08-01T02:42:53.7303440Z test consent::tests::parses_a_signed_request_from_an_enrolled_executor ... ok
+2026-08-01T02:42:53.7324308Z test push::tests::parses_device_set_wake_response_cleared ... ok
+2026-08-01T02:42:53.7325141Z test push::tests::parses_device_set_wake_response_with_policy ... ok
+2026-08-01T02:42:53.7325964Z test push::tests::parses_push_register_response_wake_handle ... ok
+2026-08-01T02:42:53.7326745Z test consent::tests::rejects_a_signed_request_missing_the_binding_fields ... ok
+2026-08-01T02:42:53.7327525Z test push::tests::push_register_webpush_maps_endpoint_and_keys ... ok
+2026-08-01T02:42:53.7332942Z test push::tests::push_register_has_no_proof_right_type_and_payload ... ok
+2026-08-01T02:42:53.7337492Z test resolver::tests::parses_vta_endpoints_tolerates_array_endpoint_and_missing_services ... ok
+2026-08-01T02:42:53.7362995Z test resolver::tests::parses_vta_endpoints_from_a_did_document ... ok
+2026-08-01T02:42:53.7393125Z test resolver::tests::resolves_webvh_over_the_network ... ignored, network: resolves a live did:webvh
+2026-08-01T02:42:53.7423012Z test consent::tests::refuses_a_request_tampered_after_signing ... ok
+2026-08-01T02:42:53.7423771Z test resolver::tests::resolves_did_key_locally_and_rejects_garbage ... ok
+2026-08-01T02:42:53.7479208Z test session::tests::challenge_request_has_no_proof_and_right_type ... ok
+2026-08-01T02:42:53.7480111Z test session::tests::empty_scope_is_omitted_from_the_refresh_request ... ok
+2026-08-01T02:42:53.7480997Z test session::tests::parses_authenticate_response_tokens ... ok
+2026-08-01T02:42:53.7481815Z test session::tests::parses_refresh_response_with_rotated_token_and_session_bump ... ok
+2026-08-01T02:42:53.7482953Z test session::tests::parses_refresh_response_without_session_or_rotated_token ... ok
+2026-08-01T02:42:53.7483985Z test session::tests::parses_revoke_session_response_count ... ok
+2026-08-01T02:42:53.7484759Z test session::tests::parses_whoami_response_with_omitted_roles_and_scopes ... ok
+2026-08-01T02:42:53.7485590Z test session::tests::parses_whoami_response_with_session_roles_and_scopes ... ok
+2026-08-01T02:42:53.7486416Z test session::tests::refresh_request_has_no_proof_and_carries_the_token ... ok
+2026-08-01T02:42:53.7487259Z test session::tests::revoke_all_sessions_carries_all_flag_not_session_id ... ok
+2026-08-01T02:42:53.7488079Z test push::tests::device_set_wake_is_signed_carries_handle_and_verifies ... ok
+2026-08-01T02:42:53.7488844Z test stepup::tests::builds_webauthn_approve_response_shape ... ok
+2026-08-01T02:42:53.7489703Z test session::tests::authenticate_is_signed_and_verifies_against_the_holder_key ... ok
+2026-08-01T02:42:53.7507166Z test session::tests::whoami_request_is_signed_and_verifies_against_the_holder_key ... ok
+2026-08-01T02:42:53.7508430Z test stepup::tests::rejects_bad_issued_at ... ok
+2026-08-01T02:42:53.7509379Z test session::tests::revoke_one_session_is_signed_and_carries_session_id ... ok
+2026-08-01T02:42:53.7510324Z test stepup::tests::rejects_non_did_key_signer ... ok
+2026-08-01T02:42:53.7512657Z test stepup::tests::rejects_short_challenge ... ok
+2026-08-01T02:42:53.7513557Z test stepup::tests::webauthn_output_round_trips_back_through_the_typed_parser ... ok
+2026-08-01T02:42:53.7528688Z test stepup::tests::denied_response_is_signed_and_carries_the_reason ... ok
+2026-08-01T02:42:53.7664142Z test stepup::tests::did_signed_response_verifies_against_the_holder_key ... ok
+2026-08-01T02:42:53.7717550Z test task::tests::parses_a_signed_0_2_request_normalising_evidence ... ok
+2026-08-01T02:42:53.7723332Z test task::tests::parses_a_signed_passkey_backed_request ... ok
+2026-08-01T02:42:53.7742939Z test task::tests::refuses_a_request_without_a_proof ... ok
+2026-08-01T02:42:53.7760605Z test task::tests::refuses_a_valid_proof_from_a_non_enrolled_did ... ok
+2026-08-01T02:42:53.7761426Z test task::tests::refuses_an_issuer_verification_method_mismatch ... ok
+2026-08-01T02:42:53.7762365Z test tsp::tests::whoami_over_tsp_without_rest ... ignored, network: submits a whoami to a live VTA over TSP
+2026-08-01T02:42:53.7766537Z test task::tests::rejects_non_request_json ... ok
+2026-08-01T02:42:53.7774556Z test task::tests::parses_authorization_context_from_ext ... ok
+2026-08-01T02:42:53.7824456Z test task::tests::refuses_a_request_tampered_after_signing ... ok
+2026-08-01T02:42:53.7824907Z 
+2026-08-01T02:42:53.7825264Z test result: ok. 56 passed; 0 failed; 4 ignored; 0 measured; 0 filtered out; finished in 0.22s
+2026-08-01T02:42:53.7825604Z 
+2026-08-01T02:42:53.7852745Z [1m[92m     Running[0m unittests src/bin/uniffi-bindgen.rs (target/debug/deps/uniffi_bindgen-8d59d1f774001bca)
+2026-08-01T02:42:53.7879045Z 
+2026-08-01T02:42:53.7879196Z running 0 tests
+2026-08-01T02:42:53.7879428Z 
+2026-08-01T02:42:53.7879697Z test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+2026-08-01T02:42:53.7880069Z 
+2026-08-01T02:42:53.7885766Z [1m[92m     Running[0m unittests src/lib.rs (target/debug/deps/vta_policy-0aee8e90d1525167)
+2026-08-01T02:42:53.7919838Z 
+2026-08-01T02:42:53.7919998Z running 37 tests
+2026-08-01T02:42:53.7930401Z test consent::tests::digest_binds_the_type_uri ... ok
+2026-08-01T02:42:53.7931885Z test consent::tests::digest_is_deterministic_and_key_order_independent ... ok
+2026-08-01T02:42:53.7932792Z test consent::tests::digest_uri_payload_boundary_is_unambiguous ... ok
+2026-08-01T02:42:53.8093371Z test consent::tests::approvals_accumulate_idempotently ... ok
+2026-08-01T02:42:53.8095008Z test consent::tests::expired_pending_reads_as_absent_and_cannot_be_approved ... ok
+2026-08-01T02:42:53.8107157Z test consent::tests::grant_is_single_use_and_expiry_checked ... ok
+2026-08-01T02:42:53.8113988Z test consent::tests::wire_digest_binds_the_type_uri ... ok
+2026-08-01T02:42:53.8114935Z test consent::tests::a_decision_resolves_its_pending_by_wire_digest ... ok
+2026-08-01T02:42:53.8116314Z test consent::tests::wire_digest_is_salted_and_distinct_from_the_internal_one ... ok
+2026-08-01T02:42:53.8242818Z test consent::tests::sweeper_prunes_lapsed_pendings_and_grants ... ok
+2026-08-01T02:42:53.8256233Z test consent::tests::grant_refuses_a_different_task_uri ... ok
+2026-08-01T02:42:53.8261671Z test defaults::tests::embedded_default_compiles ... ok
+2026-08-01T02:42:53.8295966Z test defaults::tests::an_unnamed_task_falls_through_to_the_baseline ... ok
+2026-08-01T02:42:53.8297766Z test defaults::tests::a_config_rule_requires_consent_for_its_task ... ok
+2026-08-01T02:42:53.8389373Z test defaults::tests::does_not_clobber_an_operator_policy ... ok
+2026-08-01T02:42:53.8433054Z test defaults::tests::installs_when_empty_and_is_idempotent ... ok
+2026-08-01T02:42:53.8435378Z test effects::tests::absent_before_is_omitted_not_null ... ok
+2026-08-01T02:42:53.8436896Z test effects::tests::round_trips ... ok
+2026-08-01T02:42:53.8448192Z test engine::tests::abstains_when_rule_does_not_fire ... ok
+2026-08-01T02:42:53.8458258Z test engine::tests::compile_surfaces_parse_error ... ok
+2026-08-01T02:42:53.8468801Z test engine::tests::destructive_denied_by_a_simple_policy ... ok
+2026-08-01T02:42:53.8473750Z test input::tests::subject_precedence_prefers_did_over_mnemonic ... ok
+2026-08-01T02:42:53.8474555Z test input::tests::unclassified_task_gets_the_fail_safe_floor ... ok
+2026-08-01T02:42:53.8476521Z test input::tests::uses_supplied_class_and_extracts_subject_and_context ... ok
+2026-08-01T02:42:53.8485984Z test defaults::tests::reconcile_is_idempotent_and_leaves_operator_policies_alone ... ok
+2026-08-01T02:42:53.8506708Z test defaults::tests::removing_the_rule_turns_consent_back_off ... ok
+2026-08-01T02:42:53.8547329Z test defaults::tests::synthesis_escapes_operator_strings ... ok
+2026-08-01T02:42:53.8560459Z test tests::all_abstain_denies ... ok
+2026-08-01T02:42:53.8560839Z test tests::empty_policy_set_denies ... ok
+2026-08-01T02:42:53.8567441Z test tests::higher_priority_override_wins_over_broad_allow ... ok
+2026-08-01T02:42:53.8572836Z test types::tests::decision_round_trips_from_rego_shape ... ok
+2026-08-01T02:42:53.8575060Z test types::tests::disposition_wire_casing ... ok
+2026-08-01T02:42:53.8576276Z test types::tests::policy_input_omits_absent_site_and_optionals ... ok
+2026-08-01T02:42:53.8577249Z test types::tests::side_effect_level_wire_casing ... ok
+2026-08-01T02:42:53.8627579Z test storage::tests::crud_round_trip ... ok
+2026-08-01T02:42:53.8644506Z test storage::tests::load_active_filters_disabled_and_context ... ok
+2026-08-01T02:42:53.8656320Z test storage::tests::load_active_skips_uncompilable_policy ... ok
+2026-08-01T02:42:53.8656807Z 
+2026-08-01T02:42:53.8657170Z test result: ok. 37 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.07s
+2026-08-01T02:42:53.8657673Z 
+2026-08-01T02:42:53.8670485Z [1m[92m     Running[0m unittests src/lib.rs (target/debug/deps/vta_sdk-863054b8fb9bf0e0)
+2026-08-01T02:42:53.8702465Z 
+2026-08-01T02:42:53.8702717Z running 582 tests
+2026-08-01T02:42:53.8706669Z test acl::tests::absent_defaults_to_conferring_nothing ... ok
+2026-08-01T02:42:53.8707318Z test acl::tests::a_partially_inside_scope_is_surfaced ... ok
+2026-08-01T02:42:53.8707925Z test acl::tests::act_and_approve_agree_on_coverage ... ok
+2026-08-01T02:42:53.8708523Z test acl::tests::acts_nowhere_matches_no_direction ... ok
+2026-08-01T02:42:53.8710209Z test acl::tests::act_scope_defaults_to_nothing ... ok
+2026-08-01T02:42:53.8710759Z test acl::tests::any_is_the_union_of_both_legs ... ok
+2026-08-01T02:42:53.8711771Z test acl::tests::acts_within_is_segment_aware ... ok
+2026-08-01T02:42:53.8712602Z test acl::tests::an_unknown_direction_is_refused_with_the_valid_set ... ok
+2026-08-01T02:42:53.8713253Z test acl::tests::covers_is_subtree_aware ... ok
+2026-08-01T02:42:53.8713886Z test acl::tests::named_contexts_is_empty_for_the_unlistable_variants ... ok
+2026-08-01T02:42:53.8714603Z test acl::tests::default_direction_is_the_historical_one ... ok
+2026-08-01T02:42:53.8715511Z test acl::tests::display_distinguishes_nothing_from_everything ... ok
+2026-08-01T02:42:53.8716145Z test acl::tests::the_two_directions_are_mirrors ... ok
+2026-08-01T02:42:53.8716850Z test acl::tests::unrestricted_is_reported_by_acting_in_and_any_but_not_subtree ... ok
+2026-08-01T02:42:53.8717745Z test agent_session::tests::already_registered_is_detected_across_transports ... ok
+2026-08-01T02:42:53.8718503Z test acl::tests::wire_spelling_is_pinned_and_round_trips ... ok
+2026-08-01T02:42:53.8719069Z test acl::tests::wire_shape_is_pinned ... ok
+2026-08-01T02:42:53.8721554Z test agent_session::tests::config_defaults_then_builders ... ok
+2026-08-01T02:42:53.8723600Z test agent_session::tests::inbound_message_is_lenient_about_missing_fields ... ok
+2026-08-01T02:42:53.8763297Z test agent_session::tests::inbound_message_parses_didcomm_envelope ... ok
+2026-08-01T02:42:53.8793544Z test attestation::test_quote::tests::gen_nitro_fuzz_seed ... ignored, seed-corpus generator; run explicitly with --ignored
+2026-08-01T02:42:53.8822978Z test attestation::test_quote::tests::aws_anchor_fingerprint_matches_vendored_pem ... ok
+2026-08-01T02:42:53.8863072Z test attestation::test_quote::tests::parse_failure_implies_upstream_verify_failure ... ok
+2026-08-01T02:42:53.8877572Z test attestation::test_quote::tests::parse_is_total_on_garbage ... ok
+2026-08-01T02:42:53.8893255Z test attestation::test_quote::tests::real_quote_field_parity_with_upstream ... ignored, requires a real AWS Nitro quote fixture (live enclave)
+2026-08-01T02:42:53.9053443Z test attestation::test_quote::tests::parse_extracts_fields_without_verifying ... ok
+2026-08-01T02:42:53.9075313Z test attestation::test_quote::tests::aws_anchor_fingerprint_matches_upstream_baked_value ... ok
+2026-08-01T02:42:53.9244286Z test attestation::test_quote::tests::verifier_accepts_with_matching_anchor_and_clock ... ok
+2026-08-01T02:42:53.9383363Z test agent_session::tests::from_client_wraps_without_enrolling ... ok
+2026-08-01T02:42:53.9413135Z test attestation::test_quote::tests::verifier_rejects_aws_anchor_for_synthetic_chain ... ok
+2026-08-01T02:42:53.9623674Z test attestation::test_quote::tests::verifier_rejects_bad_cose_signature ... ok
+2026-08-01T02:42:53.9643049Z test attestation::tests::check_pcrs_expecting_an_absent_pcr_fails ... ok
+2026-08-01T02:42:53.9653144Z test attestation::tests::check_pcrs_matching_passes_case_and_prefix_insensitive ... ok
+2026-08-01T02:42:53.9682715Z test attestation::tests::check_pcrs_none_is_noop ... ok
+2026-08-01T02:42:53.9712951Z test attestation::tests::check_pcrs_pcr0_mismatch_is_typed ... ok
+2026-08-01T02:42:53.9742938Z test attestation::tests::check_pcrs_pcr8_mismatch_is_typed ... ok
+2026-08-01T02:42:53.9743773Z test attestation::tests::did_signed_assertion_rejected ... ok
+2026-08-01T02:42:53.9773013Z test attestation::tests::empty_quote_bytes_rejected_as_quote_invalid ... ok
+2026-08-01T02:42:53.9802469Z test attestation::tests::malformed_base64_rejected ... ok
+2026-08-01T02:42:53.9803381Z test attestation::tests::malformed_producer_did_rejected_at_format_layer ... ok
+2026-08-01T02:42:53.9833039Z test attestation::tests::nitro_format_strings_are_case_insensitive ... ok
+2026-08-01T02:42:53.9862905Z test attestation::tests::pinned_only_assertion_rejected ... ok
+2026-08-01T02:42:53.9881861Z test attestation::tests::random_bytes_rejected_as_quote_invalid ... ok
+2026-08-01T02:42:53.9883287Z test attestation::tests::unknown_format_rejected ... ok
+2026-08-01T02:42:53.9884216Z test auth_di::tests::authenticate_doc_is_signed_and_camel_cased ... ok
+2026-08-01T02:42:53.9885148Z test auth_di::tests::non_did_key_holder_is_refused ... ok
+2026-08-01T02:42:53.9886506Z test auth_di::tests::parses_flat_and_trust_task_responses ... ok
+2026-08-01T02:42:53.9887437Z test auth_di::tests::refresh_doc_is_unsigned_and_camel_cased ... ok
+2026-08-01T02:42:53.9888345Z test auth_di::tests::rejects_unrecognisable_response ... ok
+2026-08-01T02:42:53.9889317Z test attestation::test_quote::tests::verifier_rejects_wrong_anchor ... ok
+2026-08-01T02:42:53.9890349Z test client::tests::a_separate_tsp_mediator_gets_its_own_session ... ok
+2026-08-01T02:42:53.9891593Z test client::tests::extract_does_not_mistake_a_code_field_for_an_error ... ok
+2026-08-01T02:42:53.9892849Z test client::tests::extract_reports_a_rejection_without_a_payload ... ok
+2026-08-01T02:42:53.9893805Z test client::tests::extract_returns_a_success_payload ... ok
+2026-08-01T02:42:53.9894802Z test client::tests::extract_surfaces_an_error_envelope_inside_the_payload ... ok
+2026-08-01T02:42:53.9895976Z test client::tests::same_mediator_multiplexes_rather_than_opening_a_second_socket ... ok
+2026-08-01T02:42:53.9897158Z test client::tests::surface_transport_renders_the_operator_facing_name ... ok
+2026-08-01T02:42:53.9898216Z test client::tests::test_acl_list_response_deserialization ... ok
+2026-08-01T02:42:53.9899154Z test client::tests::test_context_response_deserialization ... ok
+2026-08-01T02:42:53.9900080Z test client::tests::test_create_acl_request_serialization ... ok
+2026-08-01T02:42:53.9900980Z test client::tests::test_create_key_request_serialization ... ok
+2026-08-01T02:42:53.9901854Z test client::tests::test_encode_colon_preserved ... ok
+2026-08-01T02:42:53.9902812Z test client::tests::test_encode_hash_in_did_fragment ... ok
+2026-08-01T02:42:53.9903645Z test client::tests::test_encode_multiple_hashes ... ok
+2026-08-01T02:42:53.9904499Z test client::tests::test_encode_percent_is_escaped_first ... ok
+2026-08-01T02:42:53.9905397Z test client::tests::test_encode_plain_string_unchanged ... ok
+2026-08-01T02:42:53.9906245Z test client::tests::test_encode_question_mark ... ok
+2026-08-01T02:42:53.9907092Z test client::tests::test_encode_slash_in_derivation_path ... ok
+2026-08-01T02:42:53.9907990Z test client::tests::test_error_response_deserialization ... ok
+2026-08-01T02:42:53.9908887Z test client::tests::test_health_response_deserialization ... ok
+2026-08-01T02:42:53.9909740Z test client::tests::test_health_response_minimal ... ok
+2026-08-01T02:42:53.9910526Z test client::tests::test_list_keys_response_deserialization ... ok
+2026-08-01T02:42:53.9911511Z test attestation::test_quote::tests::verifier_rejects_expired_and_not_yet_valid ... ok
+2026-08-01T02:42:54.0005086Z test attestation::test_quote::tests::verify_nitro_quote_with_end_to_end ... ok
+2026-08-01T02:42:54.0299157Z test client::tests::a_rest_client_reports_rest_for_both_surfaces ... ok
+2026-08-01T02:42:54.0433655Z test client::tests::test_new_no_trailing_slash_unchanged ... ok
+2026-08-01T02:42:54.0693550Z test client::tests::test_new_strips_multiple_trailing_slashes ... ok
+2026-08-01T02:42:54.0694866Z test client::tests::test_update_acl_request_all_none ... ok
+2026-08-01T02:42:54.0723035Z test client::tests::test_update_acl_request_allowed_keys_three_intentions ... ok
+2026-08-01T02:42:54.0753050Z test client::tests::test_update_config_sends_only_named_keys ... ok
+2026-08-01T02:42:54.0782914Z test client::tests::trust_task_payload_extracted_from_success_doc ... ok
+2026-08-01T02:42:54.0784118Z test client::tests::trust_task_reject_doc_surfaces_reason_as_error ... ok
+2026-08-01T02:42:54.0812899Z test context_path::tests::ancestry_is_segment_aware_not_string_prefix ... ok
+2026-08-01T02:42:54.0842743Z test context_path::tests::child_path_builds_and_validates ... ok
+2026-08-01T02:42:54.0858083Z test context_path::tests::enforces_max_depth ... ok
+2026-08-01T02:42:54.0858936Z test context_path::tests::parent_and_depth ... ok
+2026-08-01T02:42:54.0859762Z test context_path::tests::rejects_malformed_paths ... ok
+2026-08-01T02:42:54.0860534Z test context_path::tests::validates_good_paths ... ok
+2026-08-01T02:42:54.0861832Z test context_policy::tests::allow_list_present_is_membership ... ok
+2026-08-01T02:42:54.0863470Z test context_policy::tests::export_is_logical_and_and_cannot_be_re_enabled ... ok
+2026-08-01T02:42:54.0864390Z test context_policy::tests::intersect_adds_child_constraint ... ok
+2026-08-01T02:42:54.0865337Z test context_policy::tests::intersect_drops_unauthorized_and_cannot_widen ... ok
+2026-08-01T02:42:54.0866309Z test context_policy::tests::intersect_inherits_when_child_unset ... ok
+2026-08-01T02:42:54.0867536Z test context_policy::tests::intersect_is_subset_of_each_input ... ok
+2026-08-01T02:42:54.0868400Z test context_policy::tests::quotas_take_min_and_union ... ok
+2026-08-01T02:42:54.0869244Z test context_policy::tests::resolve_chain_narrows_monotonically ... ok
+2026-08-01T02:42:54.0870159Z test context_policy::tests::resolve_empty_chain_is_unrestricted ... ok
+2026-08-01T02:42:54.0871114Z test context_policy::tests::serde_empty_is_unrestricted_and_roundtrips ... ok
+2026-08-01T02:42:54.0872014Z test context_policy::tests::unrestricted_allows_everything ... ok
+2026-08-01T02:42:54.0873164Z test context_provision::tests::test_serde_json_roundtrip_with_did ... ok
+2026-08-01T02:42:54.0874156Z test context_provision::tests::test_serde_json_roundtrip_without_did ... ok
+2026-08-01T02:42:54.0875000Z test credentials::tests::test_credential_bundle_full ... ok
+2026-08-01T02:42:54.0875979Z test credentials::tests::test_credential_bundle_missing_did_fails ... ok
+2026-08-01T02:42:54.0876914Z test credentials::tests::test_credential_bundle_without_url ... ok
+2026-08-01T02:42:54.0877847Z test credentials::tests::test_serde_json_roundtrip ... ok
+2026-08-01T02:42:54.0878670Z test credentials::tests::test_serde_json_roundtrip_without_url ... ok
+2026-08-01T02:42:54.0879535Z test did_key::tests::test_decode_private_key_multibase_invalid ... ok
+2026-08-01T02:42:54.0880434Z test did_key::tests::test_decode_private_key_multibase_roundtrip ... ok
+2026-08-01T02:42:54.0881396Z test did_key::tests::test_decode_private_key_multibase_with_codec_prefix ... ok
+2026-08-01T02:42:54.0882642Z test did_key::tests::test_decode_private_key_multibase_wrong_length ... ok
+2026-08-01T02:42:54.0883487Z test did_key::tests::test_ed25519_multibase_pubkey_format ... ok
+2026-08-01T02:42:54.0884236Z test did_key::tests::test_secrets_from_bundle_ed25519_and_x25519 ... ok
+2026-08-01T02:42:54.0885334Z test did_key::tests::test_secrets_from_bundle_rejects_bad_multibase ... ok
+2026-08-01T02:42:54.0886163Z test did_key::tests::test_secrets_from_bundle_roundtrips_multibase ... ok
+2026-08-01T02:42:54.0886973Z test did_key::tests::test_secrets_from_did_key_is_deterministic ... ok
+2026-08-01T02:42:54.0887777Z test did_key::tests::test_secrets_from_did_key_rejects_non_did_key ... ok
+2026-08-01T02:42:54.0888525Z test client::tests::test_new_strips_trailing_slash ... ok
+2026-08-01T02:42:54.0889380Z test did_secrets::tests::adopts_label_when_it_is_a_strict_vm_id_and_record_id_is_not ... ok
+2026-08-01T02:42:54.0890361Z test did_secrets::tests::excludes_admin_did_key_minted_into_context ... ok
+2026-08-01T02:42:54.0891236Z test did_secrets::tests::keeps_store_vm_id_and_ignores_decorative_label ... ok
+2026-08-01T02:42:54.0892315Z test did_secrets::tests::regression_did_prefixed_label_must_not_clobber_key_id ... ok
+2026-08-01T02:42:54.0923058Z test did_secrets::tests::rejects_label_vm_id_with_trailing_free_text ... ok
+2026-08-01T02:42:54.0923851Z test did_secrets::tests::test_serde_json_empty_secrets ... ok
+2026-08-01T02:42:54.0924530Z test did_secrets::tests::test_serde_json_roundtrip ... ok
+2026-08-01T02:42:54.0925339Z test did_key::tests::test_secrets_from_did_key_uses_multibase_fragment_ids ... ok
+2026-08-01T02:42:54.0926248Z test did_templates::builtin::tests::legacy_template_aliases_are_removed ... ok
+2026-08-01T02:42:54.0927091Z test did_templates::builtin::tests::unknown_builtin_errors ... ok
+2026-08-01T02:42:54.0928032Z test did_templates::tests::ai_agent_builtin_advertises_tsp_then_didcomm_via_mediator ... ok
+2026-08-01T02:42:54.0929080Z test did_templates::tests::ai_agent_builtin_has_key_agreement_for_authcrypt ... ok
+2026-08-01T02:42:54.0930446Z test did_templates::builtin::tests::every_builtin_parses_and_validates ... ok
+2026-08-01T02:42:54.0931342Z test did_templates::tests::ai_agent_builtin_loads_and_validates ... ok
+2026-08-01T02:42:54.0932306Z test did_templates::tests::ai_agent_builtin_missing_mediator_did_errors ... ok
+2026-08-01T02:42:54.0933207Z test did_templates::tests::ambient_var_missing_surfaces_as_unresolved ... ok
+2026-08-01T02:42:54.0934266Z test did_templates::tests::caller_vars_override_optional_defaults ... ok
+2026-08-01T02:42:54.0935216Z test did_templates::tests::did_host_didcomm_builtin_accept_is_native_array_not_string ... ok
+2026-08-01T02:42:54.0936257Z test did_templates::tests::did_host_didcomm_builtin_context_is_did_v1_plus_cid_v1 ... ok
+2026-08-01T02:42:54.0937293Z test did_templates::tests::did_host_didcomm_builtin_has_exactly_one_entry_per_transport ... ok
+2026-08-01T02:42:54.0938311Z test did_templates::tests::did_host_didcomm_builtin_missing_mediator_did_errors ... ok
+2026-08-01T02:42:54.0939249Z test did_templates::tests::did_host_didcomm_builtin_loads_and_validates ... ok
+2026-08-01T02:42:54.0940271Z test did_templates::tests::did_host_didcomm_builtin_rejects_unknown_placeholder_in_template ... ok
+2026-08-01T02:42:54.0941255Z test did_templates::tests::did_host_http_builtin_renders_end_to_end ... ok
+2026-08-01T02:42:54.0942321Z test did_templates::tests::did_host_didcomm_builtin_renders_exact_document_shape ... ok
+2026-08-01T02:42:54.0943300Z test did_templates::tests::did_host_http_tsp_advertises_hosting_then_tsp_only ... ok
+2026-08-01T02:42:54.0944231Z test did_templates::tests::did_host_http_tsp_missing_mediator_did_errors ... ok
+2026-08-01T02:42:54.0945190Z test did_templates::tests::did_host_http_tsp_builtin_loads_and_validates ... ok
+2026-08-01T02:42:54.0946118Z test did_templates::tests::did_host_tsp_builtin_context_is_did_v1_plus_cid_v1 ... ok
+2026-08-01T02:42:54.0947061Z test did_templates::tests::did_host_tsp_builtin_advertises_single_tsp_transport ... ok
+2026-08-01T02:42:54.0948016Z test did_templates::tests::did_host_tsp_builtin_missing_mediator_did_errors ... ok
+2026-08-01T02:42:54.0948892Z test did_templates::tests::did_host_tsp_builtin_loads_and_validates ... ok
+2026-08-01T02:42:54.0949777Z test did_templates::tests::did_host_tsp_builtin_renders_exact_document_shape ... ok
+2026-08-01T02:42:54.0950684Z test did_templates::tests::didcomm_mediator_builtin_renders_end_to_end ... ok
+2026-08-01T02:42:54.0951677Z test did_templates::tests::didcomm_mediator_builtin_renders_tsp_service_when_supplied ... ok
+2026-08-01T02:42:54.0982957Z test did_templates::tests::explicit_ws_url_overrides_derivation ... ok
+2026-08-01T02:42:54.0983914Z test did_templates::tests::didcomm_mediator_builtin_renders_p256_slots_when_supplied ... ok
+2026-08-01T02:42:54.0984849Z test did_templates::tests::missing_required_var_errors_with_name ... ok
+2026-08-01T02:42:54.0985649Z test did_templates::tests::lowercase_braces_are_not_placeholders ... ok
+2026-08-01T02:42:54.0986511Z test did_templates::tests::optional_var_default_used_when_caller_omits ... ok
+2026-08-01T02:42:54.0987339Z test did_templates::tests::null_array_elements_are_pruned ... ok
+2026-08-01T02:42:54.0988147Z test did_templates::tests::provided_token_may_pass_through_as_sentinel ... ok
+2026-08-01T02:42:54.0989025Z test did_templates::tests::placeholders_in_nested_arrays_and_objects ... ok
+2026-08-01T02:42:54.0989767Z test did_templates::tests::rejects_bad_name ... ok
+2026-08-01T02:42:54.0990482Z test did_templates::tests::rejects_document_without_did_placeholder ... ok
+2026-08-01T02:42:54.0991331Z test did_templates::tests::rejects_reserved_name_in_optional_vars ... ok
+2026-08-01T02:42:54.0992308Z test did_templates::tests::rejects_reserved_name_in_required_vars ... ok
+2026-08-01T02:42:54.0993012Z test did_templates::tests::rejects_unsupported_schema_version ... ok
+2026-08-01T02:42:54.0993786Z test did_templates::tests::rejects_undeclared_placeholder ... ok
+2026-08-01T02:42:54.0994495Z test did_templates::tests::rejects_variable_in_both_lists ... ok
+2026-08-01T02:42:54.0995527Z test did_templates::tests::renders_embedded_string_placeholder ... ok
+2026-08-01T02:42:54.0996310Z test did_templates::tests::utf8_strings_survive_substitution ... ok
+2026-08-01T02:42:54.0997090Z test did_templates::tests::vta_admin_builtin_renders_end_to_end ... ok
+2026-08-01T02:42:54.0998030Z test did_templates::tests::vtc_host_advertises_a_trust_registry_referral_when_given_one ... ok
+2026-08-01T02:42:54.0999259Z test did_templates::tests::vtc_host_omits_the_referral_when_no_registry_is_named ... ok
+2026-08-01T02:42:54.1000141Z test did_templates::tests::vtc_host_renders_with_minimal_vars ... ok
+2026-08-01T02:42:54.1000844Z test did_templates::tests::vtc_host_requires_url ... ok
+2026-08-01T02:42:54.1001608Z test did_templates::tests::whole_string_token_substitutes_native_type ... ok
+2026-08-01T02:42:54.1002615Z test did_templates::tests::vtc_host_status_list_path_override ... ok
+2026-08-01T02:42:54.1003505Z test did_templates::tests::ws_url_derivation_handles_plain_http_and_trailing_slash ... ok
+2026-08-01T02:42:54.1004426Z test did_templates::tests::ws_url_is_derived_from_url_when_omitted ... ok
+2026-08-01T02:42:54.1005290Z test did_templates::trust_registry::tests::an_empty_registry_did_is_refused ... ok
+2026-08-01T02:42:54.1006389Z test did_templates::trust_registry::tests::an_https_uri_is_refused_because_it_would_read_as_an_endpoint ... ok
+2026-08-01T02:42:54.1007617Z test did_templates::trust_registry::tests::builds_the_referral_shape_the_profile_spec_defines ... ok
+2026-08-01T02:42:54.1008653Z test did_templates::trust_registry::tests::endpoint_is_a_struct_not_a_string ... ok
+2026-08-01T02:42:54.1009545Z test did_templates::tests::ws_url_not_derived_for_non_http_scheme ... ok
+2026-08-01T02:42:54.1010534Z test did_templates::trust_registry::tests::surrounding_whitespace_does_not_defeat_the_did_check ... ok
+2026-08-01T02:42:54.1011536Z test didcomm_light::tests::extract_keyagreement_by_reference ... ok
+2026-08-01T02:42:54.1032830Z test didcomm_light::tests::extract_keyagreement_embedded_vm ... ok
+2026-08-01T02:42:54.1033805Z test didcomm_light::tests::extract_keyagreement_no_keyagreement_errors ... ok
+2026-08-01T02:42:54.1034652Z test didcomm_light::tests::resolve_keyagreement_did_key_no_io ... ok
+2026-08-01T02:42:54.1035493Z test didcomm_light::tests::extract_keyagreement_skips_non_x25519_and_errors ... ok
+2026-08-01T02:42:54.1036404Z test didcomm_light::tests::resolve_keyagreement_rejects_unsupported_method ... ok
+2026-08-01T02:42:54.1037212Z test didcomm_light::tests::test_build_message_structure ... ok
+2026-08-01T02:42:54.1037894Z test didcomm_light::tests::test_did_key_agreement_kid ... ok
+2026-08-01T02:42:54.1038599Z test didcomm_light::tests::test_ed25519_to_x25519_conversion ... ok
+2026-08-01T02:42:54.1039281Z test didcomm_light::tests::test_parse_did_key_ed25519 ... ok
+2026-08-01T02:42:54.1042007Z test didcomm_session::tests::dropping_a_leaked_guard_trips_the_debug_assert - should panic ... ok
+2026-08-01T02:42:54.1043218Z test didcomm_session::tests::leak_guard_reports_a_leak_until_shutdown_is_marked ... ok
+2026-08-01T02:42:54.1044163Z test display_name::agent_name::tests::a_claim_that_does_not_resolve_is_not_verified ... ok
+2026-08-01T02:42:54.1045178Z test display_name::agent_name::tests::a_claim_that_lands_on_another_did_is_not_verified ... ok
+2026-08-01T02:42:54.1046157Z test display_name::agent_name::tests::a_document_claiming_nothing_yields_no_names ... ok
+2026-08-01T02:42:54.1047050Z test didcomm_light::tests::test_pack_anoncrypt_produces_valid_jwe ... ok
+2026-08-01T02:42:54.1047875Z test display_name::agent_name::tests::a_round_tripping_claim_is_verified ... ok
+2026-08-01T02:42:54.1048685Z test display_name::agent_name::tests::no_claims_means_no_name ... ok
+2026-08-01T02:42:54.1049562Z test display_name::agent_name::tests::the_verified_claim_wins_over_earlier_failures ... ok
+2026-08-01T02:42:54.1050604Z test display_name::agent_name::tests::with_no_verified_claim_the_first_is_reported_unverified ... ok
+2026-08-01T02:42:54.1051443Z test display_name::tests::blank_labels_are_not_stored ... ok
+2026-08-01T02:42:54.1053830Z test display_name::tests::insert_is_order_independent ... ok
+2026-08-01T02:42:54.1054600Z test display_name::tests::insert_opt_skips_none ... ok
+2026-08-01T02:42:54.1055315Z test display_name::tests::name_source_json_tags_are_stable ... ok
+2026-08-01T02:42:54.1056090Z test display_name::tests::names_any_drives_the_optional_name_column ... ok
+2026-08-01T02:42:54.1056951Z test display_name::tests::only_unverified_agent_names_are_untrusted ... ok
+2026-08-01T02:42:54.1057942Z test display_name::tests::render_inline_always_shows_the_did ... ok
+2026-08-01T02:42:54.1058758Z test display_name::tests::render_inline_falls_back_to_the_shortened_did ... ok
+2026-08-01T02:42:54.1059540Z test display_name::tests::shorten_did_is_char_safe ... ok
+2026-08-01T02:42:54.1060235Z test display_name::tests::shorten_did_matches_shared_vectors ... ok
+2026-08-01T02:42:54.1061101Z test display_name::tests::unverified_agent_name_ranks_below_every_local_source ... ok
+2026-08-01T02:42:54.1062246Z test display_name::tests::unverified_claim_never_displaces_an_operator_label ... ok
+2026-08-01T02:42:54.1063118Z test display_name::tests::unverified_names_are_tagged_when_rendered ... ok
+2026-08-01T02:42:54.1063957Z test display_name::tests::verified_agent_name_outranks_local_label ... ok
+2026-08-01T02:42:54.1064663Z test error::tests::from_http_410_maps_to_gone ... ok
+2026-08-01T02:42:54.1065337Z test error::tests::problem_report_conflict_maps_to_typed_conflict ... ok
+2026-08-01T02:42:54.1067017Z test error::tests::suggested_fix_present_for_actionable_variants ... ok
+2026-08-01T02:42:54.1067862Z test error::tests::problem_report_unknown_code_lands_in_didcomm_remote ... ok
+2026-08-01T02:42:54.1068750Z test error::tests::typed_payload_is_none_for_non_service_management_variants ... ok
+2026-08-01T02:42:54.1069624Z test error::tests::typed_payload_wire_discriminator_is_kebab_case ... ok
+2026-08-01T02:42:54.1070475Z test error::tests::typed_payload_round_trips_every_runtime_service_variant ... ok
+2026-08-01T02:42:54.1071205Z test hex::tests::lower_formats_bytes ... ok
+2026-08-01T02:42:54.1071826Z test http::tests::env_secs_uses_default_when_unset_or_junk ... ok
+2026-08-01T02:42:54.1072637Z test http::tests::guard_allows_public_https ... ok
+2026-08-01T02:42:54.1073428Z test http::tests::guard_blocks_cloud_metadata ... ok
+2026-08-01T02:42:54.1074001Z test http::tests::guard_blocks_garbage ... ok
+2026-08-01T02:42:54.1074525Z test http::tests::guard_blocks_loopback ... ok
+2026-08-01T02:42:54.1075080Z test http::tests::guard_blocks_plain_http ... ok
+2026-08-01T02:42:54.1075627Z test http::tests::guard_blocks_private_v4 ... ok
+2026-08-01T02:42:54.1076156Z test http::tests::guard_blocks_userinfo ... ok
+2026-08-01T02:42:54.1076683Z test http::tests::guard_blocks_v6_internal ... ok
+2026-08-01T02:42:54.1077335Z test identifier::tests::accepts_common_identifier_shapes ... ok
+2026-08-01T02:42:54.1078140Z test identifier::tests::accepts_exactly_at_limit ... ok
+2026-08-01T02:42:54.1078785Z test identifier::tests::error_message_names_the_field ... ok
+2026-08-01T02:42:54.1079381Z test identifier::tests::rejects_empty ... ok
+2026-08-01T02:42:54.1079990Z test identifier::tests::rejects_separator_injection ... ok
+2026-08-01T02:42:54.1080608Z test identifier::tests::rejects_too_long ... ok
+2026-08-01T02:42:54.1082317Z test integration::auth::tests::plan_auto_with_mediator_picks_didcomm_then_rest ... ok
+2026-08-01T02:42:54.1083911Z test integration::auth::tests::plan_auto_without_mediator_picks_rest_only ... ok
+2026-08-01T02:42:54.1087905Z test client::tests::test_set_token ... ok
+2026-08-01T02:42:54.1089435Z test integration::auth::tests::plan_didcomm_only_with_mediator_does_not_fall_back ... ok
+2026-08-01T02:42:54.1090594Z test integration::auth::tests::plan_didcomm_only_without_mediator_errors ... ok
+2026-08-01T02:42:54.1091604Z test integration::auth::tests::plan_prefer_rest_ignores_mediator ... ok
+2026-08-01T02:42:54.1092728Z test integration::tests::fallback_reason_classifies_auth_errors ... ok
+2026-08-01T02:42:54.1098126Z test integration::tests::load_from_cache_io_error_becomes_cache_error ... ok
+2026-08-01T02:42:54.1099550Z test integration::tests::load_from_cache_rejects_empty_bundle ... ok
+2026-08-01T02:42:54.1101363Z test integration::tests::load_from_cache_returns_fresh_bundle_when_present ... ok
+2026-08-01T02:42:54.1103453Z test protocol::matching::tests::both_rest_service_types_are_recognised ... ok
+2026-08-01T02:42:54.1104596Z test integration::tests::load_from_cache_empty_returns_no_cached_secrets ... ok
+2026-08-01T02:42:54.1105906Z test protocol::matching::tests::empty_or_missing_service_array_is_no_capabilities ... ok
+2026-08-01T02:42:54.1106979Z test protocol::matching::tests::matches_by_type_not_id ... ok
+2026-08-01T02:42:54.1107930Z test protocol::matching::tests::parses_each_type_and_endpoint_shape ... ok
+2026-08-01T02:42:54.1109008Z test protocol::matching::tests::protocol_preference_order_is_tsp_didcomm_rest ... ok
+2026-08-01T02:42:54.1110131Z test protocol::matching::tests::select_falls_through_to_didcomm_then_rest ... ok
+2026-08-01T02:42:54.1111211Z test protocol::matching::tests::select_prefers_tsp_when_both_advertise_it ... ok
+2026-08-01T02:42:54.1112400Z test protocol::matching::tests::select_requires_both_sides_to_advertise ... ok
+2026-08-01T02:42:54.1113384Z test protocol::matching::tests::trqp_rest_only_peer_is_selectable ... ok
+2026-08-01T02:42:54.1114302Z test protocol::matching::tests::type_may_be_an_array ... ok
+2026-08-01T02:42:54.1115300Z test protocol::services::tests::empty_request_bodies_accept_empty_object ... ok
+2026-08-01T02:42:54.1116255Z test client::tests::test_new_token_initially_none ... ok
+2026-08-01T02:42:54.1117188Z test protocol::services::tests::empty_request_bodies_serialize_as_empty_object ... ok
+2026-08-01T02:42:54.1118287Z test protocol::services::tests::rest_request_types_round_trip_through_json ... ok
+2026-08-01T02:42:54.1119316Z test protocol::services::tests::rest_url_field_is_literal_url_on_wire ... ok
+2026-08-01T02:42:54.1120503Z test protocol::services::tests::service_mutation_response_accepts_explicit_null_drain_until ... ok
+2026-08-01T02:42:54.1121707Z test protocol::services::tests::service_mutation_response_decodes_legacy_payload ... ok
+2026-08-01T02:42:54.1123042Z test protocol::services::tests::service_mutation_response_round_trips_both_drain_states ... ok
+2026-08-01T02:42:54.1124356Z test protocol::services::tests::service_state_disabled_omits_config_fields ... ok
+2026-08-01T02:42:54.1125500Z test protocol::services::tests::service_state_discriminator_is_literal_kind ... ok
+2026-08-01T02:42:54.1126604Z test protocol::services::tests::services_list_response_round_trips_both_kinds ... ok
+2026-08-01T02:42:54.1127735Z test protocol::services::tests::tsp_empty_request_bodies_serialize_as_empty_object ... ok
+2026-08-01T02:42:54.1128874Z test protocol::services::tests::tsp_mediator_did_field_is_literal_on_wire ... ok
+2026-08-01T02:42:54.1129978Z test protocol::services::tests::tsp_request_types_round_trip_through_json ... ok
+2026-08-01T02:42:54.1131044Z test protocol::services::tests::validate_service_url_accepts_https ... ok
+2026-08-01T02:42:54.1132286Z test protocol::services::tests::validate_service_url_accepts_localhost_and_ip_literals ... ok
+2026-08-01T02:42:54.1133495Z test protocol::services::tests::validate_service_url_rejects_empty_and_whitespace ... ok
+2026-08-01T02:42:54.1134615Z test protocol::services::tests::validate_service_url_rejects_fragment ... ok
+2026-08-01T02:42:54.1135597Z test protocol::services::tests::validate_service_url_rejects_http ... ok
+2026-08-01T02:42:54.1136618Z test protocol::services::tests::validate_service_url_rejects_other_schemes ... ok
+2026-08-01T02:42:54.1137701Z test protocol::services::tests::validate_service_url_rejects_unparseable ... ok
+2026-08-01T02:42:54.1138743Z test protocol::services::tests::validate_service_url_rejects_userinfo ... ok
+2026-08-01T02:42:54.1139751Z test protocol::services::tests::validate_service_url_returns_parsed_url ... ok
+2026-08-01T02:42:54.1140816Z test protocols::acl_management::create::tests::pre_fold_flat_body_is_rejected ... ok
+2026-08-01T02:42:54.1142298Z test protocols::acl_management::create::tests::unknown_member_is_rejected ... ok
+2026-08-01T02:42:54.1143507Z test protocols::acl_management::create::tests::scoped_expiring_grant_keeps_its_scope_and_expiry ... ok
+2026-08-01T02:42:54.1144762Z test protocols::acl_management::entry::tests::absent_approve_confers_nothing ... ok
+2026-08-01T02:42:54.1145880Z test protocols::acl_management::entry::tests::approve_all_takes_precedence_over_scopes ... ok
+2026-08-01T02:42:54.1147365Z test protocols::acl_management::entry::tests::allowed_keys_empty_and_absent_both_survive_the_wire ... ok
+2026-08-01T02:42:54.1148549Z test protocols::acl_management::entry::tests::approve_scope_round_trips ... ok
+2026-08-01T02:42:54.1149740Z test protocols::acl_management::entry::tests::empty_approve_and_step_up_are_omitted_not_emitted ... ok
+2026-08-01T02:42:54.1150969Z test protocols::acl_management::entry::tests::expiry_round_trips_through_rfc3339 ... ok
+2026-08-01T02:42:54.1152220Z test protocols::acl_management::entry::tests::wire_form_is_camel_case ... ok
+2026-08-01T02:42:54.1153314Z test protocols::acl_management::swap::peek_tests::refuses_what_is_not_a_compact_jws ... ok
+2026-08-01T02:42:54.1154525Z test protocols::acl_management::swap::peek_tests::reads_the_holder_the_builder_signed_for ... ok
+2026-08-01T02:42:54.1163882Z test protocols::acl_management::swap::verify_impl::tests::rejects_expired ... ok
+2026-08-01T02:42:54.1319954Z test protocols::acl_management::swap::verify_impl::tests::rejects_key_binding_mismatch ... ok
+2026-08-01T02:42:54.1345592Z test protocols::acl_management::swap::verify_impl::tests::builder_round_trips_through_verifier ... ok
+2026-08-01T02:42:54.1373858Z test protocols::acl_management::swap::verify_impl::tests::rejects_wrong_audience ... ok
+2026-08-01T02:42:54.1433114Z test protocols::acl_management::swap::verify_impl::tests::rejects_tampered_signature ... ok
+2026-08-01T02:42:54.1434299Z test protocols::acl_management::update::tests::allowed_keys_clear_serializes_as_explicit_null ... ok
+2026-08-01T02:42:54.1493168Z test protocols::acl_management::update::tests::allowed_keys_distinguishes_absent_null_and_empty ... ok
+2026-08-01T02:42:54.1494265Z test protocols::acl_management::update::tests::allowed_keys_round_trips_as_camel_case ... ok
+2026-08-01T02:42:54.1495055Z test protocols::auth::tests::authenticate_response_canonical_shape ... ok
+2026-08-01T02:42:54.1495733Z test protocols::auth::tests::challenge_response_canonical_shape ... ok
+2026-08-01T02:42:54.1496533Z test protocols::auth::tests::challenge_response_with_tee_attestation_serialises_camel_case ... ok
+2026-08-01T02:42:54.1497302Z test protocols::auth::tests::epoch_to_rfc3339_round_trip ... ok
+2026-08-01T02:42:54.1497990Z test protocols::auth::tests::revoke_session_request_round_trips ... ok
+2026-08-01T02:42:54.1498814Z test protocols::auth::tests::revoke_session_response_carries_the_canonical_count ... ok
+2026-08-01T02:42:54.1499593Z test protocols::auth::tests::test_challenge_request_serialize ... ok
+2026-08-01T02:42:54.1500443Z test protocols::backup_management::descriptors::tests::algorithm_defaults_to_stream ... ok
+2026-08-01T02:42:54.1501447Z test protocols::backup_management::descriptors::tests::descriptor_round_trips ... ok
+2026-08-01T02:42:54.1502795Z test protocols::backup_management::descriptors::tests::finalize_import_confirm_defaults_to_true ... ok
+2026-08-01T02:42:54.1503902Z test protocols::backup_management::descriptors::tests::initiate_export_body_round_trips ... ok
+2026-08-01T02:42:54.1504955Z test protocols::backup_management::password_tests::counts_characters_not_bytes ... ok
+2026-08-01T02:42:54.1506050Z test protocols::backup_management::password_tests::rejects_below_minimum_and_accepts_the_boundary ... ok
+2026-08-01T02:42:54.1507060Z test protocols::credential_exchange::tests::issue_body_carries_a_sealed_bundle ... ok
+2026-08-01T02:42:54.1507950Z test protocols::credential_exchange::tests::present_body_round_trips ... ok
+2026-08-01T02:42:54.1509337Z test protocols::credential_exchange::tests::query_body_round_trips_with_a_dcql_query ... ok
+2026-08-01T02:42:54.1510351Z test protocols::credential_exchange::tests::uris_are_versioned_and_distinct ... ok
+2026-08-01T02:42:54.1515297Z test protocols::did_management::agent_name::tests::a_parked_entry_deserialises_from_the_host_shape ... ok
+2026-08-01T02:42:54.1525954Z test protocols::did_management::agent_name::tests::check_result_distinguishes_reserved_from_taken ... ok
+2026-08-01T02:42:54.1531885Z test protocols::did_management::agent_name::tests::created_at_is_camel_case_on_the_wire ... ok
+2026-08-01T02:42:54.1541963Z test protocols::did_management::agent_name::tests::list_result_carries_an_empty_registry ... ok
+2026-08-01T02:42:54.1543127Z test protocols::did_management::agent_name::tests::request_bodies_serialise_camel_case ... ok
+2026-08-01T02:42:54.1545255Z test protocols::did_management::agent_name::tests::result_body_reports_whether_the_name_resolves ... ok
+2026-08-01T02:42:54.1551533Z test protocols::did_management::create::casing_tests::create_body_reads_both_casings ... ok
+2026-08-01T02:42:54.1555160Z test protocols::did_management::create::webvh_path_mode_tests::default_is_auto_assign ... ok
+2026-08-01T02:42:54.1561401Z test protocols::did_management::create::webvh_path_mode_tests::from_legacy_path ... ok
+2026-08-01T02:42:54.1573847Z test protocols::did_management::create::webvh_path_mode_tests::resolve_prefers_explicit_mode ... ok
+2026-08-01T02:42:54.1576150Z test protocols::did_management::create::webvh_path_mode_tests::serde_round_trips ... ok
+2026-08-01T02:42:54.1577317Z test protocols::did_management::create::webvh_path_mode_tests::to_request_path_maps_each_mode ... ok
+2026-08-01T02:42:54.1578639Z test protocols::did_management::update::casing_tests::pre_rotation_count_reads_from_either_casing ... ok
+2026-08-01T02:42:54.1579824Z test protocols::did_management::update::casing_tests::single_word_members_are_unaffected ... ok
+2026-08-01T02:42:54.1581055Z test protocols::did_management::update::casing_tests::the_concurrency_precondition_is_read_from_the_wire ... ok
+2026-08-01T02:42:54.1582405Z test protocols::did_management::update::tests::result_body_round_trips ... ok
+2026-08-01T02:42:54.1583483Z test protocols::did_management::update::tests::result_body_serverless_defaults_to_false_when_absent ... ok
+2026-08-01T02:42:54.1584551Z test protocols::did_management::update::tests::rotate_body_round_trips ... ok
+2026-08-01T02:42:54.1585670Z test protocols::did_management::update::tests::update_body_expected_version_id_round_trips_and_defaults_none ... ok
+2026-08-01T02:42:54.1586837Z test protocols::did_management::update::tests::update_body_round_trips_full ... ok
+2026-08-01T02:42:54.1587815Z test protocols::did_management::update::tests::update_body_round_trips_minimal ... ok
+2026-08-01T02:42:54.1588792Z test protocols::key_management::import::tests::accepts_both_spellings_on_intake ... ok
+2026-08-01T02:42:54.1589760Z test protocols::key_management::import::tests::debug_redacts_every_carrier ... ok
+2026-08-01T02:42:54.1590635Z test protocols::key_management::import::tests::emits_camel_case ... ok
+2026-08-01T02:42:54.1591437Z test protocols::passkey_login::tests::finish_request_camel_case ... ok
+2026-08-01T02:42:54.1592396Z test protocols::passkey_login::tests::start_response_camel_case ... ok
+2026-08-01T02:42:54.1593369Z test protocols::provision_integration_management::tests::canonical_uris_match_registry ... ok
+2026-08-01T02:42:54.1594497Z test protocols::provision_integration_management::tests::lower_camel_to_snake_and_kebab ... ok
+2026-08-01T02:42:54.1595782Z test protocols::provision_integration_management::tests::request_body_v0_1_stays_snake_case_and_kebab_assertion ... ok
+2026-08-01T02:42:54.1597259Z test protocols::provision_integration_management::tests::request_body_v0_2_camelizes_opts_and_assertion_but_not_signed_vp ... ok
+2026-08-01T02:42:54.1598767Z test protocols::provision_integration_management::tests::response_body_v0_1_stays_snake_case_v0_2_camelizes_summary ... ok
+2026-08-01T02:42:54.1600573Z test protocols::provision_integration_management::tests::result_uri_for_unknown_request_defaults_to_v0_1 ... ok
+2026-08-01T02:42:54.1601932Z test protocols::provision_integration_management::tests::result_uri_for_v0_1_request_emits_v0_1_response ... ok
+2026-08-01T02:42:54.1633395Z test protocols::provision_integration_management::tests::result_uri_for_v0_2_request_emits_v0_2_response ... ok
+2026-08-01T02:42:54.1634344Z test http::tests::rest_client_builds ... ok
+2026-08-01T02:42:54.1635382Z test provision_client::ask::tests::builtin_template_constants_resolve_in_registry ... ok
+2026-08-01T02:42:54.1636497Z test protocols::acl_management::swap::verify_impl::tests::verifies_a_well_formed_presentation ... ok
+2026-08-01T02:42:54.1637786Z test protocols::acl_management::swap::verify_impl::tests::verifies_against_a_publickeyjwk_document ... ok
+2026-08-01T02:42:54.1638930Z test provision_client::ask::tests::curated_did_host_didcomm_equivalent_to_for_template ... ok
+2026-08-01T02:42:54.1639972Z test provision_client::ask::tests::curated_did_host_http_equivalent_to_for_template ... ok
+2026-08-01T02:42:54.1640956Z test provision_client::ask::tests::did_host_didcomm_sets_mediator_did_var ... ok
+2026-08-01T02:42:54.1641956Z test provision_client::ask::tests::did_host_http_didcomm_sets_url_and_mediator_did_vars ... ok
+2026-08-01T02:42:54.1643033Z test provision_client::ask::tests::did_host_http_sets_url_var ... ok
+2026-08-01T02:42:54.1643905Z test provision_client::ask::tests::didcomm_mediator_sets_url_var_and_template ... ok
+2026-08-01T02:42:54.1644947Z test provision_client::ask::tests::for_template_defaults_to_admin_rollover_via_vta_admin ... ok
+2026-08-01T02:42:54.1645900Z test provision_client::ask::tests::vta_admin_disables_rollover ... ok
+2026-08-01T02:42:54.1646874Z test provision_client::ask::tests::curated_did_host_http_didcomm_equivalent_to_for_template ... ok
+2026-08-01T02:42:54.1647935Z test provision_client::ask::tests::vta_admin_rotated_yields_admin_only_ask_shape ... ok
+2026-08-01T02:42:54.1648963Z test provision_client::ask::tests::vta_admin_rotated_produces_admin_rotation_wire_ask ... ok
+2026-08-01T02:42:54.1649979Z test provision_client::ask::tests::without_admin_rollover_clears_admin_fields ... ok
+2026-08-01T02:42:54.1650982Z test provision_client::diagnostics::tests::all_lists_split_authenticate_rows_in_order ... ok
+2026-08-01T02:42:54.1652275Z test provision_client::diagnostics::tests::apply_update_sets_status_on_matching_check ... ok
+2026-08-01T02:42:54.1653286Z test provision_client::diagnostics::tests::pending_list_has_all_checks ... ok
+2026-08-01T02:42:54.1654209Z test provision_client::diagnostics::tests::protocol_labels_are_distinct ... ok
+2026-08-01T02:42:54.1655170Z test provision_client::diagnostics::tests::provision_label_is_template_agnostic ... ok
+2026-08-01T02:42:54.1656142Z test provision_client::driver::tests::format_check_line_uses_expected_tags ... ok
+2026-08-01T02:42:54.1657114Z test provision_client::driver::tests::headless_error_display_names_every_protocol ... ok
+2026-08-01T02:42:54.1658166Z test provision_client::ask::tests::curated_didcomm_mediator_equivalent_to_for_template ... ok
+2026-08-01T02:42:54.1659320Z test provision_client::ask::tests::curated_vta_admin_equivalent_to_for_template_without_rollover ... ok
+2026-08-01T02:42:54.1660439Z test provision_client::diagnostics::tests::authenticate_rows_have_distinct_labels ... ok
+2026-08-01T02:42:54.1661667Z test provision_client::driver::tests::headless_error_with_only_a_tsp_failure_does_not_claim_nothing_was_advertised ... ok
+2026-08-01T02:42:54.1693272Z test provision_client::driver::tests::headless_error_display_no_transport_message_differs_from_post_auth ... ok
+2026-08-01T02:42:54.1694409Z test provision_client::messages::tests::defaults_have_no_success_message ... ok
+2026-08-01T02:42:54.1695329Z test provision_client::messages::tests::integration_labels_are_distinct ... ok
+2026-08-01T02:42:54.1696213Z test provision_client::driver::tests::phase1_uses_writer_not_stdout ... ok
+2026-08-01T02:42:54.1697157Z test provision_client::messages::tests::mediator_pnm_command_matches_donor_layout ... ok
+2026-08-01T02:42:54.1698441Z test provision_client::messages::tests::trait_object_is_send_sync ... ok
+2026-08-01T02:42:54.1699450Z test provision_client::driver::tests::phase1_writes_a_valid_key_file_and_prints_pnm_command ... ok
+2026-08-01T02:42:54.1700539Z test provision_client::messages::tests::webvh_server_pnm_command_uses_webvh_label ... ok
+2026-08-01T02:42:54.2916522Z test provision_client::resolve::seeded_discovery_tests::a_tsp_advertising_vta_is_discovered_as_tsp ... ok
+2026-08-01T02:42:54.2918780Z test provision_client::resolve::seeded_discovery_tests::a_non_did_tsp_endpoint_is_not_treated_as_a_mediator ... ok
+2026-08-01T02:42:54.2920049Z test provision_client::resolve::seeded_discovery_tests::a_tsp_only_vta_does_not_fall_back_to_a_guessed_rest_url ... ok
+2026-08-01T02:42:54.2921081Z test provision_client::resolve::tests::a_tsp_only_vta_reports_tsp ... ok
+2026-08-01T02:42:54.2922005Z test provision_client::resolve::tests::a_dual_transport_vta_reports_every_transport_it_offers ... ok
+2026-08-01T02:42:54.2923242Z test provision_client::resolve::tests::a_vta_advertising_nothing_reports_nothing ... ok
+2026-08-01T02:42:54.2924143Z test provision_client::resolve::tests::advertised_is_in_preference_order ... ok
+2026-08-01T02:42:54.2925007Z test provision_client::result::tests::decode_nonce_b64url_rejects_wrong_length ... ok
+2026-08-01T02:42:54.2925856Z test provision_client::result::tests::decode_nonce_b64url_round_trip ... ok
+2026-08-01T02:42:54.2926671Z test provision_client::result::tests::hex_lower_matches_known_vector ... ok
+2026-08-01T02:42:54.2927512Z test provision_client::result::tests::result_accessors_with_admin_rollover ... ok
+2026-08-01T02:42:54.2928509Z test provision_client::result::tests::result_accessors_without_admin_rollover_fall_back_to_client_did ... ok
+2026-08-01T02:42:54.2929528Z test provision_client::result::tests::webvh_log_matches_integration_did_only ... ok
+2026-08-01T02:42:54.2930458Z test provision_client::runner::tests::fallback_predicates_match_the_resolved_endpoints ... ok
+2026-08-01T02:42:54.2931475Z test provision_client::runner::tests::neither_is_reserved_for_a_document_that_advertises_nothing ... ok
+2026-08-01T02:42:54.2932674Z test provision_client::runner::tests::select_returns_all_three_when_all_three_advertised ... ok
+2026-08-01T02:42:54.2933563Z test provision_client::runner::tests::select_returns_both_when_both_advertised ... ok
+2026-08-01T02:42:54.2934466Z test provision_client::runner::tests::select_returns_didcomm_only_when_only_didcomm_advertised ... ok
+2026-08-01T02:42:54.2935459Z test provision_client::runner::tests::select_returns_neither_when_no_transport_advertised ... ok
+2026-08-01T02:42:54.2936404Z test provision_client::runner::tests::select_returns_rest_only_when_only_rest_advertised ... ok
+2026-08-01T02:42:54.2937424Z test provision_client::runner::tests::select_returns_tsp_and_didcomm_when_both_mediator_transports_advertised ... ok
+2026-08-01T02:42:54.2938485Z test provision_client::runner::tests::select_returns_tsp_and_rest_when_tsp_and_rest_advertised ... ok
+2026-08-01T02:42:54.2939390Z test provision_client::runner::tests::select_returns_tsp_only_when_only_tsp_advertised ... ok
+2026-08-01T02:42:54.2940263Z test provision_client::runner::tests::starts_with_tsp_covers_exactly_the_tsp_variants ... ok
+2026-08-01T02:42:54.2941069Z test provision_client::runner::tests::tsp_only_has_no_fallback ... ok
+2026-08-01T02:42:54.2979878Z test provision_client::runner::tests::tsp_selection_does_not_depend_on_the_tsp_feature ... ok
+2026-08-01T02:42:54.2981254Z test provision_client::runner_didcomm::tests::server_managed_explicit_path_is_injected ... ok
+2026-08-01T02:42:54.2994337Z test provision_client::runner_didcomm::tests::server_managed_no_path_leaves_webvh_path_unset ... ok
+2026-08-01T02:42:54.3023606Z test provision_client::runner_didcomm::tests::serverless_leaves_webvh_path_unset ... ok
+2026-08-01T02:42:54.3053022Z test provision_client::resolve::seeded_discovery_tests::a_didcomm_only_vta_advertises_no_tsp ... ok
+2026-08-01T02:42:54.3681431Z test provision_client::runner_rest::tests::full_setup_returns_pre_auth_failure_on_auth_401 ... ok
+2026-08-01T02:42:54.3683164Z test provision_client::runner_rest::tests::admin_only_returns_pre_auth_failure_on_401 ... ok
+2026-08-01T02:42:54.3689244Z test provision_client::setup_key::tests::generate_returns_did_key_with_private_multibase ... ok
+2026-08-01T02:42:54.3701154Z test provision_client::setup_key::tests::load_rejects_unknown_version ... ok
+2026-08-01T02:42:54.3703243Z test provision_client::setup_key::tests::persist_roundtrip_preserves_did_and_key ... ok
+2026-08-01T02:42:54.3709450Z test provision_client::setup_key::tests::two_generate_calls_produce_distinct_keys ... ok
+2026-08-01T02:42:54.3711302Z test provision_client::setup_key::tests::persisted_file_has_owner_only_permissions ... ok
+2026-08-01T02:42:54.3714793Z test provision_client::runner_rest::tests::admin_only_returns_connected_on_successful_auth ... ok
+2026-08-01T02:42:54.3763058Z test provision_integration::credential::tests::missing_type_rejected ... ok
+2026-08-01T02:42:54.3882659Z test provision_integration::credential::tests::expired_vc_rejected ... ok
+2026-08-01T02:42:54.3893069Z test provision_integration::credential::tests::test_issuer_pubkey_matches_did_key_decode ... ok
+2026-08-01T02:42:54.3893694Z test provision_integration::credential::tests::issue_and_verify_round_trip ... ok
+2026-08-01T02:42:54.3939989Z test provision_integration::credential::tests::tampered_claim_fails_verification ... ok
+2026-08-01T02:42:54.3941695Z test provision_integration::http::tests::request_accepts_both_camel_and_snake_case ... ok
+2026-08-01T02:42:54.3943061Z test provision_integration::http::tests::summary_accepts_camel_case ... ok
+2026-08-01T02:42:54.4094140Z test provision_integration::credential::tests::wrong_issuer_key_rejected ... ok
+2026-08-01T02:42:54.4106211Z test provision_integration::request::tests::admin_rotation_tampered_template_rejected ... ok
+2026-08-01T02:42:54.4111969Z test provision_integration::request::tests::admin_rotation_ask_round_trips_through_sign_verify ... ok
+2026-08-01T02:42:54.4301284Z test provision_integration::request::tests::builder_admin_template_attaches_rollover_ref ... ok
+2026-08-01T02:42:54.4312249Z test provision_integration::request::tests::admin_template_omitted_is_backward_compatible ... ok
+2026-08-01T02:42:54.4313730Z test provision_integration::request::tests::admin_template_round_trips_through_sign_verify ... ok
+2026-08-01T02:42:54.4314896Z test provision_integration::request::tests::builder_distinct_bundle_ids_per_call ... ok
+2026-08-01T02:42:54.4338534Z test provision_client::runner_rest::tests::full_setup_returns_post_auth_failure_on_provision_400 ... ok
+2026-08-01T02:42:54.4372438Z test provision_integration::request::tests::client_x25519_derivation_matches_sealed_transfer ... ok
+2026-08-01T02:42:54.4392743Z test provision_integration::request::tests::deserialize_rejects_unknown_field_in_ask ... ok
+2026-08-01T02:42:54.4422661Z test provision_integration::request::tests::deserialize_rejects_unknown_top_level_field ... ok
+2026-08-01T02:42:54.4456823Z test provision_integration::request::tests::builder_bulk_vars_preserved ... ok
+2026-08-01T02:42:54.4483316Z test provision_integration::request::tests::builder_sign_ephemeral_verifies_and_carries_ask ... ok
+2026-08-01T02:42:54.4496686Z test provision_integration::request::tests::builder_sign_with_reuses_caller_identity ... ok
+2026-08-01T02:42:54.4513159Z test provision_integration::request::tests::holder_swap_rejected ... ok
+2026-08-01T02:42:54.4553152Z test provision_integration::request::tests::expired_request_rejected ... ok
+2026-08-01T02:42:54.4661809Z test provision_integration::request::tests::for_admin_rotation_builder_emits_admin_rotation_variant ... ok
+2026-08-01T02:42:54.4663014Z test provision_integration::request::tests::sign_and_verify_round_trip ... ok
+2026-08-01T02:42:54.4673530Z test provision_integration::request::tests::roundtrip_via_json ... ok
+2026-08-01T02:42:54.4700700Z test provision_integration::request::tests::tampered_admin_template_rejected ... ok
+2026-08-01T02:42:54.4815251Z test provision_integration::request::tests::tampered_ask_rejected ... ok
+2026-08-01T02:42:54.4824711Z test provision_integration::request::tests::tampered_nonce_rejected ... ok
+2026-08-01T02:42:54.4830186Z test provision_integration::request::tests::verify_fixture_round_trips ... ok
+2026-08-01T02:42:54.4842500Z test provision_integration::request::tests::verify_rejects_cryptosuite_downgrade ... ok
+2026-08-01T02:42:54.4873242Z test provision_integration::request::tests::verify_rejects_ask_mutation ... ok
+2026-08-01T02:42:54.4899464Z test provision_integration::request::tests::verify_rejects_holder_mutation ... ok
+2026-08-01T02:42:54.4923232Z test provision_integration::request::tests::verify_rejects_missing_bootstrap_request_type ... ok
+2026-08-01T02:42:54.4943002Z test provision_integration::request::tests::verify_rejects_malformed_proof_object ... ok
+2026-08-01T02:42:54.4972654Z test provision_integration::request::tests::verify_rejects_missing_vp_type ... ok
+2026-08-01T02:42:54.5004469Z test provision_integration::request::tests::verify_rejects_id_mutation ... ok
+2026-08-01T02:42:54.5023592Z test provision_integration::request::tests::verify_rejects_label_mutation ... ok
+2026-08-01T02:42:54.5073085Z test provision_integration::request::tests::verify_rejects_verification_method_did_swap ... ok
+2026-08-01T02:42:54.5105804Z test provision_integration::request::tests::verify_rejects_nonce_mutation ... ok
+2026-08-01T02:42:54.5133462Z test provision_integration::request::tests::verify_rejects_signature_byte_flip ... ok
+2026-08-01T02:42:54.5193227Z test provision_integration::request::tests::verify_rejects_valid_until_mutation ... ok
+2026-08-01T02:42:54.5212844Z test provision_integration::request::tests::verify_value_accepts_v0_2_camelcase_ask ... ok
+2026-08-01T02:42:54.5242693Z test provision_integration::template_verify::tests::verify_rejects_mismatched_pinned_did ... ok
+2026-08-01T02:42:54.5266499Z test provision_integration::template_verify::tests::verify_rejects_unknown_verification_method ... ok
+2026-08-01T02:42:54.5303176Z test sealed_transfer::hpke::tests::open_with_tampered_kem_encap_rejected ... ok
+2026-08-01T02:42:54.5333031Z test provision_integration::request::tests::verify_value_rejects_tampered_v0_2_ask ... ok
+2026-08-01T02:42:54.5346519Z test sealed_transfer::hpke::tests::open_with_wrong_aad_rejected ... ok
+2026-08-01T02:42:54.5393129Z test provision_integration::template_verify::tests::verify_passes_for_matched_pinned_did ... ok
+2026-08-01T02:42:54.5394192Z test sealed_transfer::hpke::tests::open_with_wrong_recipient_secret_rejected ... ok
+2026-08-01T02:42:54.5403577Z test sealed_transfer::template_bootstrap::tests::admin_rotation_payload_json_round_trip ... ok
+2026-08-01T02:42:54.5426122Z test sealed_transfer::template_bootstrap::tests::admin_rotation_sealed_payload_variant_round_trip ... ok
+2026-08-01T02:42:54.5427292Z test sealed_transfer::template_bootstrap::tests::sealed_payload_variant_round_trip ... ok
+2026-08-01T02:42:54.5428422Z test sealed_transfer::template_bootstrap::tests::template_output_generic_coexists_with_typed_variants ... ok
+2026-08-01T02:42:54.5429552Z test sealed_transfer::template_bootstrap::tests::template_bootstrap_payload_json_round_trip ... ok
+2026-08-01T02:42:54.5430739Z test sealed_transfer::template_bootstrap::tests::template_output_generic_round_trips_arbitrary_payload ... ok
+2026-08-01T02:42:54.5431894Z test sealed_transfer::template_bootstrap::tests::template_output_webvh_log_tag_on_wire ... ok
+2026-08-01T02:42:54.5433035Z test sealed_transfer::hpke::tests::seal_open_round_trip ... ok
+2026-08-01T02:42:54.5433892Z test provision_integration::template_verify::tests::verify_rejects_claim_vta_drift ... ok
+2026-08-01T02:42:54.5434748Z test sealed_transfer::tests::aad_tamper_caught_by_aead ... ok
+2026-08-01T02:42:54.5435447Z test sealed_transfer::tests::armor_bundle_id_tamper_caught ... ok
+2026-08-01T02:42:54.5436179Z test sealed_transfer::tests::armor_chunk_count_tamper_caught ... ok
+2026-08-01T02:42:54.5436945Z test sealed_transfer::tests::armor_corruption_caught_by_crc24 ... ok
+2026-08-01T02:42:54.5438171Z test sealed_transfer::tests::armor_unknown_header_rejected ... ok
+2026-08-01T02:42:54.5438960Z test sealed_transfer::tests::bootstrap_request_rejects_unknown_fields ... ok
+2026-08-01T02:42:54.5439698Z test sealed_transfer::tests::armor_digest_algo_tamper_caught ... ok
+2026-08-01T02:42:54.5440385Z test sealed_transfer::tests::bootstrap_request_round_trip ... ok
+2026-08-01T02:42:54.5441183Z test sealed_transfer::tests::armor_round_trip ... ok
+2026-08-01T02:42:54.5441865Z test sealed_transfer::tests::bootstrap_request_derives_x25519_pub_from_did_key ... ok
+2026-08-01T02:42:54.5460650Z test sealed_transfer::tests::digest_match_accepted ... ok
+2026-08-01T02:42:54.5461328Z test sealed_transfer::tests::digest_mismatch_rejected ... ok
+2026-08-01T02:42:54.5501460Z test sealed_transfer::tests::pinned_only_without_digest_rejected ... ok
+2026-08-01T02:42:54.5543032Z test sealed_transfer::tests::replay_rejected_by_nonce_store ... ok
+2026-08-01T02:42:54.5572902Z test sealed_transfer::tests::round_trip_messaging_bridge_credentials ... ok
+2026-08-01T02:42:54.5602692Z test sealed_transfer::verify::tests::dispatch_attested_yields_needs_nitro_check_variant ... ok
+2026-08-01T02:42:54.5603547Z test sealed_transfer::verify::tests::dispatch_did_signed_requires_pubkey ... ok
+2026-08-01T02:42:54.5632590Z test sealed_transfer::tests::round_trip_single_chunk ... ok
+2026-08-01T02:42:54.5662833Z test sealed_transfer::verify::tests::dispatch_pinned_only_yields_acknowledged_variant ... ok
+2026-08-01T02:42:54.5683797Z test sealed_transfer::verify::tests::dispatch_did_signed_yields_verified_variant ... ok
+2026-08-01T02:42:54.5744936Z test sealed_transfer::verify::tests::verify_passes_for_matching_signature ... ok
+2026-08-01T02:42:54.5873045Z test sealed_transfer::verify::tests::verify_rejects_tampered_bundle_id ... ok
+2026-08-01T02:42:54.5874163Z test sealed_transfer::verify::tests::verify_rejects_wrong_producer_did ... ok
+2026-08-01T02:42:54.5913270Z test sealed_transfer::verify::tests::verify_rejects_tampered_signature_bytes ... ok
+2026-08-01T02:42:54.5915279Z test session::tests::bind_vta_did_accepts_did_key_vta ... ok
+2026-08-01T02:42:54.5924528Z test session::tests::bind_vta_did_promotes_pending_to_rotation ... ok
+2026-08-01T02:42:54.5925452Z test session::tests::bind_vta_did_rejects_malformed_input ... ok
+2026-08-01T02:42:54.5926338Z test session::tests::bind_vta_did_rejects_missing_session ... ok
+2026-08-01T02:42:54.5927551Z test session::tests::bind_vta_did_rejects_rebind ... ok
+2026-08-01T02:42:54.5928433Z test session::tests::connect_timeout_defaults_when_unset_or_junk ... ok
+2026-08-01T02:42:54.5929294Z test session::tests::connect_timeout_honours_env_override ... ok
+2026-08-01T02:42:54.5930169Z test session::tests::forced_didcomm_error_names_the_alternatives ... ok
+2026-08-01T02:42:54.5931107Z test session::tests::has_pending_vta_binding_false_for_direct_session ... ok
+2026-08-01T02:42:54.5932221Z test session::tests::has_pending_vta_binding_false_for_missing_entry ... ok
+2026-08-01T02:42:54.5933196Z test session::tests::mediator_timeout_error_names_the_recovery_flag ... ok
+2026-08-01T02:42:54.5943429Z test session::tests::no_rest_endpoint_error_tells_operator_to_pass_url ... ok
+2026-08-01T02:42:54.5953720Z test session::tests::no_tsp_error_only_offers_transports_that_exist ... ok
+2026-08-01T02:42:54.5963947Z test session::tests::require_vta_did_errors_on_pending ... ok
+2026-08-01T02:42:54.5969704Z test session::tests::store_pending_vta_binding_rejects_empty_inputs ... ok
+2026-08-01T02:42:54.5993328Z test session::tests::store_pending_vta_binding_rejects_non_did_key ... ok
+2026-08-01T02:42:54.6003510Z test session::tests::store_pending_vta_binding_round_trips ... ok
+2026-08-01T02:42:54.6004423Z test session::tests::test_in_memory_backend ... ok
+2026-08-01T02:42:54.6005363Z test session::tests::test_now_epoch_is_recent ... ok
+2026-08-01T02:42:54.6006679Z test session::tests::test_session_legacy_vta_url_field_silently_dropped ... ok
+2026-08-01T02:42:54.6007727Z test session::tests::test_session_round_trip ... ok
+2026-08-01T02:42:54.6009200Z test session::tests::test_session_vta_did_defaults_to_none_when_missing ... ok
+2026-08-01T02:42:54.6010148Z test session::tests::test_session_vta_did_round_trips_null ... ok
+2026-08-01T02:42:54.6011001Z test session::tests::test_url_from_did_key_returns_none ... ok
+2026-08-01T02:42:54.6011753Z test session::tests::test_url_from_did_web ... ok
+2026-08-01T02:42:54.6012625Z test session::tests::test_url_from_did_web_with_port ... ok
+2026-08-01T02:42:54.6013584Z test session::tests::test_url_from_did_webvh ... ok
+2026-08-01T02:42:54.6014337Z test session::tests::test_url_from_did_webvh_with_port ... ok
+2026-08-01T02:42:54.6015241Z test session::tests::transport_choice_defaults_to_auto ... ok
+2026-08-01T02:42:54.6016148Z test session::tests::tsp_connect_timeout_is_independent_of_the_didcomm_one ... ok
+2026-08-01T02:42:54.6017120Z test session::tests::tsp_failure_modes_have_distinct_messages ... ok
+2026-08-01T02:42:54.6028218Z test sealed_transfer::verify::tests::verify_rejects_wrong_pubkey ... ok
+2026-08-01T02:42:54.8103490Z test session_hub::tests::a_detached_did_can_attach_again ... ok
+2026-08-01T02:42:54.8104676Z test session_hub::tests::a_second_session_for_the_same_did_is_refused ... ok
+2026-08-01T02:42:54.8143202Z test session_hub::tests::already_attached_names_the_did_and_the_fix ... ok
+2026-08-01T02:42:55.0158319Z test session_hub::tests::attaching_registers_the_identity_and_its_secrets ... ok
+2026-08-01T02:42:55.0159313Z test session_hub::tests::identities_are_independent_and_detach_is_idempotent ... ok
+2026-08-01T02:42:55.0173286Z test session_hub::tests::ownership_distinguishes_a_borrowed_hub_from_an_owned_one ... ok
+2026-08-01T02:42:55.0202852Z test trust_task_sign::tests::non_did_key_holder_refused ... ok
+2026-08-01T02:42:55.0322928Z test sealed_transfer::tests::missing_chunk_rejected ... ok
+2026-08-01T02:42:55.0325733Z test trust_task_sign::tests::unsigned_sets_issuer_and_recipient ... ok
+2026-08-01T02:42:55.0332272Z test trust_task_sign::tests::signed_document_verifies_server_side ... ok
+2026-08-01T02:42:55.0333197Z test trust_task_sign::tests::tampered_payload_fails ... ok
+2026-08-01T02:42:55.0334065Z test trust_tasks::tests::every_uri_has_maj_min_version_suffix ... ok
+2026-08-01T02:42:55.0334977Z test trust_tasks::tests::every_uri_in_canonical_namespace ... ok
+2026-08-01T02:42:55.0339297Z test trust_tasks::tests::every_uri_parses_as_framework_type_uri ... ok
+2026-08-01T02:42:55.0340100Z test trust_tasks::tests::no_duplicate_uris ... ok
+2026-08-01T02:42:55.0342938Z test trust_tasks::tests::rest_routed_uris_partition_all_uris ... ok
+2026-08-01T02:42:55.0343833Z test tsp_demux::tests::a_non_json_frame_is_uncorrelated_not_dropped ... ok
+2026-08-01T02:42:55.0347027Z test tsp_demux::tests::a_push_correlates_with_no_request ... ok
+2026-08-01T02:42:55.0347930Z test tsp_demux::tests::a_reply_reaches_its_own_waiter ... ok
+2026-08-01T02:42:55.0350041Z test tsp_demux::tests::a_stale_frame_is_not_mistaken_for_our_reply ... ok
+2026-08-01T02:42:55.0351114Z test tsp_demux::tests::an_uncorrelated_document_is_returned_and_can_be_parked ... ok
+2026-08-01T02:42:55.0354522Z test tsp_demux::tests::clear_wakes_waiters_with_a_closed_channel ... ok
+2026-08-01T02:42:55.0355523Z test tsp_demux::tests::concurrent_waiters_do_not_steal_from_each_other ... ok
+2026-08-01T02:42:55.0356492Z test tsp_demux::tests::correlates_on_echoed_nonce_when_unthreaded ... ok
+2026-08-01T02:42:55.0357360Z test tsp_demux::tests::correlates_on_thread_id ... ok
+2026-08-01T02:42:55.0361955Z test tsp_demux::tests::parking_is_bounded_and_drops_the_oldest ... ok
+2026-08-01T02:42:55.0363082Z test tsp_demux::tests::request_keys_reads_id_and_nonce ... ok
+2026-08-01T02:42:55.0383332Z test tsp_demux::tests::request_keys_refuses_a_document_with_no_id ... ok
+2026-08-01T02:42:55.0402893Z test vp::tests::build_vp_token_rejects_an_empty_selection ... ok
+2026-08-01T02:42:55.0403638Z test vp::tests::select_credentials_errors_when_no_credential_satisfies_the_query ... ok
+2026-08-01T02:42:55.0404862Z test vp::tests::select_credentials_matches_the_membership_query ... ok
+2026-08-01T02:42:55.0405599Z test webvh::tests::legacy_record_loads_with_default_pre_rotation_and_fragment_id ... ok
+2026-08-01T02:42:55.0406314Z test trust_tasks::tests::constant_suffix_matches_uri_version ... ok
+2026-08-01T02:42:55.0407025Z test webvh::tests::legacy_server_record_with_embedded_tokens_deserializes_cleanly ... ok
+2026-08-01T02:42:55.0407712Z test webvh::tests::record_with_new_fields_round_trips ... ok
+2026-08-01T02:42:55.0408516Z test webvh::tests::server_record_round_trips_without_token_fields ... ok
+2026-08-01T02:42:55.0525651Z test vp::tests::build_vp_token_produces_a_holder_bound_di_vp_that_verifies ... ok
+2026-08-01T02:42:55.1867940Z test sealed_transfer::tests::round_trip_multi_chunk ... ok
+2026-08-01T02:42:55.1868388Z 
+2026-08-01T02:42:55.1869077Z test result: ok. 580 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 1.32s
+2026-08-01T02:42:55.1869619Z 
+2026-08-01T02:42:55.1891716Z [1m[92m     Running[0m tests/auth_light_rest.rs (target/debug/deps/auth_light_rest-aeaf455c41388273)
+2026-08-01T02:42:55.7029995Z 
+2026-08-01T02:42:55.7030808Z running 19 tests
+2026-08-01T02:42:55.9533204Z test authenticate_with_credential_no_url_anywhere_fails ... ok
+2026-08-01T02:42:56.0409437Z test authenticate_endpoint_401_maps_to_auth ... ok
+2026-08-01T02:42:56.0416077Z test authenticate_with_credential_uses_url_override ... ok
+2026-08-01T02:42:56.0416951Z test authenticate_with_credential_uses_bundle_url ... ok
+2026-08-01T02:42:56.0417822Z test authenticate_body_is_a_signed_trust_task ... ok
+2026-08-01T02:42:56.1125020Z test challenge_endpoint_500_maps_to_server ... ok
+2026-08-01T02:42:56.1142892Z test challenge_endpoint_401_maps_to_auth ... ok
+2026-08-01T02:42:56.1172302Z test challenge_response_success_returns_tokens ... ok
+2026-08-01T02:42:56.1177771Z test ensure_token_valid_falls_through_when_refresh_fails ... ok
+2026-08-01T02:42:56.1857790Z test ensure_token_valid_full_reauth_when_refresh_expired ... ok
+2026-08-01T02:42:56.1871763Z test from_credential_authenticates_and_exposes_token ... ok
+2026-08-01T02:42:56.1893025Z test from_credential_url_override_wins_over_bundle ... ok
+2026-08-01T02:42:56.1893784Z test ensure_token_valid_refreshes_expired_access_token ... ok
+2026-08-01T02:42:56.2573388Z test non_did_key_holder_maps_to_validation ... ok
+2026-08-01T02:42:56.2580586Z test refresh_token_401_maps_to_auth ... ok
+2026-08-01T02:42:56.2580965Z test refresh_body_is_an_unsigned_trust_task ... ok
+2026-08-01T02:42:56.2603084Z test non_key_vta_did_still_authenticates ... ok
+2026-08-01T02:42:56.3019508Z test refresh_token_success_rotates_tokens ... ok
+2026-08-01T02:42:56.3040626Z test trust_task_wrapped_response_is_unwrapped ... ok
+2026-08-01T02:42:56.3040988Z 
+2026-08-01T02:42:56.3041383Z test result: ok. 19 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.60s
+2026-08-01T02:42:56.3041731Z 
+2026-08-01T02:42:56.3061975Z [1m[92m     Running[0m tests/client_rest.rs (target/debug/deps/client_rest-2e4090ccbc484130)
+2026-08-01T02:42:56.3087233Z 
+2026-08-01T02:42:56.3087515Z running 84 tests
+2026-08-01T02:42:56.3799557Z test audit_list_percent_encodes_rfc3339_bounds ... ok
+2026-08-01T02:42:56.3800159Z test add_webvh_server_posts ... ok
+2026-08-01T02:42:56.3813814Z test backup_export_403_maps_to_forbidden ... ok
+2026-08-01T02:42:56.3833874Z test backup_export_returns_envelope ... ok
+2026-08-01T02:42:56.4503028Z test check_auth_false_when_401 ... ok
+2026-08-01T02:42:56.4504015Z test capabilities_returns_features ... ok
+2026-08-01T02:42:56.4504567Z test create_acl_409_maps_to_conflict ... ok
+2026-08-01T02:42:56.4514980Z test check_auth_true_when_200 ... ok
+2026-08-01T02:42:56.5153175Z test create_acl_posts ... ok
+2026-08-01T02:42:56.5196853Z test create_context_did_template_posts ... ok
+2026-08-01T02:42:56.5211591Z test create_did_template_posts ... ok
+2026-08-01T02:42:56.5212594Z test create_context_posts ... ok
+2026-08-01T02:42:56.5840912Z test create_did_webvh_posts ... ok
+2026-08-01T02:42:56.5885904Z test delete_acl_404_maps_to_not_found ... ok
+2026-08-01T02:42:56.5904336Z test create_key_round_trip ... ok
+2026-08-01T02:42:56.5905109Z test delete_acl_returns_unit ... ok
+2026-08-01T02:42:56.6524316Z test delete_context_did_template_returns_unit ... ok
+2026-08-01T02:42:56.6570747Z test delete_context_with_force_query ... ok
+2026-08-01T02:42:56.6579043Z test delete_context_no_force_omits_query ... ok
+2026-08-01T02:42:56.6683487Z test delete_did_template_returns_unit ... ok
+2026-08-01T02:42:56.7270337Z test get_acl_path_encodes_did ... ok
+2026-08-01T02:42:56.7312248Z test delete_did_webvh_returns_unit ... ok
+2026-08-01T02:42:56.7363415Z test get_audit_retention_returns_days ... ok
+2026-08-01T02:42:56.7953989Z test get_config_returns_the_registry ... ok
+2026-08-01T02:42:56.8028181Z test get_context_path_encodes_id ... ok
+2026-08-01T02:42:56.8047163Z test get_context_did_template_returns_one ... ok
+2026-08-01T02:42:56.8273402Z test fetch_context_secrets_walks_all_pages ... ok
+2026-08-01T02:42:56.8643657Z test get_did_template_returns_one ... ok
+2026-08-01T02:42:56.8703292Z test get_did_webvh_log_returns_log ... ok
+2026-08-01T02:42:56.8713224Z test get_did_webvh_returns_record ... ok
+2026-08-01T02:42:56.9023287Z test get_key_404_maps_to_not_found ... ok
+2026-08-01T02:42:56.9350091Z test get_key_path_encodes_did_fragment ... ok
+2026-08-01T02:42:56.9363209Z test get_key_secret_returns_multibase ... ok
+2026-08-01T02:42:56.9373075Z test get_wrapping_key_returns_jwk ... ok
+2026-08-01T02:42:56.9833355Z test health_500_maps_to_server_error ... ok
+2026-08-01T02:42:56.9943132Z test http_400_maps_to_validation ... ok
+2026-08-01T02:42:57.0093203Z test health_minimal_body_deserializes ... ok
+2026-08-01T02:42:57.0142996Z test health_returns_status ... ok
+2026-08-01T02:42:57.0533113Z test http_401_maps_to_auth ... ok
+2026-08-01T02:42:57.0664578Z test http_410_maps_to_gone ... ok
+2026-08-01T02:42:57.0788759Z test http_422_maps_to_validation ... ok
+2026-08-01T02:42:57.0789511Z test http_418_maps_to_other ... ok
+2026-08-01T02:42:57.1233192Z test import_key_posts ... ok
+2026-08-01T02:42:57.1370152Z test invalidate_key_deletes ... ok
+2026-08-01T02:42:57.1463423Z test list_acl_no_filter ... ok
+2026-08-01T02:42:57.1503714Z test list_acl_sends_the_direction_only_when_it_is_not_the_default ... ok
+2026-08-01T02:42:57.1923325Z test list_acl_with_context_query ... ok
+2026-08-01T02:42:57.1993077Z test list_audit_logs_paginates ... ok
+2026-08-01T02:42:57.2270639Z test list_context_did_templates_returns_array ... ok
+2026-08-01T02:42:57.2274315Z test list_contexts_returns_array ... ok
+2026-08-01T02:42:57.2623547Z test list_did_templates_returns_array ... ok
+2026-08-01T02:42:57.2713437Z test list_dids_webvh_filters_by_context ... ok
+2026-08-01T02:42:57.2893750Z test list_keys_paginates_query_params ... ok
+2026-08-01T02:42:57.2982988Z test list_seeds_returns_active ... ok
+2026-08-01T02:42:57.3413292Z test list_webvh_servers_returns_array ... ok
+2026-08-01T02:42:57.3455781Z test malformed_error_body_falls_back_to_raw_text ... ok
+2026-08-01T02:42:57.3543285Z test network_error_when_server_unreachable ... ok
+2026-08-01T02:42:57.3769490Z test oversized_error_body_is_truncated ... ok
+2026-08-01T02:42:57.4163716Z test preview_delete_context_returns_summary ... ok
+2026-08-01T02:42:57.4183134Z test remove_webvh_server_deletes ... ok
+2026-08-01T02:42:57.4223194Z test rename_key_409_maps_to_conflict ... ok
+2026-08-01T02:42:57.4460849Z test rename_key_patches ... ok
+2026-08-01T02:42:57.4888157Z test render_context_did_template_unwraps_document ... ok
+2026-08-01T02:42:57.4903097Z test render_did_template_unwraps_document ... ok
+2026-08-01T02:42:57.4908268Z test rest_url_returned_after_construction ... ok
+2026-08-01T02:42:57.5173316Z test restart_returns_status ... ok
+2026-08-01T02:42:57.5571128Z test shutdown_is_noop_for_rest ... ok
+2026-08-01T02:42:57.5593106Z test rotate_did_webvh_keys_posts ... ok
+2026-08-01T02:42:57.5632901Z test rotate_seed_with_mnemonic ... ok
+2026-08-01T02:42:57.5883339Z test sign_posts_base64url_payload ... ok
+2026-08-01T02:42:57.6236519Z test swap_acl_over_rest_says_which_method_takes_the_subject ... ok
+2026-08-01T02:42:57.6269369Z test token_expires_at_none_until_set ... ok
+2026-08-01T02:42:57.6289084Z test swap_acl_sends_the_canonical_task_over_rest ... ok
+2026-08-01T02:42:57.6603242Z test update_acl_patches ... ok
+2026-08-01T02:42:57.6961562Z test update_audit_retention_patches ... ok
+2026-08-01T02:42:57.6993339Z test update_config_reports_identity_as_rejected ... ok
+2026-08-01T02:42:57.6994046Z test update_config_sends_the_overrides_map ... ok
+2026-08-01T02:42:57.7283243Z test update_context_did_puts ... ok
+2026-08-01T02:42:57.7567791Z test update_did_template_puts ... ok
+2026-08-01T02:42:57.7743594Z test update_context_patches ... ok
+2026-08-01T02:42:57.7744518Z test update_context_did_template_puts ... ok
+2026-08-01T02:42:57.7956131Z test update_did_webvh_by_did_sends_the_canonical_task ... ok
+2026-08-01T02:42:57.8144438Z test update_did_webvh_posts_to_context_path ... ok
+2026-08-01T02:42:57.8173350Z test update_webvh_server_patches ... ok
+2026-08-01T02:42:57.8173708Z 
+2026-08-01T02:42:57.8174143Z test result: ok. 84 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.51s
+2026-08-01T02:42:57.8174676Z 
+2026-08-01T02:42:57.8188430Z [1m[92m     Running[0m tests/cred_formats_build.rs (target/debug/deps/cred_formats_build-331fa89038a48bc2)
+2026-08-01T02:42:57.8224160Z 
+2026-08-01T02:42:57.8224330Z running 3 tests
+2026-08-01T02:42:57.8228585Z test bbs_2023_cryptosuite_is_wired ... ok
+2026-08-01T02:42:57.8233623Z test openid4vp_types_are_reachable ... ok
+2026-08-01T02:42:58.0912584Z test bbs_sign_verify_and_selective_disclosure_round_trip ... ok
+2026-08-01T02:42:58.0913076Z 
+2026-08-01T02:42:58.0913431Z test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.27s
+2026-08-01T02:42:58.0913801Z 
+2026-08-01T02:42:58.0917584Z [1m[92m     Running[0m tests/protocol_debug_redaction.rs (target/debug/deps/protocol_debug_redaction-68d63fecc671f1bb)
+2026-08-01T02:42:58.0930159Z 
+2026-08-01T02:42:58.0930322Z running 10 tests
+2026-08-01T02:42:58.0934322Z test backup_payload_debug_redacts_active_seed_and_jwt_signing_key ... ok
+2026-08-01T02:42:58.0935101Z test create_did_webvh_result_body_debug_redacts_mnemonic ... ok
+2026-08-01T02:42:58.0936294Z test create_key_body_debug_redacts_mnemonic ... ok
+2026-08-01T02:42:58.0936828Z test export_request_debug_redacts_password ... ok
+2026-08-01T02:42:58.0937416Z test get_key_secret_result_body_debug_redacts_private_key ... ok
+2026-08-01T02:42:58.0938128Z test imported_secret_backup_debug_redacts_private_key_hex ... ok
+2026-08-01T02:42:58.0938658Z test seed_record_backup_debug_redacts_seed_hex ... ok
+2026-08-01T02:42:58.0939047Z test import_request_debug_redacts_password ... ok
+2026-08-01T02:42:58.0939495Z test rotate_seed_body_debug_redacts_mnemonic ... ok
+2026-08-01T02:42:58.0940051Z test token_bundle_debug_redacts_access_and_refresh_tokens ... ok
+2026-08-01T02:42:58.0940415Z 
+2026-08-01T02:42:58.0940779Z test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+2026-08-01T02:42:58.0941281Z 
+2026-08-01T02:42:58.0941948Z [1m[92m     Running[0m tests/protocol_rest.rs (target/debug/deps/protocol_rest-ae182588db2f9729)
+2026-08-01T02:42:58.1028284Z 
+2026-08-01T02:42:58.1029185Z running 14 tests
+2026-08-01T02:42:58.1921171Z test drain_cancel_404_when_not_in_drain ... ok
+2026-08-01T02:42:58.1922254Z test didcomm_status_gets_and_decodes_response ... ok
+2026-08-01T02:42:58.1922941Z test disable_didcomm_with_drain_window ... ok
+2026-08-01T02:42:58.1923505Z test disable_didcomm_with_immediate_drain ... ok
+2026-08-01T02:42:58.2598942Z test enable_didcomm_409_maps_to_conflict ... ok
+2026-08-01T02:42:58.2635654Z test mediator_report_403_when_not_authorized ... ok
+2026-08-01T02:42:58.2652862Z test drain_cancel_posts_request ... ok
+2026-08-01T02:42:58.2673052Z test enable_didcomm_posts_request_and_decodes_response ... ok
+2026-08-01T02:42:58.3335513Z test mediator_report_no_query_params ... ok
+2026-08-01T02:42:58.3343314Z test mediator_report_only_since ... ok
+2026-08-01T02:42:58.3344229Z test mediator_report_only_until ... ok
+2026-08-01T02:42:58.3344791Z test mediator_report_with_since_until_url_encodes_timestamps ... ok
+2026-08-01T02:42:58.3871449Z test update_didcomm_500_maps_to_server_error ... ok
+2026-08-01T02:42:58.3872247Z test update_didcomm_posts_request ... ok
+2026-08-01T02:42:58.3872542Z 
+2026-08-01T02:42:58.3872856Z test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.28s
+2026-08-01T02:42:58.3873703Z 
+2026-08-01T02:42:58.3892018Z [1m[92m     Running[0m tests/provision_client_e2e.rs (target/debug/deps/provision_client_e2e-84c52d8c378b05b6)
+2026-08-01T02:42:58.3918455Z 
+2026-08-01T02:42:58.3918663Z running 0 tests
+2026-08-01T02:42:58.3918881Z 
+2026-08-01T02:42:58.3919287Z test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+2026-08-01T02:42:58.3919774Z 
+2026-08-01T02:42:58.3922338Z [1m[92m     Running[0m tests/sd_jwt_vc_smoke.rs (target/debug/deps/sd_jwt_vc_smoke-cfd055a768e75819)
+2026-08-01T02:42:58.3956006Z 
+2026-08-01T02:42:58.3956279Z running 2 tests
+2026-08-01T02:42:58.4128647Z test tampered_issuer_signature_is_rejected ... ok
+2026-08-01T02:42:58.4130569Z test issue_and_verify_sd_jwt_vc_end_to_end ... ok
+2026-08-01T02:42:58.4130825Z 
+2026-08-01T02:42:58.4131097Z test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s
+2026-08-01T02:42:58.4131439Z 
+2026-08-01T02:42:58.4136893Z [1m[92m     Running[0m tests/session_store.rs (target/debug/deps/session_store-67b93a82d1b47746)
+2026-08-01T02:42:58.4164441Z 
+2026-08-01T02:42:58.4164787Z running 0 tests
+2026-08-01T02:42:58.4164950Z 
+2026-08-01T02:42:58.4165222Z test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+2026-08-01T02:42:58.4165576Z 
+2026-08-01T02:42:58.4168620Z [1m[92m     Running[0m tests/tsp_discovery_live.rs (target/debug/deps/tsp_discovery_live-7f7f7a0e65bd6ab8)
+2026-08-01T02:42:58.4203802Z 
+2026-08-01T02:42:58.4204172Z running 2 tests
+2026-08-01T02:42:58.4204906Z test deployed_vta_advertises_both_transports_to_a_probe ... ignored, resolves a did:webvh over the network; run explicitly with --ignored
+2026-08-01T02:42:58.4205801Z test deployed_vta_resolves_as_tsp_with_no_guessed_rest_url ... ignored, resolves a did:webvh over the network; run explicitly with --ignored
+2026-08-01T02:42:58.4206309Z 
+2026-08-01T02:42:58.4206561Z test result: ok. 0 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 0.00s
+2026-08-01T02:42:58.4206912Z 
+2026-08-01T02:42:58.4209333Z [1m[92m     Running[0m tests/tsp_dual_leg_live.rs (target/debug/deps/tsp_dual_leg_live-2086ee37605191f0)
+2026-08-01T02:42:58.4299104Z 
+2026-08-01T02:42:58.4299516Z running 2 tests
+2026-08-01T02:42:58.4300239Z test a_deployed_vta_answers_a_trust_task_over_the_didcomm_sessions_socket ... ignored, resolves a did:webvh and connects to a live mediator; run explicitly with --ignored
+2026-08-01T02:42:58.4301295Z test didcomm_control_against_the_same_deployment ... ignored, resolves a did:webvh and connects to a live mediator; run explicitly with --ignored
+2026-08-01T02:42:58.4301796Z 
+2026-08-01T02:42:58.4302248Z test result: ok. 0 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 0.00s
+2026-08-01T02:42:58.4302597Z 
+2026-08-01T02:42:58.4309680Z [1m[92m     Running[0m unittests src/lib.rs (target/debug/deps/vta_service-b78622ca8f0b37b1)
+2026-08-01T02:42:58.4382984Z 
+2026-08-01T02:42:58.4383167Z running 756 tests
+2026-08-01T02:42:58.4388488Z test auth::backend::tests::gate_allows_entry_without_device ... ok
+2026-08-01T02:42:58.4389178Z test auth::backend::tests::gate_allows_active_device ... ok
+2026-08-01T02:42:58.4389794Z test auth::backend::tests::gate_rejects_disabled_device ... ok
+2026-08-01T02:42:58.4390429Z test auth::backend::tests::gate_rejects_wiped_device ... ok
+2026-08-01T02:42:58.4403691Z test auth::credentials::tests::test_generate_did_key_format ... ok
+2026-08-01T02:42:58.4404445Z test auth::credentials::tests::test_generate_did_key_unique ... ok
+2026-08-01T02:42:58.4411810Z test auth::credentials::tests::test_generate_did_key_roundtrip ... ok
+2026-08-01T02:42:58.4474209Z test cli_store::tests::cli_store_enc_key_accessor ... ok
+2026-08-01T02:42:58.4479034Z test cli_store::tests::cli_store_deref_persist ... ok
+2026-08-01T02:42:58.4553819Z test cli_store::tests::cli_store_no_key_returns_bare_handle ... ok
+2026-08-01T02:42:58.4554673Z test didcomm_bridge::tests::detail_carries_remote_comment_and_code ... ok
+2026-08-01T02:42:58.4564884Z test didcomm_bridge::tests::remote_auth_denial_is_forbidden_not_unauthorized ... ok
+2026-08-01T02:42:58.4567166Z test didcomm_bridge::tests::remote_client_errors_keep_their_meaning ... ok
+2026-08-01T02:42:58.4573557Z test didcomm_bridge::tests::upstream_failures_and_unknown_codes_stay_bad_gateway ... ok
+2026-08-01T02:42:58.4578152Z test hardened_bootstrap::tests::derive_storage_key_differs_by_salt ... ok
+2026-08-01T02:42:58.4579013Z test hardened_bootstrap::tests::derive_storage_key_differs_by_seed ... ok
+2026-08-01T02:42:58.4580603Z test hardened_bootstrap::tests::derive_storage_key_is_deterministic ... ok
+2026-08-01T02:42:58.4584421Z test hardened_bootstrap::tests::derive_storage_key_matches_known_test_vector ... ok
+2026-08-01T02:42:58.4602451Z test cli_store::tests::cli_store_round_trips_with_same_key ... ok
+2026-08-01T02:42:58.4640261Z test cli_store::tests::cli_store_with_key_returns_encrypted_handle ... ok
+2026-08-01T02:42:58.4658110Z test cli_store::tests::cli_store_wrong_key_fails_to_decrypt ... ok
+2026-08-01T02:42:58.4793345Z test hardened_bootstrap::tests::jwt_key_row_is_bound_to_its_location ... ok
+2026-08-01T02:42:58.4805702Z test hardened_bootstrap::tests::first_boot_stores_key_in_the_encrypted_keyspace ... ok
+2026-08-01T02:42:58.4869479Z test hardened_bootstrap::tests::legacy_sealed_key_is_migrated_not_rotated ... ok
+2026-08-01T02:42:58.5077373Z test hardened_bootstrap::tests::rotate_generates_new_key ... ok
+2026-08-01T02:42:58.5280178Z test hardened_bootstrap::tests::subsequent_boot_returns_same_key ... ok
+2026-08-01T02:42:58.5494518Z test hardened_bootstrap::tests::undecryptable_legacy_row_errors ... ok
+2026-08-01T02:42:58.5694952Z test hardened_bootstrap::tests::wrong_storage_key_cannot_read_the_jwt_key ... ok
+2026-08-01T02:42:58.6575321Z test keyspaces::tests::no_bare_keyspace_literals ... ok
+2026-08-01T02:42:58.6786468Z test hardened_bootstrap::tests::migration_is_idempotent ... ok
+2026-08-01T02:42:58.6819103Z test messaging::auth::tests::accepts_unexpired_entry_with_role_and_contexts ... ok
+2026-08-01T02:42:58.6942284Z test hardened_bootstrap::tests::migration_makes_preexisting_plaintext_rows_readable ... ok
+2026-08-01T02:42:58.6964067Z test hardened_bootstrap::tests::migration_leaves_bootstrap_keyspace_bare ... ok
+2026-08-01T02:42:58.7014131Z test messaging::auth::tests::auth_from_did_fragment_collapses ... ok
+2026-08-01T02:42:58.7082490Z test messaging::auth::tests::auth_from_did_reports_persisted_elevated_acr ... ok
+2026-08-01T02:42:58.7156742Z test messaging::auth::tests::auth_from_did_resolves_role_and_contexts ... ok
+2026-08-01T02:42:58.7175561Z test messaging::auth::tests::auth_from_did_unknown_did_errors ... ok
+2026-08-01T02:42:58.7226159Z test messaging::auth::tests::fragment_in_sender_collapses_to_base_did ... ok
+2026-08-01T02:42:58.7303515Z test messaging::auth::tests::missing_sender_is_authentication_error ... ok
+2026-08-01T02:42:58.7333517Z test messaging::drain_store::tests::delete_drain_removes_entry ... ok
+2026-08-01T02:42:58.7370985Z test messaging::auth::tests::rejects_expired_entry ... ok
+2026-08-01T02:42:58.7371822Z test messaging::drain_store::tests::list_empty_when_no_drains ... ok
+2026-08-01T02:42:58.7468355Z test messaging::drain_store::tests::list_ignores_unrelated_keys ... ok
+2026-08-01T02:42:58.7478659Z test messaging::drain_store::tests::store_and_list_round_trip ... ok
+2026-08-01T02:42:58.7506062Z test messaging::drain_sweeper::tests::arm_all_replays_multiple_entries ... ok
+2026-08-01T02:42:58.7524305Z test messaging::drain_store::tests::store_replaces_existing ... ok
+2026-08-01T02:42:58.7620563Z test messaging::drain_sweeper::tests::arm_replaces_previous_task ... ok
+2026-08-01T02:42:58.7645176Z test messaging::drain_sweeper::tests::deadline_already_passed_fires_immediately ... ok
+2026-08-01T02:42:58.7646137Z test messaging::handlers::tests::app_error_catch_all_is_internal_error ... ok
+2026-08-01T02:42:58.7647328Z test messaging::handlers::tests::app_error_maps_to_byte_identical_codes ... ok
+2026-08-01T02:42:58.7653437Z test messaging::handlers::tests::invalid_cursor_is_a_bad_request_not_an_internal_error ... ok
+2026-08-01T02:42:58.7654949Z test messaging::handlers_protocol::tests::protocol_errors_map_to_byte_identical_problem_reports ... ok
+2026-08-01T02:42:58.7717401Z test messaging::drain_sweeper::tests::disarm_unknown_mediator_returns_false ... ok
+2026-08-01T02:42:58.8156023Z test messaging::drain_sweeper::tests::disarm_aborts_pending_sweep ... ok
+2026-08-01T02:42:58.8157037Z test messaging::handshake::tests::handshake_options_default_is_10s_no_force ... ok
+2026-08-01T02:42:58.8172949Z test messaging::handshake::tests::handshake_stage_string_form ... ok
+2026-08-01T02:42:58.8203505Z test messaging::handshake::tests::prover_failure_propagates_stage ... ok
+2026-08-01T02:42:58.8484937Z test messaging::drain_sweeper::tests::arm_fires_at_deadline_and_signals_teardown ... ok
+2026-08-01T02:42:58.8504091Z test messaging::live_prover::tests::handshake_stages_used_by_prover ... ok
+2026-08-01T02:42:58.8505234Z test messaging::readiness::tests::backoff_ceiling_doubles_then_caps ... ok
+2026-08-01T02:42:58.8506288Z test messaging::readiness::tests::did_key_needs_no_network_probe ... ok
+2026-08-01T02:42:58.8507290Z test messaging::readiness::tests::did_key_skips_gate_and_proceeds ... ok
+2026-08-01T02:42:58.8508341Z test messaging::readiness::tests::disabled_gate_proceeds_without_probing ... ok
+2026-08-01T02:42:58.8509390Z test messaging::readiness::tests::jitter_stays_within_ceiling ... ok
+2026-08-01T02:42:58.8510326Z test messaging::readiness::tests::loop_abandons_the_wait_on_shutdown ... ok
+2026-08-01T02:42:58.8520216Z test messaging::readiness::tests::loop_succeeds_after_a_few_attempts ... ok
+2026-08-01T02:42:58.8571805Z test messaging::handshake::tests::failed_resolve_emits_handshake_failed_with_stage ... ok
+2026-08-01T02:42:58.8573138Z test messaging::readiness::tests::no_endpoint_hint_for_did_key ... ok
+2026-08-01T02:42:58.8574134Z test messaging::readiness::tests::only_a_long_enough_session_counts_as_healthy ... ok
+2026-08-01T02:42:58.8575291Z test messaging::readiness::tests::policy_backoff_is_bounded_by_the_reconnect_cap ... ok
+2026-08-01T02:42:58.8576347Z test messaging::readiness::tests::policy_cap_below_base_still_grows ... ok
+2026-08-01T02:42:58.8577381Z test messaging::readiness::tests::policy_gives_up_once_the_horizon_is_exhausted ... ok
+2026-08-01T02:42:58.8578386Z test messaging::readiness::tests::policy_retries_forever_by_default ... ok
+2026-08-01T02:42:58.8579357Z test messaging::readiness::tests::policy_with_reconnect_disabled_never_retries ... ok
+2026-08-01T02:42:58.8580429Z test messaging::readiness::tests::timeout_error_names_the_endpoint_when_known ... ok
+2026-08-01T02:42:58.8581402Z test messaging::readiness::tests::timeout_policy_maps_to_decision ... ok
+2026-08-01T02:42:58.8582503Z test messaging::readiness::tests::unknown_method_is_not_gated ... ok
+2026-08-01T02:42:58.8583448Z test messaging::readiness::tests::webvh_and_web_need_a_network_probe ... ok
+2026-08-01T02:42:58.8584511Z test messaging::readiness::tests::webvh_endpoint_hint_is_derived_for_diagnostics ... ok
+2026-08-01T02:42:58.8585565Z test messaging::registry::tests::activate_promotes_and_returns_prior ... ok
+2026-08-01T02:42:58.8588344Z test messaging::registry::tests::active_listener_id_tracks_state ... ok
+2026-08-01T02:42:58.8590583Z test messaging::registry::tests::async_activate_emits_migrate_start ... ok
+2026-08-01T02:42:58.8593782Z test messaging::registry::tests::async_buffer_overflow_emits_response_dropped ... ok
+2026-08-01T02:42:58.8596516Z test messaging::registry::tests::async_cancel_emits_drain_cancel ... ok
+2026-08-01T02:42:58.8599383Z test messaging::registry::tests::async_drain_emits_drain_start ... ok
+2026-08-01T02:42:58.8601823Z test messaging::registry::tests::async_expire_emits_per_dropped_entry ... ok
+2026-08-01T02:42:58.8604352Z test messaging::registry::tests::buffer_outbound_evicts_oldest_at_capacity ... ok
+2026-08-01T02:42:58.8605420Z test messaging::registry::tests::buffer_outbound_queues_under_capacity ... ok
+2026-08-01T02:42:58.8606451Z test messaging::registry::tests::buffer_outbound_rejects_unknown_listener ... ok
+2026-08-01T02:42:58.8607929Z test messaging::registry::tests::buffer_outbound_works_for_draining_listener ... ok
+2026-08-01T02:42:58.8608987Z test messaging::registry::tests::cancel_drain_drops_buffered_responses ... ok
+2026-08-01T02:42:58.8609914Z test messaging::registry::tests::cancel_refuses_active ... ok
+2026-08-01T02:42:58.8610796Z test messaging::registry::tests::cancel_removes_drain_entry ... ok
+2026-08-01T02:42:58.8611692Z test messaging::registry::tests::cancel_unknown_mediator_errors ... ok
+2026-08-01T02:42:58.8612834Z test messaging::registry::tests::deactivate_drops_active_only ... ok
+2026-08-01T02:42:58.8613769Z test messaging::registry::tests::drain_after_replacement_succeeds ... ok
+2026-08-01T02:42:58.8614720Z test messaging::registry::tests::drain_count_is_observable ... ok
+2026-08-01T02:42:58.8616181Z test messaging::registry::tests::drain_refuses_active_mediator ... ok
+2026-08-01T02:42:58.8617327Z test messaging::registry::tests::drain_refuses_already_draining ... ok
+2026-08-01T02:42:58.8618450Z test messaging::registry::tests::expire_drains_drops_buffered_responses ... ok
+2026-08-01T02:42:58.8619476Z test messaging::registry::tests::expire_drains_returns_only_expired ... ok
+2026-08-01T02:42:58.8620496Z test messaging::registry::tests::generation_increments_on_every_mutation ... ok
+2026-08-01T02:42:58.8621485Z test messaging::registry::tests::overlapping_drains_coexist ... ok
+2026-08-01T02:42:58.8622674Z test messaging::registry::tests::reactivating_drained_mediator_evicts_drain_entry ... ok
+2026-08-01T02:42:58.8714081Z test messaging::registry::tests::record_cancel_persisted_removes_from_keyspace ... ok
+2026-08-01T02:42:58.8730927Z test messaging::readiness::tests::loop_times_out_when_never_ready ... ok
+2026-08-01T02:42:58.8829655Z test messaging::handshake::tests::force_bypass_skips_prover_but_still_resolves ... ok
+2026-08-01T02:42:58.8831689Z test messaging::registry::tests::record_drain_persisted_accepts_29_day_ttl ... ok
+2026-08-01T02:42:58.8850831Z test messaging::registry::tests::record_drain_persisted_rejects_30_day_cap_exceeded ... ok
+2026-08-01T02:42:58.8954572Z test messaging::registry::tests::record_drain_persisted_rejects_past_deadline ... ok
+2026-08-01T02:42:58.8990936Z test messaging::registry::tests::record_drain_persisted_writes_to_keyspace ... ok
+2026-08-01T02:42:58.9101136Z test messaging::registry::tests::replay_drains_drops_already_expired_entries ... ok
+2026-08-01T02:42:58.9118654Z test messaging::registry::tests::record_expiries_persisted_removes_expired_from_keyspace ... ok
+2026-08-01T02:42:58.9119682Z test messaging::service::tests::anonymous_encrypted_sender_is_rejected ... ok
+2026-08-01T02:42:58.9120735Z test messaging::service::tests::encrypted_and_verified_sender_is_authenticated ... ok
+2026-08-01T02:42:58.9121781Z test messaging::service::tests::plaintext_frame_is_rejected ... ok
+2026-08-01T02:42:58.9124235Z test messaging::service::tests::unverified_sender_is_rejected ... ok
+2026-08-01T02:42:58.9125051Z test messaging::shim::tests::problem_report_serializes_like_the_framework ... ok
+2026-08-01T02:42:58.9125920Z test messaging::transient_handshake::tests::transient_handshake_module_compiles ... ok
+2026-08-01T02:42:58.9126496Z test messaging::registry::tests::replay_drains_empty_keyspace_is_noop ... ok
+2026-08-01T02:42:58.9253478Z test messaging::registry::tests::replay_drains_restores_in_memory_state ... ok
+2026-08-01T02:42:58.9375911Z test messaging::handshake::tests::resolve_mediator_rejects_unresolvable_did ... ok
+2026-08-01T02:42:58.9377561Z test operations::acl::tests::acl_entry_can_confer_matches_scope_and_admin_but_not_a_sibling_context ... ok
+2026-08-01T02:42:58.9435298Z test operations::acl::tests::a_direction_without_a_context_is_refused ... ok
+2026-08-01T02:42:58.9459648Z test operations::acl::tests::a_subtree_listing_does_not_widen_what_a_context_admin_can_see ... ok
+2026-08-01T02:42:58.9627599Z test operations::acl::tests::a_subtree_listing_returns_the_leaves_an_act_in_listing_omits ... ok
+2026-08-01T02:42:58.9688836Z test operations::acl::tests::context_admin_can_mint_a_least_privilege_approver ... ok
+2026-08-01T02:42:58.9745870Z test operations::acl::tests::context_admin_cannot_confer_a_foreign_context_via_the_approver ... ok
+2026-08-01T02:42:58.9781131Z test operations::acl::tests::context_admin_still_cannot_mint_a_super_admin ... ok
+2026-08-01T02:42:58.9965980Z test operations::acl::tests::create_acl_accepts_known_context ... ok
+2026-08-01T02:42:59.0006121Z test operations::acl::tests::create_acl_rejects_unknown_context ... ok
+2026-08-01T02:42:59.0074514Z test operations::acl::tests::delete_acl_admin_can_delete_admin_entry ... ok
+2026-08-01T02:42:59.0105646Z test operations::acl::tests::delete_acl_refuses_an_entry_that_acts_outside_callers_contexts ... ok
+2026-08-01T02:42:59.0289112Z test operations::acl::tests::delete_acl_rejects_initiator_deleting_admin ... ok
+2026-08-01T02:42:59.0290119Z test operations::acl::tests::parse_step_up_require_accepts_self_and_delegated_only ... ok
+2026-08-01T02:42:59.0291955Z test operations::acl::tests::step_up_require_round_trips_to_wire ... ok
+2026-08-01T02:42:59.0295214Z test operations::acl::tests::symmetric_difference_handles_typical_cases ... ok
+2026-08-01T02:42:59.0349322Z test operations::acl::tests::delete_acl_still_conflates_a_wholly_invisible_entry_to_not_found ... ok
+2026-08-01T02:42:59.0350859Z test operations::acl::tests::to_result_body_echoes_approve_scope ... ok
+2026-08-01T02:42:59.0396046Z test operations::acl::tests::get_acl_surfaces_an_approver_conferring_into_callers_context ... ok
+2026-08-01T02:42:59.0402245Z test operations::acl::tests::list_acl_includes_an_approver_conferring_into_callers_context ... ok
+2026-08-01T02:42:59.0643203Z test operations::acl::tests::the_default_direction_is_the_historical_filter ... ok
+2026-08-01T02:42:59.0707105Z test operations::acl::tests::update_acl_applies_the_same_approve_grant_check_as_create ... ok
+2026-08-01T02:42:59.0710715Z test operations::acl::tests::update_acl_allows_remove_within_caller_scope ... ok
+2026-08-01T02:42:59.0753240Z test operations::acl::tests::update_acl_leaves_approve_scope_alone_when_absent ... ok
+2026-08-01T02:42:59.0988283Z test operations::acl::tests::update_acl_rejects_add_outside_caller_scope ... ok
+2026-08-01T02:42:59.1028410Z test operations::acl::tests::update_acl_rejects_shrink_across_caller_scope ... ok
+2026-08-01T02:42:59.1029440Z test operations::config::tests::boot_stable_keys_are_marked_restart_required ... ok
+2026-08-01T02:42:59.1030216Z test operations::config::tests::identity_is_readable ... ok
+2026-08-01T02:42:59.1035609Z test operations::config::tests::identity_is_registered_but_immutable ... ok
+2026-08-01T02:42:59.1036189Z test operations::config::tests::reasons_track_mutability ... ok
+2026-08-01T02:42:59.1040839Z test operations::acl::tests::update_acl_rejects_adding_unknown_context ... ok
+2026-08-01T02:42:59.1064202Z test operations::acl::tests::update_acl_sets_and_revokes_approve_scope ... ok
+2026-08-01T02:42:59.1199260Z test operations::contexts::tests::admin_of_parent_creates_a_nested_context_with_nested_base_path ... ok
+2026-08-01T02:42:59.1219204Z test operations::contexts::tests::creates_a_top_level_context ... ok
+2026-08-01T02:42:59.1380287Z test operations::acl::tests::update_acl_sets_empties_and_clears_the_key_filter ... ok
+2026-08-01T02:42:59.1580511Z test operations::contexts::tests::nesting_requires_admin_of_the_parent ... ok
+2026-08-01T02:42:59.1729674Z test operations::contexts::tests::nesting_under_a_missing_parent_is_not_found ... ok
+2026-08-01T02:42:59.1732551Z test operations::contexts::tests::an_admin_cannot_delete_a_context_outside_its_subtree ... ok
+2026-08-01T02:42:59.1881180Z test operations::contexts::tests::top_level_creation_requires_super_admin ... ok
+2026-08-01T02:42:59.1884840Z test operations::contexts::tests::delete_refuses_a_context_with_sub_contexts_without_force ... ok
+2026-08-01T02:42:59.1980635Z test operations::contexts::tests::force_delete_cascades_the_whole_subtree ... ok
+2026-08-01T02:42:59.2060587Z test operations::contexts::tests::update_sets_context_policy_and_chain_resolves ... ok
+2026-08-01T02:42:59.2297904Z test operations::credential_exchange::tests::approve_refuses_an_expired_deferral ... ok
+2026-08-01T02:42:59.2359609Z test operations::credential_exchange::tests::build_credential_request_for_offer_refuses_an_offer_without_a_code ... ok
+2026-08-01T02:42:59.2420333Z test operations::contexts::tests::parent_admin_can_delete_a_sub_context ... ok
+2026-08-01T02:42:59.2651943Z test operations::credential_exchange::tests::build_credential_request_for_offer_signs_a_keybinding_proof ... ok
+2026-08-01T02:42:59.2654370Z test operations::credential_exchange::tests::formats_admitted_for_dcql_are_all_presentable ... ok
+2026-08-01T02:42:59.2719650Z test operations::credential_exchange::tests::does_not_match_a_different_vct ... ok
+2026-08-01T02:42:59.2810954Z test operations::credential_exchange::tests::deny_deletes_on_terminal_and_blocks_approval ... ok
+2026-08-01T02:42:59.2962499Z test operations::credential_exchange::tests::match_vault_gathers_via_the_type_index_and_matches ... ok
+2026-08-01T02:42:59.3023885Z test operations::credential_exchange::tests::match_vault_is_empty_without_a_type_discriminator ... ok
+2026-08-01T02:42:59.3079979Z test operations::credential_exchange::tests::matches_a_held_sd_jwt_vc_by_vct_and_discloses_the_named_claim ... ok
+2026-08-01T02:42:59.3199617Z test operations::credential_exchange::tests::defer_then_approve_presents_and_deletes_on_terminal ... ok
+2026-08-01T02:42:59.3797041Z test operations::credential_exchange::tests::present_single_builds_a_consent_gated_selective_vp ... ok
+2026-08-01T02:42:59.3987283Z test operations::credential_exchange::tests::present_query_excludes_credentials_their_context_forbids_the_verifier ... ok
+2026-08-01T02:42:59.4098605Z test operations::credential_exchange::tests::present_query_runs_the_full_holder_present_path ... ok
+2026-08-01T02:42:59.4187128Z test operations::credential_exchange::tests::refuses_a_di_vc_from_a_did_web_issuer_without_a_resolver ... ok
+2026-08-01T02:42:59.4291581Z test operations::credential_exchange::tests::refuses_a_di_vc_whose_signing_key_is_outside_the_issuer ... ok
+2026-08-01T02:42:59.4310087Z test operations::credential_exchange::tests::receives_a_di_vc_from_a_did_key_issuer ... ok
+2026-08-01T02:42:59.4325575Z test operations::credential_exchange::tests::present_single_presents_a_w3c_di_vc_as_a_json_vp ... ok
+2026-08-01T02:42:59.4442854Z test operations::credential_exchange::tests::refuses_a_sealed_bundle_on_the_plaintext_path ... ok
+2026-08-01T02:42:59.4453225Z test operations::credential_exchange::tests::refuses_an_empty_issue ... ok
+2026-08-01T02:42:59.4458238Z test operations::credential_exchange::tests::present_query_presents_multiple_credentials_in_one_token ... ok
+2026-08-01T02:42:59.4746008Z test operations::credential_exchange::tests::seal_then_receive_an_issued_credential_round_trips ... ok
+2026-08-01T02:42:59.4765405Z test operations::device::tests::consumer_kind_round_trips_through_explicit_maps ... ok
+2026-08-01T02:42:59.4798190Z test operations::credential_exchange::tests::stores_an_issued_sd_jwt_vc ... ok
+2026-08-01T02:42:59.4820145Z test operations::credential_exchange::tests::skips_not_yet_presentable_formats_without_erroring ... ok
+2026-08-01T02:42:59.4903483Z test operations::credential_exchange::tests::sweep_reclaims_terminal_and_stale_records_keeps_live ... ok
+2026-08-01T02:42:59.4985109Z test operations::device::tests::disable_unknown_device_is_not_found ... ok
+2026-08-01T02:42:59.5029955Z test operations::device::tests::heartbeat_refreshes_last_seen_and_platform ... ok
+2026-08-01T02:42:59.5031869Z test operations::device::tests::heartbeat_rejects_unregistered_device ... ok
+2026-08-01T02:42:59.5139298Z test operations::device::tests::list_filters_then_disable_hides_device ... ok
+2026-08-01T02:42:59.5196980Z test operations::device::tests::register_attaches_binding_then_refuses_reregistration ... ok
+2026-08-01T02:42:59.5254058Z test operations::device::tests::register_rejects_did_not_in_acl ... ok
+2026-08-01T02:42:59.5269462Z test operations::device::tests::set_wake_clear_removes_channel ... ok
+2026-08-01T02:42:59.5376912Z test operations::device::tests::set_wake_records_channel_and_vta_owned_allowlist ... ok
+2026-08-01T02:42:59.5378128Z test operations::device::tests::wire_binding_uses_camel_case_consumer_kind ... ok
+2026-08-01T02:42:59.5378827Z test operations::device::tests::wire_capabilities_drops_internal_sign_trust_task ... ok
+2026-08-01T02:42:59.5393924Z test operations::did_peer::tests::mint_with_mediator_did_service_yields_peer2_and_two_keys ... ok
+2026-08-01T02:42:59.5403685Z test operations::did_peer::tests::secrets_map_to_entries_ed25519_then_x25519 ... ok
+2026-08-01T02:42:59.5404852Z test operations::did_webvh::concurrency::tests::log_entry_count_change_detected ... ok
+2026-08-01T02:42:59.5405919Z test operations::did_webvh::concurrency::tests::server_id_change_detected ... ok
+2026-08-01T02:42:59.5406910Z test operations::did_webvh::concurrency::tests::unchanged_record_passes ... ok
+2026-08-01T02:42:59.5407903Z test operations::did_webvh::concurrency::tests::unrelated_field_changes_do_not_trip_assertion ... ok
+2026-08-01T02:42:59.5409473Z test operations::did_webvh::concurrency::tests::updated_at_change_detected ... ok
+2026-08-01T02:42:59.5415984Z test operations::did_webvh::register_server::tests::conflict_variant_carries_race_reason ... ok
+2026-08-01T02:42:59.5431965Z test operations::device::tests::set_wake_rejects_unregistered_device ... ok
+2026-08-01T02:42:59.5493302Z test operations::device::tests::wipe_unknown_device_is_not_found ... ok
+2026-08-01T02:42:59.5499964Z test operations::device::tests::wipe_marks_wiped_and_disabled_then_hidden ... ok
+2026-08-01T02:42:59.6953712Z test operations::did_webvh::register_server::tests::rejects_non_super_admin ... ok
+2026-08-01T02:42:59.7009165Z test operations::did_webvh::register_server::tests::rejects_when_already_server_managed ... ok
+2026-08-01T02:42:59.7019547Z test operations::did_webvh::tests::backdated_version_time_is_past_and_strictly_increasing ... ok
+2026-08-01T02:42:59.7028817Z test operations::did_webvh::register_server::tests::rejects_when_did_not_found ... ok
+2026-08-01T02:42:59.7046712Z test operations::did_webvh::register_server::tests::rejects_when_log_missing ... ok
+2026-08-01T02:42:59.7193461Z test operations::did_webvh::tests::delete_did_webvh_blocks_cross_context_admin ... ok
+2026-08-01T02:42:59.7204388Z test operations::did_webvh::transport::tests::advertised_hosting_path_is_ignored_on_the_live_document ... ok
+2026-08-01T02:42:59.7205831Z test operations::did_webvh::transport::tests::didcomm_only_resolves_to_didcomm ... ok
+2026-08-01T02:42:59.7208393Z test operations::did_webvh::transport::tests::didcomm_wins_when_listed_after_rest ... ok
+2026-08-01T02:42:59.7209511Z test operations::did_webvh::transport::tests::didcomm_wins_when_listed_first ... ok
+2026-08-01T02:42:59.7210604Z test operations::did_webvh::transport::tests::empty_service_list_yields_none ... ok
+2026-08-01T02:42:59.7211672Z test operations::did_webvh::transport::tests::multi_typed_service_entry_matches_any_type ... ok
+2026-08-01T02:42:59.7213200Z test operations::did_webvh::transport::tests::rest_entry_with_empty_uri_after_trim_is_skipped ... ok
+2026-08-01T02:42:59.7214419Z test operations::did_webvh::transport::tests::rest_entry_without_endpoint_falls_through ... ok
+2026-08-01T02:42:59.7215752Z test operations::did_webvh::transport::tests::rest_url_strips_quotes_and_trailing_slash_together ... ok
+2026-08-01T02:42:59.7216954Z test operations::did_webvh::transport::tests::rest_url_strips_surrounding_quotes ... ok
+2026-08-01T02:42:59.7218372Z test operations::did_webvh::transport::tests::rest_url_strips_trailing_slash ... ok
+2026-08-01T02:42:59.7219474Z test operations::did_webvh::transport::tests::unsupported_service_type_yields_none ... ok
+2026-08-01T02:42:59.7220651Z test operations::did_webvh::transport::tests::webvh_hosting_canonical_resolves_to_rest ... ok
+2026-08-01T02:42:59.7221852Z test operations::did_webvh::transport::tests::webvh_hosting_service_legacy_alias_accepted ... ok
+2026-08-01T02:42:59.7223447Z test operations::did_webvh::update::orchestrator::agent_name_host_contract::a_name_on_another_domain_is_not_ours_to_serve ... ok
+2026-08-01T02:42:59.7225585Z test operations::did_webvh::update::orchestrator::agent_name_host_contract::a_removed_claim_leaves_nothing_for_the_host_to_index ... ok
+2026-08-01T02:42:59.7231608Z test operations::did_webvh::update::orchestrator::agent_name_host_contract::an_unrelated_also_known_as_entry_survives_and_is_ignored ... ok
+2026-08-01T02:42:59.7233558Z test operations::did_webvh::update::orchestrator::agent_name_host_contract::what_we_write_is_what_the_host_parses ... ok
+2026-08-01T02:42:59.7235220Z test operations::did_webvh::update::orchestrator::agent_name_tests::claim_direction_matches_the_hosts_rule ... ok
+2026-08-01T02:42:59.7237872Z test operations::did_webvh::update::orchestrator::agent_name_tests::disable_removes_the_name_in_any_form_and_prunes_empty ... ok
+2026-08-01T02:42:59.7240024Z test operations::did_webvh::update::orchestrator::agent_name_tests::domain_parses_host_and_decodes_port ... ok
+2026-08-01T02:42:59.7246642Z test operations::did_webvh::update::orchestrator::agent_name_tests::edited_document_matches_the_verbs_claim_direction ... ok
+2026-08-01T02:42:59.7250217Z test operations::did_webvh::update::orchestrator::agent_name_tests::enable_adds_canonical_entry_idempotently ... ok
+2026-08-01T02:42:59.7251552Z test operations::did_webvh::update::orchestrator::agent_name_tests::enable_preserves_unrelated_also_known_as ... ok
+2026-08-01T02:42:59.7255083Z test operations::did_webvh::update::orchestrator::agent_name_tests::host_state_agrees_with_the_claim_direction ... ok
+2026-08-01T02:42:59.7256435Z test operations::did_webvh::update::orchestrator::agent_name_tests::is_agent_name_matches_host_ci_local_exact ... ok
+2026-08-01T02:42:59.7258438Z test operations::did_webvh::update::orchestrator::agent_name_tests::verbs_keep_distinct_operator_facing_names ... ok
+2026-08-01T02:42:59.7265639Z test operations::did_webvh::update::orchestrator::agent_name_tests::verbs_map_onto_the_hosts_two_tasks ... ok
+2026-08-01T02:42:59.7272435Z test operations::did_webvh::update::plan::tests::a_document_change_surfaces_the_hidden_key_rotation ... ok
+2026-08-01T02:42:59.7273541Z test operations::did_webvh::update::plan::tests::added_member_reports_no_before ... ok
+2026-08-01T02:42:59.7275840Z test operations::did_webvh::update::plan::tests::no_rotation_when_keys_are_unchanged ... ok
+2026-08-01T02:42:59.7276817Z test operations::did_webvh::update::plan::tests::removal_reports_no_after ... ok
+2026-08-01T02:42:59.7935246Z test operations::did_webvh::update::pre_rotation_e2e_tests::a_moved_counter_refuses_to_derive_the_wrong_keys ... ok
+2026-08-01T02:42:59.8374038Z test operations::did_webvh::tests::refresh_resolver_doc_from_log_seeds_cache_from_log ... ok
+2026-08-01T02:42:59.8468942Z test operations::did_webvh::tests::refresh_resolver_doc_from_log_preserves_cache_on_parse_failure ... ok
+2026-08-01T02:42:59.8490755Z test operations::did_webvh::register_server::tests::rejects_when_server_not_registered ... ok
+2026-08-01T02:43:00.0616261Z test operations::did_webvh::update::pre_rotation_e2e_tests::create_then_didcomm_enable_back_to_back_resolves ... ok
+2026-08-01T02:43:01.2130627Z test operations::did_webvh::update::pre_rotation_e2e_tests::no_document_change_means_no_rotation ... ok
+2026-08-01T02:43:01.2350402Z test operations::did_webvh::update::pre_rotation_e2e_tests::effects_surface_the_rotation_hidden_in_the_payload ... ok
+2026-08-01T02:43:01.4222797Z test operations::did_webvh::update::pre_rotation_e2e_tests::plan_predicts_the_pre_rotation_commitments_execution_publishes ... ok
+2026-08-01T02:43:02.4057701Z test operations::did_webvh::update::pre_rotation_e2e_tests::disabling_pre_rotation_then_updating_succeeds ... ok
+2026-08-01T02:43:02.5950292Z test operations::did_webvh::update::pre_rotation_e2e_tests::planning_is_read_only_and_repeatable ... ok
+2026-08-01T02:43:02.6174263Z test operations::did_webvh::update::pre_rotation_e2e_tests::plan_predicts_the_update_key_that_execution_installs ... ok
+2026-08-01T02:43:02.7774970Z test operations::did_webvh::update::pre_rotation_e2e_tests::rotate_keys_with_pre_rotation_succeeds ... ok
+2026-08-01T02:43:02.9476224Z test operations::did_webvh::update::pre_rotation_e2e_tests::update_detects_concurrent_server_id_flip ... ok
+2026-08-01T02:43:03.7251824Z test operations::did_webvh::update::pre_rotation_e2e_tests::rotate_keys_with_stale_record_snapshot_conflicts ... ok
+2026-08-01T02:43:03.9274630Z test operations::did_webvh::update::pre_rotation_e2e_tests::the_compiled_class_agrees_with_the_rotation_the_plan_reports ... ok
+2026-08-01T02:43:04.2368128Z test operations::did_webvh::update::pre_rotation_e2e_tests::update_refreshes_resolver_with_latest_document ... ok
+2026-08-01T02:43:05.0477585Z test operations::did_webvh::update::pre_rotation_e2e_tests::update_with_current_expected_version_id_succeeds ... ok
+2026-08-01T02:43:05.1519528Z test operations::did_webvh::update::pre_rotation_e2e_tests::two_consecutive_updates_with_pre_rotation_succeed ... ok
+2026-08-01T02:43:05.2692455Z test operations::did_webvh::update::pre_rotation_e2e_tests::update_with_legacy_only_pre_rotation_genesis_succeeds ... ok
+2026-08-01T02:43:05.5579813Z test operations::did_webvh::update::pre_rotation_e2e_tests::update_with_pre_rotation_count_one_succeeds ... ok
+2026-08-01T02:43:05.5669873Z test operations::did_webvh::update::state::tests::both_identifier_forms_resolve_to_the_same_canonical_scid ... ok
+2026-08-01T02:43:05.5670877Z test operations::did_webvh::update::tests::conflict_maps_to_409 ... ok
+2026-08-01T02:43:05.5796828Z test operations::did_webvh::update::tests::derive_then_install_round_trips_with_real_version_id ... ok
+2026-08-01T02:43:05.5866776Z test operations::did_webvh::update::tests::derive_webvh_keys_returns_empty_for_zero_count ... ok
+2026-08-01T02:43:05.5868381Z test operations::did_webvh::update::tests::forbidden_also_maps_to_404_to_avoid_cross_context_leak ... ok
+2026-08-01T02:43:05.5869586Z test operations::did_webvh::update::tests::invalid_document_maps_to_400 ... ok
+2026-08-01T02:43:05.5870764Z test operations::did_webvh::update::tests::invalid_watcher_maps_to_400 ... ok
+2026-08-01T02:43:05.5871797Z test operations::did_webvh::update::tests::invalid_witness_maps_to_400 ... ok
+2026-08-01T02:43:05.5872961Z test operations::did_webvh::update::tests::library_maps_to_500 ... ok
+2026-08-01T02:43:05.5941179Z test operations::did_webvh::update::tests::load_active_update_key_errors_on_empty_update_keys_list ... ok
+2026-08-01T02:43:05.6041352Z test operations::did_webvh::update::tests::load_active_update_key_errors_when_no_match ... ok
+2026-08-01T02:43:05.6126426Z test operations::did_webvh::update::tests::load_active_update_key_falls_back_to_legacy_keyspace ... ok
+2026-08-01T02:43:05.6213409Z test operations::did_webvh::update::tests::load_active_update_key_finds_via_webvh_keys_fast_path ... ok
+2026-08-01T02:43:05.6214628Z test operations::did_webvh::update::tests::not_found_maps_to_404 ... ok
+2026-08-01T02:43:05.6215415Z test operations::did_webvh::update::tests::persistence_maps_to_500 ... ok
+2026-08-01T02:43:05.6216296Z test operations::did_webvh::update::tests::publish_maps_to_500 ... ok
+2026-08-01T02:43:05.6217440Z test operations::did_webvh::update::tests::validate_document_accepts_well_formed ... ok
+2026-08-01T02:43:05.6218873Z test operations::did_webvh::update::tests::validate_document_allows_externally_minted_public_key ... ok
+2026-08-01T02:43:05.6220062Z test operations::did_webvh::update::tests::validate_document_rejects_id_mismatch ... ok
+2026-08-01T02:43:05.6220928Z test operations::did_webvh::update::tests::validate_document_rejects_missing_context ... ok
+2026-08-01T02:43:05.6222020Z test operations::did_webvh::update::tests::validate_document_rejects_missing_vm_field ... ok
+2026-08-01T02:43:05.6223212Z test operations::did_webvh::update::tests::validate_document_rejects_non_object ... ok
+2026-08-01T02:43:05.6224087Z test operations::did_webvh::update::tests::validate_watchers_accepts_empty ... ok
+2026-08-01T02:43:05.6225237Z test operations::did_webvh::update::tests::validate_watchers_accepts_https ... ok
+2026-08-01T02:43:05.6226502Z test operations::did_webvh::update::tests::validate_watchers_rejects_fragment ... ok
+2026-08-01T02:43:05.6227378Z test operations::did_webvh::update::tests::validate_watchers_rejects_ftp ... ok
+2026-08-01T02:43:05.6228630Z test operations::did_webvh::update::tests::validate_watchers_rejects_malformed ... ok
+2026-08-01T02:43:05.6229584Z test operations::did_webvh::update::tests::validate_watchers_rejects_query ... ok
+2026-08-01T02:43:05.7138008Z test operations::did_webvh::update::tests::validate_witnesses_accepts_empty_disable_instruction ... ok
+2026-08-01T02:43:05.8047685Z test operations::did_webvh::update::tests::validate_witnesses_accepts_resolvable_did_key ... ok
+2026-08-01T02:43:05.8893854Z test operations::did_webvh::update::tests::validate_witnesses_rejects_threshold_above_count ... ok
+2026-08-01T02:43:05.9748122Z test operations::did_webvh::update::tests::validate_witnesses_rejects_threshold_without_witnesses ... ok
+2026-08-01T02:43:05.9831452Z test operations::did_webvh::webvh_keys::tests::find_handle_by_hash_finds_across_roles_and_versions ... ok
+2026-08-01T02:43:05.9911083Z test operations::did_webvh::webvh_keys::tests::install_and_load_round_trip_for_each_role ... ok
+2026-08-01T02:43:05.9991407Z test operations::did_webvh::webvh_keys::tests::supersede_is_idempotent ... ok
+2026-08-01T02:43:06.0080820Z test operations::did_webvh::webvh_keys::tests::supersede_moves_all_roles_for_a_version ... ok
+2026-08-01T02:43:06.0361456Z test operations::export::tests::build_context_provision_requires_existing_context ... ok
+2026-08-01T02:43:06.0745142Z test operations::export::tests::build_did_secrets_excludes_non_vm_admin_did_key ... ok
+2026-08-01T02:43:06.1036962Z test operations::export::tests::build_did_secrets_rejects_context_without_did ... ok
+2026-08-01T02:43:06.1337622Z test operations::export::tests::build_did_secrets_rejects_missing_context ... ok
+2026-08-01T02:43:06.1444917Z test operations::holder_keys::tests::parent_admin_resolves_a_descendant_context_key ... ok
+2026-08-01T02:43:06.1540167Z test operations::holder_keys::tests::refuses_a_key_outside_the_callers_context ... ok
+2026-08-01T02:43:06.1655639Z test operations::holder_keys::tests::resolves_within_an_authorised_context ... ok
+2026-08-01T02:43:06.1747742Z test operations::holder_keys::tests::unknown_subject_is_not_found ... ok
+2026-08-01T02:43:06.2050089Z test operations::keys::tests::create_key_refuses_to_overwrite_existing_record ... ok
+2026-08-01T02:43:06.2323202Z test operations::keys::tests::create_key_rejects_separator_shaped_key_id ... ok
+2026-08-01T02:43:06.2653964Z test operations::keys::tests::derive_and_sign_document_grafts_di_proof_as_derived_key ... ok
+2026-08-01T02:43:06.3080611Z test operations::keys::tests::derive_and_sign_is_ephemeral_admin_only_and_verifies ... ok
+2026-08-01T02:43:06.3360197Z test operations::keys::tests::get_key_and_list_keys_reject_monitor_role ... ok
+2026-08-01T02:43:06.3642609Z test operations::keys::tests::import_key_refuses_duplicate_key_id ... ok
+2026-08-01T02:43:06.3913605Z test operations::keys::tests::import_key_rejects_separator_shaped_label_as_key_id ... ok
+2026-08-01T02:43:06.4218432Z test operations::keys::tests::rename_key_rejects_separator_shaped_new_key_id ... ok
+2026-08-01T02:43:06.4555190Z test operations::keys::tests::sign_payload_allowed_keys_only_narrows_never_widens ... ok
+2026-08-01T02:43:06.5003368Z test operations::keys::tests::sign_payload_honours_acl_allowed_keys ... ok
+2026-08-01T02:43:06.5390046Z test operations::keys::tests::sign_payload_honours_context_policy_signable_keys ... ok
+2026-08-01T02:43:06.5984784Z test operations::keys::tests::sign_payload_refuses_a_key_outside_the_callers_contexts ... ok
+2026-08-01T02:43:06.6177137Z test operations::did_webvh::update::pre_rotation_e2e_tests::update_without_pre_rotation_succeeds ... ok
+2026-08-01T02:43:06.6564346Z test operations::keys::tests::sign_payload_restricts_unscoped_keys_to_super_admin ... ok
+2026-08-01T02:43:06.6636576Z test operations::keys::tests::test_create_key_ed25519 ... ok
+2026-08-01T02:43:06.7089825Z test operations::keys::tests::test_create_key_p256 ... ok
+2026-08-01T02:43:06.7091108Z test operations::keys::tests::test_sign_and_verify_ed25519 ... ok
+2026-08-01T02:43:06.7222331Z test operations::memory::tests::delete_removes_and_unknown_is_not_found ... ok
+2026-08-01T02:43:06.7257561Z test operations::memory::tests::context_a_memory_is_not_returned_listing_context_b ... ok
+2026-08-01T02:43:06.7372999Z test operations::memory::tests::prefix_scan_is_context_exact ... ok
+2026-08-01T02:43:06.7376540Z test operations::memory::tests::put_same_key_twice_upserts ... ok
+2026-08-01T02:43:06.7472850Z test operations::memory::tests::put_then_list_returns_the_entry ... ok
+2026-08-01T02:43:06.8683780Z test operations::passkey_login::tests::implements_vti_webauthn_resolver_trait ... ok
+2026-08-01T02:43:06.8793459Z test operations::passkey_login::tests::rejects_did_key_without_a_passkey_vm ... ok
+2026-08-01T02:43:06.9654521Z test operations::passkey_login::tests::rejects_vm_url_without_fragment ... ok
+2026-08-01T02:43:06.9803793Z test operations::passkey_login::tests::resolves_did_key_default_vm ... ok
+2026-08-01T02:43:06.9813851Z test operations::passkey_vms::multikey::tests::ed25519_cose_to_multikey ... ok
+2026-08-01T02:43:06.9823239Z test operations::passkey_vms::multikey::tests::p256_cose_to_multikey_even_y ... ok
+2026-08-01T02:43:06.9824353Z test operations::passkey_vms::multikey::tests::p256_cose_to_multikey_odd_y ... ok
+2026-08-01T02:43:06.9825462Z test operations::passkey_vms::multikey::tests::parse_auth_data_round_trip ... ok
+2026-08-01T02:43:06.9827072Z test operations::passkey_vms::multikey::tests::rs256_rejected ... ok
+2026-08-01T02:43:06.9828119Z test operations::passkey_vms::tests::append_vm_creates_authentication_reference ... ok
+2026-08-01T02:43:06.9829275Z test operations::passkey_vms::tests::append_vm_refuses_duplicate_id ... ok
+2026-08-01T02:43:06.9830311Z test operations::passkey_vms::tests::fragment_is_credential_id_sha256 ... ok
+2026-08-01T02:43:06.9831494Z test operations::passkey_vms::tests::remove_vm_absent_fragment_is_fragment_not_found ... ok
+2026-08-01T02:43:06.9832933Z test operations::passkey_vms::tests::remove_vm_drops_from_all_purpose_arrays ... ok
+2026-08-01T02:43:06.9834008Z test operations::passkey_vms::tests::user_handle_is_deterministic_per_did ... ok
+2026-08-01T02:43:07.0986451Z test operations::passkey_login::tests::surfaces_unresolvable_did ... ok
+2026-08-01T02:43:07.1310522Z test operations::protocol::disable_didcomm::tests::allows_1h_drain_over_didcomm ... ok
+2026-08-01T02:43:07.3136502Z test operations::protocol::disable_didcomm::tests::allows_zero_drain_over_rest ... ok
+2026-08-01T02:43:07.3361903Z test operations::protocol::disable_didcomm::tests::refuses_drain_ttl_above_max ... ok
+2026-08-01T02:43:07.5045153Z test operations::protocol::disable_didcomm::tests::refuses_short_drain_over_didcomm ... ok
+2026-08-01T02:43:07.5079062Z test operations::protocol::disable_didcomm::tests::refuses_when_not_currently_enabled ... ok
+2026-08-01T02:43:07.5080698Z test operations::protocol::disable_rest::tests::brick_prevention_allows_disable_rest_when_didcomm_on ... ok
+2026-08-01T02:43:07.5082624Z test operations::protocol::disable_rest::tests::brick_prevention_allows_disable_rest_when_webauthn_on ... ok
+2026-08-01T02:43:07.5084175Z test operations::protocol::disable_rest::tests::brick_prevention_rejects_disable_rest_when_didcomm_off ... ok
+2026-08-01T02:43:07.5218291Z test operations::protocol::disable_rest::tests::preconditions_reject_when_rest_disabled ... ok
+2026-08-01T02:43:07.5368078Z test operations::protocol::disable_rest::tests::preconditions_reject_when_would_brick ... ok
+2026-08-01T02:43:07.5480373Z test operations::protocol::disable_rest::tests::preconditions_reject_without_vta_did ... ok
+2026-08-01T02:43:07.5495017Z test operations::protocol::disable_rest::tests::vta_error_to_disable_rest_error_mapping_is_typed ... ok
+2026-08-01T02:43:07.5501930Z test operations::protocol::disable_tsp::tests::brick_prevention_allows_disable_tsp_when_didcomm_on ... ok
+2026-08-01T02:43:07.5504900Z test operations::protocol::disable_tsp::tests::brick_prevention_rejects_disable_tsp_when_others_off ... ok
+2026-08-01T02:43:07.5646263Z test operations::protocol::disable_tsp::tests::preconditions_reject_when_tsp_disabled ... ok
+2026-08-01T02:43:07.5763986Z test operations::protocol::disable_tsp::tests::preconditions_reject_when_would_brick ... ok
+2026-08-01T02:43:07.5905124Z test operations::did_webvh::update::pre_rotation_e2e_tests::update_with_pre_rotation_count_two_succeeds ... ok
+2026-08-01T02:43:07.5906973Z test operations::protocol::disable_tsp::tests::vta_error_to_disable_tsp_error_mapping_is_typed ... ok
+2026-08-01T02:43:07.5933564Z test operations::protocol::document::tests::current_finds_didcomm_service ... ok
+2026-08-01T02:43:07.5964351Z test operations::protocol::document::tests::current_finds_rest_service ... ok
+2026-08-01T02:43:07.6003109Z test operations::protocol::document::tests::current_rest_returns_none_when_absent ... ok
+2026-08-01T02:43:07.6023366Z test operations::protocol::document::tests::current_rest_tolerates_object_and_array_endpoints ... ok
+2026-08-01T02:43:07.6050723Z test operations::protocol::document::tests::current_returns_none_when_absent ... ok
+2026-08-01T02:43:07.6072922Z test operations::protocol::document::tests::current_tolerates_string_endpoint ... ok
+2026-08-01T02:43:07.6084060Z test operations::protocol::document::tests::current_tsp_tolerates_object_and_array_endpoints ... ok
+2026-08-01T02:43:07.6092381Z test operations::protocol::document::tests::fragment_match_is_strict_not_suffix ... ok
+2026-08-01T02:43:07.6099677Z test operations::protocol::document::tests::id_matches_tsp_is_strict ... ok
+2026-08-01T02:43:07.6109684Z test operations::protocol::document::tests::ordering_didcomm_first_when_rest_was_first ... ok
+2026-08-01T02:43:07.6115981Z test operations::protocol::document::tests::ordering_didcomm_rest_then_tee ... ok
+2026-08-01T02:43:07.6117250Z test operations::protocol::document::tests::ordering_didcomm_then_rest_when_didcomm_was_first ... ok
+2026-08-01T02:43:07.6118500Z test operations::protocol::document::tests::rest_and_didcomm_patchers_compose ... ok
+2026-08-01T02:43:07.6119668Z test operations::protocol::document::tests::round_trip_with_then_without_returns_original ... ok
+2026-08-01T02:43:07.6120813Z test operations::protocol::document::tests::sort_canonical_places_tsp_first ... ok
+2026-08-01T02:43:07.6122011Z test operations::protocol::document::tests::sort_canonical_places_webauthn_after_rest_before_other ... ok
+2026-08-01T02:43:07.6124266Z test operations::protocol::document::tests::sort_services_canonical_handles_missing_service_field ... ok
+2026-08-01T02:43:07.6129506Z test operations::protocol::document::tests::sort_services_canonical_is_idempotent ... ok
+2026-08-01T02:43:07.6137633Z test operations::protocol::document::tests::verification_method_byte_identical_after_remove ... ok
+2026-08-01T02:43:07.6140699Z test operations::protocol::document::tests::verification_method_byte_identical_after_replace ... ok
+2026-08-01T02:43:07.6143839Z test operations::protocol::disable_tsp::tests::preconditions_reject_without_vta_did ... ok
+2026-08-01T02:43:07.6146430Z test operations::protocol::document::tests::verification_method_byte_identical_after_rest_patches ... ok
+2026-08-01T02:43:07.6150482Z test operations::protocol::document::tests::with_didcomm_inserts_when_missing ... ok
+2026-08-01T02:43:07.6151622Z test operations::protocol::document::tests::with_didcomm_rejects_doc_without_id ... ok
+2026-08-01T02:43:07.6152841Z test operations::protocol::document::tests::with_didcomm_rejects_empty_mediator ... ok
+2026-08-01T02:43:07.6154214Z test operations::protocol::document::tests::with_didcomm_replaces_existing_entry ... ok
+2026-08-01T02:43:07.6155321Z test operations::protocol::document::tests::with_rest_emits_canonical_wire_shape ... ok
+2026-08-01T02:43:07.6156374Z test operations::protocol::document::tests::with_rest_inserts_when_missing ... ok
+2026-08-01T02:43:07.6157537Z test operations::protocol::document::tests::with_rest_preserves_didcomm_and_tee_entries ... ok
+2026-08-01T02:43:07.6158882Z test operations::protocol::document::tests::with_rest_rejects_doc_without_id ... ok
+2026-08-01T02:43:07.6159938Z test operations::protocol::document::tests::with_rest_rejects_empty_url ... ok
+2026-08-01T02:43:07.6160940Z test operations::protocol::document::tests::with_rest_replaces_existing_entry ... ok
+2026-08-01T02:43:07.6162013Z test operations::protocol::document::tests::with_tsp_service_inserts_then_replaces ... ok
+2026-08-01T02:43:07.6163295Z test operations::protocol::document::tests::with_tsp_service_rejects_empty_mediator ... ok
+2026-08-01T02:43:07.6164454Z test operations::protocol::document::tests::with_webauthn_service_inserts_then_replaces ... ok
+2026-08-01T02:43:07.6165625Z test operations::protocol::document::tests::with_webauthn_service_rejects_empty_url ... ok
+2026-08-01T02:43:07.6166722Z test operations::protocol::document::tests::with_didcomm_preserves_other_services ... ok
+2026-08-01T02:43:07.6167855Z test operations::protocol::document::tests::without_didcomm_drops_empty_service_array ... ok
+2026-08-01T02:43:07.6169010Z test operations::protocol::document::tests::without_didcomm_handles_no_service_field ... ok
+2026-08-01T02:43:07.6170130Z test operations::protocol::document::tests::without_didcomm_is_noop_when_absent ... ok
+2026-08-01T02:43:07.6171259Z test operations::protocol::document::tests::without_didcomm_removes_only_didcomm_entry ... ok
+2026-08-01T02:43:07.6172582Z test operations::protocol::document::tests::without_rest_drops_empty_service_array ... ok
+2026-08-01T02:43:07.6174951Z test operations::protocol::document::tests::without_rest_is_noop_when_absent ... ok
+2026-08-01T02:43:07.6176784Z test operations::protocol::document::tests::without_tsp_service_removes_entry ... ok
+2026-08-01T02:43:07.6177914Z test operations::protocol::document::tests::without_webauthn_service_removes_entry ... ok
+2026-08-01T02:43:07.6178992Z test operations::protocol::document::tests::without_rest_removes_only_rest_entry ... ok
+2026-08-01T02:43:07.6201515Z test operations::protocol::drain_cancel::tests::cancels_existing_drain ... ok
+2026-08-01T02:43:07.6212848Z test operations::protocol::drain_cancel::tests::refuses_active_mediator ... ok
+2026-08-01T02:43:07.6252335Z test operations::did_webvh::update::pre_rotation_e2e_tests::update_with_stale_expected_version_id_conflicts ... ok
+2026-08-01T02:43:07.6368027Z test operations::protocol::drain_cancel::tests::refuses_unknown_mediator ... ok
+2026-08-01T02:43:07.7534626Z test operations::protocol::disable_didcomm::tests::refuses_when_rest_also_disabled ... ok
+2026-08-01T02:43:07.8557731Z test operations::protocol::enable_didcomm::tests::no_partial_state_on_handshake_failure ... ok
+2026-08-01T02:43:07.8741668Z test operations::protocol::enable_rest::tests::enable_rest_url_validation_runs_before_persist ... ok
+2026-08-01T02:43:07.8991077Z test operations::protocol::enable_rest::tests::preconditions_reject_when_already_enabled ... ok
+2026-08-01T02:43:07.9056300Z test operations::protocol::enable_didcomm::tests::refuses_when_didcomm_already_enabled ... ok
+2026-08-01T02:43:07.9127689Z test operations::protocol::enable_didcomm::tests::refuses_when_vta_did_not_configured ... ok
+2026-08-01T02:43:07.9184094Z test operations::protocol::enable_rest::tests::preconditions_reject_without_vta_did ... ok
+2026-08-01T02:43:07.9258534Z test operations::protocol::enable_tsp::tests::enable_tsp_did_validation_runs_before_persist ... ok
+2026-08-01T02:43:07.9264696Z test operations::protocol::enable_tsp::tests::preconditions_reject_when_already_enabled ... ok
+2026-08-01T02:43:07.9266553Z test operations::protocol::invariant::tests::all_three_on_any_single_disable_is_ok ... ok
+2026-08-01T02:43:07.9268236Z test operations::protocol::invariant::tests::enable_never_violates ... ok
+2026-08-01T02:43:07.9269913Z test operations::protocol::invariant::tests::s0_disable_is_rejected ... ok
+2026-08-01T02:43:07.9271589Z test operations::protocol::invariant::tests::s0_enable_either_kind_is_accepted ... ok
+2026-08-01T02:43:07.9273663Z test operations::protocol::invariant::tests::s1_disable_didcomm_is_accepted_by_invariant ... ok
+2026-08-01T02:43:07.9275368Z test operations::protocol::invariant::tests::s1_disable_rest_is_rejected ... ok
+2026-08-01T02:43:07.9276975Z test operations::protocol::invariant::tests::s2_disable_didcomm_is_rejected ... ok
+2026-08-01T02:43:07.9278682Z test operations::protocol::invariant::tests::s2_disable_rest_is_accepted_by_invariant ... ok
+2026-08-01T02:43:07.9280394Z test operations::protocol::invariant::tests::s3_can_disable_either_kind ... ok
+2026-08-01T02:43:07.9283838Z test operations::protocol::invariant::tests::tsp_keeps_invariant_when_other_two_disabled ... ok
+2026-08-01T02:43:07.9285620Z test operations::protocol::invariant::tests::tsp_only_state_cannot_disable_tsp ... ok
+2026-08-01T02:43:07.9286788Z test operations::protocol::invariant::tests::webauthn_keeps_invariant_when_other_two_disabled ... ok
+2026-08-01T02:43:07.9291665Z test operations::protocol::invariant::tests::full_truth_table ... ok
+2026-08-01T02:43:07.9293478Z test operations::protocol::invariant::tests::webauthn_only_state_cannot_disable_webauthn ... ok
+2026-08-01T02:43:07.9305993Z test operations::protocol::enable_tsp::tests::preconditions_reject_without_vta_did ... ok
+2026-08-01T02:43:07.9428081Z test operations::protocol::list::tests::rejects_non_super_admin ... ok
+2026-08-01T02:43:07.9443854Z test operations::protocol::list::tests::rejects_when_vta_did_not_configured ... ok
+2026-08-01T02:43:07.9480920Z test operations::protocol::list::tests::list_services_returns_didcomm_first_rest_second ... ok
+2026-08-01T02:43:07.9597691Z test operations::protocol::list_drain::tests::empty_drain_set_returns_empty_list ... ok
+2026-08-01T02:43:07.9608607Z test operations::protocol::passkey_vm_cleanup::tests::strip_handles_doc_with_no_verification_method ... ok
+2026-08-01T02:43:07.9615287Z test operations::protocol::passkey_vm_cleanup::tests::strip_handles_object_form_in_relation_arrays ... ok
+2026-08-01T02:43:07.9616439Z test operations::protocol::list::tests::returns_config_state_for_did_key_vta ... ok
+2026-08-01T02:43:07.9617583Z test operations::protocol::passkey_vm_cleanup::tests::strip_removes_passkey_vms_and_scrubs_relations ... ok
+2026-08-01T02:43:07.9623442Z test operations::protocol::report::tests::aggregate_counts_per_mediator ... ok
+2026-08-01T02:43:07.9625997Z test operations::protocol::report::tests::aggregate_empty_input ... ok
+2026-08-01T02:43:07.9632752Z test operations::protocol::report::tests::aggregate_first_and_last_seen ... ok
+2026-08-01T02:43:07.9633710Z test operations::protocol::passkey_vm_cleanup::tests::strip_is_no_op_when_no_passkey_vms ... ok
+2026-08-01T02:43:07.9634691Z test operations::protocol::report::tests::aggregate_sender_last_seen_mediator_tracks_latest ... ok
+2026-08-01T02:43:07.9635542Z test operations::protocol::report::tests::aggregate_skips_events_without_mediator ... ok
+2026-08-01T02:43:07.9636314Z test operations::protocol::report::tests::mediator_report_round_trip ... ok
+2026-08-01T02:43:07.9636959Z test operations::protocol::report::tests::report_filters_by_since ... ok
+2026-08-01T02:43:07.9644931Z test operations::protocol::rollback_didcomm::tests::params_carry_transport_and_ttl ... ok
+2026-08-01T02:43:07.9646157Z test operations::protocol::rollback_didcomm::tests::rollback_kind_variants_are_distinct ... ok
+2026-08-01T02:43:07.9677944Z test operations::protocol::list_drain::tests::populated_drain_set_round_trips ... ok
+2026-08-01T02:43:07.9778539Z test operations::protocol::rollback_didcomm::tests::no_prior_mutation_error_message_is_actionable ... ok
+2026-08-01T02:43:07.9811066Z test operations::protocol::rollback_didcomm::tests::snapshot_disabled_round_trips ... ok
+2026-08-01T02:43:07.9819957Z test operations::protocol::rollback_didcomm::tests::snapshot_enabled_with_mediator_round_trips ... ok
+2026-08-01T02:43:07.9829575Z test operations::protocol::rollback_rest::tests::rollback_kind_variants_are_distinct ... ok
+2026-08-01T02:43:07.9967266Z test operations::protocol::enable_didcomm::tests::refuses_when_vta_did_record_missing ... ok
+2026-08-01T02:43:07.9971561Z test operations::protocol::rollback_rest::tests::no_prior_mutation_when_snapshot_empty ... ok
+2026-08-01T02:43:07.9972799Z test operations::protocol::rollback_tsp::tests::rollback_kind_variants_are_distinct ... ok
+2026-08-01T02:43:08.0012537Z test operations::protocol::rollback_rest::tests::snapshot_enabled_with_url_round_trips ... ok
+2026-08-01T02:43:08.0017490Z test operations::protocol::rollback_rest::tests::snapshot_disabled_round_trips ... ok
+2026-08-01T02:43:08.0130288Z test operations::protocol::rollback_tsp::tests::no_prior_mutation_when_snapshot_empty ... ok
+2026-08-01T02:43:08.0135703Z test operations::protocol::rollback_tsp::tests::snapshot_disabled_round_trips ... ok
+2026-08-01T02:43:08.0148401Z test operations::protocol::snapshot::tests::clear_is_a_noop_when_nothing_is_present ... ok
+2026-08-01T02:43:08.0158122Z test operations::protocol::rollback_tsp::tests::snapshot_enabled_with_mediator_round_trips ... ok
+2026-08-01T02:43:08.0290836Z test operations::protocol::snapshot::tests::read_rejects_kind_mismatch ... ok
+2026-08-01T02:43:08.0293989Z test operations::protocol::snapshot::tests::read_returns_none_when_no_snapshot_present ... ok
+2026-08-01T02:43:08.0299404Z test operations::protocol::snapshot::tests::snapshot_wire_form_is_stable ... ok
+2026-08-01T02:43:08.0306552Z test operations::protocol::snapshot::tests::rest_and_didcomm_snapshots_are_independent ... ok
+2026-08-01T02:43:08.0324684Z test operations::protocol::snapshot::tests::clear_removes_snapshot ... ok
+2026-08-01T02:43:08.0448455Z test operations::protocol::snapshot::tests::second_write_overwrites_first_for_same_kind ... ok
+2026-08-01T02:43:08.0474348Z test operations::protocol::snapshot::tests::write_then_read_round_trips_didcomm_enabled_no_routing_keys ... ok
+2026-08-01T02:43:08.0480666Z test operations::protocol::snapshot::tests::write_then_read_round_trips_didcomm_enabled_with_routing_keys ... ok
+2026-08-01T02:43:08.0482330Z test operations::protocol::snapshot::tests::write_then_read_round_trips_didcomm_disabled ... ok
+2026-08-01T02:43:08.0614564Z test operations::protocol::snapshot::tests::write_then_read_round_trips_rest_disabled ... ok
+2026-08-01T02:43:08.0616069Z test operations::protocol::snapshot::tests::write_then_read_round_trips_rest_enabled ... ok
+2026-08-01T02:43:08.0638808Z test operations::protocol::snapshot::tests::write_then_read_round_trips_tsp_disabled ... ok
+2026-08-01T02:43:08.0642358Z test operations::protocol::snapshot::tests::write_then_read_round_trips_tsp_enabled ... ok
+2026-08-01T02:43:08.1055429Z test operations::protocol::tests::protocol_lock_serializes_concurrent_mutations ... ok
+2026-08-01T02:43:08.1229699Z test operations::protocol::update_rest::tests::invalid_url_aborts_before_snapshot_write ... ok
+2026-08-01T02:43:08.1406960Z test operations::protocol::update_rest::tests::preconditions_reject_when_rest_disabled ... ok
+2026-08-01T02:43:08.1603162Z test operations::protocol::update_rest::tests::preconditions_reject_without_vta_did ... ok
+2026-08-01T02:43:08.1767329Z test operations::protocol::update_rest::tests::snapshot_records_prior_url_for_rollback ... ok
+2026-08-01T02:43:08.1945956Z test operations::protocol::update_tsp::tests::invalid_mediator_did_aborts_before_snapshot_write ... ok
+2026-08-01T02:43:08.2104660Z test operations::protocol::update_tsp::tests::preconditions_reject_when_tsp_disabled ... ok
+2026-08-01T02:43:08.2253887Z test operations::protocol::update_tsp::tests::preconditions_reject_without_vta_did ... ok
+2026-08-01T02:43:08.2403424Z test operations::protocol::update_tsp::tests::snapshot_records_prior_mediator_for_rollback ... ok
+2026-08-01T02:43:08.2633940Z test operations::provision_integration::preconditions::tests::infer_multi_context_grant_is_ambiguous ... ok
+2026-08-01T02:43:08.2793488Z test operations::provision_integration::preconditions::tests::infer_returns_single_allowed_context ... ok
+2026-08-01T02:43:08.3024312Z test operations::provision_integration::preconditions::tests::infer_super_admin_with_multiple_contexts_is_ambiguous ... ok
+2026-08-01T02:43:08.3063741Z test operations::protocol::update_didcomm::tests::refuses_when_didcomm_not_enabled ... ok
+2026-08-01T02:43:08.3180268Z test operations::protocol::update_didcomm::tests::refuses_migrate_to_draining_mediator ... ok
+2026-08-01T02:43:08.3189361Z test operations::protocol::update_didcomm::tests::refuses_when_no_vta_did ... ok
+2026-08-01T02:43:08.3214958Z test operations::provision_integration::preconditions::tests::infer_super_admin_with_no_contexts_returns_not_found ... ok
+2026-08-01T02:43:08.3249289Z test operations::provision_integration::preconditions::tests::infer_super_admin_with_single_context ... ok
+2026-08-01T02:43:08.3364878Z test operations::provision_integration::preconditions::tests::resolve_creates_requested_context_inline ... ok
+2026-08-01T02:43:08.3376001Z test operations::provision_integration::tests::assertion_mode_default_is_did_signed ... ok
+2026-08-01T02:43:08.3377351Z test operations::provision_integration::preconditions::tests::resolve_missing_context_without_create_is_op_not_found ... ok
+2026-08-01T02:43:08.3378863Z test operations::provision_integration::preconditions::tests::resolve_propagates_ambiguous_inference ... ok
+2026-08-01T02:43:08.3380202Z test operations::provision_integration::tests::extract_admin_template_returns_none_when_absent ... ok
+2026-08-01T02:43:08.3381631Z test operations::provision_integration::tests::extract_template_pulls_name_and_vars ... ok
+2026-08-01T02:43:08.3383057Z test operations::provision_integration::tests::extract_admin_template_returns_some_when_present ... ok
+2026-08-01T02:43:08.3447369Z test operations::provision_integration::preconditions::tests::resolve_uses_requested_existing_context ... ok
+2026-08-01T02:43:08.4608369Z test operations::provision_integration::tests::preconditions_accepts_builtin_integration_template ... ok
+2026-08-01T02:43:08.4610127Z test operations::provision_integration::tests::preconditions_rejects_unknown_template ... ok
+2026-08-01T02:43:08.6251199Z test operations::provision_integration::tests::provision_integration_admin_rotation_mints_fresh_admin_no_integration ... ok
+2026-08-01T02:43:08.6338972Z test operations::provision_integration::tests::provision_integration_admin_rotation_rejects_wrong_kind_template ... ok
+2026-08-01T02:43:08.7399857Z test operations::provision_integration::tests::provision_integration_admin_rotation_retires_ephemeral_acl_and_emits_swap_audit ... ok
+2026-08-01T02:43:08.7418056Z test operations::provision_integration::tests::provision_integration_admin_rotation_swap_audit_skipped_when_no_ephemeral_row ... ok
+2026-08-01T02:43:08.9664803Z test operations::provision_integration::tests::provision_integration_binds_minted_did_when_context_has_none ... ok
+2026-08-01T02:43:08.9865483Z test operations::provision_integration::tests::provision_integration_bundle_kids_match_published_did_document ... ok
+2026-08-01T02:43:09.0081694Z test operations::provision_integration::tests::provision_integration_did_peer_rejects_webvh_vars ... ok
+2026-08-01T02:43:09.0776502Z test operations::provision_integration::tests::provision_integration_mints_did_key_when_template_methods_is_key ... ok
+2026-08-01T02:43:09.2173821Z test operations::provision_integration::tests::resolve_template_kind_prefers_stored_record_over_builtin ... ok
+2026-08-01T02:43:09.2834684Z test operations::provision_integration::tests::provision_integration_mints_did_peer_when_template_methods_is_peer ... ok
+2026-08-01T02:43:09.2960469Z test operations::provision_integration::tests::resolve_webvh_server_absent_returns_none ... ok
+2026-08-01T02:43:09.3137888Z test operations::provision_integration::tests::resolve_template_kind_resolves_builtin_when_no_stored_record ... ok
+2026-08-01T02:43:09.3156862Z test operations::provision_integration::tests::resolve_webvh_server_empty_string_returns_none ... ok
+2026-08-01T02:43:09.3297538Z test operations::provision_integration::tests::resolve_webvh_server_null_returns_none ... ok
+2026-08-01T02:43:09.3316614Z test operations::provision_integration::tests::resolve_webvh_server_registered_id_returns_some ... ok
+2026-08-01T02:43:09.3343491Z test operations::provision_integration::tests::provision_integration_summary_counts_match_payload ... ok
+2026-08-01T02:43:09.3350408Z test operations::provision_integration::tests::provision_integration_preserves_existing_context_did ... ok
+2026-08-01T02:43:09.3351713Z test operations::provision_integration::tests::take_webvh_path_absent_returns_none ... ok
+2026-08-01T02:43:09.3354359Z test operations::provision_integration::tests::take_webvh_path_empty_string_is_validation_error ... ok
+2026-08-01T02:43:09.3355675Z test operations::provision_integration::tests::take_webvh_path_non_string_is_validation_error ... ok
+2026-08-01T02:43:09.3356806Z test operations::provision_integration::tests::take_webvh_path_null_returns_none_and_removes_key ... ok
+2026-08-01T02:43:09.3357907Z test operations::provision_integration::tests::take_webvh_path_string_returns_some_and_removes_key ... ok
+2026-08-01T02:43:09.3359142Z test operations::provision_integration::tests::take_webvh_path_trims_whitespace ... ok
+2026-08-01T02:43:09.3360428Z test operations::provision_integration::tests::take_webvh_path_whitespace_only_is_validation_error ... ok
+2026-08-01T02:43:09.3361801Z test operations::provision_integration::webvh::tests::reject_root::auto_assign_on_shared_server_is_allowed ... ok
+2026-08-01T02:43:09.3363406Z test operations::provision_integration::webvh::tests::reject_root::explicit_path_on_shared_server_is_allowed ... ok
+2026-08-01T02:43:09.3364799Z test operations::provision_integration::webvh::tests::reject_root::root_in_serverless_mode_is_allowed ... ok
+2026-08-01T02:43:09.3366140Z test operations::provision_integration::webvh::tests::reject_root::root_on_shared_server_is_rejected ... ok
+2026-08-01T02:43:09.3367257Z test operations::provision_integration::webvh::tests::take_webvh_domain_absent_is_none ... ok
+2026-08-01T02:43:09.3368085Z test operations::provision_integration::webvh::tests::take_webvh_domain_empty_string_errors ... ok
+2026-08-01T02:43:09.3368877Z test operations::provision_integration::webvh::tests::take_webvh_domain_non_string_errors ... ok
+2026-08-01T02:43:09.3369643Z test operations::provision_integration::webvh::tests::take_webvh_domain_null_is_none ... ok
+2026-08-01T02:43:09.3370396Z test operations::provision_integration::webvh::tests::take_webvh_domain_removes_from_map ... ok
+2026-08-01T02:43:09.3371203Z test operations::provision_integration::webvh::tests::take_webvh_domain_trims_and_returns ... ok
+2026-08-01T02:43:09.3470551Z test operations::provision_integration::tests::resolve_webvh_server_unknown_id_is_not_found ... ok
+2026-08-01T02:43:09.3517185Z test operations::provision_integration::tests::resolve_webvh_server_wrong_type_is_validation_error ... ok
+2026-08-01T02:43:09.3536034Z test operations::provision_integration::tests::resolve_webvh_server_trims_whitespace ... ok
+2026-08-01T02:43:09.3701516Z test operations::step_up::tests::resolve_step_up_gates_configured_vault_op_only ... ok
+2026-08-01T02:43:09.3792398Z test operations::seeds::tests::concurrent_rotations_produce_distinct_generations ... ok
+2026-08-01T02:43:09.3827713Z test operations::seeds::tests::rotate_seed_refused_on_non_durable_store_and_leaves_state_intact ... ok
+2026-08-01T02:43:09.3835961Z test operations::step_up_approval::tests::policy_approves_by_default ... ok
+2026-08-01T02:43:09.3863496Z test operations::step_up_policy::tests::canonicalize_dedupes_last_wins_preserving_order ... ok
+2026-08-01T02:43:09.3893042Z test operations::step_up_policy::tests::op_class_recognition ... ok
+2026-08-01T02:43:09.3923075Z test operations::vault::password_post::tests::build_request_body_errors_when_totp_field_set_but_no_code ... ok
+2026-08-01T02:43:09.3926008Z test operations::vault::password_post::tests::build_request_body_form_urlencoded_with_extras ... ok
+2026-08-01T02:43:09.3953177Z test operations::vault::password_post::tests::build_request_body_json_default_fields ... ok
+2026-08-01T02:43:09.3965564Z test operations::vault::password_post::tests::build_request_body_omits_username_when_none ... ok
+2026-08-01T02:43:09.3966877Z test operations::vault::password_post::tests::cookie_domain_matches_canonical_cases ... ok
+2026-08-01T02:43:09.3968518Z test operations::step_up::tests::resolve_step_up_swap_key_honours_floor_and_carveout ... ok
+2026-08-01T02:43:09.3969737Z test operations::step_up_approval::tests::approval_token_matches_contract_and_verifies ... ok
+2026-08-01T02:43:09.4009361Z test operations::seeds::tests::test_rotate_seed ... ok
+2026-08-01T02:43:09.4578375Z test operations::vault::password_post::tests::http::cookie_with_unrelated_domain_is_discarded ... ok
+2026-08-01T02:43:09.4594065Z test operations::vault::password_post::tests::http::custom_success_status_treats_302_as_success ... ok
+2026-08-01T02:43:09.4793759Z test operations::vault::password_post::tests::http::form_urlencoded_body_shape ... ok
+2026-08-01T02:43:09.4803295Z test operations::vault::password_post::tests::parse_set_cookie_full ... ok
+2026-08-01T02:43:09.4804355Z test operations::vault::password_post::tests::parse_set_cookie_minimal ... ok
+2026-08-01T02:43:09.4805481Z test operations::vault::password_post::tests::parse_set_cookie_rejects_empty_name ... ok
+2026-08-01T02:43:09.4807686Z test operations::vault::password_post::tests::validate_login_url_accepts_http_to_loopback ... ok
+2026-08-01T02:43:09.4808712Z test operations::vault::password_post::tests::validate_login_url_accepts_https ... ok
+2026-08-01T02:43:09.4817552Z test operations::vault::password_post::tests::validate_login_url_rejects_http_to_non_loopback ... ok
+2026-08-01T02:43:09.4818897Z test operations::vault::password_post::tests::validate_login_url_rejects_unsupported_scheme ... ok
+2026-08-01T02:43:09.4820116Z test operations::vault::proxy_login::tests::explicit_app_target_rejects_for_siop ... ok
+2026-08-01T02:43:09.4821477Z test operations::vault::proxy_login::tests::explicit_did_target_uses_did_as_audience_with_entry_origin_as_bind ... ok
+2026-08-01T02:43:09.4822971Z test operations::vault::proxy_login::tests::explicit_web_origin_target_audience_equals_bind ... ok
+2026-08-01T02:43:09.4824186Z test operations::vault::proxy_login::tests::no_audience_when_entry_has_only_app_targets ... ok
+2026-08-01T02:43:09.4825478Z test operations::vault::proxy_login::tests::no_explicit_target_falls_back_to_first_web_origin_when_no_did ... ok
+2026-08-01T02:43:09.4826771Z test operations::vault::proxy_login::tests::no_explicit_target_prefers_first_did_on_entry ... ok
+2026-08-01T02:43:09.4827924Z test operations::vault::proxy_login::tests::session_blob_without_hint_is_unaffected ... ok
+2026-08-01T02:43:09.4829070Z test operations::vault::proxy_login::tests::v0_1_session_blob_keeps_kebab_refresh_hint ... ok
+2026-08-01T02:43:09.4830260Z test operations::vault::proxy_login::tests::v0_2_session_blob_camelizes_refresh_hint ... ok
+2026-08-01T02:43:09.4831380Z test operations::vault::release::tests::v0_1_release_keeps_kebab_kind_and_format ... ok
+2026-08-01T02:43:09.4832678Z test operations::vault::release::tests::v0_2_release_camelizes_kind_and_login_config_format ... ok
+2026-08-01T02:43:09.4833818Z test operations::vault::release::tests::v0_2_release_camelizes_multiword_kind ... ok
+2026-08-01T02:43:09.4993823Z test operations::vault::tests::siop_id_token_different_signing_key_fails_verification ... ok
+2026-08-01T02:43:09.5023017Z test operations::vault::tests::siop_id_token_embeds_caller_nonce_verbatim ... ok
+2026-08-01T02:43:09.5052976Z test operations::vault::tests::siop_id_token_generates_uuid_nonce_when_none_supplied ... ok
+2026-08-01T02:43:09.5173169Z test operations::vault::tests::siop_id_token_round_trip_verifies_against_signing_key ... ok
+2026-08-01T02:43:09.5193489Z test routes::auth_portal::tests::html_escape_handles_common_xss_chars ... ok
+2026-08-01T02:43:09.5214285Z test routes::auth_portal::tests::portal_html_contains_expected_anchors ... ok
+2026-08-01T02:43:09.5222637Z test operations::vault::password_post::tests::http::http_4xx_maps_to_credential_rejected ... ok
+2026-08-01T02:43:09.5315859Z test operations::vault::password_post::tests::http::success_2xx_captures_cookies_and_fills_host_only_domain ... ok
+2026-08-01T02:43:09.5511182Z test operations::vault::password_post::tests::http::http_5xx_maps_to_target_unreachable ... ok
+2026-08-01T02:43:09.9067337Z test routes::backup_blob::tests::get_blob_400_for_malformed_uuid ... ok
+2026-08-01T02:43:09.9196590Z test routes::backup_blob::tests::get_blob_404_for_unknown_id ... ok
+2026-08-01T02:43:09.9715490Z test routes::backup_blob::tests::get_blob_is_one_shot ... ok
+2026-08-01T02:43:09.9918258Z test routes::backup_blob::tests::get_blob_rejects_import_bundle_as_not_found ... ok
+2026-08-01T02:43:10.3265015Z test routes::backup_blob::tests::get_blob_rejects_missing_token ... ok
+2026-08-01T02:43:10.3523845Z test routes::backup_blob::tests::get_blob_rejects_wrong_token ... ok
+2026-08-01T02:43:10.3919306Z test routes::backup_blob::tests::get_blob_returns_bytes_for_valid_token ... ok
+2026-08-01T02:43:10.4140373Z test routes::backup_blob::tests::post_blob_accepts_matching_upload ... ok
+2026-08-01T02:43:10.4886694Z test routes::bootstrap::tests::carveout_claim_admits_exactly_one_concurrent_minter ... ok
+2026-08-01T02:43:10.4889509Z test routes::bootstrap::tests::label_hash_prefix_does_not_leak_raw_label ... ok
+2026-08-01T02:43:10.4892725Z test routes::bootstrap::tests::label_hash_prefix_is_stable_and_truncated ... ok
+2026-08-01T02:43:10.4924854Z test routes::cors_tests::empty_list_disables_cors_entirely ... ok
+2026-08-01T02:43:10.4957696Z test routes::cors_tests::empty_origin_string_filtered ... ok
+2026-08-01T02:43:10.4983098Z test routes::cors_tests::explicit_origin_produces_layer ... ok
+2026-08-01T02:43:10.4985598Z test routes::cors_tests::health_router_with_cors_builds_both_branches ... ok
+2026-08-01T02:43:10.5020020Z test routes::cors_tests::invalid_origin_filtered_out_and_empty_result_returns_none ... ok
+2026-08-01T02:43:10.5093414Z test routes::cors_tests::openapi_spec_covers_the_route_groups ... ok
+2026-08-01T02:43:10.5393353Z test routes::cors_tests::openapi_spec_describes_registered_routes ... ok
+2026-08-01T02:43:10.5394323Z test routes::cors_tests::wildcard_alone_yields_no_layer ... ok
+2026-08-01T02:43:10.5451022Z test routes::cors_tests::wildcard_mixed_with_explicit_origins_drops_wildcard_keeps_others ... ok
+2026-08-01T02:43:10.7339750Z test routes::backup_blob::tests::post_blob_refuses_second_upload ... ok
+2026-08-01T02:43:10.7343987Z test routes::backup_blob::tests::post_blob_rejects_hash_mismatch_with_same_size ... ok
+2026-08-01T02:43:10.7751924Z test routes::backup_blob::tests::post_blob_rejects_size_mismatch ... ok
+2026-08-01T02:43:10.9077952Z test routes::self_hosted_did::tests::canonical_path_serves_pathful_log ... ok
+2026-08-01T02:43:11.1303655Z test routes::self_hosted_did::tests::catch_all_404_for_non_canonical_did_jsonl_path ... ok
+2026-08-01T02:43:11.1398334Z test routes::self_hosted_did::tests::catch_all_does_not_shadow_authed_route ... ok
+2026-08-01T02:43:11.1839539Z test routes::self_hosted_did::tests::catch_all_unknown_path_is_bare_404 ... ok
+2026-08-01T02:43:11.2730831Z test routes::self_hosted_did::tests::well_known_404_for_non_webvh_did ... ok
+2026-08-01T02:43:11.2950924Z test server::tests::find_vta_key_paths_errors_when_did_webvh_missing_ka ... ok
+2026-08-01T02:43:11.3141084Z test server::tests::find_vta_key_paths_loads_ka_for_did_webvh ... ok
+2026-08-01T02:43:11.3323451Z test server::tests::find_vta_key_paths_returns_none_ka_for_did_key ... ok
+2026-08-01T02:43:11.3366420Z test server::tests::missing_identity_message_falls_back_to_key_material ... ok
+2026-08-01T02:43:11.3393501Z test server::tests::missing_identity_message_names_absent_jwt_key ... ok
+2026-08-01T02:43:11.3423247Z test server::tests::missing_identity_message_names_absent_vta_did ... ok
+2026-08-01T02:43:11.5137421Z test routes::self_hosted_did::tests::well_known_404_for_pathful_did ... ok
+2026-08-01T02:43:11.5321297Z test routes::self_hosted_did::tests::well_known_404_when_no_vta_did ... ok
+2026-08-01T02:43:11.5383305Z test tee_webvh::tests::record_scid_is_third_colon_segment ... ok
+2026-08-01T02:43:11.5433464Z test trust_tasks::acl::tests::change_role_conforms_and_update_carries_no_role ... ok
+2026-08-01T02:43:11.5500889Z test trust_tasks::acl::tests::update_body_is_canonical ... ok
+2026-08-01T02:43:11.5524742Z test trust_tasks::audit::tests::request_and_response_conform_to_the_canonical_schema ... ok
+2026-08-01T02:43:11.5567050Z test trust_tasks::conformance::every_published_dispatched_uri_has_a_witness ... ok
+2026-08-01T02:43:11.5603306Z test trust_tasks::conformance::every_witnessed_task_round_trips_through_its_generated_types ... ok
+2026-08-01T02:43:11.5604920Z test trust_tasks::consent::tests::approver_set_payload_parses_wire_route ... ok
+2026-08-01T02:43:11.5633305Z test trust_tasks::consent::tests::epoch_rfc3339_round_trips ... ok
+2026-08-01T02:43:11.5663048Z test trust_tasks::consent::tests::request_payload_parses_full_wire ... ok
+2026-08-01T02:43:11.5664369Z test trust_tasks::consent::tests::wire_approver_serializes_camelcase_and_route ... ok
+2026-08-01T02:43:11.5665296Z test trust_tasks::consent::tests::wire_grant_serializes_camelcase ... ok
+2026-08-01T02:43:11.5666226Z test routes::self_hosted_did::tests::well_known_serves_root_webvh_log_with_spec_headers ... ok
+2026-08-01T02:43:11.5667220Z test trust_tasks::consent::tests::wire_subject_parses_camelcase_and_maps ... ok
+2026-08-01T02:43:11.5668139Z test trust_tasks::cred_vault::tests::custody_auto_binds_to_callers_single_context ... ok
+2026-08-01T02:43:11.5669055Z test trust_tasks::cred_vault::tests::custody_override_must_be_accessible ... ok
+2026-08-01T02:43:11.5670012Z test trust_tasks::cred_vault::tests::custody_unscoped_for_super_admin_and_multi_context ... ok
+2026-08-01T02:43:11.6168199Z test server::tests::preload_self_did_document_ignores_malformed_local_log ... ok
+2026-08-01T02:43:11.6719322Z test server::tests::preload_self_did_document_makes_vta_did_resolvable_from_cache ... ok
+2026-08-01T02:43:11.9848337Z test trust_tasks::cred_vault::tests::force_delete_allows_the_callers_own_context ... ok
+2026-08-01T02:43:11.9864520Z test trust_tasks::cred_vault::tests::archive_refuses_a_credential_owned_by_another_context ... ok
+2026-08-01T02:43:12.0113713Z test trust_tasks::cred_vault::tests::force_delete_refuses_a_credential_owned_by_another_context ... ok
+2026-08-01T02:43:12.0117133Z test trust_tasks::cred_vault::tests::receive_body_parses_with_and_without_id ... ok
+2026-08-01T02:43:12.0133540Z test trust_tasks::cred_vault::tests::storage_id_prefers_explicit_then_vc_id_then_uuid ... ok
+2026-08-01T02:43:12.0383197Z test trust_tasks::cred_vault::tests::get_allows_a_credential_owned_by_the_callers_context ... ok
+2026-08-01T02:43:12.3273987Z test trust_tasks::cred_vault::tests::query_excludes_credentials_owned_by_another_context ... ok
+2026-08-01T02:43:12.3384970Z test trust_tasks::cred_vault::tests::get_refuses_a_credential_owned_by_another_context ... ok
+2026-08-01T02:43:12.4368205Z test trust_tasks::cred_vault::tests::super_admin_still_reads_every_context ... ok
+2026-08-01T02:43:12.4470227Z test trust_tasks::credentials::tests::issue_at_aal1_is_rejected_by_the_gate ... ok
+2026-08-01T02:43:12.6763852Z test trust_tasks::credentials::tests::issue_non_admin_is_rejected ... ok
+2026-08-01T02:43:12.7080995Z test trust_tasks::credentials::tests::issue_with_step_up_succeeds_and_binds_holder ... ok
+2026-08-01T02:43:12.8252509Z test trust_tasks::credentials::tests::revoke_known_id_succeeds_then_double_revoke_conflicts ... ok
+2026-08-01T02:43:12.8292898Z test trust_tasks::credentials::tests::revoke_unknown_id_is_not_found ... ok
+2026-08-01T02:43:13.0756937Z test trust_tasks::memory::tests::caller_without_context_access_is_refused ... ok
+2026-08-01T02:43:13.0826205Z test trust_tasks::memory::tests::delete_removes_then_unknown_is_not_found ... ok
+2026-08-01T02:43:13.2038272Z test trust_tasks::memory::tests::memory_in_context_a_is_not_listed_for_context_b ... ok
+2026-08-01T02:43:13.2048824Z test trust_tasks::passkey_vms::tests::extended_codes_are_task_namespaced ... ok
+2026-08-01T02:43:13.2049983Z test trust_tasks::passkey_vms::tests::invalid_attestation_family_carries_details_reason ... ok
+2026-08-01T02:43:13.2053312Z test trust_tasks::passkey_vms::tests::slug_is_derived_from_type_uri_for_both_versions ... ok
+2026-08-01T02:43:13.2056317Z test trust_tasks::passkey_vms::tests::standard_codes_map_to_framework_codes ... ok
+2026-08-01T02:43:13.2076261Z test trust_tasks::memory::tests::put_same_key_twice_upserts ... ok
+2026-08-01T02:43:13.4444244Z test trust_tasks::memory::tests::put_then_list_returns_the_item ... ok
+2026-08-01T02:43:13.4471413Z test trust_tasks::messaging::tests::ping_is_session_less_and_echoes_nonce ... ok
+2026-08-01T02:43:13.6069244Z test trust_tasks::payload_validation_tests::an_invented_member_is_refused ... ok
+2026-08-01T02:43:13.6302855Z test trust_tasks::payload_validation_tests::a_precondition_in_the_wrong_case_is_refused_not_ignored ... ok
+2026-08-01T02:43:13.6310532Z test trust_tasks::planner::tests::a_moved_derivation_counter_is_refused ... ok
+2026-08-01T02:43:13.6314515Z test trust_tasks::planner::tests::a_moved_subject_is_refused ... ok
+2026-08-01T02:43:13.6321222Z test trust_tasks::planner::tests::a_pin_appearing_from_nowhere_is_refused ... ok
+2026-08-01T02:43:13.6321968Z test trust_tasks::planner::tests::an_unmoved_world_passes ... ok
+2026-08-01T02:43:13.7903387Z test trust_tasks::payload_validation_tests::the_correct_casing_passes ... ok
+2026-08-01T02:43:13.8317350Z test trust_tasks::payload_validation_tests::an_unspecced_task_proceeds_by_default_and_can_be_refused ... ok
+2026-08-01T02:43:13.9744245Z test trust_tasks::payload_validation_tests::the_ext_slot_the_relay_stamps_an_origin_into_is_permitted ... ok
+2026-08-01T02:43:14.0017879Z test trust_tasks::policy_gate::tests::a_resubmit_re_asks_nobody ... ok
+2026-08-01T02:43:14.1639652Z test trust_tasks::policy_gate::tests::a_revoked_approver_cannot_carry_a_grant_through ... ok
+2026-08-01T02:43:14.1933986Z test trust_tasks::policy_gate::tests::a_still_enrolled_approver_carries_the_grant_through ... ok
+2026-08-01T02:43:14.3539832Z test trust_tasks::policy_gate::tests::a_task_with_no_page_behind_it_carries_no_origin ... ok
+2026-08-01T02:43:14.3809418Z test trust_tasks::policy_gate::tests::a_threshold_raised_mid_flight_invalidates_the_grant ... ok
+2026-08-01T02:43:14.5296114Z test trust_tasks::policy_gate::tests::consent_reject_carries_vta_signed_requests ... ok
+2026-08-01T02:43:14.5843760Z test trust_tasks::policy_gate::tests::gate_inert_when_disabled_enforces_when_enabled ... ok
+2026-08-01T02:43:14.7301202Z test trust_tasks::policy_gate::tests::grant_for_one_task_uri_does_not_authorize_another ... ok
+2026-08-01T02:43:14.7313554Z test trust_tasks::policy_gate::tests::rego_requires_step_up_when_session_not_elevated ... ok
+2026-08-01T02:43:14.7315423Z test trust_tasks::replay::tests::first_submission_is_fresh_replay_is_not ... ok
+2026-08-01T02:43:14.7316604Z test trust_tasks::step_up::tests::approver_mediator_routes_did_key_to_configured_mediator ... ok
+2026-08-01T02:43:14.7673303Z test trust_tasks::step_up::tests::issue_step_up_challenge_mints_pending_and_403s ... ok
+2026-08-01T02:43:14.7685438Z test trust_tasks::step_up::tests::reason_and_context_prefers_summary_and_passes_context_through ... ok
+2026-08-01T02:43:14.7832516Z test trust_tasks::step_up::tests::rejects_a_tampered_document ... ok
+2026-08-01T02:43:14.7853463Z test trust_tasks::step_up::tests::rejects_when_proof_absent ... ok
+2026-08-01T02:43:14.7995895Z test trust_tasks::step_up::tests::rejects_when_vm_did_is_not_the_subject ... ok
+2026-08-01T02:43:14.8286587Z test trust_tasks::step_up::tests::step_up_challenge_embeds_authorization_context ... ok
+2026-08-01T02:43:14.8466000Z test trust_tasks::step_up::tests::verifies_a_did_signed_approve_response ... ok
+2026-08-01T02:43:14.8479429Z test trust_tasks::step_up::tests::wake_reply_status_parses_camel_case_token_unregistered ... ok
+2026-08-01T02:43:14.8511962Z test trust_tasks::step_up::tests::wake_reply_status_parses_delivered ... ok
+2026-08-01T02:43:14.8514426Z test trust_tasks::step_up::tests::wake_reply_status_rejects_retired_kebab_case_and_junk ... ok
+2026-08-01T02:43:14.9082568Z test trust_tasks::policy_gate::tests::require_consent_records_pending_then_grant_lets_resubmit_through ... ok
+2026-08-01T02:43:14.9761307Z test trust_tasks::policy_gate::tests::the_consent_request_names_the_origin_that_proposed_the_task ... ok
+2026-08-01T02:43:15.0852782Z test trust_tasks::policy_gate::tests::the_requester_is_never_asked_to_approve_its_own_task ... ok
+2026-08-01T02:43:15.1896322Z test trust_tasks::task_consent::tests::a_pure_approver_with_approve_scope_confers_without_admin ... ok
+2026-08-01T02:43:15.2573630Z test trust_tasks::task_consent::tests::a_reader_of_the_context_confers_nothing ... ok
+2026-08-01T02:43:15.3322612Z test trust_tasks::task_consent::tests::a_self_authorized_task_never_delegates ... ok
+2026-08-01T02:43:15.4443938Z test trust_tasks::task_consent::tests::a_super_admin_approver_can_confer_any_context ... ok
+2026-08-01T02:43:15.5413743Z test trust_tasks::task_consent::tests::an_approve_all_approver_confers_any_context_without_admin ... ok
+2026-08-01T02:43:15.6168046Z test trust_tasks::task_consent::tests::an_approver_absent_from_the_acl_confers_nothing ... ok
+2026-08-01T02:43:15.6192892Z test trust_tasks::tests::body_parse_error_wire_shape ... ok
+2026-08-01T02:43:15.6193904Z test trust_tasks::tests::class_for_carries_authoritative_classification ... ok
+2026-08-01T02:43:15.6227531Z test trust_tasks::tests::dispatcher_handles_every_vta_sdk_uri ... ok
+2026-08-01T02:43:15.6228537Z test trust_tasks::tests::every_served_uri_has_a_published_spec_or_is_tracked_debt ... ok
+2026-08-01T02:43:15.6229564Z test trust_tasks::tests::framework_requires_canonical_uri_in_wire_type_field ... ok
+2026-08-01T02:43:15.6230511Z test trust_tasks::tests::no_uri_is_both_dispatched_and_rest_routed ... ok
+2026-08-01T02:43:15.6231356Z test trust_tasks::tests::passkey_vms_0_1_dispatched ... ok
+2026-08-01T02:43:15.6238502Z test trust_tasks::tests::phase_2_uri_registry_present ... ok
+2026-08-01T02:43:15.6243391Z test trust_tasks::vault::context_scope_tests::absent_context_filter_defers_to_caller_visibility ... ok
+2026-08-01T02:43:15.6245377Z test trust_tasks::vault::context_scope_tests::authorized_nowhere_caller_is_denied_every_context ... ok
+2026-08-01T02:43:15.6248317Z test trust_tasks::vault::context_scope_tests::authorized_nowhere_initiator_is_denied_too ... ok
+2026-08-01T02:43:15.6251053Z test trust_tasks::vault::context_scope_tests::context_admin_covers_its_own_subtree ... ok
+2026-08-01T02:43:15.6258513Z test trust_tasks::vault::context_scope_tests::super_admin_still_passes_every_context ... ok
+2026-08-01T02:43:15.6260135Z test trust_tasks::vault::sealed_envelope_tests::sealed_envelope_accepts_both_tag_casings ... ok
+2026-08-01T02:43:15.6266970Z test trust_tasks::wire_v0_2::tests::apply_at_path_fans_out_over_arrays_and_objects ... ok
+2026-08-01T02:43:15.6267837Z test trust_tasks::wire_v0_2::tests::camelize_paths_is_a_noop_on_kebab_for_v0_1_seal ... ok
+2026-08-01T02:43:15.6269069Z test trust_tasks::wire_v0_2::tests::casing_transforms_are_inverse_and_idempotent ... ok
+2026-08-01T02:43:15.6270228Z test trust_tasks::wire_v0_2::tests::current_wire_version_reads_scoped_value_and_defaults_to_v0_1 ... ok
+2026-08-01T02:43:15.6271979Z test trust_tasks::wire_v0_2::tests::device_list_request_downconverts_enums ... ok
+2026-08-01T02:43:15.6273523Z test trust_tasks::wire_v0_2::tests::device_list_response_upconverts_and_retypes ... ok
+2026-08-01T02:43:15.6275729Z test trust_tasks::wire_v0_2::tests::free_text_at_non_enum_path_is_untouched ... ok
+2026-08-01T02:43:15.6276253Z test trust_tasks::wire_v0_2::tests::registry_uris_are_consistent ... ok
+2026-08-01T02:43:15.6276995Z test trust_tasks::wire_v0_2::tests::upconvert_passes_through_reject_documents ... ok
+2026-08-01T02:43:15.6278078Z test trust_tasks::wire_v0_2::tests::vault_list_response_upconverts_nested_enums ... ok
+2026-08-01T02:43:15.6282644Z test trust_tasks::wire_v0_2::tests::vault_proxy_login_response_camelizes_sealed_session_blob_envelope_tag ... ok
+2026-08-01T02:43:15.6283799Z test trust_tasks::wire_v0_2::tests::vault_release_response_camelizes_sealed_secret_envelope_tag ... ok
+2026-08-01T02:43:15.6284765Z test trust_tasks::wire_v0_2::tests::vault_upsert_request_downconverts_sealed_secret_envelope_tag ... ok
+2026-08-01T02:43:15.6286053Z test trust_tasks::wire_v0_2::tests::vault_upsert_request_downconverts_secretkind_and_target ... ok
+2026-08-01T02:43:15.6286852Z test webvh_didcomm::tests::auto_assign_omits_path ... ok
+2026-08-01T02:43:15.6287495Z test webvh_didcomm::tests::domain_included_only_when_present ... ok
+2026-08-01T02:43:15.6288146Z test webvh_didcomm::tests::explicit_path_is_sent ... ok
+2026-08-01T02:43:15.6288797Z test webvh_didcomm::tests::no_task_constant_names_a_retired_verb ... ok
+2026-08-01T02:43:15.6289548Z test webvh_didcomm::tests::not_reserved_and_unavailable_is_a_conflict ... ok
+2026-08-01T02:43:15.6290382Z test webvh_didcomm::tests::not_reserved_but_available_is_an_internal_anomaly ... ok
+2026-08-01T02:43:15.6291098Z test webvh_didcomm::tests::parses_legacy_flat_response ... ok
+2026-08-01T02:43:15.6291522Z test webvh_didcomm::tests::parses_spec_record_shaped_response ... ok
+2026-08-01T02:43:15.6292383Z test webvh_didcomm::tests::publish_registers_the_owned_slot_without_forcing ... ok
+2026-08-01T02:43:15.6293214Z test webvh_didcomm::tests::register_body_includes_domain_when_present ... ok
+2026-08-01T02:43:15.6293946Z test webvh_didcomm::tests::reserved_without_did_url_errors ... ok
+2026-08-01T02:43:15.6294586Z test webvh_didcomm::tests::well_known_is_sent_as_path ... ok
+2026-08-01T02:43:15.6853839Z test trust_tasks::task_consent::tests::approval_from_admin_of_another_context_confers_nothing ... ok
+2026-08-01T02:43:15.7949887Z test trust_tasks::task_consent::tests::context_admin_approval_confers_the_context ... ok
+2026-08-01T02:43:15.8393374Z test trust_tasks::task_consent::tests::delegation_requires_meeting_the_threshold_with_context_admins ... ok
+2026-08-01T02:43:15.8394149Z 
+2026-08-01T02:43:15.8394577Z test result: ok. 756 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 17.40s
+2026-08-01T02:43:15.8394981Z 
+2026-08-01T02:43:15.8454084Z [1m[92m     Running[0m unittests src/main.rs (target/debug/deps/vta-d43ef3e7a8e074d2)
+2026-08-01T02:43:15.8567782Z 
+2026-08-01T02:43:15.8568193Z running 64 tests
+2026-08-01T02:43:15.8599683Z test bootstrap_cli::tests::parse_var_array_is_json ... ok
+2026-08-01T02:43:15.8605779Z test bootstrap_cli::tests::parse_var_bool_is_json ... ok
+2026-08-01T02:43:15.8641749Z test bootstrap_cli::tests::parse_var_empty_key_errors ... ok
+2026-08-01T02:43:15.8645242Z test bootstrap_cli::tests::parse_var_missing_equals_errors ... ok
+2026-08-01T02:43:15.8650262Z test bootstrap_cli::tests::parse_var_number_is_json ... ok
+2026-08-01T02:43:15.8656105Z test bootstrap_cli::tests::parse_var_plain_string ... ok
+2026-08-01T02:43:15.8657878Z test bootstrap_cli::tests::parse_var_quoted_string_is_json ... ok
+2026-08-01T02:43:15.8659949Z test bootstrap_cli::tests::parse_var_value_may_contain_equals ... ok
+2026-08-01T02:43:15.8829961Z test did_peer::tests::bundle_has_two_entries_ed25519_then_x25519 ... ok
+2026-08-01T02:43:15.8900528Z test bootstrap_cli::tests::ensure_target_context_or_create_returns_actionable_error_when_missing ... ok
+2026-08-01T02:43:15.8985405Z test bootstrap_cli::tests::ensure_target_context_or_create_creates_context_when_flag_set ... ok
+2026-08-01T02:43:15.8987781Z test bootstrap_cli::tests::ensure_target_context_or_create_is_idempotent_when_context_exists ... ok
+2026-08-01T02:43:15.9010119Z test setup::from_toml::tests::audit_retention_days_round_trips ... ok
+2026-08-01T02:43:15.9015727Z test setup::from_toml::tests::admin_did_validation_rejects_non_did ... ok
+2026-08-01T02:43:15.9034886Z test setup::from_toml::tests::audit_retention_days_zero_rejected ... ok
+2026-08-01T02:43:15.9035716Z test setup::from_toml::tests::create_mediator_empty_webvh_url_rejected ... ok
+2026-08-01T02:43:15.9036757Z test setup::from_toml::tests::create_mediator_empty_ws_url_rejected ... ok
+2026-08-01T02:43:15.9037538Z test setup::from_toml::tests::create_mediator_explicit_ws_url_round_trips ... ok
+2026-08-01T02:43:15.9038376Z test setup::from_toml::tests::create_mediator_mediator_host_round_trips ... ok
+2026-08-01T02:43:15.9040492Z test setup::from_toml::tests::clear_dir_contents_empties_the_dir_but_keeps_it ... ok
+2026-08-01T02:43:15.9042543Z test setup::from_toml::tests::create_mediator_non_ws_scheme_ws_url_rejected ... ok
+2026-08-01T02:43:15.9043340Z test setup::from_toml::tests::create_mediator_webvh_url_can_be_set ... ok
+2026-08-01T02:43:15.9050142Z test setup::from_toml::tests::create_mediator_webvh_url_optional_defaults_to_none ... ok
+2026-08-01T02:43:15.9052277Z test setup::from_toml::tests::create_mediator_template_vars_round_trip ... ok
+2026-08-01T02:43:15.9055884Z test setup::from_toml::tests::create_mediator_ws_url_optional_defaults_to_none ... ok
+2026-08-01T02:43:15.9069049Z test setup::from_toml::tests::create_mediator_without_didcomm_rejected ... ok
+2026-08-01T02:43:15.9071081Z test setup::from_toml::tests::create_webvh_advanced_fields_default_absent ... ok
+2026-08-01T02:43:15.9075479Z test setup::from_toml::tests::create_webvh_conflicting_advanced_modes_rejected ... ok
+2026-08-01T02:43:15.9077433Z test setup::from_toml::tests::create_webvh_ka_key_without_signing_key_rejected ... ok
+2026-08-01T02:43:15.9079118Z test setup::from_toml::tests::create_webvh_single_advanced_mode_validates ... ok
+2026-08-01T02:43:15.9080514Z test setup::from_toml::tests::data_dir_policy_defaults_to_error_and_parses_every_variant ... ok
+2026-08-01T02:43:15.9090696Z test setup::from_toml::tests::empty_resolver_url_rejected ... ok
+2026-08-01T02:43:15.9094401Z test setup::from_toml::tests::every_wizard_backend_choice_states_its_selector ... ok
+2026-08-01T02:43:15.9106456Z test setup::from_toml::tests::existing_mediator_mediator_host_round_trips ... ok
+2026-08-01T02:43:15.9119419Z test setup::from_toml::tests::full_inputs_parse ... ok
+2026-08-01T02:43:15.9120124Z test setup::from_toml::tests::minimal_keyring_inputs_round_trip ... ok
+2026-08-01T02:43:15.9136066Z test setup::from_toml::tests::overwrite_config_defaults_to_false_and_round_trips ... ok
+2026-08-01T02:43:15.9141686Z test setup::from_toml::tests::plaintext_backend_sets_allow_plaintext_and_selects_itself ... ok
+2026-08-01T02:43:15.9147893Z test setup::from_toml::tests::resolver_url_round_trips ... ok
+2026-08-01T02:43:15.9499594Z test setup::from_toml::tests::seed_staff_creates_context_policy_and_scoped_entry ... ok
+2026-08-01T02:43:15.9562932Z test setup::from_toml::tests::services_rest_disabled_does_not_require_public_url ... ok
+2026-08-01T02:43:15.9563980Z test setup::from_toml::tests::services_rest_with_empty_public_url_rejected ... ok
+2026-08-01T02:43:15.9592828Z test setup::from_toml::tests::services_rest_with_public_url_passes ... ok
+2026-08-01T02:43:15.9622708Z test setup::from_toml::tests::services_rest_without_public_url_rejected ... ok
+2026-08-01T02:43:15.9653176Z test setup::from_toml::tests::services_tsp_with_didcomm_passes_and_carries_through ... ok
+2026-08-01T02:43:15.9682683Z test setup::from_toml::tests::services_tsp_without_didcomm_is_rejected ... ok
+2026-08-01T02:43:15.9742670Z test setup::from_toml::tests::setup_acl_defaults_to_false ... ok
+2026-08-01T02:43:15.9743713Z test setup::from_toml::tests::setup_acl_true_is_preserved_and_propagates ... ok
+2026-08-01T02:43:15.9843818Z test setup::from_toml::tests::a_failed_run_leaves_the_existing_config_intact ... ok
+2026-08-01T02:43:15.9882404Z test setup::from_toml::tests::shipped_example_parses ... ok
+2026-08-01T02:43:15.9886719Z test setup::from_toml::tests::silent_ui_behaviour ... ok
+2026-08-01T02:43:15.9896196Z test setup::from_toml::tests::staff_section_parses_with_inline_context_policy ... ok
+2026-08-01T02:43:15.9900017Z test setup::from_toml::tests::a_pre_created_empty_data_dir_is_not_a_conflict ... ok
+2026-08-01T02:43:15.9906870Z test setup::from_toml::tests::unknown_field_rejected ... ok
+2026-08-01T02:43:15.9907984Z test setup::from_toml::tests::vault_backend_round_trips ... ok
+2026-08-01T02:43:15.9924843Z test setup::interactive::tests::a_pre_created_empty_data_dir_is_never_asked_about ... ok
+2026-08-01T02:43:15.9935607Z test setup::interactive::tests::advanced_existing_keys_mode_maps_through ... ok
+2026-08-01T02:43:15.9940066Z test setup::interactive::tests::cancelling_at_the_data_dir_prompt_leaves_the_config_intact ... ok
+2026-08-01T02:43:15.9942816Z test setup::interactive::tests::existing_store_offers_reuse_and_delete ... ok
+2026-08-01T02:43:15.9946647Z test setup::tests::build_vta_additional_services_matrix ... ok
+2026-08-01T02:43:15.9948147Z test setup::tests::derive_ws_url_swaps_scheme_trims_and_appends_ws ... ok
+2026-08-01T02:43:15.9949165Z test setup::interactive::tests::interactive_matches_equivalent_toml ... ok
+2026-08-01T02:43:16.0611651Z test setup::from_toml::tests::setup_refuses_to_run_over_an_initialized_vta ... ok
+2026-08-01T02:43:16.0763310Z test setup::from_toml::tests::delete_policy_wipes_a_store_without_removing_the_directory ... ok
+2026-08-01T02:43:16.0763968Z 
+2026-08-01T02:43:16.0764303Z test result: ok. 64 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.22s
+2026-08-01T02:43:16.0764644Z 
+2026-08-01T02:43:16.0793828Z [1m[92m     Running[0m tests/api_integration.rs (target/debug/deps/api_integration-438bc9d181ccc710)
+2026-08-01T02:43:16.0993863Z 
+2026-08-01T02:43:16.0994492Z running 121 tests
+2026-08-01T02:43:16.5942846Z test acl_application_cannot_manage ... ok
+2026-08-01T02:43:16.6010367Z test acl_grant_persists_step_up_approver ... ok
+2026-08-01T02:43:16.6022674Z test acl_create_and_list ... ok
+2026-08-01T02:43:16.6274547Z test acl_get_update_delete_lifecycle ... ok
+2026-08-01T02:43:16.9910961Z test acl_update_sets_step_up_approver ... ok
+2026-08-01T02:43:17.0174263Z test acl_mutation_requires_step_up ... ok
+2026-08-01T02:43:17.0295820Z test acl_list_filters_a_context_in_both_directions ... ok
+2026-08-01T02:43:17.0516161Z test admin_can_read_config ... ok
+2026-08-01T02:43:17.3974108Z test application_role_cannot_access_admin_endpoints ... ok
+2026-08-01T02:43:17.4084335Z test audit_list_requires_admin ... ok
+2026-08-01T02:43:17.4505924Z test audit_time_bounds_are_parsed_and_applied ... ok
+2026-08-01T02:43:17.4601158Z test audit_retention_get_and_update ... ok
+2026-08-01T02:43:17.8298740Z test backup_export_rejects_short_password ... ok
+2026-08-01T02:43:17.8346451Z test backup_export_requires_super_admin ... ok
+2026-08-01T02:43:17.8374215Z test backup_blob_branch_is_rate_limited ... ok
+2026-08-01T02:43:18.3323542Z test cache_put_get_delete ... ok
+2026-08-01T02:43:18.4703134Z test body_cap_returns_413_for_oversized_payload ... ok
+2026-08-01T02:43:18.7289930Z test capabilities_requires_auth ... ok
+2026-08-01T02:43:18.9356249Z test capabilities_returns_features ... ok
+2026-08-01T02:43:19.1404186Z test context_admin_can_update_own_context_did ... ok
+2026-08-01T02:43:19.3873535Z test context_admin_cannot_update_other_context_did ... ok
+2026-08-01T02:43:19.5792856Z test context_create_get_update_delete ... ok
+2026-08-01T02:43:19.8423047Z test context_create_requires_super_admin ... ok
+2026-08-01T02:43:20.1193342Z test create_did_webvh_accepts_path_mode_field ... ok
+2026-08-01T02:43:20.3143442Z test create_did_webvh_context_scoped_template_shadows_global ... ok
+2026-08-01T02:43:20.5813210Z test create_did_webvh_didcomm_requires_ka_key ... ok
+2026-08-01T02:43:20.7693277Z test create_did_webvh_final_mode_stores_record ... ok
+2026-08-01T02:43:20.9623534Z test create_did_webvh_ka_without_signing_rejected ... ok
+2026-08-01T02:43:21.2003361Z test create_did_webvh_neither_server_nor_url_rejected ... ok
+2026-08-01T02:43:21.3673486Z test create_did_webvh_rejects_both_document_and_log ... ok
+2026-08-01T02:43:21.6303593Z test create_did_webvh_server_and_url_mutually_exclusive ... ok
+2026-08-01T02:43:21.8193874Z test create_did_webvh_set_primary_false ... ok
+2026-08-01T02:43:22.0796049Z test create_did_webvh_set_primary_true ... ok
+2026-08-01T02:43:22.2853753Z test create_did_webvh_template_missing_required_var_errors ... ok
+2026-08-01T02:43:22.6573901Z test create_did_webvh_template_mode ... ok
+2026-08-01T02:43:22.7926977Z test create_did_webvh_template_mutually_exclusive_with_did_document ... ok
+2026-08-01T02:43:23.0990126Z test create_did_webvh_template_unknown_name_errors ... ok
+2026-08-01T02:43:23.2108695Z test create_did_webvh_unknown_server_returns_404 ... ok
+2026-08-01T02:43:23.5793574Z test create_did_webvh_via_builtin_mediator_template ... ok
+2026-08-01T02:43:23.7014521Z test create_did_webvh_with_user_signing_and_ka_keys ... ok
+2026-08-01T02:43:24.0765995Z test create_did_webvh_with_user_signing_key ... ok
+2026-08-01T02:43:24.2084305Z test create_did_webvh_wrong_key_type_rejected ... ok
+2026-08-01T02:43:24.5159443Z test create_p256_key ... ok
+2026-08-01T02:43:24.6833261Z test ctx_did_templates_context_admin_can_crud ... ok
+2026-08-01T02:43:24.9403569Z test ctx_did_templates_create_requires_context_admin_or_super ... ok
+2026-08-01T02:43:25.1023233Z test ctx_did_templates_deleted_when_parent_context_deleted ... ok
+2026-08-01T02:43:25.3549925Z test ctx_did_templates_rejects_missing_context ... ok
+2026-08-01T02:43:25.5243769Z test ctx_did_templates_render_injects_context_vars ... ok
+2026-08-01T02:43:25.7733233Z test ctx_did_templates_shadow_global_without_conflict ... ok
+2026-08-01T02:43:25.9253871Z test delegated_step_up_routes_to_configured_approver ... ok
+2026-08-01T02:43:26.2024598Z test delegated_step_up_without_approver_fails_closed ... ok
+2026-08-01T02:43:26.2758058Z test did_templates_create_get_delete_roundtrip ... ok
+2026-08-01T02:43:26.6471899Z test did_templates_create_requires_super_admin ... ok
+2026-08-01T02:43:26.7151377Z test did_templates_export_round_trips_through_sdk_loader ... ok
+2026-08-01T02:43:27.0733644Z test did_templates_invalid_body_rejected_at_create ... ok
+2026-08-01T02:43:27.1376988Z test did_templates_list_empty_for_fresh_vta ... ok
+2026-08-01T02:43:27.1915677Z test backup_export_and_import_preview ... ok
+2026-08-01T02:43:27.4688053Z test did_templates_render_injects_ambient_and_merges_caller_vars ... ok
+2026-08-01T02:43:27.5340891Z test did_templates_render_missing_required_var_errors ... ok
+2026-08-01T02:43:27.5878426Z test did_templates_update_name_mismatch_rejected ... ok
+2026-08-01T02:43:27.6122701Z test backup_import_wrong_password_returns_auth_error ... ok
+2026-08-01T02:43:27.8775406Z test did_templates_update_replaces_body_preserves_created_at ... ok
+2026-08-01T02:43:27.9104804Z test didcomm_status_forbids_non_super_admin ... ok
+2026-08-01T02:43:27.9770292Z test didcomm_status_requires_auth ... ok
+2026-08-01T02:43:27.9905500Z test didcomm_status_returns_disabled_when_not_enabled ... ok
+2026-08-01T02:43:28.2973462Z test didcomm_status_returns_mediator_and_websocket_state_when_enabled ... ok
+2026-08-01T02:43:28.3215241Z test disable_didcomm_returns_typed_error_body ... ok
+2026-08-01T02:43:28.3673943Z test disable_didcomm_unauthenticated_returns_401 ... ok
+2026-08-01T02:43:28.3907119Z test drain_cancel_unauthenticated_returns_401 ... ok
+2026-08-01T02:43:28.6791447Z test drain_cancel_unknown_mediator_returns_typed_error ... ok
+2026-08-01T02:43:28.7032933Z test enable_didcomm_already_enabled_returns_409_with_suggested_fix ... ok
+2026-08-01T02:43:28.7827794Z test enable_didcomm_propagates_resolve_failure_with_stage ... ok
+2026-08-01T02:43:28.7911524Z test enable_didcomm_non_super_admin_returns_403 ... ok
+2026-08-01T02:43:29.0595528Z test enable_didcomm_unauthenticated_returns_401 ... ok
+2026-08-01T02:43:29.0776928Z test expired_session_returns_401 ... ok
+2026-08-01T02:43:29.1607862Z test health_details_reports_tsp_enabled_when_configured ... ok
+2026-08-01T02:43:29.1850325Z test health_details_requires_auth ... ok
+2026-08-01T02:43:29.4253571Z test health_details_returns_version_with_auth ... ok
+2026-08-01T02:43:29.4655918Z test health_returns_ok_without_auth ... ok
+2026-08-01T02:43:29.5403223Z test initiator_cannot_access_super_admin_endpoints ... ok
+2026-08-01T02:43:29.5757828Z test invalid_token_returns_401 ... ok
+2026-08-01T02:43:29.8403868Z test key_create_and_list ... ok
+2026-08-01T02:43:29.8713316Z test key_create_revoke_list_lifecycle ... ok
+2026-08-01T02:43:29.9327711Z test key_rename ... ok
+2026-08-01T02:43:29.9352665Z test keys_import_rejects_private_key_multibase_over_rest ... ok
+2026-08-01T02:43:30.2506219Z test mediator_report_returns_empty_report_when_no_traffic ... ok
+2026-08-01T02:43:30.2509004Z test mediator_report_unauthenticated_returns_401 ... ok
+2026-08-01T02:43:30.3138270Z test non_admin_cannot_update_context_did ... ok
+2026-08-01T02:43:30.3302292Z test missing_token_returns_401 ... ok
+2026-08-01T02:43:30.6863650Z test provision_integration_rejects_non_admin_token ... ok
+2026-08-01T02:43:30.6934884Z test operations_create_audit_entries ... ok
+2026-08-01T02:43:30.7179013Z test provision_integration_rejects_unknown_field_in_body ... ok
+2026-08-01T02:43:30.7381603Z test provision_integration_rejects_tampered_vp ... ok
+2026-08-01T02:43:31.0599134Z test reader_can_list_keys ... ok
+2026-08-01T02:43:31.0818987Z test provision_integration_requires_auth ... ok
+2026-08-01T02:43:31.1123503Z test request_timeout_layer_returns_408_for_slow_handler ... ok
+2026-08-01T02:43:31.1502612Z test reader_cannot_sign ... ok
+2026-08-01T02:43:31.1638970Z test reader_cannot_create_key ... ok
+2026-08-01T02:43:31.4726595Z test restart_requires_super_admin ... ok
+2026-08-01T02:43:31.5076773Z test rollback_routes_via_migrate_with_rollback_flag ... ok
+2026-08-01T02:43:31.5623679Z test scoped_admin_can_only_access_own_context_keys ... ok
+2026-08-01T02:43:31.6271518Z test rotate_did_webvh_keys_advances_fragment_ids ... ok
+2026-08-01T02:43:31.8803357Z test scoped_admin_cannot_update_config ... ok
+2026-08-01T02:43:31.8878391Z test scoped_admin_cannot_read_the_whole_audit_log ... ok
+2026-08-01T02:43:31.9634998Z test seed_list_returns_seeds ... ok
+2026-08-01T02:43:32.0015974Z test step_up_floor_is_per_operation_class ... ok
+2026-08-01T02:43:32.2963351Z test super_admin_can_update_config ... ok
+2026-08-01T02:43:32.2982457Z test super_admin_can_update_any_context_did ... ok
+2026-08-01T02:43:32.3520245Z test super_admin_cannot_rewrite_the_vta_identity ... ok
+2026-08-01T02:43:32.3873386Z test swap_key_carve_out_admits_aal1_when_configured ... ok
+2026-08-01T02:43:32.6629185Z test unauth_attestation_status_is_rate_limited ... ok
+2026-08-01T02:43:32.6992973Z test swap_key_gated_without_carve_out ... ok
+2026-08-01T02:43:32.7680464Z test unauth_endpoint_rate_limit_returns_429_after_burst ... ok
+2026-08-01T02:43:32.7831604Z test unknown_audience_token_rejected_by_vta_route ... ok
+2026-08-01T02:43:33.1038673Z test update_did_webvh_invalid_document_returns_400 ... ok
+2026-08-01T02:43:33.1470770Z test update_did_webvh_metadata_only_succeeds ... ok
+2026-08-01T02:43:33.1645036Z test update_did_webvh_unknown_scid_returns_404 ... ok
+2026-08-01T02:43:33.2408495Z test update_did_webvh_with_new_document_rotates_keys ... ok
+2026-08-01T02:43:33.4521775Z test update_didcomm_returns_typed_error_body ... ok
+2026-08-01T02:43:33.4774770Z test update_didcomm_unauthenticated_returns_401 ... ok
+2026-08-01T02:43:33.5034374Z test vtc_audience_token_rejected_by_vta_route ... ok
+2026-08-01T02:43:33.5034858Z 
+2026-08-01T02:43:33.5035690Z test result: ok. 121 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 17.40s
+2026-08-01T02:43:33.5036273Z 
+2026-08-01T02:43:33.5148284Z [1m[92m     Running[0m tests/app_state_single_construction.rs (target/debug/deps/app_state_single_construction-4fcbb9a415203157)
+2026-08-01T02:43:33.5252464Z 
+2026-08-01T02:43:33.5252845Z running 3 tests
+2026-08-01T02:43:33.5265659Z test router_does_not_reconstruct_divergent_state ... ok
+2026-08-01T02:43:33.7594915Z test vta_state_shares_config_rwlock ... ok
+2026-08-01T02:43:33.7595513Z test vta_state_shares_shared_components ... ok
+2026-08-01T02:43:33.7595847Z 
+2026-08-01T02:43:33.7596248Z test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.23s
+2026-08-01T02:43:33.7596797Z 
+2026-08-01T02:43:33.7623962Z [1m[92m     Running[0m tests/auth_flow.rs (target/debug/deps/auth_flow-5722ae3571802da3)
+2026-08-01T02:43:33.7832446Z 
+2026-08-01T02:43:33.7833139Z running 8 tests
+2026-08-01T02:43:34.2313346Z test challenge_endpoint_issues_session_and_persists_it ... ok
+2026-08-01T02:43:34.2601167Z test di_signed_trust_task_with_tampered_challenge_is_rejected ... ok
+2026-08-01T02:43:34.2794080Z test di_signed_trust_task_authenticates_over_rest ... ok
+2026-08-01T02:43:34.4268737Z test plaintext_didcomm_refresh_is_rejected ... ok
+2026-08-01T02:43:34.6614449Z test refresh_endpoint_rejects_malformed_token_with_401 ... ok
+2026-08-01T02:43:34.6830145Z test refresh_endpoint_rejects_unknown_token_with_401 ... ok
+2026-08-01T02:43:34.7643319Z test test_app_context_exposes_required_keyspaces ... ok
+2026-08-01T02:43:34.7689340Z test plaintext_didcomm_with_forged_sender_is_rejected ... ok
+2026-08-01T02:43:34.7689847Z 
+2026-08-01T02:43:34.7690132Z test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.99s
+2026-08-01T02:43:34.7690564Z 
+2026-08-01T02:43:34.7758292Z [1m[92m     Running[0m tests/authenticate_trust_task.rs (target/debug/deps/authenticate_trust_task-1f55a41adbf37875)
+2026-08-01T02:43:34.7972584Z 
+2026-08-01T02:43:34.7973206Z running 4 tests
+2026-08-01T02:43:35.3054872Z test tt_challenge_returns_tt_response_doc ... ok
+2026-08-01T02:43:35.3118790Z test di_signed_authenticate_rejects_tampered_proof ... ok
+2026-08-01T02:43:35.3457398Z test second_login_for_same_did_coalesces_into_one_session ... ok
+2026-08-01T02:43:35.3464582Z test di_signed_authenticate_issues_tokens ... ok
+2026-08-01T02:43:35.3465006Z 
+2026-08-01T02:43:35.3465427Z test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.55s
+2026-08-01T02:43:35.3466020Z 
+2026-08-01T02:43:35.3519816Z [1m[92m     Running[0m tests/client_round_trip.rs (target/debug/deps/client_round_trip-c7a10164dc211e94)
+2026-08-01T02:43:35.3749721Z 
+2026-08-01T02:43:35.3750134Z running 9 tests
+2026-08-01T02:43:35.9584457Z test acl_expiry_survives_the_epoch_rfc3339_conversion ... ok
+2026-08-01T02:43:35.9586278Z test acl_step_up_and_approve_survive_their_canonical_nesting ... ok
+2026-08-01T02:43:35.9719108Z test acl_lifecycle_round_trips_through_the_real_client ... ok
+2026-08-01T02:43:35.9759592Z test acl_change_role_compare_and_swaps ... ok
+2026-08-01T02:43:36.3884067Z test audit_list_round_trips_through_the_real_client ... ok
+2026-08-01T02:43:36.4148173Z test audit_cursor_is_bound_to_its_filters ... ok
+2026-08-01T02:43:36.4188266Z test config_registry_round_trips_and_identity_stays_read_only ... ok
+2026-08-01T02:43:36.5047064Z test webvh_get_did_round_trips_after_the_get_log_fold ... ok
+2026-08-01T02:43:36.6682581Z test webvh_server_register_upserts_but_refuses_a_repoint ... ok
+2026-08-01T02:43:36.6683023Z 
+2026-08-01T02:43:36.6683346Z test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.29s
+2026-08-01T02:43:36.6683714Z 
+2026-08-01T02:43:36.6728815Z [1m[92m     Running[0m tests/delegated_consent_e2e.rs (target/debug/deps/delegated_consent_e2e-4d009f3747f3e24b)
+2026-08-01T02:43:36.6928155Z 
+2026-08-01T02:43:36.6928432Z running 5 tests
+2026-08-01T02:43:37.2771128Z test an_unsatisfiable_elevation_is_refused_before_any_consent_ceremony ... ok
+2026-08-01T02:43:37.3772553Z test a_did_update_is_approved_by_a_human_and_the_keys_they_saw_are_the_keys_installed ... ok
+2026-08-01T02:43:37.3783769Z test a_context_admin_approval_lets_a_cross_context_requester_execute ... ok
+2026-08-01T02:43:37.3867475Z test an_approval_authorizes_exactly_one_execution ... ok
+2026-08-01T02:43:37.5946288Z test the_requester_cannot_approve_its_own_task ... ok
+2026-08-01T02:43:37.5946595Z 
+2026-08-01T02:43:37.5946867Z test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.90s
+2026-08-01T02:43:37.5947215Z 
+2026-08-01T02:43:37.6007029Z [1m[92m     Running[0m tests/mock_vta.rs (target/debug/deps/mock_vta-6db22cdeff435159)
+2026-08-01T02:43:37.6206967Z 
+2026-08-01T02:43:37.6207308Z running 8 tests
+2026-08-01T02:43:38.0433383Z test mock_vta_gates_authenticated_routes ... ok
+2026-08-01T02:43:38.2928098Z test create_did_webvh_round_trips_against_stub_host ... ok
+2026-08-01T02:43:38.3513459Z test mock_vta_serves_health_over_http ... ok
+2026-08-01T02:43:38.5673939Z test a_superseded_signing_key_is_recovered_from_the_seed ... ok
+2026-08-01T02:43:38.6176025Z test provisionable_mock_exposes_a_real_vta_did ... ok
+2026-08-01T02:43:38.7417171Z test seeded_webvh_server_is_listed_over_http ... ok
+2026-08-01T02:43:38.7597400Z test a_failed_publish_does_not_wedge_the_did_and_the_next_update_recovers ... ok
+2026-08-01T02:43:38.9662564Z test url_direct_admin_rotation_round_trips_against_rest_only_mock ... ok
+2026-08-01T02:43:38.9663028Z 
+2026-08-01T02:43:38.9663314Z test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.35s
+2026-08-01T02:43:38.9663655Z 
+2026-08-01T02:43:38.9713455Z [1m[92m     Running[0m tests/pending_presentation_trust_task.rs (target/debug/deps/pending_presentation_trust_task-764c287ab746f8c4)
+2026-08-01T02:43:38.9907121Z 
+2026-08-01T02:43:38.9907553Z running 4 tests
+2026-08-01T02:43:39.4115947Z test pending_surface_requires_a_bearer_token ... ok
+2026-08-01T02:43:39.4513422Z test approve_without_a_held_credential_fails_but_dispatches ... ok
+2026-08-01T02:43:39.4541951Z test pending_surface_requires_super_admin ... ok
+2026-08-01T02:43:39.4573870Z test list_then_deny_over_the_wire_deletes_the_record ... ok
+2026-08-01T02:43:39.4575025Z 
+2026-08-01T02:43:39.4577529Z test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.47s
+2026-08-01T02:43:39.4578151Z 
+2026-08-01T02:43:39.4630680Z [1m[92m     Running[0m tests/provision_integration_provisionable.rs (target/debug/deps/provision_integration_provisionable-7946af19785d33b6)
+2026-08-01T02:43:39.4723837Z 
+2026-08-01T02:43:39.4724314Z running 2 tests
+2026-08-01T02:43:39.6851488Z test plain_bootstrap_test_vta_errors_before_render_without_a_context ... ok
+2026-08-01T02:43:39.9403547Z test provisionable_vta_reaches_render_seal_issue_for_both_assertion_modes ... ok
+2026-08-01T02:43:39.9404207Z 
+2026-08-01T02:43:39.9404589Z test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.47s
+2026-08-01T02:43:39.9405033Z 
+2026-08-01T02:43:39.9427758Z [1m[92m     Running[0m tests/refresh_trust_task.rs (target/debug/deps/refresh_trust_task-073c8d97abf0a8ae)
+2026-08-01T02:43:39.9632205Z 
+2026-08-01T02:43:39.9632661Z running 2 tests
+2026-08-01T02:43:40.2762519Z test trust_task_refresh_rejects_unknown_token ... ok
+2026-08-01T02:43:40.2844309Z test trust_task_refresh_rotates_tokens ... ok
+2026-08-01T02:43:40.2844693Z 
+2026-08-01T02:43:40.2845052Z test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.32s
+2026-08-01T02:43:40.2845487Z 
+2026-08-01T02:43:40.2885541Z [1m[92m     Running[0m tests/security.rs (target/debug/deps/security-ac63eba1b0b80469)
+2026-08-01T02:43:40.2933299Z 
+2026-08-01T02:43:40.2933647Z running 34 tests
+2026-08-01T02:43:40.2943028Z test acl_validation::admin_can_create_initiator ... ok
+2026-08-01T02:43:40.2943748Z test acl_validation::admin_can_create_application ... ok
+2026-08-01T02:43:40.2944363Z test acl_validation::application_cannot_create_admin ... ok
+2026-08-01T02:43:40.2944942Z test acl_validation::admin_can_create_reader ... ok
+2026-08-01T02:43:40.2946339Z test acl_validation::initiator_can_create_application ... ok
+2026-08-01T02:43:40.2946967Z test acl_validation::initiator_cannot_create_admin ... ok
+2026-08-01T02:43:40.2947634Z test acl_validation::reader_cannot_assign_any_role ... ok
+2026-08-01T02:43:40.2948300Z test auth_enforcement::admin_passes_require_admin ... ok
+2026-08-01T02:43:40.2948882Z test auth_enforcement::admin_passes_require_manage ... ok
+2026-08-01T02:43:40.2949473Z test auth_enforcement::admin_passes_require_read ... ok
+2026-08-01T02:43:40.2950079Z test auth_enforcement::admin_passes_require_write ... ok
+2026-08-01T02:43:40.2950689Z test auth_enforcement::application_fails_require_admin ... ok
+2026-08-01T02:43:40.2951333Z test auth_enforcement::application_fails_require_manage ... ok
+2026-08-01T02:43:40.2952640Z test auth_enforcement::application_passes_require_read ... ok
+2026-08-01T02:43:40.2953512Z test auth_enforcement::initiator_fails_require_admin ... ok
+2026-08-01T02:43:40.2954247Z test acl_validation::initiator_can_create_reader ... ok
+2026-08-01T02:43:40.2954946Z test auth_enforcement::application_passes_require_write ... ok
+2026-08-01T02:43:40.2955690Z test auth_enforcement::initiator_passes_require_write ... ok
+2026-08-01T02:43:40.2957017Z test auth_enforcement::initiator_fails_require_super_admin ... ok
+2026-08-01T02:43:40.2957582Z test auth_enforcement::initiator_passes_require_manage ... ok
+2026-08-01T02:43:40.2958051Z test auth_enforcement::monitor_fails_require_read ... ok
+2026-08-01T02:43:40.2958575Z test auth_enforcement::reader_fails_require_admin ... ok
+2026-08-01T02:43:40.2958936Z test auth_enforcement::reader_fails_require_manage ... ok
+2026-08-01T02:43:40.2959442Z test auth_enforcement::monitor_fails_require_write ... ok
+2026-08-01T02:43:40.2959881Z test auth_enforcement::reader_fails_require_write ... ok
+2026-08-01T02:43:40.2960491Z test auth_enforcement::scoped_admin_fails_require_super_admin ... ok
+2026-08-01T02:43:40.2960948Z test auth_enforcement::scoped_admin_passes_require_admin ... ok
+2026-08-01T02:43:40.2961332Z test auth_enforcement::reader_passes_require_read ... ok
+2026-08-01T02:43:40.2961883Z test auth_enforcement::super_admin_has_access_to_any_context ... ok
+2026-08-01T02:43:40.2962743Z test auth_enforcement::super_admin_passes_require_super_admin ... ok
+2026-08-01T02:43:40.2963244Z test auth_enforcement::application_restricted_to_allowed_contexts ... ok
+2026-08-01T02:43:40.2963730Z test auth_enforcement::scoped_admin_restricted_to_allowed_contexts ... ok
+2026-08-01T02:43:40.2964492Z test backup_security::backup_rejects_unsupported_version ... ok
+2026-08-01T02:43:42.8221322Z test backup_security::backup_envelope_rejects_wrong_password ... ok
+2026-08-01T02:43:42.8221675Z 
+2026-08-01T02:43:42.8221966Z test result: ok. 34 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.53s
+2026-08-01T02:43:42.8222549Z 
+2026-08-01T02:43:42.8227106Z [1m[92m     Running[0m tests/session_jti_pin.rs (target/debug/deps/session_jti_pin-bb7db26b7d380927)
+2026-08-01T02:43:42.8420041Z 
+2026-08-01T02:43:42.8420407Z running 2 tests
+2026-08-01T02:43:43.1977141Z test matching_jti_authenticates_but_superseded_jti_is_rejected ... ok
+2026-08-01T02:43:43.1977775Z test unpinned_session_accepts_any_jti ... ok
+2026-08-01T02:43:43.1978151Z 
+2026-08-01T02:43:43.1978452Z test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.36s
+2026-08-01T02:43:43.1978920Z 
+2026-08-01T02:43:43.2025569Z [1m[92m     Running[0m tests/sessions_list_trust_task.rs (target/debug/deps/sessions_list_trust_task-6a3ba38dc7e217f4)
+2026-08-01T02:43:43.2255729Z 
+2026-08-01T02:43:43.2256129Z running 2 tests
+2026-08-01T02:43:43.5360876Z test sessions_list_without_bearer_is_unauthorized ... ok
+2026-08-01T02:43:43.5724529Z test sessions_list_returns_only_callers_active_sessions ... ok
+2026-08-01T02:43:43.5725018Z 
+2026-08-01T02:43:43.5725422Z test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.35s
+2026-08-01T02:43:43.5725955Z 
+2026-08-01T02:43:43.5764568Z [1m[92m     Running[0m tests/step_up_approve_response.rs (target/debug/deps/step_up_approve_response-400fe9c987b5c87f)
+2026-08-01T02:43:43.5972869Z 
+2026-08-01T02:43:43.5973203Z running 6 tests
+2026-08-01T02:43:44.0773723Z test trust_task_acl_mutation_requires_step_up ... ok
+2026-08-01T02:43:44.0851323Z test did_signed_approve_response_0_2_elevates_session_to_aal2 ... ok
+2026-08-01T02:43:44.0869089Z test delegated_approve_response_elevates_the_subjects_session ... ok
+2026-08-01T02:43:44.0892669Z test did_signed_approve_response_elevates_session_to_aal2 ... ok
+2026-08-01T02:43:44.3131847Z test unauthorized_approver_cannot_elevate ... ok
+2026-08-01T02:43:44.3509061Z test v0_2_minted_request_completes_with_a_0_1_flavored_response ... ok
+2026-08-01T02:43:44.3509818Z 
+2026-08-01T02:43:44.3510552Z test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.75s
+2026-08-01T02:43:44.3511265Z 
+2026-08-01T02:43:44.3560353Z [1m[92m     Running[0m tests/step_up_policy.rs (target/debug/deps/step_up_policy-aac2e49b00481338)
+2026-08-01T02:43:44.3751729Z 
+2026-08-01T02:43:44.3752283Z running 7 tests
+2026-08-01T02:43:44.8116514Z test enabling_delegated_floor_without_approver_is_lockout_refused ... ok
+2026-08-01T02:43:44.8145219Z test non_super_admin_cannot_set_policy ... ok
+2026-08-01T02:43:44.8154923Z test enabling_delegated_floor_with_an_approver_succeeds ... ok
+2026-08-01T02:43:44.8426966Z test non_super_admin_trust_task_is_not_authorized ... ok
+2026-08-01T02:43:45.0765169Z test trust_task_path_sets_policy ... ok
+2026-08-01T02:43:45.1282365Z test unknown_operation_is_rejected ... ok
+2026-08-01T02:43:45.1284119Z test super_admin_sets_and_reads_self_policy_via_rest ... ok
+2026-08-01T02:43:45.1284484Z 
+2026-08-01T02:43:45.1286157Z test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.75s
+2026-08-01T02:43:45.1286628Z 
+2026-08-01T02:43:45.1344232Z [1m[92m     Running[0m tests/vault_consent.rs (target/debug/deps/vault_consent-d8e66a40c49d49ad)
+2026-08-01T02:43:45.1401611Z 
+2026-08-01T02:43:45.1402282Z running 2 tests
+2026-08-01T02:43:45.1781123Z test expired_consent_authorizes_nothing_end_to_end ... ok
+2026-08-01T02:43:45.2780274Z test consent_lifecycle_end_to_end ... ok
+2026-08-01T02:43:45.2780576Z 
+2026-08-01T02:43:45.2780856Z test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.14s
+2026-08-01T02:43:45.2781211Z 
+2026-08-01T02:43:45.2789476Z [1m[92m     Running[0m tests/vault_present.rs (target/debug/deps/vault_present-581ef9704ce84094)
+2026-08-01T02:43:45.2846121Z 
+2026-08-01T02:43:45.2846326Z running 3 tests
+2026-08-01T02:43:45.3771583Z test present_refused_for_revoked_or_temporally_invalid_credential ... ok
+2026-08-01T02:43:45.3772479Z test present_discloses_only_consented_claims_with_kb_jwt_end_to_end ... ok
+2026-08-01T02:43:45.4102478Z test present_refused_for_missing_withdrawn_and_expired_consent ... ok
+2026-08-01T02:43:45.4102952Z 
+2026-08-01T02:43:45.4103321Z test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.13s
+2026-08-01T02:43:45.4103835Z 
+2026-08-01T02:43:45.4113387Z [1m[92m     Running[0m tests/vault_receive.rs (target/debug/deps/vault_receive-b3bf5586ae81ad02)
+2026-08-01T02:43:45.4167268Z 
+2026-08-01T02:43:45.4167514Z running 3 tests
+2026-08-01T02:43:45.4555967Z test expired_credential_is_rejected_and_not_stored ... ok
+2026-08-01T02:43:45.4556594Z test tampered_credential_is_rejected_and_not_stored ... ok
+2026-08-01T02:43:45.4576736Z test valid_credential_is_stored_and_findable_by_type_and_issuer ... ok
+2026-08-01T02:43:45.4577251Z 
+2026-08-01T02:43:45.4577648Z test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.04s
+2026-08-01T02:43:45.4578197Z 
+2026-08-01T02:43:45.4585736Z [1m[92m     Running[0m tests/vault_trust_task.rs (target/debug/deps/vault_trust_task-e60e8b7ffcffe1fd)
+2026-08-01T02:43:45.4788026Z 
+2026-08-01T02:43:45.4788568Z running 16 tests
+2026-08-01T02:43:45.9608268Z test delete_force_hard_deletes_immediately ... ok
+2026-08-01T02:43:45.9791582Z test archive_hides_and_blocks_then_unarchive_restores ... ok
+2026-08-01T02:43:45.9867361Z test delete_is_recoverable_soft_delete ... ok
+2026-08-01T02:43:46.0107090Z test every_vault_uri_denied_without_capability ... ok
+2026-08-01T02:43:46.3422873Z test get_cross_context_denied_after_load ... ok
+2026-08-01T02:43:46.3703845Z test list_cross_context_denied ... ok
+2026-08-01T02:43:46.3712958Z test list_happy_path_returns_seeded_entry ... ok
+2026-08-01T02:43:46.3714603Z test get_happy_path_returns_entry_metadata ... ok
+2026-08-01T02:43:46.7172707Z test list_without_filter_narrows_to_visible_contexts ... ok
+2026-08-01T02:43:46.8098767Z test proxy_login_reaches_handler_past_gate ... ok
+2026-08-01T02:43:46.8778510Z test purge_is_irreversible ... ok
+2026-08-01T02:43:46.9226835Z test reader_passes_read_gates_but_not_the_others ... ok
+2026-08-01T02:43:47.3668523Z test release_reaches_handler_past_gate ... ok
+2026-08-01T02:43:47.4459428Z test restore_of_active_entry_is_rejected ... ok
+2026-08-01T02:43:47.4467024Z test sign_trust_task_reaches_handler_past_gate ... ok
+2026-08-01T02:43:47.5083356Z test upsert_cross_context_denied ... ok
+2026-08-01T02:43:47.5083753Z 
+2026-08-01T02:43:47.5085010Z test result: ok. 16 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.03s
+2026-08-01T02:43:47.5086005Z 
+2026-08-01T02:43:47.5135286Z [1m[92m     Running[0m tests/vault_unseal_authcrypt.rs (target/debug/deps/vault_unseal_authcrypt-b656dd8d8464f2ad)
+2026-08-01T02:43:47.5542019Z 
+2026-08-01T02:43:47.5542744Z running 1 test
+2026-08-01T02:43:47.7682267Z test plaintext_sealed_secret_is_rejected ... ok
+2026-08-01T02:43:47.7682693Z 
+2026-08-01T02:43:47.7683114Z test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.21s
+2026-08-01T02:43:47.7683713Z 
+2026-08-01T02:43:47.7699333Z [1m[92m     Running[0m tests/whoami_trust_task.rs (target/debug/deps/whoami_trust_task-5b1852f26e66dfd6)
+2026-08-01T02:43:47.8577981Z 
+2026-08-01T02:43:47.8578600Z running 2 tests
+2026-08-01T02:43:48.4001692Z test whoami_without_bearer_is_unauthorized ... ok
+2026-08-01T02:43:48.4364655Z test whoami_reports_live_session_acr_not_stale_token ... ok
+2026-08-01T02:43:48.4364977Z 
+2026-08-01T02:43:48.4365887Z test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.58s
+2026-08-01T02:43:48.4366262Z 
+2026-08-01T02:43:48.4416248Z [1m[92m     Running[0m unittests src/lib.rs (target/debug/deps/vta_support-0976279a8a9705fa)
+2026-08-01T02:43:48.4433271Z 
+2026-08-01T02:43:48.4433515Z running 10 tests
+2026-08-01T02:43:48.4764223Z test contexts::tests::allocate_context_index_is_collision_free_under_concurrency ... ok
+2026-08-01T02:43:48.4765612Z test contexts::tests::validate_slug_accepts_canonical_shapes ... ok
+2026-08-01T02:43:48.4767457Z test contexts::tests::validate_slug_rejects_non_canonical_shapes ... ok
+2026-08-01T02:43:48.4858408Z test contexts::tests::concurrent_same_id_creates_admit_exactly_one ... ok
+2026-08-01T02:43:48.4859806Z test contexts::tests::low_level_create_context_enforces_the_slug_rule ... ok
+2026-08-01T02:43:48.4895271Z test contexts::tests::daily_quota_allows_up_to_limit_then_forbids ... ok
+2026-08-01T02:43:48.4921734Z test seal::tests::read_unseal_state_rejects_missing_super_admin ... ok
+2026-08-01T02:43:48.4986660Z test seal::tests::read_unseal_state_rejects_unsealed_vta ... ok
+2026-08-01T02:43:48.5051391Z test seal::tests::read_unseal_state_releases_lock ... ok
+2026-08-01T02:43:48.5067978Z test seal::tests::remove_seal_marker_is_idempotent ... ok
+2026-08-01T02:43:48.5068409Z 
+2026-08-01T02:43:48.5068816Z test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.06s
+2026-08-01T02:43:48.5069329Z 
+2026-08-01T02:43:48.5078585Z [1m[92m     Running[0m unittests src/lib.rs (target/debug/deps/vta_sweepers-122e69ca9b49a8f4)
+2026-08-01T02:43:48.5095199Z 
+2026-08-01T02:43:48.5095442Z running 3 tests
+2026-08-01T02:43:48.5098863Z test vault_sweeper::tests::purgeable_only_when_deleted_and_past_grace ... ok
+2026-08-01T02:43:48.5218137Z test acl_sweeper::tests::sweeper_handles_empty_keyspace ... ok
+2026-08-01T02:43:48.5229845Z test acl_sweeper::tests::sweeper_deletes_expired_and_preserves_permanent ... ok
+2026-08-01T02:43:48.5230463Z 
+2026-08-01T02:43:48.5230859Z test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
+2026-08-01T02:43:48.5231285Z 
+2026-08-01T02:43:48.5236639Z [1m[92m     Running[0m unittests src/lib.rs (target/debug/deps/vta_tee-1203a4d0568ac88a)
+2026-08-01T02:43:48.5250858Z 
+2026-08-01T02:43:48.5251006Z running 32 tests
+2026-08-01T02:43:48.5254827Z test anchor::tests::writer_credentials_parse_from_sealed_json ... ok
+2026-08-01T02:43:48.5255639Z test anchor::tests::writer_credentials_tolerate_extra_but_require_both ... ok
+2026-08-01T02:43:48.5258205Z test did_autogen::tests::test_template_to_url_domain_only ... ok
+2026-08-01T02:43:48.5259037Z test did_autogen::tests::test_template_to_url_empty_domain ... ok
+2026-08-01T02:43:48.5259913Z test did_autogen::tests::test_template_to_url_invalid_prefix ... ok
+2026-08-01T02:43:48.5260746Z test did_autogen::tests::test_template_to_url_nested_path ... ok
+2026-08-01T02:43:48.5261375Z test did_autogen::tests::test_template_to_url_simple ... ok
+2026-08-01T02:43:48.5262522Z test did_autogen::tests::test_template_to_url_with_port ... ok
+2026-08-01T02:43:48.5263364Z test kms_bootstrap::cms_der::tests::raw_ciphertext_starting_with_0x04_is_not_unwrapped ... ok
+2026-08-01T02:43:48.5264274Z test kms_bootstrap::cms_der::tests::explicit_octet_string_wrapper_is_unwrapped ... ok
+2026-08-01T02:43:48.5265055Z test kms_bootstrap::cms_der::tests::test_read_tlv_long_form ... ok
+2026-08-01T02:43:48.5265733Z test kms_bootstrap::cms_der::tests::test_read_tlv_short_form ... ok
+2026-08-01T02:43:48.5266424Z test kms_bootstrap::cms_der::tests::test_read_tlv_truncated ... ok
+2026-08-01T02:43:48.5267254Z test kms_bootstrap::cms_der::tests::truncated_encrypted_content_errors_without_panicking ... ok
+2026-08-01T02:43:48.5429230Z test kms_bootstrap::cms_der::tests::no_prefix_of_raw_ciphertext_is_mistaken_for_a_wrapper ... ok
+2026-08-01T02:43:48.7233682Z test kms_bootstrap::tests::cms_decrypt_with_tampered_aes_ciphertext_fails ... ok
+2026-08-01T02:43:48.7568954Z test kms_bootstrap::tests::cms_decrypt_with_corrupted_cek_fails ... ok
+2026-08-01T02:43:48.7592775Z test kms_bootstrap::tests::integrity_manifest_key_strings_match ... ok
+2026-08-01T02:43:48.8001672Z test kms_bootstrap::tests::cms_decrypt_with_malformed_pkcs8_fails_cleanly ... ok
+2026-08-01T02:43:48.8012629Z test kms_bootstrap::tests::test_derive_storage_key_deterministic ... ok
+2026-08-01T02:43:48.8017869Z test kms_bootstrap::tests::test_derive_storage_key_different_salts ... ok
+2026-08-01T02:43:48.8019258Z test kms_bootstrap::tests::test_derive_storage_key_different_seeds ... ok
+2026-08-01T02:43:48.8020385Z test kms_bootstrap::tests::test_jwt_fingerprint_deterministic ... ok
+2026-08-01T02:43:48.8021317Z test mnemonic_guard::tests::drop_zeros_entropy ... ok
+2026-08-01T02:43:48.8022507Z test mnemonic_guard::tests::empty_guard_rejects_export_with_no_entropy_message ... ok
+2026-08-01T02:43:48.8023727Z test mnemonic_guard::tests::export_after_window_expired_zeroes_entropy_and_fails ... ok
+2026-08-01T02:43:48.8025016Z test mnemonic_guard::tests::first_export_within_window_succeeds_then_burns_entropy ... ok
+2026-08-01T02:43:48.8026137Z test mnemonic_guard::tests::second_export_after_first_rejected ... ok
+2026-08-01T02:43:48.8027147Z test mnemonic_guard::tests::status_reflects_window_state_correctly ... ok
+2026-08-01T02:43:48.9184837Z test kms_bootstrap::tests::cms_decrypt_with_empty_envelope_fails_cleanly ... ok
+2026-08-01T02:43:49.0260096Z test kms_bootstrap::tests::test_cms_envelope_roundtrip ... ok
+2026-08-01T02:43:49.1627401Z test kms_bootstrap::tests::cms_decrypt_with_wrong_private_key_fails ... ok
+2026-08-01T02:43:49.1627796Z 
+2026-08-01T02:43:49.1628078Z test result: ok. 32 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.64s
+2026-08-01T02:43:49.1628467Z 
+2026-08-01T02:43:49.1632683Z [1m[92m     Running[0m unittests src/lib.rs (target/debug/deps/vta_vault-e8772f0a8b40355a)
+2026-08-01T02:43:49.1653770Z 
+2026-08-01T02:43:49.1653975Z running 92 tests
+2026-08-01T02:43:49.1841384Z test consent::tests::create_rejects_empty_credential_id ... ok
+2026-08-01T02:43:49.1986446Z test consent::tests::consent_is_bound_to_one_credential ... ok
+2026-08-01T02:43:49.1993235Z test consent::tests::authorizes_only_when_given_unexpired_recipient_and_claims_subset ... ok
+2026-08-01T02:43:49.2113229Z test consent::tests::expired_record_authorizes_nothing ... ok
+2026-08-01T02:43:49.2132933Z test consent::tests::proof_by_unrelated_key_is_rejected ... ok
+2026-08-01T02:43:49.2322317Z test consent::tests::create_signs_a_verifiable_record_with_all_fields ... ok
+2026-08-01T02:43:49.2323631Z test index::tests::colon_extended_value_is_not_a_false_prefix_match ... ok
+2026-08-01T02:43:49.2341817Z test index::tests::id_recovered_after_nul_even_when_value_has_colons ... ok
+2026-08-01T02:43:49.2346417Z test index::tests::index_key_layout_is_field_value_nul_id ... ok
+2026-08-01T02:43:49.2349301Z test index::tests::scan_prefix_pins_value_with_nul ... ok
+2026-08-01T02:43:49.2350960Z test mint::tests::empty_disclosable_mints_a_fully_cleartext_vc ... ok
+2026-08-01T02:43:49.2549999Z test consent::tests::tampered_record_fails_proof_on_get ... ok
+2026-08-01T02:43:49.2611894Z test mint::tests::mint_and_store_files_it_into_the_vault_indexed ... ok
+2026-08-01T02:43:49.2723886Z test mint::tests::minted_vc_signature_is_bound_to_the_issuer_key ... ok
+2026-08-01T02:43:49.2725163Z test mint::tests::purpose_for_vct_maps_catalog ... ok
+2026-08-01T02:43:49.2728236Z test mint::tests::rejects_bad_subject_did ... ok
+2026-08-01T02:43:49.2734824Z test mint::tests::rejects_disclosable_claim_not_in_claims ... ok
+2026-08-01T02:43:49.2740594Z test mint::tests::rejects_disclosing_protected_claim ... ok
+2026-08-01T02:43:49.2747541Z test mint::tests::rejects_empty_vct ... ok
+2026-08-01T02:43:49.2748690Z test model::tests::credential_lifecycle_transitions ... ok
+2026-08-01T02:43:49.2761165Z test model::tests::legacy_credential_without_lifecycle_defaults_active ... ok
+2026-08-01T02:43:49.2762557Z test consent::tests::list_is_local_audit_surface_over_consent_namespace ... ok
+2026-08-01T02:43:49.2789293Z test mint::tests::minted_vc_verifies_carries_vct_cnf_and_hides_disclosable_claims ... ok
+2026-08-01T02:43:49.2996688Z test consent::tests::withdraw_flips_latest_status_and_revokes_authority ... ok
+2026-08-01T02:43:49.3224268Z test present::tests::consent_bound_to_another_credential_is_refused ... ok
+2026-08-01T02:43:49.3245288Z test present::tests::consent_by_a_different_holder_cannot_present_anothers_credential ... ok
+2026-08-01T02:43:49.3246583Z test present::tests::expired_consent_record_is_refused ... ok
+2026-08-01T02:43:49.3423432Z test present::tests::missing_consent_record_is_refused ... ok
+2026-08-01T02:43:49.3625268Z test present::tests::missing_credential_is_refused ... ok
+2026-08-01T02:43:49.3782240Z test present::tests::gate_present_live_status_refuses_a_since_revoked_credential ... ok
+2026-08-01T02:43:49.4167462Z test present::tests::never_discloses_beyond_the_consent_reveal_set ... ok
+2026-08-01T02:43:49.4273428Z test present::tests::present_di_vc_refuses_a_non_di_credential ... ok
+2026-08-01T02:43:49.4298738Z test present::tests::kb_jwt_is_bound_to_the_verifier_nonce ... ok
+2026-08-01T02:43:49.4306730Z test present::tests::present_di_vc_produces_a_verifiable_holder_bound_vp ... ok
+2026-08-01T02:43:49.4575532Z test present::tests::present_di_vc_refuses_to_over_disclose ... ok
+2026-08-01T02:43:49.4766856Z test present::tests::recipient_mismatch_is_refused ... ok
+2026-08-01T02:43:49.4802769Z test present::tests::revoked_credential_is_refused ... ok
+2026-08-01T02:43:49.4914313Z test query::tests::active_descriptor_omits_lifecycle_keys ... ok
+2026-08-01T02:43:49.5023262Z test present::tests::temporally_invalid_credential_is_refused ... ok
+2026-08-01T02:43:49.5023789Z test query::tests::descriptors_never_contain_the_body ... ok
+2026-08-01T02:43:49.5024268Z test present::tests::presents_only_consented_claims_with_valid_kb_jwt ... ok
+2026-08-01T02:43:49.5159720Z test query::tests::include_flags_alone_are_not_a_filter ... ok
+2026-08-01T02:43:49.5186182Z test query::tests::include_deleted_surfaces_tombstones_with_grace ... ok
+2026-08-01T02:43:49.5205149Z test query::tests::include_archived_surfaces_archived_rows ... ok
+2026-08-01T02:43:49.5327989Z test query::tests::no_match_returns_empty_not_error ... ok
+2026-08-01T02:43:49.5330618Z test query::tests::multiple_filters_are_and_combined ... ok
+2026-08-01T02:43:49.5372770Z test query::tests::revoked_and_expired_are_excluded_from_search ... ok
+2026-08-01T02:43:49.5466806Z test query::tests::revoked_archived_row_stays_excluded_even_with_include_archived ... ok
+2026-08-01T02:43:49.5508143Z test query::tests::search_by_indexed_field_returns_descriptors ... ok
+2026-08-01T02:43:49.5523889Z test query::tests::search_by_status_filter_surfaces_valid ... ok
+2026-08-01T02:43:49.5552479Z test present::tests::withdrawn_consent_record_is_refused ... ok
+2026-08-01T02:43:49.5609112Z test query::tests::search_matches_any_type_tag ... ok
+2026-08-01T02:43:49.5690393Z test query::tests::unfiltered_query_is_rejected_no_enumeration ... ok
+2026-08-01T02:43:49.5800918Z test receive::tests::credential_signed_by_a_different_key_than_iss_is_rejected ... ok
+2026-08-01T02:43:49.5848857Z test receive::tests::di_vc_expired_is_rejected ... ok
+2026-08-01T02:43:49.5899162Z test receive::tests::di_vc_tampered_is_rejected_and_not_stored ... ok
+2026-08-01T02:43:49.5962888Z test receive::tests::di_vc_verifies_and_stores ... ok
+2026-08-01T02:43:49.5971296Z test receive::tests::extract_types_folds_vct_and_type_arrays ... ok
+2026-08-01T02:43:49.5974045Z test receive::tests::infer_purpose_maps_catalog_types ... ok
+2026-08-01T02:43:49.5974643Z test receive::tests::empty_id_is_rejected ... ok
+2026-08-01T02:43:49.6073394Z test receive::tests::dispatch_routes_di_requires_key_and_gates_bbs ... ok
+2026-08-01T02:43:49.6096845Z test receive::tests::missing_iss_is_rejected ... ok
+2026-08-01T02:43:49.6097984Z test receive::tests::zkp_format_tag_round_trips_as_kebab_case ... ok
+2026-08-01T02:43:49.6099191Z test status::tests::clear_bit_does_not_resurrect_a_time_expired_credential ... ok
+2026-08-01T02:43:49.6122685Z test receive::tests::tampered_signature_is_rejected_and_not_stored ... ok
+2026-08-01T02:43:49.6194016Z test receive::tests::expired_credential_is_rejected_and_not_stored ... ok
+2026-08-01T02:43:49.6252210Z test status::tests::clear_bit_leaves_valid_and_findable ... ok
+2026-08-01T02:43:49.6273232Z test status::tests::credential_without_status_is_not_tracked ... ok
+2026-08-01T02:43:49.6274773Z test status::tests::extract_reads_compact_jws_body ... ok
+2026-08-01T02:43:49.6278089Z test status::tests::extract_reads_sd_jwt_ietf_status_list_shape ... ok
+2026-08-01T02:43:49.6349914Z test status::tests::empty_list_leaves_valid ... ok
+2026-08-01T02:43:49.6356732Z test status::tests::malformed_status_entry_fails_closed ... ok
+2026-08-01T02:43:49.6380630Z test receive::tests::valid_sd_jwt_vc_is_stored_and_indexed ... ok
+2026-08-01T02:43:49.6403248Z test status::tests::entry_purpose_mismatch_is_rejected_and_status_unchanged ... ok
+2026-08-01T02:43:49.6404368Z test status::tests::revocation_is_terminal_but_suspension_is_reversible ... ok
+2026-08-01T02:43:49.6450394Z test status::tests::index_out_of_bounds_is_rejected_and_status_unchanged ... ok
+2026-08-01T02:43:49.6486190Z test status::tests::missing_credential_is_not_found ... ok
+2026-08-01T02:43:49.6505364Z test status::tests::signature::substituted_issuer_is_rejected ... ok
+2026-08-01T02:43:49.6549487Z test status::tests::resolver_error_leaves_status_unchanged ... ok
+2026-08-01T02:43:49.6584367Z test status::tests::signature::unsigned_list_is_rejected ... ok
+2026-08-01T02:43:49.6603272Z test status::tests::set_bit_marks_revoked_and_excludes_from_search ... ok
+2026-08-01T02:43:49.6623408Z test status::tests::signature::no_expected_issuer_still_verifies_the_signature ... ok
+2026-08-01T02:43:49.6674702Z test status::tests::signature::tampered_list_fails_the_signature ... ok
+2026-08-01T02:43:49.6768623Z test storage::tests::body_is_encrypted_at_rest ... ok
+2026-08-01T02:43:49.6770614Z test status::tests::signature::valid_signature_and_matching_issuer_passes ... ok
+2026-08-01T02:43:49.6785958Z test status::tests::suspension_set_then_clear_round_trips_valid ... ok
+2026-08-01T02:43:49.6837460Z test storage::tests::delete_removes_record_and_all_index_rows ... ok
+2026-08-01T02:43:49.6880159Z test storage::tests::empty_id_is_rejected ... ok
+2026-08-01T02:43:49.6928894Z test storage::tests::index_scans_isolate_distinct_credentials ... ok
+2026-08-01T02:43:49.6950327Z test storage::tests::prefix_scan_index_hits_each_indexed_field ... ok
+2026-08-01T02:43:49.6980818Z test storage::tests::store_then_get_by_id_round_trips ... ok
+2026-08-01T02:43:49.7007214Z test storage::tests::update_reindexes_and_drops_stale_rows ... ok
+2026-08-01T02:43:49.7007703Z 
+2026-08-01T02:43:49.7008112Z test result: ok. 92 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.54s
+2026-08-01T02:43:49.7008660Z 
+2026-08-01T02:43:49.7021344Z [1m[92m     Running[0m unittests src/lib.rs (target/debug/deps/vta_webvh-35dfffd132db03ac)
+2026-08-01T02:43:49.7043615Z 
+2026-08-01T02:43:49.7044209Z running 48 tests
+2026-08-01T02:43:49.7082841Z test webvh_auth::tests::authenticate_message_type_is_canonical_spec_uri ... ok
+2026-08-01T02:43:49.7085326Z test webvh_auth::tests::distinct_session_id_or_challenge_produces_distinct_jws ... ok
+2026-08-01T02:43:49.7201748Z test webvh_auth::tests::authenticate_message_round_trips_via_unpack ... ok
+2026-08-01T02:43:49.7203453Z test webvh_auth::tests::authenticate_message_signed_with_wrong_key_fails_unpack ... ok
+2026-08-01T02:43:49.7204691Z test webvh_auth::tests::refresh_message_type_is_distinct_from_authenticate ... ok
+2026-08-01T02:43:49.7206189Z test webvh_auth::tests::refresh_message_type_is_canonical_spec_uri ... ok
+2026-08-01T02:43:49.7207247Z test webvh_auth::tests::authenticate_message_binds_audience_via_to_field ... ok
+2026-08-01T02:43:49.7253449Z test webvh_auth::tests::refresh_message_round_trips ... ok
+2026-08-01T02:43:49.7921531Z test webvh_client::tests::agent_name_bind_surfaces_a_taken_name ... ok
+2026-08-01T02:43:49.7928704Z test webvh_client::tests::agent_name_park_posts_update_with_parked_state ... ok
+2026-08-01T02:43:49.7930130Z test webvh_client::tests::auth_response_without_refresh_token_is_rejected ... ok
+2026-08-01T02:43:49.7931422Z test webvh_client::tests::auth_response_deserializes_flat_daemon_body_and_maps_relative_expiries ... ok
+2026-08-01T02:43:49.7932854Z test webvh_client::tests::agent_name_update_maps_403_to_forbidden ... ok
+2026-08-01T02:43:49.8633082Z test webvh_client::tests::authenticate_401_surfaces_signature_freshness_hint ... ok
+2026-08-01T02:43:49.8649999Z test webvh_client::tests::authenticate_500_yields_internal_not_auth_error ... ok
+2026-08-01T02:43:49.8653360Z test webvh_client::tests::authenticate_403_surfaces_acl_hint ... ok
+2026-08-01T02:43:49.8655131Z test webvh_client::tests::challenge_response_accepts_snake_case_session_id_alias ... ok
+2026-08-01T02:43:49.8657145Z test webvh_client::tests::challenge_response_deserializes_flat_daemon_body ... ok
+2026-08-01T02:43:49.9243389Z test webvh_client::tests::agent_name_op_routes_each_host_task_with_its_state ... ok
+2026-08-01T02:43:49.9272997Z test webvh_client::tests::empty_url_is_rejected ... ok
+2026-08-01T02:43:49.9302976Z test webvh_client::tests::ftp_scheme_is_rejected ... ok
+2026-08-01T02:43:49.9332685Z test webvh_client::tests::http_to_0_0_0_0_is_rejected ... ok
+2026-08-01T02:43:49.9347918Z test webvh_client::tests::authenticate_round_trips_against_mock_daemon ... ok
+2026-08-01T02:43:49.9393256Z test webvh_client::tests::authenticate_uses_camelcase_sessionid_from_daemon ... ok
+2026-08-01T02:43:49.9394330Z test webvh_client::tests::http_to_hostname_resembling_localhost_is_rejected ... ok
+2026-08-01T02:43:49.9421213Z test webvh_client::tests::check_agent_name_reports_reserved_separately ... ok
+2026-08-01T02:43:49.9933316Z test webvh_client::tests::http_to_127_0_0_1_is_accepted ... ok
+2026-08-01T02:43:49.9943056Z test webvh_client::tests::http_to_non_loopback_is_rejected ... ok
+2026-08-01T02:43:50.0013243Z test webvh_client::tests::http_to_127_0_0_x_subnet_is_accepted ... ok
+2026-08-01T02:43:50.0063079Z test webvh_client::tests::http_to_ipv6_loopback_is_accepted ... ok
+2026-08-01T02:43:50.0090586Z test webvh_client::tests::http_to_localhost_is_accepted_for_dev ... ok
+2026-08-01T02:43:50.0582808Z test webvh_client::tests::https_url_is_accepted ... ok
+2026-08-01T02:43:50.0613244Z test webvh_client::tests::https_to_loopback_is_also_accepted ... ok
+2026-08-01T02:43:50.0642524Z test webvh_client::tests::malformed_url_is_rejected ... ok
+2026-08-01T02:43:50.0789485Z test webvh_client::tests::https_url_trailing_slash_is_normalised ... ok
+2026-08-01T02:43:50.0894109Z test webvh_client::tests::list_agent_names_returns_parked_entries ... ok
+2026-08-01T02:43:50.0897641Z test webvh_client::tests::request_uri_response_deserializes_camelcase_daemon_body ... ok
+2026-08-01T02:43:50.0899595Z test webvh_client::tests::token_data_debug_redacts_secret_fields ... ok
+2026-08-01T02:43:50.0901309Z test webvh_client::tests::ws_scheme_is_rejected ... ok
+2026-08-01T02:43:50.0913824Z test webvh_store::tests::auth_record_debug_redacts_secret_fields ... ok
+2026-08-01T02:43:50.0982421Z test webvh_store::tests::auth_record_round_trips_through_keyspace ... ok
+2026-08-01T02:43:50.1086091Z test webvh_store::tests::auth_record_uses_distinct_keyspace_prefix_from_server ... ok
+2026-08-01T02:43:50.1204063Z test webvh_store::tests::delete_server_cascades_to_auth_record ... ok
+2026-08-01T02:43:50.1259674Z test webvh_client::tests::list_agent_names_tolerates_a_host_without_the_field ... ok
+2026-08-01T02:43:50.1313945Z test webvh_store::tests::explicit_delete_server_auth_works_independently ... ok
+2026-08-01T02:43:50.1346873Z test webvh_client::tests::refresh_failure_yields_typed_authentication_error ... ok
+2026-08-01T02:43:50.1369783Z test webvh_store::tests::published_version_marker_round_trips ... ok
+2026-08-01T02:43:50.1393318Z test webvh_client::tests::refresh_returns_rotated_tokens ... ok
+2026-08-01T02:43:50.1393632Z 
+2026-08-01T02:43:50.1393907Z test result: ok. 48 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.43s
+2026-08-01T02:43:50.1394299Z 
+2026-08-01T02:43:50.1412672Z [1m[92m     Running[0m unittests src/lib.rs (target/debug/deps/vtc_client-c137d9ba4edeb658)
+2026-08-01T02:43:50.1431771Z 
+2026-08-01T02:43:50.1431915Z running 7 tests
+2026-08-01T02:43:50.1437291Z test tests::decide_result_deserializes_camel_case ... ok
+2026-08-01T02:43:50.1463028Z test tests::join_request_and_remove_results_deserialize ... ok
+2026-08-01T02:43:50.1492611Z test tests::member_extensions_default_and_parse ... ok
+2026-08-01T02:43:50.1493741Z test tests::member_page_deserializes_from_vtc_shape ... ok
+2026-08-01T02:43:50.1878379Z test tests::policy_admin_methods_without_token_are_not_authenticated ... ok
+2026-08-01T02:43:50.2116752Z test tests::list_members_without_token_is_not_authenticated ... ok
+2026-08-01T02:43:50.2117613Z test tests::admin_methods_without_token_are_not_authenticated ... ok
+2026-08-01T02:43:50.2118025Z 
+2026-08-01T02:43:50.2118428Z test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.07s
+2026-08-01T02:43:50.2118814Z 
+2026-08-01T02:43:50.2129594Z [1m[92m     Running[0m unittests src/lib.rs (target/debug/deps/vtc_service-f1e91f016bf87df4)
+2026-08-01T02:43:50.2300430Z 
+2026-08-01T02:43:50.2300821Z running 701 tests
+2026-08-01T02:43:50.2378057Z test acl::admin::tests::deserialises_legacy_shape_without_extensions ... ok
+2026-08-01T02:43:50.2383106Z test acl::admin::tests::passkey_serialises_to_camel_case ... ok
+2026-08-01T02:43:50.2393407Z test acl::entry::tests::act_scope_decodes_empty_scopes_by_role ... ok
+2026-08-01T02:43:50.2394209Z test acl::entry::tests::act_scope_is_subtree_aware ... ok
+2026-08-01T02:43:50.2452759Z test acl::entry::tests::decodes_legacy_role_admin_wire_shape ... ok
+2026-08-01T02:43:50.2454533Z test acl::entry::tests::is_expired_returns_false_for_permanent_entries ... ok
+2026-08-01T02:43:50.2455741Z test acl::entry::tests::is_expired_returns_true_after_deadline ... ok
+2026-08-01T02:43:50.2459838Z test acl::entry::tests::custom_role_round_trips ... ok
+2026-08-01T02:43:50.2460462Z test acl::entry::tests::round_trip_through_json ... ok
+2026-08-01T02:43:50.2466064Z test acl::role::tests::custom_name_with_colon_does_not_smuggle_admin ... ok
+2026-08-01T02:43:50.2469284Z test acl::role::tests::custom_variant_round_trips ... ok
+2026-08-01T02:43:50.2474096Z test acl::role::tests::custom_constructor_validates_charset ... ok
+2026-08-01T02:43:50.2481665Z test acl::role::tests::deserialise_rejects_custom_with_empty_name ... ok
+2026-08-01T02:43:50.2485100Z test acl::role::tests::deserialise_rejects_custom_with_bad_charset ... ok
+2026-08-01T02:43:50.2486240Z test acl::role::tests::deserialise_rejects_unknown_string ... ok
+2026-08-01T02:43:50.2489374Z test acl::role::tests::from_str_handles_vti_common_admin_wire_shape ... ok
+2026-08-01T02:43:50.2490092Z test acl::role::tests::is_standard_returns_true_only_for_named_variants ... ok
+2026-08-01T02:43:50.2495072Z test acl::role::tests::standard_variants_round_trip_through_wire ... ok
+2026-08-01T02:43:50.2498108Z test acl::role::tests::deserialise_rejects_custom_with_name_too_long ... ok
+2026-08-01T02:43:50.2500310Z test acl::storage::tests::admin_maps_to_admin_role ... ok
+2026-08-01T02:43:50.2501450Z test acl::storage::tests::forbidden_message_carries_no_serde_internals_or_role_name ... ok
+2026-08-01T02:43:50.2668348Z test acl::storage::tests::get_returns_none_for_unknown_did ... ok
+2026-08-01T02:43:50.2677513Z test acl::storage::tests::delete_is_idempotent ... ok
+2026-08-01T02:43:50.2698891Z test acl::storage::tests::non_admin_roles_are_cleanly_forbidden ... ok
+2026-08-01T02:43:50.2699653Z test acl::admin::tests::list_returns_every_admin ... ok
+2026-08-01T02:43:50.2712405Z test acl::admin::tests::round_trip_stores_and_retrieves ... ok
+2026-08-01T02:43:50.2812580Z test acl::storage::tests::list_acl_entries_returns_every_row ... ok
+2026-08-01T02:43:50.2841481Z test acl::storage::tests::resolve_auth_role_admits_admin_with_contexts ... ok
+2026-08-01T02:43:50.2848170Z test acl::storage::tests::resolve_auth_role_forbids_non_admin_absent_and_expired ... ok
+2026-08-01T02:43:50.2851588Z test admin_ui::tests::cache_control_no_cache_for_shell_long_ttl_for_assets ... ok
+2026-08-01T02:43:50.2866586Z test admin_ui::tests::assets_dir_is_embedded ... ok
+2026-08-01T02:43:50.2867865Z test admin_ui::tests::embedded_dir_has_index ... ok
+2026-08-01T02:43:50.2872596Z test admin_ui::tests::lookup_returns_bytes_for_known_files ... ok
+2026-08-01T02:43:50.2874437Z test admin_ui::tests::lookup_returns_none_for_unknown ... ok
+2026-08-01T02:43:50.2892563Z test admin_ui::tests::info_carries_sha_of_index_html ... ok
+2026-08-01T02:43:50.2939687Z test acl::storage::tests::store_then_get_round_trip ... ok
+2026-08-01T02:43:50.3010167Z test acl::storage::tests::paginated_walks_the_keyspace ... ok
+2026-08-01T02:43:50.3064648Z test audit_checkpoint::tests::a_missing_head_envelope_is_reported ... ok
+2026-08-01T02:43:50.3133004Z test audit_checkpoint::tests::a_shortened_log_reports_truncation ... ok
+2026-08-01T02:43:50.3188672Z test audit_checkpoint::tests::an_empty_log_measures_as_genesis ... ok
+2026-08-01T02:43:50.3191633Z test audit_checkpoint::tests::disabled_config_is_representable_and_the_default_is_not_disabled ... ok
+2026-08-01T02:43:50.3221955Z test audit_checkpoint::tests::a_second_tick_with_no_new_entries_emits_nothing ... ok
+2026-08-01T02:43:50.3257093Z test audit_checkpoint::tests::an_unparseable_checkpoint_is_an_error_not_a_skip ... ok
+2026-08-01T02:43:50.3278527Z test auth::credentials::tests::test_generate_did_key_format ... ok
+2026-08-01T02:43:50.3286073Z test auth::credentials::tests::test_generate_did_key_roundtrip ... ok
+2026-08-01T02:43:50.3293438Z test auth::credentials::tests::test_generate_did_key_unique ... ok
+2026-08-01T02:43:50.3300504Z test backup::tests::did_guard_fresh_install_accepts_any ... ok
+2026-08-01T02:43:50.3303055Z test backup::tests::did_guard_matching_accepted ... ok
+2026-08-01T02:43:50.3303765Z test backup::tests::did_guard_mismatch_rejected ... ok
+2026-08-01T02:43:50.3322935Z test audit_checkpoint::tests::a_checkpoint_over_an_empty_log_verifies_and_reports_no_truncation ... ok
+2026-08-01T02:43:50.3387395Z test audit_checkpoint::tests::no_checkpoints_is_reported_as_such_not_as_success ... ok
+2026-08-01T02:43:50.3554894Z test audit_checkpoint::tests::emitting_refuses_when_the_log_shrank_below_a_signed_checkpoint ... ok
+2026-08-01T02:43:54.7630717Z test backup::tests::rejects_bad_format_and_param_bounds ... ok
+2026-08-01T02:43:54.7663350Z test ceremony::effects::tests::deny_plans_no_state_change ... ok
+2026-08-01T02:43:54.7686813Z test ceremony::effects::tests::directory_projection_intersects_fields_with_whitelist ... ok
+2026-08-01T02:43:54.7704115Z test ceremony::effects::tests::directory_projection_omits_absent_facts ... ok
+2026-08-01T02:43:54.7713539Z test ceremony::effects::tests::join_allow_plans_admit ... ok
+2026-08-01T02:43:54.7714985Z test ceremony::effects::tests::join_allow_without_role_errors ... ok
+2026-08-01T02:43:54.7716423Z test ceremony::effects::tests::leave_allow_plans_depart ... ok
+2026-08-01T02:43:54.7718040Z test ceremony::effects::tests::role_change_allow_plans_remint ... ok
+2026-08-01T02:43:54.7885631Z test ceremony::evaluate::tests::allow_branch_parses_into_verdict ... ok
+2026-08-01T02:43:54.7890950Z test ceremony::evaluate::tests::purpose_mismatched_policy_denies ... ok
+2026-08-01T02:43:55.0424330Z test ceremony::evaluate::tests::resource_bound_abort_fails_closed_to_deny ... ok
+2026-08-01T02:43:55.0463494Z test ceremony::evaluate::tests::undefined_decision_degrades_to_host_default_deny ... ok
+2026-08-01T02:43:55.0493238Z test ceremony::evaluate::tests::unmatched_falls_through_to_policy_default_deny ... ok
+2026-08-01T02:43:55.0494497Z test ceremony::facts::tests::credential_status_is_lowercase ... ok
+2026-08-01T02:43:55.0496793Z test ceremony::facts::tests::directory_facts_omit_unused_evidence_slots ... ok
+2026-08-01T02:43:55.0497886Z test ceremony::facts::tests::join_facts_match_design_example ... ok
+2026-08-01T02:43:55.0498781Z test ceremony::facts::tests::purpose_wire_strings_match_catalog ... ok
+2026-08-01T02:43:55.0499702Z test ceremony::invariant::tests::join_admin_grant_is_vetoed ... ok
+2026-08-01T02:43:55.0500558Z test ceremony::invariant::tests::join_member_grant_passes ... ok
+2026-08-01T02:43:55.0501436Z test ceremony::invariant::tests::non_allow_verdicts_pass_through ... ok
+2026-08-01T02:43:55.0502619Z test ceremony::invariant::tests::role_change_admin_with_step_up_passes ... ok
+2026-08-01T02:43:55.0503628Z test ceremony::invariant::tests::role_change_admin_without_step_up_is_vetoed ... ok
+2026-08-01T02:43:55.0504692Z test ceremony::invariant::tests::role_change_non_admin_passes_without_step_up ... ok
+2026-08-01T02:43:55.3346187Z test ceremony::orchestrate::p0_14_role_change_policy_tests::admin_promotion_is_403_when_policy_denies_even_with_step_up ... ok
+2026-08-01T02:43:55.6031224Z test ceremony::orchestrate::p0_14_role_change_policy_tests::admin_promotion_with_step_up_is_allowed_by_default_policy ... ok
+2026-08-01T02:43:55.6059722Z test ceremony::tests::decide_passes_a_well_formed_member_grant ... ok
+2026-08-01T02:43:55.6083335Z test ceremony::tests::decide_returns_policy_deny_untouched ... ok
+2026-08-01T02:43:55.6113003Z test ceremony::tests::decide_vetoes_a_join_policy_that_grants_admin ... ok
+2026-08-01T02:43:55.6143560Z test ceremony::verdict::tests::default_deny_decision_shape ... ok
+2026-08-01T02:43:55.6163549Z test ceremony::verdict::tests::join_allow_round_trips_against_example_rego ... ok
+2026-08-01T02:43:55.6169747Z test ceremony::verdict::tests::leave_allow_uses_disposition ... ok
+2026-08-01T02:43:55.6174041Z test ceremony::verdict::tests::malformed_decision_is_internal_error ... ok
+2026-08-01T02:43:55.6177076Z test ceremony::verdict::tests::refer_to_queue ... ok
+2026-08-01T02:43:55.6178969Z test ceremony::verdict::tests::request_more_carries_needs_and_pd ... ok
+2026-08-01T02:43:55.6186346Z test ceremony::verify::tests::empty_evidence_passes_the_gate ... ok
+2026-08-01T02:43:55.6193740Z test ceremony::verify::tests::revoked_but_verified_credential_passes_the_gate ... ok
+2026-08-01T02:43:55.6197054Z test ceremony::verify::tests::unverified_invitation_is_rejected ... ok
+2026-08-01T02:43:55.6199229Z test ceremony::verify::tests::unverified_presentation_is_rejected ... ok
+2026-08-01T02:43:55.6203800Z test ceremony::verify::tests::verified_presentation_passes ... ok
+2026-08-01T02:43:55.6206692Z test community::profile::tests::apply_changes_only_returned_fields ... ok
+2026-08-01T02:43:55.6209284Z test community::profile::tests::apply_handles_optional_field_clears ... ok
+2026-08-01T02:43:55.6213340Z test community::profile::tests::apply_no_fields_yields_empty_changeset ... ok
+2026-08-01T02:43:55.6214846Z test community::profile::tests::apply_omits_unchanged_value_from_changeset ... ok
+2026-08-01T02:43:55.6215943Z test community::profile::tests::extensions_at_limit_apply ... ok
+2026-08-01T02:43:55.6217054Z test community::profile::tests::extensions_over_limit_rejected_with_validation_error ... ok
+2026-08-01T02:43:55.6218192Z test community::profile::tests::extensions_under_limit_apply ... ok
+2026-08-01T02:43:55.6259967Z test community::profile::tests::load_returns_none_when_not_initialised ... ok
+2026-08-01T02:43:55.6273187Z test community::profile::tests::profile_default_language_is_en ... ok
+2026-08-01T02:43:55.6275200Z test community::profile::tests::rejects_non_http_logo_url_but_accepts_https ... ok
+2026-08-01T02:43:55.6279996Z test community::profile::tests::rejects_oversized_text_fields ... ok
+2026-08-01T02:43:55.6366362Z test community::profile::tests::store_then_load_round_trips ... ok
+2026-08-01T02:43:55.6373497Z test config::tests::community_name_alias_is_accepted ... ok
+2026-08-01T02:43:55.6401378Z test config::tests::config_round_trip_preserves_fields ... ok
+2026-08-01T02:43:55.6404197Z test config::tests::empty_toml_parses_with_all_defaults ... ok
+2026-08-01T02:43:55.6416622Z test config::tests::invalid_toml_produces_config_error ... ok
+2026-08-01T02:43:55.6432860Z test config::tests::minimal_toml_parses ... ok
+2026-08-01T02:43:55.6439886Z test config::tests::secret_backend_omitted_is_none ... ok
+2026-08-01T02:43:55.6440826Z test config::tests::secret_backend_selector_parses_each_variant ... ok
+2026-08-01T02:43:55.6443751Z test config::tests::secret_backend_unknown_is_rejected ... ok
+2026-08-01T02:43:55.6444565Z test config::tests::secrets_config_debug_redacts_secret ... ok
+2026-08-01T02:43:55.6447645Z test config::tests::secrets_config_keyring_service_defaults_to_vtc ... ok
+2026-08-01T02:43:55.6450952Z test config::tests::secrets_known_keys_still_parse ... ok
+2026-08-01T02:43:55.6453228Z test config::tests::secrets_unknown_key_is_a_named_parse_error ... ok
+2026-08-01T02:43:55.6454161Z test config::tests::server_port_bounds ... ok
+2026-08-01T02:43:55.6455004Z test config::tests::vtc_name_canonical_field_is_accepted ... ok
+2026-08-01T02:43:55.6553150Z test config_store::tests::apply_overrides_db_beats_toml ... ok
+2026-08-01T02:43:55.6691270Z test config_store::tests::apply_overrides_ignores_out_of_range_port ... ok
+2026-08-01T02:43:55.6807880Z test config_store::tests::apply_overrides_preserves_toml_when_no_db_override ... ok
+2026-08-01T02:43:55.6922382Z test config_store::tests::apply_overrides_public_url_db_beats_toml_and_preserves_toml ... ok
+2026-08-01T02:43:55.7010594Z test config_store::tests::apply_overrides_public_url_unset_stays_none ... ok
+2026-08-01T02:43:55.7115491Z test config_store::tests::apply_overrides_writes_db_layer_into_config ... ok
+2026-08-01T02:43:55.7257864Z test config_store::tests::db_layer_beats_toml ... ok
+2026-08-01T02:43:55.7351362Z test config_store::tests::delete_removes_value ... ok
+2026-08-01T02:43:55.7462961Z test config_store::tests::effective_returns_defaults_when_no_overrides ... ok
+2026-08-01T02:43:55.7569468Z test config_store::tests::put_then_get_returns_value ... ok
+2026-08-01T02:43:55.7656891Z test config_store::tests::requires_restart_flag_propagates_from_registry ... ok
+2026-08-01T02:43:55.7781025Z test config_store::tests::snapshot_returns_all_overrides ... ok
+2026-08-01T02:43:55.7924413Z test config_store::tests::toml_layer_used_when_no_db_override ... ok
+2026-08-01T02:43:55.7953171Z test config_store::tests::validate_string_enum_kind ... ok
+2026-08-01T02:43:55.7954476Z test config_store::tests::validate_string_kind ... ok
+2026-08-01T02:43:55.8012678Z test config_store::tests::validate_u64_kind ... ok
+2026-08-01T02:43:55.8133320Z test credentials::custom_endorsement::tests::builds_signs_and_verifies ... ok
+2026-08-01T02:43:55.8134412Z test credentials::custom_endorsement::tests::rejects_empty_type ... ok
+2026-08-01T02:43:55.8135215Z test credentials::custom_endorsement::tests::rejects_non_object_claim ... ok
+2026-08-01T02:43:55.8136585Z test credentials::custom_endorsement::tests::rejects_oversized_claim ... ok
+2026-08-01T02:43:55.8153246Z test credentials::delivery::tests::issue_message_body_matches_the_vta_receive_shape ... ok
+2026-08-01T02:43:55.8443809Z test credentials::dtg::tests::credential_status_is_inside_the_signed_bytes ... ok
+2026-08-01T02:43:55.8463480Z test credentials::dtg::tests::into_typed_maps_malformed_json_to_kind_tagged_internal ... ok
+2026-08-01T02:43:55.8673610Z test credentials::dtg::tests::invitation_issues_to_a_non_member_and_verifies ... ok
+2026-08-01T02:43:55.8823247Z test credentials::dtg::tests::membership_issues_with_catalog_shape_and_verifies ... ok
+2026-08-01T02:43:55.8863405Z test credentials::dtg::tests::personhood_membership_adds_type ... ok
+2026-08-01T02:43:55.9026969Z test credentials::dtg::tests::role_vec_preserves_recognition_endorsement_shape ... ok
+2026-08-01T02:43:55.9032995Z test credentials::exchange::tests::flatten_vp_token_shreds_the_dcql_envelope_shapes ... ok
+2026-08-01T02:43:55.9057209Z test credentials::exchange::tests::gen_fuzz_seed_corpus ... ignored, fixture generator — run on demand to refresh fuzz/seeds
+2026-08-01T02:43:55.9197126Z test credentials::exchange::tests::issues_to_the_bound_holder ... ok
+2026-08-01T02:43:55.9483738Z test credentials::exchange::tests::make_offer_then_redeem_delivers_and_consumes ... ok
+2026-08-01T02:43:55.9489636Z test credentials::exchange::tests::offer_is_pre_authorized ... ok
+2026-08-01T02:43:55.9523098Z test credentials::exchange::tests::parse_core_extracts_a_well_formed_presentation_without_io ... ok
+2026-08-01T02:43:55.9534130Z test credentials::exchange::tests::parse_core_refuses_an_unbound_presentation ... ok
+2026-08-01T02:43:55.9542928Z test credentials::exchange::tests::parse_core_rejects_garbage_without_panicking ... ok
+2026-08-01T02:43:55.9935212Z test credentials::exchange::tests::redeem_refuses_wrong_holder_without_burning_the_offer ... ok
+2026-08-01T02:43:56.0079368Z test credentials::exchange::tests::redeem_rejects_an_expired_offer ... ok
+2026-08-01T02:43:56.0172297Z test credentials::exchange::tests::redeem_rejects_unknown_code ... ok
+2026-08-01T02:43:56.0193744Z test credentials::exchange::tests::refuses_a_non_did_key_holder_proof_for_now ... ok
+2026-08-01T02:43:56.0328913Z test credentials::exchange::tests::refuses_a_proof_for_another_audience ... ok
+2026-08-01T02:43:56.0353867Z test credentials::exchange::tests::refuses_a_request_with_no_proof ... ok
+2026-08-01T02:43:56.0526823Z test credentials::exchange::tests::refuses_a_stale_proof ... ok
+2026-08-01T02:43:56.0544694Z test credentials::exchange::tests::refuses_a_tampered_signature ... ok
+2026-08-01T02:43:56.0723367Z test credentials::exchange::tests::refuses_when_the_proof_binds_a_different_holder ... ok
+2026-08-01T02:43:56.0913214Z test credentials::exchange::tests::rejects_a_tampered_issuer_signature ... ok
+2026-08-01T02:43:56.1493485Z test credentials::exchange::tests::rejects_a_wrong_nonce_or_audience ... ok
+2026-08-01T02:43:56.1793181Z test credentials::exchange::tests::rejects_an_expired_presentation ... ok
+2026-08-01T02:43:56.1821909Z test credentials::exchange::tests::rejects_an_unbound_presentation_without_a_kb_jwt ... ok
+2026-08-01T02:43:56.1951717Z test credentials::exchange::tests::sweep_expired_pending_removes_only_expired ... ok
+2026-08-01T02:43:56.2114880Z test credentials::exchange::tests::verifies_a_fresh_holder_proof ... ok
+2026-08-01T02:43:56.2433447Z test credentials::exchange::tests::verifies_a_well_formed_presentation ... ok
+2026-08-01T02:43:56.2783174Z test credentials::exchange::tests::verify_vp_token_accepts_a_bare_string ... ok
+2026-08-01T02:43:56.3083168Z test credentials::exchange::tests::verify_vp_token_propagates_a_wrong_nonce ... ok
+2026-08-01T02:43:56.3263241Z test credentials::exchange::tests::verify_vp_token_rejects_a_di_vc_signed_outside_its_issuer ... ok
+2026-08-01T02:43:56.3438614Z test credentials::exchange::tests::verify_vp_token_rejects_a_di_vp_with_a_tampered_claim ... ok
+2026-08-01T02:43:56.3644047Z test credentials::exchange::tests::verify_vp_token_rejects_a_di_vp_with_a_wrong_nonce ... ok
+2026-08-01T02:43:56.3682999Z test credentials::exchange::tests::verify_vp_token_rejects_an_empty_object ... ok
+2026-08-01T02:43:56.4259519Z test credentials::exchange::tests::verify_vp_token_rejects_mixed_holders ... ok
+2026-08-01T02:43:56.4903335Z test credentials::exchange::tests::verify_vp_token_verifies_a_dcql_map ... ok
+2026-08-01T02:43:56.5213954Z test credentials::exchange::tests::verify_vp_token_verifies_a_w3c_di_vp ... ok
+2026-08-01T02:43:56.6387218Z test credentials::invitation::tests::issues_a_revocable_vic_and_burns_a_slot ... ok
+2026-08-01T02:43:56.6513813Z test credentials::invitation::tests::refuses_when_revocation_list_not_provisioned ... ok
+2026-08-01T02:43:56.7632731Z test credentials::invitation::tests::registered_schema_is_enforced_and_slot_not_burned_on_violation ... ok
+2026-08-01T02:43:56.7726340Z test credentials::invitation_registry::tests::round_trip_and_list_newest_first ... ok
+2026-08-01T02:43:56.7729059Z test credentials::invitation_verify::tests::extract_invitation_absent_is_none ... ok
+2026-08-01T02:43:56.7732019Z test credentials::invitation_verify::tests::extract_invitation_finds_the_vic ... ok
+2026-08-01T02:43:56.7734326Z test credentials::invitation_verify::tests::malformed_vp_credentials_flags_only_structural_defects ... ok
+2026-08-01T02:43:56.7766577Z test credentials::invitation_verify::tests::rejects_expired_vic ... ok
+2026-08-01T02:43:56.7953394Z test credentials::invitation_verify::tests::rejects_revoked_vic ... ok
+2026-08-01T02:43:56.8133334Z test credentials::invitation_verify::tests::rejects_tampered_signature ... ok
+2026-08-01T02:43:56.8163044Z test credentials::invitation_verify::tests::rejects_wrong_subject_binding ... ok
+2026-08-01T02:43:56.8343232Z test credentials::invitation_verify::tests::self_issued_vic_verifies_and_is_trusted ... ok
+2026-08-01T02:43:56.8344324Z test credentials::invitation_verify::tests::subject_linkage_absent_is_rejected ... ok
+2026-08-01T02:43:56.8523397Z test credentials::invitation_verify::tests::subject_linkage_authorizes_a_different_presenter ... ok
+2026-08-01T02:43:56.8643424Z test credentials::invitation_verify::tests::subject_linkage_rejects_a_different_presenter_than_signed ... ok
+2026-08-01T02:43:56.8853273Z test credentials::invitation_verify::tests::third_party_issuer_is_untrusted_without_registry ... ok
+2026-08-01T02:43:56.9003285Z test credentials::invitation_verify::tests::third_party_issuer_trusted_via_registry ... ok
+2026-08-01T02:43:56.9172831Z test credentials::invitation_verify::tests::unresolvable_status_fails_closed ... ok
+2026-08-01T02:43:56.9278877Z test credentials::present_challenge::tests::consume_is_single_use ... ok
+2026-08-01T02:43:56.9377489Z test credentials::present_challenge::tests::consume_rejects_an_expired_challenge ... ok
+2026-08-01T02:43:56.9490972Z test credentials::present_challenge::tests::consume_rejects_an_unknown_thread ... ok
+2026-08-01T02:43:56.9645373Z test credentials::present_challenge::tests::issue_then_consume_round_trips ... ok
+2026-08-01T02:43:56.9783779Z test credentials::present_challenge::tests::sweep_expired_removes_only_expired ... ok
+2026-08-01T02:43:56.9786475Z test credentials::signer::tests::assertion_method_id_is_did_hash_fragment ... ok
+2026-08-01T02:43:56.9787652Z test credentials::signer::tests::different_seeds_produce_different_public_keys ... ok
+2026-08-01T02:43:56.9788721Z test credentials::signer::tests::from_seed_constructs_with_canonical_kid ... ok
+2026-08-01T02:43:57.0593344Z test credentials::vec::tests::role_vec_round_trips_for_each_standard_role ... ok
+2026-08-01T02:43:57.0773315Z test credentials::vec::tests::role_vec_tampered_role_invalidates_proof ... ok
+2026-08-01T02:43:57.0922985Z test credentials::vmc::tests::vmc_happy_path_verifies ... ok
+2026-08-01T02:43:57.0982882Z test credentials::vmc::tests::vmc_personhood_adds_personhood_type ... ok
+2026-08-01T02:43:57.1103276Z test credentials::vmc::tests::vmc_status_ref_serialises_into_credential_status ... ok
+2026-08-01T02:43:57.1279897Z test credentials::vmc::tests::vmc_tampered_subject_invalidates_proof ... ok
+2026-08-01T02:43:57.1282285Z test credentials::vmc::tests::vmc_valid_until_pinned_to_validity_window ... ok
+2026-08-01T02:43:57.1426040Z test endorsement_types::storage::tests::delete_clears_row ... ok
+2026-08-01T02:43:57.1591080Z test endorsement_types::storage::tests::keys_with_overlapping_prefixes_round_trip ... ok
+2026-08-01T02:43:57.1749977Z test endorsement_types::storage::tests::list_paginates_alphabetically ... ok
+2026-08-01T02:43:57.1883449Z test endorsement_types::storage::tests::round_trip_with_colons_and_slashes ... ok
+2026-08-01T02:43:57.2065734Z test endorsement_types::storage::tests::type_exists_is_fast_lookup ... ok
+2026-08-01T02:43:57.2241919Z test endorsements::storage::tests::count_live_by_type_excludes_revoked ... ok
+2026-08-01T02:43:57.2383852Z test endorsements::storage::tests::delete_is_idempotent ... ok
+2026-08-01T02:43:57.2583100Z test endorsements::storage::tests::list_paginates ... ok
+2026-08-01T02:43:57.2723549Z test endorsements::storage::tests::mark_revoked_returns_none_for_unknown_id ... ok
+2026-08-01T02:43:57.2855857Z test endorsements::storage::tests::mark_revoked_sets_timestamp ... ok
+2026-08-01T02:43:57.3015742Z test endorsements::storage::tests::round_trip ... ok
+2026-08-01T02:43:57.3200549Z test holder_signature::tests::empty_tag_matches_pre_prefixed_payload ... ok
+2026-08-01T02:43:57.3201847Z test holder_signature::tests::non_did_key_and_garbage_sig_rejected ... ok
+2026-08-01T02:43:57.3350191Z test holder_signature::tests::round_trip_verifies ... ok
+2026-08-01T02:43:57.3524150Z test holder_signature::tests::wrong_domain_tag_rejected ... ok
+2026-08-01T02:43:57.3680064Z test holder_signature::tests::wrong_signer_rejected ... ok
+2026-08-01T02:43:57.3933472Z test hooks::tests::boot_recovery_flips_in_flight_back_to_pending ... ok
+2026-08-01T02:43:57.4196120Z test hooks::tests::idempotent_success_completes_the_job ... ok
+2026-08-01T02:43:57.4695325Z test hooks::tests::member_added_grants_only_mapped_roles ... ok
+2026-08-01T02:43:57.4966563Z test hooks::tests::member_removed_revokes_every_mapped_resource ... ok
+2026-08-01T02:43:57.5219292Z test hooks::tests::rejection_is_terminal_and_loud ... ok
+2026-08-01T02:43:57.5461349Z test hooks::tests::revokes_retry_past_the_grant_budget_grants_do_not ... ok
+2026-08-01T02:43:57.5728904Z test hooks::tests::role_change_enqueues_revoke_then_grant_in_order ... ok
+2026-08-01T02:43:57.5998023Z test hooks::tests::tail_walk_is_cursor_deduplicated_and_dispatch_drains ... ok
+2026-08-01T02:43:57.6013474Z test hooks::writer::tests::pending_replies_correlate_by_thread_id ... ok
+2026-08-01T02:43:57.6171295Z test hooks::writer::tests::signed_document_verifies_against_the_vtc_key ... ok
+2026-08-01T02:43:57.6193221Z test hooks::writer::tests::write_is_transient_when_messaging_is_not_up ... ok
+2026-08-01T02:43:57.6222923Z test install::claim_secret::tests::generate_produces_distinct_codes ... ok
+2026-08-01T02:43:57.6223954Z test install::claim_secret::tests::generate_uses_unambiguous_alphabet_and_correct_length ... ok
+2026-08-01T02:43:59.1298291Z test backup::tests::wrong_password_fails ... ok
+2026-08-01T02:43:59.3118791Z test backup::tests::roundtrip ... ok
+2026-08-01T02:43:59.3124265Z test install::claim_secret::tests::verify_errors_on_malformed_hash ... ok
+2026-08-01T02:43:59.4161351Z test backup::tests::tampered_ciphertext_detected ... ok
+2026-08-01T02:43:59.4336501Z test install::state_machine::tests::claim_secret_hash_is_surfaced_in_outcome ... ok
+2026-08-01T02:43:59.4536344Z test install::state_machine::tests::expired_token_rejected_on_finish ... ok
+2026-08-01T02:43:59.4734887Z test install::state_machine::tests::expired_token_rejected_on_start ... ok
+2026-08-01T02:43:59.4951682Z test install::state_machine::tests::finish_preserves_admin_did_in_consumed_row ... ok
+2026-08-01T02:43:59.4993024Z test install::state_machine::tests::issued_row_without_hash_field_deserializes ... ok
+2026-08-01T02:43:59.5665598Z test install::state_machine::tests::issued_token_is_encrypted_on_disk ... ok
+2026-08-01T02:43:59.6144602Z test install::state_machine::tests::legacy_plaintext_token_survives_migration ... ok
+2026-08-01T02:43:59.6355166Z test install::state_machine::tests::missing_token_returns_unauthorized ... ok
+2026-08-01T02:43:59.6613325Z test install::state_machine::tests::no_hash_when_token_minted_without_secret ... ok
+2026-08-01T02:43:59.6792562Z test install::claim_secret::tests::hash_and_verify_round_trip ... ok
+2026-08-01T02:43:59.6834571Z test install::state_machine::tests::peek_secret_hash_does_not_set_claim_lock ... ok
+2026-08-01T02:43:59.6988319Z test install::state_machine::tests::peek_secret_hash_none_for_no_secret_consumed_and_missing ... ok
+2026-08-01T02:43:59.7061754Z test install::state_machine::tests::retry_after_window_succeeds ... ok
+2026-08-01T02:43:59.7174016Z test install::state_machine::tests::second_concurrent_start_within_window_is_rejected ... ok
+2026-08-01T02:43:59.7203024Z test install::state_machine::tests::state_machine_serde_round_trip ... ok
+2026-08-01T02:43:59.7233514Z test install::token::tests::cnonce_is_32_bytes_base64url ... ok
+2026-08-01T02:43:59.7242834Z test install::token::tests::different_seeds_produce_disjoint_keys ... ok
+2026-08-01T02:43:59.7263310Z test install::state_machine::tests::start_then_finish_consumes_token ... ok
+2026-08-01T02:43:59.7292730Z test install::token::tests::expired_token_is_rejected ... ok
+2026-08-01T02:43:59.7313107Z test install::token::tests::epubkey_is_32_bytes_base64url ... ok
+2026-08-01T02:43:59.7315294Z test install::token::tests::round_trip_returns_same_claims ... ok
+2026-08-01T02:43:59.7316512Z test install::token::tests::tampered_signature_is_rejected ... ok
+2026-08-01T02:43:59.7317408Z test install::token::tests::wrong_audience_is_rejected ... ok
+2026-08-01T02:43:59.7319256Z test install::token::tests::wrong_subject_is_rejected ... ok
+2026-08-01T02:44:00.2684482Z test join::invitation_e2e_test::vic_bound_to_another_did_cannot_be_redeemed ... ok
+2026-08-01T02:44:00.2753551Z test join::orchestrate::tests::presentation_from_vp_does_not_present_unverified_vc_claims ... ok
+2026-08-01T02:44:00.2754753Z test join::orchestrate::tests::presentation_from_vp_with_no_embedded_vcs_is_holder_binding_only ... ok
+2026-08-01T02:44:00.3005425Z test join::orchestrate::tests::sign_then_verify_round_trip ... ok
+2026-08-01T02:44:00.3043227Z test join::orchestrate::tests::verify_rejects_garbage_signature ... ok
+2026-08-01T02:44:00.3103128Z test join::orchestrate::tests::verify_rejects_non_did_key_applicant ... ok
+2026-08-01T02:44:00.3335869Z test join::orchestrate::tests::verify_rejects_tampered_audience ... ok
+2026-08-01T02:44:00.3463572Z test join::invitation_e2e_test::vic_presented_in_vp_auto_admits_and_is_consumed ... ok
+2026-08-01T02:44:00.3731777Z test join::orchestrate::tests::verify_rejects_tampered_payload ... ok
+2026-08-01T02:44:00.3743415Z test join::orchestrate::tests::verify_rejects_wrong_signer ... ok
+2026-08-01T02:44:00.3892828Z test join::retention::tests::sweep_does_not_purge_approved_rows ... ok
+2026-08-01T02:44:00.3986981Z test join::retention::tests::sweep_all_purges_every_stale_kind_and_keeps_fresh ... ok
+2026-08-01T02:44:00.4081629Z test join::retention::tests::sweep_purges_old_rejected_rows ... ok
+2026-08-01T02:44:00.4158301Z test join::retention::tests::sweep_purges_old_withdrawn_rows ... ok
+2026-08-01T02:44:00.4173584Z test join::storage::tests::join_status_lowercase_wire ... ok
+2026-08-01T02:44:00.4217392Z test join::storage::tests::delete_is_idempotent ... ok
+2026-08-01T02:44:00.4368666Z test join::storage::tests::round_trip ... ok
+2026-08-01T02:44:00.4403067Z test join::storage::tests::list_returns_every_request ... ok
+2026-08-01T02:44:00.4433327Z test join::tests::join_request_new_uses_pending_status ... ok
+2026-08-01T02:44:00.4434217Z test join::tests::join_status_display_is_lowercase ... ok
+2026-08-01T02:44:00.4447582Z test join::tests::join_status_terminal_retainable_only_for_rejected_and_withdrawn ... ok
+2026-08-01T02:44:00.4448603Z test join::tests::join_transport_str_round_trip ... ok
+2026-08-01T02:44:00.4450912Z test keys::seed_store::tests::aws_set_without_feature_is_config_error ... ok
+2026-08-01T02:44:00.4453899Z test keys::seed_store::tests::azure_set_without_feature_is_config_error ... ok
+2026-08-01T02:44:00.4455229Z test keys::seed_store::tests::config_secret_set_without_feature_is_config_error ... ok
+2026-08-01T02:44:00.4456974Z test keys::seed_store::tests::explicit_aws_uncompiled_is_config_error ... ok
+2026-08-01T02:44:00.4459003Z test keys::seed_store::tests::explicit_backend_overrides_a_stray_implicit_field ... ok
+2026-08-01T02:44:00.4463757Z test keys::seed_store::tests::explicit_backend_uncompiled_is_config_error ... ok
+2026-08-01T02:44:00.4465946Z test keys::seed_store::tests::explicit_keyring_selects_keyring ... ok
+2026-08-01T02:44:00.4470840Z test keys::seed_store::tests::explicit_plaintext_selects_plaintext ... ok
+2026-08-01T02:44:00.4472780Z test keys::seed_store::tests::gcp_set_without_feature_is_config_error ... ok
+2026-08-01T02:44:00.4504500Z test keys::seed_store::tests::k8s_set_without_feature_is_config_error ... ok
+2026-08-01T02:44:00.4533643Z test keys::seed_store::tests::no_backend_set_falls_through_to_the_default ... ok
+2026-08-01T02:44:00.4567689Z test keys::seed_store::tests::vault_set_without_feature_is_config_error ... ok
+2026-08-01T02:44:00.4693065Z test members::storage::tests::delete_is_idempotent ... ok
+2026-08-01T02:44:00.4693920Z test members::storage::tests::disposition_default_is_policy_default ... ok
+2026-08-01T02:44:00.4724602Z test members::storage::tests::disposition_purge_resolves_to_itself ... ok
+2026-08-01T02:44:00.4740506Z test join::storage::tests::vp_size_limit_enforced ... ok
+2026-08-01T02:44:00.4849231Z test members::storage::tests::extensions_size_limit_enforced ... ok
+2026-08-01T02:44:00.4856528Z test members::storage::tests::member_backward_compat_pre_phase4_row_deserialises ... ok
+2026-08-01T02:44:00.4861957Z test members::storage::tests::member_round_trips_through_json_with_camel_case_fields ... ok
+2026-08-01T02:44:00.4865334Z test members::storage::tests::member_round_trips_with_personhood_asserted ... ok
+2026-08-01T02:44:00.4885386Z test members::storage::tests::list_returns_every_member ... ok
+2026-08-01T02:44:00.5100530Z test members::storage::tests::round_trip_through_keyspace ... ok
+2026-08-01T02:44:00.5106979Z test messaging::tests::app_error_maps_to_typed_problem_report_codes ... ok
+2026-08-01T02:44:00.5115597Z test messaging::tests::problem_report_body_is_code_and_comment ... ok
+2026-08-01T02:44:00.5116644Z test messaging::tests::problem_report_details_extracts_code_comment_and_args ... ok
+2026-08-01T02:44:00.5163232Z test messaging::tests::problem_report_details_marks_missing_fields ... ok
+2026-08-01T02:44:00.5196798Z test policy::default::tests::cross_community_relationships_default_denies_everything ... ok
+2026-08-01T02:44:00.5233011Z test policy::default::tests::cross_community_roles_default_denies_everything ... ok
+2026-08-01T02:44:00.5234676Z test policy::default::tests::defaults_cover_every_purpose ... ok
+2026-08-01T02:44:00.5235544Z test policy::default::tests::directory_default_projects_fields_by_viewer_role ... ok
+2026-08-01T02:44:00.5293277Z test members::storage::tests::paginated_walks_members ... ok
+2026-08-01T02:44:00.5297657Z test policy::default::tests::every_default_compiles ... ok
+2026-08-01T02:44:00.5744244Z test policy::default::tests::install_defaults_preserves_operator_policies ... ok
+2026-08-01T02:44:00.5776606Z test policy::default::tests::install_defaults_is_idempotent ... ok
+2026-08-01T02:44:00.5803347Z test policy::default::tests::join_default_admits_on_trusted_credential ... ok
+2026-08-01T02:44:00.5833048Z test policy::default::tests::join_default_admits_on_valid_invitation ... ok
+2026-08-01T02:44:00.5864103Z test policy::default::tests::join_default_grants_invited_role ... ok
+2026-08-01T02:44:00.5893240Z test policy::default::tests::join_default_invitation_without_role_scope_grants_member ... ok
+2026-08-01T02:44:00.5913258Z test policy::default::tests::join_default_refers_on_consumed_invitation ... ok
+2026-08-01T02:44:00.5924278Z test policy::default::tests::join_default_refers_on_untrusted_invitation_issuer ... ok
+2026-08-01T02:44:00.5945987Z test policy::default::tests::join_default_refers_without_trusted_credential ... ok
+2026-08-01T02:44:00.5953697Z test policy::default::tests::personhood_default_allows_witness_credential_with_issuer ... ok
+2026-08-01T02:44:00.5988165Z test policy::default::tests::personhood_default_denies_empty_input ... ok
+2026-08-01T02:44:00.6023044Z test policy::default::tests::personhood_default_denies_vp_without_witness_credential ... ok
+2026-08-01T02:44:00.6025040Z test policy::default::tests::personhood_default_denies_witness_credential_with_empty_issuer ... ok
+2026-08-01T02:44:00.6052958Z test policy::default::tests::personhood_default_renewal_denies_when_current_false_no_evidence ... ok
+2026-08-01T02:44:00.6082802Z test policy::default::tests::personhood_default_preserves_current_true_on_renewal ... ok
+2026-08-01T02:44:00.6102662Z test policy::default::tests::registry_default_publishes_on_join_with_tombstone_default ... ok
+2026-08-01T02:44:00.6113189Z test policy::default::tests::relationships_default_requires_both_parties_current ... ok
+2026-08-01T02:44:00.6114239Z test policy::default::tests::removal_default_allows_self_leave ... ok
+2026-08-01T02:44:00.6115261Z test policy::default::tests::removal_default_allows_admin_removing_member ... ok
+2026-08-01T02:44:00.6116422Z test policy::default::tests::removal_default_denies_admin_removing_admin ... ok
+2026-08-01T02:44:00.6147269Z test policy::default::tests::role_change_default_decides_by_target_and_step_up ... ok
+2026-08-01T02:44:00.6261919Z test policy::default::tests::role_definitions_default_matches_spec_matrix ... ok
+2026-08-01T02:44:00.6264097Z test policy::engine::tests::compile_happy_path ... ok
+2026-08-01T02:44:00.6269941Z test policy::engine::tests::compile_sha_is_deterministic ... ok
+2026-08-01T02:44:00.6271267Z test policy::engine::tests::compile_surfaces_parse_error ... ok
+2026-08-01T02:44:00.7003168Z test policy::default::tests::upgrade_replaces_only_legacy_ceremony_policies ... ok
+2026-08-01T02:44:00.7043476Z test policy::engine::tests::evaluate_allow_false ... ok
+2026-08-01T02:44:00.7092687Z test policy::engine::tests::evaluate_allow_true ... ok
+2026-08-01T02:44:00.7503237Z test policy::engine::tests::evaluate_rejects_oversized_input ... ok
+2026-08-01T02:44:00.7532916Z test policy::engine::tests::evaluate_undefined_returns_empty_and_malformed_query_errors ... ok
+2026-08-01T02:44:00.7562854Z test policy::engine::tests::validate_purpose_package_accepts_boolean_allow_in_right_package ... ok
+2026-08-01T02:44:00.7593095Z test policy::engine::tests::validate_purpose_package_accepts_decision_rule_in_right_package ... ok
+2026-08-01T02:44:00.7613574Z test policy::engine::tests::validate_purpose_package_rejects_missing_default_rule ... ok
+2026-08-01T02:44:00.7652768Z test policy::engine::tests::validate_purpose_package_rejects_wrong_package ... ok
+2026-08-01T02:44:00.7682657Z test policy::engine::tests::validate_purpose_package_skips_unpinned_purposes ... ok
+2026-08-01T02:44:00.7683600Z test policy::extract::tests::credentials_are_projected_in_order ... ok
+2026-08-01T02:44:00.7712631Z test policy::extract::tests::credentials_array_is_optional ... ok
+2026-08-01T02:44:00.7738754Z test policy::extract::tests::empty_vp_yields_empty_claims ... ok
+2026-08-01T02:44:00.7762947Z test policy::extract::tests::holder_is_extracted_from_string_or_object ... ok
+2026-08-01T02:44:00.7763869Z test policy::extract::tests::jwt_encoded_vcs_in_array_are_skipped ... ok
+2026-08-01T02:44:00.7764631Z test policy::model::tests::all_covers_every_variant ... ok
+2026-08-01T02:44:00.7765301Z test policy::model::tests::policy_round_trips_through_json ... ok
+2026-08-01T02:44:00.7802734Z test policy::model::tests::purpose_wire_shape_round_trips ... ok
+2026-08-01T02:44:00.8108801Z test policy::storage::tests::active_pointer_clear_is_idempotent ... ok
+2026-08-01T02:44:00.8562633Z test policy::storage::tests::active_pointer_overwrites_in_place ... ok
+2026-08-01T02:44:00.8804047Z test policy::engine::tests::evaluate_aborts_runaway_policy ... ok
+2026-08-01T02:44:00.8932719Z test policy::storage::tests::active_pointer_set_get_round_trips ... ok
+2026-08-01T02:44:00.9154705Z test policy::storage::tests::delete_is_idempotent ... ok
+2026-08-01T02:44:00.9254959Z test policy::storage::tests::max_version_is_purpose_scoped ... ok
+2026-08-01T02:44:00.9500309Z test policy::storage::tests::paginated_walks_policies ... ok
+2026-08-01T02:44:00.9626673Z test policy::storage::tests::round_trip_every_purpose ... ok
+2026-08-01T02:44:00.9634501Z test recognition::challenge::tests::consume_is_single_use ... ok
+2026-08-01T02:44:00.9766602Z test recognition::challenge::tests::consume_rejects_an_expired_challenge ... ok
+2026-08-01T02:44:00.9793243Z test recognition::challenge::tests::consume_rejects_an_unknown_nonce ... ok
+2026-08-01T02:44:00.9819299Z test recognition::verify::ssrf_guard_tests::allows_https_to_public_domain ... ok
+2026-08-01T02:44:00.9853498Z test recognition::verify::ssrf_guard_tests::rejects_http_scheme ... ok
+2026-08-01T02:44:00.9868910Z test recognition::verify::ssrf_guard_tests::rejects_ipv6_loopback_and_ula ... ok
+2026-08-01T02:44:00.9909388Z test recognition::verify::ssrf_guard_tests::rejects_link_local_metadata ... ok
+2026-08-01T02:44:00.9932692Z test recognition::verify::ssrf_guard_tests::rejects_loopback_ipv4 ... ok
+2026-08-01T02:44:00.9942769Z test recognition::verify::ssrf_guard_tests::rejects_rfc1918 ... ok
+2026-08-01T02:44:00.9972756Z test recognition::verify::ssrf_guard_tests::rejects_unparseable_url ... ok
+2026-08-01T02:44:00.9992782Z test recognition::verify::ssrf_guard_tests::rejects_userinfo ... ok
+2026-08-01T02:44:01.0022596Z test recognition::challenge::tests::issue_then_consume_round_trips ... ok
+2026-08-01T02:44:01.0326683Z test recognition::verify::tests::earliest_valid_until_picks_the_shorter_window ... ok
+2026-08-01T02:44:01.0375593Z test recognition::verify::tests::foreign_fetch_client_does_not_follow_redirects ... ok
+2026-08-01T02:44:01.0462943Z test recognition::verify::tests::expired_credential_is_rejected_before_network ... ok
+2026-08-01T02:44:01.0763158Z test recognition::verify::tests::happy_path_verifies_and_returns_earliest_expiry ... ok
+2026-08-01T02:44:01.0792864Z test recognition::verify::tests::issuer_id_extraction_handles_both_value_shapes ... ok
+2026-08-01T02:44:01.0832873Z test recognition::verify::tests::issuer_mismatch_between_vec_and_vmc_rejected ... ok
+2026-08-01T02:44:01.0862709Z test recognition::verify::tests::proof_mismatch_rejected_before_network_calls ... ok
+2026-08-01T02:44:01.0872752Z test recognition::verify::tests::read_body_capped_allows_body_within_cap ... ok
+2026-08-01T02:44:01.0912771Z test recognition::verify::tests::read_body_capped_rejects_oversized_body ... ok
+2026-08-01T02:44:01.1213317Z test recognition::verify::tests::registry_unreachable_maps_to_distinct_error_variant ... ok
+2026-08-01T02:44:01.1533130Z test recognition::verify::tests::revoked_credential_is_rejected ... ok
+2026-08-01T02:44:01.1733309Z test recognition::verify::tests::status_list_signature_valid_and_issuer_matched_passes ... ok
+2026-08-01T02:44:01.1742644Z test recognition::verify::tests::status_list_substituted_issuer_is_rejected ... ok
+2026-08-01T02:44:01.1883015Z test recognition::verify::tests::status_list_tampered_fails_signature ... ok
+2026-08-01T02:44:01.1912686Z test recognition::verify::tests::status_list_without_proof_is_rejected ... ok
+2026-08-01T02:44:01.2106887Z test install::claim_secret::tests::verify_rejects_wrong_secret ... ok
+2026-08-01T02:44:01.2148216Z test recognition::verify::tests::vmc_subject_mismatch_is_rejected_before_network_calls ... ok
+2026-08-01T02:44:01.2163188Z test registry::client::tests::delete_removes_from_snapshot ... ok
+2026-08-01T02:44:01.2166998Z test registry::client::tests::fail_next_publish_consumes_a_single_call ... ok
+2026-08-01T02:44:01.2168935Z test registry::client::tests::mock_persists_published_records ... ok
+2026-08-01T02:44:01.2170682Z test registry::client::tests::mock_tracks_call_counts ... ok
+2026-08-01T02:44:01.2171406Z test registry::client::tests::recognise_propagates_transport_errors ... ok
+2026-08-01T02:44:01.2203503Z test registry::client::tests::recognise_returns_true_for_seeded_issuer ... ok
+2026-08-01T02:44:01.2205141Z test registry::client::tests::registry_error_maps_to_typed_http_status ... ok
+2026-08-01T02:44:01.2215594Z test recognition::verify::tests::unrecognised_issuer_is_rejected_even_with_valid_proofs ... ok
+2026-08-01T02:44:01.2216607Z test registry::client::tests::registry_error_retriable_classification ... ok
+2026-08-01T02:44:01.2217712Z test registry::health::tests::default_status_is_degraded ... ok
+2026-08-01T02:44:01.2250727Z test registry::health::tests::consecutive_successes_dont_re_emit ... ok
+2026-08-01T02:44:01.2251976Z test registry::health::tests::health_status_wire_form ... ok
+2026-08-01T02:44:01.2253441Z test registry::health::tests::record_failure_flips_to_degraded ... ok
+2026-08-01T02:44:01.2254396Z test registry::health::tests::record_success_flips_to_active ... ok
+2026-08-01T02:44:01.2256006Z test registry::health::tests::syncer_health_tracks_enabled_running_restarts ... ok
+2026-08-01T02:44:01.2258027Z test registry::model::tests::backoff_caps_at_one_hour ... ok
+2026-08-01T02:44:01.2258870Z test registry::model::tests::backoff_is_monotonic_until_cap ... ok
+2026-08-01T02:44:01.2259589Z test registry::model::tests::departed_omits_active_to_when_none ... ok
+2026-08-01T02:44:01.2260366Z test registry::model::tests::failure_bumps_attempts_and_schedules_retry ... ok
+2026-08-01T02:44:01.2261193Z test registry::model::tests::failure_flips_to_failed_after_max_attempts ... ok
+2026-08-01T02:44:01.2261954Z test registry::model::tests::for_job_delete_member_yields_none ... ok
+2026-08-01T02:44:01.2262900Z test registry::model::tests::for_job_mark_departed_historical_fills_active_to ... ok
+2026-08-01T02:44:01.2263752Z test registry::model::tests::for_job_publish_and_update_yield_fresh_active ... ok
+2026-08-01T02:44:01.2264636Z test registry::model::tests::for_job_mark_departed_tombstone_leaves_active_to_open ... ok
+2026-08-01T02:44:01.2265553Z test registry::model::tests::fresh_job_is_immediately_dispatchable ... ok
+2026-08-01T02:44:01.2266243Z test registry::model::tests::job_wire_round_trips ... ok
+2026-08-01T02:44:01.2266882Z test registry::model::tests::registry_record_wire_round_trips ... ok
+2026-08-01T02:44:01.2267640Z test registry::model::tests::success_marks_complete_and_clears_error ... ok
+2026-08-01T02:44:01.2268472Z test registry::policy::tests::clamp_disposition_below_floor_bumps_up_to_floor ... ok
+2026-08-01T02:44:01.2269359Z test registry::policy::tests::clamp_with_no_floor_returns_requested_verbatim ... ok
+2026-08-01T02:44:01.2270151Z test registry::policy::tests::is_rtbf_purge_detects_self_purge ... ok
+2026-08-01T02:44:01.2270912Z test registry::policy::tests::is_rtbf_purge_rejects_admin_force_purge ... ok
+2026-08-01T02:44:01.2271772Z test registry::policy::tests::clamp_disposition_at_or_above_floor_passes_through ... ok
+2026-08-01T02:44:01.2273417Z test registry::policy::tests::is_rtbf_purge_rejects_non_purge_dispositions ... ok
+2026-08-01T02:44:01.2467694Z test registry::policy::tests::min_disposition_returns_none_when_no_policy ... ok
+2026-08-01T02:44:01.2469473Z test registry::policy::tests::min_disposition_reads_from_policy ... ok
+2026-08-01T02:44:01.2588976Z test registry::policy::tests::publish_on_join_defaults_to_publish_when_no_policy ... ok
+2026-08-01T02:44:01.2617822Z test registry::policy::tests::publish_on_join_reads_true_from_default_policy ... ok
+2026-08-01T02:44:01.2748923Z test registry::policy::tests::publish_on_join_returns_skip_when_policy_says_false ... ok
+2026-08-01T02:44:01.2888098Z test registry::storage::tests::list_records_walks_keyspace ... ok
+2026-08-01T02:44:01.3033118Z test registry::storage::tests::list_sync_jobs_returns_all_pending ... ok
+2026-08-01T02:44:01.3158443Z test registry::storage::tests::registry_record_round_trip ... ok
+2026-08-01T02:44:01.3373356Z test registry::storage::tests::sweep_failed_sync_jobs_reaps_only_old_failed ... ok
+2026-08-01T02:44:01.3505919Z test registry::storage::tests::sync_cursor_round_trip ... ok
+2026-08-01T02:44:01.3646794Z test recognition::verify::tests::foreign_fetch_client_times_out_on_a_slow_host ... ok
+2026-08-01T02:44:01.3685814Z test registry::storage::tests::sync_job_round_trip_across_each_state ... ok
+2026-08-01T02:44:01.4201204Z test registry::syncer::tests::delete_member_job_drops_mirror_row ... ok
+2026-08-01T02:44:01.4342306Z test registry::syncer::tests::in_flight_rows_recover_to_pending_on_boot ... ok
+2026-08-01T02:44:01.4461654Z test registry::syncer::tests::happy_path_drains_one_publish_job ... ok
+2026-08-01T02:44:01.5059819Z test registry::syncer::tests::permanent_failure_flips_to_failed_immediately ... ok
+2026-08-01T02:44:01.5305604Z test registry::syncer::tests::rtbf_override_audit_failure_does_not_advance_cursor_and_re_emits ... ok
+2026-08-01T02:44:01.5323292Z test registry::syncer::tests::publish_on_join_false_skips_dispatch ... ok
+2026-08-01T02:44:01.5758642Z test registry::tail::tests::empty_audit_log_yields_no_cursor ... ok
+2026-08-01T02:44:01.5808432Z test registry::tail::tests::cursor_advances_so_restart_is_idempotent ... ok
+2026-08-01T02:44:01.6008438Z test registry::syncer::tests::transient_failure_bumps_attempts_and_keeps_job_pending ... ok
+2026-08-01T02:44:01.6296396Z test registry::tail::tests::enqueues_publish_for_member_added ... ok
+2026-08-01T02:44:01.6323010Z test registry::tail::tests::member_removed_dispositions_map_to_correct_kinds ... ok
+2026-08-01T02:44:01.6611362Z test registry::tail::tests::member_self_tombstone_request_is_not_rtbf ... ok
+2026-08-01T02:44:01.6846724Z test registry::tail::tests::non_rtbf_delete_is_not_batched ... ok
+2026-08-01T02:44:01.6950377Z test registry::tail::tests::min_disposition_clamps_non_rtbf_purge_up_to_floor ... ok
+2026-08-01T02:44:01.7184967Z test registry::tail::tests::rewalk_without_cursor_advance_overwrites_not_duplicates ... ok
+2026-08-01T02:44:01.7400951Z test registry::tail::tests::role_changed_enqueues_update_member ... ok
+2026-08-01T02:44:01.7596551Z test registry::tail::tests::rtbf_batching_window_defers_dispatch ... ok
+2026-08-01T02:44:01.7837810Z test registry::tail::tests::rtbf_batching_window_zero_dispatches_immediately ... ok
+2026-08-01T02:44:01.7908682Z test registry::tail::tests::rtbf_purge_overrides_min_disposition_floor ... ok
+2026-08-01T02:44:01.8181133Z test registry::tail::tests::rtbf_purge_without_clamp_emits_no_override_envelope ... ok
+2026-08-01T02:44:01.8523736Z test registry::tail::tests::unrelated_envelopes_are_ignored ... ok
+2026-08-01T02:44:01.8598861Z test registry::upstream::tests::config_trims_trailing_slash ... ok
+2026-08-01T02:44:01.9199128Z test registry::upstream::tests::recognise_connection_refused_is_unreachable ... ok
+2026-08-01T02:44:01.9343391Z test registry::upstream::tests::health_against_unreachable_host_is_unreachable ... ok
+2026-08-01T02:44:01.9427145Z test registry::upstream::tests::publish_member_returns_permanent_until_m3_4 ... ok
+2026-08-01T02:44:02.0103422Z test registry::upstream::tests::recognise_maps_500_to_transient ... ok
+2026-08-01T02:44:02.0303950Z test registry::upstream::tests::recognise_maps_404_to_clean_not_recognised ... ok
+2026-08-01T02:44:02.0333325Z test registry::upstream::tests::recognise_maps_400_to_permanent ... ok
+2026-08-01T02:44:02.0903589Z test registry::upstream::tests::recognise_refuses_when_authority_did_missing ... ok
+2026-08-01T02:44:02.1683453Z test registry::upstream::tests::recognise_returns_false_when_response_recognized_is_false ... ok
+2026-08-01T02:44:02.1684582Z test registry::upstream::tests::recognise_sends_canonical_four_tuple ... ok
+2026-08-01T02:44:02.2047488Z test relationships::storage::tests::find_by_hash_returns_existing_row ... ok
+2026-08-01T02:44:02.2084136Z test relationships::storage::tests::delete_clears_primary_and_index ... ok
+2026-08-01T02:44:02.2427496Z test relationships::storage::tests::list_all_returns_every_edge ... ok
+2026-08-01T02:44:02.2453116Z test relationships::storage::tests::list_does_not_leak_colon_prefix_colliding_did ... ok
+2026-08-01T02:44:02.2799658Z test relationships::storage::tests::list_for_issuer_returns_issued ... ok
+2026-08-01T02:44:02.2809570Z test relationships::storage::tests::list_for_subject_returns_received ... ok
+2026-08-01T02:44:02.3199083Z test relationships::storage::tests::round_trip ... ok
+2026-08-01T02:44:02.3226331Z test relationships::storage::tests::list_paginates_with_cursor ... ok
+2026-08-01T02:44:02.3238860Z test routes::acl::tests::acl_entry_response_omits_expires_at_when_permanent ... ok
+2026-08-01T02:44:02.3241490Z test routes::acl::tests::acl_entry_response_serializes_with_stable_field_names ... ok
+2026-08-01T02:44:02.3243832Z test routes::acl::tests::acl_list_response_round_trips ... ok
+2026-08-01T02:44:02.3250148Z test routes::acl::tests::change_role_request_rejects_the_pre_migration_body ... ok
+2026-08-01T02:44:02.3254620Z test routes::acl::tests::change_role_request_requires_both_roles ... ok
+2026-08-01T02:44:02.3303296Z test routes::acl::tests::context_admin_covers_only_targets_fully_within_its_scope ... ok
+2026-08-01T02:44:02.3312541Z test routes::acl::tests::create_acl_request_rejects_missing_required ... ok
+2026-08-01T02:44:02.3318028Z test routes::acl::tests::custom_role_round_trip_through_request_body ... ok
+2026-08-01T02:44:02.3319028Z test registry::upstream::tests::rejects_cleartext_registry_url ... ok
+2026-08-01T02:44:02.3324001Z test routes::acl::tests::grant_request_parses_full_body ... ok
+2026-08-01T02:44:02.3324894Z test routes::acl::tests::grant_request_parses_minimal_body ... ok
+2026-08-01T02:44:02.3326193Z test routes::acl::tests::grant_request_rejects_caller_supplied_provenance ... ok
+2026-08-01T02:44:02.3333011Z test routes::acl::tests::grant_request_rejects_unknown_role ... ok
+2026-08-01T02:44:02.3333999Z test routes::acl::tests::list_acl_query_filters_are_optional ... ok
+2026-08-01T02:44:02.3335383Z test routes::acl::tests::losing_admin_role_is_a_reduction ... ok
+2026-08-01T02:44:02.3336703Z test routes::acl::tests::narrowing_contexts_is_a_reduction ... ok
+2026-08-01T02:44:02.3337705Z test routes::acl::tests::super_admin_covers_any_admin_target ... ok
+2026-08-01T02:44:02.3338490Z test routes::acl::tests::widening_or_lateral_change_is_not_a_reduction ... ok
+2026-08-01T02:44:02.3339128Z test routes::admin_ui::tests::scan_skips_invalid_ids_and_traversal_entries ... ok
+2026-08-01T02:44:02.3339637Z test routes::admin_ui::tests::cached_scan_is_not_reread_within_ttl ... ok
+2026-08-01T02:44:02.3340161Z test routes::auth::cookie_format_tests::csrf_cookie_is_root_scoped_but_not_httponly ... ok
+2026-08-01T02:44:02.3340728Z test routes::auth::cookie_format_tests::session_cookie_has_security_flags ... ok
+2026-08-01T02:44:02.3341220Z test routes::auth::cookie_format_tests::session_cookie_path_is_root ... ok
+2026-08-01T02:44:02.3341728Z test routes::auth::cookie_format_tests::session_cookie_uses_canonical_name ... ok
+2026-08-01T02:44:02.3343194Z test routes::ceremonies::tests::every_field_default_is_present_and_typed ... ok
+2026-08-01T02:44:02.3343701Z test routes::ceremonies::tests::facts_template_carries_the_purpose ... ok
+2026-08-01T02:44:02.3344226Z test routes::did_log::tests::did_log_label_returns_none_for_non_webvh ... ok
+2026-08-01T02:44:02.3344728Z test routes::ceremonies::tests::four_ceremonies_with_stable_purposes ... ok
+2026-08-01T02:44:02.3345245Z test routes::did_log::tests::did_log_label_returns_none_when_last_component_unsafe ... ok
+2026-08-01T02:44:02.3345786Z test routes::did_log::tests::safe_label_accepts_hostnames_and_scids ... ok
+2026-08-01T02:44:02.3346244Z test routes::did_log::tests::did_log_label_takes_the_last_component ... ok
+2026-08-01T02:44:02.3346689Z test routes::did_log::tests::safe_label_rejects_traversal_and_empty ... ok
+2026-08-01T02:44:02.3347149Z test routes::join_requests::present::tests::clear_bit_is_valid ... ok
+2026-08-01T02:44:02.3347659Z test routes::join_requests::present::tests::malformed_status_entry_is_unknown ... ok
+2026-08-01T02:44:02.3348191Z test routes::join_requests::present::tests::no_registry_mode_is_not_trusted ... ok
+2026-08-01T02:44:02.3348756Z test routes::join_requests::present::tests::no_status_block_is_valid_without_a_fetch ... ok
+2026-08-01T02:44:02.3349666Z test routes::join_requests::present::tests::projects_a_verified_presentation_into_a_ceremony_credential ... ok
+2026-08-01T02:44:02.3350359Z test routes::join_requests::present::tests::own_did_is_trusted_without_consulting_the_registry ... ok
+2026-08-01T02:44:02.3350942Z test routes::join_requests::present::tests::recognised_foreign_issuer_is_trusted ... ok
+2026-08-01T02:44:02.3351490Z test routes::join_requests::present::tests::registry_error_fails_soft_to_untrusted ... ok
+2026-08-01T02:44:02.3352440Z test routes::join_requests::present::tests::sd_jwt_status_list_shape_resolves ... ok
+2026-08-01T02:44:02.3353263Z test routes::join_requests::present::tests::set_revocation_bit_is_revoked ... ok
+2026-08-01T02:44:02.3354074Z test routes::join_requests::present::tests::set_suspension_bit_is_suspended ... ok
+2026-08-01T02:44:02.3354781Z test routes::join_requests::present::tests::unreachable_status_list_is_unknown_not_valid ... ok
+2026-08-01T02:44:02.3355414Z test routes::join_requests::present::tests::resolved_status_carries_through_to_the_credential ... ok
+2026-08-01T02:44:02.3356028Z test routes::join_requests::present::tests::unrecognised_foreign_issuer_is_not_trusted ... ok
+2026-08-01T02:44:02.3359302Z test routes::join_requests::present::tests::untrusted_issuer_carries_through_to_the_credential ... ok
+2026-08-01T02:44:02.3360531Z test routes::members::rotate::tests::method_of_recognises_did_webvh ... ok
+2026-08-01T02:44:02.3361540Z test routes::members::rotate::tests::method_of_recognises_did_key ... ok
+2026-08-01T02:44:02.3362668Z test routes::members::rotate::tests::method_of_rejects_non_did_strings ... ok
+2026-08-01T02:44:02.3364036Z test routes::members::rotate::tests::method_of_rejects_unknown_methods ... ok
+2026-08-01T02:44:02.3366499Z test routes::members::rotate::tests::verify_did_webvh_signature_rejects_non_hex_signature ... ok
+2026-08-01T02:44:02.3476762Z test relationships::storage::tests::self_loop_writes_one_index_entry ... ok
+2026-08-01T02:44:02.3575714Z test routes::openapi_tests::every_unauthenticated_route_is_classified ... ok
+2026-08-01T02:44:02.3596066Z test routes::openapi_tests::openapi_spec_covers_the_route_groups ... ok
+2026-08-01T02:44:02.3602914Z test routes::recognise::tests::caller_rejections_stay_403 ... ok
+2026-08-01T02:44:02.3640857Z test routes::recognise::tests::registry_failures_map_to_5xx_not_500_or_403 ... ok
+2026-08-01T02:44:02.3670824Z test routes::relationships::tests::canonicalise_is_key_order_stable ... ok
+2026-08-01T02:44:02.3671923Z test routes::relationships::tests::extract_did_field_handles_object_form ... ok
+2026-08-01T02:44:02.3673185Z test routes::relationships::tests::extract_did_field_handles_string_form ... ok
+2026-08-01T02:44:02.3674171Z test routes::relationships::tests::extract_did_field_rejects_missing ... ok
+2026-08-01T02:44:02.3675116Z test routes::relationships::tests::extract_subject_id_extracts_nested ... ok
+2026-08-01T02:44:02.3676214Z test routes::website::files::tests::walk_gathers_metadata_and_hash_window_hashes_only_the_window ... ok
+2026-08-01T02:44:02.3677296Z test routing::csrf::tests::admin_decide_on_join_mount_stays_gated ... ok
+2026-08-01T02:44:02.3678222Z test routing::csrf::tests::auth_challenge_post_bypasses ... ok
+2026-08-01T02:44:02.3679237Z test routes::openapi_tests::openapi_spec_documents_the_migrated_route_and_security_scheme ... ok
+2026-08-01T02:44:02.3680251Z test routing::csrf::tests::bearer_scheme_is_case_insensitive ... ok
+2026-08-01T02:44:02.3681260Z test routing::csrf::tests::cookie_session_post_with_matching_csrf_cookie_and_header_passes ... ok
+2026-08-01T02:44:02.3682447Z test routing::csrf::tests::bearer_post_without_cookie_or_origin_passes ... ok
+2026-08-01T02:44:02.3683525Z test routing::csrf::tests::cookie_session_post_with_non_matching_csrf_header_returns_403 ... ok
+2026-08-01T02:44:02.3685223Z test routing::csrf::tests::cookie_session_post_with_sec_fetch_site_same_origin_passes ... ok
+2026-08-01T02:44:02.3690490Z test routing::csrf::tests::cookie_session_post_without_csrf_returns_403 ... ok
+2026-08-01T02:44:02.3694532Z test routing::csrf::tests::get_bypasses ... ok
+2026-08-01T02:44:02.3698271Z test routing::csrf::tests::holder_accept_post_bypasses ... ok
+2026-08-01T02:44:02.3702593Z test routing::csrf::tests::holder_status_post_bypasses ... ok
+2026-08-01T02:44:02.3707766Z test routing::csrf::tests::non_bearer_authorization_scheme_on_cookie_session_stays_gated ... ok
+2026-08-01T02:44:02.3711531Z test routing::csrf::tests::post_without_session_cookie_passes_csrf ... ok
+2026-08-01T02:44:02.3715894Z test routing::csrf::tests::public_join_request_post_bypasses ... ok
+2026-08-01T02:44:02.3716650Z test routing::csrf::tests::session_cookie_detected_among_others ... ok
+2026-08-01T02:44:02.3753427Z test routing::host_dispatch::tests::admin_at_root_in_host_mode_resolves_by_request_host ... ok
+2026-08-01T02:44:02.3754560Z test routing::host_dispatch::tests::infra_paths_answer_on_every_recognised_host ... ok
+2026-08-01T02:44:02.3755670Z test routing::host_dispatch::tests::matches_recognises_configured_host ... ok
+2026-08-01T02:44:02.3756655Z test routing::host_dispatch::tests::path_mode_when_no_hosts_set ... ok
+2026-08-01T02:44:02.3762992Z test routing::host_dispatch::tests::surface_isolation_routes_path_to_its_own_host ... ok
+2026-08-01T02:44:02.3775988Z test routes::openapi_tests::posture_allowlists_have_no_stale_entries ... ok
+2026-08-01T02:44:02.3883538Z test schemas::accepts::tests::rejects_a_structurally_invalid_dcql_query ... ok
+2026-08-01T02:44:02.3932665Z test schemas::accepts::tests::rejects_a_criterion_referencing_an_unregistered_type ... ok
+2026-08-01T02:44:02.3936680Z test schemas::accepts::tests::stores_a_criterion_that_references_a_registered_type ... ok
+2026-08-01T02:44:02.4025463Z test schemas::defaults::tests::is_idempotent_and_preserves_operator_edits ... ok
+2026-08-01T02:44:02.4068050Z test schemas::storage::tests::is_issues_registered_only_for_issues_kind ... ok
+2026-08-01T02:44:02.4102869Z test schemas::defaults::tests::seeds_the_catalog_issues_types ... ok
+2026-08-01T02:44:02.4117516Z test schemas::validate::tests::validate_instance_accepts_and_rejects ... ok
+2026-08-01T02:44:02.4211445Z test schemas::storage::tests::list_by_kind_partitions ... ok
+2026-08-01T02:44:02.4212373Z test schemas::storage::tests::store_get_list_delete_round_trip ... ok
+2026-08-01T02:44:02.4443496Z test schemas::validate::tests::validate_issued_enforces_a_registered_schema ... ok
+2026-08-01T02:44:02.4472340Z test schemas::validate::tests::validate_issued_is_a_noop_for_unregistered_or_schemaless ... ok
+2026-08-01T02:44:02.4602537Z test server::p0_9_init_auth_tests::boots_degraded_when_vtc_did_unset ... ok
+2026-08-01T02:44:02.4639622Z test server::p0_9_init_auth_tests::hard_fails_when_store_errors ... ok
+2026-08-01T02:44:02.4654889Z test setup::bundle::tests::debug_redacts_private_keys ... ok
+2026-08-01T02:44:02.4662884Z test setup::bundle::tests::decode_secret_store_value_accepts_json_bundle ... ok
+2026-08-01T02:44:02.4676984Z test setup::bundle::tests::decode_secret_store_value_accepts_legacy_64_bytes ... ok
+2026-08-01T02:44:02.4690158Z test setup::bundle::tests::decode_secret_store_value_rejects_did_mismatch ... ok
+2026-08-01T02:44:02.4703107Z test setup::bundle::tests::ed25519_private_bytes_decodes ... ok
+2026-08-01T02:44:02.4704221Z test setup::bundle::tests::from_secret_store_bytes_clear_error_on_garbage ... ok
+2026-08-01T02:44:02.4706507Z test setup::bundle::tests::from_secret_store_bytes_rejects_unknown_fields ... ok
+2026-08-01T02:44:02.4724920Z test setup::bundle::tests::rejects_wrong_multicodec_prefix ... ok
+2026-08-01T02:44:02.4725862Z test setup::bundle::tests::round_trip_secret_store_bytes ... ok
+2026-08-01T02:44:02.4726583Z test setup::bundle::tests::x25519_private_bytes_decodes ... ok
+2026-08-01T02:44:02.4727305Z test setup::from_toml::tests::blank_registry_did_reads_as_no_registry ... ok
+2026-08-01T02:44:02.4728002Z test setup::from_toml::tests::full_inputs_parse ... ok
+2026-08-01T02:44:02.4736706Z test setup::from_toml::tests::minimal_inputs_parse_and_default ... ok
+2026-08-01T02:44:02.4739986Z test server::p0_10_timeout_tests::timeout_layer_408s_a_slow_handler_but_not_a_fast_one ... ok
+2026-08-01T02:44:02.4744525Z test setup::from_toml::tests::parse_from_toml_reports_missing_setup_key ... ok
+2026-08-01T02:44:02.4753377Z test setup::from_toml::tests::registry_did_is_optional ... ok
+2026-08-01T02:44:02.4761367Z test setup::from_toml::tests::registry_did_parses_and_validates ... ok
+2026-08-01T02:44:02.4767907Z test setup::from_toml::tests::parse_from_toml_builds_plan_with_loaded_key ... ok
+2026-08-01T02:44:02.4771506Z test setup::from_toml::tests::registry_did_rejects_a_url ... ok
+2026-08-01T02:44:02.4774325Z test setup::from_toml::tests::shipped_example_parses ... ok
+2026-08-01T02:44:02.4777669Z test setup::from_toml::tests::unknown_field_rejected ... ok
+2026-08-01T02:44:02.4779318Z test setup::from_toml::tests::validate_rejects_bad_base_url_and_vta_did ... ok
+2026-08-01T02:44:02.4792773Z 
+2026-08-01T02:44:02.4793708Z test setup::from_toml::tests::validate_rejects_empty_mediator_did ... ok
+2026-08-01T02:44:02.4794984Z test setup::phase1::tests::phase1_persists_loadable_setup_key ... ok
+2026-08-01T02:44:02.4796201Z test setup::wizard::provision_failed_tests::forbidden_keeps_the_acl_hint ... ok
+2026-08-01T02:44:02.4797604Z test setup::wizard::provision_failed_tests::transport_timeout_does_not_blame_the_acl ... ok
+2026-08-01T02:44:02.4799269Z test setup::wizard::provision_failed_tests::unclassified_failure_keeps_the_acl_hint ... ok
+2026-08-01T02:44:02.4801710Z test setup::wizard::tests::default_data_dir_falls_back_when_config_has_no_parent ... ok
+2026-08-01T02:44:02.4804250Z test setup::phase1::tests::phase1_prints_context_scoped_grant_command ... ok
+2026-08-01T02:44:02.4806292Z test setup::wizard::tests::did_log_label_is_the_final_component ... ok
+2026-08-01T02:44:02.4807437Z test setup::wizard::tests::did_log_label_refuses_non_webvh ... ok
+2026-08-01T02:44:02.4808482Z test setup::wizard::tests::secrets_choice_to_config_routes_aws_to_aws_fields ... ok
+2026-08-01T02:44:02.4810071Z test setup::wizard::tests::secrets_choice_to_config_routes_keyring_to_keyring_service ... ok
+2026-08-01T02:44:02.4811893Z test setup::wizard::tests::vtc_host_messages_use_pnm_contexts_create_command ... ok
+2026-08-01T02:44:02.4815617Z   Setup DID (ephemeral):
+2026-08-01T02:44:02.4817222Z test setup::wizard::tests::write_config_toml_produces_mode_0600 ... ok
+2026-08-01T02:44:02.4821856Z test setup::wizard::tests::default_data_dir_sits_alongside_config ... ok
+2026-08-01T02:44:02.4823100Z test status_list::allocator::tests::add_initial_decoys_only_touches_unassigned_slots ... ok
+2026-08-01T02:44:02.4824968Z test status_list::allocator::tests::allocate_refuses_when_all_free_slots_are_decoys ... ok
+2026-08-01T02:44:02.4826522Z test status_list::allocator::tests::allocator_exhausts_capacity_then_returns_none ... ok
+2026-08-01T02:44:02.4827595Z test server::p0_9_init_auth_tests::hard_fails_when_vtc_did_set_but_store_empty ... ok
+2026-08-01T02:44:02.4828658Z test status_list::allocator::tests::allocate_never_returns_a_set_slot_under_decoys ... ok
+2026-08-01T02:44:02.4829724Z test status_list::allocator::tests::flip_back_to_zero_keeps_slot_assigned ... ok
+2026-08-01T02:44:02.4830759Z test status_list::allocator::tests::allocator_never_returns_a_flipped_slot ... ok
+2026-08-01T02:44:02.4843225Z     did:key:z6Mkst5YabzTzo4y1FHL1LUL3wbgkiLVqruWBwtv2FkY5cvm
+2026-08-01T02:44:02.4843824Z 
+2026-08-01T02:44:02.4844242Z   Key stored at /tmp/.tmpMzxGHS/vtc-setup-key.json (0600)
+2026-08-01T02:44:02.4844784Z 
+2026-08-01T02:44:02.4845231Z   Using your Personal Network Manager (PNM) connected to this VTA,
+2026-08-01T02:44:02.4846079Z   create the vtc context and grant admin access to the setup DID:
+2026-08-01T02:44:02.4846653Z 
+2026-08-01T02:44:02.4847176Z     pnm contexts create --id default --name "VTC" \
+2026-08-01T02:44:02.4848668Z test status_list::credential::tests::encoded_list_round_trips_through_decode ... ok
+2026-08-01T02:44:02.4849826Z   --admin-did did:key:z6Mkst5YabzTzo4y1FHL1LUL3wbgkiLVqruWBwtv2FkY5cvm --admin-expires 1h
+2026-08-01T02:44:02.4850597Z 
+2026-08-01T02:44:02.4851689Z   --name is a human-readable label — change "VTC" to anything
+2026-08-01T02:44:02.4852565Z   that fits your naming conventions.
+2026-08-01T02:44:02.4853079Z 
+2026-08-01T02:44:02.4854018Z test status_list::allocator::tests::flip_out_of_bounds_returns_err ... ok
+2026-08-01T02:44:02.4854859Z   --admin-expires defaults to 1h. Use 24h, 7d, etc. for longer
+2026-08-01T02:44:02.4855703Z   roll-outs; the entry is promoted to permanent on first auth.
+2026-08-01T02:44:02.4856512Z 
+2026-08-01T02:44:02.4856801Z   Then finalise with:
+2026-08-01T02:44:02.4857622Z     vtc setup --from <your-setup.toml>   (with setup_key_file = "/tmp/.tmpMzxGHS/vtc-setup-key.json")
+2026-08-01T02:44:02.4858396Z 
+2026-08-01T02:44:02.4860336Z test status_list::allocator::tests::occupancy_crosses_threshold_at_75_percent ... ok
+2026-08-01T02:44:02.5025121Z test status_list::credential::tests::round_trip_status_list_vc_verifies ... ok
+2026-08-01T02:44:02.5034912Z test status_list::storage::tests::count_set_matches_bit_arithmetic ... ok
+2026-08-01T02:44:02.5129107Z test status_list::storage::tests::compact_bool_vec_round_trips ... ok
+2026-08-01T02:44:02.5149483Z test status_list::storage::tests::concurrent_allocate_under_lock_loses_no_slots ... ok
+2026-08-01T02:44:02.5385735Z test status_list::storage::tests::revoke_under_lock_survives_concurrent_allocate ... ok
+2026-08-01T02:44:02.5497343Z test status_list::storage::tests::ensure_initial_seeds_decoys ... ok
+2026-08-01T02:44:02.5520742Z test status_list::storage::tests::ensure_initial_is_idempotent ... ok
+2026-08-01T02:44:02.5524479Z test store::keyspaces::tests::all_has_no_duplicates ... ok
+2026-08-01T02:44:02.5531187Z test store::keyspaces::tests::all_matches_app_state_keyspace_count ... ok
+2026-08-01T02:44:02.5532423Z test store::keyspaces::tests::backup_partition_is_total ... ok
+2026-08-01T02:44:02.5535159Z test supervisor::tests::detection_priority_systemd_over_kubernetes ... ok
+2026-08-01T02:44:02.5536412Z test supervisor::tests::empty_env_returns_none ... ok
+2026-08-01T02:44:02.5538330Z test supervisor::tests::empty_notify_socket_does_not_match ... ok
+2026-08-01T02:44:02.5547915Z test supervisor::tests::kubernetes_service_host_detects_pod ... ok
+2026-08-01T02:44:02.5569166Z test supervisor::tests::notify_socket_detects_systemd ... ok
+2026-08-01T02:44:02.5570147Z test supervisor::tests::vtc_supervised_1_wins_first ... ok
+2026-08-01T02:44:02.5576470Z test supervisor::tests::vtc_supervised_other_values_dont_match ... ok
+2026-08-01T02:44:02.5597890Z test trust_tasks::tests::dispatched_uris_are_canonical_type_uris ... ok
+2026-08-01T02:44:02.5599275Z test status_list::storage::tests::revoked_index_survives_restart_and_is_not_reallocated ... ok
+2026-08-01T02:44:02.5600339Z test trust_tasks::tests::member_verbs_are_dispatched ... ok
+2026-08-01T02:44:02.5601278Z test webauthn::tests::extend_ccr_is_idempotent_and_additive ... ok
+2026-08-01T02:44:02.5602394Z test trust_tasks::tests::dispatcher_routes_every_dispatched_uri ... ok
+2026-08-01T02:44:02.5603396Z test webauthn::tests::start_advertises_eddsa_alongside_default_algorithms ... ok
+2026-08-01T02:44:02.5604396Z test webauthn::tests::extend_state_round_trips_through_serde ... ok
+2026-08-01T02:44:02.5605991Z test webauthn::tests::start_state_credential_algorithms_includes_eddsa ... ok
+2026-08-01T02:44:02.5617311Z test website::bundle::tests::extracts_happy_bundle ... ok
+2026-08-01T02:44:02.5652952Z test website::bundle::tests::happy_bundle_passes_verification ... ok
+2026-08-01T02:44:02.5653895Z test website::bundle::tests::rejects_blocklisted_extension ... ok
+2026-08-01T02:44:02.5682893Z test website::bundle::tests::rejects_dotdot_segment ... ok
+2026-08-01T02:44:02.5687554Z test website::bundle::tests::rejects_hidden_top_level ... ok
+2026-08-01T02:44:02.5718757Z test website::bundle::tests::rejects_oversize_declared_total ... ok
+2026-08-01T02:44:02.5724118Z test website::bundle::tests::rejects_exec_bit ... ok
+2026-08-01T02:44:02.5724918Z test website::cache::tests::cache_misses_after_ttl_expiry ... ok
+2026-08-01T02:44:02.5726021Z test website::default_site::tests::embedded_dir_has_index ... ok
+2026-08-01T02:44:02.5726878Z test website::default_site::tests::lookup_misses_on_unknown_path ... ok
+2026-08-01T02:44:02.5727747Z test website::cache::tests::cache_returns_consistent_digest ... ok
+2026-08-01T02:44:02.5728580Z test website::default_site::tests::lookup_returns_index_bytes ... ok
+2026-08-01T02:44:02.5729465Z test website::paths::tests::create_allows_new_file_in_existing_dir ... ok
+2026-08-01T02:44:02.5730561Z test website::paths::tests::create_rejects_blocklisted_extension ... ok
+2026-08-01T02:44:02.5748143Z test website::paths::tests::create_rejects_control_and_non_nfc ... ok
+2026-08-01T02:44:02.5748926Z test website::paths::tests::create_rejects_dotdot_and_creates_nothing ... ok
+2026-08-01T02:44:02.5749679Z test website::paths::tests::create_rejects_empty_and_dir_target ... ok
+2026-08-01T02:44:02.5750367Z test website::paths::tests::create_allows_new_nested_dir ... ok
+2026-08-01T02:44:02.5751029Z test website::paths::tests::create_rejects_hidden_target ... ok
+2026-08-01T02:44:02.5772792Z test website::paths::tests::create_rejects_symlinked_ancestor_escape ... ok
+2026-08-01T02:44:02.5773579Z test website::paths::tests::rejects_blocklisted_extension ... ok
+2026-08-01T02:44:02.5774267Z test website::paths::tests::happy_path_resolves_within_root ... ok
+2026-08-01T02:44:02.5793036Z test website::paths::tests::rejects_dotdot_escape ... ok
+2026-08-01T02:44:02.5793805Z test website::paths::tests::rejects_hidden_file ... ok
+2026-08-01T02:44:02.5794573Z test website::paths::tests::rejects_nested_hidden_segment ... ok
+2026-08-01T02:44:02.5806712Z test website::paths::tests::rejects_non_nfc ... ok
+2026-08-01T02:44:02.5807829Z test website::paths::tests::rejects_exec_bit_file ... ok
+2026-08-01T02:44:02.5823956Z test website::paths::tests::rejects_nul_byte ... ok
+2026-08-01T02:44:02.5829326Z test website::serve::tests::csp_override_cache_is_not_read_every_request ... ok
+2026-08-01T02:44:02.5830445Z test install::claim_secret::tests::two_hashes_of_same_secret_differ_due_to_salt ... ok
+2026-08-01T02:44:02.5831528Z test website::serve::tests::etag_matches_handles_lists_weak_and_star ... ok
+2026-08-01T02:44:02.5838061Z test website::serve::tests::directory_request_404s ... ok
+2026-08-01T02:44:02.5843796Z test website::serve::tests::rejects_blocked_extension_with_403 ... ok
+2026-08-01T02:44:02.5850677Z test website::serve::tests::rejects_dotdot_escape_with_validation_error ... ok
+2026-08-01T02:44:02.5862667Z test website::serve::tests::rejects_hidden_with_404 ... ok
+2026-08-01T02:44:02.5870483Z test website::serve::tests::loose_per_site_csp_override_is_refused ... ok
+2026-08-01T02:44:02.5871451Z test website::serve::tests::matching_if_none_match_returns_304 ... ok
+2026-08-01T02:44:02.5874601Z test website::serve::tests::safe_per_site_csp_override_wins ... ok
+2026-08-01T02:44:02.5876167Z test website::serve::tests::serves_existing_file_with_etag ... ok
+2026-08-01T02:44:02.5877120Z test website::serve::tests::validate_csp_accepts_strict_and_custom_directives ... ok
+2026-08-01T02:44:02.5878198Z test website::serve::tests::validate_csp_refuses_weakened_critical_directives ... ok
+2026-08-01T02:44:02.5879322Z test website::storage::tests::managed_mode_serves_current_symlink ... ok
+2026-08-01T02:44:02.5880319Z test website::storage::tests::live_mode_serves_root_directly ... ok
+2026-08-01T02:44:02.5881202Z test website::storage::tests::rejects_unknown_deploy_mode ... ok
+2026-08-01T02:44:02.5882413Z test website::serve::tests::serves_index_for_root_request ... ok
+2026-08-01T02:44:02.5883517Z test status_list::storage::tests::round_trip_through_keyspace_preserves_bits_and_assigned ... ok
+2026-08-01T02:44:02.5884214Z 
+2026-08-01T02:44:02.5884647Z test result: ok. 700 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 12.36s
+2026-08-01T02:44:02.5885213Z 
+2026-08-01T02:44:02.5985126Z [1m[92m     Running[0m unittests src/main.rs (target/debug/deps/vtc-4332cf807cc3e051)
+2026-08-01T02:44:02.6013657Z 
+2026-08-01T02:44:02.6014031Z running 0 tests
+2026-08-01T02:44:02.6014257Z 
+2026-08-01T02:44:02.6015237Z test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+2026-08-01T02:44:02.6015800Z 
+2026-08-01T02:44:02.6018867Z [1m[92m     Running[0m tests/acl_canonical.rs (target/debug/deps/acl_canonical-5fc1b7dd6014ce7d)
+2026-08-01T02:44:02.6178226Z 
+2026-08-01T02:44:02.6178704Z running 9 tests
+2026-08-01T02:44:03.0068228Z test each_verb_rejects_a_siblings_task ... ok
+2026-08-01T02:44:03.0254275Z test change_role_enforces_the_from_role_guard ... ok
+2026-08-01T02:44:03.0255181Z test entries_use_canonical_names_and_rfc3339_timestamps ... ok
+2026-08-01T02:44:03.0261780Z test grant_refuses_to_change_an_existing_role ... ok
+2026-08-01T02:44:03.3521208Z test grant_with_the_same_role_rewrites_the_entry ... ok
+2026-08-01T02:44:03.3649526Z test revoke_without_scopes_removes_the_entry ... ok
+2026-08-01T02:44:03.3755388Z test revoke_with_scopes_reduces_rather_than_removes ... ok
+2026-08-01T02:44:03.3794717Z test list_filters_and_paginates ... ok
+2026-08-01T02:44:03.5463511Z test revoking_every_scope_is_refused_rather_than_unscoping ... ok
+2026-08-01T02:44:03.5463942Z 
+2026-08-01T02:44:03.5464219Z test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.93s
+2026-08-01T02:44:03.5464579Z 
+2026-08-01T02:44:03.5516157Z [1m[92m     Running[0m tests/acl_cli.rs (target/debug/deps/acl_cli-30cfd013d09a2382)
+2026-08-01T02:44:03.5569570Z 
+2026-08-01T02:44:03.5569850Z running 4 tests
+2026-08-01T02:44:03.5835279Z test remove_missing_did_is_ok ... ok
+2026-08-01T02:44:03.5849419Z test add_rejects_unknown_role ... ok
+2026-08-01T02:44:03.5924349Z test add_is_upsert_and_preserves_created_at ... ok
+2026-08-01T02:44:03.5958301Z test add_list_remove_round_trip ... ok
+2026-08-01T02:44:03.5958701Z 
+2026-08-01T02:44:03.5959129Z test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.04s
+2026-08-01T02:44:03.5959721Z 
+2026-08-01T02:44:03.5969940Z [1m[92m     Running[0m tests/admin_bootstrap.rs (target/debug/deps/admin_bootstrap-75520e1302108b0a)
+2026-08-01T02:44:03.6146678Z 
+2026-08-01T02:44:03.6147245Z running 9 tests
+2026-08-01T02:44:04.0048561Z test bootstrap_returns_503_when_audit_writer_missing ... ok
+2026-08-01T02:44:04.0065758Z test bootstrap_rejects_install_token_as_setup_token ... ok
+2026-08-01T02:44:04.0084992Z test bootstrap_rejects_unsigned_token ... ok
+2026-08-01T02:44:04.0209706Z test bootstrap_rejects_when_no_passkey_user_exists ... ok
+2026-08-01T02:44:04.3186178Z test missing_trust_task_returns_400 ... ok
+2026-08-01T02:44:04.3478644Z test bootstrap_returns_503_when_install_signer_missing ... ok
+2026-08-01T02:44:04.3638167Z test full_install_to_bootstrap_succeeds ... ok
+2026-08-01T02:44:04.3654707Z test second_bootstrap_returns_409 ... ok
+2026-08-01T02:44:04.5156653Z test wrong_trust_task_returns_415 ... ok
+2026-08-01T02:44:04.5156921Z 
+2026-08-01T02:44:04.5157630Z test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.90s
+2026-08-01T02:44:04.5158175Z 
+2026-08-01T02:44:04.5205711Z [1m[92m     Running[0m tests/admin_config.rs (target/debug/deps/admin_config-155165814f82ec9c)
+2026-08-01T02:44:04.5370590Z 
+2026-08-01T02:44:04.5371051Z running 41 tests
+2026-08-01T02:44:04.9188853Z test each_verb_rejects_its_siblings_trust_task ... ok
+2026-08-01T02:44:04.9208551Z test export_requires_admin_role ... ok
+2026-08-01T02:44:04.9213617Z test export_empty_fresh_install_returns_v1_schema_no_profile_no_overrides ... ok
+2026-08-01T02:44:04.9304343Z test export_includes_profile_and_db_overrides ... ok
+2026-08-01T02:44:05.2353958Z test get_with_wrong_trust_task_returns_415 ... ok
+2026-08-01T02:44:05.2396954Z test get_returns_effective_config_with_defaults ... ok
+2026-08-01T02:44:05.2619973Z test get_requires_admin_role ... ok
+2026-08-01T02:44:05.2623221Z test get_requires_authentication ... ok
+2026-08-01T02:44:05.5855189Z test import_confirm_applies_profile_and_overrides ... ok
+2026-08-01T02:44:05.5887194Z test import_apply_503_when_audit_writer_missing ... ok
+2026-08-01T02:44:05.6217795Z test import_dry_run_works_without_audit_writer ... ok
+2026-08-01T02:44:05.6240420Z test import_dry_run_returns_diff_without_persisting ... ok
+2026-08-01T02:44:05.9164425Z test import_preview_reports_pending_restart_before_confirming ... ok
+2026-08-01T02:44:05.9409765Z test import_refuses_mismatched_community_did_with_409 ... ok
+2026-08-01T02:44:05.9442282Z test import_ignores_the_pre_migration_confirm_query_param ... ok
+2026-08-01T02:44:05.9705228Z test import_rejects_an_unknown_top_level_member ... ok
+2026-08-01T02:44:06.2363875Z test import_rejects_unknown_config_key ... ok
+2026-08-01T02:44:06.2554820Z test import_rejects_invalid_value_with_reason ... ok
+2026-08-01T02:44:06.2879558Z test import_wrong_schema_version_returns_400 ... ok
+2026-08-01T02:44:06.5434327Z test patch_503_when_audit_writer_missing ... ok
+2026-08-01T02:44:06.5943265Z test patch_applies_reloadable_key_immediately ... ok
+2026-08-01T02:44:06.6263130Z test patch_emits_config_changed_audit_with_real_actor ... ok
+2026-08-01T02:44:06.6513359Z test import_round_trip_export_then_import_equivalence ... ok
+2026-08-01T02:44:06.8719494Z test patch_empty_body_returns_empty_response ... ok
+2026-08-01T02:44:06.9300983Z test patch_invalid_value_rejected_with_reason ... ok
+2026-08-01T02:44:06.9553919Z test patch_mixed_batch_partitions_correctly ... ok
+2026-08-01T02:44:06.9786046Z test patch_rejects_only_does_not_need_audit_writer ... ok
+2026-08-01T02:44:07.2082529Z test patch_rejects_the_pre_migration_flattened_body ... ok
+2026-08-01T02:44:07.2683502Z test patch_requires_admin_role ... ok
+2026-08-01T02:44:07.2814192Z test patch_restart_required_key_is_pending ... ok
+2026-08-01T02:44:07.3038296Z test patch_unknown_key_rejected_with_reason ... ok
+2026-08-01T02:44:07.5254312Z test reload_503_when_audit_writer_missing ... ok
+2026-08-01T02:44:07.6107963Z test reload_no_diff_returns_empty_keys_reloaded ... ok
+2026-08-01T02:44:07.6251822Z test reload_applies_hot_reloadable_diff ... ok
+2026-08-01T02:44:07.6422845Z test reload_requires_admin_role ... ok
+2026-08-01T02:44:07.8644750Z test restart_503_when_audit_writer_missing ... ok
+2026-08-01T02:44:07.9402997Z test restart_emits_audit_event_before_signal ... ok
+2026-08-01T02:44:07.9576829Z test restart_requires_admin_role ... ok
+2026-08-01T02:44:07.9636203Z test restart_with_supervisor_triggers_shutdown ... ok
+2026-08-01T02:44:08.1361180Z test restart_without_supervisor_returns_412 ... ok
+2026-08-01T02:44:08.1737816Z test restart_wrong_trust_task_returns_415 ... ok
+2026-08-01T02:44:08.1738584Z 
+2026-08-01T02:44:08.1739450Z test result: ok. 41 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 3.64s
+2026-08-01T02:44:08.1740502Z 
+2026-08-01T02:44:08.1783761Z [1m[92m     Running[0m tests/admin_passkeys.rs (target/debug/deps/admin_passkeys-1032cebcba42b4cd)
+2026-08-01T02:44:08.1948677Z 
+2026-08-01T02:44:08.1949236Z running 12 tests
+2026-08-01T02:44:08.5987713Z test list_requires_authentication ... ok
+2026-08-01T02:44:08.6005307Z test list_requires_admin_role ... ok
+2026-08-01T02:44:08.6060060Z test list_returns_bootstrap_passkey ... ok
+2026-08-01T02:44:08.6083102Z test register_finish_without_start_returns_401 ... ok
+2026-08-01T02:44:08.9129316Z test register_returns_503_when_audit_writer_missing ... ok
+2026-08-01T02:44:08.9238119Z test register_succeeds_with_step_up_uv ... ok
+2026-08-01T02:44:08.9358144Z test register_start_returns_415_with_wrong_trust_task ... ok
+2026-08-01T02:44:08.9502983Z test register_rejects_when_uv_signed_by_wrong_authenticator ... ok
+2026-08-01T02:44:09.2363653Z test revoke_finish_without_start_returns_401 ... ok
+2026-08-01T02:44:09.2518612Z test revoke_last_passkey_returns_409_last_passkey_protected ... ok
+2026-08-01T02:44:09.2530074Z test revoke_rejects_unknown_credential_id ... ok
+2026-08-01T02:44:09.2565678Z test revoke_after_register_succeeds_and_emits_audit_event ... ok
+2026-08-01T02:44:09.2566390Z 
+2026-08-01T02:44:09.2567110Z test result: ok. 12 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.06s
+2026-08-01T02:44:09.2567693Z 
+2026-08-01T02:44:09.2628407Z [1m[92m     Running[0m tests/audit_list.rs (target/debug/deps/audit_list-4d8eb3a99e76f695)
+2026-08-01T02:44:09.2801306Z 
+2026-08-01T02:44:09.2802365Z running 9 tests
+2026-08-01T02:44:09.7200110Z test actor_filter_is_actually_applied ... ok
+2026-08-01T02:44:09.7207677Z test entry_hashes_are_hex_matching_audit_verify_head ... ok
+2026-08-01T02:44:09.7225956Z test action_filter_is_actually_applied ... ok
+2026-08-01T02:44:09.7234014Z test a_cursor_cannot_be_replayed_under_different_filters ... ok
+2026-08-01T02:44:10.0378114Z test non_super_admin_is_refused ... ok
+2026-08-01T02:44:10.0555285Z test truncated_reflects_matching_entries_not_raw_rows ... ok
+2026-08-01T02:44:10.0632637Z test response_and_entries_are_the_canonical_shape ... ok
+2026-08-01T02:44:10.0722270Z test time_window_filters_are_applied ... ok
+2026-08-01T02:44:10.2429023Z test unsupported_filters_are_refused_not_ignored ... ok
+2026-08-01T02:44:10.2429346Z 
+2026-08-01T02:44:10.2429768Z test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.96s
+2026-08-01T02:44:10.2430244Z 
+2026-08-01T02:44:10.2481371Z [1m[92m     Running[0m tests/audit_signout.rs (target/debug/deps/audit_signout-22a23d0ad59acf1f)
+2026-08-01T02:44:10.2649792Z 
+2026-08-01T02:44:10.2650312Z running 3 tests
+2026-08-01T02:44:10.6101423Z test a_second_sign_out_is_rejected_and_not_audited_twice ... ok
+2026-08-01T02:44:10.6103230Z test sign_out_emits_a_signed_out_envelope ... ok
+2026-08-01T02:44:10.6103935Z test sign_out_is_distinct_from_session_revoked ... ok
+2026-08-01T02:44:10.6104327Z 
+2026-08-01T02:44:10.6104736Z test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.35s
+2026-08-01T02:44:10.6105311Z 
+2026-08-01T02:44:10.6139876Z [1m[92m     Running[0m tests/audit_verify.rs (target/debug/deps/audit_verify-2f1985541e24fceb)
+2026-08-01T02:44:10.6300219Z 
+2026-08-01T02:44:10.6300688Z running 13 tests
+2026-08-01T02:44:11.0443600Z test a_dropped_envelope_breaks_the_link ... ok
+2026-08-01T02:44:11.0469729Z test a_checkpoint_naming_an_unknown_key_is_not_verified_against_the_live_one ... ok
+2026-08-01T02:44:11.0625363Z test a_checkpoint_forged_with_a_foreign_key_is_rejected ... ok
+2026-08-01T02:44:11.0683725Z test a_checkpointed_log_verifies_as_consistent ... ok
+2026-08-01T02:44:11.3651884Z test a_real_chain_verifies_and_reports_its_head ... ok
+2026-08-01T02:44:11.3838519Z test a_log_with_no_checkpoints_says_so_rather_than_looking_clean ... ok
+2026-08-01T02:44:11.3897728Z test a_tampered_envelope_is_caught ... ok
+2026-08-01T02:44:11.4049574Z test a_vtc_with_no_signing_key_cannot_claim_checkpoint_health ... ok
+2026-08-01T02:44:11.7103412Z test empty_log_verifies_vacuously ... ok
+2026-08-01T02:44:11.7119048Z test deleting_a_checkpoint_is_itself_detected ... ok
+2026-08-01T02:44:11.7195396Z test entries_written_after_a_checkpoint_are_reported_as_unattested ... ok
+2026-08-01T02:44:11.7203955Z test non_super_admin_is_refused ... ok
+2026-08-01T02:44:11.9186355Z test truncating_the_log_is_caught_even_though_the_chain_still_verifies ... ok
+2026-08-01T02:44:11.9186892Z 
+2026-08-01T02:44:11.9187190Z test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.29s
+2026-08-01T02:44:11.9187620Z 
+2026-08-01T02:44:11.9231132Z [1m[92m     Running[0m tests/auth_acl_roles.rs (target/debug/deps/auth_acl_roles-3687a9e00ab9d894)
+2026-08-01T02:44:11.9393814Z 
+2026-08-01T02:44:11.9394776Z running 3 tests
+2026-08-01T02:44:12.3710132Z test moderator_row_yields_clean_403_not_500_serde_leak ... ok
+2026-08-01T02:44:12.3724508Z test admin_row_still_authenticates ... ok
+2026-08-01T02:44:12.4604788Z test every_non_admin_vtc_role_is_cleanly_forbidden ... ok
+2026-08-01T02:44:12.4606242Z 
+2026-08-01T02:44:12.4607169Z test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.52s
+2026-08-01T02:44:12.4608073Z 
+2026-08-01T02:44:12.4642851Z [1m[92m     Running[0m tests/auth_audience.rs (target/debug/deps/auth_audience-e7e96b3b423a9aae)
+2026-08-01T02:44:12.4805568Z 
+2026-08-01T02:44:12.4806182Z running 6 tests
+2026-08-01T02:44:12.8585418Z test mismatched_trust_task_header_returns_415 ... ok
+2026-08-01T02:44:12.8604880Z test missing_trust_task_header_returns_400 ... ok
+2026-08-01T02:44:12.8605756Z test health_is_exempt_from_trust_task ... ok
+2026-08-01T02:44:12.8632594Z test no_token_rejected_by_vtc_route ... ok
+2026-08-01T02:44:13.1027760Z test vta_audience_token_rejected_by_vtc_route ... ok
+2026-08-01T02:44:13.1053430Z test unknown_audience_token_rejected_by_vtc_route ... ok
+2026-08-01T02:44:13.1054324Z 
+2026-08-01T02:44:13.1054726Z test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.63s
+2026-08-01T02:44:13.1055208Z 
+2026-08-01T02:44:13.1091426Z [1m[92m     Running[0m tests/auth_di_trust_task.rs (target/debug/deps/auth_di_trust_task-4e5ea873290bfe2e)
+2026-08-01T02:44:13.1253127Z 
+2026-08-01T02:44:13.1253631Z running 4 tests
+2026-08-01T02:44:13.6106902Z test unsigned_authenticate_document_is_not_claimed_by_the_di_path ... ok
+2026-08-01T02:44:13.6354151Z test di_login_then_trust_task_refresh_round_trips ... ok
+2026-08-01T02:44:13.6413441Z test di_signed_trust_task_authenticates_over_rest ... ok
+2026-08-01T02:44:13.6454992Z test tampered_challenge_is_rejected ... ok
+2026-08-01T02:44:13.6455384Z 
+2026-08-01T02:44:13.6455819Z test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.52s
+2026-08-01T02:44:13.6456417Z 
+2026-08-01T02:44:13.6487134Z [1m[92m     Running[0m tests/auth_forged_plaintext.rs (target/debug/deps/auth_forged_plaintext-9956e3e6943cabd3)
+2026-08-01T02:44:13.6668972Z 
+2026-08-01T02:44:13.6669547Z running 2 tests
+2026-08-01T02:44:14.1840532Z test plaintext_didcomm_refresh_is_rejected ... ok
+2026-08-01T02:44:14.1875106Z test plaintext_didcomm_with_forged_sender_is_rejected ... ok
+2026-08-01T02:44:14.1875672Z 
+2026-08-01T02:44:14.1878893Z test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.52s
+2026-08-01T02:44:14.1879502Z 
+2026-08-01T02:44:14.1906025Z [1m[92m     Running[0m tests/backup.rs (target/debug/deps/backup-da859fb6655d8772)
+2026-08-01T02:44:14.2074470Z 
+2026-08-01T02:44:14.2074967Z running 7 tests
+2026-08-01T02:44:20.4849216Z test export_rejects_short_password ... ok
+2026-08-01T02:44:24.9356693Z test full_state_roundtrip_restores_rows_and_bundle ... ok
+2026-08-01T02:44:25.6833492Z test excluding_the_audit_log_also_excludes_its_checkpoints ... ok
+2026-08-01T02:44:26.1129575Z test audit_and_its_checkpoints_round_trip_together ... ok
+2026-08-01T02:44:31.0255779Z test import_rejects_foreign_vtc_did ... ok
+2026-08-01T02:44:32.3541139Z test wrong_password_rejected ... ok
+2026-08-01T02:44:33.2062994Z test preview_does_not_mutate ... ok
+2026-08-01T02:44:33.2063396Z 
+2026-08-01T02:44:33.2063749Z test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 19.00s
+2026-08-01T02:44:33.2064121Z 
+2026-08-01T02:44:33.2095033Z [1m[92m     Running[0m tests/ceremony_execute.rs (target/debug/deps/ceremony_execute-d6a8fec6ef0430ce)
+2026-08-01T02:44:33.2247055Z 
+2026-08-01T02:44:33.2247611Z running 9 tests
+2026-08-01T02:44:33.6762864Z test admit_honours_the_plan_role ... ok
+2026-08-01T02:44:33.6763614Z test admit_duplicate_acl_is_conflict ... ok
+2026-08-01T02:44:33.6764136Z test depart_refuses_the_last_admin ... ok
+2026-08-01T02:44:33.6766495Z test concurrent_admits_for_one_did_yield_one_membership ... ok
+2026-08-01T02:44:33.9778817Z test no_state_change_is_a_noop ... ok
+2026-08-01T02:44:34.1054657Z test depart_removes_member_and_revokes ... ok
+2026-08-01T02:44:34.1369786Z test remint_changes_role_and_reissues_vec ... ok
+2026-08-01T02:44:34.1834981Z test member_count_cache_tracks_list_members_len ... ok
+2026-08-01T02:44:34.1877038Z test remint_refuses_demoting_the_last_admin ... ok
+2026-08-01T02:44:34.1877528Z 
+2026-08-01T02:44:34.1877912Z test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.96s
+2026-08-01T02:44:34.1878341Z 
+2026-08-01T02:44:34.1925903Z [1m[92m     Running[0m tests/community_profile.rs (target/debug/deps/community_profile-ef625dddf161d03e)
+2026-08-01T02:44:34.2090943Z 
+2026-08-01T02:44:34.2091303Z running 15 tests
+2026-08-01T02:44:34.5494467Z test get_requires_authentication ... ok
+2026-08-01T02:44:34.5509419Z test get_with_wrong_trust_task_returns_415 ... ok
+2026-08-01T02:44:34.5569754Z test get_returns_404_when_not_initialised ... ok
+2026-08-01T02:44:34.5622478Z test get_returns_profile_when_initialised ... ok
+2026-08-01T02:44:34.8269381Z test public_profile_returns_404_when_not_initialised ... ok
+2026-08-01T02:44:34.8371014Z test put_503_when_audit_writer_missing ... ok
+2026-08-01T02:44:34.8467996Z test public_profile_returns_curated_subset_unauthenticated ... ok
+2026-08-01T02:44:34.8569474Z test put_does_not_accept_community_did_in_request ... ok
+2026-08-01T02:44:35.1093517Z test put_emits_profile_updated_audit_with_real_actor ... ok
+2026-08-01T02:44:35.1339698Z test put_idempotent_noop_returns_empty_changeset ... ok
+2026-08-01T02:44:35.1421481Z test put_idempotent_noop_does_not_need_audit_writer ... ok
+2026-08-01T02:44:35.1559178Z test put_rejects_oversized_extensions ... ok
+2026-08-01T02:44:35.3774356Z test put_requires_admin_role ... ok
+2026-08-01T02:44:35.3856251Z test put_returns_404_when_profile_not_initialised ... ok
+2026-08-01T02:44:35.3917220Z test put_updates_profile_and_lists_changed_fields ... ok
+2026-08-01T02:44:35.3918683Z 
+2026-08-01T02:44:35.3919091Z test result: ok. 15 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.18s
+2026-08-01T02:44:35.3919684Z 
+2026-08-01T02:44:35.3949645Z [1m[92m     Running[0m tests/config_identity.rs (target/debug/deps/config_identity-3c662b79c98378f7)
+2026-08-01T02:44:35.4117525Z 
+2026-08-01T02:44:35.4117869Z running 3 tests
+2026-08-01T02:44:35.7170836Z test legacy_config_surface_is_no_longer_routed ... ok
+2026-08-01T02:44:35.7261828Z test canonical_patch_cannot_rewrite_community_identity ... ok
+2026-08-01T02:44:35.7267707Z test canonical_patch_owns_public_url_and_defers_it_to_restart ... ok
+2026-08-01T02:44:35.7268088Z 
+2026-08-01T02:44:35.7268389Z test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.32s
+2026-08-01T02:44:35.7268744Z 
+2026-08-01T02:44:35.7297374Z [1m[92m     Running[0m tests/cookie_session.rs (target/debug/deps/cookie_session-6ccc64d3b721665a)
+2026-08-01T02:44:35.7457154Z 
+2026-08-01T02:44:35.7457696Z running 8 tests
+2026-08-01T02:44:36.0943105Z test bearer_mutation_bypasses_csrf ... ok
+2026-08-01T02:44:36.1004840Z test admin_cookie_authenticates_protected_route ... ok
+2026-08-01T02:44:36.1034149Z test bearer_takes_precedence_over_cookie ... ok
+2026-08-01T02:44:36.1041297Z test cookie_alongside_other_cookies_authenticates ... ok
+2026-08-01T02:44:36.3803588Z test cookie_session_mutation_without_csrf_token_is_forbidden ... ok
+2026-08-01T02:44:36.3807654Z test cookie_session_mutation_with_same_origin_passes_csrf ... ok
+2026-08-01T02:44:36.3850495Z test foreign_audience_cookie_rejected ... ok
+2026-08-01T02:44:36.3929056Z test wrong_cookie_name_returns_401 ... ok
+2026-08-01T02:44:36.3929757Z 
+2026-08-01T02:44:36.3930183Z test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.65s
+2026-08-01T02:44:36.3930922Z 
+2026-08-01T02:44:36.3963765Z [1m[92m     Running[0m tests/diagnostics.rs (target/debug/deps/diagnostics-cdbfb0b72d8a7d02)
+2026-08-01T02:44:36.4111967Z 
+2026-08-01T02:44:36.4112641Z running 6 tests
+2026-08-01T02:44:36.7353492Z test diagnostics_requires_trust_task_header ... ok
+2026-08-01T02:44:36.7389966Z test diagnostics_requires_admin_role ... ok
+2026-08-01T02:44:36.7407204Z test diagnostics_empty_queue_reports_zero_counts ... ok
+2026-08-01T02:44:36.7441141Z test diagnostics_reports_pending_rtbf_and_failed_counts ... ok
+2026-08-01T02:44:36.9220004Z test health_payload_is_minimal_and_unauth ... ok
+2026-08-01T02:44:36.9243910Z test diagnostics_surfaces_mediator_detail_to_admin ... ok
+2026-08-01T02:44:36.9244220Z 
+2026-08-01T02:44:36.9244490Z test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.51s
+2026-08-01T02:44:36.9244928Z 
+2026-08-01T02:44:36.9268612Z [1m[92m     Running[0m tests/did_log.rs (target/debug/deps/did_log-3f24b0c8803c90a3)
+2026-08-01T02:44:36.9422756Z 
+2026-08-01T02:44:36.9423243Z running 6 tests
+2026-08-01T02:44:37.2827237Z test did_log_response_carries_nosniff ... ok
+2026-08-01T02:44:37.2836004Z test returns_404_when_only_a_foreign_label_log_exists ... ok
+2026-08-01T02:44:37.2837268Z test returns_404_when_configured_label_would_traverse ... ok
+2026-08-01T02:44:37.2838698Z test returns_404_when_file_missing ... ok
+2026-08-01T02:44:37.4560934Z test route_is_trust_task_exempt ... ok
+2026-08-01T02:44:37.4561558Z test serverless_dotted_host_did_resolves_as_jsonl ... ok
+2026-08-01T02:44:37.4561913Z 
+2026-08-01T02:44:37.4562470Z test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.51s
+2026-08-01T02:44:37.4562825Z 
+2026-08-01T02:44:37.4589821Z [1m[92m     Running[0m tests/directory.rs (target/debug/deps/directory-d379fa356d840410)
+2026-08-01T02:44:37.4765097Z 
+2026-08-01T02:44:37.4765681Z running 4 tests
+2026-08-01T02:44:37.8654896Z test unauthenticated_is_rejected ... ok
+2026-08-01T02:44:37.8784631Z test admin_viewer_sees_full_record ... ok
+2026-08-01T02:44:37.8807382Z test member_viewer_sees_did_and_role_only ... ok
+2026-08-01T02:44:37.8807988Z test non_member_subject_projects_did_only ... ok
+2026-08-01T02:44:37.8808337Z 
+2026-08-01T02:44:37.8808754Z test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.40s
+2026-08-01T02:44:37.8809347Z 
+2026-08-01T02:44:37.8855996Z [1m[92m     Running[0m tests/emergency_bootstrap.rs (target/debug/deps/emergency_bootstrap-c3cf89a6e7273d11)
+2026-08-01T02:44:37.9030863Z 
+2026-08-01T02:44:37.9031324Z running 6 tests
+2026-08-01T02:44:38.6451655Z test no_secret_in_store_yields_clean_config_error ... ok
+2026-08-01T02:44:39.4505322Z test emergency_bootstrap_clears_all_sessions_and_their_refresh_index ... ok
+2026-08-01T02:44:39.5208711Z test happy_path_clears_admin_via_vta_and_audits_on_restart ... ok
+2026-08-01T02:44:39.6664145Z test vta_rejects_unauthorized_recovery_did_and_state_unchanged ... ok
+2026-08-01T02:44:39.8544996Z test outcome_install_url_falls_back_to_vtc_scheme_when_public_url_missing ... ok
+2026-08-01T02:44:40.1132755Z test fresh_install_url_works_for_claim_start_after_emergency_bootstrap ... ok
+2026-08-01T02:44:40.1133303Z 
+2026-08-01T02:44:40.1133724Z test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.21s
+2026-08-01T02:44:40.1134307Z 
+2026-08-01T02:44:40.1186903Z [1m[92m     Running[0m tests/endorsements.rs (target/debug/deps/endorsements-304e68adc16967b9)
+2026-08-01T02:44:40.1342279Z 
+2026-08-01T02:44:40.1342696Z running 14 tests
+2026-08-01T02:44:40.5604375Z test delete_type_404_when_unknown ... ok
+2026-08-01T02:44:40.5680306Z test issue_rejects_non_issuer_non_admin ... ok
+2026-08-01T02:44:40.6099962Z test issue_happy_path_issuer_mints_credential ... ok
+2026-08-01T02:44:40.6471504Z test delete_type_refused_while_live_endorsement_exists ... ok
+2026-08-01T02:44:40.8913400Z test issue_rejects_unregistered_type ... ok
+2026-08-01T02:44:40.8925194Z test issue_rejects_unknown_subject ... ok
+2026-08-01T02:44:40.9351438Z test list_types_enforces_its_own_task_per_method ... ok
+2026-08-01T02:44:40.9707964Z test register_happy_path ... ok
+2026-08-01T02:44:41.2187608Z test register_rejects_reserved_uri ... ok
+2026-08-01T02:44:41.2239177Z test register_rejects_duplicate ... ok
+2026-08-01T02:44:41.2629148Z test register_requires_admin ... ok
+2026-08-01T02:44:41.3610839Z test revoke_idempotent_on_already_revoked ... ok
+2026-08-01T02:44:41.5403676Z test revoke_non_admin_non_issuer_forbidden ... ok
+2026-08-01T02:44:41.5625473Z test revoke_issuer_can_retract ... ok
+2026-08-01T02:44:41.5625760Z 
+2026-08-01T02:44:41.5626151Z test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.43s
+2026-08-01T02:44:41.5626555Z 
+2026-08-01T02:44:41.5668568Z [1m[92m     Running[0m tests/install_claim.rs (target/debug/deps/install_claim-9d0cfa48dabdf551)
+2026-08-01T02:44:41.5832316Z 
+2026-08-01T02:44:41.5833136Z running 13 tests
+2026-08-01T02:44:41.9586207Z test finish_rejects_mismatched_registration_id ... ok
+2026-08-01T02:44:42.1715724Z test finish_without_start_fails ... ok
+2026-08-01T02:44:42.4041144Z test full_ceremony_completes_end_to_end ... ok
+2026-08-01T02:44:42.6305774Z test missing_trust_task_header_returns_400 ... ok
+2026-08-01T02:44:42.6977670Z test claim_secret_missing_returns_required_code ... ok
+2026-08-01T02:44:42.8579016Z test second_concurrent_start_within_window_is_conflict ... ok
+2026-08-01T02:44:42.9294027Z test start_rejects_unknown_jti ... ok
+2026-08-01T02:44:43.0928828Z test start_rejects_unsigned_token ... ok
+2026-08-01T02:44:43.1583847Z test start_returns_503_when_install_signer_missing ... ok
+2026-08-01T02:44:43.3325926Z test start_returns_503_when_webauthn_missing ... ok
+2026-08-01T02:44:43.3988766Z test wrong_trust_task_header_returns_415 ... ok
+2026-08-01T02:44:43.5634973Z test claim_secret_wrong_returns_invalid_code ... ok
+2026-08-01T02:44:43.5669390Z test claim_secret_happy_path_completes_ceremony ... ok
+2026-08-01T02:44:43.5669824Z 
+2026-08-01T02:44:43.5670227Z test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.98s
+2026-08-01T02:44:43.5670652Z 
+2026-08-01T02:44:43.5725415Z [1m[92m     Running[0m tests/install_flow.rs (target/debug/deps/install_flow-3f212a765f852e8b)
+2026-08-01T02:44:43.5894648Z 
+2026-08-01T02:44:43.5894950Z running 1 test
+2026-08-01T02:44:43.8817008Z test end_to_end_install_flow_phase_0_gate ... ok
+2026-08-01T02:44:43.8817298Z 
+2026-08-01T02:44:43.8817567Z test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.29s
+2026-08-01T02:44:43.8817922Z 
+2026-08-01T02:44:43.8848233Z [1m[92m     Running[0m tests/invitations.rs (target/debug/deps/invitations-c1af9d4fad0bccee)
+2026-08-01T02:44:43.9021358Z 
+2026-08-01T02:44:43.9021588Z running 9 tests
+2026-08-01T02:44:44.3225579Z test invite_refuses_admin_role ... ok
+2026-08-01T02:44:44.3611025Z test inviting_a_departed_tombstoned_did_is_allowed ... ok
+2026-08-01T02:44:44.3894498Z test admin_issues_a_revocable_vic_bound_to_the_invitee ... ok
+2026-08-01T02:44:44.4283214Z test invite_can_grant_a_role_via_scopes ... ok
+2026-08-01T02:44:44.6413443Z test inviting_an_existing_member_is_a_conflict ... ok
+2026-08-01T02:44:44.7528143Z test non_privileged_member_cannot_issue ... ok
+2026-08-01T02:44:44.7654405Z test issuing_an_invitation_emits_audit ... ok
+2026-08-01T02:44:44.7840860Z test issue_list_revoke_round_trip ... ok
+2026-08-01T02:44:44.8745915Z test revoke_unknown_invitation_is_404 ... ok
+2026-08-01T02:44:44.8746193Z 
+2026-08-01T02:44:44.8746474Z test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.97s
+2026-08-01T02:44:44.8746829Z 
+2026-08-01T02:44:44.8786972Z [1m[92m     Running[0m tests/join_didcomm.rs (target/debug/deps/join_didcomm-c48be7bdbb43aa9d)
+2026-08-01T02:44:44.8967660Z 
+2026-08-01T02:44:44.8968117Z running 3 tests
+2026-08-01T02:44:46.1107840Z test didcomm_try_request_classifies_reject_and_keeps_going ... ok
+2026-08-01T02:44:46.1454646Z test didcomm_duplicate_submit_rejects_with_conflict_not_internal_error ... ok
+2026-08-01T02:44:48.1086644Z test didcomm_join_round_trips_submit_manifest_status_approve_and_vmc_delivery ... ok
+2026-08-01T02:44:48.1087258Z 
+2026-08-01T02:44:48.1087633Z test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 3.21s
+2026-08-01T02:44:48.1087994Z 
+2026-08-01T02:44:48.1133529Z [1m[92m     Running[0m tests/join_requests.rs (target/debug/deps/join_requests-5a0dcadd1c9f6e63)
+2026-08-01T02:44:48.1287103Z 
+2026-08-01T02:44:48.1287432Z running 45 tests
+2026-08-01T02:44:48.5431806Z test admin_query_send_requires_admin ... ok
+2026-08-01T02:44:48.5493497Z test admin_query_send_404s_an_unknown_criterion ... ok
+2026-08-01T02:44:48.5505797Z test admin_list_get_is_not_rate_limited ... ok
+2026-08-01T02:44:48.5508479Z test admin_query_send_prepares_a_dcql_query_and_issues_a_challenge ... ok
+2026-08-01T02:44:48.8742499Z test approve_404_for_unknown_id ... ok
+2026-08-01T02:44:48.9774368Z test approve_writes_acl_and_member_atomically ... ok
+2026-08-01T02:44:48.9854009Z test approve_409_when_duplicate_acl_exists ... ok
+2026-08-01T02:44:48.9865690Z test approve_409_when_request_already_decided ... ok
+2026-08-01T02:44:49.2090988Z test auto_admit_emits_membership_issuance_audit ... ok
+2026-08-01T02:44:49.4078548Z test credential_exchange_present_defers_under_default_policy ... ok
+2026-08-01T02:44:49.4502240Z test credential_exchange_present_auto_admits_under_allow_policy ... ok
+2026-08-01T02:44:49.5053771Z test credential_exchange_present_over_a_single_use_challenge_closes_the_loop ... ok
+2026-08-01T02:44:49.5140445Z test credential_exchange_present_rejects_a_wrong_nonce ... ok
+2026-08-01T02:44:49.8100837Z test list_requires_authentication ... ok
+2026-08-01T02:44:49.8634689Z test list_returns_pending_by_default ... ok
+2026-08-01T02:44:49.9039649Z test manifest_lists_registered_criteria ... ok
+2026-08-01T02:44:49.9207271Z test manifest_is_empty_when_no_criteria_registered ... ok
+2026-08-01T02:44:50.5724780Z test manual_approve_emits_membership_issuance_audit ... ok
+2026-08-01T02:44:50.6193947Z test policy_rejected_row_cannot_be_approved ... ok
+2026-08-01T02:44:50.7060970Z test reject_leaves_no_acl_or_member_rows ... ok
+2026-08-01T02:44:50.7131943Z test reject_rejects_overlong_reason ... ok
+2026-08-01T02:44:51.1119181Z test rest_submit_happy_path_persists_pending ... ok
+2026-08-01T02:44:51.1320488Z test rest_submit_dedups_an_open_request_for_the_same_applicant ... ok
+2026-08-01T02:44:51.1832884Z test rest_submit_rejects_a_foreign_recipient ... ok
+2026-08-01T02:44:51.1871689Z test rest_submit_rejects_an_expired_document ... ok
+2026-08-01T02:44:51.4718334Z test rest_submit_rejects_missing_holder_proof ... ok
+2026-08-01T02:44:51.4985108Z test rest_submit_rejects_wrong_signer ... ok
+2026-08-01T02:44:51.5682714Z test rest_submit_under_default_join_policy_lands_pending_with_vp_claims ... ok
+2026-08-01T02:44:51.6516995Z test rest_submit_under_allow_policy_auto_admits ... ok
+2026-08-01T02:44:51.8725422Z test rest_submit_under_deny_all_policy_persists_rejected_with_decision ... ok
+2026-08-01T02:44:51.9261526Z test retired_accept_type_is_no_longer_dispatched ... ok
+2026-08-01T02:44:51.9587880Z test show_returns_full_request_including_vp ... ok
+2026-08-01T02:44:52.0822584Z test status_deferred_returns_needs_and_presentation_definition ... ok
+2026-08-01T02:44:52.2862428Z test status_rejects_a_wrong_signer ... ok
+2026-08-01T02:44:52.3188654Z test status_returns_pending_for_the_applicant ... ok
+2026-08-01T02:44:52.3849575Z test status_taskfailed_for_an_unknown_request ... ok
+2026-08-01T02:44:52.4594431Z test trust_tasks_post_is_rate_limited ... ok
+2026-08-01T02:44:52.7143381Z test vmc_conflicts_when_request_not_yet_approved ... ok
+2026-08-01T02:44:52.7833567Z test vmc_rejects_a_credential_for_another_community ... ok
+2026-08-01T02:44:52.9023401Z test vmc_rejects_a_tampered_credential ... ok
+2026-08-01T02:44:52.9283579Z test vmc_rejects_a_wrong_holder_signature ... ok
+2026-08-01T02:44:53.2537205Z test vmc_taskfailed_for_an_unknown_request_id ... ok
+2026-08-01T02:44:53.2994509Z test vmc_with_request_id_is_idempotent_for_the_same_vc ... ok
+2026-08-01T02:44:53.3661154Z test vmc_with_request_id_records_the_reciprocal_edge ... ok
+2026-08-01T02:44:53.4632694Z test vmc_with_request_id_replaces_on_a_different_vc ... ok
+2026-08-01T02:44:53.4633154Z 
+2026-08-01T02:44:53.4633469Z test result: ok. 45 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 5.33s
+2026-08-01T02:44:53.4633862Z 
+2026-08-01T02:44:53.4684030Z [1m[92m     Running[0m tests/members_crud.rs (target/debug/deps/members_crud-5ffb3345b44a40a8)
+2026-08-01T02:44:53.4859667Z 
+2026-08-01T02:44:53.4860226Z running 18 tests
+2026-08-01T02:44:53.9015227Z test list_members_requires_admin_role ... ok
+2026-08-01T02:44:53.9078246Z test list_members_empty_returns_empty_items ... ok
+2026-08-01T02:44:53.9122479Z test list_members_returns_seeded_members ... ok
+2026-08-01T02:44:53.9197796Z test list_members_filter_by_role_drops_non_matching ... ok
+2026-08-01T02:44:54.2527575Z test list_members_skips_tombstoned_member_with_no_acl ... ok
+2026-08-01T02:44:54.2681079Z test patch_member_404_for_unknown_did ... ok
+2026-08-01T02:44:54.2704686Z test list_removed_returns_tombstoned_members_and_purge_deletes_them ... ok
+2026-08-01T02:44:54.3194618Z test patch_member_profile_only_emits_member_updated ... ok
+2026-08-01T02:44:54.6208040Z test patch_member_role_admin_refuses_a_lapsed_step_up ... ok
+2026-08-01T02:44:54.6211497Z test patch_member_role_admin_promotes_with_a_live_step_up ... ok
+2026-08-01T02:44:54.6330427Z test patch_member_role_admin_requires_a_fresh_step_up ... ok
+2026-08-01T02:44:54.6788002Z test patch_member_role_member_to_moderator_succeeds_and_emits_audit ... ok
+2026-08-01T02:44:54.9531650Z test promoting_an_existing_admin_is_an_idempotent_no_op ... ok
+2026-08-01T02:44:54.9639733Z test promote_404_for_non_member_target ... ok
+2026-08-01T02:44:54.9645854Z test promote_rejects_caller_promoting_themselves ... ok
+2026-08-01T02:44:55.0304697Z test show_member_rejects_malformed_did_path_param ... ok
+2026-08-01T02:44:55.1956106Z test show_member_returns_404_for_unknown_did ... ok
+2026-08-01T02:44:55.2147117Z test show_member_returns_joined_response ... ok
+2026-08-01T02:44:55.2147557Z 
+2026-08-01T02:44:55.2147951Z test result: ok. 18 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.73s
+2026-08-01T02:44:55.2148312Z 
+2026-08-01T02:44:55.2197802Z [1m[92m     Running[0m tests/passkey_state.rs (target/debug/deps/passkey_state-6a9b3d415827ec9f)
+2026-08-01T02:44:55.2268510Z 
+2026-08-01T02:44:55.2268883Z running 5 tests
+2026-08-01T02:44:55.5127277Z test token_expiries_track_auth_config_defaults ... ok
+2026-08-01T02:44:55.5157356Z test enrollment_ttl_uses_workspace_default ... ok
+2026-08-01T02:44:55.5168445Z test webauthn_returns_none_when_public_url_unset ... ok
+2026-08-01T02:44:55.5277121Z test passkey_state_acl_ks_matches_app_state_field ... ok
+2026-08-01T02:44:55.6711172Z test webauthn_returns_some_when_public_url_set ... ok
+2026-08-01T02:44:55.6712334Z 
+2026-08-01T02:44:55.6713465Z test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.44s
+2026-08-01T02:44:55.6714352Z 
+2026-08-01T02:44:55.6726796Z [1m[92m     Running[0m tests/passkey_step_up.rs (target/debug/deps/passkey_step_up-3f03c0ab80c8d54e)
+2026-08-01T02:44:55.6892202Z 
+2026-08-01T02:44:55.6892741Z running 8 tests
+2026-08-01T02:44:56.0920081Z test a_step_up_ceremony_cannot_be_replayed ... ok
+2026-08-01T02:44:56.0926611Z test step_up_elevates_the_session_in_place ... ok
+2026-08-01T02:44:56.0971155Z test plain_login_is_unchanged_by_the_purpose_field ... ok
+2026-08-01T02:44:56.0984718Z test a_step_up_authorises_the_promotion_it_was_run_for ... ok
+2026-08-01T02:44:56.4244914Z test step_up_subject_must_match_the_session ... ok
+2026-08-01T02:44:56.4245558Z test step_up_refuses_another_subjects_passkey ... ok
+2026-08-01T02:44:56.4311254Z test step_up_requires_an_authenticated_session ... ok
+2026-08-01T02:44:56.4426039Z test step_up_is_bound_to_the_session_that_started_it ... ok
+2026-08-01T02:44:56.4426515Z 
+2026-08-01T02:44:56.4426830Z test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.75s
+2026-08-01T02:44:56.4427189Z 
+2026-08-01T02:44:56.4472885Z [1m[92m     Running[0m tests/personhood.rs (target/debug/deps/personhood-369b5b5883b03de5)
+2026-08-01T02:44:56.4640122Z 
+2026-08-01T02:44:56.4640634Z running 9 tests
+2026-08-01T02:44:56.9371063Z test challenge_returns_404_for_non_member ... ok
+2026-08-01T02:44:56.9371596Z test challenge_happy_path_returns_uuid_and_expiry ... ok
+2026-08-01T02:44:56.9543948Z test assert_without_did_resolver_returns_500 ... ok
+2026-08-01T02:44:56.9561641Z test assert_with_unknown_challenge_returns_400 ... ok
+2026-08-01T02:44:57.3236773Z test revoke_returns_404_for_unknown_member ... ok
+2026-08-01T02:44:57.3479072Z test revoke_already_false_is_idempotent_noop ... ok
+2026-08-01T02:44:57.3565629Z test revoke_admin_flips_member_row_and_emits_audit ... ok
+2026-08-01T02:44:57.3680536Z test revoke_self_emits_audit_reason_self ... ok
+2026-08-01T02:44:57.5691329Z test revoke_unauthorized_when_member_revokes_someone_else ... ok
+2026-08-01T02:44:57.5691806Z 
+2026-08-01T02:44:57.5692327Z test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.11s
+2026-08-01T02:44:57.5693017Z 
+2026-08-01T02:44:57.5737841Z [1m[92m     Running[0m tests/policies.rs (target/debug/deps/policies-2d29ed72ca6cb0f5)
+2026-08-01T02:44:57.5899514Z 
+2026-08-01T02:44:57.5900486Z running 17 tests
+2026-08-01T02:44:58.0123400Z test activate_unknown_id_returns_404 ... ok
+2026-08-01T02:44:58.0388088Z test activate_swaps_active_pointer ... ok
+2026-08-01T02:44:58.0496204Z test activate_same_id_twice_returns_409 ... ok
+2026-08-01T02:44:58.0582793Z test activate_replaces_predecessor ... ok
+2026-08-01T02:44:58.3465218Z test list_active_by_purpose_is_exact_under_limit_one ... ok
+2026-08-01T02:44:58.4100688Z test list_filters_by_status ... ok
+2026-08-01T02:44:58.4143512Z test list_filters_by_purpose ... ok
+2026-08-01T02:44:58.4320569Z test list_returns_all_policies ... ok
+2026-08-01T02:44:58.6559836Z test shipped_directory_default_yields_a_decision_via_test ... ok
+2026-08-01T02:44:58.7306649Z test show_returns_full_row ... ok
+2026-08-01T02:44:58.7466307Z test show_unknown_id_returns_404 ... ok
+2026-08-01T02:44:58.7825963Z test test_does_not_mutate_state ... ok
+2026-08-01T02:44:58.9973510Z test upload_and_activate_emit_audit_envelopes ... ok
+2026-08-01T02:44:59.0558572Z test upload_happy_path_persists_policy ... ok
+2026-08-01T02:44:59.0634090Z test upload_bad_rego_returns_400 ... ok
+2026-08-01T02:44:59.1265276Z test upload_rejects_purpose_package_mismatch ... ok
+2026-08-01T02:44:59.2027124Z test upload_without_token_returns_401 ... ok
+2026-08-01T02:44:59.2027551Z 
+2026-08-01T02:44:59.2032476Z test result: ok. 17 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.61s
+2026-08-01T02:44:59.2033093Z 
+2026-08-01T02:44:59.2062865Z [1m[92m     Running[0m tests/policy_canonical.rs (target/debug/deps/policy_canonical-5ac6cab548e7ccd4)
+2026-08-01T02:44:59.2245844Z 
+2026-08-01T02:44:59.2246483Z running 11 tests
+2026-08-01T02:44:59.6312298Z test each_verb_rejects_a_siblings_task ... ok
+2026-08-01T02:44:59.6590571Z test list_and_get_return_canonical_envelopes ... ok
+2026-08-01T02:44:59.6602925Z test expected_version_is_a_real_compare_and_swap ... ok
+2026-08-01T02:44:59.6617870Z test activate_exposes_the_binding_via_policy_active ... ok
+2026-08-01T02:44:59.9614245Z test the_operator_supplied_name_and_description_survive ... ok
+2026-08-01T02:44:59.9786760Z test unsupported_list_and_active_filters_are_refused ... ok
+2026-08-01T02:44:59.9838244Z test upsert_refuses_a_caller_supplied_id ... ok
+2026-08-01T02:45:00.0154528Z test upsert_refuses_selection_hints_it_cannot_honour ... ok
+2026-08-01T02:45:00.2570475Z test upsert_still_rejects_a_package_purpose_mismatch ... ok
+2026-08-01T02:45:00.2591042Z test upsert_returns_a_canonical_policy_module ... ok
+2026-08-01T02:45:00.2642806Z test upsert_without_the_purpose_ext_is_refused ... ok
+2026-08-01T02:45:00.2643361Z 
+2026-08-01T02:45:00.2643801Z test result: ok. 11 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.04s
+2026-08-01T02:45:00.2644405Z 
+2026-08-01T02:45:00.2692909Z [1m[92m     Running[0m tests/recognise.rs (target/debug/deps/recognise-8ec278202757b7e7)
+2026-08-01T02:45:00.2879214Z 
+2026-08-01T02:45:00.2879750Z running 15 tests
+2026-08-01T02:45:00.6987254Z test allow_true_but_no_mapped_role_is_treated_as_deny ... ok
+2026-08-01T02:45:00.7013101Z test expired_credentials_rejected_with_zero_window ... ok
+2026-08-01T02:45:00.7077875Z test default_deny_policy_rejects_every_mapping ... ok
+2026-08-01T02:45:00.8321562Z test holder_binding::a_consumed_challenge_cannot_be_replayed ... ok
+2026-08-01T02:45:01.1473504Z test holder_binding::a_tampered_holder_proof_is_rejected ... ok
+2026-08-01T02:45:01.1624554Z test holder_binding::challenge_endpoint_issues_a_nonce ... ok
+2026-08-01T02:45:01.2742469Z test holder_binding::holder_that_is_not_the_subject_is_rejected ... ok
+2026-08-01T02:45:01.3712686Z test holder_binding::matching_holder_clears_the_binding_gate ... ok
+2026-08-01T02:45:01.5664071Z test holder_binding::presentation_without_a_nonce_is_rejected ... ok
+2026-08-01T02:45:01.6141689Z test missing_active_policy_surfaces_as_internal_error ... ok
+2026-08-01T02:45:01.6144919Z test holder_binding::presentation_with_an_unissued_nonce_is_rejected ... ok
+2026-08-01T02:45:01.7323842Z test permissive_policy_mints_session_with_mapped_role ... ok
+2026-08-01T02:45:01.8773625Z test session_row_is_persisted_with_xc_prefix ... ok
+2026-08-01T02:45:01.8997752Z test ttl_clamps_to_default_when_credentials_longer ... ok
+2026-08-01T02:45:01.9110989Z test ttl_clamps_to_credentials_when_shorter_than_default ... ok
+2026-08-01T02:45:01.9111659Z 
+2026-08-01T02:45:01.9113177Z test result: ok. 15 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.62s
+2026-08-01T02:45:01.9144571Z [1m[92m     Running[0m tests/relationships.rs (target/debug/deps/relationships-c60961bbdf95c054)
+2026-08-01T02:45:01.9145260Z 
+2026-08-01T02:45:01.9309438Z 
+2026-08-01T02:45:01.9310042Z running 10 tests
+2026-08-01T02:45:02.3916865Z test list_keeps_rows_for_tombstoned_other_party ... ok
+2026-08-01T02:45:02.3918364Z test list_returns_issued_and_received_edges ... ok
+2026-08-01T02:45:02.4089191Z test publish_rejects_caller_not_issuer ... ok
+2026-08-01T02:45:02.4135095Z test list_strips_rows_where_other_party_purged ... ok
+2026-08-01T02:45:02.7896103Z test publish_returns_500_when_resolver_unconfigured ... ok
+2026-08-01T02:45:02.8043158Z test revoke_admin_can_revoke_any ... ok
+2026-08-01T02:45:02.8127517Z test revoke_404_on_unknown ... ok
+2026-08-01T02:45:02.8180906Z test publish_rejects_malformed_vrc ... ok
+2026-08-01T02:45:03.0907970Z test revoke_subject_is_forbidden ... ok
+2026-08-01T02:45:03.1062664Z test revoke_issuer_can_retract_own ... ok
+2026-08-01T02:45:03.1063211Z 
+2026-08-01T02:45:03.1063924Z test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.18s
+2026-08-01T02:45:03.1064533Z 
+2026-08-01T02:45:03.1109514Z [1m[92m     Running[0m tests/removal.rs (target/debug/deps/removal-e4f1045150726f78)
+2026-08-01T02:45:03.1275021Z 
+2026-08-01T02:45:03.1275513Z running 15 tests
+2026-08-01T02:45:03.6264360Z test admin_remove_404_for_unknown_did ... ok
+2026-08-01T02:45:03.6318841Z test admin_remove_member_works ... ok
+2026-08-01T02:45:03.6471194Z test admin_remove_member_blocked_by_deny_all_policy ... ok
+2026-08-01T02:45:03.7139738Z test admin_remove_flips_revocation_bit ... ok
+2026-08-01T02:45:04.0072449Z test admin_remove_of_admin_target_is_denied_by_default_policy ... ok
+2026-08-01T02:45:04.0139331Z test admin_remove_overlong_reason_rejected ... ok
+2026-08-01T02:45:04.0353777Z test admin_remove_self_refused_with_self_remove_hint ... ok
+2026-08-01T02:45:04.1282807Z test admin_remove_uses_policy_disposition_for_default ... ok
+2026-08-01T02:45:04.4094868Z test self_remove_requires_authentication ... ok
+2026-08-01T02:45:04.4438216Z test self_remove_refused_for_sole_admin ... ok
+2026-08-01T02:45:04.4532668Z test self_remove_flips_revocation_bit ... ok
+2026-08-01T02:45:04.4892705Z test self_remove_tombstones_member_by_default ... ok
+2026-08-01T02:45:04.7653109Z test self_remove_with_historical_keeps_row_verbatim ... ok
+2026-08-01T02:45:04.7674692Z test self_remove_with_purge_deletes_member_row ... ok
+2026-08-01T02:45:04.7851936Z test self_remove_works_when_second_admin_exists ... ok
+2026-08-01T02:45:04.7852644Z 
+2026-08-01T02:45:04.7853049Z test result: ok. 15 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.66s
+2026-08-01T02:45:04.7853601Z 
+2026-08-01T02:45:04.7900305Z [1m[92m     Running[0m tests/renewal.rs (target/debug/deps/renewal-efd2a98bff8d9873)
+2026-08-01T02:45:04.8069164Z 
+2026-08-01T02:45:04.8069866Z running 5 tests
+2026-08-01T02:45:05.2753873Z test renew_requires_authentication ... ok
+2026-08-01T02:45:05.3383746Z test renew_default_downgrades_when_policy_drops_flag ... ok
+2026-08-01T02:45:05.3930667Z test renew_mints_fresh_vmc_and_role_vec ... ok
+2026-08-01T02:45:05.4026013Z test renew_preserves_personhood_when_already_asserted ... ok
+2026-08-01T02:45:05.5705680Z test renew_reuses_existing_status_list_slot ... ok
+2026-08-01T02:45:05.5706151Z 
+2026-08-01T02:45:05.5706594Z test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.76s
+2026-08-01T02:45:05.5707192Z 
+2026-08-01T02:45:05.5754586Z [1m[92m     Running[0m tests/rotation.rs (target/debug/deps/rotation-a3baa4d93c905b4e)
+2026-08-01T02:45:05.5934706Z 
+2026-08-01T02:45:05.5935238Z running 7 tests
+2026-08-01T02:45:06.1303930Z test rotation_did_webvh_requires_did_resolver ... ok
+2026-08-01T02:45:06.1704722Z test rotation_id_is_single_use ... ok
+2026-08-01T02:45:06.1752635Z test rotation_reason_reaches_the_audit_envelope ... ok
+2026-08-01T02:45:06.2030961Z test rotation_happy_path_swaps_acl_and_member ... ok
+2026-08-01T02:45:06.5159465Z test rotation_rejects_bad_new_signature ... ok
+2026-08-01T02:45:06.5483836Z test rotation_rejects_unknown_did_method ... ok
+2026-08-01T02:45:06.5904335Z test rotation_without_a_reason_records_none ... ok
+2026-08-01T02:45:06.5905044Z 
+2026-08-01T02:45:06.5905650Z test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.00s
+2026-08-01T02:45:06.5906386Z 
+2026-08-01T02:45:06.5958807Z [1m[92m     Running[0m tests/routing_cors.rs (target/debug/deps/routing_cors-15986225b7353101)
+2026-08-01T02:45:06.6137446Z 
+2026-08-01T02:45:06.6137999Z running 19 tests
+2026-08-01T02:45:06.6229556Z test allows_default_landing_page_on_shared_origin ... ok
+2026-08-01T02:45:06.6230411Z test allows_admin_ui_at_root_when_host_routed ... ok
+2026-08-01T02:45:06.6231620Z test accepts_https_and_http_origins ... ok
+2026-08-01T02:45:06.6233520Z test defaults_validate_clean ... ok
+2026-08-01T02:45:06.6247030Z test empty_cors_allowlist_is_valid ... ok
+2026-08-01T02:45:06.6251615Z test allows_filesystem_website_on_dedicated_host ... ok
+2026-08-01T02:45:07.0110122Z test preflight_from_allowed_origin_returns_cors_headers ... ok
+2026-08-01T02:45:07.0157742Z test empty_allowlist_disables_cors_headers ... ok
+2026-08-01T02:45:07.0159763Z test rejects_admin_ui_mounted_at_root_in_path_mode ... ok
+2026-08-01T02:45:07.0160593Z test rejects_duplicate_path_mounts ... ok
+2026-08-01T02:45:07.0161391Z test actual_get_from_allowed_origin_carries_cors_response_header ... ok
+2026-08-01T02:45:07.0162476Z test rejects_cors_origin_without_scheme ... ok
+2026-08-01T02:45:07.0163163Z test rejects_empty_cors_origin_entry ... ok
+2026-08-01T02:45:07.0163911Z test rejects_filesystem_website_host_colliding_with_api ... ok
+2026-08-01T02:45:07.0164750Z test rejects_filesystem_website_sharing_admin_origin ... ok
+2026-08-01T02:45:07.0165510Z test rejects_mount_without_leading_slash ... ok
+2026-08-01T02:45:07.0166227Z test rejects_partial_wildcard_cors_origin ... ok
+2026-08-01T02:45:07.0166886Z test rejects_wildcard_cors_origin ... ok
+2026-08-01T02:45:07.0270328Z test preflight_from_disallowed_origin_omits_cors_headers ... ok
+2026-08-01T02:45:07.0270678Z 
+2026-08-01T02:45:07.0270971Z test result: ok. 19 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.41s
+2026-08-01T02:45:07.0271551Z 
+2026-08-01T02:45:07.0305131Z [1m[92m     Running[0m tests/routing_modes.rs (target/debug/deps/routing_modes-12271a69804d93f5)
+2026-08-01T02:45:07.0469346Z 
+2026-08-01T02:45:07.0469789Z running 9 tests
+2026-08-01T02:45:07.4756729Z test path_mode_admin_trailing_slash_serves_admin_spa ... ok
+2026-08-01T02:45:07.4776038Z test path_mode_admin_surface_serves_embedded_spa ... ok
+2026-08-01T02:45:07.4777149Z test path_mode_health_at_root_is_exempt ... ok
+2026-08-01T02:45:07.4791766Z test path_mode_admin_bare_prefix_serves_admin_spa ... ok
+2026-08-01T02:45:07.4794272Z test pure_path_mode_middleware_is_noop ... ok
+2026-08-01T02:45:07.4795368Z test subdomain_mode_non_strict_falls_through ... ok
+2026-08-01T02:45:07.4812491Z test subdomain_mode_strict_404s_unknown_host ... ok
+2026-08-01T02:45:07.4813514Z test subdomain_mode_isolates_surfaces_across_hosts ... ok
+2026-08-01T02:45:07.6768814Z test path_mode_website_fallback_serves_default_landing_page ... ok
+2026-08-01T02:45:07.6769676Z 
+2026-08-01T02:45:07.6770167Z test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.63s
+2026-08-01T02:45:07.6770878Z 
+2026-08-01T02:45:07.6811323Z [1m[92m     Running[0m tests/status_lists.rs (target/debug/deps/status_lists-4611950e9757bf0e)
+2026-08-01T02:45:07.6989587Z 
+2026-08-01T02:45:07.6990596Z running 4 tests
+2026-08-01T02:45:08.1498989Z test show_unknown_purpose_returns_404 ... ok
+2026-08-01T02:45:08.1513701Z test show_returns_5xx_when_signer_missing ... ok
+2026-08-01T02:45:08.1742853Z test show_serves_suspension_purpose ... ok
+2026-08-01T02:45:08.1898214Z test show_returns_signed_vc_without_trust_task_header ... ok
+2026-08-01T02:45:08.1898844Z 
+2026-08-01T02:45:08.1899890Z test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.49s
+2026-08-01T02:45:08.1900567Z 
+2026-08-01T02:45:08.1938676Z [1m[92m     Running[0m tests/test_support_smoke.rs (target/debug/deps/test_support_smoke-b5a92647158cdf23)
+2026-08-01T02:45:08.2106738Z 
+2026-08-01T02:45:08.2107227Z running 4 tests
+2026-08-01T02:45:08.5805311Z test with_signers_populates_credential_and_install_signers ... ok
+2026-08-01T02:45:08.5847514Z test build_test_vtc_serves_health ... ok
+2026-08-01T02:45:08.5940441Z test minted_admin_token_is_accepted ... ok
+2026-08-01T02:45:08.6491679Z test mock_vtc_serves_over_http ... ok
+2026-08-01T02:45:08.6492695Z 
+2026-08-01T02:45:08.6493157Z test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.44s
+2026-08-01T02:45:08.6493517Z 
+2026-08-01T02:45:08.6536763Z [1m[92m     Running[0m tests/trust_task_manifest.rs (target/debug/deps/trust_task_manifest-8929d5e0124334f8)
+2026-08-01T02:45:08.6583649Z 
+2026-08-01T02:45:08.6584081Z running 7 tests
+2026-08-01T02:45:08.6813805Z test every_manifest_entry_has_files_on_disk ... ok
+2026-08-01T02:45:08.6827386Z test manifest_status_vocabulary_matches_spec ... ok
+2026-08-01T02:45:08.7224352Z test every_bound_task_is_published_or_excepted ... ok
+2026-08-01T02:45:08.7227106Z test every_published_task_is_bound_or_excepted ... ok
+2026-08-01T02:45:08.7227907Z test no_new_bindings_on_the_retired_authority ... ok
+2026-08-01T02:45:08.7228544Z test every_bound_canonical_task_exists_in_the_registry ... FAILED
+2026-08-01T02:45:08.7360166Z test retired_tasks_are_not_bound ... ok
+2026-08-01T02:45:08.7360720Z 
+2026-08-01T02:45:08.7360984Z failures:
+2026-08-01T02:45:08.7361172Z 
+2026-08-01T02:45:08.7361554Z ---- every_bound_canonical_task_exists_in_the_registry stdout ----
+2026-08-01T02:45:08.7362243Z 
+2026-08-01T02:45:08.7363066Z thread 'every_bound_canonical_task_exists_in_the_registry' (27834) panicked at vtc-service/tests/trust_task_manifest.rs:515:9:
+2026-08-01T02:45:08.7368066Z assertion `left == right` failed: https://trusttasks.org/spec/vta/ has 36 unpublished URIs, expected 44 (VTA Trust Task surface at 1.0 — predates the registry and was never reconciled with it. Down from 55 via #840 phase A: config/{get,update} onto config/{show,patch}, provision-integration/request onto provision/integration/0.2, acl/* onto the canonical acl/{grant,show,list,update,revoke} family, and audit/list-logs onto audit/list/0.1. Phase A complete at 46; phase B folded webvh/dids/get-log into webvh/dids/get, and webvh/servers/{add,update} into webvh/servers/register).
+2026-08-01T02:45:08.7373502Z 
+2026-08-01T02:45:08.7373933Z If it went DOWN, some were published upstream — lower the count here.
+2026-08-01T02:45:08.7375288Z If it went UP, a new URI was bound on an authority the registry does not serve. Author the spec upstream, or bind an authority we control; raising this number is the wrong fix.
+2026-08-01T02:45:08.7376432Z   left: 36
+2026-08-01T02:45:08.7376727Z  right: 44
+2026-08-01T02:45:08.7377223Z note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+2026-08-01T02:45:08.7377736Z 
+2026-08-01T02:45:08.7377742Z 
+2026-08-01T02:45:08.7377868Z failures:
+2026-08-01T02:45:08.7378680Z     every_bound_canonical_task_exists_in_the_registry
+2026-08-01T02:45:08.7379059Z 
+2026-08-01T02:45:08.7379499Z test result: FAILED. 6 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.08s
+2026-08-01T02:45:08.7380105Z 
+2026-08-01T02:45:08.7410843Z [1m[91merror[0m: test failed, to rerun pass `-p vtc-service --test trust_task_manifest`
+2026-08-01T02:45:08.8833063Z ##[error]Process completed with exit code 101.
+2026-08-01T02:45:08.9904370Z Post job cleanup.
+2026-08-01T02:45:09.1830416Z [command]/usr/bin/git version
+2026-08-01T02:45:09.1947895Z git version 2.54.0
+2026-08-01T02:45:09.1999222Z Temporarily overriding HOME='/home/runner/work/_temp/f550c848-3225-4449-bee6-9db1b919887f' before making global git config changes
+2026-08-01T02:45:09.2001104Z Adding repository directory to the temporary git global config as a safe directory
+2026-08-01T02:45:09.2004608Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/verifiable-trust-infrastructure/verifiable-trust-infrastructure
+2026-08-01T02:45:09.2071483Z Removing SSH command configuration
+2026-08-01T02:45:09.2081250Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+2026-08-01T02:45:09.2144292Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+2026-08-01T02:45:09.2530620Z Removing HTTP extra header
+2026-08-01T02:45:09.2536993Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+2026-08-01T02:45:09.2582722Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+2026-08-01T02:45:09.2907841Z Removing includeIf entries pointing to credentials config files
+2026-08-01T02:45:09.2916809Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+2026-08-01T02:45:09.2947755Z includeif.gitdir:/home/runner/work/verifiable-trust-infrastructure/verifiable-trust-infrastructure/.git.path
+2026-08-01T02:45:09.2962651Z includeif.gitdir:/home/runner/work/verifiable-trust-infrastructure/verifiable-trust-infrastructure/.git/worktrees/*.path
+2026-08-01T02:45:09.2963771Z includeif.gitdir:/github/workspace/.git.path
+2026-08-01T02:45:09.2964425Z includeif.gitdir:/github/workspace/.git/worktrees/*.path
+2026-08-01T02:45:09.2967943Z [command]/usr/bin/git config --local --get-all includeif.gitdir:/home/runner/work/verifiable-trust-infrastructure/verifiable-trust-infrastructure/.git.path
+2026-08-01T02:45:09.3011331Z /home/runner/work/_temp/git-credentials-08490eff-5acd-4870-9e07-5f18f662d4df.config
+2026-08-01T02:45:09.3026664Z [command]/usr/bin/git config --local --unset includeif.gitdir:/home/runner/work/verifiable-trust-infrastructure/verifiable-trust-infrastructure/.git.path /home/runner/work/_temp/git-credentials-08490eff-5acd-4870-9e07-5f18f662d4df.config
+2026-08-01T02:45:09.3133355Z [command]/usr/bin/git config --local --get-all includeif.gitdir:/home/runner/work/verifiable-trust-infrastructure/verifiable-trust-infrastructure/.git/worktrees/*.path
+2026-08-01T02:45:09.3135348Z /home/runner/work/_temp/git-credentials-08490eff-5acd-4870-9e07-5f18f662d4df.config
+2026-08-01T02:45:09.3162659Z [command]/usr/bin/git config --local --unset includeif.gitdir:/home/runner/work/verifiable-trust-infrastructure/verifiable-trust-infrastructure/.git/worktrees/*.path /home/runner/work/_temp/git-credentials-08490eff-5acd-4870-9e07-5f18f662d4df.config
+2026-08-01T02:45:09.3206950Z [command]/usr/bin/git config --local --get-all includeif.gitdir:/github/workspace/.git.path
+2026-08-01T02:45:09.3264237Z /github/runner_temp/git-credentials-08490eff-5acd-4870-9e07-5f18f662d4df.config
+2026-08-01T02:45:09.3266968Z [command]/usr/bin/git config --local --unset includeif.gitdir:/github/workspace/.git.path /github/runner_temp/git-credentials-08490eff-5acd-4870-9e07-5f18f662d4df.config
+2026-08-01T02:45:09.3317050Z [command]/usr/bin/git config --local --get-all includeif.gitdir:/github/workspace/.git/worktrees/*.path
+2026-08-01T02:45:09.3353698Z /github/runner_temp/git-credentials-08490eff-5acd-4870-9e07-5f18f662d4df.config
+2026-08-01T02:45:09.3366543Z [command]/usr/bin/git config --local --unset includeif.gitdir:/github/workspace/.git/worktrees/*.path /github/runner_temp/git-credentials-08490eff-5acd-4870-9e07-5f18f662d4df.config
+2026-08-01T02:45:09.3443838Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+2026-08-01T02:45:09.3796271Z Removing credentials config '/home/runner/work/_temp/git-credentials-08490eff-5acd-4870-9e07-5f18f662d4df.config'
+2026-08-01T02:45:09.4140909Z Cleaning up orphan processes

--- a/tests/e2e/tests/client_didcomm.rs
+++ b/tests/e2e/tests/client_didcomm.rs
@@ -123,20 +123,27 @@ async fn shutdown_all(
     mediator.join().await.expect("mediator joins");
 }
 
+/// One record in the canonical `keys/_shared/0.1/key-record` wire shape:
+/// camelCase throughout, which is what the family publishes.
 fn key_record_json(id: &str) -> Value {
     json!({
-        "key_id": id,
-        "derivation_path": "m/0/0",
-        "key_type": "ed25519",
+        "keyId": id,
+        "derivationPath": "m/0/0",
+        "keyType": "ed25519",
         "status": "active",
-        "public_key": "z6Mkpub",
+        "publicKey": "z6Mkpub",
         "label": null,
-        "context_id": null,
-        "seed_id": 1,
+        "contextId": null,
+        "seedId": 1,
         "origin": "derived",
-        "created_at": "2026-01-01T00:00:00Z",
-        "updated_at": "2026-01-01T00:00:00Z"
+        "createdAt": "2026-01-01T00:00:00Z",
+        "updatedAt": "2026-01-01T00:00:00Z"
     })
+}
+
+/// The `{ key }` envelope canonical single-record responses carry.
+fn key_envelope(id: &str) -> Value {
+    json!({ "key": key_record_json(id) })
 }
 
 fn context_json(id: &str) -> Value {
@@ -256,9 +263,9 @@ async fn get_config_via_didcomm() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn list_keys_via_didcomm() {
     let (mediator, responder, client) = build_didcomm(|msg_type, body| {
-        if is_tt(msg_type, body, trust_tasks::TASK_KEYS_LIST_1_0) {
+        if is_tt(msg_type, body, trust_tasks::TASK_KEYS_LIST_0_1) {
             tt_ok(
-                trust_tasks::TASK_KEYS_LIST_1_0,
+                trust_tasks::TASK_KEYS_LIST_0_1,
                 json!({"keys": [key_record_json("k1"), key_record_json("k2")], "total": 2}),
             )
         } else {
@@ -277,8 +284,9 @@ async fn list_keys_via_didcomm() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn get_key_via_didcomm() {
     let (mediator, responder, client) = build_didcomm(|msg_type, body| {
-        if is_tt(msg_type, body, trust_tasks::TASK_KEYS_GET_1_0) {
-            tt_ok(trust_tasks::TASK_KEYS_GET_1_0, key_record_json("k1"))
+        if is_tt(msg_type, body, trust_tasks::TASK_KEYS_SHOW_0_1) {
+            assert_eq!(body["payload"]["keyId"], "k1", "{body}");
+            tt_ok(trust_tasks::TASK_KEYS_SHOW_0_1, key_envelope("k1"))
         } else {
             no_handler()
         }
@@ -294,20 +302,9 @@ async fn get_key_via_didcomm() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn create_key_via_didcomm() {
     let (mediator, responder, client) = build_didcomm(|msg_type, body| {
-        if is_tt(msg_type, body, trust_tasks::TASK_KEYS_CREATE_1_0) {
-            assert_eq!(body["payload"]["key_type"], "ed25519");
-            tt_ok(
-                trust_tasks::TASK_KEYS_CREATE_1_0,
-                json!({
-                    "key_id": "k1",
-                    "key_type": "ed25519",
-                    "derivation_path": "m/0/0",
-                    "public_key": "z6Mkpub",
-                    "status": "active",
-                    "label": null,
-                    "created_at": "2026-01-01T00:00:00Z"
-                }),
-            )
+        if is_tt(msg_type, body, trust_tasks::TASK_KEYS_CREATE_0_1) {
+            assert_eq!(body["payload"]["keyType"], "ed25519", "{body}");
+            tt_ok(trust_tasks::TASK_KEYS_CREATE_0_1, key_envelope("k1"))
         } else {
             no_handler()
         }
@@ -325,12 +322,12 @@ async fn create_key_via_didcomm() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn sign_via_didcomm_round_trips_payload() {
     let (mediator, responder, client) = build_didcomm(|msg_type, body| {
-        if is_tt(msg_type, body, trust_tasks::TASK_KEYS_SIGN_1_0) {
+        if is_tt(msg_type, body, trust_tasks::TASK_KEYS_SIGN_0_1) {
             // Verify the SDK base64url-encoded the payload-to-sign (which
             // sits at `payload.payload` inside the trust-task document).
             assert_eq!(body["payload"]["payload"], "aGVsbG8");
             tt_ok(
-                trust_tasks::TASK_KEYS_SIGN_1_0,
+                trust_tasks::TASK_KEYS_SIGN_0_1,
                 json!({"key_id": "k1", "signature": "AQID", "algorithm": "eddsa"}),
             )
         } else {
@@ -351,9 +348,9 @@ async fn sign_via_didcomm_round_trips_payload() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn invalidate_key_via_didcomm() {
     let (mediator, responder, client) = build_didcomm(|msg_type, body| {
-        if is_tt(msg_type, body, trust_tasks::TASK_KEYS_REVOKE_1_0) {
+        if is_tt(msg_type, body, trust_tasks::TASK_KEYS_REVOKE_0_1) {
             tt_ok(
-                trust_tasks::TASK_KEYS_REVOKE_1_0,
+                trust_tasks::TASK_KEYS_REVOKE_0_1,
                 json!({
                     "key_id": "k1",
                     "status": "revoked",
@@ -375,9 +372,9 @@ async fn invalidate_key_via_didcomm() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn rename_key_via_didcomm() {
     let (mediator, responder, client) = build_didcomm(|msg_type, body| {
-        if is_tt(msg_type, body, trust_tasks::TASK_KEYS_RENAME_1_0) {
+        if is_tt(msg_type, body, trust_tasks::TASK_KEYS_RENAME_0_1) {
             tt_ok(
-                trust_tasks::TASK_KEYS_RENAME_1_0,
+                trust_tasks::TASK_KEYS_RENAME_0_1,
                 json!({"key_id": "new", "updated_at": "2026-01-01T00:00:00Z"}),
             )
         } else {
@@ -394,6 +391,43 @@ async fn rename_key_via_didcomm() {
 
 /// `import_key` is twinless — #861 left it on the legacy `rpc` path, so the
 /// mock still matches the `key-management/1.0` message type.
+/// A sealed carrier rides canonical `keys/import/0.1`, so it reaches TSP as
+/// well as DIDComm. The multibase test below pins the other half of the fork.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn sealed_import_key_via_didcomm_uses_the_canonical_task() {
+    let (mediator, responder, client) = build_didcomm(|msg_type, body| {
+        if is_tt(msg_type, body, trust_tasks::TASK_KEYS_IMPORT_0_1) {
+            let p = &body["payload"];
+            assert_eq!(p["keyType"], "ed25519", "{body}");
+            assert!(p["privateKeySealed"].is_string(), "{body}");
+            assert!(
+                p.get("privateKeyMultibase").is_none_or(Value::is_null),
+                "the cleartext carrier must never ride the canonical task: {body}"
+            );
+            tt_ok(trust_tasks::TASK_KEYS_IMPORT_0_1, key_envelope("imported"))
+        } else {
+            no_handler()
+        }
+    })
+    .await;
+
+    let req = ImportKeyRequest {
+        key_type: KeyType::Ed25519,
+        private_key_sealed: Some("-----BEGIN SEALED TRANSFER-----".into()),
+        private_key_jwe: None,
+        private_key_multibase: None,
+        label: None,
+        context_id: None,
+    };
+    let resp = client.import_key(req).await.unwrap();
+    assert_eq!(resp.key_id, "imported");
+
+    shutdown_all(client, responder, mediator).await;
+}
+
+/// A raw multibase key stays on the legacy DIDComm message, where authcrypt
+/// has established the end-to-end confidentiality the canonical task cannot
+/// assume.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn import_key_via_didcomm() {
     let (mediator, responder, client) = build_didcomm(|msg_type, _body| {

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.21.0"
+version = "0.21.1"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/client/keys.rs
+++ b/vta-sdk/src/client/keys.rs
@@ -27,19 +27,83 @@ impl VtaClient {
     /// takes effect on the REST leg — exactly as it did on the legacy
     /// DIDComm message, which never carried `key_id` either.
     pub async fn create_key(&self, req: CreateKeyRequest) -> Result<CreateKeyResponse, VtaError> {
-        self.rpc_tt(
-            trust_tasks::TASK_KEYS_CREATE_1_0,
-            serde_json::json!({
-                "key_type": serde_json::to_value(&req.key_type)?,
-                "derivation_path": req.derivation_path.as_deref().unwrap_or_default(),
-                "mnemonic": req.mnemonic.as_deref(),
-                "label": req.label.as_deref(),
-                "context_id": req.context_id.as_deref(),
-            }),
-            30,
-            |c, url| c.post(format!("{url}/keys")).json(&req),
-        )
-        .await
+        // Built from the canonical body rather than a hand-rolled map: the map
+        // spelled its members snake_case and carried `mnemonic` before the
+        // registry had a member for it, so it was one rename away from
+        // silently dropping the create-from-a-phrase path (see #884's
+        // `update_acl`, the same failure with different members).
+        let body = crate::protocols::key_management::create::CreateKeyBody {
+            key_type: req.key_type.clone(),
+            derivation_path: req.derivation_path.clone().unwrap_or_default(),
+            mnemonic: req.mnemonic.clone(),
+            label: req.label.clone(),
+            context_id: req.context_id.clone(),
+        };
+        let wrapped: crate::protocols::key_management::create::CreateKeyResponseBody = self
+            .rpc_tt(
+                trust_tasks::TASK_KEYS_CREATE_0_1,
+                serde_json::to_value(&body)?,
+                30,
+                |c, url| c.post(format!("{url}/keys")).json(&req),
+            )
+            .await?;
+        let key = wrapped.key;
+        Ok(CreateKeyResponse {
+            key_id: key.key_id,
+            key_type: key.key_type,
+            derivation_path: key.derivation_path,
+            public_key: key.public_key,
+            status: key.status,
+            label: key.label,
+            created_at: key.created_at,
+        })
+    }
+
+    /// Import an externally-created private key.
+    ///
+    /// A **sealed** or **JWE** carrier rides canonical `keys/import/0.1`, so it
+    /// works over REST, DIDComm and TSP alike. A raw `private_key_multibase`
+    /// stays on the legacy DIDComm message: the canonical task refuses
+    /// cleartext, because one dispatcher serves all three transports and cannot
+    /// establish that a given request travelled end to end — authcrypt can, and
+    /// that is exactly what the legacy path has.
+    pub async fn import_key(&self, req: ImportKeyRequest) -> Result<ImportKeyResponse, VtaError> {
+        if req.private_key_multibase.is_some() {
+            return self
+                .rpc(
+                    key_management::IMPORT_KEY,
+                    serde_json::to_value(&req)?,
+                    key_management::IMPORT_KEY_RESULT,
+                    30,
+                    |c, url| c.post(format!("{url}/keys/import")).json(&req),
+                )
+                .await;
+        }
+        let body = crate::protocols::key_management::import::ImportKeyBody {
+            key_type: req.key_type.clone(),
+            private_key_sealed: req.private_key_sealed.clone(),
+            private_key_jwe: req.private_key_jwe.clone(),
+            private_key_multibase: None,
+            label: req.label.clone(),
+            context_id: req.context_id.clone(),
+        };
+        let wrapped: crate::protocols::key_management::create::CreateKeyResponseBody = self
+            .rpc_tt(
+                trust_tasks::TASK_KEYS_IMPORT_0_1,
+                serde_json::to_value(&body)?,
+                30,
+                |c, url| c.post(format!("{url}/keys/import")).json(&req),
+            )
+            .await?;
+        Ok(ImportKeyResponse {
+            key_id: wrapped.key.key_id,
+            key_type: wrapped.key.key_type,
+            public_key: wrapped.key.public_key,
+            status: wrapped.key.status,
+            label: wrapped.key.label,
+            origin: wrapped.key.origin,
+            created_at: wrapped.key.created_at,
+        })
     }
 
     pub async fn list_keys(
@@ -50,13 +114,15 @@ impl VtaClient {
         context_id: Option<&str>,
     ) -> Result<ListKeysResponse, VtaError> {
         self.rpc_tt(
-            trust_tasks::TASK_KEYS_LIST_1_0,
-            serde_json::json!({
-                "offset": offset,
-                "limit": limit,
-                "status": status,
-                "context_id": context_id,
-            }),
+            trust_tasks::TASK_KEYS_LIST_0_1,
+            serde_json::to_value(crate::protocols::key_management::list::ListKeysBody {
+                offset: Some(offset),
+                limit: Some(limit),
+                status: status
+                    .map(str::to_string)
+                    .and_then(|s| serde_json::from_value(serde_json::Value::String(s)).ok()),
+                context_id: context_id.map(str::to_string),
+            })?,
             30,
             |c, url| {
                 let mut u = format!("{url}/keys?offset={offset}&limit={limit}");
@@ -73,13 +139,21 @@ impl VtaClient {
     }
 
     pub async fn get_key(&self, key_id: &str) -> Result<KeyRecord, VtaError> {
-        self.rpc_tt(
-            trust_tasks::TASK_KEYS_GET_1_0,
-            serde_json::json!({ "key_id": key_id }),
-            30,
-            |c, url| c.get(format!("{url}/keys/{}", encode_path_segment(key_id))),
-        )
-        .await
+        // Canonical `keys/show/0.1` answers `{ key }`, with `key: null` for a
+        // key the maintainer does not hold — a successful answer, not an error.
+        // This method promises a record, so absence becomes `NotFound` here
+        // rather than a decode failure the caller cannot interpret.
+        let wrapped: crate::protocols::key_management::get::GetKeyResponseBody = self
+            .rpc_tt(
+                trust_tasks::TASK_KEYS_SHOW_0_1,
+                serde_json::json!({ "keyId": key_id }),
+                30,
+                |c, url| c.get(format!("{url}/keys/{}", encode_path_segment(key_id))),
+            )
+            .await?;
+        wrapped
+            .key
+            .ok_or_else(|| VtaError::NotFound(format!("no key record for `{key_id}`")))
     }
 
     /// Export a key's secret material. The trust-task twin lives in the
@@ -109,9 +183,9 @@ impl VtaClient {
         use base64::Engine;
         let payload_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(payload);
         self.rpc_tt(
-            trust_tasks::TASK_KEYS_SIGN_1_0,
+            trust_tasks::TASK_KEYS_SIGN_0_1,
             serde_json::json!({
-                "key_id": key_id,
+                "keyId": key_id,
                 "payload": payload_b64,
                 "algorithm": algorithm,
             }),
@@ -146,13 +220,13 @@ impl VtaClient {
         use base64::Engine;
         let payload_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(payload);
         let body = serde_json::json!({
-            "key_type": serde_json::to_value(&key_type)?,
-            "derivation_path": derivation_path,
+            "keyType": serde_json::to_value(&key_type)?,
+            "derivationPath": derivation_path,
             "payload": payload_b64,
             "algorithm": algorithm,
         });
         self.rpc_tt(
-            trust_tasks::TASK_KEYS_DERIVE_AND_SIGN_1_0,
+            trust_tasks::TASK_KEYS_DERIVE_AND_SIGN_0_1,
             body.clone(),
             30,
             move |c, url| c.post(format!("{url}/keys/derive-and-sign")).json(&body),
@@ -173,13 +247,13 @@ impl VtaClient {
         proof_purpose: Option<&str>,
     ) -> Result<DeriveAndSignDocumentResultBody, VtaError> {
         let body = serde_json::json!({
-            "key_type": serde_json::to_value(&key_type)?,
-            "derivation_path": derivation_path,
+            "keyType": serde_json::to_value(&key_type)?,
+            "derivationPath": derivation_path,
             "document": document,
-            "proof_purpose": proof_purpose,
+            "proofPurpose": proof_purpose,
         });
         self.rpc_tt(
-            trust_tasks::TASK_KEYS_DERIVE_AND_SIGN_DOCUMENT_1_0,
+            trust_tasks::TASK_KEYS_DERIVE_AND_SIGN_DOCUMENT_0_1,
             body.clone(),
             30,
             move |c, url| {
@@ -192,8 +266,8 @@ impl VtaClient {
 
     pub async fn invalidate_key(&self, key_id: &str) -> Result<InvalidateKeyResponse, VtaError> {
         self.rpc_tt(
-            trust_tasks::TASK_KEYS_REVOKE_1_0,
-            serde_json::json!({ "key_id": key_id }),
+            trust_tasks::TASK_KEYS_REVOKE_0_1,
+            serde_json::json!({ "keyId": key_id }),
             30,
             |c, url| c.delete(format!("{url}/keys/{}", encode_path_segment(key_id))),
         )
@@ -206,8 +280,8 @@ impl VtaClient {
         new_key_id: &str,
     ) -> Result<RenameKeyResponse, VtaError> {
         self.rpc_tt(
-            trust_tasks::TASK_KEYS_RENAME_1_0,
-            serde_json::json!({ "key_id": key_id, "new_key_id": new_key_id }),
+            trust_tasks::TASK_KEYS_RENAME_0_1,
+            serde_json::json!({ "keyId": key_id, "newKeyId": new_key_id }),
             30,
             |c, url| {
                 c.patch(format!("{url}/keys/{}", encode_path_segment(key_id)))
@@ -244,18 +318,6 @@ impl VtaClient {
                 "wrapping key not needed for TSP transport".into(),
             )),
         }
-    }
-
-    /// Import an externally-created private key into the VTA.
-    pub async fn import_key(&self, req: ImportKeyRequest) -> Result<ImportKeyResponse, VtaError> {
-        self.rpc(
-            key_management::IMPORT_KEY,
-            serde_json::to_value(&req)?,
-            key_management::IMPORT_KEY_RESULT,
-            30,
-            |c, url| c.post(format!("{url}/keys/import")).json(&req),
-        )
-        .await
     }
 
     // ── Seed methods ────────────────────────────────────────────────

--- a/vta-sdk/src/keys/mod.rs
+++ b/vta-sdk/src/keys/mod.rs
@@ -32,22 +32,37 @@ fn default_derived() -> KeyOrigin {
     KeyOrigin::Derived
 }
 
+/// One key as the maintainer holds it — canonical
+/// `keys/_shared/0.1/key-record#KeyRecord`.
+///
+/// The **wire** names are canonical camelCase; the Rust field names are the
+/// maintainer's historical snake_case ones, kept so every call site did not
+/// have to move in the same change. Snake_case is additionally accepted on
+/// *intake* via aliases, so a producer written against the pre-fold shape keeps
+/// working while it migrates — emission is canonical either way.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct KeyRecord {
+    #[serde(alias = "key_id")]
     pub key_id: String,
+    #[serde(alias = "derivation_path")]
     pub derivation_path: String,
+    #[serde(alias = "key_type")]
     pub key_type: KeyType,
     pub status: KeyStatus,
+    #[serde(alias = "public_key")]
     pub public_key: String,
     pub label: Option<String>,
-    #[serde(default)]
+    #[serde(default, alias = "context_id")]
     pub context_id: Option<String>,
-    #[serde(default)]
+    #[serde(default, alias = "seed_id")]
     pub seed_id: Option<u32>,
     #[serde(default = "default_derived")]
     pub origin: KeyOrigin,
+    #[serde(alias = "created_at")]
     pub created_at: DateTime<Utc>,
+    #[serde(alias = "updated_at")]
     pub updated_at: DateTime<Utc>,
 }
 

--- a/vta-sdk/src/protocols/key_management/create.rs
+++ b/vta-sdk/src/protocols/key_management/create.rs
@@ -5,11 +5,15 @@ use crate::keys::{KeyOrigin, KeyStatus, KeyType};
 
 #[derive(Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
 pub struct CreateKeyBody {
+    #[serde(alias = "key_type")]
     pub key_type: KeyType,
+    #[serde(alias = "derivation_path")]
     pub derivation_path: String,
     pub mnemonic: Option<String>,
     pub label: Option<String>,
+    #[serde(alias = "context_id")]
     pub context_id: Option<String>,
 }
 
@@ -28,18 +32,38 @@ impl std::fmt::Debug for CreateKeyBody {
     }
 }
 
+/// The realized key record, in the canonical camelCase shape. A strict subset
+/// of `keys/_shared/0.1/key-record#KeyRecord`'s members, so it validates as one.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct CreateKeyResultBody {
+    #[serde(alias = "key_id")]
     pub key_id: String,
+    #[serde(alias = "key_type")]
     pub key_type: KeyType,
+    #[serde(alias = "derivation_path")]
     pub derivation_path: String,
+    #[serde(alias = "public_key")]
     pub public_key: String,
     pub status: KeyStatus,
     pub label: Option<String>,
     #[serde(default = "default_derived")]
     pub origin: KeyOrigin,
+    #[serde(alias = "created_at")]
     pub created_at: DateTime<Utc>,
+}
+
+/// `keys/create/0.1` response — the realized record under `key`.
+///
+/// Nested rather than flattened because the canonical `keys/*` family carries
+/// one record shape across create, show and import, so a consumer comparing
+/// records between them cannot end up looking at two spellings of the same
+/// thing. Mirrors `acl/*`'s `{ entry }`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct CreateKeyResponseBody {
+    pub key: CreateKeyResultBody,
 }
 
 fn default_derived() -> KeyOrigin {

--- a/vta-sdk/src/protocols/key_management/derive_and_sign.rs
+++ b/vta-sdk/src/protocols/key_management/derive_and_sign.rs
@@ -14,10 +14,13 @@ use crate::keys::KeyType;
 /// `m/26'/9'/<idx>'` — without leaving a `KeyRecord` per action. Admin-gated.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
 pub struct DeriveAndSignBody {
     /// Key type to derive (currently only `Ed25519` is supported).
+    #[serde(alias = "key_type")]
     pub key_type: KeyType,
     /// BIP-32 derivation path, e.g. `m/26'/9'/0'`.
+    #[serde(alias = "derivation_path")]
     pub derivation_path: String,
     /// Base64url-encoded payload bytes to sign.
     pub payload: String,
@@ -28,9 +31,11 @@ pub struct DeriveAndSignBody {
 /// Body of a derive-and-sign result.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
 pub struct DeriveAndSignResultBody {
     /// The derived public key (multibase, multicodec-prefixed) — so the caller
     /// learns the `did:key` it just signed as.
+    #[serde(alias = "public_key")]
     pub public_key: String,
     /// Base64url-encoded signature bytes.
     pub signature: String,

--- a/vta-sdk/src/protocols/key_management/derive_and_sign_document.rs
+++ b/vta-sdk/src/protocols/key_management/derive_and_sign_document.rs
@@ -16,26 +16,31 @@ use crate::keys::KeyType;
 /// so it's correct by construction. Admin-gated.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
 pub struct DeriveAndSignDocumentBody {
     /// Key type to derive (currently only `Ed25519`).
+    #[serde(alias = "key_type")]
     pub key_type: KeyType,
     /// BIP-32 derivation path, e.g. `m/26'/9'/0'`.
+    #[serde(alias = "derivation_path")]
     pub derivation_path: String,
     /// The proof-less JSON document to sign (any `proof` is stripped first).
     #[cfg_attr(feature = "openapi", schema(value_type = Object))]
     pub document: Value,
     /// Proof purpose (default `assertionMethod`, matching the DI-signed REST
     /// auth flow).
-    #[serde(default)]
+    #[serde(default, alias = "proof_purpose")]
     pub proof_purpose: Option<String>,
 }
 
 /// Result of a derive-and-sign-document request.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
 pub struct DeriveAndSignDocumentResultBody {
     /// The derived signer's `did:key` (the super-admin identity the document was
     /// signed as).
+    #[serde(alias = "signer_did")]
     pub signer_did: String,
     /// The signed document, with the Data-Integrity `proof` grafted on.
     #[cfg_attr(feature = "openapi", schema(value_type = Object))]

--- a/vta-sdk/src/protocols/key_management/get.rs
+++ b/vta-sdk/src/protocols/key_management/get.rs
@@ -5,7 +5,19 @@ use crate::keys::KeyRecord;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct GetKeyBody {
+    #[serde(rename = "keyId", alias = "key_id")]
     pub key_id: String,
 }
 
 pub type GetKeyResultBody = KeyRecord;
+
+/// `keys/show/0.1` response — the record under `key`, or `null` where the
+/// maintainer holds none for that identifier.
+///
+/// "No such key" is a successful answer, not an error: a caller that cannot
+/// distinguish absence from failure retries a lookup that will never succeed.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct GetKeyResponseBody {
+    pub key: Option<KeyRecord>,
+}

--- a/vta-sdk/src/protocols/key_management/import.rs
+++ b/vta-sdk/src/protocols/key_management/import.rs
@@ -1,0 +1,146 @@
+//! `keys/import/0.1` — hand an externally-created private key to the VTA.
+
+use serde::{Deserialize, Serialize};
+
+use crate::keys::KeyType;
+
+/// Request payload for canonical `keys/import/0.1`.
+///
+/// Exactly one carrier member conveys the key. The choice between them is a
+/// **confidentiality decision, not a formatting one**: `private_key_sealed`
+/// and `private_key_jwe` encrypt the material to the VTA, so it is opaque to
+/// every intermediary and to the transport itself, while
+/// `private_key_multibase` is cleartext and safe only where the transport is
+/// end-to-end confidential.
+///
+/// The trust-task dispatcher **refuses the cleartext carrier outright**, because
+/// one dispatcher serves REST, DIDComm and TSP and cannot tell which one carried
+/// a given request. The legacy `key-management/1.0/import-key` DIDComm message
+/// still accepts it, where authcrypt has already established that guarantee.
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct ImportKeyBody {
+    #[serde(alias = "key_type")]
+    pub key_type: KeyType,
+    /// Armored sealed-transfer bundle carrying the private key, encrypted to
+    /// the VTA. The carrier to prefer.
+    #[serde(
+        default,
+        alias = "private_key_sealed",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub private_key_sealed: Option<String>,
+    /// JWE compact serialization of the private key, encrypted to the VTA.
+    #[serde(
+        default,
+        alias = "private_key_jwe",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub private_key_jwe: Option<String>,
+    /// Raw multibase-encoded private key — **cleartext**. Refused by the
+    /// trust-task dispatcher; see the type's documentation.
+    #[serde(
+        default,
+        alias = "private_key_multibase",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub private_key_multibase: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    #[serde(default, alias = "context_id", skip_serializing_if = "Option::is_none")]
+    pub context_id: Option<String>,
+}
+
+// Manual Debug — every carrier field is (or decrypts to) the private key being
+// imported. Redact via `{:?}` so no tracing call site or panic-with-debug can
+// leak it. Serialize is unchanged.
+impl std::fmt::Debug for ImportKeyBody {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ImportKeyBody")
+            .field("key_type", &self.key_type)
+            .field(
+                "private_key_sealed",
+                &self.private_key_sealed.as_ref().map(|_| "<redacted>"),
+            )
+            .field(
+                "private_key_jwe",
+                &self.private_key_jwe.as_ref().map(|_| "<redacted>"),
+            )
+            .field(
+                "private_key_multibase",
+                &self.private_key_multibase.as_ref().map(|_| "<redacted>"),
+            )
+            .field("label", &self.label)
+            .field("context_id", &self.context_id)
+            .finish()
+    }
+}
+
+/// `keys/import/0.1` response — the realized record under `key`, exactly as
+/// `keys/create` answers.
+pub use super::create::CreateKeyResponseBody as ImportKeyResponseBody;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The canonical wire form is camelCase; the pre-fold snake_case spellings
+    /// keep deserializing so a producer written against them is not broken by
+    /// the fold.
+    #[test]
+    fn accepts_both_spellings_on_intake() {
+        let canonical = serde_json::json!({
+            "keyType": "ed25519",
+            "privateKeySealed": "-----BEGIN SEALED TRANSFER-----",
+            "contextId": "app"
+        });
+        let body: ImportKeyBody = serde_json::from_value(canonical).unwrap();
+        assert_eq!(body.context_id.as_deref(), Some("app"));
+        assert!(body.private_key_sealed.is_some());
+
+        let legacy = serde_json::json!({
+            "key_type": "ed25519",
+            "private_key_sealed": "-----BEGIN SEALED TRANSFER-----",
+            "context_id": "app"
+        });
+        let body: ImportKeyBody = serde_json::from_value(legacy).unwrap();
+        assert_eq!(body.context_id.as_deref(), Some("app"));
+    }
+
+    /// Emission is canonical regardless of which spelling came in.
+    #[test]
+    fn emits_camel_case() {
+        let body = ImportKeyBody {
+            key_type: KeyType::Ed25519,
+            private_key_sealed: Some("sealed".into()),
+            private_key_jwe: None,
+            private_key_multibase: None,
+            label: None,
+            context_id: Some("app".into()),
+        };
+        let v = serde_json::to_value(&body).unwrap();
+        assert!(v.get("keyType").is_some(), "{v}");
+        assert!(v.get("privateKeySealed").is_some(), "{v}");
+        assert!(v.get("key_type").is_none(), "{v}");
+    }
+
+    /// The redacting Debug is the only thing standing between a private key and
+    /// a log line, so it is pinned rather than assumed.
+    #[test]
+    fn debug_redacts_every_carrier() {
+        let body = ImportKeyBody {
+            key_type: KeyType::Ed25519,
+            private_key_sealed: Some("SEALED-SECRET".into()),
+            private_key_jwe: Some("JWE-SECRET".into()),
+            private_key_multibase: Some("z-MULTIBASE-SECRET".into()),
+            label: None,
+            context_id: None,
+        };
+        let rendered = format!("{body:?}");
+        assert!(!rendered.contains("SEALED-SECRET"), "{rendered}");
+        assert!(!rendered.contains("JWE-SECRET"), "{rendered}");
+        assert!(!rendered.contains("MULTIBASE-SECRET"), "{rendered}");
+        assert!(rendered.contains("<redacted>"), "{rendered}");
+    }
+}

--- a/vta-sdk/src/protocols/key_management/list.rs
+++ b/vta-sdk/src/protocols/key_management/list.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use crate::keys::{KeyRecord, KeyStatus};
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ListKeysBody {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -11,7 +12,7 @@ pub struct ListKeysBody {
     pub limit: Option<u64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub status: Option<KeyStatus>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default, alias = "context_id", skip_serializing_if = "Option::is_none")]
     pub context_id: Option<String>,
 }
 

--- a/vta-sdk/src/protocols/key_management/mod.rs
+++ b/vta-sdk/src/protocols/key_management/mod.rs
@@ -2,6 +2,7 @@ pub mod create;
 pub mod derive_and_sign;
 pub mod derive_and_sign_document;
 pub mod get;
+pub mod import;
 pub mod list;
 pub mod rename;
 pub mod revoke;

--- a/vta-sdk/src/protocols/key_management/rename.rs
+++ b/vta-sdk/src/protocols/key_management/rename.rs
@@ -4,13 +4,17 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct RenameKeyBody {
+    #[serde(rename = "keyId", alias = "key_id")]
     pub key_id: String,
+    #[serde(rename = "newKeyId", alias = "new_key_id")]
     pub new_key_id: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct RenameKeyResultBody {
+    #[serde(rename = "keyId", alias = "key_id")]
     pub key_id: String,
+    #[serde(rename = "updatedAt", alias = "updated_at")]
     pub updated_at: DateTime<Utc>,
 }

--- a/vta-sdk/src/protocols/key_management/revoke.rs
+++ b/vta-sdk/src/protocols/key_management/revoke.rs
@@ -6,13 +6,19 @@ use crate::keys::KeyStatus;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct RevokeKeyBody {
+    #[serde(rename = "keyId", alias = "key_id")]
     pub key_id: String,
+    /// Optional human-readable rationale, recorded with the revocation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct RevokeKeyResultBody {
+    #[serde(rename = "keyId", alias = "key_id")]
     pub key_id: String,
     pub status: KeyStatus,
+    #[serde(rename = "updatedAt", alias = "updated_at")]
     pub updated_at: DateTime<Utc>,
 }

--- a/vta-sdk/src/protocols/key_management/sign.rs
+++ b/vta-sdk/src/protocols/key_management/sign.rs
@@ -1,13 +1,18 @@
 use serde::{Deserialize, Serialize};
 
 /// Signing algorithms supported by the VTA sign-request protocol.
+/// Signing algorithms, spelled as the IANA JOSE registry spells them —
+/// which is what the canonical `keys/_shared/0.1/sign-algorithm` enumeration
+/// publishes. The pre-fold lowercase forms are accepted on intake so a producer
+/// written against them keeps working while it migrates.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(rename_all = "lowercase")]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub enum SignAlgorithm {
     /// Ed25519 / EdDSA signing.
+    #[serde(rename = "EdDSA", alias = "eddsa")]
     EdDSA,
     /// ECDSA with P-256 / ES256 signing.
+    #[serde(rename = "ES256", alias = "es256")]
     ES256,
 }
 
@@ -30,6 +35,7 @@ pub struct SignRequestBody {
     /// every key in it, so a signer acting for several identities needs a
     /// context each. See `docs/02-vta/integration-guide.md` §"What authorizes a
     /// sign request".
+    #[serde(rename = "keyId", alias = "key_id")]
     pub key_id: String,
     /// Base64url-encoded payload bytes to sign.
     pub payload: String,
@@ -42,6 +48,7 @@ pub struct SignRequestBody {
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct SignResultBody {
     /// Key ID that was used.
+    #[serde(rename = "keyId", alias = "key_id")]
     pub key_id: String,
     /// Base64url-encoded signature bytes.
     pub signature: String,

--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -298,32 +298,45 @@ pub const TASK_CONTEXTS_DELETE_1_0: &str = "https://trusttasks.org/spec/vta/cont
 
 /// `spec/vta/keys/list/1.0` — list key records (paginated, filterable).
 /// Payload: [`crate::protocols::key_management::list::ListKeysBody`].
-pub const TASK_KEYS_LIST_1_0: &str = "https://trusttasks.org/spec/vta/keys/list/1.0";
+pub const TASK_KEYS_LIST_0_1: &str = "https://trusttasks.org/spec/keys/list/0.1";
 
 /// `spec/vta/keys/create/1.0` — derive a new key from the active seed.
 /// Payload: [`crate::protocols::key_management::create::CreateKeyBody`].
 /// Auth: Admin.
-pub const TASK_KEYS_CREATE_1_0: &str = "https://trusttasks.org/spec/vta/keys/create/1.0";
+pub const TASK_KEYS_CREATE_0_1: &str = "https://trusttasks.org/spec/keys/create/0.1";
 
 /// `spec/vta/keys/get/1.0` — retrieve a single key record.
 /// Payload: [`crate::protocols::key_management::get::GetKeyBody`].
-pub const TASK_KEYS_GET_1_0: &str = "https://trusttasks.org/spec/vta/keys/get/1.0";
+pub const TASK_KEYS_SHOW_0_1: &str = "https://trusttasks.org/spec/keys/show/0.1";
+
+/// `keys/import/0.1` — hand an externally-created private key to the VTA,
+/// which stores it and thereafter exercises it like any key it derived.
+/// Payload: [`crate::protocols::key_management::import::ImportKeyBody`].
+/// Auth: Admin.
+///
+/// **The cleartext `privateKeyMultibase` carrier is refused on this task.**
+/// One dispatcher serves the trust-task surface over REST, DIDComm and TSP, so
+/// a handler here cannot tell whether the transport that carried the request
+/// was end-to-end confidential — and the spec's rule is that cleartext is
+/// admissible only where it was. Refusing unconditionally is the reading that
+/// cannot leak a key; sealed and JWE carriers work on every transport.
+pub const TASK_KEYS_IMPORT_0_1: &str = "https://trusttasks.org/spec/keys/import/0.1";
 
 /// `spec/vta/keys/rename/1.0` — rename a key's identifier.
 /// Payload: [`crate::protocols::key_management::rename::RenameKeyBody`].
 /// Auth: Admin.
-pub const TASK_KEYS_RENAME_1_0: &str = "https://trusttasks.org/spec/vta/keys/rename/1.0";
+pub const TASK_KEYS_RENAME_0_1: &str = "https://trusttasks.org/spec/keys/rename/0.1";
 
 /// `spec/vta/keys/revoke/1.0` — invalidate a key.
 /// Payload: [`crate::protocols::key_management::revoke::RevokeKeyBody`].
 /// Auth: Admin.
-pub const TASK_KEYS_REVOKE_1_0: &str = "https://trusttasks.org/spec/vta/keys/revoke/1.0";
+pub const TASK_KEYS_REVOKE_0_1: &str = "https://trusttasks.org/spec/keys/revoke/0.1";
 
 /// `spec/vta/keys/sign/1.0` — sign a base64url-encoded payload with a
 /// stored key (raw-bytes signing oracle).
 /// Payload: [`crate::protocols::key_management::sign::SignRequestBody`].
 /// Auth: write (Application or higher).
-pub const TASK_KEYS_SIGN_1_0: &str = "https://trusttasks.org/spec/vta/keys/sign/1.0";
+pub const TASK_KEYS_SIGN_0_1: &str = "https://trusttasks.org/spec/keys/sign/0.1";
 
 /// `spec/vta/keys/derive-and-sign/1.0` — derive a key at a BIP-32 path from the
 /// seed, sign a base64url payload, and return `{ public_key, signature }`
@@ -331,8 +344,8 @@ pub const TASK_KEYS_SIGN_1_0: &str = "https://trusttasks.org/spec/vta/keys/sign/
 /// derivation tree).
 /// Payload: [`crate::protocols::key_management::derive_and_sign::DeriveAndSignBody`].
 /// Auth: admin.
-pub const TASK_KEYS_DERIVE_AND_SIGN_1_0: &str =
-    "https://trusttasks.org/spec/vta/keys/derive-and-sign/1.0";
+pub const TASK_KEYS_DERIVE_AND_SIGN_0_1: &str =
+    "https://trusttasks.org/spec/keys/derive-and-sign/0.1";
 
 /// `spec/vta/keys/derive-and-sign-document/1.0` — derive a key at a BIP-32 path
 /// from the seed and attach an `eddsa-jcs-2022` Data-Integrity proof to a
@@ -340,8 +353,8 @@ pub const TASK_KEYS_DERIVE_AND_SIGN_1_0: &str =
 /// DI-signing counterpart of derive-and-sign.
 /// Payload: [`crate::protocols::key_management::derive_and_sign_document::DeriveAndSignDocumentBody`].
 /// Auth: admin.
-pub const TASK_KEYS_DERIVE_AND_SIGN_DOCUMENT_1_0: &str =
-    "https://trusttasks.org/spec/vta/keys/derive-and-sign-document/1.0";
+pub const TASK_KEYS_DERIVE_AND_SIGN_DOCUMENT_0_1: &str =
+    "https://trusttasks.org/spec/keys/derive-and-sign-document/0.1";
 
 // ─── Seeds slice (spec/vta/seeds/*) ──────────────────────────────────────
 
@@ -1308,14 +1321,15 @@ pub const ALL_URIS: &[&str] = &[
     TASK_CONTEXTS_PREVIEW_DELETE_1_0,
     TASK_CONTEXTS_DELETE_1_0,
     // Keys slice
-    TASK_KEYS_LIST_1_0,
-    TASK_KEYS_CREATE_1_0,
-    TASK_KEYS_GET_1_0,
-    TASK_KEYS_RENAME_1_0,
-    TASK_KEYS_REVOKE_1_0,
-    TASK_KEYS_SIGN_1_0,
-    TASK_KEYS_DERIVE_AND_SIGN_1_0,
-    TASK_KEYS_DERIVE_AND_SIGN_DOCUMENT_1_0,
+    TASK_KEYS_LIST_0_1,
+    TASK_KEYS_CREATE_0_1,
+    TASK_KEYS_IMPORT_0_1,
+    TASK_KEYS_SHOW_0_1,
+    TASK_KEYS_RENAME_0_1,
+    TASK_KEYS_REVOKE_0_1,
+    TASK_KEYS_SIGN_0_1,
+    TASK_KEYS_DERIVE_AND_SIGN_0_1,
+    TASK_KEYS_DERIVE_AND_SIGN_DOCUMENT_0_1,
     // Seeds slice
     TASK_SEEDS_LIST_1_0,
     TASK_SEEDS_ROTATE_1_0,
@@ -1557,6 +1571,12 @@ mod tests {
             // `vta/audit/list-logs` folded onto it in #840 phase A, trading
             // offset pages for the canonical opaque cursor.
             "https://trusttasks.org/spec/audit/",
+            // Canonical key custody + signing oracle — the nine-task `keys/*`
+            // family authored upstream in dtgwg-trust-tasks-tf#167. The VTA's
+            // `vta/keys/*` folded onto it in #840 phase D; holding keys for
+            // someone and signing without exporting them is generic to any
+            // agent, so the family is top-level rather than VTA-private.
+            "https://trusttasks.org/spec/keys/",
         ];
         for uri in ALL_URIS {
             assert!(

--- a/vta-sdk/tests/client_rest.rs
+++ b/vta-sdk/tests/client_rest.rs
@@ -307,41 +307,42 @@ async fn backup_export_403_maps_to_forbidden() {
 
 // ── Keys ────────────────────────────────────────────────────────────
 
+/// One record in the canonical `keys/_shared/0.1/key-record` shape — camelCase,
+/// which is what the VTA emits on every transport after the keys fold.
 fn key_record_json(id: &str) -> Value {
     json!({
-        "key_id": id,
-        "derivation_path": "m/44'/0'/0'",
-        "key_type": "ed25519",
+        "keyId": id,
+        "derivationPath": "m/44'/0'/0'",
+        "keyType": "ed25519",
         "status": "active",
-        "public_key": "z6Mkpub",
+        "publicKey": "z6Mkpub",
         "label": null,
-        "context_id": null,
-        "seed_id": 1,
+        "contextId": null,
+        "seedId": 1,
         "origin": "derived",
-        "created_at": "2026-01-01T00:00:00Z",
-        "updated_at": "2026-01-01T00:00:00Z"
+        "createdAt": "2026-01-01T00:00:00Z",
+        "updatedAt": "2026-01-01T00:00:00Z"
     })
+}
+
+/// The `{ key }` envelope canonical single-record responses carry.
+fn key_envelope(id: &str) -> Value {
+    json!({ "key": key_record_json(id) })
+}
+
+/// The same envelope for a key that arrived from outside. `origin` is the
+/// member that says a seed restore will not bring this one back, so a fixture
+/// that always said `derived` would let a broken mapping pass.
+fn imported_key_envelope(id: &str) -> Value {
+    let mut record = key_record_json(id);
+    record["origin"] = json!("imported");
+    json!({ "key": record })
 }
 
 #[tokio::test]
 async fn create_key_round_trip() {
     let server = MockServer::start().await;
-    let _g = mount_json(
-        &server,
-        "POST",
-        "/keys",
-        200,
-        json!({
-            "key_id": "k1",
-            "key_type": "ed25519",
-            "derivation_path": "m/0/0",
-            "public_key": "z6Mkpub",
-            "status": "active",
-            "label": null,
-            "created_at": "2026-01-01T00:00:00Z"
-        }),
-    )
-    .await;
+    let _g = mount_json(&server, "POST", "/keys", 200, key_envelope("k1")).await;
     let c = client(&server).await;
     let req = CreateKeyRequest::new(KeyType::Ed25519)
         .derivation_path("m/0/0")
@@ -386,7 +387,7 @@ async fn get_key_path_encodes_did_fragment() {
         "GET",
         "/keys/did:web:example.com%23key-1",
         200,
-        key_record_json("did:web:example.com#key-1"),
+        key_envelope("did:web:example.com#key-1"),
     )
     .await;
     let c = client(&server).await;
@@ -516,15 +517,7 @@ async fn import_key_posts() {
         "POST",
         "/keys/import",
         200,
-        json!({
-            "key_id": "imported",
-            "key_type": "ed25519",
-            "public_key": "z6Mkpub",
-            "status": "active",
-            "label": null,
-            "origin": "imported",
-            "created_at": "2026-01-01T00:00:00Z"
-        }),
+        imported_key_envelope("imported"),
     )
     .await;
     let c = client(&server).await;

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.14.0"
+version = "0.14.1"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/routes/keys.rs
+++ b/vta-service/src/routes/keys.rs
@@ -4,9 +4,10 @@ use axum::http::StatusCode;
 use serde::{Deserialize, Serialize};
 
 use vta_sdk::protocols::key_management::{
-    create::CreateKeyResultBody,
+    create::CreateKeyResponseBody,
     derive_and_sign::{DeriveAndSignBody, DeriveAndSignResultBody},
     derive_and_sign_document::{DeriveAndSignDocumentBody, DeriveAndSignDocumentResultBody},
+    get::GetKeyResponseBody,
     list::ListKeysResultBody,
     rename::RenameKeyResultBody,
     revoke::RevokeKeyResultBody,
@@ -19,7 +20,6 @@ use vta_sdk::protocols::seed_management::{
 
 use crate::auth::{AdminAuth, AuthClaims};
 use crate::error::AppError;
-use crate::keys::KeyRecord;
 use crate::keys::KeyStatus;
 use crate::keys::KeyType;
 use crate::operations;
@@ -41,7 +41,7 @@ pub struct CreateKeyRequest {
     security(("bearer_jwt" = [])),
     request_body = CreateKeyRequest,
     responses(
-        (status = 201, description = "Key created", body = CreateKeyResultBody),
+        (status = 201, description = "Key created", body = CreateKeyResponseBody),
         (status = 401, description = "Missing or invalid bearer token"),
         (status = 403, description = "Caller is not an admin/initiator"),
     ),
@@ -50,7 +50,7 @@ pub async fn create_key(
     auth: AdminAuth,
     State(state): State<AppState>,
     Json(req): Json<CreateKeyRequest>,
-) -> Result<(StatusCode, Json<CreateKeyResultBody>), AppError> {
+) -> Result<(StatusCode, Json<CreateKeyResponseBody>), AppError> {
     let result = operations::keys::create_key(
         &state.keys_ks,
         &state.contexts_ks,
@@ -68,7 +68,10 @@ pub async fn create_key(
         "rest",
     )
     .await?;
-    Ok((StatusCode::CREATED, Json(result)))
+    Ok((
+        StatusCode::CREATED,
+        Json(CreateKeyResponseBody { key: result }),
+    ))
 }
 
 /// GET /keys/{key_id}/secret — retrieve private key material. Auth: Admin or Initiator.
@@ -107,7 +110,7 @@ pub async fn get_key_secret(
     security(("bearer_jwt" = [])),
     params(("key_id" = String, Path, description = "Key identifier")),
     responses(
-        (status = 200, description = "Key record", body = KeyRecord),
+        (status = 200, description = "Key record", body = GetKeyResponseBody),
         (status = 401, description = "Missing or invalid bearer token"),
         (status = 404, description = "Key not found"),
     ),
@@ -116,9 +119,9 @@ pub async fn get_key(
     auth: AuthClaims,
     State(state): State<AppState>,
     Path(key_id): Path<String>,
-) -> Result<Json<KeyRecord>, AppError> {
+) -> Result<Json<GetKeyResponseBody>, AppError> {
     let result = operations::keys::get_key(&state.keys_ks, &auth, &key_id, "rest").await?;
-    Ok(Json(result))
+    Ok(Json(GetKeyResponseBody { key: Some(result) }))
 }
 
 /// DELETE /keys/{key_id} — revoke/invalidate a key. Auth: Admin or Initiator.
@@ -481,7 +484,7 @@ pub struct ImportKeyRestRequest {
     security(("bearer_jwt" = [])),
     request_body = ImportKeyRestRequest,
     responses(
-        (status = 201, description = "Key imported", body = CreateKeyResultBody),
+        (status = 201, description = "Key imported", body = CreateKeyResponseBody),
         (status = 401, description = "Missing or invalid bearer token"),
         (status = 403, description = "Caller is not an admin"),
     ),
@@ -490,7 +493,7 @@ pub async fn import_key(
     auth: AdminAuth,
     State(state): State<AppState>,
     Json(req): Json<ImportKeyRestRequest>,
-) -> Result<(StatusCode, Json<CreateKeyResultBody>), AppError> {
+) -> Result<(StatusCode, Json<CreateKeyResponseBody>), AppError> {
     // Unwrap the private key based on transport. Sealed-transfer is
     // preferred; JWE is kept as a fallback for legacy clients. The
     // plaintext `private_key_multibase` path is intentionally not
@@ -534,5 +537,8 @@ pub async fn import_key(
         "rest",
     )
     .await?;
-    Ok((StatusCode::CREATED, Json(result)))
+    Ok((
+        StatusCode::CREATED,
+        Json(CreateKeyResponseBody { key: result }),
+    ))
 }

--- a/vta-service/src/trust_tasks/conformance.rs
+++ b/vta-service/src/trust_tasks/conformance.rs
@@ -60,6 +60,7 @@ use trust_tasks_rs::specs;
 use vta_sdk::trust_tasks as uris;
 
 use vta_sdk::acl::ContextDirection;
+use vta_sdk::keys::{KeyOrigin, KeyRecord, KeyStatus, KeyType};
 use vta_sdk::protocols::acl_management::change_role::ChangeRoleBody;
 use vta_sdk::protocols::acl_management::create::{CreateAclBody, CreateAclResponseBody};
 use vta_sdk::protocols::acl_management::delete::{DeleteAclBody, DeleteAclResultBody};
@@ -79,6 +80,21 @@ use vta_sdk::protocols::credential_exchange::{
 use vta_sdk::protocols::credentials_issuance::{
     IssueCredentialBody, IssueCredentialResponse, RevokeCredentialBody, RevokeCredentialResponse,
 };
+use vta_sdk::protocols::key_management::create::{
+    CreateKeyBody, CreateKeyResponseBody, CreateKeyResultBody,
+};
+use vta_sdk::protocols::key_management::derive_and_sign::{
+    DeriveAndSignBody, DeriveAndSignResultBody,
+};
+use vta_sdk::protocols::key_management::derive_and_sign_document::{
+    DeriveAndSignDocumentBody, DeriveAndSignDocumentResultBody,
+};
+use vta_sdk::protocols::key_management::get::{GetKeyBody, GetKeyResponseBody};
+use vta_sdk::protocols::key_management::import::ImportKeyBody;
+use vta_sdk::protocols::key_management::list::{ListKeysBody, ListKeysResultBody};
+use vta_sdk::protocols::key_management::rename::{RenameKeyBody, RenameKeyResultBody};
+use vta_sdk::protocols::key_management::revoke::{RevokeKeyBody, RevokeKeyResultBody};
+use vta_sdk::protocols::key_management::sign::{SignAlgorithm, SignRequestBody, SignResultBody};
 use vta_sdk::protocols::memory::{
     MemoryDeleteBody, MemoryDeleteResponse, MemoryItem, MemoryListBody, MemoryListResponse,
     MemoryPutBody, MemoryPutResponse,
@@ -151,6 +167,37 @@ fn dt() -> chrono::DateTime<chrono::Utc> {
     chrono::DateTime::parse_from_rfc3339(TS)
         .expect("valid ts")
         .with_timezone(&chrono::Utc)
+}
+
+/// A fully-populated canonical `KeyRecord` (the keys family's shared component).
+fn key_record() -> KeyRecord {
+    KeyRecord {
+        key_id: "app-signing-key".into(),
+        derivation_path: "m/26'/2'/0'/1'".into(),
+        key_type: KeyType::Ed25519,
+        status: KeyStatus::Active,
+        public_key: "z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH".into(),
+        label: Some("app signing key".into()),
+        context_id: Some("app".into()),
+        seed_id: Some(1),
+        origin: KeyOrigin::Derived,
+        created_at: dt(),
+        updated_at: dt(),
+    }
+}
+
+/// The create/import response's record shape — a strict subset of `KeyRecord`.
+fn key_result() -> CreateKeyResultBody {
+    CreateKeyResultBody {
+        key_id: "app-signing-key".into(),
+        key_type: KeyType::Ed25519,
+        derivation_path: "m/26'/2'/0'/1'".into(),
+        public_key: "z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH".into(),
+        status: KeyStatus::Active,
+        label: Some("app signing key".into()),
+        origin: KeyOrigin::Derived,
+        created_at: dt(),
+    }
 }
 
 /// A fully-populated canonical `AclEntry` (the family's shared component).
@@ -583,6 +630,153 @@ fn table() -> Vec<(&'static str, Conformance)> {
                 to_v(SwapKeyResultBody {
                     entry: acl_entry(),
                     previous_subject: SUBJECT.into(),
+                })
+            ),
+        ),
+        // ─── keys (the signing-oracle + custody family, #167) ────
+        (
+            uris::TASK_KEYS_LIST_0_1,
+            checked!(
+                specs::keys::list::v0_1::Payload,
+                specs::keys::list::v0_1::Response,
+                to_v(ListKeysBody {
+                    offset: Some(0),
+                    limit: Some(50),
+                    status: Some(KeyStatus::Active),
+                    context_id: Some("app".into()),
+                }),
+                to_v(ListKeysResultBody {
+                    keys: vec![key_record()],
+                    total: 1,
+                    offset: 0,
+                    limit: 50,
+                })
+            ),
+        ),
+        (
+            uris::TASK_KEYS_CREATE_0_1,
+            checked!(
+                specs::keys::create::v0_1::Payload,
+                specs::keys::create::v0_1::Response,
+                to_v(CreateKeyBody {
+                    key_type: KeyType::Ed25519,
+                    derivation_path: "m/26'/2'/0'/1'".into(),
+                    mnemonic: None,
+                    label: Some("app signing key".into()),
+                    context_id: Some("app".into()),
+                }),
+                to_v(CreateKeyResponseBody { key: key_result() })
+            ),
+        ),
+        (
+            uris::TASK_KEYS_IMPORT_0_1,
+            checked!(
+                specs::keys::import::v0_1::Payload,
+                specs::keys::import::v0_1::Response,
+                to_v(ImportKeyBody {
+                    key_type: KeyType::Ed25519,
+                    private_key_sealed: Some("-----BEGIN SEALED TRANSFER-----".into()),
+                    private_key_jwe: None,
+                    private_key_multibase: None,
+                    label: Some("migrated signer".into()),
+                    context_id: Some("app".into()),
+                }),
+                to_v(CreateKeyResponseBody { key: key_result() })
+            ),
+        ),
+        (
+            uris::TASK_KEYS_SHOW_0_1,
+            checked!(
+                specs::keys::show::v0_1::Payload,
+                specs::keys::show::v0_1::Response,
+                to_v(GetKeyBody {
+                    key_id: "app-signing-key".into(),
+                }),
+                to_v(GetKeyResponseBody {
+                    key: Some(key_record()),
+                })
+            ),
+        ),
+        (
+            uris::TASK_KEYS_RENAME_0_1,
+            checked!(
+                specs::keys::rename::v0_1::Payload,
+                specs::keys::rename::v0_1::Response,
+                to_v(RenameKeyBody {
+                    key_id: "app-signing-key".into(),
+                    new_key_id: "app-signing-key-2026".into(),
+                }),
+                to_v(RenameKeyResultBody {
+                    key_id: "app-signing-key-2026".into(),
+                    updated_at: dt(),
+                })
+            ),
+        ),
+        (
+            uris::TASK_KEYS_REVOKE_0_1,
+            checked!(
+                specs::keys::revoke::v0_1::Payload,
+                specs::keys::revoke::v0_1::Response,
+                to_v(RevokeKeyBody {
+                    key_id: "app-signing-key".into(),
+                    reason: Some("superseded".into()),
+                }),
+                to_v(RevokeKeyResultBody {
+                    key_id: "app-signing-key".into(),
+                    status: KeyStatus::Revoked,
+                    updated_at: dt(),
+                })
+            ),
+        ),
+        (
+            uris::TASK_KEYS_SIGN_0_1,
+            checked!(
+                specs::keys::sign::v0_1::Payload,
+                specs::keys::sign::v0_1::Response,
+                to_v(SignRequestBody {
+                    key_id: "app-signing-key".into(),
+                    payload: "aGVsbG8".into(),
+                    algorithm: SignAlgorithm::EdDSA,
+                }),
+                to_v(SignResultBody {
+                    key_id: "app-signing-key".into(),
+                    signature: "3q2-7w".into(),
+                    algorithm: SignAlgorithm::EdDSA,
+                })
+            ),
+        ),
+        (
+            uris::TASK_KEYS_DERIVE_AND_SIGN_0_1,
+            checked!(
+                specs::keys::derive_and_sign::v0_1::Payload,
+                specs::keys::derive_and_sign::v0_1::Response,
+                to_v(DeriveAndSignBody {
+                    key_type: KeyType::Ed25519,
+                    derivation_path: "m/26'/9'/0'".into(),
+                    payload: "aGVsbG8".into(),
+                    algorithm: SignAlgorithm::EdDSA,
+                }),
+                to_v(DeriveAndSignResultBody {
+                    public_key: "z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH".into(),
+                    signature: "3q2-7w".into(),
+                    algorithm: SignAlgorithm::EdDSA,
+                })
+            ),
+        ),
+        (
+            uris::TASK_KEYS_DERIVE_AND_SIGN_DOCUMENT_0_1,
+            checked!(
+                specs::keys::derive_and_sign_document::v0_1::Payload,
+                specs::keys::derive_and_sign_document::v0_1::Response,
+                to_v(DeriveAndSignDocumentBody {
+                    key_type: KeyType::Ed25519,
+                    derivation_path: "m/26'/9'/0'".into(),
+                    document: json!({ "id": "urn:uuid:1", "payload": { "a": 1 } }),
+                    proof_purpose: Some("assertionMethod".into()),
+                }),
+                to_v(DeriveAndSignDocumentResultBody {
+                    signer_did: "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH".into(),
+                    document: json!({ "id": "urn:uuid:1", "proof": { "type": "DataIntegrityProof" } }),
                 })
             ),
         ),

--- a/vta-service/src/trust_tasks/keys.rs
+++ b/vta-service/src/trust_tasks/keys.rs
@@ -12,6 +12,7 @@ use vta_sdk::protocols::key_management::create::CreateKeyBody;
 use vta_sdk::protocols::key_management::derive_and_sign::DeriveAndSignBody;
 use vta_sdk::protocols::key_management::derive_and_sign_document::DeriveAndSignDocumentBody;
 use vta_sdk::protocols::key_management::get::GetKeyBody;
+use vta_sdk::protocols::key_management::import::{ImportKeyBody, ImportKeyResponseBody};
 use vta_sdk::protocols::key_management::list::ListKeysBody;
 use vta_sdk::protocols::key_management::rename::RenameKeyBody;
 use vta_sdk::protocols::key_management::revoke::RevokeKeyBody;
@@ -25,7 +26,7 @@ use super::helpers::{
     TRANSPORT_TRUST_TASK, app_error_to_reject, parse_payload, reject_with, success_response,
 };
 
-/// Handler for `spec/vta/keys/list/1.0`.
+/// Handler for `keys/list/0.1`.
 pub(super) async fn handle_list(
     state: &AppState,
     auth: &AuthClaims,
@@ -53,7 +54,7 @@ pub(super) async fn handle_list(
     }
 }
 
-/// Handler for `spec/vta/keys/create/1.0`. Admin only.
+/// Handler for `keys/create/0.1`. Admin only.
 pub(super) async fn handle_create(
     state: &AppState,
     auth: &AuthClaims,
@@ -87,12 +88,18 @@ pub(super) async fn handle_create(
     )
     .await
     {
-        Ok(body) => success_response(&doc, body),
+        // Canonical `keys/create/0.1` answers the realized record under `key`,
+        // like `keys/show` and `keys/import` — one record shape across the
+        // family, so a consumer cannot end up holding two spellings of it.
+        Ok(body) => success_response(
+            &doc,
+            vta_sdk::protocols::key_management::create::CreateKeyResponseBody { key: body },
+        ),
         Err(e) => app_error_to_reject(&doc, e),
     }
 }
 
-/// Handler for `spec/vta/keys/get/1.0`.
+/// Handler for `keys/show/0.1`.
 pub(super) async fn handle_get(
     state: &AppState,
     auth: &AuthClaims,
@@ -103,12 +110,15 @@ pub(super) async fn handle_get(
         Err(resp) => return resp,
     };
     match operations::keys::get_key(&state.keys_ks, auth, &req.key_id, TRANSPORT_TRUST_TASK).await {
-        Ok(record) => success_response(&doc, record),
+        Ok(record) => success_response(
+            &doc,
+            vta_sdk::protocols::key_management::get::GetKeyResponseBody { key: Some(record) },
+        ),
         Err(e) => app_error_to_reject(&doc, e),
     }
 }
 
-/// Handler for `spec/vta/keys/rename/1.0`. Admin only.
+/// Handler for `keys/rename/0.1`. Admin only.
 pub(super) async fn handle_rename(
     state: &AppState,
     auth: &AuthClaims,
@@ -136,7 +146,7 @@ pub(super) async fn handle_rename(
     }
 }
 
-/// Handler for `spec/vta/keys/revoke/1.0`. Admin only.
+/// Handler for `keys/revoke/0.1`. Admin only.
 pub(super) async fn handle_revoke(
     state: &AppState,
     auth: &AuthClaims,
@@ -165,7 +175,7 @@ pub(super) async fn handle_revoke(
     }
 }
 
-/// Handler for `spec/vta/keys/sign/1.0`. Application-or-higher (write).
+/// Handler for `keys/sign/0.1`. Application-or-higher (write).
 ///
 /// Decodes the base64url payload before invoking the signing oracle —
 /// matches the legacy REST handler's behaviour. The signature in the
@@ -215,7 +225,7 @@ pub(super) async fn handle_sign(
     }
 }
 
-/// Handler for `spec/vta/keys/derive-and-sign/1.0`. Admin only.
+/// Handler for `keys/derive-and-sign/0.1`. Admin only.
 ///
 /// Ephemeral: derives at the requested BIP-32 path, signs, and returns the
 /// signature + derived public key without persisting a key record.
@@ -262,7 +272,7 @@ pub(super) async fn handle_derive_and_sign(
     }
 }
 
-/// Handler for `spec/vta/keys/derive-and-sign-document/1.0`. Admin only.
+/// Handler for `keys/derive-and-sign-document/0.1`. Admin only.
 ///
 /// Attaches an `eddsa-jcs-2022` Data-Integrity proof to the document, signed as
 /// the key derived at the requested path — without persisting a key record.
@@ -291,6 +301,93 @@ pub(super) async fn handle_derive_and_sign_document(
     .await
     {
         Ok(body) => success_response(&doc, body),
+        Err(e) => app_error_to_reject(&doc, e),
+    }
+}
+
+/// Handler for `keys/import/0.1`. Admin only.
+///
+/// **The cleartext `privateKeyMultibase` carrier is refused here, always.** The
+/// specification admits it only where the transport is end-to-end confidential,
+/// and one dispatcher serves this task over REST, DIDComm and TSP — so a handler
+/// at this layer cannot tell which carried the request. Refusing is the reading
+/// that cannot leak a key; the legacy `key-management/1.0/import-key` DIDComm
+/// message still accepts multibase, where authcrypt has already established the
+/// guarantee.
+pub(super) async fn handle_import(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    if let Err(e) = auth.require_admin() {
+        return app_error_to_reject(&doc, e);
+    }
+    let req: ImportKeyBody = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+
+    if req.private_key_multibase.is_some() {
+        return reject_with(
+            &doc,
+            RejectReason::MalformedRequest {
+                reason: "keys/import: the cleartext `privateKeyMultibase` carrier is not                          accepted on the trust-task surface, which is served over REST as well                          as DIDComm and TSP and cannot establish that this request travelled                          end to end. Seal the key to this VTA and send `privateKeySealed`."
+                    .to_string(),
+            },
+        );
+    }
+
+    let private_key_bytes = if let Some(sealed) = req.private_key_sealed.as_deref() {
+        match state.wrapping_cache.unwrap_sealed(sealed).await {
+            Ok((sealed_type, bytes)) => {
+                if sealed_type != req.key_type.to_string() {
+                    return reject_with(
+                        &doc,
+                        RejectReason::MalformedRequest {
+                            reason: format!(
+                                "sealed keyType `{sealed_type}` does not match the request's                                  `{}`",
+                                req.key_type
+                            ),
+                        },
+                    );
+                }
+                bytes
+            }
+            Err(e) => return app_error_to_reject(&doc, e),
+        }
+    } else if let Some(jwe) = req.private_key_jwe.as_deref() {
+        tracing::warn!("key import via legacy JWE carrier — prefer privateKeySealed");
+        match state.wrapping_cache.unwrap_jwe(jwe).await {
+            Ok(bytes) => bytes,
+            Err(e) => return app_error_to_reject(&doc, e),
+        }
+    } else {
+        return reject_with(
+            &doc,
+            RejectReason::MalformedRequest {
+                reason: "keys/import: one of `privateKeySealed` or `privateKeyJwe` is required"
+                    .to_string(),
+            },
+        );
+    };
+
+    match operations::keys::import_key(
+        &state.keys_ks,
+        &state.imported_ks,
+        &state.seed_store,
+        &state.audit_ks,
+        auth,
+        operations::keys::ImportKeyParams {
+            key_type: req.key_type,
+            private_key_bytes,
+            label: req.label,
+            context_id: req.context_id,
+        },
+        TRANSPORT_TRUST_TASK,
+    )
+    .await
+    {
+        Ok(body) => success_response(&doc, ImportKeyResponseBody { key: body }),
         Err(e) => app_error_to_reject(&doc, e),
     }
 }

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -226,15 +226,6 @@ const UNSPECCED_DISPATCHED_URIS: &[&str] = &[
     "https://trusttasks.org/spec/vta/contexts/update-did/1.0",
     "https://trusttasks.org/spec/vta/contexts/preview-delete/1.0",
     "https://trusttasks.org/spec/vta/contexts/delete/1.0",
-    // ─ vta/keys/* — author top-level `keys/*` (reduction plan §D).
-    "https://trusttasks.org/spec/vta/keys/list/1.0",
-    "https://trusttasks.org/spec/vta/keys/create/1.0",
-    "https://trusttasks.org/spec/vta/keys/get/1.0",
-    "https://trusttasks.org/spec/vta/keys/rename/1.0",
-    "https://trusttasks.org/spec/vta/keys/revoke/1.0",
-    "https://trusttasks.org/spec/vta/keys/sign/1.0",
-    "https://trusttasks.org/spec/vta/keys/derive-and-sign/1.0",
-    "https://trusttasks.org/spec/vta/keys/derive-and-sign-document/1.0",
     // ─ vta/seeds/* — keep-and-spec under `vta/` (reduction plan §E).
     "https://trusttasks.org/spec/vta/seeds/list/1.0",
     "https://trusttasks.org/spec/vta/seeds/rotate/1.0",
@@ -813,21 +804,23 @@ dispatch_table! {
     vta_sdk::trust_tasks::TASK_CONTEXTS_DELETE_1_0 => contexts::handle_delete
         [ Destructive None false ],
     // ─── Keys slice ──────────────────────────────────────────────
-    vta_sdk::trust_tasks::TASK_KEYS_LIST_1_0 => keys::handle_list
+    vta_sdk::trust_tasks::TASK_KEYS_LIST_0_1 => keys::handle_list
         [ None Metadata false ],
-    vta_sdk::trust_tasks::TASK_KEYS_CREATE_1_0 => keys::handle_create
+    vta_sdk::trust_tasks::TASK_KEYS_CREATE_0_1 => keys::handle_create
         [ Mutating None false ],
-    vta_sdk::trust_tasks::TASK_KEYS_GET_1_0 => keys::handle_get
+    vta_sdk::trust_tasks::TASK_KEYS_IMPORT_0_1 => keys::handle_import
+        [ Mutating None false ],
+    vta_sdk::trust_tasks::TASK_KEYS_SHOW_0_1 => keys::handle_get
         [ None Metadata false ],
-    vta_sdk::trust_tasks::TASK_KEYS_RENAME_1_0 => keys::handle_rename
+    vta_sdk::trust_tasks::TASK_KEYS_RENAME_0_1 => keys::handle_rename
         [ Mutating None false ],
-    vta_sdk::trust_tasks::TASK_KEYS_REVOKE_1_0 => keys::handle_revoke
+    vta_sdk::trust_tasks::TASK_KEYS_REVOKE_0_1 => keys::handle_revoke
         [ Destructive None false ],
-    vta_sdk::trust_tasks::TASK_KEYS_SIGN_1_0 => keys::handle_sign
+    vta_sdk::trust_tasks::TASK_KEYS_SIGN_0_1 => keys::handle_sign
         [ None None true ],
-    vta_sdk::trust_tasks::TASK_KEYS_DERIVE_AND_SIGN_1_0 => keys::handle_derive_and_sign
+    vta_sdk::trust_tasks::TASK_KEYS_DERIVE_AND_SIGN_0_1 => keys::handle_derive_and_sign
         [ Mutating None true ],
-    vta_sdk::trust_tasks::TASK_KEYS_DERIVE_AND_SIGN_DOCUMENT_1_0 => keys::handle_derive_and_sign_document
+    vta_sdk::trust_tasks::TASK_KEYS_DERIVE_AND_SIGN_DOCUMENT_0_1 => keys::handle_derive_and_sign_document
         [ Mutating None true ],
     // ─── Seeds slice ─────────────────────────────────────────────
     vta_sdk::trust_tasks::TASK_SEEDS_LIST_1_0 => seeds::handle_list

--- a/vta-service/src/trust_tasks/policy_gate.rs
+++ b/vta-service/src/trust_tasks/policy_gate.rs
@@ -76,7 +76,7 @@ fn op_class_for(type_uri: &str) -> Option<&'static str> {
         t::TASK_ACL_UPDATE_0_1 => Some(op::ACL_CHANGE_ROLE),
         t::TASK_ACL_REVOKE_0_1 => Some(op::ACL_REVOKE),
         t::TASK_CONTEXTS_DELETE_1_0 => Some(op::CONTEXT_DELETE),
-        t::TASK_KEYS_REVOKE_1_0 => Some(op::KEY_REVOKE),
+        t::TASK_KEYS_REVOKE_0_1 => Some(op::KEY_REVOKE),
         t::TASK_VAULT_RELEASE_0_1 => Some(op::VAULT_RELEASE),
         t::TASK_VAULT_PROXY_LOGIN_0_1 => Some(op::VAULT_PROXY_LOGIN),
         t::TASK_VAULT_SIGN_TRUST_TASK_0_1 => Some(op::VAULT_SIGN_TRUST_TASK),

--- a/vta-service/tests/api_integration.rs
+++ b/vta-service/tests/api_integration.rs
@@ -1065,8 +1065,10 @@ async fn key_create_and_list() {
         ))
         .await;
     assert!(status.is_success(), "create key: {body}");
-    assert!(body["key_id"].is_string());
-    assert_eq!(body["key_type"], "ed25519");
+    // Canonical `keys/create/0.1` answers the realized record under `key`, in
+    // the camelCase the whole family speaks.
+    assert!(body["key"]["keyId"].is_string(), "{body}");
+    assert_eq!(body["key"]["keyType"], "ed25519", "{body}");
 
     // List keys
     let (status, body) = app.request(get_auth("/keys", &token)).await;
@@ -1338,7 +1340,9 @@ async fn scoped_admin_can_only_access_own_context_keys() {
         ))
         .await;
     assert!(status.is_success());
-    let key_id = key_body["key_id"].as_str().unwrap();
+    let key_id = key_body["key"]["keyId"]
+        .as_str()
+        .unwrap_or_else(|| panic!("create answers {{ key }}: {key_body}"));
 
     // Scoped admin for ctx-b cannot get the key in ctx-a (returns 403 or 404 — both are valid)
     let encoded_id = urlencoding::encode(key_id);
@@ -1361,7 +1365,7 @@ async fn scoped_admin_can_only_access_own_context_keys() {
         .request(get_auth(&format!("/keys/{encoded_id}"), &scoped_a_token))
         .await;
     assert_eq!(status, StatusCode::OK);
-    assert_eq!(body["key_id"], key_id);
+    assert_eq!(body["key"]["keyId"], key_id, "{body}");
 }
 
 // ── Key lifecycle ──────────────────────────────────────────────────
@@ -1385,8 +1389,10 @@ async fn key_create_revoke_list_lifecycle() {
             json!({"key_type": "ed25519", "context_id": "lc"}),
         ))
         .await;
-    let key_id = key_body["key_id"].as_str().unwrap();
-    assert_eq!(key_body["status"], "active");
+    let key_id = key_body["key"]["keyId"]
+        .as_str()
+        .unwrap_or_else(|| panic!("create answers {{ key }}: {key_body}"));
+    assert_eq!(key_body["key"]["status"], "active", "{key_body}");
 
     // Revoke the key (key_id may contain slashes from derivation path, URL-encode it)
     let encoded_id = urlencoding::encode(key_id);
@@ -1400,7 +1406,7 @@ async fn key_create_revoke_list_lifecycle() {
         .request(get_auth(&format!("/keys/{encoded_id}"), &token))
         .await;
     assert_eq!(status, StatusCode::OK);
-    assert_eq!(body["status"], "revoked");
+    assert_eq!(body["key"]["status"], "revoked", "{body}");
 }
 
 #[tokio::test]
@@ -1421,7 +1427,9 @@ async fn key_rename() {
             json!({"key_type": "ed25519", "context_id": "rn", "label": "original"}),
         ))
         .await;
-    let key_id = key_body["key_id"].as_str().unwrap();
+    let key_id = key_body["key"]["keyId"]
+        .as_str()
+        .unwrap_or_else(|| panic!("create answers {{ key }}: {key_body}"));
 
     // Rename the key (PATCH expects new key_id in body)
     let encoded_id = urlencoding::encode(key_id);
@@ -1433,7 +1441,7 @@ async fn key_rename() {
         ))
         .await;
     assert!(status.is_success(), "rename: {status} {body}");
-    assert_eq!(body["key_id"], "renamed-key");
+    assert_eq!(body["keyId"], "renamed-key", "{body}");
 }
 
 // ── Seed management ────────────────────────────────────────────────
@@ -1720,8 +1728,8 @@ async fn create_p256_key() {
         ))
         .await;
     assert!(status.is_success(), "create p256: {status} {body}");
-    assert_eq!(body["key_type"], "p256");
-    assert!(body["public_key"].is_string());
+    assert_eq!(body["key"]["keyType"], "p256", "{body}");
+    assert!(body["key"]["publicKey"].is_string(), "{body}");
 }
 
 // ── Context DID update (context admin) ────────────────────────────
@@ -2258,7 +2266,10 @@ async fn import_key_via_sealed_transfer(
         status.is_success(),
         "import {key_type_str} via sealed-transfer: {status} {body}",
     );
-    body["key_id"].as_str().unwrap().to_string()
+    body["key"]["keyId"]
+        .as_str()
+        .unwrap_or_else(|| panic!("import answers {{ key }}: {body}"))
+        .to_string()
 }
 
 /// Helper: import an Ed25519 key via the sealed-transfer wrapping

--- a/vta-service/tests/mock_vta.rs
+++ b/vta-service/tests/mock_vta.rs
@@ -245,6 +245,7 @@ async fn create_did_webvh_round_trips_against_stub_host() {
 /// advanced the key counter and the DID looped forever.
 #[cfg(feature = "webvh")]
 #[tokio::test]
+#[allow(deprecated)] // pins the legacy (context_id, scid) route until it is removed
 async fn a_failed_publish_does_not_wedge_the_did_and_the_next_update_recovers() {
     use vta_sdk::client::{CreateDidWebvhRequest, VtaClient};
     use vta_sdk::protocols::did_management::create::WebvhPathMode;
@@ -362,6 +363,7 @@ async fn a_failed_publish_does_not_wedge_the_did_and_the_next_update_recovers() 
 /// update fails at signing and loops.
 #[cfg(feature = "webvh")]
 #[tokio::test]
+#[allow(deprecated)] // pins the legacy (context_id, scid) route until it is removed
 async fn a_superseded_signing_key_is_recovered_from_the_seed() {
     use vta_sdk::client::{CreateDidWebvhRequest, VtaClient};
     use vta_sdk::protocols::did_management::create::WebvhPathMode;

--- a/vtc-service/tests/trust_task_manifest.rs
+++ b/vtc-service/tests/trust_task_manifest.rs
@@ -437,14 +437,17 @@ const UNPUBLISHED_CANONICAL_OK: &[(&str, usize, &str)] = &[
     // 77.
     (
         "https://trusttasks.org/spec/vta/",
-        44,
+        36,
         "VTA Trust Task surface at 1.0 — predates the registry and was never reconciled with it. \
          Down from 55 via #840 phase A: config/{get,update} onto config/{show,patch}, \
          provision-integration/request onto provision/integration/0.2, acl/* onto the \
          canonical acl/{grant,show,list,update,revoke} family, and audit/list-logs onto \
          audit/list/0.1. Phase A complete at 46; phase B folded \
          webvh/dids/get-log into webvh/dids/get, and webvh/servers/{add,update} \
-         into webvh/servers/register",
+         into webvh/servers/register. Phase D (#888) took the last eight: \
+         keys/{list,create,get,rename,revoke,sign,derive-and-sign,\
+         derive-and-sign-document} onto the canonical top-level keys/* family \
+         authored upstream in dtgwg-trust-tasks-tf#167",
     ),
 ];
 


### PR DESCRIPTION
Phase D of the canonical-task reduction. The specs were authored upstream first
(`trustoverip/dtgwg-trust-tasks-tf` #167 and #169) and published as
`trust-tasks-rs` 0.2.53; this binds them.

## Breaking

The VTA now emits the canonical shapes on **every** transport: camelCase members,
and the single-record responses (`create`, `show`, `import`) wrapped as `{ key }`.
Snake_case is still accepted on *intake* via serde aliases, so a producer written
against the old spelling keeps working — but **a consumer reading responses must
be rebuilt**, `pnm` included. Same trade #842 made for ACL, and the reason to make
the fold once rather than per-transport.

| Was | Now |
|---|---|
| `vta/keys/{list,create,get,rename,revoke,sign,derive-and-sign,derive-and-sign-document}/1.0` | `keys/{list,create,show,rename,revoke,sign,derive-and-sign,derive-and-sign-document}/0.1` |
| *(no task)* | `keys/import/0.1` — new binding |

Nine URIs leave `UNSPECCED_DISPATCHED_URIS` — the metric this programme tracks —
and nine conformance witnesses take their place. `SignAlgorithm` moves to the IANA
JOSE spellings (`EdDSA`, `ES256`), lowercase accepted on intake.

## `keys/import` refuses the cleartext carrier

The new task takes `privateKeySealed` or `privateKeyJwe` and **refuses
`privateKeyMultibase` outright**. One dispatcher serves the trust-task surface
over REST, DIDComm *and* TSP, so a handler there cannot establish that a request
travelled end to end — and cleartext is admissible only where it did. Refusing is
the only reading that cannot leak a key.

The client forks on the same line: sealed and JWE carriers ride the canonical task
(and so reach TSP); a raw multibase key stays on the legacy DIDComm message, where
authcrypt has already established the guarantee. No capability is lost, and none
moves to a transport that cannot carry it safely.

## What conformance caught

The round-trip harness rejected the first cut of my own spec:

```
keys/create/0.1: request is not canonical: unknown field `mnemonic`
```

`create_key` has always been able to derive from a caller-supplied BIP-39 phrase,
and the published schema had no member for it. Binding the task as it stood would
have compiled cleanly and **silently dropped the capability** — create-from-a-phrase
would have kept "working" while deriving from the wrong seed. Fixed at the source
(#169), which is why the dependency is 0.2.53 rather than 0.2.52.

That is the second time a hand-rolled client payload has been the defect in this
programme (after `update_acl` in #884), so `create_key`, `list_keys` and
`import_key` now build their task payloads from the canonical Rust bodies rather
than a `json!` map. A member present in the type but missing from the map is now a
compile error instead of a silent omission.

## Testing

- Nine conformance witnesses; every task round-trips through its generated
  `Payload`/`Response` types.
- `tests/e2e/tests/client_didcomm.rs` (48 passed) pins the canonical envelope and
  both sides of the import fork, including that the cleartext carrier never rides
  the canonical task.
- `vta-sdk/tests/client_rest.rs` (84 passed) and
  `vta-service/tests/api_integration.rs` (120 passed) move to the canonical shape;
  the imported-key fixture carries `origin: "imported"` so a broken mapping cannot
  pass.
- `cargo check --workspace --all-targets`, clippy and fmt clean.
