### PR TITLE
test(trust-tasks): check what we send, not what we wrote down

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2922,7 +2922,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c54e03a951783e8b327515db3f2a2fd0e3bed362a96b066f341ce66ed49b4ead"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4587,7 +4587,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -6453,7 +6453,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.43",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "thiserror 2.0.20",
  "tokio",
  "tracing",
@@ -6492,7 +6492,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -9383,7 +9383,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.21.12"
+version = "0.21.13"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -9427,6 +9427,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.11.0",
+ "syn 2.0.119",
  "tempfile",
  "thiserror 2.0.20",
  "time",
@@ -9445,7 +9446,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.14.25"
+version = "0.14.26"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/changelog.d/920-producer-payload-census.md
+++ b/changelog.d/920-producer-payload-census.md
@@ -1,0 +1,64 @@
+### vta-sdk 0.21.13 / vta-service 0.14.26 — check what we *send*, not what we wrote down (#920)
+
+#919 fixed `keys/create` sending `"mnemonic": null`. It did not answer the
+question the fix raised: how many more are there, and what would have caught
+this? Both defects of this shape (#895, #919) were found in production, by a
+person, from a rejected request. This adds the two checks that find them
+without one.
+
+**A source census, in `vta-sdk`** (`tests/payload_null_census.rs`). Every
+`Option` member of every `Serialize` struct under `protocols/` must skip `None`,
+because every Trust Task schema types its optional members by what they hold and
+none of them accepts null. Exceptions go in `NULLABLE_BY_DESIGN` with a reason
+and are checked in both directions, so an exemption cannot outlive the member it
+exempts. Parsed with `syn` rather than grepped — the attribute is routinely
+written across several lines, which a line-oriented regex misreads in exactly
+the direction that lets a violation through.
+
+It found five on its first run, all latent, all now fixed:
+`CreateAclResultBody::label`, `CreateContextResultBody::{did,description}`,
+`CreateKeyResultBody::label`, `SeedRecordBackup::retired_at`, plus
+`AclEntryBackup::label`. Each sits in a struct whose *sibling* members already
+skip, so these were oversights rather than decisions. Only
+`GetKeyResponseBody::key` is exempt, and that one is spec-mandated:
+`keys/show/0.1#response` types it `oneOf: [KeyRecord, null]` and requires it
+present, because "no such key" is a successful answer.
+
+**A producer census, in `vta-service`**
+(`tests/producer_payload_conformance.rs`). The census above cannot see a payload
+built by hand, and the conformance sweep (#857) cannot see one at all — it
+checks a witness written in the test, and no client method runs during it. So
+this drives the client methods themselves, through a new in-process transport
+(`vta_sdk::client::loopback`, behind `test-loopback`), with **every optional
+argument unset** — the shape that broke `keys/create` — and validates what they
+emit against the published schema. No VTA, no mediator, no socket.
+
+It found a live one immediately: **`derive_and_sign_document` sent
+`"proofPurpose": null`** on every call that did not name a purpose. Omitting the
+purpose is what selects the documented `assertionMethod` default, so the
+documented way to call it was the way that could not work. #919's fix had
+already added `skip_serializing_if` to `DeriveAndSignDocumentBody` — and the
+method did not use it, building a `json!` map instead. That is the gap between
+the two censuses in one example: fixing the struct does not fix a producer that
+never touches the struct. It now builds the canonical body, as #888 intended.
+
+The census also makes four unvalidatable tasks visible in `UNPUBLISHED`, each
+with its reason. They share a pattern worth naming: every one is a legacy
+`vta/`-namespaced task the canonical folds have not reached, so the
+unvalidatable surface is exactly the un-folded surface, and each closes for free
+when its family is folded.
+
+**On the loopback seam.** It intercepts ahead of the transport rather than
+adding a `Transport` variant. A variant would have to be answered at each of the
+~20 sites that match on `Transport`, almost all of which would say
+"unsupported" — twenty arms of noise in production code to serve a test. The
+hook touches the three functions that dispatch a Trust Task and leaves every
+transport match exhaustive over the transports that really exist.
+
+**Not covered, deliberately.** Framing — TSP sealing, DIDComm authcrypt,
+mediator routing — sits below the loopback point and still needs a harness with
+a real mediator. And 26 of the sweep's 70 witnesses still transcribe their
+request as a `json!` fixture rather than building it from the producer; 21 of
+those name a client method that exists today, so the module comment calling
+those slices "module-private" is stale. Converting them is follow-up work this
+does not do.

--- a/changelog.d/921-producer-payload-census.md
+++ b/changelog.d/921-producer-payload-census.md
@@ -1,4 +1,4 @@
-### vta-sdk 0.21.13 / vta-service 0.14.26 — check what we *send*, not what we wrote down (#920)
+### vta-sdk 0.21.13 / vta-service 0.14.26 — check what we *send*, not what we wrote down (#921)
 
 #919 fixed `keys/create` sending `"mnemonic": null`. It did not answer the
 question the fix raised: how many more are there, and what would have caught

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.21.12"
+version = "0.21.13"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -11,6 +11,13 @@ license.workspace = true
 repository.workspace = true
 
 [features]
+# In-process Trust-Task transport for tests (`client::loopback`). Lets a test
+# drive the real client methods and observe the payloads they build without a
+# VTA, a mediator, or a socket — the producer side was otherwise unreachable
+# without the whole stack, which is why #895 and #919 were both found in
+# production rather than in CI. Carries no dependencies and no production code
+# path; `vta-sdk`'s own test suite turns it on.
+test-loopback = []
 didcomm = [
   "dep:affinidi-tdk",
   "dep:affinidi-did-resolver-cache-sdk",
@@ -354,6 +361,12 @@ affinidi-data-integrity = { workspace = true, features = ["bbs-2023"] }
 # assemble synthetic quote chains via its `builder` feature. Production no
 # longer calls into it.
 nitro_attest = { version = "0.2", features = ["builder"] }
+# The null-member census (tests/payload_null_census.rs) parses this crate's own
+# `protocols/` source and asserts no wire member can serialize as `null`. Parsed
+# rather than grepped: the attribute it looks for is routinely written across
+# several lines, which a regex reads wrong in exactly the direction that lets a
+# violation through.
+syn = { version = "2", features = ["full", "parsing", "extra-traits"] }
 
 [lints]
 workspace = true

--- a/vta-sdk/src/client/keys.rs
+++ b/vta-sdk/src/client/keys.rs
@@ -238,12 +238,22 @@ impl VtaClient {
         document: serde_json::Value,
         proof_purpose: Option<&str>,
     ) -> Result<DeriveAndSignDocumentResultBody, VtaError> {
-        let body = serde_json::json!({
-            "keyType": serde_json::to_value(&key_type)?,
-            "derivationPath": derivation_path,
-            "document": document,
-            "proofPurpose": proof_purpose,
-        });
+        // Built from the canonical body, not a hand-rolled map. The map spelled
+        // `proofPurpose` unconditionally, so an unset purpose went on the wire
+        // as `null` and `keys/derive-and-sign-document/0.1` — which types it
+        // `"string"` — rejected the request. Omitting the member is what
+        // selects the `assertionMethod` default, so the *documented* way to
+        // call this was the one that could not work. Same defect as #919's
+        // `keys/create`, and the same fix: let the body struct's
+        // `skip_serializing_if` decide what reaches the wire.
+        let body = serde_json::to_value(
+            crate::protocols::key_management::derive_and_sign_document::DeriveAndSignDocumentBody {
+                key_type,
+                derivation_path: derivation_path.to_string(),
+                document,
+                proof_purpose: proof_purpose.map(str::to_string),
+            },
+        )?;
         self.rpc_tt(
             trust_tasks::TASK_KEYS_DERIVE_AND_SIGN_DOCUMENT_0_1,
             body.clone(),

--- a/vta-sdk/src/client/loopback.rs
+++ b/vta-sdk/src/client/loopback.rs
@@ -1,0 +1,127 @@
+//! A transport that hands each Trust Task straight back to the caller.
+//!
+//! ## What this is for
+//!
+//! Every other transport needs something on the far end — a running VTA, a
+//! mediator, a websocket. That cost is why the SDK's *producer* side went
+//! untested: the only way to see the bytes a client method emits was to stand
+//! up the whole stack, so nothing did, and payload defects were found in
+//! production instead. `keys/create` sent `"mnemonic": null` on every call for
+//! a month (#919); `vta/webvh/dids/update` did the same before it (#895).
+//!
+//! A loopback transport removes the far end. The client method runs its real
+//! body-building code, `dispatch_trust_task` wraps the real envelope, and the
+//! bytes arrive at a [`LoopbackSink`] the test controls. What the test does
+//! with them — validate against the published schema, feed a real dispatcher,
+//! assert on a member — is its business.
+//!
+//! This is deliberately *not* a mock of the VTA. It asserts nothing and
+//! implements no behaviour; it is a tap on the wire.
+//!
+//! ## What it does not cover
+//!
+//! Framing. TSP sealing, DIDComm authcrypt, mediator routing and the
+//! addressing in [`VtaClient::address_trust_task`] all sit below this point,
+//! so a defect in any of them is invisible here. Those need a transport
+//! harness with a real mediator. What this does cover is the layer where the
+//! two shipped defects actually lived: the payload a client method builds.
+
+use std::sync::Arc;
+
+use serde_json::Value;
+
+use crate::error::VtaError;
+
+/// The far end of a [`Transport::Loopback`](super::Transport) client.
+///
+/// Called once per dispatched Trust Task, with the task's type URI and the
+/// payload the client method built. The returned value is handed back to the
+/// client method as the task's response payload — return whatever shape that
+/// method expects, or an error to exercise its failure path.
+///
+/// A test that only cares about requests may return `Value::Null` and ignore
+/// every client method's return value; the payload has already been captured
+/// by then.
+pub trait LoopbackSink: Send + Sync {
+    /// Receive one dispatched task. `payload` is the exact value that would
+    /// have gone on the wire.
+    fn dispatch(&self, type_uri: &str, payload: &Value) -> Result<Value, VtaError>;
+}
+
+/// A [`LoopbackSink`] that records every task and answers with a fixed value.
+///
+/// The common case: drive the producers, then inspect what they emitted.
+#[derive(Default)]
+pub struct RecordingSink {
+    seen: std::sync::Mutex<Vec<(String, Value)>>,
+    reply: Option<Value>,
+}
+
+impl RecordingSink {
+    /// A sink that answers every task with `Value::Null`.
+    ///
+    /// Most client methods will fail to deserialize that into their response
+    /// type and return `Err` — which is fine and expected. The request was
+    /// captured before the response was parsed, so a test that is asking "what
+    /// did we send?" can discard the return value entirely.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// A sink that answers every task with `reply`.
+    #[must_use]
+    pub fn replying_with(reply: Value) -> Self {
+        Self {
+            seen: std::sync::Mutex::new(Vec::new()),
+            reply: Some(reply),
+        }
+    }
+
+    /// Every `(type_uri, payload)` dispatched so far, in order.
+    #[must_use]
+    pub fn recorded(&self) -> Vec<(String, Value)> {
+        self.seen
+            .lock()
+            .expect("sink mutex is not poisoned")
+            .clone()
+    }
+}
+
+impl LoopbackSink for RecordingSink {
+    fn dispatch(&self, type_uri: &str, payload: &Value) -> Result<Value, VtaError> {
+        self.seen
+            .lock()
+            .expect("sink mutex is not poisoned")
+            .push((type_uri.to_string(), payload.clone()));
+        Ok(self.reply.clone().unwrap_or(Value::Null))
+    }
+}
+
+impl super::VtaClient {
+    /// A client whose Trust-Task surface is answered in-process by `sink`.
+    ///
+    /// The sink is consulted *ahead of* the transport, so only the Trust-Task
+    /// surface is intercepted. The REST routes and the DIDComm
+    /// protocol-message surface ([`rpc`](super::VtaClient::rpc)) fall through
+    /// to the transport underneath, which is a REST client pointed at an
+    /// unroutable address — reaching one from a loopback client is a test bug,
+    /// and it should fail rather than quietly succeed against something real.
+    #[must_use]
+    pub fn loopback(sink: Arc<dyn LoopbackSink>) -> Self {
+        Self {
+            transport: super::Transport::Rest {
+                client: crate::http::rest_client(),
+                base_url: "http://loopback.invalid".to_string(),
+                auth: Arc::new(tokio::sync::Mutex::new(super::RestAuth {
+                    token: None,
+                    expires_at: None,
+                    refresh_token: None,
+                    refresh_expires_at: None,
+                    credential: None,
+                })),
+            },
+            loopback: Some(sink),
+        }
+    }
+}

--- a/vta-sdk/src/client/mod.rs
+++ b/vta-sdk/src/client/mod.rs
@@ -167,6 +167,17 @@ impl std::fmt::Display for SurfaceTransport {
 #[derive(Clone)]
 pub struct VtaClient {
     pub(super) transport: Transport,
+    /// Test-only interception, ahead of the transport — see [`loopback`].
+    ///
+    /// A hook rather than a `Transport` variant on purpose. A variant would
+    /// have to be answered at every one of the ~20 sites that match on
+    /// `Transport`, almost all of which would say "unsupported", so 20 arms
+    /// of noise would be carried in production code to serve a test seam.
+    /// Intercepting ahead of the match touches only the three functions that
+    /// dispatch a Trust Task, and leaves every transport match exhaustive over
+    /// the transports that really exist.
+    #[cfg(feature = "test-loopback")]
+    pub(super) loopback: Option<std::sync::Arc<dyn loopback::LoopbackSink>>,
 }
 
 // ── Protocol response aliases ──────────────────────────────────────
@@ -214,6 +225,13 @@ mod contexts;
 mod credentials;
 mod did_templates;
 mod keys;
+// Consumed from `vta-service`'s dev-dependency, which enables the feature the
+// ordinary way. `cargo -p vta-sdk --features test-loopback` does *not* rebuild
+// this crate — the workspace patches `vta-sdk` onto itself, so the `-p` node
+// and the built node differ and cargo reports the unit Fresh — which is why the
+// census lives downstream rather than in this crate's own tests.
+#[cfg(feature = "test-loopback")]
+pub mod loopback;
 mod memory;
 mod policy;
 mod secrets;
@@ -331,6 +349,8 @@ impl VtaClient {
     /// Create a new REST-only client.
     pub fn new(base_url: &str) -> Self {
         Self {
+            #[cfg(feature = "test-loopback")]
+            loopback: None,
             transport: Transport::Rest {
                 client: crate::http::rest_client(),
                 base_url: base_url.trim_end_matches('/').to_string(),
@@ -362,6 +382,8 @@ impl VtaClient {
             .to_string();
 
         Ok(Self {
+            #[cfg(feature = "test-loopback")]
+            loopback: None,
             transport: Transport::Rest {
                 client: http,
                 base_url,
@@ -443,6 +465,8 @@ impl VtaClient {
     ) -> Self {
         let rest_client = rest_url.as_ref().map(|_| crate::http::rest_client());
         Self {
+            #[cfg(feature = "test-loopback")]
+            loopback: None,
             transport: Transport::DIDComm {
                 session,
                 rest_client,
@@ -679,6 +703,8 @@ impl VtaClient {
     ) -> Self {
         let rest_client = rest_url.as_ref().map(|_| crate::http::rest_client());
         Self {
+            #[cfg(feature = "test-loopback")]
+            loopback: None,
             transport: Transport::Tsp {
                 session: std::sync::Arc::new(session),
                 vta_did: vta_did.to_string(),
@@ -1303,6 +1329,17 @@ impl VtaClient {
         timeout: u64,
         build_rest: impl FnOnce(&Client, &str) -> RequestBuilder,
     ) -> Result<T, VtaError> {
+        // Ahead of the transport, and of the REST fork in particular: on a REST
+        // transport this method takes `build_rest` and never builds a Trust
+        // Task at all, so a loopback client that fell through to the match
+        // would observe nothing. See `client::loopback`.
+        #[cfg(feature = "test-loopback")]
+        if let Some(sink) = &self.loopback {
+            let response = sink.dispatch(tt_uri, &payload)?;
+            return serde_json::from_value(response)
+                .map_err(|e| VtaError::Protocol(format!("loopback response decode: {e}")));
+        }
+
         match &self.transport {
             Transport::Rest {
                 client,
@@ -1341,6 +1378,13 @@ impl VtaClient {
         timeout: u64,
         build_rest: impl FnOnce(&Client, &str) -> RequestBuilder,
     ) -> Result<(), VtaError> {
+        // As in `rpc_tt` — see `client::loopback`.
+        #[cfg(feature = "test-loopback")]
+        if let Some(sink) = &self.loopback {
+            sink.dispatch(tt_uri, &payload)?;
+            return Ok(());
+        }
+
         match &self.transport {
             Transport::Rest {
                 client,
@@ -1389,6 +1433,13 @@ impl VtaClient {
         payload: serde_json::Value,
         timeout: u64,
     ) -> Result<serde_json::Value, VtaError> {
+        // Ahead of the transport: a loopback client answers the Trust-Task
+        // surface in-process. See `client::loopback`.
+        #[cfg(feature = "test-loopback")]
+        if let Some(sink) = &self.loopback {
+            return sink.dispatch(type_uri, &payload);
+        }
+
         let doc = serde_json::json!({
             "id": format!("urn:uuid:{}", uuid::Uuid::new_v4()),
             "type": type_uri,

--- a/vta-sdk/src/protocols/acl_management/create.rs
+++ b/vta-sdk/src/protocols/acl_management/create.rs
@@ -46,6 +46,7 @@ pub struct CreateAclResponseBody {
 pub struct CreateAclResultBody {
     pub did: String,
     pub role: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub label: Option<String>,
     pub allowed_contexts: Vec<String>,
     pub created_at: u64,

--- a/vta-sdk/src/protocols/backup_management/types.rs
+++ b/vta-sdk/src/protocols/backup_management/types.rs
@@ -207,6 +207,7 @@ pub struct SeedRecordBackup {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub seed_enc: Option<Vec<u8>>,
     pub created_at: DateTime<Utc>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub retired_at: Option<DateTime<Utc>>,
 }
 
@@ -228,6 +229,7 @@ impl std::fmt::Debug for SeedRecordBackup {
 pub struct AclEntryBackup {
     pub did: String,
     pub role: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub label: Option<String>,
     #[serde(default)]
     pub allowed_contexts: Vec<String>,

--- a/vta-sdk/src/protocols/context_management/create.rs
+++ b/vta-sdk/src/protocols/context_management/create.rs
@@ -20,7 +20,9 @@ pub struct CreateContextBody {
 pub struct CreateContextResultBody {
     pub id: String,
     pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub did: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     /// Parent context id, or `None` for a top-level context.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/vta-sdk/src/protocols/key_management/create.rs
+++ b/vta-sdk/src/protocols/key_management/create.rs
@@ -52,6 +52,7 @@ pub struct CreateKeyResultBody {
     #[serde(alias = "public_key")]
     pub public_key: String,
     pub status: KeyStatus,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub label: Option<String>,
     #[serde(default = "default_derived")]
     pub origin: KeyOrigin,

--- a/vta-sdk/tests/payload_null_census.rs
+++ b/vta-sdk/tests/payload_null_census.rs
@@ -1,0 +1,302 @@
+//! Census: no wire member under `protocols/` may serialize as `null`.
+//!
+//! ## The invariant
+//!
+//! An unset optional member must be **absent** from the serialized payload,
+//! never `null`. Trust Task schemas type each optional member by what it holds
+//! — `"string"`, `"object"`, `"integer"` — and none of them accepts null, so a
+//! `None` that serializes as `null` is refused on arrival by the recipient's
+//! `validate_payload`:
+//!
+//! ```text
+//! payload does not conform to https://trusttasks.org/spec/keys/create/0.1:
+//! payload failed schema validation: null is not of type "string"
+//! ```
+//!
+//! ## Why a census rather than another fixture
+//!
+//! This defect has now shipped twice, on unrelated tasks, roughly a month
+//! apart:
+//!
+//! - #895 — `vta/webvh/dids/update/1.0`. Every *partial* update was rejected,
+//!   once per unset member. `pnm did-mgmt dids edit --label x` could not run at
+//!   all, and supplying more flags did not help: each one removed a single null
+//!   and left the rest.
+//! - #919 — `keys/create/0.1`. Every call that did not carry a BIP-39 phrase
+//!   sent `"mnemonic": null`, so nothing downstream could mint a key over
+//!   DIDComm or TSP. An OpenVTC community join died on its first round-trip.
+//!
+//! Both were found in production, by a person, from a rejected request. Both
+//! were one missing attribute. The second was introduced by a refactor that
+//! moved a call off a hand-rolled map — which skipped its `None`s — onto a
+//! struct that did not, which is a shape any future fold can reproduce.
+//!
+//! Per-task fixtures cannot close this: they prove the members a fixture
+//! happens to set, and this bug lives in the members it happens to leave unset.
+//! The invariant is a property of the *source*, so it is checked against the
+//! source, once, for every wire type at the same time.
+//!
+//! ## Scope
+//!
+//! Every `Option<T>` field of every `Serialize`-deriving struct under
+//! `vta-sdk/src/protocols/` — the crate's wire types. Genuine exceptions go in
+//! [`NULLABLE_BY_DESIGN`] with a reason; there is no way to pass by silence.
+//!
+//! Parsed with `syn`, not grepped. The attribute is routinely written across
+//! several lines, and a line-oriented regex misreads that in exactly the
+//! direction that lets a violation through.
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use syn::{Fields, Item, ItemStruct, Meta, Type};
+
+/// Members that are legitimately nullable, each with the reason.
+///
+/// An entry here is a claim that `null` is the *correct* wire form for this
+/// member — not that the fix is inconvenient. Adding one without a spec that
+/// admits null re-opens the defect this file exists to prevent.
+const NULLABLE_BY_DESIGN: &[(&str, &str, &str)] = &[(
+    "GetKeyResponseBody",
+    "key",
+    "`keys/show/0.1#response` types this `oneOf: [KeyRecord, null]` and \
+         requires it present. Null is the answer meaning \"the custodian holds \
+         no key for this identifier\" — a successful answer, not an error, and \
+         a caller that cannot tell absence from failure retries a lookup that \
+         will never succeed. Omitting the member would violate `required`.",
+)];
+
+/// One `Option` member that would reach the wire as `null`.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct Violation {
+    file: String,
+    strukt: String,
+    field: String,
+}
+
+fn protocols_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("src")
+        .join("protocols")
+}
+
+fn rust_sources(dir: &Path, out: &mut Vec<PathBuf>) {
+    for entry in fs::read_dir(dir).expect("protocols/ is readable") {
+        let path = entry.expect("readable dir entry").path();
+        if path.is_dir() {
+            rust_sources(&path, out);
+        } else if path.extension().is_some_and(|e| e == "rs") {
+            out.push(path);
+        }
+    }
+}
+
+/// Does this attribute list derive `Serialize`?
+///
+/// A `Deserialize`-only type never reaches the wire from here, so
+/// `skip_serializing_if` on it would be inert.
+fn derives_serialize(attrs: &[syn::Attribute]) -> bool {
+    attrs.iter().any(|attr| {
+        attr.path().is_ident("derive")
+            && matches!(&attr.meta, Meta::List(l) if l.tokens.to_string().contains("Serialize"))
+    })
+}
+
+fn skips_none(attrs: &[syn::Attribute]) -> bool {
+    attrs.iter().any(|attr| {
+        attr.path().is_ident("serde")
+            && matches!(&attr.meta, Meta::List(l) if l.tokens.to_string().contains("skip_serializing_if"))
+    })
+}
+
+fn is_option(ty: &Type) -> bool {
+    let Type::Path(p) = ty else { return false };
+    p.path
+        .segments
+        .last()
+        .is_some_and(|seg| seg.ident == "Option")
+}
+
+/// `#[cfg(test)]` items are not wire types.
+fn is_cfg_test(attrs: &[syn::Attribute]) -> bool {
+    attrs.iter().any(|attr| {
+        attr.path().is_ident("cfg")
+            && matches!(&attr.meta, Meta::List(l) if l.tokens.to_string().contains("test"))
+    })
+}
+
+fn inspect_struct(s: &ItemStruct, file: &str, inspected: &mut usize, out: &mut Vec<Violation>) {
+    if !derives_serialize(&s.attrs) {
+        return;
+    }
+    let Fields::Named(fields) = &s.fields else {
+        return;
+    };
+
+    for field in &fields.named {
+        if !is_option(&field.ty) {
+            continue;
+        }
+        *inspected += 1;
+
+        let name = field
+            .ident
+            .as_ref()
+            .expect("named field has an ident")
+            .to_string();
+
+        if skips_none(&field.attrs) {
+            continue;
+        }
+        if NULLABLE_BY_DESIGN
+            .iter()
+            .any(|(st, f, _)| s.ident == st && *f == name)
+        {
+            continue;
+        }
+
+        out.push(Violation {
+            file: file.to_string(),
+            strukt: s.ident.to_string(),
+            field: name,
+        });
+    }
+}
+
+fn walk_items(items: &[Item], file: &str, inspected: &mut usize, out: &mut Vec<Violation>) {
+    for item in items {
+        match item {
+            Item::Struct(s) if !is_cfg_test(&s.attrs) => inspect_struct(s, file, inspected, out),
+            Item::Mod(m) if !is_cfg_test(&m.attrs) => {
+                if let Some((_, inner)) = &m.content {
+                    walk_items(inner, file, inspected, out);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+#[test]
+fn no_wire_member_serializes_as_null() {
+    let root = protocols_dir();
+    let mut files = Vec::new();
+    rust_sources(&root, &mut files);
+    files.sort();
+
+    assert!(
+        files.len() > 10,
+        "found only {} source files under {} — the walk is broken, and a \
+         census that inspects nothing passes vacuously",
+        files.len(),
+        root.display()
+    );
+
+    let mut inspected = 0usize;
+    let mut violations = Vec::new();
+
+    for path in &files {
+        let src = fs::read_to_string(path).expect("source file is readable");
+        let parsed = syn::parse_file(&src)
+            .unwrap_or_else(|e| panic!("{}: does not parse: {e}", path.display()));
+        let rel = path
+            .strip_prefix(&root)
+            .unwrap_or(path)
+            .display()
+            .to_string();
+        walk_items(&parsed.items, &rel, &mut inspected, &mut violations);
+    }
+
+    // Teeth. A parser that silently matches nothing — a `syn` upgrade changing
+    // how `Meta::List` renders, a refactor moving the wire types elsewhere —
+    // would otherwise report a clean census over an empty set.
+    assert!(
+        inspected > 100,
+        "the census inspected only {inspected} Option members across {} files. \
+         There are well over a hundred; this means the parser stopped \
+         recognising them, not that they went away.",
+        files.len()
+    );
+
+    violations.sort();
+    assert!(
+        violations.is_empty(),
+        "these wire members serialize as `null` when unset, and every Trust \
+         Task schema that types them rejects null:\n\n{}\n\n\
+         Add `#[serde(default, skip_serializing_if = \"Option::is_none\")]` so \
+         an unset member is absent from the payload. If `null` really is the \
+         correct wire form — the spec must say so, as `keys/show`'s `key` does \
+         — add it to NULLABLE_BY_DESIGN with that reason.\n\n\
+         This has shipped twice as a production outage (#895, #919). It is one \
+         attribute.",
+        violations
+            .iter()
+            .map(|v| format!("  {}: {}::{}", v.file, v.strukt, v.field))
+            .collect::<Vec<_>>()
+            .join("\n")
+    );
+}
+
+/// Every allowlist entry names a member that still exists and still lacks the
+/// skip — so a stale exemption cannot outlive the thing it exempts.
+///
+/// The other direction of the same coverage assertion the conformance sweep
+/// makes: an exemption for a member that has since been fixed or deleted reads
+/// as "null is fine here" to the next person, and nothing would ever say
+/// otherwise.
+#[test]
+fn every_allowlist_entry_is_still_live() {
+    let root = protocols_dir();
+    let mut files = Vec::new();
+    rust_sources(&root, &mut files);
+
+    let mut unskipped_options: BTreeSet<(String, String)> = BTreeSet::new();
+    for path in &files {
+        let src = fs::read_to_string(path).expect("source file is readable");
+        let parsed = syn::parse_file(&src).expect("source parses");
+        collect_unskipped(&parsed.items, &mut unskipped_options);
+    }
+
+    for (strukt, field, reason) in NULLABLE_BY_DESIGN {
+        assert!(
+            !reason.trim().is_empty(),
+            "{strukt}::{field}: an exemption must state why null is correct"
+        );
+        assert!(
+            unskipped_options.contains(&(strukt.to_string(), field.to_string())),
+            "NULLABLE_BY_DESIGN exempts {strukt}::{field}, but no such \
+             unskipped Option member exists any more — it was renamed, \
+             removed, or given the skip. Drop the entry."
+        );
+    }
+}
+
+fn collect_unskipped(items: &[Item], out: &mut BTreeSet<(String, String)>) {
+    for item in items {
+        match item {
+            Item::Struct(s) if !is_cfg_test(&s.attrs) && derives_serialize(&s.attrs) => {
+                if let Fields::Named(fields) = &s.fields {
+                    for field in &fields.named {
+                        if is_option(&field.ty) && !skips_none(&field.attrs) {
+                            out.insert((
+                                s.ident.to_string(),
+                                field
+                                    .ident
+                                    .as_ref()
+                                    .expect("named field has an ident")
+                                    .to_string(),
+                            ));
+                        }
+                    }
+                }
+            }
+            Item::Mod(m) if !is_cfg_test(&m.attrs) => {
+                if let Some((_, inner)) = &m.content {
+                    collect_unskipped(inner, out);
+                }
+            }
+            _ => {}
+        }
+    }
+}

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.14.25"
+version = "0.14.26"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -307,7 +307,17 @@ vta-service = { path = ".", features = ["test-support"] }
 # `provision_admin_rotated_via_rest` + DI-signed REST auth) the `MockVta`
 # bootstrap→provision e2e tests drive (issues #406, DI-auth follow-up). Kept out
 # of the production `vta-sdk` dep above so the server build stays lean.
-vta-sdk = { path = "../vta-sdk", version = "0.21", features = ["provision-client"] }
+# `test-loopback` adds the in-process Trust-Task transport the producer census
+# (`tests/producer_payload_conformance.rs`) drives: it runs every SDK client
+# method's real body-building code and checks the payload against the published
+# schema, with no VTA, mediator or socket involved. It has to be enabled from
+# here rather than from `vta-sdk`'s own tests — the workspace patches `vta-sdk`
+# onto itself, so `-p vta-sdk --features test-loopback` leaves the built unit
+# Fresh and the feature never reaches the compiler.
+vta-sdk = { path = "../vta-sdk", version = "0.21", features = [
+  "provision-client",
+  "test-loopback",
+] }
 # Mock HTTP server for the did-hosting-daemon REST auth flow tests. Each
 # test spins up a real local server bound to a random port, validates
 # the JWS-signed request bodies the daemon would see, and serves

--- a/vta-service/tests/producer_payload_conformance.rs
+++ b/vta-service/tests/producer_payload_conformance.rs
@@ -1,0 +1,347 @@
+//! Producer census: what a client method *sends*, with nothing optional set.
+//!
+//! ## The gap this fills
+//!
+//! The conformance sweep in `vta-service::trust_tasks::conformance` checks a
+//! *witness* — a value written in the test — against each task's schema. It
+//! proves the shape is right. It cannot prove that any client method builds
+//! that shape, because no client method runs during it.
+//!
+//! That is where both shipped payload defects lived:
+//!
+//! - #895 — `vta/webvh/dids/update/1.0` sent `null` for every unset member.
+//! - #919 — `keys/create/0.1` sent `"mnemonic": null` on every call that was
+//!   not importing a BIP-39 phrase, which is every call OpenVTC makes. The
+//!   sweep's witness for that task was built from the real `CreateKeyBody`,
+//!   with `mnemonic: None`, and it still passed: the sweep parsed the witness
+//!   into the generated type, and serde reads `null` into an `Option<String>`
+//!   without complaint.
+//!
+//! Both were found by a person, from a rejected request, in production.
+//!
+//! ## What runs here
+//!
+//! Each client method below is called for real, through
+//! [`VtaClient::loopback`], with **every optional argument unset** — the shape
+//! that broke `keys/create`, and the shape a caller reaches for first. The
+//! payload it builds is captured and validated against the URI's published
+//! schema, which is the same check the recipient's dispatch spine runs.
+//!
+//! No VTA, no mediator, no socket: the loopback transport answers in-process,
+//! so this is a unit test in cost and an integration test in what it covers.
+//!
+//! ## Why these methods
+//!
+//! The 19 methods here are every Trust-Task client method that takes an
+//! optional argument *and builds its payload by hand* — `json!` plus a
+//! conditional insert per member. They are the surface the `vta-sdk` null
+//! census (`tests/payload_null_census.rs`) cannot see, because there is no
+//! struct to inspect: the invariant lives in the shape of an `if let`, not in
+//! an attribute.
+//!
+//! Methods that take a typed body instead (`create_key(CreateKeyRequest)` and
+//! friends) are covered by that census at the source, and by the sweep on the
+//! wire.
+//!
+//! ## What this does not cover
+//!
+//! Framing — TSP sealing, DIDComm authcrypt, mediator routing. Those sit below
+//! the loopback point and need a transport harness with a real mediator.
+
+use std::sync::Arc;
+
+use serde_json::{Value, json};
+use vta_sdk::client::VtaClient;
+use vta_sdk::client::loopback::RecordingSink;
+
+/// Drive `f` against a loopback client and return everything it dispatched.
+async fn captured<F, Fut>(f: F) -> Vec<(String, Value)>
+where
+    F: FnOnce(VtaClient) -> Fut,
+    Fut: std::future::Future<Output = ()>,
+{
+    let sink = Arc::new(RecordingSink::new());
+    let client = VtaClient::loopback(sink.clone());
+    f(client).await;
+    sink.recorded()
+}
+
+/// Tasks this census drives that have no published payload schema.
+///
+/// Not a pass and not a waiver — a list of the places where nothing can check
+/// us. A task here is dispatched by a client method, reaches a real VTA, and no
+/// schema exists on either side to say whether the payload is right. The only
+/// remedy is publishing the spec; until then this is where the gap is visible.
+///
+/// Kept exact in both directions by
+/// [`every_unpublished_entry_is_still_unpublished`], so an entry cannot outlive
+/// the gap it records.
+///
+/// Every entry is a legacy `vta/`-namespaced task that the canonical folds have
+/// not reached, and that is the useful signal: the unvalidatable surface is
+/// exactly the un-folded surface, so each of these closes for free when its
+/// family is folded onto a published spec.
+const UNPUBLISHED: &[(&str, &str)] = &[
+    (
+        "https://trusttasks.org/spec/vta/seeds/rotate/1.0",
+        "The canonical `keys/*` fold (#888) did not reach the seed family.",
+    ),
+    (
+        "https://trusttasks.org/spec/vta/webvh/dids/register-with-server/1.0",
+        "The webvh fold reached `dids/update` (#885) but not registration.",
+    ),
+    (
+        "https://trusttasks.org/spec/vta/webvh/dids/list/1.0",
+        "As `register-with-server` — same family, same unfolded half.",
+    ),
+    (
+        "https://trusttasks.org/spec/vault/credentials/receive/0.1",
+        "The `vault/*` fold published query/get/upsert/delete but not \
+         `credentials/receive`.",
+    ),
+];
+
+/// Every captured payload conforms to its task's published schema.
+///
+/// `None` for a URI is only tolerated when [`UNPUBLISHED`] records it — a task
+/// that quietly lost its schema would otherwise turn this census green by
+/// having nothing left to check.
+fn assert_conforms(captured: &[(String, Value)]) {
+    assert!(
+        !captured.is_empty(),
+        "the client method dispatched nothing — it failed before reaching the \
+         transport, so this row proves nothing"
+    );
+
+    for (uri, payload) in captured {
+        let Some(schema) = trust_tasks_rs::schema_index::schema_for(uri) else {
+            assert!(
+                UNPUBLISHED.iter().any(|(u, _)| u == uri),
+                "no published payload schema for `{uri}`, and it is not \
+                 recorded in UNPUBLISHED. Either the task was renamed / the \
+                 registry moved — in which case fix the constant — or this is \
+                 a new unvalidatable task, in which case record it there with \
+                 the reason. A missing schema is a coverage hole, not a pass."
+            );
+            continue;
+        };
+        trust_tasks_rs::validate::against_schema(schema, payload).unwrap_or_else(|e| {
+            panic!(
+                "{uri}: the payload this client method builds does not conform \
+                 to its own schema: {e}\n\n{payload:#}\n\n\
+                 An unset optional member must be ABSENT, not `null` — build \
+                 the payload with a conditional insert, or with a body struct \
+                 whose members carry `skip_serializing_if`."
+            )
+        });
+    }
+}
+
+/// The census, one row per client method, every optional argument `None`.
+///
+/// Each row's `Err` is discarded on purpose: the loopback sink answers with
+/// `null`, so most methods fail to deserialize their response. The request has
+/// already been captured by then, and the request is what is under test.
+#[tokio::test]
+async fn every_optional_argument_unset_still_builds_a_conforming_payload() {
+    // ── keys ─────────────────────────────────────────────────────────
+    assert_conforms(&captured(|c| async move { drop(c.list_keys(0, 50, None, None).await) }).await);
+    assert_conforms(
+        &captured(|c| async move {
+            drop(
+                c.derive_and_sign_document(
+                    vta_sdk::keys::KeyType::Ed25519,
+                    "m/26'/9'/0'",
+                    json!({"hello": "world"}),
+                    None,
+                )
+                .await,
+            )
+        })
+        .await,
+    );
+    assert_conforms(&captured(|c| async move { drop(c.rotate_seed(None).await) }).await);
+
+    // ── acl ──────────────────────────────────────────────────────────
+    assert_conforms(
+        &captured(|c| async move {
+            drop(
+                c.list_acl_in_direction(None, vta_sdk::acl::ContextDirection::Subtree)
+                    .await,
+            )
+        })
+        .await,
+    );
+
+    // ── credentials ──────────────────────────────────────────────────
+    assert_conforms(
+        &captured(|c| async move {
+            drop(
+                c.issue_credential("did:key:z6MkHolder", json!({"a": 1}), None, 3600, None)
+                    .await,
+            )
+        })
+        .await,
+    );
+    assert_conforms(
+        &captured(|c| async move { drop(c.revoke_credential("urn:uuid:cred-1", None).await) })
+            .await,
+    );
+
+    // ── webvh ────────────────────────────────────────────────────────
+    assert_conforms(
+        &captured(|c| async move {
+            drop(
+                c.register_did_with_server("did:webvh:scid:vta.example", "server-1", false, None)
+                    .await,
+            )
+        })
+        .await,
+    );
+    assert_conforms(&captured(|c| async move { drop(c.list_dids_webvh(None, None).await) }).await);
+
+    // ── consent ──────────────────────────────────────────────────────
+    // `ConsentSubject` is `additionalProperties: false` with four required
+    // members, and `challenge` carries `minLength: 16` — the census validates
+    // against the real schema, so its fixtures have to satisfy the real
+    // constraints, not just look plausible.
+    let subject = json!({
+        "platform": "signal",
+        "conversationRef": "sig-1a2b3c4d",
+        "kind": "dm",
+        "agent": "did:key:z6MkAgent",
+    });
+    const CHALLENGE: &str = "Y2hhbGxlbmdlLW5vbmNlLTEyOA";
+    let s = subject.clone();
+    assert_conforms(
+        &captured(|c| async move {
+            drop(
+                c.consent_request(s, "converse", CHALLENGE, None, None)
+                    .await,
+            )
+        })
+        .await,
+    );
+    let s = subject.clone();
+    assert_conforms(
+        &captured(|c| async move { drop(c.consent_decision(s, "allow", None, None, None).await) })
+            .await,
+    );
+    let s = subject.clone();
+    assert_conforms(&captured(|c| async move { drop(c.consent_revoke(s, None).await) }).await);
+    assert_conforms(
+        &captured(|c| async move { drop(c.consent_list(None, None, None).await) }).await,
+    );
+    assert_conforms(
+        &captured(|c| async move {
+            drop(
+                c.consent_approver_set("cli", "ctx", "did:key:z6MkApprover", None, None)
+                    .await,
+            )
+        })
+        .await,
+    );
+    assert_conforms(
+        &captured(|c| async move { drop(c.consent_approver_list(None, None).await) }).await,
+    );
+
+    // ── devices ──────────────────────────────────────────────────────
+    assert_conforms(
+        &captured(|c| async move {
+            // `ConsumerKind` is a tagged `oneOf`, not a bare string.
+            drop(
+                c.device_register(
+                    json!({"kind": "companion", "formFactor": "desktop"}),
+                    "laptop",
+                    None,
+                    None,
+                )
+                .await,
+            )
+        })
+        .await,
+    );
+    assert_conforms(&captured(|c| async move { drop(c.device_heartbeat(None).await) }).await);
+
+    // ── vault ────────────────────────────────────────────────────────
+    // `vault_upsert` takes the whole payload from its caller, so the SDK
+    // contributes only `sealedSecret`. The row still earns its place: it pins
+    // that an absent `sealed_secret` inserts no member at all.
+    assert_conforms(
+        &captured(|c| async move {
+            drop(
+                c.vault_upsert(
+                    json!({
+                        "id": "secret-1",
+                        "contextId": "openvtc",
+                        // `SiteTarget` is a `kind`-tagged union, not a bare URL.
+                        "targets": [{"kind": "web-origin", "origin": "https://example.test"}],
+                        "label": "example login",
+                        "secretKind": "password",
+                    }),
+                    None,
+                )
+                .await,
+            )
+        })
+        .await,
+    );
+    assert_conforms(
+        &captured(|c| async move { drop(c.vault_delete("secret-1", None, false, None).await) })
+            .await,
+    );
+    assert_conforms(
+        &captured(|c| async move {
+            drop(
+                c.cred_vault_receive(json!({"id": "urn:uuid:vc-1"}), None)
+                    .await,
+            )
+        })
+        .await,
+    );
+}
+
+/// An [`UNPUBLISHED`] entry names a task that really has no schema *today*.
+///
+/// The stale direction: once a spec is published, the entry must go, or the
+/// census would keep skipping a task it could now check — the same
+/// both-directions discipline the conformance sweep's coverage assertion uses.
+#[test]
+fn every_unpublished_entry_is_still_unpublished() {
+    for (uri, reason) in UNPUBLISHED {
+        assert!(
+            !reason.trim().is_empty(),
+            "{uri}: an UNPUBLISHED entry must state why no schema exists"
+        );
+        assert!(
+            trust_tasks_rs::schema_index::schema_for(uri).is_none(),
+            "`{uri}` now HAS a published payload schema, so the census can \
+             validate it. Remove the UNPUBLISHED entry — leaving it there \
+             silently skips a task that is now checkable."
+        );
+    }
+}
+
+/// The loopback seam itself reports what was sent, not what was asked for.
+///
+/// Teeth for the census: if the sink recorded the *arguments* rather than the
+/// serialized payload, every row above would pass regardless of what went on
+/// the wire. This pins that a `None` argument reaches the payload as an absent
+/// member, and a `Some` reaches it as a present one.
+#[tokio::test]
+async fn the_sink_observes_the_serialized_payload() {
+    let unset = captured(|c| async move { drop(c.device_heartbeat(None).await) }).await;
+    let (_, payload) = &unset[0];
+    assert!(
+        payload.get("platform").is_none(),
+        "an unset optional must be absent from the payload, got: {payload:#}"
+    );
+
+    let set = captured(|c| async move { drop(c.device_heartbeat(Some("macos")).await) }).await;
+    let (_, payload) = &set[0];
+    assert_eq!(
+        payload.get("platform").and_then(Value::as_str),
+        Some("macos"),
+        "a set optional must reach the payload: {payload:#}"
+    );
+}


### PR DESCRIPTION
Stacked on #919 — review that first; this PR's diff is the second commit.

#919 fixed `keys/create` sending `"mnemonic": null`. It did not answer the question the fix raised: **how many more are there, and what would have caught this?** Both defects of this shape (#895, #919) were found in production, by a person, from a rejected request. This adds the two checks that find them without one.

## A source census — `vta-sdk/tests/payload_null_census.rs`

Every `Option` member of every `Serialize` struct under `protocols/` must skip `None`, because every Trust Task schema types its optional members by what they hold and none accepts null. Exceptions go in `NULLABLE_BY_DESIGN` with a reason, checked in both directions so one cannot outlive the member it exempts.

Parsed with `syn`, not grepped — the attribute is routinely written across several lines, which a line-oriented regex misreads in exactly the direction that lets a violation through.

**Five latent violations on its first run**, all fixed here:

| Member | |
|---|---|
| `CreateAclResultBody::label` | also `SwapKeyResponseBody`, `UpdateAclResultBody`, `ChangeRoleResultBody` |
| `CreateContextResultBody::{did,description}` | |
| `CreateKeyResultBody::label` | the response half of the task #919 fixed |
| `SeedRecordBackup::retired_at` | its sibling `seed_enc` already skipped |
| `AclEntryBackup::label` | |

Each sits in a struct whose *sibling* members already skip — oversights, not decisions. Only `GetKeyResponseBody::key` is exempt, and that one is spec-mandated: `keys/show/0.1#response` types it `oneOf: [KeyRecord, null]` and requires it present, because "no such key" is a successful answer.

## A producer census — `vta-service/tests/producer_payload_conformance.rs`

The source census cannot see a payload built by hand, and the conformance sweep (#857) cannot see one at all — it checks a witness written in the test, and no client method runs during it.

So this drives the client methods themselves, through a new in-process transport (`vta_sdk::client::loopback`, behind `test-loopback`), with **every optional argument unset** — the shape that broke `keys/create` — and validates what they emit against the published schema. No VTA, no mediator, no socket: a unit test in cost, an integration test in what it covers.

**It found a live defect immediately.** `derive_and_sign_document` sent `"proofPurpose": null` on every call that did not name a purpose — and omitting the purpose is what selects the documented `assertionMethod` default, so *the documented way to call it was the way that could not work*.

#919 had already added `skip_serializing_if` to `DeriveAndSignDocumentBody`. The method never touched it, building a `json!` map instead. That is the gap between the two censuses in one example: fixing the struct does not fix a producer that does not use the struct. It now builds the canonical body, as #888 intended.

Four unvalidatable tasks are recorded in `UNPUBLISHED` with reasons. They share a pattern worth naming: every one is a legacy `vta/`-namespaced task the canonical folds have not reached, so **the unvalidatable surface is exactly the un-folded surface**, and each closes for free when its family is folded.

## On the loopback seam

It intercepts *ahead of* the transport rather than adding a `Transport` variant. A variant would have to be answered at each of the ~20 sites that match on `Transport`, almost all saying "unsupported" — twenty arms of noise in production code to serve a test seam. The hook touches the three functions that dispatch a Trust Task and leaves every transport match exhaustive over the transports that really exist.

## Not covered, deliberately

- **Framing** — TSP sealing, DIDComm authcrypt, mediator routing sit below the loopback point and still need a harness with a real mediator.
- **26 of the sweep's 70 witnesses** still transcribe their request as a `json!` fixture rather than building it from the producer. 21 of those name a client method that exists today, so the module comment calling those slices "module-private" is stale. Converting them is follow-up work.
- **Response-side validation** — `trust-tasks-rs` codegen emits `ValidatedPayload` for `Payload` but not `Response`, so there is still no embedded response schema to check against.

## Pre-merge checklist

- [x] `cargo check` passes for the entire workspace
- [x] `cargo test` passes (`vta-sdk` incl. the new census, `vta-service` lib 787, producer census 3)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets` clean on both touched crates
- [x] Both censuses verified non-vacuous — each was run against the un-fixed source and reproduced the exact production error
- [x] Changelog fragment `changelog.d/920-producer-payload-census.md`
- [x] Commits signed off (DCO)
