### PR TITLE
chore(deps): affinidi-messaging-delivery 0.1.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -319,9 +319,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-delivery"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c10577a9de3302bc2981faefb3201a6faec788d22d8cc1a7a5dea3005c716cb"
+checksum = "7e5655cfc5cdac34b52b8de49e0297af3bd347b9989707053be8711fdd4c54f9"
 dependencies = [
  "affinidi-messaging-core",
  "async-trait",
@@ -2945,7 +2945,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c54e03a951783e8b327515db3f2a2fd0e3bed362a96b066f341ce66ed49b4ead"
 dependencies = [
  "data-encoding",
- "syn 3.0.3",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3494,7 +3494,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4610,7 +4610,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -6476,7 +6476,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.43",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "thiserror 2.0.20",
  "tokio",
  "tracing",
@@ -6515,9 +6515,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7123,7 +7123,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7202,7 +7202,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8113,7 +8113,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10258,7 +10258,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]


### PR DESCRIPTION
Takes [affinidi-tdk-rs#710](https://github.com/affinidi/affinidi-tdk-rs/pull/710) — the fix for the delivery layer acking a message no consumer received.

## Why this matters here

An ack is a delete at the mediator, and `run_dispatcher` acked unconditionally — including when its subscriber broadcast had just returned `Err`, meaning nobody was listening. Those messages were destroyed.

The window is small and its contents are not: no subscriber is installed for a moment at startup and again on the way down, and what arrives then is whatever the peer happened to send. **For the VTC that's a join submit or a credential-exchange reply; for the VTA, a trust task.** It surfaced first in OpenVTC (its #221) only because that's where a lost membership credential is visible to a human — the same window exists on both services here.

## What changed

**Lockfile only.** The requirement was already `"0.1.12"`, so 0.1.14 satisfies it and no manifest moves. But resolution is the point: the fix landing upstream does nothing for a build still resolving 0.1.13 from crates.io, which is what this workspace was doing.

## Verified

- `cargo build --workspace` clean
- `cargo clippy --workspace -- -D warnings` — the exact CI invocation — clean
- `cargo fmt --all --check` clean
- `cargo test --workspace --exclude vti-e2e-tests` passes

## Pre-existing failure worth knowing about (not from this PR)

If you run clippy with `--all-targets` locally it fails:

```
error: use of deprecated method `vta_sdk::client::backup::…::backup_export`:
       inline export rides a legacy protocol message with no TSP path
       — use the descriptor flow (backup/initiate-export)
  --> tests/e2e/tests/client_didcomm.rs:1154:22
```

I confirmed this is **already on main** with an unmodified tree — `vta-sdk 0.24` deprecated `backup_export`, and that arrived with the release, not with this bump. CI runs `cargo clippy --workspace` without `--all-targets`, so it isn't caught there. Migrating that test to the descriptor flow is worth its own change; I've deliberately not folded it in here.
