### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2401,7 +2401,7 @@ checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cnm-cli"
-version = "0.11.15"
+version = "0.11.16"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "clap",
@@ -2922,7 +2922,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c54e03a951783e8b327515db3f2a2fd0e3bed362a96b066f341ce66ed49b4ead"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4587,7 +4587,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -6261,7 +6261,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "pnm-cli"
-version = "0.11.22"
+version = "0.12.0"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-resolver-cache-sdk",
@@ -6453,7 +6453,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.43",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "thiserror 2.0.20",
  "tokio",
  "tracing",
@@ -6492,7 +6492,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -9226,7 +9226,7 @@ dependencies = [
 
 [[package]]
 name = "vta-cli-common"
-version = "0.10.28"
+version = "0.10.29"
 dependencies = [
  "aes-gcm",
  "affinidi-crypto",
@@ -9383,7 +9383,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.21.21"
+version = "0.22.0"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -9667,7 +9667,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-client"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "chrono",
  "reqwest",
@@ -9764,7 +9764,7 @@ dependencies = [
 
 [[package]]
 name = "vti-common"
-version = "0.11.37"
+version = "0.11.38"
 dependencies = [
  "aes-gcm",
  "affinidi-data-integrity",
@@ -9837,7 +9837,7 @@ dependencies = [
 
 [[package]]
 name = "vti-secrets"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "aws-config",
  "aws-sdk-secretsmanager",

--- a/cnm-cli/CHANGELOG.md
+++ b/cnm-cli/CHANGELOG.md
@@ -2,5 +2,8 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.11.16](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/cnm-cli-v0.11.15...cnm-cli-v0.11.16) — 2026-08-12
+
+
 ## [0.11.15](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/cnm-cli-v0.11.14...cnm-cli-v0.11.15) — 2026-08-12
 

--- a/cnm-cli/Cargo.toml
+++ b/cnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cnm-cli"
 description = "CLI Tool for Verified Trust Agents operating in Verified Trust Communities"
-version = "0.11.15"
+version = "0.11.16"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -21,7 +21,7 @@ config-session = ["vta-sdk/config-session"]
 azure-secrets = ["vta-sdk/azure-secrets"]
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.21", features = ["session", "crypto-provider", "acl-setup"] }
+vta-sdk = { path = "../vta-sdk", version = "0.22", features = ["session", "crypto-provider", "acl-setup"] }
 # `agent-names` powers the global `--resolve-agent-names` flag; without it
 # the flag parses but can never resolve anything.
 vta-cli-common = { path = "../vta-cli-common", version = "0.10", features = [

--- a/didcomm-test/Cargo.toml
+++ b/didcomm-test/Cargo.toml
@@ -13,7 +13,7 @@ name = "didcomm-test"
 path = "src/main.rs"
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.21", features = ["didcomm", "crypto-provider"] }
+vta-sdk = { path = "../vta-sdk", version = "0.22", features = ["didcomm", "crypto-provider"] }
 affinidi-tdk = { workspace = true }
 affinidi-did-resolver-cache-sdk = { workspace = true }
 tokio = { workspace = true }

--- a/pnm-cli/CHANGELOG.md
+++ b/pnm-cli/CHANGELOG.md
@@ -2,5 +2,47 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.12.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/pnm-cli-v0.11.22...pnm-cli-v0.12.0) — 2026-08-12
+
+
+### Fixed
+
+- **provisioning**: Relay the holder's bootstrap VP as raw JSON ([#949](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/949))
+
+A relayer is usually not the holder — the air-gap onboarding flow exists
+  precisely so it isn't — so `pnm bootstrap provision-integration` forwards
+  a document some other process signed. It parsed that document into a
+  typed `BootstrapRequest` and let serde re-render it on the way out, so
+  the maintainer verified bytes the holder never signed. Both transports,
+  every relayed request.
+
+  Same defect as #946 one layer up, and with the same trigger: #917 moved
+  `ask.type` to the 0.2 camelCase tag, so a holder on vta-sdk < 0.21.11
+  (did-hosting `VTI-Cypress-RC-1` among them) has its own valid signature
+  rewritten in transit and rejected as a forgery at the far end. #946 fixed
+  the two maintainer-side surfaces that re-serialised; this is the client
+  side of the same rule, and the two together close the flow.
+
+  `ProvisionIntegrationRequest.request` and `provision_integration_didcomm`
+  now take `serde_json::Value`. **Breaking** for anything constructing that
+  struct. Callers that signed the VP themselves — every SDK runner — go
+  through the new `BootstrapRequest::to_signed_wire_value`, where serde
+  output and signed bytes are the same document by construction; pnm keeps
+  a typed view purely to read `contextHint` and relays the raw JSON.
+
+  `provision_integration_didcomm`'s doc comment already promised the VP was
+  "left byte-identical either way". It now is.
+
+  The existing relay tests could not have caught this: they assert the body
+  carries `serde_json::to_value(&vp)`, which is the SDK's rendering
+  compared against itself and true however badly the relayer mangles a
+  foreign document. The new test starts from a VP this crate did not
+  render, relays it under both spec versions, and requires it to arrive
+  byte-for-byte and still verify. It also asserts the fixture actually
+  diverges from this crate's serde output, so it fails loudly rather than
+  going quietly vacuous if the casings ever converge.
+
+
+
 ## [0.11.22](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/pnm-cli-v0.11.21...pnm-cli-v0.11.22) — 2026-08-12
 

--- a/pnm-cli/Cargo.toml
+++ b/pnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pnm-cli"
 description = "CLI Tool for managing a personal Verifiable Trust Agent"
-version = "0.11.22"
+version = "0.12.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -28,7 +28,7 @@ azure-secrets = ["vta-sdk/azure-secrets"]
 tsp = ["vta-sdk/tsp"]
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.21", features = ["session", "sealed-transfer", "attest-verify", "provision-integration", "crypto-provider", "acl-setup"] }
+vta-sdk = { path = "../vta-sdk", version = "0.22", features = ["session", "sealed-transfer", "attest-verify", "provision-integration", "crypto-provider", "acl-setup"] }
 affinidi-crypto = { workspace = true }
 base64 = { workspace = true }
 reqwest = { workspace = true }

--- a/vta-audit/Cargo.toml
+++ b/vta-audit/Cargo.toml
@@ -16,6 +16,6 @@ repository.workspace = true
 
 [dependencies]
 vti-common = { path = "../vti-common", version = "0.11" }
-vta-sdk = { path = "../vta-sdk", version = "0.21" }
+vta-sdk = { path = "../vta-sdk", version = "0.22" }
 tracing = { workspace = true }
 uuid = { workspace = true }

--- a/vta-backup/Cargo.toml
+++ b/vta-backup/Cargo.toml
@@ -23,7 +23,7 @@ tee = ["vta-config/tee", "dep:async-trait"]
 
 [dependencies]
 vti-common = { path = "../vti-common", version = "0.11" }
-vta-sdk = { path = "../vta-sdk", version = "0.21" }
+vta-sdk = { path = "../vta-sdk", version = "0.22" }
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.1" }
 vta-keys = { path = "../vta-keys", version = "0.2" }
 vta-config = { path = "../vta-config", version = "0.3" }

--- a/vta-cli-common/CHANGELOG.md
+++ b/vta-cli-common/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+Notable changes to the published crates. Generated from conventional commits by
+[git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.10.29](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-cli-common-v0.10.28...vta-cli-common-v0.10.29) — 2026-08-12
+
+
+### Fixed
+
+- **vault**: Send entryId on vault release, from both the CLI and the MCP bridge ([#948](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/948))
+
+* fix(vault): use entryId instead of id in vault release payload
+
+  cmd_vault_release was constructing the vault/release/0.1 Trust Task
+  payload with key `id`, which fails schema validation. The schema
+  requires `entryId` (matching VaultReleaseBody's camelCase
+  serialisation on the server side).
+
+

--- a/vta-cli-common/Cargo.toml
+++ b/vta-cli-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-cli-common"
 description = "Shared CLI command handlers and rendering helpers for VTA CLIs"
 readme = "README.md"
-version = "0.10.28"
+version = "0.10.29"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -18,7 +18,7 @@ agent-names = ["vta-sdk/agent-names"]
 [dependencies]
 # `time` for the consent loop's bounded wait between polls.
 tokio = { workspace = true, features = ["time"] }
-vta-sdk = { path = "../vta-sdk", version = "0.21", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.22", features = [
   "client",
   "sealed-transfer",
   "provision-integration",

--- a/vta-config/Cargo.toml
+++ b/vta-config/Cargo.toml
@@ -25,7 +25,7 @@ vti-common = { path = "../vti-common", version = "0.11" }
 vti-secrets = { path = "../vti-secrets", version = "0.1" }
 # Types only: the declarative approvals rule shape, so a config seed and the
 # runtime row are the same struct rather than two that must be kept in step.
-vta-sdk = { path = "../vta-sdk", version = "0.21", default-features = false }
+vta-sdk = { path = "../vta-sdk", version = "0.22", default-features = false }
 serde = { workspace = true }
 toml = { workspace = true }
 serde_ignored = { workspace = true }

--- a/vta-keys/Cargo.toml
+++ b/vta-keys/Cargo.toml
@@ -33,7 +33,7 @@ vta-keyspaces = { path = "../vta-keyspaces", version = "0.1" }
 vta-config = { path = "../vta-config", version = "0.3" }
 vti-common = { path = "../vti-common", version = "0.11" }
 vti-secrets = { path = "../vti-secrets", version = "0.1" }
-vta-sdk = { path = "../vta-sdk", version = "0.21", features = ["sealed-transfer"] }
+vta-sdk = { path = "../vta-sdk", version = "0.22", features = ["sealed-transfer"] }
 affinidi-tdk = { workspace = true }
 affinidi-crypto = { workspace = true }
 ed25519-dalek = { workspace = true }

--- a/vta-mcp/Cargo.toml
+++ b/vta-mcp/Cargo.toml
@@ -14,7 +14,7 @@ publish = false
 # accept-all on connect (`vta_sdk::acl_setup::set_client_acl_on_connection`).
 # Without it the MCP server's ACL is never configured and the mediator silently
 # drops message types it was not told to accept.
-vta-sdk = { path = "../vta-sdk", version = "0.21", features = ["client", "session", "sealed-transfer", "didcomm", "vp", "crypto-provider", "acl-setup"] }
+vta-sdk = { path = "../vta-sdk", version = "0.22", features = ["client", "session", "sealed-transfer", "didcomm", "vp", "crypto-provider", "acl-setup"] }
 rmcp = { version = "1.7", features = ["server", "transport-io", "macros", "schemars"] }
 schemars = "1"
 tokio = { workspace = true }

--- a/vta-mobile-core/Cargo.toml
+++ b/vta-mobile-core/Cargo.toml
@@ -72,7 +72,7 @@ affinidi-messaging-didcomm = "0.15"
 # lookup the approval sheets render through. Costs a DID resolution plus an
 # outbound fetch per claimed name, which is why the app resolves lazily and
 # caches; see `crate::display_name`.
-vta-sdk = { path = "../vta-sdk", version = "0.21", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.22", features = [
   "session",
   "tsp",
   "agent-names",

--- a/vta-policy/Cargo.toml
+++ b/vta-policy/Cargo.toml
@@ -20,7 +20,7 @@ vta-config = { path = "../vta-config", version = "0.3" }
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.1" }
 # Types only (default features off): the declarative approvals model + its Rego
 # synthesizer, shared with the CLI so both sides derive the same module.
-vta-sdk = { path = "../vta-sdk", version = "0.21", default-features = false }
+vta-sdk = { path = "../vta-sdk", version = "0.22", default-features = false }
 regorus = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/vta-sdk/CHANGELOG.md
+++ b/vta-sdk/CHANGELOG.md
@@ -1,0 +1,97 @@
+# Changelog
+
+Notable changes to the published crates. Generated from conventional commits by
+[git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.22.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-sdk-v0.21.21...vta-sdk-v0.22.0) — 2026-08-12
+
+
+### Fixed
+
+- **vault**: Send entryId on vault release, from both the CLI and the MCP bridge ([#948](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/948))
+
+* fix(vault): use entryId instead of id in vault release payload
+
+  cmd_vault_release was constructing the vault/release/0.1 Trust Task
+  payload with key `id`, which fails schema validation. The schema
+  requires `entryId` (matching VaultReleaseBody's camelCase
+  serialisation on the server side).
+
+- **provisioning**: Relay the holder's bootstrap VP as raw JSON ([#949](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/949))
+
+A relayer is usually not the holder — the air-gap onboarding flow exists
+  precisely so it isn't — so `pnm bootstrap provision-integration` forwards
+  a document some other process signed. It parsed that document into a
+  typed `BootstrapRequest` and let serde re-render it on the way out, so
+  the maintainer verified bytes the holder never signed. Both transports,
+  every relayed request.
+
+  Same defect as #946 one layer up, and with the same trigger: #917 moved
+  `ask.type` to the 0.2 camelCase tag, so a holder on vta-sdk < 0.21.11
+  (did-hosting `VTI-Cypress-RC-1` among them) has its own valid signature
+  rewritten in transit and rejected as a forgery at the far end. #946 fixed
+  the two maintainer-side surfaces that re-serialised; this is the client
+  side of the same rule, and the two together close the flow.
+
+  `ProvisionIntegrationRequest.request` and `provision_integration_didcomm`
+  now take `serde_json::Value`. **Breaking** for anything constructing that
+  struct. Callers that signed the VP themselves — every SDK runner — go
+  through the new `BootstrapRequest::to_signed_wire_value`, where serde
+  output and signed bytes are the same document by construction; pnm keeps
+  a typed view purely to read `contextHint` and relays the raw JSON.
+
+  `provision_integration_didcomm`'s doc comment already promised the VP was
+  "left byte-identical either way". It now is.
+
+  The existing relay tests could not have caught this: they assert the body
+  carries `serde_json::to_value(&vp)`, which is the SDK's rendering
+  compared against itself and true however badly the relayer mangles a
+  foreign document. The new test starts from a VP this crate did not
+  render, relays it under both spec versions, and requires it to arrive
+  byte-for-byte and still verify. It also asserts the fixture actually
+  diverges from this crate's serde output, so it fails loudly rather than
+  going quietly vacuous if the casings ever converge.
+
+- **provisioning**: Verify the bootstrap VP as received, not re-serialised ([#946](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/946))
+
+`vta bootstrap provision-integration` and `POST /bootstrap/provision-integration`
+  rejected a validly-signed request from any holder on vta-sdk < 0.21.11:
+
+      Error: verify BootstrapRequest: proof verification failed:
+      verify VP: signature invalid for cryptosuite EddsaJcs2022
+
+  Both called `BootstrapRequest::verify()`, which re-serialises the typed
+  struct and re-imposes this crate's casing on the bytes the holder signed.
+  #917 flipped `ask.type` to the 0.2 camelCase tag (`templateBootstrap`),
+  so a 0.1 holder's `TemplateBootstrap` — accepted on the way in by the
+  serde alias, then re-emitted camelCase on the way to the verifier — no
+  longer matched its own signature. The failure is indistinguishable from
+  a forgery, which is what makes it expensive to diagnose in the field.
+  did-hosting `VTI-Cypress-RC-1` pins vta-sdk 0.21.9 and hits this on
+  every offline provision.
+
+  #917 fixed exactly this defect at the Trust-Task handler and the DIDComm
+  handler already did the right thing; the offline CLI and the REST route
+  were the two surfaces left behind. Both now go through `verify_value`
+  over the bytes as received, which is what its own docs require of any
+  surface taking a request from elsewhere. The REST body consequently
+  carries `request` as raw JSON — deserialising it into the typed struct
+  at the extractor is what discarded the signed bytes. `deny_unknown_fields`
+  still rejects smuggled fields, one layer in, inside `verify_value`.
+
+  Tests cover the direction that was missing. #917's fixture signed the
+  0.2 casing against a 0.2 maintainer; nothing exercised an *older* holder
+  against a current one, which is the far commoner deployment shape. Added
+  a PascalCase-signed fixture at both layers, plus a test pinning that
+  `verify()` breaks such a request — so a call site reverting to it fails
+  rather than shipping.
+
+  Note for follow-up: the relayer has the same defect one layer up.
+  `ProvisionIntegrationRequest.request` is a typed `BootstrapRequest`, so
+  `pnm bootstrap provision-integration` re-serialises a request file before
+  sending it (both transports), and the maintainer never sees the signed
+  bytes. `provision_integration_didcomm`'s doc comment already claims the
+  VP is "left byte-identical either way", which the code does not honour.
+  Fixing it changes a published vta-sdk struct field, so it is deliberately
+  not bundled here.
+
+

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.21.21"
+version = "0.22.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -159,7 +159,7 @@ vta-policy = { path = "../vta-policy", version = "0.2" }
 # extracted to its own crate and re-exported as crate::{webvh_store,
 # webvh_client, webvh_auth} behind this crate's `webvh` feature.
 vta-webvh = { path = "../vta-webvh", version = "0.1", optional = true }
-vta-sdk = { path = "../vta-sdk", version = "0.21", features = ["didcomm", "sealed-transfer", "provision-integration", "openapi", "crypto-provider", "acl-setup"] }
+vta-sdk = { path = "../vta-sdk", version = "0.22", features = ["didcomm", "sealed-transfer", "provision-integration", "openapi", "crypto-provider", "acl-setup"] }
 # DID-VM-resolved WebAuthn assertion verifier — drives the new
 # `vta/auth/passkey-login-{start,finish}/1.0` trust-task handlers.
 # Distinct from `webauthn-rs` (which drives the passkey *enrolment*
@@ -352,7 +352,7 @@ vta-service = { path = ".", features = ["test-support", "config-seed"] }
 # here rather than from `vta-sdk`'s own tests — the workspace patches `vta-sdk`
 # onto itself, so `-p vta-sdk --features test-loopback` leaves the built unit
 # Fresh and the feature never reaches the compiler.
-vta-sdk = { path = "../vta-sdk", version = "0.21", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.22", features = [
   "provision-client",
   "test-loopback",
 ] }

--- a/vta-support/Cargo.toml
+++ b/vta-support/Cargo.toml
@@ -25,7 +25,7 @@ vta-config = { path = "../vta-config", version = "0.3" }
 # does not exist and the tarball fails to compile. That is what broke the
 # publish run for 0.2.0.
 vti-common = { path = "../vti-common", version = "0.11", features = ["encryption"] }
-vta-sdk = { path = "../vta-sdk", version = "0.21", features = ["sealed-transfer"] }
+vta-sdk = { path = "../vta-sdk", version = "0.22", features = ["sealed-transfer"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 chrono = { workspace = true }

--- a/vta-vault/Cargo.toml
+++ b/vta-vault/Cargo.toml
@@ -29,7 +29,7 @@ webvh = ["dep:reqwest", "vta-sdk/client"]
 [dependencies]
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.1" }
 vti-common = { path = "../vti-common", version = "0.11", features = ["encryption"] }
-vta-sdk = { path = "../vta-sdk", version = "0.21", features = ["didcomm", "sealed-transfer"] }
+vta-sdk = { path = "../vta-sdk", version = "0.22", features = ["didcomm", "sealed-transfer"] }
 affinidi-crypto = { workspace = true }
 affinidi-secrets-resolver = { workspace = true }
 affinidi-data-integrity = { workspace = true }

--- a/vta-webvh/Cargo.toml
+++ b/vta-webvh/Cargo.toml
@@ -17,7 +17,7 @@ repository.workspace = true
 [dependencies]
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.1" }
 vti-common = { path = "../vti-common", version = "0.11" }
-vta-sdk = { path = "../vta-sdk", version = "0.21" }
+vta-sdk = { path = "../vta-sdk", version = "0.22" }
 affinidi-tdk = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/vtc-client/CHANGELOG.md
+++ b/vtc-client/CHANGELOG.md
@@ -2,5 +2,8 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.3.3](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vtc-client-v0.3.2...vtc-client-v0.3.3) — 2026-08-12
+
+
 ## [0.3.2](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vtc-client-v0.3.1...vtc-client-v0.3.2) — 2026-08-12
 

--- a/vtc-client/Cargo.toml
+++ b/vtc-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vtc-client"
 description = "Client SDK for Verifiable Trust Communities (VTC) — auth, members, join, removal, policies"
-version = "0.3.2"
+version = "0.3.3"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -14,7 +14,7 @@ repository.workspace = true
 # Reuses the VTA SDK's challenge-response auth (audience-agnostic) and the
 # published join-request protocol types. `session` gates `auth_light` +
 # `protocols`.
-vta-sdk = { path = "../vta-sdk", version = "0.21", features = ["session"] }
+vta-sdk = { path = "../vta-sdk", version = "0.22", features = ["session"] }
 # `TrustTask` — the join-submit document this client signs, and the `#response`
 # envelope the VTC answers it with. Same crate `vta-sdk` builds the document
 # from, so one shape crosses the boundary.

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -134,7 +134,7 @@ vti-common = { path = "../vti-common", version = "0.11", features = [
 # factory + `*SecretStore` names are a thin facade over these). Per-backend
 # features are activated by this crate's matching features above.
 vti-secrets = { path = "../vti-secrets", version = "0.1" }
-vta-sdk = { path = "../vta-sdk", version = "0.21", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.22", features = [
   "didcomm",
   "session",
   "config-session",

--- a/vti-common/CHANGELOG.md
+++ b/vti-common/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+Notable changes to the published crates. Generated from conventional commits by
+[git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.11.38](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-common-v0.11.37...vti-common-v0.11.38) — 2026-08-12
+

--- a/vti-common/Cargo.toml
+++ b/vti-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-common"
 description = "Shared server-side infrastructure for VTA and VTC services"
 readme = "README.md"
-version = "0.11.37"
+version = "0.11.38"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -48,7 +48,7 @@ openapi = ["dep:utoipa", "dep:utoipa-axum"]
 # `default-features = false` skips the optional client transports
 # (didcomm, sealed-transfer, etc.); we only consume the type
 # definitions in the default feature set.
-vta-sdk = { path = "../vta-sdk", version = "0.21", default-features = false }
+vta-sdk = { path = "../vta-sdk", version = "0.22", default-features = false }
 async-trait = "0.1"
 # Durable OutboxStore backend (`outbox_store::VtiOutboxStore`) for the D1
 # delivery layer — the Guaranteed-send outbox, persisted via `store::Store`.

--- a/vti-secrets/CHANGELOG.md
+++ b/vti-secrets/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+Notable changes to the published crates. Generated from conventional commits by
+[git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.1.10](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-secrets-v0.1.9...vti-secrets-v0.1.10) — 2026-08-12
+

--- a/vti-secrets/Cargo.toml
+++ b/vti-secrets/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-secrets"
 description = "Pluggable secret-store backends + integration onboarding flow for Verifiable Trust Infrastructure"
 readme = "README.md"
-version = "0.1.9"
+version = "0.1.10"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -54,7 +54,7 @@ tracing = { workspace = true }
 tokio = { workspace = true }
 
 # Onboarding feature: the SDK session/auth state machine + local did:key mint.
-vta-sdk = { path = "../vta-sdk", version = "0.21", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.22", features = [
   "session",
 ], optional = true }
 ed25519-dalek = { workspace = true, optional = true }


### PR DESCRIPTION



## 🤖 New release

* `vta-sdk`: 0.21.21 -> 0.22.0 (✓ API compatible changes)
* `vta-cli-common`: 0.10.28 -> 0.10.29 (✓ API compatible changes)
* `pnm-cli`: 0.11.22 -> 0.12.0
* `vti-common`: 0.11.37 -> 0.11.38
* `cnm-cli`: 0.11.15 -> 0.11.16
* `vti-secrets`: 0.1.9 -> 0.1.10
* `vtc-client`: 0.3.2 -> 0.3.3

<details><summary><i><b>Changelog</b></i></summary><p>

## `vta-sdk`

<blockquote>

## [0.22.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-sdk-v0.21.21...vta-sdk-v0.22.0) — 2026-08-12

### Fixed

- **vault**: Send entryId on vault release, from both the CLI and the MCP bridge ([#948](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/948))

* fix(vault): use entryId instead of id in vault release payload

  cmd_vault_release was constructing the vault/release/0.1 Trust Task
  payload with key `id`, which fails schema validation. The schema
  requires `entryId` (matching VaultReleaseBody's camelCase
  serialisation on the server side).

- **provisioning**: Relay the holder's bootstrap VP as raw JSON ([#949](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/949))

A relayer is usually not the holder — the air-gap onboarding flow exists
  precisely so it isn't — so `pnm bootstrap provision-integration` forwards
  a document some other process signed. It parsed that document into a
  typed `BootstrapRequest` and let serde re-render it on the way out, so
  the maintainer verified bytes the holder never signed. Both transports,
  every relayed request.

  Same defect as #946 one layer up, and with the same trigger: #917 moved
  `ask.type` to the 0.2 camelCase tag, so a holder on vta-sdk < 0.21.11
  (did-hosting `VTI-Cypress-RC-1` among them) has its own valid signature
  rewritten in transit and rejected as a forgery at the far end. #946 fixed
  the two maintainer-side surfaces that re-serialised; this is the client
  side of the same rule, and the two together close the flow.

  `ProvisionIntegrationRequest.request` and `provision_integration_didcomm`
  now take `serde_json::Value`. **Breaking** for anything constructing that
  struct. Callers that signed the VP themselves — every SDK runner — go
  through the new `BootstrapRequest::to_signed_wire_value`, where serde
  output and signed bytes are the same document by construction; pnm keeps
  a typed view purely to read `contextHint` and relays the raw JSON.

  `provision_integration_didcomm`'s doc comment already promised the VP was
  "left byte-identical either way". It now is.

  The existing relay tests could not have caught this: they assert the body
  carries `serde_json::to_value(&vp)`, which is the SDK's rendering
  compared against itself and true however badly the relayer mangles a
  foreign document. The new test starts from a VP this crate did not
  render, relays it under both spec versions, and requires it to arrive
  byte-for-byte and still verify. It also asserts the fixture actually
  diverges from this crate's serde output, so it fails loudly rather than
  going quietly vacuous if the casings ever converge.

- **provisioning**: Verify the bootstrap VP as received, not re-serialised ([#946](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/946))

`vta bootstrap provision-integration` and `POST /bootstrap/provision-integration`
  rejected a validly-signed request from any holder on vta-sdk < 0.21.11:

      Error: verify BootstrapRequest: proof verification failed:
      verify VP: signature invalid for cryptosuite EddsaJcs2022

  Both called `BootstrapRequest::verify()`, which re-serialises the typed
  struct and re-imposes this crate's casing on the bytes the holder signed.
  #917 flipped `ask.type` to the 0.2 camelCase tag (`templateBootstrap`),
  so a 0.1 holder's `TemplateBootstrap` — accepted on the way in by the
  serde alias, then re-emitted camelCase on the way to the verifier — no
  longer matched its own signature. The failure is indistinguishable from
  a forgery, which is what makes it expensive to diagnose in the field.
  did-hosting `VTI-Cypress-RC-1` pins vta-sdk 0.21.9 and hits this on
  every offline provision.

  #917 fixed exactly this defect at the Trust-Task handler and the DIDComm
  handler already did the right thing; the offline CLI and the REST route
  were the two surfaces left behind. Both now go through `verify_value`
  over the bytes as received, which is what its own docs require of any
  surface taking a request from elsewhere. The REST body consequently
  carries `request` as raw JSON — deserialising it into the typed struct
  at the extractor is what discarded the signed bytes. `deny_unknown_fields`
  still rejects smuggled fields, one layer in, inside `verify_value`.

  Tests cover the direction that was missing. #917's fixture signed the
  0.2 casing against a 0.2 maintainer; nothing exercised an *older* holder
  against a current one, which is the far commoner deployment shape. Added
  a PascalCase-signed fixture at both layers, plus a test pinning that
  `verify()` breaks such a request — so a call site reverting to it fails
  rather than shipping.

  Note for follow-up: the relayer has the same defect one layer up.
  `ProvisionIntegrationRequest.request` is a typed `BootstrapRequest`, so
  `pnm bootstrap provision-integration` re-serialises a request file before
  sending it (both transports), and the maintainer never sees the signed
  bytes. `provision_integration_didcomm`'s doc comment already claims the
  VP is "left byte-identical either way", which the code does not honour.
  Fixing it changes a published vta-sdk struct field, so it is deliberately
  not bundled here.
</blockquote>

## `vta-cli-common`

<blockquote>

## [0.10.29](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-cli-common-v0.10.28...vta-cli-common-v0.10.29) — 2026-08-12

### Fixed

- **vault**: Send entryId on vault release, from both the CLI and the MCP bridge ([#948](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/948))

* fix(vault): use entryId instead of id in vault release payload

  cmd_vault_release was constructing the vault/release/0.1 Trust Task
  payload with key `id`, which fails schema validation. The schema
  requires `entryId` (matching VaultReleaseBody's camelCase
  serialisation on the server side).
</blockquote>

## `pnm-cli`

<blockquote>

## [0.12.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/pnm-cli-v0.11.22...pnm-cli-v0.12.0) — 2026-08-12

### Fixed

- **provisioning**: Relay the holder's bootstrap VP as raw JSON ([#949](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/949))

A relayer is usually not the holder — the air-gap onboarding flow exists
  precisely so it isn't — so `pnm bootstrap provision-integration` forwards
  a document some other process signed. It parsed that document into a
  typed `BootstrapRequest` and let serde re-render it on the way out, so
  the maintainer verified bytes the holder never signed. Both transports,
  every relayed request.

  Same defect as #946 one layer up, and with the same trigger: #917 moved
  `ask.type` to the 0.2 camelCase tag, so a holder on vta-sdk < 0.21.11
  (did-hosting `VTI-Cypress-RC-1` among them) has its own valid signature
  rewritten in transit and rejected as a forgery at the far end. #946 fixed
  the two maintainer-side surfaces that re-serialised; this is the client
  side of the same rule, and the two together close the flow.

  `ProvisionIntegrationRequest.request` and `provision_integration_didcomm`
  now take `serde_json::Value`. **Breaking** for anything constructing that
  struct. Callers that signed the VP themselves — every SDK runner — go
  through the new `BootstrapRequest::to_signed_wire_value`, where serde
  output and signed bytes are the same document by construction; pnm keeps
  a typed view purely to read `contextHint` and relays the raw JSON.

  `provision_integration_didcomm`'s doc comment already promised the VP was
  "left byte-identical either way". It now is.

  The existing relay tests could not have caught this: they assert the body
  carries `serde_json::to_value(&vp)`, which is the SDK's rendering
  compared against itself and true however badly the relayer mangles a
  foreign document. The new test starts from a VP this crate did not
  render, relays it under both spec versions, and requires it to arrive
  byte-for-byte and still verify. It also asserts the fixture actually
  diverges from this crate's serde output, so it fails loudly rather than
  going quietly vacuous if the casings ever converge.
</blockquote>






</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).