### PR TITLE
feat(vtc): reach the trust registry by DID over TSP or DIDComm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -400,6 +400,20 @@ jobs:
           # minutes to this job.
           VTC_SKIP_ADMIN_UI_BUILD: "1"
 
+      # The VTC's trust-registry **send** path — the other direction from the
+      # test above, and the one with an extra failure mode: a registry write
+      # completes only when a correlated reply comes back through the inbound
+      # demux, which is a different code path from the send. A demux that drops
+      # the reply is indistinguishable from a registry that never answered
+      # (the call times out, the syncer backs off, the queue grows), so the
+      # round trip has to be exercised, not just the two halves. Same reasoning
+      # as the join tests: `didcomm-harness` is not a default feature, so
+      # `cargo test --workspace` never builds this.
+      - name: vtc-service trust-registry round trip over a real mediator
+        run: cargo test -p vtc-service --features didcomm-harness --test registry_didcomm
+        env:
+          VTC_SKIP_ADMIN_UI_BUILD: "1"
+
   enclave:
     # The Nitro enclave binary uses a TEE-only feature combo that the
     # default `check` job never touches. Linux-only because vsock-store

--- a/docs/03-vtc/trust-registry-deployment.md
+++ b/docs/03-vtc/trust-registry-deployment.md
@@ -454,50 +454,86 @@ In the VTC's `config.toml`:
 
 ```toml
 [registry]
-url = "https://trust-registry.example.org"
+did = "did:webvh:Qm…:webvh.example:trust-registry"
 health_probe_interval_seconds = 60
 http_timeout_seconds = 5
 rtbf_batch_window_hours = 24
+# url = "https://trust-registry.example.org"   # optional — see below
 ```
 
-Deliberately omit `did` for now — see the caveat below.
+**`did` is the address; `url` is optional.** The VTC resolves the
+registry's DID, reads its advertised services, and uses the
+highest-preference transport both sides speak (TSP > DIDComm >
+REST, matched on service `type`, never on the `#id` fragment).
+Everything runs over that transport: membership sync
+(`registry/record/{put,delete,query}/0.1`), recognition queries,
+the health probe, and the git-trust capability hooks.
 
-- `url` unset → registry features no-op and `registry_status`
-  reads `degraded`.
-- `did` unset → membership hooks are not spawned.
+- `did` set → the messaging client. `url`, if also set, becomes
+  its REST arm — used only if the registry advertises `TRQPRest`
+  and no messaging transport.
+- `url` alone → the HTTP-only client. TRQP queries work; record
+  writes do not (the registry exposes writes over Trust Tasks
+  only), so membership never syncs.
+- Neither → registry features no-op, `registry_status` reads
+  `degraded`.
+- No overlap between the two documents' advertised transports →
+  a typed `NoMatchingProtocol` naming what each side offers. The
+  VTC never silently downgrades past what the registry
+  advertises.
 - `degraded_threshold_seconds` appears in
   [trust-registry.md](trust-registry.md) but not in
   `RegistryConfig`. Setting it has no effect.
 
-The health probe is a `GET /.well-known/did.json` against `url`,
-so a passing stage 4 means the VTC will report the registry
-healthy.
+**The registry must authorise the VTC's DID.** Record writes
+require a Data-Integrity proof *and* a sender DID listed in the
+registry's `ADMIN_DIDS`. A VTC that is not listed gets
+`permissionDenied`, which is classified permanent — the syncer
+parks the job in `Failed` rather than retrying, which is what you
+want, but it means a missing entry shows up as failed jobs, not
+as a retry backlog. Add the VTC DID to the registry's admin list
+before expecting sync to work.
+
+### What the health probe now means
+
+The probe is a read-only `registry/record/query/0.1` round trip
+over the selected transport. It needs no proof and no admin ACL,
+so it works even on a registry that would refuse your writes —
+but unlike the old `GET /.well-known/did.json` it exercises the
+whole path the VTC depends on: mediator, transport, dispatcher,
+storage.
+
+Any correlated reply counts as healthy, **including a rejection**
+— the registry answered. Only silence is unhealthy. So a green
+`registry_status` now means "the registry is answering us on the
+transport we use", not "a URL returned 200".
 
 ---
 
 ## Known defects on this seam
 
-Tracked as **D6** in the networking remediation plan. Both change
-how you should read symptoms.
+**TSP framing differs between this workspace and the registry.**
+VTI sends bare Trust-Task document bytes over TSP; the registry
+implements the published `trust-tasks-tsp` binding, which wraps
+them in `{"type": ".../binding/tsp/0.1/envelope", "document": …}`
+and rejects a payload without it. The VTC therefore emits the
+envelope when talking to the registry and accepts either shape
+inbound. A peer that speaks neither convention shows up as a
+reply timeout, not a parse error — the frame is dropped at the
+far end.
 
-**DIDComm writes are not yet functional.**
-`UpstreamRegistryClient::publish_member` and `delete_member`
-return `RegistryError::Permanent` unconditionally — the DIDComm
-transport is still pending, and `with_atm` is never called. Every
-membership sync fails. Because `health()` only issues a `GET
-/.well-known/did.json`, **`registry_status` stays green while
-nothing syncs.** This is why stage 5 leaves `registry.did` unset:
-setting it today buys failing hooks and a misleading indicator.
-
-**The `recognized` field is a two-sided optionality mismatch.**
-The registry serialises `recognized` with
-`skip_serializing_if = Option::is_none`; the VTC's
-`RecognitionResponse` requires it. A 200 response omitting the
-field fails to parse, is misclassified as transient, and surfaces
-as `RegistryUnreachable` — so cross-community session mint returns
-**503 indefinitely instead of a clean 403**. Persistent 503s on
-cross-community mint are this, not a network fault. Absence must
-be treated restrictively rather than as transport failure.
+**Historical (fixed, but you may still read the symptom in old
+logs).** Tracked as **D6** in the networking remediation plan:
+`publish_member` / `delete_member` used to return
+`RegistryError::Permanent` unconditionally while `health()`
+probed only a static document, so `registry_status` stayed green
+while nothing synced. Both are now closed — writes go over Trust
+Tasks and health is a real round trip. The related `recognized`
+optionality mismatch (an omitted field parsed as a transport
+failure and surfaced as an indefinite 503 on cross-community
+mint) does not exist on the Trust-Task arm, which reads absence
+restrictively as "not recognised". It remains live on the
+HTTP-only (`url`-alone) path.
 
 ---
 
@@ -510,8 +546,11 @@ be treated restrictively rather than as transport failure.
 | Parse error on a valid credential file | mistyped URI scheme → treated as a literal |
 | Private ACL not enforced | `ACL_MODE` typo → silent `ExplicitDeny` |
 | Peers cannot reach the registry | `did:webvh` generated but never hosted |
-| VTC green, membership never syncs | DIDComm write defect above |
-| Cross-community mint 503s forever | `recognized` mismatch above |
+| Sync jobs go straight to `Failed`, never retried | VTC DID missing from the registry's `ADMIN_DIDS` → `permissionDenied` (permanent by design) |
+| Every registry call times out after 60s | reply never correlated: registry not running the Trust-Task listener, or a TSP framing mismatch (see above) |
+| `NoMatchingProtocol` at boot or on first sync | the two DID documents advertise no transport in common — add `DIDCommMessaging` (or `TSPTransport`) to whichever side lacks it |
+| `registry_status` degraded but the URL is up | expected: health now follows a Trust-Task round trip, not the URL |
+| Cross-community mint 503s forever | `recognized` mismatch — only on the `url`-alone HTTP path; set `registry.did` |
 | `bootstrap open` produced no file | `--out` omitted; the bundle is now spent, start over from `bootstrap request` |
 | Second `bootstrap open` fails | single-use secret already consumed by the first open |
 | Docker image ignores VTA settings | `vta` not compiled into the shipped image |

--- a/docs/03-vtc/trust-registry.md
+++ b/docs/03-vtc/trust-registry.md
@@ -39,6 +39,35 @@ The VTC uses **TRQP v2.0** (Trust Registry Query Protocol) via the
 `affinidi-trust-registry-rs` client (or any TRQP-compatible
 backend).
 
+## How the VTC reaches the registry
+
+The registry is addressed by **DID** (`registry.did`), not by URL.
+The VTC resolves that DID, reads the transports it advertises, and
+uses the highest-preference one both sides speak — TSP, then
+DIDComm, then REST — matched on the service `type`. Every
+interaction rides that transport as a canonical Trust Task:
+
+| Operation | Trust Task | Proof |
+|---|---|---|
+| Publish / update a member | `registry/record/put/0.1` | signed |
+| Remove a member (RTBF, departure) | `registry/record/delete/0.1` | signed |
+| Read a member's record | `registry/record/query/0.1` | none |
+| Recognition check | `registry/recognition/0.1` | none |
+| Health probe | `registry/record/query/0.1` (limit 1) | none |
+
+Writes are signed with the VTC's assertion key (`{vtc_did}#key-0`)
+— the same identity that mints VMC/VEC — and the registry must
+carry that DID in its admin list, or every write is
+`permissionDenied`.
+
+A send returning `Ok` is never treated as delivery. Each call
+registers a waiter keyed by the request document id, and completes
+only when the correlated reply arrives; silence is a retriable
+failure the syncer backs off on.
+
+`registry.url` remains as the REST arm for a registry that
+advertises `TRQPRest` and no messaging transport.
+
 ## Publication
 
 ```mermaid
@@ -188,33 +217,38 @@ sequenceDiagram
 ```toml
 # config.toml
 [registry]
-url = "https://trust-registry.example.org"
+did = "did:webvh:Qm…:webvh.example:trust-registry"
 http_timeout_seconds = 30
 health_probe_interval_seconds = 300       # 5 minutes; 0 disables
 rtbf_batch_window_hours = 24              # daily flush
 degraded_threshold_seconds = 3600         # status flips to degraded after 1h lag
+# url = "https://trust-registry.example.org"   # optional REST arm
 ```
 
-Setting `registry.url = ""` (or omitting it) disables registry
-features entirely — the daemon runs in "no-registry" mode,
+Configuring neither `did` nor `url` disables registry features
+entirely — the daemon runs in "no-registry" mode,
 `registry_status` reports `degraded`, and `cross_community_roles`
-short-circuits to deny-all.
+short-circuits to deny-all. Configuring `url` alone gives you TRQP
+queries without membership sync: record writes exist only as Trust
+Tasks, so they need a DID to address.
 
-## CLI quick reference
+## Operator surface
+
+There is **no `cnm registry` command** — an earlier version of this
+document listed one that was never built. What exists today:
 
 ```sh
-# Registry health
-cnm registry health
-cnm registry profile show     # community's registry record
-
-# Sync queue inspection
-cnm registry queue list
-cnm registry queue retry --id <job-id>
-cnm registry queue cancel --id <job-id>
-
-# Force a re-publish
-cnm registry refresh
+# Reconciler state: registry_status, queue_depth, failed_count,
+# oldest_pending_age_seconds, last_error, syncer liveness.
+curl -H "Authorization: Bearer $TOKEN" \
+  https://vtc.example.org/v1/health/diagnostics | jq .
 ```
+
+In the admin UI, the **Recognition** page shows the registry
+status and a per-DID recognition lookup, and the **Audit** page
+carries `RegistryStatusChanged` / `RegistrySyncSucceeded` /
+`RegistrySyncFailed`. Queue depth and failed-job counts are
+currently JSON-only.
 
 ## See also
 

--- a/vtc-service/src/config.rs
+++ b/vtc-service/src/config.rs
@@ -248,19 +248,38 @@ pub enum PersonhoodFailMode {
 #[serde(rename_all = "snake_case")]
 pub struct RegistryConfig {
     /// Base URL of the upstream TRQP-compliant registry
-    /// (e.g. `https://registry.example.com`). When `None`,
-    /// registry features no-op — `registry_status` reads
-    /// `"degraded"`, sync is skipped.
+    /// (e.g. `https://registry.example.com`).
+    ///
+    /// **Optional, and no longer the primary address.** With [`Self::did`] set
+    /// this is the REST *arm* of the messaging client — used only when the
+    /// registry advertises `TRQPRest` and no messaging transport. On its own it
+    /// selects the HTTP-only client, which can answer TRQP queries but cannot
+    /// write records (the upstream exposes writes over Trust Tasks only).
+    ///
+    /// Neither `url` nor `did` ⇒ registry features no-op, `registry_status`
+    /// reads `"degraded"`, sync is skipped.
     #[serde(default)]
     pub url: Option<String>,
-    /// DID of the trust registry — the recipient of DIDComm capability
-    /// writes (`governance/capability/*`, `git-trust/*`). Required for the
-    /// membership hook relay; unset ⇒ hooks are not spawned.
+    /// DID of the trust registry.
+    ///
+    /// The primary address: the registry is reached over whichever transport
+    /// both DID documents advertise (TSP > DIDComm > REST, matched on service
+    /// `type`). Covers membership sync (`registry/record/{put,delete,query}`),
+    /// recognition queries, the health probe, and the git-trust /
+    /// `governance/capability/*` hook relay — so a registry that publishes a
+    /// DID and nothing else is fully usable.
+    ///
+    /// Unset ⇒ the hook relay is not spawned and the client falls back to
+    /// [`Self::url`], if set.
     #[serde(default)]
     pub did: Option<String>,
     /// Period (seconds) between background health probes.
     /// `0` disables the periodic probe (only boot-time probe
     /// runs). Default: 60s.
+    ///
+    /// Over messaging the probe is a read-only `registry/record/query` round
+    /// trip, so `registry_status` tracks whether the registry actually answers
+    /// — not merely whether a URL is up.
     #[serde(default = "default_health_probe_interval")]
     pub health_probe_interval_seconds: u64,
     /// Per-call HTTP timeout for registry operations (seconds).

--- a/vtc-service/src/messaging.rs
+++ b/vtc-service/src/messaging.rs
@@ -72,6 +72,14 @@ pub struct VtcMessaging {
     /// the delivery layer's `send`. Same socket either way — the mediator permits
     /// one per DID.
     pub profile: Arc<ATMProfile>,
+    /// The mediator this socket is bound to.
+    ///
+    /// A TSP send is `send_routed(&profile, &[mediator, recipient], …)`, so an
+    /// outbound TSP caller that is not answering an inbound frame (which
+    /// carries the mediator with it) needs the first hop from somewhere. Kept
+    /// here rather than re-read from config so the routed hop is always the
+    /// mediator the socket is actually on.
+    pub mediator_did: String,
 }
 
 /// The VTC's signing + key-agreement verification-method ids, read from its
@@ -376,6 +384,7 @@ pub async fn run_didcomm_service(
         atm: atm.clone(),
         vtc_did: vtc_did.to_string(),
         profile: profile.clone(),
+        mediator_did: mediator_did.clone(),
     });
     #[cfg(feature = "tsp")]
     let tsp_messaging = messaging.clone();
@@ -536,6 +545,32 @@ fn tsp_sender(message: &affinidi_messaging_core::ReceivedMessage) -> Option<Stri
     message.sender.clone().filter(|_| message.verified)
 }
 
+/// Is this inbound TSP payload a **reply** to a task we sent, rather than a
+/// request addressed to us?
+///
+/// Accepts both wire shapes deliberately. This workspace sends Trust-Task
+/// document bytes bare over TSP (`vta_sdk::session::DIDCommSession::
+/// send_document`), while the published `trust-tasks-tsp` binding — which the
+/// trust registry implements — wraps them in
+/// `{"type": ".../binding/tsp/0.1/envelope", "document": …}`. Being liberal
+/// here costs nothing: the two shapes are unambiguous, and the alternative is
+/// a peer's replies silently falling through to the request dispatcher.
+///
+/// Returns `Some` only for a `#response` or `trust-task-error` carrying a
+/// `threadId` — a request never qualifies, so no inbound work is diverted.
+#[cfg(feature = "tsp")]
+fn tsp_reply_document(payload: &[u8]) -> Option<trust_tasks_rs::TrustTask<serde_json::Value>> {
+    let value: serde_json::Value = serde_json::from_slice(payload).ok()?;
+    let inner = match value.get("document") {
+        Some(document) => document.clone(),
+        None => value,
+    };
+    let doc: trust_tasks_rs::TrustTask<serde_json::Value> = serde_json::from_value(inner).ok()?;
+    doc.thread_id.as_ref()?;
+    let is_reply = doc.type_uri.is_response() || doc.type_uri.slug() == "trust-task-error";
+    is_reply.then_some(doc)
+}
+
 #[cfg(feature = "tsp")]
 async fn handle_tsp(
     inbound: Inbound,
@@ -547,6 +582,22 @@ async fn handle_tsp(
         warn!("inbound TSP frame has no cryptographically-verified sender VID — dropping");
         return;
     };
+
+    // A reply to a task *we* sent (a trust-registry record write, say) arrives
+    // on this socket like any other frame. Complete its waiter instead of
+    // dispatching it: the spine would answer a `#response` with an
+    // unsupported-type error, and the caller — which is waiting on a
+    // correlated reply, not on a send `Ok` — would time out and retry forever.
+    //
+    // The DIDComm arm gets this from its envelope branch in `dispatch`; TSP
+    // carries documents bare, so the check is here.
+    if let Some(doc) = tsp_reply_document(&inbound.message.payload) {
+        let thread_id = doc.thread_id.clone().unwrap_or_default();
+        if !state.pending_replies.complete(doc) {
+            debug!(%thread_id, sender = %sender_vid, "TSP reply had no waiter — dropping");
+        }
+        return;
+    }
 
     let ctx = JoinAuthCtx {
         transport: JoinTransport::Tsp,
@@ -615,7 +666,7 @@ async fn dispatch(inbound: Inbound, state: &AppState) -> Option<Reply> {
         if let Some((_thid, doc)) =
             vti_common::capability_client::parse_envelope_document(&msg.body)
         {
-            state.capability_replies.complete(doc);
+            state.pending_replies.complete(doc);
         }
         return None;
     }
@@ -1322,6 +1373,79 @@ pub(crate) fn parse_disposition(s: &str) -> Result<Disposition, String> {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    /// A `#response` must be recognised as a reply in **both** TSP wire
+    /// shapes: bare (what this workspace sends) and wrapped in the
+    /// `trust-tasks-tsp` binding envelope (what the trust registry sends).
+    /// Miss either and the reply falls through to the request dispatcher,
+    /// which answers it with an unsupported-type error while the caller waits
+    /// out its whole timeout.
+    #[cfg(feature = "tsp")]
+    #[test]
+    fn a_tsp_reply_is_recognised_bare_and_enveloped() {
+        let doc = json!({
+            "id": "urn:uuid:reply",
+            "type": "https://trusttasks.org/spec/registry/record/put/0.1#response",
+            "threadId": "urn:uuid:request",
+            "payload": { "ok": true, "created": true },
+        });
+        let bare = serde_json::to_vec(&doc).unwrap();
+        assert_eq!(
+            tsp_reply_document(&bare).and_then(|d| d.thread_id),
+            Some("urn:uuid:request".to_string()),
+        );
+
+        let enveloped = serde_json::to_vec(&json!({
+            "type": "https://trusttasks.org/binding/tsp/0.1/envelope",
+            "document": doc,
+        }))
+        .unwrap();
+        assert_eq!(
+            tsp_reply_document(&enveloped).and_then(|d| d.thread_id),
+            Some("urn:uuid:request".to_string()),
+        );
+    }
+
+    /// The demux must divert replies and nothing else. A request — no
+    /// `threadId`, not a `#response` — has to reach the dispatcher, or every
+    /// inbound TSP Trust Task is silently dropped.
+    #[cfg(feature = "tsp")]
+    #[test]
+    fn an_inbound_request_is_not_mistaken_for_a_reply() {
+        let request = serde_json::to_vec(&json!({
+            "id": "urn:uuid:req",
+            "type": "https://trusttasks.org/spec/vtc/join/submit/0.1",
+            "payload": {},
+        }))
+        .unwrap();
+        assert!(tsp_reply_document(&request).is_none());
+
+        // A `#response` without a thread to correlate on is not actionable
+        // either — completing a waiter needs the thread id.
+        let unthreaded = serde_json::to_vec(&json!({
+            "id": "urn:uuid:resp",
+            "type": "https://trusttasks.org/spec/registry/record/put/0.1#response",
+            "payload": { "ok": true },
+        }))
+        .unwrap();
+        assert!(tsp_reply_document(&unthreaded).is_none());
+    }
+
+    /// A `trust-task-error` is how the registry says "permission denied", and
+    /// it is a reply like any other: the waiter must be completed so the caller
+    /// classifies it, rather than left to time out as though nothing answered.
+    #[cfg(feature = "tsp")]
+    #[test]
+    fn an_error_document_counts_as_a_reply() {
+        let error = serde_json::to_vec(&json!({
+            "id": "urn:uuid:err",
+            "type": "https://trusttasks.org/spec/trust-task-error/0.1",
+            "threadId": "urn:uuid:request",
+            "payload": { "code": "permissionDenied" },
+        }))
+        .unwrap();
+        assert!(tsp_reply_document(&error).is_some());
+    }
 
     #[test]
     fn problem_report_details_extracts_code_comment_and_args() {

--- a/vtc-service/src/messaging.rs
+++ b/vtc-service/src/messaging.rs
@@ -1412,9 +1412,12 @@ mod tests {
     #[cfg(feature = "tsp")]
     #[test]
     fn an_inbound_request_is_not_mistaken_for_a_reply() {
+        // A published request URI, deliberately: binding a `trusttasks.org/spec/`
+        // literal asserts the registry serves that task, and the canonical-task
+        // census checks every one of them — including the ones in tests.
         let request = serde_json::to_vec(&json!({
             "id": "urn:uuid:req",
-            "type": "https://trusttasks.org/spec/vtc/join/submit/0.1",
+            "type": "https://trusttasks.org/spec/registry/record/query/0.1",
             "payload": {},
         }))
         .unwrap();

--- a/vtc-service/src/registry/messaging.rs
+++ b/vtc-service/src/registry/messaging.rs
@@ -162,7 +162,10 @@ impl MessagingRegistryClient {
         }
     }
 
-    #[cfg(test)]
+    /// Shorten the reply window. Test-only: the production window is a
+    /// deliberate 60s, and the silence case would otherwise take that long to
+    /// assert.
+    #[cfg(any(test, feature = "didcomm-harness"))]
     pub fn with_reply_timeout(mut self, timeout: Duration) -> Self {
         self.reply_timeout = timeout;
         self
@@ -646,12 +649,17 @@ mod tests {
     use super::*;
     use chrono::{TimeZone, Utc};
 
-    fn record_doc(slug: &str, payload: Value) -> TrustTask<Value> {
+    /// The `#response` to `request_type`.
+    ///
+    /// Built from the whole request URI rather than by interpolating a slug
+    /// into a `trusttasks.org/spec/…` template: the canonical-task census
+    /// scans source for `spec/` literals and asserts the registry publishes
+    /// each one, so a templated URI reads to it as a bound task named
+    /// `{slug}`.
+    fn record_doc(request_type: &str, payload: Value) -> TrustTask<Value> {
         TrustTask::new(
             "urn:uuid:reply".to_string(),
-            format!("https://trusttasks.org/spec/{slug}/0.1#response")
-                .parse()
-                .unwrap(),
+            format!("{request_type}#response").parse().unwrap(),
             payload,
         )
     }
@@ -706,12 +714,9 @@ mod tests {
 
     #[test]
     fn a_wrong_response_type_does_not_pass_as_success() {
-        let wrong = record_doc("registry/record/query", json!({ "records": [] }));
+        let wrong = record_doc(RECORD_QUERY, json!({ "records": [] }));
         assert!(classify(&wrong, "registry/record/put").is_err());
-        let right = record_doc(
-            "registry/record/put",
-            json!({ "ok": true, "created": true }),
-        );
+        let right = record_doc(RECORD_PUT, json!({ "ok": true, "created": true }));
         assert!(classify(&right, "registry/record/put").is_ok());
     }
 

--- a/vtc-service/src/registry/messaging.rs
+++ b/vtc-service/src/registry/messaging.rs
@@ -1,0 +1,845 @@
+//! `MessagingRegistryClient` — the trust-registry client that addresses the
+//! registry by **DID**, over TSP or DIDComm, using the canonical `registry/*`
+//! Trust Tasks.
+//!
+//! ## Why this exists
+//!
+//! [`UpstreamRegistryClient`](super::upstream::UpstreamRegistryClient) reaches
+//! the registry at a configured `registry.url` over HTTP. That works for the
+//! two TRQP *reads* the upstream exposes on its HTTP surface, but:
+//!
+//! - every **write** was a `Permanent` stub, so membership never synced;
+//! - a URL is not always available — a registry is named by DID in the
+//!   community's DID document (`#trust-registry` referral), and a deployment
+//!   may publish nothing else;
+//! - `health()` was an HTTP `GET /.well-known/did.json`, which stays green
+//!   while every write fails (R6.2: a health flag must be driven by a signal
+//!   that can go false again — this one could not).
+//!
+//! This client closes all three. It speaks the registry's Trust Tasks —
+//! `registry/record/{put,delete,query}/0.1` and `registry/recognition/0.1` —
+//! over the transport both parties advertise, and derives liveness from a real
+//! round-trip rather than from a URL being up.
+//!
+//! ## Transport selection
+//!
+//! Per CLAUDE.md the DID document is authoritative and the preference order is
+//! TSP > DIDComm > REST, matched on the service **`type`** (never the `#id`
+//! fragment). We resolve the registry's DID, read its
+//! [`ServiceCapabilities`], intersect with what this build can speak, and take
+//! the highest-preference overlap. An empty intersection is a typed error, not
+//! a silent downgrade — [`select_protocol`] returns `NoMatchingProtocol`
+//! carrying both advertised sets so the operator can see which side is missing
+//! what.
+//!
+//! REST remains reachable as the last-resort arm: when the match lands on
+//! `Protocol::Rest` we delegate to the HTTP client, which is why
+//! `registry.url` stays meaningful for a registry that advertises `TRQPRest`
+//! and nothing else.
+//!
+//! ## Replies
+//!
+//! Both messaging transports are one-way sends; the answer arrives back on the
+//! inbound listener as a separate frame. We register a waiter keyed by the
+//! request document id **before** sending (so a fast reply cannot be lost) and
+//! the inbound demux completes it by `threadId` — the same
+//! [`PendingReplies`] the git-trust hook writer uses, which is why a registry
+//! reply needs no new inbound plumbing on the DIDComm side.
+//!
+//! R1.1 discipline throughout: a send returning `Ok` means "accepted locally",
+//! never "delivered". A call is complete only when a correlated reply arrives;
+//! no reply within the window is `Transient`, which the syncer retries.
+//!
+//! ## The TSP envelope
+//!
+//! TSP frames to the registry are wrapped in the `trust-tasks-tsp` binding
+//! envelope (`{"type": <ENVELOPE_TYPE>, "document": <TrustTask>}`). This is
+//! **not** what the rest of this workspace does over TSP — VTI sends bare
+//! Trust-Task document bytes (see `vta_sdk::session::DIDCommSession::
+//! send_document` and `messaging::handle_tsp`) — but the registry's TSP
+//! binding rejects a payload without the envelope, and the envelope is the
+//! published binding. We therefore emit the envelope and accept **either**
+//! shape inbound.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use affinidi_did_resolver_cache_sdk::DIDCacheClient;
+use affinidi_messaging_delivery::Delivery;
+use affinidi_messaging_didcomm::Message;
+use async_trait::async_trait;
+use serde_json::{Value, json};
+use tokio::sync::OnceCell;
+use tracing::debug;
+use trust_tasks_rs::TrustTask;
+use uuid::Uuid;
+use vta_sdk::protocol::matching::{Protocol, ServiceCapabilities, select_protocol};
+
+use vti_common::capability_client::{TRUST_TASK_ENVELOPE_TYPE, build_document};
+
+use crate::credentials::LocalSigner;
+use crate::hooks::PendingReplies;
+use crate::messaging::VtcMessaging;
+
+use super::client::{RegistryError, TrustRegistryClient};
+use super::model::{RegistryRecord, RegistryStatus};
+use super::upstream::UpstreamRegistryClient;
+use super::{RECOGNISE_ACTION, TRUST_GRAPH_RESOURCE};
+
+/// The `trust-tasks-tsp` binding envelope type.
+///
+/// Mirrored from `trust_tasks_tsp::ENVELOPE_TYPE` rather than depended upon:
+/// pulling the binding crate in would drag a second TSP stack into the build
+/// graph for one constant. [`tsp_envelope_type_matches_the_binding`] pins the
+/// string.
+const TSP_ENVELOPE_TYPE: &str = "https://trusttasks.org/binding/tsp/0.1/envelope";
+
+/// Canonical `registry/*` Trust Task type URIs.
+const RECORD_PUT: &str = "https://trusttasks.org/spec/registry/record/put/0.1";
+const RECORD_DELETE: &str = "https://trusttasks.org/spec/registry/record/delete/0.1";
+const RECORD_QUERY: &str = "https://trusttasks.org/spec/registry/record/query/0.1";
+const RECOGNITION: &str = "https://trusttasks.org/spec/registry/recognition/0.1";
+
+/// Default wait for the registry's reply before a call is deemed transient.
+/// Matches the hook writer's window — same mediator, same round trip.
+pub const DEFAULT_REPLY_TIMEOUT_SECONDS: u64 = 60;
+
+/// Trust-registry client addressing the registry by DID over TSP / DIDComm,
+/// with the HTTP client as the REST arm.
+pub struct MessagingRegistryClient {
+    /// DID of the community's trust registry — the recipient of every task.
+    registry_did: String,
+    /// Our own DID: the TRQP `authority_id` on every record we write or query,
+    /// and the issuer of every document we sign. `None` before setup completes,
+    /// in which case every call refuses rather than writing a half-keyed record.
+    authority_did: Option<String>,
+    /// Messaging handle. Empty until the listener is up — a not-yet-running
+    /// messaging is transient, not permanent.
+    didcomm: Arc<OnceCell<Arc<VtcMessaging>>>,
+    /// The VTC's assertion signer (`{vtc_did}#key-0`), the same identity that
+    /// mints VMC/VEC. The community is the authority its records are written
+    /// under, so this is the right key — and its canonical form already
+    /// verifies at the registry (proven by the git-trust path).
+    signer: Arc<LocalSigner>,
+    /// Shared with the inbound demux; completed by `threadId`.
+    replies: PendingReplies,
+    /// Resolver for the registry's DID document (transport selection).
+    did_resolver: Option<DIDCacheClient>,
+    reply_timeout: Duration,
+    /// REST arm — present when `registry.url` is configured.
+    http: Option<UpstreamRegistryClient>,
+}
+
+impl std::fmt::Debug for MessagingRegistryClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MessagingRegistryClient")
+            .field("registry_did", &self.registry_did)
+            .field("authority_did", &self.authority_did)
+            .field("http_arm", &self.http.is_some())
+            .finish()
+    }
+}
+
+impl MessagingRegistryClient {
+    pub fn new(
+        registry_did: String,
+        authority_did: Option<String>,
+        didcomm: Arc<OnceCell<Arc<VtcMessaging>>>,
+        signer: Arc<LocalSigner>,
+        replies: PendingReplies,
+        did_resolver: Option<DIDCacheClient>,
+        http: Option<UpstreamRegistryClient>,
+    ) -> Self {
+        Self {
+            registry_did,
+            authority_did,
+            didcomm,
+            signer,
+            replies,
+            did_resolver,
+            reply_timeout: Duration::from_secs(DEFAULT_REPLY_TIMEOUT_SECONDS),
+            http,
+        }
+    }
+
+    #[cfg(test)]
+    pub fn with_reply_timeout(mut self, timeout: Duration) -> Self {
+        self.reply_timeout = timeout;
+        self
+    }
+
+    /// Our own DID as TRQP authority, or a `Permanent` refusal.
+    fn authority(&self) -> Result<&str, RegistryError> {
+        self.authority_did.as_deref().ok_or_else(|| {
+            RegistryError::Permanent(
+                "vtc_did not configured — cannot address the trust registry (complete `vtc setup` \
+                 first)"
+                    .into(),
+            )
+        })
+    }
+
+    /// Which transport to use for the registry, this call.
+    ///
+    /// Re-evaluated per call rather than cached at boot: a registry that adds
+    /// `#tsp` mid-life should be reached over TSP on the next attempt, and the
+    /// resolver's own cache keeps this cheap.
+    async fn select(&self) -> Result<Protocol, RegistryError> {
+        let Some(resolver) = self.did_resolver.as_ref() else {
+            // No resolver configured: we cannot read the peer's document, and
+            // guessing is exactly the failure mode CLAUDE.md forbids.
+            return Err(RegistryError::Permanent(
+                "no DID resolver configured — cannot read the trust registry's advertised \
+                 transports"
+                    .into(),
+            ));
+        };
+        let resolved = resolver.resolve(&self.registry_did).await.map_err(|e| {
+            // Resolution failure is a network-shaped condition (the DID host or
+            // the resolver sidecar is down), so it is retriable.
+            RegistryError::Unreachable(format!(
+                "could not resolve trust-registry DID {}: {e}",
+                self.registry_did
+            ))
+        })?;
+        let doc = serde_json::to_value(&resolved.doc).map_err(|e| {
+            RegistryError::Transient(format!("could not read the registry's DID document: {e}"))
+        })?;
+        let theirs = ServiceCapabilities::from_did_document(&doc);
+        let ours = self.our_capabilities();
+        let matched = select_protocol(&ours, &theirs, &self.registry_did)
+            // No overlap is an operator-fixable configuration fault, not a
+            // blip: park the job rather than retrying it forever.
+            .map_err(|e| RegistryError::Permanent(e.to_string()))?;
+        debug!(
+            registry_did = %self.registry_did,
+            protocol = %matched.protocol.as_str(),
+            "selected trust-registry transport",
+        );
+        Ok(matched.protocol)
+    }
+
+    /// What *this* VTC can speak to a peer, as a capability set.
+    ///
+    /// Not our advertised document: this is the **client** side. TSP and
+    /// DIDComm need our mediator (hence the messaging handle), REST needs only
+    /// an HTTP client, which we always have when a URL is configured. The
+    /// endpoint strings are never read for our own side — [`select_protocol`]
+    /// only tests presence — so they carry our identity for readability.
+    fn our_capabilities(&self) -> ServiceCapabilities {
+        let messaging_up = self.didcomm.get().is_some();
+        ServiceCapabilities {
+            tsp: (messaging_up && cfg!(feature = "tsp")).then(|| self.registry_did.clone()),
+            didcomm: messaging_up.then(|| self.registry_did.clone()),
+            rest: self.http.is_some().then(|| "rest-client".to_string()),
+        }
+    }
+
+    /// Build, optionally sign, send, and await the reply for one task.
+    ///
+    /// `sign` is the spec's `IS_PROOF_REQUIRED` for the type: writes
+    /// (`record/put`, `record/delete`) carry the VTC's Data-Integrity proof;
+    /// reads (`record/query`, `recognition`) do not.
+    async fn round_trip(
+        &self,
+        type_uri: &str,
+        payload: Value,
+        sign: bool,
+        protocol: Protocol,
+    ) -> Result<TrustTask<Value>, RegistryError> {
+        let issuer = self.authority()?.to_string();
+        let messaging = self.didcomm.get().ok_or_else(|| {
+            RegistryError::Transient("VTC messaging is not running yet".to_string())
+        })?;
+
+        let mut doc = build_document(&issuer, &self.registry_did, type_uri, payload);
+        if sign {
+            let mut as_value = serde_json::to_value(&doc)
+                .map_err(|e| RegistryError::Transient(format!("serialise document: {e}")))?;
+            self.signer
+                .sign_doc(&mut as_value)
+                .await
+                .map_err(|e| RegistryError::Transient(format!("sign document: {e}")))?;
+            doc = serde_json::from_value(as_value)
+                .map_err(|e| RegistryError::Transient(format!("reparse signed document: {e}")))?;
+        }
+
+        // Register before sending: a reply can land while the send is still
+        // returning.
+        let receiver = self.replies.register(&doc.id);
+        let send = match protocol {
+            Protocol::Tsp => self.send_tsp(messaging, &doc).await,
+            Protocol::Didcomm => self.send_didcomm(messaging, &doc).await,
+            // Handled by the callers, which delegate to the HTTP arm before
+            // ever reaching a round trip.
+            Protocol::Rest => Err(RegistryError::Permanent(
+                "REST transport does not use the Trust-Task round trip".into(),
+            )),
+        };
+        if let Err(e) = send {
+            self.replies.abandon(&doc.id);
+            return Err(e);
+        }
+
+        match tokio::time::timeout(self.reply_timeout, receiver).await {
+            Ok(Ok(reply)) => Ok(reply),
+            Ok(Err(_closed)) => {
+                self.replies.abandon(&doc.id);
+                Err(RegistryError::Transient("reply channel closed".to_string()))
+            }
+            Err(_elapsed) => {
+                self.replies.abandon(&doc.id);
+                // The registry may simply be slow, or the frame may have been
+                // dropped in a reconnect. Either way the syncer's backoff owns
+                // the retry — this is never a delivery confirmation.
+                Err(RegistryError::Unreachable(format!(
+                    "no reply from the trust registry within {}s",
+                    self.reply_timeout.as_secs()
+                )))
+            }
+        }
+    }
+
+    /// Pack the document in the DIDComm trust-task envelope and hand it to the
+    /// delivery layer.
+    async fn send_didcomm(
+        &self,
+        messaging: &VtcMessaging,
+        doc: &TrustTask<Value>,
+    ) -> Result<(), RegistryError> {
+        let body = serde_json::to_value(doc)
+            .map_err(|e| RegistryError::Transient(format!("serialise envelope body: {e}")))?;
+        let envelope = Message::build(
+            format!("urn:uuid:{}", Uuid::new_v4()),
+            TRUST_TASK_ENVELOPE_TYPE.to_string(),
+            body,
+        )
+        .from(messaging.vtc_did.clone())
+        .to(self.registry_did.clone())
+        .thid(doc.id.clone())
+        .finalize();
+
+        let (packed, _) = messaging
+            .atm
+            .pack_encrypted(
+                &envelope,
+                &self.registry_did,
+                Some(&messaging.vtc_did),
+                Some(&messaging.vtc_did),
+            )
+            .await
+            .map_err(|e| RegistryError::Unreachable(format!("pack failed: {e}")))?;
+
+        messaging
+            .service
+            .send(
+                &self.registry_did,
+                packed.into_bytes(),
+                Delivery::BestEffort,
+            )
+            .await
+            .map_err(|e| RegistryError::Unreachable(format!("send failed: {e}")))?;
+        Ok(())
+    }
+
+    /// Seal the document in the `trust-tasks-tsp` binding envelope and route it
+    /// to the registry over the existing mediator socket.
+    #[cfg(feature = "tsp")]
+    async fn send_tsp(
+        &self,
+        messaging: &VtcMessaging,
+        doc: &TrustTask<Value>,
+    ) -> Result<(), RegistryError> {
+        let body = tsp_envelope(doc)?;
+        // Route: our mediator, then the registry. TSP send is an HTTP post
+        // through the same profile the pickup socket is bound to — no second
+        // websocket (the mediator permits one per DID).
+        let route = vec![messaging.mediator_did.clone(), self.registry_did.clone()];
+        messaging
+            .atm
+            .tsp()
+            .send_routed(&messaging.profile, &route, &body)
+            .await
+            .map_err(|e| RegistryError::Unreachable(format!("TSP send failed: {e}")))?;
+        Ok(())
+    }
+
+    #[cfg(not(feature = "tsp"))]
+    async fn send_tsp(
+        &self,
+        _messaging: &VtcMessaging,
+        _doc: &TrustTask<Value>,
+    ) -> Result<(), RegistryError> {
+        // Unreachable in practice: `our_capabilities` never offers TSP without
+        // the feature, so the match can't land here. Kept as a typed refusal
+        // rather than an `unreachable!` so a future caller can't panic a daemon.
+        Err(RegistryError::Permanent(
+            "this build has no `tsp` feature and cannot send TSP frames".into(),
+        ))
+    }
+
+    /// The TRQP record key for one member of this community.
+    ///
+    /// The four parts must match [`UpstreamRegistryClient::recognise`]'s query
+    /// tuple exactly, or we publish records nobody looks up — a silent,
+    /// green-status failure. Both sides read the same constants.
+    fn record_key(&self, member_did: &str) -> Result<(String, String), RegistryError> {
+        Ok((member_did.to_string(), self.authority()?.to_string()))
+    }
+}
+
+/// Wrap a document in the `trust-tasks-tsp` binding envelope.
+fn tsp_envelope(doc: &TrustTask<Value>) -> Result<Vec<u8>, RegistryError> {
+    let document = serde_json::to_value(doc)
+        .map_err(|e| RegistryError::Transient(format!("serialise document: {e}")))?;
+    serde_json::to_vec(&json!({ "type": TSP_ENVELOPE_TYPE, "document": document }))
+        .map_err(|e| RegistryError::Transient(format!("serialise TSP envelope: {e}")))
+}
+
+/// Classify a reply document into "the task succeeded" or a typed failure.
+///
+/// The split that matters is retriable versus not: an `internalError` or
+/// `unavailable` is worth another attempt, whereas `permissionDenied` (the
+/// VTC's DID is not in the registry's `admin_dids`) or `proofInvalid` needs an
+/// operator and must not spin.
+fn classify(doc: &TrustTask<Value>, expect_slug: &str) -> Result<(), RegistryError> {
+    let slug = doc.type_uri.slug();
+    if slug == "trust-task-error" {
+        let code = doc
+            .payload
+            .get("code")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown");
+        let message = doc
+            .payload
+            .get("message")
+            .and_then(Value::as_str)
+            .unwrap_or("");
+        let detail = format!("registry rejected {expect_slug}: {code}");
+        let detail = if message.is_empty() {
+            detail
+        } else {
+            format!("{detail} ({message})")
+        };
+        return match code {
+            "internalError" | "unavailable" => Err(RegistryError::Transient(detail)),
+            _ => Err(RegistryError::Permanent(detail)),
+        };
+    }
+    if !doc.type_uri.is_response() || slug != expect_slug {
+        // A correlated reply of the wrong type is a contract bug on one side or
+        // the other. Retrying cannot fix it, but calling it permanent would
+        // strand a job that a redeploy would fix — transient and loud.
+        return Err(RegistryError::Transient(format!(
+            "expected a {expect_slug} response, got `{}`",
+            doc.type_uri
+        )));
+    }
+    Ok(())
+}
+
+/// Build the TRQP record for a member as this community asserts it.
+///
+/// The spec's `TrustRecord` carries no validity window, so the membership
+/// status and its dates ride in `context` — the record's own opaque governance
+/// object. `recognized` is the machine-readable half: an active member is
+/// recognised, a departed one is not, which is what a TRQP verifier reads.
+fn trust_record(authority_did: &str, record: &RegistryRecord) -> Value {
+    let recognised = matches!(record.status, RegistryStatus::Active);
+    let mut context = json!({
+        "status": if recognised { "active" } else { "departed" },
+        "activeFrom": record.active_from.to_rfc3339(),
+    });
+    if let Some(active_to) = record.active_to {
+        context["activeTo"] = json!(active_to.to_rfc3339());
+    }
+    json!({
+        "entity_id": record.member_did,
+        "authority_id": authority_did,
+        "action": RECOGNISE_ACTION,
+        "resource": TRUST_GRAPH_RESOURCE,
+        "record_type": "recognition",
+        "recognized": recognised,
+        "context": context,
+    })
+}
+
+/// Rebuild a [`RegistryRecord`] from a TRQP record returned by the registry.
+///
+/// Absence is read restrictively (R3.3): a record whose `recognized` is missing
+/// is not treated as an active member.
+fn registry_record_from(value: &Value) -> Option<RegistryRecord> {
+    let member_did = value.get("entity_id")?.as_str()?.to_string();
+    let recognised = value
+        .get("recognized")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let context = value.get("context");
+    let parse_time = |key: &str| {
+        context
+            .and_then(|c| c.get(key))
+            .and_then(Value::as_str)
+            .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+            .map(|t| t.with_timezone(&chrono::Utc))
+    };
+    let now = chrono::Utc::now();
+    Some(RegistryRecord {
+        member_did,
+        status: if recognised {
+            RegistryStatus::Active
+        } else {
+            RegistryStatus::Departed
+        },
+        active_from: parse_time("activeFrom").unwrap_or(now),
+        active_to: parse_time("activeTo"),
+        last_synced_at: now,
+    })
+}
+
+#[async_trait]
+impl TrustRegistryClient for MessagingRegistryClient {
+    async fn publish_member(&self, record: &RegistryRecord) -> Result<(), RegistryError> {
+        let authority = self.authority()?.to_string();
+        match self.select().await? {
+            Protocol::Rest => self.rest()?.publish_member(record).await,
+            protocol => {
+                let payload = json!({ "record": trust_record(&authority, record) });
+                let reply = self.round_trip(RECORD_PUT, payload, true, protocol).await?;
+                classify(&reply, "registry/record/put")
+            }
+        }
+    }
+
+    async fn delete_member(&self, member_did: &str) -> Result<(), RegistryError> {
+        let (entity_id, authority_id) = self.record_key(member_did)?;
+        match self.select().await? {
+            Protocol::Rest => self.rest()?.delete_member(member_did).await,
+            protocol => {
+                let payload = json!({
+                    "entity_id": entity_id,
+                    "authority_id": authority_id,
+                    "action": RECOGNISE_ACTION,
+                    "resource": TRUST_GRAPH_RESOURCE,
+                });
+                let reply = self
+                    .round_trip(RECORD_DELETE, payload, true, protocol)
+                    .await?;
+                classify(&reply, "registry/record/delete")
+            }
+        }
+    }
+
+    async fn read_member(&self, member_did: &str) -> Result<Option<RegistryRecord>, RegistryError> {
+        let (entity_id, authority_id) = self.record_key(member_did)?;
+        match self.select().await? {
+            Protocol::Rest => self.rest()?.read_member(member_did).await,
+            protocol => {
+                // Deliberately *not* a fully-keyed fetch: supplying all four key
+                // parts makes this an exact lookup that errors on a miss, and a
+                // missing member is a normal answer, not a failure. Three
+                // filters keep it an enumeration — empty list on a miss — and
+                // we match `resource` here.
+                let payload = json!({
+                    "entity_id": entity_id,
+                    "authority_id": authority_id,
+                    "action": RECOGNISE_ACTION,
+                    "limit": 50,
+                });
+                let reply = self
+                    .round_trip(RECORD_QUERY, payload, false, protocol)
+                    .await?;
+                classify(&reply, "registry/record/query")?;
+                let found = reply
+                    .payload
+                    .get("records")
+                    .and_then(Value::as_array)
+                    .into_iter()
+                    .flatten()
+                    .find(|r| {
+                        r.get("resource").and_then(Value::as_str) == Some(TRUST_GRAPH_RESOURCE)
+                    })
+                    .and_then(registry_record_from);
+                Ok(found)
+            }
+        }
+    }
+
+    async fn recognise(&self, foreign_issuer_did: &str) -> Result<bool, RegistryError> {
+        let authority = self.authority()?.to_string();
+        match self.select().await? {
+            Protocol::Rest => self.rest()?.recognise(foreign_issuer_did).await,
+            protocol => {
+                let payload = json!({
+                    "entity_id": foreign_issuer_did,
+                    "authority_id": authority,
+                    "action": RECOGNISE_ACTION,
+                    "resource": TRUST_GRAPH_RESOURCE,
+                });
+                let reply = self
+                    .round_trip(RECOGNITION, payload, false, protocol)
+                    .await?;
+                classify(&reply, "registry/recognition")?;
+                // Absence is "not recognised", never "recognised" — the
+                // restrictive reading a missing scope field always gets
+                // (R3.3). This is also what makes the Trust-Task arm immune to
+                // the HTTP arm's `recognized`-optionality defect, where an
+                // omitted field parsed as a transport failure and surfaced as
+                // an indefinite 503.
+                Ok(reply
+                    .payload
+                    .get("recognized")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false))
+            }
+        }
+    }
+
+    async fn health(&self) -> Result<(), RegistryError> {
+        match self.select().await? {
+            Protocol::Rest => self.rest()?.health().await,
+            protocol => {
+                // A read-only `record/query` round trip. It needs no proof and
+                // no admin ACL, so it works on a registry that would refuse our
+                // writes — but unlike an HTTP GET of a static document it
+                // exercises the whole path we actually depend on: mediator,
+                // transport, dispatcher, storage.
+                //
+                // Any correlated reply proves liveness, **including a rejection**
+                // — the registry answered. Only silence is unhealthy, which is
+                // what makes this signal re-falsifiable (R6.2).
+                let payload = json!({ "limit": 1 });
+                match self
+                    .round_trip(RECORD_QUERY, payload, false, protocol)
+                    .await
+                {
+                    Ok(_) => Ok(()),
+                    Err(RegistryError::Permanent(e)) => {
+                        // A rejection still proves the registry is answering.
+                        debug!(error = %e, "registry health probe answered with a rejection");
+                        Ok(())
+                    }
+                    Err(e) => Err(e),
+                }
+            }
+        }
+    }
+}
+
+impl MessagingRegistryClient {
+    /// The REST arm, or a `Permanent` refusal when the registry advertises
+    /// `TRQPRest` but no `registry.url` is configured.
+    fn rest(&self) -> Result<&UpstreamRegistryClient, RegistryError> {
+        self.http.as_ref().ok_or_else(|| {
+            RegistryError::Permanent(
+                "the trust registry advertises only REST, but `registry.url` is not configured — \
+                 set it, or advertise a messaging transport on the registry's DID"
+                    .into(),
+            )
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+
+    use super::*;
+    use chrono::{TimeZone, Utc};
+
+    fn record_doc(slug: &str, payload: Value) -> TrustTask<Value> {
+        TrustTask::new(
+            "urn:uuid:reply".to_string(),
+            format!("https://trusttasks.org/spec/{slug}/0.1#response")
+                .parse()
+                .unwrap(),
+            payload,
+        )
+    }
+
+    fn error_doc(code: &str) -> TrustTask<Value> {
+        TrustTask::new(
+            "urn:uuid:err".to_string(),
+            "https://trusttasks.org/spec/trust-task-error/0.1"
+                .parse()
+                .unwrap(),
+            json!({ "code": code, "message": "nope" }),
+        )
+    }
+
+    #[test]
+    fn tsp_envelope_type_matches_the_binding() {
+        // Pinned against `trust_tasks_tsp::ENVELOPE_TYPE`. A drift here is a
+        // silent interop break: the registry rejects an envelope whose `type`
+        // it does not recognise, and the failure surfaces only as a timeout.
+        assert_eq!(
+            TSP_ENVELOPE_TYPE,
+            "https://trusttasks.org/binding/tsp/0.1/envelope"
+        );
+    }
+
+    #[test]
+    fn tsp_envelope_wraps_the_document() {
+        let doc = build_document(
+            "did:webvh:vtc",
+            "did:webvh:registry",
+            RECORD_QUERY,
+            json!({ "limit": 1 }),
+        );
+        let bytes = tsp_envelope(&doc).unwrap();
+        let parsed: Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(parsed["type"], TSP_ENVELOPE_TYPE);
+        assert_eq!(parsed["document"]["type"], RECORD_QUERY);
+    }
+
+    #[test]
+    fn permission_denied_is_permanent_and_internal_error_is_transient() {
+        // `permissionDenied` means the VTC's DID is not in the registry's
+        // `admin_dids`. Retrying cannot fix that, and a retry loop would hide
+        // it behind an ever-growing queue instead of surfacing a failed job.
+        let denied = classify(&error_doc("permissionDenied"), "registry/record/put").unwrap_err();
+        assert!(matches!(denied, RegistryError::Permanent(_)));
+        assert!(!denied.is_retriable());
+
+        let internal = classify(&error_doc("internalError"), "registry/record/put").unwrap_err();
+        assert!(internal.is_retriable());
+    }
+
+    #[test]
+    fn a_wrong_response_type_does_not_pass_as_success() {
+        let wrong = record_doc("registry/record/query", json!({ "records": [] }));
+        assert!(classify(&wrong, "registry/record/put").is_err());
+        let right = record_doc(
+            "registry/record/put",
+            json!({ "ok": true, "created": true }),
+        );
+        assert!(classify(&right, "registry/record/put").is_ok());
+    }
+
+    #[test]
+    fn published_record_carries_the_query_tuple_and_recognition() {
+        let mut record = RegistryRecord::fresh_active("did:key:zMember");
+        record.active_from = Utc.with_ymd_and_hms(2026, 8, 1, 0, 0, 0).unwrap();
+        let value = trust_record("did:webvh:vtc", &record);
+
+        // The four key parts must equal the tuple `recognise()` queries with,
+        // or we publish records that are never read.
+        assert_eq!(value["entity_id"], "did:key:zMember");
+        assert_eq!(value["authority_id"], "did:webvh:vtc");
+        assert_eq!(value["action"], RECOGNISE_ACTION);
+        assert_eq!(value["resource"], TRUST_GRAPH_RESOURCE);
+        assert_eq!(value["record_type"], "recognition");
+        assert_eq!(value["recognized"], true);
+        assert_eq!(value["context"]["status"], "active");
+        assert_eq!(value["context"]["activeFrom"], "2026-08-01T00:00:00+00:00");
+    }
+
+    #[test]
+    fn a_departed_member_is_published_as_not_recognised() {
+        let from = Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap();
+        let to = Utc.with_ymd_and_hms(2026, 8, 1, 0, 0, 0).unwrap();
+        let record = RegistryRecord::departed("did:key:zGone", from, Some(to));
+        let value = trust_record("did:webvh:vtc", &record);
+        assert_eq!(value["recognized"], false);
+        assert_eq!(value["context"]["status"], "departed");
+        assert_eq!(value["context"]["activeTo"], "2026-08-01T00:00:00+00:00");
+    }
+
+    #[test]
+    fn a_record_without_recognized_reads_as_departed() {
+        // Absence is read restrictively: a record we cannot confirm is a
+        // recognition is not treated as live membership.
+        let parsed = registry_record_from(&json!({
+            "entity_id": "did:key:zMember",
+            "authority_id": "did:webvh:vtc",
+            "action": RECOGNISE_ACTION,
+            "resource": TRUST_GRAPH_RESOURCE,
+            "record_type": "recognition",
+        }))
+        .unwrap();
+        assert_eq!(parsed.status, RegistryStatus::Departed);
+    }
+
+    #[test]
+    fn record_round_trips_through_the_wire_shape() {
+        let record = RegistryRecord::fresh_active("did:key:zMember");
+        let wire = trust_record("did:webvh:vtc", &record);
+        let back = registry_record_from(&wire).unwrap();
+        assert_eq!(back.member_did, record.member_did);
+        assert_eq!(back.status, RegistryStatus::Active);
+        assert_eq!(back.active_from.timestamp(), record.active_from.timestamp());
+    }
+
+    #[test]
+    fn our_capabilities_offer_rest_only_with_a_url_and_messaging_only_when_up() {
+        let client = MessagingRegistryClient::new(
+            "did:webvh:registry".into(),
+            Some("did:webvh:vtc".into()),
+            Arc::new(OnceCell::new()),
+            Arc::new(LocalSigner::from_ed25519_seed(
+                "did:webvh:vtc".into(),
+                &[7u8; 32],
+            )),
+            PendingReplies::new(),
+            None,
+            None,
+        );
+        let caps = client.our_capabilities();
+        // Messaging is not up (empty OnceCell) and no URL is configured, so we
+        // can speak nothing — `select_protocol` will say so rather than the
+        // client silently picking a transport it cannot use.
+        assert_eq!(caps.advertised(), Vec::<Protocol>::new());
+    }
+
+    #[tokio::test]
+    async fn every_call_refuses_before_setup() {
+        // No `vtc_did` means no TRQP authority: writing a half-keyed record
+        // would publish rows under an empty authority that nothing can query.
+        let client = MessagingRegistryClient::new(
+            "did:webvh:registry".into(),
+            None,
+            Arc::new(OnceCell::new()),
+            Arc::new(LocalSigner::from_ed25519_seed(
+                "did:webvh:vtc".into(),
+                &[7u8; 32],
+            )),
+            PendingReplies::new(),
+            None,
+            None,
+        );
+        let err = client
+            .delete_member("did:key:zMember")
+            .await
+            .expect_err("refuses without an authority DID");
+        assert!(matches!(err, RegistryError::Permanent(_)));
+        assert!(err.to_string().contains("vtc_did"));
+    }
+
+    #[tokio::test]
+    async fn a_write_is_transient_while_messaging_is_down() {
+        // Messaging comes up after the client is built; a call in that window
+        // must be retriable, not a permanent failure that parks the job.
+        let client = MessagingRegistryClient::new(
+            "did:webvh:registry".into(),
+            Some("did:webvh:vtc".into()),
+            Arc::new(OnceCell::new()),
+            Arc::new(LocalSigner::from_ed25519_seed(
+                "did:webvh:vtc".into(),
+                &[7u8; 32],
+            )),
+            PendingReplies::new(),
+            None,
+            None,
+        )
+        .with_reply_timeout(Duration::from_millis(50));
+        let err = client
+            .round_trip(
+                RECORD_QUERY,
+                json!({ "limit": 1 }),
+                false,
+                Protocol::Didcomm,
+            )
+            .await
+            .expect_err("messaging is not running");
+        assert!(err.is_retriable(), "got {err:?}");
+    }
+}

--- a/vtc-service/src/registry/mod.rs
+++ b/vtc-service/src/registry/mod.rs
@@ -48,6 +48,7 @@
 
 pub mod client;
 pub mod health;
+pub mod messaging;
 pub mod model;
 pub mod policy;
 pub mod storage;
@@ -55,8 +56,23 @@ pub mod syncer;
 pub mod tail;
 pub mod upstream;
 
+/// The TRQP `action` every membership record and recognition query uses.
+///
+/// A record is only ever found by the **whole** four-part key
+/// (entity+authority+action+resource), so the tuple a member record is
+/// published under and the tuple `recognise()` queries with must be
+/// character-identical. Two constants, read by both the messaging client and
+/// the HTTP client, are what stop those drifting into a registry full of rows
+/// nobody looks up — a failure with no error anywhere.
+pub const RECOGNISE_ACTION: &str = "recognise";
+
+/// The TRQP `resource` scope for the community's recognition graph. See
+/// [`RECOGNISE_ACTION`].
+pub const TRUST_GRAPH_RESOURCE: &str = "trust-graph";
+
 pub use client::{MockRegistryClient, RegistryError, TrustRegistryClient};
 pub use health::{HealthStatus, RegistryHealth, SyncerHealth, SyncerHealthSnapshot};
+pub use messaging::MessagingRegistryClient;
 pub use model::{
     DEFAULT_MAX_ATTEMPTS, MAX_BACKOFF_SECONDS, RegistryRecord, RegistryStatus, SyncJob,
     SyncJobKind, SyncJobState, exponential_backoff_seconds,

--- a/vtc-service/src/registry/upstream.rs
+++ b/vtc-service/src/registry/upstream.rs
@@ -245,6 +245,10 @@ impl TrustRegistryClient for UpstreamRegistryClient {
             action: &'static str,
             resource: &'static str,
         }
+        // The same two constants the messaging client publishes records under
+        // (`super::RECOGNISE_ACTION` / `TRUST_GRAPH_RESOURCE`). A record is
+        // found only by its whole four-part key, so a divergence here would
+        // mean querying a tuple nothing was ever written to.
         #[derive(serde::Deserialize)]
         #[allow(dead_code)]
         struct RecognitionResponse {
@@ -262,8 +266,8 @@ impl TrustRegistryClient for UpstreamRegistryClient {
         let body = RecognitionRequest {
             entity_id: foreign_issuer_did,
             authority_id: authority,
-            action: "recognise",
-            resource: "trust-graph",
+            action: super::RECOGNISE_ACTION,
+            resource: super::TRUST_GRAPH_RESOURCE,
         };
         debug!(%url, entity = %foreign_issuer_did, authority = %authority, "trust-registry recognise");
         let resp = self

--- a/vtc-service/src/server.rs
+++ b/vtc-service/src/server.rs
@@ -97,7 +97,7 @@ pub struct AppState {
     pub hooks_cursor_ks: KeyspaceHandle,
     /// In-flight capability writes awaiting their DIDComm reply — shared
     /// between the hook relay's writer and the inbound demux.
-    pub capability_replies: crate::hooks::PendingReplies,
+    pub pending_replies: crate::hooks::PendingReplies,
     /// VRC trust-edge rows (Phase 4 M4.5). Primary keyspace.
     pub relationships_ks: KeyspaceHandle,
     /// VRC per-DID secondary index (Phase 4 M4.5). Keyed by
@@ -454,39 +454,7 @@ pub async fn run(
         );
     }
 
-    // M3.2: build the trust-registry client + run the boot
-    // health probe. When `registry.url` is unset, the client
-    // is `None` and `registry_health` stays Degraded. The
-    // periodic probe task is spawned later, after the audit
-    // writer is available.
     let registry_health = crate::registry::RegistryHealth::new();
-    let registry_client: Option<Arc<dyn crate::registry::TrustRegistryClient>> = match config
-        .registry
-        .url
-        .as_deref()
-    {
-        Some(url) => {
-            let cfg = crate::registry::upstream::UpstreamConfig {
-                base_url: url.to_string(),
-                http_timeout: std::time::Duration::from_secs(config.registry.http_timeout_seconds),
-                authority_did: config.vtc_did.clone(),
-            };
-            match crate::registry::UpstreamRegistryClient::new(cfg) {
-                Ok(c) => Some(Arc::new(c) as Arc<dyn crate::registry::TrustRegistryClient>),
-                Err(e) => {
-                    warn!(error = ?e, "failed to construct trust-registry client; running with registry features disabled");
-                    None
-                }
-            }
-        }
-        None => {
-            debug!(
-                "trust-registry url not configured — registry features disabled; \
-                     registry_status reads 'degraded'"
-            );
-            None
-        }
-    };
 
     // Initialize auth infrastructure. Pass the audit keyspaces in so
     // `init_auth` can derive the HMAC audit key from the same secret
@@ -557,6 +525,83 @@ pub async fn run(
         }
     };
 
+    // Build the trust-registry client. Two addressing modes, in preference
+    // order:
+    //
+    // - `registry.did` — the registry is a peer we reach over the transport
+    //   both DID documents advertise (TSP > DIDComm > REST). This is the
+    //   normal case: a registry is named by DID in the community's
+    //   `#trust-registry` referral, and a deployment need publish no URL at
+    //   all. `registry.url`, when also set, becomes the REST arm of that
+    //   client rather than a separate path.
+    // - `registry.url` alone — a registry that speaks only TRQP over HTTP.
+    //
+    // Neither ⇒ no client, registry features no-op, `registry_status` reads
+    // `degraded`. Constructed here rather than earlier because the messaging
+    // client needs the credential signer and DID resolver `init_auth` produces;
+    // the messaging handle itself arrives later, through the shared `OnceCell`.
+    let didcomm_cell: Arc<tokio::sync::OnceCell<Arc<crate::messaging::VtcMessaging>>> =
+        Arc::new(tokio::sync::OnceCell::new());
+    let pending_replies = crate::hooks::PendingReplies::new();
+    let http_arm = match config.registry.url.as_deref() {
+        Some(url) => {
+            let cfg = crate::registry::upstream::UpstreamConfig {
+                base_url: url.to_string(),
+                http_timeout: std::time::Duration::from_secs(config.registry.http_timeout_seconds),
+                authority_did: config.vtc_did.clone(),
+            };
+            match crate::registry::UpstreamRegistryClient::new(cfg) {
+                Ok(c) => Some(c),
+                Err(e) => {
+                    warn!(error = ?e, "failed to construct the HTTP trust-registry arm");
+                    None
+                }
+            }
+        }
+        None => None,
+    };
+    let registry_client: Option<Arc<dyn crate::registry::TrustRegistryClient>> =
+        match (config.registry.did.clone(), credential_signer.clone()) {
+            (Some(registry_did), Some(signer)) => {
+                info!(%registry_did, "trust registry addressed by DID over messaging");
+                Some(Arc::new(crate::registry::MessagingRegistryClient::new(
+                    registry_did,
+                    config.vtc_did.clone(),
+                    didcomm_cell.clone(),
+                    signer,
+                    pending_replies.clone(),
+                    did_resolver.clone(),
+                    http_arm,
+                ))
+                    as Arc<dyn crate::registry::TrustRegistryClient>)
+            }
+            // A registry DID without a credential signer would be able to build
+            // documents but not sign them, so every write would fail
+            // `proofRequired` at the registry. Refusing to construct the client
+            // is the honest outcome — `registry_status` reads degraded and the
+            // reason is in the log, rather than a queue that only fills up.
+            (Some(_), None) => {
+                warn!(
+                    "registry.did is set but the VTC has no credential signer — registry \
+                     features disabled until setup completes"
+                );
+                None
+            }
+            (None, _) => match http_arm {
+                Some(c) => {
+                    debug!("trust registry addressed by URL (REST only — no registry.did set)");
+                    Some(Arc::new(c) as Arc<dyn crate::registry::TrustRegistryClient>)
+                }
+                None => {
+                    debug!(
+                        "no trust registry configured (neither registry.did nor registry.url) — \
+                         registry features disabled; registry_status reads 'degraded'"
+                    );
+                    None
+                }
+            },
+        };
+
     // Bind TCP listener on the main thread for early port validation
     let addr = format!("{}:{}", config.server.host, config.server.port);
     let std_listener = std::net::TcpListener::bind(&addr).map_err(AppError::Io)?;
@@ -610,7 +655,7 @@ pub async fn run(
         sync_cursor_ks,
         hooks_queue_ks,
         hooks_cursor_ks,
-        capability_replies: crate::hooks::PendingReplies::new(),
+        pending_replies: pending_replies.clone(),
         relationships_ks,
         relationships_by_did_ks,
         endorsement_types_ks,
@@ -638,7 +683,7 @@ pub async fn run(
         audit_writer,
         shutdown_tx: shutdown_tx.clone(),
         supervisor: detect_supervisor(),
-        didcomm: Arc::new(tokio::sync::OnceCell::new()),
+        didcomm: didcomm_cell,
     };
 
     // Heal missing AdminEntries: any DID with an Admin ACL grant +
@@ -855,7 +900,7 @@ pub async fn run(
             state.didcomm.clone(),
             signer,
             registry_did,
-            state.capability_replies.clone(),
+            state.pending_replies.clone(),
         ));
         let audit_ks = state.audit_ks.clone();
         let queue_ks = state.hooks_queue_ks.clone();

--- a/vtc-service/src/test_support.rs
+++ b/vtc-service/src/test_support.rs
@@ -755,6 +755,49 @@ mod didcomm_harness {
         (did, secrets)
     }
 
+    /// Mint a `did:peer:2` advertising a single `DIDCommMessaging` service at
+    /// `mediator_did`.
+    ///
+    /// The applicant's plain `generate_did_peer` is enough to *send* to the
+    /// VTC, because the VTC replies to the authcrypt sender it already has. A
+    /// peer the VTC has to reach on its own initiative is different: the
+    /// transport is chosen by reading that peer's document
+    /// (`ServiceCapabilities::from_did_document`), so a service-less `did:peer`
+    /// is a peer no matcher can route to — which is the honest behaviour, and
+    /// the reason this exists rather than a looser matcher.
+    ///
+    /// One service, so the identifier stays inside the 1000-byte limit every
+    /// stock `DIDCacheClient` applies before parsing (see
+    /// [`mint_dual_transport_did`] for what going over it costs).
+    fn mint_didcomm_peer(mediator_did: &str) -> (String, Vec<Secret>) {
+        use affinidi_tdk::dids::{
+            OneOrMany, PeerService, PeerServiceEndpoint, PeerServiceEndpointLong,
+        };
+
+        let (did, secrets) = DID::generate_did_peer_with_services(
+            peer_key_roles(),
+            Some(vec![PeerService {
+                type_: "DIDCommMessaging".into(),
+                endpoint: PeerServiceEndpoint::Long(OneOrMany::One(PeerServiceEndpointLong {
+                    uri: mediator_did.to_string(),
+                    accept: vec![],
+                    routing_keys: vec![],
+                })),
+                id: None,
+            }]),
+        )
+        .expect("mint a DIDComm-advertising did:peer");
+
+        const MAX_DID_BYTES: usize = 1_000;
+        assert!(
+            did.len() < MAX_DID_BYTES,
+            "peer did:peer is {} bytes, over the {MAX_DID_BYTES}-byte stock resolver limit",
+            did.len(),
+        );
+
+        (did, secrets)
+    }
+
     /// Build an ATM whose secrets resolver holds `secrets` (a `did:peer`'s keys).
     async fn build_atm(secrets: &[Secret]) -> ATM {
         let tdk = TDKSharedState::new(TDKConfig::builder().build().expect("TDK config"))
@@ -883,6 +926,45 @@ mod didcomm_harness {
         /// manifest's DCQL via `vta_sdk::vp::build_vp_token`.
         pub fn holder_secret(&self) -> &Secret {
             &self.holder_secret
+        }
+
+        /// Await the next inbound Trust-Task envelope, whatever it is threaded
+        /// to, and return the **document** the VTC sent.
+        ///
+        /// The counterpart to [`request`](Self::request): that one drives the
+        /// VTC from a client, this one lets a peer receive what the VTC sends
+        /// *out* — the direction a trust registry sits in. `None` on timeout.
+        pub async fn next_trust_task(&self, timeout: Duration) -> Option<Value> {
+            self.recv_matching(
+                |r| r.typ == vti_common::capability_client::TRUST_TASK_ENVELOPE_TYPE,
+                timeout,
+            )
+            .await
+            .map(|r| r.body)
+        }
+
+        /// Send `document` back to `to` as a Trust-Task envelope.
+        ///
+        /// Correlation is by the document's own `threadId` (the VTC's inbound
+        /// demux reads it off the body, not the DIDComm envelope), so the
+        /// caller sets that field; the DIDComm `thid` is set to match for
+        /// consistency with what a real peer emits.
+        pub async fn send_trust_task(&self, to: &str, document: Value) {
+            let thid = document
+                .get("threadId")
+                .and_then(Value::as_str)
+                .map(str::to_string);
+            let mut msg = Message::build(
+                format!("urn:uuid:{}", Uuid::new_v4()),
+                vti_common::capability_client::TRUST_TASK_ENVELOPE_TYPE.to_string(),
+                document,
+            )
+            .from(self.did.clone())
+            .to(to.to_string());
+            if let Some(thid) = thid {
+                msg = msg.thid(thid);
+            }
+            self.send(&msg.finalize(), to).await;
         }
 
         /// Send `body` as a `typ` DIDComm message to `vtc_did` (authcrypt,
@@ -1256,6 +1338,30 @@ mod didcomm_harness {
         /// The VTC's DIDComm identity — address join messages here.
         pub fn vtc_did(&self) -> &str {
             &self.vtc_did
+        }
+
+        /// Connect a second peer that stands in for a **trust registry**: a
+        /// `did:peer` advertising `DIDCommMessaging` at the shared mediator,
+        /// registered as a local account so it can open an inbound channel.
+        ///
+        /// Lazy rather than part of [`start`](Self::start) because every peer
+        /// costs a websocket, and the join suite has no registry in it.
+        ///
+        /// The caller owns the returned client's shutdown — [`shutdown`](Self::shutdown)
+        /// only knows about the applicant.
+        pub async fn connect_registry_peer(&self) -> TestJoinClient {
+            let (did, secrets) = mint_didcomm_peer(self.mediator.did());
+            self.mediator
+                .register_local_did(&did)
+                .await
+                .expect("register the registry peer as a local mediator account");
+            TestJoinClient::connect(
+                &secrets,
+                did,
+                self.mediator.did().to_string(),
+                generate_holder_secret(),
+            )
+            .await
         }
 
         /// The shared mediator's DID.

--- a/vtc-service/src/test_support.rs
+++ b/vtc-service/src/test_support.rs
@@ -344,7 +344,7 @@ impl TestVtcBuilder {
             sync_cursor_ks,
             hooks_queue_ks,
             hooks_cursor_ks,
-            capability_replies: crate::hooks::PendingReplies::new(),
+            pending_replies: crate::hooks::PendingReplies::new(),
             relationships_ks,
             relationships_by_did_ks,
             endorsement_types_ks,

--- a/vtc-service/tests/emergency_bootstrap.rs
+++ b/vtc-service/tests/emergency_bootstrap.rs
@@ -313,7 +313,7 @@ async fn build_fixture(public_url: Option<&str>) -> Fixture {
         sync_cursor_ks: sync_cursor_ks.clone(),
         hooks_queue_ks: hooks_queue_ks.clone(),
         hooks_cursor_ks: hooks_cursor_ks.clone(),
-        capability_replies: vtc_service::hooks::PendingReplies::new(),
+        pending_replies: vtc_service::hooks::PendingReplies::new(),
         relationships_ks: relationships_ks.clone(),
         relationships_by_did_ks: relationships_by_did_ks.clone(),
         endorsement_types_ks: endorsement_types_ks.clone(),

--- a/vtc-service/tests/passkey_state.rs
+++ b/vtc-service/tests/passkey_state.rs
@@ -88,7 +88,7 @@ fn build_state(public_url: Option<&str>) -> (AppState, tempfile::TempDir) {
         sync_cursor_ks: sync_cursor_ks.clone(),
         hooks_queue_ks: hooks_queue_ks.clone(),
         hooks_cursor_ks: hooks_cursor_ks.clone(),
-        capability_replies: vtc_service::hooks::PendingReplies::new(),
+        pending_replies: vtc_service::hooks::PendingReplies::new(),
         relationships_ks: relationships_ks.clone(),
         relationships_by_did_ks: relationships_by_did_ks.clone(),
         endorsement_types_ks: endorsement_types_ks.clone(),

--- a/vtc-service/tests/registry_didcomm.rs
+++ b/vtc-service/tests/registry_didcomm.rs
@@ -1,0 +1,315 @@
+//! A membership record reaches a trust registry over DIDComm, and the reply
+//! completes the call.
+//!
+//! What this pins that the unit tests cannot: the unit tests assert the wire
+//! shapes and the classification of a reply handed to them directly. They say
+//! nothing about whether a document the VTC builds can *leave* — whether
+//! transport selection finds a route, whether the send reaches a peer through
+//! a real mediator, and whether the peer's answer gets back to the caller that
+//! is blocked waiting for it.
+//!
+//! That last leg is the one that broke twice in this area. A send returning
+//! `Ok` means "the mediator accepted it" and nothing more (R1.1), so the only
+//! thing that can complete a registry write is a correlated reply — and the
+//! reply arrives on a different code path from the send, through the inbound
+//! demux. A demux that drops it looks exactly like a registry that never
+//! answered: the call times out, the syncer backs off, and the queue grows
+//! with no error anywhere naming the cause.
+//!
+//! The peer here is a real second DIDComm identity on the same mediator whose
+//! `did:peer` advertises `DIDCommMessaging`, so the VTC has to resolve it and
+//! choose a transport rather than be handed one.
+//!
+//! Requires `--features didcomm-harness`; CI runs it.
+
+#![cfg(feature = "didcomm-harness")]
+
+use std::time::Duration;
+
+use serde_json::{Value, json};
+
+use vtc_service::registry::{
+    MessagingRegistryClient, RECOGNISE_ACTION, RegistryRecord, RegistryStatus,
+    TRUST_GRAPH_RESOURCE, TrustRegistryClient,
+};
+use vtc_service::test_support::{MockVtcDidcomm, TestJoinClient};
+
+fn init_tracing() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .with_test_writer()
+        .try_init();
+}
+
+/// Build the client under test against `registry_did`, wired to the same
+/// messaging handle, signer, resolver and reply demux the daemon wires at boot.
+fn client_for(mock: &MockVtcDidcomm, registry_did: &str) -> MessagingRegistryClient {
+    let state = &mock.vtc.state;
+    MessagingRegistryClient::new(
+        registry_did.to_string(),
+        Some(mock.vtc_did().to_string()),
+        state.didcomm.clone(),
+        state
+            .credential_signer
+            .clone()
+            .expect("harness builds a credential signer"),
+        state.pending_replies.clone(),
+        state.did_resolver.clone(),
+        None,
+    )
+}
+
+/// Stand in for the registry: await the VTC's task, hand it to `answer`, and
+/// send whatever that returns back on the request's thread.
+///
+/// Returns the request document so the test can assert on what was actually
+/// put on the wire — the bytes the registry would verify, not a re-serialised
+/// copy of what we meant to send.
+async fn serve_once(
+    registry: &TestJoinClient,
+    vtc_did: &str,
+    answer: impl FnOnce(&Value) -> Value,
+) -> Value {
+    let request = registry
+        .next_trust_task(Duration::from_secs(30))
+        .await
+        .expect("the VTC's task reached the registry peer");
+    let mut reply = answer(&request);
+    reply["threadId"] = json!(request["id"].as_str().expect("request carries an id"));
+    registry.send_trust_task(vtc_did, reply).await;
+    request
+}
+
+const RECORD_PUT: &str = "https://trusttasks.org/spec/registry/record/put/0.1";
+const RECORD_QUERY: &str = "https://trusttasks.org/spec/registry/record/query/0.1";
+
+/// The `#response` to `request_type`, carrying `payload`.
+///
+/// Takes the whole request URI rather than interpolating a slug into a
+/// `trusttasks.org/spec/…` template: the canonical-task census scans source
+/// for `spec/` literals and asserts each one is a task the registry actually
+/// publishes, so a templated URI reads to it as a bound task named `{slug}`.
+fn response(request_type: &str, payload: Value) -> Value {
+    json!({
+        "id": format!("urn:uuid:{}", uuid::Uuid::new_v4()),
+        "type": format!("{request_type}#response"),
+        "issuedAt": "2026-01-01T00:00:00Z",
+        "payload": payload,
+    })
+}
+
+/// A `trust-task-error` with `code`.
+fn rejection(code: &str) -> Value {
+    json!({
+        "id": format!("urn:uuid:{}", uuid::Uuid::new_v4()),
+        "type": "https://trusttasks.org/spec/trust-task-error/0.1",
+        "issuedAt": "2026-01-01T00:00:00Z",
+        "payload": { "code": code, "message": "not on the admin list" },
+    })
+}
+
+#[tokio::test]
+async fn a_member_record_reaches_the_registry_and_the_reply_completes_the_write() {
+    init_tracing();
+    let mock = MockVtcDidcomm::start().await;
+    let registry = mock.connect_registry_peer().await;
+    let client = client_for(&mock, registry.did());
+
+    let record = RegistryRecord::fresh_active("did:key:zMemberOne");
+    let (result, request) = tokio::join!(
+        client.publish_member(&record),
+        serve_once(&registry, mock.vtc_did(), |_| response(
+            RECORD_PUT,
+            json!({ "ok": true, "created": true }),
+        )),
+    );
+
+    result.expect("the write completes once the registry answers");
+
+    // The document the registry actually received. `record/put` is a write, so
+    // the registry requires a proof and the four-part key must be the tuple a
+    // recognition query later looks up.
+    assert_eq!(
+        request["type"],
+        "https://trusttasks.org/spec/registry/record/put/0.1"
+    );
+    assert_eq!(request["issuer"], mock.vtc_did());
+    assert_eq!(request["recipient"], registry.did());
+    assert!(
+        request["proof"].is_object(),
+        "a record write must be signed — the registry rejects it as `proofRequired` otherwise: \
+         {request}",
+    );
+    let stored = &request["payload"]["record"];
+    assert_eq!(stored["entity_id"], "did:key:zMemberOne");
+    assert_eq!(stored["authority_id"], mock.vtc_did());
+    assert_eq!(stored["action"], RECOGNISE_ACTION);
+    assert_eq!(stored["resource"], TRUST_GRAPH_RESOURCE);
+    assert_eq!(stored["recognized"], true);
+
+    registry.shutdown().await;
+    mock.shutdown().await;
+}
+
+#[tokio::test]
+async fn a_rejection_is_a_permanent_failure_not_a_retry_loop() {
+    init_tracing();
+    let mock = MockVtcDidcomm::start().await;
+    let registry = mock.connect_registry_peer().await;
+    let client = client_for(&mock, registry.did());
+
+    // `permissionDenied` is what a registry says when the VTC's DID is not on
+    // its admin list. Retrying cannot fix that, so it must reach the syncer as
+    // permanent — a retriable classification here is how a misconfiguration
+    // turns into an ever-growing queue with no failed job to look at.
+    let record = RegistryRecord::fresh_active("did:key:zMemberTwo");
+    let (result, _) = tokio::join!(
+        client.publish_member(&record),
+        serve_once(&registry, mock.vtc_did(), |_| rejection("permissionDenied")),
+    );
+
+    let err = result.expect_err("a rejected write is a failure");
+    assert!(!err.is_retriable(), "got {err:?}");
+    assert!(err.to_string().contains("permissionDenied"), "got {err}");
+
+    registry.shutdown().await;
+    mock.shutdown().await;
+}
+
+#[tokio::test]
+async fn health_follows_the_round_trip_not_a_url() {
+    init_tracing();
+    let mock = MockVtcDidcomm::start().await;
+    let registry = mock.connect_registry_peer().await;
+    let client = client_for(&mock, registry.did());
+
+    // A registry that answers is healthy. The probe is a read, so it carries
+    // no proof — the registry serves it without consulting its admin list.
+    let (result, request) = tokio::join!(
+        client.health(),
+        serve_once(&registry, mock.vtc_did(), |_| response(
+            RECORD_QUERY,
+            json!({ "records": [] }),
+        )),
+    );
+    result.expect("a registry that answers is healthy");
+    assert_eq!(
+        request["type"],
+        "https://trusttasks.org/spec/registry/record/query/0.1"
+    );
+    assert!(
+        request["proof"].is_null(),
+        "the health probe must not need a proof, or it stops working on a \
+         registry that refuses our writes: {request}",
+    );
+
+    // A registry that *rejects* is still answering, and answering is what the
+    // signal reports on.
+    let (result, _) = tokio::join!(
+        client.health(),
+        serve_once(&registry, mock.vtc_did(), |_| rejection("permissionDenied")),
+    );
+    result.expect("a rejection still proves the registry is alive");
+
+    registry.shutdown().await;
+    mock.shutdown().await;
+}
+
+#[tokio::test]
+async fn silence_is_unhealthy_and_retriable() {
+    init_tracing();
+    let mock = MockVtcDidcomm::start().await;
+    let registry = mock.connect_registry_peer().await;
+    // Deliberately no `serve_once`: the peer is connected but never answers.
+    // This is the case the old HTTP probe could not represent — the registry's
+    // URL is up, its DID resolves, and it is still not doing its job.
+    let client = client_for(&mock, registry.did()).with_reply_timeout(Duration::from_secs(2));
+
+    let err = client
+        .health()
+        .await
+        .expect_err("a registry that never answers is not healthy");
+    assert!(err.is_retriable(), "silence is transient, got {err:?}");
+
+    registry.shutdown().await;
+    mock.shutdown().await;
+}
+
+#[tokio::test]
+async fn a_member_record_round_trips_through_query() {
+    init_tracing();
+    let mock = MockVtcDidcomm::start().await;
+    let registry = mock.connect_registry_peer().await;
+    let client = client_for(&mock, registry.did());
+
+    // Echo back the record shape the registry stores, and check the client
+    // reconstructs the member from it — the pairing that decides whether boot
+    // drift detection compares like with like.
+    let (result, request) = tokio::join!(
+        client.read_member("did:key:zMemberThree"),
+        serve_once(&registry, mock.vtc_did(), |req| {
+            let entity = req["payload"]["entity_id"].as_str().unwrap_or_default();
+            response(
+                RECORD_QUERY,
+                json!({
+                    "records": [{
+                        "entity_id": entity,
+                        "authority_id": req["payload"]["authority_id"],
+                        "action": RECOGNISE_ACTION,
+                        "resource": TRUST_GRAPH_RESOURCE,
+                        "record_type": "recognition",
+                        "recognized": true,
+                        "context": { "status": "active", "activeFrom": "2026-08-01T00:00:00Z" },
+                    }],
+                }),
+            )
+        }),
+    );
+
+    let found = result
+        .expect("query completes")
+        .expect("the registry returned a record for this member");
+    assert_eq!(found.member_did, "did:key:zMemberThree");
+    assert_eq!(found.status, RegistryStatus::Active);
+    // Not a fully-keyed fetch: all four parts make it an exact lookup that
+    // errors on a miss, and "this member has no record" is a normal answer.
+    assert!(
+        request["payload"]["resource"].is_null(),
+        "read_member must stay an enumeration: {request}",
+    );
+
+    registry.shutdown().await;
+    mock.shutdown().await;
+}
+
+#[tokio::test]
+async fn a_peer_advertising_no_transport_is_refused_by_name() {
+    init_tracing();
+    let mock = MockVtcDidcomm::start().await;
+    // The applicant's `did:peer` carries no service block, so there is nothing
+    // to match on. The point is that this fails as a *typed* refusal naming
+    // both sides' advertised sets, rather than defaulting to DIDComm because
+    // the peer happens to be reachable on the mediator — inferring transport
+    // from reachability is precisely what the matcher exists to prevent.
+    let client = client_for(&mock, mock.client.did());
+
+    let err = client
+        .health()
+        .await
+        .expect_err("a peer that advertises nothing cannot be routed to");
+    assert!(!err.is_retriable(), "a config fault must not spin: {err:?}");
+    // The message has to carry both sides' advertised sets, not just "failed":
+    // an operator reading it should be able to tell which side to fix without
+    // resolving the DID by hand.
+    let message = err.to_string();
+    assert!(
+        message.contains("no transport protocol in common"),
+        "the error should name the mismatch: {message}",
+    );
+    assert!(
+        message.contains("we advertise") && message.contains("they advertise []"),
+        "the error should quote both advertised sets: {message}",
+    );
+
+    mock.shutdown().await;
+}


### PR DESCRIPTION
The trust registry was addressed by URL and written to by nobody:
`publish_member` / `delete_member` / `read_member` were `Permanent`
stubs against a `tr-admin/1.0/*` premise the registry has since
replaced, and `with_atm` was never called, so membership never synced.
Meanwhile `health()` probed `GET /.well-known/did.json`, which stays
green while every write fails — a health flag that could not go false
for the thing it was reporting on (R6.2).

`registry.did` is now the address. The VTC resolves it, reads the
transports it advertises, and uses the highest-preference one both
sides speak (TSP > DIDComm > REST, matched on service `type`, never on
the `#id` fragment). No overlap raises `NoMatchingProtocol` carrying
both advertised sets rather than silently downgrading. `registry.url`
becomes the REST arm of that client, and still selects the HTTP-only
client on its own.

Everything rides canonical Trust Tasks: `registry/record/put`,
`registry/record/delete`, `registry/record/query`, and
`registry/recognition`. Writes carry the VTC's Data-Integrity proof
from the same assertion key that mints VMC/VEC — the key the registry
already verifies on the git-trust path. Reads carry none, per the
specs' own `IS_PROOF_REQUIRED`.

Health is a read-only `record/query` round trip. It needs no proof and
no admin ACL, so it works on a registry that would refuse our writes,
but it exercises mediator, transport, dispatcher and storage. Any
correlated reply counts as alive, including a rejection; only silence
is unhealthy.

Replies reuse the hook writer's `PendingReplies` (field renamed to
match its widened role), so the DIDComm arm needed no new inbound
plumbing. The TSP arm did: `handle_tsp` dispatched every frame as a
request, so a reply would have been answered with an unsupported-type
error while the caller timed out. It now demuxes `#response` and
`trust-task-error` documents to their waiters first.

TSP framing differs between the two repos: this workspace sends bare
Trust-Task bytes, the registry implements the published
`trust-tasks-tsp` binding envelope and rejects anything else. We emit
the envelope and accept either shape inbound.

The record key tuple (`recognise` / `trust-graph`) moves to shared
constants read by both clients — publishing under a tuple the
recognition query does not use would be a silent, green-status
failure.

Not covered: no end-to-end test against a live registry. The unit
tests pin the wire shapes, the reply classification, and the demux;
the round trip itself needs a mediator and a registry.

Signed-off-by: Glenn Gore <glenn.g@affinidi.com>

