### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2424,7 +2424,7 @@ checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cnm-cli"
-version = "0.11.20"
+version = "0.11.21"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "clap",
@@ -6284,7 +6284,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "pnm-cli"
-version = "0.12.4"
+version = "0.12.5"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-resolver-cache-sdk",
@@ -9474,7 +9474,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/cnm-cli/CHANGELOG.md
+++ b/cnm-cli/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.11.21](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/cnm-cli-v0.11.20...cnm-cli-v0.11.21) — 2026-08-16
+
+
 ## [0.11.20](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/cnm-cli-v0.11.19...cnm-cli-v0.11.20) — 2026-08-16
 
 

--- a/cnm-cli/Cargo.toml
+++ b/cnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cnm-cli"
 description = "CLI Tool for Verified Trust Agents operating in Verified Trust Communities"
-version = "0.11.20"
+version = "0.11.21"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/pnm-cli/CHANGELOG.md
+++ b/pnm-cli/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.12.5](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/pnm-cli-v0.12.4...pnm-cli-v0.12.5) — 2026-08-16
+
+
 ## [0.12.4](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/pnm-cli-v0.12.3...pnm-cli-v0.12.4) — 2026-08-16
 
 

--- a/pnm-cli/Cargo.toml
+++ b/pnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pnm-cli"
 description = "CLI Tool for managing a personal Verifiable Trust Agent"
-version = "0.12.4"
+version = "0.12.5"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/CHANGELOG.md
+++ b/vta-service/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.16.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-service-v0.16.0...vta-service-v0.16.1) — 2026-08-16
+
+
 ## [0.16.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-service-v0.15.4...vta-service-v0.16.0) — 2026-08-16
 
 

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.16.0"
+version = "0.16.1"
 edition.workspace = true
 # Published for one reason: `openvtc-core` dev-depends on it for
 # `test_support::MockVta`, the in-process VTA its end-to-end tests run against.


### PR DESCRIPTION



## 🤖 New release

* `cnm-cli`: 0.11.20 -> 0.11.21
* `pnm-cli`: 0.12.4 -> 0.12.5
* `vta-service`: 0.16.0 -> 0.16.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>





</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).