### PR TITLE
fix(wire)!: emit canonical lowerCamelCase on Trust Task payloads, accept snake_case

### DIFF
--- a/vta-sdk/src/client/acl.rs
+++ b/vta-sdk/src/client/acl.rs
@@ -3,7 +3,7 @@
 use super::types::AclEntryEnvelope;
 use super::{
     AclEntryResponse, AclListResponse, ChangeAclRoleRequest, CreateAclRequest, SwapAclRequest,
-    UpdateAclRequest, VtaClient, encode_path_segment,
+    UpdateAclRequest, VtaClient,
 };
 use crate::acl::ContextDirection;
 use crate::error::VtaError;
@@ -59,22 +59,6 @@ impl VtaClient {
             crate::trust_tasks::TASK_ACL_LIST_0_1,
             serde_json::Value::Object(payload),
             30,
-            |c, url| {
-                // Both parameters are appended independently — a direction
-                // without a context is a caller error, and the VTA says so;
-                // dropping it here would make REST answer a question DIDComm
-                // refuses.
-                let mut u = format!("{url}/acl");
-                let mut sep = '?';
-                if let Some(ctx) = context {
-                    u.push_str(&format!("{sep}context={ctx}"));
-                    sep = '&';
-                }
-                if direction != ContextDirection::default() {
-                    u.push_str(&format!("{sep}direction={direction}"));
-                }
-                c.get(u)
-            },
         )
         .await
     }
@@ -87,7 +71,6 @@ impl VtaClient {
                 crate::trust_tasks::TASK_ACL_SHOW_0_1,
                 serde_json::json!({ "subject": did }),
                 30,
-                |c, url| c.get(format!("{url}/acl/{}", encode_path_segment(did))),
             )
             .await?;
         Ok(wrapped.entry)
@@ -103,7 +86,6 @@ impl VtaClient {
                 crate::trust_tasks::TASK_ACL_GRANT_0_1,
                 serde_json::to_value(&req)?,
                 30,
-                |c, url| c.post(format!("{url}/acl")).json(&req),
             )
             .await?;
         Ok(wrapped.entry)
@@ -145,10 +127,6 @@ impl VtaClient {
                 crate::trust_tasks::TASK_ACL_UPDATE_0_1,
                 serde_json::to_value(&body)?,
                 30,
-                |c, url| {
-                    c.patch(format!("{url}/acl/{}", encode_path_segment(did)))
-                        .json(&req)
-                },
             )
             .await?;
         Ok(wrapped.entry)
@@ -183,13 +161,6 @@ impl VtaClient {
                     reason: req.reason.clone(),
                 })?,
                 30,
-                |c, url| {
-                    c.post(format!(
-                        "{url}/acl/{}/change-role",
-                        encode_path_segment(did)
-                    ))
-                    .json(&req)
-                },
             )
             .await?;
         Ok(wrapped.entry)
@@ -200,7 +171,6 @@ impl VtaClient {
             crate::trust_tasks::TASK_ACL_REVOKE_0_1,
             serde_json::json!({ "subject": did }),
             30,
-            |c, url| c.delete(format!("{url}/acl/{}", encode_path_segment(did))),
         )
         .await
     }

--- a/vta-sdk/src/client/audit.rs
+++ b/vta-sdk/src/client/audit.rs
@@ -3,15 +3,6 @@
 use super::VtaClient;
 use crate::error::VtaError;
 
-/// Percent-encode a query-parameter value.
-///
-/// Not optional for these params: an RFC 3339 timestamp ends in a `+`
-/// offset (`…+00:00`), which a query-string decoder reads as a space —
-/// so an unencoded `from`/`to` arrives as an unparseable datetime.
-fn enc(value: &str) -> String {
-    url::form_urlencoded::byte_serialize(value.as_bytes()).collect()
-}
-
 impl VtaClient {
     /// List audit logs with optional filtering and pagination.
     pub async fn list_audit_logs(
@@ -25,37 +16,6 @@ impl VtaClient {
             crate::trust_tasks::TASK_AUDIT_LIST_0_1,
             serde_json::to_value(params)?,
             30,
-            |c, url| {
-                // Query-param names are the canonical camelCase ones the
-                // route binds; a snake_case key here is silently dropped
-                // by serde and the filter never applies.
-                let mut qs: Vec<String> = Vec::new();
-                if let Some(page_size) = params.page_size {
-                    qs.push(format!("pageSize={page_size}"));
-                }
-                if let Some(from) = params.from {
-                    qs.push(format!("from={}", enc(&from.to_rfc3339())));
-                }
-                if let Some(to) = params.to {
-                    qs.push(format!("to={}", enc(&to.to_rfc3339())));
-                }
-                if let Some(ref action) = params.action {
-                    qs.push(format!("action={}", enc(action)));
-                }
-                if let Some(ref actor) = params.actor {
-                    qs.push(format!("actor={}", enc(actor)));
-                }
-                if let Some(ref outcome) = params.outcome {
-                    qs.push(format!("outcome={}", enc(outcome)));
-                }
-                if let Some(ref ctx) = params.context_id {
-                    qs.push(format!("contextId={}", enc(ctx)));
-                }
-                if let Some(ref cursor) = params.cursor {
-                    qs.push(format!("cursor={}", enc(cursor)));
-                }
-                c.get(format!("{url}/audit/logs?{}", qs.join("&")))
-            },
         )
         .await
     }
@@ -68,7 +28,6 @@ impl VtaClient {
             crate::trust_tasks::TASK_AUDIT_GET_RETENTION_1_0,
             serde_json::json!({}),
             30,
-            |c, url| c.get(format!("{url}/audit/retention")),
         )
         .await
     }
@@ -84,7 +43,6 @@ impl VtaClient {
             crate::trust_tasks::TASK_AUDIT_UPDATE_RETENTION_1_0,
             serde_json::to_value(&body)?,
             30,
-            |c, url| c.patch(format!("{url}/audit/retention")).json(&body),
         )
         .await
     }

--- a/vta-sdk/src/client/contexts.rs
+++ b/vta-sdk/src/client/contexts.rs
@@ -1,8 +1,7 @@
 //! Context methods on [`VtaClient`].
 
 use super::{
-    ContextListResponse, ContextResponse, CreateContextRequest, UpdateContextDidRequest,
-    UpdateContextRequest, VtaClient, encode_path_segment,
+    ContextListResponse, ContextResponse, CreateContextRequest, UpdateContextRequest, VtaClient,
 };
 use crate::error::VtaError;
 
@@ -16,7 +15,6 @@ impl VtaClient {
             crate::trust_tasks::TASK_CONTEXTS_LIST_1_0,
             serde_json::json!({}),
             30,
-            |c, url| c.get(format!("{url}/contexts")),
         )
         .await
     }
@@ -26,7 +24,6 @@ impl VtaClient {
             crate::trust_tasks::TASK_CONTEXTS_GET_1_0,
             serde_json::json!({ "id": id }),
             30,
-            |c, url| c.get(format!("{url}/contexts/{}", encode_path_segment(id))),
         )
         .await
     }
@@ -39,7 +36,6 @@ impl VtaClient {
             crate::trust_tasks::TASK_CONTEXTS_CREATE_1_0,
             serde_json::to_value(&req)?,
             30,
-            |c, url| c.post(format!("{url}/contexts")).json(&req),
         )
         .await
     }
@@ -58,10 +54,6 @@ impl VtaClient {
                 "description": &req.description,
             }),
             30,
-            |c, url| {
-                c.patch(format!("{url}/contexts/{}", encode_path_segment(id)))
-                    .json(&req)
-            },
         )
         .await
     }
@@ -77,10 +69,6 @@ impl VtaClient {
             crate::trust_tasks::TASK_CONTEXTS_UPDATE_DID_1_0,
             serde_json::json!({ "id": id, "did": &did }),
             30,
-            |c, url| {
-                c.put(format!("{url}/contexts/{}/did", encode_path_segment(id)))
-                    .json(&UpdateContextDidRequest { did: did.clone() })
-            },
         )
         .await
     }
@@ -93,12 +81,6 @@ impl VtaClient {
             crate::trust_tasks::TASK_CONTEXTS_PREVIEW_DELETE_1_0,
             serde_json::json!({ "id": id }),
             30,
-            |c, url| {
-                c.get(format!(
-                    "{url}/contexts/{}/delete-preview",
-                    encode_path_segment(id)
-                ))
-            },
         )
         .await
     }
@@ -108,13 +90,6 @@ impl VtaClient {
             crate::trust_tasks::TASK_CONTEXTS_DELETE_1_0,
             serde_json::json!({ "id": id, "force": force }),
             30,
-            |c, url| {
-                let mut url = format!("{url}/contexts/{}", encode_path_segment(id));
-                if force {
-                    url.push_str("?force=true");
-                }
-                c.delete(url)
-            },
         )
         .await
     }

--- a/vta-sdk/src/client/did_templates.rs
+++ b/vta-sdk/src/client/did_templates.rs
@@ -13,7 +13,7 @@ use std::collections::HashMap;
 
 use serde_json::Value;
 
-use super::{VtaClient, encode_path_segment};
+use super::VtaClient;
 use crate::did_templates::{DidTemplate, DidTemplateRecord};
 use crate::error::VtaError;
 use crate::protocols::did_template_management as proto;
@@ -32,7 +32,6 @@ impl VtaClient {
                 trust_tasks::TASK_DID_TEMPLATES_LIST_2_0,
                 serde_json::to_value(proto::list::ListDidTemplatesBody { context_id: None })?,
                 30,
-                |c, url| c.get(format!("{url}/did-templates")),
             )
             .await?;
         Ok(resp.templates)
@@ -50,7 +49,6 @@ impl VtaClient {
                 name: name.to_string(),
             })?,
             30,
-            |c, url| c.get(format!("{url}/did-templates/{}", encode_path_segment(name))),
         )
         .await
     }
@@ -67,13 +65,8 @@ impl VtaClient {
             context_id: None,
             template: template.clone(),
         })?;
-        self.rpc_tt(
-            trust_tasks::TASK_DID_TEMPLATES_CREATE_2_0,
-            payload,
-            30,
-            |c, url| c.post(format!("{url}/did-templates")).json(&template),
-        )
-        .await
+        self.rpc_tt(trust_tasks::TASK_DID_TEMPLATES_CREATE_2_0, payload, 30)
+            .await
     }
 
     /// Replace a global template. Super admin only.
@@ -90,16 +83,8 @@ impl VtaClient {
             name: name.to_string(),
             template: template.clone(),
         })?;
-        self.rpc_tt(
-            trust_tasks::TASK_DID_TEMPLATES_UPDATE_2_0,
-            payload,
-            30,
-            |c, url| {
-                c.put(format!("{url}/did-templates/{}", encode_path_segment(name)))
-                    .json(&template)
-            },
-        )
-        .await
+        self.rpc_tt(trust_tasks::TASK_DID_TEMPLATES_UPDATE_2_0, payload, 30)
+            .await
     }
 
     /// Delete a global template. Super admin only.
@@ -114,7 +99,6 @@ impl VtaClient {
                 name: name.to_string(),
             })?,
             30,
-            |c, url| c.delete(format!("{url}/did-templates/{}", encode_path_segment(name))),
         )
         .await
     }
@@ -137,18 +121,7 @@ impl VtaClient {
             vars: vars.clone(),
         })?;
         let resp: proto::render::RenderDidTemplateResultBody = self
-            .rpc_tt(
-                trust_tasks::TASK_DID_TEMPLATES_RENDER_2_0,
-                payload,
-                30,
-                |c, url| {
-                    c.post(format!(
-                        "{url}/did-templates/{}/render",
-                        encode_path_segment(name)
-                    ))
-                    .json(&serde_json::json!({ "vars": vars }))
-                },
-            )
+            .rpc_tt(trust_tasks::TASK_DID_TEMPLATES_RENDER_2_0, payload, 30)
             .await?;
         Ok(resp.document)
     }
@@ -170,12 +143,6 @@ impl VtaClient {
                     context_id: Some(context_id.to_string()),
                 })?,
                 30,
-                |c, url| {
-                    c.get(format!(
-                        "{url}/contexts/{}/did-templates",
-                        encode_path_segment(context_id)
-                    ))
-                },
             )
             .await?;
         Ok(resp.templates)
@@ -197,13 +164,6 @@ impl VtaClient {
                 name: name.to_string(),
             })?,
             30,
-            |c, url| {
-                c.get(format!(
-                    "{url}/contexts/{}/did-templates/{}",
-                    encode_path_segment(context_id),
-                    encode_path_segment(name)
-                ))
-            },
         )
         .await
     }
@@ -221,19 +181,8 @@ impl VtaClient {
             context_id: Some(context_id.to_string()),
             template: template.clone(),
         })?;
-        self.rpc_tt(
-            trust_tasks::TASK_DID_TEMPLATES_CREATE_2_0,
-            payload,
-            30,
-            |c, url| {
-                c.post(format!(
-                    "{url}/contexts/{}/did-templates",
-                    encode_path_segment(context_id)
-                ))
-                .json(&template)
-            },
-        )
-        .await
+        self.rpc_tt(trust_tasks::TASK_DID_TEMPLATES_CREATE_2_0, payload, 30)
+            .await
     }
 
     /// Replace a context-scoped template.
@@ -251,20 +200,8 @@ impl VtaClient {
             name: name.to_string(),
             template: template.clone(),
         })?;
-        self.rpc_tt(
-            trust_tasks::TASK_DID_TEMPLATES_UPDATE_2_0,
-            payload,
-            30,
-            |c, url| {
-                c.put(format!(
-                    "{url}/contexts/{}/did-templates/{}",
-                    encode_path_segment(context_id),
-                    encode_path_segment(name)
-                ))
-                .json(&template)
-            },
-        )
-        .await
+        self.rpc_tt(trust_tasks::TASK_DID_TEMPLATES_UPDATE_2_0, payload, 30)
+            .await
     }
 
     /// Delete a context-scoped template.
@@ -283,13 +220,6 @@ impl VtaClient {
                 name: name.to_string(),
             })?,
             30,
-            |c, url| {
-                c.delete(format!(
-                    "{url}/contexts/{}/did-templates/{}",
-                    encode_path_segment(context_id),
-                    encode_path_segment(name)
-                ))
-            },
         )
         .await
     }
@@ -313,19 +243,7 @@ impl VtaClient {
             vars: vars.clone(),
         })?;
         let resp: proto::render::RenderDidTemplateResultBody = self
-            .rpc_tt(
-                trust_tasks::TASK_DID_TEMPLATES_RENDER_2_0,
-                payload,
-                30,
-                |c, url| {
-                    c.post(format!(
-                        "{url}/contexts/{}/did-templates/{}/render",
-                        encode_path_segment(context_id),
-                        encode_path_segment(name)
-                    ))
-                    .json(&serde_json::json!({ "vars": vars }))
-                },
-            )
+            .rpc_tt(trust_tasks::TASK_DID_TEMPLATES_RENDER_2_0, payload, 30)
             .await?;
         Ok(resp.document)
     }

--- a/vta-sdk/src/client/keys.rs
+++ b/vta-sdk/src/client/keys.rs
@@ -2,9 +2,8 @@
 
 use super::{
     CreateKeyRequest, CreateKeyResponse, GetKeySecretResponse, ImportKeyRequest, ImportKeyResponse,
-    InvalidateKeyResponse, ListKeysResponse, ListSeedsResponse, RenameKeyRequest,
-    RenameKeyResponse, RotateSeedRequest, RotateSeedResponse, SignResponse, Transport, VtaClient,
-    WrappingKeyResponse, encode_path_segment,
+    InvalidateKeyResponse, ListKeysResponse, ListSeedsResponse, RenameKeyResponse,
+    RotateSeedRequest, RotateSeedResponse, SignResponse, Transport, VtaClient, WrappingKeyResponse,
 };
 use crate::error::VtaError;
 use crate::keys::{KeyRecord, KeyType};
@@ -42,7 +41,6 @@ impl VtaClient {
                 trust_tasks::TASK_KEYS_CREATE_0_1,
                 serde_json::to_value(&body)?,
                 30,
-                |c, url| c.post(format!("{url}/keys")).json(&req),
             )
             .await?;
         let key = wrapped.key;
@@ -86,7 +84,6 @@ impl VtaClient {
                 trust_tasks::TASK_KEYS_IMPORT_0_1,
                 serde_json::to_value(&body)?,
                 30,
-                |c, url| c.post(format!("{url}/keys/import")).json(&req),
             )
             .await?;
         Ok(ImportKeyResponse {
@@ -118,16 +115,6 @@ impl VtaClient {
                 context_id: context_id.map(str::to_string),
             })?,
             30,
-            |c, url| {
-                let mut u = format!("{url}/keys?offset={offset}&limit={limit}");
-                if let Some(s) = status {
-                    u.push_str(&format!("&status={s}"));
-                }
-                if let Some(ctx) = context_id {
-                    u.push_str(&format!("&context_id={ctx}"));
-                }
-                c.get(u)
-            },
         )
         .await
     }
@@ -142,7 +129,6 @@ impl VtaClient {
                 trust_tasks::TASK_KEYS_SHOW_0_1,
                 serde_json::json!({ "keyId": key_id }),
                 30,
-                |c, url| c.get(format!("{url}/keys/{}", encode_path_segment(key_id))),
             )
             .await?;
         wrapped
@@ -159,7 +145,6 @@ impl VtaClient {
             trust_tasks::TASK_SEEDS_EXPORT_MNEMONIC_1_0,
             serde_json::json!({ "key_id": key_id }),
             30,
-            |c, url| c.get(format!("{url}/keys/{}/secret", encode_path_segment(key_id))),
         )
         .await
     }
@@ -184,13 +169,6 @@ impl VtaClient {
                 "algorithm": algorithm,
             }),
             30,
-            |c, url| {
-                c.post(format!("{url}/keys/{}/sign", encode_path_segment(key_id)))
-                    .json(&serde_json::json!({
-                        "payload": payload_b64,
-                        "algorithm": algorithm,
-                    }))
-            },
         )
         .await
     }
@@ -219,13 +197,8 @@ impl VtaClient {
             "payload": payload_b64,
             "algorithm": algorithm,
         });
-        self.rpc_tt(
-            trust_tasks::TASK_KEYS_DERIVE_AND_SIGN_0_1,
-            body.clone(),
-            30,
-            move |c, url| c.post(format!("{url}/keys/derive-and-sign")).json(&body),
-        )
-        .await
+        self.rpc_tt(trust_tasks::TASK_KEYS_DERIVE_AND_SIGN_0_1, body.clone(), 30)
+            .await
     }
 
     /// Derive a key at `derivation_path` and attach an `eddsa-jcs-2022`
@@ -260,10 +233,6 @@ impl VtaClient {
             trust_tasks::TASK_KEYS_DERIVE_AND_SIGN_DOCUMENT_0_1,
             body.clone(),
             30,
-            move |c, url| {
-                c.post(format!("{url}/keys/derive-and-sign-document"))
-                    .json(&body)
-            },
         )
         .await
     }
@@ -273,7 +242,6 @@ impl VtaClient {
             trust_tasks::TASK_KEYS_REVOKE_0_1,
             serde_json::json!({ "keyId": key_id }),
             30,
-            |c, url| c.delete(format!("{url}/keys/{}", encode_path_segment(key_id))),
         )
         .await
     }
@@ -287,12 +255,6 @@ impl VtaClient {
             trust_tasks::TASK_KEYS_RENAME_0_1,
             serde_json::json!({ "keyId": key_id, "newKeyId": new_key_id }),
             30,
-            |c, url| {
-                c.patch(format!("{url}/keys/{}", encode_path_segment(key_id)))
-                    .json(&RenameKeyRequest {
-                        key_id: new_key_id.to_string(),
-                    })
-            },
         )
         .await
     }
@@ -327,27 +289,21 @@ impl VtaClient {
     // ── Seed methods ────────────────────────────────────────────────
 
     pub async fn list_seeds(&self) -> Result<ListSeedsResponse, VtaError> {
-        self.rpc_tt(
-            trust_tasks::TASK_SEEDS_LIST_1_0,
-            serde_json::json!({}),
-            30,
-            |c, url| c.get(format!("{url}/keys/seeds")),
-        )
-        .await
+        self.rpc_tt(trust_tasks::TASK_SEEDS_LIST_1_0, serde_json::json!({}), 30)
+            .await
     }
 
     pub async fn rotate_seed(
         &self,
         mnemonic: Option<String>,
     ) -> Result<RotateSeedResponse, VtaError> {
-        let body = RotateSeedRequest {
+        let _body = RotateSeedRequest {
             mnemonic: mnemonic.clone(),
         };
         self.rpc_tt(
             trust_tasks::TASK_SEEDS_ROTATE_1_0,
             serde_json::json!({ "mnemonic": mnemonic }),
             30,
-            |c, url| c.post(format!("{url}/keys/seeds/rotate")).json(&body),
         )
         .await
     }

--- a/vta-sdk/src/client/mod.rs
+++ b/vta-sdk/src/client/mod.rs
@@ -309,20 +309,6 @@ impl VtaClient {
         }
     }
 
-    pub(super) async fn handle_delete_response(resp: reqwest::Response) -> Result<(), VtaError> {
-        if resp.status().is_success() {
-            Ok(())
-        } else {
-            let status = resp.status();
-            let text = resp.text().await?;
-            if status == reqwest::StatusCode::CONFLICT {
-                return Err(VtaError::Conflict(text));
-            }
-            let body = Self::extract_error_message(&text);
-            Err(VtaError::from_http(status, body))
-        }
-    }
-
     /// Extract the `error` field from a JSON response body, or fall back to
     /// "unknown error" with the raw text appended for diagnostics. The raw text
     /// is truncated so a large non-JSON body (e.g. a 1 MB proxy error page)
@@ -1332,7 +1318,6 @@ impl VtaClient {
         tt_uri: &str,
         payload: serde_json::Value,
         timeout: u64,
-        build_rest: impl FnOnce(&Client, &str) -> RequestBuilder,
     ) -> Result<T, VtaError> {
         // Ahead of the transport, and of the REST fork in particular: on a REST
         // transport this method takes `build_rest` and never builds a Trust
@@ -1383,7 +1368,6 @@ impl VtaClient {
         tt_uri: &str,
         payload: serde_json::Value,
         timeout: u64,
-        build_rest: impl FnOnce(&Client, &str) -> RequestBuilder,
     ) -> Result<(), VtaError> {
         // As in `rpc_tt` — see `client::loopback`.
         #[cfg(feature = "test-loopback")]
@@ -1901,7 +1885,6 @@ impl VtaClient {
             crate::trust_tasks::TASK_DISCOVERY_CAPABILITIES_1_0,
             serde_json::json!({}),
             30,
-            |c, url| c.get(format!("{url}/capabilities")),
         )
         .await
     }

--- a/vta-sdk/src/client/mod.rs
+++ b/vta-sdk/src/client/mod.rs
@@ -1346,14 +1346,16 @@ impl VtaClient {
         }
 
         match &self.transport {
-            Transport::Rest {
-                client,
-                base_url,
-                auth,
-            } => {
-                let req = build_rest(client, base_url);
-                let resp = Self::send_authed(client, base_url, auth, req).await?;
-                Self::handle_response(resp).await
+            // REST carries the Trust Task too, over the HTTPS binding
+            // (`POST /api/trust-tasks`) — the same document DIDComm and TSP
+            // send. It used to fork here into a bespoke per-operation route
+            // with its own request and response bodies, which is why REST was
+            // the one transport whose wire did not match the published
+            // schemas.
+            Transport::Rest { .. } => {
+                let payload = self.dispatch_trust_task(tt_uri, payload, timeout).await?;
+                serde_json::from_value(payload)
+                    .map_err(|e| VtaError::Protocol(format!("trust-task response decode: {e}")))
             }
             #[cfg(feature = "session")]
             Transport::DIDComm { .. } => {
@@ -1391,14 +1393,10 @@ impl VtaClient {
         }
 
         match &self.transport {
-            Transport::Rest {
-                client,
-                base_url,
-                auth,
-            } => {
-                let req = build_rest(client, base_url);
-                let resp = Self::send_authed(client, base_url, auth, req).await?;
-                Self::handle_delete_response(resp).await
+            // Same fold as `rpc_tt`: the HTTPS binding carries the task.
+            Transport::Rest { .. } => {
+                let _ = self.dispatch_trust_task(tt_uri, payload, timeout).await?;
+                Ok(())
             }
             #[cfg(feature = "session")]
             Transport::DIDComm { .. } => {
@@ -1498,9 +1496,35 @@ impl VtaClient {
                     .json(&doc);
                 let resp = Self::send_authed(client, base_url, auth, req).await?;
                 if !resp.status().is_success() {
+                    // Parse the body before throwing on the status (R3.7).
+                    //
+                    // A refused task answers with a `trust-task-error` document
+                    // whose payload carries the machine-readable `code` and the
+                    // human `message`; deciding on the status alone throws both
+                    // away and reports the raw JSON as "unknown error". It is
+                    // also what surfaces `ConsentRequired`, so skipping it turns
+                    // an answerable question into a dead end.
+                    //
+                    // The fallback matches the bespoke REST routes this binding
+                    // replaced: read the document's `error` field, and truncate
+                    // an unparseable body rather than letting a
+                    // server-controlled page of text reach logs and CLI output.
                     let status = resp.status();
-                    let body = resp.text().await.unwrap_or_default();
-                    return Err(VtaError::from_http(status, body));
+                    let text = resp.text().await.unwrap_or_default();
+
+                    if let Ok(doc) = serde_json::from_str::<serde_json::Value>(&text)
+                        && let Some(payload) = doc.get("payload")
+                        && let Some(err) = Self::trust_task_error(payload)
+                    {
+                        return Err(err);
+                    }
+                    if status == reqwest::StatusCode::CONFLICT {
+                        return Err(VtaError::Conflict(text));
+                    }
+                    return Err(VtaError::from_http(
+                        status,
+                        Self::extract_error_message(&text),
+                    ));
                 }
                 let response_doc: serde_json::Value = resp.json().await?;
                 Self::extract_trust_task_payload(response_doc)

--- a/vta-sdk/src/client/policy.rs
+++ b/vta-sdk/src/client/policy.rs
@@ -36,8 +36,7 @@ impl VtaClient {
             30,
             // No `.query(&req)`: reqwest is built without default features here,
             // so query-string serialization is unavailable. Filters ride the
-            // trust-task payload, which is the path this surface actually uses.
-            |c, url| c.get(format!("{url}/policies")),
+            // trust-task payload
         )
         .await
     }
@@ -49,7 +48,6 @@ impl VtaClient {
             crate::trust_tasks::TASK_POLICY_GET_0_1,
             serde_json::to_value(&req)?,
             30,
-            |c, url| c.get(format!("{url}/policies/{id}")),
         )
         .await
     }
@@ -68,7 +66,6 @@ impl VtaClient {
             crate::trust_tasks::TASK_POLICY_UPSERT_0_2,
             serde_json::to_value(&req)?,
             30,
-            |c, url| c.put(format!("{url}/policies")).json(&req),
         )
         .await
     }
@@ -78,12 +75,11 @@ impl VtaClient {
         &self,
         req: DeletePolicyBody,
     ) -> Result<DeletePolicyResultBody, VtaError> {
-        let id = req.id.clone();
+        let _id = req.id.clone();
         self.rpc_tt(
             crate::trust_tasks::TASK_POLICY_DELETE_0_1,
             serde_json::to_value(&req)?,
             30,
-            |c, url| c.delete(format!("{url}/policies/{id}")).json(&req),
         )
         .await
     }

--- a/vta-sdk/src/client/vta_management.rs
+++ b/vta-sdk/src/client/vta_management.rs
@@ -14,10 +14,6 @@ impl VtaClient {
             crate::trust_tasks::TASK_MANAGEMENT_RELOAD_SERVICES_1_0,
             serde_json::json!({}),
             30,
-            |c, url| {
-                c.post(format!("{url}/vta/restart"))
-                    .json(&serde_json::json!({}))
-            },
         )
         .await
     }
@@ -27,7 +23,6 @@ impl VtaClient {
             crate::trust_tasks::TASK_CONFIG_SHOW_0_1,
             serde_json::json!({}),
             30,
-            |c, url| c.get(format!("{url}/config")),
         )
         .await
     }
@@ -43,7 +38,6 @@ impl VtaClient {
             crate::trust_tasks::TASK_CONFIG_PATCH_0_1,
             serde_json::to_value(&req)?,
             30,
-            |c, url| c.patch(format!("{url}/config")).json(&req),
         )
         .await
     }

--- a/vta-sdk/src/client/webvh.rs
+++ b/vta-sdk/src/client/webvh.rs
@@ -23,7 +23,6 @@ impl VtaClient {
             crate::trust_tasks::TASK_WEBVH_SERVERS_REGISTER_1_0,
             serde_json::to_value(&req)?,
             30,
-            |c, url| c.post(format!("{url}/webvh/servers")).json(&req),
         )
         .await
     }
@@ -36,7 +35,6 @@ impl VtaClient {
             crate::trust_tasks::TASK_WEBVH_SERVERS_LIST_1_0,
             serde_json::json!({}),
             30,
-            |c, url| c.get(format!("{url}/webvh/servers")),
         )
         .await
     }
@@ -58,12 +56,6 @@ impl VtaClient {
             crate::trust_tasks::TASK_WEBVH_SERVERS_DOMAINS_0_1,
             serde_json::json!({ "serverId": server_id }),
             30,
-            |c, url| {
-                c.get(format!(
-                    "{url}/webvh/servers/{}/domains",
-                    encode_path_segment(server_id)
-                ))
-            },
         )
         .await
     }
@@ -87,12 +79,6 @@ impl VtaClient {
             // Longer than the domains read beside it: this makes a listing call
             // to the host and the host may be paging thousands of slots.
             60,
-            |c, url| {
-                c.get(format!(
-                    "{url}/webvh/servers/{}/reconcile",
-                    encode_path_segment(server_id)
-                ))
-            },
         )
         .await
     }
@@ -112,10 +98,6 @@ impl VtaClient {
             crate::trust_tasks::TASK_WEBVH_SERVERS_REGISTER_1_0,
             serde_json::json!({ "id": id, "label": &req.label }),
             30,
-            |c, url| {
-                c.patch(format!("{url}/webvh/servers/{}", encode_path_segment(id)))
-                    .json(&req)
-            },
         )
         .await
     }
@@ -125,7 +107,6 @@ impl VtaClient {
             crate::trust_tasks::TASK_WEBVH_SERVERS_REMOVE_1_0,
             serde_json::json!({ "id": id }),
             30,
-            |c, url| c.delete(format!("{url}/webvh/servers/{}", encode_path_segment(id))),
         )
         .await
     }
@@ -159,13 +140,6 @@ impl VtaClient {
             crate::trust_tasks::TASK_WEBVH_DIDS_REGISTER_WITH_SERVER_1_0,
             serde_json::to_value(&body)?,
             60,
-            |c, url| {
-                c.post(format!(
-                    "{url}/webvh/dids/{}/register-server",
-                    encode_path_segment(did)
-                ))
-                .json(&body)
-            },
         )
         .await
     }
@@ -180,7 +154,6 @@ impl VtaClient {
             crate::trust_tasks::TASK_WEBVH_DIDS_CREATE_1_0,
             serde_json::to_value(&req)?,
             60,
-            |c, url| c.post(format!("{url}/webvh/dids")).json(&req),
         )
         .await
     }
@@ -197,18 +170,6 @@ impl VtaClient {
                 "server_id": server_id,
             }),
             30,
-            |c, url| {
-                let mut u = format!("{url}/webvh/dids");
-                let mut sep = '?';
-                if let Some(ctx) = context_id {
-                    u.push_str(&format!("{sep}context_id={ctx}"));
-                    sep = '&';
-                }
-                if let Some(srv) = server_id {
-                    u.push_str(&format!("{sep}server_id={srv}"));
-                }
-                c.get(u)
-            },
         )
         .await
     }
@@ -221,7 +182,6 @@ impl VtaClient {
             crate::trust_tasks::TASK_WEBVH_DIDS_GET_1_0,
             serde_json::json!({ "did": did }),
             30,
-            |c, url| c.get(format!("{url}/webvh/dids/{}", encode_path_segment(did))),
         )
         .await
     }
@@ -234,7 +194,6 @@ impl VtaClient {
             crate::trust_tasks::TASK_WEBVH_DIDS_GET_1_0,
             serde_json::json!({ "did": did, "includeLog": true }),
             30,
-            |c, url| c.get(format!("{url}/webvh/dids/{}/log", encode_path_segment(did))),
         )
         .await
     }
@@ -244,7 +203,6 @@ impl VtaClient {
             crate::trust_tasks::TASK_WEBVH_DIDS_DELETE_1_0,
             serde_json::json!({ "did": did }),
             60,
-            |c, url| c.delete(format!("{url}/webvh/dids/{}", encode_path_segment(did))),
         )
         .await
     }

--- a/vta-sdk/src/context_policy.rs
+++ b/vta-sdk/src/context_policy.rs
@@ -41,13 +41,25 @@ use std::collections::{BTreeMap, BTreeSet};
 #[serde(rename_all = "camelCase")]
 pub struct ContextPolicy {
     /// Verifier DIDs an actor in this context may present to. `None` = any.
-    #[serde(default, skip_serializing_if = "Option::is_none", alias = "trusted_verifiers")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        alias = "trusted_verifiers"
+    )]
     pub trusted_verifiers: Option<BTreeSet<String>>,
     /// Credential `type`s an actor may present. `None` = any.
-    #[serde(default, skip_serializing_if = "Option::is_none", alias = "presentable_types")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        alias = "presentable_types"
+    )]
     pub presentable_types: Option<BTreeSet<String>>,
     /// Key ids the signing oracle may be invoked on. `None` = any.
-    #[serde(default, skip_serializing_if = "Option::is_none", alias = "signable_keys")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        alias = "signable_keys"
+    )]
     pub signable_keys: Option<BTreeSet<String>>,
     /// Whether sealed-transfer export is permitted. Defaults to `true`
     /// (unrestricted) when absent from the wire.

--- a/vta-sdk/src/context_policy.rs
+++ b/vta-sdk/src/context_policy.rs
@@ -38,19 +38,20 @@ use std::collections::{BTreeMap, BTreeSet};
 /// Per-context policy. See the module docs for the resolution model.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
 pub struct ContextPolicy {
     /// Verifier DIDs an actor in this context may present to. `None` = any.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none", alias = "trusted_verifiers")]
     pub trusted_verifiers: Option<BTreeSet<String>>,
     /// Credential `type`s an actor may present. `None` = any.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none", alias = "presentable_types")]
     pub presentable_types: Option<BTreeSet<String>>,
     /// Key ids the signing oracle may be invoked on. `None` = any.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none", alias = "signable_keys")]
     pub signable_keys: Option<BTreeSet<String>>,
     /// Whether sealed-transfer export is permitted. Defaults to `true`
     /// (unrestricted) when absent from the wire.
-    #[serde(default = "default_true")]
+    #[serde(default = "default_true", alias = "export_allowed")]
     pub export_allowed: bool,
     /// Per-operation-class daily ceilings. `None` = no quota.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -64,8 +65,10 @@ fn default_true() -> bool {
 /// Per-operation-class daily ceilings (e.g. `"sign" -> 1000`).
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
 pub struct Quotas {
     /// operation-class -> maximum invocations per day.
+    #[serde(alias = "per_day")]
     pub per_day: BTreeMap<String, u64>,
 }
 

--- a/vta-sdk/src/contexts.rs
+++ b/vta-sdk/src/contexts.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
 pub struct ContextRecord {
     /// The context's materialized path identifier — slash-separated segments
     /// (e.g. `acme/eng/team-a`). A top-level context is a single segment.
@@ -17,15 +18,18 @@ pub struct ContextRecord {
     pub parent: Option<String>,
     /// BIP-32 derivation base for this context's keys. For a sub-context this
     /// nests under the parent's base (`{parent.base_path}/<child>'`).
+    #[serde(alias = "base_path")]
     pub base_path: String,
     pub index: u32,
+    #[serde(alias = "created_at")]
     pub created_at: DateTime<Utc>,
+    #[serde(alias = "updated_at")]
     pub updated_at: DateTime<Utc>,
     /// Per-context policy constraining what context-scoped actors may do within
     /// this context (see [`crate::context_policy::ContextPolicy`]). Absent on
     /// legacy records and by default, which imposes no constraints — enforcement
     /// resolves the policy across the whole ancestor chain, so a missing policy
     /// at any level simply contributes nothing.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none", alias = "context_policy")]
     pub context_policy: Option<crate::context_policy::ContextPolicy>,
 }

--- a/vta-sdk/src/contexts.rs
+++ b/vta-sdk/src/contexts.rs
@@ -30,6 +30,10 @@ pub struct ContextRecord {
     /// legacy records and by default, which imposes no constraints — enforcement
     /// resolves the policy across the whole ancestor chain, so a missing policy
     /// at any level simply contributes nothing.
-    #[serde(default, skip_serializing_if = "Option::is_none", alias = "context_policy")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        alias = "context_policy"
+    )]
     pub context_policy: Option<crate::context_policy::ContextPolicy>,
 }

--- a/vta-sdk/src/did_templates/mod.rs
+++ b/vta-sdk/src/did_templates/mod.rs
@@ -98,8 +98,9 @@ pub enum Scope {
 /// A parsed DID template. Serialized shape matches the on-disk JSON file.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
 pub struct DidTemplate {
-    #[serde(rename = "schemaVersion")]
+    #[serde(rename = "schemaVersion", alias = "schema_version")]
     pub schema_version: u32,
 
     pub name: String,
@@ -119,11 +120,11 @@ pub struct DidTemplate {
 
     /// Variables the caller MUST supply. Reserved ambient names are not
     /// allowed here (see [`RESERVED_VARS`]).
-    #[serde(default, rename = "requiredVars")]
+    #[serde(default, rename = "requiredVars", alias = "required_vars")]
     pub required_vars: Vec<String>,
 
     /// Variables with default values. Caller-supplied values override.
-    #[serde(default, rename = "optionalVars")]
+    #[serde(default, rename = "optionalVars", alias = "optional_vars")]
     pub optional_vars: serde_json::Map<String, Value>,
 
     /// Hints for the CLI / setup wizards (e.g. `preRotationCount`, `portable`).

--- a/vta-sdk/src/protocols/acl_management/create.rs
+++ b/vta-sdk/src/protocols/acl_management/create.rs
@@ -60,27 +60,47 @@ pub struct CreateAclResultBody {
     pub expires_at: Option<u64>,
     /// The delegated step-up approver the maintainer now holds for this
     /// subject, if any (echoes the stored `step_up_approver`).
-    #[serde(default, skip_serializing_if = "Option::is_none", alias = "step_up_approver")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        alias = "step_up_approver"
+    )]
     pub step_up_approver: Option<String>,
     /// The per-entry step-up override the maintainer now holds for this subject,
     /// if any (echoes the stored `step_up_require`).
-    #[serde(default, skip_serializing_if = "Option::is_none", alias = "step_up_require")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        alias = "step_up_require"
+    )]
     pub step_up_require: Option<String>,
     /// Approve-authority the entry holds — `true` means it may confer *any*
     /// context via approval (while acting nowhere). Echoes the stored
     /// `approve_scope`; takes precedence over `approve_contexts`.
-    #[serde(default, skip_serializing_if = "std::ops::Not::not", alias = "approve_all_contexts")]
+    #[serde(
+        default,
+        skip_serializing_if = "std::ops::Not::not",
+        alias = "approve_all_contexts"
+    )]
     pub approve_all_contexts: bool,
     /// Approve-authority scoped to these contexts (echoes the stored
     /// `approve_scope`). Empty = confers nothing, unless `approve_all_contexts`.
-    #[serde(default, skip_serializing_if = "Vec::is_empty", alias = "approve_contexts")]
+    #[serde(
+        default,
+        skip_serializing_if = "Vec::is_empty",
+        alias = "approve_contexts"
+    )]
     pub approve_contexts: Vec<String>,
     /// The signing-oracle key filter the maintainer now holds for this
     /// subject (#818), echoing the stored `allowed_keys`. `None` = no filter
     /// (every key in the entry's contexts); **`Some([])` = no keys at all** —
     /// the skip is deliberately `Option::is_none`, never emptiness, so the
     /// two cannot collapse.
-    #[serde(default, skip_serializing_if = "Option::is_none", alias = "allowed_keys")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        alias = "allowed_keys"
+    )]
     pub allowed_keys: Option<Vec<String>>,
 }
 

--- a/vta-sdk/src/protocols/acl_management/create.rs
+++ b/vta-sdk/src/protocols/acl_management/create.rs
@@ -43,40 +43,44 @@ pub struct CreateAclResponseBody {
 /// approve members — so the storage layer is unaffected by the canonical fold.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
 pub struct CreateAclResultBody {
     pub did: String,
     pub role: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub label: Option<String>,
+    #[serde(alias = "allowed_contexts")]
     pub allowed_contexts: Vec<String>,
+    #[serde(alias = "created_at")]
     pub created_at: u64,
+    #[serde(alias = "created_by")]
     pub created_by: String,
     /// Unix-epoch seconds at which the entry auto-expires, if set.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none", alias = "expires_at")]
     pub expires_at: Option<u64>,
     /// The delegated step-up approver the maintainer now holds for this
     /// subject, if any (echoes the stored `step_up_approver`).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none", alias = "step_up_approver")]
     pub step_up_approver: Option<String>,
     /// The per-entry step-up override the maintainer now holds for this subject,
     /// if any (echoes the stored `step_up_require`).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none", alias = "step_up_require")]
     pub step_up_require: Option<String>,
     /// Approve-authority the entry holds — `true` means it may confer *any*
     /// context via approval (while acting nowhere). Echoes the stored
     /// `approve_scope`; takes precedence over `approve_contexts`.
-    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    #[serde(default, skip_serializing_if = "std::ops::Not::not", alias = "approve_all_contexts")]
     pub approve_all_contexts: bool,
     /// Approve-authority scoped to these contexts (echoes the stored
     /// `approve_scope`). Empty = confers nothing, unless `approve_all_contexts`.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty", alias = "approve_contexts")]
     pub approve_contexts: Vec<String>,
     /// The signing-oracle key filter the maintainer now holds for this
     /// subject (#818), echoing the stored `allowed_keys`. `None` = no filter
     /// (every key in the entry's contexts); **`Some([])` = no keys at all** —
     /// the skip is deliberately `Option::is_none`, never emptiness, so the
     /// two cannot collapse.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none", alias = "allowed_keys")]
     pub allowed_keys: Option<Vec<String>>,
 }
 

--- a/vta-sdk/src/protocols/audit_management/list.rs
+++ b/vta-sdk/src/protocols/audit_management/list.rs
@@ -25,6 +25,7 @@ use serde::{Deserialize, Serialize};
 /// deserialize.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
 pub struct AuditLogEntry {
     pub id: String,
     pub timestamp: u64,
@@ -35,7 +36,7 @@ pub struct AuditLogEntry {
     pub outcome: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub channel: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none", alias = "context_id")]
     pub context_id: Option<String>,
     /// Optional human-readable rationale supplied by the actor (e.g. the
     /// `reason` on a `vault.delete` / `vault.archive`). `#[serde(default)]`

--- a/vta-sdk/src/protocols/audit_management/retention.rs
+++ b/vta-sdk/src/protocols/audit_management/retention.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 /// operation takes no input parameters.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
 pub struct GetRetentionBody {}
 
 /// Request body for updating the audit log retention period.
@@ -12,12 +13,15 @@ pub struct GetRetentionBody {}
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct UpdateRetentionBody {
     /// Number of days to retain audit logs (minimum 1, maximum 365).
+    #[serde(alias = "retention_days")]
     pub retention_days: u32,
 }
 
 /// Response body for get/update retention.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
 pub struct RetentionResultBody {
+    #[serde(alias = "retention_days")]
     pub retention_days: u32,
 }

--- a/vta-sdk/src/protocols/backup_management/descriptors.rs
+++ b/vta-sdk/src/protocols/backup_management/descriptors.rs
@@ -25,9 +25,11 @@ use serde::{Deserialize, Serialize};
 /// only `SHA-256(token)` so a leaked DB doesn't leak the token.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
 pub struct BundleDescriptor {
     /// Server-generated UUID v4. Unique to this bundle for its
     /// entire lifecycle.
+    #[serde(alias = "bundle_id")]
     pub bundle_id: String,
 
     /// Transport algorithm. v1 supports only `"stream"`. Future:
@@ -37,23 +39,28 @@ pub struct BundleDescriptor {
 
     /// HTTPS URL for the byte transfer. For `stream`, this is the
     /// VTA's `{GET, POST} /backup/blob/{bundle_id}` URL.
+    #[serde(alias = "transport_url")]
     pub transport_url: String,
 
     /// Bearer token for the byte endpoint. Passed in the
     /// `X-Backup-Token` header. Never reused across bundles.
+    #[serde(alias = "transport_token")]
     pub transport_token: String,
 
     /// Hex-encoded SHA-256 of the byte stream. Wire-level integrity
     /// check independent of the encrypted envelope's internal MAC.
+    #[serde(alias = "expected_sha256")]
     pub expected_sha256: String,
 
     /// Total byte count. Lets the recipient pre-allocate buffers
     /// and detect truncated transfers.
+    #[serde(alias = "expected_size_bytes")]
     pub expected_size_bytes: u64,
 
     /// RFC 3339 timestamp after which the bundle is
     /// garbage-collected and the token rejected. Default 5 minutes
     /// from descriptor mint; max 1 hour.
+    #[serde(alias = "expires_at")]
     pub expires_at: DateTime<Utc>,
 }
 
@@ -71,6 +78,7 @@ fn default_true() -> bool {
 /// Auth: super-admin.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
 pub struct InitiateExportBody {
     /// Password to derive the AES-256-GCM key (Argon2id KDF).
     /// Minimum length is [`super::MIN_BACKUP_PASSWORD_LEN`], enforced at the
@@ -78,7 +86,7 @@ pub struct InitiateExportBody {
     pub password: String,
 
     /// Include audit logs in the backup. Default: false.
-    #[serde(default)]
+    #[serde(default, alias = "include_audit")]
     pub include_audit: bool,
 
     /// Preferred transport algorithm. Defaults to `"stream"`.
@@ -91,11 +99,13 @@ pub struct InitiateExportBody {
 /// `spec/vta/backup/initiate-export/1.0` response body.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
 pub struct InitiateExportResultBody {
     pub descriptor: BundleDescriptor,
 
     /// Operator-facing hint the CLI prints so they know how to
     /// complete the download.
+    #[serde(alias = "completion_hint")]
     pub completion_hint: String,
 }
 
@@ -103,14 +113,18 @@ pub struct InitiateExportResultBody {
 /// from the client after a successful download.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
 pub struct CompleteExportBody {
+    #[serde(alias = "bundle_id")]
     pub bundle_id: String,
 }
 
 /// `spec/vta/backup/complete-export/1.0` response body.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
 pub struct CompleteExportResultBody {
+    #[serde(alias = "bundle_id")]
     pub bundle_id: String,
     /// True if the byte stream was downloaded before this ack.
     /// False when the operator skipped the download or the bundle
@@ -124,13 +138,16 @@ pub struct CompleteExportResultBody {
 /// Auth: super-admin.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
 pub struct InitiateImportBody {
     /// Hex-encoded SHA-256 of the `.vtabak` bytes the client is
     /// about to upload. Pre-committed so the VTA detects tampered
     /// uploads.
+    #[serde(alias = "expected_sha256")]
     pub expected_sha256: String,
 
     /// Byte count of the upcoming upload.
+    #[serde(alias = "expected_size_bytes")]
     pub expected_size_bytes: u64,
 
     /// Preferred transport algorithm. Defaults to `"stream"`.
@@ -141,8 +158,10 @@ pub struct InitiateImportBody {
 /// `spec/vta/backup/initiate-import/1.0` response body.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
 pub struct InitiateImportResultBody {
     pub descriptor: BundleDescriptor,
+    #[serde(alias = "completion_hint")]
     pub completion_hint: String,
 }
 
@@ -152,7 +171,9 @@ pub struct InitiateImportResultBody {
 /// mode (no state mutation), `confirm: true` commits.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
 pub struct FinalizeImportBody {
+    #[serde(alias = "bundle_id")]
     pub bundle_id: String,
 
     /// Password to derive the AES-256-GCM key. Kept in the
@@ -172,17 +193,23 @@ pub struct FinalizeImportBody {
 /// becomes a structured `"preview" | "committed"`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
 pub struct FinalizeImportResultBody {
+    #[serde(alias = "bundle_id")]
     pub bundle_id: String,
     /// `"preview"` or `"committed"`.
     pub status: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "source_did")]
     pub source_did: Option<String>,
+    #[serde(alias = "key_count")]
     pub key_count: usize,
+    #[serde(alias = "acl_count")]
     pub acl_count: usize,
+    #[serde(alias = "context_count")]
     pub context_count: usize,
+    #[serde(alias = "audit_count")]
     pub audit_count: usize,
-    #[serde(default)]
+    #[serde(default, alias = "imported_secret_count")]
     pub imported_secret_count: usize,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
@@ -195,14 +222,18 @@ pub struct FinalizeImportResultBody {
 /// `BundleRecord.created_by`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
 pub struct AbortBundleBody {
+    #[serde(alias = "bundle_id")]
     pub bundle_id: String,
 }
 
 /// `spec/vta/backup/abort/1.0` response body.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
 pub struct AbortBundleResultBody {
+    #[serde(alias = "bundle_id")]
     pub bundle_id: String,
     /// True when the abort transitioned a live bundle to
     /// `Aborted`. False if the bundle was already in a terminal

--- a/vta-sdk/src/protocols/context_management/create.rs
+++ b/vta-sdk/src/protocols/context_management/create.rs
@@ -17,6 +17,7 @@ pub struct CreateContextBody {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
 pub struct CreateContextResultBody {
     pub id: String,
     pub name: String,
@@ -27,7 +28,10 @@ pub struct CreateContextResultBody {
     /// Parent context id, or `None` for a top-level context.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub parent: Option<String>,
+    #[serde(alias = "base_path")]
     pub base_path: String,
+    #[serde(alias = "created_at")]
     pub created_at: DateTime<Utc>,
+    #[serde(alias = "updated_at")]
     pub updated_at: DateTime<Utc>,
 }

--- a/vta-sdk/src/protocols/context_management/delete.rs
+++ b/vta-sdk/src/protocols/context_management/delete.rs
@@ -24,15 +24,19 @@ pub struct DeleteContextPreviewBody {
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
 pub struct DeleteContextPreviewResultBody {
     pub id: String,
     pub keys: Vec<String>,
+    #[serde(alias = "webvh_dids")]
     pub webvh_dids: Vec<String>,
     /// ACL entries that will be deleted (only have this context).
+    #[serde(alias = "acl_entries_removed")]
     pub acl_entries_removed: Vec<String>,
     /// ACL entries that will have this context removed from their allowed list.
+    #[serde(alias = "acl_entries_updated")]
     pub acl_entries_updated: Vec<String>,
     /// DID templates scoped to this context that will be deleted.
-    #[serde(default)]
+    #[serde(default, alias = "did_templates")]
     pub did_templates: Vec<String>,
 }

--- a/vta-sdk/src/protocols/context_management/update.rs
+++ b/vta-sdk/src/protocols/context_management/update.rs
@@ -5,6 +5,7 @@ use crate::context_policy::ContextPolicy;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
 pub struct UpdateContextBody {
     pub id: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -15,7 +16,7 @@ pub struct UpdateContextBody {
     pub description: Option<String>,
     /// Set this context's policy (super-admin only). Omitted leaves it
     /// unchanged; send [`ContextPolicy::unrestricted`] to clear constraints.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none", alias = "context_policy")]
     pub context_policy: Option<ContextPolicy>,
 }
 

--- a/vta-sdk/src/protocols/context_management/update.rs
+++ b/vta-sdk/src/protocols/context_management/update.rs
@@ -16,7 +16,11 @@ pub struct UpdateContextBody {
     pub description: Option<String>,
     /// Set this context's policy (super-admin only). Omitted leaves it
     /// unchanged; send [`ContextPolicy::unrestricted`] to clear constraints.
-    #[serde(default, skip_serializing_if = "Option::is_none", alias = "context_policy")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        alias = "context_policy"
+    )]
     pub context_policy: Option<ContextPolicy>,
 }
 

--- a/vta-sdk/src/protocols/did_management/create.rs
+++ b/vta-sdk/src/protocols/did_management/create.rs
@@ -217,22 +217,28 @@ pub struct CreateDidWebvhBody {
 
 #[derive(Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
 pub struct CreateDidWebvhResultBody {
     pub did: String,
+    #[serde(alias = "context_id")]
     pub context_id: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none", alias = "server_id")]
     pub server_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mnemonic: Option<String>,
     pub scid: String,
     pub portable: bool,
+    #[serde(alias = "signing_key_id")]
     pub signing_key_id: String,
+    #[serde(alias = "ka_key_id")]
     pub ka_key_id: String,
+    #[serde(alias = "pre_rotation_key_count")]
     pub pre_rotation_key_count: u32,
+    #[serde(alias = "created_at")]
     pub created_at: DateTime<Utc>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none", alias = "did_document")]
     pub did_document: Option<serde_json::Value>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none", alias = "log_entry")]
     pub log_entry: Option<String>,
 }
 

--- a/vta-sdk/src/protocols/did_management/create.rs
+++ b/vta-sdk/src/protocols/did_management/create.rs
@@ -236,7 +236,11 @@ pub struct CreateDidWebvhResultBody {
     pub pre_rotation_key_count: u32,
     #[serde(alias = "created_at")]
     pub created_at: DateTime<Utc>,
-    #[serde(default, skip_serializing_if = "Option::is_none", alias = "did_document")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        alias = "did_document"
+    )]
     pub did_document: Option<serde_json::Value>,
     #[serde(default, skip_serializing_if = "Option::is_none", alias = "log_entry")]
     pub log_entry: Option<String>,

--- a/vta-sdk/src/protocols/did_management/delete.rs
+++ b/vta-sdk/src/protocols/did_management/delete.rs
@@ -25,6 +25,10 @@ pub struct DeleteDidWebvhResultBody {
     /// backwards-compatible with consumers that expect the older
     /// `{did, deleted}` shape — a missing field deserialises as
     /// `None`, treated as "no daemon call needed."
-    #[serde(default, skip_serializing_if = "Option::is_none", alias = "daemon_cleanup_error")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        alias = "daemon_cleanup_error"
+    )]
     pub daemon_cleanup_error: Option<String>,
 }

--- a/vta-sdk/src/protocols/did_management/delete.rs
+++ b/vta-sdk/src/protocols/did_management/delete.rs
@@ -8,6 +8,7 @@ pub struct DeleteDidWebvhBody {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
 pub struct DeleteDidWebvhResultBody {
     pub did: String,
     pub deleted: bool,
@@ -24,6 +25,6 @@ pub struct DeleteDidWebvhResultBody {
     /// backwards-compatible with consumers that expect the older
     /// `{did, deleted}` shape — a missing field deserialises as
     /// `None`, treated as "no daemon call needed."
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none", alias = "daemon_cleanup_error")]
     pub daemon_cleanup_error: Option<String>,
 }

--- a/vta-sdk/src/protocols/did_management/passkey_vms.rs
+++ b/vta-sdk/src/protocols/did_management/passkey_vms.rs
@@ -68,6 +68,7 @@ pub struct RevokePasskeyVmBody {
 /// don't bump the wire version.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
 pub struct RevokePasskeyVmResponse {}
 
 /// Server-issued WebAuthn registration challenge. Returned by
@@ -81,7 +82,7 @@ pub struct EnrollPasskeyChallengeResponse {
     /// Opaque ceremony id — pass back via the `Idempotency-Key` /
     /// `X-Pnm-Ceremony-Id` header on submit. Stored server-side
     /// against the `PasskeyRegistration` state.
-    #[serde(rename = "ceremonyId")]
+    #[serde(rename = "ceremonyId", alias = "ceremony_id")]
     pub ceremony_id: String,
 
     /// WebAuthn challenge (base64url, ≥32 random bytes).
@@ -89,28 +90,28 @@ pub struct EnrollPasskeyChallengeResponse {
 
     /// Relying-Party identifier. A DNS name that matches the origin
     /// the browser is served from.
-    #[serde(rename = "rpId")]
+    #[serde(rename = "rpId", alias = "rp_id")]
     pub rp_id: String,
 
     /// Human-readable RP name.
-    #[serde(rename = "rpName")]
+    #[serde(rename = "rpName", alias = "rp_name")]
     pub rp_name: String,
 
     /// Stable WebAuthn user handle (base64url). Opaque to the
     /// client — the VTA derives a per-DID handle.
-    #[serde(rename = "userHandle")]
+    #[serde(rename = "userHandle", alias = "user_handle")]
     pub user_handle: String,
 
     /// WebAuthn user name (e.g. the DID or operator-supplied label).
-    #[serde(rename = "userName")]
+    #[serde(rename = "userName", alias = "user_name")]
     pub user_name: String,
 
     /// WebAuthn user display name.
-    #[serde(rename = "userDisplayName")]
+    #[serde(rename = "userDisplayName", alias = "user_display_name")]
     pub user_display_name: String,
 
     /// Suggested ceremony timeout, milliseconds.
-    #[serde(rename = "timeoutMs", default, skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "timeoutMs", default, skip_serializing_if = "Option::is_none", alias = "timeout_ms")]
     pub timeout_ms: Option<u32>,
 }
 
@@ -172,23 +173,25 @@ pub struct EnrollPasskeySubmitBody {
 /// to the DID document via a WebVH log entry.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
 pub struct EnrollPasskeySubmitResponse {
     /// The full verificationMethod entry as it now appears in the
     /// DID document.
-    #[serde(rename = "verificationMethod")]
+    #[serde(rename = "verificationMethod", alias = "verification_method")]
     pub verification_method: PasskeyVerificationMethod,
 
     /// WebVH log entry version that recorded the change (e.g.
     /// `"3-Qm…"`).
-    #[serde(rename = "webvhVersion")]
+    #[serde(rename = "webvhVersion", alias = "webvh_version")]
     pub webvh_version: String,
 }
 
 /// `GET` response.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
 pub struct ListPasskeyVmsResponse {
-    #[serde(rename = "verificationMethods")]
+    #[serde(rename = "verificationMethods", alias = "verification_methods")]
     pub verification_methods: Vec<PasskeyVerificationMethod>,
 }
 
@@ -197,20 +200,21 @@ pub struct ListPasskeyVmsResponse {
 /// `@pnm/core` `PasskeyVerificationMethod` type byte-for-byte.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
 pub struct PasskeyVerificationMethod {
     /// `<did>#passkey-<base64url(sha256(credential_id))>`.
     pub id: String,
     /// Always `"Multikey"`.
-    #[serde(rename = "type")]
+    #[serde(rename = "type", alias = "vm_type")]
     pub vm_type: String,
     /// The DID being augmented.
     pub controller: String,
     /// W3C Multikey form of the WebAuthn public key.
-    #[serde(rename = "publicKeyMultibase")]
+    #[serde(rename = "publicKeyMultibase", alias = "public_key_multibase")]
     pub public_key_multibase: String,
     /// WebAuthn `credential.id` (base64url) — lets a verifier find
     /// this VM by recomputing `sha256(credential.id)`.
-    #[serde(rename = "webauthnCredentialId")]
+    #[serde(rename = "webauthnCredentialId", alias = "webauthn_credential_id")]
     pub webauthn_credential_id: String,
     /// Transport hints; advisory only.
     #[serde(
@@ -218,6 +222,7 @@ pub struct PasskeyVerificationMethod {
         default,
         skip_serializing_if = "Vec::is_empty"
     )]
+    #[serde(alias = "webauthn_transports")]
     pub webauthn_transports: Vec<String>,
     /// Optional operator-supplied label.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/vta-sdk/src/protocols/did_management/passkey_vms.rs
+++ b/vta-sdk/src/protocols/did_management/passkey_vms.rs
@@ -111,7 +111,12 @@ pub struct EnrollPasskeyChallengeResponse {
     pub user_display_name: String,
 
     /// Suggested ceremony timeout, milliseconds.
-    #[serde(rename = "timeoutMs", default, skip_serializing_if = "Option::is_none", alias = "timeout_ms")]
+    #[serde(
+        rename = "timeoutMs",
+        default,
+        skip_serializing_if = "Option::is_none",
+        alias = "timeout_ms"
+    )]
     pub timeout_ms: Option<u32>,
 }
 

--- a/vta-sdk/src/protocols/did_management/servers.rs
+++ b/vta-sdk/src/protocols/did_management/servers.rs
@@ -52,6 +52,7 @@ pub struct ListWebvhServersResultBody {
 /// prompt in `create-did` / `register-did`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
 pub struct ListWebvhServerDomainsBody {
     #[serde(rename = "serverId", alias = "server_id")]
     pub server_id: String,
@@ -71,6 +72,7 @@ pub struct ListWebvhServerDomainsResultBody {
 /// server holds for this VTA against the DIDs the VTA has records for.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
 pub struct ReconcileWebvhServerDidsBody {
     #[serde(rename = "serverId", alias = "server_id")]
     pub server_id: String,
@@ -184,8 +186,10 @@ pub struct RemoveWebvhServerResultBody {
 /// always allowed without force.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
 pub struct RegisterDidWithServerBody {
     pub did: String,
+    #[serde(alias = "server_id")]
     pub server_id: String,
     #[serde(default)]
     pub force: bool,
@@ -200,8 +204,11 @@ pub struct RegisterDidWithServerBody {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
 pub struct RegisterDidWithServerResultBody {
     pub did: String,
+    #[serde(alias = "server_id")]
     pub server_id: String,
+    #[serde(alias = "log_entry_count")]
     pub log_entry_count: u32,
 }

--- a/vta-sdk/src/protocols/discovery.rs
+++ b/vta-sdk/src/protocols/discovery.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 /// shape; the operation takes no input parameters.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
 pub struct CapabilitiesBody {}
 
 pub const PROTOCOL_BASE: &str = "https://firstperson.network/protocols/discovery/1.0";
@@ -25,8 +26,10 @@ pub struct CapabilitiesResponse {
     /// Enabled services (REST, DIDComm).
     pub services: ServicesInfo,
     /// Configured WebVH servers available for DID creation.
+    #[serde(alias = "webvh_servers")]
     pub webvh_servers: Vec<WebvhServerInfo>,
     /// Supported DID creation modes.
+    #[serde(alias = "did_creation_modes")]
     pub did_creation_modes: Vec<String>,
 }
 

--- a/vta-sdk/src/protocols/key_management/get.rs
+++ b/vta-sdk/src/protocols/key_management/get.rs
@@ -4,6 +4,7 @@ use crate::keys::KeyRecord;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
 pub struct GetKeyBody {
     #[serde(rename = "keyId", alias = "key_id")]
     pub key_id: String,

--- a/vta-sdk/src/protocols/key_management/rename.rs
+++ b/vta-sdk/src/protocols/key_management/rename.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
 pub struct RenameKeyBody {
     #[serde(rename = "keyId", alias = "key_id")]
     pub key_id: String,
@@ -12,6 +13,7 @@ pub struct RenameKeyBody {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
 pub struct RenameKeyResultBody {
     #[serde(rename = "keyId", alias = "key_id")]
     pub key_id: String,

--- a/vta-sdk/src/protocols/key_management/revoke.rs
+++ b/vta-sdk/src/protocols/key_management/revoke.rs
@@ -5,6 +5,7 @@ use crate::keys::KeyStatus;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
 pub struct RevokeKeyBody {
     #[serde(rename = "keyId", alias = "key_id")]
     pub key_id: String,
@@ -15,6 +16,7 @@ pub struct RevokeKeyBody {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
 pub struct RevokeKeyResultBody {
     #[serde(rename = "keyId", alias = "key_id")]
     pub key_id: String,

--- a/vta-sdk/src/protocols/key_management/secret.rs
+++ b/vta-sdk/src/protocols/key_management/secret.rs
@@ -4,16 +4,23 @@ use crate::keys::KeyType;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
 pub struct GetKeySecretBody {
+    #[serde(alias = "key_id")]
     pub key_id: String,
 }
 
 #[derive(Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
 pub struct GetKeySecretResultBody {
+    #[serde(alias = "key_id")]
     pub key_id: String,
+    #[serde(alias = "key_type")]
     pub key_type: KeyType,
+    #[serde(alias = "public_key_multibase")]
     pub public_key_multibase: String,
+    #[serde(alias = "private_key_multibase")]
     pub private_key_multibase: String,
 }
 

--- a/vta-sdk/src/protocols/key_management/sign.rs
+++ b/vta-sdk/src/protocols/key_management/sign.rs
@@ -19,6 +19,7 @@ pub enum SignAlgorithm {
 /// Body of a sign-request message.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
 pub struct SignRequestBody {
     /// Key ID to sign with. Must be **active**, and the consumer enforces the
     /// caller's authority over it — this is not merely a caller-side
@@ -46,6 +47,7 @@ pub struct SignRequestBody {
 /// Body of a sign-result message.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
 pub struct SignResultBody {
     /// Key ID that was used.
     #[serde(rename = "keyId", alias = "key_id")]

--- a/vta-sdk/src/protocols/seed_management/list.rs
+++ b/vta-sdk/src/protocols/seed_management/list.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 /// operation takes no input parameters.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
 pub struct ListSeedsBody {}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -13,14 +14,17 @@ pub struct ListSeedsBody {}
 pub struct SeedInfo {
     pub id: u32,
     pub status: String,
+    #[serde(alias = "created_at")]
     pub created_at: DateTime<Utc>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none", alias = "retired_at")]
     pub retired_at: Option<DateTime<Utc>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
 pub struct ListSeedsResultBody {
     pub seeds: Vec<SeedInfo>,
+    #[serde(alias = "active_seed_id")]
     pub active_seed_id: u32,
 }

--- a/vta-sdk/src/protocols/seed_management/rotate.rs
+++ b/vta-sdk/src/protocols/seed_management/rotate.rs
@@ -20,7 +20,10 @@ impl std::fmt::Debug for RotateSeedBody {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
 pub struct RotateSeedResultBody {
+    #[serde(alias = "previous_seed_id")]
     pub previous_seed_id: u32,
+    #[serde(alias = "new_seed_id")]
     pub new_seed_id: u32,
 }

--- a/vta-sdk/src/webvh.rs
+++ b/vta-sdk/src/webvh.rs
@@ -23,40 +23,49 @@ use serde::{Deserialize, Serialize};
 /// from another VTA can't replay stale tokens here.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
 pub struct WebvhServerRecord {
     pub id: String,
     pub did: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub label: Option<String>,
+    #[serde(alias = "created_at")]
     pub created_at: DateTime<Utc>,
+    #[serde(alias = "updated_at")]
     pub updated_at: DateTime<Utc>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
 pub struct WebvhDidRecord {
     pub did: String,
+    #[serde(alias = "server_id")]
     pub server_id: String,
     pub mnemonic: String,
     pub scid: String,
+    #[serde(alias = "context_id")]
     pub context_id: String,
     pub portable: bool,
+    #[serde(alias = "log_entry_count")]
     pub log_entry_count: u32,
     /// Number of pre-rotation keys committed by the most recent log
     /// entry (matches `next_key_hashes.len()` of that entry). `0` means
     /// pre-rotation is disabled. Defaults to `0` for legacy records
     /// written before this field existed; the next update reads the
     /// effective value off the loaded log entry and persists it back.
-    #[serde(default)]
+    #[serde(default, alias = "pre_rotation_count")]
     pub pre_rotation_count: u32,
     /// Next monotonically-increasing fragment id to use when minting a
     /// new verificationMethod (`#key-{n}`). Stays stable for the
     /// lifetime of the DID; never decremented. Defaults to `1` for
     /// legacy records — the next rotate-keys call performs a one-shot
     /// scan of the existing document and persists the correct value.
-    #[serde(default = "default_next_fragment_id")]
+    #[serde(default = "default_next_fragment_id", alias = "next_fragment_id")]
     pub next_fragment_id: u32,
+    #[serde(alias = "created_at")]
     pub created_at: DateTime<Utc>,
+    #[serde(alias = "updated_at")]
     pub updated_at: DateTime<Utc>,
 }
 

--- a/vta-sdk/tests/auth_light_rest.rs
+++ b/vta-sdk/tests/auth_light_rest.rs
@@ -544,14 +544,18 @@ async fn ensure_token_valid_refreshes_expired_access_token() {
         .await;
 
     // Downstream call must carry the *refreshed* token, not the expired one.
-    Mock::given(method("GET"))
-        .and(path("/config"))
+    // `get_config` is the probe for "an authenticated call"; it now rides the
+    // Trust Tasks HTTPS binding like every other typed operation.
+    Mock::given(method("POST"))
+        .and(path("/api/trust-tasks"))
         .and(wiremock::matchers::header(
             "authorization",
             "Bearer fresh-access",
         ))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "fields": []
+            "id": "urn:uuid:00000000-0000-4000-8000-000000000000",
+            "type": "urn:test:response",
+            "payload": {"fields": []}
         })))
         .expect(1)
         .mount(&server)
@@ -637,14 +641,18 @@ async fn ensure_token_valid_full_reauth_when_refresh_expired() {
         .mount(&server)
         .await;
 
-    Mock::given(method("GET"))
-        .and(path("/config"))
+    // `get_config` is the probe for "an authenticated call"; it now rides the
+    // Trust Tasks HTTPS binding like every other typed operation.
+    Mock::given(method("POST"))
+        .and(path("/api/trust-tasks"))
         .and(wiremock::matchers::header(
             "authorization",
             "Bearer reauth-access",
         ))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "fields": []
+            "id": "urn:uuid:00000000-0000-4000-8000-000000000000",
+            "type": "urn:test:response",
+            "payload": {"fields": []}
         })))
         .expect(1)
         .mount(&server)
@@ -729,14 +737,18 @@ async fn ensure_token_valid_falls_through_when_refresh_fails() {
         .mount(&server)
         .await;
 
-    Mock::given(method("GET"))
-        .and(path("/config"))
+    // `get_config` is the probe for "an authenticated call"; it now rides the
+    // Trust Tasks HTTPS binding like every other typed operation.
+    Mock::given(method("POST"))
+        .and(path("/api/trust-tasks"))
         .and(wiremock::matchers::header(
             "authorization",
             "Bearer fallback-access",
         ))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "fields": []
+            "id": "urn:uuid:00000000-0000-4000-8000-000000000000",
+            "type": "urn:test:response",
+            "payload": {"fields": []}
         })))
         .expect(1)
         .mount(&server)

--- a/vta-sdk/tests/client_rest.rs
+++ b/vta-sdk/tests/client_rest.rs
@@ -21,8 +21,48 @@ use vta_sdk::client::*;
 use vta_sdk::error::VtaError;
 use vta_sdk::keys::{KeyOrigin, KeyStatus, KeyType};
 use vta_sdk::protocols::key_management::sign::SignAlgorithm;
-use wiremock::matchers::{header, method, path};
+use wiremock::matchers::{body_partial_json, header, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
+
+// ── Trust Tasks HTTPS binding test surface ─────────────────────────────
+//
+// Every `rpc_tt` call posts the same envelope to the same path, so a mock can
+// no longer be selected by method and route. What identifies a call now is the
+// envelope `type` and the `payload` — which is strictly more precise, because
+// the payload is what the VTA actually acts on.
+
+const TASK_ACL_LIST: &str = "https://trusttasks.org/spec/acl/list/0.1";
+const TASK_KEYS_LIST: &str = "https://trusttasks.org/spec/keys/list/0.1";
+const TASK_AUDIT_LIST: &str = "https://trusttasks.org/spec/audit/list/0.1";
+/// `get_key_secret` dispatches this: the operation moved to the seeds slice
+/// because it acts on the seed behind the key, not the key itself.
+const TASK_SEEDS_EXPORT_MNEMONIC: &str =
+    "https://trusttasks.org/spec/vta/seeds/export-mnemonic/1.0";
+const TASK_WEBVH_DIDS_LIST: &str = "https://trusttasks.org/spec/vta/webvh/dids/list/1.0";
+
+/// A success response document carrying `payload`.
+fn tt_ok(payload: Value) -> ResponseTemplate {
+    ResponseTemplate::new(200).set_body_json(json!({
+        "id": "urn:uuid:00000000-0000-4000-8000-000000000000",
+        "type": "urn:test:response",
+        "payload": payload,
+    }))
+}
+
+/// Assert a key is *absent* from the payload.
+///
+/// `body_partial_json` can only assert presence, so omission — which is the
+/// whole point of a field a forward-compatible VTA would reject — needs its
+/// own matcher.
+fn no_payload_key(key: &'static str) -> impl Fn(&wiremock::Request) -> bool {
+    move |req: &wiremock::Request| {
+        serde_json::from_slice::<Value>(&req.body)
+            .ok()
+            .and_then(|v| v.get("payload").cloned())
+            .map(|p| p.get(key).is_none())
+            .unwrap_or(false)
+    }
+}
 
 // ── Test harness ────────────────────────────────────────────────────
 
@@ -42,19 +82,37 @@ fn auth_match() -> impl wiremock::Match {
     header("authorization", &*format!("Bearer {TOKEN}"))
 }
 
-/// Helper to mount a single mock that matches method + path + auth and
-/// returns a JSON body. The mock is auto-asserted via `.expect(1)` so a
-/// missing or extra call surfaces in the test failure.
+/// Mount the reply to one typed call.
+///
+/// Every operation now leaves over the HTTPS binding — `POST /api/trust-tasks`
+/// carrying a Trust Task document — so there is no per-operation method or
+/// path left to match on. The `m` and `p` arguments are retained because each
+/// test still documents which REST route its operation *used* to occupy, and
+/// losing that would make this file harder to read against its own history;
+/// they are deliberately not matched.
+///
+/// The body a test supplies is the operation's payload, so it is wrapped in a
+/// response document the way a conforming server replies. What each operation
+/// *dispatches* is asserted separately, in `dispatches_the_canonical_task`.
+/// Mock the Trust Tasks HTTPS binding: every `rpc_tt`/`rpc_tt_void` call posts
+/// to `/api/trust-tasks` regardless of the operation, so the method and path
+/// arguments no longer select anything. They are kept because the call sites
+/// read better naming the operation being mocked, and because a future
+/// per-task assertion will want them back.
 async fn mount_json(
     server: &MockServer,
-    m: &str,
-    p: &str,
+    _m: &str,
+    _p: &str,
     status: u16,
     body: Value,
 ) -> wiremock::MockGuard {
-    let resp = ResponseTemplate::new(status).set_body_json(body);
-    Mock::given(method(m))
-        .and(path(p))
+    let resp = ResponseTemplate::new(status).set_body_json(json!({
+        "id": "urn:uuid:00000000-0000-4000-8000-000000000000",
+        "type": "urn:test:response",
+        "payload": body,
+    }));
+    Mock::given(method("POST"))
+        .and(path("/api/trust-tasks"))
         .and(auth_match())
         .respond_with(resp)
         .expect(1)
@@ -62,9 +120,44 @@ async fn mount_json(
         .await
 }
 
-async fn mount_status(server: &MockServer, m: &str, p: &str, status: u16) -> wiremock::MockGuard {
+/// Mock a genuinely-REST route — one with no trust-task twin, which therefore
+/// keeps its bespoke method and path. Backup blob streaming, the import
+/// wrapping key and the deprecated legacy-`rpc` DID verbs are the whole set;
+/// anything else reaching for this helper is probably a task in disguise.
+async fn mount_rest_json(
+    server: &MockServer,
+    m: &str,
+    p: &str,
+    status: u16,
+    body: Value,
+) -> wiremock::MockGuard {
     Mock::given(method(m))
         .and(path(p))
+        .and(auth_match())
+        .respond_with(ResponseTemplate::new(status).set_body_json(body))
+        .expect(1)
+        .mount_as_scoped(server)
+        .await
+}
+
+async fn mount_rest_status(
+    server: &MockServer,
+    m: &str,
+    p: &str,
+    status: u16,
+) -> wiremock::MockGuard {
+    Mock::given(method(m))
+        .and(path(p))
+        .and(auth_match())
+        .respond_with(ResponseTemplate::new(status).set_body_json(err_body("bad")))
+        .expect(1)
+        .mount_as_scoped(server)
+        .await
+}
+
+async fn mount_status(server: &MockServer, _m: &str, _p: &str, status: u16) -> wiremock::MockGuard {
+    Mock::given(method("POST"))
+        .and(path("/api/trust-tasks"))
         .and(auth_match())
         .respond_with(ResponseTemplate::new(status).set_body_json(err_body("bad")))
         .expect(1)
@@ -289,7 +382,7 @@ async fn backup_export_returns_envelope() {
         "includes_audit": false,
         "ciphertext": "AAAA"
     });
-    let _g = mount_json(&server, "POST", "/backup/export", 200, envelope).await;
+    let _g = mount_rest_json(&server, "POST", "/backup/export", 200, envelope).await;
     let c = client(&server).await;
     let env = c.backup_export("hunter2hunter2", false).await.unwrap();
     assert_eq!(env.version, 1);
@@ -300,7 +393,7 @@ async fn backup_export_returns_envelope() {
 #[tokio::test]
 async fn backup_export_403_maps_to_forbidden() {
     let server = MockServer::start().await;
-    let _g = mount_status(&server, "POST", "/backup/export", 403).await;
+    let _g = mount_rest_status(&server, "POST", "/backup/export", 403).await;
     let c = client(&server).await;
     let err = c.backup_export("pw", false).await.unwrap_err();
     assert!(matches!(err, VtaError::Forbidden(_)));
@@ -358,14 +451,17 @@ async fn create_key_round_trip() {
 #[tokio::test]
 async fn list_keys_paginates_query_params() {
     let server = MockServer::start().await;
-    Mock::given(method("GET"))
-        .and(path("/keys"))
+    Mock::given(method("POST"))
+        .and(path("/api/trust-tasks"))
         .and(auth_match())
-        .and(wiremock::matchers::query_param("offset", "10"))
-        .and(wiremock::matchers::query_param("limit", "5"))
-        .and(wiremock::matchers::query_param("status", "active"))
-        .and(wiremock::matchers::query_param("context_id", "ctx-a"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+        .and(body_partial_json(json!({
+            "type": TASK_KEYS_LIST,
+            "payload": {
+                "offset": 10, "limit": 5,
+                "status": "active", "contextId": "ctx-a"
+            }
+        })))
+        .respond_with(tt_ok(json!({
             "keys": [key_record_json("k1")],
             "total": 1
         })))
@@ -497,7 +593,7 @@ async fn rename_key_409_maps_to_conflict() {
 #[tokio::test]
 async fn get_wrapping_key_returns_jwk() {
     let server = MockServer::start().await;
-    let _g = mount_json(
+    let _g = mount_rest_json(
         &server,
         "GET",
         "/keys/import/wrapping-key",
@@ -616,11 +712,16 @@ async fn list_acl_no_filter() {
 #[tokio::test]
 async fn list_acl_with_context_query() {
     let server = MockServer::start().await;
-    Mock::given(method("GET"))
-        .and(path("/acl"))
+    Mock::given(method("POST"))
+        .and(path("/api/trust-tasks"))
         .and(auth_match())
-        .and(wiremock::matchers::query_param("context", "ctx-a"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"entries": []})))
+        // `scope`, not `context`: the task payload names the filter
+        // differently from the query string it replaced.
+        .and(body_partial_json(json!({
+            "type": TASK_ACL_LIST,
+            "payload": {"scope": "ctx-a"}
+        })))
+        .respond_with(tt_ok(json!({"entries": []})))
         .expect(1)
         .mount(&server)
         .await;
@@ -637,12 +738,13 @@ async fn list_acl_sends_the_direction_only_when_it_is_not_the_default() {
     use vta_sdk::acl::ContextDirection;
 
     let server = MockServer::start().await;
-    Mock::given(method("GET"))
-        .and(path("/acl"))
+    Mock::given(method("POST"))
+        .and(path("/api/trust-tasks"))
         .and(auth_match())
-        .and(wiremock::matchers::query_param("context", "acme/eng"))
-        .and(wiremock::matchers::query_param("direction", "subtree"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"entries": []})))
+        .and(body_partial_json(json!({
+            "payload": {"scope": "acme/eng", "direction": "subtree"}
+        })))
+        .respond_with(tt_ok(json!({"entries": []})))
         .expect(1)
         .mount(&server)
         .await;
@@ -652,12 +754,14 @@ async fn list_acl_sends_the_direction_only_when_it_is_not_the_default() {
         .unwrap();
     server.reset().await;
 
-    Mock::given(method("GET"))
-        .and(path("/acl"))
+    Mock::given(method("POST"))
+        .and(path("/api/trust-tasks"))
         .and(auth_match())
-        .and(wiremock::matchers::query_param("context", "acme/eng"))
-        .and(wiremock::matchers::query_param_is_missing("direction"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"entries": []})))
+        .and(body_partial_json(json!({"payload": {"scope": "acme/eng"}})))
+        // An old VTA rejects an unknown field, so the default direction must
+        // be omitted rather than spelled out.
+        .and(no_payload_key("direction"))
+        .respond_with(tt_ok(json!({"entries": []})))
         .expect(2)
         .mount(&server)
         .await;
@@ -812,10 +916,10 @@ async fn update_acl_patches() {
 #[tokio::test]
 async fn delete_acl_returns_unit() {
     let server = MockServer::start().await;
-    Mock::given(method("DELETE"))
-        .and(path("/acl/did:key:zAdmin"))
+    Mock::given(method("POST"))
+        .and(path("/api/trust-tasks"))
         .and(auth_match())
-        .respond_with(ResponseTemplate::new(204))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"payload": {}})))
         .expect(1)
         .mount(&server)
         .await;
@@ -955,11 +1059,10 @@ async fn preview_delete_context_returns_summary() {
 #[tokio::test]
 async fn delete_context_with_force_query() {
     let server = MockServer::start().await;
-    Mock::given(method("DELETE"))
-        .and(path("/contexts/primary"))
+    Mock::given(method("POST"))
+        .and(path("/api/trust-tasks"))
         .and(auth_match())
-        .and(wiremock::matchers::query_param("force", "true"))
-        .respond_with(ResponseTemplate::new(204))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"payload": {}})))
         .expect(1)
         .mount(&server)
         .await;
@@ -970,10 +1073,10 @@ async fn delete_context_with_force_query() {
 #[tokio::test]
 async fn delete_context_no_force_omits_query() {
     let server = MockServer::start().await;
-    Mock::given(method("DELETE"))
-        .and(path("/contexts/primary"))
+    Mock::given(method("POST"))
+        .and(path("/api/trust-tasks"))
         .and(auth_match())
-        .respond_with(ResponseTemplate::new(204))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"payload": {}})))
         .expect(1)
         .mount(&server)
         .await;
@@ -1106,10 +1209,10 @@ async fn update_webvh_server_patches() {
 #[tokio::test]
 async fn remove_webvh_server_deletes() {
     let server = MockServer::start().await;
-    Mock::given(method("DELETE"))
-        .and(path("/webvh/servers/s1"))
+    Mock::given(method("POST"))
+        .and(path("/api/trust-tasks"))
         .and(auth_match())
-        .respond_with(ResponseTemplate::new(204))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"payload": {}})))
         .expect(1)
         .mount(&server)
         .await;
@@ -1187,12 +1290,14 @@ async fn create_did_webvh_posts() {
 #[tokio::test]
 async fn list_dids_webvh_filters_by_context() {
     let server = MockServer::start().await;
-    Mock::given(method("GET"))
-        .and(path("/webvh/dids"))
+    Mock::given(method("POST"))
+        .and(path("/api/trust-tasks"))
         .and(auth_match())
-        .and(wiremock::matchers::query_param("context_id", "primary"))
-        .and(wiremock::matchers::query_param("server_id", "s1"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+        .and(body_partial_json(json!({
+            "type": TASK_WEBVH_DIDS_LIST,
+            "payload": {"context_id": "primary", "server_id": "s1"}
+        })))
+        .respond_with(tt_ok(json!({
             "dids": [webvh_did_record_json("did:webvh:Qabc:server.example.com:primary")]
         })))
         .expect(1)
@@ -1242,10 +1347,10 @@ async fn get_did_webvh_log_returns_log() {
 #[tokio::test]
 async fn delete_did_webvh_returns_unit() {
     let server = MockServer::start().await;
-    Mock::given(method("DELETE"))
-        .and(path("/webvh/dids/did:webvh:abc"))
+    Mock::given(method("POST"))
+        .and(path("/api/trust-tasks"))
         .and(auth_match())
-        .respond_with(ResponseTemplate::new(204))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"payload": {}})))
         .expect(1)
         .mount(&server)
         .await;
@@ -1302,7 +1407,7 @@ async fn update_did_webvh_by_did_sends_the_canonical_task() {
 #[tokio::test]
 async fn update_did_webvh_posts_to_context_path() {
     let server = MockServer::start().await;
-    let _g = mount_json(
+    let _g = mount_rest_json(
         &server,
         "POST",
         "/contexts/primary/dids/Qabc/update",
@@ -1330,7 +1435,7 @@ async fn update_did_webvh_posts_to_context_path() {
 #[tokio::test]
 async fn rotate_did_webvh_keys_posts() {
     let server = MockServer::start().await;
-    let _g = mount_json(
+    let _g = mount_rest_json(
         &server,
         "POST",
         "/contexts/primary/dids/Qabc/rotate-keys",
@@ -1362,16 +1467,21 @@ async fn rotate_did_webvh_keys_posts() {
 #[tokio::test]
 async fn list_audit_logs_paginates() {
     let server = MockServer::start().await;
-    Mock::given(method("GET"))
-        .and(path("/audit/logs"))
+    Mock::given(method("POST"))
+        .and(path("/api/trust-tasks"))
         .and(auth_match())
         // camelCase, per canonical `audit/list/0.1`. A snake_case key
-        // here would be dropped by the route's serde binding and the
+        // here would be dropped by the handler's serde binding and the
         // filter would silently not apply.
-        .and(wiremock::matchers::query_param("pageSize", "25"))
-        .and(wiremock::matchers::query_param("action", "key.create"))
-        .and(wiremock::matchers::query_param("cursor", "opaque-token"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+        .and(body_partial_json(json!({
+            "type": TASK_AUDIT_LIST,
+            "payload": {
+                "pageSize": 25,
+                "action": "key.create",
+                "cursor": "opaque-token"
+            }
+        })))
+        .respond_with(tt_ok(json!({
             "entries": [{
                 "eventId": "e1",
                 "recordedAt": "2026-07-01T00:00:00+00:00",
@@ -1406,16 +1516,13 @@ async fn list_audit_logs_paginates() {
 #[tokio::test]
 async fn audit_list_percent_encodes_rfc3339_bounds() {
     let server = MockServer::start().await;
-    Mock::given(method("GET"))
-        .and(path("/audit/logs"))
+    Mock::given(method("POST"))
+        .and(path("/api/trust-tasks"))
         .and(auth_match())
-        .and(wiremock::matchers::query_param(
-            "from",
-            "2026-07-01T00:00:00+00:00",
-        ))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "entries": [], "truncated": false
+        .and(body_partial_json(json!({
+            "payload": {"from": "2026-07-01T00:00:00Z"}
         })))
+        .respond_with(tt_ok(json!({"entries": [], "truncated": false})))
         .expect(1)
         .mount(&server)
         .await;
@@ -1558,10 +1665,10 @@ async fn update_did_template_puts() {
 #[tokio::test]
 async fn delete_did_template_returns_unit() {
     let server = MockServer::start().await;
-    Mock::given(method("DELETE"))
-        .and(path("/did-templates/x"))
+    Mock::given(method("POST"))
+        .and(path("/api/trust-tasks"))
         .and(auth_match())
-        .respond_with(ResponseTemplate::new(204))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"payload": {}})))
         .expect(1)
         .mount(&server)
         .await;
@@ -1662,10 +1769,10 @@ async fn update_context_did_template_puts() {
 #[tokio::test]
 async fn delete_context_did_template_returns_unit() {
     let server = MockServer::start().await;
-    Mock::given(method("DELETE"))
-        .and(path("/contexts/primary/did-templates/x"))
+    Mock::given(method("POST"))
+        .and(path("/api/trust-tasks"))
         .and(auth_match())
-        .respond_with(ResponseTemplate::new(204))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"payload": {}})))
         .expect(1)
         .mount(&server)
         .await;
@@ -1732,11 +1839,14 @@ async fn fetch_context_secrets_walks_all_pages() {
     for i in 0..100 {
         page1_keys.push(key_record_json(&format!("k{i}")));
     }
-    Mock::given(method("GET"))
-        .and(path("/keys"))
+    Mock::given(method("POST"))
+        .and(path("/api/trust-tasks"))
         .and(auth_match())
-        .and(wiremock::matchers::query_param("offset", "0"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+        .and(body_partial_json(json!({
+            "type": TASK_KEYS_LIST,
+            "payload": {"offset": 0}
+        })))
+        .respond_with(tt_ok(json!({
             "keys": page1_keys,
             "total": 101
         })))
@@ -1745,11 +1855,14 @@ async fn fetch_context_secrets_walks_all_pages() {
         .await;
 
     // Page 2: 1 key
-    Mock::given(method("GET"))
-        .and(path("/keys"))
+    Mock::given(method("POST"))
+        .and(path("/api/trust-tasks"))
         .and(auth_match())
-        .and(wiremock::matchers::query_param("offset", "100"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+        .and(body_partial_json(json!({
+            "type": TASK_KEYS_LIST,
+            "payload": {"offset": 100}
+        })))
+        .respond_with(tt_ok(json!({
             "keys": [key_record_json("k100")],
             "total": 101
         })))
@@ -1762,10 +1875,13 @@ async fn fetch_context_secrets_walks_all_pages() {
     // x25519 multibase below is a literal `[2u8; 32]` encoded with
     // multicodec X25519 (0xec01) — `secret_from_key_response` accepts
     // any 32-byte key, so the value just needs to round-trip.
-    Mock::given(method("GET"))
-        .and(path_regex(r"^/keys/[^/]+/secret$"))
+    Mock::given(method("POST"))
+        .and(path("/api/trust-tasks"))
         .and(auth_match())
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+        .and(body_partial_json(
+            json!({"type": TASK_SEEDS_EXPORT_MNEMONIC}),
+        ))
+        .respond_with(tt_ok(json!({
             "key_id": "k",
             "key_type": "x25519",
             "public_key_multibase": "z6LSqHQEbN8eMpx9NhMTXmxqYDhtbW5kqwQYWN9y91vxqMtq",
@@ -1834,8 +1950,8 @@ async fn http_418_maps_to_other() {
 #[tokio::test]
 async fn malformed_error_body_falls_back_to_raw_text() {
     let server = MockServer::start().await;
-    Mock::given(method("GET"))
-        .and(path("/config"))
+    Mock::given(method("POST"))
+        .and(path("/api/trust-tasks"))
         .respond_with(ResponseTemplate::new(500).set_body_string("not json"))
         .mount(&server)
         .await;
@@ -1856,8 +1972,8 @@ async fn oversized_error_body_is_truncated() {
     // error string. The fallback truncates the raw text and marks it with `…`.
     let server = MockServer::start().await;
     let huge = "x".repeat(10_000);
-    Mock::given(method("GET"))
-        .and(path("/config"))
+    Mock::given(method("POST"))
+        .and(path("/api/trust-tasks"))
         .respond_with(ResponseTemplate::new(500).set_body_string(huge))
         .mount(&server)
         .await;

--- a/vta-service/tests/api_integration.rs
+++ b/vta-service/tests/api_integration.rs
@@ -1953,10 +1953,7 @@ async fn create_did_webvh_template_mode() {
         "template create: {status} {body}"
     );
     assert!(body["did"].as_str().is_some(), "response has did");
-    assert!(
-        body["didDocument"].is_object(),
-        "response has did_document"
-    );
+    assert!(body["didDocument"].is_object(), "response has did_document");
     assert!(
         body["logEntry"].as_str().is_some(),
         "response has log_entry"
@@ -2961,10 +2958,7 @@ async fn ctx_did_templates_deleted_when_parent_context_deleted() {
         ))
         .await;
     assert_eq!(status, StatusCode::OK);
-    assert_eq!(
-        preview["didTemplates"].as_array().map(|a| a.len()),
-        Some(1)
-    );
+    assert_eq!(preview["didTemplates"].as_array().map(|a| a.len()), Some(1));
     assert_eq!(preview["didTemplates"][0], "will-be-deleted");
 
     // Force-delete the context.

--- a/vta-service/tests/api_integration.rs
+++ b/vta-service/tests/api_integration.rs
@@ -1455,7 +1455,7 @@ async fn audit_retention_get_and_update() {
     // Get current retention
     let (status, body) = app.request(get_auth("/audit/retention", &token)).await;
     assert_eq!(status, StatusCode::OK);
-    assert!(body["retention_days"].is_number());
+    assert!(body["retentionDays"].is_number());
 
     // Update retention
     let (status, body) = app
@@ -1954,15 +1954,15 @@ async fn create_did_webvh_template_mode() {
     );
     assert!(body["did"].as_str().is_some(), "response has did");
     assert!(
-        body["did_document"].is_object(),
+        body["didDocument"].is_object(),
         "response has did_document"
     );
     assert!(
-        body["log_entry"].as_str().is_some(),
+        body["logEntry"].as_str().is_some(),
         "response has log_entry"
     );
     // Verify the template was used (custom key ID present in returned document)
-    let doc = &body["did_document"];
+    let doc = &body["didDocument"];
     let vm = doc["verificationMethod"]
         .as_array()
         .expect("verificationMethod array");
@@ -1999,7 +1999,7 @@ async fn create_did_webvh_final_mode_stores_record() {
         StatusCode::CREATED,
         "bootstrap create: {status} {created}"
     );
-    let log_entry = created["log_entry"].as_str().expect("log_entry string");
+    let log_entry = created["logEntry"].as_str().expect("log_entry string");
 
     // Now create another DID using the log entry in final mode, under a new context
     let token2 = setup_webvh_context(&app, &ctx, "test-final-2").await;
@@ -2022,8 +2022,8 @@ async fn create_did_webvh_final_mode_stores_record() {
     let final_did = body["did"].as_str().expect("did in response");
     assert!(!final_did.is_empty());
     // signing_key_id and ka_key_id are empty in final mode (VTA didn't derive keys)
-    assert_eq!(body["signing_key_id"].as_str().unwrap(), "");
-    assert_eq!(body["ka_key_id"].as_str().unwrap(), "");
+    assert_eq!(body["signingKeyId"].as_str().unwrap(), "");
+    assert_eq!(body["kaKeyId"].as_str().unwrap(), "");
 }
 
 #[cfg(feature = "webvh")]
@@ -2299,7 +2299,7 @@ async fn create_did_webvh_with_user_signing_key() {
     );
     assert!(body["did"].as_str().is_some());
     // Document should have signing key but no keyAgreement
-    let doc = &body["did_document"];
+    let doc = &body["didDocument"];
     assert!(doc["authentication"].is_array());
     assert!(doc.get("keyAgreement").is_none() || doc["keyAgreement"].is_null());
 }
@@ -2329,7 +2329,7 @@ async fn create_did_webvh_with_user_signing_and_ka_keys() {
         StatusCode::CREATED,
         "both keys create: {status} {body}"
     );
-    let doc = &body["did_document"];
+    let doc = &body["didDocument"];
     assert!(doc["keyAgreement"].is_array(), "should have keyAgreement");
     let vm = doc["verificationMethod"].as_array().unwrap();
     assert_eq!(vm.len(), 2, "should have 2 verification methods");
@@ -2962,10 +2962,10 @@ async fn ctx_did_templates_deleted_when_parent_context_deleted() {
         .await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(
-        preview["did_templates"].as_array().map(|a| a.len()),
+        preview["didTemplates"].as_array().map(|a| a.len()),
         Some(1)
     );
-    assert_eq!(preview["did_templates"][0], "will-be-deleted");
+    assert_eq!(preview["didTemplates"][0], "will-be-deleted");
 
     // Force-delete the context.
     let (status, _) = app
@@ -3024,7 +3024,7 @@ async fn create_did_webvh_via_builtin_mediator_template() {
     // serviceEndpoint is an array of two endpoints — HTTP first, WSS
     // second. The mediator template advertises both transports under one
     // `#service` entry; clients pick whichever transport they support.
-    let doc = &body["did_document"];
+    let doc = &body["didDocument"];
     assert!(doc.is_object(), "result must include did_document");
     let services = doc["service"].as_array().unwrap();
     let didcomm = services
@@ -3400,7 +3400,7 @@ async fn create_did_webvh_context_scoped_template_shadows_global() {
     // The fact that it succeeded (and the service shape from `sample_template`
     // is present — a `Custom` service type we used in the sample) confirms
     // the rendered doc came from a template, not the VTA's auto-builder.
-    let doc = &body["did_document"];
+    let doc = &body["didDocument"];
     assert_eq!(doc["service"][0]["type"], "Custom");
 }
 


### PR DESCRIPTION
## What

53 wire structs across `vta-sdk/src/protocols/**` (plus `webvh.rs`,
`contexts.rs`, `context_policy.rs`, `did_templates/mod.rs`) emitted snake_case
on Trust Task payloads. SPEC §4.10 makes lowerCamelCase the wire contract, so
every consumer generated from the published schemas disagreed with what this
agent actually sends.

The fold is Postel's: `rename_all = "camelCase"` changes what is **emitted**, a
per-field `alias` keeps the old spelling accepted on **intake**. 126 fields
carry an alias, so a producer written against the previous wire keeps working
while it migrates.

## Why it was invisible

Nothing round-trips both sides. A hand-transcribed TS type has nothing to
disagree with, and the Rust side never reads its own output — so the drift only
surfaces when someone writes a client from the spec and it doesn't work.
Specifying the families upstream (trustoverip/dtgwg-trust-tasks-tf#240) is the
other half of this fix.

## Three exclusions that are not oversights

- **Config (`setup/from_toml.rs`)** — TOML, where snake_case is idiomatic. Not
  a wire.
- **Persisted stores and the backup format** (`backup_management/types.rs`,
  `drain_store.rs`) — read back from disk. Re-casing these would fail to read
  data already written, which is a worse bug than the one being fixed.
  `WebvhDidRecord` is both wire and persisted: it *is* folded, and existing
  snake_case records still read because of the aliases.
- **`protocols/credential_exchange.rs`** — OID4VCI/OID4VP structures
  (`vp_token`, `credential_offer`, `dcql_query`). §4.10 requires externally
  owned names to be carried verbatim. A first pass re-cased `vp_token` and the
  conformance harness caught it, which is exactly what that test is for.

## Deliberately out of scope

REST request/response bodies (`routes/`, `client/types.rs`, `protocol/`) are a
further 54 structs with the same problem. Unlike task payloads, no published
schema pins their casing and they have no aliases to fall back on, so changing
what they emit breaks readers silently.

The follow-up PR takes a different route: it removes the bespoke REST bodies
from the picture entirely by carrying Trust Tasks over the HTTPS binding, which
makes their casing moot rather than needing a second fold.

## Known gap

The fold rewrites **structs**. A payload built as an inline `serde_json::json!`
literal has no struct to fold, so it keeps whatever spelling was typed —
`list_dids_webvh` and `get_key_secret` still emit `context_id` / `server_id` /
`key_id`. Nothing breaks (the receiving structs carry aliases), but the SDK is
emitting a non-canonical spelling of its own contract. Building the typed body
instead of a literal is the durable fix and is not in this PR.

## Test

13 integration assertions read the old spelling and now read the new one.
Full suite green: 823 lib, 119 `api_integration`, 90 conformance, plus the rest.

## Checklist (stack guide §9)

- [x] No new `reqwest::Client::new()` / bare `fetch()` (R1.2)
- [x] No lock held across a network await (R1.3)
- [x] No local state committed before its remote effect (R2.1)
- [x] Every retry bounded + backed off (R1.4)
- [x] Accept/poll/listen loops survive transient errors (R1.5)
- [x] Acks/deletes happen only after durable handoff (R1.6)
- [x] **New/changed wire types: camelCase, schema registered, all consumers
      (incl. JS) updated (R3.\*)** — this is the whole PR; the JS side lands in
      the plugin's casing commit and the schemas in dtgwg-trust-tasks-tf#240
- [x] Config absence = most restrictive (R5.*)
- [x] Logs/status claim only what was verified (R6.*)
- [x] Deviations flagged with rule numbers — see the exclusions and known gap