### PR TITLE
feat(device): canonical request bodies, and witnesses built from them

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2922,7 +2922,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c54e03a951783e8b327515db3f2a2fd0e3bed362a96b066f341ce66ed49b4ead"
 dependencies = [
  "data-encoding",
- "syn 3.0.3",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4587,7 +4587,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -6453,7 +6453,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.43",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "thiserror 2.0.20",
  "tokio",
  "tracing",
@@ -6492,7 +6492,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -9383,7 +9383,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.21.15"
+version = "0.21.16"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -9446,7 +9446,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.14.28"
+version = "0.14.29"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/changelog.d/925-device-canonical-bodies.md
+++ b/changelog.d/925-device-canonical-bodies.md
@@ -1,0 +1,58 @@
+### vta-sdk 0.21.16 / vta-service 0.14.29 — the #888 fold reaches `device/*` (#925)
+
+The `device/*` client methods built their payloads as an inline `json!` plus a
+conditional insert per optional member:
+
+```rust
+let mut payload = json!({ "consumerKind": …, "displayName": … });
+if let Some(p) = platform { payload["platform"] = json!(p); }
+```
+
+That shape is not wrong — the conditional insert is exactly what kept `null` off
+the wire — but it is **unguarded and untestable**, and both matter:
+
+- **Unguarded.** The invariant lives in the shape of an `if let`, so nothing
+  checks it. `vta-sdk`'s null census (#921) walks structs under `protocols/` and
+  would have caught `keys/create` (#919); it cannot see an inline map. The next
+  person who reaches for a struct here — as #888 did for `keys/create` —
+  reintroduces the defect with nothing to stop them.
+- **Untestable.** A conformance witness has no type to point at, so it
+  hand-writes the JSON and stops tracking the producer the moment the producer
+  changes.
+
+New `protocols::device_management` carries canonical bodies for register,
+heartbeat, disable, wipe and set-wake, each with `skip_serializing_if` on its
+optionals. Both properties then fall out for free: the census enforces the
+invariant, and the five witnesses are **built** rather than transcribed.
+
+**The conversion has teeth, checked rather than assumed.** Reverting the skips on
+`DeviceHeartbeatBody` now fails the sweep:
+
+```text
+device/heartbeat/0.1: request fails its own payload schema:
+payload failed schema validation: null is not of type "string";
+null is not of type "integer"
+```
+
+The old fixture set both members and so could not have caught it — the same trap
+that made #924's first webvh conversion pass vacuously.
+
+**The witnesses got smaller on purpose.** The old device fixtures set members no
+producer here sends — `keyCustody`, `attestation`, `pushPlatform`, `issuedAt`.
+A witness asserting members we never emit proves nothing about our wire form,
+and leaves almost nothing unset, which is where this class of defect lives. The
+heartbeat witness is now a bare `{}` — the "still here" call — and register sets
+neither optional.
+
+Only what the client can actually send is modelled: `attestation` and
+`keyCustody` are in the schema but have no producer, and a field nothing sets is
+a claim the type should not make.
+
+`device/list` is **not** folded. Like `vault/*`, it takes a caller-supplied
+`Value` filter object and the SDK is a pass-through; giving it a type is an API
+change, not a test change. It stays a transcription, now recorded as such.
+
+The conformance module's per-family account is updated: 21 witnesses still
+transcribe (from 26), of which 5 are consumer-only and correct as they stand,
+7 (`consent/*` + `messaging/ping`) await this same fold, and 8 are
+pass-throughs awaiting an API decision.

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.21.15"
+version = "0.21.16"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/client/agent_devices.rs
+++ b/vta-sdk/src/client/agent_devices.rs
@@ -15,10 +15,14 @@
 //! marked deprecated in favour of `0.2`, but `0.1` is what the VTA dispatches.
 #![allow(deprecated)]
 
-use serde_json::{Value, json};
+use serde_json::Value;
 
 use super::VtaClient;
 use crate::error::VtaError;
+use crate::protocols::device_management::{
+    DeviceDisableBody, DeviceHeartbeatBody, DeviceRegisterBody, DeviceSetWakeBody, DeviceWipeBody,
+    WakeHandle,
+};
 use crate::trust_tasks;
 
 /// Round-trip timeout (seconds) for device trust tasks. Device ops are cheap
@@ -38,16 +42,12 @@ impl VtaClient {
         platform: Option<&str>,
         hpke_public_key: Option<&str>,
     ) -> Result<Value, VtaError> {
-        let mut payload = json!({
-            "consumerKind": consumer_kind,
-            "displayName": display_name,
-        });
-        if let Some(p) = platform {
-            payload["platform"] = json!(p);
-        }
-        if let Some(k) = hpke_public_key {
-            payload["hpkePublicKey"] = json!(k);
-        }
+        let payload = serde_json::to_value(DeviceRegisterBody {
+            consumer_kind,
+            display_name: display_name.to_string(),
+            platform: platform.map(str::to_string),
+            hpke_public_key: hpke_public_key.map(str::to_string),
+        })?;
         self.dispatch_trust_task(
             trust_tasks::TASK_DEVICE_REGISTER_0_1,
             payload,
@@ -59,10 +59,10 @@ impl VtaClient {
     /// `device/heartbeat/0.1` — refresh `lastSeenAt` (and `platform` if
     /// supplied). Returns server time + any queued operations for the device.
     pub async fn device_heartbeat(&self, platform: Option<&str>) -> Result<Value, VtaError> {
-        let mut payload = json!({});
-        if let Some(p) = platform {
-            payload["platform"] = json!(p);
-        }
+        let payload = serde_json::to_value(DeviceHeartbeatBody {
+            platform: platform.map(str::to_string),
+            vault_seq: None,
+        })?;
         self.dispatch_trust_task(
             trust_tasks::TASK_DEVICE_HEARTBEAT_0_1,
             payload,
@@ -86,7 +86,10 @@ impl VtaClient {
     /// `device/disable/0.1` — disable a device by id (the record is kept; it can
     /// no longer authenticate). The maintainer/operator kill switch.
     pub async fn device_disable(&self, device_id: &str) -> Result<Value, VtaError> {
-        let payload = json!({ "deviceId": device_id });
+        let payload = serde_json::to_value(DeviceDisableBody {
+            device_id: device_id.to_string(),
+            reason: None,
+        })?;
         self.dispatch_trust_task(
             trust_tasks::TASK_DEVICE_DISABLE_0_1,
             payload,
@@ -105,7 +108,11 @@ impl VtaClient {
         reason: &str,
         scope: &str,
     ) -> Result<Value, VtaError> {
-        let payload = json!({ "deviceId": device_id, "reason": reason, "scope": scope });
+        let payload = serde_json::to_value(DeviceWipeBody {
+            device_id: device_id.to_string(),
+            scope: scope.to_string(),
+            reason: reason.to_string(),
+        })?;
         self.dispatch_trust_task(
             trust_tasks::TASK_DEVICE_WIPE_0_1,
             payload,
@@ -123,10 +130,13 @@ impl VtaClient {
         handle: &str,
         suggested_triggers: Vec<String>,
     ) -> Result<Value, VtaError> {
-        let payload = json!({
-            "wakeHandle": { "gateway": gateway, "handle": handle },
-            "suggestedTriggers": suggested_triggers,
-        });
+        let payload = serde_json::to_value(DeviceSetWakeBody {
+            wake_handle: Some(WakeHandle {
+                gateway: gateway.to_string(),
+                handle: handle.to_string(),
+            }),
+            suggested_triggers: Some(suggested_triggers),
+        })?;
         self.dispatch_trust_task(
             trust_tasks::TASK_DEVICE_SET_WAKE_0_1,
             payload,

--- a/vta-sdk/src/protocols/device_management.rs
+++ b/vta-sdk/src/protocols/device_management.rs
@@ -1,0 +1,171 @@
+//! Canonical `device/*` request bodies.
+//!
+//! The #888 fold, applied to the family it did not reach. These methods used to
+//! build their payloads as an inline `json!` plus a conditional insert per
+//! optional member:
+//!
+//! ```ignore
+//! let mut payload = json!({ "consumerKind": …, "displayName": … });
+//! if let Some(p) = platform { payload["platform"] = json!(p); }
+//! ```
+//!
+//! That shape is not wrong — the conditional insert is what kept `null` off the
+//! wire — but it is unguarded and untestable. Unguarded because the invariant
+//! lives in the shape of an `if let` rather than in an attribute, so nothing
+//! checks it: the `vta-sdk` null census walks these structs and would have
+//! caught `keys/create`, and it cannot see an inline map. Untestable because a
+//! conformance witness has no type to point at, so it hand-writes the JSON and
+//! stops tracking the producer the moment the producer changes.
+//!
+//! With a body struct both fall out for free: `skip_serializing_if` is what
+//! keeps the member absent, the census enforces it, and the witness is built
+//! rather than transcribed.
+//!
+//! Members mirror `device/*/0.1`. Only what the client can actually send is
+//! modelled — `attestation` and `keyCustody` are in the schema but have no
+//! producer here yet, and a field nothing sets is a claim the type should not
+//! make.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// `device/register/0.1` — claim a `DeviceBinding` on the caller's ACL entry.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeviceRegisterBody {
+    /// The tagged `ConsumerKind` union (`{kind: "service", serviceKind: …}`).
+    ///
+    /// Stays a `Value` because the caller supplies it as one and the union has
+    /// no Rust model here yet; modelling it is an API change, not a fold.
+    pub consumer_kind: Value,
+    pub display_name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub platform: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hpke_public_key: Option<String>,
+}
+
+/// `device/heartbeat/0.1` — refresh `lastSeenAt`, and `platform` if supplied.
+///
+/// Every member is optional: an empty body is the common case (a bare "still
+/// here"), and it must serialize to `{}`, not to a map of nulls.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeviceHeartbeatBody {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub platform: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub vault_seq: Option<u64>,
+}
+
+/// `device/disable/0.1` — disable a device by id; the record is kept.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeviceDisableBody {
+    pub device_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+/// `device/wipe/0.1` — remote-wipe a compromised or lost device.
+///
+/// `scope` and `reason` are both required by the spec: a wipe with no recorded
+/// reason is an audit gap, and the schema refuses one.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeviceWipeBody {
+    pub device_id: String,
+    /// `cache` | `cache-and-keys` | `full`.
+    pub scope: String,
+    pub reason: String,
+}
+
+/// The device's opaque push handle.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WakeHandle {
+    pub gateway: String,
+    pub handle: String,
+}
+
+/// `device/set-wake/0.1` — convey the device's `WakeHandle`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeviceSetWakeBody {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub wake_handle: Option<WakeHandle>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub suggested_triggers: Option<Vec<String>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The property the fold exists to make enforceable: an unset optional is
+    /// absent, so a bare heartbeat is `{}` rather than a map of nulls.
+    ///
+    /// The old inline builder got this right by construction. Nothing checked
+    /// it, and `keys/create` is what that costs when someone later reaches for
+    /// a struct instead (#919).
+    #[test]
+    fn a_bare_heartbeat_is_an_empty_object() {
+        assert_eq!(
+            serde_json::to_value(DeviceHeartbeatBody::default()).expect("serialises"),
+            serde_json::json!({})
+        );
+    }
+
+    #[test]
+    fn an_unset_register_member_is_absent() {
+        let minimal = DeviceRegisterBody {
+            consumer_kind: serde_json::json!({"kind": "companion", "formFactor": "desktop"}),
+            display_name: "laptop".into(),
+            platform: None,
+            hpke_public_key: None,
+        };
+        assert_eq!(
+            serde_json::to_value(&minimal).expect("serialises"),
+            serde_json::json!({
+                "consumerKind": {"kind": "companion", "formFactor": "desktop"},
+                "displayName": "laptop",
+            })
+        );
+    }
+
+    /// Set members still reach the wire under their canonical camelCase names —
+    /// the skip must not be reachable for `Some`.
+    #[test]
+    fn set_members_serialise_camel_case() {
+        let full = DeviceRegisterBody {
+            consumer_kind: serde_json::json!({"kind": "service", "serviceKind": "ai-agent"}),
+            display_name: "agent".into(),
+            platform: Some("macos".into()),
+            hpke_public_key: Some("zHpke".into()),
+        };
+        let v = serde_json::to_value(&full).expect("serialises");
+        assert_eq!(v.get("platform").and_then(Value::as_str), Some("macos"));
+        assert_eq!(
+            v.get("hpkePublicKey").and_then(Value::as_str),
+            Some("zHpke")
+        );
+    }
+
+    #[test]
+    fn a_wake_handle_nests_under_its_camel_case_member() {
+        let body = DeviceSetWakeBody {
+            wake_handle: Some(WakeHandle {
+                gateway: "apns".into(),
+                handle: "opaque".into(),
+            }),
+            suggested_triggers: Some(vec!["message".into()]),
+        };
+        assert_eq!(
+            serde_json::to_value(&body).expect("serialises"),
+            serde_json::json!({
+                "wakeHandle": {"gateway": "apns", "handle": "opaque"},
+                "suggestedTriggers": ["message"],
+            })
+        );
+    }
+}

--- a/vta-sdk/src/protocols/mod.rs
+++ b/vta-sdk/src/protocols/mod.rs
@@ -8,6 +8,7 @@ pub mod credential_exchange;
 /// Issued-credential lifecycle (`spec/vta/credentials/{issue,revoke}/0.1`) —
 /// mint + revoke a VTA-signed W3C VC addressed to a holder DID.
 pub mod credentials_issuance;
+pub mod device_management;
 pub mod did_management;
 pub mod did_template_management;
 pub mod discovery;

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.14.28"
+version = "0.14.29"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/trust_tasks/conformance.rs
+++ b/vta-service/src/trust_tasks/conformance.rs
@@ -89,6 +89,10 @@ use vta_sdk::protocols::credential_exchange::{
 use vta_sdk::protocols::credentials_issuance::{
     IssueCredentialBody, IssueCredentialResponse, RevokeCredentialBody, RevokeCredentialResponse,
 };
+use vta_sdk::protocols::device_management::{
+    DeviceDisableBody, DeviceHeartbeatBody, DeviceRegisterBody, DeviceSetWakeBody, DeviceWipeBody,
+    WakeHandle,
+};
 use vta_sdk::protocols::did_management::servers::{
     ListWebvhServerDomainsBody, ListWebvhServerDomainsResultBody, WebvhServerDomainEntry,
 };
@@ -168,30 +172,31 @@ fn validates<T: ValidatedPayload>(v: &Value) -> Result<(), String> {
 ///
 /// ## Where a transcription remains, and why
 ///
-/// 26 of these witnesses still build their request with `json!`. The reason is
+/// 21 of these witnesses still build their request with `json!`. The reason is
 /// **not** the one this comment used to give ("the slice's wire type is
-/// module-private"): 21 of the 26 name a `vta-sdk` client method that exists
+/// module-private") — most of them name a `vta-sdk` client method that exists
 /// today. The accurate position, per family:
 ///
 /// - **`auth/{whoami,sessions-list,step-up/approve-response}`,
 ///   `task-consent/decision`** (5) — the VTA is the *consumer*; no `vta-sdk`
 ///   producer sends these, so there is no emission of ours to assert. A fixture
-///   is the honest witness here.
-/// - **`consent/*` (6), `device/*` (6), `messaging/ping`** — a producer exists,
-///   but it builds its payload as an inline `json!` with a conditional insert
-///   per optional member. There is no type to point a witness at. Converting
-///   these means first giving those producers canonical body structs — the
-///   #888 fold, applied to the families it did not reach — and only then can a
-///   witness be built rather than transcribed.
-/// - **`vault/*` (7)** — `vault_upsert` and friends take a caller-supplied
+///   is the honest witness here, and no further work is owed.
+/// - **`consent/*` (6), `messaging/ping`** (7 total) — a producer exists, but
+///   it builds its payload as an inline `json!` with a conditional insert per
+///   optional member. There is no type to point a witness at. Converting these
+///   means first giving those producers canonical body structs — the #888 fold,
+///   applied to the families it did not reach — and only then can a witness be
+///   built rather than transcribed. `device/*` went this way in #925 and is the
+///   worked example.
+/// - **`vault/*` (7), `device/list`** (8 total) — these take a caller-supplied
 ///   `Value`; the SDK is a pass-through that contributes at most one member.
 ///   There is no SDK type at all, and inventing one is an API change, not a
 ///   test change.
 ///
-/// So the remaining work is real but is *not* "rewrite 26 fixtures": it is one
-/// producer fold (consent/device/ping) plus an API decision (vault), with five
-/// entries that are correct as they stand. Recorded here rather than in an
-/// issue because the next person to read this comment is the one who needs it.
+/// So the remaining work is one producer fold (consent + ping) plus an API
+/// decision (the pass-throughs), with five entries that are correct as they
+/// stand. Recorded here rather than in an issue because the next person to read
+/// this comment is the one who needs it.
 struct Witness {
     request: Value,
     parse_request: ParseFn,
@@ -903,12 +908,16 @@ fn table() -> Vec<(&'static str, Conformance)> {
             checked!(
                 specs::device::register::v0_1::Payload,
                 specs::device::register::v0_1::Response,
-                json!({
-                    "consumerKind": { "kind": "companion", "formFactor": "browser" },
-                    "displayName": "Laptop",
-                    "platform": "macOS",
-                    "keyCustody": { "tier": "hardware" },
-                    "attestation": { "kind": "none" },
+                // The producer's own body, with its optionals unset — the
+                // shape `device_register(kind, name, None, None)` emits, and
+                // the one a caller reaches for first. The fixture used to set
+                // `keyCustody` and `attestation`, which no producer here sends:
+                // members we never emit prove nothing about our wire form.
+                to_v(DeviceRegisterBody {
+                    consumer_kind: json!({ "kind": "companion", "formFactor": "browser" }),
+                    display_name: "Laptop".into(),
+                    platform: None,
+                    hpke_public_key: None,
                 }),
                 json!({ "binding": device_binding_json() })
             ),
@@ -918,7 +927,9 @@ fn table() -> Vec<(&'static str, Conformance)> {
             checked!(
                 specs::device::heartbeat::v0_1::Payload,
                 specs::device::heartbeat::v0_1::Response,
-                json!({ "platform": "macOS", "vaultSeq": 42 }),
+                // A bare "still here" — every member unset, which must
+                // serialize to `{}` rather than a map of nulls.
+                to_v(DeviceHeartbeatBody::default()),
                 json!({ "serverTime": TS, "queuedOperations": [], "syncHint": "up-to-date" })
             ),
         ),
@@ -936,7 +947,10 @@ fn table() -> Vec<(&'static str, Conformance)> {
             checked!(
                 specs::device::disable::v0_1::Payload,
                 specs::device::disable::v0_1::Response,
-                json!({ "deviceId": "dev-1", "reason": "lost" }),
+                to_v(DeviceDisableBody {
+                    device_id: "dev-1".into(),
+                    reason: None,
+                }),
                 json!({ "deviceId": "dev-1", "disabledAt": TS })
             ),
         ),
@@ -945,7 +959,11 @@ fn table() -> Vec<(&'static str, Conformance)> {
             checked!(
                 specs::device::wipe::v0_1::Payload,
                 specs::device::wipe::v0_1::Response,
-                json!({ "deviceId": "dev-1", "scope": "full", "reason": "stolen", "issuedAt": TS }),
+                to_v(DeviceWipeBody {
+                    device_id: "dev-1".into(),
+                    scope: "full".into(),
+                    reason: "stolen".into(),
+                }),
                 json!({ "deviceId": "dev-1", "scope": "full", "completedAt": TS })
             ),
         ),
@@ -954,10 +972,12 @@ fn table() -> Vec<(&'static str, Conformance)> {
             checked!(
                 specs::device::set_wake::v0_1::Payload,
                 specs::device::set_wake::v0_1::Response,
-                json!({
-                    "wakeHandle": { "gateway": "did:web:gateway.example", "handle": "h-1" },
-                    "pushPlatform": "apns",
-                    "suggestedTriggers": ["did:web:mediator.example"],
+                to_v(DeviceSetWakeBody {
+                    wake_handle: Some(WakeHandle {
+                        gateway: "did:web:gateway.example".into(),
+                        handle: "h-1".into(),
+                    }),
+                    suggested_triggers: Some(vec!["did:web:mediator.example".into()]),
                 }),
                 json!({
                     "pushCapable": true,


### PR DESCRIPTION
The #888 fold, applied to `device/*`. Follows #924, which converted the one witness that already had a type to point at; this one creates the types.

## The problem with the old shape

```rust
let mut payload = json!({ "consumerKind": …, "displayName": … });
if let Some(p) = platform { payload["platform"] = json!(p); }
```

That is not *wrong* — the conditional insert is exactly what kept `null` off the wire. But it is **unguarded** and **untestable**, and both matter:

- **Unguarded.** The invariant lives in the shape of an `if let`, so nothing checks it. `vta-sdk`'s null census (#921) walks structs under `protocols/` and would have caught `keys/create` (#919) — it cannot see an inline map. The next person who reaches for a struct here, exactly as #888 did for `keys/create`, reintroduces the defect with nothing to stop them.
- **Untestable.** A conformance witness has no type to point at, so it hand-writes the JSON and stops tracking the producer the moment the producer changes.

## What this does

New `protocols::device_management` with canonical bodies for **register, heartbeat, disable, wipe, set-wake**, each carrying `skip_serializing_if` on its optionals. Both properties then fall out for free: the census enforces the invariant, and the five witnesses are **built** rather than transcribed.

## The conversion has teeth — checked, not assumed

Reverting the skips on `DeviceHeartbeatBody` fails the sweep:

```text
device/heartbeat/0.1: request fails its own payload schema:
payload failed schema validation: null is not of type "string";
null is not of type "integer"
```

The old fixture set both members, so it could never have caught that — the same trap that made #924's *first* webvh conversion pass vacuously. Worth stating because it's the easy mistake in this work: a witness can look converted and exercise nothing.

## The witnesses got smaller on purpose

The old fixtures set members no producer here sends — `keyCustody`, `attestation`, `pushPlatform`, `issuedAt`. A witness asserting members we never emit proves nothing about our wire form, and leaves almost nothing unset, which is precisely where this defect class lives.

Heartbeat is now a bare `{}` (the "still here" call); register sets neither optional.

Correspondingly, only what the client can actually send is modelled. `attestation` and `keyCustody` are in the schema but have no producer here, and **a field nothing sets is a claim the type should not make**.

## `device/list` is deliberately not folded

Like `vault/*`, it takes a caller-supplied `Value` filter object and the SDK is a pass-through. Giving it a type is an API change, not a test change. It stays a transcription, now recorded as one rather than lumped in with the rest.

## Running total

The module's per-family account is updated: **21** witnesses still transcribe (down from 26) — 5 consumer-only and correct as they stand, 7 (`consent/*` + `messaging/ping`) awaiting this same fold, 8 pass-throughs awaiting an API decision.

## Verification

- `cargo test -p vta-service --lib` — 787 passed
- `cargo test -p vta-sdk` — green, including the null census now covering the new bodies
- `cargo clippy -p vta-sdk -p vta-service --all-targets` — clean
- `cargo +1.95.0 check --workspace --locked` — green **against the committed tree**, and `git status` clean afterwards (#924 failed CI because a rebase left the committed `Cargo.lock` stale while local runs silently fixed the working tree)
