### PR TITLE
chore: pin the mediator at 0.18.12 so the vta-sdk 0.22 patch applies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,9 +332,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-mediator"
-version = "0.18.10"
+version = "0.18.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a270daf049da285cea52202013ee44fddde28b02ef2cde9b6f76564aaa88cc4"
+checksum = "d132fa1d916270b24e432004fe4fb33544b874889ee5b72078f6d178125a094e"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-common",
@@ -2922,7 +2922,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c54e03a951783e8b327515db3f2a2fd0e3bed362a96b066f341ce66ed49b4ead"
 dependencies = [
  "data-encoding",
- "syn 3.0.3",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4587,7 +4587,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -6453,7 +6453,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.43",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "thiserror 2.0.20",
  "tokio",
  "tracing",
@@ -6492,7 +6492,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.61.2",
 ]


### PR DESCRIPTION
chore: pin the mediator at 0.18.12 so the vta-sdk 0.22 patch applies

Inert on main, decisive on the release PR. Nothing here changes today's
build — it stops the next one from being blocked.

Release PR #950 bumps vta-sdk 0.21.21 -> 0.22.0. Under 0.x semver `^0.21`
excludes 0.22, so `affinidi-messaging-mediator` 0.18.10 — reached through
`vtc-service [dev-dependencies] -> affinidi-messaging-test-mediator` —
can no longer be satisfied by the workspace copy. Cargo then silently stops
applying `[patch.crates-io] vta-sdk` and reinstates the registry node the
patch exists to delete, which `lockfile self-pins` reports as PATCH BROKEN
and which no change on that branch can fix.

affinidi/affinidi-tdk-rs#702 released mediator 0.18.12 requiring
`vta-sdk = ">=0.21.0, <0.23.0"`, which admits both. Moving the pin here
rather than on the release branch is deliberate: release-plz regenerates
that branch from main on every push, and did so mid-fix, discarding a
commit made directly against it. Landing it on main means every
regenerated release PR inherits it.

On main the patch already applies (0.21.21 satisfies `^0.21`), so this is
a six-line pin move with no resolution change. Verified on the release
branch, where it does bite: `Removing vta-sdk v0.21.21`, one vta-sdk node
again, guard back to "nothing to check". Also verified that the published
mediator compiles against the patched local vta-sdk 0.22.0 —
`cargo check -p vtc-service --features didcomm-harness --tests` builds
`vta-sdk v0.22.0` (path) then `affinidi-messaging-mediator v0.18.12`
clean. That combination is not covered by CI's default-feature test run.

Lockfile only; no manifest or version field is touched.

Signed-off-by: Glenn Gore <glenn.g@affinidi.com>

