### PR TITLE
test(vtc): make the join_didcomm credential-delivery failure diagnosable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10955,7 +10955,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-service"
-version = "0.11.51"
+version = "0.11.52"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/changelog.d/906-join-didcomm-flake-diagnostics.md
+++ b/changelog.d/906-join-didcomm-flake-diagnostics.md
@@ -1,0 +1,65 @@
+### vtc-service 0.11.52 — make the join_didcomm credential-delivery failure diagnosable (#906)
+
+`didcomm_join_round_trips_submit_manifest_status_approve_and_vmc_delivery` has
+failed on CI at least three times across unrelated PRs (#903, #904 — one of them
+with a diff that was purely DIDComm framing in another crate). Every failure
+produced the same line and no way to act on it:
+
+```
+panicked at vtc-service/tests/join_didcomm.rs:288:14:
+admission credential delivered over DIDComm
+```
+
+**This changes no production behaviour and does not attempt a fix.** It removes
+the reasons the failure has never been attributable.
+
+## What the investigation ruled out
+
+- **R1.1 silent drop.** `send_to_member` uses `Delivery::Guaranteed` — durable
+  outbox with retries. Not a bare send.
+- **Idempotency-key collision.** `deliver_credentials` mints a fresh UUID per
+  credential and `push_to_holder` uses it as the message id, so the two pushes
+  cannot dedup against each other.
+- **Arrival-order race.** Already handled; the test collects both and searches.
+- **Runner slowness — the explanation the test itself gives.** It does not fit.
+  The bound is already **60s** on a test that completes in ~23s on CI, and the
+  client polls every 300ms, so a failure means ~200 consecutive empty polls.
+  That is a message that is not there, not one that is late.
+
+Six local runs did not reproduce it. No root cause is claimed here.
+
+## Three blind spots, all removed
+
+**No tracing subscriber.** These tests installed none, so the service's
+`warn!("membership-credential delivery failed on approve…")` — the *only* report
+of a failed push, and deliberately non-fatal because the credentials are already
+issued and returned inline — went nowhere. `init_tracing()` installs one, with
+`lsm_tree` filtered out: its temp-dir teardown emits a screenful of harmless
+cleanup warnings exactly when a test fails, which would bury the line that
+matters.
+
+**The assertion could not distinguish "got 0" from "got 1".** `deliver_credentials`
+is a sequential loop with `?`, so a failure on the first push sends **zero** and a
+failure on the second sends **one** — different bugs, identical symptom. The
+panic now names the index, the timeout, how many arrived, and which of the two
+explanations applies.
+
+**`recv_matching` discarded every pickup error.** `if let Ok(Some(..)) = next`
+swallowed up to ~200 `Err`s per failure, so a broken socket and an unsent message
+looked the same. Errors are now counted and reported on timeout — still
+non-fatal, since a transient pickup error is expected and retrying is the point.
+
+## Verified
+
+The new panic path was exercised rather than assumed (timeout shortened, loop
+extended by one) and produces:
+
+```
+admission credential 3/2 not delivered over DIDComm within 3s (2 already received).
+The first arrived and the second did not, so the VTC either failed on the second
+`push_to_holder` (again warn-only) or the frame was lost between the mediator and
+this client.
+```
+
+with no `lsm_tree` noise around it. Restored to 60s / two credentials; the suite
+passes.

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.11.51"
+version = "0.11.52"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vtc-service/src/test_support.rs
+++ b/vtc-service/src/test_support.rs
@@ -938,12 +938,24 @@ mod didcomm_harness {
                 return Some(found);
             }
             let start = tokio::time::Instant::now();
+            // Pickup errors were discarded here. At a 300ms poll against a 60s
+            // bound that is up to ~200 silent failures behind a single "not
+            // delivered" — so a broken socket and an unsent message looked
+            // identical. Counted and reported on timeout instead; still not
+            // fatal, because a transient pickup error is expected and the retry
+            // is the point.
+            let mut poll_errors = 0usize;
+            let mut last_error = String::new();
             while start.elapsed() < timeout {
                 let next = self
                     .atm
                     .message_pickup()
                     .live_stream_next(&self.profile, Some(POLL), true)
                     .await;
+                if let Err(e) = &next {
+                    poll_errors += 1;
+                    last_error = e.to_string();
+                }
                 if let Ok(Some((msg, _meta))) = next {
                     if is_error_reply(&msg.typ)
                         && self.panic_on_problem_report.load(Ordering::SeqCst)
@@ -963,6 +975,15 @@ mod didcomm_harness {
                     }
                     self.inbox.lock().await.push_back(r);
                 }
+            }
+            if poll_errors > 0 {
+                tracing::warn!(
+                    poll_errors,
+                    last_error = %last_error,
+                    ?timeout,
+                    "message pickup errored while waiting; the awaited message may have been \
+                     lost to the transport rather than never sent"
+                );
             }
             None
         }

--- a/vtc-service/tests/join_didcomm.rs
+++ b/vtc-service/tests/join_didcomm.rs
@@ -16,8 +16,42 @@
 //!
 //! This is the template a downstream consumer (OpenVTC) copies to test its join
 //! + activation path against a real VTC.
+//!
+//! ## Debugging a credential-delivery failure
+//!
+//! Run with `RUST_LOG=vtc_service=debug cargo test -p vtc-service --test
+//! join_didcomm -- --nocapture`.
+//!
+//! Without a subscriber installed, the service's `warn!` lines go nowhere — and
+//! the one that matters here, *"membership-credential delivery failed on
+//! approve"*, is the only place a failed push is reported at all. Its caller
+//! deliberately swallows the error (the credentials are already issued and
+//! returned inline, so a delivery failure must not unwind the decision), which
+//! means a silent send failure and a lost frame look identical from the
+//! assertion. [`init_tracing`] installs the subscriber so they don't.
 
 use std::time::Duration;
+
+/// Install a `RUST_LOG`-driven subscriber once per test binary.
+///
+/// `try_init` rather than `init`: several tests in this binary may call it, and
+/// a second `init` panics.
+///
+/// The default filter silences `lsm_tree`, whose temp-dir teardown emits a
+/// screenful of "Failed to cleanup deleted table … No such file or directory"
+/// warnings on every run. Those are harmless and they are *only* printed when a
+/// test fails — which is precisely when they would bury the delivery warning
+/// this subscriber exists to surface. Override the whole thing with `RUST_LOG`
+/// when you want it back.
+fn init_tracing() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn,lsm_tree=off")),
+        )
+        .with_test_writer()
+        .try_init();
+}
 
 /// How long to wait for one admission credential to arrive over DIDComm.
 ///
@@ -159,6 +193,7 @@ async fn rest_post(
 
 #[tokio::test]
 async fn didcomm_join_round_trips_submit_manifest_status_approve_and_vmc_delivery() {
+    init_tracing();
     let mock = MockVtcDidcomm::start().await;
     let admin_token = seed_join_ceremony(&mock).await;
     let vtc_did = mock.vtc_did().to_string();
@@ -279,13 +314,37 @@ async fn didcomm_join_round_trips_submit_manifest_status_approve_and_vmc_deliver
     //    assertion on unrelated PRs — including one whose entire diff was a
     //    `pub use` line — so the bound, not the code, was what broke. Still
     //    bounded (never a hang), just past where runner slowness lives.
+    //    When this *does* fail, the message has to say which credential went
+    //    missing. `deliver_credentials` is a sequential loop with `?`, so a
+    //    failure on the first push sends **zero** and a failure on the second
+    //    sends **one** — two different bugs that a bare "not delivered" cannot
+    //    tell apart, and this assertion has fired on CI several times without
+    //    ever distinguishing them. The index is the whole diagnostic.
     let mut delivered = Vec::new();
-    for _ in 0..2 {
+    for i in 0..2 {
         let (typ, issue_body) = mock
             .client
             .next_pushed(CREDENTIAL_PUSH_TIMEOUT)
             .await
-            .expect("admission credential delivered over DIDComm");
+            .unwrap_or_else(|| {
+                panic!(
+                    "admission credential {}/2 not delivered over DIDComm within {:?} \
+                     ({} already received). {}",
+                    i + 1,
+                    CREDENTIAL_PUSH_TIMEOUT,
+                    delivered.len(),
+                    if i == 0 {
+                        "Zero arrived, so the VTC most likely never sent: \
+                         `deliver_credentials` returns on the first `?`, and its caller only \
+                         `warn!`s — which is invisible here unless a tracing subscriber is \
+                         installed (see RUST_LOG note at the top of this test)."
+                    } else {
+                        "The first arrived and the second did not, so the VTC either failed on \
+                         the second `push_to_holder` (again warn-only) or the frame was lost \
+                         between the mediator and this client."
+                    }
+                )
+            });
         assert_eq!(typ, CREDENTIAL_ISSUE_TYPE);
         let issue: IssueBody = serde_json::from_value(issue_body).expect("issue body");
         delivered.push(


### PR DESCRIPTION
`didcomm_join_round_trips_submit_manifest_status_approve_and_vmc_delivery` has
failed on CI at least **three times across unrelated PRs** (#903, #904 — one of
them a diff that was purely DIDComm framing in a different crate). Every failure
produced the same line, and no way to act on it:

```
panicked at vtc-service/tests/join_didcomm.rs:288:14:
admission credential delivered over DIDComm
```

**No production behaviour changes here, and this does not attempt a fix.** It
removes the three reasons the failure has never been attributable.

## What I ruled out

| Hypothesis | Verdict |
|---|---|
| R1.1 silent drop | **No** — `send_to_member` uses `Delivery::Guaranteed`: durable outbox, retries. Not a bare send |
| Idempotency-key collision deduping push #2 | **No** — `deliver_credentials` mints a fresh UUID per credential; `push_to_holder` uses it as the message id |
| Arrival-order race | **No** — already handled; the test collects both and searches |
| Runner slowness *(the test's own explanation)* | **Doesn't fit** — see below |

The slowness story is the one worth retiring. The bound is already **60s** on a
test that completes in ~23s on CI, and the client polls every **300ms** — so a
failure is ~200 consecutive empty polls. That is a message that isn't there, not
one that's late.

Six local runs did not reproduce it. **No root cause is claimed.**

## Three blind spots, removed

**1. No tracing subscriber.** These tests installed none, so the service's
`warn!("membership-credential delivery failed on approve…")` went nowhere. That
warn is the *only* report of a failed push — the caller deliberately swallows the
error, because the credentials are already issued and returned inline, so a
delivery failure must not unwind the decision. Result: a silent send failure and
a lost frame were indistinguishable.

`init_tracing()` installs one, filtering `lsm_tree` — its temp-dir teardown emits
a screenful of harmless cleanup warnings *precisely when a test fails*, which
would bury the line that matters. `RUST_LOG` overrides.

**2. The assertion couldn't tell "got 0" from "got 1".** `deliver_credentials` is
a sequential loop with `?`: a failure on the first push sends **zero**, a failure
on the second sends **one**. Two different bugs, identical symptom. The panic now
names the index, the timeout, how many arrived, and which explanation applies.

**3. `recv_matching` discarded every pickup error.** `if let Ok(Some(..)) = next`
swallowed up to ~200 `Err`s per failure, so a broken socket and an unsent message
looked the same. Now counted and reported on timeout — still non-fatal, since a
transient pickup error is expected and retrying is the point.

## Verified against a real failure, not assumed

Timeout shortened to 3s and the loop extended by one, to force the path:

```
admission credential 3/2 not delivered over DIDComm within 3s (2 already received).
The first arrived and the second did not, so the VTC either failed on the second
`push_to_holder` (again warn-only) or the frame was lost between the mediator and
this client.
```

`lsm_tree` lines in that output: **0**. Restored to 60s / two credentials; the
suite passes.

## What this buys

The next CI failure produces one data point that settles it: whether the VTC sent
zero, sent one, or sent two that didn't arrive — and, if the service logged a
send failure, the reason. That is what a fix needs and what nobody has had.

Deliberately **not** done: raising the timeout. If the message never arrives, a
bigger bound just fails slower.

## Pre-merge checklist (guide §9)

- [x] No new reqwest::Client::new() / bare fetch(); all clients have finite timeouts (R1.2) — n/a, test-only
- [x] No lock held across a network await (R1.3) — n/a
- [x] No local state committed before its remote effect, or the flow is resumable with an idempotency key (R2.1) — n/a
- [x] Every retry is bounded + backed off; non-idempotent ops are not blind-retried (R1.4) — the poll loop's bound is unchanged
- [x] Accept/poll/listen loops survive transient errors (R1.5) — unchanged behaviour; errors are now *counted* rather than discarded, still non-fatal
- [x] Acks/deletes happen only after durable handoff (R1.6) — unchanged
- [x] New/changed wire types: camelCase, deny_unknown_fields where security-relevant, schema registered, all consumers (incl. JS) updated (R3.*) — none
- [x] Config absence = most restrictive; fail-closed if enforcement can't start (R5.*) — n/a
- [x] Logs/status claim only what was verified; background-job failures are surfaced (R6.*) — **the point of the PR**: a swallowed delivery failure and a swallowed pickup error are both now surfaced
- [x] "Process dies on the next line" answered for every mutation touched (R2.1) — no mutations
- [x] Deviations from this guide flagged explicitly with rule numbers — none

Takes `0.11.52`; #905 already claims `0.11.51`.