### PR TITLE
feat(vta-vault): give ISO mdoc a first-class CredentialFormat identity

### DIFF
--- a/vta-service/src/operations/credential_exchange.rs
+++ b/vta-service/src/operations/credential_exchange.rs
@@ -458,7 +458,9 @@ fn candidate_from_stored(
             (vc, None, true)
         }
         // Unreachable: `dcql_format` returned `Some` only for the arms above.
-        CredentialFormat::Zkp | CredentialFormat::Other(_) => return Ok(None),
+        CredentialFormat::MsoMdoc | CredentialFormat::Zkp | CredentialFormat::Other(_) => {
+            return Ok(None);
+        }
     };
 
     Ok(Some(CandidateCredential {
@@ -1142,7 +1144,16 @@ fn dcql_format(format: &CredentialFormat) -> Option<&'static str> {
     match format {
         CredentialFormat::SdJwtVc => Some("dc+sd-jwt"),
         CredentialFormat::EddsaJcs2022 => Some("ldp_vc"),
-        CredentialFormat::Bbs2023 | CredentialFormat::Zkp | CredentialFormat::Other(_) => None,
+        // `MsoMdoc` is deliberately `None` even though the DCQL token is
+        // exactly the variant's serde tag. Returning `Some` here would let a
+        // stored mdoc past the guard in `candidate_from_stored`, which then
+        // cannot build a `CandidateCredential` — it has no way to decode
+        // `IssuerSigned` from CBOR (no codec in affinidi-mdoc 0.2.5). Keeping
+        // the two consistent means an mdoc is skipped, never half-matched.
+        CredentialFormat::MsoMdoc
+        | CredentialFormat::Bbs2023
+        | CredentialFormat::Zkp
+        | CredentialFormat::Other(_) => None,
     }
 }
 
@@ -1175,6 +1186,7 @@ mod tests {
             CredentialFormat::EddsaJcs2022,
             CredentialFormat::Bbs2023,
             CredentialFormat::Zkp,
+            CredentialFormat::MsoMdoc,
             CredentialFormat::Other("vendor-thing".into()),
         ];
         // The set `present_single` can actually render today.

--- a/vta-vault/src/model.rs
+++ b/vta-vault/src/model.rs
@@ -52,6 +52,24 @@ pub enum CredentialFormat {
     EddsaJcs2022,
     /// IETF SD-JWT-VC.
     SdJwtVc,
+    /// ISO/IEC 18013-5 mdoc (`IssuerSigned`, CBOR). One of the two credential
+    /// formats eIDAS 2.0 mandates, alongside [`Self::SdJwtVc`].
+    ///
+    /// The tag is spelled `mso_mdoc` — **not** the `rename_all` kebab-case
+    /// `mso-mdoc` — because it is the same token OpenID4VP and OpenID4VCI use
+    /// on the wire (`CredentialQuery.format`). One spelling across storage and
+    /// protocol means [`crate::…`] callers never translate between them.
+    ///
+    /// **Storage identity only, for now.** Receive, DCQL matching, and
+    /// presentation all need to decode `IssuerSigned` from CBOR, and
+    /// `affinidi-mdoc` 0.2.5 ships no wire codec for it (`IssuerSigned` and
+    /// `DeviceResponse` are `#[derive(Debug, Clone)]` with no `Serialize` /
+    /// `Deserialize` and no `to_cbor_bytes` / `from_cbor_bytes`). Giving the
+    /// format a name here is what lets a stored mdoc be *identified* rather
+    /// than landing in [`Self::Other`]; the paths that must parse the body
+    /// return an explicit not-yet-supported error naming that gap.
+    #[serde(rename = "mso_mdoc")]
+    MsoMdoc,
     /// Forward-compatibility escape hatch — carries the raw tag verbatim so
     /// an unknown format round-trips losslessly.
     #[serde(untagged)]

--- a/vta-vault/src/receive.rs
+++ b/vta-vault/src/receive.rs
@@ -430,6 +430,18 @@ pub async fn receive(
              + Circom/Groth16 verifier not yet wired)"
                 .to_string(),
         )),
+        // Blocked upstream, not here. Verifying an mdoc means decoding
+        // `IssuerSigned` from CBOR, checking `issuerAuth` (COSE_Sign1),
+        // recomputing `valueDigests` and checking `validityInfo` — every
+        // primitive for which `affinidi-mdoc` already has, except the wire
+        // codec: `IssuerSigned` derives only `Debug, Clone`, so there is no
+        // supported way to turn `body` into one. Reject explicitly rather
+        // than storing an mdoc we could never re-read.
+        CredentialFormat::MsoMdoc => Err(AppError::Validation(
+            "mdoc receive is not yet supported: affinidi-mdoc exposes no CBOR codec \
+             for IssuerSigned, so the credential body cannot be decoded or verified"
+                .to_string(),
+        )),
         CredentialFormat::Other(tag) => Err(AppError::Validation(format!(
             "unsupported credential format `{tag}`"
         ))),
@@ -986,6 +998,25 @@ mod tests {
             matches!(&zkp_err, AppError::Validation(m) if m.contains("ZKP")),
             "{zkp_err:?}"
         );
+        // mdoc is refused rather than stored: there is no codec to decode
+        // `IssuerSigned` from the body, so it could never be re-read or
+        // presented. The error names the upstream gap so an operator hitting
+        // it is not left guessing whether they mis-tagged the credential.
+        let mdoc_err = receive(
+            &vault,
+            "c4",
+            &CredentialFormat::MsoMdoc,
+            &vc,
+            None,
+            None,
+            Utc::now(),
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            matches!(&mdoc_err, AppError::Validation(m) if m.contains("affinidi-mdoc")),
+            "error should name the missing codec, got {mdoc_err:?}"
+        );
     }
 
     #[test]
@@ -996,5 +1027,28 @@ mod tests {
         assert_eq!(json, "\"zkp\"");
         let back: CredentialFormat = serde_json::from_str(&json).unwrap();
         assert_eq!(back, CredentialFormat::Zkp);
+    }
+
+    /// The mdoc tag is `mso_mdoc` — underscore, matching OpenID4VP's
+    /// `CredentialQuery.format` — and NOT the `rename_all` kebab-case
+    /// `mso-mdoc` the enum would otherwise produce. Storage and protocol must
+    /// spell it identically or a DCQL selector silently matches nothing, so
+    /// pin the exact bytes rather than only the round-trip.
+    #[test]
+    fn mso_mdoc_format_tag_is_the_openid4vp_spelling() {
+        let json = serde_json::to_string(&CredentialFormat::MsoMdoc).unwrap();
+        assert_eq!(json, "\"mso_mdoc\"", "must match the OID4VP format token");
+        let back: CredentialFormat = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, CredentialFormat::MsoMdoc);
+    }
+
+    /// Before this variant existed an mdoc deserialised into the
+    /// `Other("mso_mdoc")` escape hatch. It must now land on the real variant,
+    /// or every downstream `match` treats a known format as unknown.
+    #[test]
+    fn mso_mdoc_no_longer_falls_into_the_other_escape_hatch() {
+        let parsed: CredentialFormat = serde_json::from_str("\"mso_mdoc\"").unwrap();
+        assert_eq!(parsed, CredentialFormat::MsoMdoc);
+        assert_ne!(parsed, CredentialFormat::Other("mso_mdoc".to_string()));
     }
 }


### PR DESCRIPTION
## Why

ISO mdoc is one of the two credential formats eIDAS 2.0 mandates, alongside
SD-JWT VC. An mdoc arriving at the credential vault previously deserialised into
the `CredentialFormat::Other(String)` escape hatch, so every downstream `match`
treated a mandated format as an unknown vendor tag.

This gives it a name. It does **not** yet make the VTA able to read one — see
"What this deliberately does not do".

## What

- **`CredentialFormat::MsoMdoc`**, tagged **`mso_mdoc`**. Explicitly renamed
  rather than taking the enum's `rename_all` kebab-case `mso-mdoc`, because
  `mso_mdoc` is the token OpenID4VP and OpenID4VCI use for
  `CredentialQuery.format`. One spelling across storage and protocol means no
  call site has to translate between them.

  A test pins the **exact bytes**, not just the round trip — a one-character
  divergence here makes a DCQL selector silently match nothing, which is the kind
  of defect that surfaces as "the wallet just doesn't return that credential".

- **Receive refuses an mdoc** rather than storing a body it could never re-read,
  with an error naming the cause so an operator is not left wondering whether they
  mis-tagged the credential.

- **`dcql_format` returns `None`** for it. There is an existing guard test in
  `credential_exchange` for a *matchable ⇒ presentable* invariant: admitting a
  format that cannot build a `CandidateCredential` would let an mdoc match a
  verifier's query and then bail the **entire** `vp_token`, not just that
  credential. Keeping the two consistent means an mdoc is skipped, never
  half-matched.

  That guard enumerates formats by hand, so `MsoMdoc` is added to its list too —
  otherwise a new variant is silently uncovered by the very test meant to catch
  this.

## What this deliberately does not do

Decode, verify or present an mdoc. The vault stores credential bodies as opaque
bytes, and until now `affinidi-mdoc` shipped no CBOR codec for `IssuerSigned`
(it derived only `Debug, Clone`).

That codec is now up for review as
**affinidi/affinidi-tdk-rs#711** (`affinidi-mdoc` 0.2.6). Once it releases, the
follow-up here is small and well-bounded:

1. flip `dcql_format` to `Some("mso_mdoc")`;
2. add the `candidate_from_stored` arm — decode `IssuerSigned`, resolve items into
   a claims tree keyed by namespace, lift `docType` into the `doctype` field the
   DCQL matcher already exposes (the VTA currently passes `None`), and set
   `supports_holder_binding` from `mso.deviceKeyInfo.deviceKey`;
3. wire receive verification.

Step 3 carries the one real design decision, and it is not mechanical: **mdoc
anchors issuer trust in an X.509 chain (`x5chain`, COSE label 33) rooted in an
IACA, while this stack is DID-rooted end to end.** The likely answer is a
configured trust-anchor set of IACA / Document Signer certificates for the
verification path — how production EUDI verifiers work, and it keeps X.509 at the
boundary rather than in the core — but that deserves its own discussion rather
than being settled inside a format-identity PR.

Presentation (an mdoc `vp_token` entry is a base64url CBOR `DeviceResponse`, not
a W3C Data-Integrity VP, so `build_vp_token` needs a format branch) additionally
needs a `DeviceResponse` encoder, which is out of scope of the upstream PR above.

## Testing

`cargo test -p vta-vault --lib` — 89 passed.
`cargo test -p vta-service --lib credential_exchange` — 24 passed.

New: `mso_mdoc_format_tag_is_the_openid4vp_spelling`,
`mso_mdoc_no_longer_falls_into_the_other_escape_hatch`, plus an mdoc arm in the
existing receive-dispatch test. `MsoMdoc` added to
`formats_admitted_for_dcql_are_all_presentable`.

`cargo fmt` and `cargo clippy -p vta-vault -p vta-service` clean.
No `version =` edits — release-plz owns those.
