### PR TITLE
build: take affinidi-messaging-mediator 0.18.16 for the live-delivery fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,9 +332,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-mediator"
-version = "0.18.13"
+version = "0.18.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "607115f65cb92828b4998cf0c692c14e22dfd9f4f17c3a685f27d9d16a5ebc0c"
+checksum = "00ab7a0d72bcd13008008e8d4b7398f0d165373c989953b63d2207a4a25482eb"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-common",
@@ -446,9 +446,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-sdk"
-version = "0.19.4"
+version = "0.19.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aed8bc60621324d13d4d44648433e14909c0826efecd930f6782f0393343954c"
+checksum = "3994145193a940c4fce2905cfc89d85e5999c804295cdd7e7dc8c3c32d6ed018"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-authentication",


### PR DESCRIPTION
0.18.16 (tdk#707) redelivers a recipient's queued inbox when a socket
enables live delivery. Without it, a message arriving in the window
between a socket registering and that socket going live is stored and
never streamed — the defect behind the join_didcomm VMC-delivery flake
(VTI#918), where a credential sat queued for a full 60s while its
recipient polled the live stream.

The embedded test mediator carries the mediator crate, so this is what
puts the fix under the harness. The client-side queue sweep (#974)
covers mediators that do not have it; this covers the one CI runs
against.

Targeted rather than a blanket `cargo update`: four lines of lockfile,
the mediator and the SDK it requires. A workspace-wide refresh here is
known to break `vta-service` on the published-crate `ApproveScope`
skew, and there is nothing else in this change that wants a new
dependency. Both crates declare rust-version 1.95.0, matching the
workspace MSRV.

Signed-off-by: Glenn Gore <glenn.g@affinidi.com>

