### PR TITLE
chore(deps): move DIDComm messaging onto the enforced-authcrypt SDK (…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,9 +90,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7b538d0d00a984f3eff5c994553df5a0c8bb93b30305b964fd380d6d1e64554"
 dependencies = [
  "bls12_381_plus",
- "elliptic-curve",
- "ff",
- "group",
+ "elliptic-curve 0.13.8",
+ "ff 0.13.1",
+ "group 0.13.0",
  "hex",
  "rand 0.9.5",
  "sha2 0.10.9",
@@ -124,9 +124,9 @@ dependencies = [
  "ed25519-dalek",
  "getrandom 0.2.17",
  "hmac 0.12.1",
- "k256",
+ "k256 0.13.4",
  "multibase",
- "p256",
+ "p256 0.13.2",
  "p384",
  "p521",
  "rand 0.10.2",
@@ -333,15 +333,15 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-didcomm"
-version = "0.15.6"
+version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93889ea5df8140074fa9a3ed5f0def3e785f21ff2708d9f37459ef2b2efbfb3f"
+checksum = "7e50820cf32736246a5e918a5eb1773c31ffcec898ad2ab5b26477cf7a547fa5"
 dependencies = [
  "affinidi-crypto",
  "base64ct",
  "ed25519-dalek",
- "k256",
- "p256",
+ "k256 0.14.0",
+ "p256 0.14.0",
  "rand 0.10.2",
  "rand_core 0.6.4",
  "serde",
@@ -354,9 +354,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-mediator"
-version = "0.18.1"
+version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f332431a1186288f0f121974e37a96dc7130adf2b5c141f36267f681dbab56a0"
+checksum = "c0e69d98b2f52c0a1047277c743ba06f702dde58397dbbde507f14650464e955"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-common",
@@ -419,9 +419,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-mediator-common"
-version = "0.15.32"
+version = "0.15.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8740756329af4040d2c488f2d2e5c27a62b91c4cdde04e9f8d3876cb583ce9a"
+checksum = "0a33fc5457ab11facaaa3dae422773f0ad944d64afc3f9d05880163523c9c3cd"
 dependencies = [
  "aes-gcm",
  "ahash 0.8.12",
@@ -469,9 +469,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-sdk"
-version = "0.18.65"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b4901696220a28519f77af11ec6c38ebfde678ce7c59f6748f0a65d7166d688"
+checksum = "ba9d874a748a081ba9645706f2ff1bf5f4226d8f671505cf07860945ba1b0bb8"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-authentication",
@@ -507,9 +507,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-test-mediator"
-version = "0.2.44"
+version = "0.2.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "000d5bb24597fe363a376cf6d845e7c842e27aa46f1c13a49974d829cc574d8d"
+checksum = "22eab86ebced9cb0c12997c7a931c3d0ed3b995bd46a305e67d381390427e673"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-didcomm",
@@ -540,7 +540,7 @@ checksum = "fc66cb297f338fbaf058fff9b27273b871e0eccf60d0aaf867fcf6d7303b597e"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",
- "p256",
+ "p256 0.13.2",
  "rand 0.10.2",
  "serde",
  "serde_json",
@@ -685,9 +685,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-tdk"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9556076f1e2a8894647c5e9e9b682d83b3f7ad8199e289b05c579d9f73f5e68c"
+checksum = "8efce5081936f04938a5be1c754065036cd66a510a67b2092e464a3a24612728"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -1869,6 +1869,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
+name = "base16ct"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
+
+[[package]]
 name = "base256emoji"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2109,9 +2115,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa37cf2a8c96054d2dc3d708efe35cc0347014af0d30b86c736b4388ff8491c"
 dependencies = [
  "arrayref",
- "elliptic-curve",
- "ff",
- "group",
+ "elliptic-curve 0.13.8",
+ "ff 0.13.1",
+ "group 0.13.0",
  "hex",
  "pairing",
  "rand_core 0.6.4",
@@ -2824,6 +2830,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-bigint"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a52aa3fcda4e6302a9f48734f234d35d4721b96f8fe07d073f07ce9df4f0271"
+dependencies = [
+ "cpubits",
+ "ctutils",
+ "getrandom 0.4.3",
+ "hybrid-array",
+ "num-traits",
+ "rand_core 0.10.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2840,6 +2862,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
+ "getrandom 0.4.3",
  "hybrid-array",
  "rand_core 0.10.1",
 ]
@@ -2891,6 +2914,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
 dependencies = [
  "cmov",
+ "subtle",
 ]
 
 [[package]]
@@ -3137,7 +3161,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid 0.9.6",
- "pem-rfc7468",
+ "pem-rfc7468 0.7.0",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
+dependencies = [
+ "const-oid 0.10.2",
+ "pem-rfc7468 1.0.0",
  "zeroize",
 ]
 
@@ -3459,12 +3494,27 @@ version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der",
+ "der 0.7.10",
  "digest 0.10.7",
- "elliptic-curve",
- "rfc6979",
+ "elliptic-curve 0.13.8",
+ "rfc6979 0.4.0",
  "signature 2.2.0",
- "spki",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0681a4fc24c767085329728d8dfba959af91228aa4610cca4f8ce317ba46ae0"
+dependencies = [
+ "der 0.8.1",
+ "digest 0.11.3",
+ "elliptic-curve 0.14.1",
+ "rfc6979 0.6.0",
+ "signature 3.0.0",
+ "spki 0.8.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -3527,20 +3577,39 @@ version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
- "base16ct",
- "base64ct",
- "crypto-bigint",
+ "base16ct 0.2.0",
+ "crypto-bigint 0.5.5",
  "digest 0.10.7",
- "ff",
+ "ff 0.13.1",
  "generic-array",
- "group",
+ "group 0.13.0",
  "hkdf 0.12.4",
- "pem-rfc7468",
- "pkcs8",
+ "pem-rfc7468 0.7.0",
+ "pkcs8 0.10.2",
  "rand_core 0.6.4",
- "sec1",
- "serde_json",
- "serdect",
+ "sec1 0.7.3",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d65aa39b3a5c1c9c1b745c9a019234bb7a21b77abcb4f4d266d706e2d577d65"
+dependencies = [
+ "base16ct 1.0.0",
+ "crypto-bigint 0.7.5",
+ "crypto-common 0.2.2",
+ "digest 0.11.3",
+ "ff 0.14.0",
+ "group 0.14.0",
+ "hkdf 0.13.0",
+ "hybrid-array",
+ "pem-rfc7468 1.0.0",
+ "pkcs8 0.11.0",
+ "rand_core 0.10.1",
+ "sec1 0.8.1",
  "subtle",
  "zeroize",
 ]
@@ -3723,6 +3792,16 @@ checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
  "bitvec",
  "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "ff"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1f686ab92a9fb0eaf188f6c6c87b89490baa6fdb0db4544ba4dc47f7942489f"
+dependencies = [
+ "rand_core 0.10.1",
  "subtle",
 ]
 
@@ -4329,8 +4408,19 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
- "ff",
+ "ff 0.13.1",
  "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "group"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd1a1c7a5206c5b7a3f5a0d7ccd3ff85d0c8f5133d62a02680255b0004af5f4"
+dependencies = [
+ "ff 0.14.0",
+ "rand_core 0.10.1",
  "subtle",
 ]
 
@@ -4654,6 +4744,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
  "ctutils",
+ "subtle",
  "typenum",
  "zeroize",
 ]
@@ -5436,11 +5527,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
 dependencies = [
  "cfg-if",
- "ecdsa",
- "elliptic-curve",
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
  "once_cell",
  "sha2 0.10.9",
  "signature 2.2.0",
+]
+
+[[package]]
+name = "k256"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93f50113171a713f4a4231ef82eb26703607139b35dcb56241f0ceab2ae1f7d8"
+dependencies = [
+ "cpubits",
+ "ecdsa 0.17.0",
+ "elliptic-curve 0.14.1",
+ "primeorder 0.14.0",
+ "sha2 0.11.0",
+ "signature 3.0.0",
+ "wnaf",
 ]
 
 [[package]]
@@ -6483,10 +6589,23 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
 dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
+ "primeorder 0.13.6",
  "sha2 0.10.9",
+]
+
+[[package]]
+name = "p256"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2c9239b2dbc807adbbe147e8cf72ea7450c3a0aabe62cb8e75ff4ec22e1f72a"
+dependencies = [
+ "ecdsa 0.17.0",
+ "elliptic-curve 0.14.1",
+ "primefield",
+ "primeorder 0.14.0",
+ "sha2 0.11.0",
 ]
 
 [[package]]
@@ -6495,9 +6614,9 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
 dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
+ "primeorder 0.13.6",
  "sha2 0.10.9",
 ]
 
@@ -6507,10 +6626,10 @@ version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fc9e2161f1f215afdfce23677034ae137bbd45016a880c2eb3ba8eb95f085b2"
 dependencies = [
- "base16ct",
- "ecdsa",
- "elliptic-curve",
- "primeorder",
+ "base16ct 0.2.0",
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
+ "primeorder 0.13.6",
  "rand_core 0.6.4",
  "sha2 0.10.9",
 ]
@@ -6521,7 +6640,7 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81fec4625e73cf41ef4bb6846cafa6d44736525f442ba45e407c4a000a13996f"
 dependencies = [
- "group",
+ "group 0.13.0",
 ]
 
 [[package]]
@@ -6631,6 +6750,15 @@ name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
 dependencies = [
  "base64ct",
 ]
@@ -6797,8 +6925,18 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
- "spki",
+ "der 0.7.10",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
+dependencies = [
+ "der 0.8.1",
+ "spki 0.8.0",
 ]
 
 [[package]]
@@ -6934,12 +7072,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "primefield"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c555a6e4eb7d4e158fcb028c835c3b8642206ddc279b5c6b202ef9a8bdb592f4"
+dependencies = [
+ "crypto-bigint 0.7.5",
+ "crypto-common 0.2.2",
+ "ff 0.14.0",
+ "rand_core 0.10.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "primeorder"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
- "elliptic-curve",
+ "elliptic-curve 0.13.8",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c9f42978c78a00e3d68f69fc03e57a234debae69da4020a4fb588fcdcd07b06"
+dependencies = [
+ "elliptic-curve 0.14.1",
+ "once_cell",
+ "primefield",
+ "serdect",
+ "wnaf",
 ]
 
 [[package]]
@@ -7628,6 +7793,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a459cddafb3fe76b31fd8f1108007566c40301feb64dc7b54656eb7388172b"
+dependencies = [
+ "crypto-bigint 0.7.5",
+ "hmac 0.13.0",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8008,11 +8183,24 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
- "base16ct",
- "der",
+ "base16ct 0.2.0",
+ "der 0.7.10",
  "generic-array",
- "pkcs8",
- "serdect",
+ "pkcs8 0.10.2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "sec1"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56d437c2f19203ce5f7122e507831de96f3d2d4d3be5af44a0b0a09d8a80e4d"
+dependencies = [
+ "base16ct 1.0.0",
+ "ctutils",
+ "der 0.8.1",
+ "hybrid-array",
  "subtle",
  "zeroize",
 ]
@@ -8281,11 +8469,11 @@ dependencies = [
 
 [[package]]
 name = "serdect"
-version = "0.2.0"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
+checksum = "66cf8fedced2fcf12406bcb34223dffb92eaf34908ede12fed414c82b7f00b3e"
 dependencies = [
- "base16ct",
+ "base16ct 1.0.0",
  "serde",
 ]
 
@@ -8465,6 +8653,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
 dependencies = [
+ "digest 0.11.3",
  "rand_core 0.10.1",
 ]
 
@@ -8621,7 +8810,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.10",
+]
+
+[[package]]
+name = "spki"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
+dependencies = [
+ "base64ct",
+ "der 0.8.1",
 ]
 
 [[package]]
@@ -8692,7 +8891,7 @@ dependencies = [
  "getrandom 0.2.17",
  "hex",
  "iref",
- "k256",
+ "k256 0.13.4",
  "keccak-hash",
  "pin-project",
  "rand 0.8.7",
@@ -8777,14 +8976,14 @@ dependencies = [
  "bs58 0.4.0",
  "getrandom 0.2.17",
  "json-syntax",
- "k256",
+ "k256 0.13.4",
  "lazy_static",
  "linked-data",
  "multibase",
  "num-bigint",
  "num-derive 0.3.3",
  "num-traits",
- "p256",
+ "p256 0.13.2",
  "rand 0.8.7",
  "serde",
  "serde_jcs",
@@ -10322,7 +10521,7 @@ dependencies = [
  "hkdf 0.13.0",
  "hmac 0.13.0",
  "multibase",
- "p256",
+ "p256 0.13.2",
  "rand 0.10.2",
  "serde",
  "serde_json",
@@ -10408,7 +10607,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.21.6"
+version = "0.21.7"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10470,7 +10669,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.14.10"
+version = "0.14.11"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",
@@ -10516,7 +10715,7 @@ dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
  "multibase",
- "p256",
+ "p256 0.13.2",
  "rand 0.10.2",
  "regorus",
  "reqwest 0.13.4",
@@ -10786,7 +10985,7 @@ dependencies = [
 
 [[package]]
 name = "vti-common"
-version = "0.11.34"
+version = "0.11.35"
 dependencies = [
  "aes-gcm",
  "affinidi-data-integrity",
@@ -10894,7 +11093,7 @@ dependencies = [
  "aws-lc-rs",
  "base64 0.22.1",
  "multibase",
- "p256",
+ "p256 0.13.2",
  "serde",
  "serde_json",
  "serde_json_canonicalizer",
@@ -11528,6 +11727,17 @@ name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wnaf"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab12e7090f27e2ffd9322651492942d50c2926094af30601e1964337db39daf1"
+dependencies = [
+ "ff 0.14.0",
+ "group 0.14.0",
+ "hybrid-array",
+]
 
 [[package]]
 name = "writeable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,8 +77,13 @@ repository = "https://github.com/OpenVTC/verifiable-trust-infrastructure"
 # Foreign-language bindings for the mobile engine crate (`vta-mobile-core`).
 uniffi = "0.28"
 
-# Affinidi Trust Development Kit
-affinidi-tdk = "0.8"
+# Affinidi Trust Development Kit.
+# Pinned to a minimum patch (not just `0.8`) because 0.8.5 is the release that
+# carries the enforced-authcrypt security fix (#671): it depends on
+# `affinidi-messaging-sdk` 0.19 + `affinidi-messaging-didcomm` 0.15.8, so this
+# pin is what pulls the fix through the default (non-`tsp`) build path. Do not
+# relax below 0.8.5 — earlier releases resolve pre-fix messaging crates.
+affinidi-tdk = "0.8.5"
 # Raw crypto primitives (ed25519↔x25519 conversion, did:key helpers). Pulled
 # directly so sealed-transfer can use `affinidi_crypto::did_key::*` without
 # going through the higher-level Secret wrapper in secrets-resolver.
@@ -112,7 +117,7 @@ affinidi-bbs = "0.3"
 affinidi-openid4vp = "0.1.2"
 affinidi-openid4vci = "0.2"
 affinidi-secrets-resolver = "0.5"
-affinidi-messaging-didcomm-service = "0.3"
+affinidi-messaging-didcomm-service = "0.3.22"
 # Reliable messaging delivery layer (durable outbox + drain + §5a confirmation)
 # over the MessageTransport contract — the D1 delivery layer the VTI cut-over
 # (D2) wires in. `VtiOutboxStore` (vti-common) backs its OutboxStore with fjall.

--- a/changelog.d/900-enforced-authcrypt-sdk-0-19.md
+++ b/changelog.d/900-enforced-authcrypt-sdk-0-19.md
@@ -1,0 +1,39 @@
+### vti-common 0.11.35 / vta-sdk 0.21.7 / vta-service 0.14.11 — move onto the enforced-authcrypt messaging SDK (#900)
+
+Bumps the Affinidi TDK to the released enforced-authcrypt line: `affinidi-tdk`
+0.8.5, which pulls `affinidi-messaging-sdk` 0.19.0 and
+`affinidi-messaging-didcomm` 0.15.8. This is the upstream fix (affinidi-tdk-rs
+#671) that makes DIDComm `unpack` reject plaintext / anoncrypt / forged-`from`
+envelopes **by default**, moving the sender-authentication guarantee down into
+the library.
+
+## What changed
+
+- **Workspace dependency pins** (`Cargo.toml`): `affinidi-tdk` `0.8` → `0.8.5`
+  and `affinidi-messaging-didcomm-service` `0.3` → `0.3.22`, pinned to a minimum
+  patch so a fresh resolve cannot land on a pre-fix messaging crate (0.15.7 was
+  published as pre-fix code and renumbered to 0.15.8).
+- **Direct `affinidi-messaging-sdk` pins** (`vta-sdk`, `vta-service`, the e2e
+  crate): `0.18` → `0.19` — a semver-breaking bump, required so the `tsp`
+  feature and the e2e mediator fixture resolve to the same 0.19 line the default
+  build already gets transitively through `affinidi-tdk` 0.8.5. Leaving them at
+  `^0.18` splits the graph into two `affinidi-messaging-sdk` copies.
+- **`Cargo.lock`**: `sdk` 0.18.65 → 0.19.0, `didcomm` 0.15.6 → 0.15.8, `tdk`
+  0.8.4 → 0.8.5, `mediator` 0.18.1 → 0.18.5, `test-mediator` 0.2.44 → 0.2.46.
+
+## Source
+
+`affinidi-messaging-sdk` 0.19 makes `UnpackMetadata` `#[non_exhaustive]`, so the
+`meta()` test helper in `vti-common/src/auth/didcomm.rs` can no longer use a
+struct literal; it now starts from `Default` and assigns the fields under test.
+This is the only source change — the production `bind_authcrypt_sender` guard and
+the DIDComm `inbound_gate` are unchanged and remain in place as defence in depth.
+
+## Scope
+
+Dependency + test-helper only. No production behaviour, wire types, or config
+change: VTA already required authcrypt on both inbound paths, so the new library
+default is aligned with existing enforcement rather than a new constraint. The
+CVE-class guards (`rejects_plaintext`, `rejects_anoncrypt`,
+`rejects_sender_mismatch`) stay green.
+

--- a/tests/e2e/Cargo.toml
+++ b/tests/e2e/Cargo.toml
@@ -31,7 +31,7 @@ vti-common = { path = "../../vti-common" }
 affinidi-tdk = { workspace = true }
 affinidi-secrets-resolver = { workspace = true }
 affinidi-did-resolver-cache-sdk = { workspace = true }
-affinidi-messaging-sdk = "0.18"
+affinidi-messaging-sdk = "0.19"
 affinidi-messaging-didcomm = "0.15"
 
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time", "net"] }

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.21.6"
+version = "0.21.7"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -233,7 +233,7 @@ futures-util = { workspace = true, optional = true }
 # `TspPingSession` needs. Depend on the same crate directly (Cargo unifies to
 # one instance, the one `affinidi_tdk::messaging` re-exports) so the `tsp`
 # feature can turn its `tsp` on — mirrors what `vta-service` does.
-affinidi-messaging-sdk = { version = "0.18", optional = true, default-features = false }
+affinidi-messaging-sdk = { version = "0.19", optional = true, default-features = false }
 reqwest = { workspace = true, optional = true }
 # Only for `crypto_init` (the aws-lc-rs CryptoProvider installer).
 rustls = { workspace = true, optional = true }

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.14.10"
+version = "0.14.11"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -192,9 +192,9 @@ futures-util = "0.3"
 # Direct (optional) dependency only so the `tsp` feature can turn on the
 # messaging-SDK's own `tsp` ops (`atm.tsp()`), which are gated behind that
 # crate's `tsp` feature and are NOT reachable via `affinidi-tdk/tsp`. The crate
-# is already present transitively via `affinidi-tdk` at the same 0.18.x; this
+# is already present transitively via `affinidi-tdk` at the same 0.19.x; this
 # entry adds no new code when `tsp` is off (optional + default-features off).
-affinidi-messaging-sdk = { version = "0.18", optional = true, default-features = false }
+affinidi-messaging-sdk = { version = "0.19", optional = true, default-features = false }
 async-trait = "0.1"
 affinidi-tdk-common = "0.6"
 affinidi-did-resolver-cache-sdk = { workspace = true }

--- a/vti-common/Cargo.toml
+++ b/vti-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-common"
 description = "Shared server-side infrastructure for VTA and VTC services"
 readme = "README.md"
-version = "0.11.34"
+version = "0.11.35"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vti-common/src/auth/didcomm.rs
+++ b/vti-common/src/auth/didcomm.rs
@@ -125,12 +125,14 @@ mod tests {
 
     /// Unpack metadata with the given authcrypt flags + sender key id.
     fn meta(encrypted: bool, authenticated: bool, kid: Option<&str>) -> UnpackMetadata {
-        UnpackMetadata {
-            encrypted,
-            authenticated,
-            encrypted_from_kid: kid.map(str::to_string),
-            ..Default::default()
-        }
+        // `UnpackMetadata` is `#[non_exhaustive]` as of affinidi-messaging-sdk
+        // 0.19, so it can't be built with a struct literal from here — start
+        // from `Default` and assign the fields under test.
+        let mut m = UnpackMetadata::default();
+        m.encrypted = encrypted;
+        m.authenticated = authenticated;
+        m.encrypted_from_kid = kid.map(str::to_string);
+        m
     }
 
     /// Happy path: authcrypt with a `from` matching the authenticated key's DID


### PR DESCRIPTION
…0.19)

Bump affinidi-tdk 0.8->0.8.5 (pulls affinidi-messaging-sdk 0.19.0 + affinidi-messaging-didcomm 0.15.8) and the direct affinidi-messaging-sdk pins in vta-sdk/vta-service/e2e from 0.18 to 0.19, so the tsp feature and the e2e mediator fixture resolve to the same 0.19 line the default build gets transitively. This is upstream affinidi-tdk-rs #671: unpack now rejects plaintext/anoncrypt/forged-from envelopes by default. sdk 0.19 makes UnpackMetadata #[non_exhaustive]; the meta() test helper in vti-common/src/auth/didcomm.rs switches from a struct literal to Default + field assignment. No production behaviour change; the existing bind_authcrypt_sender guard and DIDComm inbound_gate remain as defence in depth.
Bumps vti-common 0.11.35 / vta-sdk 0.21.7 / vta-service 0.14.11.