### PR TITLE
chore: release

### DIFF
--- a/cnm-cli/CHANGELOG.md
+++ b/cnm-cli/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
-## [0.11.22](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/cnm-cli-v0.11.21...cnm-cli-v0.11.22) — 2026-08-16
+## [0.11.22](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/cnm-cli-v0.11.21...cnm-cli-v0.11.22) — 2026-08-17
 
 
 ### Added

--- a/pnm-cli/CHANGELOG.md
+++ b/pnm-cli/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
-## [0.12.6](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/pnm-cli-v0.12.5...pnm-cli-v0.12.6) — 2026-08-16
+## [0.12.6](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/pnm-cli-v0.12.5...pnm-cli-v0.12.6) — 2026-08-17
 
 
 ### Added

--- a/vta-audit/CHANGELOG.md
+++ b/vta-audit/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
-## [0.1.6](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-audit-v0.1.5...vta-audit-v0.1.6) — 2026-08-16
+## [0.1.6](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-audit-v0.1.5...vta-audit-v0.1.6) — 2026-08-17
 
 
 ## [0.1.5](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-audit-v0.1.4...vta-audit-v0.1.5) — 2026-08-16

--- a/vta-backup/CHANGELOG.md
+++ b/vta-backup/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
-## [0.1.10](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-backup-v0.1.9...vta-backup-v0.1.10) — 2026-08-16
+## [0.1.10](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-backup-v0.1.9...vta-backup-v0.1.10) — 2026-08-17
 
 
 ## [0.1.9](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-backup-v0.1.8...vta-backup-v0.1.9) — 2026-08-16

--- a/vta-cli-common/CHANGELOG.md
+++ b/vta-cli-common/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
-## [0.11.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-cli-common-v0.10.33...vta-cli-common-v0.11.0) — 2026-08-16
+## [0.11.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-cli-common-v0.10.33...vta-cli-common-v0.11.0) — 2026-08-17
 
 
 ### Added

--- a/vta-config/CHANGELOG.md
+++ b/vta-config/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
-## [0.3.8](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-config-v0.3.7...vta-config-v0.3.8) — 2026-08-16
+## [0.3.8](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-config-v0.3.7...vta-config-v0.3.8) — 2026-08-17
 
 
 ## [0.3.7](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-config-v0.3.6...vta-config-v0.3.7) — 2026-08-16

--- a/vta-keys/CHANGELOG.md
+++ b/vta-keys/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
-## [0.2.5](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-keys-v0.2.4...vta-keys-v0.2.5) — 2026-08-16
+## [0.2.5](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-keys-v0.2.4...vta-keys-v0.2.5) — 2026-08-17
 
 
 ### Added

--- a/vta-keyspaces/CHANGELOG.md
+++ b/vta-keyspaces/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
-## [0.1.4](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-keyspaces-v0.1.3...vta-keyspaces-v0.1.4) — 2026-08-16
+## [0.1.4](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-keyspaces-v0.1.3...vta-keyspaces-v0.1.4) — 2026-08-17
 
 
 ### Added

--- a/vta-policy/CHANGELOG.md
+++ b/vta-policy/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
-## [0.2.7](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-policy-v0.2.6...vta-policy-v0.2.7) — 2026-08-16
+## [0.2.7](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-policy-v0.2.6...vta-policy-v0.2.7) — 2026-08-17
 
 
 ## [0.2.6](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-policy-v0.2.5...vta-policy-v0.2.6) — 2026-08-16

--- a/vta-sdk/CHANGELOG.md
+++ b/vta-sdk/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
-## [0.25.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-sdk-v0.24.0...vta-sdk-v0.25.0) — 2026-08-16
+## [0.25.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-sdk-v0.24.0...vta-sdk-v0.25.0) — 2026-08-17
 
 
 ### Added

--- a/vta-service/CHANGELOG.md
+++ b/vta-service/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
-## [0.17.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-service-v0.16.1...vta-service-v0.17.0) — 2026-08-16
+## [0.17.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-service-v0.16.1...vta-service-v0.17.0) — 2026-08-17
 
 
 ### Added
@@ -87,6 +87,54 @@ An ordinary VTA key is BIP-32 derived, so anyone holding the 24-word mnemonic
   base64url CBOR of a DeviceResponse, not a W3C VP object, so present_mdoc sits
   beside it. Selective disclosure is by omission — only the [namespace, element]
   paths the query asked for are included.
+
+
+
+### Chore
+
+- **deps**: Track trust-tasks 0.9 across the workspace ([#996](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/996))
+
+Moves all five `trust-tasks-*` requirements and `trust-tasks-capability-client`
+  (0.5 -> 0.8) together, as the family requires: `trust-tasks-rs`'s core types
+  cross the public API of `-https` / `-didcomm` / `-proof`, so a graph mixing
+  majors does not type-check. Takes the `affinidi-messaging-*` releases built on
+  0.9 (sdk 0.19.8, mediator 0.18.18, didcomm-service 0.3.26, test-mediator 0.2.51)
+  in the same move, so the lockfile carries exactly one copy of everything.
+
+  There are no `consume_inbound` call sites in this workspace, so 0.9.0's new
+  `PayloadPolicy` argument costs nothing here, and nothing matches on
+  `StandardCode`, so 0.7.0's `#[non_exhaustive]` costs nothing either. The
+  `validate` feature stays enabled and unused, as before.
+
+  What did change is the wire version of the error documents this stack emits.
+
+  `trust-task-error` moved 0.3 -> 0.4 -> 0.5 upstream, each step for the same
+  reason the 0.3 step happened: a new standard code that the older payload
+  schema's `code` enum does not list and whose extended-code pattern does not
+  match, so a document carrying it would not validate as the older version. 0.4
+  carries `idConflict`, 0.5 carries `cancelled` (SPEC §8.3).
+
+  Both services hand-write that version on their one unrouted path — where there
+  is no request document to reject from, and so no framework call to ask —
+  and both were left naming 0.3 while `reject_with` stamped 0.5 on every routed
+  rejection. One service emitting two versions is a trap for exactly the consumer
+  that pins one of them. `unrouted_and_routed_errors_agree_on_the_type_uri` exists
+  in both services to catch precisely this, and it did: the bump failed those two
+  tests rather than shipping two dialects. Constants updated, rationale extended.
+
+  Two in-`src` VTC test fixtures that also named 0.3 now take the version from
+  `framework_error_type_uri()` instead of repeating it, so they follow the emitter
+  on the next bump rather than stranding a version behind. That also keeps
+  `trust_task_manifest`'s unpublished-URI census at one URI for the family; the
+  census is deliberately exact so the debt can shrink but never grow unnoticed,
+  and raising the expected count would have been the wrong fix.
+
+  Backward acceptance of an *older* error document keeps its coverage:
+  `vtc-service/tests/registry_didcomm.rs` pins 0.1 on purpose, and is left alone.
+
+  Per SPEC §5.2 forward-minor compatibility, a consumer still pinned to
+  `trust-task-error/0.3` SHOULD accept 0.5. Marked `!` because this changes the
+  version on the wire, not because any Rust signature moved.
 
 
 

--- a/vta-support/CHANGELOG.md
+++ b/vta-support/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
-## [0.2.7](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-support-v0.2.6...vta-support-v0.2.7) — 2026-08-16
+## [0.2.7](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-support-v0.2.6...vta-support-v0.2.7) — 2026-08-17
 
 
 ## [0.2.6](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-support-v0.2.5...vta-support-v0.2.6) — 2026-08-16

--- a/vta-sweepers/CHANGELOG.md
+++ b/vta-sweepers/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
-## [0.1.3](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-sweepers-v0.1.2...vta-sweepers-v0.1.3) — 2026-08-16
+## [0.1.3](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-sweepers-v0.1.2...vta-sweepers-v0.1.3) — 2026-08-17
 
 
 ## [0.1.2](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-sweepers-v0.1.1...vta-sweepers-v0.1.2) — 2026-08-16

--- a/vta-vault/CHANGELOG.md
+++ b/vta-vault/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
-## [0.3.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-vault-v0.2.0...vta-vault-v0.3.0) — 2026-08-16
+## [0.3.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-vault-v0.2.0...vta-vault-v0.3.0) — 2026-08-17
 
 
 ### Added

--- a/vta-webvh/CHANGELOG.md
+++ b/vta-webvh/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
-## [0.1.9](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-webvh-v0.1.8...vta-webvh-v0.1.9) — 2026-08-16
+## [0.1.9](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-webvh-v0.1.8...vta-webvh-v0.1.9) — 2026-08-17
 
 
 ## [0.1.8](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-webvh-v0.1.7...vta-webvh-v0.1.8) — 2026-08-16

--- a/vtc-client/CHANGELOG.md
+++ b/vtc-client/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
-## [0.3.7](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vtc-client-v0.3.6...vtc-client-v0.3.7) — 2026-08-16
+## [0.3.7](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vtc-client-v0.3.6...vtc-client-v0.3.7) — 2026-08-17
 
 
 ## [0.3.6](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vtc-client-v0.3.5...vtc-client-v0.3.6) — 2026-08-16

--- a/vti-common/CHANGELOG.md
+++ b/vti-common/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
-## [0.12.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-common-v0.12.0...vti-common-v0.12.1) — 2026-08-16
+## [0.12.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-common-v0.12.0...vti-common-v0.12.1) — 2026-08-17
 
 
 ## [0.12.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-common-v0.11.41...vti-common-v0.12.0) — 2026-08-16

--- a/vti-secrets/CHANGELOG.md
+++ b/vti-secrets/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
-## [0.1.14](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-secrets-v0.1.13...vti-secrets-v0.1.14) — 2026-08-16
+## [0.1.14](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-secrets-v0.1.13...vti-secrets-v0.1.14) — 2026-08-17
 
 
 ## [0.1.13](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-secrets-v0.1.12...vti-secrets-v0.1.13) — 2026-08-16


### PR DESCRIPTION



## 🤖 New release

* `vta-sdk`: 0.24.0 -> 0.25.0 (⚠ API breaking changes)
* `vti-common`: 0.12.0 -> 0.12.1 (✓ API compatible changes)
* `vta-cli-common`: 0.10.33 -> 0.11.0 (⚠ API breaking changes)
* `cnm-cli`: 0.11.21 -> 0.11.22
* `pnm-cli`: 0.12.5 -> 0.12.6
* `vta-keyspaces`: 0.1.3 -> 0.1.4
* `vta-keys`: 0.2.4 -> 0.2.5
* `vta-vault`: 0.2.0 -> 0.3.0
* `vta-service`: 0.16.1 -> 0.17.0 (✓ API compatible changes)
* `vtc-client`: 0.3.6 -> 0.3.7 (✓ API compatible changes)
* `vta-audit`: 0.1.5 -> 0.1.6
* `vti-secrets`: 0.1.13 -> 0.1.14
* `vta-config`: 0.3.7 -> 0.3.8
* `vta-support`: 0.2.6 -> 0.2.7
* `vta-backup`: 0.1.9 -> 0.1.10
* `vta-policy`: 0.2.6 -> 0.2.7
* `vta-sweepers`: 0.1.2 -> 0.1.3
* `vta-webvh`: 0.1.8 -> 0.1.9

### ⚠ `vta-sdk` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field CreateKeyBody.internal in /tmp/.tmpiXc5Xr/verifiable-trust-infrastructure/vta-sdk/src/protocols/key_management/create.rs:29
  field CreateKeyRequest.internal in /tmp/.tmpiXc5Xr/verifiable-trust-infrastructure/vta-sdk/src/client/types.rs:83
  field CreateKeyRequest.internal in /tmp/.tmpiXc5Xr/verifiable-trust-infrastructure/vta-sdk/src/client/types.rs:83
  field QueryBody.oid4vp_session in /tmp/.tmpiXc5Xr/verifiable-trust-infrastructure/vta-sdk/src/protocols/credential_exchange.rs:116
  field CreateKeyResponse.origin in /tmp/.tmpiXc5Xr/verifiable-trust-infrastructure/vta-sdk/src/client/types.rs:259
  field CreateKeyResponse.origin in /tmp/.tmpiXc5Xr/verifiable-trust-infrastructure/vta-sdk/src/client/types.rs:259

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant KeyOrigin:Internal in /tmp/.tmpiXc5Xr/verifiable-trust-infrastructure/vta-sdk/src/keys/mod.rs:44
```

### ⚠ `vta-cli-common` breaking changes

```text
--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/function_parameter_count_changed.ron

Failed in:
  vta_cli_common::commands::keys::cmd_key_create now takes 8 parameters instead of 6, in /tmp/.tmpiXc5Xr/verifiable-trust-infrastructure/vta-cli-common/src/commands/keys.rs:12
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `vta-sdk`

<blockquote>

## [0.25.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-sdk-v0.24.0...vta-sdk-v0.25.0) — 2026-08-17

### Added

- **vta-keys**: Add non-extractable internal signing keys ([#995](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/995))

An ordinary VTA key is BIP-32 derived, so anyone holding the 24-word mnemonic
  can reconstruct it offline. That is what makes the VTA recoverable, and equally
  what makes "the operator cannot obtain this key" false — the second limb of what
  eIDAS calls sole control.

  An internal key is generated from the system CSPRNG, has no derivation path, and
  is never returned by any surface. The VTA acts only as a signing oracle for it.

  Deliberately not a flag on the imported-key path. That path wraps its secrets
  under a KEK derived from the master seed (derive_kek(seed, salt)), so a
  non-extractable flag on it would be decorative: the boundary it claims to
  enforce has already been walked around. Internal keys get their own keyspace,
  INTERNAL_KEYS, with no seed involvement at any point, and that keyspace is in
  EXCLUDED_FROM_BACKUP by design — a backup carrying it would be an export of keys
  the VTA promises never to export, and restoring it elsewhere would clone a
  signer.

  Refused for did:webvh log entries, enforced in code rather than left to
  guidance. WebVH is append-only and each entry is authorised by the update key
  the previous entry named; an unrecoverable update key means that if storage is
  lost the DID can never be updated again by anyone, permanently, and every
  integration pinned to it is stranded. Credentials can be re-issued, an
  append-only identity log cannot. Internal keys remain fine as a signing
  verificationMethod inside a published document, where loss costs the ability to
  produce new signatures rather than control of the identity.

  The export refusal is not a permission check — admin is not a bypass, because
  the value of the origin is that no caller holds this power. There are two
  refusals (an early return and an in-match arm); removing either leaves the other,
  and removing both does not compile, since the match over KeyOrigin becomes
  non-exhaustive. An export path cannot silently reopen.

  Operator surfaces carry the cost prominently: `pnm keys create --internal`
  prints what is lost and requires the operator to type a confirmation phrase
  rather than mash y, the response repeats the warning, and docs/02-vta/
  internal-keys.md covers when to use one, what actually protects it (enclave
  measurement + KMS, not a mnemonic), and the two things that genuinely destroy
  it.

- **vta-service**: Present ISO mdoc credentials over OID4VP ([#993](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/993))

* feat(vta-service)!: present ISO mdoc credentials over OID4VP

  Completes mdoc support. A VTA could receive, verify and store an mdoc; it could
  not present one. This is the last piece, and it needed three things the other
  formats do not.

  An OID4VP session on the query wire. An mdoc's holder binding is a DeviceAuth
  signature over an ISO 18013-7 SessionTranscript, whose handover is
  [clientId, responseUri, nonce, mdocGeneratedNonce]. Two of those exist only in
  an OID4VP exchange, so a verifier that wants an mdoc supplies them; QueryBody
  gains an optional oid4vp_session carrying OID4VP's own field names, so a
  verifier can copy them out of its authorization request unrenamed.

  Absent, an mdoc is not offered at all rather than offered unbound. A DeviceAuth
  over invented handover values verifies nowhere and, worse, looks bound. The gate
  lives in match_held so matchable and presentable stay the same set: a
  matched-but-unpresentable credential bails the entire vp_token, not just itself,
  taking every other credential the verifier legitimately asked for with it. A
  mutation removing the gate fails the test that pins this.

  Holder identity that is key-shaped. ConsentGrant.holder_did becomes
  HolderIdentity::{Subject, DeviceKey}: every other format names a subject DID,
  while an mdoc names a device key discovered at receive. Both resolve to a
  did:key because ConsentRecord::verify_proof binds the proof's
  verificationMethod to the data subject — the variant records provenance that
  would otherwise be silently lost, not a different kind of value.

  A P-256 consent receipt. The device key signs its own receipt under
  ecdsa-jcs-2019 (affinidi-data-integrity 0.7.10), where every other format uses
  eddsa-jcs-2022. Signing the receipt with some other key would break the
  verificationMethod binding above; that is why the cryptosuite was added upstream
  rather than worked around here.

  Presentation itself is not a present_single arm: an mdoc vp_token entry is
  base64url CBOR of a DeviceResponse, not a W3C VP object, so present_mdoc sits
  beside it. Selective disclosure is by omission — only the [namespace, element]
  paths the query asked for are included.
</blockquote>


## `vta-cli-common`

<blockquote>

## [0.11.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-cli-common-v0.10.33...vta-cli-common-v0.11.0) — 2026-08-17

### Added

- **vta-keys**: Add non-extractable internal signing keys ([#995](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/995))

An ordinary VTA key is BIP-32 derived, so anyone holding the 24-word mnemonic
  can reconstruct it offline. That is what makes the VTA recoverable, and equally
  what makes "the operator cannot obtain this key" false — the second limb of what
  eIDAS calls sole control.

  An internal key is generated from the system CSPRNG, has no derivation path, and
  is never returned by any surface. The VTA acts only as a signing oracle for it.

  Deliberately not a flag on the imported-key path. That path wraps its secrets
  under a KEK derived from the master seed (derive_kek(seed, salt)), so a
  non-extractable flag on it would be decorative: the boundary it claims to
  enforce has already been walked around. Internal keys get their own keyspace,
  INTERNAL_KEYS, with no seed involvement at any point, and that keyspace is in
  EXCLUDED_FROM_BACKUP by design — a backup carrying it would be an export of keys
  the VTA promises never to export, and restoring it elsewhere would clone a
  signer.

  Refused for did:webvh log entries, enforced in code rather than left to
  guidance. WebVH is append-only and each entry is authorised by the update key
  the previous entry named; an unrecoverable update key means that if storage is
  lost the DID can never be updated again by anyone, permanently, and every
  integration pinned to it is stranded. Credentials can be re-issued, an
  append-only identity log cannot. Internal keys remain fine as a signing
  verificationMethod inside a published document, where loss costs the ability to
  produce new signatures rather than control of the identity.

  The export refusal is not a permission check — admin is not a bypass, because
  the value of the origin is that no caller holds this power. There are two
  refusals (an early return and an in-match arm); removing either leaves the other,
  and removing both does not compile, since the match over KeyOrigin becomes
  non-exhaustive. An export path cannot silently reopen.

  Operator surfaces carry the cost prominently: `pnm keys create --internal`
  prints what is lost and requires the operator to type a confirmation phrase
  rather than mash y, the response repeats the warning, and docs/02-vta/
  internal-keys.md covers when to use one, what actually protects it (enclave
  measurement + KMS, not a mnemonic), and the two things that genuinely destroy
  it.
</blockquote>

## `cnm-cli`

<blockquote>

## [0.11.22](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/cnm-cli-v0.11.21...cnm-cli-v0.11.22) — 2026-08-17

### Added

- **vta-keys**: Add non-extractable internal signing keys ([#995](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/995))

An ordinary VTA key is BIP-32 derived, so anyone holding the 24-word mnemonic
  can reconstruct it offline. That is what makes the VTA recoverable, and equally
  what makes "the operator cannot obtain this key" false — the second limb of what
  eIDAS calls sole control.

  An internal key is generated from the system CSPRNG, has no derivation path, and
  is never returned by any surface. The VTA acts only as a signing oracle for it.

  Deliberately not a flag on the imported-key path. That path wraps its secrets
  under a KEK derived from the master seed (derive_kek(seed, salt)), so a
  non-extractable flag on it would be decorative: the boundary it claims to
  enforce has already been walked around. Internal keys get their own keyspace,
  INTERNAL_KEYS, with no seed involvement at any point, and that keyspace is in
  EXCLUDED_FROM_BACKUP by design — a backup carrying it would be an export of keys
  the VTA promises never to export, and restoring it elsewhere would clone a
  signer.

  Refused for did:webvh log entries, enforced in code rather than left to
  guidance. WebVH is append-only and each entry is authorised by the update key
  the previous entry named; an unrecoverable update key means that if storage is
  lost the DID can never be updated again by anyone, permanently, and every
  integration pinned to it is stranded. Credentials can be re-issued, an
  append-only identity log cannot. Internal keys remain fine as a signing
  verificationMethod inside a published document, where loss costs the ability to
  produce new signatures rather than control of the identity.

  The export refusal is not a permission check — admin is not a bypass, because
  the value of the origin is that no caller holds this power. There are two
  refusals (an early return and an in-match arm); removing either leaves the other,
  and removing both does not compile, since the match over KeyOrigin becomes
  non-exhaustive. An export path cannot silently reopen.

  Operator surfaces carry the cost prominently: `pnm keys create --internal`
  prints what is lost and requires the operator to type a confirmation phrase
  rather than mash y, the response repeats the warning, and docs/02-vta/
  internal-keys.md covers when to use one, what actually protects it (enclave
  measurement + KMS, not a mnemonic), and the two things that genuinely destroy
  it.
</blockquote>

## `pnm-cli`

<blockquote>

## [0.12.6](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/pnm-cli-v0.12.5...pnm-cli-v0.12.6) — 2026-08-17

### Added

- **vta-keys**: Add non-extractable internal signing keys ([#995](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/995))

An ordinary VTA key is BIP-32 derived, so anyone holding the 24-word mnemonic
  can reconstruct it offline. That is what makes the VTA recoverable, and equally
  what makes "the operator cannot obtain this key" false — the second limb of what
  eIDAS calls sole control.

  An internal key is generated from the system CSPRNG, has no derivation path, and
  is never returned by any surface. The VTA acts only as a signing oracle for it.

  Deliberately not a flag on the imported-key path. That path wraps its secrets
  under a KEK derived from the master seed (derive_kek(seed, salt)), so a
  non-extractable flag on it would be decorative: the boundary it claims to
  enforce has already been walked around. Internal keys get their own keyspace,
  INTERNAL_KEYS, with no seed involvement at any point, and that keyspace is in
  EXCLUDED_FROM_BACKUP by design — a backup carrying it would be an export of keys
  the VTA promises never to export, and restoring it elsewhere would clone a
  signer.

  Refused for did:webvh log entries, enforced in code rather than left to
  guidance. WebVH is append-only and each entry is authorised by the update key
  the previous entry named; an unrecoverable update key means that if storage is
  lost the DID can never be updated again by anyone, permanently, and every
  integration pinned to it is stranded. Credentials can be re-issued, an
  append-only identity log cannot. Internal keys remain fine as a signing
  verificationMethod inside a published document, where loss costs the ability to
  produce new signatures rather than control of the identity.

  The export refusal is not a permission check — admin is not a bypass, because
  the value of the origin is that no caller holds this power. There are two
  refusals (an early return and an in-match arm); removing either leaves the other,
  and removing both does not compile, since the match over KeyOrigin becomes
  non-exhaustive. An export path cannot silently reopen.

  Operator surfaces carry the cost prominently: `pnm keys create --internal`
  prints what is lost and requires the operator to type a confirmation phrase
  rather than mash y, the response repeats the warning, and docs/02-vta/
  internal-keys.md covers when to use one, what actually protects it (enclave
  measurement + KMS, not a mnemonic), and the two things that genuinely destroy
  it.
</blockquote>

## `vta-keyspaces`

<blockquote>

## [0.1.4](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-keyspaces-v0.1.3...vta-keyspaces-v0.1.4) — 2026-08-17

### Added

- **vta-keys**: Add non-extractable internal signing keys ([#995](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/995))

An ordinary VTA key is BIP-32 derived, so anyone holding the 24-word mnemonic
  can reconstruct it offline. That is what makes the VTA recoverable, and equally
  what makes "the operator cannot obtain this key" false — the second limb of what
  eIDAS calls sole control.

  An internal key is generated from the system CSPRNG, has no derivation path, and
  is never returned by any surface. The VTA acts only as a signing oracle for it.

  Deliberately not a flag on the imported-key path. That path wraps its secrets
  under a KEK derived from the master seed (derive_kek(seed, salt)), so a
  non-extractable flag on it would be decorative: the boundary it claims to
  enforce has already been walked around. Internal keys get their own keyspace,
  INTERNAL_KEYS, with no seed involvement at any point, and that keyspace is in
  EXCLUDED_FROM_BACKUP by design — a backup carrying it would be an export of keys
  the VTA promises never to export, and restoring it elsewhere would clone a
  signer.

  Refused for did:webvh log entries, enforced in code rather than left to
  guidance. WebVH is append-only and each entry is authorised by the update key
  the previous entry named; an unrecoverable update key means that if storage is
  lost the DID can never be updated again by anyone, permanently, and every
  integration pinned to it is stranded. Credentials can be re-issued, an
  append-only identity log cannot. Internal keys remain fine as a signing
  verificationMethod inside a published document, where loss costs the ability to
  produce new signatures rather than control of the identity.

  The export refusal is not a permission check — admin is not a bypass, because
  the value of the origin is that no caller holds this power. There are two
  refusals (an early return and an in-match arm); removing either leaves the other,
  and removing both does not compile, since the match over KeyOrigin becomes
  non-exhaustive. An export path cannot silently reopen.

  Operator surfaces carry the cost prominently: `pnm keys create --internal`
  prints what is lost and requires the operator to type a confirmation phrase
  rather than mash y, the response repeats the warning, and docs/02-vta/
  internal-keys.md covers when to use one, what actually protects it (enclave
  measurement + KMS, not a mnemonic), and the two things that genuinely destroy
  it.
</blockquote>

## `vta-keys`

<blockquote>

## [0.2.5](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-keys-v0.2.4...vta-keys-v0.2.5) — 2026-08-17

### Added

- **vta-keys**: Add non-extractable internal signing keys ([#995](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/995))

An ordinary VTA key is BIP-32 derived, so anyone holding the 24-word mnemonic
  can reconstruct it offline. That is what makes the VTA recoverable, and equally
  what makes "the operator cannot obtain this key" false — the second limb of what
  eIDAS calls sole control.

  An internal key is generated from the system CSPRNG, has no derivation path, and
  is never returned by any surface. The VTA acts only as a signing oracle for it.

  Deliberately not a flag on the imported-key path. That path wraps its secrets
  under a KEK derived from the master seed (derive_kek(seed, salt)), so a
  non-extractable flag on it would be decorative: the boundary it claims to
  enforce has already been walked around. Internal keys get their own keyspace,
  INTERNAL_KEYS, with no seed involvement at any point, and that keyspace is in
  EXCLUDED_FROM_BACKUP by design — a backup carrying it would be an export of keys
  the VTA promises never to export, and restoring it elsewhere would clone a
  signer.

  Refused for did:webvh log entries, enforced in code rather than left to
  guidance. WebVH is append-only and each entry is authorised by the update key
  the previous entry named; an unrecoverable update key means that if storage is
  lost the DID can never be updated again by anyone, permanently, and every
  integration pinned to it is stranded. Credentials can be re-issued, an
  append-only identity log cannot. Internal keys remain fine as a signing
  verificationMethod inside a published document, where loss costs the ability to
  produce new signatures rather than control of the identity.

  The export refusal is not a permission check — admin is not a bypass, because
  the value of the origin is that no caller holds this power. There are two
  refusals (an early return and an in-match arm); removing either leaves the other,
  and removing both does not compile, since the match over KeyOrigin becomes
  non-exhaustive. An export path cannot silently reopen.

  Operator surfaces carry the cost prominently: `pnm keys create --internal`
  prints what is lost and requires the operator to type a confirmation phrase
  rather than mash y, the response repeats the warning, and docs/02-vta/
  internal-keys.md covers when to use one, what actually protects it (enclave
  measurement + KMS, not a mnemonic), and the two things that genuinely destroy
  it.
</blockquote>

## `vta-vault`

<blockquote>

## [0.3.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-vault-v0.2.0...vta-vault-v0.3.0) — 2026-08-17

### Added

- **vta-service**: Present ISO mdoc credentials over OID4VP ([#993](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/993))

* feat(vta-service)!: present ISO mdoc credentials over OID4VP

  Completes mdoc support. A VTA could receive, verify and store an mdoc; it could
  not present one. This is the last piece, and it needed three things the other
  formats do not.

  An OID4VP session on the query wire. An mdoc's holder binding is a DeviceAuth
  signature over an ISO 18013-7 SessionTranscript, whose handover is
  [clientId, responseUri, nonce, mdocGeneratedNonce]. Two of those exist only in
  an OID4VP exchange, so a verifier that wants an mdoc supplies them; QueryBody
  gains an optional oid4vp_session carrying OID4VP's own field names, so a
  verifier can copy them out of its authorization request unrenamed.

  Absent, an mdoc is not offered at all rather than offered unbound. A DeviceAuth
  over invented handover values verifies nowhere and, worse, looks bound. The gate
  lives in match_held so matchable and presentable stay the same set: a
  matched-but-unpresentable credential bails the entire vp_token, not just itself,
  taking every other credential the verifier legitimately asked for with it. A
  mutation removing the gate fails the test that pins this.

  Holder identity that is key-shaped. ConsentGrant.holder_did becomes
  HolderIdentity::{Subject, DeviceKey}: every other format names a subject DID,
  while an mdoc names a device key discovered at receive. Both resolve to a
  did:key because ConsentRecord::verify_proof binds the proof's
  verificationMethod to the data subject — the variant records provenance that
  would otherwise be silently lost, not a different kind of value.

  A P-256 consent receipt. The device key signs its own receipt under
  ecdsa-jcs-2019 (affinidi-data-integrity 0.7.10), where every other format uses
  eddsa-jcs-2022. Signing the receipt with some other key would break the
  verificationMethod binding above; that is why the cryptosuite was added upstream
  rather than worked around here.

  Presentation itself is not a present_single arm: an mdoc vp_token entry is
  base64url CBOR of a DeviceResponse, not a W3C VP object, so present_mdoc sits
  beside it. Selective disclosure is by omission — only the [namespace, element]
  paths the query asked for are included.
</blockquote>

## `vta-service`

<blockquote>

## [0.17.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-service-v0.16.1...vta-service-v0.17.0) — 2026-08-17

### Added

- **vta-keys**: Add non-extractable internal signing keys ([#995](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/995))

An ordinary VTA key is BIP-32 derived, so anyone holding the 24-word mnemonic
  can reconstruct it offline. That is what makes the VTA recoverable, and equally
  what makes "the operator cannot obtain this key" false — the second limb of what
  eIDAS calls sole control.

  An internal key is generated from the system CSPRNG, has no derivation path, and
  is never returned by any surface. The VTA acts only as a signing oracle for it.

  Deliberately not a flag on the imported-key path. That path wraps its secrets
  under a KEK derived from the master seed (derive_kek(seed, salt)), so a
  non-extractable flag on it would be decorative: the boundary it claims to
  enforce has already been walked around. Internal keys get their own keyspace,
  INTERNAL_KEYS, with no seed involvement at any point, and that keyspace is in
  EXCLUDED_FROM_BACKUP by design — a backup carrying it would be an export of keys
  the VTA promises never to export, and restoring it elsewhere would clone a
  signer.

  Refused for did:webvh log entries, enforced in code rather than left to
  guidance. WebVH is append-only and each entry is authorised by the update key
  the previous entry named; an unrecoverable update key means that if storage is
  lost the DID can never be updated again by anyone, permanently, and every
  integration pinned to it is stranded. Credentials can be re-issued, an
  append-only identity log cannot. Internal keys remain fine as a signing
  verificationMethod inside a published document, where loss costs the ability to
  produce new signatures rather than control of the identity.

  The export refusal is not a permission check — admin is not a bypass, because
  the value of the origin is that no caller holds this power. There are two
  refusals (an early return and an in-match arm); removing either leaves the other,
  and removing both does not compile, since the match over KeyOrigin becomes
  non-exhaustive. An export path cannot silently reopen.

  Operator surfaces carry the cost prominently: `pnm keys create --internal`
  prints what is lost and requires the operator to type a confirmation phrase
  rather than mash y, the response repeats the warning, and docs/02-vta/
  internal-keys.md covers when to use one, what actually protects it (enclave
  measurement + KMS, not a mnemonic), and the two things that genuinely destroy
  it.

- **vta-service**: Present ISO mdoc credentials over OID4VP ([#993](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/993))

* feat(vta-service)!: present ISO mdoc credentials over OID4VP

  Completes mdoc support. A VTA could receive, verify and store an mdoc; it could
  not present one. This is the last piece, and it needed three things the other
  formats do not.

  An OID4VP session on the query wire. An mdoc's holder binding is a DeviceAuth
  signature over an ISO 18013-7 SessionTranscript, whose handover is
  [clientId, responseUri, nonce, mdocGeneratedNonce]. Two of those exist only in
  an OID4VP exchange, so a verifier that wants an mdoc supplies them; QueryBody
  gains an optional oid4vp_session carrying OID4VP's own field names, so a
  verifier can copy them out of its authorization request unrenamed.

  Absent, an mdoc is not offered at all rather than offered unbound. A DeviceAuth
  over invented handover values verifies nowhere and, worse, looks bound. The gate
  lives in match_held so matchable and presentable stay the same set: a
  matched-but-unpresentable credential bails the entire vp_token, not just itself,
  taking every other credential the verifier legitimately asked for with it. A
  mutation removing the gate fails the test that pins this.

  Holder identity that is key-shaped. ConsentGrant.holder_did becomes
  HolderIdentity::{Subject, DeviceKey}: every other format names a subject DID,
  while an mdoc names a device key discovered at receive. Both resolve to a
  did:key because ConsentRecord::verify_proof binds the proof's
  verificationMethod to the data subject — the variant records provenance that
  would otherwise be silently lost, not a different kind of value.

  A P-256 consent receipt. The device key signs its own receipt under
  ecdsa-jcs-2019 (affinidi-data-integrity 0.7.10), where every other format uses
  eddsa-jcs-2022. Signing the receipt with some other key would break the
  verificationMethod binding above; that is why the cryptosuite was added upstream
  rather than worked around here.

  Presentation itself is not a present_single arm: an mdoc vp_token entry is
  base64url CBOR of a DeviceResponse, not a W3C VP object, so present_mdoc sits
  beside it. Selective disclosure is by omission — only the [namespace, element]
  paths the query asked for are included.



### Chore

- **deps**: Track trust-tasks 0.9 across the workspace ([#996](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/996))

Moves all five `trust-tasks-*` requirements and `trust-tasks-capability-client`
  (0.5 -> 0.8) together, as the family requires: `trust-tasks-rs`'s core types
  cross the public API of `-https` / `-didcomm` / `-proof`, so a graph mixing
  majors does not type-check. Takes the `affinidi-messaging-*` releases built on
  0.9 (sdk 0.19.8, mediator 0.18.18, didcomm-service 0.3.26, test-mediator 0.2.51)
  in the same move, so the lockfile carries exactly one copy of everything.

  There are no `consume_inbound` call sites in this workspace, so 0.9.0's new
  `PayloadPolicy` argument costs nothing here, and nothing matches on
  `StandardCode`, so 0.7.0's `#[non_exhaustive]` costs nothing either. The
  `validate` feature stays enabled and unused, as before.

  What did change is the wire version of the error documents this stack emits.

  `trust-task-error` moved 0.3 -> 0.4 -> 0.5 upstream, each step for the same
  reason the 0.3 step happened: a new standard code that the older payload
  schema's `code` enum does not list and whose extended-code pattern does not
  match, so a document carrying it would not validate as the older version. 0.4
  carries `idConflict`, 0.5 carries `cancelled` (SPEC §8.3).

  Both services hand-write that version on their one unrouted path — where there
  is no request document to reject from, and so no framework call to ask —
  and both were left naming 0.3 while `reject_with` stamped 0.5 on every routed
  rejection. One service emitting two versions is a trap for exactly the consumer
  that pins one of them. `unrouted_and_routed_errors_agree_on_the_type_uri` exists
  in both services to catch precisely this, and it did: the bump failed those two
  tests rather than shipping two dialects. Constants updated, rationale extended.

  Two in-`src` VTC test fixtures that also named 0.3 now take the version from
  `framework_error_type_uri()` instead of repeating it, so they follow the emitter
  on the next bump rather than stranding a version behind. That also keeps
  `trust_task_manifest`'s unpublished-URI census at one URI for the family; the
  census is deliberately exact so the debt can shrink but never grow unnoticed,
  and raising the expected count would have been the wrong fix.

  Backward acceptance of an *older* error document keeps its coverage:
  `vtc-service/tests/registry_didcomm.rs` pins 0.1 on purpose, and is left alone.

  Per SPEC §5.2 forward-minor compatibility, a consumer still pinned to
  `trust-task-error/0.3` SHOULD accept 0.5. Marked `!` because this changes the
  version on the wire, not because any Rust signature moved.
</blockquote>











</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).