### PR TITLE
chore: drop the vta-sdk patch — the cycle it papered over is gone

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,9 +332,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-mediator"
-version = "0.18.12"
+version = "0.18.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d132fa1d916270b24e432004fe4fb33544b874889ee5b72078f6d178125a094e"
+checksum = "607115f65cb92828b4998cf0c692c14e22dfd9f4f17c3a685f27d9d16a5ebc0c"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-common",
@@ -392,7 +392,6 @@ dependencies = [
  "trust-tasks-rs",
  "url",
  "uuid",
- "vta-sdk",
 ]
 
 [[package]]
@@ -2922,7 +2921,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c54e03a951783e8b327515db3f2a2fd0e3bed362a96b066f341ce66ed49b4ead"
 dependencies = [
  "data-encoding",
- "syn 3.0.3",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4587,7 +4586,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -6453,7 +6452,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.43",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "thiserror 2.0.20",
  "tokio",
  "tracing",
@@ -6492,7 +6491,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.61.2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -372,46 +372,40 @@ needless_pass_by_value = "allow"
 too_many_arguments = "allow"
 type_complexity = "allow"
 
-# Make the workspace copy of `vta-sdk` the ONLY one in the graph.
+# There is deliberately no `[patch.crates-io]` here any more.
 #
-# A transitive dev-dependency pulls our own crate back in from crates.io —
+# One used to live at this spot, forcing the workspace copy of `vta-sdk` to be
+# the only one in the graph. A transitive dev-dependency pulled our own crate
+# back in from crates.io —
 #
 #   vtc-service [dev-dependencies]
 #     -> affinidi-messaging-test-mediator
 #       -> affinidi-messaging-mediator
 #         -> vta-sdk   (registry, NOT the workspace path copy)
 #
-# so without this, Cargo.lock carries two `vta-sdk` nodes: the path copy at the
-# local version and a registry copy pinned at whatever was current when that
-# dependency was last resolved. That second node is a standing hazard. It goes
-# stale the instant we publish, `cargo publish --locked` verifies dependents
-# against it, and a dependent therefore gets built against the PREVIOUS
-# release's source — silently, because the workspace's own path-dep build stays
-# green throughout. That is how pnm-cli 0.11.2 was verified against vta-sdk
-# 0.19.11 minutes after 0.19.12 shipped, and sat unpublished for three releases.
+# — so Cargo.lock carried two `vta-sdk` nodes, and the registry one went stale
+# the instant we published. `cargo publish --locked` verifies dependents against
+# it, so a dependent got built against the PREVIOUS release's source, silently,
+# while the workspace's own path-dep build stayed green. That is how pnm-cli
+# 0.11.2 was verified against vta-sdk 0.19.11 minutes after 0.19.12 shipped, and
+# sat unpublished for three releases.
 #
-# Refreshing the pin after each publish was the previous fix, and it can only
-# happen in the publish job (the version does not exist until then), which means
-# committing to a protected branch from CI — blocked by the org ruleset, so the
-# refresh PR could not be opened and main kept going stale. Seven releases in a
-# row ended that way.
+# The patch deleted that second node rather than chasing it — but only while the
+# workspace copy satisfied the mediator's requirement on `vta-sdk`. Under 0.x
+# semver a minor bump does not, so the patch silently stopped applying and the
+# node came back, at 0.20 (#797), 0.21 (#887) and 0.22 (#950). Each time the fix
+# was an upstream release widening a requirement, which buys one version of
+# headroom and leaves the cycle in place.
 #
-# Patching removes the second node instead of chasing it. Note the patch is
-# workspace-local: `cargo publish`'s packaged verification build does not see it
-# and resolves `vta-sdk` from the registry, picking the newest published
-# version — which, in a release run, is the one published moments earlier in the
-# same loop. So the property the self-pin was trying to guarantee now holds by
-# construction.
+# affinidi/affinidi-tdk-rs#703 removed the last hop instead. `vta-sdk` is now
+# optional in `affinidi-messaging-mediator` (0.18.13+) behind a default-on `vta`
+# feature, and `affinidi-messaging-test-mediator` already depends on that crate
+# with `default-features = false`, so the chain above no longer reaches
+# `vta-sdk` at all. Nothing pulls a registry copy in, so there is nothing to
+# patch out.
 #
-# Trade-off worth knowing: the published `affinidi-messaging-mediator` now
-# compiles against our local `vta-sdk` rather than the published one. A
-# `vta-sdk` change that breaks it surfaces here immediately instead of after a
-# release — but it is a combination that does not exist in the wild, so a
-# breaking change within `0.19.x` shows up as a confusing build failure in a
-# third-party crate.
-#
-# One entry per crate that gets pulled back in. `scripts/check-lockfile-self-pins.sh`
-# is what tells you a new one has appeared: it now passes with "nothing to
-# check", and that is the expected steady state.
-[patch.crates-io]
-vta-sdk = { path = "vta-sdk" }
+# `scripts/check-lockfile-self-pins.sh` stays. Its job is to notice a NEW
+# self-pin — some other dev-dependency chain reaching one of our crates. If it
+# ever reports one, the fix is the same choice we faced here: patch it (fast,
+# and it will break again on the next minor bump) or cut the dependency edge
+# upstream (slower, permanent).


### PR DESCRIPTION
chore: drop the vta-sdk patch — the cycle it papered over is gone

`[patch.crates-io] vta-sdk = { path = "vta-sdk" }` existed because a
transitive dev-dependency pulled our own crate back in from crates.io:

    vtc-service [dev-dependencies]
      -> affinidi-messaging-test-mediator
        -> affinidi-messaging-mediator
          -> vta-sdk   (registry, NOT the workspace path copy)

Two `vta-sdk` nodes in the lock, the registry one going stale the instant we
publish, and `cargo publish --locked` verifying dependents against it — that
is how pnm-cli 0.11.2 was verified against vta-sdk 0.19.11 minutes after
0.19.12 shipped and sat unpublished for three releases.

The patch deleted that node, but only while the workspace copy satisfied the
mediator's requirement on `vta-sdk`. Under 0.x semver a minor bump does not,
so it silently stopped applying and the node came back — at 0.20 (#797), 0.21
(#887) and again at 0.22, which blocked #950 until affinidi-tdk-rs cut a
release widening the requirement. Three incidents, three upstream releases,
each buying exactly one version of headroom.

affinidi/affinidi-tdk-rs#703 cut the last hop instead. `vta-sdk` is now
optional in `affinidi-messaging-mediator` (0.18.13+) behind a default-on `vta`
feature, and `affinidi-messaging-test-mediator` already depends on that crate
with `default-features = false, features = ["didcomm", "memory-backend"]` — so
it no longer asks for `vta`, and the chain above stops one hop short. Nothing
pulls a registry copy in, so there is nothing left to patch out.

The clinching check: Cargo.lock is **byte-identical** with and without the
`[patch]` section. It is resolving nothing, so removing it changes nothing.

Verified after removing it and re-resolving:

  - Cargo.lock holds exactly one `vta-sdk` node, the path copy at 0.22.0,
    with no `source = "registry+..."` line.
  - The locked `affinidi-messaging-mediator 0.18.13` entry does not list
    `vta-sdk` as a dependency at all.
  - `scripts/check-lockfile-self-pins.sh` reports "nothing to check" — this
    time because no workspace crate is reachable from the registry, not
    because a patch is hiding one.
  - `cargo check -p vtc-service --features didcomm-harness --tests` builds,
    which is the feature that compiles the test mediator and is not covered
    by CI's default-feature run.

The lockfile also moves `syn` and three `socket2` entries onto lower
versions. That is the mediator bump, not the patch removal — it reproduces
with the `[patch]` still in place, because 0.18.13 no longer pulls `vta-sdk`
and the constraints that forced the newer duplicates leave the unified graph
with it.

The guard stays. Its job is to notice a NEW self-pin — some other
dev-dependency chain reaching one of our crates — and that is still worth
catching. What has changed is the recommended response: patching is fast but
breaks again on the next minor bump, so prefer cutting the dependency edge
upstream when the upstream crate is ours to change.

Also drops the trade-off the patch carried: the published
`affinidi-messaging-mediator` no longer compiles against our local `vta-sdk`,
so a breaking `vta-sdk` change can no longer surface as a confusing build
failure inside a third-party crate.

Signed-off-by: Glenn Gore <glenn.g@affinidi.com>

