### PR TITLE
fix(consent): say when an approver is not notified

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10470,7 +10470,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.14.8"
+version = "0.14.9"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/changelog.d/898-say-when-an-approver-is-not-notified.md
+++ b/changelog.d/898-say-when-an-approver-is-not-notified.md
@@ -1,0 +1,41 @@
+### vta-service 0.14.9 — say when an approver is not notified (#898)
+
+A consent request the VTA decides not to push produced **no output on a normal
+deployment**. The skip was `tracing::debug!`, so at INFO the log showed a
+perfectly healthy sequence — `pending:raised`, requests minted and signed, a 422
+back to the caller — with nothing to indicate that no device had been told.
+
+From the outside that is indistinguishable from a device that is simply asleep,
+and the two have opposite fixes: one is a config error on the VTA, the other is
+a client that needs to reconnect. Diagnosing a real "nothing pops up" report
+against production logs came down to guessing between them, because the one line
+that decides it was compiled to a level nobody runs.
+
+## What changed
+
+- The no-route skip is now `warn`, and says what it means: the approver will not
+  learn of this request unless the **requester** relays it — which a CLI cannot
+  do to a browser extension. It also reports the configured mediator, since a
+  `did:key` approver routes via the VTA's own `[messaging] mediator_did` and an
+  unset one is the most likely cause.
+- A successful push logs at `info` with the approver DID, the mediator and the
+  transport. "Who did we notify, and how?" was previously unanswerable from a
+  normal log — the approver DID appeared nowhere, so an approver-set entry
+  pointing at a stale device DID looked identical to a working push.
+
+The push log is emitted *before* the enqueue rather than after. The enqueue is
+the last thing this service controls; beyond it the message is the mediator's to
+hold and the device's to collect, and silence there is not ours to claim either
+way. What must be on the record is that we tried, to which DID, over which
+mediator — so a missing prompt can be attributed to a side instead of argued
+about.
+
+## Not changed
+
+`push_granted`'s equivalent skip stays at `debug`. That notice is explicitly
+best-effort and non-load-bearing — the requester re-submits regardless and the
+single-use grant is the real gate — so a lost one costs a poll cycle, not an
+approval. Raising it would add noise without adding a decision anyone acts on.
+
+No behaviour changes: the same requests are pushed to the same approvers by the
+same routes. This only makes the existing decision visible.

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.14.8"
+version = "0.14.9"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/trust_tasks/consent_request.rs
+++ b/vta-service/src/trust_tasks/consent_request.rs
@@ -166,18 +166,31 @@ async fn push_one(
     approver: &str,
     #[cfg_attr(not(any(feature = "didcomm", feature = "tsp")), allow(unused))] request: &Value,
 ) {
-    let mediator_did = {
+    // Captured before the route decision so the log can say *why* it went the
+    // way it did. Diagnosing "the approver was never told" from the outside
+    // meant guessing between "no route" and "delivered, device asleep", and the
+    // two have opposite fixes.
+    let configured_mediator = {
         let cfg = state.config.read().await;
-        super::step_up::approver_mediator(
-            approver,
-            cfg.messaging.as_ref().map(|m| m.mediator_did.as_str()),
-        )
+        cfg.messaging.as_ref().map(|m| m.mediator_did.clone())
     };
+    let mediator_did = super::step_up::approver_mediator(approver, configured_mediator.as_deref());
+
     #[cfg_attr(not(any(feature = "didcomm", feature = "tsp")), allow(unused))]
     let Some(mediator_did) = mediator_did else {
-        tracing::debug!(
+        // `warn`, not `debug`. This is the VTA deciding not to notify anybody
+        // about a consent request it is now holding — the approver will never
+        // learn of it unless the requester relays, and a CLI requester cannot.
+        // At debug it is invisible on a normal deployment, so the symptom
+        // ("nothing pops up") is indistinguishable from a sleeping device, and
+        // the operator has no way to tell which. That is not routine.
+        tracing::warn!(
             approver = %approver,
-            "no mediator route for consent approver; the relay fallback applies"
+            configured_mediator = ?configured_mediator,
+            "no mediator route for consent approver — NOT notifying; the approver \
+             learns of this request only if the requester relays it (a CLI cannot). \
+             A did:key approver routes via the VTA's own [messaging] mediator_did: \
+             unset config, or a non-did:key approver, produces this."
         );
         return;
     };
@@ -186,10 +199,24 @@ async fn push_one(
     // (learn-from-inbound); otherwise fall through to DIDComm below.
     #[cfg(feature = "tsp")]
     if super::step_up::try_push_over_tsp(state, approver, &mediator_did, request).await {
+        tracing::info!(
+            approver = %approver, mediator = %mediator_did, transport = "tsp",
+            "consent request pushed to approver"
+        );
         #[cfg(feature = "didcomm")]
         super::step_up::trigger_gateway_wake(state, approver, &mediator_did).await;
         return;
     }
+
+    // Said before the send rather than after: the enqueue is the last thing we
+    // control. Beyond it the message is the mediator's to hold and the device's
+    // to collect, and silence there is not ours to report — but "we tried, to
+    // this DID, via this mediator" must be on the record either way, so a
+    // missing prompt can be attributed to a side rather than argued about.
+    tracing::info!(
+        approver = %approver, mediator = %mediator_did, transport = "didcomm",
+        "pushing consent request to approver"
+    );
 
     #[cfg(feature = "didcomm")]
     {


### PR DESCRIPTION
A consent request the VTA decides **not** to push produced no output on a normal deployment. The skip was `tracing::debug!`, so at INFO the log showed a perfectly healthy sequence — `pending:raised`, requests minted and signed, a 422 back to the caller — with nothing indicating that no device had been told.

From the outside that is indistinguishable from a device that is simply asleep, and the two have opposite fixes: a config error on the VTA, versus a client that needs to reconnect.

This is not hypothetical. Diagnosing a live "the browser extension never pops up" report came down to guessing between those two for several rounds of log-passing, because the one line that decides it was compiled to a level nobody runs in production.

## What changed

**The no-route skip is now `warn`**, and says what it means: the approver learns of this request only if the *requester* relays it — which a CLI cannot do to a browser extension. It also reports the configured mediator, since a `did:key` approver routes via the VTA's own `[messaging] mediator_did` and an unset one is the likeliest cause.

**A successful push logs at `info`** with the approver DID, the mediator, and the transport. This was previously unanswerable from a normal log: the approver DID appeared *nowhere*, so an approver-set entry naming a stale device DID looked identical to a working push.

The push log is emitted **before** the enqueue rather than after. The enqueue is the last thing this service controls; beyond it the message is the mediator's to hold and the device's to collect, and silence there is not ours to claim in either direction. What must be on the record is that we tried, to which DID, over which mediator — so a missing prompt can be attributed to a side rather than argued about.

## Deliberately not changed

`push_granted`'s equivalent skip stays at `debug`. That notice is explicitly best-effort and non-load-bearing — the requester re-submits regardless and the single-use grant is the real gate — so a lost one costs a poll cycle, not an approval. Raising it adds noise without adding a decision anyone acts on.

## Scope

Observability only. Same requests, to the same approvers, by the same routes. No wire types, no config, no control flow beyond the log statements themselves. Full `vta-service` suite and `clippy --all-targets` clean; all three repo guards pass.

## Pre-merge checklist (vti-stack-development-guide §9)

```
- [x] No new reqwest::Client::new() / bare fetch(); all clients have finite timeouts (R1.2)
- [x] No lock held across a network await (R1.3)
- [x] No local state committed before its remote effect, or the flow is resumable with an idempotency key (R2.1)
- [x] Every retry is bounded + backed off; non-idempotent ops are not blind-retried (R1.4)
- [x] Accept/poll/listen loops survive transient errors (R1.5)
- [x] Acks/deletes happen only after durable handoff (R1.6)
- [x] New/changed wire types: camelCase, deny_unknown_fields where security-relevant, schema registered, all consumers (incl. JS) updated (R3.*)
- [x] Config absence = most restrictive; fail-closed if enforcement can't start (R5.*)
- [x] Logs/status claim only what was verified; background-job failures are surfaced (R6.*)
- [x] "Process dies on the next line" answered for every mutation touched (R2.1)
- [x] Deviations from this guide flagged explicitly with rule numbers
```

**R6.\*** is the entire point of the PR, and both halves of the rule apply:

- *Background-job failures are surfaced* — a silently-skipped notification is exactly the failure the rule means. It is now surfaced.
- *Claim only what was verified* — which is why the success log sits before the enqueue and says "pushing", not "delivered". The VTA cannot verify the device received anything, so it does not say so. Moving the line after a successful enqueue would have been the easy mistake: it would read as delivery confirmation for something that is only a hop-accepted handoff.

One lock note against R1.3: the config read guard is now scoped to a block and dropped before the route decision and any send, rather than being held across the `await`s that follow.
