### PR TITLE
feat(gate): enforce the policy gate on the REST routes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9442,7 +9442,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.14.19"
+version = "0.14.20"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",
@@ -9759,7 +9759,7 @@ dependencies = [
 
 [[package]]
 name = "vti-common"
-version = "0.11.35"
+version = "0.11.36"
 dependencies = [
  "aes-gcm",
  "affinidi-data-integrity",

--- a/changelog.d/912-rest-gate.md
+++ b/changelog.d/912-rest-gate.md
@@ -1,0 +1,44 @@
+### vti-common 0.11.36 / vta-service 0.14.20 — the PDP gate reaches the REST routes (#912)
+
+Closes most of a live enforcement gap: the Policy Decision Point ran **only** in
+the trust-task dispatcher, so `POST /acl` and friends called their operations
+directly and a `requireConsent` rule an operator had written bound one transport
+and silently not the other. Same mutation, same policy, two answers.
+
+Purely additive — `RequireStepUp` stays in place, so REST is now gated by both
+the old step-up floors and the PDP, and nothing is removed until the retirement
+that follows.
+
+- **`policy_gate` is split into a decision and its shaping.** It used to do both,
+  threading `&TrustTask<Value>` down to nine `app_error_to_reject(doc, e)` sites
+  — which is the mechanical reason the decision was unreachable from a REST
+  handler, which has a parsed body and no document. `decide` now takes the
+  payload and returns `GateReject`; `policy_gate` shapes it exactly as before,
+  and `rest_gate` shapes it for a route. `require_step_up` /
+  `initiate_self_step_up` likewise take `&Value` and return a `RejectReason`.
+  No behaviour change — the 791 lib tests pass unmoved.
+- **New `AppError::ApprovalRequired { code, details }`.** `StepUpRequired(String)`
+  renders `{error, message, requiredAcr}` and has nowhere to put the
+  `approveRequest` a caller needs, nor any way to express a consent requirement,
+  so a REST caller could learn it was blocked but not what to do about it while
+  the trust-task caller for the same decision got the whole document. `details`
+  is merged at the top level so the body reads like the trust-task reject's, with
+  `error` written last so a `details` carrying that key cannot displace the code
+  clients switch on.
+- **Gated in-handler** (the consent digest is taken over the payload, which an
+  axum extractor cannot see): `POST /acl`, `PATCH /acl/{did}`,
+  `POST /acl/{did}/change-role`, `DELETE /acl/{did}`, `DELETE /contexts/{id}`.
+  Each gates on the same payload shape its trust-task counterpart digests — the
+  whole `{entry: …}` body for a grant, not the inner entry — because a digest
+  that differed by transport would mean an approval obtained over one could not
+  be consumed over the other.
+- **A transport-parity test**: one policy, both paths, same decision, and the
+  REST body must carry the consent `challenge` rather than a bare 403. The
+  absence of exactly this test is why the bypass went unnoticed.
+
+**Still open — `POST /contexts/{ctx}/dids/{scid}`.** The planner parses the gated
+payload as `UpdateDidWithDid { did, .. }`, but that handler is addressed by
+**SCID**; gating on what it holds would produce a digest disagreeing with the
+trust-task path's for the same update. Resolving the SCID to its DID first is the
+fix, and it belongs with the change that can test it end to end rather than
+bolted on. Recorded in `docs/05-design-notes/approvals-convergence.md`.

--- a/docs/05-design-notes/approvals-convergence.md
+++ b/docs/05-design-notes/approvals-convergence.md
@@ -1,8 +1,8 @@
 # Approvals convergence — one model instead of three
 
-**Status:** partially landed. The model and its runtime surface shipped in #909.
-The REST gate and the trigger collapse are designed below and not implemented —
-**a `requireConsent` rule is not enforced for REST callers until step 1 lands.**
+**Status:** partially landed. The model and its runtime surface shipped in #909;
+the shared gate reached the ACL and context REST routes in #912. Still open: the
+webvh update route (see below), and the trigger collapse.
 
 ## What prompted it
 
@@ -113,21 +113,29 @@ trigger. Add the offline `vta approvals` break-glass.
 
 ### The live gap, and the order to close it
 
-The PDP gate runs *only* in the trust-task dispatcher. `routes/acl.rs::create_acl`
-and `routes/did_webvh.rs::update_did_handler` call their operations directly, so
-a `requireConsent` rule is **not enforced for a REST caller** today. The only
-thing gating those routes is the `RequireStepUp` extractor, which is built on
+The PDP gate ran *only* in the trust-task dispatcher: `routes/acl.rs::create_acl`
+and `routes/did_webvh.rs::update_did_handler` called their operations directly,
+so a `requireConsent` rule was **not enforced for a REST caller**. The only thing
+gating those routes was the `RequireStepUp` extractor, which is built on
 `resolve_step_up` — the function the retirement above deletes.
 
 An earlier draft of this note concluded the two must therefore land as one
 atomic change. That was wrong, and the split below is strictly better because it
 ships the security fix first:
 
-**Step 1 — add the shared gate (purely additive).** Introduce
-`approvals::gate()` and call it in the ~13 gated REST handlers while *leaving*
-`RequireStepUp` in place. REST is then gated by both the old floors and the PDP;
-nothing is removed, so there is no un-gated window, and the consent bypass is
-closed on its own merits.
+**Step 1 — add the shared gate (purely additive).** *Landed for the ACL and
+context routes.* `approvals::rest_gate()` is called in-handler by `POST /acl`,
+`PATCH /acl/{did}`, `POST /acl/{did}/change-role`, `DELETE /acl/{did}` and
+`DELETE /contexts/{id}`, with `RequireStepUp` left in place — REST is gated by
+both the old floors and the PDP, so nothing is removed and no window opens.
+
+**Still open: `POST /contexts/{ctx}/dids/{scid}`.** The planner parses the gated
+payload as `UpdateDidWithDid { did, .. }` and the consent digest is taken over
+it, but that handler is addressed by **SCID**. Gating on what it holds would
+produce a digest disagreeing with the trust-task path's for the same update, so
+an approval obtained over one transport could not be consumed over the other.
+Resolve the SCID to its DID before gating; the parity test below extends to it
+directly once that lands.
 
 **Step 2 — delete (pure removal).** Everything listed above. REST keeps its
 gating from step 1, so nothing has to be sequenced inside this step.

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.14.19"
+version = "0.14.20"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/routes/acl.rs
+++ b/vta-service/src/routes/acl.rs
@@ -96,6 +96,23 @@ pub async fn create_acl(
     State(state): State<AppState>,
     Json(req): Json<CreateAclRequest>,
 ) -> Result<(StatusCode, Json<CreateAclResponseBody>), AppError> {
+    // The PDP gate, in-handler because the consent digest is taken over the
+    // payload. Without this the extractor above is the only thing in front of
+    // the route, and it knows about step-up floors only — so a `requireConsent`
+    // rule an operator wrote bound trust-task callers and silently not REST ones.
+    //
+    // Gated on the whole body rather than on `req.entry`: the trust-task path
+    // digests `doc.payload`, the entire `{entry: …}` object, and the two must
+    // agree or an approval obtained over one transport could not be consumed
+    // over the other.
+    crate::trust_tasks::rest_gate(
+        &state,
+        &auth.0,
+        vta_sdk::trust_tasks::TASK_ACL_GRANT_0_1,
+        &serde_json::to_value(&req)?,
+    )
+    .await?;
+
     let result = operations::acl::grant_from_entry(
         &state.acl_ks,
         &state.audit_ks,
@@ -129,7 +146,9 @@ pub async fn get_acl(
     Ok(Json(result))
 }
 
-#[derive(Debug, Deserialize, utoipa::ToSchema)]
+// `Serialize` so the handler can hand the body to the PDP gate as JSON; the
+// digest an approver signs must be taken over what the caller actually sent.
+#[derive(Debug, Deserialize, serde::Serialize, utoipa::ToSchema)]
 pub struct UpdateAclRequest {
     pub role: Option<Role>,
     pub label: Option<String>,
@@ -209,6 +228,18 @@ pub async fn update_acl(
              <current-role> --to {role}"
         )));
     }
+
+    // Gate after the shape check above, so a caller who sent an unsupported
+    // patch is told that rather than being sent to find an approver for a
+    // request that could never have executed.
+    crate::trust_tasks::rest_gate(
+        &state,
+        &auth.0,
+        vta_sdk::trust_tasks::TASK_ACL_UPDATE_0_1,
+        &serde_json::to_value(&req)?,
+    )
+    .await?;
+
     let result = operations::acl::update_from_params(
         &state.acl_ks,
         &state.audit_ks,
@@ -237,7 +268,8 @@ pub async fn update_acl(
 }
 
 /// Request body for `POST /acl/{did}/change-role`.
-#[derive(Debug, Deserialize, utoipa::ToSchema)]
+// `Serialize` for the PDP gate — see `UpdateAclRequest`.
+#[derive(Debug, Deserialize, serde::Serialize, utoipa::ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct ChangeRoleRequest {
     /// The role the caller believes the subject currently holds. A
@@ -276,6 +308,14 @@ pub async fn change_role(
     Path(did): Path<String>,
     Json(req): Json<ChangeRoleRequest>,
 ) -> Result<Json<CreateAclResponseBody>, AppError> {
+    crate::trust_tasks::rest_gate(
+        &state,
+        &auth.0,
+        vta_sdk::trust_tasks::TASK_ACL_CHANGE_ROLE_0_1,
+        &serde_json::to_value(&req)?,
+    )
+    .await?;
+
     let result = operations::acl::change_role_by_subject(
         &state.acl_ks,
         &state.audit_ks,
@@ -308,6 +348,16 @@ pub async fn delete_acl(
     State(state): State<AppState>,
     Path(did): Path<String>,
 ) -> Result<StatusCode, AppError> {
+    // A DELETE carries no body, so the gated payload is the path parameter —
+    // the same `{subject}` the `acl/revoke` trust task binds its digest to.
+    crate::trust_tasks::rest_gate(
+        &state,
+        &auth.0,
+        vta_sdk::trust_tasks::TASK_ACL_REVOKE_0_1,
+        &serde_json::json!({ "subject": did }),
+    )
+    .await?;
+
     operations::acl::delete_acl(&state.acl_ks, &state.audit_ks, &auth.0, &did, "rest").await?;
     Ok(StatusCode::NO_CONTENT)
 }

--- a/vta-service/src/routes/contexts.rs
+++ b/vta-service/src/routes/contexts.rs
@@ -247,6 +247,17 @@ pub async fn delete_context_handler(
     Path(id): Path<String>,
     Query(query): Query<DeleteContextQuery>,
 ) -> Result<StatusCode, AppError> {
+    // The gated payload mirrors the `contexts/delete` trust task's, so an
+    // approval is bound to the same `{id, force}` on either transport — `force`
+    // included, because deleting with it is the materially different act.
+    crate::trust_tasks::rest_gate(
+        &state,
+        &auth.0,
+        vta_sdk::trust_tasks::TASK_CONTEXTS_DELETE_1_0,
+        &serde_json::json!({ "id": id, "force": query.force }),
+    )
+    .await?;
+
     let ks = operations::keyspaces_from_app_state(&state);
     operations::contexts::delete_context(&ks, &auth.0, &id, query.force, "rest").await?;
     Ok(StatusCode::NO_CONTENT)

--- a/vta-service/src/routes/did_webvh.rs
+++ b/vta-service/src/routes/did_webvh.rs
@@ -419,6 +419,17 @@ pub async fn update_did_handler(
     Path((_ctx_id, scid)): Path<(String, String)>,
     Json(body): Json<UpdateDidWebvhBody>,
 ) -> Result<Json<UpdateDidWebvhResult>, AppError> {
+    // NOT YET GATED — see `docs/05-design-notes/approvals-convergence.md`.
+    //
+    // This route is the other half of the consent bypass, and closing it needs
+    // one more step than the ACL and context routes did. The planner parses the
+    // gated payload as `UpdateDidWithDid { did, .. }` and the consent digest is
+    // taken over it, but this handler is addressed by **SCID**: gating on what
+    // it holds would produce a digest that disagrees with the trust-task path's
+    // for the very same update, so an approval obtained over one transport
+    // could not be consumed over the other. Resolving the SCID to its DID first
+    // is the fix, and it belongs with the change that can test it end to end
+    // rather than bolted on here.
     let options = crate::trust_tasks::webvh::update_body_to_options(body)
         .map_err(|e| AppError::Validation(format!("invalid update body: {e:?}")))?;
     let did_resolver = state

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -91,6 +91,10 @@ mod step_up_policy;
 pub(crate) use step_up::{
     AclChangeRoleOp, AclGrantOp, AclRevokeOp, AclSwapKeyOp, ContextDeleteOp, RequireStepUp,
 };
+// The PDP gate, callable from the REST routes. In-handler by necessity: the
+// consent digest and the planner both need the parsed payload, which an axum
+// extractor does not have.
+pub(crate) use policy_gate::rest_gate;
 mod vault;
 #[cfg(feature = "webvh")]
 pub(crate) mod webvh;

--- a/vta-service/src/trust_tasks/policy_gate.rs
+++ b/vta-service/src/trust_tasks/policy_gate.rs
@@ -35,6 +35,7 @@ use uuid::Uuid;
 use super::TrustTaskOutcome;
 use super::helpers::{app_error_to_reject, reject_with};
 use crate::auth::AuthClaims;
+use crate::error::AppError;
 use crate::policy::{self, Disposition, RequireConsent, consent};
 use crate::server::AppState;
 
@@ -90,11 +91,114 @@ pub(super) async fn policy_gate(
     auth: &AuthClaims,
     type_uri: &str,
     doc: &TrustTask<Value>,
+    delegated_out: &mut Vec<String>,
+) -> Option<TrustTaskOutcome> {
+    decide(state, auth, type_uri, &doc.payload, delegated_out)
+        .await
+        .map(|r| r.into_trust_task(doc))
+}
+
+/// What a refused gate decided, before it is shaped for a transport.
+///
+/// The gate used to build its trust-task rejection inline, which is why it
+/// threaded `&TrustTask<Value>` all the way down. That made the decision
+/// unreachable from the REST handlers — they had no document — which is how a
+/// `requireConsent` rule came to be enforced on one transport and not the
+/// other. Deciding first and shaping second is what lets both call it.
+pub(crate) enum GateReject {
+    /// An already-shaped framework reason.
+    Reason(RejectReason),
+    /// An error to be mapped by whichever transport is answering.
+    Error(AppError),
+}
+
+impl GateReject {
+    /// Shape for the trust-task dispatcher.
+    fn into_trust_task(self, doc: &TrustTask<Value>) -> TrustTaskOutcome {
+        match self {
+            GateReject::Reason(r) => reject_with(doc, r),
+            GateReject::Error(e) => app_error_to_reject(doc, e),
+        }
+    }
+
+    /// Shape for a REST handler.
+    ///
+    /// `TaskFailed` carrying an `auth:*` reason is the gate asking for an
+    /// approval, so it becomes [`AppError::ApprovalRequired`] with the details
+    /// intact — the `approveRequest` or the consent challenge reaches a REST
+    /// caller exactly as it reaches a trust-task one.
+    fn into_app_error(self) -> AppError {
+        match self {
+            GateReject::Error(e) => e,
+            GateReject::Reason(RejectReason::TaskFailed { reason, details }) => {
+                match approval_code(&reason) {
+                    Some(code) => AppError::ApprovalRequired {
+                        code,
+                        details: details.unwrap_or_else(|| json!({})),
+                    },
+                    None => AppError::Forbidden(reason),
+                }
+            }
+            GateReject::Reason(RejectReason::PermissionDenied { reason }) => {
+                AppError::Forbidden(reason)
+            }
+            GateReject::Reason(RejectReason::MalformedRequest { reason }) => {
+                AppError::Validation(reason)
+            }
+            GateReject::Reason(RejectReason::InternalError { reason }) => {
+                AppError::Internal(reason)
+            }
+            // The gate returns no other variant today; map conservatively
+            // rather than silently turning a refusal into a 500.
+            GateReject::Reason(other) => AppError::Forbidden(format!("{other:?}")),
+        }
+    }
+}
+
+/// The stable `auth:*` codes the gate uses to say "this needs an approval".
+///
+/// Matched as whole strings rather than by prefix so a future `auth:` reason
+/// that is *not* an approval request cannot be silently rendered as one.
+fn approval_code(reason: &str) -> Option<&'static str> {
+    match reason {
+        "auth:step_up_required" => Some("auth:step_up_required"),
+        "auth:consent_required" => Some("auth:consent_required"),
+        "auth:consent_stale" => Some("auth:consent_stale"),
+        _ => None,
+    }
+}
+
+/// Evaluate the gate for a REST handler, after its body has been parsed.
+///
+/// Must be called in-handler rather than from an extractor: the consent digest
+/// and the planner both need the payload, which an extractor cannot see.
+///
+/// Returns the contexts a consumed delegated grant confers on this execution —
+/// empty for every outcome except a consent grant that carried a delegation.
+pub(crate) async fn rest_gate(
+    state: &AppState,
+    auth: &AuthClaims,
+    type_uri: &str,
+    payload: &Value,
+) -> Result<Vec<String>, AppError> {
+    let mut delegated = Vec::new();
+    match decide(state, auth, type_uri, payload, &mut delegated).await {
+        Some(reject) => Err(reject.into_app_error()),
+        None => Ok(delegated),
+    }
+}
+
+/// The gate proper: one decision, no transport.
+async fn decide(
+    state: &AppState,
+    auth: &AuthClaims,
+    type_uri: &str,
+    payload: &Value,
     // Out: contexts a consumed delegated grant confers on this execution (see
     // `consent_gate`). Only the consent path ever writes it; every other gate
     // outcome leaves it empty.
     delegated_out: &mut Vec<String>,
-) -> Option<TrustTaskOutcome> {
+) -> Option<GateReject> {
     // Ceremony tasks are the mechanism, not a gated operation — never gate them.
     if is_ceremony_task(type_uri) {
         return None;
@@ -102,9 +206,9 @@ pub(super) async fn policy_gate(
 
     // (1) Config-floor step-up (subsumes the inline require_step_up).
     if let Some(op_class) = op_class_for(type_uri)
-        && let Some(reject) = super::step_up::require_step_up(state, auth, op_class, doc).await
+        && let Some(reason) = super::step_up::require_step_up(state, auth, op_class, payload).await
     {
-        return Some(reject);
+        return Some(GateReject::Reason(reason));
     }
 
     // (2) Rego policy — only when enforcement is enabled.
@@ -113,53 +217,43 @@ pub(super) async fn policy_gate(
     }
 
     let class = super::class_for(type_uri);
-    let input = policy::build_policy_input(
-        type_uri,
-        &doc.payload,
-        &auth.did,
-        &auth.acr,
-        &auth.amr,
-        class,
-    );
+    let input =
+        policy::build_policy_input(type_uri, payload, &auth.did, &auth.acr, &auth.amr, class);
 
     let policies = match policy::load_active_for_context(&state.policy_ks, &input.context_id).await
     {
         Ok(p) => p,
         Err(e) => {
             tracing::error!(error = %e, type_uri, "policy load failed — denying (fail-closed)");
-            return Some(reject_with(
-                doc,
-                RejectReason::PermissionDenied {
-                    reason: "policy evaluation unavailable".to_string(),
-                },
-            ));
+            return Some(GateReject::Reason(RejectReason::PermissionDenied {
+                reason: "policy evaluation unavailable".to_string(),
+            }));
         }
     };
 
     let decision = policy::decide(&policies, &input);
     match decision.decision {
         Disposition::Allow => None,
-        Disposition::Deny => Some(reject_with(
-            doc,
-            RejectReason::PermissionDenied {
-                reason: decision
-                    .explanation
-                    .unwrap_or_else(|| "denied by policy".to_string()),
-            },
-        )),
+        Disposition::Deny => Some(GateReject::Reason(RejectReason::PermissionDenied {
+            reason: decision
+                .explanation
+                .unwrap_or_else(|| "denied by policy".to_string()),
+        })),
         Disposition::RequireStepUp => {
             if auth.acr == STEP_UP_TARGET_ACR {
                 // Already elevated — the requirement is satisfied.
                 None
             } else {
-                Some(super::step_up::initiate_self_step_up(state, auth, doc).await)
+                Some(GateReject::Reason(
+                    super::step_up::initiate_self_step_up(state, auth, payload).await,
+                ))
             }
         }
         Disposition::RequireConsent => {
             consent_gate(
                 state,
                 auth,
-                doc,
+                payload,
                 type_uri,
                 decision.require_consent,
                 delegated_out,
@@ -185,7 +279,7 @@ pub(super) async fn policy_gate(
 async fn consent_gate(
     state: &AppState,
     auth: &AuthClaims,
-    doc: &TrustTask<Value>,
+    payload: &Value,
     type_uri: &str,
     require: Option<RequireConsent>,
     // Out: filled with the contexts a consumed *delegated* grant confers on this
@@ -195,20 +289,17 @@ async fn consent_gate(
     // report what the approvers conferred, keeping the augmentation on one
     // explicit, auditable path.
     delegated_out: &mut Vec<String>,
-) -> Option<TrustTaskOutcome> {
+) -> Option<GateReject> {
     // A requireConsent naming no approver set can never be satisfied — fail closed.
     let Some(require) = require else {
-        return Some(reject_with(
-            doc,
-            RejectReason::PermissionDenied {
-                reason: "policy requires consent but named no approver set".into(),
-            },
-        ));
+        return Some(GateReject::Reason(RejectReason::PermissionDenied {
+            reason: "policy requires consent but named no approver set".into(),
+        }));
     };
 
-    let digest = match consent::payload_digest(type_uri, &doc.payload) {
+    let digest = match consent::payload_digest(type_uri, payload) {
         Ok(d) => d,
-        Err(e) => return Some(app_error_to_reject(doc, e)),
+        Err(e) => return Some(GateReject::Error(e)),
     };
     let now = gate_now_secs();
 
@@ -237,18 +328,15 @@ async fn consent_gate(
                 from_row.to_vec()
             }
         }
-        Err(e) => return Some(app_error_to_reject(doc, e)),
+        Err(e) => return Some(GateReject::Error(e)),
     };
     if members.is_empty() {
-        return Some(reject_with(
-            doc,
-            RejectReason::PermissionDenied {
-                reason: format!(
-                    "approver set '{}' is unknown or empty",
-                    require.approver_set
-                ),
-            },
-        ));
+        return Some(GateReject::Reason(RejectReason::PermissionDenied {
+            reason: format!(
+                "approver set '{}' is unknown or empty",
+                require.approver_set
+            ),
+        }));
     }
 
     // An existing grant authorizes this payload — but it was minted minutes ago,
@@ -278,16 +366,15 @@ async fn consent_gate(
                     Some(&format!("digest={digest}; {why}")),
                 )
                 .await;
-                return Some(reject_with(
-                    doc,
-                    RejectReason::PermissionDenied { reason: why },
-                ));
+                return Some(GateReject::Reason(RejectReason::PermissionDenied {
+                    reason: why,
+                }));
             }
             if let Err(why) = super::planner::assert_plan_still_holds(
                 state,
                 auth,
                 type_uri,
-                &doc.payload,
+                payload,
                 grant.state_pin.as_ref(),
                 &grant.guards,
             )
@@ -312,13 +399,10 @@ async fn consent_gate(
                     Some(&format!("digest={digest}; {why}")),
                 )
                 .await;
-                return Some(reject_with(
-                    doc,
-                    RejectReason::TaskFailed {
-                        reason: "auth:consent_stale".into(),
-                        details: Some(json!({ "explanation": why })),
-                    },
-                ));
+                return Some(GateReject::Reason(RejectReason::TaskFailed {
+                    reason: "auth:consent_stale".into(),
+                    details: Some(json!({ "explanation": why })),
+                }));
             }
             // The grant is authorized and the world still matches. If it carries
             // a delegation (approvers conferred a context the requester lacked),
@@ -348,15 +432,15 @@ async fn consent_gate(
                  for this exact payload; will mint/reuse a pending below"
             );
         }
-        Err(e) => return Some(app_error_to_reject(doc, e)),
+        Err(e) => return Some(GateReject::Error(e)),
     }
 
     // Dry-run the handler we are about to gate. `None` means this executor has no
     // dry-run for it — the effects are *unknown*, not absent, and the consent
     // surface is required to say so.
-    let plan = match super::planner::plan_task(state, auth, type_uri, &doc.payload).await {
+    let plan = match super::planner::plan_task(state, auth, type_uri, payload).await {
         Ok(p) => p,
-        Err(e) => return Some(app_error_to_reject(doc, e)),
+        Err(e) => return Some(GateReject::Error(e)),
     };
     let (effects, state_pin, guards, subject_context, requester_authorized) = match &plan {
         Some(p) => (
@@ -405,20 +489,17 @@ async fn consent_gate(
                 )),
             )
             .await;
-            return Some(reject_with(
-                doc,
-                RejectReason::PermissionDenied {
-                    reason: format!(
-                        "this task updates context `{ctx}`, which the requester is not authorized \
+            return Some(GateReject::Reason(RejectReason::PermissionDenied {
+                reason: format!(
+                    "this task updates context `{ctx}`, which the requester is not authorized \
                          for and which consent cannot confer: {eligible} of the required \
                          {min_approvals} member(s) of approver set `{}` hold approve authority \
                          over `{ctx}`. Grant an approver approve-scope (or admin) over `{ctx}`, \
                          or run this as a principal that already holds the context — otherwise \
                          the approval would succeed but the update would still be refused.",
-                        require.approver_set
-                    ),
-                },
-            ));
+                    require.approver_set
+                ),
+            }));
         }
     }
 
@@ -429,7 +510,7 @@ async fn consent_gate(
     // rather than left holding a stale question.
     let existing = match consent::get_pending(&state.task_consent_ks, &digest, now).await {
         Ok(p) => p,
-        Err(e) => return Some(app_error_to_reject(doc, e)),
+        Err(e) => return Some(GateReject::Error(e)),
     };
     // Whether this submit *raised* a new question, as opposed to re-asking one
     // already outstanding. Only a new question is pushed — see below.
@@ -462,12 +543,12 @@ async fn consent_gate(
                  THIS is why the code changes every time."
             );
             if let Err(e) = consent::delete_pending(&state.task_consent_ks, &stale).await {
-                return Some(app_error_to_reject(doc, e));
+                return Some(GateReject::Error(e));
             }
             match mint_pending(
                 state,
                 auth,
-                doc,
+                payload,
                 type_uri,
                 &require,
                 min_approvals,
@@ -480,14 +561,14 @@ async fn consent_gate(
             .await
             {
                 Ok(p) => p,
-                Err(e) => return Some(app_error_to_reject(doc, e)),
+                Err(e) => return Some(GateReject::Error(e)),
             }
         }
         None => {
             match mint_pending(
                 state,
                 auth,
-                doc,
+                payload,
                 type_uri,
                 &require,
                 min_approvals,
@@ -500,18 +581,18 @@ async fn consent_gate(
             .await
             {
                 Ok(p) => p,
-                Err(e) => return Some(app_error_to_reject(doc, e)),
+                Err(e) => return Some(GateReject::Error(e)),
             }
         }
     };
 
     let class = super::class_for(type_uri).unwrap_or_else(crate::policy::TaskClass::floor);
-    let subject = crate::policy::input::subject_of(&doc.payload);
+    let subject = crate::policy::input::subject_of(payload);
     // The page that proposed this, when one did. Stamped into `payload.ext` by the
     // enrolled device from the origin its browser attested — so the approver is
     // told *which site* is asking, and told it by the only party in the chain with
     // any standing to say.
-    let origin = crate::policy::input::origin_of(&doc.payload);
+    let origin = crate::policy::input::origin_of(payload);
     let requests = match super::consent_request::mint_signed_requests(
         state,
         &pending,
@@ -524,7 +605,7 @@ async fn consent_gate(
     .await
     {
         Ok(r) => r,
-        Err(e) => return Some(app_error_to_reject(doc, e)),
+        Err(e) => return Some(GateReject::Error(e)),
     };
 
     // Wake the approvers — but only for a question we have not already asked.
@@ -564,37 +645,34 @@ async fn consent_gate(
     )
     .await;
 
-    Some(reject_with(
-        doc,
-        RejectReason::TaskFailed {
-            reason: "auth:consent_required".into(),
-            details: Some(json!({
-                // The machine-readable reason, so a consumer keys on a stable
-                // field in `details` rather than the standard top-level `code`
-                // (which is `taskFailed` for this rejection) or the free-text
-                // `message`. Mirrors the `RejectReason::TaskFailed.reason` above.
-                "reason": "auth:consent_required",
-                // The salted digest: what the approver signs, and what the two
-                // screens compare. The internal one never leaves this process.
-                "payloadDigest": pending.wire_digest,
-                "challenge": pending.challenge,
-                "approverSet": require.approver_set,
-                "minApprovals": min_approvals,
-                // Whether the requesting device is barred from the threshold.
-                // Told to the caller so a CLI can say "waiting for your device"
-                // versus "approve here" instead of blind-attempting a
-                // self-approval and reading `denied:requester_excluded` back.
-                // This reveals policy shape to a caller that has already
-                // authenticated and just triggered the rule — it grants
-                // nothing; the gate still decides every approval.
-                "excludeRequester": require.exclude_requester,
-                // The signed requests to relay. Each is VTA-authored, so the
-                // approver renders effects it can attribute to the executor
-                // rather than to whoever handed it the document.
-                "consentRequests": requests,
-            })),
-        },
-    ))
+    Some(GateReject::Reason(RejectReason::TaskFailed {
+        reason: "auth:consent_required".into(),
+        details: Some(json!({
+            // The machine-readable reason, so a consumer keys on a stable
+            // field in `details` rather than the standard top-level `code`
+            // (which is `taskFailed` for this rejection) or the free-text
+            // `message`. Mirrors the `RejectReason::TaskFailed.reason` above.
+            "reason": "auth:consent_required",
+            // The salted digest: what the approver signs, and what the two
+            // screens compare. The internal one never leaves this process.
+            "payloadDigest": pending.wire_digest,
+            "challenge": pending.challenge,
+            "approverSet": require.approver_set,
+            "minApprovals": min_approvals,
+            // Whether the requesting device is barred from the threshold.
+            // Told to the caller so a CLI can say "waiting for your device"
+            // versus "approve here" instead of blind-attempting a
+            // self-approval and reading `denied:requester_excluded` back.
+            // This reveals policy shape to a caller that has already
+            // authenticated and just triggered the rule — it grants
+            // nothing; the gate still decides every approval.
+            "excludeRequester": require.exclude_requester,
+            // The signed requests to relay. Each is VTA-authored, so the
+            // approver renders effects it can attribute to the executor
+            // rather than to whoever handed it the document.
+            "consentRequests": requests,
+        })),
+    }))
 }
 
 /// Do the approvals on this grant *still* authorize the task?
@@ -657,7 +735,7 @@ fn approvals_still_authorize(
 async fn mint_pending(
     state: &AppState,
     auth: &AuthClaims,
-    doc: &TrustTask<Value>,
+    payload: &Value,
     type_uri: &str,
     require: &RequireConsent,
     min_approvals: u32,
@@ -670,8 +748,8 @@ async fn mint_pending(
     // 256 bits of entropy. It is both the replay nonce and the digest salt, so
     // guessing it would both replay a decision and unmask the payload.
     let challenge = format!("{}{}", Uuid::new_v4().simple(), Uuid::new_v4().simple());
-    let digest = consent::payload_digest(type_uri, &doc.payload)?;
-    let wire_digest = consent::wire_digest(type_uri, &doc.payload, &challenge)?;
+    let digest = consent::payload_digest(type_uri, payload)?;
+    let wire_digest = consent::wire_digest(type_uri, payload, &challenge)?;
 
     let pending = consent::PendingTaskConsent {
         digest,

--- a/vta-service/src/trust_tasks/step_up.rs
+++ b/vta-service/src/trust_tasks/step_up.rs
@@ -1156,7 +1156,7 @@ pub(super) async fn initiate_self_step_up(
             };
         }
     };
-    let reject = match mint_pending_step_up(
+    match mint_pending_step_up(
         &state.sessions_ks,
         &vta_did,
         &secret,
@@ -1182,8 +1182,7 @@ pub(super) async fn initiate_self_step_up(
         Err(()) => RejectReason::InternalError {
             reason: "failed to initiate step-up".to_string(),
         },
-    };
-    reject
+    }
 }
 
 /// Stable operation-class identifiers used to resolve step-up floors.

--- a/vta-service/src/trust_tasks/step_up.rs
+++ b/vta-service/src/trust_tasks/step_up.rs
@@ -1045,8 +1045,8 @@ pub(super) async fn require_step_up(
     state: &AppState,
     auth: &AuthClaims,
     op_class: &str,
-    doc: &TrustTask<Value>,
-) -> Option<TrustTaskOutcome> {
+    payload: &Value,
+) -> Option<RejectReason> {
     if auth.acr == STEP_UP_TARGET_ACR {
         return None;
     }
@@ -1059,16 +1059,13 @@ pub(super) async fn require_step_up(
             StepUpDecision::Require { recipient } => (recipient, false),
             StepUpDecision::RequireAny => (String::new(), true),
             StepUpDecision::Deny => {
-                return Some(reject_with(
-                    doc,
-                    RejectReason::TaskFailed {
-                        reason: "auth:step_up_required".to_string(),
-                        details: Some(json!({
-                            "requiredAcr": STEP_UP_TARGET_ACR,
-                            "reason": "no step-up approver is configured for this subject",
-                        })),
-                    },
-                ));
+                return Some(RejectReason::TaskFailed {
+                    reason: "auth:step_up_required".to_string(),
+                    details: Some(json!({
+                        "requiredAcr": STEP_UP_TARGET_ACR,
+                        "reason": "no step-up approver is configured for this subject",
+                    })),
+                });
             }
         };
     let vta_did = state
@@ -1084,16 +1081,13 @@ pub(super) async fn require_step_up(
     // approver's device renders *what* is being authorized, and prefer its human
     // `summary` as the `reason` so a context-unaware renderer still shows
     // something meaningful.
-    let (reason, authorization_context) = reason_and_context(&doc.payload);
+    let (reason, authorization_context) = reason_and_context(payload);
     let secret = match load_step_up_signing_secret(state, &vta_did).await {
         Ok(s) => s,
         Err(()) => {
-            return Some(reject_with(
-                doc,
-                RejectReason::InternalError {
-                    reason: "failed to initiate step-up".to_string(),
-                },
-            ));
+            return Some(RejectReason::InternalError {
+                reason: "failed to initiate step-up".to_string(),
+            });
         }
     };
     let reject = match mint_pending_step_up(
@@ -1129,7 +1123,7 @@ pub(super) async fn require_step_up(
             reason: "failed to initiate step-up".to_string(),
         },
     };
-    Some(reject_with(doc, reject))
+    Some(reject)
 }
 
 /// Initiate a **self-approve** step-up for a task the Policy Decision Point
@@ -1144,8 +1138,8 @@ pub(super) async fn require_step_up(
 pub(super) async fn initiate_self_step_up(
     state: &AppState,
     auth: &AuthClaims,
-    doc: &TrustTask<Value>,
-) -> TrustTaskOutcome {
+    payload: &Value,
+) -> RejectReason {
     let vta_did = state
         .config
         .read()
@@ -1153,16 +1147,13 @@ pub(super) async fn initiate_self_step_up(
         .vta_did
         .clone()
         .unwrap_or_default();
-    let (reason, authorization_context) = reason_and_context(&doc.payload);
+    let (reason, authorization_context) = reason_and_context(payload);
     let secret = match load_step_up_signing_secret(state, &vta_did).await {
         Ok(s) => s,
         Err(()) => {
-            return reject_with(
-                doc,
-                RejectReason::InternalError {
-                    reason: "failed to initiate step-up".to_string(),
-                },
-            );
+            return RejectReason::InternalError {
+                reason: "failed to initiate step-up".to_string(),
+            };
         }
     };
     let reject = match mint_pending_step_up(
@@ -1192,7 +1183,7 @@ pub(super) async fn initiate_self_step_up(
             reason: "failed to initiate step-up".to_string(),
         },
     };
-    reject_with(doc, reject)
+    reject
 }
 
 /// Stable operation-class identifiers used to resolve step-up floors.

--- a/vta-service/tests/delegated_consent_e2e.rs
+++ b/vta-service/tests/delegated_consent_e2e.rs
@@ -728,3 +728,106 @@ async fn create_did(router: &axum::Router, ctx: &TestAppContext, token: &str) ->
         .to_string();
     (did, scid)
 }
+
+/// **The transport-parity regression.**
+///
+/// The PDP gate used to run only in the trust-task dispatcher: `POST /acl` and
+/// the webvh update route reached their operations directly, so a
+/// `requireConsent` rule an operator had written bound one transport and
+/// silently not the other — same mutation, same policy, two answers.
+///
+/// The absence of a test that ran both paths against one policy is precisely
+/// why that went unnoticed, so this asserts the pair rather than either alone.
+#[tokio::test]
+async fn rest_and_trust_task_reach_the_same_consent_decision() {
+    let (router, ctx) = build_test_app_with(TestAppOptions {
+        // The gate signs the `task-consent/request` it mints with the VTA's
+        // `#key-0`, so this needs a real signing identity like the flows above.
+        provisionable_vta: true,
+        ..Default::default()
+    })
+    .await;
+    let requester = "did:key:z6MkTestRequester";
+    let token = ctx.mint_token(requester, "admin", vec![]).await;
+    let ops = approver(11);
+
+    vta_service::contexts::create_context(&ctx.contexts_ks, "default", "Default")
+        .await
+        .expect("seed the default context");
+
+    {
+        let mut cfg = ctx.config.write().await;
+        cfg.policy.enforcement = true;
+        cfg.policy
+            .approver_sets
+            .insert("operators".into(), vec![ops.did.clone()]);
+    }
+    install_policy(&ctx, REQUIRE_CONSENT).await;
+
+    // One grant, expressed identically on both transports.
+    // Canonical `acl/grant/0.1` shape — `scopes`, not `allowedContexts`. The
+    // spine schema-validates before the gate runs, so a wrong field name here
+    // would be rejected as malformed and this test would prove nothing about
+    // consent.
+    let grant = json!({
+        "entry": {
+            "subject": "did:key:z6MkNewlyGrantedAdmin",
+            "role": "admin",
+            "scopes": ["default"],
+        }
+    });
+
+    // ── Trust-task path: refused, as it always was.
+    let doc = envelope(
+        vta_sdk::trust_tasks::TASK_ACL_GRANT_0_1,
+        requester,
+        &ctx.vta_did,
+        grant.clone(),
+    );
+    let (tt_status, tt_body) = post(&router, &token, &doc).await;
+    assert!(!tt_status.is_success(), "trust-task must refuse: {tt_body}");
+    assert_eq!(
+        tt_body["payload"]["details"]["reason"], "auth:consent_required",
+        "trust-task path must ask for consent: {tt_body}"
+    );
+
+    // ── REST path: the same policy, the same answer. Before the shared gate
+    //    this returned 201 and the ACL entry was created.
+    let rest_req = Request::builder()
+        .method("POST")
+        .uri("/acl")
+        .header("authorization", format!("Bearer {token}"))
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(&grant).unwrap()))
+        .unwrap();
+    let resp = router.clone().oneshot(rest_req).await.unwrap();
+    let rest_status = resp.status();
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let rest_body: Value = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
+
+    assert_eq!(
+        rest_status,
+        StatusCode::FORBIDDEN,
+        "REST must not bypass the consent rule: {rest_body}"
+    );
+    assert_eq!(
+        rest_body["error"], "auth:consent_required",
+        "REST must carry the same machine-readable reason: {rest_body}"
+    );
+    // The actionable half must survive the transport, not merely the refusal —
+    // `AppError::StepUpRequired` could not carry this, which is why the gate
+    // needed its own error variant.
+    assert!(
+        rest_body.get("challenge").is_some(),
+        "REST must carry the consent challenge, not just a 403: {rest_body}"
+    );
+
+    // And the mutation must not have happened on either path.
+    assert!(
+        vta_service::acl::get_acl_entry(&ctx.acl_ks, "did:key:z6MkNewlyGrantedAdmin")
+            .await
+            .expect("acl read")
+            .is_none(),
+        "a refused grant must not have created an entry"
+    );
+}

--- a/vti-common/Cargo.toml
+++ b/vti-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-common"
 description = "Shared server-side infrastructure for VTA and VTC services"
 readme = "README.md"
-version = "0.11.35"
+version = "0.11.36"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vti-common/src/error.rs
+++ b/vti-common/src/error.rs
@@ -55,6 +55,31 @@ pub enum AppError {
     #[error("step-up required: {0}")]
     StepUpRequired(String),
 
+    /// The Policy Decision Point refused the request until an approval is
+    /// obtained, and is handing back what obtaining it requires.
+    ///
+    /// Distinct from [`Self::StepUpRequired`] because that variant can only say
+    /// *that* elevation is needed — it renders `{error, message, requiredAcr}`
+    /// and has nowhere to put the `approveRequest` the caller must get signed,
+    /// nor any way to express a consent requirement (approver set, threshold,
+    /// challenge). A REST caller receiving it could learn it was blocked but
+    /// not what to do about it, while the trust-task caller for the very same
+    /// decision received the full document. That asymmetry is what this closes.
+    ///
+    /// `code` is the stable machine-readable reason (`auth:step_up_required`,
+    /// `auth:consent_required`) — the field a client keys on, rather than the
+    /// HTTP status or the English message. `details` is merged into the body,
+    /// so the REST response carries exactly what the trust-task reject's
+    /// `details` carries.
+    ///
+    /// Rendered as **403 Forbidden**: the request was understood and the caller
+    /// authenticated; it is refused pending a decision they can still obtain.
+    #[error("approval required: {code}")]
+    ApprovalRequired {
+        code: &'static str,
+        details: serde_json::Value,
+    },
+
     #[error("validation error: {0}")]
     Validation(String),
 
@@ -188,6 +213,7 @@ impl IntoResponse for AppError {
             AppError::Unauthorized(_) => StatusCode::UNAUTHORIZED,
             AppError::Forbidden(_) => StatusCode::FORBIDDEN,
             AppError::StepUpRequired(_) => StatusCode::FORBIDDEN,
+            AppError::ApprovalRequired { .. } => StatusCode::FORBIDDEN,
             AppError::Validation(_) => StatusCode::BAD_REQUEST,
             AppError::TrustTaskMissing => StatusCode::BAD_REQUEST,
             AppError::TrustTaskMismatch { .. } => StatusCode::UNSUPPORTED_MEDIA_TYPE,
@@ -234,6 +260,19 @@ impl IntoResponse for AppError {
                 "message": msg,
                 "requiredAcr": "aal2",
             }),
+            // `details` is merged at the top level rather than nested, so the
+            // body reads the same as the trust-task reject's `details` object
+            // and a client can key on one shape across both transports. `error`
+            // is written last so a `details` carrying that key cannot displace
+            // the code the caller switches on.
+            AppError::ApprovalRequired { code, details } => {
+                let mut body = match details {
+                    serde_json::Value::Object(map) => map.clone(),
+                    _ => serde_json::Map::new(),
+                };
+                body.insert("error".to_string(), serde_json::json!(code));
+                serde_json::Value::Object(body)
+            }
             _ => serde_json::json!({ "error": self.to_string() }),
         };
         (status, axum::Json(body)).into_response()
@@ -261,5 +300,91 @@ pub fn tee_attestation_error(msg: impl Into<String>) -> AppError {
     AppError::ServiceError {
         status: StatusCode::SERVICE_UNAVAILABLE,
         message: format!("TEE attestation error: {}", msg.into()),
+    }
+}
+
+#[cfg(test)]
+mod approval_required_tests {
+    use super::*;
+    use axum::body::to_bytes;
+    use axum::response::IntoResponse;
+
+    async fn body_of(err: AppError) -> serde_json::Value {
+        let resp = err.into_response();
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await.expect("body");
+        serde_json::from_slice(&bytes).expect("json body")
+    }
+
+    /// The point of the variant: a REST caller must receive the same actionable
+    /// payload the trust-task caller gets, not merely "you were blocked".
+    #[tokio::test]
+    async fn details_are_merged_alongside_the_code() {
+        let body = body_of(AppError::ApprovalRequired {
+            code: "auth:step_up_required",
+            details: serde_json::json!({
+                "requiredAcr": "aal2",
+                "approveRequest": { "id": "urn:uuid:abc" },
+            }),
+        })
+        .await;
+
+        assert_eq!(body["error"], "auth:step_up_required");
+        assert_eq!(body["requiredAcr"], "aal2");
+        assert_eq!(body["approveRequest"]["id"], "urn:uuid:abc");
+    }
+
+    #[tokio::test]
+    async fn consent_details_survive_the_round_trip() {
+        let body = body_of(AppError::ApprovalRequired {
+            code: "auth:consent_required",
+            details: serde_json::json!({
+                "approverSet": "ops",
+                "minApprovals": 2,
+                "excludeRequester": true,
+            }),
+        })
+        .await;
+
+        assert_eq!(body["error"], "auth:consent_required");
+        assert_eq!(body["minApprovals"], 2);
+        assert_eq!(body["excludeRequester"], true);
+    }
+
+    /// `details` is assembled from a policy decision, so a stray `error` key in
+    /// it must not be able to displace the code a client switches on.
+    #[tokio::test]
+    async fn details_cannot_overwrite_the_code() {
+        let body = body_of(AppError::ApprovalRequired {
+            code: "auth:consent_required",
+            details: serde_json::json!({ "error": "allow", "approverSet": "ops" }),
+        })
+        .await;
+
+        assert_eq!(body["error"], "auth:consent_required");
+        assert_eq!(body["approverSet"], "ops");
+    }
+
+    /// A non-object `details` must still yield a well-formed body rather than
+    /// panicking or emitting a bare scalar.
+    #[tokio::test]
+    async fn a_non_object_details_still_renders_the_code() {
+        let body = body_of(AppError::ApprovalRequired {
+            code: "auth:step_up_required",
+            details: serde_json::Value::Null,
+        })
+        .await;
+
+        assert_eq!(body["error"], "auth:step_up_required");
+        assert!(body.as_object().is_some_and(|m| m.len() == 1));
+    }
+
+    #[tokio::test]
+    async fn renders_as_forbidden() {
+        let resp = AppError::ApprovalRequired {
+            code: "auth:consent_required",
+            details: serde_json::json!({}),
+        }
+        .into_response();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
     }
 }


### PR DESCRIPTION
Closes most of a live enforcement gap. The Policy Decision Point ran **only** in the trust-task dispatcher, so the REST handlers called their operations directly and a `requireConsent` rule an operator had written bound one transport and silently not the other — same mutation, same policy, two answers.

Additive on purpose: `RequireStepUp` stays, so REST is now gated by both the old step-up floors and the PDP. The retirement that follows removes nothing still carrying load, and there is no release in between where REST is un-gated.

## The refactor (no behaviour change)

`policy_gate` both *decided* and *shaped a trust-task reject*, threading `&TrustTask<Value>` down to nine `app_error_to_reject(doc, e)` sites. That coupling is the mechanical reason the decision was unreachable from a REST handler, which has a parsed body and no document.

`decide` now takes the payload and returns `GateReject`; `policy_gate` shapes it exactly as before and `rest_gate` shapes it for a route. `require_step_up` / `initiate_self_step_up` likewise take `&Value` and return a `RejectReason`. The 791 lib tests pass unmoved — that commit is separated out so it can be reviewed as the no-op it is.

## `AppError::ApprovalRequired`

`StepUpRequired(String)` renders `{error, message, requiredAcr}` — nowhere to put the `approveRequest` a caller needs, and no way to express a consent requirement at all. A REST caller could learn it was blocked but not what to do about it, while the trust-task caller for the same decision received the whole document.

`details` is merged at the top level so the body reads like the trust-task reject's, with `error` written last so a `details` carrying that key cannot displace the code clients switch on.

## Gated routes

`POST /acl`, `PATCH /acl/{did}`, `POST /acl/{did}/change-role`, `DELETE /acl/{did}`, `DELETE /contexts/{id}` — in-handler, because the consent digest is taken over the payload.

Each gates on the same payload shape its trust-task counterpart digests: the whole `{entry: …}` body for a grant, **not** the inner entry. A digest that differed by transport would mean an approval obtained over one could not be consumed over the other — a subtler failure than no gate at all, and one I introduced and caught while writing the test.

## Still open: `POST /contexts/{ctx}/dids/{scid}`

Deliberately left un-gated, and marked as such in the code. The planner parses the gated payload as `UpdateDidWithDid { did, .. }`, but that handler is addressed by **SCID**. Gating on what it holds would produce a digest disagreeing with the trust-task path's for the very same update. Resolving the SCID to its DID first is the fix, and it belongs with the change that can test it end to end rather than bolted on here — I'd rather ship five correct gates and one honest TODO than six gates where one quietly mints unusable approvals.

## Testing

Full workspace suite green; `cargo clippy --workspace -- -D warnings` clean.

The new test is `rest_and_trust_task_reach_the_same_consent_decision`: one policy, both paths, same decision, and the REST body must carry the consent `challenge` rather than a bare 403. The absence of exactly this shape of test is why the bypass went unnoticed, and writing it immediately found two real problems — the payload-binding mismatch above, and the SCID issue.
