### PR TITLE
fix(didcomm): the last three device pushes carry the envelope type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10721,7 +10721,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.14.12"
+version = "0.14.13"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/changelog.d/903-envelope-type-remaining-pushes.md
+++ b/changelog.d/903-envelope-type-remaining-pushes.md
@@ -1,0 +1,57 @@
+### vta-service 0.14.13 — the last three device pushes carry the envelope type (#903)
+
+#901 fixed the consent-request push and named three sites it had not reached.
+This is those three. Same defect, same binding rule, same silence: the DIDComm
+message carried the **task** type where `trust_tasks_didcomm::ENVELOPE_TYPE` is
+required with the `TrustTask` in the body, and a conformant peer rejects that
+without saying so — "not an envelope" is indistinguishable from "not addressed
+to me".
+
+| site | protocol family | what the breakage cost |
+|---|---|---|
+| `push_granted` | `task-consent/*` | a requester waits for its next poll instead of re-submitting at once |
+| `maybe_push_step_up` | `auth/step-up/*` | **delegated step-up approvals never reached the device** |
+| `maybe_wake_consent_approver` | `consent/*` | a `wake`-routed approver is never roused |
+
+## The one that mattered
+
+`maybe_push_step_up` had been broken the entire time and nothing surfaced it.
+The reject still carries the `approveRequest` as a relay fallback, so the
+ceremony completes by the slow route while the proactive push lands in a void —
+delivered, acked, unreadable. A push whose only failure mode is *latency* is a
+push nobody notices is dead.
+
+## Protocol family, confirmed rather than assumed
+
+`consent/approve-request/0.1` belongs to **`spec/consent/*`** — the conversation
+consent family (`request` / `decision` / `revoke` / `list`, all `1.0`) — not to
+`spec/task-consent/*`, which is the per-task RP→wallet family `consent_request.rs`
+serves. The distinction does not change the fix: neither family puts its task
+type on the DIDComm envelope, because the envelope belongs to the binding, not
+the task.
+
+## Also
+
+`STEP_UP_APPROVE_REQUEST_TYPE` was the DIDComm message type *and* the document
+type. Now it is only the document type — and `mint_pending_step_up` reads the
+constant instead of repeating the literal, so the two cannot drift. Its
+`#[cfg(feature = "didcomm")]` gate came off with that move: the mint site is not
+DIDComm-specific.
+
+TSP is untouched, deliberately. It carries the document bytes directly
+(`serde_json::to_vec(doc)` → `send_routed`), so the wrapper is a property of the
+DIDComm binding. Every `ENVELOPE_TYPE` import is `#[cfg]`-gated to the feature
+combination that actually sends over DIDComm, so reduced builds neither break nor
+carry an unused import.
+
+## Tests
+
+Four new tests, each asserting the **envelope on the message** and the **task
+type inside the document** — the shape #901 established when it un-pinned
+`a_resubmit_re_asks_nobody`. Verified to actually catch the defect: reinstating
+the old `message_type` on the step-up push fails
+`delegated_step_up_push_is_an_envelope` with the task URI on the left and the
+envelope URI on the right.
+
+`vta-service` compiles clean at `--no-default-features` and with each of
+`didcomm`, `rest`, `tsp`, `didcomm,tsp`, `rest,didcomm,webvh,tsp`.

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.14.12"
+version = "0.14.13"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/trust_tasks/consent.rs
+++ b/vta-service/src/trust_tasks/consent.rs
@@ -15,6 +15,11 @@
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+// Carries the same gate as `CONSENT_APPROVE_REQUEST_TYPE` below: its only use is
+// the mediator-registry buffer, which needs the `webvh`-gated
+// `AppState::mediator_registry`. From the binding crate, never copied (#900).
+#[cfg(all(feature = "didcomm", feature = "webvh"))]
+use trust_tasks_didcomm::ENVELOPE_TYPE as TRUST_TASK_ENVELOPE_TYPE;
 use trust_tasks_rs::TrustTask;
 use uuid::Uuid;
 
@@ -377,7 +382,18 @@ async fn maybe_wake_consent_approver(
         });
         let pending = crate::messaging::registry::PendingResponse {
             recipient_did: approver.to_string(),
-            message_type: CONSENT_APPROVE_REQUEST_TYPE.to_string(),
+            // Envelope type, not the task type. `approve_request` above is a
+            // Trust Task document (`id`/`type`/`payload`) and the DIDComm
+            // binding requires it in the body of an `ENVELOPE_TYPE` message; a
+            // conformant approver silently rejects anything else. Same defect,
+            // same fix as the task-consent request (#900) and the step-up push.
+            //
+            // `CONSENT_APPROVE_REQUEST_TYPE` is still the document's own `type`
+            // — it belongs to the `spec/consent/*` family (the conversation
+            // consent protocol: request / decision / revoke / list), not to the
+            // `spec/task-consent/*` family that `consent_request.rs` serves.
+            // Neither family puts its task type on the DIDComm envelope.
+            message_type: TRUST_TASK_ENVELOPE_TYPE.to_string(),
             body: approve_request.clone(),
             thread_id: approve_request
                 .get("id")
@@ -742,5 +758,79 @@ mod tests {
         assert!(v.get("routeHint").is_none());
         let list = serde_json::to_value(ApproverListResponse { approvers: vec![] }).unwrap();
         assert_eq!(list["approvers"], serde_json::json!([]));
+    }
+}
+
+#[cfg(all(test, feature = "didcomm", feature = "webvh"))]
+mod envelope_push_tests {
+    use crate::messaging::registry::MediatorBinding;
+    use serde_json::json;
+    use vti_common::consent::ConsentScope;
+
+    const MEDIATOR: &str = "did:example:mediator";
+    const APPROVER: &str = "did:key:zConsentApprover";
+
+    /// The Track-B wake prompt goes out under the **envelope** type, with the
+    /// task type inside the document.
+    ///
+    /// Same defect as the task-consent request (#900) and the step-up push, in a
+    /// different protocol family: this one is `spec/consent/*` (conversation
+    /// consent), not `spec/task-consent/*`. Neither family puts its task type on
+    /// the DIDComm envelope — the envelope belongs to the binding, not the task.
+    #[tokio::test]
+    async fn consent_approve_request_is_pushed_as_an_envelope() {
+        let (state, _dir) = crate::test_support::build_signing_test_app_state().await;
+
+        state
+            .mediator_registry
+            .record_activate(MediatorBinding {
+                mediator_did: MEDIATOR.into(),
+                endpoint: "https://mediator.test".into(),
+            })
+            .await;
+        {
+            let mut cfg = state.config.write().await;
+            cfg.messaging = Some(vti_common::config::MessagingConfig {
+                mediator_url: String::new(),
+                mediator_did: MEDIATOR.into(),
+                mediator_host: None,
+                setup_acl: false,
+                drain_inbox_on_start: false,
+            });
+        }
+
+        let subject = json!({
+            "platform": "signal",
+            "conversationRef": "conv-1",
+            "kind": "dm",
+            "agent": "did:key:zAgent",
+        });
+        super::maybe_wake_consent_approver(
+            &state,
+            APPROVER,
+            subject,
+            ConsentScope::Converse,
+            "challenge-xyz",
+        )
+        .await;
+
+        let pushed = state.mediator_registry.take_outbound(MEDIATOR).await;
+        assert_eq!(pushed.len(), 1, "the approver is roused exactly once");
+        assert_eq!(
+            pushed[0].message_type,
+            trust_tasks_didcomm::ENVELOPE_TYPE,
+            "the DIDComm message must carry the binding's envelope type"
+        );
+        assert_eq!(
+            pushed[0].body.get("type").and_then(|t| t.as_str()),
+            Some(super::CONSENT_APPROVE_REQUEST_TYPE),
+            "the task type belongs in the enveloped document, not on the envelope"
+        );
+        assert_eq!(pushed[0].recipient_did, APPROVER);
+        assert_eq!(
+            pushed[0].body["payload"]["challenge"].as_str(),
+            Some("challenge-xyz"),
+            "the challenge the approver signs against must survive the re-wrap"
+        );
     }
 }

--- a/vta-service/src/trust_tasks/consent_request.rs
+++ b/vta-service/src/trust_tasks/consent_request.rs
@@ -362,8 +362,12 @@ pub(super) async fn push_granted(
         #[cfg(feature = "webvh")]
         {
             let pending = crate::messaging::registry::PendingResponse {
+                // Envelope type, not the task type — same binding rule as the
+                // request push above. `body` is already a full `TrustTask`
+                // document (it has to be: the binding deserialises the body as
+                // `TrustTask<P>`), so the only thing wrong here was the wrapper.
+                message_type: TRUST_TASK_ENVELOPE_TYPE.to_string(),
                 recipient_did: requester.to_string(),
-                message_type: TASK_CONSENT_GRANTED_0_1.to_string(),
                 body: body.clone(),
                 thread_id: Some(wire_digest.to_string()),
             };
@@ -384,7 +388,8 @@ pub(super) async fn push_granted(
             .send_guaranteed(
                 "vta-main",
                 requester,
-                TASK_CONSENT_GRANTED_0_1,
+                // Envelope type, per the DIDComm binding — see the buffer above.
+                TRUST_TASK_ENVELOPE_TYPE,
                 body,
                 Some(format!("granted:{wire_digest}")),
                 Duration::from_secs(CONSENT_PUSH_DELIVER_BY_SECS),
@@ -398,5 +403,70 @@ pub(super) async fn push_granted(
         }
 
         super::step_up::trigger_gateway_wake(state, requester, &mediator_did).await;
+    }
+}
+
+#[cfg(all(test, feature = "didcomm", feature = "webvh"))]
+mod tests {
+    use crate::messaging::registry::MediatorBinding;
+
+    const MEDIATOR: &str = "did:example:mediator";
+    const REQUESTER: &str = "did:key:zRequester";
+
+    /// The granted notice goes out under the **envelope** type, with the task
+    /// type inside the document.
+    ///
+    /// It had the same defect as the request push (#900) and was invisible for
+    /// the same reason: a conformant peer that cannot read the envelope drops it
+    /// silently, and the requester's fallback is to re-submit anyway — so the
+    /// only symptom was a poll cycle nobody was measuring.
+    #[tokio::test]
+    async fn granted_notice_is_pushed_as_an_envelope() {
+        let (state, _dir) = crate::test_support::build_signing_test_app_state().await;
+
+        state
+            .mediator_registry
+            .record_activate(MediatorBinding {
+                mediator_did: MEDIATOR.into(),
+                endpoint: "https://mediator.test".into(),
+            })
+            .await;
+        {
+            let mut cfg = state.config.write().await;
+            cfg.messaging = Some(vti_common::config::MessagingConfig {
+                mediator_url: String::new(),
+                mediator_did: MEDIATOR.into(),
+                mediator_host: None,
+                setup_acl: false,
+                drain_inbox_on_start: false,
+            });
+        }
+
+        super::push_granted(
+            &state,
+            REQUESTER,
+            "digest-abc",
+            "https://example.org/task/1.0",
+        )
+        .await;
+
+        let pushed = state.mediator_registry.take_outbound(MEDIATOR).await;
+        assert_eq!(pushed.len(), 1, "the requester is notified exactly once");
+        assert_eq!(
+            pushed[0].message_type,
+            trust_tasks_didcomm::ENVELOPE_TYPE,
+            "the DIDComm message must carry the binding's envelope type"
+        );
+        assert_eq!(
+            pushed[0].body.get("type").and_then(|t| t.as_str()),
+            Some(super::TASK_CONSENT_GRANTED_0_1),
+            "the task type belongs in the enveloped document, not on the envelope"
+        );
+        assert_eq!(pushed[0].recipient_did, REQUESTER);
+        // The payload the requester acts on must survive the re-wrap.
+        assert_eq!(
+            pushed[0].body["payload"]["payloadDigest"].as_str(),
+            Some("digest-abc")
+        );
     }
 }

--- a/vta-service/src/trust_tasks/step_up.rs
+++ b/vta-service/src/trust_tasks/step_up.rs
@@ -39,6 +39,11 @@ use base64::Engine as _;
 use base64::engine::general_purpose;
 use serde_json::{Value, json};
 use trust_tasks_rs::specs::auth::step_up::approve_response::v0_1 as approve_response;
+// Only the DIDComm sends name the envelope; TSP carries the document bytes
+// directly, so this is unused when the binding is compiled out. Imported from the
+// binding crate rather than copied — one source, no local literals (#900).
+#[cfg(feature = "didcomm")]
+use trust_tasks_didcomm::ENVELOPE_TYPE as TRUST_TASK_ENVELOPE_TYPE;
 #[cfg(feature = "didcomm")]
 use trust_tasks_rs::specs::push::wake::v0_2 as push_wake;
 use trust_tasks_rs::{RejectReason, TrustTask};
@@ -611,7 +616,7 @@ async fn mint_pending_step_up(
 
     let mut doc = json!({
         "id": format!("urn:uuid:{}", Uuid::new_v4()),
-        "type": "https://trusttasks.org/spec/auth/step-up/approve-request/0.2",
+        "type": STEP_UP_APPROVE_REQUEST_TYPE,
         "issuer": vta_did,
         "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         "payload": {
@@ -740,11 +745,16 @@ fn step_up_denied_response() -> Response {
         .into_response()
 }
 
-/// Trust Task `type` of a step-up approve-request (also the DIDComm message
-/// `type` used when pushing one to an approver). 0.2 — matches the minted
-/// document; both fielded approver stacks (vta-mobile-core #871, the browser
-/// plugin) accept 0.1 and 0.2 request URIs.
-#[cfg(feature = "didcomm")]
+/// Trust Task `type` of a step-up approve-request. 0.2 — both fielded approver
+/// stacks (vta-mobile-core #871, the browser plugin) accept 0.1 and 0.2 request
+/// URIs.
+///
+/// This is the **document's** type, and only that. It is no longer the DIDComm
+/// message type: that is `trust_tasks_didcomm::ENVELOPE_TYPE`, and naming this
+/// one there is precisely the defect fixed in this change. `mint_pending_step_up`
+/// now reads the constant instead of repeating the literal, so the document and
+/// this name cannot drift apart — which is why the gate came off, the mint site
+/// not being DIDComm-specific.
 const STEP_UP_APPROVE_REQUEST_TYPE: &str =
     "https://trusttasks.org/spec/auth/step-up/approve-request/0.2";
 
@@ -864,7 +874,22 @@ async fn maybe_push_step_up(
         {
             let pending = crate::messaging::registry::PendingResponse {
                 recipient_did: recipient.to_string(),
-                message_type: STEP_UP_APPROVE_REQUEST_TYPE.to_string(),
+                // The DIDComm binding's envelope type, NOT the task type. A
+                // conformant approver unwraps `ENVELOPE_TYPE` and reads the
+                // `TrustTask` from the body; anything else it rejects, and
+                // rejects *silently* — "not an envelope" is indistinguishable
+                // from "not addressed to me". This path had the same defect as
+                // the consent request (#900) and nobody noticed, because the
+                // relay fallback below hides it: the reject still carries the
+                // approveRequest, so the flow completes via the slow path and
+                // only the proactive push is dead.
+                //
+                // `STEP_UP_APPROVE_REQUEST_TYPE` remains the document's own
+                // `type` — it moved into the envelope, it did not disappear.
+                // TSP is untouched above: it carries the document bytes
+                // directly, so the wrapper belongs to the DIDComm binding, not
+                // to the task.
+                message_type: TRUST_TASK_ENVELOPE_TYPE.to_string(),
                 body: approve_request.clone(),
                 thread_id: approve_request
                     .get("id")
@@ -897,7 +922,8 @@ async fn maybe_push_step_up(
             .send_guaranteed(
                 "vta-main",
                 recipient,
-                STEP_UP_APPROVE_REQUEST_TYPE,
+                // Envelope type, per the DIDComm binding — see the buffer above.
+                TRUST_TASK_ENVELOPE_TYPE,
                 approve_request.clone(),
                 approve_request
                     .get("id")
@@ -933,11 +959,6 @@ pub(super) async fn trigger_gateway_wake(
     recipient: &str,
     approver_mediator: &str,
 ) {
-    // Only the DIDComm sends below name the envelope; TSP carries the document
-    // bytes directly, so this is unused when the DIDComm binding is compiled out.
-    #[cfg(feature = "didcomm")]
-    use trust_tasks_didcomm::ENVELOPE_TYPE as TRUST_TASK_ENVELOPE_TYPE;
-
     let wake = match get_acl_entry(&state.acl_ks, recipient).await {
         Ok(Some(entry)) => entry.device.and_then(|d| d.wake),
         _ => None,
@@ -1636,5 +1657,95 @@ mod tests {
             verify_did_signed_gate(&doc, &did).await,
             Err(GateError::ProofInvalid(_))
         ));
+    }
+}
+
+#[cfg(all(test, feature = "didcomm", feature = "webvh"))]
+mod envelope_push_tests {
+    use crate::messaging::registry::MediatorBinding;
+    use serde_json::json;
+
+    const MEDIATOR: &str = "did:example:mediator";
+    const APPROVER: &str = "did:key:zStepUpApprover";
+    const CALLER: &str = "did:key:zCaller";
+
+    /// The delegated step-up push goes out under the **envelope** type, with the
+    /// task type inside the document.
+    ///
+    /// This one mattered most and showed least. Step-up approvals to a device
+    /// were broken on this path the whole time, and nothing surfaced it: the
+    /// reject still carries the `approveRequest` as a relay fallback, so the
+    /// ceremony completes by the slow route while the proactive push lands in a
+    /// void — delivered, acked, unreadable.
+    #[tokio::test]
+    async fn delegated_step_up_push_is_an_envelope() {
+        let (state, _dir) = crate::test_support::build_signing_test_app_state().await;
+
+        state
+            .mediator_registry
+            .record_activate(MediatorBinding {
+                mediator_did: MEDIATOR.into(),
+                endpoint: "https://mediator.test".into(),
+            })
+            .await;
+        {
+            let mut cfg = state.config.write().await;
+            cfg.messaging = Some(vti_common::config::MessagingConfig {
+                mediator_url: String::new(),
+                mediator_did: MEDIATOR.into(),
+                mediator_host: None,
+                setup_acl: false,
+                drain_inbox_on_start: false,
+            });
+        }
+
+        // The shape `mint_pending_step_up` produces: a Trust Task document whose
+        // own `type` is the approve-request URI.
+        let approve_request = json!({
+            "id": "urn:uuid:11111111-1111-1111-1111-111111111111",
+            "type": super::STEP_UP_APPROVE_REQUEST_TYPE,
+            "issuer": "did:key:zVta",
+            "payload": { "subject": CALLER, "challenge": "c" },
+        });
+
+        super::maybe_push_step_up(&state, APPROVER, CALLER, &approve_request).await;
+
+        let pushed = state.mediator_registry.take_outbound(MEDIATOR).await;
+        assert_eq!(pushed.len(), 1, "the approver is pushed exactly once");
+        assert_eq!(
+            pushed[0].message_type,
+            trust_tasks_didcomm::ENVELOPE_TYPE,
+            "the DIDComm message must carry the binding's envelope type"
+        );
+        assert_eq!(
+            pushed[0].body.get("type").and_then(|t| t.as_str()),
+            Some(super::STEP_UP_APPROVE_REQUEST_TYPE),
+            "the task type belongs in the enveloped document, not on the envelope"
+        );
+        assert_eq!(pushed[0].recipient_did, APPROVER);
+    }
+
+    /// Self-approval is not a delegation, so nothing is pushed at all.
+    #[tokio::test]
+    async fn self_approval_pushes_nothing() {
+        let (state, _dir) = crate::test_support::build_signing_test_app_state().await;
+        state
+            .mediator_registry
+            .record_activate(MediatorBinding {
+                mediator_did: MEDIATOR.into(),
+                endpoint: "https://mediator.test".into(),
+            })
+            .await;
+
+        super::maybe_push_step_up(&state, CALLER, CALLER, &json!({})).await;
+
+        assert!(
+            state
+                .mediator_registry
+                .take_outbound(MEDIATOR)
+                .await
+                .is_empty(),
+            "a caller satisfying its own step-up must not ring its own phone"
+        );
     }
 }


### PR DESCRIPTION
#901 fixed the consent-request push and named three sites it had not reached.
This is those three.

Same defect, same binding rule, same silence: the DIDComm message carried the
**task** type where `trust_tasks_didcomm::ENVELOPE_TYPE` is required with the
`TrustTask` in the body. A conformant peer rejects that — and rejects it
*silently*, because "not an envelope" is indistinguishable from "not addressed
to me".

| site | family | what the breakage cost |
|---|---|---|
| `push_granted` | `task-consent/*` | requester waits for its next poll instead of re-submitting at once |
| `maybe_push_step_up` | `auth/step-up/*` | **delegated step-up approvals never reached the device** |
| `maybe_wake_consent_approver` | `consent/*` | a `wake`-routed approver is never roused |

## The one that mattered

`maybe_push_step_up` had been broken the entire time this shipped, and nothing
surfaced it. The reject still carries the `approveRequest` as a relay fallback,
so the ceremony completes by the slow route while the proactive push lands in a
void — delivered, acked, unreadable.

A push whose only failure mode is *latency* is a push nobody notices is dead.

## Protocol family: confirmed, not assumed

`consent/approve-request/0.1` belongs to **`spec/consent/*`** — the conversation
consent family (`request` / `decision` / `revoke` / `list`, all `1.0`) — not to
`spec/task-consent/*`, the per-task RP→wallet family `consent_request.rs` serves.

It does not change the fix. Neither family puts its task type on the DIDComm
envelope, because the envelope belongs to the **binding**, not the task.

## Also in here

`STEP_UP_APPROVE_REQUEST_TYPE` was the DIDComm message type *and* the document
type. It is now only the document type — and `mint_pending_step_up` reads the
constant instead of repeating the literal, so the two cannot drift apart. Its
`#[cfg(feature = "didcomm")]` gate came off with that move: the mint site is not
DIDComm-specific.

**TSP is untouched, deliberately.** It carries the document bytes directly
(`serde_json::to_vec(doc)` → `send_routed`), so the wrapper is a property of the
DIDComm binding, not of the task. Every `ENVELOPE_TYPE` import is `#[cfg]`-gated
to the feature combination that actually sends over DIDComm, so reduced builds
neither break nor carry an unused import.

**No local URI copies** — `trust_tasks_didcomm::ENVELOPE_TYPE` throughout, per
#901's rule.

## Tests

Four new tests, each asserting the **envelope on the message** and the **task
type inside the document** — the shape #901 established when it un-pinned
`a_resubmit_re_asks_nobody`.

They were checked against the *defect*, not just the fix. Reinstating the old
`message_type` on the step-up push fails `delegated_step_up_push_is_an_envelope`:

```
assertion `left == right` failed: the DIDComm message must carry the binding's envelope type
  left: "https://trusttasks.org/spec/auth/step-up/approve-request/0.2"
 right: "https://trusttasks.org/binding/didcomm/0.1/envelope"
```

Compiles clean (no errors, no new warnings) at `--no-default-features` and with
each of `didcomm`, `rest`, `tsp`, `didcomm,tsp`, `rest,didcomm,webvh,tsp`.

## Scope

This is the **browser-extension / device peer** half of the envelope work and is
independent of the did-hosting side. The VTA↔DID-hosting switch
(`webvh_didcomm.rs`) is a separate PR, gated on affinidi-webvh-service#155 being
deployed.

## Pre-merge checklist (guide §9)

- [x] No new reqwest::Client::new() / bare fetch(); all clients have finite timeouts (R1.2) — no client code
- [x] No lock held across a network await (R1.3) — n/a
- [x] No local state committed before its remote effect, or the flow is resumable with an idempotency key (R2.1) — n/a; these pushes are best-effort notifications with a relay/poll fallback, unchanged
- [x] Every retry is bounded + backed off; non-idempotent ops are not blind-retried (R1.4) — unchanged; `send_guaranteed` keeps its existing `deliver_by` + idempotency key
- [x] Accept/poll/listen loops survive transient errors (R1.5) — n/a
- [x] Acks/deletes happen only after durable handoff (R1.6) — n/a
- [x] New/changed wire types: camelCase, deny_unknown_fields where security-relevant, schema registered, all consumers (incl. JS) updated (R3.*) — no new wire type; the *document* is unchanged and only its DIDComm framing is corrected to what the binding already specifies
- [x] Config absence = most restrictive; fail-closed if enforcement can't start (R5.*) — n/a
- [x] Logs/status claim only what was verified; background-job failures are surfaced (R6.*) — unchanged; these paths already log before the send and warn on enqueue failure
- [x] "Process dies on the next line" answered for every mutation touched (R2.1) — no mutations; all three sites are post-commit notifications
- [x] Deviations from this guide flagged explicitly with rule numbers — none

**Peer note:** approver stacks that (incorrectly) accepted the bare task type
will now receive the envelope. Both fielded stacks — `vta-mobile-core` and the
browser plugin — already unwrap `ENVELOPE_TYPE`, which is why these pushes were
being dropped rather than mishandled.