### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2400,7 +2400,7 @@ checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cnm-cli"
-version = "0.11.18"
+version = "0.11.19"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "clap",
@@ -6260,7 +6260,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "pnm-cli"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-resolver-cache-sdk",
@@ -9377,7 +9377,7 @@ dependencies = [
 
 [[package]]
 name = "vta-policy"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "hex",
  "multibase",
@@ -9397,7 +9397,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -9460,7 +9460,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",
@@ -9681,7 +9681,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-client"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "chrono",
  "reqwest",
@@ -9778,7 +9778,7 @@ dependencies = [
 
 [[package]]
 name = "vti-common"
-version = "0.11.39"
+version = "0.11.40"
 dependencies = [
  "aes-gcm",
  "affinidi-data-integrity",

--- a/cnm-cli/CHANGELOG.md
+++ b/cnm-cli/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.11.19](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/cnm-cli-v0.11.18...cnm-cli-v0.11.19) — 2026-08-14
+
+
 ## [0.11.18](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/cnm-cli-v0.11.17...cnm-cli-v0.11.18) — 2026-08-14
 
 

--- a/cnm-cli/Cargo.toml
+++ b/cnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cnm-cli"
 description = "CLI Tool for Verified Trust Agents operating in Verified Trust Communities"
-version = "0.11.18"
+version = "0.11.19"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/pnm-cli/CHANGELOG.md
+++ b/pnm-cli/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.12.3](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/pnm-cli-v0.12.2...pnm-cli-v0.12.3) — 2026-08-14
+
+
 ## [0.12.2](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/pnm-cli-v0.12.1...pnm-cli-v0.12.2) — 2026-08-14
 
 

--- a/pnm-cli/Cargo.toml
+++ b/pnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pnm-cli"
 description = "CLI Tool for managing a personal Verifiable Trust Agent"
-version = "0.12.2"
+version = "0.12.3"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-policy/CHANGELOG.md
+++ b/vta-policy/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.2.4](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-policy-v0.2.3...vta-policy-v0.2.4) — 2026-08-14
+
+
 ## [0.2.3](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-policy-v0.2.2...vta-policy-v0.2.3) — 2026-08-13
 
 

--- a/vta-policy/Cargo.toml
+++ b/vta-policy/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-policy"
 description = "VTA policy subsystem — the regorus (Rego) engine, the default policy bundle, consent model, and decision evaluators"
 readme = "README.md"
-version = "0.2.3"
+version = "0.2.4"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own

--- a/vta-sdk/CHANGELOG.md
+++ b/vta-sdk/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.23.2](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-sdk-v0.23.1...vta-sdk-v0.23.2) — 2026-08-14
+
+
 ## [0.23.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-sdk-v0.23.0...vta-sdk-v0.23.1) — 2026-08-14
 
 

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.23.1"
+version = "0.23.2"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/CHANGELOG.md
+++ b/vta-service/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.15.2](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-service-v0.15.1...vta-service-v0.15.2) — 2026-08-14
+
+
 ## [0.15.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-service-v0.15.0...vta-service-v0.15.1) — 2026-08-14
 
 

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.15.1"
+version = "0.15.2"
 edition.workspace = true
 # Published for one reason: `openvtc-core` dev-depends on it for
 # `test_support::MockVta`, the in-process VTA its end-to-end tests run against.

--- a/vtc-client/CHANGELOG.md
+++ b/vtc-client/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.3.5](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vtc-client-v0.3.4...vtc-client-v0.3.5) — 2026-08-14
+
+
 ## [0.3.4](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vtc-client-v0.3.3...vtc-client-v0.3.4) — 2026-08-12
 
 

--- a/vtc-client/Cargo.toml
+++ b/vtc-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vtc-client"
 description = "Client SDK for Verifiable Trust Communities (VTC) — auth, members, join, removal, policies"
-version = "0.3.4"
+version = "0.3.5"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vti-common/CHANGELOG.md
+++ b/vti-common/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.11.40](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-common-v0.11.39...vti-common-v0.11.40) — 2026-08-14
+
+
 ## [0.11.39](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-common-v0.11.38...vti-common-v0.11.39) — 2026-08-12
 
 

--- a/vti-common/Cargo.toml
+++ b/vti-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-common"
 description = "Shared server-side infrastructure for VTA and VTC services"
 readme = "README.md"
-version = "0.11.39"
+version = "0.11.40"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `vta-sdk`: 0.23.1 -> 0.23.2 (✓ API compatible changes)
* `vti-common`: 0.11.39 -> 0.11.40 (✓ API compatible changes)
* `cnm-cli`: 0.11.18 -> 0.11.19
* `pnm-cli`: 0.12.2 -> 0.12.3
* `vta-policy`: 0.2.3 -> 0.2.4
* `vta-service`: 0.15.1 -> 0.15.2 (✓ API compatible changes)
* `vtc-client`: 0.3.4 -> 0.3.5 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>









</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).