### PR TITLE
feat(vta-mcp): enable the SDK acl-setup feature so the MCP server configures its mediator ACL

### DIFF
--- a/vta-mcp/Cargo.toml
+++ b/vta-mcp/Cargo.toml
@@ -10,7 +10,11 @@ repository.workspace = true
 publish = false
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.21", features = ["client", "session", "sealed-transfer", "didcomm", "vp", "crypto-provider"] }
+# `acl-setup` makes `DIDCommSession::connect` set this client's mediator ACL to
+# accept-all on connect (`vta_sdk::acl_setup::set_client_acl_on_connection`).
+# Without it the MCP server's ACL is never configured and the mediator silently
+# drops message types it was not told to accept.
+vta-sdk = { path = "../vta-sdk", version = "0.21", features = ["client", "session", "sealed-transfer", "didcomm", "vp", "crypto-provider", "acl-setup"] }
 rmcp = { version = "1.7", features = ["server", "transport-io", "macros", "schemars"] }
 schemars = "1"
 tokio = { workspace = true }


### PR DESCRIPTION
Original work by @raghavendrram in #843, split out and rebased onto current `main`. Credited as co-author on the commit.

## What

One line: `vta-mcp` now enables the `vta-sdk` `acl-setup` feature.

## Why

`DIDCommSession::connect` calls `set_client_acl_on_connection` only under `#[cfg(feature = "acl-setup")]` (`vta-sdk/src/didcomm_session.rs:493`). `vta-mcp` did not enable it, so the MCP server never told the mediator which message types to accept. The mediator then silently drops anything outside its default ACL — which surfaces as missing replies, not an error.

No source change is needed; the feature pulls in `session` + `trust-tasks-rs`, both of which `vta-mcp` already had.

## Verification

`cargo check -p vta-mcp` clean.

## Follow-up (not in this PR)

`set_client_acl_on_connection` is called with `client_name: "pnm"` hardcoded in `didcomm_session.rs`, so the MCP server will now identify itself to the mediator as `pnm`. Worth threading through, but it is an SDK change affecting PNM too, so it does not belong here.

---
Split 1 of 3 from #843. The others: `--mediator-did` for `create-did-peer`, and the external-key import for `create-did-key`.