### PR TITLE
fix(webvh): an unpublished local head no longer wedges every future update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10470,7 +10470,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.14.4"
+version = "0.14.5"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/changelog.d/894-unpublished-head-no-longer-wedges-updates.md
+++ b/changelog.d/894-unpublished-head-no-longer-wedges-updates.md
@@ -1,0 +1,82 @@
+### vta-service 0.14.5 — an unpublished local head no longer wedges every future update (#894)
+
+A `did:webvh` DID could reach a state where **every** update failed, permanently,
+with `concurrent update: … has been updated since you read it`. Observed in
+production on `webvh.storm.ws`: an agent-name bind published a version the host
+never received, and from then on the admin UI could neither show the new version
+nor bind the name, retry after retry.
+
+Two independent defects, one of which was hiding the other.
+
+## 1. The reconciler sat below the check that made it necessary
+
+`run_update` does its optimistic-concurrency check (step 4a) *before* the
+reconciler that heals a failed publish (step 4b). Those two steps disagree about
+what the caller's `expectedVersionId` means.
+
+The caller reads that version from the **host**. 4a compares it against the
+VTA's **local** log head. Those are the same value right up until a publish
+fails — at which point the local head advances and the host does not, and the
+comparison starts calling the caller stale for correctly reading the only thing
+it can see.
+
+Refusing there is what makes the state permanent. Step 4b exists precisely to
+re-publish an unconfirmed local head, and its own comment says so: *"That is
+what makes a failed attempt self-recover instead of wedging the DID."* It never
+ran, because 4a returned first. Every retry died in the same place.
+
+The consent flow makes it worse. There the refusal is raised by the **Plan**
+dry-run, and 4b is `Mode::Execute`-only by design — a plan must not mutate. So a
+delegated update could not self-heal even in principle: the task never got far
+enough to try.
+
+4a now consults `get_published_version` before declaring a conflict. If the
+caller matches the last version we *confirmed* on the host, the caller is not
+stale — we are — so the update proceeds and 4b reconciles. This grants no new
+authority: the unpublished head was already signed under a prior authorization,
+so it resumes an interrupted publish rather than smuggling in an unapproved
+change.
+
+The precondition is unchanged where it earns its keep. `None` (never confirmed)
+still conflicts, because nothing proves the caller read anything real, and
+serverless DIDs never set the marker — with no host, the local head is the only
+truth and a mismatch really is a stale caller. `a_stale_caller_still_conflicts`
+pins that.
+
+## 2. REST silently dropped the precondition entirely
+
+`update_did_handler` deserialised the request body straight into the op-layer
+`UpdateDidWebvhOptions`. That struct is snake_case with no aliases; the wire body
+`UpdateDidWebvhBody` is `rename_all = "camelCase"`. A caller sending
+`expectedVersionId` — every SDK caller — matched no field, and with no
+`deny_unknown_fields` nothing rejected it. It defaulted to `None`: **the
+optimistic-concurrency precondition never applied to any REST update.**
+
+This is the same defect `the_concurrency_precondition_is_read_from_the_wire`
+was written to pin. That test fixed the SDK type; the REST route kept its own
+shortcut and stayed broken. The doc comment on `UpdateDidWebvhOptions` already
+said route handlers "deserialise the SDK body and convert to this struct at
+intake" — the route simply wasn't doing it.
+
+It now takes `UpdateDidWebvhBody` and converts via the same
+`update_body_to_options` the trust-task dispatcher uses. One conversion, so the
+two paths cannot drift.
+
+A silently-ignored safety precondition is worse than an absent one: it reads, in
+the caller's source, as though the lost update were handled. Per R3.6, a request
+contract includes what you ignore.
+
+## Testing
+
+- `a_caller_pinned_to_the_host_version_recovers_a_failed_publish` reproduces the
+  production wedge: land an update, fail the next publish, then re-submit pinned
+  to the host's version the way the admin UI does. **Verified by mutation** —
+  reverting the 4a change fails it with the exact `concurrent update` error.
+- `a_stale_caller_still_conflicts` pins the other side, so the fix cannot
+  quietly become "the precondition was deleted".
+- The pre-existing `a_failed_publish_does_not_wedge_the_did_and_the_next_update_recovers`
+  passed throughout — it sends no `expectedVersionId`, which is exactly why the
+  wedge survived it. That gap is now covered.
+
+Note that defect 2 was masking defect 1 in the test suite: until REST forwarded
+the field, no integration test could reach 4a at all.

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.14.4"
+version = "0.14.5"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/operations/did_webvh/update/orchestrator.rs
+++ b/vta-service/src/operations/did_webvh/update/orchestrator.rs
@@ -575,14 +575,59 @@ async fn run_update(
     //     `log_entry_count` check at the end does NOT — that one only
     //     covers two server calls racing each other; this one covers
     //     a client call that was authored against a stale view.
+    //
+    //     `expected` and `latest` are NOT the same source of truth, and the
+    //     difference decides whether a mismatch is the caller's fault. The
+    //     caller read `expected` from the **host**; `latest` is **our local**
+    //     head. They diverge in two opposite situations:
+    //
+    //       - the host moved on under the caller — a genuine lost update; or
+    //       - we hold a local head we never managed to publish, so the caller
+    //         is reading the host perfectly correctly and *we* are the one out
+    //         of step.
+    //
+    //     `get_published_version` tells them apart. Treating the second case
+    //     as a conflict is what wedges a DID permanently: step 4b — the
+    //     reconciler written to heal exactly this divergence — sits *below*
+    //     this check, so refusing here means it never runs, and every retry
+    //     dies in the same place. That is the unrecoverable loop 4b's own
+    //     comment warns about, reached from the other side. It bites hardest
+    //     through the consent flow, where the failure is raised by the Plan
+    //     dry-run: 4b is Execute-only by design, so a plan cannot self-heal
+    //     and the task never gets far enough to try.
     if let Some(expected) = opts.expected_version_id.as_deref() {
         let latest = last_state.get_version_id();
         if latest != expected {
-            return Err(UpdateDidWebvhError::Conflict(format!(
-                "DID {} has been updated since you read it (expected versionId `{expected}`, \
-                 current is `{latest}`). Re-fetch the document and re-apply your edits.",
-                record.did
-            )));
+            let confirmed = webvh_store::get_published_version(webvh_ks, &record.did)
+                .await
+                .map_err(|e| {
+                    UpdateDidWebvhError::Persistence(format!("get_published_version: {e}"))
+                })?;
+            // Only when the caller is in step with the last version we
+            // *confirmed* on the host. `None` (never confirmed) keeps the
+            // conflict: we cannot show the caller was reading anything real.
+            // Serverless DIDs never set the marker, so they stay strict — with
+            // no host, the local head is the only truth and a mismatch really
+            // is a stale caller.
+            if confirmed.as_deref() != Some(expected) {
+                return Err(UpdateDidWebvhError::Conflict(format!(
+                    "DID {} has been updated since you read it (expected versionId `{expected}`, \
+                     current is `{latest}`). Re-fetch the document and re-apply your edits.",
+                    record.did
+                )));
+            }
+            // Proceed against the local head. In Execute mode 4b republishes it
+            // and the host catches up; the new version is then built on top. No
+            // new authority is granted by that — the unpublished head was signed
+            // under a prior authorization — so this resumes an interrupted
+            // publish rather than smuggling in an unapproved change.
+            tracing::warn!(
+                did = %record.did,
+                caller_expected = %expected,
+                local_head = %latest,
+                "caller is in step with the last confirmed publish but our local head is \
+                 ahead — an earlier publish never landed; continuing so the reconcile can heal it"
+            );
         }
     }
 

--- a/vta-service/src/routes/did_webvh.rs
+++ b/vta-service/src/routes/did_webvh.rs
@@ -11,6 +11,7 @@ use vta_sdk::protocols::did_management::{
         ListWebvhServersResultBody, RegisterDidWithServerBody, RegisterDidWithServerResultBody,
         RegisterWebvhServerResultBody,
     },
+    update::UpdateDidWebvhBody,
 };
 
 use crate::auth::{AdminAuth, AuthClaims, SuperAdminAuth};
@@ -18,7 +19,7 @@ use crate::error::AppError;
 use crate::operations;
 use crate::operations::did_webvh::{
     RegisterDidWithServerError, RegisterDidWithServerParams, RotateDidWebvhKeysOptions,
-    UpdateDidWebvhOptions, UpdateDidWebvhResult, register_did_with_server,
+    UpdateDidWebvhResult, register_did_with_server,
 };
 use crate::server::AppState;
 
@@ -394,20 +395,32 @@ pub async fn delete_did_handler(
         ("ctx_id" = String, Path, description = "Context identifier"),
         ("scid" = String, Path, description = "DID SCID"),
     ),
-    request_body = UpdateDidWebvhOptions,
+    request_body = UpdateDidWebvhBody,
     responses(
         (status = 200, description = "DID updated", body = UpdateDidWebvhResult),
+        (status = 400, description = "Malformed request body"),
         (status = 401, description = "Missing or invalid bearer token"),
         (status = 403, description = "Caller is not an admin"),
         (status = 404, description = "DID not found"),
     ),
 )]
+/// Takes the **wire** body, not the op-layer options.
+///
+/// Deserialising straight into `UpdateDidWebvhOptions` silently dropped
+/// `expectedVersionId` — the wire body is camelCase, that struct is snake_case
+/// with no aliases — so the optimistic-concurrency precondition never applied
+/// to REST callers. A precondition that is accepted and ignored is worse than
+/// one that is absent: it reads in the caller's source as though the lost
+/// update were handled. Conversion goes through the same
+/// `update_body_to_options` the trust-task dispatcher uses.
 pub async fn update_did_handler(
     auth: AdminAuth,
     State(state): State<AppState>,
     Path((_ctx_id, scid)): Path<(String, String)>,
-    Json(body): Json<UpdateDidWebvhOptions>,
+    Json(body): Json<UpdateDidWebvhBody>,
 ) -> Result<Json<UpdateDidWebvhResult>, AppError> {
+    let options = crate::trust_tasks::webvh::update_body_to_options(body)
+        .map_err(|e| AppError::Validation(format!("invalid update body: {e:?}")))?;
     let did_resolver = state
         .did_resolver
         .as_ref()
@@ -418,7 +431,7 @@ pub async fn update_did_handler(
         &deps,
         &auth.0,
         &scid,
-        body,
+        options,
         vta_did.as_deref(),
         "rest",
     )

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -87,7 +87,7 @@ pub(crate) use step_up::{
 };
 mod vault;
 #[cfg(feature = "webvh")]
-mod webvh;
+pub(crate) mod webvh;
 pub(crate) mod wire_v0_2;
 
 /// The transport-neutral dispatch result — see [`helpers::TrustTaskOutcome`].

--- a/vta-service/src/trust_tasks/webvh.rs
+++ b/vta-service/src/trust_tasks/webvh.rs
@@ -635,7 +635,17 @@ fn map_register_err(e: RegisterDidWithServerError) -> AppError {
 
 // ─── Helpers internal to this slice ─────────────────────────────────────
 
-pub(super) fn update_body_to_options(
+/// Convert the camelCase wire body into the op-layer options shape.
+///
+/// `pub(crate)` so the REST route shares this one conversion rather than
+/// deserialising the caller's JSON straight into [`UpdateDidWebvhOptions`].
+/// That shortcut silently dropped `expectedVersionId`: the wire body is
+/// `rename_all = "camelCase"`, the op-layer struct is snake_case with no
+/// aliases and no `deny_unknown_fields`, so the field matched nothing and
+/// defaulted to `None` — the optimistic-concurrency precondition never
+/// applied on that path. Two conversions are two chances to drift; there is
+/// deliberately only one.
+pub(crate) fn update_body_to_options(
     body: UpdateDidWebvhBody,
 ) -> Result<UpdateDidWebvhOptions, RejectReason> {
     let witnesses = match body.witnesses {

--- a/vta-service/tests/mock_vta.rs
+++ b/vta-service/tests/mock_vta.rs
@@ -354,6 +354,235 @@ async fn a_failed_publish_does_not_wedge_the_did_and_the_next_update_recovers() 
     mock.shutdown().await;
 }
 
+/// The same self-recovery, but for a caller that sends `expectedVersionId`.
+///
+/// The test above passes `None`, which is why the wedge it is meant to prevent
+/// survived anyway. A real client — the webvh admin UI — reads the DID from the
+/// **host** and pins that version as its optimistic-concurrency precondition. A
+/// failed publish leaves the local head ahead, so the caller's expectation no
+/// longer matches the local head even though it matches the host exactly.
+///
+/// Comparing the two naively makes the caller wrong for reading the only thing
+/// it can see, and refuses before step 4b can reconcile — so the DID wedges
+/// permanently, every retry failing identically. Worse through the consent
+/// flow: the refusal comes from the Plan dry-run, and 4b is Execute-only, so
+/// the task can never reach the code that would heal it.
+///
+/// The precondition still has to work. `a_stale_caller_still_conflicts` below
+/// pins the other side.
+#[cfg(feature = "webvh")]
+#[tokio::test]
+#[allow(deprecated)] // pins the legacy (context_id, scid) route until it is removed
+async fn a_caller_pinned_to_the_host_version_recovers_a_failed_publish() {
+    use vta_sdk::client::{CreateDidWebvhRequest, VtaClient};
+    use vta_sdk::protocols::did_management::create::WebvhPathMode;
+    use vta_sdk::protocols::did_management::update::UpdateDidWebvhBody;
+
+    let mock = MockVta::start_with_webvh_host().await;
+    let token = mock
+        .ctx
+        .mint_token("did:key:z6MkWebvhAdmin", "admin", vec![])
+        .await;
+    let client = VtaClient::new(mock.base_url());
+    client.set_token_async(token).await;
+
+    let create = client
+        .create_did_webvh(CreateDidWebvhRequest {
+            context_id: "ctx1".into(),
+            server_id: Some(MockVta::WEBVH_SERVER_ID.into()),
+            url: None,
+            path: None,
+            path_mode: Some(WebvhPathMode::AutoAssign),
+            domain: None,
+            label: None,
+            portable: false,
+            add_mediator_service: false,
+            additional_services: None,
+            pre_rotation_count: 0,
+            did_document: None,
+            did_log: None,
+            set_primary: false,
+            signing_key_id: None,
+            ka_key_id: None,
+            template: None,
+            template_context: None,
+            template_vars: Default::default(),
+        })
+        .await
+        .expect("create server-managed DID against the stub host");
+    let did = create.did;
+    let scid = create.scid;
+
+    let confirmed = |did: &str| {
+        let did = did.to_string();
+        let ks = mock.ctx.webvh_ks.clone();
+        async move {
+            vta_service::webvh_store::get_published_version(&ks, &did)
+                .await
+                .unwrap()
+        }
+    };
+    let update = |label: &str, expected: Option<String>| {
+        let scid = scid.clone();
+        let did = did.clone();
+        let client = &client;
+        let body = UpdateDidWebvhBody {
+            document: Some(serde_json::json!({
+                "@context": ["https://www.w3.org/ns/did/v1"],
+                "id": did,
+                "verificationMethod": [{
+                    "id": format!("{did}#key-0"),
+                    "type": "Multikey",
+                    "controller": did,
+                    "publicKeyMultibase": "z6MkExternalPubForTest",
+                }],
+            })),
+            label: Some(label.into()),
+            expected_version_id: expected,
+            ..Default::default()
+        };
+        async move { client.update_did_webvh("ctx1", &scid, body).await }
+    };
+
+    update("u1", None).await.expect("first update succeeds");
+    let host_version = confirmed(&did).await.expect("a landed update confirms");
+
+    // The publish fails: local head advances, the host stays on `host_version`.
+    mock.fail_next_publishes(1);
+    assert!(
+        update("u2-fails", Some(host_version.clone()))
+            .await
+            .is_err(),
+        "a publish failure surfaces as an error"
+    );
+    assert_eq!(
+        confirmed(&did).await.as_deref(),
+        Some(host_version.as_str()),
+        "a failed publish must not advance the confirmed-published marker"
+    );
+
+    // What the admin UI does next: re-read the host (still `host_version`,
+    // since the failed publish never landed) and submit pinned to it. This is
+    // the call that used to fail forever with `concurrent update`.
+    update("u3-recovers", Some(host_version.clone()))
+        .await
+        .expect("a caller in step with the host must not be refused as stale");
+    assert_ne!(
+        confirmed(&did).await.as_deref(),
+        Some(host_version.as_str()),
+        "recovery re-publishes the pending log and advances the host past the failure"
+    );
+
+    mock.shutdown().await;
+}
+
+/// The precondition still refuses a genuinely stale caller.
+///
+/// The relaxation above keys on the caller matching the last *confirmed*
+/// publish. A caller pinned to a version the host has already moved past
+/// matches neither the local head nor the confirmed marker, so it is still a
+/// lost update and must still be refused — otherwise the fix for the wedge
+/// would have quietly deleted the optimistic-concurrency guarantee.
+#[cfg(feature = "webvh")]
+#[tokio::test]
+#[allow(deprecated)] // pins the legacy (context_id, scid) route until it is removed
+async fn a_stale_caller_still_conflicts() {
+    use vta_sdk::client::{CreateDidWebvhRequest, VtaClient};
+    use vta_sdk::protocols::did_management::create::WebvhPathMode;
+    use vta_sdk::protocols::did_management::update::UpdateDidWebvhBody;
+
+    let mock = MockVta::start_with_webvh_host().await;
+    let token = mock
+        .ctx
+        .mint_token("did:key:z6MkWebvhAdmin", "admin", vec![])
+        .await;
+    let client = VtaClient::new(mock.base_url());
+    client.set_token_async(token).await;
+
+    let create = client
+        .create_did_webvh(CreateDidWebvhRequest {
+            context_id: "ctx1".into(),
+            server_id: Some(MockVta::WEBVH_SERVER_ID.into()),
+            url: None,
+            path: None,
+            path_mode: Some(WebvhPathMode::AutoAssign),
+            domain: None,
+            label: None,
+            portable: false,
+            add_mediator_service: false,
+            additional_services: None,
+            pre_rotation_count: 0,
+            did_document: None,
+            did_log: None,
+            set_primary: false,
+            signing_key_id: None,
+            ka_key_id: None,
+            template: None,
+            template_context: None,
+            template_vars: Default::default(),
+        })
+        .await
+        .expect("create server-managed DID against the stub host");
+    let did = create.did;
+    let scid = create.scid;
+
+    let confirmed = |did: &str| {
+        let did = did.to_string();
+        let ks = mock.ctx.webvh_ks.clone();
+        async move {
+            vta_service::webvh_store::get_published_version(&ks, &did)
+                .await
+                .unwrap()
+        }
+    };
+    let update = |label: &str, expected: Option<String>| {
+        let scid = scid.clone();
+        let did = did.clone();
+        let client = &client;
+        let body = UpdateDidWebvhBody {
+            document: Some(serde_json::json!({
+                "@context": ["https://www.w3.org/ns/did/v1"],
+                "id": did,
+                "verificationMethod": [{
+                    "id": format!("{did}#key-0"),
+                    "type": "Multikey",
+                    "controller": did,
+                    "publicKeyMultibase": "z6MkExternalPubForTest",
+                }],
+            })),
+            label: Some(label.into()),
+            expected_version_id: expected,
+            ..Default::default()
+        };
+        async move { client.update_did_webvh("ctx1", &scid, body).await }
+    };
+
+    update("u1", None).await.expect("first update succeeds");
+    let stale = confirmed(&did).await.expect("a landed update confirms");
+
+    // Somebody else updates the DID; both the host and the local head move on,
+    // so `stale` is now genuinely behind rather than merely unpublished.
+    update("u2-by-someone-else", None)
+        .await
+        .expect("second update succeeds");
+    assert_ne!(
+        confirmed(&did).await.as_deref(),
+        Some(stale.as_str()),
+        "the host really did move past the version our caller is pinned to"
+    );
+
+    let err = update("u3-stale", Some(stale.clone()))
+        .await
+        .expect_err("a caller pinned behind the host must still conflict");
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains(&stale),
+        "the refusal should name the stale version the caller sent: {msg}"
+    );
+
+    mock.shutdown().await;
+}
+
 /// Backward-recovery: a DID whose signing-key handle was superseded out of the
 /// active prefix (the state a pre-#730 failed-publish loop left) still updates,
 /// because the resolver re-derives the committed key from the seed.


### PR DESCRIPTION
A `did:webvh` DID could reach a state where **every** update failed, permanently, with `concurrent update: … has been updated since you read it (expected versionId 1-…, current is 2-…)`.

Hit in production on `webvh.storm.ws`: an agent-name bind produced a version the host never received. From then on the webvh admin UI could neither display the new version nor bind the name — the control plane sat on v1, the VTA on v2, and every retry failed identically with no way forward.

Two independent defects, one of which was hiding the other.

## 1. The reconciler sits below the check that makes it necessary

`run_update` runs its optimistic-concurrency check (**step 4a**) *before* the reconciler that heals a failed publish (**step 4b**). Those two steps disagree about what `expectedVersionId` means.

The caller reads that version from the **host**. 4a compares it against the VTA's **local** log head. Identical values — right up until a publish fails, at which point the local head advances and the host does not, and the comparison begins calling the caller stale for correctly reading the only thing it can observe.

Refusing there is what makes the state permanent. 4b exists precisely to re-publish an unconfirmed local head, and its own comment says so:

> *"That is what makes a failed attempt self-recover instead of wedging the DID."*

It never ran, because 4a returned first.

The consent flow makes it strictly worse. There the refusal is raised by the **Plan** dry-run, and 4b is `Mode::Execute`-only by design — a plan must not mutate. So a delegated update could not self-heal even in principle: the task never got far enough to try.

**Fix:** 4a consults `get_published_version` before declaring a conflict. If the caller matches the last version we *confirmed* on the host, the caller is not stale — we are — so the update proceeds and 4b reconciles.

This grants no new authority. The unpublished head was already signed under a prior authorization, so this resumes an interrupted publish rather than smuggling in an unapproved change.

The precondition is unchanged where it earns its keep:
- `None` (never confirmed) still conflicts — nothing proves the caller read anything real.
- Serverless DIDs never set the marker, so they stay strict: with no host, the local head is the only truth and a mismatch really is a stale caller.

## 2. REST silently dropped the precondition entirely

`update_did_handler` deserialised the request body straight into the op-layer `UpdateDidWebvhOptions`. That struct is snake_case with no aliases; the wire body `UpdateDidWebvhBody` is `rename_all = "camelCase"`. A caller sending `expectedVersionId` — every SDK caller — matched no field, and with no `deny_unknown_fields` nothing rejected it. It defaulted to `None`.

**The optimistic-concurrency precondition never applied to any REST update.**

This is the same defect `the_concurrency_precondition_is_read_from_the_wire` was written to pin. That test fixed the *SDK* type; the REST route kept its own shortcut and stayed broken. The doc comment on `UpdateDidWebvhOptions` already stated the rule — route handlers "deserialise the SDK body and convert to this struct at intake" — the route simply wasn't following it.

It now takes `UpdateDidWebvhBody` and converts through the same `update_body_to_options` the trust-task dispatcher uses, so the two paths cannot drift.

Per **R3.6**, a request contract includes what you ignore. A silently-ignored safety precondition is worse than an absent one: it reads, in the caller's source, as though the lost update were handled.

## Testing

- **`a_caller_pinned_to_the_host_version_recovers_a_failed_publish`** reproduces the production wedge exactly: land an update, fail the next publish, then re-submit pinned to the host's version the way the admin UI does. **Verified by mutation** — reverting the 4a change fails it with the precise `concurrent update` error from the field report.
- **`a_stale_caller_still_conflicts`** pins the other side, so this fix cannot quietly degrade into "the precondition was deleted".
- The pre-existing `a_failed_publish_does_not_wedge_the_did_and_the_next_update_recovers` passed throughout — it sends no `expectedVersionId`, which is exactly why the wedge survived it. That gap is now closed.

Worth flagging for review: **defect 2 was masking defect 1 in the test suite.** Until REST forwarded the field, no integration test could reach 4a at all. My first attempt at the regression test passed against unfixed code for that reason.

Full `vta-service` suite green (753 lib + all integration), `cargo fmt`, `cargo clippy --all-targets`, and all three repo guards (`check-changelogs`, `check-version-bumps`, `check-lockfile-self-pins`) pass.

## Pre-merge checklist (vti-stack-development-guide §9)

```
- [x] No new reqwest::Client::new() / bare fetch(); all clients have finite timeouts (R1.2)
- [x] No lock held across a network await (R1.3)
- [x] No local state committed before its remote effect, or the flow is resumable with an idempotency key (R2.1)
- [x] Every retry is bounded + backed off; non-idempotent ops are not blind-retried (R1.4)
- [x] Accept/poll/listen loops survive transient errors (R1.5)
- [x] Acks/deletes happen only after durable handoff (R1.6)
- [x] New/changed wire types: camelCase, deny_unknown_fields where security-relevant, schema registered, all consumers (incl. JS) updated (R3.*)
- [x] Config absence = most restrictive; fail-closed if enforcement can't start (R5.*)
- [x] Logs/status claim only what was verified; background-job failures are surfaced (R6.*)
- [x] "Process dies on the next line" answered for every mutation touched (R2.1)
- [x] Deviations from this guide flagged explicitly with rule numbers
```

Notes on the load-bearing items:

- **R2.1** is the rule this whole PR is about. `run_update` commits local state before it can confirm the host received it — that seam is deliberate and documented, and 4b is the resumability mechanism that makes it safe. The bug was that 4b had been made unreachable. This restores the intended property rather than adding a new one.
- **R3.\*** — defect 2 is a direct R3.6 violation (accepted-and-ignored request field), now fixed by routing REST through the wire type. No new wire types; `UpdateDidWebvhBody` was already the published camelCase shape, and the OpenAPI `request_body` now names it correctly instead of the internal struct.
- **R6.\*** — the new `tracing::warn!` on the reconcile path states only what was observed (caller matches the confirmed publish; local head is ahead) and does not claim the republish succeeded; 4b logs that separately on its own success.
- No new HTTP clients, no new retries, no config surface.

## Deployment note

This unwedges *future* updates. A DID already in the diverged state recovers on its next update, which is now able to run: 4b re-publishes the pending local head, the host catches up, and the agent-name registry reconciles from the published document as it lands.
