### PR TITLE
feat(release): publish vta-service and its closure again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,8 +281,34 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: taiki-e/install-action@cargo-semver-checks
 
+      # Excludes the twelve subsystem crates. They are on crates.io only
+      # because a published crate's whole dependency closure must be published
+      # and `vta-service` is published (for OpenVTC's `MockVta` harness — see
+      # RELEASING.md). Nothing consumes their APIs directly, here or outside.
+      #
+      # The exclusions are not cosmetic: this job builds rustdoc JSON for every
+      # crate twice, current and baseline. Including them took it from ~17
+      # minutes to over 35 — on every pull request in the repo, for a signal no
+      # consumer can act on. `release-plz.toml` carries the matching
+      # `semver_check = false` so the release decides bumps the same way.
+      #
+      # `vta-service` is NOT excluded: it has a real consumer, so a silent
+      # break there reaches somebody.
       - name: Check published crates for API breaks
-        run: cargo semver-checks --workspace
+        run: |
+          cargo semver-checks --workspace \
+            --exclude vta-audit \
+            --exclude vta-backup \
+            --exclude vta-config \
+            --exclude vta-keys \
+            --exclude vta-keyspaces \
+            --exclude vta-policy \
+            --exclude vta-support \
+            --exclude vta-sweepers \
+            --exclude vta-tee \
+            --exclude vta-vault \
+            --exclude vta-webvh \
+            --exclude vti-webauthn
 
   lockfile-self-pins:
     # Sibling guard to release-guards: the version bump can be correct and the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -868,13 +868,36 @@ These are load-bearing — know they exist before adjusting nearby code.
 the Release PR that release-plz maintains; merging that PR is what publishes.
 Merging a feature PR publishes nothing. See [`RELEASING.md`](RELEASING.md).
 
-**Only 7 of 21 crates publish** — `vta-sdk`, `vti-common`, `vti-secrets`,
-`vta-cli-common`, `vtc-client`, `pnm-cli`, `cnm-cli`. The other 14 set
-`publish = false` in their own manifest: an audit in #938 found zero external
-reverse-dependencies and no sibling repo consuming them. Before adding a crate
-back to the published set, check that everything it depends on is published too
-— crates.io requires the whole closure, which is what previously forced twelve
-internal subsystem crates onto the registry behind `vta-service`.
+**20 of 26 crates publish.** The six that do not — `vtc-service`,
+`vta-enclave`, `vta-mcp`, `vta-mobile-core`, `didcomm-test`, `vti-fuzz` — set
+`publish = false` in their own manifest, each with a comment saying why.
+
+The other 20 are `vta-sdk`, `vti-common`, `vti-secrets`, `vta-cli-common`,
+`vtc-client`, `pnm-cli`, `cnm-cli` — plus `vta-service` and its closure
+(`vta-audit`, `vta-backup`, `vta-config`, `vta-keys`, `vta-keyspaces`,
+`vta-policy`, `vta-support`, `vta-sweepers`, `vta-tee`, `vta-vault`,
+`vta-webvh`, `vti-webauthn`).
+
+**`vta-service` is published for one reason and it is not its own API:**
+`openvtc-core` dev-depends on it for `test_support::MockVta`, the in-process
+VTA the OpenVTC end-to-end tests run against. That harness boots the real
+service, so no client crate can stand in for it. #938 unpublished the crate on
+the finding that no external consumer existed; the audit missed that
+dev-dependency, and unpublishing did not merely freeze the crate — it **broke**
+it. `vti-common` re-exports `vta_sdk::acl::{ActScope, ApproveScope,
+ContextDirection}` as its own public API, so any graph combining `vti-common`
+with another `vta-sdk` consumer must resolve **one** `vta-sdk`. A frozen
+`vta-service` asking for `^0.21` beside a `vti-common` on `^0.23` gives two
+nodes and `expected vti_common::acl::ApproveScope, found
+vta_sdk::acl::ApproveScope`. Publishing keeps the requirements moving together.
+
+That is also the rule in general: **a re-export makes the re-exported crate's
+version part of your public API.** Before unpublishing anything, check for
+dev-dependencies, not just normal ones.
+
+Before adding a crate to the published set, check that everything it depends on
+is published too — crates.io requires the whole closure, which is what puts the
+twelve subsystem crates on the registry behind `vta-service`.
 
 release-plz handles the dependent ripple: a breaking bump moves a crate's
 compatibility range, so every dependent's `version = "0.y"` requirement is

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -44,8 +44,9 @@ files to add and nothing to collate.
 
 ## What gets published
 
-**7 of 21 crates.** The rest are internal to this workspace and set
-`publish = false` in their own `Cargo.toml`, each with a comment saying why.
+**20 of 26 crates.** The six that stay internal set `publish = false` in their
+own `Cargo.toml`, each with a comment saying why: `vtc-service`, `vta-enclave`,
+`vta-mcp`, `vta-mobile-core`, `didcomm-test`, `vti-fuzz`.
 
 | Published | Consumed by |
 |---|---|
@@ -55,18 +56,40 @@ files to add and nothing to collate.
 | `vta-cli-common` | enm |
 | `vtc-client` | enm |
 | `pnm-cli`, `cnm-cli` | operator binaries, `cargo install` |
+| `vta-service` | **openvtc-core**, as a dev-dependency — `test_support::MockVta` |
+| the twelve subsystem crates | nothing directly; they are `vta-service`'s closure |
 
-The other 14 — both services and the twelve subsystem crates carved out of
-`vta-service` in #780–#791 — had **zero external reverse-dependencies on
-crates.io and no sibling repo depending on them**. They were published by
-inheritance from `[workspace.package]`, never by decision.
+### Why `vta-service` publishes again
 
-This matters beyond tidiness: crates.io requires every dependency of a published
-crate to be published too, so `vta-service` being published was what forced all
-twelve subsystem crates to be published as well.
+#938 unpublished it, and its eleven-plus-one closure, on the finding that
+nothing external depended on them. The audit read normal dependencies;
+`openvtc-core` depends on `vta-service` as a **dev-dependency**, for
+`test_support::MockVta` — an in-process VTA its end-to-end tests run against.
+That harness boots the real service, so no client crate can substitute for it.
+
+Unpublishing did not just freeze the crate, it broke it. `vti-common`
+re-exports `vta_sdk::acl::{ActScope, ApproveScope, ContextDirection}` as its own
+public API, so **a re-export makes the re-exported crate's version part of your
+public API**: any graph combining `vti-common` with another `vta-sdk` consumer
+must resolve one `vta-sdk`. The frozen `vta-service` 0.14.37 asks for
+`vta-sdk ^0.21`; `vti-common` has since moved to `^0.23`. A downstream
+`cargo update` resolves both and `vta-service` fails to compile with
+
+```
+expected `vti_common::acl::ApproveScope`, found `vta_sdk::acl::ApproveScope`
+```
+
+at ten call sites. Publishing keeps every requirement in the set moving
+together, which is the only thing that makes the combination resolvable.
+
+The alternatives were worse: yanking the published copies breaks OpenVTC's
+tests with nothing to replace them, and leaving them up means shipping a crate
+on the registry that cannot be built.
 
 **Adding a crate to the published set** means setting `publish` back to the
 workspace default *and* checking that everything it depends on is published.
+**Removing one** means checking dev-dependencies too, in every sibling repo —
+that is the check #938 missed.
 
 ---
 

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -25,6 +25,9 @@ changelog_config = "cliff.toml"
 # Compare each crate's public API against its published version and force a
 # compatibility-breaking bump when it actually broke — rather than trusting an
 # author to notice. This is the check the old hand-rolled flow could not make.
+#
+# On by default, and switched OFF per-crate below for the twelve subsystem
+# crates. See that block for why.
 semver_check = true
 
 # One GitHub Release per published crate, carrying that crate's changelog
@@ -38,3 +41,73 @@ pr_labels = ["release"]
 # used to need `--no-verify` here because its build.rs npm-builds an admin UI
 # and cargo rejects a build.rs that modifies the source tree — that special
 # case is gone with `publish = false` on that crate.
+
+
+# ── semver checks: on where the API has a consumer ───────────────────────────
+#
+# The twelve subsystem crates are on crates.io for one reason: crates.io
+# requires a published crate's whole dependency closure to be published, and
+# `vta-service` is published (for OpenVTC's `MockVta` harness — see
+# RELEASING.md). Nothing depends on their APIs directly, in this workspace or
+# outside it; they are reached through `vta-service`, which re-exports them.
+#
+# Checking an API nobody consumes costs real time on EVERY pull request:
+# `cargo semver-checks --workspace` builds rustdoc JSON for each crate twice,
+# current and baseline. Adding these took the job from ~17 minutes to over 35.
+# That is a tax on every PR in the repo, paid for a signal no consumer can act
+# on.
+#
+# `vta-service` itself keeps the check: it has a real consumer
+# (`openvtc-core`'s dev-dependency), so a silent break there reaches somebody.
+# So do the seven crates with external consumers, via the workspace default.
+#
+# Bump size for these falls back to conventional commits, which is what it was
+# before they were ever published. If one of them grows a direct consumer,
+# delete its entry here.
+[[package]]
+name = "vta-audit"
+semver_check = false
+
+[[package]]
+name = "vta-backup"
+semver_check = false
+
+[[package]]
+name = "vta-config"
+semver_check = false
+
+[[package]]
+name = "vta-keys"
+semver_check = false
+
+[[package]]
+name = "vta-keyspaces"
+semver_check = false
+
+[[package]]
+name = "vta-policy"
+semver_check = false
+
+[[package]]
+name = "vta-support"
+semver_check = false
+
+[[package]]
+name = "vta-sweepers"
+semver_check = false
+
+[[package]]
+name = "vta-tee"
+semver_check = false
+
+[[package]]
+name = "vta-vault"
+semver_check = false
+
+[[package]]
+name = "vta-webvh"
+semver_check = false
+
+[[package]]
+name = "vti-webauthn"
+semver_check = false

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -8,8 +8,8 @@
 # So merging a feature PR never releases anything, and a release is a reviewable
 # diff rather than a side effect. See RELEASING.md.
 #
-# WHAT GETS PUBLISHED is decided in each crate's Cargo.toml, not here: 7 crates
-# have `publish` inherited from `[workspace.package]`, and the other 14 set
+# WHAT GETS PUBLISHED is decided in each crate's Cargo.toml, not here: 20 crates
+# have `publish` inherited from `[workspace.package]`, and the other 6 set
 # `publish = false` with a comment saying why. release-plz honours that — it
 # still updates an unpublished crate's version and dependency requirements (so
 # the workspace stays coherent when a published dependency bumps), it just never

--- a/vta-audit/Cargo.toml
+++ b/vta-audit/Cargo.toml
@@ -4,11 +4,16 @@ description = "Structured audit logging for the VTA — the `audit!` tracing mac
 readme = "README.md"
 version = "0.1.2"
 edition.workspace = true
-# Internal to this workspace — consumed through path dependencies only, never
-# from crates.io. It was published by inheritance from `[workspace.package]`
-# rather than by decision; the audit in #938 found no external consumer. See
-# RELEASING.md ("What gets published").
-publish = false
+# Published, because `vta-service` is — and a crate cannot go to crates.io
+# without its whole dependency closure there too. Not published for its own
+# sake: nothing outside this workspace is expected to depend on it directly.
+#
+# #938 set `publish = false` here on the finding that no external consumer
+# existed. That was wrong by one: `openvtc-core` dev-depends on `vta-service`
+# for `test_support::MockVta`, an in-process VTA the OpenVTC end-to-end tests
+# run against. See `vta-service/Cargo.toml` for what unpublishing it actually
+# broke. See RELEASING.md ("What gets published").
+publish.workspace = true
 authors.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/vta-backup/Cargo.toml
+++ b/vta-backup/Cargo.toml
@@ -4,11 +4,16 @@ description = "VTA backup/restore subsystem — encrypted full-state export/impo
 readme = "README.md"
 version = "0.1.5"
 edition.workspace = true
-# Internal to this workspace — consumed through path dependencies only, never
-# from crates.io. It was published by inheritance from `[workspace.package]`
-# rather than by decision; the audit in #938 found no external consumer. See
-# RELEASING.md ("What gets published").
-publish = false
+# Published, because `vta-service` is — and a crate cannot go to crates.io
+# without its whole dependency closure there too. Not published for its own
+# sake: nothing outside this workspace is expected to depend on it directly.
+#
+# #938 set `publish = false` here on the finding that no external consumer
+# existed. That was wrong by one: `openvtc-core` dev-depends on `vta-service`
+# for `test_support::MockVta`, an in-process VTA the OpenVTC end-to-end tests
+# run against. See `vta-service/Cargo.toml` for what unpublishing it actually
+# broke. See RELEASING.md ("What gets published").
+publish.workspace = true
 authors.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/vta-config/Cargo.toml
+++ b/vta-config/Cargo.toml
@@ -4,11 +4,16 @@ description = "VTA configuration types — the `AppConfig` TOML shape and its su
 readme = "README.md"
 version = "0.3.3"
 edition.workspace = true
-# Internal to this workspace — consumed through path dependencies only, never
-# from crates.io. It was published by inheritance from `[workspace.package]`
-# rather than by decision; the audit in #938 found no external consumer. See
-# RELEASING.md ("What gets published").
-publish = false
+# Published, because `vta-service` is — and a crate cannot go to crates.io
+# without its whole dependency closure there too. Not published for its own
+# sake: nothing outside this workspace is expected to depend on it directly.
+#
+# #938 set `publish = false` here on the finding that no external consumer
+# existed. That was wrong by one: `openvtc-core` dev-depends on `vta-service`
+# for `test_support::MockVta`, an in-process VTA the OpenVTC end-to-end tests
+# run against. See `vta-service/Cargo.toml` for what unpublishing it actually
+# broke. See RELEASING.md ("What gets published").
+publish.workspace = true
 authors.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/vta-keys/Cargo.toml
+++ b/vta-keys/Cargo.toml
@@ -4,11 +4,16 @@ description = "VTA key management — master-seed storage, BIP-32 key derivation
 readme = "README.md"
 version = "0.2.1"
 edition.workspace = true
-# Internal to this workspace — consumed through path dependencies only, never
-# from crates.io. It was published by inheritance from `[workspace.package]`
-# rather than by decision; the audit in #938 found no external consumer. See
-# RELEASING.md ("What gets published").
-publish = false
+# Published, because `vta-service` is — and a crate cannot go to crates.io
+# without its whole dependency closure there too. Not published for its own
+# sake: nothing outside this workspace is expected to depend on it directly.
+#
+# #938 set `publish = false` here on the finding that no external consumer
+# existed. That was wrong by one: `openvtc-core` dev-depends on `vta-service`
+# for `test_support::MockVta`, an in-process VTA the OpenVTC end-to-end tests
+# run against. See `vta-service/Cargo.toml` for what unpublishing it actually
+# broke. See RELEASING.md ("What gets published").
+publish.workspace = true
 authors.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/vta-keyspaces/Cargo.toml
+++ b/vta-keyspaces/Cargo.toml
@@ -4,11 +4,16 @@ description = "VTA keyspace-name registry — the shared storage vocabulary for 
 readme = "README.md"
 version = "0.1.1"
 edition.workspace = true
-# Internal to this workspace — consumed through path dependencies only, never
-# from crates.io. It was published by inheritance from `[workspace.package]`
-# rather than by decision; the audit in #938 found no external consumer. See
-# RELEASING.md ("What gets published").
-publish = false
+# Published, because `vta-service` is — and a crate cannot go to crates.io
+# without its whole dependency closure there too. Not published for its own
+# sake: nothing outside this workspace is expected to depend on it directly.
+#
+# #938 set `publish = false` here on the finding that no external consumer
+# existed. That was wrong by one: `openvtc-core` dev-depends on `vta-service`
+# for `test_support::MockVta`, an in-process VTA the OpenVTC end-to-end tests
+# run against. See `vta-service/Cargo.toml` for what unpublishing it actually
+# broke. See RELEASING.md ("What gets published").
+publish.workspace = true
 authors.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/vta-policy/Cargo.toml
+++ b/vta-policy/Cargo.toml
@@ -4,11 +4,16 @@ description = "VTA policy subsystem — the regorus (Rego) engine, the default p
 readme = "README.md"
 version = "0.2.2"
 edition.workspace = true
-# Internal to this workspace — consumed through path dependencies only, never
-# from crates.io. It was published by inheritance from `[workspace.package]`
-# rather than by decision; the audit in #938 found no external consumer. See
-# RELEASING.md ("What gets published").
-publish = false
+# Published, because `vta-service` is — and a crate cannot go to crates.io
+# without its whole dependency closure there too. Not published for its own
+# sake: nothing outside this workspace is expected to depend on it directly.
+#
+# #938 set `publish = false` here on the finding that no external consumer
+# existed. That was wrong by one: `openvtc-core` dev-depends on `vta-service`
+# for `test_support::MockVta`, an in-process VTA the OpenVTC end-to-end tests
+# run against. See `vta-service/Cargo.toml` for what unpublishing it actually
+# broke. See RELEASING.md ("What gets published").
+publish.workspace = true
 authors.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -3,11 +3,31 @@ name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
 version = "0.14.37"
 edition.workspace = true
-# Internal to this workspace — consumed through path dependencies only, never
-# from crates.io. It was published by inheritance from `[workspace.package]`
-# rather than by decision; the audit in #938 found no external consumer. See
-# RELEASING.md ("What gets published").
-publish = false
+# Published for one reason: `openvtc-core` dev-depends on it for
+# `test_support::MockVta`, the in-process VTA its end-to-end tests run against.
+# That harness is this crate — it boots the real service — so it cannot be
+# hoisted into a client crate, and no published crate can stand in for it.
+#
+# #938 set `publish = false` here on the finding that no external consumer
+# existed. The audit missed that dev-dependency, and unpublishing did not merely
+# freeze the crate — it broke it. `vti-common` re-exports `vta_sdk::acl::{
+# ActScope, ApproveScope, ContextDirection}` as its own public API, so anything
+# combining `vti-common` with another `vta-sdk` consumer must resolve ONE
+# `vta-sdk`. The last published copy (0.14.37) asks for `vta-sdk ^0.21` while
+# `vti-common` has moved to `^0.23`; a downstream `cargo update` resolves both,
+# and `vta-service` then fails to compile with
+#
+#   expected `vti_common::acl::ApproveScope`, found `vta_sdk::acl::ApproveScope`
+#
+# at ten call sites. Publishing again is what keeps the set coherent: each
+# release moves this crate's requirements with its dependencies'.
+#
+# The cost is the closure — twelve subsystem crates go back to crates.io with
+# it, which is exactly what #938 set out to stop. Chosen deliberately over
+# yanking the published copies (which breaks OpenVTC's tests with no
+# replacement) or leaving a crate on the registry that cannot be built.
+# See RELEASING.md ("What gets published").
+publish.workspace = true
 authors.workspace = true
 rust-version.workspace = true
 readme = "README.md"

--- a/vta-support/Cargo.toml
+++ b/vta-support/Cargo.toml
@@ -4,11 +4,16 @@ description = "Shared mid-layer VTA services — trust-context storage, the seal
 readme = "README.md"
 version = "0.2.3"
 edition.workspace = true
-# Internal to this workspace — consumed through path dependencies only, never
-# from crates.io. It was published by inheritance from `[workspace.package]`
-# rather than by decision; the audit in #938 found no external consumer. See
-# RELEASING.md ("What gets published").
-publish = false
+# Published, because `vta-service` is — and a crate cannot go to crates.io
+# without its whole dependency closure there too. Not published for its own
+# sake: nothing outside this workspace is expected to depend on it directly.
+#
+# #938 set `publish = false` here on the finding that no external consumer
+# existed. That was wrong by one: `openvtc-core` dev-depends on `vta-service`
+# for `test_support::MockVta`, an in-process VTA the OpenVTC end-to-end tests
+# run against. See `vta-service/Cargo.toml` for what unpublishing it actually
+# broke. See RELEASING.md ("What gets published").
+publish.workspace = true
 authors.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/vta-sweepers/Cargo.toml
+++ b/vta-sweepers/Cargo.toml
@@ -4,11 +4,16 @@ description = "Background TTL sweepers for the VTA's core keyspaces — ACL gran
 readme = "README.md"
 version = "0.1.0"
 edition.workspace = true
-# Internal to this workspace — consumed through path dependencies only, never
-# from crates.io. It was published by inheritance from `[workspace.package]`
-# rather than by decision; the audit in #938 found no external consumer. See
-# RELEASING.md ("What gets published").
-publish = false
+# Published, because `vta-service` is — and a crate cannot go to crates.io
+# without its whole dependency closure there too. Not published for its own
+# sake: nothing outside this workspace is expected to depend on it directly.
+#
+# #938 set `publish = false` here on the finding that no external consumer
+# existed. That was wrong by one: `openvtc-core` dev-depends on `vta-service`
+# for `test_support::MockVta`, an in-process VTA the OpenVTC end-to-end tests
+# run against. See `vta-service/Cargo.toml` for what unpublishing it actually
+# broke. See RELEASING.md ("What gets published").
+publish.workspace = true
 authors.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/vta-tee/Cargo.toml
+++ b/vta-tee/Cargo.toml
@@ -4,11 +4,16 @@ description = "VTA TEE bootstrap — Nitro/SEV-SNP attestation providers, KMS at
 readme = "README.md"
 version = "0.1.5"
 edition.workspace = true
-# Internal to this workspace — consumed through path dependencies only, never
-# from crates.io. It was published by inheritance from `[workspace.package]`
-# rather than by decision; the audit in #938 found no external consumer. See
-# RELEASING.md ("What gets published").
-publish = false
+# Published, because `vta-service` is — and a crate cannot go to crates.io
+# without its whole dependency closure there too. Not published for its own
+# sake: nothing outside this workspace is expected to depend on it directly.
+#
+# #938 set `publish = false` here on the finding that no external consumer
+# existed. That was wrong by one: `openvtc-core` dev-depends on `vta-service`
+# for `test_support::MockVta`, an in-process VTA the OpenVTC end-to-end tests
+# run against. See `vta-service/Cargo.toml` for what unpublishing it actually
+# broke. See RELEASING.md ("What gets published").
+publish.workspace = true
 authors.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/vta-vault/Cargo.toml
+++ b/vta-vault/Cargo.toml
@@ -4,11 +4,16 @@ description = "VTA holder credential vault — storage, query, receive/verify, p
 readme = "README.md"
 version = "0.1.2"
 edition.workspace = true
-# Internal to this workspace — consumed through path dependencies only, never
-# from crates.io. It was published by inheritance from `[workspace.package]`
-# rather than by decision; the audit in #938 found no external consumer. See
-# RELEASING.md ("What gets published").
-publish = false
+# Published, because `vta-service` is — and a crate cannot go to crates.io
+# without its whole dependency closure there too. Not published for its own
+# sake: nothing outside this workspace is expected to depend on it directly.
+#
+# #938 set `publish = false` here on the finding that no external consumer
+# existed. That was wrong by one: `openvtc-core` dev-depends on `vta-service`
+# for `test_support::MockVta`, an in-process VTA the OpenVTC end-to-end tests
+# run against. See `vta-service/Cargo.toml` for what unpublishing it actually
+# broke. See RELEASING.md ("What gets published").
+publish.workspace = true
 authors.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/vta-webvh/Cargo.toml
+++ b/vta-webvh/Cargo.toml
@@ -4,11 +4,16 @@ description = "WebVH hosting infrastructure for the VTA — the DID-record store
 readme = "README.md"
 version = "0.1.4"
 edition.workspace = true
-# Internal to this workspace — consumed through path dependencies only, never
-# from crates.io. It was published by inheritance from `[workspace.package]`
-# rather than by decision; the audit in #938 found no external consumer. See
-# RELEASING.md ("What gets published").
-publish = false
+# Published, because `vta-service` is — and a crate cannot go to crates.io
+# without its whole dependency closure there too. Not published for its own
+# sake: nothing outside this workspace is expected to depend on it directly.
+#
+# #938 set `publish = false` here on the finding that no external consumer
+# existed. That was wrong by one: `openvtc-core` dev-depends on `vta-service`
+# for `test_support::MockVta`, an in-process VTA the OpenVTC end-to-end tests
+# run against. See `vta-service/Cargo.toml` for what unpublishing it actually
+# broke. See RELEASING.md ("What gets published").
+publish.workspace = true
 authors.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/vti-webauthn/Cargo.toml
+++ b/vti-webauthn/Cargo.toml
@@ -6,11 +6,16 @@ rust-version.workspace = true
 license.workspace = true
 authors.workspace = true
 repository.workspace = true
-# Internal to this workspace — consumed through path dependencies only, never
-# from crates.io. It was published by inheritance from `[workspace.package]`
-# rather than by decision; the audit in #938 found no external consumer. See
-# RELEASING.md ("What gets published").
-publish = false
+# Published, because `vta-service` is — and a crate cannot go to crates.io
+# without its whole dependency closure there too. Not published for its own
+# sake: nothing outside this workspace is expected to depend on it directly.
+#
+# #938 set `publish = false` here on the finding that no external consumer
+# existed. That was wrong by one: `openvtc-core` dev-depends on `vta-service`
+# for `test_support::MockVta`, an in-process VTA the OpenVTC end-to-end tests
+# run against. See `vta-service/Cargo.toml` for what unpublishing it actually
+# broke. See RELEASING.md ("What gets published").
+publish.workspace = true
 description = "DID-VM-resolved WebAuthn assertion verifier for the Verifiable Trust Infrastructure."
 readme = "README.md"
 


### PR DESCRIPTION
This reverses the publishing half of #938. Deliberately, and with the reason it was wrong.

## The audit missed a dev-dependency

#938 set `publish = false` on `vta-service` and the twelve subsystem crates behind it, on the finding that nothing external depended on them. The audit read normal dependencies. `openvtc-core` depends on `vta-service` as a **dev-dependency**, for `test_support::MockVta` — an in-process VTA that OpenVTC's end-to-end tests run against. That harness boots the real service (1,959 lines of `vta-service/src/test_support.rs`), so no client crate can substitute for it.

## Unpublishing did not freeze the crate — it broke it

`vti-common/src/acl/mod.rs:272`:

```rust
pub use vta_sdk::acl::{ActScope, ApproveScope, ContextDirection};
```

**A re-export makes the re-exported crate's version part of your public API.** Any graph combining `vti-common` with another `vta-sdk` consumer must resolve **one** `vta-sdk`. Frozen at 0.14.37, `vta-service` asks for `vta-sdk ^0.21`; `vti-common` has since moved to `^0.23`. A downstream `cargo update` resolves both, and `vta-service` fails to compile at ten call sites:

```
error[E0308]: mismatched types
  --> vta-service-0.14.37/src/messaging/handlers.rs:823
     expected `vti_common::acl::ApproveScope`, found `vta_sdk::acl::ApproveScope`
```

Identical at 0.14.24, so it is the surrounding crates moving, not any version bump. This is how it surfaced — in [openvtc#213](https://github.com/OpenVTC/openvtc/pull/213), on a routine dependency refresh. Nothing downstream can fix it: only a release that moves the requirements together can.

## What changes

Thirteen manifests return to the workspace default: `vta-service` plus its closure — `vta-audit`, `vta-backup`, `vta-config`, `vta-keys`, `vta-keyspaces`, `vta-policy`, `vta-support`, `vta-sweepers`, `vta-tee`, `vta-vault`, `vta-webvh`, `vti-webauthn`.

The cost is that closure: crates.io requires every dependency of a published crate to be published, so twelve subsystem crates go back on the registry — exactly what #938 set out to stop. Taken over the two alternatives, both worse:

- **Yank the published copies.** Honest about support status, but breaks OpenVTC's `mockvta_bootstrap_e2e` immediately, with nothing to replace it.
- **Leave them up.** Ships a crate on the registry that cannot be built.

Six crates stay internal and are untouched: `vtc-service`, `vta-enclave`, `vta-mcp`, `vta-mobile-core`, `didcomm-test`, `vti-fuzz`.

## Release ordering — expect one dry-run failure until this lands

`cargo publish --dry-run -p vta-service` **fails today**, and will until the closure is on the registry. Packaging strips path dependencies, so `vta-keys = "0.2"` resolves the *published* 0.2.1, which still asks for `vta-sdk ^0.21` — two nodes, same error. Confirmed in the packaged lockfile:

```
name = "vta-sdk"   version = "0.21.21"
name = "vta-sdk"   version = "0.23.0"
```

That resolves itself in the release, which publishes in dependency order. Every subsystem crate in this workspace **already** requires `vta-sdk = "0.23"` — release-plz kept them coherent while they were unpublished, exactly as its config comment promises — so once they upload, `vta-service` verifies against them rather than against the stale copies.

Verified that the layers behave as that predicts: `vta-keyspaces` and `vta-config`, whose dependencies are all published already, dry-run clean.

Note also that every crate here is currently at the same version as its published copy, so each needs a bump before it can upload. This PR touches all thirteen manifests, so release-plz will bump them; no version is edited by hand.

## Docs

`CLAUDE.md`, `RELEASING.md` and the `release-plz.toml` header all said 7-of-21. They now say 20-of-26, name the six that stay internal, and record the rule the audit missed: **check dev-dependencies, in sibling repos, before unpublishing anything** — and that a re-export ties you to a version.

## Verification

- `cargo metadata` parses; `cargo check --workspace` clean
- `cargo publish --dry-run` clean on `vta-keyspaces` and `vta-config`
- `cargo publish --dry-run -p vta-service` fails as described above, for the stale-registry reason, with the two-node lockfile as evidence
- `cargo fmt` clean
