### PR TITLE
fix(messaging): an unknown inbound protocol is dropped, not fatal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10721,7 +10721,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.14.14"
+version = "0.14.15"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",
@@ -10955,7 +10955,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-service"
-version = "0.11.50"
+version = "0.11.51"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,9 +303,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-core"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da7cdce5ec80c3d3826420a787f2a325c60864888ed0b33b128766699adfba40"
+checksum = "3502004e98ecb8e86a26c1570a495c29945c3af8b0357c2047f084bbc91db8d0"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -3089,7 +3089,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 2.0.119",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3746,7 +3746,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4908,7 +4908,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "system-configuration 0.7.0",
  "tokio",
  "tower-service",
@@ -7226,7 +7226,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.43",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
@@ -7265,9 +7265,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7968,7 +7968,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8056,7 +8056,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9327,7 +9327,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11496,7 +11496,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/changelog.d/905-protocol-non-exhaustive.md
+++ b/changelog.d/905-protocol-non-exhaustive.md
@@ -1,0 +1,41 @@
+### vta-service 0.14.15 / vtc-service 0.11.51 — an unknown inbound protocol is dropped, not fatal (#905)
+
+`affinidi-messaging-core` 0.1.6 added a `Protocol::DIDCommV1` variant and marked
+the enum `#[non_exhaustive]`, so both inbound routers stopped compiling:
+
+```
+error[E0004]: non-exhaustive patterns: `_` not covered
+  --> vta-service/src/messaging/service.rs:310:11
+  --> vtc-service/src/messaging.rs:341:23
+```
+
+## Not the fix rustc suggests
+
+rustc proposes `_ => todo!()`. That would be a **remotely triggerable panic**:
+this match runs on every inbound frame off the mediator socket, so any peer
+sending a protocol we don't implement yet would take the listener down. Both
+routers now warn and drop.
+
+## DIDComm v1 is not a flavour of v2.1
+
+`DIDCommV1` (Aries RFC 0019) gets its own arm rather than being folded into the
+`DIDComm` one. Upstream is explicit that the two "share no wire format, no
+algorithms, and no identifier scheme", and both services speak v2.1 only.
+
+In `vtc-service` this distinction is load-bearing rather than cosmetic: its
+`Protocol::DIDComm` arm falls *through* to the v2.1 parse below, so an unhandled
+variant reaching it would be parsed as a v2.1 plaintext and dropped **silently** —
+which is precisely the failure the comment above that match already records for
+TSP. The new arms `continue` instead.
+
+## Why this class keeps landing
+
+Second `#[non_exhaustive]` break in two days (#902 carried the `UnpackMetadata`
+one). Both were invisible until a dependency moved: the upstream attribute exists
+so *additive* changes are not breaking, but a `match` without a wildcard opts back
+into breakage. Worth preferring a wildcard on any upstream enum matched in a hot
+inbound path, whether or not it is `#[non_exhaustive]` today.
+
+`affinidi-messaging-core` 0.1.5 → 0.1.6. Verified: workspace at `--all-features`
+and `--all-targets`; `vta-service` at `--no-default-features` and each of
+`didcomm`, `rest`, `tsp`, `didcomm,tsp`, `rest,didcomm,webvh,tsp`.

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.14.14"
+version = "0.14.15"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/messaging/service.rs
+++ b/vta-service/src/messaging/service.rs
@@ -321,6 +321,27 @@ async fn handle_inbound(
             let _ = mediator_did;
             warn!("received an inbound TSP frame but the `tsp` feature is disabled — dropping");
         }
+        // DIDComm v1 (Aries RFC 0019) is a different protocol wearing a similar
+        // name: it shares no wire format, no algorithms and no identifier scheme
+        // with v2.1, so it must NOT fall through to `handle_didcomm`. The VTA
+        // speaks v2.1 only, so this is a drop, and a deliberate one.
+        Protocol::DIDCommV1 => {
+            warn!("received an inbound DIDComm v1 frame; this VTA speaks v2.1 only — dropping");
+        }
+        // `Protocol` is `#[non_exhaustive]` upstream, so a new variant is a minor
+        // release away and must not break the build — nor take the process down.
+        //
+        // Emphatically not `todo!()` (which is what rustc suggests): this runs on
+        // every inbound frame from the mediator, so a panic here is a remotely
+        // triggerable crash — any peer that sends a protocol we don't know yet
+        // would kill the listener. Unknown protocol, unknown frame, drop it and
+        // say so.
+        other => {
+            warn!(
+                protocol = ?other,
+                "received an inbound frame in a protocol this VTA does not implement — dropping"
+            );
+        }
     }
 }
 

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.11.50"
+version = "0.11.51"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vtc-service/src/messaging.rs
+++ b/vtc-service/src/messaging.rs
@@ -353,6 +353,31 @@ pub async fn run_didcomm_service(
                         );
                         continue;
                     }
+                    // DIDComm v1 (Aries RFC 0019) shares no wire format,
+                    // algorithms or identifier scheme with v2.1, so it must
+                    // `continue` rather than fall through — the branch below
+                    // would try to parse it as a v2.1 plaintext and drop it
+                    // silently, which is the exact failure the note above
+                    // describes for TSP.
+                    Protocol::DIDCommV1 => {
+                        warn!(
+                            "received an inbound DIDComm v1 frame; this VTC speaks v2.1 only — \
+                             dropping"
+                        );
+                        continue;
+                    }
+                    // `Protocol` is `#[non_exhaustive]` upstream. Drop rather
+                    // than fall through, for the reason above, and never panic:
+                    // this runs on every inbound frame, so an unknown protocol
+                    // must not be a remotely triggerable crash.
+                    other => {
+                        warn!(
+                            protocol = ?other,
+                            "received an inbound frame in a protocol this VTC does not implement \
+                             — dropping"
+                        );
+                        continue;
+                    }
                 }
 
                 let reply_to = inbound.message.sender.clone().or_else(|| {


### PR DESCRIPTION
`affinidi-messaging-core` 0.1.6 added a `Protocol::DIDCommV1` variant and marked
the enum `#[non_exhaustive]`. Both inbound routers stopped compiling:

```
error[E0004]: non-exhaustive patterns: `_` not covered
  --> vta-service/src/messaging/service.rs:310:11
  --> vtc-service/src/messaging.rs:341:23
```

## Not the fix rustc suggests

rustc proposes `_ => todo!()`. That would be a **remotely triggerable panic** —
this match runs on every inbound frame off the mediator socket, so any peer
sending a protocol we don't implement yet takes the listener down. Both routers
warn and drop.

## DIDComm v1 is not a flavour of v2.1

`DIDCommV1` (Aries RFC 0019) gets its own arm rather than folding into the
`DIDComm` one. Upstream is explicit that the two *"share no wire format, no
algorithms, and no identifier scheme"*, and both services speak v2.1 only.

In `vtc-service` this is load-bearing, not cosmetic. Its `Protocol::DIDComm` arm
is `{}` and falls **through** to the v2.1 parse below, so an unhandled variant
reaching it would be parsed as a v2.1 plaintext and dropped *silently* — which is
exactly the failure the comment directly above that match already records for
TSP:

> the DIDComm branch below would fail to parse the payload and drop the frame
> silently, which is what happened before this

The new arms `continue`.

## Why this class keeps landing

Second `#[non_exhaustive]` break in two days — #902 carried the `UnpackMetadata`
one. Both were invisible until a dependency moved. The attribute exists so
*additive* upstream changes aren't breaking; a `match` without a wildcard opts
back into breakage. Worth preferring a wildcard on any upstream enum matched in a
hot inbound path, `#[non_exhaustive]` or not.

## Verification

`affinidi-messaging-core` 0.1.5 → 0.1.6.

| target | feature sets |
|---|---|
| workspace | `--all-features`, `--all-targets` (test targets included) |
| `vta-service` | `--no-default-features`, and each of `didcomm`, `rest`, `tsp`, `didcomm,tsp`, `rest,didcomm,webvh,tsp` |

`cargo fmt --check`, `check-version-bumps.sh`, `check-changelogs.sh` clean.

## Pre-merge checklist (guide §9)

- [x] No new reqwest::Client::new() / bare fetch(); all clients have finite timeouts (R1.2) — n/a
- [x] No lock held across a network await (R1.3) — n/a
- [x] No local state committed before its remote effect, or the flow is resumable with an idempotency key (R2.1) — n/a
- [x] Every retry is bounded + backed off; non-idempotent ops are not blind-retried (R1.4) — n/a
- [x] Accept/poll/listen loops survive transient errors (R1.5) — **directly on point**: this is what the change is for. An unknown protocol no longer aborts (or, under rustc's suggestion, panics) the inbound loop; it logs and continues
- [x] Acks/deletes happen only after durable handoff (R1.6) — unchanged
- [x] New/changed wire types: camelCase, deny_unknown_fields where security-relevant, schema registered, all consumers (incl. JS) updated (R3.*) — no wire types changed
- [x] Config absence = most restrictive; fail-closed if enforcement can't start (R5.*) — an unrecognised protocol is dropped, not optimistically parsed
- [x] Logs/status claim only what was verified; background-job failures are surfaced (R6.*) — each drop warns with the protocol named, rather than vanishing
- [x] "Process dies on the next line" answered for every mutation touched (R2.1) — no mutations
- [x] Deviations from this guide flagged explicitly with rule numbers — none