### PR TITLE
ci: no job restores another job's cache; backup defaults to trust tasks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,16 @@ jobs:
           key: ${{ runner.os }}-cargo-check-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-check-
-            ${{ runner.os }}-cargo-
+          # Deliberately NO `${{ runner.os }}-cargo-` fallback on any job.
+          # It let a job restore a DIFFERENT job's cache, whose `target/` was
+          # built with other feature sets — so almost none of it is reusable
+          # (fingerprints differ) while all of it costs disk and download time.
+          # #891's Test failure logged the proof: `Cache restored from key:
+          # Linux-cargo-features-…`, ~3 GB of the Feature-combos tree unpacked
+          # before Test built its own, on a runner that then ran out of disk.
+          # The same shared key is what let one fat Enclave cache evict the
+          # repo's whole 10 GB allowance. Each job keeps its OWN prefix
+          # fallback, which is what actually warms a branch build from main.
 
       - run: cargo check --workspace
 
@@ -71,7 +80,13 @@ jobs:
           key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-test-
-            ${{ runner.os }}-cargo-
+
+      # The failure this guards against reports as `No space left on device`
+      # from the runner's own log writer — no failing step, no job log, just a
+      # red job that reads like a code failure. Printing the free space after
+      # the cache restore means the next occurrence says so in one line.
+      - name: Disk after cache restore
+        run: df -h /
 
       - run: cargo test --workspace
 
@@ -97,7 +112,6 @@ jobs:
           key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-clippy-
-            ${{ runner.os }}-cargo-
 
       - run: cargo clippy --workspace -- -D warnings
 
@@ -245,7 +259,6 @@ jobs:
           key: ${{ runner.os }}-cargo-features-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-features-
-            ${{ runner.os }}-cargo-
 
       - name: vta-service tee + webvh
         run: cargo check -p vta-service --no-default-features --features tee,rest,didcomm
@@ -308,7 +321,6 @@ jobs:
           key: ${{ runner.os }}-cargo-enclave-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-enclave-
-            ${{ runner.os }}-cargo-
 
       - run: cargo check -p vta-enclave --no-default-features --features rest,didcomm,vsock-store
 
@@ -343,7 +355,6 @@ jobs:
           key: ${{ runner.os }}-cargo-mobile-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-mobile-
-            ${{ runner.os }}-cargo-
 
       - name: Cross-compile (iOS + Android) and generate bindings
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6815,7 +6815,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "pnm-cli"
-version = "0.11.17"
+version = "0.11.18"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-resolver-cache-sdk",
@@ -10408,7 +10408,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.21.2"
+version = "0.21.3"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",

--- a/changelog.d/892-ci-headroom-and-backup-default.md
+++ b/changelog.d/892-ci-headroom-and-backup-default.md
@@ -1,0 +1,59 @@
+### vta-sdk 0.21.3 / pnm-cli 0.11.18 — backup defaults to the descriptor flow, and CI stops restoring other jobs' caches (#892)
+
+## CI: no job restores another job's cache
+
+`Test` failed on #891 with `No space left on device` — reported from the runner's
+*own* log writer, so there was no failing step and no job log, only a red job that
+reads exactly like a code failure. The successful rerun logged the cause:
+
+```
+Cache Size: ~2962 MB
+Cache restored from key: Linux-cargo-features-74bb9c97…
+```
+
+`Test` missed its own cache keys, fell through to the shared
+`${{ runner.os }}-cargo-` fallback, and unpacked ~3 GB of the **Feature combos**
+job's `target/` before building its own. Almost none of it is reusable —
+different feature sets mean different fingerprints — so it is pure cost: disk,
+and download time. This workspace's `target/` after a full `cargo test
+--workspace` is enormous (196 GB locally), so a job that starts by importing a
+foreign tree is the one that runs out.
+
+The shared fallback is removed from **every** job. Each keeps its own prefix
+(`Linux-cargo-test-` and friends), which is what actually warms a branch build
+from `main`; only the cross-job fallback goes. This is the same fix #884 applied
+to MSRV, now supported by a log line naming the foreign cache — and the same
+shared key that let one fat Enclave cache evict the repo's whole 10 GB
+allowance.
+
+`Test` also prints `df -h /` after the cache restore, so the next occurrence says
+so in one line instead of presenting as an unexplained failure.
+
+## Backup: the descriptor flow is the default
+
+Rollout step 5 of `docs/05-design-notes/backup-descriptor-pattern.md`, whose
+bake-in condition ("one release cycle") has been met several times over.
+`pnm backup export|import` now use the two-phase trust-task flow; the escape
+hatch is `--use-rest-legacy`, which step 6 removes along with the route it calls.
+
+**This corrects something I had wrong.** Backup was described as blocked on the
+descriptor's `chunked-trust-task` algorithm. It is not: the two-phase flow has
+been implemented, tested and CLI-exposed for some time, and only the *byte
+transfer* uses the descriptor's HTTPS URL — deliberately, so a multi-megabyte
+envelope never enters a message envelope. `chunked-trust-task` would move those
+bytes too, which is a refinement, not a prerequisite.
+
+The SDK's inline `backup_export` / `backup_import` are now `#[deprecated]`: they
+ride a legacy protocol message and therefore have no TSP dispatcher at all, which
+is the concrete reason the descriptor flow is the default rather than merely the
+newer option.
+
+## The one remaining first-party legacy send is deliberate
+
+`import_key`'s cleartext `privateKeyMultibase` carrier stays on the legacy
+DIDComm message, because that is the transport where authcrypt has already
+established end-to-end confidentiality — the canonical task refuses cleartext
+precisely because one dispatcher serves REST, DIDComm and TSP and cannot tell
+which carried a request. Sealed and JWE carriers ride the canonical task and
+reach TSP. Both legs are covered by tests, so the fork is a recorded decision
+rather than an unexamined leftover.

--- a/docs/05-design-notes/backup-descriptor-pattern.md
+++ b/docs/05-design-notes/backup-descriptor-pattern.md
@@ -462,6 +462,12 @@ once we add an `auto-relay` algorithm.
 4. Add the `pnm backup save/restore --use-trust-task` flag.
 5. After bake-in (one release cycle), flip the CLI default to
    trust-task; legacy `--use-rest-legacy` remains for emergency.
+   **Done (#892).** `--use-trust-task` is gone; the descriptor flow is
+   what `pnm backup export|import` does. The SDK's inline
+   `backup_export` / `backup_import` are deprecated — they ride a legacy
+   protocol message and so have no TSP dispatcher, which is the concrete
+   reason the descriptor flow is the default rather than merely the
+   newer option.
 6. Next release: remove the `--use-*` flags, remove the legacy
    REST routes.
 

--- a/pnm-cli/Cargo.toml
+++ b/pnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pnm-cli"
 description = "CLI Tool for managing a personal Verifiable Trust Agent"
-version = "0.11.17"
+version = "0.11.18"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/pnm-cli/src/cli.rs
+++ b/pnm-cli/src/cli.rs
@@ -609,13 +609,16 @@ pub(crate) enum BackupCommands {
         /// Output file path (default: `vta-backup-<timestamp>.vtabak`)
         #[arg(short, long)]
         output: Option<std::path::PathBuf>,
-        /// Use the new descriptor-pattern trust-task flow instead of
-        /// the legacy inline `/backup/export` REST route. Off by
-        /// default during the transition window; will flip to on by
-        /// default in a future release. See
-        /// `docs/05-design-notes/backup-descriptor-pattern.md`.
+        /// Fall back to the legacy inline `/backup/export` REST route
+        /// instead of the descriptor-pattern trust-task flow.
+        ///
+        /// The trust-task flow is the default as of rollout step 5
+        /// (`docs/05-design-notes/backup-descriptor-pattern.md`). This
+        /// escape hatch exists for an emergency where the descriptor
+        /// flow cannot complete — it is removed at step 6, along with
+        /// the legacy route itself.
         #[arg(long)]
-        use_trust_task: bool,
+        use_rest_legacy: bool,
     },
     /// Import VTA state from an encrypted backup file
     Import {
@@ -624,11 +627,11 @@ pub(crate) enum BackupCommands {
         /// Preview only — show what would be imported without applying
         #[arg(long)]
         preview: bool,
-        /// Use the new descriptor-pattern trust-task flow instead of
-        /// the legacy inline `/backup/import` REST route. Off by
-        /// default during the transition window.
+        /// Fall back to the legacy inline `/backup/import` REST route
+        /// instead of the descriptor-pattern trust-task flow. See
+        /// `Export::use_rest_legacy`; removed at rollout step 6.
         #[arg(long)]
-        use_trust_task: bool,
+        use_rest_legacy: bool,
     },
 }
 

--- a/pnm-cli/src/commands/backup.rs
+++ b/pnm-cli/src/commands/backup.rs
@@ -19,28 +19,29 @@ pub(crate) async fn run(
         BackupCommands::Export {
             include_audit,
             output,
-            use_trust_task,
+            use_rest_legacy,
         } => {
-            if use_trust_task {
-                cmd_backup_export_descriptor(client, include_audit, output).await
-            } else {
+            if use_rest_legacy {
                 cmd_backup_export(client, include_audit, output).await
+            } else {
+                cmd_backup_export_descriptor(client, include_audit, output).await
             }
         }
         BackupCommands::Import {
             file,
             preview,
-            use_trust_task,
+            use_rest_legacy,
         } => {
-            if use_trust_task {
-                cmd_backup_import_descriptor(client, file, preview).await
-            } else {
+            if use_rest_legacy {
                 cmd_backup_import(client, file, preview).await
+            } else {
+                cmd_backup_import_descriptor(client, file, preview).await
             }
         }
     }
 }
 
+#[allow(deprecated)] // the `--use-rest-legacy` escape hatch; removed at rollout step 6
 async fn cmd_backup_export(
     client: &VtaClient,
     include_audit: bool,
@@ -82,6 +83,7 @@ async fn cmd_backup_export(
     Ok(())
 }
 
+#[allow(deprecated)] // the `--use-rest-legacy` escape hatch; removed at rollout step 6
 async fn cmd_backup_import(
     client: &VtaClient,
     file: std::path::PathBuf,

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.21.2"
+version = "0.21.3"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/client/backup.rs
+++ b/vta-sdk/src/client/backup.rs
@@ -4,7 +4,20 @@ use super::VtaClient;
 use crate::error::VtaError;
 
 impl VtaClient {
-    /// Export VTA state to an encrypted backup.
+    /// Export VTA state to an encrypted backup, inline.
+    ///
+    /// **The legacy path.** The whole envelope crosses the wire in one
+    /// response, which is why this rides a protocol message rather than a Trust
+    /// Task — and why it has no TSP dispatcher. The descriptor flow
+    /// (`backup/initiate-export` + a blob fetch + `backup/complete-export`) is
+    /// the default as of rollout step 5 and works on every transport; this
+    /// remains only as the `--use-rest-legacy` escape hatch, and goes at step 6
+    /// with the route it calls.
+    #[deprecated(
+        since = "0.21.3",
+        note = "inline export rides a legacy protocol message with no TSP path — \
+                use the descriptor flow (backup/initiate-export)"
+    )]
     pub async fn backup_export(
         &self,
         password: &str,
@@ -24,7 +37,15 @@ impl VtaClient {
         .await
     }
 
-    /// Import VTA state from an encrypted backup.
+    /// Import VTA state from an encrypted backup, inline.
+    ///
+    /// The legacy counterpart of [`backup_export`](Self::backup_export); see
+    /// its note.
+    #[deprecated(
+        since = "0.21.3",
+        note = "inline import rides a legacy protocol message with no TSP path — \
+                use the descriptor flow (backup/initiate-import)"
+    )]
     pub async fn backup_import(
         &self,
         backup: &crate::protocols::backup_management::types::BackupEnvelope,


### PR DESCRIPTION
Two defaults that were quietly costing us.

## CI: no job restores another job's cache

`Test` failed on #891 with `No space left on device`, reported from the runner's
**own log writer** — so there was no failing step and no job log, only a red job
that reads exactly like a code failure. The successful rerun logged the cause:

```
Cache Size: ~2962 MB
Cache restored from key: Linux-cargo-features-74bb9c97…
```

`Test` missed its own cache keys, fell through to the shared
`${{ runner.os }}-cargo-` fallback, and unpacked ~3 GB of the **Feature combos**
job's `target/` before building its own. Different feature sets mean different
fingerprints, so almost none of it is reusable — pure disk and download cost, on
the one job that links the entire workspace. This tree's `target/` after `cargo
test --workspace` is enormous (196 GB locally), so the job that starts by
importing a foreign one is the job that runs out.

Removed from **every** job. Each keeps its own prefix fallback
(`Linux-cargo-test-` and friends), which is what actually warms a branch build
from `main`; only the cross-job fallback goes. This is the fix #884 applied to
MSRV, now with a log line naming the foreign cache — and the same shared key that
let one fat Enclave cache evict the repo's whole 10 GB allowance.

`Test` also prints `df -h /` after the cache restore, so the next occurrence says
so in one line rather than presenting as an unexplained red job.

## Backup: the descriptor flow is the default

Rollout **step 5** of `docs/05-design-notes/backup-descriptor-pattern.md`, whose
bake-in condition ("one release cycle") has been met several times over. `pnm
backup export|import` now use the two-phase trust-task flow; `--use-rest-legacy`
is the emergency hatch that step 6 removes along with the route it calls.

**This corrects something I had wrong.** I described backup as blocked on the
descriptor's `chunked-trust-task` algorithm. It isn't: the two-phase flow has been
implemented, tested and CLI-exposed for releases. Only the *byte transfer* uses
the descriptor's HTTPS URL — deliberately, so a multi-megabyte envelope never
enters a message envelope. `chunked-trust-task` would move those bytes too, which
is a refinement, not a prerequisite.

The SDK's inline `backup_export` / `backup_import` are now `#[deprecated]`: they
ride a legacy protocol message and therefore have **no TSP dispatcher at all**,
which is the concrete reason the descriptor flow is the default rather than
merely the newer option. The two `--use-rest-legacy` call sites carry
`#[allow(deprecated)]` so the escape hatch stays compilable without hiding future
accidental uses.

## One first-party legacy send remains, deliberately

`import_key`'s cleartext `privateKeyMultibase` carrier stays on the legacy DIDComm
message, because that is where authcrypt has already established end-to-end
confidentiality — the canonical task refuses cleartext precisely because one
dispatcher serves REST, DIDComm and TSP and cannot tell which carried a request.
Sealed and JWE carriers ride the canonical task and reach TSP. Both legs are
covered by tests, so this is a recorded decision rather than an unexamined
leftover.

## Testing

`cargo test --workspace --no-fail-fast`: **4153 passed, 0 failed**. Clippy and fmt
clean (the `vti-common` dead-field warning is pre-existing on `main`). The CLI
help was checked by hand — `--use-trust-task` is gone and `--use-rest-legacy`
documents its own removal date.
