### PR TITLE
fix(provisioning): send the 0.2 tags, verify the bytes as received, and take messaging-sdk 0.19.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -447,9 +447,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-sdk"
-version = "0.19.3"
+version = "0.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "276d0db4e6424387c7340fccc0609df1c1e4e1fd12502b90d24d4ab3ceaa717d"
+checksum = "aed8bc60621324d13d4d44648433e14909c0826efecd930f6782f0393343954c"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-authentication",
@@ -9383,7 +9383,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.21.10"
+version = "0.21.11"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -9445,7 +9445,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.14.23"
+version = "0.14.24"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/changelog.d/917-provisioning-casing-and-messaging-0-19-4.md
+++ b/changelog.d/917-provisioning-casing-and-messaging-0-19-4.md
@@ -1,0 +1,87 @@
+### vta-sdk 0.21.11 / vta-service 0.14.24 — provisioning speaks 0.2, and the messaging SDK stops stalling shutdown (#917)
+
+Three fixes that ship together because they land in the same release: the client
+had to move to the 0.2 wire tags, the server had to stop re-imposing its own
+casing on a signed document, and both want the messaging SDK that no longer
+holds a lock through shutdown. One `vta-sdk` release, one VTA redeploy.
+
+#### `ask.type` goes out camelCase — provisioning works again
+
+`BootstrapAsk` serialised the **0.1** PascalCase tags (`AdminRotation`,
+`TemplateBootstrap`) while the client submitted under
+`provision/integration/**0.2**`. The two schemas differ in exactly that constant
+— 0.1 requires `AdminRotation`, 0.2 requires `adminRotation` — so the VTA's
+payload-schema gate rejected every request:
+
+```
+malformed request: payload does not conform to
+https://trusttasks.org/spec/provision/integration/0.2:
+{"adminTemplate":{…},"contextHint":"openvtc","note":"openvtc","type":"AdminRotation"}
+is not valid under any of the schemas listed in the 'oneOf' keyword
+```
+
+Latent since the client moved to the 0.2 URI; fatal once the schema gate landed.
+No config could bypass it — `policy.require_payload_schema` only governs *unknown*
+URIs, and a known schema is always enforced.
+
+The variants now `rename_all = "camelCase"`, with the PascalCase spellings kept
+as inbound **aliases** so a 0.1 holder still parses. That direction matters: the
+tag is inside the signed VP, so an existing holder that signed `AdminRotation`
+must keep verifying.
+
+Reported from OpenVTC, whose setup wizard could not get past
+"Provision integration DID + admin credential".
+
+#### The trust-task handler verifies the bytes it received
+
+`handle_request` called `req.request.verify()`, which re-serialises the typed
+struct — re-imposing this crate's serde casing on the very bytes the holder
+signed. It only worked while both sides happened to agree; changing either one's
+casing breaks the signature over a document nobody tampered with.
+
+It now uses `verify_value` over the raw `doc.payload["request"]`, which is what
+the DIDComm handler already did and what `verify_value`'s own documentation
+tells network handlers to do. Client and server casing no longer have to match.
+
+Fixing only the client would have moved the failure one step later rather than
+resolving it.
+
+#### `affinidi-messaging-sdk` 0.19.3 → 0.19.4
+
+Carries [affinidi-tdk-rs#694](https://github.com/affinidi/affinidi-tdk-rs/pull/694):
+`live_stream_next*` held a **read** guard on `ws_channel_tx` across its wait,
+while `stop_websocket` needs the **write** guard — so a poll in flight blocked
+every shutdown until the poll window elapsed.
+
+For the delivery layer that is 10s, and its inbound pump issues a read-ahead
+after every frame, so any consumer finishing mid-window paid the remainder on
+exit. `pnm` showed it as a fixed pause *after* its output. Measured against a
+live VTA: **13.1s → ~3.5s**, with the remaining time genuine mediator
+round-trips.
+
+Lockfile-only on our side — the `affinidi-tdk = "0.8.5"` pin already admits it
+via a caret requirement. The lockfile also reassigns which `socket2` / `syn` a
+few dependents use; both versions were already present, and this is the resolver
+normalising on any lock touch, not a downgrade of the graph.
+
+#### Tests
+
+- `the_request_payload_conforms_to_the_0_2_schema` builds the exact
+  AdminRotation request from the report and validates it against the **real**
+  published schema, through the same `trust_tasks_rs::validate` call the VTA
+  runs. Reverting the casing fix reproduces the reported error character for
+  character.
+- `ask_type_serialises_with_the_0_2_camelcase_tags` pins the wire tags, asserted
+  on serialized JSON rather than a round-trip — the inbound aliases accept both
+  spellings, so a round-trip passes either way and would not have caught this.
+- `the_0_1_pascalcase_tags_are_still_accepted_inbound` pins the alias direction,
+  since dropping one while renaming the variants would strand existing holders
+  silently.
+
+`admin_rotation_ask_round_trips_through_sign_verify` asserted the old
+PascalCase tag incidentally — its stated subject is the `adminTemplate` field
+name — and is updated to the 0.2 form.
+
+#### Downstream
+
+OpenVTC needs only a dependency bump; no code change there.

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.21.10"
+version = "0.21.11"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/provision_integration/http.rs
+++ b/vta-sdk/src/provision_integration/http.rs
@@ -292,4 +292,67 @@ mod tests {
         assert_eq!(s.client_did, "did:key:zClient");
         assert_eq!(s.bundle_id_hex, "deadbeef");
     }
+
+    /// What this crate sends must satisfy the schema of the URI it sends under.
+    ///
+    /// The client submits `provision/integration/0.2`
+    /// ([`crate::trust_tasks::TASK_PROVISION_INTEGRATION_0_2`]) but serialised
+    /// the 0.1 PascalCase `ask.type` tags. The two schemas differ in exactly
+    /// that constant, so the VTA's payload-schema gate rejected every request:
+    ///
+    /// ```text
+    /// malformed request: payload does not conform to
+    /// https://trusttasks.org/spec/provision/integration/0.2:
+    /// {...,"type":"AdminRotation"} is not valid under any of the schemas
+    /// listed in the 'oneOf' keyword
+    /// ```
+    ///
+    /// Latent since the client moved to the 0.2 URI, fatal once the gate
+    /// landed. The unit tests on `BootstrapAsk` pin the tag itself; this pins
+    /// the property that actually matters — the whole payload validating
+    /// against the real published schema, through the same
+    /// `trust_tasks_rs::validate` call the VTA runs.
+    #[tokio::test]
+    async fn the_request_payload_conforms_to_the_0_2_schema() {
+        use crate::provision_integration::{
+            AdminRotationAsk, BootstrapAsk, BootstrapRequest, DidTemplateRef,
+        };
+        use chrono::Duration;
+
+        let schema = trust_tasks_rs::schema_index::schema_for(
+            crate::trust_tasks::TASK_PROVISION_INTEGRATION_0_2,
+        )
+        .expect("the 0.2 schema is published and indexed");
+
+        let (seed, pub_bytes) = crate::sealed_transfer::generate_ed25519_keypair();
+        let client_did = affinidi_crypto::did_key::ed25519_pub_to_did_key(&pub_bytes);
+
+        // The AdminRotation shape from the failing report: an OpenVTC setup
+        // rotating its ephemeral setup key to a VTA-minted admin identity.
+        let vp = BootstrapRequest::sign(
+            &seed,
+            &client_did,
+            [0x5Au8; 16],
+            Duration::hours(1),
+            Some("openvtc".into()),
+            BootstrapAsk::AdminRotation(AdminRotationAsk {
+                context_hint: Some("openvtc".into()),
+                admin_template: DidTemplateRef {
+                    name: "vta-admin".into(),
+                    vars: Default::default(),
+                },
+                note: Some("openvtc".into()),
+            }),
+        )
+        .await
+        .expect("sign the VP");
+
+        let payload = serde_json::json!({
+            "request": serde_json::to_value(&vp).expect("serialize VP"),
+        });
+
+        trust_tasks_rs::validate::against_schema(schema, &payload).unwrap_or_else(|e| {
+            panic!("the payload this crate sends must satisfy the 0.2 schema: {e}\n{payload:#}")
+        });
+    }
 }

--- a/vta-sdk/src/provision_integration/request.rs
+++ b/vta-sdk/src/provision_integration/request.rs
@@ -82,7 +82,12 @@ pub struct BootstrapRequest {
 /// Tagged enum of bootstrap intents. Extensible — add new variants as new
 /// kinds of integration bootstrap emerge.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(tag = "type")]
+// `rename_all` renames the *variants*, which are the `type` tag values here.
+// This crate submits under `provision/integration/0.2`, whose schema requires
+// the camelCase tags; emitting the 0.1 PascalCase form made every request fail
+// the VTA's payload-schema gate. Inbound still accepts both, via the aliases
+// below, so a 0.1 holder is unaffected.
+#[serde(tag = "type", rename_all = "camelCase")]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub enum BootstrapAsk {
     /// Template-driven integration bootstrap. The VTA mints a fresh
@@ -92,12 +97,12 @@ pub enum BootstrapAsk {
     /// in a [`SealedPayloadV1::TemplateBootstrap`](crate::sealed_transfer::SealedPayloadV1)
     /// bundle.
     ///
-    /// The `templateBootstrap` alias accepts the
-    /// `provision/integration/0.2` camelCase tag; serialisation keeps the
-    /// 0.1 `TemplateBootstrap` form. The tag is inside the signed VP, so
-    /// verification must run over the wire bytes — see
+    /// Serialises as `templateBootstrap`, the tag
+    /// `provision/integration/0.2` requires. The `TemplateBootstrap` alias
+    /// keeps accepting the 0.1 form inbound. The tag is inside the signed VP,
+    /// so verification must run over the wire bytes — see
     /// [`BootstrapRequest::verify_value`].
-    #[serde(alias = "templateBootstrap")]
+    #[serde(alias = "TemplateBootstrap")]
     TemplateBootstrap(TemplateBootstrapAsk),
     /// Admin-DID rotation only — no integration DID minted. The VTA
     /// renders `admin_template`, mints a fresh long-term admin DID,
@@ -113,9 +118,10 @@ pub enum BootstrapAsk {
     /// [`SealedPayloadV1::AdminRotation`]:
     /// crate::sealed_transfer::SealedPayloadV1::AdminRotation
     ///
-    /// The `adminRotation` alias accepts the `provision/integration/0.2`
-    /// camelCase tag; serialisation keeps the 0.1 `AdminRotation` form.
-    #[serde(alias = "adminRotation")]
+    /// Serialises as `adminRotation`, the tag `provision/integration/0.2`
+    /// requires. The `AdminRotation` alias keeps accepting the 0.1 form
+    /// inbound.
+    #[serde(alias = "AdminRotation")]
     AdminRotation(AdminRotationAsk),
 }
 
@@ -846,6 +852,66 @@ mod tests {
         let json = serde_json::to_string(&vp).unwrap();
         let parsed: BootstrapRequest = serde_json::from_str(&json).unwrap();
         parsed.verify().expect("verify deserialized VP");
+    }
+
+    /// The `ask.type` tag goes out camelCase, because that is what the schema
+    /// for the URI this crate submits under actually requires.
+    ///
+    /// This crate sends `provision/integration/0.2`
+    /// ([`crate::trust_tasks::TASK_PROVISION_INTEGRATION_0_2`]) while
+    /// serialising the 0.1 PascalCase tags. The two schemas differ in exactly
+    /// this constant — 0.1 says `AdminRotation`, 0.2 says `adminRotation` — so
+    /// every request failed the VTA's payload-schema gate with a
+    /// `malformedRequest` naming neither casing. Latent since the client moved
+    /// to the 0.2 URI; fatal once the gate landed.
+    ///
+    /// Asserted on the serialized JSON rather than through a round-trip: the
+    /// inbound aliases accept both spellings, so a round-trip passes either way
+    /// and would not have caught this.
+    #[test]
+    fn ask_type_serialises_with_the_0_2_camelcase_tags() {
+        let template = serde_json::to_value(sample_ask()).expect("serialize templateBootstrap");
+        assert_eq!(
+            template["type"], "templateBootstrap",
+            "provision/integration/0.2 requires the camelCase tag: {template}"
+        );
+
+        let admin = serde_json::to_value(BootstrapAsk::AdminRotation(AdminRotationAsk {
+            context_hint: Some("openvtc".into()),
+            admin_template: DidTemplateRef {
+                name: "vta-admin".into(),
+                vars: Default::default(),
+            },
+            note: Some("openvtc".into()),
+        }))
+        .expect("serialize adminRotation");
+        assert_eq!(
+            admin["type"], "adminRotation",
+            "provision/integration/0.2 requires the camelCase tag: {admin}"
+        );
+    }
+
+    /// The 0.1 PascalCase tags are still accepted inbound.
+    ///
+    /// The tag is inside the signed VP, so an existing holder that signed
+    /// `AdminRotation` must keep verifying — changing the outbound casing must
+    /// not strand them. The aliases are what make that true, and dropping one
+    /// while renaming the variants would be an easy and silent mistake.
+    #[test]
+    fn the_0_1_pascalcase_tags_are_still_accepted_inbound() {
+        let template: BootstrapAsk = serde_json::from_value(serde_json::json!({
+            "type": "TemplateBootstrap",
+            "template": { "name": "didcomm-mediator", "vars": {} }
+        }))
+        .expect("0.1 TemplateBootstrap must still parse");
+        assert!(matches!(template, BootstrapAsk::TemplateBootstrap(_)));
+
+        let admin: BootstrapAsk = serde_json::from_value(serde_json::json!({
+            "type": "AdminRotation",
+            "adminTemplate": { "name": "vta-admin", "vars": {} }
+        }))
+        .expect("0.1 AdminRotation must still parse");
+        assert!(matches!(admin, BootstrapAsk::AdminRotation(_)));
     }
 
     #[tokio::test]
@@ -1590,10 +1656,12 @@ mod tests {
         .await
         .unwrap();
 
-        // VP must serialize the AdminRotation tag with its `adminTemplate`
-        // JSON name, not the snake_case Rust name.
+        // VP must serialize the adminRotation tag with its `adminTemplate`
+        // JSON name, not the snake_case Rust name. The tag is camelCase since
+        // this crate submits under `provision/integration/0.2`, whose schema
+        // requires it — see `ask_type_serialises_with_the_0_2_camelcase_tags`.
         let json = serde_json::to_value(&vp).unwrap();
-        assert_eq!(json["ask"]["type"], "AdminRotation");
+        assert_eq!(json["ask"]["type"], "adminRotation");
         assert_eq!(json["ask"]["adminTemplate"]["name"], "vta-admin");
 
         let parsed: BootstrapRequest = serde_json::from_value(json).unwrap();

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.14.23"
+version = "0.14.24"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/trust_tasks/provision_integration.rs
+++ b/vta-service/src/trust_tasks/provision_integration.rs
@@ -48,9 +48,28 @@ pub(super) async fn handle_request(
         Err(resp) => return resp,
     };
 
-    // Verify the inbound BootstrapRequest's VP before doing any
-    // state changes.
-    let verified = match req.request.verify() {
+    // Verify the inbound BootstrapRequest's VP before doing any state changes,
+    // over the JSON **as received** — the same thing the DIDComm handler does.
+    //
+    // `req.request.verify()` re-serialises the typed struct first, which
+    // re-imposes this crate's serde casing on the very bytes the holder signed.
+    // That only worked while both sides happened to agree: the moment either
+    // one's casing moves, the proof breaks over a document nobody tampered
+    // with. `verify_value` takes the wire bytes, so the signed form survives
+    // JCS canonicalisation and the typed view is built from it separately.
+    let request_raw = match doc.payload.get("request") {
+        Some(v) => v.clone(),
+        None => {
+            return reject_with(
+                &doc,
+                trust_tasks_rs::RejectReason::MalformedRequest {
+                    reason: "provision-integration request missing 'request' field".into(),
+                },
+            );
+        }
+    };
+    let verified = match vta_sdk::provision_integration::BootstrapRequest::verify_value(request_raw)
+    {
         Ok(v) => v,
         Err(e) => {
             return reject_with(


### PR DESCRIPTION
### vta-sdk 0.21.11 / vta-service 0.14.24 — provisioning speaks 0.2, and the messaging SDK stops stalling shutdown (#917)

Three fixes that ship together because they land in the same release: the client
had to move to the 0.2 wire tags, the server had to stop re-imposing its own
casing on a signed document, and both want the messaging SDK that no longer
holds a lock through shutdown. One `vta-sdk` release, one VTA redeploy.

#### `ask.type` goes out camelCase — provisioning works again

`BootstrapAsk` serialised the **0.1** PascalCase tags (`AdminRotation`,
`TemplateBootstrap`) while the client submitted under
`provision/integration/**0.2**`. The two schemas differ in exactly that constant
— 0.1 requires `AdminRotation`, 0.2 requires `adminRotation` — so the VTA's
payload-schema gate rejected every request:

```
malformed request: payload does not conform to
https://trusttasks.org/spec/provision/integration/0.2:
{"adminTemplate":{…},"contextHint":"openvtc","note":"openvtc","type":"AdminRotation"}
is not valid under any of the schemas listed in the 'oneOf' keyword
```

Latent since the client moved to the 0.2 URI; fatal once the schema gate landed.
No config could bypass it — `policy.require_payload_schema` only governs *unknown*
URIs, and a known schema is always enforced.

The variants now `rename_all = "camelCase"`, with the PascalCase spellings kept
as inbound **aliases** so a 0.1 holder still parses. That direction matters: the
tag is inside the signed VP, so an existing holder that signed `AdminRotation`
must keep verifying.

Reported from OpenVTC, whose setup wizard could not get past
"Provision integration DID + admin credential".

#### The trust-task handler verifies the bytes it received

`handle_request` called `req.request.verify()`, which re-serialises the typed
struct — re-imposing this crate's serde casing on the very bytes the holder
signed. It only worked while both sides happened to agree; changing either one's
casing breaks the signature over a document nobody tampered with.

It now uses `verify_value` over the raw `doc.payload["request"]`, which is what
the DIDComm handler already did and what `verify_value`'s own documentation
tells network handlers to do. Client and server casing no longer have to match.

Fixing only the client would have moved the failure one step later rather than
resolving it.

#### `affinidi-messaging-sdk` 0.19.3 → 0.19.4

Carries [affinidi-tdk-rs#694](https://github.com/affinidi/affinidi-tdk-rs/pull/694):
`live_stream_next*` held a **read** guard on `ws_channel_tx` across its wait,
while `stop_websocket` needs the **write** guard — so a poll in flight blocked
every shutdown until the poll window elapsed.

For the delivery layer that is 10s, and its inbound pump issues a read-ahead
after every frame, so any consumer finishing mid-window paid the remainder on
exit. `pnm` showed it as a fixed pause *after* its output. Measured against a
live VTA: **13.1s → ~3.5s**, with the remaining time genuine mediator
round-trips.

Lockfile-only on our side — the `affinidi-tdk = "0.8.5"` pin already admits it
via a caret requirement. The lockfile also reassigns which `socket2` / `syn` a
few dependents use; both versions were already present, and this is the resolver
normalising on any lock touch, not a downgrade of the graph.

#### Tests

- `the_request_payload_conforms_to_the_0_2_schema` builds the exact
  AdminRotation request from the report and validates it against the **real**
  published schema, through the same `trust_tasks_rs::validate` call the VTA
  runs. Reverting the casing fix reproduces the reported error character for
  character.
- `ask_type_serialises_with_the_0_2_camelcase_tags` pins the wire tags, asserted
  on serialized JSON rather than a round-trip — the inbound aliases accept both
  spellings, so a round-trip passes either way and would not have caught this.
- `the_0_1_pascalcase_tags_are_still_accepted_inbound` pins the alias direction,
  since dropping one while renaming the variants would strand existing holders
  silently.

`admin_rotation_ask_round_trips_through_sign_verify` asserted the old
PascalCase tag incidentally — its stated subject is the `adminTemplate` field
name — and is updated to the 0.2 form.

#### Downstream

OpenVTC needs only a dependency bump; no code change there.
