### PR TITLE
fix(provisioning): verify the bootstrap VP as received, not re-serialised

### DIFF
--- a/vta-sdk/src/provision_integration/request.rs
+++ b/vta-sdk/src/provision_integration/request.rs
@@ -1390,6 +1390,92 @@ mod tests {
         );
     }
 
+    /// Build a `provision/integration/0.1`-shape VP — the mirror image of
+    /// [`build_valid_camelcase_vp`]. `ask.type` is PascalCase
+    /// (`TemplateBootstrap`), signed over that exact wire form.
+    ///
+    /// This is what any holder on vta-sdk < 0.21.11 emits, which as of
+    /// this writing includes shipped integrations (did-hosting
+    /// `VTI-Cypress-RC-1` pins 0.21.9). The casing flip landed in #917;
+    /// the fixture there covered the 0.2 direction only, so nothing
+    /// tested the far commoner case of an *older* holder meeting a
+    /// current maintainer — which is how the offline `vta bootstrap
+    /// provision-integration` surface stayed broken.
+    async fn build_valid_pascalcase_vp() -> (Value, String) {
+        use base64::Engine;
+        use base64::engine::general_purpose::URL_SAFE_NO_PAD as B64URL;
+
+        let (seed, client_did) = sample_client_did(0xD1);
+        let vm_id = did_key_to_vm(&client_did).expect("vm id");
+        let mut signer = Secret::generate_ed25519(Some(&vm_id), Some(&seed));
+        signer.id = vm_id;
+
+        let now = Utc::now();
+        let mut doc = serde_json::json!({
+            "@context": [VC_V2_CONTEXT_URL, BOOTSTRAP_CONTEXT_URL],
+            "type": ["VerifiablePresentation", "BootstrapRequest"],
+            "id": format!("urn:uuid:{}", uuid::Uuid::new_v4()),
+            "holder": client_did,
+            "nonce": B64URL.encode([0xD1u8; 16]),
+            "validUntil": rfc3339(now + Duration::hours(1)),
+            "label": "v0.1-pascalcase-fixture",
+            // 0.1 wire form: PascalCase tag, inside the signed VP.
+            "ask": {
+                "type": "TemplateBootstrap",
+                "template": {
+                    "name": "didcomm-mediator",
+                    "vars": { "URL": "https://mediator.example.com" }
+                }
+            }
+        });
+
+        let sign_options = SignOptions::new()
+            .with_proof_purpose("authentication")
+            .with_created(now);
+        let proof = DataIntegrityProof::sign(&doc, &signer, sign_options)
+            .await
+            .expect("sign PascalCase VP");
+        doc.as_object_mut()
+            .unwrap()
+            .insert("proof".into(), serde_json::to_value(&proof).unwrap());
+        (doc, client_did)
+    }
+
+    #[tokio::test]
+    async fn verify_value_accepts_v0_1_pascalcase_ask() {
+        // A 0.1 holder signs `ask.type` as PascalCase. Verifying over the
+        // wire bytes must accept it, and the typed view must normalise to
+        // the same variant downstream logic already handles.
+        let (doc, holder) = build_valid_pascalcase_vp().await;
+        let verified = BootstrapRequest::verify_value(doc).expect("0.1 PascalCase VP verifies");
+        assert_eq!(verified.holder(), holder);
+        assert!(matches!(verified.ask(), BootstrapAsk::TemplateBootstrap(_)));
+    }
+
+    #[tokio::test]
+    async fn verify_reserialises_and_so_rejects_a_v0_1_pascalcase_holder() {
+        // Pins *why* no surface receiving a request from elsewhere may
+        // call `verify()`: it re-serialises the typed struct, re-emitting
+        // `ask.type` as this crate's 0.2 `templateBootstrap`, and then
+        // checks that against a signature made over `TemplateBootstrap`.
+        //
+        // The failure is indistinguishable from a forgery — `BadProof`,
+        // "signature invalid for cryptosuite EddsaJcs2022" — which is
+        // what makes it expensive to diagnose in the field. If this test
+        // ever starts passing `verify()`, the casing divergence is gone
+        // and this whole hazard can be revisited; until then, treat a
+        // `verify()` call on received bytes as a bug.
+        let (doc, _) = build_valid_pascalcase_vp().await;
+        let typed: BootstrapRequest = serde_json::from_value(doc.clone()).expect("parse 0.1 VP");
+        let err = typed.verify().unwrap_err();
+        assert!(
+            matches!(err, ProvisionIntegrationError::BadProof(_)),
+            "re-serialising a 0.1 holder's VP must break its proof, got {err:?}"
+        );
+        // …and the same bytes verify fine through the as-received path.
+        BootstrapRequest::verify_value(doc).expect("as-received path verifies");
+    }
+
     #[tokio::test]
     async fn verify_rejects_holder_mutation() {
         let (mut vp, _) = build_valid_vp().await;

--- a/vta-service/src/bootstrap_cli.rs
+++ b/vta-service/src/bootstrap_cli.rs
@@ -492,12 +492,21 @@ pub async fn run_provision_integration(
     use vta_sdk::provision_integration::BootstrapRequest;
 
     // 1. Parse + verify the request file (VP shape).
+    //
+    // Verify over the JSON **exactly as it arrived in the file**, never a
+    // re-serialisation of the typed struct: the holder's proof covers the
+    // bytes it signed, and this crate's serde output need not reproduce
+    // them. `ask.type` is the live example — a holder on vta-sdk < 0.21.11
+    // signed the 0.1 `TemplateBootstrap` tag, which `verify()` would
+    // re-emit as 0.2's `templateBootstrap` and then fail to verify against
+    // its own signature. `verify_value` is what the DIDComm and Trust-Task
+    // handlers already use, and what its own docs require of any surface
+    // receiving a request from elsewhere.
     let request_json = std::fs::read_to_string(&request_path)
         .map_err(|e| format!("read {}: {e}", request_path.display()))?;
-    let request: BootstrapRequest = serde_json::from_str(&request_json)
+    let request_value: serde_json::Value = serde_json::from_str(&request_json)
         .map_err(|e| format!("parse BootstrapRequest (VP): {e}"))?;
-    let verified = request
-        .verify()
+    let verified = BootstrapRequest::verify_value(request_value)
         .map_err(|e| format!("verify BootstrapRequest: {e}"))?;
 
     // 2. Resolve target context: explicit --context overrides the

--- a/vta-service/src/routes/bootstrap.rs
+++ b/vta-service/src/routes/bootstrap.rs
@@ -569,7 +569,17 @@ mod provision {
     pub struct ProvisionIntegrationRequestBody {
         /// The integration's VP-framed bootstrap request (signed by its
         /// ephemeral `client_did`).
-        pub request: BootstrapRequest,
+        ///
+        /// Held as raw JSON, **not** as a typed [`BootstrapRequest`]:
+        /// deserialising into the struct here would discard the very bytes
+        /// the holder's Data-Integrity proof covers, and the handler would
+        /// then verify against this crate's re-serialisation of them. The
+        /// typed view is what [`BootstrapRequest::verify_value`] returns
+        /// once the proof checks out. Same shape as the DIDComm and
+        /// Trust-Task bodies, which carry the request as `Value` for this
+        /// reason.
+        #[schema(value_type = Object)]
+        pub request: serde_json::Value,
         /// VTA context to provision into. **Optional** per the canonical
         /// Trust Task spec; omit to let the VTA infer from the caller's
         /// ACL grant or its own contexts state. See
@@ -672,9 +682,7 @@ mod provision {
         State(state): State<AppState>,
         Json(req): Json<ProvisionIntegrationRequestBody>,
     ) -> Result<Json<ProvisionIntegrationResponseBody>, AppError> {
-        let verified = req
-            .request
-            .verify()
+        let verified = BootstrapRequest::verify_value(req.request)
             .map_err(|e| AppError::Validation(format!("verify BootstrapRequest: {e}")))?;
 
         let assertion_mode = req.assertion.map(AssertionMode::from).unwrap_or_default();

--- a/vta-service/tests/api_integration.rs
+++ b/vta-service/tests/api_integration.rs
@@ -3238,6 +3238,96 @@ async fn provision_integration_rejects_tampered_vp() {
     assert_eq!(status, StatusCode::BAD_REQUEST);
 }
 
+/// Sign a `provision/integration/0.1`-shape VP: `ask.type` PascalCase
+/// (`TemplateBootstrap`), signed over that exact wire form.
+///
+/// Built as raw JSON rather than through `BootstrapRequest::sign`,
+/// because vta-sdk ≥ 0.21.11 emits the 0.2 camelCase tag — the whole
+/// point here is to reproduce a holder that predates that flip, which
+/// shipped integrations still are.
+#[cfg(feature = "webvh")]
+async fn sign_pascalcase_bootstrap_request() -> Value {
+    use affinidi_data_integrity::{DataIntegrityProof, SignOptions};
+    use affinidi_secrets_resolver::secrets::Secret;
+    use base64::Engine;
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD as B64URL;
+    use vta_sdk::provision_integration::{BOOTSTRAP_CONTEXT_URL, VC_V2_CONTEXT_URL};
+
+    let (seed_box, pub_bytes) = vta_sdk::sealed_transfer::generate_ed25519_keypair();
+    let client_did = affinidi_crypto::did_key::ed25519_pub_to_did_key(&pub_bytes);
+    let mb = client_did
+        .strip_prefix("did:key:")
+        .expect("did:key prefix")
+        .to_string();
+    let vm_id = format!("{client_did}#{mb}");
+    let mut signer = Secret::generate_ed25519(Some(&vm_id), Some(&seed_box));
+    signer.id = vm_id;
+
+    let now = chrono::Utc::now();
+    let mut doc = json!({
+        "@context": [VC_V2_CONTEXT_URL, BOOTSTRAP_CONTEXT_URL],
+        "type": ["VerifiablePresentation", "BootstrapRequest"],
+        "id": format!("urn:uuid:{}", uuid::Uuid::new_v4()),
+        "holder": client_did,
+        "nonce": B64URL.encode([0xA1u8; 16]),
+        "validUntil": (now + chrono::Duration::hours(1)).to_rfc3339(),
+        "label": "v0.1-pascalcase-rest-test",
+        "ask": {
+            "type": "TemplateBootstrap",
+            "contextHint": "prod-mediator",
+            "template": {
+                "name": "didcomm-mediator",
+                "vars": { "URL": "https://mediator.example.com" }
+            }
+        }
+    });
+
+    let proof = DataIntegrityProof::sign(
+        &doc,
+        &signer,
+        SignOptions::new()
+            .with_proof_purpose("authentication")
+            .with_created(now),
+    )
+    .await
+    .expect("sign PascalCase VP");
+    doc.as_object_mut()
+        .unwrap()
+        .insert("proof".into(), serde_json::to_value(&proof).unwrap());
+    doc
+}
+
+#[cfg(feature = "webvh")]
+#[tokio::test]
+async fn provision_integration_accepts_a_v0_1_pascalcase_holder() {
+    // A holder on vta-sdk < 0.21.11 signs `ask.type` as PascalCase. The
+    // route must verify the proof against the bytes as posted; if it
+    // instead re-serialises the typed struct it re-emits the 0.2
+    // `templateBootstrap` tag and the holder's own valid signature is
+    // rejected as a forgery.
+    //
+    // Asserted as the absence of a *proof* failure rather than a 200:
+    // provisioning proper needs template + context state this fixture
+    // app doesn't stand up, so it legitimately fails further in. What
+    // must never come back is "signature invalid".
+    let (app, ctx) = TestApp::new().await;
+    let token = ctx
+        .auth_token("did:key:z6MkAdmin", "admin", vec!["prod-mediator".into()])
+        .await;
+    let body = json!({
+        "request": sign_pascalcase_bootstrap_request().await,
+        "context": "prod-mediator",
+    });
+    let (_status, err) = app
+        .request(post_auth("/bootstrap/provision-integration", &token, body))
+        .await;
+    let err = err.to_string();
+    assert!(
+        !err.contains("signature invalid") && !err.contains("verify BootstrapRequest"),
+        "0.1-cased holder must clear proof verification, got {err}"
+    );
+}
+
 #[cfg(feature = "webvh")]
 #[tokio::test]
 async fn provision_integration_rejects_unknown_field_in_body() {


### PR DESCRIPTION
`vta bootstrap provision-integration` and `POST /bootstrap/provision-integration`
rejected a validly-signed request from any holder on vta-sdk < 0.21.11:

    Error: verify BootstrapRequest: proof verification failed:
    verify VP: signature invalid for cryptosuite EddsaJcs2022

Both called `BootstrapRequest::verify()`, which re-serialises the typed
struct and re-imposes this crate's casing on the bytes the holder signed.
#917 flipped `ask.type` to the 0.2 camelCase tag (`templateBootstrap`),
so a 0.1 holder's `TemplateBootstrap` — accepted on the way in by the
serde alias, then re-emitted camelCase on the way to the verifier — no
longer matched its own signature. The failure is indistinguishable from
a forgery, which is what makes it expensive to diagnose in the field.
did-hosting `VTI-Cypress-RC-1` pins vta-sdk 0.21.9 and hits this on
every offline provision.

#917 fixed exactly this defect at the Trust-Task handler and the DIDComm
handler already did the right thing; the offline CLI and the REST route
were the two surfaces left behind. Both now go through `verify_value`
over the bytes as received, which is what its own docs require of any
surface taking a request from elsewhere. The REST body consequently
carries `request` as raw JSON — deserialising it into the typed struct
at the extractor is what discarded the signed bytes. `deny_unknown_fields`
still rejects smuggled fields, one layer in, inside `verify_value`.

Tests cover the direction that was missing. #917's fixture signed the
0.2 casing against a 0.2 maintainer; nothing exercised an *older* holder
against a current one, which is the far commoner deployment shape. Added
a PascalCase-signed fixture at both layers, plus a test pinning that
`verify()` breaks such a request — so a call site reverting to it fails
rather than shipping.

Note for follow-up: the relayer has the same defect one layer up.
`ProvisionIntegrationRequest.request` is a typed `BootstrapRequest`, so
`pnm bootstrap provision-integration` re-serialises a request file before
sending it (both transports), and the maintainer never sees the signed
bytes. `provision_integration_didcomm`'s doc comment already claims the
VP is "left byte-identical either way", which the code does not honour.
Fixing it changes a published vta-sdk struct field, so it is deliberately
not bundled here.

Signed-off-by: Glenn Gore <glenn.g@affinidi.com>

