### PR TITLE
fix(ci): pin the release-plz action to a version that exists

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -52,7 +52,11 @@ jobs:
         id: auth
 
       - name: Run release-plz
-        uses: release-plz/action@v0
+        # Pinned to a full version: release-plz/action does NOT publish a
+        # moving major tag, so `@v0` resolves to nothing and the job fails at
+        # "Set up job" before running a step. (actions/checkout@v6 works
+        # because that repo does publish v6 — the convention is not universal.)
+        uses: release-plz/action@v0.5.131
         with:
           command: release
         env:
@@ -91,7 +95,11 @@ jobs:
         uses: taiki-e/install-action@cargo-semver-checks
 
       - name: Run release-plz
-        uses: release-plz/action@v0
+        # Pinned to a full version: release-plz/action does NOT publish a
+        # moving major tag, so `@v0` resolves to nothing and the job fails at
+        # "Set up job" before running a step. (actions/checkout@v6 works
+        # because that repo does publish v6 — the convention is not universal.)
+        uses: release-plz/action@v0.5.131
         with:
           command: release-pr
         env:


### PR DESCRIPTION
The Release-plz workflow failed on its first run, immediately after #938 merged:

```
Unable to resolve action `release-plz/action@v0`, unable to find version `v0`
```

`release-plz/action` publishes only full versions (`v0.5.131`, `v0.5.130`, …) and **no moving major tag**, so `@v0` resolves to nothing. Both jobs died at "Set up job" before a single step ran.

My mistake: `actions/checkout@v6` works in the sibling workflows because that repo *does* publish a `v6` tag, and I assumed the convention was universal instead of using the pin release-plz's own quickstart shows.

Pinned both jobs to `v0.5.131` (latest, 2026-07-14), with a comment so the next person doesn't repeat it.

**Nothing was published and no state is inconsistent** — the failure was before any release logic ran. The seven anchor tags are already on origin, so once this lands the next push to main produces a real Release PR.