### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2400,7 +2400,7 @@ checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cnm-cli"
-version = "0.11.16"
+version = "0.11.17"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "clap",
@@ -6260,7 +6260,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "pnm-cli"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-resolver-cache-sdk",
@@ -9225,7 +9225,7 @@ dependencies = [
 
 [[package]]
 name = "vta-cli-common"
-version = "0.10.29"
+version = "0.10.30"
 dependencies = [
  "aes-gcm",
  "affinidi-crypto",
@@ -9382,7 +9382,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -9666,7 +9666,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-client"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "chrono",
  "reqwest",
@@ -9763,7 +9763,7 @@ dependencies = [
 
 [[package]]
 name = "vti-common"
-version = "0.11.38"
+version = "0.11.39"
 dependencies = [
  "aes-gcm",
  "affinidi-data-integrity",
@@ -9836,7 +9836,7 @@ dependencies = [
 
 [[package]]
 name = "vti-secrets"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "aws-config",
  "aws-sdk-secretsmanager",

--- a/cnm-cli/CHANGELOG.md
+++ b/cnm-cli/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.11.17](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/cnm-cli-v0.11.16...cnm-cli-v0.11.17) — 2026-08-12
+
+
 ## [0.11.16](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/cnm-cli-v0.11.15...cnm-cli-v0.11.16) — 2026-08-12
 
 

--- a/cnm-cli/Cargo.toml
+++ b/cnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cnm-cli"
 description = "CLI Tool for Verified Trust Agents operating in Verified Trust Communities"
-version = "0.11.16"
+version = "0.11.17"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -21,7 +21,7 @@ config-session = ["vta-sdk/config-session"]
 azure-secrets = ["vta-sdk/azure-secrets"]
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.22", features = ["session", "crypto-provider", "acl-setup"] }
+vta-sdk = { path = "../vta-sdk", version = "0.23", features = ["session", "crypto-provider", "acl-setup"] }
 # `agent-names` powers the global `--resolve-agent-names` flag; without it
 # the flag parses but can never resolve anything.
 vta-cli-common = { path = "../vta-cli-common", version = "0.10", features = [

--- a/didcomm-test/Cargo.toml
+++ b/didcomm-test/Cargo.toml
@@ -13,7 +13,7 @@ name = "didcomm-test"
 path = "src/main.rs"
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.22", features = ["didcomm", "crypto-provider"] }
+vta-sdk = { path = "../vta-sdk", version = "0.23", features = ["didcomm", "crypto-provider"] }
 affinidi-tdk = { workspace = true }
 affinidi-did-resolver-cache-sdk = { workspace = true }
 tokio = { workspace = true }

--- a/pnm-cli/CHANGELOG.md
+++ b/pnm-cli/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.12.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/pnm-cli-v0.12.0...pnm-cli-v0.12.1) — 2026-08-12
+
+
 ## [0.12.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/pnm-cli-v0.11.22...pnm-cli-v0.12.0) — 2026-08-12
 
 

--- a/pnm-cli/Cargo.toml
+++ b/pnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pnm-cli"
 description = "CLI Tool for managing a personal Verifiable Trust Agent"
-version = "0.12.0"
+version = "0.12.1"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -28,7 +28,7 @@ azure-secrets = ["vta-sdk/azure-secrets"]
 tsp = ["vta-sdk/tsp"]
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.22", features = ["session", "sealed-transfer", "attest-verify", "provision-integration", "crypto-provider", "acl-setup"] }
+vta-sdk = { path = "../vta-sdk", version = "0.23", features = ["session", "sealed-transfer", "attest-verify", "provision-integration", "crypto-provider", "acl-setup"] }
 affinidi-crypto = { workspace = true }
 base64 = { workspace = true }
 reqwest = { workspace = true }

--- a/vta-audit/Cargo.toml
+++ b/vta-audit/Cargo.toml
@@ -16,6 +16,6 @@ repository.workspace = true
 
 [dependencies]
 vti-common = { path = "../vti-common", version = "0.11" }
-vta-sdk = { path = "../vta-sdk", version = "0.22" }
+vta-sdk = { path = "../vta-sdk", version = "0.23" }
 tracing = { workspace = true }
 uuid = { workspace = true }

--- a/vta-backup/Cargo.toml
+++ b/vta-backup/Cargo.toml
@@ -23,7 +23,7 @@ tee = ["vta-config/tee", "dep:async-trait"]
 
 [dependencies]
 vti-common = { path = "../vti-common", version = "0.11" }
-vta-sdk = { path = "../vta-sdk", version = "0.22" }
+vta-sdk = { path = "../vta-sdk", version = "0.23" }
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.1" }
 vta-keys = { path = "../vta-keys", version = "0.2" }
 vta-config = { path = "../vta-config", version = "0.3" }

--- a/vta-cli-common/CHANGELOG.md
+++ b/vta-cli-common/CHANGELOG.md
@@ -2,6 +2,51 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.10.30](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-cli-common-v0.10.29...vta-cli-common-v0.10.30) — 2026-08-12
+
+
+### Added
+
+- **did-webvh**: Let a minted DID advertise TSP at the VTA's mediator ([#959](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/959))
+
+A VTA-minted DID could never advertise TSP, whatever the VTA's own config
+  said. `add_mediator_service` publishes the VTA's mediator as a
+  `DIDCommMessaging` service and nothing else, so a caller wanting `#tsp`
+  had to hand-build the service entry and pass it through
+  `additional_services` — which means knowing the mediator DID, the one
+  thing `add_mediator_service` exists so a caller does not have to know.
+  Nobody did, so every persona-shaped identity is DIDComm-only by
+  construction, and the both-ends transport rule can never resolve to TSP
+  for one. TSP could be enabled end to end and the intersection would still
+  be DIDComm.
+
+  Surfaced by OpenVTC #211, where a join failed at the mediator and the
+  applicant persona's document turned out to carry exactly one service
+  entry.
+
+  Adds `add_tsp_service` to the create-DID wire, honoured by
+  `with_tsp_service` in `did_webvh/document.rs`. The entry points at the
+  same mediator the DIDComm entry names — TSP advertises a mediator DID,
+  not a transport URL (D8) — using the fragment and type the setup path and
+  the runtime `services tsp enable` patcher already emit, so a document
+  minted here, minted at setup, or patched later are the same shape.
+
+  Two gates, neither redundant. The caller's flag is opt-in and
+  deliberately not implied by `add_mediator_service`: a DID advertising a
+  transport its holder cannot decode is unreachable over that transport,
+  and only the caller knows whether the client behind the DID reads TSP
+  frames. Ours is `[services] tsp` plus a configured mediator: a VTA whose
+  own stack does not run TSP must not mint documents claiming it does,
+  which is the failure this prevents rather than spreads. A caller-supplied
+  `TSPTransport` entry wins over the injected one — matched on the service
+  `type`, never the `#id` fragment.
+
+  Additive on the wire in both directions: `skip_serializing_if` on the
+  request and `Option` on the body, so an unset field serialises exactly as
+  before and a VTA that predates it ignores the key.
+
+
+
 ## [0.10.29](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-cli-common-v0.10.28...vta-cli-common-v0.10.29) — 2026-08-12
 
 

--- a/vta-cli-common/Cargo.toml
+++ b/vta-cli-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-cli-common"
 description = "Shared CLI command handlers and rendering helpers for VTA CLIs"
 readme = "README.md"
-version = "0.10.29"
+version = "0.10.30"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -18,7 +18,7 @@ agent-names = ["vta-sdk/agent-names"]
 [dependencies]
 # `time` for the consent loop's bounded wait between polls.
 tokio = { workspace = true, features = ["time"] }
-vta-sdk = { path = "../vta-sdk", version = "0.22", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.23", features = [
   "client",
   "sealed-transfer",
   "provision-integration",

--- a/vta-config/Cargo.toml
+++ b/vta-config/Cargo.toml
@@ -25,7 +25,7 @@ vti-common = { path = "../vti-common", version = "0.11" }
 vti-secrets = { path = "../vti-secrets", version = "0.1" }
 # Types only: the declarative approvals rule shape, so a config seed and the
 # runtime row are the same struct rather than two that must be kept in step.
-vta-sdk = { path = "../vta-sdk", version = "0.22", default-features = false }
+vta-sdk = { path = "../vta-sdk", version = "0.23", default-features = false }
 serde = { workspace = true }
 toml = { workspace = true }
 serde_ignored = { workspace = true }

--- a/vta-keys/Cargo.toml
+++ b/vta-keys/Cargo.toml
@@ -33,7 +33,7 @@ vta-keyspaces = { path = "../vta-keyspaces", version = "0.1" }
 vta-config = { path = "../vta-config", version = "0.3" }
 vti-common = { path = "../vti-common", version = "0.11" }
 vti-secrets = { path = "../vti-secrets", version = "0.1" }
-vta-sdk = { path = "../vta-sdk", version = "0.22", features = ["sealed-transfer"] }
+vta-sdk = { path = "../vta-sdk", version = "0.23", features = ["sealed-transfer"] }
 affinidi-tdk = { workspace = true }
 affinidi-crypto = { workspace = true }
 ed25519-dalek = { workspace = true }

--- a/vta-mcp/Cargo.toml
+++ b/vta-mcp/Cargo.toml
@@ -14,7 +14,7 @@ publish = false
 # accept-all on connect (`vta_sdk::acl_setup::set_client_acl_on_connection`).
 # Without it the MCP server's ACL is never configured and the mediator silently
 # drops message types it was not told to accept.
-vta-sdk = { path = "../vta-sdk", version = "0.22", features = ["client", "session", "sealed-transfer", "didcomm", "vp", "crypto-provider", "acl-setup"] }
+vta-sdk = { path = "../vta-sdk", version = "0.23", features = ["client", "session", "sealed-transfer", "didcomm", "vp", "crypto-provider", "acl-setup"] }
 rmcp = { version = "1.7", features = ["server", "transport-io", "macros", "schemars"] }
 schemars = "1"
 tokio = { workspace = true }

--- a/vta-mobile-core/Cargo.toml
+++ b/vta-mobile-core/Cargo.toml
@@ -72,7 +72,7 @@ affinidi-messaging-didcomm = "0.15"
 # lookup the approval sheets render through. Costs a DID resolution plus an
 # outbound fetch per claimed name, which is why the app resolves lazily and
 # caches; see `crate::display_name`.
-vta-sdk = { path = "../vta-sdk", version = "0.22", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.23", features = [
   "session",
   "tsp",
   "agent-names",

--- a/vta-policy/Cargo.toml
+++ b/vta-policy/Cargo.toml
@@ -20,7 +20,7 @@ vta-config = { path = "../vta-config", version = "0.3" }
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.1" }
 # Types only (default features off): the declarative approvals model + its Rego
 # synthesizer, shared with the CLI so both sides derive the same module.
-vta-sdk = { path = "../vta-sdk", version = "0.22", default-features = false }
+vta-sdk = { path = "../vta-sdk", version = "0.23", default-features = false }
 regorus = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/vta-sdk/CHANGELOG.md
+++ b/vta-sdk/CHANGELOG.md
@@ -2,6 +2,51 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.23.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-sdk-v0.22.0...vta-sdk-v0.23.0) — 2026-08-12
+
+
+### Added
+
+- **did-webvh**: Let a minted DID advertise TSP at the VTA's mediator ([#959](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/959))
+
+A VTA-minted DID could never advertise TSP, whatever the VTA's own config
+  said. `add_mediator_service` publishes the VTA's mediator as a
+  `DIDCommMessaging` service and nothing else, so a caller wanting `#tsp`
+  had to hand-build the service entry and pass it through
+  `additional_services` — which means knowing the mediator DID, the one
+  thing `add_mediator_service` exists so a caller does not have to know.
+  Nobody did, so every persona-shaped identity is DIDComm-only by
+  construction, and the both-ends transport rule can never resolve to TSP
+  for one. TSP could be enabled end to end and the intersection would still
+  be DIDComm.
+
+  Surfaced by OpenVTC #211, where a join failed at the mediator and the
+  applicant persona's document turned out to carry exactly one service
+  entry.
+
+  Adds `add_tsp_service` to the create-DID wire, honoured by
+  `with_tsp_service` in `did_webvh/document.rs`. The entry points at the
+  same mediator the DIDComm entry names — TSP advertises a mediator DID,
+  not a transport URL (D8) — using the fragment and type the setup path and
+  the runtime `services tsp enable` patcher already emit, so a document
+  minted here, minted at setup, or patched later are the same shape.
+
+  Two gates, neither redundant. The caller's flag is opt-in and
+  deliberately not implied by `add_mediator_service`: a DID advertising a
+  transport its holder cannot decode is unreachable over that transport,
+  and only the caller knows whether the client behind the DID reads TSP
+  frames. Ours is `[services] tsp` plus a configured mediator: a VTA whose
+  own stack does not run TSP must not mint documents claiming it does,
+  which is the failure this prevents rather than spreads. A caller-supplied
+  `TSPTransport` entry wins over the injected one — matched on the service
+  `type`, never the `#id` fragment.
+
+  Additive on the wire in both directions: `skip_serializing_if` on the
+  request and `Option` on the body, so an unset field serialises exactly as
+  before and a VTA that predates it ignores the key.
+
+
+
 ## [0.22.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-sdk-v0.21.21...vta-sdk-v0.22.0) — 2026-08-12
 
 

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.22.0"
+version = "0.23.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -159,7 +159,7 @@ vta-policy = { path = "../vta-policy", version = "0.2" }
 # extracted to its own crate and re-exported as crate::{webvh_store,
 # webvh_client, webvh_auth} behind this crate's `webvh` feature.
 vta-webvh = { path = "../vta-webvh", version = "0.1", optional = true }
-vta-sdk = { path = "../vta-sdk", version = "0.22", features = ["didcomm", "sealed-transfer", "provision-integration", "openapi", "crypto-provider", "acl-setup"] }
+vta-sdk = { path = "../vta-sdk", version = "0.23", features = ["didcomm", "sealed-transfer", "provision-integration", "openapi", "crypto-provider", "acl-setup"] }
 # DID-VM-resolved WebAuthn assertion verifier — drives the new
 # `vta/auth/passkey-login-{start,finish}/1.0` trust-task handlers.
 # Distinct from `webauthn-rs` (which drives the passkey *enrolment*
@@ -352,7 +352,7 @@ vta-service = { path = ".", features = ["test-support", "config-seed"] }
 # here rather than from `vta-sdk`'s own tests — the workspace patches `vta-sdk`
 # onto itself, so `-p vta-sdk --features test-loopback` leaves the built unit
 # Fresh and the feature never reaches the compiler.
-vta-sdk = { path = "../vta-sdk", version = "0.22", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.23", features = [
   "provision-client",
   "test-loopback",
 ] }

--- a/vta-support/Cargo.toml
+++ b/vta-support/Cargo.toml
@@ -25,7 +25,7 @@ vta-config = { path = "../vta-config", version = "0.3" }
 # does not exist and the tarball fails to compile. That is what broke the
 # publish run for 0.2.0.
 vti-common = { path = "../vti-common", version = "0.11", features = ["encryption"] }
-vta-sdk = { path = "../vta-sdk", version = "0.22", features = ["sealed-transfer"] }
+vta-sdk = { path = "../vta-sdk", version = "0.23", features = ["sealed-transfer"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 chrono = { workspace = true }

--- a/vta-vault/Cargo.toml
+++ b/vta-vault/Cargo.toml
@@ -29,7 +29,7 @@ webvh = ["dep:reqwest", "vta-sdk/client"]
 [dependencies]
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.1" }
 vti-common = { path = "../vti-common", version = "0.11", features = ["encryption"] }
-vta-sdk = { path = "../vta-sdk", version = "0.22", features = ["didcomm", "sealed-transfer"] }
+vta-sdk = { path = "../vta-sdk", version = "0.23", features = ["didcomm", "sealed-transfer"] }
 affinidi-crypto = { workspace = true }
 affinidi-secrets-resolver = { workspace = true }
 affinidi-data-integrity = { workspace = true }

--- a/vta-webvh/Cargo.toml
+++ b/vta-webvh/Cargo.toml
@@ -17,7 +17,7 @@ repository.workspace = true
 [dependencies]
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.1" }
 vti-common = { path = "../vti-common", version = "0.11" }
-vta-sdk = { path = "../vta-sdk", version = "0.22" }
+vta-sdk = { path = "../vta-sdk", version = "0.23" }
 affinidi-tdk = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/vtc-client/CHANGELOG.md
+++ b/vtc-client/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.3.4](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vtc-client-v0.3.3...vtc-client-v0.3.4) — 2026-08-12
+
+
 ## [0.3.3](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vtc-client-v0.3.2...vtc-client-v0.3.3) — 2026-08-12
 
 

--- a/vtc-client/Cargo.toml
+++ b/vtc-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vtc-client"
 description = "Client SDK for Verifiable Trust Communities (VTC) — auth, members, join, removal, policies"
-version = "0.3.3"
+version = "0.3.4"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -14,7 +14,7 @@ repository.workspace = true
 # Reuses the VTA SDK's challenge-response auth (audience-agnostic) and the
 # published join-request protocol types. `session` gates `auth_light` +
 # `protocols`.
-vta-sdk = { path = "../vta-sdk", version = "0.22", features = ["session"] }
+vta-sdk = { path = "../vta-sdk", version = "0.23", features = ["session"] }
 # `TrustTask` — the join-submit document this client signs, and the `#response`
 # envelope the VTC answers it with. Same crate `vta-sdk` builds the document
 # from, so one shape crosses the boundary.

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -134,7 +134,7 @@ vti-common = { path = "../vti-common", version = "0.11", features = [
 # factory + `*SecretStore` names are a thin facade over these). Per-backend
 # features are activated by this crate's matching features above.
 vti-secrets = { path = "../vti-secrets", version = "0.1" }
-vta-sdk = { path = "../vta-sdk", version = "0.22", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.23", features = [
   "didcomm",
   "session",
   "config-session",

--- a/vti-common/CHANGELOG.md
+++ b/vti-common/CHANGELOG.md
@@ -2,5 +2,8 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.11.39](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-common-v0.11.38...vti-common-v0.11.39) — 2026-08-12
+
+
 ## [0.11.38](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-common-v0.11.37...vti-common-v0.11.38) — 2026-08-12
 

--- a/vti-common/Cargo.toml
+++ b/vti-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-common"
 description = "Shared server-side infrastructure for VTA and VTC services"
 readme = "README.md"
-version = "0.11.38"
+version = "0.11.39"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -48,7 +48,7 @@ openapi = ["dep:utoipa", "dep:utoipa-axum"]
 # `default-features = false` skips the optional client transports
 # (didcomm, sealed-transfer, etc.); we only consume the type
 # definitions in the default feature set.
-vta-sdk = { path = "../vta-sdk", version = "0.22", default-features = false }
+vta-sdk = { path = "../vta-sdk", version = "0.23", default-features = false }
 async-trait = "0.1"
 # Durable OutboxStore backend (`outbox_store::VtiOutboxStore`) for the D1
 # delivery layer — the Guaranteed-send outbox, persisted via `store::Store`.

--- a/vti-secrets/CHANGELOG.md
+++ b/vti-secrets/CHANGELOG.md
@@ -2,5 +2,8 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.1.11](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-secrets-v0.1.10...vti-secrets-v0.1.11) — 2026-08-12
+
+
 ## [0.1.10](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-secrets-v0.1.9...vti-secrets-v0.1.10) — 2026-08-12
 

--- a/vti-secrets/Cargo.toml
+++ b/vti-secrets/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-secrets"
 description = "Pluggable secret-store backends + integration onboarding flow for Verifiable Trust Infrastructure"
 readme = "README.md"
-version = "0.1.10"
+version = "0.1.11"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -54,7 +54,7 @@ tracing = { workspace = true }
 tokio = { workspace = true }
 
 # Onboarding feature: the SDK session/auth state machine + local did:key mint.
-vta-sdk = { path = "../vta-sdk", version = "0.22", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.23", features = [
   "session",
 ], optional = true }
 ed25519-dalek = { workspace = true, optional = true }


### PR DESCRIPTION



## 🤖 New release

* `vta-sdk`: 0.22.0 -> 0.23.0 (⚠ API breaking changes)
* `vta-cli-common`: 0.10.29 -> 0.10.30 (✓ API compatible changes)
* `cnm-cli`: 0.11.16 -> 0.11.17
* `pnm-cli`: 0.12.0 -> 0.12.1
* `vti-common`: 0.11.38 -> 0.11.39
* `vti-secrets`: 0.1.10 -> 0.1.11
* `vtc-client`: 0.3.3 -> 0.3.4

### ⚠ `vta-sdk` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field CreateDidWebvhBody.add_tsp_service in /tmp/.tmpPkR32J/verifiable-trust-infrastructure/vta-sdk/src/protocols/did_management/create.rs:147
  field CreateDidWebvhRequest.add_tsp_service in /tmp/.tmpPkR32J/verifiable-trust-infrastructure/vta-sdk/src/client/types.rs:698
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `vta-sdk`

<blockquote>

## [0.23.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-sdk-v0.22.0...vta-sdk-v0.23.0) — 2026-08-12

### Added

- **did-webvh**: Let a minted DID advertise TSP at the VTA's mediator ([#959](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/959))

A VTA-minted DID could never advertise TSP, whatever the VTA's own config
  said. `add_mediator_service` publishes the VTA's mediator as a
  `DIDCommMessaging` service and nothing else, so a caller wanting `#tsp`
  had to hand-build the service entry and pass it through
  `additional_services` — which means knowing the mediator DID, the one
  thing `add_mediator_service` exists so a caller does not have to know.
  Nobody did, so every persona-shaped identity is DIDComm-only by
  construction, and the both-ends transport rule can never resolve to TSP
  for one. TSP could be enabled end to end and the intersection would still
  be DIDComm.

  Surfaced by OpenVTC #211, where a join failed at the mediator and the
  applicant persona's document turned out to carry exactly one service
  entry.

  Adds `add_tsp_service` to the create-DID wire, honoured by
  `with_tsp_service` in `did_webvh/document.rs`. The entry points at the
  same mediator the DIDComm entry names — TSP advertises a mediator DID,
  not a transport URL (D8) — using the fragment and type the setup path and
  the runtime `services tsp enable` patcher already emit, so a document
  minted here, minted at setup, or patched later are the same shape.

  Two gates, neither redundant. The caller's flag is opt-in and
  deliberately not implied by `add_mediator_service`: a DID advertising a
  transport its holder cannot decode is unreachable over that transport,
  and only the caller knows whether the client behind the DID reads TSP
  frames. Ours is `[services] tsp` plus a configured mediator: a VTA whose
  own stack does not run TSP must not mint documents claiming it does,
  which is the failure this prevents rather than spreads. A caller-supplied
  `TSPTransport` entry wins over the injected one — matched on the service
  `type`, never the `#id` fragment.

  Additive on the wire in both directions: `skip_serializing_if` on the
  request and `Option` on the body, so an unset field serialises exactly as
  before and a VTA that predates it ignores the key.
</blockquote>

## `vta-cli-common`

<blockquote>

## [0.10.30](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-cli-common-v0.10.29...vta-cli-common-v0.10.30) — 2026-08-12

### Added

- **did-webvh**: Let a minted DID advertise TSP at the VTA's mediator ([#959](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/959))

A VTA-minted DID could never advertise TSP, whatever the VTA's own config
  said. `add_mediator_service` publishes the VTA's mediator as a
  `DIDCommMessaging` service and nothing else, so a caller wanting `#tsp`
  had to hand-build the service entry and pass it through
  `additional_services` — which means knowing the mediator DID, the one
  thing `add_mediator_service` exists so a caller does not have to know.
  Nobody did, so every persona-shaped identity is DIDComm-only by
  construction, and the both-ends transport rule can never resolve to TSP
  for one. TSP could be enabled end to end and the intersection would still
  be DIDComm.

  Surfaced by OpenVTC #211, where a join failed at the mediator and the
  applicant persona's document turned out to carry exactly one service
  entry.

  Adds `add_tsp_service` to the create-DID wire, honoured by
  `with_tsp_service` in `did_webvh/document.rs`. The entry points at the
  same mediator the DIDComm entry names — TSP advertises a mediator DID,
  not a transport URL (D8) — using the fragment and type the setup path and
  the runtime `services tsp enable` patcher already emit, so a document
  minted here, minted at setup, or patched later are the same shape.

  Two gates, neither redundant. The caller's flag is opt-in and
  deliberately not implied by `add_mediator_service`: a DID advertising a
  transport its holder cannot decode is unreachable over that transport,
  and only the caller knows whether the client behind the DID reads TSP
  frames. Ours is `[services] tsp` plus a configured mediator: a VTA whose
  own stack does not run TSP must not mint documents claiming it does,
  which is the failure this prevents rather than spreads. A caller-supplied
  `TSPTransport` entry wins over the injected one — matched on the service
  `type`, never the `#id` fragment.

  Additive on the wire in both directions: `skip_serializing_if` on the
  request and `Option` on the body, so an unset field serialises exactly as
  before and a VTA that predates it ignores the key.
</blockquote>







</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).