### PR TITLE
feat(vta-vault): verify and store ISO mdoc credentials on receive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,6 +259,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "affinidi-mdoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d30e7a1c8678393a0114d11f4418af6e894021add84f4656a1679f4670fcd910"
+dependencies = [
+ "aes-gcm",
+ "ciborium",
+ "ciborium-io",
+ "coset 0.3.8",
+ "hex",
+ "hkdf 0.12.4",
+ "hmac 0.12.1",
+ "p256 0.14.0",
+ "rand 0.9.5",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "sha2 0.10.9",
+ "thiserror 2.0.20",
+ "time",
+ "tracing",
+]
+
+[[package]]
 name = "affinidi-meeting-place"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9627,6 +9651,7 @@ dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
  "affinidi-did-resolver-cache-sdk",
+ "affinidi-mdoc",
  "affinidi-sd-jwt",
  "affinidi-sd-jwt-vc",
  "affinidi-secrets-resolver",
@@ -9634,12 +9659,14 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "chrono",
+ "coset 0.3.8",
  "ed25519-dalek",
  "multibase",
  "reqwest",
  "serde",
  "serde_json",
  "tempfile",
+ "time",
  "tokio",
  "tracing",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,6 +107,12 @@ affinidi-status-list = "0.1.3"
 #     credentials (tasks §0.5).
 #   - affinidi-openid4vp  — OID4VP presentation exchange (DCQL lands upstream
 #     in a later task; this is the published base).
+#   - affinidi-mdoc       — ISO/IEC 18013-5 mdoc, the second credential format
+#     eIDAS 2.0 mandates alongside SD-JWT VC. 0.2.6 added the `IssuerSigned`
+#     CBOR wire codec without which a vault storing opaque bodies could never
+#     re-read what it held. `default-features = false` + `es256`: ISO 18013-5
+#     and the EUDI profiles mandate ES256, which the VTA already has via
+#     `KeyType::P256`, so no new curve enters the graph.
 # The `bbs-2023` Data Integrity cryptosuite lives behind the
 # `affinidi-data-integrity` `bbs-2023` feature, enabled per-consumer where the
 # BBS proof path is wired. If you path-override these to the local TDK for an
@@ -116,6 +122,13 @@ affinidi-sd-jwt-vc = "0.2"
 affinidi-sd-jwt = "0.1.2"
 affinidi-bbs = "0.3"
 affinidi-openid4vp = "0.1.2"
+affinidi-mdoc = { version = "0.2.6", default-features = false, features = ["es256"] }
+# Both already enter the graph through `affinidi-mdoc`; declared here because
+# the mdoc receive path names their types directly (`coset` for the COSE_Sign1
+# `alg` header, `time` for the `validityInfo` window) and depending on a
+# transitive is how a version bump elsewhere breaks an unrelated crate.
+coset = "0.3"
+time = "0.3"
 affinidi-openid4vci = "0.2"
 affinidi-secrets-resolver = "0.5"
 # Reliable messaging delivery layer (durable outbox + drain + §5a confirmation)

--- a/vta-service/src/operations/credential_exchange.rs
+++ b/vta-service/src/operations/credential_exchange.rs
@@ -1144,12 +1144,14 @@ fn dcql_format(format: &CredentialFormat) -> Option<&'static str> {
     match format {
         CredentialFormat::SdJwtVc => Some("dc+sd-jwt"),
         CredentialFormat::EddsaJcs2022 => Some("ldp_vc"),
-        // `MsoMdoc` is deliberately `None` even though the DCQL token is
-        // exactly the variant's serde tag. Returning `Some` here would let a
-        // stored mdoc past the guard in `candidate_from_stored`, which then
-        // cannot build a `CandidateCredential` — it has no way to decode
-        // `IssuerSigned` from CBOR (no codec in affinidi-mdoc 0.2.5). Keeping
-        // the two consistent means an mdoc is skipped, never half-matched.
+        // `MsoMdoc` stays `None` even though the DCQL token is exactly the
+        // variant's serde tag, and even though the body is now decodable
+        // (affinidi-mdoc 0.2.6). Admitting it here without a `present_single`
+        // arm trips `formats_admitted_for_dcql_are_all_presentable`, and that
+        // guard is right: a matched-but-unpresentable credential bails the
+        // *entire* `vp_token`, not just itself. Presenting an mdoc needs
+        // `DeviceResponse::to_cbor_bytes` (0.2.7), so matching and presentation
+        // land together in a follow-up rather than separately.
         CredentialFormat::MsoMdoc
         | CredentialFormat::Bbs2023
         | CredentialFormat::Zkp

--- a/vta-vault/Cargo.toml
+++ b/vta-vault/Cargo.toml
@@ -40,6 +40,11 @@ affinidi-secrets-resolver = { workspace = true }
 affinidi-data-integrity = { workspace = true }
 affinidi-sd-jwt = { workspace = true }
 affinidi-sd-jwt-vc = { workspace = true }
+# ISO 18013-5 mdoc — receive-side verification (issuerAuth COSE_Sign1, MSO
+# digests, validityInfo) and the CBOR codec that makes a stored body readable.
+affinidi-mdoc = { workspace = true }
+coset = { workspace = true }
+time = { workspace = true }
 affinidi-status-list = { workspace = true }
 affinidi-did-resolver-cache-sdk = { workspace = true }
 affinidi-bbs = { workspace = true, optional = true }

--- a/vta-vault/src/receive.rs
+++ b/vta-vault/src/receive.rs
@@ -378,6 +378,118 @@ pub async fn receive_di_vc(
     Ok(cred)
 }
 
+/// Receive an ISO/IEC 18013-5 **mdoc** into the vault: verify, map, and store.
+///
+/// `body` is the CBOR `IssuerSigned` wire form. `issuer_pub` is the **caller-
+/// resolved** Document Signer public key (SEC1, P-256) — deliberately the same
+/// shape as [`receive_di_vc`]'s issuer key, and for the same reason: resolving
+/// *which* key to trust is a policy decision that belongs to the wire layer,
+/// not to the verifier.
+///
+/// That seam matters more here than for DI. **mdoc anchors issuer trust in an
+/// X.509 chain** (`x5chain`, COSE header label 33, rooted in an IACA), while
+/// this stack is DID-rooted end to end. Taking a resolved key here keeps that
+/// unresolved question — configured trust-anchor set, trust-registry mapping,
+/// or `did:x509` — out of the storage layer instead of quietly settling it.
+///
+/// Verifies three things, rejecting-without-storing on any failure, per
+/// ISO 18013-5 §9.3.1:
+/// 1. **`issuerAuth`** — the COSE_Sign1 over the MSO, against `issuer_pub`.
+/// 2. **Digests** — every disclosed item against the MSO's `valueDigests`. A
+///    valid signature over an MSO whose digests do not match the items is a
+///    tampered credential.
+/// 3. **`validityInfo`** — `now` inside `[validFrom, validUntil]`.
+///
+/// ES256 only. ISO 18013-5 and the EUDI profiles mandate it, and it is what the
+/// VTA already has via [`vta_sdk::keys::KeyType::P256`], so no new curve enters
+/// the graph. A credential signed with any other algorithm is refused by name
+/// rather than silently mis-verified.
+pub async fn receive_mdoc(
+    vault: &KeyspaceHandle,
+    id: &str,
+    body: &[u8],
+    issuer_pub: &[u8],
+    source: Provenance,
+    now: DateTime<Utc>,
+) -> Result<StoredCredential, AppError> {
+    if id.trim().is_empty() {
+        return Err(AppError::Validation(
+            "credential id must be non-empty".to_string(),
+        ));
+    }
+
+    // Parse. This is structure only — nothing is trusted yet.
+    let issued = affinidi_mdoc::IssuerSigned::from_cbor_bytes(body)
+        .map_err(|e| AppError::Validation(format!("mdoc body is not a valid IssuerSigned: {e}")))?;
+
+    // Refuse an unexpected algorithm before touching the signature, mirroring
+    // the SD-JWT path's `alg` check.
+    let alg = issued.issuer_auth.protected.header.alg.clone();
+    let expected = coset::RegisteredLabelWithPrivate::Assigned(coset::iana::Algorithm::ES256);
+    if alg.as_ref() != Some(&expected) {
+        return Err(AppError::Validation(format!(
+            "mdoc issuerAuth must be ES256 (ISO 18013-5 / EUDI); got {alg:?}"
+        )));
+    }
+
+    // 1. issuerAuth signature, against the caller-resolved Document Signer key.
+    let verifier = affinidi_mdoc::es256_cose::Es256CoseVerifier::from_bytes(issuer_pub)
+        .map_err(|e| AppError::Validation(format!("invalid mdoc issuer key: {e}")))?;
+    let mso = issued
+        .verify_issuer_auth(&verifier)
+        .map_err(|e| AppError::Validation(format!("mdoc issuerAuth did not verify: {e}")))?;
+
+    // 2. Digests. A good signature over an MSO whose digests do not match the
+    //    items means the items were swapped after signing.
+    if !issued
+        .verify_digests()
+        .map_err(|e| AppError::Validation(format!("mdoc digest check failed: {e}")))?
+    {
+        return Err(AppError::Validation(
+            "mdoc item digests do not match the signed MSO".to_string(),
+        ));
+    }
+
+    // 3. Temporal validity.
+    let now_odt = time::OffsetDateTime::from_unix_timestamp(now.timestamp())
+        .map_err(|e| AppError::Internal(format!("clock conversion: {e}")))?;
+    mso.validity_info
+        .check(now_odt)
+        .map_err(|e| AppError::Validation(format!("mdoc is not currently valid: {e}")))?;
+
+    // Map. `docType` is the credential's type — taken from the *signed* MSO,
+    // never from the outer map (the codec guarantees this).
+    let cred = StoredCredential {
+        id: id.to_string(),
+        format: CredentialFormat::MsoMdoc,
+        types: vec![mso.doc_type.clone()],
+        schema_id: None,
+        community_did: None,
+        context_id: None,
+        // An mdoc binds to the holder through the MSO's `deviceKey`, not a
+        // subject DID, and carries no issuer DID — its issuer identity is the
+        // X.509 chain. Leaving both `None` is truthful; inventing a DID here
+        // would put an unverifiable identifier into a secondary index.
+        subject_did: None,
+        issuer_did: None,
+        purpose: Some(CredentialPurpose::Other(mso.doc_type.clone())),
+        status: CredentialStatus::Valid,
+        valid_from: Some(mso.validity_info.valid_from.clone()),
+        valid_until: Some(mso.validity_info.valid_until.clone()),
+        received_at: now.to_rfc3339(),
+        source,
+        tags: std::collections::BTreeMap::new(),
+        body: body.to_vec(),
+        lifecycle: vti_common::vault::VaultStatus::Active,
+        archived_at: None,
+        deleted_at: None,
+        grace_until: None,
+    };
+
+    storage::put(vault, &cred).await?;
+    Ok(cred)
+}
+
 /// Format-dispatching receive — the vault's single entry point for storing an
 /// incoming credential of any format (spec D4).
 ///
@@ -430,18 +542,14 @@ pub async fn receive(
              + Circom/Groth16 verifier not yet wired)"
                 .to_string(),
         )),
-        // Blocked upstream, not here. Verifying an mdoc means decoding
-        // `IssuerSigned` from CBOR, checking `issuerAuth` (COSE_Sign1),
-        // recomputing `valueDigests` and checking `validityInfo` — every
-        // primitive for which `affinidi-mdoc` already has, except the wire
-        // codec: `IssuerSigned` derives only `Debug, Clone`, so there is no
-        // supported way to turn `body` into one. Reject explicitly rather
-        // than storing an mdoc we could never re-read.
-        CredentialFormat::MsoMdoc => Err(AppError::Validation(
-            "mdoc receive is not yet supported: affinidi-mdoc exposes no CBOR codec \
-             for IssuerSigned, so the credential body cannot be decoded or verified"
-                .to_string(),
-        )),
+        CredentialFormat::MsoMdoc => {
+            let pubkey = issuer_pub.ok_or_else(|| {
+                AppError::Validation(
+                    "an mdoc needs a caller-resolved Document Signer key (SEC1 P-256)".to_string(),
+                )
+            })?;
+            receive_mdoc(vault, id, body, pubkey, source, now).await
+        }
         CredentialFormat::Other(tag) => Err(AppError::Validation(format!(
             "unsupported credential format `{tag}`"
         ))),
@@ -998,10 +1106,9 @@ mod tests {
             matches!(&zkp_err, AppError::Validation(m) if m.contains("ZKP")),
             "{zkp_err:?}"
         );
-        // mdoc is refused rather than stored: there is no codec to decode
-        // `IssuerSigned` from the body, so it could never be re-read or
-        // presented. The error names the upstream gap so an operator hitting
-        // it is not left guessing whether they mis-tagged the credential.
+        // mdoc, like DI, needs a caller-resolved issuer key — for mdoc that is
+        // the Document Signer's P-256 key, since issuer trust there is an X.509
+        // chain rather than a resolvable DID.
         let mdoc_err = receive(
             &vault,
             "c4",
@@ -1014,8 +1121,8 @@ mod tests {
         .await
         .unwrap_err();
         assert!(
-            matches!(&mdoc_err, AppError::Validation(m) if m.contains("affinidi-mdoc")),
-            "error should name the missing codec, got {mdoc_err:?}"
+            matches!(&mdoc_err, AppError::Validation(m) if m.contains("Document Signer")),
+            "error should name the missing issuer key, got {mdoc_err:?}"
         );
     }
 
@@ -1050,5 +1157,171 @@ mod tests {
         let parsed: CredentialFormat = serde_json::from_str("\"mso_mdoc\"").unwrap();
         assert_eq!(parsed, CredentialFormat::MsoMdoc);
         assert_ne!(parsed, CredentialFormat::Other("mso_mdoc".to_string()));
+    }
+    // ── mdoc receive ──────────────────────────────────────────────────
+
+    /// Build a signed mdoc plus its Document Signer public key.
+    fn test_mdoc() -> (Vec<u8>, Vec<u8>) {
+        use affinidi_mdoc::es256_cose::Es256CoseSigner;
+        use affinidi_mdoc::mso::ValidityInfo;
+
+        let signer = Es256CoseSigner::generate();
+        let issued = affinidi_mdoc::MdocBuilder::new("eu.europa.ec.eudi.pid.1")
+            .validity(ValidityInfo {
+                signed: "2026-01-01T00:00:00Z".into(),
+                valid_from: "2026-01-01T00:00:00Z".into(),
+                valid_until: "2036-01-01T00:00:00Z".into(),
+            })
+            .add_json_attribute(
+                affinidi_mdoc::EIDAS_PID_NAMESPACE,
+                "family_name",
+                &serde_json::json!("Gore"),
+            )
+            .build(&signer)
+            .unwrap();
+        (issued.to_cbor_bytes().unwrap(), signer.public_key_bytes())
+    }
+
+    #[tokio::test]
+    async fn mdoc_receive_verifies_and_stores() {
+        let (_tmp, _store, vault) = fresh_vault();
+        let (body, issuer_pub) = test_mdoc();
+
+        let cred = receive(
+            &vault,
+            "m1",
+            &CredentialFormat::MsoMdoc,
+            &body,
+            Some(&issuer_pub),
+            None,
+            Utc::now(),
+        )
+        .await
+        .expect("a well-formed mdoc should store");
+
+        assert_eq!(cred.format, CredentialFormat::MsoMdoc);
+        // docType comes from the signed MSO, and becomes the credential type.
+        assert_eq!(cred.types, vec!["eu.europa.ec.eudi.pid.1"]);
+        // No subject/issuer DID: an mdoc binds via the MSO deviceKey and its
+        // issuer identity is an X.509 chain. Inventing either would put an
+        // unverifiable identifier into a secondary index.
+        assert!(cred.subject_did.is_none());
+        assert!(cred.issuer_did.is_none());
+        assert_eq!(cred.body, body, "the body is stored verbatim");
+    }
+
+    #[tokio::test]
+    async fn mdoc_receive_rejects_a_wrong_issuer_key() {
+        use affinidi_mdoc::es256_cose::Es256CoseSigner;
+        let (_tmp, _store, vault) = fresh_vault();
+        let (body, _) = test_mdoc();
+        let attacker = Es256CoseSigner::generate().public_key_bytes();
+
+        let err = receive(
+            &vault,
+            "m2",
+            &CredentialFormat::MsoMdoc,
+            &body,
+            Some(&attacker),
+            None,
+            Utc::now(),
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            matches!(&err, AppError::Validation(m) if m.contains("issuerAuth")),
+            "{err:?}"
+        );
+    }
+
+    /// Reject-before-store: a failed verification must leave nothing behind.
+    #[tokio::test]
+    async fn mdoc_receive_stores_nothing_when_verification_fails() {
+        use affinidi_mdoc::es256_cose::Es256CoseSigner;
+        let (_tmp, _store, vault) = fresh_vault();
+        let (body, _) = test_mdoc();
+        let attacker = Es256CoseSigner::generate().public_key_bytes();
+
+        let _ = receive(
+            &vault,
+            "m3",
+            &CredentialFormat::MsoMdoc,
+            &body,
+            Some(&attacker),
+            None,
+            Utc::now(),
+        )
+        .await;
+
+        assert!(
+            storage::get(&vault, "m3").await.unwrap().is_none(),
+            "a rejected mdoc must not be stored"
+        );
+    }
+
+    /// An expired credential is refused even though its signature is perfectly
+    /// good — ISO 18013-5 §9.3.1 requires the validityInfo check separately.
+    #[tokio::test]
+    async fn mdoc_receive_rejects_an_expired_credential() {
+        let (_tmp, _store, vault) = fresh_vault();
+        let (body, issuer_pub) = test_mdoc();
+        let long_after = "2040-01-01T00:00:00Z".parse::<DateTime<Utc>>().unwrap();
+
+        let err = receive(
+            &vault,
+            "m4",
+            &CredentialFormat::MsoMdoc,
+            &body,
+            Some(&issuer_pub),
+            None,
+            long_after,
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            matches!(&err, AppError::Validation(m) if m.contains("not currently valid")),
+            "{err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn mdoc_receive_requires_an_issuer_key() {
+        let (_tmp, _store, vault) = fresh_vault();
+        let (body, _) = test_mdoc();
+        let err = receive(
+            &vault,
+            "m5",
+            &CredentialFormat::MsoMdoc,
+            &body,
+            None,
+            None,
+            Utc::now(),
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            matches!(&err, AppError::Validation(m) if m.contains("Document Signer")),
+            "{err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn mdoc_receive_rejects_a_body_that_is_not_an_mdoc() {
+        let (_tmp, _store, vault) = fresh_vault();
+        let err = receive(
+            &vault,
+            "m6",
+            &CredentialFormat::MsoMdoc,
+            b"not cbor at all",
+            Some(&[0u8; 65]),
+            None,
+            Utc::now(),
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            matches!(&err, AppError::Validation(m) if m.contains("IssuerSigned")),
+            "{err:?}"
+        );
     }
 }


### PR DESCRIPTION
## Why

#984 gave mdoc a `CredentialFormat` identity, but receive still refused it —
`affinidi-mdoc` had no way to turn a stored body back into an `IssuerSigned`.
[affinidi-mdoc 0.2.6](https://github.com/affinidi/affinidi-tdk-rs/pull/711) added
that codec and is published, so receive can now do the real work.

An mdoc that arrives at the VTA is verified and stored.

## What it verifies

Three things, per ISO/IEC 18013-5 §9.3.1, rejecting-**without**-storing on any
failure:

1. **`issuerAuth`** — the COSE_Sign1 over the MSO, against the issuer key.
2. **Digests** — every item against the MSO's `valueDigests`. A valid signature
   over an MSO whose digests do not match the items means the items were swapped
   after signing, so this is a separate check, not a redundant one.
3. **`validityInfo`** — `now` inside `[validFrom, validUntil]`. Explicitly
   separate, because a perfectly-signed credential can still be expired.

## The X.509 seam — the decision this PR deliberately does *not* make

`issuer_pub` is the **caller-resolved** Document Signer key, deliberately the
same shape as `receive_di_vc`'s issuer key and for the same reason: deciding
*which* key to trust is policy that belongs to the wire layer, not the verifier.

That matters more here than for DI. **mdoc anchors issuer trust in an X.509
chain** (`x5chain`, COSE header label 33, rooted in an IACA), while this stack is
DID-rooted end to end. The three candidate answers — a configured IACA/DS
trust-anchor set, an issuer-DID→certificate mapping via the trust registry, or
`did:x509` — have materially different operational consequences.

Taking a resolved key here keeps that question open at the right layer instead of
quietly settling it inside the storage crate. It should be decided on its own
merits, not inherited from whatever this PR happened to do first.

## Other decisions

- **ES256 only**, checked explicitly *before* the signature so a mismatched
  algorithm is refused by name rather than surfacing as an opaque bad signature.
  ISO 18013-5 and the EUDI profiles mandate ES256, which the VTA already has via
  `KeyType::P256` — no new curve enters the graph.
- **`subject_did` and `issuer_did` are `None`.** An mdoc binds to its holder
  through the MSO's `deviceKey`, not a subject DID, and carries no issuer DID.
  Inventing either would put an unverifiable identifier into a secondary index.
- **`coset` and `time` are declared as direct dependencies** rather than used
  transitively through `affinidi-mdoc`. Both were already in the graph, so the
  tree is unchanged; but the receive path names their types, and depending on a
  transitive is how an unrelated version bump breaks a crate.

## What is deliberately NOT here

**DCQL matching and presentation.** `dcql_format` still returns `None` for mdoc.

I wired the matching path first, and `formats_admitted_for_dcql_are_all_presentable`
failed — correctly:

```
dcql_format admits MsoMdoc but present_single cannot render it
  — this matches-then-fails the entire vp_token
```

A matched-but-unpresentable credential bails the **whole** `vp_token`, not just
itself, so admitting mdoc for matching before presentation works would be a
regression for every other credential in the same query. Presenting an mdoc needs
`DeviceResponse::to_cbor_bytes` (affinidi-mdoc 0.2.7, under review as
[affinidi/affinidi-tdk-rs#712](https://github.com/affinidi/affinidi-tdk-rs/pull/712)),
so matching and presentation land together in a follow-up — which is what that
guard is telling us they are.

## Testing

`cargo test -p vta-vault --lib` — 95 passed (6 new).
`cargo test -p vta-service --lib credential_exchange` — 24 passed.

New tests cover the happy path (docType from the signed MSO becomes the
credential type; body stored verbatim), a wrong issuer key, **reject-before-store**
(a failed verification leaves nothing behind), an expired-but-validly-signed
credential, a missing issuer key, and a body that is not an mdoc at all.

One pre-existing assertion from #984 was updated: it asserted the error named the
missing codec, which is no longer the failure mode.

`cargo fmt --check` and `cargo clippy -p vta-vault -p vta-service` clean.
No `version =` edits — release-plz owns those.
