### PR TITLE
fix(cli): make `dids list` show the DID, and plan errors say what failed

### DIFF
--- a/vta-cli-common/src/commands/webvh.rs
+++ b/vta-cli-common/src/commands/webvh.rs
@@ -88,13 +88,18 @@ pub async fn cmd_webvh_server_list(client: &VtaClient) -> Result<(), Box<dyn std
 
     let title = format!(" WebVH Servers ({}) ", resp.servers.len());
 
+    // Column order is ID, Name, DID, Created — as the header and the rows
+    // above build it. The widths were written against a different order (their
+    // own comments still said "DID, Label"), so the name column was handed the
+    // DID's flexing `Min(40)` and the DID was squeezed into 16 characters:
+    // every row read as a wide name beside an unusable `did:webvh:Qm0M8Cr`.
     let table = Table::new(
         rows,
         [
             Constraint::Length(16), // ID
-            Constraint::Min(40),    // DID
-            Constraint::Min(16),    // Label
-            Constraint::Length(18), // Created
+            Constraint::Min(16),    // Name
+            Constraint::Min(46),    // DID
+            Constraint::Length(16), // Created
         ],
     )
     .header(header)
@@ -442,6 +447,36 @@ pub async fn cmd_webvh_did_create_with_files(
     cmd_webvh_did_create(client, req).await
 }
 
+/// Header cells **and** column widths for `dids list`, returned together.
+///
+/// One function because the Name column is conditional and the two lists have
+/// to agree: a widths list shorter than the row is not padded, it *truncates* —
+/// ratatui lays out exactly as many columns as it has constraints. When the
+/// widths were built separately and nobody added the conditional Name entry,
+/// every width landed one column to the left (Name inherited the DID's flexing
+/// `Min`, the DID inherited Context's fixed 16) and `Created` fell off the
+/// right-hand end. The rendered table was a full-width name beside a DID cut to
+/// `did:webvh:Qm0M8Cr`, which is the one thing the column exists to show.
+///
+/// `Min(46)` for the DID because `shorten_did` abbreviates only the SCID and
+/// keeps the host and path in full; below that a `did:webvh` stops being
+/// copyable.
+fn did_list_columns(show_names: bool) -> (Vec<&'static str>, Vec<Constraint>) {
+    let mut headers = vec!["DID", "Context", "Server", "Portable", "Created"];
+    let mut constraints = vec![
+        Constraint::Min(46),    // DID
+        Constraint::Length(16), // Context
+        Constraint::Length(16), // Server
+        Constraint::Length(8),  // Portable
+        Constraint::Length(16), // Created
+    ];
+    if show_names {
+        headers.insert(0, NAME_HEADER);
+        constraints.insert(0, Constraint::Min(16));
+    }
+    (headers, constraints)
+}
+
 pub async fn cmd_webvh_did_list(
     client: &VtaClient,
     context_id: Option<&str>,
@@ -485,10 +520,7 @@ pub async fn cmd_webvh_did_list(
         .fg(Color::White)
         .add_modifier(Modifier::BOLD);
     let show_names = book.names_any(resp.dids.iter().map(|d| d.did.as_str()));
-    let mut header_cells = vec!["DID", "Context", "Server", "Portable", "Created"];
-    if show_names {
-        header_cells.insert(0, NAME_HEADER);
-    }
+    let (header_cells, constraints) = did_list_columns(show_names);
     let header = Row::new(header_cells).style(header_style).bottom_margin(1);
 
     let rows: Vec<Row> = resp
@@ -518,23 +550,14 @@ pub async fn cmd_webvh_did_list(
 
     let title = format!(" WebVH DIDs ({}) ", resp.dids.len());
 
-    let table = Table::new(
-        rows,
-        [
-            Constraint::Min(40),    // DID
-            Constraint::Length(16), // Context
-            Constraint::Length(16), // Server
-            Constraint::Length(10), // Portable
-            Constraint::Length(18), // Created
-        ],
-    )
-    .header(header)
-    .column_spacing(2)
-    .block(
-        Block::bordered()
-            .title(title)
-            .border_style(Style::default().fg(Color::DarkGray)),
-    );
+    let table = Table::new(rows, constraints)
+        .header(header)
+        .column_spacing(2)
+        .block(
+            Block::bordered()
+                .title(title)
+                .border_style(Style::default().fg(Color::DarkGray)),
+        );
 
     let height = resp.dids.len() as u16 + 4;
     print_widget(table, height);
@@ -609,4 +632,47 @@ pub async fn cmd_webvh_did_log(
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The header and the widths must describe the same columns. They are
+    /// separate lists in ratatui, and a short widths list silently drops the
+    /// trailing columns while shifting every width onto the wrong one — which
+    /// is how `dids list` came to render a full-width name beside a truncated
+    /// DID, with `Created` missing altogether.
+    #[test]
+    fn did_list_headers_and_widths_describe_the_same_columns() {
+        for show_names in [false, true] {
+            let (headers, constraints) = did_list_columns(show_names);
+            assert_eq!(
+                headers.len(),
+                constraints.len(),
+                "header/width mismatch with show_names={show_names}"
+            );
+        }
+    }
+
+    /// The DID column is the flexing one, and it flexes from a width that can
+    /// still hold an abbreviated `did:webvh:…:<host>:<path>`. Pinned because
+    /// the failure mode is not a panic or a wrong value — it is a table that
+    /// renders, looks fine, and cannot be read.
+    #[test]
+    fn did_column_gets_the_width_a_webvh_did_needs() {
+        let (headers, constraints) = did_list_columns(true);
+        let did_at = headers
+            .iter()
+            .position(|h| *h == "DID")
+            .expect("DID column present");
+        assert_eq!(constraints[did_at], Constraint::Min(46));
+
+        // …and the name column must not be the one absorbing the spare width.
+        let name_at = headers
+            .iter()
+            .position(|h| *h == NAME_HEADER)
+            .expect("Name column present");
+        assert_eq!(constraints[name_at], Constraint::Min(16));
+    }
 }

--- a/vta-service/src/trust_tasks/planner.rs
+++ b/vta-service/src/trust_tasks/planner.rs
@@ -106,7 +106,7 @@ async fn plan_webvh_update(
 
     let plan = did_webvh::plan_did_webvh_update(&deps, auth, &req.did, options)
         .await
-        .map_err(|e| AppError::Internal(format!("webvh update dry-run failed: {e}")))?;
+        .map_err(dry_run_error)?;
 
     Ok(TaskPlan {
         effects: plan.to_effects(),
@@ -120,6 +120,36 @@ async fn plan_webvh_update(
         subject_context: Some(plan.subject_context.clone()),
         requester_authorized: plan.requester_authorized,
     })
+}
+
+/// Map a dry-run failure onto the same typed [`AppError`] the *execute* path
+/// would raise for the same cause, keeping "this happened while planning" in
+/// the message.
+///
+/// Every failure here used to become `AppError::Internal`, which loses exactly
+/// the detail that makes one diagnosable — and loses it in the worst place. The
+/// planner runs on the consent path and only there, so this is the report an
+/// approver-gated update produces: a DID this VTA does not hold, a context the
+/// requester cannot act in, and a genuine signing bug all arrived as one opaque
+/// `internalError`, while the *ungated* execution of the very same task
+/// answered `taskFailed: did not found: …`. Routing through the existing
+/// `From<UpdateDidWebvhError>` makes plan and execute agree on the variant, so
+/// turning consent on can no longer make an error less legible than leaving it
+/// off.
+#[cfg(feature = "webvh")]
+fn dry_run_error(err: crate::operations::did_webvh::UpdateDidWebvhError) -> AppError {
+    // `From<UpdateDidWebvhError>` owns the variant choice (notably: NotFound
+    // and Forbidden both collapse to NotFound so a plan cannot be used to probe
+    // for DIDs in a context the caller can't see). Re-wrap in the same variant
+    // rather than matching on the source error, so that policy stays in one
+    // place and a new variant there needs no edit here.
+    let framed = |msg: String| format!("webvh update dry-run: {msg}");
+    match AppError::from(err) {
+        AppError::NotFound(m) => AppError::NotFound(framed(m)),
+        AppError::Conflict(m) => AppError::Conflict(framed(m)),
+        AppError::Validation(m) => AppError::Validation(framed(m)),
+        other => AppError::Internal(framed(other.to_string())),
+    }
 }
 
 /// Re-run the dry-run at execution and check the world has not moved under the
@@ -239,5 +269,50 @@ mod tests {
     fn a_pin_appearing_from_nowhere_is_refused() {
         let unplanned = TaskPlan::default();
         assert!(check_unchanged(Some(&pin("3-Qm")), &Guards::default(), &unplanned).is_err());
+    }
+
+    /// Planning an update for a DID this VTA does not hold is a `NotFound`, the
+    /// same answer the execute path gives. It used to be an `internalError`,
+    /// which meant turning consent *on* made the report strictly worse than
+    /// leaving it off: the ungated task said "did not found", the gated one
+    /// said "internal error" and named nothing.
+    #[cfg(feature = "webvh")]
+    #[test]
+    fn a_missing_did_plans_as_not_found() {
+        let err = dry_run_error(crate::operations::did_webvh::UpdateDidWebvhError::NotFound(
+            "SCID did:webvh:QmNope:example.com:agent not found".into(),
+        ));
+        assert!(matches!(err, AppError::NotFound(_)), "{err:?}");
+        // The cause survives the reframing — that string is the whole
+        // diagnostic value of the error.
+        assert!(err.to_string().contains("QmNope"), "{err}");
+        assert!(err.to_string().contains("dry-run"), "{err}");
+    }
+
+    /// A context the requester cannot act in also plans as `NotFound`: the
+    /// `From<UpdateDidWebvhError>` mapping deliberately collapses Forbidden
+    /// into NotFound so a dry-run cannot be used to probe for DIDs in contexts
+    /// the caller cannot see. Re-wrapping must not undo that.
+    #[cfg(feature = "webvh")]
+    #[test]
+    fn a_forbidden_context_does_not_leak_through_the_plan() {
+        let err = dry_run_error(
+            crate::operations::did_webvh::UpdateDidWebvhError::Forbidden(
+                "not an admin of context `payroll`".into(),
+            ),
+        );
+        assert!(matches!(err, AppError::NotFound(_)), "{err:?}");
+    }
+
+    /// A genuine library/signing failure is still internal — the point of the
+    /// change is to stop flattening *everything* into that, not to stop using
+    /// it where it is right.
+    #[cfg(feature = "webvh")]
+    #[test]
+    fn a_library_failure_stays_internal() {
+        let err = dry_run_error(crate::operations::did_webvh::UpdateDidWebvhError::Library(
+            "chain validation: bad proof".into(),
+        ));
+        assert!(matches!(err, AppError::Internal(_)), "{err:?}");
     }
 }


### PR DESCRIPTION
Two unrelated fixes to the same delegated-update path, found chasing a
`webvh/dids/update` that failed after its consent gate passed.

**`pnm dids list` rendered a wide name beside an unreadable DID.** A
ratatui `Table` lays out exactly as many columns as it has width
constraints — a widths list shorter than the row is not padded, it
truncates. `dids list` builds its header and its rows with a conditional
Name column but built the widths without one, so every width landed a
column to the left: Name inherited the DID's flexing `Min`, the DID
inherited Context's fixed 16 (`did:webvh:Qm0M8Cr`, cut mid-SCID) and
`Created` fell off the right-hand end. The servers table above it had the
same shape of bug from the other direction — its widths were written
against a different column order, and their own comments still said so.

Header and widths are now returned together from `did_list_columns`, so
the two cannot drift, and the DID column starts at 46 columns: `shorten_did`
abbreviates only the SCID and keeps host and path in full, which is what
makes the value copyable.

**Every webvh dry-run failure became `internalError`.** The planner runs
on the consent path and only there, so that flattening applied to exactly
the report an approver-gated update produces: a DID the VTA does not hold,
a context the requester cannot act in, and a genuine signing bug all
arrived as one opaque internal error — while the *ungated* execution of
the very same task answered `taskFailed: did not found: …`. Turning
consent on made the diagnosis worse than leaving it off.

Dry-run failures now route through the existing
`From<UpdateDidWebvhError> for AppError`, so plan and execute answer with
the same variant for the same cause, with `webvh update dry-run:` framing
the message. The Forbidden-collapses-to-NotFound rule that stops a
dry-run being used to probe for DIDs in unseen contexts is preserved, and
pinned by a test.

Signed-off-by: Glenn Gore <glenn.g@affinidi.com>

