### PR TITLE
feat(vtc-service): publish which transports a community offers, and whether they answer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9681,7 +9681,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-service"
-version = "0.11.56"
+version = "0.11.57"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/changelog.d/926-public-transport-connectivity-view.md
+++ b/changelog.d/926-public-transport-connectivity-view.md
@@ -1,0 +1,55 @@
+### vtc-service 0.11.57 — publish which transports a community offers, and whether they answer (#926)
+
+A community's DID document says how to reach it, but resolving a `did:webvh`
+and matching service `type`s is a lot to ask of someone who just wants to know
+whether they can connect — and it still cannot tell them whether the endpoint on
+the other side is actually answering. That gap is what let a VTC advertise
+`#tsp` while silently dropping every join (#923): from outside, a working
+transport and a dead one looked identical.
+
+`GET /v1/community/public-profile` (public, unauthenticated) now carries a
+`transports` array, and the default landing page renders it:
+
+```json
+"transports": [
+  { "protocol": "tsp",     "advertised": true,  "serviceable": true,
+    "endpoint": "did:webvh:QmTS3…:mediator" },
+  { "protocol": "didcomm", "advertised": false, "serviceable": true },
+  { "protocol": "rest",    "advertised": true,  "serviceable": true,
+    "endpoint": "https://first.openvtc.net" }
+]
+```
+
+Two facts per transport, deliberately not collapsed into one "reachable"
+boolean:
+
+- **`advertised`** — the DID document offers it, so a resolving client will find
+  it. Read from the document as *resolved* at request time.
+- **`serviceable`** — this VTC can answer on it right now: the build supports the
+  protocol *and* the mediator connection is live, off the same re-falsifiable
+  signal `/health/diagnostics` uses, never a boot latch (R6.2).
+
+Reachable means both. `advertised && !serviceable` is exactly the state that
+broke the reference deployment, and a single boolean would have hidden it the
+same way the original defect did.
+
+**The DID document remains authoritative.** This is a view of it for humans and
+monitors, never a substitute or a second source of truth — a client selecting a
+transport still matches on the document's service `type`. If the two ever
+disagree, the document wins and this field is what is wrong.
+
+Notes:
+
+- **Endpoint, not page.** Operators replace the public website
+  (`website.root_dir`), so a landing-page-only change would vanish for exactly
+  the real deployments worth checking. The endpoint survives, is machine-readable
+  for CI and monitoring, and any custom site can render it. `website-default`
+  renders it from the fetch it already makes.
+- **Unknown is not "none".** A community whose own DID does not resolve reports
+  an empty array. Publishing "advertises nothing" would be an actionable claim,
+  and a false one.
+- **Nothing about the build is disclosed.** Build feature flags, versions, and
+  the operator remediation text in `transport_capability::Finding` stay in
+  `vtc status` and the daemon log. `advertised` and `endpoint` are already public
+  in the DID document; `serviceable` is discoverable by attempting the transport.
+  Pinned by tests on both the wire type and the route response.

--- a/docs/03-vtc/website-and-admin.md
+++ b/docs/03-vtc/website-and-admin.md
@@ -188,6 +188,61 @@ that fetches `/v1/community/profile` + `/health` and renders them.
 The moment an operator sets `root_dir`, the filesystem handler
 takes over and the default is unreachable.
 
+### Transport connectivity
+
+`GET /v1/community/public-profile` (public, unauthenticated) carries a
+`transports` array, and the default landing page renders it as a
+**Transports** row. Anyone can use it to check how to reach the
+community and whether each route currently answers:
+
+```console
+$ curl -s https://community.example/v1/community/public-profile | jq .transports
+[
+  { "protocol": "tsp",     "advertised": true,  "serviceable": true,
+    "endpoint": "did:webvh:QmTS3…:mediator" },
+  { "protocol": "didcomm", "advertised": false, "serviceable": true },
+  { "protocol": "rest",    "advertised": true,  "serviceable": true,
+    "endpoint": "https://community.example" }
+]
+```
+
+Each transport carries **two** facts, and they mean different things:
+
+| Field | Question it answers |
+|---|---|
+| `advertised` | Does the community's DID document offer this transport, so a resolving client will find it? |
+| `serviceable` | Can this VTC answer on it *right now* — protocol compiled in, and the mediator connection live? |
+
+A transport is genuinely reachable only when **both** are true. The
+interesting combinations:
+
+- `advertised: true, serviceable: false` — clients will choose this
+  transport and get nothing. This is the state that silently broke a
+  live deployment; the daemon also refuses to start if *no* advertised
+  transport is serviceable (see `vtc status`).
+- `advertised: false, serviceable: true` — the binary supports it but
+  the DID document has not caught up. Normal mid-rollout; nothing
+  routes to it yet.
+- An **empty** array means the community's own DID could not be
+  resolved, so the answer is *unknown* — not "offers nothing".
+
+Because it is a plain unauthenticated GET, it works from a browser,
+from `curl`, and from a monitoring check. Note the endpoint — not the
+page — is the durable surface: an operator who replaces the website
+with their own keeps the endpoint and can render it however they like.
+
+> **The DID document stays authoritative.** This field is a *view* of
+> it, resolved at request time, published so connectivity can be
+> validated without resolving the DID by hand. A client selecting a
+> transport must still match on the document's service `type`. If the
+> two ever disagree, the document wins.
+
+Deliberately **not** published here: build feature flags, version
+strings, and the operator-facing remediation text. Those stay in
+`vtc status` and the daemon log. Everything in `transports` is either
+already public in the DID document or discoverable by attempting the
+transport.
+
 ## Admin UX
 
 ```mermaid

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.11.56"
+version = "0.11.57"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vtc-service/src/routes/community/profile.rs
+++ b/vtc-service/src/routes/community/profile.rs
@@ -72,6 +72,23 @@ pub struct PublicCommunityProfile {
     /// Sourced from the live daemon config (same as `/health`), not
     /// the persisted profile row.
     pub mediator_did: Option<String>,
+    /// How to reach this community, and whether each route currently works.
+    ///
+    /// Every protocol is listed, each carrying `advertised` (the DID document
+    /// offers it) and `serviceable` (this VTC can answer on it right now).
+    /// Reachable means both.
+    ///
+    /// **The DID document remains authoritative.** This is a *view* of it,
+    /// resolved at request time, published so a visitor or a monitor can
+    /// validate connectivity without resolving the DID themselves — never an
+    /// independent declaration. A client choosing a transport must still match
+    /// on the document's service `type`; if the two ever disagree, the document
+    /// wins and this field is the thing that is wrong.
+    ///
+    /// Empty when the community's own DID could not be resolved — reported as
+    /// unknown rather than as "advertises nothing", which would be a lie a
+    /// caller might act on.
+    pub transports: Vec<crate::transport_capability::TransportStatus>,
 }
 
 /// Public GET handler. Trust-Task-exempt, no auth. Returns only the
@@ -98,6 +115,37 @@ pub async fn get_public_profile(
         .messaging
         .as_ref()
         .map(|m| m.mediator_did.clone());
+
+    // Live mediator connectivity, off the delivery transport's re-falsifiable
+    // signal — the same source `/health/diagnostics` reads, never a boot latch
+    // (R6.2). A published "reachable" that cannot go false again would be worse
+    // than publishing nothing.
+    let messaging_connected = matches!(
+        state.didcomm.get().map(|m| m.service.status()),
+        Some(affinidi_messaging_delivery::MessagingStatus::Connected)
+    );
+
+    // Resolved rather than read from config or the local `did.jsonl`: the
+    // document is the authority for what this community advertises, and it can
+    // gain a service long after the VTC last wrote its own mirror — which is
+    // exactly what happened to the deployment that motivated this
+    // (`#tsp` arrived at DID log version 3). The resolver caches, so the common
+    // case costs no network even though this endpoint is unauthenticated.
+    let transports = match crate::transport_capability::resolved_capabilities(
+        state.did_resolver.as_ref(),
+        &profile.community_did,
+    )
+    .await
+    {
+        Some(caps) => {
+            crate::transport_capability::public_transport_view_for_build(&caps, messaging_connected)
+        }
+        // Unknown, not "none". Publishing an empty advertised set would tell a
+        // visitor this community offers no way in, which is a different — and
+        // actionable — claim from "we could not check".
+        None => Vec::new(),
+    };
+
     Ok(Json(PublicCommunityProfile {
         community_did: profile.community_did,
         name: profile.name,
@@ -108,6 +156,7 @@ pub async fn get_public_profile(
         language: profile.language,
         created_at: profile.created_at,
         mediator_did,
+        transports,
     }))
 }
 

--- a/vtc-service/src/transport_capability.rs
+++ b/vtc-service/src/transport_capability.rs
@@ -48,6 +48,7 @@
 //! is unservable, and both ways to fix it — so an operator can tell a
 //! capability mismatch from a network or auth failure.
 
+use serde::Serialize;
 use vta_sdk::protocol::matching::{Protocol, ServiceCapabilities};
 
 /// The transports a build with the `tsp` feature serves inbound.
@@ -312,6 +313,92 @@ pub fn findings_against(served: &[Protocol], caps: &ServiceCapabilities) -> Vec<
 #[must_use]
 pub fn findings_for_build(caps: &ServiceCapabilities) -> Vec<Finding> {
     findings_against(served_transports(), caps)
+}
+
+/// One transport's public connectivity status, as reported on the
+/// unauthenticated community profile.
+///
+/// The two flags answer different questions and both are needed:
+///
+/// - `advertised` — will a client resolving this community's DID *find* this
+///   transport? Read from the DID document, which is the authority (CLAUDE.md).
+/// - `serviceable` — if reached on it, can this VTC actually answer? Build
+///   capability plus live messaging connectivity.
+///
+/// A transport is genuinely reachable only when **both** are true. Splitting
+/// them is the point: the failure that motivated all of this was `advertised`
+/// without `serviceable`, and a single boolean would have hidden it exactly the
+/// way the original defect did.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct TransportStatus {
+    /// `"tsp"` / `"didcomm"` / `"rest"`.
+    pub protocol: String,
+    /// Present in the community's DID document, so a resolving client will
+    /// find it.
+    pub advertised: bool,
+    /// This VTC can answer on it right now. For the messaging transports that
+    /// means the build supports the protocol *and* the mediator connection is
+    /// live — a re-falsifiable signal, never a boot-time latch (R6.2).
+    pub serviceable: bool,
+    /// The advertised endpoint: the mediator DID for TSP/DIDComm, the base URL
+    /// for REST. `None` when not advertised — there is no endpoint to give.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub endpoint: Option<String>,
+}
+
+/// The public transport view: every protocol, whether the document advertises
+/// it, and whether this VTC can serve it.
+///
+/// Deliberately reports **all three** protocols rather than only the advertised
+/// ones, so the response shape is stable and a client can tell "not advertised"
+/// from "absent from an older response". A `serviceable` transport that is not
+/// `advertised` is the staged-rollout state — the binary is ready, the DID
+/// document has not caught up.
+///
+/// Discloses nothing that isn't already public or externally observable:
+/// `advertised` and `endpoint` are read straight out of the DID document, which
+/// anyone can resolve, and `serviceable` is discoverable by simply attempting
+/// the transport. Deliberately **excluded**: build feature flags, version
+/// strings, and the operator-facing remediation text from [`Finding`] — those
+/// are for `vtc status` and the daemon log, not a public page.
+///
+/// `messaging_connected` is the live mediator-connection signal; REST is always
+/// serviceable, since serving this response proves it.
+#[must_use]
+pub fn public_transport_view(
+    served: &[Protocol],
+    caps: &ServiceCapabilities,
+    messaging_connected: bool,
+) -> Vec<TransportStatus> {
+    Protocol::PREFERENCE_ORDER
+        .into_iter()
+        .map(|protocol| {
+            let endpoint = caps.endpoint(protocol).map(str::to_string);
+            let serviceable = match protocol {
+                // Answering this request is the proof.
+                Protocol::Rest => true,
+                // A messaging transport needs both halves: compiled in, and a
+                // live socket to the mediator.
+                _ => served.contains(&protocol) && messaging_connected,
+            };
+            TransportStatus {
+                protocol: protocol.as_str().to_string(),
+                advertised: endpoint.is_some(),
+                serviceable,
+                endpoint,
+            }
+        })
+        .collect()
+}
+
+/// [`public_transport_view`] for the transports this build serves.
+#[must_use]
+pub fn public_transport_view_for_build(
+    caps: &ServiceCapabilities,
+    messaging_connected: bool,
+) -> Vec<TransportStatus> {
+    public_transport_view(served_transports(), caps, messaging_connected)
 }
 
 /// The DID-document state from the VTC's own on-disk `did.jsonl`, if it has
@@ -680,6 +767,108 @@ mod tests {
             cfg!(feature = "tsp"),
             "`tsp` must stay a default feature of vtc-service: the shipped binary has to serve \
              the TSP its DID document may advertise."
+        );
+    }
+
+    // ─── the public transport view ───────────────────────────────────────
+
+    fn status<'a>(view: &'a [TransportStatus], protocol: &str) -> &'a TransportStatus {
+        view.iter()
+            .find(|t| t.protocol == protocol)
+            .unwrap_or_else(|| panic!("{protocol} missing from the view: {view:?}"))
+    }
+
+    /// The shape is stable: all three protocols, always, in preference order.
+    /// A consumer must be able to tell "not advertised" from "this response is
+    /// from an older build that omitted the field".
+    #[test]
+    fn every_protocol_is_reported_in_preference_order() {
+        let view = public_transport_view(TSP_BUILD, &deployed_shape(), true);
+        assert_eq!(
+            view.iter().map(|t| t.protocol.as_str()).collect::<Vec<_>>(),
+            vec!["tsp", "didcomm", "rest"]
+        );
+    }
+
+    /// The deployed community, served by a build that can answer: TSP is
+    /// advertised and serviceable, and carries the mediator DID a client needs.
+    #[test]
+    fn an_advertised_and_servable_transport_reports_both() {
+        let view = public_transport_view(TSP_BUILD, &deployed_shape(), true);
+        let tsp = status(&view, "tsp");
+        assert!(tsp.advertised && tsp.serviceable);
+        assert_eq!(tsp.endpoint.as_deref(), Some("did:webvh:y:h:mediator"));
+    }
+
+    /// The failure this whole line of work exists for, as a visitor would see
+    /// it: advertised, but not serviceable. A single "reachable" boolean would
+    /// have collapsed these two and hidden it — the same way the original
+    /// defect was hidden.
+    #[test]
+    fn advertised_but_unservable_is_visible_as_two_separate_facts() {
+        let view = public_transport_view(NON_TSP_BUILD, &deployed_shape(), true);
+        let tsp = status(&view, "tsp");
+        assert!(tsp.advertised, "the document offers it");
+        assert!(!tsp.serviceable, "this build cannot answer on it");
+    }
+
+    /// The staged-rollout state: the binary is ready, the document has not
+    /// caught up. Serviceable, not advertised, and no endpoint to give.
+    #[test]
+    fn servable_but_unadvertised_reports_no_endpoint() {
+        let view = public_transport_view(TSP_BUILD, &didcomm_only(), true);
+        let tsp = status(&view, "tsp");
+        assert!(!tsp.advertised);
+        assert!(tsp.serviceable);
+        assert_eq!(tsp.endpoint, None, "nothing to publish when unadvertised");
+    }
+
+    /// A dropped mediator connection makes every messaging transport
+    /// unserviceable — and must, or the published flag is a latch (R6.2).
+    /// REST stays serviceable: answering the request proves it.
+    #[test]
+    fn losing_the_mediator_makes_messaging_unserviceable_but_not_rest() {
+        let view = public_transport_view(TSP_BUILD, &tsp_and_didcomm(), false);
+        assert!(!status(&view, "tsp").serviceable);
+        assert!(!status(&view, "didcomm").serviceable);
+        assert!(
+            status(&view, "rest").serviceable,
+            "serving this response is the proof REST works"
+        );
+    }
+
+    /// Nothing in the public view leaks build configuration or operator
+    /// remediation. `Finding`'s text names feature flags and rebuild commands
+    /// on purpose — for `vtc status` and the daemon log. It must not ride out
+    /// on an unauthenticated endpoint.
+    #[test]
+    fn the_public_view_leaks_no_build_detail() {
+        let view = public_transport_view(NON_TSP_BUILD, &deployed_shape(), true);
+        let json = serde_json::to_string(&view).expect("serialises");
+        for leak in ["feature", "--features", "rebuild", "cargo", "version"] {
+            assert!(
+                !json.contains(leak),
+                "public transport view must not mention {leak:?}: {json}"
+            );
+        }
+    }
+
+    /// Wire casing is camelCase (R3.1), and the two flags are named
+    /// distinctly enough that a consumer cannot confuse them.
+    #[test]
+    fn wire_shape_is_camel_case() {
+        let view = public_transport_view(TSP_BUILD, &deployed_shape(), true);
+        let json = serde_json::to_value(&view).expect("serialises");
+        let first = &json[0];
+        assert!(first.get("protocol").is_some());
+        assert!(first.get("advertised").is_some());
+        assert!(first.get("serviceable").is_some());
+        assert!(first.get("endpoint").is_some());
+        // Not snake_case, and no stray fields.
+        assert_eq!(
+            first.as_object().unwrap().len(),
+            4,
+            "unexpected fields on the public wire type: {first}"
         );
     }
 

--- a/vtc-service/tests/community_profile.rs
+++ b/vtc-service/tests/community_profile.rs
@@ -369,6 +369,64 @@ async fn public_profile_returns_curated_subset_unauthenticated() {
     // Curated subset — operational + opaque fields stay private.
     assert!(body.get("registryStatus").is_none());
     assert!(body.get("extensions").is_none());
+    // The transport view is always present, even when empty (see below), so a
+    // consumer can tell "this VTC reports no transports" from "this response
+    // predates the field".
+    assert!(
+        body.get("transports").is_some_and(|t| t.is_array()),
+        "public profile must always carry a transports array: {body}"
+    );
+}
+
+/// A VTC whose own DID cannot be resolved reports transports as **unknown**
+/// (an empty array), never as "advertises nothing".
+///
+/// The distinction matters to a visitor: "no way in" is actionable and would be
+/// a lie here. This fixture has no DID resolver wired, which is the same
+/// observable state as a resolution failure.
+#[tokio::test]
+async fn public_profile_reports_unknown_transports_when_the_did_does_not_resolve() {
+    let fix = build().await;
+    seed_profile(&fix).await;
+    let req = Request::builder()
+        .method("GET")
+        .uri("/v1/community/public-profile")
+        .body(Body::empty())
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    let (status, body) = body_value(resp).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        body["transports"].as_array().map(Vec::len),
+        Some(0),
+        "unresolvable DID must yield an empty (unknown) transport list, not a \
+         fabricated one: {body}"
+    );
+}
+
+/// The public endpoint must not leak build configuration. The operator-facing
+/// remediation text in `transport_capability::Finding` names feature flags and
+/// rebuild commands on purpose — for `vtc status` and the daemon log. None of
+/// it may ride out on an unauthenticated response.
+#[tokio::test]
+async fn public_profile_leaks_no_build_configuration() {
+    let fix = build().await;
+    seed_profile(&fix).await;
+    let req = Request::builder()
+        .method("GET")
+        .uri("/v1/community/public-profile")
+        .body(Body::empty())
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    let (status, body) = body_value(resp).await;
+    assert_eq!(status, StatusCode::OK);
+    let serialised = body.to_string();
+    for leak in ["--features", "cargo", "rebuild", "feature"] {
+        assert!(
+            !serialised.contains(leak),
+            "public profile must not mention {leak:?}: {serialised}"
+        );
+    }
 }
 
 #[tokio::test]

--- a/vtc-service/tests/join_tsp.rs
+++ b/vtc-service/tests/join_tsp.rs
@@ -177,6 +177,7 @@ async fn the_mock_advertises_tsp_and_didcomm_and_serves_both() {
     // This build serves everything it advertises...
     assert_eq!(classify_against(TSP_BUILD, &caps), MessagingVerdict::Ok);
     // ...and the same document in a build without `tsp` is a mismatch the
+
     // startup check reports rather than a silent drop. Degraded, not
     // Unreachable, because DIDComm is still advertised here — unlike the
     // deployed VTC, which offered TSP alone.
@@ -186,6 +187,96 @@ async fn the_mock_advertises_tsp_and_didcomm_and_serves_both() {
             MessagingVerdict::Degraded(u) if u.len() == 1 && u[0].protocol == Protocol::Tsp
         ),
         "a non-tsp build must report the advertised TSP it cannot serve"
+    );
+
+    mock.shutdown().await;
+}
+
+/// The public connectivity view, end to end against a real running VTC: a
+/// visitor (or a monitor) fetching the unauthenticated community profile can
+/// see which transports this community offers and whether each one answers.
+///
+/// This is the populated counterpart to
+/// `community_profile::public_profile_reports_unknown_transports_when_the_did_does_not_resolve`,
+/// and it needs the TSP harness because it needs a VTC whose DID actually
+/// resolves to a document advertising real transports — the whole point being
+/// that the view is derived from the document rather than declared.
+#[tokio::test]
+async fn the_public_profile_publishes_a_usable_connectivity_view() {
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+
+    init_tracing();
+    let mock = MockVtcDidcomm::start_with_tsp().await;
+
+    // `public-profile` 404s without a profile row; the community DID must be
+    // the harness's resolvable did:peer so the view is built from its document.
+    vtc_service::community::store_profile(
+        &mock.vtc.state.community_ks,
+        &vtc_service::community::CommunityProfile::new(mock.vtc_did(), "TSP Test Community"),
+    )
+    .await
+    .expect("seed community profile");
+
+    let resp = mock
+        .vtc
+        .router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/v1/community/public-profile")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body: serde_json::Value =
+        serde_json::from_slice(&resp.into_body().collect().await.unwrap().to_bytes())
+            .expect("public profile is JSON");
+
+    let transports = body["transports"]
+        .as_array()
+        .unwrap_or_else(|| panic!("no transports array: {body}"));
+
+    let find = |protocol: &str| {
+        transports
+            .iter()
+            .find(|t| t["protocol"] == protocol)
+            .unwrap_or_else(|| panic!("{protocol} missing: {body}"))
+    };
+
+    // The harness advertises both messaging transports and this build serves
+    // both, so both read as genuinely reachable — advertised *and* serviceable.
+    for protocol in ["tsp", "didcomm"] {
+        let t = find(protocol);
+        assert_eq!(
+            t["advertised"], true,
+            "{protocol} should be advertised: {t}"
+        );
+        assert_eq!(
+            t["serviceable"], true,
+            "{protocol} should be serviceable — the listener is up and this build supports it: {t}"
+        );
+        assert!(
+            t["endpoint"].is_string(),
+            "an advertised transport must publish the endpoint a client routes to: {t}"
+        );
+    }
+
+    // REST is always serviceable — answering this very request proves it — but
+    // this harness's did:peer advertises no REST service, so it is not
+    // reachable. Exactly the "supported, not advertised" state, and the reason
+    // the two flags are reported separately rather than as one boolean.
+    let rest = find("rest");
+    assert_eq!(rest["serviceable"], true);
+    assert_eq!(rest["advertised"], false);
+    assert!(
+        rest["endpoint"].is_null(),
+        "an unadvertised transport has no endpoint to publish: {rest}"
     );
 
     mock.shutdown().await;

--- a/vtc-service/website-default/index.html
+++ b/vtc-service/website-default/index.html
@@ -133,6 +133,19 @@
               </button>
             </dd>
           </div>
+          <!--
+            How to reach this community, and whether each route works right
+            now. Hidden until the profile fetch fills it: an empty transport
+            list means the community's DID could not be resolved, which is
+            "unknown", not "no way in" — better to show nothing than to
+            imply the latter.
+          -->
+          <div class="status-row stacked" id="transports-row" hidden>
+            <dt>Transports</dt>
+            <dd>
+              <ul class="transport-list" id="transport-list"></ul>
+            </dd>
+          </div>
         </dl>
       </section>
 

--- a/vtc-service/website-default/site.css
+++ b/vtc-service/website-default/site.css
@@ -296,6 +296,75 @@ h2 {
   scrollbar-width: thin;
 }
 
+/* Transports — how to reach this community, and whether each route
+ * currently works. Two independent facts per row (advertised /
+ * serviceable), never collapsed: "advertised but not responding" is the
+ * state worth seeing, and one badge would hide it. */
+.transport-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.transport {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.transport-name {
+  flex: 0 0 auto;
+  background: var(--bg-subtle);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 0.25rem 0.5rem;
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  color: var(--text);
+}
+
+.transport.is-reachable .transport-name {
+  border-color: color-mix(in srgb, var(--success) 50%, var(--border-strong));
+}
+
+.transport.is-degraded .transport-name {
+  border-color: color-mix(in srgb, var(--warning) 50%, var(--border-strong));
+}
+
+.transport-note {
+  flex: 0 0 auto;
+  font-size: 0.8rem;
+}
+
+.transport-note.ok {
+  color: var(--success);
+}
+
+.transport-note.warn {
+  color: var(--warning);
+}
+
+.transport-note.muted {
+  color: var(--text-faint);
+}
+
+/* The endpoint is a mediator DID or a URL — same opaque-token problem as
+ * `.did-value`, so the same treatment: one line, scroll rather than wrap. */
+.transport-endpoint {
+  flex: 1 1 100%;
+  min-width: 0;
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  overflow-x: auto;
+  white-space: nowrap;
+  scrollbar-width: thin;
+}
+
 .copy-btn {
   flex: 0 0 auto;
   display: inline-flex;

--- a/vtc-service/website-default/site.js
+++ b/vtc-service/website-default/site.js
@@ -37,6 +37,81 @@ function showMediatorRow(did) {
   row.hidden = false;
 }
 
+/**
+ * Render "how do I reach this community, and does it work right now".
+ *
+ * Each transport carries two independent facts, and both are shown:
+ *   advertised  — the community's DID document offers it, so a resolving
+ *                 client will find it;
+ *   serviceable — this VTC can answer on it at the moment.
+ *
+ * Reachable means both. They are deliberately not collapsed into one badge:
+ * "advertised but not serviceable" is precisely the state that silently broke
+ * a live deployment (a DID document offering TSP to a binary that could not
+ * serve it), and a single boolean would hide it all over again.
+ *
+ * The DID document remains authoritative for transport selection — this is a
+ * view of it for humans and monitors, never a substitute. A client picks a
+ * transport by matching the document's service `type`.
+ */
+function showTransports(transports) {
+  const row = document.getElementById("transports-row");
+  const list = document.getElementById("transport-list");
+  // An empty list means the community DID did not resolve, so the daemon
+  // could not tell us what it advertises. Leave the row hidden rather than
+  // render an empty state a visitor would read as "offers nothing".
+  if (!row || !list || !Array.isArray(transports) || transports.length === 0) {
+    return;
+  }
+
+  list.replaceChildren();
+  for (const t of transports) {
+    if (!t || typeof t.protocol !== "string") continue;
+
+    const item = document.createElement("li");
+    item.className = "transport";
+
+    const name = document.createElement("code");
+    name.className = "transport-name";
+    name.textContent = t.protocol.toUpperCase();
+    item.append(name);
+
+    const note = document.createElement("span");
+    if (t.advertised && t.serviceable) {
+      item.classList.add("is-reachable");
+      note.className = "transport-note ok";
+      note.textContent = "reachable";
+    } else if (t.advertised) {
+      // Advertised but not answering. The one a visitor most needs to see:
+      // a conforming client will choose this and get nothing.
+      item.classList.add("is-degraded");
+      note.className = "transport-note warn";
+      note.textContent = "advertised, not responding";
+    } else if (t.serviceable) {
+      // Supported but not published, so nothing will route to it. Normal
+      // mid-rollout; stated so the gap is legible rather than mysterious.
+      note.className = "transport-note muted";
+      note.textContent = "supported, not advertised";
+    } else {
+      note.className = "transport-note muted";
+      note.textContent = "not available";
+    }
+    item.append(note);
+
+    // Only meaningful when advertised — that is the address a client uses.
+    if (t.advertised && t.endpoint) {
+      const endpoint = document.createElement("code");
+      endpoint.className = "transport-endpoint";
+      endpoint.textContent = t.endpoint;
+      item.append(endpoint);
+    }
+
+    list.append(item);
+  }
+
+  row.hidden = false;
+}
+
 function showLogo(url, alt) {
   const img = document.getElementById("community-logo");
   if (!img || !url) return;
@@ -186,6 +261,9 @@ async function refresh() {
       if (profile.mediatorDid) {
         showMediatorRow(profile.mediatorDid);
       }
+      // Same fetch carries the transport view, so validating connectivity
+      // costs nothing extra.
+      showTransports(profile.transports);
     }
   } catch (err) {
     // The default landing page sits in front of every freshly-


### PR DESCRIPTION
A community's DID document says how to reach it — but resolving a `did:webvh`
and matching service `type`s is a lot to ask of someone who just wants to know
whether they can connect, and it still cannot tell them whether the endpoint on
the other side is *answering*.

That gap is what let a VTC advertise `#tsp` while silently dropping every join
(#923). From outside, a working transport and a dead one looked identical.

## What this adds

`GET /v1/community/public-profile` (public, unauthenticated, already fetched by
the default landing page) now carries a `transports` array:

```json
"transports": [
  { "protocol": "tsp",     "advertised": true,  "serviceable": true,
    "endpoint": "did:webvh:QmTS3…:mediator" },
  { "protocol": "didcomm", "advertised": false, "serviceable": true },
  { "protocol": "rest",    "advertised": true,  "serviceable": true,
    "endpoint": "https://first.openvtc.net" }
]
```

The default landing page renders it as a **Transports** row:

```
Transports   TSP      reachable        did:webvh:QmTS3…:mediator
             DIDCOMM  supported, not advertised
             REST     reachable        https://first.openvtc.net
```

## Two facts, deliberately not one

| Field | Question |
|---|---|
| `advertised` | Does the DID document offer it, so a resolving client will find it? |
| `serviceable` | Can this VTC answer on it *right now* — protocol compiled in, mediator connection live? |

Reachable means both. **`advertised && !serviceable` is exactly the state that
broke the reference deployment**, and collapsing these into one "reachable"
boolean would hide it the same way the original defect did. The interesting
combinations each render distinctly:

- `advertised, !serviceable` → "advertised, not responding" — clients will
  choose this and get nothing;
- `!advertised, serviceable` → "supported, not advertised" — normal
  mid-rollout, nothing routes to it yet;
- empty array → **unknown** (the community's own DID did not resolve), never
  "offers nothing".

## Design decisions worth reviewing

**The DID document stays authoritative.** This is a *view* of it, resolved at
request time, published so connectivity can be validated without resolving the
DID by hand — never a second source of truth. A client selecting a transport
still matches on the document's service `type` (CLAUDE.md D9). If the two ever
disagree, the document wins and this field is what is wrong. Said in the type
docs, the route docs, and the operator guide, because it is the one way this
feature could do harm.

**Resolved, not read from config or the local mirror.** A document can gain a
service long after the VTC last wrote its own `did.jsonl` — which is precisely
what happened here (`#tsp` arrived at DID log version 3, post-mint). The
resolver caches, so the common case costs no network despite the endpoint being
unauthenticated.

**`serviceable` is re-falsifiable (R6.2).** Off `MessagingService::status()` —
the same source `/health/diagnostics` uses — so a dropped mediator connection
flips it back. A published "reachable" that could never go false again would be
worse than publishing nothing.

**Endpoint, not page.** Operators replace the public website
(`website.root_dir`), so a landing-page-only change would vanish for exactly the
real deployments worth checking. The endpoint survives, is machine-readable for
CI and monitoring, and any custom site can render it. `website-default` renders
it from the fetch it already makes — no extra request.

## Disclosure

Nothing here is new information. `advertised` and `endpoint` come straight out
of the DID document, which anyone can resolve; `serviceable` is discoverable by
simply attempting the transport.

Deliberately **excluded**: build feature flags, version strings, and the
operator-facing remediation text from `transport_capability::Finding` — that
text names `--features tsp` and rebuild commands on purpose, for `vtc status`
and the daemon log, and must not ride out on an unauthenticated endpoint.
Pinned by tests at both layers (`the_public_view_leaks_no_build_detail` on the
wire type, `public_profile_leaks_no_build_configuration` on the route).

## Verification

- `transport_capability` 22/22 — including the new view tests: preference
  ordering, all four advertised×serviceable combinations, mediator-loss
  flipping messaging unserviceable while REST stays true, camelCase wire shape
  (R3.1), and the no-leak assertion
- `community_profile` 17/17 — including unknown-vs-none and the route-level
  no-leak check
- `join_tsp` 3/3 — the new `the_public_profile_publishes_a_usable_connectivity_view`
  drives the endpoint against a **real running VTC** whose DID actually resolves
  to a document advertising both transports, so the populated view is proven
  end to end rather than only in unit tests
- `cargo test -p vtc-service --lib` 727 pass (the 4 `admin_ui` failures are the
  known `VTC_SKIP_ADMIN_UI_BUILD=1` empty-embedded-dir artifact; CI builds the UI)
- clippy + fmt clean; `--no-default-features` builds; `node --check` on the page JS
- OpenAPI tests green — utoipa resolves the nested schema, no registration needed
- both release guards pass (0.11.56 → 0.11.57)
