### PR TITLE
fix(webvh): a partial DID edit no longer serialises nulls the schema refuses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10408,7 +10408,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.21.4"
+version = "0.21.5"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10470,7 +10470,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.14.5"
+version = "0.14.6"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/changelog.d/895-partial-webvh-update-no-nulls.md
+++ b/changelog.d/895-partial-webvh-update-no-nulls.md
@@ -1,0 +1,65 @@
+### vta-sdk 0.21.5 / vta-service 0.14.6 — a partial webvh DID edit no longer serialises nulls the schema refuses (#895)
+
+`pnm did-mgmt dids edit --did <DID> --label resync --no-confirm` could not run
+at all:
+
+```
+✗ Protocol error: trust task failed [malformedRequest]: malformed request:
+  payload does not conform to https://trusttasks.org/spec/vta/webvh/dids/update/1.0:
+  payload failed schema validation: null is not of type "object";
+  null is not of type "string"; null is not of type "integer";
+  null is not of type "integer"; null is not of type "array"
+```
+
+`UpdateDidWebvhBody` carried **no** `skip_serializing_if`, so every field the
+caller did not set serialised as an explicit `null`. The published schema types
+each optional member by what it holds — object, string, integer, array — and
+none of them are nullable, so the payload was refused once per unset field.
+
+This was not specific to `--label`. Every partial edit failed, and adding flags
+did not help: each one removed a single null and left the rest. The documented
+non-interactive edit path did not work over the trust-task transport for any
+combination of arguments.
+
+Every sibling body in `did_management` already skipped its `None`s — `create.rs`
+in 22 places, `servers.rs` in 6, `list.rs` in 2. `update.rs` was the sole
+outlier at zero. `UpdateDidWebvhBody` and `RotateDidWebvhKeysBody` now skip
+theirs, nine fields in total. `UpdateDidWebvhResultBody` has no optional members
+and is unchanged.
+
+## Why the existing tests did not catch it
+
+Both of the obvious guards look like they cover this, and neither does.
+
+The **conformance sweep** validates each witnessed task against its *generated
+type*, and its `vta/webvh/dids/update/1.0` fixture sets every member. A fully
+populated payload has no nulls to reject — and even a null-bearing one would
+have passed, because `null` deserialises happily into `Option::None`. The sweep
+tests the generated types; only the JSON-Schema validator types the members.
+
+The **round-trip tests** serialise and deserialise the same struct, so a null
+written on the way out is read straight back as `None` on the way in. That is
+symmetric and wrong in exactly the way that survives a round trip.
+
+## Testing
+
+- `a_partial_edit_from_the_cli_validates` drives the CLI's real payload —
+  **serialised from `UpdateDidWebvhBody`, not hand-written JSON** — through
+  `validate_payload`. A literal would only encode what the author believed the
+  type emits, which is precisely the gap that produced the bug.
+  **Verified by mutation**: reverting the `skip_serializing_if` attributes fails
+  it on the no-nulls assertion.
+- `the_null_form_that_broke_the_cli_is_still_refused` puts the nulls back by
+  hand and asserts the refusal, so the test above pins the serialisation rather
+  than a schema that stopped typing its members.
+- `an_unset_field_is_absent_from_the_wire_not_null` pins the wire shape at the
+  SDK layer, including that an empty body is `{}` rather than seven nulls.
+- `a_set_field_still_reaches_the_wire` guards the other direction: `Some(0)`
+  (disable pre-rotation) and `Some(vec![])` (disable watchers) are meaningful
+  values, not absences, and must survive the skip.
+
+## Context
+
+Third defect found in this flow, after #894's two. The first two wedged updates
+that had already diverged; this one blocked the CLI path an operator would use
+to *recover* from that state.

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.21.4"
+version = "0.21.5"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/protocols/did_management/update.rs
+++ b/vta-sdk/src/protocols/did_management/update.rs
@@ -34,25 +34,29 @@ pub struct UpdateDidWebvhBody {
     /// New DID document. `None` = keep existing. When `Some`, the VTA
     /// rotates `update_keys` + pre-rotation commitments as a parallel
     /// consequence.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub document: Option<Value>,
     /// Override pre-rotation count. `None` = keep current; `Some(0)`
     /// disables pre-rotation; `Some(n)` uses `n` new commitments.
-    #[serde(default, alias = "pre_rotation_count")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        alias = "pre_rotation_count"
+    )]
     pub pre_rotation_count: Option<u32>,
     /// New witness configuration as raw JSON (matches the library's
     /// `Witnesses` enum on the wire). The vta-service handler
     /// deserializes into the typed shape.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub witnesses: Option<Value>,
     /// New watcher URLs. `None` = keep current; `Some(vec![])` disables.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub watchers: Option<Vec<String>>,
     /// New TTL in seconds. `None` = keep current.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ttl: Option<u32>,
     /// Operator-facing audit label.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub label: Option<String>,
     /// Optimistic-concurrency precondition. When `Some`, the VTA refuses
     /// the update if the DID's latest log entry no longer matches this
@@ -64,7 +68,11 @@ pub struct UpdateDidWebvhBody {
     ///
     /// `None` (default) preserves prior behaviour for scripted callers
     /// that don't care about concurrent edits.
-    #[serde(default, alias = "expected_version_id")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        alias = "expected_version_id"
+    )]
     pub expected_version_id: Option<String>,
 }
 
@@ -77,10 +85,14 @@ pub struct UpdateDidWebvhBody {
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct RotateDidWebvhKeysBody {
     /// Override pre-rotation count for the new commitment set.
-    #[serde(default, alias = "pre_rotation_count")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        alias = "pre_rotation_count"
+    )]
     pub pre_rotation_count: Option<u32>,
     /// Operator-facing audit label.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub label: Option<String>,
 }
 
@@ -231,6 +243,89 @@ mod casing_tests {
     /// to prevent happened anyway, and every signature in the resulting chain
     /// still verified.
     ///
+    /// An unset field must be **absent**, never `null`.
+    ///
+    /// The published `vta/webvh/dids/update/1.0` schema types each optional
+    /// member by what it holds — object, string, integer, array — and none of
+    /// them accept null. Serialising `None` as `null` therefore fails schema
+    /// validation on arrival, and it fails once per unset field:
+    ///
+    /// ```text
+    /// payload failed schema validation: null is not of type "object";
+    /// null is not of type "string"; null is not of type "integer";
+    /// null is not of type "integer"; null is not of type "array"
+    /// ```
+    ///
+    /// Every other body in `did_management` already skips its `None`s; this
+    /// one did not, which made *every partial update* unusable over the
+    /// trust-task transport — `pnm did-mgmt dids edit --label x` could not
+    /// run at all. Supplying more flags did not help: each one only removed
+    /// a single null and left the rest.
+    #[test]
+    fn an_unset_field_is_absent_from_the_wire_not_null() {
+        // The exact shape the CLI sends for `--label resync`.
+        let partial = UpdateDidWebvhBody {
+            label: Some("resync".into()),
+            ..Default::default()
+        };
+        let json = serde_json::to_value(&partial).expect("serialises");
+
+        assert_eq!(
+            json,
+            serde_json::json!({"label": "resync"}),
+            "a partial update must carry only the fields that were set"
+        );
+
+        // Stated independently of the equality above: the schema rejects null
+        // per member, so no member may serialise to one.
+        let obj = json.as_object().expect("object");
+        assert!(
+            obj.values().all(|v| !v.is_null()),
+            "no member may serialise as null: {json}"
+        );
+
+        // An empty body is the degenerate case — `{}`, not seven nulls.
+        assert_eq!(
+            serde_json::to_value(UpdateDidWebvhBody::default()).expect("serialises"),
+            serde_json::json!({}),
+        );
+
+        // The sibling request body has the same contract.
+        assert_eq!(
+            serde_json::to_value(RotateDidWebvhKeysBody {
+                label: Some("resync".into()),
+                ..Default::default()
+            })
+            .expect("serialises"),
+            serde_json::json!({"label": "resync"}),
+        );
+    }
+
+    /// Skipping `None` must not make a set field vanish — including the
+    /// falsy-looking ones a naive `skip_serializing_if` would drop.
+    #[test]
+    fn a_set_field_still_reaches_the_wire() {
+        let body = UpdateDidWebvhBody {
+            // `Some(0)` is meaningful: it *disables* pre-rotation, which is
+            // the opposite of "leave it alone". It must survive.
+            pre_rotation_count: Some(0),
+            // `Some(vec![])` likewise disables watchers rather than keeping
+            // the current set.
+            watchers: Some(vec![]),
+            expected_version_id: Some("1-QmPrior".into()),
+            ..Default::default()
+        };
+        let json = serde_json::to_value(&body).expect("serialises");
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "preRotationCount": 0,
+                "watchers": [],
+                "expectedVersionId": "1-QmPrior",
+            }),
+        );
+    }
+
     /// A silently-ignored safety precondition is worse than an absent one: it
     /// reads, in the caller's source, as though the danger were handled.
     #[test]

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.14.5"
+version = "0.14.6"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -1420,6 +1420,76 @@ mod payload_validation_tests {
         );
     }
 
+    /// The payload the CLI actually sends for a partial edit must validate.
+    ///
+    /// Built by **serialising the real wire type**, not by hand-writing the
+    /// JSON. A literal here would only ever encode what the author believed
+    /// the type emits, and the defect this pins was precisely a gap between
+    /// those two: `UpdateDidWebvhBody` serialised every unset `Option` as an
+    /// explicit `null`, and the schema types each member by what it holds —
+    /// object, string, integer, array — with none of them nullable. So
+    /// `pnm did-mgmt dids edit --label resync` was refused with one complaint
+    /// per unset field, and no combination of flags helped: each one removed a
+    /// single null and left the others.
+    ///
+    /// Every sibling body in `did_management` already skipped its `None`s.
+    /// This one did not, which made the whole documented CLI edit path
+    /// unusable over the trust-task transport.
+    #[tokio::test]
+    async fn a_partial_edit_from_the_cli_validates() {
+        use vta_sdk::protocols::did_management::update::UpdateDidWebvhBody;
+
+        let (state, _dir) = crate::test_support::build_signing_test_app_state().await;
+
+        // `--label resync --no-confirm`, exactly as the CLI builds it.
+        let body = UpdateDidWebvhBody {
+            label: Some("resync".into()),
+            ..Default::default()
+        };
+        let mut payload = serde_json::to_value(&body).expect("serialises");
+        // `UpdateDidWithDid` flattens the body alongside `did`.
+        payload
+            .as_object_mut()
+            .expect("object")
+            .insert("did".into(), json!("did:webvh:QmScid:example.com:acme"));
+
+        assert!(
+            !payload.to_string().contains("null"),
+            "the CLI's own payload must carry no nulls: {payload}"
+        );
+
+        let reject = super::validate_payload(&state, WEBVH_UPDATE, &doc(payload.clone())).await;
+        assert!(
+            reject.is_none(),
+            "a label-only edit must validate, got: {:?}",
+            reject.map(|r| String::from_utf8_lossy(&r.body).into_owned())
+        );
+    }
+
+    /// The same payload with the nulls put back is refused — so the test above
+    /// pins the serialisation rather than passing incidentally.
+    #[tokio::test]
+    async fn the_null_form_that_broke_the_cli_is_still_refused() {
+        let (state, _dir) = crate::test_support::build_signing_test_app_state().await;
+        let d = doc(json!({
+            "did": "did:webvh:QmScid:example.com:acme",
+            "document": Value::Null,
+            "preRotationCount": Value::Null,
+            "witnesses": Value::Null,
+            "watchers": Value::Null,
+            "ttl": Value::Null,
+            "label": "resync",
+            "expectedVersionId": Value::Null,
+        }));
+        assert!(
+            super::validate_payload(&state, WEBVH_UPDATE, &d)
+                .await
+                .is_some(),
+            "an explicit null is not a valid member value — if this passes, the \
+             schema stopped typing its members and the fix above proves nothing"
+        );
+    }
+
     #[tokio::test]
     async fn an_invented_member_is_refused() {
         let (state, _dir) = crate::test_support::build_signing_test_app_state().await;


### PR DESCRIPTION
`pnm did-mgmt dids edit --did <DID> --label resync --no-confirm` could not run at all:

```
✗ Protocol error: trust task failed [malformedRequest]: malformed request:
  payload does not conform to https://trusttasks.org/spec/vta/webvh/dids/update/1.0:
  payload failed schema validation: null is not of type "object";
  null is not of type "string"; null is not of type "integer";
  null is not of type "integer"; null is not of type "array"
```

## Cause

`UpdateDidWebvhBody` carried **no** `skip_serializing_if`, so every field the caller did not set serialised as an explicit `null`. The published schema types each optional member by what it holds — object, string, integer, array — and none of them are nullable. One complaint per unset field.

This was not specific to `--label`. **Every** partial edit failed, and adding flags did not help — each one removed a single null and left the rest. The documented non-interactive edit path did not work over the trust-task transport for any combination of arguments.

Every sibling body in `did_management` already skips its `None`s: `create.rs` in 22 places, `servers.rs` in 6, `list.rs` in 2, `passkey_vms.rs` in 5. `update.rs` was the sole outlier at zero. `UpdateDidWebvhBody` and `RotateDidWebvhKeysBody` now skip theirs — nine fields. `UpdateDidWebvhResultBody` has no optional members and is untouched.

## Why the existing guards missed it

Both of the tests that look like they cover this don't, and the reasons are worth knowing because they'll recur:

**The conformance sweep** validates each witnessed task against its *generated type*. `null` deserialises happily into `Option::None`, so a null-bearing payload would pass it regardless — and the `vta/webvh/dids/update/1.0` fixture sets every member anyway, so there were no nulls to find. The sweep tests the generated types; only the JSON-Schema validator types the members.

**The round-trip tests** serialise and deserialise the same struct. A null written on the way out reads straight back as `None` on the way in — symmetric, and wrong in precisely the way that survives a round trip.

## Testing

- **`a_partial_edit_from_the_cli_validates`** drives the CLI's real payload through `validate_payload` — **serialised from `UpdateDidWebvhBody`, not hand-written JSON**. A literal would only encode what the author believed the type emits, which is exactly the gap that produced this bug. **Verified by mutation**: reverting the attributes fails it on the no-nulls assertion.
- **`the_null_form_that_broke_the_cli_is_still_refused`** puts the nulls back by hand and asserts the refusal, so the test above pins the serialisation rather than a schema that quietly stopped typing its members.
- **`an_unset_field_is_absent_from_the_wire_not_null`** pins the wire shape at the SDK layer, including that an empty body is `{}` and not seven nulls.
- **`a_set_field_still_reaches_the_wire`** guards the opposite direction: `Some(0)` (disable pre-rotation) and `Some(vec![])` (disable watchers) are meaningful values rather than absences, and must survive the skip.

## Context

This is the third defect in this flow, after the two in #894. Worth noting the order they bite in: #894 fixed updates that had already diverged, and **this one blocked the CLI path an operator would use to recover from that state** — so a DID stuck before #894 could not be repaired by the documented route either.

## Pre-merge checklist (vti-stack-development-guide §9)

```
- [x] No new reqwest::Client::new() / bare fetch(); all clients have finite timeouts (R1.2)
- [x] No lock held across a network await (R1.3)
- [x] No local state committed before its remote effect, or the flow is resumable with an idempotency key (R2.1)
- [x] Every retry is bounded + backed off; non-idempotent ops are not blind-retried (R1.4)
- [x] Accept/poll/listen loops survive transient errors (R1.5)
- [x] Acks/deletes happen only after durable handoff (R1.6)
- [x] New/changed wire types: camelCase, deny_unknown_fields where security-relevant, schema registered, all consumers (incl. JS) updated (R3.*)
- [x] Config absence = most restrictive; fail-closed if enforcement can't start (R5.*)
- [x] Logs/status claim only what was verified; background-job failures are surfaced (R6.*)
- [x] "Process dies on the next line" answered for every mutation touched (R2.1)
- [x] Deviations from this guide flagged explicitly with rule numbers
```

**R3.\*** is the only substantive one. This is a wire-shape change to a published task: emission moves from `{"document": null, …, "label": "x"}` to `{"label": "x"}`. It is compatible in both directions — the fields were already `#[serde(default)]` on intake, so a receiver treats absent and null identically, and the schema *requires* absence. No other consumer reads these bodies (the JS clients do not touch `did_management`). No behaviour change beyond the payload validating.

No new clients, retries, config surface, or mutations.
