### PR TITLE
feat(keys): import is canonical on every transport; the spine knows its own

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10408,7 +10408,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.21.3"
+version = "0.21.4"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10470,7 +10470,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.14.3"
+version = "0.14.4"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/changelog.d/893-import-canonical-every-transport.md
+++ b/changelog.d/893-import-canonical-every-transport.md
@@ -1,0 +1,67 @@
+### vta-sdk 0.21.4 / vta-service 0.14.4 — `keys/import` is canonical on every transport, because the dispatcher now knows its own transport (#893)
+
+The last first-party legacy send is gone. `import_key` sends canonical
+`keys/import/0.1` for **every** carrier, on REST, DIDComm and TSP alike.
+
+## The path this replaces was dead, not deliberate
+
+The cleartext `privateKeyMultibase` carrier forked onto the legacy
+`key-management/1.0/import-key` message, justified as preserving a capability on
+the transport where authcrypt makes cleartext safe. **The VTA has never routed
+that type** — it is absent from `messaging/router.rs` — so the call failed with
+`unsupported message type` over DIDComm, and REST refuses the field outright.
+Multibase import worked nowhere. The fork preserved nothing; it was asserted from
+the client side without checking the router.
+
+## The rule was always right; the VTA could not evaluate it
+
+The published spec says a custodian must refuse cleartext *"unless the transport
+provides end-to-end confidentiality"*. One spine serves the Trust-Task surface
+over REST, DIDComm and TSP and discarded the transport before any handler ran, so
+the only safe reading was a blanket refusal — over-refusing on precisely the two
+transports where cleartext is safe.
+
+`vta-service/src/trust_tasks/transport.rs` records what the transport
+guarantees, set at the three entry points that know it:
+
+| transport | guarantee | why |
+|---|---|---|
+| DIDComm | end-to-end | authcrypt seals to this VTA's key; the mediator never holds plaintext |
+| TSP | end-to-end | seals to the recipient VID |
+| REST | hop-by-hop | TLS terminates wherever the operator terminates it — a load balancer, an ingress — and the plaintext exists there |
+
+`keys/import` then applies the specification's actual rule.
+
+## Two decisions worth reviewing
+
+**A task-local, not a handler parameter.** The dispatch table has 157 entries
+sharing one signature. Threading a parameter through all of them to serve one
+handler would be a large mechanical diff that buries the single call site that
+matters. It is set in exactly one place (`dispatch_trust_task_core`) and read in
+exactly one (`keys::handle_import`).
+
+**The default is the restrictive one.** Outside a dispatch scope,
+`transport::current()` reports hop-by-hop. A future entry point that dispatches
+without establishing the scope therefore refuses cleartext rather than accepting
+it: a wiring mistake costs a working import, not a leaked key. That direction is
+pinned by a unit test.
+
+## Testing
+
+- `keys_import_trust_task_refuses_cleartext_over_rest` posts the task to
+  `/api/trust-tasks` and asserts both the refusal and its reason.
+  **Verified by mutation**: with the gate disabled the request proceeds past it
+  and the assertion fails, so the test pins the gate rather than passing
+  incidentally.
+- `multibase_import_key_via_didcomm_uses_the_canonical_task` pins the accepting
+  side, with a fixture carrying `origin: "imported"` so a broken mapping cannot
+  pass.
+- The scope's default and non-leakage are unit-tested in `transport.rs`.
+
+## Where the legacy surface stands
+
+No first-party call sends a legacy protocol message on any default path. What
+remains on `rpc` is deprecated and reachable only by explicit opt-in: the inline
+`backup_export`/`backup_import` behind `--use-rest-legacy` (removed at rollout
+step 6), and the `(context_id, scid)` webvh update pair, which has no first-party
+caller at all.

--- a/tests/e2e/tests/client_didcomm.rs
+++ b/tests/e2e/tests/client_didcomm.rs
@@ -17,8 +17,8 @@
 //!   `{ id, type, payload }`, so the responder must dispatch on the *inner*
 //!   `type` URI (a `vta_sdk::trust_tasks::TASK_*` constant) — see [`is_tt`]
 //!   / [`tt_ok`].
-//! - **Legacy protocol message**: the surfaces still on `rpc` (`import_key`,
-//!   `backup_export`/`backup_import`, the webvh server/DID updates) dispatch
+//! - **Legacy protocol message**: what remains on `rpc` — the deprecated
+//!   `backup_export`/`backup_import` and webvh server/DID updates — dispatch
 //!   on the `*_management` message-type constant. The ACL reads and updates
 //!   left behind by #861 moved to Trust Tasks in #884 — they were the ones
 //!   where the maintainer had already folded and the client had not.
@@ -29,8 +29,8 @@ use vta_sdk::client::*;
 use vta_sdk::did_key::ed25519_multibase_pubkey;
 use vta_sdk::error::VtaError;
 use vta_sdk::keys::{KeyOrigin, KeyStatus, KeyType};
+use vta_sdk::protocols::backup_management;
 use vta_sdk::protocols::key_management::sign::SignAlgorithm;
-use vta_sdk::protocols::{backup_management, key_management};
 use vta_sdk::trust_tasks;
 
 mod common;
@@ -144,6 +144,15 @@ fn key_record_json(id: &str) -> Value {
 /// The `{ key }` envelope canonical single-record responses carry.
 fn key_envelope(id: &str) -> Value {
     json!({ "key": key_record_json(id) })
+}
+
+/// The same envelope for a key that arrived from outside. `origin` is what
+/// tells an operator a seed restore will not bring this one back, so a fixture
+/// that always said `derived` would let a broken mapping pass.
+fn imported_key_envelope(id: &str) -> Value {
+    let mut record = key_record_json(id);
+    record["origin"] = json!("imported");
+    json!({ "key": record })
 }
 
 fn context_json(id: &str) -> Value {
@@ -425,24 +434,23 @@ async fn sealed_import_key_via_didcomm_uses_the_canonical_task() {
     shutdown_all(client, responder, mediator).await;
 }
 
-/// A raw multibase key stays on the legacy DIDComm message, where authcrypt
-/// has established the end-to-end confidentiality the canonical task cannot
-/// assume.
+/// The cleartext multibase carrier now rides the **canonical** task over
+/// DIDComm, where authcrypt has sealed the envelope to the VTA's own key.
+///
+/// It used to fork onto `key-management/1.0/import-key`, which the VTA has
+/// never routed — so this path failed with `unsupported message type` and the
+/// capability existed only on paper.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn import_key_via_didcomm() {
-    let (mediator, responder, client) = build_didcomm(|msg_type, _body| {
-        if msg_type == key_management::IMPORT_KEY {
-            ResponderReply::ok(
-                key_management::IMPORT_KEY_RESULT,
-                json!({
-                    "key_id": "imported",
-                    "key_type": "ed25519",
-                    "public_key": "z6Mkpub",
-                    "status": "active",
-                    "label": null,
-                    "origin": "imported",
-                    "created_at": "2026-01-01T00:00:00Z"
-                }),
+async fn multibase_import_key_via_didcomm_uses_the_canonical_task() {
+    let (mediator, responder, client) = build_didcomm(|msg_type, body| {
+        if is_tt(msg_type, body, trust_tasks::TASK_KEYS_IMPORT_0_1) {
+            assert_eq!(
+                body["payload"]["privateKeyMultibase"], "zSeed",
+                "the cleartext carrier must reach the canonical task: {body}"
+            );
+            tt_ok(
+                trust_tasks::TASK_KEYS_IMPORT_0_1,
+                imported_key_envelope("imported"),
             )
         } else {
             no_handler()

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.21.3"
+version = "0.21.4"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/client/keys.rs
+++ b/vta-sdk/src/client/keys.rs
@@ -14,9 +14,6 @@ use crate::protocols::key_management::sign::SignAlgorithm;
 use crate::trust_tasks;
 
 #[cfg(feature = "client")]
-use crate::protocols::key_management;
-
-#[cfg(feature = "client")]
 impl VtaClient {
     // ── Key methods ─────────────────────────────────────────────────
 
@@ -61,29 +58,24 @@ impl VtaClient {
 
     /// Import an externally-created private key.
     ///
-    /// A **sealed** or **JWE** carrier rides canonical `keys/import/0.1`, so it
-    /// works over REST, DIDComm and TSP alike. A raw `private_key_multibase`
-    /// stays on the legacy DIDComm message: the canonical task refuses
-    /// cleartext, because one dispatcher serves all three transports and cannot
-    /// establish that a given request travelled end to end — authcrypt can, and
-    /// that is exactly what the legacy path has.
+    /// Canonical `keys/import/0.1` on **every** transport. The carrier is a
+    /// confidentiality decision the VTA enforces rather than a formatting one:
+    /// `private_key_sealed` and `private_key_jwe` encrypt to the VTA and are
+    /// accepted anywhere, while the cleartext `private_key_multibase` is
+    /// accepted only where the transport is confidential end-to-end — DIDComm
+    /// and TSP — and refused over REST, whose TLS terminates wherever the
+    /// operator terminates it.
+    ///
+    /// The multibase carrier used to fork onto the legacy
+    /// `key-management/1.0/import-key` message here. That was dead: the VTA has
+    /// never routed that type, so the call failed with `unsupported message
+    /// type` on DIDComm and was refused outright on REST. It works now.
     pub async fn import_key(&self, req: ImportKeyRequest) -> Result<ImportKeyResponse, VtaError> {
-        if req.private_key_multibase.is_some() {
-            return self
-                .rpc(
-                    key_management::IMPORT_KEY,
-                    serde_json::to_value(&req)?,
-                    key_management::IMPORT_KEY_RESULT,
-                    30,
-                    |c, url| c.post(format!("{url}/keys/import")).json(&req),
-                )
-                .await;
-        }
         let body = crate::protocols::key_management::import::ImportKeyBody {
             key_type: req.key_type.clone(),
             private_key_sealed: req.private_key_sealed.clone(),
             private_key_jwe: req.private_key_jwe.clone(),
-            private_key_multibase: None,
+            private_key_multibase: req.private_key_multibase.clone(),
             label: req.label.clone(),
             context_id: req.context_id.clone(),
         };

--- a/vta-sdk/tests/client_rest.rs
+++ b/vta-sdk/tests/client_rest.rs
@@ -275,6 +275,7 @@ async fn update_config_reports_identity_as_rejected() {
 
 // ── Backup ──────────────────────────────────────────────────────────
 
+#[allow(deprecated)] // pins the inline path until rollout step 6 removes it
 #[tokio::test]
 async fn backup_export_returns_envelope() {
     let server = MockServer::start().await;
@@ -295,6 +296,7 @@ async fn backup_export_returns_envelope() {
     assert!(!env.includes_audit);
 }
 
+#[allow(deprecated)] // pins the inline path until rollout step 6 removes it
 #[tokio::test]
 async fn backup_export_403_maps_to_forbidden() {
     let server = MockServer::start().await;

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.14.3"
+version = "0.14.4"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/messaging/handlers.rs
+++ b/vta-service/src/messaging/handlers.rs
@@ -282,17 +282,26 @@ pub async fn handle_trust_task(
     // failure (e.g. the peer has no ACL entry) reply with a Trust-Task
     // `permission_denied` *envelope*, not a DIDComm problem-report — a
     // conformant Trust-Task client only understands binding envelopes.
-    let response = match auth_from_message(&message, &app_state.acl_ks, &app_state.sessions_ks)
-        .await
-    {
-        Ok(auth) => crate::trust_tasks::dispatch_trust_task_core(&app_state, &auth, &body).await,
-        Err(e) => crate::trust_tasks::reject_trust_task(
-            &body,
-            trust_tasks_rs::RejectReason::PermissionDenied {
-                reason: e.to_string(),
-            },
-        ),
-    };
+    let response =
+        match auth_from_message(&message, &app_state.acl_ks, &app_state.sessions_ks).await {
+            // Authcrypt sealed this envelope to the VTA's own key, so no
+            // intermediary — mediator included — held the plaintext.
+            Ok(auth) => {
+                crate::trust_tasks::dispatch_trust_task_core(
+                    &app_state,
+                    &auth,
+                    &body,
+                    crate::trust_tasks::transport::TransportConfidentiality::EndToEnd,
+                )
+                .await
+            }
+            Err(e) => crate::trust_tasks::reject_trust_task(
+                &body,
+                trust_tasks_rs::RejectReason::PermissionDenied {
+                    reason: e.to_string(),
+                },
+            ),
+        };
 
     // The dispatch core returns a typed `TrustTaskOutcome`; its `body` is
     // already the serialised framework trust-task document, so we parse it

--- a/vta-service/src/messaging/tsp_inbound.rs
+++ b/vta-service/src/messaging/tsp_inbound.rs
@@ -58,7 +58,16 @@ pub async fn dispatch_one(app_state: &AppState, payload: &[u8], sender_vid: &str
     app_state.tsp_reach.record(sender_vid);
     tracing::debug!(sender = %sender_vid, "recorded TSP reachability (learn-from-inbound)");
     let outcome = match auth_from_did(sender_vid, &app_state.acl_ks, &app_state.sessions_ks).await {
-        Ok(auth) => crate::trust_tasks::dispatch_trust_task_core(app_state, &auth, payload).await,
+        // TSP seals to the recipient VID, same guarantee as authcrypt.
+        Ok(auth) => {
+            crate::trust_tasks::dispatch_trust_task_core(
+                app_state,
+                &auth,
+                payload,
+                crate::trust_tasks::transport::TransportConfidentiality::EndToEnd,
+            )
+            .await
+        }
         Err(e) => crate::trust_tasks::reject_trust_task(
             payload,
             trust_tasks_rs::RejectReason::PermissionDenied {

--- a/vta-service/src/trust_tasks/keys.rs
+++ b/vta-service/src/trust_tasks/keys.rs
@@ -307,13 +307,16 @@ pub(super) async fn handle_derive_and_sign_document(
 
 /// Handler for `keys/import/0.1`. Admin only.
 ///
-/// **The cleartext `privateKeyMultibase` carrier is refused here, always.** The
-/// specification admits it only where the transport is end-to-end confidential,
-/// and one dispatcher serves this task over REST, DIDComm and TSP — so a handler
-/// at this layer cannot tell which carried the request. Refusing is the reading
-/// that cannot leak a key; the legacy `key-management/1.0/import-key` DIDComm
-/// message still accepts multibase, where authcrypt has already established the
-/// guarantee.
+/// **The cleartext `privateKeyMultibase` carrier is admitted only where the
+/// transport established confidentiality end-to-end** — DIDComm authcrypt and
+/// TSP, which seal to this VTA's own key. Over REST it is refused: TLS
+/// terminates wherever the operator terminates it, and the plaintext exists
+/// there.
+///
+/// This is the specification's own rule ("only where the transport is
+/// end-to-end confidential") rather than the blanket refusal that stood in for
+/// it while the spine discarded the transport before handlers ran. See
+/// [`crate::trust_tasks::transport`].
 pub(super) async fn handle_import(
     state: &AppState,
     auth: &AuthClaims,
@@ -327,11 +330,18 @@ pub(super) async fn handle_import(
         Err(resp) => return resp,
     };
 
-    if req.private_key_multibase.is_some() {
+    if req.private_key_multibase.is_some()
+        && crate::trust_tasks::transport::current()
+            != crate::trust_tasks::transport::TransportConfidentiality::EndToEnd
+    {
         return reject_with(
             &doc,
             RejectReason::MalformedRequest {
-                reason: "keys/import: the cleartext `privateKeyMultibase` carrier is not                          accepted on the trust-task surface, which is served over REST as well                          as DIDComm and TSP and cannot establish that this request travelled                          end to end. Seal the key to this VTA and send `privateKeySealed`."
+                reason: "keys/import: the cleartext `privateKeyMultibase` carrier needs a \
+                         transport that is confidential end to end, and this request did not \
+                         arrive on one — TLS terminates wherever the operator terminates it, so \
+                         the key would exist in plaintext there. Seal the key to this VTA and \
+                         send `privateKeySealed`, or send it over DIDComm or TSP."
                     .to_string(),
             },
         );
@@ -361,11 +371,42 @@ pub(super) async fn handle_import(
             Ok(bytes) => bytes,
             Err(e) => return app_error_to_reject(&doc, e),
         }
+    } else if let Some(mb) = req.private_key_multibase.as_deref() {
+        // Only reachable on an end-to-end-confidential transport — the gate
+        // above refused it otherwise. The key arrives multicodec-prefixed
+        // (ed25519-priv `0x8026`); strip the prefix so the operation receives
+        // the raw private key, exactly as the sealed and JWE carriers deliver.
+        match multibase::decode(mb) {
+            Ok((_, decoded)) => match decoded.len() {
+                34 => decoded[2..].to_vec(),
+                32 => decoded,
+                other => {
+                    return reject_with(
+                        &doc,
+                        RejectReason::MalformedRequest {
+                            reason: format!(
+                                "keys/import: `privateKeyMultibase` decoded to {other} bytes; \
+                                 expected 32 raw or 34 multicodec-prefixed"
+                            ),
+                        },
+                    );
+                }
+            },
+            Err(e) => {
+                return reject_with(
+                    &doc,
+                    RejectReason::MalformedRequest {
+                        reason: format!("keys/import: `privateKeyMultibase` is not multibase: {e}"),
+                    },
+                );
+            }
+        }
     } else {
         return reject_with(
             &doc,
             RejectReason::MalformedRequest {
-                reason: "keys/import: one of `privateKeySealed` or `privateKeyJwe` is required"
+                reason: "keys/import: one of `privateKeySealed`, `privateKeyJwe` or \
+                         `privateKeyMultibase` is required"
                     .to_string(),
             },
         );

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -74,6 +74,7 @@ mod provision_integration;
 mod replay;
 mod seeds;
 mod task_consent;
+pub(crate) mod transport;
 // `pub(crate)` so the REST routes (`routes::acl`, `routes::contexts`) can
 // reach the `RequireStepUp` extractor + op markers. The step-up *engine* lives
 // in `operations::step_up` (P2.4); this module holds only the transport
@@ -387,9 +388,16 @@ pub async fn dispatch_trust_task(
     State(state): State<AppState>,
     body: axum::body::Bytes,
 ) -> Result<Response, AppError> {
-    Ok(dispatch_trust_task_core(&state, &auth, &body)
-        .await
-        .into_response())
+    // REST is hop-by-hop by construction: TLS terminates at whatever the
+    // operator put in front of this process, and the plaintext exists there.
+    Ok(dispatch_trust_task_core(
+        &state,
+        &auth,
+        &body,
+        transport::TransportConfidentiality::HopByHop,
+    )
+    .await
+    .into_response())
 }
 
 /// Transport-agnostic trust-task dispatch core.
@@ -457,6 +465,22 @@ async fn validate_payload(
 }
 
 pub(crate) async fn dispatch_trust_task_core(
+    state: &AppState,
+    auth: &AuthClaims,
+    body: &[u8],
+    confidentiality: transport::TransportConfidentiality,
+) -> TrustTaskOutcome {
+    transport::with_confidentiality(confidentiality, async move {
+        dispatch_trust_task_inner(state, auth, body).await
+    })
+    .await
+}
+
+/// The dispatch spine proper. Split from [`dispatch_trust_task_core`] only so
+/// the transport scope wraps every path out of it, including the early
+/// rejections — a handler that reads the transport must never see a scope that
+/// was skipped because the envelope failed validation first.
+async fn dispatch_trust_task_inner(
     state: &AppState,
     auth: &AuthClaims,
     body: &[u8],

--- a/vta-service/src/trust_tasks/transport.rs
+++ b/vta-service/src/trust_tasks/transport.rs
@@ -1,0 +1,84 @@
+//! What the transport that carried a Trust Task guarantees about
+//! confidentiality — and how a handler asks.
+//!
+//! One dispatcher serves the Trust-Task surface over REST, DIDComm and TSP.
+//! That is the point of the spine, but it means a handler cannot tell how a
+//! request reached it, and a few tasks genuinely need to know: `keys/import`
+//! admits a **cleartext** private-key carrier, and its specification permits
+//! that "only where the transport is end-to-end confidential". Without this,
+//! the handler's only safe reading was to refuse cleartext on every transport
+//! — over-refusing on exactly the transports where it is safe.
+//!
+//! # Why a task-local rather than a handler parameter
+//!
+//! The dispatch table has 157 entries sharing one handler signature. Threading
+//! a parameter through all of them to serve one handler would be a large,
+//! noisy change whose diff obscures the one call site that matters. This is set
+//! in exactly one place ([`crate::trust_tasks::dispatch_trust_task_core`]) and
+//! read in exactly one ([`crate::trust_tasks::keys::handle_import`]).
+//!
+//! # The default is the restrictive one, deliberately
+//!
+//! [`current`] returns [`TransportConfidentiality::HopByHop`] when nothing has
+//! been set. A future entry point that dispatches without establishing the
+//! scope therefore **refuses** cleartext rather than accepting it: a wiring
+//! mistake costs a working import, not a leaked key.
+
+/// Whether the transport established confidentiality end-to-end between the
+/// producer and this consumer, or only hop-by-hop.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum TransportConfidentiality {
+    /// The producer encrypted to *this* consumer, so no intermediary — and no
+    /// terminating proxy — ever held the plaintext. DIDComm authcrypt and TSP
+    /// both provide this.
+    EndToEnd,
+    /// Confidential in transit at best. TLS qualifies, but it terminates
+    /// wherever the operator terminates it: a load balancer, an ingress, a
+    /// sidecar. The plaintext exists there, so a secret-bearing member must not
+    /// travel this way.
+    HopByHop,
+}
+
+tokio::task_local! {
+    static CONFIDENTIALITY: TransportConfidentiality;
+}
+
+/// Run `f` with the transport's confidentiality recorded for its duration.
+pub(crate) async fn with_confidentiality<F, T>(level: TransportConfidentiality, f: F) -> T
+where
+    F: std::future::Future<Output = T>,
+{
+    CONFIDENTIALITY.scope(level, f).await
+}
+
+/// What the transport carrying the current Trust Task guarantees.
+///
+/// Falls back to [`TransportConfidentiality::HopByHop`] outside a dispatch
+/// scope — see the module docs on why the default is the restrictive one.
+pub(crate) fn current() -> TransportConfidentiality {
+    CONFIDENTIALITY
+        .try_with(|c| *c)
+        .unwrap_or(TransportConfidentiality::HopByHop)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The whole safety argument rests on this: an unset scope must read as
+    /// hop-by-hop, so a dispatch path someone forgets to wire refuses a
+    /// cleartext key instead of forwarding one.
+    #[test]
+    fn defaults_to_hop_by_hop_outside_a_scope() {
+        assert_eq!(current(), TransportConfidentiality::HopByHop);
+    }
+
+    #[tokio::test]
+    async fn reports_what_the_scope_set() {
+        let seen =
+            with_confidentiality(TransportConfidentiality::EndToEnd, async { current() }).await;
+        assert_eq!(seen, TransportConfidentiality::EndToEnd);
+        // And the scope does not leak past its future.
+        assert_eq!(current(), TransportConfidentiality::HopByHop);
+    }
+}

--- a/vta-service/tests/api_integration.rs
+++ b/vta-service/tests/api_integration.rs
@@ -2153,6 +2153,47 @@ async fn create_did_webvh_set_primary_true() {
 /// channel). `#[serde(deny_unknown_fields)]` is the load-bearing
 /// mechanism — operators get a specific "unknown field" error
 /// pointing them at the sealed-transfer migration path.
+/// REST is hop-by-hop — TLS terminates wherever the operator terminates it —
+/// so the canonical task must refuse the cleartext carrier here even though it
+/// accepts it over DIDComm and TSP.
+///
+/// This is the whole security property of making the dispatcher
+/// transport-aware. If the spine ever stops establishing the transport scope,
+/// `transport::current()` falls back to hop-by-hop and this test still passes;
+/// if it were to fall back the other way, this test is what fails.
+#[tokio::test]
+async fn keys_import_trust_task_refuses_cleartext_over_rest() {
+    let (app, ctx) = TestApp::new().await;
+    let token = ctx
+        .auth_token("did:key:z6MkSuperAdmin", "admin", vec![])
+        .await;
+
+    let (status, body) = app
+        .request(post_auth(
+            "/api/trust-tasks",
+            &token,
+            json!({
+                "id": "urn:uuid:6f1b2c3d-4e5f-4061-8293-a4b5c6d7e8f9",
+                "type": "https://trusttasks.org/spec/keys/import/0.1",
+                "payload": {
+                    "keyType": "ed25519",
+                    "privateKeyMultibase": "z6MkDeadbeefDeadbeefDeadbeef",
+                },
+            }),
+        ))
+        .await;
+
+    let rendered = body.to_string();
+    assert!(
+        !status.is_success(),
+        "cleartext key over REST must be refused, got {status} {rendered}"
+    );
+    assert!(
+        rendered.contains("confidential end to end"),
+        "the refusal must say why, so an operator can act on it: {rendered}"
+    );
+}
+
 #[tokio::test]
 async fn keys_import_rejects_private_key_multibase_over_rest() {
     let (app, ctx) = TestApp::new().await;


### PR DESCRIPTION
`import_key` now sends canonical `keys/import/0.1` for **every** carrier, on
REST, DIDComm and TSP alike. That is the last first-party legacy send.

## The path this replaces was dead, not deliberate

The cleartext `privateKeyMultibase` carrier forked onto the legacy
`key-management/1.0/import-key` message. I justified that as preserving a
capability on the transport where authcrypt makes cleartext safe.

**The VTA has never routed that type.** It is absent from
`messaging/router.rs`, so the call failed with `unsupported message type` over
DIDComm — and REST refuses the field outright. Multibase import worked nowhere.
The fork preserved nothing; I asserted it from the client side without checking
the router.

## The rule was always right; the VTA could not evaluate it

The published spec says a custodian must refuse cleartext *"unless the transport
provides end-to-end confidentiality"*. One spine serves the Trust-Task surface
over REST, DIDComm and TSP and discarded which one carried a request before any
handler ran — so a blanket refusal was the only safe reading, over-refusing on
precisely the two transports where cleartext is safe.

`vta-service/src/trust_tasks/transport.rs` records the guarantee, set at the
three entry points that know it:

| transport | guarantee | why |
|---|---|---|
| DIDComm | end-to-end | authcrypt seals to this VTA's key; the mediator never holds plaintext |
| TSP | end-to-end | seals to the recipient VID |
| REST | hop-by-hop | TLS terminates wherever the operator terminates it — load balancer, ingress — and the plaintext exists there |

`keys/import` then applies the specification's actual rule.

## Two decisions worth review

**A task-local, not a handler parameter.** The dispatch table has 157 entries
sharing one signature. Threading a parameter through all of them to serve one
handler would be a large mechanical diff that buries the single call site that
matters. Set in exactly one place (`dispatch_trust_task_core`), read in exactly
one (`keys::handle_import`).

**The default is the restrictive one.** Outside a dispatch scope,
`transport::current()` reports hop-by-hop — so a future entry point that
dispatches without establishing the scope refuses cleartext rather than accepting
it. A wiring mistake costs a working import, not a leaked key. Unit-tested in
that direction.

## Testing

- `keys_import_trust_task_refuses_cleartext_over_rest` posts the task to
  `/api/trust-tasks` and asserts the refusal *and its reason*. **Verified by
  mutation**: with the gate disabled the request proceeds past it and the
  assertion fails, so the test pins the gate rather than passing incidentally.
- `multibase_import_key_via_didcomm_uses_the_canonical_task` pins the accepting
  side, with a fixture carrying `origin: "imported"` so a broken mapping cannot
  pass.
- The scope's default and non-leakage are unit-tested in `transport.rs`.
- Full workspace: **4156 passed, 0 failed**. Clippy and fmt clean.

## Where the legacy surface stands

No first-party call sends a legacy protocol message on any default path. What
remains on `rpc` is deprecated and reachable only by explicit opt-in: the inline
`backup_export`/`backup_import` behind `--use-rest-legacy` (removed at rollout
step 6), and the `(context_id, scid)` webvh update pair, which has no first-party
caller at all.

The 57 legacy DIDComm types the VTA still *serves* are untouched — deleting those
is Phase 6 in the migration runbook, a coordinated release with operator notice.
