### PR TITLE
feat(vta-service)!: accept ISO mdoc over the credential-receive Trust Task

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9481,6 +9481,7 @@ dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
  "affinidi-did-resolver-cache-sdk",
+ "affinidi-mdoc",
  "affinidi-messaging-core",
  "affinidi-messaging-delivery",
  "affinidi-messaging-didcomm",

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -223,6 +223,9 @@ affinidi-bbs = { workspace = true, optional = true }
 # DCQL matcher — the holder runs a verifier's DCQL query over held credentials
 # (`credential-exchange/query`, task 3.5). Same crate vta-sdk's QueryBody uses.
 affinidi-openid4vp = { workspace = true }
+# ISO 18013-5 mdoc — the receive handler decodes an inbound IssuerSigned to read
+# its x5chain before asking the trust store which issuer key to demand.
+affinidi-mdoc = { workspace = true }
 # OID4VCI offer/request types + wallet builders — the holder `offer → request`
 # leg (task 3.2). Same crate vta-sdk's OfferBody / RequestBody use.
 affinidi-openid4vci = { workspace = true }

--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -109,6 +109,13 @@ pub struct AppState {
     pub backup_blob_dir: std::path::PathBuf,
     #[cfg(feature = "webvh")]
     pub webvh_ks: KeyspaceHandle,
+    /// IACA roots this VTA accepts as ISO 18013-5 mdoc issuers, parsed once at
+    /// boot from `[vault] mdoc_iaca_trust_anchors`.
+    ///
+    /// Empty unless configured, and the resolver fails closed on empty — mdoc
+    /// is the one credential format whose issuer is not a resolvable DID, so
+    /// there is no safe default to fall back to.
+    pub mdoc_trust: Arc<vta_vault::mdoc_trust::IacaTrustAnchors>,
     /// In-flight WebAuthn registration state for the
     /// passkey-as-verificationMethod enrolment ceremony. Holds
     /// `PasskeyRegistration` keyed by ceremony id; consumed (taken)
@@ -271,6 +278,14 @@ pub async fn build_app_state(
     restart_tx: watch::Sender<bool>,
     parts: AppStateParts,
 ) -> Result<AppState, AppError> {
+    // Parse the configured IACA roots once, here, so a malformed certificate
+    // fails the boot rather than surfacing as a puzzling rejection on the first
+    // mdoc that arrives. Empty is legal and means "this VTA accepts no mdoc
+    // issuers" — the resolver fails closed on it.
+    let mdoc_trust = Arc::new(vta_vault::mdoc_trust::IacaTrustAnchors::from_pem(
+        &config.vault.mdoc_iaca_trust_anchors,
+    )?);
+
     let apply_encryption = |ks: KeyspaceHandle| -> KeyspaceHandle {
         if let Some(key) = storage_encryption_key {
             ks.with_encryption(key)
@@ -394,6 +409,7 @@ pub async fn build_app_state(
         webvh_auth_locks: crate::operations::did_webvh::WebvhAuthLocks::new(),
         telemetry,
         wrapping_cache: crate::keys::wrapping::WrappingKeyCache::new(),
+        mdoc_trust,
         config: Arc::new(RwLock::new(config)),
         seed_store,
         did_resolver: auth.did_resolver.clone(),

--- a/vta-service/src/test_support.rs
+++ b/vta-service/src/test_support.rs
@@ -1008,6 +1008,13 @@ pub async fn build_test_app_with(opts: TestAppOptions) -> (axum::Router, TestApp
 
     let policy_ks = store.keyspace(crate::keyspaces::POLICY).unwrap();
     let state = crate::server::AppState {
+        // Empty by default: a test VTA trusts no mdoc issuer until one is
+        // configured, matching the fail-closed production default. A test that
+        // needs mdoc receive builds its own anchors and swaps this out.
+        mdoc_trust: std::sync::Arc::new(
+            vta_vault::mdoc_trust::IacaTrustAnchors::from_pem(&[])
+                .expect("an empty anchor set always parses"),
+        ),
         keys_ks: keys_ks.clone(),
         sessions_ks: sessions_ks.clone(),
         acl_ks: acl_ks.clone(),

--- a/vta-service/src/trust_tasks/cred_vault.rs
+++ b/vta-service/src/trust_tasks/cred_vault.rs
@@ -17,6 +17,8 @@
 //!   presentation. Not-found is conflated with permission-denied to deny
 //!   enumeration.
 
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -65,7 +67,23 @@ fn require_cap(
 struct ReceiveBody {
     /// The credential to store — a Data-Integrity W3C VC (object form, with its
     /// own `proof`).
-    credential: Value,
+    ///
+    /// Optional only so a binary format can arrive via [`Self::credential_base64`]
+    /// instead. Exactly one of the two must be present; a body carrying neither,
+    /// or both, is rejected. Existing clients send this field alone and are
+    /// unaffected.
+    #[serde(default)]
+    credential: Option<Value>,
+    /// A binary credential, base64url-no-pad. Required when `format` names a
+    /// binary format (today: `mso_mdoc`, CBOR `IssuerSigned`), which cannot be
+    /// carried as JSON.
+    #[serde(default)]
+    credential_base64: Option<String>,
+    /// Wire format tag. Absent means a Data-Integrity W3C VC — the shape every
+    /// existing client sends — so omitting it keeps the current behaviour
+    /// exactly.
+    #[serde(default)]
+    format: Option<String>,
     /// Optional explicit storage id; defaults to the VC's top-level `id`, else a
     /// fresh `urn:uuid`.
     #[serde(default)]
@@ -122,8 +140,6 @@ pub(super) async fn handle_receive(
         Err(resp) => return resp,
     };
 
-    let id = resolve_storage_id(req.id, &req.credential);
-
     // Resolve the custody context (which context owns the credential, governing
     // its disclosure via ContextPolicy).
     let custody_context = match resolve_custody_context(auth, req.context_id) {
@@ -131,45 +147,150 @@ pub(super) async fn handle_receive(
         Err(e) => return app_error_to_reject(&doc, e),
     };
 
-    // Resolve the issuer's signing key from the credential's DID (did:key
-    // locally, did:webvh / did:web via the cache) — the data plane verifies the
-    // proof against it.
-    let issuer_pub = match di_verify::resolve_di_issuer_key(
-        state.did_resolver.as_ref(),
-        &req.credential,
-    )
-    .await
-    {
-        Ok(k) => k,
-        Err(e) => return app_error_to_reject(&doc, e),
-    };
+    let now = Utc::now();
+    let provenance = Some("vault/credentials/receive/0.1".to_string());
 
-    let body = match serde_json::to_vec(&req.credential) {
-        Ok(b) => b,
-        Err(e) => {
+    // Two wire shapes, one per credential family. The format tag decides;
+    // absent means Data-Integrity, which is what every existing client sends.
+    let mut stored = match req.format.as_deref() {
+        None | Some("ldp_vc") => {
+            let Some(credential) = req.credential else {
+                return reject_with(
+                    &doc,
+                    RejectReason::MalformedRequest {
+                        reason: "a Data-Integrity credential must be supplied as `credential`"
+                            .to_string(),
+                    },
+                );
+            };
+            if req.credential_base64.is_some() {
+                return reject_with(
+                    &doc,
+                    RejectReason::MalformedRequest {
+                        reason: "supply exactly one of `credential` or `credentialBase64`"
+                            .to_string(),
+                    },
+                );
+            }
+
+            let id = resolve_storage_id(req.id, &credential);
+
+            // Resolve the issuer's signing key from the credential's DID
+            // (did:key locally, did:webvh / did:web via the cache) — the data
+            // plane verifies the proof against it.
+            let issuer_pub =
+                match di_verify::resolve_di_issuer_key(state.did_resolver.as_ref(), &credential)
+                    .await
+                {
+                    Ok(k) => k,
+                    Err(e) => return app_error_to_reject(&doc, e),
+                };
+
+            let body = match serde_json::to_vec(&credential) {
+                Ok(b) => b,
+                Err(e) => {
+                    return reject_with(
+                        &doc,
+                        RejectReason::MalformedRequest {
+                            reason: format!("credential serialise: {e}"),
+                        },
+                    );
+                }
+            };
+
+            match receive::receive_di_vc(&state.vault_ks, &id, &body, &issuer_pub, provenance, now)
+                .await
+            {
+                Ok(s) => s,
+                Err(e) => return app_error_to_reject(&doc, e),
+            }
+        }
+
+        // ISO 18013-5 mdoc. The issuer is an X.509 Document Signer rather than
+        // a resolvable DID, so the key comes from the configured IACA anchors
+        // instead of the resolver — the one place the two families genuinely
+        // diverge.
+        Some("mso_mdoc") => {
+            let Some(b64) = req.credential_base64 else {
+                return reject_with(
+                    &doc,
+                    RejectReason::MalformedRequest {
+                        reason: "an mdoc must be supplied as `credentialBase64` (CBOR \
+                                 IssuerSigned), not `credential`"
+                            .to_string(),
+                    },
+                );
+            };
+            if req.credential.is_some() {
+                return reject_with(
+                    &doc,
+                    RejectReason::MalformedRequest {
+                        reason: "supply exactly one of `credential` or `credentialBase64`"
+                            .to_string(),
+                    },
+                );
+            }
+
+            let body = match URL_SAFE_NO_PAD.decode(b64.as_bytes()) {
+                Ok(b) => b,
+                Err(e) => {
+                    return reject_with(
+                        &doc,
+                        RejectReason::MalformedRequest {
+                            reason: format!("`credentialBase64` is not base64url-no-pad: {e}"),
+                        },
+                    );
+                }
+            };
+
+            // Parse before trusting: the x5chain has to be read out of the
+            // credential to find out which issuer key to demand.
+            let issued = match affinidi_mdoc::IssuerSigned::from_cbor_bytes(&body) {
+                Ok(i) => i,
+                Err(e) => {
+                    return reject_with(
+                        &doc,
+                        RejectReason::MalformedRequest {
+                            reason: format!("not a decodable mdoc IssuerSigned: {e}"),
+                        },
+                    );
+                }
+            };
+
+            let issuer_pub = match state
+                .mdoc_trust
+                .resolve_issuer_key(&issued.issuer_auth, now)
+            {
+                Ok(k) => k,
+                Err(e) => return app_error_to_reject(&doc, e),
+            };
+
+            // An mdoc has no `id` of its own to fall back on, so an explicit id
+            // or a fresh urn:uuid it is.
+            let id = req
+                .id
+                .unwrap_or_else(|| format!("urn:uuid:{}", Uuid::new_v4()));
+
+            match receive::receive_mdoc(&state.vault_ks, &id, &body, &issuer_pub, provenance, now)
+                .await
+            {
+                Ok(s) => s,
+                Err(e) => return app_error_to_reject(&doc, e),
+            }
+        }
+
+        Some(other) => {
             return reject_with(
                 &doc,
                 RejectReason::MalformedRequest {
-                    reason: format!("credential serialise: {e}"),
+                    reason: format!(
+                        "unsupported credential format `{other}` (expected `ldp_vc` or \
+                         `mso_mdoc`)"
+                    ),
                 },
             );
         }
     };
-
-    let mut stored = match receive::receive_di_vc(
-        &state.vault_ks,
-        &id,
-        &body,
-        &issuer_pub,
-        Some("vault/credentials/receive/0.1".to_string()),
-        Utc::now(),
-    )
-    .await
-    {
-        Ok(s) => s,
-        Err(e) => return app_error_to_reject(&doc, e),
-    };
-
     // Persist the custody binding (receive_di_vc stores it unscoped). Only an
     // extra write when a context was resolved.
     if custody_context.is_some() {
@@ -832,5 +953,68 @@ mod tests {
         let without: ReceiveBody =
             serde_json::from_value(json!({ "credential": {"id": "x"} })).unwrap();
         assert_eq!(without.id, None);
+    }
+}
+
+#[cfg(test)]
+mod receive_body_wire_tests {
+    use super::*;
+    use serde_json::json;
+
+    /// The back-compatibility guarantee this change rests on: a body from an
+    /// existing client — `credential` alone, no `format` — must still
+    /// deserialize and still route to the Data-Integrity path. If this breaks,
+    /// every deployed wallet breaks with it.
+    #[test]
+    fn a_pre_existing_body_still_deserializes_and_stays_on_the_di_path() {
+        let body: ReceiveBody = serde_json::from_value(json!({
+            "credential": {"id": "urn:uuid:abc", "type": ["VerifiableCredential"]},
+            "id": "urn:uuid:abc"
+        }))
+        .expect("an existing client body must still parse");
+
+        assert!(body.credential.is_some());
+        assert!(body.credential_base64.is_none());
+        assert!(
+            body.format.is_none(),
+            "absent format must stay absent — it is what selects the DI path"
+        );
+    }
+
+    /// camelCase on the wire, per R3.1. A snake_case `credential_base64` must
+    /// NOT bind, or a client that guesses wrong silently sends nothing.
+    #[test]
+    fn the_binary_field_is_camel_case_on_the_wire() {
+        let ok: ReceiveBody = serde_json::from_value(json!({
+            "credentialBase64": "AAAA",
+            "format": "mso_mdoc"
+        }))
+        .expect("camelCase parses");
+        assert_eq!(ok.credential_base64.as_deref(), Some("AAAA"));
+
+        let wrong: ReceiveBody = serde_json::from_value(json!({
+            "credential_base64": "AAAA",
+            "format": "mso_mdoc"
+        }))
+        .expect("unknown fields are ignored today");
+        assert!(
+            wrong.credential_base64.is_none(),
+            "snake_case must not bind — the wire contract is camelCase"
+        );
+    }
+
+    /// `mso_mdoc` is the OpenID4VP spelling and the `CredentialFormat` serde
+    /// tag. Pin it here too: this is the third place it has to agree.
+    #[test]
+    fn the_mdoc_format_tag_matches_the_stored_credential_format() {
+        let body: ReceiveBody =
+            serde_json::from_value(json!({"credentialBase64": "AA", "format": "mso_mdoc"}))
+                .unwrap();
+        let stored = serde_json::to_string(&vta_vault::model::CredentialFormat::MsoMdoc).unwrap();
+        assert_eq!(
+            format!("\"{}\"", body.format.unwrap()),
+            stored,
+            "the wire format tag and the stored format tag must be the same token"
+        );
     }
 }


### PR DESCRIPTION
## Why

Everything shipped for mdoc so far — format identity (#984), receive-side
verification (#986), IACA trust anchors (#987) — was reachable **only through
the library**. `handle_receive` was hardcoded to the Data-Integrity path: a JSON
credential, an issuer DID resolved through the cache, no format parameter. An
mdoc could not arrive at the VTA at all.

This connects it. After this, a client can actually send one.

## Wire change

`ReceiveBody` gains two optional fields:

```jsonc
{
  "credential":       { /* ... */ },   // existing — Data-Integrity W3C VC
  "credentialBase64": "…",             // new — CBOR IssuerSigned, base64url-no-pad
  "format":           "mso_mdoc"       // new — absent means Data-Integrity
}
```

**Absent `format` still means Data-Integrity**, which is the shape every existing
client sends, so a deployed wallet is unaffected. That is the guarantee this
change rests on, so it is pinned by a test that parses a pre-existing body and
asserts it still routes to the DI path — not just that it deserializes.

Exactly one of `credential` / `credentialBase64` must be present. Both, or
neither, is a `malformedRequest` rather than a silent preference.

## Where the two families diverge

This is the interesting part, and it is the reason #987 existed:

- a **DI credential** names its issuer as a DID → key resolved through the DID
  cache;
- an **mdoc** names its issuer as an X.509 Document Signer → the credential is
  decoded *first* to read its `x5chain`, and the key comes from the configured
  IACA anchors.

So the mdoc arm parses before it trusts, which is why `from_cbor_bytes` and
`resolve_issuer_key` are separate calls rather than one.

## Fail-closed is preserved

`AppState` carries the parsed anchors, built once in `build_app_state` from
`[vault] mdoc_iaca_trust_anchors`. Two consequences worth stating plainly:

- **A malformed certificate fails the boot**, rather than surfacing as a puzzling
  rejection on the first mdoc that arrives.
- **Empty is legal and means this VTA accepts no mdoc issuers.** The resolver
  fails closed on it, so merging this does **not** by itself make any VTA start
  trusting mdocs — an operator still has to configure anchors deliberately.

## No schema change

`vault/credentials/receive/0.1` is in `UNSPECCED_DISPATCHED_URIS`, so there is no
published payload schema to update, and dispatch validation is a no-op for it
either way. (Worth knowing rather than assuming: adding fields to a URI that
*does* carry a schema would need the schema moved in lockstep.)

## Semver — a declared break

`cargo-semver-checks` reports **`constructible_struct_adds_field`** on
`AppState.mdoc_trust` (`vta-service/src/server.rs:118`): `AppState` is
exhaustively constructible through `vta-service`'s public API, so adding a field
stops an external struct literal compiling. That job is `continue-on-error: true`
by design — a 0.x break is allowed here provided it is **known**, so the release
moves the compatibility field rather than shipping it as a patch. The title
carries `!`; release-plz does the rest.

Worth noting *why* `vta-service` is published at all (RELEASING.md): solely so
`openvtc-core` can dev-depend on `test_support::MockVta`. A consumer going
through that harness is unaffected — the harness constructs the `AppState`
literal internally, and this PR updates it. Only a consumer hand-rolling its own
`AppState` literal would break, which the harness exists to make unnecessary.

## Testing

`cargo test -p vta-service --lib` — 817 passed (3 new). fmt and clippy clean.

The three new tests are contract tests, not behaviour tests:
- a pre-existing body still parses **and stays on the DI path**;
- `credentialBase64` binds camelCase and **snake_case does not** — a client that
  guesses wrong would otherwise silently send nothing;
- the wire `format` tag and `CredentialFormat::MsoMdoc`'s serde tag are the same
  token. That is now the *third* place `mso_mdoc` has to agree (storage, DCQL,
  wire), so it is pinned rather than assumed.

## Noted, not fixed

`test_support.rs` constructs an `AppState` literal directly, so `build_app_state`
is not in practice "the single `AppState` constructor" its doc comment claims —
adding a field has to be done in both places. Left alone here; it is a
pre-existing divergence and not this PR's to resolve.

