### PR TITLE
feat(vtc): show which transport each service is actually reached on

### DIFF
--- a/docs/03-vtc/trust-registry.md
+++ b/docs/03-vtc/trust-registry.md
@@ -239,16 +239,45 @@ document listed one that was never built. What exists today:
 
 ```sh
 # Reconciler state: registry_status, queue_depth, failed_count,
-# oldest_pending_age_seconds, last_error, syncer liveness.
+# oldest_pending_age_seconds, last_error, syncer liveness, plus the
+# transport view below.
 curl -H "Authorization: Bearer $TOKEN" \
   https://vtc.example.org/v1/health/diagnostics | jq .
 ```
 
-In the admin UI, the **Recognition** page shows the registry
-status and a per-DID recognition lookup, and the **Audit** page
+Two transport fields on that payload answer "how are we actually
+talking to it?":
+
+```jsonc
+"registry_transport": {
+  "did": "did:webvh:…:trust-registry",
+  "advertised": ["tsp", "didcomm"],   // the registry's own DID document
+  "active": "tsp"                     // what the last call chose
+},
+"transports": [                        // this VTC's own document
+  { "protocol": "tsp",     "advertised": true,  "serviceable": true  },
+  { "protocol": "didcomm", "advertised": false, "serviceable": true  }
+]
+```
+
+`advertised` and `active` are separate on purpose. A registry that
+advertises only TSP while this VTC can answer only DIDComm is
+configured and unreachable at the same time, and a single
+"protocol" field would have to drop one of those two facts. When
+selection fails, `active` is absent and `error` carries the
+reason — `advertised` still shows what the peer offered, which is
+the half that tells you which side to fix.
+
+In the admin UI: the **Dashboard** names the live mediator
+protocols on its tile, adds a trust-registry tile (active
+protocol + status), lists the registry DID under Identity, and
+raises a "Transport advertisement" card when the document and the
+build disagree in either direction. The **Recognition** page
+shows the registry DID, what it advertises, what we are
+connecting over, and the last transport error. The **Audit** page
 carries `RegistryStatusChanged` / `RegistrySyncSucceeded` /
-`RegistrySyncFailed`. Queue depth and failed-job counts are
-currently JSON-only.
+`RegistrySyncFailed`. Queue depth and failed-job counts remain
+JSON-only.
 
 ## See also
 

--- a/vtc-service/admin-ui/src/lib/api.ts
+++ b/vtc-service/admin-ui/src/lib/api.ts
@@ -20,6 +20,34 @@ export interface HealthResponse {
 // trust-registry reconciler state plus the identity/mediator detail
 // that used to live on `/health`. The dashboard only needs the
 // identity fields; the rest are typed for future diagnostics views.
+/** One protocol's state on this VTC's own DID document. */
+export interface TransportStatus {
+  /** "tsp" | "didcomm" | "rest" */
+  protocol: string;
+  /** The DID document advertises it, so a resolving client will find it. */
+  advertised: boolean;
+  /** This build can answer on it right now (compiled in + live mediator). */
+  serviceable: boolean;
+  /** Mediator DID for TSP/DIDComm, base URL for REST. */
+  endpoint?: string;
+}
+
+/**
+ * How the VTC reaches its trust registry.
+ *
+ * `advertised` is the registry's own claim (read from its DID document);
+ * `active` is what the last call actually chose. They are separate because a
+ * registry can be configured and unreachable at once — advertising a transport
+ * this VTC cannot answer — and one merged field would have to drop half of it.
+ */
+export interface RegistryTransport {
+  did?: string;
+  url?: string;
+  advertised: string[];
+  active?: string;
+  error?: string;
+}
+
 export interface DiagnosticsResponse {
   registry_status: string;
   queue_depth: number;
@@ -35,6 +63,9 @@ export interface DiagnosticsResponse {
   syncer_enabled: boolean;
   syncer_running: boolean;
   syncer_restarts: number;
+  messaging_status?: string;
+  registry_transport?: RegistryTransport;
+  transports?: TransportStatus[];
 }
 
 export interface BuildInfo {

--- a/vtc-service/admin-ui/src/plugins/dashboard.tsx
+++ b/vtc-service/admin-ui/src/plugins/dashboard.tsx
@@ -21,6 +21,36 @@ export function Dashboard() {
   const status = health.data?.status;
   const mediatorDid = diagnostics.data?.mediator_did;
   const vtaDid = diagnostics.data?.vta_did;
+  const registry = diagnostics.data?.registry_transport;
+  const registryStatus = diagnostics.data?.registry_status;
+
+  // The messaging transports this VTC actually serves right now. "DIDComm
+  // transport ready" was true of every deployment and told an operator
+  // nothing: a VTC on TSP, or one advertising a transport its build cannot
+  // answer, read identically. Name the protocols instead.
+  const messaging = (diagnostics.data?.transports ?? []).filter(
+    (t) => t.protocol !== "rest",
+  );
+  const live = messaging.filter((t) => t.advertised && t.serviceable);
+  const advertisedOnly = messaging.filter((t) => t.advertised && !t.serviceable);
+  const servedOnly = messaging.filter((t) => !t.advertised && t.serviceable);
+
+  const mediatorFoot = !mediatorDid
+    ? "REST-only deployment"
+    : live.length
+      ? `${live.map((t) => protocolName(t.protocol)).join(" + ")} live`
+      : messaging.some((t) => t.advertised)
+        ? "advertised, not connected"
+        : "no messaging transport advertised";
+
+  // An advertised transport this build cannot answer is the failure that
+  // motivated the boot-time check: every conforming client picks it, and the
+  // more correct the client, the more certainly it fails.
+  const mediatorTone = !mediatorDid
+    ? "neutral"
+    : advertisedOnly.length || !live.length
+      ? "warn"
+      : "ok";
 
   return (
     <section className="page">
@@ -59,11 +89,75 @@ export function Dashboard() {
         />
         <StatTile
           label="Mediator"
-          value={mediatorDid ? "Configured" : "Not set"}
-          foot={mediatorDid ? "DIDComm transport ready" : "REST-only deployment"}
-          tone={mediatorDid ? "ok" : "neutral"}
+          value={
+            mediatorDid
+              ? live.length
+                ? live.map((t) => protocolName(t.protocol)).join(" · ")
+                : "Configured"
+              : "Not set"
+          }
+          foot={mediatorFoot}
+          tone={mediatorTone}
         />
+        {registry && (
+          <StatTile
+            label="Trust registry"
+            value={
+              registry.active
+                ? protocolName(registry.active)
+                : registryStatus === "active"
+                  ? "Active"
+                  : "Unreachable"
+            }
+            foot={
+              registry.error
+                ? registry.error
+                : registry.active
+                  ? `${registryStatus ?? "unknown"} · advertises ${
+                      registry.advertised.length
+                        ? registry.advertised.map(protocolName).join(", ")
+                        : "nothing"
+                    }`
+                  : "no transport selected yet"
+            }
+            tone={
+              registry.error
+                ? "warn"
+                : registryStatus === "active"
+                  ? "ok"
+                  : "warn"
+            }
+          />
+        )}
       </div>
+
+      {/* Advertised-but-unservable is worth its own line rather than a tone:
+          it is the one state where a *more* conforming client fails harder,
+          and the fix is a document change, not a restart. */}
+      {mediatorDid && (advertisedOnly.length > 0 || servedOnly.length > 0) && (
+        <section className="card">
+          <h3>Transport advertisement</h3>
+          {advertisedOnly.length > 0 && (
+            <p>
+              Advertised but not servable:{" "}
+              <strong>
+                {advertisedOnly.map((t) => protocolName(t.protocol)).join(", ")}
+              </strong>
+              . A client resolving this community's DID will choose it and fail.
+            </p>
+          )}
+          {servedOnly.length > 0 && (
+            <p className="muted">
+              Served but not advertised:{" "}
+              <strong>
+                {servedOnly.map((t) => protocolName(t.protocol)).join(", ")}
+              </strong>
+              . No client will choose it — add the service entry to the DID
+              document to start receiving that traffic.
+            </p>
+          )}
+        </section>
+      )}
 
       <section className="card">
         <h3>Identity</h3>
@@ -95,6 +189,32 @@ export function Dashboard() {
               successMessage="Mediator DID copied"
             />
           </dd>
+          {registry?.did && (
+            <>
+              <dt>Trust registry DID</dt>
+              <dd>
+                <code>{registry.did}</code>
+                <CopyButton
+                  value={registry.did}
+                  label="Copy trust registry DID"
+                  successMessage="Trust registry DID copied"
+                />
+              </dd>
+            </>
+          )}
+          {registry?.url && !registry.did && (
+            <>
+              <dt>Trust registry URL</dt>
+              <dd>
+                <code>{registry.url}</code>
+                <CopyButton
+                  value={registry.url}
+                  label="Copy trust registry URL"
+                  successMessage="Trust registry URL copied"
+                />
+              </dd>
+            </>
+          )}
           <dt>Health endpoint</dt>
           <dd>
             <a href="/health" target="_blank" rel="noreferrer">
@@ -117,6 +237,20 @@ export function Dashboard() {
       )}
     </section>
   );
+}
+
+/** Protocol names as the specs write them, not as the wire encodes them. */
+function protocolName(protocol: string): string {
+  switch (protocol) {
+    case "tsp":
+      return "TSP";
+    case "didcomm":
+      return "DIDComm";
+    case "rest":
+      return "REST";
+    default:
+      return protocol;
+  }
 }
 
 function StatTile({

--- a/vtc-service/admin-ui/src/plugins/recognition.tsx
+++ b/vtc-service/admin-ui/src/plugins/recognition.tsx
@@ -16,6 +16,21 @@ import {
   type RecognitionCheck,
 } from "@/lib/api";
 import { useToast } from "@/lib/toast";
+import { CopyButton } from "@/components/CopyButton";
+
+/** Protocol names as the specs write them, not as the wire encodes them. */
+function protocolName(protocol: string): string {
+  switch (protocol) {
+    case "tsp":
+      return "TSP";
+    case "didcomm":
+      return "DIDComm";
+    case "rest":
+      return "REST";
+    default:
+      return protocol;
+  }
+}
 
 export function Recognition() {
   const toast = useToast();
@@ -56,6 +71,59 @@ export function Recognition() {
             <dd>
               <code>{diagnostics.data.registry_status}</code>
             </dd>
+            {diagnostics.data.registry_transport?.did && (
+              <>
+                <dt>Registry DID</dt>
+                <dd>
+                  <code>{diagnostics.data.registry_transport.did}</code>
+                  <CopyButton
+                    value={diagnostics.data.registry_transport.did}
+                    label="Copy trust registry DID"
+                    successMessage="Trust registry DID copied"
+                  />
+                </dd>
+              </>
+            )}
+            {diagnostics.data.registry_transport?.url && (
+              <>
+                <dt>Registry URL</dt>
+                <dd>
+                  <code>{diagnostics.data.registry_transport.url}</code>
+                </dd>
+              </>
+            )}
+            {diagnostics.data.registry_transport && (
+              <>
+                {/* Advertised is the registry's own claim, read from its DID
+                    document; active is what the last call chose. Shown apart
+                    because "advertises TSP, talking DIDComm" and "advertises
+                    TSP, nothing in common" are different problems. */}
+                <dt>Advertises</dt>
+                <dd>
+                  <code>
+                    {diagnostics.data.registry_transport.advertised.length
+                      ? diagnostics.data.registry_transport.advertised
+                          .map(protocolName)
+                          .join(", ")
+                      : "(not resolved)"}
+                  </code>
+                </dd>
+                <dt>Connecting over</dt>
+                <dd>
+                  <code>
+                    {diagnostics.data.registry_transport.active
+                      ? protocolName(diagnostics.data.registry_transport.active)
+                      : "(none selected)"}
+                  </code>
+                </dd>
+              </>
+            )}
+            {diagnostics.data.registry_transport?.error && (
+              <>
+                <dt>Last transport error</dt>
+                <dd>{diagnostics.data.registry_transport.error}</dd>
+              </>
+            )}
           </dl>
         )}
       </section>

--- a/vtc-service/src/registry/client.rs
+++ b/vtc-service/src/registry/client.rs
@@ -124,6 +124,50 @@ pub trait TrustRegistryClient: Send + Sync {
     /// graph mid-session loses access on the next mint /
     /// refresh, not when a TTL elapses.
     async fn recognise(&self, foreign_issuer_did: &str) -> Result<bool, RegistryError>;
+
+    /// How this client is reaching the registry, for operator diagnostics.
+    ///
+    /// Defaults to "nothing known", so a test double need not implement it.
+    fn transport(&self) -> RegistryTransport {
+        RegistryTransport::default()
+    }
+}
+
+/// How the VTC reaches its trust registry, as an operator sees it.
+///
+/// The two protocol fields answer different questions, and reporting only one
+/// of them is what made the old `registry_status` misleading:
+///
+/// - `advertised` — what the registry's **DID document** says it speaks. Read
+///   from the document, which is the authority (CLAUDE.md), so an operator can
+///   see the registry's own claim without resolving the DID by hand.
+/// - `active` — what the last selection actually **chose**, which is the
+///   highest-preference protocol present in both parties' documents. Empty
+///   until the first call; `error` says why if selection failed.
+///
+/// Advertised without active means the two sides have no transport in common,
+/// or nothing has tried yet — a distinction a single "protocol" field cannot
+/// express, and precisely the state that leaves a registry looking configured
+/// while nothing can reach it.
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, utoipa::ToSchema)]
+pub struct RegistryTransport {
+    /// The registry's DID, when it is addressed by one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub did: Option<String>,
+    /// The registry's REST base URL, when one is configured.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    /// Protocols the registry's DID document advertises, in preference order
+    /// (`tsp`, `didcomm`, `rest`). Empty when the DID has not been resolved
+    /// yet, or when the registry is addressed by URL alone.
+    pub advertised: Vec<String>,
+    /// The protocol the last selection chose. `None` before the first call, or
+    /// when selection failed — see `error`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub active: Option<String>,
+    /// Why the last selection failed, if it did.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
 }
 
 // ---------------------------------------------------------------------------

--- a/vtc-service/src/registry/messaging.rs
+++ b/vtc-service/src/registry/messaging.rs
@@ -61,7 +61,7 @@
 //! published binding. We therefore emit the envelope and accept **either**
 //! shape inbound.
 
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
 use affinidi_did_resolver_cache_sdk::DIDCacheClient;
@@ -81,7 +81,7 @@ use crate::credentials::LocalSigner;
 use crate::hooks::PendingReplies;
 use crate::messaging::VtcMessaging;
 
-use super::client::{RegistryError, TrustRegistryClient};
+use super::client::{RegistryError, RegistryTransport, TrustRegistryClient};
 use super::model::{RegistryRecord, RegistryStatus};
 use super::upstream::UpstreamRegistryClient;
 use super::{RECOGNISE_ACTION, TRUST_GRAPH_RESOURCE};
@@ -128,6 +128,17 @@ pub struct MessagingRegistryClient {
     reply_timeout: Duration,
     /// REST arm — present when `registry.url` is configured.
     http: Option<UpstreamRegistryClient>,
+    /// What the last transport selection saw and chose, for the diagnostics
+    /// surface.
+    ///
+    /// Written on every [`select`](Self::select) rather than cached at boot,
+    /// because the selection is itself per-call: a registry that adds `#tsp`
+    /// mid-life changes this without a restart, and an operator looking at the
+    /// page needs the answer for the call that just ran, not the one at boot.
+    ///
+    /// A `std::sync::RwLock` and not a tokio one on purpose — every critical
+    /// section here is a field assignment with no `await` inside it (R1.3).
+    transport: Arc<RwLock<RegistryTransport>>,
 }
 
 impl std::fmt::Debug for MessagingRegistryClient {
@@ -150,6 +161,11 @@ impl MessagingRegistryClient {
         did_resolver: Option<DIDCacheClient>,
         http: Option<UpstreamRegistryClient>,
     ) -> Self {
+        let transport = Arc::new(RwLock::new(RegistryTransport {
+            did: Some(registry_did.clone()),
+            url: http.as_ref().map(|c| c.base_url().to_string()),
+            ..RegistryTransport::default()
+        }));
         Self {
             registry_did,
             authority_did,
@@ -159,6 +175,7 @@ impl MessagingRegistryClient {
             did_resolver,
             reply_timeout: Duration::from_secs(DEFAULT_REPLY_TIMEOUT_SECONDS),
             http,
+            transport,
         }
     }
 
@@ -188,38 +205,90 @@ impl MessagingRegistryClient {
     /// `#tsp` mid-life should be reached over TSP on the next attempt, and the
     /// resolver's own cache keeps this cheap.
     async fn select(&self) -> Result<Protocol, RegistryError> {
+        match self.select_inner().await {
+            Ok((protocol, advertised)) => {
+                self.record_selection(advertised, Some(protocol), None);
+                Ok(protocol)
+            }
+            Err((e, advertised)) => {
+                // Record the failure *with* whatever we learned about the peer.
+                // "Advertised [tsp], active none, error: no transport in common"
+                // is a diagnosis; "unreachable" on its own is not.
+                self.record_selection(advertised, None, Some(e.to_string()));
+                Err(e)
+            }
+        }
+    }
+
+    /// [`select`](Self::select) without the bookkeeping. Returns the peer's
+    /// advertised set alongside either outcome so the failure path can report
+    /// it too.
+    async fn select_inner(
+        &self,
+    ) -> Result<(Protocol, Vec<Protocol>), (RegistryError, Vec<Protocol>)> {
         let Some(resolver) = self.did_resolver.as_ref() else {
             // No resolver configured: we cannot read the peer's document, and
             // guessing is exactly the failure mode CLAUDE.md forbids.
-            return Err(RegistryError::Permanent(
-                "no DID resolver configured — cannot read the trust registry's advertised \
-                 transports"
-                    .into(),
+            return Err((
+                RegistryError::Permanent(
+                    "no DID resolver configured — cannot read the trust registry's advertised \
+                     transports"
+                        .into(),
+                ),
+                Vec::new(),
             ));
         };
         let resolved = resolver.resolve(&self.registry_did).await.map_err(|e| {
             // Resolution failure is a network-shaped condition (the DID host or
             // the resolver sidecar is down), so it is retriable.
-            RegistryError::Unreachable(format!(
-                "could not resolve trust-registry DID {}: {e}",
-                self.registry_did
-            ))
+            (
+                RegistryError::Unreachable(format!(
+                    "could not resolve trust-registry DID {}: {e}",
+                    self.registry_did
+                )),
+                Vec::new(),
+            )
         })?;
         let doc = serde_json::to_value(&resolved.doc).map_err(|e| {
-            RegistryError::Transient(format!("could not read the registry's DID document: {e}"))
+            (
+                RegistryError::Transient(format!(
+                    "could not read the registry's DID document: {e}"
+                )),
+                Vec::new(),
+            )
         })?;
         let theirs = ServiceCapabilities::from_did_document(&doc);
+        let advertised = theirs.advertised();
         let ours = self.our_capabilities();
         let matched = select_protocol(&ours, &theirs, &self.registry_did)
             // No overlap is an operator-fixable configuration fault, not a
             // blip: park the job rather than retrying it forever.
-            .map_err(|e| RegistryError::Permanent(e.to_string()))?;
+            .map_err(|e| (RegistryError::Permanent(e.to_string()), advertised.clone()))?;
         debug!(
             registry_did = %self.registry_did,
             protocol = %matched.protocol.as_str(),
             "selected trust-registry transport",
         );
-        Ok(matched.protocol)
+        Ok((matched.protocol, advertised))
+    }
+
+    /// Publish what the last selection saw, for the diagnostics surface.
+    fn record_selection(
+        &self,
+        advertised: Vec<Protocol>,
+        active: Option<Protocol>,
+        error: Option<String>,
+    ) {
+        let mut slot = match self.transport.write() {
+            Ok(slot) => slot,
+            // A poisoned lock means a panic while holding it. Diagnostics are
+            // not worth propagating that into a registry call, so drop the
+            // update rather than unwrap.
+            Err(_) => return,
+        };
+        slot.advertised = advertised.iter().map(|p| p.as_str().to_string()).collect();
+        slot.active = active.map(|p| p.as_str().to_string());
+        slot.error = error;
     }
 
     /// What *this* VTC can speak to a peer, as a capability set.
@@ -597,6 +666,19 @@ impl TrustRegistryClient for MessagingRegistryClient {
         }
     }
 
+    fn transport(&self) -> RegistryTransport {
+        // A poisoned lock only happens if a writer panicked mid-update; report
+        // the address we were configured with rather than failing a diagnostics
+        // read over it.
+        self.transport
+            .read()
+            .map(|t| t.clone())
+            .unwrap_or_else(|_| RegistryTransport {
+                did: Some(self.registry_did.clone()),
+                ..RegistryTransport::default()
+            })
+    }
+
     async fn health(&self) -> Result<(), RegistryError> {
         match self.select().await? {
             Protocol::Rest => self.rest()?.health().await,
@@ -774,11 +856,12 @@ mod tests {
         assert_eq!(back.active_from.timestamp(), record.active_from.timestamp());
     }
 
-    #[test]
-    fn our_capabilities_offer_rest_only_with_a_url_and_messaging_only_when_up() {
-        let client = MessagingRegistryClient::new(
+    /// A client with no messaging, no resolver and no REST arm — enough to
+    /// exercise everything that happens before a transport is chosen.
+    fn client_with(authority_did: Option<&str>) -> MessagingRegistryClient {
+        MessagingRegistryClient::new(
             "did:webvh:registry".into(),
-            Some("did:webvh:vtc".into()),
+            authority_did.map(str::to_string),
             Arc::new(OnceCell::new()),
             Arc::new(LocalSigner::from_ed25519_seed(
                 "did:webvh:vtc".into(),
@@ -787,7 +870,53 @@ mod tests {
             PendingReplies::new(),
             None,
             None,
-        );
+        )
+    }
+
+    #[test]
+    fn the_transport_snapshot_carries_the_did_before_any_call() {
+        // The diagnostics surface must be able to name the registry from the
+        // moment it is configured. Waiting for the first successful call would
+        // leave the page blank in exactly the situation an operator opens it:
+        // nothing is working yet.
+        let client = client_with(None);
+        let snapshot = client.transport();
+        assert_eq!(snapshot.did.as_deref(), Some("did:webvh:registry"));
+        assert!(snapshot.advertised.is_empty());
+        assert_eq!(snapshot.active, None);
+    }
+
+    #[test]
+    fn a_failed_selection_records_the_peer_set_alongside_the_error() {
+        // "advertised [tsp], active none, error: no transport in common" is a
+        // diagnosis an operator can act on. Recording the error while dropping
+        // what the peer offered would leave them resolving the DID by hand to
+        // learn the half that matters.
+        let client = client_with(None);
+        client.record_selection(vec![Protocol::Tsp], None, Some("no overlap".into()));
+        let snapshot = client.transport();
+        assert_eq!(snapshot.advertised, vec!["tsp".to_string()]);
+        assert_eq!(snapshot.active, None);
+        assert_eq!(snapshot.error.as_deref(), Some("no overlap"));
+    }
+
+    #[test]
+    fn a_later_success_clears_the_earlier_error() {
+        // Selection is re-evaluated per call, so the snapshot has to be
+        // re-falsifiable in both directions (R6.2): a registry that adds the
+        // missing service must stop reading as broken without a restart.
+        let client = client_with(None);
+        client.record_selection(vec![], None, Some("no overlap".into()));
+        client.record_selection(vec![Protocol::Didcomm], Some(Protocol::Didcomm), None);
+        let snapshot = client.transport();
+        assert_eq!(snapshot.advertised, vec!["didcomm".to_string()]);
+        assert_eq!(snapshot.active.as_deref(), Some("didcomm"));
+        assert_eq!(snapshot.error, None);
+    }
+
+    #[test]
+    fn our_capabilities_offer_rest_only_with_a_url_and_messaging_only_when_up() {
+        let client = client_with(Some("did:webvh:vtc"));
         let caps = client.our_capabilities();
         // Messaging is not up (empty OnceCell) and no URL is configured, so we
         // can speak nothing — `select_protocol` will say so rather than the
@@ -799,18 +928,7 @@ mod tests {
     async fn every_call_refuses_before_setup() {
         // No `vtc_did` means no TRQP authority: writing a half-keyed record
         // would publish rows under an empty authority that nothing can query.
-        let client = MessagingRegistryClient::new(
-            "did:webvh:registry".into(),
-            None,
-            Arc::new(OnceCell::new()),
-            Arc::new(LocalSigner::from_ed25519_seed(
-                "did:webvh:vtc".into(),
-                &[7u8; 32],
-            )),
-            PendingReplies::new(),
-            None,
-            None,
-        );
+        let client = client_with(None);
         let err = client
             .delete_member("did:key:zMember")
             .await
@@ -823,19 +941,8 @@ mod tests {
     async fn a_write_is_transient_while_messaging_is_down() {
         // Messaging comes up after the client is built; a call in that window
         // must be retriable, not a permanent failure that parks the job.
-        let client = MessagingRegistryClient::new(
-            "did:webvh:registry".into(),
-            Some("did:webvh:vtc".into()),
-            Arc::new(OnceCell::new()),
-            Arc::new(LocalSigner::from_ed25519_seed(
-                "did:webvh:vtc".into(),
-                &[7u8; 32],
-            )),
-            PendingReplies::new(),
-            None,
-            None,
-        )
-        .with_reply_timeout(Duration::from_millis(50));
+        let client =
+            client_with(Some("did:webvh:vtc")).with_reply_timeout(Duration::from_millis(50));
         let err = client
             .round_trip(
                 RECORD_QUERY,

--- a/vtc-service/src/registry/mod.rs
+++ b/vtc-service/src/registry/mod.rs
@@ -70,7 +70,7 @@ pub const RECOGNISE_ACTION: &str = "recognise";
 /// [`RECOGNISE_ACTION`].
 pub const TRUST_GRAPH_RESOURCE: &str = "trust-graph";
 
-pub use client::{MockRegistryClient, RegistryError, TrustRegistryClient};
+pub use client::{MockRegistryClient, RegistryError, RegistryTransport, TrustRegistryClient};
 pub use health::{HealthStatus, RegistryHealth, SyncerHealth, SyncerHealthSnapshot};
 pub use messaging::MessagingRegistryClient;
 pub use model::{

--- a/vtc-service/src/registry/upstream.rs
+++ b/vtc-service/src/registry/upstream.rs
@@ -121,6 +121,13 @@ impl UpstreamRegistryClient {
         self
     }
 
+    /// The registry base URL this client posts to, normalised (no trailing
+    /// slash). Read by the messaging client, which carries this one as its
+    /// REST arm and reports the URL on the diagnostics surface.
+    pub fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
     /// Classify a reqwest error into the workspace's error
     /// taxonomy. Connect / timeout / DNS errors are
     /// `Unreachable`; 5xx are `Transient`; 4xx are
@@ -304,6 +311,19 @@ impl TrustRegistryClient for UpstreamRegistryClient {
             .await
             .map_err(|e| RegistryError::Transient(format!("parse recognise response: {e}")))?;
         Ok(body.recognized)
+    }
+
+    fn transport(&self) -> super::client::RegistryTransport {
+        // URL-addressed: there is no DID to resolve, so nothing is "advertised"
+        // — we were told where to go. REST is active by construction, since
+        // this client has no other arm.
+        super::client::RegistryTransport {
+            did: None,
+            url: Some(self.base_url.clone()),
+            advertised: Vec::new(),
+            active: Some("rest".to_string()),
+            error: None,
+        }
     }
 
     async fn health(&self) -> Result<(), RegistryError> {

--- a/vtc-service/src/routes/health.rs
+++ b/vtc-service/src/routes/health.rs
@@ -111,6 +111,25 @@ pub struct DiagnosticsResponse {
     /// boot-time latch, per R6.2). `"disconnected"` when messaging is
     /// unconfigured.
     pub messaging_status: String,
+    /// How this VTC reaches its **trust registry**: its DID, the protocols the
+    /// registry's own document advertises, and the one the last call actually
+    /// chose. `None` when no registry is configured.
+    ///
+    /// Advertised and active are reported separately on purpose. A registry
+    /// that advertises TSP while this VTC can only answer DIDComm is
+    /// *configured* and *unreachable* at the same time, and one collapsed
+    /// "protocol" field cannot say so — it would have to pick one of the two
+    /// facts and drop the other.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub registry_transport: Option<crate::registry::RegistryTransport>,
+    /// This VTC's **own** transports: per protocol, whether its DID document
+    /// advertises it and whether this build can serve it right now.
+    ///
+    /// The same view the unauthenticated community profile publishes, from the
+    /// same helper — an operator comparing the two should never see them
+    /// disagree. Empty when the VTC's DID could not be resolved, which is
+    /// "unknown", not "none advertised".
+    pub transports: Vec<crate::transport_capability::TransportStatus>,
 }
 
 #[utoipa::path(
@@ -179,6 +198,7 @@ pub async fn diagnostics(
 
     let config = state.config.read().await;
     let vta_did = config.vta_did.clone();
+    let config_vtc_did = config.vtc_did.clone();
     let (mediator_url, mediator_did) = config
         .messaging
         .as_ref()
@@ -193,6 +213,27 @@ pub async fn diagnostics(
         registry_status = %registry_status,
         "diagnostics queried"
     );
+
+    // How we reach the registry, straight off the live client — so this
+    // reflects the transport the last call actually used, not the one config
+    // implies.
+    let registry_transport = state.registry_client.as_ref().map(|c| c.transport());
+
+    // Our own advertised-versus-servable view, resolved from the document
+    // rather than config: the deployment that motivated this had `#tsp` added
+    // to its DID log long after the VTC last wrote its own mirror.
+    let transports = match crate::transport_capability::resolved_capabilities(
+        state.did_resolver.as_ref(),
+        config_vtc_did.as_deref().unwrap_or_default(),
+    )
+    .await
+    {
+        Some(caps) => crate::transport_capability::public_transport_view_for_build(
+            &caps,
+            messaging_status == "connected",
+        ),
+        None => Vec::new(),
+    };
 
     Ok(Json(DiagnosticsResponse {
         registry_status,
@@ -210,5 +251,7 @@ pub async fn diagnostics(
         syncer_running: syncer.running,
         syncer_restarts: syncer.restarts,
         messaging_status,
+        registry_transport,
+        transports,
     }))
 }

--- a/vtc-service/tests/registry_didcomm.rs
+++ b/vtc-service/tests/registry_didcomm.rs
@@ -147,7 +147,49 @@ async fn a_member_record_reaches_the_registry_and_the_reply_completes_the_write(
     assert_eq!(stored["resource"], TRUST_GRAPH_RESOURCE);
     assert_eq!(stored["recognized"], true);
 
+    // What the diagnostics surface will report. It has to describe the call
+    // that just happened, not the configuration that implies it: the whole
+    // point of showing advertised *and* active is that an operator can tell a
+    // registry we are talking to from one we merely have a DID for.
+    let transport = client.transport();
+    assert_eq!(transport.did.as_deref(), Some(registry.did()));
+    assert_eq!(
+        transport.advertised,
+        vec!["didcomm".to_string()],
+        "the peer's did:peer advertises DIDComm and nothing else",
+    );
+    assert_eq!(
+        transport.active.as_deref(),
+        Some("didcomm"),
+        "the reported transport must be the one that carried the write",
+    );
+    assert_eq!(transport.error, None);
+
     registry.shutdown().await;
+    mock.shutdown().await;
+}
+
+#[tokio::test]
+async fn a_failed_selection_is_visible_on_the_transport_snapshot() {
+    init_tracing();
+    let mock = MockVtcDidcomm::start().await;
+    // The applicant advertises no service block, so there is nothing to match.
+    let client = client_for(&mock, mock.client.did());
+
+    client.health().await.expect_err("no route to this peer");
+
+    // The snapshot has to carry *why*, not just the absence of a transport —
+    // "advertised nothing" is the actionable half, and it is the half a bare
+    // `active: none` would drop.
+    let transport = client.transport();
+    assert_eq!(transport.active, None);
+    assert!(transport.advertised.is_empty());
+    let error = transport.error.expect("the failure is recorded");
+    assert!(
+        error.contains("no transport protocol in common"),
+        "got {error}",
+    );
+
     mock.shutdown().await;
 }
 


### PR DESCRIPTION
"Trust registry: active" and "Mediator: DIDComm transport ready" were
true of every deployment that had one configured. Neither said which
protocol was carrying the traffic, and the mediator line said DIDComm
even on a VTC whose document advertises only TSP — so the tile that
looked most reassuring was the one most likely to be wrong.

Diagnostics gains two views. `registry_transport` carries the
registry's DID (or URL), the protocols its own DID document
advertises, the protocol the last call actually chose, and the error
if selection failed. `transports` is this VTC's own advertised-versus-
servable matrix, from the same helper the unauthenticated community
profile already publishes — an operator comparing the two should never
see them disagree.

Advertised and active stay separate deliberately. A registry that
advertises TSP while this VTC can answer only DIDComm is configured
and unreachable at the same time; one merged "protocol" field would
have to pick one of those facts and drop the other. The same split is
why a failed selection still records what the peer offered — that is
the half that says which side to fix.

The registry client records the outcome on every selection rather than
caching at boot, because selection is itself per-call: a registry that
adds `#tsp` mid-life is reached over TSP on the next attempt, and the
snapshot has to be re-falsifiable in both directions.

In the UI: the mediator tile names the live protocols, a trust-registry
tile carries the active one, the registry DID appears under Identity,
Recognition shows advertised / connecting-over / last error, and a
"Transport advertisement" card appears when the document and the build
disagree — the state where a *more* conforming client fails harder,
and the fix is a document change rather than a restart.

Not covered: the VTA tile is unchanged. The VTC↔VTA relationship is
provisioning-time (sealed bundle over REST), with no runtime session
to report a protocol for, so there is nothing honest to put there.

Signed-off-by: Glenn Gore <glenn.g@affinidi.com>

