### PR TITLE
feat(vta-vault)!: bind an mdoc to the VTA key that can present it

### DIFF
--- a/vta-service/src/operations/keys.rs
+++ b/vta-service/src/operations/keys.rs
@@ -1164,6 +1164,43 @@ pub async fn derive_and_sign_document(
     })
 }
 
+/// Find a VTA key by its multibase public key.
+///
+/// Used by the mdoc receive path to answer "do we hold the private half of this
+/// credential's MSO `deviceKey`?". A linear scan of the key records: the
+/// keyspace is indexed by key id, not by public key, and adding a reverse index
+/// for one caller on the receive path is not worth the write amplification on
+/// every mint.
+///
+/// Deliberately takes no `AuthClaims` — it answers a factual question about the
+/// keyspace, not an authorization one. The **caller** must gate on the returned
+/// record's `context_id`, because binding a credential to a key in a context the
+/// caller cannot act in would be a cross-tenant escape.
+pub async fn find_key_by_public_multibase(
+    keys_ks: &KeyspaceHandle,
+    public_key: &str,
+) -> Result<Option<KeyRecord>, AppError> {
+    for (raw_key, value) in keys_ks.prefix_iter_raw("key:").await? {
+        // Skip (don't abort on) a corrupt row, matching `list_keys`: one bad
+        // record must not make every lookup fail.
+        let record: KeyRecord = match serde_json::from_slice(&value) {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::warn!(
+                    key = %String::from_utf8_lossy(&raw_key),
+                    error = %e,
+                    "skipping undeserializable key record during public-key lookup"
+                );
+                continue;
+            }
+        };
+        if record.public_key == public_key {
+            return Ok(Some(record));
+        }
+    }
+    Ok(None)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/vta-service/src/trust_tasks/cred_vault.rs
+++ b/vta-service/src/trust_tasks/cred_vault.rs
@@ -265,14 +265,63 @@ pub(super) async fn handle_receive(
                 Err(e) => return app_error_to_reject(&doc, e),
             };
 
+            // Holder binding. An mdoc is issued to a specific device key, and
+            // only its private half can sign DeviceAuth — so a credential whose
+            // device key this VTA does not hold could be stored but never
+            // presented. Resolve it now and refuse if we cannot, rather than
+            // letting the failure surface at presentation with nothing pointing
+            // at the cause.
+            let device_point = match vta_vault::mdoc_trust::mdoc_device_key_sec1(&issued.mso) {
+                Ok(p) => p,
+                Err(e) => return app_error_to_reject(&doc, e),
+            };
+            let device_mb =
+                vta_keys::encode_public_multibase(&vta_sdk::keys::KeyType::P256, &device_point);
+            let device_key = match crate::operations::keys::find_key_by_public_multibase(
+                &state.keys_ks,
+                &device_mb,
+            )
+            .await
+            {
+                Ok(Some(k)) => k,
+                Ok(None) => {
+                    return reject_with(
+                        &doc,
+                        RejectReason::MalformedRequest {
+                            reason: "this VTA does not hold the mdoc's MSO deviceKey, so the \
+                                     credential could never be presented with holder binding"
+                                .to_string(),
+                        },
+                    );
+                }
+                Err(e) => return app_error_to_reject(&doc, e),
+            };
+
+            // Context gate on the *key*, not just the credential: binding an
+            // mdoc to a key in a context the caller cannot act in would let one
+            // tenant park a credential on another tenant's key.
+            if let Some(ctx) = device_key.context_id.as_deref()
+                && let Err(e) = auth.require_context(ctx)
+            {
+                return app_error_to_reject(&doc, e);
+            }
+
             // An mdoc has no `id` of its own to fall back on, so an explicit id
             // or a fresh urn:uuid it is.
             let id = req
                 .id
                 .unwrap_or_else(|| format!("urn:uuid:{}", Uuid::new_v4()));
 
-            match receive::receive_mdoc(&state.vault_ks, &id, &body, &issuer_pub, provenance, now)
-                .await
+            match receive::receive_mdoc(
+                &state.vault_ks,
+                &id,
+                &body,
+                &issuer_pub,
+                &device_key.key_id,
+                provenance,
+                now,
+            )
+            .await
             {
                 Ok(s) => s,
                 Err(e) => return app_error_to_reject(&doc, e),

--- a/vta-vault/src/mdoc_trust.rs
+++ b/vta-vault/src/mdoc_trust.rs
@@ -264,6 +264,54 @@ fn extract_leaf_certificate(issuer_auth: &coset::CoseSign1) -> Result<Vec<u8>, A
     }
 }
 
+/// Extract the MSO `deviceKey` as a **compressed SEC1 point** (33 bytes).
+///
+/// This is the holder-binding key an mdoc is issued to: only its private half
+/// can sign `DeviceAuth`, so a VTA that does not hold it can never present the
+/// credential with holder binding. Returning the compressed encoding is
+/// deliberate — it is the form the VTA stores its own P-256 public keys in
+/// (`to_encoded_point(true)` + multicodec `p256-pub`), so the caller can compare
+/// without re-deriving either side.
+///
+/// Lives here rather than in the caller because it reads mdoc internals; the
+/// *matching* stays with the caller, which is the layer that can see the VTA's
+/// keyspace.
+pub fn mdoc_device_key_sec1(
+    mso: &affinidi_mdoc::MobileSecurityObject,
+) -> Result<Vec<u8>, AppError> {
+    let cose =
+        affinidi_mdoc::CoseKey::from_cbor_value(&mso.device_key_info.device_key).map_err(|e| {
+            AppError::Validation(format!("mdoc deviceKey is not a valid COSE_Key: {e}"))
+        })?;
+
+    if !matches!(cose.crv, affinidi_mdoc::Curve::P256) {
+        return Err(AppError::Validation(format!(
+            "mdoc deviceKey must be P-256 (ISO 18013-5 / EUDI); got {:?}",
+            cose.crv
+        )));
+    }
+
+    let x = &cose.x;
+    let y = cose
+        .y
+        .as_ref()
+        .ok_or_else(|| AppError::Validation("mdoc deviceKey has no Y coordinate".to_string()))?;
+    if x.len() != 32 || y.len() != 32 {
+        return Err(AppError::Validation(format!(
+            "mdoc deviceKey coordinates must be 32 bytes each; got x={} y={}",
+            x.len(),
+            y.len()
+        )));
+    }
+
+    // SEC1 compressed: 0x02 for an even Y, 0x03 for odd, then X.
+    let prefix = if y[31] & 1 == 0 { 0x02u8 } else { 0x03u8 };
+    let mut point = Vec::with_capacity(33);
+    point.push(prefix);
+    point.extend_from_slice(x);
+    Ok(point)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/vta-vault/src/model.rs
+++ b/vta-vault/src/model.rs
@@ -25,6 +25,16 @@
 use serde::{Deserialize, Serialize};
 use vti_common::vault::{LifecycleError, VaultStatus, default_active};
 
+/// Reserved [`StoredCredential::tags`] key naming the VTA key whose public half
+/// is the mdoc's MSO `deviceKey` — the key that must sign `DeviceAuth` when this
+/// credential is presented.
+///
+/// Recorded at receive because an mdoc's holder binding is a **key**, not a DID:
+/// there is nothing in the stored envelope that would otherwise say which of the
+/// VTA's keys can speak for it. Without this, a held mdoc could never be
+/// presented with holder binding, and nothing would have noticed at receive time.
+pub const MDOC_DEVICE_KEY_TAG: &str = "mdoc:deviceKeyId";
+
 /// Reserved [`StoredCredential::tags`] key holding the BBS pseudonym holder
 /// link secret (`prover_nym`), base64url-no-pad. See [`StoredCredential::tags`].
 pub const BBS_PROVER_NYM_TAG: &str = "bbs:prover_nym";

--- a/vta-vault/src/receive.rs
+++ b/vta-vault/src/receive.rs
@@ -400,6 +400,15 @@ pub async fn receive_di_vc(
 ///    tampered credential.
 /// 3. **`validityInfo`** — `now` inside `[validFrom, validUntil]`.
 ///
+/// `device_key_id` names the VTA key whose public half is the MSO's
+/// `deviceKey` — the caller resolves it, because matching a COSE_Key against
+/// the VTA's own keyspace is above this layer. It is recorded on the stored
+/// envelope so presentation can find the key that must sign `DeviceAuth`.
+/// Refusing an mdoc whose device key the VTA does not hold is the point: such a
+/// credential could be stored but never presented with holder binding, and the
+/// failure would otherwise surface much later, at presentation, with nothing
+/// pointing at the cause.
+///
 /// ES256 only. ISO 18013-5 and the EUDI profiles mandate it, and it is what the
 /// VTA already has via [`vta_sdk::keys::KeyType::P256`], so no new curve enters
 /// the graph. A credential signed with any other algorithm is refused by name
@@ -409,6 +418,7 @@ pub async fn receive_mdoc(
     id: &str,
     body: &[u8],
     issuer_pub: &[u8],
+    device_key_id: &str,
     source: Provenance,
     now: DateTime<Utc>,
 ) -> Result<StoredCredential, AppError> {
@@ -478,7 +488,12 @@ pub async fn receive_mdoc(
         valid_until: Some(mso.validity_info.valid_until.clone()),
         received_at: now.to_rfc3339(),
         source,
-        tags: std::collections::BTreeMap::new(),
+        // The holder-binding key, recorded now because nothing else in the
+        // stored envelope says which VTA key can speak for this credential.
+        tags: std::collections::BTreeMap::from([(
+            super::model::MDOC_DEVICE_KEY_TAG.to_string(),
+            device_key_id.to_string(),
+        )]),
         body: body.to_vec(),
         lifecycle: vti_common::vault::VaultStatus::Active,
         archived_at: None,
@@ -542,14 +557,15 @@ pub async fn receive(
              + Circom/Groth16 verifier not yet wired)"
                 .to_string(),
         )),
-        CredentialFormat::MsoMdoc => {
-            let pubkey = issuer_pub.ok_or_else(|| {
-                AppError::Validation(
-                    "an mdoc needs a caller-resolved Document Signer key (SEC1 P-256)".to_string(),
-                )
-            })?;
-            receive_mdoc(vault, id, body, pubkey, source, now).await
-        }
+        // Not reachable through this entry point: an mdoc needs a
+        // caller-resolved Document Signer key *and* the VTA key id holding its
+        // MSO deviceKey. This signature can carry the first but not the second,
+        // and guessing the binding is exactly what must not happen.
+        CredentialFormat::MsoMdoc => Err(AppError::Validation(
+            "receive an mdoc through `receive_mdoc`, which takes the device-key binding \
+             this format-agnostic entry point cannot supply"
+                .to_string(),
+        )),
         CredentialFormat::Other(tag) => Err(AppError::Validation(format!(
             "unsupported credential format `{tag}`"
         ))),
@@ -1106,9 +1122,9 @@ mod tests {
             matches!(&zkp_err, AppError::Validation(m) if m.contains("ZKP")),
             "{zkp_err:?}"
         );
-        // mdoc, like DI, needs a caller-resolved issuer key — for mdoc that is
-        // the Document Signer's P-256 key, since issuer trust there is an X.509
-        // chain rather than a resolvable DID.
+        // mdoc is deliberately unreachable through the format-dispatching entry
+        // point: it needs the device-key binding, which this signature cannot
+        // carry. Guessing that binding is exactly what must not happen.
         let mdoc_err = receive(
             &vault,
             "c4",
@@ -1121,8 +1137,8 @@ mod tests {
         .await
         .unwrap_err();
         assert!(
-            matches!(&mdoc_err, AppError::Validation(m) if m.contains("Document Signer")),
-            "error should name the missing issuer key, got {mdoc_err:?}"
+            matches!(&mdoc_err, AppError::Validation(m) if m.contains("receive_mdoc")),
+            "error should point at the right entry point, got {mdoc_err:?}"
         );
     }
 
@@ -1160,7 +1176,8 @@ mod tests {
     }
     // ── mdoc receive ──────────────────────────────────────────────────
 
-    /// Build a signed mdoc plus its Document Signer public key.
+    /// Build a signed mdoc plus its Document Signer public key. The MSO carries
+    /// a generated P-256 device key, returned so a test can assert the binding.
     fn test_mdoc() -> (Vec<u8>, Vec<u8>) {
         use affinidi_mdoc::es256_cose::Es256CoseSigner;
         use affinidi_mdoc::mso::ValidityInfo;
@@ -1187,12 +1204,12 @@ mod tests {
         let (_tmp, _store, vault) = fresh_vault();
         let (body, issuer_pub) = test_mdoc();
 
-        let cred = receive(
+        let cred = receive_mdoc(
             &vault,
             "m1",
-            &CredentialFormat::MsoMdoc,
             &body,
-            Some(&issuer_pub),
+            &issuer_pub,
+            "key-device-1",
             None,
             Utc::now(),
         )
@@ -1217,12 +1234,12 @@ mod tests {
         let (body, _) = test_mdoc();
         let attacker = Es256CoseSigner::generate().public_key_bytes();
 
-        let err = receive(
+        let err = receive_mdoc(
             &vault,
             "m2",
-            &CredentialFormat::MsoMdoc,
             &body,
-            Some(&attacker),
+            &attacker,
+            "key-device-1",
             None,
             Utc::now(),
         )
@@ -1242,12 +1259,12 @@ mod tests {
         let (body, _) = test_mdoc();
         let attacker = Es256CoseSigner::generate().public_key_bytes();
 
-        let _ = receive(
+        let _ = receive_mdoc(
             &vault,
             "m3",
-            &CredentialFormat::MsoMdoc,
             &body,
-            Some(&attacker),
+            &attacker,
+            "key-device-1",
             None,
             Utc::now(),
         )
@@ -1267,12 +1284,12 @@ mod tests {
         let (body, issuer_pub) = test_mdoc();
         let long_after = "2040-01-01T00:00:00Z".parse::<DateTime<Utc>>().unwrap();
 
-        let err = receive(
+        let err = receive_mdoc(
             &vault,
             "m4",
-            &CredentialFormat::MsoMdoc,
             &body,
-            Some(&issuer_pub),
+            &issuer_pub,
+            "key-device",
             None,
             long_after,
         )
@@ -1284,36 +1301,42 @@ mod tests {
         );
     }
 
+    /// The device-key binding is recorded on the stored envelope. Without it
+    /// nothing downstream could know which VTA key may sign `DeviceAuth`, and
+    /// the credential would be unpresentable with no trace of why.
     #[tokio::test]
-    async fn mdoc_receive_requires_an_issuer_key() {
+    async fn mdoc_receive_records_the_device_key_binding() {
         let (_tmp, _store, vault) = fresh_vault();
-        let (body, _) = test_mdoc();
-        let err = receive(
+        let (body, issuer_pub) = test_mdoc();
+
+        let cred = receive_mdoc(
             &vault,
             "m5",
-            &CredentialFormat::MsoMdoc,
             &body,
-            None,
+            &issuer_pub,
+            "key-device-42",
             None,
             Utc::now(),
         )
         .await
-        .unwrap_err();
-        assert!(
-            matches!(&err, AppError::Validation(m) if m.contains("Document Signer")),
-            "{err:?}"
+        .expect("stores");
+
+        assert_eq!(
+            cred.tags.get(super::super::model::MDOC_DEVICE_KEY_TAG),
+            Some(&"key-device-42".to_string()),
+            "the binding must survive onto the stored envelope"
         );
     }
 
     #[tokio::test]
     async fn mdoc_receive_rejects_a_body_that_is_not_an_mdoc() {
         let (_tmp, _store, vault) = fresh_vault();
-        let err = receive(
+        let err = receive_mdoc(
             &vault,
             "m6",
-            &CredentialFormat::MsoMdoc,
             b"not cbor at all",
-            Some(&[0u8; 65]),
+            &[0u8; 65],
+            "key-device-1",
             None,
             Utc::now(),
         )


### PR DESCRIPTION
> Was stacked on #989; that has merged, so this is rebased onto `main` as a
> single commit and CI exercises it directly.

## Why

An mdoc's holder binding is a **key, not a DID**. The MSO carries a `deviceKey`,
and only its private half can sign `DeviceAuth`. Nothing in the stored envelope
said which VTA key that was — so a received mdoc could be stored and then turn
out to be **unpresentable**, with the failure surfacing much later at
presentation and nothing pointing at the cause.

This was one of the three blockers found while attempting the presentation PR.
Storing a credential you can never present is a trap, and the right moment to
discover it is the moment it arrives.

## What

Receive resolves the binding and **refuses the credential if this VTA does not
hold the key**:

1. `mdoc_device_key_sec1` extracts the MSO `deviceKey` as a **compressed SEC1
   point** — deliberately the same encoding the VTA stores its own P-256 public
   keys in (`to_encoded_point(true)` + multicodec `p256-pub`), so neither side
   has to be re-derived to compare.
2. `find_key_by_public_multibase` looks it up in the keyspace.
3. `receive_mdoc` records the key id on the stored envelope under
   `MDOC_DEVICE_KEY_TAG`, so presentation can find the signer later.

## Layering

Extraction is in **vta-vault** because it reads mdoc internals. Matching is in
**vta-service** because that is the layer that can see the keyspace. `vta-vault`
does not depend on `vta-keys` (per the crate map) and this keeps it that way —
which is why the helper returns raw bytes rather than a multibase string.

## Two security details worth a look

**The lookup takes no `AuthClaims`.** It answers a factual question about the
keyspace, not an authorization one. The **caller** gates on the returned
record's `context_id` — binding a credential to a key in a context the caller
cannot act in would be a cross-tenant escape, so that check is explicit at the
call site rather than buried in the helper.

**It's a linear scan, on purpose.** The keyspace is indexed by key id, not by
public key. A reverse index for one caller on the receive path is not worth the
write amplification on every mint. It skips (rather than aborts on) a corrupt
row, matching `list_keys` — one bad record must not make every lookup fail.

## Breaking change

`receive_mdoc` takes a `device_key_id`, and the format-dispatching `receive()`
**no longer accepts `MsoMdoc` at all**. That signature can carry a resolved
issuer key but not a device-key binding, and guessing the binding is exactly
what must not happen — so the arm errors and names `receive_mdoc` instead.

Both crates are 0.x; release-plz moves the compatibility field from the `!`.
`semver checks` will report it, which is that job working as intended.

## Testing

`vta-vault` 104 passed, `vta-service` 817 passed. fmt and clippy clean.

The mdoc receive tests were repointed at `receive_mdoc`; the format-dispatch
test now asserts mdoc is *refused* by that entry point and that the error names
the right one. New: `mdoc_receive_records_the_device_key_binding`, which asserts
the binding survives onto the stored envelope — without it, nothing downstream
could know which key may sign.

## Next

This unblocks the third piece: OID4VP session context on the query wire, plus
presentation. `QueryBody` is `{dcql_query, nonce, purpose}` and ISO 18013-7's
SessionTranscript needs `[clientId, responseUri, nonce, mdocGeneratedNonce]`, so
that PR extends the query and refuses to *match* an mdoc when the session
context is absent — keeping the matchable⇒presentable invariant true rather than
presenting something unbound.

