### PR TITLE
test(vtc): ask the mediator what it is holding when delivery times out

### DIFF
--- a/vtc-service/src/test_support.rs
+++ b/vtc-service/src/test_support.rs
@@ -1175,10 +1175,68 @@ mod didcomm_harness {
                 frames_seen,
                 poll_errors,
                 buffered = %self.inbox_summary().await,
+                mediator = %self.mediator_queue_report().await,
                 ?timeout,
                 "timed out waiting for a matching message",
             );
             None
+        }
+
+        /// Ask the mediator, at the moment of the timeout, what it is still
+        /// holding for this client — and then actually request delivery of it.
+        ///
+        /// This is the fork the VMC-delivery flake (VTI#918) has been narrowed
+        /// down to. The sender is cleared (`outbox drain pass sent=2 failed=0`)
+        /// and the client's inbox holds no unmatched credential, so the frame
+        /// did not reach the live stream. Two very different things look
+        /// identical from here:
+        ///
+        /// - `queued=0` — the mediator never held the message, or dropped it.
+        ///   The loss is at or before the mediator's queue.
+        /// - `queued>0`, and a delivery request returns the missing
+        ///   credential — the mediator had it all along and the **live-stream
+        ///   path** never yielded it. Not a loss at all: a delivery-mechanism
+        ///   bug, and the polling client is the wrong place to have been
+        ///   looking.
+        ///
+        /// Best-effort and bounded: this runs on a path that has already
+        /// failed, so it must add evidence without adding a second way to
+        /// hang. Any error is reported rather than propagated.
+        pub async fn mediator_queue_report(&self) -> String {
+            const PROBE: Duration = Duration::from_secs(5);
+
+            let status = match self
+                .atm
+                .message_pickup()
+                .send_status_request(&self.profile, true, Some(PROBE))
+                .await
+            {
+                Ok(Some(s)) => format!(
+                    "queued={} bytes={} live_delivery={} longest_waited={:?}",
+                    s.message_count, s.total_bytes, s.live_delivery, s.longest_waited_seconds,
+                ),
+                Ok(None) => "status request returned nothing".to_string(),
+                Err(e) => format!("status request failed: {e}"),
+            };
+
+            // Only pull if something is actually queued: an unconditional
+            // delivery request on a healthy run would consume messages a later
+            // assertion is waiting for.
+            let delivered = match self
+                .atm
+                .message_pickup()
+                .send_delivery_request(&self.profile, Some(10), true)
+                .await
+            {
+                Ok(messages) if messages.is_empty() => "delivery request: empty".to_string(),
+                Ok(messages) => {
+                    let types: Vec<&str> = messages.iter().map(|(m, _)| m.typ.as_str()).collect();
+                    format!("delivery request returned {}: {:?}", messages.len(), types)
+                }
+                Err(e) => format!("delivery request failed: {e}"),
+            };
+
+            format!("{status}; {delivered}")
         }
 
         /// One line describing everything sitting unmatched in this client's

--- a/vtc-service/tests/join_didcomm.rs
+++ b/vtc-service/tests/join_didcomm.rs
@@ -355,32 +355,42 @@ async fn didcomm_join_round_trips_submit_manifest_status_approve_and_vmc_deliver
         // on the 2026-08-14 failure — so the remaining question is whether the
         // frame reached this client at all.
         let buffered = mock.client.inbox_summary().await;
+        // Only on the failing path: the probe issues a delivery request, which
+        // would consume messages a healthy run's next assertion is waiting for.
+        let mediator = if pushed.is_none() {
+            mock.client.mediator_queue_report().await
+        } else {
+            String::new()
+        };
         let (typ, issue_body) = pushed.unwrap_or_else(|| {
             panic!(
                 "admission credential {}/2 not delivered over DIDComm within {:?} \
-                     ({} already received; inbox: {}). {}",
+                     ({} already received; inbox: {}; mediator: {}). {}",
                 i + 1,
                 CREDENTIAL_PUSH_TIMEOUT,
                 delivered.len(),
                 buffered,
+                mediator,
                 if i == 0 {
                     "Zero arrived, so the VTC most likely never sent: \
                          `deliver_credentials` attempts every credential, but its caller only \
                          `warn!`s — which is invisible here unless a tracing subscriber is \
                          installed (see RUST_LOG note at the top of this test)."
                 } else {
-                    // VTI#918. The sender is no longer a candidate: the
-                    // 2026-08-14 failure logged `outbox drain pass sent=2
-                    // retried=0 failed=0`, so both frames left the VTC.
-                    // What splits the two remaining suspects is the inbox
-                    // above — a non-empty inbox means the frame reached
-                    // this socket and the *matching* is wrong (a test bug);
-                    // an empty one means it never arrived, and the loss is
-                    // at the mediator.
-                    "The first arrived and the second did not. The sender is cleared \
-                         (`sent=2 failed=0` in the drain log), so read the inbox above: \
-                         non-empty ⇒ the frame arrived and did not match; empty ⇒ it never \
-                         reached this client, and the mediator is the remaining suspect."
+                    // VTI#918, reproduced 2026-08-14 (soak run 31769042608,
+                    // stream 6 iteration 31). Two suspects are already gone:
+                    // the sender logged `outbox drain pass sent=2 retried=0
+                    // failed=0`, and the client's inbox held only a
+                    // pickup-status heartbeat — no unmatched credential — so
+                    // the frame never reached the live stream. The `mediator:`
+                    // clause splits what is left.
+                    "The first arrived and the second did not. Sender cleared (`sent=2 \
+                         failed=0`) and no unmatched credential in the inbox, so read the \
+                         `mediator:` clause: `queued=0` ⇒ the mediator never held it and the \
+                         loss is at or before its queue; `queued>0`, or a delivery request that \
+                         returns the credential, ⇒ the mediator had it all along and the \
+                         live-stream path never yielded it — a delivery-mechanism bug, not a \
+                         loss."
                 }
             )
         });


### PR DESCRIPTION
The contention soak reproduced VTI#918 on its first run — stream 6,
iteration 31 of 240, once `parallel` recreated the load the isolated
loop was missing (run 31769042608). The evidence added in #969 did its
job and closed two of the three suspects:

    outbox drain pass sent=2 retried=0 failed=0
    inbox: 1 buffered: [https://didcomm.org/messagepickup/3.0/status thid=6d2eb…]

Both frames left the VTC's outbox, and the only thing buffered at the
client was a pickup-status heartbeat — no unmatched credential. So the
frame never reached the live stream, and "the harness failed to match
it" is dead as a theory.

What remains splits two ways that look identical from a polling
client, and the mediator can be asked directly. On timeout the client
now issues a status request (`queued`, `total_bytes`, `live_delivery`,
`longest_waited`) and then a delivery request, reporting what comes
back:

  - `queued=0` ⇒ the mediator never held the message. The loss is at
    or before its queue.
  - `queued>0`, or a delivery request that returns the missing
    credential ⇒ the mediator had it all along and the live-stream
    path never yielded it. That is not a loss at all — it is a
    delivery-mechanism bug, and every probe so far has been on the
    wrong side of it.

Runs only on the failing path: a delivery request consumes queued
messages, which on a healthy run are what the next assertion is
waiting for. Bounded and best-effort — this executes after something
has already gone wrong and must not add a second way to hang.

Signed-off-by: Glenn Gore <glenn.g@affinidi.com>

