### PR TITLE
feat(vtc-service): choose a community's transports at setup, when it is still possible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9383,7 +9383,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.21.17"
+version = "0.21.18"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -9681,7 +9681,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-service"
-version = "0.11.57"
+version = "0.11.58"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/changelog.d/929-vtc-setup-chooses-transports.md
+++ b/changelog.d/929-vtc-setup-chooses-transports.md
@@ -1,0 +1,57 @@
+### vtc-service 0.11.58 / vta-sdk 0.21.18 — choose a community's transports at setup, when it is still possible (#929)
+
+`vtc setup` asked which mediator to route through, wrote it to `config.toml`, and
+never advertised it. The `vtc-host` template minted `#vtc-rest` and
+`#vtc-status-list` and no messaging service at all — so a VTC connected outbound
+to a mediator while its DID document told nobody, and DIDComm only worked when
+the sender had been handed the mediator out of band.
+
+That is also why the reference deployment acquired its `#tsp` entry at DID log
+version 3, published by hand long after mint — the state that led to #923 and
+#926.
+
+**Setup is the only clean moment to fix this.** A VTC serves a write-once
+`did.jsonl` and cannot re-sign its own log, so adding a service afterwards means
+a VTA-side `dids edit` plus redelivering the log by hand. So the decision moves
+to provisioning, where the document is being minted anyway.
+
+**Interactive** — after the mediator choice, a multi-select with both transports
+pre-ticked (the §12 Phase A shape, which strands nobody). It states that both
+entries point at the operator's mediator, warns that advertising one the mediator
+does not route makes the community unreachable on it, notes the choice is fixed
+at mint, and echoes back what will be advertised. Deselecting everything re-asks
+rather than minting a community that connects to a mediator and advertises no way
+in.
+
+**Non-interactive** — `transports` is **required** in `[messaging]`:
+
+```toml
+[messaging]
+mediator_did = "did:web:mediator.example.com"
+transports   = ["tsp", "didcomm"]
+```
+
+Required rather than defaulted: it decides whether anyone can reach the
+community, it cannot be changed after mint, and any default would be a guess
+about someone else's mediator. `transports = []` is refused by name with the
+REST-only alternative spelled out, and duplicates are refused (they would render
+the same service entry twice). **Existing setup files that omit `[messaging]`
+entirely are unaffected** — a REST-only community stays valid.
+
+Deliberately no capability detection. Nothing here can verify that the named
+mediator actually routes the protocol being advertised; its services belong to
+its own controller (§14 Q3). The operator is told that plainly rather than having
+it guessed for them.
+
+`vta-sdk`: new `did_templates::{tsp_service, didcomm_service}` build the service
+entries, and `vtc-host` gains `SERVICE_TSP` / `SERVICE_DIDCOMM` null-pruning
+slots — the same mechanism `SERVICE_TRUST_REGISTRY` uses, and the only conditional
+the template format has. Both entries name the *same* mediator DID (§14 Q2), and
+the emitted service order is canonical (TSP, DIDComm, then REST) because array
+order is what encodes transport preference to a resolver. A URL endpoint is
+refused: the sender's routing layer reads this value as a DID to resolve onward,
+so a URL is unroutable rather than merely unconventional.
+
+Closes the loop with #923 (a build cannot advertise what it can't serve) and #926
+(the public transport view) — a community can now *say* how to reach it, and
+everything downstream already checks that the saying is true.

--- a/docs/03-vtc/examples/vtc-setup.example.toml
+++ b/docs/03-vtc/examples/vtc-setup.example.toml
@@ -54,13 +54,34 @@ context = "default"   # the VTA context this community provisions under
 # domain    = "tenant.example.com"     # tenant domain on a multi-domain host
 # path      = "communities/acme"       # path in did:webvh:<scid>:<host>:<path>
 
-# ── DIDComm messaging (optional) ────────────────────────────────────────
-# Omit for no messaging — the daemon stays healthy on REST and logs a
-# one-line "messaging not configured" warning at startup. When present,
-# `mediator_did` is required; the endpoint is resolved from its DID
-# document, so `mediator_url` is informational only.
+# ── Messaging (optional) ────────────────────────────────────────────────
+# Omit the whole table for no messaging — the daemon stays healthy on REST
+# and logs a one-line "messaging not configured" warning at startup.
+#
+# When present, `mediator_did` and `transports` are both REQUIRED;
+# `mediator_url` is informational (the endpoint is resolved from the
+# mediator's DID document).
+#
+# `transports` decides what this community's DID document advertises, and
+# therefore how anyone reaches it. Every entry points at `mediator_did` —
+# TSP and DIDComm share one dual-protocol mediator.
+#
+#   ["tsp", "didcomm"]  both. The recommended shape: clients prefer TSP,
+#                       and peers that don't speak it fall back to DIDComm.
+#   ["didcomm"]         mediator routes DIDComm only.
+#   ["tsp"]             TSP only — strands every peer that can't speak it.
+#
+# ⚠ Advertising a transport your mediator does not route makes this
+#   community unreachable on it: conforming clients prefer it and fail.
+#   Confirm your mediator advertises the matching service first — nothing
+#   here can check it for you.
+#
+# ⚠ Fixed at mint. The VTC serves a write-once did.jsonl and cannot re-sign
+#   its own log, so changing this later needs a VTA-side `dids edit` plus
+#   redelivering the log by hand.
 # [messaging]
 # mediator_did = "did:web:mediator.example.com"
+# transports   = ["tsp", "didcomm"]
 # mediator_url = "https://mediator.example.com"
 
 # ── Secret-store backend (required) ─────────────────────────────────────

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.21.17"
+version = "0.21.18"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/did_templates/mod.rs
+++ b/vta-sdk/src/did_templates/mod.rs
@@ -40,6 +40,7 @@
 
 mod builtin;
 mod render;
+mod transports;
 mod trust_registry;
 mod validate;
 
@@ -54,6 +55,7 @@ use serde_json::Value;
 use thiserror::Error;
 
 pub use builtin::{BUILTIN_NAMES, load_embedded};
+pub use transports::{DIDCOMM_SERVICE_VAR, TSP_SERVICE_VAR, didcomm_service, tsp_service};
 pub use trust_registry::{
     TRQP_PROFILE_URI, TRUST_REGISTRY_SERVICE_TYPE, TRUST_REGISTRY_SERVICE_VAR, referral_service,
 };

--- a/vta-sdk/src/did_templates/tests.rs
+++ b/vta-sdk/src/did_templates/tests.rs
@@ -956,6 +956,127 @@ fn vtc_host_omits_the_referral_when_no_registry_is_named() {
     );
 }
 
+// ─── vtc-host messaging transports ───────────────────────────────────
+
+const MEDIATOR: &str = "did:webvh:QmTS3:webvh.example.com:mediator";
+
+/// The shape §12 Phase A asks for: both transports advertised, both naming the
+/// same mediator, ahead of REST in the array.
+///
+/// Order is not cosmetic — CLAUDE.md §3.3 encodes transport preference as array
+/// order (TSP > DIDComm > REST), so a DID-Core resolver walking `service` picks
+/// the highest-preference transport first. Rendering REST ahead of the
+/// messaging entries would quietly demote them for every conforming client.
+#[test]
+fn vtc_host_advertises_both_transports_in_canonical_order() {
+    let tpl = load_embedded("vtc-host").unwrap();
+    let mut vars = ambient_vars();
+    vars.insert_string("KA_KEY_MB", "z6LSKeyAgreement");
+    vars.insert_string("URL", "https://vtc.example.com");
+    vars.insert(TSP_SERVICE_VAR, tsp_service(MEDIATOR).unwrap());
+    vars.insert(DIDCOMM_SERVICE_VAR, didcomm_service(MEDIATOR).unwrap());
+
+    let out = tpl.render(&vars).unwrap();
+    let services = out["service"].as_array().unwrap();
+
+    assert_eq!(services.len(), 4, "tsp + didcomm + rest + status-list");
+    assert_eq!(
+        services
+            .iter()
+            .map(|s| s["type"].as_str().unwrap())
+            .collect::<Vec<_>>(),
+        vec![
+            "TSPTransport",
+            "DIDCommMessaging",
+            "VTCRest",
+            "VTCStatusList"
+        ],
+    );
+
+    // Both messaging entries carry the *same* mediator DID (§14 Q2) — one
+    // dual-protocol mediator advertised twice, never two endpoints.
+    assert_eq!(services[0]["serviceEndpoint"], MEDIATOR);
+    assert_eq!(services[1]["serviceEndpoint"], MEDIATOR);
+    assert_eq!(services[0]["id"], "{DID}#tsp");
+    assert_eq!(services[1]["id"], "{DID}#didcomm");
+}
+
+/// DIDComm alone — the shape for a community whose mediator does not route
+/// TSP. The TSP slot prunes, leaving no null and no half-built entry.
+#[test]
+fn vtc_host_advertises_didcomm_alone_when_tsp_is_not_selected() {
+    let tpl = load_embedded("vtc-host").unwrap();
+    let mut vars = ambient_vars();
+    vars.insert_string("KA_KEY_MB", "z6LSKeyAgreement");
+    vars.insert_string("URL", "https://vtc.example.com");
+    vars.insert(DIDCOMM_SERVICE_VAR, didcomm_service(MEDIATOR).unwrap());
+
+    let out = tpl.render(&vars).unwrap();
+    let services = out["service"].as_array().unwrap();
+
+    assert_eq!(services.len(), 3);
+    assert_eq!(services[0]["type"], "DIDCommMessaging");
+    assert!(
+        !services.iter().any(|s| s["type"] == "TSPTransport"),
+        "the unselected TSP slot must prune entirely: {services:#?}"
+    );
+}
+
+/// The pre-existing shape has to keep rendering unchanged: a community that
+/// skips messaging advertises REST + status-list and nothing else. This is the
+/// regression guard for every VTC provisioned before transports were
+/// selectable.
+#[test]
+fn vtc_host_advertises_no_messaging_when_neither_transport_is_selected() {
+    let tpl = load_embedded("vtc-host").unwrap();
+    let mut vars = ambient_vars();
+    vars.insert_string("KA_KEY_MB", "z6LSKeyAgreement");
+    vars.insert_string("URL", "https://vtc.example.com");
+
+    let out = tpl.render(&vars).unwrap();
+    let services = out["service"].as_array().unwrap();
+
+    assert_eq!(services.len(), 2);
+    assert_eq!(services[0]["type"], "VTCRest");
+    assert_eq!(services[1]["type"], "VTCStatusList");
+    assert!(
+        !services.iter().any(|s| s.is_null()),
+        "a pruned slot must vanish, not render as null: {services:#?}"
+    );
+}
+
+/// Transports and the registry referral prune independently — three optional
+/// slots in one array, and selecting some must not disturb the others.
+#[test]
+fn transport_and_registry_slots_prune_independently() {
+    let tpl = load_embedded("vtc-host").unwrap();
+    let mut vars = ambient_vars();
+    vars.insert_string("KA_KEY_MB", "z6LSKeyAgreement");
+    vars.insert_string("URL", "https://vtc.example.com");
+    vars.insert(TSP_SERVICE_VAR, tsp_service(MEDIATOR).unwrap());
+    vars.insert(
+        TRUST_REGISTRY_SERVICE_VAR,
+        referral_service("did:webvh:xyz:registry.example.com").unwrap(),
+    );
+
+    let out = tpl.render(&vars).unwrap();
+    let types: Vec<&str> = out["service"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|s| s["type"].as_str().unwrap())
+        .collect();
+    assert_eq!(
+        types,
+        vec![
+            "TSPTransport",
+            "VTCRest",
+            "VTCStatusList",
+            TRUST_REGISTRY_SERVICE_TYPE
+        ],
+    );
+}
+
 #[test]
 fn vtc_host_status_list_path_override() {
     let tpl = load_embedded("vtc-host").unwrap();

--- a/vta-sdk/src/did_templates/transports.rs
+++ b/vta-sdk/src/did_templates/transports.rs
@@ -1,0 +1,201 @@
+//! The messaging-transport entries a community publishes in its DID document.
+//!
+//! A DID document is how a party says *how to reach it*. Until now the
+//! `vtc-host` template published none: a VTC connected outbound to a mediator
+//! and its document told nobody, so a conforming client resolving the community
+//! found no messaging transport at all and DIDComm only worked when the sender
+//! had been handed the mediator out of band.
+//!
+//! ## Why this has to happen at mint
+//!
+//! A VTC serves a **write-once** `did.jsonl` and cannot re-sign its own log, so
+//! adding a service afterwards means a VTA-side `dids edit` plus redelivering
+//! the log by hand. That is exactly how the reference deployment acquired its
+//! `#tsp` entry at DID log version 3 — out of band, long after mint, and with
+//! nothing checking that the binary could serve it. Provisioning is the only
+//! moment the community's own setup gets to decide this, so the decision is
+//! taken there and rendered into the document it is minting.
+//!
+//! ## Both entries name the mediator, not a URL
+//!
+//! TSP and DIDComm use the same indirection: the `serviceEndpoint` is the
+//! **mediator's DID**, and the transport URL lives in the mediator's own
+//! document. They also bind the *same* mediator — one dual-protocol mediator
+//! serves both (`docs/05-design-notes/tsp-enablement.md` §14 Q2), so a
+//! community advertising both publishes one mediator DID twice under two
+//! service types.
+//!
+//! ## Advertising is a promise about the mediator, too
+//!
+//! Managing a mediator's own service entries belongs to the mediator's
+//! controller (§14 Q3), so nothing here can confirm the named mediator
+//! actually routes the protocol being advertised. Advertising `#tsp` against a
+//! mediator that does not route TSP produces a service entry clients will
+//! choose and cannot use — the same shape of failure as advertising a
+//! transport the binary cannot serve. The operator makes that call at setup;
+//! `vtc-service` warns at the prompt.
+
+use serde_json::{Value, json};
+
+use crate::protocol::matching::{DIDCOMM_SERVICE_TYPE, TSP_SERVICE_TYPE};
+
+use super::TemplateError;
+
+/// Template variable carrying the whole `DIDCommMessaging` entry.
+///
+/// Declared in `vtc-host`'s `optionalVars` with a `null` default and placed as
+/// a bare array member, so a community provisioned without DIDComm has the
+/// element pruned. That null-pruning slot is the only conditional the template
+/// format has, which is why the entry is built here in Rust rather than spelled
+/// out in the template JSON.
+pub const DIDCOMM_SERVICE_VAR: &str = "SERVICE_DIDCOMM";
+
+/// Template variable carrying the whole `TSPTransport` entry. Same
+/// null-pruning mechanism as [`DIDCOMM_SERVICE_VAR`].
+pub const TSP_SERVICE_VAR: &str = "SERVICE_TSP";
+
+/// Emitted service-id fragment for the DIDComm entry.
+///
+/// The workspace convention is the bare protocol name — `#didcomm`, not
+/// `#vta-didcomm`. Discovery matches on service `type`, never on the fragment,
+/// which is an arbitrary label (CLAUDE.md D9); the fragment only has to be
+/// stable and readable.
+const DIDCOMM_FRAGMENT: &str = "#didcomm";
+
+/// Emitted service-id fragment for the TSP entry. The OWF reference impl uses
+/// `#tsp-transport` for the same `type`; both resolve, because nothing matches
+/// on the fragment.
+const TSP_FRAGMENT: &str = "#tsp";
+
+/// Build the `DIDCommMessaging` entry routing through `mediator_did`.
+///
+/// Pass the result as [`DIDCOMM_SERVICE_VAR`] in a template's vars map. The
+/// `id` carries the literal `{DID}` sentinel: caller-supplied variable values
+/// are not re-substituted by the renderer, but `didwebvh-rs` resolves `{DID}`
+/// across every leaf string once the SCID is computed, so the entry lands with
+/// the community's minted DID.
+///
+/// # Errors
+///
+/// [`TemplateError::Invalid`] if `mediator_did` is not a DID. A URL here would
+/// render an entry claiming this community hosts a DIDComm endpoint directly,
+/// which it does not — the sender's routing layer reads this value as the first
+/// hop to resolve, so a URL simply fails to route.
+pub fn didcomm_service(mediator_did: &str) -> Result<Value, TemplateError> {
+    transport_service(
+        mediator_did,
+        DIDCOMM_SERVICE_TYPE,
+        DIDCOMM_FRAGMENT,
+        "DIDComm",
+    )
+}
+
+/// Build the `TSPTransport` entry routing through `mediator_did`.
+///
+/// Same shape and the same mediator as [`didcomm_service`] — see the module
+/// docs for why both name a DID rather than a URL.
+///
+/// # Errors
+///
+/// [`TemplateError::Invalid`] if `mediator_did` is not a DID.
+pub fn tsp_service(mediator_did: &str) -> Result<Value, TemplateError> {
+    transport_service(mediator_did, TSP_SERVICE_TYPE, TSP_FRAGMENT, "TSP")
+}
+
+fn transport_service(
+    mediator_did: &str,
+    type_: &str,
+    fragment: &str,
+    label: &str,
+) -> Result<Value, TemplateError> {
+    let mediator_did = mediator_did.trim();
+    if !mediator_did.starts_with("did:") {
+        return Err(TemplateError::Invalid(format!(
+            "{label} service must name the mediator by DID, got '{mediator_did}'. The \
+             serviceEndpoint is the mediator's DID — the transport URL lives in the \
+             mediator's own document — so a URL here renders an entry no sender can route."
+        )));
+    }
+    Ok(json!({
+        "id": format!("{{DID}}{fragment}"),
+        "type": type_,
+        "serviceEndpoint": mediator_did,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+
+    use super::*;
+
+    const MEDIATOR: &str = "did:webvh:QmTS3:webvh.example.com:mediator";
+
+    #[test]
+    fn didcomm_entry_names_the_mediator_by_did() {
+        let e = didcomm_service(MEDIATOR).unwrap();
+        assert_eq!(e["id"], "{DID}#didcomm");
+        assert_eq!(e["type"], DIDCOMM_SERVICE_TYPE);
+        assert_eq!(e["serviceEndpoint"], MEDIATOR);
+    }
+
+    #[test]
+    fn tsp_entry_names_the_mediator_by_did() {
+        let e = tsp_service(MEDIATOR).unwrap();
+        assert_eq!(e["id"], "{DID}#tsp");
+        assert_eq!(e["type"], TSP_SERVICE_TYPE);
+        assert_eq!(e["serviceEndpoint"], MEDIATOR);
+    }
+
+    /// Both transports bind the *same* mediator (§14 Q2) — one dual-protocol
+    /// mediator, advertised twice under two types. A change that started
+    /// deriving one endpoint from the other would break that.
+    #[test]
+    fn both_transports_bind_the_same_mediator() {
+        assert_eq!(
+            didcomm_service(MEDIATOR).unwrap()["serviceEndpoint"],
+            tsp_service(MEDIATOR).unwrap()["serviceEndpoint"]
+        );
+    }
+
+    /// A URL is refused for both. The endpoint is read by the sender's routing
+    /// layer as `route[0]` — a DID to resolve onward — so a URL is not a
+    /// degraded entry, it is an unroutable one.
+    #[test]
+    fn a_url_endpoint_is_refused() {
+        for build in [
+            didcomm_service as fn(&str) -> Result<Value, TemplateError>,
+            tsp_service,
+        ] {
+            let err = build("https://mediator.example.com").unwrap_err();
+            let msg = err.to_string();
+            assert!(msg.contains("by DID"), "must say what is wrong: {msg}");
+        }
+    }
+
+    #[test]
+    fn surrounding_whitespace_does_not_defeat_the_did_check() {
+        let e = tsp_service(&format!("  {MEDIATOR}  ")).unwrap();
+        assert_eq!(e["serviceEndpoint"], MEDIATOR);
+    }
+
+    #[test]
+    fn an_empty_mediator_is_refused() {
+        assert!(didcomm_service("").is_err());
+        assert!(tsp_service("   ").is_err());
+    }
+
+    /// The `{DID}` sentinel must survive verbatim into the rendered entry —
+    /// `didwebvh-rs` resolves it after the SCID exists. A helper that
+    /// interpolated a real DID here would emit an id that cannot match the
+    /// document it lands in.
+    #[test]
+    fn the_id_carries_the_did_sentinel_for_late_substitution() {
+        assert!(
+            tsp_service(MEDIATOR).unwrap()["id"]
+                .as_str()
+                .unwrap()
+                .starts_with("{DID}")
+        );
+    }
+}

--- a/vta-sdk/templates/vtc-host.json
+++ b/vta-sdk/templates/vtc-host.json
@@ -2,12 +2,14 @@
   "schemaVersion": 1,
   "name": "vtc-host",
   "kind": "vtc-host",
-  "description": "Verifiable Trust Community (VTC) service identity. Provisions the did:webvh that a vtc-service binary operates under. The document advertises the VTC's REST endpoint and the URL where its BitstringStatusList credentials will be hosted (populated in Phase 2 of the VTC MVP — the endpoint is gracefully present in the DID document from day one so external verifiers can pre-cache the resolution). Optionally advertises a TrustRegistry referral naming the registry authoritative for this community by DID, so a client holding only the community's DID can resolve one hop to its registry (TRQP v2 §'machine-discoverable via the authority_id'); supply SERVICE_TRUST_REGISTRY, built by vta_sdk::did_templates::referral_service, and omit it for a community with no registry. No messaging transport is advertised here by default — neither DIDComm nor TSP; a community that needs one adds it after mint via the runtime-service-management flow (see docs/02-vta/runtime-service-management.md). Add both when you add either: the stack prefers TSP over DIDComm over REST, so a document advertising TSP alone leaves every peer that does not speak TSP with no messaging route in, and a vtc-service built without its `tsp` feature with none at all (it refuses to start on that mismatch — see vtc-service's transport_capability). The URL variable must not end with a trailing slash to avoid double-slash artefacts in the status-list endpoint.",
+  "description": "Verifiable Trust Community (VTC) service identity. Provisions the did:webvh that a vtc-service binary operates under. The document advertises the VTC's REST endpoint and the URL where its BitstringStatusList credentials will be hosted (populated in Phase 2 of the VTC MVP — the endpoint is gracefully present in the DID document from day one so external verifiers can pre-cache the resolution). Optionally advertises a TrustRegistry referral naming the registry authoritative for this community by DID, so a client holding only the community's DID can resolve one hop to its registry (TRQP v2 §'machine-discoverable via the authority_id'); supply SERVICE_TRUST_REGISTRY, built by vta_sdk::did_templates::referral_service, and omit it for a community with no registry. Messaging transports are chosen at setup and rendered here: supply SERVICE_TSP and/or SERVICE_DIDCOMM (built by vta_sdk::did_templates::tsp_service / didcomm_service) to advertise them, and omit either to prune it. Both name the SAME mediator DID — the transport URL lives in the mediator's own document. This must be decided at mint: a VTC serves a write-once did.jsonl and cannot re-sign its own log, so adding a transport later means a VTA-side `dids edit` plus redelivering the log by hand. Advertise both when you advertise either — the stack prefers TSP over DIDComm over REST, so a document offering TSP alone leaves every peer that does not speak TSP with no messaging route in. Advertising a transport the named mediator does not actually route produces an entry clients will choose and cannot use; the mediator's own services are its controller's responsibility and nothing here can verify them. Emitted service order is canonical (TSP, DIDComm, then REST). The URL variable must not end with a trailing slash to avoid double-slash artefacts in the status-list endpoint.",
   "methods": ["webvh", "web"],
   "requiredVars": ["URL"],
   "optionalVars": {
     "STATUS_LIST_PATH": "/v1/status-lists",
-    "SERVICE_TRUST_REGISTRY": null
+    "SERVICE_TRUST_REGISTRY": null,
+    "SERVICE_DIDCOMM": null,
+    "SERVICE_TSP": null
   },
   "defaults": {
     "preRotationCount": 2,
@@ -38,6 +40,8 @@
     "authentication": ["{DID}#key-0"],
     "keyAgreement": ["{DID}#key-1"],
     "service": [
+      "{SERVICE_TSP}",
+      "{SERVICE_DIDCOMM}",
       {
         "id": "{DID}#vtc-rest",
         "type": "VTCRest",

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vtc-service"
 description = "Service for Verifiable Trust Communities"
 readme = "README.md"
-version = "0.11.57"
+version = "0.11.58"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vtc-service/src/setup/from_toml.rs
+++ b/vtc-service/src/setup/from_toml.rs
@@ -37,9 +37,39 @@ use vti_common::error::AppError;
 use crate::config::{MessagingConfig, SecretsConfig};
 
 use super::wizard::{
-    SetupOutcome, WebvhTarget, WizardInputs, WizardPlan, apply, normalize_registry_did,
+    SetupOutcome, Transport, WebvhTarget, WizardInputs, WizardPlan, apply, normalize_registry_did,
     refuse_if_already_set_up,
 };
+
+/// The `[messaging]` table: the mediator, plus which transports the
+/// community's DID document advertises over it.
+///
+/// Flattens [`MessagingConfig`] — the runtime shape written to `config.toml`
+/// — and adds `transports`, which is **not** runtime config. It is consumed
+/// once, at mint, to render service entries into the DID document, and the
+/// document is authoritative thereafter. Persisting it would create a second
+/// source of truth that could drift from the document it produced.
+///
+/// `transports` is required rather than defaulted. The choice determines
+/// whether anyone can reach this community over a mediator, it cannot be
+/// changed after mint without a VTA-side `dids edit`, and a silent default
+/// would be a guess about someone else's mediator — see
+/// [`super::wizard::prompt_transports`] for the same reasoning interactively.
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct MessagingSetup {
+    #[serde(flatten)]
+    pub config: MessagingConfig,
+
+    /// Transports to advertise: `["tsp"]`, `["didcomm"]`, or both. Both is the
+    /// §12 Phase A shape and strands nobody.
+    ///
+    /// Every entry points at `mediator_did`. Advertising a transport that
+    /// mediator does not route makes this community unreachable on it —
+    /// conforming clients prefer it and fail — and nothing here can verify the
+    /// mediator's own services.
+    pub transports: Vec<Transport>,
+}
 
 /// TOML schema for `vtc setup --from <file>`.
 ///
@@ -96,13 +126,16 @@ pub(crate) struct VtcWizardInputs {
     #[serde(default)]
     pub webvh: WebvhTarget,
 
-    /// DIDComm mediator the VTC routes through. Omit for no messaging
-    /// (the daemon stays healthy on REST and logs a one-line warning).
-    /// `mediator_did` is required when present; `mediator_url` /
-    /// `mediator_host` are optional (the endpoint is resolved from the
-    /// DID document).
+    /// Mediator the VTC routes through, and which transports its DID
+    /// document advertises over that mediator. Omit the whole table for no
+    /// messaging (the daemon stays healthy on REST and logs a one-line
+    /// warning).
+    ///
+    /// `mediator_did` and `transports` are both required when the table is
+    /// present; `mediator_url` / `mediator_host` are optional (the endpoint is
+    /// resolved from the mediator's DID document).
     #[serde(default)]
-    pub messaging: Option<MessagingConfig>,
+    pub messaging: Option<MessagingSetup>,
 
     /// Secret-store backend for the VTC's key bundle. Required — the
     /// choice is security-sensitive and there is no safe implicit
@@ -151,6 +184,15 @@ pub(crate) fn parse_from_toml(file_path: &Path) -> Result<WizardPlan, AppError> 
     // both front-ends hand `apply` the same shape.
     let registry_did = normalize_registry_did(inputs.registry_did.as_deref().unwrap_or(""))?;
 
+    // Split the `[messaging]` table: `transports` feeds the DID document being
+    // minted, the rest becomes the daemon's runtime messaging config. One
+    // operator decision, two destinations — and `transports` is deliberately
+    // not persisted, because the minted document is authoritative for it.
+    let (messaging, transports) = match inputs.messaging {
+        Some(m) => (Some(m.config), m.transports),
+        None => (None, Vec::new()),
+    };
+
     Ok(WizardPlan {
         config_path: inputs.config_path,
         inputs: WizardInputs {
@@ -158,10 +200,11 @@ pub(crate) fn parse_from_toml(file_path: &Path) -> Result<WizardPlan, AppError> 
             vta_did: inputs.vta_did,
             context: inputs.context,
             registry_did,
+            transports,
         },
         webvh: inputs.webvh,
         secrets: inputs.secrets,
-        messaging: inputs.messaging,
+        messaging,
         setup_key,
     })
 }
@@ -216,10 +259,33 @@ fn validate(inputs: &VtcWizardInputs) -> Result<(), AppError> {
         }
     }
 
-    if let Some(messaging) = inputs.messaging.as_ref()
-        && messaging.mediator_did.trim().is_empty()
-    {
-        errors.push("messaging.mediator_did must not be empty when [messaging] is present".into());
+    if let Some(messaging) = inputs.messaging.as_ref() {
+        if messaging.config.mediator_did.trim().is_empty() {
+            errors.push(
+                "messaging.mediator_did must not be empty when [messaging] is present".into(),
+            );
+        }
+        // `transports = []` parses, so serde's required-field check does not
+        // catch it — and it is the one value that silently produces an
+        // unreachable community: connected to a mediator, advertising no way to
+        // reach it. Refuse it by name, with the fix.
+        if messaging.transports.is_empty() {
+            errors.push(
+                "messaging.transports must name at least one transport when [messaging] is \
+                 present — e.g. transports = [\"tsp\", \"didcomm\"]. An empty list connects this \
+                 VTC to the mediator while advertising no way to reach it, and the DID document \
+                 is write-once. Omit the whole [messaging] table for a REST-only community."
+                    .into(),
+            );
+        }
+        // Duplicates would render the same service entry twice, which is a
+        // malformed document rather than a stronger claim.
+        let mut seen = messaging.transports.clone();
+        seen.sort_unstable();
+        seen.dedup();
+        if seen.len() != messaging.transports.len() {
+            errors.push("messaging.transports must not repeat a transport".into());
+        }
     }
 
     if errors.is_empty() {
@@ -339,6 +405,7 @@ path      = "communities/acme"
 
 [messaging]
 mediator_did = "did:web:mediator.example.com"
+transports   = ["tsp", "didcomm"]
 
 [secrets]
 keyring_service = "vtc-acme"
@@ -348,9 +415,137 @@ keyring_service = "vtc-acme"
         assert_eq!(inputs.webvh.server_id.as_deref(), Some("host-1"));
         assert_eq!(inputs.webvh.domain.as_deref(), Some("tenant.example.com"));
         assert_eq!(inputs.webvh.path.as_deref(), Some("communities/acme"));
+        let messaging = inputs.messaging.as_ref().unwrap();
         assert_eq!(
-            inputs.messaging.as_ref().unwrap().mediator_did,
+            messaging.config.mediator_did,
             "did:web:mediator.example.com"
+        );
+        assert_eq!(
+            messaging.transports,
+            vec![Transport::Tsp, Transport::Didcomm]
+        );
+    }
+
+    /// `transports` is required, not defaulted. A `[messaging]` table without
+    /// it must fail loudly at parse rather than mint a community that connects
+    /// to a mediator and advertises no way to reach it — a state the write-once
+    /// `did.jsonl` makes expensive to correct.
+    #[test]
+    fn messaging_without_transports_is_refused() {
+        let err = toml::from_str::<VtcWizardInputs>(
+            r#"
+config_path = "/srv/vtc/config.toml"
+base_url    = "https://vtc.example.com"
+vta_did     = "did:web:vta.example.com"
+setup_key_file = "/tmp/key.json"
+
+[messaging]
+mediator_did = "did:web:mediator.example.com"
+
+[secrets]
+"#,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(
+            err.contains("transports"),
+            "must name the missing key: {err}"
+        );
+    }
+
+    /// An *empty* list parses (serde only checks presence), so validation has
+    /// to catch it — and it is the exact shape that produces an unreachable
+    /// community.
+    #[test]
+    fn validate_rejects_an_empty_transport_list() {
+        let inputs: VtcWizardInputs = toml::from_str(
+            r#"
+config_path = "/srv/vtc/config.toml"
+base_url    = "https://vtc.example.com"
+vta_did     = "did:web:vta.example.com"
+setup_key_file = "/tmp/key.json"
+
+[messaging]
+mediator_did = "did:web:mediator.example.com"
+transports   = []
+
+[secrets]
+"#,
+        )
+        .expect("an empty list is valid TOML");
+        let err = validate(&inputs).unwrap_err().to_string();
+        assert!(err.contains("at least one transport"), "{err}");
+        assert!(
+            err.contains("Omit the whole [messaging] table"),
+            "must name the REST-only alternative: {err}"
+        );
+    }
+
+    /// A repeated transport would render the same service entry twice —
+    /// malformed, not emphatic.
+    #[test]
+    fn validate_rejects_duplicate_transports() {
+        let inputs: VtcWizardInputs = toml::from_str(
+            r#"
+config_path = "/srv/vtc/config.toml"
+base_url    = "https://vtc.example.com"
+vta_did     = "did:web:vta.example.com"
+setup_key_file = "/tmp/key.json"
+
+[messaging]
+mediator_did = "did:web:mediator.example.com"
+transports   = ["tsp", "tsp"]
+
+[secrets]
+"#,
+        )
+        .expect("parse");
+        let err = validate(&inputs).unwrap_err().to_string();
+        assert!(err.contains("must not repeat"), "{err}");
+    }
+
+    /// Omitting `[messaging]` entirely stays valid — a REST-only community is
+    /// a supported shape, and this is the migration path for an existing setup
+    /// file that never configured messaging.
+    #[test]
+    fn no_messaging_table_needs_no_transports() {
+        let inputs: VtcWizardInputs = toml::from_str(
+            r#"
+config_path = "/srv/vtc/config.toml"
+base_url    = "https://vtc.example.com"
+vta_did     = "did:web:vta.example.com"
+setup_key_file = "/tmp/key.json"
+
+[secrets]
+"#,
+        )
+        .expect("parse");
+        assert!(inputs.messaging.is_none());
+        validate(&inputs).expect("REST-only is valid");
+    }
+
+    /// One transport is legal — a community whose mediator routes only DIDComm.
+    #[test]
+    fn a_single_transport_is_accepted() {
+        let inputs: VtcWizardInputs = toml::from_str(
+            r#"
+config_path = "/srv/vtc/config.toml"
+base_url    = "https://vtc.example.com"
+vta_did     = "did:web:vta.example.com"
+setup_key_file = "/tmp/key.json"
+
+[messaging]
+mediator_did = "did:web:mediator.example.com"
+transports   = ["didcomm"]
+
+[secrets]
+"#,
+        )
+        .expect("parse");
+        validate(&inputs).expect("didcomm-only is valid");
+        assert_eq!(
+            inputs.messaging.unwrap().transports,
+            vec![Transport::Didcomm]
         );
     }
 
@@ -384,6 +579,7 @@ setup_key_file = "/tmp/key.json"
 
 [messaging]
 mediator_did = ""
+transports   = ["didcomm"]
 
 [secrets]
 "#,

--- a/vtc-service/src/setup/wizard.rs
+++ b/vtc-service/src/setup/wizard.rs
@@ -39,7 +39,10 @@ use serde_json::Value as JsonValue;
 use tokio::sync::mpsc;
 use tracing::warn;
 use vta_sdk::client::VtaClient;
-use vta_sdk::did_templates::{TRUST_REGISTRY_SERVICE_VAR, referral_service};
+use vta_sdk::did_templates::{
+    DIDCOMM_SERVICE_VAR, TRUST_REGISTRY_SERVICE_VAR, TSP_SERVICE_VAR, didcomm_service,
+    referral_service, tsp_service,
+};
 use vta_sdk::provision_client::{
     EphemeralSetupKey, OperatorMessages, ProvisionAsk, ProvisionResult, ResolvedVta, VtaEvent,
     VtaIntent, VtaReply, resolve_vta, run_connection_test, run_provision_flight,
@@ -100,8 +103,15 @@ async fn collect_interactive(config_path: Option<PathBuf>) -> Result<WizardPlan,
         }
     };
 
-    // 2. Mediator choice.
+    // 2. Mediator choice, then which transports to advertise over it. Both
+    //    happen before the mint below, because the answers become service
+    //    entries in the document being minted and cannot be added afterwards.
     let messaging = prompt_messaging(resolved.as_ref().and_then(|r| r.mediator_did.clone()))?;
+    let transports = match messaging.as_ref() {
+        Some(m) => prompt_transports(&m.mediator_did)?,
+        // No mediator, nothing to advertise. The document carries REST only.
+        None => Vec::new(),
+    };
 
     // 3. Mint the ephemeral DID first so we can show it to the
     //    operator before they pick a secret-store backend (the
@@ -137,7 +147,13 @@ async fn collect_interactive(config_path: Option<PathBuf>) -> Result<WizardPlan,
 
     Ok(WizardPlan {
         config_path,
-        inputs,
+        // The transport choice is gathered at step 2 (it needs the mediator),
+        // long after `prompt_inputs` built the rest. Folded in here rather than
+        // threaded through every intervening prompt.
+        inputs: WizardInputs {
+            transports,
+            ..inputs
+        },
         webvh,
         secrets,
         messaging,
@@ -164,7 +180,7 @@ pub(crate) async fn apply(plan: WizardPlan) -> Result<SetupOutcome, AppError> {
     // Drive the provision-integration round-trip. Capture and discard
     // event traffic so the setup UX stays terse — long-form progress UX
     // is for `pnm`, not the daemon setup flow.
-    let provision = run_provision_quietly(&inputs, &webvh, &setup_key).await?;
+    let provision = run_provision_quietly(&inputs, &webvh, messaging.as_ref(), &setup_key).await?;
     let integration_did = provision
         .integration_did()
         .ok_or_else(|| {
@@ -357,6 +373,44 @@ pub(crate) struct WizardInputs {
     /// `did.jsonl` and cannot re-sign its own log, so changing it later means
     /// a VTA-side `dids edit` plus redelivering the log by hand.
     pub(crate) registry_did: Option<String>,
+    /// Messaging transports to advertise in the community's DID document.
+    ///
+    /// Empty when the operator skipped messaging — the document then carries
+    /// REST only, and nothing can be delivered to this community over a
+    /// mediator by any route a DID-driven client would find.
+    ///
+    /// Fixed at mint, like [`Self::registry_did`] and for the same reason: the
+    /// VTC serves a write-once `did.jsonl` and cannot re-sign its own log, so
+    /// adding a transport later means a VTA-side `dids edit` plus redelivering
+    /// the log by hand. This is the community's one chance to say how it can be
+    /// reached.
+    pub(crate) transports: Vec<Transport>,
+}
+
+/// A messaging transport a community can advertise.
+///
+/// Both bind the *same* mediator DID — one dual-protocol mediator serves both
+/// (`docs/05-design-notes/tsp-enablement.md` §14 Q2) — so this enum selects
+/// which service entries are rendered, never which mediator.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Deserialize, serde::Serialize,
+)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum Transport {
+    /// `TSPTransport`. Listed first: the workspace prefers TSP over DIDComm
+    /// over REST, and array order is what encodes that to a resolver.
+    Tsp,
+    /// `DIDCommMessaging`.
+    Didcomm,
+}
+
+impl Transport {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Transport::Tsp => "tsp",
+            Transport::Didcomm => "didcomm",
+        }
+    }
 }
 
 /// A fully-resolved setup plan: every operator decision gathered, no
@@ -516,6 +570,9 @@ fn prompt_inputs() -> Result<WizardInputs, AppError> {
         vta_did,
         context,
         registry_did,
+        // Gathered later, once the mediator is known (see `collect_interactive`
+        // step 2) — there is nothing to advertise before then.
+        transports: Vec::new(),
     })
 }
 
@@ -611,6 +668,101 @@ fn prompt_messaging(vta_mediator: Option<String>) -> Result<Option<MessagingConf
         setup_acl: false,
         drain_inbox_on_start: false,
     }))
+}
+
+/// Ask which transports the community's DID document should advertise.
+///
+/// Only reached when the operator configured a mediator: with no mediator there
+/// is no endpoint to advertise, and the document carries REST alone.
+///
+/// **Both are pre-selected**, matching §12 Phase A ("advertise TSP + DIDComm").
+/// Advertising TSP alone strands every peer that does not speak it; advertising
+/// DIDComm alone forgoes the preferred transport. Neither is wrong, so both are
+/// offered — but the default is the one that strands nobody.
+///
+/// The warning is not decoration. Both entries name the operator's mediator,
+/// and nothing here can check that the mediator actually routes the protocol
+/// being advertised — its services belong to its own controller
+/// (`docs/05-design-notes/tsp-enablement.md` §14 Q3). Advertising a transport
+/// the mediator cannot carry produces an entry every conforming client will
+/// choose and none can use, which is the same failure shape as advertising one
+/// the binary cannot serve.
+fn prompt_transports(mediator_did: &str) -> Result<Vec<Transport>, AppError> {
+    use dialoguer::MultiSelect;
+
+    println!();
+    println!("  Which transports should this community advertise in its DID document?");
+    println!();
+    println!("  Both entries point at your mediator:");
+    println!("    {mediator_did}");
+    println!();
+    println!("  ⚠ Advertising a transport your mediator does not route makes this");
+    println!("    community unreachable on it — clients will prefer it and fail.");
+    println!("    Check your mediator advertises the matching service before enabling.");
+    println!();
+    println!("  This is fixed at mint: the VTC serves a write-once did.jsonl and cannot");
+    println!("  re-sign its own log, so changing it later needs a VTA-side `dids edit`.");
+    println!();
+
+    // Order matches the workspace preference (TSP > DIDComm), so the list reads
+    // the way a resolver walks it.
+    let options = [
+        (
+            "TSP     (TSPTransport)   — preferred transport",
+            Transport::Tsp,
+        ),
+        (
+            "DIDComm (DIDCommMessaging) — supported fallback",
+            Transport::Didcomm,
+        ),
+    ];
+    let labels: Vec<&str> = options.iter().map(|(label, _)| *label).collect();
+
+    loop {
+        let picked = MultiSelect::new()
+            .with_prompt("Transports (space to toggle, enter to confirm)")
+            .items(&labels)
+            .defaults(&[true, true])
+            .interact()
+            .map_err(prompt_err)?;
+
+        if picked.is_empty() {
+            // A mediator with no advertised transport is almost certainly a
+            // mis-toggle: the operator just chose a mediator, and this leaves
+            // the VTC connected to it while telling nobody. Re-ask rather than
+            // silently minting an unreachable community.
+            println!();
+            println!("  No transport selected — this community would connect to the mediator");
+            println!("  but advertise no way to reach it. Select at least one, or restart");
+            println!("  setup and choose \"Skip messaging\" if that is what you want.");
+            println!();
+            continue;
+        }
+
+        let chosen: Vec<Transport> = picked.into_iter().map(|i| options[i].1).collect();
+
+        // Echo the decision in the terms the document will carry, so the
+        // operator sees what is about to be minted rather than which
+        // checkboxes they ticked. This is their last chance to notice it.
+        println!();
+        println!(
+            "  Advertising: {}",
+            chosen
+                .iter()
+                .map(|t| t.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+        if chosen.len() == 1 && chosen[0] == Transport::Tsp {
+            println!(
+                "  Note: TSP only — peers that do not speak TSP will have no way to reach this"
+            );
+            println!("        community over a mediator.");
+        }
+        println!();
+
+        return Ok(chosen);
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1158,6 +1310,12 @@ fn secrets_choice_to_config(choice: SecretsBackendChoice) -> SecretsConfig {
 async fn run_provision_quietly(
     inputs: &WizardInputs,
     webvh: &WebvhTarget,
+    // Supplies the mediator DID that `inputs.transports` advertise. Passed
+    // separately rather than folded into `WizardInputs` because it is also the
+    // daemon's *runtime* messaging config — the DID document and `config.toml`
+    // read the same operator decision, and duplicating the DID into both
+    // structs would let them drift.
+    messaging: Option<&MessagingConfig>,
     setup_key: &EphemeralSetupKey,
 ) -> Result<ProvisionResult, AppError> {
     let mut vars = BTreeMap::new();
@@ -1206,6 +1364,38 @@ async fn run_provision_quietly(
             referral_service(registry_did)
                 .map_err(|e| AppError::Config(format!("trust-registry referral: {e}")))?,
         );
+    }
+    // The messaging transports, same null-pruning slots. Both name the one
+    // mediator the operator chose — TSP and DIDComm share it (§14 Q2), so this
+    // renders one DID under two service types rather than two endpoints.
+    //
+    // A transport selected without a mediator is unrepresentable: the selection
+    // prompt only runs when `messaging` is `Some`, and `from_toml` rejects the
+    // combination. Guarding again here would be dead code that reads as if the
+    // case were possible.
+    if !inputs.transports.is_empty() {
+        let mediator_did = messaging.map(|m| m.mediator_did.as_str()).ok_or_else(|| {
+            AppError::Internal(
+                "transports selected with no mediator configured — the setup front-ends must \
+                     not produce this"
+                    .into(),
+            )
+        })?;
+        for transport in &inputs.transports {
+            let (var, entry) = match transport {
+                Transport::Tsp => (
+                    TSP_SERVICE_VAR,
+                    tsp_service(mediator_did)
+                        .map_err(|e| AppError::Config(format!("TSP service entry: {e}")))?,
+                ),
+                Transport::Didcomm => (
+                    DIDCOMM_SERVICE_VAR,
+                    didcomm_service(mediator_did)
+                        .map_err(|e| AppError::Config(format!("DIDComm service entry: {e}")))?,
+                ),
+            };
+            vars.insert(var.to_string(), entry);
+        }
     }
     let ask = ProvisionAsk::for_template("vtc-host", vars, inputs.context.clone())
         .with_label("vtc-host integration");


### PR DESCRIPTION
Answering "can setup manage which transport protocols are enabled and create the
matching DID service endpoints?" — it could not, and the gap was bigger than a
missing option.

## The gap

`vtc setup` asked which mediator to route through, wrote it to `config.toml`,
and **never advertised it**. The `vtc-host` template minted `#vtc-rest` and
`#vtc-status-list` and no messaging service at all.

| | Before |
|---|---|
| Wizard asks about a mediator | Yes (step 2) |
| Where that answer goes | `config.toml` `[messaging]` — and nowhere else |
| `#didcomm` in the DID document | Never |
| `#tsp` in the DID document | Never |

So a VTC connected *outbound* to a mediator while its document told nobody. A
conforming client resolving the community found no messaging transport, and
DIDComm only worked if the sender had been handed the mediator out of band.

It is also how the reference deployment acquired its `#tsp` at DID log version 3
— published by hand, long after mint, with nothing checking the binary could
serve it. The state that produced #923 and #926.

## Why setup, and not "add it later"

`wizard.rs` already said it, about the trust-registry referral:

> fixed at mint time — the VTC serves a write-once `did.jsonl` and cannot
> re-sign its own log, so changing it later means a VTA-side `dids edit` plus
> redelivering the log by hand

Same constraint, same conclusion. Provisioning is the one moment a community can
say how it is reached, so the decision belongs there.

## Interactive

After the mediator choice, both transports pre-ticked — the §12 Phase A shape,
which strands nobody:

```
  Which transports should this community advertise in its DID document?

  Both entries point at your mediator:
    did:webvh:QmTS3…:mediator

  ⚠ Advertising a transport your mediator does not route makes this
    community unreachable on it — clients will prefer it and fail.
    Check your mediator advertises the matching service before enabling.

  This is fixed at mint: the VTC serves a write-once did.jsonl and cannot
  re-sign its own log, so changing it later needs a VTA-side `dids edit`.

? Transports (space to toggle, enter to confirm)
 [x] TSP     (TSPTransport)   — preferred transport
 [x] DIDComm (DIDCommMessaging) — supported fallback

  Advertising: tsp, didcomm
```

Deselecting everything **re-asks** rather than minting a community that connects
to a mediator and advertises no way in — that is a mis-toggle, not a
configuration. Choosing TSP alone prints the consequence.

## Non-interactive

```toml
[messaging]
mediator_did = "did:web:mediator.example.com"
transports   = ["tsp", "didcomm"]
```

`transports` is **required**, not defaulted: it decides whether anyone can reach
the community, it cannot be changed after mint, and any default would be a guess
about someone else's mediator. `transports = []` parses as valid TOML, so
validation refuses it by name and points at the REST-only alternative;
duplicates are refused (they would render one service entry twice).

**Existing setup files that omit `[messaging]` are unaffected** — a REST-only
community stays valid, which is the migration path.

## Deliberately no capability detection

I offered auto-detection (resolve the mediator, advertise `#tsp` only if it
advertises `TSPTransport`) and it was not chosen — explicit selection was. Worth
recording the trade: nothing here can verify the named mediator actually routes
the protocol, because its services belong to its own controller (§14 Q3). So the
operator is *told* that plainly, at the prompt and in the example TOML, rather
than having it guessed for them.

## vta-sdk

New `did_templates::{tsp_service, didcomm_service}` build the entries;
`vtc-host` gains `SERVICE_TSP` / `SERVICE_DIDCOMM` null-pruning slots — the same
mechanism `SERVICE_TRUST_REGISTRY` uses, and the only conditional the template
format has, which is why the entries are built in Rust rather than spelled out
in JSON.

Three things pinned by tests:

- both entries name the **same** mediator DID (§14 Q2) — one dual-protocol
  mediator, two service types, never two endpoints;
- emitted order is **canonical** (TSP, DIDComm, then REST), because array order
  is what encodes transport preference to a resolver — rendering REST first
  would quietly demote messaging for every conforming client;
- a **URL** endpoint is refused: the sender's routing layer reads this value as
  a DID to resolve onward, so a URL is unroutable rather than unconventional.

## Verification

- `vta-sdk` `did_templates` 70/70 — including all four render shapes (both
  transports, DIDComm alone, neither, and transports + registry pruning
  independently), plus the builder tests
- `vtc-service` `setup::` 40/40 — the required-key parse failure, empty-list and
  duplicate validation, single-transport, and the REST-only migration path
- clippy + fmt clean on both crates
- `cargo check --workspace --locked` passes — lockfile committed (the MSRV
  failure on #926 was this exact omission)
- both release guards pass

Rebased onto `52c73620` (#927). Took `vta-sdk` 0.21.18 because #928 already
claims 0.21.17.

Completes the arc: #923 stopped a build advertising what it cannot serve, #926
made the result visible from outside, and this lets a community say how to reach
it in the first place.
