### PR TITLE
feat(cli): a CLI can answer a consent gate instead of dying on it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10256,7 +10256,7 @@ dependencies = [
 
 [[package]]
 name = "vta-cli-common"
-version = "0.10.23"
+version = "0.10.24"
 dependencies = [
  "aes-gcm",
  "affinidi-crypto",
@@ -10408,7 +10408,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.21.5"
+version = "0.21.6"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10470,7 +10470,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.14.7"
+version = "0.14.8"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/changelog.d/897-cli-can-answer-a-consent-gate.md
+++ b/changelog.d/897-cli-can-answer-a-consent-gate.md
@@ -1,0 +1,89 @@
+### vta-sdk 0.21.6 / vta-cli-common 0.10.24 / vta-service 0.14.8 — a CLI can answer a consent gate (#897)
+
+A `requireConsent` rule made the task it gates unreachable from the command
+line. `pnm` printed
+
+```
+✗ Protocol error: trust task failed [taskFailed]: task failed: auth:consent_required
+```
+
+and exited. No digest, no instruction, no way to proceed — so an operator whose
+policy gated `webvh/dids/update` could not manage those DIDs from the CLI at
+all, however privileged. The browser extension implemented the approval loop;
+nothing in Rust did.
+
+A consent refusal is not a dead end. It is a question the VTA is holding an
+answer for, and everything needed to answer it was already on the wire — the
+SDK was throwing it away.
+
+## The refusal is now something a caller can act on
+
+`trust_task_error` folded every rejection into `VtaError::Protocol(String)`,
+discarding `details`. `VtaError::ConsentRequired` now carries `payload_digest`,
+`challenge`, `approver_set`, `min_approvals` and `exclude_requester`.
+
+Detection keys on `details.reason`, which is where the gate puts the
+machine-readable answer precisely so consumers do not key on the top-level
+`code` (`taskFailed` for every gated task) or the free-text message.
+
+## `excludeRequester` is now reported
+
+The gate knew whether the requesting device may approve its own request and did
+not say. Without it a CLI must blind-attempt a self-approval and read
+`denied:requester_excluded` back, so it cannot tell the operator whether to
+approve *here* or on *another device* — the one thing they need to know. The
+field is added to the rejection details.
+
+This reveals policy shape to a caller that has already authenticated and just
+triggered the rule. It grants nothing; the gate still decides every approval.
+The SDK defaults it to `true` when absent, so an older server produces "use
+another device", which is correct wherever a second device exists.
+
+## Waiting, without turning a refusal into a nag
+
+`vta_cli_common::consent::with_consent` wraps a submit and waits. Shared with
+the offline `vta` binary so both CLIs behave identically.
+
+There is no read-only status surface for task-consent, so "approved yet?" can
+only be asked by submitting again — and whether that is safe depends on state
+in a way that is easy to get wrong:
+
+- **Pending**: the gate recognises the payload, returns the *same* `challenge`,
+  and deliberately does not re-notify. The push follows the question, not the
+  submit. Polling cannot ring the approver's device.
+- **Denied or lapsed**: the pending record is **deleted**. The next submit finds
+  nothing, raises a *new* question, and pushes again.
+
+So the loop stops the instant the challenge changes. Continuing would convert a
+"no" into repeated prompts — the habituation attack the gate's own design notes
+call out, where a prompt an attacker can summon on demand is worth more than one
+they must wait for. One re-prompt after a denial is unavoidable without a
+server-side status task; an unbounded stream is not.
+
+The timeout is bounded because an operator is sitting at a terminal, and giving
+up is not failure: the request stays pending, so re-running resumes on the same
+challenge.
+
+## Testing
+
+- Five loop cases: approval lets the task through; an ungated task submits
+  exactly once; **a changed challenge stops the loop** (asserting the call count,
+  so a regression that keeps polling fails); the wait is bounded; a non-consent
+  error propagates instead of reading as "still waiting".
+- Three SDK cases from the gate's real rejection shape: the refusal carries what
+  answering needs; an absent `excludeRequester` defaults to the restrictive
+  reading; a non-consent failure with a `details` object stays a `Protocol`
+  error, so the new variant cannot swallow unrelated rejections.
+
+Note the SDK tests need `--features client` — the module is feature-gated, and
+without it they compile out and pass vacuously. `--lib` alone reported an
+unchanged 239.
+
+## Scope
+
+Remote approval only: the CLI shows the code and waits for a device. Letting the
+CLI approve its own request needs a `task-consent/decision/0.1` signer, which
+exists in no client crate; that is the single-operator posture
+(`exclude_requester = false` with the CLI's DID in the approver set) and is
+tracked separately. Wired into `did-mgmt dids edit` here; the helper is generic
+and other gated commands can adopt it.

--- a/vta-cli-common/Cargo.toml
+++ b/vta-cli-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-cli-common"
 description = "Shared CLI command handlers and rendering helpers for VTA CLIs"
 readme = "README.md"
-version = "0.10.23"
+version = "0.10.24"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -16,6 +16,8 @@ repository.workspace = true
 agent-names = ["vta-sdk/agent-names"]
 
 [dependencies]
+# `time` for the consent loop's bounded wait between polls.
+tokio = { workspace = true, features = ["time"] }
 vta-sdk = { path = "../vta-sdk", version = "0.21", features = [
   "client",
   "sealed-transfer",
@@ -49,7 +51,10 @@ dialoguer = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["macros", "rt"] }
+# `test-util` for `#[tokio::test(start_paused = true)]`: the consent loop sleeps
+# between polls, and a paused clock lets its tests assert the poll/stop
+# behaviour without spending the real interval on every run.
+tokio = { workspace = true, features = ["macros", "rt", "test-util"] }
 
 [lints]
 workspace = true

--- a/vta-cli-common/src/commands/webvh.rs
+++ b/vta-cli-common/src/commands/webvh.rs
@@ -276,7 +276,34 @@ pub async fn cmd_webvh_did_edit(
 
     confirm_publish(&body, no_confirm)?;
 
-    let result = client.update_did_webvh_by_did(did, body).await?;
+    // Cloned per attempt rather than moved: a consent grant is bound to a
+    // digest of the payload, so every retry must send the identical bytes or
+    // it raises a second, unanswerable question instead of consuming the
+    // approval already in flight.
+    let result = match crate::consent::with_consent(|| {
+        let body = body.clone();
+        async move { client.update_did_webvh_by_did(did, body).await }
+    })
+    .await?
+    {
+        Ok(result) => result,
+        Err(outcome) => {
+            match outcome {
+                crate::consent::ConsentOutcome::Resolved => {
+                    eprintln!(
+                        "Not approved — the request was denied or expired. Nothing was published."
+                    );
+                }
+                crate::consent::ConsentOutcome::TimedOut => {
+                    eprintln!(
+                        "Gave up waiting. The request is still pending, so approving on your \
+                         device and re-running this command will publish it."
+                    );
+                }
+            }
+            return Ok(());
+        }
+    };
     println!("WebVH DID updated.");
     println!("  DID:             {}", result.did);
     println!("  New version ID:  {}", result.new_version_id);

--- a/vta-cli-common/src/consent.rs
+++ b/vta-cli-common/src/consent.rs
@@ -1,0 +1,273 @@
+//! Wait out a `requireConsent` gate from a CLI.
+//!
+//! A consent-gated task is not refused, it is *deferred*: the VTA raises a
+//! question, pushes it to the approver set, and holds the answer. Until this
+//! existed, no CLI could answer it — `pnm` printed `auth:consent_required` and
+//! exited, so every gated task was simply unreachable from the command line
+//! however privileged the operator was. The browser extension implemented the
+//! loop; nothing in Rust did.
+//!
+//! ## Re-submitting is the only way to ask
+//!
+//! There is no read-only status surface for task-consent, so "has it been
+//! approved yet?" can only be asked by submitting the task again. That is safe
+//! **while the request is pending** and unsafe once it is resolved, and the
+//! difference is load-bearing:
+//!
+//! - Pending: the gate recognises the same payload, returns the *same*
+//!   `challenge`, and deliberately does not re-notify. The push follows the
+//!   question, not the submit — so polling cannot ring the approver's device.
+//! - Denied or lapsed: the pending record is **deleted**. The next submit finds
+//!   nothing, raises a *new* question, and pushes again.
+//!
+//! So the loop stops the moment the challenge changes. Continuing would turn a
+//! "no" into a nag, which is the habituation attack the gate's own design notes
+//! warn about — a consent prompt an attacker can summon on demand is worth more
+//! to them than one they must wait for. One re-prompt is unavoidable without a
+//! server-side status task; an unbounded stream of them is not.
+//!
+//! ## What the operator has to do
+//!
+//! Compare the code printed here against the code on the approving device, and
+//! approve only if they match. That comparison is the entire security value of
+//! the flow: the digest is what the approver signs, so two screens showing the
+//! same code means the thing being approved is the thing that will run.
+
+use std::time::Duration;
+
+use vta_sdk::error::VtaError;
+
+/// How often to re-ask while the request is pending.
+///
+/// Each tick is a submit the gate answers from its pending record without
+/// notifying anyone, so this trades responsiveness against request volume
+/// only. Three seconds keeps a human-paced approval feeling immediate.
+const POLL_INTERVAL: Duration = Duration::from_secs(3);
+
+/// How long to wait before giving up.
+///
+/// Bounded because the operator is sitting at a terminal. Giving up is not
+/// failure — the request stays pending server-side, so re-running the same
+/// command resumes waiting on the same challenge.
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(300);
+
+/// Why the wait ended without the task running.
+#[derive(Debug)]
+pub enum ConsentOutcome {
+    /// The approver said no, or the request lapsed — either way the pending
+    /// record is gone and the challenge we were waiting on will never be
+    /// answered.
+    Resolved,
+    /// Nobody answered within the timeout. The request is still pending.
+    TimedOut,
+}
+
+/// Print the approval prompt for a freshly raised consent request.
+fn announce(payload_digest: &str, approver_set: &str, min_approvals: u32, exclude_requester: bool) {
+    eprintln!();
+    eprintln!("  Approval required before this can run.");
+    eprintln!();
+    eprintln!("      code: {payload_digest}");
+    eprintln!();
+    if exclude_requester {
+        eprintln!(
+            "  {min_approvals} approval(s) needed from `{approver_set}`, and this device is not \
+             eligible to give them — your policy requires a different device."
+        );
+        eprintln!("  Check the code above matches the one on your approving device, then approve");
+        eprintln!("  it there. Do not approve a code that differs: a mismatch means the change");
+        eprintln!("  being shown is not the change that would be made.");
+    } else {
+        eprintln!(
+            "  {min_approvals} approval(s) needed from `{approver_set}`. This device may give \
+             one if its DID is a member of that set."
+        );
+        eprintln!("  Approve on whichever enrolled device is showing this code.");
+    }
+    eprintln!();
+    eprintln!("  Waiting… (Ctrl-C to stop; the request stays pending and re-running resumes it)");
+}
+
+/// Run `submit`, and if the VTA defers it for consent, wait for the approval
+/// and run it again.
+///
+/// `submit` MUST produce a byte-identical request each time it is called. The
+/// grant is bound to a digest of the payload, so a request that differs on
+/// retry — a regenerated nonce, a re-read timestamp — will not match the
+/// approval and will raise a second, unanswerable question instead.
+///
+/// Returns `Ok(Ok(value))` when the task ran, `Ok(Err(outcome))` when the wait
+/// ended without it running, and `Err` for any non-consent failure.
+pub async fn with_consent<F, Fut, T>(submit: F) -> Result<Result<T, ConsentOutcome>, VtaError>
+where
+    F: Fn() -> Fut,
+    Fut: Future<Output = Result<T, VtaError>>,
+{
+    with_consent_timeout(submit, DEFAULT_TIMEOUT).await
+}
+
+/// [`with_consent`] with an explicit deadline. Separate so tests do not sleep
+/// for the production timeout.
+pub async fn with_consent_timeout<F, Fut, T>(
+    submit: F,
+    timeout: Duration,
+) -> Result<Result<T, ConsentOutcome>, VtaError>
+where
+    F: Fn() -> Fut,
+    Fut: Future<Output = Result<T, VtaError>>,
+{
+    // The challenge from the first refusal. Everything below is about noticing
+    // when the server stops answering with this one.
+    let waiting_on = match submit().await {
+        Ok(value) => return Ok(Ok(value)),
+        Err(VtaError::ConsentRequired {
+            payload_digest,
+            challenge,
+            approver_set,
+            min_approvals,
+            exclude_requester,
+        }) => {
+            announce(
+                &payload_digest,
+                &approver_set,
+                min_approvals,
+                exclude_requester,
+            );
+            challenge
+        }
+        Err(other) => return Err(other),
+    };
+
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        if tokio::time::Instant::now() >= deadline {
+            return Ok(Err(ConsentOutcome::TimedOut));
+        }
+        tokio::time::sleep(POLL_INTERVAL).await;
+
+        match submit().await {
+            Ok(value) => return Ok(Ok(value)),
+            Err(VtaError::ConsentRequired { challenge, .. }) if challenge == waiting_on => {
+                // Still the same question. The gate answered from its pending
+                // record and notified nobody; keep waiting.
+            }
+            Err(VtaError::ConsentRequired { .. }) => {
+                // A *different* challenge means our request is gone — denied,
+                // or lapsed — and this submit has just raised a fresh one.
+                // Stop here: asking again is what turns a refusal into a nag.
+                return Ok(Err(ConsentOutcome::Resolved));
+            }
+            Err(other) => return Err(other),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    fn consent_required(challenge: &str) -> VtaError {
+        VtaError::ConsentRequired {
+            payload_digest: "ABC123".into(),
+            challenge: challenge.into(),
+            approver_set: "webvh-approvers".into(),
+            min_approvals: 1,
+            exclude_requester: true,
+        }
+    }
+
+    /// The happy path: deferred, then approved.
+    #[tokio::test(start_paused = true)]
+    async fn an_approval_lets_the_task_through() {
+        let calls = AtomicUsize::new(0);
+        let out = with_consent(|| async {
+            // Deferred twice, then the approval lands.
+            match calls.fetch_add(1, Ordering::SeqCst) {
+                0 | 1 => Err(consent_required("chal-1")),
+                _ => Ok("published"),
+            }
+        })
+        .await
+        .expect("no transport error");
+
+        assert!(matches!(out, Ok("published")));
+        assert_eq!(calls.load(Ordering::SeqCst), 3, "polled until approved");
+    }
+
+    /// A task that is not gated must not pay for the machinery.
+    #[tokio::test(start_paused = true)]
+    async fn an_ungated_task_runs_immediately() {
+        let calls = AtomicUsize::new(0);
+        let out = with_consent(|| async {
+            calls.fetch_add(1, Ordering::SeqCst);
+            Ok::<_, VtaError>("published")
+        })
+        .await
+        .expect("no transport error");
+
+        assert!(matches!(out, Ok("published")));
+        assert_eq!(calls.load(Ordering::SeqCst), 1, "submitted exactly once");
+    }
+
+    /// The rule that keeps a denial from becoming a nag.
+    ///
+    /// A denial deletes the pending request, so the submit that discovers it
+    /// has already raised — and pushed — a new one. Stopping on the changed
+    /// challenge bounds that at a single prompt. Without this the loop would
+    /// re-ask every tick, which is a consent prompt on demand.
+    #[tokio::test(start_paused = true)]
+    async fn a_changed_challenge_stops_the_loop() {
+        let calls = AtomicUsize::new(0);
+        let out = with_consent(|| async {
+            match calls.fetch_add(1, Ordering::SeqCst) {
+                0 => Err::<(), _>(consent_required("chal-1")),
+                // Denied: the pending is gone and this submit raised a new one.
+                _ => Err(consent_required("chal-2")),
+            }
+        })
+        .await
+        .expect("no transport error");
+
+        assert!(matches!(out, Err(ConsentOutcome::Resolved)));
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            2,
+            "stopped on the first changed challenge — no further prompts"
+        );
+    }
+
+    /// Giving up leaves the request pending, so this is a bounded wait rather
+    /// than a failure.
+    #[tokio::test(start_paused = true)]
+    async fn waiting_is_bounded() {
+        let calls = AtomicUsize::new(0);
+        let out = with_consent_timeout(
+            || async {
+                calls.fetch_add(1, Ordering::SeqCst);
+                Err::<(), _>(consent_required("chal-1"))
+            },
+            Duration::from_secs(10),
+        )
+        .await
+        .expect("no transport error");
+
+        assert!(matches!(out, Err(ConsentOutcome::TimedOut)));
+    }
+
+    /// A real failure must not be mistaken for "still waiting".
+    #[tokio::test(start_paused = true)]
+    async fn a_non_consent_error_surfaces_immediately() {
+        let calls = AtomicUsize::new(0);
+        let err = with_consent(|| async {
+            match calls.fetch_add(1, Ordering::SeqCst) {
+                0 => Err::<(), _>(consent_required("chal-1")),
+                _ => Err(VtaError::Protocol("the DID vanished".into())),
+            }
+        })
+        .await
+        .expect_err("a transport error must propagate");
+
+        assert!(matches!(err, VtaError::Protocol(_)));
+    }
+}

--- a/vta-cli-common/src/lib.rs
+++ b/vta-cli-common/src/lib.rs
@@ -1,4 +1,7 @@
 pub mod commands;
+// Waiting out a `requireConsent` gate. Shared with the offline `vta` binary so
+// both CLIs answer an approval question the same way.
+pub mod consent;
 // Terminal rendering for DIDs + their display names. The CLI layer over
 // `vta_sdk::display_name`.
 pub mod display;

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.21.5"
+version = "0.21.6"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/client/mod.rs
+++ b/vta-sdk/src/client/mod.rs
@@ -1553,6 +1553,41 @@ impl VtaClient {
     fn trust_task_error(payload: &serde_json::Value) -> Option<VtaError> {
         let code = payload.get("code")?.as_str()?;
         let message = payload.get("message")?.as_str()?;
+
+        // A consent refusal is not a dead end — it is a question the caller can
+        // answer — so it gets a variant carrying what answering requires. The
+        // gate puts the machine-readable reason in `details.reason` precisely
+        // so a consumer keys on a stable field rather than the top-level `code`
+        // (`taskFailed` for every gated task) or the free-text message.
+        if let Some(details) = payload.get("details")
+            && details.get("reason").and_then(|r| r.as_str()) == Some("auth:consent_required")
+        {
+            let s = |k: &str| {
+                details
+                    .get(k)
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_default()
+                    .to_string()
+            };
+            return Some(VtaError::ConsentRequired {
+                payload_digest: s("payloadDigest"),
+                challenge: s("challenge"),
+                approver_set: s("approverSet"),
+                min_approvals: details
+                    .get("minApprovals")
+                    .and_then(serde_json::Value::as_u64)
+                    .unwrap_or(1) as u32,
+                // Absent on a server older than the field. `true` is the
+                // conservative read: it tells the caller to wait for another
+                // device rather than to offer a self-approval that the gate
+                // would refuse with `denied:requester_excluded`.
+                exclude_requester: details
+                    .get("excludeRequester")
+                    .and_then(serde_json::Value::as_bool)
+                    .unwrap_or(true),
+            });
+        }
+
         Some(VtaError::Protocol(format!(
             "trust task failed [{code}]: {message}"
         )))
@@ -1855,6 +1890,86 @@ impl VtaClient {
 mod tests {
     use super::*;
     use crate::keys::KeyType;
+
+    // ── consent refusals ────────────────────────────────────────────
+
+    /// A `requireConsent` refusal must arrive as something a caller can act
+    /// on, not a flat string.
+    ///
+    /// The fixture is the gate's real shape: `code` is `taskFailed` for every
+    /// gated task and the message is free text, so the machine-readable answer
+    /// lives in `details.reason` — keying on anything else would match the
+    /// wrong rejections or none. Folded into `Protocol(String)`, the digest and
+    /// challenge were discarded, and a CLI could only print the refusal and
+    /// exit; that is why a consent-gated task was unreachable from `pnm`.
+    #[test]
+    fn a_consent_refusal_carries_what_answering_it_needs() {
+        let payload = serde_json::json!({
+            "code": "taskFailed",
+            "message": "task failed: auth:consent_required",
+            "details": {
+                "reason": "auth:consent_required",
+                "payloadDigest": "A1B2C3",
+                "challenge": "chal-xyz",
+                "approverSet": "webvh-approvers",
+                "minApprovals": 1,
+                "excludeRequester": true,
+                "consentRequests": [],
+            }
+        });
+
+        match VtaClient::trust_task_error(&payload) {
+            Some(VtaError::ConsentRequired {
+                payload_digest,
+                challenge,
+                approver_set,
+                min_approvals,
+                exclude_requester,
+            }) => {
+                assert_eq!(payload_digest, "A1B2C3");
+                assert_eq!(challenge, "chal-xyz");
+                assert_eq!(approver_set, "webvh-approvers");
+                assert_eq!(min_approvals, 1);
+                assert!(exclude_requester, "the two-device posture must be reported");
+            }
+            other => panic!("expected ConsentRequired, got {other:?}"),
+        }
+    }
+
+    /// Against a server that predates `excludeRequester`, assume the
+    /// restrictive answer. Guessing `false` would have the CLI offer a
+    /// self-approval the gate then refuses with `denied:requester_excluded`;
+    /// guessing `true` only tells the operator to use another device, which is
+    /// correct whenever a second device exists.
+    #[test]
+    fn an_absent_exclude_requester_defaults_to_the_restrictive_reading() {
+        let payload = serde_json::json!({
+            "code": "taskFailed",
+            "message": "task failed: auth:consent_required",
+            "details": { "reason": "auth:consent_required", "challenge": "c" }
+        });
+        match VtaClient::trust_task_error(&payload) {
+            Some(VtaError::ConsentRequired {
+                exclude_requester, ..
+            }) => assert!(exclude_requester),
+            other => panic!("expected ConsentRequired, got {other:?}"),
+        }
+    }
+
+    /// Every other failure keeps its existing shape — the new variant must not
+    /// swallow unrelated rejections that merely carry a `details` object.
+    #[test]
+    fn a_non_consent_failure_is_still_a_protocol_error() {
+        let payload = serde_json::json!({
+            "code": "malformedRequest",
+            "message": "payload does not conform",
+            "details": { "reason": "schema:invalid" }
+        });
+        assert!(matches!(
+            VtaClient::trust_task_error(&payload),
+            Some(VtaError::Protocol(_))
+        ));
+    }
 
     // ── extract_trust_task_payload ──────────────────────────────────
 

--- a/vta-sdk/src/error.rs
+++ b/vta-sdk/src/error.rs
@@ -75,6 +75,42 @@ pub enum VtaError {
     #[error("protocol error: {0}")]
     Protocol(String),
 
+    /// The task needs a human approval that has not been given yet.
+    ///
+    /// Structured rather than folded into [`Self::Protocol`] because a caller
+    /// has to *act* on it: show the operator `payload_digest` so they can
+    /// compare it against the code on the approving device, then re-submit the
+    /// byte-identical request once approved. A flat string cannot carry that,
+    /// and the CLI's only option was to print the refusal and exit — which is
+    /// why a consent-gated task was unreachable from `pnm` entirely.
+    ///
+    /// The re-submit is safe to repeat *while the request is pending*: the
+    /// server returns the same `challenge` and deliberately does not re-notify
+    /// (the push follows the question, not the submit). It is NOT safe to
+    /// repeat blindly after a decision — a denial deletes the pending request,
+    /// so the next submit raises a new one and pushes again. Callers must stop
+    /// when `challenge` changes; see `vta_cli_common::consent`.
+    #[error(
+        "consent required: {min_approvals} approval(s) from `{approver_set}` — \
+         approve code {payload_digest} on an approving device"
+    )]
+    ConsentRequired {
+        /// The salted digest the approver signs and both screens compare.
+        payload_digest: String,
+        /// Nonce binding the decision to this request. Changes when the
+        /// request is resolved and a new one is raised.
+        challenge: String,
+        /// Named approver set the policy requires.
+        approver_set: String,
+        /// Distinct approvals needed.
+        min_approvals: u32,
+        /// Whether the requesting device is barred from counting toward the
+        /// threshold. `true` means this caller cannot self-approve however it
+        /// is enrolled, and must wait for another device; `false` means it may
+        /// approve its own request if it is a member of the set.
+        exclude_requester: bool,
+    },
+
     /// Serialization/deserialization error.
     #[error("serialization error: {0}")]
     Serialization(#[from] serde_json::Error),
@@ -406,6 +442,11 @@ impl VtaError {
             // No generic hint for these — the message itself is the
             // hint, or the failure is a protocol/programmer error
             // surface that an automated suggestion would only confuse.
+            // The hint depends on policy the message already reports — whether
+            // another device must approve, or this one may. A static string
+            // would have to guess, and guessing wrong sends the operator to the
+            // wrong screen. The CLI's consent loop says it precisely instead.
+            Self::ConsentRequired { .. } => None,
             Self::NotFound(_)
             | Self::DidcommRemote { .. }
             | Self::Protocol(_)

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.14.7"
+version = "0.14.8"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/trust_tasks/policy_gate.rs
+++ b/vta-service/src/trust_tasks/policy_gate.rs
@@ -570,6 +570,14 @@ async fn consent_gate(
                 "challenge": pending.challenge,
                 "approverSet": require.approver_set,
                 "minApprovals": min_approvals,
+                // Whether the requesting device is barred from the threshold.
+                // Told to the caller so a CLI can say "waiting for your device"
+                // versus "approve here" instead of blind-attempting a
+                // self-approval and reading `denied:requester_excluded` back.
+                // This reveals policy shape to a caller that has already
+                // authenticated and just triggered the rule — it grants
+                // nothing; the gate still decides every approval.
+                "excludeRequester": require.exclude_requester,
                 // The signed requests to relay. Each is VTA-authored, so the
                 // approver renders effects it can attribute to the executor
                 // rather than to whoever handed it the document.


### PR DESCRIPTION
A `requireConsent` rule made the task it gates unreachable from the command line. `pnm` printed

```
✗ Protocol error: trust task failed [taskFailed]: task failed: auth:consent_required
```

and exited. No digest, no instruction, no way forward — so an operator whose policy gates `webvh/dids/update` could not manage those DIDs from the CLI **at all**, however privileged. The browser extension implemented the approval loop; nothing in Rust did.

A consent refusal is not a dead end. It is a question the VTA is holding an answer for, and everything needed to answer it was already on the wire — the SDK was throwing it away.

## The refusal is now actionable

`trust_task_error` folded every rejection into `VtaError::Protocol(String)`, discarding `details`. `VtaError::ConsentRequired` now carries `payload_digest`, `challenge`, `approver_set`, `min_approvals`, `exclude_requester`.

Detection keys on `details.reason` — where the gate deliberately puts the machine-readable answer, so consumers don't key on the top-level `code` (`taskFailed` for every gated task) or the free-text message.

## `excludeRequester` is now reported

The gate knew whether the requesting device may approve its own request, and didn't say. Without it a CLI must blind-attempt a self-approval and read `denied:requester_excluded` back — so it can't tell the operator whether to approve *here* or on *another device*, the one thing they need to know.

This reveals policy shape to a caller that has already authenticated and just triggered the rule. It grants nothing; the gate still decides every approval. The SDK defaults it to `true` when absent, so an older server yields "use another device" — correct wherever a second device exists.

## Waiting, without turning a refusal into a nag

`vta_cli_common::consent::with_consent` wraps a submit and waits. Shared with the offline `vta` binary so both CLIs behave identically.

There is no read-only status surface for task-consent, so "approved yet?" can only be asked by submitting again — and whether that's safe depends on state in a way that's easy to get wrong:

- **Pending** — the gate recognises the payload, returns the *same* `challenge`, and deliberately does not re-notify. The push follows the question, not the submit. Polling cannot ring the approver's device.
- **Denied or lapsed** — the pending record is **deleted**. The next submit finds nothing, raises a *new* question, and pushes again.

So the loop stops the instant the challenge changes. Continuing would convert a "no" into repeated prompts — the habituation attack the gate's own notes call out, where a prompt an attacker can summon on demand is worth more than one they must wait for. One re-prompt after a denial is unavoidable without a server-side status task; an unbounded stream is not.

The timeout is bounded because an operator is at a terminal, and giving up isn't failure: the request stays pending, so re-running resumes on the same challenge.

Retries clone the body rather than rebuilding it — the grant is bound to a payload digest, so a request that differs on retry raises a second unanswerable question instead of consuming the approval in flight.

## Testing

Five loop cases: approval lets the task through; an ungated task submits exactly once; **a changed challenge stops the loop** (asserting the call count, so a regression that keeps polling fails); the wait is bounded; a non-consent error propagates rather than reading as "still waiting".

Three SDK cases built from the gate's real rejection shape: the refusal carries what answering needs; an absent `excludeRequester` defaults to the restrictive reading; a non-consent failure carrying a `details` object stays a `Protocol` error, so the new variant can't swallow unrelated rejections.

**One trap worth flagging for review**: the SDK tests need `--features client`. The module is feature-gated, so without it they compile out and pass vacuously — `--lib` alone reported an unchanged 239 and looked green. That's the third time in this series a test has looked like coverage without being it, so I checked the count moved (305) rather than trusting the pass.

## Scope

Remote approval only — the CLI shows the code and waits for a device. This is what works with a `exclude_requester = true` two-device policy.

Letting the CLI approve its **own** request needs a `task-consent/decision/0.1` signer, which exists in no client crate. That's the single-operator posture (`exclude_requester = false` with the CLI's DID in the approver set) and is deliberately not in this PR — it's real crypto, not a flag.

Deliberately **not** done: making `exclude_requester` per-requester-DID. That would turn a structural second-device control into a per-identity opt-out, granted to the admin CLI — the highest-value identity to compromise. Both postures are already expressible per deployment; only the client half was missing.

Wired into `did-mgmt dids edit`; the helper is generic and other gated commands can adopt it.

## Pre-merge checklist (vti-stack-development-guide §9)

```
- [x] No new reqwest::Client::new() / bare fetch(); all clients have finite timeouts (R1.2)
- [x] No lock held across a network await (R1.3)
- [x] No local state committed before its remote effect, or the flow is resumable with an idempotency key (R2.1)
- [x] Every retry is bounded + backed off; non-idempotent ops are not blind-retried (R1.4)
- [x] Accept/poll/listen loops survive transient errors (R1.5)
- [x] Acks/deletes happen only after durable handoff (R1.6)
- [x] New/changed wire types: camelCase, deny_unknown_fields where security-relevant, schema registered, all consumers (incl. JS) updated (R3.*)
- [x] Config absence = most restrictive; fail-closed if enforcement can't start (R5.*)
- [x] Logs/status claim only what was verified; background-job failures are surfaced (R6.*)
- [x] "Process dies on the next line" answered for every mutation touched (R2.1)
- [x] Deviations from this guide flagged explicitly with rule numbers
```

- **R1.4** is the substantive one. The poll is bounded in both duration and continuation: fixed interval, hard deadline, and a terminal stop on a changed challenge. The re-submit is idempotent *by server design* while pending (same payload → same challenge → no re-notify), which is exactly why it is safe to repeat and why it must stop when that stops holding.
- **R1.5** — a non-consent error terminates rather than being swallowed as "keep waiting"; pinned by test.
- **R3.\*** — `excludeRequester` is camelCase, additive, and optional on intake. Read defensively (`unwrap_or(true)`) so an older server degrades to the safe reading rather than a wrong one.
- **R5.\*** — the absent-field default is the restrictive one.
- No new HTTP clients, no config surface, no mutations.
