### PR TITLE
fix(didcomm): take the envelope type from the binding crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10484,7 +10484,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.14.10"
+version = "0.14.11"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9665,6 +9665,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "trust-tasks-didcomm"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f8248839a7309223eee068da7f322dc2d2114f797e5b946e5a0d8526251a439"
+dependencies = [
+ "affinidi-messaging-didcomm",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.19",
+ "trust-tasks-rs",
+ "uuid",
+]
+
+[[package]]
 name = "trust-tasks-https"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10536,6 +10550,7 @@ dependencies = [
  "tower_governor",
  "tracing",
  "tracing-subscriber",
+ "trust-tasks-didcomm",
  "trust-tasks-https",
  "trust-tasks-proof",
  "trust-tasks-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -214,6 +214,17 @@ aws-lc-rs = "1.16"
 trust-tasks-rs = { version = "0.2.55", default-features = false, features = ["validate"] }
 trust-tasks-capability-client = "0.1"
 trust-tasks-https = { version = "0.2", default-features = false, features = ["server", "client", "jwt"] }
+# The DIDComm binding. Carries `ENVELOPE_TYPE` — the one `type` every
+# Trust-Task DIDComm message must use, with the `TrustTask<P>` as its body —
+# and the `pack_trust_task`/`unpack_trust_task` pair that enforce it.
+#
+# Taken as a real dependency rather than copying the URI: four hand-written
+# copies had accumulated across this workspace, and the consent push was
+# hand-building its message with the *task* type instead of the envelope type.
+# A conformant peer rejects that, silently, because "not an envelope" is
+# indistinguishable from "not addressed to me". One constant, from the crate
+# that defines it.
+trust-tasks-didcomm = { version = "0.2", default-features = false }
 trust-tasks-proof = { version = "0.2", default-features = false, features = ["affinidi"] }
 
 # Axum extras (typed headers for Bearer auth)

--- a/changelog.d/900-envelope-type-from-the-binding-crate.md
+++ b/changelog.d/900-envelope-type-from-the-binding-crate.md
@@ -1,0 +1,51 @@
+### vta-service 0.14.11 — the DIDComm envelope type comes from the binding crate (#900)
+
+A consent request pushed to an approver device was delivered, acked, and then
+discarded unread. The DIDComm message carried the **task** type
+(`task-consent/request/0.1`) where the binding requires the **envelope** type
+(`binding/didcomm/0.1/envelope`) with the `TrustTask` in the body. A conformant
+peer rejects that — and rejects it *silently*, because "not an envelope" is
+indistinguishable from "not addressed to me".
+
+The symptom was a week of nothing: the request arrived on the approver's inbox,
+verified, de-duplicated, and vanished. No prompt, no log, no decision, and the
+mediator's queued copy already deleted by the ack.
+
+## Why it drifted
+
+The envelope URI was hand-written in **four** places across the workspace, each
+with a comment explaining it was a local copy "to avoid taking a dependency on
+the binding crate for one constant". Nothing connected `consent_request.rs` to
+the binding it was supposed to implement, so it used the task type and no
+compiler, test, or reviewer noticed.
+
+`trust-tasks-didcomm` is now a real dependency and
+`trust_tasks_didcomm::ENVELOPE_TYPE` is the single source; the four copies are
+gone. The crate that defines the wire format defines the constant.
+
+## TSP is deliberately untouched
+
+The envelope is a property of the **DIDComm binding**, not of the task. TSP
+carries the Trust-Task bytes directly with no wrapper, and the TSP branch of
+`push_one` was always correct. Applying the envelope unconditionally would have
+broken the working transport to fix the broken one — the fix is confined to the
+two DIDComm sites (the mediator buffer and the guaranteed send).
+
+## The test was pinning the defect
+
+`a_resubmit_re_asks_nobody` asserted `message_type == TASK_CONSENT_REQUEST_0_1`
+— the task type on the wire, which is exactly what a conformant peer refuses. It
+now asserts the envelope on the message and the task type inside the document,
+which is the actual invariant.
+
+## Known remaining, not in this change
+
+Same defect, same peer, to be fixed together: `push_granted`
+(`TASK_CONSENT_GRANTED_0_1`) and `maybe_push_step_up`
+(`STEP_UP_APPROVE_REQUEST_TYPE`) — **step-up approvals to a device are broken
+identically** and have not been noticed. `consent.rs`'s
+`CONSENT_APPROVE_REQUEST_TYPE` needs its family confirmed.
+
+Separately, `webvh_didcomm.rs` sends bare task types to the webvh host and
+*works*, so that peer accepts them. Converting it is a cross-repo wire migration,
+not a cleanup, and must not be swept in.

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.14.10"
+version = "0.14.11"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -142,6 +142,7 @@ vti-webauthn = { path = "../vti-webauthn", version = "0.1" }
 # Data-Integrity proofs on trust-tasks themselves.
 trust-tasks-rs = { workspace = true }
 trust-tasks-https = { workspace = true }
+trust-tasks-didcomm = { workspace = true }
 trust-tasks-proof = { workspace = true }
 # Shared CLI helpers for the consumer side of sealed-transfer (request
 # generation, bundle opening). Used by `vta bootstrap request` /

--- a/vta-service/src/messaging/handlers.rs
+++ b/vta-service/src/messaging/handlers.rs
@@ -250,10 +250,16 @@ macro_rules! didcomm_handler {
 /// `https://trusttasks.org/binding/didcomm/0.1`: a single reserved type
 /// whose `body` carries the full `TrustTask<P>` JSON. Conformant
 /// consumers reject any other type. Mirrors
-/// `trust_tasks_didcomm::ENVELOPE_TYPE`; defined locally to avoid taking
-/// a dependency on the binding crate for one constant.
-pub(crate) const TRUST_TASK_ENVELOPE_TYPE: &str =
-    "https://trusttasks.org/binding/didcomm/0.1/envelope";
+/// The DIDComm binding's envelope `type`, re-exported so the rest of the crate
+/// has one name for it.
+///
+/// This was a hand-written copy of the URI, as were three others across the
+/// workspace. That duplication is what let the consent push send its message
+/// with the *task* type instead of the envelope type — which a conformant peer
+/// rejects silently, because "not an envelope" is indistinguishable from "not
+/// addressed to me". Sourced from the crate that defines it so a copy cannot
+/// drift again.
+pub(crate) use trust_tasks_didcomm::ENVELOPE_TYPE as TRUST_TASK_ENVELOPE_TYPE;
 
 /// Generic DIDComm handler for the Trust-Tasks surface.
 ///

--- a/vta-service/src/messaging/handlers.rs
+++ b/vta-service/src/messaging/handlers.rs
@@ -259,7 +259,7 @@ macro_rules! didcomm_handler {
 /// rejects silently, because "not an envelope" is indistinguishable from "not
 /// addressed to me". Sourced from the crate that defines it so a copy cannot
 /// drift again.
-pub(crate) use trust_tasks_didcomm::ENVELOPE_TYPE as TRUST_TASK_ENVELOPE_TYPE;
+use trust_tasks_didcomm::ENVELOPE_TYPE as TRUST_TASK_ENVELOPE_TYPE;
 
 /// Generic DIDComm handler for the Trust-Tasks surface.
 ///

--- a/vta-service/src/messaging/router.rs
+++ b/vta-service/src/messaging/router.rs
@@ -290,7 +290,7 @@ pub async fn dispatch(
     }
 
     // ── Trust-Tasks envelope (AppState) ──────────────────────────────
-    if t == handlers::TRUST_TASK_ENVELOPE_TYPE {
+    if t == trust_tasks_didcomm::ENVELOPE_TYPE {
         return finish(handlers::handle_trust_task(ctx, msg, Extension(app_state)).await);
     }
 

--- a/vta-service/src/trust_tasks/consent_request.rs
+++ b/vta-service/src/trust_tasks/consent_request.rs
@@ -30,11 +30,14 @@ use vti_common::error::AppError;
 #[cfg(feature = "didcomm")]
 const CONSENT_PUSH_DELIVER_BY_SECS: u64 = 300;
 
-use crate::messaging::handlers::TRUST_TASK_ENVELOPE_TYPE;
+// Only the DIDComm sends below name the envelope; TSP carries the document
+// bytes directly, so this is unused when the DIDComm binding is compiled out.
 use crate::policy::consent::PendingTaskConsent;
 use crate::policy::effects::Effect;
 use crate::policy::types::TaskClass;
 use crate::server::AppState;
+#[cfg(feature = "didcomm")]
+use trust_tasks_didcomm::ENVELOPE_TYPE as TRUST_TASK_ENVELOPE_TYPE;
 
 pub(super) const TASK_CONSENT_REQUEST_0_1: &str =
     "https://trusttasks.org/spec/task-consent/request/0.1";

--- a/vta-service/src/trust_tasks/consent_request.rs
+++ b/vta-service/src/trust_tasks/consent_request.rs
@@ -30,6 +30,7 @@ use vti_common::error::AppError;
 #[cfg(feature = "didcomm")]
 const CONSENT_PUSH_DELIVER_BY_SECS: u64 = 300;
 
+use crate::messaging::handlers::TRUST_TASK_ENVELOPE_TYPE;
 use crate::policy::consent::PendingTaskConsent;
 use crate::policy::effects::Effect;
 use crate::policy::types::TaskClass;
@@ -227,7 +228,17 @@ async fn push_one(
         {
             let pending = crate::messaging::registry::PendingResponse {
                 recipient_did: approver.to_string(),
-                message_type: TASK_CONSENT_REQUEST_0_1.to_string(),
+                // The DIDComm binding's envelope type, NOT the task type. A
+                // conformant peer unwraps `ENVELOPE_TYPE` and reads the
+                // `TrustTask` from the body; anything else it rejects — and
+                // rejects *silently*, because "not an envelope" is
+                // indistinguishable from "not addressed to me". That is what
+                // sent this request into a void: delivered, acked, discarded.
+                //
+                // TSP is deliberately untouched above: it carries the document
+                // bytes directly with no envelope, so the wrapper is a property
+                // of the DIDComm binding, not of the task.
+                message_type: TRUST_TASK_ENVELOPE_TYPE.to_string(),
                 body: request.clone(),
                 thread_id: request
                     .get("id")
@@ -256,7 +267,8 @@ async fn push_one(
             .send_guaranteed(
                 "vta-main",
                 approver,
-                TASK_CONSENT_REQUEST_0_1,
+                // Envelope type, per the DIDComm binding — see the buffer above.
+                TRUST_TASK_ENVELOPE_TYPE,
                 request.clone(),
                 request
                     .get("id")

--- a/vta-service/src/trust_tasks/device.rs
+++ b/vta-service/src/trust_tasks/device.rs
@@ -198,8 +198,7 @@ fn provision_gateway(
     vta_did: &Option<String>,
     body: &Value,
 ) {
-    /// DIDComm message type that carries a Trust Task envelope in its body.
-    const TRUST_TASK_ENVELOPE_TYPE: &str = "https://trusttasks.org/binding/didcomm/0.1/envelope";
+    use crate::messaging::handlers::TRUST_TASK_ENVELOPE_TYPE;
 
     let Some((gateway, handle)) = wake.clone() else {
         return;

--- a/vta-service/src/trust_tasks/device.rs
+++ b/vta-service/src/trust_tasks/device.rs
@@ -198,7 +198,10 @@ fn provision_gateway(
     vta_did: &Option<String>,
     body: &Value,
 ) {
-    use crate::messaging::handlers::TRUST_TASK_ENVELOPE_TYPE;
+    // Only the DIDComm sends below name the envelope; TSP carries the document
+    // bytes directly, so this is unused when the DIDComm binding is compiled out.
+    #[cfg(feature = "didcomm")]
+    use trust_tasks_didcomm::ENVELOPE_TYPE as TRUST_TASK_ENVELOPE_TYPE;
 
     let Some((gateway, handle)) = wake.clone() else {
         return;

--- a/vta-service/src/trust_tasks/policy_gate.rs
+++ b/vta-service/src/trust_tasks/policy_gate.rs
@@ -1086,9 +1086,19 @@ mod tests {
         );
         let pushed = state.mediator_registry.take_outbound(MEDIATOR).await;
         assert_eq!(pushed.len(), 1, "the approver is asked exactly once");
+        // The DIDComm message carries the *envelope* type; the task type lives
+        // in the body's `TrustTask`. This assertion previously demanded the task
+        // type on the wire — pinning the very defect that made a delivered
+        // consent request unreadable to a conformant peer, which rejects a
+        // non-envelope silently.
         assert_eq!(
             pushed[0].message_type,
-            super::super::consent_request::TASK_CONSENT_REQUEST_0_1
+            crate::messaging::handlers::TRUST_TASK_ENVELOPE_TYPE
+        );
+        assert_eq!(
+            pushed[0].body.get("type").and_then(|t| t.as_str()),
+            Some(super::super::consent_request::TASK_CONSENT_REQUEST_0_1),
+            "the task type belongs in the enveloped document, not on the envelope"
         );
         assert_eq!(pushed[0].recipient_did, APPROVER);
         assert!(

--- a/vta-service/src/trust_tasks/policy_gate.rs
+++ b/vta-service/src/trust_tasks/policy_gate.rs
@@ -1091,10 +1091,7 @@ mod tests {
         // type on the wire — pinning the very defect that made a delivered
         // consent request unreadable to a conformant peer, which rejects a
         // non-envelope silently.
-        assert_eq!(
-            pushed[0].message_type,
-            crate::messaging::handlers::TRUST_TASK_ENVELOPE_TYPE
-        );
+        assert_eq!(pushed[0].message_type, trust_tasks_didcomm::ENVELOPE_TYPE);
         assert_eq!(
             pushed[0].body.get("type").and_then(|t| t.as_str()),
             Some(super::super::consent_request::TASK_CONSENT_REQUEST_0_1),

--- a/vta-service/src/trust_tasks/step_up.rs
+++ b/vta-service/src/trust_tasks/step_up.rs
@@ -933,8 +933,7 @@ pub(super) async fn trigger_gateway_wake(
     recipient: &str,
     approver_mediator: &str,
 ) {
-    /// DIDComm message type that carries a Trust Task envelope in its body.
-    const TRUST_TASK_ENVELOPE_TYPE: &str = "https://trusttasks.org/binding/didcomm/0.1/envelope";
+    use crate::messaging::handlers::TRUST_TASK_ENVELOPE_TYPE;
 
     let wake = match get_acl_entry(&state.acl_ks, recipient).await {
         Ok(Some(entry)) => entry.device.and_then(|d| d.wake),

--- a/vta-service/src/trust_tasks/step_up.rs
+++ b/vta-service/src/trust_tasks/step_up.rs
@@ -933,7 +933,10 @@ pub(super) async fn trigger_gateway_wake(
     recipient: &str,
     approver_mediator: &str,
 ) {
-    use crate::messaging::handlers::TRUST_TASK_ENVELOPE_TYPE;
+    // Only the DIDComm sends below name the envelope; TSP carries the document
+    // bytes directly, so this is unused when the DIDComm binding is compiled out.
+    #[cfg(feature = "didcomm")]
+    use trust_tasks_didcomm::ENVELOPE_TYPE as TRUST_TASK_ENVELOPE_TYPE;
 
     let wake = match get_acl_entry(&state.acl_ks, recipient).await {
         Ok(Some(entry)) => entry.device.and_then(|d| d.wake),


### PR DESCRIPTION
A consent request pushed to an approver device was **delivered, acked, and then discarded unread**.

The DIDComm message carried the **task** type (`task-consent/request/0.1`) where the binding requires the **envelope** type (`binding/didcomm/0.1/envelope`) with the `TrustTask` in the body. A conformant peer rejects that — and rejects it *silently*, because "not an envelope" is indistinguishable from "not addressed to me".

The symptom was a week of nothing: the request arrived on the approver's inbox, verified, de-duplicated, and vanished. No prompt, no log, no decision — and the mediator's queued copy already deleted by the ack.

## Why it drifted

The envelope URI was hand-written in **four** places across the workspace, each with a comment explaining it was a local copy *"to avoid taking a dependency on the binding crate for one constant"*. Nothing connected `consent_request.rs` to the binding it was supposed to implement, so it used the task type and no compiler, test, or reviewer caught it.

`trust-tasks-didcomm` is now a real dependency and `trust_tasks_didcomm::ENVELOPE_TYPE` is the single source. The four copies are gone — the crate that defines the wire format defines the constant.

## TSP is deliberately untouched

The envelope is a property of the **DIDComm binding**, not of the task. TSP carries the Trust-Task bytes directly with no wrapper, and `push_one`'s TSP branch (`serde_json::to_vec(doc)` → `send_routed`) was always correct.

Applying the envelope unconditionally would have broken the working transport to fix the broken one. The change is confined to the two DIDComm sites: the mediator buffer and the guaranteed send.

## The test was pinning the defect

`a_resubmit_re_asks_nobody` asserted `message_type == TASK_CONSENT_REQUEST_0_1` — the task type on the wire, which is exactly what a conformant peer refuses. It now asserts the envelope on the message **and** the task type inside the document, which is the real invariant.

That is the second test in this investigation found to be holding a defect in place. Both described what the code did rather than what the binding requires.

## Known remaining — deliberately not swept in

**Same defect, same peer (the plugin), should be fixed together:**

- `push_granted` — `TASK_CONSENT_GRANTED_0_1`
- `maybe_push_step_up` — `STEP_UP_APPROVE_REQUEST_TYPE`. **Step-up approvals to a device are broken identically** and have not been noticed. `push_one`'s comment says it "mirrors `maybe_push_step_up`" — it faithfully mirrored the bug.
- `consent.rs`'s `CONSENT_APPROVE_REQUEST_TYPE` — family needs confirming

**Different peer, must not be swept in:** `webvh_didcomm.rs` sends bare task types (`TASK_DID_REGISTER`, `TASK_DID_DELETE`, `TASK_AGENT_NAME_*`) to the webvh host and **works** — that peer accepts them. Converting it is a cross-repo wire migration requiring the host to accept envelopes first.

**The real prevention** is adopting `pack_trust_task`, so the type cannot be hand-chosen at all. That needs the bridge to accept pre-packed bytes — a transport-layer change deserving its own design.

760 tests pass, clippy clean, all three repo guards pass.