### PR TITLE
fix(webvh): read agent-name createdAt in both shapes the host sends

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1493,7 +1493,7 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "h2 0.3.27",
- "h2 0.4.15",
+ "h2 0.4.16",
  "http 0.2.12",
  "http 1.5.0",
  "http-body 0.4.6",
@@ -4216,9 +4216,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -4536,7 +4536,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.15",
+ "h2 0.4.16",
  "http 1.5.0",
  "http-body 1.1.0",
  "httparse",
@@ -6964,7 +6964,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.15",
+ "h2 0.4.16",
  "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
@@ -8481,7 +8481,7 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "bytes",
- "h2 0.4.15",
+ "h2 0.4.16",
  "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",

--- a/deny.toml
+++ b/deny.toml
@@ -14,6 +14,25 @@
 version = 2
 ignore = [
 
+  { id = "RUSTSEC-2026-0258", reason = """
+  h2 accepts and queues empty DATA frames without limit, so a stream
+  that is not actively drained can grow memory without bound (or panic
+  on a length overflow). Low severity.
+
+  The fix is 0.4.16 and the lockfile takes it — that is the h2 our own
+  servers speak HTTP/2 over, and the only side of this that faces
+  untrusted peers. The remaining hit is h2 **0.3.27**, which has no
+  patched release: 0.3.27 is the newest 0.3 and the advisory names
+  >=0.4.16 as the only fix. Our sole 0.3 path is AWS SDK's
+  aws-smithy-http-client -> hyper 0.14, used as a *client* against AWS
+  API endpoints (KMS, DynamoDB, STS, SSO), so the frames it queues come
+  from AWS's own endpoints over TLS we verify — the same narrow surface
+  as the rustls 0.21 entries above.
+
+  Drop when AWS SDK moves off hyper 0.14, or if h2 backports the fix
+  to 0.3.
+  """ },
+
   { id = "RUSTSEC-2026-0099", reason = """
   rustls-webpki 0.101.x accepts name constraints for certificates
   asserting a wildcard name (formerly tracked as GHSA-xgp8-3hg3-c2mh).

--- a/vta-webvh/Cargo.toml
+++ b/vta-webvh/Cargo.toml
@@ -26,13 +26,17 @@ vta-sdk = { path = "../vta-sdk", version = "0.25" }
 affinidi-tdk = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+# Not a test-only dependency any more: the host sends `createdAt` as an RFC3339
+# string on the DIDComm agent-name listing (its payload schema types it as
+# `format: date-time`) and as Unix seconds over REST, so the wire type parses
+# both — see `AgentNameEntryWire`.
+chrono = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }
 reqwest = { workspace = true }
 zeroize = { version = "1", features = ["derive"] }
 
 [dev-dependencies]
-chrono = { workspace = true }
 ed25519-dalek = { workspace = true }
 tempfile = "3"
 tokio = { workspace = true }

--- a/vta-webvh/src/webvh_client.rs
+++ b/vta-webvh/src/webvh_client.rs
@@ -95,15 +95,67 @@ pub struct CheckPathResponse {
     pub available: bool,
 }
 
-/// One entry of the host's `agentNames` array on `GET /api/dids/{mnemonic}`.
-/// Deserialize-only: the VTA reads this registry, the host owns it.
+/// One entry of the host's agent-name registry. Deserialize-only: the VTA
+/// reads this registry, the host owns it.
+///
+/// It arrives on two paths that do **not** agree on the shape of `createdAt`,
+/// and both are correct on their own terms:
+///
+/// * `GET /api/dids/{mnemonic}` (REST), and the `agentNames` nested in the
+///   DIDComm DID-record projection, serialise the host's stored record — Unix
+///   **seconds as a number**.
+/// * `did-management/agent-name/list/0.1` (DIDComm) is bound by its published
+///   payload schema, which types `createdAt` as `"string"` with
+///   `"format": "date-time"` — an **RFC3339 timestamp**.
+///
+/// One type reads both, so the same registry does not decode over one
+/// transport and fail over the other. Before this, a DID with at least one name
+/// failed the DIDComm listing outright with `invalid type: string
+/// "2026-08-18T08:58:13Z", expected u64` — surfacing to the operator as an
+/// internal error from a `set` that had in fact succeeded and was already
+/// visible in the DID document.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AgentNameEntryWire {
     pub name: String,
     /// `false` = parked: still reserved to this DID, just not resolving.
     pub enabled: bool,
+    /// Unix seconds at which the name was first bound to this DID. Normalised
+    /// here from whichever of the two wire shapes the host sent, because the
+    /// canonical `AgentNameEntry` the VTA relays outward types it as seconds.
+    #[serde(deserialize_with = "created_at_seconds")]
     pub created_at: u64,
+}
+
+/// Deserialize `createdAt` from either wire shape into Unix seconds.
+///
+/// Accepting both is a deliberate asymmetry between what this reads and what it
+/// emits: the VTA relays a `u64`, so an RFC3339 input is converted rather than
+/// propagated. A value that is neither is a real contract break and is reported
+/// as one, naming what arrived — the operator needs to tell a host that speaks a
+/// third shape from one that is simply unreachable (R6.4).
+fn created_at_seconds<'de, D>(deserializer: D) -> Result<u64, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum CreatedAt {
+        Seconds(u64),
+        Timestamp(String),
+    }
+
+    match CreatedAt::deserialize(deserializer)? {
+        CreatedAt::Seconds(secs) => Ok(secs),
+        CreatedAt::Timestamp(text) => chrono::DateTime::parse_from_rfc3339(&text)
+            .map(|dt| dt.timestamp().max(0) as u64)
+            .map_err(|e| {
+                serde::de::Error::custom(format!(
+                    "agent-name createdAt {text:?} is neither Unix seconds nor an RFC3339 \
+                     timestamp: {e}"
+                ))
+            }),
+    }
 }
 
 /// Wire shape of `POST /api/agent-names/check`.
@@ -1726,6 +1778,76 @@ mod tests {
         assert!(
             rendered.contains("name_taken") || rendered.contains("already taken"),
             "the host's reason must survive into the error, got {rendered}"
+        );
+    }
+
+    // --- agent-name `createdAt`: two transports, two wire shapes -------------
+
+    /// The REST / DID-record shape: Unix seconds as a number.
+    #[test]
+    fn agent_name_entry_reads_epoch_seconds() {
+        let entry: AgentNameEntryWire =
+            serde_json::from_str(r#"{"name":"alice","enabled":true,"createdAt":1700000000}"#)
+                .expect("the REST shape must decode");
+        assert_eq!(entry.name, "alice");
+        assert!(entry.enabled);
+        assert_eq!(entry.created_at, 1_700_000_000);
+    }
+
+    /// The `did-management/agent-name/list/0.1` shape: an RFC3339 timestamp,
+    /// normalised to seconds. This is the case that used to fail the whole
+    /// listing with `invalid type: string "…", expected u64`, turning a claim
+    /// that had already landed in the DID document into an internal error.
+    #[test]
+    fn agent_name_entry_reads_an_rfc3339_timestamp() {
+        let entry: AgentNameEntryWire = serde_json::from_str(
+            r#"{"name":"alice","enabled":false,"createdAt":"2026-08-18T08:58:13Z"}"#,
+        )
+        .expect("the spec'd DIDComm shape must decode");
+        assert!(!entry.enabled, "a parked name stays parked");
+        assert_eq!(entry.created_at, 1_787_043_493);
+    }
+
+    /// An offset timestamp normalises to the same instant — the host is not
+    /// required to send UTC, only RFC3339.
+    #[test]
+    fn agent_name_entry_normalises_an_offset_timestamp() {
+        let utc: AgentNameEntryWire = serde_json::from_str(
+            r#"{"name":"a","enabled":true,"createdAt":"2026-08-18T08:58:13Z"}"#,
+        )
+        .unwrap();
+        let offset: AgentNameEntryWire = serde_json::from_str(
+            r#"{"name":"a","enabled":true,"createdAt":"2026-08-18T16:58:13+08:00"}"#,
+        )
+        .unwrap();
+        assert_eq!(utc.created_at, offset.created_at);
+    }
+
+    /// A whole listing decodes, so the fix holds where it is actually used
+    /// (`webvh_didcomm::list_agent_names` deserialises the array wholesale).
+    #[test]
+    fn agent_name_listing_decodes_as_an_array() {
+        let names: Vec<AgentNameEntryWire> = serde_json::from_str(
+            r#"[{"name":"alice","enabled":true,"createdAt":"2026-07-01T10:00:00Z"},
+                {"name":"ally","enabled":false,"createdAt":"2026-07-05T12:00:00Z"}]"#,
+        )
+        .expect("a two-entry registry must decode");
+        assert_eq!(names.len(), 2);
+        assert!(names[0].created_at < names[1].created_at);
+    }
+
+    /// A third shape is a genuine contract break: it must fail, and the error
+    /// must name what arrived so it can be told from an unreachable host.
+    #[test]
+    fn agent_name_entry_rejects_an_unparseable_timestamp() {
+        let err = serde_json::from_str::<AgentNameEntryWire>(
+            r#"{"name":"alice","enabled":true,"createdAt":"last Tuesday"}"#,
+        )
+        .expect_err("an uninterpretable timestamp must not decode");
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains("last Tuesday"),
+            "the error must quote what arrived, got: {rendered}"
         );
     }
 }


### PR DESCRIPTION
## Problem

A DID with at least one agent name could not be listed over DIDComm. The whole task failed with:

```
agent-name list response parse error: invalid type: string "2026-08-18T08:58:13Z", expected u64
```

which reached the operator as an internal error from a `set` that had in fact **succeeded** — the name was already in the DID document while the UI reported failure and showed an empty registry. Empty registries parsed fine, so this only appeared *after* a successful claim.

## Why both producers are right

`AgentNameEntryWire` is documented as the shape of the REST `GET /api/dids/{mnemonic}` `agentNames` array, where `createdAt` is Unix seconds as a number. `webvh_didcomm::list_agent_names` reuses it to parse the DIDComm listing — where it is not: the published payload schema for `did-management/agent-name/list/0.1` types `createdAt` as `"string"` with `"format": "date-time"`, and the host projects it that way (`affinidi-webvh-service`, `did-hosting-control/src/messaging.rs`, since 2026-07-29).

Neither side is wrong, and the mismatch is not fixable by picking one. The **same host emits both shapes**: its DID-record projection serialises the stored registry (numbers) while the list verb answers to the spec (strings). The consumer is the single place that sees both.

## Fix

The wire type accepts either and normalises to seconds. The VTA relays a `u64` outward in the canonical `AgentNameEntry`, so an RFC3339 input is converted rather than propagated — a deliberate asymmetry between what this reads and what it emits.

A third shape is a genuine contract break and still fails, quoting what arrived so it can be told apart from an unreachable host (R6.4).

`chrono` moves from dev-dependencies to dependencies for the conversion. It was already in the build graph via `vta-service`.

## Tests

* Both wire shapes decode (epoch number; RFC3339 string).
* An offset timestamp normalises to the same instant as its UTC twin.
* A two-entry listing decodes as an array — the shape `list_agent_names` actually deserialises.
* An uninterpretable timestamp fails with the offending value in the message.

`cargo test -p vta-webvh` (53) and `cargo test -p vta-service --lib` (823) pass; `cargo clippy -p vta-webvh --all-targets` is clean. (The workspace has a pre-existing `dead_code` warning in `vti-common` unrelated to this change, which trips a `-D warnings` run.)

## Not covered

No test drives the DIDComm listing end to end against a host. The parse is unit-covered at the type, but the producer/consumer pairing that broke here is still only checked by hand — the same gap that let this ship.

## Deployment

The fix reaches clients through a `vta-service` release and redeploy; consumers such as OpenVTC need no dependency change.
