### PR TITLE
test(vtc): probe where the join_didcomm VMC frame is lost

### DIFF
--- a/.github/workflows/join-didcomm-soak.yml
+++ b/.github/workflows/join-didcomm-soak.yml
@@ -1,0 +1,83 @@
+# Soak the `join_didcomm` VMC-delivery test to reproduce VTI#918 on demand.
+#
+# The flake ("admission credential 2/2 not delivered within 60s") has only ever
+# appeared on a GitHub runner. 30 local runs under CPU contention were green,
+# so a laptop does not reproduce what the runner does — which left triage
+# waiting for the flake to strike a random PR, roughly once a fortnight, and
+# each occurrence yielded one log and no way to test a hypothesis.
+#
+# This turns that around: run the test N times on the machine that does
+# reproduce it, and stop on the first failure with the full log. Manual
+# (`workflow_dispatch`) only — it is minutes of runner time per invocation and
+# has no business gating a PR.
+#
+# Read the failure with `docs/05-design-notes/` context; the discriminators as
+# of 2026-08-14 are:
+#   - `outbox drain pass sent=N` — N=1 means the loss is in the sender's
+#     outbox, N=2 means both frames left the VTC (this is what we observed).
+#   - the `inbox:` clause in the panic — non-empty means the frame reached the
+#     client and failed to match (a test bug); empty means it never arrived,
+#     leaving the mediator as the suspect.
+name: join_didcomm soak
+
+on:
+  workflow_dispatch:
+    inputs:
+      runs:
+        description: "How many times to run the test (stops at the first failure)"
+        required: false
+        default: "50"
+      log:
+        description: "RUST_LOG filter for the run"
+        required: false
+        default: "warn,lsm_tree=off,affinidi_messaging_delivery=debug"
+
+permissions:
+  contents: read
+
+jobs:
+  soak:
+    name: Soak join_didcomm VMC delivery
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      # Built once, then executed in a loop: `cargo test` would re-check the
+      # workspace on every iteration and most of the wall-clock would be cargo,
+      # not the code under investigation.
+      - name: Build the test binary
+        run: cargo test -p vtc-service --features didcomm-harness --test join_didcomm --no-run
+        env:
+          VTC_SKIP_ADMIN_UI_BUILD: "1"
+
+      - name: Soak
+        env:
+          RUST_LOG: ${{ inputs.log }}
+          VTC_SKIP_ADMIN_UI_BUILD: "1"
+        run: |
+          set -uo pipefail
+          runs="${{ inputs.runs }}"
+          bin=$(cargo test -p vtc-service --features didcomm-harness --test join_didcomm \
+                  --no-run --message-format=json 2>/dev/null \
+                | jq -r 'select(.executable != null and (.target.name == "join_didcomm")) | .executable' \
+                | tail -1)
+          echo "test binary: $bin"
+          for i in $(seq 1 "$runs"); do
+            echo "::group::run $i/$runs"
+            if ! "$bin" --test-threads=1 --nocapture \
+                 didcomm_join_round_trips_submit_manifest_status_approve_and_vmc_delivery; then
+              echo "::endgroup::"
+              echo "::error::reproduced on run $i of $runs — the log above carries the drain count and the inbox summary"
+              exit 1
+            fi
+            echo "::endgroup::"
+          done
+          echo "no reproduction in $runs runs"

--- a/vtc-service/src/test_support.rs
+++ b/vtc-service/src/test_support.rs
@@ -1120,6 +1120,14 @@ mod didcomm_harness {
             // is the point.
             let mut poll_errors = 0usize;
             let mut last_error = String::new();
+            // Every frame this client saw while waiting, matched or not. The
+            // count is the discriminator the VMC-delivery flake (VTI#918) still
+            // lacks: the sender's outbox is now known to report `sent=2`, so
+            // either the awaited frame reached this socket (and something here
+            // failed to match it) or it did not (and the loss is at the
+            // mediator). "Nothing arrived" and "something arrived that I
+            // ignored" are indistinguishable without this.
+            let mut frames_seen = 0usize;
             while start.elapsed() < timeout {
                 let next = self
                     .atm
@@ -1131,6 +1139,7 @@ mod didcomm_harness {
                     last_error = e.to_string();
                 }
                 if let Ok(Some((msg, _meta))) = next {
+                    frames_seen += 1;
                     if is_error_reply(&msg.typ)
                         && self.panic_on_problem_report.load(Ordering::SeqCst)
                     {
@@ -1159,7 +1168,37 @@ mod didcomm_harness {
                      lost to the transport rather than never sent"
                 );
             }
+            // Always, not only on poll errors: a clean timeout is the failure
+            // mode under investigation, and this is the only record of what
+            // reached the socket during it.
+            tracing::warn!(
+                frames_seen,
+                poll_errors,
+                buffered = %self.inbox_summary().await,
+                ?timeout,
+                "timed out waiting for a matching message",
+            );
             None
+        }
+
+        /// One line describing everything sitting unmatched in this client's
+        /// inbox: `2 buffered: [type thid=…, type thid=none]`.
+        ///
+        /// Unmatched frames are buffered and, until now, never reported — so a
+        /// frame that *arrived* but failed the caller's predicate looked
+        /// exactly like one that never arrived. Those are a test bug and a
+        /// transport bug respectively, and the VMC-delivery flake has been
+        /// triaged twice without the evidence to tell them apart.
+        pub async fn inbox_summary(&self) -> String {
+            let inbox = self.inbox.lock().await;
+            if inbox.is_empty() {
+                return "0 buffered".to_string();
+            }
+            let entries: Vec<String> = inbox
+                .iter()
+                .map(|r| format!("{} thid={}", r.typ, r.thid.as_deref().unwrap_or("none"),))
+                .collect();
+            format!("{} buffered: [{}]", entries.len(), entries.join(", "))
         }
 
         async fn take_buffered<F: Fn(&Received) -> bool>(&self, pred: &F) -> Option<Received> {

--- a/vtc-service/tests/join_didcomm.rs
+++ b/vtc-service/tests/join_didcomm.rs
@@ -347,29 +347,43 @@ async fn didcomm_join_round_trips_submit_manifest_status_approve_and_vmc_deliver
     //    ever distinguishing them. The index is the whole diagnostic.
     let mut delivered = Vec::new();
     for i in 0..2 {
-        let (typ, issue_body) = mock
-            .client
-            .next_pushed(CREDENTIAL_PUSH_TIMEOUT)
-            .await
-            .unwrap_or_else(|| {
-                panic!(
-                    "admission credential {}/2 not delivered over DIDComm within {:?} \
-                     ({} already received). {}",
-                    i + 1,
-                    CREDENTIAL_PUSH_TIMEOUT,
-                    delivered.len(),
-                    if i == 0 {
-                        "Zero arrived, so the VTC most likely never sent: \
-                         `deliver_credentials` returns on the first `?`, and its caller only \
+        let pushed = mock.client.next_pushed(CREDENTIAL_PUSH_TIMEOUT).await;
+        // Collected *before* the panic formats: what else reached this socket
+        // while we waited is the evidence that decides where the frame went,
+        // and a panic that omits it costs another CI cycle to learn nothing.
+        // The sender is already cleared — `outbox drain pass sent=2 failed=0`
+        // on the 2026-08-14 failure — so the remaining question is whether the
+        // frame reached this client at all.
+        let buffered = mock.client.inbox_summary().await;
+        let (typ, issue_body) = pushed.unwrap_or_else(|| {
+            panic!(
+                "admission credential {}/2 not delivered over DIDComm within {:?} \
+                     ({} already received; inbox: {}). {}",
+                i + 1,
+                CREDENTIAL_PUSH_TIMEOUT,
+                delivered.len(),
+                buffered,
+                if i == 0 {
+                    "Zero arrived, so the VTC most likely never sent: \
+                         `deliver_credentials` attempts every credential, but its caller only \
                          `warn!`s — which is invisible here unless a tracing subscriber is \
                          installed (see RUST_LOG note at the top of this test)."
-                    } else {
-                        "The first arrived and the second did not, so the VTC either failed on \
-                         the second `push_to_holder` (again warn-only) or the frame was lost \
-                         between the mediator and this client."
-                    }
-                )
-            });
+                } else {
+                    // VTI#918. The sender is no longer a candidate: the
+                    // 2026-08-14 failure logged `outbox drain pass sent=2
+                    // retried=0 failed=0`, so both frames left the VTC.
+                    // What splits the two remaining suspects is the inbox
+                    // above — a non-empty inbox means the frame reached
+                    // this socket and the *matching* is wrong (a test bug);
+                    // an empty one means it never arrived, and the loss is
+                    // at the mediator.
+                    "The first arrived and the second did not. The sender is cleared \
+                         (`sent=2 failed=0` in the drain log), so read the inbox above: \
+                         non-empty ⇒ the frame arrived and did not match; empty ⇒ it never \
+                         reached this client, and the mediator is the remaining suspect."
+                }
+            )
+        });
         assert_eq!(typ, CREDENTIAL_ISSUE_TYPE);
         let issue: IssueBody = serde_json::from_value(issue_body).expect("issue body");
         delivered.push(


### PR DESCRIPTION
VTI#918 has been triaged three times and each occurrence yielded one
log and no way to test a hypothesis. The 2026-08-14 failure did move
it: the drain diagnostic added in #918 printed `outbox drain pass
sent=2 retried=0 failed=0`, so both frames left the VTC's outbox and
the entire sender side is now eliminated with evidence rather than
inference.

That leaves two suspects, and nothing in the harness could tell them
apart. Unmatched inbound frames are buffered in the client's inbox and
never reported, so a frame that *arrived* and failed the caller's
predicate looked exactly like one that never arrived — a test bug and
a transport bug, indistinguishable at the assertion.

The receive loop now counts every frame it saw while waiting and, on
timeout, logs that count alongside a summary of everything buffered.
The panic carries the same summary, because the evidence has to be in
the failure message: a CI run that omits it costs another fortnight of
waiting to learn nothing. Non-empty inbox ⇒ the frame reached the
socket and the matching is wrong; empty ⇒ it never arrived and the
mediator is what is left.

Also adds a manual soak workflow. The flake has only ever appeared on
a runner — 30 local runs under CPU contention were green — so triage
has been waiting for it to strike a random PR. `workflow_dispatch`
with a run count builds the test binary once and loops it, stopping at
the first failure with the full log, which turns "wait for it to
happen" into "reproduce it on demand". Manual only: it is minutes of
runner time and has no business gating a PR.

No fix yet — this is the instrumentation that makes the next
reproduction decisive.

Signed-off-by: Glenn Gore <glenn.g@affinidi.com>

