### PR TITLE
build(docker): add a non-TEE image and a CI job that builds it

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,9 @@ docs/
 *.md
 !README.md
 .claude/
+# CI definitions are not build inputs. Excluding them keeps an edit to a
+# workflow from invalidating the plain Dockerfile's `COPY . .` source layer.
+.github/
 # Keep enclave signing keys and Nitro runtime state out of the build context.
 # The Nitro build uses selective per-crate COPYs, but excluding these avoids
 # shipping private keys / large EIF artifacts to the Docker daemon.

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,76 @@
+name: Docker
+
+# The non-TEE `Dockerfile` is a deployment artifact, so it needs a build that
+# actually runs — an unbuilt Dockerfile rots the moment a native dependency,
+# feature name, or toolchain version moves, and the failure then lands on
+# whoever is trying to deploy.
+#
+# Path-filtered rather than run on every PR: a full release build of
+# vta-service in a container takes tens of minutes, and the container-specific
+# risks are all manifest/toolchain-shaped. Ordinary source changes are already
+# covered by the `Check` / `Test` jobs in ci.yml, which compile the same crate.
+on:
+  push:
+    branches: [main, nightly]
+    paths:
+      - "Dockerfile"
+      - ".dockerignore"
+      - "**/Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/docker.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "Dockerfile"
+      - ".dockerignore"
+      - "**/Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/docker.yml"
+
+jobs:
+  image:
+    name: Docker image
+    runs-on: ubuntu-latest
+    # A cold release build of the workspace runs ~25 min. The cap is there to
+    # kill a hang, not to bound the normal build.
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: docker/setup-buildx-action@v3
+
+      # Deliberately NO build cache — neither `type=gha` nor actions/cache.
+      # GitHub's Actions cache is a single ~10 GB allowance shared across the
+      # whole repo, and a Rust dependency layer is multiple GB. ci.yml already
+      # documents what happens when one fat cache lands in it: it evicted every
+      # other job's cache, and the jobs that then restored a foreign tree ran
+      # the runner out of disk. Path-filtering this job is the cheaper lever —
+      # it makes the build rare rather than making it fast.
+      - name: Build image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          push: false
+          load: true
+          tags: vta:ci
+
+      # Proves more than "the build exited 0": running the binary in the
+      # runtime stage exercises the dynamic linking, so a missing shared
+      # library there (libdbus-1-3, ca-certificates) fails here rather than on
+      # first deploy.
+      - name: Smoke-test the runtime image
+        run: |
+          docker run --rm vta:ci --version
+          docker run --rm vta:ci --help > /dev/null
+
+      # The image ships a non-root user; a regression to root is worth
+      # catching, since the runtime stage is easy to edit without noticing.
+      - name: Assert the image does not run as root
+        run: |
+          uid="$(docker run --rm --entrypoint id vta:ci -u)"
+          if [ "$uid" = "0" ]; then
+            echo "::error::image runs as root (uid 0); expected the unprivileged 'vta' user"
+            exit 1
+          fi
+          echo "image runs as uid $uid"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,116 @@
+# =============================================================================
+# VTA Non-TEE Image
+# =============================================================================
+#
+# Plain Docker image running the ordinary `vta` server binary on a normal host
+# (EC2, ECS, Kubernetes, a laptop). Use `Dockerfile.nitro` for AWS Nitro
+# Enclave / TEE deployments — that image has a different feature set, a
+# vsock-proxy entrypoint, and is consumed by `nitro-cli build-enclave`.
+#
+# Usage:
+#   docker build -t vta .
+#   docker build --build-arg FEATURES="setup,rest,didcomm" -t vta .
+#
+# CACHING: dependency builds are cached with cargo-chef. `prepare` distils the
+# workspace into a recipe.json describing only the dependency graph; `cook`
+# builds that. The expensive dependency layer is therefore keyed on the recipe
+# and is reused until a dependency actually changes — a source edit does not
+# invalidate it.
+#
+# Deliberately NOT the manifests-plus-dummy-sources trick `Dockerfile.nitro`
+# uses. That approach hand-maintains the list of workspace members four times
+# over (COPY manifests, mkdir, dummy sources, COPY sources) and warms the cache
+# under `|| true`, so forgetting to add a new crate is silent: you get a
+# full-from-scratch dependency rebuild on every build and no error saying why.
+# cargo-chef derives the member list from the workspace itself, so adding a
+# crate needs no edit here.
+# =============================================================================
+
+ARG RUST_VERSION=1.95
+# Pinned: cargo-chef's recipe format is tied to its version, and an unpinned
+# `cargo install` would silently change the cache key across builds.
+ARG CARGO_CHEF_VERSION=0.1.78
+
+# -----------------------------------------------------------------------------
+# Stage 1: toolchain + cargo-chef (shared base for planner and builder)
+# -----------------------------------------------------------------------------
+FROM rust:${RUST_VERSION}-bookworm AS chef
+ARG CARGO_CHEF_VERSION
+RUN cargo install cargo-chef --locked --version ${CARGO_CHEF_VERSION}
+WORKDIR /build
+
+# -----------------------------------------------------------------------------
+# Stage 2: plan — reduce the workspace to its dependency graph
+# -----------------------------------------------------------------------------
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+# -----------------------------------------------------------------------------
+# Stage 3: build the VTA server binary
+# -----------------------------------------------------------------------------
+FROM chef AS builder
+
+# Build deps for the non-TEE feature set. libdbus-1-dev is required because
+# affinidi-tdk-common (pulled transitively via didcomm/vta-sdk) depends on
+# dbus-secret-service-keyring-store, which links libdbus at build time. That is
+# independent of VTA's own vti-secrets keyring backend, which is feature-gated
+# and off here.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        clang \
+        cmake \
+        libdbus-1-dev \
+        libssl-dev \
+        pkg-config && \
+    rm -rf /var/lib/apt/lists/*
+
+# Feature flags for the plain non-TEE image. Override with:
+#   docker build --build-arg FEATURES="setup,rest,didcomm,aws-secrets" .
+# `keyring` is intentionally excluded — containers have no desktop
+# secret-service session. `aws-secrets` reads the instance/task role via IMDS.
+ARG FEATURES="setup,rest,didcomm,cli-synthesis,aws-secrets,webvh"
+
+# Dependency layer. No `--locked` here: cook builds from the recipe rather than
+# the real manifests, and the flag buys nothing for a warm-up whose output is
+# discarded. The real build below is locked, which is where it matters.
+COPY --from=planner /build/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json \
+        --package vta-service \
+        --no-default-features --features ${FEATURES}
+
+# Source layer. `--locked` so the image is built against the committed
+# Cargo.lock and cannot silently resolve a different dependency set than CI
+# tested.
+COPY . .
+RUN cargo build --release --locked --package vta-service \
+        --no-default-features --features ${FEATURES}
+
+# -----------------------------------------------------------------------------
+# Stage 4: runtime
+# -----------------------------------------------------------------------------
+FROM debian:bookworm-slim AS runtime
+
+# libdbus-1-3 is the runtime half of the libdbus-1-dev link above; wget backs
+# the HEALTHCHECK.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        libdbus-1-3 \
+        wget && \
+    rm -rf /var/lib/apt/lists/* && \
+    useradd --uid 1000 --system --home-dir /var/lib/vta --create-home --shell /usr/sbin/nologin vta && \
+    mkdir -p /var/lib/vta /etc/vta && \
+    chown -R vta:vta /var/lib/vta /etc/vta
+
+COPY --from=builder /build/target/release/vta /usr/local/bin/vta
+
+USER vta
+EXPOSE 8100
+VOLUME ["/var/lib/vta"]
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
+    CMD wget -qO- http://localhost:8100/health || exit 1
+
+ENTRYPOINT ["/usr/local/bin/vta"]
+CMD ["--config", "/etc/vta/config.toml"]


### PR DESCRIPTION
Original work by @raghavendrram in #843, split out, **reworked**, and rebased onto current `main`. Credited as co-author on the commit. This is the fourth and last piece; #951, #952 and #953 are the others.

## What

- A plain `Dockerfile` for the ordinary `vta` server binary on a normal host (EC2, ECS, Kubernetes, a laptop). `Dockerfile.nitro` stays the path for Nitro Enclave / TEE deployments.
- A `Docker` workflow that actually builds it.

## Why CI matters here

An unbuilt Dockerfile rots the moment a native dependency, feature name, or toolchain version moves — and the failure lands on whoever is next trying to deploy. Nothing in `.github/workflows/` builds a container today, so this is the first.

Beyond compiling, the job:
- **smoke-tests the runtime image** — `vta --version` inside the container exercises dynamic linking, so a shared library missing from the slim runtime stage (`libdbus-1-3`, `ca-certificates`) fails in CI rather than on first deploy;
- **asserts the image is not root**, since the runtime stage is easy to edit without noticing.

## Changes from #843

**cargo-chef instead of manifests-plus-dummy-sources.** The original copied the workspace member list **four times** in one file (COPY manifests, mkdir, dummy sources, COPY sources) and warmed the cache under `2>/dev/null || true`. That combination is silent on failure: omit a newly added crate and every build rebuilds all dependencies from scratch with nothing saying why. `Dockerfile.nitro` has the same shape, so keeping it would have meant eight hand-maintained copies of the member list. cargo-chef derives the graph from the workspace — **adding a crate needs no edit here**, and there is no `|| true`.

I checked the original list, for the record: it matched all 26 workspace members exactly, no drift. The objection is the maintenance shape, not its current state.

**`--locked`** on the real build, so the image cannot silently resolve a dependency set other than the one CI tested. (Not on `chef cook`, whose output is a discarded warm-up built from the recipe rather than the manifests.)

**Pinned `cargo-chef` version** — the recipe format is tied to it, so an unpinned `cargo install` would silently move the cache key.

## Two deliberate cost decisions

**Path-filtered**, to `Dockerfile` / `.dockerignore` / `**/Cargo.toml` / `Cargo.lock` / its own workflow. A cold release build is tens of minutes, and the container-specific risks are manifest- and toolchain-shaped; ordinary source changes already compile the same crate in ci.yml's `Check` and `Test`.

**No build cache at all**, neither `type=gha` nor `actions/cache`. GitHub's Actions cache is one ~10 GB allowance shared across the repo, and a Rust dependency layer is several GB. ci.yml already documents what happened when one fat cache landed in it: it evicted every other job's cache, and jobs that then restored a foreign tree ran the runner out of disk. Making this build *rare* is the cheaper lever than making it *fast*.

`.github/` joins `.dockerignore` so editing a workflow does not invalidate the image's source layer.

## Verification status — please read

**CI on this PR is the first real build.** My local Docker daemon was not running, so I could not build the image before pushing. The Dockerfile is a rewrite (cargo-chef), not a copy, so treat a red build as expected-and-I-will-fix rather than surprising. What I *did* verify statically:

- the workflow YAML parses, and the path filter covers the files this PR touches, so the job self-triggers here;
- `cargo-chef 0.1.78` is the current release on crates.io;
- the feature list (`setup,rest,didcomm,cli-synthesis,aws-secrets,webvh`) all still resolve in `vta-service/Cargo.toml`, and `/health` exists at `routes/mod.rs:200`;
- `.dockerignore` excludes `docs/`, and the only `include_str!` reaching into it (`setup/from_toml.rs:3138`) is inside `#[cfg(test)]`, so a release build is unaffected by that exclusion. The other `include_str!` assets (`vta-sdk/contexts`, `vta-sdk/templates`, `vta-policy/policies`) are crate-local and unignored.

## Follow-up, not in this PR

`Dockerfile.nitro` still uses the four-times-duplicated member list. Converting it to cargo-chef would be the consistent move, but enclave builds are higher-risk and deserve their own change.
