### PR TITLE
feat(setup): mint a mediator that actually carries TSP, and design the transport-neutral model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2922,7 +2922,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c54e03a951783e8b327515db3f2a2fd0e3bed362a96b066f341ce66ed49b4ead"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4587,7 +4587,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -6453,7 +6453,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.43",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "thiserror 2.0.20",
  "tokio",
  "tracing",
@@ -6492,7 +6492,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -9383,7 +9383,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.21.20"
+version = "0.21.21"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -9446,7 +9446,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.14.33"
+version = "0.14.34"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/changelog.d/934-transport-neutral-mediator.md
+++ b/changelog.d/934-transport-neutral-mediator.md
@@ -1,0 +1,42 @@
+### vta-sdk 0.21.21 / vta-service 0.14.34 — mint a mediator that actually carries TSP (#934)
+
+A mediator minted by `vta setup` never advertised TSP, on any VTA. The
+`didcomm-mediator` template has carried a `{SERVICE_TSP}` null-pruning slot
+since #929, but neither setup front-end supplied the variable —
+`MessagingInput::CreateMediator` built `effective_vars` with `URL` and `WS_URL`
+only.
+
+So the state a TSP-enabled VTA reached through `vta setup` was: the VTA's
+document advertises `#tsp` → mediator *m* (as of #933), and *m*'s own document
+advertises `DIDCommMessaging` and no `TSPTransport`. A peer following the
+documents finds a TSP endpoint whose mediator says it doesn't carry TSP — the
+same class of defect #933 fixed one hop earlier, failing two layers down as a
+parse error rather than as anything nameable.
+
+Setup now fills the slot. Which transports a minted mediator serves is
+**derived from `[services]`** — DIDComm always (the template renders that entry
+unconditionally), plus TSP when the VTA advertises TSP. Deriving rather than
+prompting is deliberate: the two must agree for the VTA to be reachable, and
+setup already knows the only correct answer. A new `[messaging] protocols`
+overrides it for the one case derivation can't reach — a shared mediator
+serving *more* than this VTA uses. Serving *less* is refused by name, as are
+`rest` (not a mediator transport), duplicates (they would render one entry
+twice), an empty list, and a list omitting `didcomm` (the template always
+advertises it, so such a config describes a document setup does not mint).
+
+`vta-sdk` gains `did_templates::tsp_transport_service`, the **mediator side** of
+the TSP entry. It is the inverse of the existing `tsp_service`: a consumer's
+`#tsp` names its mediator's DID, a mediator's own `#tsp` names the URL it serves
+TSP at, because the indirection has to terminate at the node that actually
+carries the transport (`forward_tsp_remote` URL-parses exactly this value for
+the mediator→mediator hop). Each helper refuses the other's argument with a
+message naming the other — handing a mediator DID to the mediator-side builder
+is the likelier slip, since it is the value in scope at every call site.
+
+Design note: `docs/05-design-notes/transport-neutral-mediator.md`, which also
+covers what this deliberately does *not* yet do — per-transport mediators
+(`[messaging.tsp]`, default stays one shared mediator) and TSP without DIDComm.
+Both need runtime work sequenced there, and two open questions want a live
+mediator run first. The note revises D8 of `tsp-enablement.md`: its default (one
+dual-protocol mediator) stands, its "no separate TSP-mediator field, ever" does
+not.

--- a/docs/02-vta/examples/vta-setup.example.toml
+++ b/docs/02-vta/examples/vta-setup.example.toml
@@ -170,6 +170,16 @@ service = "vta-prod"   # default "vta"; use a unique name per VTA on the same ho
 # traffic goes via a vsock proxy that needs the upstream hostname for SNI.
 # `setup_acl` provisions a per-DID allow-all ACL on the mediator after
 # connecting (required for mediators using ExplicitAllow mode; default false).
+# `protocols` (create_mediator only, for now) declares which transports the
+# minted mediator will serve, rendered into the mediator's own DID document.
+# Omit it — the normal case — and it follows `[services]`: DIDComm always,
+# plus TSP when `services.tsp = true`. Set it only to mint a mediator that
+# serves MORE than this VTA uses (a shared mediator carrying TSP for other
+# clients). Serving less is refused: the VTA's `#tsp` would point at a
+# mediator whose own document says it doesn't carry TSP. See
+# docs/05-design-notes/transport-neutral-mediator.md.
+#   protocols = ["didcomm", "tsp"]
+
 # [messaging]
 # kind          = "existing"
 # did           = "did:webvh:.../mediator"

--- a/docs/02-vta/tsp.md
+++ b/docs/02-vta/tsp.md
@@ -40,7 +40,11 @@ hosted DID, exactly as it can't advertise REST/DIDComm without one.
 
 ## Enabling TSP
 
-TSP shares the DIDComm mediator, so **enable DIDComm first**. Two paths:
+TSP shares the DIDComm mediator, so **enable DIDComm first**. That is a
+constraint of this implementation, not of TSP — a TSP-only mediator is
+legitimate, and lifting the requirement is designed in
+[transport-neutral-mediator.md](../05-design-notes/transport-neutral-mediator.md).
+Two paths:
 
 - **Runtime (recommended):** once you've verified TSP against your mediator,
   `pnm services tsp enable --mediator-did <did>` advertises a `#tsp` service on
@@ -95,6 +99,12 @@ requires a Bidirectional relationship — `tsp-outbound-send.md` §3).
   protocol tag (a TSP VID is a DID too) — deferred until there's a consumer.
 - **`vta-mcp` / `didcomm-test`** TSP wiring — deferred until they have a
   TSP-specific path to exercise.
+- **TSP-only VTAs.** TSP currently requires DIDComm (shared mediator, shared
+  socket, shared cargo feature). Also note that a mediator minted by `vta setup`
+  does **not** advertise `TSPTransport` today, so a TSP-enabled VTA can point
+  `#tsp` at a mediator whose own document says it doesn't carry TSP. Both are
+  addressed in
+  [transport-neutral-mediator.md](../05-design-notes/transport-neutral-mediator.md).
 
 ## References
 

--- a/docs/05-design-notes/transport-neutral-mediator.md
+++ b/docs/05-design-notes/transport-neutral-mediator.md
@@ -1,0 +1,221 @@
+# Transport-neutral mediator configuration
+
+**Status:** proposed. No code yet — this note is the design, and the open
+questions in §8 are load-bearing enough that some want a live check before
+anything is built.
+
+**Supersedes in part:** the "TSP requires DIDComm" rule introduced in #598 and
+surfaced to operators in #933.
+
+## 1. The problem
+
+`vta setup` refuses to enable TSP unless DIDComm is enabled too:
+
+```
+TSP shares the DIDComm mediator — select DIDComm Messaging as well, or leave
+TSP off and enable it later with `pnm services tsp enable`.
+```
+
+That message describes an implementation constraint as though it were a fact
+about TSP. It isn't. TSP is an independent transport, and a TSP-only mediator
+(or intermediary) is entirely legitimate — the OWF reference implementation has
+them. Nothing in the protocol requires a VTA that speaks TSP to also speak
+DIDComm.
+
+The rule exists because three separate things in this workspace assume DIDComm
+is present whenever a mediator is:
+
+1. **There is nowhere to put a TSP mediator.** `MessagingConfig` has exactly one
+   `mediator_did` (`vti-common/src/config.rs:102`), and both setup front-ends
+   collect it inside the DIDComm branch — the interactive wizard only reaches
+   `configure_messaging` when DIDComm is selected. With DIDComm off there is no
+   mediator DID for `#tsp`'s `serviceEndpoint` to name, so the entry would point
+   nowhere.
+2. **TSP inbound is a leg of the DIDComm session, not its own connection.**
+   `DidCommTransport::inbound()` multiplexes DIDComm *and* TSP frames off the
+   single mediator socket (one socket per DID — a second is evicted as
+   `duplicate-channel`), and the whole supervisor is mounted under
+   `if config.services.didcomm` (`vta-service/src/server.rs:943`). With DIDComm
+   off there is no session at all, so nothing receives TSP — and nothing sends
+   it either, since `atm.tsp().send_routed` rides the same ATM.
+3. **The cargo feature encodes it**: `tsp = ["didcomm", …]`
+   (`vta-service/Cargo.toml`), because `messaging::{tsp_inbound,tsp_reach}` live
+   inside the `didcomm`-gated module. This one is pure module organisation.
+
+D8 ("a VTA's `#tsp` and `#didcomm` both bind the **same** `{MEDIATOR_DID}` — the
+published mediator is one dual-protocol node") described the Affinidi mediator
+accurately. It was a true observation about one deployment, and it hardened into
+an assumption about every deployment.
+
+**This note does not overturn D8.** D8 says *one* mediator, and one mediator is
+what this keeps — no separate TSP-mediator field, which is the anti-pattern D8
+names. What changes is that the mediator's *protocol set* becomes explicit
+instead of being assumed to include DIDComm. D8 itself allows for this: it calls
+a distinct TSP mediator "a purely *additive*, non-breaking change if a concrete
+need ever lands — not built speculatively". A TSP-only mediator is that need
+landing, and it needs less than D8 anticipated.
+
+## 2. The finding that makes this urgent
+
+A mediator minted by `vta setup` **does not advertise TSP**, even on a
+TSP-enabled VTA.
+
+The `didcomm-mediator` template has a `{SERVICE_TSP}` null-pruning slot (added
+in #929, same mechanism as `vtc-host`), but neither setup front-end supplies the
+variable: `MessagingInput::CreateMediator` builds `effective_vars` with `URL` and
+`WS_URL` only. An operator *can* hand-craft one through `template_vars`, but
+nothing prompts for it and nothing derives it from `services.tsp`.
+
+So the state a TSP-enabled VTA reaches through `vta setup` today is:
+
+- the VTA's DID document advertises `#tsp` → mediator DID *M* (as of #933);
+- *M*'s own DID document advertises `DIDCommMessaging` and **no**
+  `TSPTransport`.
+
+A peer that follows the documents finds a TSP endpoint whose mediator says it
+does not carry TSP. A DID document naming a transport that isn't served fails
+two layers down — typically as a JSON parse error — rather than as anything
+nameable. **This is the same class of defect #933 fixed one hop earlier**, and
+it is exactly what a transport-neutral model would refuse to configure.
+
+## 3. The model
+
+Two facts are currently conflated into one flag:
+
+| | What it is | Who owns it |
+|---|---|---|
+| **M** — mediator protocols | which transports the mediator can carry | the mediator's controller (except when *we* mint it) |
+| **V** — VTA services | which transports this VTA advertises and serves (`services.{tsp,didcomm}`) | us |
+
+**Rule: V ⊆ M.** Advertising a transport the mediator does not carry publishes
+an unreachable route — and because TSP sits *first* in the preference order,
+an unreachable `#tsp` captures traffic that would otherwise have worked over
+DIDComm. Nothing downgrades past what a peer advertises, by design.
+
+With M explicit, the wizard rule becomes **"TSP requires a mediator that carries
+TSP"**, and DIDComm stops being load-bearing for a TSP-only VTA.
+
+## 4. Where M comes from
+
+In preference order — and this is the part where "ask the operator" is the
+fallback, not the primary:
+
+1. **Resolve the mediator's DID document.** The DID document is authoritative
+   for which protocols a party speaks; match on service `type`
+   (`TSPTransport` / `DIDCommMessaging`), never on the `#id` fragment. This is
+   already built: `vta_sdk::protocol::matching::ServiceCapabilities::from_did_document`
+   + `select_protocol`. Applies to `[messaging] kind = "existing"`.
+2. **When we mint the mediator (`kind = "create_mediator"`), M is a choice, not
+   a discovery.** The VTA renders the mediator's DID document from the
+   `didcomm-mediator` template, so it decides what that document says. The
+   wizard should ask which transports the mediator will serve and pass
+   `SERVICE_TSP` accordingly — closing §2.
+3. **Explicit `[messaging] protocols = [...]`**, for the cases resolution can't
+   serve: air-gapped/offline setup, a mediator whose DID isn't published yet, or
+   a mediator whose controller has not yet updated its document. Also the
+   override when resolution disagrees with what the operator knows.
+
+Note the difference from #929's "no capability detection, deliberately". That
+decision was about not being able to verify a mediator *routes* a protocol —
+still true, and unchanged here. Reading what a mediator *advertises* is a
+different question, answered by the same evidence we use for every other peer.
+Advertisement is necessary, not sufficient: the operator is still told that
+nothing here proves the mediator will actually carry the traffic.
+
+## 5. Config shape
+
+```toml
+[messaging]
+kind      = "existing"
+did       = "did:webvh:mediator.example.com:mediator"
+# Optional. Omitted → resolved from the mediator's DID document.
+protocols = ["tsp", "didcomm"]
+```
+
+`protocols` is transport-neutral and belongs to the *mediator*, not to us;
+`services.{tsp,didcomm}` stays the statement about this VTA.
+
+**Back-compat.** Every existing config omits `protocols`. Absent ⇒ derive from
+the enabled services (`services.didcomm` → `didcomm`, `services.tsp` → `tsp`),
+which reproduces today's behaviour exactly for both a DIDComm-only VTA and one
+that already set `tsp = true`. A defaulted `["didcomm"]` would have invalidated
+the latter on restart, which is not an acceptable upgrade. New configs written
+by either setup front-end record it explicitly.
+
+## 6. Code changes
+
+1. **`vti-common`** — `MessagingConfig.protocols: Vec<Protocol>` (or a small
+   bitflag mirroring the upstream `Protocols`), defaulted as in §5.
+2. **`vta-service/src/server.rs:943`** — mount the connect supervisor on
+   `services.didcomm || services.tsp`, and build the transport's protocol set
+   from **V ∩ M** rather than assuming DIDComm. Upstream already models this:
+   `affinidi-messaging-didcomm-service` has `Protocols::{DIDCOMM_ONLY,TSP_ONLY,
+   BOTH}` and rejects the empty set at construction
+   (`ConfigError::NoProtocolEnabled`).
+3. **`vta-service/Cargo.toml` + `messaging/`** — move `tsp_inbound` / `tsp_reach`
+   out from under the `didcomm` module gate; drop the `tsp = ["didcomm"]` edge.
+   Mechanical, but it is what makes a TSP-only build expressible at all.
+4. **Setup (both front-ends)** — ask which transports the mediator carries (or
+   confirm what resolution found), pass `SERVICE_TSP` on the `create_mediator`
+   path, and persist `protocols`.
+5. **Validation** — replace "TSP requires DIDComm" with "V ⊆ M", in
+   `validate_inputs` *and* in the interactive prompt. The wizard's third option
+   then stands alone.
+6. **`services tsp enable`** — the runtime path needs the same V ⊆ M check
+   against the mediator named in the request, so the guard can't be walked
+   around after setup.
+7. **`build_vta_additional_services`** — unchanged in shape: `#tsp` still names
+   the mediator DID. It gains the precondition that the mediator carries TSP.
+
+## 7. What this closes
+
+- Advertising `#tsp` at a mediator that doesn't carry TSP (§2) — refused at
+  setup instead of failing as a parse error in production.
+- A TSP-only VTA being inexpressible, which is the actual question that started
+  this note.
+- The `tsp`-implies-`didcomm` feature edge, which quietly forces the DIDComm
+  stack into a build that may not want it.
+
+## 8. Open questions (verify before building)
+
+1. **Does the Affinidi mediator require per-protocol registration or ACL?**
+   `setup_acl` is DIDComm-shaped (`MessagingConfig.setup_acl` provisions a
+   per-DID allow-all ACL after the DIDComm connect). If TSP delivery keys off
+   the same account, TSP-only registration may need its own path.
+2. **Does a TSP-only session still need the DIDComm authenticate handshake?**
+   The mediator template advertises `#auth` → `{URL}/authenticate`, and the SDK
+   has `TspAuthHandler` against `POST /tsp/authenticate`. Whether a socket
+   carrying only TSP frames can be established without the DIDComm auth leg is
+   unverified.
+3. **What do `mediator_url` / `mediator_host` mean for TSP-only?** Both exist
+   for display and for the TEE vsock-proxy SNI path. Probably unchanged, but the
+   TEE path deserves an explicit answer rather than an assumption.
+4. **Outbound.** TSP send from `send_to_member` is still designed-not-built
+   (`tsp-outbound-send.md`), including the open relationship question. A
+   TSP-only VTA has no DIDComm fallback, so that gap binds harder here than it
+   does for a dual-transport VTA.
+
+Questions 1 and 2 want one live run against the mediator — the same smoke test
+`tsp.md` already asks for before enabling TSP in production.
+
+## 9. Suggested sequencing
+
+- **A** — §6.4 alone: teach `create_mediator` to pass `SERVICE_TSP` when the
+  operator chooses TSP. Small, and it closes §2 (today's live hazard) without
+  any of the model change.
+- **B** — `protocols` + resolution + V ⊆ M validation (§6.1, §6.4, §6.5). The
+  config surface, still DIDComm-required at runtime.
+- **C** — the mount gate + feature-edge removal (§6.2, §6.3), gated on the §8
+  answers. This is what actually makes a TSP-only VTA run.
+- **D** — `services tsp enable` parity (§6.6).
+
+A and B are useful on their own; C is the one that needs the live check first.
+
+## References
+
+- `docs/05-design-notes/tsp-enablement.md` — the rollout SDD; D8 is in the
+  decisions table (§2), and §9 covers the setup wizards.
+- `docs/02-vta/tsp.md` — operator guide + shipped-vs-pending status.
+- `docs/05-design-notes/tsp-outbound-send.md` — the outbound gap in §8.4.
+- #929 (VTC transports at setup), #933 (the VTA wizard's TSP option, and the
+  rule this note revisits).

--- a/docs/05-design-notes/transport-neutral-mediator.md
+++ b/docs/05-design-notes/transport-neutral-mediator.md
@@ -1,11 +1,11 @@
 # Transport-neutral mediator configuration
 
-**Status:** proposed. No code yet — this note is the design, and the open
-questions in §8 are load-bearing enough that some want a live check before
-anything is built.
+**Status:** proposed, with phase A implemented in the same PR. The open
+questions in §9 are load-bearing enough that the runtime phases want a live
+mediator check before they are built.
 
-**Supersedes in part:** the "TSP requires DIDComm" rule introduced in #598 and
-surfaced to operators in #933.
+**Revises:** the "TSP requires DIDComm" rule introduced in #598 and surfaced to
+operators in #933; and D8 of `tsp-enablement.md` (see §4).
 
 ## 1. The problem
 
@@ -16,25 +16,23 @@ TSP shares the DIDComm mediator — select DIDComm Messaging as well, or leave
 TSP off and enable it later with `pnm services tsp enable`.
 ```
 
-That message describes an implementation constraint as though it were a fact
-about TSP. It isn't. TSP is an independent transport, and a TSP-only mediator
-(or intermediary) is entirely legitimate — the OWF reference implementation has
-them. Nothing in the protocol requires a VTA that speaks TSP to also speak
-DIDComm.
+That message states an implementation constraint as though it were a fact about
+TSP. It isn't. TSP is an independent transport, a TSP-only mediator is
+legitimate (the OWF reference implementation has them), and nothing in the
+protocol requires a VTA that speaks TSP to also speak DIDComm.
 
-The rule exists because three separate things in this workspace assume DIDComm
-is present whenever a mediator is:
+The rule exists because three things in this workspace assume DIDComm is present
+whenever a mediator is:
 
 1. **There is nowhere to put a TSP mediator.** `MessagingConfig` has exactly one
    `mediator_did` (`vti-common/src/config.rs:102`), and both setup front-ends
    collect it inside the DIDComm branch — the interactive wizard only reaches
    `configure_messaging` when DIDComm is selected. With DIDComm off there is no
-   mediator DID for `#tsp`'s `serviceEndpoint` to name, so the entry would point
-   nowhere.
+   mediator DID for `#tsp`'s `serviceEndpoint` to name.
 2. **TSP inbound is a leg of the DIDComm session, not its own connection.**
    `DidCommTransport::inbound()` multiplexes DIDComm *and* TSP frames off the
-   single mediator socket (one socket per DID — a second is evicted as
-   `duplicate-channel`), and the whole supervisor is mounted under
+   single mediator socket (one socket per DID at a given mediator — a second is
+   evicted as `duplicate-channel`), and the whole supervisor is mounted under
    `if config.services.didcomm` (`vta-service/src/server.rs:943`). With DIDComm
    off there is no session at all, so nothing receives TSP — and nothing sends
    it either, since `atm.tsp().send_routed` rides the same ATM.
@@ -42,180 +40,255 @@ is present whenever a mediator is:
    (`vta-service/Cargo.toml`), because `messaging::{tsp_inbound,tsp_reach}` live
    inside the `didcomm`-gated module. This one is pure module organisation.
 
-D8 ("a VTA's `#tsp` and `#didcomm` both bind the **same** `{MEDIATOR_DID}` — the
-published mediator is one dual-protocol node") described the Affinidi mediator
-accurately. It was a true observation about one deployment, and it hardened into
-an assumption about every deployment.
-
-**This note does not overturn D8.** D8 says *one* mediator, and one mediator is
-what this keeps — no separate TSP-mediator field, which is the anti-pattern D8
-names. What changes is that the mediator's *protocol set* becomes explicit
-instead of being assumed to include DIDComm. D8 itself allows for this: it calls
-a distinct TSP mediator "a purely *additive*, non-breaking change if a concrete
-need ever lands — not built speculatively". A TSP-only mediator is that need
-landing, and it needs less than D8 anticipated.
-
 ## 2. The finding that makes this urgent
 
 A mediator minted by `vta setup` **does not advertise TSP**, even on a
 TSP-enabled VTA.
 
-The `didcomm-mediator` template has a `{SERVICE_TSP}` null-pruning slot (added
-in #929, same mechanism as `vtc-host`), but neither setup front-end supplies the
-variable: `MessagingInput::CreateMediator` builds `effective_vars` with `URL` and
-`WS_URL` only. An operator *can* hand-craft one through `template_vars`, but
+The `didcomm-mediator` template has carried a `{SERVICE_TSP}` null-pruning slot
+since #929 (same mechanism as `vtc-host`), but neither setup front-end supplies
+the variable: `MessagingInput::CreateMediator` builds `effective_vars` with `URL`
+and `WS_URL` only. An operator *can* hand-craft one through `template_vars`, but
 nothing prompts for it and nothing derives it from `services.tsp`.
 
 So the state a TSP-enabled VTA reaches through `vta setup` today is:
 
-- the VTA's DID document advertises `#tsp` → mediator DID *M* (as of #933);
-- *M*'s own DID document advertises `DIDCommMessaging` and **no**
+- the VTA's DID document advertises `#tsp` → mediator DID *m* (as of #933);
+- *m*'s own DID document advertises `DIDCommMessaging` and **no**
   `TSPTransport`.
 
 A peer that follows the documents finds a TSP endpoint whose mediator says it
 does not carry TSP. A DID document naming a transport that isn't served fails
 two layers down — typically as a JSON parse error — rather than as anything
-nameable. **This is the same class of defect #933 fixed one hop earlier**, and
-it is exactly what a transport-neutral model would refuse to configure.
+nameable. **This is the same class of defect #933 fixed one hop earlier.**
+
+Phase A (§10) fixes this and is implemented in this PR; it needs none of the
+model below.
 
 ## 3. The model
 
-Two facts are currently conflated into one flag:
+Three facts, today carried by one flag and one field:
 
 | | What it is | Who owns it |
 |---|---|---|
-| **M** — mediator protocols | which transports the mediator can carry | the mediator's controller (except when *we* mint it) |
 | **V** — VTA services | which transports this VTA advertises and serves (`services.{tsp,didcomm}`) | us |
+| **R** — routing | which mediator carries each transport | us — a deployment choice |
+| **M(m)** — mediator protocols | which transports mediator *m* can carry | *m*'s controller, except when we mint it |
 
-**Rule: V ⊆ M.** Advertising a transport the mediator does not carry publishes
-an unreachable route — and because TSP sits *first* in the preference order,
-an unreachable `#tsp` captures traffic that would otherwise have worked over
+**Invariant: for every transport `p` enabled in V, `R(p)` is defined and
+`p ∈ M(R(p))`.**
+
+Advertising a transport whose mediator does not carry it publishes an
+unreachable route — and because TSP sits *first* in the preference order, an
+unreachable `#tsp` captures traffic that would otherwise have worked over
 DIDComm. Nothing downgrades past what a peer advertises, by design.
 
-With M explicit, the wizard rule becomes **"TSP requires a mediator that carries
-TSP"**, and DIDComm stops being load-bearing for a TSP-only VTA.
+**R defaults to one mediator for every transport.** That is D8's shape, what
+every existing config means, and what most deployments want: the published
+Affinidi mediator is one dual-protocol node. Splitting R is opt-in.
 
-## 4. Where M comes from
+With this, the wizard rule becomes **"TSP requires a mediator that carries
+TSP"** — DIDComm stops being load-bearing for a TSP-only VTA.
 
-In preference order — and this is the part where "ask the operator" is the
-fallback, not the primary:
+## 4. Relationship to D8
+
+D8 says: *"a VTA's `#tsp` and `#didcomm` both bind the same `{MEDIATOR_DID}` —
+the published mediator is one dual-protocol node… **No separate TSP-mediator var
+or config field.** A distinct TSP mediator is a purely additive, non-breaking
+change if a concrete need ever lands — not built speculatively."*
+
+**This note takes D8 up on that clause.** Two needs have landed: a TSP-only
+mediator must be expressible, and an operator may legitimately run TSP through a
+different mediator than DIDComm (different provider, different trust domain,
+staged migration one transport at a time). So a per-transport mediator field is
+added — the thing D8 declined to build speculatively — while D8's *default*
+survives unchanged: one mediator, both entries pointing at it, no config needed
+to get that.
+
+The part of D8 that does **not** survive is "no separate field, ever". The part
+that does is "one mediator is the normal case", and it stays the default.
+
+## 5. Where M comes from
+
+In preference order — "ask the operator" is the fallback, not the primary:
 
 1. **Resolve the mediator's DID document.** The DID document is authoritative
-   for which protocols a party speaks; match on service `type`
-   (`TSPTransport` / `DIDCommMessaging`), never on the `#id` fragment. This is
-   already built: `vta_sdk::protocol::matching::ServiceCapabilities::from_did_document`
-   + `select_protocol`. Applies to `[messaging] kind = "existing"`.
+   for which protocols a party speaks; match on service `type` (`TSPTransport` /
+   `DIDCommMessaging`), never on the `#id` fragment. Already built:
+   `vta_sdk::protocol::matching::ServiceCapabilities::from_did_document` +
+   `select_protocol`. Applies to `kind = "existing"`.
 2. **When we mint the mediator (`kind = "create_mediator"`), M is a choice, not
-   a discovery.** The VTA renders the mediator's DID document from the
-   `didcomm-mediator` template, so it decides what that document says. The
-   wizard should ask which transports the mediator will serve and pass
-   `SERVICE_TSP` accordingly — closing §2.
-3. **Explicit `[messaging] protocols = [...]`**, for the cases resolution can't
-   serve: air-gapped/offline setup, a mediator whose DID isn't published yet, or
-   a mediator whose controller has not yet updated its document. Also the
-   override when resolution disagrees with what the operator knows.
+   a discovery.** The VTA renders that document from the `didcomm-mediator`
+   template, so it decides what it says — and the only choice that leaves the
+   VTA reachable is one covering what the VTA advertises. So setup *derives*
+   M from `services.*` and fills `SERVICE_TSP` accordingly, rather than asking
+   a question whose only correct answer it already knows. `messaging.protocols`
+   overrides that for the one case derivation can't reach: a shared mediator
+   serving *more* than this VTA uses. Serving less is refused. This is phase A.
+3. **Explicit `protocols = [...]`**, for what resolution can't serve:
+   air-gapped setup, a mediator whose DID isn't published yet, a controller who
+   hasn't updated its document. Also the override when resolution disagrees with
+   what the operator knows.
 
-Note the difference from #929's "no capability detection, deliberately". That
-decision was about not being able to verify a mediator *routes* a protocol —
-still true, and unchanged here. Reading what a mediator *advertises* is a
-different question, answered by the same evidence we use for every other peer.
-Advertisement is necessary, not sufficient: the operator is still told that
-nothing here proves the mediator will actually carry the traffic.
+This does not reopen #929's "no capability detection, deliberately". That was
+about being unable to verify a mediator *routes* a protocol — still true, still
+unchanged. Reading what a mediator *advertises* is a different question,
+answered by the same evidence we use for every other peer. Advertisement is
+necessary, not sufficient, and the operator is still told that nothing here
+proves the traffic will flow.
 
-## 5. Config shape
+## 6. Config shape
+
+The default — one mediator, every enabled transport — needs no new keys:
 
 ```toml
 [messaging]
 kind      = "existing"
 did       = "did:webvh:mediator.example.com:mediator"
-# Optional. Omitted → resolved from the mediator's DID document.
+# Optional. Omitted → resolved from the mediator's DID document (§5.1),
+# or, for kind = "create_mediator", chosen at setup (§5.2).
 protocols = ["tsp", "didcomm"]
 ```
 
-`protocols` is transport-neutral and belongs to the *mediator*, not to us;
-`services.{tsp,didcomm}` stays the statement about this VTA.
+A split routing table is an opt-in per-transport override:
 
-**Back-compat.** Every existing config omits `protocols`. Absent ⇒ derive from
-the enabled services (`services.didcomm` → `didcomm`, `services.tsp` → `tsp`),
-which reproduces today's behaviour exactly for both a DIDComm-only VTA and one
-that already set `tsp = true`. A defaulted `["didcomm"]` would have invalidated
-the latter on restart, which is not an acceptable upgrade. New configs written
-by either setup front-end record it explicitly.
+```toml
+[messaging]
+kind      = "existing"
+did       = "did:webvh:mediator.example.com:mediator"
+protocols = ["didcomm"]
 
-## 6. Code changes
+# TSP rides a different mediator. Same shape as `[messaging]`; anything
+# omitted falls back to it.
+[messaging.tsp]
+did       = "did:webvh:tsp-mediator.example.com:mediator"
+protocols = ["tsp"]
+```
 
-1. **`vti-common`** — `MessagingConfig.protocols: Vec<Protocol>` (or a small
-   bitflag mirroring the upstream `Protocols`), defaulted as in §5.
-2. **`vta-service/src/server.rs:943`** — mount the connect supervisor on
-   `services.didcomm || services.tsp`, and build the transport's protocol set
-   from **V ∩ M** rather than assuming DIDComm. Upstream already models this:
-   `affinidi-messaging-didcomm-service` has `Protocols::{DIDCOMM_ONLY,TSP_ONLY,
-   BOTH}` and rejects the empty set at construction
-   (`ConfigError::NoProtocolEnabled`).
-3. **`vta-service/Cargo.toml` + `messaging/`** — move `tsp_inbound` / `tsp_reach`
-   out from under the `didcomm` module gate; drop the `tsp = ["didcomm"]` edge.
-   Mechanical, but it is what makes a TSP-only build expressible at all.
-4. **Setup (both front-ends)** — ask which transports the mediator carries (or
+Rules:
+
+- `[messaging]` is the **default mediator** for every enabled transport.
+- `[messaging.<transport>]` overrides that transport's mediator. Absent ⇒ same
+  mediator, which is what every existing config means.
+- An override is only meaningful for a transport in V; an override for a
+  disabled transport is refused rather than ignored (it is always a mistake, and
+  ignoring it is how a config comes to mean something other than it says).
+- Each mediator's `protocols` must include the transports routed to it (§3's
+  invariant), checked at setup and at `services … enable`.
+
+**Back-compat.** Every existing config omits both `protocols` and the override
+table. Absent `protocols` ⇒ derive from the enabled services, which reproduces
+today's behaviour exactly for a DIDComm-only VTA *and* for one that already set
+`tsp = true`. A defaulted `["didcomm"]` would have invalidated the latter on
+restart; that is not an acceptable upgrade.
+
+## 7. Runtime: how a split routing table actually runs
+
+This is the part that looked expensive and isn't, because the seam already
+exists.
+
+`MessagingService` holds **many transports**, not one. `live_prover.rs` already
+does exactly the required shape for a *candidate* mediator during the
+protocol-management handshake: build a `DidCommTransport` over a fresh
+`ATMProfile` for that mediator, `add_transport(candidate_id, …)` — at which
+point it starts receiving immediately via the merged inbound dispatcher — send
+over it with `request_via(candidate_id, …)`, then `promote` or `remove_transport`.
+Listener id is the mediator DID by convention (`registry.rs`), and inbound
+frames carry it, so attribution is already per-mediator.
+
+So a split table is: one `DidCommTransport` per distinct mediator in R, all
+installed, inbound merged as it is today, and **outbound selected by protocol →
+transport id** instead of always using the primary. The `#tsp` and `#didcomm`
+service entries in the VTA's DID document each name their own mediator, which
+they already do structurally — they just happen to name the same one today.
+
+What genuinely has to be built: per-transport connect supervision (today
+`MessagingConnect` owns one `MessagingConfig` — `server.rs:1884`), outbound
+protocol routing in `DIDCommBridge` (today one `BridgeInner`,
+`didcomm_bridge.rs:88`), and health/telemetry reporting that no longer assumes a
+single mediator. Non-trivial, but built on a seam that exists rather than a new
+session stack.
+
+Note the one-socket-per-DID rule is per *mediator*: two mediators means two
+sockets, one to each, which is legitimate. Two sockets to the **same** mediator
+is what gets evicted — so the same-mediator default must keep multiplexing on
+one transport, exactly as it does now.
+
+## 8. Code changes
+
+1. **`vti-common`** — `MessagingConfig.protocols`, plus the per-transport
+   override (`MessagingConfig` becomes composable with itself, or a small
+   `MediatorRef` the parent and overrides both use).
+2. **Setup, both front-ends** — ask which transports the mediator carries (or
    confirm what resolution found), pass `SERVICE_TSP` on the `create_mediator`
-   path, and persist `protocols`.
-5. **Validation** — replace "TSP requires DIDComm" with "V ⊆ M", in
-   `validate_inputs` *and* in the interactive prompt. The wizard's third option
-   then stands alone.
-6. **`services tsp enable`** — the runtime path needs the same V ⊆ M check
-   against the mediator named in the request, so the guard can't be walked
-   around after setup.
-7. **`build_vta_additional_services`** — unchanged in shape: `#tsp` still names
-   the mediator DID. It gains the precondition that the mediator carries TSP.
+   path, persist `protocols`, and accept the override table.
+3. **Validation** — replace "TSP requires DIDComm" with §3's invariant, in
+   `validate_inputs` *and* in the interactive prompt.
+4. **`vta-service/src/server.rs:943`** — mount the connect supervisor on
+   `services.didcomm || services.tsp`; build each transport's protocol set from
+   V ∩ M(m). Upstream models this already: `Protocols::{DIDCOMM_ONLY,TSP_ONLY,
+   BOTH}`, empty rejected as `ConfigError::NoProtocolEnabled`.
+5. **Multi-mediator runtime** — §7: a supervisor per distinct mediator, outbound
+   routing by protocol.
+6. **`Cargo.toml` + `messaging/`** — move `tsp_inbound` / `tsp_reach` out from
+   under the `didcomm` module gate; drop the `tsp = ["didcomm"]` edge. Mechanical,
+   and it is what makes a TSP-only build expressible at all.
+7. **`services tsp enable`** — same invariant check against the mediator named in
+   the request, so the guard can't be walked around after setup.
+8. **`build_vta_additional_services`** — unchanged in shape; `#tsp` names
+   `R(tsp)` rather than "the mediator".
 
-## 7. What this closes
-
-- Advertising `#tsp` at a mediator that doesn't carry TSP (§2) — refused at
-  setup instead of failing as a parse error in production.
-- A TSP-only VTA being inexpressible, which is the actual question that started
-  this note.
-- The `tsp`-implies-`didcomm` feature edge, which quietly forces the DIDComm
-  stack into a build that may not want it.
-
-## 8. Open questions (verify before building)
+## 9. Open questions (verify before building §8.4–§8.6)
 
 1. **Does the Affinidi mediator require per-protocol registration or ACL?**
-   `setup_acl` is DIDComm-shaped (`MessagingConfig.setup_acl` provisions a
-   per-DID allow-all ACL after the DIDComm connect). If TSP delivery keys off
-   the same account, TSP-only registration may need its own path.
+   `setup_acl` is DIDComm-shaped (a per-DID allow-all ACL provisioned after the
+   DIDComm connect). If TSP delivery keys off the same account this is free; if
+   not, TSP-only registration needs its own path.
 2. **Does a TSP-only session still need the DIDComm authenticate handshake?**
    The mediator template advertises `#auth` → `{URL}/authenticate`, and the SDK
    has `TspAuthHandler` against `POST /tsp/authenticate`. Whether a socket
    carrying only TSP frames can be established without the DIDComm auth leg is
    unverified.
-3. **What do `mediator_url` / `mediator_host` mean for TSP-only?** Both exist
-   for display and for the TEE vsock-proxy SNI path. Probably unchanged, but the
-   TEE path deserves an explicit answer rather than an assumption.
-4. **Outbound.** TSP send from `send_to_member` is still designed-not-built
-   (`tsp-outbound-send.md`), including the open relationship question. A
-   TSP-only VTA has no DIDComm fallback, so that gap binds harder here than it
-   does for a dual-transport VTA.
+3. **What do `mediator_url` / `mediator_host` mean per-mediator?** Both exist for
+   display and for the TEE vsock-proxy SNI path. A split table needs one of each
+   per mediator; the TEE proxy path deserves an explicit answer rather than an
+   assumption.
+4. **Outbound TSP send** is still designed-not-built (`tsp-outbound-send.md`),
+   including the open relationship question. A TSP-only VTA has no DIDComm
+   fallback, so that gap binds harder here than for a dual-transport VTA.
 
-Questions 1 and 2 want one live run against the mediator — the same smoke test
+Questions 1 and 2 want one live run against a mediator — the same smoke test
 `tsp.md` already asks for before enabling TSP in production.
 
-## 9. Suggested sequencing
+## 10. Sequencing
 
-- **A** — §6.4 alone: teach `create_mediator` to pass `SERVICE_TSP` when the
-  operator chooses TSP. Small, and it closes §2 (today's live hazard) without
-  any of the model change.
-- **B** — `protocols` + resolution + V ⊆ M validation (§6.1, §6.4, §6.5). The
+- **A — mint a TSP-capable mediator.** `create_mediator` fills `SERVICE_TSP`
+  when the mediator serves TSP, derived from `services.tsp` and overridable via
+  `messaging.protocols`. Closes §2, needs none of the model. **Implemented in
+  this PR**, along with the mint-time slice of §3's invariant (a minted mediator
+  may not serve less than the VTA advertises) and the SDK's mediator-side
+  `tsp_transport_service` — the mediator's own `#tsp` names its **URL**, the
+  inverse of the consumer entry `tsp_service` builds, and the existing helper
+  refuses a URL by design.
+- **B — `protocols` + resolution + the §3 invariant**, same-mediator only. The
   config surface, still DIDComm-required at runtime.
-- **C** — the mount gate + feature-edge removal (§6.2, §6.3), gated on the §8
-  answers. This is what actually makes a TSP-only VTA run.
-- **D** — `services tsp enable` parity (§6.6).
+- **C — split routing table** (§7): per-mediator transports and outbound
+  protocol routing. What makes `[messaging.tsp]` real.
+- **D — TSP-only runtime**: the mount gate and the feature edge (§8.4, §8.6),
+  gated on §9's answers.
+- **E — `services tsp enable` parity** (§8.7).
 
-A and B are useful on their own; C is the one that needs the live check first.
+A is useful standing alone. B is useful with A. C and D are independent of each
+other: C gives a dual-transport VTA two mediators, D gives a single-mediator VTA
+TSP without DIDComm.
 
 ## References
 
 - `docs/05-design-notes/tsp-enablement.md` — the rollout SDD; D8 is in the
-  decisions table (§2), and §9 covers the setup wizards.
+  decisions table (§2), §9 covers the setup wizards.
 - `docs/02-vta/tsp.md` — operator guide + shipped-vs-pending status.
-- `docs/05-design-notes/tsp-outbound-send.md` — the outbound gap in §8.4.
+- `docs/05-design-notes/tsp-outbound-send.md` — the outbound gap in §9.4.
+- `docs/05-design-notes/runtime-service-management.md` — the drain/registry
+  machinery §7 builds on.
 - #929 (VTC transports at setup), #933 (the VTA wizard's TSP option, and the
-  rule this note revisits).
+  rule this note revises).

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.21.20"
+version = "0.21.21"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-sdk/src/did_templates/mod.rs
+++ b/vta-sdk/src/did_templates/mod.rs
@@ -55,7 +55,9 @@ use serde_json::Value;
 use thiserror::Error;
 
 pub use builtin::{BUILTIN_NAMES, load_embedded};
-pub use transports::{DIDCOMM_SERVICE_VAR, TSP_SERVICE_VAR, didcomm_service, tsp_service};
+pub use transports::{
+    DIDCOMM_SERVICE_VAR, TSP_SERVICE_VAR, didcomm_service, tsp_service, tsp_transport_service,
+};
 pub use trust_registry::{
     TRQP_PROFILE_URI, TRUST_REGISTRY_SERVICE_TYPE, TRUST_REGISTRY_SERVICE_VAR, referral_service,
 };

--- a/vta-sdk/src/did_templates/transports.rs
+++ b/vta-sdk/src/did_templates/transports.rs
@@ -102,6 +102,40 @@ pub fn tsp_service(mediator_did: &str) -> Result<Value, TemplateError> {
     transport_service(mediator_did, TSP_SERVICE_TYPE, TSP_FRAGMENT, "TSP")
 }
 
+/// Build the `TSPTransport` entry a **mediator** publishes for *itself*.
+///
+/// This is the other end of the indirection [`tsp_service`] builds, and it is
+/// the inverse shape. A consumer's `#tsp` names its mediator's DID; a
+/// mediator's own `#tsp` names the **URL** its TSP transport is served at,
+/// because the chain has to terminate somewhere. `forward_tsp_remote` on the
+/// sending mediator URL-parses exactly this value for the mediator→mediator
+/// hop, so a DID here is unroutable in the same way a URL is unroutable in a
+/// consumer's entry.
+///
+/// Pass the result as [`TSP_SERVICE_VAR`] when rendering `didcomm-mediator`.
+/// Without it the template's null-pruning slot drops the entry and the mediator
+/// advertises DIDComm only.
+///
+/// # Errors
+///
+/// [`TemplateError::Invalid`] if `url` is not an `http(s)` URL — including when
+/// it is a DID, which is the confusion this pair of helpers exists to prevent.
+pub fn tsp_transport_service(url: &str) -> Result<Value, TemplateError> {
+    let url = url.trim();
+    if !(url.starts_with("http://") || url.starts_with("https://")) {
+        return Err(TemplateError::Invalid(format!(
+            "a mediator's own TSP service must name the URL it serves TSP at, got '{url}'. \
+             The mediator is the endpoint — a DID here would point at another node to \
+             resolve onward, which is the consumer-side shape (see `tsp_service`)."
+        )));
+    }
+    Ok(json!({
+        "id": format!("{{DID}}{TSP_FRAGMENT}"),
+        "type": TSP_SERVICE_TYPE,
+        "serviceEndpoint": url,
+    }))
+}
+
 fn transport_service(
     mediator_did: &str,
     type_: &str,
@@ -183,6 +217,51 @@ mod tests {
     fn an_empty_mediator_is_refused() {
         assert!(didcomm_service("").is_err());
         assert!(tsp_service("   ").is_err());
+    }
+
+    /// A mediator's own entry is the inverse shape: the URL it serves TSP at,
+    /// because the mediator is where the indirection terminates.
+    #[test]
+    fn a_mediators_own_tsp_entry_names_its_url() {
+        let e = tsp_transport_service("https://mediator.example.com").unwrap();
+        assert_eq!(e["id"], "{DID}#tsp");
+        assert_eq!(e["type"], TSP_SERVICE_TYPE);
+        assert_eq!(e["serviceEndpoint"], "https://mediator.example.com");
+
+        // Same `{DID}` late-substitution contract as the consumer entry.
+        assert!(e["id"].as_str().unwrap().starts_with("{DID}"));
+        // And the same whitespace tolerance.
+        assert_eq!(
+            tsp_transport_service("  https://mediator.example.com  ").unwrap()["serviceEndpoint"],
+            "https://mediator.example.com"
+        );
+    }
+
+    /// The two helpers refuse each other's argument. Handing a mediator DID to
+    /// the mediator-side builder is the likelier slip — it is the value in
+    /// scope at every call site — and it would publish a mediator that points
+    /// at itself for onward resolution.
+    #[test]
+    fn the_two_tsp_shapes_refuse_each_others_input() {
+        let err = tsp_transport_service(MEDIATOR).unwrap_err().to_string();
+        assert!(err.contains("URL it serves TSP at"), "got: {err}");
+        assert!(
+            err.contains("tsp_service"),
+            "must point at the other helper: {err}"
+        );
+
+        let err = tsp_service("https://mediator.example.com")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("by DID"), "got: {err}");
+    }
+
+    #[test]
+    fn a_mediator_tsp_entry_refuses_empty_and_non_http() {
+        assert!(tsp_transport_service("").is_err());
+        assert!(tsp_transport_service("   ").is_err());
+        assert!(tsp_transport_service("wss://mediator.example.com/ws").is_err());
+        assert!(tsp_transport_service("mediator.example.com").is_err());
     }
 
     /// The `{DID}` sentinel must survive verbatim into the rendered entry —

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.14.33"
+version = "0.14.34"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/src/setup/from_toml.rs
+++ b/vta-service/src/setup/from_toml.rs
@@ -34,6 +34,7 @@ use serde_json::json;
 use url::Url;
 
 use affinidi_did_resolver_cache_sdk::{DIDCacheClient, config::DIDCacheConfigBuilder};
+use vta_sdk::protocol::matching::Protocol;
 
 use crate::config::{
     AppConfig, AuditConfig, AuthConfig, LogConfig, MessagingConfig, SecretBackend, SecretsConfig,
@@ -475,11 +476,52 @@ pub enum MessagingInput {
         template_vars: HashMap<String, serde_json::Value>,
         #[serde(default)]
         setup_acl: bool,
+        /// Which transports this mediator will serve, rendered into the
+        /// mediator's own DID document.
+        ///
+        /// Omitted — the normal case — means "whatever this VTA advertises":
+        /// DIDComm always, TSP when `services.tsp` is on. We are minting the
+        /// mediator, so its capability is a choice rather than a discovery,
+        /// and the only choice that keeps the VTA reachable is one that
+        /// covers what the VTA advertises.
+        ///
+        /// Set it explicitly to mint a mediator that serves *more* than this
+        /// VTA uses — e.g. a shared mediator carrying TSP for other clients
+        /// while this VTA stays on DIDComm. Serving *less* is refused: it
+        /// would publish a VTA `#tsp` pointing at a mediator whose own
+        /// document says it doesn't carry TSP.
+        ///
+        /// `rest` is not a mediator transport and is refused here.
+        #[serde(default)]
+        protocols: Option<Vec<Protocol>>,
     },
 }
 
 fn default_mediator_context() -> String {
     "mediator".into()
+}
+
+/// Which transports a mediator minted by setup will serve.
+///
+/// Explicit `messaging.protocols` wins. Omitted — the normal case — it is
+/// whatever this VTA advertises: DIDComm always (the `didcomm-mediator`
+/// template renders that entry unconditionally), plus TSP when the VTA
+/// advertises TSP. Deriving is not a convenience here: the two must agree for
+/// the VTA to be reachable, and the operator has no information setup lacks.
+///
+/// `validate_inputs` refuses an explicit list that serves *less* than the VTA
+/// advertises; serving more is legitimate (a shared mediator).
+fn mediator_protocols(explicit: Option<&[Protocol]>, services: &ServicesConfig) -> Vec<Protocol> {
+    match explicit {
+        Some(list) => list.to_vec(),
+        None => {
+            let mut derived = vec![Protocol::Didcomm];
+            if services.tsp {
+                derived.push(Protocol::Tsp);
+            }
+            derived
+        }
+    }
 }
 
 #[derive(Debug, Deserialize, Serialize, Default)]
@@ -802,6 +844,7 @@ pub async fn apply_inputs(
             mediator_host,
             template_vars,
             setup_acl,
+            protocols,
         } => {
             let _med_ctx =
                 create_seed_context(&contexts_ks, context, "DIDComm Messaging Mediator").await?;
@@ -828,6 +871,23 @@ pub async fn apply_inputs(
                 })?,
             };
             effective_vars.insert("WS_URL".into(), json!(ws_url));
+
+            // TSP: fill the template's `{SERVICE_TSP}` null-pruning slot when
+            // this mediator serves TSP. Omitted, the slot prunes and the
+            // mediator advertises DIDComm only — which is what happened to
+            // every TSP-enabled VTA before this, leaving the VTA's `#tsp`
+            // pointing at a mediator whose own document said it didn't carry
+            // TSP (transport-neutral-mediator.md §2).
+            //
+            // The mediator's own entry names its **URL**, the inverse of the
+            // VTA's, which names the mediator's DID. The indirection has to
+            // terminate at the node that actually serves the transport.
+            if mediator_protocols(protocols.as_deref(), &inputs.services).contains(&Protocol::Tsp) {
+                let entry = vta_sdk::did_templates::tsp_transport_service(url)
+                    .map_err(|e| format!("build the mediator's TSP service entry: {e}"))?;
+                effective_vars.insert(vta_sdk::did_templates::TSP_SERVICE_VAR.into(), entry);
+                eprintln!("  Mediator will advertise: TSP + DIDComm");
+            }
 
             // `url` is the DIDComm endpoint; `webvh_url` is the DID-document
             // hosting URL. They are usually the same host but are semantically
@@ -1130,11 +1190,75 @@ fn validate_inputs(inputs: &WizardInputs) -> Result<(), Box<dyn std::error::Erro
         context,
         webvh_url,
         ws_url,
+        protocols,
         ..
     } = &inputs.messaging
     {
         if context.trim().is_empty() {
             errors.push("messaging.context cannot be empty".into());
+        }
+        if let Some(protocols) = protocols {
+            if protocols.is_empty() {
+                errors.push(
+                    "messaging.protocols = [] — a mediator that carries nothing is not a \
+                     mediator. Remove the key to serve what this VTA advertises, or list \
+                     the transports it should serve"
+                        .into(),
+                );
+            }
+            if protocols.contains(&Protocol::Rest) {
+                errors.push(
+                    "messaging.protocols contains \"rest\" — REST is not a mediator transport \
+                     (a REST peer is reached directly, with no mediator). Use \"tsp\" and/or \
+                     \"didcomm\""
+                        .into(),
+                );
+            }
+            // Duplicates would render one service entry twice. Always a
+            // mistake, and refused rather than de-duplicated (same call as
+            // the VTC's `transports`, #929).
+            let mut seen = Vec::new();
+            for p in protocols {
+                if seen.contains(p) {
+                    errors.push(format!(
+                        "messaging.protocols lists \"{p}\" more than once; each transport is \
+                         advertised exactly once"
+                    ));
+                } else {
+                    seen.push(*p);
+                }
+            }
+            // The `didcomm-mediator` template renders its DIDComm `#service`
+            // block unconditionally — only `{SERVICE_TSP}` is a pruning slot.
+            // So a `protocols` omitting DIDComm describes a document setup
+            // does not mint, and would be believed by nothing.
+            if !protocols.contains(&Protocol::Didcomm) {
+                errors.push(
+                    "messaging.protocols omits \"didcomm\", but the `didcomm-mediator` \
+                     template always advertises a DIDComm endpoint — a minted mediator \
+                     cannot be TSP-only today. Include \"didcomm\", or point at a TSP-only \
+                     mediator with kind = \"existing\""
+                        .into(),
+                );
+            }
+        }
+        // §3's invariant, on the slice setup can enforce today: the VTA must
+        // not advertise a transport its own mediator doesn't carry. Since we
+        // are the ones minting that mediator, an explicit `protocols` that
+        // omits TSP while the VTA advertises it is a contradiction the
+        // operator has to resolve, not something to silently widen.
+        if inputs.services.tsp
+            && protocols
+                .as_ref()
+                .is_some_and(|p| !p.contains(&Protocol::Tsp))
+        {
+            errors.push(
+                "services.tsp = true but messaging.protocols omits \"tsp\" — the VTA would \
+                 advertise `#tsp` pointing at a mediator whose own DID document says it \
+                 does not carry TSP. Add \"tsp\" to messaging.protocols, or set \
+                 services.tsp = false"
+                    .into(),
+            );
         }
         if webvh_url.as_deref().is_some_and(str::is_empty) {
             errors.push(
@@ -2799,6 +2923,114 @@ mod tests {
         "#;
         let inputs = parse(raw).expect("parses");
         validate_inputs(&inputs).expect("rest disabled means public_url is optional");
+    }
+
+    /// A minted mediator serves what the VTA advertises, unless the operator
+    /// says otherwise. This is what decides whether `{SERVICE_TSP}` gets
+    /// filled, so it is the difference between a reachable `#tsp` and one
+    /// pointing at a mediator that doesn't carry TSP.
+    #[test]
+    fn minted_mediator_protocols_follow_the_vtas_services() {
+        let didcomm_only = ServicesConfig {
+            rest: true,
+            didcomm: true,
+            webauthn: false,
+            tsp: false,
+        };
+        let with_tsp = ServicesConfig {
+            tsp: true,
+            ..didcomm_only
+        };
+
+        // Derived: DIDComm always (the template renders it unconditionally),
+        // TSP iff the VTA advertises TSP.
+        assert_eq!(
+            mediator_protocols(None, &didcomm_only),
+            vec![Protocol::Didcomm]
+        );
+        assert_eq!(
+            mediator_protocols(None, &with_tsp),
+            vec![Protocol::Didcomm, Protocol::Tsp]
+        );
+
+        // Explicit wins, including serving more than this VTA uses — a
+        // shared mediator carrying TSP for other clients.
+        assert_eq!(
+            mediator_protocols(Some(&[Protocol::Didcomm, Protocol::Tsp]), &didcomm_only),
+            vec![Protocol::Didcomm, Protocol::Tsp]
+        );
+    }
+
+    /// The mint-time slice of the §3 invariant: a VTA that advertises TSP
+    /// cannot mint itself a mediator that doesn't carry it.
+    #[test]
+    fn a_minted_mediator_may_not_serve_less_than_the_vta_advertises() {
+        let raw = r#"
+            config_path = "/tmp/vta-test/config.toml"
+            data_dir    = "/tmp/vta-test/data"
+
+            [services]
+            rest    = false
+            didcomm = true
+            tsp     = true
+
+            [secrets]
+            backend = "keyring"
+
+            [messaging]
+            kind      = "create_mediator"
+            url       = "https://mediator.example.com"
+            protocols = ["didcomm"]
+        "#;
+        let inputs = parse(raw).expect("parses");
+        let err = validate_inputs(&inputs).expect_err("must refuse a TSP-less mediator");
+        assert!(
+            err.to_string()
+                .contains("messaging.protocols omits \"tsp\""),
+            "got: {err}"
+        );
+    }
+
+    /// The other ways `messaging.protocols` can be wrong. Each is refused by
+    /// name rather than normalised — a config that means something other than
+    /// it says is how the `#tsp`-at-a-DIDComm-mediator state arose.
+    #[test]
+    fn messaging_protocols_rejects_malformed_lists() {
+        let cases = [
+            (r#"protocols = []"#, "a mediator that carries nothing"),
+            (
+                r#"protocols = ["didcomm", "rest"]"#,
+                "REST is not a mediator transport",
+            ),
+            (r#"protocols = ["didcomm", "didcomm"]"#, "more than once"),
+            (r#"protocols = ["tsp"]"#, "always advertises a DIDComm"),
+        ];
+        for (line, expected) in cases {
+            let raw = format!(
+                r#"
+                config_path = "/tmp/vta-test/config.toml"
+                data_dir    = "/tmp/vta-test/data"
+
+                [services]
+                rest    = false
+                didcomm = true
+                tsp     = false
+
+                [secrets]
+                backend = "keyring"
+
+                [messaging]
+                kind = "create_mediator"
+                url  = "https://mediator.example.com"
+                {line}
+            "#
+            );
+            let inputs = parse(&raw).unwrap_or_else(|e| panic!("{line} should parse: {e}"));
+            let err = validate_inputs(&inputs)
+                .expect_err(&format!("{line} must be refused"))
+                .to_string();
+            assert!(err.contains(expected), "{line}: got {err}");
+        }
     }
 
     #[test]

--- a/vta-service/src/setup/interactive.rs
+++ b/vta-service/src/setup/interactive.rs
@@ -767,6 +767,11 @@ async fn configure_messaging(p: &dyn Prompter) -> Result<MessagingInput, DynErr>
                 mediator_host,
                 template_vars,
                 setup_acl,
+                // Derived from the services chosen earlier: a mediator minted
+                // for this VTA serves what this VTA advertises. Overriding
+                // that (a shared mediator carrying more) is a `--from <toml>`
+                // affair — see `MessagingInput::CreateMediator::protocols`.
+                protocols: None,
             })
         }
         _ => Ok(MessagingInput::Skip),


### PR DESCRIPTION
Started as the design note answering *why does TSP need DIDComm, can't a
mediator be TSP-only?* — now also carries **phase A**, the live hazard it turned
up.

## The bug (fixed here)

**A mediator minted by `vta setup` never advertised TSP, on any VTA.** The
`didcomm-mediator` template has carried a `{SERVICE_TSP}` null-pruning slot
since #929, but neither setup front-end supplied the variable:
`MessagingInput::CreateMediator` built `effective_vars` with `URL` and `WS_URL`
only.

So the state a TSP-enabled VTA reached through `vta setup` was:

- the VTA's document advertises `#tsp` → mediator *m* (as of #933);
- *m*'s own document advertises `DIDCommMessaging` and **no** `TSPTransport`.

A peer following the documents finds a TSP endpoint whose mediator says it
doesn't carry TSP — the same class of defect #933 fixed one hop earlier, failing
two layers down as a parse error rather than as anything nameable.

Setup now fills the slot, **derived from `[services]`**: DIDComm always (the
template renders that entry unconditionally), plus TSP when the VTA advertises
TSP. Deriving rather than prompting is the point — the two must agree for the
VTA to be reachable and setup already knows the only correct answer, so asking
would only invite the operator to author a contradiction. A new
`[messaging] protocols` overrides it for the one case derivation can't reach: a
shared mediator serving *more* than this VTA uses. Serving less is refused by
name, as are `rest`, duplicates, an empty list, and a list omitting `didcomm`.

`vta-sdk` gains `did_templates::tsp_transport_service` — the **mediator side**
of the TSP entry, and the inverse of the existing `tsp_service`. A consumer's
`#tsp` names its mediator's DID; a mediator's own `#tsp` names the URL it serves
TSP at, because the indirection has to terminate at the node that actually
carries the transport (`forward_tsp_remote` URL-parses exactly this value for
the mediator→mediator hop). Each helper refuses the other's argument with a
message naming the other.

## The model (design note)

Three facts, today carried by one flag and one field: **V** (what this VTA
advertises), **R** (which mediator carries each transport), **M(m)** (what
mediator *m* can carry). Invariant: for every transport in V, `R(p)` is defined
and `p ∈ M(R(p))`.

**R defaults to one mediator for everything** — D8's shape, what every existing
config means, and no new keys to get it. A split table is opt-in:

```toml
[messaging]
kind      = "existing"
did       = "did:webvh:mediator.example.com:mediator"
protocols = ["didcomm"]

[messaging.tsp]                       # TSP rides a different mediator
did       = "did:webvh:tsp-mediator.example.com:mediator"
protocols = ["tsp"]
```

M is resolved from the mediator's DID document where it can be
(`ServiceCapabilities::from_did_document`, matched on service `type`), chosen by
us when we mint the mediator, and declarable explicitly for offline /
not-yet-published mediators.

**On D8.** Its default survives — one mediator, both entries pointing at it, no
config needed. Its "no separate TSP-mediator field, ever" does not: D8 itself
called a distinct TSP mediator "purely additive… if a concrete need ever lands",
and two have (a TSP-only mediator must be expressible; an operator may run TSP
through a different provider or migrate one transport at a time).

**§7 is the load-bearing finding for the runtime**: `MessagingService` already
holds *many* transports, and `live_prover.rs` already installs a second one per
candidate mediator during the protocol-management handshake (`add_transport` →
merged inbound dispatcher → `request_via` → `promote`/`remove_transport`, with
listener id = mediator DID). So a split routing table is per-mediator transports
plus outbound protocol routing — not a second session stack.

## Sequencing (§10)

- **A — mint a TSP-capable mediator.** ✅ this PR.
- **B** — `protocols` + DID-doc resolution + the full invariant.
- **C** — split routing table (what makes `[messaging.tsp]` real).
- **D** — TSP-only runtime: the `services.didcomm` mount gate and the
  `tsp = ["didcomm"]` feature edge.
- **E** — `services tsp enable` parity.

C and D are independent: C gives a dual-transport VTA two mediators, D gives a
single-mediator VTA TSP without DIDComm. Both want the §9 open questions
answered against a live mediator first (per-protocol registration; whether a
TSP-only session still needs the DIDComm auth leg).

## Tests

New: mediator-side vs consumer-side TSP entry shapes and their mutual refusal
(`vta-sdk`); derivation of a minted mediator's protocols from `[services]`; the
mint-time invariant; the four malformed-`protocols` refusals. Full `vta-sdk` and
`vta-service --bin vta` suites green, clippy clean, `cargo check --workspace
--all-targets` clean.
