### PR TITLE
feat(setup): offer TSP in the wizard, and advertise it at mint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9446,7 +9446,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.14.32"
+version = "0.14.33"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/changelog.d/933-vta-setup-offers-tsp.md
+++ b/changelog.d/933-vta-setup-offers-tsp.md
@@ -1,0 +1,52 @@
+### vta-service 0.14.33 — the setup wizard can choose TSP, and minting says so (#933)
+
+`vta setup` offered two transports, REST and DIDComm, in a hardcoded two-item
+list, and wrote `services.tsp = false` unconditionally — the wizard's TSP prompt
+had been deferred to "a later phase". A build compiled with `--features tsp`
+looked exactly like one without it.
+
+**The wizard now offers TSP as a third option**, but only in a build that
+compiled it. Without the feature there is no TSP dispatcher, and `#tsp` is the
+*first* entry a peer matching on transport preference picks — advertising it
+from a binary that can't answer would make the VTA unreachable for exactly the
+peers that read its DID document most carefully. An option that can't be served
+isn't offered.
+
+It is not pre-ticked. Whether TSP works depends on the operator's mediator,
+which nothing here can check, so opting in is a decision rather than a default
+someone accepted by pressing enter. Selecting it without DIDComm re-asks: TSP
+advertises the *same* mediator as DIDComm (D8), and that mediator is configured
+in the DIDComm section. The wizard says all of this at the prompt, including
+that `pnm services tsp enable` / `disable` can change it later.
+
+**Minting now advertises what was chosen.** `build_vta_additional_services`
+emits the `#tsp` entry (`TSPTransport`, endpoint = the mediator's DID, not a
+URL) alongside `VTARest`, using the same fragment and type constants the runtime
+`services tsp enable` patcher uses. Before this, `[services] tsp = true` set a
+config flag and published nothing — the VTA spoke TSP while its DID document
+told nobody, which is the shape of the bug #929 fixed for the VTC, and how the
+reference deployment acquired its `#tsp` entry at DID log version 3 by hand.
+A TSP-enabled VTA now carries it from log v1.
+
+`build_did_document_inner` ends by sorting `service[]` through
+`sort_services_canonical`, the same helper every runtime `with_*_service`
+patcher ends with. The entries are appended in construction order — DIDComm
+before the caller's additional services, which is where `#tsp` arrives — so
+without the sort a minted document would advertise DIDComm ahead of TSP and
+invert the preference order it is supposed to encode.
+
+**`--from <toml>`** gains the matching refusal: `services.tsp = true` in a
+binary built without the `tsp` feature now fails validation by name, next to the
+existing "TSP requires DIDComm" rule. The declarative path can't be protected by
+declining to offer a menu item, so it says it out loud.
+
+No capability detection, deliberately — nothing here can verify the named
+mediator routes TSP; its services belong to its own controller. The operator is
+told that plainly instead.
+
+Wizard test scripts answer the services multi-select **by label** rather than by
+index (`Answer::Labels`), the convention the secrets-backend menu already
+follows: its option list varies with the compiled feature set, so a positional
+answer would mean something different under `--features tsp`. The selection
+helpers take the option list as an argument, so the TSP mapping is covered in
+CI's default (non-`tsp`) build too, not only where the option appears.

--- a/docs/02-vta/cold-start.md
+++ b/docs/02-vta/cold-start.md
@@ -87,6 +87,13 @@ Data directory [data/vta]: data/vta
 (For a REST-only setup, uncheck DIDComm. DIDComm requires a mediator —
 see "Adding DIDComm messaging" at the end.)
 
+A binary built with `--features tsp` offers a third option, **TSP**, which
+advertises `#tsp` in the VTA DID document alongside DIDComm and points it at
+the same mediator. It is not pre-ticked, and it requires DIDComm — that is
+where the mediator is configured. Leave it off if you are unsure whether your
+mediator routes TSP: peers that prefer TSP fail rather than fall back, and
+`pnm services tsp enable` turns it on later.
+
 ### 2.2 BIP-39 mnemonic
 
 Choose **Generate new 24-word mnemonic**. Write down and store the

--- a/docs/02-vta/examples/vta-setup.example.toml
+++ b/docs/02-vta/examples/vta-setup.example.toml
@@ -69,6 +69,12 @@ admin_label = "ops-bootstrap"
 # Hand-editing it later has no effect.
 rest    = true
 didcomm = true
+# TSP (off by default). Advertises `#tsp` in the VTA DID document at mint,
+# pointing at the same mediator as DIDComm. Requires `didcomm = true` and a
+# binary built with `--features tsp`; setup refuses either combination rather
+# than publishing a transport this VTA cannot serve. Nothing checks that the
+# mediator actually routes TSP — see docs/02-vta/tsp.md.
+# tsp = true
 
 [server]
 host = "0.0.0.0"

--- a/docs/02-vta/non-interactive-setup.md
+++ b/docs/02-vta/non-interactive-setup.md
@@ -164,6 +164,12 @@ summary.
   `pnm services {kind} {enable,disable}` persist to a fjall keyspace
   (`service_state`), not back into `config.toml`. Hand-editing this block after
   first boot has no effect — use the runtime commands.
+  `tsp = true` additionally advertises `#tsp` in the VTA DID document at mint,
+  pointing at the same mediator as DIDComm. It requires `didcomm = true` (that
+  is where the mediator is configured) and a binary built with
+  `--features tsp`; setup refuses either combination by name rather than
+  publishing a transport the VTA cannot answer on. Nothing checks that the
+  mediator actually routes TSP — its services belong to its own controller.
 - **`[server]`** — `host = "0.0.0.0"`, `port = 8100`.
 - **`[log]`** — `level = "info"`, `format = "text"`.
 - **`[secrets]`** — required; tagged enum on `backend`. See below.

--- a/docs/02-vta/tsp.md
+++ b/docs/02-vta/tsp.md
@@ -48,10 +48,14 @@ TSP shares the DIDComm mediator, so **enable DIDComm first**. Two paths:
   transports. See [runtime-service-management.md](./runtime-service-management.md).
   Unlike `services didcomm enable`, `services tsp enable` works over **either**
   transport. TSP has **no drain** and **no handshake**.
-- **Declarative setup:** in a `vta setup --from <toml>` file, `[services] tsp =
-  true` (which **requires** `services.didcomm = true`). The interactive `vta
-  setup` wizard does **not** prompt for TSP yet — prefer enabling it post-setup
-  via `services tsp enable`, after verification.
+- **At setup:** the interactive `vta setup` wizard lists **TSP** in its services
+  multi-select, and a `vta setup --from <toml>` file takes `[services] tsp =
+  true`. Both **require** `services.didcomm = true` (that is where the mediator
+  is configured) and a binary built with `--features tsp` — setup refuses either
+  combination by name rather than publishing a transport it cannot serve. TSP is
+  not pre-ticked in the wizard, for the reason in *Rollout posture* below.
+  Choosing it here puts `#tsp` in the DID document from log v1, rather than
+  adding it in a later log entry.
 
 `pnm services list` shows TSP on/off + its mediator; `GET /health/details`
 reports `tsp_enabled`.
@@ -72,6 +76,7 @@ the automatic fallback for any peer that doesn't speak TSP.
 | `services tsp {enable,update,disable,rollback}` (REST + DIDComm + CLI + offline) | ✅ shipped |
 | DID templates advertise `#tsp` | ✅ shipped |
 | Health `tsp_enabled` + `services list` | ✅ shipped |
+| Setup: wizard multi-select + `--from` `[services] tsp`, both minting `#tsp` | ✅ shipped |
 | Inbound: `tsp-message` vault unseal | ✅ shipped (feature-gated; live unpack pending verification) |
 | Inbound: TSP listener (raw-TSP websocket → trust-task spine) | ✅ shipped (feature-gated; live loop pending verification) |
 | Auth over TSP | ✅ by construction (rides the inbound spine → `handle_authenticate`) |

--- a/docs/05-design-notes/tsp-enablement.md
+++ b/docs/05-design-notes/tsp-enablement.md
@@ -466,11 +466,19 @@ mediator-DID convention work, and the constraints to honour when building routes
 
 ## 9. Setup wizards
 
-- `vta-service/src/setup/interactive.rs`: add **TSP** to the services multiselect
-  (`["REST API", "DIDComm Messaging", "TSP"]`, ≥1 required) and a TSP-config branch
-  (endpoint URL / host) in the messaging section.
-- `vta-service/src/setup/from_toml.rs`: `ServicesConfig.tsp` + a TSP variant of
-  `MessagingInput`.
+- `vta-service/src/setup/interactive.rs`: **done** — TSP is the third entry in the
+  services multiselect, listed only in a `--features tsp` build (an option that
+  can't be served isn't offered), not pre-ticked, and refused without DIDComm.
+  No TSP-config branch was needed after all: D8 settled that TSP advertises the
+  *same* mediator as DIDComm, so there is no separate endpoint to ask for — the
+  DIDComm messaging section already collected it.
+- `vta-service/src/setup/from_toml.rs`: **done** — `ServicesConfig.tsp`, with
+  `validate_inputs` refusing `tsp` without `didcomm` and refusing `tsp` in a
+  binary built without the transport. No TSP variant of `MessagingInput`, for
+  the same D8 reason.
+- `vta-service/src/setup.rs`: **done** — `build_vta_additional_services` emits the
+  `#tsp` entry at mint, so a TSP-enabled VTA advertises it from DID log v1
+  rather than acquiring it by hand later.
 - `pnm-cli/src/setup.rs`, `cnm-cli/src/setup.rs`: these **discover** transport from the
   peer DID doc rather than prompting, so they inherit §3 with little new prompting; PNM
   persists a TSP analog next to `mediator_did` where relevant.

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.14.32"
+version = "0.14.33"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/operations/did_webvh/document.rs
+++ b/vta-service/src/operations/did_webvh/document.rs
@@ -174,5 +174,85 @@ fn build_did_document_inner(
         }));
     }
 
+    // `service[]` order is what tells a resolver which transport to
+    // prefer (TSP > DIDComm > REST > WebAuthn — runtime-service-
+    // management spec §3.3), and the entries above are appended in
+    // construction order, not preference order: DIDComm before the
+    // caller's `additional_services`, which is where `#tsp` arrives.
+    // Sort through the same helper every runtime `with_*_service`
+    // patcher ends with, so a document minted here and one patched by
+    // `services … enable` agree.
+    crate::operations::protocol::document::sort_services_canonical(&mut did_document);
+
     did_document
+}
+
+#[cfg(test)]
+mod tests {
+    use affinidi_tdk::secrets_resolver::secrets::Secret;
+
+    use super::*;
+    use crate::config::MessagingConfig;
+
+    /// Deterministic key material — this module only reads the public
+    /// multibase strings out of it.
+    fn fake_keys() -> keys::DerivedEntityKeys {
+        let signing_secret = Secret::generate_ed25519(None, Some(&[7u8; 32]));
+        let ka_secret = Secret::generate_ed25519(None, Some(&[9u8; 32]))
+            .to_x25519()
+            .expect("x25519 conversion");
+        keys::DerivedEntityKeys {
+            signing_pub: signing_secret.get_public_keymultibase().unwrap(),
+            signing_secret,
+            signing_path: "m/26'/2'/0'/0'".into(),
+            signing_priv: String::new(),
+            signing_label: "signing".into(),
+            ka_pub: ka_secret.get_public_keymultibase().unwrap(),
+            ka_secret,
+            ka_path: "m/26'/2'/0'/1'".into(),
+            ka_priv: String::new(),
+            ka_label: "ka".into(),
+        }
+    }
+
+    /// `service[]` order encodes transport preference to a resolver, and
+    /// the entries are appended here in construction order — DIDComm
+    /// before the caller's `additional_services`, which is where `#tsp`
+    /// and `#vta-rest` arrive. The builder must leave them canonically
+    /// ordered (TSP > DIDComm > REST) regardless.
+    #[test]
+    fn services_are_published_in_canonical_transport_order() {
+        let mut config = crate::test_support::test_app_config(std::path::PathBuf::from("/tmp/x"));
+        config.messaging = Some(MessagingConfig {
+            mediator_url: "https://mediator.example.com".into(),
+            mediator_did: "did:webvh:mediator.example.com:mediator".into(),
+            mediator_host: None,
+            setup_acl: false,
+            drain_inbox_on_start: false,
+        });
+
+        // The order the setup path hands them over: TSP then REST, both
+        // *after* the DIDComm entry this builder pushes itself.
+        let additional = Some(vec![
+            json!({
+                "id": "{DID}#tsp",
+                "type": "TSPTransport",
+                "serviceEndpoint": "did:webvh:mediator.example.com:mediator",
+            }),
+            json!({
+                "id": "{DID}#vta-rest",
+                "type": "VTARest",
+                "serviceEndpoint": "https://vta.example.com",
+            }),
+        ]);
+
+        let doc = build_did_document(&fake_keys(), &config, true, &additional);
+        let types: Vec<&str> = doc["service"]
+            .as_array()
+            .expect("service array")
+            .iter()
+            .map(|s| s["type"].as_str().unwrap())
+            .collect();
+        assert_eq!(types, ["TSPTransport", "DIDCommMessaging", "VTARest"]);
+    }
 }

--- a/vta-service/src/setup.rs
+++ b/vta-service/src/setup.rs
@@ -21,6 +21,7 @@ use url::Url;
 
 use crate::config::ServicesConfig;
 use crate::contexts::{self, ContextRecord};
+use crate::operations::protocol::document::{TSP_SERVICE_FRAGMENT, TSP_SERVICE_TYPE};
 use crate::store::KeyspaceHandle;
 
 mod from_toml;
@@ -114,11 +115,24 @@ pub(crate) fn generate_mnemonic_silent() -> Result<Mnemonic, Box<dyn std::error:
 /// publishes apart from the auto-injected DIDComm/Authentication
 /// entries that `create_simple_webvh_did` adds itself.
 ///
-/// Currently this is just the `VTARest` entry: present iff REST is
-/// enabled and a `public_url` is configured. Returns `None` (rather
-/// than `Some(vec![])`) when the array would be empty so the
-/// downstream call can pass `None` through to the WebVH builder
-/// without a special case.
+/// Two entries live here:
+///
+/// - `VTARest`, present iff REST is enabled and a `public_url` is
+///   configured;
+/// - `TSPTransport` (`#tsp`), present iff TSP is enabled and a mediator
+///   was resolved — TSP advertises the **same** mediator as DIDComm
+///   (tsp-enablement.md D8), so the endpoint is that mediator's DID, not
+///   a transport URL.
+///
+/// Returns `None` (rather than `Some(vec![])`) when the array would be
+/// empty so the downstream call can pass `None` through to the WebVH
+/// builder without a special case.
+///
+/// Minting `#tsp` here rather than leaving it to a later `services tsp
+/// enable` is the point: a VTA that speaks TSP but doesn't say so in its
+/// DID document is unreachable over TSP, since the document is what a
+/// peer matches on. Publishing it by hand after the fact is how the
+/// reference deployment ended up with a `#tsp` entry at log version 3.
 ///
 /// The non-interactive setup path's `validate_inputs` rejects
 /// `services.rest = true` + `public_url = None` at parse time, and
@@ -134,8 +148,22 @@ pub(crate) fn generate_mnemonic_silent() -> Result<Mnemonic, Box<dyn std::error:
 pub(crate) fn build_vta_additional_services(
     services: &ServicesConfig,
     public_url: Option<&str>,
+    mediator_did: Option<&str>,
 ) -> Option<Vec<JsonValue>> {
     let mut additional = Vec::new();
+    // Same fragment + type the runtime `services tsp enable` patcher
+    // emits, so a document minted at setup and one patched later are the
+    // same shape. Order within this Vec doesn't matter: the document
+    // builder sorts `service[]` canonically once everything is appended.
+    if services.tsp
+        && let Some(did) = mediator_did.map(str::trim).filter(|d| !d.is_empty())
+    {
+        additional.push(json!({
+            "id": format!("{{DID}}{TSP_SERVICE_FRAGMENT}"),
+            "type": TSP_SERVICE_TYPE,
+            "serviceEndpoint": did,
+        }));
+    }
     if services.rest
         && let Some(url) = public_url.map(str::trim).filter(|u| !u.is_empty())
     {
@@ -261,7 +289,7 @@ mod tests {
             webauthn: false,
             tsp: false,
         };
-        let out = build_vta_additional_services(&services, url)
+        let out = build_vta_additional_services(&services, url, None)
             .expect("REST + URL must emit a service entry");
         assert_eq!(out.len(), 1);
         assert_eq!(out[0]["type"], "VTARest");
@@ -269,18 +297,19 @@ mod tests {
         assert_eq!(out[0]["id"], "{DID}#vta-rest");
 
         // 2. REST + URL with surrounding whitespace → trimmed in the entry.
-        let out = build_vta_additional_services(&services, Some("  https://vta.example.com  "))
-            .expect("whitespace-padded URL must still emit");
+        let out =
+            build_vta_additional_services(&services, Some("  https://vta.example.com  "), None)
+                .expect("whitespace-padded URL must still emit");
         assert_eq!(out[0]["serviceEndpoint"], "https://vta.example.com");
 
         // 3. REST + None → empty (validate_inputs rejects this combo
         //    upstream, but the helper still must not produce a bogus
         //    entry if it ever sees it).
-        assert!(build_vta_additional_services(&services, None).is_none());
+        assert!(build_vta_additional_services(&services, None, None).is_none());
 
         // 4. REST + empty string → empty (treated like None).
-        assert!(build_vta_additional_services(&services, Some("")).is_none());
-        assert!(build_vta_additional_services(&services, Some("   ")).is_none());
+        assert!(build_vta_additional_services(&services, Some(""), None).is_none());
+        assert!(build_vta_additional_services(&services, Some("   "), None).is_none());
 
         // 5. REST disabled, URL set → no VTARest entry. The URL is
         //    still in `AppConfig.public_url` for other uses, but it
@@ -292,7 +321,7 @@ mod tests {
             tsp: false,
         };
         assert!(
-            build_vta_additional_services(&services, url).is_none(),
+            build_vta_additional_services(&services, url, None).is_none(),
             "URL must not be published as a service when REST is disabled"
         );
 
@@ -304,7 +333,65 @@ mod tests {
             webauthn: false,
             tsp: false,
         };
-        assert!(build_vta_additional_services(&services, None).is_none());
+        assert!(build_vta_additional_services(&services, None, None).is_none());
+    }
+
+    /// The `#tsp` half of the same helper: swept over
+    /// `(services.tsp, mediator_did)`.
+    ///
+    /// TSP advertises the DIDComm mediator's **DID** (mediator
+    /// indirection — the transport URL lives in the mediator's own
+    /// document), so with no mediator resolved there is nothing to
+    /// point at and the entry must not be emitted.
+    #[test]
+    fn build_vta_additional_services_tsp_matrix() {
+        let mediator = Some("did:webvh:mediator.example.com:mediator");
+        let tsp_only = ServicesConfig {
+            rest: false,
+            didcomm: true,
+            webauthn: false,
+            tsp: true,
+        };
+
+        // 1. TSP + mediator → one TSPTransport entry, endpoint = the
+        //    mediator DID as a plain string (not an object, not a URL).
+        let out = build_vta_additional_services(&tsp_only, None, mediator)
+            .expect("TSP + mediator must emit a service entry");
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0]["type"], "TSPTransport");
+        assert_eq!(out[0]["id"], "{DID}#tsp");
+        assert_eq!(
+            out[0]["serviceEndpoint"],
+            "did:webvh:mediator.example.com:mediator"
+        );
+
+        // 2. TSP without a mediator (messaging skipped) → nothing. An
+        //    endpoint-less `#tsp` would advertise a route to nowhere.
+        assert!(build_vta_additional_services(&tsp_only, None, None).is_none());
+        assert!(build_vta_additional_services(&tsp_only, None, Some("")).is_none());
+        assert!(build_vta_additional_services(&tsp_only, None, Some("   ")).is_none());
+
+        // 3. TSP off + mediator present → no `#tsp`. A VTA running
+        //    DIDComm through a TSP-capable mediator still doesn't claim
+        //    TSP unless the operator asked for it.
+        let no_tsp = ServicesConfig {
+            tsp: false,
+            ..tsp_only
+        };
+        assert!(build_vta_additional_services(&no_tsp, None, mediator).is_none());
+
+        // 4. REST + TSP → both entries. Their order in this Vec is not
+        //    the published order: `build_did_document_inner` sorts
+        //    `service[]` canonically after appending.
+        let both = ServicesConfig {
+            rest: true,
+            ..tsp_only
+        };
+        let out = build_vta_additional_services(&both, Some("https://vta.example.com"), mediator)
+            .expect("REST + TSP must emit both entries");
+        assert_eq!(out.len(), 2);
+        let types: Vec<&str> = out.iter().map(|s| s["type"].as_str().unwrap()).collect();
+        assert!(types.contains(&"TSPTransport") && types.contains(&"VTARest"));
     }
 
     /// `derive_ws_url` is the single source of truth for the mediator's

--- a/vta-service/src/setup/from_toml.rs
+++ b/vta-service/src/setup/from_toml.rs
@@ -925,6 +925,11 @@ pub async fn apply_inputs(
             let services = super::build_vta_additional_services(
                 &inputs.services,
                 inputs.public_url.as_deref(),
+                // `#tsp` points at the DIDComm mediator resolved above.
+                // `None` when messaging was skipped — then there is no
+                // endpoint to advertise and the entry is dropped rather
+                // than published empty.
+                messaging.as_ref().map(|m| m.mediator_did.as_str()),
             );
             let did = create_simple_webvh_did(
                 "VTA",
@@ -1102,6 +1107,22 @@ fn validate_inputs(inputs: &WizardInputs) -> Result<(), Box<dyn std::error::Erro
              the same mediator as DIDComm. Set services.didcomm = true (and \
              configure messaging), or leave TSP off here and enable it later with \
              `services tsp enable`"
+                .into(),
+        );
+    }
+    // A binary built without the `tsp` feature has no TSP dispatcher (the
+    // inbound half lives behind that flag), so `services.tsp = true` would
+    // advertise `#tsp` — the *first* entry a peer matching on transport
+    // preference picks — for a transport this VTA cannot answer on. The
+    // interactive wizard handles this by not offering the option; the
+    // declarative path has to say it out loud.
+    #[cfg(not(feature = "tsp"))]
+    if inputs.services.tsp {
+        errors.push(
+            "services.tsp = true, but this VTA was built without the `tsp` feature and has \
+             no TSP dispatcher — advertising `#tsp` would publish a transport it cannot \
+             serve, and TSP-preferring peers would fail rather than fall back to DIDComm. \
+             Rebuild with `--features tsp`, or set services.tsp = false"
                 .into(),
         );
     }
@@ -2805,12 +2826,11 @@ mod tests {
         );
     }
 
-    #[test]
-    fn services_tsp_with_didcomm_passes_and_carries_through() {
-        // The declarative TSP path: `[services] tsp = true` (with DIDComm)
-        // parses, validates, and the flag is carried on `WizardInputs.services`
-        // (which `apply` writes verbatim to `config.services`).
-        let raw = r#"
+    /// A `[services] tsp = true` + DIDComm setup file, whose fate depends
+    /// on whether this binary can serve TSP. Both outcomes are asserted
+    /// below — one per build.
+    #[cfg(test)]
+    const TSP_WITH_DIDCOMM_TOML: &str = r#"
             config_path = "/tmp/vta-test/config.toml"
             data_dir    = "/tmp/vta-test/data"
 
@@ -2822,9 +2842,31 @@ mod tests {
             [secrets]
             backend = "keyring"
         "#;
-        let inputs = parse(raw).expect("parses");
+
+    #[cfg(feature = "tsp")]
+    #[test]
+    fn services_tsp_with_didcomm_passes_and_carries_through() {
+        // The declarative TSP path: `[services] tsp = true` (with DIDComm)
+        // parses, validates, and the flag is carried on `WizardInputs.services`
+        // (which `apply` writes verbatim to `config.services`).
+        let inputs = parse(TSP_WITH_DIDCOMM_TOML).expect("parses");
         validate_inputs(&inputs).expect("tsp + didcomm should validate");
         assert!(inputs.services.tsp, "tsp flag must be carried through");
+    }
+
+    #[cfg(not(feature = "tsp"))]
+    #[test]
+    fn services_tsp_is_refused_when_the_binary_cannot_serve_it() {
+        // Same file, a binary with no TSP dispatcher: refused by name
+        // rather than minting a DID document that advertises `#tsp` and
+        // then never answering on it.
+        let inputs = parse(TSP_WITH_DIDCOMM_TOML).expect("parses");
+        let err = validate_inputs(&inputs)
+            .expect_err("tsp must be refused without the compiled transport");
+        assert!(
+            err.to_string().contains("built without the `tsp` feature"),
+            "got: {err}"
+        );
     }
 
     #[test]

--- a/vta-service/src/setup/interactive.rs
+++ b/vta-service/src/setup/interactive.rs
@@ -223,20 +223,117 @@ fn prompt_hardened(p: &dyn Prompter) -> Result<HardenedConfig, DynErr> {
     })
 }
 
-/// Prompt which services to enable. Returns `(rest, didcomm)`; at least one.
-fn prompt_services(p: &dyn Prompter) -> Result<(bool, bool), DynErr> {
-    let items = ["REST API", "DIDComm Messaging"];
+/// Labels for the transport multiselect. Answers are mapped back onto
+/// flags **by label** ([`services_from_selection`]) rather than by
+/// position, because the option list varies with the compiled feature
+/// set — a positional mapping would quietly mean something different in
+/// a `--features tsp` build than in a default one.
+const REST_ITEM: &str = "REST API";
+const DIDCOMM_ITEM: &str = "DIDComm Messaging";
+const TSP_ITEM: &str = "TSP (Trust Spanning Protocol)";
+
+/// Which transports the operator chose.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) struct ServiceSelection {
+    pub rest: bool,
+    pub didcomm: bool,
+    pub tsp: bool,
+}
+
+/// The transport options *this build* can offer.
+///
+/// TSP is listed only when the binary was compiled with `--features
+/// tsp`. Without it there is no TSP dispatcher (the inbound half lives
+/// behind that flag), so advertising a `#tsp` service would publish a
+/// transport this VTA cannot serve — and because TSP is *first* in the
+/// preference order, a peer that honours the DID document would pick it
+/// and fail rather than fall back to DIDComm. An option that can't be
+/// served isn't offered.
+fn service_items() -> Vec<&'static str> {
+    // `mut` is load-bearing only in a `tsp` build.
+    #[allow(unused_mut)]
+    let mut items = vec![REST_ITEM, DIDCOMM_ITEM];
+    #[cfg(feature = "tsp")]
+    items.push(TSP_ITEM);
+    items
+}
+
+/// Resolve the chosen indices into flags by matching labels, so the
+/// mapping is independent of how many options this build offered.
+fn services_from_selection(items: &[&str], selected: &[usize]) -> ServiceSelection {
+    let picked = |label: &str| {
+        items
+            .iter()
+            .position(|it| *it == label)
+            .is_some_and(|i| selected.contains(&i))
+    };
+    ServiceSelection {
+        rest: picked(REST_ITEM),
+        didcomm: picked(DIDCOMM_ITEM),
+        tsp: picked(TSP_ITEM),
+    }
+}
+
+/// The rules a transport selection must satisfy, as the text shown when
+/// it doesn't. `Ok(())` means the selection is usable.
+fn validate_services(sel: &ServiceSelection) -> Result<(), String> {
+    if !sel.rest && !sel.didcomm && !sel.tsp {
+        return Err("Please select at least one service.".into());
+    }
+    // TSP advertises the **same** mediator as DIDComm (one dual-protocol
+    // mediator — tsp-enablement.md D8), and that mediator is configured in
+    // the DIDComm section further down. TSP without DIDComm would point
+    // `#tsp` at a mediator this VTA never configured. `validate_inputs`
+    // enforces the same rule for `--from <toml>`; both paths need it
+    // because neither reaches the other's checkpoint.
+    if sel.tsp && !sel.didcomm {
+        return Err(
+            "TSP shares the DIDComm mediator — select DIDComm Messaging as well, \
+                    or leave TSP off and enable it later with `pnm services tsp enable`."
+                .into(),
+        );
+    }
+    Ok(())
+}
+
+/// Prompt which services to enable. At least one, and TSP implies
+/// DIDComm; anything else re-asks rather than proceeding.
+fn prompt_services(p: &dyn Prompter) -> Result<ServiceSelection, DynErr> {
+    let items = service_items();
+    // TSP is not pre-ticked even in a build that can serve it: whether it
+    // works depends on the operator's mediator, which nothing here can
+    // check. Opting in should be a decision, not a default someone
+    // accepted by pressing enter.
+    let defaults: Vec<bool> = items.iter().map(|it| *it != TSP_ITEM).collect();
     loop {
         let selected = p.multiselect(
             "Services to enable (select at least one)",
             &items,
-            &[true, true],
+            &defaults,
         )?;
-        if selected.is_empty() {
-            eprintln!("\x1b[31mPlease select at least one service.\x1b[0m");
+        let selection = services_from_selection(&items, &selected);
+        if let Err(msg) = validate_services(&selection) {
+            eprintln!("\x1b[31m{msg}\x1b[0m");
             continue;
         }
-        return Ok((selected.contains(&0), selected.contains(&1)));
+        if selection.tsp {
+            eprintln!();
+            eprintln!(
+                "  \x1b[2mTSP will be advertised as `#tsp` in the VTA DID document, \
+                 pointing at the same mediator as DIDComm.\x1b[0m"
+            );
+            eprintln!(
+                "  \x1b[2mNothing here can verify that mediator routes TSP — its services \
+                 belong to its own controller. If it doesn't, peers that prefer TSP fail \
+                 rather than fall back.\x1b[0m"
+            );
+            eprintln!(
+                "  \x1b[2mThis is changeable later: `pnm services tsp enable` / \
+                 `disable`.\x1b[0m"
+            );
+            eprintln!();
+        }
+        return Ok(selection);
     }
 }
 
@@ -861,7 +958,11 @@ async fn gather_inputs(
     };
 
     // 3. Services.
-    let (enable_rest, enable_didcomm) = prompt_services(p)?;
+    let ServiceSelection {
+        rest: enable_rest,
+        didcomm: enable_didcomm,
+        tsp: enable_tsp,
+    } = prompt_services(p)?;
 
     // 4. Server host + port + REST URL (URL asked after the port so the
     //    localhost default can use it).
@@ -1056,9 +1157,7 @@ async fn gather_inputs(
             rest: enable_rest,
             didcomm: enable_didcomm,
             webauthn,
-            // TSP is enabled post-setup via `services tsp enable` (the
-            // interactive wizard's TSP prompt lands in a later phase).
-            tsp: false,
+            tsp: enable_tsp,
         },
         server: ServerConfig {
             host,
@@ -1115,7 +1214,6 @@ mod tests {
         Text(String),
         Bool(bool),
         Index(usize),
-        Indices(Vec<usize>),
         /// Pick a `select` option by its **label** rather than its position.
         ///
         /// Prefer this over [`Answer::Index`] whenever the option list depends
@@ -1130,6 +1228,10 @@ mod tests {
         /// Matching on the label is immune to options being added, removed, or
         /// reordered, and fails at the *right* prompt when a label disappears.
         Label(&'static str),
+        /// [`Answer::Label`] for a `multiselect`: pick every listed option by
+        /// label. The services prompt needs it for the same reason — its option
+        /// list grows a "TSP" entry under `--features tsp`.
+        Labels(Vec<&'static str>),
     }
 
     /// Head-less [`Prompter`] that replays a fixed script of answers. Panics on
@@ -1194,12 +1296,23 @@ mod tests {
         fn multiselect(
             &self,
             prompt: &str,
-            _items: &[&str],
+            items: &[&str],
             _defaults: &[bool],
         ) -> Result<Vec<usize>, DynErr> {
             match self.next(prompt) {
-                Answer::Indices(v) => Ok(v),
-                _ => panic!("expected Indices answer for prompt: {prompt}"),
+                Answer::Labels(want) => want
+                    .iter()
+                    .map(|w| {
+                        items.iter().position(|it| it == w).ok_or_else(|| {
+                            format!(
+                                "scripted label {w:?} is not an option for prompt {prompt:?}; \
+                                 available: {items:?}"
+                            )
+                            .into()
+                        })
+                    })
+                    .collect(),
+                _ => panic!("expected Labels answer for prompt: {prompt}"),
             }
         }
     }
@@ -1224,12 +1337,14 @@ mod tests {
         let answers = vec![
             text("/tmp/vta-golden/config.toml"), // config path (doesn't exist)
             text("golden-vta"),                  // vta name
-            Answer::Indices(vec![0, 1]),         // services: REST + DIDComm
-            text("0.0.0.0"),                     // host
-            text("8100"),                        // port
-            text("https://trust.example.com"),   // REST URL
-            text("info"),                        // log level
-            Answer::Index(0),                    // log format = text
+            // Labels, not indices: the services list grows a TSP option
+            // under `--features tsp`.
+            Answer::Labels(vec![REST_ITEM, DIDCOMM_ITEM]), // services
+            text("0.0.0.0"),                               // host
+            text("8100"),                                  // port
+            text("https://trust.example.com"),             // REST URL
+            text("info"),                                  // log level
+            Answer::Index(0),                              // log format = text
             // TEE builds add an extra "Remote DID resolver WebSocket URL"
             // prompt here (vsock-bridged resolution); empty = skip. Only
             // scripted when `tee` is active so the answer sequence stays
@@ -1330,7 +1445,7 @@ mod tests {
         let answers = vec![
             text(dir.path().join("config.toml").to_str().unwrap()), // doesn't exist
             text(""),                                               // vta name (skip)
-            Answer::Indices(vec![0]),                               // services: REST only
+            Answer::Labels(vec![REST_ITEM]),                        // services: REST only
             text("0.0.0.0"),                                        // host
             text("8100"),                                           // port
             text("https://t.example.com"),                          // REST URL
@@ -1380,7 +1495,7 @@ mod tests {
             text(config_path.to_str().unwrap()), // config path — exists
             Answer::Bool(true),                  // overwrite? yes
             text(""),                            // vta name (skip)
-            Answer::Indices(vec![1]),            // services: DIDComm only (no URL prompts)
+            Answer::Labels(vec![DIDCOMM_ITEM]),  // services: DIDComm only (no URL prompts)
             text("info"),                        // log level
             Answer::Index(0),                    // log format
             #[cfg(feature = "tee")]
@@ -1420,20 +1535,20 @@ mod tests {
 
             let answers = vec![
                 text(dir.path().join("config.toml").to_str().unwrap()),
-                text(""),                 // vta name (skip)
-                Answer::Indices(vec![1]), // services: DIDComm only
-                text("info"),             // log level
-                Answer::Index(0),         // log format
+                text(""),                           // vta name (skip)
+                Answer::Labels(vec![DIDCOMM_ITEM]), // services: DIDComm only
+                text("info"),                       // log level
+                Answer::Index(0),                   // log format
                 #[cfg(feature = "tee")]
                 text(""), // TEE-only: remote DID resolver URL (skip)
-                text("28"),               // audit retention
-                text(data_dir.to_str().unwrap()), // data dir — holds a store
-                Answer::Index(choice),    // reuse / delete
-                Answer::Label("OS keyring"), // label, not index: menu grows with features
-                text("vta"),              // keyring service
-                Answer::Bool(false),      // hardened configuration? no
-                Answer::Index(2),         // messaging = skip
-                Answer::Index(1),         // VTA DID = did:key
+                text("28"),                         // audit retention
+                text(data_dir.to_str().unwrap()),   // data dir — holds a store
+                Answer::Index(choice),              // reuse / delete
+                Answer::Label("OS keyring"),        // label, not index: menu grows with features
+                text("vta"),                        // keyring service
+                Answer::Bool(false),                // hardened configuration? no
+                Answer::Index(2),                   // messaging = skip
+                Answer::Index(1),                   // VTA DID = did:key
             ];
             let gathered = gather_inputs(&ScriptedPrompter::new(answers), None)
                 .await
@@ -1449,13 +1564,13 @@ mod tests {
     async fn advanced_existing_keys_mode_maps_through() {
         let answers = vec![
             text("/tmp/vta-golden2/config.toml"),
-            text(""),                      // vta name (skip)
-            Answer::Indices(vec![0]),      // services: REST only
-            text("0.0.0.0"),               // host
-            text("8100"),                  // port
-            text("https://t.example.com"), // REST URL
-            text("info"),                  // log level
-            Answer::Index(0),              // log format
+            text(""),                        // vta name (skip)
+            Answer::Labels(vec![REST_ITEM]), // services: REST only
+            text("0.0.0.0"),                 // host
+            text("8100"),                    // port
+            text("https://t.example.com"),   // REST URL
+            text("info"),                    // log level
+            Answer::Index(0),                // log format
             // TEE-only "Remote DID resolver WebSocket URL" prompt; empty =
             // skip. See the note in `interactive_matches_equivalent_toml`.
             #[cfg(feature = "tee")]
@@ -1503,5 +1618,184 @@ mod tests {
             }
             other => panic!("expected CreateWebvh, got {other:?}"),
         }
+    }
+
+    // -----------------------------------------------------------------
+    // Transport selection
+    //
+    // The three helpers below are deliberately feature-independent: they
+    // take the option list as an argument, so these tests exercise the
+    // TSP mapping in *every* build. CI runs a plain `cargo test
+    // --workspace` (no `tsp`), so a `#[cfg(feature = "tsp")]` test of the
+    // mapping would never run there.
+    // -----------------------------------------------------------------
+
+    /// TSP is offered iff this build can serve it.
+    #[test]
+    fn service_items_lists_tsp_only_in_a_tsp_build() {
+        let items = service_items();
+        assert!(items.contains(&REST_ITEM) && items.contains(&DIDCOMM_ITEM));
+        assert_eq!(
+            items.contains(&TSP_ITEM),
+            cfg!(feature = "tsp"),
+            "a build without the TSP dispatcher must not offer to advertise `#tsp`"
+        );
+    }
+
+    /// Answers map to flags by label, so the same index means different
+    /// things in the two-option and three-option lists.
+    #[test]
+    fn services_from_selection_maps_by_label_not_position() {
+        let without_tsp = [REST_ITEM, DIDCOMM_ITEM];
+        let with_tsp = [REST_ITEM, DIDCOMM_ITEM, TSP_ITEM];
+
+        // Index 1 is DIDComm in both lists — and TSP in neither.
+        for items in [&without_tsp[..], &with_tsp[..]] {
+            let sel = services_from_selection(items, &[1]);
+            assert_eq!(
+                sel,
+                ServiceSelection {
+                    rest: false,
+                    didcomm: true,
+                    tsp: false
+                },
+                "items {items:?}"
+            );
+        }
+
+        // Index 2 is TSP only where TSP is on the menu; a selection that
+        // can't be resolved to a label leaves the flag off rather than
+        // guessing.
+        assert_eq!(
+            services_from_selection(&with_tsp, &[1, 2]),
+            ServiceSelection {
+                rest: false,
+                didcomm: true,
+                tsp: true
+            }
+        );
+        assert_eq!(
+            services_from_selection(&without_tsp, &[1, 2]),
+            ServiceSelection {
+                rest: false,
+                didcomm: true,
+                tsp: false
+            }
+        );
+
+        // Everything ticked.
+        assert_eq!(
+            services_from_selection(&with_tsp, &[0, 1, 2]),
+            ServiceSelection {
+                rest: true,
+                didcomm: true,
+                tsp: true
+            }
+        );
+    }
+
+    /// At least one transport, and TSP implies DIDComm (it advertises the
+    /// DIDComm mediator). Mirrors `validate_inputs`' rule for `--from`.
+    #[test]
+    fn validate_services_requires_one_and_tsp_implies_didcomm() {
+        let none = ServiceSelection::default();
+        assert!(
+            validate_services(&none)
+                .unwrap_err()
+                .contains("at least one service")
+        );
+
+        let tsp_only = ServiceSelection {
+            rest: false,
+            didcomm: false,
+            tsp: true,
+        };
+        assert!(
+            validate_services(&tsp_only)
+                .unwrap_err()
+                .contains("shares the DIDComm mediator"),
+            "TSP alone points `#tsp` at a mediator the VTA never configured"
+        );
+
+        // REST + TSP is the same defect with a transport in hand — still
+        // refused, because the `#tsp` endpoint would still be unset.
+        let rest_and_tsp = ServiceSelection {
+            rest: true,
+            didcomm: false,
+            tsp: true,
+        };
+        assert!(validate_services(&rest_and_tsp).is_err());
+
+        for ok in [
+            ServiceSelection {
+                rest: true,
+                didcomm: false,
+                tsp: false,
+            },
+            ServiceSelection {
+                rest: false,
+                didcomm: true,
+                tsp: false,
+            },
+            ServiceSelection {
+                rest: true,
+                didcomm: true,
+                tsp: true,
+            },
+        ] {
+            assert!(validate_services(&ok).is_ok(), "{ok:?} must be accepted");
+        }
+    }
+
+    /// End-to-end: ticking TSP in the wizard reaches `services.tsp` in the
+    /// plan the engine consumes. Only meaningful where TSP is on the menu
+    /// — the mapping itself is covered feature-independently above.
+    #[cfg(feature = "tsp")]
+    #[tokio::test]
+    async fn ticking_tsp_reaches_the_plan() {
+        let dir = tempfile::tempdir().unwrap();
+        let answers = vec![
+            text(dir.path().join("config.toml").to_str().unwrap()),
+            text(""), // vta name (skip)
+            Answer::Labels(vec![DIDCOMM_ITEM, TSP_ITEM]),
+            text("info"),     // log level
+            Answer::Index(0), // log format
+            #[cfg(feature = "tee")]
+            text(""), // TEE-only: remote DID resolver URL (skip)
+            text("28"),       // audit retention
+            text(dir.path().join("data").to_str().unwrap()), // data dir (fresh)
+            Answer::Label("OS keyring"),
+            text("vta"),         // keyring service
+            Answer::Bool(false), // hardened configuration? no
+            Answer::Index(2),    // messaging = skip
+            Answer::Index(1),    // VTA DID = did:key
+        ];
+        let gathered = gather_inputs(&ScriptedPrompter::new(answers), None)
+            .await
+            .expect("gather should succeed")
+            .expect("gather should not cancel");
+
+        assert!(gathered.services.tsp, "ticking TSP must set services.tsp");
+        assert!(gathered.services.didcomm);
+        assert!(!gathered.services.rest);
+    }
+
+    /// Selecting TSP without DIDComm re-asks instead of proceeding.
+    #[cfg(feature = "tsp")]
+    #[test]
+    fn tsp_without_didcomm_reasks() {
+        let p = ScriptedPrompter::new(vec![
+            Answer::Labels(vec![TSP_ITEM]), // refused → re-prompt
+            Answer::Labels(vec![DIDCOMM_ITEM, TSP_ITEM]),
+        ]);
+        let sel = prompt_services(&p).expect("second answer is valid");
+        assert_eq!(
+            sel,
+            ServiceSelection {
+                rest: false,
+                didcomm: true,
+                tsp: true
+            }
+        );
     }
 }


### PR DESCRIPTION
`vta setup` offered two transports from a hardcoded two-item list and wrote
`services.tsp = false` unconditionally — the TSP prompt had been deferred to "a
later phase" (SDD §9, left undone by #598). A build compiled with `--features
tsp` looked exactly like one without it.

## The prompt

TSP is now the third option in the services multi-select, listed **only in a
build that compiled it**. Without the feature there is no TSP dispatcher, and
`#tsp` is the *first* entry a peer matching on transport preference picks —
advertising it from a binary that can't answer would make the VTA unreachable
for exactly the peers that read its DID document most carefully. An option that
can't be served isn't offered.

It is **not pre-ticked**. Whether TSP works depends on the operator's mediator,
which nothing here can check, so opting in is a decision rather than a default
someone accepted by pressing enter. Selecting it without DIDComm re-asks: TSP
advertises the *same* mediator as DIDComm (D8), and that mediator is configured
in the DIDComm section. The prompt says all of this, including that
`pnm services tsp enable` / `disable` can change it later.

## Minting now advertises what was chosen

Found while doing the above: `[services] tsp = true` set a config flag and
published **nothing**. `build_vta_additional_services` only ever emitted
`#vta-rest`, so a TSP-enabled VTA spoke TSP while its DID document told nobody
— the shape of the bug #929 fixed for the VTC, and how the reference deployment
acquired its `#tsp` entry at DID log version 3 by hand. A prompt writing an
inert flag would have been a half-feature, so:

- `build_vta_additional_services` emits the `#tsp` entry (`TSPTransport`,
  endpoint = the mediator's DID, not a URL) through the same fragment/type
  constants the runtime `services tsp enable` patcher uses. A TSP-enabled VTA
  now carries it from DID log v1.
- `build_did_document_inner` ends by sorting `service[]` through
  `sort_services_canonical`, the helper every runtime `with_*_service` patcher
  ends with. Entries are appended in construction order — DIDComm before the
  caller's additional services, which is where `#tsp` arrives — so without the
  sort a minted document would advertise DIDComm ahead of TSP and invert the
  preference order it exists to encode.
- `--from <toml>` gains the matching refusal: `services.tsp = true` in a binary
  built without the transport now fails validation by name, beside the existing
  "TSP requires DIDComm" rule. The declarative path can't be protected by
  declining to offer a menu item, so it says it out loud.

No capability detection, deliberately — nothing here can verify the named
mediator routes TSP; its services belong to its own controller.

No TSP-config prompt was needed either: D8 settled that TSP reuses the DIDComm
mediator, so the SDD's "TSP-config branch (endpoint URL / host)" is obsolete and
§9 is updated to say so.

## Tests

Wizard test scripts answer the services multi-select **by label**
(`Answer::Labels`) rather than by index, the convention the secrets-backend menu
already follows: the option list varies with the compiled feature set, so a
positional answer would mean something different under `--features tsp`. The
selection helpers take the option list as an argument, so the TSP mapping is
covered in CI's default (non-`tsp`) build too, not only where the option
appears.

`cargo test -p vta-service` green in both feature sets (75 / 77 bin tests, 788
lib, 118 integration); clippy clean both ways; `cargo check --workspace
--all-targets` clean.

## Docs

`docs/02-vta/tsp.md` (which told operators the wizard does not prompt for TSP),
`cold-start.md`, `non-interactive-setup.md`, the example setup TOML, and SDD §9.
