### PR TITLE
chore(release): vta-service 0.14.27 — 0.14.26 shipped without #921

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9446,7 +9446,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.14.26"
+version = "0.14.27"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/changelog.d/921-producer-payload-census.md
+++ b/changelog.d/921-producer-payload-census.md
@@ -1,4 +1,4 @@
-### vta-sdk 0.21.13 / vta-service 0.14.26 — check what we *send*, not what we wrote down (#921)
+### vta-sdk 0.21.13 / vta-service 0.14.27 — check what we *send*, not what we wrote down (#921)
 
 #919 fixed `keys/create` sending `"mnemonic": null`. It did not answer the
 question the fix raised: how many more are there, and what would have caught

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.14.26"
+version = "0.14.27"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true


### PR DESCRIPTION
#920 and #921 both moved `vta-service` from 0.14.25 to **0.14.26**. Because they made the *same* edit to the same line, git merged the second one without a conflict and the bump silently disappeared — #921 landed on a version #920 had already published.

The publish workflow does not fail on that. It treats an already-published version as a no-op, and [the run went green](https://github.com/OpenVTC/verifiable-trust-infrastructure/actions/runs/31459771492), so nothing said so.

**Result:** `vta-service 0.14.26` on crates.io is #920's tree, while main's 0.14.26 is #920 + #921.

The divergence is **dev-only** — a test file (`tests/producer_payload_conformance.rs`) and a dev-dependency feature; no library code differs. That is why this corrects forward cheaply rather than yanking: 0.14.27 republishes with the content main actually has, and the version-to-content invariant the release guards exist to protect holds again.

`vta-sdk` was unaffected — 0.21.13 published normally, since only #921 touched it.

Also corrects #921's changelog fragment, which still names 0.14.26.

## Worth noting

**Both release guards passed throughout.** `check-version-bumps.sh` asks whether a changed crate was bumped; `check-changelogs.sh` asks whether the bump is documented. Neither can see that the version being bumped *to* is already taken on crates.io — and two PRs in flight against the same crate is all it takes. If that is worth closing, the check is a `cargo info` / index lookup against the target version at CI time. Not done here; this PR is the correction, not the guard.

## Verification

- `cargo check -p vta-service` — clean
- Both release guards — pass (`0.14.26 -> 0.14.27`, documented)
- No source changes beyond the version string and the fragment heading
