### PR TITLE
fix(vtc): a registry unreachable at boot is retriable, not permanent

### DIFF
--- a/docs/03-vtc/trust-registry.md
+++ b/docs/03-vtc/trust-registry.md
@@ -276,8 +276,25 @@ build disagree in either direction. The **Recognition** page
 shows the registry DID, what it advertises, what we are
 connecting over, and the last transport error. The **Audit** page
 carries `RegistryStatusChanged` / `RegistrySyncSucceeded` /
-`RegistrySyncFailed`. Queue depth and failed-job counts remain
-JSON-only.
+`RegistrySyncFailed`.
+
+### Reading the sync queue
+
+Recognition's **Membership sync** card is where a stalled
+reconciler becomes visible. It polls every 15s and shows:
+
+| Counter | What it means |
+|---|---|
+| **Pending** | Queued + in-flight jobs, with the age of the oldest *dispatchable* one. Depth alone is normal — a burst of joins drains. Depth that stays **old** is a stuck reconciler; ≥1h is the spec's degraded SLI. |
+| **Failed** | Terminal rows: `attempts > max_attempts`, or a `Permanent` error such as `permissionDenied`. **The syncer will not retry these** — they need operator triage, and they never clear on their own. |
+| **RTBF batched** | Deletions parked behind the daily flush window. Expected to be non-zero between flushes. |
+| **Syncer** | `running` / `stopped` / `off`, plus the panic-restart count. `enabled` but not `running` means the task is spawned and dead; a rising restart count is a "keeps crashing" signal. |
+
+Last success / last failure / last error sit underneath. The
+dashboard's trust-registry tile surfaces the two states worth
+interrupting for — any failed job, or a queue ≥1h behind — in
+place of the transport line, so a registry that answers while
+nothing is landing does not read as healthy.
 
 ## See also
 

--- a/vtc-service/admin-ui/src/lib/format.ts
+++ b/vtc-service/admin-ui/src/lib/format.ts
@@ -89,6 +89,30 @@ export function formatIso(iso: string): string {
 }
 
 /**
+ * Format an elapsed duration in seconds as a compact age (`45s`, `12m`,
+ * `3h 20m`, `2d 4h`).
+ *
+ * Used for staleness — "how long has the oldest sync job been waiting" — where
+ * the operator's question is scale, not precision: a queue 3 hours behind and
+ * one 3 hours and 12 minutes behind call for the same action. Seconds are shown
+ * only under a minute, where they are the whole signal.
+ */
+export function formatDuration(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds < 0) return "—";
+  if (seconds < 60) return `${Math.floor(seconds)}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) {
+    const rem = minutes % 60;
+    return rem ? `${hours}h ${rem}m` : `${hours}h`;
+  }
+  const days = Math.floor(hours / 24);
+  const rem = hours % 24;
+  return rem ? `${days}d ${rem}h` : `${days}d`;
+}
+
+/**
  * Format a Unix-seconds epoch (i.e. `seconds since 1970-01-01 UTC`)
  * into the operator's locale-string. Used by session / ACL rows
  * that carry epochs rather than ISO strings.

--- a/vtc-service/admin-ui/src/plugins/dashboard.tsx
+++ b/vtc-service/admin-ui/src/plugins/dashboard.tsx
@@ -3,6 +3,7 @@ import { ExternalLink } from "lucide-react";
 
 import { CopyButton } from "@/components/CopyButton";
 import { fetchHealth, fetchBuildInfo, fetchDiagnostics } from "@/lib/api";
+import { formatDuration } from "@/lib/format";
 
 export function Dashboard() {
   const health = useQuery({ queryKey: ["health"], queryFn: fetchHealth });
@@ -23,6 +24,19 @@ export function Dashboard() {
   const vtaDid = diagnostics.data?.vta_did;
   const registry = diagnostics.data?.registry_transport;
   const registryStatus = diagnostics.data?.registry_status;
+
+  // The two queue states worth interrupting the dashboard for. Failed rows are
+  // terminal — the syncer has given up, so they never clear on their own — and
+  // a queue an hour behind is the spec's degraded SLI. Plain depth is not
+  // trouble: a burst of joins drains.
+  const failed = diagnostics.data?.failed_count ?? 0;
+  const oldestPending = diagnostics.data?.oldest_pending_age_seconds;
+  const queueTrouble =
+    failed > 0
+      ? `${failed} sync job${failed === 1 ? "" : "s"} failed`
+      : oldestPending !== undefined && oldestPending >= 3600
+        ? `sync ${formatDuration(oldestPending)} behind`
+        : undefined;
 
   // The messaging transports this VTC actually serves right now. "DIDComm
   // transport ready" was true of every deployment and told an operator
@@ -109,19 +123,25 @@ export function Dashboard() {
                   ? "Active"
                   : "Unreachable"
             }
+            // Queue trouble outranks the transport line. A registry we are
+            // happily connected to while jobs pile up unsent is the exact
+            // state the old green indicator hid, so when there is a backlog
+            // this tile says so instead of reporting the protocol.
             foot={
               registry.error
-                ? registry.error
-                : registry.active
-                  ? `${registryStatus ?? "unknown"} · advertises ${
-                      registry.advertised.length
-                        ? registry.advertised.map(protocolName).join(", ")
-                        : "nothing"
-                    }`
-                  : "no transport selected yet"
+                ? summarise(registry.error)
+                : queueTrouble
+                  ? queueTrouble
+                  : registry.active
+                    ? `${registryStatus ?? "unknown"} · advertises ${
+                        registry.advertised.length
+                          ? registry.advertised.map(protocolName).join(", ")
+                          : "nothing"
+                      }`
+                    : "no transport selected yet"
             }
             tone={
-              registry.error
+              registry.error || queueTrouble
                 ? "warn"
                 : registryStatus === "active"
                   ? "ok"
@@ -237,6 +257,19 @@ export function Dashboard() {
       )}
     </section>
   );
+}
+
+/**
+ * Trim a transport error to a tile-sized line.
+ *
+ * These errors quote both parties' advertised sets and a full `did:webvh`,
+ * which runs to five wrapped lines in a stat tile and pushes the rest of the
+ * dashboard down. The Recognition page shows the whole thing; here it only has
+ * to be recognisable.
+ */
+function summarise(error: string, max = 90): string {
+  const oneLine = error.replace(/\s+/g, " ").trim();
+  return oneLine.length > max ? `${oneLine.slice(0, max - 1)}…` : oneLine;
 }
 
 /** Protocol names as the specs write them, not as the wire encodes them. */

--- a/vtc-service/admin-ui/src/plugins/recognition.tsx
+++ b/vtc-service/admin-ui/src/plugins/recognition.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/lib/api";
 import { useToast } from "@/lib/toast";
 import { CopyButton } from "@/components/CopyButton";
+import { formatDuration, formatIso } from "@/lib/format";
 
 /** Protocol names as the specs write them, not as the wire encodes them. */
 function protocolName(protocol: string): string {
@@ -36,9 +37,13 @@ export function Recognition() {
   const toast = useToast();
   const [did, setDid] = useState("");
 
+  // Polled, not fetched once: the queue below is the live picture of a
+  // background reconciler, and a snapshot frozen at page-load would show a
+  // drained queue as permanently stuck (or a stuck one as briefly busy).
   const diagnostics = useQuery({
     queryKey: ["diagnostics"],
     queryFn: fetchDiagnostics,
+    refetchInterval: 15_000,
   });
 
   const lookup = useMutation<RecognitionCheck, Error, string>({
@@ -47,6 +52,7 @@ export function Recognition() {
   });
 
   const result = lookup.data;
+  const oldestPending = diagnostics.data?.oldest_pending_age_seconds;
 
   return (
     <div className="page">
@@ -129,6 +135,107 @@ export function Recognition() {
       </section>
 
       <section className="card">
+        <h3>Membership sync</h3>
+        <p className="muted">
+          Member changes reach the registry through a durable queue with
+          exponential backoff. These counts are the only place a stalled
+          reconciler is visible — <code>registry_status</code> reports whether
+          the registry answers, not whether our writes are landing.
+        </p>
+        {diagnostics.isPending && <p className="muted">Loading…</p>}
+        {diagnostics.data && (
+          <>
+            <div className="stat-tiles">
+              <QueueTile
+                label="Pending"
+                value={diagnostics.data.queue_depth}
+                foot={
+                  oldestPending === undefined
+                    ? "nothing waiting"
+                    : `oldest ${formatDuration(oldestPending)}`
+                }
+                // A queue an hour behind is the spec's degraded SLI. Rising
+                // depth on its own is normal (a burst of joins drains); depth
+                // that stays *old* is the shape of a stuck reconciler.
+                tone={
+                  oldestPending !== undefined && oldestPending >= 3600
+                    ? "warn"
+                    : "neutral"
+                }
+              />
+              <QueueTile
+                label="Failed"
+                value={diagnostics.data.failed_count}
+                // Terminal rows: the syncer has given up on them, so unlike
+                // pending they will never clear on their own.
+                foot={
+                  diagnostics.data.failed_count > 0
+                    ? "given up — needs operator triage"
+                    : "none"
+                }
+                tone={diagnostics.data.failed_count > 0 ? "warn" : "ok"}
+              />
+              <QueueTile
+                label="RTBF batched"
+                value={diagnostics.data.rtbf_batched_count}
+                foot="held for the daily flush"
+              />
+              <QueueTile
+                label="Syncer"
+                value={
+                  !diagnostics.data.syncer_enabled
+                    ? "off"
+                    : diagnostics.data.syncer_running
+                      ? "running"
+                      : "stopped"
+                }
+                // Enabled but not running means the task is spawned and dead —
+                // mid-restart after a panic, or wedged. Rising restarts is the
+                // "keeps crashing" signal.
+                foot={
+                  !diagnostics.data.syncer_enabled
+                    ? "no registry configured"
+                    : diagnostics.data.syncer_restarts > 0
+                      ? `${diagnostics.data.syncer_restarts} restart${
+                          diagnostics.data.syncer_restarts === 1 ? "" : "s"
+                        }`
+                      : "no restarts"
+                }
+                tone={
+                  !diagnostics.data.syncer_enabled
+                    ? "neutral"
+                    : diagnostics.data.syncer_running &&
+                        diagnostics.data.syncer_restarts === 0
+                      ? "ok"
+                      : "warn"
+                }
+              />
+            </div>
+            <dl>
+              <dt>Last success</dt>
+              <dd>
+                {diagnostics.data.last_success_at
+                  ? formatIso(diagnostics.data.last_success_at)
+                  : "(never)"}
+              </dd>
+              <dt>Last failure</dt>
+              <dd>
+                {diagnostics.data.last_failure_at
+                  ? formatIso(diagnostics.data.last_failure_at)
+                  : "(none)"}
+              </dd>
+              {diagnostics.data.last_error && (
+                <>
+                  <dt>Last error</dt>
+                  <dd>{diagnostics.data.last_error}</dd>
+                </>
+              )}
+            </dl>
+          </>
+        )}
+      </section>
+
+      <section className="card">
         <h3>Check recognition</h3>
         <form
           onSubmit={(e) => {
@@ -190,6 +297,37 @@ export function Recognition() {
           </p>
         )}
       </section>
+    </div>
+  );
+}
+
+/**
+ * One queue counter. Deliberately the same visual language as the dashboard's
+ * `StatTile` — an operator reading "3 failed" here and a warn-toned tile there
+ * should not have to work out whether the two mean the same thing.
+ */
+function QueueTile({
+  label,
+  value,
+  foot,
+  tone = "neutral",
+}: {
+  label: string;
+  value: React.ReactNode;
+  foot?: string;
+  tone?: "ok" | "warn" | "neutral";
+}) {
+  return (
+    <div className="stat-tile">
+      <span className="stat-tile-label">{label}</span>
+      <span className="stat-tile-value">{value}</span>
+      {foot && (
+        <span
+          className={`stat-tile-foot${tone === "ok" ? " ok" : tone === "warn" ? " warn" : ""}`}
+        >
+          {foot}
+        </span>
+      )}
     </div>
   );
 }

--- a/vtc-service/src/registry/messaging.rs
+++ b/vtc-service/src/registry/messaging.rs
@@ -260,10 +260,12 @@ impl MessagingRegistryClient {
         let theirs = ServiceCapabilities::from_did_document(&doc);
         let advertised = theirs.advertised();
         let ours = self.our_capabilities();
-        let matched = select_protocol(&ours, &theirs, &self.registry_did)
-            // No overlap is an operator-fixable configuration fault, not a
-            // blip: park the job rather than retrying it forever.
-            .map_err(|e| (RegistryError::Permanent(e.to_string()), advertised.clone()))?;
+        let matched = select_protocol(&ours, &theirs, &self.registry_did).map_err(|e| {
+            (
+                classify_no_match(&ours, &advertised, e.to_string()),
+                advertised.clone(),
+            )
+        })?;
         debug!(
             registry_did = %self.registry_did,
             protocol = %matched.protocol.as_str(),
@@ -458,6 +460,35 @@ impl MessagingRegistryClient {
     fn record_key(&self, member_did: &str) -> Result<(String, String), RegistryError> {
         Ok((member_did.to_string(), self.authority()?.to_string()))
     }
+}
+
+/// Is an empty transport intersection a configuration fault, or are we just not
+/// ready yet?
+///
+/// The distinction is load-bearing and was got wrong at first: at boot the
+/// registry client exists before the messaging listener has published its
+/// handle, so `our_capabilities` is momentarily **empty** and every peer looks
+/// like "no transport in common". Reported as `Permanent` — which is what an
+/// empty intersection normally means — that transient startup window would park
+/// the first sync jobs in `Failed`, where the syncer never retries them. The
+/// health probe recovered on its next tick and looked fine; the queue would not
+/// have.
+///
+/// So: if *we* can currently speak nothing, this is our own startup race and it
+/// is retriable. Only an intersection that is empty while we do have a
+/// transport available is the operator's configuration to fix.
+fn classify_no_match(
+    ours: &ServiceCapabilities,
+    theirs: &[Protocol],
+    detail: String,
+) -> RegistryError {
+    if ours.advertised().is_empty() {
+        return RegistryError::Transient(format!(
+            "no transport available yet to reach the trust registry (VTC messaging is still \
+             starting, and no REST arm is configured); the registry advertises {theirs:?}",
+        ));
+    }
+    RegistryError::Permanent(detail)
 }
 
 /// Wrap a document in the `trust-tasks-tsp` binding envelope.
@@ -871,6 +902,34 @@ mod tests {
             None,
             None,
         )
+    }
+
+    #[test]
+    fn not_being_ready_is_transient_but_a_real_mismatch_is_permanent() {
+        // The boot race: the registry client is built before the messaging
+        // listener publishes its handle, so for a moment we can speak nothing
+        // and every peer reads as "no transport in common". Permanent there
+        // would park the first sync jobs in `Failed`, which the syncer never
+        // retries — the health probe would recover on its next tick and the
+        // queue would stay broken.
+        let not_ready = ServiceCapabilities::default();
+        let err = classify_no_match(&not_ready, &[Protocol::Didcomm], "no overlap".into());
+        assert!(err.is_retriable(), "got {err:?}");
+        assert!(
+            err.to_string().contains("still \nstarting")
+                || err.to_string().contains("still starting"),
+            "the message should name the startup race: {err}",
+        );
+
+        // We can speak DIDComm and the peer offers only TSP: a genuine
+        // configuration fault, and retrying it forever would hide it behind an
+        // ever-growing queue.
+        let ready = ServiceCapabilities {
+            didcomm: Some("did:webvh:mediator".into()),
+            ..ServiceCapabilities::default()
+        };
+        let err = classify_no_match(&ready, &[Protocol::Tsp], "no overlap".into());
+        assert!(!err.is_retriable(), "got {err:?}");
     }
 
     #[test]

--- a/vtc-service/tests/registry_didcomm.rs
+++ b/vtc-service/tests/registry_didcomm.rs
@@ -24,6 +24,7 @@
 
 #![cfg(feature = "didcomm-harness")]
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use serde_json::{Value, json};
@@ -164,6 +165,46 @@ async fn a_member_record_reaches_the_registry_and_the_reply_completes_the_write(
         "the reported transport must be the one that carried the write",
     );
     assert_eq!(transport.error, None);
+
+    registry.shutdown().await;
+    mock.shutdown().await;
+}
+
+#[tokio::test]
+async fn the_boot_race_is_retriable_not_a_permanent_config_fault() {
+    init_tracing();
+    let mock = MockVtcDidcomm::start().await;
+    let registry = mock.connect_registry_peer().await;
+
+    // Exactly the boot ordering: the registry client is constructed before the
+    // messaging listener publishes its handle, so this one holds an empty cell
+    // while the peer is perfectly reachable. Everything else — resolver, peer,
+    // its advertised DIDComm service — is real.
+    let client = MessagingRegistryClient::new(
+        registry.did().to_string(),
+        Some(mock.vtc_did().to_string()),
+        Arc::new(tokio::sync::OnceCell::new()),
+        mock.vtc
+            .state
+            .credential_signer
+            .clone()
+            .expect("harness builds a credential signer"),
+        mock.vtc.state.pending_replies.clone(),
+        mock.vtc.state.did_resolver.clone(),
+        None,
+    );
+
+    let err = client
+        .health()
+        .await
+        .expect_err("nothing can be sent before messaging is up");
+    // The whole point: `Permanent` here parks the first sync jobs in `Failed`,
+    // which the syncer never retries. The health probe would recover on its
+    // next tick and the queue would stay broken — a failure that looks fixed.
+    assert!(
+        err.is_retriable(),
+        "the startup window must be retriable, got {err:?}",
+    );
 
     registry.shutdown().await;
     mock.shutdown().await;


### PR DESCRIPTION
The boot log said it plainly: "no transport protocol in common … we
advertise [], they advertise [Didcomm]". We advertise nothing because
the registry client is constructed before the messaging listener
publishes its handle, so for the first seconds of a boot
`our_capabilities` is empty and every peer reads as having no
transport in common.

An empty intersection is normally an operator's configuration fault,
so it was classified `Permanent` — and that is the damaging part. The
health probe recovers on its next tick (the deployment flipped to
active 60s later, which is why a refresh looked fine), but a sync job
dispatched inside that window is parked in `Failed`, where the syncer
never retries it. The indicator heals and the queue does not.

Selection now asks which side is empty. If *we* can currently speak
nothing, that is our own startup race and it is transient. Only an
intersection that is empty while we do have a transport available is
the operator's to fix, and only that one parks the job.

Also surfaces the sync queue, which is the other half of the same
problem — a stalled reconciler had no representation in the UI at all.
Recognition gains a Membership sync card (pending with the age of the
oldest job, failed, RTBF-batched, syncer liveness + restarts, last
success/failure/error) polling every 15s, because a snapshot frozen at
page load shows a drained queue as permanently stuck. The dashboard's
trust-registry tile reports any failed job, or a queue an hour behind,
in place of its transport line: a registry that answers while nothing
lands is exactly the state the old green indicator hid.

Transport errors are trimmed on the tile — they quote both advertised
sets and a full did:webvh, which wrapped to five lines and pushed the
dashboard down. Recognition still shows the whole string.

Signed-off-by: Glenn Gore <glenn.g@affinidi.com>

