### PR TITLE
fix(webvh): sign with the update keys in force, not the ones the head restated

### DIFF
--- a/vta-service/src/operations/did_webvh/update/mod.rs
+++ b/vta-service/src/operations/did_webvh/update/mod.rs
@@ -2189,6 +2189,108 @@ mod pre_rotation_e2e_tests {
         );
     }
 
+    /// A metadata-only update leaves a head entry with **no** `updateKeys`, and
+    /// the DID must still be updatable afterwards.
+    ///
+    /// The regression, seen in production on a hosting-server DID: webvh
+    /// parameters are a delta, so that head inherits its update key from an
+    /// earlier entry — but the orchestrator read `validated_parameters.update_keys`
+    /// (what the entry *declared*, `None` here) instead of `active_update_keys`
+    /// (what validation carried forward). The empty list short-circuits
+    /// `load_active_update_key` before it looks up anything, so the DID became
+    /// permanently un-updatable and said "log entry has no update_keys — DID is
+    /// deactivated or malformed" about a DID that was neither deactivated nor
+    /// malformed. It reads as lost keys; the keys were never consulted.
+    ///
+    /// Two updates in sequence is the whole test — the first writes the head the
+    /// second has to read.
+    #[tokio::test]
+    async fn update_succeeds_after_a_metadata_only_entry_that_omits_update_keys() {
+        let (ts, seed_store) = setup("ctx-inherit").await;
+        let cfg = ts_app_config(&ts);
+        let auth = admin_auth();
+        let resolver = build_resolver().await;
+        let bridge = dummy_bridge();
+        let auth_locks = crate::operations::did_webvh::WebvhAuthLocks::new();
+        let deps = webvh_deps(&ts, &seed_store, &resolver, &bridge, &auth_locks);
+
+        let (did, scid) = create_did(
+            &ts,
+            &seed_store,
+            &cfg,
+            &auth,
+            &resolver,
+            &bridge,
+            "ctx-inherit",
+            0,
+        )
+        .await;
+        sleep(VERSION_TIME_GAP).await;
+
+        // v2: metadata only. No document, no pre-rotation, so nothing forces an
+        // update-key reveal and the entry lands with `updateKeys` absent.
+        update_did_webvh(
+            &deps,
+            &auth,
+            &scid,
+            UpdateDidWebvhOptions {
+                ttl: Some(600),
+                ..Default::default()
+            },
+            None,
+            "test",
+        )
+        .await
+        .expect("metadata-only update");
+        sleep(VERSION_TIME_GAP).await;
+
+        // Precondition: the head really does omit the parameter. Without this the
+        // test could pass for the wrong reason if the write path ever starts
+        // restating keys on a metadata-only entry.
+        let log = crate::webvh_store::get_did_log(&ts.webvh_ks, &did)
+            .await
+            .expect("get_did_log")
+            .expect("log present");
+        let head = log
+            .lines()
+            .rfind(|l| !l.trim().is_empty())
+            .expect("head entry");
+        let head_json: serde_json::Value = serde_json::from_str(head).expect("head parses");
+        assert!(
+            head_json["parameters"].get("updateKeys").is_none(),
+            "the metadata-only entry should not restate updateKeys — got {}",
+            head_json["parameters"]
+        );
+
+        // v3: the update that used to fail. It has to sign with the key the head
+        // inherited rather than the one it declared, because it declared none.
+        let result = update_did_webvh(
+            &deps,
+            &auth,
+            &scid,
+            UpdateDidWebvhOptions {
+                document: Some(doc_patch(&did, "v3")),
+                ..Default::default()
+            },
+            None,
+            "test",
+        )
+        .await
+        .expect("update on a DID whose head inherited its update keys");
+
+        assert!(result.new_version_id.starts_with("3-"));
+        assert_chain_validates(&ts, &did).await;
+
+        // And the inherited key is what stayed in force through v2 — i.e. the
+        // signer was the genesis key, not something re-minted along the way.
+        let (in_force, _) = committed_params(&ts, &did).await;
+        assert_eq!(
+            in_force.len(),
+            1,
+            "one update key in force across the inherit step"
+        );
+    }
+
     /// Read back the update keys and pre-rotation commitments actually in force
     /// after the last entry.
     ///

--- a/vta-service/src/operations/did_webvh/update/orchestrator.rs
+++ b/vta-service/src/operations/did_webvh/update/orchestrator.rs
@@ -694,11 +694,30 @@ async fn run_update(
     }
 
     let last_params = last_state.validated_parameters.clone();
-    let last_update_keys: Vec<Multibase> = last_params
-        .update_keys
-        .as_ref()
-        .map(|arc| (**arc).clone())
-        .unwrap_or_default();
+    // `active_update_keys`, NOT `update_keys`. The two are different things and
+    // reading the wrong one bricks the DID.
+    //
+    // webvh parameters are a delta: an entry that does not restate `updateKeys`
+    // leaves the previous entry's in force. `didwebvh-rs` models that with two
+    // fields — `update_keys` is what *this entry declared* (`None` when it
+    // declared nothing) and `active_update_keys` is the effective set that
+    // validation carried forward (`parameters/mod.rs`, the `None =>` arm:
+    // "If absent, keep current updateKeys"). Only the second answers "which key
+    // signs the next entry", which is the question here.
+    //
+    // Reading `update_keys` therefore returned an empty list for every DID whose
+    // head entry omitted the parameter — which is exactly what this function
+    // writes for a metadata-only update (`set_update_keys` is `None` unless a new
+    // document or pre-rotation forces a reveal, so the entry lands as
+    // `"parameters": {}`). The DID was then permanently un-updatable: the empty
+    // list short-circuits `load_active_update_key` before it looks anything up,
+    // and reports "log entry has no update_keys — DID is deactivated or
+    // malformed" about a DID that is neither. The operator reads that as lost
+    // keys. The keys were never consulted.
+    //
+    // `next_key_hashes` needs no equivalent care: the library inherits it into
+    // the field itself, so `last_params.next_key_hashes` is already effective.
+    let last_update_keys: Vec<Multibase> = (*last_params.active_update_keys).clone();
     // Owned snapshot of the prior state. Taken here because `state` is moved
     // into the update config below, which ends `last_state`'s borrow — and a
     // plan needs the before-picture after that point.

--- a/vta-service/src/trust_tasks/helpers.rs
+++ b/vta-service/src/trust_tasks/helpers.rs
@@ -105,6 +105,14 @@ pub(super) fn app_error_to_reject(doc: &TrustTask<Value>, err: AppError) -> Trus
             reason: message,
             details: None,
         },
+        // Hand the framework the *cause*, not the rendered error. Both
+        // `AppError::Internal` and `RejectReason::InternalError` render as
+        // "internal error: {…}", so passing the outer `Display` in put the
+        // prefix on twice and the operator dialog read "internal error:
+        // internal error: log entry has no update_keys". Every other arm above
+        // pairs a differently-worded reason with its variant, so only this one
+        // stutters — and only this one is fixed here.
+        AppError::Internal(cause) => RejectReason::InternalError { reason: cause },
         _ => RejectReason::InternalError { reason: message },
     };
     reject_with(doc, reason)
@@ -204,4 +212,55 @@ pub(super) fn body_parse_error_response(reason: &str) -> TrustTaskOutcome {
         extra: Default::default(),
     };
     error_response(err)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn doc() -> TrustTask<Value> {
+        let uri: TypeUri = vta_sdk::trust_tasks::TASK_WEBVH_DIDS_UPDATE_1_0
+            .parse()
+            .expect("update uri");
+        TrustTask::new("urn:uuid:test", uri, json!({}))
+    }
+
+    fn message_of(outcome: TrustTaskOutcome) -> String {
+        let doc: Value = serde_json::from_slice(&outcome.body).expect("error doc parses");
+        doc["payload"]["message"]
+            .as_str()
+            .expect("payload carries a message")
+            .to_string()
+    }
+
+    /// The framework already says "internal error"; so does `AppError::Internal`.
+    /// Rendering the outer error into the reason put the prefix on twice, and the
+    /// operator's dialog read "internal error: internal error: log entry has no
+    /// update_keys". The cause is what the framework wants, not the rendering.
+    #[test]
+    fn an_internal_error_does_not_say_internal_error_twice() {
+        let message = message_of(app_error_to_reject(
+            &doc(),
+            AppError::Internal("log entry has no update_keys".into()),
+        ));
+        assert_eq!(message, "internal error: log entry has no update_keys");
+        assert!(
+            !message.contains("internal error: internal error"),
+            "{message}"
+        );
+    }
+
+    /// The other arms pair a differently-worded reject reason with the variant,
+    /// so their `Display` is not redundant and stays — a `NotFound` still reads
+    /// "task failed: not found: …", naming both the framework's verdict and ours.
+    /// Pinned so a future tidy-up does not strip the cause along with the stutter.
+    #[test]
+    fn a_not_found_keeps_the_cause_the_operator_needs() {
+        let message = message_of(app_error_to_reject(
+            &doc(),
+            AppError::NotFound("SCID QmNope not found".into()),
+        ));
+        assert!(message.contains("SCID QmNope not found"), "{message}");
+    }
 }


### PR DESCRIPTION
fix(webvh): sign with the update keys in force, not the ones the head restated

A DID whose most recent log entry did not restate `updateKeys` could not be
updated again. Every attempt died with

    webvh library error: log entry has no update_keys — DID is deactivated or malformed

about a DID that was neither deactivated nor malformed, and the operator reads
that as lost keys. Nothing was lost. The keys were never consulted.

webvh parameters are a delta: an entry that omits `updateKeys` leaves the
previous entry's in force. `didwebvh-rs` models that as two fields —
`update_keys` is what the entry *declared* (`None` when it declared nothing) and
`active_update_keys` is the effective set validation carried forward
(`parameters/mod.rs`, the `None =>` arm: "If absent, keep current updateKeys").
Only the second answers "which key signs the next entry". The orchestrator read
the first, got an empty list, and handed it to `load_active_update_key`, whose
first line rejects an empty list — so the DID's real update key was never looked
up in the handle cache, never re-derived from the seed, never tried.

The head entry that triggers it is one this code writes itself: for a
metadata-only update with no pre-rotation, `set_update_keys` is `None` (nothing
forces a key reveal, and rotating on a no-op change would be wrong), so the
entry lands as `"parameters": {}`. One such update and the DID is permanently
un-updatable by this VTA. Found on a live hosting-server DID whose v3 was
exactly that; v1 declared the keys, v2 rotated them, v3 declared nothing.

`next_key_hashes` needs no equivalent change: the library inherits that one into
the field itself, so the pre-rotation path was always reading the effective set.
That is also why the failure looked so selective — a DID whose head happens to
restate its keys, which every document-changing update does, works fine.

Regression test drives the real sequence: create, metadata-only update, then
update again. It asserts the intermediate entry really does omit the parameter,
so it cannot pass for the wrong reason if the write path ever changes. Reverting
the one-line read reproduces the production error verbatim.

Also: `AppError::Internal` and `RejectReason::InternalError` both render as
"internal error: {…}", and `app_error_to_reject` passed the rendered outer error
in as the reason — so the operator's dialog read "internal error: internal
error: log entry has no update_keys". That arm now passes the cause and lets the
framework own the prefix. Only that arm; the others pair a differently-worded
reason with their variant, so their `Display` is not redundant.
