### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9211,7 +9211,7 @@ dependencies = [
 
 [[package]]
 name = "vta-audit"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "tracing",
  "uuid",
@@ -9221,7 +9221,7 @@ dependencies = [
 
 [[package]]
 name = "vta-backup"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -9250,7 +9250,7 @@ dependencies = [
 
 [[package]]
 name = "vta-cli-common"
-version = "0.10.32"
+version = "0.10.33"
 dependencies = [
  "aes-gcm",
  "affinidi-crypto",
@@ -9275,7 +9275,7 @@ dependencies = [
 
 [[package]]
 name = "vta-config"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "serde",
  "serde_ignored",
@@ -9308,7 +9308,7 @@ dependencies = [
 
 [[package]]
 name = "vta-keys"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "aes-gcm",
  "affinidi-crypto",
@@ -9341,7 +9341,7 @@ dependencies = [
 
 [[package]]
 name = "vta-keyspaces"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "vti-common",
 ]
@@ -9391,7 +9391,7 @@ dependencies = [
 
 [[package]]
 name = "vta-policy"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "hex",
  "multibase",
@@ -9474,7 +9474,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.15.4"
+version = "0.16.0"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",
@@ -9577,7 +9577,7 @@ dependencies = [
 
 [[package]]
 name = "vta-support"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "chrono",
  "ed25519-dalek",
@@ -9597,7 +9597,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sweepers"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "chrono",
  "serde_json",
@@ -9613,7 +9613,7 @@ dependencies = [
 
 [[package]]
 name = "vta-tee"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "aes 0.9.2",
  "aes-gcm",
@@ -9647,7 +9647,7 @@ dependencies = [
 
 [[package]]
 name = "vta-vault"
-version = "0.1.4"
+version = "0.2.0"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -9681,7 +9681,7 @@ dependencies = [
 
 [[package]]
 name = "vta-webvh"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "affinidi-tdk",
  "chrono",
@@ -9799,7 +9799,7 @@ dependencies = [
 
 [[package]]
 name = "vti-common"
-version = "0.11.41"
+version = "0.12.0"
 dependencies = [
  "aes-gcm",
  "affinidi-data-integrity",
@@ -9873,7 +9873,7 @@ dependencies = [
 
 [[package]]
 name = "vti-secrets"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "aws-config",
  "aws-sdk-secretsmanager",

--- a/didcomm-test/Cargo.toml
+++ b/didcomm-test/Cargo.toml
@@ -26,7 +26,7 @@ ed25519-dalek = { workspace = true }
 hex = { workspace = true }
 # SLIP-0010 key derivation (`vti_common::slip10`) — the harness re-derives the
 # same keys the VTA does, from the same seed and paths.
-vti-common = { path = "../vti-common", version = "0.11" }
+vti-common = { path = "../vti-common", version = "0.12" }
 
 [lints]
 workspace = true

--- a/vta-audit/CHANGELOG.md
+++ b/vta-audit/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.1.5](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-audit-v0.1.4...vta-audit-v0.1.5) — 2026-08-16
+
+
 ## [0.1.4](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-audit-v0.1.3...vta-audit-v0.1.4) — 2026-08-16
 
 

--- a/vta-audit/Cargo.toml
+++ b/vta-audit/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-audit"
 description = "Structured audit logging for the VTA — the `audit!` tracing macro plus the audit-keyspace persistence helpers"
 readme = "README.md"
-version = "0.1.4"
+version = "0.1.5"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -20,7 +20,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.11" }
+vti-common = { path = "../vti-common", version = "0.12" }
 vta-sdk = { path = "../vta-sdk", version = "0.24" }
 tracing = { workspace = true }
 uuid = { workspace = true }

--- a/vta-backup/CHANGELOG.md
+++ b/vta-backup/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.1.9](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-backup-v0.1.8...vta-backup-v0.1.9) — 2026-08-16
+
+
 ## [0.1.8](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-backup-v0.1.7...vta-backup-v0.1.8) — 2026-08-16
 
 

--- a/vta-backup/Cargo.toml
+++ b/vta-backup/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-backup"
 description = "VTA backup/restore subsystem — encrypted full-state export/import, the sealed backup-bundle store, and its TTL sweeper"
 readme = "README.md"
-version = "0.1.8"
+version = "0.1.9"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -27,7 +27,7 @@ webvh = ["vta-keyspaces/webvh"]
 tee = ["vta-config/tee", "dep:async-trait"]
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.11" }
+vti-common = { path = "../vti-common", version = "0.12" }
 vta-sdk = { path = "../vta-sdk", version = "0.24" }
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.1" }
 vta-keys = { path = "../vta-keys", version = "0.2" }

--- a/vta-cli-common/CHANGELOG.md
+++ b/vta-cli-common/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.10.33](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-cli-common-v0.10.32...vta-cli-common-v0.10.33) — 2026-08-16
+
+
 ## [0.10.32](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-cli-common-v0.10.31...vta-cli-common-v0.10.32) — 2026-08-16
 
 

--- a/vta-cli-common/Cargo.toml
+++ b/vta-cli-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-cli-common"
 description = "Shared CLI command handlers and rendering helpers for VTA CLIs"
 readme = "README.md"
-version = "0.10.32"
+version = "0.10.33"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -24,7 +24,7 @@ vta-sdk = { path = "../vta-sdk", version = "0.24", features = [
   "provision-integration",
 ] }
 # Owner-only file-permission helper (`secure_file`), shared workspace-wide.
-vti-common = { path = "../vti-common", version = "0.11" }
+vti-common = { path = "../vti-common", version = "0.12" }
 affinidi-crypto = { workspace = true }
 chrono = { workspace = true }
 ed25519-dalek = { workspace = true }

--- a/vta-config/CHANGELOG.md
+++ b/vta-config/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.3.7](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-config-v0.3.6...vta-config-v0.3.7) — 2026-08-16
+
+
 ## [0.3.6](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-config-v0.3.5...vta-config-v0.3.6) — 2026-08-16
 
 

--- a/vta-config/Cargo.toml
+++ b/vta-config/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-config"
 description = "VTA configuration types — the `AppConfig` TOML shape and its sub-configs, composing the vti-common and vti-secrets config types"
 readme = "README.md"
-version = "0.3.6"
+version = "0.3.7"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -26,7 +26,7 @@ default = []
 tee = []
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.11" }
+vti-common = { path = "../vti-common", version = "0.12" }
 vti-secrets = { path = "../vti-secrets", version = "0.1" }
 # Types only: the declarative approvals rule shape, so a config seed and the
 # runtime row are the same struct rather than two that must be kept in step.

--- a/vta-enclave/Cargo.toml
+++ b/vta-enclave/Cargo.toml
@@ -34,8 +34,8 @@ vsock-log = ["dep:tokio-vsock"]
 tenant-overlay = ["dep:vta-tee", "vta-tee/tenant-overlay"]
 
 [dependencies]
-vta-service = { path = "../vta-service", version = "0.15", default-features = false, features = ["tee"] }
-vti-common = { path = "../vti-common", version = "0.11", features = ["encryption"] }
+vta-service = { path = "../vta-service", version = "0.16", default-features = false, features = ["tee"] }
+vti-common = { path = "../vti-common", version = "0.12", features = ["encryption"] }
 # Direct dep only for the `tenant-overlay` fetch entry point; the rest of the
 # TEE bootstrap is reached through `vta_service::tee`. Optional so a baked build
 # links no overlay code.

--- a/vta-keys/CHANGELOG.md
+++ b/vta-keys/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.2.4](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-keys-v0.2.3...vta-keys-v0.2.4) — 2026-08-16
+
+
 ## [0.2.3](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-keys-v0.2.2...vta-keys-v0.2.3) — 2026-08-16
 
 

--- a/vta-keys/Cargo.toml
+++ b/vta-keys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-keys"
 description = "VTA key management — master-seed storage, BIP-32 key derivation, key wrapping, and the seed-store backend selection"
 readme = "README.md"
-version = "0.2.3"
+version = "0.2.4"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -36,7 +36,7 @@ tee = ["vti-secrets/tee"]
 [dependencies]
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.1" }
 vta-config = { path = "../vta-config", version = "0.3" }
-vti-common = { path = "../vti-common", version = "0.11" }
+vti-common = { path = "../vti-common", version = "0.12" }
 vti-secrets = { path = "../vti-secrets", version = "0.1" }
 vta-sdk = { path = "../vta-sdk", version = "0.24", features = ["sealed-transfer"] }
 affinidi-tdk = { workspace = true }

--- a/vta-keyspaces/CHANGELOG.md
+++ b/vta-keyspaces/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.1.3](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-keyspaces-v0.1.2...vta-keyspaces-v0.1.3) — 2026-08-16
+
+
 ## [0.1.2](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-keyspaces-v0.1.1...vta-keyspaces-v0.1.2) — 2026-08-13
 
 

--- a/vta-keyspaces/Cargo.toml
+++ b/vta-keyspaces/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-keyspaces"
 description = "VTA keyspace-name registry — the shared storage vocabulary for the VTA subsystem crates"
 readme = "README.md"
-version = "0.1.2"
+version = "0.1.3"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -26,4 +26,4 @@ webvh = []
 
 [dependencies]
 # For `KeyspaceHandle` in the shared `Keyspaces` handle bundle.
-vti-common = { path = "../vti-common", version = "0.11" }
+vti-common = { path = "../vti-common", version = "0.12" }

--- a/vta-policy/CHANGELOG.md
+++ b/vta-policy/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.2.6](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-policy-v0.2.5...vta-policy-v0.2.6) — 2026-08-16
+
+
 ## [0.2.5](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-policy-v0.2.4...vta-policy-v0.2.5) — 2026-08-16
 
 

--- a/vta-policy/Cargo.toml
+++ b/vta-policy/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-policy"
 description = "VTA policy subsystem — the regorus (Rego) engine, the default policy bundle, consent model, and decision evaluators"
 readme = "README.md"
-version = "0.2.5"
+version = "0.2.6"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -20,7 +20,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.11" }
+vti-common = { path = "../vti-common", version = "0.12" }
 vta-config = { path = "../vta-config", version = "0.3" }
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.1" }
 # Types only (default features off): the declarative approvals model + its Rego

--- a/vta-service/CHANGELOG.md
+++ b/vta-service/CHANGELOG.md
@@ -2,6 +2,75 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.16.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-service-v0.15.4...vta-service-v0.16.0) — 2026-08-16
+
+
+### Added
+
+- **vta-vault**: Bind an mdoc to the VTA key that can present it ([#990](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/990))
+
+An mdoc's holder binding is a key, not a DID: the MSO carries a deviceKey, and
+  only its private half can sign DeviceAuth. Nothing in the stored envelope said
+  which VTA key that was, so a received mdoc could be stored and then turn out to
+  be unpresentable — with the failure surfacing much later, at presentation, and
+  nothing pointing at the cause.
+
+  Receive now resolves that binding and refuses the credential if this VTA does
+  not hold the key. Storing a credential you can never present is a trap, and the
+  right moment to find out is the moment it arrives.
+
+  mdoc_device_key_sec1 extracts the MSO deviceKey as a compressed SEC1 point —
+  the same encoding the VTA stores its own P-256 public keys in — so the caller
+  can compare without re-deriving either side. Extraction lives in vta-vault
+  because it reads mdoc internals; the matching lives in vta-service because that
+  is the layer that can see the keyspace. vta-vault does not depend on vta-keys,
+  and this keeps it that way.
+
+  find_key_by_public_multibase is a linear scan: the keyspace is indexed by key
+  id, not by public key, and a reverse index for one receive-path caller is not
+  worth the write amplification on every mint. It takes no AuthClaims because it
+  answers a factual question, not an authorization one — the caller gates on the
+  returned record's context_id, because binding a credential to a key in a
+  context the caller cannot act in would be a cross-tenant escape.
+
+- **vta-service**: Accept ISO mdoc over the credential-receive Trust Task ([#989](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/989))
+
+Everything shipped for mdoc so far — the format identity ([#984](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/984)), receive-side
+  verification ([#986](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/986)) and the IACA trust anchors ([#987](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/987)) — was reachable only
+  through the library. handle_receive was hardcoded to the Data-Integrity path:
+  a JSON credential, an issuer DID resolved through the DID cache, no format
+  parameter. An mdoc could not arrive at the VTA at all. This connects it.
+
+  ReceiveBody gains an optional format tag and a credentialBase64 carrier, since
+  an mdoc is CBOR and cannot travel as JSON. Absent format still means
+  Data-Integrity, which is the shape every existing client sends, so a deployed
+  wallet is unaffected — pinned by a test that parses a pre-existing body and
+  asserts it still routes to the DI path. Exactly one of credential or
+  credentialBase64 must be present; both, or neither, is a malformedRequest.
+
+  The mdoc arm is where the two credential families genuinely diverge. A DI
+  credential names its issuer as a DID and the key is resolved through the cache;
+  an mdoc names its issuer as an X.509 Document Signer, so the credential is
+  decoded first to read its x5chain and the key comes from the configured IACA
+  anchors instead. That asymmetry is the whole reason the anchors exist.
+
+  AppState carries the parsed anchors, built once in build_app_state from
+  [vault] mdoc_iaca_trust_anchors. A malformed certificate fails the boot rather
+  than surfacing as a puzzling rejection on the first mdoc that arrives. Empty is
+  legal and means this VTA accepts no mdoc issuers; the resolver fails closed on
+  it, so wiring the wire surface does not by itself make any VTA start trusting
+  mdocs — an operator still has to configure anchors deliberately.
+
+  No schema change: vault/credentials/receive/0.1 is in UNSPECCED_DISPATCHED_URIS,
+  so there is no published payload schema to update and dispatch validation is a
+  no-op for it either way.
+
+  Note for a follow-up, not changed here: test_support.rs constructs an AppState
+  literal directly, so build_app_state is not in practice the single constructor
+  its doc comment claims. Adding a field has to be done in both places.
+
+
+
 ## [0.15.4](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-service-v0.15.3...vta-service-v0.15.4) — 2026-08-16
 
 

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.15.4"
+version = "0.16.0"
 edition.workspace = true
 # Published for one reason: `openvtc-core` dev-depends on it for
 # `test_support::MockVta`, the in-process VTA its end-to-end tests run against.
@@ -139,7 +139,7 @@ path = "src/main.rs"
 required-features = ["cli-synthesis"]
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.11", features = ["encryption", "passkey", "openapi"] }
+vti-common = { path = "../vti-common", version = "0.12", features = ["encryption", "passkey", "openapi"] }
 # Seed-store backends + `create_seed_store` factory + `SecretsConfig` (lifted
 # from this crate into a shared crate so external integrations can reuse them).
 # Per-backend features are activated by this crate's matching features below.
@@ -160,7 +160,7 @@ vta-keys = { path = "../vta-keys", version = "0.2" }
 # Holder credential vault (storage/query/receive/present/status), extracted to
 # its own crate and re-exported as `crate::vault`. Feature edges: this crate's
 # `bbs` / `webvh` features enable `vta-vault/bbs` / `vta-vault/webvh`.
-vta-vault = { path = "../vta-vault", version = "0.1" }
+vta-vault = { path = "../vta-vault", version = "0.2" }
 # Background TTL sweepers (acl/consent/vault), extracted and re-exported as
 # crate::{acl_sweeper,consent_sweeper,vault_sweeper}.
 vta-sweepers = { path = "../vta-sweepers", version = "0.1" }

--- a/vta-support/CHANGELOG.md
+++ b/vta-support/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.2.6](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-support-v0.2.5...vta-support-v0.2.6) — 2026-08-16
+
+
 ## [0.2.5](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-support-v0.2.4...vta-support-v0.2.5) — 2026-08-16
 
 

--- a/vta-support/Cargo.toml
+++ b/vta-support/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-support"
 description = "Shared mid-layer VTA services — trust-context storage, the sealed-transfer seal helper, and the sealed-bootstrap nonce store"
 readme = "README.md"
-version = "0.2.5"
+version = "0.2.6"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -29,7 +29,7 @@ vta-config = { path = "../vta-config", version = "0.3" }
 # verifies each crate in isolation, where nothing enables it, so the method
 # does not exist and the tarball fails to compile. That is what broke the
 # publish run for 0.2.0.
-vti-common = { path = "../vti-common", version = "0.11", features = ["encryption"] }
+vti-common = { path = "../vti-common", version = "0.12", features = ["encryption"] }
 vta-sdk = { path = "../vta-sdk", version = "0.24", features = ["sealed-transfer"] }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/vta-sweepers/CHANGELOG.md
+++ b/vta-sweepers/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.1.2](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-sweepers-v0.1.1...vta-sweepers-v0.1.2) — 2026-08-16
+
+
 ## [0.1.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-sweepers-v0.1.0...vta-sweepers-v0.1.1) — 2026-08-13
 
 

--- a/vta-sweepers/Cargo.toml
+++ b/vta-sweepers/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sweepers"
 description = "Background TTL sweepers for the VTA's core keyspaces — ACL grant expiry, pending-consent expiry, and soft-deleted-vault purge"
 readme = "README.md"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -20,10 +20,10 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.11" }
+vti-common = { path = "../vti-common", version = "0.12" }
 vta-audit = { path = "../vta-audit", version = "0.1" }
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.1" }
-vta-vault = { path = "../vta-vault", version = "0.1" }
+vta-vault = { path = "../vta-vault", version = "0.2" }
 tracing = { workspace = true }
 chrono = { workspace = true }
 serde_json = { workspace = true }

--- a/vta-tee/CHANGELOG.md
+++ b/vta-tee/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.1.8](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-tee-v0.1.7...vta-tee-v0.1.8) — 2026-08-16
+
+
 ## [0.1.7](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-tee-v0.1.6...vta-tee-v0.1.7) — 2026-08-14
 
 

--- a/vta-tee/Cargo.toml
+++ b/vta-tee/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-tee"
 description = "VTA TEE bootstrap — Nitro/SEV-SNP attestation providers, KMS attest/decrypt + storage-key derivation, the anchor MAC, and first-boot DID autogen"
 readme = "README.md"
-version = "0.1.7"
+version = "0.1.8"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -27,7 +27,7 @@ repository.workspace = true
 tenant-overlay = ["dep:tokio-vsock"]
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.11", features = ["encryption", "openapi"] }
+vti-common = { path = "../vti-common", version = "0.12", features = ["encryption", "openapi"] }
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.1" }
 vta-config = { path = "../vta-config", version = "0.3", features = ["tee"] }
 vta-keys = { path = "../vta-keys", version = "0.2" }

--- a/vta-vault/CHANGELOG.md
+++ b/vta-vault/CHANGELOG.md
@@ -2,6 +2,83 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.2.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-vault-v0.1.4...vta-vault-v0.2.0) — 2026-08-16
+
+
+### Added
+
+- **vta-vault**: Bind an mdoc to the VTA key that can present it ([#990](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/990))
+
+An mdoc's holder binding is a key, not a DID: the MSO carries a deviceKey, and
+  only its private half can sign DeviceAuth. Nothing in the stored envelope said
+  which VTA key that was, so a received mdoc could be stored and then turn out to
+  be unpresentable — with the failure surfacing much later, at presentation, and
+  nothing pointing at the cause.
+
+  Receive now resolves that binding and refuses the credential if this VTA does
+  not hold the key. Storing a credential you can never present is a trap, and the
+  right moment to find out is the moment it arrives.
+
+  mdoc_device_key_sec1 extracts the MSO deviceKey as a compressed SEC1 point —
+  the same encoding the VTA stores its own P-256 public keys in — so the caller
+  can compare without re-deriving either side. Extraction lives in vta-vault
+  because it reads mdoc internals; the matching lives in vta-service because that
+  is the layer that can see the keyspace. vta-vault does not depend on vta-keys,
+  and this keeps it that way.
+
+  find_key_by_public_multibase is a linear scan: the keyspace is indexed by key
+  id, not by public key, and a reverse index for one receive-path caller is not
+  worth the write amplification on every mint. It takes no AuthClaims because it
+  answers a factual question, not an authorization one — the caller gates on the
+  returned record's context_id, because binding a credential to a key in a
+  context the caller cannot act in would be a cross-tenant escape.
+
+- **vta-vault**: Resolve mdoc issuers against configured IACA trust anchors ([#987](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/987))
+
+Answers the one question mdoc asks differently from every other credential
+  format here: which key do I trust to have issued this?
+
+  Every other format names its issuer as a DID, so receiving resolves that DID
+  and verifies against whatever comes back — the VTA holds no list and there is
+  no operator step. An mdoc has no issuer DID. It carries an X.509 chain in the
+  issuerAuth COSE unprotected header (x5chain, label 33): a Document Signer
+  certificate issued by an IACA. Verifying it means the VTA must already hold the
+  roots it accepts, which is a trust store, not a lookup.
+
+  The decision taken is a configured set of IACA root certificates — how
+  production EUDI verifiers work, and what Member State trusted lists (ETSI TS
+  119 612) distribute. It keeps X.509 at the boundary: nothing below this module
+  learns certificates exist, and receive_mdoc still takes a plain resolved key.
+
+  Validation is scoped to what ISO 18013-5 Annex B actually specifies — a
+  two-level IACA to Document Signer hierarchy, so no general RFC 5280 path
+  building. Checks the leaf issuer DN against a configured anchor subject, the
+  leaf signature against that anchor key, the leaf validity window, that the
+  anchor is a CA (a DS certificate configured by mistake cannot become a root),
+  and keyUsage.digitalSignature where present.
+
+  Deliberately not checked, both documented in the module: revocation (CRL/OCSP
+  needs egress and an unavailability policy — its own decision), and the ISO mDL
+  EKU 1.0.18013.5.1.2, which the EUDI PID profile does not share, so enforcing it
+  would reject valid PID credentials as what looks exactly like a trust failure.
+
+  Fails closed. An empty anchor set is an error, not permissive — mdoc is the one
+  format whose issuer is not a resolvable DID, so there is no safe default. The
+  config field defaults to empty, so an existing config still loads and an upgrade
+  neither breaks a deployment nor silently starts trusting mdocs.
+
+  Anchors are inline PEM in [vault] rather than file paths: an enclave has no
+  convenient filesystem, and inline values are covered by the effective-config
+  digest boot attestation commits to, so a verifier can see which issuers a TEE
+  VTA was trusting when it was attested.
+
+  x509-parser takes the verify-aws feature rather than the default verify, which
+  pulls ring — ring currently only reaches this workspace through a
+  dev-dependency, while aws-lc-rs is already a real dependency. Same crypto, no
+  new production tree.
+
+
+
 ## [0.1.4](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-vault-v0.1.3...vta-vault-v0.1.4) — 2026-08-16
 
 

--- a/vta-vault/Cargo.toml
+++ b/vta-vault/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-vault"
 description = "VTA holder credential vault — storage, query, receive/verify, present, and status refresh for credentials a holder stores on a VTA"
 readme = "README.md"
-version = "0.1.4"
+version = "0.2.0"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -33,7 +33,7 @@ webvh = ["dep:reqwest", "vta-sdk/client"]
 
 [dependencies]
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.1" }
-vti-common = { path = "../vti-common", version = "0.11", features = ["encryption"] }
+vti-common = { path = "../vti-common", version = "0.12", features = ["encryption"] }
 vta-sdk = { path = "../vta-sdk", version = "0.24", features = ["didcomm", "sealed-transfer"] }
 affinidi-crypto = { workspace = true }
 affinidi-secrets-resolver = { workspace = true }

--- a/vta-webvh/CHANGELOG.md
+++ b/vta-webvh/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.1.8](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-webvh-v0.1.7...vta-webvh-v0.1.8) — 2026-08-16
+
+
 ## [0.1.7](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-webvh-v0.1.6...vta-webvh-v0.1.7) — 2026-08-16
 
 

--- a/vta-webvh/Cargo.toml
+++ b/vta-webvh/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-webvh"
 description = "WebVH hosting infrastructure for the VTA — the DID-record store, the HTTP client to a did:webvh hosting server, and its DID-auth handshake"
 readme = "README.md"
-version = "0.1.7"
+version = "0.1.8"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -21,7 +21,7 @@ repository.workspace = true
 
 [dependencies]
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.1" }
-vti-common = { path = "../vti-common", version = "0.11" }
+vti-common = { path = "../vti-common", version = "0.12" }
 vta-sdk = { path = "../vta-sdk", version = "0.24" }
 affinidi-tdk = { workspace = true }
 serde = { workspace = true }

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -117,7 +117,7 @@ name = "vtc"
 path = "src/main.rs"
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.11", features = [
+vti-common = { path = "../vti-common", version = "0.12", features = [
   "passkey",
   # `setup` gates the shared dialoguer-driven secrets-prompt helper
   # the wizard calls into.

--- a/vti-common/CHANGELOG.md
+++ b/vti-common/CHANGELOG.md
@@ -2,6 +2,57 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.12.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-common-v0.11.41...vti-common-v0.12.0) — 2026-08-16
+
+
+### Added
+
+- **vta-vault**: Resolve mdoc issuers against configured IACA trust anchors ([#987](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/987))
+
+Answers the one question mdoc asks differently from every other credential
+  format here: which key do I trust to have issued this?
+
+  Every other format names its issuer as a DID, so receiving resolves that DID
+  and verifies against whatever comes back — the VTA holds no list and there is
+  no operator step. An mdoc has no issuer DID. It carries an X.509 chain in the
+  issuerAuth COSE unprotected header (x5chain, label 33): a Document Signer
+  certificate issued by an IACA. Verifying it means the VTA must already hold the
+  roots it accepts, which is a trust store, not a lookup.
+
+  The decision taken is a configured set of IACA root certificates — how
+  production EUDI verifiers work, and what Member State trusted lists (ETSI TS
+  119 612) distribute. It keeps X.509 at the boundary: nothing below this module
+  learns certificates exist, and receive_mdoc still takes a plain resolved key.
+
+  Validation is scoped to what ISO 18013-5 Annex B actually specifies — a
+  two-level IACA to Document Signer hierarchy, so no general RFC 5280 path
+  building. Checks the leaf issuer DN against a configured anchor subject, the
+  leaf signature against that anchor key, the leaf validity window, that the
+  anchor is a CA (a DS certificate configured by mistake cannot become a root),
+  and keyUsage.digitalSignature where present.
+
+  Deliberately not checked, both documented in the module: revocation (CRL/OCSP
+  needs egress and an unavailability policy — its own decision), and the ISO mDL
+  EKU 1.0.18013.5.1.2, which the EUDI PID profile does not share, so enforcing it
+  would reject valid PID credentials as what looks exactly like a trust failure.
+
+  Fails closed. An empty anchor set is an error, not permissive — mdoc is the one
+  format whose issuer is not a resolvable DID, so there is no safe default. The
+  config field defaults to empty, so an existing config still loads and an upgrade
+  neither breaks a deployment nor silently starts trusting mdocs.
+
+  Anchors are inline PEM in [vault] rather than file paths: an enclave has no
+  convenient filesystem, and inline values are covered by the effective-config
+  digest boot attestation commits to, so a verifier can see which issuers a TEE
+  VTA was trusting when it was attested.
+
+  x509-parser takes the verify-aws feature rather than the default verify, which
+  pulls ring — ring currently only reaches this workspace through a
+  dev-dependency, while aws-lc-rs is already a real dependency. Same crypto, no
+  new production tree.
+
+
+
 ## [0.11.41](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-common-v0.11.40...vti-common-v0.11.41) — 2026-08-16
 
 

--- a/vti-common/Cargo.toml
+++ b/vti-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-common"
 description = "Shared server-side infrastructure for VTA and VTC services"
 readme = "README.md"
-version = "0.11.41"
+version = "0.12.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vti-secrets/CHANGELOG.md
+++ b/vti-secrets/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.1.13](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-secrets-v0.1.12...vti-secrets-v0.1.13) — 2026-08-16
+
+
 ## [0.1.12](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-secrets-v0.1.11...vti-secrets-v0.1.12) — 2026-08-16
 
 

--- a/vti-secrets/Cargo.toml
+++ b/vti-secrets/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-secrets"
 description = "Pluggable secret-store backends + integration onboarding flow for Verifiable Trust Infrastructure"
 readme = "README.md"
-version = "0.1.12"
+version = "0.1.13"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -47,7 +47,7 @@ onboarding = [
 ]
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.11" }
+vti-common = { path = "../vti-common", version = "0.12" }
 serde = { workspace = true }
 hex = { workspace = true }
 tracing = { workspace = true }


### PR DESCRIPTION



## 🤖 New release

* `vti-common`: 0.11.41 -> 0.12.0 (⚠ API breaking changes)
* `vta-vault`: 0.1.4 -> 0.2.0
* `vta-service`: 0.15.4 -> 0.16.0 (⚠ API breaking changes)
* `vta-cli-common`: 0.10.32 -> 0.10.33
* `vta-audit`: 0.1.4 -> 0.1.5
* `vti-secrets`: 0.1.12 -> 0.1.13
* `vta-config`: 0.3.6 -> 0.3.7
* `vta-keyspaces`: 0.1.2 -> 0.1.3
* `vta-keys`: 0.2.3 -> 0.2.4
* `vta-support`: 0.2.5 -> 0.2.6
* `vta-backup`: 0.1.8 -> 0.1.9
* `vta-policy`: 0.2.5 -> 0.2.6
* `vta-sweepers`: 0.1.1 -> 0.1.2
* `vta-tee`: 0.1.7 -> 0.1.8
* `vta-webvh`: 0.1.7 -> 0.1.8

### ⚠ `vti-common` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field VaultConfig.mdoc_iaca_trust_anchors in /tmp/.tmp20KozW/verifiable-trust-infrastructure/vti-common/src/config.rs:178
```

### ⚠ `vta-service` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field AppState.mdoc_trust in /tmp/.tmp20KozW/verifiable-trust-infrastructure/vta-service/src/server.rs:118
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `vti-common`

<blockquote>

## [0.12.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-common-v0.11.41...vti-common-v0.12.0) — 2026-08-16

### Added

- **vta-vault**: Resolve mdoc issuers against configured IACA trust anchors ([#987](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/987))

Answers the one question mdoc asks differently from every other credential
  format here: which key do I trust to have issued this?

  Every other format names its issuer as a DID, so receiving resolves that DID
  and verifies against whatever comes back — the VTA holds no list and there is
  no operator step. An mdoc has no issuer DID. It carries an X.509 chain in the
  issuerAuth COSE unprotected header (x5chain, label 33): a Document Signer
  certificate issued by an IACA. Verifying it means the VTA must already hold the
  roots it accepts, which is a trust store, not a lookup.

  The decision taken is a configured set of IACA root certificates — how
  production EUDI verifiers work, and what Member State trusted lists (ETSI TS
  119 612) distribute. It keeps X.509 at the boundary: nothing below this module
  learns certificates exist, and receive_mdoc still takes a plain resolved key.

  Validation is scoped to what ISO 18013-5 Annex B actually specifies — a
  two-level IACA to Document Signer hierarchy, so no general RFC 5280 path
  building. Checks the leaf issuer DN against a configured anchor subject, the
  leaf signature against that anchor key, the leaf validity window, that the
  anchor is a CA (a DS certificate configured by mistake cannot become a root),
  and keyUsage.digitalSignature where present.

  Deliberately not checked, both documented in the module: revocation (CRL/OCSP
  needs egress and an unavailability policy — its own decision), and the ISO mDL
  EKU 1.0.18013.5.1.2, which the EUDI PID profile does not share, so enforcing it
  would reject valid PID credentials as what looks exactly like a trust failure.

  Fails closed. An empty anchor set is an error, not permissive — mdoc is the one
  format whose issuer is not a resolvable DID, so there is no safe default. The
  config field defaults to empty, so an existing config still loads and an upgrade
  neither breaks a deployment nor silently starts trusting mdocs.

  Anchors are inline PEM in [vault] rather than file paths: an enclave has no
  convenient filesystem, and inline values are covered by the effective-config
  digest boot attestation commits to, so a verifier can see which issuers a TEE
  VTA was trusting when it was attested.

  x509-parser takes the verify-aws feature rather than the default verify, which
  pulls ring — ring currently only reaches this workspace through a
  dev-dependency, while aws-lc-rs is already a real dependency. Same crypto, no
  new production tree.
</blockquote>

## `vta-vault`

<blockquote>

## [0.2.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-vault-v0.1.4...vta-vault-v0.2.0) — 2026-08-16

### Added

- **vta-vault**: Bind an mdoc to the VTA key that can present it ([#990](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/990))

An mdoc's holder binding is a key, not a DID: the MSO carries a deviceKey, and
  only its private half can sign DeviceAuth. Nothing in the stored envelope said
  which VTA key that was, so a received mdoc could be stored and then turn out to
  be unpresentable — with the failure surfacing much later, at presentation, and
  nothing pointing at the cause.

  Receive now resolves that binding and refuses the credential if this VTA does
  not hold the key. Storing a credential you can never present is a trap, and the
  right moment to find out is the moment it arrives.

  mdoc_device_key_sec1 extracts the MSO deviceKey as a compressed SEC1 point —
  the same encoding the VTA stores its own P-256 public keys in — so the caller
  can compare without re-deriving either side. Extraction lives in vta-vault
  because it reads mdoc internals; the matching lives in vta-service because that
  is the layer that can see the keyspace. vta-vault does not depend on vta-keys,
  and this keeps it that way.

  find_key_by_public_multibase is a linear scan: the keyspace is indexed by key
  id, not by public key, and a reverse index for one receive-path caller is not
  worth the write amplification on every mint. It takes no AuthClaims because it
  answers a factual question, not an authorization one — the caller gates on the
  returned record's context_id, because binding a credential to a key in a
  context the caller cannot act in would be a cross-tenant escape.

- **vta-vault**: Resolve mdoc issuers against configured IACA trust anchors ([#987](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/987))

Answers the one question mdoc asks differently from every other credential
  format here: which key do I trust to have issued this?

  Every other format names its issuer as a DID, so receiving resolves that DID
  and verifies against whatever comes back — the VTA holds no list and there is
  no operator step. An mdoc has no issuer DID. It carries an X.509 chain in the
  issuerAuth COSE unprotected header (x5chain, label 33): a Document Signer
  certificate issued by an IACA. Verifying it means the VTA must already hold the
  roots it accepts, which is a trust store, not a lookup.

  The decision taken is a configured set of IACA root certificates — how
  production EUDI verifiers work, and what Member State trusted lists (ETSI TS
  119 612) distribute. It keeps X.509 at the boundary: nothing below this module
  learns certificates exist, and receive_mdoc still takes a plain resolved key.

  Validation is scoped to what ISO 18013-5 Annex B actually specifies — a
  two-level IACA to Document Signer hierarchy, so no general RFC 5280 path
  building. Checks the leaf issuer DN against a configured anchor subject, the
  leaf signature against that anchor key, the leaf validity window, that the
  anchor is a CA (a DS certificate configured by mistake cannot become a root),
  and keyUsage.digitalSignature where present.

  Deliberately not checked, both documented in the module: revocation (CRL/OCSP
  needs egress and an unavailability policy — its own decision), and the ISO mDL
  EKU 1.0.18013.5.1.2, which the EUDI PID profile does not share, so enforcing it
  would reject valid PID credentials as what looks exactly like a trust failure.

  Fails closed. An empty anchor set is an error, not permissive — mdoc is the one
  format whose issuer is not a resolvable DID, so there is no safe default. The
  config field defaults to empty, so an existing config still loads and an upgrade
  neither breaks a deployment nor silently starts trusting mdocs.

  Anchors are inline PEM in [vault] rather than file paths: an enclave has no
  convenient filesystem, and inline values are covered by the effective-config
  digest boot attestation commits to, so a verifier can see which issuers a TEE
  VTA was trusting when it was attested.

  x509-parser takes the verify-aws feature rather than the default verify, which
  pulls ring — ring currently only reaches this workspace through a
  dev-dependency, while aws-lc-rs is already a real dependency. Same crypto, no
  new production tree.
</blockquote>

## `vta-service`

<blockquote>

## [0.16.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-service-v0.15.4...vta-service-v0.16.0) — 2026-08-16

### Added

- **vta-vault**: Bind an mdoc to the VTA key that can present it ([#990](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/990))

An mdoc's holder binding is a key, not a DID: the MSO carries a deviceKey, and
  only its private half can sign DeviceAuth. Nothing in the stored envelope said
  which VTA key that was, so a received mdoc could be stored and then turn out to
  be unpresentable — with the failure surfacing much later, at presentation, and
  nothing pointing at the cause.

  Receive now resolves that binding and refuses the credential if this VTA does
  not hold the key. Storing a credential you can never present is a trap, and the
  right moment to find out is the moment it arrives.

  mdoc_device_key_sec1 extracts the MSO deviceKey as a compressed SEC1 point —
  the same encoding the VTA stores its own P-256 public keys in — so the caller
  can compare without re-deriving either side. Extraction lives in vta-vault
  because it reads mdoc internals; the matching lives in vta-service because that
  is the layer that can see the keyspace. vta-vault does not depend on vta-keys,
  and this keeps it that way.

  find_key_by_public_multibase is a linear scan: the keyspace is indexed by key
  id, not by public key, and a reverse index for one receive-path caller is not
  worth the write amplification on every mint. It takes no AuthClaims because it
  answers a factual question, not an authorization one — the caller gates on the
  returned record's context_id, because binding a credential to a key in a
  context the caller cannot act in would be a cross-tenant escape.

- **vta-service**: Accept ISO mdoc over the credential-receive Trust Task ([#989](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/989))

Everything shipped for mdoc so far — the format identity ([#984](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/984)), receive-side
  verification ([#986](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/986)) and the IACA trust anchors ([#987](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/987)) — was reachable only
  through the library. handle_receive was hardcoded to the Data-Integrity path:
  a JSON credential, an issuer DID resolved through the DID cache, no format
  parameter. An mdoc could not arrive at the VTA at all. This connects it.

  ReceiveBody gains an optional format tag and a credentialBase64 carrier, since
  an mdoc is CBOR and cannot travel as JSON. Absent format still means
  Data-Integrity, which is the shape every existing client sends, so a deployed
  wallet is unaffected — pinned by a test that parses a pre-existing body and
  asserts it still routes to the DI path. Exactly one of credential or
  credentialBase64 must be present; both, or neither, is a malformedRequest.

  The mdoc arm is where the two credential families genuinely diverge. A DI
  credential names its issuer as a DID and the key is resolved through the cache;
  an mdoc names its issuer as an X.509 Document Signer, so the credential is
  decoded first to read its x5chain and the key comes from the configured IACA
  anchors instead. That asymmetry is the whole reason the anchors exist.

  AppState carries the parsed anchors, built once in build_app_state from
  [vault] mdoc_iaca_trust_anchors. A malformed certificate fails the boot rather
  than surfacing as a puzzling rejection on the first mdoc that arrives. Empty is
  legal and means this VTA accepts no mdoc issuers; the resolver fails closed on
  it, so wiring the wire surface does not by itself make any VTA start trusting
  mdocs — an operator still has to configure anchors deliberately.

  No schema change: vault/credentials/receive/0.1 is in UNSPECCED_DISPATCHED_URIS,
  so there is no published payload schema to update and dispatch validation is a
  no-op for it either way.

  Note for a follow-up, not changed here: test_support.rs constructs an AppState
  literal directly, so build_app_state is not in practice the single constructor
  its doc comment claims. Adding a field has to be done in both places.
</blockquote>














</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).