### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2401,7 +2401,7 @@ checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cnm-cli"
-version = "0.11.14"
+version = "0.11.15"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "clap",
@@ -6261,7 +6261,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "pnm-cli"
-version = "0.11.21"
+version = "0.11.22"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-resolver-cache-sdk",
@@ -9667,7 +9667,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-client"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "chrono",
  "reqwest",

--- a/cnm-cli/CHANGELOG.md
+++ b/cnm-cli/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+Notable changes to the published crates. Generated from conventional commits by
+[git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.11.15](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/cnm-cli-v0.11.14...cnm-cli-v0.11.15) — 2026-08-12
+

--- a/cnm-cli/Cargo.toml
+++ b/cnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cnm-cli"
 description = "CLI Tool for Verified Trust Agents operating in Verified Trust Communities"
-version = "0.11.14"
+version = "0.11.15"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/pnm-cli/CHANGELOG.md
+++ b/pnm-cli/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+Notable changes to the published crates. Generated from conventional commits by
+[git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.11.22](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/pnm-cli-v0.11.21...pnm-cli-v0.11.22) — 2026-08-12
+

--- a/pnm-cli/Cargo.toml
+++ b/pnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pnm-cli"
 description = "CLI Tool for managing a personal Verifiable Trust Agent"
-version = "0.11.21"
+version = "0.11.22"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vtc-client/CHANGELOG.md
+++ b/vtc-client/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+Notable changes to the published crates. Generated from conventional commits by
+[git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.3.2](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vtc-client-v0.3.1...vtc-client-v0.3.2) — 2026-08-12
+

--- a/vtc-client/Cargo.toml
+++ b/vtc-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vtc-client"
 description = "Client SDK for Verifiable Trust Communities (VTC) — auth, members, join, removal, policies"
-version = "0.3.1"
+version = "0.3.2"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `cnm-cli`: 0.11.14 -> 0.11.15
* `pnm-cli`: 0.11.21 -> 0.11.22
* `vtc-client`: 0.3.1 -> 0.3.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>





</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).