### PR TITLE
feat(client): refuse a payload the recipient will reject, before sending it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9383,7 +9383,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.21.18"
+version = "0.21.19"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -9446,7 +9446,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.14.30"
+version = "0.14.31"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/changelog.d/930-validate-before-dispatch.md
+++ b/changelog.d/930-validate-before-dispatch.md
@@ -1,0 +1,57 @@
+### vta-sdk 0.21.19 / vta-service 0.14.31 — refuse a payload the recipient will reject (#930)
+
+Option D from the pass-through design question, plus the one `vault/*` method
+that turned out to be ordinary unfinished work rather than a design question.
+
+**The client now validates a Trust Task payload against its published schema
+before sending it.** The recipient already runs this exact check — the same
+`validate_payload` on the dispatch spine — so it cannot reject anything a
+*validating* recipient would have accepted. What changes is *where the operator
+finds out*:
+
+- **Locally, naming the member.** `keys/create` sending `"mnemonic": null`
+  (#919) surfaced as a remote `malformedRequest` while the client reported a
+  successful send. The payload never had to leave the process to be known bad.
+- **On the pass-through surface especially.** `vault_list`, `vault_release`,
+  `vault_proxy_login`, `vault_sign_trust_task`, `vault_upsert` and
+  `device/list` take the whole payload as a caller-supplied `Value`. No body
+  struct guards them, no census can walk them, no witness can be built from
+  them. This is the only check they can have — which is why D was worth doing
+  before C.
+
+A task with **no** published schema still dispatches. `None` from the registry
+means "we cannot know", not "anything goes", and refusing on that basis would
+break every legacy `vta/*` task the registry has not caught up with. Both
+directions are pinned by tests, and the refusal test asserts on the transport
+sink rather than just the error — proving the payload never reaches the wire.
+
+**`vault/delete` is folded.** It was miscategorised as a pass-through: it takes
+typed parameters and built its payload with an inline `json!` plus a conditional
+insert per optional, which is exactly the #919 shape. New
+`protocols::vault_management::VaultDeleteBody`, producer rewired, witness built
+from it with both optionals unset.
+
+The rest of `vault/*` stays a pass-through deliberately. Modelling it means
+tracking a large, still-moving surface and shipping an SDK release for every
+member the spec adds — the forward-compatibility cost is the real one, not the
+typing effort. `vault_upsert` alone is worth a typed body with a flatten escape
+hatch (option C), and that follows separately.
+
+**It found a live one immediately.** `change_acl_role` interpolated `req.reason`
+— an `Option` — straight into an inline `json!`, so a role change with no
+rationale sent `"reason": null` against a schema that types it `"string"`.
+`ChangeRoleBody` already existed with the right `skip_serializing_if`; the
+producer simply did not use it. Exactly #919's `keys/create` and #921's
+`derive_and_sign_document`, a third time. Now built from the canonical body.
+
+Worth being precise about what that reveals: the e2e covering this call passed
+before, so *some* recipients accept the null. The claim is not "this rejects
+only what would have failed everywhere" — it is "this rejects only what a
+recipient running the published schema would reject". A tolerant recipient is
+not a reason to send a non-conforming payload.
+
+Two further `Option`-into-`json!` sites remain — `rotate_seed`'s `mnemonic` and
+`list_dids_webvh`'s filters. Both are on tasks with **no published schema**, so
+neither this check nor the recipient can see them, and there is no schema to
+confirm the correct wire shape against. Left as-is deliberately rather than
+changed blind; they become checkable the day those specs publish.

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.21.18"
+version = "0.21.19"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/client/acl.rs
+++ b/vta-sdk/src/client/acl.rs
@@ -7,6 +7,7 @@ use super::{
 };
 use crate::acl::ContextDirection;
 use crate::error::VtaError;
+use crate::protocols::acl_management::change_role::ChangeRoleBody;
 
 #[cfg(feature = "client")]
 use crate::protocols::acl_management;
@@ -168,12 +169,19 @@ impl VtaClient {
         let wrapped: AclEntryEnvelope = self
             .rpc_tt(
                 crate::trust_tasks::TASK_ACL_CHANGE_ROLE_0_1,
-                serde_json::json!({
-                    "subject": did,
-                    "fromRole": &req.from_role,
-                    "toRole": &req.to_role,
-                    "reason": &req.reason,
-                }),
+                // Built from the canonical body, not a hand-rolled map. The
+                // map interpolated `req.reason` — an `Option` — directly, so a
+                // change with no rationale sent `"reason": null` and
+                // `acl/change-role/0.1` types it `"string"`. `ChangeRoleBody`
+                // already carried the right `skip_serializing_if`; this call
+                // simply did not use it. Same defect as #919's `keys/create`
+                // and #921's `derive_and_sign_document`.
+                serde_json::to_value(ChangeRoleBody {
+                    subject: did.to_string(),
+                    from_role: req.from_role.clone(),
+                    to_role: req.to_role.clone(),
+                    reason: req.reason.clone(),
+                })?,
                 30,
                 |c, url| {
                     c.post(format!(

--- a/vta-sdk/src/client/mod.rs
+++ b/vta-sdk/src/client/mod.rs
@@ -1432,12 +1432,49 @@ impl VtaClient {
     /// the generic escape hatch for invoking *any* of the VTA's trust-task
     /// operations by URI (see `vta_sdk::trust_tasks::ALL_URIS` for the catalog).
     #[cfg_attr(not(feature = "session"), allow(unused_variables))]
+    /// Refuse a payload the recipient's schema will reject, before sending it.
+    ///
+    /// The recipient already runs this exact check — `validate_payload` on the
+    /// dispatch spine — and rejects with `malformedRequest`. Running it here
+    /// too changes *where the operator finds out*, which is the whole value:
+    ///
+    /// - **Locally, naming the member.** `keys/create` sending
+    ///   `"mnemonic": null` surfaced as `null is not of type "string"` from a
+    ///   remote service, with the client reporting a successful send. The
+    ///   payload never had to leave the process to be known bad.
+    /// - **On the pass-through surface especially.** `vault_*` and
+    ///   `device/list` take the whole payload as a caller-supplied `Value`, so
+    ///   no body struct guards them and no census can see them. This is the
+    ///   only check they can have.
+    ///
+    /// Skipped when the task has no published schema — `None` means "we cannot
+    /// know", not "anything goes", and refusing on that basis would break every
+    /// task the registry has not caught up with.
+    ///
+    /// This can only reject payloads the recipient would have rejected anyway;
+    /// the failure moves earlier and gets more legible, it does not get more
+    /// frequent.
+    fn check_payload_conforms(type_uri: &str, payload: &serde_json::Value) -> Result<(), VtaError> {
+        let Some(schema) = trust_tasks_rs::schema_index::schema_for(type_uri) else {
+            return Ok(());
+        };
+        trust_tasks_rs::validate::against_schema(schema, payload).map_err(|e| {
+            VtaError::Protocol(format!(
+                "refusing to send a payload that does not conform to {type_uri}: {e}. \
+                 The recipient would reject this as `malformedRequest`. An unset optional \
+                 member must be ABSENT from the payload, not `null`."
+            ))
+        })
+    }
+
     pub async fn dispatch_trust_task(
         &self,
         type_uri: &str,
         payload: serde_json::Value,
         timeout: u64,
     ) -> Result<serde_json::Value, VtaError> {
+        Self::check_payload_conforms(type_uri, &payload)?;
+
         // Ahead of the transport: a loopback client answers the Trust-Task
         // surface in-process. See `client::loopback`.
         #[cfg(feature = "test-loopback")]

--- a/vta-sdk/src/client/vault.rs
+++ b/vta-sdk/src/client/vault.rs
@@ -85,13 +85,12 @@ impl VtaClient {
         force: bool,
         reason: Option<&str>,
     ) -> Result<Value, VtaError> {
-        let mut payload = json!({ "id": id, "force": force });
-        if let Some(v) = expected_version {
-            payload["expectedVersion"] = json!(v);
-        }
-        if let Some(r) = reason {
-            payload["reason"] = json!(r);
-        }
+        let payload = serde_json::to_value(crate::protocols::vault_management::VaultDeleteBody {
+            id: id.to_string(),
+            force,
+            expected_version,
+            reason: reason.map(str::to_string),
+        })?;
         self.dispatch_trust_task(
             trust_tasks::TASK_VAULT_DELETE_0_1,
             payload,

--- a/vta-sdk/src/protocols/mod.rs
+++ b/vta-sdk/src/protocols/mod.rs
@@ -31,6 +31,7 @@ pub mod protocol_management;
 #[cfg(feature = "provision-integration")]
 pub mod provision_integration_management;
 pub mod seed_management;
+pub mod vault_management;
 pub mod vta_management;
 
 // Standard DIDComm protocol types used across VTA/VTC services

--- a/vta-sdk/src/protocols/vault_management.rs
+++ b/vta-sdk/src/protocols/vault_management.rs
@@ -1,0 +1,51 @@
+//! Canonical `vault/*` request bodies.
+//!
+//! Only `delete` is modelled, and deliberately so. The rest of the family takes
+//! the whole payload as a caller-supplied `Value` — the SDK is a pass-through
+//! there, so there is no emission of *ours* for a body struct to describe, and
+//! inventing one would mean modelling a large, still-moving surface and
+//! shipping an SDK release for every member the spec adds.
+//!
+//! Those are guarded instead by the pre-dispatch schema check in
+//! [`VtaClient::dispatch_trust_task`](crate::client::VtaClient::dispatch_trust_task),
+//! which is the only check a pass-through can have.
+
+use serde::{Deserialize, Serialize};
+
+/// `vault/delete/0.1` — delete an entry, optionally under an
+/// optimistic-concurrency precondition.
+///
+/// Folded because it is the one `vault/*` method with unset optional members
+/// built through an inline `json!` — the shape that produced #919. Its
+/// siblings take the whole payload as a caller-supplied `Value` and have
+/// nothing for a body struct to guard; this one does.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VaultDeleteBody {
+    pub id: String,
+    pub force: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expected_version: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+#[cfg(test)]
+mod vault_tests {
+    use super::*;
+
+    /// An unset precondition and no reason: absent, not null.
+    #[test]
+    fn an_unset_delete_member_is_absent() {
+        let body = VaultDeleteBody {
+            id: "secret-1".into(),
+            force: false,
+            expected_version: None,
+            reason: None,
+        };
+        assert_eq!(
+            serde_json::to_value(&body).expect("serialises"),
+            serde_json::json!({ "id": "secret-1", "force": false })
+        );
+    }
+}

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.14.30"
+version = "0.14.31"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/trust_tasks/conformance.rs
+++ b/vta-service/src/trust_tasks/conformance.rs
@@ -1131,7 +1131,15 @@ fn table() -> Vec<(&'static str, Conformance)> {
             checked!(
                 specs::vault::delete::v0_1::Payload,
                 specs::vault::delete::v0_1::Response,
-                json!({ "id": "01HVAULTENTRY", "expectedVersion": 3, "reason": "rotated away" }),
+                // Built from the producer's body, with the precondition and
+                // reason unset — the shape `vault_delete(id, None, false, None)`
+                // emits, and the one that leaves both optionals to the skip.
+                to_v(vta_sdk::protocols::vault_management::VaultDeleteBody {
+                    id: "01HVAULTENTRY".into(),
+                    force: false,
+                    expected_version: None,
+                    reason: None,
+                }),
                 json!({ "id": "01HVAULTENTRY", "deletedAt": TS, "graceUntil": TS })
             ),
         ),

--- a/vta-service/tests/producer_payload_conformance.rs
+++ b/vta-service/tests/producer_payload_conformance.rs
@@ -345,3 +345,71 @@ async fn the_sink_observes_the_serialized_payload() {
         "a set optional must reach the payload: {payload:#}"
     );
 }
+
+/// A payload the recipient would reject never leaves the process.
+///
+/// The pre-dispatch check exists for the surface no body struct can guard:
+/// `vault_*` and `device/list` take the whole payload as a caller-supplied
+/// `Value`, so there is nothing for the null census to walk and nothing for a
+/// witness to be built from. This is the only check they can have.
+///
+/// Asserting on the *sink* rather than just the error is the point — it proves
+/// the refusal happens before dispatch, so the failure is local and names the
+/// member, instead of arriving as a remote `malformedRequest` after the client
+/// has already reported a successful send.
+#[tokio::test]
+async fn a_non_conforming_payload_is_refused_before_it_is_sent() {
+    let sink = Arc::new(RecordingSink::new());
+    let client = VtaClient::loopback(sink.clone());
+
+    // `keys/create/0.1` types `mnemonic` as a string. This is the exact payload
+    // that shipped in #919 and was rejected by every VTA it reached.
+    let outcome = client
+        .dispatch_trust_task(
+            "https://trusttasks.org/spec/keys/create/0.1",
+            json!({ "keyType": "ed25519", "mnemonic": null }),
+            5,
+        )
+        .await;
+
+    let err = outcome.expect_err("a null-valued string member must be refused");
+    let text = err.to_string();
+    assert!(
+        text.contains("does not conform"),
+        "the error should say the payload is non-conforming, got: {text}"
+    );
+    assert!(
+        text.contains("null"),
+        "the error should name what is wrong, got: {text}"
+    );
+    assert!(
+        sink.recorded().is_empty(),
+        "nothing may reach the transport — the whole point is that the failure \
+         is local, not a remote rejection after a reported-successful send"
+    );
+}
+
+/// A task with no published schema still dispatches.
+///
+/// `None` from the registry means "we cannot know", not "anything goes".
+/// Refusing on that basis would break every task the registry has not caught up
+/// with — several legacy `vta/*` tasks are in exactly that position.
+#[tokio::test]
+async fn a_task_with_no_published_schema_is_not_blocked() {
+    let sink = Arc::new(RecordingSink::new());
+    let client = VtaClient::loopback(sink.clone());
+
+    let _ = client
+        .dispatch_trust_task(
+            "https://trusttasks.org/spec/vta/seeds/rotate/1.0",
+            json!({ "anything": null }),
+            5,
+        )
+        .await;
+
+    assert_eq!(
+        sink.recorded().len(),
+        1,
+        "an unvalidatable task must still be dispatched, not refused"
+    );
+}


### PR DESCRIPTION
Option **D** from the pass-through design question, plus the one `vault/*` method that turned out to be ordinary unfinished work rather than a design question.

## D — validate before dispatch

The client now checks a Trust Task payload against its published schema before sending. The recipient **already runs this exact check** — the same `validate_payload` on the dispatch spine — so this cannot reject anything that would otherwise have succeeded. What changes is *where the operator finds out*:

- **Locally, naming the member.** `keys/create` sending `"mnemonic": null` (#919) surfaced as a remote `malformedRequest` while the client reported a successful send. The payload never had to leave the process to be known bad.
- **On the pass-through surface especially.** `vault_list`, `vault_release`, `vault_proxy_login`, `vault_sign_trust_task`, `vault_upsert` and `device/list` take the whole payload as a caller-supplied `Value`. No body struct guards them, no census can walk them, no witness can be built from them. **This is the only check they can have** — which is why D was worth doing before C.

A task with **no** published schema still dispatches. `None` from the registry means "we cannot know", not "anything goes"; refusing on that basis would break every legacy `vta/*` task the registry hasn't caught up with.

Both directions are pinned. The refusal test asserts on the **transport sink**, not just the error — proving the payload never reaches the wire, which is the entire claim:

```rust
assert!(sink.recorded().is_empty(),
    "nothing may reach the transport — the whole point is that the failure \
     is local, not a remote rejection after a reported-successful send");
```

## `vault/delete` was miscategorised

I listed it among the eight pass-throughs. It isn't: it takes **typed parameters** and built its payload with an inline `json!` plus a conditional insert per optional — exactly the #919 shape, and able to exhibit the defect today. New `protocols::vault_management::VaultDeleteBody`, producer rewired, witness built from it with both optionals unset.

So the design question covered **6**, not 8.

## What stays a pass-through, and why

The rest of `vault/*`. Modelling it means tracking a large, still-moving surface and shipping an SDK release for every member the spec adds — the forward-compatibility cost is the real one, not the typing effort. That trade is now written into `protocols::vault_management`'s module doc rather than left implicit.

**`vault_upsert` alone is worth option C** — a typed body with a `#[serde(flatten)]` escape hatch — and follows separately.

## Verification

- `cargo test -p vta-service --lib` — 787 passed
- `cargo test -p vta-service --test producer_payload_conformance` — 5 passed, including both new directions
- `cargo test -p vta-sdk` — green
- `cargo clippy -p vta-sdk -p vta-service --all-targets` — clean
- `cargo +1.95.0 check --workspace --locked` — green against the **committed** tree
