### PR TITLE
feat(approvals): the offline break-glass for a rules lockout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9223,7 +9223,7 @@ dependencies = [
 
 [[package]]
 name = "vta-cli-common"
-version = "0.10.27"
+version = "0.10.28"
 dependencies = [
  "aes-gcm",
  "affinidi-crypto",
@@ -9442,7 +9442,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.14.22"
+version = "0.14.23"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/changelog.d/915-offline-approvals-break-glass.md
+++ b/changelog.d/915-offline-approvals-break-glass.md
@@ -1,0 +1,66 @@
+### vta-service 0.14.23 / vta-cli-common 0.10.28 — the offline approvals break-glass (#915)
+
+#914 retired `vta step-up`, which was the offline way out of an over-strict
+`[auth.step_up]`. The lockout it recovered from did not go away — it moved. This
+is the replacement, and the last open item from the trigger collapse.
+
+Approvals are self-gating on purpose: `policy/*` is not exempt from the policy
+gate, because two-person control over the gate *itself* is a feature. The cost is
+a reachable, wire-unrecoverable lockout:
+
+- a `consent` rule on `policy/upsert` whose approver set has rotated away;
+- a rule that gates the very task you would use to remove it;
+- a hand-authored Rego module that denies the `policy/delete` which would remove
+  it;
+- `enforcement = true` with no policy that decides — the gate default-denies, on
+  purpose, and nothing on the wire can fix it.
+
+#### New
+
+```
+vta approvals list                    # what this VTA requires, from the store
+vta approvals remove <task-uri>       # drop one rule — the surgical fix
+vta approvals disable                 # drop the row and every approver set
+vta policy list [--show-module]       # hand-authored Rego
+vta policy delete <id>
+```
+
+Same security model as every other `vta …` offline surface (`acl`, `keys`,
+`services`, `vault`): direct fjall access, no auth ceremony, whoever holds the
+filesystem holds this. Daemon must be stopped; not available in TEE.
+
+#### Two choices worth stating
+
+**Read-mostly.** There is no offline `require`. Adding a gate is never an
+emergency, and a break-glass path that can install one is a way to plant a
+control that never passed through the authenticated surface.
+
+**`approvals list` names hand-authored modules.** The declarative view refuses to
+show Rego it did not generate — a row whose module said something other than its
+rules would make the printout a lie — but an operator diagnosing a lockout who
+sees an empty rule list will otherwise conclude nothing is gating them. So the
+listing names them and points at `vta policy list`.
+
+#### Found while testing
+
+The first draft was wrong in the same way twice: `list` and `disable` each parsed
+the declarative row *before* acting, so neither worked on an unparseable row —
+the state where every other command has already failed and this is all that is
+left. `list` died with a bare serde error on the row it was being run to inspect;
+`disable`, the hammer, refused to swing. Parsing is best-effort in both now:
+`list` reports the row as unreadable and names the escape hatch, `disable`
+deletes first and summarises only if it can.
+
+Both surfaces render through one shared `render_model`, moved out of
+`vta_cli_common::commands::approvals::cmd_list`. An operator diagnosing a lockout
+is comparing what the offline command prints against what they remember
+`pnm approvals list` printing; two implementations of "what does this VTA
+require" would eventually disagree at exactly the moment that comparison matters.
+
+Covered by seven unit tests over a real fjall store and four end-to-end tests
+that drive the built `vta` binary against a real config file — the wiring, not
+just the functions, because "correct function, subcommand never wired up" is a
+failure an operator would otherwise discover mid-incident with no way in.
+
+Docs: `docs/02-vta/approvals.md` §"If you lock yourself out" is now concrete
+rather than a promise.

--- a/docs/02-vta/approvals.md
+++ b/docs/02-vta/approvals.md
@@ -140,11 +140,41 @@ rules `pnm approvals list` shows are always the rules that actually decide.
 Approval rules apply to policy management too, which is a feature: a `consent`
 rule on `https://trusttasks.org/spec/policy/upsert/0.2` gives you two-person
 control over changes to the gate itself. It also means a set of approvers whose
-keys are all lost can wedge you.
+keys are all lost can wedge you — as can a hand-authored module that denies the
+`policy/delete` which would remove it, or `enforcement = true` with no policy
+that decides anything.
 
-The recovery is the offline break-glass — stop the daemon and edit the rules
-directly on the host, with no auth ceremony, the same shape as
-`vta services …`. It requires possession of the machine, which is the point.
+Every one of those is unrecoverable over the wire *by construction*. The way out
+is the offline break-glass: stop the daemon and work on the store directly, with
+no auth ceremony, the same shape as `vta services …`. It requires possession of
+the machine, which is the point.
+
+```bash
+# What does this VTA actually require? (also names any hand-authored modules —
+# an empty rule list does not mean nothing is gating you)
+vta approvals list
+
+# Drop the one rule that wedged you, keeping every other control.
+vta approvals remove https://trusttasks.org/spec/policy/upsert/0.2
+
+# Or, when no single rule is identifiable: delete the whole row.
+# Every task goes back to running on the caller's own authority.
+vta approvals disable
+
+# The hand-authored half — Rego installed with `pnm policy upsert`.
+vta policy list --show-module
+vta policy delete <id>
+```
+
+There is deliberately **no** offline command that *adds* a rule. Adding a gate is
+never an emergency, and a break-glass path that can install one is a way to plant
+a control that never passed through the authenticated surface. Once the VTA is
+reachable again, re-declare what you still want with `pnm approvals require …`.
+
+Two constraints, shared with every other `vta …` offline surface: the daemon must
+be **stopped** (fjall takes a per-data-dir lock, so it will refuse to open
+otherwise), and it is **not available in TEE** — inside an enclave the store lives
+behind a vsock proxy that the host-side binary cannot reach.
 
 ## See also
 

--- a/docs/05-design-notes/approvals-convergence.md
+++ b/docs/05-design-notes/approvals-convergence.md
@@ -102,21 +102,51 @@ validation, deterministic Rego synthesis); the canonical
 explain}` and `pnm policy`; seed-once config; the consent gate resolving
 approver sets from the declarative row.
 
+## The offline break-glass
+
+*Landed (#915).* `vta approvals {list,remove,disable}` and
+`vta policy {list,delete}` read and write the policy keyspace directly, the way
+`vta services …` does for the DID document. This is what the retired
+`vta step-up disable` used to be for the config floors.
+
+Two design choices worth keeping:
+
+- **Read-mostly.** There is no offline `require`. Adding a gate is never an
+  emergency, and a break-glass path that can install one is a way to plant a
+  control that never passed through the authenticated surface.
+- **`approvals list` surfaces hand-authored modules by name.** The declarative
+  view deliberately refuses to show Rego it did not generate — a row whose module
+  said something other than its rules would make the printout a lie — but an
+  operator diagnosing a lockout who sees an empty rule list will otherwise
+  conclude nothing is gating them. `vta policy list/delete` is the other half:
+  a hand-authored module can deny the `policy/delete` that would remove it.
+
+Writing tests for it found two defects in the first draft, both in the same
+place: `list` and `disable` each parsed the declarative row *before* acting, so
+neither worked on an unparseable row — the state where every other command has
+already failed and this is all that is left. Parsing is now best-effort in both.
+
 ## Not yet landed
 
-**The offline `vta approvals` break-glass.** The retired `vta step-up` could
-disable an over-strict policy by editing the config file directly, which is what
-an operator reached for when the wire path had locked everyone out. A rule can
-lock an operator out the same way — `policy/*` is deliberately gateable, because
-two-person control over the gate itself is a feature — and the answer is a
-command that reads and writes the policy keyspace offline, the way
-`vta services …` does for the DID document. Nothing else in the convergence
-blocks on it, and nothing replaces it in the meantime.
+**`AclEntry.step_up_approver` / `step_up_require`.** Published wire fields across
+~250 VTA-side references (`operations/acl.rs` alone has 49) plus CLI flags.
+`step_up_require` is now *refused* on write rather than stored-and-ignored, so
+the field grants nothing, but the removal is its own slice with its own wire
+consequences.
 
-**`AclEntry.step_up_approver` / `step_up_require`.** Published wire fields on
-~35 vta-sdk sites plus CLI flags. `step_up_require` is now *refused* on write
-rather than stored-and-ignored, so the field grants nothing, but the removal
-itself is its own slice with its own wire consequences.
+**`trusted_presentation_verifiers`.** A config allowlist of verifier DIDs that
+auto-consent credential presentation; everything else defers
+(`operations::credential_exchange::ConsentPolicy`). Config-only, no runtime
+surface, invisible to `pnm approvals list` — the same defect class this
+convergence closed twice, on the credential-presentation path rather than the
+task path. It asks a genuinely different question ("may this verifier see my
+credentials?" vs "does this task need a human?"), so folding it in needs a design
+call rather than a mechanical port.
+
+**`policy/evaluate/0.3`.** Still not served: its `PolicyInput` marks `site` (a
+vault-flow `SiteTarget`) required, and there is no honest value for "would
+`acl/grant` need approval". Needs an upstream schema relaxation;
+`pnm approvals explain` answers from the rules instead.
 
 ### The live gap, and the order to close it
 

--- a/vta-cli-common/Cargo.toml
+++ b/vta-cli-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-cli-common"
 description = "Shared CLI command handlers and rendering helpers for VTA CLIs"
 readme = "README.md"
-version = "0.10.27"
+version = "0.10.28"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-cli-common/src/commands/approvals.rs
+++ b/vta-cli-common/src/commands/approvals.rs
@@ -101,23 +101,34 @@ async fn save(client: &VtaClient, model: Model) -> CmdResult {
 /// `approvals list` — the rules and the sets they draw on.
 pub async fn cmd_list(client: &VtaClient) -> CmdResult {
     let model = load(client).await?;
+    render_model(&model.rules, &model.approver_sets)
+}
 
+/// Print the declarative model — the rules and the sets they draw on.
+///
+/// Shared with the **offline** `vta approvals list` break-glass, which reads the
+/// same row straight from fjall when the wire path is unreachable. One renderer
+/// on purpose: an operator diagnosing a lockout is comparing what the offline
+/// command prints against what they remember `pnm approvals list` printing, and
+/// two implementations of "what does this VTA require" would eventually disagree
+/// at exactly the moment that comparison matters most.
+pub fn render_model(rules: &[ApprovalRule], approver_sets: &ApproverSets) -> CmdResult {
     if crate::render::is_json_output() {
         println!(
             "{}",
             serde_json::to_string_pretty(&serde_json::json!({
-                "rules": model.rules,
-                "approverSets": model.approver_sets,
+                "rules": rules,
+                "approverSets": approver_sets,
             }))?
         );
         return Ok(());
     }
 
-    if model.rules.is_empty() {
+    if rules.is_empty() {
         println!("No approval rules — every task runs on the caller's own authority.");
     } else {
         println!("Approval rules:");
-        for rule in &model.rules {
+        for rule in rules {
             println!("  {}", rule.task_type);
             match rule.requires {
                 Requires::Reauth => {
@@ -142,9 +153,9 @@ pub async fn cmd_list(client: &VtaClient) -> CmdResult {
         }
     }
 
-    if !model.approver_sets.is_empty() {
+    if !approver_sets.is_empty() {
         println!("\nApprover sets:");
-        for (name, members) in &model.approver_sets {
+        for (name, members) in approver_sets {
             println!("  {name}");
             for did in members {
                 println!("      {did}");

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.14.22"
+version = "0.14.23"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/approvals_cli.rs
+++ b/vta-service/src/approvals_cli.rs
@@ -1,0 +1,589 @@
+//! `vta approvals …` / `vta policy …` — the offline approvals break-glass.
+//!
+//! Reads and writes the policy keyspace **directly**, with no HTTP, no operator
+//! authentication, and no running VTA. Same security model as every other `vta`
+//! offline surface (`acl`, `keys`, `services`, `vault`): whoever holds the
+//! filesystem holds this.
+//!
+//! ## Why this exists
+//!
+//! Approvals are deliberately self-gating. `policy/*` is not exempt from the
+//! policy gate, because two-person control over the gate *itself* is a feature —
+//! an operator who can silently drop the rule that requires a second approver
+//! has no second approver. The cost of that choice is a reachable lockout:
+//!
+//! - a rule requiring consent for `policy/upsert` whose approver set is empty,
+//!   or whose members have all rotated away;
+//! - a rule that gates the very task you would use to remove it;
+//! - a hand-authored Rego module that denies everything, installed through
+//!   `pnm policy upsert` and now denying the `policy/delete` that would remove
+//!   it;
+//! - `policy.enforcement = true` with no policy that decides — the gate
+//!   default-denies, on purpose, and nothing on the wire can fix it.
+//!
+//! Every one of those is unrecoverable over the wire by construction. The
+//! retired `vta step-up disable` used to cover the equivalent case for the
+//! config floors; the floors are gone, so this covers it for the rules.
+//!
+//! ## Read-mostly, and deliberately cannot add a gate
+//!
+//! `list` diagnoses; `remove` / `disable` / `policy delete` recover. There is no
+//! offline command that *creates* an approval rule, and that asymmetry is
+//! intentional: adding a gate is never an emergency, and a break-glass path that
+//! can install one is a way to plant a control that never went through the
+//! authenticated surface. Use `pnm approvals require …` against a running VTA.
+//!
+//! ## Not for TEE deployments
+//!
+//! In a Nitro Enclave the fjall store lives behind a vsock proxy and the `vta`
+//! binary on the parent host cannot reach it — the same constraint every other
+//! offline surface carries. A TEE operator's recovery path is the enclave's own
+//! bootstrap, not this.
+//!
+//! ## Don't run while the VTA is up
+//!
+//! fjall takes a file-level lock per data dir, so the daemon holding the store
+//! makes this fail to open rather than corrupt anything. That is the protection,
+//! not the intent: a running VTA also caches nothing of the policy row (it is
+//! read per request), so a change made here is picked up without a restart —
+//! but stop the daemon anyway, because the lock will refuse you otherwise.
+
+use std::path::PathBuf;
+
+use vta_cli_common::commands::approvals::render_model;
+use vta_sdk::approvals::{DECLARATIVE_POLICY_ID, synthesize_rego, validate};
+
+use crate::cli_store::CliStore;
+use crate::config::AppConfig;
+use crate::policy::approvals::{DeclarativeModel, declarative_row, load as load_model};
+use crate::policy::storage;
+
+type CliResult = Result<(), Box<dyn std::error::Error>>;
+
+/// Open the policy keyspace from the config file.
+async fn policy_ks(
+    config_path: Option<PathBuf>,
+) -> Result<vti_common::store::KeyspaceHandle, Box<dyn std::error::Error>> {
+    let config = AppConfig::load(config_path)?;
+    let cs = CliStore::open(&config).await?;
+    Ok(cs.keyspace(crate::keyspaces::POLICY)?)
+}
+
+/// `vta approvals list` — what this VTA requires, read straight from the store.
+///
+/// The diagnosis half. An operator staring at an `auth:consent_required` they
+/// cannot get past runs this to find out which rule produced it and which
+/// approver set it names — the question that started this whole convergence,
+/// answerable now even when the wire path is the thing that is broken.
+pub async fn run_list(config_path: Option<PathBuf>) -> CliResult {
+    list_on(&policy_ks(config_path).await?).await
+}
+
+/// [`run_list`] against an already-open keyspace. Split out so the behaviour is
+/// testable without a config file on disk; the `run_*` wrappers exist only to
+/// open the store.
+async fn list_on(ks: &vti_common::store::KeyspaceHandle) -> CliResult {
+    // A row whose `ext` will not parse must not abort the listing. That row is
+    // *the thing being diagnosed* — a diagnostic command that dies on it leaves
+    // the operator with a bare parse error and no idea what else is installed or
+    // what to run next. Report it, name the escape hatch, and carry on.
+    match load_model(ks).await {
+        Ok(model) => render_model(&model.rules, &model.approver_sets)?,
+        Err(e) => {
+            println!(
+                "The declarative approvals row is present but unreadable: {e}\n\
+                 Its rules cannot be shown, and `vta approvals remove` cannot edit it.\n\
+                 `vta approvals disable` will delete the row outright."
+            );
+        }
+    }
+
+    // Rules are not the only thing that can deny. A hand-authored module is
+    // invisible to the declarative view by design — `pnm approvals` refuses to
+    // show Rego it did not generate, because a declarative row whose module said
+    // something else would make the printout a lie. But an operator diagnosing a
+    // lockout needs to know such a module exists, or they will conclude from an
+    // empty rule list that nothing is gating them.
+    let others: Vec<_> = storage::list_policies(ks)
+        .await?
+        .into_iter()
+        .filter(|p| p.id != DECLARATIVE_POLICY_ID)
+        .collect();
+    if !others.is_empty() {
+        println!("\nOther policy modules (hand-authored Rego — `vta policy list` for detail):");
+        for p in &others {
+            println!(
+                "  {}{}  priority {}",
+                p.id,
+                if p.enabled { "" } else { "  (disabled)" },
+                p.priority
+            );
+        }
+    }
+    Ok(())
+}
+
+/// `vta approvals remove <task-uri>` — drop the rule(s) for one task type.
+///
+/// The surgical fix: the operator knows which rule wedged them and keeps every
+/// other control in place. Mirrors `pnm approvals remove`, including the
+/// re-synthesis and the validation below.
+pub async fn run_remove(
+    config_path: Option<PathBuf>,
+    task_type: String,
+    contexts: Option<Vec<String>>,
+) -> CliResult {
+    remove_on(&policy_ks(config_path).await?, task_type, contexts).await
+}
+
+async fn remove_on(
+    ks: &vti_common::store::KeyspaceHandle,
+    task_type: String,
+    contexts: Option<Vec<String>>,
+) -> CliResult {
+    let existing = storage::get_policy(ks, DECLARATIVE_POLICY_ID).await?;
+    let mut model = load_model(ks).await?;
+
+    let before = model.rules.len();
+    model.rules.retain(|r| {
+        r.task_type != task_type || contexts.as_ref().is_some_and(|c| &r.contexts != c)
+    });
+    if model.rules.len() == before {
+        return Err(format!(
+            "no approval rule for {task_type} — run `vta approvals list` to see what is set"
+        )
+        .into());
+    }
+
+    write_model(ks, &model, existing.as_ref()).await?;
+    println!(
+        "Removed the approval rule for {task_type}. {} rule(s) remain.",
+        model.rules.len()
+    );
+    Ok(())
+}
+
+/// `vta approvals disable` — delete the whole declarative row.
+///
+/// The hammer, for when the operator cannot identify a single culprit or the row
+/// itself is unparseable. Every task goes back to running on the caller's own
+/// authority, so it is a real reduction in control — the print below says so
+/// rather than reporting a bare success, because an operator who reaches for
+/// this under pressure should leave knowing what they just switched off.
+///
+/// Approver sets go with it: they live on the same row, and a set with no rule
+/// naming it grants nothing. Re-declare both with `pnm approvals`.
+pub async fn run_disable(config_path: Option<PathBuf>) -> CliResult {
+    disable_on(&policy_ks(config_path).await?).await
+}
+
+async fn disable_on(ks: &vti_common::store::KeyspaceHandle) -> CliResult {
+    if storage::get_policy(ks, DECLARATIVE_POLICY_ID)
+        .await?
+        .is_none()
+    {
+        println!("No declarative approvals row — nothing to disable.");
+        return Ok(());
+    }
+
+    // Read the model for the *summary only*, and never let it gate the delete.
+    // An earlier version loaded it first and propagated the error, which meant
+    // the hammer did not work on an unparseable row — the one state where every
+    // other command has already failed and this is all that is left. Counting
+    // what was removed is a nicety; removing it is the point.
+    let summary = match load_model(ks).await {
+        Ok(m) => format!(
+            "{} rule(s) and {} approver set(s) are gone",
+            m.rules.len(),
+            m.approver_sets.len()
+        ),
+        Err(_) => "its contents were unreadable, so there is nothing to summarise".to_string(),
+    };
+
+    storage::delete_policy(ks, DECLARATIVE_POLICY_ID).await?;
+    println!("Removed the declarative approvals row: {summary}.");
+    println!(
+        "Every task now runs on the caller's own authority. Re-declare what you still \
+         want with `pnm approvals require …` once the VTA is reachable."
+    );
+    Ok(())
+}
+
+/// `vta policy list` — every stored policy module, declarative or hand-authored.
+///
+/// The declarative row's Rego is generated and already described by
+/// `approvals list`, so this exists for the modules that surface cannot show:
+/// operator-authored Rego, which is equally capable of denying everything and
+/// has no other offline view.
+pub async fn run_policy_list(config_path: Option<PathBuf>, show_module: bool) -> CliResult {
+    let ks = policy_ks(config_path).await?;
+    let policies = storage::list_policies(&ks).await?;
+
+    if vta_cli_common::render::is_json_output() {
+        println!("{}", serde_json::to_string_pretty(&policies)?);
+        return Ok(());
+    }
+    if policies.is_empty() {
+        println!("No policy modules stored.");
+        return Ok(());
+    }
+    for p in &policies {
+        println!(
+            "{}{}  priority {}  v{}",
+            p.id,
+            if p.enabled { "" } else { "  (disabled)" },
+            p.priority,
+            p.version
+        );
+        if let Some(d) = &p.description {
+            println!("    {d}");
+        }
+        if !p.applies_to.is_empty() {
+            println!("    contexts  {}", p.applies_to.join(", "));
+        }
+        if show_module {
+            for line in p.module.lines() {
+                println!("    | {line}");
+            }
+        }
+    }
+    Ok(())
+}
+
+/// `vta policy delete <id>` — remove one policy module.
+///
+/// The recovery path for a hand-authored module that denies what you need to
+/// reach. Refuses the declarative row: deleting it here would silently drop the
+/// rules *and* the approver sets, which `approvals disable` does deliberately
+/// and says so. Two commands, because the operator should have to mean it.
+pub async fn run_policy_delete(config_path: Option<PathBuf>, id: String) -> CliResult {
+    // The refusal is checked before the store is opened: it is a property of the
+    // id, and an operator who typed the wrong one should be told so rather than
+    // told the daemon holds the lock.
+    if id == DECLARATIVE_POLICY_ID {
+        return Err(format!(
+            "`{id}` is the declarative approvals row, not a hand-authored module — use \
+             `vta approvals remove <task-uri>` to drop one rule, or `vta approvals disable` \
+             to drop the row and every approver set with it"
+        )
+        .into());
+    }
+    policy_delete_on(&policy_ks(config_path).await?, id).await
+}
+
+async fn policy_delete_on(ks: &vti_common::store::KeyspaceHandle, id: String) -> CliResult {
+    if storage::get_policy(ks, &id).await?.is_none() {
+        return Err(format!("no policy module `{id}` — run `vta policy list` to see them").into());
+    }
+    storage::delete_policy(ks, &id).await?;
+    println!("Deleted policy module `{id}`.");
+    Ok(())
+}
+
+/// Re-synthesize and store the declarative row after a rule change.
+///
+/// The Rego is derived here for the same reason the online path derives it: the
+/// VTA byte-compares a submitted module against what the rules imply, and a row
+/// whose module disagreed with its rules would make every future `approvals
+/// list` — online or offline — describe something other than what decides.
+/// Writing the rules without regenerating the module would leave exactly that.
+///
+/// `version` is carried forward rather than reset so the online surface's
+/// `expectedVersion` conflict detection still sees a monotonic row after an
+/// offline edit; `created_at` likewise survives.
+async fn write_model(
+    ks: &vti_common::store::KeyspaceHandle,
+    model: &DeclarativeModel,
+    existing: Option<&crate::policy::types::PolicyModule>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // Validate before writing, exactly as the online path does. A break-glass
+    // surface is the wrong place to seat a model the authenticated path would
+    // have refused — the operator would "recover" into a row that `pnm
+    // approvals` then cannot edit.
+    validate(&model.rules, &model.approver_sets)
+        .map_err(|e| format!("the resulting rules are invalid: {e}"))?;
+
+    let now = chrono::Utc::now().to_rfc3339();
+    let created_at = existing.map(|p| p.created_at.as_str()).unwrap_or(&now);
+    let version = existing.map(|p| p.version.saturating_add(1)).unwrap_or(1);
+    let row = declarative_row(model, version, &now, created_at);
+
+    // Compile-check for the same reason the seed path does: a module that will
+    // not compile is skipped at load time, which silently un-gates every task it
+    // named. Recovering from a lockout must not do that quietly.
+    crate::policy::engine::compile(&row.module, DECLARATIVE_POLICY_ID)
+        .map_err(|e| format!("the regenerated policy module does not compile: {e}"))?;
+    debug_assert_eq!(row.module, synthesize_rego(&model.rules));
+
+    storage::store_policy(ks, &row).await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vta_sdk::approvals::ApprovalRule;
+    use vti_common::config::StoreConfig;
+    use vti_common::store::{KeyspaceHandle, Store};
+
+    const POLICY_UPSERT: &str = "https://trusttasks.org/spec/policy/upsert/0.1";
+    const ACL_GRANT: &str = "https://trusttasks.org/spec/acl/grant/0.1";
+
+    async fn ks() -> (KeyspaceHandle, tempfile::TempDir) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Store::open(&StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        })
+        .expect("open store");
+        let ks = store.keyspace(crate::keyspaces::POLICY).expect("keyspace");
+        (ks, dir)
+    }
+
+    /// Seat the row an operator would have written with `pnm approvals`.
+    async fn seed(ks: &KeyspaceHandle, rules: Vec<ApprovalRule>, sets: &[(&str, &[&str])]) {
+        let model = DeclarativeModel {
+            rules,
+            approver_sets: sets
+                .iter()
+                .map(|(k, v)| {
+                    (
+                        k.to_string(),
+                        v.iter().map(|s| s.to_string()).collect::<Vec<_>>(),
+                    )
+                })
+                .collect(),
+        };
+        let row = declarative_row(&model, 1, "2026-08-10T00:00:00Z", "2026-08-10T00:00:00Z");
+        storage::store_policy(ks, &row).await.expect("seed");
+    }
+
+    /// The lockout this surface exists for, start to finish.
+    ///
+    /// An operator requires consent for `policy/upsert` from a set whose only
+    /// member has since rotated away. The rule now gates the very task that
+    /// would remove it — nothing on the wire can help, by construction. The
+    /// offline `remove` must clear it and leave a row the online surface can
+    /// still edit.
+    #[tokio::test]
+    async fn removing_the_rule_that_gates_the_gate() {
+        let (ks, _d) = ks().await;
+        seed(
+            &ks,
+            vec![
+                ApprovalRule::consent(POLICY_UPSERT, "ops"),
+                ApprovalRule::reauth(ACL_GRANT),
+            ],
+            &[("ops", &["did:key:zGoneForever"])],
+        )
+        .await;
+
+        remove_on(&ks, POLICY_UPSERT.to_string(), None)
+            .await
+            .expect("the wedging rule comes out");
+
+        let after = load_model(&ks).await.expect("row still readable");
+        assert!(
+            after.rule_for(POLICY_UPSERT, "default").is_none(),
+            "the rule that gated policy/upsert must be gone"
+        );
+        assert!(
+            after.rule_for(ACL_GRANT, "default").is_some(),
+            "the surgical fix must leave every other control standing"
+        );
+        assert!(
+            after.approver_sets.contains_key("ops"),
+            "approver sets survive a rule removal — they are not what wedged us"
+        );
+
+        // The row the online surface will read next must still be coherent: its
+        // Rego regenerated from the remaining rules, and its version advanced so
+        // `expectedVersion` conflict detection keeps working across the offline
+        // edit.
+        let row = storage::get_policy(&ks, DECLARATIVE_POLICY_ID)
+            .await
+            .unwrap()
+            .expect("row still present");
+        assert_eq!(row.module, synthesize_rego(&after.rules));
+        assert_eq!(row.version, 2, "an offline edit must advance the version");
+        assert_eq!(
+            row.created_at, "2026-08-10T00:00:00Z",
+            "created_at belongs to the row, not to this edit"
+        );
+        assert!(
+            crate::policy::engine::compile(&row.module, DECLARATIVE_POLICY_ID).is_ok(),
+            "a module that will not compile is skipped at load — which would \
+             silently un-gate every rule it still names"
+        );
+    }
+
+    /// `disable` is the hammer: the row goes, and the approver sets with it.
+    #[tokio::test]
+    async fn disable_drops_the_row_and_its_sets() {
+        let (ks, _d) = ks().await;
+        seed(
+            &ks,
+            vec![ApprovalRule::consent(POLICY_UPSERT, "ops")],
+            &[("ops", &["did:key:zApprover"])],
+        )
+        .await;
+
+        disable_on(&ks).await.expect("disable");
+
+        assert!(
+            storage::get_policy(&ks, DECLARATIVE_POLICY_ID)
+                .await
+                .unwrap()
+                .is_none()
+        );
+        let after = load_model(&ks).await.expect("a missing row reads as empty");
+        assert!(after.rules.is_empty());
+        assert!(after.approver_sets.is_empty());
+    }
+
+    /// Removing the last rule leaves an empty row rather than an unparseable
+    /// one — `pnm approvals require` has to be able to write to it afterwards.
+    #[tokio::test]
+    async fn removing_the_last_rule_leaves_a_usable_row() {
+        let (ks, _d) = ks().await;
+        seed(&ks, vec![ApprovalRule::reauth(ACL_GRANT)], &[]).await;
+
+        remove_on(&ks, ACL_GRANT.to_string(), None).await.unwrap();
+
+        let row = storage::get_policy(&ks, DECLARATIVE_POLICY_ID)
+            .await
+            .unwrap()
+            .expect("the row survives its last rule");
+        assert!(crate::policy::engine::compile(&row.module, DECLARATIVE_POLICY_ID).is_ok());
+        assert!(load_model(&ks).await.unwrap().rules.is_empty());
+    }
+
+    /// A context-scoped removal takes only the scoped rule.
+    #[tokio::test]
+    async fn a_scoped_removal_leaves_the_unscoped_rule() {
+        let (ks, _d) = ks().await;
+        let mut scoped = ApprovalRule::reauth(ACL_GRANT);
+        scoped.contexts = vec!["acme".into()];
+        seed(&ks, vec![ApprovalRule::reauth(ACL_GRANT), scoped], &[]).await;
+
+        remove_on(&ks, ACL_GRANT.to_string(), Some(vec!["acme".into()]))
+            .await
+            .unwrap();
+
+        let after = load_model(&ks).await.unwrap();
+        assert_eq!(after.rules.len(), 1);
+        assert!(
+            after.rules[0].contexts.is_empty(),
+            "the unscoped rule must survive a scoped removal"
+        );
+    }
+
+    /// Removing a rule that is not there fails loudly. An operator recovering
+    /// from a lockout must not read a silent success as "that fixed it".
+    #[tokio::test]
+    async fn removing_an_absent_rule_is_an_error() {
+        let (ks, _d) = ks().await;
+        seed(&ks, vec![ApprovalRule::reauth(ACL_GRANT)], &[]).await;
+
+        let err = remove_on(&ks, POLICY_UPSERT.to_string(), None)
+            .await
+            .expect_err("no such rule");
+        assert!(
+            err.to_string().contains("vta approvals list"),
+            "the error should point at the command that shows what IS set, got: {err}"
+        );
+        assert_eq!(
+            load_model(&ks).await.unwrap().rules.len(),
+            1,
+            "a failed removal must not have written anything"
+        );
+    }
+
+    /// A hand-authored module denying everything is the other half of the
+    /// lockout, and `approvals disable` cannot touch it — `policy delete` is
+    /// what recovers, and it must leave the declarative row alone.
+    #[tokio::test]
+    async fn policy_delete_removes_a_hand_authored_module_only() {
+        let (ks, _d) = ks().await;
+        seed(&ks, vec![ApprovalRule::reauth(ACL_GRANT)], &[]).await;
+        storage::store_policy(
+            &ks,
+            &crate::policy::types::PolicyModule {
+                id: "operator-deny-all".into(),
+                name: "deny all".into(),
+                description: None,
+                module: "package vta.policy\nimport rego.v1\ndecision := {\"decision\": \"deny\"}"
+                    .into(),
+                applies_to: vec![],
+                priority: 500,
+                enabled: true,
+                version: 1,
+                created_at: "2026-08-10T00:00:00Z".into(),
+                updated_at: "2026-08-10T00:00:00Z".into(),
+                ext: serde_json::Value::Null,
+            },
+        )
+        .await
+        .unwrap();
+
+        policy_delete_on(&ks, "operator-deny-all".into())
+            .await
+            .expect("the deny-all module comes out");
+
+        assert!(
+            storage::get_policy(&ks, "operator-deny-all")
+                .await
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            storage::get_policy(&ks, DECLARATIVE_POLICY_ID)
+                .await
+                .unwrap()
+                .is_some(),
+            "the declarative row is not this command's business"
+        );
+    }
+
+    /// The corrupt-row case, which is where the first draft of this module was
+    /// wrong in both commands.
+    ///
+    /// `list` parsed the row before printing anything, so it died with a bare
+    /// serde error on the one row an operator would be running it to inspect.
+    /// `disable` parsed the row before deleting it, so the hammer — the last
+    /// thing left when every other command has failed — did not work on the
+    /// state that most needs it. Both now treat parsing as best-effort.
+    #[tokio::test]
+    async fn an_unparseable_row_can_still_be_seen_and_cleared() {
+        let (ks, _d) = ks().await;
+        storage::store_policy(
+            &ks,
+            &crate::policy::types::PolicyModule {
+                id: DECLARATIVE_POLICY_ID.into(),
+                name: "corrupt".into(),
+                description: None,
+                module: "package vta.policy".into(),
+                applies_to: vec![],
+                priority: 100,
+                enabled: true,
+                version: 1,
+                created_at: "2026-08-10T00:00:00Z".into(),
+                updated_at: "2026-08-10T00:00:00Z".into(),
+                // `ext` is where the rules live; this one carries none.
+                ext: serde_json::json!({ "openvtc.approvals": "not-an-object" }),
+            },
+        )
+        .await
+        .unwrap();
+
+        list_on(&ks)
+            .await
+            .expect("list must report an unreadable row, not fail on it");
+        disable_on(&ks).await.expect("disable clears a corrupt row");
+        assert!(
+            storage::get_policy(&ks, DECLARATIVE_POLICY_ID)
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+}

--- a/vta-service/src/main.rs
+++ b/vta-service/src/main.rs
@@ -1,5 +1,6 @@
 // CLI-only modules (not part of the library)
 mod acl_cli;
+mod approvals_cli;
 mod bootstrap_cli;
 mod did_key;
 #[cfg(feature = "setup")]
@@ -123,12 +124,27 @@ enum Commands {
         #[command(subcommand)]
         command: ConfigCommands,
     },
-    // `vta step-up …` lived here — the offline break-glass for an over-strict
-    // `[auth.step_up]`. The floors are retired, so there is nothing for it to
-    // edit. The break-glass it provided still matters, because the rules can
-    // lock an operator out the same way: that job belongs to an offline
-    // `vta approvals` reading the policy keyspace, which is tracked as the
-    // remaining work in this convergence.
+    /// Inspect and unwedge the approval rules (offline break-glass).
+    ///
+    /// Reads and writes the policy keyspace directly — no auth, no running
+    /// VTA. Approvals are self-gating on purpose (two-person control over the
+    /// gate itself is a feature), so a rule that gates `policy/*` with an
+    /// unreachable approver set cannot be removed over the wire. This is the
+    /// way out. Replaces the retired `vta step-up`, which did the same job for
+    /// the config floors. Daemon must be stopped; not available in TEE.
+    Approvals {
+        #[command(subcommand)]
+        command: ApprovalsCommands,
+    },
+    /// Inspect and remove stored policy modules (offline break-glass).
+    ///
+    /// The hand-authored-Rego half of the above: a module installed with
+    /// `pnm policy upsert` can deny everything, including the `policy/delete`
+    /// that would remove it.
+    Policy {
+        #[command(subcommand)]
+        command: PolicyCommands,
+    },
     /// Create a did:key in a context (offline, no server required)
     CreateDidKey {
         /// Target context ID
@@ -1131,6 +1147,52 @@ enum ConfigCommands {
     Show,
 }
 
+/// `vta approvals …` — the offline break-glass over the declarative rules.
+///
+/// Read-mostly by design. There is no offline `require`: adding a gate is never
+/// an emergency, and a break-glass path that can install one is a way to plant a
+/// control that never passed through the authenticated surface.
+#[derive(Subcommand)]
+enum ApprovalsCommands {
+    /// Show the approval rules and approver sets, read from the store.
+    ///
+    /// Also names any hand-authored policy modules present — an empty rule list
+    /// does not mean nothing is gating you, and an operator diagnosing a lockout
+    /// will otherwise conclude that it does.
+    List,
+    /// Drop the rule(s) for one task type — the surgical fix.
+    Remove {
+        /// Trust Task Type URI, e.g.
+        /// `https://trusttasks.org/spec/policy/upsert/0.1`.
+        task_type: String,
+        /// Remove only the rule scoped to exactly these contexts.
+        #[arg(long, value_delimiter = ',')]
+        context: Option<Vec<String>>,
+    },
+    /// Delete the whole declarative row — every rule and every approver set.
+    ///
+    /// The hammer, for when no single rule is identifiable or the row itself is
+    /// unparseable. Every task goes back to running on the caller's own
+    /// authority.
+    Disable,
+}
+
+/// `vta policy …` — the offline break-glass over hand-authored Rego.
+#[derive(Subcommand)]
+enum PolicyCommands {
+    /// List stored policy modules.
+    List {
+        /// Print each module's Rego source, not just its metadata.
+        #[arg(long)]
+        show_module: bool,
+    },
+    /// Delete one policy module by id.
+    Delete {
+        /// Module id, as shown by `vta policy list`.
+        id: String,
+    },
+}
+
 #[derive(Subcommand)]
 enum AuthCommands {
     /// Sign an unseal challenge using a key from the local fjall keystore.
@@ -1509,6 +1571,33 @@ async fn main() {
         Some(Commands::Config { command }) => {
             let result = match command {
                 ConfigCommands::Show => run_config_show(cli.config),
+            };
+            if let Err(e) = result {
+                eprintln!("Error: {e}");
+                std::process::exit(1);
+            }
+        }
+        Some(Commands::Approvals { command }) => {
+            let result = match command {
+                ApprovalsCommands::List => approvals_cli::run_list(cli.config).await,
+                ApprovalsCommands::Remove { task_type, context } => {
+                    approvals_cli::run_remove(cli.config, task_type, context).await
+                }
+                ApprovalsCommands::Disable => approvals_cli::run_disable(cli.config).await,
+            };
+            if let Err(e) = result {
+                eprintln!("Error: {e}");
+                std::process::exit(1);
+            }
+        }
+        Some(Commands::Policy { command }) => {
+            let result = match command {
+                PolicyCommands::List { show_module } => {
+                    approvals_cli::run_policy_list(cli.config, show_module).await
+                }
+                PolicyCommands::Delete { id } => {
+                    approvals_cli::run_policy_delete(cli.config, id).await
+                }
             };
             if let Err(e) = result {
                 eprintln!("Error: {e}");

--- a/vta-service/tests/approvals_breakglass_cli.rs
+++ b/vta-service/tests/approvals_breakglass_cli.rs
@@ -1,0 +1,228 @@
+//! End-to-end: the offline approvals break-glass, driven as an operator drives
+//! it — the real `vta` binary, a real config file, a real fjall store.
+//!
+//! The unit tests beside `approvals_cli.rs` cover the model manipulation. This
+//! covers the part they cannot: that the clap wiring reaches those functions at
+//! all, that a populated row renders, and that the whole thing works from a
+//! config file rather than a hand-built `KeyspaceHandle`.
+//!
+//! That distinction earns its keep here specifically. This is a recovery path —
+//! it runs only when every other way in has already failed — so "the function is
+//! correct but the subcommand was never wired up" is a failure mode that would
+//! otherwise be discovered by an operator, mid-incident, with no way in.
+
+use std::path::Path;
+use std::process::Command;
+
+use vta_policy::approvals::{DeclarativeModel, declarative_row};
+use vta_policy::storage;
+use vta_sdk::approvals::ApprovalRule;
+use vti_common::config::StoreConfig;
+use vti_common::store::Store;
+
+const POLICY_UPSERT: &str = "https://trusttasks.org/spec/policy/upsert/0.1";
+const ACL_GRANT: &str = "https://trusttasks.org/spec/acl/grant/0.1";
+
+/// Write the config file the `vta` binary will read.
+fn write_config(dir: &Path) -> std::path::PathBuf {
+    let data_dir = dir.join("data");
+    std::fs::create_dir_all(&data_dir).expect("data dir");
+    let config_path = dir.join("config.toml");
+    std::fs::write(
+        &config_path,
+        format!(
+            r#"vta_did = "did:key:z6MkTestVTA"
+
+[server]
+port = 8080
+
+[store]
+data_dir = "{}"
+
+[auth]
+jwt_signing_key = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+"#,
+            data_dir.display()
+        ),
+    )
+    .expect("write config");
+    config_path
+}
+
+/// Seat the row that wedges the VTA: consent for `policy/upsert` from a set
+/// whose only member has rotated away. The rule gates the very task that would
+/// remove it, so nothing on the wire can recover — which is the whole reason
+/// this surface exists.
+async fn seed_lockout(data_dir: &Path) {
+    let store = Store::open(&StoreConfig {
+        data_dir: data_dir.to_path_buf(),
+    })
+    .expect("open store");
+    let ks = store.keyspace(vta_keyspaces::POLICY).expect("policy ks");
+
+    let model = DeclarativeModel {
+        rules: vec![
+            ApprovalRule::consent(POLICY_UPSERT, "ops"),
+            ApprovalRule::reauth(ACL_GRANT),
+        ],
+        approver_sets: [("ops".to_string(), vec!["did:key:zGoneForever".to_string()])]
+            .into_iter()
+            .collect(),
+    };
+    let row = declarative_row(&model, 1, "2026-08-10T00:00:00Z", "2026-08-10T00:00:00Z");
+    storage::store_policy(&ks, &row).await.expect("seed row");
+    // Drop the store so the binary can take fjall's per-data-dir lock.
+    drop(store);
+}
+
+/// Run the built `vta` binary and return (success, stdout+stderr).
+fn vta(config: &Path, args: &[&str]) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_vta"))
+        .arg("--config")
+        .arg(config)
+        .args(args)
+        .output()
+        .expect("run vta");
+    let mut text = String::from_utf8_lossy(&out.stdout).into_owned();
+    text.push_str(&String::from_utf8_lossy(&out.stderr));
+    (out.status.success(), text)
+}
+
+#[tokio::test]
+async fn an_operator_can_diagnose_and_clear_a_lockout_offline() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let config = write_config(dir.path());
+    seed_lockout(&dir.path().join("data")).await;
+
+    // 1. Diagnose. The command that answers "why am I being asked for consent
+    //    I cannot satisfy" — the question this whole convergence started from.
+    let (ok, out) = vta(&config, &["approvals", "list"]);
+    assert!(ok, "approvals list failed: {out}");
+    assert!(
+        out.contains(POLICY_UPSERT),
+        "the wedging rule must be named: {out}"
+    );
+    assert!(
+        out.contains("consent") && out.contains("ops"),
+        "the operator needs to see WHAT it requires and from WHICH set: {out}"
+    );
+    assert!(
+        out.contains("did:key:zGoneForever"),
+        "and who is in that set — which is how they learn it is unsatisfiable: {out}"
+    );
+
+    // 2. Recover, surgically.
+    let (ok, out) = vta(&config, &["approvals", "remove", POLICY_UPSERT]);
+    assert!(ok, "approvals remove failed: {out}");
+
+    // 3. The gate is gone and every other control still stands.
+    let (ok, out) = vta(&config, &["approvals", "list"]);
+    assert!(ok, "approvals list failed after remove: {out}");
+    assert!(
+        !out.contains(POLICY_UPSERT),
+        "the removed rule must be gone: {out}"
+    );
+    assert!(
+        out.contains(ACL_GRANT),
+        "the unrelated rule must survive: {out}"
+    );
+}
+
+#[tokio::test]
+async fn disable_clears_everything_and_says_so() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let config = write_config(dir.path());
+    seed_lockout(&dir.path().join("data")).await;
+
+    let (ok, out) = vta(&config, &["approvals", "disable"]);
+    assert!(ok, "approvals disable failed: {out}");
+    assert!(
+        out.contains("2 rule(s)") && out.contains("1 approver set(s)"),
+        "the operator should leave knowing exactly what they switched off: {out}"
+    );
+    assert!(
+        out.contains("caller's own authority"),
+        "and that it is a real reduction in control: {out}"
+    );
+
+    let (ok, out) = vta(&config, &["approvals", "list"]);
+    assert!(ok);
+    assert!(out.contains("No approval rules"), "{out}");
+}
+
+/// `vta policy delete` refuses the declarative row, and the refusal names the
+/// two commands that do the job — an operator reaching for the wrong one under
+/// pressure should be redirected, not stopped.
+#[tokio::test]
+async fn policy_delete_redirects_away_from_the_declarative_row() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let config = write_config(dir.path());
+    seed_lockout(&dir.path().join("data")).await;
+
+    let (ok, out) = vta(&config, &["policy", "delete", "approvals"]);
+    assert!(
+        !ok,
+        "deleting the declarative row this way must fail: {out}"
+    );
+    assert!(out.contains("vta approvals remove"), "{out}");
+    assert!(out.contains("vta approvals disable"), "{out}");
+
+    // …and the row is untouched.
+    let (ok, out) = vta(&config, &["approvals", "list"]);
+    assert!(ok);
+    assert!(out.contains(POLICY_UPSERT), "{out}");
+}
+
+/// An empty rule list does not mean nothing is gating you. A hand-authored
+/// module denies just as effectively and is invisible to the declarative view,
+/// so `approvals list` has to point at it or the operator stops looking.
+#[tokio::test]
+async fn a_hand_authored_module_is_surfaced_and_removable() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let config = write_config(dir.path());
+    let data_dir = dir.path().join("data");
+    std::fs::create_dir_all(&data_dir).expect("data dir");
+    {
+        let store = Store::open(&StoreConfig {
+            data_dir: data_dir.clone(),
+        })
+        .expect("open store");
+        let ks = store.keyspace(vta_keyspaces::POLICY).expect("policy ks");
+        storage::store_policy(
+            &ks,
+            &vta_policy::types::PolicyModule {
+                id: "operator-deny-all".into(),
+                name: "deny all".into(),
+                description: Some("hand-authored".into()),
+                module: "package vta.policy\nimport rego.v1\ndecision := {\"decision\": \"deny\"}"
+                    .into(),
+                applies_to: vec![],
+                priority: 500,
+                enabled: true,
+                version: 1,
+                created_at: "2026-08-10T00:00:00Z".into(),
+                updated_at: "2026-08-10T00:00:00Z".into(),
+                ext: serde_json::Value::Null,
+            },
+        )
+        .await
+        .expect("seed module");
+    }
+
+    // No rules at all — but something IS denying, and the listing must say so.
+    let (ok, out) = vta(&config, &["approvals", "list"]);
+    assert!(ok, "{out}");
+    assert!(out.contains("No approval rules"), "{out}");
+    assert!(
+        out.contains("operator-deny-all"),
+        "a hand-authored module must be surfaced, or an empty rule list reads as \
+         'nothing is gating me' when something is: {out}"
+    );
+
+    let (ok, out) = vta(&config, &["policy", "delete", "operator-deny-all"]);
+    assert!(ok, "policy delete failed: {out}");
+
+    let (ok, out) = vta(&config, &["policy", "list"]);
+    assert!(ok);
+    assert!(out.contains("No policy modules stored"), "{out}");
+}


### PR DESCRIPTION
**Stacked on #914** — review that first; this diff is only the last two commits.
Retarget to `main` once #914 merges.

#914 retired `vta step-up`, which was the offline way out of an over-strict
`[auth.step_up]`. The lockout it recovered from did not go away, it moved to the
rules. This is the replacement, and the last open item from the trigger collapse.

## Why a break-glass has to exist

Approvals are self-gating on purpose: `policy/*` is **not** exempt from the
policy gate, because two-person control over the gate itself is a feature. The
cost of that choice is a lockout that is unrecoverable over the wire *by
construction*:

- a `consent` rule on `policy/upsert` whose approver set has all rotated away;
- a rule that gates the very task you would use to remove it;
- a hand-authored Rego module that denies the `policy/delete` which would remove
  it;
- `enforcement = true` with no policy that decides — the gate default-denies, on
  purpose, and nothing on the wire can fix it.

## What's new

```
vta approvals list                    # what this VTA requires, read from the store
vta approvals remove <task-uri>       # drop one rule — the surgical fix
vta approvals disable                 # drop the row and every approver set
vta policy list [--show-module]       # the hand-authored Rego half
vta policy delete <id>
```

Same security model as every other `vta …` offline surface (`acl`, `keys`,
`services`, `vault`): direct fjall access, no auth ceremony, whoever holds the
filesystem holds this. Daemon must be stopped (fjall's per-data-dir lock enforces
it); not available in TEE.

## Two choices worth flagging in review

**Read-mostly — there is no offline `require`.** Adding a gate is never an
emergency, and a break-glass path that can install one is a way to plant a
control that never passed through the authenticated surface. Recovery only.

**`approvals list` names hand-authored modules.** The declarative view refuses to
show Rego it did not generate — a row whose module said something other than its
rules would make the whole printout a lie. But an operator diagnosing a lockout
who sees an empty rule list will otherwise conclude nothing is gating them, so
the listing names any other modules and points at `vta policy list`. That is also
why `vta policy delete` exists here rather than being left to a later PR: a
hand-authored module is exactly as capable of denying everything, and had no
offline view at all.

`vta policy delete` refuses the declarative row by name, redirecting to
`approvals remove` / `approvals disable`. Deleting it there would silently drop
the approver sets too; `disable` does that deliberately and says so.

## Found while testing

The first draft was wrong in the same way twice: `list` and `disable` each parsed
the declarative row **before** acting, so neither worked on an unparseable row —
the one state where every other command has already failed and this is all that
is left. `list` died with a bare serde error on the row it was being run to
inspect; `disable`, the hammer, refused to swing. Parsing is best-effort in both
now — `list` reports the row as unreadable and names the escape hatch, `disable`
deletes first and summarises only if it can.

That is the case for testing a recovery path at all, and it is why the coverage
here is heavier than the diff size suggests.

## Reuse

Rendering moved out of `cmd_list` into a shared `render_model`, so the offline
and online listings cannot drift. An operator diagnosing a lockout is comparing
what this prints against what they remember `pnm approvals list` printing; two
implementations of "what does this VTA require" would eventually disagree at
exactly the moment that comparison matters most.

## Testing

- **7 unit tests** over a real fjall store: the full lockout-and-recover cycle,
  scoped vs unscoped removal, the last-rule case leaving a still-usable row, a
  failed removal writing nothing, `policy delete` touching only what it should,
  and the corrupt-row case above.
- **4 end-to-end tests** driving the built `vta` binary against a real config
  file (`CARGO_BIN_EXE_vta` — a new pattern in this repo; no other offline CLI
  module has any test at all). These cover the wiring rather than the functions:
  "correct function, subcommand never wired up" is a failure mode an operator
  would otherwise discover mid-incident with no way in.

`cargo test --workspace --all-features` green except the three `vta-sdk
provision_client_e2e` tests that fail identically on `origin/main`. Clippy and
`cargo fmt --check` clean; both release guards pass.

## Docs

`docs/02-vta/approvals.md` §"If you lock yourself out" already described this
surface in the future tense — it is now concrete, with the commands and the two
constraints. The design note records what landed, the two design choices, and the
corrupt-row defect.

## Not in this PR

The design note's "Not yet landed" section now carries three items, all
deliberately out of scope here:

- **`AclEntry.step_up_approver` / `step_up_require`** — ~250 VTA-side references
  plus CLI flags. `step_up_require` is already refused on write, so the field
  grants nothing; the removal is its own slice.
- **`trusted_presentation_verifiers`** — a config allowlist that auto-consents
  credential presentation, with no runtime surface and invisible to
  `pnm approvals list`. Same defect class this convergence closed twice, on the
  credential path rather than the task path. It asks a genuinely different
  question, so folding it in needs a design call, not a mechanical port.
- **`policy/evaluate/0.3`** — blocked on an upstream schema relaxation.
