### PR TITLE
build(docker): cache the Nitro image with cargo-chef and build it in CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,20 +1,26 @@
 name: Docker
 
-# The non-TEE `Dockerfile` is a deployment artifact, so it needs a build that
-# actually runs — an unbuilt Dockerfile rots the moment a native dependency,
-# feature name, or toolchain version moves, and the failure then lands on
-# whoever is trying to deploy.
+# Both Dockerfiles are deployment artifacts, so they need a build that actually
+# runs — an unbuilt Dockerfile rots the moment a native dependency, feature
+# name, or toolchain version moves, and the failure then lands on whoever is
+# trying to deploy. The Nitro image is the sharper case: its failures surface at
+# `nitro-cli build-enclave` time or, worse, as a binary that will not start
+# inside an enclave you cannot shell into.
 #
-# Path-filtered rather than run on every PR: a full release build of
-# vta-service in a container takes tens of minutes, and the container-specific
-# risks are all manifest/toolchain-shaped. Ordinary source changes are already
-# covered by the `Check` / `Test` jobs in ci.yml, which compile the same crate.
+# Path-filtered rather than run on every PR: a cold release build in a container
+# takes tens of minutes, and the container-specific risks are all
+# manifest/toolchain-shaped. Ordinary source changes are already covered by the
+# `Check` / `Test` jobs in ci.yml, which compile the same crates.
 on:
   push:
     branches: [main, nightly]
+    # Duplicated below rather than shared via a YAML anchor: the Actions
+    # workflow parser does not support anchors/aliases.
     paths:
       - "Dockerfile"
+      - "Dockerfile.nitro"
       - ".dockerignore"
+      - "deploy/nitro/**"
       - "**/Cargo.toml"
       - "Cargo.lock"
       - ".github/workflows/docker.yml"
@@ -22,18 +28,42 @@ on:
     branches: [main]
     paths:
       - "Dockerfile"
+      - "Dockerfile.nitro"
       - ".dockerignore"
+      - "deploy/nitro/**"
       - "**/Cargo.toml"
       - "Cargo.lock"
       - ".github/workflows/docker.yml"
 
 jobs:
   image:
-    name: Docker image
+    name: Docker image (${{ matrix.name }})
     runs-on: ubuntu-latest
-    # A cold release build of the workspace runs ~25 min. The cap is there to
-    # kill a hang, not to bound the normal build.
-    timeout-minutes: 60
+    # A cold release build of the workspace runs ~15 min for the non-TEE image;
+    # the enclave build pulls the whole AWS SDK / TEE stack on top. The cap is
+    # there to kill a hang, not to bound the normal build.
+    timeout-minutes: 90
+    strategy:
+      # Report both images independently — knowing only the enclave build broke
+      # is most of the diagnosis.
+      fail-fast: false
+      matrix:
+        include:
+          - name: non-TEE
+            file: Dockerfile
+            tag: vta:ci
+            # `vta` declares `version` in its clap command; `vta-enclave` does
+            # not, so only this one can be smoke-tested with --version.
+            binary: /usr/local/bin/vta
+            expect_non_root: true
+          - name: nitro
+            file: Dockerfile.nitro
+            tag: vta-nitro:ci
+            binary: /usr/local/bin/vta-enclave
+            # The enclave entrypoint needs root for `ip link set lo up` and the
+            # socat vsock proxies; Nitro provides hardware isolation instead of
+            # a user boundary. Asserting non-root here would be wrong.
+            expect_non_root: false
     steps:
       - uses: actions/checkout@v6
 
@@ -50,25 +80,29 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          file: Dockerfile
+          file: ${{ matrix.file }}
           push: false
           load: true
-          tags: vta:ci
+          tags: ${{ matrix.tag }}
 
-      # Proves more than "the build exited 0": running the binary in the
-      # runtime stage exercises the dynamic linking, so a missing shared
-      # library there (libdbus-1-3, ca-certificates) fails here rather than on
-      # first deploy.
+      # Proves more than "the build exited 0": running the binary in the runtime
+      # stage exercises dynamic linking. For the non-TEE image that covers
+      # libdbus-1-3 / ca-certificates in debian-slim. For the enclave image it
+      # covers the far more fragile glibc-on-Alpine path — gcompat plus the
+      # LD_PRELOAD'd __res_init stub — which otherwise fails first inside an
+      # enclave with no shell.
+      #
+      # --entrypoint is required for the Nitro image, whose ENTRYPOINT is the
+      # vsock-proxy setup script rather than the binary.
       - name: Smoke-test the runtime image
         run: |
-          docker run --rm vta:ci --version
-          docker run --rm vta:ci --help > /dev/null
+          docker run --rm --entrypoint ${{ matrix.binary }} ${{ matrix.tag }} --help > /dev/null
+          echo "binary starts and links cleanly"
 
-      # The image ships a non-root user; a regression to root is worth
-      # catching, since the runtime stage is easy to edit without noticing.
       - name: Assert the image does not run as root
+        if: matrix.expect_non_root
         run: |
-          uid="$(docker run --rm --entrypoint id vta:ci -u)"
+          uid="$(docker run --rm --entrypoint id ${{ matrix.tag }} -u)"
           if [ "$uid" = "0" ]; then
             echo "::error::image runs as root (uid 0); expected the unprivileged 'vta' user"
             exit 1

--- a/Dockerfile.nitro
+++ b/Dockerfile.nitro
@@ -13,109 +13,61 @@
 # starts socat-based vsock proxies inside the enclave to bridge TCP<->vsock.
 # The parent EC2 instance runs parent-proxy.sh to bridge vsock<->internet.
 #
-# CACHING NOTE: config.toml is copied ONLY in Stage 2 (runtime), so editing
-# deploy/nitro/config.toml re-layers just the tiny Alpine stage and does NOT
-# invalidate the Rust build. Stage 1 copies the workspace crates explicitly
-# (never `COPY . .`) so deploy/ never enters the compile layer, and the
-# manifest list below covers ALL workspace members so the dependency-cache
-# warm-up build actually succeeds.
+# CACHING, two separate mechanisms — both load-bearing:
+#
+#  1. Dependencies are cached with cargo-chef. `prepare` distils the workspace
+#     into a recipe.json of just the dependency graph; `cook` builds that. The
+#     expensive layer is keyed on the recipe, so it survives every source edit
+#     and is rebuilt only when a dependency actually moves. This replaces the
+#     older manifests-plus-dummy-sources trick, which hand-maintained the
+#     workspace member list three times over — including one copy that had to
+#     get each crate's target kind right (bin vs lib vs both) — and warmed the
+#     cache under `|| true`, so getting it wrong was silent: you got a
+#     full-from-scratch dependency rebuild on every build with nothing saying
+#     why. Adding a crate to the workspace no longer requires an edit there.
+#
+#  2. config.toml is copied ONLY in Stage 3 (runtime), so editing
+#     deploy/nitro/config.toml re-layers just the tiny Alpine stage and does
+#     NOT invalidate the Rust build. This is why Stage 2 still copies the
+#     workspace crates explicitly instead of `COPY . .` — that one list is
+#     deliberate, and the reason it cannot be dropped. (`COPY --exclude=deploy`
+#     would express it directly, but needs Dockerfile syntax 1.19, i.e. pulling
+#     a frontend image from Docker Hub at build time. Not worth a new network
+#     dependency and a new variable in layer construction for an image whose
+#     PCR measurements are attestation-critical.)
+#     The planner in Stage 1 may `COPY . .` freely: deploy/ does not affect
+#     recipe.json, so the byte-identical recipe keeps Stage 2's cook layer warm.
 # =============================================================================
 
+ARG RUST_VERSION=1.95
+# Pinned: cargo-chef's recipe format is tied to its version, and an unpinned
+# `cargo install` would silently change the dependency-cache key across builds.
+ARG CARGO_CHEF_VERSION=0.1.78
+
 # ---------------------------------------------------------------------------
-# Stage 1: Build the VTA binary
+# Stage 0: toolchain + cargo-chef (shared base for planner and builder)
 # ---------------------------------------------------------------------------
-FROM rust:1.95-bookworm AS builder
+FROM rust:${RUST_VERSION}-bookworm AS chef
+ARG CARGO_CHEF_VERSION
+RUN cargo install cargo-chef --locked --version ${CARGO_CHEF_VERSION}
+WORKDIR /build
+
+# ---------------------------------------------------------------------------
+# Stage 1: plan — reduce the workspace to its dependency graph
+# ---------------------------------------------------------------------------
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+# ---------------------------------------------------------------------------
+# Stage 2: Build the VTA enclave binary
+# ---------------------------------------------------------------------------
+FROM chef AS builder
 
 # Install build dependencies (dbus-1 is required by the keyring crate's build script)
 RUN apt-get update && \
     apt-get install -y --no-install-recommends libdbus-1-dev pkg-config && \
     rm -rf /var/lib/apt/lists/*
-
-WORKDIR /build
-
-# Cache dependency builds: copy manifests first, create dummy sources, build deps.
-# This must list EVERY workspace member from the root Cargo.toml [workspace].members
-# or `cargo build` fails workspace resolution (and the `|| true` below silently
-# swallows it, giving you a full-from-scratch dep rebuild every time).
-COPY Cargo.toml Cargo.lock ./
-COPY cnm-cli/Cargo.toml cnm-cli/Cargo.toml
-COPY didcomm-test/Cargo.toml didcomm-test/Cargo.toml
-COPY pnm-cli/Cargo.toml pnm-cli/Cargo.toml
-COPY tests/e2e/Cargo.toml tests/e2e/Cargo.toml
-COPY vta-cli-common/Cargo.toml vta-cli-common/Cargo.toml
-COPY vta-config/Cargo.toml vta-config/Cargo.toml
-COPY vta-keyspaces/Cargo.toml vta-keyspaces/Cargo.toml
-COPY vta-audit/Cargo.toml vta-audit/Cargo.toml
-COPY vta-backup/Cargo.toml vta-backup/Cargo.toml
-COPY vta-keys/Cargo.toml vta-keys/Cargo.toml
-COPY vta-policy/Cargo.toml vta-policy/Cargo.toml
-COPY vta-mcp/Cargo.toml vta-mcp/Cargo.toml
-COPY vta-mobile-core/Cargo.toml vta-mobile-core/Cargo.toml
-COPY vta-sdk/Cargo.toml vta-sdk/Cargo.toml
-COPY vta-support/Cargo.toml vta-support/Cargo.toml
-COPY vta-tee/Cargo.toml vta-tee/Cargo.toml
-COPY vta-sweepers/Cargo.toml vta-sweepers/Cargo.toml
-COPY vta-vault/Cargo.toml vta-vault/Cargo.toml
-COPY vta-webvh/Cargo.toml vta-webvh/Cargo.toml
-COPY vta-service/Cargo.toml vta-service/Cargo.toml
-COPY vta-enclave/Cargo.toml vta-enclave/Cargo.toml
-COPY vtc-client/Cargo.toml vtc-client/Cargo.toml
-COPY vtc-service/Cargo.toml vtc-service/Cargo.toml
-COPY vti-common/Cargo.toml vti-common/Cargo.toml
-COPY vti-secrets/Cargo.toml vti-secrets/Cargo.toml
-COPY vti-webauthn/Cargo.toml vti-webauthn/Cargo.toml
-
-# Create dummy source files so cargo can resolve + dep-build the workspace.
-# Target kind (bin vs lib) must match each crate's manifest:
-#   bins  (src/main.rs):  cnm-cli, didcomm-test, pnm-cli, vta-mcp, vta-enclave
-#   libs  (src/lib.rs):   vta-cli-common, vta-config, vta-keyspaces, vta-audit,
-#                         vta-backup, vta-keys, vta-policy, vta-sdk, vta-support,
-#                         vta-tee, vta-sweepers, vta-vault, vta-webvh, vtc-client,
-#                         vti-common, vti-secrets, vti-webauthn
-#   both:                 vta-service, vtc-service
-#   lib + custom bin:     vta-mobile-core (uniffi-bindgen)
-#   stub lib:             tests/e2e (autobins=false + no src until the real
-#                         COPY below, so a stub lib.rs is needed here purely to
-#                         satisfy workspace resolution during the warm-up build)
-RUN mkdir -p \
-      cnm-cli/src didcomm-test/src pnm-cli/src tests/e2e/src \
-      vta-cli-common/src vta-config/src vta-keyspaces/src vta-audit/src \
-      vta-backup/src vta-keys/src vta-policy/src vta-mcp/src \
-      vta-mobile-core/src vta-mobile-core/src/bin \
-      vta-sdk/src vta-support/src vta-tee/src vta-sweepers/src \
-      vta-vault/src vta-webvh/src \
-      vta-service/src vta-enclave/src \
-      vtc-client/src vtc-service/src \
-      vti-common/src vti-secrets/src vti-webauthn/src && \
-    echo "fn main() {}"       > cnm-cli/src/main.rs && \
-    echo "fn main() {}"       > didcomm-test/src/main.rs && \
-    echo "fn main() {}"       > pnm-cli/src/main.rs && \
-    echo "pub fn dummy() {}"  > tests/e2e/src/lib.rs && \
-    echo "fn main() {}"       > vta-mcp/src/main.rs && \
-    echo "fn main() {}"       > vta-enclave/src/main.rs && \
-    echo "pub fn dummy() {}"  > vta-cli-common/src/lib.rs && \
-    echo "pub fn dummy() {}"  > vta-config/src/lib.rs && \
-    echo "pub fn dummy() {}"  > vta-keyspaces/src/lib.rs && \
-    echo "pub fn dummy() {}"  > vta-audit/src/lib.rs && \
-    echo "pub fn dummy() {}"  > vta-backup/src/lib.rs && \
-    echo "pub fn dummy() {}"  > vta-keys/src/lib.rs && \
-    echo "pub fn dummy() {}"  > vta-policy/src/lib.rs && \
-    echo "pub fn dummy() {}"  > vta-sdk/src/lib.rs && \
-    echo "pub fn dummy() {}"  > vta-support/src/lib.rs && \
-    echo "pub fn dummy() {}"  > vta-tee/src/lib.rs && \
-    echo "pub fn dummy() {}"  > vta-sweepers/src/lib.rs && \
-    echo "pub fn dummy() {}"  > vta-vault/src/lib.rs && \
-    echo "pub fn dummy() {}"  > vta-webvh/src/lib.rs && \
-    echo "pub fn dummy() {}"  > vtc-client/src/lib.rs && \
-    echo "pub fn dummy() {}"  > vti-common/src/lib.rs && \
-    echo "pub fn dummy() {}"  > vti-secrets/src/lib.rs && \
-    echo "pub fn dummy() {}"  > vti-webauthn/src/lib.rs && \
-    echo "pub fn dummy() {}"  > vta-service/src/lib.rs && \
-    echo "fn main() {}"       > vta-service/src/main.rs && \
-    echo "pub fn dummy() {}"  > vtc-service/src/lib.rs && \
-    echo "fn main() {}"       > vtc-service/src/main.rs && \
-    echo "pub fn dummy() {}"  > vta-mobile-core/src/lib.rs && \
-    echo "fn main() {}"       > vta-mobile-core/src/bin/uniffi-bindgen.rs
 
 # Feature flags for the VTA enclave build.
 # Override with: docker build --build-arg FEATURES="didcomm,vsock-store" ...
@@ -130,15 +82,21 @@ RUN mkdir -p \
 # or aws-secrets features.
 ARG FEATURES="rest,didcomm,vsock-store,vsock-log"
 
-# Build dependencies only (cached unless Cargo.toml, Cargo.lock or features change)
-RUN cargo build --release --package vta-enclave \
-    --no-default-features --features ${FEATURES} \
-    2>/dev/null || true
+# Dependency layer. No `--locked` here: cook builds from the recipe rather than
+# the real manifests, and the flag buys nothing for a warm-up whose output is
+# discarded. The real build below is locked, which is where it matters.
+COPY --from=planner /build/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json \
+        --package vta-enclave \
+        --no-default-features --features ${FEATURES}
 
-# Copy actual source code — every workspace member EXCEPT deploy/ (whose
-# config.toml is baked later in Stage 2). Never use `COPY . .` here: that would
-# pull deploy/nitro/config.toml into this layer and make every config edit
-# trigger a full Rust recompile.
+# Real sources — every workspace member EXCEPT deploy/, whose config.toml is
+# baked in Stage 3. See the CACHING note at the top: `COPY . .` here would pull
+# deploy/nitro/config.toml into this layer and make every config edit trigger a
+# Rust rebuild. A member missing from this list keeps cargo-chef's skeleton
+# stub instead of its real source, which fails the build below rather than
+# silently producing a broken binary.
+COPY Cargo.toml Cargo.lock ./
 COPY cnm-cli/ cnm-cli/
 COPY didcomm-test/ didcomm-test/
 COPY pnm-cli/ pnm-cli/
@@ -166,18 +124,10 @@ COPY vti-common/ vti-common/
 COPY vti-secrets/ vti-secrets/
 COPY vti-webauthn/ vti-webauthn/
 
-# Touch source files to invalidate the dummy build cache so the real crates
-# (not the dummy stubs) get compiled.
-RUN find cnm-cli didcomm-test pnm-cli tests vta-cli-common vta-config \
-        vta-keyspaces vta-audit vta-backup vta-keys vta-policy vta-mcp \
-        vta-mobile-core vta-sdk vta-support vta-tee vta-sweepers vta-vault \
-        vta-webvh vta-service vta-enclave vtc-client vtc-service \
-        vti-common vti-secrets vti-webauthn \
-        -name '*.rs' -exec touch {} +
-
-# Build the VTA enclave binary with selected feature flags
-RUN cargo build --release --package vta-enclave \
-    --no-default-features --features ${FEATURES}
+# Build the VTA enclave binary with selected feature flags. `--locked` so the
+# image cannot silently resolve a dependency set other than the one CI tested.
+RUN cargo build --release --locked --package vta-enclave \
+        --no-default-features --features ${FEATURES}
 
 # Build a tiny stub for __res_init — an obsolete glibc resolver function
 # that musl/Alpine don't provide. Returning 0 (success) is safe; modern
@@ -186,7 +136,7 @@ RUN echo 'int __res_init(void) { return 0; }' > /tmp/res_stub.c && \
     gcc -shared -nostartfiles -o /tmp/libresolv_compat.so /tmp/res_stub.c
 
 # ---------------------------------------------------------------------------
-# Stage 2: Minimal runtime image for the Nitro Enclave
+# Stage 3: Minimal runtime image for the Nitro Enclave
 # ---------------------------------------------------------------------------
 # Alpine Linux: ~7 MB base vs ~180 MB for debian:bookworm-slim.
 # Busybox provides `ip` (replacing iproute2) and `sed` natively.
@@ -207,8 +157,8 @@ COPY --from=builder /tmp/libresolv_compat.so /usr/lib/libresolv_compat.so
 ENV LD_PRELOAD=/usr/lib/libresolv_compat.so
 
 # Copy the entrypoint script and config.
-# config.toml is baked HERE (Stage 2) on purpose: editing it re-layers only
-# this tiny Alpine stage, never the Rust build in Stage 1.
+# config.toml is baked HERE (Stage 3) on purpose: editing it re-layers only
+# this tiny Alpine stage, never the Rust build in Stage 2.
 COPY deploy/nitro/enclave-entrypoint.sh /usr/local/bin/enclave-entrypoint.sh
 RUN chmod +x /usr/local/bin/enclave-entrypoint.sh
 COPY deploy/nitro/config.toml /etc/vta/config.toml


### PR DESCRIPTION
Follow-up to #955, which introduced the Docker workflow and the non-TEE image. Applies the same cleanup to the enclave image and puts it under CI. Co-authored with @raghavendrram, whose #843 started this thread.

## What

1. `Dockerfile.nitro` caches dependencies with cargo-chef instead of the manifests-plus-dummy-sources trick.
2. The `Docker` workflow becomes a matrix and builds the Nitro image too.

## Why the old caching had to go

The file hand-maintained the workspace member list **three times** — the manifest COPYs, the dummy-source block, and the `find … -exec touch` that undid it — and warmed the cache under `2>/dev/null || true`. Getting it wrong was silent: every build rebuilt all dependencies from scratch with nothing saying why.

The dummy-source block was the sharp edge. It also required knowing each crate's **target kind** — the file carried a 10-line comment classifying every member as `bin`, `lib`, `both`, or `lib + custom bin` — and there is no error when that is wrong, only a cache miss. cargo-chef derives all of it from the workspace.

**186 lines → 125**, and adding a crate no longer requires an edit.

## What deliberately did NOT change

The `deploy/` boundary. Stage 2 still copies workspace crates explicitly rather than `COPY . .`, because `config.toml` must not land in the Rust layer — editing `deploy/nitro/config.toml` has to re-layer only the tiny Alpine stage. That is now the *only* remaining list, and the comment says why it cannot go.

I did look at expressing it directly with `COPY --exclude=deploy`, which would have removed the last list. It needs Dockerfile syntax **1.19**, i.e. pulling a frontend image from Docker Hub at build time. Not worth a new build-time network dependency, or a new variable in layer construction, for an image whose **PCR measurements are attestation-critical**. Noting it in case you disagree — it is the one judgement call here.

The planner stage may `COPY . .` freely: `deploy/` does not affect `recipe.json`, so the byte-identical recipe keeps the cook layer warm.

Also new: `--locked` on the real build, so the enclave image cannot silently resolve a dependency set other than the one CI tested.

## Why CI matters more for this image than the last one

A broken non-TEE build fails in front of you. A broken enclave build surfaces at `nitro-cli build-enclave` time or, worse, as a binary that will not start inside an enclave you cannot shell into.

The smoke test runs `vta-enclave --help` in the runtime image. That is not a formality — it exercises the **glibc-on-Alpine path** the image exists to paper over: `gcompat`, plus the `LD_PRELOAD`'d `__res_init` stub the Dockerfile compiles by hand. If that ever stops working, this is where you want to find out.

Matrix details:
- `--entrypoint` is required, since the Nitro `ENTRYPOINT` is the vsock-proxy setup script rather than the binary.
- `--help` rather than `--version`: `vta-enclave`'s clap command does not declare `version`, only `vta`'s does.
- The **non-root assertion is skipped** for this image by design — the entrypoint needs root for `ip link set lo up` and socat, and Nitro supplies hardware isolation instead of a user boundary. That is asserted only for the non-TEE image.
- `fail-fast: false`, so "only the enclave build broke" is visible rather than masked.
- `deploy/nitro/**` joins the path filter, since the entrypoint and config are baked in.

## Verification

Statically checked before pushing: the workflow YAML parses and the matrix expands to the two expected entries; the source-COPY list covers **all 26 workspace members** (`tests/` covering `tests/e2e`); and the path filter includes the files this PR touches, so the job self-triggers here.

Not verified locally — no Docker daemon on this machine — so CI is again the first real build. #955's equivalent rewrite passed first time and this reuses that mechanism, but the enclave feature set is different, so it is a genuine test rather than a formality.

Note the path filter now matches `Dockerfile` too, so **both** images build on this PR — you get a regression check on #955's image for free.

## Also worth knowing

YAML anchors would have deduplicated the two identical `paths:` lists, but the Actions workflow parser does not support them; the duplication is annotated as deliberate.
