### PR TITLE
fix(trust-tasks): an unset payload member is absent, never null

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2922,7 +2922,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c54e03a951783e8b327515db3f2a2fd0e3bed362a96b066f341ce66ed49b4ead"
 dependencies = [
  "data-encoding",
- "syn 3.0.3",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4587,7 +4587,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -6453,7 +6453,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.43",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "thiserror 2.0.20",
  "tokio",
  "tracing",
@@ -6492,7 +6492,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -9383,7 +9383,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.21.11"
+version = "0.21.12"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -9445,7 +9445,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.14.24"
+version = "0.14.25"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/changelog.d/919-keys-create-null-members.md
+++ b/changelog.d/919-keys-create-null-members.md
@@ -1,0 +1,50 @@
+### vta-sdk 0.21.12 / vta-service 0.14.25 — an unset member is absent, never `null` (#919)
+
+`keys/create` was unusable over DIDComm and TSP. Every call that did not supply
+a BIP-39 phrase — which is every call that is not importing external seed
+material — sent `"mnemonic": null`, and `keys/create/0.1` types that member
+`"string"`:
+
+```text
+malformed request: payload does not conform to
+https://trusttasks.org/spec/keys/create/0.1: payload failed schema validation:
+null is not of type "string"
+```
+
+Nothing downstream could mint a key. An OpenVTC community join, whose first act
+is to create a persona's signing key, died on its first round-trip with that
+text and rolled back.
+
+This is the same defect as #895 (`vta/webvh/dids/update/1.0`, where every
+partial update was unusable for the same reason), reintroduced on a different
+task by the canonical-body fold in #888: `create_key` moved off a hand-rolled
+map — which skipped its `None`s — onto `CreateKeyBody`, which did not.
+
+- **`vta-sdk`**: `CreateKeyBody`'s `mnemonic` / `label` / `contextId`,
+  `DeriveAndSignDocumentBody`'s `proofPurpose`, and `SelfRemoveBody`'s
+  `disposition` all skip `None` now. The other two were latent variants of the
+  same bug, not collateral: `vtc/members/self-remove/0.1` constrains
+  `disposition` to an enum of strings, so a member removing themselves under
+  the community's default preference was sending the one value the schema
+  cannot accept.
+- **`vta-service`**: the schema-conformance sweep (#857) now validates each
+  witness's request against its embedded `payload.schema.json` — the check
+  `validate_payload` runs on the dispatch spine — and not only parses it into
+  the generated type.
+
+That last part is why this shipped. The sweep already built its `keys/create`
+witness from a real `CreateKeyBody` with `mnemonic: None`, and it passed:
+serde reads `null` into an `Option<String>` without complaint, while JSON
+Schema types the member `"string"` and refuses it. Parsing is strictly weaker
+than validating, so the witness proved the shape and said nothing about the
+wire. Reverting the SDK fix now fails the sweep with the exact production
+error.
+
+The REST leg was never affected — it serializes `CreateKeyRequest`, which
+already skipped its `None`s. Only the transports the stack prefers were broken.
+
+Requests only: `trust-tasks-rs` codegen emits `ValidatedPayload` for `Payload`
+but not for `Response` (0.4 and 0.5 alike), so there is no embedded response
+schema to validate against. The response side keeps its parse check. Closing
+that half needs the codegen to emit response schemas, which is an upstream
+change and is not included here.

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.21.11"
+version = "0.21.12"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/protocols/join_requests.rs
+++ b/vta-sdk/src/protocols/join_requests.rs
@@ -321,7 +321,11 @@ pub const MEMBER_SELF_REMOVE_RECEIPT_TYPE: &str =
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct SelfRemoveBody {
-    #[serde(default)]
+    /// Absent when unset, never `null`. `vtc/members/self-remove/0.1` types
+    /// `disposition` as a `"string"` constrained to the disposition enum, so a
+    /// serialized `None` is rejected as malformed instead of falling through to
+    /// the stored preference the way an omitted member does.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub disposition: Option<String>,
 }
 

--- a/vta-sdk/src/protocols/key_management/create.rs
+++ b/vta-sdk/src/protocols/key_management/create.rs
@@ -11,9 +11,14 @@ pub struct CreateKeyBody {
     pub key_type: KeyType,
     #[serde(alias = "derivation_path")]
     pub derivation_path: String,
+    /// An unset member must be **absent**, never `null` — `keys/create/0.1`
+    /// types each of these as `"string"`, and none of them accepts null. See
+    /// the `an_unset_member_is_absent_from_the_wire_not_null` test below.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mnemonic: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub label: Option<String>,
-    #[serde(alias = "context_id")]
+    #[serde(default, alias = "context_id", skip_serializing_if = "Option::is_none")]
     pub context_id: Option<String>,
 }
 
@@ -68,4 +73,74 @@ pub struct CreateKeyResponseBody {
 
 fn default_derived() -> KeyOrigin {
     KeyOrigin::Derived
+}
+
+#[cfg(test)]
+mod null_member_tests {
+    use super::*;
+
+    /// The bug this skip fixes, pinned.
+    ///
+    /// `keys/create/0.1` types every optional member — `mnemonic`, `label`,
+    /// `contextId`, `derivationPath` — as `"string"`. None of them accepts
+    /// null, so serialising `None` as `null` failed schema validation the
+    /// moment the payload reached a maintainer:
+    ///
+    /// ```text
+    /// malformed request: payload does not conform to
+    /// https://trusttasks.org/spec/keys/create/0.1: payload failed schema
+    /// validation: null is not of type "string"
+    /// ```
+    ///
+    /// Every caller that mints a key without a BIP-39 phrase — which is every
+    /// caller that is not importing external seed material — sent
+    /// `"mnemonic": null` and was refused. That is the whole of `keys/create`
+    /// over the trust-task transports, so an OpenVTC persona mint could not
+    /// get past its first key. The REST leg was unaffected: it serialises
+    /// [`CreateKeyRequest`](crate::client::CreateKeyRequest), which already
+    /// skipped its `None`s.
+    ///
+    /// Same defect, same shape, as `did_management::update`'s
+    /// `an_unset_field_is_absent_from_the_wire_not_null` — the canonical-body
+    /// fold reintroduced it on a different task.
+    #[test]
+    fn an_unset_member_is_absent_from_the_wire_not_null() {
+        // What `create_key` builds for a plain, unlabelled, uncontexted key.
+        let minimal = CreateKeyBody {
+            key_type: KeyType::Ed25519,
+            derivation_path: String::new(),
+            mnemonic: None,
+            label: None,
+            context_id: None,
+        };
+
+        assert_eq!(
+            serde_json::to_value(&minimal).expect("serialises"),
+            serde_json::json!({"keyType": "ed25519", "derivationPath": ""}),
+            "an unset member must be absent, not null"
+        );
+    }
+
+    /// A set member still reaches the wire under its canonical camelCase name
+    /// — the skip must not be reachable for `Some`.
+    #[test]
+    fn a_set_member_still_serialises() {
+        let labelled = CreateKeyBody {
+            key_type: KeyType::Ed25519,
+            derivation_path: "m/26'/2'/0'/1'".into(),
+            mnemonic: None,
+            label: Some("persona-signing".into()),
+            context_id: Some("openvtc".into()),
+        };
+
+        assert_eq!(
+            serde_json::to_value(&labelled).expect("serialises"),
+            serde_json::json!({
+                "keyType": "ed25519",
+                "derivationPath": "m/26'/2'/0'/1'",
+                "label": "persona-signing",
+                "contextId": "openvtc",
+            })
+        );
+    }
 }

--- a/vta-sdk/src/protocols/key_management/derive_and_sign_document.rs
+++ b/vta-sdk/src/protocols/key_management/derive_and_sign_document.rs
@@ -29,7 +29,15 @@ pub struct DeriveAndSignDocumentBody {
     pub document: Value,
     /// Proof purpose (default `assertionMethod`, matching the DI-signed REST
     /// auth flow).
-    #[serde(default, alias = "proof_purpose")]
+    ///
+    /// Absent when unset, never `null`: `keys/derive-and-sign-document/0.1`
+    /// types `proofPurpose` as `"string"`, so a serialized `None` fails schema
+    /// validation on arrival rather than being read as "use the default".
+    #[serde(
+        default,
+        alias = "proof_purpose",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub proof_purpose: Option<String>,
 }
 

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.14.24"
+version = "0.14.25"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/trust_tasks/conformance.rs
+++ b/vta-service/src/trust_tasks/conformance.rs
@@ -22,8 +22,16 @@
 //! annotated [`Conformance::KnownDrift`] debt entry. The witness's request
 //! must parse as the generated `specs::…::Payload` and the response as
 //! `specs::…::Response`; the generated types carry `deny_unknown_fields`
-//! plus the spec's required set, so the round-trip *is* the conformance
-//! check.
+//! plus the spec's required set.
+//!
+//! The request is then validated against its embedded
+//! `payload.schema.json` — the same check `validate_payload` runs on the
+//! dispatch spine. Parsing alone is strictly weaker and let a whole class of
+//! defect through: serde accepts `null` into an `Option<T>` field, JSON
+//! Schema types that member `"string"` and rejects it. `keys/create/0.1`
+//! shipped a body that serialized every unset member as `null`, its witness
+//! parsed green, and live key creation over DIDComm/TSP failed on arrival.
+//! See [`validates`].
 //!
 //! **Non-vacuity is enforced mechanically.** The `acl/update` defect
 //! survived three PRs because an assertion of the form "adding a forbidden
@@ -57,6 +65,7 @@ use serde_json::{Value, json};
 use std::collections::{BTreeSet, HashMap};
 
 use trust_tasks_rs::specs;
+use trust_tasks_rs::validate::ValidatedPayload;
 use vta_sdk::trust_tasks as uris;
 
 use vta_sdk::acl::ContextDirection;
@@ -124,11 +133,28 @@ fn resolved_uris() -> BTreeSet<&'static str> {
 }
 
 type ParseFn = fn(Value) -> Result<(), String>;
+type ValidateFn = fn(&Value) -> Result<(), String>;
 
 fn parses<T: DeserializeOwned>(v: Value) -> Result<(), String> {
     serde_json::from_value::<T>(v)
         .map(|_| ())
         .map_err(|e| e.to_string())
+}
+
+/// Validate against the embedded `payload.schema.json`, which is what the
+/// dispatch spine actually runs (`validate_payload` → `against_schema`).
+///
+/// This is **not** what [`parses`] checks, and the gap is where a whole class
+/// of defect lived. serde reads `null` into an `Option<T>` field happily; JSON
+/// Schema types the same member `"string"` and rejects null outright. So a body
+/// that serialized every unset member as `null` round-tripped through the
+/// generated type — green sweep — and was refused by the first maintainer it
+/// reached. `keys/create/0.1` shipped exactly that way: the witness below
+/// serializes a real `CreateKeyBody` with `mnemonic: None`, it parsed, and
+/// every live key creation over DIDComm/TSP failed with `null is not of type
+/// "string"`. Both checks now run on every witness.
+fn validates<T: ValidatedPayload>(v: &Value) -> Result<(), String> {
+    T::validate_value(v).map_err(|e| e.to_string())
 }
 
 /// A representative request/response pair for one published, dispatched URI.
@@ -141,6 +167,7 @@ fn parses<T: DeserializeOwned>(v: Value) -> Result<(), String> {
 struct Witness {
     request: Value,
     parse_request: ParseFn,
+    validate_request: ValidateFn,
     response: Value,
     parse_response: ParseFn,
 }
@@ -159,6 +186,7 @@ macro_rules! checked {
         Conformance::Checked(Witness {
             request: $req,
             parse_request: parses::<$p>,
+            validate_request: validates::<$p>,
             response: $resp,
             parse_response: parses::<$r>,
         })
@@ -1799,6 +1827,23 @@ fn every_witnessed_task_round_trips_through_its_generated_types() {
             .unwrap_or_else(|e| panic!("{uri}: request is not canonical: {e}\n{:#}", w.request));
         (w.parse_response)(w.response.clone())
             .unwrap_or_else(|e| panic!("{uri}: response is not canonical: {e}\n{:#}", w.response));
+
+        // And the request against the schema itself — the check the dispatch
+        // spine runs on arrival. Parsing is strictly weaker: serde reads
+        // `null` into an `Option<T>` where the schema types the member
+        // `"string"` and refuses it. See [`validates`].
+        //
+        // Request-only: `trust-tasks-rs` codegen emits `ValidatedPayload` for
+        // `Payload` but not for `Response` (0.4 and 0.5 alike), so there is no
+        // embedded response schema to check against. The response side keeps
+        // its parse check; closing that half needs the codegen to emit the
+        // response schema, which is an upstream change.
+        (w.validate_request)(&w.request).unwrap_or_else(|e| {
+            panic!(
+                "{uri}: request fails its own payload schema: {e}\n{:#}",
+                w.request
+            )
+        });
 
         // Teeth: an unknown member must be rejected on both sides. The
         // generated types carry `deny_unknown_fields` wherever the spec is


### PR DESCRIPTION
`keys/create` was unusable over DIDComm and TSP. Every call that did not supply a BIP-39 phrase — which is every call that is not importing external seed material — sent `"mnemonic": null`, and `keys/create/0.1` types that member `"string"`:

```text
malformed request: payload does not conform to
https://trusttasks.org/spec/keys/create/0.1: payload failed schema validation:
null is not of type "string"
```

Nothing downstream could mint a key. An OpenVTC community join, whose first act is to create a persona's signing key, died on its first round-trip with that text and rolled back. Reported from OpenVTC.

Same defect as #895 (`vta/webvh/dids/update/1.0`, where every partial update was unusable for the same reason), reintroduced on a different task by the canonical-body fold in #888: `create_key` moved off a hand-rolled map — which skipped its `None`s — onto `CreateKeyBody`, which did not.

## What changed

- **`vta-sdk` 0.21.12** — `CreateKeyBody`'s `mnemonic` / `label` / `contextId`, `DeriveAndSignDocumentBody`'s `proofPurpose`, and `SelfRemoveBody`'s `disposition` all skip `None` now. The latter two are latent variants of the same bug, not collateral: `vtc/members/self-remove/0.1` constrains `disposition` to an enum of strings, so a member removing themselves under the community's default preference was sending the one value the schema cannot accept.
- **`vta-service` 0.14.25** — the schema-conformance sweep (#857) now validates each witness's request against its embedded `payload.schema.json`, the check `validate_payload` runs on the dispatch spine, and not only parses it into the generated type.

## Why it shipped

The sweep already built its `keys/create` witness from a real `CreateKeyBody` with `mnemonic: None`, and it passed. serde reads `null` into an `Option<String>` without complaint, while JSON Schema types the member `"string"` and refuses it. **Parsing is strictly weaker than validating**, so the witness proved the shape and said nothing about the wire.

Reverting the SDK fix now fails the sweep with the exact production error:

```text
https://trusttasks.org/spec/keys/create/0.1: request fails its own payload
schema: payload failed schema validation: null is not of type "string"
```

The REST leg was never affected — it serialises `CreateKeyRequest`, which already skipped its `None`s. Only the transports the stack prefers were broken.

## Scope left open

Requests only: `trust-tasks-rs` codegen emits `ValidatedPayload` for `Payload` but not for `Response` (0.4 and 0.5 alike), so there is no embedded response schema to validate against. The response side keeps its parse check. Closing that half needs the codegen to emit response schemas — an upstream change, not included here.

Three response bodies still serialise `None` as `null` against non-nullable members (`CreateKeyResultBody.label`, `CreateContextResultBody.did`/`description`, `CreateAclResultBody.label`). Nothing validates them today, so they are not currently breaking anything; they become live the moment response validation lands.

## Pre-merge checklist

- [x] `cargo check` passes for the entire workspace
- [x] `cargo test` passes with no failures (`vta-sdk` 257, `vta-service` lib 787)
- [x] `cargo fmt --check` shows no formatting issues
- [x] `cargo clippy` clean on both touched crates (`--all-targets`)
- [x] Regression test pinned (`create.rs::null_member_tests`), and the sweep verified non-vacuous by reverting the fix
- [x] Changelog fragment `changelog.d/919-keys-create-null-members.md`
- [x] Commits signed off (DCO)
