### PR TITLE
fix(credentials): one credential's failure must not abandon the rest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9679,7 +9679,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-service"
-version = "0.11.54"
+version = "0.11.55"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/changelog.d/918-credential-delivery-attempts-every-credential.md
+++ b/changelog.d/918-credential-delivery-attempts-every-credential.md
@@ -1,0 +1,49 @@
+### vtc-service 0.11.55 — one credential's failure no longer abandons the rest (#918)
+
+`deliver_credentials` was a `for` loop ending in `push_to_holder(..).await?`, so
+the first failure returned and every **remaining** credential was silently
+dropped.
+
+Admission delivers two — the MembershipCredential and the role
+EndorsementCredential — as independent one-way deposits. A transient failure on
+the first therefore meant the member never received their role credential, and
+never would: `send_to_member` enqueues with `Delivery::Guaranteed`, so the
+retry-until-delivered machinery lives *behind* the very call that was skipped.
+Nothing was queued, so nothing was retried.
+
+The caller only `warn!`s — correctly, since the credentials are already issued
+and persisted and a delivery failure must not unwind the decision that issued
+them. The result was a member admitted into the community with a credential
+missing from their wallet and a single log line to say so.
+
+Independent deposits have no reason to share a fate. Each credential is now
+attempted regardless of what happened to the others, and the error names every
+one that failed, by credential *type* rather than position — "the
+EndorsementCredential did not go" is actionable where "credential 2 of 2" is a
+puzzle. A per-credential `warn!` fires as each failure happens, so the log shows
+which ones went and which did not rather than only the first casualty.
+
+#### Tests
+
+`a_failed_credential_does_not_abandon_the_rest` drives delivery with messaging
+deliberately not running, so every push fails identically, and asserts the error
+names **both** credentials. Under the old short-circuit it names only the first;
+verified by re-introducing the early return, which fails the test.
+
+#### Not the `join_didcomm` flake
+
+This was found while investigating
+`didcomm_join_round_trips_…_vmc_delivery`, which intermittently fails with "1 of
+2 credentials delivered". It is **not** the cause, and this change does not fix
+it:
+
+- In that failure the *second* push is the one that goes missing, so
+  short-circuiting after it abandons nothing. The outcome is identical before
+  and after this change.
+- The CI log for the failing run carries **no** VTC delivery-failure warning —
+  and that test defaults its subscriber to `warn`, so one would have printed.
+  Both sends succeeded.
+
+That places the loss on the receive side (the client's pickup loop or the
+mediator), not on the VTC's send. Recorded here so the next investigation starts
+from that, rather than re-examining a send path now known to be sound.

--- a/changelog.d/918-credential-delivery-attempts-every-credential.md
+++ b/changelog.d/918-credential-delivery-attempts-every-credential.md
@@ -47,3 +47,13 @@ it:
 That places the loss on the receive side (the client's pickup loop or the
 mediator), not on the VTC's send. Recorded here so the next investigation starts
 from that, rather than re-examining a send path now known to be sound.
+
+Local reproduction was attempted and failed — 30 runs under CPU contention, all
+green — so the next CI occurrence is the only chance to observe it. To keep that
+chance from being wasted a fourth time, the test's default log filter now runs
+`affinidi_messaging_delivery` at `debug`, which prints `drain_once`'s per-tick
+`sent` / `retried` / `failed` report. A passing run shows `sent=2`; a failing run
+showing `sent=1` puts the loss in the sender's outbox, and `sent=2` puts it at
+the mediator or below. Three counters per 2s tick, printed only for a failing
+test — it costs nothing until it is needed, and it turns the next occurrence
+into evidence instead of another round of inference.

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.11.54"
+version = "0.11.55"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vtc-service/src/credentials/delivery.rs
+++ b/vtc-service/src/credentials/delivery.rs
@@ -43,24 +43,86 @@ pub(crate) async fn deliver_membership_credentials(
 ///
 /// Packed authcrypt **to the proven holder** (not a relayer) and forwarded via
 /// the holder's own mediator. Best-effort by nature (mediator delivery is
-/// end-to-end): the first failure is returned so the caller can log it, but the
+/// end-to-end): failures are reported so the caller can log them, but the
 /// credentials are already issued and persisted — a failure must not unwind the
 /// decision that issued them.
+///
+/// # Every credential is attempted
+///
+/// This loop used to be `push_to_holder(..).await?`, which abandoned every
+/// *remaining* credential the moment one failed. Admission delivers two — the
+/// VMC and the role VEC — so a transient failure packing the second (holder DID
+/// resolution, say) meant the member got their membership credential, never got
+/// their role credential, and never would: the enqueue that makes delivery
+/// durable is the very step that was skipped, so there was nothing to retry.
+/// The caller only `warn!`s, so the member's wallet was simply missing a
+/// credential with nothing but a log line to say why.
+///
+/// Independent one-way deposits have no reason to share a fate. Each is now
+/// attempted regardless of what happened to the others, and the error names
+/// every one that failed — a caller that logs it can say *which* credential to
+/// re-deliver, which the previous first-failure-wins error could not.
 pub(crate) async fn deliver_credentials(
     state: &AppState,
     holder_did: &str,
     credentials: &[&VerifiableCredential],
 ) -> Result<(), AppError> {
-    for credential in credentials {
-        let credential_json = serde_json::to_value(credential)
-            .map_err(|e| AppError::Internal(format!("issued credential serialise: {e}")))?;
-        let body = issue_message_body(credential_json)?;
-        // A fresh thread per delivered credential — `issue` is a one-way deposit,
-        // not a request/response, so it needs no correlation to a prior thread.
-        let msg_id = Uuid::new_v4().to_string();
-        push_to_holder(state, holder_did, &msg_id, CREDENTIAL_ISSUE_TYPE, body).await?;
+    let mut failures: Vec<String> = Vec::new();
+
+    for (index, credential) in credentials.iter().enumerate() {
+        // `push_of` is fallible at three points (serialise, wrap, send); running
+        // it as one unit keeps a failure at any of them from skipping the rest.
+        let push = async {
+            let credential_json = serde_json::to_value(credential)
+                .map_err(|e| AppError::Internal(format!("issued credential serialise: {e}")))?;
+            let body = issue_message_body(credential_json)?;
+            // A fresh thread per delivered credential — `issue` is a one-way
+            // deposit, not a request/response, so it needs no correlation to a
+            // prior thread.
+            let msg_id = Uuid::new_v4().to_string();
+            push_to_holder(state, holder_did, &msg_id, CREDENTIAL_ISSUE_TYPE, body).await
+        };
+
+        if let Err(e) = push.await {
+            // Name the credential by type, not just position: "the role VEC did
+            // not go" is actionable where "credential 2 of 2" is a puzzle.
+            let kind = credential_kind(credential);
+            tracing::warn!(
+                holder = %holder_did,
+                credential = %kind,
+                error = %e,
+                "credential delivery failed; continuing with the rest"
+            );
+            failures.push(format!("{kind} (#{}): {e}", index + 1));
+        }
     }
-    Ok(())
+
+    if failures.is_empty() {
+        return Ok(());
+    }
+    Err(AppError::Internal(format!(
+        "{} of {} credential(s) failed to deliver to {holder_did}: {}",
+        failures.len(),
+        credentials.len(),
+        failures.join("; ")
+    )))
+}
+
+/// The most specific `type` on a VC, for diagnostics — `MembershipCredential`
+/// rather than the `VerifiableCredential` every one of them carries.
+fn credential_kind(credential: &VerifiableCredential) -> String {
+    serde_json::to_value(credential)
+        .ok()
+        .and_then(|v| {
+            v.get("type").and_then(|t| t.as_array()).and_then(|types| {
+                types
+                    .iter()
+                    .filter_map(|t| t.as_str())
+                    .find(|t| *t != "VerifiableCredential")
+                    .map(str::to_string)
+            })
+        })
+        .unwrap_or_else(|| "credential".to_string())
 }
 
 /// Wrap an issued credential JSON value in a `credential-exchange/issue` body —
@@ -147,6 +209,71 @@ mod tests {
         assert_eq!(
             credential, vmc,
             "the delivered credential round-trips intact"
+        );
+    }
+
+    /// The most specific type is what names the credential in a failure.
+    #[test]
+    fn credential_kind_names_the_specific_type() {
+        let vmc: VerifiableCredential = serde_json::from_value(json!({
+            "@context": ["https://www.w3.org/ns/credentials/v2"],
+            "type": ["VerifiableCredential", "MembershipCredential"],
+            "issuer": "did:web:vtc.example",
+            "credentialSubject": { "id": "did:key:zHolder" },
+        }))
+        .expect("parse VMC");
+        assert_eq!(credential_kind(&vmc), "MembershipCredential");
+    }
+
+    /// One credential failing must not abandon the others.
+    ///
+    /// The loop was `push_to_holder(..).await?`, so the first failure returned
+    /// and every remaining credential was silently dropped. Admission delivers
+    /// two — the VMC and the role VEC — so a transient failure on the second
+    /// left the member holding one credential, with no retry possible: the
+    /// enqueue that makes delivery durable is the step that was skipped. The
+    /// caller only `warn!`s, so nothing surfaced but a log line.
+    ///
+    /// Driven with messaging deliberately **not** running, which makes every
+    /// push fail identically. That is the point: if delivery still short-
+    /// circuited, the error would name one credential. It must name both,
+    /// because both must have been attempted.
+    #[tokio::test]
+    async fn a_failed_credential_does_not_abandon_the_rest() {
+        let tv = crate::test_support::build_test_vtc().await;
+
+        let vmc: VerifiableCredential = serde_json::from_value(json!({
+            "@context": ["https://www.w3.org/ns/credentials/v2"],
+            "type": ["VerifiableCredential", "MembershipCredential"],
+            "issuer": "did:web:vtc.example",
+            "credentialSubject": { "id": "did:key:zHolder" },
+        }))
+        .expect("parse VMC");
+        let vec_: VerifiableCredential = serde_json::from_value(json!({
+            "@context": ["https://www.w3.org/ns/credentials/v2"],
+            "type": ["VerifiableCredential", "EndorsementCredential"],
+            "issuer": "did:web:vtc.example",
+            "credentialSubject": { "id": "did:key:zHolder" },
+        }))
+        .expect("parse VEC");
+
+        let err = deliver_credentials(&tv.state, "did:key:zHolder", &[&vmc, &vec_])
+            .await
+            .expect_err("messaging is not running, so both pushes fail");
+        let msg = err.to_string();
+
+        assert!(
+            msg.contains("MembershipCredential"),
+            "the first credential must be named: {msg}"
+        );
+        assert!(
+            msg.contains("EndorsementCredential"),
+            "the second must be attempted too — naming only the first is the \
+             short-circuit this test exists to catch: {msg}"
+        );
+        assert!(
+            msg.contains("2 of 2"),
+            "the summary should say how many of how many failed: {msg}"
         );
     }
 }

--- a/vtc-service/tests/join_didcomm.rs
+++ b/vtc-service/tests/join_didcomm.rs
@@ -43,11 +43,36 @@ use std::time::Duration;
 /// test fails — which is precisely when they would bury the delivery warning
 /// this subscriber exists to surface. Override the whole thing with `RUST_LOG`
 /// when you want it back.
+///
+/// # The delivery layer runs at `debug`, on purpose
+///
+/// This test has failed intermittently in CI with "1 of 2 credentials
+/// delivered", and every attempt to place the loss has run out of evidence.
+/// Two things are already known from the warnings, which do print at `warn`:
+/// the VTC logged no delivery failure, and the client's pickup logged no poll
+/// errors. So the VTC sent, the client polled healthily for the full 60s, and
+/// the message was lost between them — and neither side can say more.
+///
+/// `affinidi_messaging_delivery=debug` adds the one fact that decides it:
+/// `drain_once` logs a per-tick `sent` / `retried` / `failed` report, so a
+/// failing run shows whether the sender's outbox actually put **two** messages
+/// on the wire. If it did, the loss is at the mediator or below and the next
+/// probe goes there; if it did not, the loss is in the outbox and this is the
+/// wrong place to have been looking.
+///
+/// It is concise (three counters per 2s tick, not message dumps) and prints
+/// only for a failing test, so it costs nothing until it is needed. Local
+/// reproduction has been tried and failed — 30 runs under CPU contention, all
+/// green — so the next CI occurrence is the only opportunity, and it should not
+/// be wasted a fourth time.
 fn init_tracing() {
     let _ = tracing_subscriber::fmt()
         .with_env_filter(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn,lsm_tree=off")),
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+                tracing_subscriber::EnvFilter::new(
+                    "warn,lsm_tree=off,affinidi_messaging_delivery=debug",
+                )
+            }),
         )
         .with_test_writer()
         .try_init();


### PR DESCRIPTION
### vtc-service 0.11.55 — one credential's failure no longer abandons the rest (#918)

`deliver_credentials` was a `for` loop ending in `push_to_holder(..).await?`, so
the first failure returned and every **remaining** credential was silently
dropped.

Admission delivers two — the MembershipCredential and the role
EndorsementCredential — as independent one-way deposits. A transient failure on
the first therefore meant the member never received their role credential, and
never would: `send_to_member` enqueues with `Delivery::Guaranteed`, so the
retry-until-delivered machinery lives *behind* the very call that was skipped.
Nothing was queued, so nothing was retried.

The caller only `warn!`s — correctly, since the credentials are already issued
and persisted and a delivery failure must not unwind the decision that issued
them. The result was a member admitted into the community with a credential
missing from their wallet and a single log line to say so.

Independent deposits have no reason to share a fate. Each credential is now
attempted regardless of what happened to the others, and the error names every
one that failed, by credential *type* rather than position — "the
EndorsementCredential did not go" is actionable where "credential 2 of 2" is a
puzzle. A per-credential `warn!` fires as each failure happens, so the log shows
which ones went and which did not rather than only the first casualty.

#### Tests

`a_failed_credential_does_not_abandon_the_rest` drives delivery with messaging
deliberately not running, so every push fails identically, and asserts the error
names **both** credentials. Under the old short-circuit it names only the first;
verified by re-introducing the early return, which fails the test.

#### Not the `join_didcomm` flake

This was found while investigating
`didcomm_join_round_trips_…_vmc_delivery`, which intermittently fails with "1 of
2 credentials delivered". It is **not** the cause, and this change does not fix
it:

- In that failure the *second* push is the one that goes missing, so
  short-circuiting after it abandons nothing. The outcome is identical before
  and after this change.
- The CI log for the failing run carries **no** VTC delivery-failure warning —
  and that test defaults its subscriber to `warn`, so one would have printed.
  Both sends succeeded.

That places the loss on the receive side (the client's pickup loop or the
mediator), not on the VTC's send. Recorded here so the next investigation starts
from that, rather than re-examining a send path now known to be sound.
