### PR TITLE
fix(vta-service): share one key derivation with the interactive DID preview

### DIFF
--- a/vta-service/src/did_webvh.rs
+++ b/vta-service/src/did_webvh.rs
@@ -98,20 +98,18 @@ pub async fn run_create_did_webvh(
     .map_err(|e| format!("{e}"))?;
 
     // In non-interactive mode, the operation derives keys and builds the
-    // document itself. In interactive mode, we derive a preview for the user
-    // to inspect/edit before passing it to the operation.
-    //
-    // KNOWN LIMITATION (interactive only): the preview derivation allocates
-    // its own BIP-32 path indices, and the operation allocates another pair
-    // when it derives the keys it actually stores. The document the operator
-    // sees and edits therefore carries different keys from the ones the store
-    // serves — the same mismatch this change fixes for `--url`. Fixing it
-    // means the two sides sharing one derivation, which is a larger change to
-    // `CreateDidWebvhParams` than belongs here.
-    let did_document = if interactive {
-        Some(build_interactive_did_document(&seed, &ctx.base_path, label, &config, &keys_ks).await?)
+    // document itself. In interactive mode we must render a document *first*,
+    // for the operator to inspect and edit — so the keys have to be derived
+    // out here, and then handed to the operation via `pre_derived` so it uses
+    // the same pair rather than allocating a second one. Deriving on both
+    // sides is what made the DID advertise keys the store could not sign
+    // with; `derive_entity_keys` allocates a fresh path index per call.
+    let (did_document, pre_derived) = if interactive {
+        let (doc, derived) =
+            build_interactive_did_document(&seed, &ctx.base_path, label, &config, &keys_ks).await?;
+        (Some(doc), Some(derived))
     } else {
-        None
+        (None, None)
     };
 
     // Portability (interactive prompt; non-interactive uses the prompt default).
@@ -163,6 +161,7 @@ pub async fn run_create_did_webvh(
         did_document,
         did_log: None,
         set_primary: true,
+        pre_derived,
         signing_key_id: None,
         ka_key_id: None,
         template: None,
@@ -334,15 +333,20 @@ pub async fn run_create_did_webvh(
     Ok(())
 }
 
-/// Interactive DID document builder: derives preview keys, prompts for
+/// Interactive DID document builder: derives the entity keys, prompts for
 /// service endpoints, displays the document, and offers editor access.
+///
+/// Returns the document **and the keys it was built from**. The caller must
+/// hand those keys to the operation (`CreateDidWebvhParams::pre_derived`) —
+/// letting it derive its own pair would store keys this document does not
+/// name, which is precisely the mismatch the non-interactive path had.
 async fn build_interactive_did_document(
     seed: &[u8],
     base_path: &str,
     label: &str,
     config: &AppConfig,
     keys_ks: &vti_common::store::KeyspaceHandle,
-) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
+) -> Result<(serde_json::Value, crate::keys::DerivedEntityKeys), Box<dyn std::error::Error>> {
     let derived = crate::keys::derive_entity_keys(
         seed,
         base_path,
@@ -394,7 +398,7 @@ async fn build_interactive_did_document(
         doc = edit_did_document(doc)?;
     }
 
-    Ok(doc)
+    Ok((doc, derived))
 }
 
 fn edit_did_document(
@@ -639,16 +643,13 @@ mod tests {
         );
     }
 
-    /// Stand up a config + seeded store + context, run a non-interactive
-    /// `create-did-webvh`, and return the loaded config alongside the first
-    /// `did.jsonl` log entry.
-    ///
-    /// `mediator_did` adds a `[messaging]` section — the switch that decides
-    /// whether the minted DID advertises a DIDComm service.
-    async fn run_non_interactive_create(
+    /// Write a config + open a seeded store with one context, ready for a
+    /// `create-did-webvh`. `mediator_did` adds a `[messaging]` section — the
+    /// switch that decides whether the minted DID advertises DIDComm.
+    async fn setup_seeded_store(
         dir: &tempfile::TempDir,
         mediator_did: Option<&str>,
-    ) -> (AppConfig, serde_json::Value) {
+    ) -> (AppConfig, std::path::PathBuf) {
         let data_dir = dir.path().join("data");
         std::fs::create_dir_all(&data_dir).unwrap();
         let config_path = dir.path().join("config.toml");
@@ -692,6 +693,20 @@ mod tests {
         drop(contexts_ks);
         drop(store);
 
+        (config, config_path)
+    }
+
+    /// Stand up a config + seeded store + context, run a non-interactive
+    /// `create-did-webvh`, and return the loaded config alongside the first
+    /// `did.jsonl` log entry.
+    ///
+    /// `mediator_did` adds a `[messaging]` section — the switch that decides
+    /// whether the minted DID advertises a DIDComm service.
+    async fn run_non_interactive_create(
+        dir: &tempfile::TempDir,
+        mediator_did: Option<&str>,
+    ) -> (AppConfig, serde_json::Value) {
+        let (config, config_path) = setup_seeded_store(dir, mediator_did).await;
         // Create DID non-interactively with --did-log-file
         let log_path = dir.path().join("did.jsonl");
         let args = CreateDidWebvhArgs {
@@ -818,6 +833,136 @@ mod tests {
         assert!(
             endpoint.contains(MEDIATOR_DID),
             "the DIDComm service must route via the configured mediator DID, got {didcomm}"
+        );
+    }
+
+    /// A caller that renders the DID document itself must get a DID whose
+    /// stored keys are the ones its document names.
+    ///
+    /// This is the interactive path in miniature. That path cannot be driven
+    /// from a test — it blocks on `dialoguer` prompts — so this exercises the
+    /// mechanism underneath it: derive once out here (as
+    /// `build_interactive_did_document` does), build a document from those
+    /// keys, and hand both to the operation. Before `pre_derived`, the
+    /// operation ignored the caller's derivation and allocated its own path
+    /// indices, so the document advertised `n, n+1` while the store held
+    /// `n+2, n+3` — a DID that cannot sign for the keys it publishes.
+    #[tokio::test]
+    async fn caller_rendered_document_names_the_keys_the_store_holds() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let (config, _config_path) = setup_seeded_store(&dir, None).await;
+
+        let store = Store::open(&config.store).expect("open store");
+        let keys_ks = store.keyspace(crate::keyspaces::KEYS).unwrap();
+        let imported_ks = store.keyspace(crate::keyspaces::IMPORTED_SECRETS).unwrap();
+        let contexts_ks = store.keyspace(crate::keyspaces::CONTEXTS).unwrap();
+        let webvh_ks = store.keyspace(crate::keyspaces::WEBVH).unwrap();
+        let audit_ks = store.keyspace(crate::keyspaces::AUDIT).unwrap();
+        let did_templates_ks = store.keyspace(crate::keyspaces::DID_TEMPLATES).unwrap();
+        let seed_store = create_seed_store(&config).unwrap();
+
+        let ctx = crate::contexts::get_context(&contexts_ks, "test-ctx")
+            .await
+            .unwrap()
+            .expect("context");
+        let seed = crate::keys::seeds::load_seed_bytes(&keys_ks, &*seed_store, Some(0))
+            .await
+            .expect("load seed");
+
+        // Derive once, exactly as the interactive preview does, and build the
+        // document from that pair.
+        let derived = crate::keys::derive_entity_keys(
+            &seed,
+            &ctx.base_path,
+            "test signing key",
+            "test key-agreement key",
+            &keys_ks,
+        )
+        .await
+        .expect("derive");
+        let preview_signing_pub = derived.signing_pub.clone();
+        let did_document =
+            operations::did_webvh::build_did_document(&derived, &config, false, &None);
+
+        let did_resolver = DIDCacheClient::new(DIDCacheConfigBuilder::default().build())
+            .await
+            .unwrap();
+        let no_bridge: Arc<crate::didcomm_bridge::DIDCommBridge> =
+            Arc::new(crate::didcomm_bridge::DIDCommBridge::placeholder());
+        let auth_locks = operations::did_webvh::WebvhAuthLocks::new();
+        let deps = operations::did_webvh::CreateDidWebvhDeps {
+            keys_ks: &keys_ks,
+            imported_ks: &imported_ks,
+            contexts_ks: &contexts_ks,
+            webvh_ks: &webvh_ks,
+            did_templates_ks: &did_templates_ks,
+            audit_ks: &audit_ks,
+            seed_store: &*seed_store,
+            config: &config,
+            did_resolver: &did_resolver,
+            didcomm_bridge: &no_bridge,
+            auth_locks: &auth_locks,
+        };
+
+        let result = operations::did_webvh::create_did_webvh(
+            &deps,
+            &cli_super_admin(),
+            CreateDidWebvhParams {
+                context_id: "test-ctx".to_string(),
+                server_id: None,
+                url: Some("https://example.com/test".to_string()),
+                path_mode: WebvhPathMode::default(),
+                domain: None,
+                label: Some("test".to_string()),
+                portable: true,
+                add_mediator_service: false,
+                additional_services: None,
+                pre_rotation_count: 1,
+                did_document: Some(did_document),
+                did_log: None,
+                set_primary: true,
+                pre_derived: Some(derived),
+                signing_key_id: None,
+                ka_key_id: None,
+                template: None,
+                template_context: None,
+                template_vars: std::collections::HashMap::new(),
+                is_vta_identity: false,
+            },
+            "test",
+        )
+        .await
+        .expect("create_did_webvh");
+
+        // What the store will serve for `#key-0`.
+        let secret = crate::operations::keys::get_key_secret(
+            &keys_ks,
+            &imported_ks,
+            &Arc::from(create_seed_store(&config).unwrap()),
+            &audit_ks,
+            &cli_super_admin(),
+            &format!("{}#key-0", result.did),
+            "test",
+        )
+        .await
+        .expect("fetch key secret");
+        let secret_bytes =
+            multibase::decode(&secret.private_key_multibase).expect("decode secret multibase");
+        let signing_key =
+            ed25519_dalek::SigningKey::from_bytes(secret_bytes.1[2..].try_into().unwrap());
+        let store_pub_mb = multibase::encode(
+            multibase::Base::Base58Btc,
+            [
+                &[0xed, 0x01][..],
+                &signing_key.verifying_key().to_bytes()[..],
+            ]
+            .concat(),
+        );
+
+        assert_eq!(
+            store_pub_mb, preview_signing_pub,
+            "the store must hold the key the caller's document names — if this \
+             fails, the operation re-derived and allocated a second path index"
         );
     }
 

--- a/vta-service/src/operations/did_webvh/mod.rs
+++ b/vta-service/src/operations/did_webvh/mod.rs
@@ -368,6 +368,22 @@ pub struct CreateDidWebvhParams {
     pub did_log: Option<String>,
     /// Whether to set this DID as the primary DID for the context.
     pub set_primary: bool,
+    /// Entity keys the caller already derived, used instead of deriving a
+    /// fresh pair.
+    ///
+    /// Exists for one case: a caller that must render the DID document
+    /// *before* calling this function — the offline CLI shows the operator a
+    /// preview to edit. Without this, that caller derives one pair for the
+    /// document and this function derives another for the store, because
+    /// `derive_entity_keys` allocates a fresh BIP-32 path index per call.
+    /// The DID then advertises keys the VTA cannot sign with, and nothing
+    /// notices until a verifier rejects a signature.
+    ///
+    /// In-process only — there is no wire field, and there must not be: a
+    /// remote caller supplying key material would invert the rule that the
+    /// VTA is the key generator. Use `signing_key_id`/`ka_key_id` to point
+    /// at keys this VTA already holds.
+    pub pre_derived: Option<keys::DerivedEntityKeys>,
     /// Use an existing key as the signing verification method.
     pub signing_key_id: Option<String>,
     /// Use an existing key as the key-agreement verification method.
@@ -408,6 +424,8 @@ impl From<CreateDidWebvhBody> for CreateDidWebvhParams {
             pre_rotation_count: body.pre_rotation_count.unwrap_or(0),
             did_document: body.did_document,
             did_log: body.did_log,
+            // No wire field by design — see the field docs.
+            pre_derived: None,
             set_primary: body.set_primary.unwrap_or(true),
             signing_key_id: body.signing_key_id,
             ka_key_id: body.ka_key_id,
@@ -768,7 +786,25 @@ pub async fn create_did_webvh(
     let user_specified_keys = params.signing_key_id.is_some();
 
     // Load or derive entity keys
-    let (derived, active_seed_id) = if let Some(ref signing_key_id) = params.signing_key_id {
+    let (derived, active_seed_id) = if let Some(mut pre) = params.pre_derived.take() {
+        // ── Caller-derived keys ─────────────────────────────────────
+        // The caller already allocated the path indices and built its
+        // document from these keys. Deriving again here would allocate a
+        // second pair and store keys the document does not name.
+        let active_seed_id = get_active_seed_id(keys_ks)
+            .await
+            .map_err(|e| AppError::Internal(format!("{e}")))?;
+
+        // Same normalisation the derive branch applies — didwebvh-rs keys
+        // the signing secret by its did:key verification-method id.
+        let pub_mb = pre
+            .signing_secret
+            .get_public_keymultibase()
+            .map_err(|e| AppError::Internal(format!("{e}")))?;
+        pre.signing_secret.id = format!("did:key:{pub_mb}#{pub_mb}");
+
+        (pre, Some(active_seed_id))
+    } else if let Some(ref signing_key_id) = params.signing_key_id {
         // ── User-specified keys ─────────────────────────────────────
         let (mut signing_secret, signing_pub, signing_record) = load_key_as_secret(
             keys_ks,

--- a/vta-service/src/operations/did_webvh/update/mod.rs
+++ b/vta-service/src/operations/did_webvh/update/mod.rs
@@ -744,6 +744,7 @@ mod pre_rotation_e2e_tests {
                 did_document: None,
                 did_log: None,
                 set_primary: true,
+                pre_derived: None,
                 signing_key_id: None,
                 ka_key_id: None,
                 template: None,

--- a/vta-service/src/operations/provision_integration/mod.rs
+++ b/vta-service/src/operations/provision_integration/mod.rs
@@ -476,6 +476,10 @@ pub async fn provision_integration(
                 did_document: None,
                 did_log: None,
                 set_primary,
+                // Template rendering happens inside the operation, from the
+                // keys it derives — nothing out here needs the document
+                // first, so there is nothing to share.
+                pre_derived: None,
                 signing_key_id: None,
                 ka_key_id: None,
                 template: Some(template_name.clone()),

--- a/vta-service/src/setup/from_toml.rs
+++ b/vta-service/src/setup/from_toml.rs
@@ -1784,6 +1784,9 @@ async fn create_simple_webvh_did(
         did_document: advanced.did_document,
         did_log: advanced.did_log,
         set_primary: true,
+        // The wizard passes a template name, not a pre-rendered document,
+        // so the operation derives and renders in one place.
+        pre_derived: None,
         signing_key_id: advanced.signing_key_id,
         ka_key_id: advanced.ka_key_id,
         template,

--- a/vta-service/src/webvh_cli.rs
+++ b/vta-service/src/webvh_cli.rs
@@ -183,6 +183,8 @@ pub async fn run_create_did(
         did_document: None,
         did_log: None,
         set_primary: true,
+        // Online CLI: no local preview to keep in step with.
+        pre_derived: None,
         signing_key_id: None,
         ka_key_id: None,
         template: None,


### PR DESCRIPTION
`vta create-did-webvh` without `--url` still minted a DID advertising keys
the store could not sign with. #945 fixed that for `--url` by dropping the
preview; interactive cannot drop it, because the operator has to see and
edit the document before it is created.

So both sides derived. `derive_entity_keys` allocates a fresh BIP-32 path
index per call, and `create_did_webvh` derives unconditionally whenever
`signing_key_id` is `None` — before the `did_document` match, regardless of
a caller-supplied document. The preview took indices n, n+1 and built its
document from them; the operation then took n+2, n+3 and stored those. The
published DID named one key, `get_key_secret` served another, and nothing
noticed until a verifier rejected a signature.

`CreateDidWebvhParams::pre_derived` lets a caller that must render the
document first hand over the keys it rendered from, so the operation uses
that pair instead of allocating a second one. In-process only, and there
is deliberately no wire field: a remote caller supplying key material
would invert the rule that the VTA is the key generator — remote callers
point at existing keys with `signing_key_id`/`ka_key_id`. The pre-derived
branch applies the same did:key verification-method normalisation the
derive branch does, which didwebvh-rs requires.

The interactive path itself is untestable — it blocks on dialoguer — so
the test drives the mechanism underneath it: derive once, build a document
from those keys, pass both, and require the store to serve the key the
document names. Verified it fails without the fix, with the two keys
differing exactly as reported.

Signed-off-by: Glenn Gore <glenn.g@affinidi.com>


---

Finishes the other half of #945, which fixed the same bug for `--url` only.
