### PR TITLE
feat(tsp): a VTA can speak TSP without DIDComm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,6 +285,13 @@ jobs:
       # consumers were behind `didcomm`; nothing built it, so nothing said so.
       - name: vta-service rest only
         run: cargo clippy -p vta-service --no-default-features --features rest -- -D warnings
+      # TSP *without* DIDComm — the combination the `tsp = ["didcomm"]` feature
+      # edge used to make unbuildable. `-D warnings` for the same reason as the
+      # REST-only step above: the dead code this build exposes (DIDComm-only
+      # imports, helpers and constants that no longer have a consumer) is
+      # exactly what a silent-pass would hide.
+      - name: vta-service tsp without didcomm
+        run: cargo clippy -p vta-service --no-default-features --features setup,keyring,rest,tsp,cli-synthesis --all-targets -- -D warnings
       - name: vta-service aws-secrets
         run: cargo check -p vta-service --no-default-features --features aws-secrets,keyring,rest
       - name: vta-service azure-secrets

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9446,7 +9446,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.14.35"
+version = "0.14.36"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/changelog.d/937-tsp-without-didcomm.md
+++ b/changelog.d/937-tsp-without-didcomm.md
@@ -1,4 +1,4 @@
-### vta-service 0.14.35 — a VTA can speak TSP without DIDComm (#937)
+### vta-service 0.14.36 — a VTA can speak TSP without DIDComm (#937)
 
 `vta setup` refused TSP unless DIDComm was selected too, and said so as though it
 were a fact about TSP: "TSP shares the DIDComm mediator". It isn't — TSP is an

--- a/changelog.d/937-tsp-without-didcomm.md
+++ b/changelog.d/937-tsp-without-didcomm.md
@@ -1,0 +1,46 @@
+### vta-service 0.14.35 — a VTA can speak TSP without DIDComm (#937)
+
+`vta setup` refused TSP unless DIDComm was selected too, and said so as though it
+were a fact about TSP: "TSP shares the DIDComm mediator". It isn't — TSP is an
+independent transport and a TSP-only mediator is legitimate. Three things in this
+crate assumed otherwise, and all three are gone.
+
+- **The mediator question was asked only in the DIDComm branch.** `[messaging]`
+  is transport-neutral — its `mediator_did` is what `#tsp` names — so the wizard
+  reaches it when either transport is selected, and says what it is configuring
+  when TSP is the only one. `validate_services` drops the implication, the
+  `--from <toml>` rule goes with it, and `[messaging]` now requires *a* transport
+  rather than DIDComm specifically. A TSP-only VTA that skips `[messaging]`
+  degrades exactly as a DIDComm one always has: enabled in config, no service
+  entry published, because there is no endpoint to name.
+- **The connect supervisor was mounted on `services.didcomm`**; it is now
+  `services.didcomm || services.tsp`. TSP receive arrives on that same mediator
+  socket (ADR 0005 — one websocket per DID) and TSP send is an HTTP post through
+  the same ATM, so gating the socket on DIDComm meant a TSP-only VTA would
+  advertise `#tsp` and never connect. The queue-recovery helpers, the mediator
+  ACL (keyed on the VTA DID, so it authorises whichever protocol rides the
+  socket), the VM ids that collect the profile's secrets, and the outbound bridge
+  move with it. A TSP-only VTA must not advertise `#vta-didcomm`, so the mint
+  flag becomes `messaging.is_some() && services.didcomm`.
+- **The cargo feature carried the edge** (`tsp = ["didcomm", …]`). The split is
+  now by role: `messaging::{service,readiness,auth}` and the module itself build
+  for either transport, while the DIDComm protocol surface (router, handlers,
+  shim, registry, drain store/sweeper, handshake, live prover, transient
+  handshake) is `didcomm`-only, along with the ops, REST routes and offline CLI
+  commands that drive it. `ceremony` and `reject_trust_task` widen to either
+  transport — an approver must not be reachable over one and not the other.
+
+`transport-harness` named `tsp` and relied on it pulling `didcomm` in; it now
+names both, or its own DIDComm fixture would have had no dispatcher behind it.
+CI gains a `tsp without didcomm` combo at `-D warnings --all-targets`: the
+combination that was unbuildable is the one nothing would notice rotting.
+
+**A TSP-only build has no DIDComm protocol-message surface** (`key-management/1.0/*`,
+`create_did_webvh`, `list_contexts` are REST-only there), no drain machinery or
+`services didcomm …` commands, and no path back without a rebuild. A
+dual-transport build keeps all of it. See `docs/02-vta/tsp.md`.
+
+Per-transport mediators (`[messaging.tsp]`) are still designed-not-built
+(`transport-neutral-mediator.md` §7), and that note's two open questions —
+per-protocol mediator registration, and whether a TSP-only session needs the
+DIDComm auth leg — want a live mediator run.

--- a/docs/02-vta/tsp.md
+++ b/docs/02-vta/tsp.md
@@ -40,10 +40,15 @@ hosted DID, exactly as it can't advertise REST/DIDComm without one.
 
 ## Enabling TSP
 
-TSP shares the DIDComm mediator, so **enable DIDComm first**. That is a
-constraint of this implementation, not of TSP — a TSP-only mediator is
-legitimate, and lifting the requirement is designed in
-[transport-neutral-mediator.md](../05-design-notes/transport-neutral-mediator.md).
+TSP needs a **mediator** — it does not need DIDComm. A TSP-only VTA connects to
+a mediator, speaks TSP on that socket, and has no DIDComm dispatcher compiled or
+advertised. Whether your mediator *carries* TSP is your call; nothing here can
+verify it. (Until recently TSP did require DIDComm — the mediator was collected
+only in the DIDComm branch of setup and the TSP dispatcher was compiled behind
+the DIDComm one. See
+[transport-neutral-mediator.md](../05-design-notes/transport-neutral-mediator.md)
+for what that was and what remains.)
+
 Two paths:
 
 - **Runtime (recommended):** once you've verified TSP against your mediator,
@@ -53,16 +58,36 @@ Two paths:
   Unlike `services didcomm enable`, `services tsp enable` works over **either**
   transport. TSP has **no drain** and **no handshake**.
 - **At setup:** the interactive `vta setup` wizard lists **TSP** in its services
-  multi-select, and a `vta setup --from <toml>` file takes `[services] tsp =
-  true`. Both **require** `services.didcomm = true` (that is where the mediator
-  is configured) and a binary built with `--features tsp` — setup refuses either
-  combination by name rather than publishing a transport it cannot serve. TSP is
+  multi-select — selectable on its own — and a `vta setup --from <toml>` file
+  takes `[services] tsp = true`. Selecting TSP (with or without DIDComm) leads
+  into the `[messaging]` mediator questions, since `#tsp` names a mediator. A
+  binary built without `--features tsp` refuses `tsp = true` by name and never
+  offers the option, rather than publishing a transport it cannot serve. TSP is
   not pre-ticked in the wizard, for the reason in *Rollout posture* below.
   Choosing it here puts `#tsp` in the DID document from log v1, rather than
   adding it in a later log entry.
 
 `pnm services list` shows TSP on/off + its mediator; `GET /health/details`
 reports `tsp_enabled`.
+
+### What a TSP-only build does not have
+
+Building with `--features tsp` and no `didcomm` removes the DIDComm dispatcher
+outright, not just its advertisement. That means:
+
+- **No DIDComm protocol-message surface** (`key-management/1.0/*`,
+  `create_did_webvh`, `list_contexts`). Those never had a TSP dispatcher behind
+  them — TSP carries the *Trust-Task* surface — so on a TSP-only VTA they are
+  reachable over REST only.
+- **No drain machinery and no `services didcomm …` commands**, online or
+  offline: drain is a DIDComm concept, and the ops behind those commands are
+  compiled out. `services {rest,tsp,webauthn} …` are unaffected.
+- **No path back without a rebuild.** Adding DIDComm later means a binary built
+  with the feature, then `pnm services didcomm enable`.
+
+A dual-transport build (`--features tsp` *and* `didcomm`, both advertised) keeps
+all of it and is still the recommended shape unless you specifically want DIDComm
+gone.
 
 ## Rollout posture
 
@@ -81,6 +106,8 @@ the automatic fallback for any peer that doesn't speak TSP.
 | DID templates advertise `#tsp` | ✅ shipped |
 | Health `tsp_enabled` + `services list` | ✅ shipped |
 | Setup: wizard multi-select + `--from` `[services] tsp`, both minting `#tsp` | ✅ shipped |
+| TSP **without** DIDComm (`--features tsp` alone; mediator connects, `#vta-didcomm` not advertised) | ✅ shipped (live run pending) |
+| Per-transport mediators (`[messaging.tsp]`) | ⏳ designed, not built — `transport-neutral-mediator.md` §7 |
 | Inbound: `tsp-message` vault unseal | ✅ shipped (feature-gated; live unpack pending verification) |
 | Inbound: TSP listener (raw-TSP websocket → trust-task spine) | ✅ shipped (feature-gated; live loop pending verification) |
 | Auth over TSP | ✅ by construction (rides the inbound spine → `handle_authenticate`) |
@@ -99,12 +126,12 @@ requires a Bidirectional relationship — `tsp-outbound-send.md` §3).
   protocol tag (a TSP VID is a DID too) — deferred until there's a consumer.
 - **`vta-mcp` / `didcomm-test`** TSP wiring — deferred until they have a
   TSP-specific path to exercise.
-- **TSP-only VTAs.** TSP currently requires DIDComm (shared mediator, shared
-  socket, shared cargo feature). Also note that a mediator minted by `vta setup`
-  does **not** advertise `TSPTransport` today, so a TSP-enabled VTA can point
-  `#tsp` at a mediator whose own document says it doesn't carry TSP. Both are
-  addressed in
-  [transport-neutral-mediator.md](../05-design-notes/transport-neutral-mediator.md).
+- **Per-transport mediators.** TSP and DIDComm still ride the *same* mediator
+  when both are enabled. Routing them to different mediators
+  (`[messaging.tsp]`) is designed in
+  [transport-neutral-mediator.md](../05-design-notes/transport-neutral-mediator.md)
+  §7 and not built — it needs per-mediator transports and outbound protocol
+  routing.
 
 ## References
 

--- a/docs/05-design-notes/transport-neutral-mediator.md
+++ b/docs/05-design-notes/transport-neutral-mediator.md
@@ -262,6 +262,17 @@ Questions 1 and 2 want one live run against a mediator — the same smoke test
 
 ## 10. Sequencing
 
+**Update (phase D shipped).** §1's three reasons are now history: the mediator
+prompt is reached by either transport, the connect supervisor is mounted on
+`services.didcomm || services.tsp`, and the `tsp = ["didcomm"]` feature edge is
+gone — `messaging::{service,readiness,auth}` are gated on either transport while
+the DIDComm protocol surface (router, handlers, drain, registry, protocol
+management, and their routes and CLI) is `didcomm`-only. A TSP-only VTA connects
+to its mediator, speaks TSP on that socket, and does not advertise
+`#vta-didcomm`. §9's two open questions are unchanged and are what the live run
+answers. Phases B and C — `protocols` with DID-document resolution, and the
+split routing table — remain.
+
 - **A — mint a TSP-capable mediator.** `create_mediator` fills `SERVICE_TSP`
   when the mediator serves TSP, derived from `services.tsp` and overridable via
   `messaging.protocols`. Closes §2, needs none of the model. **Implemented in

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.14.35"
+version = "0.14.36"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -18,16 +18,13 @@ didcomm = []
 # gated; DIDComm stays in `default`). Enables the SDK's `tsp` capability; later
 # PRs add the TSP listener + `services tsp` surface behind this flag.
 tsp = [
-    # In *this* crate TSP is not a standalone transport: its inbound dispatcher
-    # and reachability map (`messaging::{tsp_inbound,tsp_reach}`) live inside
-    # the `didcomm`-gated `messaging` module, because TSP receive arrives on the
-    # DIDComm pickup socket rather than opening a second one (ADR 0005 — one
-    # websocket per DID). Without this, `--features tsp` alone names
-    # `crate::messaging`, which is configured out.
-    #
-    # `vta-sdk/tsp` is deliberately NOT given the same edge: its `TspPingSession`
-    # is a genuinely TSP-only client that owns its own socket.
-    "didcomm",
+    # No `didcomm` edge. TSP still *rides* the mediator socket the DIDComm
+    # transport owns (ADR 0005 — one websocket per DID), but that socket
+    # carries either protocol: `messaging::{service,readiness}` and the
+    # module itself are gated on `any(didcomm, tsp)`, and only the DIDComm
+    # protocol surface (handlers, drain, registry, protocol management) is
+    # `didcomm`-only. So `--features tsp` alone builds a VTA that connects to
+    # a mediator and speaks TSP on it, with no DIDComm dispatcher present.
     "vta-sdk/tsp",
     "dep:affinidi-messaging-sdk",
     "affinidi-messaging-sdk/tsp",
@@ -90,11 +87,15 @@ test-support = ["webvh", "dep:tempfile"]
 # `MockVta` cannot.
 #
 # One socket serves both protocols (ADR 0005), so this is a single feature
-# rather than one per transport. Implies `tsp`, which implies `didcomm`.
+# rather than one per transport. It drives a Trust Task over EITHER, so it
+# names both explicitly: `tsp` used to imply `didcomm` and no longer does, and
+# without the explicit edge this harness would build with no DIDComm dispatcher
+# behind the DIDComm half of its own fixture.
 # Test-only — never in a production build.
 transport-harness = [
     "test-support",
     "tsp",
+    "didcomm",
     "rest",
     "dep:affinidi-messaging-test-mediator",
 ]

--- a/vta-service/src/lib.rs
+++ b/vta-service/src/lib.rs
@@ -57,7 +57,11 @@ pub mod error;
 pub use vta_keys as keys;
 pub mod hardened_bootstrap;
 pub mod keyspaces;
-#[cfg(feature = "didcomm")]
+/// Mediator connection + inbound dispatch. Present whenever *either*
+/// transport is compiled: the mediator socket is shared, and TSP rides it
+/// (ADR 0005 — one websocket per DID). The DIDComm protocol surface inside
+/// is separately gated on `didcomm`.
+#[cfg(any(feature = "didcomm", feature = "tsp"))]
 pub mod messaging;
 #[cfg(feature = "rest")]
 pub mod metrics;

--- a/vta-service/src/main.rs
+++ b/vta-service/src/main.rs
@@ -1367,6 +1367,7 @@ enum ServicesCommands {
         command: RestCommands,
     },
     /// Manage DIDComm advertisement.
+    #[cfg(feature = "didcomm")]
     Didcomm {
         #[command(subcommand)]
         command: DidcommCommands,
@@ -2039,9 +2040,10 @@ async fn main() {
             // List/report/drain-list are read-only and skip the
             // check.
             match &command {
-                ServicesCommands::List
-                | ServicesCommands::Report { .. }
-                | ServicesCommands::Didcomm {
+                ServicesCommands::List | ServicesCommands::Report { .. } => {}
+                // `drain list` is the DIDComm family's only read-only member.
+                #[cfg(feature = "didcomm")]
+                ServicesCommands::Didcomm {
                     command:
                         DidcommCommands::Drain {
                             command: DrainCommands::List,
@@ -2079,6 +2081,10 @@ async fn main() {
                         services_cli::run_services_rest_rollback(cli.config).await
                     }
                 },
+                // The DIDComm family of `vta services …` exists only in a
+                // build with a DIDComm dispatcher; the clap subcommand is
+                // gated alongside it, so this arm is unreachable elsewhere.
+                #[cfg(feature = "didcomm")]
                 ServicesCommands::Didcomm { command } => match command {
                     DidcommCommands::Enable {
                         mediator_did,

--- a/vta-service/src/messaging/mod.rs
+++ b/vta-service/src/messaging/mod.rs
@@ -1,22 +1,39 @@
+//! Mediator connection and inbound dispatch, for both transports.
+//!
+//! The split below is the one that matters: the **connection** is shared and
+//! the **protocol surfaces** are not. `service` builds one `DidCommTransport`
+//! over the mediator socket and its inbound loop hands DIDComm frames to the
+//! DIDComm router and TSP frames to [`tsp_inbound`] — one socket per DID
+//! carrying either protocol (ADR 0005). So `service`, `readiness` and `auth`
+//! are gated on `any(didcomm, tsp)`, while the DIDComm protocol machinery
+//! (routing, handlers, drain windows, the mediator registry, protocol
+//! management) stays `didcomm`-only and is simply absent from a TSP-only build.
 pub mod auth;
+#[cfg(feature = "didcomm")]
 pub mod drain_store;
+#[cfg(feature = "didcomm")]
 pub mod drain_sweeper;
+#[cfg(feature = "didcomm")]
 pub mod handlers;
 #[cfg(all(feature = "webvh", feature = "didcomm"))]
 pub mod handlers_protocol;
+#[cfg(feature = "didcomm")]
 pub mod handshake;
 #[cfg(feature = "didcomm")]
 pub mod live_prover;
-/// Startup self-readiness gate for the mediator DIDComm connection.
-#[cfg(feature = "didcomm")]
+/// Startup self-readiness gate for the mediator connection. Transport-neutral:
+/// the mediator authenticates us by resolving our DID whichever protocol we
+/// then speak on the socket.
 pub mod readiness;
+#[cfg(feature = "didcomm")]
 pub mod registry;
+#[cfg(feature = "didcomm")]
 pub mod router;
 /// Delivery-layer construction + protocol-routed inbound loop (D2 P2a).
-#[cfg(feature = "didcomm")]
 pub mod service;
 /// Local replacements for the `affinidi-messaging-didcomm-service` types the
 /// DIDComm handlers depend on (D2 P2a cut-over). See [`shim`].
+#[cfg(feature = "didcomm")]
 pub mod shim;
 #[cfg(all(feature = "webvh", feature = "didcomm"))]
 pub mod transient_handshake;

--- a/vta-service/src/messaging/service.rs
+++ b/vta-service/src/messaging/service.rs
@@ -20,7 +20,10 @@ use std::time::Duration;
 use affinidi_did_resolver_cache_sdk::DIDCacheClient;
 use affinidi_did_resolver_cache_sdk::config::DIDCacheConfigBuilder;
 use affinidi_messaging_core::{Inbound, MessageTransport, Protocol, ReceivedMessage};
-use affinidi_messaging_delivery::{Delivery, MessagingService, OutboxStore};
+#[cfg(feature = "didcomm")]
+use affinidi_messaging_delivery::Delivery;
+use affinidi_messaging_delivery::{MessagingService, OutboxStore};
+#[cfg(feature = "didcomm")]
 use affinidi_messaging_didcomm::Message;
 use affinidi_tdk::common::TDKSharedState;
 use affinidi_tdk::common::config::TDKConfig;
@@ -35,7 +38,9 @@ use tracing::{info, warn};
 
 use vti_common::outbox_store::VtiOutboxStore;
 
+#[cfg(feature = "didcomm")]
 use crate::messaging::router::{self, VtaState};
+#[cfg(feature = "didcomm")]
 use crate::messaging::shim::{DIDCommResponse, ProblemReport, ServiceProblemReport};
 use crate::server::AppState;
 use crate::store::KeyspaceHandle;
@@ -229,6 +234,10 @@ pub async fn run_inbound_loop(
     mediator_did: String,
     shutdown: CancellationToken,
 ) {
+    // Handler state for the DIDComm dispatcher only — TSP's spine entry
+    // (`tsp_inbound::dispatch_one`) takes `AppState` directly, so a TSP-only
+    // build never assembles this.
+    #[cfg(feature = "didcomm")]
     let vta_state = Arc::new(VtaState::from(&app_state));
     let mut stream = messaging.service.subscribe();
     info!("VTA messaging connected to mediator — inbound messages will be processed");
@@ -272,11 +281,17 @@ pub async fn run_inbound_loop(
 
                 let messaging = Arc::clone(&messaging);
                 let app_state = app_state.clone();
+                #[cfg(feature = "didcomm")]
                 let vta_state = Arc::clone(&vta_state);
                 let vta_did = vta_did.clone();
                 let mediator_did = mediator_did.clone();
                 tokio::spawn(async move {
                     let _permit = permit;
+                    // Two call sites rather than one with a `#[cfg]` argument:
+                    // attributes on call arguments are not stable, while
+                    // attributes on the parameter (below) and on a statement
+                    // are.
+                    #[cfg(feature = "didcomm")]
                     handle_inbound(
                         inbound,
                         &messaging,
@@ -286,6 +301,8 @@ pub async fn run_inbound_loop(
                         &mediator_did,
                     )
                     .await;
+                    #[cfg(not(feature = "didcomm"))]
+                    handle_inbound(inbound, &messaging, &app_state, &vta_did, &mediator_did).await;
                 });
             }
             _ = shutdown.cancelled() => {
@@ -303,14 +320,25 @@ async fn handle_inbound(
     inbound: Inbound,
     messaging: &Arc<VtaMessaging>,
     app_state: &AppState,
-    vta_state: &Arc<VtaState>,
+    #[cfg(feature = "didcomm")] vta_state: &Arc<VtaState>,
     vta_did: &str,
     mediator_did: &str,
 ) {
     match inbound.message.protocol {
+        #[cfg(feature = "didcomm")]
         Protocol::DIDComm => {
             let _ = mediator_did;
             handle_didcomm(inbound, messaging, app_state, vta_state, vta_did).await;
+        }
+        // Mirror of the TSP arm below: a mediator that routes both protocols
+        // can hand a TSP-only VTA a DIDComm frame, and dropping it with a
+        // named reason beats a panic or a silent discard.
+        #[cfg(not(feature = "didcomm"))]
+        Protocol::DIDComm => {
+            let _ = (messaging, app_state, vta_did, mediator_did);
+            warn!(
+                "received an inbound DIDComm frame but the `didcomm` feature is disabled — dropping"
+            );
         }
         #[cfg(feature = "tsp")]
         Protocol::TSP => {
@@ -348,6 +376,7 @@ async fn handle_inbound(
 /// Outcome of the framework `MessagePolicy` gate for one inbound DIDComm frame,
 /// factored out of [`handle_didcomm`] so the policy is unit-testable without a
 /// live mediator socket. See [`inbound_gate`].
+#[cfg(feature = "didcomm")]
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum InboundGate {
     /// The frame was not encrypted — reply `bad_request` ("must be encrypted").
@@ -361,6 +390,7 @@ enum InboundGate {
     Authenticated(String),
 }
 
+#[cfg(feature = "didcomm")]
 impl InboundGate {
     /// The dispatchable sender DID, or `None` for a rejected frame.
     fn authenticated_sender(&self) -> Option<&str> {
@@ -387,6 +417,7 @@ impl InboundGate {
 /// sender, exactly as the removed middleware layer guaranteed. There is NO
 /// discovery exemption: the old policy layer required authcrypt for discovery
 /// too, so requiring it here is behaviour-preserving.
+#[cfg(feature = "didcomm")]
 fn inbound_gate(message: &ReceivedMessage) -> InboundGate {
     if !message.encrypted {
         return InboundGate::NotEncrypted;
@@ -402,6 +433,7 @@ fn inbound_gate(message: &ReceivedMessage) -> InboundGate {
 
 /// DIDComm inbound: rehydrate, stamp the verified sender, gate encryption,
 /// dispatch, pack + send the reply.
+#[cfg(feature = "didcomm")]
 async fn handle_didcomm(
     inbound: Inbound,
     messaging: &Arc<VtaMessaging>,

--- a/vta-service/src/operations/did_webvh/mod.rs
+++ b/vta-service/src/operations/did_webvh/mod.rs
@@ -111,7 +111,11 @@ impl<'a> WebvhDeps<'a> {
     /// (REST + trust-task transports). `did_resolver` is threaded separately
     /// because `AppState` holds it as an `Option` — the caller unwraps it
     /// (surfacing the typed "DID resolver not available" reject) first.
-    #[cfg(all(feature = "webvh", feature = "didcomm"))]
+    // Only `webvh`: every field it borrows exists in any build. The DIDComm
+    // edge came from `from_vta_state` below (VtaState is the DIDComm handler
+    // state) and was never needed on this side — trust tasks reach these ops
+    // over whichever transport is compiled.
+    #[cfg(feature = "webvh")]
     pub fn from_app_state(
         s: &'a crate::server::AppState,
         did_resolver: &'a DIDCacheClient,
@@ -184,7 +188,11 @@ impl<'a> CreateDidWebvhDeps<'a> {
     /// Borrow create-deps from an [`AppState`](crate::server::AppState) (REST +
     /// trust-task). `config` (the read-guard snapshot) and the unwrapped
     /// `did_resolver` are threaded separately.
-    #[cfg(all(feature = "webvh", feature = "didcomm"))]
+    // Only `webvh`: every field it borrows exists in any build. The DIDComm
+    // edge came from `from_vta_state` below (VtaState is the DIDComm handler
+    // state) and was never needed on this side — trust tasks reach these ops
+    // over whichever transport is compiled.
+    #[cfg(feature = "webvh")]
     pub fn from_app_state(
         s: &'a crate::server::AppState,
         config: &'a AppConfig,

--- a/vta-service/src/operations/protocol/mod.rs
+++ b/vta-service/src/operations/protocol/mod.rs
@@ -6,22 +6,31 @@
 //! DIDComm transports (enable / update / disable / rollback / list)
 //! plus the DIDComm-only drain set (cancel / list / report).
 
+// The `*_didcomm` family and the drain surface it owns exist only in a build
+// that speaks DIDComm. Everything else here — REST, TSP, WebAuthn, the shared
+// document/invariant/snapshot machinery — is transport-neutral and always
+// compiled, so a TSP-only VTA still gets `services {rest,tsp} …`.
+#[cfg(feature = "didcomm")]
 pub mod disable_didcomm;
 pub mod disable_rest;
 pub mod disable_tsp;
 pub mod disable_webauthn;
 pub mod document;
+#[cfg(feature = "didcomm")]
 pub mod drain_cancel;
+#[cfg(feature = "didcomm")]
 pub mod enable_didcomm;
 pub mod enable_rest;
 pub mod enable_tsp;
 pub mod enable_webauthn;
 pub mod invariant;
 pub mod list;
+#[cfg(feature = "didcomm")]
 pub mod list_drain;
 pub mod passkey_vm_cleanup;
 pub mod preconditions;
 pub mod report;
+#[cfg(feature = "didcomm")]
 pub mod rollback_didcomm;
 pub mod rollback_rest;
 pub mod rollback_tsp;
@@ -29,6 +38,7 @@ pub mod rollback_webauthn;
 pub mod runtime_state;
 pub(crate) mod service_lifecycle;
 pub mod snapshot;
+#[cfg(feature = "didcomm")]
 pub mod update_didcomm;
 pub mod update_rest;
 pub mod update_tsp;
@@ -79,6 +89,10 @@ impl std::error::Error for DrainTtlBoundsError {}
 /// `update_didcomm`, `rollback_didcomm` — enforce the same bounds.
 /// Mirrors the spec §7a.4 "drain-ttl 31d" / "drain-ttl 30s over
 /// DIDComm" matrix cells.
+///
+/// Drain is a DIDComm-only concept (REST and TSP have no drain window), so
+/// this and its bounds live with the transport that has them.
+#[cfg(feature = "didcomm")]
 pub fn validate_drain_ttl(
     transport: crate::operations::protocol::disable_didcomm::DisableTransport,
     ttl: std::time::Duration,
@@ -176,10 +190,10 @@ pub struct ServiceOpDeps<'a> {
     pub telemetry: &'a vti_common::telemetry::SharedTelemetrySink,
     pub webvh_auth_locks: &'a crate::operations::did_webvh::WebvhAuthLocks,
     /// Active + draining mediator listener registry — DIDComm family only.
-    #[cfg(feature = "webvh")]
+    #[cfg(all(feature = "webvh", feature = "didcomm"))]
     pub registry: &'a crate::messaging::registry::MediatorListenerRegistry,
     /// Per-mediator drain-TTL sweeper — DIDComm family only.
-    #[cfg(feature = "webvh")]
+    #[cfg(all(feature = "webvh", feature = "didcomm"))]
     pub sweeper: &'a crate::messaging::drain_sweeper::DrainSweeper,
 }
 
@@ -190,7 +204,10 @@ impl<'a> ServiceOpDeps<'a> {
     /// `did_resolver` is threaded separately because `AppState` holds it as an
     /// `Option` — the caller unwraps it (surfacing the typed
     /// `DidResolverUnavailable` reject) before building the deps.
-    #[cfg(all(feature = "webvh", feature = "didcomm"))]
+    // Only `webvh`: the REST, TSP and WebAuthn ops all build their deps this
+    // way, and none of them touch the DIDComm-only registry/sweeper — those two
+    // fields are simply absent from a TSP-only build (see the struct above).
+    #[cfg(feature = "webvh")]
     pub fn from_app_state(
         s: &'a crate::server::AppState,
         did_resolver: &'a affinidi_did_resolver_cache_sdk::DIDCacheClient,
@@ -210,7 +227,9 @@ impl<'a> ServiceOpDeps<'a> {
             didcomm_bridge: &s.didcomm_bridge,
             telemetry: &s.telemetry,
             webvh_auth_locks: &s.webvh_auth_locks,
+            #[cfg(feature = "didcomm")]
             registry: &s.mediator_registry,
+            #[cfg(feature = "didcomm")]
             sweeper: &s.drain_sweeper,
         }
     }

--- a/vta-service/src/routes/mod.rs
+++ b/vta-service/src/routes/mod.rs
@@ -456,9 +456,6 @@ fn build_api_router(trust_xff: bool) -> OpenApiRouter<AppState> {
     // docs/05-design-notes/runtime-service-management.md §3.4).
     #[cfg(feature = "webvh")]
     let router = router
-        .routes(routes!(protocol::enable_didcomm_handler))
-        .routes(routes!(protocol::get_didcomm_status_handler))
-        .routes(routes!(protocol::disable_didcomm_handler))
         .routes(routes!(protocol::enable_rest_handler))
         .routes(routes!(protocol::update_rest_handler))
         .routes(routes!(protocol::disable_rest_handler))
@@ -472,6 +469,17 @@ fn build_api_router(trust_xff: bool) -> OpenApiRouter<AppState> {
         .routes(routes!(protocol::disable_webauthn_handler))
         .routes(routes!(protocol::rollback_webauthn_handler))
         .routes(routes!(protocol::list_services_handler))
+        .routes(routes!(protocol::mediator_report_handler));
+
+    // The DIDComm half of service management — enable/disable/update/rollback
+    // plus the drain surface, which is DIDComm-only (REST and TSP have no
+    // drain window). Absent from a TSP-only build, along with the operations
+    // behind them; `services {rest,tsp,webauthn} …` above stay mounted.
+    #[cfg(all(feature = "webvh", feature = "didcomm"))]
+    let router = router
+        .routes(routes!(protocol::enable_didcomm_handler))
+        .routes(routes!(protocol::get_didcomm_status_handler))
+        .routes(routes!(protocol::disable_didcomm_handler))
         // GET list-drain + POST cancel share /services/didcomm/drain.
         .routes(routes!(
             protocol::list_drain_handler,
@@ -485,8 +493,7 @@ fn build_api_router(trust_xff: bool) -> OpenApiRouter<AppState> {
         .route(
             "/mediators/drain/cancel",
             post(protocol::drain_cancel_handler),
-        )
-        .routes(routes!(protocol::mediator_report_handler));
+        );
 
     // WebVH routes (feature-gated)
     #[cfg(feature = "webvh")]

--- a/vta-service/src/routes/protocol.rs
+++ b/vta-service/src/routes/protocol.rs
@@ -6,7 +6,9 @@
 //! routes (`/services/didcomm/disable`, `/services`, `/mediators/*`)
 //! are added by Phase 4 verticals.
 
+#[cfg(feature = "didcomm")]
 use std::sync::Arc;
+#[cfg(feature = "didcomm")]
 use std::time::Duration;
 
 use axum::Json;
@@ -16,8 +18,11 @@ use axum::response::{IntoResponse, Response};
 use serde::{Deserialize, Serialize};
 
 use crate::auth::SuperAdminAuth;
+#[cfg(feature = "didcomm")]
 use crate::messaging::handshake::{AlwaysOkProver, HandshakeError, HandshakeStage};
+#[cfg(feature = "didcomm")]
 use crate::operations::protocol::disable_didcomm::DisableTransport as DidcommTransport;
+#[cfg(feature = "didcomm")]
 use crate::operations::protocol::disable_didcomm::{
     DisableDidcommError, DisableDidcommParams, DisableTransport, disable_didcomm,
 };
@@ -28,6 +33,7 @@ use crate::operations::protocol::disable_tsp::{DisableTspError, DisableTspParams
 use crate::operations::protocol::disable_webauthn::{
     DisableWebauthnError, DisableWebauthnParams, disable_webauthn,
 };
+#[cfg(feature = "didcomm")]
 use crate::operations::protocol::enable_didcomm::{
     EnableDidcommError, EnableDidcommParams, enable_didcomm,
 };
@@ -36,6 +42,7 @@ use crate::operations::protocol::enable_tsp::{EnableTspError, EnableTspParams, e
 use crate::operations::protocol::enable_webauthn::{
     EnableWebauthnError, EnableWebauthnParams, enable_webauthn,
 };
+#[cfg(feature = "didcomm")]
 use crate::operations::protocol::rollback_didcomm::{
     RollbackDidcommError, RollbackDidcommParams, RollbackKind as DidcommRollbackKind,
     rollback_didcomm,
@@ -50,6 +57,7 @@ use crate::operations::protocol::rollback_webauthn::{
     RollbackKind as WebauthnRollbackKind, RollbackWebauthnError, RollbackWebauthnParams,
     rollback_webauthn,
 };
+#[cfg(feature = "didcomm")]
 use crate::operations::protocol::update_didcomm::{
     MigrateAuditKind, UpdateDidcommError, UpdateDidcommParams, update_didcomm,
 };
@@ -60,13 +68,16 @@ use crate::operations::protocol::update_webauthn::{
 };
 use crate::operations::protocol::{OpContext, ServiceOpDeps};
 use crate::server::AppState;
+#[cfg(feature = "didcomm")]
 use vta_sdk::protocol::DidcommStatusResponse;
 
 /// Default trust-ping round-trip timeout for first-enable when the
 /// caller doesn't specify `handshake_timeout_secs`. Spec default 10s.
+#[cfg(feature = "didcomm")]
 const DEFAULT_HANDSHAKE_TIMEOUT_SECS: u64 = 10;
 
 #[derive(Debug, Deserialize, utoipa::ToSchema)]
+#[cfg(feature = "didcomm")]
 pub struct EnableDidcommRequest {
     pub mediator_did: String,
     /// Optional: skip steps 2-5 of the handshake (DID resolution
@@ -81,6 +92,7 @@ pub struct EnableDidcommRequest {
 }
 
 #[derive(Debug, Serialize, utoipa::ToSchema)]
+#[cfg(feature = "didcomm")]
 pub struct EnableDidcommResponse {
     pub new_version_id: String,
     pub mediator_did: String,
@@ -120,6 +132,7 @@ pub struct EnableDidcommResponse {
         (status = 409, description = "DIDComm is already enabled"),
     ),
 )]
+#[cfg(feature = "didcomm")]
 pub async fn enable_didcomm_handler(
     auth: SuperAdminAuth,
     State(state): State<AppState>,
@@ -206,6 +219,7 @@ pub async fn enable_didcomm_handler(
         (status = 403, description = "Caller is not a super-admin"),
     ),
 )]
+#[cfg(feature = "didcomm")]
 pub async fn get_didcomm_status_handler(
     _auth: SuperAdminAuth,
     State(state): State<AppState>,
@@ -258,6 +272,7 @@ pub async fn get_didcomm_status_handler(
     })
 }
 
+#[cfg(feature = "didcomm")]
 async fn current_didcomm_mediator_did(state: &AppState) -> Option<String> {
     state
         .config
@@ -272,12 +287,14 @@ async fn current_didcomm_mediator_did(state: &AppState) -> Option<String> {
 /// HTTP error wrapper for `EnableDidcommError` that maps each typed
 /// variant to an appropriate status code + suggested-fix body.
 #[derive(Debug)]
+#[cfg(feature = "didcomm")]
 pub enum EnableDidcommHttpError {
     Op(EnableDidcommError),
     AlreadyEnabled { mediator_did: Option<String> },
     DidResolverUnavailable,
 }
 
+#[cfg(feature = "didcomm")]
 impl From<EnableDidcommError> for EnableDidcommHttpError {
     fn from(value: EnableDidcommError) -> Self {
         Self::Op(value)
@@ -299,6 +316,7 @@ struct ErrorBody {
     stage: Option<&'static str>,
 }
 
+#[cfg(feature = "didcomm")]
 impl IntoResponse for EnableDidcommHttpError {
     fn into_response(self) -> Response {
         let (status, body) = match self {
@@ -465,6 +483,7 @@ impl IntoResponse for EnableDidcommHttpError {
     }
 }
 
+#[cfg(feature = "didcomm")]
 fn stage_str(stage: HandshakeStage) -> &'static str {
     match stage {
         HandshakeStage::Resolve => "resolve",
@@ -480,6 +499,7 @@ fn stage_str(stage: HandshakeStage) -> &'static str {
 // ────────────────────────────────────────────────────────────────────
 
 #[derive(Debug, Deserialize, utoipa::ToSchema)]
+#[cfg(feature = "didcomm")]
 pub struct DisableDidcommRequest {
     /// Drain TTL in seconds. 0 = immediate teardown (REST only;
     /// over DIDComm transport, minimum 1h is enforced).
@@ -488,6 +508,7 @@ pub struct DisableDidcommRequest {
 }
 
 #[derive(Debug, Serialize, utoipa::ToSchema)]
+#[cfg(feature = "didcomm")]
 pub struct DisableDidcommResponse {
     pub new_version_id: String,
     pub prior_mediator_did: String,
@@ -519,6 +540,7 @@ pub struct DisableDidcommResponse {
         (status = 409, description = "DIDComm not enabled, or last remaining service"),
     ),
 )]
+#[cfg(feature = "didcomm")]
 pub async fn disable_didcomm_handler(
     auth: SuperAdminAuth,
     State(state): State<AppState>,
@@ -553,17 +575,20 @@ pub async fn disable_didcomm_handler(
 }
 
 #[derive(Debug)]
+#[cfg(feature = "didcomm")]
 pub enum DisableDidcommHttpError {
     Op(DisableDidcommError),
     DidResolverUnavailable,
 }
 
+#[cfg(feature = "didcomm")]
 impl From<DisableDidcommError> for DisableDidcommHttpError {
     fn from(value: DisableDidcommError) -> Self {
         Self::Op(value)
     }
 }
 
+#[cfg(feature = "didcomm")]
 impl IntoResponse for DisableDidcommHttpError {
     fn into_response(self) -> Response {
         let (status, body) = match self {
@@ -749,6 +774,7 @@ impl IntoResponse for DisableDidcommHttpError {
 // ────────────────────────────────────────────────────────────────────
 
 #[derive(Debug, Deserialize, utoipa::ToSchema)]
+#[cfg(feature = "didcomm")]
 pub struct UpdateDidcommRequest {
     pub new_mediator_did: String,
     pub drain_ttl_secs: u64,
@@ -762,6 +788,7 @@ pub struct UpdateDidcommRequest {
 }
 
 #[derive(Debug, Serialize, utoipa::ToSchema)]
+#[cfg(feature = "didcomm")]
 pub struct UpdateDidcommResponse {
     pub new_version_id: String,
     pub prior_mediator_did: String,
@@ -796,6 +823,7 @@ pub struct UpdateDidcommResponse {
         (status = 409, description = "DIDComm not enabled, or mediator already active/draining"),
     ),
 )]
+#[cfg(feature = "didcomm")]
 pub async fn update_didcomm_handler(
     auth: SuperAdminAuth,
     State(state): State<AppState>,
@@ -863,17 +891,20 @@ pub async fn update_didcomm_handler(
 }
 
 #[derive(Debug)]
+#[cfg(feature = "didcomm")]
 pub enum UpdateDidcommHttpError {
     Op(UpdateDidcommError),
     DidResolverUnavailable,
 }
 
+#[cfg(feature = "didcomm")]
 impl From<UpdateDidcommError> for UpdateDidcommHttpError {
     fn from(value: UpdateDidcommError) -> Self {
         Self::Op(value)
     }
 }
 
+#[cfg(feature = "didcomm")]
 impl IntoResponse for UpdateDidcommHttpError {
     fn into_response(self) -> Response {
         let (status, body) = match self {
@@ -1100,11 +1131,13 @@ impl IntoResponse for UpdateDidcommHttpError {
 // ────────────────────────────────────────────────────────────────────
 
 #[derive(Debug, Deserialize, utoipa::ToSchema)]
+#[cfg(feature = "didcomm")]
 pub struct DrainCancelRequest {
     pub mediator_did: String,
 }
 
 #[derive(Debug, Serialize, utoipa::ToSchema)]
+#[cfg(feature = "didcomm")]
 pub struct DrainCancelResponse {
     pub mediator_did: String,
 }
@@ -1120,6 +1153,7 @@ pub struct DrainCancelResponse {
         (status = 409, description = "Mediator not in drain state, or is the active mediator"),
     ),
 )]
+#[cfg(feature = "didcomm")]
 pub async fn drain_cancel_handler(
     auth: SuperAdminAuth,
     State(state): State<AppState>,
@@ -1144,16 +1178,19 @@ pub async fn drain_cancel_handler(
 }
 
 #[derive(Debug)]
+#[cfg(feature = "didcomm")]
 pub enum DrainCancelHttpError {
     Op(crate::operations::protocol::drain_cancel::DrainCancelError),
 }
 
+#[cfg(feature = "didcomm")]
 impl From<crate::operations::protocol::drain_cancel::DrainCancelError> for DrainCancelHttpError {
     fn from(value: crate::operations::protocol::drain_cancel::DrainCancelError) -> Self {
         Self::Op(value)
     }
 }
 
+#[cfg(feature = "didcomm")]
 impl IntoResponse for DrainCancelHttpError {
     fn into_response(self) -> Response {
         use crate::operations::protocol::drain_cancel::DrainCancelError;
@@ -1320,6 +1357,7 @@ impl IntoResponse for MediatorReportHttpError {
 /// intended behaviour when DIDComm isn't running. The live prover
 /// is only meaningful for `update_didcomm` and `services didcomm
 /// rollback`, where DIDComm is by definition already up.
+#[cfg(feature = "didcomm")]
 async fn build_live_prover(
     state: &AppState,
     bridge: &Arc<crate::didcomm_bridge::DIDCommBridge>,
@@ -1348,6 +1386,7 @@ async fn build_live_prover(
 /// built — that one is a `Connect`-stage failure rather than a fall
 /// through, because the only available fallback resolves DIDs locally
 /// and would defeat the point of running the handshake at all.
+#[cfg(feature = "didcomm")]
 async fn try_run_first_enable_handshake(
     state: &AppState,
     resolver: &affinidi_did_resolver_cache_sdk::DIDCacheClient,
@@ -2262,6 +2301,7 @@ pub async fn rollback_tsp_handler(
         (status = 409, description = "No prior mutation, or last remaining service"),
     ),
 )]
+#[cfg(feature = "didcomm")]
 pub async fn rollback_didcomm_handler(
     auth: SuperAdminAuth,
     State(state): State<AppState>,
@@ -2322,6 +2362,7 @@ pub async fn rollback_didcomm_handler(
 /// is optional — server applies the spec §3.6 default (24h) when
 /// omitted.
 #[derive(Debug, Deserialize, utoipa::ToSchema)]
+#[cfg(feature = "didcomm")]
 pub struct RollbackDidcommHttpRequest {
     #[serde(default)]
     pub drain_ttl_secs: Option<u64>,
@@ -2382,6 +2423,7 @@ fn tsp_kind_str(k: TspRollbackKind) -> &'static str {
     }
 }
 
+#[cfg(feature = "didcomm")]
 fn didcomm_kind_str(k: DidcommRollbackKind) -> &'static str {
     match k {
         DidcommRollbackKind::Disabled => "disabled",
@@ -2529,17 +2571,20 @@ impl IntoResponse for RollbackTspHttpError {
 }
 
 #[derive(Debug)]
+#[cfg(feature = "didcomm")]
 pub enum RollbackDidcommHttpError {
     Op(RollbackDidcommError),
     DidResolverUnavailable,
 }
 
+#[cfg(feature = "didcomm")]
 impl From<RollbackDidcommError> for RollbackDidcommHttpError {
     fn from(value: RollbackDidcommError) -> Self {
         Self::Op(value)
     }
 }
 
+#[cfg(feature = "didcomm")]
 impl IntoResponse for RollbackDidcommHttpError {
     fn into_response(self) -> Response {
         let (status, body) = match self {
@@ -2675,6 +2720,7 @@ impl IntoResponse for ListServicesHttpError {
 
 // ── List drain handler (T5/list_drain) ────────────────────────────
 
+#[cfg(feature = "didcomm")]
 use crate::operations::protocol::list_drain::{ListDrainError, list_drain};
 
 #[utoipa::path(
@@ -2686,6 +2732,7 @@ use crate::operations::protocol::list_drain::{ListDrainError, list_drain};
         (status = 403, description = "Caller is not a super-admin"),
     ),
 )]
+#[cfg(feature = "didcomm")]
 pub async fn list_drain_handler(
     auth: SuperAdminAuth,
     State(state): State<AppState>,
@@ -2695,16 +2742,19 @@ pub async fn list_drain_handler(
 }
 
 #[derive(Debug)]
+#[cfg(feature = "didcomm")]
 pub enum ListDrainHttpError {
     Op(ListDrainError),
 }
 
+#[cfg(feature = "didcomm")]
 impl From<ListDrainError> for ListDrainHttpError {
     fn from(value: ListDrainError) -> Self {
         Self::Op(value)
     }
 }
 
+#[cfg(feature = "didcomm")]
 impl IntoResponse for ListDrainHttpError {
     fn into_response(self) -> Response {
         let (status, body) = match self {

--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -16,7 +16,7 @@ use crate::auth::AuthState;
 use crate::auth::jwt::JwtKeys;
 use crate::auth::session::cleanup_expired_sessions;
 use crate::config::{AppConfig, AuthConfig};
-#[cfg(feature = "didcomm")]
+#[cfg(any(feature = "didcomm", feature = "tsp"))]
 use crate::didcomm_bridge::DIDCommBridge;
 use crate::error::AppError;
 use crate::keys::KeyRecord;
@@ -35,10 +35,11 @@ use tracing::{debug, error, info, warn};
 // D2 P2a: the reliable-messaging delivery layer replaces the
 // `affinidi-messaging-didcomm-service` framework. `MessagingService` (built in
 // `messaging::service`) drives inbound + outbound over a `DidCommTransport`.
-#[cfg(feature = "didcomm")]
+#[cfg(any(feature = "didcomm", feature = "tsp"))]
 use tokio_util::sync::CancellationToken;
-// Only the DIDComm listener wires the client ACL on connect.
-#[cfg(feature = "didcomm")]
+// The mediator ACL is keyed on the VTA DID, so it authorises whichever
+// protocol rides the socket — either transport wires it on connect.
+#[cfg(any(feature = "didcomm", feature = "tsp"))]
 use vta_sdk::acl_setup;
 
 /// TEE context passed by the caller (main.rs or vta-enclave).
@@ -146,7 +147,7 @@ pub struct AppState {
     /// In-process registry of active + draining mediator listeners.
     /// Owns the per-listener bounded outbound buffer and the
     /// active/drain state machine.
-    #[cfg(feature = "webvh")]
+    #[cfg(all(feature = "webvh", feature = "didcomm"))]
     pub mediator_registry: Arc<crate::messaging::registry::MediatorListenerRegistry>,
     /// Per-webvh-server async mutex registry for serializing
     /// daemon-REST auth-cache read-modify-writes. Two concurrent
@@ -159,7 +160,7 @@ pub struct AppState {
     /// task per drain entry; on expiry, calls
     /// `record_expiries_persisted` and signals upstream listener
     /// teardown via the teardown channel.
-    #[cfg(feature = "webvh")]
+    #[cfg(all(feature = "webvh", feature = "didcomm"))]
     pub drain_sweeper: Arc<crate::messaging::drain_sweeper::DrainSweeper>,
     /// Pluggable telemetry sink for mediator-attribution events.
     /// Default impl is the in-memory ring buffer; alternative
@@ -179,13 +180,15 @@ pub struct AppState {
     /// `{did}#key-0`). Populated by `init_auth`. Needed by the
     /// live mediator-handshake prover to fetch the corresponding
     /// secret out of [`Self::secrets_resolver`].
-    #[cfg(feature = "didcomm")]
+    #[cfg(any(feature = "didcomm", feature = "tsp"))]
     pub signing_vm_id: Option<String>,
     /// Verification-method id for the VTA's key-agreement key
     /// (e.g. `{did}#key-1`). Populated by `init_auth`.
-    #[cfg(feature = "didcomm")]
+    #[cfg(any(feature = "didcomm", feature = "tsp"))]
     pub ka_vm_id: Option<String>,
-    #[cfg(feature = "didcomm")]
+    /// Outbound seam over the mediator socket. Present for either transport —
+    /// the service it holds multiplexes DIDComm and TSP.
+    #[cfg(any(feature = "didcomm", feature = "tsp"))]
     pub didcomm_bridge: Arc<DIDCommBridge>,
 
     /// Learn-from-inbound TSP reachability: which device DIDs were last seen
@@ -239,13 +242,13 @@ pub struct AppStateParts {
     /// Telemetry sink shared with the mediator registry. `None` → fresh ring buffer.
     pub telemetry: Option<vti_common::telemetry::SharedTelemetrySink>,
     /// Live mediator listener registry. `None` → fresh registry over `telemetry`.
-    #[cfg(feature = "webvh")]
+    #[cfg(all(feature = "webvh", feature = "didcomm"))]
     pub mediator_registry: Option<Arc<crate::messaging::registry::MediatorListenerRegistry>>,
     /// Drain sweeper wired to a real teardown channel. `None` → dead-channel no-op sweeper.
-    #[cfg(feature = "webvh")]
+    #[cfg(all(feature = "webvh", feature = "didcomm"))]
     pub drain_sweeper: Option<Arc<crate::messaging::drain_sweeper::DrainSweeper>>,
-    /// Outbound DIDComm bridge. `None` → placeholder (no live service).
-    #[cfg(feature = "didcomm")]
+    /// Outbound mediator bridge. `None` → placeholder (no live service).
+    #[cfg(any(feature = "didcomm", feature = "tsp"))]
     pub didcomm_bridge: Option<Arc<DIDCommBridge>>,
     /// Prometheus handle for `/metrics`. `None` → no metrics rendering.
     #[cfg(feature = "rest")]
@@ -333,7 +336,7 @@ pub async fn build_app_state(
     let telemetry: vti_common::telemetry::SharedTelemetrySink = parts
         .telemetry
         .unwrap_or_else(|| Arc::new(vti_common::telemetry::RingBufferTelemetry::new()));
-    #[cfg(feature = "webvh")]
+    #[cfg(all(feature = "webvh", feature = "didcomm"))]
     let mediator_registry = parts.mediator_registry.unwrap_or_else(|| {
         Arc::new(crate::messaging::registry::MediatorListenerRegistry::new(
             Arc::clone(&telemetry),
@@ -343,7 +346,7 @@ pub async fn build_app_state(
     // consumed by a real task that calls `DIDCommService::remove_listener`.
     // Non-axum front-ends (e.g. Lambda) that don't run a teardown consumer get
     // a sweeper whose channel sender goes nowhere, so signals become no-ops.
-    #[cfg(feature = "webvh")]
+    #[cfg(all(feature = "webvh", feature = "didcomm"))]
     let drain_sweeper = parts.drain_sweeper.unwrap_or_else(|| {
         let (tx, _rx) = crate::messaging::drain_sweeper::teardown_channel(
             crate::messaging::drain_sweeper::DEFAULT_TEARDOWN_CHANNEL_CAPACITY,
@@ -383,9 +386,9 @@ pub async fn build_app_state(
         drains_ks,
         #[cfg(feature = "webvh")]
         snapshot_ks,
-        #[cfg(feature = "webvh")]
+        #[cfg(all(feature = "webvh", feature = "didcomm"))]
         mediator_registry,
-        #[cfg(feature = "webvh")]
+        #[cfg(all(feature = "webvh", feature = "didcomm"))]
         drain_sweeper,
         #[cfg(feature = "webvh")]
         webvh_auth_locks: crate::operations::did_webvh::WebvhAuthLocks::new(),
@@ -396,11 +399,11 @@ pub async fn build_app_state(
         did_resolver: auth.did_resolver.clone(),
         status_list_resolver: crate::vault::status::default_status_resolver(auth.did_resolver),
         secrets_resolver: auth.secrets_resolver,
-        #[cfg(feature = "didcomm")]
+        #[cfg(any(feature = "didcomm", feature = "tsp"))]
         signing_vm_id: auth.signing_vm_id,
-        #[cfg(feature = "didcomm")]
+        #[cfg(any(feature = "didcomm", feature = "tsp"))]
         ka_vm_id: auth.ka_vm_id,
-        #[cfg(feature = "didcomm")]
+        #[cfg(any(feature = "didcomm", feature = "tsp"))]
         didcomm_bridge: parts
             .didcomm_bridge
             .unwrap_or_else(|| Arc::new(DIDCommBridge::placeholder())),
@@ -675,7 +678,9 @@ pub async fn run(
         let vault_ks = apply_encryption(store.keyspace(crate::keyspaces::VAULT)?);
         let backup_bundles_ks = apply_encryption(store.keyspace(crate::keyspaces::BACKUP_BUNDLES)?);
         let backup_blob_dir = config.store.data_dir.join("backups");
-        #[cfg(feature = "webvh")]
+        // Read by the DIDComm drain machinery only; a TSP-only build has no
+        // drain window, so it never opens the keyspace.
+        #[cfg(all(feature = "webvh", feature = "didcomm"))]
         let drains_ks = apply_encryption(store.keyspace(crate::keyspaces::DRAINS)?);
 
         // Pluggable telemetry sink + multi-mediator listener registry.
@@ -684,7 +689,7 @@ pub async fn run(
         // `docs/05-design-notes/didcomm-protocol-management.md`.
         let telemetry: vti_common::telemetry::SharedTelemetrySink =
             Arc::new(vti_common::telemetry::RingBufferTelemetry::new());
-        #[cfg(feature = "webvh")]
+        #[cfg(all(feature = "webvh", feature = "didcomm"))]
         let mediator_registry = Arc::new(
             crate::messaging::registry::MediatorListenerRegistry::new(Arc::clone(&telemetry)),
         );
@@ -693,11 +698,11 @@ pub async fn run(
         // teardown channel; the consumer task spawned below
         // translates each signal into a
         // `DIDCommService::remove_listener` call.
-        #[cfg(feature = "webvh")]
+        #[cfg(all(feature = "webvh", feature = "didcomm"))]
         let (teardown_tx, teardown_rx) = crate::messaging::drain_sweeper::teardown_channel(
             crate::messaging::drain_sweeper::DEFAULT_TEARDOWN_CHANNEL_CAPACITY,
         );
-        #[cfg(feature = "webvh")]
+        #[cfg(all(feature = "webvh", feature = "didcomm"))]
         let drain_sweeper = Arc::new(crate::messaging::drain_sweeper::DrainSweeper::new(
             Arc::clone(&mediator_registry),
             drains_ks.clone(),
@@ -706,7 +711,7 @@ pub async fn run(
         // Boot replay: load any drains persisted from a previous
         // run, drop already-expired entries, register the live
         // ones with the registry, and arm the sweeper for each.
-        #[cfg(feature = "webvh")]
+        #[cfg(all(feature = "webvh", feature = "didcomm"))]
         match mediator_registry.replay_drains(&drains_ks).await {
             Ok(live) => {
                 if !live.is_empty() {
@@ -723,7 +728,7 @@ pub async fn run(
         let (shutdown_tx, shutdown_rx) = watch::channel(false);
         let (restart_tx, mut restart_rx) = watch::channel(false);
 
-        #[cfg(feature = "didcomm")]
+        #[cfg(any(feature = "didcomm", feature = "tsp"))]
         let didcomm_shutdown = CancellationToken::new();
 
         // Spawn signal handler. First signal triggers cooperative shutdown;
@@ -732,13 +737,13 @@ pub async fn run(
         // complete before its timeout fires).
         tokio::spawn({
             let shutdown_tx = shutdown_tx.clone();
-            #[cfg(feature = "didcomm")]
+            #[cfg(any(feature = "didcomm", feature = "tsp"))]
             let didcomm_shutdown = didcomm_shutdown.clone();
             async move {
                 shutdown_signal().await;
                 info!("shutting down — press Ctrl-C again to force exit");
                 let _ = shutdown_tx.send(true);
-                #[cfg(feature = "didcomm")]
+                #[cfg(any(feature = "didcomm", feature = "tsp"))]
                 didcomm_shutdown.cancel();
 
                 shutdown_signal().await;
@@ -762,7 +767,7 @@ pub async fn run(
 
         // Shared DIDComm bridge for outbound request-response messaging.
         // The service reference is set after DIDCommService::start().
-        #[cfg(feature = "didcomm")]
+        #[cfg(any(feature = "didcomm", feature = "tsp"))]
         let didcomm_bridge: Arc<DIDCommBridge> = Arc::new(DIDCommBridge::new("vta-main"));
 
         // Build the shared `AppState` once, via the single constructor
@@ -775,11 +780,11 @@ pub async fn run(
         let app_state = {
             let parts = AppStateParts {
                 telemetry: Some(Arc::clone(&telemetry)),
-                #[cfg(feature = "webvh")]
+                #[cfg(all(feature = "webvh", feature = "didcomm"))]
                 mediator_registry: Some(Arc::clone(&mediator_registry)),
-                #[cfg(feature = "webvh")]
+                #[cfg(all(feature = "webvh", feature = "didcomm"))]
                 drain_sweeper: Some(Arc::clone(&drain_sweeper)),
-                #[cfg(feature = "didcomm")]
+                #[cfg(any(feature = "didcomm", feature = "tsp"))]
                 didcomm_bridge: Some(didcomm_bridge.clone()),
                 #[cfg(feature = "rest")]
                 metrics_handle: metrics_handle.clone(), // installed once, before the loop
@@ -937,10 +942,15 @@ pub async fn run(
         // back into an `Err` after the threads are joined, so the exit status
         // still says "failed" for a systemd `Restart=on-failure` or anything else
         // that reads it.
-        #[cfg(feature = "didcomm")]
+        #[cfg(any(feature = "didcomm", feature = "tsp"))]
         let readiness_fatal = Arc::new(std::sync::atomic::AtomicBool::new(false));
-        #[cfg(feature = "didcomm")]
-        if config.services.didcomm {
+        // Either advertised transport needs the mediator socket: TSP receive
+        // arrives on it (ADR 0005 — one websocket per DID) and TSP send is an
+        // HTTP post through the same ATM. Gating this on DIDComm alone is what
+        // made a TSP-only VTA impossible — it would have advertised `#tsp` and
+        // never connected to anything.
+        #[cfg(any(feature = "didcomm", feature = "tsp"))]
+        if config.services.didcomm || config.services.tsp {
             match (
                 &app_state.secrets_resolver,
                 &config.vta_did,
@@ -1101,15 +1111,15 @@ pub async fn run(
             }
         }
 
-        // Stop DIDComm messaging: cancel the inbound loop's shutdown token
+        // Stop mediator messaging: cancel the inbound loop's shutdown token
         // (also stops the `MessagingConnect` reconnect supervisor between
         // attempts). The delivery-layer background tasks (dispatcher, transport
         // forwarder, outbox drain loops) are detached — as in the VTC pilot —
         // and wind down as their `Arc<MessagingService>`/transport handles drop.
-        #[cfg(feature = "didcomm")]
+        #[cfg(any(feature = "didcomm", feature = "tsp"))]
         {
             didcomm_shutdown.cancel();
-            info!("DIDComm messaging stopped");
+            info!("mediator messaging stopped");
         }
 
         if any_panic {
@@ -1131,7 +1141,7 @@ pub async fn run(
 
         // Surface a `fail`-policy readiness timeout as a non-zero exit, now that
         // the threads are joined and the store is flushed.
-        #[cfg(feature = "didcomm")]
+        #[cfg(any(feature = "didcomm", feature = "tsp"))]
         if readiness_fatal.load(std::sync::atomic::Ordering::Relaxed) {
             return Err(AppError::Internal(
                 "mediator self-readiness gate timed out with on_timeout = \"fail\"".into(),
@@ -1880,7 +1890,7 @@ fn decode_jwt_key(b64: &str) -> Result<JwtKeys, AppError> {
 ///
 /// All of it runs in a spawned task: nothing here may block `server::run`, which
 /// has to reach its shutdown/restart select for a signal to be honoured.
-#[cfg(feature = "didcomm")]
+#[cfg(any(feature = "didcomm", feature = "tsp"))]
 struct MessagingConnect {
     app_state: AppState,
     vta_did: String,
@@ -1900,7 +1910,7 @@ struct MessagingConnect {
     fatal_flag: Arc<std::sync::atomic::AtomicBool>,
 }
 
-#[cfg(feature = "didcomm")]
+#[cfg(any(feature = "didcomm", feature = "tsp"))]
 impl MessagingConnect {
     /// Gate, then run the connect/supervise/reconnect loop until shutdown, the
     /// configured horizon, or a `reconnect = false` single-shot failure.
@@ -2140,7 +2150,7 @@ impl MessagingConnect {
         // Register the config-loaded mediator in the listener registry so the
         // delegated step-up push (buffered through the registry) can reach
         // approvers on this mediator.
-        #[cfg(feature = "webvh")]
+        #[cfg(all(feature = "webvh", feature = "didcomm"))]
         app_state
             .mediator_registry
             .record_activate(crate::messaging::registry::MediatorBinding {
@@ -2182,7 +2192,7 @@ impl MessagingConnect {
 /// before the live listener starts. Each cleared message is logged; a batch that
 /// can't be fetched is logged loudly and stops the drain (so it can't spin).
 /// Returns how many were cleared. Never panics — a failure just skips the drain.
-#[cfg(feature = "didcomm")]
+#[cfg(any(feature = "didcomm", feature = "tsp"))]
 async fn drain_mediator_inbox(atm: &ATM, mediator_did: &str, vta_did: &str) -> usize {
     // A mediator-connected profile for REST pickup — added without live delivery
     // (`false`), so this never opens the websocket that's the thing wedging.
@@ -2254,7 +2264,7 @@ async fn drain_mediator_inbox(atm: &ATM, mediator_did: &str, vta_did: &str) -> u
 /// delete them because the mediator's owner check admits the message's `FROM`
 /// (sender), not only its `TO` (recipient). Best-effort; returns how many were
 /// cleared and never panics.
-#[cfg(feature = "didcomm")]
+#[cfg(any(feature = "didcomm", feature = "tsp"))]
 async fn flush_mediator_outbox(atm: &ATM, mediator_did: &str, vta_did: &str) -> usize {
     use affinidi_tdk::messaging::messages::{DeleteMessageRequest, Folder};
 

--- a/vta-service/src/services_cli.rs
+++ b/vta-service/src/services_cli.rs
@@ -45,26 +45,35 @@ use crate::cli_store::CliStore;
 use crate::config::AppConfig;
 use crate::didcomm_bridge::DIDCommBridge;
 use crate::keys::seed_store::{SeedStore, create_seed_store};
+#[cfg(feature = "didcomm")]
 use crate::messaging::drain_sweeper::{DrainSweeper, teardown_channel};
+#[cfg(feature = "didcomm")]
 use crate::messaging::handshake::AlwaysOkProver;
+#[cfg(feature = "didcomm")]
 use crate::messaging::registry::MediatorListenerRegistry;
 use crate::operations::protocol::OpContext;
 use crate::operations::protocol::ServiceOpDeps;
+#[cfg(feature = "didcomm")]
 use crate::operations::protocol::disable_didcomm::{
     DisableDidcommParams, DisableTransport, disable_didcomm,
 };
 use crate::operations::protocol::disable_rest::{DisableRestParams, disable_rest};
 use crate::operations::protocol::disable_tsp::{DisableTspParams, disable_tsp};
+#[cfg(feature = "didcomm")]
 use crate::operations::protocol::drain_cancel::{DrainCancelParams, drain_cancel};
+#[cfg(feature = "didcomm")]
 use crate::operations::protocol::enable_didcomm::{EnableDidcommParams, enable_didcomm};
 use crate::operations::protocol::enable_rest::{EnableRestParams, enable_rest};
 use crate::operations::protocol::enable_tsp::{EnableTspParams, enable_tsp};
 use crate::operations::protocol::list::list_services;
+#[cfg(feature = "didcomm")]
 use crate::operations::protocol::list_drain::list_drain;
+#[cfg(feature = "didcomm")]
 use crate::operations::protocol::rollback_didcomm::{RollbackDidcommParams, rollback_didcomm};
 use crate::operations::protocol::rollback_rest::{RollbackRestParams, rollback_rest};
 use crate::operations::protocol::rollback_tsp::{RollbackTspParams, rollback_tsp};
 use crate::operations::protocol::snapshot;
+#[cfg(feature = "didcomm")]
 use crate::operations::protocol::update_didcomm::{
     MigrateAuditKind, UpdateDidcommParams, update_didcomm,
 };
@@ -92,7 +101,9 @@ struct OfflineDeps {
     did_resolver: DIDCacheClient,
     didcomm_bridge: Arc<DIDCommBridge>,
     telemetry: SharedTelemetrySink,
+    #[cfg(feature = "didcomm")]
     registry: Arc<MediatorListenerRegistry>,
+    #[cfg(feature = "didcomm")]
     sweeper: Arc<DrainSweeper>,
     auth: AuthClaims,
     /// Fresh per-invocation auth-locks. The offline CLI is a
@@ -123,7 +134,9 @@ impl OfflineDeps {
             didcomm_bridge: &self.didcomm_bridge,
             telemetry: &self.telemetry,
             webvh_auth_locks: &self.webvh_auth_locks,
+            #[cfg(feature = "didcomm")]
             registry: &self.registry,
+            #[cfg(feature = "didcomm")]
             sweeper: &self.sweeper,
         }
     }
@@ -181,8 +194,11 @@ async fn build_offline_deps(
     let did_resolver = DIDCacheClient::new(DIDCacheConfigBuilder::default().build()).await?;
     let didcomm_bridge = Arc::new(DIDCommBridge::placeholder());
     let telemetry: SharedTelemetrySink = Arc::new(RingBufferTelemetry::new());
+    #[cfg(feature = "didcomm")]
     let registry = Arc::new(MediatorListenerRegistry::new(Arc::clone(&telemetry)));
+    #[cfg(feature = "didcomm")]
     let (tx, _rx) = teardown_channel(8);
+    #[cfg(feature = "didcomm")]
     let sweeper = Arc::new(DrainSweeper::new(
         Arc::clone(&registry),
         drains_ks.clone(),
@@ -210,7 +226,9 @@ async fn build_offline_deps(
         did_resolver,
         didcomm_bridge,
         telemetry,
+        #[cfg(feature = "didcomm")]
         registry,
+        #[cfg(feature = "didcomm")]
         sweeper,
         auth,
         webvh_auth_locks: crate::operations::did_webvh::WebvhAuthLocks::new(),
@@ -472,6 +490,7 @@ pub async fn run_services_tsp_rollback(config_path: Option<PathBuf>) -> CliResul
 
 // ── services didcomm {enable, update, disable, rollback} ──────────
 
+#[cfg(feature = "didcomm")]
 pub async fn run_services_didcomm_enable(
     config_path: Option<PathBuf>,
     mediator_did: String,
@@ -506,6 +525,7 @@ pub async fn run_services_didcomm_enable(
     Ok(())
 }
 
+#[cfg(feature = "didcomm")]
 pub async fn run_services_didcomm_update(
     config_path: Option<PathBuf>,
     new_mediator_did: String,
@@ -542,6 +562,7 @@ pub async fn run_services_didcomm_update(
     Ok(())
 }
 
+#[cfg(feature = "didcomm")]
 pub async fn run_services_didcomm_disable(
     config_path: Option<PathBuf>,
     drain_ttl_secs: u64,
@@ -575,6 +596,7 @@ pub async fn run_services_didcomm_disable(
     Ok(())
 }
 
+#[cfg(feature = "didcomm")]
 pub async fn run_services_didcomm_rollback(
     config_path: Option<PathBuf>,
     drain_ttl_secs: Option<u64>,
@@ -619,6 +641,7 @@ pub async fn run_services_didcomm_rollback(
 
 // ── services didcomm drain {list, cancel} ─────────────────────────
 
+#[cfg(feature = "didcomm")]
 pub async fn run_services_didcomm_drain_list(config_path: Option<PathBuf>) -> CliResult {
     let d = build_offline_deps(config_path).await?;
     let response = list_drain(&d.config, &d.drains_ks, &d.auth)
@@ -639,6 +662,7 @@ pub async fn run_services_didcomm_drain_list(config_path: Option<PathBuf>) -> Cl
     Ok(())
 }
 
+#[cfg(feature = "didcomm")]
 pub async fn run_services_didcomm_drain_cancel(
     config_path: Option<PathBuf>,
     mediator_did: String,

--- a/vta-service/src/setup/from_toml.rs
+++ b/vta-service/src/setup/from_toml.rs
@@ -998,7 +998,13 @@ pub async fn apply_inputs(
                 *portable,
                 *pre_rotation_count,
                 services,
-                /* add_mediator_service */ messaging.is_some(),
+                // `#vta-didcomm` is published only when this VTA actually
+                // speaks DIDComm. A mediator alone is no longer sufficient
+                // grounds: a TSP-only VTA configures one too (for `#tsp`),
+                // and advertising DIDComm off the back of it would publish a
+                // transport with no dispatcher behind it.
+                /* add_mediator_service */
+                messaging.is_some() && inputs.services.didcomm,
                 /* template */ None,
                 HashMap::new(),
                 /* is_vta_identity */ true,
@@ -1135,12 +1141,24 @@ pub async fn apply_inputs(
 fn validate_inputs(inputs: &WizardInputs) -> Result<(), Box<dyn std::error::Error>> {
     let mut errors: Vec<String> = Vec::new();
 
-    if matches!(inputs.messaging, MessagingInput::CreateMediator { .. }) && !inputs.services.didcomm
-    {
-        errors.push("messaging.kind = \"create_mediator\" requires services.didcomm = true".into());
+    // A mediator is configured *for* a transport, and either transport rides
+    // it — so what `[messaging]` requires is that one of them is enabled, not
+    // DIDComm specifically. Configuring a mediator no VTA transport uses is
+    // still refused: it would mint (or bind) one and advertise nothing.
+    let mediator_transport = inputs.services.didcomm || inputs.services.tsp;
+    if matches!(inputs.messaging, MessagingInput::CreateMediator { .. }) && !mediator_transport {
+        errors.push(
+            "messaging.kind = \"create_mediator\" requires services.didcomm = true or \
+             services.tsp = true — a mediator no transport rides is minted and never used"
+                .into(),
+        );
     }
-    if matches!(inputs.messaging, MessagingInput::Existing { .. }) && !inputs.services.didcomm {
-        errors.push("messaging.kind = \"existing\" requires services.didcomm = true".into());
+    if matches!(inputs.messaging, MessagingInput::Existing { .. }) && !mediator_transport {
+        errors.push(
+            "messaging.kind = \"existing\" requires services.didcomm = true or \
+             services.tsp = true"
+                .into(),
+        );
     }
     // REST requires a public URL — without it the VTA DID document
     // ends up with no `VTARest` service entry, leaving downstream
@@ -1155,21 +1173,12 @@ fn validate_inputs(inputs: &WizardInputs) -> Result<(), Box<dyn std::error::Erro
                 .into(),
         );
     }
-    // TSP advertises the **same** mediator as DIDComm (one dual-protocol
-    // mediator — tsp-enablement.md D8), so `services.tsp = true` without
-    // DIDComm would point the `#tsp` service at a mediator the VTA never
-    // configured. Require DIDComm when TSP is on. (TSP is usually enabled
-    // post-setup via `services tsp enable` once it's been verified; this rule
-    // guards the declarative `--from <toml>` path.)
-    if inputs.services.tsp && !inputs.services.didcomm {
-        errors.push(
-            "services.tsp = true requires services.didcomm = true — TSP advertises \
-             the same mediator as DIDComm. Set services.didcomm = true (and \
-             configure messaging), or leave TSP off here and enable it later with \
-             `services tsp enable`"
-                .into(),
-        );
-    }
+    // TSP no longer requires DIDComm. `[messaging]` is transport-neutral —
+    // both protocols arrive on the same mediator socket — and the DIDComm
+    // dispatcher is simply absent from a `--features tsp` build. What TSP
+    // requires is a *mediator*, since `#tsp` names one; without `[messaging]`
+    // the transport is enabled in config and no service entry is published,
+    // exactly as DIDComm has always degraded.
     // A binary built without the `tsp` feature has no TSP dispatcher (the
     // inbound half lives behind that flag), so `services.tsp = true` would
     // advertise `#tsp` — the *first* entry a peer matching on transport
@@ -3033,10 +3042,15 @@ mod tests {
         }
     }
 
+    // Only where TSP can be served: a build without the feature refuses
+    // `tsp = true` for that reason instead, asserted by its own test below.
+    #[cfg(feature = "tsp")]
     #[test]
-    fn services_tsp_without_didcomm_is_rejected() {
-        // TSP shares the DIDComm mediator, so it can't be advertised without
-        // DIDComm — the `--from <toml>` path must reject the combination.
+    fn services_tsp_without_didcomm_is_accepted() {
+        // The combination this change exists to permit: a VTA that speaks TSP
+        // and nothing else. It was refused on the theory that `#tsp` could only
+        // name the DIDComm mediator — `[messaging]` is transport-neutral now,
+        // and the DIDComm dispatcher is simply absent from such a build.
         let raw = r#"
             config_path = "/tmp/vta-test/config.toml"
             data_dir    = "/tmp/vta-test/data"
@@ -3048,14 +3062,14 @@ mod tests {
 
             [secrets]
             backend = "keyring"
+
+            [messaging]
+            kind = "existing"
+            did  = "did:webvh:mediator.example.com:mediator"
         "#;
         let inputs = parse(raw).expect("parses");
-        let err = validate_inputs(&inputs).expect_err("tsp without didcomm must be rejected");
-        assert!(
-            err.to_string()
-                .contains("services.tsp = true requires services.didcomm = true"),
-            "got: {err}"
-        );
+        validate_inputs(&inputs).expect("a TSP-only VTA is a valid setup");
+        assert!(inputs.services.tsp && !inputs.services.didcomm);
     }
 
     /// A `[services] tsp = true` + DIDComm setup file, whose fate depends

--- a/vta-service/src/setup/interactive.rs
+++ b/vta-service/src/setup/interactive.rs
@@ -280,19 +280,14 @@ fn validate_services(sel: &ServiceSelection) -> Result<(), String> {
     if !sel.rest && !sel.didcomm && !sel.tsp {
         return Err("Please select at least one service.".into());
     }
-    // TSP advertises the **same** mediator as DIDComm (one dual-protocol
-    // mediator — tsp-enablement.md D8), and that mediator is configured in
-    // the DIDComm section further down. TSP without DIDComm would point
-    // `#tsp` at a mediator this VTA never configured. `validate_inputs`
-    // enforces the same rule for `--from <toml>`; both paths need it
-    // because neither reaches the other's checkpoint.
-    if sel.tsp && !sel.didcomm {
-        return Err(
-            "TSP shares the DIDComm mediator — select DIDComm Messaging as well, \
-                    or leave TSP off and enable it later with `pnm services tsp enable`."
-                .into(),
-        );
-    }
+    // TSP no longer implies DIDComm. Both transports ride the same mediator
+    // socket, and the mediator section below is now reached by either — so a
+    // TSP-only VTA is a VTA that connects to a mediator and speaks TSP on it,
+    // with no DIDComm dispatcher compiled or advertised. Whether that mediator
+    // *carries* TSP is the operator's call (nothing here can verify it), and
+    // skipping the mediator entirely degrades the same way it always has for
+    // DIDComm: the transport is enabled in config and no service entry is
+    // published, because there is no endpoint to name.
     Ok(())
 }
 
@@ -1141,8 +1136,25 @@ async fn gather_inputs(
     // 11. Hardened configuration.
     let hardened = prompt_hardened(p)?;
 
-    // 12. Messaging (DIDComm only).
-    let messaging = if enable_didcomm {
+    // 12. Messaging — the mediator, for whichever transports ride it.
+    //
+    // Reached by TSP as well as DIDComm: both arrive on the same mediator
+    // socket, and `#tsp`'s serviceEndpoint is that mediator's DID. Asking only
+    // in the DIDComm branch is what made TSP-without-DIDComm inexpressible —
+    // there was nowhere to put the mediator a TSP-only VTA needs.
+    let messaging = if enable_didcomm || enable_tsp {
+        if enable_tsp && !enable_didcomm {
+            eprintln!();
+            eprintln!(
+                "  \x1b[2mTSP rides a mediator, the same way DIDComm does — `#tsp` in your DID \
+                 document names the mediator's DID, and the transport URL lives in the \
+                 mediator's own document.\x1b[0m"
+            );
+            eprintln!(
+                "  \x1b[2mThe questions below configure that mediator. It must route TSP; \
+                 nothing here can verify that it does.\x1b[0m"
+            );
+        }
         configure_messaging(p).await?
     } else {
         MessagingInput::Skip
@@ -1699,10 +1711,12 @@ mod tests {
         );
     }
 
-    /// At least one transport, and TSP implies DIDComm (it advertises the
-    /// DIDComm mediator). Mirrors `validate_inputs`' rule for `--from`.
+    /// At least one transport — and that is now the *only* rule. TSP used to
+    /// imply DIDComm because the mediator was collected in the DIDComm branch
+    /// and the TSP dispatcher was compiled behind the DIDComm one; neither is
+    /// true any more.
     #[test]
-    fn validate_services_requires_one_and_tsp_implies_didcomm() {
+    fn validate_services_requires_at_least_one_and_tsp_may_stand_alone() {
         let none = ServiceSelection::default();
         assert!(
             validate_services(&none)
@@ -1710,28 +1724,18 @@ mod tests {
                 .contains("at least one service")
         );
 
-        let tsp_only = ServiceSelection {
-            rest: false,
-            didcomm: false,
-            tsp: true,
-        };
-        assert!(
-            validate_services(&tsp_only)
-                .unwrap_err()
-                .contains("shares the DIDComm mediator"),
-            "TSP alone points `#tsp` at a mediator the VTA never configured"
-        );
-
-        // REST + TSP is the same defect with a transport in hand — still
-        // refused, because the `#tsp` endpoint would still be unset.
-        let rest_and_tsp = ServiceSelection {
-            rest: true,
-            didcomm: false,
-            tsp: true,
-        };
-        assert!(validate_services(&rest_and_tsp).is_err());
-
         for ok in [
+            // TSP alone — the selection this whole change exists to permit.
+            ServiceSelection {
+                rest: false,
+                didcomm: false,
+                tsp: true,
+            },
+            ServiceSelection {
+                rest: true,
+                didcomm: false,
+                tsp: true,
+            },
             ServiceSelection {
                 rest: true,
                 didcomm: false,
@@ -1788,17 +1792,29 @@ mod tests {
     /// Selecting TSP without DIDComm re-asks instead of proceeding.
     #[cfg(feature = "tsp")]
     #[test]
-    fn tsp_without_didcomm_reasks() {
-        let p = ScriptedPrompter::new(vec![
-            Answer::Labels(vec![TSP_ITEM]), // refused → re-prompt
-            Answer::Labels(vec![DIDCOMM_ITEM, TSP_ITEM]),
-        ]);
-        let sel = prompt_services(&p).expect("second answer is valid");
+    fn tsp_alone_is_accepted_and_an_empty_selection_reasks() {
+        // TSP on its own: accepted at the prompt, no re-ask. This is the
+        // selection the wizard used to refuse.
+        let p = ScriptedPrompter::new(vec![Answer::Labels(vec![TSP_ITEM])]);
         assert_eq!(
-            sel,
+            prompt_services(&p).expect("TSP alone is a valid selection"),
             ServiceSelection {
                 rest: false,
-                didcomm: true,
+                didcomm: false,
+                tsp: true
+            }
+        );
+
+        // Selecting nothing is still the one thing that re-asks.
+        let p = ScriptedPrompter::new(vec![
+            Answer::Labels(vec![]), // refused → re-prompt
+            Answer::Labels(vec![TSP_ITEM]),
+        ]);
+        assert_eq!(
+            prompt_services(&p).expect("second answer is valid"),
+            ServiceSelection {
+                rest: false,
+                didcomm: false,
                 tsp: true
             }
         );

--- a/vta-service/src/trust_tasks/ceremony.rs
+++ b/vta-service/src/trust_tasks/ceremony.rs
@@ -36,7 +36,7 @@
 //! auth_for_trust_task_envelope` lets a ceremony task through on a
 //! zero-authority claim when — and only when — the ACL turns its sender away.
 
-#[cfg(feature = "didcomm")]
+#[cfg(any(feature = "didcomm", feature = "tsp"))]
 use crate::auth::AuthClaims;
 
 /// Does this Type URI name a ceremony task?
@@ -82,7 +82,7 @@ pub(crate) fn is_ceremony_task(type_uri: &str) -> bool {
 /// `handle_approve_response` writes no audit row on `challenge_unknown`,
 /// `subject_mismatch` or `approver_unauthorized`, so an unknown sender leaves no
 /// durable trace to flood.
-#[cfg(feature = "didcomm")]
+#[cfg(any(feature = "didcomm", feature = "tsp"))]
 pub(crate) async fn may_attempt_ceremony(
     state: &crate::server::AppState,
     type_uri: &str,
@@ -116,7 +116,7 @@ pub(crate) async fn may_attempt_ceremony(
 /// Only the intrinsic-sender transports need this — REST authenticates on a JWT
 /// the caller had to obtain first, so there is no pre-auth routing decision to
 /// make there.
-#[cfg(feature = "didcomm")]
+#[cfg(any(feature = "didcomm", feature = "tsp"))]
 pub(crate) fn peek_type_uri(body: &[u8]) -> Option<String> {
     #[derive(serde::Deserialize)]
     struct TypeOnly {
@@ -143,7 +143,7 @@ pub(crate) fn peek_type_uri(body: &[u8]) -> Option<String> {
 /// mediator write a row. `session_id` mirrors the DID-keyed convention
 /// [`vti_common::auth::session::resolve_did_session`] uses so the value lines up
 /// with what an enrolled peer would see, without persisting anything.
-#[cfg(feature = "didcomm")]
+#[cfg(any(feature = "didcomm", feature = "tsp"))]
 pub(crate) fn ceremony_claims(sender_did: &str) -> AuthClaims {
     AuthClaims {
         did: sender_did.to_string(),
@@ -164,7 +164,7 @@ pub(crate) fn ceremony_claims(sender_did: &str) -> AuthClaims {
 #[cfg(test)]
 mod tests {
     use super::*;
-    #[cfg(feature = "didcomm")]
+    #[cfg(any(feature = "didcomm", feature = "tsp"))]
     use crate::acl::Role;
 
     #[test]
@@ -186,7 +186,7 @@ mod tests {
         assert!(!is_ceremony_task(""));
     }
 
-    #[cfg(feature = "didcomm")]
+    #[cfg(any(feature = "didcomm", feature = "tsp"))]
     #[test]
     fn peek_reads_the_type_and_ignores_the_rest() {
         let body = br#"{"id":"urn:uuid:1","type":"https://example.com/a/0.1",
@@ -200,7 +200,7 @@ mod tests {
     /// A body we cannot read must fall through to the ordinary ACL path, not
     /// past it. This is the only reason the function returns `Option` rather
     /// than defaulting to something.
-    #[cfg(feature = "didcomm")]
+    #[cfg(any(feature = "didcomm", feature = "tsp"))]
     #[test]
     fn an_unreadable_body_is_not_a_ceremony_task() {
         assert!(peek_type_uri(b"not json").is_none());
@@ -211,7 +211,7 @@ mod tests {
 
     /// The claim must confer nothing. If this ever loosens, an unenrolled DID
     /// that can reach the mediator gains standing at the VTA.
-    #[cfg(feature = "didcomm")]
+    #[cfg(any(feature = "didcomm", feature = "tsp"))]
     #[test]
     fn ceremony_claims_are_authorized_nowhere() {
         let auth = ceremony_claims("did:key:zApprover");

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -736,7 +736,9 @@ fn vault_audit_outcome_label(outcome: &TrustTaskOutcome) -> String {
 /// conformant Trust-Task client can't read. (On REST the JWT extractor
 /// rejects unauthenticated callers before dispatch, so this gap is
 /// DIDComm-only — hence the feature gate.)
-#[cfg(feature = "didcomm")]
+// Either inbound transport rejects malformed work the same way — TSP frames
+// arrive on the same mediator socket and go through the same spine.
+#[cfg(any(feature = "didcomm", feature = "tsp"))]
 pub(crate) fn reject_trust_task(body: &[u8], reason: RejectReason) -> TrustTaskOutcome {
     match serde_json::from_slice::<TrustTask<Value>>(body) {
         Ok(doc) => reject_with(&doc, reason),


### PR DESCRIPTION
Phases 1–3 of `transport-neutral-mediator.md` §10 D — the ones that make a
TSP-only VTA possible. Ready to test against Berlin.

`vta setup` refused TSP unless DIDComm was selected too, and said so as though it
were a fact about TSP: *"TSP shares the DIDComm mediator"*. It isn't. Three
things in this crate assumed otherwise; all three are gone.

## 1. The mediator question was asked only in the DIDComm branch

`[messaging]` is transport-neutral — its `mediator_did` is exactly what `#tsp`
names — so the wizard now reaches it when **either** transport is selected, and
says what it is configuring when TSP is the only one. `validate_services` drops
the implication and the `--from <toml>` rule goes with it; `[messaging]` in turn
now requires *a* transport rather than DIDComm specifically.

A TSP-only VTA that skips `[messaging]` degrades exactly as a DIDComm one always
has: transport enabled in config, no service entry published, because there is
no endpoint to name.

## 2. The connect supervisor was mounted on `services.didcomm`

Now `services.didcomm || services.tsp`. TSP receive arrives on that same mediator
socket (ADR 0005 — one websocket per DID) and TSP send is an HTTP post through
the same ATM, so gating the socket on DIDComm meant a TSP-only VTA would
advertise `#tsp` and never connect to anything.

Moving with it: the queue-recovery helpers, the mediator ACL (keyed on the VTA
DID, so it authorises whichever protocol rides the socket), the VM ids used to
collect the profile's secrets, and the outbound bridge.

A TSP-only VTA must also not advertise `#vta-didcomm`, so the mint flag becomes
`messaging.is_some() && services.didcomm` — a configured mediator is no longer
sufficient grounds, since a TSP-only VTA has one too.

## 3. The cargo feature carried the edge

`tsp = ["didcomm", …]` is gone. The module split is now by role rather than by
history:

- `messaging::{service,readiness,auth}` and the module itself → `any(didcomm, tsp)`
- DIDComm protocol surface — router, handlers, shim, registry, drain
  store/sweeper, handshake, live prover, transient handshake → `didcomm`, along
  with the ops, REST routes and offline CLI commands that drive it
- `ceremony` + `reject_trust_task` → `any(didcomm, tsp)`: an approver must not be
  able to reach the VTA over one transport and not the other

## Caught while doing it

**`transport-harness` named `tsp` and relied on it pulling `didcomm` in.** It now
names both — otherwise its own DIDComm fixture would have built with no
dispatcher behind it. This is the class of breakage a removed feature edge causes
silently, which is why CI gains a **`tsp without didcomm`** combo at
`-D warnings --all-targets`: the combination that was unbuildable is precisely
the one nothing would notice rotting, and the dead code it exposes is the point.

## Tests

| build | result |
|---|---|
| default (`didcomm`, no `tsp`) | 77 bin + 788 lib + 118 integration ✅ |
| `--features tsp` (both) | 80 bin + 795 lib ✅ |
| `--features tsp` without `didcomm` | 80 bin ✅, clippy `-D warnings --all-targets` clean |

The two tests that encoded the old rule now assert the new one: TSP alone is
accepted at the prompt (empty selection is still the only thing that re-asks),
and a TSP-only `--from` file validates.

## Not in this PR

- **Per-transport mediators** (`[messaging.tsp]`) — TSP and DIDComm still share
  one mediator when both are on. Designed in the note §7, needs per-mediator
  transports plus outbound protocol routing.
- **The two open questions** (§9): whether the mediator needs per-protocol
  registration (`setup_acl` is DIDComm-shaped), and whether a TSP-only session
  can be established without the DIDComm auth leg. Neither is answerable from the
  code — they are what the Berlin run answers.

`docs/02-vta/tsp.md` gains a **"What a TSP-only build does not have"** section:
no DIDComm protocol-message surface (`key-management/1.0/*` et al are REST-only
there), no drain machinery or `services didcomm …` commands, and no path back
without a rebuild.
