### PR TITLE
feat(vtc)!: let an applicant poll a join without knowing its request id

### DIFF
--- a/vta-sdk/src/protocols/join_requests.rs
+++ b/vta-sdk/src/protocols/join_requests.rs
@@ -146,11 +146,28 @@ pub const JOIN_REQUEST_STATUS_RESPONSE_TYPE: &str =
 
 /// Body of the status message (DIDComm). Over REST the `{id}` is the
 /// path segment; over DIDComm it travels here.
+///
+/// `request_id` is **optional**: omit it to ask "what is my open request?"
+/// and the community resolves it from the authenticated applicant.
+///
+/// That is not a convenience. The id an applicant polls with is the
+/// community's, minted on submit and learned from the first correlated
+/// reply — so an applicant whose reply was lost holds only its own
+/// placeholder and cannot name the request at all. Requiring the id made
+/// this poll unusable in exactly the case it exists for: a join whose
+/// answer went missing. The response always carries `request_id`, so one
+/// id-less poll also repairs the applicant's record for every poll after.
+///
+/// At most one request per applicant is open at a time (the submit
+/// dedup), so "my open request" is unambiguous.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct JoinRequestStatusBody {
-    pub request_id: Uuid,
+    /// The community's request id, when the applicant knows it. `None`
+    /// asks the community to resolve the applicant's open request.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub request_id: Option<Uuid>,
 }
 
 /// Status response: the request's lifecycle, plus (when `deferred`) what

--- a/vtc-service/src/join/orchestrate.rs
+++ b/vtc-service/src/join/orchestrate.rs
@@ -615,9 +615,14 @@ fn canonical_payload(
     .map_err(|e| AppError::Internal(format!("canonical payload serialize: {e}")))
 }
 
-/// Find an applicant's open (Pending/Deferred) join request, if any. Used to
-/// dedup / cap open requests per applicant (P0.13).
-async fn find_open_request(
+/// Find an applicant's open (Pending/Deferred) join request, if any.
+///
+/// Two callers, both relying on the same invariant that at most one is open per
+/// applicant: the submit dedup that establishes it (P0.13), and the id-less
+/// status poll (`status_by_applicant`), which is only well-defined because of
+/// it — an applicant that has lost the community's request id can ask about
+/// "my open request" and get exactly one answer.
+pub(crate) async fn find_open_request(
     ks: &vti_common::store::KeyspaceHandle,
     applicant_did: &str,
 ) -> Result<Option<Uuid>, AppError> {

--- a/vtc-service/src/routes/join_requests/status.rs
+++ b/vtc-service/src/routes/join_requests/status.rs
@@ -88,7 +88,50 @@ pub async fn status_inner(
             "applicantDid does not match the join request applicant".into(),
         ));
     }
+    project_status(id, req)
+}
 
+/// Resolve the applicant's **open** request without being told its id.
+///
+/// The id an applicant polls with is the community's, minted here on submit and
+/// learned from the first correlated reply. An applicant whose reply was lost
+/// therefore holds only the id of the document it sent — which this VTC has
+/// never heard of — and cannot name its request at all. That made
+/// [`status_inner`] unusable in precisely the situation it exists for: a join
+/// whose answer went missing.
+///
+/// The applicant is already authenticated (authcrypt sender over DIDComm/TSP),
+/// and the submit dedup allows at most one open request per applicant, so
+/// "my open request" is both safe to ask and unambiguous to answer. The response
+/// carries `request_id`, so one id-less poll also repairs the applicant's record
+/// for every poll after it.
+///
+/// `NotFound` when nothing is open: either the applicant never reached us — in
+/// which case re-submitting is the move, not polling — or the request already
+/// settled and was retained past its window.
+pub async fn status_by_applicant(
+    state: &AppState,
+    applicant_did: String,
+) -> Result<JoinRequestStatusResponseBody, AppError> {
+    let id = crate::join::orchestrate::find_open_request(&state.join_requests_ks, &applicant_did)
+        .await?
+        .ok_or_else(|| {
+            AppError::NotFound(format!(
+                "no open join request for applicant {applicant_did}"
+            ))
+        })?;
+    let req = get_join_request(&state.join_requests_ks, id)
+        .await?
+        .ok_or_else(|| AppError::NotFound(format!("join request not found: {id}")))?;
+    project_status(id, req)
+}
+
+/// Shared projection of a stored request into the applicant-facing response.
+/// Only non-sensitive lifecycle fields (never the stored VP).
+fn project_status(
+    id: Uuid,
+    req: crate::join::JoinRequest,
+) -> Result<JoinRequestStatusResponseBody, AppError> {
     // Project the outstanding requirements only for a Deferred request
     // (a `request_more` verdict the daemon persisted on `policy_decision`).
     let (needs, presentation_definition) = if req.status == JoinStatus::Deferred {

--- a/vtc-service/src/trust_tasks/mod.rs
+++ b/vtc-service/src/trust_tasks/mod.rs
@@ -315,14 +315,31 @@ async fn handle_status(
         Err(reject) => return reject,
     };
 
-    match crate::routes::join_requests::status::status_inner(
-        state,
-        body.request_id,
-        applicant_did,
-        None,
-    )
-    .await
-    {
+    // No `requestId` means "what is my open request?" — the applicant is already
+    // authenticated by the authcrypt sender, and at most one request per
+    // applicant is open (the submit dedup), so the community can resolve it.
+    //
+    // This is the only form of the poll available to an applicant whose first
+    // correlated reply was lost: the id it would otherwise quote is the
+    // community's, learned from that reply, so it holds nothing this VTC
+    // recognises. The response carries `requestId`, so answering once also
+    // repairs the applicant's record for every later poll.
+    let result = match body.request_id {
+        Some(request_id) => {
+            crate::routes::join_requests::status::status_inner(
+                state,
+                request_id,
+                applicant_did,
+                None,
+            )
+            .await
+        }
+        None => {
+            crate::routes::join_requests::status::status_by_applicant(state, applicant_did).await
+        }
+    };
+
+    match result {
         Ok(resp) => success_response(&doc, resp),
         Err(e) => app_error_to_reject(&doc, &e),
     }

--- a/vtc-service/tests/join_didcomm.rs
+++ b/vtc-service/tests/join_didcomm.rs
@@ -302,12 +302,41 @@ async fn didcomm_join_round_trips_submit_manifest_status_approve_and_vmc_deliver
             .request(
                 &vtc_did,
                 JOIN_REQUEST_STATUS_TYPE,
-                serde_json::to_value(JoinRequestStatusBody { request_id }).unwrap(),
+                serde_json::to_value(JoinRequestStatusBody {
+                    request_id: Some(request_id),
+                })
+                .unwrap(),
             )
             .await,
     ))
     .expect("status response");
     assert_eq!(status.status, "pending");
+
+    // 4b. The same poll with **no** request id — "what is my open request?".
+    //
+    // This is the only form available to an applicant whose first correlated
+    // reply was lost: the id it would otherwise quote is the community's, learned
+    // from that reply, so it holds nothing this VTC recognises. Requiring the id
+    // made the poll unusable in precisely the case it exists for.
+    //
+    // The response must name the id, because that is what repairs the
+    // applicant's record and makes every later poll possible.
+    let recovered: JoinRequestStatusResponseBody = serde_json::from_value(response_payload(
+        mock.client
+            .request(
+                &vtc_did,
+                JOIN_REQUEST_STATUS_TYPE,
+                serde_json::to_value(JoinRequestStatusBody { request_id: None }).unwrap(),
+            )
+            .await,
+    ))
+    .expect("id-less status response");
+    assert_eq!(
+        recovered.request_id, request_id,
+        "the community must name the request id it minted — an applicant that \
+         cannot learn it stays unable to poll forever"
+    );
+    assert_eq!(recovered.status, "pending");
 
     // 5. Admin approves over REST — the real ceremony admits the applicant,
     //    issues the VMC + role VEC, and pushes them to the applicant's wallet


### PR DESCRIPTION
The status poll exists so an applicant can find out what became of a join the community never volunteered an answer for. **It could not be used for that.**

## The problem

The id it takes is the *community's* — minted here on submit, and learned by the applicant from the first correlated reply. An applicant that never received that reply, which is the exact failure the poll is meant to recover from, holds only the id of the document it sent. This VTC has never heard of that id, so it answers `not found`.

The poll therefore worked whenever it wasn't needed and failed whenever it was.

Downstream, the two recovery paths share the blind spot and fail together. OpenVTC gates polling on `request_id_confirmed`, and its other recovery — collecting stored mail — is empty once that mail has been acked and deleted. The record sits `Pending` forever. That's [OpenVTC/openvtc#221](https://github.com/OpenVTC/openvtc/pull/221), where the only remedy for the affected user was hand-editing a config file with an id read out of the VTC's own logs.

## The change

`requestId` is now optional. Omitted, it means *"what is my open request?"* and the community resolves it from the authenticated applicant.

That's safe and unambiguous for the same reason the submit dedup is: **at most one request per applicant is open at a time**, and the applicant is already proven by the authcrypt sender over DIDComm/TSP. So this needs no new auth surface, no new route and no new domain tag — the id simply stops being the only way to name a request.

Crucially, the response has always carried `requestId`. So one id-less poll doesn't just answer the question, it **repairs the applicant's record** — every later poll can quote the id. That's what turns this from a query into a recovery.

`find_open_request` becomes `pub(crate)`; it was the dedup's private helper and both callers rely on the same invariant.

## Scope

REST still requires the id — it's a path segment there, and the stranded case is a messaging one. Worth revisiting if a REST applicant ever hits it.

## Breaking change

`JoinRequestStatusBody::request_id` is now `Option<Uuid>`. Callers constructing it need `Some(id)`.

**The wire format is unchanged** for anyone sending an id: the field serialises identically and is only omitted when absent. A current client talking to an updated VTC is unaffected; an updated client talking to an old VTC gets a deserialize error rather than silent misbehaviour.

## Testing

Extended the `join_didcomm` e2e round-trip, which drives the real handlers over a real mediator:

- Step 4 keeps the existing id-carrying poll (now `Some(request_id)`).
- **Step 4b** is new: the same poll with no id, asserting the community both answers `pending` *and* names the request id — because naming it is what makes every later poll possible.

All 3 `join_didcomm` tests pass; `vtc-service` + `vta-sdk` suites green; `fmt` and `clippy -D warnings` clean. No version bumps or changelog edits — release-plz derives both from the commit, and the `!` marks the API break for its API-diff guard.

## Follow-up

The OpenVTC client change is **blocked on a `vta-sdk` release** carrying this field. Once published:

- `poll_join_status` takes `Option<Uuid>`.
- `is_pollable_pending()` stops requiring `request_id_confirmed`, polling with `None` instead.
- No further work needed for the repair — `handle_join_status_response` already calls `confirm_request_id(body.request_id)`, so the record fixes itself on the first answer.
