### PR TITLE
chore(deps): dtg-credentials 0.2, and pin the catalog wire shape

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2922,7 +2922,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c54e03a951783e8b327515db3f2a2fd0e3bed362a96b066f341ce66ed49b4ead"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3281,15 +3281,18 @@ dependencies = [
 
 [[package]]
 name = "dtg-credentials"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ac7fa3bbea7023541deabdc0301959bc0ac18dcdde3871a460ac7c9f8435862"
+checksum = "c722ab4e0ca0f145c0e391320fe28d9043c889a0a5ba8d186bc527cf0ce2cace"
 dependencies = [
  "affinidi-data-integrity",
  "affinidi-secrets-resolver",
  "chrono",
+ "multibase",
  "serde",
  "serde_json",
+ "serde_json_canonicalizer",
+ "sha2 0.10.9",
  "thiserror 2.0.20",
  "tracing",
 ]
@@ -4584,7 +4587,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -6450,7 +6453,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.43",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "thiserror 2.0.20",
  "tokio",
  "tracing",
@@ -6489,7 +6492,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -9676,7 +9679,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-service"
-version = "0.11.53"
+version = "0.11.54"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,7 +132,7 @@ affinidi-messaging-core = "0.1"
 futures-util = "0.3"
 
 # Decentralized Trust Graph Credentials
-dtg-credentials = "0.1.3"
+dtg-credentials = "0.2"
 
 # JSON Schema validation (issue-time credentialSchema checks)
 jsonschema = "0.46"

--- a/changelog.d/916-dtg-credentials-0-2.md
+++ b/changelog.d/916-dtg-credentials-0-2.md
@@ -1,0 +1,51 @@
+### vtc-service 0.11.54 — dtg-credentials 0.2 (#916)
+
+Moves the workspace from `dtg-credentials` 0.1.3 to 0.2, tracking DTG Core
+Credentials **Working Draft 01**. The catalog is the source of truth for the
+canonical wire shape of every credential the VTC mints, so staying a spec draft
+behind means issuing a form the rest of the ecosystem has moved off.
+
+#### Nothing we mint changed
+
+Verified rather than assumed: the emitted VMC, VEC and VIC documents are
+**byte-identical** across the bump — same `@context` (both URIs, same order),
+same `type` array, same `credentialSubject` shape. Checked by emitting all three
+under 0.1.3 and 0.2.0 and diffing, not by reading the changelog.
+
+A 0.x minor bump is semver-breaking and this crate fixes wire shapes, so "it
+compiles" was never sufficient: the constructors could have kept their signatures
+while every credential quietly became a different document.
+
+#### What 0.2 actually changes, and why none of it reaches us
+
+- **`taskContext` is REQUIRED on Witness credentials (VWC).** Parsing a VWC
+  without one is now `MissingTaskContext`. We construct only VMC/VEC/VIC; the
+  `WitnessCredential` references in `ceremony/` and `policy/` are JSON string
+  literals in the decision pipeline and never round-trip through `DTGCredential`.
+  **Worth knowing before that changes**: the day the VTC parses a witness
+  credential through this crate, it must carry a `taskContext`.
+- **`digest_multibase()` / `verify_digest()` are new** — SHA-256 over JCS,
+  multihash, base58btc multibase. Deliberately *not* the
+  `sha256:<lowercase-hex>` of Working Draft 01. Same underlying hash, different
+  encoding; the same hex → `digestMultibase` move trust-tasks 0.4 made in #911.
+- **`DTGCredentialType::RCard` is deprecated.** The R-Card was removed as a DTG
+  credential *type* in WD-01 — it is a verifiable data structure, to be defined
+  by the planned DTG VDS spec. We never constructed one; the `VtcRole::Issuer`
+  doc comment that listed it is corrected.
+
+No new transitive dependencies — `multibase`, `sha2` and
+`serde_json_canonicalizer` were already in the tree. `cargo deny` clean on
+advisories, bans, licenses and sources.
+
+#### The gap this exposed
+
+The existing tests asserted the `type` array but **nothing asserted `@context`**,
+so a changed context would have compiled, passed 85 credential tests, and shipped
+a document no one else in the ecosystem recognises. Four new tests pin
+`@context` and `type` exactly — including order, which is load-bearing in JSON-LD
+because a later context overlays an earlier one.
+
+Verified by canary: flipping the expected context fails all four with
+`@context drifted`. A future failure there is not automatically a defect — the
+catalog is allowed to move — but it forces the change to be deliberate and
+coordinated rather than silent.

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.11.53"
+version = "0.11.54"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vtc-service/src/acl/role.rs
+++ b/vtc-service/src/acl/role.rs
@@ -62,7 +62,12 @@ pub enum VtcRole {
     /// Approves / rejects join requests; policy-gated removal of
     /// other members.
     Moderator,
-    /// Issues VEC / VWC / RCard on behalf of the community.
+    /// Issues VEC / VWC on behalf of the community.
+    ///
+    /// The R-Card was dropped from this list in dtg-credentials 0.2: Working
+    /// Draft 01 removed it as a DTG credential *type* — it is a verifiable data
+    /// structure, to be defined by the planned DTG VDS specification — so it is
+    /// not something an Issuer mints as a credential.
     Issuer,
     /// Standard member. Default role on join.
     Member,

--- a/vtc-service/src/credentials/dtg.rs
+++ b/vtc-service/src/credentials/dtg.rs
@@ -353,3 +353,141 @@ mod tests {
         );
     }
 }
+
+/// The catalog's wire shape, pinned.
+///
+/// The point of minting through `dtg-credentials` is that every issuer in the
+/// ecosystem emits the same document, so what this crate decides — the
+/// `@context` URIs, their order, and the `type` array — *is* the interop
+/// contract. It is also the part a dependency bump can change without changing
+/// a single line here: the constructors keep their signatures, the code keeps
+/// compiling, and every credential the VTC mints quietly becomes a different
+/// document.
+///
+/// The tests above assert `type` and were the whole of the coverage; nothing
+/// asserted `@context`. That gap is why this exists. Verified byte-identical
+/// across the 0.1.3 → 0.2.0 bump by emitting under both and diffing — this test
+/// is what makes the *next* bump answerable without repeating that.
+///
+/// A failure here is not necessarily a defect: the catalog is allowed to move.
+/// It means the wire form changed, so the change is deliberate, coordinated with
+/// the other issuers, and reflected in the values below.
+#[cfg(test)]
+mod catalog_wire_shape {
+    use super::*;
+
+    const TEST_DID: &str = "did:web:acme.example";
+    const CONTEXT: [&str; 2] = [
+        "https://www.w3.org/ns/credentials/v2",
+        "https://firstperson.network/credentials/dtg/v1",
+    ];
+
+    fn signer() -> LocalSigner {
+        LocalSigner::from_ed25519_seed(TEST_DID.into(), &[7u8; 32])
+    }
+
+    /// `@context` and `type`, exactly, in order. Order matters in JSON-LD: the
+    /// later context overlays the earlier, so a swap changes what the terms mean.
+    fn assert_shape(doc: &Value, expected_types: &[&str], kind: &str) {
+        let ctx: Vec<String> = serde_json::from_value(doc["@context"].clone())
+            .unwrap_or_else(|e| panic!("{kind}: @context is not a string array: {e}"));
+        assert_eq!(ctx, CONTEXT, "{kind}: @context drifted");
+
+        let types: Vec<String> = serde_json::from_value(doc["type"].clone())
+            .unwrap_or_else(|e| panic!("{kind}: type is not a string array: {e}"));
+        assert_eq!(types, expected_types, "{kind}: type array drifted");
+    }
+
+    #[tokio::test]
+    async fn membership_credential_wire_shape() {
+        let doc = issue_membership(
+            &signer(),
+            "did:key:zM",
+            None,
+            None,
+            Duration::days(30),
+            true,
+        )
+        .await
+        .expect("issue VMC");
+        assert_shape(
+            &doc,
+            &[
+                "VerifiableCredential",
+                "DTGCredential",
+                "MembershipCredential",
+                // Personhood rides as an extra type, not a separate credential.
+                "PersonhoodCredential",
+            ],
+            "VMC",
+        );
+    }
+
+    #[tokio::test]
+    async fn membership_without_personhood_drops_only_that_type() {
+        let doc = issue_membership(
+            &signer(),
+            "did:key:zM",
+            None,
+            None,
+            Duration::days(30),
+            false,
+        )
+        .await
+        .expect("issue VMC");
+        assert_shape(
+            &doc,
+            &[
+                "VerifiableCredential",
+                "DTGCredential",
+                "MembershipCredential",
+            ],
+            "VMC (no personhood)",
+        );
+    }
+
+    #[tokio::test]
+    async fn endorsement_credential_wire_shape() {
+        let doc = issue_endorsement(
+            &signer(),
+            "did:key:zM",
+            serde_json::json!({ "type": "CommunityRole", "role": "member" }),
+            None,
+            None,
+            Duration::days(30),
+        )
+        .await
+        .expect("issue VEC");
+        assert_shape(
+            &doc,
+            &[
+                "VerifiableCredential",
+                "DTGCredential",
+                "EndorsementCredential",
+            ],
+            "VEC",
+        );
+        // The caller-supplied endorsement rides verbatim — `recognition` parses
+        // this exact path for cross-community role verification.
+        assert_eq!(
+            doc["credentialSubject"]["endorsement"]["type"],
+            "CommunityRole"
+        );
+    }
+
+    #[tokio::test]
+    async fn invitation_credential_wire_shape() {
+        let doc = issue_invitation(&signer(), "did:key:zM", None, None, Duration::days(30), &[])
+            .await
+            .expect("issue VIC");
+        assert_shape(
+            &doc,
+            &[
+                "VerifiableCredential",
+                "DTGCredential",
+                "InvitationCredential",
+            ],
+            "VIC",
+        );
+    }
+}


### PR DESCRIPTION
Moves the workspace from `dtg-credentials` 0.1.3 to **0.2**, tracking DTG Core
Credentials **Working Draft 01**. The catalog is the source of truth for the
canonical wire shape of every credential the VTC mints, so staying a spec draft
behind means issuing a form the rest of the ecosystem has moved off.

## Nothing we mint changed — verified, not assumed

The emitted VMC, VEC and VIC documents are **byte-identical** across the bump:
same `@context` (both URIs, same order), same `type` array, same
`credentialSubject`. Checked by emitting all three under 0.1.3 and 0.2.0 and
diffing the JSON.

A 0.x minor bump is semver-breaking, and this crate's whole job is fixing wire
shapes — so "it compiles" was never sufficient evidence. The constructors could
have kept their signatures while every credential the VTC issues quietly became
a different document, and the existing tests would not have noticed (see below).

## What 0.2 changes, and why none of it reaches us

- **`taskContext` is REQUIRED on Witness credentials (VWC).** Parsing one
  without it is now `MissingTaskContext`. We construct only VMC/VEC/VIC; the
  `WitnessCredential` references in `ceremony/` and `policy/` are JSON string
  literals in the decision pipeline and never round-trip through
  `DTGCredential`. **Worth knowing before that changes** — the day the VTC parses
  a witness credential through this crate, it must carry a `taskContext`.
- **`digest_multibase()` / `verify_digest()` are new** — SHA-256 over JCS,
  multihash, base58btc multibase; deliberately *not* WD-01's
  `sha256:<lowercase-hex>`. Same underlying hash, different encoding. This is the
  same hex → `digestMultibase` move trust-tasks 0.4 made in #911, so the
  ecosystem is converging on one encoding. Unused here; note that
  `vta_policy::consent::encode_digest_multibase` computes the identical form for
  a different input (task payloads, not credentials), so they agree by
  convention rather than duplicating.
- **`DTGCredentialType::RCard` is deprecated** — removed as a DTG credential
  *type* in WD-01 (it is a verifiable data structure, to be defined by the
  planned DTG VDS spec). We never constructed one; the `VtcRole::Issuer` doc
  comment that listed it is corrected.

No new transitive dependencies — `multibase`, `sha2` and
`serde_json_canonicalizer` were already in the tree; the lockfile diff is one
version line. `cargo deny` clean on advisories, bans, licenses and sources.

## The gap this exposed

The existing tests asserted the `type` array. **Nothing asserted `@context`.** A
changed context would have compiled, passed all 85 credential tests, and shipped
a document no one else in the ecosystem recognises — the exact failure mode a
catalog dependency exists to prevent.

Four new tests (`catalog_wire_shape`) pin `@context` and `type` exactly for VMC,
VMC-without-personhood, VEC and VIC — **including order**, which is load-bearing
in JSON-LD because a later context overlays an earlier one.

Verified by canary: flipping the expected context fails all four with
`@context drifted`. A future failure there is not automatically a defect — the
catalog is allowed to move — but it forces the change to be deliberate and
coordinated with the other issuers rather than silent.

## Testing

`cargo test -p vtc-service` (default features, as CI runs it) plus the new
wire-shape tests, clippy and `cargo fmt --check` clean, both release guards pass.

**Pre-existing, not from this change:** 8 `keys::seed_store` tests fail under
`--all-features` — they assert a backend is *not* compiled in, so enabling every
feature breaks them by construction. Confirmed by stashing this branch's changes
and reproducing the identical 8 failures on the unmodified tree.
