### PR TITLE
ci(dco): exempt verified org-member commits, so releases can pass

### DIFF
--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,0 +1,22 @@
+# DCO configuration (github.com/cncf/dco2).
+#
+# Skip the sign-off requirement for commits that are BOTH authored by an
+# OpenVTC organisation member AND cryptographically signed.
+#
+# This exists for the Release PR. release-plz assigns versions and writes
+# changelogs in a commit it makes itself, and it has no option to add a
+# `Signed-off-by` trailer — the whole config schema was checked. DCO is the
+# only required status check on main, so without this every release would fail
+# it, and the workaround would be clicking override on the one PR that
+# publishes to crates.io.
+#
+# The release commit qualifies on both counts: it is authored by the
+# RELEASE_PLZ_TOKEN identity (an org member) and GitHub signs it, because
+# release-plz pushes through the API.
+#
+# WHAT THIS DOES NOT DO: contributors outside the organisation are unaffected
+# and still need `git commit -s`. The DCO attestation for members is instead
+# carried by their employment or contributor agreement — which is the case this
+# option exists for.
+require:
+  members: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -888,7 +888,10 @@ unwrap (drops RUSTSEC-2023-0071 exposure); don't reintroduce `rsa`.
 ## Commit hygiene
 
 - Run `cargo fmt` before committing.
-- All commits must be DCO-signed (`git commit -s`).
+- All commits must be DCO-signed (`git commit -s`). `.github/dco.yml` exempts
+  commits that are both authored by an org member and cryptographically signed
+  — that exists for release-plz's release commit, which cannot carry a
+  `Signed-off-by` trailer. Sign off anyway; don't rely on the exemption.
 - Don't bypass hooks (`--no-verify`), don't skip signatures, don't amend
   published commits.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ Before submitting a pull request:
 - [ ] Security-sensitive changes include tests (auth, ACL, crypto)
 - [ ] PR title is a conventional commit — it becomes the changelog entry (see [Changelog](#changelog))
 - [ ] No `version = ` edits in any `Cargo.toml` — the Release PR assigns versions (see [RELEASING.md](RELEASING.md))
-- [ ] Commits are signed off (DCO: `git commit -s`)
+- [ ] Commits are signed off (DCO: `git commit -s`) — required for all outside contributions
 
 ## Changelog
 


### PR DESCRIPTION
Release PR #942 is failing DCO, and **every future Release PR would fail the same way**.

release-plz writes the version bumps and changelogs in a commit it makes itself, and it has **no option to add a `Signed-off-by` trailer** — I checked its entire config schema (`release-plz generate-schema`), there's no key for it.

DCO is the only required status check on main, so the alternatives were:
- click override on the one PR that publishes to crates.io, every release, or
- force-amend a generated branch from inside the workflow on every push to main.

## What this does

dco2 supports exempting commits that are **both authored by an org member and cryptographically signed**. The release commit qualifies on both counts — verified against #942:

```
author:   Glenn Gore <glenn.g@affinidi.com>
verified: true (valid)          <- GitHub signs it; release-plz pushes via the API
signoff:  NO
```

## What it does not do

**Contributors outside the organisation are unaffected** and still need `git commit -s`. For members, the DCO attestation is carried by their employment or contributor agreement — which is the case this dco2 option exists for.

`CLAUDE.md` and `CONTRIBUTING.md` both stated sign-off as unconditional. Both now say what is actually enforced, and still tell members to sign off rather than lean on the exemption.

## After this merges

#942 should go green on a re-run of its DCO check and become mergeable — that's the first release.