### PR TITLE
fix(provisioning)!: relay the holder's bootstrap VP as raw JSON

### DIFF
--- a/pnm-cli/src/bootstrap.rs
+++ b/pnm-cli/src/bootstrap.rs
@@ -518,10 +518,20 @@ pub async fn run_provision_integration(
 
     // 1. Parse the integration's VP (but don't verify locally — the
     //    server does the authoritative verification).
+    //
+    //    Two views of the same document, deliberately. `vp_raw` is what
+    //    goes on the wire: this VP was signed by the integration, not by
+    //    us, so relaying the typed struct would re-render it in the SDK's
+    //    casing and the maintainer would verify bytes the holder never
+    //    signed. `vp` is a local read-only view, used only to resolve the
+    //    context hint below.
     let request_json =
         fs::read_to_string(&request).map_err(|e| format!("read {}: {e}", request.display()))?;
-    let vp: vta_sdk::provision_integration::BootstrapRequest = serde_json::from_str(&request_json)
+    let vp_raw: serde_json::Value = serde_json::from_str(&request_json)
         .map_err(|e| format!("parse BootstrapRequest (VP): {e}"))?;
+    let vp: vta_sdk::provision_integration::BootstrapRequest =
+        serde_json::from_value(vp_raw.clone())
+            .map_err(|e| format!("parse BootstrapRequest (VP): {e}"))?;
 
     // 2. Resolve context: explicit > hint > fail. If both present they
     //    must agree.
@@ -542,7 +552,7 @@ pub async fn run_provision_integration(
     // 4. Submit.
     let resp = client
         .provision_integration(ProvisionIntegrationRequest {
-            request: vp,
+            request: vp_raw,
             // `--context` is required on the pnm-cli surface today, so
             // we always pass a concrete value. The wire field is
             // `Option<String>` per the canonical spec; future flag

--- a/vta-sdk/src/protocols/provision_integration_management.rs
+++ b/vta-sdk/src/protocols/provision_integration_management.rs
@@ -284,7 +284,7 @@ mod tests {
             .expect("sign VP");
         let vp_value = serde_json::to_value(&vp).expect("serialize VP");
         let req = ProvisionIntegrationRequest {
-            request: vp,
+            request: vp_value.clone(),
             context: Some("ctx".into()),
             assertion,
             vc_validity_seconds,
@@ -328,6 +328,99 @@ mod tests {
         assert_eq!(v["context"], "ctx");
         // The signed VP subtree is byte-identical — the proof still covers it.
         assert_eq!(v["request"], vp_value);
+    }
+
+    /// Sign a VP the way a holder on vta-sdk < 0.21.11 does: `ask.type`
+    /// PascalCase (`TemplateBootstrap`), signed over that wire form.
+    ///
+    /// Deliberately *not* built through [`ProvisionRequestBuilder`]. The
+    /// point is a document this crate did not render — the relaying tests
+    /// above compare the SDK's own serde output against itself, which is
+    /// true by construction and cannot catch a relayer that re-renders
+    /// what it forwards.
+    async fn foreign_holder_vp() -> Value {
+        use affinidi_data_integrity::{DataIntegrityProof, SignOptions};
+        use affinidi_secrets_resolver::secrets::Secret;
+        use base64::Engine;
+        use base64::engine::general_purpose::URL_SAFE_NO_PAD as B64URL;
+
+        let (seed, pub_bytes) = crate::sealed_transfer::generate_ed25519_keypair();
+        let did = affinidi_crypto::did_key::ed25519_pub_to_did_key(&pub_bytes);
+        let mb = did.strip_prefix("did:key:").expect("did:key prefix");
+        let vm_id = format!("{did}#{mb}");
+        let mut signer = Secret::generate_ed25519(Some(&vm_id), Some(&seed));
+        signer.id = vm_id;
+
+        let now = chrono::Utc::now();
+        let mut doc = serde_json::json!({
+            "@context": [
+                crate::provision_integration::VC_V2_CONTEXT_URL,
+                crate::provision_integration::BOOTSTRAP_CONTEXT_URL,
+            ],
+            "type": ["VerifiablePresentation", "BootstrapRequest"],
+            "id": format!("urn:uuid:{}", uuid::Uuid::new_v4()),
+            "holder": did,
+            "nonce": B64URL.encode([0xF1u8; 16]),
+            "validUntil": (now + chrono::Duration::hours(1)).to_rfc3339(),
+            "ask": {
+                "type": "TemplateBootstrap",
+                "template": { "name": "didcomm-mediator", "vars": {} }
+            }
+        });
+        let proof = DataIntegrityProof::sign(
+            &doc,
+            &signer,
+            SignOptions::new()
+                .with_proof_purpose("authentication")
+                .with_created(now),
+        )
+        .await
+        .expect("sign foreign VP");
+        doc.as_object_mut()
+            .unwrap()
+            .insert("proof".into(), serde_json::to_value(&proof).unwrap());
+        doc
+    }
+
+    #[tokio::test]
+    async fn a_foreign_holders_vp_is_relayed_byte_for_byte() {
+        let vp = foreign_holder_vp().await;
+
+        // Guard against this test going vacuous. It only proves anything
+        // while the SDK's rendering of the document differs from the
+        // document — if the two ever converge, the assertions below pass
+        // for the wrong reason and the fixture needs a new divergence.
+        let round_tripped = serde_json::to_value(
+            serde_json::from_value::<crate::provision_integration::BootstrapRequest>(vp.clone())
+                .expect("foreign VP parses"),
+        )
+        .expect("re-serialize");
+        assert_ne!(
+            round_tripped, vp,
+            "fixture no longer diverges from this crate's serde output"
+        );
+
+        for uri in [
+            CANONICAL_PROVISION_INTEGRATION,
+            CANONICAL_PROVISION_INTEGRATION_0_2,
+        ] {
+            let req = ProvisionIntegrationRequest {
+                request: vp.clone(),
+                context: Some("ctx".into()),
+                assertion: None,
+                vc_validity_seconds: None,
+                create_context: false,
+            };
+            let body = request_body_for_version(&req, uri).expect("build body");
+            assert_eq!(
+                body["request"], vp,
+                "relaying under {uri} altered the holder's signed document"
+            );
+            // The end the relayer is talking to must still be able to
+            // verify it — the whole reason the bytes matter.
+            crate::provision_integration::BootstrapRequest::verify_value(body["request"].clone())
+                .expect("relayed VP still verifies");
+        }
     }
 
     #[test]

--- a/vta-sdk/src/provision_client/runner_didcomm.rs
+++ b/vta-sdk/src/provision_client/runner_didcomm.rs
@@ -61,7 +61,7 @@ pub async fn provision_via_didcomm(
         let nonce = decode_nonce_b64url(&vp.nonce).map_err(ProvisionError::Armor)?;
         let response = provision_integration_didcomm(
             &session,
-            vp,
+            vp.to_signed_wire_value()?,
             Some(ask.context.clone()),
             None,
             None,
@@ -390,7 +390,7 @@ pub async fn provision_admin_rotation_via_didcomm(
         let nonce = decode_nonce_b64url(&vp.nonce).map_err(ProvisionError::Armor)?;
         let response = provision_integration_didcomm(
             &session,
-            vp,
+            vp.to_signed_wire_value()?,
             Some(ask.context.clone()),
             None,
             None,

--- a/vta-sdk/src/provision_client/runner_rest.rs
+++ b/vta-sdk/src/provision_client/runner_rest.rs
@@ -190,8 +190,22 @@ pub(crate) async fn run_rest_attempt_full_setup(
         }
     };
 
+    // This process signed `vp` moments ago, so its serde rendering *is*
+    // the signed bytes. A VP from anywhere else must travel as the raw
+    // JSON it arrived as.
+    let request = match vp.to_signed_wire_value() {
+        Ok(v) => v,
+        Err(e) => {
+            let _ = tx.send(VtaEvent::CheckDone(
+                DiagCheck::ProvisionIntegration,
+                DiagStatus::Failed(e.to_string()),
+            ));
+            return AttemptOutcome::PostAuthFailure(format!("serialize VP: {e}"));
+        }
+    };
+
     let req = ProvisionIntegrationRequest {
-        request: vp,
+        request,
         context: Some(ask.context.clone()),
         assertion: None,
         vc_validity_seconds: None,
@@ -341,8 +355,22 @@ pub(crate) async fn run_rest_attempt_admin_rotated(
         }
     };
 
+    // This process signed `vp` moments ago, so its serde rendering *is*
+    // the signed bytes. A VP from anywhere else must travel as the raw
+    // JSON it arrived as.
+    let request = match vp.to_signed_wire_value() {
+        Ok(v) => v,
+        Err(e) => {
+            let _ = tx.send(VtaEvent::CheckDone(
+                DiagCheck::ProvisionIntegration,
+                DiagStatus::Failed(e.to_string()),
+            ));
+            return AttemptOutcome::PostAuthFailure(format!("serialize VP: {e}"));
+        }
+    };
+
     let req = ProvisionIntegrationRequest {
-        request: vp,
+        request,
         context: Some(ask.context.clone()),
         assertion: None,
         vc_validity_seconds: None,

--- a/vta-sdk/src/provision_client/runner_tsp.rs
+++ b/vta-sdk/src/provision_client/runner_tsp.rs
@@ -404,7 +404,8 @@ async fn provision_over(
         .map_err(|e| ProvisionError::SetupKeyMalformed(e.to_string()))?;
     let vp = ask.to_builder().sign_with(&seed, setup_did).await?;
     let nonce = decode_nonce_b64url(&vp.nonce).map_err(ProvisionError::Armor)?;
-    let response = dispatch_provision_integration(client, vp, ask).await?;
+    let request = vp.to_signed_wire_value()?;
+    let response = dispatch_provision_integration(client, request, ask).await?;
     response_to_result(&seed, nonce, response)
 }
 
@@ -424,7 +425,8 @@ async fn provision_admin_rotation_over(
         .map_err(|e| ProvisionError::SetupKeyMalformed(e.to_string()))?;
     let vp = ask.to_builder().sign_with(&seed, setup_did).await?;
     let nonce = decode_nonce_b64url(&vp.nonce).map_err(ProvisionError::Armor)?;
-    let response = dispatch_provision_integration(client, vp, ask).await?;
+    let request = vp.to_signed_wire_value()?;
+    let response = dispatch_provision_integration(client, request, ask).await?;
     admin_rotation_response_to_reply(&seed, nonce, response)
 }
 
@@ -435,7 +437,7 @@ async fn provision_admin_rotation_over(
 #[cfg(feature = "tsp")]
 async fn dispatch_provision_integration(
     client: &crate::client::VtaClient,
-    request: crate::provision_integration::BootstrapRequest,
+    request: serde_json::Value,
     ask: &ProvisionAsk,
 ) -> Result<
     crate::provision_integration::http::ProvisionIntegrationResponse,

--- a/vta-sdk/src/provision_integration/didcomm.rs
+++ b/vta-sdk/src/provision_integration/didcomm.rs
@@ -33,7 +33,8 @@ use crate::protocols::provision_integration_management::{
     ProvisionSpecVersion, request_body_for_version, result_uri_for,
 };
 
-use super::BootstrapRequest;
+use serde_json::Value;
+
 use super::http::{AssertionMode, ProvisionIntegrationRequest, ProvisionIntegrationResponse};
 
 /// Default DIDComm round-trip timeout (seconds). Generous so the VTA
@@ -76,9 +77,14 @@ const DEFAULT_TIMEOUT_SECS: u64 = 60;
 /// lowerCamelCase (`vcValiditySeconds` / `createContext` / `didSigned`) under
 /// the `0.2` URI. The signed VP carried in `request` is left byte-identical
 /// either way — its casing is the holder's, and the VTA dual-accepts both.
+/// That is why `request` is a raw [`Value`] and not a typed
+/// [`BootstrapRequest`](super::BootstrapRequest): the claim above was
+/// false while this took the
+/// struct, because serialising it re-rendered the holder's document in
+/// this crate's casing.
 pub async fn provision_integration_didcomm(
     session: &DIDCommSession,
-    request: BootstrapRequest,
+    request: Value,
     context: Option<String>,
     assertion: Option<AssertionMode>,
     vc_validity_seconds: Option<i64>,

--- a/vta-sdk/src/provision_integration/http.rs
+++ b/vta-sdk/src/provision_integration/http.rs
@@ -7,8 +7,6 @@
 
 use serde::{Deserialize, Serialize};
 
-use super::BootstrapRequest;
-
 /// Request body. Used by both transports — REST clients serialize and
 /// the DIDComm provision-integration handler (`vta-service`) deserializes.
 #[derive(Debug, Serialize, Deserialize)]
@@ -18,7 +16,20 @@ pub struct ProvisionIntegrationRequest {
     /// The integration's VP-framed bootstrap request (signed by its
     /// ephemeral `client_did`). The caller sends it unverified — the
     /// server verifies on intake.
-    pub request: BootstrapRequest,
+    ///
+    /// Raw JSON, **not** a typed [`BootstrapRequest`](super::BootstrapRequest).
+    /// A relayer is
+    /// usually not the holder — the air-gap flow exists precisely so it
+    /// isn't — so this field routinely carries a document some other
+    /// process signed. Holding it typed meant serialising this struct
+    /// re-rendered that document with this crate's casing, and the
+    /// maintainer verified bytes the holder never signed. Build it from
+    /// [`to_signed_wire_value`](super::BootstrapRequest::to_signed_wire_value)
+    /// when this process did
+    /// the signing, or pass the received JSON through untouched when it
+    /// didn't.
+    #[cfg_attr(feature = "openapi", schema(value_type = Object))]
+    pub request: serde_json::Value,
     /// VTA context to provision into.
     ///
     /// **Optional** per the canonical Trust Task spec

--- a/vta-sdk/src/provision_integration/request.rs
+++ b/vta-sdk/src/provision_integration/request.rs
@@ -270,6 +270,25 @@ impl BootstrapRequest {
         Ok(out)
     }
 
+    /// Wire form of a request **this process just signed**, for handing to
+    /// [`ProvisionIntegrationRequest`].
+    ///
+    /// Only correct on a VP whose signature this process produced, where
+    /// serde output and signed bytes are the same by construction. A VP
+    /// that arrived from elsewhere — read from a file, received over a
+    /// socket — must be carried as the raw [`Value`] it arrived as and
+    /// never routed through the typed struct: re-serialising re-imposes
+    /// this crate's casing on someone else's signature, and the holder's
+    /// own valid proof then reads as a forgery. See [`verify_value`] for
+    /// the same rule on the verifying side.
+    ///
+    /// [`ProvisionIntegrationRequest`]: super::http::ProvisionIntegrationRequest
+    /// [`verify_value`]: Self::verify_value
+    pub fn to_signed_wire_value(&self) -> Result<Value, ProvisionIntegrationError> {
+        serde_json::to_value(self)
+            .map_err(|e| ProvisionIntegrationError::Parse(format!("serialize VP: {e}")))
+    }
+
     /// Verify the proof + freshness + structure, returning the typestate
     /// form that downstream handlers consume.
     ///

--- a/vta-sdk/tests/provision_client_e2e.rs
+++ b/vta-sdk/tests/provision_client_e2e.rs
@@ -519,7 +519,7 @@ async fn admin_rotated_via_rest_round_trip() {
     client.set_token_async(token.access_token).await;
 
     let req = ProvisionIntegrationRequest {
-        request: signed,
+        request: signed.to_signed_wire_value().expect("serialize VP"),
         context: Some("ctx-1".into()),
         assertion: None,
         vc_validity_seconds: None,


### PR DESCRIPTION
A relayer is usually not the holder — the air-gap onboarding flow exists
precisely so it isn't — so `pnm bootstrap provision-integration` forwards
a document some other process signed. It parsed that document into a
typed `BootstrapRequest` and let serde re-render it on the way out, so
the maintainer verified bytes the holder never signed. Both transports,
every relayed request.

Same defect as #946 one layer up, and with the same trigger: #917 moved
`ask.type` to the 0.2 camelCase tag, so a holder on vta-sdk < 0.21.11
(did-hosting `VTI-Cypress-RC-1` among them) has its own valid signature
rewritten in transit and rejected as a forgery at the far end. #946 fixed
the two maintainer-side surfaces that re-serialised; this is the client
side of the same rule, and the two together close the flow.

`ProvisionIntegrationRequest.request` and `provision_integration_didcomm`
now take `serde_json::Value`. **Breaking** for anything constructing that
struct. Callers that signed the VP themselves — every SDK runner — go
through the new `BootstrapRequest::to_signed_wire_value`, where serde
output and signed bytes are the same document by construction; pnm keeps
a typed view purely to read `contextHint` and relays the raw JSON.

`provision_integration_didcomm`'s doc comment already promised the VP was
"left byte-identical either way". It now is.

The existing relay tests could not have caught this: they assert the body
carries `serde_json::to_value(&vp)`, which is the SDK's rendering
compared against itself and true however badly the relayer mangles a
foreign document. The new test starts from a VP this crate did not
render, relays it under both spec versions, and requires it to arrive
byte-for-byte and still verify. It also asserts the fixture actually
diverges from this crate's serde output, so it fails loudly rather than
going quietly vacuous if the casings ever converge.

Signed-off-by: Glenn Gore <glenn.g@affinidi.com>


---

Pairs with #946 (maintainer side). Either can merge first — neither regresses the other; the flow is only end-to-end correct once both are in.
