### PR TITLE
chore(deps): take test-mediator 0.2.50 so one trust-tasks copy remains

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,9 +332,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-mediator"
-version = "0.18.16"
+version = "0.18.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00ab7a0d72bcd13008008e8d4b7398f0d165373c989953b63d2207a4a25482eb"
+checksum = "95435c2e6cc192765e0dd4d7d00aa8995869cce73040852d3035c35ca8018e53"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-common",
@@ -389,7 +389,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
- "trust-tasks-rs 0.4.0",
+ "trust-tasks-rs",
  "url",
  "uuid",
 ]
@@ -478,15 +478,15 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "tracing",
- "trust-tasks-rs 0.6.1",
+ "trust-tasks-rs",
  "uuid",
 ]
 
 [[package]]
 name = "affinidi-messaging-test-mediator"
-version = "0.2.48"
+version = "0.2.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd22771fc262c7043ff91548726d9f657a8d3fdadf204514a2ea2abd15f3281b"
+checksum = "60b360ddb78e934a51d9ad7343e0fa0fbe25b60a4e1dabf4f40b25955bc6ceba"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-didcomm",
@@ -2921,7 +2921,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c54e03a951783e8b327515db3f2a2fd0e3bed362a96b066f341ce66ed49b4ead"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4586,7 +4586,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -6452,7 +6452,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.43",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "thiserror 2.0.20",
  "tokio",
  "tracing",
@@ -6491,7 +6491,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -8639,7 +8639,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.20",
- "trust-tasks-rs 0.6.1",
+ "trust-tasks-rs",
  "uuid",
 ]
 
@@ -8653,7 +8653,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.20",
- "trust-tasks-rs 0.6.1",
+ "trust-tasks-rs",
  "uuid",
 ]
 
@@ -8672,7 +8672,7 @@ dependencies = [
  "thiserror 2.0.20",
  "tokio",
  "tower",
- "trust-tasks-rs 0.6.1",
+ "trust-tasks-rs",
  "uuid",
 ]
 
@@ -8690,22 +8690,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.20",
- "trust-tasks-rs 0.6.1",
-]
-
-[[package]]
-name = "trust-tasks-rs"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbf218c8edb7f216a8c966b087589c93f0e5e35d0ea8b52780e6ee63e7c4891c"
-dependencies = [
- "async-trait",
- "chrono",
- "regress",
- "serde",
- "serde_json",
- "serde_with",
- "thiserror 2.0.20",
+ "trust-tasks-rs",
 ]
 
 [[package]]
@@ -9370,7 +9355,7 @@ dependencies = [
  "tokio-tungstenite",
  "tracing-subscriber",
  "trust-tasks-proof",
- "trust-tasks-rs 0.6.1",
+ "trust-tasks-rs",
  "uniffi",
  "vta-sdk",
 ]
@@ -9447,7 +9432,7 @@ dependencies = [
  "time",
  "tokio",
  "tracing",
- "trust-tasks-rs 0.6.1",
+ "trust-tasks-rs",
  "url",
  "utoipa",
  "uuid",
@@ -9530,7 +9515,7 @@ dependencies = [
  "trust-tasks-didcomm",
  "trust-tasks-https",
  "trust-tasks-proof",
- "trust-tasks-rs 0.6.1",
+ "trust-tasks-rs",
  "url",
  "urlencoding",
  "utoipa",
@@ -9689,7 +9674,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.20",
  "tokio",
- "trust-tasks-rs 0.6.1",
+ "trust-tasks-rs",
  "vta-sdk",
 ]
 
@@ -9758,7 +9743,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "trust-tasks-https",
- "trust-tasks-rs 0.6.1",
+ "trust-tasks-rs",
  "unicode-normalization",
  "url",
  "utoipa",
@@ -9812,7 +9797,7 @@ dependencies = [
  "tower",
  "tracing",
  "trust-tasks-capability-client",
- "trust-tasks-rs 0.6.1",
+ "trust-tasks-rs",
  "url",
  "utoipa",
  "utoipa-axum",


### PR DESCRIPTION
#979 moved the workspace to `trust-tasks-rs` 0.6, but the lockfile still
resolved **two** copies of it:

    name = "trust-tasks-rs"    version = "0.4.0"
    name = "trust-tasks-rs"    version = "0.6.1"

The 0.4.0 node came in through dev-dependencies:

    trust-tasks-rs v0.4.0
    └── affinidi-messaging-mediator v0.18.16
        └── affinidi-messaging-test-mediator v0.2.48
            └── vtc-service (dev) / vti-e2e-tests (dev)

Both are caret requirements, and the versions carrying 0.6 did not exist when
#979 was authored — affinidi-messaging-mediator 0.18.17 and -test-mediator
0.2.50 were published by affinidi/affinidi-tdk-rs#709 shortly afterwards. So
this needs no manifest change, only a lockfile update, and it removes the
duplicate.

Worth clearing rather than leaving: `trust-tasks-rs` is a public dependency of
the SDK's `trust_tasks()` surface, so two copies in one graph is the shape that
produces `expected MediatorAcl, found a different MediatorAcl` at whichever call
site first passes a framework type across that boundary. It compiles today
because the dev-dependency side happens not to, which makes it latent rather
than absent.

`cargo test --workspace` is 4387 passing, 0 failing.

Signed-off-by: Glenn Gore <glenn.g@affinidi.com>