### PR TITLE
fix(consent): an approver need not hold VTA authority to answer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10721,7 +10721,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.14.15"
+version = "0.14.16"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/changelog.d/907-approver-need-not-hold-authority.md
+++ b/changelog.d/907-approver-need-not-hold-authority.md
@@ -1,0 +1,54 @@
+### vta-service 0.14.16 — an approver need not hold VTA authority to answer (#907)
+
+A `task-consent/decision` is authorized by the document — the approver's
+Data-Integrity proof, checked against the policy-named approver set.
+`handle_decision` does not read its `AuthClaims` at all, and the PDP gate already
+exempts ceremony tasks from re-gating. But the ACL check every intrinsic-sender
+transport (DIDComm, TSP) runs before dispatch did not know that, and refused
+those senders outright.
+
+That inverts the model. An approver device holds no authority to *act* — the
+whole point of the `approve_scope` axis — so it has no reason to hold an ACL
+entry, and the consent subsystem is built for exactly that: both
+`compute_delegated_contexts` and the gate's eligibility count read "absent from
+the ACL" as *confers nothing*, never as *cannot speak*. Only the transport gate
+disagreed, and it disagreed first, before any of the code written to accommodate
+that approver could run.
+
+It failed silently in both directions. The VTA replies with a `permissionDenied`
+envelope an approver wallet has no reason to recognise, and logs nothing — the
+`trust-task received` line and every `consent.decision` audit row live past the
+gate. So a decision a human gave and a wallet sent looked, from either end,
+exactly like one that was never delivered, while the requester re-submitted into
+a pending that could never be granted.
+
+The ceremony predicate now lives in `trust_tasks::ceremony`, shared by the PDP
+gate and both transports so the two cannot disagree about what a ceremony task
+is. When — and only when — the ACL turns a sender away and the envelope names a
+ceremony task, `messaging::auth::auth_for_trust_task_envelope` dispatches on the
+proven sender DID over `Role::Monitor` with no contexts: authorized nowhere, and
+no session row minted. It is a fallback, not an override — an enrolled sender
+keeps the claims its entry earns it, an expired grant does not resurrect its
+role, every non-ceremony task from an unenrolled DID is refused as before, and an
+unparseable body is not a ceremony task.
+
+The carve-out is floored on approver-set membership for consent decisions, since
+a decision citing an unknown digest writes a durable audit row and retention is
+time-based rather than size-capped. That keeps the write to DIDs the operator
+actually named, without narrowing the population the feature serves. Step-up
+`approve-response` is deliberately unfiltered: its authorized signer is
+`pending.approver`, recorded at mint and not required to hold an ACL entry (the
+delegated phone-as-authorizer), and it writes no audit row on an unknown
+challenge.
+
+Both transports now name the sender and type URI when they refuse a trust task,
+and a refused ceremony task says which of the two enrolments — approver set or
+ACL — is missing.
+
+**Operator note.** An approver device needs to be in the approver set the policy
+names; it no longer additionally needs an ACL entry to deliver its decision. An
+ACL entry granted purely to get an approver past the transport (e.g.
+`--role reader --approve-contexts …` with no act scope) is still honoured and
+still what you want when the approver must *confer* a context the requester
+lacks — approve-authority for delegation is resolved from live ACL state at the
+moment the grant is minted, and is unchanged by this release.

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.14.15"
+version = "0.14.16"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/messaging/auth.rs
+++ b/vta-service/src/messaging/auth.rs
@@ -28,6 +28,89 @@ pub async fn auth_from_message(
     auth_from_did(did, acl_ks, sessions_ks).await
 }
 
+/// Resolve claims for a **Trust-Task envelope** arriving on an intrinsic-sender
+/// transport (DIDComm authcrypt, raw TSP).
+///
+/// This is [`auth_from_did`] plus one carve-out, and it is the only entry point
+/// the two transports should use for the trust-task surface.
+///
+/// ## The carve-out
+///
+/// A ceremony task — a `task-consent/decision`, a step-up `approve-response` —
+/// is authorized by the **document**: the approver's Data-Integrity proof
+/// establishes who signed, and the handler checks that signer against the
+/// policy-named approver set (or the pending step-up it echoes). The submitting
+/// peer's standing at this VTA decides nothing; `task_consent::handle_decision`
+/// does not read its `AuthClaims` at all.
+///
+/// Yet the ACL lookup ran first and refused those senders outright, which meant
+/// the least-privilege approver the `approve_scope` axis exists to serve — a
+/// device that may *confer* a context and *act* in none, and which therefore has
+/// no reason to hold an ACL entry — could never deliver its answer. The
+/// surrounding consent code already assumes such an approver can appear:
+/// `compute_delegated_contexts` and the gate's eligibility count both treat
+/// "absent from the ACL" as *confers nothing*, not *cannot speak*. Only this
+/// gate disagreed, and it disagreed first.
+///
+/// So when — and only when — the ACL turns a sender away (`Forbidden`: unknown
+/// DID, or a lapsed grant) **and** the envelope names a ceremony task, dispatch
+/// proceeds on [`ceremony_claims`]: the proven sender DID over a role and
+/// context list that reach nothing. Every other failure, and every other task,
+/// is refused exactly as before.
+///
+/// An expired grant falls through the same way on purpose. Approve-authority
+/// comes from the approver set, not from an ACL row; and where a grant's
+/// *delegation* does depend on live ACL state, `compute_delegated_contexts`
+/// re-reads it and refuses the expired entry there — at the point where it
+/// actually confers something.
+///
+/// [`ceremony_claims`]: crate::trust_tasks::ceremony::ceremony_claims
+pub async fn auth_for_trust_task_envelope(
+    sender_did: &str,
+    body: &[u8],
+    acl_ks: &KeyspaceHandle,
+    sessions_ks: &KeyspaceHandle,
+) -> Result<AuthClaims, AppError> {
+    use crate::trust_tasks::ceremony;
+
+    let denial = match auth_from_did(sender_did, acl_ks, sessions_ks).await {
+        Ok(auth) => return Ok(auth),
+        // Only an authorization denial is eligible. A store or session failure
+        // is an infrastructure fault, and quietly downgrading it to a
+        // zero-authority dispatch would hide it behind a task that then fails
+        // for some unrelated-looking reason.
+        Err(AppError::Forbidden(why)) => why,
+        Err(e) => return Err(e),
+    };
+
+    let type_uri = ceremony::peek_type_uri(body);
+    match type_uri.as_deref() {
+        Some(uri) if ceremony::is_ceremony_task(uri) => {
+            tracing::info!(
+                sender = %sender_did,
+                type_uri = %uri,
+                acl = %denial,
+                "ceremony task from a sender with no ACL standing — dispatching on a \
+                 zero-authority claim; the document's own proof is the authority"
+            );
+            Ok(ceremony::ceremony_claims(sender_did))
+        }
+        // Named so the operator can tell a refused task from one that never
+        // arrived. Without this the reply is a `permissionDenied` envelope the
+        // peer may not surface, and the VTA logs nothing at all — which is how a
+        // consent ceremony that was answered by a human looked, from both ends,
+        // exactly like one that was never delivered.
+        other => {
+            tracing::warn!(
+                sender = %sender_did,
+                type_uri = other.unwrap_or("<unparseable>"),
+                "refusing trust task: {denial}"
+            );
+            Err(AppError::Forbidden(denial))
+        }
+    }
+}
+
 /// Resolve an envelope-authenticated sender DID into unified `AuthClaims`.
 ///
 /// This is the DID-based core shared by every intrinsic-sender transport
@@ -243,6 +326,150 @@ mod tests {
             .await
             .unwrap_err();
         assert!(matches!(err, AppError::Authentication(_)), "got {err:?}");
+    }
+
+    // ── The ceremony carve-out ───────────────────────────────────────────
+    //
+    // An approver device holds no authority to *act* — that is the entire point
+    // of the `approve_scope` axis — so it has no reason to hold an ACL entry.
+    // Before these, the transport gate refused it before any of the consent code
+    // written to accommodate it could run, and the operator saw an approval that
+    // a human gave, the wallet sent, and the VTA silently discarded.
+
+    const DECISION: &str = vta_sdk::trust_tasks::TASK_TASK_CONSENT_DECISION_0_1;
+    const ORDINARY: &str = "https://trusttasks.org/spec/vta/webvh/dids/update/1.0";
+
+    fn envelope(type_uri: &str) -> Vec<u8> {
+        serde_json::to_vec(&serde_json::json!({
+            "id": "urn:uuid:00000000-0000-0000-0000-000000000001",
+            "type": type_uri,
+            "issuer": "did:key:zApproverDevice",
+            "recipient": "did:example:vta",
+            "issuedAt": "2026-08-08T21:56:00Z",
+            "payload": { "challenge": "n", "payloadDigest": "d", "decision": "approve" },
+        }))
+        .unwrap()
+    }
+
+    /// The case from the field: an approver in the VTA's `approver_set` but not
+    /// in its ACL. Its decision must reach the dispatcher.
+    #[tokio::test]
+    async fn a_ceremony_task_from_an_unenrolled_approver_is_dispatched() {
+        let (_store, acl_ks, sessions_ks, _dir) = fresh_acl_ks().await;
+        let approver = "did:key:zApproverNotInAcl";
+
+        let claims =
+            auth_for_trust_task_envelope(approver, &envelope(DECISION), &acl_ks, &sessions_ks)
+                .await
+                .expect("an unenrolled approver must be able to deliver its decision");
+
+        // The proven DID rides through — replay dedup, the audit trail and
+        // `handle_approve_response`'s issuer check all key on it.
+        assert_eq!(claims.did, approver);
+        // …carrying no authority whatsoever.
+        assert_eq!(claims.role, Role::Monitor);
+        assert!(claims.allowed_contexts.is_empty());
+        assert!(!claims.is_super_admin());
+    }
+
+    /// The carve-out is for ceremony tasks and nothing else. The same
+    /// unenrolled DID submitting the operation the ceremony *authorizes* is
+    /// refused exactly as before — otherwise this would be a hole, not a gate.
+    #[tokio::test]
+    async fn the_same_unenrolled_sender_cannot_submit_an_ordinary_task() {
+        let (_store, acl_ks, sessions_ks, _dir) = fresh_acl_ks().await;
+        let err = auth_for_trust_task_envelope(
+            "did:key:zApproverNotInAcl",
+            &envelope(ORDINARY),
+            &acl_ks,
+            &sessions_ks,
+        )
+        .await
+        .expect_err("a webvh update from an unenrolled DID must still be refused");
+        assert!(matches!(err, AppError::Forbidden(_)), "got {err:?}");
+    }
+
+    /// A body we cannot read is not a ceremony task. Nothing may talk its way
+    /// past the ACL by being unparseable.
+    #[tokio::test]
+    async fn an_unreadable_envelope_from_an_unenrolled_sender_is_refused() {
+        let (_store, acl_ks, sessions_ks, _dir) = fresh_acl_ks().await;
+        for body in [b"not json".as_slice(), b"{}".as_slice(), b"".as_slice()] {
+            let err =
+                auth_for_trust_task_envelope("did:key:zStranger", body, &acl_ks, &sessions_ks)
+                    .await
+                    .expect_err("an unparseable body must not reach the carve-out");
+            assert!(matches!(err, AppError::Forbidden(_)), "got {err:?}");
+        }
+    }
+
+    /// The carve-out is a *fallback*, not an override. An approver that IS
+    /// enrolled keeps the claims its ACL entry earns it — a co-located approver
+    /// which is also an admin must not be silently downgraded.
+    #[tokio::test]
+    async fn an_enrolled_sender_keeps_its_real_claims_on_a_ceremony_task() {
+        let (_store, acl_ks, sessions_ks, _dir) = fresh_acl_ks().await;
+        let did = "did:key:zEnrolledApprover";
+        store_acl_entry(
+            &acl_ks,
+            &AclEntry::new(did, Role::Admin, "test").with_contexts(vec!["ctx-a".into()]),
+        )
+        .await
+        .unwrap();
+
+        let claims = auth_for_trust_task_envelope(did, &envelope(DECISION), &acl_ks, &sessions_ks)
+            .await
+            .unwrap();
+        assert_eq!(claims.role, Role::Admin);
+        assert_eq!(claims.allowed_contexts, vec!["ctx-a"]);
+    }
+
+    /// A lapsed ACL grant must not strand a decision either. Approve-authority
+    /// comes from the approver set, not from an ACL row; where a grant's
+    /// *delegation* does depend on live ACL state, `compute_delegated_contexts`
+    /// re-reads it and refuses the expired entry at the point it would actually
+    /// confer something.
+    #[tokio::test]
+    async fn an_expired_grant_still_lets_a_ceremony_task_through_with_nothing() {
+        let (_store, acl_ks, sessions_ks, _dir) = fresh_acl_ks().await;
+        let did = "did:key:zLapsedApprover";
+        store_acl_entry(
+            &acl_ks,
+            &AclEntry::new(did, Role::Admin, "test")
+                .with_contexts(vec!["ctx-a".into()])
+                .with_created_at(now_epoch().saturating_sub(7200))
+                .with_expires_at(Some(now_epoch().saturating_sub(60))),
+        )
+        .await
+        .unwrap();
+
+        let claims = auth_for_trust_task_envelope(did, &envelope(DECISION), &acl_ks, &sessions_ks)
+            .await
+            .expect("a lapsed grant must not strand an approval");
+        assert_eq!(
+            claims.role,
+            Role::Monitor,
+            "the lapsed entry's admin role must NOT be resurrected by the carve-out"
+        );
+        assert!(claims.allowed_contexts.is_empty());
+    }
+
+    /// No session row is minted for an unenrolled approver. Otherwise any DID
+    /// that can reach the mediator could write one.
+    #[tokio::test]
+    async fn the_carve_out_does_not_mint_a_session_for_an_unenrolled_did() {
+        use crate::auth::session::get_session;
+        let (_store, acl_ks, sessions_ks, _dir) = fresh_acl_ks().await;
+        let approver = "did:key:zNoSessionPlease";
+
+        auth_for_trust_task_envelope(approver, &envelope(DECISION), &acl_ks, &sessions_ks)
+            .await
+            .unwrap();
+
+        assert!(
+            get_session(&sessions_ks, approver).await.unwrap().is_none(),
+            "a ceremony dispatch must not create session state for an unenrolled DID"
+        );
     }
 
     /// First contact reports `aal1`, keyed on the DID. After a step-up elevates

--- a/vta-service/src/messaging/auth.rs
+++ b/vta-service/src/messaging/auth.rs
@@ -64,16 +64,21 @@ pub async fn auth_from_message(
 /// re-reads it and refuses the expired entry there — at the point where it
 /// actually confers something.
 ///
+/// The carve-out is additionally floored by
+/// [`may_attempt_ceremony`](crate::trust_tasks::ceremony::may_attempt_ceremony),
+/// so a consent decision only reaches the dispatcher from a DID the operator
+/// actually named as an approver. That keeps the durable write a rejected
+/// decision produces out of reach of anyone who merely found the mediator.
+///
 /// [`ceremony_claims`]: crate::trust_tasks::ceremony::ceremony_claims
 pub async fn auth_for_trust_task_envelope(
+    state: &crate::server::AppState,
     sender_did: &str,
     body: &[u8],
-    acl_ks: &KeyspaceHandle,
-    sessions_ks: &KeyspaceHandle,
 ) -> Result<AuthClaims, AppError> {
     use crate::trust_tasks::ceremony;
 
-    let denial = match auth_from_did(sender_did, acl_ks, sessions_ks).await {
+    let denial = match auth_from_did(sender_did, &state.acl_ks, &state.sessions_ks).await {
         Ok(auth) => return Ok(auth),
         // Only an authorization denial is eligible. A store or session failure
         // is an infrastructure fault, and quietly downgrading it to a
@@ -85,7 +90,10 @@ pub async fn auth_for_trust_task_envelope(
 
     let type_uri = ceremony::peek_type_uri(body);
     match type_uri.as_deref() {
-        Some(uri) if ceremony::is_ceremony_task(uri) => {
+        Some(uri)
+            if ceremony::is_ceremony_task(uri)
+                && ceremony::may_attempt_ceremony(state, uri, sender_did).await =>
+        {
             tracing::info!(
                 sender = %sender_did,
                 type_uri = %uri,
@@ -100,12 +108,28 @@ pub async fn auth_for_trust_task_envelope(
         // peer may not surface, and the VTA logs nothing at all — which is how a
         // consent ceremony that was answered by a human looked, from both ends,
         // exactly like one that was never delivered.
+        //
+        // A ceremony task landing here means the sender is in neither the ACL
+        // nor any approver set — most often an approver the operator added to
+        // one and not the other. Say so, because from the wallet's side the two
+        // are indistinguishable.
         other => {
-            tracing::warn!(
-                sender = %sender_did,
-                type_uri = other.unwrap_or("<unparseable>"),
-                "refusing trust task: {denial}"
-            );
+            let uri = other.unwrap_or("<unparseable>");
+            if ceremony::is_ceremony_task(uri) {
+                tracing::warn!(
+                    sender = %sender_did,
+                    type_uri = %uri,
+                    "refusing a ceremony task: this sender is in no configured approver set \
+                     and has no ACL entry ({denial}). If this is an approver device, add it to \
+                     the approver set the policy names"
+                );
+            } else {
+                tracing::warn!(
+                    sender = %sender_did,
+                    type_uri = %uri,
+                    "refusing trust task: {denial}"
+                );
+            }
             Err(AppError::Forbidden(denial))
         }
     }
@@ -337,13 +361,15 @@ mod tests {
     // a human gave, the wallet sent, and the VTA silently discarded.
 
     const DECISION: &str = vta_sdk::trust_tasks::TASK_TASK_CONSENT_DECISION_0_1;
+    const STEP_UP: &str = vta_sdk::trust_tasks::TASK_AUTH_STEP_UP_APPROVE_RESPONSE_0_2;
     const ORDINARY: &str = "https://trusttasks.org/spec/vta/webvh/dids/update/1.0";
+    const APPROVER: &str = "did:key:zApproverNotInAcl";
 
     fn envelope(type_uri: &str) -> Vec<u8> {
         serde_json::to_vec(&serde_json::json!({
             "id": "urn:uuid:00000000-0000-0000-0000-000000000001",
             "type": type_uri,
-            "issuer": "did:key:zApproverDevice",
+            "issuer": APPROVER,
             "recipient": "did:example:vta",
             "issuedAt": "2026-08-08T21:56:00Z",
             "payload": { "challenge": "n", "payloadDigest": "d", "decision": "approve" },
@@ -351,41 +377,77 @@ mod tests {
         .unwrap()
     }
 
+    /// State whose `webvh-approvers` set names `APPROVER` — the operator has
+    /// declared it an approver, and has (correctly) given it no ACL entry.
+    async fn state_with_named_approver() -> (crate::server::AppState, tempfile::TempDir) {
+        let (state, dir) = crate::test_support::build_signing_test_app_state().await;
+        state
+            .config
+            .write()
+            .await
+            .policy
+            .approver_sets
+            .insert("webvh-approvers".into(), vec![APPROVER.into()]);
+        (state, dir)
+    }
+
     /// The case from the field: an approver in the VTA's `approver_set` but not
     /// in its ACL. Its decision must reach the dispatcher.
     #[tokio::test]
     async fn a_ceremony_task_from_an_unenrolled_approver_is_dispatched() {
-        let (_store, acl_ks, sessions_ks, _dir) = fresh_acl_ks().await;
-        let approver = "did:key:zApproverNotInAcl";
+        let (state, _dir) = state_with_named_approver().await;
 
-        let claims =
-            auth_for_trust_task_envelope(approver, &envelope(DECISION), &acl_ks, &sessions_ks)
-                .await
-                .expect("an unenrolled approver must be able to deliver its decision");
+        let claims = auth_for_trust_task_envelope(&state, APPROVER, &envelope(DECISION))
+            .await
+            .expect("an unenrolled approver must be able to deliver its decision");
 
         // The proven DID rides through — replay dedup, the audit trail and
         // `handle_approve_response`'s issuer check all key on it.
-        assert_eq!(claims.did, approver);
+        assert_eq!(claims.did, APPROVER);
         // …carrying no authority whatsoever.
         assert_eq!(claims.role, Role::Monitor);
         assert!(claims.allowed_contexts.is_empty());
         assert!(!claims.is_super_admin());
     }
 
-    /// The carve-out is for ceremony tasks and nothing else. The same
-    /// unenrolled DID submitting the operation the ceremony *authorizes* is
-    /// refused exactly as before — otherwise this would be a hole, not a gate.
+    /// The floor on the carve-out. A DID in no approver set is refused before it
+    /// can reach `handle_decision` — whose `denied:no_pending` audit row is a
+    /// durable write, and audit retention is time-based, not size-capped. Only
+    /// DIDs the operator actually named get to spend that write.
     #[tokio::test]
-    async fn the_same_unenrolled_sender_cannot_submit_an_ordinary_task() {
-        let (_store, acl_ks, sessions_ks, _dir) = fresh_acl_ks().await;
-        let err = auth_for_trust_task_envelope(
-            "did:key:zApproverNotInAcl",
-            &envelope(ORDINARY),
-            &acl_ks,
-            &sessions_ks,
-        )
-        .await
-        .expect_err("a webvh update from an unenrolled DID must still be refused");
+    async fn a_stranger_cannot_use_a_consent_decision_to_reach_the_handler() {
+        let (state, _dir) = state_with_named_approver().await;
+        let err = auth_for_trust_task_envelope(&state, "did:key:zPasserby", &envelope(DECISION))
+            .await
+            .expect_err("a DID in no approver set must not reach the consent handler");
+        assert!(matches!(err, AppError::Forbidden(_)), "got {err:?}");
+    }
+
+    /// Step-up is deliberately unfiltered: its authorized signer is
+    /// `pending.approver`, recorded at mint and not required to hold an ACL
+    /// entry — the delegated phone-as-authorizer — and no cheap membership test
+    /// covers it. It needs no floor either: `handle_approve_response` writes no
+    /// audit row on an unknown challenge, so there is no durable write to spend.
+    #[tokio::test]
+    async fn a_step_up_approve_response_needs_no_approver_set_membership() {
+        let (state, _dir) = state_with_named_approver().await;
+        let claims =
+            auth_for_trust_task_envelope(&state, "did:key:zHoldersPhone", &envelope(STEP_UP))
+                .await
+                .expect("a delegated step-up approver holds neither ACL entry nor set membership");
+        assert_eq!(claims.role, Role::Monitor);
+        assert!(claims.allowed_contexts.is_empty());
+    }
+
+    /// The carve-out is for ceremony tasks and nothing else. The same
+    /// named approver submitting the operation the ceremony *authorizes* is
+    /// refused — otherwise this would be a hole, not a gate.
+    #[tokio::test]
+    async fn a_named_approver_still_cannot_submit_an_ordinary_task() {
+        let (state, _dir) = state_with_named_approver().await;
+        let err = auth_for_trust_task_envelope(&state, APPROVER, &envelope(ORDINARY))
+            .await
+            .expect_err("a webvh update from an unenrolled DID must still be refused");
         assert!(matches!(err, AppError::Forbidden(_)), "got {err:?}");
     }
 
@@ -393,12 +455,11 @@ mod tests {
     /// past the ACL by being unparseable.
     #[tokio::test]
     async fn an_unreadable_envelope_from_an_unenrolled_sender_is_refused() {
-        let (_store, acl_ks, sessions_ks, _dir) = fresh_acl_ks().await;
+        let (state, _dir) = state_with_named_approver().await;
         for body in [b"not json".as_slice(), b"{}".as_slice(), b"".as_slice()] {
-            let err =
-                auth_for_trust_task_envelope("did:key:zStranger", body, &acl_ks, &sessions_ks)
-                    .await
-                    .expect_err("an unparseable body must not reach the carve-out");
+            let err = auth_for_trust_task_envelope(&state, APPROVER, body)
+                .await
+                .expect_err("an unparseable body must not reach the carve-out");
             assert!(matches!(err, AppError::Forbidden(_)), "got {err:?}");
         }
     }
@@ -408,16 +469,16 @@ mod tests {
     /// which is also an admin must not be silently downgraded.
     #[tokio::test]
     async fn an_enrolled_sender_keeps_its_real_claims_on_a_ceremony_task() {
-        let (_store, acl_ks, sessions_ks, _dir) = fresh_acl_ks().await;
+        let (state, _dir) = state_with_named_approver().await;
         let did = "did:key:zEnrolledApprover";
         store_acl_entry(
-            &acl_ks,
+            &state.acl_ks,
             &AclEntry::new(did, Role::Admin, "test").with_contexts(vec!["ctx-a".into()]),
         )
         .await
         .unwrap();
 
-        let claims = auth_for_trust_task_envelope(did, &envelope(DECISION), &acl_ks, &sessions_ks)
+        let claims = auth_for_trust_task_envelope(&state, did, &envelope(DECISION))
             .await
             .unwrap();
         assert_eq!(claims.role, Role::Admin);
@@ -431,11 +492,10 @@ mod tests {
     /// confer something.
     #[tokio::test]
     async fn an_expired_grant_still_lets_a_ceremony_task_through_with_nothing() {
-        let (_store, acl_ks, sessions_ks, _dir) = fresh_acl_ks().await;
-        let did = "did:key:zLapsedApprover";
+        let (state, _dir) = state_with_named_approver().await;
         store_acl_entry(
-            &acl_ks,
-            &AclEntry::new(did, Role::Admin, "test")
+            &state.acl_ks,
+            &AclEntry::new(APPROVER, Role::Admin, "test")
                 .with_contexts(vec!["ctx-a".into()])
                 .with_created_at(now_epoch().saturating_sub(7200))
                 .with_expires_at(Some(now_epoch().saturating_sub(60))),
@@ -443,7 +503,7 @@ mod tests {
         .await
         .unwrap();
 
-        let claims = auth_for_trust_task_envelope(did, &envelope(DECISION), &acl_ks, &sessions_ks)
+        let claims = auth_for_trust_task_envelope(&state, APPROVER, &envelope(DECISION))
             .await
             .expect("a lapsed grant must not strand an approval");
         assert_eq!(
@@ -459,15 +519,17 @@ mod tests {
     #[tokio::test]
     async fn the_carve_out_does_not_mint_a_session_for_an_unenrolled_did() {
         use crate::auth::session::get_session;
-        let (_store, acl_ks, sessions_ks, _dir) = fresh_acl_ks().await;
-        let approver = "did:key:zNoSessionPlease";
+        let (state, _dir) = state_with_named_approver().await;
 
-        auth_for_trust_task_envelope(approver, &envelope(DECISION), &acl_ks, &sessions_ks)
+        auth_for_trust_task_envelope(&state, APPROVER, &envelope(DECISION))
             .await
             .unwrap();
 
         assert!(
-            get_session(&sessions_ks, approver).await.unwrap().is_none(),
+            get_session(&state.sessions_ks, APPROVER)
+                .await
+                .unwrap()
+                .is_none(),
             "a ceremony dispatch must not create session state for an unenrolled DID"
         );
     }

--- a/vta-service/src/messaging/handlers.rs
+++ b/vta-service/src/messaging/handlers.rs
@@ -300,10 +300,7 @@ pub async fn handle_trust_task(
     // overwrites the plaintext `from` with it (or `None`) before routing, so a
     // missing sender means the envelope was never authenticated.
     let authenticated = match message.from.as_deref() {
-        Some(sender) => {
-            auth_for_trust_task_envelope(sender, &body, &app_state.acl_ks, &app_state.sessions_ks)
-                .await
-        }
+        Some(sender) => auth_for_trust_task_envelope(&app_state, sender, &body).await,
         None => Err(AppError::Authentication(
             "message has no sender (from)".into(),
         )),

--- a/vta-service/src/messaging/handlers.rs
+++ b/vta-service/src/messaging/handlers.rs
@@ -19,7 +19,7 @@ use tracing::{info, warn};
 
 use crate::acl::Role;
 use crate::error::AppError;
-use crate::messaging::auth::auth_from_message;
+use crate::messaging::auth::{auth_for_trust_task_envelope, auth_from_message};
 use crate::operations;
 use crate::server::AppState;
 
@@ -288,26 +288,46 @@ pub async fn handle_trust_task(
     // failure (e.g. the peer has no ACL entry) reply with a Trust-Task
     // `permission_denied` *envelope*, not a DIDComm problem-report — a
     // conformant Trust-Task client only understands binding envelopes.
-    let response =
-        match auth_from_message(&message, &app_state.acl_ks, &app_state.sessions_ks).await {
-            // Authcrypt sealed this envelope to the VTA's own key, so no
-            // intermediary — mediator included — held the plaintext.
-            Ok(auth) => {
-                crate::trust_tasks::dispatch_trust_task_core(
-                    &app_state,
-                    &auth,
-                    &body,
-                    crate::trust_tasks::transport::TransportConfidentiality::EndToEnd,
-                )
+    //
+    // Routed through `auth_for_trust_task_envelope` rather than
+    // `auth_from_message` so a ceremony task (a `task-consent/decision`, a
+    // step-up `approve-response`) from an approver with no ACL standing is
+    // dispatched on a zero-authority claim instead of being refused at the
+    // door — the document's own proof is the authority there. See that
+    // function.
+    //
+    // `message.from` here is the *proven* authcrypt sender — `handle_didcomm`
+    // overwrites the plaintext `from` with it (or `None`) before routing, so a
+    // missing sender means the envelope was never authenticated.
+    let authenticated = match message.from.as_deref() {
+        Some(sender) => {
+            auth_for_trust_task_envelope(sender, &body, &app_state.acl_ks, &app_state.sessions_ks)
                 .await
-            }
-            Err(e) => crate::trust_tasks::reject_trust_task(
+        }
+        None => Err(AppError::Authentication(
+            "message has no sender (from)".into(),
+        )),
+    };
+
+    let response = match authenticated {
+        // Authcrypt sealed this envelope to the VTA's own key, so no
+        // intermediary — mediator included — held the plaintext.
+        Ok(auth) => {
+            crate::trust_tasks::dispatch_trust_task_core(
+                &app_state,
+                &auth,
                 &body,
-                trust_tasks_rs::RejectReason::PermissionDenied {
-                    reason: e.to_string(),
-                },
-            ),
-        };
+                crate::trust_tasks::transport::TransportConfidentiality::EndToEnd,
+            )
+            .await
+        }
+        Err(e) => crate::trust_tasks::reject_trust_task(
+            &body,
+            trust_tasks_rs::RejectReason::PermissionDenied {
+                reason: e.to_string(),
+            },
+        ),
+    };
 
     // The dispatch core returns a typed `TrustTaskOutcome`; its `body` is
     // already the serialised framework trust-task document, so we parse it

--- a/vta-service/src/messaging/tsp_inbound.rs
+++ b/vta-service/src/messaging/tsp_inbound.rs
@@ -63,14 +63,7 @@ pub async fn dispatch_one(app_state: &AppState, payload: &[u8], sender_vid: &str
     // a zero-authority claim rather than refused. Kept identical to the DIDComm
     // bridge — an approver must not be able to reach the VTA over one transport
     // and not the other.
-    let outcome = match auth_for_trust_task_envelope(
-        sender_vid,
-        payload,
-        &app_state.acl_ks,
-        &app_state.sessions_ks,
-    )
-    .await
-    {
+    let outcome = match auth_for_trust_task_envelope(app_state, sender_vid, payload).await {
         // TSP seals to the recipient VID, same guarantee as authcrypt.
         Ok(auth) => {
             crate::trust_tasks::dispatch_trust_task_core(

--- a/vta-service/src/messaging/tsp_inbound.rs
+++ b/vta-service/src/messaging/tsp_inbound.rs
@@ -29,7 +29,7 @@
 
 use tracing::info;
 
-use crate::messaging::auth::auth_from_did;
+use crate::messaging::auth::auth_for_trust_task_envelope;
 use crate::server::AppState;
 
 /// Per-message bridge: turn one unpacked TSP message into a dispatched Trust
@@ -57,7 +57,20 @@ pub async fn dispatch_one(app_state: &AppState, payload: &[u8], sender_vid: &str
     // transport fact, and only DIDs we later push to are ever queried.
     app_state.tsp_reach.record(sender_vid);
     tracing::debug!(sender = %sender_vid, "recorded TSP reachability (learn-from-inbound)");
-    let outcome = match auth_from_did(sender_vid, &app_state.acl_ks, &app_state.sessions_ks).await {
+    // `auth_for_trust_task_envelope`, not the bare ACL lookup: a ceremony task
+    // (`task-consent/decision`, step-up `approve-response`) is authorized by the
+    // document's own proof, so an approver with no ACL standing is dispatched on
+    // a zero-authority claim rather than refused. Kept identical to the DIDComm
+    // bridge — an approver must not be able to reach the VTA over one transport
+    // and not the other.
+    let outcome = match auth_for_trust_task_envelope(
+        sender_vid,
+        payload,
+        &app_state.acl_ks,
+        &app_state.sessions_ks,
+    )
+    .await
+    {
         // TSP seals to the recipient VID, same guarantee as authcrypt.
         Ok(auth) => {
             crate::trust_tasks::dispatch_trust_task_core(

--- a/vta-service/src/trust_tasks/ceremony.rs
+++ b/vta-service/src/trust_tasks/ceremony.rs
@@ -1,0 +1,180 @@
+//! Ceremony tasks — the mechanism by which authority is granted, as distinct
+//! from the operations that consume it.
+//!
+//! Three Type URIs carry their **own** authority in the document: a
+//! `task-consent/decision` is authorized by the approver's Data-Integrity proof
+//! plus membership of the policy-named approver set; a step-up
+//! `approve-response` by the approver's proof plus the pending step-up it
+//! echoes. In neither case does the submitting peer's standing at this VTA
+//! decide anything — the handlers read the proven signer, and
+//! [`is_ceremony_task`] is what keeps the PDP from re-gating them (approving a
+//! task must not itself require approval).
+//!
+//! ## Why this module exists
+//!
+//! The predicate used to be private to `policy_gate`, which meant only *one* of
+//! the two gates in front of a handler knew about it. The other — the ACL check
+//! every intrinsic-sender transport runs on the authcrypt/TSP sender before
+//! dispatch — applied to ceremony tasks like any other, and refused them.
+//!
+//! That inverts the model. The consent subsystem is explicitly built for an
+//! approver that holds no authority to *act*: `task_consent::
+//! compute_delegated_contexts` and `policy_gate`'s eligibility count both read
+//! "absent from the ACL" as **confers nothing**, never as **cannot speak**.
+//! `handle_decision` does not so much as look at its `AuthClaims`. The
+//! least-privilege approver the whole `approve_scope` axis exists to serve — a
+//! device that can confer a context and act in none — was nonetheless turned
+//! away at the door, before any of the code written to accommodate it ran.
+//!
+//! Worse, it failed *silently*: the transport replies with a `permissionDenied`
+//! envelope that an approver wallet has no reason to recognise, so the operator
+//! sees an approval that was given, accepted by the human, and then simply
+//! never took effect — while the requester re-submits into a pending that will
+//! never be granted.
+//!
+//! So the two gates now share one predicate, and `messaging::auth::
+//! auth_for_trust_task_envelope` lets a ceremony task through on a
+//! zero-authority claim when — and only when — the ACL turns its sender away.
+
+#[cfg(feature = "didcomm")]
+use crate::auth::AuthClaims;
+
+/// Does this Type URI name a ceremony task?
+///
+/// Ceremony tasks carry their own authority (an approver's proof, a step-up
+/// approve-response) and must NOT themselves be gated — else approving a task
+/// could itself require consent/step-up, ad infinitum.
+#[allow(deprecated)]
+pub(crate) fn is_ceremony_task(type_uri: &str) -> bool {
+    use vta_sdk::trust_tasks as t;
+    type_uri == t::TASK_TASK_CONSENT_DECISION_0_1
+        || type_uri == t::TASK_AUTH_STEP_UP_APPROVE_RESPONSE_0_1
+        || type_uri == t::TASK_AUTH_STEP_UP_APPROVE_RESPONSE_0_2
+}
+
+/// Read just the `type` member out of a Trust-Task envelope.
+///
+/// Deliberately not a full `TrustTask<Value>` parse: this runs *before*
+/// authentication, on bytes from a peer we have not yet authorized, and it must
+/// answer exactly one question — "is this a ceremony task?" — without taking a
+/// position on anything else in the document. A body that doesn't parse, or
+/// carries no `type`, yields `None` and is treated as an ordinary task, so a
+/// malformed envelope can never talk its way past the ACL.
+///
+/// The envelope is re-parsed and fully validated by the dispatch spine
+/// afterwards; nothing here is trusted beyond routing this one decision.
+///
+/// Only the intrinsic-sender transports need this — REST authenticates on a JWT
+/// the caller had to obtain first, so there is no pre-auth routing decision to
+/// make there.
+#[cfg(feature = "didcomm")]
+pub(crate) fn peek_type_uri(body: &[u8]) -> Option<String> {
+    #[derive(serde::Deserialize)]
+    struct TypeOnly {
+        #[serde(rename = "type")]
+        type_uri: String,
+    }
+    serde_json::from_slice::<TypeOnly>(body)
+        .ok()
+        .map(|t| t.type_uri)
+}
+
+/// Claims for a ceremony task from a sender the ACL does not know.
+///
+/// Carries the **proven** sender DID — the authcrypt/TSP unpack established it,
+/// and the replay-dedup key, the audit trail and `handle_approve_response`'s
+/// `issuer == caller` check all read it — over the least-privileged role in the
+/// system with no contexts. Per the workspace's act-scope rule, a non-`Admin`
+/// role with an empty `allowed_contexts` is authorized *nowhere*, so if a
+/// ceremony handler ever does consult its claims it is handed standing to do
+/// precisely nothing.
+///
+/// No session row is created. An unenrolled approver is not a session-holder at
+/// this VTA, and minting a session for one would let any DID that can reach the
+/// mediator write a row. `session_id` mirrors the DID-keyed convention
+/// [`vti_common::auth::session::resolve_did_session`] uses so the value lines up
+/// with what an enrolled peer would see, without persisting anything.
+#[cfg(feature = "didcomm")]
+pub(crate) fn ceremony_claims(sender_did: &str) -> AuthClaims {
+    AuthClaims {
+        did: sender_did.to_string(),
+        // `Role::Monitor` is the crate's least-privileged role and its
+        // `Default` — infrastructure-only, and with no contexts it reaches
+        // nothing.
+        role: crate::acl::Role::Monitor,
+        allowed_contexts: Vec::new(),
+        session_id: sender_did.to_string(),
+        // No JWT, hence no access-token expiry — same as every other
+        // intrinsic-sender caller.
+        access_expires_at: 0,
+        amr: vec!["did".to_string()],
+        acr: "aal1".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[cfg(feature = "didcomm")]
+    use crate::acl::Role;
+
+    #[test]
+    fn the_three_ceremony_uris_are_recognised_and_nothing_else_is() {
+        use vta_sdk::trust_tasks as t;
+        assert!(is_ceremony_task(t::TASK_TASK_CONSENT_DECISION_0_1));
+        #[allow(deprecated)]
+        {
+            assert!(is_ceremony_task(t::TASK_AUTH_STEP_UP_APPROVE_RESPONSE_0_1));
+        }
+        assert!(is_ceremony_task(t::TASK_AUTH_STEP_UP_APPROVE_RESPONSE_0_2));
+
+        // The operations a ceremony authorizes are emphatically not ceremonies.
+        assert!(!is_ceremony_task(t::TASK_ACL_GRANT_0_1));
+        assert!(!is_ceremony_task(t::TASK_KEYS_REVOKE_0_1));
+        assert!(!is_ceremony_task(
+            "https://trusttasks.org/spec/vta/webvh/dids/update/1.0"
+        ));
+        assert!(!is_ceremony_task(""));
+    }
+
+    #[cfg(feature = "didcomm")]
+    #[test]
+    fn peek_reads_the_type_and_ignores_the_rest() {
+        let body = br#"{"id":"urn:uuid:1","type":"https://example.com/a/0.1",
+                        "issuer":"did:key:zA","payload":{"x":1}}"#;
+        assert_eq!(
+            peek_type_uri(body).as_deref(),
+            Some("https://example.com/a/0.1")
+        );
+    }
+
+    /// A body we cannot read must fall through to the ordinary ACL path, not
+    /// past it. This is the only reason the function returns `Option` rather
+    /// than defaulting to something.
+    #[cfg(feature = "didcomm")]
+    #[test]
+    fn an_unreadable_body_is_not_a_ceremony_task() {
+        assert!(peek_type_uri(b"not json").is_none());
+        assert!(peek_type_uri(b"{}").is_none());
+        assert!(peek_type_uri(br#"{"type":42}"#).is_none());
+        assert!(peek_type_uri(b"").is_none());
+    }
+
+    /// The claim must confer nothing. If this ever loosens, an unenrolled DID
+    /// that can reach the mediator gains standing at the VTA.
+    #[cfg(feature = "didcomm")]
+    #[test]
+    fn ceremony_claims_are_authorized_nowhere() {
+        let auth = ceremony_claims("did:key:zApprover");
+        assert_eq!(auth.did, "did:key:zApprover");
+        assert_eq!(auth.role, Role::Monitor);
+        assert!(auth.allowed_contexts.is_empty());
+        assert!(
+            !auth.is_super_admin(),
+            "an empty context list must not read as unrestricted for a non-admin role"
+        );
+        assert!(!auth.has_context_access("default"));
+        assert!(!auth.act_scope().is_unrestricted());
+        assert_ne!(auth.acr, "aal2", "a ceremony claim is never pre-elevated");
+    }
+}

--- a/vta-service/src/trust_tasks/ceremony.rs
+++ b/vta-service/src/trust_tasks/ceremony.rs
@@ -52,6 +52,55 @@ pub(crate) fn is_ceremony_task(type_uri: &str) -> bool {
         || type_uri == t::TASK_AUTH_STEP_UP_APPROVE_RESPONSE_0_2
 }
 
+/// Could `sender_did` conceivably be an approver for a ceremony of this type?
+///
+/// A cheap pre-filter, run *before* the carve-out lets an unenrolled sender past
+/// the ACL. It answers only "is this sender in the population this ceremony is
+/// for", never "is this decision valid" — the handlers still decide that, and
+/// nothing here grants anything.
+///
+/// ## Why it exists
+///
+/// The carve-out costs the VTA a durable write. A `task-consent/decision` that
+/// verifies but cites a digest with no live pending records
+/// `consent.decision / denied:no_pending`, and audit retention is time-based,
+/// not size-capped — so without a filter a remote party who can reach the
+/// mediator could flood the audit log with rows that persist for the retention
+/// window. That is not privilege escalation, but it is a new capability, and it
+/// is cheap to remove.
+///
+/// For a consent decision the answer is an in-memory config read: membership of
+/// *some* configured approver set. That is the entire population the carve-out
+/// serves, so the filter costs nothing in function while shrinking the reachable
+/// set from "any DID" to "the DIDs the operator named". The handler still checks
+/// the specific set the pending named — this is a floor, not the decision.
+///
+/// Step-up `approve-response` is unfiltered, deliberately. Its authorized signer
+/// is `pending.approver`, recorded when the step-up was minted and **not**
+/// required to hold an ACL entry — that is the delegated phone-as-authorizer,
+/// and no cheap membership test covers it. It needs no filter either:
+/// `handle_approve_response` writes no audit row on `challenge_unknown`,
+/// `subject_mismatch` or `approver_unauthorized`, so an unknown sender leaves no
+/// durable trace to flood.
+#[cfg(feature = "didcomm")]
+pub(crate) async fn may_attempt_ceremony(
+    state: &crate::server::AppState,
+    type_uri: &str,
+    sender_did: &str,
+) -> bool {
+    if type_uri != vta_sdk::trust_tasks::TASK_TASK_CONSENT_DECISION_0_1 {
+        return true;
+    }
+    state
+        .config
+        .read()
+        .await
+        .policy
+        .approver_sets
+        .values()
+        .any(|members| members.iter().any(|m| m == sender_did))
+}
+
 /// Read just the `type` member out of a Trust-Task envelope.
 ///
 /// Deliberately not a full `TrustTask<Value>` parse: this runs *before*

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -48,6 +48,11 @@ mod acl;
 mod audit;
 mod auth;
 mod backup;
+/// The ceremony-task predicate + the zero-authority claim an unenrolled
+/// approver is dispatched under. Shared by the PDP gate and every
+/// intrinsic-sender transport, so the two gates in front of a handler cannot
+/// disagree about what a ceremony task is.
+pub(crate) mod ceremony;
 mod config;
 #[cfg(test)]
 mod conformance;

--- a/vta-service/src/trust_tasks/policy_gate.rs
+++ b/vta-service/src/trust_tasks/policy_gate.rs
@@ -49,16 +49,11 @@ fn gate_now_secs() -> u64 {
         .unwrap_or(0)
 }
 
-/// Ceremony tasks carry their own authority (an approver's proof, a step-up
-/// approve-response) and must NOT themselves be gated — else approving a task
-/// could itself require consent/step-up, ad infinitum.
-#[allow(deprecated)]
-fn is_ceremony_task(type_uri: &str) -> bool {
-    use vta_sdk::trust_tasks as t;
-    type_uri == t::TASK_TASK_CONSENT_DECISION_0_1
-        || type_uri == t::TASK_AUTH_STEP_UP_APPROVE_RESPONSE_0_1
-        || type_uri == t::TASK_AUTH_STEP_UP_APPROVE_RESPONSE_0_2
-}
+// The ceremony-task predicate now lives in [`super::ceremony`], shared with the
+// transport-level ACL gate. It was private here, which meant only one of the two
+// gates in front of a handler knew that a `task-consent/decision` carries its
+// own authority — and the other one refused it. See that module's header.
+use super::ceremony::is_ceremony_task;
 
 /// The ACR a satisfied step-up reaches. Mirrors `step_up::STEP_UP_TARGET_ACR`.
 const STEP_UP_TARGET_ACR: &str = "aal2";

--- a/vta-service/src/trust_tasks/task_consent.rs
+++ b/vta-service/src/trust_tasks/task_consent.rs
@@ -502,14 +502,9 @@ mod tests {
 
         // The transport gate, for real. Previously this returned
         // `Forbidden("DID not in ACL: …")` and the decision died here.
-        let auth = crate::messaging::auth::auth_for_trust_task_envelope(
-            &approver,
-            &body,
-            &state.acl_ks,
-            &state.sessions_ks,
-        )
-        .await
-        .expect("an unenrolled approver must get past the transport gate");
+        let auth = crate::messaging::auth::auth_for_trust_task_envelope(&state, &approver, &body)
+            .await
+            .expect("an unenrolled approver must get past the transport gate");
         assert_eq!(auth.role, Role::Monitor, "…on a claim that confers nothing");
 
         let outcome = crate::trust_tasks::dispatch_trust_task_core(

--- a/vta-service/src/trust_tasks/task_consent.rs
+++ b/vta-service/src/trust_tasks/task_consent.rs
@@ -398,6 +398,149 @@ mod tests {
     use crate::acl::Role;
     use crate::test_support::{build_signing_test_app_state, seed_acl_entry};
 
+    /// The reported failure, end to end.
+    ///
+    /// An approver enrolled in the VTA's `approver_set` but **not** in its ACL —
+    /// which is the whole point of a least-privilege approver: it may confer a
+    /// context and act in none, so it has no reason to hold an ACL entry — signs
+    /// a decision and submits it on an intrinsic-sender transport. Before the
+    /// ceremony carve-out the transport gate refused it before dispatch, so the
+    /// grant never appeared: the human approved, the wallet sent, the VTA
+    /// discarded it, the requester re-submitted into a pending that could never
+    /// be granted, and nothing in the log said so.
+    ///
+    /// Runs the real transport gate, not a hand-made claim, so a regression in
+    /// either half — the gate refusing again, or the spine rejecting the
+    /// zero-authority claim — fails here. The assertion that matters is the last
+    /// one: a consumable grant exists.
+    #[cfg(feature = "didcomm")]
+    #[tokio::test]
+    async fn an_unenrolled_approvers_decision_mints_the_grant() {
+        use affinidi_data_integrity::{DataIntegrityProof, SignOptions};
+        use affinidi_secrets_resolver::secrets::Secret;
+
+        let (state, _dir) = build_signing_test_app_state().await;
+
+        // The approver: a locally-minted `did:key`, exactly as the browser
+        // plugin's approver identity is. No ACL entry, deliberately.
+        let mut secret = Secret::generate_ed25519(None, Some(&[0xA7; 32]));
+        let pub_mb = secret.get_public_keymultibase().expect("approver pubkey");
+        let approver = format!("did:key:{pub_mb}");
+        secret.id = format!("{approver}#{pub_mb}");
+        assert!(
+            crate::acl::get_acl_entry(&state.acl_ks, &approver)
+                .await
+                .unwrap()
+                .is_none(),
+            "the point of this test is that the approver holds no ACL entry"
+        );
+
+        // …but it IS a member of the set the policy names.
+        state
+            .config
+            .write()
+            .await
+            .policy
+            .approver_sets
+            .insert("webvh-approvers".into(), vec![approver.clone()]);
+
+        // An outstanding pending, as the gate would have minted it for a
+        // requester that can authorize the task itself (so no delegation is in
+        // play — the approver's ACL standing is not consulted by any of the
+        // consent logic, only by the transport gate this test exercises).
+        const REQUESTER: &str = "did:key:zRequestingAgent";
+        const TYPE_URI: &str = "https://trusttasks.org/spec/vta/webvh/dids/update/1.0";
+        let task_payload = json!({ "did": "did:webvh:zScid:example.com:thing" });
+        let digest = consent::payload_digest(TYPE_URI, &task_payload).unwrap();
+        let challenge = "0123456789abcdef0123456789abcdef";
+        let wire_digest = consent::wire_digest(TYPE_URI, &task_payload, challenge).unwrap();
+        let now = now_secs();
+        consent::store_pending(
+            &state.task_consent_ks,
+            &consent::PendingTaskConsent {
+                digest: digest.clone(),
+                wire_digest: wire_digest.clone(),
+                type_uri: TYPE_URI.into(),
+                requester_did: REQUESTER.into(),
+                approver_set: "webvh-approvers".into(),
+                min_approvals: 1,
+                exclude_requester: true,
+                challenge: challenge.into(),
+                approvals: vec![],
+                state_pin: None,
+                guards: Default::default(),
+                subject_context: None,
+                requester_authorized: true,
+                created_at: now,
+                expires_at: now + 900,
+            },
+        )
+        .await
+        .unwrap();
+
+        // The decision the wallet signs and sends.
+        let vta_did = state.config.read().await.vta_did.clone().unwrap();
+        let mut doc = json!({
+            "id": format!("urn:uuid:{}", uuid::Uuid::new_v4()),
+            "type": vta_sdk::trust_tasks::TASK_TASK_CONSENT_DECISION_0_1,
+            "issuer": approver,
+            "recipient": vta_did,
+            "issuedAt": "2026-08-08T21:56:00Z",
+            "payload": {
+                "challenge": challenge,
+                "payloadDigest": wire_digest,
+                "decision": "approve",
+            },
+        });
+        let proof = DataIntegrityProof::sign(&doc, &secret, SignOptions::new())
+            .await
+            .expect("sign the decision");
+        doc.as_object_mut()
+            .unwrap()
+            .insert("proof".into(), serde_json::to_value(proof).unwrap());
+        let body = serde_json::to_vec(&doc).unwrap();
+
+        // The transport gate, for real. Previously this returned
+        // `Forbidden("DID not in ACL: …")` and the decision died here.
+        let auth = crate::messaging::auth::auth_for_trust_task_envelope(
+            &approver,
+            &body,
+            &state.acl_ks,
+            &state.sessions_ks,
+        )
+        .await
+        .expect("an unenrolled approver must get past the transport gate");
+        assert_eq!(auth.role, Role::Monitor, "…on a claim that confers nothing");
+
+        let outcome = crate::trust_tasks::dispatch_trust_task_core(
+            &state,
+            &auth,
+            &body,
+            crate::trust_tasks::transport::TransportConfidentiality::EndToEnd,
+        )
+        .await;
+        let reply: Value = serde_json::from_slice(&outcome.body).unwrap();
+        assert_eq!(
+            reply.pointer("/payload/status").and_then(Value::as_str),
+            Some("granted"),
+            "the decision must be recorded and cross the threshold: {reply}"
+        );
+
+        // …and the requester's re-submit finds a grant waiting for it. This is
+        // the line that was never reached in the field.
+        let grant = consent::consume_grant(
+            &state.task_consent_ks,
+            REQUESTER,
+            TYPE_URI,
+            &digest,
+            now_secs(),
+        )
+        .await
+        .unwrap()
+        .expect("a consumable grant must exist for the requester");
+        assert_eq!(grant.approvers, vec![approver]);
+    }
+
     const OPENVTC: &str = "openvtc";
     const ADMIN_A: &str = "did:key:zAdminOpenvtc";
     const ADMIN_OTHER: &str = "did:key:zAdminElsewhere";


### PR DESCRIPTION
## The bug

An approver device holds no authority to *act* — that is the entire point of the `approve_scope` axis — so it has no reason to hold an ACL entry. But the ACL check every intrinsic-sender transport runs before dispatch applied to `task-consent/decision` like any other task, and refused it.

That inverts the model. A decision is authorized by the **document**: the approver's Data-Integrity proof, checked against the policy-named approver set. `handle_decision` does not read its `AuthClaims` at all, and `policy_gate` already exempts ceremony tasks from re-gating. The surrounding consent code is explicitly built for an approver that may be absent from the ACL — `compute_delegated_contexts` and the gate's eligibility count both read "absent from the ACL" as *confers nothing*, never as *cannot speak*. Only the transport gate disagreed, and it disagreed first, before any of the code written to accommodate that approver could run.

Execution was never the issue: the grant is keyed to the requester and the task runs under the requester's claims. The approver's ACL entry was doing exactly one job — getting the message past the doorman.

## Why it was so hard to see

It failed silently in both directions. The VTA replies with a `permissionDenied` **envelope**, which an approver wallet has no reason to recognise, and logs nothing — the `trust-task received` line and every `consent.decision` audit row live *past* the gate. So this:

```
consent-diag: no grant found for (requester, digest) …
consent-diag: REUSING the outstanding pending … waiting on the approver's grant
audit: action="consent.required" … outcome="pending:reasked"
   ×N forever
```

was indistinguishable from a decision that was never delivered — while the human had approved, the wallet had sent, and the VTA had discarded it.

## The fix

- **`trust_tasks::ceremony`** (new) — the ceremony predicate, lifted out of `policy_gate` where it was private. That privacy *was* the bug: only one of the two gates in front of a handler knew what a ceremony task is. Both now share it.
- **`messaging::auth::auth_for_trust_task_envelope`** — the single entry point both transports use for the trust-task surface. `auth_from_did` plus one carve-out: when the ACL turns a sender away **and** the envelope names a ceremony task, dispatch proceeds on the proven sender DID over `Role::Monitor` with no contexts. Authorized nowhere, no session row minted.
- **Both transports name the sender and type URI when they refuse**, so a task the VTA rejected can be told apart from one that never arrived. `handle_decision` already argues the case for exactly this line one layer down.

A fallback, not an override:

| case | result |
|---|---|
| named approver, no ACL entry, decision | dispatched, zero authority |
| DID in no approver set, decision | refused (see hardening below) |
| named approver, `dids/update` | refused, as before |
| unparseable body | refused — can't talk past the ACL by being malformed |
| enrolled admin, decision | keeps its real claims, no downgrade |
| **expired** ACL grant, decision | through, but the lapsed admin role is not resurrected |
| store/session error (not `Forbidden`) | propagates — infrastructure faults are not downgraded |

## Second commit: the carve-out has a floor

The carve-out costs one durable write. A decision that verifies but cites a digest with no live pending records `consent.decision / denied:no_pending`, and audit retention is time-based (`retention_days`), not size-capped — so without a filter, anyone who can reach the mediator could flood the audit log with rows that outlive the incident by weeks. Not privilege escalation; the claim still reaches nothing. But it is a capability that did not exist when the ACL refused those senders outright.

For a consent decision the eligible population is an in-memory config read: membership of some configured approver set. That is exactly the population the carve-out serves, so the filter costs nothing in function while shrinking the reachable set from "any DID" to "the DIDs the operator named". The handler still enforces the specific set the pending named — a floor, not the decision.

Step-up `approve-response` stays unfiltered, deliberately, on two findings:
- Its authorized signer is `pending.approver`, recorded at mint and **not** required to hold an ACL entry — the delegated phone-as-authorizer. A blanket "approvers must be enrolled" rule would break it.
- It needs no floor: `handle_approve_response` writes no audit row on `challenge_unknown`, `subject_mismatch` or `approver_unauthorized`, so an unknown sender leaves nothing durable behind.

Also: a refused ceremony task now says which of the two enrolments is missing. An approver added to the approver set but not the ACL, and one added to neither, are the same silence from the wallet's side.

## Scope

REST is untouched — `/api/trust-tasks` still requires a JWT. The approver paths (browser plugin, mobile) are DIDComm/TSP; widening REST would mean route-level auth changes and is not needed here.

## Tests

790 lib tests pass; clippy clean; `rest` / `didcomm` / `rest,didcomm` / `rest,didcomm,tsp,webvh` all build warning-free.

New coverage:
- `messaging/auth.rs` — 8 gate cases, one per row of the table above plus the approver-set floor, the step-up exemption, and "no session row is minted".
- `trust_tasks/ceremony.rs` — the predicate, the pre-auth `type` peek, and `ceremony_claims` asserted to reach nothing.
- `trust_tasks/task_consent.rs` — end-to-end: signs a real decision as an unenrolled `did:key`, runs it through the **actual** transport gate, and asserts a consumable grant lands for the requester. That is the line that was never reached in the field.

## Verification

Found against a live VTA where the browser-plugin approver was in `webvh-approvers` but not the ACL:

```
$ pnm acl get did:key:z6Mkngm…Ufke
✗ not found: ACL entry not found for DID: did:key:z6Mkngm…Ufke
```

That deployment is deliberately left unfixed so this can be confirmed end-to-end against a real wallet once merged.

## Follow-ups (not in this PR)

- `pnm-browser-plugin`: `onInboundMessage` drops the VTA's rejection envelope with no log (`offscreen.ts:1878`). This PR stops the rejection happening; the wallet should still surface one when it does.
