### PR TITLE
feat(gate): enforce the policy gate on the webvh update route

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9442,7 +9442,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.14.20"
+version = "0.14.21"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/changelog.d/913-webvh-rest-gate.md
+++ b/changelog.d/913-webvh-rest-gate.md
@@ -1,0 +1,27 @@
+### vta-service 0.14.21 — the webvh update route joins the shared gate (#913)
+
+Completes the REST half of the policy gate. `POST /contexts/{ctx}/dids/{scid}/update`
+was the last route reaching its operation directly, and it is the one a
+`webvh/dids/update` consent rule actually targets — a DID-document update
+silently rotates the DID's update key, which is exactly the effect an operator
+writes such a rule for.
+
+It needed one step the ACL and context routes did not. The route is addressed by
+**SCID** while the gate's payload — and therefore the consent digest an approver
+signs — is keyed on the DID, as the trust-task path sends it. Gating on what the
+handler holds would have digested the same update differently depending on how it
+arrived, so an approval obtained over one transport could not have been consumed
+over the other: a subtler failure than no gate at all. `resolve_webvh_did`
+resolves the SCID first (reusing `find_record_by_scid`, which already accepts
+either identifier form), and the route gates on `{did, …body}`.
+
+The parity test extends to this route, asserting the refusal, that the body
+carries the consent `challenge`, and that the DID's update key was **not**
+rotated.
+
+One note for whoever writes the next route test: assert on the route you mean.
+An earlier draft posted to `…/dids/{scid}` rather than `…/dids/{scid}/update`,
+fell through to the 404 fallback, and came back `500 Unable To Extract Key!` —
+`tower_governor` failing to extract a peer IP from a `oneshot` request. That
+reads like a handler fault and is not one; it cost a full debugging cycle and a
+wrong conclusion about where the problem was.

--- a/docs/05-design-notes/approvals-convergence.md
+++ b/docs/05-design-notes/approvals-convergence.md
@@ -1,8 +1,8 @@
 # Approvals convergence — one model instead of three
 
 **Status:** partially landed. The model and its runtime surface shipped in #909;
-the shared gate reached the ACL and context REST routes in #912. Still open: the
-webvh update route (see below), and the trigger collapse.
+the shared gate reached every gated REST route in #912 and #913. Still open: the
+trigger collapse.
 
 ## What prompted it
 
@@ -123,19 +123,18 @@ An earlier draft of this note concluded the two must therefore land as one
 atomic change. That was wrong, and the split below is strictly better because it
 ships the security fix first:
 
-**Step 1 — add the shared gate (purely additive).** *Landed for the ACL and
-context routes.* `approvals::rest_gate()` is called in-handler by `POST /acl`,
-`PATCH /acl/{did}`, `POST /acl/{did}/change-role`, `DELETE /acl/{did}` and
-`DELETE /contexts/{id}`, with `RequireStepUp` left in place — REST is gated by
+**Step 1 — add the shared gate (purely additive).** *Landed.* `rest_gate()` is
+called in-handler by `POST /acl`, `PATCH /acl/{did}`,
+`POST /acl/{did}/change-role`, `DELETE /acl/{did}`, `DELETE /contexts/{id}` and
+`POST /contexts/{ctx}/dids/{scid}/update`, with `RequireStepUp` left in place — REST is gated by
 both the old floors and the PDP, so nothing is removed and no window opens.
 
-**Still open: `POST /contexts/{ctx}/dids/{scid}`.** The planner parses the gated
-payload as `UpdateDidWithDid { did, .. }` and the consent digest is taken over
-it, but that handler is addressed by **SCID**. Gating on what it holds would
-produce a digest disagreeing with the trust-task path's for the same update, so
-an approval obtained over one transport could not be consumed over the other.
-Resolve the SCID to its DID before gating; the parity test below extends to it
-directly once that lands.
+The webvh update route needed one extra step: it is addressed by **SCID** while
+the gate's payload is keyed on the DID, so it resolves the SCID first
+(`resolve_webvh_did`) and gates on `{did, …body}` — the shape the trust-task
+path sends. Gating on the SCID would have digested the same update differently
+per transport, so an approval obtained over one could not be consumed over the
+other: a subtler failure than no gate at all.
 
 **Step 2 — delete (pure removal).** Everything listed above. REST keeps its
 gating from step 1, so nothing has to be sequenced inside this step.

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.14.20"
+version = "0.14.21"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/operations/did_webvh/mod.rs
+++ b/vta-service/src/operations/did_webvh/mod.rs
@@ -37,7 +37,8 @@ pub use servers::{
 pub use update::{
     AgentNameVerb, RotateDidWebvhKeysOptions, UpdateDidWebvhError, UpdateDidWebvhOptions,
     UpdateDidWebvhResult, UpdatePlan, agent_name_op, check_agent_name, list_agent_names,
-    plan_did_webvh_update, rotate_did_webvh_keys, state_from_jsonl_pub, update_did_webvh,
+    plan_did_webvh_update, resolve_webvh_did, rotate_did_webvh_keys, state_from_jsonl_pub,
+    update_did_webvh,
 };
 
 use std::sync::Arc;

--- a/vta-service/src/operations/did_webvh/update/mod.rs
+++ b/vta-service/src/operations/did_webvh/update/mod.rs
@@ -49,6 +49,7 @@ pub use orchestrator::{
 };
 pub use plan::UpdatePlan;
 pub use rotate::rotate_did_webvh_keys;
+pub use state::resolve_webvh_did;
 
 /// Cross-module accessor for `state_from_jsonl`. `passkey_vms` uses
 /// it to read the current DID document before appending a passkey

--- a/vta-service/src/operations/did_webvh/update/state.rs
+++ b/vta-service/src/operations/did_webvh/update/state.rs
@@ -42,6 +42,23 @@ pub(in crate::operations::did_webvh) async fn find_record_by_scid(
         .find(|r| r.scid == scid_or_did || r.did == scid_or_did))
 }
 
+/// Resolve a SCID **or** a full `did:webvh:…` to the canonical DID.
+///
+/// Exists for the REST update route, which is addressed by SCID while the PDP
+/// gate's payload — and therefore the consent digest an approver signs — is
+/// keyed on the DID, exactly as the trust-task path sends it. Without this the
+/// two transports would digest the same update differently, and an approval
+/// obtained over one could not be consumed over the other.
+pub async fn resolve_webvh_did(
+    webvh_ks: &KeyspaceHandle,
+    scid_or_did: &str,
+) -> Result<String, UpdateDidWebvhError> {
+    find_record_by_scid(webvh_ks, scid_or_did)
+        .await?
+        .map(|r| r.did)
+        .ok_or_else(|| UpdateDidWebvhError::NotFound(format!("SCID {scid_or_did} not found")))
+}
+
 /// Build a [`DIDWebVHState`] from a stored JSONL log string. Splits on
 /// newlines, deserializes each non-empty line as a `LogEntry`, then
 /// validates the chain so `validated_parameters` is populated.

--- a/vta-service/src/routes/did_webvh.rs
+++ b/vta-service/src/routes/did_webvh.rs
@@ -419,17 +419,27 @@ pub async fn update_did_handler(
     Path((_ctx_id, scid)): Path<(String, String)>,
     Json(body): Json<UpdateDidWebvhBody>,
 ) -> Result<Json<UpdateDidWebvhResult>, AppError> {
-    // NOT YET GATED — see `docs/05-design-notes/approvals-convergence.md`.
+    // The PDP gate. A webvh update silently rotates the DID's update key, which
+    // is exactly the effect an operator writes a `requireConsent` rule for.
     //
-    // This route is the other half of the consent bypass, and closing it needs
-    // one more step than the ACL and context routes did. The planner parses the
-    // gated payload as `UpdateDidWithDid { did, .. }` and the consent digest is
-    // taken over it, but this handler is addressed by **SCID**: gating on what
-    // it holds would produce a digest that disagrees with the trust-task path's
-    // for the very same update, so an approval obtained over one transport
-    // could not be consumed over the other. Resolving the SCID to its DID first
-    // is the fix, and it belongs with the change that can test it end to end
-    // rather than bolted on here.
+    // Gated on `{did, …body}` — the shape the trust-task path sends and digests
+    // — which is why the SCID this route is addressed by is resolved to its DID
+    // first. Gating on the SCID would digest the same update differently
+    // depending on how it arrived, so an approval obtained over one transport
+    // could not be consumed over the other: a subtler failure than no gate.
+    let did = operations::did_webvh::resolve_webvh_did(&state.webvh_ks, &scid).await?;
+    let mut gated = serde_json::to_value(&body)?;
+    if let Some(map) = gated.as_object_mut() {
+        map.insert("did".to_string(), serde_json::json!(did));
+    }
+    crate::trust_tasks::rest_gate(
+        &state,
+        &auth.0,
+        vta_sdk::trust_tasks::TASK_WEBVH_DIDS_UPDATE_1_0,
+        &gated,
+    )
+    .await?;
+
     let options = crate::trust_tasks::webvh::update_body_to_options(body)
         .map_err(|e| AppError::Validation(format!("invalid update body: {e:?}")))?;
     let did_resolver = state

--- a/vta-service/tests/delegated_consent_e2e.rs
+++ b/vta-service/tests/delegated_consent_e2e.rs
@@ -831,3 +831,80 @@ async fn rest_and_trust_task_reach_the_same_consent_decision() {
         "a refused grant must not have created an entry"
     );
 }
+
+/// The same parity claim for the webvh update route — the one a
+/// `webvh/dids/update` consent rule actually targets, and the harder of the two
+/// because REST addresses it by **SCID** while the gate's payload is keyed on
+/// the DID. Gating on what the handler holds would digest the same update
+/// differently per transport, so an approval taken over one could not be
+/// consumed over the other.
+///
+/// Note the URL: `…/dids/{scid}/update`, not `…/dids/{scid}`. An earlier draft
+/// of this test dropped the last segment, fell through to the 404 fallback, and
+/// came back `500 Unable To Extract Key!` from the rate limiter — which reads
+/// like a handler fault and is not one. Assert on the route you mean.
+#[tokio::test]
+async fn the_webvh_rest_route_is_gated_like_its_trust_task() {
+    let (router, ctx) = build_test_app_with(TestAppOptions {
+        provisionable_vta: true,
+        ..Default::default()
+    })
+    .await;
+    let requester = "did:key:z6MkTestRequester";
+    let token = ctx.mint_token(requester, "admin", vec![]).await;
+    let ops = approver(13);
+
+    let (did, scid) = create_did(&router, &ctx, &token).await;
+    let keys_before = update_keys_in_force(&ctx, &did).await;
+
+    {
+        let mut cfg = ctx.config.write().await;
+        cfg.policy.enforcement = true;
+        cfg.policy
+            .approver_sets
+            .insert("operators".into(), vec![ops.did.clone()]);
+    }
+    install_policy(&ctx, REQUIRE_CONSENT).await;
+
+    let new_doc = json!({
+        "@context": ["https://www.w3.org/ns/did/v1"],
+        "id": did,
+        "service": [{
+            "id": "#files",
+            "type": "FileStore",
+            "serviceEndpoint": "https://files.example.com/acme"
+        }]
+    });
+
+    let rest_req = Request::builder()
+        .method("POST")
+        .uri(format!("/contexts/default/dids/{scid}/update"))
+        .header("authorization", format!("Bearer {token}"))
+        .header("content-type", "application/json")
+        .body(Body::from(
+            serde_json::to_vec(&json!({ "document": new_doc })).unwrap(),
+        ))
+        .unwrap();
+    let resp = router.clone().oneshot(rest_req).await.unwrap();
+    let status = resp.status();
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let raw = String::from_utf8_lossy(&bytes).to_string();
+    let body: Value = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
+
+    assert_eq!(
+        status,
+        StatusCode::FORBIDDEN,
+        "the webvh REST route must not bypass the consent rule: {raw}"
+    );
+    assert_eq!(body["error"], "auth:consent_required", "{raw}");
+    assert!(
+        body.get("challenge").is_some(),
+        "must carry the consent challenge: {raw}"
+    );
+
+    assert_eq!(
+        update_keys_in_force(&ctx, &did).await,
+        keys_before,
+        "a refused update must not have rotated the DID's update key"
+    );
+}


### PR DESCRIPTION
Completes the REST half of the policy gate, following #912. `POST /contexts/{ctx}/dids/{scid}/update` was the last route reaching its operation directly — and it is the one a `webvh/dids/update` consent rule actually targets, since a DID-document update silently rotates the DID's update key.

## Why it needed more than the other routes

The route is addressed by **SCID**, while the gate's payload — and therefore the consent digest an approver signs — is keyed on the **DID**, as the trust-task path sends it.

Gating on what the handler holds would have digested the same update differently depending on how it arrived. An approval obtained over one transport then could not be consumed over the other: the ceremony completes, the human agrees, the re-submit finds no grant. That is a subtler failure than no gate at all, which is why #912 deliberately left this route open rather than shipping a plausible-looking gate.

`resolve_webvh_did` resolves the SCID first — reusing `find_record_by_scid`, which already accepts either identifier form for the same reason this needs it — and the route gates on `{did, …body}`.

## Testing

Full workspace suite green; `cargo clippy --workspace -- -D warnings` clean. The transport-parity test extends to this route: the refusal, the consent `challenge` present in the body, and the DID's update key **unrotated**.

## One finding worth flagging to reviewers

My first draft of that test posted to `…/dids/{scid}` instead of `…/dids/{scid}/update`. It fell through to the 404 fallback — which sits behind `tower_governor`, while the gated route does not — and came back:

```
500 Unable To Extract Key!
```

That is the rate limiter failing to extract a peer IP from a `oneshot` request with no `ConnectInfo`. It reads exactly like a fault in the handler under test, and I initially concluded the gating itself was broken and backed the change out. It wasn't; the URL was.

The test now carries a comment saying so, because the next person writing a route test against this harness will hit the same thing and draw the same wrong conclusion.
