### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2424,7 +2424,7 @@ checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cnm-cli"
-version = "0.11.22"
+version = "0.11.23"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "clap",
@@ -6295,7 +6295,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "pnm-cli"
-version = "0.12.6"
+version = "0.12.7"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-resolver-cache-sdk",
@@ -9222,7 +9222,7 @@ dependencies = [
 
 [[package]]
 name = "vta-audit"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "tracing",
  "uuid",
@@ -9232,7 +9232,7 @@ dependencies = [
 
 [[package]]
 name = "vta-backup"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -9261,7 +9261,7 @@ dependencies = [
 
 [[package]]
 name = "vta-cli-common"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "aes-gcm",
  "affinidi-crypto",
@@ -9286,7 +9286,7 @@ dependencies = [
 
 [[package]]
 name = "vta-config"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "serde",
  "serde_ignored",
@@ -9319,7 +9319,7 @@ dependencies = [
 
 [[package]]
 name = "vta-keys"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "aes-gcm",
  "affinidi-crypto",
@@ -9352,7 +9352,7 @@ dependencies = [
 
 [[package]]
 name = "vta-keyspaces"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "vti-common",
 ]
@@ -9402,7 +9402,7 @@ dependencies = [
 
 [[package]]
 name = "vta-policy"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "hex",
  "multibase",
@@ -9422,7 +9422,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -9485,7 +9485,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",
@@ -9588,7 +9588,7 @@ dependencies = [
 
 [[package]]
 name = "vta-support"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "chrono",
  "ed25519-dalek",
@@ -9608,7 +9608,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sweepers"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "chrono",
  "serde_json",
@@ -9658,7 +9658,7 @@ dependencies = [
 
 [[package]]
 name = "vta-vault"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -9692,7 +9692,7 @@ dependencies = [
 
 [[package]]
 name = "vta-webvh"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "affinidi-tdk",
  "chrono",
@@ -9713,7 +9713,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-client"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "chrono",
  "reqwest",
@@ -9810,7 +9810,7 @@ dependencies = [
 
 [[package]]
 name = "vti-common"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "aes-gcm",
  "affinidi-data-integrity",
@@ -9884,7 +9884,7 @@ dependencies = [
 
 [[package]]
 name = "vti-secrets"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "aws-config",
  "aws-sdk-secretsmanager",

--- a/cnm-cli/CHANGELOG.md
+++ b/cnm-cli/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.11.23](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/cnm-cli-v0.11.22...cnm-cli-v0.11.23) — 2026-08-18
+
+
 ## [0.11.22](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/cnm-cli-v0.11.21...cnm-cli-v0.11.22) — 2026-08-17
 
 

--- a/cnm-cli/Cargo.toml
+++ b/cnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cnm-cli"
 description = "CLI Tool for Verified Trust Agents operating in Verified Trust Communities"
-version = "0.11.22"
+version = "0.11.23"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/pnm-cli/CHANGELOG.md
+++ b/pnm-cli/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.12.7](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/pnm-cli-v0.12.6...pnm-cli-v0.12.7) — 2026-08-18
+
+
 ## [0.12.6](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/pnm-cli-v0.12.5...pnm-cli-v0.12.6) — 2026-08-17
 
 

--- a/pnm-cli/Cargo.toml
+++ b/pnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pnm-cli"
 description = "CLI Tool for managing a personal Verifiable Trust Agent"
-version = "0.12.6"
+version = "0.12.7"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-audit/CHANGELOG.md
+++ b/vta-audit/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.1.7](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-audit-v0.1.6...vta-audit-v0.1.7) — 2026-08-18
+
+
 ## [0.1.6](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-audit-v0.1.5...vta-audit-v0.1.6) — 2026-08-17
 
 

--- a/vta-audit/Cargo.toml
+++ b/vta-audit/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-audit"
 description = "Structured audit logging for the VTA — the `audit!` tracing macro plus the audit-keyspace persistence helpers"
 readme = "README.md"
-version = "0.1.6"
+version = "0.1.7"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own

--- a/vta-backup/CHANGELOG.md
+++ b/vta-backup/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.1.11](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-backup-v0.1.10...vta-backup-v0.1.11) — 2026-08-18
+
+
 ## [0.1.10](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-backup-v0.1.9...vta-backup-v0.1.10) — 2026-08-17
 
 

--- a/vta-backup/Cargo.toml
+++ b/vta-backup/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-backup"
 description = "VTA backup/restore subsystem — encrypted full-state export/import, the sealed backup-bundle store, and its TTL sweeper"
 readme = "README.md"
-version = "0.1.10"
+version = "0.1.11"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own

--- a/vta-cli-common/CHANGELOG.md
+++ b/vta-cli-common/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.11.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-cli-common-v0.11.0...vta-cli-common-v0.11.1) — 2026-08-18
+
+
 ## [0.11.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-cli-common-v0.10.33...vta-cli-common-v0.11.0) — 2026-08-17
 
 

--- a/vta-cli-common/Cargo.toml
+++ b/vta-cli-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-cli-common"
 description = "Shared CLI command handlers and rendering helpers for VTA CLIs"
 readme = "README.md"
-version = "0.11.0"
+version = "0.11.1"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-config/CHANGELOG.md
+++ b/vta-config/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.3.9](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-config-v0.3.8...vta-config-v0.3.9) — 2026-08-18
+
+
 ## [0.3.8](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-config-v0.3.7...vta-config-v0.3.8) — 2026-08-17
 
 

--- a/vta-config/Cargo.toml
+++ b/vta-config/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-config"
 description = "VTA configuration types — the `AppConfig` TOML shape and its sub-configs, composing the vti-common and vti-secrets config types"
 readme = "README.md"
-version = "0.3.8"
+version = "0.3.9"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own

--- a/vta-keys/CHANGELOG.md
+++ b/vta-keys/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.2.6](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-keys-v0.2.5...vta-keys-v0.2.6) — 2026-08-18
+
+
 ## [0.2.5](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-keys-v0.2.4...vta-keys-v0.2.5) — 2026-08-17
 
 

--- a/vta-keys/Cargo.toml
+++ b/vta-keys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-keys"
 description = "VTA key management — master-seed storage, BIP-32 key derivation, key wrapping, and the seed-store backend selection"
 readme = "README.md"
-version = "0.2.5"
+version = "0.2.6"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own

--- a/vta-keyspaces/CHANGELOG.md
+++ b/vta-keyspaces/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.1.5](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-keyspaces-v0.1.4...vta-keyspaces-v0.1.5) — 2026-08-18
+
+
 ## [0.1.4](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-keyspaces-v0.1.3...vta-keyspaces-v0.1.4) — 2026-08-17
 
 

--- a/vta-keyspaces/Cargo.toml
+++ b/vta-keyspaces/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-keyspaces"
 description = "VTA keyspace-name registry — the shared storage vocabulary for the VTA subsystem crates"
 readme = "README.md"
-version = "0.1.4"
+version = "0.1.5"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own

--- a/vta-policy/CHANGELOG.md
+++ b/vta-policy/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.2.8](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-policy-v0.2.7...vta-policy-v0.2.8) — 2026-08-18
+
+
 ## [0.2.7](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-policy-v0.2.6...vta-policy-v0.2.7) — 2026-08-17
 
 

--- a/vta-policy/Cargo.toml
+++ b/vta-policy/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-policy"
 description = "VTA policy subsystem — the regorus (Rego) engine, the default policy bundle, consent model, and decision evaluators"
 readme = "README.md"
-version = "0.2.7"
+version = "0.2.8"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own

--- a/vta-sdk/CHANGELOG.md
+++ b/vta-sdk/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.25.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-sdk-v0.25.0...vta-sdk-v0.25.1) — 2026-08-18
+
+
 ## [0.25.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-sdk-v0.24.0...vta-sdk-v0.25.0) — 2026-08-17
 
 

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.25.0"
+version = "0.25.1"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/CHANGELOG.md
+++ b/vta-service/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.17.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-service-v0.17.0...vta-service-v0.17.1) — 2026-08-18
+
+
 ## [0.17.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-service-v0.16.1...vta-service-v0.17.0) — 2026-08-17
 
 

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.17.0"
+version = "0.17.1"
 edition.workspace = true
 # Published for one reason: `openvtc-core` dev-depends on it for
 # `test_support::MockVta`, the in-process VTA its end-to-end tests run against.

--- a/vta-support/CHANGELOG.md
+++ b/vta-support/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.2.8](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-support-v0.2.7...vta-support-v0.2.8) — 2026-08-18
+
+
 ## [0.2.7](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-support-v0.2.6...vta-support-v0.2.7) — 2026-08-17
 
 

--- a/vta-support/Cargo.toml
+++ b/vta-support/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-support"
 description = "Shared mid-layer VTA services — trust-context storage, the sealed-transfer seal helper, and the sealed-bootstrap nonce store"
 readme = "README.md"
-version = "0.2.7"
+version = "0.2.8"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own

--- a/vta-sweepers/CHANGELOG.md
+++ b/vta-sweepers/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.1.4](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-sweepers-v0.1.3...vta-sweepers-v0.1.4) — 2026-08-18
+
+
 ## [0.1.3](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-sweepers-v0.1.2...vta-sweepers-v0.1.3) — 2026-08-17
 
 

--- a/vta-sweepers/Cargo.toml
+++ b/vta-sweepers/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sweepers"
 description = "Background TTL sweepers for the VTA's core keyspaces — ACL grant expiry, pending-consent expiry, and soft-deleted-vault purge"
 readme = "README.md"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own

--- a/vta-vault/CHANGELOG.md
+++ b/vta-vault/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.3.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-vault-v0.3.0...vta-vault-v0.3.1) — 2026-08-18
+
+
 ## [0.3.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-vault-v0.2.0...vta-vault-v0.3.0) — 2026-08-17
 
 

--- a/vta-vault/Cargo.toml
+++ b/vta-vault/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-vault"
 description = "VTA holder credential vault — storage, query, receive/verify, present, and status refresh for credentials a holder stores on a VTA"
 readme = "README.md"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own

--- a/vta-webvh/CHANGELOG.md
+++ b/vta-webvh/CHANGELOG.md
@@ -2,6 +2,45 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.1.10](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-webvh-v0.1.9...vta-webvh-v0.1.10) — 2026-08-18
+
+
+### Fixed
+
+- **webvh**: Read agent-name createdAt in both shapes the host sends ([#999](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/999))
+
+* fix(webvh): read agent-name createdAt in both shapes the host sends
+
+  A DID with at least one agent name could not be listed over DIDComm. The
+  whole task failed with `agent-name list response parse error: invalid
+  type: string "2026-08-18T08:58:13Z", expected u64`, which reached the
+  operator as an internal error from a `set` that had in fact succeeded —
+  the name was already in the DID document while the UI reported failure
+  and showed an empty registry.
+
+  `AgentNameEntryWire` is documented as the shape of the REST
+  `GET /api/dids/{mnemonic}` `agentNames` array, where `createdAt` is Unix
+  seconds as a number, and `webvh_didcomm::list_agent_names` reuses it to
+  parse the DIDComm listing — where it is not. The published payload
+  schema for `did-management/agent-name/list/0.1` types `createdAt` as
+  `"string"` with `"format": "date-time"`, and the host projects it that
+  way (affinidi-webvh-service, `did-hosting-control/src/messaging.rs`).
+
+  Both producers are right. The same host emits *both* shapes: its DID
+  record projection serialises the stored registry (numbers) while the
+  list verb answers to the spec (strings), so one shape cannot simply be
+  declared wrong. The consumer is the single place that sees both, so the
+  wire type now accepts either and normalises to seconds — the VTA relays
+  a `u64` outward in the canonical `AgentNameEntry`, so an RFC3339 input
+  is converted rather than propagated. A third shape is a genuine contract
+  break and still fails, quoting what arrived so it can be told apart from
+  an unreachable host (R6.4).
+
+  `chrono` moves from dev-dependencies to dependencies for the conversion.
+  It was already in the build graph via `vta-service`.
+
+
+
 ## [0.1.9](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-webvh-v0.1.8...vta-webvh-v0.1.9) — 2026-08-17
 
 

--- a/vta-webvh/Cargo.toml
+++ b/vta-webvh/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-webvh"
 description = "WebVH hosting infrastructure for the VTA — the DID-record store, the HTTP client to a did:webvh hosting server, and its DID-auth handshake"
 readme = "README.md"
-version = "0.1.9"
+version = "0.1.10"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own

--- a/vtc-client/CHANGELOG.md
+++ b/vtc-client/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.3.8](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vtc-client-v0.3.7...vtc-client-v0.3.8) — 2026-08-18
+
+
 ## [0.3.7](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vtc-client-v0.3.6...vtc-client-v0.3.7) — 2026-08-17
 
 

--- a/vtc-client/Cargo.toml
+++ b/vtc-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vtc-client"
 description = "Client SDK for Verifiable Trust Communities (VTC) — auth, members, join, removal, policies"
-version = "0.3.7"
+version = "0.3.8"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vti-common/CHANGELOG.md
+++ b/vti-common/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.12.2](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-common-v0.12.1...vti-common-v0.12.2) — 2026-08-18
+
+
 ## [0.12.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-common-v0.12.0...vti-common-v0.12.1) — 2026-08-17
 
 

--- a/vti-common/Cargo.toml
+++ b/vti-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-common"
 description = "Shared server-side infrastructure for VTA and VTC services"
 readme = "README.md"
-version = "0.12.1"
+version = "0.12.2"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vti-secrets/CHANGELOG.md
+++ b/vti-secrets/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.1.15](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-secrets-v0.1.14...vti-secrets-v0.1.15) — 2026-08-18
+
+
 ## [0.1.14](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-secrets-v0.1.13...vti-secrets-v0.1.14) — 2026-08-17
 
 

--- a/vti-secrets/Cargo.toml
+++ b/vti-secrets/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-secrets"
 description = "Pluggable secret-store backends + integration onboarding flow for Verifiable Trust Infrastructure"
 readme = "README.md"
-version = "0.1.14"
+version = "0.1.15"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `vta-sdk`: 0.25.0 -> 0.25.1 (✓ API compatible changes)
* `vti-common`: 0.12.1 -> 0.12.2 (✓ API compatible changes)
* `vta-cli-common`: 0.11.0 -> 0.11.1 (✓ API compatible changes)
* `cnm-cli`: 0.11.22 -> 0.11.23
* `pnm-cli`: 0.12.6 -> 0.12.7
* `vta-audit`: 0.1.6 -> 0.1.7
* `vti-secrets`: 0.1.14 -> 0.1.15 (✓ API compatible changes)
* `vta-config`: 0.3.8 -> 0.3.9
* `vta-keyspaces`: 0.1.4 -> 0.1.5
* `vta-keys`: 0.2.5 -> 0.2.6
* `vta-support`: 0.2.7 -> 0.2.8
* `vta-backup`: 0.1.10 -> 0.1.11
* `vta-policy`: 0.2.7 -> 0.2.8
* `vta-vault`: 0.3.0 -> 0.3.1
* `vta-sweepers`: 0.1.3 -> 0.1.4
* `vta-webvh`: 0.1.9 -> 0.1.10
* `vta-service`: 0.17.0 -> 0.17.1 (✓ API compatible changes)
* `vtc-client`: 0.3.7 -> 0.3.8 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>
















## `vta-webvh`

<blockquote>

## [0.1.10](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-webvh-v0.1.9...vta-webvh-v0.1.10) — 2026-08-18

### Fixed

- **webvh**: Read agent-name createdAt in both shapes the host sends ([#999](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/999))

* fix(webvh): read agent-name createdAt in both shapes the host sends

  A DID with at least one agent name could not be listed over DIDComm. The
  whole task failed with `agent-name list response parse error: invalid
  type: string "2026-08-18T08:58:13Z", expected u64`, which reached the
  operator as an internal error from a `set` that had in fact succeeded —
  the name was already in the DID document while the UI reported failure
  and showed an empty registry.

  `AgentNameEntryWire` is documented as the shape of the REST
  `GET /api/dids/{mnemonic}` `agentNames` array, where `createdAt` is Unix
  seconds as a number, and `webvh_didcomm::list_agent_names` reuses it to
  parse the DIDComm listing — where it is not. The published payload
  schema for `did-management/agent-name/list/0.1` types `createdAt` as
  `"string"` with `"format": "date-time"`, and the host projects it that
  way (affinidi-webvh-service, `did-hosting-control/src/messaging.rs`).

  Both producers are right. The same host emits *both* shapes: its DID
  record projection serialises the stored registry (numbers) while the
  list verb answers to the spec (strings), so one shape cannot simply be
  declared wrong. The consumer is the single place that sees both, so the
  wire type now accepts either and normalises to seconds — the VTA relays
  a `u64` outward in the canonical `AgentNameEntry`, so an RFC3339 input
  is converted rather than propagated. A third shape is a genuine contract
  break and still fails, quoting what arrived so it can be told apart from
  an unreachable host (R6.4).

  `chrono` moves from dev-dependencies to dependencies for the conversion.
  It was already in the build graph via `vta-service`.
</blockquote>




</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).