### PR TITLE
test(trust-tasks): witness the producer, not a transcription of it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2922,7 +2922,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c54e03a951783e8b327515db3f2a2fd0e3bed362a96b066f341ce66ed49b4ead"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4587,7 +4587,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -6453,7 +6453,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.43",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "thiserror 2.0.20",
  "tokio",
  "tracing",
@@ -6492,7 +6492,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -9383,7 +9383,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.21.14"
+version = "0.21.15"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -9446,7 +9446,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.14.27"
+version = "0.14.28"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/changelog.d/924-witness-the-producer.md
+++ b/changelog.d/924-witness-the-producer.md
@@ -1,0 +1,54 @@
+### vta-sdk 0.21.15 / vta-service 0.14.28 — witness the producer, not a transcription of it (#924)
+
+The conformance sweep (#857) checks a *witness* per task — a request/response
+pair — against that task's schema. 26 of its 70 witnesses build their request
+from a hand-written `json!` literal rather than from the type the producer
+actually sends. A transcription only proves someone can type valid JSON: it
+stops tracking the producer the moment the producer changes, and stays green
+while live traffic fails.
+
+`vta/webvh/dids/update/1.0` is the worked example, and the reason to start
+there: its witness was transcribed, and #895 shipped anyway — every unset member
+went out as `null`, so `pnm did-mgmt dids edit --label x` could not run at all.
+
+**The root cause was an API boundary, not laziness.** The request shape for that
+family lives in `flatten_with_did` — body members flattened beside `did` — and
+that function was private to `vta-sdk`. From another crate the shape was
+literally unassertable except by hand-writing it. So `flatten_with_did` is now
+`pub` (re-exported as `vta_sdk::client::flatten_with_did`) and the witness is
+built by the producer's own shaping.
+
+The witness is deliberately a **one-member** update — `label` and nothing else,
+which is the invocation that could not run. A witness that set most members
+would leave almost nothing unset and so would not exercise the defect at all;
+this was caught while checking the conversion had teeth, because the first
+version of it set five members and passed happily with the fix reverted.
+Reverting a `skip_serializing_if` now reproduces #895 exactly:
+
+```text
+vta/webvh/dids/update/1.0: request fails its own payload schema:
+payload failed schema validation: null is not of type "integer"
+```
+
+**The remaining 25 are documented accurately for the first time.** The module
+claimed they were transcribed because "the slice's wire type is module-private
+(consent, task-consent, vault)". That is no longer true — 21 of the 26 name a
+`vta-sdk` client method that exists today. The honest position, now recorded per
+family:
+
+- **5** (`auth/{whoami,sessions-list,step-up/approve-response}`,
+  `task-consent/decision`) — the VTA is the consumer; no producer of ours sends
+  these, so a fixture is the correct witness and needs no further work.
+- **13** (`consent/*`, `device/*`, `messaging/ping`) — a producer exists but
+  builds its payload as an inline `json!` with a conditional insert per optional
+  member. There is no type to witness. Converting these means first giving those
+  producers canonical body structs — the #888 fold, applied to the families it
+  did not reach.
+- **7** (`vault/*`) — the SDK is a pass-through over a caller-supplied `Value`
+  and contributes at most one member. No SDK type exists, and inventing one is
+  an API change rather than a test change.
+
+So the outstanding work is one producer fold plus one API decision, not "rewrite
+26 fixtures" — which is a materially smaller and better-shaped job than the
+previous comment implied, and the reason to write it down rather than leave it
+as a count.

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.21.14"
+version = "0.21.15"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/client/mod.rs
+++ b/vta-sdk/src/client/mod.rs
@@ -238,6 +238,11 @@ mod secrets;
 mod vault;
 mod vta_management;
 mod webvh;
+/// The `vta/webvh/dids/*` request shaping — see [`webvh::flatten_with_did`].
+///
+/// Re-exported so the shape can be *built* by anything that needs to assert it,
+/// rather than hand-written a second time and left to drift.
+pub use webvh::flatten_with_did;
 
 #[cfg(feature = "client")]
 mod audit;

--- a/vta-sdk/src/client/webvh.rs
+++ b/vta-sdk/src/client/webvh.rs
@@ -492,7 +492,16 @@ impl VtaClient {
 /// programming error here, and is refused rather than silently reshaped: a
 /// dropped member on an update body is a DID-document change the operator
 /// believes they published.
-fn flatten_with_did<T: serde::Serialize>(
+/// **Public because the wire shape must be testable from outside.**
+///
+/// This function *is* the `vta/webvh/dids/*` request shape — body members
+/// flattened beside `did`. While it was private, the only way to assert that
+/// shape from another crate was to hand-write the JSON, and a hand-written
+/// fixture stops tracking the code the moment the code changes. The
+/// conformance sweep's witness for `dids/update` did exactly that, for the task
+/// that had already shipped broken once (#895). Exporting the shaping is what
+/// lets a witness be built rather than transcribed.
+pub fn flatten_with_did<T: serde::Serialize>(
     did: &str,
     body: &T,
 ) -> Result<serde_json::Value, VtaError> {

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.14.27"
+version = "0.14.28"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/trust_tasks/conformance.rs
+++ b/vta-service/src/trust_tasks/conformance.rs
@@ -159,11 +159,39 @@ fn validates<T: ValidatedPayload>(v: &Value) -> Result<(), String> {
 
 /// A representative request/response pair for one published, dispatched URI.
 ///
-/// The request is, wherever a public producer/consumer type exists, the
-/// serialization of that type — so the assertion is about **our wire form**,
-/// not about a hand-typed fixture. Where the slice's wire type is
-/// module-private (consent, task-consent, vault), the fixture replicates the
-/// handler's emission and the comment names the type it mirrors.
+/// The request should be the serialization of the type the producer actually
+/// sends, so the assertion is about **our wire form** rather than a hand-typed
+/// fixture. A transcription only proves someone can type valid JSON: it stops
+/// tracking the producer the moment the producer changes, and stays green while
+/// live traffic fails. `dids/update` is the worked example — its witness was
+/// transcribed, and #895 shipped anyway.
+///
+/// ## Where a transcription remains, and why
+///
+/// 26 of these witnesses still build their request with `json!`. The reason is
+/// **not** the one this comment used to give ("the slice's wire type is
+/// module-private"): 21 of the 26 name a `vta-sdk` client method that exists
+/// today. The accurate position, per family:
+///
+/// - **`auth/{whoami,sessions-list,step-up/approve-response}`,
+///   `task-consent/decision`** (5) — the VTA is the *consumer*; no `vta-sdk`
+///   producer sends these, so there is no emission of ours to assert. A fixture
+///   is the honest witness here.
+/// - **`consent/*` (6), `device/*` (6), `messaging/ping`** — a producer exists,
+///   but it builds its payload as an inline `json!` with a conditional insert
+///   per optional member. There is no type to point a witness at. Converting
+///   these means first giving those producers canonical body structs — the
+///   #888 fold, applied to the families it did not reach — and only then can a
+///   witness be built rather than transcribed.
+/// - **`vault/*` (7)** — `vault_upsert` and friends take a caller-supplied
+///   `Value`; the SDK is a pass-through that contributes at most one member.
+///   There is no SDK type at all, and inventing one is an API change, not a
+///   test change.
+///
+/// So the remaining work is real but is *not* "rewrite 26 fixtures": it is one
+/// producer fold (consent/device/ping) plus an API decision (vault), with five
+/// entries that are correct as they stand. Recorded here rather than in an
+/// issue because the next person to read this comment is the one who needs it.
 struct Witness {
     request: Value,
     parse_request: ParseFn,
@@ -1725,22 +1753,34 @@ fn table() -> Vec<(&'static str, Conformance)> {
     // ─── vta/webvh/dids/update (webvh-gated like its dispatch arm) ─
     #[cfg(feature = "webvh")]
     {
-        use vta_sdk::protocols::did_management::update::UpdateDidWebvhResultBody;
+        use vta_sdk::protocols::did_management::update::{
+            UpdateDidWebvhBody, UpdateDidWebvhResultBody,
+        };
         t.push((
             uris::TASK_WEBVH_DIDS_UPDATE_1_0,
             checked!(
                 specs::vta::webvh::dids::update::v1_0::Payload,
                 specs::vta::webvh::dids::update::v1_0::Response,
-                // Mirrors `webvh.rs`'s `UpdateDidWithDid` (did + flattened
-                // camelCase `UpdateDidWebvhBody`).
-                json!({
-                    "did": "did:webvh:scid:vta.example",
-                    "label": "rotate after audit",
-                    "preRotationCount": 2,
-                    "ttl": 3600,
-                    "watchers": ["https://watcher.example"],
-                    "expectedVersionId": "1-zVer",
-                }),
+                // Built by the producer's own shaping, not transcribed. The
+                // comment here used to name a `UpdateDidWithDid` type that does
+                // not exist — the shape lives in `flatten_with_did`, which is
+                // now public for exactly this reason.
+                //
+                // **Deliberately a one-member update.** `--label x` and nothing
+                // else is the exact invocation that could not run in #895: six
+                // unset members each went out as `null` and the maintainer
+                // refused all six. A witness that sets most members would leave
+                // almost nothing unset and so would not exercise the defect
+                // this task has already shipped. Setting one member and leaving
+                // the rest is what keeps the other six honest.
+                vta_sdk::client::flatten_with_did(
+                    "did:webvh:scid:vta.example",
+                    &UpdateDidWebvhBody {
+                        label: Some("rotate after audit".into()),
+                        ..Default::default()
+                    },
+                )
+                .expect("the producer's own shaping succeeds"),
                 to_v(UpdateDidWebvhResultBody {
                     did: "did:webvh:scid:vta.example".into(),
                     new_version_id: "2-zVer".into(),


### PR DESCRIPTION
Stacked on #923 — review that first; this PR's diff is the second commit. Based there rather than on main so the version bumps stay ordered (the #920/#921 collision).

## The problem

The conformance sweep (#857) checks a *witness* per task against that task's schema. **26 of its 70 witnesses build their request from a hand-written `json!` literal** rather than from the type the producer actually sends.

A transcription only proves someone can type valid JSON. It stops tracking the producer the moment the producer changes, and stays green while live traffic fails.

`vta/webvh/dids/update/1.0` is the worked example, and the reason to start there: **its witness was transcribed, and #895 shipped anyway** — every unset member went out as `null`, so `pnm did-mgmt dids edit --label x` could not run at all.

## The root cause was an API boundary

That family's request shape lives in `flatten_with_did` — body members flattened beside `did` — and that function was **private** to `vta-sdk`. From another crate the shape was literally unassertable except by hand-writing it, so the witness had no honest option.

`flatten_with_did` is now `pub` (re-exported as `vta_sdk::client::flatten_with_did`), and the witness is built by the producer's own shaping.

## The witness is deliberately a one-member update

`label` and nothing else — the invocation that could not run. A witness that set most members would leave almost nothing unset and so would not exercise the defect at all.

That distinction is not theoretical: **my first version of this conversion set five members, and passed happily with the fix reverted.** Only after narrowing it to one member did reverting a `skip_serializing_if` reproduce #895:

```text
vta/webvh/dids/update/1.0: request fails its own payload schema:
payload failed schema validation: null is not of type "integer"
```

## The remaining 25, documented accurately for the first time

The module claimed these were transcribed because "the slice's wire type is module-private (consent, task-consent, vault)". **That is no longer true — 21 of the 26 name a `vta-sdk` client method that exists today.** The honest position, now recorded per family:

| Family | Count | Why |
|---|---|---|
| `auth/{whoami,sessions-list,step-up/approve-response}`, `task-consent/decision` | 5 | VTA is the **consumer**; no producer of ours sends these. A fixture is the correct witness — no further work. |
| `consent/*`, `device/*`, `messaging/ping` | 13 | Producer exists but builds inline `json!` with a conditional insert per optional member. **No type to witness.** Needs the #888 canonical-body fold applied to these families first. |
| `vault/*` | 7 | SDK is a pass-through over a caller-supplied `Value`, contributing at most one member. No SDK type exists; inventing one is an API change, not a test change. |

So the outstanding work is **one producer fold plus one API decision** — materially smaller and better-shaped than "rewrite 26 fixtures", which is why it is written into the module rather than left as a count in an issue.

## Verification

- `cargo test -p vta-service --lib` — 787 passed
- `cargo test -p vta-sdk` — green
- `cargo clippy -p vta-sdk -p vta-service --all-targets` — clean
- `cargo fmt --check` — clean
- Conversion verified non-vacuous by reverting a `skip_serializing_if` and confirming the sweep reproduces #895's exact error
