### PR TITLE
feat(consent): canonical request bodies, and witnesses built from them

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2922,7 +2922,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c54e03a951783e8b327515db3f2a2fd0e3bed362a96b066f341ce66ed49b4ead"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4587,7 +4587,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -6453,7 +6453,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.43",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "thiserror 2.0.20",
  "tokio",
  "tracing",
@@ -6492,7 +6492,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -9383,7 +9383,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.21.16"
+version = "0.21.17"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -9446,7 +9446,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.14.29"
+version = "0.14.30"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/changelog.d/928-consent-canonical-bodies.md
+++ b/changelog.d/928-consent-canonical-bodies.md
@@ -1,0 +1,37 @@
+### vta-sdk 0.21.17 / vta-service 0.14.30 — the #888 fold reaches `consent/*` (#928)
+
+Same shape as #925, applied to the last family that had unset optional members
+going out through an inline `json!` plus a conditional insert each.
+
+New `protocols::consent_management` carries canonical bodies for request,
+decision, revoke, list, approver-set and approver-list, each with
+`skip_serializing_if` on its optionals. The null census then sees them — it
+walks structs under `protocols/` and an inline map is invisible to it — and the
+six witnesses are built from the producer's body rather than transcribed.
+
+**Teeth checked, not assumed.** Reverting the skips on `ConsentRequestBody` and
+`ConsentListBody` fails the sweep with `null is not of type "string"`. The old
+fixtures set those members, so they could not have caught it.
+
+The witnesses are minimal on purpose: `consent/list` and `consent/approver-list`
+are now bare `{}` (the unfiltered call), and request sets neither hint. A
+witness that fills every member leaves nothing unset, which is exactly where
+this defect class lives.
+
+**The count was wrong, and is now measured.** #925's note said 21 witnesses
+still transcribed; the real figure was 20 — arithmetic rather than a count. The
+module now states **14**, counted from the table, and more usefully splits them
+into three situations of which only one is unfinished work:
+
+- **5** (`auth/*`, `task-consent/decision`) — the VTA is the consumer; no
+  producer of ours sends these, so a fixture is the honest witness and nothing
+  is owed.
+- **8** (`vault/*`, `device/list`) — the caller supplies the whole payload as a
+  `Value`; the SDK is a pass-through. An API decision, not a test change.
+- **1** (`messaging/ping`) — a producer exists, but the payload is a single
+  required `nonce`. A body struct would guard nothing today: this defect class
+  lives in *unset optional* members and ping has none. Worth folding the day it
+  gains a second member, not before.
+
+So the fold is complete for every family that could exhibit the defect. What is
+left is one design question and a handful of witnesses that are already correct.

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.21.16"
+version = "0.21.17"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/client/consent.rs
+++ b/vta-sdk/src/client/consent.rs
@@ -9,10 +9,14 @@
 //! object; `conversationRef` is the bridge's OPAQUE handle — never a raw
 //! platform address.
 
-use serde_json::{Value, json};
+use serde_json::Value;
 
 use super::VtaClient;
 use crate::error::VtaError;
+use crate::protocols::consent_management::{
+    ConsentApproverListBody, ConsentApproverSetBody, ConsentDecisionBody, ConsentListBody,
+    ConsentRequestBody, ConsentRevokeBody,
+};
 use crate::trust_tasks;
 
 /// Round-trip timeout (seconds) for consent trust tasks.
@@ -31,17 +35,13 @@ impl VtaClient {
         display_hint: Option<&str>,
         context_hint: Option<&str>,
     ) -> Result<Value, VtaError> {
-        let mut payload = json!({
-            "subject": subject,
-            "scope": scope,
-            "challenge": challenge,
-        });
-        if let Some(h) = display_hint {
-            payload["displayHint"] = json!(h);
-        }
-        if let Some(c) = context_hint {
-            payload["contextHint"] = json!(c);
-        }
+        let payload = serde_json::to_value(ConsentRequestBody {
+            subject,
+            scope: scope.to_string(),
+            challenge: challenge.to_string(),
+            display_hint: display_hint.map(str::to_string),
+            context_hint: context_hint.map(str::to_string),
+        })?;
         self.dispatch_trust_task(
             trust_tasks::TASK_CONSENT_REQUEST_1_0,
             payload,
@@ -62,19 +62,13 @@ impl VtaClient {
         challenge: Option<&str>,
         expires_at: Option<&str>,
     ) -> Result<Value, VtaError> {
-        let mut payload = json!({
-            "subject": subject,
-            "effect": effect,
-        });
-        if let Some(s) = scope {
-            payload["scope"] = json!(s);
-        }
-        if let Some(c) = challenge {
-            payload["challenge"] = json!(c);
-        }
-        if let Some(e) = expires_at {
-            payload["expiresAt"] = json!(e);
-        }
+        let payload = serde_json::to_value(ConsentDecisionBody {
+            subject,
+            effect: effect.to_string(),
+            scope: scope.map(str::to_string),
+            challenge: challenge.map(str::to_string),
+            expires_at: expires_at.map(str::to_string),
+        })?;
         self.dispatch_trust_task(
             trust_tasks::TASK_CONSENT_DECISION_1_0,
             payload,
@@ -89,10 +83,10 @@ impl VtaClient {
         subject: Value,
         reason: Option<&str>,
     ) -> Result<Value, VtaError> {
-        let mut payload = json!({ "subject": subject });
-        if let Some(r) = reason {
-            payload["reason"] = json!(r);
-        }
+        let payload = serde_json::to_value(ConsentRevokeBody {
+            subject,
+            reason: reason.map(str::to_string),
+        })?;
         self.dispatch_trust_task(
             trust_tasks::TASK_CONSENT_REVOKE_1_0,
             payload,
@@ -109,16 +103,11 @@ impl VtaClient {
         platform: Option<&str>,
         subject: Option<Value>,
     ) -> Result<Value, VtaError> {
-        let mut payload = json!({});
-        if let Some(a) = agent {
-            payload["agent"] = json!(a);
-        }
-        if let Some(p) = platform {
-            payload["platform"] = json!(p);
-        }
-        if let Some(s) = subject {
-            payload["subject"] = s;
-        }
+        let payload = serde_json::to_value(ConsentListBody {
+            agent: agent.map(str::to_string),
+            platform: platform.map(str::to_string),
+            subject,
+        })?;
         self.dispatch_trust_task(
             trust_tasks::TASK_CONSENT_LIST_1_0,
             payload,
@@ -138,17 +127,13 @@ impl VtaClient {
         route: Option<&str>,
         route_hint: Option<&str>,
     ) -> Result<Value, VtaError> {
-        let mut payload = json!({
-            "platform": platform,
-            "context": context,
-            "approver": approver,
-        });
-        if let Some(r) = route {
-            payload["route"] = json!(r);
-        }
-        if let Some(h) = route_hint {
-            payload["routeHint"] = json!(h);
-        }
+        let payload = serde_json::to_value(ConsentApproverSetBody {
+            platform: platform.to_string(),
+            context: context.to_string(),
+            approver: approver.to_string(),
+            route: route.map(str::to_string),
+            route_hint: route_hint.map(str::to_string),
+        })?;
         self.dispatch_trust_task(
             trust_tasks::TASK_CONSENT_APPROVER_SET_1_0,
             payload,
@@ -164,13 +149,10 @@ impl VtaClient {
         platform: Option<&str>,
         context: Option<&str>,
     ) -> Result<Value, VtaError> {
-        let mut payload = json!({});
-        if let Some(p) = platform {
-            payload["platform"] = json!(p);
-        }
-        if let Some(c) = context {
-            payload["context"] = json!(c);
-        }
+        let payload = serde_json::to_value(ConsentApproverListBody {
+            platform: platform.map(str::to_string),
+            context: context.map(str::to_string),
+        })?;
         self.dispatch_trust_task(
             trust_tasks::TASK_CONSENT_APPROVER_LIST_1_0,
             payload,

--- a/vta-sdk/src/protocols/consent_management.rs
+++ b/vta-sdk/src/protocols/consent_management.rs
@@ -1,0 +1,154 @@
+//! Canonical `consent/*` request bodies.
+//!
+//! The #888 fold, applied to the family `device/*` went through in #925. Same
+//! reasoning, restated because it is the whole point: these methods built their
+//! payloads as an inline `json!` plus a conditional insert per optional member,
+//! which keeps `null` off the wire correctly but leaves the invariant living in
+//! the shape of an `if let`. Nothing checks that — `vta-sdk`'s null census walks
+//! structs under `protocols/`, and an inline map is invisible to it — and a
+//! conformance witness has no type to point at, so it hand-writes the JSON and
+//! stops tracking the producer.
+//!
+//! Members mirror `consent/*/1.0`. `subject` stays a `Value`: `ConsentSubject`
+//! is a four-member object the caller already assembles, and modelling it is an
+//! API change rather than a fold. `scope`, `effect` and `route` are schema
+//! enums carried as `String` for the same reason — the producers take `&str`
+//! today, and narrowing that is a separate, caller-visible decision.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// `consent/request/1.0` — ask whether an inbound conversation may reach an agent.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConsentRequestBody {
+    pub subject: Value,
+    /// `receive` | `converse`.
+    pub scope: String,
+    /// base64url nonce, `minLength` 16 — echoed by the matching decision.
+    pub challenge: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub display_hint: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_hint: Option<String>,
+}
+
+/// `consent/decision/1.0` — the operator's answer.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConsentDecisionBody {
+    pub subject: Value,
+    /// The decision itself (`allow` / `deny` per the spec's `Effect`).
+    pub effect: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scope: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub challenge: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<String>,
+}
+
+/// `consent/revoke/1.0` — withdraw a previously granted consent.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConsentRevokeBody {
+    pub subject: Value,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+/// `consent/list/1.0` — enumerate consents, optionally filtered.
+///
+/// Every member is optional: an unfiltered list is the common call and must
+/// serialize to `{}`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConsentListBody {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub platform: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subject: Option<Value>,
+}
+
+/// `consent/approver-set/1.0` — nominate the approver for a platform+context.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConsentApproverSetBody {
+    pub platform: String,
+    pub context: String,
+    pub approver: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub route: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub route_hint: Option<String>,
+}
+
+/// `consent/approver-list/1.0` — list configured approvers, optionally filtered.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConsentApproverListBody {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub platform: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The property the fold makes enforceable: an unfiltered list is `{}`,
+    /// not a map of nulls. The inline builders got this right by construction;
+    /// nothing checked it, and `keys/create` is what that costs when someone
+    /// later reaches for a struct instead (#919).
+    #[test]
+    fn unfiltered_list_bodies_are_empty_objects() {
+        assert_eq!(
+            serde_json::to_value(ConsentListBody::default()).expect("serialises"),
+            serde_json::json!({})
+        );
+        assert_eq!(
+            serde_json::to_value(ConsentApproverListBody::default()).expect("serialises"),
+            serde_json::json!({})
+        );
+    }
+
+    /// A request with neither hint carries neither member — the shape
+    /// `consent_request(subject, scope, challenge, None, None)` emits.
+    #[test]
+    fn an_unset_hint_is_absent_from_a_request() {
+        let body = ConsentRequestBody {
+            subject: serde_json::json!({
+                "platform": "signal",
+                "conversationRef": "sig-1a2b3c4d",
+                "kind": "dm",
+                "agent": "did:key:z6MkAgent",
+            }),
+            scope: "converse".into(),
+            challenge: "Y2hhbGxlbmdlLW5vbmNlLTEyOA".into(),
+            display_hint: None,
+            context_hint: None,
+        };
+        let v = serde_json::to_value(&body).expect("serialises");
+        assert!(v.get("displayHint").is_none());
+        assert!(v.get("contextHint").is_none());
+        assert_eq!(v.as_object().expect("object").len(), 3);
+    }
+
+    /// Set members reach the wire under their canonical camelCase names — the
+    /// skip must not be reachable for `Some`.
+    #[test]
+    fn set_members_serialise_camel_case() {
+        let body = ConsentApproverSetBody {
+            platform: "signal".into(),
+            context: "openvtc".into(),
+            approver: "did:key:z6MkApprover".into(),
+            route: Some("push".into()),
+            route_hint: Some("apns".into()),
+        };
+        let v = serde_json::to_value(&body).expect("serialises");
+        assert_eq!(v.get("routeHint").and_then(Value::as_str), Some("apns"));
+    }
+}

--- a/vta-sdk/src/protocols/mod.rs
+++ b/vta-sdk/src/protocols/mod.rs
@@ -3,10 +3,11 @@ pub mod attestation_management;
 pub mod audit_management;
 pub mod auth;
 pub mod backup_management;
-pub mod context_management;
-pub mod credential_exchange;
 /// Issued-credential lifecycle (`spec/vta/credentials/{issue,revoke}/0.1`) —
 /// mint + revoke a VTA-signed W3C VC addressed to a holder DID.
+pub mod consent_management;
+pub mod context_management;
+pub mod credential_exchange;
 pub mod credentials_issuance;
 pub mod device_management;
 pub mod did_management;

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.14.29"
+version = "0.14.30"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/trust_tasks/conformance.rs
+++ b/vta-service/src/trust_tasks/conformance.rs
@@ -82,6 +82,10 @@ use vta_sdk::protocols::audit_management::list::{
     AuditEnvelope, ListAuditLogsBody, ListAuditLogsResultBody,
 };
 use vta_sdk::protocols::auth::{RevokeSessionRequest, RevokeSessionResponse};
+use vta_sdk::protocols::consent_management::{
+    ConsentApproverListBody, ConsentApproverSetBody, ConsentDecisionBody, ConsentListBody,
+    ConsentRequestBody, ConsentRevokeBody,
+};
 use vta_sdk::protocols::credential_exchange::{
     self as credx, PendingApproveBody, PendingDenyBody, PendingDenyResponse, PendingListResponse,
     PendingPresentationSummary, PresentBody, RequestedCredentialSummary,
@@ -172,31 +176,27 @@ fn validates<T: ValidatedPayload>(v: &Value) -> Result<(), String> {
 ///
 /// ## Where a transcription remains, and why
 ///
-/// 21 of these witnesses still build their request with `json!`. The reason is
-/// **not** the one this comment used to give ("the slice's wire type is
-/// module-private") — most of them name a `vta-sdk` client method that exists
-/// today. The accurate position, per family:
+/// **14** of these witnesses still build their request with `json!`, and the
+/// count is not the useful framing — what remains is three distinct situations,
+/// only one of which is unfinished work. (The previous note said 21; it was
+/// arithmetic, not measurement. The number above is counted from the table.)
 ///
 /// - **`auth/{whoami,sessions-list,step-up/approve-response}`,
 ///   `task-consent/decision`** (5) — the VTA is the *consumer*; no `vta-sdk`
 ///   producer sends these, so there is no emission of ours to assert. A fixture
-///   is the honest witness here, and no further work is owed.
-/// - **`consent/*` (6), `messaging/ping`** (7 total) — a producer exists, but
-///   it builds its payload as an inline `json!` with a conditional insert per
-///   optional member. There is no type to point a witness at. Converting these
-///   means first giving those producers canonical body structs — the #888 fold,
-///   applied to the families it did not reach — and only then can a witness be
-///   built rather than transcribed. `device/*` went this way in #925 and is the
-///   worked example.
-/// - **`vault/*` (7), `device/list`** (8 total) — these take a caller-supplied
-///   `Value`; the SDK is a pass-through that contributes at most one member.
-///   There is no SDK type at all, and inventing one is an API change, not a
-///   test change.
+///   is the honest witness, and **nothing is owed here**.
+/// - **`vault/*` (7), `device/list`** (8) — the caller supplies the whole
+///   payload as a `Value` and the SDK is a pass-through contributing at most one
+///   member. There is no SDK type, and giving them one is an **API decision**,
+///   not a test change.
+/// - **`messaging/ping`** (1) — a producer exists, but its payload is a single
+///   required `nonce`. A body struct would guard nothing today: this defect
+///   class lives in *unset optional* members, and ping has none. Worth folding
+///   the day it gains a second member, not before.
 ///
-/// So the remaining work is one producer fold (consent + ping) plus an API
-/// decision (the pass-throughs), with five entries that are correct as they
-/// stand. Recorded here rather than in an issue because the next person to read
-/// this comment is the one who needs it.
+/// The families that did have unset optionals — `keys/*` (#888), `webvh` (#924),
+/// `device/*` (#925), `consent/*` (#928) — are folded, and their witnesses are
+/// built from the producer's own body rather than transcribed.
 struct Witness {
     request: Value,
     parse_request: ParseFn,
@@ -509,11 +509,15 @@ fn table() -> Vec<(&'static str, Conformance)> {
             checked!(
                 specs::consent::request::v1_0::Payload,
                 specs::consent::request::v1_0::Response,
-                json!({
-                    "subject": consent_subject_json(),
-                    "scope": "converse",
-                    "challenge": "chal-0123456789abcdef",
-                    "contextHint": "ctx-a",
+                // Neither hint set — the shape
+                // `consent_request(subject, scope, challenge, None, None)`
+                // emits, and the one that leaves both optionals to the skip.
+                to_v(ConsentRequestBody {
+                    subject: consent_subject_json(),
+                    scope: "converse".into(),
+                    challenge: "chal-0123456789abcdef".into(),
+                    display_hint: None,
+                    context_hint: None,
                 }),
                 json!({ "status": "accepted", "requestId": "chal-1" })
             ),
@@ -523,12 +527,12 @@ fn table() -> Vec<(&'static str, Conformance)> {
             checked!(
                 specs::consent::decision::v1_0::Payload,
                 specs::consent::decision::v1_0::Response,
-                json!({
-                    "subject": consent_subject_json(),
-                    "effect": "allow",
-                    "scope": "converse",
-                    "challenge": "chal-0123456789abcdef",
-                    "expiresAt": TS,
+                to_v(ConsentDecisionBody {
+                    subject: consent_subject_json(),
+                    effect: "allow".into(),
+                    scope: Some("converse".into()),
+                    challenge: Some("chal-0123456789abcdef".into()),
+                    expires_at: None,
                 }),
                 json!({ "status": "recorded", "grantId": "urn:uuid:6d9c" })
             ),
@@ -538,7 +542,10 @@ fn table() -> Vec<(&'static str, Conformance)> {
             checked!(
                 specs::consent::revoke::v1_0::Payload,
                 specs::consent::revoke::v1_0::Response,
-                json!({ "subject": consent_subject_json(), "reason": "operator revoked" }),
+                to_v(ConsentRevokeBody {
+                    subject: consent_subject_json(),
+                    reason: None,
+                }),
                 json!({ "status": "revoked" })
             ),
         ),
@@ -547,7 +554,9 @@ fn table() -> Vec<(&'static str, Conformance)> {
             checked!(
                 specs::consent::list::v1_0::Payload,
                 specs::consent::list::v1_0::Response,
-                json!({ "platform": "slack", "agent": "agent-1" }),
+                // An unfiltered list — every member unset, which must
+                // serialize to `{}` rather than a map of nulls.
+                to_v(ConsentListBody::default()),
                 json!({ "grants": [{
                     "subject": consent_subject_json(),
                     "effect": "allow",
@@ -564,12 +573,12 @@ fn table() -> Vec<(&'static str, Conformance)> {
             checked!(
                 specs::consent::approver_set::v1_0::Payload,
                 specs::consent::approver_set::v1_0::Response,
-                json!({
-                    "platform": "slack",
-                    "context": "ctx-a",
-                    "approver": "did:key:z6MkKeeper",
-                    "route": "wake",
-                    "routeHint": "gateway-1",
+                to_v(ConsentApproverSetBody {
+                    platform: "slack".into(),
+                    context: "ctx-a".into(),
+                    approver: "did:key:z6MkKeeper".into(),
+                    route: Some("wake".into()),
+                    route_hint: None,
                 }),
                 json!({ "status": "set" })
             ),
@@ -579,7 +588,7 @@ fn table() -> Vec<(&'static str, Conformance)> {
             checked!(
                 specs::consent::approver_list::v1_0::Payload,
                 specs::consent::approver_list::v1_0::Response,
-                json!({ "platform": "slack" }),
+                to_v(ConsentApproverListBody::default()),
                 json!({ "approvers": [{
                     "platform": "slack",
                     "context": "ctx-a",


### PR DESCRIPTION
Same shape as #925, applied to the last family that had unset optional members going out through an inline `json!` plus a conditional insert each.

## What this does

New `protocols::consent_management` with canonical bodies for **request, decision, revoke, list, approver-set, approver-list**, each carrying `skip_serializing_if` on its optionals. All six producers rewired; all six witnesses now built from the producer's body rather than transcribed.

The two properties that matter both follow: the null census (#921) can finally *see* these payloads — it walks structs under `protocols/`, and an inline map is invisible to it — and the witnesses track the producer instead of a hand-typed copy.

## Teeth checked, not assumed

Reverting the skips on `ConsentRequestBody` and `ConsentListBody` fails the sweep:

```text
consent/request/1.0: request fails its own payload schema:
payload failed schema validation: null is not of type "string"
```

The old fixtures set those members, so they could not have caught it.

The witnesses are minimal on purpose: `consent/list` and `consent/approver-list` are now bare `{}` (the unfiltered call), and request sets neither hint. **A witness that fills every member leaves nothing unset, which is exactly where this defect class lives** — the trap that made #924's first conversion pass vacuously.

## The count was wrong, and is now measured

#925's note said 21 witnesses still transcribed. The real figure was **20** — that was arithmetic, not a count. The module now states **14**, counted from the table, and splits them into three situations of which only one is unfinished work:

| | N | Status |
|---|---|---|
| `auth/*`, `task-consent/decision` | 5 | VTA is the **consumer** — a fixture is the honest witness. **Nothing owed.** |
| `vault/*`, `device/list` | 8 | Caller supplies the whole payload as a `Value`; SDK is a pass-through. **API decision**, not a test change. |
| `messaging/ping` | 1 | Producer exists, but the payload is a single required `nonce`. A body struct would **guard nothing today** — this defect class lives in *unset optional* members, and ping has none. Worth folding the day it gains a second member. |

Correcting my own miscount is part of the point of this series: a coverage claim nobody measures is how `keys/create` shipped.

## So the fold is done

Every family that could exhibit the defect — `keys/*` (#888), `webvh` (#924), `device/*` (#925), `consent/*` (here) — is folded, with witnesses built from the producer. What remains is one design question (should the pass-through surface stay untyped?) and a handful of witnesses that are already correct.

## Verification

- `cargo test -p vta-service --lib` — 787 passed
- `cargo test -p vta-sdk` — green, null census included
- `cargo clippy -p vta-sdk -p vta-service --all-targets` — clean
- `cargo +1.95.0 check --workspace --locked` — green **against the committed tree**, `git status` clean afterwards (the #924 CI failure was a stale committed `Cargo.lock` while local runs silently fixed the working tree)
