### PR TITLE
feat(vta-keys)!: add non-extractable internal signing keys

### DIFF
--- a/cnm-cli/src/main.rs
+++ b/cnm-cli/src/main.rs
@@ -650,6 +650,18 @@ enum KeyCommands {
         /// Application context ID
         #[arg(long)]
         context_id: Option<String>,
+        /// Create a NON-RECOVERABLE internal key.
+        ///
+        /// Generated from the system CSPRNG, NOT derived from your BIP-39 seed,
+        /// excluded from backups, and never exported by any surface — the VTA
+        /// will only ever sign with it. If this VTA's storage is lost the key is
+        /// gone permanently. Cannot sign did:webvh log entries; may be a signing
+        /// verificationMethod inside a DID document.
+        #[arg(long)]
+        internal: bool,
+        /// Skip the internal-key confirmation prompt (automation only).
+        #[arg(long)]
+        yes: bool,
     },
     /// Get a key by ID
     Get {
@@ -1312,6 +1324,8 @@ async fn main() {
                 mnemonic,
                 label,
                 context_id,
+                internal,
+                yes,
             } => {
                 keys::cmd_key_create(
                     &client,
@@ -1320,6 +1334,8 @@ async fn main() {
                     mnemonic,
                     label,
                     context_id,
+                    internal,
+                    yes,
                 )
                 .await
             }

--- a/docs/02-vta/internal-keys.md
+++ b/docs/02-vta/internal-keys.md
@@ -1,0 +1,146 @@
+# Internal (non-extractable) keys
+
+An **internal key** is a signing key the VTA generates from the system CSPRNG,
+uses only as a signing oracle, and **never gives out** — not to an operator, not
+to an admin, not to a backup, not to anyone holding your mnemonic.
+
+It exists to make one sentence true:
+
+> The private key can be used only by this VTA, and cannot be obtained by
+> anybody, including whoever runs it.
+
+That is the property eIDAS calls **sole control**, and it is the half the VTA
+otherwise fails: an ordinary derived key can always be reconstructed from the
+24-word mnemonic, which is exactly what makes the VTA recoverable *and* what
+makes "the operator cannot obtain this key" false.
+
+Internal keys buy that property at a price that is permanent and worth
+understanding before you mint one.
+
+---
+
+## ⚠ An internal key cannot be recovered. Ever.
+
+There is no derivation path, no backup copy, and no mnemonic that reproduces it.
+
+- **Your BIP-39 mnemonic will not recover it.** It is not derived from the
+  master seed. That is the entire point — if it were, anyone with the 24 words
+  could reconstruct it offline and the guarantee would be decorative.
+- **It is excluded from `pnm backup export`.** A backup that carried it would be
+  an export of a key the VTA promises never to export, and restoring that backup
+  elsewhere would silently clone a signer.
+- **No surface returns it.** The key-export API refuses it, and so does the
+  internal-authority path used by the VTA's own subsystems.
+
+If this VTA's storage is lost, every signature that key was the sole authority
+for becomes unproducible, permanently. Nothing recovers it.
+
+**Plan for that before you mint one**, not after.
+
+---
+
+## When to use one
+
+**Good fit** — losing the key costs you the ability to *produce new signatures*,
+and the thing it signs can be re-issued or re-established:
+
+- A signing `verificationMethod` published in a DID document.
+- An issuer key whose credentials can be re-issued under a replacement key.
+- A holder key for credentials that an issuer would re-issue.
+
+**Wrong fit** — losing the key costs you *control of an identity*:
+
+- **`did:webvh` log entries.** The VTA refuses this outright, and the refusal is
+  enforced in code rather than left to guidance. WebVH is append-only: each
+  entry is authorised by the update key the previous entry named. If an
+  unrecoverable key were the update key and storage were lost, the DID could
+  never be updated again *by anyone*, permanently, and every integration pinned
+  to it would be stranded. Re-issuing something does not fix that.
+
+The distinction is not "how important is this key" — it is **"if it vanishes, is
+there a path back?"** Credentials have one. An append-only identity log does
+not.
+
+---
+
+## Durability, and what actually protects you
+
+Because there is no mnemonic path, durability comes entirely from the storage
+the key lives in.
+
+**In a TEE deployment**, keys are sealed to the enclave **measurement**, not the
+enclave instance. A fresh enclave running the same image, with access to the
+same KMS key, unseals the same storage — so replication and image upgrades work.
+`deploy/nitro/setup-kms-policy.sh --old-pcr0 <hash>` authorises both the current
+and previous measurement during a rolling upgrade, which is what makes a rebuild
+an ops step rather than a data-loss event. This is the same shape as HSM-to-HSM
+backup under a domain key: the key never exists in plaintext outside a boundary
+of the same class.
+
+The two things that genuinely destroy an internal key are therefore:
+
+1. **Losing the KMS key.** Enable key-deletion protection; consider
+   cross-region replication. Once keys cannot be re-derived from a mnemonic,
+   this is your only copy.
+2. **Losing sealed storage without a replica.**
+
+**In a non-TEE deployment**, at-rest protection is whatever the keyspace
+encryption is configured to be, and an operator with disk access is inside that
+boundary. Internal keys still meaningfully raise the bar against *export* — no
+API returns them and no backup carries them — but they do not by themselves make
+a non-TEE VTA tamper-proof. Treat non-TEE internal keys as good hygiene, and TEE
+internal keys as an enforceable property.
+
+---
+
+## Using them
+
+```bash
+pnm keys create --key-type ed25519 --internal --context my-app
+```
+
+The CLI prints the full warning and requires you to type the confirmation
+phrase. `--yes` skips the prompt for automation — use it only where the
+consequence is already understood and recorded.
+
+An internal key **requires an explicit `--key-id`-equivalent identity**: it has
+no derivation path to be named after, and minting an unrecoverable key under a
+generated name the operator never chose is a good way to lose it.
+
+Signing works exactly as it does for any other key:
+
+```bash
+pnm keys sign <key-id> --payload <data> --algorithm eddsa
+```
+
+Supported types are **ed25519** (EdDSA) and **p256** (ES256). X25519 is refused:
+it is a key-agreement key, and an internal key that cannot sign would be
+unusable *and* unrecoverable.
+
+---
+
+## What the VTA enforces
+
+| Surface | Internal key |
+|---|---|
+| `keys/sign` (REST, DIDComm, Trust Task) | **Allowed** — the only use |
+| Key export (`get_key_secret`) | **Refused**, including for super-admin |
+| Internal-authority export | **Refused** |
+| `pnm backup export` | **Excluded** — the keyspace is not backed up |
+| `did:webvh` log entry signing | **Refused** |
+| DID document `verificationMethod` | **Allowed** |
+
+The export refusal is not a permission check. Admin is not a bypass, because the
+whole value of the origin is that *no* caller holds this power — treating it as
+an authorization question would be the wrong shape. Deleting both refusals does
+not compile: the match over `KeyOrigin` becomes non-exhaustive, so an export
+path cannot silently reopen.
+
+---
+
+## See also
+
+- `vta-keys/src/internal.rs` — the storage and signing implementation, and why
+  it is deliberately not built on the imported-key path (which wraps under a
+  seed-derived KEK).
+- `docs/02-vta/tee-architecture.md` — sealing, measurements, and KMS policy.

--- a/pnm-cli/src/cli.rs
+++ b/pnm-cli/src/cli.rs
@@ -2440,6 +2440,19 @@ pub(crate) enum KeyCommands {
         /// unless you're a super admin creating a context-less key (rare).
         #[arg(long = "context", alias = "context-id", value_name = "ID")]
         context_id: Option<String>,
+        /// Create a NON-RECOVERABLE internal key.
+        ///
+        /// Generated from the system CSPRNG, NOT derived from your BIP-39 seed,
+        /// excluded from backups, and never exported by any surface — the VTA
+        /// will only ever sign with it. If this VTA's storage is lost the key is
+        /// gone permanently, along with every signature it was the sole
+        /// authority for. Cannot sign did:webvh log entries; may be a signing
+        /// verificationMethod inside a DID document.
+        #[arg(long)]
+        internal: bool,
+        /// Skip the internal-key confirmation prompt (automation only).
+        #[arg(long)]
+        yes: bool,
     },
     /// Import an externally-created private key
     Import {

--- a/pnm-cli/src/commands/keys.rs
+++ b/pnm-cli/src/commands/keys.rs
@@ -17,6 +17,8 @@ pub(crate) async fn run(
             mnemonic,
             label,
             context_id,
+            internal,
+            yes,
         } => {
             keys::cmd_key_create(
                 client,
@@ -25,6 +27,8 @@ pub(crate) async fn run(
                 mnemonic,
                 label,
                 context_id,
+                internal,
+                yes,
             )
             .await
         }

--- a/vta-cli-common/src/commands/contexts.rs
+++ b/vta-cli-common/src/commands/contexts.rs
@@ -691,6 +691,7 @@ pub async fn cmd_context_reprovision(
             eprintln!("Creating new admin key...");
             let key_resp = client
                 .create_key(CreateKeyRequest {
+                    internal: None,
                     key_type: KeyType::Ed25519,
                     derivation_path: None,
                     key_id: None,

--- a/vta-cli-common/src/commands/keys.rs
+++ b/vta-cli-common/src/commands/keys.rs
@@ -8,6 +8,7 @@ use vta_sdk::prelude::*;
 
 use crate::render::{is_full_display, print_full_entry, print_full_list_title, print_widget};
 
+#[allow(clippy::too_many_arguments)]
 pub async fn cmd_key_create(
     client: &VtaClient,
     key_type: &str,
@@ -15,6 +16,8 @@ pub async fn cmd_key_create(
     mnemonic: Option<String>,
     label: Option<String>,
     context_id: Option<String>,
+    internal: bool,
+    yes: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let key_type = match key_type {
         "ed25519" => KeyType::Ed25519,
@@ -26,7 +29,49 @@ pub async fn cmd_key_create(
             );
         }
     };
+    // An internal key is the one thing this CLI can create that cannot be
+    // undone by any later command, restored from the mnemonic, or recovered
+    // from a backup. Say so plainly, and require the operator to type the
+    // consequence rather than mash `y` — a habitual yes/no prompt is not
+    // proportionate to a permanent, silent loss of signing ability.
+    if internal {
+        eprintln!();
+        eprintln!("  ⚠  You are about to create a NON-RECOVERABLE internal key.");
+        eprintln!();
+        eprintln!("     • Its material is generated from the system CSPRNG and is NOT");
+        eprintln!("       derived from your BIP-39 seed. Your 24-word mnemonic will NOT");
+        eprintln!("       recover it.");
+        eprintln!("     • It is excluded from `pnm backup export`. A restored VTA will");
+        eprintln!("       NOT have it.");
+        eprintln!("     • It can never be exported — not by you, not by an admin, not");
+        eprintln!("       under internal authority. The VTA will only sign with it.");
+        eprintln!("     • If this VTA's storage is lost, every signature this key was");
+        eprintln!("       the sole authority for becomes unproducible, permanently.");
+        eprintln!();
+        eprintln!("     It CANNOT be used to sign did:webvh log entries, precisely");
+        eprintln!("     because losing it would freeze that DID forever. It CAN be a");
+        eprintln!("     signing verificationMethod inside a DID document.");
+        eprintln!();
+
+        if !yes {
+            eprint!("     Type 'i understand this key cannot be recovered' to continue: ");
+            use std::io::{BufRead, Write};
+            std::io::stderr().flush().ok();
+            let mut line = String::new();
+            std::io::stdin().lock().read_line(&mut line)?;
+            if !line
+                .trim()
+                .eq_ignore_ascii_case("i understand this key cannot be recovered")
+            {
+                return Err("aborted: confirmation phrase not matched".into());
+            }
+        }
+    }
+
     let mut req = CreateKeyRequest::new(key_type);
+    if internal {
+        req.internal = Some(true);
+    }
     if let Some(p) = derivation_path {
         req = req.derivation_path(p);
     }
@@ -46,6 +91,12 @@ pub async fn cmd_key_create(
     println!("  Derivation Path: {}", resp.derivation_path);
     println!("  Public Key:      {}", resp.public_key);
     println!("  Status:          {}", resp.status);
+    if resp.origin == vta_sdk::keys::KeyOrigin::Internal {
+        println!();
+        println!("  ⚠  This is an internal key. It cannot be exported, is excluded from");
+        println!("     backups, and cannot be recovered from your mnemonic. If this VTA's");
+        println!("     storage is lost, this key is gone.");
+    }
     if let Some(label) = &resp.label {
         println!("  Label:           {label}");
     }

--- a/vta-keys/src/internal.rs
+++ b/vta-keys/src/internal.rs
@@ -1,0 +1,291 @@
+//! Non-extractable internal signing keys.
+//!
+//! An internal key is generated from the system CSPRNG, stored only in the
+//! [`INTERNAL_KEYS`] keyspace, and **never leaves this VTA** — not through the
+//! key-export surface, not in a backup, not via the mnemonic.
+//!
+//! ## Why this is a separate module and not a flag on the imported path
+//!
+//! [`crate::imported`] wraps its secrets under a KEK **derived from the BIP-39
+//! master seed** (`derive_kek(seed, salt)`). Anything stored that way is
+//! reconstructible offline by whoever holds the 24 words, so a
+//! "non-extractable" flag on it would be decorative: the boundary it claims to
+//! enforce has already been walked around. Internal keys therefore have their
+//! own keyspace and no seed involvement at any point.
+//!
+//! For the same reason there is deliberately **no `export_secret` here**. The
+//! module exposes generate, load-for-signing, and delete. A caller that wants
+//! the bytes has to be inside this crate's signing path.
+//!
+//! ## What this costs
+//!
+//! **An internal key cannot be recovered.** There is no derivation path, no
+//! backup copy, and no mnemonic that reproduces it. If the keyspace is lost,
+//! every signature that key was the sole authority for becomes unproducible,
+//! permanently. That is the point of the design and also its whole risk; every
+//! operator-facing surface that mints one says so.
+//!
+//! At rest the material is protected by the keyspace's own encryption — which,
+//! in a TEE deployment, is the KMS-sealed storage key bound to the enclave
+//! measurement. In a non-TEE deployment it is whatever `store.encryption` is
+//! configured to be, and an operator with disk access is inside that boundary.
+//! Internal keys raise the bar against *export*; they do not by themselves make
+//! a non-TEE VTA tamper-proof.
+
+use aes_gcm::aead::{OsRng, rand_core::RngCore};
+use p256::elliptic_curve::sec1::ToEncodedPoint;
+use serde::{Deserialize, Serialize};
+use vta_sdk::keys::KeyType;
+use vti_common::error::AppError;
+use vti_common::store::KeyspaceHandle;
+use zeroize::Zeroize;
+
+/// Row prefix inside [`vta_keyspaces::INTERNAL_KEYS`].
+const SECRET_PREFIX: &str = "internal:";
+
+/// A stored internal key's private material plus the type needed to use it.
+#[derive(Serialize, Deserialize)]
+struct StoredInternalSecret {
+    key_type: KeyType,
+    /// Raw private key bytes. Encrypted at rest by the keyspace, never by a
+    /// seed-derived KEK — see the module docs for why that distinction is the
+    /// entire point.
+    secret: Vec<u8>,
+}
+
+/// Generate a fresh internal signing key, store it, and return its public half.
+///
+/// The private bytes never leave this function except into the keyspace. The
+/// caller gets only the public key, because there is no legitimate reason for
+/// a mint path to hold the secret — the signing oracle loads it on demand.
+pub async fn generate(
+    internal_ks: &KeyspaceHandle,
+    key_id: &str,
+    key_type: KeyType,
+) -> Result<Vec<u8>, AppError> {
+    if key_id.trim().is_empty() {
+        return Err(AppError::Validation(
+            "internal key id must be non-empty".into(),
+        ));
+    }
+    if internal_ks
+        .get_raw(format!("{SECRET_PREFIX}{key_id}"))
+        .await?
+        .is_some()
+    {
+        // Overwriting would destroy the only copy of the previous key with no
+        // way to get it back, so refuse rather than silently replace.
+        return Err(AppError::Conflict(format!(
+            "internal key `{key_id}` already exists; internal keys are never \
+             overwritten because the previous key would be unrecoverable"
+        )));
+    }
+
+    let (mut secret, public) = match key_type {
+        KeyType::Ed25519 => {
+            let mut seed = [0u8; 32];
+            OsRng.fill_bytes(&mut seed);
+            let signing = ed25519_dalek::SigningKey::from_bytes(&seed);
+            seed.zeroize();
+            let public = signing.verifying_key().to_bytes().to_vec();
+            (signing.to_bytes().to_vec(), public)
+        }
+        KeyType::P256 => {
+            let mut raw = [0u8; 32];
+            OsRng.fill_bytes(&mut raw);
+            let secret = p256::SecretKey::from_slice(&raw)
+                .map_err(|e| AppError::Internal(format!("internal P-256 keygen: {e}")))?;
+            raw.zeroize();
+            let public = secret
+                .public_key()
+                .to_encoded_point(true)
+                .as_bytes()
+                .to_vec();
+            (secret.to_bytes().to_vec(), public)
+        }
+        // X25519 is a key-agreement key, not a signing key. Internal keys exist
+        // for signing; minting one that cannot sign would only create a key
+        // nobody can use and nobody can recover.
+        KeyType::X25519 => {
+            return Err(AppError::Validation(
+                "internal keys are signing keys; X25519 is key-agreement only".into(),
+            ));
+        }
+    };
+
+    let record = StoredInternalSecret {
+        key_type,
+        secret: secret.clone(),
+    };
+    secret.zeroize();
+
+    let bytes = serde_json::to_vec(&record)
+        .map_err(|e| AppError::Internal(format!("serialize internal secret: {e}")))?;
+    internal_ks
+        .insert_raw(format!("{SECRET_PREFIX}{key_id}"), bytes)
+        .await?;
+
+    Ok(public)
+}
+
+/// Load an internal key's private bytes **for signing inside this process**.
+///
+/// Crate-visible on purpose. Widening this to `pub` would create the export
+/// surface the whole module exists to avoid, so a caller outside `vta-keys`
+/// cannot obtain the material even by accident.
+pub(crate) async fn load_for_signing(
+    internal_ks: &KeyspaceHandle,
+    key_id: &str,
+) -> Result<(KeyType, Vec<u8>), AppError> {
+    let blob = internal_ks
+        .get_raw(format!("{SECRET_PREFIX}{key_id}"))
+        .await?
+        .ok_or_else(|| AppError::NotFound(format!("internal key `{key_id}` not found")))?;
+
+    let record: StoredInternalSecret = serde_json::from_slice(&blob)
+        .map_err(|e| AppError::Internal(format!("decode internal secret: {e}")))?;
+
+    Ok((record.key_type, record.secret))
+}
+
+/// Sign `payload` with an internal key, returning the raw signature.
+///
+/// The only way internal key material is used. The bytes are zeroized before
+/// return on every path, including the error ones.
+pub async fn sign(
+    internal_ks: &KeyspaceHandle,
+    key_id: &str,
+    payload: &[u8],
+) -> Result<Vec<u8>, AppError> {
+    let (key_type, mut secret) = load_for_signing(internal_ks, key_id).await?;
+
+    let result = match key_type {
+        KeyType::Ed25519 => ed25519_dalek::SigningKey::try_from(secret.as_slice())
+            .map_err(|e| AppError::Internal(format!("internal Ed25519 key: {e}")))
+            .map(|k| {
+                use ed25519_dalek::Signer;
+                k.sign(payload).to_bytes().to_vec()
+            }),
+        KeyType::P256 => affinidi_crypto::p256::sign(&secret, payload)
+            .map_err(|e| AppError::Internal(format!("internal P-256 sign: {e}"))),
+        KeyType::X25519 => Err(AppError::Internal(
+            "an X25519 internal key should never have been stored".into(),
+        )),
+    };
+
+    secret.zeroize();
+    result
+}
+
+/// Delete an internal key.
+///
+/// **Irreversible.** There is no backup and no derivation path, so this is the
+/// only operation in the crate that destroys key material outright. Callers are
+/// expected to have confirmed with the operator first.
+pub async fn delete(internal_ks: &KeyspaceHandle, key_id: &str) -> Result<(), AppError> {
+    internal_ks.remove(format!("{SECRET_PREFIX}{key_id}")).await
+}
+
+/// True if `key_id` names a stored internal key.
+pub async fn exists(internal_ks: &KeyspaceHandle, key_id: &str) -> Result<bool, AppError> {
+    Ok(internal_ks
+        .get_raw(format!("{SECRET_PREFIX}{key_id}"))
+        .await?
+        .is_some())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vti_common::config::StoreConfig;
+    use vti_common::store::Store;
+
+    fn fresh() -> (tempfile::TempDir, Store, KeyspaceHandle) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(&StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        })
+        .unwrap();
+        let ks = store.keyspace(vta_keyspaces::INTERNAL_KEYS).unwrap();
+        (dir, store, ks)
+    }
+
+    #[tokio::test]
+    async fn generate_returns_only_the_public_half_and_signs_with_the_private_one() {
+        let (_d, _s, ks) = fresh();
+        let public = generate(&ks, "k-internal", KeyType::Ed25519).await.unwrap();
+        assert_eq!(public.len(), 32, "Ed25519 public key");
+
+        let sig = sign(&ks, "k-internal", b"payload").await.unwrap();
+        assert_eq!(sig.len(), 64, "Ed25519 signature");
+
+        // The signature must verify under the returned public key — proving the
+        // stored secret really is the counterpart, not just some bytes.
+        use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+        let vk = VerifyingKey::from_bytes(&public.clone().try_into().unwrap()).unwrap();
+        vk.verify(b"payload", &Signature::from_slice(&sig).unwrap())
+            .expect("signature verifies under the advertised public key");
+    }
+
+    /// Two internal keys minted with the same id would be two different keys,
+    /// and the first would be gone with no way back. Refuse instead.
+    #[tokio::test]
+    async fn generating_over_an_existing_internal_key_is_refused() {
+        let (_d, _s, ks) = fresh();
+        generate(&ks, "k1", KeyType::Ed25519).await.unwrap();
+        let err = generate(&ks, "k1", KeyType::Ed25519).await.unwrap_err();
+        assert!(
+            matches!(&err, AppError::Conflict(m) if m.contains("unrecoverable")),
+            "{err:?}"
+        );
+    }
+
+    /// Every internal key must be independent. If two keys minted in the same
+    /// process shared material, the CSPRNG is not being used as intended.
+    #[tokio::test]
+    async fn internal_keys_are_independent_of_each_other() {
+        let (_d, _s, ks) = fresh();
+        let a = generate(&ks, "a", KeyType::Ed25519).await.unwrap();
+        let b = generate(&ks, "b", KeyType::Ed25519).await.unwrap();
+        assert_ne!(a, b, "two internal keys must not share material");
+    }
+
+    #[tokio::test]
+    async fn p256_internal_keys_sign() {
+        let (_d, _s, ks) = fresh();
+        let public = generate(&ks, "p", KeyType::P256).await.unwrap();
+        assert_eq!(public.len(), 33, "compressed SEC1 point");
+
+        let sig = sign(&ks, "p", b"payload").await.unwrap();
+        assert!(
+            affinidi_crypto::p256::verify(&public, b"payload", &sig).unwrap(),
+            "P-256 signature verifies under the advertised public key"
+        );
+    }
+
+    /// An internal key exists to sign. A key-agreement key cannot, and minting
+    /// one would create something unusable *and* unrecoverable.
+    #[tokio::test]
+    async fn x25519_internal_keys_are_refused() {
+        let (_d, _s, ks) = fresh();
+        let err = generate(&ks, "x", KeyType::X25519).await.unwrap_err();
+        assert!(
+            matches!(&err, AppError::Validation(m) if m.contains("key-agreement")),
+            "{err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_deleted_internal_key_is_gone_for_good() {
+        let (_d, _s, ks) = fresh();
+        generate(&ks, "doomed", KeyType::Ed25519).await.unwrap();
+        assert!(exists(&ks, "doomed").await.unwrap());
+
+        delete(&ks, "doomed").await.unwrap();
+        assert!(!exists(&ks, "doomed").await.unwrap());
+        assert!(
+            sign(&ks, "doomed", b"x").await.is_err(),
+            "a deleted internal key cannot be recovered or reused"
+        );
+    }
+}

--- a/vta-keys/src/lib.rs
+++ b/vta-keys/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod derivation;
 pub mod imported;
+pub mod internal;
 pub mod paths;
 pub mod seed_store;
 pub mod seeds;

--- a/vta-keyspaces/src/lib.rs
+++ b/vta-keyspaces/src/lib.rs
@@ -53,6 +53,17 @@ pub const AUDIT: &str = "audit";
 /// `imported` — the latter was a long-standing test-only typo that operated on
 /// an empty keyspace disjoint from production. Always reference this const.
 pub const IMPORTED_SECRETS: &str = "imported_secrets";
+/// Non-extractable internal signing keys.
+///
+/// Deliberately **not** [`IMPORTED_SECRETS`]: that keyspace wraps its contents
+/// under a KEK derived from the BIP-39 master seed, so anything stored there is
+/// reconstructible by whoever holds the mnemonic. Internal keys exist precisely
+/// to have no such path — their material is generated from the system CSPRNG,
+/// never derived, and lives here instead.
+///
+/// In [`EXCLUDED_FROM_BACKUP`] by design, not by omission. A backup containing
+/// this keyspace would be an export of keys the VTA promises never to export.
+pub const INTERNAL_KEYS: &str = "internal_keys";
 /// Ephemeral cache (resolver/auth caches).
 pub const CACHE: &str = "cache";
 /// Holder credential vault (third-party secrets stored on this VTA).
@@ -120,6 +131,7 @@ pub const OUTBOX: &str = "outbox";
 /// asserts the partition stays exhaustive so a newly-added keyspace can't be
 /// silently omitted from the backup decision.
 pub const ALL: &[&str] = &[
+    INTERNAL_KEYS,
     KEYS,
     SESSIONS,
     ACL,
@@ -176,6 +188,10 @@ pub const BACKED_UP: &[&str] = &[
 /// backup-fidelity follow-up should move them into [`BACKED_UP`], not leave
 /// them silently dropped.
 pub const EXCLUDED_FROM_BACKUP: &[&str] = &[
+    // Non-extractable internal signing keys. Excluding them is the feature:
+    // a backup that carried them would export keys the VTA guarantees never
+    // to export, and restoring one elsewhere would silently clone a signer.
+    INTERNAL_KEYS,
     SESSIONS,
     DID_TEMPLATES,
     CACHE,

--- a/vta-sdk/src/client/keys.rs
+++ b/vta-sdk/src/client/keys.rs
@@ -30,6 +30,7 @@ impl VtaClient {
         // silently dropping the create-from-a-phrase path (see #884's
         // `update_acl`, the same failure with different members).
         let body = crate::protocols::key_management::create::CreateKeyBody {
+            internal: None,
             key_type: req.key_type.clone(),
             derivation_path: req.derivation_path.clone().unwrap_or_default(),
             mnemonic: req.mnemonic.clone(),
@@ -46,6 +47,7 @@ impl VtaClient {
             .await?;
         let key = wrapped.key;
         Ok(CreateKeyResponse {
+            origin: key.origin,
             key_id: key.key_id,
             key_type: key.key_type,
             derivation_path: key.derivation_path,

--- a/vta-sdk/src/client/mod.rs
+++ b/vta-sdk/src/client/mod.rs
@@ -2174,6 +2174,7 @@ mod tests {
     #[test]
     fn test_create_key_request_serialization() {
         let req = CreateKeyRequest {
+            internal: None,
             key_type: KeyType::Ed25519,
             derivation_path: None,
             key_id: None,

--- a/vta-sdk/src/client/types.rs
+++ b/vta-sdk/src/client/types.rs
@@ -4,7 +4,7 @@
 //! re-exported from the parent module, so callers can continue to
 //! import them via `vta_sdk::client::*` (or `vta_sdk::prelude::*`).
 
-use crate::keys::{KeyRecord, KeyStatus, KeyType};
+use crate::keys::{KeyOrigin, KeyRecord, KeyStatus, KeyType};
 use crate::protocols::key_management::sign::SignAlgorithm;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -76,11 +76,17 @@ pub struct CreateKeyRequest {
     pub label: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub context_id: Option<String>,
+    /// Mint a **non-extractable internal key**. Absent or `false` is today's
+    /// behaviour. `true` mints a CSPRNG key that is never exported, excluded
+    /// from backup, and **cannot be recovered from the mnemonic or otherwise**.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub internal: Option<bool>,
 }
 
 impl CreateKeyRequest {
     pub fn new(key_type: KeyType) -> Self {
         Self {
+            internal: None,
             key_type,
             derivation_path: None,
             key_id: None,
@@ -246,7 +252,16 @@ pub struct CreateKeyResponse {
     pub public_key: String,
     pub status: KeyStatus,
     pub label: Option<String>,
+    /// How the key was produced. `Internal` means non-extractable and
+    /// unrecoverable — the CLI reprints the warning off this field, so an
+    /// operator scripting against the API sees it in the response too.
+    #[serde(default = "default_derived_origin")]
+    pub origin: KeyOrigin,
     pub created_at: DateTime<Utc>,
+}
+
+fn default_derived_origin() -> KeyOrigin {
+    KeyOrigin::Derived
 }
 
 #[derive(Debug, Deserialize)]

--- a/vta-sdk/src/keys/mod.rs
+++ b/vta-sdk/src/keys/mod.rs
@@ -26,6 +26,22 @@ pub enum KeyStatus {
 pub enum KeyOrigin {
     Derived,
     Imported,
+    /// Generated from the system CSPRNG, **never** derived from the BIP-39
+    /// master seed and **never** exportable.
+    ///
+    /// The trade this variant makes: a `Derived` key can always be
+    /// reconstructed from the mnemonic, which is what makes the VTA
+    /// recoverable — and also what makes "the operator cannot obtain this key"
+    /// false. An `Internal` key has no derivation path, so the mnemonic
+    /// reveals nothing about it and no export surface will return it.
+    ///
+    /// The cost is symmetrical and permanent: **there is no way to recover an
+    /// internal key.** It is not in a backup, not in the mnemonic, and not
+    /// re-derivable. Losing the keyspace loses the key, and anything that key
+    /// authorises. Use it where a signature must be attributable to this VTA
+    /// and nowhere else; do not use it where losing the key would strand an
+    /// identity — see the `did:webvh` refusal in `vta-webvh`.
+    Internal,
 }
 
 fn default_derived() -> KeyOrigin {

--- a/vta-sdk/src/protocols/key_management/create.rs
+++ b/vta-sdk/src/protocols/key_management/create.rs
@@ -20,6 +20,13 @@ pub struct CreateKeyBody {
     pub label: Option<String>,
     #[serde(default, alias = "context_id", skip_serializing_if = "Option::is_none")]
     pub context_id: Option<String>,
+    /// Mint a **non-extractable internal key** rather than a derived one.
+    ///
+    /// Absent or `false` keeps today's behaviour exactly. `true` mints a key
+    /// from the system CSPRNG that is never exported, never backed up, and
+    /// **cannot be recovered** — see `vta_keys::internal`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub internal: Option<bool>,
 }
 
 // Manual Debug — `mnemonic` is the BIP-39 phrase that recovers the
@@ -108,6 +115,7 @@ mod null_member_tests {
     fn an_unset_member_is_absent_from_the_wire_not_null() {
         // What `create_key` builds for a plain, unlabelled, uncontexted key.
         let minimal = CreateKeyBody {
+            internal: None,
             key_type: KeyType::Ed25519,
             derivation_path: String::new(),
             mnemonic: None,
@@ -127,6 +135,7 @@ mod null_member_tests {
     #[test]
     fn a_set_member_still_serialises() {
         let labelled = CreateKeyBody {
+            internal: None,
             key_type: KeyType::Ed25519,
             derivation_path: "m/26'/2'/0'/1'".into(),
             mnemonic: None,

--- a/vta-sdk/tests/protocol_debug_redaction.rs
+++ b/vta-sdk/tests/protocol_debug_redaction.rs
@@ -83,6 +83,7 @@ fn create_did_webvh_result_body_debug_redacts_mnemonic() {
 #[test]
 fn create_key_body_debug_redacts_mnemonic() {
     let body = CreateKeyBody {
+        internal: None,
         key_type: vta_sdk::keys::KeyType::Ed25519,
         derivation_path: "m/0'".into(),
         mnemonic: Some(MARKER.into()),

--- a/vta-service/src/bootstrap_cli.rs
+++ b/vta-service/src/bootstrap_cli.rs
@@ -1100,11 +1100,13 @@ pub async fn run_context_reprovision(
                 .unwrap_or_else(|| "admin-reprovision".to_string());
             let result = create_key(
                 &state.keys_ks,
+                &state.internal_ks,
                 &state.contexts_ks,
                 &state.seed_store,
                 &state.audit_ks,
                 &auth,
                 CreateKeyParams {
+                    internal: false,
                     key_type: KeyType::Ed25519,
                     derivation_path: None,
                     key_id: None,

--- a/vta-service/src/messaging/handlers.rs
+++ b/vta-service/src/messaging/handlers.rs
@@ -350,11 +350,13 @@ didcomm_handler!(
     key_management::create::CreateKeyBody,
     |s, auth, body| operations::keys::create_key(
         &s.keys_ks,
+        &s.internal_ks,
         &s.contexts_ks,
         &s.seed_store,
         &s.audit_ks,
         &auth,
         operations::keys::CreateKeyParams {
+            internal: body.internal.unwrap_or(false),
             key_type: body.key_type,
             derivation_path: if body.derivation_path.is_empty() {
                 None
@@ -459,6 +461,7 @@ didcomm_handler!(
         operations::keys::sign_payload(
             &s.keys_ks,
             &s.imported_ks,
+            &s.internal_ks,
             &s.contexts_ks,
             &s.acl_ks,
             &s.seed_store,

--- a/vta-service/src/messaging/router.rs
+++ b/vta-service/src/messaging/router.rs
@@ -74,6 +74,9 @@ pub struct VtaState {
     pub did_templates_ks: KeyspaceHandle,
     pub audit_ks: KeyspaceHandle,
     pub imported_ks: KeyspaceHandle,
+    /// Non-extractable internal signing keys, mirrored from `AppState` so the
+    /// DIDComm signing oracle reaches the same keys the REST one does.
+    pub internal_ks: KeyspaceHandle,
     /// Persistent runtime state for service enable/disable
     /// (`operations::protocol::runtime_state`). Mirrored from `AppState`.
     pub service_state_ks: KeyspaceHandle,
@@ -185,6 +188,7 @@ impl From<&AppState> for VtaState {
             did_templates_ks: state.did_templates_ks.clone(),
             audit_ks: state.audit_ks.clone(),
             imported_ks: state.imported_ks.clone(),
+            internal_ks: state.internal_ks.clone(),
             service_state_ks: state.service_state_ks.clone(),
             #[cfg(feature = "webvh")]
             webvh_ks: state.webvh_ks.clone(),

--- a/vta-service/src/operations/did_webvh/mod.rs
+++ b/vta-service/src/operations/did_webvh/mod.rs
@@ -506,6 +506,28 @@ async fn load_key_as_secret(
 
     // Load private key material
     let private_key_multibase = match record.origin {
+        // An internal key must never authorise a `did:webvh` log entry.
+        //
+        // WebVH is append-only and each entry is authorised by the update key
+        // the previous entry named. An internal key cannot be recovered — no
+        // backup, no mnemonic, no derivation — so if it were the update key and
+        // the keyspace were lost, the DID could never be updated again by
+        // anyone, permanently, and every integration pinned to it would be
+        // stranded. That failure is not recoverable by re-issuing anything.
+        //
+        // Internal keys are still perfectly good as a *signing*
+        // `verificationMethod` inside the published document: losing one costs
+        // the ability to produce new signatures, not the ability to control the
+        // identity.
+        KeyOrigin::Internal => {
+            return Err(AppError::Validation(format!(
+                "key `{key_id}` is an internal key and cannot sign did:webvh log \
+                 entries: internal keys are unrecoverable, and losing the update \
+                 key would freeze this DID permanently. Use a derived key for the \
+                 update authority; an internal key may still be a signing \
+                 verificationMethod in the document"
+            )));
+        }
         KeyOrigin::Imported => {
             let seed = load_seed_bytes(keys_ks, seed_store, None)
                 .await

--- a/vta-service/src/operations/keys.rs
+++ b/vta-service/src/operations/keys.rs
@@ -37,6 +37,14 @@ use crate::store::KeyspaceHandle;
 
 pub struct CreateKeyParams {
     pub key_type: KeyType,
+    /// Mint a **non-extractable internal key** instead of a BIP-32 derived one.
+    ///
+    /// The key is generated from the system CSPRNG, has no derivation path,
+    /// and **cannot be recovered by any means** — not from the mnemonic, not
+    /// from a backup. Losing it loses every signature it was the sole authority
+    /// for, permanently. Callers must surface that to an operator before
+    /// setting this; the CLI requires an explicit confirmation.
+    pub internal: bool,
     pub derivation_path: Option<String>,
     pub key_id: Option<String>,
     pub mnemonic: Option<String>,
@@ -51,8 +59,89 @@ pub struct ListKeysParams {
     pub context_id: Option<String>,
 }
 
+/// Mint a non-extractable internal key.
+///
+/// Split out of [`create_key`] rather than branched inline because the two
+/// share almost nothing: this path loads no seed, builds no BIP-32 root, and
+/// records no derivation path. Every one of those absences is deliberate — a
+/// derivation path would be a reconstruction route, and the origin's whole
+/// value is that none exists.
+#[allow(clippy::too_many_arguments)]
+async fn create_internal_key(
+    keys_ks: &KeyspaceHandle,
+    internal_ks: &KeyspaceHandle,
+    audit_ks: &KeyspaceHandle,
+    auth: &AuthClaims,
+    params: CreateKeyParams,
+    context_id: Option<String>,
+    channel: &str,
+) -> Result<CreateKeyResultBody, AppError> {
+    let key_id = params.key_id.clone().ok_or_else(|| {
+        AppError::Validation(
+            "an internal key needs an explicit key_id: it has no derivation path to \
+             name it after"
+                .into(),
+        )
+    })?;
+
+    if keys_ks
+        .get::<KeyRecord>(keys::store_key(&key_id))
+        .await?
+        .is_some()
+    {
+        return Err(AppError::Conflict(format!("key `{key_id}` already exists")));
+    }
+
+    let key_type = params.key_type.clone();
+    let label = params.label.clone();
+    let public = vta_keys::internal::generate(internal_ks, &key_id, key_type.clone()).await?;
+    let public_key = encode_public_multibase(&key_type, &public);
+
+    let now = Utc::now();
+    let record = KeyRecord {
+        key_id: key_id.clone(),
+        // Deliberately not a BIP-32 path. It names the origin instead, so a
+        // reader of the record cannot mistake it for something re-derivable.
+        derivation_path: "internal".to_string(),
+        key_type: key_type.clone(),
+        status: KeyStatus::Active,
+        public_key: public_key.clone(),
+        label: label.clone(),
+        context_id: context_id.clone(),
+        // No seed is involved, so there is no seed generation to pin to.
+        seed_id: None,
+        origin: keys::KeyOrigin::Internal,
+        created_at: now,
+        updated_at: now,
+    };
+    keys_ks.insert(keys::store_key(&key_id), &record).await?;
+
+    let _ = audit::record(
+        audit_ks,
+        "key.create.internal",
+        &auth.did,
+        Some(&key_id),
+        "success",
+        Some(channel),
+        context_id.as_deref(),
+    )
+    .await;
+
+    Ok(CreateKeyResultBody {
+        key_id,
+        key_type,
+        derivation_path: "internal".to_string(),
+        public_key,
+        status: KeyStatus::Active,
+        label,
+        origin: keys::KeyOrigin::Internal,
+        created_at: now,
+    })
+}
+
 pub async fn create_key(
     keys_ks: &KeyspaceHandle,
+    internal_ks: &KeyspaceHandle,
     contexts_ks: &KeyspaceHandle,
     seed_store: &Arc<dyn SeedStore>,
     audit_ks: &KeyspaceHandle,
@@ -83,6 +172,22 @@ pub async fn create_key(
             "context_id required: admin has access to multiple contexts".into(),
         ));
     };
+
+    // Internal keys short-circuit here, before any derivation-path resolution:
+    // they load no seed, build no BIP-32 root, and record no path, because each
+    // of those would be the reconstruction route the origin exists to deny.
+    if params.internal {
+        return create_internal_key(
+            keys_ks,
+            internal_ks,
+            audit_ks,
+            auth,
+            params,
+            context_id,
+            channel,
+        )
+        .await;
+    }
 
     // Resolve derivation path: use explicit value, or auto-derive from context
     let derivation_path = match params.derivation_path {
@@ -381,6 +486,20 @@ pub async fn get_key(
         .await?
         .ok_or_else(|| AppError::NotFound(format!("key {key_id} not found")))?;
 
+    // The guarantee, enforced before any authorization check so it cannot be
+    // reasoned around: an internal key is never exported, to anybody, at any
+    // role. Admin is not a bypass — the whole point of the origin is that no
+    // caller has this power, so treating it as a permission question would be
+    // the wrong shape.
+    if record.origin == KeyOrigin::Internal {
+        return Err(AppError::Forbidden(format!(
+            "key `{key_id}` is an internal key: its material is generated from the \
+             system CSPRNG, is not derived from the master seed, and is never \
+             exported by any surface. Use the signing oracle instead — and note \
+             that an internal key cannot be recovered if lost"
+        )));
+    }
+
     if let Some(ref ctx) = record.context_id {
         auth.require_context(ctx)?;
     } else if !auth.is_super_admin() {
@@ -612,7 +731,26 @@ pub async fn get_key_secret(
         ));
     }
 
+    // Internal keys are refused here too. `InternalAuthority` bypasses the ACL,
+    // not the non-extractability guarantee — an internal key has no export
+    // surface at all, and an internal caller wanting a signature must go
+    // through the signing oracle like everyone else.
+    if record.origin == KeyOrigin::Internal {
+        return Err(AppError::Forbidden(format!(
+            "key `{key_id}` is an internal key and is never exported, including \
+             under internal authority"
+        )));
+    }
+
     let (public_key_multibase, private_key_multibase) = match record.origin {
+        // Unreachable: the early return above refuses internal keys. Kept as a
+        // second, local refusal so deleting that guard cannot quietly turn this
+        // match into an export path for them.
+        KeyOrigin::Internal => {
+            return Err(AppError::Forbidden(format!(
+                "key `{key_id}` is an internal key and is never exported"
+            )));
+        }
         KeyOrigin::Imported => {
             // Decrypt from imported_secrets keyspace
             let seed = load_seed_bytes(keys_ks, &**seed_store, None)
@@ -727,6 +865,14 @@ pub async fn get_key_secret_internal(
     // possessing an `InternalAuthority` IS the gate.
 
     let (public_key_multibase, private_key_multibase) = match record.origin {
+        // Unreachable: the early return above refuses internal keys. Kept as a
+        // second, local refusal so deleting that guard cannot quietly turn this
+        // match into an export path for them.
+        KeyOrigin::Internal => {
+            return Err(AppError::Forbidden(format!(
+                "key `{key_id}` is an internal key and is never exported"
+            )));
+        }
         KeyOrigin::Imported => {
             let seed = load_seed_bytes(keys_ks, seed_store, None)
                 .await
@@ -859,6 +1005,7 @@ async fn require_key_in_caller_scope(
 pub async fn sign_payload(
     keys_ks: &KeyspaceHandle,
     imported_ks: &KeyspaceHandle,
+    internal_ks: &KeyspaceHandle,
     contexts_ks: &KeyspaceHandle,
     acl_ks: &KeyspaceHandle,
     seed_store: &Arc<dyn SeedStore>,
@@ -918,6 +1065,22 @@ pub async fn sign_payload(
     }
 
     let signature_bytes = match record.origin {
+        // The one place internal key material is used. It never leaves this
+        // call: `vta_keys::internal::sign` loads, signs, and zeroizes without
+        // returning the secret to any caller.
+        KeyOrigin::Internal => {
+            let expected = matches!(
+                (algorithm, &record.key_type),
+                (SignAlgorithm::EdDSA, KeyType::Ed25519) | (SignAlgorithm::ES256, KeyType::P256)
+            );
+            if !expected {
+                return Err(AppError::Validation(format!(
+                    "algorithm {} incompatible with key type {}",
+                    algorithm, record.key_type
+                )));
+            }
+            vta_keys::internal::sign(internal_ks, key_id, payload).await?
+        }
         KeyOrigin::Imported => {
             // Decrypt imported secret and sign
             let seed = load_seed_bytes(keys_ks, &**seed_store, None)
@@ -1251,6 +1414,7 @@ mod tests {
         contexts_ks: KeyspaceHandle,
         audit_ks: KeyspaceHandle,
         imported_ks: KeyspaceHandle,
+        internal_ks: KeyspaceHandle,
         acl_ks: KeyspaceHandle,
         seed_store: Arc<dyn SeedStore>,
         _dir: tempfile::TempDir,
@@ -1268,6 +1432,7 @@ mod tests {
             let contexts_ks = store.keyspace(crate::keyspaces::CONTEXTS).unwrap();
             let audit_ks = store.keyspace(crate::keyspaces::AUDIT).unwrap();
             let imported_ks = store.keyspace(crate::keyspaces::IMPORTED_SECRETS).unwrap();
+            let internal_ks = store.keyspace(crate::keyspaces::INTERNAL_KEYS).unwrap();
             let acl_ks = store.keyspace(crate::keyspaces::ACL).unwrap();
 
             // 32-byte seed; will be expanded to 64 bytes by BIP-32 internally
@@ -1284,6 +1449,7 @@ mod tests {
                 contexts_ks,
                 audit_ks,
                 imported_ks,
+                internal_ks,
                 acl_ks,
                 seed_store,
                 _dir: dir,
@@ -1313,11 +1479,13 @@ mod tests {
 
         let victim = create_key(
             &h.keys_ks,
+            &h.internal_ks,
             &h.contexts_ks,
             &h.seed_store,
             &h.audit_ks,
             &auth,
             CreateKeyParams {
+                internal: false,
                 key_type: KeyType::Ed25519,
                 derivation_path: None,
                 key_id: Some("victim-key".into()),
@@ -1332,11 +1500,13 @@ mod tests {
 
         let err = create_key(
             &h.keys_ks,
+            &h.internal_ks,
             &h.contexts_ks,
             &h.seed_store,
             &h.audit_ks,
             &auth,
             CreateKeyParams {
+                internal: false,
                 key_type: KeyType::Ed25519,
                 derivation_path: Some("m/26'/2'/0'/7'".into()),
                 key_id: Some("victim-key".into()),
@@ -1372,11 +1542,13 @@ mod tests {
         for bad in ["did:web:example.com#key-0", "key:sneaky", "a/b", "x y"] {
             let err = create_key(
                 &h.keys_ks,
+                &h.internal_ks,
                 &h.contexts_ks,
                 &h.seed_store,
                 &h.audit_ks,
                 &auth,
                 CreateKeyParams {
+                    internal: false,
                     key_type: KeyType::Ed25519,
                     derivation_path: None,
                     key_id: Some(bad.into()),
@@ -1461,11 +1633,13 @@ mod tests {
 
         create_key(
             &h.keys_ks,
+            &h.internal_ks,
             &h.contexts_ks,
             &h.seed_store,
             &h.audit_ks,
             &auth,
             CreateKeyParams {
+                internal: false,
                 key_type: KeyType::Ed25519,
                 derivation_path: None,
                 key_id: Some("plain-key".into()),
@@ -1526,11 +1700,13 @@ mod tests {
 
         let result = create_key(
             &h.keys_ks,
+            &h.internal_ks,
             &h.contexts_ks,
             &h.seed_store,
             &h.audit_ks,
             &auth,
             CreateKeyParams {
+                internal: false,
                 key_type: KeyType::Ed25519,
                 derivation_path: None,
                 key_id: Some("test-ed25519".into()),
@@ -1559,11 +1735,13 @@ mod tests {
 
         let result = create_key(
             &h.keys_ks,
+            &h.internal_ks,
             &h.contexts_ks,
             &h.seed_store,
             &h.audit_ks,
             &auth,
             CreateKeyParams {
+                internal: false,
                 key_type: KeyType::P256,
                 derivation_path: None,
                 key_id: Some("test-p256".into()),
@@ -1593,11 +1771,13 @@ mod tests {
         // First create a key
         let key = create_key(
             &h.keys_ks,
+            &h.internal_ks,
             &h.contexts_ks,
             &h.seed_store,
             &h.audit_ks,
             &auth,
             CreateKeyParams {
+                internal: false,
                 key_type: KeyType::Ed25519,
                 derivation_path: None,
                 key_id: Some("sign-test-key".into()),
@@ -1615,6 +1795,7 @@ mod tests {
         let result = sign_payload(
             &h.keys_ks,
             &h.imported_ks,
+            &h.internal_ks,
             &h.contexts_ks,
             &h.acl_ks,
             &h.seed_store,
@@ -1827,11 +2008,13 @@ mod tests {
 
         let key = create_key(
             &h.keys_ks,
+            &h.internal_ks,
             &h.contexts_ks,
             &h.seed_store,
             &h.audit_ks,
             &admin,
             CreateKeyParams {
+                internal: false,
                 key_type: KeyType::Ed25519,
                 derivation_path: None,
                 key_id: Some("blocked-key".into()),
@@ -1857,6 +2040,7 @@ mod tests {
         let denied = sign_payload(
             &h.keys_ks,
             &h.imported_ks,
+            &h.internal_ks,
             &h.contexts_ks,
             &h.acl_ks,
             &h.seed_store,
@@ -1877,6 +2061,7 @@ mod tests {
         let denied_admin = sign_payload(
             &h.keys_ks,
             &h.imported_ks,
+            &h.internal_ks,
             &h.contexts_ks,
             &h.acl_ks,
             &h.seed_store,
@@ -1895,11 +2080,13 @@ mod tests {
         // A key the policy *does* permit signs fine for the scoped actor.
         let allowed = create_key(
             &h.keys_ks,
+            &h.internal_ks,
             &h.contexts_ks,
             &h.seed_store,
             &h.audit_ks,
             &admin,
             CreateKeyParams {
+                internal: false,
                 key_type: KeyType::Ed25519,
                 derivation_path: None,
                 key_id: Some("allowed-key".into()),
@@ -1914,6 +2101,7 @@ mod tests {
         sign_payload(
             &h.keys_ks,
             &h.imported_ks,
+            &h.internal_ks,
             &h.contexts_ks,
             &h.acl_ks,
             &h.seed_store,
@@ -1941,11 +2129,13 @@ mod tests {
         for id in ["tenant-key-a", "tenant-key-b"] {
             create_key(
                 &h.keys_ks,
+                &h.internal_ks,
                 &h.contexts_ks,
                 &h.seed_store,
                 &h.audit_ks,
                 &admin,
                 CreateKeyParams {
+                    internal: false,
                     key_type: KeyType::Ed25519,
                     derivation_path: None,
                     key_id: Some(id.into()),
@@ -1976,6 +2166,7 @@ mod tests {
                 sign_payload(
                     &h.keys_ks,
                     &h.imported_ks,
+                    &h.internal_ks,
                     &h.contexts_ks,
                     &h.acl_ks,
                     &h.seed_store,
@@ -2068,11 +2259,13 @@ mod tests {
         .unwrap();
         let foreign = create_key(
             &h.keys_ks,
+            &h.internal_ks,
             &h.contexts_ks,
             &h.seed_store,
             &h.audit_ks,
             &admin,
             CreateKeyParams {
+                internal: false,
                 key_type: KeyType::Ed25519,
                 derivation_path: None,
                 key_id: Some("foreign-key".into()),
@@ -2108,6 +2301,7 @@ mod tests {
         let denied = sign_payload(
             &h.keys_ks,
             &h.imported_ks,
+            &h.internal_ks,
             &h.contexts_ks,
             &h.acl_ks,
             &h.seed_store,
@@ -2127,11 +2321,13 @@ mod tests {
         // filter is bound by it even where no context policy exists.
         let unscoped = create_key(
             &h.keys_ks,
+            &h.internal_ks,
             &h.contexts_ks,
             &h.seed_store,
             &h.audit_ks,
             &admin,
             CreateKeyParams {
+                internal: false,
                 key_type: KeyType::Ed25519,
                 derivation_path: Some("m/26'/2'/77'/0'".into()),
                 key_id: Some("unscoped-key".into()),
@@ -2153,6 +2349,7 @@ mod tests {
         let denied = sign_payload(
             &h.keys_ks,
             &h.imported_ks,
+            &h.internal_ks,
             &h.contexts_ks,
             &h.acl_ks,
             &h.seed_store,
@@ -2219,11 +2416,13 @@ mod tests {
 
         let key = create_key(
             &h.keys_ks,
+            &h.internal_ks,
             &h.contexts_ks,
             &h.seed_store,
             &h.audit_ks,
             &admin,
             CreateKeyParams {
+                internal: false,
                 key_type: KeyType::Ed25519,
                 derivation_path: None,
                 key_id: Some("domain-a-key".into()),
@@ -2250,6 +2449,7 @@ mod tests {
         let denied = sign_payload(
             &h.keys_ks,
             &h.imported_ks,
+            &h.internal_ks,
             &h.contexts_ks,
             &h.acl_ks,
             &h.seed_store,
@@ -2269,11 +2469,13 @@ mod tests {
         // so the refusal above is the scope check and not an unrelated failure.
         let own = create_key(
             &h.keys_ks,
+            &h.internal_ks,
             &h.contexts_ks,
             &h.seed_store,
             &h.audit_ks,
             &admin,
             CreateKeyParams {
+                internal: false,
                 key_type: KeyType::Ed25519,
                 derivation_path: None,
                 key_id: Some("domain-b-key".into()),
@@ -2288,6 +2490,7 @@ mod tests {
         sign_payload(
             &h.keys_ks,
             &h.imported_ks,
+            &h.internal_ks,
             &h.contexts_ks,
             &h.acl_ks,
             &h.seed_store,
@@ -2315,11 +2518,13 @@ mod tests {
 
         let key = create_key(
             &h.keys_ks,
+            &h.internal_ks,
             &h.contexts_ks,
             &h.seed_store,
             &h.audit_ks,
             &admin,
             CreateKeyParams {
+                internal: false,
                 key_type: KeyType::Ed25519,
                 derivation_path: Some("m/26'/2'/99'/0'".into()),
                 key_id: Some("unscoped-key".into()),
@@ -2349,6 +2554,7 @@ mod tests {
 
         let denied = sign_payload(
             &h.keys_ks,
+            &h.internal_ks,
             &h.imported_ks,
             &h.contexts_ks,
             &h.acl_ks,
@@ -2368,6 +2574,7 @@ mod tests {
         sign_payload(
             &h.keys_ks,
             &h.imported_ks,
+            &h.internal_ks,
             &h.contexts_ks,
             &h.acl_ks,
             &h.seed_store,
@@ -2393,11 +2600,13 @@ mod tests {
         // Plant a key under test-ctx so there's something to read.
         let key = create_key(
             &h.keys_ks,
+            &h.internal_ks,
             &h.contexts_ks,
             &h.seed_store,
             &h.audit_ks,
             &admin,
             CreateKeyParams {
+                internal: false,
                 key_type: KeyType::Ed25519,
                 derivation_path: None,
                 key_id: Some("monitor-floor-key".into()),
@@ -2463,5 +2672,142 @@ mod tests {
         get_key(&h.keys_ks, &reader, &key.key_id, "test")
             .await
             .expect("reader-role caller can get_key");
+    }
+    // ── internal (non-extractable) keys ──────────────────────────────
+
+    async fn mint_internal(h: &TestHarness, key_id: &str) -> CreateKeyResultBody {
+        create_key(
+            &h.keys_ks,
+            &h.internal_ks,
+            &h.contexts_ks,
+            &h.seed_store,
+            &h.audit_ks,
+            &h.super_admin_auth(),
+            CreateKeyParams {
+                internal: true,
+                key_type: KeyType::Ed25519,
+                derivation_path: None,
+                key_id: Some(key_id.to_string()),
+                mnemonic: None,
+                label: None,
+                context_id: None,
+            },
+            "test",
+        )
+        .await
+        .expect("mint internal key")
+    }
+
+    /// The guarantee, stated as a test: no export surface returns an internal
+    /// key, and admin is not a bypass — a super-admin is refused like anyone.
+    #[tokio::test]
+    async fn an_internal_key_is_never_exported_even_to_a_super_admin() {
+        let h = TestHarness::new().await;
+        mint_internal(&h, "k-internal").await;
+
+        let err = get_key_secret(
+            &h.keys_ks,
+            &h.imported_ks,
+            &h.seed_store,
+            &h.audit_ks,
+            &h.super_admin_auth(),
+            "k-internal",
+            "test",
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            matches!(&err, AppError::Forbidden(m) if m.contains("internal key")),
+            "a super-admin must still be refused; got {err:?}"
+        );
+    }
+
+    /// `InternalAuthority` bypasses the ACL, not the non-extractability
+    /// guarantee. If this ever passes, the export surface has reopened through
+    /// the back door rather than the front.
+    #[tokio::test]
+    async fn internal_authority_does_not_bypass_non_extractability() {
+        let h = TestHarness::new().await;
+        mint_internal(&h, "k-internal").await;
+
+        let err = get_key_secret_internal(
+            &h.keys_ks,
+            &h.imported_ks,
+            &*h.seed_store,
+            &h.audit_ks,
+            crate::operations::internal_authority::InternalAuthority::new("test"),
+            "k-internal",
+            "test",
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            matches!(&err, AppError::Forbidden(m) if m.contains("internal key")),
+            "{err:?}"
+        );
+    }
+
+    /// The other half: an internal key must actually be usable. A key nobody
+    /// can export *and* nobody can sign with is just a liability.
+    #[tokio::test]
+    async fn an_internal_key_signs_through_the_oracle() {
+        let h = TestHarness::new().await;
+        let created = mint_internal(&h, "k-sign").await;
+        assert_eq!(created.origin, keys::KeyOrigin::Internal);
+        assert_eq!(
+            created.derivation_path, "internal",
+            "an internal key records no BIP-32 path — there is nothing to derive"
+        );
+
+        let sig = sign_payload(
+            &h.keys_ks,
+            &h.imported_ks,
+            &h.internal_ks,
+            &h.contexts_ks,
+            &h.acl_ks,
+            &h.seed_store,
+            &h.super_admin_auth(),
+            "k-sign",
+            b"payload",
+            &SignAlgorithm::EdDSA,
+            "test",
+        )
+        .await
+        .expect("an internal key must be usable for signing");
+        assert!(!sig.signature.is_empty());
+    }
+
+    /// An internal key has no derivation path, so it cannot be named after one.
+    /// Refusing here beats minting an unrecoverable key under a generated id
+    /// the operator never chose and may not record.
+    #[tokio::test]
+    async fn an_internal_key_requires_an_explicit_key_id() {
+        let h = TestHarness::new().await;
+        let err = create_key(
+            &h.keys_ks,
+            &h.internal_ks,
+            &h.contexts_ks,
+            &h.seed_store,
+            &h.audit_ks,
+            &h.super_admin_auth(),
+            CreateKeyParams {
+                internal: true,
+                key_type: KeyType::Ed25519,
+                derivation_path: None,
+                key_id: None,
+                mnemonic: None,
+                label: None,
+                context_id: None,
+            },
+            "test",
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            matches!(&err, AppError::Validation(m) if m.contains("explicit key_id")),
+            "{err:?}"
+        );
     }
 }

--- a/vta-service/src/routes/keys.rs
+++ b/vta-service/src/routes/keys.rs
@@ -28,6 +28,11 @@ use crate::server::AppState;
 #[derive(Debug, Deserialize, utoipa::ToSchema)]
 pub struct CreateKeyRequest {
     pub key_type: KeyType,
+    /// Mint a non-extractable internal key. Absent or `false` is today's
+    /// behaviour; `true` mints a key that is never exported, never backed up,
+    /// and **cannot be recovered**.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub internal: Option<bool>,
     pub derivation_path: Option<String>,
     pub key_id: Option<String>,
     pub mnemonic: Option<String>,
@@ -53,11 +58,13 @@ pub async fn create_key(
 ) -> Result<(StatusCode, Json<CreateKeyResponseBody>), AppError> {
     let result = operations::keys::create_key(
         &state.keys_ks,
+        &state.internal_ks,
         &state.contexts_ks,
         &state.seed_store,
         &state.audit_ks,
         &auth.0,
         operations::keys::CreateKeyParams {
+            internal: req.internal.unwrap_or(false),
             key_type: req.key_type,
             derivation_path: req.derivation_path,
             key_id: req.key_id,
@@ -317,6 +324,7 @@ pub async fn sign_with_key(
     let result = operations::keys::sign_payload(
         &state.keys_ks,
         &state.imported_ks,
+        &state.internal_ks,
         &state.contexts_ks,
         &state.acl_ks,
         &state.seed_store,

--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -78,6 +78,10 @@ pub struct AppState {
     pub did_templates_ks: KeyspaceHandle,
     pub audit_ks: KeyspaceHandle,
     pub imported_ks: KeyspaceHandle,
+    /// Non-extractable internal signing keys. Separate from `imported_ks`
+    /// because that keyspace wraps under a seed-derived KEK; these must have
+    /// no path back to the mnemonic.
+    pub internal_ks: KeyspaceHandle,
     pub cache_ks: KeyspaceHandle,
     /// Vault — third-party credentials the holder has stored on this VTA.
     /// M1 reads only; upsert/delete/sync/release land in M2+. Encrypted at
@@ -301,6 +305,7 @@ pub async fn build_app_state(
     let did_templates_ks = apply_encryption(store.keyspace(crate::keyspaces::DID_TEMPLATES)?);
     let audit_ks = apply_encryption(store.keyspace(crate::keyspaces::AUDIT)?);
     let imported_ks = apply_encryption(store.keyspace(crate::keyspaces::IMPORTED_SECRETS)?);
+    let internal_ks = apply_encryption(store.keyspace(crate::keyspaces::INTERNAL_KEYS)?);
     let cache_ks = apply_encryption(store.keyspace(crate::keyspaces::CACHE)?);
     let vault_ks = apply_encryption(store.keyspace(crate::keyspaces::VAULT)?);
     // Persistent runtime state for service enable/disable. Encrypted because
@@ -381,6 +386,7 @@ pub async fn build_app_state(
         did_templates_ks,
         audit_ks,
         imported_ks,
+        internal_ks,
         cache_ks,
         vault_ks,
         service_state_ks,

--- a/vta-service/src/test_support.rs
+++ b/vta-service/src/test_support.rs
@@ -1008,6 +1008,7 @@ pub async fn build_test_app_with(opts: TestAppOptions) -> (axum::Router, TestApp
 
     let policy_ks = store.keyspace(crate::keyspaces::POLICY).unwrap();
     let state = crate::server::AppState {
+        internal_ks: store.keyspace(crate::keyspaces::INTERNAL_KEYS).unwrap(),
         // Empty by default: a test VTA trusts no mdoc issuer until one is
         // configured, matching the fail-closed production default. A test that
         // needs mdoc receive builds its own anchors and swaps this out.

--- a/vta-service/src/trust_tasks/conformance.rs
+++ b/vta-service/src/trust_tasks/conformance.rs
@@ -836,6 +836,7 @@ fn table() -> Vec<(&'static str, Conformance)> {
                 specs::keys::create::v0_1::Payload,
                 specs::keys::create::v0_1::Response,
                 to_v(CreateKeyBody {
+                    internal: None,
                     key_type: KeyType::Ed25519,
                     derivation_path: "m/26'/2'/0'/1'".into(),
                     mnemonic: None,

--- a/vta-service/src/trust_tasks/keys.rs
+++ b/vta-service/src/trust_tasks/keys.rs
@@ -69,11 +69,13 @@ pub(super) async fn handle_create(
     };
     match operations::keys::create_key(
         &state.keys_ks,
+        &state.internal_ks,
         &state.contexts_ks,
         &state.seed_store,
         &state.audit_ks,
         auth,
         operations::keys::CreateKeyParams {
+            internal: req.internal.unwrap_or(false),
             key_type: req.key_type,
             derivation_path: Some(req.derivation_path),
             // Trust-task envelope auto-generates key_id from derivation
@@ -209,6 +211,7 @@ pub(super) async fn handle_sign(
     match operations::keys::sign_payload(
         &state.keys_ks,
         &state.imported_ks,
+        &state.internal_ks,
         &state.contexts_ks,
         &state.acl_ks,
         &state.seed_store,


### PR DESCRIPTION
## Why

An ordinary VTA key is BIP-32 derived, so **anyone holding the 24-word mnemonic
can reconstruct it offline**. That is what makes the VTA recoverable — and
equally what makes *"the operator cannot obtain this key"* false, which is the
second limb of what eIDAS calls **sole control**.

An internal key is generated from the system CSPRNG, has no derivation path, and
is never returned by any surface. The VTA acts only as a signing oracle for it.

## The detail that decides whether this works

**It is deliberately not a flag on the imported-key path.** That path wraps
secrets under a KEK derived from the master seed (`derive_kek(seed, salt)`), so a
"non-extractable" flag on it would be decorative — the boundary it claims to
enforce has already been walked around, and the mnemonic still reconstructs the
key.

So internal keys get their own keyspace, `INTERNAL_KEYS`, with **no seed
involvement at any point**, and that keyspace is in `EXCLUDED_FROM_BACKUP` by
design rather than omission. A backup carrying it would be an export of keys the
VTA promises never to export, and restoring one elsewhere would silently clone a
signer.

## Refused for `did:webvh`, enforced in code

WebVH is append-only: each entry is authorised by the update key the previous
entry named. If an unrecoverable key were the update key and storage were lost,
the DID could **never be updated again by anyone**, permanently, and every
integration pinned to it would be stranded.

The distinction isn't "how important is this key" — it's **"if it vanishes, is
there a path back?"** Credentials can be re-issued. An append-only identity log
cannot. So the refusal lives in `did_webvh`, not in a doc note.

Internal keys remain fine as a **signing `verificationMethod`** in a published
document, where loss costs the ability to produce new signatures rather than
control of the identity.

## The export refusal is not a permission check

Admin is not a bypass, because the value of the origin is that *no* caller holds
this power — treating it as an authorization question would be the wrong shape.

There are two refusals: an early return and an in-match arm. I mutation-tested
both:

| mutation | result |
|---|---|
| remove the early return | in-match arm still refuses ✓ |
| remove **both** | **does not compile** — the `KeyOrigin` match becomes non-exhaustive ✓ |

That second row is the stronger guarantee: an export path cannot silently reopen,
because the type system stops you. The tests pin the *message*; exhaustiveness
pins the *existence*.

## Operator surfaces carry the cost

`pnm keys create --internal` prints exactly what is lost — mnemonic won't recover
it, excluded from backup, never exported, storage loss is permanent, and the
webvh restriction — then requires the operator to **type a confirmation phrase**
rather than mash `y`. A habitual yes/no prompt isn't proportionate to a
permanent, silent loss of signing ability. `--yes` exists for automation.

The response repeats the warning (and `CreateKeyResponse` gained `origin`, so an
API consumer sees it too). `docs/02-vta/internal-keys.md` covers when to use one,
what actually protects it — **enclave measurement + KMS, not a mnemonic** — and
the two things that genuinely destroy it: losing the KMS key, or losing sealed
storage without a replica.

It's also explicit that in **non-TEE** deployments this is meaningful hygiene
against export, not a tamper-proofing claim: an operator with disk access is
inside that boundary.

## Enforcement summary

| Surface | Internal key |
|---|---|
| `keys/sign` | **Allowed** — the only use |
| Key export | **Refused**, including super-admin |
| Internal-authority export | **Refused** |
| `backup export` | **Excluded** (keyspace not backed up) |
| `did:webvh` log signing | **Refused** |
| DID document `verificationMethod` | **Allowed** |

## Breaking changes

All 0.x; release-plz moves the compatibility fields.

- `KeyOrigin` gains `Internal`
- `CreateKeyParams` gains `internal`; wire `CreateKeyBody` / `CreateKeyRequest`
  gain an optional `internal`
- `CreateKeyResponse` gains `origin`
- `create_key` and `sign_payload` take the internal keyspace

## Testing

**3225 workspace tests pass**, `cargo check --workspace --all-targets` and
`cargo clippy --workspace --all-targets` clean (one pre-existing `backup_export`
deprecation in the e2e tests, untouched by this change).

New: 6 in `vta-keys::internal` (signature verifies under the advertised public
key; keys are independent; overwrite refused; delete is final; X25519 refused)
and 4 in `operations::keys` (no export even for super-admin; internal authority
doesn't bypass; signing works; explicit key id required).
