### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2424,7 +2424,7 @@ checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cnm-cli"
-version = "0.11.19"
+version = "0.11.20"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "clap",
@@ -6284,7 +6284,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "pnm-cli"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-resolver-cache-sdk",
@@ -9210,7 +9210,7 @@ dependencies = [
 
 [[package]]
 name = "vta-audit"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "tracing",
  "uuid",
@@ -9220,7 +9220,7 @@ dependencies = [
 
 [[package]]
 name = "vta-backup"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -9249,7 +9249,7 @@ dependencies = [
 
 [[package]]
 name = "vta-cli-common"
-version = "0.10.31"
+version = "0.10.32"
 dependencies = [
  "aes-gcm",
  "affinidi-crypto",
@@ -9274,7 +9274,7 @@ dependencies = [
 
 [[package]]
 name = "vta-config"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "serde",
  "serde_ignored",
@@ -9307,7 +9307,7 @@ dependencies = [
 
 [[package]]
 name = "vta-keys"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "aes-gcm",
  "affinidi-crypto",
@@ -9390,7 +9390,7 @@ dependencies = [
 
 [[package]]
 name = "vta-policy"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "hex",
  "multibase",
@@ -9410,7 +9410,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.23.3"
+version = "0.24.0"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -9473,7 +9473,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.15.3"
+version = "0.15.4"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",
@@ -9575,7 +9575,7 @@ dependencies = [
 
 [[package]]
 name = "vta-support"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "chrono",
  "ed25519-dalek",
@@ -9645,7 +9645,7 @@ dependencies = [
 
 [[package]]
 name = "vta-vault"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -9677,7 +9677,7 @@ dependencies = [
 
 [[package]]
 name = "vta-webvh"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "affinidi-tdk",
  "chrono",
@@ -9698,7 +9698,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-client"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "chrono",
  "reqwest",
@@ -9795,7 +9795,7 @@ dependencies = [
 
 [[package]]
 name = "vti-common"
-version = "0.11.40"
+version = "0.11.41"
 dependencies = [
  "aes-gcm",
  "affinidi-data-integrity",
@@ -9868,7 +9868,7 @@ dependencies = [
 
 [[package]]
 name = "vti-secrets"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "aws-config",
  "aws-sdk-secretsmanager",

--- a/cnm-cli/CHANGELOG.md
+++ b/cnm-cli/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.11.20](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/cnm-cli-v0.11.19...cnm-cli-v0.11.20) — 2026-08-16
+
+
 ## [0.11.19](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/cnm-cli-v0.11.18...cnm-cli-v0.11.19) — 2026-08-14
 
 

--- a/cnm-cli/Cargo.toml
+++ b/cnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cnm-cli"
 description = "CLI Tool for Verified Trust Agents operating in Verified Trust Communities"
-version = "0.11.19"
+version = "0.11.20"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -21,7 +21,7 @@ config-session = ["vta-sdk/config-session"]
 azure-secrets = ["vta-sdk/azure-secrets"]
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.23", features = ["session", "crypto-provider", "acl-setup"] }
+vta-sdk = { path = "../vta-sdk", version = "0.24", features = ["session", "crypto-provider", "acl-setup"] }
 # `agent-names` powers the global `--resolve-agent-names` flag; without it
 # the flag parses but can never resolve anything.
 vta-cli-common = { path = "../vta-cli-common", version = "0.10", features = [

--- a/didcomm-test/Cargo.toml
+++ b/didcomm-test/Cargo.toml
@@ -13,7 +13,7 @@ name = "didcomm-test"
 path = "src/main.rs"
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.23", features = ["didcomm", "crypto-provider"] }
+vta-sdk = { path = "../vta-sdk", version = "0.24", features = ["didcomm", "crypto-provider"] }
 affinidi-tdk = { workspace = true }
 affinidi-did-resolver-cache-sdk = { workspace = true }
 tokio = { workspace = true }

--- a/pnm-cli/CHANGELOG.md
+++ b/pnm-cli/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.12.4](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/pnm-cli-v0.12.3...pnm-cli-v0.12.4) — 2026-08-16
+
+
 ## [0.12.3](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/pnm-cli-v0.12.2...pnm-cli-v0.12.3) — 2026-08-14
 
 

--- a/pnm-cli/Cargo.toml
+++ b/pnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pnm-cli"
 description = "CLI Tool for managing a personal Verifiable Trust Agent"
-version = "0.12.3"
+version = "0.12.4"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -28,7 +28,7 @@ azure-secrets = ["vta-sdk/azure-secrets"]
 tsp = ["vta-sdk/tsp"]
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.23", features = ["session", "sealed-transfer", "attest-verify", "provision-integration", "crypto-provider", "acl-setup"] }
+vta-sdk = { path = "../vta-sdk", version = "0.24", features = ["session", "sealed-transfer", "attest-verify", "provision-integration", "crypto-provider", "acl-setup"] }
 affinidi-crypto = { workspace = true }
 base64 = { workspace = true }
 reqwest = { workspace = true }

--- a/vta-audit/CHANGELOG.md
+++ b/vta-audit/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.1.4](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-audit-v0.1.3...vta-audit-v0.1.4) — 2026-08-16
+
+
 ## [0.1.3](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-audit-v0.1.2...vta-audit-v0.1.3) — 2026-08-13
 
 

--- a/vta-audit/Cargo.toml
+++ b/vta-audit/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-audit"
 description = "Structured audit logging for the VTA — the `audit!` tracing macro plus the audit-keyspace persistence helpers"
 readme = "README.md"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -21,6 +21,6 @@ repository.workspace = true
 
 [dependencies]
 vti-common = { path = "../vti-common", version = "0.11" }
-vta-sdk = { path = "../vta-sdk", version = "0.23" }
+vta-sdk = { path = "../vta-sdk", version = "0.24" }
 tracing = { workspace = true }
 uuid = { workspace = true }

--- a/vta-backup/CHANGELOG.md
+++ b/vta-backup/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.1.8](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-backup-v0.1.7...vta-backup-v0.1.8) — 2026-08-16
+
+
 ## [0.1.7](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-backup-v0.1.6...vta-backup-v0.1.7) — 2026-08-14
 
 

--- a/vta-backup/Cargo.toml
+++ b/vta-backup/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-backup"
 description = "VTA backup/restore subsystem — encrypted full-state export/import, the sealed backup-bundle store, and its TTL sweeper"
 readme = "README.md"
-version = "0.1.7"
+version = "0.1.8"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -28,7 +28,7 @@ tee = ["vta-config/tee", "dep:async-trait"]
 
 [dependencies]
 vti-common = { path = "../vti-common", version = "0.11" }
-vta-sdk = { path = "../vta-sdk", version = "0.23" }
+vta-sdk = { path = "../vta-sdk", version = "0.24" }
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.1" }
 vta-keys = { path = "../vta-keys", version = "0.2" }
 vta-config = { path = "../vta-config", version = "0.3" }

--- a/vta-cli-common/CHANGELOG.md
+++ b/vta-cli-common/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.10.32](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-cli-common-v0.10.31...vta-cli-common-v0.10.32) — 2026-08-16
+
+
 ## [0.10.31](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-cli-common-v0.10.30...vta-cli-common-v0.10.31) — 2026-08-14
 
 

--- a/vta-cli-common/Cargo.toml
+++ b/vta-cli-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-cli-common"
 description = "Shared CLI command handlers and rendering helpers for VTA CLIs"
 readme = "README.md"
-version = "0.10.31"
+version = "0.10.32"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -18,7 +18,7 @@ agent-names = ["vta-sdk/agent-names"]
 [dependencies]
 # `time` for the consent loop's bounded wait between polls.
 tokio = { workspace = true, features = ["time"] }
-vta-sdk = { path = "../vta-sdk", version = "0.23", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.24", features = [
   "client",
   "sealed-transfer",
   "provision-integration",

--- a/vta-config/CHANGELOG.md
+++ b/vta-config/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.3.6](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-config-v0.3.5...vta-config-v0.3.6) — 2026-08-16
+
+
 ## [0.3.5](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-config-v0.3.4...vta-config-v0.3.5) — 2026-08-14
 
 

--- a/vta-config/Cargo.toml
+++ b/vta-config/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-config"
 description = "VTA configuration types — the `AppConfig` TOML shape and its sub-configs, composing the vti-common and vti-secrets config types"
 readme = "README.md"
-version = "0.3.5"
+version = "0.3.6"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -30,7 +30,7 @@ vti-common = { path = "../vti-common", version = "0.11" }
 vti-secrets = { path = "../vti-secrets", version = "0.1" }
 # Types only: the declarative approvals rule shape, so a config seed and the
 # runtime row are the same struct rather than two that must be kept in step.
-vta-sdk = { path = "../vta-sdk", version = "0.23", default-features = false }
+vta-sdk = { path = "../vta-sdk", version = "0.24", default-features = false }
 serde = { workspace = true }
 toml = { workspace = true }
 serde_ignored = { workspace = true }

--- a/vta-keys/CHANGELOG.md
+++ b/vta-keys/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.2.3](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-keys-v0.2.2...vta-keys-v0.2.3) — 2026-08-16
+
+
 ## [0.2.2](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-keys-v0.2.1...vta-keys-v0.2.2) — 2026-08-13
 
 

--- a/vta-keys/Cargo.toml
+++ b/vta-keys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-keys"
 description = "VTA key management — master-seed storage, BIP-32 key derivation, key wrapping, and the seed-store backend selection"
 readme = "README.md"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -38,7 +38,7 @@ vta-keyspaces = { path = "../vta-keyspaces", version = "0.1" }
 vta-config = { path = "../vta-config", version = "0.3" }
 vti-common = { path = "../vti-common", version = "0.11" }
 vti-secrets = { path = "../vti-secrets", version = "0.1" }
-vta-sdk = { path = "../vta-sdk", version = "0.23", features = ["sealed-transfer"] }
+vta-sdk = { path = "../vta-sdk", version = "0.24", features = ["sealed-transfer"] }
 affinidi-tdk = { workspace = true }
 affinidi-crypto = { workspace = true }
 ed25519-dalek = { workspace = true }

--- a/vta-mcp/Cargo.toml
+++ b/vta-mcp/Cargo.toml
@@ -14,7 +14,7 @@ publish = false
 # accept-all on connect (`vta_sdk::acl_setup::set_client_acl_on_connection`).
 # Without it the MCP server's ACL is never configured and the mediator silently
 # drops message types it was not told to accept.
-vta-sdk = { path = "../vta-sdk", version = "0.23", features = ["client", "session", "sealed-transfer", "didcomm", "vp", "crypto-provider", "acl-setup"] }
+vta-sdk = { path = "../vta-sdk", version = "0.24", features = ["client", "session", "sealed-transfer", "didcomm", "vp", "crypto-provider", "acl-setup"] }
 rmcp = { version = "1.7", features = ["server", "transport-io", "macros", "schemars"] }
 schemars = "1"
 tokio = { workspace = true }

--- a/vta-mobile-core/Cargo.toml
+++ b/vta-mobile-core/Cargo.toml
@@ -72,7 +72,7 @@ affinidi-messaging-didcomm = "0.15"
 # lookup the approval sheets render through. Costs a DID resolution plus an
 # outbound fetch per claimed name, which is why the app resolves lazily and
 # caches; see `crate::display_name`.
-vta-sdk = { path = "../vta-sdk", version = "0.23", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.24", features = [
   "session",
   "tsp",
   "agent-names",

--- a/vta-policy/CHANGELOG.md
+++ b/vta-policy/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.2.5](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-policy-v0.2.4...vta-policy-v0.2.5) — 2026-08-16
+
+
 ## [0.2.4](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-policy-v0.2.3...vta-policy-v0.2.4) — 2026-08-14
 
 

--- a/vta-policy/Cargo.toml
+++ b/vta-policy/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-policy"
 description = "VTA policy subsystem — the regorus (Rego) engine, the default policy bundle, consent model, and decision evaluators"
 readme = "README.md"
-version = "0.2.4"
+version = "0.2.5"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -25,7 +25,7 @@ vta-config = { path = "../vta-config", version = "0.3" }
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.1" }
 # Types only (default features off): the declarative approvals model + its Rego
 # synthesizer, shared with the CLI so both sides derive the same module.
-vta-sdk = { path = "../vta-sdk", version = "0.23", default-features = false }
+vta-sdk = { path = "../vta-sdk", version = "0.24", default-features = false }
 regorus = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/vta-sdk/CHANGELOG.md
+++ b/vta-sdk/CHANGELOG.md
@@ -2,6 +2,50 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.24.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-sdk-v0.23.3...vta-sdk-v0.24.0) — 2026-08-16
+
+
+### Added
+
+- **vtc**: Let an applicant poll a join without knowing its request id ([#985](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/985))
+
+The status poll exists so an applicant can find out what became of a join
+  the community never volunteered an answer for. It could not be used for
+  that.
+
+  The id it takes is the *community's*, minted here on submit and learned by
+  the applicant from the first correlated reply. An applicant that never
+  received that reply — the exact failure the poll is meant to recover from
+  — holds only the id of the document it sent, which this VTC has never
+  heard of, and gets `not found` for it. So the poll worked whenever it was
+  not needed and failed whenever it was.
+
+  Downstream the two recovery paths shared the blind spot and failed
+  together: OpenVTC gates polling on having a confirmed id, and its other
+  recovery (collecting stored mail) is empty once the mail has been acked
+  and deleted. The record then sits Pending forever with no way back —
+  OpenVTC/openvtc#221, where the only fix was hand-editing a config file.
+
+  `requestId` is now optional. Omitted, it means "what is my open request?",
+  and the community resolves it from the authenticated applicant. That is
+  safe and unambiguous for the same reason the dedup on submit is: at most
+  one request per applicant is open at a time, and the applicant is already
+  proven by the authcrypt sender over DIDComm/TSP. No new auth surface, no
+  new route, no new domain tag — the id simply stops being the only way to
+  name a request.
+
+  The response has always carried `requestId`, so one id-less poll also
+  repairs the applicant's record and every later poll can quote it. That is
+  what turns this from a query into a recovery.
+
+  `find_open_request` is now `pub(crate)`: it was the dedup's private
+  helper, and it is the same invariant both callers rely on.
+
+  REST keeps requiring the id — it is a path segment there, and the stranded
+  case is a messaging one. Worth revisiting if a REST applicant ever hits it.
+
+
+
 ## [0.23.3](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-sdk-v0.23.2...vta-sdk-v0.23.3) — 2026-08-14
 
 

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.23.3"
+version = "0.24.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/CHANGELOG.md
+++ b/vta-service/CHANGELOG.md
@@ -2,6 +2,75 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.15.4](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-service-v0.15.3...vta-service-v0.15.4) — 2026-08-16
+
+
+### Added
+
+- **vta-vault**: Verify and store ISO mdoc credentials on receive ([#986](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/986))
+
+#984 gave mdoc a CredentialFormat identity but receive still refused it, because
+  affinidi-mdoc had no way to turn a stored body back into an IssuerSigned. 0.2.6
+  added that codec, so receive can now do the real work.
+
+  Verifies three things per ISO 18013-5 S9.3.1, rejecting-without-storing on any
+  failure: the issuerAuth COSE_Sign1 over the MSO, every item digest against the
+  MSO valueDigests (a good signature over an MSO whose digests do not match means
+  the items were swapped after signing), and the validityInfo window.
+
+  issuer_pub is the caller-resolved Document Signer key — deliberately the same
+  shape as the DI path's issuer key, and for the same reason: deciding *which*
+  key to trust is policy that belongs to the wire layer. That seam matters more
+  here, because mdoc anchors issuer trust in an X.509 chain (x5chain, COSE label
+  33, rooted in an IACA) while this stack is DID-rooted end to end. Taking a
+  resolved key keeps that unresolved question out of the storage layer instead of
+  quietly settling it.
+
+  ES256 only, checked explicitly before the signature so a mismatched algorithm
+  is refused by name rather than failing as an opaque bad signature. ISO 18013-5
+  and the EUDI profiles mandate ES256, which the VTA already has via
+  KeyType::P256, so no new curve enters the graph.
+
+  subject_did and issuer_did are left None: an mdoc binds to its holder through
+  the MSO deviceKey, not a subject DID, and carries no issuer DID. Inventing
+  either would put an unverifiable identifier into a secondary index.
+
+  coset and time are declared as direct dependencies rather than used
+  transitively through affinidi-mdoc — the receive path names their types, and
+  depending on a transitive is how an unrelated version bump breaks a crate.
+
+  DCQL matching and presentation are deliberately NOT in this change. dcql_format
+  still returns None for mdoc: admitting it without a present_single arm trips
+  formats_admitted_for_dcql_are_all_presentable, and that guard is right — a
+  matched-but-unpresentable credential bails the entire vp_token, not just itself.
+  Presenting an mdoc needs DeviceResponse::to_cbor_bytes (affinidi-mdoc 0.2.7,
+  under review as affinidi/affinidi-tdk-rs#712), so matching and presentation land
+  together in a follow-up.
+
+- **vta-vault**: Give ISO mdoc a first-class CredentialFormat identity ([#984](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/984))
+
+An mdoc arriving at the credential vault previously deserialised into the
+  `Other(String)` escape hatch, so every downstream `match` treated one of
+  the two eIDAS-mandated credential formats as an unknown vendor tag.
+
+  Adds `CredentialFormat::MsoMdoc`, tagged `mso_mdoc` — the OpenID4VP
+  `CredentialQuery.format` spelling, explicitly renamed rather than taking
+  the enum's kebab-case `mso-mdoc`, so storage and protocol agree on one
+  token. A test pins the exact bytes, not just the round-trip.
+
+  Receive refuses an mdoc rather than storing a body it cannot re-read, and
+  `dcql_format` returns `None` for it, keeping the existing matchable-implies-
+  presentable invariant true. Both carry the reason: affinidi-mdoc 0.2.5 has
+  no CBOR codec for `IssuerSigned` (it derives only Debug + Clone, with no
+  Serialize/Deserialize and no to/from_cbor_bytes), so the body cannot be
+  decoded, verified, or re-encoded for presentation. Wiring receive, DCQL
+  matching and presentation is blocked on that codec landing upstream.
+
+  The invariant guard in credential_exchange enumerates formats by hand, so
+  MsoMdoc is added there too — otherwise a new variant is silently uncovered.
+
+
+
 ## [0.15.3](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-service-v0.15.2...vta-service-v0.15.3) — 2026-08-14
 
 

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.15.3"
+version = "0.15.4"
 edition.workspace = true
 # Published for one reason: `openvtc-core` dev-depends on it for
 # `test_support::MockVta`, the in-process VTA its end-to-end tests run against.
@@ -179,7 +179,7 @@ vta-policy = { path = "../vta-policy", version = "0.2" }
 # extracted to its own crate and re-exported as crate::{webvh_store,
 # webvh_client, webvh_auth} behind this crate's `webvh` feature.
 vta-webvh = { path = "../vta-webvh", version = "0.1", optional = true }
-vta-sdk = { path = "../vta-sdk", version = "0.23", features = ["didcomm", "sealed-transfer", "provision-integration", "openapi", "crypto-provider", "acl-setup"] }
+vta-sdk = { path = "../vta-sdk", version = "0.24", features = ["didcomm", "sealed-transfer", "provision-integration", "openapi", "crypto-provider", "acl-setup"] }
 # DID-VM-resolved WebAuthn assertion verifier — drives the new
 # `vta/auth/passkey-login-{start,finish}/1.0` trust-task handlers.
 # Distinct from `webauthn-rs` (which drives the passkey *enrolment*
@@ -372,7 +372,7 @@ vta-service = { path = ".", features = ["test-support", "config-seed"] }
 # here rather than from `vta-sdk`'s own tests — the workspace patches `vta-sdk`
 # onto itself, so `-p vta-sdk --features test-loopback` leaves the built unit
 # Fresh and the feature never reaches the compiler.
-vta-sdk = { path = "../vta-sdk", version = "0.23", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.24", features = [
   "provision-client",
   "test-loopback",
 ] }

--- a/vta-support/CHANGELOG.md
+++ b/vta-support/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.2.5](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-support-v0.2.4...vta-support-v0.2.5) — 2026-08-16
+
+
 ## [0.2.4](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-support-v0.2.3...vta-support-v0.2.4) — 2026-08-13
 
 

--- a/vta-support/Cargo.toml
+++ b/vta-support/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-support"
 description = "Shared mid-layer VTA services — trust-context storage, the sealed-transfer seal helper, and the sealed-bootstrap nonce store"
 readme = "README.md"
-version = "0.2.4"
+version = "0.2.5"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -30,7 +30,7 @@ vta-config = { path = "../vta-config", version = "0.3" }
 # does not exist and the tarball fails to compile. That is what broke the
 # publish run for 0.2.0.
 vti-common = { path = "../vti-common", version = "0.11", features = ["encryption"] }
-vta-sdk = { path = "../vta-sdk", version = "0.23", features = ["sealed-transfer"] }
+vta-sdk = { path = "../vta-sdk", version = "0.24", features = ["sealed-transfer"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 chrono = { workspace = true }

--- a/vta-vault/CHANGELOG.md
+++ b/vta-vault/CHANGELOG.md
@@ -2,6 +2,75 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.1.4](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-vault-v0.1.3...vta-vault-v0.1.4) — 2026-08-16
+
+
+### Added
+
+- **vta-vault**: Verify and store ISO mdoc credentials on receive ([#986](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/986))
+
+#984 gave mdoc a CredentialFormat identity but receive still refused it, because
+  affinidi-mdoc had no way to turn a stored body back into an IssuerSigned. 0.2.6
+  added that codec, so receive can now do the real work.
+
+  Verifies three things per ISO 18013-5 S9.3.1, rejecting-without-storing on any
+  failure: the issuerAuth COSE_Sign1 over the MSO, every item digest against the
+  MSO valueDigests (a good signature over an MSO whose digests do not match means
+  the items were swapped after signing), and the validityInfo window.
+
+  issuer_pub is the caller-resolved Document Signer key — deliberately the same
+  shape as the DI path's issuer key, and for the same reason: deciding *which*
+  key to trust is policy that belongs to the wire layer. That seam matters more
+  here, because mdoc anchors issuer trust in an X.509 chain (x5chain, COSE label
+  33, rooted in an IACA) while this stack is DID-rooted end to end. Taking a
+  resolved key keeps that unresolved question out of the storage layer instead of
+  quietly settling it.
+
+  ES256 only, checked explicitly before the signature so a mismatched algorithm
+  is refused by name rather than failing as an opaque bad signature. ISO 18013-5
+  and the EUDI profiles mandate ES256, which the VTA already has via
+  KeyType::P256, so no new curve enters the graph.
+
+  subject_did and issuer_did are left None: an mdoc binds to its holder through
+  the MSO deviceKey, not a subject DID, and carries no issuer DID. Inventing
+  either would put an unverifiable identifier into a secondary index.
+
+  coset and time are declared as direct dependencies rather than used
+  transitively through affinidi-mdoc — the receive path names their types, and
+  depending on a transitive is how an unrelated version bump breaks a crate.
+
+  DCQL matching and presentation are deliberately NOT in this change. dcql_format
+  still returns None for mdoc: admitting it without a present_single arm trips
+  formats_admitted_for_dcql_are_all_presentable, and that guard is right — a
+  matched-but-unpresentable credential bails the entire vp_token, not just itself.
+  Presenting an mdoc needs DeviceResponse::to_cbor_bytes (affinidi-mdoc 0.2.7,
+  under review as affinidi/affinidi-tdk-rs#712), so matching and presentation land
+  together in a follow-up.
+
+- **vta-vault**: Give ISO mdoc a first-class CredentialFormat identity ([#984](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/984))
+
+An mdoc arriving at the credential vault previously deserialised into the
+  `Other(String)` escape hatch, so every downstream `match` treated one of
+  the two eIDAS-mandated credential formats as an unknown vendor tag.
+
+  Adds `CredentialFormat::MsoMdoc`, tagged `mso_mdoc` — the OpenID4VP
+  `CredentialQuery.format` spelling, explicitly renamed rather than taking
+  the enum's kebab-case `mso-mdoc`, so storage and protocol agree on one
+  token. A test pins the exact bytes, not just the round-trip.
+
+  Receive refuses an mdoc rather than storing a body it cannot re-read, and
+  `dcql_format` returns `None` for it, keeping the existing matchable-implies-
+  presentable invariant true. Both carry the reason: affinidi-mdoc 0.2.5 has
+  no CBOR codec for `IssuerSigned` (it derives only Debug + Clone, with no
+  Serialize/Deserialize and no to/from_cbor_bytes), so the body cannot be
+  decoded, verified, or re-encoded for presentation. Wiring receive, DCQL
+  matching and presentation is blocked on that codec landing upstream.
+
+  The invariant guard in credential_exchange enumerates formats by hand, so
+  MsoMdoc is added there too — otherwise a new variant is silently uncovered.
+
+
+
 ## [0.1.3](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-vault-v0.1.2...vta-vault-v0.1.3) — 2026-08-13
 
 

--- a/vta-vault/Cargo.toml
+++ b/vta-vault/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-vault"
 description = "VTA holder credential vault — storage, query, receive/verify, present, and status refresh for credentials a holder stores on a VTA"
 readme = "README.md"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -34,7 +34,7 @@ webvh = ["dep:reqwest", "vta-sdk/client"]
 [dependencies]
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.1" }
 vti-common = { path = "../vti-common", version = "0.11", features = ["encryption"] }
-vta-sdk = { path = "../vta-sdk", version = "0.23", features = ["didcomm", "sealed-transfer"] }
+vta-sdk = { path = "../vta-sdk", version = "0.24", features = ["didcomm", "sealed-transfer"] }
 affinidi-crypto = { workspace = true }
 affinidi-secrets-resolver = { workspace = true }
 affinidi-data-integrity = { workspace = true }

--- a/vta-webvh/CHANGELOG.md
+++ b/vta-webvh/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.1.7](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-webvh-v0.1.6...vta-webvh-v0.1.7) — 2026-08-16
+
+
 ## [0.1.6](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-webvh-v0.1.5...vta-webvh-v0.1.6) — 2026-08-14
 
 

--- a/vta-webvh/Cargo.toml
+++ b/vta-webvh/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-webvh"
 description = "WebVH hosting infrastructure for the VTA — the DID-record store, the HTTP client to a did:webvh hosting server, and its DID-auth handshake"
 readme = "README.md"
-version = "0.1.6"
+version = "0.1.7"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -22,7 +22,7 @@ repository.workspace = true
 [dependencies]
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.1" }
 vti-common = { path = "../vti-common", version = "0.11" }
-vta-sdk = { path = "../vta-sdk", version = "0.23" }
+vta-sdk = { path = "../vta-sdk", version = "0.24" }
 affinidi-tdk = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/vtc-client/CHANGELOG.md
+++ b/vtc-client/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.3.6](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vtc-client-v0.3.5...vtc-client-v0.3.6) — 2026-08-16
+
+
 ## [0.3.5](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vtc-client-v0.3.4...vtc-client-v0.3.5) — 2026-08-14
 
 

--- a/vtc-client/Cargo.toml
+++ b/vtc-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vtc-client"
 description = "Client SDK for Verifiable Trust Communities (VTC) — auth, members, join, removal, policies"
-version = "0.3.5"
+version = "0.3.6"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -14,7 +14,7 @@ repository.workspace = true
 # Reuses the VTA SDK's challenge-response auth (audience-agnostic) and the
 # published join-request protocol types. `session` gates `auth_light` +
 # `protocols`.
-vta-sdk = { path = "../vta-sdk", version = "0.23", features = ["session"] }
+vta-sdk = { path = "../vta-sdk", version = "0.24", features = ["session"] }
 # `TrustTask` — the join-submit document this client signs, and the `#response`
 # envelope the VTC answers it with. Same crate `vta-sdk` builds the document
 # from, so one shape crosses the boundary.

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -134,7 +134,7 @@ vti-common = { path = "../vti-common", version = "0.11", features = [
 # factory + `*SecretStore` names are a thin facade over these). Per-backend
 # features are activated by this crate's matching features above.
 vti-secrets = { path = "../vti-secrets", version = "0.1" }
-vta-sdk = { path = "../vta-sdk", version = "0.23", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.24", features = [
   "didcomm",
   "session",
   "config-session",

--- a/vti-common/CHANGELOG.md
+++ b/vti-common/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.11.41](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-common-v0.11.40...vti-common-v0.11.41) — 2026-08-16
+
+
 ## [0.11.40](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-common-v0.11.39...vti-common-v0.11.40) — 2026-08-14
 
 

--- a/vti-common/Cargo.toml
+++ b/vti-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-common"
 description = "Shared server-side infrastructure for VTA and VTC services"
 readme = "README.md"
-version = "0.11.40"
+version = "0.11.41"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -48,7 +48,7 @@ openapi = ["dep:utoipa", "dep:utoipa-axum"]
 # `default-features = false` skips the optional client transports
 # (didcomm, sealed-transfer, etc.); we only consume the type
 # definitions in the default feature set.
-vta-sdk = { path = "../vta-sdk", version = "0.23", default-features = false }
+vta-sdk = { path = "../vta-sdk", version = "0.24", default-features = false }
 async-trait = "0.1"
 # Durable OutboxStore backend (`outbox_store::VtiOutboxStore`) for the D1
 # delivery layer — the Guaranteed-send outbox, persisted via `store::Store`.

--- a/vti-secrets/CHANGELOG.md
+++ b/vti-secrets/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.1.12](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-secrets-v0.1.11...vti-secrets-v0.1.12) — 2026-08-16
+
+
 ## [0.1.11](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-secrets-v0.1.10...vti-secrets-v0.1.11) — 2026-08-12
 
 

--- a/vti-secrets/Cargo.toml
+++ b/vti-secrets/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-secrets"
 description = "Pluggable secret-store backends + integration onboarding flow for Verifiable Trust Infrastructure"
 readme = "README.md"
-version = "0.1.11"
+version = "0.1.12"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -54,7 +54,7 @@ tracing = { workspace = true }
 tokio = { workspace = true }
 
 # Onboarding feature: the SDK session/auth state machine + local did:key mint.
-vta-sdk = { path = "../vta-sdk", version = "0.23", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.24", features = [
   "session",
 ], optional = true }
 ed25519-dalek = { workspace = true, optional = true }


### PR DESCRIPTION



## 🤖 New release

* `vta-sdk`: 0.23.3 -> 0.24.0 (✓ API compatible changes)
* `cnm-cli`: 0.11.19 -> 0.11.20
* `pnm-cli`: 0.12.3 -> 0.12.4
* `vta-vault`: 0.1.3 -> 0.1.4
* `vta-service`: 0.15.3 -> 0.15.4 (✓ API compatible changes)
* `vti-common`: 0.11.40 -> 0.11.41
* `vta-cli-common`: 0.10.31 -> 0.10.32
* `vta-audit`: 0.1.3 -> 0.1.4
* `vti-secrets`: 0.1.11 -> 0.1.12
* `vta-config`: 0.3.5 -> 0.3.6
* `vta-keys`: 0.2.2 -> 0.2.3
* `vta-support`: 0.2.4 -> 0.2.5
* `vta-backup`: 0.1.7 -> 0.1.8
* `vta-policy`: 0.2.4 -> 0.2.5
* `vta-webvh`: 0.1.6 -> 0.1.7
* `vtc-client`: 0.3.5 -> 0.3.6

<details><summary><i><b>Changelog</b></i></summary><p>

## `vta-sdk`

<blockquote>

## [0.24.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-sdk-v0.23.3...vta-sdk-v0.24.0) — 2026-08-16

### Added

- **vtc**: Let an applicant poll a join without knowing its request id ([#985](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/985))

The status poll exists so an applicant can find out what became of a join
  the community never volunteered an answer for. It could not be used for
  that.

  The id it takes is the *community's*, minted here on submit and learned by
  the applicant from the first correlated reply. An applicant that never
  received that reply — the exact failure the poll is meant to recover from
  — holds only the id of the document it sent, which this VTC has never
  heard of, and gets `not found` for it. So the poll worked whenever it was
  not needed and failed whenever it was.

  Downstream the two recovery paths shared the blind spot and failed
  together: OpenVTC gates polling on having a confirmed id, and its other
  recovery (collecting stored mail) is empty once the mail has been acked
  and deleted. The record then sits Pending forever with no way back —
  OpenVTC/openvtc#221, where the only fix was hand-editing a config file.

  `requestId` is now optional. Omitted, it means "what is my open request?",
  and the community resolves it from the authenticated applicant. That is
  safe and unambiguous for the same reason the dedup on submit is: at most
  one request per applicant is open at a time, and the applicant is already
  proven by the authcrypt sender over DIDComm/TSP. No new auth surface, no
  new route, no new domain tag — the id simply stops being the only way to
  name a request.

  The response has always carried `requestId`, so one id-less poll also
  repairs the applicant's record and every later poll can quote it. That is
  what turns this from a query into a recovery.

  `find_open_request` is now `pub(crate)`: it was the dedup's private
  helper, and it is the same invariant both callers rely on.

  REST keeps requiring the id — it is a path segment there, and the stranded
  case is a messaging one. Worth revisiting if a REST applicant ever hits it.
</blockquote>



## `vta-vault`

<blockquote>

## [0.1.4](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-vault-v0.1.3...vta-vault-v0.1.4) — 2026-08-16

### Added

- **vta-vault**: Verify and store ISO mdoc credentials on receive ([#986](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/986))

#984 gave mdoc a CredentialFormat identity but receive still refused it, because
  affinidi-mdoc had no way to turn a stored body back into an IssuerSigned. 0.2.6
  added that codec, so receive can now do the real work.

  Verifies three things per ISO 18013-5 S9.3.1, rejecting-without-storing on any
  failure: the issuerAuth COSE_Sign1 over the MSO, every item digest against the
  MSO valueDigests (a good signature over an MSO whose digests do not match means
  the items were swapped after signing), and the validityInfo window.

  issuer_pub is the caller-resolved Document Signer key — deliberately the same
  shape as the DI path's issuer key, and for the same reason: deciding *which*
  key to trust is policy that belongs to the wire layer. That seam matters more
  here, because mdoc anchors issuer trust in an X.509 chain (x5chain, COSE label
  33, rooted in an IACA) while this stack is DID-rooted end to end. Taking a
  resolved key keeps that unresolved question out of the storage layer instead of
  quietly settling it.

  ES256 only, checked explicitly before the signature so a mismatched algorithm
  is refused by name rather than failing as an opaque bad signature. ISO 18013-5
  and the EUDI profiles mandate ES256, which the VTA already has via
  KeyType::P256, so no new curve enters the graph.

  subject_did and issuer_did are left None: an mdoc binds to its holder through
  the MSO deviceKey, not a subject DID, and carries no issuer DID. Inventing
  either would put an unverifiable identifier into a secondary index.

  coset and time are declared as direct dependencies rather than used
  transitively through affinidi-mdoc — the receive path names their types, and
  depending on a transitive is how an unrelated version bump breaks a crate.

  DCQL matching and presentation are deliberately NOT in this change. dcql_format
  still returns None for mdoc: admitting it without a present_single arm trips
  formats_admitted_for_dcql_are_all_presentable, and that guard is right — a
  matched-but-unpresentable credential bails the entire vp_token, not just itself.
  Presenting an mdoc needs DeviceResponse::to_cbor_bytes (affinidi-mdoc 0.2.7,
  under review as affinidi/affinidi-tdk-rs#712), so matching and presentation land
  together in a follow-up.

- **vta-vault**: Give ISO mdoc a first-class CredentialFormat identity ([#984](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/984))

An mdoc arriving at the credential vault previously deserialised into the
  `Other(String)` escape hatch, so every downstream `match` treated one of
  the two eIDAS-mandated credential formats as an unknown vendor tag.

  Adds `CredentialFormat::MsoMdoc`, tagged `mso_mdoc` — the OpenID4VP
  `CredentialQuery.format` spelling, explicitly renamed rather than taking
  the enum's kebab-case `mso-mdoc`, so storage and protocol agree on one
  token. A test pins the exact bytes, not just the round-trip.

  Receive refuses an mdoc rather than storing a body it cannot re-read, and
  `dcql_format` returns `None` for it, keeping the existing matchable-implies-
  presentable invariant true. Both carry the reason: affinidi-mdoc 0.2.5 has
  no CBOR codec for `IssuerSigned` (it derives only Debug + Clone, with no
  Serialize/Deserialize and no to/from_cbor_bytes), so the body cannot be
  decoded, verified, or re-encoded for presentation. Wiring receive, DCQL
  matching and presentation is blocked on that codec landing upstream.

  The invariant guard in credential_exchange enumerates formats by hand, so
  MsoMdoc is added there too — otherwise a new variant is silently uncovered.
</blockquote>

## `vta-service`

<blockquote>

## [0.15.4](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-service-v0.15.3...vta-service-v0.15.4) — 2026-08-16

### Added

- **vta-vault**: Verify and store ISO mdoc credentials on receive ([#986](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/986))

#984 gave mdoc a CredentialFormat identity but receive still refused it, because
  affinidi-mdoc had no way to turn a stored body back into an IssuerSigned. 0.2.6
  added that codec, so receive can now do the real work.

  Verifies three things per ISO 18013-5 S9.3.1, rejecting-without-storing on any
  failure: the issuerAuth COSE_Sign1 over the MSO, every item digest against the
  MSO valueDigests (a good signature over an MSO whose digests do not match means
  the items were swapped after signing), and the validityInfo window.

  issuer_pub is the caller-resolved Document Signer key — deliberately the same
  shape as the DI path's issuer key, and for the same reason: deciding *which*
  key to trust is policy that belongs to the wire layer. That seam matters more
  here, because mdoc anchors issuer trust in an X.509 chain (x5chain, COSE label
  33, rooted in an IACA) while this stack is DID-rooted end to end. Taking a
  resolved key keeps that unresolved question out of the storage layer instead of
  quietly settling it.

  ES256 only, checked explicitly before the signature so a mismatched algorithm
  is refused by name rather than failing as an opaque bad signature. ISO 18013-5
  and the EUDI profiles mandate ES256, which the VTA already has via
  KeyType::P256, so no new curve enters the graph.

  subject_did and issuer_did are left None: an mdoc binds to its holder through
  the MSO deviceKey, not a subject DID, and carries no issuer DID. Inventing
  either would put an unverifiable identifier into a secondary index.

  coset and time are declared as direct dependencies rather than used
  transitively through affinidi-mdoc — the receive path names their types, and
  depending on a transitive is how an unrelated version bump breaks a crate.

  DCQL matching and presentation are deliberately NOT in this change. dcql_format
  still returns None for mdoc: admitting it without a present_single arm trips
  formats_admitted_for_dcql_are_all_presentable, and that guard is right — a
  matched-but-unpresentable credential bails the entire vp_token, not just itself.
  Presenting an mdoc needs DeviceResponse::to_cbor_bytes (affinidi-mdoc 0.2.7,
  under review as affinidi/affinidi-tdk-rs#712), so matching and presentation land
  together in a follow-up.

- **vta-vault**: Give ISO mdoc a first-class CredentialFormat identity ([#984](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/984))

An mdoc arriving at the credential vault previously deserialised into the
  `Other(String)` escape hatch, so every downstream `match` treated one of
  the two eIDAS-mandated credential formats as an unknown vendor tag.

  Adds `CredentialFormat::MsoMdoc`, tagged `mso_mdoc` — the OpenID4VP
  `CredentialQuery.format` spelling, explicitly renamed rather than taking
  the enum's kebab-case `mso-mdoc`, so storage and protocol agree on one
  token. A test pins the exact bytes, not just the round-trip.

  Receive refuses an mdoc rather than storing a body it cannot re-read, and
  `dcql_format` returns `None` for it, keeping the existing matchable-implies-
  presentable invariant true. Both carry the reason: affinidi-mdoc 0.2.5 has
  no CBOR codec for `IssuerSigned` (it derives only Debug + Clone, with no
  Serialize/Deserialize and no to/from_cbor_bytes), so the body cannot be
  decoded, verified, or re-encoded for presentation. Wiring receive, DCQL
  matching and presentation is blocked on that codec landing upstream.

  The invariant guard in credential_exchange enumerates formats by hand, so
  MsoMdoc is added there too — otherwise a new variant is silently uncovered.
</blockquote>













</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).