### PR TITLE
fix(webvh): a DID with no confirmed-publish marker is no longer wedged

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10470,7 +10470,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.14.6"
+version = "0.14.7"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/changelog.d/896-absent-published-marker-no-longer-wedges.md
+++ b/changelog.d/896-absent-published-marker-no-longer-wedges.md
@@ -1,0 +1,66 @@
+### vta-service 0.14.7 — a DID with no confirmed-publish marker is no longer wedged (#896)
+
+#894 unwedged DIDs whose local head had run ahead of the host, but only when
+the confirmed-publish marker matched what the caller read. It left the case
+that marker is *absent* still refusing — and absent is not rare, it is what
+every DID carried until its first successful update. A DID in that state was
+still uneditable through the admin UI, which is the surface that actually
+implements the consent flow, so there was no route out at all.
+
+## The marker was never written outside the update path
+
+`set_published_version` had exactly two call sites, both in the update
+orchestrator. Creation published the genesis log to the host and recorded
+nothing; register-with-server pushed the log and recorded nothing. So "absent"
+conflated two states that need opposite treatment — *hosted since creation,
+host has our log* and *we have never confirmed a publish*.
+
+Both publish sites now record what they published. Serverless creation
+deliberately still does not: there is no host to confirm against, and its
+marker is legitimately always absent.
+
+## The precondition, stated properly
+
+Step 4a now refuses only when the caller is genuinely stale. It excuses a
+mismatch when **all** of:
+
+- the DID is **hosted** — serverless has no host, so the local head is the only
+  truth and a mismatch really is a stale caller;
+- `expected` **names an entry in our own chain**, so the caller read a real
+  past state rather than a value we never issued; and
+- **nothing after it reached the host** — the marker is `expected`, or absent.
+
+Absent has to count. The marker is written only on a successful publish, so a
+genuine concurrent update would have set it; its absence alongside a moved
+local head means a publish that never landed — the wedge itself. Seeding the
+marker at the two publish sites makes absence rare going forward, but DIDs
+already in the field have none, and they are exactly the ones stuck today.
+
+The rule is extracted to `caller_is_merely_ahead_of_an_unpublished_head` so it
+can be pinned as a truth table rather than inferred from control flow. Getting
+it wrong is costly in both directions: too strict wedges a DID permanently
+(the reconciler that would heal it sits *below* the check that refuses), too
+loose silently drops the lost-update protection the check exists for.
+
+## Testing
+
+Five cases, one per branch of the rule:
+
+- `a_caller_in_step_with_the_confirmed_publish_is_not_stale` — the #894 case.
+- `an_absent_marker_counts_as_nothing_published_beyond` — the case #894 missed.
+- `a_caller_behind_the_confirmed_publish_is_still_stale` — the protection the
+  check exists for, so the relaxation cannot become "precondition deleted".
+- `a_version_absent_from_our_chain_is_never_excused` — an invented version is
+  not a past state anyone could have read.
+- `a_serverless_did_is_never_excused` — both marker states.
+
+The integration coverage from #894
+(`a_caller_pinned_to_the_host_version_recovers_a_failed_publish`,
+`a_stale_caller_still_conflicts`) continues to pin the end-to-end paths.
+
+## Note on the register-with-server marker write
+
+Best-effort, and deliberately so: by that point the DID is registered on the
+host and the local record already flipped to hosted, so failing the operation
+over a bookkeeping write would undo nothing while reporting failure for work
+that succeeded. An absent marker is a state the update path now handles.

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.14.6"
+version = "0.14.7"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/operations/did_webvh/mod.rs
+++ b/vta-service/src/operations/did_webvh/mod.rs
@@ -1315,6 +1315,16 @@ pub async fn create_did_webvh(
         };
         webvh_store::store_did(webvh_ks, &did_record).await?;
         webvh_store::store_did_log(webvh_ks, &final_did, &log_content).await?;
+        // The host has the genesis log — `publish_did` above returned Ok — so
+        // record it as confirmed. The update orchestrator is otherwise the only
+        // writer of this marker, so without this it stays absent until the
+        // DID's first successful update, and "absent" then conflates *never
+        // published* with *hosted since creation*. The concurrency check reads
+        // it to tell a stale caller from a local head we failed to publish;
+        // leaving it empty makes a freshly-created DID indistinguishable from
+        // one whose publishes have never landed. Serverless creation
+        // deliberately does not set it — there is no host to confirm against.
+        webvh_store::set_published_version(webvh_ks, &final_did, &genesis_version_id).await?;
         refresh_resolver_doc_from_log(did_resolver, &final_did, &log_content, channel).await;
 
         info!(

--- a/vta-service/src/operations/did_webvh/register_server.rs
+++ b/vta-service/src/operations/did_webvh/register_server.rs
@@ -230,6 +230,37 @@ pub async fn register_did_with_server(
     let log_entry_count = record.log_entry_count;
     webvh_store::store_did(deps.webvh_ks, &record).await?;
 
+    // The atomic claim-and-publish above put this exact log on the host, so
+    // record its head as confirmed. The DID is only now becoming hosted — it
+    // had no marker as a serverless DID and legitimately needed none — and
+    // without this it would carry an absent marker into its hosted life. The
+    // update path reads the marker to tell a stale caller from a local head it
+    // failed to publish; seeding it here means the very first hosted update
+    // starts from a known-published version rather than an unknown one.
+    // Best-effort: the DID is already registered and the record already
+    // flipped, so failing the whole operation over a bookkeeping write would
+    // undo nothing and report failure for work that succeeded. An absent
+    // marker is a state the update path already handles.
+    match super::update::state_from_jsonl_pub(&did_log) {
+        Ok(state) => match state.log_entries().last() {
+            Some(head) => {
+                if let Err(e) = webvh_store::set_published_version(
+                    deps.webvh_ks,
+                    &record.did,
+                    head.get_version_id(),
+                )
+                .await
+                {
+                    tracing::warn!(error = %e, did = %record.did,
+                        "could not record the published version after register-with-server");
+                }
+            }
+            None => tracing::warn!(did = %record.did, "registered log has no entries"),
+        },
+        Err(e) => tracing::warn!(error = %e, did = %record.did,
+            "could not parse the registered log to record its published version"),
+    }
+
     // 6. Audit. Best-effort; log+swallow on error.
     let resource = format!("did:webvh:{}", record.scid);
     if let Err(e) = audit::record(

--- a/vta-service/src/operations/did_webvh/update/orchestrator.rs
+++ b/vta-service/src/operations/did_webvh/update/orchestrator.rs
@@ -445,6 +445,39 @@ enum PublishTarget {
     AgentName { name: String, verb: AgentNameVerb },
 }
 
+/// Is a caller whose `expectedVersionId` differs from our local head merely
+/// reading a host we failed to publish to — rather than being stale?
+///
+/// See the commentary at step 4a in [`run_update`]. Extracted so the rule can
+/// be pinned exhaustively: it decides whether an optimistic-concurrency
+/// refusal is real, and getting it wrong in either direction is costly. Too
+/// strict wedges a DID forever (the reconciler that heals the divergence sits
+/// *below* the check that refuses); too loose silently drops the lost-update
+/// protection.
+///
+/// - `hosted` — false for serverless DIDs, where the local head is the only
+///   truth and any mismatch really is a stale caller.
+/// - `caller_read_a_real_version` — `expected` names an entry in our own
+///   chain, so the caller read a genuine past state rather than inventing one.
+/// - `confirmed` — the last version we know reached the host. `None` counts as
+///   "nothing published beyond": this marker is written only on a successful
+///   publish, so a genuine concurrent update would have set it, and its
+///   absence alongside a moved head means a publish that never landed.
+fn caller_is_merely_ahead_of_an_unpublished_head(
+    hosted: bool,
+    caller_read_a_real_version: bool,
+    confirmed: Option<&str>,
+    expected: &str,
+) -> bool {
+    if !hosted || !caller_read_a_real_version {
+        return false;
+    }
+    match confirmed {
+        None => true,
+        Some(c) => c == expected,
+    }
+}
+
 async fn run_update(
     deps: &super::super::WebvhDeps<'_>,
     auth: &AuthClaims,
@@ -586,30 +619,59 @@ async fn run_update(
     //         is reading the host perfectly correctly and *we* are the one out
     //         of step.
     //
-    //     `get_published_version` tells them apart. Treating the second case
-    //     as a conflict is what wedges a DID permanently: step 4b — the
-    //     reconciler written to heal exactly this divergence — sits *below*
-    //     this check, so refusing here means it never runs, and every retry
-    //     dies in the same place. That is the unrecoverable loop 4b's own
-    //     comment warns about, reached from the other side. It bites hardest
-    //     through the consent flow, where the failure is raised by the Plan
-    //     dry-run: 4b is Execute-only by design, so a plan cannot self-heal
-    //     and the task never gets far enough to try.
+    //     Treating the second case as a conflict is what wedges a DID
+    //     permanently: step 4b — the reconciler written to heal exactly this
+    //     divergence — sits *below* this check, so refusing here means it
+    //     never runs, and every retry dies in the same place. That is the
+    //     unrecoverable loop 4b's own comment warns about, reached from the
+    //     other side. It bites hardest through the consent flow, where the
+    //     failure is raised by the Plan dry-run: 4b is Execute-only by design,
+    //     so a plan cannot self-heal and the task never gets far enough to try.
+    //
+    //     Two conditions separate "we failed to publish" from "the caller is
+    //     stale", and BOTH are required:
+    //
+    //       1. `expected` names a real entry in our own chain. The caller read
+    //          a genuine past state of this DID rather than sending a value we
+    //          have never issued.
+    //       2. Nothing after `expected` ever reached the host — the confirmed
+    //          marker is `expected` itself, or absent.
+    //
+    //     An absent marker has to count. It is only ever written by *this*
+    //     function, so a DID created before its first successful update has
+    //     none at all, and requiring `Some(expected)` would leave exactly those
+    //     DIDs wedged with no route out. It is also safe: a genuine concurrent
+    //     update would have completed and written the marker, so the only way
+    //     to reach a moved local head with no marker is an update that stored
+    //     its log and never confirmed a publish — the wedge itself.
+    //
+    //     Hosted DIDs only. A serverless DID has no host, so the local head is
+    //     the sole truth, its marker is legitimately always absent, and a
+    //     mismatch there really is a stale caller.
     if let Some(expected) = opts.expected_version_id.as_deref() {
         let latest = last_state.get_version_id();
         if latest != expected {
-            let confirmed = webvh_store::get_published_version(webvh_ks, &record.did)
-                .await
-                .map_err(|e| {
-                    UpdateDidWebvhError::Persistence(format!("get_published_version: {e}"))
-                })?;
-            // Only when the caller is in step with the last version we
-            // *confirmed* on the host. `None` (never confirmed) keeps the
-            // conflict: we cannot show the caller was reading anything real.
-            // Serverless DIDs never set the marker, so they stay strict — with
-            // no host, the local head is the only truth and a mismatch really
-            // is a stale caller.
-            if confirmed.as_deref() != Some(expected) {
+            let hosted = record.server_id != "serverless";
+            let caller_read_a_real_version = state
+                .log_entries()
+                .iter()
+                .any(|e| e.get_version_id() == expected);
+            let confirmed = if hosted {
+                webvh_store::get_published_version(webvh_ks, &record.did)
+                    .await
+                    .map_err(|e| {
+                        UpdateDidWebvhError::Persistence(format!("get_published_version: {e}"))
+                    })?
+            } else {
+                None
+            };
+
+            if !caller_is_merely_ahead_of_an_unpublished_head(
+                hosted,
+                caller_read_a_real_version,
+                confirmed.as_deref(),
+                expected,
+            ) {
                 return Err(UpdateDidWebvhError::Conflict(format!(
                     "DID {} has been updated since you read it (expected versionId `{expected}`, \
                      current is `{latest}`). Re-fetch the document and re-apply your edits.",
@@ -625,7 +687,7 @@ async fn run_update(
                 did = %record.did,
                 caller_expected = %expected,
                 local_head = %latest,
-                "caller is in step with the last confirmed publish but our local head is \
+                "caller is in step with what the host last confirmed but our local head is \
                  ahead — an earlier publish never landed; continuing so the reconcile can heal it"
             );
         }
@@ -1413,6 +1475,59 @@ mod agent_name_tests {
 /// ever stops satisfying that parser, nothing errors anywhere — the claim is
 /// simply never indexed and the name silently 404s. So these tests use the
 /// host's own parser rather than re-asserting our format against itself.
+#[cfg(test)]
+mod concurrency_precondition {
+    use super::caller_is_merely_ahead_of_an_unpublished_head as merely_ahead;
+
+    const V1: &str = "1-QmUCAL";
+    const V2: &str = "2-QmXAXx";
+
+    /// The production wedge: the host confirmed v1, our local head is v2
+    /// because a publish never landed, and the caller is pinned to v1 — which
+    /// is exactly what the host told it. Refusing this is what made the DID
+    /// permanently uneditable.
+    #[test]
+    fn a_caller_in_step_with_the_confirmed_publish_is_not_stale() {
+        assert!(merely_ahead(true, true, Some(V1), V1));
+    }
+
+    /// The case that survived the first fix. This marker is written only by a
+    /// successful publish, so a DID created before its first update has none —
+    /// and requiring `Some(expected)` left exactly those DIDs wedged with no
+    /// route out. Absent must count as "nothing published beyond".
+    #[test]
+    fn an_absent_marker_counts_as_nothing_published_beyond() {
+        assert!(merely_ahead(true, true, None, V1));
+    }
+
+    /// The protection this check exists for. The host really has moved past
+    /// the caller, so the caller is genuinely stale and must be refused —
+    /// otherwise the relaxation above would have quietly deleted the
+    /// lost-update guarantee rather than narrowed it.
+    #[test]
+    fn a_caller_behind_the_confirmed_publish_is_still_stale() {
+        assert!(!merely_ahead(true, true, Some(V2), V1));
+    }
+
+    /// A version we never issued is not a past state the caller could have
+    /// read. Without this, any unrecognised string would slip through
+    /// alongside an absent marker.
+    #[test]
+    fn a_version_absent_from_our_chain_is_never_excused() {
+        assert!(!merely_ahead(true, false, None, "9-QmInvented"));
+        assert!(!merely_ahead(true, false, Some(V1), "9-QmInvented"));
+    }
+
+    /// Serverless DIDs have no host, so the local head is the only truth and
+    /// the marker is legitimately always absent. Excusing a mismatch there
+    /// would drop the precondition entirely for every serverless DID.
+    #[test]
+    fn a_serverless_did_is_never_excused() {
+        assert!(!merely_ahead(false, true, None, V1));
+        assert!(!merely_ahead(false, true, Some(V1), V1));
+    }
+}
+
 #[cfg(test)]
 mod agent_name_host_contract {
     use super::edit_agent_name;


### PR DESCRIPTION
#894 unwedged DIDs whose local head had run ahead of the host — but only when the confirmed-publish marker matched what the caller read. It left the case where that marker is **absent** still refusing.

Absent is not an edge case. It is what every DID carried until its first successful update, and those DIDs stayed uneditable through the admin UI — the surface that actually implements the consent flow — so there was no route out at all. This was found on a DID still stuck after #894 shipped.

## The marker was never written outside the update path

`set_published_version` had exactly two call sites, both in the update orchestrator. Creation published the genesis log to the host and recorded nothing. Register-with-server pushed the log and recorded nothing.

So "absent" conflated two states needing opposite treatment: *hosted since creation, host has our log* and *we have never confirmed a publish*. Both publish sites now record what they published. Serverless creation deliberately still does not — there is no host to confirm against, and its marker is legitimately always absent.

## The precondition, stated properly

Step 4a now excuses a mismatch when **all** of:

- the DID is **hosted** — serverless has no host, so the local head is the only truth and a mismatch really is a stale caller;
- `expected` **names an entry in our own chain** — the caller read a real past state, not a value we never issued;
- **nothing after it reached the host** — the marker is `expected`, or absent.

Absent has to count. The marker is written only on a successful publish, so a genuine concurrent update would have set it; its absence alongside a moved local head means a publish that never landed — the wedge itself. Seeding the marker at the two publish sites makes absence rare going forward, but DIDs already in the field have none, and they are precisely the ones stuck today.

The rule is extracted to `caller_is_merely_ahead_of_an_unpublished_head` so it can be pinned as a truth table rather than inferred from control flow. Getting it wrong is costly in both directions: too strict wedges a DID permanently (the reconciler that would heal it sits *below* the check that refuses); too loose silently drops the lost-update protection.

## Testing

Five cases, one per branch:

- `a_caller_in_step_with_the_confirmed_publish_is_not_stale` — the #894 case.
- `an_absent_marker_counts_as_nothing_published_beyond` — the case #894 missed.
- `a_caller_behind_the_confirmed_publish_is_still_stale` — the protection the check exists for, so the relaxation cannot become "precondition deleted".
- `a_version_absent_from_our_chain_is_never_excused` — an invented version is not a past state anyone could have read.
- `a_serverless_did_is_never_excused` — both marker states.

#894's integration tests (`a_caller_pinned_to_the_host_version_recovers_a_failed_publish`, `a_stale_caller_still_conflicts`) continue to pin the end-to-end paths. Full `vta-service` suite and `clippy --all-targets` clean; all three repo guards pass.

## Note on the register-with-server marker write

Best-effort, deliberately. By that point the DID is registered on the host and the local record has already flipped to hosted, so failing the operation over a bookkeeping write would undo nothing while reporting failure for work that succeeded. An absent marker is a state the update path now handles.

## Pre-merge checklist (vti-stack-development-guide §9)

```
- [x] No new reqwest::Client::new() / bare fetch(); all clients have finite timeouts (R1.2)
- [x] No lock held across a network await (R1.3)
- [x] No local state committed before its remote effect, or the flow is resumable with an idempotency key (R2.1)
- [x] Every retry is bounded + backed off; non-idempotent ops are not blind-retried (R1.4)
- [x] Accept/poll/listen loops survive transient errors (R1.5)
- [x] Acks/deletes happen only after durable handoff (R1.6)
- [x] New/changed wire types: camelCase, deny_unknown_fields where security-relevant, schema registered, all consumers (incl. JS) updated (R3.*)
- [x] Config absence = most restrictive; fail-closed if enforcement can't start (R5.*)
- [x] Logs/status claim only what was verified; background-job failures are surfaced (R6.*)
- [x] "Process dies on the next line" answered for every mutation touched (R2.1)
- [x] Deviations from this guide flagged explicitly with rule numbers
```

- **R2.1** is the substance. The two new marker writes are exactly the "record the remote effect you just achieved" half that was missing; the update path's reconciler remains the resumability mechanism, and this makes its input honest. Process death between publish and marker write leaves an absent marker — the state the relaxed check now handles, and which the reconciler heals on the next update.
- **R5.\*** — the relaxation is narrowed by three conjunctive conditions and stays closed for serverless and for unrecognised versions. It admits absence only where absence is provably not evidence of a concurrent writer.
- **R6.\*** — the register-with-server write logs its failure rather than swallowing it, and the `warn!` on the relaxed path states only what was observed.
- No wire types, config, clients or retries changed.
