### PR TITLE
feat(delivery): see what a Guaranteed send actually did

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10470,7 +10470,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.14.9"
+version = "0.14.10"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",
@@ -10786,7 +10786,7 @@ dependencies = [
 
 [[package]]
 name = "vti-common"
-version = "0.11.33"
+version = "0.11.34"
 dependencies = [
  "aes-gcm",
  "affinidi-data-integrity",

--- a/changelog.d/899-see-what-a-guaranteed-send-actually-did.md
+++ b/changelog.d/899-see-what-a-guaranteed-send-actually-did.md
@@ -1,0 +1,51 @@
+### vti-common 0.11.34 / vta-service 0.14.10 — see what a Guaranteed send actually did (#899)
+
+A durable send that never reached its mediator was indistinguishable, from the
+outside, from one that arrived. `send_guaranteed` returns the moment the outbox
+entry is written; the three delivery loops that move it afterwards
+(`drain_loop`, `outbox_drain_loop`, `confirmation_loop`) logged nothing. So the
+whole state machine — `Queued → Sent → Delivered | Unconfirmed | Failed` — ran
+in silence, and a message that settled `Unconfirmed` after its `deliver_by`
+elapsed produced no output at all.
+
+This is not hypothetical. Diagnosing a live "the approver is never notified"
+report reached the point where the sender logged a correct push (#898: right
+approver, right mediator, right transport), the recipient's inbox was confirmed
+listening on the right DID, and the message still never appeared. Establishing
+that it had never reached the mediator took manually SHA-256'ing DIDs to match
+the mediator's hashed recipient records against the VTA's plaintext ones.
+
+## What changed
+
+**`VtiOutboxStore::put` logs every transition.** It is the single point every
+state change passes through, so one log site covers the entire lifecycle.
+`Unconfirmed` and `Failed` are `warn` — they mean the send is over without
+confirmed delivery — and the rest are `info`. An operator scanning for trouble
+should not have to know the state machine to spot a message that never arrived.
+
+Each line carries `dest_hash = sha256(dest_did)` alongside the plaintext DID.
+The mediator records recipients as hashed DIDs, so this is the field that makes
+a sender log line greppable against a mediator one, instead of the hand-hashing
+described above.
+
+**`send_guaranteed` stops discarding the message id.** It was bound as
+`_msg_id`, leaving nothing to correlate a send against — not the outbox entry,
+not the mediator's record, not the recipient's. It now logs `msg_id`,
+recipient, type, `deliver_by` and idempotency key *before* the enqueue, so an
+enqueue that fails still names what was being sent and to whom.
+
+## Note on expiry
+
+Deliberately unchanged: neither transport carries a message expiry. DIDComm's
+`expires_time` is not set (see the comment in `send_guaranteed` — `deliver_by`
+bounds hop-retry, not content validity, because a held push must stay
+collectable until the request's own `expiresAt`), and the TSP envelope has no
+expiry field at all. Expiry for consent requests is application-level:
+`task-consent/request/0.1` carries `expiresAt`, and the executor holds the
+authoritative `PENDING_TTL_SECS`.
+
+## Scope
+
+Instrumentation only — no behaviour change, no wire types, no config. Same
+sends, same recipients, same delivery semantics; the difference is that the
+outcome is now on the record.

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.14.9"
+version = "0.14.10"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/didcomm_bridge.rs
+++ b/vta-service/src/didcomm_bridge.rs
@@ -269,7 +269,19 @@ impl DIDCommBridge {
         // request's own `expiresAt` — a shorter message expiry could make the
         // mediator drop it before an offline device reconnects. (This preserves
         // the prior `send_oneway` behaviour, which set no expiry.)
-        let (_msg_id, packed) = Self::pack(&inner, recipient_did, msg_type, body, None).await?;
+        let (msg_id, packed) = Self::pack(&inner, recipient_did, msg_type, body, None).await?;
+        // The message id was discarded here, which left nothing to correlate a
+        // send against — not the outbox entry, not the mediator's record, not
+        // the recipient's. Logged before the enqueue so an enqueue that fails
+        // still names what was being sent and to whom.
+        tracing::info!(
+            msg_id = %msg_id,
+            recipient = %recipient_did,
+            msg_type = %msg_type,
+            deliver_by_secs = deliver_by.as_secs(),
+            idempotency_key = ?idempotency_key,
+            "enqueueing guaranteed push"
+        );
         inner
             .service
             .send(

--- a/vti-common/Cargo.toml
+++ b/vti-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-common"
 description = "Shared server-side infrastructure for VTA and VTC services"
 readme = "README.md"
-version = "0.11.33"
+version = "0.11.34"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vti-common/src/outbox_store.rs
+++ b/vti-common/src/outbox_store.rs
@@ -67,6 +67,50 @@ impl VtiOutboxStore {
 #[async_trait]
 impl OutboxStore for VtiOutboxStore {
     async fn put(&self, entry: OutboxEntry) -> Result<(), OutboxError> {
+        // Every state transition the delivery layer makes lands here — this is
+        // the one place that sees `Queued → Sent → Delivered | Unconfirmed |
+        // Failed` for a durable send. Nothing else logged it, so a Guaranteed
+        // send that was accepted for enqueue and then never reached its
+        // mediator looked, from the outside, exactly like one that arrived: the
+        // caller's `send_guaranteed` returns as soon as the entry is written,
+        // and the loops that move it afterwards are silent.
+        //
+        // Diagnosing "the approver was never notified" without this meant
+        // comparing the sender's logs against the mediator's by hand and
+        // matching hashed DIDs. `dest_hash` is emitted for exactly that reason:
+        // the mediator records recipients as `sha256(did)`, so this is what
+        // makes a VTA log line greppable against a mediator one.
+        //
+        // Terminal states are `warn` when they mean loss, `info` otherwise —
+        // an operator scanning for trouble should not have to know the state
+        // machine to spot a message that never arrived.
+        let dest_hash = {
+            use sha2::{Digest, Sha256};
+            let mut h = Sha256::new();
+            h.update(entry.dest_did.as_bytes());
+            hex::encode(h.finalize())
+        };
+        match entry.state {
+            OutboxState::Unconfirmed | OutboxState::Failed => tracing::warn!(
+                key = %entry.idempotency_key,
+                dest = %entry.dest_did,
+                dest_hash = %dest_hash,
+                state = ?entry.state,
+                attempts = entry.attempts,
+                deliver_by_ms = entry.deliver_by_ms,
+                "outbox: durable send settled without confirmed delivery"
+            ),
+            _ => tracing::info!(
+                key = %entry.idempotency_key,
+                dest = %entry.dest_did,
+                dest_hash = %dest_hash,
+                state = ?entry.state,
+                attempts = entry.attempts,
+                next_attempt_at_ms = entry.next_attempt_at_ms,
+                deliver_by_ms = entry.deliver_by_ms,
+                "outbox: durable send state"
+            ),
+        }
         self.ks
             .insert(outbox_key(&entry.idempotency_key), &entry)
             .await


### PR DESCRIPTION
A durable send that never reached its mediator was **indistinguishable from one that arrived**.

`send_guaranteed` returns the moment the outbox entry is written, and the three delivery loops that move it afterwards (`drain_loop`, `outbox_drain_loop`, `confirmation_loop`) logged nothing. So the whole state machine — `Queued → Sent → Delivered | Unconfirmed | Failed` — ran in silence, and a send settling `Unconfirmed` after its `deliver_by` elapsed produced no output at all.

## Why this exists

Diagnosing a live *"the approver is never notified"* report reached a dead end: the sender logged a correct push (#898 — right approver, right mediator, right transport), the recipient's inbox was confirmed listening on the right DID, and the message still never appeared.

Establishing that it had **never reached the mediator** required hand-SHA256'ing DIDs to match the mediator's hashed recipient records against the VTA's plaintext ones. That is not a diagnostic path anyone should have to find.

## What changed

**`VtiOutboxStore::put` logs every transition.** It is the single point every state change passes through, so one log site covers the entire lifecycle. `Unconfirmed` and `Failed` are `warn` — the send is over without confirmed delivery — and the rest are `info`. Spotting a message that never arrived shouldn't require knowing the state machine.

Each line carries `dest_hash = sha256(dest_did)` beside the plaintext DID. The mediator records recipients as hashed DIDs, so this is the field that makes a sender log line greppable against a mediator one — replacing the manual hashing above.

**`send_guaranteed` stops discarding the message id.** It was bound as `_msg_id`, leaving nothing to correlate a send against: not the outbox entry, not the mediator's record, not the recipient's. It now logs `msg_id`, recipient, type, `deliver_by` and idempotency key **before** the enqueue, so an enqueue that fails still names what was being sent and to whom.

## Expiry — deliberately unchanged

Neither transport carries a message expiry, and that stays true:

- DIDComm `expires_time` is not set. Per the existing comment in `send_guaranteed`, `deliver_by` bounds the outbox **hop-retry** window, not content validity — a held push must remain collectable until the request's own `expiresAt`, and a shorter transport expiry could make the mediator drop it before an offline device reconnects.
- The **TSP envelope has no expiry field at all** (verified against `affinidi-tsp` 0.1.13).

So consent expiry is application-level: `task-consent/request/0.1` carries `expiresAt`, and the executor holds the authoritative `PENDING_TTL_SECS`. Anything consuming a queued push must check the payload, not the transport.

## Scope

Instrumentation only. No behaviour change, no wire types, no config — same sends, same recipients, same delivery semantics. The difference is that the outcome is now on the record.

## Pre-merge checklist (vti-stack-development-guide §9)

```
- [x] No new reqwest::Client::new() / bare fetch(); all clients have finite timeouts (R1.2)
- [x] No lock held across a network await (R1.3)
- [x] No local state committed before its remote effect, or the flow is resumable with an idempotency key (R2.1)
- [x] Every retry is bounded + backed off; non-idempotent ops are not blind-retried (R1.4)
- [x] Accept/poll/listen loops survive transient errors (R1.5)
- [x] Acks/deletes happen only after durable handoff (R1.6)
- [x] New/changed wire types: camelCase, deny_unknown_fields where security-relevant, schema registered, all consumers (incl. JS) updated (R3.*)
- [x] Config absence = most restrictive; fail-closed if enforcement can't start (R5.*)
- [x] Logs/status claim only what was verified; background-job failures are surfaced (R6.*)
- [x] "Process dies on the next line" answered for every mutation touched (R2.1)
- [x] Deviations from this guide flagged explicitly with rule numbers
```

**R6.\*** is the whole PR, and both halves apply:

- *Background-job failures are surfaced* — a Guaranteed send settling `Unconfirmed` is precisely the background failure the rule means, and it was silent. It is now a `warn`.
- *Claim only what was verified* — the `warn` says "settled without confirmed delivery", not "failed": `Unconfirmed` means no end-to-end evidence was obtained, which is not the same as knowing it was lost. The wording preserves that distinction rather than overstating it.

**R1.1** is worth noting as the underlying rule: this makes the difference between "handed to transport" and "delivered" observable, which is the evidence the rule demands and which the sender previously could not produce.
