### PR TITLE
ci: put the build on a diet — drop debuginfo bulk and incremental artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,35 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+  # ── Build-artifact diet ──────────────────────────────────────────────────
+  #
+  # Applies to every job below. Both settings trade away things only a human
+  # at a debugger wants, and both are set HERE rather than in a `[profile.dev]`
+  # block so a local `cargo test` is completely unaffected.
+  #
+  # `debug = "line-tables-only"` keeps what CI actually reads — a panic
+  # backtrace still names the file and line — and drops the rest of the DWARF,
+  # which is the bulk of `target/`. Full `debug = 2` is what the Test job was
+  # linking when it died: `rustc-LLVM ERROR: IO failure on output stream: No
+  # space left on device`, then `ld terminated with signal 7 [Bus error]`,
+  # while linking the `vta` test binary with the whole AWS SDK stack behind
+  # `tee`. `debug = 0` would shrink it further and is the wrong trade: a
+  # backtrace with no line numbers turns a one-line CI diagnosis into a local
+  # repro.
+  #
+  # `CARGO_INCREMENTAL=0` because incremental compilation is a bet on a NEXT
+  # build in the same tree, and CI jobs are one-shot. The `incremental/`
+  # directory is pure cost here — twice over, since `target/` is cached, so
+  # the bloat is paid again as cache upload, download, and against the repo's
+  # 10 GB cache allowance.
+  #
+  # `test` is set alongside `dev`: `cargo test` compiles the crate under test
+  # with the `test` profile and its dependencies with `dev`, so setting only
+  # one leaves half the tree at full debuginfo.
+  CARGO_INCREMENTAL: 0
+  CARGO_PROFILE_DEV_DEBUG: line-tables-only
+  CARGO_PROFILE_TEST_DEBUG: line-tables-only
+
 jobs:
   check:
     name: Check


### PR DESCRIPTION
ci: put the build on a diet — drop debuginfo bulk and incremental artifacts

The Test job has been failing on disk, and not subtly:

    rustc-LLVM ERROR: IO failure on output stream: No space left on device
    error: linking with `cc` failed: exit status: 1
    collect2: fatal error: ld terminated with signal 7 [Bus error], core dumped

It dies while linking the `vta` test binary — the biggest one in the
workspace, pulling the whole AWS SDK stack in behind `tee`. `cargo test
--workspace` builds a test binary for every crate, so the job's peak is
`target/` plus the linker's scratch, and it no longer fits.

The existing mitigation is already spent. The job reclaims ~13 GB of unused
Android / .NET / GHC toolchains and prints `df -h` after the cache restore;
that bought headroom once and workspace growth has eaten it. Reclaiming more
of the runner is a smaller and smaller lever. So this shrinks what we build
instead.

Measured on `cargo test -p vta-service --no-run` — one crate, not the
workspace, so CI's absolute saving is larger:

                        before     after
    target/             8.8 GB     5.3 GB     -40%
      debug/deps        7.0 GB     5.1 GB     -1.9 GB   (debuginfo)
      debug/incremental 1.6 GB     0          -1.6 GB   (incremental)

Two settings, both at the workflow `env:` level so every job gets them:

`CARGO_PROFILE_{DEV,TEST}_DEBUG=line-tables-only` keeps what CI actually
reads — a panic backtrace still names the file and line — and drops the rest
of the DWARF. `debug = 0` would save more and is the wrong trade: a backtrace
without line numbers turns a one-line CI diagnosis into a local repro. Both
profiles are set because `cargo test` compiles the crate under test with
`test` and its dependencies with `dev`; setting one leaves half the tree at
full debuginfo.

`CARGO_INCREMENTAL=0` because incremental compilation is a bet on a NEXT
build in the same tree, and CI jobs are one-shot. Here it is pure cost, and
paid twice: `target/` is cached, so the bloat is also upload time, download
time, and 1.6 GB of the repo's 10 GB cache allowance — the same allowance
whose exhaustion previously evicted every job's cache.

Set in the workflow rather than a `[profile.dev]` block on purpose. A profile
block would follow developers onto their machines and quietly degrade local
debugging; this is a CI-only trade.

The `Free disk space` step and the `Disk after cache restore` diagnostic both
stay. This lowers the pressure; it does not make the guard unnecessary, and
the `df -h` line is what will say so plainly if the ceiling is ever reached
again.

Signed-off-by: Glenn Gore <glenn.g@affinidi.com>

