### PR TITLE
fix(ci): name the workflow publish.yml — crates.io pins the filename

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,20 @@
 name: Release-plz
 
+# THE FILENAME OF THIS FILE IS LOAD-BEARING. Do not rename it.
+#
+# crates.io Trusted Publishing is configured per crate against a specific
+# repository + workflow FILENAME, and every crate here is registered against
+# `publish.yml`. Renaming this file to release-plz.yml made the OIDC exchange
+# fail before any release logic ran:
+#
+#   Failed to retrieve token from Cargo registry. Status: 400.
+#   The Trusted Publishing config ... does not match the workflow filename
+#   `release-plz.yml` in the JWT. Expected workflow filenames: `publish.yml` ...
+#
+# To rename it you must first update the Trusted Publisher config of every
+# published crate on crates.io. Not worth it — the name is ours to choose, the
+# registry's expectation is not.
+
 # Versioning, changelogs and publishing. Replaces the old publish.yml, which
 # fired on every push to main and published whatever versions were newly
 # present — making a version bump the release trigger, and therefore making

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -149,7 +149,7 @@ changelog sections — there is no range for it to read commits from.
 |---|---|
 | `release-plz.toml` | what release-plz does; published set lives in the manifests |
 | `cliff.toml` | how commits become changelog entries |
-| `.github/workflows/release-plz.yml` | the Release PR + release jobs |
+| `.github/workflows/publish.yml` | the Release PR + release jobs |
 | `scripts/check-lockfile-self-pins.sh` | catches a stale registry self-pin in `Cargo.lock` |
 | CI `commit lint` | PR title must be a conventional commit |
 | CI `semver checks` | reports API breaks on the PR that causes them |


### PR DESCRIPTION
The `Release-plz PR` job **succeeded** on #941's merge — that half is working. The `release` job failed at the OIDC exchange, before any release logic ran:

```
Failed to retrieve token from Cargo registry. Status: 400.
The Trusted Publishing config for repository `OpenVTC/verifiable-trust-infrastructure`
does not match the workflow filename `release-plz.yml` in the JWT.
Expected workflow filenames: `publish.yml`, `publish.yml`, ...
```

**crates.io Trusted Publishing is registered per crate against a repository *and a workflow filename*.** Every crate is registered against `publish.yml` — which #938 deleted and replaced with `release-plz.yml`. The registry simply stopped recognising the workflow asking it for a token.

Renaming the file back is the cheap fix. The name is ours to choose; the registry's expectation is not. The alternative is hand-editing the Trusted Publisher config of every published crate on crates.io.

Added a header saying so, because nothing else in the repo hints that the filename is load-bearing and the symptom is a bare 400.

## Nothing was at risk

The failure is at authentication, before release-plz runs. And this particular run had nothing to publish anyway — the anchor tags sit at current main.

## Minor cleanup for later

The error lists `publish.yml` 22 times, once per registered crate. After the publish-set audit in #938, **14 of those Trusted Publisher registrations are stale** (`vta-service`, `vtc-service`, and the twelve subsystem crates). They're harmless — a registration for a crate we never publish is inert — but worth removing on crates.io when convenient, so the config matches reality.