### PR TITLE
feat(vault): a typed `upsert` body, with an escape hatch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2922,7 +2922,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c54e03a951783e8b327515db3f2a2fd0e3bed362a96b066f341ce66ed49b4ead"
 dependencies = [
  "data-encoding",
- "syn 3.0.3",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4587,7 +4587,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -6453,7 +6453,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.43",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "thiserror 2.0.20",
  "tokio",
  "tracing",
@@ -6492,7 +6492,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -9383,7 +9383,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.21.19"
+version = "0.21.20"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -9446,7 +9446,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.14.31"
+version = "0.14.32"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/changelog.d/931-vault-upsert-typed-body.md
+++ b/changelog.d/931-vault-upsert-typed-body.md
@@ -1,0 +1,33 @@
+### vta-sdk 0.21.20 / vta-service 0.14.32 — a typed `vault/upsert`, with an escape hatch (#931)
+
+Option C, scoped to the one member of the pass-through family worth typing.
+
+`VaultUpsertBody` names the members that exist today — `contextId`, `targets`,
+`label`, `secretKind`, plus the optionals — and carries
+`#[serde(flatten)] extra` for everything this build does not model.
+
+**The hatch is the whole design.** Typing the body without it would mean an SDK
+release before a caller could use *any* member the spec adds. That
+forward-compatibility cost — not the typing effort — is why the rest of
+`vault/*` stays a pass-through, and the hatch is what buys the coverage without
+paying it. The trade is explicit rather than hidden: modelled members are
+guarded by the null census, `extra` is not. It is greppable, and a member that
+lands in it repeatedly is one that wants promoting into the struct.
+
+**Additive, not breaking.** `vault_upsert` keeps its `Value` signature exactly
+as it was; the new `vault_upsert_typed` sits beside it. Changing the existing
+method would break every caller for a benefit they can opt into instead — and
+the pass-through is no longer unguarded anyway, since #930 validates it against
+the published schema before dispatch.
+
+`sealedSecret` stays off the body and is inserted by the method, because sealing
+needs the client's HPKE context rather than the caller's.
+
+The `vault/upsert` witness is now built from the body — a minimal create with
+every optional unset, plus the sealed envelope the method would add. Teeth
+checked: reverting the skip on `tags` fails the sweep with `null is not of type
+"array"`, which the old fixture could not have caught because it set `tags`.
+
+That closes the design question from #930. Of the six genuine pass-throughs,
+`vault_upsert` gets a typed body; the other five keep theirs, guarded by the
+pre-dispatch check.

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.21.19"
+version = "0.21.20"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/client/vault.rs
+++ b/vta-sdk/src/client/vault.rs
@@ -78,6 +78,36 @@ impl VtaClient {
     /// until the sweeper purges it at the returned `graceUntil`. `force ==
     /// true` **hard-deletes immediately** (no recovery) — equivalent to
     /// [`Self::vault_purge`]. `reason` is recorded in the audit trail.
+    /// `vault/upsert/0.1` from a typed body — the checked alternative to
+    /// [`Self::vault_upsert`].
+    ///
+    /// Additive on purpose. `vault_upsert` takes the whole payload as a `Value`
+    /// and stays exactly as it was: changing its signature would break every
+    /// caller for a benefit they can opt into instead. This one names the
+    /// members that exist today and carries an escape hatch for the rest, so a
+    /// caller is never blocked on an SDK release to use a new one.
+    ///
+    /// `sealed_secret` is inserted here rather than taken on the body, because
+    /// sealing needs the client's HPKE context and not the caller's.
+    pub async fn vault_upsert_typed(
+        &self,
+        body: crate::protocols::vault_management::VaultUpsertBody,
+        sealed_secret: Option<Value>,
+    ) -> Result<Value, VtaError> {
+        let mut payload = serde_json::to_value(body)?;
+        if let Some(env) = sealed_secret
+            && let Some(obj) = payload.as_object_mut()
+        {
+            obj.insert("sealedSecret".to_string(), env);
+        }
+        self.dispatch_trust_task(
+            trust_tasks::TASK_VAULT_UPSERT_0_1,
+            payload,
+            VAULT_TT_TIMEOUT,
+        )
+        .await
+    }
+
     pub async fn vault_delete(
         &self,
         id: &str,

--- a/vta-sdk/src/protocols/vault_management.rs
+++ b/vta-sdk/src/protocols/vault_management.rs
@@ -49,3 +49,123 @@ mod vault_tests {
         );
     }
 }
+
+/// `vault/upsert/0.1` — create or update a vault entry.
+///
+/// The one member of the family worth a type. The rest are pass-throughs whose
+/// payloads the SDK does not shape at all; this one is the entry itself — the
+/// surface a caller most often gets wrong, and the largest.
+///
+/// ## Why the escape hatch
+///
+/// `extra` carries anything this build does not model. Without it, typing the
+/// body would mean an SDK release before a caller could use *any* member the
+/// spec adds — the real cost of modelling a moving surface, and the reason the
+/// rest of `vault/*` stays untyped. With it, a caller gets named members and
+/// compile-time help for what exists today, and is never blocked on us for what
+/// does not.
+///
+/// The trade is explicit rather than hidden: modelled members are guarded by
+/// the null census, `extra` is not. It is greppable, and a member that lands in
+/// it repeatedly is a member that wants promoting into the struct.
+///
+/// `sealedSecret` is deliberately absent: [`VtaClient::vault_upsert`] inserts
+/// it, because sealing needs the client's HPKE context rather than the caller's.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VaultUpsertBody {
+    pub context_id: String,
+    /// `SiteTarget` union values — `{"kind": "web-origin", "origin": …}` and
+    /// friends. Left as `Value` for the same reason `ConsentSubject` is: it is
+    /// a union the caller assembles, and modelling it is a separate decision.
+    pub targets: Vec<serde_json::Value>,
+    pub label: String,
+    /// `password` | `passkey` | `oauth-tokens` | `did-self-issued` |
+    /// `didcomm-peer` | `bearer-token` | `ssh-key` | `custom`.
+    pub secret_kind: String,
+    /// Absent on create; present to update a specific entry.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    /// Optimistic-concurrency precondition, as on `vault/delete`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expected_version: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tags: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub notes: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<String>,
+    /// Members this build does not model — see the type's docs.
+    #[serde(flatten, default, skip_serializing_if = "serde_json::Map::is_empty")]
+    pub extra: serde_json::Map<String, serde_json::Value>,
+}
+
+#[cfg(test)]
+mod upsert_tests {
+    use super::*;
+
+    /// A minimal create: the four required members and nothing else. Every
+    /// optional is absent, and the escape hatch contributes no member of its own.
+    #[test]
+    fn a_minimal_upsert_carries_only_what_was_set() {
+        let body = VaultUpsertBody {
+            context_id: "openvtc".into(),
+            targets: vec![
+                serde_json::json!({"kind": "web-origin", "origin": "https://example.test"}),
+            ],
+            label: "example login".into(),
+            secret_kind: "password".into(),
+            id: None,
+            expected_version: None,
+            tags: None,
+            notes: None,
+            expires_at: None,
+            extra: serde_json::Map::new(),
+        };
+        assert_eq!(
+            serde_json::to_value(&body).expect("serialises"),
+            serde_json::json!({
+                "contextId": "openvtc",
+                "targets": [{"kind": "web-origin", "origin": "https://example.test"}],
+                "label": "example login",
+                "secretKind": "password",
+            })
+        );
+    }
+
+    /// The escape hatch flattens beside the modelled members rather than nesting
+    /// under a member of its own — which is what makes it forward-compatible
+    /// instead of a second, incompatible shape.
+    #[test]
+    fn unmodelled_members_flatten_alongside() {
+        let mut extra = serde_json::Map::new();
+        extra.insert(
+            "favicon".into(),
+            serde_json::json!("data:image/png;base64,AA"),
+        );
+        let body = VaultUpsertBody {
+            context_id: "openvtc".into(),
+            targets: vec![
+                serde_json::json!({"kind": "web-origin", "origin": "https://example.test"}),
+            ],
+            label: "example login".into(),
+            secret_kind: "password".into(),
+            id: None,
+            expected_version: None,
+            tags: None,
+            notes: None,
+            expires_at: None,
+            extra,
+        };
+        let v = serde_json::to_value(&body).expect("serialises");
+        assert_eq!(
+            v.get("favicon").and_then(|f| f.as_str()),
+            Some("data:image/png;base64,AA"),
+            "an unmodelled member sits beside the modelled ones"
+        );
+        assert!(
+            v.get("extra").is_none(),
+            "the hatch itself is never a member"
+        );
+    }
+}

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.14.31"
+version = "0.14.32"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/trust_tasks/conformance.rs
+++ b/vta-service/src/trust_tasks/conformance.rs
@@ -123,6 +123,7 @@ use vta_sdk::protocols::policy_management::{
     DeletePolicyBody, DeletePolicyResultBody, GetPolicyBody, GetPolicyResultBody, ListPoliciesBody,
     ListPoliciesResultBody, PolicyModuleView, UpsertPolicyBody, UpsertPolicyResultBody,
 };
+use vta_sdk::protocols::vault_management::VaultUpsertBody;
 use vta_sdk::protocols::vta_management::get_config::{
     ConfigField, GetConfigBody, GetConfigResultBody,
 };
@@ -1114,15 +1115,31 @@ fn table() -> Vec<(&'static str, Conformance)> {
             checked!(
                 specs::vault::upsert::v0_1::Payload,
                 specs::vault::upsert::v0_1::Response,
-                json!({
-                    "contextId": "ctx-a",
-                    "targets": [{ "kind": "web-origin", "origin": "https://example.com" }],
-                    "label": "example.com login",
-                    "secretKind": "password",
-                    "tags": ["work"],
-                    "sealedSecret": { "envelope": "didcomm-authcrypt", "jwe": "eyJwcm90ZWN0ZWQiOiJ..." },
-                    "expectedVersion": 3,
-                }),
+                {
+                    // Built from the producer's body — the minimal create,
+                    // with every optional unset. `sealedSecret` is not on the
+                    // body: `vault_upsert_typed` inserts it, because sealing
+                    // needs the client's HPKE context rather than the caller's.
+                    let mut v = to_v(VaultUpsertBody {
+                        context_id: "ctx-a".into(),
+                        targets: vec![
+                            json!({ "kind": "web-origin", "origin": "https://example.com" }),
+                        ],
+                        label: "example.com login".into(),
+                        secret_kind: "password".into(),
+                        id: None,
+                        expected_version: None,
+                        tags: None,
+                        notes: None,
+                        expires_at: None,
+                        extra: serde_json::Map::new(),
+                    });
+                    v.as_object_mut().expect("body is an object").insert(
+                        "sealedSecret".into(),
+                        json!({ "envelope": "didcomm-authcrypt", "jwe": "eyJ0eXAiOiJKV0UifQ" }),
+                    );
+                    v
+                },
                 json!({ "entry": to_v(vault_entry()), "created": false })
             ),
         ),


### PR DESCRIPTION
Stacked on #930 — review that first; this PR's diff is the second commit.

Option **C**, scoped to the one member of the pass-through family worth typing. #930 landed D (validate before dispatch) as the general backstop; this adds the type where a caller most benefits from one.

## The body

`VaultUpsertBody` names what exists today — `contextId`, `targets`, `label`, `secretKind`, plus the optionals — and carries `#[serde(flatten)] extra` for everything this build does not model.

**The hatch is the whole design.** Typing the body without it would mean an SDK release before a caller could use *any* member the spec adds. That forward-compatibility cost — not the typing effort — is exactly why the rest of `vault/*` stays a pass-through, and the hatch is what buys the coverage without paying it.

The trade is explicit rather than hidden: modelled members are guarded by the null census, `extra` is not. It's greppable, and **a member that lands in it repeatedly is one that wants promoting into the struct**.

## Additive, not breaking

`vault_upsert` keeps its `Value` signature exactly as it was; `vault_upsert_typed` sits beside it. Changing the existing method would break every caller for a benefit they can opt into instead — and after #930 the pass-through is no longer unguarded anyway, since it's validated against the published schema before dispatch. **D first, then C, was the right order for precisely that reason.**

`sealedSecret` stays off the body and is inserted by the method, because sealing needs the client's HPKE context rather than the caller's.

## Witness

Built from the body — a minimal create with every optional unset, plus the sealed envelope the method would add.

Teeth checked: reverting the skip on `tags` fails the sweep with `null is not of type "array"`. The old fixture set `tags`, so it could not have caught it.

## This closes the design question

Of the six genuine pass-throughs, `vault_upsert` gets a typed body; the other five keep theirs, guarded by #930's pre-dispatch check. `vault_delete` — which I had miscategorised as a pass-through — was folded in #930.

## Verification

- `cargo test -p vta-sdk --lib vault_management` — 3 passed
- `cargo test -p vta-service --lib trust_tasks::conformance` — 2 passed
- `cargo test -p vta-service --test producer_payload_conformance` — 5 passed
- `cargo clippy -p vta-sdk -p vta-service --all-targets` — clean
- `cargo +1.95.0 check --workspace --locked` — green against the **committed** tree
