### PR TITLE
fix(webvh): VTA→DID-hosting DIDComm uses the Trust-Task envelope binding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10721,7 +10721,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.14.13"
+version = "0.14.14"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/changelog.d/904-webvh-didcomm-envelope-binding.md
+++ b/changelog.d/904-webvh-didcomm-envelope-binding.md
@@ -1,0 +1,64 @@
+### vta-service 0.14.14 — VTA↔DID-hosting DIDComm uses the Trust-Task envelope binding (#904)
+
+The last and largest of the envelope-binding fixes (#901, #903). `webvh_didcomm.rs`
+sent seven DID-management verbs with the **task** type as the DIDComm message
+type, where `trust_tasks_didcomm::ENVELOPE_TYPE` is required with the `TrustTask`
+in the body.
+
+## Why this one was invisible
+
+Unlike the device pushes, **this never broke anything**. did-hosting's control
+plane accepts both framings — `build_control_router` routes the bare `MSG_*`
+types *and* `ENVELOPE_TYPE` — so DID publish, register, delete and the
+agent-name verbs all worked. The defect was latent: the moment the host retires
+bare-type acceptance (its stated direction), every one of these verbs would have
+started timing out at 30s with no diagnostic, exactly as the retired
+`did/publish/0.1` did in affinidi-webvh-service#144.
+
+## The shape of the change
+
+One private `send_task` is now the only place this module names a DIDComm
+message type, and it names the envelope both ways. Each verb passes just its
+task URI, so no call site can put a task type on the wire.
+
+- **Outbound:** `build_outbound` returns the `(message_type, document)` pair —
+  envelope type on the message, task type on the document, payload unchanged.
+- **Inbound:** `unwrap_envelope_reply` discriminates on the *document's* type,
+  because on this binding every reply arrives as `ENVELOPE_TYPE` and
+  `send_and_wait`'s outer type check can no longer tell success from rejection:
+  - `<task>#response` → its `payload`,
+  - `did/problem-report/0.1` → the typed `AppError`, through the **same**
+    `problem_report_to_app_error` table the bare framing uses (now
+    `pub(crate)`), so a host rejection keeps its status — `path-unavailable`
+    stays a 409 rather than collapsing to 502,
+  - `trust-task-error/0.x` → 502; the framework refused the envelope, not the
+    task, so it is not an outcome a caller can act on. Matched by prefix: the
+    version floats between 0.1 and 0.2 within one conversation.
+
+## Prerequisite, already shipped
+
+affinidi-webvh-service#155 gave the host's envelope path the anti-replay gate
+its bare-type path already had. Both framings reach the same `dispatch_did_op`
+table, so without it this change would have worked *and* silently dropped replay
+protection for delete, change-owner and register. Merged first, deliberately.
+
+## Tests
+
+Six new tests. The outbound one asserts both halves off `build_outbound`, which
+is what keeps it from being circular — `send_task` destructures that return, so
+restoring the defect means bypassing the function rather than editing an
+argument. Verified against the defect, not just the fix:
+
+```
+assertion `left == right` failed: the DIDComm message must carry the binding's envelope type
+  left: "https://trusttasks.org/spec/did-management/did/check-name/0.1"
+ right: "https://trusttasks.org/binding/didcomm/0.1/envelope"
+```
+
+An earlier draft tested only the document builder and did **not** catch that
+regression; the tests were restructured until they did.
+
+TSP is untouched — it carries document bytes directly, so the envelope belongs
+to the DIDComm binding. `webvh_didcomm` and `trust-tasks-didcomm` are both
+ungated, so the import needs no `#[cfg]`; verified at `--no-default-features` and
+with each of `didcomm`, `rest`, `tsp`, `didcomm,tsp`, `rest,didcomm,webvh,tsp`.

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.14.13"
+version = "0.14.14"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/didcomm_bridge.rs
+++ b/vta-service/src/didcomm_bridge.rs
@@ -34,7 +34,13 @@ use vta_sdk::protocols::{PROBLEM_REPORT_TYPE, extract_problem_report};
 /// is the VTA's own DID that lacks rights on the host. A 401 would make the
 /// CLI print a misleading "token may be expired" hint (see the
 /// `e.p.msg.forbidden` note in the workspace CLAUDE.md).
-fn problem_report_to_app_error(code: &str, comment: &str) -> AppError {
+/// `pub(crate)` so the envelope-binding client in `webvh_didcomm` maps the
+/// *inner* document's problem report through the same table. On the envelope
+/// binding the DIDComm `type` is always `ENVELOPE_TYPE`, so error detection
+/// necessarily moves inside the body — but the code→status mapping must not
+/// fork, or the same host rejection would surface as a different HTTP status
+/// depending on which framing carried it.
+pub(crate) fn problem_report_to_app_error(code: &str, comment: &str) -> AppError {
     let detail = format!("remote peer rejected the request: {comment} [{code}]");
     match code.rsplit('.').next().unwrap_or_default() {
         "unauthorized" | "forbidden" => AppError::Forbidden(detail),

--- a/vta-service/src/webvh_didcomm.rs
+++ b/vta-service/src/webvh_didcomm.rs
@@ -34,8 +34,11 @@
 //! envelope-layer guarantees.
 
 use crate::didcomm_bridge::DIDCommBridge;
-use crate::error::AppError;
+use crate::error::{AppError, bad_gateway_error};
 use crate::webvh_client::RequestUriResponse;
+// The one DIDComm message type this module names, taken from the binding crate
+// rather than copied (#900). Every task URI below travels *inside* the envelope.
+use trust_tasks_didcomm::ENVELOPE_TYPE as TRUST_TASK_ENVELOPE_TYPE;
 
 // did-management Trust-Task URIs (v0.1, hosted-DID category).
 //
@@ -238,9 +241,180 @@ pub struct WebvhDIDCommClient<'a> {
     server_did: &'a str,
 }
 
+/// The `trust-task-error/0.x` family the framework emits for transport-level
+/// refusals (malformed body, proof required, wrong recipient). Matched by prefix
+/// because the version floats — did-hosting emits `0.1` for a body-parse failure
+/// and `0.2` from the typed §7.2 pipeline, in the same conversation.
+const TRUST_TASK_ERROR_PREFIX: &str = "https://trusttasks.org/spec/trust-task-error/";
+
+/// Build the complete outbound pair: the DIDComm **message type** and the
+/// `TrustTask` document that rides in its body.
+///
+/// The message type is returned from here rather than written at the send site
+/// on purpose. It is the value this entire change exists to get right, and a
+/// wrong one fails *silently* — so it must come from somewhere a test can look
+/// at. `send_task` destructures this and passes both through verbatim; putting
+/// the literal back at the send site means bypassing this function, which is a
+/// visible edit rather than a one-word slip.
+fn build_outbound(
+    task: &str,
+    recipient: &str,
+    issuer: Option<String>,
+    payload: serde_json::Value,
+) -> (&'static str, serde_json::Value) {
+    (
+        TRUST_TASK_ENVELOPE_TYPE,
+        build_envelope_document(task, recipient, issuer, payload),
+    )
+}
+
+/// Build the `TrustTask` document that rides inside the envelope.
+///
+/// Extracted so the outbound shape is assertable without a live bridge — the
+/// same reason `build_register_body` exists, and for the same class of bug: the
+/// failure this whole change addresses is a *silent* one, so nothing downstream
+/// would have caught a malformed document either.
+fn build_envelope_document(
+    task: &str,
+    recipient: &str,
+    issuer: Option<String>,
+    payload: serde_json::Value,
+) -> serde_json::Value {
+    let mut doc = serde_json::json!({
+        "id": format!("urn:uuid:{}", uuid::Uuid::new_v4()),
+        // The task type lives HERE, on the document — never on the DIDComm
+        // message, which is always the envelope type.
+        "type": task,
+        // Addressed to the host, per SPEC §4.8. did-hosting does not enforce
+        // `recipient` on the DID-management bridge (it authorizes the authcrypt
+        // sender), but an unaddressed document is one a stricter peer is
+        // entitled to refuse.
+        "recipient": recipient,
+        "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+        "payload": payload,
+    });
+    // `issuer` only when we actually know it. SPEC §4.8.1 requires an in-band
+    // issuer to match the transport-authenticated sender, so a guess would be
+    // worse than the omission the spec permits.
+    if let Some(vta_did) = issuer {
+        doc["issuer"] = serde_json::Value::String(vta_did);
+    }
+    doc
+}
+
+/// Unwrap a reply document from a trust-task envelope into its `payload`.
+///
+/// On the envelope binding every reply arrives with the *same* DIDComm `type`
+/// (`ENVELOPE_TYPE`), so `send_and_wait`'s type check can no longer tell success
+/// from rejection — that decision moves in here, onto the document's own `type`.
+/// Three outcomes, and the caller must not be able to confuse them:
+///
+/// - the expected `<task>#response` → its `payload`,
+/// - `did/problem-report/0.1` → the typed [`AppError`] the REST path produces,
+///   via the *same* mapping table `didcomm_bridge` uses for the bare framing,
+/// - `trust-task-error/0.x` → a 502; the framework refused the envelope itself
+///   rather than the task, so it is not an outcome the caller can act on.
+///
+/// Anything else is a 502 naming both types, because a reply that threads to our
+/// request but answers a different task is a contract break, not a task failure.
+fn unwrap_envelope_reply(
+    doc: serde_json::Value,
+    expected: &str,
+) -> Result<serde_json::Value, AppError> {
+    let doc_type = doc.get("type").and_then(|v| v.as_str()).unwrap_or_default();
+
+    if doc_type == TASK_DID_PROBLEM_REPORT {
+        let payload = doc.get("payload").unwrap_or(&serde_json::Value::Null);
+        let code = payload
+            .get("code")
+            .and_then(|v| v.as_str())
+            .unwrap_or("e.p.did.unknown");
+        let comment = payload
+            .get("comment")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default();
+        return Err(crate::didcomm_bridge::problem_report_to_app_error(
+            code, comment,
+        ));
+    }
+
+    if doc_type.starts_with(TRUST_TASK_ERROR_PREFIX) {
+        let payload = doc.get("payload").unwrap_or(&serde_json::Value::Null);
+        let code = payload
+            .get("code")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown");
+        let message = payload
+            .get("message")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default();
+        return Err(bad_gateway_error(format!(
+            "hosting peer refused the trust-task envelope: {message} [{code}]"
+        )));
+    }
+
+    if doc_type != expected {
+        return Err(bad_gateway_error(format!(
+            "unexpected response document type: expected {expected}, got {doc_type}"
+        )));
+    }
+
+    Ok(doc
+        .get("payload")
+        .cloned()
+        .unwrap_or(serde_json::Value::Null))
+}
+
 impl<'a> WebvhDIDCommClient<'a> {
     pub fn new(bridge: &'a DIDCommBridge, server_did: &'a str) -> Self {
         Self { bridge, server_did }
+    }
+
+    /// Send one DID-management task over the **DIDComm envelope binding** and
+    /// return the response document's `payload`.
+    ///
+    /// The single place this client names a DIDComm message type, and it names
+    /// `ENVELOPE_TYPE` both ways. Every verb below passes only its task URI, so
+    /// no call site can put a task type on the wire — which is the mistake this
+    /// whole change exists to make unrepresentable (#900, #903).
+    ///
+    /// The task type moves *into* the document, where the binding requires it.
+    /// did-hosting reads it back out via `bridge_did_management` and dispatches
+    /// through the same `dispatch_did_op` table the bare `MSG_*` framing hits, so
+    /// the operation, its authorization and its responses are unchanged — only
+    /// the framing differs.
+    async fn send_task(
+        &self,
+        task: &str,
+        response_task: &str,
+        payload: serde_json::Value,
+    ) -> Result<serde_json::Value, AppError> {
+        // Both halves come from `build_outbound` — see its note on why the
+        // message type is not written here.
+        let (message_type, doc) =
+            build_outbound(task, self.server_did, self.bridge.vta_did(), payload);
+
+        let reply = self
+            .bridge
+            .send_and_wait(
+                self.server_did,
+                message_type,
+                doc,
+                // Expected *outer* type: the binding replies in the same
+                // envelope, so the reply's type is the one we sent. The real
+                // discrimination happens on the inner document, in
+                // `unwrap_envelope_reply`.
+                message_type,
+                // A DIDComm-level problem report is still possible ahead of the
+                // envelope (an unroutable message never reaches the dispatcher),
+                // so keep mapping it; task-level rejections now arrive *inside*
+                // the envelope instead.
+                TASK_DID_PROBLEM_REPORT,
+                30,
+            )
+            .await?;
+
+        unwrap_envelope_reply(reply.body, response_task)
     }
 
     /// Reserve a path on the remote DID-hosting server (v0.1
@@ -265,19 +439,15 @@ impl<'a> WebvhDIDCommClient<'a> {
     ) -> Result<RequestUriResponse, AppError> {
         let body = build_check_name_body(path, domain);
 
-        let response = self
-            .bridge
-            .send_and_wait(
-                self.server_did,
+        let payload = self
+            .send_task(
                 TASK_DID_CHECK_NAME,
-                serde_json::Value::Object(body),
                 TASK_DID_CHECK_NAME_RESPONSE,
-                TASK_DID_PROBLEM_REPORT,
-                30,
+                serde_json::Value::Object(body),
             )
             .await?;
 
-        parse_check_name_response(response.body)
+        parse_check_name_response(payload)
     }
 
     /// Atomic claim-and-publish (v0.1 `did-management/did/register/0.1`).
@@ -292,29 +462,24 @@ impl<'a> WebvhDIDCommClient<'a> {
         force: bool,
         domain: Option<&str>,
     ) -> Result<RequestUriResponse, AppError> {
-        let response = self
-            .bridge
-            .send_and_wait(
-                self.server_did,
+        let payload = self
+            .send_task(
                 TASK_DID_REGISTER,
-                serde_json::Value::Object(build_register_body(path, did_log, force, domain)),
                 TASK_DID_REGISTER_RESPONSE,
-                TASK_DID_PROBLEM_REPORT,
-                30,
+                serde_json::Value::Object(build_register_body(path, did_log, force, domain)),
             )
             .await?;
 
         // v0.1 response carries `{ record: DidRecord }`; we project
         // the mnemonic + didUrl out of it for the local response shape.
-        let record = response
-            .body
+        let record = payload
             .get("record")
             .cloned()
             .or_else(|| {
                 // Legacy did-hosting-control responses (still emitted
                 // by pre-v0.7 hosts) flatten the fields at the top
                 // level. Fall back to that shape transparently.
-                Some(response.body.clone())
+                Some(payload.clone())
             })
             .unwrap_or(serde_json::Value::Null);
         let mnemonic = record
@@ -376,16 +541,12 @@ impl<'a> WebvhDIDCommClient<'a> {
             );
         }
 
-        self.bridge
-            .send_and_wait(
-                self.server_did,
-                TASK_DID_DELETE,
-                serde_json::Value::Object(body),
-                TASK_DID_DELETE_RESPONSE,
-                TASK_DID_PROBLEM_REPORT,
-                30,
-            )
-            .await?;
+        self.send_task(
+            TASK_DID_DELETE,
+            TASK_DID_DELETE_RESPONSE,
+            serde_json::Value::Object(body),
+        )
+        .await?;
         Ok(())
     }
 
@@ -421,15 +582,7 @@ impl<'a> WebvhDIDCommClient<'a> {
         if let Some(d) = domain {
             body.insert("domain".to_string(), serde_json::json!(d));
         }
-        self.bridge
-            .send_and_wait(
-                self.server_did,
-                task,
-                serde_json::Value::Object(body),
-                response_task,
-                TASK_DID_PROBLEM_REPORT,
-                30,
-            )
+        self.send_task(task, response_task, serde_json::Value::Object(body))
             .await?;
         Ok(())
     }
@@ -498,15 +651,11 @@ impl<'a> WebvhDIDCommClient<'a> {
         if let Some(d) = domain {
             body.insert("domain".to_string(), serde_json::json!(d));
         }
-        let resp = self
-            .bridge
-            .send_and_wait(
-                self.server_did,
+        let payload = self
+            .send_task(
                 TASK_AGENT_NAME_LIST,
-                serde_json::Value::Object(body),
                 TASK_AGENT_NAME_LIST_RESPONSE,
-                TASK_DID_PROBLEM_REPORT,
-                30,
+                serde_json::Value::Object(body),
             )
             .await?;
         // A host predating the registry omits the field entirely. That is an
@@ -515,7 +664,7 @@ impl<'a> WebvhDIDCommClient<'a> {
         // (`webvh_client::list_agent_names`); erroring on one transport and
         // succeeding on the other made the same DID appear to have names or
         // not depending on how the VTA happened to reach its host.
-        let Some(names) = resp.body.get("agentNames") else {
+        let Some(names) = payload.get("agentNames") else {
             return Ok(Vec::new());
         };
         serde_json::from_value(names.clone())
@@ -536,18 +685,14 @@ impl<'a> WebvhDIDCommClient<'a> {
         if let Some(d) = domain {
             body.insert("domain".to_string(), serde_json::json!(d));
         }
-        let resp = self
-            .bridge
-            .send_and_wait(
-                self.server_did,
+        let payload = self
+            .send_task(
                 TASK_AGENT_NAME_CHECK,
-                serde_json::Value::Object(body),
                 TASK_AGENT_NAME_CHECK_RESPONSE,
-                TASK_DID_PROBLEM_REPORT,
-                30,
+                serde_json::Value::Object(body),
             )
             .await?;
-        serde_json::from_value(resp.body)
+        serde_json::from_value(payload)
             .map_err(|e| AppError::Internal(format!("agent-name check response parse error: {e}")))
     }
 }
@@ -758,5 +903,150 @@ mod tests {
         });
         let err = parse_check_name_response(body).expect_err("must error");
         assert!(err.to_string().contains("didUrl"), "got: {err}");
+    }
+}
+
+#[cfg(test)]
+mod envelope_binding_tests {
+    use super::{
+        TASK_DID_CHECK_NAME, TASK_DID_CHECK_NAME_RESPONSE, TASK_DID_PROBLEM_REPORT, build_outbound,
+        unwrap_envelope_reply,
+    };
+    use crate::error::AppError;
+    use serde_json::json;
+
+    const SERVER: &str = "did:webvh:example.com:control";
+    const VTA: &str = "did:webvh:example.com:vta";
+
+    /// The whole point, in one assertion pair: the **envelope** type goes on the
+    /// DIDComm message, the **task** type goes in the document.
+    ///
+    /// Both halves come from `build_outbound`, which is what makes this
+    /// meaningful rather than circular — `send_task` destructures that function's
+    /// return and passes both through, so putting a task type back on the wire
+    /// means bypassing it, not editing one argument.
+    #[test]
+    fn the_envelope_is_on_the_message_and_the_task_is_in_the_document() {
+        let (message_type, doc) = build_outbound(
+            TASK_DID_CHECK_NAME,
+            SERVER,
+            Some(VTA.to_string()),
+            json!({ "path": "bob", "reserve": true }),
+        );
+
+        assert_eq!(
+            message_type,
+            trust_tasks_didcomm::ENVELOPE_TYPE,
+            "the DIDComm message must carry the binding's envelope type — a task \
+             type here is rejected silently by a conformant host"
+        );
+        assert_ne!(
+            message_type, TASK_DID_CHECK_NAME,
+            "the task type must never be the message type"
+        );
+        assert_eq!(doc["type"], TASK_DID_CHECK_NAME);
+        assert_eq!(doc["recipient"], SERVER);
+        assert_eq!(doc["issuer"], VTA);
+        // The body the host dispatches on must survive the wrap untouched — the
+        // envelope adds framing, it does not reshape the request.
+        assert_eq!(doc["payload"]["path"], "bob");
+        assert_eq!(doc["payload"]["reserve"], true);
+        assert!(
+            doc["id"]
+                .as_str()
+                .unwrap_or_default()
+                .starts_with("urn:uuid:"),
+            "the document id is the thread anchor and must be a urn:uuid"
+        );
+    }
+
+    /// No `issuer` rather than a wrong one. SPEC §4.8.1 makes an in-band issuer
+    /// that disagrees with the transport sender a rejection, so omitting it when
+    /// the bridge has no DID yet is the safe half of the choice.
+    #[test]
+    fn an_unknown_issuer_is_omitted_not_guessed() {
+        let (_, doc) = build_outbound(TASK_DID_CHECK_NAME, SERVER, None, json!({}));
+        assert!(
+            doc.get("issuer").is_none(),
+            "an unknown issuer must be absent, not empty or invented: {doc}"
+        );
+    }
+
+    /// The happy path yields the response document's `payload`, which is what
+    /// every verb's parser consumes.
+    #[test]
+    fn a_response_document_yields_its_payload() {
+        let reply = json!({
+            "id": "urn:uuid:2",
+            "type": TASK_DID_CHECK_NAME_RESPONSE,
+            "payload": { "available": true, "reserved": true, "record": { "mnemonic": "bob" } },
+        });
+        let payload = unwrap_envelope_reply(reply, TASK_DID_CHECK_NAME_RESPONSE)
+            .expect("a matching response document unwraps");
+        assert_eq!(payload["available"], true);
+        assert_eq!(payload["record"]["mnemonic"], "bob");
+    }
+
+    /// A problem report inside the envelope maps through the *same* table the
+    /// bare framing uses, so the operator-facing status does not depend on which
+    /// framing carried the rejection.
+    ///
+    /// `path-unavailable` → 409 is the case that matters: it is a clean client
+    /// conflict, and collapsing it to 502 was the bug the mapping table was
+    /// introduced to fix.
+    #[test]
+    fn an_enveloped_problem_report_keeps_its_typed_meaning() {
+        let reply = json!({
+            "id": "urn:uuid:3",
+            "type": TASK_DID_PROBLEM_REPORT,
+            "payload": { "code": "e.p.did.path-unavailable", "comment": "taken" },
+        });
+        let err = unwrap_envelope_reply(reply, TASK_DID_CHECK_NAME_RESPONSE)
+            .expect_err("a problem report is an error, not a payload");
+        assert!(
+            matches!(err, AppError::Conflict(_)),
+            "path-unavailable must stay a 409, got: {err:?}"
+        );
+    }
+
+    /// A framework-level refusal is not a task outcome, so it surfaces as a 502
+    /// rather than being mistaken for a rejection the caller could act on. The
+    /// version floats (0.1 from a body-parse failure, 0.2 from the typed
+    /// pipeline), so the match is by prefix.
+    #[test]
+    fn a_trust_task_error_is_a_bad_gateway_at_either_version() {
+        for version in ["0.1", "0.2"] {
+            let reply = json!({
+                "id": "urn:uuid:4",
+                "type": format!("https://trusttasks.org/spec/trust-task-error/{version}"),
+                "payload": { "code": "malformedRequest", "message": "nope" },
+            });
+            let err = unwrap_envelope_reply(reply, TASK_DID_CHECK_NAME_RESPONSE)
+                .expect_err("a framework error is not a payload");
+            let msg = format!("{err:?}");
+            assert!(
+                msg.contains("refused the trust-task envelope"),
+                "trust-task-error/{version} must surface as an envelope refusal, got: {msg}"
+            );
+        }
+    }
+
+    /// A reply that threads to our request but answers a different task is a
+    /// contract break, not a task failure — it must never be handed to a parser
+    /// as though it were the expected payload.
+    #[test]
+    fn a_mismatched_response_type_is_refused() {
+        let reply = json!({
+            "id": "urn:uuid:5",
+            "type": "https://trusttasks.org/spec/did-management/did/delete/0.1#response",
+            "payload": { "deleted": true },
+        });
+        let err = unwrap_envelope_reply(reply, TASK_DID_CHECK_NAME_RESPONSE)
+            .expect_err("an off-task response must not be accepted");
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("unexpected response document type"),
+            "got: {msg}"
+        );
     }
 }


### PR DESCRIPTION
The last and largest of the envelope-binding fixes (#901, #903).
`webvh_didcomm.rs` sent **seven** DID-management verbs with the *task* type as
the DIDComm message type, where `trust_tasks_didcomm::ENVELOPE_TYPE` is required
with the `TrustTask` in the body.

`did/check-name`, `did/register` (which also carries publish), `did/delete`,
`agent-name/{update,remove,list,check}`.

## Why this one was invisible

Unlike the device pushes, **this never broke anything.** did-hosting's control
plane accepts both framings — `build_control_router` routes the bare `MSG_*`
types *and* `ENVELOPE_TYPE`, and the envelope path reaches the same
`dispatch_did_op` table via `bridge_did_management` — so publish, register,
delete and the agent-name verbs all worked, and still do.

The defect was **latent**. The moment the host retires bare-type acceptance —
its stated direction — every one of these verbs starts timing out at 30s with no
diagnostic. That is not hypothetical: it is exactly what the retired
`did/publish/0.1` did in affinidi-webvh-service#144, one verb at a time.

## The shape

`send_task` is now the only place this module names a DIDComm message type, and
it names the envelope both ways. Each verb passes just its task URI, so **no call
site can put a task type on the wire**.

**Outbound** — `build_outbound` returns the `(message_type, document)` pair:
envelope on the message, task type on the document, payload untouched.

**Inbound** — reply handling had to move. On this binding every reply arrives as
`ENVELOPE_TYPE`, so `send_and_wait`'s outer type check can no longer tell success
from rejection. `unwrap_envelope_reply` discriminates on the *document's* type:

| document type | result |
|---|---|
| `<task>#response` | its `payload` |
| `did/problem-report/0.1` | typed `AppError`, via the **same** `problem_report_to_app_error` table the bare framing uses (now `pub(crate)`) |
| `trust-task-error/0.x` | 502 — the framework refused the *envelope*, not the task |
| anything else | 502 naming both types |

Routing the problem report through the shared table is what keeps
`path-unavailable` a **409** instead of collapsing to 502 — the exact regression
that table was introduced to fix. A host rejection must not change status
depending on which framing carried it.

`trust-task-error` is matched by **prefix**: did-hosting emits `0.1` for a
body-parse failure and `0.2` from the typed §7.2 pipeline, in the same
conversation.

## Prerequisite — already shipped

**affinidi-webvh-service#155** gave the host's envelope path the anti-replay gate
its bare-type path already had (`check_and_insert` had two production callers,
neither on the envelope path). Both framings reach the same state-changing
operations, so without it this PR would have worked *and* silently dropped replay
protection for `delete`, `change-owner` and `register`.

Merged and on `upstream/main` as `f7a70a6` before this was written.

⚠️ **Deploy #155 before merging this.** Merged is not deployed; the ordering
constraint is on the running host, not the branch.

## Tests

Six new. The outbound one asserts **both** halves off `build_outbound`, which is
what keeps it from being circular: `send_task` destructures that return, so
restoring the defect means bypassing the function rather than editing one
argument.

Verified against the *defect*, not just the fix:

```
assertion `left == right` failed: the DIDComm message must carry the binding's envelope type
  left: "https://trusttasks.org/spec/did-management/did/check-name/0.1"
 right: "https://trusttasks.org/binding/didcomm/0.1/envelope"
```

Worth stating plainly: an earlier draft of these tests covered only the document
builder and did **not** catch that regression — I checked, found the gap, and
restructured until they did. Given that this whole workstream exists because a
test pinned the defect rather than caught it, "the tests pass" was not a
sufficient claim to stop on.

`cargo clippy -p vta-service --all-targets` clean. Compiles at
`--no-default-features` and with each of `didcomm`, `rest`, `tsp`, `didcomm,tsp`,
`rest,didcomm,webvh,tsp`.

## Not in scope

**TSP is untouched, deliberately.** It carries the document bytes directly
(`serde_json::to_vec(doc)` → `send_routed`), so the envelope is a property of the
DIDComm binding, not of the task. Applying it there would break a working
transport to fix a latent one.

`webvh_didcomm` and `trust-tasks-didcomm` are both ungated, so the
`ENVELOPE_TYPE` import needs no `#[cfg]` — verified across the feature matrix
above rather than assumed.

**Adopting `pack_trust_task` is designed, not done.** It generates the envelope
id internally (`Message::new`) and returns only the JWE, while the bridge's reply
correlation *is* that id — peers reply `.thid(message.id)`. Adopting it as-is
makes every `send_and_wait` time out. Written up in
`design-docs/vti-pack-trust-task-adoption.md`, which recommends a typed seam on
`DIDCommBridge` instead and names the upstream ask (return the id, or accept a
caller-supplied one).

## Merge order

1. affinidi-webvh-service#155 — merged ✅, **needs deploying**
2. #903 (device pushes) — independent of this
3. **this PR**

## Pre-merge checklist (guide §9)

- [x] No new reqwest::Client::new() / bare fetch(); all clients have finite timeouts (R1.2) — no HTTP client code; the 30s `send_and_wait` bound is unchanged
- [x] No lock held across a network await (R1.3) — n/a
- [x] No local state committed before its remote effect, or the flow is resumable with an idempotency key (R2.1) — unchanged; this is framing only, no reordering of local vs remote effects
- [x] Every retry is bounded + backed off; non-idempotent ops are not blind-retried (R1.4) — unchanged
- [x] Accept/poll/listen loops survive transient errors (R1.5) — n/a
- [x] Acks/deletes happen only after durable handoff (R1.6) — n/a
- [x] New/changed wire types: camelCase, deny_unknown_fields where security-relevant, schema registered, all consumers (incl. JS) updated (R3.*) — no new wire type; the document and its payload are unchanged and only the DIDComm framing is corrected to what the binding already specifies. Response parsing now reads `payload` rather than the message body — same bytes, one level in
- [x] Config absence = most restrictive; fail-closed if enforcement can't start (R5.*) — n/a
- [x] Logs/status claim only what was verified; background-job failures are surfaced (R6.*) — an unrecognised reply is a 502 naming both types rather than being parsed optimistically
- [x] "Process dies on the next line" answered for every mutation touched (R2.1) — no mutation ordering changed
- [x] Deviations from this guide flagged explicitly with rule numbers — none