### PR TITLE
feat(webvh): find DIDs a host serves that this VTA has no record of

### DIFF
--- a/docs/02-vta/runtime-service-management.md
+++ b/docs/02-vta/runtime-service-management.md
@@ -507,6 +507,61 @@ against the [`did-management/_shared/0.1/CONVENTIONS.md`](https://github.com/tru
 spec. `list-domains` against the same server tells you which
 values are currently legitimate.
 
+## Walkthrough: find DIDs the host and the VTA disagree about
+
+Use case: the hosting UI lists a DID your VTA has never heard of, or
+an edit fails with `did not found: SCID … not found` for a DID the
+host is visibly serving.
+
+```bash
+pnm did-mgmt dids reconcile --server primary
+```
+
+Read-only. It prints two lists:
+
+- **On the host but NOT in this VTA** — *orphans*. The host serves a
+  DID this VTA holds no update key for, so nothing can sign a new
+  version of it, and any delegated edit against it will fail at
+  signing no matter who asks. The usual cause is a delete whose
+  remote leg failed: `delete_did_webvh` calls the host first and, if
+  that call errors, logs `continuing local cleanup but DID is now
+  orphaned on the daemon` and removes the local record anyway. The
+  remedy is to remove it on the host — or re-create the DID here if
+  the identifier is still wanted.
+- **In this VTA but NOT on the host** — usually a create whose
+  publish never landed. `pnm did-mgmt dids register --did <did>
+  --server <id>` re-publishes one.
+
+It repairs nothing on purpose: the two divergences want opposite
+remedies, and neither is safe to infer from a list.
+
+### Why the VTA has to answer this
+
+Neither end can do it alone. The CLI holds no credentials for the
+hosting server; the host has no view of the VTA's records. The VTA
+holds both, so it authenticates to the host with its own credentials,
+asks for `GET /api/dids?owner=<its own DID>`, and compares.
+
+That `owner` parameter is not optional in practice. A VTA that
+administers its own host is an admin caller, and the host answers an
+admin who names no owner with *every* DID on the server — which would
+report every other tenant's DID as missing locally.
+
+### Requires an unrestricted admin
+
+The host has no notion of VTA contexts, so its listing cannot be
+filtered by `has_context_access` the way `dids list` filters local
+records. Scoping the result instead would hide orphans from everyone,
+since an orphan has no local record and therefore no context to check
+against. So the command is super-admin only, like `backup export`.
+
+### REST-registered servers only
+
+The host's DID listing is REST-only. Against a DIDComm-only
+registration the command refuses rather than returning an empty
+diff — "nothing to report" is the one wrong answer here, because it
+is the answer an operator stops looking after.
+
 ## Walkthrough: edit an existing DID document
 
 Use case: you want to add or remove a service entry, change a

--- a/docs/05-design-notes/registry-drift-triage.md
+++ b/docs/05-design-notes/registry-drift-triage.md
@@ -159,6 +159,7 @@ Recommendation vocabulary: **spec** (author upstream, URI stays),
 | `vta/webvh/dids/{list,get,delete}/1.0` | Diff against `did-management/did/{list,info,delete}/0.1`; expected **fold** for list/delete; `get` vs `info` needs the diff before calling it. |
 | `vta/webvh/dids/{create,rotate-keys,register-with-server}/1.0` | Genuinely VTA-side (local key material involved): **spec** under `vta/`. `dids/update` is already published — these join it. |
 | `vta/webvh/servers/{list,register,remove}/1.0` | **spec** under `vta/` — the VTA's own registry of known hosts. `did-management/server/register` is the *host* registering itself: different subject, not a fold. |
+| `vta/webvh/servers/dids/0.1` | **spec** under `vta/`, same reasoning. Added after this table was written (host/VTA DID reconcile: which DIDs a host serves that the VTA has no record of, and the reverse). Not a fold candidate — `did-management/did/list/0.1` is the host's own listing, whereas this is the *comparison* of that listing against VTA-local records, and only the VTA can make it: the operator holds no host credentials, the host holds no VTA records. Author it alongside `servers/{list,register,remove}` when this family is next taken upstream — `servers/domains/0.1` shows the path, having gone up as dtgwg-trust-tasks-tf#171 and left this list. |
 
 ### `vault/*` archival + credential store — 12 → 4 new specs (§C)
 

--- a/pnm-cli/src/cli.rs
+++ b/pnm-cli/src/cli.rs
@@ -846,6 +846,23 @@ pub(crate) enum WebvhCommands {
         #[arg(long)]
         server: String,
     },
+    /// Compare a hosting server's DIDs against this VTA's records.
+    ///
+    /// Reports two divergences. **On the host but not here** is an
+    /// orphan: the host serves a DID this VTA has no key for, so no
+    /// update to it can ever be signed. It is what a delete leaves
+    /// behind when the host call fails — the local record goes
+    /// anyway. **Here but not on the host** is usually a create whose
+    /// publish never landed.
+    ///
+    /// Read-only: it repairs nothing, because the two want opposite
+    /// remedies. Requires an unrestricted admin — the host has no
+    /// view of contexts, so its listing cannot be context-scoped.
+    Reconcile {
+        /// Registered server id (from `pnm did-mgmt servers add`).
+        #[arg(long)]
+        server: String,
+    },
     /// List WebVH DIDs
     ListDids {
         /// FILTER: only show DIDs belonging to this context.
@@ -1194,6 +1211,23 @@ pub(crate) enum DidMgmtDidCommands {
         #[arg(long)]
         server: String,
     },
+    /// Compare a hosting server's DIDs against this VTA's records.
+    ///
+    /// Reports two divergences. **On the host but not here** is an
+    /// orphan: the host serves a DID this VTA has no key for, so no
+    /// update to it can ever be signed. It is what a delete leaves
+    /// behind when the host call fails — the local record goes
+    /// anyway. **Here but not on the host** is usually a create whose
+    /// publish never landed.
+    ///
+    /// Read-only: it repairs nothing, because the two want opposite
+    /// remedies. Requires an unrestricted admin — the host has no
+    /// view of contexts, so its listing cannot be context-scoped.
+    Reconcile {
+        /// Registered server id (from `pnm did-mgmt servers add`).
+        #[arg(long)]
+        server: String,
+    },
 }
 
 impl From<DidMgmtCommands> for WebvhCommands {
@@ -1298,6 +1332,7 @@ impl From<DidMgmtCommands> for WebvhCommands {
                 DidMgmtDidCommands::Delete { did } => WebvhCommands::DeleteDid { did },
                 DidMgmtDidCommands::GetLog { did, out } => WebvhCommands::DidLog { did, out },
                 DidMgmtDidCommands::ListDomains { server } => WebvhCommands::ListDomains { server },
+                DidMgmtDidCommands::Reconcile { server } => WebvhCommands::Reconcile { server },
             },
         }
     }

--- a/pnm-cli/src/commands/webvh.rs
+++ b/pnm-cli/src/commands/webvh.rs
@@ -125,7 +125,74 @@ pub(crate) async fn run(
         WebvhCommands::DeleteDid { did } => webvh::cmd_webvh_did_delete(client, &did).await,
         WebvhCommands::DidLog { did, out } => webvh::cmd_webvh_did_log(client, &did, out).await,
         WebvhCommands::ListDomains { server } => cmd_list_domains(client, &server).await,
+        WebvhCommands::Reconcile { server } => cmd_reconcile(client, &server).await,
     }
+}
+
+/// Print the host/VTA diff for one hosting server.
+///
+/// The output is written to be read by someone who has just been told a DID
+/// they can see does not exist: it names the state, says what causes it, and
+/// gives the next command. A clean result says how many were checked rather
+/// than printing nothing — "no output" and "the listing failed" look identical
+/// otherwise, and this is a command people run precisely when they already
+/// distrust what they are seeing.
+async fn cmd_reconcile(
+    client: &VtaClient,
+    server_id: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let report = client.reconcile_webvh_server_dids(server_id).await?;
+
+    if report.host_only.is_empty() && report.local_only.is_empty() {
+        println!(
+            "`{server_id}` and this VTA agree on all {} DID(s).",
+            report.in_both
+        );
+        return Ok(());
+    }
+
+    if !report.host_only.is_empty() {
+        println!(
+            "On the host but NOT in this VTA — {} orphan(s):",
+            report.host_only.len()
+        );
+        for e in &report.host_only {
+            let did = e.did.as_deref().unwrap_or("(slot never published)");
+            let domain = e
+                .domain
+                .as_deref()
+                .map(|d| format!("  [{d}]"))
+                .unwrap_or_default();
+            let disabled = if e.disabled { "  (disabled)" } else { "" };
+            println!("  {:<20} {did}{domain}{disabled}", e.mnemonic);
+        }
+        println!(
+            "\n  This VTA holds no update key for these, so nothing can sign a new\n  \
+             version of them. That is what a delete leaves behind when the host\n  \
+             call fails. Remove them on the host, or re-create them here if the\n  \
+             DID is still wanted."
+        );
+    }
+
+    if !report.local_only.is_empty() {
+        if !report.host_only.is_empty() {
+            println!();
+        }
+        println!(
+            "In this VTA but NOT on the host — {}:",
+            report.local_only.len()
+        );
+        for e in &report.local_only {
+            println!("  {:<20} {}  (context {})", e.mnemonic, e.did, e.context_id);
+        }
+        println!(
+            "\n  Usually a create whose publish never reached the host. `pnm did-mgmt\n  \
+             dids register --did <did> --server {server_id}` re-publishes one."
+        );
+    }
+
+    println!("\nIn both: {}", report.in_both);
+    Ok(())
 }
 
 /// Fetch the server's `/api/me/domains` view and print it as a

--- a/vta-sdk/src/client/webvh.rs
+++ b/vta-sdk/src/client/webvh.rs
@@ -68,6 +68,35 @@ impl VtaClient {
         .await
     }
 
+    /// Ask the VTA to compare a hosting server's DIDs against its own records.
+    ///
+    /// Read-only. The VTA is the only party that can answer it — the CLI has no
+    /// host credentials, and the host has no view of the VTA's records — which
+    /// is why this is a VTA task rather than something the caller assembles
+    /// from two listings.
+    pub async fn reconcile_webvh_server_dids(
+        &self,
+        server_id: &str,
+    ) -> Result<
+        crate::protocols::did_management::servers::ReconcileWebvhServerDidsResultBody,
+        VtaError,
+    > {
+        self.rpc_tt(
+            crate::trust_tasks::TASK_WEBVH_SERVERS_RECONCILE_0_1,
+            serde_json::json!({ "serverId": server_id }),
+            // Longer than the domains read beside it: this makes a listing call
+            // to the host and the host may be paging thousands of slots.
+            60,
+            |c, url| {
+                c.get(format!(
+                    "{url}/webvh/servers/{}/reconcile",
+                    encode_path_segment(server_id)
+                ))
+            },
+        )
+        .await
+    }
+
     pub async fn update_webvh_server(
         &self,
         id: &str,

--- a/vta-sdk/src/protocols/did_management/servers.rs
+++ b/vta-sdk/src/protocols/did_management/servers.rs
@@ -67,6 +67,73 @@ pub struct ListWebvhServerDomainsResultBody {
     pub default: Option<String>,
 }
 
+/// Request body for `vta/webvh/servers/dids/0.1` — compare the DIDs a hosting
+/// server holds for this VTA against the DIDs the VTA has records for.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct ReconcileWebvhServerDidsBody {
+    #[serde(rename = "serverId", alias = "server_id")]
+    pub server_id: String,
+}
+
+/// The two-sided diff between a hosting server and this VTA.
+///
+/// Read-only, and deliberately so: the two divergences have opposite remedies
+/// (one needs a DID removed from a host, the other needs a publish or a local
+/// delete) and neither is safe to guess at. Naming them precisely is the whole
+/// job — the operator decides.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct ReconcileWebvhServerDidsResultBody {
+    pub server_id: String,
+    /// Served by the host, unknown to this VTA — **orphans**. The usual cause
+    /// is a delete whose remote leg failed: `delete_did_webvh` calls the host
+    /// first and, when that call fails, drops the local record anyway
+    /// ("continuing local cleanup but DID is now orphaned on the daemon"). The
+    /// host keeps serving a DID whose controller has discarded its keys, so no
+    /// update to it can ever be signed again.
+    pub host_only: Vec<HostOnlyDid>,
+    /// Recorded here as hosted on this server, but the host does not have it.
+    /// A create whose publish never landed, or a DID removed on the host by
+    /// another admin.
+    pub local_only: Vec<LocalOnlyDid>,
+    /// How many the two agree on. Present so a clean result reads as "checked
+    /// 14, all matched" rather than an empty screen that could equally mean the
+    /// listing failed.
+    pub in_both: u32,
+}
+
+/// A DID the host serves that this VTA has no record of.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct HostOnlyDid {
+    /// The host's slot identifier — what `pnm did-mgmt` and the host's own API
+    /// address this DID by, and the only identifier a never-published slot has.
+    pub mnemonic: String,
+    /// The DID served at that slot, when the slot has been published to.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub did: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub domain: Option<String>,
+    /// Whether the host has the slot disabled.
+    #[serde(default)]
+    pub disabled: bool,
+}
+
+/// A DID this VTA records as hosted on the server, which the server does not
+/// have.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct LocalOnlyDid {
+    pub did: String,
+    /// The slot this VTA believes the DID occupies on the host.
+    pub mnemonic: String,
+    pub context_id: String,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]

--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -305,6 +305,17 @@ pub const TASK_KEYS_SHOW_0_1: &str = "https://trusttasks.org/spec/keys/show/0.1"
 /// server and relays its caller-scoped view; the response items are the
 /// canonical `did-management` `DomainEntry`, unfiltered.
 /// Payload: [`crate::protocols::did_management::servers::ListWebvhServerDomainsBody`].
+/// `vta/webvh/servers/dids/0.1` — ask the VTA to compare the DIDs a hosting
+/// server holds for it against its own records, and report the divergences.
+///
+/// The VTA is the only party that can answer this: it holds the host
+/// credentials, and it holds the local records. Read-only — it names what is
+/// out of step and repairs nothing, because the two divergences want opposite
+/// remedies.
+/// Payload: [`crate::protocols::did_management::servers::ReconcileWebvhServerDidsBody`].
+pub const TASK_WEBVH_SERVERS_RECONCILE_0_1: &str =
+    "https://trusttasks.org/spec/vta/webvh/servers/dids/0.1";
+
 pub const TASK_WEBVH_SERVERS_DOMAINS_0_1: &str =
     "https://trusttasks.org/spec/vta/webvh/servers/domains/0.1";
 
@@ -1438,6 +1449,7 @@ pub const ALL_URIS: &[&str] = &[
     TASK_WEBVH_SERVERS_REGISTER_1_0,
     TASK_WEBVH_SERVERS_REMOVE_1_0,
     TASK_WEBVH_SERVERS_DOMAINS_0_1,
+    TASK_WEBVH_SERVERS_RECONCILE_0_1,
     TASK_WEBVH_DIDS_LIST_1_0,
     TASK_WEBVH_DIDS_CREATE_1_0,
     TASK_WEBVH_DIDS_GET_1_0,

--- a/vta-service/src/operations/did_webvh/mod.rs
+++ b/vta-service/src/operations/did_webvh/mod.rs
@@ -32,7 +32,8 @@ pub use register_server::{
     register_did_with_server,
 };
 pub use servers::{
-    list_webvh_server_domains, list_webvh_servers, register_webvh_server, remove_webvh_server,
+    list_webvh_server_domains, list_webvh_servers, reconcile_webvh_server_dids,
+    register_webvh_server, remove_webvh_server,
 };
 pub use update::{
     AgentNameVerb, RotateDidWebvhKeysOptions, UpdateDidWebvhError, UpdateDidWebvhOptions,

--- a/vta-service/src/operations/did_webvh/servers.rs
+++ b/vta-service/src/operations/did_webvh/servers.rs
@@ -205,6 +205,160 @@ pub async fn list_webvh_server_domains(
     Ok(entries)
 }
 
+/// Compare what a hosting server holds for this VTA against what the VTA has
+/// records for, and report the two divergences.
+///
+/// Read-only. It repairs nothing on purpose: the two sides need opposite
+/// remedies — a host-only entry is a DID nobody can update any more and wants
+/// removing from the host, a local-only entry may be a publish worth retrying —
+/// and neither is safe to guess at from a list. Naming them is the whole job.
+///
+/// **Super-admin.** The host has no notion of VTA contexts, so its listing
+/// cannot be filtered the way `list_dids_webvh` filters local records by
+/// `has_context_access`. A context-scoped caller would see DIDs from contexts
+/// they cannot act in — and scoping the *result* instead would hide orphans
+/// from everyone, since an orphan has no local record and therefore no context
+/// to check. So the operation is unrestricted-admin only, like the other
+/// cross-context reads (`backup export`, `contexts create`).
+///
+/// **Matched on the host's slot identifier (`mnemonic`), not the DID.** A slot
+/// that was reserved but never published to has no DID at all, and it is
+/// exactly as orphaned as one that was.
+pub async fn reconcile_webvh_server_dids(
+    deps: &crate::operations::did_webvh::WebvhDeps<'_>,
+    auth: &AuthClaims,
+    vta_did: Option<&str>,
+    server_id: &str,
+) -> Result<vta_sdk::protocols::did_management::servers::ReconcileWebvhServerDidsResultBody, AppError>
+{
+    auth.require_super_admin()?;
+
+    let server = webvh_store::get_server(deps.webvh_ks, server_id)
+        .await?
+        .ok_or_else(|| AppError::NotFound(format!("webvh server not found: {server_id}")))?;
+
+    let vta_did_value = vta_did.ok_or_else(|| {
+        AppError::Validation(
+            "VTA DID is not configured — complete `vta setup` before reconciling with a host."
+                .to_string(),
+        )
+    })?;
+
+    let identity = crate::operations::did_webvh::auth_cache::load_vta_webvh_signing_identity(
+        deps.keys_ks,
+        deps.imported_ks,
+        deps.seed_store,
+        deps.audit_ks,
+        vta_did_value,
+    )
+    .await?;
+    let auth_ctx = crate::operations::did_webvh::auth_cache::AuthContext {
+        webvh_ks: deps.webvh_ks,
+        identity: &identity,
+        locks: deps.auth_locks,
+    };
+    let transport = crate::operations::did_webvh::WebvhTransport::from_server_authenticated(
+        &server,
+        deps.did_resolver,
+        deps.didcomm_bridge,
+        &auth_ctx,
+    )
+    .await?;
+
+    let hosted = match transport {
+        crate::operations::did_webvh::WebvhTransport::Rest(c) => {
+            c.list_dids_for_owner(vta_did_value).await?
+        }
+        crate::operations::did_webvh::WebvhTransport::DIDComm { .. } => {
+            // Refuse rather than answer "nothing to report". `/api/dids` is
+            // REST-only on the host, and an empty diff here would read as
+            // "checked, all clean" — the one wrong answer this operation can
+            // give, because it is the answer an operator stops looking after.
+            return Err(AppError::Validation(format!(
+                "server `{server_id}` is reachable over DIDComm only, and the host's DID \
+                 listing is REST-only — this VTA cannot reconcile against it. Register a \
+                 REST endpoint for the server to use this command."
+            )));
+        }
+    };
+
+    let all_local = webvh_store::list_dids(deps.webvh_ks).await?;
+    let report = diff_host_against_local(&hosted, &all_local, &server.id, server_id);
+
+    info!(
+        caller = %auth.did,
+        server_id = %server_id,
+        host_only = report.host_only.len(),
+        local_only = report.local_only.len(),
+        in_both = report.in_both,
+        "webvh server DIDs reconciled"
+    );
+
+    Ok(report)
+}
+
+/// The comparison itself, with the I/O lifted out so it can be tested.
+///
+/// `server_key` is the record's `server_id` (what the local side is filtered
+/// by); `server_label` is what goes in the report. They are the same value in
+/// practice — separate parameters only so the filter cannot silently read the
+/// caller's raw argument instead of the resolved server's id.
+fn diff_host_against_local(
+    hosted: &[crate::webvh_client::HostedDidEntry],
+    all_local: &[vta_sdk::webvh::WebvhDidRecord],
+    server_key: &str,
+    server_label: &str,
+) -> vta_sdk::protocols::did_management::servers::ReconcileWebvhServerDidsResultBody {
+    use vta_sdk::protocols::did_management::servers::{
+        HostOnlyDid, LocalOnlyDid, ReconcileWebvhServerDidsResultBody,
+    };
+
+    // Only records that claim to live on *this* server. `serverless` records
+    // name no host, so they are not missing from one — they were never on it.
+    let local: Vec<_> = all_local
+        .iter()
+        .filter(|r| r.server_id == server_key)
+        .collect();
+
+    let local_mnemonics: std::collections::HashSet<&str> =
+        local.iter().map(|r| r.mnemonic.as_str()).collect();
+    let host_mnemonics: std::collections::HashSet<&str> =
+        hosted.iter().map(|e| e.mnemonic.as_str()).collect();
+
+    let mut host_only: Vec<HostOnlyDid> = hosted
+        .iter()
+        .filter(|e| !local_mnemonics.contains(e.mnemonic.as_str()))
+        .map(|e| HostOnlyDid {
+            mnemonic: e.mnemonic.clone(),
+            did: e.did_id.clone(),
+            domain: e.domain.clone(),
+            disabled: e.disabled,
+        })
+        .collect();
+    let mut local_only: Vec<LocalOnlyDid> = local
+        .iter()
+        .filter(|r| !host_mnemonics.contains(r.mnemonic.as_str()))
+        .map(|r| LocalOnlyDid {
+            did: r.did.clone(),
+            mnemonic: r.mnemonic.clone(),
+            context_id: r.context_id.clone(),
+        })
+        .collect();
+    // Stable order so two runs are diffable and a scripted check can compare
+    // output between them.
+    host_only.sort_by(|a, b| a.mnemonic.cmp(&b.mnemonic));
+    local_only.sort_by(|a, b| a.mnemonic.cmp(&b.mnemonic));
+
+    let in_both = u32::try_from(hosted.len().saturating_sub(host_only.len())).unwrap_or(u32::MAX);
+
+    ReconcileWebvhServerDidsResultBody {
+        server_id: server_label.to_string(),
+        host_only,
+        local_only,
+        in_both,
+    }
+}
+
 pub async fn remove_webvh_server(
     webvh_ks: &KeyspaceHandle,
     auth: &AuthClaims,
@@ -249,4 +403,135 @@ pub(super) async fn validate_server_did(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod reconcile_tests {
+    use super::*;
+    use crate::webvh_client::HostedDidEntry;
+    use vta_sdk::webvh::WebvhDidRecord;
+
+    fn hosted(mnemonic: &str, did: Option<&str>) -> HostedDidEntry {
+        HostedDidEntry {
+            mnemonic: mnemonic.into(),
+            did_id: did.map(str::to_string),
+            domain: Some("webvh.example".into()),
+            disabled: false,
+            updated_at: 0,
+        }
+    }
+
+    fn local(mnemonic: &str, server_id: &str) -> WebvhDidRecord {
+        WebvhDidRecord {
+            did: format!("did:webvh:QmScid:webvh.example:{mnemonic}"),
+            server_id: server_id.into(),
+            mnemonic: mnemonic.into(),
+            scid: "QmScid".into(),
+            context_id: "ctx".into(),
+            portable: false,
+            log_entry_count: 1,
+            pre_rotation_count: 0,
+            next_fragment_id: 2,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        }
+    }
+
+    #[test]
+    fn agreement_reports_a_count_and_no_divergence() {
+        let report = diff_host_against_local(
+            &[hosted(
+                "alpha",
+                Some("did:webvh:QmScid:webvh.example:alpha"),
+            )],
+            &[local("alpha", "prod")],
+            "prod",
+            "prod",
+        );
+        assert!(report.host_only.is_empty());
+        assert!(report.local_only.is_empty());
+        // Counted, not merely silent — "nothing to report" and "the listing
+        // failed" have to look different to the operator.
+        assert_eq!(report.in_both, 1);
+    }
+
+    /// The case this command exists for: the host serves a DID the VTA deleted.
+    #[test]
+    fn a_did_the_host_has_and_the_vta_does_not_is_an_orphan() {
+        let report = diff_host_against_local(
+            &[hosted(
+                "attract-case",
+                Some("did:webvh:Qmc33:webvh.example:attract-case"),
+            )],
+            &[],
+            "prod",
+            "prod",
+        );
+        assert_eq!(report.host_only.len(), 1);
+        assert_eq!(report.host_only[0].mnemonic, "attract-case");
+        assert_eq!(
+            report.host_only[0].did.as_deref(),
+            Some("did:webvh:Qmc33:webvh.example:attract-case")
+        );
+        assert_eq!(report.in_both, 0);
+    }
+
+    /// A slot reserved but never published to has no DID at all — and is
+    /// exactly as orphaned as one that was. Matching on the DID instead of the
+    /// host's slot identifier would drop these silently.
+    #[test]
+    fn a_never_published_slot_is_still_an_orphan() {
+        let report = diff_host_against_local(&[hosted("reserved", None)], &[], "prod", "prod");
+        assert_eq!(report.host_only.len(), 1);
+        assert!(report.host_only[0].did.is_none());
+    }
+
+    #[test]
+    fn a_did_the_vta_has_and_the_host_does_not_is_reported_the_other_way() {
+        let report = diff_host_against_local(&[], &[local("never-landed", "prod")], "prod", "prod");
+        assert_eq!(report.local_only.len(), 1);
+        assert_eq!(report.local_only[0].mnemonic, "never-landed");
+        assert_eq!(report.local_only[0].context_id, "ctx");
+        assert!(report.host_only.is_empty());
+    }
+
+    /// Records belonging to another server — or to no server — are not missing
+    /// from this one. Without the filter every serverless DID would be reported
+    /// as absent from a host it was never on, which is the kind of false alarm
+    /// that gets a diagnostic ignored.
+    #[test]
+    fn records_for_other_servers_are_not_reported_as_missing() {
+        let report = diff_host_against_local(
+            &[],
+            &[
+                local("elsewhere", "staging"),
+                local("local-only-did", "serverless"),
+            ],
+            "prod",
+            "prod",
+        );
+        assert!(report.local_only.is_empty());
+        assert!(report.host_only.is_empty());
+        assert_eq!(report.in_both, 0);
+    }
+
+    #[test]
+    fn output_order_is_stable_regardless_of_listing_order() {
+        let report = diff_host_against_local(
+            &[
+                hosted("zulu", None),
+                hosted("alpha", None),
+                hosted("mike", None),
+            ],
+            &[],
+            "prod",
+            "prod",
+        );
+        let order: Vec<&str> = report
+            .host_only
+            .iter()
+            .map(|e| e.mnemonic.as_str())
+            .collect();
+        assert_eq!(order, ["alpha", "mike", "zulu"]);
+    }
 }

--- a/vta-service/src/routes/did_webvh.rs
+++ b/vta-service/src/routes/did_webvh.rs
@@ -128,6 +128,46 @@ pub async fn list_server_domains_handler(
     Ok(Json(result))
 }
 
+/// `GET /webvh/servers/:id/reconcile` — compare the hosting server's DIDs for
+/// this VTA against the VTA's own records, and report both divergences.
+/// Read-only; super-admin (see the operation for why it cannot be
+/// context-scoped). Authentication to the hosting server uses the VTA's own
+/// credentials, which is why the caller cannot do this themselves.
+#[utoipa::path(
+    get, path = "/webvh/servers/{id}/reconcile", tag = "did-webvh",
+    security(("bearer_jwt" = [])),
+    params(("id" = String, Path, description = "Server identifier")),
+    responses(
+        (status = 200, description = "Host/VTA divergences", body = vta_sdk::protocols::did_management::servers::ReconcileWebvhServerDidsResultBody),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller is not an unrestricted admin"),
+        (status = 404, description = "Server not found"),
+    ),
+)]
+pub async fn reconcile_server_dids_handler(
+    auth: AuthClaims,
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<
+    Json<vta_sdk::protocols::did_management::servers::ReconcileWebvhServerDidsResultBody>,
+    AppError,
+> {
+    let did_resolver = state
+        .did_resolver
+        .as_ref()
+        .ok_or_else(|| AppError::Internal("DID resolver not available".into()))?;
+    let config = state.config.read().await;
+    let deps = operations::did_webvh::WebvhDeps::from_app_state(&state, did_resolver);
+    let result = operations::did_webvh::reconcile_webvh_server_dids(
+        &deps,
+        &auth,
+        config.vta_did.as_deref(),
+        &id,
+    )
+    .await?;
+    Ok(Json(result))
+}
+
 #[derive(Debug, Deserialize, utoipa::ToSchema)]
 pub struct UpdateServerRequest {
     pub label: Option<String>,

--- a/vta-service/src/routes/mod.rs
+++ b/vta-service/src/routes/mod.rs
@@ -533,6 +533,7 @@ fn build_api_router(trust_xff: bool, interval_secs: u64, burst: u32) -> OpenApiR
             did_webvh::remove_server_handler
         ))
         .routes(routes!(did_webvh::list_server_domains_handler))
+        .routes(routes!(did_webvh::reconcile_server_dids_handler))
         .routes(routes!(
             did_webvh::list_dids_handler,
             did_webvh::create_did_handler

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -256,6 +256,16 @@ const UNSPECCED_DISPATCHED_URIS: &[&str] = &[
     "https://trusttasks.org/spec/vta/webvh/servers/list/1.0",
     "https://trusttasks.org/spec/vta/webvh/servers/register/1.0",
     "https://trusttasks.org/spec/vta/webvh/servers/remove/1.0",
+    // Host/VTA DID reconcile. Added knowingly rather than found here: this
+    // list's own rule is "author the spec upstream, do not grow the list", and
+    // the answer for a genuinely new capability is that the spec comes later —
+    // it cannot come first from inside this repo. The disposition is **spec
+    // under `vta/`**, recorded in `registry-drift-triage.md` beside
+    // `servers/{list,register,remove}`, and for the same reason: the subject is
+    // the VTA's own view of a host it uses, which no `did-management/*` task
+    // describes. Nothing else here can answer it either — the operator holds no
+    // host credentials and the host holds no VTA records.
+    "https://trusttasks.org/spec/vta/webvh/servers/dids/0.1",
     "https://trusttasks.org/spec/vta/webvh/dids/list/1.0",
     "https://trusttasks.org/spec/vta/webvh/dids/create/1.0",
     "https://trusttasks.org/spec/vta/webvh/dids/get/1.0",
@@ -1023,6 +1033,11 @@ dispatch_table! {
         [ Mutating None false ],
     #[cfg(feature = "webvh")]
     vta_sdk::trust_tasks::TASK_WEBVH_SERVERS_DOMAINS_0_1 => webvh::handle_servers_domains
+        [ None Metadata false ],
+    // Reads two listings and compares them — no side effects, same class as
+    // the domains read beside it.
+    #[cfg(feature = "webvh")]
+    vta_sdk::trust_tasks::TASK_WEBVH_SERVERS_RECONCILE_0_1 => webvh::handle_servers_reconcile
         [ None Metadata false ],
     #[cfg(feature = "webvh")]
     vta_sdk::trust_tasks::TASK_WEBVH_DIDS_LIST_1_0 => webvh::handle_dids_list

--- a/vta-service/src/trust_tasks/webvh.rs
+++ b/vta-service/src/trust_tasks/webvh.rs
@@ -46,8 +46,9 @@ use vta_sdk::protocols::did_management::{
     get::GetDidWebvhBody,
     list::ListDidsWebvhBody,
     servers::{
-        ListWebvhServerDomainsBody, ListWebvhServersBody, RegisterDidWithServerBody,
-        RegisterDidWithServerResultBody, RegisterWebvhServerBody, RemoveWebvhServerBody,
+        ListWebvhServerDomainsBody, ListWebvhServersBody, ReconcileWebvhServerDidsBody,
+        RegisterDidWithServerBody, RegisterDidWithServerResultBody, RegisterWebvhServerBody,
+        RemoveWebvhServerBody,
     },
     update::{RotateDidWebvhKeysBody, UpdateDidWebvhBody},
 };
@@ -697,6 +698,41 @@ pub(super) struct UpdateDidWithDid {
 /// deliberately transparent — no second filter here, because narrowing a list
 /// the server already scoped would report fewer domains than the caller may
 /// actually use, and the caller has no way to tell that happened.
+/// `spec/vta/webvh/servers/dids/0.1` — diff a hosting server's DIDs against
+/// this VTA's records. Read-only; super-admin (the operation explains why).
+pub(super) async fn handle_servers_reconcile(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    let req: ReconcileWebvhServerDidsBody = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    let did_resolver = match state.did_resolver.as_ref() {
+        Some(r) => r,
+        None => {
+            return app_error_to_reject(
+                &doc,
+                AppError::Internal("DID resolver not available".into()),
+            );
+        }
+    };
+    let vta_did = state.config.read().await.vta_did.clone();
+    let deps = operations::did_webvh::WebvhDeps::from_app_state(state, did_resolver);
+    match operations::did_webvh::reconcile_webvh_server_dids(
+        &deps,
+        auth,
+        vta_did.as_deref(),
+        &req.server_id,
+    )
+    .await
+    {
+        Ok(body) => success_response(&doc, body),
+        Err(e) => app_error_to_reject(&doc, e),
+    }
+}
+
 pub(super) async fn handle_servers_domains(
     state: &AppState,
     auth: &AuthClaims,

--- a/vta-webvh/src/webvh_client.rs
+++ b/vta-webvh/src/webvh_client.rs
@@ -815,6 +815,55 @@ impl WebvhClient {
             .await
             .map_err(|e| AppError::Internal(format!("webvh-server response parse error: {e}")))
     }
+
+    /// GET /api/dids?owner=… — the DIDs this host holds for one owner.
+    ///
+    /// **`owner` is not optional here even though the endpoint allows it.** The
+    /// host answers an admin caller who names no owner with *every* DID on the
+    /// server (`did_ops::list_dids` short-circuits to `list_all_dids`), and a
+    /// VTA that administers its own host is exactly that caller. Reconciling
+    /// against an unscoped list would report every other tenant's DID as
+    /// missing locally, which is both wrong and alarming. Always pass the DID
+    /// whose records you mean.
+    pub async fn list_dids_for_owner(&self, owner: &str) -> Result<Vec<HostedDidEntry>, AppError> {
+        // Built through `Url` rather than `format!` so the owner DID is
+        // percent-encoded by something that knows the rules — a `did:webvh:`
+        // carries colons, and a path DID can carry characters that would
+        // silently truncate a hand-spliced query string.
+        let mut url = Url::parse(&format!("{}/api/dids", self.server_url))
+            .map_err(|e| AppError::Validation(format!("invalid webvh server URL: {e}")))?;
+        url.query_pairs_mut().append_pair("owner", owner);
+        let url = url.to_string();
+        info!(method = "GET", %url, owner, "webvh: sending via rest");
+        let req = self.with_auth(self.http.get(&url));
+        let resp = self.send(req, "GET /api/dids").await?;
+        resp.json()
+            .await
+            .map_err(|e| AppError::Internal(format!("webvh-server response parse error: {e}")))
+    }
+}
+
+/// One row of the host's DID list (`did_hosting_common::DidListEntry`).
+///
+/// Only the members the reconcile needs. The host's row carries resolve counts,
+/// service types and agent names too; deserialising them here would tie this
+/// struct to shape changes in fields nothing reads.
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HostedDidEntry {
+    /// The host's path segment for this DID — its slot identifier, and what
+    /// `PUT /api/dids/{mnemonic}` addresses.
+    pub mnemonic: String,
+    /// The DID the host serves at that slot. `None` for a reserved slot that
+    /// has never been published to, which is why the reconcile keys on
+    /// `mnemonic` and treats this as descriptive.
+    #[serde(default)]
+    pub did_id: Option<String>,
+    #[serde(default)]
+    pub domain: Option<String>,
+    #[serde(default)]
+    pub disabled: bool,
+    pub updated_at: u64,
 }
 
 #[derive(Debug, serde::Deserialize)]

--- a/vtc-service/tests/trust_task_manifest.rs
+++ b/vtc-service/tests/trust_task_manifest.rs
@@ -437,7 +437,7 @@ const UNPUBLISHED_CANONICAL_OK: &[(&str, usize, &str)] = &[
     // 77.
     (
         "https://trusttasks.org/spec/vta/",
-        36,
+        37,
         "VTA Trust Task surface at 1.0 — predates the registry and was never reconciled with it. \
          Down from 55 via #840 phase A: config/{get,update} onto config/{show,patch}, \
          provision-integration/request onto provision/integration/0.2, acl/* onto the \
@@ -447,7 +447,14 @@ const UNPUBLISHED_CANONICAL_OK: &[(&str, usize, &str)] = &[
          into webvh/servers/register. Phase D (#888) took the last eight: \
          keys/{list,create,get,rename,revoke,sign,derive-and-sign,\
          derive-and-sign-document} onto the canonical top-level keys/* family \
-         authored upstream in dtgwg-trust-tasks-tf#167",
+         authored upstream in dtgwg-trust-tasks-tf#167. \
+         UP one, 36 → 37: webvh/servers/dids/0.1 (host/VTA DID reconcile). Only \
+         the VTA can answer it — it holds the host credentials and the local \
+         records, and neither end can make the comparison alone. Its nearest \
+         sibling, webvh/servers/domains/0.1, shows the path out: it relays the \
+         same host's domain view and was authored upstream as \
+         dtgwg-trust-tasks-tf#171, which is why it is published and not counted \
+         here. Author this one the same way",
     ),
 ];
 


### PR DESCRIPTION
feat(webvh): find DIDs a host serves that this VTA has no record of

A DID can exist on a hosting server and nowhere in the VTA that owns it. The
delete path says so out loud: `delete_did_webvh` calls the host first and, when
that call fails, logs "continuing local cleanup but DID is now orphaned on the
daemon" and removes the local record anyway. The host keeps serving a DID whose
controller has discarded its keys, and nothing since then could tell you.

Found the hard way: the hosting UI listed a DID, a delegated edit against it was
refused with `did not found: SCID … not found`, and from the outside that reads
as lost keys rather than an orphan.

    pnm did-mgmt dids reconcile --server primary

Read-only, and repairs nothing on purpose — a host-only entry wants removing at
the host, a local-only entry wants its publish retrying, and neither is safe to
infer from a list. Naming them is the job.

**Only the VTA can answer it.** The operator holds no credentials for the
hosting server; the host has no view of the VTA's records. So the VTA
authenticates with its own credentials, reads `GET /api/dids?owner=<its own
DID>`, and compares against its local records.

Three decisions worth the reviewer's attention:

- **`owner` is always sent**, though the endpoint allows omitting it. A VTA that
  administers its own host *is* an admin caller, and the host answers an admin
  who names no owner with every DID on the server — reporting every other
  tenant's DID as missing locally.
- **Matched on the host's slot id, not the DID.** A slot reserved but never
  published to has no DID at all and is exactly as orphaned as one that was.
  Pinned by a test.
- **Super-admin, and DIDComm-only registrations are refused.** The host has no
  notion of VTA contexts, so its listing cannot be filtered by
  `has_context_access` the way `dids list` filters local records — and scoping
  the *result* instead would hide orphans from everyone, since an orphan has no
  local record to carry a context. The host's listing is REST-only, so against a
  DIDComm-only server this errors rather than returning an empty diff: "nothing
  to report" is the one wrong answer available, because it is the answer an
  operator stops looking after.

## The registry cost, stated plainly

This adds one URI — `vta/webvh/servers/dids/0.1` — that the published registry
has no spec for, so it lands on **both** drift registers: the per-family census
in `vtc-service` (spec/vta 36 → 37) and the per-URI
`UNSPECCED_DISPATCHED_URIS` in this crate, whose own rule reads "author the spec
upstream — growing the allowlist is the wrong fix".

It is added knowingly. The spec cannot come first from inside this repo: it
needs a PR to trustoverip/dtgwg-trust-tasks-tf and a `trust-tasks-rs` release
before the URI resolves, which is how every entry on that list arrived. The
disposition is **spec under `vta/`**, recorded in `registry-drift-triage.md`
beside `servers/{list,register,remove}` and for the same reason: the subject is
the VTA's own view of a host it uses, and `did-management/did/list/0.1` is the
host's listing rather than the comparison against local records. The nearest
sibling shows the way out — `servers/domains/0.1` relays the same host's domain
view, went upstream as dtgwg-trust-tasks-tf#171, and is on neither list as a
result.

The alternatives were weighed and are worse: a REST-only route is unreachable
from a TSP-transport CLI, and folding this onto `webvh/dids/list/1.0` makes a
local read do network I/O and grows a response shape most callers never want.

The `did-hosting-ui` half — the warning beside the delegated-edit button, and
the hint that names this command when the agent answers "not found" — is
affinidi/affinidi-webvh-service#163.
