### PR TITLE
fix(trust-tasks): stop emitting two versions of the framework error document

### DIFF
--- a/vta-service/src/trust_tasks/helpers.rs
+++ b/vta-service/src/trust_tasks/helpers.rs
@@ -183,7 +183,30 @@ pub(super) fn error_response(err_doc: ErrorResponse) -> TrustTaskOutcome {
     TrustTaskOutcome { status, body }
 }
 
-/// Build a `trust-task-error/0.1` document for a body-parse failure.
+/// The framework's error-document Type URI — the one `TrustTask::reject_with`
+/// stamps on every *routed* rejection this service emits.
+///
+/// Named here because `trust-tasks-rs` keeps `trust_task_error_type_uri()`
+/// `pub(crate)`, so the only unrouted path — where there is no request document
+/// to reject from — has to write the value out. It said `0.1` while every
+/// routed reject went out as `0.3` (the framework has emitted `0.3` since its
+/// own 0.3 release, for the §8.2 `inResponseTo` member that `0.2`'s
+/// `additionalProperties: false` payload schema cannot admit). One service
+/// emitting two versions is a trap for exactly the consumer that pins one of
+/// them, which is not hypothetical: a client matching `0.1`/`0.2` by
+/// enumeration read every `0.3` rejection as a *success*.
+///
+/// The constant is pinned by `unrouted_and_routed_errors_agree_on_the_type_uri`
+/// below, which compares it against a real `reject_with`. When the framework
+/// bumps the version, that test fails rather than this service silently
+/// speaking two dialects again.
+fn framework_error_type_uri() -> TypeUri {
+    "https://trusttasks.org/spec/trust-task-error/0.3"
+        .parse()
+        .expect("framework error Type URI parses")
+}
+
+/// Build a framework error document for a body-parse failure.
 /// Unrouted (no issuer / recipient) — the framework permits this on
 /// malformed-body failures since the producer can correlate on the
 /// response `id`.
@@ -192,9 +215,7 @@ pub(super) fn body_parse_error_response(reason: &str) -> TrustTaskOutcome {
         reason: format!("body did not parse as a Trust Task document: {reason}"),
     };
     let payload: ErrorPayload = reject.into();
-    let type_uri: TypeUri = "https://trusttasks.org/spec/trust-task-error/0.1"
-        .parse()
-        .expect("framework error Type URI parses");
+    let type_uri: TypeUri = framework_error_type_uri();
     let err = ErrorResponse {
         id: format!("urn:uuid:{}", Uuid::new_v4()),
         thread_id: None,
@@ -248,6 +269,39 @@ mod tests {
         assert!(
             !message.contains("internal error: internal error"),
             "{message}"
+        );
+    }
+
+    /// The unrouted body-parse error must claim the same document type as a
+    /// routed one. It cannot ask the framework — `trust_task_error_type_uri()`
+    /// is `pub(crate)` there — so it names the version, and this compares that
+    /// against what `reject_with` actually stamps. A framework bump fails here
+    /// instead of splitting this service into two dialects, which is how the
+    /// unrouted path came to say `0.1` while every routed reject said `0.3`.
+    #[test]
+    fn unrouted_and_routed_errors_agree_on_the_type_uri() {
+        let routed = doc().reject_with(
+            "urn:uuid:routed",
+            RejectReason::InternalError {
+                reason: "probe".into(),
+            },
+        );
+        assert_eq!(
+            framework_error_type_uri(),
+            routed.type_uri,
+            "the unrouted body-parse error names a different document type than \
+             the framework stamps on a routed rejection"
+        );
+    }
+
+    /// …and the bytes on the wire carry it, not just the value we compute.
+    #[test]
+    fn the_body_parse_error_goes_out_as_a_framework_error_document() {
+        let outcome = body_parse_error_response("not json");
+        let doc: Value = serde_json::from_slice(&outcome.body).expect("error doc parses");
+        assert_eq!(
+            doc["type"].as_str().expect("type present"),
+            framework_error_type_uri().to_string()
         );
     }
 

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -32,7 +32,7 @@
 //!
 //! Like the webvh-service dispatcher, we accept the body as
 //! `axum::body::Bytes` and parse to `TrustTask<Value>` by hand so a
-//! malformed body produces a `trust-task-error/0.1` document (per
+//! malformed body produces a `trust-task-error` document (per
 //! framework SPEC §8.5) instead of axum's plain-text 400 default.
 
 use axum::extract::State;
@@ -385,7 +385,7 @@ macro_rules! dispatch_table {
 /// each typed handler.
 ///
 /// Body is accepted as raw bytes so a parse failure surfaces as a
-/// `trust-task-error/0.1` document with `code: malformed_request`
+/// `trust-task-error` document with `code: malformed_request`
 /// rather than axum's text/plain default. The route mount caps body
 /// size separately (the workspace-wide 1 MB cap applies).
 pub async fn dispatch_trust_task(

--- a/vta-service/src/trust_tasks/wire_v0_2.rs
+++ b/vta-service/src/trust_tasks/wire_v0_2.rs
@@ -475,7 +475,7 @@ mod tests {
         let spec = lookup_0_2("https://trusttasks.org/spec/device/list/0.2").unwrap();
         let doc = serde_json::json!({
             "id": "urn:uuid:2",
-            "type": "https://trusttasks.org/spec/trust-task-error/0.1",
+            "type": "https://trusttasks.org/spec/trust-task-error/0.3",
             "payload": { "code": "permission_denied", "reason": "nope" }
         });
         let outcome = TrustTaskOutcome {
@@ -486,7 +486,7 @@ mod tests {
         let v: Value = serde_json::from_slice(&out.body).unwrap();
         assert_eq!(
             v["type"],
-            "https://trusttasks.org/spec/trust-task-error/0.1"
+            "https://trusttasks.org/spec/trust-task-error/0.3"
         );
         assert_eq!(v["payload"]["code"], "permission_denied");
     }

--- a/vtc-service/src/messaging.rs
+++ b/vtc-service/src/messaging.rs
@@ -1442,7 +1442,7 @@ mod tests {
     fn an_error_document_counts_as_a_reply() {
         let error = serde_json::to_vec(&json!({
             "id": "urn:uuid:err",
-            "type": "https://trusttasks.org/spec/trust-task-error/0.1",
+            "type": "https://trusttasks.org/spec/trust-task-error/0.3",
             "threadId": "urn:uuid:request",
             "payload": { "code": "permissionDenied" },
         }))

--- a/vtc-service/src/messaging.rs
+++ b/vtc-service/src/messaging.rs
@@ -875,11 +875,17 @@ fn tt_didcomm_reply(outcome: TrustTaskOutcome, thid: String) -> Option<Reply> {
             ));
         }
     };
+    // A reply document with no `type` at all is malformed; label it as the
+    // framework error document it will be treated as. Through the shared helper
+    // rather than a literal — this crate must name exactly one version of that
+    // URI, and the census test enforces it (`trust_task_manifest`'s
+    // `UNPUBLISHED_CANONICAL_OK` pins the family at one URI, so a second
+    // spelling here fails the build even though nothing on the wire changed).
     let typ = doc
         .get("type")
         .and_then(|t| t.as_str())
-        .unwrap_or("https://trusttasks.org/spec/trust-task-error/0.1")
-        .to_string();
+        .map(str::to_string)
+        .unwrap_or_else(|| crate::trust_tasks::framework_error_type_uri().to_string());
     Some(Reply {
         type_: typ,
         body: doc,

--- a/vtc-service/src/registry/messaging.rs
+++ b/vtc-service/src/registry/messaging.rs
@@ -780,7 +780,7 @@ mod tests {
     fn error_doc(code: &str) -> TrustTask<Value> {
         TrustTask::new(
             "urn:uuid:err".to_string(),
-            "https://trusttasks.org/spec/trust-task-error/0.1"
+            "https://trusttasks.org/spec/trust-task-error/0.3"
                 .parse()
                 .unwrap(),
             json!({ "code": code, "message": "nope" }),

--- a/vtc-service/src/trust_tasks/helpers.rs
+++ b/vtc-service/src/trust_tasks/helpers.rs
@@ -166,7 +166,7 @@ pub(crate) fn error_response(err_doc: ErrorResponse) -> TrustTaskOutcome {
 /// Pinned by `unrouted_and_routed_errors_agree_on_the_type_uri` below, which
 /// compares it against a real `reject_with`, so a framework bump fails a test
 /// rather than splitting this service into two dialects.
-fn framework_error_type_uri() -> TypeUri {
+pub(crate) fn framework_error_type_uri() -> TypeUri {
     "https://trusttasks.org/spec/trust-task-error/0.3"
         .parse()
         .expect("framework error Type URI parses")
@@ -226,10 +226,17 @@ mod tests {
     use super::*;
     use serde_json::json;
 
+    /// A probe request to reject. Deliberately typed with a URI this crate
+    /// **already binds** (`acl/list/0.1`): `trust_task_manifest`'s census scans
+    /// this source tree for `trusttasks.org/spec/` literals and asserts every
+    /// one is served by the registry, so inventing a plausible-looking type
+    /// here — even in a test — adds a binding the registry has never published
+    /// and fails the build. Which is the census working: a URI written down is
+    /// a claim about what the registry serves, wherever it is written.
     fn doc() -> TrustTask<Value> {
-        let uri: TypeUri = "https://trusttasks.org/spec/vtc/join/request/0.1"
+        let uri: TypeUri = "https://trusttasks.org/spec/acl/list/0.1"
             .parse()
-            .expect("join uri");
+            .expect("acl/list Type URI parses");
         TrustTask::new("urn:uuid:test", uri, json!({}))
     }
 

--- a/vtc-service/src/trust_tasks/helpers.rs
+++ b/vtc-service/src/trust_tasks/helpers.rs
@@ -151,7 +151,28 @@ pub(crate) fn error_response(err_doc: ErrorResponse) -> TrustTaskOutcome {
     TrustTaskOutcome { status, body }
 }
 
-/// Build a `trust-task-error/0.1` document for a body-parse failure.
+/// The framework's error-document Type URI — the one `TrustTask::reject_with`
+/// stamps on every *routed* rejection this service emits.
+///
+/// Named here because `trust-tasks-rs` keeps `trust_task_error_type_uri()`
+/// `pub(crate)`, so the only unrouted path — where there is no request document
+/// to reject from — has to write the value out. It said `0.1` while every
+/// routed reject went out as `0.3` (the framework has emitted `0.3` since its
+/// own 0.3 release, for the §8.2 `inResponseTo` member that `0.2`'s
+/// `additionalProperties: false` payload schema cannot admit). One service
+/// emitting two versions is a trap for exactly the consumer that pins one of
+/// them.
+///
+/// Pinned by `unrouted_and_routed_errors_agree_on_the_type_uri` below, which
+/// compares it against a real `reject_with`, so a framework bump fails a test
+/// rather than splitting this service into two dialects.
+fn framework_error_type_uri() -> TypeUri {
+    "https://trusttasks.org/spec/trust-task-error/0.3"
+        .parse()
+        .expect("framework error Type URI parses")
+}
+
+/// Build a framework error document for a body-parse failure.
 /// Unrouted (no issuer / recipient) — the framework permits this on
 /// malformed-body failures since the producer can correlate on the response
 /// `id`.
@@ -160,9 +181,7 @@ pub(crate) fn body_parse_error_response(reason: &str) -> TrustTaskOutcome {
         reason: format!("body did not parse as a Trust Task document: {reason}"),
     };
     let payload: ErrorPayload = reject.into();
-    let type_uri: TypeUri = "https://trusttasks.org/spec/trust-task-error/0.1"
-        .parse()
-        .expect("framework error Type URI parses");
+    let type_uri: TypeUri = framework_error_type_uri();
     let err = ErrorResponse {
         id: format!("urn:uuid:{}", Uuid::new_v4()),
         thread_id: None,
@@ -200,4 +219,50 @@ pub(crate) async fn verify_trust_task_proof(doc: &TrustTask<Value>) -> Result<St
     vti_common::auth::di_proof::verify_trust_task_proof(doc)
         .await
         .map_err(|e| AppError::Unauthorized(format!("Trust Task {e}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn doc() -> TrustTask<Value> {
+        let uri: TypeUri = "https://trusttasks.org/spec/vtc/join/request/0.1"
+            .parse()
+            .expect("join uri");
+        TrustTask::new("urn:uuid:test", uri, json!({}))
+    }
+
+    /// The unrouted body-parse error must claim the same document type as a
+    /// routed one. It cannot ask the framework — `trust_task_error_type_uri()`
+    /// is `pub(crate)` there — so it names the version, and this compares that
+    /// against what `reject_with` actually stamps. A framework bump fails here
+    /// instead of splitting this service into two dialects, which is how the
+    /// unrouted path came to say `0.1` while every routed reject said `0.3`.
+    #[test]
+    fn unrouted_and_routed_errors_agree_on_the_type_uri() {
+        let routed = doc().reject_with(
+            "urn:uuid:routed",
+            RejectReason::InternalError {
+                reason: "probe".into(),
+            },
+        );
+        assert_eq!(
+            framework_error_type_uri(),
+            routed.type_uri,
+            "the unrouted body-parse error names a different document type than \
+             the framework stamps on a routed rejection"
+        );
+    }
+
+    /// …and the bytes on the wire carry it, not just the value we compute.
+    #[test]
+    fn the_body_parse_error_goes_out_as_a_framework_error_document() {
+        let outcome = body_parse_error_response("not json");
+        let doc: Value = serde_json::from_slice(&outcome.body).expect("error doc parses");
+        assert_eq!(
+            doc["type"].as_str().expect("type present"),
+            framework_error_type_uri().to_string()
+        );
+    }
 }

--- a/vtc-service/src/trust_tasks/mod.rs
+++ b/vtc-service/src/trust_tasks/mod.rs
@@ -48,6 +48,10 @@ use crate::join::{JoinSubmitOutcome, JoinTransport};
 use crate::server::AppState;
 
 pub(crate) use helpers::TrustTaskOutcome;
+// The one spelling of the framework error document's Type URI in this crate.
+// Re-exported so the messaging layer labels a type-less reply with the same
+// value the reject path emits, rather than a second literal.
+pub(crate) use helpers::framework_error_type_uri;
 use helpers::{
     app_error_to_reject, body_parse_error_response, parse_payload, reject_with, success_response,
     verdict_response, verify_trust_task_proof,


### PR DESCRIPTION
fix(trust-tasks): stop emitting two versions of the framework error document

Both services routed their rejections through `TrustTask::reject_with`, which
stamps whatever version `trust-tasks-rs` emits — `trust-task-error/0.3` since
the framework's own 0.3 release. But each service also has one *unrouted* path,
for a body that never parsed into a Trust Task at all, and with no request
document to reject from it had to write the Type URI out by hand. Both wrote
`0.1`.

So a single service spoke two dialects, distinguished only by whether the
request happened to parse. That is a trap for exactly the consumer that pins a
version, and it is not hypothetical: a client enumerating `0.1`/`0.2` read every
`0.3` rejection as a **success**, because an unrecognised error document falls
through to the success branch and its payload is returned as the operation's
result (OpenVTC/vta-browser-plugin#115, affinidi/affinidi-webvh-service#160).
The version a service emits is wire contract; emitting two is worse than
emitting the wrong one, because whichever a consumer pins is right half the time.

`trust-tasks-rs` keeps `trust_task_error_type_uri()` `pub(crate)`, so the value
cannot be read from the framework. Each service now names it once, in
`framework_error_type_uri()` beside the unrouted builder, and a test compares
that against the Type URI a real `reject_with` produces. A framework bump now
fails a test instead of silently re-splitting the service in two. A second test
asserts the bytes on the wire carry it, not just the value we compute.

Test fixtures that stood in for a peer's rejection were built at `0.1` — a
version no peer on trust-tasks-rs 0.4 sends. They now use what a peer actually
emits. Those assertions pass either way (the matchers key on the slug, which is
the right way to match), but a suite that exercises a wire nobody speaks is how
the client-side version pin survived this long unnoticed.

Left alone deliberately: `vtc-service::messaging`'s `.unwrap_or(…/0.1)` default,
which labels an inbound document that carries no `type` at all. It is not an
emitted document, and every consumer of that label matches on the slug.
